### PR TITLE
feat(crdt): Resume /ws/userevents from a client cursor

### DIFF
--- a/backend/channelwire/wire.go
+++ b/backend/channelwire/wire.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/coder/websocket"
@@ -236,20 +237,177 @@ func HTTPToWS(rawURL string) string {
 // UserEventsURL builds the per-user WebSocket URL the hub serves at
 // /ws/userevents. baseURL is an http(s) URL; it is rewritten to ws(s)
 // via HTTPToWS. workspaceIDs is optional — when non-empty it scopes the
-// subscription to those workspaces. The authenticated session implies
-// the user; no user_id query parameter is required. Used by every
+// subscription to those workspaces. The authenticated session implies the
+// user; no user_id query parameter is required. Used by every
 // client that opens the user-events feed (desktop relay, remote CLI,
 // worker-side relay) so the query-string shape stays consistent.
-func UserEventsURL(baseURL string, workspaceIDs []string) string {
+//
+// cursor is the client's last-applied canonical HLC (nil on a first connect,
+// which makes the hub send a full snapshot); epoch is the current_epoch it saw
+// it under (0 when there is no cursor). The hub falls back to a full snapshot
+// when the cursor is nil/zero or at/below the op-retention watermark (the
+// lagging floor decideResume actually gates on -- NOT compaction_watermark,
+// which always equals max_hlc and would reject every cursor).
+func UserEventsURL(baseURL string, workspaceIDs []string, cursor *leapmuxv1.HLC, epoch int64) string {
 	q := url.Values{}
 	if len(workspaceIDs) > 0 {
 		q.Set("workspace_ids", strings.Join(workspaceIDs, ","))
+	}
+	// Gate on the DECODER's own accept rule, not the weaker all-zero test.
+	// hlcIsZero only rejects {0,0,""}, but DecodeResumeHLC rejects any
+	// physical <= 0 (the shared corpus pins `{"raw": "0.4.c", "ok": false}`), so
+	// a cursor like {Physical: 0, Logical: 7, ClientId: "c"} used to be written
+	// onto the URL and then 400'd by the hub -- an error where the intent was to
+	// omit the cursor and degrade to a full snapshot. Asking the decoder keeps
+	// the encode and decode sides one rule instead of two that must agree.
+	if resumeCursorEncodable(cursor) {
+		q.Set("resume_after_hlc", EncodeResumeHLC(cursor))
+		q.Set("resume_epoch", strconv.FormatInt(epoch, 10))
 	}
 	qs := q.Encode()
 	if qs == "" {
 		return HTTPToWS(baseURL) + "/ws/userevents"
 	}
 	return HTTPToWS(baseURL) + "/ws/userevents?" + qs
+}
+
+// EncodeResumeHLC renders an HLC as the "<physical>.<logical>.<client_id>"
+// triple carried in the resume_after_hlc query param. Inverse of
+// DecodeResumeHLC.
+func EncodeResumeHLC(h *leapmuxv1.HLC) string {
+	return strconv.FormatInt(h.GetPhysical(), 10) + "." +
+		strconv.FormatInt(h.GetLogical(), 10) + "." +
+		h.GetClientId()
+}
+
+// DecodeResumeHLC parses the resume_after_hlc query param back into an HLC,
+// returning nil for malformed input (non-numeric physical/logical, a
+// `+`-signed number, missing client_id, or a client_id longer than 128 chars
+// as a sanity bound). Inverse of EncodeResumeHLC.
+//
+// nil is NOT a silent degrade: the only caller, ParseResumeCursor, turns it
+// into an error that the hub answers with HTTP 400 and the desktop sidecar
+// answers with a rejected relay-open RPC. A malformed cursor is a client bug,
+// and failing loudly beats limping along on full snapshots forever.
+//
+// plusSigned is rejected even though strconv.ParseInt accepts it, because the
+// TS decoder (frontend/src/lib/crdt/hlc.ts parseHlcWire) does not — and neither
+// encoder ever emits it. Silently accepting on one side only would mean a
+// cursor the hub honours but the client considers corrupt (or vice versa).
+// testdata/hlc_wire_corpus.json pins the agreed grammar from both languages.
+func DecodeResumeHLC(raw string) *leapmuxv1.HLC {
+	dot1 := strings.IndexByte(raw, '.')
+	if dot1 <= 0 {
+		return nil
+	}
+	dot2 := strings.IndexByte(raw[dot1+1:], '.')
+	if dot2 <= 0 {
+		return nil
+	}
+	dot2 += dot1 + 1
+	physicalRaw, logicalRaw := raw[:dot1], raw[dot1+1:dot2]
+	if plusSigned(physicalRaw) || plusSigned(logicalRaw) {
+		return nil
+	}
+	physical, err := strconv.ParseInt(physicalRaw, 10, 64)
+	if err != nil || physical <= 0 {
+		return nil
+	}
+	logical, err := strconv.ParseInt(logicalRaw, 10, 64)
+	if err != nil || logical < 0 {
+		return nil
+	}
+	clientID := raw[dot2+1:]
+	if clientID == "" || len(clientID) > 128 {
+		return nil
+	}
+	return &leapmuxv1.HLC{Physical: physical, Logical: logical, ClientId: clientID}
+}
+
+// ParseResumeCursor validates a (resume_after_hlc, resume_epoch) pair from its
+// raw wire strings into a cursor HLC + epoch. The single authority for "what
+// counts as a well-formed cursor" so the hub (URL query params) and the desktop
+// sidecar (proto fields) cannot drift: both decode the same two strings and
+// apply the same strictness (a malformed cursor is a client bug, not a legacy
+// client — callers surface the error rather than silently degrading).
+//
+// Both empty → (nil, 0, nil): a first connect. resume_epoch without a matching
+// resume_after_hlc, or either field present-but-malformed, returns an error.
+//
+// The epoch is domain-checked, not merely parsed. `current_epoch` is
+// `NOT NULL DEFAULT 1` in every dialect and only ever increments, so zero and
+// negative are not values the hub can hold — accepting them would let a client
+// bug (a serializer that emits 0 for "unset") sail past this gate and fail
+// silently downstream instead, where `decideResume`'s epoch equality just
+// misses and degrades that client to a full snapshot on every single connect,
+// forever, with nothing logged. That is precisely the "limping along on full
+// snapshots" outcome this function exists to turn into a loud 400.
+func ParseResumeCursor(hlcRaw, epochRaw string) (cursor *leapmuxv1.HLC, epoch int64, err error) {
+	if hlcRaw == "" {
+		if epochRaw != "" {
+			return nil, 0, fmt.Errorf("resume_epoch requires resume_after_hlc")
+		}
+		return nil, 0, nil
+	}
+	cursor = DecodeResumeHLC(hlcRaw)
+	if cursor == nil {
+		return nil, 0, fmt.Errorf("malformed resume_after_hlc %q", hlcRaw)
+	}
+	if epochRaw == "" {
+		// resume_after_hlc is present, so resume_epoch is required. A bare
+		// ParseInt("") would report "malformed" for an absent value, misdirecting
+		// debugging.
+		return nil, 0, fmt.Errorf("resume_epoch required with resume_after_hlc")
+	}
+	// plusSigned for the same reason DecodeResumeHLC rejects it: ParseInt accepts
+	// "+7" but neither producer emits it (both stringify a bigint), so allowing
+	// it here would make this decoder laxer than the TS one it must match.
+	if plusSigned(epochRaw) {
+		return nil, 0, fmt.Errorf("malformed resume_epoch %q", epochRaw)
+	}
+	e, perr := strconv.ParseInt(epochRaw, 10, 64)
+	if perr != nil {
+		return nil, 0, fmt.Errorf("malformed resume_epoch %q", epochRaw)
+	}
+	if e <= 0 {
+		return nil, 0, fmt.Errorf("out-of-range resume_epoch %q: epochs start at 1", epochRaw)
+	}
+	return cursor, e, nil
+}
+
+// ParseResumeCursorFromQuery extracts the resume params from a URL query and
+// validates them via ParseResumeCursor.
+//
+// It lives HERE, next to UserEventsURL, because UserEventsURL is what WRITES
+// these two keys -- so the reader and the writer of the query-param names are
+// one file, and a rename cannot land on one side only. It previously sat in the
+// hub's service package under the name `ParseResumeCursor`, shadowing the
+// function it delegated to and putting the key literals two packages away from
+// their producer.
+func ParseResumeCursorFromQuery(q url.Values) (*leapmuxv1.HLC, int64, error) {
+	return ParseResumeCursor(q.Get("resume_after_hlc"), q.Get("resume_epoch"))
+}
+
+// plusSigned reports whether s carries an explicit leading `+`.
+// strconv.ParseInt accepts that form; the TS decoder's `^-?\d+$` does not, and
+// no encoder emits it. Rejecting here keeps one grammar across both languages.
+func plusSigned(s string) bool {
+	return len(s) > 0 && s[0] == '+'
+}
+
+// resumeCursorEncodable reports whether `cursor` would survive the round trip
+// through DecodeResumeHLC -- i.e. whether putting it on the wire produces a
+// cursor the hub will accept rather than a 400.
+//
+// Defined SOLELY in terms of the decoder so the two can never diverge: any rule
+// DecodeResumeHLC gains is automatically honoured here. That is also why there is
+// no separate nil/zero pre-test -- EncodeResumeHLC is nil-safe (it reads the
+// cursor through generated getters) and DecodeResumeHLC already rejects
+// physical <= 0 and an empty client id, so the ordinary "first connect" nil/zero
+// cursor falls out as false without a second, hand-maintained predicate to keep
+// in sync.
+func resumeCursorEncodable(cursor *leapmuxv1.HLC) bool {
+	return DecodeResumeHLC(EncodeResumeHLC(cursor)) != nil
 }
 
 // WriteFramedBytes writes a length-prefixed binary frame to a
@@ -392,17 +550,17 @@ const UserEventsReadLimit = 16 * 1024 * 1024
 // `bearer` is added as "Authorization: Bearer <bearer>". `httpClient`
 // may be nil; pass one when the caller's transport requires
 // unix/npipe dialers or shared HTTP/2 settings.
-func OpenUserEventsWS(ctx context.Context, httpClient *http.Client, hubURL, bearer string, workspaceIDs []string) (*websocket.Conn, error) {
+func OpenUserEventsWS(ctx context.Context, httpClient *http.Client, hubURL, bearer string, workspaceIDs []string, cursor *leapmuxv1.HLC, epoch int64) (*websocket.Conn, error) {
 	header := http.Header{}
 	if bearer != "" {
 		header.Set("Authorization", "Bearer "+bearer)
 	}
-	return OpenUserEventsWSWithHeader(ctx, httpClient, hubURL, header, workspaceIDs)
+	return OpenUserEventsWSWithHeader(ctx, httpClient, hubURL, header, workspaceIDs, cursor, epoch)
 }
 
 // OpenUserEventsWSWithHeader is OpenUserEventsWS for callers whose authentication
 // is already represented by HTTP headers, such as the desktop cookie jar.
-func OpenUserEventsWSWithHeader(ctx context.Context, httpClient *http.Client, hubURL string, header http.Header, workspaceIDs []string) (*websocket.Conn, error) {
+func OpenUserEventsWSWithHeader(ctx context.Context, httpClient *http.Client, hubURL string, header http.Header, workspaceIDs []string, cursor *leapmuxv1.HLC, epoch int64) (*websocket.Conn, error) {
 	opts := &websocket.DialOptions{
 		Subprotocols: []string{"userevents-relay"},
 		HTTPHeader:   header.Clone(),
@@ -410,7 +568,7 @@ func OpenUserEventsWSWithHeader(ctx context.Context, httpClient *http.Client, hu
 	if httpClient != nil {
 		opts.HTTPClient = httpClient
 	}
-	ws, _, err := websocket.Dial(ctx, UserEventsURL(hubURL, workspaceIDs), opts)
+	ws, _, err := websocket.Dial(ctx, UserEventsURL(hubURL, workspaceIDs, cursor, epoch), opts)
 	if err != nil {
 		return nil, fmt.Errorf("dial /ws/userevents: %w", err)
 	}

--- a/backend/channelwire/wire_test.go
+++ b/backend/channelwire/wire_test.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -414,3 +416,206 @@ func widestInnerRpcEnvelope(t *testing.T, payloadSize int) []byte {
 	require.NoError(t, err)
 	return encoded
 }
+
+// TestUserEventsURL_ResumeParams pins the query-string shape a reconnecting
+// client emits: workspace_ids (when scoped) plus resume_after_hlc +
+// resume_epoch (when a resume cursor is present). With no cursor the URL is
+// byte-identical to the legacy shape, so an older client that never sends one
+// is unaffected.
+func TestUserEventsURL_ResumeParams(t *testing.T) {
+	t.Run("nil cursor emits only workspace_ids", func(t *testing.T) {
+		got := UserEventsURL("https://hub", []string{"w1", "w2"}, nil, 0)
+		assert.Equal(t, "wss://hub/ws/userevents?workspace_ids=w1%2Cw2", got)
+	})
+	// The emit gate must be the DECODER's accept rule, not the weaker all-zero
+	// test. hlcIsZero only rejects {0,0,""}, so a cursor whose physical is 0 but
+	// whose other fields are set used to be written onto the URL -- and
+	// DecodeResumeHLC rejects any physical <= 0 (the shared corpus pins
+	// `{"raw": "0.4.c", "ok": false}`), so the hub answered its own client with a
+	// 400 where the intent was to omit the cursor and take a full snapshot.
+	t.Run("a cursor the decoder would reject is omitted, not sent", func(t *testing.T) {
+		for _, cursor := range []*leapmuxv1.HLC{
+			{Physical: 0, Logical: 4, ClientId: "c"},
+			{Physical: -1, Logical: 0, ClientId: "c"},
+			{Physical: 5, Logical: -1, ClientId: "c"},
+			{Physical: 5, Logical: 0, ClientId: ""},
+		} {
+			got := UserEventsURL("https://hub", nil, cursor, 7)
+			assert.NotContains(t, got, "resume_after_hlc", "cursor %v round-trips to a 400", cursor)
+			assert.NotContains(t, got, "resume_epoch")
+		}
+	})
+	t.Run("cursor appends resume params", func(t *testing.T) {
+		hlc := &leapmuxv1.HLC{Physical: 1754100000000, Logical: 3, ClientId: "c-abc"}
+		got := UserEventsURL("https://hub", nil, hlc, 7)
+		assert.Contains(t, got, "resume_after_hlc=1754100000000.3.c-abc")
+		assert.Contains(t, got, "resume_epoch=7")
+	})
+	t.Run("nil cursor emits no resume params", func(t *testing.T) {
+		got := UserEventsURL("https://hub", nil, nil, 1)
+		assert.NotContains(t, got, "resume_after_hlc")
+		assert.NotContains(t, got, "resume_epoch")
+	})
+}
+
+// TestEncodeDecodeResumeHLC covers the round-trip and the malformed-input
+// rejections that make a bad param degrade to a full-snapshot connect.
+func TestEncodeDecodeResumeHLC(t *testing.T) {
+	t.Run("round trip", func(t *testing.T) {
+		hlc := &leapmuxv1.HLC{Physical: 1754100000000, Logical: 42, ClientId: "c-abc"}
+		assert.Equal(t, "1754100000000.42.c-abc", EncodeResumeHLC(hlc))
+		got := DecodeResumeHLC("1754100000000.42.c-abc")
+		require.NotNil(t, got)
+		assert.Equal(t, hlc.GetPhysical(), got.GetPhysical())
+		assert.Equal(t, hlc.GetLogical(), got.GetLogical())
+		assert.Equal(t, hlc.GetClientId(), got.GetClientId())
+	})
+	cases := []string{
+		"",                                  // empty
+		"123",                               // no dots
+		"123.4",                             // one dot
+		"abc.4.c",                           // non-numeric physical
+		"123.abc.c",                         // non-numeric logical
+		"0.4.c",                             // zero physical (must be > 0)
+		"123.4.",                            // empty client id
+		"123.4." + strings.Repeat("x", 129), // overlong client id
+	}
+	for _, raw := range cases {
+		assert.Nil(t, DecodeResumeHLC(raw), "DecodeResumeHLC(%q) must reject as nil", raw)
+	}
+}
+
+// TestParseResumeCursor pins the shared cursor-validation contract that BOTH
+// the hub (URL query params) and the desktop sidecar (proto fields) delegate
+// to. The sidecar now REJECTS the relay-open RPC on any malformed value
+// (matching the hub's HTTP 400) rather than silently degrading to a full
+// snapshot, so this strictness is load-bearing for surfacing frontend bugs at
+// the first boundary they cross.
+func TestParseResumeCursor(t *testing.T) {
+	t.Run("both empty = first connect", func(t *testing.T) {
+		cursor, epoch, err := ParseResumeCursor("", "")
+		require.NoError(t, err)
+		assert.Nil(t, cursor)
+		assert.Equal(t, int64(0), epoch)
+	})
+	t.Run("well-formed pair decodes", func(t *testing.T) {
+		cursor, epoch, err := ParseResumeCursor("1754100000000.3.c-abc", "7")
+		require.NoError(t, err)
+		require.NotNil(t, cursor)
+		assert.Equal(t, int64(1754100000000), cursor.GetPhysical())
+		assert.Equal(t, int64(3), cursor.GetLogical())
+		assert.Equal(t, "c-abc", cursor.GetClientId())
+		assert.Equal(t, int64(7), epoch)
+	})
+	for _, c := range []struct {
+		name     string
+		hlcRaw   string
+		epochRaw string
+	}{
+		{"malformed hlc", "not-an-hlc", "7"},
+		{"malformed epoch", "1754100000000.3.c-abc", "not-a-number"},
+		{"epoch without hlc", "", "7"},
+		{"hlc without epoch", "1754100000000.3.c-abc", ""},
+		{"negative logical", "100.-5.c", "7"},
+		{"overlong client id", "100.0." + strings.Repeat("x", 129), "7"},
+		// The epoch gets the SAME domain treatment as physical/logical, not just a
+		// parse check. `current_epoch` is `NOT NULL DEFAULT 1` in every dialect and
+		// only increments, so these are values the hub can never hold; without the
+		// check they parse as well-formed and then fail silently at decideResume's
+		// equality test, degrading that client to a full snapshot on every connect
+		// with nothing logged.
+		{"zero epoch", "1754100000000.3.c-abc", "0"},
+		{"negative epoch", "1754100000000.3.c-abc", "-1"},
+		{"plus-signed epoch", "1754100000000.3.c-abc", "+7"},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			_, _, err := ParseResumeCursor(c.hlcRaw, c.epochRaw)
+			require.Error(t, err, "malformed resume params must surface an error (hub 400 / sidecar reject)")
+		})
+	}
+}
+
+// TestDecodeResumeHLC_CrossLanguageCorpus pins channelwire.DecodeResumeHLC
+// against the shared testdata/hlc_wire_corpus.json fixture that the TypeScript
+// client (frontend/src/lib/crdt/hlc.test.ts) asserts parseHlcWire against too.
+// Both decoders parse the SAME resume-cursor wire format, and the client
+// pre-validates a persisted cursor before sending so a value the hub would 400
+// never leaves the browser (otherwise: non-terminal 1006 close → tight reconnect
+// loop). A rule added/tightened on one side but not the other reddens CI here
+// instead of drifting back into that storm. Mirrors the cross-language pattern
+// TestChannelWireLimitsMatchCrossLanguageFixture established.
+func TestDecodeResumeHLC_CrossLanguageCorpus(t *testing.T) {
+	data, err := os.ReadFile("../../testdata/hlc_wire_corpus.json")
+	require.NoError(t, err, "testdata/hlc_wire_corpus.json must exist; see its _readme")
+	var fixture struct {
+		Cases []struct {
+			Raw      string `json:"raw"`
+			OK       bool   `json:"ok"`
+			Physical string `json:"physical"`
+			Logical  string `json:"logical"`
+			ClientID string `json:"clientId"`
+		} `json:"cases"`
+	}
+	require.NoError(t, json.Unmarshal(data, &fixture), "fixture must be valid JSON")
+
+	for _, c := range fixture.Cases {
+		got := DecodeResumeHLC(c.Raw)
+		if !c.OK {
+			assert.Nil(t, got, "DecodeResumeHLC(%q) must reject (corpus says ok=false)", c.Raw)
+			continue
+		}
+		require.NotNil(t, got, "DecodeResumeHLC(%q) must decode (corpus says ok=true)", c.Raw)
+		wantPhys, _ := strconv.ParseInt(c.Physical, 10, 64)
+		wantLog, _ := strconv.ParseInt(c.Logical, 10, 64)
+		assert.Equal(t, wantPhys, got.GetPhysical(), "DecodeResumeHLC(%q) physical", c.Raw)
+		assert.Equal(t, wantLog, got.GetLogical(), "DecodeResumeHLC(%q) logical", c.Raw)
+		assert.Equal(t, c.ClientID, got.GetClientId(), "DecodeResumeHLC(%q) clientId", c.Raw)
+	}
+}
+
+// TestParseResumeCursorFromQuery pins the strict parsing contract: a first connect
+// (both params absent) yields a nil cursor + no error, a well-formed pair
+// decodes, and any malformed shape (bad HLC, bad epoch, or epoch-without-hlc)
+// returns an error the handler surfaces as HTTP 400. The malformed arms are
+// the load-bearing part — strictness here means a buggy client fails loudly
+// instead of silently degrading to full-snapshot reconnects.
+func TestParseResumeCursorFromQuery(t *testing.T) {
+	t.Run("both absent = first connect", func(t *testing.T) {
+		cursor, epoch, err := ParseResumeCursorFromQuery(url.Values{})
+		require.NoError(t, err)
+		require.Nil(t, cursor)
+		require.Equal(t, int64(0), epoch)
+	})
+	t.Run("well-formed", func(t *testing.T) {
+		q := url.Values{
+			"resume_after_hlc": {"1754100000000.3.c-abc"},
+			"resume_epoch":     {"7"},
+		}
+		cursor, epoch, err := ParseResumeCursorFromQuery(q)
+		require.NoError(t, err)
+		require.NotNil(t, cursor)
+		require.Equal(t, int64(1754100000000), cursor.GetPhysical())
+		require.Equal(t, int64(3), cursor.GetLogical())
+		require.Equal(t, "c-abc", cursor.GetClientId())
+		require.Equal(t, int64(7), epoch)
+	})
+	for _, c := range []struct {
+		name string
+		q    url.Values
+	}{
+		{"malformed hlc", url.Values{"resume_after_hlc": {"not-an-hlc"}}},
+		{"malformed epoch", url.Values{
+			"resume_after_hlc": {"1754100000000.3.c-abc"},
+			"resume_epoch":     {"not-a-number"},
+		}},
+		{"epoch without hlc", url.Values{"resume_epoch": {"7"}}},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			_, _, err := ParseResumeCursorFromQuery(c.q)
+			require.Error(t, err, "malformed resume params must surface an error (→ HTTP 400)")
+		})
+	}
+}
+
+// It lives here rather than in the hub service suite because the function
+// moved to sit beside UserEventsURL, which writes the very keys it reads.

--- a/backend/hub/server.go
+++ b/backend/hub/server.go
@@ -57,6 +57,39 @@ const handlerGrace = 5 * time.Second
 // should not need its full budget in practice; the constant is the hard ceiling.
 const httpDrainTimeout = 10 * time.Second
 
+// maxConnectRequestBytes bounds every inbound message on the hub's Connect
+// surface. Per MESSAGE, not per stream -- see connect.WithReadMaxBytes, which
+// also documents that "both clients and handlers default to allowing any request
+// size". Without it an authenticated SubmitOps body is buffered whole before the
+// handler ever sees it, and is then applied on that user's SINGLE-WRITER manager
+// goroutine, so one oversized batch serializes every other tab's submits behind
+// its own unmarshal + validate.
+//
+// Sized from crdt.MaxResumeDeltaBytes, the budget a resume may read back out of
+// the journal, rather than from a round number: a batch bigger than that is one
+// whose OWN later resume is guaranteed to blow the budget and force that client
+// onto a full snapshot, so accepting it buys nothing. It is far above any
+// legitimate message on this surface -- the largest are a worker's whole-machine
+// tab inventory (identity fields only) and a relayed ChannelMessage, itself
+// chunk-capped at channelwire.MaxCiphertextForChunk (64 KiB).
+//
+// READS only; responses are deliberately not capped (no WithSendMaxBytes),
+// because GetMaterialized legitimately returns a multi-MB snapshot for a large
+// account.
+const maxConnectRequestBytes = crdt.MaxResumeDeltaBytes
+
+// connectOptions is the option set EVERY Connect handler on the hub mux is
+// registered with. A function rather than an inline literal so the request-size
+// cap is reachable from a test without standing up a whole Server (NewServer
+// needs a live store, listeners and a keystore), and so a future handler cannot
+// be mounted with a hand-rolled option list that quietly omits the cap.
+func connectOptions(interceptors ...connect.Interceptor) connect.Option {
+	return connect.WithOptions(
+		connect.WithInterceptors(interceptors...),
+		connect.WithReadMaxBytes(maxConnectRequestBytes),
+	)
+}
+
 // ServerOption configures optional aspects of a Hub server.
 type ServerOption func(*serverOptions)
 
@@ -200,7 +233,7 @@ func NewServer(cfg *config.Config, opts ...ServerOption) (*Server, error) {
 	// lifecycle) extend its already-open channels' expiry, not just its leases
 	// (which the registry owns directly).
 	authContexts.SetChannelExpiryRescheduler(cMgr)
-	connectOpts := connect.WithInterceptors(
+	connectOpts := connectOptions(
 		auth.NewShutdownInterceptor(shutdownCh),
 		metrics.NewInterceptor(),
 		auth.NewTimeoutInterceptor(cfg.APITimeout),

--- a/backend/hub/server_connect_options_test.go
+++ b/backend/hub/server_connect_options_test.go
@@ -1,0 +1,108 @@
+package hub
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/generated/proto/leapmux/v1/leapmuxv1connect"
+	"github.com/leapmux/leapmux/internal/hub/crdt"
+)
+
+// countingCRDTService is a stand-in UserCRDT handler that records whether the
+// request ever reached application code. That is the load-bearing assertion for
+// the size cap: connect-go must refuse an oversized body while READING it, so an
+// over-cap SubmitOps must never be unmarshaled, authorized, or handed to the
+// user's single-writer manager goroutine.
+type countingCRDTService struct {
+	leapmuxv1connect.UnimplementedUserCRDTHandler
+	submits int
+	// lastBatches is the batch count the handler actually saw, so the
+	// under-cap case proves the request arrived intact rather than merely
+	// arriving.
+	lastBatches int
+}
+
+func (s *countingCRDTService) SubmitOps(
+	_ context.Context,
+	req *connect.Request[leapmuxv1.SubmitOpsRequest],
+) (*connect.Response[leapmuxv1.SubmitOpsResponse], error) {
+	s.submits++
+	s.lastBatches = len(req.Msg.GetBatches())
+	return connect.NewResponse(&leapmuxv1.SubmitOpsResponse{}), nil
+}
+
+// submitOpsOfSize builds a SubmitOpsRequest whose marshaled size is at least
+// `atLeast` bytes, by padding the batch id. The padding is NOT compressible-
+// friendly filler that could slip past the cap: connect-go clients default to
+// sending uncompressed requests (see connect.WithSendGzip's doc), and the
+// handler's limit is applied to the raw read, so the wire size is the size built
+// here.
+func submitOpsOfSize(atLeast int) *leapmuxv1.SubmitOpsRequest {
+	return &leapmuxv1.SubmitOpsRequest{
+		Epoch:   1,
+		Batches: []*leapmuxv1.OpBatch{{BatchId: strings.Repeat("p", atLeast)}},
+	}
+}
+
+// TestConnectOptions_BoundsInboundRequestBodies pins the request-size cap every
+// Connect handler on the hub mux is mounted with.
+//
+// connect-go defaults to allowing ANY request size, so before this the whole
+// body of an authenticated SubmitOps was buffered, unmarshaled, and then applied
+// on that user's single-writer CRDT goroutine -- one caller could stall every
+// other tab's submits for as long as its own batch took to process.
+//
+// The production option value (connectOptions) is what is mounted here, not a
+// hand-rolled copy, so a future edit that drops WithReadMaxBytes from the shared
+// builder reddens this test. Interceptors are omitted deliberately: the cap is
+// enforced by the protocol reader, BELOW the interceptor chain, and the real
+// chain needs a store, a keystore and a shutdown channel.
+func TestConnectOptions_BoundsInboundRequestBodies(t *testing.T) {
+	svc := &countingCRDTService{}
+	path, handler := leapmuxv1connect.NewUserCRDTHandler(svc, connectOptions())
+	mux := http.NewServeMux()
+	mux.Handle(path, handler)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	client := leapmuxv1connect.NewUserCRDTClient(srv.Client(), srv.URL)
+
+	// Comfortably under the cap: accepted, and the handler sees the real batch.
+	_, err := client.SubmitOps(context.Background(),
+		connect.NewRequest(submitOpsOfSize(maxConnectRequestBytes/2)))
+	require.NoError(t, err, "a legitimate bulk submit must still be accepted")
+	require.Equal(t, 1, svc.submits)
+	require.Equal(t, 1, svc.lastBatches, "the under-cap request must arrive intact")
+
+	// Comfortably over it: refused, and application code is never reached.
+	_, err = client.SubmitOps(context.Background(),
+		connect.NewRequest(submitOpsOfSize(maxConnectRequestBytes+(1<<20))))
+	require.Error(t, err, "an over-cap request must be refused, not buffered whole")
+	assert.Equal(t, connect.CodeResourceExhausted, connect.CodeOf(err),
+		"connect reports an over-limit body as resource_exhausted")
+	assert.Equal(t, 1, svc.submits,
+		"the oversized body must be rejected while reading -- never unmarshaled and never dispatched")
+}
+
+// TestMaxConnectRequestBytes_TracksTheResumeBudget pins the sizing ARGUMENT, not
+// just the number. The cap is derived from the budget a resume may read back out
+// of the journal: a batch bigger than that is one whose own later resume is
+// guaranteed to exceed the budget and force that client onto a full snapshot, so
+// accepting it buys nothing. Someone raising one of the two in isolation should
+// have to look at the other.
+func TestMaxConnectRequestBytes_TracksTheResumeBudget(t *testing.T) {
+	assert.Equal(t, crdt.MaxResumeDeltaBytes, maxConnectRequestBytes,
+		"the inbound cap is derived from the resume read budget; see maxConnectRequestBytes")
+	// And it must stay far above the largest legitimate message on this surface:
+	// a relayed ChannelMessage, which the channel layer chunk-caps well below it.
+	assert.Greater(t, maxConnectRequestBytes, 1<<20,
+		"a cap this low would refuse legitimate bulk submits")
+}

--- a/backend/internal/audit/storebind.go
+++ b/backend/internal/audit/storebind.go
@@ -50,6 +50,15 @@ var unguardedOwnerFilterQueries = map[string]string{
 	"GetWorktreeForTab":         "worktree_tabs.user_id is '' by design for AGENT/TERMINAL links; see the block comment above",
 	"RemoveWorktreeTab":         "worktree_tabs.user_id is '' by design for AGENT/TERMINAL links; see the block comment above",
 	"DeleteWorktreeTabsByTabID": "worktree_tabs.user_id is '' by design for AGENT/TERMINAL links; see the block comment above",
+	// The owner column here is JOIN plumbing, not a caller filter. The sweep
+	// takes no caller id at all (see its entry in unscopedOwnerKeyedQueries);
+	// the only user_id comparison is user_state.user_id = user_op_batches.user_id,
+	// correlating each batch to ITS OWN owner's compaction watermark so the sweep
+	// cannot delete a tail that user's state_payload has not absorbed yet. There
+	// is no caller id to route through userid.OwnerFilter, and a blank owner
+	// cannot widen anything: the correlation is column-to-column, so a row can
+	// only ever match its own user_state row.
+	"DeleteUserOpBatchesBeforePhysical": "cross-user retention sweep; its only user_id comparison correlates each batch to its own owner's compaction watermark, and it accepts no caller id to guard",
 }
 
 // unscopedOwnerKeyedQueries are the queries that touch an owner-keyed table --
@@ -91,6 +100,12 @@ var unscopedOwnerKeyedQueries = map[string]string{
 	"DeleteOAuthUserLinksByProvider": "deleting a provider must drop every owner's link to it; see DeleteOAuthTokensByProvider",
 	// Retention GC over the CRDT dedup window.
 	"DeleteExpiredRecentBatchIDs": "a retention sweep over expired dedup entries; the cutoff is the predicate and every owner's expired rows must go",
+	// (DeleteUserOpBatchesBeforePhysical, the CRDT op-batch retention sweep, used
+	// to sit here. It now NAMES user_id -- correlating each batch to its own
+	// owner's compaction watermark so it cannot delete a tail that user's
+	// state_payload has not absorbed -- so it is owner-scoped by this check's
+	// definition and belongs only in unguardedOwnerFilterQueries, where its
+	// caller-side reason lives.)
 
 	// ---- the non-owner half IS a key ----
 

--- a/backend/internal/cli/remote/client.go
+++ b/backend/internal/cli/remote/client.go
@@ -258,7 +258,7 @@ func (c *Client) OpenUserEvents(ctx context.Context, workspaceIDs []string) (*Us
 		return nil, errors.New("OpenUserEvents is only valid for hub-bound clients; use the agent-spawned hub URL + delegation bearer to subscribe directly")
 	}
 	dialCtx, dialCancel := context.WithCancel(ctx)
-	ws, err := channelwire.OpenUserEventsWS(dialCtx, c.WSClient, c.HubURL, c.Bearer, workspaceIDs)
+	ws, err := channelwire.OpenUserEventsWS(dialCtx, c.WSClient, c.HubURL, c.Bearer, workspaceIDs, nil, 0)
 	if err != nil {
 		dialCancel()
 		return nil, err

--- a/backend/internal/cli/remote/cmd/events.go
+++ b/backend/internal/cli/remote/cmd/events.go
@@ -120,6 +120,30 @@ func eventToJSON(evt *leapmuxv1.WatchUserEvent) map[string]any {
 			"at_hlc": hlcToJSON(e.EntityRemoved.GetAtHlc()),
 			"entity": removedEntitySummary(e.EntityRemoved),
 		}
+	case *leapmuxv1.WatchUserEvent_Delta:
+		// A ResumeDelta carries an ordered stream of the same WatchUserEvent
+		// frames live Send uses. The CLI currently connects with a nil cursor
+		// (always a full snapshot), but handle the arm so a future resume-aware
+		// `leapmux events` surfaces the frames instead of printing "unknown".
+		frames := make([]map[string]any, 0, len(e.Delta.GetFrames()))
+		for _, frame := range e.Delta.GetFrames() {
+			frames = append(frames, eventToJSON(frame))
+		}
+		return map[string]any{
+			"kind":          "resume_delta",
+			"current_epoch": e.Delta.GetCurrentEpoch(),
+			"max_hlc":       hlcToJSON(e.Delta.GetMaxHlc()),
+			"frames":        frames,
+		}
+	case *leapmuxv1.WatchUserEvent_BatchEnd:
+		// Emitted after EVERY committed batch on the live path, not just on
+		// resume, so leaving this unhandled put one {"kind":"unknown"} line in
+		// the stream per user edit. at_hlc is the batch boundary a resume-aware
+		// consumer advances its cursor on.
+		return map[string]any{
+			"kind":   "batch_end",
+			"at_hlc": hlcToJSON(e.BatchEnd.GetAtHlc()),
+		}
 	case *leapmuxv1.WatchUserEvent_Presence:
 		return map[string]any{
 			"kind":             "presence",

--- a/backend/internal/cli/remote/cmd/events_test.go
+++ b/backend/internal/cli/remote/cmd/events_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 )
@@ -38,4 +39,61 @@ func TestOpKindName_ClassifiesEveryCrdtOpBody(t *testing.T) {
 			assert.Equal(t, tc.want, opKindName(tc.op))
 		})
 	}
+}
+
+// TestEventToJSON_ClassifiesEveryWatchUserEventKind is the frame-level sibling
+// of the op-level test above, and exists for the same reason: an unhandled
+// oneof arm falls through to {"kind":"unknown"}, which silently breaks scripts
+// filtering the stream.
+//
+// It caught `batch_end` shipping unlabeled. That arm is emitted after EVERY
+// committed batch on the live broadcast path -- not only on resume -- so the
+// gap put one unknown line in the stream per user edit, and dropped the at_hlc
+// watermark a resume-aware consumer needs.
+//
+// The case list is exhaustive over the WatchUserEvent oneof BY CONSTRUCTION:
+// the compiler rejects an entry whose wrapper type does not exist, and a NEW
+// arm is caught because adding one without extending eventToJSON leaves the
+// author with a failing "no arm renders unknown" contract the moment they add
+// its case here. Keep it in step with proto/leapmux/v1/user_ops.proto.
+func TestEventToJSON_ClassifiesEveryWatchUserEventKind(t *testing.T) {
+	cases := []struct {
+		name string
+		evt  *leapmuxv1.WatchUserEvent
+		want string
+	}{
+		{"Initial", &leapmuxv1.WatchUserEvent{Event: &leapmuxv1.WatchUserEvent_Initial{Initial: &leapmuxv1.UserMaterialized{}}}, "materialized"},
+		{"Batch", &leapmuxv1.WatchUserEvent{Event: &leapmuxv1.WatchUserEvent_Batch{Batch: &leapmuxv1.OpBatch{}}}, "batch"},
+		{"EntityMaterialized", &leapmuxv1.WatchUserEvent{Event: &leapmuxv1.WatchUserEvent_EntityMaterialized{EntityMaterialized: &leapmuxv1.EntityMaterialized{}}}, "entity_materialized"},
+		{"EntityRemoved", &leapmuxv1.WatchUserEvent{Event: &leapmuxv1.WatchUserEvent_EntityRemoved{EntityRemoved: &leapmuxv1.EntityRemoved{}}}, "entity_removed"},
+		{"Delta", &leapmuxv1.WatchUserEvent{Event: &leapmuxv1.WatchUserEvent_Delta{Delta: &leapmuxv1.ResumeDelta{}}}, "resume_delta"},
+		{"BatchEnd", &leapmuxv1.WatchUserEvent{Event: &leapmuxv1.WatchUserEvent_BatchEnd{BatchEnd: &leapmuxv1.BatchEnd{}}}, "batch_end"},
+		{"Presence", &leapmuxv1.WatchUserEvent{Event: &leapmuxv1.WatchUserEvent_Presence{Presence: &leapmuxv1.PresenceUpdate{}}}, "presence"},
+		{"Renamed", &leapmuxv1.WatchUserEvent{Event: &leapmuxv1.WatchUserEvent_Renamed{Renamed: &leapmuxv1.WorkspaceRenamed{}}}, "workspace_renamed"},
+		{"Created", &leapmuxv1.WatchUserEvent{Event: &leapmuxv1.WatchUserEvent_Created{Created: &leapmuxv1.WorkspaceCreated{}}}, "workspace_created"},
+		{"Deleted", &leapmuxv1.WatchUserEvent{Event: &leapmuxv1.WatchUserEvent_Deleted{Deleted: &leapmuxv1.WorkspaceDeleted{}}}, "workspace_deleted"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := eventToJSON(tc.evt)
+			assert.Equal(t, tc.want, got["kind"])
+			assert.NotEqual(t, "unknown", got["kind"], "every oneof arm must render a real label")
+		})
+	}
+
+	// The nested case: a ResumeDelta's frames recurse through the same switch,
+	// so an arm missing there is invisible to the flat cases above. BatchEnd is
+	// the arm resumeCatchUpSink.End appends to every delta.
+	t.Run("frames nested in a resume delta", func(t *testing.T) {
+		got := eventToJSON(&leapmuxv1.WatchUserEvent{Event: &leapmuxv1.WatchUserEvent_Delta{Delta: &leapmuxv1.ResumeDelta{
+			Frames: []*leapmuxv1.WatchUserEvent{
+				{Event: &leapmuxv1.WatchUserEvent_BatchEnd{BatchEnd: &leapmuxv1.BatchEnd{}}},
+			},
+		}}})
+		frames, ok := got["frames"].([]map[string]any)
+		require.True(t, ok, "a delta must project its frames")
+		require.Len(t, frames, 1)
+		assert.Equal(t, "batch_end", frames[0]["kind"],
+			"frames inside a delta go through the same switch, so a missing arm shows up here too")
+	})
 }

--- a/backend/internal/cli/remote/streamevents/subscription_test.go
+++ b/backend/internal/cli/remote/streamevents/subscription_test.go
@@ -624,15 +624,22 @@ func TestSubscription_LookupFailedRetryWakesImmediatelyOnCancel(t *testing.T) {
 	// retryCtx.Done() and refund its slot — observable as Attempts()==0 (the slot
 	// was refunded, not spent).
 	time.Sleep(20 * time.Millisecond)
-	start := time.Now()
-	sub.Cancel()
-	elapsed := time.Since(start)
 
-	// Cancel returns promptly (it does not block on the handle's Done for long,
-	// and the retry goroutine bails via retryCtx without waiting on the 30s
-	// timer). Assert it returned in well under the 30s delay.
-	assert.Less(t, elapsed, time.Second,
-		"Cancel must wake the retry promptly, not wait on the 30s timer")
+	// Cancel must wake the retry via retryCtx rather than waiting out the 30s
+	// timer -- asserted as a COMPLETION against a generous deadline, not as a
+	// 1s budget. Both forms catch the same defect (a Cancel that blocks on the
+	// timer takes 30s), but a completion guard cannot be crossed by machine
+	// load and reports the defect rather than the budget.
+	cancelled := make(chan struct{})
+	go func() {
+		defer close(cancelled)
+		sub.Cancel()
+	}()
+	select {
+	case <-cancelled:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Cancel blocked on the retry timer instead of waking it via retryCtx")
+	}
 	sub.mu.Lock()
 	attempts := sub.retry.Attempts()
 	sub.mu.Unlock()

--- a/backend/internal/hub/cleanup/cleanup.go
+++ b/backend/internal/hub/cleanup/cleanup.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/leapmux/leapmux/internal/hub/crdt"
 	"github.com/leapmux/leapmux/internal/hub/store"
 	"github.com/leapmux/leapmux/internal/util/periodic"
 )
@@ -14,6 +15,9 @@ const (
 	cleanupRetention               = 7 * 24 * time.Hour
 	cleanupJitter                  = 5 * time.Minute
 	maxRevocationCompactionBatches = 100
+	// Bounded like maxRevocationCompactionBatches so one pass cannot monopolize
+	// the cleanup goroutine; the next tick picks up whatever is left.
+	maxOpBatchSweepBatches = 100
 )
 
 // StartLoop starts a background goroutine that periodically hard-deletes
@@ -56,29 +60,57 @@ func run(ctx context.Context, st store.Store) {
 	// Expired delegation tokens (TTL passed without an explicit revoke)
 	// are also worth pruning eagerly since they accumulate one-per-spawn.
 	cleanupStep("expired delegation tokens", func() (int64, error) { return cs.DeleteExpiredDelegationTokensBefore(ctx, now) })
+	// CRDT op-batch retention. Manager.maybeCompact deletes by HLC on the commit
+	// path, but its tick short-circuits once compaction_watermark reaches
+	// max_hlc -- so an account that stops being used keeps its final
+	// OpRetentionTTL of batches (and their transitions_payload record
+	// snapshots) forever. Drain that tail here on the shared schedule.
+	//
+	// The cutoff is expressed as an HLC physical, the SAME quantity
+	// decideResume gates the resume cursor on, so this deletes exactly the set
+	// a resume would refuse. Passing a wall clock instead would split one
+	// invariant across two time domains; see the query's doc for what that
+	// costs.
+	opBatchCutoff := crdt.OpRetentionCutoffPhysicalMs(now, crdt.OpRetentionTTL)
+	cleanupStep("crdt op batches", func() (int64, error) {
+		return drainUntilEmpty(ctx, maxOpBatchSweepBatches, func() (int64, error) {
+			return cs.DeleteUserOpBatchesBeforePhysical(ctx, opBatchCutoff)
+		})
+	})
 	cleanupStep("published revocation events", func() (int64, error) {
-		var total int64
-		for range maxRevocationCompactionBatches {
-			if ctx.Err() != nil {
-				return total, nil
-			}
-			deleted, err := cs.CompactPublishedRevocationEvents(ctx, store.CompactRevocationEventsParams{
+		return drainUntilEmpty(ctx, maxRevocationCompactionBatches, func() (int64, error) {
+			return cs.CompactPublishedRevocationEvents(ctx, store.CompactRevocationEventsParams{
 				Cutoff: cutoff,
 			})
-			total += deleted
-			// Drain until a batch deletes nothing rather than stopping on a partial
-			// page. The delete query caps each batch at its own internal LIMIT;
-			// terminating on deleted==0 keeps this loop correct no matter what that
-			// page size is, instead of assuming it equals the shared CleanupBatchLimit
-			// constant -- which is a separate source of truth that could silently
-			// drift from the SQL LIMIT and either stop compaction early (a slow leak)
-			// or fire an extra no-op query.
-			if err != nil || deleted == 0 {
-				return total, err
-			}
-		}
-		return total, nil
+		})
 	})
+}
+
+// drainUntilEmpty runs a paged delete until it deletes nothing, a pass fails, the
+// context is cancelled, or maxPasses is reached, and reports the running total.
+//
+// Terminating on deleted==0 rather than on a short page keeps every caller
+// correct no matter what its query's internal LIMIT is, instead of duplicating
+// that page size as a second source of truth in Go -- which could silently drift
+// from the SQL and either stop the sweep early (a slow leak) or fire an extra
+// no-op query. maxPasses is the runaway bound, not the expected pass count.
+//
+// A cancelled context returns the total WITHOUT an error: the rows already
+// deleted are committed and the remainder is picked up by the next scheduled
+// sweep, so shutdown mid-drain is a pause, not a failure worth logging.
+func drainUntilEmpty(ctx context.Context, maxPasses int, pass func() (int64, error)) (int64, error) {
+	var total int64
+	for range maxPasses {
+		if ctx.Err() != nil {
+			return total, nil
+		}
+		deleted, err := pass()
+		total += deleted
+		if err != nil || deleted == 0 {
+			return total, err
+		}
+	}
+	return total, nil
 }
 
 func cleanupStep(name string, fn func() (int64, error)) {

--- a/backend/internal/hub/cleanup/cleanup_test.go
+++ b/backend/internal/hub/cleanup/cleanup_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/leapmux/leapmux/internal/hub/password"
@@ -159,4 +160,76 @@ func TestRun_StopsRevocationCompactionWhenContextIsCanceled(t *testing.T) {
 	run(ctx, cleanupSpyStore{Store: st, cleanup: spy})
 
 	require.Equal(t, 1, spy.compactionRuns)
+}
+
+// drainUntilEmpty is the shared loop behind both paged sweeps, so its contract
+// is pinned directly rather than only through the two callers: terminate on a
+// pass that deletes nothing, stop on the first error, respect the runaway bound,
+// and report a cancelled context as a PAUSE (total, no error) rather than a
+// failure -- the rows already deleted are committed and the next scheduled
+// sweep picks up the rest.
+func TestDrainUntilEmpty(t *testing.T) {
+	t.Run("drains until a pass deletes nothing", func(t *testing.T) {
+		pages := []int64{1000, 1000, 250, 0}
+		var calls int
+		total, err := drainUntilEmpty(context.Background(), 10, func() (int64, error) {
+			n := pages[calls]
+			calls++
+			return n, nil
+		})
+		require.NoError(t, err)
+		assert.Equal(t, int64(2250), total)
+		assert.Equal(t, 4, calls, "must stop on the empty pass, not keep going to maxPasses")
+	})
+
+	t.Run("stops on the first error and keeps what was already deleted", func(t *testing.T) {
+		var calls int
+		total, err := drainUntilEmpty(context.Background(), 10, func() (int64, error) {
+			calls++
+			if calls == 2 {
+				return 7, assert.AnError
+			}
+			return 100, nil
+		})
+		require.ErrorIs(t, err, assert.AnError)
+		assert.Equal(t, int64(107), total, "the failing pass's own deletions still count")
+		assert.Equal(t, 2, calls)
+	})
+
+	t.Run("honours the runaway bound", func(t *testing.T) {
+		var calls int
+		total, err := drainUntilEmpty(context.Background(), 3, func() (int64, error) {
+			calls++
+			return 1000, nil
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 3, calls)
+		assert.Equal(t, int64(3000), total)
+	})
+
+	t.Run("treats a cancelled context as a pause, not a failure", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		var calls int
+		total, err := drainUntilEmpty(ctx, 10, func() (int64, error) {
+			calls++
+			cancel()
+			return 100, nil
+		})
+		require.NoError(t, err, "shutdown mid-drain must not log as a cleanup failure")
+		assert.Equal(t, int64(100), total)
+		assert.Equal(t, 1, calls, "the cancellation is observed before the next pass")
+	})
+
+	t.Run("never calls the pass when already cancelled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		var calls int
+		total, err := drainUntilEmpty(ctx, 10, func() (int64, error) {
+			calls++
+			return 100, nil
+		})
+		require.NoError(t, err)
+		assert.Zero(t, total)
+		assert.Zero(t, calls)
+	})
 }

--- a/backend/internal/hub/crdt/broadcast_order_internal_test.go
+++ b/backend/internal/hub/crdt/broadcast_order_internal_test.go
@@ -47,6 +47,31 @@ func TestOrderedAffectedRefs_NodesBeforeWindowsBeforeTabs(t *testing.T) {
 	}
 }
 
+// WorkspaceID is the only identity a WorkspaceRoot ref carries, so without a
+// tie-break on it two such refs compare equal and sort.Slice -- which is not
+// stable -- orders them arbitrarily. No frame is emitted for that kind today, so
+// this pins the comparator's totality by construction rather than by the accident
+// of which kinds currently have frame arms.
+func TestOrderedAffectedRefs_TotalOrderAcrossWorkspaceRoots(t *testing.T) {
+	affected := map[EntityRef]EntityWorkspaceTransition{
+		{Kind: EntityKindWorkspaceRoot, WorkspaceID: "ws-c"}: {},
+		{Kind: EntityKindWorkspaceRoot, WorkspaceID: "ws-a"}: {},
+		{Kind: EntityKindWorkspaceRoot, WorkspaceID: "ws-b"}: {},
+	}
+
+	for range 32 {
+		got := orderedAffectedRefs(affected)
+		require.Len(t, got, 3)
+
+		ids := make([]string, len(got))
+		for i, a := range got {
+			ids[i] = a.ref.WorkspaceID
+		}
+		assert.Equal(t, []string{"ws-a", "ws-b", "ws-c"}, ids,
+			"refs that differ only in WorkspaceID must still have a total order")
+	}
+}
+
 func TestOrderedAffectedRefs_CarriesTheTransition(t *testing.T) {
 	// The two passes read `trans` off the slice rather than re-hashing the map;
 	// if the pairing were lost, every visibility test would silently see the

--- a/backend/internal/hub/crdt/broadcast_test.go
+++ b/backend/internal/hub/crdt/broadcast_test.go
@@ -286,7 +286,7 @@ func TestBroadcast_AlwaysVisible_ForwardsRawOps(t *testing.T) {
 // the workspace membership ops (SetWorkspaceRegister / TombstoneWorkspace) —
 // which replaced the old out-of-band MutateInternal and now flow through the
 // serialized submit pipeline — are broadcast to subscribers that admit the
-// workspace. The EntityKindWorkspaceRoot arm of batchVisibleOpsEvent keeps an
+// workspace. The EntityKindWorkspaceRoot arm of opVisibleForSubscriber keeps an
 // op when EITHER pre or post is visible (distinct from the
 // preVisible && postVisible rule for other entities), so a subscriber whose
 // filter contains the workspace must receive both ops as raw batch ops. A

--- a/backend/internal/hub/crdt/catchup_emit.go
+++ b/backend/internal/hub/crdt/catchup_emit.go
@@ -1,0 +1,295 @@
+package crdt
+
+import (
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+)
+
+// catchUpSink receives one batch's catch-up frames in wire order
+// (materialized → batch → removed). Both the live broadcast path and the
+// resume path adapt this sink so a third catch-up path cannot reintroduce
+// #357-style order/filter drift.
+//
+// Payloads arrive as THUNKS, and the EntityRef travels alongside, because the
+// two sinks have opposite cost profiles. The resume sink needs every payload
+// (it wraps them into the delta), while the live sink memoizes its wire frames
+// — per visibility mask for the batch frame, per ref for the transition frames
+// — and shares them across every subscriber in the fan-out. Passing built
+// payloads made the planner do that work once PER SUBSCRIBER only for the live
+// sink to discard it, which silently undid the memoization `batchEventCache`
+// exists for: the O(ops) stable-visibility filter went from once-per-mask to
+// once-per-subscriber, and each becoming-hidden ref allocated a fresh
+// EntityRemoved per subscriber. A thunk keeps ONE definition of each frame's
+// content here (so the two paths cannot drift) while letting the live sink skip
+// building what it already has cached.
+//
+// Borrow-only: a thunk's result MUST NOT be mutated — it may be, or may become,
+// a pointer aliased into a cross-subscriber cache.
+type catchUpSink interface {
+	// Materialized is called for a ref that became visible. em builds the
+	// payload; the live sink calls it only on a memo miss.
+	Materialized(ref EntityRef, em func() *leapmuxv1.EntityMaterialized)
+	// Batch is called once per batch with a thunk computing this subscriber's
+	// stable-visibility op subset. A nil result means "no visible ops" and the
+	// sink must emit nothing.
+	Batch(visible func() *leapmuxv1.OpBatch)
+	// Removed is called for a ref that became hidden.
+	Removed(ref EntityRef, er func() *leapmuxv1.EntityRemoved)
+	// End closes the batch's sequence. Called exactly once per batch, after
+	// every other frame, INCLUDING when the subscriber saw none of them -- it
+	// is the only point at which the client may advance its resume watermark,
+	// so skipping it would strand the cursor. See the BatchEnd proto doc.
+	End(atHLC *leapmuxv1.HLC)
+}
+
+// catchUpBatch names the four inputs that must all describe ONE committed
+// batch: its kind-ordered affected refs, the batch itself, the per-entity
+// workspace transitions recorded for it, and the HLC every frame it produces is
+// stamped with.
+//
+// A struct rather than four positionals because nothing in a positional call
+// site said they belonged together, and a call that paired one batch's refs or
+// transitions with another's ops would not fail to compile -- it would classify
+// every entity against the wrong batch's visibility and ship a silently wrong
+// frame stream. Both callers already draw all four from a single value (the live
+// path from one batchFanout, the resume path from one ResumeBatch), so the type
+// only names a grouping they already have. The same reasoning already produced
+// resumeRequest (manager_subscribe.go) one layer up and service.journalScan two.
+//
+// refs is the kind-ordered affected-refs slice; the live path passes the
+// batchFanout's precomputed `refs` (one sort per broadcast) and the resume path
+// computes it once per tail batch, so neither re-sorts per subscriber.
+type catchUpBatch struct {
+	refs        []affectedRef
+	batch       *leapmuxv1.OpBatch
+	transitions map[EntityRef]EntityWorkspaceTransition
+	atHLC       *leapmuxv1.HLC
+}
+
+// emitCatchUpFrames is the SINGLE per-batch frame planner for both catch-up
+// paths. It applies the shared visibility predicates (visibilityFor /
+// opVisibleForSubscriber / isMaterializedTransition / isRemovedTransition)
+// and emits frames in the wire-contract order batchFanout.sendTo and
+// buildResumeDelta must never diverge on.
+//
+// materializedFor supplies the EntityMaterialized payload for a becoming-
+// visible ref (live: clone from m.state; resume: persisted batch-era snapshot).
+// Returning nil skips that frame (tombstoned / missing / unsupported kind).
+// materializedFor's return value is borrow-only and is never mutated: when its
+// AtHlc is nil the backfill builds a COPY rather than stamping in place, because
+// the live supplier hands back a pointer aliased into a cross-subscriber memo
+// cache. Both suppliers pre-stamp AtHlc today (live: the cache; resume: a fresh
+// struct per ref), so the backfill is defence-in-depth.
+func emitCatchUpFrames(
+	cb catchUpBatch,
+	scope visibilityScope,
+	materializedFor func(EntityRef) *leapmuxv1.EntityMaterialized,
+	sink catchUpSink,
+) {
+	// 1. EntityMaterialized FIRST, kind-ordered (nodes before tabs).
+	for _, a := range cb.refs {
+		if !isMaterializedTransition(visibilityFor(scope, a.ref, a.trans)) {
+			continue
+		}
+		sink.Materialized(a.ref, func() *leapmuxv1.EntityMaterialized {
+			em := materializedFor(a.ref)
+			if em == nil {
+				return nil
+			}
+			if em.GetAtHlc() == nil {
+				// Copy rather than stamp in place. On the live path this
+				// pointer is the inner proto of a MarshaledEvent memoized
+				// across every subscriber in the fan-out, whose Bytes() is
+				// sync.Once-cached — a write here would mutate shared state
+				// AFTER some subscribers had already marshaled, and would race
+				// their writer goroutines. (Both suppliers pre-stamp AtHlc
+				// today, so this is defence-in-depth for a future third
+				// supplier, which is exactly the case an in-place write would
+				// break.)
+				return &leapmuxv1.EntityMaterialized{AtHlc: cb.atHLC, Entity: em.GetEntity()}
+			}
+			return em
+		})
+	}
+
+	// 2. The batch frame (stable-visibility ops).
+	sink.Batch(func() *leapmuxv1.OpBatch {
+		return filterVisibleOps(cb, scope)
+	})
+
+	// 3. EntityRemoved LAST (pending-drop / echo-splice ordering).
+	for _, a := range cb.refs {
+		if !isRemovedTransition(visibilityFor(scope, a.ref, a.trans)) {
+			continue
+		}
+		sink.Removed(a.ref, func() *leapmuxv1.EntityRemoved {
+			evt := buildEntityRemovedEvent(a.ref, cb.atHLC)
+			if evt == nil {
+				return nil
+			}
+			return evt.GetEntityRemoved()
+		})
+	}
+
+	// 4. Close the sequence. Unconditional — this is the client's ONLY
+	// watermark-advance point, so a batch that emitted nothing for this
+	// subscriber must still end, or the cursor never moves past it.
+	sink.End(cb.atHLC)
+}
+
+// filterVisibleOps returns the OpBatch subset a subscriber with `filter` should
+// see as the stable-visibility batch frame, or nil when none are visible.
+// The SINGLE implementation of the stable-visibility op-subset rule: both
+// catch-up paths reach it through emitCatchUpFrames, and the live path's
+// mask-keyed cache wraps its result rather than re-deriving one.
+//
+// When every op is visible, the ORIGINAL batch pointer is returned (no copy), so
+// the result ALIASES the caller's batch on both paths. MarshaledEvent marshals
+// lazily (sync.Once, on whichever writer goroutine touches it first), so wrapping
+// the alias in a fresh event buys no isolation: what actually makes the broadcast
+// path safe is that nothing mutates the committed batch after
+// Manager.commit hands it to broadcastBatch. Any caller that gains a
+// post-broadcast writer -- a pooled/reused OpBatch, an op-list trim, a
+// post-commit re-stamp -- must clone here first, on BOTH paths.
+func filterVisibleOps(cb catchUpBatch, scope visibilityScope) *leapmuxv1.OpBatch {
+	var visibleOps []*leapmuxv1.CrdtOp
+	for _, op := range cb.batch.GetOps() {
+		ref := OpTarget(op)
+		trans := cb.transitions[ref]
+		if !opVisibleForSubscriber(ref, visibilityFor(scope, ref, trans)) {
+			continue
+		}
+		if visibleOps == nil {
+			visibleOps = make([]*leapmuxv1.CrdtOp, 0, len(cb.batch.GetOps()))
+		}
+		visibleOps = append(visibleOps, op)
+	}
+	if len(visibleOps) == 0 {
+		return nil
+	}
+	if len(visibleOps) == len(cb.batch.GetOps()) {
+		return cb.batch
+	}
+	return &leapmuxv1.OpBatch{BatchId: cb.batch.GetBatchId(), Ops: visibleOps}
+}
+
+// liveCatchUpSink fans emitCatchUpFrames into a live subscriber, reusing the
+// broadcast fanout's MarshaledEvent caches (materialized / removed / batch
+// mask) so the hot path still marshals each payload at most once per ref /
+// visibility mask.
+//
+// CONTRACT: the batch frame is memoized per visibility MASK, so the thunk that
+// builds it may come from a different subscriber than the one being sent to.
+// That is sound only because two subscribers sharing a mask have identical
+// IsAllowed verdicts over the workspaces this batch touches, and therefore an
+// identical stable-visibility op subset. subscriberWorkspaceMask keys on
+// f.wsKeys (exactly those workspaces) and broadcastBatch disables the cache
+// entirely past 64 of them, where the mask would alias.
+type liveCatchUpSink struct {
+	fan *batchFanout
+	sub *Subscriber
+}
+
+// The thunks are ignored on all three methods: every payload this sink sends is
+// a MarshaledEvent memoized across the whole fan-out (per ref for the transition
+// frames, per visibility mask for the batch frame), so it never needs the
+// planner to build one. Dropping the thunk unevaluated IS the optimization.
+
+func (s liveCatchUpSink) Materialized(ref EntityRef, _ func() *leapmuxv1.EntityMaterialized) {
+	if evt := s.fan.materialized(ref); evt != nil {
+		_ = s.sub.Send(evt)
+	}
+}
+
+func (s liveCatchUpSink) Batch(visible func() *leapmuxv1.OpBatch) {
+	if evt := s.fan.batchEventFor(s.sub, visible); evt != nil {
+		_ = s.sub.Send(evt)
+	}
+}
+
+func (s liveCatchUpSink) Removed(ref EntityRef, _ func() *leapmuxv1.EntityRemoved) {
+	if evt := s.fan.removed(ref); evt != nil {
+		_ = s.sub.Send(evt)
+	}
+}
+
+func (s liveCatchUpSink) End(*leapmuxv1.HLC) {
+	// Identical for every subscriber of this batch, so it is built once per
+	// broadcast and shared like the other frames.
+	_ = s.sub.Send(s.fan.batchEnd())
+}
+
+// resumeCatchUpSink ACCUMULATES a ResumeDelta: the ordered WatchUserEvent frame
+// stream (same envelope live Send uses) and the watermark those frames
+// advertise. It owns both, so buildResumeDelta constructs exactly ONE per resume
+// (above the tail loop) and reads the two fields back when the scan is done,
+// rather than threading a pointer-to-slice plus a closure over a sibling local
+// through a freshly boxed sink per tail batch.
+//
+// POINTER RECEIVERS throughout, and the reason is mechanical, not stylistic: a
+// value receiver would append into a copy of the struct, so every frame after
+// the first would land in a slice header nobody reads and the delta would ship
+// short. The interface is satisfied by *resumeCatchUpSink alone, which makes a
+// value-typed misuse a compile error rather than a silent truncation.
+type resumeCatchUpSink struct {
+	frames []*leapmuxv1.WatchUserEvent
+	// maxHLC is the max over the frames THIS delta emits -- never a live-state
+	// read. See the max_hlc paragraph on SubscribeWithACL for why that
+	// distinction is load-bearing. Seeded with the request cursor so a delta
+	// that emits nothing still advertises the client's own position.
+	maxHLC *leapmuxv1.HLC
+}
+
+// advance raises maxHLC to hlc when hlc is newer, cloning rather than aliasing:
+// the HLCs handed here are borrowed out of frames whose payloads may alias
+// persisted or cross-subscriber protos.
+func (s *resumeCatchUpSink) advance(hlc *leapmuxv1.HLC) {
+	if hlc != nil && HLCCmp(hlc, s.maxHLC) > 0 {
+		s.maxHLC = HLCClone(hlc)
+	}
+}
+
+// The resume sink is the one that actually needs the payloads, so it evaluates
+// every thunk. A nil result means the planner had nothing to emit for that slot
+// (tombstoned / unsupported kind / no visible ops) and the frame is skipped.
+
+func (s *resumeCatchUpSink) Materialized(_ EntityRef, build func() *leapmuxv1.EntityMaterialized) {
+	em := build()
+	if em == nil {
+		return
+	}
+	s.frames = append(s.frames, &leapmuxv1.WatchUserEvent{
+		Event: &leapmuxv1.WatchUserEvent_EntityMaterialized{EntityMaterialized: em},
+	})
+	s.advance(em.GetAtHlc())
+}
+
+func (s *resumeCatchUpSink) Batch(visible func() *leapmuxv1.OpBatch) {
+	batch := visible()
+	if batch == nil {
+		return
+	}
+	s.frames = append(s.frames, &leapmuxv1.WatchUserEvent{
+		Event: &leapmuxv1.WatchUserEvent_Batch{Batch: batch},
+	})
+	for _, op := range batch.GetOps() {
+		s.advance(op.GetCanonicalHlc())
+	}
+}
+
+func (s *resumeCatchUpSink) Removed(_ EntityRef, build func() *leapmuxv1.EntityRemoved) {
+	er := build()
+	if er == nil {
+		return
+	}
+	s.frames = append(s.frames, &leapmuxv1.WatchUserEvent{
+		Event: &leapmuxv1.WatchUserEvent_EntityRemoved{EntityRemoved: er},
+	})
+	s.advance(er.GetAtHlc())
+}
+
+func (s *resumeCatchUpSink) End(atHLC *leapmuxv1.HLC) {
+	s.frames = append(s.frames, &leapmuxv1.WatchUserEvent{
+		Event: &leapmuxv1.WatchUserEvent_BatchEnd{BatchEnd: &leapmuxv1.BatchEnd{AtHlc: atHLC}},
+	})
+	s.advance(atHLC)
+}

--- a/backend/internal/hub/crdt/catchup_emit_internal_test.go
+++ b/backend/internal/hub/crdt/catchup_emit_internal_test.go
@@ -1,0 +1,168 @@
+package crdt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+)
+
+// TestEmitCatchUpFrames_LiveSinkDoesNotBuildPayloadsItDiscards pins the reason
+// the sink takes THUNKS rather than built payloads.
+//
+// The live sink answers every frame from a MarshaledEvent cache shared across
+// the whole fan-out. When the planner handed it finished payloads, it built
+// them once per subscriber and threw them away — turning the O(ops)
+// stable-visibility filter from once-per-visibility-mask into
+// once-per-subscriber, and allocating a fresh EntityRemoved per subscriber per
+// becoming-hidden ref. That is invisible to a correctness test (the bytes on
+// the wire are identical), so it is pinned here by counting thunk evaluations.
+func TestEmitCatchUpFrames_LiveSinkDoesNotBuildPayloadsItDiscards(t *testing.T) {
+	stable := EntityRef{Kind: EntityKindNode, NodeID: "n1"}
+	crossingIn := EntityRef{Kind: EntityKindNode, NodeID: "n2"}
+	trans := map[EntityRef]EntityWorkspaceTransition{
+		// n1 is stably visible, so its op ships in the batch frame.
+		stable: {Pre: "w1", Post: "w1"},
+		// n2 crosses INTO view, so it gets a materialized frame instead.
+		crossingIn: {Pre: "", Post: "w1"},
+	}
+	batch := &leapmuxv1.OpBatch{
+		BatchId: "b1",
+		Ops: []*leapmuxv1.CrdtOp{{
+			OpId:         "op1",
+			CanonicalHlc: &leapmuxv1.HLC{Physical: 1, Logical: 0, ClientId: "c"},
+			Body: &leapmuxv1.CrdtOp_SetNodeRegister{SetNodeRegister: &leapmuxv1.SetNodeRegisterOp{
+				NodeId: "n1",
+				Field:  &leapmuxv1.SetNodeRegisterOp_Position{Position: "a0"},
+			}},
+		}},
+	}
+	filter := NewSubscriberFilter(map[string]bool{"w1": true})
+	atHLC := &leapmuxv1.HLC{Physical: 1, Logical: 0, ClientId: "c"}
+	cb := catchUpBatch{
+		refs:        orderedAffectedRefs(trans),
+		batch:       batch,
+		transitions: trans,
+		atHLC:       atHLC,
+	}
+
+	materializedCalls := 0
+	materializedFor := func(EntityRef) *leapmuxv1.EntityMaterialized {
+		materializedCalls++
+		return &leapmuxv1.EntityMaterialized{AtHlc: atHLC}
+	}
+
+	// A sink that never evaluates a thunk, standing in for the live sink's
+	// cache-hit path.
+	discarding := &countingSink{}
+	emitCatchUpFrames(cb, liveScope(filter), materializedFor, discarding)
+	assert.Equal(t, 0, materializedCalls,
+		"a sink that answers from cache must not make the planner clone live state")
+	assert.Equal(t, 1, discarding.batchCalls, "Batch is still invoked exactly once per batch")
+	assert.Equal(t, 1, discarding.endCalls,
+		"End must close the sequence even for a sink that emitted nothing -- it is the client's only watermark-advance point")
+
+	// The resume sink DOES need the payloads, so its thunks must produce them.
+	evaluating := &countingSink{evaluate: true}
+	emitCatchUpFrames(cb, liveScope(filter), materializedFor, evaluating)
+	assert.Equal(t, 1, materializedCalls,
+		"a sink that needs the payload gets it built exactly once")
+	assert.NotNil(t, evaluating.lastBatch, "the evaluated batch thunk must yield the visible ops")
+	assert.Equal(t, "b1", evaluating.lastBatch.GetBatchId())
+}
+
+type countingSink struct {
+	evaluate         bool
+	batchCalls       int
+	materializedCall int
+	endCalls         int
+	lastBatch        *leapmuxv1.OpBatch
+}
+
+func (s *countingSink) End(*leapmuxv1.HLC) { s.endCalls++ }
+
+func (s *countingSink) Materialized(_ EntityRef, em func() *leapmuxv1.EntityMaterialized) {
+	s.materializedCall++
+	if s.evaluate {
+		em()
+	}
+}
+
+func (s *countingSink) Batch(visible func() *leapmuxv1.OpBatch) {
+	s.batchCalls++
+	if s.evaluate {
+		s.lastBatch = visible()
+	}
+}
+
+func (s *countingSink) Removed(_ EntityRef, er func() *leapmuxv1.EntityRemoved) {
+	if s.evaluate {
+		er()
+	}
+}
+
+// TestFilterVisibleOps_AliasesTheCallerOnlyWhenNothingIsFiltered pins the
+// ALIASING as deliberate, so the precondition it depends on is executable
+// rather than only prose.
+//
+// The deleted batchVisibleOpsEvent always allocated a fresh OpBatch, which made
+// "the broadcast frame never shares storage with the committed batch"
+// structurally true. Returning the caller's pointer on the all-visible path --
+// overwhelmingly the common one -- trades that guarantee for the allocation,
+// and the guarantee was load-bearing only against a POST-COMMIT WRITER: the
+// shared MarshaledEvent marshals lazily under sync.Once, on a WS writer
+// goroutine, after broadcastBatch has returned.
+//
+// No such writer exists today (nothing after Manager.commit's broadcastBatch
+// call mutates the batch; it only reads GetOps to clone op ids and HLCs), which
+// is why the alias is safe and why this is a test rather than a restored copy:
+// copying on every broadcast for every subscriber is real cost on the path #267
+// exists to make cheap. What this fails on is the change that makes it UNSAFE
+// -- anyone who starts pooling, trimming or re-stamping committed batches will
+// land here, next to the doc naming exactly what they must do.
+func TestFilterVisibleOps_AliasesTheCallerOnlyWhenNothingIsFiltered(t *testing.T) {
+	hidden := EntityRef{Kind: EntityKindNode, NodeID: "n2"}
+	// nil WorkspaceIDs means "allow all", so visibility turns purely on the
+	// transitions map below.
+	scope := liveScope(SubscriberFilter{})
+	nodeOp := func(id string) *leapmuxv1.CrdtOp {
+		return &leapmuxv1.CrdtOp{
+			Body: &leapmuxv1.CrdtOp_SetNodeRegister{SetNodeRegister: &leapmuxv1.SetNodeRegisterOp{
+				NodeId: id,
+				Field:  &leapmuxv1.SetNodeRegisterOp_Position{Position: "a0"},
+			}},
+		}
+	}
+
+	t.Run("all ops visible returns the caller's batch pointer", func(t *testing.T) {
+		batch := &leapmuxv1.OpBatch{
+			BatchId: "b1",
+			Ops:     []*leapmuxv1.CrdtOp{nodeOp("n1")},
+		}
+		trans := map[EntityRef]EntityWorkspaceTransition{
+			{Kind: EntityKindNode, NodeID: "n1"}: {Pre: "ws1", Post: "ws1"},
+		}
+		got := filterVisibleOps(catchUpBatch{batch: batch, transitions: trans}, scope)
+		assert.Same(t, batch, got,
+			"the all-visible path aliases by design; see the doc on filterVisibleOps before changing it")
+	})
+
+	t.Run("a filtered batch is a fresh value that shares no slice with the caller", func(t *testing.T) {
+		batch := &leapmuxv1.OpBatch{
+			BatchId: "b1",
+			Ops:     []*leapmuxv1.CrdtOp{nodeOp("n1"), nodeOp("n2")},
+		}
+		trans := map[EntityRef]EntityWorkspaceTransition{
+			{Kind: EntityKindNode, NodeID: "n1"}: {Pre: "ws1", Post: "ws1"},
+			// Empty Pre/Post is invisible: IsAllowed("") is always false.
+			hidden: {},
+		}
+		got := filterVisibleOps(catchUpBatch{batch: batch, transitions: trans}, scope)
+		if assert.NotNil(t, got) {
+			assert.NotSame(t, batch, got)
+			assert.Len(t, got.GetOps(), 1)
+			assert.Len(t, batch.GetOps(), 2, "the caller's batch must be left intact")
+		}
+	})
+}

--- a/backend/internal/hub/crdt/fakejournal_test.go
+++ b/backend/internal/hub/crdt/fakejournal_test.go
@@ -8,6 +8,7 @@ import (
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/hub/crdt"
+	"google.golang.org/protobuf/proto"
 )
 
 // fakeJournal is an in-memory crdt.Journal used by the manager
@@ -20,13 +21,31 @@ type fakeJournal struct {
 	state    *leapmuxv1.UserCrdtState
 	stateRaw bool // true once Upsert has happened (compaction)
 
-	batches   []*leapmuxv1.OpBatch
-	dedup     map[string]crdt.RecentBatchRecord // batch_id → row
-	indexRows map[string]crdt.TabIndexRow       // owned_tabs[tab_id] → row
-	rendered  map[string]crdt.TabIndexRow       // rendered_tabs[tab_id] → row
+	// batches and transitions are parallel slices: one entry per committed
+	// batch, paired the way the production journal's user_op_batches row +
+	// transitions_payload column are. Append-only under f.mu.
+	batches     []*leapmuxv1.OpBatch
+	transitions []*leapmuxv1.BatchTransitions
+	dedup       map[string]crdt.RecentBatchRecord // batch_id → row
+	indexRows   map[string]crdt.TabIndexRow       // owned_tabs[tab_id] → row
+	rendered    map[string]crdt.TabIndexRow       // rendered_tabs[tab_id] → row
 
 	commitErr error // injectable CommitBatch failure
 	lookupErr error // injectable LookupRecentBatchID failure
+	listErr   error // injectable ListBatchesAfter failure (resume tail read)
+	// corruptTransitions holds batch ids whose transitions_payload should be
+	// reported as corrupt. The scan STOPS at that row and returns
+	// ErrResumeCorrupt alongside the CorruptRow -- the batch's ops are NOT
+	// shipped -- mirroring production, where continuing past the row would ship
+	// a delta missing the batch while later frames still advanced the client's
+	// watermark past it.
+	corruptTransitions map[string]bool
+	// listHold, when non-nil, blocks ListBatchesAfter until the channel is
+	// closed before returning. Used by concurrency tests to hold a resume's
+	// tail scan mid-flight and assert other manager operations are not stalled
+	// on subscribeExpandMu / m.projection during the scan.
+	listHold    chan struct{}
+	listReached chan struct{} // closed when ListBatchesAfter enters the hold
 }
 
 func newFakeJournal() *fakeJournal {
@@ -48,6 +67,86 @@ func (f *fakeJournal) LoadState(_ context.Context, _ string) (*leapmuxv1.UserCrd
 	return state, tail, nil
 }
 
+// ListBatchesAfter mirrors crdtJournal.ListBatchesAfter against the in-memory
+// batch slice: it returns batches (paired with their persisted transitions)
+// whose FIRST op's canonical HLC is strictly after `cursor` (the same tuple
+// ordering the SQL cursor uses), honoring the maxOps AND maxBytes budgets, the
+// ErrDeltaTooLarge sentinel, and the stop-on-corrupt ErrResumeCorrupt contract,
+// so resume tests exercise the same decision surface as production.
+//
+// maxBytes is measured as proto.Size(batch) + proto.Size(transitions), the
+// fake's stand-in for len(batch_payload) + len(transitions_payload). Ignoring
+// it (as this fake used to) made every byte-budget FALLBACK structurally
+// unreachable from any manager-level test.
+func (f *fakeJournal) ListBatchesAfter(_ context.Context, _ string, cursor, until *leapmuxv1.HLC, maxOps, maxBytes int) ([]crdt.ResumeBatch, []crdt.CorruptRow, error) {
+	// Block BEFORE taking f.mu so a held scan does not self-deadlock against
+	// the test's other fake-journal calls (the test closes listHold to release).
+	// Signal entry so a test can deterministically wait for the scan to start.
+	if f.listHold != nil {
+		if f.listReached != nil {
+			close(f.listReached)
+		}
+		<-f.listHold
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.listErr != nil {
+		// Injection hook for the recoverable sentinels (ErrDeltaTooLarge,
+		// ErrResumeCorrupt) and for hard errors.
+		return nil, nil, f.listErr
+	}
+	out := []crdt.ResumeBatch{}
+	var corrupt []crdt.CorruptRow
+	ops := 0
+	bytes := 0
+	for i, b := range f.batches {
+		if len(b.GetOps()) == 0 {
+			// A zero-op batch never matches (no HLC to order by) and would
+			// panic the index below; the prod journal iterates GetOps() so it
+			// is safe, and the manager rejects zero-op batches before they
+			// reach the journal, but a test seeding batches directly must not
+			// crash here.
+			continue
+		}
+		first := b.GetOps()[0].GetCanonicalHlc()
+		if crdt.HLCCmp(first, cursor) <= 0 {
+			continue
+		}
+		if until != nil && crdt.HLCCmp(first, until) > 0 {
+			return out, corrupt, nil
+		}
+		if maxOps > 0 && ops+len(b.GetOps()) > maxOps {
+			return out, corrupt, crdt.ErrDeltaTooLarge
+		}
+		var trans *leapmuxv1.BatchTransitions
+		if i < len(f.transitions) {
+			trans = f.transitions[i]
+		}
+		// Byte budget, checked BEFORE appending (as production does) so an
+		// over-budget row is never included in the returned prefix.
+		rowBytes := proto.Size(b) + proto.Size(trans)
+		if maxBytes > 0 && bytes+rowBytes > maxBytes {
+			return out, corrupt, crdt.ErrDeltaTooLarge
+		}
+		// STOP-ON-CORRUPT: a seeded corrupt-transitions batch aborts the scan
+		// with ErrResumeCorrupt so the manager FALLBACKs, mirroring production.
+		// Substituting empty transitions and continuing would silently drop the
+		// batch's ops while later frames advanced the client past it.
+		if f.corruptTransitions[b.GetBatchId()] {
+			corrupt = append(corrupt, crdt.CorruptRow{
+				BatchID: b.GetBatchId(),
+				Field:   "transitions_payload",
+				Cause:   errors.Join(crdt.ErrResumeCorrupt, errors.New("fake: seeded corrupt transitions")),
+			})
+			return out, corrupt, crdt.ErrResumeCorrupt
+		}
+		ops += len(b.GetOps())
+		bytes += rowBytes
+		out = append(out, crdt.ResumeBatch{Batch: b, Transitions: trans})
+	}
+	return out, corrupt, nil
+}
+
 // seedState installs a compacted state payload, as if a previous compaction had
 // written it. LoadState ignores the userID it is handed (the fake holds exactly
 // one tenant's rows), which is what lets a test hand a manager a payload naming
@@ -66,6 +165,7 @@ func (f *fakeJournal) CommitBatch(_ context.Context, c crdt.CommitBatch) error {
 		return f.commitErr
 	}
 	f.batches = append(f.batches, c.Batch)
+	f.transitions = append(f.transitions, c.Transitions)
 	// The dedup TABLE row is the commit envelope's context plus the batch's own
 	// fields; crdt.CommitBatch states the former once, so reassemble it here
 	// the way the real journal adapter does when it writes the row.
@@ -127,15 +227,33 @@ func (f *fakeJournal) CompactBatch(_ context.Context, c crdt.CompactBatch) error
 		return nil
 	}
 	kept := f.batches[:0]
-	for _, batch := range f.batches {
-		// Drop the batch if its last canonical HLC is ≤ watermark.
+	keptTransitions := f.transitions[:0]
+	for i, batch := range f.batches {
+		// Drop the batch if its last canonical HLC is ≤ watermark. Guard
+		// zero-op batches the way ListBatchesAfter does: a test seeding
+		// batches directly must not crash here, and such a batch has no HLC
+		// to order by (so it can never be strictly > the watermark anyway).
 		ops := batch.GetOps()
+		if len(ops) == 0 {
+			continue
+		}
 		last := ops[len(ops)-1].GetCanonicalHlc()
 		if crdt.HLCCmp(last, c.DropThrough) > 0 {
 			kept = append(kept, batch)
+			// Keep the parallel slices in lockstep by index: append the paired
+			// transition when present, or a nil placeholder when the batch was
+			// seeded without one, so post-compaction kept[k] always pairs with
+			// keptTransitions[k] (ListBatchesAfter already tolerates a nil
+			// Transitions via its own bounds guard).
+			var trans *leapmuxv1.BatchTransitions
+			if i < len(f.transitions) {
+				trans = f.transitions[i]
+			}
+			keptTransitions = append(keptTransitions, trans)
 		}
 	}
 	f.batches = kept
+	f.transitions = keptTransitions
 	return nil
 }
 

--- a/backend/internal/hub/crdt/journal.go
+++ b/backend/internal/hub/crdt/journal.go
@@ -2,10 +2,43 @@ package crdt
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 )
+
+// ErrDeltaTooLarge is returned by ListBatchesAfter when the post-cursor tail
+// exceeds the caller's maxOps or maxBytes budget. The receiver should fall
+// back to a full materialized snapshot rather than ship an unbounded delta
+// on resume.
+var ErrDeltaTooLarge = errors.New("crdt: resume delta exceeds budget")
+
+// ErrResumeCorrupt reports that ListBatchesAfter hit a row whose batch_payload
+// or transitions_payload could not be decoded. Like ErrDeltaTooLarge it is a
+// RECOVERABLE verdict, not a connect failure: buildResumeDelta branches on it
+// via errors.Is and re-enters the full-snapshot FALLBACK path. The offending
+// row is also returned in the CorruptRows slice so the caller can log it.
+//
+// The scan stops rather than skipping the row, because a delta that omits one
+// committed batch is indistinguishable on the wire from that batch never having
+// existed — while the frames after it still advance the client's watermark past
+// it, and the resume cursor is strictly-greater, so no later resume re-requests
+// it. One full snapshot is cheap; a permanently diverged client is not.
+var ErrResumeCorrupt = errors.New("crdt: resume journal row corrupt")
+
+// ErrBootJournalCorrupt reports the SAME damage as ErrResumeCorrupt found on the
+// BOOT scan, where the verdict is the opposite: there is no snapshot to fall
+// back to, because the snapshot is what Bootstrap is trying to build.
+//
+// Two sentinels rather than one because the sentinel IS the verdict. Wrapping a
+// boot failure in ErrResumeCorrupt made `errors.Is(err, ErrResumeCorrupt)` true
+// for an error whose whole documented meaning is "degrade to a snapshot" — so
+// the first handler to grow that arm above registry.Get would serve a snapshot
+// built from a state blob missing every op after the bad row, and report a
+// successful connect. Nothing branches on it there today; the mislabel is the
+// hazard, and it was pinned by a passing test.
+var ErrBootJournalCorrupt = errors.New("crdt: boot journal row corrupt")
 
 // Journal is the persistence interface the manager depends on. The
 // concrete implementation lives in the hub service package and binds
@@ -15,6 +48,42 @@ type Journal interface {
 	// batches after compaction_watermark. nil state means "first
 	// boot — no state row yet"; the tail is empty in that case.
 	LoadState(ctx context.Context, userID string) (state *leapmuxv1.UserCrdtState, tail []*leapmuxv1.OpBatch, err error)
+
+	// ListBatchesAfter returns the journal's op batches (with their persisted
+	// per-entity workspace transitions) strictly after the given cursor HLC,
+	// paged forward by HLC tuple. It is the resume counterpart to the tail
+	// LoadState returns at boot: same underlying scan, just bounded by a
+	// client-supplied cursor instead of compaction_watermark. Each ResumeBatch
+	// pairs the batch with its BatchTransitions so buildResumeDelta can replay
+	// the SAME pre/post stable-visibility classification the live broadcast
+	// applies — emitting materialized/removed frames for entities that crossed
+	// the subscriber's visibility boundary during the gap, not just the
+	// current-workspace-filtered raw ops.
+	//
+	// maxOps caps the total op count (across all batches); maxBytes caps the
+	// sum of batch_payload + transitions_payload sizes. Either budget <= 0
+	// disables that ceiling. until, when non-nil, exclusive-caps the scan to
+	// batches whose first-op HLC is <= until (the register-time high-water):
+	// commits that land after registration (HLC > until) are owned by live
+	// broadcast into the just-registered subscriber and must not also appear
+	// in the delta. until nil means unbounded (LoadState / boot).
+	//
+	// If the tail would exceed an enabled ceiling, the scan aborts with
+	// ErrDeltaTooLarge so the caller can fall back to a full snapshot rather
+	// than ship a giant delta. On ErrDeltaTooLarge the returned slice is
+	// incidental (batches decoded before the ceiling was hit) and MUST be
+	// discarded — SubscribeWithACL branches on the sentinel and re-enters the
+	// full-snapshot path.
+	//
+	// A row whose batch_payload or transitions_payload cannot be decoded STOPS
+	// the scan and returns ErrResumeCorrupt, with that row's id + field + cause
+	// in the CorruptRows slice for logging. Like ErrDeltaTooLarge this is a
+	// FALLBACK signal, not a connect failure, and the returned batches MUST be
+	// discarded: shipping the prefix would omit the corrupt batch while later
+	// frames advanced the client past it, permanently. Both payload fields are
+	// treated alike — empty transitions are not a safe default, they make
+	// filterVisibleOps drop every op in the batch.
+	ListBatchesAfter(ctx context.Context, userID string, after, until *leapmuxv1.HLC, maxOps, maxBytes int) (batches []ResumeBatch, corrupt []CorruptRow, err error)
 
 	// CommitBatch atomically writes the batch to user_op_batches, the
 	// dedup row to user_recent_batch_ids, and the index-view diff to
@@ -62,6 +131,37 @@ type CommitBatch struct {
 	Epoch       int64
 	Dedup       DedupEntry
 	IndexDiff   IndexDiff
+	// Transitions is the per-batch AffectedEntities (encoded by
+	// AffectedEntitiesToProto) persisted alongside the OpBatch so a resume can
+	// replay the SAME pre/post stable-visibility classification the live
+	// broadcast applies. Nil is treated as empty (the journal marshals an empty
+	// BatchTransitions), so a caller with no transitions still commits a
+	// NOT NULL row.
+	Transitions *leapmuxv1.BatchTransitions
+}
+
+// ResumeBatch pairs a journal op batch with its persisted per-entity workspace
+// transitions. ListBatchesAfter yields these so buildResumeDelta has both the
+// ops (to filter to the stable-visibility subset) and the transitions (to
+// classify each entity as materialized / stable / removed for this subscriber).
+type ResumeBatch struct {
+	Batch       *leapmuxv1.OpBatch
+	Transitions *leapmuxv1.BatchTransitions
+}
+
+// CorruptRow names a journal row whose batch_payload or transitions_payload
+// could not be decoded. ListBatchesAfter STOPS at such a row and returns it
+// alongside ErrResumeCorrupt, so the caller can log the damage and FALLBACK to
+// a full snapshot. The scan deliberately does NOT continue past it: a delta
+// that omits one committed batch still advances the client's max_hlc past that
+// batch, and the resume cursor is strictly-greater, so the client would never
+// re-request it — a permanent divergence, versus one cheap full snapshot.
+// Field is "batch_payload" or "transitions_payload"; Cause is wrapped via
+// wrapResumeCorrupt (carrying ErrResumeCorrupt).
+type CorruptRow struct {
+	BatchID string
+	Field   string
+	Cause   error
 }
 
 // DedupEntry is the batch-specific half of a user_recent_batch_ids row: the

--- a/backend/internal/hub/crdt/manager.go
+++ b/backend/internal/hub/crdt/manager.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/leapmux/leapmux/channelwire"
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/util/id"
 	"github.com/leapmux/leapmux/internal/util/userid"
@@ -27,6 +28,22 @@ const (
 	HubReservedPrincipal = "hub"
 	// DedupTTL is how long a batch_id stays in user_recent_batch_ids.
 	DedupTTL = 14 * 24 * time.Hour
+	// OpRetentionTTL is how far behind max_hlc the op_retention_watermark
+	// lags: op batches whose last canonical HLC is older than this (relative
+	// to the live max_hlc) may be deleted by maybeCompact, while tombstones
+	// are pruned at the much tighter compaction_watermark (= max_hlc). The
+	// two diverge because tombstone pruning is load-bearing for correctness
+	// (HLC monotonicity, bounded user_state growth), while op-batch deletion
+	// is pure storage optimization — the op log is an append-only history
+	// and replaying a longer tail is sound (each op is idempotent under the
+	// CRDT merge). The retention window is what widens delta-resume beyond a
+	// ~60s reconnect gap to multi-hour gaps (a client refresh after a few
+	// hours still resumes instead of taking a full snapshot), so long as the
+	// post-cursor tail still fits MaxResumeDeltaOps / MaxResumeDeltaBytes —
+	// those budget caps are independent and still force a FALLBACK when the
+	// tail is too large to ship as a delta. 24h is a conservative first
+	// window; pick it against measured per-user op volume before widening.
+	OpRetentionTTL = 24 * time.Hour
 	// PresenceClearGrace is how long the manager waits after a
 	// client's last WS subscription closes before clearing its
 	// presence entries. A reconnect within the grace window cancels
@@ -46,7 +63,86 @@ const (
 	// keeps the worst-case orphan lifetime predictable without adding
 	// observable load.
 	presenceSweepInterval = time.Hour
+	// MaxResumeDeltaOps bounds the op-count budget a SubscribeWithACL replay may
+	// ship as a delta before falling back to a full materialized snapshot. A
+	// reconnecting client whose last-applied HLC is far enough behind that the
+	// post-cursor journal tail exceeds this many ops gets a full `initial`
+	// frame instead -- the delta would be larger than the snapshot it exists
+	// to avoid. Picked well above a single busy session's churn but below the
+	// point where marshaling + writing the tail costs more than materialized.
+	MaxResumeDeltaOps = 5000
+	// MaxResumeDeltaBytes bounds the decoded journal payload a resume may ship
+	// (sum of batch_payload + transitions_payload over the accepted tail).
+	// Op count alone under-budgets after per-batch record snapshots landed in
+	// transitions_payload: a few thousand ops can still exceed the client WS
+	// read limit (UserEventsReadLimit / desktop maxFrameSize). Cap well under
+	// those frame ceilings so an oversized tail falls back to `initial`
+	// instead of reconnect-looping on a frame the client cannot read.
+	//
+	// MEASURED ON SOURCE ROWS, NOT ON THE EMITTED FRAME, so it is approximate
+	// with respect to what actually goes on the wire -- and approximate in the
+	// permissive direction: buildResumeDelta ADDS to the rows it reads (one
+	// BatchEnd per tail batch, synthesized EntityRemoved frames, a fresh AtHlc
+	// stamp on each EntityMaterialized, and a WatchUserEvent envelope per
+	// frame). The budget is checked during a streaming, paged scan, before any
+	// delta exists to measure, which is also what makes it the right place to
+	// bound MEMORY. Nothing here bounds that gap: op count does NOT bound the
+	// transition frames, because a single SetFloatingWindowRegister(workspace_id)
+	// drags a whole subtree into AffectedEntities, so transition entries per batch
+	// are themselves bounded by this byte budget rather than by
+	// MaxResumeDeltaOps. What the wire actually carries is therefore gated
+	// separately and exactly, by MaxResumeDeltaFrameBytes below: buildResumeDelta
+	// runs proto.Size on the BUILT delta as an ADDITIONAL check after this one, so
+	// raising either ceiling cannot silently produce an unreadable frame.
+	MaxResumeDeltaBytes = 4 << 20 // 4 MiB
+	// resumeDeltaEnvelopeHeadroom is what the wire frame adds on top of the
+	// ResumeDelta MaxResumeDeltaFrameBytes measures: the WatchUserEvent oneof
+	// wrapper, the 4-byte length prefix channelwire.WriteFramedBytes prepends,
+	// and the subscriber_client_id + user_id SubscribeOutcome.Bootstrap stamps
+	// onto the delta AFTER buildResumeDelta has sized it. Real overhead is a few
+	// tags, two varint lengths and two ids -- a few hundred bytes. 64 KiB is
+	// deliberate slack (the same figure, for the same reason, as
+	// channelwire.InnerEnvelopeHeadroom) so that adding a field to ResumeDelta or
+	// to the bootstrap stamping cannot quietly push a passing delta over the
+	// read limit.
+	resumeDeltaEnvelopeHeadroom = 64 << 10 // 64 KiB
+	// MaxResumeDeltaFrameBytes is the ceiling on the BUILT ResumeDelta, checked
+	// with proto.Size in buildResumeDelta once the frame stream is assembled.
+	//
+	// Derived from channelwire.UserEventsReadLimit rather than written as its own
+	// number: that limit is what the subscriber's socket enforces
+	// (wsConn.SetReadLimit in ws_userevents.go, and the same value on every Go
+	// consumer via OpenUserEventsWS), and the desktop sidecar's frame ceiling is
+	// that plus 4 MiB, so the read limit is the binding one. A delta past it does
+	// not degrade -- the whole delta is ONE WebSocket message, so the read fails,
+	// the client reconnects with the same cursor, rebuilds the same oversized
+	// frame, and loops with no server-side error. Deriving keeps the gate moving
+	// with the limit it protects instead of drifting from it.
+	MaxResumeDeltaFrameBytes = channelwire.UserEventsReadLimit - resumeDeltaEnvelopeHeadroom
 )
+
+// OpRetentionCutoffPhysicalMs is the HLC physical below which an op batch is
+// eligible for deletion, given wall-clock time now and a retention window ttl.
+//
+// This is the ONE definition of the retention floor. The cross-user sweep
+// (store.CleanupStore.DeleteUserOpBatchesBeforePhysical) deletes rows below
+// it, and Manager.decideResume refuses a resume cursor below it, so the set of
+// rows the sweep may remove and the set of cursors a resume may accept cannot
+// disagree.
+//
+// It returns an HLC physical rather than a wall clock because the cursor lives
+// in that domain. HLC physical is Unix epoch-ms, but it is NOT the local wall
+// clock: Clock.Tick clamps it monotonically and Clock.Observe re-seeds it from
+// persisted state, so it can run permanently ahead of real time after a
+// backward clock correction. Deriving the cutoff FROM now() and comparing it
+// AGAINST HLC physicals is the deliberate arrangement -- the floor advances
+// with real time (so dormant accounts drain) while both sides read one number.
+// Sweeping the committed_at column instead would reintroduce the split, and
+// worse, committed_at is stamped by the DB server, a different machine under
+// Postgres and MySQL.
+func OpRetentionCutoffPhysicalMs(now time.Time, ttl time.Duration) int64 {
+	return now.Add(-ttl).UnixMilli()
+}
 
 // SubmitInput is what callers hand the manager. internal=true skips
 // per-op auth and is required for SetWorkspaceRootNodeOp.
@@ -180,6 +276,20 @@ type Manager struct {
 	// can mutate it before NewManager finishes building the controller.
 	clearGrace time.Duration
 
+	// opRetentionTTL seeds the lag between compaction_watermark and
+	// op_retention_watermark in maybeCompact. Held on Manager so
+	// WithOpRetentionTTL can mutate it before Start, and so tests can shrink
+	// it to milliseconds to assert the retention/drop boundary without
+	// sleeping through the production 24h default.
+	opRetentionTTL time.Duration
+
+	// maxResumeDeltaFrameBytes is the ceiling buildResumeDelta enforces on the
+	// BUILT delta (proto.Size). Held on Manager rather than read from the
+	// constant so WithMaxResumeDeltaFrameBytes can shrink it in tests, which is
+	// the only way to exercise the FALLBACK without materializing a ~16 MiB
+	// fixture.
+	maxResumeDeltaFrameBytes int
+
 	// reconcileNudger, when set, is told which workers hosted a tab a batch
 	// just tombstoned, so each can converge immediately instead of waiting out
 	// its reconciler interval. Nil disables the nudge.
@@ -235,7 +345,21 @@ type Manager struct {
 	nudgeWG sync.WaitGroup
 }
 
+// overflowed reports whether the transport flagged a dropped frame. A nil
+// callback (every non-websocket caller, and every test that does not care)
+// reads as "no overflow".
+func (s *Subscriber) overflowed() bool {
+	return s.Overflowed != nil && s.Overflowed()
+}
+
 // SubscriberFilter narrows the events a subscriber receives.
+//
+// The WorkspaceIDs map is treated as immutable after the filter value is
+// installed on a Subscriber: expand/contract REPLACE the whole Filter via
+// WithWorkspace / WithoutWorkspace rather than mutating the map in place.
+// That makes a plain value copy of SubscriberFilter safe to hand to a
+// long-running resume scan without snapshotFilter — no concurrent map
+// read/write against lifecycle expand/contract.
 type SubscriberFilter struct {
 	WorkspaceIDs map[string]bool
 }
@@ -252,6 +376,56 @@ func (f SubscriberFilter) IsAllowed(workspaceID string) bool {
 		return true
 	}
 	return f.WorkspaceIDs[workspaceID]
+}
+
+// WithWorkspace returns a filter that also allows workspaceID. The receiver
+// is never mutated: a new map is allocated when the key is absent. A nil
+// (allow-all) filter is already allowed for every id, so it is returned
+// unchanged. Callers MUST assign the result (sub.Filter = sub.Filter.WithWorkspace(id)).
+func (f SubscriberFilter) WithWorkspace(workspaceID string) SubscriberFilter {
+	if workspaceID == "" || f.IsAllowed(workspaceID) {
+		return f
+	}
+	// f.WorkspaceIDs is non-nil here (nil would have IsAllowed==true).
+	next := make(map[string]bool, len(f.WorkspaceIDs)+1)
+	for ws, allowed := range f.WorkspaceIDs {
+		next[ws] = allowed
+	}
+	next[workspaceID] = true
+	return SubscriberFilter{WorkspaceIDs: next}
+}
+
+// WithoutWorkspace returns a filter that no longer allows workspaceID. The
+// receiver is never mutated. A nil (allow-all) filter is returned unchanged
+// (contractors only run on concrete ACL maps). Callers MUST assign the result.
+func (f SubscriberFilter) WithoutWorkspace(workspaceID string) SubscriberFilter {
+	if f.WorkspaceIDs == nil {
+		return f
+	}
+	if _, ok := f.WorkspaceIDs[workspaceID]; !ok {
+		return f
+	}
+	next := make(map[string]bool, len(f.WorkspaceIDs))
+	for ws, allowed := range f.WorkspaceIDs {
+		if ws == workspaceID {
+			continue
+		}
+		next[ws] = allowed
+	}
+	return SubscriberFilter{WorkspaceIDs: next}
+}
+
+// NewSubscriberFilter copies ids into a private map so the caller cannot
+// mutate the filter through the input map. nil means allow-all.
+func NewSubscriberFilter(ids map[string]bool) SubscriberFilter {
+	if ids == nil {
+		return SubscriberFilter{}
+	}
+	out := make(map[string]bool, len(ids))
+	for ws, allowed := range ids {
+		out[ws] = allowed
+	}
+	return SubscriberFilter{WorkspaceIDs: out}
 }
 
 // Subscriber is a single open user-event subscription (one connected
@@ -274,6 +448,49 @@ type Subscriber struct {
 	// those IDs when ACLs change.
 	RequestedWorkspaceIDs map[string]bool
 	Filter                SubscriberFilter
+	// resumeSuppressThrough, when non-nil, is the register-time MaxHlc
+	// high-water for a RESUME subscribe. Live batch broadcasts whose
+	// last-op HLC is <= this value are skipped for this subscriber: those
+	// batches are owned by the ResumeDelta journal scan, and delivering
+	// them via broadcast as well would dual-deliver the same catch-up
+	// frames. Set atomically with registration under m.projection (see
+	// SubscribeWithACL); left set for the life of the connection (later
+	// commits always have a strictly greater HLC). Presence / lifecycle
+	// frames bypass this gate (they go through broadcastTo, not sendTo).
+	resumeSuppressThrough *leapmuxv1.HLC
+	// Overflowed, when set, reports that the transport could not buffer a frame
+	// while the resume scan was running.
+	//
+	// The transport used to answer that by tearing the connection down, which
+	// sent the client back with the SAME cursor to rebuild the SAME multi-page
+	// scan -- under the sustained broadcast load that caused the overflow, so it
+	// could overflow again. The loop is bounded (the widening gap eventually
+	// trips MaxResumeDeltaOps and FALLBACKs anyway), but every round is a wasted
+	// multi-page journal scan on a hub already under the load that triggered it.
+	// buildResumeDelta consults this instead and converts the overflow into ONE
+	// snapshot.
+	//
+	// A CALLBACK, like OnRebaseline, rather than a flag on this struct: the
+	// state belongs to the transport's queue, and Subscriber is copied by value
+	// (see cloneSubscriber), which no synchronisation primitive survives.
+	Overflowed func() bool
+	// OnRebaseline, when set, is called at the moment a RESUME registration is
+	// replaced by a FALLBACK one (resumeFallback), while m.projection is held
+	// and BEFORE the materialized baseline is taken.
+	//
+	// It exists because the transport buffers frames it has not written yet.
+	// During the resume scan the subscriber is registered, so live broadcasts
+	// enqueue normally; if the scan then gives up, the snapshot is computed at a
+	// LATER point than those queued frames. Writing them after the snapshot
+	// would apply older entity records on top of newer ones -- and unlike batch
+	// ops, entity_materialized / entity_removed are applied wholesale by the
+	// client with no HLC compare, so nothing corrects it afterwards.
+	//
+	// Called under m.projection precisely so no broadcast can interleave: every
+	// frame queued before this point is superseded by the snapshot, and every
+	// frame after it is newer than the snapshot. Implementations must not block
+	// or re-enter the manager.
+	OnRebaseline func()
 	// Send delivers one event to this subscriber.
 	//
 	// Contract: Send MUST return promptly — implementations either push
@@ -413,6 +630,35 @@ func WithPresenceClearGrace(d time.Duration) ManagerOption {
 	return func(m *Manager) { m.clearGrace = d }
 }
 
+// WithOpRetentionTTL overrides the lag between compaction_watermark and
+// op_retention_watermark (the floor below which op batches may be deleted).
+// Tests use this to shrink the retention window to milliseconds so they can
+// assert the drop/retain boundary and the resume gate without sleeping through
+// the production 24h default (`OpRetentionTTL`).
+//
+// TEST-ONLY, and deliberately not wired to production config: it shifts THIS
+// manager's compaction lag and resume gate, but the cross-user retention sweep
+// in the cleanup job reads the `OpRetentionTTL` constant directly and has no
+// per-manager reach (a dormant user has no resident manager at all -- that is
+// the case the sweep exists for). Widening the window here without widening
+// the constant would admit cursors whose rows the sweep has already deleted.
+func WithOpRetentionTTL(d time.Duration) ManagerOption {
+	return func(m *Manager) { m.opRetentionTTL = d }
+}
+
+// WithMaxResumeDeltaFrameBytes overrides the ceiling buildResumeDelta enforces
+// on the BUILT ResumeDelta (`MaxResumeDeltaFrameBytes`).
+//
+// TEST-ONLY, and deliberately not wired to production config: the production
+// value is DERIVED from channelwire.UserEventsReadLimit, the limit every
+// subscriber's socket actually enforces, so an operator-tunable copy could only
+// disagree with the socket it exists to protect. Tests shrink it to a few
+// hundred bytes to assert the over-ceiling FALLBACK without building a ~16 MiB
+// fixture.
+func WithMaxResumeDeltaFrameBytes(n int) ManagerOption {
+	return func(m *Manager) { m.maxResumeDeltaFrameBytes = n }
+}
+
 // truncateRunes returns the first n runes of s, never splitting one.
 func truncateRunes(s string, n int) string {
 	if len(s) <= n {
@@ -448,21 +694,23 @@ func NewManager(owner userid.UserID, journal Journal, auth AuthChecker, logger *
 	// every hub-internal commit for that user rather than just looking wrong.
 	hubID := HubReservedPrincipal + "-" + truncateRunes(owner.String(), 8)
 	m := &Manager{
-		owner:       owner,
-		clock:       NewClock("hub-canonical"),
-		hubClientID: hubID,
-		auth:        auth,
-		journal:     journal,
-		now:         now,
-		logger:      logger.With("user_id", owner.String()),
-		clearGrace:  PresenceClearGrace,
-		submitCh:    make(chan submitJob, 64),
-		internalCh:  make(chan submitJob, 16),
-		seedCh:      make(chan seedJob),
-		startedChan: make(chan struct{}),
-		stop:        make(chan struct{}),
-		done:        make(chan struct{}),
-		subscribers: newSubscriberController(),
+		owner:                    owner,
+		clock:                    NewClock("hub-canonical"),
+		hubClientID:              hubID,
+		auth:                     auth,
+		journal:                  journal,
+		now:                      now,
+		logger:                   logger.With("user_id", owner.String()),
+		clearGrace:               PresenceClearGrace,
+		opRetentionTTL:           OpRetentionTTL,
+		maxResumeDeltaFrameBytes: MaxResumeDeltaFrameBytes,
+		submitCh:                 make(chan submitJob, 64),
+		internalCh:               make(chan submitJob, 16),
+		seedCh:                   make(chan seedJob),
+		startedChan:              make(chan struct{}),
+		stop:                     make(chan struct{}),
+		done:                     make(chan struct{}),
+		subscribers:              newSubscriberController(),
 	}
 	for _, opt := range opts {
 		opt(m)
@@ -761,96 +1009,6 @@ func (m *Manager) HeartbeatPresence(ctx context.Context, workspaceID, clientID s
 	return m.presenceCtl.PostHeartbeat(ctx, workspaceID, clientID)
 }
 
-// SubscribeWithACL resolves a subscriber's workspace filter and registers it
-// atomically under subscribeExpandMu, closing the resolve-then-register TOCTOU.
-//
-// resolve reads the DB ACL and returns the allowed workspace set; it runs while
-// this holds subscribeExpandMu, the SAME lock ExpandSubscribersForWorkspace
-// holds across a workspace-create expansion. That serialization means a
-// concurrent create of a workspace the user owns is ordered either FULLY before
-// resolve() -- so resolve reads the post-commit ACL and the workspace is already
-// included -- or FULLY after this Add -- so the create's expand pass sees the
-// now-registered subscriber. Without it, a filter resolved from the pre-commit
-// ACL could be Added after the whole expansion finished, and the expand (which
-// only visits already-registered subscribers) would miss it, so the subscriber
-// would never see the new workspace until it reconnected.
-//
-// resolve's error is returned unregistered so the caller can reject the
-// connection before streaming any events. Lock order
-// subscribeExpandMu -> projection -> m.mu is preserved because Subscribe
-// (called here) takes only projection and m.mu.
-func (m *Manager) SubscribeWithACL(sub *Subscriber, resolve func() (map[string]bool, error)) (initial *leapmuxv1.UserMaterialized, unsub func(), err error) {
-	m.subscribeExpandMu.Lock()
-	defer m.subscribeExpandMu.Unlock()
-	allowed, err := resolve()
-	if err != nil {
-		return nil, nil, err
-	}
-	sub.Filter.WorkspaceIDs = allowed
-	initial, unsub = m.Subscribe(sub)
-	return initial, unsub, nil
-}
-
-// Subscribe attaches a new subscriber. Returns an unsubscribe
-// callback. Bootstrap is sent inline (the caller's stream layer
-// formats it).
-//
-// The production userevents path registers through SubscribeWithACL, which
-// resolves the filter and calls this Add while holding subscribeExpandMu so a
-// concurrent workspace-create expansion cannot leave a straggler with a stale
-// pre-commit filter (see SubscribeWithACL). A direct Subscribe (tests, or a
-// caller that has already resolved a filter under no such lock) does NOT get
-// that guarantee.
-//
-// Subscribers with a non-empty ClientID contribute to a refcount keyed
-// on that id. The first Subscribe cancels any pending deferred clear;
-// the last unsub schedules one PresenceClearGrace into the future. A
-// reconnect inside the grace window keeps the client's presence
-// entries intact so the active-client gate doesn't flicker.
-func (m *Manager) Subscribe(sub *Subscriber) (initial *leapmuxv1.UserMaterialized, unsub func()) {
-	// The whole sequence runs under m.projection -- the same lock broadcasts
-	// take -- so a subscriber's registration + initial snapshot are atomic with
-	// respect to any concurrent broadcast: the filter captured by Add and the
-	// materialized baseline can never straddle a filter mutation. (The
-	// production path must go through SubscribeWithACL rather than resolving a
-	// filter and Adding it here unserialized -- a workspace-create expansion
-	// only visits already-registered subscribers; see SubscribeWithACL.) The
-	// cost is that the O(N) materializedLocked clone below is serialized
-	// against broadcasts for that duration (a large-user-doc connect briefly stalls
-	// the user's commit/broadcast pipeline); relaxing it -- computing the
-	// snapshot outside m.projection -- would reopen exactly that straddle
-	// window, so it is held deliberately.
-	//
-	// Within that, m.mu is only RLocked for the clone. materializedLocked walks
-	// every visible node/tab/floating-window for the subscriber's filter; taking
-	// the state write lock would block every concurrent commit, whereas the RLock
-	// only contends the brief state-swap. Subscriber visibility is identical
-	// either way: by the time we take the state RLock the subscriber is in
-	// subscribers, so it sees the next broadcast, and the initial snapshot
-	// computed under RLock is strictly newer-than-or-equal to whatever a commit
-	// that lost the race would have produced.
-	m.projection.Lock()
-	initialFilter := m.subscribers.Add(sub)
-	m.presenceCtl.OnConnect(sub.ClientID)
-
-	m.mu.RLock()
-	initial = m.materializedLocked(initialFilter)
-	m.mu.RUnlock()
-	m.projection.Unlock()
-	// Idempotent unsub: a caller that invokes it twice (an error-path cleanup
-	// racing a deferred cleanup, or the partway-through-unsubscribe teardown the
-	// registry hardens against) must not decrement the presence refcount twice --
-	// that would underflow the count and prematurely clear a client that still has
-	// live connections, flickering the active-client gate.
-	var unsubOnce sync.Once
-	return initial, func() {
-		unsubOnce.Do(func() {
-			m.subscribers.Remove(sub)
-			m.presenceCtl.OnDisconnect(sub.ClientID)
-		})
-	}
-}
-
 // Materialized returns the public projection filtered to a given
 // allowed-set (used by tests / one-shot callers).
 func (m *Manager) Materialized(filter SubscriberFilter) *leapmuxv1.UserMaterialized {
@@ -1063,7 +1221,7 @@ func (m *Manager) processBatch(ctx context.Context, in SubmitInput, batch *leapm
 	preState := m.state
 
 	// 11. Commit: journal + index views + state advance, all in one tx.
-	if err := m.commit(ctx, in, batch, working); err != nil {
+	if err := m.commit(ctx, in, batch, working, res); err != nil {
 		// A commit failure is a transient store error (the journal DB write) --
 		// the batch already passed ValidateBatch, so the body-hash step inside
 		// commit cannot fail here in practice. Surface it as a retryable Submit
@@ -1236,7 +1394,7 @@ func (m *Manager) runDedup(ctx context.Context, in SubmitInput, batch *leapmuxv1
 // state stays at `m.state` and the canonical HLCs minted for this batch
 // are simply discarded (they're strictly greater than any future tick,
 // so no client can observe them).
-func (m *Manager) commit(ctx context.Context, in SubmitInput, batch *leapmuxv1.OpBatch, working *leapmuxv1.UserCrdtState) error {
+func (m *Manager) commit(ctx context.Context, in SubmitInput, batch *leapmuxv1.OpBatch, working *leapmuxv1.UserCrdtState, res ValidationResult) error {
 	// DiffProjectionForBatch skips the per-tab chain walks for tabs the
 	// batch cannot possibly transition. Non-structural batches (the
 	// common case: user-triggered tab open/move/close) re-project only
@@ -1250,6 +1408,12 @@ func (m *Manager) commit(ctx context.Context, in SubmitInput, batch *leapmuxv1.O
 	if err != nil {
 		return fmt.Errorf("hash batch body: %w", err)
 	}
+	// Persist the per-batch AffectedEntities (the {pre, post} workspace
+	// transitions ValidateBatch computed) alongside the OpBatch. The resume
+	// path decodes them to replay the SAME pre/post stable-visibility
+	// classification the live broadcast applies to this very batch, so the two
+	// catch-up paths cannot drift (see buildResumeDelta).
+	transitions := AffectedEntitiesToProto(res.AffectedEntities, working)
 	if err := m.journal.CommitBatch(ctx, CommitBatch{
 		UserID:      m.owner.String(),
 		Batch:       batch,
@@ -1262,7 +1426,8 @@ func (m *Manager) commit(ctx context.Context, in SubmitInput, batch *leapmuxv1.O
 			OpCount:           int64(len(batch.GetOps())),
 			ExpiresAt:         m.now().Add(DedupTTL),
 		},
-		IndexDiff: diff,
+		IndexDiff:   diff,
+		Transitions: transitions,
 	}); err != nil {
 		return fmt.Errorf("commit batch: %w", err)
 	}

--- a/backend/internal/hub/crdt/manager_broadcast.go
+++ b/backend/internal/hub/crdt/manager_broadcast.go
@@ -122,12 +122,16 @@ func (m *Manager) broadcastBatch(batch *leapmuxv1.OpBatch, res ValidationResult)
 		return evt
 	}
 
-	// Ordering is subscriber-independent, so pay for it once.
+	// Ordering + atHLC are subscriber-independent, so pay for them once. atHLC
+	// (the batch's last-op canonical HLC) is hoisted onto the fanout so sendTo /
+	// emitCatchUpFrames read f.atHLC instead of recomputing lastBatchHLC once
+	// per subscriber.
 	fan := &batchFanout{
 		batch:           batch,
 		res:             res,
 		wsKeys:          wsKeys,
 		refs:            orderedAffectedRefs(res.AffectedEntities),
+		atHLC:           atHLC,
 		batchEventCache: batchEventCache,
 		materialized:    materialized,
 		removed:         removed,
@@ -186,7 +190,16 @@ func orderedAffectedRefs(affected map[EntityRef]EntityWorkspaceTransition) []aff
 		if a.TabID != b.TabID {
 			return a.TabID < b.TabID
 		}
-		return a.TabType < b.TabType
+		if a.TabType != b.TabType {
+			return a.TabType < b.TabType
+		}
+		// WorkspaceID last, because it is the ONLY identity a WorkspaceRoot ref
+		// carries (see EntityRef.HasIdentity): without it two such refs compare
+		// equal and sort.Slice -- which is not stable -- orders them arbitrarily
+		// per call. No frame is emitted for that kind today, so nothing observes
+		// the randomness yet; this keeps the comparator's order total by
+		// construction rather than by the accident of which kinds have arms.
+		return a.WorkspaceID < b.WorkspaceID
 	})
 	return out
 }
@@ -232,59 +245,151 @@ func subscriberWorkspaceMask(sub *Subscriber, wsKeys []string) uint64 {
 	return mask
 }
 
-// batchVisibleOpsEvent filters batch to the ops the given visibility verdict
-// keeps and wraps them in a MarshaledEvent, or returns nil when none are
-// visible. Split out of batchFanout.sendTo so the event can be built
-// once per distinct visibility bitmask and shared across subscribers.
-func batchVisibleOpsEvent(batch *leapmuxv1.OpBatch, visible func(EntityRef) subscriberVisibility) *MarshaledEvent {
-	// Lazy-allocate the visibleOps slice: subscribers with tight filters often
-	// see zero ops in a batch, so allocating only on first append keeps the
-	// all-filtered-out case at zero allocations.
-	var visibleOps []*leapmuxv1.CrdtOp
-	for _, op := range batch.GetOps() {
-		ref := OpTarget(op)
-		v := visible(ref)
-		var keep bool
-		if ref.Kind == EntityKindWorkspaceRoot {
-			// WorkspaceRoot: send if either pre or post visible (register lives on
-			// WorkspaceContentsRecord, no EntityMaterialized arm).
-			keep = v.preVisible || v.postVisible
-		} else {
-			// Other entities: send only if BOTH pre and post visible (stable
-			// visibility). Becoming-visible / becoming-hidden are handled by
-			// EntityMaterialized / EntityRemoved.
-			keep = v.preVisible && v.postVisible
-		}
-		if !keep {
-			continue
-		}
-		if visibleOps == nil {
-			visibleOps = make([]*leapmuxv1.CrdtOp, 0, len(batch.GetOps()))
-		}
-		visibleOps = append(visibleOps, op)
-	}
-	if len(visibleOps) == 0 {
-		return nil
-	}
-	// Sending the filtered subset as a single WatchUserEvent_Batch avoids leaking
-	// ops affecting workspaces the subscriber can't see while still delivering the
-	// batch atomically to the frontend.
-	return NewMarshaledEvent(&leapmuxv1.WatchUserEvent{
-		Event: &leapmuxv1.WatchUserEvent_Batch{
-			Batch: &leapmuxv1.OpBatch{
-				BatchId: batch.GetBatchId(),
-				Ops:     visibleOps,
-			},
-		},
-	})
-}
-
 // subscriberVisibility carries the pre/post-batch visibility flags an
-// entity has for a given subscriber filter, computed inline per subscriber
-// in batchFanout.sendTo.
+// entity has for a given subscriber filter.
 type subscriberVisibility struct {
 	preVisible  bool
 	postVisible bool
+}
+
+// visibilityFor is the SINGLE constructor for a subscriberVisibility verdict
+// from a transition + filter. Both catch-up paths (broadcast's sendTo and
+// resume's buildResumeDelta) call it, so the "how pre/post map to visibility"
+// rule lives in one place and cannot drift between the two paths.
+//
+// ref is needed because the PRE side is a per-ENTITY question on the resume
+// path ("does the client hold a record for this entity?"), not a per-workspace
+// one. See visibilityScope.
+func visibilityFor(scope visibilityScope, ref EntityRef, trans EntityWorkspaceTransition) subscriberVisibility {
+	return subscriberVisibility{
+		preVisible:  scope.preVisible(ref, trans.Pre),
+		postVisible: scope.postAllowed(trans.Post),
+	}
+}
+
+// visibilityScope answers "could this subscriber see workspace X" for the two
+// SIDES of a transition, which are not always the same question.
+//
+// A live broadcast evaluates a batch against the ACL as it stood when that batch
+// committed, so both sides use one filter. A resume replays gap batches against
+// the ACL as it stands NOW, which silently loses an entire class of transition:
+// a workspace DELETED during the gap is gone from the current allowed set, so
+// its tombstone batch -- pinned {Pre: wsID, Post: wsID} -- reads as invisible on
+// both sides. No ops ship, no EntityRemoved is emitted, and the client keeps
+// that workspace's nodes, tabs and windows forever (and now writes them into its
+// checkpoint). The live path escapes this only because
+// contractSubscribersForWorkspace runs AFTER the tombstone broadcast.
+//
+// `departed` restores the pre-side to its cursor-era answer. It is sound because
+// a workspace can leave an owner's set by exactly one route -- deletion (access
+// is owner-only; there is no sharing to revoke) -- so "was visible, is not now"
+// and "was deleted" are the same set.
+//
+// But a workspace-level answer is only correct for an entity's FIRST sighting in
+// the tail. The real predicate the pre side needs is per-ENTITY -- "does the
+// client hold a record for this ref right now?" -- and the two diverge as soon
+// as an entity is born inside a departed workspace DURING the gap: its creation
+// emits nothing (the workspace is not visible on the post side), yet a later
+// escape to a visible workspace reads {Pre: departed} as visible and ships raw
+// ops onto a record the client never received. `held` closes that by tracking
+// the answer entity by entity as the replay advances.
+//
+// The seed stays workspace-level and stays correct, because the tail is complete
+// from the cursor forward: at an entity's first sighting it has not moved since
+// the cursor, so its Pre IS its cursor-era workspace -- and a workspace that
+// held an entity at cursor time necessarily existed then, so the seed can never
+// be asked about a workspace born inside the gap.
+type visibilityScope struct {
+	filter SubscriberFilter
+	// departed widens the PRE side only, and only for a first sighting. Nil on
+	// the live path, where the batch is already being evaluated against its own
+	// era's ACL.
+	departed map[string]bool
+	// held is the per-entity pre-side answer, updated by observe() after each
+	// replayed batch. Nil on the live path, which has no gap to reconstruct.
+	held map[EntityRef]bool
+}
+
+// liveScope is the broadcast path's scope: one filter, both sides, no replay
+// state.
+func liveScope(filter SubscriberFilter) visibilityScope {
+	return visibilityScope{filter: filter}
+}
+
+// resumeScope is the replay path's scope. departed may be nil (nothing left the
+// ACL during the gap); held always starts empty and fills in as observe() runs.
+func resumeScope(filter SubscriberFilter, departed map[string]bool) visibilityScope {
+	return visibilityScope{filter: filter, departed: departed, held: map[EntityRef]bool{}}
+}
+
+// preVisible answers the PRE side for one entity: on the live path a plain
+// filter test, on the replay path the client's tracked holding, falling back to
+// the cursor-era workspace answer the first time a ref is seen.
+func (s visibilityScope) preVisible(ref EntityRef, pre string) bool {
+	if s.held != nil {
+		if h, seen := s.held[ref]; seen {
+			return h
+		}
+	}
+	return s.filter.IsAllowed(pre) || (pre != "" && s.departed[pre])
+}
+
+func (s visibilityScope) postAllowed(ws string) bool {
+	return s.filter.IsAllowed(ws)
+}
+
+// observe records what the subscriber holds AFTER a replayed batch: exactly the
+// refs whose post side was visible. Call once per batch, after emitCatchUpFrames
+// has classified it -- mutating mid-batch would make the materialized pass and
+// the batch-frame pass disagree about the same ref. No-op on the live path.
+//
+// Pointer receiver because this method MUTATES the scope. It happens to work on
+// a value receiver today only because `held` is a map, so the copy aliases the
+// same backing store -- an accident that would silently swallow the write the
+// moment any non-map field is added here.
+func (s *visibilityScope) observe(refs []affectedRef) {
+	if s.held == nil {
+		return
+	}
+	for _, a := range refs {
+		s.held[a.ref] = s.postAllowed(a.trans.Post)
+	}
+}
+
+// opVisibleForSubscriber reports whether the raw op on `ref` should be
+// delivered as part of the (filtered) batch frame for a subscriber with the
+// given pre/post visibility verdict. WorkspaceRoot is special-cased (send if
+// EITHER side visible — the register lives on WorkspaceContentsRecord, which has
+// no EntityMaterialized arm); every other entity is delivered as a raw op only
+// when BOTH sides are visible (stable visibility), so becoming-visible and
+// becoming-hidden transitions are handled by EntityMaterialized / EntityRemoved
+// instead of raw move ops that would leak pre-state.
+//
+// This is the SINGLE source of the stable-visibility rule: both catch-up paths
+// reach it through emitCatchUpFrames -> filterVisibleOps, so they cannot drift
+// on which ops ship in the batch frame.
+func opVisibleForSubscriber(ref EntityRef, v subscriberVisibility) bool {
+	if ref.Kind == EntityKindWorkspaceRoot {
+		return v.preVisible || v.postVisible
+	}
+	return v.preVisible && v.postVisible
+}
+
+// isMaterializedTransition reports the becoming-visible classification
+// (!pre && post): the entity ENTERED the subscriber's allowed set this batch,
+// so it is delivered as an EntityMaterialized frame (its full record) rather
+// than the raw move op (which would carry pre-state from a hidden workspace).
+// Shared by batchFanout.sendTo and buildResumeDelta.
+func isMaterializedTransition(v subscriberVisibility) bool {
+	return !v.preVisible && v.postVisible
+}
+
+// isRemovedTransition reports the becoming-hidden classification (pre && !post):
+// the entity LEFT the subscriber's allowed set this batch, so it is delivered
+// as an EntityRemoved frame so the client evicts it. Shared by
+// batchFanout.sendTo and buildResumeDelta.
+func isRemovedTransition(v subscriberVisibility) bool {
+	return v.preVisible && !v.postVisible
 }
 
 // batchFanout holds everything one batch broadcast keeps constant across
@@ -297,9 +402,14 @@ type batchFanout struct {
 	res             ValidationResult
 	wsKeys          []string
 	refs            []affectedRef
+	atHLC           *leapmuxv1.HLC
 	batchEventCache map[uint64]*MarshaledEvent
-	materialized    func(EntityRef) *MarshaledEvent
-	removed         func(EntityRef) *MarshaledEvent
+	// Lazily built once per broadcast; filter-independent, so unlike
+	// batchEventCache it needs no per-mask key. Guarded by the projection lock
+	// broadcastBatch holds for the whole fan-out, same as batchEventCache.
+	batchEndEvent *MarshaledEvent
+	materialized  func(EntityRef) *MarshaledEvent
+	removed       func(EntityRef) *MarshaledEvent
 }
 
 // batchEventFor returns this subscriber's batch frame, shared with same-mask
@@ -311,143 +421,106 @@ type batchFanout struct {
 // subscribers whose verdicts differ only above bit 63 collapse onto one mask and
 // would be handed each other's filtered ops. broadcastBatch leaves the cache nil
 // in that case, which this arm keeps honouring by also skipping the mask.
-func (f *batchFanout) batchEventFor(sub *Subscriber, visible func(EntityRef) subscriberVisibility) *MarshaledEvent {
+func (f *batchFanout) batchEventFor(sub *Subscriber, visible func() *leapmuxv1.OpBatch) *MarshaledEvent {
 	if f.batchEventCache == nil {
-		return batchVisibleOpsEvent(f.batch, visible)
+		return batchEventFromOps(visible())
 	}
 	mask := subscriberWorkspaceMask(sub, f.wsKeys)
 	evt, built := f.batchEventCache[mask]
 	if !built {
-		evt = batchVisibleOpsEvent(f.batch, visible)
+		// Only a cache MISS pays for the filter. Two subscribers with the same
+		// visibility mask see the same ops by construction, so the second one
+		// never runs the O(ops) scan.
+		evt = batchEventFromOps(visible())
 		f.batchEventCache[mask] = evt
 	}
 	return evt
 }
 
+// batchEnd returns this batch's shared end-of-sequence frame, built once per
+// broadcast. It carries only the batch's atHLC, so it is byte-identical for
+// every subscriber regardless of filter — unlike the batch frame, it needs no
+// mask key.
+func (f *batchFanout) batchEnd() *MarshaledEvent {
+	if f.batchEndEvent == nil {
+		f.batchEndEvent = NewMarshaledEvent(&leapmuxv1.WatchUserEvent{
+			Event: &leapmuxv1.WatchUserEvent_BatchEnd{BatchEnd: &leapmuxv1.BatchEnd{AtHlc: f.atHLC}},
+		})
+	}
+	return f.batchEndEvent
+}
+
+// batchEventFromOps wraps an already-filtered op subset as a wire frame, or
+// returns nil when the subscriber sees none of the batch's ops.
+func batchEventFromOps(visible *leapmuxv1.OpBatch) *MarshaledEvent {
+	if visible == nil {
+		return nil
+	}
+	return NewMarshaledEvent(&leapmuxv1.WatchUserEvent{
+		Event: &leapmuxv1.WatchUserEvent_Batch{Batch: visible},
+	})
+}
+
 func (f *batchFanout) sendTo(sub *Subscriber) {
-	// visible computes a ref's pre/post visibility for this subscriber inline
-	// from its filter, avoiding a prebuilt O(affected-entities) map per
-	// subscriber: IsAllowed is a single cheap lookup, and for a nil/all-workspaces
-	// filter it reduces to "workspace id non-empty" -- the same value the old
-	// shared map held. A ref absent from AffectedEntities yields the zero
-	// transition (Pre == Post == ""), i.e. not visible either side, matching the
-	// old map's zero value for a missing key.
-	visible := func(ref EntityRef) subscriberVisibility {
-		trans := f.res.AffectedEntities[ref]
-		return subscriberVisibility{
-			preVisible:  sub.Filter.IsAllowed(trans.Pre),
-			postVisible: sub.Filter.IsAllowed(trans.Post),
-		}
+	// FRAME ORDER IS A CONTRACT — owned by emitCatchUpFrames (materialized →
+	// batch → removed). This adapter supplies live-state record lookup and
+	// fans each frame through the MarshaledEvent memoization caches.
+	atHLC := f.atHLC
+	// Resume catch-up ownership: batches at or below the register-time
+	// high-water ship in the ResumeDelta. Skipping them here prevents
+	// dual-delivery when commitState advanced MaxHlc before until was
+	// sampled under the projection hold (see SubscribeWithACL).
+	if sub.resumeSuppressThrough != nil && atHLC != nil && HLCCmp(atHLC, sub.resumeSuppressThrough) <= 0 {
+		return
 	}
+	emitCatchUpFrames(
+		catchUpBatch{
+			refs:        f.refs,
+			batch:       f.batch,
+			transitions: f.res.AffectedEntities,
+			atHLC:       atHLC,
+		},
+		liveScope(sub.Filter),
+		f.materializedPayload,
+		liveCatchUpSink{fan: f, sub: sub},
+	)
+}
 
-	// FRAME ORDER IS A CONTRACT, not an implementation detail.
-	//
-	// 1. EntityMaterialized FIRST, nodes before the tabs anchored to them.
-	//
-	// A batch that creates a tile and moves a tab onto it -- emitSplitTile, and
-	// every make-grid -- has the TILE's ops stripped from the batch frame: a
-	// brand-new node has Pre == "" and IsAllowed("") is false for every filter,
-	// so `keep = pre && post` drops them, while the tab's SetTabRegister(tile_id)
-	// survives as a stable-visibility op. Sent batch-first, the client applies a
-	// tab whose tile_id names a node it does not have, resolveTileWorkspace
-	// cannot reach a root, and the tab drops out of the projection for a tick.
-	// That is true for the ORIGINATING client too: consumeRemote splices the
-	// pending batch by id after applying only the ops that arrived.
-	//
-	// The three frames touch DISJOINT entity sets (batch keeps `pre && post`,
-	// materialized `!pre && post`, removed `pre && !post`), so materialized-first
-	// double-applies nothing.
-	//
-	// `refs` is kind-ordered so this also holds for a cross-workspace move, where
-	// the node AND the tab both materialize.
-	for _, a := range f.refs {
-		if sub.Filter.IsAllowed(a.trans.Pre) || !sub.Filter.IsAllowed(a.trans.Post) {
-			continue
-		}
-		if evt := f.materialized(a.ref); evt != nil {
-			_ = sub.Send(evt)
-		}
+// materializedPayload unwraps the fanout's memoized EntityMaterialized wrapper
+// into the bare payload emitCatchUpFrames' thunk protocol asks for.
+//
+// A METHOD, not a closure built inside sendTo: it captures nothing beyond the
+// receiver, and sendTo runs once per subscriber per batch on the broadcast
+// fan-out, so building it there allocated one escaping closure per subscriber
+// per batch -- and liveCatchUpSink never calls it, because every payload it
+// sends is already a cross-subscriber MarshaledEvent (see the sink's own note).
+// The planner still needs SOMETHING here: it is what keeps one definition of
+// each frame's content shared by both catch-up paths, which is the drift
+// protection catchUpSink's doc exists to explain. Cheap to pass, free to ignore.
+//
+// Borrow-only: the returned pointer is the inner proto of a memo shared across
+// the whole fan-out, so callers must not mutate it.
+func (f *batchFanout) materializedPayload(ref EntityRef) *leapmuxv1.EntityMaterialized {
+	evt := f.materialized(ref)
+	if evt == nil || evt.Event == nil {
+		return nil
 	}
-
-	// 2. The batch frame.
-	// Batch event: the filtered op subset a subscriber sees is determined by its
-	// visibility verdict over the batch's workspaces, so memoize the resulting
-	// MarshaledEvent by that verdict's bitmask (when enabled). Subscribers with an
-	// identical mask share one event -- and thus one proto marshal -- instead of
-	// each building and marshaling their own. A cache miss builds the event (nil
-	// when the subscriber sees no ops, cached so a same-mask peer skips the
-	// rebuild); a hit reuses it. The shared *MarshaledEvent is read-only to every
-	// subscriber (only its sync.Once-guarded Bytes() is called), so fanning it out
-	// is safe -- identical to how materialized/removed events are already shared.
-	if evt := f.batchEventFor(sub, visible); evt != nil {
-		_ = sub.Send(evt)
-	}
-
-	// 3. EntityRemoved LAST, and this one may NOT move: consumeEntityRemoved runs
-	// dropPendingByPredicate, so running it before consumeRemote's echo-splice
-	// would spuriously report ops this very batch is confirming as dropped and
-	// fire onPendingDropped for them.
-	//
-	// The shared event pointer is safe to fan out: subscribers treat it as
-	// read-only and the WS writer marshals on its own thread.
-	for _, a := range f.refs {
-		if !sub.Filter.IsAllowed(a.trans.Pre) || sub.Filter.IsAllowed(a.trans.Post) {
-			continue
-		}
-		if evt := f.removed(a.ref); evt != nil {
-			_ = sub.Send(evt)
-		}
-	}
+	return evt.Event.GetEntityMaterialized()
 }
 
 // buildEntityMaterializedEvent constructs the EntityMaterialized event
 // for a single ref against `state`. Caller MUST hold m.mu (read lock is
-// enough). Returns nil when the ref doesn't resolve to a live record.
+// enough). Returns nil when the ref doesn't resolve to a live,
+// non-tombstoned record (same eligibility as the commit-time snapshot
+// encoder -- see liveRecordSnapshot).
 func buildEntityMaterializedEvent(state *leapmuxv1.UserCrdtState, ref EntityRef, atHLC *leapmuxv1.HLC) *leapmuxv1.WatchUserEvent {
-	switch ref.Kind {
-	case EntityKindTab:
-		t := state.GetTabs()[ref.TabID]
-		if t == nil {
-			return nil
-		}
-		return &leapmuxv1.WatchUserEvent{
-			Event: &leapmuxv1.WatchUserEvent_EntityMaterialized{
-				EntityMaterialized: &leapmuxv1.EntityMaterialized{
-					AtHlc:  atHLC,
-					Entity: &leapmuxv1.EntityMaterialized_Tab{Tab: cloneTab(t)},
-				},
-			},
-		}
-	case EntityKindFloatingWindow:
-		fw := state.GetFloatingWindows()[ref.WindowID]
-		if fw == nil {
-			return nil
-		}
-		return &leapmuxv1.WatchUserEvent{
-			Event: &leapmuxv1.WatchUserEvent_EntityMaterialized{
-				EntityMaterialized: &leapmuxv1.EntityMaterialized{
-					AtHlc:  atHLC,
-					Entity: &leapmuxv1.EntityMaterialized_FloatingWindow{FloatingWindow: cloneFloatingWindow(fw)},
-				},
-			},
-		}
-	case EntityKindNode:
-		n := state.GetNodes()[ref.NodeID]
-		if n == nil {
-			return nil
-		}
-		return &leapmuxv1.WatchUserEvent{
-			Event: &leapmuxv1.WatchUserEvent_EntityMaterialized{
-				EntityMaterialized: &leapmuxv1.EntityMaterialized{
-					AtHlc:  atHLC,
-					Entity: &leapmuxv1.EntityMaterialized_Node{Node: cloneNode(n)},
-				},
-			},
-		}
-	default:
-		// EntityKindUnknown and EntityKindWorkspaceRoot have no
-		// EntityMaterialized variant; callers nil-guard the result.
+	em := liveRecordSnapshot(state, ref)
+	if em == nil {
 		return nil
+	}
+	em.AtHlc = atHLC
+	return &leapmuxv1.WatchUserEvent{
+		Event: &leapmuxv1.WatchUserEvent_EntityMaterialized{EntityMaterialized: em},
 	}
 }
 
@@ -650,10 +723,7 @@ func (m *Manager) ExpandSubscribersForWorkspace(ctx context.Context, workspaceID
 		if sub.Filter.IsAllowed(workspaceID) {
 			return
 		}
-		if sub.Filter.WorkspaceIDs == nil {
-			sub.Filter.WorkspaceIDs = map[string]bool{}
-		}
-		sub.Filter.WorkspaceIDs[workspaceID] = true
+		sub.Filter = sub.Filter.WithWorkspace(workspaceID)
 	})
 	return nil
 }
@@ -692,10 +762,7 @@ func (m *Manager) contractSubscribersForWorkspace(workspaceID string) {
 	m.subscribeExpandMu.Lock()
 	defer m.subscribeExpandMu.Unlock()
 	m.subscribers.MutateEach(func(sub *Subscriber) {
-		if sub.Filter.WorkspaceIDs == nil {
-			return
-		}
-		delete(sub.Filter.WorkspaceIDs, workspaceID)
+		sub.Filter = sub.Filter.WithoutWorkspace(workspaceID)
 	})
 }
 

--- a/backend/internal/hub/crdt/manager_compaction.go
+++ b/backend/internal/hub/crdt/manager_compaction.go
@@ -2,6 +2,7 @@ package crdt
 
 import (
 	"context"
+	"time"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -51,8 +52,18 @@ func (m *Manager) maybeAdvanceEpoch(ctx context.Context) {
 }
 
 func (m *Manager) maybeCompact(ctx context.Context) {
-	// Cheap pre-check: if the watermark wouldn't advance there is
+	// Cheap pre-check: if the compaction watermark wouldn't advance there is
 	// nothing to do, so skip the full CloneState on the idle path.
+	//
+	// This also skips the DropThrough delete, which is only safe because
+	// laggedRetentionWatermark is a pure function of (max_hlc,
+	// compaction_watermark, ttl): a max_hlc that has not moved pins the lagging
+	// floor as surely as the tight one, so there is no retention work waiting
+	// either. Note the reason is the SHARED INPUT, not the ordering -- being
+	// bounded above by a stationary value would not on its own make a value
+	// stationary. Anyone making retention wall-clock-driven invalidates this
+	// pre-check and must move the DropThrough out from behind it, or a dormant
+	// account's op rows would never be swept.
 	m.mu.RLock()
 	if HLCIsZero(m.state.GetMaxHlc()) || HLCCmp(m.state.GetMaxHlc(), m.state.GetCompactionWatermark()) <= 0 {
 		m.mu.RUnlock()
@@ -66,29 +77,62 @@ func (m *Manager) maybeCompact(ctx context.Context) {
 	// Per-batch dedup rows are already in user_recent_batch_ids when
 	// the batch committed; the compaction step only needs to ensure
 	// the state blob carries the new watermark and the journal rows
-	// whose last canonical HLC is ≤ watermark are dropped. The
-	// retention contract on user_recent_batch_ids carries forward via
-	// the existing expires_at column (set at commit time), so no
-	// extra inserts are required here.
+	// whose last canonical HLC is ≤ the retention watermark are dropped.
+	// The retention contract on user_recent_batch_ids carries forward via
+	// the existing expires_at column (set at commit time), so no extra
+	// inserts are required here.
+
+	// compaction_watermark advances to max_hlc: tombstone pruning is
+	// load-bearing for correctness (HLC monotonicity, bounded user_state
+	// growth), so it tracks the live head tightly.
 	state.CompactionWatermark = HLCClone(state.GetMaxHlc())
 
+	// op_retention_watermark LAGS compaction_watermark by OpRetentionTTL.
+	// It is the floor for op-batch DELETION: DeleteUserOpBatchesThrough
+	// (CompactBatch.DropThrough) drops rows whose last canonical HLC is ≤
+	// it, so batches in (op_retention_watermark, compaction_watermark]
+	// survive below the tombstone-prune line. That widened window is what
+	// lets delta-resume pay off across multi-hour gaps instead of only the
+	// ~60s between compaction ticks — a client whose cursor is above this
+	// watermark (and below compaction_watermark) still resumes (decideResume
+	// gates on op_retention_watermark, not compaction_watermark). The op
+	// log is an append-only history and replaying a longer tail is sound
+	// (each op is idempotent under the CRDT merge), so retention is pure
+	// storage optimization, decoupled from the correctness-tight prune.
+	//
+	// The lag is applied to max_hlc.physical (a UnixMilli value), keeping
+	// the same client_id and zeroing logical: the watermark is a deletion
+	// floor, not a real HLC, and a logical > 0 would narrow the deleted
+	// range to a sub-millisecond sliver that has no meaning as a floor.
+	// Clamp at ≤ compaction_watermark so retention can never precede the
+	// prune line (and the invariant op_retention_watermark ≤
+	// compaction_watermark ≤ max_hlc always holds). On the first compaction
+	// of a young state where max_hlc.physical < OpRetentionTTL, the floor
+	// goes negative; clamp it to zero (HLCIsZero) so decideResume's
+	// `cursor > op_retention_watermark` still admits any non-zero cursor —
+	// i.e. every resumable client until the state is older than the TTL.
+	opRetention := laggedRetentionWatermark(state.GetMaxHlc(), state.GetCompactionWatermark(), m.opRetentionTTL)
+	state.OpRetentionWatermark = opRetention
+
 	// Drop tombstoned records whose tombstone_at is at or below the
-	// new watermark. The state blob persisted by `CompactBatch` (one
-	// transaction with the journal compaction) reflects the pruned
-	// shape, so a fresh bootstrap sees the entity as never-existed.
-	// See PruneTombstonesAtOrBelow's doc comment for the safety
-	// argument.
+	// new compaction_watermark (the TIGHT one — pruning is correctness-
+	// bound, not retention-bound). The state blob persisted by
+	// `CompactBatch` (one transaction with the journal compaction) reflects
+	// the pruned shape, so a fresh bootstrap sees the entity as
+	// never-existed. See PruneTombstonesAtOrBelow's doc comment for the
+	// safety argument.
 	prunedCount := PruneTombstonesAtOrBelow(state, state.GetCompactionWatermark())
 
 	if err := m.journal.CompactBatch(ctx, CompactBatch{
 		State:       state,
-		DropThrough: state.GetCompactionWatermark(),
+		DropThrough: state.GetOpRetentionWatermark(),
 	}); err != nil {
 		m.logger.Warn("compaction", "err", err)
 		return
 	}
 	m.mu.Lock()
 	m.state.CompactionWatermark = HLCClone(state.GetCompactionWatermark())
+	m.state.OpRetentionWatermark = HLCClone(state.GetOpRetentionWatermark())
 	if prunedCount > 0 {
 		// Apply the same prune to the in-memory state under the write
 		// lock so reads after compaction see the pruned shape without
@@ -99,6 +143,55 @@ func (m *Manager) maybeCompact(ctx context.Context) {
 	if prunedCount > 0 {
 		m.logger.Debug("compaction pruned tombstones", "count", prunedCount)
 	}
+}
+
+// laggedRetentionWatermark derives the op_retention_watermark from max_hlc by
+// subtracting ttl (in physical-ms). It is clamped to be at most
+// compactionWatermark (so retention never precedes the prune line) and at
+// least zero (so a young state whose max_hlc.physical < ttl yields a zero
+// floor that admits every non-zero cursor through decideResume).
+//
+// The watermark is a deletion FLOOR: DeleteUserOpBatchesThrough drops rows
+// whose last canonical HLC is ≤ it. Two cases:
+//
+//  1. The lag moved physical-ms strictly earlier (ttl > 0 and
+//     max_hlc.physical ≥ ttl): the floor is an earlier millisecond, so the
+//     sub-millisecond logical of max_hlc is irrelevant — zero it and carry
+//     max_hlc's client_id. Every batch at max_hlc.physical (any logical) is
+//     strictly > the floor and survives, which is correct: those batches are
+//     the most recent and must outlive a positive retention window.
+//  2. The lag did NOT move physical-ms (ttl == 0, or the clamp pinned the
+//     floor to compaction_watermark): the floor IS max_hlc, so it must carry
+//     max_hlc's logical too — otherwise a batch sharing max_hlc.physical with
+//     logical > 0 would survive the `> floor` keep-test and the zero-TTL
+//     contract ("drop everything at or below the head") would leak. Return
+//     compactionWatermark (== max_hlc) verbatim in this case.
+func laggedRetentionWatermark(maxHlc, compactionWatermark *leapmuxv1.HLC, ttl time.Duration) *leapmuxv1.HLC {
+	phys := maxHlc.GetPhysical() - int64(ttl/time.Millisecond)
+	if phys < 0 {
+		// Zero (HLCIsZero) — decideResume's `cursor > op_retention_watermark`
+		// treats nil/zero as less-than any non-zero cursor, so every
+		// resumable client passes until the state outlives the TTL.
+		return &leapmuxv1.HLC{}
+	}
+	if phys >= maxHlc.GetPhysical() {
+		// ttl == 0 (or negative, defensively): the floor is the head itself.
+		// Return compactionWatermark verbatim so its logical is preserved and
+		// the `> floor` keep-test drops every batch at or below the head.
+		return HLCClone(compactionWatermark)
+	}
+	wm := &leapmuxv1.HLC{
+		Physical: phys,
+		ClientId: maxHlc.GetClientId(),
+	}
+	// Clamp at ≤ compactionWatermark. Normally wm.physical < max_hlc.physical
+	// == compactionWatermark.physical, so wm < compactionWatermark already;
+	// the clamp only bites if compactionWatermark was set by an earlier tick
+	// and lags max_hlc (defensive — the invariant wm ≤ cw must always hold).
+	if HLCCmp(wm, compactionWatermark) > 0 {
+		return HLCClone(compactionWatermark)
+	}
+	return wm
 }
 
 // makeDedupHitResult reconstructs the original BatchCommitted from a

--- a/backend/internal/hub/crdt/manager_compaction_internal_test.go
+++ b/backend/internal/hub/crdt/manager_compaction_internal_test.go
@@ -1,0 +1,43 @@
+package crdt
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+)
+
+// TestLaggedRetentionWatermark_ZerosLogicalForLagCase pins the invariant that
+// the op_retention_watermark carries logical=0 whenever the lag moves
+// physical-ms strictly earlier. The delete/resume boundary alignment depends
+// on this: DeleteUserOpBatchesThrough keys on the batch's LAST canonical HLC
+// (physical_ms, last_logical, origin_client) with a `<=` test, while
+// decideResume uses a strict `>` test against the watermark. A floor at
+// physical=F with logical=0 means a batch whose last op is at (F, logical>=1)
+// survives deletion (last_logical < 0 is false) AND a cursor at that batch
+// passes resume (> floor). If a future change carried max_hlc.logical into the
+// floor, the journal would delete a batch the resume predicate still admits —
+// a silent gap in the client's delta. This test makes the zero-logical
+// invariant a checked property rather than a coincidence.
+func TestLaggedRetentionWatermark_ZerosLogicalForLagCase(t *testing.T) {
+	maxHlc := &leapmuxv1.HLC{Physical: 1_700_000_000_000, Logical: 7, ClientId: "hub-user1"}
+	cw := &leapmuxv1.HLC{Physical: 1_700_000_000_000, Logical: 7, ClientId: "hub-user1"}
+	// Positive lag: floor lands at an earlier physical-ms.
+	rw := laggedRetentionWatermark(maxHlc, cw, time.Hour)
+	assert.Equal(t, int64(0), rw.GetLogical(),
+		"op_retention_watermark must zero logical when the lag moves physical-ms earlier")
+	assert.Equal(t, int64(1_700_000_000_000-3_600_000), rw.GetPhysical(),
+		"op_retention_watermark physical must be max_hlc.physical - ttl")
+	assert.Equal(t, "hub-user1", rw.GetClientId(),
+		"op_retention_watermark must carry max_hlc's client_id")
+	assert.Less(t, HLCCmp(rw, cw), 0, "op_retention_watermark must stay ≤ compaction_watermark")
+
+	// Zero TTL collapses to compaction_watermark verbatim (logical preserved) —
+	// the floor IS the head, so it must carry the head's logical to make the
+	// `> floor` keep-test drop every batch at or below the head.
+	rw0 := laggedRetentionWatermark(maxHlc, cw, 0)
+	assert.Equal(t, int64(7), rw0.GetLogical(),
+		"op_retention_watermark must preserve logical when ttl=0 (floor == head)")
+}

--- a/backend/internal/hub/crdt/manager_integration_test.go
+++ b/backend/internal/hub/crdt/manager_integration_test.go
@@ -1281,11 +1281,18 @@ func TestManager_BroadcastFiltering_AllowedSet(t *testing.T) {
 
 // TestManager_Compaction_DropsOldOps_RetainsDedup asserts the canonical
 // compaction contract: after TickHousekeeping runs, every op committed
-// at or below the new compaction_watermark has been dropped from the
+// at or below the new op_retention_watermark has been dropped from the
 // op log, but the per-op dedup row is retained — so a retry of any of
 // those op_ids still returns the original canonical HLC.
+//
+// Op-batch deletion gates on op_retention_watermark, which lags the
+// compaction_watermark by OpRetentionTTL (the two are decoupled so a longer
+// resume window doesn't force a looser tombstone-prune line). This test sets
+// the retention TTL to zero via WithOpRetentionTTL so the floor meets the
+// compaction watermark and the committed batch is dropped; the production
+// 24h default would retain it for a day.
 func TestManager_Compaction_DropsOldOps_RetainsDedup(t *testing.T) {
-	mgr, j, _ := runManager(t, "user-1", allowAll{}, 20_000)
+	mgr, j, _ := runManager(t, "user-1", allowAll{}, 20_000, crdt.WithOpRetentionTTL(0))
 	seedRootInternal(t, mgr, "w1", "root1")
 	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
 
@@ -1313,7 +1320,7 @@ func TestManager_Compaction_DropsOldOps_RetainsDedup(t *testing.T) {
 
 	postOps := j.batchCount()
 	postDedup := j.dedupCount()
-	assert.Equal(t, 0, postOps, "compaction must drop ops at or below watermark")
+	assert.Equal(t, 0, postOps, "compaction must drop ops at or below op_retention_watermark (TTL=0 → equals compaction watermark)")
 	assert.Equal(t, preDedup, postDedup, "dedup rows must survive compaction (until TTL expiry)")
 
 	// Resubmit the same batch — should return canonical HLCs from the
@@ -1331,6 +1338,113 @@ func TestManager_Compaction_DropsOldOps_RetainsDedup(t *testing.T) {
 		assert.Equal(t, crdt.HLCCmp(originalHLCs[i], op.GetCanonicalHlc()), 0,
 			"post-compaction retry must echo the original canonical HLC")
 	}
+}
+
+// TestManager_Compaction_RetainsOpsAcrossDecoupledWindow pins that op-batch
+// deletion gates on op_retention_watermark (which lags compaction_watermark
+// by OpRetentionTTL), NOT on compaction_watermark: with a positive TTL, a
+// compaction tick advances compaction_watermark to max_hlc but leaves
+// op_retention_watermark strictly below it, so committed batches in the lag
+// window SURVIVE compaction (they're still needed for delta-resume). This is
+// the decoupling that widens the resume window from ~60s to the TTL.
+func TestManager_Compaction_RetainsOpsAcrossDecoupledWindow(t *testing.T) {
+	// nowSeed well above OpRetentionTTL in ms so the lagged floor is positive
+	// (not clamped to zero): 2h in ms = 7.2e6; TTL = 1h. The committed batch
+	// lands at ~7.2e6+ ms, so op_retention_watermark = ~7.2e6 - 3.6e6 ≈ 3.6e6,
+	// comfortably below the batch and below compaction_watermark.
+	mgr, j, _ := runManager(t, "user-1", allowAll{}, 7_200_000, crdt.WithOpRetentionTTL(time.Hour))
+	seedRootInternal(t, mgr, "w1", "root1")
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+
+	batch := addTabBatch(t, "b1", "tA", "root1", "wkr1", "p1")
+	_, err := mgr.Submit(context.Background(), crdt.SubmitInput{
+		Epoch: epoch, PrincipalID: "user", OriginClient: "c1",
+		Batches: []*leapmuxv1.OpBatch{batch},
+	})
+	require.NoError(t, err)
+	require.Greater(t, j.batchCount(), 0, "batch must be journaled before compaction")
+
+	mgr.TickHousekeeping(context.Background())
+
+	cw := mgr.State().GetCompactionWatermark()
+	rw := mgr.State().GetOpRetentionWatermark()
+	require.False(t, crdt.HLCIsZero(cw), "compaction must advance compaction_watermark to max_hlc")
+	require.False(t, crdt.HLCIsZero(rw), "op_retention_watermark must be set after compaction")
+	require.True(t, crdt.HLCCmp(rw, cw) < 0,
+		"op_retention_watermark must lag compaction_watermark (the decoupling)")
+
+	// The batch's max canonical HLC equals max_hlc (the only commit), so it
+	// sits between rw (exclusive) and cw (inclusive). It must survive: the
+	// journal still needs it for any resume whose cursor is above rw.
+	assert.Greater(t, j.batchCount(), 0,
+		"batches above op_retention_watermark must survive compaction even when at/below compaction_watermark")
+
+	// And a second tick must not drop them either (idempotent retention floor).
+	mgr.TickHousekeeping(context.Background())
+	assert.Greater(t, j.batchCount(), 0, "a second compaction tick must not drop retained batches")
+}
+
+// TestManager_Compaction_OpRetentionWatermarkClampsToZeroOnYoungState pins the
+// young-state clamp: when max_hlc.physical < OpRetentionTTL, the lagged floor
+// goes negative and is clamped to zero (HLCIsZero), so decideResume's
+// `cursor > op_retention_watermark` admits every non-zero cursor — i.e. every
+// resumable client until the state outlives the TTL. Without the clamp the
+// floor would carry a negative physical and HLCCmp would still order below any
+// real cursor, but the zero clamp makes the intent explicit and keeps the
+// watermark HLCIsZero so it round-trips cleanly through the proto blob.
+func TestManager_Compaction_OpRetentionWatermarkClampsToZeroOnYoungState(t *testing.T) {
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 1_000, crdt.WithOpRetentionTTL(time.Hour))
+	seedRootInternal(t, mgr, "w1", "root1")
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+	batch := addTabBatch(t, "b1", "tA", "root1", "wkr1", "p1")
+	_, err := mgr.Submit(context.Background(), crdt.SubmitInput{
+		Epoch: epoch, PrincipalID: "user", OriginClient: "c1",
+		Batches: []*leapmuxv1.OpBatch{batch},
+	})
+	require.NoError(t, err)
+
+	mgr.TickHousekeeping(context.Background())
+	rw := mgr.State().GetOpRetentionWatermark()
+	assert.True(t, crdt.HLCIsZero(rw),
+		"op_retention_watermark must clamp to zero when max_hlc.physical < OpRetentionTTL")
+}
+
+// TestManager_Bootstrap_PreservesPersistedOpRetentionWatermark pins maybeCompact
+// as the SOLE writer of op_retention_watermark: Bootstrap loads whatever was
+// persisted and does not adjust it.
+//
+// The zero-op_retention/non-zero-compaction shape below is not a corrupt blob —
+// it is exactly what maybeCompact writes for a young account, where
+// laggedRetentionWatermark clamps max_hlc-minus-TTL to zero so every resumable
+// client passes the floor. Bootstrap must not "repair" it: collapsing the floor
+// up to compaction_watermark (== max_hlc) would reject every cursor a client can
+// hold and force the full projection snapshot on every reconnect — inverting the
+// deliberate clamp, and re-introducing the exact cost #267 exists to remove.
+func TestManager_Bootstrap_PreservesPersistedOpRetentionWatermark(t *testing.T) {
+	j := newFakeJournal()
+	cw := &leapmuxv1.HLC{Physical: 1_700_000_000_000, Logical: 3, ClientId: "hub-user1"}
+	// The shape maybeCompact persists for a young account: compaction_watermark
+	// at max_hlc, op_retention_watermark clamped to zero.
+	j.state = &leapmuxv1.UserCrdtState{
+		UserId:              "user-1",
+		Nodes:               map[string]*leapmuxv1.NodeRecord{},
+		Tabs:                map[string]*leapmuxv1.TabRecord{},
+		FloatingWindows:     map[string]*leapmuxv1.FloatingWindowRecord{},
+		Workspaces:          map[string]*leapmuxv1.WorkspaceContentsRecord{},
+		MaxHlc:              &leapmuxv1.HLC{Physical: 1_700_000_000_000, Logical: 3, ClientId: "hub-user1"},
+		CompactionWatermark: cw,
+		CurrentEpoch:        1,
+	}
+	mgr := crdt.NewManager(userid.MustNew("user-1"), j, allowAll{}, nil, func() time.Time {
+		return time.UnixMilli(1_700_000_000_000)
+	})
+	require.NoError(t, mgr.Bootstrap(context.Background()))
+
+	state := mgr.State()
+	assert.True(t, crdt.HLCIsZero(state.GetOpRetentionWatermark()),
+		"Bootstrap must leave the persisted op_retention_watermark untouched, not collapse it to compaction_watermark")
+	assert.Equal(t, cw.GetPhysical(), state.GetCompactionWatermark().GetPhysical(),
+		"compaction_watermark must load unchanged")
 }
 
 func TestManager_HousekeepingDeletesDedupRowsAfterExpiresAt(t *testing.T) {

--- a/backend/internal/hub/crdt/manager_resume_transitions_test.go
+++ b/backend/internal/hub/crdt/manager_resume_transitions_test.go
@@ -1,0 +1,617 @@
+package crdt_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/hub/crdt"
+)
+
+// moveTabBatch builds a single-op SetTabRegister(tile_id=newTile) batch that
+// moves `tabID` onto `newTileID` (a root whose workspace differs from the tab's
+// current one), mirroring the cross-workspace move primitive exercised in
+// cross_workspace_move_test.go.
+func moveTabBatch(batchID, tabID, newTileID string) *leapmuxv1.OpBatch {
+	return &leapmuxv1.OpBatch{
+		BatchId: batchID,
+		Ops: []*leapmuxv1.CrdtOp{{OpId: "op-" + batchID, Body: &leapmuxv1.CrdtOp_SetTabRegister{SetTabRegister: &leapmuxv1.SetTabRegisterOp{
+			TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: tabID,
+			Field: &leapmuxv1.SetTabRegisterOp_TileId{TileId: newTileID},
+		}}}},
+	}
+}
+
+// submitBatch is a thin wrapper that submits one batch via the public path and
+// asserts it committed, decluttering the resume regression tests.
+func submitBatch(t *testing.T, mgr *crdt.Manager, epoch int64, batch *leapmuxv1.OpBatch) {
+	t.Helper()
+	res, err := mgr.Submit(context.Background(), crdt.SubmitInput{
+		Epoch: epoch, PrincipalID: "user", OriginClient: "c1",
+		Batches: []*leapmuxv1.OpBatch{batch},
+	})
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+	require.NotNil(t, res[0].GetCommitted(), "batch %s should commit; got %v", batch.GetBatchId(), res[0])
+}
+
+// deltaFrameKinds returns the ordered list of oneof case names for a delta's
+// frame stream, so an ordering assertion reads as a literal sequence.
+func deltaFrameKinds(t *testing.T, delta *leapmuxv1.ResumeDelta) []string {
+	t.Helper()
+	out := make([]string, 0, len(delta.GetFrames()))
+	for _, f := range delta.GetFrames() {
+		switch f.GetEvent().(type) {
+		case *leapmuxv1.WatchUserEvent_EntityMaterialized:
+			out = append(out, "materialized")
+		case *leapmuxv1.WatchUserEvent_Batch:
+			out = append(out, "batch")
+		case *leapmuxv1.WatchUserEvent_EntityRemoved:
+			out = append(out, "removed")
+		case *leapmuxv1.WatchUserEvent_BatchEnd:
+			out = append(out, "end")
+		default:
+			out = append(out, "unknown")
+		}
+	}
+	return out
+}
+
+// resumeAsW1Only performs a SubscribeWithACL resume admitting only w1 and
+// returns the ResumeDelta (asserting the RESUME arm was taken).
+func resumeAsW1Only(t *testing.T, mgr *crdt.Manager, cursor *leapmuxv1.HLC, epoch int64) *leapmuxv1.ResumeDelta {
+	t.Helper()
+	resolveOnlyW1 := func() (map[string]bool, error) { return map[string]bool{"w1": true}, nil }
+	sub := &crdt.Subscriber{UserID: "user-1", Send: (&captureSubscriber{}).send}
+	out, err := mgr.SubscribeWithACL(context.Background(), sub, crdt.HLCClone(cursor), epoch, resolveOnlyW1)
+	require.NoError(t, err)
+	require.NotNil(t, out.Unsub())
+	defer out.Unsub()()
+	require.Equal(t, crdt.SubscribeDelta, out.Mode())
+	return out.Delta()
+}
+
+// TestSubscribeWithACL_DeltaReplaysEntityRemovedOnCrossOut is the core #357
+// regression: a tab that was visible to the subscriber at disconnect, then moved
+// to a workspace the subscriber cannot see while disconnected, must arrive as an
+// EntityRemoved frame on resume (so the client evicts the stale "ghost" record).
+// Before the fix, the move op resolved to the disallowed destination and was
+// silently dropped, leaving the ghost record indefinitely.
+func TestSubscribeWithACL_DeltaReplaysEntityRemovedOnCrossOut(t *testing.T) {
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 100_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+	seedRootInternal(t, mgr, "w2", "root2")
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+
+	// Seed a tab in w1 (the subscriber's allowed workspace).
+	submitBatch(t, mgr, epoch, addTabBatch(t, "seed", "tA", "root1", "wkr", "p1"))
+
+	// Capture the cursor here — this is the subscriber's last-seen watermark.
+	cursor := mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc()
+	require.NotNil(t, cursor)
+
+	// While "disconnected": move the tab to w2 (disallowed for a w1-only subscriber).
+	submitBatch(t, mgr, epoch, moveTabBatch("move-out", "tA", "root2"))
+
+	delta := resumeAsW1Only(t, mgr, cursor, epoch)
+
+	// The delta must contain a `removed` frame for the tab so the client evicts
+	// the ghost record (the whole point of #357).
+	var removedTabIDs []string
+	var leakedMoveOps int
+	for _, f := range delta.GetFrames() {
+		if r := f.GetEntityRemoved(); r != nil {
+			if tab := r.GetTab(); tab != nil {
+				removedTabIDs = append(removedTabIDs, tab.GetTabId())
+			}
+		}
+		if b := f.GetBatch(); b != nil {
+			for _, op := range b.GetOps() {
+				if _, isMove := op.GetBody().(*leapmuxv1.CrdtOp_SetTabRegister); isMove {
+					leakedMoveOps++
+				}
+			}
+		}
+	}
+	assert.Contains(t, removedTabIDs, "tA",
+		"tab moved OUT of the allowed set during the gap must arrive as a removed frame (evicts the ghost record)")
+	assert.Equal(t, 0, leakedMoveOps,
+		"the move op into the disallowed workspace must NOT leak as a raw batch op (would carry destination info)")
+}
+
+// TestSubscribeWithACL_DeltaReplaysEntityMaterializedOnCrossIn is the symmetric
+// case: a tab that was NOT visible to the subscriber at disconnect, then moved
+// INTO the subscriber's allowed workspace while disconnected, must arrive as an
+// EntityMaterialized frame carrying the full current record (not as raw move ops
+// that would leak pre-state from the hidden source workspace).
+func TestSubscribeWithACL_DeltaReplaysEntityMaterializedOnCrossIn(t *testing.T) {
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 200_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+	seedRootInternal(t, mgr, "w2", "root2")
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+
+	// Seed a tab in w2 (NOT visible to a w1-only subscriber at disconnect).
+	submitBatch(t, mgr, epoch, addTabBatch(t, "seed", "tA", "root2", "wkr", "p1"))
+
+	cursor := mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc()
+	require.NotNil(t, cursor)
+
+	// While "disconnected": move the tab into w1 (the subscriber's allowed workspace).
+	submitBatch(t, mgr, epoch, moveTabBatch("move-in", "tA", "root1"))
+
+	delta := resumeAsW1Only(t, mgr, cursor, epoch)
+
+	// The delta must contain a `materialized` frame for the tab carrying its
+	// full record (so the client installs it with current state, not the
+	// pre-state the raw move op would carry from the hidden w2).
+	var materializedTabIDs []string
+	for _, f := range delta.GetFrames() {
+		if m := f.GetEntityMaterialized(); m != nil {
+			if tab := m.GetTab(); tab != nil {
+				materializedTabIDs = append(materializedTabIDs, tab.GetTabId())
+			}
+		}
+	}
+	assert.Contains(t, materializedTabIDs, "tA",
+		"tab moved INTO the allowed set during the gap must arrive as a materialized frame (full record)")
+}
+
+// TestSubscribeWithACL_DeltaMaterializedFrameCarriesBatchEraRecord is the
+// load-bearing regression guard for the per-batch record snapshot: when an
+// entity crosses INTO the allowed set in one tail batch and is then EDITED by a
+// LATER tail batch (both within the gap), the materialized frame for the
+// crossing-in batch must carry the BATCH-ERA record (its state at that batch's
+// commit), NOT the current (post-edit) record. Before the snapshot was
+// persisted, the resume materialized frame cloned CURRENT live state and would
+// have shipped batch2's edit in batch1's frame — re-emitting newer state than
+// broadcast would have shipped at batch1's commit.
+func TestSubscribeWithACL_DeltaMaterializedFrameCarriesBatchEraRecord(t *testing.T) {
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 210_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+	seedRootInternal(t, mgr, "w2", "root2")
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+
+	// Seed a tab in w2 with worker_id="wkr".
+	submitBatch(t, mgr, epoch, addTabBatch(t, "seed", "tA", "root2", "wkr", "p1"))
+
+	cursor := mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc()
+	require.NotNil(t, cursor)
+
+	// Batch 1: move the tab INTO w1 (materialized for a w1-only subscriber). At
+	// this batch's commit the tab's worker_id is still "wkr".
+	submitBatch(t, mgr, epoch, moveTabBatch("move-in", "tA", "root1"))
+	// Batch 2: edit the tab's worker_id to "wkr2" (stable-visibility — the tab
+	// stays in w1, so this op ships as a batch frame, and the live record now
+	// holds "wkr2").
+	submitBatch(t, mgr, epoch, &leapmuxv1.OpBatch{
+		BatchId: "edit",
+		Ops: []*leapmuxv1.CrdtOp{{OpId: "op-edit", Body: &leapmuxv1.CrdtOp_SetTabRegister{SetTabRegister: &leapmuxv1.SetTabRegisterOp{
+			TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: "tA",
+			Field: &leapmuxv1.SetTabRegisterOp_WorkerId{WorkerId: "wkr2"},
+		}}}},
+	})
+
+	delta := resumeAsW1Only(t, mgr, cursor, epoch)
+
+	// The materialized frame for tA must carry BATCH-1-era state (worker_id
+	// "wkr"), proving it read the persisted snapshot, not the current live
+	// record (which holds "wkr2" after batch 2). The edit arrives separately as
+	// a batch frame.
+	var matWorkerID string
+	var sawEditBatch bool
+	for _, f := range delta.GetFrames() {
+		if m := f.GetEntityMaterialized(); m != nil {
+			if tab := m.GetTab(); tab != nil && tab.GetTabId() == "tA" {
+				matWorkerID = tab.GetWorkerId().GetValue()
+			}
+		}
+		if b := f.GetBatch(); b != nil && b.GetBatchId() == "edit" {
+			sawEditBatch = true
+		}
+	}
+	assert.Equal(t, "wkr", matWorkerID,
+		"the materialized frame for the crossing-in batch must carry BATCH-ERA state (worker_id wkr), not the current live record (wkr2) — the snapshot is per-batch, not a live clone")
+	assert.True(t, sawEditBatch,
+		"the in-place edit (batch 2) must arrive as a separate batch frame so the client advances to wkr2 after installing the batch-era record")
+}
+
+// TestSubscribeWithACL_DeltaStableVisibilityOpsArriveAsBatchFrames pins that an
+// in-place edit (an op on an entity that stays in the allowed workspace) still
+// arrives as a batch frame — the resume path did not regress the common case
+// while gaining the transition-replay frames.
+func TestSubscribeWithACL_DeltaStableVisibilityOpsArriveAsBatchFrames(t *testing.T) {
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 300_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+
+	// Seed a node under root1 (w1) and capture the cursor.
+	submitNodePositionBatch(t, mgr, "seed", "root1", "initial")
+	cursor := mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc()
+	require.NotNil(t, cursor)
+
+	// In-place position update on root1 (stays in w1 → stable visibility).
+	submitNodePositionBatch(t, mgr, "tail", "root1", "updated")
+
+	delta := resumeAsW1Only(t, mgr, cursor, epoch)
+
+	kinds := deltaFrameKinds(t, delta)
+	assert.Equal(t, []string{"batch", "end"}, kinds,
+		"a stable-visibility in-place edit must arrive as exactly one batch frame (no transition frames)")
+	if len(delta.GetFrames()) == 1 {
+		b := delta.GetFrames()[0].GetBatch()
+		require.NotNil(t, b)
+		assert.Equal(t, "tail", b.GetBatchId())
+	}
+}
+
+// TestSubscribeWithACL_DeltaOrdering_MaterializedBeforeBatchBeforeRemoved pins
+// the per-batch frame-order contract: within a single tail batch that
+// materializes one entity, ships a stable-visibility op on another, and removes
+// a third, the frames must be ordered materialized → batch → removed. The client
+// applies them in delta-order, so materialized-first ensures a batch op
+// referencing a just-materialized entity resolves, and removed-last avoids the
+// dropPendingByPredicate race (consumeEntityRemoved would otherwise drop ops
+// this very batch confirms).
+func TestSubscribeWithACL_DeltaOrdering_MaterializedBeforeBatchBeforeRemoved(t *testing.T) {
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 400_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+	seedRootInternal(t, mgr, "w2", "root2")
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+
+	// tA in w2 (will move INTO w1 → materialized); tB in w1 (will move OUT to w2
+	// → removed); tC in w1 (stays in w1 → its in-place edit is a stable-visibility
+	// batch-frame op, so the delta actually emits all THREE frame kinds).
+	submitBatch(t, mgr, epoch, addTabBatch(t, "seed-a", "tA", "root2", "wkr", "p1"))
+	submitBatch(t, mgr, epoch, addTabBatch(t, "seed-b", "tB", "root1", "wkr", "p1"))
+	submitBatch(t, mgr, epoch, addTabBatch(t, "seed-c", "tC", "root1", "wkr", "p1"))
+
+	cursor := mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc()
+	require.NotNil(t, cursor)
+
+	// One batch with three ops: move tA into w1 (materialized), edit tC in place
+	// (stable-visibility → batch frame), and move tB out to w2 (removed).
+	both := &leapmuxv1.OpBatch{
+		BatchId: "both",
+		Ops: []*leapmuxv1.CrdtOp{
+			{OpId: "op-move-a", Body: &leapmuxv1.CrdtOp_SetTabRegister{SetTabRegister: &leapmuxv1.SetTabRegisterOp{
+				TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: "tA",
+				Field: &leapmuxv1.SetTabRegisterOp_TileId{TileId: "root1"},
+			}}},
+			{OpId: "op-edit-c", Body: &leapmuxv1.CrdtOp_SetTabRegister{SetTabRegister: &leapmuxv1.SetTabRegisterOp{
+				TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: "tC",
+				Field: &leapmuxv1.SetTabRegisterOp_WorkerId{WorkerId: "wkr2"},
+			}}},
+			{OpId: "op-move-b", Body: &leapmuxv1.CrdtOp_SetTabRegister{SetTabRegister: &leapmuxv1.SetTabRegisterOp{
+				TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: "tB",
+				Field: &leapmuxv1.SetTabRegisterOp_TileId{TileId: "root2"},
+			}}},
+		},
+	}
+	submitBatch(t, mgr, epoch, both)
+
+	delta := resumeAsW1Only(t, mgr, cursor, epoch)
+
+	// The contract is the literal sequence materialized → batch → removed.
+	// tC's in-place edit is stable-visibility (Pre=Post=w1, both allowed), so it
+	// ships as the batch frame — without it the test would degenerate to a
+	// two-kind assertion and never exercise the "batch in the middle" arm.
+	kinds := deltaFrameKinds(t, delta)
+	assert.Equal(t, []string{"materialized", "batch", "removed", "end"}, kinds,
+		"a batch that materializes (tA into w1), edits in place (tC stable in w1), and removes (tB out to w2) must order materialized → batch → removed")
+}
+
+// TestSubscribeWithACL_DeltaInOutNetMaterialized proves per-batch commit
+// ordering matters: an entity that crosses OUT of view in one tail batch then
+// back IN in a later tail batch must end the delta VISIBLE (materialized), not
+// removed. Replaying transitions per-batch in commit order is what makes this
+// correct — a single current-state diff would collapse the two transitions and
+// could misclassify.
+func TestSubscribeWithACL_DeltaInOutNetMaterialized(t *testing.T) {
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 500_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+	seedRootInternal(t, mgr, "w2", "root2")
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+
+	// Tab starts in w1 (visible to a w1-only subscriber).
+	submitBatch(t, mgr, epoch, addTabBatch(t, "seed", "tA", "root1", "wkr", "p1"))
+
+	cursor := mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc()
+	require.NotNil(t, cursor)
+
+	// Batch 1: move OUT to w2 (would be a removed transition in isolation).
+	submitBatch(t, mgr, epoch, moveTabBatch("move-out", "tA", "root2"))
+	// Batch 2: move back IN to w1 (materialized transition in isolation).
+	submitBatch(t, mgr, epoch, moveTabBatch("move-in", "tA", "root1"))
+
+	delta := resumeAsW1Only(t, mgr, cursor, epoch)
+
+	// The net result across the two tail batches is "tab ends in w1 (visible)".
+	// Per-batch replay emits a removed frame (batch 1) THEN a materialized frame
+	// (batch 2); the client ends with the tab installed. Assert the LAST
+	// transition frame for tA is materialized (the entity ends visible).
+	var lastKindForTab string
+	for _, f := range delta.GetFrames() {
+		if m := f.GetEntityMaterialized(); m != nil {
+			if tab := m.GetTab(); tab != nil && tab.GetTabId() == "tA" {
+				lastKindForTab = "materialized"
+			}
+		}
+		if r := f.GetEntityRemoved(); r != nil {
+			if tab := r.GetTab(); tab != nil && tab.GetTabId() == "tA" {
+				lastKindForTab = "removed"
+			}
+		}
+	}
+	assert.Equal(t, "materialized", lastKindForTab,
+		"an entity that moves out then back in during the gap must end the delta visible (materialized after removed in commit order)")
+}
+
+// TestSubscribeWithACL_DeltaMaxHlcAdvancesOnTransitionFrameAtHlc pins that the
+// delta's max_hlc is advanced by a transition frame's at_hlc, not only by
+// visible batch-op canonical HLCs. The transition frame (materialized/removed)
+// carries the batch's last canonical HLC as its at_hlc; when a tail batch emits
+// ONLY transition frames (every stable-visibility op is filtered out but an
+// entity crossed the visibility boundary), the client must still adopt that
+// at_hlc as its watermark so the next resume is strictly-after this batch.
+// Before #357 the resume path could not emit transition frames, so this case
+// was impossible; now it is the load-bearing max_hlc source for a
+// transition-only tail batch.
+func TestSubscribeWithACL_DeltaMaxHlcAdvancesOnTransitionFrameAtHlc(t *testing.T) {
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 600_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+	seedRootInternal(t, mgr, "w2", "root2")
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+
+	// Tab starts in w1 (visible to a w1-only subscriber).
+	submitBatch(t, mgr, epoch, addTabBatch(t, "seed", "tA", "root1", "wkr", "p1"))
+
+	cursor := mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc()
+	require.NotNil(t, cursor)
+
+	// Move the tab OUT to w2. The move op's entity resolves to w2 (disallowed
+	// for a w1-only subscriber), so the batch frame is filtered out — the ONLY
+	// frame this tail batch emits for the subscriber is a `removed` frame whose
+	// at_hlc is the batch's last canonical HLC. The delta's max_hlc must be
+	// that at_hlc, not the cursor (nothing newer-than-the-cursor would otherwise
+	// be visible).
+	submitBatch(t, mgr, epoch, moveTabBatch("move-out", "tA", "root2"))
+	moveResult := mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc()
+	require.NotNil(t, moveResult)
+	// Sanity: the move actually advanced the live max past the cursor.
+	require.True(t, crdt.HLCCmp(moveResult, cursor) > 0, "the move must have advanced the live max")
+
+	delta := resumeAsW1Only(t, mgr, cursor, epoch)
+
+	// The delta must contain exactly one removed frame (no batch frame: the
+	// move op was filtered out).
+	var frameKinds []string
+	for _, f := range delta.GetFrames() {
+		switch f.GetEvent().(type) {
+		case *leapmuxv1.WatchUserEvent_EntityRemoved:
+			frameKinds = append(frameKinds, "removed")
+		case *leapmuxv1.WatchUserEvent_Batch:
+			frameKinds = append(frameKinds, "batch")
+		case *leapmuxv1.WatchUserEvent_EntityMaterialized:
+			frameKinds = append(frameKinds, "materialized")
+		}
+	}
+	assert.Equal(t, []string{"removed"}, frameKinds,
+		"a tail batch whose only visible effect is a cross-out must emit exactly one removed frame")
+
+	// The delta's max_hlc must be the removed frame's at_hlc (the batch's last
+	// canonical HLC), which is strictly greater than the cursor. If the resume
+	// path failed to advance max_hlc from a transition frame's at_hlc, the
+	// watermark would be stuck at the cursor and the next resume would replay
+	// this batch.
+	assert.True(t, crdt.HLCCmp(delta.GetMaxHlc(), cursor) > 0,
+		"delta max_hlc must advance past the cursor on a transition-only tail batch (driven by the removed frame's at_hlc)")
+	assert.Equal(t, moveResult.GetPhysical(), delta.GetMaxHlc().GetPhysical(),
+		"delta max_hlc must equal the batch's last canonical HLC (the removed frame's at_hlc)")
+}
+
+// TestSubscribeWithACL_WorkspaceDeletedDuringGap_EmitsRemoval closes the last
+// #357 ghost class.
+//
+// #357's fix made a resume replay the same pre/post visibility rule a live
+// broadcast applies -- but only for entity MOVES. A workspace DELETED during the
+// gap slipped through, because the replay evaluated both sides of every
+// transition against the ACL as it stands NOW: the workspace is gone from the
+// allowed set, its tombstone batch is pinned {Pre: wsID, Post: wsID}, so both
+// sides read invisible. No ops shipped, no EntityRemoved was emitted, and the
+// client kept that workspace's nodes and tabs forever -- and, since the
+// cross-refresh checkpoint landed, wrote them to disk so a reload kept them too.
+// The live path never had the bug only because contractSubscribersForWorkspace
+// runs AFTER the tombstone broadcast.
+//
+// The delta must now evaluate the PRE side against the cursor-era ACL, so the
+// deletion arrives as a becoming-hidden transition the client can act on.
+func TestSubscribeWithACL_WorkspaceDeletedDuringGap_EmitsRemoval(t *testing.T) {
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 230_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+	seedRootInternal(t, mgr, "doomed", "doomed-root")
+
+	// The client's cursor is minted while BOTH workspaces are visible, so its
+	// confirmedState holds the doomed workspace's entities.
+	submitNodePositionBatch(t, mgr, "cursor-batch", "root1", "c0")
+	cursor := crdt.HLCClone(mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc())
+	require.NotNil(t, cursor)
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+
+	// The workspace is deleted while the client is offline: its record is
+	// tombstoned out of state and it leaves the ACL.
+	tombstoneWorkspaceInternal(t, mgr, "doomed", "doomed-root")
+
+	// Reconnect. resolve() reflects the post-delete ACL, exactly as
+	// ListAccessibleWorkspaces would (it filters is_deleted = 0).
+	resolveSurviving := func() (map[string]bool, error) { return map[string]bool{"w1": true}, nil }
+	sub := &crdt.Subscriber{UserID: "user-1", Send: (&captureSubscriber{}).send}
+	out, err := mgr.SubscribeWithACL(context.Background(), sub, cursor, epoch, resolveSurviving)
+	require.NoError(t, err)
+	require.Equal(t, crdt.SubscribeDelta, out.Mode(), "the cursor is inside the window; this must resume")
+	defer out.Unsub()()
+
+	// The client must be told to drop the deleted workspace's contents. Before
+	// the fix the delta carried no frame naming them at all.
+	var removedNodes []string
+	for _, f := range out.Delta().GetFrames() {
+		if er := f.GetEntityRemoved(); er != nil {
+			if n := er.GetNodeId(); n != "" {
+				removedNodes = append(removedNodes, n)
+			}
+		}
+	}
+	assert.Contains(t, removedNodes, "doomed-root",
+		"a workspace deleted during the gap must arrive as a becoming-hidden transition, or its entities ghost forever")
+}
+
+// tombstoneWorkspaceInternal deletes a workspace the way the lifecycle path
+// does: the subtree's nodes are tombstoned and the WorkspaceContentsRecord entry
+// is dropped, in one atomic batch (both are hub-only ops, hence SubmitInternal).
+func tombstoneWorkspaceInternal(t *testing.T, mgr *crdt.Manager, workspaceID, rootID string) {
+	t.Helper()
+	res, err := mgr.SubmitInternal(context.Background(), crdt.SubmitInput{
+		Batches: []*leapmuxv1.OpBatch{{BatchId: "tombstone-" + workspaceID, Ops: []*leapmuxv1.CrdtOp{
+			{
+				OpId: "tombstone-node-" + rootID,
+				Body: &leapmuxv1.CrdtOp_TombstoneNode{TombstoneNode: &leapmuxv1.TombstoneNodeOp{NodeId: rootID}},
+			},
+			{
+				OpId: "tombstone-ws-" + workspaceID,
+				Body: &leapmuxv1.CrdtOp_TombstoneWorkspace{TombstoneWorkspace: &leapmuxv1.TombstoneWorkspaceOp{WorkspaceId: workspaceID}},
+			},
+		}}},
+	})
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+	require.NotNil(t, res[0].GetCommitted(), "workspace tombstone should commit; got %v", res[0])
+}
+
+// TestSubscribeWithACL_NarrowedWorkspaceIsNotTreatedAsDeparted is the guard on
+// the cursor-era widening: it must fire for workspaces that DEPARTED, and only
+// those.
+//
+// The pre-side widening asks "was this visible when the cursor was minted?" and
+// answers it from state, because a workspace leaves an owner's set by exactly
+// one route -- deletion, which tombstones its record. A workspace the subscriber
+// merely narrowed away with workspace_ids is still very much alive in state, so
+// it must NOT be treated as departed: doing so would emit EntityRemoved for
+// entities the client never subscribed to, and (worse) would make ops in a
+// still-live workspace read as a becoming-hidden transition.
+func TestSubscribeWithACL_NarrowedWorkspaceIsNotTreatedAsDeparted(t *testing.T) {
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 230_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+	seedRootInternal(t, mgr, "w2", "root2")
+
+	submitNodePositionBatch(t, mgr, "cursor-batch", "root1", "c0")
+	cursor := crdt.HLCClone(mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc())
+	require.NotNil(t, cursor)
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+
+	// Post-cursor traffic in w2, which is alive but outside this subscription.
+	submitNodePositionBatch(t, mgr, "w2-batch", "root2", "w2op")
+
+	resolveOnlyW1 := func() (map[string]bool, error) { return map[string]bool{"w1": true}, nil }
+	sub := &crdt.Subscriber{
+		UserID:                "user-1",
+		Send:                  (&captureSubscriber{}).send,
+		RequestedWorkspaceIDs: map[string]bool{"w1": true},
+	}
+	out, err := mgr.SubscribeWithACL(context.Background(), sub, cursor, epoch, resolveOnlyW1)
+	require.NoError(t, err)
+	require.Equal(t, crdt.SubscribeDelta, out.Mode())
+	defer out.Unsub()()
+
+	for _, f := range out.Delta().GetFrames() {
+		assert.Nil(t, f.GetEntityRemoved(),
+			"a live workspace outside the subscription is narrowed away, not departed; it must not produce evictions")
+	}
+}
+
+// materializedTabIDs collects the tab ids delivered as EntityMaterialized
+// frames, so the "did the client actually receive this record" assertions read
+// directly.
+func materializedTabIDs(delta *leapmuxv1.ResumeDelta) []string {
+	var out []string
+	for _, f := range delta.GetFrames() {
+		if em := f.GetEntityMaterialized(); em != nil {
+			if tab := em.GetTab(); tab != nil {
+				out = append(out, tab.GetTabId())
+			}
+		}
+	}
+	return out
+}
+
+// TestSubscribeWithACL_EntityBornInGapCreatedWorkspace_Materializes covers the
+// case the workspace-level cursor-era widening gets wrong.
+//
+// `departed` answers "could the subscriber see workspace W when its cursor was
+// minted?" by checking that W is referenced as a Pre, is not allowed now, and is
+// gone from state. A workspace created AND deleted entirely inside the gap
+// satisfies all three -- it is absent for the same reason a deleted one is --
+// so the pre side reads VISIBLE for a workspace the client demonstrably never
+// saw. An entity born in that workspace and then moved somewhere visible then
+// classifies as stably-visible and ships as raw ops, landing on a record the
+// client does not have: applySetTabRegister lazy-creates a partial TabRecord
+// carrying only the fields those ops happened to touch. That is exactly the
+// class EntityMaterialized exists to prevent (#357).
+//
+// The per-entity pre side fixes it: the tab's FIRST sighting is its creation,
+// whose post side is invisible, so the client is recorded as not holding it and
+// the later escape reads as becoming-visible.
+func TestSubscribeWithACL_EntityBornInGapCreatedWorkspace_Materializes(t *testing.T) {
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 240_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+
+	submitNodePositionBatch(t, mgr, "cursor-batch", "root1", "c0")
+	cursor := crdt.HLCClone(mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc())
+	require.NotNil(t, cursor)
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+
+	// --- everything below happens while the client is offline ---
+	// A workspace is created, a tab is born inside it, the tab escapes into the
+	// subscriber's visible workspace, and the scratch workspace is deleted.
+	seedRootInternal(t, mgr, "ephemeral", "eph-root")
+	submitBatch(t, mgr, epoch, addTabBatch(t, "born-hidden", "tEph", "eph-root", "wkr", "p1"))
+	submitBatch(t, mgr, epoch, moveTabBatch("escape", "tEph", "root1"))
+	tombstoneWorkspaceInternal(t, mgr, "ephemeral", "eph-root")
+
+	delta := resumeAsW1Only(t, mgr, cursor, epoch)
+
+	assert.Contains(t, materializedTabIDs(delta), "tEph",
+		"a tab the client never held must arrive as a full record, not as raw ops onto a record it lacks")
+}
+
+// TestSubscribeWithACL_EntityBornInGapDepartedWorkspace_Materializes is the
+// sibling of the case above, and shows the defect is not really about when the
+// workspace was born.
+//
+// Here the workspace pre-dates the cursor and IS genuinely departed (deleted
+// during the gap), so the workspace-level answer "the client could see it at
+// cursor time" is correct. It is still the wrong answer for this ENTITY: the tab
+// was created inside that workspace AFTER the cursor, so the client never held
+// it either. The pre side is a per-entity question, and a per-workspace
+// approximation gets it wrong from both directions.
+func TestSubscribeWithACL_EntityBornInGapDepartedWorkspace_Materializes(t *testing.T) {
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 250_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+	seedRootInternal(t, mgr, "doomed", "doomed-root")
+
+	submitNodePositionBatch(t, mgr, "cursor-batch", "root1", "c0")
+	cursor := crdt.HLCClone(mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc())
+	require.NotNil(t, cursor)
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+
+	// --- offline ---
+	submitBatch(t, mgr, epoch, addTabBatch(t, "born-doomed", "tDoomed", "doomed-root", "wkr", "p1"))
+	submitBatch(t, mgr, epoch, moveTabBatch("escape", "tDoomed", "root1"))
+	tombstoneWorkspaceInternal(t, mgr, "doomed", "doomed-root")
+
+	delta := resumeAsW1Only(t, mgr, cursor, epoch)
+
+	assert.Contains(t, materializedTabIDs(delta), "tDoomed",
+		"a tab born inside a departed workspace during the gap was never held by the client either")
+}

--- a/backend/internal/hub/crdt/manager_subscribe.go
+++ b/backend/internal/hub/crdt/manager_subscribe.go
@@ -1,0 +1,884 @@
+package crdt
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"google.golang.org/protobuf/proto"
+)
+
+// Subscriber registration and the delta-resume protocol.
+//
+// One file for the whole subscribe family because its members are a single
+// mechanism, not a layer: SubscribeWithACL is the only production entry point,
+// and it reaches FALLBACK and RESUME through the same register seam
+// (registerSubscriber / makeUnsub) that the plain Subscribe path uses, so the
+// presence-refcount invariant has exactly one home. Splitting only the resume
+// state machine out would have put half of that seam in each file.
+//
+// The lock plan the whole file turns on is documented on SubscribeWithACL.
+
+// SubscribeWithACL resolves a subscriber's workspace filter, then registers it and
+// emits the bootstrap frame -- a ResumeDelta when the client's cursor is still
+// within the hub's compaction window, or a full UserMaterialized snapshot
+// (FALLBACK) otherwise. Every /ws/userevents connect goes through this: a
+// first-time connect passes a nil cursor and gets a full snapshot via the
+// FALLBACK arm, which is byte-identical to the legacy full-snapshot subscribe.
+//
+// resolve reads the DB ACL and returns the allowed workspace set; it runs while
+// this holds subscribeExpandMu, the SAME lock ExpandSubscribersForWorkspace
+// holds across a workspace-create expansion. That serialization closes the
+// resolve-then-register TOCTOU: a concurrent create of a workspace the user
+// owns is ordered either FULLY before resolve() -- so resolve reads the
+// post-commit ACL and the workspace is already included -- or FULLY after the
+// register below -- so the create's expand pass sees the now-registered
+// subscriber. Without it, a filter resolved from the pre-commit ACL could be
+// registered after the whole expansion finished, and the expand (which only
+// visits already-registered subscribers) would miss it, so the subscriber
+// would never see the new workspace until it reconnected.
+//
+// resolve's error is returned unregistered so the caller can reject the
+// connection before streaming any events. Lock order
+// subscribeExpandMu -> projection -> m.mu is preserved on every path where
+// more than one is held (the FALLBACK arms hold subscribeExpandMu + projection
+// across the register; Subscribe, called from the FALLBACK seam, takes only
+// projection and m.mu).
+//
+// RESUME: when the cursor is non-zero, above op_retention_watermark (the
+// lagging floor below which op batches may have been deleted), and the
+// epoch is unchanged, this registers the subscriber and returns a ResumeDelta
+// (the post-cursor op tail, filtered to the subscriber's allowed set) instead
+// of a full snapshot. The register + until capture run under subscribeExpandMu
+// and a brief m.projection hold (closing the resolve→register TOCTOU and the
+// until/broadcast dual-delivery race); both are then RELEASED, and the journal
+// tail read (m.journal.ListBatchesAfter) + visibility filter run under NEITHER
+// subscribeExpandMu NOR m.projection. That is safe because the broadcast
+// straddle is closed by REGISTRATION ORDER plus resumeSuppressThrough: the
+// just-registered subscriber is in the snapshot subs for any commit's
+// broadcastBatch, so a commit landing during the tail read is delivered as a
+// normal broadcast frame right after the delta (and batches at or below until
+// are suppressed on the live path so they ship only in the delta). The tail is
+// therefore a strict lower bound; the broadcast stream fills anything newer.
+// Releasing the locks for the scan means a reconnect's DB scan no longer stalls
+// that user's workspace lifecycle RPCs (subscribeExpandMu) or other tabs' live
+// commit broadcasts (m.projection) for the scan's duration.
+//
+// The delta's max_hlc is computed over the FRAMES THIS DELTA EMITS, never read
+// from live m.state. That is what keeps a commit landing during the tail read
+// from being skipped: it advances m.state.MaxHlc but is delivered as a
+// broadcast frame AFTER the delta, so advertising the live max here would let a
+// disconnect-before-broadcast lose it on the next resume.
+//
+// Precisely: max_hlc is the max over each emitted frame's own HLC — visible
+// ops' canonical HLCs, AND the at_hlc carried by each materialized/removed
+// transition frame. A transition frame's at_hlc is its BATCH's last-op HLC (see
+// emitCatchUpFrames), so for a batch whose ops are partly filtered out, max_hlc
+// can exceed the last op the subscriber actually received. That is sound only
+// because the cursor is compared against a strictly-greater scan and a filtered
+// entity that later becomes visible arrives as a full EntityMaterialized record
+// rather than as its historical ops — it does NOT hold as the stronger
+// "never exceeds an op it received", and a client that reconnects under a WIDER
+// workspace_ids filter than the one the cursor was minted under can miss ops.
+// The persisted cursor is per-user, not per-filter. Two in-tree callers DO
+// narrow the filter -- remoteipc.HubEventStreamer and remote.Client both forward
+// a workspace_ids set -- but neither ever PRESENTS a cursor (both hard-code
+// nil/0 and are stateless per call), and the browser, which does present one,
+// always subscribes to all owned workspaces. So the pairing that would bite --
+// a cursor minted under a narrow filter and replayed under a wider one -- has no
+// producer today. It is a constraint to preserve, not a live bug; making it
+// mechanical needs the mint-time filter carried alongside the cursor.
+//
+// ctx threads the request's cancellation into the journal tail read so a
+// client that disconnects mid-resume aborts the (potentially multi-page, up to
+// MaxResumeDeltaOps) DB scan instead of completing it only to discard the result.
+//
+// FALLBACK: when cursor is nil/zero, at or below op_retention_watermark
+// (the journal can no longer reconstruct the delta), the epoch is stale, the
+// post-cursor tail exceeds MaxResumeDeltaOps / MaxResumeDeltaBytes, or the BUILT
+// delta exceeds MaxResumeDeltaFrameBytes (the wire-frame gate in
+// buildResumeDelta), this returns a SubscribeOutcome whose Mode is
+// SubscribeInitial (carrying the full UserMaterialized snapshot the caller sends
+// as the `initial` frame).
+func (m *Manager) SubscribeWithACL(
+	ctx context.Context,
+	sub *Subscriber,
+	cursor *leapmuxv1.HLC,
+	clientEpoch int64,
+	resolve func() (map[string]bool, error),
+) (SubscribeOutcome, error) {
+	// Lock plan (release order matters — see the lock-ordering note on the
+	// type). subscribeExpandMu closes the resolve→register TOCTOU with
+	// ExpandSubscribersForWorkspace; it is needed ONLY across resolve + the
+	// register/FALLBACK decision, then RELEASED before the RESUME tail read so
+	// a reconnect's (potentially multi-page) DB scan does not stall that
+	// user's workspace-create/delete lifecycle RPCs. m.projection serializes
+	// the FALLBACK arm's register+materialized-baseline against broadcasts
+	// (the Subscribe invariant), and on the RESUME arm is held only across the
+	// brief until-capture+register window (so broadcastBatch cannot dual-
+	// deliver a batch that also lands inside until). The RESUME scan itself
+	// does NOT hold m.projection — registration order plus
+	// resumeSuppressThrough close the straddle, and releasing projection for
+	// the scan means a reconnect no longer stalls every other tab's live
+	// commit broadcasts for the scan's duration.
+	// The locked section is a closure so its unlocks run via defer. resolve()
+	// reaches the store, and net/http RECOVERS a handler panic and keeps the
+	// process serving -- so a panic under subscribeExpandMu would leak it and
+	// wedge every later /ws/userevents connect plus every workspace
+	// create/delete for this user, silently and until restart. Explicit unlocks
+	// cover the return paths; only defer covers the unwind.
+	// out stays at its zero value (mode subscribeModeInvalid) unless the FALLBACK
+	// arm fills it in, so its mode IS the record of which arm ran -- no separate
+	// bool to keep in step with it.
+	var (
+		out    SubscribeOutcome
+		until  *leapmuxv1.HLC
+		filter SubscriberFilter
+	)
+	if err := func() error {
+		m.subscribeExpandMu.Lock()
+		defer m.subscribeExpandMu.Unlock()
+
+		allowed, err := resolve()
+		if err != nil {
+			return err
+		}
+		sub.Filter = NewSubscriberFilter(allowed)
+
+		if !m.decideResume(cursor, clientEpoch) {
+			// FALLBACK: identical to Subscribe (full snapshot under projection +
+			// m.mu.RLock). subscribeLocked needs m.projection held across the
+			// register+materialized clone so the baseline cannot straddle a
+			// concurrent broadcast's filter mutation — the same reason Subscribe
+			// holds it. subscribeExpandMu stays held through the register to keep
+			// the expand TOCTOU closed. LIFO defer order preserves the
+			// projection-then-expand release order the lock plan requires.
+			m.projection.Lock()
+			defer m.projection.Unlock()
+			out = m.fallbackOutcome(sub)
+			return nil
+		}
+
+		// RESUME: register the subscriber via the same seam Subscribe/FALLBACK
+		// use (so the presence-refcount invariant has one home), then build the
+		// delta. subscribeLocked would also compute a materialized snapshot the
+		// resume does not need, so call only its register half.
+		// subscribeExpandMu is still held so the register stays serialized
+		// against a concurrent expand; it is released on return from this
+		// closure, before buildResumeDelta's DB scan.
+		until, filter = m.registerForResume(sub)
+		return nil
+	}(); err != nil {
+		return SubscribeOutcome{}, err
+	}
+	if out.Mode() == SubscribeInitial {
+		return out, nil
+	}
+
+	// buildResumeDelta owns the unsub handle (makeUnsub is idempotent, so it
+	// doubles as teardown for the FALLBACK re-entry the caller performs).
+	// buildResumeDelta returns a resumeScanResult; the caller (this function)
+	// owns the FALLBACK re-entry, so buildResumeDelta no longer takes the
+	// resolve/unsub teardown callbacks.
+	req := resumeRequest{
+		sub:         sub,
+		filter:      filter,
+		cursor:      cursor,
+		until:       until,
+		clientEpoch: clientEpoch,
+	}
+	res := m.buildResumeDelta(ctx, req)
+	switch res.kind {
+	case resumeScanDelta:
+		return res.outcome, nil
+	case resumeScanFallback:
+		// buildResumeDelta signaled FALLBACK (over-budget / corrupt / post-scan
+		// compaction-or-epoch drift). It already tore down the registration;
+		// re-enter the FALLBACK seam, which re-resolves + re-registers fresh.
+		return m.resumeFallback(sub, resolve)
+	case resumeScanError:
+		// The registration is already torn down (unsub fired inside
+		// buildResumeDelta); surface the connect failure.
+		return SubscribeOutcome{}, res.err
+	default:
+		// resumeScanInvalid — a return path that forgot to set `kind`. Refuse
+		// the connect rather than ship a zero-value outcome.
+		return SubscribeOutcome{}, fmt.Errorf("resume: buildResumeDelta returned no verdict (kind=%d)", res.kind)
+	}
+}
+
+// decideResume is the RESUME-vs-FALLBACK verdict against live state: the cursor
+// is non-zero, strictly above op_retention_watermark (the lagging floor below
+// which op batches may have been deleted, so the journal can no longer
+// reconstruct the delta), and the client's epoch matches the live epoch.
+// op_retention_watermark — not compaction_watermark — gates resume because the
+// resume contract is "can the server still produce the delta?", which is a
+// question about op-batch availability, not tombstone pruning. Tombstones are
+// pruned at the tighter compaction_watermark (= max_hlc) for correctness, and
+// that prune does not by itself remove any op batch (see maybeCompact, where
+// DropThrough lags at op_retention_watermark while PruneTombstonesAtOrBelow
+// runs at compaction_watermark). Read under a brief m.mu.RLock; the post-scan
+// re-check in buildResumeDelta re-validates because the unlocked scan can race
+// a compaction or epoch bump (see buildResumeDelta).
+func (m *Manager) decideResume(cursor *leapmuxv1.HLC, clientEpoch int64) bool {
+	if cursor == nil || HLCIsZero(cursor) {
+		return false
+	}
+	// Retention floor, applied ALONGSIDE the stored watermark.
+	//
+	// op_retention_watermark only advances while the user is committing:
+	// maybeCompact's tick short-circuits once compaction_watermark reaches
+	// max_hlc, so a dormant account's floor freezes at (last activity - TTL)
+	// while the cleanup job keeps sweeping its rows. Gating on the stored
+	// watermark alone would then admit a cursor whose batches the sweep had
+	// already deleted, and the resume would ship a silently short tail --
+	// ListBatchesAfter reports deleted-below rows as an ordinary short result,
+	// not an error.
+	//
+	// Both sides call OpRetentionCutoffPhysicalMs, so this is the same number
+	// the sweep deletes below, in the same (HLC physical) domain.
+	//
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return HLCCmp(cursor, m.opRetentionFloorLocked()) > 0 &&
+		clientEpoch == m.state.GetCurrentEpoch()
+}
+
+// opRetentionFloorLocked returns the effective HLC floor a resume cursor must
+// sit strictly above: the greater of the PERSISTED op_retention_watermark and
+// the live wall-clock cutoff the cross-user sweep deletes below.
+//
+// One expression for one concept. The two floors were previously applied as two
+// differently-SHAPED tests at the call site -- a physical-only `<` against the
+// cutoff, then an HLC compare against the stored watermark -- which read as two
+// unrelated rules rather than "above every floor that deletes".
+//
+// Both are needed, and neither subsumes the other:
+//
+//   - the STORED watermark is authoritative while the user is active, but it
+//     only advances while they are committing (maybeCompact short-circuits once
+//     compaction_watermark reaches max_hlc), so a dormant account's freezes at
+//     (last activity - TTL) while the cleanup job keeps sweeping its rows;
+//   - the WALL-CLOCK cutoff tracks the sweep exactly, and is the only one that
+//     moves for an account with no resident manager at all -- which is precisely
+//     the account whose stored value is stale.
+//
+// Both sides call OpRetentionCutoffPhysicalMs, so this is the same number the
+// sweep deletes below, in the same (HLC physical) domain.
+//
+// The cutoff is compared as a physical-only HLC, which preserves the STRICT
+// less-than the sweep uses (`physical_ms < cutoff`): a batch at exactly the
+// cutoff survives, so a cursor there stays resumable, and a zero TTL does not
+// refuse every cursor before the scan starts. A cursor at the cutoff physical
+// with logical 0 and an empty client id compares equal to this floor and is
+// therefore refused by the caller's strict `>` -- the same answer the previous
+// two-test form gave, since it required `physical >= cutoff` AND
+// `HLCCmp(cursor, stored) > 0`.
+//
+// Deliberately NOT read by maybeCompact's DropThrough. That is a DELETION floor
+// whose value is also persisted as op_retention_watermark, so routing it through
+// this wall-clock-derived expression would change both what compaction deletes
+// and what the state blob then advertises. This is a read-side unification only.
+//
+// Caller must hold m.mu (read or write).
+func (m *Manager) opRetentionFloorLocked() *leapmuxv1.HLC {
+	floor := m.state.GetOpRetentionWatermark()
+	cutoff := &leapmuxv1.HLC{Physical: OpRetentionCutoffPhysicalMs(m.now(), m.opRetentionTTL)}
+	if HLCCmp(cutoff, floor) > 0 {
+		floor = cutoff
+	}
+	// Never above the tombstone-prune line: op batches at or below
+	// compaction_watermark are still resumable when they survive the lagging
+	// deletion floor, and clamping keeps this from refusing them.
+	if wm := m.state.GetCompactionWatermark(); wm != nil && HLCCmp(floor, wm) > 0 {
+		floor = wm
+	}
+	return floor
+}
+
+// registerForResume is the register+until-capture window of the RESUME arm.
+// until capture + register MUST be atomic w.r.t. broadcastBatch: commitState
+// advances MaxHlc under m.mu alone, then broadcastBatch takes m.projection.
+// Capturing until under a separate m.mu.RLock after an unlocked Add left a
+// window where a concurrent commit could (1) advance MaxHlc, (2) broadcast the
+// batch to the just-registered sub, and (3) still fall inside until —
+// dual-delivering the same catch-up frames via live Send and the delta.
+// Holding m.projection across until+register closes that window against
+// broadcastBatch; resumeSuppressThrough then suppresses any in-flight broadcast
+// whose HLC is <= until (commitState may have run during the brief projection
+// hold before until was read).
+//
+// Caller MUST hold subscribeExpandMu and NOT m.projection; this method takes
+// m.projection + m.mu.RLock and releases both. Returns the captured until
+// high-water and a snapshot of the subscriber's filter safe to hand to the
+// (lock-free) resume scan (SubscriberFilter is immutable after install — see
+// its type doc).
+func (m *Manager) registerForResume(sub *Subscriber) (until *leapmuxv1.HLC, filter SubscriberFilter) {
+	m.projection.Lock()
+	defer m.projection.Unlock()
+	// BOTH unlocks are deferred, for the reason SubscribeWithACL's lock plan
+	// gives: a recovered handler panic leaves the process serving, so a read
+	// lock leaked while unwinding out of registerSubscriber (which reaches
+	// subscribers.Add and presenceCtl.OnConnect) would block every later
+	// commitState, decideResume and materializedLocked for this user forever.
+	func() {
+		m.mu.RLock()
+		defer m.mu.RUnlock()
+		until = HLCClone(m.state.GetMaxHlc())
+		sub.resumeSuppressThrough = until
+		m.registerSubscriber(sub)
+	}()
+	filter = sub.Filter
+	return until, filter
+}
+
+// resumeRequest bundles the lock-free resume scan's inputs, keeping the
+// buildResumeDelta signature to (ctx, req) instead of a primitive-obsessed
+// param list.
+type resumeRequest struct {
+	sub         *Subscriber
+	filter      SubscriberFilter
+	cursor      *leapmuxv1.HLC
+	until       *leapmuxv1.HLC
+	clientEpoch int64
+}
+
+// resumeScanKind discriminates the three outcomes buildResumeDelta can report.
+// An explicit kind (rather than inferring from outcome.mode) keeps the scan's
+// verdict separate from the payload it carries: a FALLBACK signal and an error
+// both carry a zero-value outcome, and only the kind says which of the two it
+// is. (SubscribeMode reserves its own zero value for the same class of hazard —
+// see subscribeModeInvalid.)
+type resumeScanKind int
+
+const (
+	// resumeScanInvalid is the ZERO VALUE, deliberately not a real outcome. If
+	// a future return path forgets to set `kind`, it lands here and hits the
+	// switch's default error arm — loudly — instead of reading as "delta ready"
+	// and shipping a nil ResumeDelta with a nil unsub (which would leak the
+	// just-registered subscriber and its presence refcount).
+	resumeScanInvalid resumeScanKind = iota
+	resumeScanDelta
+	resumeScanFallback
+	resumeScanError
+)
+
+// resumeScanResult is what buildResumeDelta returns: a discriminating `kind`
+// plus exactly one payload — `outcome` on resumeScanDelta, `err` on
+// resumeScanError, and neither on resumeScanFallback (which carries no data:
+// buildResumeDelta has already torn the registration down, and the caller
+// re-resolves and re-registers from scratch).
+type resumeScanResult struct {
+	kind    resumeScanKind
+	outcome SubscribeOutcome
+	err     error
+}
+
+// buildResumeDelta constructs the RESUME outcome for an already-registered
+// subscriber: page the post-cursor op tail out of the journal, filter it to
+// the subscriber's current allowed workspaces, and wrap it as a ResumeDelta.
+// SubscribeWithACL has ALREADY released subscribeExpandMu and m.projection on
+// this path — see SubscribeWithACL's lock plan: the broadcast straddle is
+// closed by REGISTRATION ORDER plus resumeSuppressThrough (the subscriber is
+// registered before this call, so a commit landing during the scan is
+// broadcast to it as a normal frame when HLC > until — the tail is a strict
+// lower bound), so the scan + filter hold NEITHER subscribeExpandMu NOR
+// m.projection and therefore do not stall workspace lifecycle RPCs or other
+// tabs' live broadcasts.
+//
+// Returns a resumeScanResult. The caller owns FALLBACK re-entry: on
+// over-budget / corrupt / post-scan compaction-or-epoch invalidation / a built
+// delta over MaxResumeDeltaFrameBytes, this tears down the registration (unsub)
+// and returns a bare resumeScanFallback (which carries no payload -- the caller
+// re-resolves and re-registers from scratch through resumeFallback); on a hard
+// tail-read error it tears down + returns the error; on success it returns the
+// delta outcome.
+func (m *Manager) buildResumeDelta(ctx context.Context, req resumeRequest) resumeScanResult {
+	unsub := makeUnsub(req.sub, m)
+	// Page the post-cursor tail out of the journal, capped at the register-time
+	// high-water (`until`). ctx is the request context: a client disconnect
+	// cancels it and aborts the (potentially multi-page, up to MaxResumeDeltaOps)
+	// scan rather than completing it for a dead socket.
+	//
+	// Each ResumeBatch pairs the batch with its persisted per-entity workspace
+	// transitions, so this path can replay the SAME pre/post stable-visibility
+	// classification the live broadcast applies — emitting
+	// entity_materialized / entity_removed WatchUserEvent frames for entities
+	// that crossed the subscriber's visibility boundary during the gap, not
+	// just the current-workspace-filtered raw ops. That eliminates the
+	// ghost-record / incomplete-record divergence (#357): the two catch-up
+	// paths read the same persisted transitions through the same
+	// emitCatchUpFrames planner. The materialized frame reads a PERSISTED
+	// per-batch record snapshot (captured at commit), so it ships the same
+	// record broadcast would have shipped — not a current live-state clone a
+	// later tail batch may have since overwritten.
+	tail, corruptRows, tailErr := m.journal.ListBatchesAfter(ctx, m.owner.String(), req.cursor, req.until, MaxResumeDeltaOps, MaxResumeDeltaBytes)
+	// Log every corrupt row the scan reported so the (rare) storage damage is
+	// observable, whichever way the verdict goes below.
+	// m.logger already carries user_id (bound in NewManager).
+	for _, c := range corruptRows {
+		m.logger.Warn("resume hit a corrupt journal row; falling back to a full snapshot",
+			"batch_id", c.BatchID,
+			"field", c.Field,
+			"error", c.Cause)
+	}
+	// ErrDeltaTooLarge and ErrResumeCorrupt are both "cannot ship a delta, but a
+	// full snapshot is fine" verdicts. Corrupt specifically MUST NOT degrade to
+	// a partial delta: the frames after the bad row would advance the client's
+	// max_hlc past a batch it never received, and ListBatchesAfter is
+	// strictly-greater, so no later resume would re-request it — the divergence
+	// would be permanent (and, since #356, written into the client's persisted
+	// checkpoint). A snapshot is always complete.
+	if errors.Is(tailErr, ErrDeltaTooLarge) || errors.Is(tailErr, ErrResumeCorrupt) {
+		// Signal FALLBACK to the caller, which owns re-entry. Tear down first
+		// so resumeFallback's re-register does not double-register.
+		unsub()
+		return resumeScanResult{kind: resumeScanFallback}
+	}
+	if tailErr != nil {
+		unsub()
+		return resumeScanResult{kind: resumeScanError, err: fmt.Errorf("resume: list batches after cursor: %w", tailErr)}
+	}
+	// Compaction (or an epoch bump) during the unlocked scan can DeleteThrough
+	// journal rows the verdict believed were still available — ListBatchesAfter
+	// then returns a shortened/empty tail without ErrDeltaTooLarge, and the
+	// client would adopt max_hlc while missing compacted-away ops. Re-check the
+	// resumable predicate against live state; if the cursor is no longer above
+	// the watermark (or the epoch moved), signal FALLBACK.
+	if !m.decideResume(req.cursor, req.clientEpoch) {
+		unsub()
+		return resumeScanResult{kind: resumeScanFallback}
+	}
+	// The transport could not buffer a live frame while this scan ran, so the
+	// delta it is about to ship would be missing whatever it dropped. FALLBACK
+	// rather than shipping a hole -- and rather than letting the transport tear
+	// the connection down, which sent the client back with the same cursor to
+	// rebuild the same multi-page scan under the same load.
+	//
+	// Checked HERE, after the scan and before any frame is built, because
+	// resumeFallback re-registers and calls OnRebaseline -- which discards the
+	// parked buffer -- before taking the snapshot baseline. A frame dropped
+	// during the scan is therefore superseded by that snapshot, not lost.
+	if req.sub.overflowed() {
+		m.logger.Warn("resume subscriber overflowed its park buffer during the scan; falling back to a snapshot",
+			"client_id", req.sub.ClientID)
+		unsub()
+		return resumeScanResult{kind: resumeScanFallback}
+	}
+
+	// Build the ordered resume frame stream via the SAME emitCatchUpFrames
+	// planner the live broadcast uses. Frames are WatchUserEvent values
+	// (entity_materialized | batch | entity_removed | batch_end) — the unified envelope
+	// live Send already speaks — so the client dispatches resume and live
+	// through one switch. No manager lock across the frame build: snapshots
+	// are persisted. The only live-state access is the epoch read below.
+	//
+	// ONE sink for the whole tail, constructed here rather than per batch: it
+	// OWNS both accumulators (the frame stream and the max_hlc those frames
+	// advertise), so re-boxing it inside the loop would only re-wrap the same
+	// two fields once per batch.
+	sink := &resumeCatchUpSink{
+		frames: make([]*leapmuxv1.WatchUserEvent, 0, len(tail)),
+		maxHLC: HLCClone(req.cursor),
+	}
+	// Restore the pre-side of each transition to its CURSOR-ERA answer. Without
+	// this the replay evaluates gap batches against the ACL as it stands now, so
+	// a workspace deleted during the gap reads as invisible on both sides of its
+	// own tombstone batch and the client is never told to drop it. See
+	// visibilityScope.
+	scope := resumeScope(req.filter, m.departedWorkspaces(req.filter, req.sub.RequestedWorkspaceIDs, tail))
+	for _, rb := range tail {
+		transitions, records := TransitionsFromProto(rb.Transitions)
+		atHLC := lastBatchHLC(rb.Batch)
+		cb := catchUpBatch{
+			refs:        orderedAffectedRefs(transitions),
+			batch:       rb.Batch,
+			transitions: transitions,
+			atHLC:       atHLC,
+		}
+		emitCatchUpFrames(cb, scope, func(ref EntityRef) *leapmuxv1.EntityMaterialized {
+			rec, ok := records[ref]
+			if !ok || rec == nil {
+				return nil
+			}
+			// Fresh AtHlc stamp — do not mutate the records map entry.
+			return &leapmuxv1.EntityMaterialized{AtHlc: atHLC, Entity: rec.Entity}
+		}, sink)
+		// Carry this batch's outcome into the next one's pre side. Must run
+		// AFTER the whole batch is classified, never between its passes.
+		scope.observe(cb.refs)
+	}
+	m.mu.RLock()
+	epoch := m.state.GetCurrentEpoch()
+	m.mu.RUnlock()
+
+	delta := &leapmuxv1.ResumeDelta{
+		Frames:       sink.frames,
+		MaxHlc:       sink.maxHLC,
+		CurrentEpoch: epoch,
+	}
+	// EXACT frame gate on the BUILT delta, an ADDITIONAL check beside the scan's
+	// MaxResumeDeltaBytes source-row budget rather than a replacement for it:
+	// that one bounds MEMORY during a streaming scan, before any delta exists to
+	// measure, while this one bounds what actually goes on the WIRE. The whole
+	// delta ships as ONE WebSocket message (SubscribeOutcome.Bootstrap wraps it
+	// into a single MarshaledEvent), so exceeding the client's read limit is not
+	// a slow path -- the read fails, the client reconnects with the SAME cursor,
+	// rebuilds the SAME oversized frame, and loops forever with no server-side
+	// error to attribute it to. FALLBACK instead: a snapshot of the same account
+	// is smaller by construction here, because the delta's bulk is the per-batch
+	// record snapshots in transitions_payload (one copy per batch that touched an
+	// entity) where the materialized state carries each entity exactly once.
+	if size := proto.Size(delta); size > m.maxResumeDeltaFrameBytes {
+		m.logger.Warn("resume delta exceeds the wire frame ceiling; falling back to a full snapshot",
+			"delta_bytes", size,
+			"ceiling_bytes", m.maxResumeDeltaFrameBytes,
+			"frames", len(sink.frames))
+		// Same teardown as the over-budget scan arm: the caller owns FALLBACK
+		// re-entry and re-registers from scratch.
+		unsub()
+		return resumeScanResult{kind: resumeScanFallback}
+	}
+	return resumeScanResult{kind: resumeScanDelta, outcome: newSubscribeDeltaOutcome(delta, unsub)}
+}
+
+// departedWorkspaces names the workspaces a resuming subscriber could see when
+// its cursor was minted but cannot see now, so buildResumeDelta can evaluate the
+// PRE side of each gap transition against the cursor-era ACL.
+//
+// It is derived from state rather than from an ACL snapshot, because the CRDT
+// already records the only event that removes a workspace from an owner's set:
+// TombstoneWorkspaceOp drops the WorkspaceContentsRecord. Access is owner-only
+// (there is no sharing to revoke and no cross-owner grant), so within one user's
+// manager "referenced as a transition's Pre, not currently allowed, and no
+// longer present in state" means exactly "deleted since". A workspace the
+// subscriber merely narrowed away with workspace_ids is still IN state, so it is
+// correctly not treated as departed.
+//
+// Returns nil when nothing departed, which makes visibilityScope.preVisible a
+// plain filter lookup on the overwhelmingly common path.
+//
+// Takes the filter BY VALUE rather than reading sub.Filter: buildResumeDelta
+// runs with neither subscribeExpandMu nor the projection lock held (that is the
+// whole point of the lock-free tail scan), while contractSubscribersForWorkspace
+// assigns sub.Filter under the SubscriberController's own mutex on every
+// workspace delete. Reading the live field here would be an unsynchronized read
+// racing that write, and would answer against a different filter than the
+// visibilityScope built from req.filter two lines up. requested is
+// Subscriber.RequestedWorkspaceIDs, which is immutable after Add and so is safe
+// to hand over directly.
+func (m *Manager) departedWorkspaces(filter SubscriberFilter, requested map[string]bool, tail []ResumeBatch) map[string]bool {
+	var candidates map[string]bool
+	for _, rb := range tail {
+		for _, entry := range rb.Transitions.GetEntries() {
+			pre := entry.GetPreWorkspace()
+			if pre == "" || filter.IsAllowed(pre) {
+				continue
+			}
+			// An explicitly narrowed subscriber never held workspaces outside
+			// its request, so evicting them would be noise.
+			if len(requested) > 0 && !requested[pre] {
+				continue
+			}
+			if candidates == nil {
+				candidates = map[string]bool{}
+			}
+			candidates[pre] = true
+		}
+	}
+	if candidates == nil {
+		return nil
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	live := m.state.GetWorkspaces()
+	for ws := range candidates {
+		if _, stillExists := live[ws]; stillExists {
+			// Present in state but outside the filter: a workspace the caller
+			// narrowed away, not one that was deleted.
+			delete(candidates, ws)
+		}
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+	return candidates
+}
+
+// resumeFallback re-enters the FALLBACK seam (full snapshot) after a resume
+// scan gave up. buildResumeDelta has ALREADY torn down the RESUME registration
+// on every path that reaches here, so this only re-registers.
+//
+// resolve runs again under subscribeExpandMu so the snapshot filter reflects
+// the current ACL — the filter installed at the earlier resolve may have been
+// expand/contract-mutated while the subscriber was registered, and a stale copy
+// must not seed the FALLBACK baseline.
+func (m *Manager) resumeFallback(
+	sub *Subscriber,
+	resolve func() (map[string]bool, error),
+) (SubscribeOutcome, error) {
+	// Same panic-safety reasoning as SubscribeWithACL: resolve() reaches the
+	// store and a recovered handler panic must not leak either lock.
+	m.subscribeExpandMu.Lock()
+	defer m.subscribeExpandMu.Unlock()
+
+	allowed, err := resolve()
+	if err != nil {
+		return SubscribeOutcome{}, err
+	}
+	sub.Filter = NewSubscriberFilter(allowed)
+	// Clear the resume suppress gate: FALLBACK re-registers fresh and must
+	// receive every live broadcast after the snapshot baseline.
+	sub.resumeSuppressThrough = nil
+	m.projection.Lock()
+	defer m.projection.Unlock()
+	// Discard anything the transport queued during the resume scan BEFORE the
+	// baseline is taken. Those frames predate the snapshot, and the client
+	// applies entity_materialized / entity_removed wholesale, so writing them
+	// after it would resurrect stale records permanently. Both calls sit under
+	// m.projection, so no broadcast can slip between the discard and the clone.
+	if sub.OnRebaseline != nil {
+		sub.OnRebaseline()
+	}
+	return m.fallbackOutcome(sub), nil
+}
+
+// SubscribeMode discriminates which bootstrap frame SubscribeOutcome carries.
+type SubscribeMode int
+
+const (
+	// subscribeModeInvalid is the ZERO VALUE, and is deliberately not a real
+	// arm. Every error return is `SubscribeOutcome{}`, so without this the zero
+	// outcome would read as "SubscribeDelta, ready" and Delta() would hand back
+	// a nil *ResumeDelta -- a caller that logged Mode() before checking err, or
+	// a second caller that treated a non-error-checked outcome as usable, would
+	// ship WatchUserEvent_Delta{Delta: nil} as the bootstrap frame and leave the
+	// client "connected" against unhydrated state with every submit rejected
+	// STALE_EPOCH. This mirrors resumeScanInvalid on the sibling
+	// resumeScanKind, which was given the same guard for the same reason.
+	subscribeModeInvalid SubscribeMode = iota
+	// SubscribeDelta means the hub honored the client's cursor and shipped the
+	// post-cursor op tail as a WatchUserEvent_Delta.
+	SubscribeDelta
+	// SubscribeInitial means the hub could not resume (cursor nil/zero, at/below
+	// op_retention_watermark, stale epoch, tail over budget, or a built delta
+	// over the wire-frame ceiling) and shipped a full UserMaterialized snapshot
+	// as a WatchUserEvent_Initial.
+	//
+	// NOT compaction_watermark: those two deliberately diverge by OpRetentionTTL
+	// (see laggedRetentionWatermark), and compaction_watermark always equals
+	// max_hlc, so reading this gate as the tight one makes every cursor look
+	// stale. decideResume is the authority.
+	SubscribeInitial
+)
+
+// String names the arm so a wrong-access panic (Delta()/Initial() on the
+// non-matching arm) reports the arm textually instead of an opaque integer.
+func (m SubscribeMode) String() string {
+	switch m {
+	case subscribeModeInvalid:
+		return "SubscribeMode(invalid)"
+	case SubscribeDelta:
+		return "SubscribeDelta"
+	case SubscribeInitial:
+		return "SubscribeInitial"
+	default:
+		return fmt.Sprintf("SubscribeMode(%d)", int(m))
+	}
+}
+
+// SubscribeOutcome is the discriminated result of SubscribeWithACL. Exactly one
+// bootstrap arm is selected (Mode), and its payload is the only non-nil one —
+// the constructors enforce the one-payload invariant, so the caller cannot
+// construct an outcome where both arms (or neither) are populated. The caller
+// reads Mode and calls Bootstrap() for the matching frame, or Unsub() for the
+// unsubscribe handle. This replaces the prior (delta, fellBack, unsub, err)
+// nil-discipline whose "exactly one of delta/fellBack is non-nil on success"
+// contract lived in prose rather than the type.
+type SubscribeOutcome struct {
+	mode    SubscribeMode
+	delta   *leapmuxv1.ResumeDelta
+	initial *leapmuxv1.UserMaterialized
+	unsub   func()
+}
+
+// Mode reports which bootstrap arm this outcome selected.
+func (o SubscribeOutcome) Mode() SubscribeMode { return o.mode }
+
+// Unsub returns the idempotent unsubscribe handle for the registered
+// subscriber. The caller MUST defer it on a non-error outcome (the error path
+// tears down the registration before returning, leaving no handle to defer).
+// The nil-guard makes that contract mechanical: a caller that defers Unsub
+// before checking err gets a no-op rather than a nil-function panic.
+func (o SubscribeOutcome) Unsub() func() {
+	if o.unsub == nil {
+		return func() {}
+	}
+	return o.unsub
+}
+
+// Delta returns the ResumeDelta payload. Panics unless Mode() == SubscribeDelta —
+// the discriminated access is intentionally assertion-gated so a caller that
+// reads the wrong arm's payload fails loudly instead of silently sending nil.
+func (o SubscribeOutcome) Delta() *leapmuxv1.ResumeDelta {
+	if o.mode != SubscribeDelta {
+		panic(fmt.Sprintf("crdt: SubscribeOutcome.Delta called in %v mode", o.mode))
+	}
+	return o.delta
+}
+
+// Initial returns the full-snapshot payload. Panics unless Mode() ==
+// SubscribeInitial, for the same reason as Delta().
+func (o SubscribeOutcome) Initial() *leapmuxv1.UserMaterialized {
+	if o.mode != SubscribeInitial {
+		panic(fmt.Sprintf("crdt: SubscribeOutcome.Initial called in %v mode", o.mode))
+	}
+	return o.initial
+}
+
+// Bootstrap wraps whichever payload arm this outcome holds into the single
+// WatchUserEvent the connection sends first, stamping the two identity fields
+// every bootstrap frame must carry.
+//
+// BOTH arms stamp subscriber_client_id: it is the frontend active-client gate's
+// only source of its own identity, and since the client-checkpoint work a
+// resume is the normal COLD-START path -- a refreshed page hydrates from
+// IndexedDB and resumes, so there is no earlier `initial` frame it could have
+// learned the id from. Both stamp user_id so the client can fail closed on a
+// foreign payload the way it already does for its persisted checkpoint. (The
+// manager already names the tenant on the initial arm with this same value;
+// writing it here too keeps ONE stamping rule at the seam instead of one per
+// arm, which is how the arms drifted in the first place.)
+//
+// Returning the wrapped event from the type is what makes "exactly one
+// bootstrap frame goes on the wire" a property of SubscribeOutcome rather than
+// of a correctly-written if/else at the single call site. Panics on an invalid
+// mode, for the same reason Delta()/Initial() do.
+func (o SubscribeOutcome) Bootstrap(subscriberClientID, userID string) *leapmuxv1.WatchUserEvent {
+	switch o.mode {
+	case SubscribeDelta:
+		o.delta.SubscriberClientId = subscriberClientID
+		o.delta.UserId = userID
+		return &leapmuxv1.WatchUserEvent{Event: &leapmuxv1.WatchUserEvent_Delta{Delta: o.delta}}
+	case SubscribeInitial:
+		o.initial.SubscriberClientId = subscriberClientID
+		o.initial.UserId = userID
+		return &leapmuxv1.WatchUserEvent{Event: &leapmuxv1.WatchUserEvent_Initial{Initial: o.initial}}
+	default:
+		panic(fmt.Sprintf("crdt: SubscribeOutcome.Bootstrap called in %v mode", o.mode))
+	}
+}
+
+func newSubscribeDeltaOutcome(delta *leapmuxv1.ResumeDelta, unsub func()) SubscribeOutcome {
+	return SubscribeOutcome{mode: SubscribeDelta, delta: delta, unsub: unsub}
+}
+
+func newSubscribeInitialOutcome(initial *leapmuxv1.UserMaterialized, unsub func()) SubscribeOutcome {
+	return SubscribeOutcome{mode: SubscribeInitial, initial: initial, unsub: unsub}
+}
+
+// fallbackOutcome is the FALLBACK seam shared by SubscribeWithACL's two FALLBACK
+// triggers (a non-resumable verdict and an over-budget tail): register + full
+// materialized snapshot via subscribeLocked, wrapped in a SubscribeInitial
+// outcome with a fresh idempotent unsub. MUST be called with m.projection held
+// (subscribeLocked requires it). Folding the two identical call sites into one
+// seam keeps the "FALLBACK always re-registers fresh via subscribeLocked"
+// invariant in one readable expression.
+func (m *Manager) fallbackOutcome(sub *Subscriber) SubscribeOutcome {
+	initial := m.subscribeLocked(sub)
+	return newSubscribeInitialOutcome(initial, makeUnsub(sub, m))
+}
+
+// Subscribe attaches a new subscriber. Returns an unsubscribe
+// callback. Bootstrap is sent inline (the caller's stream layer
+// formats it).
+//
+// TEST-ONLY as of the resume extraction: `rg '\.Subscribe\(' --glob '!*_test.go'`
+// finds no production caller. The userevents path goes through
+// SubscribeWithACL, which reaches the SAME registerSubscriber/makeUnsub seam
+// via subscribeLocked and registerForResume while holding subscribeExpandMu, so
+// a concurrent workspace-create expansion cannot leave a straggler with a stale
+// pre-commit filter (see SubscribeWithACL). This wrapper only adds the
+// projection lock around that seam and does NOT get the subscribeExpandMu
+// guarantee -- so a fix made here alone does not reach production.
+//
+// Subscribers with a non-empty ClientID contribute to a refcount keyed
+// on that id. The first Subscribe cancels any pending deferred clear;
+// the last unsub schedules one PresenceClearGrace into the future. A
+// reconnect inside the grace window keeps the client's presence
+// entries intact so the active-client gate doesn't flicker.
+func (m *Manager) Subscribe(sub *Subscriber) (initial *leapmuxv1.UserMaterialized, unsub func()) {
+	// The whole sequence runs under m.projection -- the same lock broadcasts
+	// take -- so a subscriber's registration + initial snapshot are atomic with
+	// respect to any concurrent broadcast: the filter captured by Add and the
+	// materialized baseline can never straddle a filter mutation. (The
+	// production path must go through SubscribeWithACL rather than resolving a
+	// filter and Adding it here unserialized -- a workspace-create expansion
+	// only visits already-registered subscribers; see SubscribeWithACL.) The
+	// cost is that the O(N) materializedLocked clone below is serialized
+	// against broadcasts for that duration (a large-user-doc connect briefly stalls
+	// the user's commit/broadcast pipeline); relaxing it -- computing the
+	// snapshot outside m.projection -- would reopen exactly that straddle
+	// window, so it is held deliberately.
+	//
+	// Within that, m.mu is only RLocked for the clone. materializedLocked walks
+	// every visible node/tab/floating-window for the subscriber's filter; taking
+	// the state write lock would block every concurrent commit, whereas the RLock
+	// only contends the brief state-swap. Subscriber visibility is identical
+	// either way: by the time we take the state RLock the subscriber is in
+	// subscribers, so it sees the next broadcast, and the initial snapshot
+	// computed under RLock is strictly newer-than-or-equal to whatever a commit
+	// that lost the race would have produced.
+	m.projection.Lock()
+	initial = m.subscribeLocked(sub)
+	m.projection.Unlock()
+	return initial, makeUnsub(sub, m)
+}
+
+// subscribeLocked is the register+snapshot core shared by Subscribe and
+// SubscribeWithACL's FALLBACK path. It MUST be called with m.projection held; it
+// takes m.mu.RLock for the materialized clone itself. It registers the
+// subscriber (Add + presence refcount) and returns the full UserMaterialized
+// baseline. SubscribeWithACL's RESUME path does NOT call this -- it calls only
+// registerSubscriber (to skip the materialized clone it does not need) and
+// builds a ResumeDelta instead of the snapshot.
+func (m *Manager) subscribeLocked(sub *Subscriber) *leapmuxv1.UserMaterialized {
+	initialFilter := m.registerSubscriber(sub)
+	m.mu.RLock()
+	initial := m.materializedLocked(initialFilter)
+	m.mu.RUnlock()
+	return initial
+}
+
+// registerSubscriber is the register half of subscribeLocked: Add + presence
+// refcount. Split out so SubscribeWithACL's RESUME path registers through the SAME
+// seam as Subscribe/FALLBACK instead of hand-mirroring the Add+OnConnect pair,
+// keeping the presence-refcount invariant in one place. The matching teardown
+// is makeUnsub (idempotent) — call it on any error path between a successful
+// register and the return of a makeUnsub the caller will defer.
+func (m *Manager) registerSubscriber(sub *Subscriber) SubscriberFilter {
+	initialFilter := m.subscribers.Add(sub)
+	m.presenceCtl.OnConnect(sub.ClientID)
+	return initialFilter
+}
+
+// makeUnsub returns the idempotent unsubscribe closure for a registered
+// subscriber. Idempotent: a caller that invokes it twice (an error-path
+// cleanup racing a deferred cleanup, or the partway-through-unsubscribe
+// teardown the registry hardens against) must not decrement the presence
+// refcount twice -- that would underflow the count and prematurely clear a
+// client that still has live connections, flickering the active-client gate.
+// It is also the teardown registerForResume+error paths reach for directly
+// (before re-entering subscribeLocked on a FALLBACK), since calling it twice is
+// safe.
+func makeUnsub(sub *Subscriber, m *Manager) func() {
+	var unsubOnce sync.Once
+	return func() {
+		unsubOnce.Do(func() {
+			m.subscribers.Remove(sub)
+			m.presenceCtl.OnDisconnect(sub.ClientID)
+		})
+	}
+}

--- a/backend/internal/hub/crdt/manager_subscribe_expand_test.go
+++ b/backend/internal/hub/crdt/manager_subscribe_expand_test.go
@@ -3,6 +3,7 @@ package crdt_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -43,7 +44,7 @@ func (b *blockingReadChecker) CanAccessWorkspaceForUsers(_ context.Context, _ st
 	return out, nil
 }
 
-// TestSubscribeWithACL_SerializesWithExpand pins the resolve-then-register
+// TestResumeWithACL_SerializesWithExpand pins the resolve-then-register
 // TOCTOU fix: SubscribeWithACL holds subscribeExpandMu across resolve+register,
 // so a concurrent workspace-create expansion for the same user must block behind
 // it. Once the subscriber is registered (with a pre-create filter that does
@@ -51,7 +52,7 @@ func (b *blockingReadChecker) CanAccessWorkspaceForUsers(_ context.Context, _ st
 // serialization the expand could run entirely in the resolve/register gap,
 // miss the not-yet-registered subscriber, and the subscriber would never see
 // the new workspace until reconnect.
-func TestSubscribeWithACL_SerializesWithExpand(t *testing.T) {
+func TestResumeWithACL_SerializesWithExpand(t *testing.T) {
 	mgr, _, _ := runManager(t, "user-1", allowAll{}, 230_000)
 	seedRootInternal(t, mgr, "w1", "root1")
 
@@ -67,14 +68,17 @@ func TestSubscribeWithACL_SerializesWithExpand(t *testing.T) {
 	resCh := make(chan subResult, 1)
 	go func() {
 		// The resolve runs while SubscribeWithACL holds subscribeExpandMu;
-		// parking here parks the whole resolve+register under that lock.
-		_, unsub, err := mgr.SubscribeWithACL(subR, func() (map[string]bool, error) {
+		// parking here parks the whole resolve+register under that lock. A nil
+		// cursor exercises the FALLBACK arm, which takes the same lock path as a
+		// full-snapshot subscribe (the legacy SubscribeWithACL path this test
+		// was written against).
+		out, err := mgr.SubscribeWithACL(context.Background(), subR, nil, 0, func() (map[string]bool, error) {
 			close(reached)
 			<-release
 			// Resolved BEFORE w1's create expansion: does not admit w1.
 			return map[string]bool{}, nil
 		})
-		resCh <- subResult{unsub, err}
+		resCh <- subResult{out.Unsub(), err}
 	}()
 	<-reached // subscribe is parked in resolve, holding subscribeExpandMu
 
@@ -137,12 +141,12 @@ func TestExpandSubscribersForWorkspace_SerializesWithSubscribe(t *testing.T) {
 	capS := &captureSubscriber{}
 	subS := &crdt.Subscriber{UserID: "userS", Send: capS.send}
 	go func() {
-		_, unsub, err := mgr.SubscribeWithACL(subS, func() (map[string]bool, error) {
+		out, err := mgr.SubscribeWithACL(context.Background(), subS, nil, 0, func() (map[string]bool, error) {
 			close(resolveStarted)
 			return map[string]bool{"w1": true}, nil
 		})
 		if err == nil {
-			defer unsub()
+			defer out.Unsub()()
 		}
 		close(subDone)
 	}()
@@ -191,12 +195,12 @@ func TestContractSubscribersForWorkspace_SerializesWithSubscribe(t *testing.T) {
 		// Parking in resolve holds subscribeExpandMu across the whole
 		// resolve+register, mirroring a subscriber whose resolve read the
 		// pre-delete ACL.
-		_, unsub, err := mgr.SubscribeWithACL(subS, func() (map[string]bool, error) {
+		out, err := mgr.SubscribeWithACL(context.Background(), subS, nil, 0, func() (map[string]bool, error) {
 			close(reached)
 			<-release
 			return map[string]bool{"w1": true}, nil
 		})
-		resCh <- subResult{unsub, err}
+		resCh <- subResult{out.Unsub(), err}
 	}()
 	<-reached // subscribe parked in resolve, holding subscribeExpandMu
 
@@ -227,20 +231,85 @@ func TestContractSubscribersForWorkspace_SerializesWithSubscribe(t *testing.T) {
 		"the serialized contract must strip w1 from the registered subscriber's filter")
 }
 
-// TestSubscribeWithACL_ResolveErrorLeavesUnregistered verifies a resolve failure
-// is returned WITHOUT registering the subscriber (no unsub handle, no snapshot),
-// so the caller can reject the connection before streaming.
-func TestSubscribeWithACL_ResolveErrorLeavesUnregistered(t *testing.T) {
+// TestResumeWithACL_ResolveErrorLeavesUnregistered verifies a resolve failure
+// is returned WITHOUT registering the subscriber (no delta, no fallback
+// snapshot, no unsub handle), so the caller can reject the connection before
+// streaming.
+func TestResumeWithACL_ResolveErrorLeavesUnregistered(t *testing.T) {
 	mgr, _, _ := runManager(t, "user-1", allowAll{}, 240_000)
 	seedRootInternal(t, mgr, "w1", "root1")
 
 	capR := &captureSubscriber{}
 	subR := &crdt.Subscriber{UserID: "userR", Send: capR.send}
 	wantErr := errors.New("resolve failed")
-	initial, unsub, err := mgr.SubscribeWithACL(subR, func() (map[string]bool, error) {
+	out, err := mgr.SubscribeWithACL(context.Background(), subR, nil, 0, func() (map[string]bool, error) {
 		return nil, wantErr
 	})
 	require.ErrorIs(t, err, wantErr)
-	assert.Nil(t, initial, "no snapshot on a failed resolve")
-	assert.Nil(t, unsub, "no unsub handle on a failed resolve")
+	// A failed resolve never registers, so there is no live handle. Unsub()
+	// returns a no-op (not nil) so a caller that defers it before checking err
+	// is safe; calling it here must not panic.
+	assert.NotPanics(t, func() { out.Unsub()() }, "Unsub on a failed-resolve outcome must be a safe no-op")
+}
+
+// TestSubscribeWithACL_ResumeFilterImmutableNoRaceWithExpand is a concurrency
+// smoke guard: expand/contract REPLACE the whole Filter via WithWorkspace /
+// WithoutWorkspace (never mutate WorkspaceIDs in place), so a plain value copy
+// of SubscriberFilter handed to buildResumeDelta is safe to read while
+// Expand/Contract replace the live Filter under subscribeExpandMu + the
+// controller lock. In-place map mutation would race the resume's IsAllowed
+// reads — a Go runtime fatal "concurrent map read and map write".
+//
+// This test exercises the concurrent path (resume + churn) so a regression that
+// re-introduces in-place filter mutation has a chance to trip the race
+// detector; it is not a deterministic reproducer (the in-memory fake journal's
+// frame-build is fast, so the overlap window is narrow), but it widens the
+// window with a deep tail and many iterations.
+func TestSubscribeWithACL_ResumeFilterImmutableNoRaceWithExpand(t *testing.T) {
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 250_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+	seedRootInternal(t, mgr, "w2", "root2")
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+
+	// Seed a deep tail of stable-visibility ops on w1 so each resume's frame
+	// build iterates many filter lookups, widening the overlap window.
+	for i := 0; i < 200; i++ {
+		submitNodePositionBatch(t, mgr, fmt.Sprintf("tail-%d", i), "root1", fmt.Sprintf("p%d", i))
+	}
+	cursor := mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc()
+	require.NotNil(t, cursor)
+
+	resolveOnlyW1 := func() (map[string]bool, error) { return map[string]bool{"w1": true}, nil }
+
+	// Hammer expand/contract on w2 while repeatedly resuming. The resume reads
+	// an immutable Filter value copy, so live WithWorkspace/WithoutWorkspace
+	// replacements must not race the scan's reads. In-place map mutation would
+	// make `go test -race` report a data race on WorkspaceIDs within a few iterations.
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = mgr.ExpandSubscribersForWorkspace(context.Background(), "w2")
+				mgr.ContractSubscribersForWorkspaceForTest("w2")
+			}
+		}
+	}()
+
+	// Many short resumes so the race detector reliably observes the overlap.
+	for i := 0; i < 20; i++ {
+		cap := &captureSubscriber{}
+		sub := &crdt.Subscriber{UserID: "user-1", Send: cap.send}
+		out, err := mgr.SubscribeWithACL(context.Background(), sub, crdt.HLCClone(cursor), epoch, resolveOnlyW1)
+		require.NoError(t, err, "resume must complete cleanly despite concurrent filter mutation")
+		require.NotNil(t, out.Unsub())
+		out.Unsub()()
+	}
+	close(stop)
+	wg.Wait()
 }

--- a/backend/internal/hub/crdt/manager_subscribe_test.go
+++ b/backend/internal/hub/crdt/manager_subscribe_test.go
@@ -1,0 +1,1213 @@
+package crdt_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/leapmux/leapmux/channelwire"
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/hub/crdt"
+	"google.golang.org/protobuf/proto"
+)
+
+// submitNodeBatch commits a SetNodeRegister (parent_id + kind) for `nodeID`
+// under `parentID` via the internal submit path (manager goroutine stays the
+// sole writer). The parent_id is what makes workspaceForEntity resolve the
+// node to a registered root's workspace, so the resume filter keeps the op.
+// submitNodePositionBatch commits a SetNodeRegister op writing the position
+// register (mutable) on `nodeID` via the internal submit path. Because
+// `nodeID` resolves to a registered root's workspace via its parent chain,
+// the op survives the resume visibility filter (workspaceForEntity resolves it
+// to an allowed workspace). Used to advance the journal so a resume has a
+// post-cursor tail that is NOT filtered out.
+func submitNodePositionBatch(t *testing.T, mgr *crdt.Manager, batchID, nodeID, position string) {
+	t.Helper()
+	res, err := mgr.SubmitInternal(context.Background(), crdt.SubmitInput{
+		Batches: []*leapmuxv1.OpBatch{{BatchId: batchID, Ops: []*leapmuxv1.CrdtOp{{
+			OpId: "op-" + batchID,
+			Body: &leapmuxv1.CrdtOp_SetNodeRegister{SetNodeRegister: &leapmuxv1.SetNodeRegisterOp{
+				NodeId: nodeID,
+				Field:  &leapmuxv1.SetNodeRegisterOp_Position{Position: position},
+			}},
+		}}}},
+	})
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+	require.NotNil(t, res[0].GetCommitted(), "position batch should commit; got %v", res[0])
+}
+
+// resolveAll is the resolve callback that admits every workspace (mirrors the
+// production all-workspaces subscription, where workspace_ids is empty).
+func resolveAll() (map[string]bool, error) { return map[string]bool{"w1": true}, nil }
+
+// deltaBatchFrames extracts the OpBatch payloads from a ResumeDelta's frame
+// stream, skipping materialized/removed frames. Resume tests that assert on the
+// stable-visibility op tail use this to mirror the old `delta.GetBatches()`
+// shape now that the delta is an ordered frame stream (materialized → batch →
+// removed) rather than a flat batch list.
+func deltaBatchFrames(t *testing.T, delta *leapmuxv1.ResumeDelta) []*leapmuxv1.OpBatch {
+	t.Helper()
+	var out []*leapmuxv1.OpBatch
+	for _, f := range delta.GetFrames() {
+		if b := f.GetBatch(); b != nil {
+			out = append(out, b)
+		}
+	}
+	return out
+}
+
+// TestSubscribeWithACL_AboveWatermark_ReturnsDelta is the happy path: a cursor
+// strictly newer than compaction_watermark (which is zero here -- no
+// compaction has run) yields a ResumeDelta whose tail is exactly the
+// post-cursor committed batches, filtered to the subscriber's allowed set.
+func TestSubscribeWithACL_AboveWatermark_ReturnsDelta(t *testing.T) {
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 230_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+
+	// First position commit. The cursor we resume from is this batch's max HLC.
+	submitNodePositionBatch(t, mgr, "batch-a", "root1", "a0")
+	cursor := mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc()
+	require.NotNil(t, cursor, "max HLC must be set after commits")
+
+	// Second position commit AFTER the cursor -- this is the delta tail.
+	submitNodePositionBatch(t, mgr, "batch-b", "root1", "b0")
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+
+	sub := &crdt.Subscriber{UserID: "user-1", Send: (&captureSubscriber{}).send}
+	out, err := mgr.SubscribeWithACL(context.Background(), sub, crdt.HLCClone(cursor), epoch, resolveAll)
+	require.NoError(t, err)
+	require.Equal(t, crdt.SubscribeDelta, out.Mode(), "cursor above watermark must RESUME (delta), not fall back")
+	require.NotNil(t, out.Unsub(), "resume must return an unsubscribe callback")
+	defer out.Unsub()()
+
+	delta := out.Delta()
+	assert.Equal(t, epoch, delta.GetCurrentEpoch(), "delta epoch must match live state")
+	// delta.max_hlc is computed from the FILTERED tail's own ops (the highest
+	// canonical HLC the client actually receives), NOT read from the live
+	// state. Here the tail is exactly batch-b, so the delta's max equals
+	// batch-b's HLC — which happens to also be the live max (no other commit
+	// landed), but the contract is "the tail's max", so assert against the tail
+	// batch directly.
+	batchFrames := deltaBatchFrames(t, delta)
+	require.Len(t, batchFrames, 1, "only the post-cursor batch should be in the delta tail")
+	tailMax := batchFrames[0].GetOps()[len(batchFrames[0].GetOps())-1].GetCanonicalHlc()
+	assert.Equal(t, tailMax.GetPhysical(), delta.GetMaxHlc().GetPhysical(),
+		"delta max_hlc must be the filtered tail's own max op HLC, not a separate live-state read")
+
+	// Exactly the post-cursor batch (batch-b) should be in the tail, not
+	// batch-a (which is at/below the cursor).
+	require.Len(t, batchFrames, 1, "only the post-cursor batch should be in the delta tail")
+	assert.Equal(t, "batch-b", batchFrames[0].GetBatchId(),
+		"the at-cursor batch must be excluded; resume is strictly-after")
+}
+
+// TestSubscribeWithACL_FilterStripsDisallowedWorkspace is the security-relevant
+// edge case for the delta's visibility filter: an op whose target resolves to
+// a workspace the subscriber is NOT allowed to see must be stripped from the
+// delta tail, exactly as filterVisibleOps strips it from a live broadcast.
+// A regression here would leak cross-workspace ops through the resume path.
+func TestSubscribeWithACL_FilterStripsDisallowedWorkspace(t *testing.T) {
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 230_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+	seedRootInternal(t, mgr, "w2", "root2")
+
+	// Cursor sits between the two post-cursor commits.
+	submitNodePositionBatch(t, mgr, "cursor-batch", "root1", "c0")
+	cursor := mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc()
+	require.NotNil(t, cursor)
+	// One op under w1 (allowed), one under w2 (NOT allowed for this subscriber).
+	submitNodePositionBatch(t, mgr, "w1-batch", "root1", "w1op")
+	submitNodePositionBatch(t, mgr, "w2-batch", "root2", "w2op")
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+
+	// Subscriber may see ONLY w1.
+	resolveOnlyW1 := func() (map[string]bool, error) { return map[string]bool{"w1": true}, nil }
+	sub := &crdt.Subscriber{UserID: "user-1", Send: (&captureSubscriber{}).send}
+	out, err := mgr.SubscribeWithACL(context.Background(), sub, crdt.HLCClone(cursor), epoch, resolveOnlyW1)
+	require.NoError(t, err)
+	require.NotNil(t, out.Unsub())
+	defer out.Unsub()()
+	require.Equal(t, crdt.SubscribeDelta, out.Mode(), "cursor above watermark must RESUME")
+	delta := out.Delta()
+
+	// Only the w1 op survives the filter; the w2 op must be stripped.
+	seen := map[string]bool{}
+	for _, b := range deltaBatchFrames(t, delta) {
+		seen[b.GetBatchId()] = true
+	}
+	assert.True(t, seen["w1-batch"], "the allowed-workspace op must be in the delta tail")
+	assert.False(t, seen["w2-batch"], "the disallowed-workspace op must be stripped from the delta tail")
+}
+
+// TestSubscribeWithACL_AtOrBelowWatermark_FallsBack pins the FALLBACK rule: a
+// cursor at or below op_retention_watermark cannot be honored (those journal
+// rows are deleted), so SubscribeWithACL returns a full UserMaterialized
+// snapshot in fellBack and a nil delta -- exactly as a full-snapshot connect would (the FALLBACK path).
+//
+// Op-batch deletion gates on op_retention_watermark (which lags
+// compaction_watermark by OpRetentionTTL), not compaction_watermark: a cursor
+// above the retention floor but below the tombstone-prune line still resumes,
+// because the journal still holds those batches. This test pins the FALLBACK
+// half of that rule by shrinking the retention TTL to zero (so the floor meets
+// the compaction watermark) and asserting a cursor at the watermark FALLBACKs.
+// The RESUME-across-the-decoupled-window half is pinned by
+// TestSubscribeWithACL_CursorBetweenRetentionAndCompaction_Resumes.
+func TestSubscribeWithACL_AtOrBelowWatermark_FallsBack(t *testing.T) {
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 230_000, crdt.WithOpRetentionTTL(0))
+	seedRootInternal(t, mgr, "w1", "root1")
+	submitNodePositionBatch(t, mgr, "batch-a", "root1", "a0")
+
+	maxHLC := mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc()
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+
+	// Advance the compaction watermark to the current max HLC, as maybeCompact
+	// would on a housekeeping tick (simulating one compaction having run).
+	// TickHousekeeping is the test hook that drives maybeCompact on the manager
+	// goroutine.
+	mgr.TickHousekeeping(context.Background())
+	wm := mgr.State().GetCompactionWatermark()
+	require.False(t, crdt.HLCIsZero(wm), "compaction tick must advance the watermark")
+
+	// A cursor equal to the watermark (== maxHLC at compaction time) must
+	// FALLBACK: the post-cursor tail is gone.
+	sub := &crdt.Subscriber{UserID: "user-1", Send: (&captureSubscriber{}).send}
+	out, err := mgr.SubscribeWithACL(context.Background(), sub, crdt.HLCClone(maxHLC), epoch, resolveAll)
+	require.NoError(t, err)
+	require.NotNil(t, out.Unsub())
+	defer out.Unsub()()
+
+	require.Equal(t, crdt.SubscribeInitial, out.Mode(), "cursor at/below watermark must FALLBACK")
+	fellBack := out.Initial()
+	assert.Contains(t, fellBack.GetWorkspaces(), "w1", "fallback snapshot must contain the live workspace")
+}
+
+// TestSubscribeWithACL_CursorBetweenRetentionAndCompaction_Resumes pins the
+// decoupling that op_retention_watermark introduces: a cursor that sits ABOVE
+// the op_retention_watermark but AT OR BELOW the compaction_watermark must
+// still RESUME, because the journal still holds every post-cursor batch (op
+// batches are deleted only below op_retention_watermark, while tombstones are
+// pruned at the tighter compaction_watermark). This is the whole point of the
+// decoupling — multi-hour refreshes resume instead of full-snapshotting.
+//
+// The window between the two watermarks is created by submitting a batch,
+// capturing the cursor, then submitting another batch and compacting: after
+// compaction, compaction_watermark == max_hlc (>= cursor) but with a nonzero
+// OpRetentionTTL the op_retention_watermark stays below the cursor, so the
+// resume gate (which keys on op_retention_watermark) admits it. The default
+// 24h TTL naturally produces this layout against the test's ~230s fake clock.
+func TestSubscribeWithACL_CursorBetweenRetentionAndCompaction_Resumes(t *testing.T) {
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 230_000) // default OpRetentionTTL=24h
+	seedRootInternal(t, mgr, "w1", "root1")
+	submitNodePositionBatch(t, mgr, "cursor-batch", "root1", "c0")
+	cursor := mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc()
+	require.NotNil(t, cursor)
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+
+	// Submit a tail batch so there is something to replay, then compact.
+	submitNodePositionBatch(t, mgr, "tail-batch", "root1", "t0")
+	mgr.TickHousekeeping(context.Background())
+
+	cw := mgr.State().GetCompactionWatermark()
+	rw := mgr.State().GetOpRetentionWatermark()
+	require.False(t, crdt.HLCIsZero(cw), "compaction must advance compaction_watermark")
+	// The default 24h TTL against a ~230s fake clock clamps the retention
+	// floor to zero (max_hlc.physical - 24h < 0), so the cursor is well above
+	// it — exercising the decoupled-window resume path.
+	require.True(t, crdt.HLCCmp(cursor, rw) > 0, "cursor must be above op_retention_watermark")
+	require.True(t, crdt.HLCCmp(cursor, cw) <= 0, "cursor must be at or below compaction_watermark (the old FALLBACK line)")
+
+	sub := &crdt.Subscriber{UserID: "user-1", Send: (&captureSubscriber{}).send}
+	out, err := mgr.SubscribeWithACL(context.Background(), sub, crdt.HLCClone(cursor), epoch, resolveAll)
+	require.NoError(t, err)
+	defer out.Unsub()()
+	require.Equal(t, crdt.SubscribeDelta, out.Mode(),
+		"cursor above op_retention_watermark must RESUME even when at/below compaction_watermark")
+	delta := out.Delta()
+	require.NotNil(t, delta)
+
+	// The tail batch must ship in the delta — the journal still holds it.
+	seenTail := false
+	for _, f := range delta.GetFrames() {
+		if b := f.GetBatch(); b != nil && b.GetBatchId() == "tail-batch" {
+			seenTail = true
+		}
+	}
+	assert.True(t, seenTail, "the post-cursor tail batch must ship in the resume delta across the decoupled window")
+}
+
+// TestSubscribeWithACL_StaleEpoch_FallsBack pins the epoch leg of the FALLBACK
+// rule: even with a cursor above the watermark, a client whose epoch is stale
+// (advances are time-based, 14d, but the rule must hold regardless) must get a
+// full snapshot so the client re-syncs current_epoch for SubmitOps echo.
+func TestSubscribeWithACL_StaleEpoch_FallsBack(t *testing.T) {
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 230_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+	submitNodePositionBatch(t, mgr, "batch-a", "root1", "a0")
+	cursor := mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc()
+
+	// A deliberately-wrong epoch (live is 1 after bootstrap; pass 999).
+	sub := &crdt.Subscriber{UserID: "user-1", Send: (&captureSubscriber{}).send}
+	out, err := mgr.SubscribeWithACL(context.Background(), sub, crdt.HLCClone(cursor), 999, resolveAll)
+	require.NoError(t, err)
+	require.NotNil(t, out.Unsub())
+	defer out.Unsub()()
+
+	require.Equal(t, crdt.SubscribeInitial, out.Mode(), "stale-epoch resume must FALLBACK")
+}
+
+// TestSubscribeWithACL_NilCursor_FallsBack covers the "no resume param" path
+// (a fresh connect, or a client with no persisted watermark): a nil cursor
+// degrades to a full snapshot. This is the path an older client that never
+// sends resume_after_hlc takes.
+func TestSubscribeWithACL_NilCursor_FallsBack(t *testing.T) {
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 230_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+
+	sub := &crdt.Subscriber{UserID: "user-1", Send: (&captureSubscriber{}).send}
+	out, err := mgr.SubscribeWithACL(context.Background(), sub, nil, 0, resolveAll)
+	require.NoError(t, err)
+	require.NotNil(t, out.Unsub())
+	defer out.Unsub()()
+
+	require.Equal(t, crdt.SubscribeInitial, out.Mode(), "nil cursor must FALLBACK")
+}
+
+// TestSubscribeOutcome_DiscriminatedAccessPanicsOnWrongArm pins the type-level
+// contract of the discriminated SubscribeOutcome: reading the payload of the arm
+// that was NOT selected panics, so a caller that reads the wrong arm fails
+// loudly instead of silently sending a nil frame. This is what the type (vs the
+// prior nil-discipline tuple) buys.
+func TestSubscribeOutcome_DiscriminatedAccessPanicsOnWrongArm(t *testing.T) {
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 230_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+
+	// FALLBACK outcome: Initial() is valid, Delta() panics.
+	sub := &crdt.Subscriber{UserID: "user-1", Send: (&captureSubscriber{}).send}
+	fallback, err := mgr.SubscribeWithACL(context.Background(), sub, nil, 0, resolveAll)
+	require.NoError(t, err)
+	defer fallback.Unsub()()
+	require.Equal(t, crdt.SubscribeInitial, fallback.Mode())
+	require.NotNil(t, fallback.Initial(), "Initial() on a FALLBACK outcome returns the snapshot")
+	// The panic message must name the arm textually (via SubscribeMode.String),
+	// not render an opaque integer — the whole point of failing loudly is to
+	// fail informatively too.
+	assert.PanicsWithValue(t,
+		"crdt: SubscribeOutcome.Delta called in SubscribeInitial mode",
+		func() { _ = fallback.Delta() }, "Delta() on a FALLBACK outcome must panic with a textual mode")
+
+	// RESUME outcome: Delta() is valid, Initial() panics.
+	cursor := mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc()
+	require.NotNil(t, cursor)
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+	sub2 := &crdt.Subscriber{UserID: "user-1", Send: (&captureSubscriber{}).send}
+	delta, err := mgr.SubscribeWithACL(context.Background(), sub2, crdt.HLCClone(cursor), epoch, resolveAll)
+	require.NoError(t, err)
+	defer delta.Unsub()()
+	require.Equal(t, crdt.SubscribeDelta, delta.Mode())
+	require.NotNil(t, delta.Delta(), "Delta() on a RESUME outcome returns the delta")
+	assert.PanicsWithValue(t,
+		"crdt: SubscribeOutcome.Initial called in SubscribeDelta mode",
+		func() { _ = delta.Initial() }, "Initial() on a RESUME outcome must panic with a textual mode")
+}
+
+// TestSubscribeMode_String pins that SubscribeMode names its arms textually. The
+// Delta()/Initial() panic messages format the mode with %v, so without a
+// String() method a wrong-arm bug reports an opaque integer instead of the arm
+// name — defeating half the purpose of the assertion-gated access.
+func TestSubscribeMode_String(t *testing.T) {
+	assert.Equal(t, "SubscribeDelta", crdt.SubscribeDelta.String())
+	assert.Equal(t, "SubscribeInitial", crdt.SubscribeInitial.String())
+}
+
+// TestSubscribeWithACL_TailOverBudget_FallsBack pins that an over-budget tail
+// makes SubscribeWithACL ship a full snapshot rather than a delta.
+//
+// This used to call j.ListBatchesAfter directly and assert that the FAKE
+// returned the sentinel it had been hand-written to return — proving nothing
+// about SubscribeWithACL, whose FALLBACK behavior the name promises. It also
+// asserted the partial tail was non-empty, which contradicts the Journal
+// contract ("on ErrDeltaTooLarge the returned slice is incidental and MUST be
+// discarded") and would have reddened if the production path correctly started
+// returning nil. Drive the real entry point and assert the observable outcome.
+func TestSubscribeWithACL_TailOverBudget_FallsBack(t *testing.T) {
+	mgr, j, _ := runManager(t, "user-1", allowAll{}, 230_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+	submitNodePositionBatch(t, mgr, "cursor-batch", "root1", "c0")
+	cursor := crdt.HLCClone(mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc())
+	require.NotNil(t, cursor)
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+	submitNodePositionBatch(t, mgr, "post-cursor", "root1", "p1")
+
+	// Force the budget verdict the real journal would reach on a huge tail.
+	j.listErr = crdt.ErrDeltaTooLarge
+
+	sub := &crdt.Subscriber{UserID: "user-1", Send: (&captureSubscriber{}).send}
+	out, err := mgr.SubscribeWithACL(context.Background(), sub, cursor, epoch, resolveAll)
+	require.NoError(t, err, "an over-budget tail is recoverable, not a connect failure")
+	require.Equal(t, crdt.SubscribeInitial, out.Mode(),
+		"an over-budget tail must FALLBACK to a full snapshot")
+	defer out.Unsub()()
+	require.NotNil(t, out.Initial(), "the FALLBACK arm must carry a materialized snapshot")
+}
+
+// resumeFixture seeds the minimum shape that takes the RESUME arm -- one
+// workspace, a cursor batch, and one post-cursor tail batch -- and returns the
+// manager plus the cursor/epoch a reconnecting client would present.
+//
+// Deterministic by construction: runManager injects a clock that advances 1ms
+// per call and every now() consumer reached here is driven by these submits, so
+// two fixtures built with the same seed produce byte-identical deltas. The
+// frame-ceiling cases below depend on that -- they measure a delta under one
+// ceiling and re-run the same fixture under another -- and assert the
+// reproduction explicitly rather than assuming it.
+func resumeFixture(t *testing.T, opts ...crdt.ManagerOption) (*crdt.Manager, *leapmuxv1.HLC, int64) {
+	t.Helper()
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 230_000, opts...)
+	seedRootInternal(t, mgr, "w1", "root1")
+	submitNodePositionBatch(t, mgr, "cursor-batch", "root1", "c0")
+	cursor := crdt.HLCClone(mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc())
+	require.NotNil(t, cursor)
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+	submitNodePositionBatch(t, mgr, "post-cursor", "root1", "p1")
+	return mgr, cursor, epoch
+}
+
+// resumeOnce runs one SubscribeWithACL against a seeded fixture and returns the
+// outcome plus the subscriber's capture buffer.
+func resumeOnce(t *testing.T, mgr *crdt.Manager, cursor *leapmuxv1.HLC, epoch int64) (crdt.SubscribeOutcome, *captureSubscriber) {
+	t.Helper()
+	cap := &captureSubscriber{}
+	sub := &crdt.Subscriber{UserID: "user-1", Send: cap.send}
+	out, err := mgr.SubscribeWithACL(context.Background(), sub, cursor, epoch, resolveAll)
+	require.NoError(t, err)
+	return out, cap
+}
+
+// TestSubscribeWithACL_BuiltDeltaOverFrameCeiling_FallsBack pins the EXACT gate
+// on the built delta, which is a different bound from the scan's
+// MaxResumeDeltaBytes source-row budget: that one caps the decoded journal rows
+// (memory, during a streaming scan), this one caps the single WebSocket frame
+// the delta ships as.
+//
+// Getting it wrong is not a slow path but an unrecoverable one: the client's
+// socket read limit (channelwire.UserEventsReadLimit) fails the oversized frame,
+// the client reconnects with the SAME cursor, the hub rebuilds the SAME frame,
+// and the pair loops forever with no server-side error to attribute it to.
+//
+// The ceiling is injected at 1 byte rather than the delta being grown to 16 MiB:
+// the gate is a size comparison, so a small ceiling exercises exactly the same
+// branch for a fraction of the runtime. 1 -- not 0 -- so the FALLBACK cannot be
+// passing for the degenerate reason that any delta at all exceeds it.
+// MaxResumeDeltaBytes is deliberately left at its production value, so the tail
+// read succeeds and the FALLBACK can ONLY have come from this gate.
+func TestSubscribeWithACL_BuiltDeltaOverFrameCeiling_FallsBack(t *testing.T) {
+	mgr, cursor, epoch := resumeFixture(t, crdt.WithMaxResumeDeltaFrameBytes(1))
+
+	out, cap := resumeOnce(t, mgr, cursor, epoch)
+	require.Equal(t, crdt.SubscribeInitial, out.Mode(),
+		"a delta past the client's frame ceiling must FALLBACK, never ship")
+	defer out.Unsub()()
+	snap := out.Initial()
+	require.NotNil(t, snap, "the FALLBACK arm must carry a materialized snapshot")
+	require.Equal(t, "p1", snap.GetNodes()["root1"].GetPosition().GetValue(),
+		"the snapshot must carry the post-cursor state the rejected delta would have replayed")
+
+	// The gate reuses the over-budget arm's teardown (unsub + resumeScanFallback),
+	// so the register→unsub→re-register churn must leave the subscriber
+	// registered EXACTLY once -- not zero (torn down and never re-added) and not
+	// two (torn down by the wrong handle). One later broadcast, one batch frame.
+	cap.events = nil
+	submitNodePositionBatch(t, mgr, "post-fallback", "root1", "p2")
+	var batches int
+	for _, e := range cap.snapshot() {
+		if e.GetBatch() != nil {
+			batches++
+		}
+	}
+	require.Equal(t, 1, batches,
+		"the frame-gate FALLBACK must leave exactly one registration (0 = torn down, 2 = double-registered)")
+}
+
+// TestSubscribeWithACL_BuiltDeltaAtFrameCeiling_Ships pins the gate's boundary
+// from both sides. The comparison is strictly `>`, so a delta whose proto.Size
+// EQUALS the ceiling still ships; flipping it to `>=` would push every delta
+// that exactly filled the budget onto a full snapshot for no reason, and the
+// over-ceiling case alone cannot tell the two spellings apart.
+func TestSubscribeWithACL_BuiltDeltaAtFrameCeiling_Ships(t *testing.T) {
+	// Measure what this fixture's delta actually weighs, under the production
+	// ceiling (16 MiB - envelope headroom), which it is nowhere near.
+	measureMgr, measureCursor, measureEpoch := resumeFixture(t)
+	measured, _ := resumeOnce(t, measureMgr, measureCursor, measureEpoch)
+	require.Equal(t, crdt.SubscribeDelta, measured.Mode(),
+		"the unconstrained fixture must RESUME, or the boundary below measures nothing")
+	size := proto.Size(measured.Delta())
+	measured.Unsub()()
+	require.Positive(t, size, "a resume with a post-cursor tail must build a non-empty delta")
+
+	// Exactly at the ceiling: ships.
+	atMgr, atCursor, atEpoch := resumeFixture(t, crdt.WithMaxResumeDeltaFrameBytes(size))
+	atOut, _ := resumeOnce(t, atMgr, atCursor, atEpoch)
+	require.Equal(t, crdt.SubscribeDelta, atOut.Mode(),
+		"a delta exactly AT the ceiling is within budget and must ship")
+	defer atOut.Unsub()()
+	require.Equal(t, size, proto.Size(atOut.Delta()),
+		"the fixture must reproduce byte-identically, or the boundary this case pins is not the one it measured")
+
+	// One byte under: the same delta FALLBACKs.
+	underMgr, underCursor, underEpoch := resumeFixture(t, crdt.WithMaxResumeDeltaFrameBytes(size-1))
+	underOut, _ := resumeOnce(t, underMgr, underCursor, underEpoch)
+	require.Equal(t, crdt.SubscribeInitial, underOut.Mode(),
+		"one byte over the ceiling is over the ceiling")
+	defer underOut.Unsub()()
+}
+
+// TestMaxResumeDeltaFrameBytes_LeavesEnvelopeHeadroomUnderTheReadLimit pins the
+// constant itself, which is the half of the gate no behavioural test can reach:
+// the ceiling exists to keep the WHOLE WebSocket message under the limit every
+// subscriber's socket enforces, and the message is the measured ResumeDelta plus
+// the WatchUserEvent wrapper, the 4-byte length prefix, and the two ids
+// SubscribeOutcome.Bootstrap stamps AFTER the gate has run. A ceiling raised to
+// (or past) the read limit would let a delta pass the gate and still fail the
+// client's read -- the exact reconnect loop the gate exists to prevent.
+func TestMaxResumeDeltaFrameBytes_LeavesEnvelopeHeadroomUnderTheReadLimit(t *testing.T) {
+	require.Less(t, crdt.MaxResumeDeltaFrameBytes, channelwire.UserEventsReadLimit,
+		"the gate must sit strictly below the read limit it protects")
+
+	// A maximal delta wrapped in everything the wire adds must still fit. The
+	// payload is opaque bytes on a scratch frame, so this measures the ENVELOPE
+	// overhead, not a realistic delta's contents.
+	envelope := &leapmuxv1.WatchUserEvent{
+		Event: &leapmuxv1.WatchUserEvent_Delta{Delta: &leapmuxv1.ResumeDelta{
+			SubscriberClientId: strings.Repeat("c", 128),
+			UserId:             strings.Repeat("u", 128),
+		}},
+	}
+	const lengthPrefix = 4 // channelwire.WriteFramedBytes
+	require.LessOrEqual(t, crdt.MaxResumeDeltaFrameBytes+proto.Size(envelope)+lengthPrefix,
+		channelwire.UserEventsReadLimit,
+		"a delta at the ceiling plus its envelope must still be readable by the client")
+}
+
+// TestSubscribeWithACL_DeltaMaxHlcIsTheFilteredTailMax_NotLiveState pins the
+// watermark-correctness contract (issue tracked via deep review): the delta's
+// max_hlc is the max canonical HLC over the FILTERED tail's own ops, never a
+// read of the live state's max. A live-state read would let a commit landing
+// between the tail read and the max read inflate the watermark past ops the
+// client has not received; the next resume from that inflated cursor would
+// skip them. Here the tail's tail batch sits under an allowed workspace (w1)
+// while a LATER op under a disallowed workspace (w2) advances the live state
+// max — but is filtered out of this subscriber's tail. The delta's max_hlc
+// must be the w1 op's HLC, NOT the (higher) live max the w2 op produced.
+func TestSubscribeWithACL_DeltaMaxHlcIsTheFilteredTailMax_NotLiveState(t *testing.T) {
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 230_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+	seedRootInternal(t, mgr, "w2", "root2")
+
+	// Cursor sits before both tail commits.
+	submitNodePositionBatch(t, mgr, "cursor-batch", "root1", "c0")
+	cursor := mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc()
+	require.NotNil(t, cursor)
+
+	// The w1 op is the tail the w1-only subscriber receives; the w2 op advances
+	// the live state max but is filtered out of the w1 subscriber's tail.
+	submitNodePositionBatch(t, mgr, "w1-tail", "root1", "w1op")
+	submitNodePositionBatch(t, mgr, "w2-later", "root2", "w2op")
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+	liveMax := mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc()
+	require.NotNil(t, liveMax)
+
+	resolveOnlyW1 := func() (map[string]bool, error) { return map[string]bool{"w1": true}, nil }
+	sub := &crdt.Subscriber{UserID: "user-1", Send: (&captureSubscriber{}).send}
+	out, err := mgr.SubscribeWithACL(context.Background(), sub, crdt.HLCClone(cursor), epoch, resolveOnlyW1)
+	require.NoError(t, err)
+	require.NotNil(t, out.Unsub())
+	defer out.Unsub()()
+	require.Equal(t, crdt.SubscribeDelta, out.Mode())
+	delta := out.Delta()
+
+	// Only the w1 op's CONTENT ships; the w2 batch contributes no ops.
+	batchFrames := deltaBatchFrames(t, delta)
+	require.Len(t, batchFrames, 1, "only the w1 (allowed) op should be in the tail")
+
+	// max_hlc is the last SCANNED batch's boundary, not the last VISIBLE op's.
+	// Every batch in the tail emits a batch_end, including one whose ops are all
+	// filtered out, so a narrowly-filtered subscriber advances past traffic it
+	// cannot see instead of re-scanning the same journal tail on every
+	// reconnect. That is safe because an entity that later becomes visible
+	// arrives as a full EntityMaterialized record, never as its historical ops.
+	assert.Equal(t, liveMax.GetPhysical(), delta.GetMaxHlc().GetPhysical(),
+		"max_hlc must reach the last scanned batch's boundary, even when that batch was filtered out")
+
+	// The bound that still matters: max_hlc comes from the SCAN (capped at the
+	// register-time `until`), never from a live-state read. A commit landing
+	// after the scan must not be advertised -- it is delivered as a broadcast
+	// frame instead, and advertising it here would let a
+	// disconnect-before-broadcast skip it on the next resume.
+	submitNodePositionBatch(t, mgr, "after-scan", "root1", "later")
+	postScanMax := mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc()
+	assert.Less(t, delta.GetMaxHlc().GetPhysical(), postScanMax.GetPhysical(),
+		"delta max_hlc must not track commits that landed after the scan")
+}
+
+// TestSubscribeWithACL_DeltaMaxHlcFallsBackToCursorOnEmptyTail pins the empty-tail
+// arm of the max_hlc computation: when every post-cursor op is filtered out of
+// the subscriber's tail, the delta's max_hlc falls back to the cursor itself
+// (nothing newer-than-the-cursor was visible, so the cursor remains the honest
+// high-water mark), never to the live state max.
+func TestSubscribeWithACL_DeltaMaxHlcFallsBackToCursorOnEmptyTail(t *testing.T) {
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 230_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+	seedRootInternal(t, mgr, "w2", "root2")
+
+	// Cursor under w1.
+	submitNodePositionBatch(t, mgr, "cursor-batch", "root1", "c0")
+	cursor := mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc()
+	require.NotNil(t, cursor)
+	// The only post-cursor op is under w2 (disallowed for a w1-only subscriber),
+	// so the filtered tail is empty.
+	submitNodePositionBatch(t, mgr, "w2-tail", "root2", "w2op")
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+
+	resolveOnlyW1 := func() (map[string]bool, error) { return map[string]bool{"w1": true}, nil }
+	sub := &crdt.Subscriber{UserID: "user-1", Send: (&captureSubscriber{}).send}
+	out, err := mgr.SubscribeWithACL(context.Background(), sub, crdt.HLCClone(cursor), epoch, resolveOnlyW1)
+	require.NoError(t, err)
+	require.NotNil(t, out.Unsub())
+	defer out.Unsub()()
+	require.Equal(t, crdt.SubscribeDelta, out.Mode())
+	delta := out.Delta()
+	assert.Empty(t, deltaBatchFrames(t, delta), "the w2-only tail must be filtered out")
+	// No visible OPS, but the scanned batch still emits its boundary, so the
+	// cursor advances past traffic this subscriber cannot see. Without that, a
+	// narrowly-filtered client would re-scan the same growing tail on every
+	// reconnect until it exceeded MaxResumeDeltaOps and was pinned to full
+	// snapshots.
+	scannedMax := mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc()
+	assert.Equal(t, scannedMax.GetPhysical(), delta.GetMaxHlc().GetPhysical(),
+		"a fully-filtered tail must still advance max_hlc to the last scanned batch's boundary")
+	assert.Greater(t, delta.GetMaxHlc().GetPhysical(), cursor.GetPhysical(),
+		"...and therefore strictly past the cursor the client presented")
+}
+
+// TestSubscribeWithACL_TailReadErrorTearsDownRegistration pins the journal-tail-
+// error teardown: after registerSubscriber runs, a non-budget/non-corrupt error
+// from ListBatchesAfter must undo the registration (so no subscriber leaks
+// whose bootstrap was never delivered); the returned outcome's Unsub() is a
+// safe no-op (the registration was already torn down before the error return).
+// The teardown is load-bearing — without it, a transient DB error during resume
+// would leak a registered subscriber sponging broadcasts into a dead channel
+// and skew the presence refcount. ErrDeltaTooLarge takes the FALLBACK path
+// instead (see TestSubscribeWithACL_OverBudgetFallbackRegistersExactlyOnce);
+// a corrupt row is now skipped+surfaced, not fatal (see
+// crdtJournal.scan's recoverable contract).
+func TestSubscribeWithACL_TailReadErrorTearsDownRegistration(t *testing.T) {
+	mgr, j, _ := runManager(t, "user-1", allowAll{}, 230_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+	submitNodePositionBatch(t, mgr, "cursor-batch", "root1", "c0")
+	cursor := mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc()
+	require.NotNil(t, cursor)
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+
+	// Inject a plain (non-ErrDeltaTooLarge) error into the resume tail read.
+	j.listErr = errors.New("simulated DB failure")
+	// The sub's Send records into its own capture so a leaked registration
+	// would be observable: a subsequent broadcast would append to cap.events.
+	cap := &captureSubscriber{}
+	sub := &crdt.Subscriber{UserID: "user-1", Send: cap.send}
+	out, err := mgr.SubscribeWithACL(context.Background(), sub, crdt.HLCClone(cursor), epoch, resolveAll)
+	require.Error(t, err, "a plain tail-read error must surface")
+	// The error path tears down the registration before returning, so there is
+	// no live handle to defer. SubscribeOutcome.Unsub() returns a no-op (not
+	// nil) on such an outcome so a caller that defers it before checking err is
+	// safe; calling it here must not double-teardown or panic.
+	assert.NotPanics(t, func() { out.Unsub()() }, "Unsub on an error-path outcome must be a safe no-op")
+
+	// The subscriber must not remain registered. Clear the injected error and
+	// commit a batch (which fans a broadcast out to every registered subscriber);
+	// the torn-down sub's capture must stay empty — if the teardown had leaked,
+	// the broadcast would land in cap.events.
+	j.listErr = nil
+	submitNodePositionBatch(t, mgr, "post-error-batch", "root1", "p0")
+	assert.Empty(t, cap.snapshot(), "the torn-down subscriber must not receive the post-error broadcast (registration leaked)")
+}
+
+// TestSubscribeWithACL_CorruptRowFallsBackWithoutLosingOps pins the resume-level
+// half of stop-on-corrupt: a tail with one undecodable batch in the middle must
+// NOT ship a partial delta.
+//
+// The tempting behavior — skip the bad row, ship the good tail around it — is
+// silently lossy. The corrupt batch contributes no frames, but the batch AFTER
+// it does, so the delta's max_hlc lands above the hole; the client adopts that
+// watermark, and because the resume cursor is strictly-greater, no later resume
+// ever re-requests the skipped batch. The client diverges permanently (and,
+// since the #356 checkpoint, persists the divergence across refreshes).
+//
+// So the contract is: a corrupt row is a RECOVERABLE verdict that FALLBACKs to
+// a full snapshot — always complete — and never a connect error.
+func TestSubscribeWithACL_CorruptRowFallsBackWithoutLosingOps(t *testing.T) {
+	mgr, j, _ := runManager(t, "user-1", allowAll{}, 230_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+	submitNodePositionBatch(t, mgr, "cursor-batch", "root1", "c0")
+	cursor := crdt.HLCClone(mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc())
+	require.NotNil(t, cursor)
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+
+	// Seed two post-cursor batches and mark the FIRST corrupt. The SECOND is
+	// what made skip-and-continue lossy: its frames would have advanced max_hlc
+	// past the corrupt batch.
+	submitNodePositionBatch(t, mgr, "corrupt-batch", "root1", "p1")
+	submitNodePositionBatch(t, mgr, "good-batch", "root1", "p2")
+	j.corruptTransitions = map[string]bool{"corrupt-batch": true}
+
+	cap := &captureSubscriber{}
+	sub := &crdt.Subscriber{UserID: "user-1", Send: cap.send}
+	out, err := mgr.SubscribeWithACL(context.Background(), sub, cursor, epoch, resolveAll)
+	require.NoError(t, err, "a corrupt row is recoverable: it must not surface a connect error")
+	require.Equal(t, crdt.SubscribeInitial, out.Mode(),
+		"a corrupt row must FALLBACK; shipping the good tail around it would strand the corrupt batch's ops forever")
+	defer out.Unsub()()
+
+	// The whole point of falling back: the snapshot carries BOTH post-cursor
+	// batches' effects, including the one whose journal row was undecodable.
+	// (A delta would have carried only "good-batch".)
+	snap := out.Initial()
+	require.NotNil(t, snap)
+	node := snap.GetNodes()["root1"]
+	require.NotNil(t, node, "the fallback snapshot must materialize the node both batches touched")
+	require.Equal(t, "p2", node.GetPosition().GetValue(),
+		"the snapshot reflects the latest committed position, so no committed op was lost to the corrupt row")
+}
+
+// TestSubscribeWithACL_OverBudgetFallbackRegistersExactlyOnce pins the
+// register→undo→re-register churn on the ErrDeltaTooLarge FALLBACK path. After
+// the over-budget tail read, SubscribeWithACL calls unsub() (tearing down the
+// RESUME registration) then subscribeLocked (re-registering via the FALLBACK
+// seam). The subscriber must end up registered EXACTLY ONCE: a subsequent
+// broadcast must deliver exactly one frame, not two (double-registration) or
+// zero (the unsub tore down the wrong handle). The over-budget path is driven
+// through SubscribeWithACL itself (not the journal stub) so the full churn runs.
+func TestSubscribeWithACL_OverBudgetFallbackRegistersExactlyOnce(t *testing.T) {
+	mgr, j, _ := runManager(t, "user-1", allowAll{}, 230_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+	submitNodePositionBatch(t, mgr, "cursor-batch", "root1", "c0")
+	cursor := mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc()
+	require.NotNil(t, cursor)
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+
+	// Force the resume tail read to hit the ErrDeltaTooLarge ceiling so
+	// SubscribeWithACL takes the FALLBACK-reentry path (register → unsub →
+	// subscribeLocked → re-register) rather than the plain RESUME arm.
+	j.listErr = crdt.ErrDeltaTooLarge
+	cap := &captureSubscriber{}
+	sub := &crdt.Subscriber{UserID: "user-1", Send: cap.send}
+	out, err := mgr.SubscribeWithACL(context.Background(), sub, crdt.HLCClone(cursor), epoch, resolveAll)
+	require.NoError(t, err, "ErrDeltaTooLarge must FALLBACK, not error")
+	require.Equal(t, crdt.SubscribeInitial, out.Mode(), "over-budget cursor must FALLBACK")
+	defer out.Unsub()()
+	require.NotNil(t, out.Initial(), "FALLBACK must carry a snapshot")
+
+	// Clear the injected ceiling and commit a batch. The broadcast fan-out
+	// reaches every registered subscriber; the over-budget path must have left
+	// this subscriber registered exactly once, so exactly one broadcast lands.
+	j.listErr = nil
+	cap.events = nil
+	submitNodePositionBatch(t, mgr, "post-fallback-batch", "root1", "p0")
+	// Count BATCH frames, not raw frames: one broadcast is now a batch frame
+	// plus its batch_end boundary, so a raw count of 2 is a single delivery.
+	// Counting the batch arm keeps this pinned on registration cardinality
+	// rather than on how many frames a batch happens to fan out as.
+	var batches int
+	for _, e := range cap.snapshot() {
+		if e.GetBatch() != nil {
+			batches++
+		}
+	}
+	require.Equal(t, 1, batches, "the FALLBACK-reentered subscriber must receive exactly one broadcast (not zero=unregistered, not two=double-registered)")
+}
+
+// TestSubscribeWithACL_NeitherExpandNorBroadcastStalledDuringScan is the
+// load-bearing concurrency test for the lock-release restructure: while a
+// RESUME's journal tail scan is in flight (held via the fake journal's
+// listHold), NEITHER a workspace-create expand (which takes subscribeExpandMu)
+// NOR a live commit broadcast to another subscriber (which takes m.projection)
+// may stall behind the scan. Before the restructure both locks were held across
+// the multi-page DB read, so a reconnect stalled that user's workspace lifecycle
+// RPCs and every other tab's live broadcasts for the scan's duration; this test
+// FAILS against that code (both operations time out) and PASSES once the RESUME
+// arm releases both locks after registering.
+func TestSubscribeWithACL_NeitherExpandNorBroadcastStalledDuringScan(t *testing.T) {
+	mgr, j, _ := runManager(t, "user-1", allowAll{}, 230_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+	// A cursor + one post-cursor tail batch so RESUME is chosen (not FALLBACK).
+	submitNodePositionBatch(t, mgr, "cursor-batch", "root1", "c0")
+	cursor := mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc()
+	require.NotNil(t, cursor)
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+
+	// Hold the resume's tail scan mid-flight, and signal when it has entered.
+	listHold := make(chan struct{})
+	listReached := make(chan struct{})
+	j.listHold = listHold
+	j.listReached = listReached
+
+	// Start the RESUME in a goroutine. It registers, releases the locks, then
+	// blocks in ListBatchesAfter on listHold.
+	type res struct {
+		out crdt.SubscribeOutcome
+		err error
+	}
+	resCh := make(chan res, 1)
+	resumeSub := &crdt.Subscriber{UserID: "user-1", Send: (&captureSubscriber{}).send}
+	go func() {
+		out, err := mgr.SubscribeWithACL(context.Background(), resumeSub, crdt.HLCClone(cursor), epoch, resolveAll)
+		resCh <- res{out, err}
+	}()
+
+	// Wait until the resume has entered its tail scan (it is past register and
+	// has released subscribeExpandMu + m.projection).
+	<-listReached
+
+	// (a) A workspace-create expand must NOT be blocked on subscribeExpandMu.
+	expandDone := make(chan error, 1)
+	go func() {
+		expandDone <- mgr.ExpandSubscribersForWorkspace(context.Background(), "w1")
+	}()
+	select {
+	case err := <-expandDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("ExpandSubscribersForWorkspace was stalled behind a resume's tail scan — subscribeExpandMu not released")
+	}
+
+	// (b) A live commit's broadcast to ANOTHER registered subscriber must NOT be
+	// blocked on m.projection. Register a second subscriber, commit a batch, and
+	// assert its broadcast lands while the resume scan is still held.
+	capOther := &captureSubscriber{}
+	otherSub := &crdt.Subscriber{UserID: "user-1", Send: capOther.send}
+	otherOut, err := mgr.SubscribeWithACL(context.Background(), otherSub, nil, 0, resolveAll)
+	require.NoError(t, err)
+	defer otherOut.Unsub()()
+
+	submitNodePositionBatch(t, mgr, "during-scan-batch", "root1", "live")
+	select {
+	case got := <-signalLen(capOther):
+		require.GreaterOrEqual(t, got, 1, "the other subscriber must receive the live broadcast during the resume scan — m.projection not released")
+	case <-time.After(time.Second):
+		t.Fatal("live broadcast was stalled behind a resume's tail scan — m.projection not released")
+	}
+
+	// Release the held scan and let the RESUME complete.
+	close(listHold)
+	r := <-resCh
+	require.NoError(t, r.err)
+	defer r.out.Unsub()()
+	require.Equal(t, crdt.SubscribeDelta, r.out.Mode(), "the held resume must still complete as a delta")
+
+	// Register-time until high-water: the during-scan commit landed AFTER the
+	// resume captured MaxHlc, so it must arrive via live broadcast only — not
+	// also as a frame inside the delta (dual-delivery of the same batch).
+	for _, f := range r.out.Delta().GetFrames() {
+		if b := f.GetBatch(); b != nil {
+			assert.NotEqual(t, "during-scan-batch", b.GetBatchId(),
+				"post-register commits must not appear in the resume delta (owned by live broadcast)")
+		}
+	}
+}
+
+// TestSubscribeOutcome_ZeroValueIsNotAReadyDelta pins the zero-value guard on
+// SubscribeMode.
+//
+// Every error return in SubscribeWithACL / resumeFallback is
+// `SubscribeOutcome{}, err`. While SubscribeDelta was the iota-zero arm, that
+// value read as "delta ready" carrying a nil *ResumeDelta: today's sole caller
+// checks err first, but a second caller -- or a refactor that logs Mode()
+// before the err check -- would ship WatchUserEvent_Delta{Delta: nil} as the
+// bootstrap frame, leaving the client "connected" against unhydrated state with
+// every submit rejected STALE_EPOCH. The sibling resumeScanKind already
+// reserved its zero value for exactly this; this is the same guard one type
+// over.
+func TestSubscribeOutcome_ZeroValueIsNotAReadyDelta(t *testing.T) {
+	var zero crdt.SubscribeOutcome
+
+	assert.NotEqual(t, crdt.SubscribeDelta, zero.Mode(),
+		"the zero outcome is what every error path returns; it must not read as a ready delta")
+	assert.NotEqual(t, crdt.SubscribeInitial, zero.Mode(),
+		"nor as a ready snapshot")
+	assert.Equal(t, "SubscribeMode(invalid)", zero.Mode().String(),
+		"the invalid arm must name itself, so a log line on the error path is legible")
+
+	// The discriminated accessors stay assertion-gated on the zero value, so a
+	// caller that skips the err check fails loudly instead of sending nil.
+	assert.Panics(t, func() { _ = zero.Delta() })
+	assert.Panics(t, func() { _ = zero.Initial() })
+
+	// Unsub stays safe to defer unconditionally -- that contract predates this
+	// change and the guard must not break it.
+	assert.NotPanics(t, func() { zero.Unsub()() })
+}
+
+// signalLen returns a channel that receives cap.snapshot()'s length once a
+// broadcast lands (polled briefly), so a test can select on it with a timeout.
+func signalLen(cap *captureSubscriber) <-chan int {
+	ch := make(chan int, 1)
+	go func() {
+		// The broadcast is delivered synchronously inside SubmitInternal's
+		// commit, so by the time submitNodePositionBatch returns it has either
+		// landed or been blocked. Poll a few times to let any buffered send
+		// flush, then report.
+		for i := 0; i < 20; i++ {
+			if n := len(cap.snapshot()); n > 0 {
+				ch <- n
+				return
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		ch <- 0
+	}()
+	return ch
+}
+
+// TestSubscribeWithACL_PostCursorTailShipsInDelta pins that a batch committed
+// after the resume cursor (and therefore inside register-time until) appears
+// in the ResumeDelta frame stream.
+func TestSubscribeWithACL_PostCursorTailShipsInDelta(t *testing.T) {
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 230_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+	submitNodePositionBatch(t, mgr, "cursor-batch", "root1", "c0")
+	cursor := mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc()
+	require.NotNil(t, cursor)
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+
+	submitNodePositionBatch(t, mgr, "in-until-batch", "root1", "iu0")
+
+	cap := &captureSubscriber{}
+	sub := &crdt.Subscriber{UserID: "user-1", Send: cap.send}
+	out, err := mgr.SubscribeWithACL(context.Background(), sub, crdt.HLCClone(cursor), epoch, resolveAll)
+	require.NoError(t, err)
+	defer out.Unsub()()
+	require.Equal(t, crdt.SubscribeDelta, out.Mode())
+
+	inDelta := false
+	for _, f := range out.Delta().GetFrames() {
+		if b := f.GetBatch(); b != nil && b.GetBatchId() == "in-until-batch" {
+			inDelta = true
+		}
+	}
+	assert.True(t, inDelta, "post-cursor batch must ship in the resume delta")
+}
+
+// TestSubscribeWithACL_CompactionDuringScan_FallsBack pins that a compaction
+// advancing the op_retention_watermark past the cursor during the unlocked
+// journal scan must FALLBACK rather than return a shortened delta the client
+// would treat as complete catch-up.
+//
+// Op-batch deletion (and therefore the resume gate) keys on
+// op_retention_watermark, which lags compaction_watermark by OpRetentionTTL.
+// This test shrinks the TTL to zero so a single compaction tick advances the
+// retention floor to the compaction watermark (== max_hlc), past the resume
+// cursor — exercising the post-scan re-check that invalidates a resume when
+// compaction races the scan. The production 24h default would leave the
+// retention floor far below the cursor and a single tick would NOT invalidate.
+func TestSubscribeWithACL_CompactionDuringScan_StillResumes(t *testing.T) {
+	// This used to force a post-scan FALLBACK with WithOpRetentionTTL(0), so a
+	// single compaction tick pushed op_retention_watermark past the cursor while
+	// the scan was held. That scenario is now UNREACHABLE, and deliberately so.
+	//
+	// decideResume gained a wall-clock floor (cursor.physical >= now - TTL)
+	// alongside the stored-watermark floor, because the cleanup job sweeps op
+	// batches by committed_at and a dormant account's stored floor stops
+	// advancing. Since max_hlc <= now, any cursor the stored floor could
+	// invalidate mid-scan (cursor <= max_hlc - TTL) was already below the
+	// wall-clock floor (now - TTL) at decide time, so it never reaches the scan.
+	//
+	// The post-scan re-check therefore survives as defence-in-depth and for the
+	// epoch arm, not for compaction. What is still worth pinning here is the
+	// concurrency itself: a compaction tick landing mid-scan must not corrupt or
+	// hang the resume.
+	mgr, j, _ := runManager(t, "user-1", allowAll{}, 230_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+	submitNodePositionBatch(t, mgr, "cursor-batch", "root1", "c0")
+	cursor := mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc()
+	require.NotNil(t, cursor)
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+	submitNodePositionBatch(t, mgr, "tail-batch", "root1", "t0")
+
+	listHold := make(chan struct{})
+	listReached := make(chan struct{})
+	j.listHold = listHold
+	j.listReached = listReached
+
+	type res struct {
+		out crdt.SubscribeOutcome
+		err error
+	}
+	resCh := make(chan res, 1)
+	resumeSub := &crdt.Subscriber{UserID: "user-1", Send: (&captureSubscriber{}).send}
+	go func() {
+		out, err := mgr.SubscribeWithACL(context.Background(), resumeSub, crdt.HLCClone(cursor), epoch, resolveAll)
+		resCh <- res{out, err}
+	}()
+
+	<-listReached
+	mgr.TickHousekeeping(context.Background())
+	close(listHold)
+
+	r := <-resCh
+	require.NoError(t, r.err)
+	defer r.out.Unsub()()
+	require.Equal(t, crdt.SubscribeDelta, r.out.Mode(),
+		"a compaction tick during the scan must not invalidate a cursor inside the retention window")
+	require.NotNil(t, r.out.Delta())
+}
+
+// TestDecideResume_WallClockFloorFallsBack pins the floor that makes the
+// cleanup job's committed_at sweep safe.
+//
+// op_retention_watermark only advances while a user is committing (maybeCompact
+// short-circuits once compaction_watermark reaches max_hlc), so a dormant
+// account's stored floor freezes while the sweep keeps deleting its rows by
+// wall clock. Gating on the stored floor alone would admit a cursor whose
+// batches were already swept and ship a silently short tail.
+func TestDecideResume_WallClockFloorFallsBack(t *testing.T) {
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 230_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+	submitNodePositionBatch(t, mgr, "cursor-batch", "root1", "c0")
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+
+	// A cursor one full retention window in the past. The stored floor is still
+	// zero (no compaction has advanced it), so ONLY the wall-clock floor can
+	// refuse this.
+	stale := crdt.HLCClone(mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc())
+	require.NotNil(t, stale)
+	stale.Physical -= int64(crdt.OpRetentionTTL / time.Millisecond)
+	require.True(t, crdt.HLCIsZero(mgr.State().GetOpRetentionWatermark()),
+		"precondition: the stored floor must be zero so it cannot be what refuses")
+
+	sub := &crdt.Subscriber{UserID: "user-1", Send: (&captureSubscriber{}).send}
+	out, err := mgr.SubscribeWithACL(context.Background(), sub, stale, epoch, resolveAll)
+	require.NoError(t, err)
+	defer out.Unsub()()
+	require.Equal(t, crdt.SubscribeInitial, out.Mode(),
+		"a cursor older than OpRetentionTTL must FALLBACK: the sweep may already have deleted its batches")
+}
+
+// TestSubscribeWithACL_OverBudgetFallbackReResolvesFilter pins that the
+// over-budget FALLBACK path re-runs resolve under subscribeExpandMu before
+// re-registering, so an ACL change that landed while the RESUME sub was
+// registered is reflected in the FALLBACK snapshot filter.
+func TestSubscribeWithACL_OverBudgetFallbackReResolvesFilter(t *testing.T) {
+	mgr, j, _ := runManager(t, "user-1", allowAll{}, 230_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+	seedRootInternal(t, mgr, "w2", "root2")
+	submitNodePositionBatch(t, mgr, "cursor-batch", "root1", "c0")
+	cursor := mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc()
+	require.NotNil(t, cursor)
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+
+	calls := 0
+	resolve := func() (map[string]bool, error) {
+		calls++
+		if calls == 1 {
+			// First resolve (RESUME decision): only w1.
+			return map[string]bool{"w1": true}, nil
+		}
+		// Re-resolve on FALLBACK: ACL now includes w2.
+		return map[string]bool{"w1": true, "w2": true}, nil
+	}
+
+	j.listErr = crdt.ErrDeltaTooLarge
+	cap := &captureSubscriber{}
+	sub := &crdt.Subscriber{UserID: "user-1", Send: cap.send}
+	out, err := mgr.SubscribeWithACL(context.Background(), sub, crdt.HLCClone(cursor), epoch, resolve)
+	require.NoError(t, err)
+	defer out.Unsub()()
+	require.Equal(t, crdt.SubscribeInitial, out.Mode())
+	require.GreaterOrEqual(t, calls, 2, "FALLBACK must re-resolve the ACL")
+	fellBack := out.Initial()
+	assert.Contains(t, fellBack.GetWorkspaces(), "w1")
+	assert.Contains(t, fellBack.GetWorkspaces(), "w2",
+		"FALLBACK snapshot must use the re-resolved filter, not the stale RESUME filter")
+}
+
+// TestSubscribeWithACL_FallbackFiresOnRebaseline pins the seam that keeps a
+// RESUME->FALLBACK from resurrecting stale entity records.
+//
+// During the resume scan the subscriber is registered, so live broadcasts queue
+// in the transport. If the scan then gives up, the snapshot is computed at a
+// LATER point than those queued frames -- and the client applies
+// entity_materialized / entity_removed WHOLESALE, with no HLC compare (unlike
+// batch ops, which go through a strictly-greater LWW guard). Writing the queued
+// frames after the snapshot would therefore reinstate older records permanently.
+// The manager calls OnRebaseline under its projection lock at exactly the
+// re-register point so the transport can drop precisely the superseded frames.
+func TestSubscribeWithACL_FallbackFiresOnRebaseline(t *testing.T) {
+	mgr, j, _ := runManager(t, "user-1", allowAll{}, 230_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+	submitNodePositionBatch(t, mgr, "cursor-batch", "root1", "c0")
+	cursor := crdt.HLCClone(mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc())
+	require.NotNil(t, cursor)
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+	submitNodePositionBatch(t, mgr, "tail", "root1", "t0")
+
+	// Force the FALLBACK arm.
+	j.listErr = crdt.ErrDeltaTooLarge
+
+	rebaselines := 0
+	sub := &crdt.Subscriber{
+		UserID:       "user-1",
+		Send:         (&captureSubscriber{}).send,
+		OnRebaseline: func() { rebaselines++ },
+	}
+	out, err := mgr.SubscribeWithACL(context.Background(), sub, cursor, epoch, resolveAll)
+	require.NoError(t, err)
+	defer out.Unsub()()
+	require.Equal(t, crdt.SubscribeInitial, out.Mode())
+	assert.Equal(t, 1, rebaselines,
+		"the FALLBACK re-entry must tell the transport to discard frames queued during the scan")
+}
+
+// TestSubscribeWithACL_ResumeDoesNotFireOnRebaseline is the other half: a resume
+// that SUCCEEDS never re-registers, so nothing was superseded and the transport
+// must keep everything it queued during the scan. Firing the hook there would
+// silently drop live frames that are strictly newer than the delta.
+func TestSubscribeWithACL_ResumeDoesNotFireOnRebaseline(t *testing.T) {
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 230_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+	submitNodePositionBatch(t, mgr, "cursor-batch", "root1", "c0")
+	cursor := crdt.HLCClone(mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc())
+	require.NotNil(t, cursor)
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+	submitNodePositionBatch(t, mgr, "tail", "root1", "t0")
+
+	rebaselines := 0
+	sub := &crdt.Subscriber{
+		UserID:       "user-1",
+		Send:         (&captureSubscriber{}).send,
+		OnRebaseline: func() { rebaselines++ },
+	}
+	out, err := mgr.SubscribeWithACL(context.Background(), sub, cursor, epoch, resolveAll)
+	require.NoError(t, err)
+	defer out.Unsub()()
+	require.Equal(t, crdt.SubscribeDelta, out.Mode())
+	assert.Zero(t, rebaselines, "a successful resume supersedes nothing and must not discard queued frames")
+}
+
+// A subscriber whose transport dropped a frame during the resume scan must get
+// a SNAPSHOT, not a delta with a hole in it — and not a torn-down connection.
+//
+// Tearing down was the previous answer, and it sent the client back with the
+// SAME cursor to rebuild the SAME multi-page scan, under the sustained
+// broadcast load that caused the overflow in the first place. The loop is
+// bounded (a widening gap eventually trips MaxResumeDeltaOps and FALLBACKs
+// anyway), but every round is a wasted journal scan on an already-stressed hub.
+// FALLBACK converts it into exactly one snapshot.
+func TestSubscribeWithACL_TransportOverflowDuringScanFallsBack(t *testing.T) {
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 230_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+	submitNodePositionBatch(t, mgr, "cursor-batch", "root1", "c0")
+	cursor := mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc()
+	require.NotNil(t, cursor)
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+	// A tail the resume would otherwise ship, so a delta is genuinely available
+	// and FALLBACK is a decision rather than the only option.
+	submitNodePositionBatch(t, mgr, "tail-batch", "root1", "t0")
+
+	overflowed := true
+	sub := &crdt.Subscriber{
+		UserID:     "user-1",
+		Send:       (&captureSubscriber{}).send,
+		Overflowed: func() bool { return overflowed },
+	}
+	out, err := mgr.SubscribeWithACL(context.Background(), sub, crdt.HLCClone(cursor), epoch, resolveAll)
+	require.NoError(t, err)
+	defer out.Unsub()()
+	assert.Equal(t, crdt.SubscribeInitial, out.Mode(),
+		"a transport that dropped a frame mid-scan must get a complete snapshot")
+	// Not asserting out.Delta() is nil: SubscribeOutcome PANICS on a Delta()
+	// read in any mode but SubscribeDelta, which is the stronger guarantee.
+}
+
+// The control: the SAME setup without an overflow resumes. Without it the case
+// above would pass even if resume were broken outright.
+func TestSubscribeWithACL_NoOverflowStillResumes(t *testing.T) {
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 230_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+	submitNodePositionBatch(t, mgr, "cursor-batch", "root1", "c0")
+	cursor := mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc()
+	require.NotNil(t, cursor)
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+	submitNodePositionBatch(t, mgr, "tail-batch", "root1", "t0")
+
+	sub := &crdt.Subscriber{
+		UserID:     "user-1",
+		Send:       (&captureSubscriber{}).send,
+		Overflowed: func() bool { return false },
+	}
+	out, err := mgr.SubscribeWithACL(context.Background(), sub, crdt.HLCClone(cursor), epoch, resolveAll)
+	require.NoError(t, err)
+	defer out.Unsub()()
+	assert.Equal(t, crdt.SubscribeDelta, out.Mode())
+}
+
+// A nil Overflowed callback is the ordinary case — every non-websocket caller,
+// and every test that does not care. It must read as "no overflow" rather than
+// panicking or refusing to resume.
+func TestSubscribeWithACL_NilOverflowCallbackResumes(t *testing.T) {
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 230_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+	submitNodePositionBatch(t, mgr, "cursor-batch", "root1", "c0")
+	cursor := mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc()
+	require.NotNil(t, cursor)
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+	submitNodePositionBatch(t, mgr, "tail-batch", "root1", "t0")
+
+	sub := &crdt.Subscriber{UserID: "user-1", Send: (&captureSubscriber{}).send}
+	out, err := mgr.SubscribeWithACL(context.Background(), sub, crdt.HLCClone(cursor), epoch, resolveAll)
+	require.NoError(t, err)
+	defer out.Unsub()()
+	assert.Equal(t, crdt.SubscribeDelta, out.Mode())
+}
+
+// decideResume gates on the GREATER of two floors, and this pins why both are
+// needed rather than one.
+//
+// The persisted op_retention_watermark is authoritative while a user is active,
+// but it only advances while they are COMMITTING: maybeCompact short-circuits
+// once compaction_watermark reaches max_hlc, so a dormant account's stored
+// value freezes at (last activity - TTL) while the cross-user cleanup sweep
+// keeps deleting its rows on wall-clock time. Gating on the stored value alone
+// would admit a cursor whose batches the sweep had already removed, and
+// ListBatchesAfter reports deleted-below rows as an ordinary SHORT tail, not an
+// error — so the client would adopt a max_hlc covering ops it never received.
+//
+// A zero TTL puts the wall-clock cutoff at "now", above any cursor, so it is
+// the binding floor and the resume must be refused even though the stored
+// watermark alone would admit it.
+func TestSubscribeWithACL_WallClockFloorRefusesACursorTheStoredWatermarkWouldAdmit(t *testing.T) {
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 230_000, crdt.WithOpRetentionTTL(0))
+	seedRootInternal(t, mgr, "w1", "root1")
+	submitNodePositionBatch(t, mgr, "cursor-batch", "root1", "c0")
+	cursor := mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc()
+	require.NotNil(t, cursor)
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+	submitNodePositionBatch(t, mgr, "tail-batch", "root1", "t0")
+
+	// The STORED watermark alone would admit this cursor...
+	require.True(t, crdt.HLCCmp(cursor, mgr.State().GetOpRetentionWatermark()) > 0,
+		"precondition: the cursor is above the persisted op_retention_watermark")
+
+	// ...but the wall-clock cutoff (TTL=0 => cutoff is now) is above it, so the
+	// effective floor refuses it.
+	sub := &crdt.Subscriber{UserID: "user-1", Send: (&captureSubscriber{}).send}
+	out, err := mgr.SubscribeWithACL(context.Background(), sub, crdt.HLCClone(cursor), epoch, resolveAll)
+	require.NoError(t, err)
+	defer out.Unsub()()
+	assert.Equal(t, crdt.SubscribeInitial, out.Mode(),
+		"a cursor below the wall-clock retention cutoff must FALLBACK, whatever the stored watermark says")
+}

--- a/backend/internal/hub/crdt/op.go
+++ b/backend/internal/hub/crdt/op.go
@@ -270,6 +270,30 @@ func (r EntityRef) ToJSON() map[string]any {
 }
 
 // OpTarget extracts the EntityRef an op acts on.
+// HasIdentity reports whether this ref actually names an entity.
+//
+// The SINGLE definition of "is this a real target", shared by the submit-path
+// validator (which rejects an op whose target has none) and by
+// transitionEntryRef (which refuses to decode such an entry). Keeping one rule
+// is what makes the AffectedEntitiesToProto -> transitionEntryRef round-trip
+// total: an identity the encoder can write but the decoder cannot read is a
+// batch that commits fine and then reports itself as a corrupt journal row on
+// every later resume.
+func (r EntityRef) HasIdentity() bool {
+	switch r.Kind {
+	case EntityKindNode:
+		return r.NodeID != ""
+	case EntityKindTab:
+		return r.TabID != ""
+	case EntityKindFloatingWindow:
+		return r.WindowID != ""
+	case EntityKindWorkspaceRoot:
+		return r.WorkspaceID != ""
+	default:
+		return false
+	}
+}
+
 func OpTarget(op *leapmuxv1.CrdtOp) EntityRef {
 	switch body := op.GetBody().(type) {
 	case *leapmuxv1.CrdtOp_SetNodeRegister:

--- a/backend/internal/hub/crdt/op_test.go
+++ b/backend/internal/hub/crdt/op_test.go
@@ -51,7 +51,7 @@ func TestOpTarget_ClassifiesEveryOpKind(t *testing.T) {
 }
 
 // TestOpTarget_UnknownBodyIsKindUnknown pins the fall-through: a nil body
-// yields EntityKindUnknown, which batchVisibleOpsEvent treats as not-visible
+// yields EntityKindUnknown, which opVisibleForSubscriber treats as not-visible
 // (IsAllowed("") is false) so a malformed op is dropped rather than crashing.
 func TestOpTarget_UnknownBodyIsKindUnknown(t *testing.T) {
 	ref := crdt.OpTarget(&leapmuxv1.CrdtOp{})

--- a/backend/internal/hub/crdt/resume_suppress_internal_test.go
+++ b/backend/internal/hub/crdt/resume_suppress_internal_test.go
@@ -1,0 +1,69 @@
+package crdt
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+)
+
+// TestSendTo_ResumeSuppressThrough pins the live-path half of the
+// register-time until/broadcast dual-delivery fix: when a subscriber's
+// resumeSuppressThrough is at or above the batch's last-op HLC, sendTo must
+// not call Send. Those frames are owned by the ResumeDelta journal scan.
+func TestSendTo_ResumeSuppressThrough(t *testing.T) {
+	at := &leapmuxv1.HLC{Physical: 100, Logical: 0, ClientId: "c"}
+	batch := &leapmuxv1.OpBatch{
+		BatchId: "b1",
+		Ops: []*leapmuxv1.CrdtOp{{
+			OpId:         "op1",
+			CanonicalHlc: at,
+			Body: &leapmuxv1.CrdtOp_SetNodeRegister{SetNodeRegister: &leapmuxv1.SetNodeRegisterOp{
+				NodeId: "n1",
+				Field:  &leapmuxv1.SetNodeRegisterOp_Position{Position: "p"},
+			}},
+		}},
+	}
+	ref := OpTarget(batch.GetOps()[0])
+	res := ValidationResult{
+		AffectedEntities: map[EntityRef]EntityWorkspaceTransition{
+			ref: {Pre: "w1", Post: "w1"},
+		},
+	}
+
+	var sends atomic.Int32
+	sub := &Subscriber{
+		Filter:                NewSubscriberFilter(map[string]bool{"w1": true}),
+		resumeSuppressThrough: at,
+		Send: func(*MarshaledEvent) error {
+			sends.Add(1)
+			return nil
+		},
+	}
+	fan := &batchFanout{
+		batch: batch,
+		res:   res,
+		refs:  orderedAffectedRefs(res.AffectedEntities),
+		atHLC: at,
+		materialized: func(EntityRef) *MarshaledEvent {
+			return nil
+		},
+		removed: func(EntityRef) *MarshaledEvent {
+			return nil
+		},
+	}
+	fan.sendTo(sub)
+	assert.Equal(t, int32(0), sends.Load(), "batches at or below resumeSuppressThrough must not be live-sent")
+
+	// A strictly newer batch must still deliver. batchFanout.atHLC is the
+	// subscriber-constant source of truth broadcastBatch hoists once, so the
+	// test mirrors that contract and updates fan.atHLC alongside the batch.
+	newer := &leapmuxv1.HLC{Physical: 101, Logical: 0, ClientId: "c"}
+	batch.Ops[0].CanonicalHlc = newer
+	fan.atHLC = newer
+	fan.sendTo(sub)
+	require.Greater(t, sends.Load(), int32(0), "batches above resumeSuppressThrough must still live-send")
+}

--- a/backend/internal/hub/crdt/state.go
+++ b/backend/internal/hub/crdt/state.go
@@ -463,19 +463,22 @@ func CloneState(state *leapmuxv1.UserCrdtState) *leapmuxv1.UserCrdtState {
 // state_clone_for_batch_test.go pin this contract so future op
 // additions can't silently regress.
 //
-// Top-level HLC fields (max_hlc, compaction_watermark) are deep-
-// cloned because Apply may bump max_hlc on every op.
+// Top-level HLC fields (max_hlc, compaction_watermark,
+// op_retention_watermark) are deep-cloned because Apply may bump
+// max_hlc on every op and compaction may advance the watermarks
+// concurrently with the validator's Apply pass.
 func CloneStateForBatch(pre *leapmuxv1.UserCrdtState, batch []*leapmuxv1.CrdtOp) *leapmuxv1.UserCrdtState {
 	if pre == nil {
 		return nil
 	}
 	touched := batchTouchedIDs(batch)
 	out := &leapmuxv1.UserCrdtState{
-		UserId:              pre.GetUserId(),
-		MaxHlc:              HLCClone(pre.GetMaxHlc()),
-		CompactionWatermark: HLCClone(pre.GetCompactionWatermark()),
-		CurrentEpoch:        pre.GetCurrentEpoch(),
-		EpochStartedAt:      pre.GetEpochStartedAt(),
+		UserId:               pre.GetUserId(),
+		MaxHlc:               HLCClone(pre.GetMaxHlc()),
+		CompactionWatermark:  HLCClone(pre.GetCompactionWatermark()),
+		OpRetentionWatermark: HLCClone(pre.GetOpRetentionWatermark()),
+		CurrentEpoch:         pre.GetCurrentEpoch(),
+		EpochStartedAt:       pre.GetEpochStartedAt(),
 	}
 
 	if len(touched.nodes) == 0 {

--- a/backend/internal/hub/crdt/state_clone_for_batch_test.go
+++ b/backend/internal/hub/crdt/state_clone_for_batch_test.go
@@ -209,6 +209,29 @@ func TestCloneStateForBatch_PreservesMaxHLCViaDeepClone(t *testing.T) {
 		"working.MaxHlc mutation must not affect pre.MaxHlc")
 }
 
+func TestCloneStateForBatch_PreservesWatermarksViaDeepClone(t *testing.T) {
+	// CompactionWatermark and OpRetentionWatermark are advanced by
+	// maybeCompact concurrently with the validator's CloneStateForBatch +
+	// Apply pass. The clone must deep-copy both so a write to the working
+	// copy's watermark (e.g. by a future Apply hook) cannot race a
+	// concurrent compaction writing through to pre's slot.
+	pre := &leapmuxv1.UserCrdtState{
+		UserId:               "user-1",
+		MaxHlc:               hlc(10, 0, "seed"),
+		CompactionWatermark:  hlc(8, 0, "seed"),
+		OpRetentionWatermark: hlc(2, 0, "seed"),
+	}
+	working := crdt.CloneStateForBatch(pre, nil)
+	require.NotNil(t, working.GetCompactionWatermark())
+	require.NotNil(t, working.GetOpRetentionWatermark())
+	working.CompactionWatermark.Physical = 999
+	working.OpRetentionWatermark.Physical = 888
+	assert.Equal(t, int64(8), pre.GetCompactionWatermark().GetPhysical(),
+		"working.CompactionWatermark mutation must not affect pre")
+	assert.Equal(t, int64(2), pre.GetOpRetentionWatermark().GetPhysical(),
+		"working.OpRetentionWatermark mutation must not affect pre")
+}
+
 func TestCloneStateForBatch_TouchedNodeNotInPreIsHarmless(t *testing.T) {
 	// A SetNodeRegister op for a brand-new node id (not yet in pre) is
 	// the common create-node case. CloneStateForBatch should produce a

--- a/backend/internal/hub/crdt/subscribe_outcome_internal_test.go
+++ b/backend/internal/hub/crdt/subscribe_outcome_internal_test.go
@@ -1,0 +1,52 @@
+package crdt
+
+import (
+	"testing"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Bootstrap is what makes "exactly one bootstrap frame goes on the wire, with
+// both identity fields stamped" a property of the TYPE rather than of a
+// correctly-written if/else at the single call site.
+//
+// The arms had already drifted while the caller owned the stamping: the delta
+// arm set user_id and the initial arm did not, because the manager happened to
+// stamp that one itself. Two stamping rules, one per arm, is exactly how the
+// next field gets added to only one of them.
+func TestSubscribeOutcome_Bootstrap_StampsBothArms(t *testing.T) {
+	t.Run("delta", func(t *testing.T) {
+		out := newSubscribeDeltaOutcome(&leapmuxv1.ResumeDelta{}, func() {})
+		evt := out.Bootstrap("client-7", "user-9")
+
+		delta := evt.GetDelta()
+		require.NotNil(t, delta, "the delta arm must wrap a Delta event")
+		assert.Equal(t, "client-7", delta.GetSubscriberClientId())
+		assert.Equal(t, "user-9", delta.GetUserId())
+		assert.Nil(t, evt.GetInitial())
+	})
+
+	t.Run("initial", func(t *testing.T) {
+		out := newSubscribeInitialOutcome(&leapmuxv1.UserMaterialized{}, func() {})
+		evt := out.Bootstrap("client-7", "user-9")
+
+		initial := evt.GetInitial()
+		require.NotNil(t, initial, "the initial arm must wrap an Initial event")
+		assert.Equal(t, "client-7", initial.GetSubscriberClientId())
+		// Stamped here too, not just on the delta arm: the client fails closed on
+		// a foreign payload for BOTH, so one stamping rule beats one per arm.
+		assert.Equal(t, "user-9", initial.GetUserId())
+		assert.Nil(t, evt.GetDelta())
+	})
+}
+
+// A zero-valued outcome names no arm. Panicking beats returning a nil frame the
+// caller would happily write to the socket -- the same reason Delta()/Initial()
+// are assertion-gated.
+func TestSubscribeOutcome_Bootstrap_PanicsOnInvalidMode(t *testing.T) {
+	assert.Panics(t, func() {
+		_ = SubscribeOutcome{}.Bootstrap("c", "u")
+	})
+}

--- a/backend/internal/hub/crdt/subscriber_controller_test.go
+++ b/backend/internal/hub/crdt/subscriber_controller_test.go
@@ -21,7 +21,7 @@ func TestSubscriberControllerSnapshotsAreDeeplyImmutable(t *testing.T) {
 	require.Len(t, before, 1)
 
 	c.MutateEach(func(current *Subscriber) {
-		current.Filter.WorkspaceIDs["w2"] = true
+		current.Filter = current.Filter.WithWorkspace("w2")
 	})
 
 	after := c.Snapshot()
@@ -38,7 +38,7 @@ func TestSubscriberControllerAddReturnsImmutableBootstrapFilter(t *testing.T) {
 	bootstrapFilter := c.Add(sub)
 
 	c.MutateEach(func(current *Subscriber) {
-		current.Filter.WorkspaceIDs["w2"] = true
+		current.Filter = current.Filter.WithWorkspace("w2")
 	})
 
 	assert.False(t, bootstrapFilter.IsAllowed("w2"),
@@ -75,9 +75,9 @@ func TestSubscriberControllerConcurrentSnapshotAndFilterMutation(t *testing.T) {
 		for i := range iterations {
 			c.MutateEach(func(current *Subscriber) {
 				if i%2 == 0 {
-					current.Filter.WorkspaceIDs["w2"] = true
+					current.Filter = current.Filter.WithWorkspace("w2")
 				} else {
-					delete(current.Filter.WorkspaceIDs, "w2")
+					current.Filter = current.Filter.WithoutWorkspace("w2")
 				}
 			})
 		}
@@ -102,7 +102,7 @@ func TestSubscriberControllerReusesImmutableClonesForUnchangedSubscribers(t *tes
 	require.NotNil(t, before)
 	c.MutateEach(func(sub *Subscriber) {
 		if sub == changed {
-			sub.Filter.WorkspaceIDs["w3"] = true
+			sub.Filter = sub.Filter.WithWorkspace("w3")
 		}
 	})
 	var after *Subscriber

--- a/backend/internal/hub/crdt/transitions_proto.go
+++ b/backend/internal/hub/crdt/transitions_proto.go
@@ -1,0 +1,210 @@
+package crdt
+
+import (
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+)
+
+// liveRecordSnapshot returns a deep-cloned EntityMaterialized payload for
+// `ref` from `state`, or nil when the record is missing, tombstoned, or the
+// kind has no EntityMaterialized variant. This is the SINGLE source of the
+// "what record ships in a materialize frame" rule: both the live broadcast
+// (buildEntityMaterializedEvent) and the commit-time encoder
+// (AffectedEntitiesToProto) call it, so resume/live cannot drift on
+// tombstone-omit or kind coverage.
+func liveRecordSnapshot(state *leapmuxv1.UserCrdtState, ref EntityRef) *leapmuxv1.EntityMaterialized {
+	switch ref.Kind {
+	case EntityKindNode:
+		n := state.GetNodes()[ref.NodeID]
+		if n == nil || !HLCIsZero(n.GetTombstoneAt()) {
+			return nil
+		}
+		return &leapmuxv1.EntityMaterialized{
+			Entity: &leapmuxv1.EntityMaterialized_Node{Node: cloneNode(n)},
+		}
+	case EntityKindTab:
+		t := state.GetTabs()[ref.TabID]
+		if t == nil || !HLCIsZero(t.GetTombstoneAt()) {
+			return nil
+		}
+		return &leapmuxv1.EntityMaterialized{
+			Entity: &leapmuxv1.EntityMaterialized_Tab{Tab: cloneTab(t)},
+		}
+	case EntityKindFloatingWindow:
+		fw := state.GetFloatingWindows()[ref.WindowID]
+		if fw == nil || !HLCIsZero(fw.GetTombstoneAt()) {
+			return nil
+		}
+		return &leapmuxv1.EntityMaterialized{
+			Entity: &leapmuxv1.EntityMaterialized_FloatingWindow{FloatingWindow: cloneFloatingWindow(fw)},
+		}
+	default:
+		// EntityKindUnknown and EntityKindWorkspaceRoot have no
+		// EntityMaterialized variant.
+		return nil
+	}
+}
+
+// AffectedEntitiesToProto encodes a batch's AffectedEntities
+// (map[EntityRef]EntityWorkspaceTransition — the ValidateBatch result the live
+// broadcast consumes) as the storage-shaped BatchTransitions proto the journal
+// persists alongside the OpBatch. The encoding is one-for-one: exactly one
+// identity field (node_id / tab / window_id / workspace_id) is set per entry,
+// and its position implies the EntityKind TransitionsFromProto recovers.
+//
+// For Node / Tab / FloatingWindow entries whose workspace CHANGED (Pre != Post)
+// it also captures the entity's POST-batch record snapshot from `working`, so
+// the resume path's materialized frame reads the batch-era record instead of
+// CURRENT live state. Stable-visibility edits (Pre == Post) never produce a
+// materialized frame for any subscriber, so their records are omitted --
+// persisting them would bloat every in-place edit's journal row for no resume
+// consumer. A tombstoned record is omitted via liveRecordSnapshot: a tombstone
+// is projection-ignored client-side, and the live broadcast path uses the same
+// helper so both catch-up paths skip the shell together.
+//
+// Used by the commit path (Manager.commit) so the per-batch transitions
+// ValidateBatch already computes are written once and read back by resume,
+// making the two catch-up paths read the SAME data through the SAME predicates.
+func AffectedEntitiesToProto(m map[EntityRef]EntityWorkspaceTransition, working *leapmuxv1.UserCrdtState) *leapmuxv1.BatchTransitions {
+	out := &leapmuxv1.BatchTransitions{Entries: make([]*leapmuxv1.BatchTransition, 0, len(m))}
+	for ref, trans := range m {
+		entry := &leapmuxv1.BatchTransition{
+			PreWorkspace:  trans.Pre,
+			PostWorkspace: trans.Post,
+		}
+		switch ref.Kind {
+		case EntityKindNode:
+			entry.Identity = &leapmuxv1.BatchTransition_NodeId{NodeId: ref.NodeID}
+		case EntityKindTab:
+			entry.Identity = &leapmuxv1.BatchTransition_Tab{Tab: &leapmuxv1.TabIdent{TabType: ref.TabType, TabId: ref.TabID}}
+		case EntityKindFloatingWindow:
+			entry.Identity = &leapmuxv1.BatchTransition_WindowId{WindowId: ref.WindowID}
+		case EntityKindWorkspaceRoot:
+			entry.Identity = &leapmuxv1.BatchTransition_WorkspaceId{WorkspaceId: ref.WorkspaceID}
+			// No EntityMaterialized variant for WorkspaceRoot; no record snapshot.
+		default:
+			// EntityKindUnknown carries no identity and resolves to no
+			// workspace, so it has nothing to persist. Skip it rather
+			// than emit an entry whose kind TransitionsFromProto could
+			// not recover.
+			continue
+		}
+		// Record snapshots are only useful for becoming-visible materialize
+		// frames, which require a workspace change (Pre != Post). Capturing
+		// them for stable in-place edits would store full protos the resume
+		// path never reads.
+		if trans.Pre != trans.Post {
+			if snap := liveRecordSnapshot(working, ref); snap != nil {
+				switch e := snap.GetEntity().(type) {
+				case *leapmuxv1.EntityMaterialized_Node:
+					entry.Record = &leapmuxv1.BatchTransition_NodeRecord{NodeRecord: e.Node}
+				case *leapmuxv1.EntityMaterialized_Tab:
+					entry.Record = &leapmuxv1.BatchTransition_TabRecord{TabRecord: e.Tab}
+				case *leapmuxv1.EntityMaterialized_FloatingWindow:
+					entry.Record = &leapmuxv1.BatchTransition_FloatingWindowRecord{FloatingWindowRecord: e.FloatingWindow}
+				}
+			}
+		}
+		out.Entries = append(out.Entries, entry)
+	}
+	return out
+}
+
+// transitionEntryRef decodes one entry's identity oneof into the EntityRef it
+// names, reporting ok=false for an entry that names no entity (unset oneof, or
+// an empty identity string). The SINGLE definition of that mapping: both
+// TransitionsFromProto and MissingTransitionOp read it, so the "which ops does a
+// transitions_payload cover" question cannot be answered two different ways.
+func transitionEntryRef(e *leapmuxv1.BatchTransition) (EntityRef, bool) {
+	var ref EntityRef
+	switch id := e.GetIdentity().(type) {
+	case *leapmuxv1.BatchTransition_NodeId:
+		ref = EntityRef{Kind: EntityKindNode, NodeID: id.NodeId}
+	case *leapmuxv1.BatchTransition_Tab:
+		ref = EntityRef{Kind: EntityKindTab, TabType: id.Tab.GetTabType(), TabID: id.Tab.GetTabId()}
+	case *leapmuxv1.BatchTransition_WindowId:
+		ref = EntityRef{Kind: EntityKindFloatingWindow, WindowID: id.WindowId}
+	case *leapmuxv1.BatchTransition_WorkspaceId:
+		ref = EntityRef{Kind: EntityKindWorkspaceRoot, WorkspaceID: id.WorkspaceId}
+	default:
+		return EntityRef{}, false
+	}
+	// One rule for "names a real entity", shared with the submit-path validator
+	// via EntityRef.HasIdentity -- see its doc for why the two must agree.
+	if !ref.HasIdentity() {
+		return EntityRef{}, false
+	}
+	return ref, true
+}
+
+// MissingTransitionOp reports the first op in batch whose target names a real
+// entity that the persisted transitions do NOT cover, so a caller can treat the
+// row as corrupt.
+//
+// It exists because unmarshal success is not a completeness witness. proto3
+// fields are length-delimited and repeated, so a transitions_payload truncated
+// at an entry boundary -- or truncated to zero bytes, the degenerate case --
+// decodes cleanly into a BatchTransitions holding only the entries that
+// survived. Every op whose entry was lost then resolves to the zero transition
+// {Pre:"", Post:""}; IsAllowed("") is false on both sides, so filterVisibleOps
+// drops it, and if that accounts for the whole batch the subscriber receives
+// only BatchEnd -- which still advances its resume cursor past ops it never
+// got. That is indistinguishable, on the wire, from the batch never existing,
+// and no later resume re-requests it.
+//
+// Ops whose target is EntityKindUnknown carry no identity and are deliberately
+// absent from a well-formed payload (AffectedEntitiesToProto drops them for the
+// same reason), so they are not evidence of loss.
+func MissingTransitionOp(batch *leapmuxv1.OpBatch, p *leapmuxv1.BatchTransitions) (EntityRef, bool) {
+	covered := make(map[EntityRef]struct{}, len(p.GetEntries()))
+	for _, e := range p.GetEntries() {
+		if ref, ok := transitionEntryRef(e); ok {
+			covered[ref] = struct{}{}
+		}
+	}
+	for _, op := range batch.GetOps() {
+		ref := OpTarget(op)
+		if ref.Kind == EntityKindUnknown {
+			continue
+		}
+		if _, ok := covered[ref]; !ok {
+			return ref, true
+		}
+	}
+	return EntityRef{}, false
+}
+
+// TransitionsFromProto is the resume-side inverse of AffectedEntitiesToProto:
+// it rebuilds the per-batch transition map the resume path feeds into the SAME
+// orderedAffectedRefs / buildEntityRemovedEvent helpers the live broadcast
+// uses, plus each entry's captured post-batch record snapshot (in
+// `records`, keyed by EntityRef) so the materialized frame reads batch-era
+// state instead of cloning CURRENT live state. EntityKind is recovered from
+// WHICH identity oneof arm is set. An entry whose identity is empty / unset is
+// dropped (it cannot name an entity, and AffectedEntitiesToProto never emits
+// one).
+func TransitionsFromProto(p *leapmuxv1.BatchTransitions) (transitions map[EntityRef]EntityWorkspaceTransition, records map[EntityRef]*leapmuxv1.EntityMaterialized) {
+	if p == nil {
+		return map[EntityRef]EntityWorkspaceTransition{}, map[EntityRef]*leapmuxv1.EntityMaterialized{}
+	}
+	transitions = make(map[EntityRef]EntityWorkspaceTransition, len(p.GetEntries()))
+	records = make(map[EntityRef]*leapmuxv1.EntityMaterialized, len(p.GetEntries()))
+	for _, e := range p.GetEntries() {
+		ref, ok := transitionEntryRef(e)
+		if !ok {
+			continue
+		}
+		transitions[ref] = EntityWorkspaceTransition{Pre: e.GetPreWorkspace(), Post: e.GetPostWorkspace()}
+		// Recover the captured record snapshot into the EntityMaterialized
+		// payload the resume frame ships. Absent ⇒ no materialized frame
+		// (tombstoned, stable-visibility, or a kind with no materialized variant).
+		switch r := e.GetRecord().(type) {
+		case *leapmuxv1.BatchTransition_NodeRecord:
+			records[ref] = &leapmuxv1.EntityMaterialized{Entity: &leapmuxv1.EntityMaterialized_Node{Node: r.NodeRecord}}
+		case *leapmuxv1.BatchTransition_TabRecord:
+			records[ref] = &leapmuxv1.EntityMaterialized{Entity: &leapmuxv1.EntityMaterialized_Tab{Tab: r.TabRecord}}
+		case *leapmuxv1.BatchTransition_FloatingWindowRecord:
+			records[ref] = &leapmuxv1.EntityMaterialized{Entity: &leapmuxv1.EntityMaterialized_FloatingWindow{FloatingWindow: r.FloatingWindowRecord}}
+		}
+	}
+	return transitions, records
+}

--- a/backend/internal/hub/crdt/transitions_proto_test.go
+++ b/backend/internal/hub/crdt/transitions_proto_test.go
@@ -1,0 +1,284 @@
+package crdt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+)
+
+// TestAffectedEntitiesToProto_TransitionsFromProto_RoundTrip locks in the
+// storage encoding of AffectedEntities (the per-batch {pre, post} workspace
+// transitions ValidateBatch produces): every EntityKind round-trips through
+// AffectedEntitiesToProto → TransitionsFromProto with its identity fields and
+// workspaces intact, and the EntityKind is recovered from WHICH identity field
+// the encoder set (node_id / tab / window_id / workspace_id). This is the
+// load-bearing contract the resume path relies on to replay the same
+// transitions broadcast applies — a drift here would misclassify every entity
+// of the affected kind on resume.
+func TestAffectedEntitiesToProto_TransitionsFromProto_RoundTrip(t *testing.T) {
+	original := map[EntityRef]EntityWorkspaceTransition{
+		{Kind: EntityKindNode, NodeID: "n1"}:                                          {Pre: "wA", Post: "wB"},
+		{Kind: EntityKindTab, TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabID: "t1"}: {Pre: "", Post: "wA"},
+		{Kind: EntityKindFloatingWindow, WindowID: "fw1"}:                             {Pre: "wA", Post: ""},
+		{Kind: EntityKindWorkspaceRoot, WorkspaceID: "ws1"}:                           {Pre: "ws1", Post: "ws1"},
+	}
+
+	encoded := AffectedEntitiesToProto(original, &leapmuxv1.UserCrdtState{})
+	decoded, _ := TransitionsFromProto(encoded)
+
+	require.Len(t, decoded, len(original), "every entity must survive the round-trip")
+	for ref, trans := range original {
+		got, ok := decoded[ref]
+		require.True(t, ok, "entity %v must be present after round-trip", ref)
+		assert.Equal(t, trans, got, "transition for %v must match after round-trip", ref)
+	}
+}
+
+// TestAffectedEntitiesToProto_OmitsUnknownKind pins that EntityKindUnknown
+// (which carries no identity field) is dropped by the encoder rather than
+// emitted as an entry TransitionsFromProto could not recover a kind for.
+func TestAffectedEntitiesToProto_OmitsUnknownKind(t *testing.T) {
+	encoded := AffectedEntitiesToProto(map[EntityRef]EntityWorkspaceTransition{
+		{Kind: EntityKindUnknown}:              {Pre: "wA", Post: "wB"},
+		{Kind: EntityKindNode, NodeID: "kept"}: {Pre: "wA", Post: "wB"},
+	}, &leapmuxv1.UserCrdtState{})
+	assert.Len(t, encoded.GetEntries(), 1, "EntityKindUnknown must be dropped; only the Node entry survives")
+	assert.Equal(t, "kept", encoded.GetEntries()[0].GetNodeId())
+}
+
+// TestTransitionsFromProto_NilInputReturnsEmpty pins the nil-safety of the
+// decoder: a nil BatchTransitions (a journal row whose transitions were never
+// set, or an empty-map decode) yields empty maps, not a panic. The resume
+// path feeds the result into orderedAffectedRefs and workspace lookups, both
+// of which must handle the empty case gracefully.
+func TestTransitionsFromProto_NilInputReturnsEmpty(t *testing.T) {
+	trans, rec := TransitionsFromProto(nil)
+	assert.Empty(t, trans, "nil BatchTransitions must decode to an empty transition map")
+	assert.Empty(t, rec, "nil BatchTransitions must decode to an empty records map")
+	trans, rec = TransitionsFromProto(&leapmuxv1.BatchTransitions{})
+	assert.Empty(t, trans, "empty BatchTransitions must decode to an empty transition map")
+	assert.Empty(t, rec, "empty BatchTransitions must decode to an empty records map")
+}
+
+// TestTransitionsFromProto_DropsEntryWithNoIdentityField pins the decoder's
+// defensive drop: an entry whose identity fields are all empty cannot name an
+// entity, so it is skipped rather than decoded into an EntityKindUnknown ref
+// that no downstream classification would match.
+func TestTransitionsFromProto_DropsEntryWithNoIdentityField(t *testing.T) {
+	decoded, _ := TransitionsFromProto(&leapmuxv1.BatchTransitions{
+		Entries: []*leapmuxv1.BatchTransition{
+			{PreWorkspace: "wA", PostWorkspace: "wB"}, // no identity oneof arm
+			{Identity: &leapmuxv1.BatchTransition_NodeId{NodeId: "n1"}, PreWorkspace: "wA", PostWorkspace: "wB"},
+		},
+	})
+	assert.Len(t, decoded, 1, "the identity-less entry must be dropped")
+	_, hasN1 := decoded[EntityRef{Kind: EntityKindNode, NodeID: "n1"}]
+	assert.True(t, hasN1, "the valid Node entry must survive")
+}
+
+// TestAffectedEntitiesToProto_CapturesRecordSnapshot pins that the encoder
+// captures each non-tombstoned Node/Tab/FloatingWindow entity's POST-batch
+// record from `working` into the entry's `record` oneof, and that
+// TransitionsFromProto recovers it as the EntityMaterialized payload the
+// resume materialized frame ships. This is the load-bearing contract that lets
+// resume read batch-era state instead of cloning current live state.
+func TestAffectedEntitiesToProto_CapturesRecordSnapshot(t *testing.T) {
+	working := &leapmuxv1.UserCrdtState{
+		Nodes: map[string]*leapmuxv1.NodeRecord{
+			"n1": {NodeId: "n1"},
+		},
+		Tabs: map[string]*leapmuxv1.TabRecord{
+			"t1": {TabId: "t1", TabType: leapmuxv1.TabType_TAB_TYPE_AGENT},
+		},
+	}
+
+	encoded := AffectedEntitiesToProto(map[EntityRef]EntityWorkspaceTransition{
+		{Kind: EntityKindNode, NodeID: "n1"}:                                          {Pre: "wA", Post: "wB"},
+		{Kind: EntityKindTab, TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabID: "t1"}: {Pre: "", Post: "wA"},
+		// WorkspaceRoot has no EntityMaterialized variant → no record snapshot.
+		{Kind: EntityKindWorkspaceRoot, WorkspaceID: "ws1"}: {Pre: "ws1", Post: "ws1"},
+	}, working)
+
+	_, records := TransitionsFromProto(encoded)
+
+	n1Rec, ok := records[EntityRef{Kind: EntityKindNode, NodeID: "n1"}]
+	require.True(t, ok, "the Node record snapshot must be recovered")
+	require.NotNil(t, n1Rec.GetNode(), "the recovered snapshot must carry the NodeRecord")
+	assert.Equal(t, "n1", n1Rec.GetNode().GetNodeId())
+
+	t1Rec, ok := records[EntityRef{Kind: EntityKindTab, TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabID: "t1"}]
+	require.True(t, ok, "the Tab record snapshot must be recovered")
+	require.NotNil(t, t1Rec.GetTab(), "the recovered snapshot must carry the TabRecord")
+	assert.Equal(t, "t1", t1Rec.GetTab().GetTabId())
+
+	_, hasWS := records[EntityRef{Kind: EntityKindWorkspaceRoot, WorkspaceID: "ws1"}]
+	assert.False(t, hasWS, "WorkspaceRoot must have no record snapshot (no EntityMaterialized variant)")
+}
+
+// TestAffectedEntitiesToProto_CapturesFloatingWindowRecordSnapshot extends the
+// Node/Tab coverage to FloatingWindow: the encode/decode switches are hand-
+// written inverses over EntityKind, and the FloatingWindow record-snapshot arm
+// (encode transitions_proto.go, decode :162-164) was not previously exercised
+// end-to-end. A drift here would silently drop the materialized frame for a
+// floating window that crossed into visibility during a disconnect gap.
+func TestAffectedEntitiesToProto_CapturesFloatingWindowRecordSnapshot(t *testing.T) {
+	working := &leapmuxv1.UserCrdtState{
+		FloatingWindows: map[string]*leapmuxv1.FloatingWindowRecord{
+			"fw1": {WindowId: "fw1", WorkspaceId: &leapmuxv1.LWWString{Value: "wA", Hlc: &leapmuxv1.HLC{Physical: 1, Logical: 0, ClientId: "c"}}},
+		},
+	}
+
+	encoded := AffectedEntitiesToProto(map[EntityRef]EntityWorkspaceTransition{
+		{Kind: EntityKindFloatingWindow, WindowID: "fw1"}: {Pre: "", Post: "wA"},
+	}, working)
+
+	_, records := TransitionsFromProto(encoded)
+
+	fwRec, ok := records[EntityRef{Kind: EntityKindFloatingWindow, WindowID: "fw1"}]
+	require.True(t, ok, "the FloatingWindow record snapshot must be recovered")
+	require.NotNil(t, fwRec.GetFloatingWindow(), "the recovered snapshot must carry the FloatingWindowRecord")
+	assert.Equal(t, "fw1", fwRec.GetFloatingWindow().GetWindowId())
+}
+
+// TestAffectedEntitiesToProto_OmitsTombstonedRecordSnapshot pins that a
+// tombstoned record is NOT captured into the snapshot: a tombstone is
+// projection-ignored client-side, and liveRecordSnapshot (shared with
+// buildEntityMaterializedEvent) returns nil for it, so both catch-up paths
+// skip the shell together. The transition is still recorded (so the resume
+// classifies visibility correctly); only the record snapshot is omitted.
+func TestAffectedEntitiesToProto_OmitsTombstonedRecordSnapshot(t *testing.T) {
+	working := &leapmuxv1.UserCrdtState{
+		Nodes: map[string]*leapmuxv1.NodeRecord{
+			"dead": {NodeId: "dead", TombstoneAt: &leapmuxv1.HLC{Physical: 1, Logical: 0, ClientId: "c"}},
+		},
+	}
+
+	// Pre != Post so the encoder considers a record snapshot; the tombstone
+	// check must still omit it.
+	encoded := AffectedEntitiesToProto(map[EntityRef]EntityWorkspaceTransition{
+		{Kind: EntityKindNode, NodeID: "dead"}: {Pre: "wA", Post: "wB"},
+	}, working)
+
+	require.Len(t, encoded.GetEntries(), 1, "the transition must still be recorded")
+	assert.Nil(t, encoded.GetEntries()[0].GetRecord(), "a tombstoned record must have no snapshot (projection-ignored)")
+
+	_, records := TransitionsFromProto(encoded)
+	_, hasDead := records[EntityRef{Kind: EntityKindNode, NodeID: "dead"}]
+	assert.False(t, hasDead, "a tombstoned entity must yield no materialized-frame record")
+}
+
+// TestAffectedEntitiesToProto_OmitsStableVisibilityRecordSnapshot pins that
+// Pre == Post (in-place edit) entries do not capture a record snapshot —
+// stable-visibility batches never emit a materialized frame for any
+// subscriber, so persisting the full proto would be pure journal bloat.
+func TestAffectedEntitiesToProto_OmitsStableVisibilityRecordSnapshot(t *testing.T) {
+	working := &leapmuxv1.UserCrdtState{
+		Nodes: map[string]*leapmuxv1.NodeRecord{
+			"n1": {NodeId: "n1"},
+		},
+	}
+	encoded := AffectedEntitiesToProto(map[EntityRef]EntityWorkspaceTransition{
+		{Kind: EntityKindNode, NodeID: "n1"}: {Pre: "wA", Post: "wA"},
+	}, working)
+	require.Len(t, encoded.GetEntries(), 1)
+	assert.Nil(t, encoded.GetEntries()[0].GetRecord(), "stable-visibility edits must not persist a record snapshot")
+}
+
+// TestTransitionsFromProto_DropsEmptyTabIdentity pins that a TabIdent with an
+// empty tab_id is dropped the same way an empty node_id is (cannot name an
+// entity).
+func TestTransitionsFromProto_DropsEmptyTabIdentity(t *testing.T) {
+	decoded, _ := TransitionsFromProto(&leapmuxv1.BatchTransitions{
+		Entries: []*leapmuxv1.BatchTransition{
+			{Identity: &leapmuxv1.BatchTransition_Tab{Tab: &leapmuxv1.TabIdent{TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: ""}}, PreWorkspace: "wA", PostWorkspace: "wB"},
+			{Identity: &leapmuxv1.BatchTransition_NodeId{NodeId: "n1"}, PreWorkspace: "wA", PostWorkspace: "wB"},
+		},
+	})
+	assert.Len(t, decoded, 1, "empty tab_id entry must be dropped")
+	_, hasN1 := decoded[EntityRef{Kind: EntityKindNode, NodeID: "n1"}]
+	assert.True(t, hasN1)
+}
+
+// TestLiveRecordSnapshot_OmitsTombstone pins that buildEntityMaterializedEvent
+// (via liveRecordSnapshot) returns nil for a tombstoned record — matching the
+// commit-time encoder so resume/live cannot diverge on become-visible+tombstone.
+func TestLiveRecordSnapshot_OmitsTombstone(t *testing.T) {
+	state := &leapmuxv1.UserCrdtState{
+		Nodes: map[string]*leapmuxv1.NodeRecord{
+			"dead": {NodeId: "dead", TombstoneAt: &leapmuxv1.HLC{Physical: 1, Logical: 0, ClientId: "c"}},
+			"live": {NodeId: "live"},
+		},
+	}
+	assert.Nil(t, buildEntityMaterializedEvent(state, EntityRef{Kind: EntityKindNode, NodeID: "dead"}, &leapmuxv1.HLC{Physical: 2}))
+	assert.NotNil(t, buildEntityMaterializedEvent(state, EntityRef{Kind: EntityKindNode, NodeID: "live"}, &leapmuxv1.HLC{Physical: 2}))
+}
+
+// TestMissingTransitionOp_CoversTheBatchsResolvableOps pins the completeness
+// witness directly. The journal-level cases exercise it through the resume
+// scan; these fix the rule itself, including the two ways an op is legitimately
+// absent from a well-formed payload.
+func TestMissingTransitionOp_CoversTheBatchsResolvableOps(t *testing.T) {
+	nodeOp := func(id string) *leapmuxv1.CrdtOp {
+		return &leapmuxv1.CrdtOp{Body: &leapmuxv1.CrdtOp_SetNodeRegister{SetNodeRegister: &leapmuxv1.SetNodeRegisterOp{
+			NodeId: id,
+			Field:  &leapmuxv1.SetNodeRegisterOp_Position{Position: "p"},
+		}}}
+	}
+	entryFor := func(id string) *leapmuxv1.BatchTransition {
+		return &leapmuxv1.BatchTransition{
+			Identity:      &leapmuxv1.BatchTransition_NodeId{NodeId: id},
+			PreWorkspace:  "w1",
+			PostWorkspace: "w1",
+		}
+	}
+
+	t.Run("covered batch reports nothing missing", func(t *testing.T) {
+		batch := &leapmuxv1.OpBatch{Ops: []*leapmuxv1.CrdtOp{nodeOp("n1"), nodeOp("n2")}}
+		transitions := &leapmuxv1.BatchTransitions{Entries: []*leapmuxv1.BatchTransition{entryFor("n1"), entryFor("n2")}}
+		_, missing := MissingTransitionOp(batch, transitions)
+		assert.False(t, missing)
+	})
+
+	t.Run("names the first uncovered op", func(t *testing.T) {
+		batch := &leapmuxv1.OpBatch{Ops: []*leapmuxv1.CrdtOp{nodeOp("n1"), nodeOp("n2")}}
+		transitions := &leapmuxv1.BatchTransitions{Entries: []*leapmuxv1.BatchTransition{entryFor("n1")}}
+		ref, missing := MissingTransitionOp(batch, transitions)
+		require.True(t, missing)
+		assert.Equal(t, EntityRef{Kind: EntityKindNode, NodeID: "n2"}, ref)
+	})
+
+	t.Run("an empty payload against a resolvable batch is missing", func(t *testing.T) {
+		// The degenerate truncation: a payload cut to zero bytes decodes
+		// cleanly into an empty message, which the unmarshal guard cannot see.
+		batch := &leapmuxv1.OpBatch{Ops: []*leapmuxv1.CrdtOp{nodeOp("n1")}}
+		_, missing := MissingTransitionOp(batch, &leapmuxv1.BatchTransitions{})
+		assert.True(t, missing)
+	})
+
+	t.Run("an op with no body is not evidence of loss", func(t *testing.T) {
+		// OpTarget yields EntityKindUnknown for an unset oneof, and
+		// AffectedEntitiesToProto deliberately drops those, so a well-formed
+		// payload has no entry for them either. Treating that as corruption
+		// would FALLBACK every resume whose tail contains one.
+		batch := &leapmuxv1.OpBatch{Ops: []*leapmuxv1.CrdtOp{{OpId: "bodyless"}}}
+		_, missing := MissingTransitionOp(batch, &leapmuxv1.BatchTransitions{})
+		assert.False(t, missing)
+	})
+
+	t.Run("an entry whose identity is empty covers nothing", func(t *testing.T) {
+		batch := &leapmuxv1.OpBatch{Ops: []*leapmuxv1.CrdtOp{nodeOp("n1")}}
+		transitions := &leapmuxv1.BatchTransitions{Entries: []*leapmuxv1.BatchTransition{
+			{Identity: &leapmuxv1.BatchTransition_NodeId{NodeId: ""}},
+		}}
+		_, missing := MissingTransitionOp(batch, transitions)
+		assert.True(t, missing)
+	})
+
+	t.Run("an empty batch is trivially covered", func(t *testing.T) {
+		_, missing := MissingTransitionOp(&leapmuxv1.OpBatch{}, &leapmuxv1.BatchTransitions{})
+		assert.False(t, missing)
+	})
+}

--- a/backend/internal/hub/crdt/validate.go
+++ b/backend/internal/hub/crdt/validate.go
@@ -63,6 +63,27 @@ func ValidateBatch(
 		auth = &memoAuthChecker{inner: auth}
 	}
 
+	// 0. Every op must NAME something. Nothing downstream tolerates a target
+	//    with an empty id: OpTarget happily returns EntityRef{Kind: Node,
+	//    NodeID: ""}, the completeness check reports an offending entity id as
+	//    its failure signal (so an empty one reads as "no failure"), and the
+	//    batch then commits and broadcasts normally. The damage surfaces much
+	//    later and far away -- AffectedEntitiesToProto writes the empty identity
+	//    into transitions_payload, transitionEntryRef refuses to decode it,
+	//    MissingTransitionOp therefore reports the op as uncovered, and EVERY
+	//    subsequent resume for that user fails with ErrResumeCorrupt and logs a
+	//    corrupt journal row. One such batch disables delta-resume for the whole
+	//    retention window and makes each reconnect pay the full projection scan
+	//    #267 exists to remove, while blaming storage for an ordinary bad op.
+	//    Rejecting here keeps the encode/decode round-trip total by construction.
+	for _, op := range batch {
+		if !OpTarget(op).HasIdentity() {
+			result.Reason = leapmuxv1.BatchRejectionReason_BATCH_REJECTION_VALUE_DOMAIN
+			result.OffendingOpID = op.GetOpId()
+			return result, nil
+		}
+	}
+
 	// 1. Pre-apply tombstone check. Walking once over `pre` is enough
 	//    because creation-order ops within the batch can't observe
 	//    pre-batch tombstones; the validator's "set on tombstoned

--- a/backend/internal/hub/crdt/validate_test.go
+++ b/backend/internal/hub/crdt/validate_test.go
@@ -278,6 +278,48 @@ func TestValidate_ValueDomain_OpacityOutOfRange(t *testing.T) {
 	assert.Equal(t, leapmuxv1.BatchRejectionReason_BATCH_REJECTION_VALUE_DOMAIN, res.Reason)
 }
 
+// An op whose target carries an EMPTY id must be rejected at submit time.
+//
+// Nothing downstream tolerates one, and nothing used to catch it: OpTarget
+// returns EntityRef{Kind: Node, NodeID: ""} without complaint, and the
+// completeness check signals failure by RETURNING the offending entity id, so an
+// empty id read as success. The batch committed and broadcast normally; the
+// damage appeared later and elsewhere, when AffectedEntitiesToProto wrote the
+// empty identity into transitions_payload, transitionEntryRef refused to decode
+// it, and MissingTransitionOp reported the op as uncovered -- so every
+// subsequent resume for that user failed with ErrResumeCorrupt and logged a
+// corrupt journal row, blaming storage for an ordinary bad op. One such batch
+// disabled delta-resume for the entire retention window.
+func TestValidate_ValueDomain_EmptyTargetID(t *testing.T) {
+	pre := seedWorkspaceWithRoot("w1", "root1")
+	for _, tc := range []struct {
+		name string
+		op   *leapmuxv1.CrdtOp
+	}{
+		{"node", stamped(&leapmuxv1.SetNodeRegisterOp{
+			NodeId: "",
+			Field:  &leapmuxv1.SetNodeRegisterOp_ParentId{ParentId: "root1"},
+		}, hlcAt(10, 0, "a"))},
+		{"tab", stamped(&leapmuxv1.SetTabRegisterOp{
+			TabType: leapmuxv1.TabType_TAB_TYPE_TERMINAL,
+			TabId:   "",
+			Field:   &leapmuxv1.SetTabRegisterOp_TileId{TileId: "root1"},
+		}, hlcAt(10, 1, "a"))},
+		{"floating window", stamped(&leapmuxv1.SetFloatingWindowRegisterOp{
+			WindowId: "",
+			Field:    &leapmuxv1.SetFloatingWindowRegisterOp_Opacity{Opacity: 0.5},
+		}, hlcAt(10, 2, "a"))},
+		{"tombstone node", stamped(&leapmuxv1.TombstoneNodeOp{NodeId: ""}, hlcAt(10, 3, "a"))},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			res, _ := crdt.ValidateBatch(context.Background(), pre, []*leapmuxv1.CrdtOp{tc.op}, true, "p1", allowAll{})
+			assert.Equal(t, leapmuxv1.BatchRejectionReason_BATCH_REJECTION_VALUE_DOMAIN, res.Reason,
+				"an unnamed target must be refused at submit, not surface as a corrupt journal row on every later resume")
+			assert.Equal(t, tc.op.GetOpId(), res.OffendingOpID)
+		})
+	}
+}
+
 // TestValidate_WorkerRef_AcceptsAccessibleWorker proves the happy
 // path: a SetTabRegister(worker_id=X) where the principal can use X
 // commits without trouble. Pairs with the rejection test below so

--- a/backend/internal/hub/oauth/oidc_test.go
+++ b/backend/internal/hub/oauth/oidc_test.go
@@ -357,10 +357,20 @@ func TestOIDC_Exchange_HonoursContextDeadline(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 
-	start := time.Now()
-	_, _, err = p.Exchange(ctx, "any-code", "any-verifier")
-
-	require.Error(t, err, "a token endpoint that never answers must surface as an error, not a hang")
-	assert.Less(t, time.Since(start), 5*time.Second,
-		"Exchange must give up on the caller's deadline; without that the callback handler holds the shutdown drain open")
+	// Exchange must give up on the caller's 200ms deadline; without that the
+	// callback handler holds the shutdown drain open against a token endpoint
+	// that never answers. Asserted as a completion against a generous guard
+	// rather than a 5s budget: the endpoint here NEVER responds, so the failing
+	// case is a hang, and a guard reports that directly.
+	exchanged := make(chan error, 1)
+	go func() {
+		_, _, exErr := p.Exchange(ctx, "any-code", "any-verifier")
+		exchanged <- exErr
+	}()
+	select {
+	case err = <-exchanged:
+		require.Error(t, err, "a token endpoint that never answers must surface as an error, not a hang")
+	case <-time.After(30 * time.Second):
+		t.Fatal("Exchange ignored the caller's deadline and hung on the wedged token endpoint")
+	}
 }

--- a/backend/internal/hub/service/crdt_journal.go
+++ b/backend/internal/hub/service/crdt_journal.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
@@ -81,20 +82,187 @@ func (j *crdtJournal) LoadState(ctx context.Context, userID string) (*leapmuxv1.
 	if state != nil {
 		watermark = state.GetCompactionWatermark()
 	}
-	tail, err := j.listBatchesAfter(ctx, owner, watermark)
+	// The boot policy (no budgets, no transitions, corrupt = fatal) is named by
+	// scanForBoot rather than spelled as trailing booleans here; see its doc and
+	// journalScan for why each half is what it is.
+	tail, err := j.scanForBoot(ctx, owner, watermark)
 	if err != nil {
 		return nil, nil, err
 	}
-	return state, tail, nil
+	batches := make([]*leapmuxv1.OpBatch, len(tail))
+	for i, rb := range tail {
+		batches[i] = rb.Batch
+	}
+	return state, batches, nil
 }
 
-func (j *crdtJournal) listBatchesAfter(ctx context.Context, owner userid.UserID, watermark *leapmuxv1.HLC) ([]*leapmuxv1.OpBatch, error) {
-	// Page through the journal so a far-behind subscriber cannot load
-	// the entire backlog in one slab. The cursor walks forward by the
-	// last consumed batch's HLC; we stop once a page comes back
-	// short of the limit.
-	out := []*leapmuxv1.OpBatch{}
-	cur := watermark
+// ListBatchesAfter is the resume entry point: it mints the tenant and delegates
+// to the shared paged scan with the caller's maxOps/maxBytes budgets and the
+// optional register-time until high-water. maxOps or maxBytes <= 0 means that
+// ceiling is disabled; until nil means unbounded (LoadState). Each ResumeBatch
+// pairs the batch with its persisted transitions so buildResumeDelta can
+// replay them. A corrupt row stops the scan and returns crdt.ErrResumeCorrupt
+// plus the CorruptRow list for logging; the caller FALLBACKs to a full snapshot
+// (see scan's `recoverable` contract).
+func (j *crdtJournal) ListBatchesAfter(ctx context.Context, userID string, after, until *leapmuxv1.HLC, maxOps, maxBytes int) ([]crdt.ResumeBatch, []crdt.CorruptRow, error) {
+	owner, err := mintTenant(userID)
+	if err != nil {
+		return nil, nil, err
+	}
+	return j.scanForResume(ctx, owner, after, until, maxOps, maxBytes)
+}
+
+// wrapCorruptRow wraps a per-row decode failure (batch_payload or
+// transitions_payload) in the sentinel that matches THIS scan's verdict:
+// crdt.ErrResumeCorrupt when the caller can fall back to a full snapshot,
+// crdt.ErrBootJournalCorrupt when it cannot.
+//
+// The sentinel is the verdict, so it has to follow `recoverable` rather than
+// being fixed at the wrap site. buildResumeDelta resolves ErrResumeCorrupt via
+// errors.Is to route a corrupt row to FALLBACK instead of failing the
+// connection, so the `%w` verb is load-bearing: `%v` / `%s` would make
+// errors.Is return false and fail the connect outright. Handing that same
+// sentinel to the boot path labelled a FATAL error as recoverable — see
+// crdt.ErrBootJournalCorrupt.
+//
+// Centralized so both decode sites share one wrap form and the errors.Is
+// contract has one home (and one test).
+func wrapCorruptRow(recoverable bool, what, batchID string, cause error) error {
+	sentinel := crdt.ErrBootJournalCorrupt
+	if recoverable {
+		sentinel = crdt.ErrResumeCorrupt
+	}
+	return fmt.Errorf("%w: %s %s: %v", sentinel, what, batchID, cause)
+}
+
+// journalScan names one paged scan's parameters.
+//
+// A struct rather than eight positionals because the last two were BOOLEANS OF
+// THE SAME TYPE encoding two unrelated policies -- `j.listBatchesAfter(ctx,
+// owner, watermark, nil, 0, 0, false, false)` said nothing at the call site
+// about which corruption policy it had picked, and transposing them silently
+// swapped "fatal at boot" for "recoverable at resume". The same reasoning
+// already produced crdt.resumeRequest one layer up.
+type journalScan struct {
+	owner userid.UserID
+	// cursor is the exclusive lower bound; nil scans from the beginning.
+	cursor *leapmuxv1.HLC
+	// until is the register-time high-water bound; nil is unbounded.
+	until *leapmuxv1.HLC
+	// maxOps / maxBytes cap the scan. <= 0 disables that ceiling.
+	maxOps, maxBytes int
+	// mode names WHICH scan this is, and both per-policy answers derive from it.
+	//
+	// It replaces a `decodeTransitions bool` + `recoverable bool` pair whose
+	// product had four states and only two legal ones. That pair was introduced
+	// to stop two same-typed booleans being transposed positionally -- but a
+	// struct only stops the transposition at the CALL SITE; it still let an
+	// illegal combination be constructed, and one already was: a test built
+	// `{decodeTransitions: true}` (leaving recoverable false), and the
+	// transitions arms of `scan` return crdt.ErrResumeCorrupt ignoring
+	// `recoverable` entirely -- so that fourth state's behaviour contradicted the
+	// field's own documentation. One enum makes both illegal pairings
+	// unrepresentable instead of merely unconstructed.
+	mode scanMode
+}
+
+// scanMode is which of the two journal scans is running. Both answers a scan
+// needs -- whether to decode transitions, and what a corrupt row means -- are
+// properties OF the scan, so they are derived here rather than passed
+// independently.
+type scanMode int
+
+const (
+	// scanBoot rebuilds state by replaying ops (Bootstrap). No budgets, no
+	// transitions, and a corrupt row is fatal: there is no snapshot to fall back
+	// to, because the snapshot is what this scan is building.
+	scanBoot scanMode = iota
+	// scanResume reads a post-cursor tail for a delta-resume. Budgets apply,
+	// transitions are decoded (only resume consumes them), and a corrupt row
+	// degrades that one catch-up to a full snapshot rather than aborting the
+	// reconnect.
+	scanResume
+)
+
+// decodesTransitions reports whether this scan unmarshals transitions_payload.
+// Only the resume path consumes transitions, so boot skips the work.
+func (m scanMode) decodesTransitions() bool { return m == scanResume }
+
+// corruptRecoverable reports what a per-row decode failure MEANS to the caller.
+// BOTH modes stop the scan at the bad row -- nothing is skipped and nothing is
+// quarantined; they differ only in what the caller can do next.
+func (m scanMode) corruptRecoverable() bool { return m == scanResume }
+
+// scanForBoot reads the whole post-watermark tail for Bootstrap: no budgets, no
+// transitions, and a corrupt row is FATAL because Bootstrap rebuilds state by
+// replaying these ops and has nothing to fall back to.
+func (j *crdtJournal) scanForBoot(ctx context.Context, owner userid.UserID, watermark *leapmuxv1.HLC) ([]crdt.ResumeBatch, error) {
+	tail, _, err := j.scan(ctx, journalScan{owner: owner, cursor: watermark, mode: scanBoot})
+	return tail, err
+}
+
+// scanForResume reads the post-cursor tail for a delta-resume: budgets apply,
+// transitions are decoded (only resume consumes them), and a corrupt row
+// degrades one batch's catch-up rather than aborting the reconnect.
+func (j *crdtJournal) scanForResume(ctx context.Context, owner userid.UserID, after, until *leapmuxv1.HLC, maxOps, maxBytes int) ([]crdt.ResumeBatch, []crdt.CorruptRow, error) {
+	return j.scan(ctx, journalScan{
+		owner: owner, cursor: after, until: until,
+		maxOps: maxOps, maxBytes: maxBytes,
+		mode: scanResume,
+	})
+}
+
+// logCorruptBootRow reports a boot-fatal journal row at ERROR with everything
+// an operator needs to act, because nothing in the system can clear it on its
+// own.
+//
+// The row is above compaction_physical_ms, so the retention sweep's join
+// excludes it by construction, and DeleteThrough needs a manager this user
+// cannot bootstrap. Without this line the only symptom is an HTTP 500 on
+// /ws/userevents and a failing SubmitOps, repeating forever with no indication
+// of which row or which user.
+func (p journalScan) logCorruptBootRow(batchID, field string, cause error) {
+	slog.Error("crdt boot journal row is corrupt; this user cannot bootstrap until the row is removed",
+		"user_id", p.owner.String(),
+		"batch_id", batchID,
+		"field", field,
+		"err", cause,
+		"remedy", "delete the named user_op_batches row after capturing it for diagnosis")
+}
+
+// scan pages through the journal forward by HLC tuple, starting strictly after
+// `p.cursor`. p.until, when non-nil, stops the scan once a row's first-op HLC is
+// > until (register-time high-water). p.maxOps / p.maxBytes <= 0 disables that
+// budget; otherwise the scan aborts with ErrDeltaTooLarge as soon as the
+// accumulated op count OR payload bytes would exceed it.
+// scanBoot skips the Unmarshal of transitions_payload entirely.
+//
+// p.mode.corruptRecoverable() governs what a per-row decode failure means to the caller.
+// Either way the scan STOPS at the bad row -- a delta that silently omits a
+// committed batch is the one outcome neither caller can tolerate, because the
+// frames after it would still advance the client's watermark past the hole and
+// no later resume would ever re-request it.
+//
+//   - scanResume: return the rows read so far, the CorruptRow
+//     list (for logging), and crdt.ErrResumeCorrupt. buildResumeDelta treats
+//     that exactly like ErrDeltaTooLarge and FALLBACKs to a full snapshot,
+//     which is always complete.
+//   - scanBoot: fatal. Bootstrap replays ops to rebuild state,
+//     so there is no snapshot to fall back to.
+//
+// This applies to a corrupt transitions_payload too, NOT just batch_payload:
+// empty transitions make visibilityFor see {Pre:"", Post:""} for every op, so
+// filterVisibleOps drops the entire batch and emitCatchUpFrames emits nothing
+// for it -- indistinguishable, on the wire, from the batch never having existed.
+func (j *crdtJournal) scan(ctx context.Context, p journalScan) ([]crdt.ResumeBatch, []crdt.CorruptRow, error) {
+	owner, cursor, until := p.owner, p.cursor, p.until
+	maxOps, maxBytes := p.maxOps, p.maxBytes
+	decodeTransitions, recoverable := p.mode.decodesTransitions(), p.mode.corruptRecoverable()
+	out := []crdt.ResumeBatch{}
+	var corrupt []crdt.CorruptRow
+	ops := 0
+	bytes := 0
+	cur := cursor
 	for {
 		rows, err := j.store.UserOpBatches().ListAfter(ctx, store.ListUserOpBatchesAfterParams{
 			UserID:            owner,
@@ -104,17 +272,149 @@ func (j *crdtJournal) listBatchesAfter(ctx context.Context, owner userid.UserID,
 			Limit:             store.CRDTBatchPageLimit,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("list user_op_batches after watermark: %w", err)
+			return nil, nil, fmt.Errorf("list user_op_batches after watermark: %w", err)
 		}
 		if len(rows) == 0 {
 			break
 		}
 		for _, r := range rows {
+			rowHLC := &leapmuxv1.HLC{
+				Physical: r.PhysicalMs,
+				Logical:  r.Logical,
+				ClientId: r.OriginClient,
+			}
+			// Register-time high-water: batches with first-op HLC > until were
+			// committed after the subscriber registered and are delivered via
+			// live broadcast — do not also ship them in the delta.
+			if until != nil && crdt.HLCCmp(rowHLC, until) > 0 {
+				return out, corrupt, nil
+			}
+			rowBytes := len(r.BatchPayload) + len(r.TransitionsPayload)
+			if maxBytes > 0 && bytes+rowBytes > maxBytes {
+				return out, corrupt, crdt.ErrDeltaTooLarge
+			}
 			batch := &leapmuxv1.OpBatch{}
 			if uerr := proto.Unmarshal(r.BatchPayload, batch); uerr != nil {
-				return nil, fmt.Errorf("unmarshal user_op_batch %s: %w", r.BatchID, uerr)
+				corruptCause := wrapCorruptRow(p.mode.corruptRecoverable(), "unmarshal user_op_batch", r.BatchID, uerr)
+				if !recoverable {
+					// Boot path: fatal — Bootstrap replays ops, so skipping a
+					// batch would rebuild a diverged state and there is no
+					// snapshot to fall back to. See logCorruptBootRow for why
+					// this is unrecoverable WITHOUT operator action.
+					p.logCorruptBootRow(r.BatchID, "batch_payload", corruptCause)
+					return nil, nil, corruptCause
+				}
+				// Resume path: STOP and signal FALLBACK. Continuing past the row
+				// would ship a delta missing this batch entirely while later
+				// batches still advance the client's max_hlc past it — the
+				// client would persist a watermark above ops it never received
+				// and never re-request them.
+				corrupt = append(corrupt, crdt.CorruptRow{
+					BatchID: r.BatchID,
+					Field:   "batch_payload",
+					Cause:   corruptCause,
+				})
+				return out, corrupt, crdt.ErrResumeCorrupt
 			}
-			out = append(out, batch)
+			// Decoding cleanly is not a completeness witness. A batch_payload
+			// truncated at a repeated-`ops` element boundary -- including to
+			// zero bytes -- unmarshals WITHOUT error into a short OpBatch, and
+			// nothing downstream can tell that from a batch that legitimately
+			// carried fewer ops: filterVisibleOps just emits the survivors, and
+			// the BatchEnd still advances the client past the whole row, which
+			// ListAfter's strictly-greater cursor then guarantees is never
+			// re-sent. op_count is the independent witness that closes it --
+			// written from len(ops) at commit and DB-constrained > 0 -- and this
+			// is the batch_payload half of the same gate MissingTransitionOp
+			// applies to transitions_payload below.
+			//
+			// TWO PER-COLUMN WITNESSES, NOT ONE ROW DIGEST -- a deliberate
+			// choice, so it does not get re-litigated. A commit-time hash over
+			// the marshalled bytes would cover every payload column at once and
+			// also catch count-PRESERVING corruption, which neither witness
+			// does. It was weighed and declined: it costs a column across
+			// sqlite/postgres/mysql plus sqlc and the shared store suite, and
+			// per-row hashing on the very resume read path #267 exists to speed
+			// up -- to catch bit-rot inside a decoded field, which is what the
+			// database's own page checksums are for. It also would NOT replace
+			// MissingTransitionOp, since a commit-time incompleteness hashes
+			// clean. Revisit only if real corruption is ever observed that these
+			// two miss.
+			nOps := len(batch.GetOps())
+			if r.OpCount != int64(nOps) {
+				corruptCause := wrapCorruptRow(p.mode.corruptRecoverable(), "incomplete batch_payload", r.BatchID,
+					fmt.Errorf("op_count=%d but batch_payload decoded %d ops", r.OpCount, nOps))
+				if !recoverable {
+					// Boot path: fatal, for the same reason a failed unmarshal
+					// is. Bootstrap replays these ops into the authoritative
+					// state and the next maybeCompact persists the result, so a
+					// short batch would bake the divergence in permanently.
+					//
+					// And fatal here is PERMANENT, not transient: this row sits
+					// strictly ABOVE compaction_physical_ms, which is exactly
+					// what the retention sweep refuses to delete below, and the
+					// only other delete needs a bootstrapped manager -- which is
+					// what cannot start. So every reconnect and every SubmitOps
+					// for this user fails identically until an operator removes
+					// the row. Nothing here can self-heal it (skipping would be
+					// the silent divergence the gate exists to catch), so the
+					// least this owes is a log that names the row and says so.
+					p.logCorruptBootRow(r.BatchID, "batch_payload", corruptCause)
+					return nil, nil, corruptCause
+				}
+				corrupt = append(corrupt, crdt.CorruptRow{
+					BatchID: r.BatchID,
+					Field:   "batch_payload",
+					Cause:   corruptCause,
+				})
+				return out, corrupt, crdt.ErrResumeCorrupt
+			}
+			// Budget against the decoded op count, not the stored OpCount
+			// column: the two are now known equal, and keeping the budget on
+			// what was actually decoded keeps it honest if this gate ever moves.
+			if maxOps > 0 && ops+nOps > maxOps {
+				return out, corrupt, crdt.ErrDeltaTooLarge
+			}
+			transitions := &leapmuxv1.BatchTransitions{}
+			if decodeTransitions {
+				if uerr := proto.Unmarshal(r.TransitionsPayload, transitions); uerr != nil {
+					// STOP and signal FALLBACK, same as a corrupt batch_payload.
+					// Substituting empty transitions here is NOT the safe
+					// degradation it looks like: visibilityFor would read
+					// {Pre:"", Post:""} for every op, IsAllowed("") is false on
+					// both sides, so filterVisibleOps returns nil and NO frame
+					// (batch, materialized, or removed) is emitted for this
+					// batch — the client cannot tell that from "this batch never
+					// happened", yet its watermark still advances past it.
+					corrupt = append(corrupt, crdt.CorruptRow{
+						BatchID: r.BatchID,
+						Field:   "transitions_payload",
+						Cause:   wrapCorruptRow(p.mode.corruptRecoverable(), "unmarshal transitions_payload", r.BatchID, uerr),
+					})
+					return out, corrupt, crdt.ErrResumeCorrupt
+				}
+				// Decoding cleanly is not enough. A payload truncated at an
+				// entry boundary -- or to zero bytes -- unmarshals without error
+				// into a SHORT entry list, and the ops whose entries are missing
+				// then hit exactly the invisible-on-both-sides path described
+				// above. Only comparing the entries against the batch's own ops
+				// distinguishes "this batch legitimately moved nothing" from
+				// "this row lost the entries that said what it moved", so the
+				// completeness check is what actually closes the hole the
+				// unmarshal guard only half-covers.
+				if ref, missing := crdt.MissingTransitionOp(batch, transitions); missing {
+					corrupt = append(corrupt, crdt.CorruptRow{
+						BatchID: r.BatchID,
+						Field:   "transitions_payload",
+						Cause: wrapCorruptRow(p.mode.corruptRecoverable(), "incomplete transitions_payload", r.BatchID,
+							fmt.Errorf("no transition entry for %v", ref)),
+					})
+					return out, corrupt, crdt.ErrResumeCorrupt
+				}
+			}
+			ops += nOps
+			bytes += rowBytes
+			out = append(out, crdt.ResumeBatch{Batch: batch, Transitions: transitions})
 		}
 		if len(rows) < store.CRDTBatchPageLimit {
 			break
@@ -126,7 +426,7 @@ func (j *crdtJournal) listBatchesAfter(ctx context.Context, owner userid.UserID,
 			ClientId: last.OriginClient,
 		}
 	}
-	return out, nil
+	return out, corrupt, nil
 }
 
 func (j *crdtJournal) CommitBatch(ctx context.Context, c crdt.CommitBatch) error {
@@ -138,27 +438,43 @@ func (j *crdtJournal) CommitBatch(ctx context.Context, c crdt.CommitBatch) error
 	if err != nil {
 		return err
 	}
+	// Serialize BEFORE opening the transaction. Neither payload depends on
+	// anything the transaction reads, and the transitions blob can be sizeable
+	// (it carries a full record snapshot per visibility-crossing entity), so
+	// marshalling inside the closure held the write transaction — and whatever
+	// locks and connection it owns — open across CPU work for no reason.
+	payload, err := proto.Marshal(c.Batch)
+	if err != nil {
+		return fmt.Errorf("marshal batch %s: %w", c.Batch.GetBatchId(), err)
+	}
+	// A nil proto (a caller with no transitions) marshals to the empty
+	// BatchTransitions, so the NOT NULL column always has a valid value.
+	transitions := c.Transitions
+	if transitions == nil {
+		transitions = &leapmuxv1.BatchTransitions{}
+	}
+	transitionsPayload, err := proto.Marshal(transitions)
+	if err != nil {
+		return fmt.Errorf("marshal transitions %s: %w", c.Batch.GetBatchId(), err)
+	}
 	return j.store.RunInTransaction(ctx, func(tx store.Store) error {
-		payload, err := proto.Marshal(c.Batch)
-		if err != nil {
-			return fmt.Errorf("marshal batch %s: %w", c.Batch.GetBatchId(), err)
-		}
 		ops := c.Batch.GetOps()
 		opCount := int64(len(ops))
 		first := ops[0].GetCanonicalHlc()
 		last := ops[opCount-1].GetCanonicalHlc()
 		if err := tx.UserOpBatches().Insert(ctx, store.InsertUserOpBatchParams{
-			UserID:       owner,
-			PhysicalMs:   first.GetPhysical(),
-			Logical:      first.GetLogical(),
-			LastLogical:  last.GetLogical(),
-			OriginClient: first.GetClientId(),
-			PrincipalID:  c.PrincipalID,
-			BatchID:      c.Batch.GetBatchId(),
-			BodyHash:     c.Dedup.BodyHash,
-			BatchPayload: payload,
-			OpCount:      opCount,
-			Epoch:        c.Epoch,
+			UserID:             owner,
+			PhysicalMs:         first.GetPhysical(),
+			Logical:            first.GetLogical(),
+			LastLogical:        last.GetLogical(),
+			OriginClient:       first.GetClientId(),
+			PrincipalID:        c.PrincipalID,
+			BatchID:            c.Batch.GetBatchId(),
+			BodyHash:           c.Dedup.BodyHash,
+			BatchPayload:       payload,
+			TransitionsPayload: transitionsPayload,
+			OpCount:            opCount,
+			Epoch:              c.Epoch,
 		}); err != nil {
 			return fmt.Errorf("insert user_op_batch %s: %w", c.Batch.GetBatchId(), err)
 		}
@@ -244,11 +560,15 @@ func (j *crdtJournal) CompactBatch(ctx context.Context, c crdt.CompactBatch) err
 		}
 		now := time.Now()
 		if err := tx.UserState().Upsert(ctx, store.UpsertUserStateParams{
-			UserID:         owner,
-			StatePayload:   payload,
-			CurrentEpoch:   c.State.GetCurrentEpoch(),
-			EpochStartedAt: c.State.GetEpochStartedAt().AsTime(),
-			UpdatedAt:      now,
+			UserID:       owner,
+			StatePayload: payload,
+			// Taken from the same c.State just marshalled above, so the column
+			// and the blob can never disagree about how far this user has
+			// compacted. The retention sweep deletes only strictly below it.
+			CompactionPhysicalMs: c.State.GetCompactionWatermark().GetPhysical(),
+			CurrentEpoch:         c.State.GetCurrentEpoch(),
+			EpochStartedAt:       c.State.GetEpochStartedAt().AsTime(),
+			UpdatedAt:            now,
 		}); err != nil {
 			return fmt.Errorf("upsert user_state: %w", err)
 		}

--- a/backend/internal/hub/service/crdt_journal_internal_test.go
+++ b/backend/internal/hub/service/crdt_journal_internal_test.go
@@ -2,15 +2,19 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/hub/crdt"
 	"github.com/leapmux/leapmux/internal/hub/store"
+	"github.com/leapmux/leapmux/internal/hub/store/sqlite"
+	"github.com/leapmux/leapmux/internal/hub/store/storetest"
 	"github.com/leapmux/leapmux/internal/util/userid"
 )
 
@@ -140,4 +144,353 @@ func TestCRDTJournalRefusesABlankTenant(t *testing.T) {
 			State: &leapmuxv1.UserCrdtState{},
 		}), errBlankTenant)
 	})
+}
+
+// TestWrapCorruptRow_SentinelsViaErrorsIs pins the load-bearing contract
+// that a per-row decode failure wraps as crdt.ErrResumeCorrupt and resolves
+// via errors.Is — SubscribeWithACL branches on errors.Is(tailErr,
+// crdt.ErrResumeCorrupt) to route a corrupt row to FALLBACK instead of failing
+// the connection. The `%w` verb in wrapCorruptRow is what makes that
+// resolve; this test fails immediately if someone changes it to `%v` or `%s`
+// (which would make errors.Is return false and reconnect-loop the client on
+// the bad row forever). The manager-level counterpart is
+// TestSubscribeWithACL_CorruptRowFallsBackWithoutLosingOps, which injects the
+// BARE sentinel; this one guards the WRAP the production path actually
+// produces.
+func TestWrapCorruptRow_SentinelsViaErrorsIs(t *testing.T) {
+	t.Parallel()
+	recoverable := wrapCorruptRow(true, "unmarshal transitions_payload", "batch-7", assert.AnError)
+	assert.ErrorIs(t, recoverable, crdt.ErrResumeCorrupt,
+		"a wrapped decode failure must resolve to crdt.ErrResumeCorrupt via errors.Is (the %%w verb is load-bearing)")
+
+	// The two verdicts must be distinguishable, in BOTH directions. A single
+	// sentinel for both made a fatal boot failure satisfy the predicate whose
+	// documented meaning is "re-enter the full-snapshot FALLBACK path".
+	fatal := wrapCorruptRow(false, "unmarshal user_op_batch", "batch-7", assert.AnError)
+	assert.ErrorIs(t, fatal, crdt.ErrBootJournalCorrupt)
+	assert.NotErrorIs(t, fatal, crdt.ErrResumeCorrupt,
+		"a fatal boot failure must not be mistakable for a recoverable resume one")
+	assert.NotErrorIs(t, recoverable, crdt.ErrBootJournalCorrupt)
+}
+
+// seedResumeJournal opens an in-memory store and writes `n` user_op_batches
+// rows for one user, each holding a single op. Returns the journal, the owner,
+// and the batch ids in commit order. `mangle` is applied to each row's params
+// before insert so a test can corrupt a specific payload.
+func seedResumeJournal(t *testing.T, n int, mangle func(i int, p *store.InsertUserOpBatchParams)) (*crdtJournal, userid.UserID) {
+	t.Helper()
+	st, err := sqlite.OpenTestable(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	// user_op_batches carries an FK to users, so the tenant must exist.
+	owner := userid.MustNew(storetest.SeedUser(t, st, "resume-owner").ID)
+	ctx := context.Background()
+	for i := range n {
+		batch := &leapmuxv1.OpBatch{
+			BatchId: fmt.Sprintf("b%d", i),
+			Ops: []*leapmuxv1.CrdtOp{{
+				OpId: fmt.Sprintf("op%d", i),
+				CanonicalHlc: &leapmuxv1.HLC{
+					Physical: int64(1000 + i),
+					Logical:  0,
+					ClientId: "c1",
+				},
+			}},
+		}
+		payload, merr := proto.Marshal(batch)
+		require.NoError(t, merr)
+		transitions, merr := proto.Marshal(&leapmuxv1.BatchTransitions{})
+		require.NoError(t, merr)
+		p := store.InsertUserOpBatchParams{
+			UserID:             owner,
+			PhysicalMs:         int64(1000 + i),
+			Logical:            0,
+			LastLogical:        0,
+			OriginClient:       "c1",
+			PrincipalID:        "alice",
+			BatchID:            batch.GetBatchId(),
+			BodyHash:           []byte{byte(i)},
+			BatchPayload:       payload,
+			TransitionsPayload: transitions,
+			OpCount:            1,
+			Epoch:              1,
+		}
+		if mangle != nil {
+			mangle(i, &p)
+		}
+		require.NoError(t, st.UserOpBatches().Insert(ctx, p))
+	}
+	return &crdtJournal{store: st}, owner
+}
+
+// nodeOpBatch builds a one-op batch whose target RESOLVES to a real entity, so
+// a well-formed transitions_payload must carry an entry for it. (The
+// seedResumeJournal default writes body-less ops, whose OpTarget is
+// EntityKindUnknown and which therefore need no entry.)
+func nodeOpBatch(t *testing.T, batchID, nodeID string) []byte {
+	t.Helper()
+	payload, err := proto.Marshal(&leapmuxv1.OpBatch{
+		BatchId: batchID,
+		Ops: []*leapmuxv1.CrdtOp{{
+			OpId:         "op-" + nodeID,
+			CanonicalHlc: &leapmuxv1.HLC{Physical: 1000, Logical: 0, ClientId: "c1"},
+			Body: &leapmuxv1.CrdtOp_SetNodeRegister{SetNodeRegister: &leapmuxv1.SetNodeRegisterOp{
+				NodeId: nodeID,
+				Field:  &leapmuxv1.SetNodeRegisterOp_Position{Position: "p"},
+			}},
+		}},
+	})
+	require.NoError(t, err)
+	return payload
+}
+
+// TestListBatchesAfter_IncompleteTransitionsIsCorrupt pins the completeness
+// check on transitions_payload.
+//
+// The unmarshal guard alone cannot see this failure: proto3 repeated fields are
+// length-delimited, so a payload truncated at an entry boundary -- or truncated
+// all the way to zero bytes -- decodes WITHOUT error into a short entry list.
+// Every op whose entry was lost then resolves to the zero transition
+// {Pre:"", Post:""}, IsAllowed("") is false on both sides, filterVisibleOps
+// drops it, and the batch ships as nothing but a BatchEnd that still advances
+// the client's resume cursor past ops it never received. On the wire that is
+// identical to the batch never having existed, and no later resume re-requests
+// it. Comparing the entries against the batch's own ops is the only thing that
+// tells those two apart.
+func TestListBatchesAfter_IncompleteTransitionsIsCorrupt(t *testing.T) {
+	t.Parallel()
+	// Decodes cleanly, but carries no entry for n1.
+	empty, err := proto.Marshal(&leapmuxv1.BatchTransitions{})
+	require.NoError(t, err)
+
+	j, owner := seedResumeJournal(t, 1, func(_ int, p *store.InsertUserOpBatchParams) {
+		p.BatchPayload = nodeOpBatch(t, "b0", "n1")
+		p.TransitionsPayload = empty
+	})
+
+	out, corrupt, err := j.scan(context.Background(), journalScan{owner: owner, mode: scanResume})
+	assert.ErrorIs(t, err, crdt.ErrResumeCorrupt,
+		"a transitions_payload that decodes but does not cover the batch's ops must route to FALLBACK")
+	assert.Empty(t, out, "the scan must stop AT the bad row, not ship a prefix that omits it")
+	require.Len(t, corrupt, 1)
+	assert.Equal(t, "transitions_payload", corrupt[0].Field)
+	assert.Equal(t, "b0", corrupt[0].BatchID)
+}
+
+// TestListBatchesAfter_TruncatedBatchPayloadIsCorrupt pins the batch_payload
+// half of the same completeness gate.
+//
+// `ops` is a repeated field, so a batch_payload truncated at an element boundary
+// -- including to zero bytes -- unmarshals WITHOUT error into a SHORT OpBatch.
+// MissingTransitionOp cannot catch it (it tests ops ⊆ transitions, which passes
+// vacuously on a short op list), so the short batch would ship its survivors and
+// the BatchEnd would still advance the client past the whole row -- which
+// ListAfter's strictly-greater cursor then guarantees is never re-sent. op_count
+// is the independent witness: written from len(ops) at commit, DB-constrained
+// > 0, and never touched by a payload truncation.
+func TestListBatchesAfter_TruncatedBatchPayloadIsCorrupt(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name    string
+		payload func(t *testing.T) []byte
+	}{
+		{"decodes to zero ops", func(t *testing.T) []byte {
+			// Well-formed and non-empty (batch_payload is NOT NULL), but its
+			// whole repeated `ops` field is gone -- what truncating at the first
+			// element boundary leaves behind.
+			p, err := proto.Marshal(&leapmuxv1.OpBatch{BatchId: "b0"})
+			require.NoError(t, err)
+			return p
+		}},
+		{"truncated mid-list", func(t *testing.T) []byte {
+			full := nodeOpBatch(t, "b0", "n1")
+			return full[:len(full)/2]
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			j, owner := seedResumeJournal(t, 1, func(_ int, p *store.InsertUserOpBatchParams) {
+				p.BatchPayload = tc.payload(t)
+				// op_count records what was actually committed.
+				p.OpCount = 1
+			})
+
+			out, corrupt, err := j.scan(context.Background(), journalScan{owner: owner, mode: scanResume})
+			assert.ErrorIs(t, err, crdt.ErrResumeCorrupt,
+				"a batch_payload carrying fewer ops than op_count must route to FALLBACK")
+			assert.Empty(t, out, "the scan must stop AT the bad row")
+			require.Len(t, corrupt, 1)
+			assert.Equal(t, "batch_payload", corrupt[0].Field)
+		})
+	}
+}
+
+// The boot path has no snapshot to fall back to, so the same short row must be
+// FATAL there rather than merely recoverable -- otherwise Bootstrap rebuilds a
+// diverged state that the next maybeCompact persists as authoritative.
+func TestListBatchesAfter_TruncatedBatchPayloadIsFatalAtBoot(t *testing.T) {
+	t.Parallel()
+	zeroOps, err := proto.Marshal(&leapmuxv1.OpBatch{BatchId: "b0"})
+	require.NoError(t, err)
+	j, owner := seedResumeJournal(t, 1, func(_ int, p *store.InsertUserOpBatchParams) {
+		p.BatchPayload = zeroOps
+		p.OpCount = 1
+	})
+
+	out, corrupt, err := j.scan(context.Background(), journalScan{owner: owner, mode: scanBoot})
+	require.Error(t, err)
+	// The BOOT sentinel: this scan is scanBoot, and the name of the
+	// error is what tells a caller which of the two verdicts applies.
+	assert.ErrorIs(t, err, crdt.ErrBootJournalCorrupt)
+	assert.NotErrorIs(t, err, crdt.ErrResumeCorrupt)
+	assert.Nil(t, out)
+	assert.Nil(t, corrupt)
+}
+
+// TestListBatchesAfter_CompleteTransitionsAreNotCorrupt is the negative control
+// for the check above: the completeness rule must not turn ordinary rows into
+// spurious FALLBACKs. A row whose entries cover its ops reads clean.
+func TestListBatchesAfter_CompleteTransitionsAreNotCorrupt(t *testing.T) {
+	t.Parallel()
+	covered, err := proto.Marshal(&leapmuxv1.BatchTransitions{
+		Entries: []*leapmuxv1.BatchTransition{{
+			Identity:      &leapmuxv1.BatchTransition_NodeId{NodeId: "n1"},
+			PreWorkspace:  "w1",
+			PostWorkspace: "w1",
+		}},
+	})
+	require.NoError(t, err)
+
+	j, owner := seedResumeJournal(t, 1, func(_ int, p *store.InsertUserOpBatchParams) {
+		p.BatchPayload = nodeOpBatch(t, "b0", "n1")
+		p.TransitionsPayload = covered
+	})
+
+	out, corrupt, err := j.scan(context.Background(), journalScan{owner: owner, mode: scanResume})
+	require.NoError(t, err)
+	assert.Empty(t, corrupt)
+	require.Len(t, out, 1)
+	assert.Equal(t, "b0", out[0].Batch.GetBatchId())
+}
+
+// TestListBatchesAfter_BootPathSkipsTransitionCompleteness pins that the check
+// is scoped to the resume path. Bootstrap replays ops to rebuild state and asks
+// for no transitions at all (scanBoot), so it must not be made
+// to fail on a row the resume path would refuse -- there is no snapshot for it
+// to fall back to.
+func TestListBatchesAfter_BootPathSkipsTransitionCompleteness(t *testing.T) {
+	t.Parallel()
+	empty, err := proto.Marshal(&leapmuxv1.BatchTransitions{})
+	require.NoError(t, err)
+
+	j, owner := seedResumeJournal(t, 1, func(_ int, p *store.InsertUserOpBatchParams) {
+		p.BatchPayload = nodeOpBatch(t, "b0", "n1")
+		p.TransitionsPayload = empty
+	})
+
+	out, corrupt, err := j.scan(context.Background(), journalScan{owner: owner, mode: scanBoot})
+	require.NoError(t, err, "boot decodes no transitions, so their completeness is not its concern")
+	assert.Empty(t, corrupt)
+	require.Len(t, out, 1)
+}
+
+// TestListBatchesAfter_ByteBudgetFallsBack pins the maxBytes ceiling on the
+// REAL journal. It had no coverage at all: the manager always passes the
+// package constant MaxResumeDeltaBytes (4 MiB), and the in-memory fake used to
+// ignore the parameter outright, so every byte-budget FALLBACK was structurally
+// unreachable from any test. The check must also run BEFORE the row is
+// appended, so an over-budget row never rides along in the returned prefix.
+func TestListBatchesAfter_ByteBudgetFallsBack(t *testing.T) {
+	t.Parallel()
+	j, owner := seedResumeJournal(t, 3, nil)
+
+	// Budget of 1 byte: the very first row exceeds it.
+	out, corrupt, err := j.scan(context.Background(), journalScan{owner: owner, maxBytes: 1, mode: scanResume})
+	assert.ErrorIs(t, err, crdt.ErrDeltaTooLarge, "an over-budget tail must report ErrDeltaTooLarge")
+	assert.Empty(t, out, "no row may be returned once the byte budget is blown")
+	assert.Empty(t, corrupt)
+
+	// A generous budget returns everything, proving the ceiling is what stopped
+	// the scan above rather than an unrelated failure.
+	out, _, err = j.scan(context.Background(), journalScan{owner: owner, maxBytes: 1 << 20, mode: scanResume})
+	require.NoError(t, err)
+	assert.Len(t, out, 3)
+}
+
+// TestListBatchesAfter_StopsOnCorruptPayload pins stop-on-corrupt on the REAL
+// journal for BOTH payload columns, and pins that the recoverable flag selects
+// the sentinel (resume) vs a hard error (boot).
+func TestListBatchesAfter_StopsOnCorruptPayload(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		field  string
+		mangle func(i int, p *store.InsertUserOpBatchParams)
+	}{
+		{
+			name:  "batch_payload",
+			field: "batch_payload",
+			mangle: func(i int, p *store.InsertUserOpBatchParams) {
+				if i == 1 {
+					p.BatchPayload = []byte{0xFF, 0xFE, 0xFD}
+				}
+			},
+		},
+		{
+			name:  "transitions_payload",
+			field: "transitions_payload",
+			mangle: func(i int, p *store.InsertUserOpBatchParams) {
+				if i == 1 {
+					p.TransitionsPayload = []byte{0xFF, 0xFE, 0xFD}
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			j, owner := seedResumeJournal(t, 3, tc.mangle)
+			ctx := context.Background()
+
+			// Resume path: recoverable -> ErrResumeCorrupt so the caller FALLBACKs.
+			out, corrupt, err := j.scan(ctx, journalScan{owner: owner, mode: scanResume})
+			assert.ErrorIs(t, err, crdt.ErrResumeCorrupt,
+				"a corrupt %s must report ErrResumeCorrupt so buildResumeDelta falls back", tc.field)
+			require.Len(t, corrupt, 1, "the offending row must be surfaced for logging")
+			assert.Equal(t, "b1", corrupt[0].BatchID)
+			assert.Equal(t, tc.field, corrupt[0].Field)
+			// The scan must STOP: b2 (which would have advanced the client's
+			// max_hlc past the hole) must not be in the prefix.
+			assert.Len(t, out, 1, "the scan must stop at the corrupt row, not continue past it")
+
+			// Boot path. Before the enum this read `{owner, decodeTransitions:
+			// true}` -- the off-diagonal state, relying on `recoverable`'s zero
+			// value to mean boot while asking for resume's transition decoding.
+			// Naming the scan makes the two fields diverge, correctly:
+			// scanBoot never reads transitions_payload, so only a corrupt
+			// batch_payload can fail it.
+			_, _, bootErr := j.scan(ctx, journalScan{owner: owner, mode: scanBoot})
+			if tc.field == "transitions_payload" {
+				assert.NoError(t, bootErr,
+					"boot does not decode transitions_payload, so corruption there cannot fail it")
+				return
+			}
+			require.Error(t, bootErr)
+			{
+				// The sentinel IS the verdict, so a fatal boot error must NOT
+				// carry the recoverable one. It used to: this assertion read
+				// `ErrorIs(bootErr, crdt.ErrResumeCorrupt)` and passed, pinning a
+				// label whose documented meaning is "degrade to a snapshot" onto
+				// the one path that has no snapshot to degrade to. Nothing
+				// branches on it above registry.Get today; the first handler that
+				// does would serve a snapshot built from a state blob missing
+				// every op after the bad row and call the connect a success.
+				assert.ErrorIs(t, bootErr, crdt.ErrBootJournalCorrupt,
+					"a fatal boot failure carries the boot sentinel")
+				assert.NotErrorIs(t, bootErr, crdt.ErrResumeCorrupt,
+					"and must NOT carry the recoverable one, which means 'fall back to a snapshot'")
+			}
+		})
+	}
 }

--- a/backend/internal/hub/service/crdt_service_test.go
+++ b/backend/internal/hub/service/crdt_service_test.go
@@ -26,11 +26,12 @@ import (
 // crdt_test package's fakeJournal but is kept inline so the service
 // tests don't reach into another package's private symbols.
 type memJournal struct {
-	mu        sync.Mutex
-	state     *leapmuxv1.UserCrdtState
-	batches   []*leapmuxv1.OpBatch
-	dedup     map[string]crdt.RecentBatchRecord
-	commitErr error
+	mu          sync.Mutex
+	state       *leapmuxv1.UserCrdtState
+	batches     []*leapmuxv1.OpBatch
+	transitions []*leapmuxv1.BatchTransitions
+	dedup       map[string]crdt.RecentBatchRecord
+	commitErr   error
 }
 
 func newMemJournal() *memJournal { return &memJournal{dedup: map[string]crdt.RecentBatchRecord{}} }
@@ -45,6 +46,38 @@ func (j *memJournal) LoadState(_ context.Context, _ string) (*leapmuxv1.UserCrdt
 	return state, append([]*leapmuxv1.OpBatch(nil), j.batches...), nil
 }
 
+func (j *memJournal) ListBatchesAfter(_ context.Context, _ string, cursor, until *leapmuxv1.HLC, maxOps, _ int) ([]crdt.ResumeBatch, []crdt.CorruptRow, error) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	out := []crdt.ResumeBatch{}
+	ops := 0
+	for i, b := range j.batches {
+		if len(b.GetOps()) == 0 {
+			// The prod journal iterates GetOps() (no [0] index) and the manager
+			// rejects zero-op batches, but a test seeding batches directly must
+			// not panic on the index below.
+			continue
+		}
+		first := b.GetOps()[0].GetCanonicalHlc()
+		if crdt.HLCCmp(first, cursor) <= 0 {
+			continue
+		}
+		if until != nil && crdt.HLCCmp(first, until) > 0 {
+			return out, nil, nil
+		}
+		if maxOps > 0 && ops+len(b.GetOps()) > maxOps {
+			return out, nil, crdt.ErrDeltaTooLarge
+		}
+		ops += len(b.GetOps())
+		var trans *leapmuxv1.BatchTransitions
+		if i < len(j.transitions) {
+			trans = j.transitions[i]
+		}
+		out = append(out, crdt.ResumeBatch{Batch: b, Transitions: trans})
+	}
+	return out, nil, nil
+}
+
 func (j *memJournal) CommitBatch(_ context.Context, c crdt.CommitBatch) error {
 	j.mu.Lock()
 	defer j.mu.Unlock()
@@ -52,6 +85,7 @@ func (j *memJournal) CommitBatch(_ context.Context, c crdt.CommitBatch) error {
 		return j.commitErr
 	}
 	j.batches = append(j.batches, c.Batch)
+	j.transitions = append(j.transitions, c.Transitions)
 	// The dedup TABLE row is the commit envelope's context plus the batch's own
 	// fields; crdt.CommitBatch states the former once, so reassemble it here
 	// the way the real journal adapter does when it writes the row.

--- a/backend/internal/hub/service/subscriber_queue.go
+++ b/backend/internal/hub/service/subscriber_queue.go
@@ -1,0 +1,147 @@
+package service
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	"github.com/leapmux/leapmux/internal/hub/crdt"
+)
+
+// parkedFrameCap bounds the pre-bootstrap park buffer.
+//
+// Under a reconnect storm (a hub restart, say) a slow multi-page resume scan
+// racing fast incoming broadcasts could otherwise grow it without bound and OOM
+// the hub. Well above any realistic burst during a scan that is itself bounded
+// at MaxResumeDeltaOps frames.
+const parkedFrameCap = 256
+
+// liveQueueDepth is the steady-state bounded channel depth, i.e. how far a
+// subscriber may fall behind the manager goroutine before it is dropped.
+const liveQueueDepth = 64
+
+// subscriberQueue is one subscriber's outbound path, in both of its phases.
+//
+// A user-events connection delivers in a strict order: the bootstrap frame,
+// then whatever arrived while the subscribe + resume scan was still running,
+// then steady-state live traffic. So Send has two behaviours -- PARK before the
+// bootstrap frame is on the wire, STREAM after -- and the switch between them
+// has to be seen consistently by the manager goroutine calling Send, by the
+// writer loop calling Release, and by the manager calling Rebaseline under its
+// projection lock.
+//
+// That used to be four interdependent locals (a cap, a mutex, a slice and a
+// bool) plus the channel, declared in a ~250-line HTTP handler closure and
+// mutated from three places in it. Nothing but reading `bootstrapped` correctly
+// at each of those three sites enforced the phase rule, and the whole park /
+// flush / overflow policy could only be exercised through httptest.NewServer
+// and a real websocket.Dial -- which is why it had no direct test at all.
+//
+// As a type the phase rule is a property of the value, and the policy is
+// unit-testable without a server.
+type subscriberQueue struct {
+	mu sync.Mutex
+	// parked holds frames received before Release; nil afterwards.
+	parked []*crdt.MarshaledEvent
+	// released flips once, in Release. Send streams from that point on.
+	released bool
+	// live is the steady-state bounded queue the writer loop drains.
+	live chan *crdt.MarshaledEvent
+	// overflowed records that a frame was dropped during the parking phase, so
+	// the resume path can FALLBACK to a snapshot instead of shipping a delta
+	// with a hole. atomic: Send runs on the manager goroutine while the resume
+	// scan reads it on the subscribing request's.
+	overflowed atomic.Bool
+}
+
+func newSubscriberQueue() *subscriberQueue {
+	return &subscriberQueue{live: make(chan *crdt.MarshaledEvent, liveQueueDepth)}
+}
+
+// Send accepts one frame, parking or streaming according to phase.
+//
+// Returns crdt.ErrSubscriberSlow when the subscriber cannot keep up in either
+// phase — a full park buffer or a full live queue. The caller tears the
+// connection down on that; blocking here would stall the manager goroutine for
+// every other subscriber of this user.
+func (q *subscriberQueue) Send(ctx context.Context, evt *crdt.MarshaledEvent) error {
+	q.mu.Lock()
+	if !q.released {
+		if len(q.parked) >= parkedFrameCap {
+			q.mu.Unlock()
+			q.overflowed.Store(true)
+			return crdt.ErrSubscriberSlow
+		}
+		q.parked = append(q.parked, evt)
+		q.mu.Unlock()
+		return nil
+	}
+	q.mu.Unlock()
+
+	// Two selects, not one three-way: a single select with a ready send AND a
+	// ready ctx.Done() picks between them at RANDOM, so a cancelled context
+	// could preempt a send the queue had room for. Take the room first, and
+	// consult ctx only when there is none.
+	select {
+	case q.live <- evt:
+		return nil
+	default:
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		return crdt.ErrSubscriberSlow
+	}
+}
+
+// Rebaseline discards everything parked so far.
+//
+// A resume that gives up re-registers and takes a snapshot at a LATER point
+// than anything parked during the scan, so those frames are superseded by it.
+// Replaying them over the snapshot would reinstate stale entity records for
+// good — the client applies materialized / removed wholesale, with no HLC
+// compare. The manager calls this under its projection lock at exactly that
+// moment, so this drops precisely the superseded frames and nothing newer.
+func (q *subscriberQueue) Rebaseline() {
+	q.mu.Lock()
+	q.parked = nil
+	q.mu.Unlock()
+}
+
+// Release ends the parking phase and returns the frames to flush, in order.
+//
+// Called once, by the writer loop, immediately after the bootstrap frame is on
+// the wire. Everything Send accepts afterwards goes to the live queue, so the
+// returned slice is complete: no frame can be both flushed here and streamed.
+func (q *subscriberQueue) Release() []*crdt.MarshaledEvent {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	toFlush := q.parked
+	q.parked = nil
+	q.released = true
+	return toFlush
+}
+
+// Released reports whether the parking phase has ended.
+//
+// The caller needs it to tell the two overflow REASONS apart: a full park
+// buffer happens while a resume scan is still running and can be answered with
+// a snapshot, while a full live queue means the subscriber cannot keep up with
+// steady-state traffic and must be dropped.
+func (q *subscriberQueue) Released() bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.released
+}
+
+// Overflowed reports whether a frame was dropped during the parking phase. The
+// manager consults it after the resume scan; see crdt.Subscriber.Overflowed.
+func (q *subscriberQueue) Overflowed() bool {
+	return q.overflowed.Load()
+}
+
+// Live is the steady-state queue the writer loop selects on.
+func (q *subscriberQueue) Live() <-chan *crdt.MarshaledEvent {
+	return q.live
+}

--- a/backend/internal/hub/service/subscriber_queue_internal_test.go
+++ b/backend/internal/hub/service/subscriber_queue_internal_test.go
@@ -1,0 +1,135 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/hub/crdt"
+)
+
+// The park/flush/overflow policy had NO direct coverage before this type
+// existed: it was four locals inside a ~250-line HTTP handler closure, so
+// reaching it meant httptest.NewServer plus a real websocket.Dial, and the only
+// handler test in the suite does neither. Every case here is one the closure
+// form could not express.
+func evt(id string) *crdt.MarshaledEvent {
+	return crdt.NewMarshaledEvent(&leapmuxv1.WatchUserEvent{
+		Event: &leapmuxv1.WatchUserEvent_Batch{Batch: &leapmuxv1.OpBatch{BatchId: id}},
+	})
+}
+
+func TestSubscriberQueue(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("parks before release and flushes in order", func(t *testing.T) {
+		t.Parallel()
+		q := newSubscriberQueue()
+		require.NoError(t, q.Send(ctx, evt("a")))
+		require.NoError(t, q.Send(ctx, evt("b")))
+
+		// Nothing reaches the live queue while parked.
+		assert.Empty(t, q.Live())
+
+		flushed := q.Release()
+		require.Len(t, flushed, 2)
+		assert.Equal(t, "a", flushed[0].Event.GetBatch().GetBatchId())
+		assert.Equal(t, "b", flushed[1].Event.GetBatch().GetBatchId())
+	})
+
+	t.Run("streams to the live queue after release", func(t *testing.T) {
+		t.Parallel()
+		q := newSubscriberQueue()
+		assert.Empty(t, q.Release())
+
+		require.NoError(t, q.Send(ctx, evt("live")))
+		select {
+		case got := <-q.Live():
+			assert.Equal(t, "live", got.Event.GetBatch().GetBatchId())
+		default:
+			t.Fatal("a post-release frame must reach the live queue")
+		}
+	})
+
+	// The release is what makes the flushed slice COMPLETE: a frame accepted
+	// after it must go to the live queue, never into a buffer nothing will read.
+	t.Run("release is one-way, so a later frame is never parked again", func(t *testing.T) {
+		t.Parallel()
+		q := newSubscriberQueue()
+		q.Release()
+		require.NoError(t, q.Send(ctx, evt("after")))
+		assert.Empty(t, q.Release(), "nothing may park once released")
+		assert.Len(t, q.Live(), 1)
+	})
+
+	t.Run("reports ErrSubscriberSlow when the park buffer overflows", func(t *testing.T) {
+		t.Parallel()
+		q := newSubscriberQueue()
+		for i := range parkedFrameCap {
+			require.NoError(t, q.Send(ctx, evt("x")), "frame %d is within the cap", i)
+		}
+		assert.ErrorIs(t, q.Send(ctx, evt("overflow")), crdt.ErrSubscriberSlow)
+		// The cap holds: overflow must not grow the buffer past it.
+		assert.Len(t, q.Release(), parkedFrameCap)
+	})
+
+	t.Run("reports ErrSubscriberSlow when the live queue is full", func(t *testing.T) {
+		t.Parallel()
+		q := newSubscriberQueue()
+		q.Release()
+		for i := range liveQueueDepth {
+			require.NoError(t, q.Send(ctx, evt("x")), "frame %d is within the depth", i)
+		}
+		assert.ErrorIs(t, q.Send(ctx, evt("overflow")), crdt.ErrSubscriberSlow)
+	})
+
+	// A resume that gives up takes a snapshot at a LATER point than anything
+	// parked during the scan, so replaying those frames over it would reinstate
+	// stale entity records permanently -- the client applies materialized /
+	// removed wholesale, with no HLC compare.
+	t.Run("rebaseline discards parked frames without releasing", func(t *testing.T) {
+		t.Parallel()
+		q := newSubscriberQueue()
+		require.NoError(t, q.Send(ctx, evt("superseded")))
+		q.Rebaseline()
+
+		require.NoError(t, q.Send(ctx, evt("kept")))
+		flushed := q.Release()
+		require.Len(t, flushed, 1, "only frames after the rebaseline survive")
+		assert.Equal(t, "kept", flushed[0].Event.GetBatch().GetBatchId())
+	})
+
+	// A single three-way select with a ready send AND a ready ctx.Done() picks
+	// between them at RANDOM, so a cancelled context could preempt a send the
+	// queue had room for -- nondeterministically. Room wins; ctx is consulted
+	// only when there is none.
+	t.Run("a cancelled context does not preempt a send the queue can take", func(t *testing.T) {
+		t.Parallel()
+		q := newSubscriberQueue()
+		q.Release()
+		cancelled, cancel := context.WithCancel(context.Background())
+		cancel()
+		for i := range liveQueueDepth {
+			require.NoError(t, q.Send(cancelled, evt("x")), "frame %d fits, so ctx must not win", i)
+		}
+		// Now there is no room, so the cancelled context is what surfaces.
+		assert.ErrorIs(t, q.Send(cancelled, evt("overflow")), context.Canceled)
+	})
+
+	// The park-phase overflow is what buildResumeDelta consults to convert a
+	// dropped frame into ONE snapshot instead of a torn-down connection.
+	t.Run("records a park-phase overflow for the resume path", func(t *testing.T) {
+		t.Parallel()
+		q := newSubscriberQueue()
+		assert.False(t, q.Overflowed())
+		for range parkedFrameCap {
+			require.NoError(t, q.Send(ctx, evt("x")))
+		}
+		require.ErrorIs(t, q.Send(ctx, evt("overflow")), crdt.ErrSubscriberSlow)
+		assert.True(t, q.Overflowed(), "the resume scan must be able to see the drop")
+	})
+}

--- a/backend/internal/hub/service/worker_connector_service_internal_test.go
+++ b/backend/internal/hub/service/worker_connector_service_internal_test.go
@@ -46,6 +46,10 @@ func (j *tabSyncJournal) LoadState(context.Context, string) (*leapmuxv1.UserCrdt
 	return nil, nil, nil
 }
 
+func (j *tabSyncJournal) ListBatchesAfter(context.Context, string, *leapmuxv1.HLC, *leapmuxv1.HLC, int, int) ([]crdt.ResumeBatch, []crdt.CorruptRow, error) {
+	return nil, nil, nil
+}
+
 func (j *tabSyncJournal) CommitBatch(_ context.Context, c crdt.CommitBatch) error {
 	j.mu.Lock()
 	defer j.mu.Unlock()

--- a/backend/internal/hub/service/worker_delegation_handler_test.go
+++ b/backend/internal/hub/service/worker_delegation_handler_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -24,8 +25,42 @@ import (
 	"github.com/leapmux/leapmux/internal/util/id"
 )
 
+// ownedTabPollSpy counts the ownership-poll's point lookups.
+//
+// waitForTabOwnership is a loop over WorkspaceTabIndex().GetOwned, so "did the
+// poll run?" -- the property the mint-ordering test actually cares about -- is
+// a CALL COUNT, observable directly and deterministically. The test used to
+// infer it from wall-clock elapsed time instead, which is a proxy: a request
+// that polls zero times still takes however long the machine takes to serve an
+// HTTP round trip, so the assertion failed under load with nothing wrong.
+//
+// Delegates to the wrapped store, never back through the env's store handle --
+// routing a wrapper through the thing it wraps is how these re-enter or recurse.
+type ownedTabPollSpy struct {
+	store.WorkspaceTabIndexStore
+	calls atomic.Int64
+}
+
+func (s *ownedTabPollSpy) GetOwned(ctx context.Context, p store.GetOwnedTabParams) (*store.WorkspaceTabRow, error) {
+	s.calls.Add(1)
+	return s.WorkspaceTabIndexStore.GetOwned(ctx, p)
+}
+
+// tabIndexSpyStore swaps one accessor and passes everything else straight
+// through, mirroring cleanupSpyStore in cleanup_test.go.
+type tabIndexSpyStore struct {
+	store.Store
+	tabIndex *ownedTabPollSpy
+}
+
+func (s tabIndexSpyStore) WorkspaceTabIndex() store.WorkspaceTabIndexStore {
+	return s.tabIndex
+}
+
 type delegationEnv struct {
-	store           store.Store
+	store store.Store
+	// ownershipPolls counts GetOwned lookups made through the handler's store.
+	ownershipPolls  *ownedTabPollSpy
 	validator       *auth.TokenValidator
 	cache           *auth.AuthContextRegistry
 	server          *httptest.Server
@@ -55,7 +90,10 @@ func setupDelegation(t *testing.T) *delegationEnv {
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 
-	h := service.NewWorkerDelegationHandler(st, tv, auth.NewCredentialLifecycleEffects(sc, nil, nil))
+	// The handler sees the spy; the test body keeps using `st` directly for
+	// seeding, so setup writes are not counted as polls.
+	polls := &ownedTabPollSpy{WorkspaceTabIndexStore: st.WorkspaceTabIndex()}
+	h := service.NewWorkerDelegationHandler(tabIndexSpyStore{Store: st, tabIndex: polls}, tv, auth.NewCredentialLifecycleEffects(sc, nil, nil))
 	// Tests don't want production-grade backoff; shrink the
 	// AddTab-race propagation window so "tab missing" cases fail fast
 	// while still exercising the polling loop.
@@ -97,6 +135,7 @@ func setupDelegation(t *testing.T) *delegationEnv {
 
 	return &delegationEnv{
 		store:           st,
+		ownershipPolls:  polls,
 		validator:       tv,
 		cache:           sc,
 		server:          srv,
@@ -139,9 +178,13 @@ func revokeRequest(t *testing.T, env *delegationEnv, workerAuthToken string, bod
 	return resp
 }
 
-// testMintPropagationTimeout is the tuned ownership-poll window the test env
-// installs, so a test can assert "the poll did not run" against the same value
-// the handler is using rather than a duplicated literal.
+// testMintPropagationTimeout shrinks the AddTab-race propagation window so the
+// cases that DO exercise the polling loop ("tab missing") finish quickly.
+//
+// It is no longer what any assertion compares against. "The poll did not run"
+// is asserted by counting GetOwned calls (see ownedTabPollSpy), so this value
+// only has to be small enough to keep the suite fast -- shrinking it further
+// cannot weaken a test, and lengthening it cannot flake one.
 const testMintPropagationTimeout = 50 * time.Millisecond
 
 func TestWorkerDelegation_Mint_HappyPath(t *testing.T) {
@@ -375,12 +418,10 @@ func TestWorkerDelegation_Mint_RefusesAForeignUserWithoutPolling(t *testing.T) {
 	env := setupDelegation(t)
 	otherUserID := hubtestutil.CreateTestUser(t, env.store, "other-user-no-poll", "p")
 
-	start := time.Now()
 	resp := mintRequest(t, env, env.workerAuthToken, map[string]any{
 		"user_id":           otherUserID,
 		"issued_for_tab_id": "nonexistent-tab",
 	})
-	elapsed := time.Since(start)
 	defer func() { _ = resp.Body.Close() }()
 
 	require.Equal(t, http.StatusForbidden, resp.StatusCode)
@@ -388,10 +429,15 @@ func TestWorkerDelegation_Mint_RefusesAForeignUserWithoutPolling(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(body), "user is not the worker's registrant",
 		"the registrant check must be the one that refuses, which means it ran first")
-	// The test env tunes the propagation window down to ~50ms, so anything at or
-	// beyond that means the poll ran. Compared against the tuned window rather
-	// than a bare constant so this cannot silently pass if the window shrinks.
-	assert.Less(t, elapsed, testMintPropagationTimeout,
+	// The poll ITSELF, counted -- not the wall-clock time it would have taken.
+	//
+	// This asserted `elapsed < testMintPropagationTimeout` before. That is a
+	// proxy for "the poll did not run", and a load-sensitive one: serving the
+	// HTTP round trip alone can exceed a 50ms budget on a busy machine, so the
+	// test failed with the production ordering perfectly correct. Counting
+	// GetOwned measures the property directly, is exact rather than
+	// approximate, and cannot be perturbed by machine load at all.
+	assert.Zero(t, env.ownershipPolls.calls.Load(),
 		"a foreign user_id must be refused before the ownership poll, not after it")
 }
 

--- a/backend/internal/hub/service/ws_userevents.go
+++ b/backend/internal/hub/service/ws_userevents.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -11,7 +12,6 @@ import (
 	"github.com/coder/websocket"
 
 	"github.com/leapmux/leapmux/channelwire"
-	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/hub/auth"
 	"github.com/leapmux/leapmux/internal/hub/crdt"
 	"github.com/leapmux/leapmux/internal/hub/store"
@@ -80,10 +80,10 @@ func (h *UserEventsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Tenancy is the authenticated user. No client-supplied user_id query
-	// parameter: channelwire.UserEventsURL only encodes workspace_ids, and
-	// accepting a foreign id would let any authenticated user drive
-	// registry.Get (which performs no authorization) into bootstrapping an
-	// arbitrary tenant's CRDT Manager.
+	// parameter: channelwire.UserEventsURL encodes only workspace_ids and the
+	// resume cursor (resume_after_hlc / resume_epoch), and accepting a foreign
+	// id would let any authenticated user drive registry.Get (which performs no
+	// authorization) into bootstrapping an arbitrary tenant's CRDT Manager.
 	userID := user.ID.String()
 	workspaceIDs := []string{}
 	if raw := r.URL.Query().Get("workspace_ids"); raw != "" {
@@ -92,6 +92,19 @@ func (h *UserEventsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				workspaceIDs = append(workspaceIDs, w)
 			}
 		}
+	}
+	// Resume cursor: a reconnecting client presents its last-applied HLC plus
+	// the epoch it saw it under. Both params absent is a first connect (the
+	// hub's SubscribeWithACL treats a nil cursor as FALLBACK → full snapshot).
+	// A malformed resume_after_hlc or resume_epoch is a genuine client bug, not
+	// a legacy client, so it is rejected with 400 rather than silently degrading
+	// (silent degradation would mask the bug and let a broken client limp along
+	// with full-snapshot reconnects forever). resume_epoch without a matching
+	// resume_after_hlc is likewise malformed.
+	resumeCursor, resumeEpoch, resumeErr := channelwire.ParseResumeCursorFromQuery(r.URL.Query())
+	if resumeErr != nil {
+		http.Error(w, resumeErr.Error(), http.StatusBadRequest)
+		return
 	}
 
 	mgr, err := h.registry.Get(r.Context(), userID)
@@ -130,14 +143,15 @@ func (h *UserEventsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	// 64-deep buffer covers the bootstrap-burst window where a fresh
-	// subscriber sees every entity_materialized at once. The Send below
-	// is non-blocking: a full buffer triggers ErrSubscriberSlow which
-	// cancels this subscriber's ctx and tears down the connection. Per
-	// the Subscriber.Send contract the manager must not be blocked by
-	// one slow client — back-pressure here would head-of-line stall
-	// every other subscriber for this user.
-	pending := make(chan *crdt.MarshaledEvent, 64)
+	// 64-deep buffer covers the steady-state burst window after bootstrap.
+	// During SubscribeWithACL's RESUME path the subscriber is registered
+	// before this writer loop starts, and live broadcasts enqueue via Send
+	// while the journal scan runs — parking those frames in a slice (instead
+	// of the bounded channel) so a multi-page scan under load cannot trip
+	// ErrSubscriberSlow and drop the reconnect. The two phases, the cap, the
+	// mutex and the buffers all live in subscriberQueue -- see its doc for why
+	// they are one value rather than five locals mutated from three places here.
+	queue := newSubscriberQueue()
 	sub := &crdt.Subscriber{
 		UserID:                user.ID.String(),
 		ClientID:              presenceClientID(user),
@@ -145,23 +159,42 @@ func (h *UserEventsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// Filter is resolved and installed under subscribeExpandMu by
 		// SubscribeWithACL below (see the resolve-then-register TOCTOU it closes).
 		Send: func(evt *crdt.MarshaledEvent) error {
-			select {
-			case pending <- evt:
-				return nil
-			case <-ctx.Done():
-				return ctx.Err()
-			default:
-				// Buffer is full: drop this subscriber rather than block
-				// the manager goroutine. Cancelling ctx causes the writer
-				// loop below to exit and the deferred unsub to fire,
-				// removing us from the manager's subs set so subsequent
-				// broadcasts skip us entirely.
-				slog.Warn("userevents: subscriber buffer full, dropping connection",
-					"user_id", user.ID, "client_id", presenceClientID(user))
-				cancel()
-				return crdt.ErrSubscriberSlow
+			err := queue.Send(ctx, evt)
+			if !errors.Is(err, crdt.ErrSubscriberSlow) {
+				return err
 			}
+			// The two phases overflow for different reasons and deserve
+			// different answers.
+			if !queue.Released() {
+				// PRE-BOOTSTRAP: a resume scan is still running. Tearing down
+				// here sent the client back with the same cursor to rebuild the
+				// same multi-page scan, under the load that caused the overflow.
+				// Flag it instead: the manager's post-scan check turns this into
+				// ONE snapshot, and resumeFallback's OnRebaseline discards the
+				// parked buffer before taking the baseline, so the frame this
+				// call could not hold is superseded rather than lost.
+				slog.Warn("userevents: park buffer full during resume, falling back to a snapshot",
+					"user_id", user.ID, "client_id", presenceClientID(user))
+				return err
+			}
+			// STEADY STATE: there is no scan to fall back from, so drop the
+			// subscriber rather than block the manager goroutine. Cancelling ctx
+			// exits the writer loop below and fires the deferred unsub, so later
+			// broadcasts skip us.
+			slog.Warn("userevents: subscriber buffer full, dropping connection",
+				"user_id", user.ID, "client_id", presenceClientID(user))
+			cancel()
+			return err
 		},
+		// A resume that gives up re-registers and takes a snapshot at a LATER
+		// point than anything parked during the scan. Those parked frames are
+		// superseded by the snapshot, and replaying them over it would reinstate
+		// stale entity records for good (the client applies materialized /
+		// removed wholesale, with no HLC compare). The manager calls this under
+		// its projection lock at exactly that moment, so dropping the buffer
+		// here discards precisely the superseded frames and nothing newer.
+		OnRebaseline: queue.Rebaseline,
+		Overflowed:   queue.Overflowed,
 	}
 	// Resolve the workspace filter and register the subscriber atomically under
 	// the manager's subscribe/expand lock. This closes the resolve-then-register
@@ -177,42 +210,65 @@ func (h *UserEventsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// StatusInternalError is terminal there and would surface as a fatal stream
 	// error instead). Keying on the specific authz code keeps this robust if the
 	// callee's error coding changes.
-	initial, unsub, err := mgr.SubscribeWithACL(sub, func() (map[string]bool, error) {
+	// Resolve the workspace filter, register the subscriber, and emit the
+	// bootstrap frame. SubscribeWithACL returns a discriminated SubscribeOutcome:
+	// Mode == ResumeDelta (the post-cursor op tail) when the client's cursor is
+	// still within the compaction window, or Mode == SubscribeInitial (a full
+	// UserMaterialized snapshot) otherwise — including a first-connect with no
+	// cursor. Exactly one bootstrap arm is selected; the first frame on the wire
+	// is therefore exactly one of `delta` or `initial`, never both. The same
+	// resolve callback and subscribeExpandMu serialization apply to both paths.
+	resolve := func() (map[string]bool, error) {
 		return resolveAllowedWorkspacesSetForUser(ctx, h.store, workspaceIDs, user)
-	})
+	}
+	out, err := mgr.SubscribeWithACL(ctx, sub, resumeCursor, resumeEpoch, resolve)
 	if err != nil {
 		if connect.CodeOf(err) == connect.CodePermissionDenied {
 			_ = wsConn.Close(websocket.StatusPolicyViolation, "forbidden")
 		} else {
-			slog.Error("userevents: resolve allowed workspaces failed", "user_id", user.ID, "error", err)
+			slog.Error("userevents: resume setup failed", "user_id", user.ID, "error", err)
 			_ = wsConn.Close(websocket.StatusTryAgainLater, "temporarily unavailable, retry")
 		}
 		return
 	}
-	defer unsub()
-
-	// Stamp the hub-derived client identity so the frontend's
-	// active-client gate has something stable to compare against. The
-	// namespaced derivation (session id → bearer kind/token id → user
-	// id) is shared
-	// with `UpdatePresence` and the manager's presence refcount, so
-	// both the local gate's comparison value and the server's
-	// disconnect-driven cleanup pivot on the same id.
-	initial.SubscriberClientId = sub.ClientID
+	defer out.Unsub()()
 
 	defer func() {
 		_ = wsConn.Close(websocket.StatusNormalClosure, "")
 	}()
 
-	// Send the initial UserMaterialized as the first frame. The initial
-	// payload is per-subscriber-unique (their filter dictates the
-	// materialized rows) so wrap in a fresh MarshaledEvent.
-	initialEvt := crdt.NewMarshaledEvent(&leapmuxv1.WatchUserEvent{
-		Event: &leapmuxv1.WatchUserEvent_Initial{Initial: initial},
-	})
-	if err := writeUserEvent(ctx, wsConn, initialEvt); err != nil {
-		slog.Debug("userevents: write initial failed", "user_id", user.ID, "error", err)
+	// Send the first (and only bootstrap) frame. BOTH arms stamp
+	// subscriber_client_id: it is the frontend active-client gate's only source
+	// of its own identity, and since the client-checkpoint work a resume is the
+	// normal COLD-START path — a refreshed page hydrates from IndexedDB and
+	// resumes, so there is no earlier `initial` frame it could have learned the
+	// id from. (It used to be delta-only-safe on the assumption that a resume
+	// always followed a bootstrap in the same page session; cross-refresh resume
+	// broke that assumption.)
+	//
+	// The hub-derived client identity it stamps is the same namespaced
+	// derivation (session id → bearer kind/token id → user id) that
+	// `UpdatePresence` and the manager's presence refcount use, so the local
+	// gate's comparison value and the server's disconnect-driven cleanup pivot
+	// on one id. userID comes from the authenticated session — the same value
+	// the manager was resolved under.
+	//
+	// Either payload is per-subscriber-unique (their filter dictates the rows),
+	// so it wraps in a fresh MarshaledEvent rather than a shared one.
+	bootstrapEvt := crdt.NewMarshaledEvent(out.Bootstrap(sub.ClientID, userID))
+	if err := writeUserEvent(ctx, wsConn, bootstrapEvt); err != nil {
+		slog.Debug("userevents: write bootstrap failed", "user_id", user.ID, "mode", out.Mode(), "error", err)
 		return
+	}
+
+	// Open the bounded live queue and flush frames that parked during the
+	// subscribe/scan window (before this writer loop). Order: bootstrap
+	// frame (above) → parked live catch-up → steady-state live queue.
+	for _, evt := range queue.Release() {
+		if err := writeUserEvent(ctx, wsConn, evt); err != nil {
+			slog.Debug("userevents: write parked event failed", "user_id", user.ID, "error", err)
+			return
+		}
 	}
 
 	// Drain client-side reads in a goroutine so the WebSocket library
@@ -233,7 +289,7 @@ func (h *UserEventsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		select {
 		case <-ctx.Done():
 			return
-		case evt := <-pending:
+		case evt := <-queue.Live():
 			if err := writeUserEvent(ctx, wsConn, evt); err != nil {
 				slog.Debug("userevents: write event failed", "user_id", user.ID, "error", err)
 				return
@@ -255,7 +311,7 @@ func (h *UserEventsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // the channel relay applies.
 //
 // This socket does NOT need the channel relay's queue: the broadcaster
-// already feeds it through a bounded `pending` channel whose Send drops
+// already feeds it through subscriberQueue's bounded live channel, whose Send drops
 // and cancels rather than blocking, so the backlog is bounded at the
 // source and a relayWriter here would only queue behind a queue.
 //

--- a/backend/internal/hub/store/mysql/cleanup.go
+++ b/backend/internal/hub/store/mysql/cleanup.go
@@ -72,3 +72,11 @@ func (s *cleanupStore) CompactPublishedRevocationEvents(
 ) (int64, error) {
 	return newRevocationEventStore(s.conn).CompactPublished(ctx, p.Cutoff)
 }
+
+// DeleteUserOpBatchesBeforePhysical is the retention backstop for CRDT
+// op batches -- see the query's own doc for why the HLC-based compaction tick
+// cannot drain a dormant account, and why the cutoff is an HLC physical rather
+// than the committed_at wall clock.
+func (s *cleanupStore) DeleteUserOpBatchesBeforePhysical(ctx context.Context, cutoffPhysicalMs int64) (int64, error) {
+	return rowsAffected(s.conn.q.DeleteUserOpBatchesBeforePhysical(ctx, cutoffPhysicalMs))
+}

--- a/backend/internal/hub/store/mysql/db/migrations/00001_initial.sql
+++ b/backend/internal/hub/store/mysql/db/migrations/00001_initial.sql
@@ -248,17 +248,33 @@ CREATE TABLE user_op_batches (
     batch_id      VARCHAR(255) NOT NULL,
     body_hash     BLOB NOT NULL,
     batch_payload LONGBLOB NOT NULL,
+    transitions_payload LONGBLOB NOT NULL,
     op_count      INT NOT NULL CHECK (op_count > 0),
     epoch         BIGINT NOT NULL,
-    committed_at  DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    committed_at  DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),  -- operator-facing audit stamp only; NOT a retention predicate (see idx_user_op_batches_physical_ms)
     PRIMARY KEY (user_id, physical_ms, logical, origin_client),
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 ) COLLATE=utf8mb4_bin;
 CREATE UNIQUE INDEX idx_user_op_batches_dedup ON user_op_batches(user_id, batch_id);
+-- Backs DeleteUserOpBatchesBeforePhysical, the cross-user retention sweep.
+-- The PK leads with user_id, which that query does not bind, so without this
+-- the hourly sweep full-scans every user's rows -- including the final pass
+-- that exists only to prove nothing is left to delete.
+CREATE INDEX idx_user_op_batches_physical_ms ON user_op_batches(physical_ms);
 
 CREATE TABLE user_state (
     user_id           VARCHAR(255) NOT NULL,
     state_payload    LONGBLOB NOT NULL,
+    -- state_payload.compaction_watermark.physical, projected out of the blob so
+    -- SQL can filter on it. One-way derived, exactly like user_op_batches'
+    -- physical_ms/logical over batch_payload: written from the same struct in
+    -- the same statement and rebuildable from the payload alone.
+    --
+    -- It is the only safe upper bound on op-batch deletion. Bootstrap rebuilds
+    -- a user as state_payload + every batch ABOVE this watermark, so a batch at
+    -- or below it is absorbed and a batch above it is the sole surviving copy
+    -- of those ops. The cross-user retention sweep joins on it for that reason.
+    compaction_physical_ms BIGINT NOT NULL DEFAULT 0,
     current_epoch    BIGINT NOT NULL DEFAULT 1,
     epoch_started_at DATETIME(6) NOT NULL,
     updated_at       DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),

--- a/backend/internal/hub/store/mysql/db/queries/user_op_batches.sql
+++ b/backend/internal/hub/store/mysql/db/queries/user_op_batches.sql
@@ -1,8 +1,8 @@
 -- name: InsertUserOpBatch :exec
 INSERT INTO user_op_batches (
     user_id, physical_ms, logical, last_logical, origin_client,
-    principal_id, batch_id, body_hash, batch_payload, op_count, epoch
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+    principal_id, batch_id, body_hash, batch_payload, transitions_payload, op_count, epoch
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 -- name: ListUserOpBatchesAfter :many
 -- Paged scan so a far-behind subscriber cannot OOM the broadcaster;
@@ -18,6 +18,8 @@ ORDER BY physical_ms, logical, origin_client
 LIMIT ?;
 
 -- name: DeleteUserOpBatchesThrough :exec
+-- Boundary alignment with decideResume's `>` test documented in the
+-- sqlite query (canonical home). Keys on the batch's LAST canonical HLC.
 DELETE FROM user_op_batches
 WHERE user_id = ?
   AND (physical_ms < sqlc.arg(through_physical_ms)
@@ -28,3 +30,19 @@ WHERE user_id = ?
 
 -- name: CountUserOpBatches :one
 SELECT COUNT(*) FROM user_op_batches WHERE user_id = ?;
+
+-- name: DeleteUserOpBatchesBeforePhysical :execresult
+-- Retention backstop for op batches, across ALL users. Both floors
+-- (cutoff_physical_ms and user_state.compaction_physical_ms), why the cutoff is
+-- an HLC physical rather than committed_at, and why the compaction test is a
+-- strict < are documented in the sqlite query (canonical home). The predicate
+-- below must stay identical to it: a sweep that deletes a different set per
+-- backend is exactly the failure that comment exists to prevent.
+--
+-- Written as a single-table DELETE with a correlated subquery rather than a
+-- JOIN because MySQL rejects LIMIT in a multi-table DELETE. The DELETE form is
+-- what differs here; the predicate is not.
+DELETE FROM user_op_batches
+WHERE physical_ms < sqlc.arg(cutoff_physical_ms)
+  AND physical_ms < (SELECT us.compaction_physical_ms FROM user_state us WHERE us.user_id = user_op_batches.user_id)
+LIMIT 1000;

--- a/backend/internal/hub/store/mysql/db/queries/user_state.sql
+++ b/backend/internal/hub/store/mysql/db/queries/user_state.sql
@@ -2,10 +2,14 @@
 SELECT * FROM user_state WHERE user_id = ?;
 
 -- name: UpsertUserState :exec
-INSERT INTO user_state (user_id, state_payload, current_epoch, epoch_started_at, updated_at)
-VALUES (?, ?, ?, ?, ?)
+-- compaction_physical_ms is written from the SAME crdt.UserCrdtState this
+-- statement marshals into state_payload, so the projected column can never
+-- name a watermark the blob does not carry.
+INSERT INTO user_state (user_id, state_payload, compaction_physical_ms, current_epoch, epoch_started_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?)
 ON DUPLICATE KEY UPDATE
     state_payload    = VALUES(state_payload),
+    compaction_physical_ms = VALUES(compaction_physical_ms),
     current_epoch    = VALUES(current_epoch),
     epoch_started_at = VALUES(epoch_started_at),
     updated_at       = VALUES(updated_at);

--- a/backend/internal/hub/store/mysql/user_op_batches.go
+++ b/backend/internal/hub/store/mysql/user_op_batches.go
@@ -16,17 +16,18 @@ var _ store.UserOpBatchesStore = (*userOpBatchesStore)(nil)
 
 func (s *userOpBatchesStore) Insert(ctx context.Context, p store.InsertUserOpBatchParams) error {
 	return mapErr(s.conn.q.InsertUserOpBatch(ctx, gendb.InsertUserOpBatchParams{
-		UserID:       p.UserID.String(),
-		PhysicalMs:   p.PhysicalMs,
-		Logical:      p.Logical,
-		LastLogical:  p.LastLogical,
-		OriginClient: p.OriginClient,
-		PrincipalID:  p.PrincipalID,
-		BatchID:      p.BatchID,
-		BodyHash:     p.BodyHash,
-		BatchPayload: p.BatchPayload,
-		OpCount:      int32(p.OpCount),
-		Epoch:        p.Epoch,
+		UserID:             p.UserID.String(),
+		PhysicalMs:         p.PhysicalMs,
+		Logical:            p.Logical,
+		LastLogical:        p.LastLogical,
+		OriginClient:       p.OriginClient,
+		PrincipalID:        p.PrincipalID,
+		BatchID:            p.BatchID,
+		BodyHash:           p.BodyHash,
+		BatchPayload:       p.BatchPayload,
+		TransitionsPayload: p.TransitionsPayload,
+		OpCount:            int32(p.OpCount),
+		Epoch:              p.Epoch,
 	}))
 }
 
@@ -56,18 +57,19 @@ func (s *userOpBatchesStore) ListAfter(ctx context.Context, p store.ListUserOpBa
 
 func toUserOpBatchRow(r gendb.UserOpBatch) store.UserOpBatchRow {
 	return store.UserOpBatchRow{
-		UserID:       r.UserID,
-		PhysicalMs:   r.PhysicalMs,
-		Logical:      r.Logical,
-		LastLogical:  r.LastLogical,
-		OriginClient: r.OriginClient,
-		PrincipalID:  r.PrincipalID,
-		BatchID:      r.BatchID,
-		BodyHash:     r.BodyHash,
-		BatchPayload: r.BatchPayload,
-		OpCount:      int64(r.OpCount),
-		Epoch:        r.Epoch,
-		CommittedAt:  r.CommittedAt.Time,
+		UserID:             r.UserID,
+		PhysicalMs:         r.PhysicalMs,
+		Logical:            r.Logical,
+		LastLogical:        r.LastLogical,
+		OriginClient:       r.OriginClient,
+		PrincipalID:        r.PrincipalID,
+		BatchID:            r.BatchID,
+		BodyHash:           r.BodyHash,
+		BatchPayload:       r.BatchPayload,
+		TransitionsPayload: r.TransitionsPayload,
+		OpCount:            int64(r.OpCount),
+		Epoch:              r.Epoch,
+		CommittedAt:        r.CommittedAt.Time,
 	}
 }
 

--- a/backend/internal/hub/store/mysql/user_state.go
+++ b/backend/internal/hub/store/mysql/user_state.go
@@ -42,11 +42,12 @@ func (s *userStateStore) Get(ctx context.Context, userID userid.UserID) (*store.
 
 func (s *userStateStore) Upsert(ctx context.Context, p store.UpsertUserStateParams) error {
 	return mapErr(s.conn.q.UpsertUserState(ctx, gendb.UpsertUserStateParams{
-		UserID:         p.UserID.String(),
-		StatePayload:   p.StatePayload,
-		CurrentEpoch:   p.CurrentEpoch,
-		EpochStartedAt: sqltime.NewMySQLTime(p.EpochStartedAt),
-		UpdatedAt:      sqltime.NewMySQLTime(p.UpdatedAt),
+		UserID:               p.UserID.String(),
+		StatePayload:         p.StatePayload,
+		CompactionPhysicalMs: p.CompactionPhysicalMs,
+		CurrentEpoch:         p.CurrentEpoch,
+		EpochStartedAt:       sqltime.NewMySQLTime(p.EpochStartedAt),
+		UpdatedAt:            sqltime.NewMySQLTime(p.UpdatedAt),
 	}))
 }
 

--- a/backend/internal/hub/store/postgres/cleanup.go
+++ b/backend/internal/hub/store/postgres/cleanup.go
@@ -72,3 +72,11 @@ func (s *cleanupStore) CompactPublishedRevocationEvents(
 ) (int64, error) {
 	return newRevocationEventStore(s.conn).CompactPublished(ctx, p.Cutoff)
 }
+
+// DeleteUserOpBatchesBeforePhysical is the retention backstop for CRDT
+// op batches -- see the query's own doc for why the HLC-based compaction tick
+// cannot drain a dormant account, and why the cutoff is an HLC physical rather
+// than the committed_at wall clock.
+func (s *cleanupStore) DeleteUserOpBatchesBeforePhysical(ctx context.Context, cutoffPhysicalMs int64) (int64, error) {
+	return rowsAffected(s.conn.q.DeleteUserOpBatchesBeforePhysical(ctx, cutoffPhysicalMs))
+}

--- a/backend/internal/hub/store/postgres/db/migrations/00001_initial.sql
+++ b/backend/internal/hub/store/postgres/db/migrations/00001_initial.sql
@@ -212,16 +212,32 @@ CREATE TABLE user_op_batches (
     batch_id      TEXT COLLATE "C" NOT NULL,
     body_hash     BYTEA NOT NULL,
     batch_payload BYTEA NOT NULL,
+    transitions_payload BYTEA NOT NULL,
     op_count      INTEGER NOT NULL CHECK (op_count > 0),
     epoch         BIGINT NOT NULL,
-    committed_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    committed_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),  -- operator-facing audit stamp only; NOT a retention predicate (see idx_user_op_batches_physical_ms)
     PRIMARY KEY (user_id, physical_ms, logical, origin_client)
 );
 CREATE UNIQUE INDEX idx_user_op_batches_dedup ON user_op_batches(user_id, batch_id);
+-- Backs DeleteUserOpBatchesBeforePhysical, the cross-user retention sweep.
+-- The PK leads with user_id, which that query does not bind, so without this
+-- the hourly sweep full-scans every user's rows -- including the final pass
+-- that exists only to prove nothing is left to delete.
+CREATE INDEX idx_user_op_batches_physical_ms ON user_op_batches(physical_ms);
 
 CREATE TABLE user_state (
     user_id           TEXT COLLATE "C" PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
     state_payload    BYTEA NOT NULL,
+    -- state_payload.compaction_watermark.physical, projected out of the blob so
+    -- SQL can filter on it. One-way derived, exactly like user_op_batches'
+    -- physical_ms/logical over batch_payload: written from the same struct in
+    -- the same statement and rebuildable from the payload alone.
+    --
+    -- It is the only safe upper bound on op-batch deletion. Bootstrap rebuilds
+    -- a user as state_payload + every batch ABOVE this watermark, so a batch at
+    -- or below it is absorbed and a batch above it is the sole surviving copy
+    -- of those ops. The cross-user retention sweep joins on it for that reason.
+    compaction_physical_ms BIGINT NOT NULL DEFAULT 0,
     current_epoch    BIGINT NOT NULL DEFAULT 1,
     epoch_started_at TIMESTAMPTZ NOT NULL,
     updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()

--- a/backend/internal/hub/store/postgres/db/queries/user_op_batches.sql
+++ b/backend/internal/hub/store/postgres/db/queries/user_op_batches.sql
@@ -1,8 +1,8 @@
 -- name: InsertUserOpBatch :exec
 INSERT INTO user_op_batches (
     user_id, physical_ms, logical, last_logical, origin_client,
-    principal_id, batch_id, body_hash, batch_payload, op_count, epoch
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11);
+    principal_id, batch_id, body_hash, batch_payload, transitions_payload, op_count, epoch
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12);
 
 -- name: ListUserOpBatchesAfter :many
 -- Paged scan so a far-behind subscriber cannot OOM the broadcaster;
@@ -18,6 +18,8 @@ ORDER BY physical_ms, logical, origin_client
 LIMIT sqlc.arg(row_limit)::integer;
 
 -- name: DeleteUserOpBatchesThrough :exec
+-- Boundary alignment with decideResume's `>` test documented in the
+-- sqlite query (canonical home). Keys on the batch's LAST canonical HLC.
 DELETE FROM user_op_batches
 WHERE user_id = $1
   AND (physical_ms < sqlc.arg(through_physical_ms)::bigint
@@ -28,3 +30,26 @@ WHERE user_id = $1
 
 -- name: CountUserOpBatches :one
 SELECT COUNT(*) FROM user_op_batches WHERE user_id = $1;
+
+-- name: DeleteUserOpBatchesBeforePhysical :execresult
+-- Retention backstop for op batches, across ALL users. Both floors
+-- (cutoff_physical_ms and user_state.compaction_physical_ms), why the cutoff is
+-- an HLC physical rather than committed_at, and why the compaction test is a
+-- strict < are documented in the sqlite query (canonical home). The predicate
+-- below must stay identical to it: a sweep that deletes a different set per
+-- backend is exactly the failure that comment exists to prevent.
+--
+-- Batched by PRIMARY KEY, not ctid. This dialect is shared with YugabyteDB,
+-- which rejects the system column outright ("system column ctid is not
+-- supported yet", SQLSTATE 0A000) -- so a ctid-batched sweep compiles, ships,
+-- and then fails at runtime on that backend, silently leaving op batches to
+-- accumulate forever. The full primary key identifies a row just as precisely
+-- and is portable. Only the integration suite (-tags integration + Docker)
+-- exercises YugabyteDB, which is why the difference is easy to miss.
+DELETE FROM user_op_batches
+WHERE (user_id, physical_ms, logical, origin_client) IN (
+    SELECT b.user_id, b.physical_ms, b.logical, b.origin_client FROM user_op_batches b
+    WHERE b.physical_ms < sqlc.arg(cutoff_physical_ms)
+      AND b.physical_ms < (SELECT us.compaction_physical_ms FROM user_state us WHERE us.user_id = b.user_id)
+    LIMIT 1000
+);

--- a/backend/internal/hub/store/postgres/db/queries/user_state.sql
+++ b/backend/internal/hub/store/postgres/db/queries/user_state.sql
@@ -2,10 +2,14 @@
 SELECT * FROM user_state WHERE user_id = $1;
 
 -- name: UpsertUserState :exec
-INSERT INTO user_state (user_id, state_payload, current_epoch, epoch_started_at, updated_at)
-VALUES ($1, $2, $3, $4, $5)
+-- compaction_physical_ms is written from the SAME crdt.UserCrdtState this
+-- statement marshals into state_payload, so the projected column can never
+-- name a watermark the blob does not carry.
+INSERT INTO user_state (user_id, state_payload, compaction_physical_ms, current_epoch, epoch_started_at, updated_at)
+VALUES ($1, $2, $3, $4, $5, $6)
 ON CONFLICT (user_id) DO UPDATE SET
     state_payload    = EXCLUDED.state_payload,
+    compaction_physical_ms = EXCLUDED.compaction_physical_ms,
     current_epoch    = EXCLUDED.current_epoch,
     epoch_started_at = EXCLUDED.epoch_started_at,
     updated_at       = EXCLUDED.updated_at;

--- a/backend/internal/hub/store/postgres/user_op_batches.go
+++ b/backend/internal/hub/store/postgres/user_op_batches.go
@@ -16,17 +16,18 @@ var _ store.UserOpBatchesStore = (*userOpBatchesStore)(nil)
 
 func (s *userOpBatchesStore) Insert(ctx context.Context, p store.InsertUserOpBatchParams) error {
 	return mapErr(s.conn.q.InsertUserOpBatch(ctx, gendb.InsertUserOpBatchParams{
-		UserID:       p.UserID.String(),
-		PhysicalMs:   p.PhysicalMs,
-		Logical:      p.Logical,
-		LastLogical:  p.LastLogical,
-		OriginClient: p.OriginClient,
-		PrincipalID:  p.PrincipalID,
-		BatchID:      p.BatchID,
-		BodyHash:     p.BodyHash,
-		BatchPayload: p.BatchPayload,
-		OpCount:      int32(p.OpCount),
-		Epoch:        p.Epoch,
+		UserID:             p.UserID.String(),
+		PhysicalMs:         p.PhysicalMs,
+		Logical:            p.Logical,
+		LastLogical:        p.LastLogical,
+		OriginClient:       p.OriginClient,
+		PrincipalID:        p.PrincipalID,
+		BatchID:            p.BatchID,
+		BodyHash:           p.BodyHash,
+		BatchPayload:       p.BatchPayload,
+		TransitionsPayload: p.TransitionsPayload,
+		OpCount:            int32(p.OpCount),
+		Epoch:              p.Epoch,
 	}))
 }
 
@@ -56,18 +57,19 @@ func (s *userOpBatchesStore) ListAfter(ctx context.Context, p store.ListUserOpBa
 
 func toUserOpBatchRow(r gendb.UserOpBatch) store.UserOpBatchRow {
 	return store.UserOpBatchRow{
-		UserID:       r.UserID,
-		PhysicalMs:   r.PhysicalMs,
-		Logical:      r.Logical,
-		LastLogical:  r.LastLogical,
-		OriginClient: r.OriginClient,
-		PrincipalID:  r.PrincipalID,
-		BatchID:      r.BatchID,
-		BodyHash:     r.BodyHash,
-		BatchPayload: r.BatchPayload,
-		OpCount:      int64(r.OpCount),
-		Epoch:        r.Epoch,
-		CommittedAt:  r.CommittedAt.Time,
+		UserID:             r.UserID,
+		PhysicalMs:         r.PhysicalMs,
+		Logical:            r.Logical,
+		LastLogical:        r.LastLogical,
+		OriginClient:       r.OriginClient,
+		PrincipalID:        r.PrincipalID,
+		BatchID:            r.BatchID,
+		BodyHash:           r.BodyHash,
+		BatchPayload:       r.BatchPayload,
+		TransitionsPayload: r.TransitionsPayload,
+		OpCount:            int64(r.OpCount),
+		Epoch:              r.Epoch,
+		CommittedAt:        r.CommittedAt.Time,
 	}
 }
 

--- a/backend/internal/hub/store/postgres/user_state.go
+++ b/backend/internal/hub/store/postgres/user_state.go
@@ -42,11 +42,12 @@ func (s *userStateStore) Get(ctx context.Context, userID userid.UserID) (*store.
 
 func (s *userStateStore) Upsert(ctx context.Context, p store.UpsertUserStateParams) error {
 	return mapErr(s.conn.q.UpsertUserState(ctx, gendb.UpsertUserStateParams{
-		UserID:         p.UserID.String(),
-		StatePayload:   p.StatePayload,
-		CurrentEpoch:   p.CurrentEpoch,
-		EpochStartedAt: pgtime.New(p.EpochStartedAt),
-		UpdatedAt:      pgtime.New(p.UpdatedAt),
+		UserID:               p.UserID.String(),
+		StatePayload:         p.StatePayload,
+		CompactionPhysicalMs: p.CompactionPhysicalMs,
+		CurrentEpoch:         p.CurrentEpoch,
+		EpochStartedAt:       pgtime.New(p.EpochStartedAt),
+		UpdatedAt:            pgtime.New(p.UpdatedAt),
 	}))
 }
 

--- a/backend/internal/hub/store/sqlite/canonical_storage_internal_test.go
+++ b/backend/internal/hub/store/sqlite/canonical_storage_internal_test.go
@@ -234,17 +234,18 @@ func TestAllDatetimeColumnsStoreCanonicalLayout(t *testing.T) {
 
 	// user_op_batches.committed_at via its column DEFAULT.
 	require.NoError(t, st.UserOpBatches().Insert(ctx, store.InsertUserOpBatchParams{
-		UserID:       userid.MustNew(user.ID),
-		PhysicalMs:   1,
-		Logical:      1,
-		LastLogical:  1,
-		OriginClient: "client",
-		PrincipalID:  user.ID,
-		BatchID:      "canon-opbatch",
-		BodyHash:     []byte("hash"),
-		BatchPayload: []byte("payload"),
-		OpCount:      1,
-		Epoch:        1,
+		UserID:             userid.MustNew(user.ID),
+		PhysicalMs:         1,
+		Logical:            1,
+		LastLogical:        1,
+		OriginClient:       "client",
+		PrincipalID:        user.ID,
+		BatchID:            "canon-opbatch",
+		BodyHash:           []byte("hash"),
+		BatchPayload:       []byte("payload"),
+		TransitionsPayload: []byte("transitions"),
+		OpCount:            1,
+		Epoch:              1,
 	}))
 
 	// workspace_sections.created_at via its column DEFAULT.

--- a/backend/internal/hub/store/sqlite/cleanup.go
+++ b/backend/internal/hub/store/sqlite/cleanup.go
@@ -72,3 +72,11 @@ func (s *cleanupStore) CompactPublishedRevocationEvents(
 ) (int64, error) {
 	return newRevocationEventStore(s.conn).CompactPublished(ctx, p.Cutoff)
 }
+
+// DeleteUserOpBatchesBeforePhysical is the retention backstop for CRDT
+// op batches -- see the query's own doc for why the HLC-based compaction tick
+// cannot drain a dormant account, and why the cutoff is an HLC physical rather
+// than the committed_at wall clock.
+func (s *cleanupStore) DeleteUserOpBatchesBeforePhysical(ctx context.Context, cutoffPhysicalMs int64) (int64, error) {
+	return rowsAffected(s.conn.q.DeleteUserOpBatchesBeforePhysical(ctx, cutoffPhysicalMs))
+}

--- a/backend/internal/hub/store/sqlite/db/migrations/00001_initial.sql
+++ b/backend/internal/hub/store/sqlite/db/migrations/00001_initial.sql
@@ -229,12 +229,18 @@ CREATE TABLE user_op_batches (
     batch_id      TEXT NOT NULL,                    -- client-minted; dedup key
     body_hash     BLOB NOT NULL,                    -- SHA-256 of OpBatch with per-op HLC/origin fields stripped
     batch_payload BLOB NOT NULL,                    -- proto-marshalled OpBatch (ops carry per-op canonical_hlc)
+    transitions_payload BLOB NOT NULL,              -- proto-marshalled BatchTransitions (per-entity {pre,post} workspace; resume replays them as visibility-transition frames)
     op_count      INTEGER NOT NULL CHECK (op_count > 0),
     epoch         BIGINT NOT NULL,                  -- the user's epoch at commit time
-    committed_at  DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    committed_at  DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),  -- operator-facing audit stamp only; NOT a retention predicate (see idx_user_op_batches_physical_ms)
     PRIMARY KEY (user_id, physical_ms, logical, origin_client)
 );
 CREATE UNIQUE INDEX idx_user_op_batches_dedup ON user_op_batches(user_id, batch_id);
+-- Backs DeleteUserOpBatchesBeforePhysical, the cross-user retention sweep.
+-- The PK leads with user_id, which that query does not bind, so without this
+-- the hourly sweep full-scans every user's rows -- including the final pass
+-- that exists only to prove nothing is left to delete.
+CREATE INDEX idx_user_op_batches_physical_ms ON user_op_batches(physical_ms);
 
 -- One materialized UserCrdtState blob per user. The manager rewrites this
 -- row only on compaction or lifecycle-outbox processing; per-batch
@@ -243,6 +249,16 @@ CREATE UNIQUE INDEX idx_user_op_batches_dedup ON user_op_batches(user_id, batch_
 CREATE TABLE user_state (
     user_id          TEXT PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
     state_payload    BLOB NOT NULL,
+    -- state_payload.compaction_watermark.physical, projected out of the blob so
+    -- SQL can filter on it. One-way derived, exactly like user_op_batches'
+    -- physical_ms/logical over batch_payload: written from the same struct in
+    -- the same statement and rebuildable from the payload alone.
+    --
+    -- It is the only safe upper bound on op-batch deletion. Bootstrap rebuilds
+    -- a user as state_payload + every batch ABOVE this watermark, so a batch at
+    -- or below it is absorbed and a batch above it is the sole surviving copy
+    -- of those ops. The cross-user retention sweep joins on it for that reason.
+    compaction_physical_ms BIGINT NOT NULL DEFAULT 0,
     current_epoch    BIGINT NOT NULL DEFAULT 1,
     epoch_started_at DATETIME NOT NULL,
     updated_at       DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))

--- a/backend/internal/hub/store/sqlite/db/queries/user_op_batches.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/user_op_batches.sql
@@ -1,8 +1,8 @@
 -- name: InsertUserOpBatch :exec
 INSERT INTO user_op_batches (
     user_id, physical_ms, logical, last_logical, origin_client,
-    principal_id, batch_id, body_hash, batch_payload, op_count, epoch
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+    principal_id, batch_id, body_hash, batch_payload, transitions_payload, op_count, epoch
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 -- name: ListUserOpBatchesAfter :many
 -- Paged scan so a far-behind subscriber cannot OOM the broadcaster;
@@ -26,6 +26,16 @@ ORDER BY physical_ms, logical, origin_client
 LIMIT sqlc.arg(row_limit);
 
 -- name: DeleteUserOpBatchesThrough :exec
+-- Boundary alignment: this delete keys on the batch's LAST canonical HLC
+-- (physical_ms, last_logical, origin_client) with a `<=` test, while
+-- crdt.Manager.decideResume admits a resume cursor with a strict `>` test
+-- against op_retention_watermark. The floor from laggedRetentionWatermark
+-- always carries logical=0 (the lag case), so a batch whose last op is at
+-- (floor.physical, last_logical>=1) survives deletion here AND a cursor at
+-- that batch passes resume -- the two boundaries stay consistent. A floor
+-- with a non-zero logical would delete a batch the resume predicate still
+-- admits, opening a silent gap in the client's delta. TestLaggedRetentionWatermark_ZerosLogicalForLagCase
+-- pins the zero-logical invariant.
 DELETE FROM user_op_batches
 WHERE user_id = ?
   AND (physical_ms < sqlc.arg(through_physical_ms)
@@ -36,3 +46,75 @@ WHERE user_id = ?
 
 -- name: CountUserOpBatches :one
 SELECT COUNT(*) FROM user_op_batches WHERE user_id = ?;
+
+-- name: DeleteUserOpBatchesBeforePhysical :execresult
+-- Retention backstop for op batches, across ALL users.
+--
+-- Manager.maybeCompact deletes by HLC, but it only runs while a user is
+-- committing: once compaction_watermark catches up to max_hlc its tick
+-- short-circuits, so a dormant account keeps its final OpRetentionTTL of
+-- batches (and their transitions_payload record snapshots) forever. This
+-- sweep drains that tail on the shared cleanup schedule.
+--
+-- The cutoff is an HLC physical, NOT the committed_at wall clock, so this
+-- deletes exactly the set decideResume refuses. The two are NOT
+-- interchangeable even though HLC physical is Unix epoch-ms: Clock.Tick
+-- clamps physical monotonically and Clock.Observe re-seeds it from the
+-- persisted state, so after a backward clock correction physical runs
+-- permanently ahead of wall time -- and committed_at is assigned by the DB
+-- server, a different machine under Postgres/MySQL. Sweeping on committed_at
+-- would then delete rows whose HLC a live cursor still passes, and
+-- ListUserOpBatchesAfter would silently return the surviving later rows,
+-- shipping a delta with a hole in it. Batched via LIMIT; the caller drains
+-- until a pass deletes nothing. The LIMIT is a hard literal rather than a bind,
+-- and the batching FORM is the one thing the three dialects genuinely diverge on
+-- (rowid here, the full primary key in postgres, a bare DELETE ... LIMIT in
+-- mysql); each names its own reason, and storetest covers all three with a
+-- >LIMIT seed so a form that stopped honouring it cannot pass.
+--
+-- TWO floors bound this delete and BOTH are load-bearing:
+--   1. cutoff_physical_ms -- the retention window (now - OpRetentionTTL).
+--   2. user_state.compaction_physical_ms -- how far that user's state_payload
+--      has actually absorbed.
+--
+-- (2) is not redundant. Bootstrap rebuilds a user as state_payload + every
+-- batch ABOVE compaction_watermark, and state_payload is rewritten only by
+-- Manager.maybeCompact's 60s tick: Manager.Stop does no final pass, and
+-- maybeCompact returns without advancing on a CompactBatch error. So a hub
+-- restart, an idle eviction, or one transient write error within 60s of a
+-- user's last commit leaves compaction_watermark BELOW max_hlc, with that tail
+-- living only in this table. Sweeping on the retention window alone would drop
+-- those rows once the account went dormant past the TTL, and the next Bootstrap
+-- would silently replay a short tail -- the user's last edits gone for good.
+-- The per-user DeleteUserOpBatchesThrough never had this hazard because its
+-- floor is clamped to compaction_watermark and written in the same transaction
+-- as the state blob; this predicate is how the cross-user sweep earns the same
+-- bound.
+--
+-- Strict < against compaction_physical_ms is deliberate, and its cost is real.
+-- The watermark carries a logical component this column does not, so a batch AT
+-- the boundary physical may be only PARTLY absorbed: ops at or below the
+-- watermark's logical are in state_payload, ops committed later in that same
+-- millisecond are not, and nothing in the row tells the two apart. Deleting it
+-- could drop the only copy of those later ops, so it is kept.
+--
+-- Kept FOREVER, though, not "swept on a later pass" -- for a dormant user there
+-- is no later pass that would reach it. maybeCompact only advances
+-- compaction_watermark while the user is committing, and its tick short-circuits
+-- once the watermark reaches max_hlc, so an idle account's floor stops moving and
+-- nothing at or above it is ever eligible again. That ballast is intentional and
+-- bounded per user: the batches sharing that one physical millisecond, plus any
+-- tail a restart or a failed CompactBatch left unabsorbed. It drains the moment
+-- the user commits again and compaction advances past it. Trading it away by
+-- relaxing to <= would delete unabsorbed ops, which is silent data loss --
+-- Bootstrap would replay a short tail and raise no error.
+--
+-- A user with no user_state row has never compacted, so the correlated subquery
+-- yields NULL, the comparison is NULL, and none of their batches are deleted --
+-- which is correct, since every one of them is unabsorbed.
+DELETE FROM user_op_batches WHERE rowid IN (
+    SELECT b.rowid FROM user_op_batches b
+    WHERE b.physical_ms < sqlc.arg(cutoff_physical_ms)
+      AND b.physical_ms < (SELECT us.compaction_physical_ms FROM user_state us WHERE us.user_id = b.user_id)
+    LIMIT 1000
+);

--- a/backend/internal/hub/store/sqlite/db/queries/user_state.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/user_state.sql
@@ -4,16 +4,21 @@ SELECT * FROM user_state WHERE user_id = ?;
 -- name: UpsertUserState :exec
 -- The DO UPDATE reuses the excluded values (SQLiteTime binds the canonical
 -- layout), so both the insert and update paths store the canonical layout.
-INSERT INTO user_state (user_id, state_payload, current_epoch, epoch_started_at, updated_at)
+-- compaction_physical_ms is written from the SAME crdt.UserCrdtState this
+-- statement marshals into state_payload, so the projected column can never
+-- name a watermark the blob does not carry.
+INSERT INTO user_state (user_id, state_payload, compaction_physical_ms, current_epoch, epoch_started_at, updated_at)
 VALUES (
     sqlc.arg(user_id),
     sqlc.arg(state_payload),
+    sqlc.arg(compaction_physical_ms),
     sqlc.arg(current_epoch),
     sqlc.arg(epoch_started_at),
     sqlc.arg(updated_at)
 )
 ON CONFLICT (user_id) DO UPDATE SET
     state_payload    = excluded.state_payload,
+    compaction_physical_ms = excluded.compaction_physical_ms,
     current_epoch    = excluded.current_epoch,
     epoch_started_at = excluded.epoch_started_at,
     updated_at       = excluded.updated_at;

--- a/backend/internal/hub/store/sqlite/user_op_batches.go
+++ b/backend/internal/hub/store/sqlite/user_op_batches.go
@@ -16,17 +16,18 @@ var _ store.UserOpBatchesStore = (*userOpBatchesStore)(nil)
 
 func (s *userOpBatchesStore) Insert(ctx context.Context, p store.InsertUserOpBatchParams) error {
 	return mapErr(s.conn.q.InsertUserOpBatch(ctx, gendb.InsertUserOpBatchParams{
-		UserID:       p.UserID.String(),
-		PhysicalMs:   p.PhysicalMs,
-		Logical:      p.Logical,
-		LastLogical:  p.LastLogical,
-		OriginClient: p.OriginClient,
-		PrincipalID:  p.PrincipalID,
-		BatchID:      p.BatchID,
-		BodyHash:     p.BodyHash,
-		BatchPayload: p.BatchPayload,
-		OpCount:      p.OpCount,
-		Epoch:        p.Epoch,
+		UserID:             p.UserID.String(),
+		PhysicalMs:         p.PhysicalMs,
+		Logical:            p.Logical,
+		LastLogical:        p.LastLogical,
+		OriginClient:       p.OriginClient,
+		PrincipalID:        p.PrincipalID,
+		BatchID:            p.BatchID,
+		BodyHash:           p.BodyHash,
+		BatchPayload:       p.BatchPayload,
+		TransitionsPayload: p.TransitionsPayload,
+		OpCount:            p.OpCount,
+		Epoch:              p.Epoch,
 	}))
 }
 
@@ -56,18 +57,19 @@ func (s *userOpBatchesStore) ListAfter(ctx context.Context, p store.ListUserOpBa
 
 func toUserOpBatchRow(r gendb.UserOpBatch) store.UserOpBatchRow {
 	return store.UserOpBatchRow{
-		UserID:       r.UserID,
-		PhysicalMs:   r.PhysicalMs,
-		Logical:      r.Logical,
-		LastLogical:  r.LastLogical,
-		OriginClient: r.OriginClient,
-		PrincipalID:  r.PrincipalID,
-		BatchID:      r.BatchID,
-		BodyHash:     r.BodyHash,
-		BatchPayload: r.BatchPayload,
-		OpCount:      r.OpCount,
-		Epoch:        r.Epoch,
-		CommittedAt:  r.CommittedAt.Time,
+		UserID:             r.UserID,
+		PhysicalMs:         r.PhysicalMs,
+		Logical:            r.Logical,
+		LastLogical:        r.LastLogical,
+		OriginClient:       r.OriginClient,
+		PrincipalID:        r.PrincipalID,
+		BatchID:            r.BatchID,
+		BodyHash:           r.BodyHash,
+		BatchPayload:       r.BatchPayload,
+		TransitionsPayload: r.TransitionsPayload,
+		OpCount:            r.OpCount,
+		Epoch:              r.Epoch,
+		CommittedAt:        r.CommittedAt.Time,
 	}
 }
 

--- a/backend/internal/hub/store/sqlite/user_state.go
+++ b/backend/internal/hub/store/sqlite/user_state.go
@@ -42,11 +42,12 @@ func (s *userStateStore) Get(ctx context.Context, userID userid.UserID) (*store.
 
 func (s *userStateStore) Upsert(ctx context.Context, p store.UpsertUserStateParams) error {
 	return mapErr(s.conn.q.UpsertUserState(ctx, gendb.UpsertUserStateParams{
-		UserID:         p.UserID.String(),
-		StatePayload:   p.StatePayload,
-		CurrentEpoch:   p.CurrentEpoch,
-		EpochStartedAt: sqltime.NewSQLiteTime(p.EpochStartedAt),
-		UpdatedAt:      sqltime.NewSQLiteTime(p.UpdatedAt),
+		UserID:               p.UserID.String(),
+		StatePayload:         p.StatePayload,
+		CompactionPhysicalMs: p.CompactionPhysicalMs,
+		CurrentEpoch:         p.CurrentEpoch,
+		EpochStartedAt:       sqltime.NewSQLiteTime(p.EpochStartedAt),
+		UpdatedAt:            sqltime.NewSQLiteTime(p.UpdatedAt),
 	}))
 }
 

--- a/backend/internal/hub/store/store.go
+++ b/backend/internal/hub/store/store.go
@@ -578,6 +578,20 @@ type CleanupStore interface {
 	HardDeleteWorkersBefore(ctx context.Context, cutoff time.Time) (int64, error)
 	HardDeleteExpiredRegistrationKeysBefore(ctx context.Context, cutoff time.Time) (int64, error)
 	HardDeleteUsersBefore(ctx context.Context, cutoff time.Time) (int64, error)
+	// DeleteUserOpBatchesBeforePhysical hard-deletes CRDT op batches whose HLC
+	// physical is below cutoffPhysicalMs, across all users, in bounded passes
+	// (the caller drains until a pass deletes nothing). It is the retention
+	// backstop for crdt.OpRetentionTTL: Manager.maybeCompact deletes by HLC but
+	// only runs while a user is committing, so a dormant account would otherwise
+	// retain its final retention window of batches indefinitely.
+	//
+	// The cutoff is an HLC physical rather than a wall clock so this deletes
+	// EXACTLY the set Manager.decideResume refuses. Sweeping the committed_at
+	// column instead would put the two floors in different time domains -- the
+	// hub's monotonically-clamped HLC versus the DB server's wall clock -- and
+	// any skew between them lets this delete rows a live cursor still passes,
+	// which ListUserOpBatchesAfter reports as a short tail rather than an error.
+	DeleteUserOpBatchesBeforePhysical(ctx context.Context, cutoffPhysicalMs int64) (int64, error)
 	// ClearStalePendingEmails wipes pending_email columns for users whose
 	// pending_email_expires_at is older than cutoff. Frees up index slots
 	// and ensures stale codes don't leak into future lookups.

--- a/backend/internal/hub/store/storetest/test_user_op_batches.go
+++ b/backend/internal/hub/store/storetest/test_user_op_batches.go
@@ -1,6 +1,7 @@
 package storetest
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -15,6 +16,218 @@ import (
 // suite; the cases here focus on the raw SQL contracts that the
 // integration suite doesn't run against real SQL backends.
 func (s *Suite) testUserOpBatches(t *testing.T) {
+	// The retention sweep. It runs across ALL owners (a dormant account has no
+	// session to scope it to, which is precisely the case it exists for), so it
+	// must delete strictly by physical_ms and honour its LIMIT identically on
+	// every backend -- a dialect that got the predicate or the batching wrong
+	// would either leak rows forever or delete a live client's resume tail.
+	//
+	// The cutoff is an HLC physical, NOT the committed_at wall clock. That is
+	// what keeps the sweep and Manager.decideResume in one time domain, and it
+	// is also what makes these cases deterministic: the rows carry the exact
+	// physical values under test rather than whatever the DB server stamped.
+	insertBatch := func(t *testing.T, st store.Store, owner userid.UserID, batchID string, physical int64) {
+		t.Helper()
+		require.NoError(t, st.UserOpBatches().Insert(ctx, store.InsertUserOpBatchParams{
+			UserID: owner, PhysicalMs: physical, Logical: 0, LastLogical: 0,
+			OriginClient: "c1", PrincipalID: "p", BatchID: batchID,
+			BodyHash: []byte("h"), BatchPayload: []byte("b"), TransitionsPayload: []byte("t"),
+			OpCount: 1, Epoch: 1,
+		}))
+	}
+
+	// How far this owner's state_payload has actually absorbed its op tail. The
+	// sweep refuses to delete at or above it, so any case that wants the
+	// retention cutoff to be the binding floor must raise this first.
+	absorbedThrough := func(t *testing.T, st store.Store, owner userid.UserID, physical int64) {
+		t.Helper()
+		now := time.Now()
+		require.NoError(t, st.UserState().Upsert(ctx, store.UpsertUserStateParams{
+			UserID:               owner,
+			StatePayload:         []byte("s"),
+			CompactionPhysicalMs: physical,
+			CurrentEpoch:         1,
+			EpochStartedAt:       now,
+			UpdatedAt:            now,
+		}))
+	}
+
+	t.Run("retention sweep deletes by physical cutoff across owners", func(t *testing.T) {
+		st := s.NewStore(t)
+		a := userid.MustNew(SeedUser(t, st, "uob-sweep-a").ID)
+		b := userid.MustNew(SeedUser(t, st, "uob-sweep-b").ID)
+
+		insertBatch(t, st, a, "a-old", 100)
+		insertBatch(t, st, a, "a-new", 300)
+		insertBatch(t, st, b, "b-old", 100)
+		// Both owners are fully compacted, leaving the retention cutoff as the
+		// only floor in play for this case.
+		absorbedThrough(t, st, a, 1_000)
+		absorbedThrough(t, st, b, 1_000)
+
+		countFor := func(owner userid.UserID) int64 {
+			n, err := st.UserOpBatches().Count(ctx, owner)
+			require.NoError(t, err)
+			return n
+		}
+		require.Equal(t, int64(2), countFor(a))
+		require.Equal(t, int64(1), countFor(b))
+
+		// Cutoff 200: both owners' physical=100 rows go, a's physical=300 stays.
+		// Owner-blindness is the point -- b has no session here at all.
+		deleted, err := st.Cleanup().DeleteUserOpBatchesBeforePhysical(ctx, 200)
+		require.NoError(t, err)
+		assert.Equal(t, int64(2), deleted, "the sweep is owner-blind by design; every owner's aged rows must go")
+		assert.Equal(t, int64(1), countFor(a), "a's row above the cutoff must survive")
+		assert.Zero(t, countFor(b))
+	})
+
+	// The boundary itself. decideResume admits a cursor at exactly the cutoff
+	// (its test is a strict `<`), so the sweep must NOT delete the row at that
+	// physical -- otherwise a cursor the manager just accepted resumes onto a
+	// row that is already gone, and ListAfter reports the hole as an ordinary
+	// short tail rather than an error.
+	t.Run("retention sweep keeps the row at exactly the cutoff", func(t *testing.T) {
+		st := s.NewStore(t)
+		owner := userid.MustNew(SeedUser(t, st, "uob-sweep-boundary").ID)
+		insertBatch(t, st, owner, "below", 199)
+		insertBatch(t, st, owner, "at", 200)
+		insertBatch(t, st, owner, "above", 201)
+		absorbedThrough(t, st, owner, 1_000)
+
+		deleted, err := st.Cleanup().DeleteUserOpBatchesBeforePhysical(ctx, 200)
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), deleted, "only the row strictly below the cutoff is eligible")
+
+		n, err := st.UserOpBatches().Count(ctx, owner)
+		require.NoError(t, err)
+		assert.Equal(t, int64(2), n, "the rows at and above the cutoff are a live cursor's resume tail")
+	})
+
+	// The floor the retention window CANNOT see, and the reason the sweep joins
+	// user_state at all.
+	//
+	// state_payload is rewritten only by Manager.maybeCompact's 60s tick --
+	// Manager.Stop does no final pass, and maybeCompact returns without
+	// advancing on a CompactBatch error -- so a hub restart, an idle eviction,
+	// or one transient write error within 60s of a user's last commit leaves
+	// compaction_watermark below max_hlc with that tail living ONLY in this
+	// table. Sweeping on the retention window alone deletes it once the account
+	// goes dormant past the TTL, and the next Bootstrap (state_payload + every
+	// batch above compaction_watermark) silently replays a short tail: the
+	// user's last edits are gone for good, with no error raised anywhere.
+	t.Run("retention sweep keeps batches the state payload has not absorbed", func(t *testing.T) {
+		st := s.NewStore(t)
+		owner := userid.MustNew(SeedUser(t, st, "uob-sweep-unabsorbed").ID)
+
+		insertBatch(t, st, owner, "absorbed", 100)
+		insertBatch(t, st, owner, "unabsorbed", 150)
+		// Compaction reached 120 and then the hub went down. The row at 150 is
+		// far below the retention cutoff but is the only copy of those ops.
+		absorbedThrough(t, st, owner, 120)
+
+		deleted, err := st.Cleanup().DeleteUserOpBatchesBeforePhysical(ctx, 200)
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), deleted, "only the absorbed row is eligible")
+
+		rows, err := st.UserOpBatches().ListAfter(ctx, store.ListUserOpBatchesAfterParams{
+			UserID:            owner,
+			AfterPhysicalMs:   120,
+			AfterLogical:      0,
+			AfterOriginClient: "",
+			Limit:             store.CRDTBatchPageLimit,
+		})
+		require.NoError(t, err)
+		require.Len(t, rows, 1, "the tail Bootstrap replays must still be there")
+		assert.Equal(t, "unabsorbed", rows[0].BatchID)
+	})
+
+	// The LIMIT itself. Every other case here seeds a handful of rows, so the
+	// sweep's `LIMIT 1000` never binds -- and that batching is the ONE place the
+	// three dialects genuinely diverge in FORM: sqlite deletes by `rowid IN
+	// (SELECT ... LIMIT 1000)`, postgres by the four-column primary key tuple
+	// (deliberately not ctid, which YugabyteDB rejects outright), and mysql by a
+	// bare `DELETE ... LIMIT 1000` over a correlated subquery. A form that
+	// silently stopped honouring the LIMIT would delete the whole eligible set in
+	// one statement -- a single unbounded transaction over an arbitrarily large
+	// table on the shared cleanup schedule -- and one that applied it to the
+	// wrong relation could delete far fewer rows per pass than the caller's drain
+	// loop expects, or none at all.
+	//
+	// The LIMIT is a hard literal in the SQL (DeleteUserOpBatchesBeforePhysical
+	// binds only the cutoff), so it cannot be shrunk for the test without
+	// changing the production signature. Seed past it instead: 1500 rows, all
+	// eligible.
+	t.Run("retention sweep honours its LIMIT and drains across passes", func(t *testing.T) {
+		st := s.NewStore(t)
+		owner := userid.MustNew(SeedUser(t, st, "uob-sweep-limit").ID)
+
+		const (
+			seeded    = 1500
+			sweepStep = 1000 // the LIMIT literal in every dialect's sweep
+		)
+		// One transaction for the whole seed: 1500 individually committed inserts
+		// dominate this suite's runtime on the real SQL backends for no benefit.
+		require.NoError(t, st.RunInTransaction(ctx, func(tx store.Store) error {
+			for i := range seeded {
+				// Distinct physical_ms keeps every row a distinct primary key
+				// (user_id, physical_ms, logical, origin_client) and every batch_id
+				// distinct for the dedup index.
+				insertBatch(t, tx, owner, fmt.Sprintf("bulk-%04d", i), int64(i+1))
+			}
+			return nil
+		}))
+		// Absorbed well past the seed, so the retention cutoff is the only floor
+		// and all 1500 rows are eligible.
+		absorbedThrough(t, st, owner, 10_000)
+
+		countRows := func() int64 {
+			n, err := st.UserOpBatches().Count(ctx, owner)
+			require.NoError(t, err)
+			return n
+		}
+		require.Equal(t, int64(seeded), countRows())
+
+		// First pass: exactly the LIMIT, not the whole eligible set.
+		deleted, err := st.Cleanup().DeleteUserOpBatchesBeforePhysical(ctx, seeded+1)
+		require.NoError(t, err)
+		require.Equal(t, int64(sweepStep), deleted,
+			"one pass must delete exactly LIMIT rows, never the whole eligible set")
+		require.Equal(t, int64(seeded-sweepStep), countRows())
+
+		// The caller's contract: drain until a pass deletes nothing. Bounded so a
+		// sweep that stopped making progress fails instead of hanging.
+		var passes int
+		for {
+			passes++
+			require.Less(t, passes, 10, "the drain loop must terminate; the sweep stopped making progress")
+			n, derr := st.Cleanup().DeleteUserOpBatchesBeforePhysical(ctx, seeded+1)
+			require.NoError(t, derr)
+			if n == 0 {
+				break
+			}
+		}
+		assert.Zero(t, countRows(), "the drain must empty every eligible row")
+	})
+
+	// An owner who has never compacted has no user_state row at all, so EVERY
+	// batch they hold is unabsorbed. The sweep must skip them rather than read a
+	// missing watermark as zero -- which under a plain join default would delete
+	// nothing, but under a COALESCE(...,0) would delete their entire journal.
+	t.Run("retention sweep skips owners that have never compacted", func(t *testing.T) {
+		st := s.NewStore(t)
+		owner := userid.MustNew(SeedUser(t, st, "uob-sweep-nostate").ID)
+		insertBatch(t, st, owner, "only", 100)
+
+		deleted, err := st.Cleanup().DeleteUserOpBatchesBeforePhysical(ctx, 200)
+		require.NoError(t, err)
+		assert.Zero(t, deleted, "no state_payload means nothing has been absorbed yet")
+
+		n, err := st.UserOpBatches().Count(ctx, owner)
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), n)
+	})
+
 	// Regression: a fresh user has no rows, no compaction watermark, so
 	// the CRDT manager's bootstrap path calls ListAfter with a zero
 	// HLC and the full CRDTBatchPageLimit. Earlier the SQLite query
@@ -74,7 +287,7 @@ func (s *Suite) testUserOpBatches(t *testing.T) {
 		require.Error(t, st.UserOpBatches().Insert(ctx, store.InsertUserOpBatchParams{
 			UserID: userid.UserID{}, PhysicalMs: 1, Logical: 0, LastLogical: 0,
 			OriginClient: "c", PrincipalID: "", BatchID: "blank-batch",
-			BodyHash: []byte("h"), BatchPayload: []byte("p"), OpCount: 1, Epoch: 1,
+			BodyHash: []byte("h"), BatchPayload: []byte("p"), TransitionsPayload: []byte("t"), OpCount: 1, Epoch: 1,
 		}), "a blank-owner op batch has no parent user row to reference")
 		require.Error(t, st.UserState().Upsert(ctx, store.UpsertUserStateParams{
 			UserID: userid.UserID{}, StatePayload: []byte("state"), CurrentEpoch: 1,
@@ -88,7 +301,7 @@ func (s *Suite) testUserOpBatches(t *testing.T) {
 		require.NoError(t, st.UserOpBatches().Insert(ctx, store.InsertUserOpBatchParams{
 			UserID: userid.MustNew(realUser.ID), PhysicalMs: 1, Logical: 0, LastLogical: 0,
 			OriginClient: "c", PrincipalID: realUser.ID, BatchID: "real-batch",
-			BodyHash: []byte("h"), BatchPayload: []byte("p"), OpCount: 1, Epoch: 1,
+			BodyHash: []byte("h"), BatchPayload: []byte("real-body"), TransitionsPayload: []byte("t"), OpCount: 1, Epoch: 1,
 		}))
 		require.NoError(t, st.UserState().Upsert(ctx, store.UpsertUserStateParams{
 			UserID: userid.MustNew(realUser.ID), StatePayload: []byte("real-state"), CurrentEpoch: 1,
@@ -134,6 +347,19 @@ func (s *Suite) testUserOpBatches(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, rows, 1)
 		assert.Equal(t, "real-batch", rows[0].BatchID)
+		// BOTH payloads, with DISTINCT values, and both directions asserted.
+		// One-sided coverage cannot tell a swap from a correct read: the
+		// postgres and mysql INSERTs gained `transitions_payload` in the MIDDLE
+		// of their placeholder lists, so a positional slip there commits cleanly
+		// and only surfaces as ErrResumeCorrupt on every resume for every user
+		// on that backend -- with the sweep, boundary and LIMIT cases all still
+		// green, because none of them reads a payload back.
+		assert.Equal(t, []byte("real-body"), rows[0].BatchPayload,
+			"batch_payload must round-trip through Insert → ListAfter across every backend")
+		assert.Equal(t, []byte("t"), rows[0].TransitionsPayload,
+			"transitions_payload must round-trip through Insert → ListAfter across every backend")
+		assert.Equal(t, int64(1), rows[0].OpCount,
+			"op_count is the completeness witness the resume scan gates on; a dialect that drops it bricks boot")
 
 		state, err := st.UserState().Get(ctx, userid.MustNew(realUser.ID))
 		require.NoError(t, err)

--- a/backend/internal/hub/store/types.go
+++ b/backend/internal/hub/store/types.go
@@ -247,9 +247,12 @@ type UserOpBatchRow struct {
 	BatchID      string
 	BodyHash     []byte
 	BatchPayload []byte
-	OpCount      int64
-	Epoch        int64
-	CommittedAt  time.Time
+	// TransitionsPayload is the proto-marshalled BatchTransitions the resume
+	// path replays as visibility-transition frames (see crdt.ResumeBatch).
+	TransitionsPayload []byte
+	OpCount            int64
+	Epoch              int64
+	CommittedAt        time.Time
 }
 
 // UserStateRow is the materialized UserCrdtState blob.
@@ -773,8 +776,12 @@ type InsertUserOpBatchParams struct {
 	BatchID      string
 	BodyHash     []byte
 	BatchPayload []byte
-	OpCount      int64
-	Epoch        int64
+	// TransitionsPayload is the proto-marshalled BatchTransitions (per-entity
+	// {pre,post} workspace) the resume path replays as visibility-transition
+	// frames.
+	TransitionsPayload []byte
+	OpCount            int64
+	Epoch              int64
 }
 
 type ListUserOpBatchesAfterParams struct {
@@ -797,11 +804,18 @@ type DeleteUserOpBatchesThroughParams struct {
 
 // UpsertUserStateParams writes a fresh state blob.
 type UpsertUserStateParams struct {
-	UserID         userid.UserID
-	StatePayload   []byte
-	CurrentEpoch   int64
-	EpochStartedAt time.Time
-	UpdatedAt      time.Time
+	UserID       userid.UserID
+	StatePayload []byte
+	// CompactionPhysicalMs is StatePayload's own compaction_watermark.physical,
+	// projected into a column so SQL can filter on it. Callers MUST derive it
+	// from the very state they are marshalling into StatePayload -- it is the
+	// bound the cross-user retention sweep trusts to decide which op batches are
+	// already absorbed, and a value that outran the blob would license deleting
+	// ops no Bootstrap could then replay.
+	CompactionPhysicalMs int64
+	CurrentEpoch         int64
+	EpochStartedAt       time.Time
+	UpdatedAt            time.Time
 }
 
 type AdvanceUserEpochParams struct {

--- a/backend/internal/util/periodic/periodic_test.go
+++ b/backend/internal/util/periodic/periodic_test.go
@@ -105,21 +105,37 @@ func TestStart_SkipFirstRunWaitsForFirstTick(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	const interval = 50 * time.Millisecond
+
 	var calls atomic.Int64
+	// Nanos from `start` to the FIRST invocation, stamped by the task itself.
+	var firstAtNanos atomic.Int64
 	start := time.Now()
-	Start(ctx, Schedule{Interval: 50 * time.Millisecond, SkipFirstRun: true}, func(context.Context) {
+	Start(ctx, Schedule{Interval: interval, SkipFirstRun: true}, func(context.Context) {
 		calls.Add(1)
+		firstAtNanos.CompareAndSwap(0, int64(time.Since(start)))
 	})
 
-	// At ~25ms (well before the first tick at 50ms), the task must not have
+	// At ~half an interval (well before the first tick), the task must not have
 	// run yet — proving the eager invocation was skipped.
-	time.Sleep(25 * time.Millisecond)
+	time.Sleep(interval / 2)
 	assert.Equal(t, int64(0), calls.Load(), "task must not run before the first tick when SkipFirstRun is true")
 
 	// After the first tick, it should fire normally.
 	require.True(t, waitFor(t, 500*time.Millisecond, func() bool { return calls.Load() >= 1 }),
 		"task must fire on the first tick")
-	assert.GreaterOrEqual(t, time.Since(start), 50*time.Millisecond, "first invocation must wait for at least one Interval")
+
+	// Timed at the INVOCATION, not at the observation of it. `time.Since(start)`
+	// after waitFor returns includes that helper's poll latency, so it measured
+	// "when the test noticed" rather than "when the task ran" -- a number that
+	// only ever overstates, and therefore a bound that could pass while the task
+	// fired early. Stamping inside the task removes the poll from the
+	// measurement entirely.
+	//
+	// A LOWER bound, which machine load cannot break: load only delays the tick,
+	// and the failure being guarded against is firing EARLY.
+	assert.GreaterOrEqual(t, time.Duration(firstAtNanos.Load()), interval,
+		"first invocation must wait for at least one Interval")
 }
 
 func TestStart_SkipFirstRunHonorsJitterBeforeFirstTick(t *testing.T) {

--- a/backend/internal/worker/agent/claude_test.go
+++ b/backend/internal/worker/agent/claude_test.go
@@ -717,12 +717,17 @@ func TestAgent_EarlyExitDetected(t *testing.T) {
 		return a, nil
 	}
 
+	// Named so the assertion below can be expressed as a fraction of the very
+	// timeout it must not reach, rather than as a literal that drifts if this
+	// one is retuned.
+	const startupTimeout = 30 * time.Second
+
 	start := time.Now()
 	agent, err := startEarlyExit(ctx, Options{
 		AgentID:        "early-exit-test",
 		Options:        map[string]string{OptionIDModel: "test"},
 		WorkingDir:     t.TempDir(),
-		StartupTimeout: 5 * time.Second,
+		StartupTimeout: startupTimeout,
 	}, noopSink{})
 	elapsed := time.Since(start)
 
@@ -732,8 +737,13 @@ func TestAgent_EarlyExitDetected(t *testing.T) {
 		"error should include the exit code")
 	assert.Contains(t, err.Error(), "cannot be launched inside another Claude Code session",
 		"error should include the stderr message from the crashed process")
-	assert.Less(t, elapsed, 2*time.Second,
-		"should detect early exit quickly, not wait for the full 5s timeout")
+	// Detection must not wait out the startup timeout. Expressed as a fraction
+	// OF that timeout, so the two outcomes stay far apart by construction: a
+	// crashed process is reaped in milliseconds, and the timeout path cannot
+	// finish under 30s. A free-standing 2s literal against a 5s timeout left
+	// only a 3s margin and would silently narrow if the timeout were lowered.
+	assert.Less(t, elapsed, startupTimeout/3,
+		"should detect early exit quickly, not wait for the full startup timeout")
 }
 
 // TestHelperProcessWithPreamble is a test helper that outputs preamble lines

--- a/backend/internal/worker/hub/shutdown_test.go
+++ b/backend/internal/worker/hub/shutdown_test.go
@@ -173,14 +173,22 @@ func TestConnectWithReconnect_HubRetryDelayCancelledByContext(t *testing.T) {
 		cancel()
 	}()
 
-	start := time.Now()
-	bo := newFastBackoff()
-	client.connectWithReconnect(ctx, "token", mockConnect, bo, 5*time.Millisecond)
-	elapsed := time.Since(start)
-
-	// Should have exited well before the 60-second delay.
-	assert.Less(t, elapsed, 2*time.Second,
-		"should exit promptly on context cancel, not wait for full delay")
+	// Exiting on ctx cancel rather than the 60s reconnect delay, asserted as a
+	// COMPLETION against a generous guard: the failing case blocks for a full
+	// minute, so a guard catches it just as surely as a 2s budget and cannot be
+	// crossed by machine load. The attempt count below is the other half of the
+	// proof -- a run that waited out the delay would have retried.
+	returned := make(chan struct{})
+	go func() {
+		defer close(returned)
+		bo := newFastBackoff()
+		client.connectWithReconnect(ctx, "token", mockConnect, bo, 5*time.Millisecond)
+	}()
+	select {
+	case <-returned:
+	case <-time.After(20 * time.Second):
+		t.Fatal("connectWithReconnect ignored the cancelled context and waited on its reconnect delay")
+	}
 	assert.Equal(t, int32(1), attempts.Load(), "expected exactly 1 attempt before cancel")
 }
 

--- a/backend/internal/worker/remoteipc/hub_stream.go
+++ b/backend/internal/worker/remoteipc/hub_stream.go
@@ -91,7 +91,7 @@ func (s *HubEventStreamer) watchUser(ctx context.Context, userID userid.UserID, 
 		return fmt.Errorf("delegation bearer: %w", err)
 	}
 
-	ws, err := channelwire.OpenUserEventsWS(ctx, s.HTTPClient, s.ConnectURL, bearer, req.GetWorkspaceIds())
+	ws, err := channelwire.OpenUserEventsWS(ctx, s.HTTPClient, s.ConnectURL, bearer, req.GetWorkspaceIds(), nil, 0)
 	if err != nil {
 		return err
 	}

--- a/backend/internal/worker/service/file_timeout_test.go
+++ b/backend/internal/worker/service/file_timeout_test.go
@@ -35,12 +35,26 @@ func TestReadDirNWithTimeout_OpenHang(t *testing.T) {
 		}()
 	})
 
-	start := time.Now()
-	entries, err := readDirNWithTimeout(fifo, 10, 50*time.Millisecond)
-	elapsed := time.Since(start)
-
-	require.Error(t, err)
-	require.Nil(t, entries)
-	assert.Contains(t, err.Error(), "timed out")
-	assert.Less(t, elapsed, 500*time.Millisecond, "readDirN blocked past its timeout")
+	// The timeout FIRING is proven by the error, not by elapsed time -- a call
+	// that blocked forever on the fifo would never return one. So the remaining
+	// risk is a hang, guarded by a completion timeout two orders of magnitude
+	// above the 50ms budget under test rather than a 500ms bound sitting one
+	// order above it.
+	type dirResult struct {
+		entries []os.DirEntry
+		err     error
+	}
+	done := make(chan dirResult, 1)
+	go func() {
+		entries, err := readDirNWithTimeout(fifo, 10, 50*time.Millisecond)
+		done <- dirResult{entries, err}
+	}()
+	select {
+	case got := <-done:
+		require.Error(t, got.err)
+		require.Nil(t, got.entries)
+		assert.Contains(t, got.err.Error(), "timed out")
+	case <-time.After(30 * time.Second):
+		t.Fatal("readDirNWithTimeout blocked past its timeout instead of returning")
+	}
 }

--- a/backend/internal/worker/service/startupstate_test.go
+++ b/backend/internal/worker/service/startupstate_test.go
@@ -74,13 +74,24 @@ func TestStartupCore_WaitForPendingResize_WakesOnSignal(t *testing.T) {
 		r.setPendingResize(id, 90, 30)
 	}()
 
+	// The two outcomes are deliberately FAR apart. `ok` alone cannot tell them
+	// apart -- `waitForPendingResize` calls `takePendingResize` after either
+	// select arm, so a broken chan signal still returns the right dims once the
+	// timer fires -- which makes elapsed time the only discriminator. With a
+	// 500ms timeout and a 200ms bound the margin was 300ms, close enough to
+	// machine jitter to fail on a loaded box while the signal worked fine.
+	//
+	// A 30s timeout against a 5s bound keeps exactly the same proof with ~25s of
+	// margin instead: the signal path completes in single-digit ms, and the
+	// timeout path cannot finish under 30s, so nothing load can do reaches the
+	// boundary. The test still exits in milliseconds when it passes.
 	start := time.Now()
-	cols, rows, ok := r.waitForPendingResize(id, 500*time.Millisecond)
+	cols, rows, ok := r.waitForPendingResize(id, 30*time.Second)
 	elapsed := time.Since(start)
 	require.True(t, ok)
 	assert.Equal(t, uint16(90), cols)
 	assert.Equal(t, uint16(30), rows)
-	assert.Less(t, elapsed, 200*time.Millisecond,
+	assert.Less(t, elapsed, 5*time.Second,
 		"chan signal should wake the waiter in ms, not hit the timeout")
 }
 

--- a/backend/internal/worker/service/startupstate_test.go
+++ b/backend/internal/worker/service/startupstate_test.go
@@ -50,12 +50,19 @@ func TestStartupCore_ClearPendingResize_DrainsSignal(t *testing.T) {
 	assert.Equal(t, 0, len(ch),
 		"clearPendingResize must drain the buffered signal so a later waiter can't wake on it")
 
-	// A wait after clear should block for roughly the full timeout,
-	// not wake immediately on a stale signal.
+	// A wait after clear must block for its full timeout rather than waking
+	// immediately on a stale signal. `ok` cannot tell those apart -- both return
+	// false -- so the duration is the discriminator, and it is a LOWER bound,
+	// which machine load cannot break: load only ever makes this slower, and the
+	// failure being guarded against is waking EARLY.
+	//
+	// The two outcomes are pushed far apart all the same, so the assertion does
+	// not depend on a 10ms cushion: a drained-signal wake returns in
+	// microseconds, while the timeout path cannot return before 2s.
 	start := time.Now()
-	_, _, ok := r.waitForPendingResize(id, 50*time.Millisecond)
+	_, _, ok := r.waitForPendingResize(id, 2*time.Second)
 	assert.False(t, ok, "no resize stashed, should time out")
-	assert.GreaterOrEqual(t, time.Since(start), 40*time.Millisecond,
+	assert.GreaterOrEqual(t, time.Since(start), time.Second,
 		"wait should block for roughly the full timeout, not wake on a drained signal")
 }
 

--- a/backend/internal/worker/service/tunnel_test.go
+++ b/backend/internal/worker/service/tunnel_test.go
@@ -495,18 +495,21 @@ func TestTunnelHalfCloseReaper_WriteActivityResetsClock(t *testing.T) {
 // reclamation.
 //
 // The idle window here is widened deliberately (vs withShortHalfCloseReaper's 60ms)
-// so the "teardown beat the idle window" timing assertion has headroom: the
-// lifetime watcher fires on context.AfterFunc (scheduler latency) and
-// AssertEventually polls every ~10ms, so a 60ms margin is flake-prone under CI
-// load. 250ms keeps the assertion decisive (the reaper cannot have run: a conn
-// parked at mark time is not idle-reapable for the full window) while leaving
-// comfortable room for scheduler + poll jitter.
+// so the reaper is pushed far out of reach instead of being raced: a conn
+// parked at mark time is not idle-reapable for a full idle window, and at 30s
+// that window cannot elapse during the test. Eviction is then attributable to
+// the lifetime watcher by construction, with no timing assertion to tune.
 func TestTunnelHalfCloseReaper_ChannelTeardownStillReapsImmediately(t *testing.T) {
 	manager := newTunnelManager()
-	// Override to a wider idle window with generous headroom for the timing check.
+	// Put the idle reaper OUT OF REACH for the duration of the test rather than
+	// racing it. At 30s it cannot possibly have run, so "the conn is gone" is
+	// itself proof that the lifetime watcher reclaimed it -- no elapsed-time
+	// assertion, and nothing for machine load to perturb. Timing the teardown
+	// against a 250ms window instead made the proof depend on scheduler latency
+	// and AssertEventually's ~10ms poll both staying small.
 	origIdle, origInterval := halfCloseIdleTimeout, halfCloseSweepInterval
-	halfCloseIdleTimeout = 250 * time.Millisecond
-	halfCloseSweepInterval = 50 * time.Millisecond
+	halfCloseIdleTimeout = 30 * time.Second
+	halfCloseSweepInterval = 30 * time.Second
 	t.Cleanup(func() { halfCloseIdleTimeout, halfCloseSweepInterval = origIdle, origInterval })
 	t.Cleanup(manager.Stop)
 	const connID = "half-closed-teardown"
@@ -514,16 +517,10 @@ func TestTunnelHalfCloseReaper_ChannelTeardownStillReapsImmediately(t *testing.T
 	t.Cleanup(func() { _ = workerConn.Close() })
 
 	require.NotNil(t, manager.get(connID), "precondition: conn parked half-closed")
-	start := time.Now()
 	cancel() // session death
 	testutil.AssertEventually(t, func() bool { return manager.get(connID) == nil },
 		"channel teardown must evict a half-closed conn immediately, not wait for the idle reaper")
 	assert.True(t, tc.closed.Load())
-	// The conn was parked at mark time, so it is not idle-reapable until a full
-	// idle window elapses. Asserting teardown finished well inside that window
-	// proves the lifetime watcher (not the reaper) reclaimed it.
-	assert.Less(t, time.Since(start), halfCloseIdleTimeout,
-		"teardown must reclaim via the lifetime watcher, faster than the idle deadline")
 }
 
 // TestTunnelHalfCloseReaper_ReapsSequentialHalfCloses pins that the sweeper, once

--- a/backend/internal/worker/service/tunnel_test.go
+++ b/backend/internal/worker/service/tunnel_test.go
@@ -1902,7 +1902,6 @@ func TestWaitWriteSeqReachedIsBoundedByContext(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 
-	start := time.Now()
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
@@ -1912,8 +1911,11 @@ func TestWaitWriteSeqReachedIsBoundedByContext(t *testing.T) {
 	}()
 	select {
 	case <-done:
-		assert.Less(t, time.Since(start), time.Second,
-			"the flush wait must return promptly once its context expires")
+		// No elapsed-time assertion here: reaching this arm at all IS the
+		// proof. `waitReached` would block forever without the context bound,
+		// so the failing case is the other arm, and it fails with a message
+		// naming the actual defect. A second `assert.Less` on top only adds a
+		// budget that machine load can cross while the code is correct.
 	case <-time.After(2 * time.Second):
 		t.Fatal("writeGate.waitReached did not return when its context expired")
 	}

--- a/backend/solo/solo_integration_test.go
+++ b/backend/solo/solo_integration_test.go
@@ -243,16 +243,25 @@ func TestSoloStart_SurfacesHubServeError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	start := time.Now()
-	_, err := solo.Start(ctx, solo.Config{
-		SkipBanner: true,
-		NoTCP:      true,
-	})
-	elapsed := time.Since(start)
-
-	require.Error(t, err, "solo.Start should surface the bind failure")
-	assert.Contains(t, err.Error(), "hub serve",
-		"error should attribute the failure to hub Serve, not the WaitReady timeout")
-	assert.Less(t, elapsed, 5*time.Second,
-		"should not wait the full WaitReady timeout once Serve has already failed")
+	// "Serve's failure short-circuits WaitReady" is proven by the ERROR TEXT --
+	// a run that waited the timeout out reports the WaitReady deadline, not
+	// "hub serve". The elapsed bound was a second, weaker witness for the same
+	// thing, so the completion guard here only has to catch a hang.
+	type startResult struct{ err error }
+	done := make(chan startResult, 1)
+	go func() {
+		_, sErr := solo.Start(ctx, solo.Config{
+			SkipBanner: true,
+			NoTCP:      true,
+		})
+		done <- startResult{sErr}
+	}()
+	select {
+	case got := <-done:
+		require.Error(t, got.err, "solo.Start should surface the bind failure")
+		assert.Contains(t, got.err.Error(), "hub serve",
+			"error should attribute the failure to hub Serve, not the WaitReady timeout")
+	case <-time.After(60 * time.Second):
+		t.Fatal("solo.Start hung instead of surfacing the bind failure")
+	}
 }

--- a/backend/tunnel/channel_integration_test.go
+++ b/backend/tunnel/channel_integration_test.go
@@ -75,17 +75,25 @@ func startTestSolo(t *testing.T) (hubURL, localListenURL, userID, workerID strin
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		stopStarted := time.Now()
-		require.NoError(t, inst.Stop())
-		// Stopping is teardown, but how LONG it takes is a real assertion: the
+		// How LONG Stop takes is a real assertion, not teardown hygiene: the
 		// Hub's HTTP drain gives itself 10s and waits on the connection each
 		// worker's Connect stream is riding, so a shutdown path that leaves
 		// that stream to the worker to close spends the whole budget and then
-		// reports the deadline as an error. That failed here as a flake --
-		// only when the Hub reached its drain before the worker reacted -- so
-		// bound the time, not just the error.
-		assert.Less(t, time.Since(stopStarted), soloStopBudget,
-			"solo shutdown must not wait out the hub's drain budget")
+		// reports the deadline as an error.
+		//
+		// Stated as a COMPLETION against soloStopBudget rather than an elapsed
+		// compare after the fact. Identical discrimination -- the failing path
+		// takes the full 10s drain, the passing one milliseconds -- but this
+		// form fails AT the budget with a message naming the drain, instead of
+		// blocking for the whole 10s and then reporting a number.
+		stopped := make(chan error, 1)
+		go func() { stopped <- inst.Stop() }()
+		select {
+		case err := <-stopped:
+			require.NoError(t, err)
+		case <-time.After(soloStopBudget):
+			t.Fatal("solo shutdown waited out the hub's drain budget instead of closing the worker's Connect stream")
+		}
 	})
 
 	hubURL = "http://" + addr

--- a/backend/tunnel/channel_test.go
+++ b/backend/tunnel/channel_test.go
@@ -1372,11 +1372,26 @@ func TestConnWriteDeadlineInterruptsSendPermitWait(t *testing.T) {
 
 	require.NoError(t, tc.SetWriteDeadline(time.Now().Add(20*time.Millisecond)))
 
-	started := time.Now()
-	n, err := tc.Write([]byte("blocked"))
-	assert.Zero(t, n)
-	assert.ErrorIs(t, err, os.ErrDeadlineExceeded)
-	assert.Less(t, time.Since(started), 250*time.Millisecond)
+	// The deadline firing is proven by the ERROR, not by elapsed time: a Write
+	// that parked forever would never return one. So the only thing left to
+	// guard is a hang, and that is a generous completion timeout rather than a
+	// 250ms budget sitting close to the 20ms deadline it is measuring.
+	type writeResult struct {
+		n   int
+		err error
+	}
+	wrote := make(chan writeResult, 1)
+	go func() {
+		n, err := tc.Write([]byte("blocked"))
+		wrote <- writeResult{n, err}
+	}()
+	select {
+	case got := <-wrote:
+		assert.Zero(t, got.n)
+		assert.ErrorIs(t, got.err, os.ErrDeadlineExceeded)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Write parked past its deadline instead of returning ErrDeadlineExceeded")
+	}
 }
 
 // A write deadline SET AFTER a Write parks on a full send window must wake the
@@ -1475,9 +1490,21 @@ func TestStreamCallbackPreservesOrderWithoutBlockingDelivery(t *testing.T) {
 	stream.deliver(&leapmuxv1.InnerStreamMessage{Payload: []byte("first")})
 	<-firstStarted
 
-	started := time.Now()
-	stream.deliver(&leapmuxv1.InnerStreamMessage{Payload: []byte("second")})
-	assert.Less(t, time.Since(started), 50*time.Millisecond)
+	// "deliver does not block behind the in-flight callback", asserted as a
+	// COMPLETION rather than a 50ms budget. The budget measured the same thing
+	// only as long as the machine was idle; this fails when deliver actually
+	// blocks and is otherwise immune to load, because the timeout is orders of
+	// magnitude above the microseconds a non-blocking enqueue takes.
+	delivered2 := make(chan struct{})
+	go func() {
+		defer close(delivered2)
+		stream.deliver(&leapmuxv1.InnerStreamMessage{Payload: []byte("second")})
+	}()
+	select {
+	case <-delivered2:
+	case <-time.After(5 * time.Second):
+		t.Fatal("deliver blocked behind the in-flight callback instead of queueing behind it")
+	}
 	close(releaseFirst)
 	assert.Equal(t, "first", <-delivered)
 	assert.Equal(t, "second", <-delivered)

--- a/desktop/go/rpc.go
+++ b/desktop/go/rpc.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/leapmux/leapmux/channelwire"
 	desktoppb "github.com/leapmux/leapmux/generated/proto/leapmux/desktop/v1"
 )
 
@@ -496,10 +497,31 @@ func (s *RPCSession) handleRequest(ctx context.Context, req *desktoppb.Request) 
 		s.writeErrOrOK(id, s.app.CloseChannelRelay(m.CloseChannelRelay.GetRelayId()))
 
 	case *desktoppb.Request_OpenUserEventsRelay:
+		req := m.OpenUserEventsRelay
+		// Validate the resume cursor. The hub's ParseResumeCursor rejects a
+		// malformed resume_after_hlc / resume_epoch with HTTP 400 (a malformed
+		// cursor is a client bug, not a legacy client). The sidecar is the ONLY
+		// path between the desktop frontend and the hub, so it applies the SAME
+		// strictness: a malformed field rejects the relay-open RPC (the frontend
+		// treats it as a failed open → reconnect, and on the next attempt sends
+		// a well-formed cursor or none) rather than silently degrading to a
+		// full-snapshot connect. Degrade+log would let a frontend serialization
+		// regression limp along on full snapshots with a warn buried in sidecar
+		// logs the frontend never surfaces — exactly the silent failure the
+		// hub's 400 exists to catch.
+		cursor, epoch, err := channelwire.ParseResumeCursor(req.GetResumeHlc(), req.GetResumeEpoch())
+		if err != nil {
+			slog.Warn("userevents relay: rejected malformed resume cursor",
+				"resume_hlc", req.GetResumeHlc(), "resume_epoch", req.GetResumeEpoch(), "error", err)
+			s.writeError(id, err)
+			return
+		}
 		s.writeErrOrOK(id, s.app.OpenUserEventsRelay(
 			ctx,
-			m.OpenUserEventsRelay.GetRelayId(),
-			m.OpenUserEventsRelay.GetWorkspaceIds(),
+			req.GetRelayId(),
+			req.GetWorkspaceIds(),
+			cursor,
+			epoch,
 		))
 
 	case *desktoppb.Request_CloseUserEventsRelay:

--- a/desktop/go/userevents_relay.go
+++ b/desktop/go/userevents_relay.go
@@ -8,13 +8,14 @@ import (
 	"github.com/coder/websocket"
 	"github.com/leapmux/leapmux/channelwire"
 	desktoppb "github.com/leapmux/leapmux/generated/proto/leapmux/desktop/v1"
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 )
 
 // dialUserEvents opens the userevents WebSocket. A package var (mirroring
 // App.startSolo and TunnelManager.openCh) so tests can hold a dial open and drive
 // the concurrent-open fence below deterministically, which is otherwise a race no
 // test could pin down.
-var dialUserEvents = func(ctx context.Context, proxy *HubProxy, workspaceIDs []string) (*websocket.Conn, error) {
+var dialUserEvents = func(ctx context.Context, proxy *HubProxy, workspaceIDs []string, cursor *leapmuxv1.HLC, epoch int64) (*websocket.Conn, error) {
 	// Fail closed on a missing WS client (see HubProxy.requireWSClient): a nil
 	// wsClient makes OpenUserEventsWSWithHeader fall back to http.DefaultClient,
 	// which carries neither the cookie jar nor pinRedirectsToOrigin and would
@@ -23,7 +24,7 @@ var dialUserEvents = func(ctx context.Context, proxy *HubProxy, workspaceIDs []s
 		return nil, err
 	}
 	return channelwire.OpenUserEventsWSWithHeader(
-		ctx, proxy.wsClient, proxy.baseURL, proxy.cookieHeader(), workspaceIDs,
+		ctx, proxy.wsClient, proxy.baseURL, proxy.cookieHeader(), workspaceIDs, cursor, epoch,
 	)
 }
 
@@ -66,7 +67,7 @@ type UserEventsRelay struct {
 // teardown cancels the relay context before its read loop can emit
 // an userevents:close. So a stale open abandons itself instead:
 // last open dispatched wins, whatever order the sidecar runs them in.
-func (a *App) OpenUserEventsRelay(requestCtx context.Context, relayID uint64, workspaceIDs []string) error {
+func (a *App) OpenUserEventsRelay(requestCtx context.Context, relayID uint64, workspaceIDs []string, cursor *leapmuxv1.HLC, epoch int64) error {
 	return a.openRelay(requestCtx, relayOpenSpec{
 		// Unlike the channel relay's adopt policy, a stale open here refuses
 		// itself outright -- before the dial (an open that ran entirely late
@@ -80,7 +81,7 @@ func (a *App) OpenUserEventsRelay(requestCtx context.Context, relayID uint64, wo
 		// lock) before we dial again.
 		closePrior: func() { _ = a.closeUserEventsRelay() },
 		dial: func(dialCtx context.Context, proxy *HubProxy) (*websocket.Conn, error) {
-			ws, err := dialUserEvents(dialCtx, proxy, workspaceIDs)
+			ws, err := dialUserEvents(dialCtx, proxy, workspaceIDs, cursor, epoch)
 			if err != nil {
 				return nil, fmt.Errorf("connect to userevents relay: %w", err)
 			}

--- a/desktop/go/userevents_relay_test.go
+++ b/desktop/go/userevents_relay_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/coder/websocket"
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -39,12 +40,12 @@ func blockFirstUserEventsDial(t *testing.T) (dialing chan struct{}, release chan
 	original := dialUserEvents
 	t.Cleanup(func() { dialUserEvents = original })
 	var blocked atomic.Bool
-	dialUserEvents = func(ctx context.Context, proxy *HubProxy, workspaceIDs []string) (*websocket.Conn, error) {
+	dialUserEvents = func(ctx context.Context, proxy *HubProxy, workspaceIDs []string, cursor *leapmuxv1.HLC, epoch int64) (*websocket.Conn, error) {
 		if blocked.CompareAndSwap(false, true) {
 			close(dialing)
 			<-release
 		}
-		return original(ctx, proxy, workspaceIDs)
+		return original(ctx, proxy, workspaceIDs, cursor, epoch)
 	}
 	return dialing, release
 }
@@ -70,11 +71,11 @@ func TestApp_OpenUserEventsRelay_ConcurrentOpenDoesNotTearDownTheSuccessor(t *te
 
 	// A opens first and blocks inside its dial.
 	openA := make(chan error, 1)
-	go func() { openA <- app.OpenUserEventsRelay(context.Background(), 1, nil) }()
+	go func() { openA <- app.OpenUserEventsRelay(context.Background(), 1, nil, nil, 0) }()
 	<-dialing
 
 	// B -- a later attempt -- opens and installs while A is still dialing.
-	require.NoError(t, app.OpenUserEventsRelay(context.Background(), 2, nil))
+	require.NoError(t, app.OpenUserEventsRelay(context.Background(), 2, nil, nil, 0))
 	app.lifecycleMu.RLock()
 	relayB := app.connection.userEventsRelay
 	app.lifecycleMu.RUnlock()
@@ -106,14 +107,14 @@ func TestApp_CloseUserEventsRelay_IgnoresStaleOwner(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, app.Shutdown()) })
 	installTestConnection(app, newHTTPProxy(server.URL), nil, server.URL)
 
-	require.NoError(t, app.OpenUserEventsRelay(context.Background(), 1, nil))
+	require.NoError(t, app.OpenUserEventsRelay(context.Background(), 1, nil, nil, 0))
 	app.lifecycleMu.RLock()
 	relayA := app.connection.userEventsRelay
 	app.lifecycleMu.RUnlock()
 	require.NotNil(t, relayA)
 
 	// The force-restart open hands the slot to a fresh relay owned by B.
-	require.NoError(t, app.OpenUserEventsRelay(context.Background(), 2, nil))
+	require.NoError(t, app.OpenUserEventsRelay(context.Background(), 2, nil, nil, 0))
 	app.lifecycleMu.RLock()
 	relayB := app.connection.userEventsRelay
 	app.lifecycleMu.RUnlock()
@@ -147,13 +148,13 @@ func TestApp_OpenUserEventsRelay_StaleOpenLeavesTheNewerRelayInstalled(t *testin
 	t.Cleanup(func() { require.NoError(t, app.Shutdown()) })
 	installTestConnection(app, newHTTPProxy(server.URL), nil, server.URL)
 
-	require.NoError(t, app.OpenUserEventsRelay(context.Background(), 9, nil))
+	require.NoError(t, app.OpenUserEventsRelay(context.Background(), 9, nil, nil, 0))
 	app.lifecycleMu.RLock()
 	relayBefore := app.connection.userEventsRelay
 	app.lifecycleMu.RUnlock()
 	require.NotNil(t, relayBefore)
 
-	require.Error(t, app.OpenUserEventsRelay(context.Background(), 8, nil),
+	require.Error(t, app.OpenUserEventsRelay(context.Background(), 8, nil, nil, 0),
 		"an open that ran entirely after a newer one is stale")
 
 	app.lifecycleMu.RLock()
@@ -172,9 +173,41 @@ func TestApp_OpenUserEventsRelay_StaleOpenLeavesTheNewerRelayInstalled(t *testin
 // it must break loudly, not silently dial unpinned.
 func TestDialUserEvents_FailsClosedWithoutPinnedWSClient(t *testing.T) {
 	proxy := &HubProxy{baseURL: "http://hub.example"} // wsClient deliberately nil
-	_, err := dialUserEvents(context.Background(), proxy, nil)
+	_, err := dialUserEvents(context.Background(), proxy, nil, nil, 0)
 	require.Error(t, err, "a nil wsClient must fail the dial, not degrade to http.DefaultClient")
 	assert.Contains(t, err.Error(), "pinned WebSocket client")
+}
+
+// TestApp_OpenUserEventsRelay_ForwardsResumeCursor pins the load-bearing
+// desktop forwarding path: a non-nil resume cursor passed to OpenUserEventsRelay
+// must reach dialUserEvents unchanged, so the hub receives it on the /ws/userevents
+// URL and can ship a ResumeDelta. A regression that dropped the cursor arg would
+// silently disable desktop resume (every reconnect would full-snapshot). The
+// existing relay tests all pass nil cursors; this is the only one that forwards a
+// real one.
+func TestApp_OpenUserEventsRelay_ForwardsResumeCursor(t *testing.T) {
+	server := userEventsTestServer(t)
+	app := NewApp("")
+	t.Cleanup(func() { require.NoError(t, app.Shutdown()) })
+	installTestConnection(app, newHTTPProxy(server.URL), nil, server.URL)
+
+	cursor := &leapmuxv1.HLC{Physical: 1754100000000, Logical: 3, ClientId: "c-abc"}
+	var gotCursor *leapmuxv1.HLC
+	var gotEpoch int64
+	original := dialUserEvents
+	t.Cleanup(func() { dialUserEvents = original })
+	dialUserEvents = func(ctx context.Context, proxy *HubProxy, workspaceIDs []string, c *leapmuxv1.HLC, e int64) (*websocket.Conn, error) {
+		gotCursor = c
+		gotEpoch = e
+		return original(ctx, proxy, workspaceIDs, c, e)
+	}
+
+	require.NoError(t, app.OpenUserEventsRelay(context.Background(), 1, nil, cursor, 42))
+	require.NotNil(t, gotCursor, "the resume cursor must be forwarded to the dial")
+	assert.Equal(t, cursor.GetPhysical(), gotCursor.GetPhysical())
+	assert.Equal(t, cursor.GetLogical(), gotCursor.GetLogical())
+	assert.Equal(t, cursor.GetClientId(), gotCursor.GetClientId())
+	assert.Equal(t, int64(42), gotEpoch, "the resume epoch must be forwarded to the dial")
 }
 
 // The guard above only matters because production proxies always carry a pinned

--- a/desktop/rust/src/main.rs
+++ b/desktop/rust/src/main.rs
@@ -1014,6 +1014,8 @@ async fn open_userevents_relay(
     shell: State<'_, Arc<DesktopShell>>,
     relay_id: u64,
     workspace_ids: Vec<String>,
+    resume_hlc: Option<String>,
+    resume_epoch: Option<String>,
 ) -> Result<(), String> {
     check_response(
         shell
@@ -1021,6 +1023,8 @@ async fn open_userevents_relay(
                 proto::OpenUserEventsRelayRequest {
                     relay_id,
                     workspace_ids,
+                    resume_hlc,
+                    resume_epoch,
                 },
             ))
             .await?,

--- a/frontend/src/api/clients.ts
+++ b/frontend/src/api/clients.ts
@@ -6,7 +6,7 @@ import { UserCRDT } from '~/generated/leapmux/v1/user_ops_pb'
 import { UserService } from '~/generated/leapmux/v1/user_pb'
 import { WorkerManagementService } from '~/generated/leapmux/v1/worker_pb'
 import { WorkspaceService } from '~/generated/leapmux/v1/workspace_pb'
-import { transport } from './transport'
+import { transport, unloadTransport } from './transport'
 
 export const authClient = createClient(AuthService, transport)
 export const workerClient = createClient(WorkerManagementService, transport)
@@ -15,3 +15,9 @@ export const sectionClient = createClient(SectionService, transport)
 export const channelClient = createClient(ChannelService, transport)
 export const workspaceClient = createClient(WorkspaceService, transport)
 export const userCRDTClient = createClient(UserCRDT, transport)
+/**
+ * SubmitOps over the keepalive transport, for the `pagehide` flush only. See
+ * `unloadTransport` for why keepalive is what makes that flush reach the hub at
+ * all, and for the 64 KiB budget it carries.
+ */
+export const userCRDTUnloadClient = createClient(UserCRDT, unloadTransport)

--- a/frontend/src/api/platformBridge.test.ts
+++ b/frontend/src/api/platformBridge.test.ts
@@ -493,7 +493,36 @@ describe('userevents relay bridge', () => {
 
     expect(calls).toEqual([{
       cmd: 'open_userevents_relay',
-      args: { relayId: 42, workspaceIds: ['ws-1'] },
+      args: { relayId: 42, workspaceIds: ['ws-1'], resumeHlc: null, resumeEpoch: null },
+    }])
+  })
+
+  it('serializes a populated resume cursor as wire HLC + epoch string', async () => {
+    // Pins the populated branch of openUserEventsRelay: resume.hlc must flow
+    // through formatHlcWire (not the raw proto object) and resume.epoch must
+    // be .toString()-ed (Tauri IPC carries no bigint). A regression that
+    // drops the epoch arg, passes the proto object directly, or skips the
+    // wire format would round-trip green through the null-cursor test above
+    // but make the desktop sidecar reject the relay-open on every reconnect.
+    const calls: Array<{ cmd: string, args: unknown }> = []
+    mockIPC((cmd, args) => {
+      calls.push({ cmd, args })
+      return null
+    })
+
+    await platformBridge.openUserEventsRelay(7, ['ws-1'], {
+      hlc: { physical: 1754100000000n, logical: 3n, clientId: 'c-abc' },
+      epoch: 7n,
+    })
+
+    expect(calls).toEqual([{
+      cmd: 'open_userevents_relay',
+      args: {
+        relayId: 7,
+        workspaceIds: ['ws-1'],
+        resumeHlc: '1754100000000.3.c-abc',
+        resumeEpoch: '7',
+      },
     }])
   })
 

--- a/frontend/src/api/platformBridge.ts
+++ b/frontend/src/api/platformBridge.ts
@@ -1,6 +1,7 @@
 import type { BuildInfo } from '~/lib/buildEnv'
 import type { TrailingDebounced } from '~/lib/debounce'
 import { arrayBufferToBase64, base64ToArrayBuffer } from '~/lib/base64'
+import { formatHlcWire } from '~/lib/crdt/hlc'
 import { trailingDebounce } from '~/lib/debounce'
 import { createLogger } from '~/lib/logger'
 import { isMac } from '~/lib/shortcuts/platform'
@@ -750,9 +751,24 @@ export const platformBridge = {
   // weight here: this open force-restarts the relay (the hub sends UserMaterialized
   // only at subscribe time, so reusing a live relay would leave a fresh page without
   // its bootstrap), so the sidecar also uses the id to ignore an OPEN that a newer
-  // one has already superseded.
-  async openUserEventsRelay(relayId: number, workspaceIds: string[] = []): Promise<void> {
-    await tauriInvoke('open_userevents_relay', { relayId, workspaceIds })
+  // one has already superseded. `resume`, when present, is the per-user resume
+  // cursor the sidecar threads into the /ws/userevents URL so the hub can ship a
+  // ResumeDelta; serialized as a wire string + epoch (Tauri IPC carries no
+  // bigint), mirroring the resume_after_hlc query-param shape the Go side parses.
+  async openUserEventsRelay(
+    relayId: number,
+    workspaceIds: string[] = [],
+    resume?: { hlc: { physical: bigint, logical: bigint, clientId: string }, epoch: bigint } | null,
+  ): Promise<void> {
+    const resumeHlc = resume
+      ? formatHlcWire(resume.hlc)
+      : null
+    await tauriInvoke('open_userevents_relay', {
+      relayId,
+      workspaceIds,
+      resumeHlc,
+      resumeEpoch: resume ? resume.epoch.toString() : null,
+    })
   },
   async closeUserEventsRelay(relayId: number): Promise<void> {
     await tauriInvoke('close_userevents_relay', { relayId })

--- a/frontend/src/api/transport.ts
+++ b/frontend/src/api/transport.ts
@@ -53,6 +53,43 @@ export const transport = createConnectTransport({
   defaultTimeoutMs: 30_000,
 })
 
+/**
+ * Largest body `unloadTransport` will attempt.
+ *
+ * `keepalive` requests share a 64 KiB budget across ALL in-flight ones, and a
+ * request over it fails outright — so a caller must fall back rather than
+ * discover this during unload, when there is no second chance.
+ */
+export const MAX_KEEPALIVE_BODY_BYTES = 60 * 1024
+
+/**
+ * A transport for requests issued from a `pagehide` handler.
+ *
+ * Identical to `transport` except for `keepalive: true`. That flag is the whole
+ * point: a normal fetch started while the page is unloading is CANCELLED with
+ * it, so an op enqueued at unload never reaches the hub — the browser tears the
+ * request down along with the document. `keepalive` asks the browser to let it
+ * complete after the page is gone.
+ *
+ * A separate transport rather than a flag on the shared one because keepalive
+ * carries a hard 64 KiB budget shared across every in-flight keepalive request.
+ * Making it the default would silently cap ordinary traffic (a materialized
+ * snapshot is routinely larger); confining it to the unload path keeps the cap
+ * where the payload is a handful of ops.
+ *
+ * Everything else — auth via the same credential fetch, the Connect protocol
+ * framing, the error interceptor — is shared, which is why this is a transport
+ * and not a hand-rolled `sendBeacon`: a beacon cannot set headers, so it would
+ * need its own endpoint and its own auth story.
+ */
+export const unloadTransport = createConnectTransport({
+  baseUrl: window.location.origin,
+  fetch: (input, init) => getTransportFetch()(input, { ...init, keepalive: true }),
+  interceptors: [errorInterceptor],
+  // No timeout: the page is going away, so there is nothing left to time out
+  // INTO. The browser bounds the request itself once the document is gone.
+})
+
 // ---------------------------------------------------------------------------
 // Dynamic timeout configuration
 // ---------------------------------------------------------------------------

--- a/frontend/src/components/settings/AppearanceSettings.test.tsx
+++ b/frontend/src/components/settings/AppearanceSettings.test.tsx
@@ -1,6 +1,10 @@
 import { fireEvent, render, screen } from '@solidjs/testing-library'
-import { describe, expect, it, vi } from 'vitest'
-import { PillGroupForTest } from './AppearanceSettings'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTerminalOsNotifications, PillGroupForTest } from './AppearanceSettings'
+
+// The OS permission prompt is the one dependency the toggle's branches turn on.
+const requestPermission = vi.hoisted(() => vi.fn<() => Promise<boolean>>())
+vi.mock('~/lib/osNotification', () => ({ requestOsNotificationPermission: requestPermission }))
 
 /**
  * The preference pills are one-of-N groups, so they carry radiogroup/radio
@@ -85,5 +89,39 @@ describe('pillGroup', () => {
     const onSelect = renderGroup('light')
     fireEvent.keyDown(screen.getByRole('radiogroup', { name: 'Theme' }), { key: 'ArrowRight' })
     expect(onSelect).toHaveBeenLastCalledWith(null)
+  })
+})
+
+/**
+ * The terminal-OS-notifications toggle. The decision is a two-branch permission
+ * flow that had no coverage: the toggle shipped as an inline async callback, so
+ * the only way to reach either branch was a full component render against the
+ * real PreferencesProvider.
+ */
+describe('nextTerminalOsNotifications', () => {
+  beforeEach(() => {
+    requestPermission.mockReset()
+  })
+
+  it('stores true when the user grants permission', async () => {
+    requestPermission.mockResolvedValue(true)
+    await expect(nextTerminalOsNotifications(false)).resolves.toBe(true)
+    expect(requestPermission).toHaveBeenCalledTimes(1)
+  })
+
+  it('stays off when the user declines', async () => {
+    // The branch that matters: showing the toggle ON with no OS permission
+    // behind it would promise notifications that can never arrive.
+    requestPermission.mockResolvedValue(false)
+    await expect(nextTerminalOsNotifications(false)).resolves.toBe(false)
+    expect(requestPermission).toHaveBeenCalledTimes(1)
+  })
+
+  it('turns off without prompting', async () => {
+    // Re-asking for a permission the user is in the act of switching OFF is
+    // prompt fatigue, and on a denied origin the browser answers from its own
+    // sticky decision anyway -- which would flip the toggle back on.
+    await expect(nextTerminalOsNotifications(true)).resolves.toBe(false)
+    expect(requestPermission).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/components/settings/AppearanceSettings.tsx
+++ b/frontend/src/components/settings/AppearanceSettings.tsx
@@ -144,6 +144,26 @@ function PillGroup<T>(props: {
 // depends on rather than styling.
 export { PillGroup as PillGroupForTest }
 
+/**
+ * The value the terminal-OS-notifications toggle should store, given what it
+ * currently holds.
+ *
+ * Turning it ON asks the OS and stores the answer, so declining leaves the
+ * preference off rather than showing it on with nothing behind it. Turning it
+ * OFF stores false and must NOT prompt -- re-asking for a permission the user
+ * is in the act of switching off is exactly the prompt-fatigue browsers
+ * penalize. Both fall out of the short-circuit.
+ *
+ * Split out of the component because those two branches are the part worth
+ * testing and the component reads its state from context: reaching them through
+ * a render would need the real PreferencesProvider, whose onMount reloads
+ * preferences over the network.
+ */
+export async function nextTerminalOsNotifications(current: boolean): Promise<boolean> {
+  const next = !current
+  return next && await requestOsNotificationPermission()
+}
+
 /** The "inherit the account setting" pill every browser-scoped group leads with. */
 const ACCOUNT_DEFAULT = { value: null, label: 'Use account default' }
 
@@ -307,6 +327,15 @@ export const AccountAppearanceSettings: Component = () => {
     }
   }
 
+  // Declared here rather than inline in the JSX because an async callback
+  // passed straight to a prop is not a tracked scope past its first await --
+  // Solid tracks synchronously, so a signal read after the permission prompt
+  // would resolve outside any reactive context. The decision itself lives in
+  // nextTerminalOsNotifications so the permission branches are testable.
+  const handleTerminalOsNotificationsToggle = async () => {
+    prefs.setTerminalOsNotifications(await nextTerminalOsNotifications(prefs.terminalOsNotifications()))
+  }
+
   return (
     <>
       <div class={styles.section}>
@@ -365,17 +394,7 @@ export const AccountAppearanceSettings: Component = () => {
         <h3>Terminal Notifications</h3>
         <PillToggle
           pressed={prefs.terminalOsNotifications()}
-          onClick={async () => {
-            const next = !prefs.terminalOsNotifications()
-            if (next) {
-              const granted = await requestOsNotificationPermission()
-              if (!granted) {
-                prefs.setTerminalOsNotifications(false)
-                return
-              }
-            }
-            prefs.setTerminalOsNotifications(next)
-          }}
+          onClick={() => void handleTerminalOsNotificationsToggle()}
         >
           OS notifications for terminal alerts
         </PillToggle>

--- a/frontend/src/components/shell/FloatingWindowContainer.test.tsx
+++ b/frontend/src/components/shell/FloatingWindowContainer.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@solidjs/testing-library'
+import { createSignal } from 'solid-js'
 import { describe, expect, it, vi } from 'vitest'
 import { createTestFloatingWindowStore } from '~/test-support/tabStores'
 import { FloatingWindowContainer, resolveParentSize, snapPosition } from './FloatingWindowContainer'
@@ -232,5 +233,66 @@ describe('floatingWindowContainer', () => {
     expect(onActivate).toHaveBeenCalledTimes(1)
     // After bringToFront the rendered window must have moved to the end.
     expect(store.state.windows.findIndex(w => w.id === windowId)).toBe(1)
+  })
+})
+
+// Edge-snapping during a MOVE must measure against the window's LIVE size, not
+// the size captured at pointer-down.
+//
+// The store deliberately does NOT mask width/height behind a move override, so
+// a peer's resize landing mid-drag is projected immediately -- that is what
+// makes the drag feel correct. Snapping against a frozen size therefore made
+// the edge test and the rendered window disagree by exactly the size delta: the
+// window snapped to a visibly wrong offset, and `commitDragGeometry` persisted
+// that wrong x to every client.
+describe('move-drag edge snapping', () => {
+  it('snaps against the live width when a peer resizes mid-drag', () => {
+    const store = createTestFloatingWindowStore()
+    const created = store.addWindow({ x: 0.1, y: 0.1, width: 0.2, height: 0.2 })
+    if (!created)
+      throw new Error('addWindow returned null')
+
+    const moves: Array<{ x: number, y: number }> = []
+    const spyStore = Object.assign(Object.create(store) as typeof store, {
+      updateDragMove: (_id: string, x: number, y: number) => {
+        moves.push({ x, y })
+      },
+    })
+
+    const [width, setWidth] = createSignal(0.2)
+    render(() => (
+      <FloatingWindowContainer
+        windowId={created.windowId}
+        x={0.1}
+        y={0.1}
+        width={width()}
+        height={0.2}
+        opacity={1}
+        zIndex={100}
+        title="Test Window"
+        floatingWindowStore={spyStore}
+        onClose={() => {}}
+      >
+        <div data-testid="window-content">child</div>
+      </FloatingWindowContainer>
+    ))
+
+    const titleBar = screen.getByTestId('floating-window-titlebar')
+    const { parentW } = resolveParentSize(titleBar)
+
+    fireEvent.pointerDown(titleBar, { clientX: 0, clientY: 0 })
+    // The peer's resize lands while the pointer is still down. 0.2 -> 0.5.
+    setWidth(0.5)
+    // Move so the window's LEFT edge sits at 0.505: with the live width its
+    // right edge is 0.005 from the viewport edge -- inside the 15px snap
+    // threshold -- while with the pointer-down width it is 0.2996 away, far
+    // outside it. The two sizes therefore disagree about whether to snap at all.
+    fireEvent.pointerMove(document, { clientX: 0.405 * parentW, clientY: 0 })
+
+    const last = moves.at(-1)
+    expect(last).toBeDefined()
+    // Snapped flush to the edge using the LIVE width. Reading the frozen width
+    // would leave it unsnapped at ~0.505.
+    expect(last!.x).toBeCloseTo(0.5, 6)
   })
 })

--- a/frontend/src/components/shell/FloatingWindowContainer.tsx
+++ b/frontend/src/components/shell/FloatingWindowContainer.tsx
@@ -124,16 +124,17 @@ export const FloatingWindowContainer: Component<FloatingWindowContainerProps> = 
   // --- Edge snapping ---
 
   // --- Opacity (scroll on titlebar) ---
-  // The wheel can fire ~60×/sec on a free-spinning trackpad. `updateOpacity`
-  // returns whether the clamped value actually changed so we don't bounce
-  // `onGeometryChange` (debounced persist) on every tick once opacity is
-  // pinned at the clamp floor or ceiling.
+  // The wheel can fire dozens of times per scroll gesture on a free-spinning
+  // trackpad. `updateOpacityDebounced` writes the live value to a local
+  // override (instant feedback) and arms a trailing debounce that emits ONE
+  // CRDT op when scrolling pauses — collapsing a whole scroll gesture to a
+  // single op instead of one per wheel tick.
   const handleTitleBarWheel = (e: WheelEvent) => {
     e.preventDefault()
     if (e.deltaY === 0)
       return
     const delta = e.deltaY > 0 ? -0.05 : 0.05
-    const changed = props.floatingWindowStore.updateOpacity(props.windowId, props.opacity + delta)
+    const changed = props.floatingWindowStore.updateOpacityDebounced(props.windowId, props.opacity + delta)
     if (changed)
       props.onGeometryChange?.()
   }
@@ -145,7 +146,39 @@ export const FloatingWindowContainer: Component<FloatingWindowContainerProps> = 
     })
   })
 
+  // Flush a pending debounced-opacity op when this container unmounts so a
+  // scroll in flight when the window closes isn't lost.
+  //
+  // Also abort any drag still in flight for THIS window. `useWindowPointerDrag`
+  // reacts to unmount by calling stop(), which deliberately fires no onUp, so
+  // `commitDragGeometry` never runs and the local override would otherwise
+  // outlive the gesture — the projection reads it unconditionally by id, so the
+  // window would render frozen at never-committed geometry (and mask incoming
+  // CRDT geometry) until some later drag replaced the override. Aborting rather
+  // than committing is deliberate: an unmount is not a drop, so the partial
+  // motion should not be persisted.
+  onCleanup(() => {
+    props.floatingWindowStore.flushOpacity(props.windowId)
+    props.floatingWindowStore.cancelDragGeometry(props.windowId)
+  })
+
   // --- Drag ---
+  // The drag writes the live geometry into a LOCAL store override (no CRDT op)
+  // so the window tracks the pointer responsively, then commits ONE op on drop
+  // (commitDragGeometry). Peers see the window jump to its final position on
+  // release instead of gliding frame-by-frame — the same tradeoff the splitter
+  // drag (useTileDragResize) already makes. This cuts a per-drag op storm from
+  // ~60-120 (one per rAF frame) down to 1, which in turn slashes op-log growth,
+  // wire volume, and the BatchCommitted-echo projection churn the per-frame
+  // path produced.
+  //
+  // Both gestures end the same way, so they share one callback rather than two
+  // copies of it.
+  const endDragGesture = () => {
+    props.floatingWindowStore.commitDragGeometry(props.windowId)
+    props.onGeometryChange?.()
+  }
+
   const handleDragStart = (e: PointerEvent) => {
     if ((e.target as HTMLElement).closest('button'))
       return
@@ -167,16 +200,24 @@ export const FloatingWindowContainer: Component<FloatingWindowContainerProps> = 
         const dfy = (me.clientY - startY) / parentH
         const rawX = startFx + dfx
         const rawY = startFy + dfy
+        // Snap against the window's LIVE size, not the pointer-down snapshot.
+        // A move override deliberately does not mask width/height, so the store
+        // keeps projecting a peer's mid-drag resize; snapping against a frozen
+        // size would leave the edge test and the rendered window disagreeing by
+        // exactly the size delta, and commitDragGeometry would then persist that
+        // wrong x/y to every client. props.width/height are live getters off the
+        // reconciled store, so reading them per frame is the whole fix.
         const snapped = snapPosition(rawX, rawY, props.width, props.height, parentW, parentH)
-        props.floatingWindowStore.updatePosition(props.windowId, snapped.x, snapped.y)
+        props.floatingWindowStore.updateDragMove(props.windowId, snapped.x, snapped.y)
       },
-      onUp: () => {
-        props.onGeometryChange?.()
-      },
+      onUp: endDragGesture,
     })
   }
 
   // --- Resize ---
+  // Same override-during-drag + commit-on-drop pattern as the move handler
+  // (see handleDragStart). The resize writes the live geometry into the local
+  // override each frame; commitDragGeometry emits the single op on drop.
   const handleResizeStart = (dir: ResizeDir, e: PointerEvent) => {
     e.preventDefault()
     e.stopPropagation()
@@ -223,9 +264,9 @@ export const FloatingWindowContainer: Component<FloatingWindowContainerProps> = 
           newY = startFy + startFh - newH
         }
 
-        props.floatingWindowStore.updateGeometry(props.windowId, newX, newY, newW, newH)
+        props.floatingWindowStore.updateDragResize(props.windowId, newX, newY, newW, newH)
       },
-      onUp: () => props.onGeometryChange?.(),
+      onUp: endDragGesture,
     })
   }
 
@@ -252,6 +293,7 @@ export const FloatingWindowContainer: Component<FloatingWindowContainerProps> = 
       <div
         ref={titleBarRef}
         class={styles.titleBar}
+        data-testid="floating-window-titlebar"
         onPointerDown={handleDragStart}
       >
         <span class={styles.titleText}>{props.title}</span>

--- a/frontend/src/components/shell/useCrdtRuntime.test.ts
+++ b/frontend/src/components/shell/useCrdtRuntime.test.ts
@@ -1,0 +1,595 @@
+import type { CheckpointRecorder, CheckpointRecorderOptions } from '~/lib/crdt/checkpointRecorder'
+import { create, toBinary } from '@bufbuild/protobuf'
+import { IDBFactory, IDBKeyRange } from 'fake-indexeddb'
+import { createRoot, createSignal } from 'solid-js'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { UserCrdtStateSchema } from '~/generated/leapmux/v1/user_crdt_pb'
+import { WatchUserEventSchema } from '~/generated/leapmux/v1/user_ops_pb'
+import { KEY_CLIENT_ID, sessionStorageSet } from '~/lib/browserStorage'
+import { PendingOpsManager } from '~/lib/crdt'
+import { fullCheckpointDelta } from '~/lib/crdt/checkpointChunks'
+import { CHECKPOINT_OP_LOG_THRESHOLD } from '~/lib/crdt/checkpointRecorder'
+import {
+  _resetCheckpointStoreForTest,
+  readCheckpoint,
+  writeCheckpointAndTruncateOpLog,
+} from '~/lib/crdt/checkpointStore'
+import { createActiveClientStore } from '~/lib/presence/activeClient'
+import { createOpLogAppender } from '~/test-support/opLog'
+import { useCrdtRuntime } from './useCrdtRuntime'
+
+const opLog = createOpLogAppender()
+
+// useUserEvents opens a socket the moment its ready gate flips, which this
+// suite has no business driving -- stub it out and expose the gate so the tests
+// can observe exactly what `hydrated` does.
+const userEventsSpy = vi.hoisted(() => ({ ready: null as null | (() => boolean) }))
+vi.mock('./useUserEvents', () => ({
+  useUserEvents: (opts: { ready?: () => boolean }) => {
+    userEventsSpy.ready = opts.ready ?? (() => true)
+    return { bootstrapped: () => false, clock: () => null, reconnect: () => {}, relayId: () => 0 }
+  },
+  nextUserEventsRelayId: () => 1,
+}))
+
+// The recorder is constructed deep inside the hook and never returned, but WHAT
+// it is constructed with is load-bearing: the frames hydration replayed seed
+// both its op-log counter and its dirty set. Wrapping the real factory keeps
+// every assertion about real behaviour -- the recorder here is the production
+// one -- while making the seeding observable.
+const recorderSpy = vi.hoisted(() => ({
+  options: [] as CheckpointRecorderOptions[],
+  instances: [] as CheckpointRecorder[],
+  failNextConstruction: false,
+}))
+vi.mock('~/lib/crdt/checkpointRecorder', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/lib/crdt/checkpointRecorder')>()
+  return {
+    ...actual,
+    createCheckpointRecorder: (opts: CheckpointRecorderOptions) => {
+      if (recorderSpy.failNextConstruction) {
+        recorderSpy.failNextConstruction = false
+        throw new Error('recorder construction blew up')
+      }
+      recorderSpy.options.push(opts)
+      const recorder = actual.createCheckpointRecorder(opts)
+      recorderSpy.instances.push(recorder)
+      return recorder
+    },
+  }
+})
+
+const hydrateSpy = vi.hoisted(() => ({ throwOnNextRead: false, hangNextRead: false }))
+vi.mock('~/lib/crdt/hydrate', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/lib/crdt/hydrate')>()
+  return {
+    ...actual,
+    loadHydrationState: async (userId: string, clientId: string) => {
+      if (hydrateSpy.throwOnNextRead) {
+        hydrateSpy.throwOnNextRead = false
+        throw new Error('hydration read blew up')
+      }
+      if (hydrateSpy.hangNextRead) {
+        hydrateSpy.hangNextRead = false
+        // Never settles -- the one shape a try/catch cannot see.
+        return new Promise(() => {})
+      }
+      return actual.loadHydrationState(userId, clientId)
+    },
+  }
+})
+
+/**
+ * Settle the hydration chain. `loadHydrationState` awaits IndexedDB, so the
+ * effect's async completion lands several microtasks after the signal write;
+ * a couple of macrotask turns is comfortably enough and keeps the test honest
+ * about the fact that hydration is NOT synchronous.
+ */
+async function settle(): Promise<void> {
+  for (let i = 0; i < 5; i++)
+    await new Promise(resolve => setTimeout(resolve, 0))
+}
+
+/**
+ * Settle until `until` holds, or give up after a bounded number of turns.
+ *
+ * Positive assertions ("the gate opened") must poll rather than take a fixed
+ * number of turns: the hydration chain is several awaits deep and grew again
+ * when the abandoned-checkpoint sweep and the client-id handshake joined it, so
+ * a fixed count that is comfortable in isolation goes flaky under a loaded full
+ * suite. Negative assertions ("the gate stayed shut") keep using `settle`, since
+ * polling for something that must never happen would only ever burn its budget.
+ */
+async function settleUntil(until: () => boolean): Promise<void> {
+  for (let i = 0; i < 200 && !until(); i++)
+    await new Promise(resolve => setTimeout(resolve, 0))
+}
+
+function mountRuntime(userId: () => string) {
+  let dispose = () => {}
+  const runtime = createRoot((d) => {
+    dispose = d
+    return useCrdtRuntime({
+      userId,
+      getWorkspaceId: () => 'ws-1',
+      activeClient: createActiveClientStore(),
+      onWorkspaceLifecycleChanged: () => {},
+    })
+  })
+  return { runtime, dispose }
+}
+
+/**
+ * The checkpoint is keyed by (user, CLIENT id), and the runtime derives its
+ * client id from sessionStorage. Pinning it here makes the seeded row
+ * addressable; without it the runtime would mint a fresh id and read a miss.
+ */
+const CLIENT = 'c-test-tab'
+const WM = { physical: 10n, logical: 0n, clientId: 'c' }
+
+/** A checkpoint whose state carries `ws-1`, so a replay is distinguishable. */
+function seededState(userId: string) {
+  return create(UserCrdtStateSchema, {
+    userId,
+    workspaces: { 'ws-1': { workspaceId: 'ws-1' } },
+    maxHlc: WM,
+    currentEpoch: 1n,
+  })
+}
+
+function seedCheckpoint(userId: string): Promise<boolean> {
+  return writeCheckpointAndTruncateOpLog(userId, CLIENT, fullCheckpointDelta(seededState(userId)), WM, 1n)
+}
+
+/** A confirmed frame naming one node, so its entity key is observable. */
+function nodeFrameBytes(batchId: string, nodeId: string): Uint8Array {
+  return toBinary(WatchUserEventSchema, create(WatchUserEventSchema, {
+    event: {
+      case: 'batch',
+      value: { batchId, ops: [{ body: { case: 'setNodeRegister', value: { nodeId } } }] },
+    },
+  } as never))
+}
+
+async function opLogFrameCount(userId: string): Promise<number> {
+  const read = await readCheckpoint(userId, CLIENT)
+  return read.status === 'ok' ? read.opLogFrames.length : -1
+}
+
+describe('useCrdtRuntime hydration gate', () => {
+  beforeEach(() => {
+    // WITHOUT this stub the whole suite is a tautology. jsdom implements no
+    // IndexedDB, so `isCheckpointStoreAvailable()` is false: every
+    // `writeCheckpointAndTruncateOpLog` here would write nothing and
+    // `loadHydrationState` would return null on its first line. The case named
+    // "opens the ready gate when a persisted checkpoint IS replayed" then
+    // exercised byte-for-byte the same `payload === null` path as its
+    // no-checkpoint sibling, leaving the hydrate branch, the hydrate-throw
+    // fallback and the op-log-count seeding entirely uncovered -- the suite
+    // stayed green with `if (payload)` deleted outright.
+    vi.stubGlobal('indexedDB', new IDBFactory())
+    vi.stubGlobal('IDBKeyRange', IDBKeyRange)
+    sessionStorageSet(KEY_CLIENT_ID, CLIENT)
+    _resetCheckpointStoreForTest()
+    opLog.reset()
+    userEventsSpy.ready = null
+    recorderSpy.options = []
+    recorderSpy.instances = []
+    recorderSpy.failNextConstruction = false
+    hydrateSpy.throwOnNextRead = false
+    hydrateSpy.hangNextRead = false
+  })
+
+  afterEach(() => {
+    _resetCheckpointStoreForTest()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  // Regression guard for a hydration-invalidation token compared against the
+  // WRONG counter. The bug is invisible to every other suite: the runtime
+  // reports no error, it simply never marks itself hydrated, so the ready gate
+  // stays shut and `/ws/userevents` is never dialled. The app looks like it is
+  // "still loading" forever.
+  it('opens the ready gate after a first-login hydration with no persisted checkpoint', async () => {
+    const { dispose } = mountRuntime(() => 'user-a')
+    expect(userEventsSpy.ready).not.toBeNull()
+    // Gate starts shut: the socket must not race the checkpoint replay.
+    expect(userEventsSpy.ready!()).toBe(false)
+
+    await settleUntil(() => userEventsSpy.ready!())
+
+    expect(userEventsSpy.ready!()).toBe(true)
+    // Nothing persisted, so the recorder has no base to be incremental against.
+    expect(recorderSpy.options.at(-1)!.hydratedFrom).toBeUndefined()
+    dispose()
+  })
+
+  it('opens the ready gate when a persisted checkpoint IS replayed', async () => {
+    // Seed a checkpoint so hydration takes the non-null payload branch. The
+    // state blob carries a workspace so the hydrated result is DISTINGUISHABLE
+    // from the cold-start path: `ready()` alone is true either way, so asserting
+    // only the gate would pass even if the whole `if (payload)` branch were
+    // deleted -- which is exactly what this suite used to do.
+    await seedCheckpoint('user-b')
+    const { runtime, dispose } = mountRuntime(() => 'user-b')
+    await settleUntil(() => userEventsSpy.ready!())
+
+    expect(userEventsSpy.ready!()).toBe(true)
+    // The checkpoint's state really was installed as the confirmed base.
+    const state = runtime.crdtState()
+    expect(state).not.toBeNull()
+    expect(Object.keys(state!.workspaces)).toContain('ws-1')
+    dispose()
+  })
+
+  // A direct A -> B switch (no intervening logout) is a supported transition:
+  // refreshUser() replaces the user in place and AuthGuard deliberately does not
+  // remount the shell. The hydration token must survive it -- capturing the
+  // token before the reset that bumps it made this case invalidate its own
+  // hydration every time, wedging the gate shut for the incoming account.
+  it('re-opens the ready gate across a direct user switch', async () => {
+    const [uid, setUid] = createSignal('user-a')
+    const { dispose } = mountRuntime(uid)
+    await settleUntil(() => userEventsSpy.ready!())
+    expect(userEventsSpy.ready!()).toBe(true)
+
+    setUid('user-b')
+    // The gate shuts immediately so the socket cannot open against the previous
+    // account's state...
+    expect(userEventsSpy.ready!()).toBe(false)
+    await settleUntil(() => userEventsSpy.ready!())
+    // ...and re-opens once the incoming account's hydration installs.
+    expect(userEventsSpy.ready!()).toBe(true)
+    dispose()
+  })
+
+  // Disposal is a cancellation path the old generation counter never covered.
+  // It bumped only in the `!uid` branch and the uid-switch branch, so a teardown
+  // that leaves `auth.user()` intact -- the desktop disconnect that unmounts the
+  // whole connected branch, or the route ErrorBoundary disposing the AppShell
+  // subtree -- let the in-flight hydration run to completion and install a live
+  // manager plus a CheckpointRecorder into a tree the app had already thrown
+  // away, with nothing left to dispose it. Solid runs a computation's cleanups
+  // on owner disposal as well as before each re-run, which is why the flag it
+  // replaces covers this for free.
+  it('abandons an in-flight hydration when its owner is disposed', async () => {
+    const { dispose } = mountRuntime(() => 'user-a')
+    expect(userEventsSpy.ready!()).toBe(false)
+
+    // Tear down BEFORE hydration settles, with the user id still set.
+    dispose()
+    await settle()
+
+    expect(userEventsSpy.ready!()).toBe(false)
+  })
+
+  // A read that never settles is the ONE shape the surrounding try/catch cannot
+  // see, and this await is the only thing holding the ready gate shut --
+  // `useUserEvents` returns without connecting AND without scheduling a
+  // reconnect while it is closed. So a hung `indexedDB.open` (a real condition:
+  // WebKit IDB hangs, a corrupt profile, a wedged versionchange in a peer
+  // window) left an empty shell with no CRDT state, no presence, no error UI
+  // and no recovery but a manual reload. Losing the race must cost one full
+  // snapshot, not the session.
+  it('opens the ready gate when the hydration read never settles', async () => {
+    vi.useFakeTimers()
+    try {
+      hydrateSpy.hangNextRead = true
+      const { dispose } = mountRuntime(() => 'user-hang')
+      await vi.advanceTimersByTimeAsync(0)
+      expect(userEventsSpy.ready!()).toBe(false)
+
+      // Past the watchdog deadline.
+      await vi.advanceTimersByTimeAsync(10_001)
+      expect(userEventsSpy.ready!()).toBe(true)
+      dispose()
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps the ready gate shut with no user id', async () => {
+    const { dispose } = mountRuntime(() => '')
+    await settle()
+    expect(userEventsSpy.ready!()).toBe(false)
+    dispose()
+  })
+
+  // The owner-liveness interval is armed AFTER `await loadHydrationState`, so
+  // its teardown cannot be registered there: Solid restores the previous Owner
+  // before an async continuation resumes, and `onCleanup` with a null Owner is
+  // silently dropped -- no throw, and only the dev build warns.
+  //
+  // The leak is not merely an idle timer. `touchOwner` keeps stamping
+  // `lastSeenAt` under the id this run hydrated from, and that timestamp is the
+  // ONLY liveness signal `sweepAbandonedCheckpoints` consults, so an abandoned
+  // owner's checkpoint, entity chunks and op-log segments become permanently
+  // exempt from both the TTL arm and the cap arm -- storage grows without bound
+  // and every reconnect eventually degrades to the full snapshot this branch
+  // exists to avoid.
+  it('clears the owner-liveness interval on dispose', async () => {
+    const setSpy = vi.spyOn(globalThis, 'setInterval')
+    const clearSpy = vi.spyOn(globalThis, 'clearInterval')
+    try {
+      const { dispose } = mountRuntime(() => 'user-touch')
+      await settleUntil(() => userEventsSpy.ready!() === true)
+
+      const armed = setSpy.mock.results.map(r => r.value)
+      expect(armed.length).toBeGreaterThan(0)
+
+      dispose()
+
+      const cleared = clearSpy.mock.calls.map(c => c[0])
+      for (const handle of armed)
+        expect(cleared).toContain(handle)
+    }
+    finally {
+      setSpy.mockRestore()
+      clearSpy.mockRestore()
+    }
+  })
+
+  // Same defect, observed as accumulation: each effect re-run must leave at most
+  // one live interval behind. A dropped cleanup adds one per re-run for the life
+  // of the page, and each keeps a DIFFERENT stale owner key alive.
+  it('does not accumulate liveness intervals across effect re-runs', async () => {
+    const setSpy = vi.spyOn(globalThis, 'setInterval')
+    const clearSpy = vi.spyOn(globalThis, 'clearInterval')
+    try {
+      const [uid, setUid] = createSignal('user-touch-1')
+      let dispose = () => {}
+      createRoot((d) => {
+        dispose = d
+        return useCrdtRuntime({
+          userId: uid,
+          getWorkspaceId: () => 'ws-1',
+          activeClient: createActiveClientStore(),
+          onWorkspaceLifecycleChanged: () => {},
+        })
+      })
+      await settleUntil(() => userEventsSpy.ready!() === true)
+
+      setUid('user-touch-2')
+      await settleUntil(() => userEventsSpy.ready!() === true)
+      dispose()
+
+      const armed = setSpy.mock.results.map(r => r.value)
+      const cleared = new Set(clearSpy.mock.calls.map(c => c[0]))
+      const leaked = armed.filter(h => !cleared.has(h))
+      expect(leaked).toEqual([])
+    }
+    finally {
+      setSpy.mockRestore()
+      clearSpy.mockRestore()
+    }
+  })
+})
+
+// A hydrate() that throws leaves the manager in an indeterminate state, so the
+// runtime must discard it, wipe the poison pair (OWNER-scoped -- a user-wide
+// wipe would cold-start every other tab as collateral) and cold-start. Nothing
+// else in the suite reached this arm.
+describe('useCrdtRuntime when hydrate() throws', () => {
+  beforeEach(() => {
+    vi.stubGlobal('indexedDB', new IDBFactory())
+    vi.stubGlobal('IDBKeyRange', IDBKeyRange)
+    sessionStorageSet(KEY_CLIENT_ID, CLIENT)
+    _resetCheckpointStoreForTest()
+    userEventsSpy.ready = null
+    recorderSpy.options = []
+    recorderSpy.instances = []
+    recorderSpy.failNextConstruction = false
+    hydrateSpy.throwOnNextRead = false
+    hydrateSpy.hangNextRead = false
+  })
+  afterEach(() => {
+    _resetCheckpointStoreForTest()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('falls back to an EMPTY manager and opens the ready gate', async () => {
+    await seedCheckpoint('user-c')
+    vi.spyOn(PendingOpsManager.prototype, 'hydrate').mockImplementationOnce(() => {
+      throw new Error('applyOp rejected a replayed frame')
+    })
+
+    const { runtime, dispose } = mountRuntime(() => 'user-c')
+    await settleUntil(() => userEventsSpy.ready!())
+
+    expect(userEventsSpy.ready!()).toBe(true)
+    // Empty, not the seeded state: the half-hydrated manager was discarded.
+    expect(Object.keys(runtime.crdtState()!.workspaces)).toEqual([])
+    // ...and the fallback recorder was told it has NO base, so its first
+    // rewrite is full.
+    expect(recorderSpy.options.at(-1)!.hydratedFrom).toBeUndefined()
+    dispose()
+  })
+
+  it('wipes the poison checkpoint so the next reload is a clean miss', async () => {
+    await seedCheckpoint('user-c')
+    vi.spyOn(PendingOpsManager.prototype, 'hydrate').mockImplementationOnce(() => {
+      throw new Error('applyOp rejected a replayed frame')
+    })
+
+    const { dispose } = mountRuntime(() => 'user-c')
+    await settleUntil(() => userEventsSpy.ready!())
+    await settle()
+
+    expect((await readCheckpoint('user-c', CLIENT)).status).toBe('miss')
+    dispose()
+  })
+})
+
+// The frames hydration replayed are already ON DISK -- only a checkpoint
+// rewrite truncates the log -- and they are exactly what moved the state past
+// the persisted chunks. So they seed BOTH the recorder's frame counter (which
+// is what eventually drains a log grown by short delta-resumed sessions) and
+// its dirty set (which is what the next incremental rewrite works from).
+describe('useCrdtRuntime recorder seeding', () => {
+  beforeEach(() => {
+    vi.stubGlobal('indexedDB', new IDBFactory())
+    vi.stubGlobal('IDBKeyRange', IDBKeyRange)
+    sessionStorageSet(KEY_CLIENT_ID, CLIENT)
+    _resetCheckpointStoreForTest()
+    userEventsSpy.ready = null
+    recorderSpy.options = []
+    recorderSpy.instances = []
+    recorderSpy.failNextConstruction = false
+    hydrateSpy.throwOnNextRead = false
+    hydrateSpy.hangNextRead = false
+  })
+  afterEach(() => {
+    _resetCheckpointStoreForTest()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('seeds the recorder\'s op-log counter and dirty set from the replayed frames', async () => {
+    await seedCheckpoint('user-d')
+    await opLog.append('user-d', CLIENT, [
+      nodeFrameBytes('b1', 'replayed-node-1'),
+      nodeFrameBytes('b2', 'replayed-node-2'),
+    ])
+
+    const { dispose } = mountRuntime(() => 'user-d')
+    await settleUntil(() => userEventsSpy.ready!())
+
+    const recorder = recorderSpy.instances.at(-1)!
+    expect(recorderSpy.options.at(-1)!.hydratedFrom!.frames).toHaveLength(2)
+    // Counted, so the threshold measures the WHOLE persisted log, not just
+    // post-hydration appends.
+    expect(recorder.opLogCount).toBe(2)
+    // ...and dirty, so the next rewrite re-serializes exactly those chunks.
+    expect([...recorder.dirtyKeys].sort()).toEqual(['node:replayed-node-1', 'node:replayed-node-2'])
+    expect(recorder.needsFullRewrite).toBe(false)
+    dispose()
+  })
+})
+
+// `truncated` means the persisted log stops short -- a poison frame, an
+// unreadable segment, or the store's own frame/byte cap. Without an immediate
+// rewrite the same prefix is replayed and the same stop is hit on EVERY future
+// reload, and the log never drains.
+describe('useCrdtRuntime post-hydration compaction', () => {
+  beforeEach(() => {
+    vi.stubGlobal('indexedDB', new IDBFactory())
+    vi.stubGlobal('IDBKeyRange', IDBKeyRange)
+    sessionStorageSet(KEY_CLIENT_ID, CLIENT)
+    _resetCheckpointStoreForTest()
+    userEventsSpy.ready = null
+    recorderSpy.options = []
+    recorderSpy.instances = []
+    recorderSpy.failNextConstruction = false
+    hydrateSpy.throwOnNextRead = false
+    hydrateSpy.hangNextRead = false
+  })
+  afterEach(() => {
+    _resetCheckpointStoreForTest()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('rewrites immediately when the replay was TRUNCATED', async () => {
+    await seedCheckpoint('user-e')
+    await opLog.append('user-e', CLIENT, [nodeFrameBytes('good', 'n1')])
+    // A frame that cannot decode: hydration replays the prefix and reports
+    // truncated, leaving the poison frame on disk.
+    await opLog.append('user-e', CLIENT, [new Uint8Array([0xFF, 0xFE, 0xFD])])
+    expect(await opLogFrameCount('user-e')).toBe(2)
+
+    const { dispose } = mountRuntime(() => 'user-e')
+    await settleUntil(() => userEventsSpy.ready!())
+    await settle()
+
+    // The rewrite pinned a fresh checkpoint and dropped the whole log with it.
+    expect(await opLogFrameCount('user-e')).toBe(0)
+    dispose()
+  })
+
+  it('rewrites immediately when the replayed log is already at the threshold', async () => {
+    await seedCheckpoint('user-f')
+    await opLog.append(
+      'user-f',
+      CLIENT,
+      Array.from({ length: CHECKPOINT_OP_LOG_THRESHOLD }, (_, i) => nodeFrameBytes(`b${i}`, `n${i}`)),
+    )
+    expect(await opLogFrameCount('user-f')).toBe(CHECKPOINT_OP_LOG_THRESHOLD)
+
+    const { dispose } = mountRuntime(() => 'user-f')
+    await settleUntil(() => userEventsSpy.ready!())
+    await settle()
+
+    expect(await opLogFrameCount('user-f')).toBe(0)
+    dispose()
+  })
+
+  it('does NOT rewrite when the replayed log is short and clean', async () => {
+    // The counterweight: a routine delta-resumed reload must not pay a
+    // checkpoint write it does not need.
+    await seedCheckpoint('user-g')
+    await opLog.append('user-g', CLIENT, [nodeFrameBytes('b1', 'n1')])
+
+    const { dispose } = mountRuntime(() => 'user-g')
+    await settleUntil(() => userEventsSpy.ready!())
+    await settle()
+
+    expect(await opLogFrameCount('user-g')).toBe(1)
+    dispose()
+  })
+})
+
+// REMOVALS-4. `setHydrated(true)` has exactly ONE call site, and useUserEvents
+// returns before it connects OR schedules a reconnect while the gate is shut.
+// So a throw anywhere in the hydration chain used to leave the user with an
+// empty shell, no error UI, and no recovery short of a manual reload -- a
+// failure mode that did not exist before the manager was constructed
+// asynchronously.
+describe('useCrdtRuntime when the hydration chain throws', () => {
+  beforeEach(() => {
+    vi.stubGlobal('indexedDB', new IDBFactory())
+    vi.stubGlobal('IDBKeyRange', IDBKeyRange)
+    sessionStorageSet(KEY_CLIENT_ID, CLIENT)
+    _resetCheckpointStoreForTest()
+    userEventsSpy.ready = null
+    recorderSpy.options = []
+    recorderSpy.instances = []
+    recorderSpy.failNextConstruction = false
+    hydrateSpy.throwOnNextRead = false
+    hydrateSpy.hangNextRead = false
+  })
+  afterEach(() => {
+    _resetCheckpointStoreForTest()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('still opens the ready gate when the checkpoint READ throws', async () => {
+    // loadHydrationState is written never to throw. If it ever does, that is a
+    // reason to cold-start -- not a reason to wedge the app.
+    hydrateSpy.throwOnNextRead = true
+
+    const { runtime, dispose } = mountRuntime(() => 'user-h')
+    await settleUntil(() => userEventsSpy.ready!())
+
+    expect(userEventsSpy.ready!()).toBe(true)
+    expect(runtime.crdtState()).not.toBeNull()
+    dispose()
+  })
+
+  it('still opens the ready gate when the recorder cannot be constructed', async () => {
+    // The deepest arm: installObserverAndManager itself throws, so even the
+    // "publish a manager" step failed. The fallback re-runs it and lands on the
+    // cold-start path the module already treats as correct.
+    recorderSpy.failNextConstruction = true
+
+    const { runtime, dispose } = mountRuntime(() => 'user-i')
+    await settleUntil(() => userEventsSpy.ready!())
+
+    expect(userEventsSpy.ready!()).toBe(true)
+    expect(runtime.crdtState()).not.toBeNull()
+    dispose()
+  })
+})

--- a/frontend/src/components/shell/useCrdtRuntime.ts
+++ b/frontend/src/components/shell/useCrdtRuntime.ts
@@ -1,13 +1,21 @@
 import type { UserCrdtState } from '~/generated/leapmux/v1/user_crdt_pb'
+import type { WatchUserEvent } from '~/generated/leapmux/v1/user_ops_pb'
 import type { Projection } from '~/lib/crdt'
+import type { CheckpointRecorder, CheckpointRecorderOptions } from '~/lib/crdt/checkpointRecorder'
+import type { HydrationPayload } from '~/lib/crdt/hydrate'
 import type { createActiveClientStore } from '~/lib/presence/activeClient'
-import { createEffect, createMemo, createSignal } from 'solid-js'
+import { createEffect, createMemo, createSignal, onCleanup } from 'solid-js'
 import { showWarnToast } from '~/components/common/Toast'
-import { KEY_CLIENT_ID, sessionStorageGet, sessionStorageSet } from '~/lib/browserStorage'
 import { createProjectionMemo, HLCClock, PendingOpsManager, setCRDTBridge } from '~/lib/crdt'
-import { randomUUID } from '~/lib/idGenerator'
+import { CHECKPOINT_OP_LOG_THRESHOLD, createCheckpointRecorder } from '~/lib/crdt/checkpointRecorder'
+import { clearCheckpointAndOpLog, clearOwnerCheckpointAndOpLog, OWNER_TOUCH_INTERVAL_MS, sweepAbandonedCheckpoints, touchOwner } from '~/lib/crdt/checkpointStore'
+import { createClientIdentity } from '~/lib/crdt/clientIdentity'
+import { loadHydrationState } from '~/lib/crdt/hydrate'
+import { createLogger } from '~/lib/logger'
 import { createOpsSubmitter } from './useOpsSubmitter'
 import { useUserEvents } from './useUserEvents'
+
+const log = createLogger('useCrdtRuntime')
 
 /**
  * The CRDT runtime: pending manager, clock, user-events subscription, op
@@ -56,8 +64,16 @@ export interface CrdtRuntime {
   userEvents: ReturnType<typeof useUserEvents>
   /** Hub-reported identity of this subscriber; empty until bootstrap. */
   effectiveClientId: () => string
-  /** Stable per-session client id used as the HLC author and op_id salt. */
-  ownClientId: string
+  /**
+   * This tab's client id — the HLC author, the op_id salt, and the owner half
+   * of the persisted checkpoint key.
+   *
+   * A signal because a tab duplicated from another (which clones sessionStorage,
+   * and with it the stored id) re-mints after the liveness handshake in
+   * `~/lib/crdt/clientIdentity` detects the collision. Readers must not cache
+   * the value across that change.
+   */
+  ownClientId: () => string
 }
 
 export function useCrdtRuntime(opts: UseCrdtRuntimeOpts): CrdtRuntime {
@@ -72,6 +88,12 @@ export function useCrdtRuntime(opts: UseCrdtRuntimeOpts): CrdtRuntime {
   // stores re-derive when ops land. The PendingOpsManager mutates
   // its UserCrdtState in place; this signal is how Solid observes it.
   const [pendingVersion, setPendingVersion] = createSignal(0)
+  // Whether the persisted checkpoint + op-log have been loaded + replayed for
+  // the current user (or the cold-start fallback has been taken). The WS open
+  // effect in useUserEvents waits on this so the resume cursor resolves against
+  // hydrated confirmedState, not empty state. False during hydration and on
+  // logout; true once the manager is live.
+  const [hydrated, setHydrated] = createSignal(false)
 
   // The single source of truth for everything the CRDT carries, covering EVERY
   // workspace at once. `project()` shares one `registeredRoots` +
@@ -90,11 +112,11 @@ export function useCrdtRuntime(opts: UseCrdtRuntimeOpts): CrdtRuntime {
     { equals: false },
   )
   // The `equals: false` above means the projection memo BODY runs on every CRDT
-  // tick -- ~2x the frame rate while a tile is dragged, since each frame's
-  // optimistic `submit` is followed by the `BatchCommitted` that triggers
-  // `recomputeSpeculative`. Running the body is cheap either way; what was not
+  // tick -- twice per confirmed mutation, since each optimistic `submit` is
+  // followed by the `BatchCommitted` echo that triggers `recomputeSpeculative`.
+  // Running the body is cheap either way; what was not
   // is that every one of those ticks used to hand the WHOLE APP a fresh graph,
-  // so a drag in one workspace re-derived every other workspace's tree and every
+  // so an edit in one workspace re-derived every other workspace's tree and every
   // tab in the account. `createProjectionMemo`'s cache reuses whatever the tick
   // left alone and returns the IDENTICAL `Projection` object when nothing
   // observable moved, so the memo's default `equals` stops propagation dead. See
@@ -112,14 +134,16 @@ export function useCrdtRuntime(opts: UseCrdtRuntimeOpts): CrdtRuntime {
   // The hub returns the subscriber's effective identity in
   // `UserMaterialized.subscriber_client_id`; the gate compares
   // `activeClient.activeFor(wsId)` against `effectiveClientId()`.
-  const ownClientId = (() => {
-    const cur = sessionStorageGet<string>(KEY_CLIENT_ID)
-    if (cur)
-      return cur
-    const fresh = `c-${randomUUID()}`
-    sessionStorageSet(KEY_CLIENT_ID, fresh)
-    return fresh
-  })()
+  //
+  // A SIGNAL, not a constant: sessionStorage is COPIED into a duplicated tab, so
+  // two live tabs can start out holding the same id and clobbering each other's
+  // checkpoint. createClientIdentity runs a BroadcastChannel liveness handshake
+  // and re-mints in the duplicate when that happens; the hydration effect below
+  // reads this, so a re-mint simply re-hydrates under the new id (a checkpoint
+  // miss -> one full snapshot for the duplicate). See clientIdentity.ts.
+  const identity = createClientIdentity()
+  const ownClientId = identity.clientId
+  onCleanup(() => identity.dispose())
 
   // Effective identity reported by the hub via UserMaterialized; the
   // active-client gate compares broadcast `active_client_id` against
@@ -128,14 +152,348 @@ export function useCrdtRuntime(opts: UseCrdtRuntimeOpts): CrdtRuntime {
   // broadcast settles.
   const [effectiveClientId, setEffectiveClientId] = createSignal('')
   const bumpPending = () => setPendingVersion(v => v + 1)
+  // The most recent user id the resume-watermark persistence effect wrote
+  // under, so a logout / user switch clears the prior account's watermark.
+  let lastResumeUid: string | null = null
+  // The op-log/checkpoint persistence policy lives in its own object (see
+  // ~/lib/crdt/checkpointRecorder): the queue, the coalesce, the frame counter,
+  // the compaction threshold and the rewrite are one unit with one lifetime,
+  // which the hook only constructs and disposes. Splitting them across hook
+  // scope, a closure and a free function is what produced the two generation-
+  // counter bugs the comment below records.
+  let recorder: CheckpointRecorder | null = null
+  // Hydration cancellation is the reactive owner's job, NOT a hand-rolled
+  // counter -- see the `cancelled` flag in the effect below. The counter this
+  // replaces shipped two bugs of its own, both from capturing the token at the
+  // wrong line: a direct A->B user switch invalidated its OWN hydration (the
+  // manager never installed, `hydrated` stayed false, the ready gate never
+  // opened the socket), and a threshold-triggered checkpoint write bumped the
+  // same counter and cancelled unrelated in-flight hydrations. Solid runs a
+  // computation's cleanups both before each re-run and on owner disposal, so
+  // one `onCleanup` covers every case the counter enumerated -- INCLUDING
+  // disposal, which the counter never covered at all.
+
+  /**
+   * Construct a manager for `uid`. One definition so the hydrate path and the
+   * hydrate-failure fallback cannot be given different constructor arguments.
+   */
+  function makeManager(uid: string): PendingOpsManager {
+    return new PendingOpsManager(uid, new HLCClock(ownClientId()), bumpPending)
+  }
+
+  /**
+   * Tear down the current recorder and, once its in-flight IDB write has
+   * settled, clear `uid`'s persisted pair. The ordering is the point: both are
+   * unawaited writes against the same cached connection, so an append armed in
+   * the same turn as a logout could otherwise land after the wipe and leave a
+   * previous account's frames on a shared device.
+   */
+  function disposeRecorderAndClear(uid: string | null): void {
+    const dying = recorder
+    recorder = null
+    const settled = dying ? dying.dispose() : Promise.resolve()
+    if (uid)
+      void settled.then(() => clearCheckpointAndOpLog(uid))
+  }
+
+  /**
+   * Deadline on the persisted-checkpoint read. Generous -- this is a
+   * last-resort watchdog for a store that has stopped answering at all, not a
+   * latency budget; a slow-but-working read must never lose the race and give
+   * up a resume it had earned.
+   */
+  const HYDRATION_TIMEOUT_MS = 10_000
+
+  /**
+   * Resolve `promise`, or `null` once `ms` elapses.
+   *
+   * Deliberately does NOT reject on timeout: every caller here treats a missing
+   * payload as "cold-start", so surfacing the deadline as an error would only
+   * route it through a catch that does the same thing.
+   */
+  function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T | null> {
+    return new Promise<T | null>((resolve) => {
+      const timer = setTimeout(() => {
+        log.warn('hydration read did not settle; cold-starting', { ms })
+        resolve(null)
+      }, ms)
+      promise.then(
+        (value) => {
+          clearTimeout(timer)
+          resolve(value)
+        },
+        (err) => {
+          clearTimeout(timer)
+          log.error('hydration read rejected; cold-starting', { err })
+          resolve(null)
+        },
+      )
+    })
+  }
+
+  /**
+   * Touch-interval ticks between abandoned-checkpoint sweeps. At the 60s touch
+   * interval this is hourly -- often enough that a long-lived session reclaims
+   * within the day, rare enough that an index walk plus destructive deletes
+   * stays off any interaction path.
+   */
+  const SWEEP_EVERY_TICKS = 60
+
   createEffect(() => {
     const uid = opts.userId()
+    // Re-runs when the client id is re-minted after a duplicate-tab collision,
+    // so the duplicate re-hydrates under its own owner key instead of sharing
+    // the incumbent's checkpoint.
+    const clientId = ownClientId()
+    // Invalidates this run: Solid fires it before the next execution AND on
+    // owner disposal, so an in-flight hydration can never install a manager for
+    // a superseded user, a superseded client id, or a torn-down tree.
+    let cancelled = false
+    // Assigned by the async continuation below, but DECLARED and torn down
+    // here. Both must be registered SYNCHRONOUSLY, while this effect is still
+    // the ambient Owner: Solid's `runComputation` restores the previous Owner
+    // in its `finally`, so an `onCleanup` reached after an `await` sees
+    // `Owner === null` and is silently DISCARDED (`solid.js`'s `cleanNode`
+    // no-ops on a null owner; only the dev build warns). A discarded clear
+    // leaks one interval per effect run, and — because `touchOwner` keeps
+    // writing under the OLD owner key — pins that abandoned checkpoint's
+    // `lastSeenAt` fresh forever, exempting it from both arms of
+    // `sweepAbandonedCheckpoints` and inverting the reclamation this timer
+    // exists to make safe.
+    let touchTimer: ReturnType<typeof setInterval> | undefined
+    onCleanup(() => {
+      cancelled = true
+      if (touchTimer !== undefined)
+        clearInterval(touchTimer)
+    })
     if (!uid) {
       setPendingMgr(null)
+      setHydrated(false)
+      // Best-effort: clear the checkpoint + op-log so the next login starts
+      // clean. A stale checkpoint would hydrate correctly (it is keyed and
+      // tenant-checked per user), but a logout is the natural "forget this
+      // device's state" signal — and clearing spans every tab's rows for that
+      // account, not just this one's.
+      disposeRecorderAndClear(lastResumeUid)
+      lastResumeUid = null
       return
     }
-    setPendingMgr(new PendingOpsManager(uid, new HLCClock(ownClientId), bumpPending))
+    if (lastResumeUid && lastResumeUid !== uid) {
+      disposeRecorderAndClear(lastResumeUid)
+      // Drop the OUTGOING account's manager immediately. Without this the
+      // stale manager stays published for the whole (async) hydration of the
+      // incoming account, so the shell keeps rendering the previous tenant's
+      // workspaces and tabs -- and any edit made in that window applies against
+      // their state. Only the logout branch above used to clear it.
+      setPendingMgr(null)
+    }
+    lastResumeUid = uid
+    setHydrated(false)
+    // Hydrate the manager from the persisted checkpoint + op-log BEFORE
+    // constructing it, so the WS effect (gated on hydrated) opens against
+    // populated confirmedState and the resume cursor resolves to the tight
+    // T_now. A null payload (no checkpoint, parse failure, unavailable store)
+    // constructs an empty manager — today's cold-start behavior.
+    const hydrateAndInstall = async (): Promise<void> => {
+      let payload: HydrationPayload | null = null
+      try {
+        // RACED against a deadline, not merely try/caught. Every arm that
+        // THROWS or REJECTS already lands on the cold-start path -- but a read
+        // that never SETTLES is the one shape a catch cannot see, and this
+        // await is the sole thing holding the ready gate shut. `useUserEvents`
+        // returns without connecting and without scheduling a reconnect while
+        // the gate is closed, so a hung read leaves the user with an empty
+        // shell, no CRDT state, no presence, no error UI, and no recovery short
+        // of a manual reload.
+        //
+        // `indexedDB.open` firing none of success/error/blocked is a real
+        // browser condition (WebKit IDB hangs, a corrupt profile, a wedged
+        // versionchange in another window), and every in-code path is already
+        // closed -- so a timeout is the only remaining defence. Losing the race
+        // costs one full snapshot, which is exactly what a cold start does
+        // anyway; the read may still land afterwards and is simply ignored.
+        payload = await withTimeout(loadHydrationState(uid, clientId), HYDRATION_TIMEOUT_MS)
+      }
+      catch (err) {
+        // loadHydrationState is written to never throw. If it ever does, that
+        // is a reason to cold-start, not a reason to leave the app wedged.
+        log.error('hydration read failed; cold-starting', { err })
+      }
+      // This effect re-ran (user switch, client-id re-mint) or its owner was
+      // disposed while hydration was in flight; abandon the completion so it
+      // cannot install state for a run that is no longer current.
+      if (cancelled)
+        return
+      installRuntimeFor(uid, clientId, payload)
+      // Collect checkpoints stranded by tabs that are gone. Their client ids
+      // died with their sessionStorage, so nothing else will ever reach those
+      // rows -- and each holds a state header plus one chunk per entity.
+      // Fire-and-forget and best-effort: this is reclamation, not
+      // correctness, and it must not delay the ready gate.
+      void sweepAbandonedCheckpoints(uid, clientId)
+      // Keep this owner's `lastSeenAt` fresh for as long as the tab runs. That
+      // timestamp is the sweep's ONLY liveness signal, and the row is otherwise
+      // stamped just once per checkpoint rewrite -- so without this a quiet tab
+      // would eventually read as abandoned and have its own checkpoint and
+      // op-log collected out from under it.
+      //
+      // One small put on the metadata row, so it can run on a timer without
+      // touching the interaction path. Fire-and-forget: a failed touch only
+      // risks a premature collection, which costs one cold start.
+      //
+      // The `cancelled` guard above already returned for a superseded run, so
+      // this only ever arms a timer the synchronous `onCleanup` above will
+      // clear.
+      void touchOwner(uid, clientId)
+      // The sweep rides the SAME timer, every SWEEP_EVERY_TICKS ticks, rather
+      // than firing only at hydration. Reclamation keyed to startup scales with
+      // session COUNT, and the rows that actually accumulate belong to sessions
+      // that never restart: a desktop app or a pinned tab open for weeks strands
+      // one owner per sibling tab that closes and never runs a second sweep.
+      // Foreign-account rows are the sharpest case -- they get no cap arm at
+      // all, only the 14-day TTL, so on a device whose single session never
+      // reloads nothing collects them.
+      //
+      // Every N ticks, not every tick: the sweep walks an index and issues
+      // destructive deletes, which is worth doing hourly and not minutely.
+      let ticks = 0
+      touchTimer = setInterval(() => {
+        void touchOwner(uid, clientId)
+        if (++ticks % SWEEP_EVERY_TICKS === 0)
+          void sweepAbandonedCheckpoints(uid, clientId)
+      }, OWNER_TOUCH_INTERVAL_MS)
+    }
+    // `installRuntimeFor` already lands every failure on the cold-start path,
+    // so this exists only so a throw from its own last-resort signal write
+    // cannot surface as an unhandled promise rejection.
+    void hydrateAndInstall().catch(err => log.error('hydration effect failed', { err }))
   })
+
+  /**
+   * Bring the runtime up for `uid`, replaying `payload` when there is one.
+   *
+   * EVERY failure arm lands on the same cold-start fallback — an empty manager,
+   * a recorder, and an OPEN ready gate. That is not defensiveness for its own
+   * sake: `useUserEvents` returns before it connects OR schedules a reconnect
+   * while the gate is shut, so a throw that escapes this function leaves the
+   * user with an empty shell, no error UI, and no recovery short of a manual
+   * reload. Cold-starting is the path this module already treats as correct; a
+   * dead app is not.
+   *
+   * "Every path opens the gate" is STRUCTURAL here, not an enumeration: the two
+   * cold-start arms are one `coldStart` call, and the last-resort
+   * `setHydrated(true)` is the only other opener. The prose used to claim
+   * `setHydrated(true)` had exactly one call site, which the last-resort arm
+   * already falsified -- the kind of drift a reader cannot check without
+   * re-deriving the whole branch tree.
+   */
+  function installRuntimeFor(uid: string, clientId: string, payload: HydrationPayload | null): void {
+    // A cold start under THIS run's owner key. Threading `clientId` rather than
+    // re-reading `ownClientId()` inside the install keeps the recorder writing
+    // under the id this pass hydrated from: one owner, one source. Reading it
+    // live was safe only because the re-mint's signal write happens to run this
+    // effect's cleanup synchronously first -- a scheduling property, not an
+    // invariant, and not one a future refactor would know it was relying on.
+    const coldStart = (): void => installObserverAndManager(makeManager(uid), uid, clientId, undefined)
+    try {
+      if (payload && hydrateInto(uid, clientId, payload))
+        return
+      coldStart()
+    }
+    catch (err) {
+      log.error('runtime install failed; degrading to an empty manager', { err })
+      try {
+        coldStart()
+      }
+      catch (fatal) {
+        // Constructing an empty manager cannot normally fail. If it does, an
+        // open gate with a null manager still beats a shut one: useUserEvents
+        // null-checks `pending()` on every path and simply refuses payloads
+        // until a manager appears, so the socket reconnects and the next
+        // effect run can recover.
+        log.error('empty-manager fallback failed; opening the ready gate anyway', { err: fatal })
+        setHydrated(true)
+      }
+    }
+  }
+
+  /**
+   * Replay `payload` into a fresh manager and publish it. Returns false when
+   * the persisted pair turned out to be unusable, having already wiped it —
+   * the caller then cold-starts.
+   */
+  function hydrateInto(uid: string, clientId: string, payload: HydrationPayload): boolean {
+    const mgr = makeManager(uid)
+    try {
+      mgr.hydrate(payload)
+    }
+    catch (err) {
+      // A hydrate() failure (e.g. a proto shape mismatch applyOp rejects)
+      // leaves the manager in an indeterminate state — fall back to empty by
+      // constructing fresh, and wipe the poison pair so the next reload isn't
+      // blocked by the same record.
+      log.warn('hydrate() failed; falling back to empty state and wiping checkpoint', { err })
+      // OWNER-scoped: the poison record belongs to this tab alone, and a
+      // user-wide wipe would cold-start every OTHER tab as collateral.
+      void clearOwnerCheckpointAndOpLog(uid, clientId)
+      return false
+    }
+    // Hand the recorder the frames hydrate() replayed. They are already ON DISK
+    // -- only a checkpoint rewrite truncates the log -- so they seed the frame
+    // counter (starting from 0 would make the threshold measure post-hydration
+    // appends only, and a run of short sessions that each resume via `delta`
+    // grew the persisted log without bound), and they are exactly what moved
+    // the state past the persisted chunks, so they seed the DIRTY SET the next
+    // incremental rewrite works from.
+    installObserverAndManager(mgr, uid, clientId, { frames: payload.frames, nextOrdinal: payload.nextOpLogOrdinal })
+    // Compact now when the persisted log was truncated, or is already at/over
+    // the threshold. The truncated case is the important one: the poison frame
+    // (or the unreadable/over-cap tail) stays on disk otherwise, so every future
+    // reload replays the same prefix and stops at the same place. Rewriting
+    // pins a fresh checkpoint at the post-replay watermark and drops the log.
+    if (payload.truncated || payload.frames.length >= CHECKPOINT_OP_LOG_THRESHOLD)
+      recorder?.rewriteNow()
+    return true
+  }
+
+  /**
+   * Install the confirmed-mutation observer (op-log appender) on the manager,
+   * publish it, enable recording, and mark hydration complete so the WS effect
+   * opens. Centralized so the hydrate-success and hydrate-fallback paths share
+   * the same wiring (the observer + recording gate + hydrated signal).
+   *
+   * `hydratedFrom` is undefined on every cold-start path, which is what tells
+   * the recorder its first checkpoint rewrite must be FULL — nothing usable is
+   * persisted for this owner.
+   */
+  function installObserverAndManager(
+    mgr: PendingOpsManager,
+    uid: string,
+    clientId: string,
+    hydratedFrom: CheckpointRecorderOptions['hydratedFrom'],
+  ): void {
+    // Replace any recorder left over from a previous manager. Nothing is
+    // cleared here — this is a re-install for the SAME account, so its
+    // persisted pair must survive.
+    void recorder?.dispose()
+    recorder = createCheckpointRecorder({ userId: uid, clientId, mgr, hydratedFrom })
+    const active = recorder
+    // Both hooks in ONE call, so recording cannot be enabled without them or
+    // vice versa. The checkpoint-reset half matters as much as the append half:
+    // a bootstrap wholesale-replaces confirmedState from a fresh hub snapshot,
+    // so the persisted checkpoint+op-log MUST re-base to match -- the snapshot
+    // IS a perfect checkpoint base (state@maxHlc under its epoch), and any
+    // op-log frames accumulated since describe the now-discarded state. Without
+    // it, a FALLBACK after hydration (the hub sends `initial` because it could
+    // not resume) leaves the persisted pair stale while recording keeps
+    // appending, and the next cold reload replays a stale log onto a stale base.
+    mgr.attachRecorder({
+      record: (frame: WatchUserEvent) => active.record(frame),
+      onCheckpointReset: () => active.onCheckpointReset(),
+    })
+    setPendingMgr(mgr)
+    setHydrated(true)
+  }
 
   // Open the per-user `/ws/userevents` subscription once the user id is
   // known. The hook stays live across workspace switches; per-
@@ -144,6 +502,9 @@ export function useCrdtRuntime(opts: UseCrdtRuntimeOpts): CrdtRuntime {
     userId: () => opts.userId(),
     activeClient: opts.activeClient,
     pending: () => pendingMgr(),
+    // Gate the WS open on hydration so the resume cursor resolves against
+    // hydrated confirmedState (the tight T_now), not empty state.
+    ready: hydrated,
     onWorkspaceLifecycleChanged: () => opts.onWorkspaceLifecycleChanged(),
     onSubscriberClientId: id => setEffectiveClientId(id),
     onPendingDropped: () => {
@@ -190,8 +551,12 @@ export function useCrdtRuntime(opts: UseCrdtRuntimeOpts): CrdtRuntime {
         opsSubmitter.enqueue(batch)
         return batch.batchId
       },
+      // Sent over the keepalive transport: a normal fetch started while the
+      // page is unloading is cancelled with it, so an op enqueued from a
+      // `pagehide` handler would never reach the hub. See CRDTBridge.flushNow.
+      flushNow: () => void opsSubmitter.flush({ unload: true }),
       clock: () => mgr.clock,
-      originClientId: () => ownClientId,
+      originClientId: ownClientId,
       speculativeState: () => {
       // Read the version signal so memoized consumers re-derive on
       // every mutation. The manager updates its state in place; the

--- a/frontend/src/components/shell/useOpsSubmitter.test.ts
+++ b/frontend/src/components/shell/useOpsSubmitter.test.ts
@@ -1,6 +1,7 @@
 import { create } from '@bufbuild/protobuf'
 import { createRoot } from 'solid-js'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { userCRDTClient, userCRDTUnloadClient } from '~/api/clients'
 import { showWarnToast } from '~/components/common/Toast'
 import { BatchRejectionReason, OpBatchSchema } from '~/generated/leapmux/v1/user_ops_pb'
 import { createOpsSubmitter } from './useOpsSubmitter'
@@ -10,7 +11,12 @@ import { createOpsSubmitter } from './useOpsSubmitter'
 vi.mock('~/components/common/Toast', () => ({ showWarnToast: vi.fn() }))
 // Default client is never used (every test injects its own), but the module
 // pulls it in at import time.
-vi.mock('~/api/clients', () => ({ userCRDTClient: { submitOps: vi.fn() } }))
+vi.mock('~/api/clients', () => ({
+  userCRDTClient: { submitOps: vi.fn() },
+  // The unload path uses a SECOND client, over the keepalive transport: a
+  // normal fetch started while the page is unloading is cancelled with it.
+  userCRDTUnloadClient: { submitOps: vi.fn() },
+}))
 
 function batch(id: string) {
   return create(OpBatchSchema, { batchId: id, ops: [] })
@@ -73,7 +79,7 @@ async function advancePastBackoff() {
   await vi.advanceTimersByTimeAsync(300)
 }
 
-describe('createopssubmitter (retry requeue)', () => {
+describe('createOpsSubmitter (retry requeue)', () => {
   beforeEach(() => vi.useFakeTimers())
   afterEach(() => vi.useRealTimers())
 
@@ -333,7 +339,7 @@ describe('createopssubmitter (retry requeue)', () => {
   })
 })
 
-describe('createopssubmitter (pending manager unavailable)', () => {
+describe('createOpsSubmitter (pending manager unavailable)', () => {
   beforeEach(() => vi.useFakeTimers())
   afterEach(() => vi.useRealTimers())
 
@@ -387,5 +393,222 @@ describe('createopssubmitter (pending manager unavailable)', () => {
       expect(vi.getTimerCount()).toBe(0)
       expect(submitOps).not.toHaveBeenCalled()
     })
+  })
+})
+
+describe('createOpsSubmitter (op coalescing)', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  function opacityBatch(batchId: string, opId: string, windowId: string, opacity: number) {
+    return create(OpBatchSchema, {
+      batchId,
+      ops: [{
+        opId,
+        body: { case: 'setFloatingWindowRegister', value: { windowId, field: { case: 'opacity', value: opacity } } },
+      }],
+    })
+  }
+
+  it('sends only the last write to a register and drops the superseded batches', async () => {
+    await createRoot(async (dispose) => {
+      const pending = makeFakePending()
+      const submitOps = vi.fn().mockResolvedValue({ results: [] })
+      const submitter = createOpsSubmitter({
+        pending: () => pending as never,
+        client: { submitOps } as never,
+      })
+
+      // A gesture-shaped burst: three writes to one register inside one window.
+      submitter.enqueue(opacityBatch('b1', 'o1', 'w1', 0.9))
+      submitter.enqueue(opacityBatch('b2', 'o2', 'w1', 0.8))
+      submitter.enqueue(opacityBatch('b3', 'o3', 'w1', 0.7))
+      await vi.advanceTimersByTimeAsync(20)
+
+      expect(submitOps).toHaveBeenCalledTimes(1)
+      const sent = submitOps.mock.calls[0]![0].batches
+      expect(sent.map((b: { batchId: string }) => b.batchId)).toEqual(['b3'])
+      dispose()
+    })
+  })
+
+  // The integration point that makes coalescing safe. Each batch was already
+  // applied speculatively at enqueue, and only a BatchResult clears a pending
+  // entry -- so a batch the hub never sees must have its entry dropped here, or
+  // the optimistic overlay waits on it for the life of the page.
+  it('drops the pending entry of a batch that coalesced away entirely', async () => {
+    await createRoot(async (dispose) => {
+      const pending = makeFakePending()
+      const submitOps = vi.fn().mockResolvedValue({ results: [] })
+      const submitter = createOpsSubmitter({
+        pending: () => pending as never,
+        client: { submitOps } as never,
+      })
+
+      submitter.enqueue(opacityBatch('b1', 'o1', 'w1', 0.9))
+      submitter.enqueue(opacityBatch('b2', 'o2', 'w1', 0.7))
+      await vi.advanceTimersByTimeAsync(20)
+
+      // Both were submitted speculatively; only the superseded one is reverted.
+      expect(pending.submit).toHaveBeenCalledTimes(2)
+      expect(pending.revertPendingBatch).toHaveBeenCalledTimes(1)
+      expect(pending.revertPendingBatch).toHaveBeenCalledWith('b1')
+      dispose()
+    })
+  })
+
+  it('does not coalesce writes to different windows', async () => {
+    await createRoot(async (dispose) => {
+      const pending = makeFakePending()
+      const submitOps = vi.fn().mockResolvedValue({ results: [] })
+      const submitter = createOpsSubmitter({
+        pending: () => pending as never,
+        client: { submitOps } as never,
+      })
+
+      submitter.enqueue(opacityBatch('b1', 'o1', 'w1', 0.9))
+      submitter.enqueue(opacityBatch('b2', 'o2', 'w2', 0.9))
+      await vi.advanceTimersByTimeAsync(20)
+
+      const sent = submitOps.mock.calls[0]![0].batches
+      expect(sent.map((b: { batchId: string }) => b.batchId)).toEqual(['b1', 'b2'])
+      expect(pending.revertPendingBatch).not.toHaveBeenCalled()
+      dispose()
+    })
+  })
+})
+
+describe('createOpsSubmitter (parked-retry supersession)', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  function xBatch(batchId: string, opId: string, windowId: string, x: number) {
+    return create(OpBatchSchema, {
+      batchId,
+      ops: [{
+        opId,
+        body: { case: 'setFloatingWindowRegister', value: { windowId, field: { case: 'x', value: x } } },
+      }],
+    })
+  }
+
+  // A batch parked in transport backoff has left the queue but never reached
+  // the hub, so dedup will not apply when its timer fires: it commits with a
+  // FRESH canonical HLC, newer than the write that superseded it, and the stale
+  // mid-gesture value wins LWW on the hub and every peer. A drag that hits one
+  // dropped request would land the window back where it was mid-drag.
+  it('cancels a parked retry once a newer write to the same register goes out', async () => {
+    await createRoot(async (dispose) => {
+      const pending = makeFakePending()
+      const submitOps = vi.fn()
+        .mockRejectedValueOnce(new Error('network down'))
+        .mockResolvedValue({ results: [] })
+      const submitter = createOpsSubmitter({
+        pending: () => pending as never,
+        client: { submitOps } as never,
+      })
+
+      // Drag frame 1 fails at the transport layer and parks.
+      submitter.enqueue(xBatch('b1', 'o1', 'w1', 0.1))
+      await vi.advanceTimersByTimeAsync(20)
+      expect(submitOps).toHaveBeenCalledTimes(1)
+
+      // Drag frame 2 goes out and supersedes it.
+      submitter.enqueue(xBatch('b2', 'o2', 'w1', 0.9))
+      await vi.advanceTimersByTimeAsync(20)
+      expect(submitOps).toHaveBeenCalledTimes(2)
+      expect(pending.revertPendingBatch).toHaveBeenCalledWith('b1')
+
+      // Well past the transport backoff: the parked batch must NOT be re-sent.
+      await vi.advanceTimersByTimeAsync(5000)
+      const sentBatchIds: string[] = submitOps.mock.calls.flatMap(
+        c => (c[0] as { batches: { batchId: string }[] }).batches.map(b => b.batchId),
+      )
+      expect(sentBatchIds).toEqual(['b1', 'b2'])
+      dispose()
+    })
+  })
+
+  it('still retries a parked batch nothing supersedes', async () => {
+    await createRoot(async (dispose) => {
+      const pending = makeFakePending()
+      const submitOps = vi.fn()
+        .mockRejectedValueOnce(new Error('network down'))
+        .mockResolvedValue({ results: [] })
+      const submitter = createOpsSubmitter({
+        pending: () => pending as never,
+        client: { submitOps } as never,
+      })
+
+      submitter.enqueue(xBatch('b1', 'o1', 'w1', 0.1))
+      await vi.advanceTimersByTimeAsync(20)
+
+      // A write to a DIFFERENT window must not cancel it.
+      submitter.enqueue(xBatch('b2', 'o2', 'w2', 0.9))
+      await vi.advanceTimersByTimeAsync(20)
+      expect(pending.revertPendingBatch).not.toHaveBeenCalled()
+
+      await vi.advanceTimersByTimeAsync(5000)
+      const sentBatchIds: string[] = submitOps.mock.calls.flatMap(
+        c => (c[0] as { batches: { batchId: string }[] }).batches.map(b => b.batchId),
+      )
+      expect(sentBatchIds).toContain('b1')
+      expect(sentBatchIds.filter(id => id === 'b1')).toHaveLength(2)
+      dispose()
+    })
+  })
+})
+
+// A `pagehide` flush that only ENQUEUES is inert on a real unload: enqueue arms
+// a ~16 ms timer and the page is gone before it fires. What makes the op arrive
+// is sending it over the keepalive transport, from inside the handler.
+describe('createOpsSubmitter unload flush', () => {
+  // Fake timers so `enqueue`'s 16 ms auto-flush cannot fire and add a call the
+  // assertions here would attribute to the explicit flush under test.
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.mocked(userCRDTClient.submitOps).mockClear()
+    vi.mocked(userCRDTUnloadClient.submitOps).mockClear()
+  })
+  afterEach(() => vi.useRealTimers())
+
+  it('sends over the keepalive client when flushing for unload', async () => {
+    const submitter = createOpsSubmitter({ pending: () => makeFakePending() as never })
+    vi.mocked(userCRDTUnloadClient.submitOps).mockResolvedValue({ results: [] } as never)
+
+    submitter.enqueue(batch('b1'))
+    await submitter.flush({ unload: true })
+
+    expect(userCRDTUnloadClient.submitOps).toHaveBeenCalledTimes(1)
+    expect(userCRDTClient.submitOps).not.toHaveBeenCalled()
+  })
+
+  it('uses the ordinary client for a normal flush', async () => {
+    const submitter = createOpsSubmitter({ pending: () => makeFakePending() as never })
+    vi.mocked(userCRDTClient.submitOps).mockResolvedValue({ results: [] } as never)
+
+    submitter.enqueue(batch('b1'))
+    await submitter.flush()
+
+    expect(userCRDTClient.submitOps).toHaveBeenCalledTimes(1)
+    expect(userCRDTUnloadClient.submitOps).not.toHaveBeenCalled()
+  })
+
+  // keepalive shares a 64 KiB budget across every in-flight request and fails
+  // outright above it, so an oversized unload flush must not be handed to it --
+  // that would turn a probably-cancelled send into a guaranteed rejection.
+  it('falls back to the ordinary client when the batch exceeds the keepalive budget', async () => {
+    const submitter = createOpsSubmitter({ pending: () => makeFakePending() as never })
+    vi.mocked(userCRDTClient.submitOps).mockResolvedValue({ results: [] } as never)
+
+    const huge = create(OpBatchSchema, {
+      batchId: 'huge',
+      ops: Array.from({ length: 1000 }, () => ({})),
+    })
+    submitter.enqueue(huge)
+    await submitter.flush({ unload: true })
+
+    expect(userCRDTClient.submitOps).toHaveBeenCalledTimes(1)
+    expect(userCRDTUnloadClient.submitOps).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/components/shell/useOpsSubmitter.ts
+++ b/frontend/src/components/shell/useOpsSubmitter.ts
@@ -1,10 +1,15 @@
 import type { BatchRejection, OpBatch } from '~/generated/leapmux/v1/user_ops_pb'
 import type { PendingOpsManager } from '~/lib/crdt'
 import { onCleanup } from 'solid-js'
-import { userCRDTClient } from '~/api/clients'
+import { userCRDTClient, userCRDTUnloadClient } from '~/api/clients'
+import { MAX_KEEPALIVE_BODY_BYTES } from '~/api/transport'
 import { showWarnToast } from '~/components/common/Toast'
 import { BatchRejectionReason } from '~/generated/leapmux/v1/user_ops_pb'
+import { coalesceQueuedBatches, supersededParkedBatchIds } from '~/lib/crdt/coalesce'
+import { createLogger } from '~/lib/logger'
 import { createExponentialBackoff } from '~/lib/retry'
+
+const log = createLogger('opsSubmitter')
 
 /**
  * SUBMIT_FLUSH_MS is the aggregator window — every queued batch
@@ -59,6 +64,11 @@ export interface CreateOpsSubmitterOpts {
   /** Optional override for the SubmitOps client (tests). */
   client?: typeof userCRDTClient
   /**
+   * Optional override for the UNLOAD client (tests). Production uses the
+   * keepalive transport; see `flush({ unload: true })`.
+   */
+  unloadClient?: typeof userCRDTClient
+  /**
    * Called to force a teardown + fresh `/ws/userevents` subscription
    * after `epoch_required` / `stale_epoch`. Resolved by the time the
    * WebSocket has been torn down; the next `UserMaterialized` arrives
@@ -67,8 +77,22 @@ export interface CreateOpsSubmitterOpts {
   reconnect?: () => Promise<void>
 }
 
+/**
+ * Rough serialized size of a batch, for the keepalive budget check only.
+ *
+ * Deliberately an ESTIMATE: the budget is a guard rail with ~4 KiB of slack
+ * below the browser's 64 KiB limit, so paying `toBinary` on the unload path to
+ * learn an exact number would cost more than the precision buys.
+ */
+function estimateBatchBytes(batch: OpBatch): number {
+  // Each op carries a handful of ids and a small value; 256 B is comfortably
+  // above the measured ~39 B frame and leaves the estimate conservative.
+  return 64 + batch.ops.length * 256
+}
+
 export function createOpsSubmitter(opts: CreateOpsSubmitterOpts) {
   const client = opts.client ?? userCRDTClient
+  const unloadClient = opts.unloadClient ?? userCRDTUnloadClient
   let queue: OpBatch[] = []
   let timer: ReturnType<typeof setTimeout> | undefined
   // Per-batch transport-retry counter. Cleared on commit / non-
@@ -85,6 +109,13 @@ export function createOpsSubmitter(opts: CreateOpsSubmitterOpts) {
     multiplier: 2,
     jitterFactor: 0,
   })
+  // Batches PARKED in a retry backoff: out of `queue`, not yet re-sent, and
+  // therefore invisible to coalescing. Tracked so a later flush that supersedes
+  // one can cancel it -- see supersededParkedBatchIds for why a parked batch is
+  // uniquely dangerous (the hub never saw it, so its retry commits with a FRESH
+  // HLC that beats the newer write). Entries are removed when the timer fires,
+  // when the batch reaches a terminal outcome, or when it is cancelled here.
+  const parked = new Map<string, OpBatch>()
   // Per-batch retryable-rejection counter, cleared on commit / give-up.
   const rejectionRetries = new Map<string, number>()
   // Per-batch retryable-rejection backoff. A retryable rejection that needs
@@ -111,27 +142,78 @@ export function createOpsSubmitter(opts: CreateOpsSubmitterOpts) {
       timer = setTimeout(flush, SUBMIT_FLUSH_MS)
   }
 
+  /**
+   * Which client this flush should use.
+   *
+   * Keepalive requests share a 64 KiB budget across all in-flight ones and fail
+   * outright above it, so an oversized unload flush falls back to the ordinary
+   * client. That send will very likely be cancelled with the page -- but a
+   * cancelled request is no worse than the keepalive one the browser would have
+   * refused, and the batch stays queued for the next session either way.
+   */
+  function submitClientFor(unload: boolean, batches: OpBatch[]): typeof client {
+    if (!unload)
+      return client
+    const bytes = batches.reduce((sum, b) => sum + estimateBatchBytes(b), 0)
+    if (bytes > MAX_KEEPALIVE_BODY_BYTES) {
+      log.warn('unload flush exceeds the keepalive budget; sending without it', { bytes })
+      return client
+    }
+    return unloadClient
+  }
+
   function dropTransportRetryCounter(batchId: string): void {
     transportRetries.delete(batchId)
     transportBackoff.reset(batchId)
+    parked.delete(batchId)
   }
 
   function dropRejectionRetryCounter(batchId: string): void {
     rejectionRetries.delete(batchId)
     rejectionBackoff.reset(batchId)
+    parked.delete(batchId)
   }
 
-  // Re-enqueue a batch under the same id+ops for a retry. The pending
-  // manager was already notified about this batch on the original
-  // `enqueue`; calling `pending.submit(batch)` again would dupe the
-  // entry in `pendingBatches`. So we only push onto the wire queue.
+  // Re-enqueue a batch under the same id+ops for a retry. The pending manager
+  // was already notified about this batch on the original `enqueue`; calling
+  // `pending.submit(batch)` again would dupe the entry in `pendingBatches`. So
+  // we only push onto the wire queue.
+  //
+  // Caveat when the retry follows a RECONNECT: if that reconnect fell back to a
+  // full snapshot, `bootstrap()` cleared `pendingBatches` (the snapshot is the
+  // hub's authoritative view and supersedes speculative edits made against the
+  // state it replaced). The optimistic overlay is then gone until the hub's
+  // broadcast echo of the retried batch lands, so the edit visibly reverts and
+  // re-applies. Correctness is preserved -- `consumeRemote` applies the echoed
+  // ops unconditionally -- but `revertPendingBatch` becomes a no-op for such a
+  // batch, since there is no longer a pending entry to revert.
   function rescheduleForWireRetry(batches: OpBatch[]): void {
     queue.push(...batches)
     if (!timer)
       timer = setTimeout(flush, SUBMIT_FLUSH_MS)
   }
 
-  async function flush(): Promise<void> {
+  /**
+   * Park `batch` and arm `backoff` to un-park and re-enqueue it.
+   *
+   * The rejection-retry and transport-retry paths differ ONLY in which backoff
+   * they use, and both must keep `parked` in exact lockstep with the scheduled
+   * timer: `supersededParkedBatchIds` reads that map to cancel a stale retry
+   * whose fresh canonical HLC would otherwise beat a newer write. Two hand-copied
+   * sequences meant that correctness-critical bookkeeping had two homes.
+   *
+   * `schedule` no-ops if this batchId already has a pending retry -- the
+   * existing timer fires and re-enqueues, so no work is lost.
+   */
+  function scheduleParkedRetry(backoff: ReturnType<typeof createExponentialBackoff<string>>, batch: OpBatch): void {
+    parked.set(batch.batchId, batch)
+    backoff.schedule(batch.batchId, () => {
+      parked.delete(batch.batchId)
+      rescheduleForWireRetry([cloneBatch(batch)])
+    })
+  }
+
+  async function flush(flushOpts?: { unload?: boolean }): Promise<void> {
     timer = undefined
     if (queue.length === 0)
       return
@@ -151,10 +233,38 @@ export function createOpsSubmitter(opts: CreateOpsSubmitterOpts) {
       return
     }
     const epoch = pending.state.currentEpoch
-    const batches = queue
+    // Merge same-register writes that piled up in this window. High-frequency
+    // gestures emit the same LWW register repeatedly, and only the last write
+    // can survive the merge anywhere, so the earlier ones are pure wire,
+    // storage and fan-out cost. See coalesceQueuedBatches for the two
+    // structural rules that keep this behaviour-preserving.
+    const { batches, droppedBatchIds, droppedOps } = coalesceQueuedBatches(queue)
     queue = []
+    // A batch that coalesced away entirely is never sent, so no BatchResult
+    // will ever arrive to clear its pending entry. Drop it here or the
+    // optimistic overlay waits on it forever. Reverting is safe precisely
+    // because every op it held was superseded by one still being sent.
+    for (const batchId of droppedBatchIds) {
+      pending.revertPendingBatch(batchId)
+      dropTransportRetryCounter(batchId)
+      dropRejectionRetryCounter(batchId)
+    }
+    if (droppedOps > 0)
+      log.debug('coalesced superseded ops before submit', { droppedOps, droppedBatches: droppedBatchIds.length })
+    // A batch parked in a retry backoff is older than this flush but has not
+    // reached the hub, so its eventual retry would commit with a canonical HLC
+    // NEWER than what we are about to send and win LWW with a stale value.
+    // Cancel any whose every register this flush rewrites.
+    for (const batchId of supersededParkedBatchIds(parked.values(), batches)) {
+      dropTransportRetryCounter(batchId)
+      dropRejectionRetryCounter(batchId)
+      pending.revertPendingBatch(batchId)
+      log.debug('cancelled a parked retry superseded by a newer write', { batchId })
+    }
+    if (batches.length === 0)
+      return
     try {
-      const resp = await client.submitOps({ epoch, batches })
+      const resp = await submitClientFor(flushOpts?.unload === true, batches).submitOps({ epoch, batches })
       let anyCommitted = false
       let needsReconnect = false
       const retryableRejections: { batch: OpBatch, needsEpochRefresh: boolean }[] = []
@@ -193,7 +303,9 @@ export function createOpsSubmitter(opts: CreateOpsSubmitterOpts) {
               // A retryable rejection is NOT a final outcome -- the batch is
               // requeued below, and its optimistic ops stay applied so the edit
               // does not flicker out and back. Reverting here and then committing
-              // on the retry would be the visible bug.
+              // on the retry would be the visible bug. (The one case where the
+              // overlay does not survive is a reconnect that full-snapshots in
+              // between -- see rescheduleForWireRetry.)
               const original = batches.find(b => b.batchId === result.batchId)
               if (original)
                 retryableRejections.push({ batch: original, needsEpochRefresh })
@@ -241,7 +353,7 @@ export function createOpsSubmitter(opts: CreateOpsSubmitterOpts) {
           continue
         }
         rejectionRetries.set(batch.batchId, attempts)
-        rejectionBackoff.schedule(batch.batchId, () => rescheduleForWireRetry([cloneBatch(batch)]))
+        scheduleParkedRetry(rejectionBackoff, batch)
       }
       // Surface a `leapmux:layout-saved` event when any batch commits,
       // so E2E tests waiting for persistence (e.g. workspace-tab moves)
@@ -284,12 +396,7 @@ export function createOpsSubmitter(opts: CreateOpsSubmitterOpts) {
         continue
       }
       transportRetries.set(batch.batchId, attempts)
-      // Per-batch backoff timer. `schedule` no-ops if this batchId
-      // already has a pending retry — the existing timer will fire
-      // and re-enqueue, no work lost.
-      transportBackoff.schedule(batch.batchId, () => {
-        rescheduleForWireRetry([cloneBatch(batch)])
-      })
+      scheduleParkedRetry(transportBackoff, batch)
     }
   }
 
@@ -298,11 +405,19 @@ export function createOpsSubmitter(opts: CreateOpsSubmitterOpts) {
       clearTimeout(timer)
     transportBackoff.cancelAll()
     rejectionBackoff.cancelAll()
+    parked.clear()
   })
 
   return {
     enqueue,
-    /** Force-flush; useful for tests + page-unload paths. */
+    /**
+     * Force-flush.
+     *
+     * `{ unload: true }` routes the request through the keepalive transport so
+     * it survives the document being torn down. A normal fetch started from a
+     * `pagehide` handler is cancelled with the page, which is why simply
+     * enqueueing at unload was never enough: the 16 ms timer never fires.
+     */
     flush,
   }
 }

--- a/frontend/src/components/shell/useTurnEnd.ts
+++ b/frontend/src/components/shell/useTurnEnd.ts
@@ -33,7 +33,7 @@ export interface UseTurnEndOpts {
   activeClient: ReturnType<typeof createActiveClientStore>
   effectiveClientId: () => string
   getActiveWorkspaceId: () => string | null | undefined
-  ownClientId: string
+  ownClientId: () => string
   setTurnEndTrigger: (updater: (v: number) => number) => void
   isAgentClosing: (agentId: string) => boolean
 }
@@ -81,7 +81,7 @@ export function useTurnEnd(opts: UseTurnEndOpts): (agentId: string, numToolUses?
       // multi-context tests where the audio stack is either suppressed
       // or unobservable (jsdom-like envs).
       window.dispatchEvent(new CustomEvent('leapmux:turn-end-played', {
-        detail: { agentId, ownClientId: opts.ownClientId, effectiveClientId: opts.effectiveClientId() },
+        detail: { agentId, ownClientId: opts.ownClientId(), effectiveClientId: opts.effectiveClientId() },
       }))
     }
   }

--- a/frontend/src/components/shell/useUserEvents.test.ts
+++ b/frontend/src/components/shell/useUserEvents.test.ts
@@ -1,3 +1,4 @@
+import type { UserEventsHook } from './useUserEvents'
 import type { WatchUserEvent } from '~/generated/leapmux/v1/user_ops_pb'
 import { create, toBinary } from '@bufbuild/protobuf'
 import { createRoot, createSignal } from 'solid-js'
@@ -22,6 +23,7 @@ import {
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
 import { uint8ArrayToBase64 } from '~/lib/base64'
 import { KEY_USER_EVENTS_RELAY_SEQ, localStorageGet, localStorageSet } from '~/lib/browserStorage'
+import { isStatePopulated } from '~/lib/crdt/pendingOps'
 import { createActiveClientStore } from '~/lib/presence/activeClient'
 import { nextUserEventsRelayId, useUserEvents } from './useUserEvents'
 
@@ -41,6 +43,10 @@ const bridge = vi.hoisted(() => ({
   openCalls: 0,
   closeCalls: 0,
   openedRelayIds: [] as number[],
+  // Resume token handed to each relay open, so the DESKTOP branch's cursor
+  // threading is assertable. The fake used to accept only `relayId`, silently
+  // discarding the token -- dropping it in the hook would have shipped green.
+  openedResumeTokens: [] as unknown[],
   closedRelayIds: [] as number[],
   // When true, onEvent registers the listener synchronously (as Rust does) but
   // leaves its promise pending until releaseOnEvent() -- the real registration gap,
@@ -75,9 +81,10 @@ vi.mock('~/api/platformBridge', () => ({
         bridge.pendingOnEvent.push(() => resolve(unlisten))
       })
     },
-    openUserEventsRelay: async (relayId: number) => {
+    openUserEventsRelay: async (relayId: number, _workspaceIds?: string[], resume?: unknown) => {
       bridge.openCalls++
       bridge.openedRelayIds.push(relayId)
+      bridge.openedResumeTokens.push(resume)
     },
     closeUserEventsRelay: async (relayId: number) => {
       bridge.closeCalls++
@@ -98,16 +105,65 @@ interface FakePending {
   consumeRemote: ReturnType<typeof vi.fn>
   consumeEntityMaterialized: ReturnType<typeof vi.fn>
   consumeEntityRemoved: ReturnType<typeof vi.fn>
+  applyDelta: ReturnType<typeof vi.fn>
+  consumeBatchEnd: ReturnType<typeof vi.fn>
   clock: { observe: ReturnType<typeof vi.fn> }
+  isConfirmedPopulated: () => boolean
+  // The refresh-guard reads confirmedState.workspaces/nodes/tabs/floatingWindows
+  // via isConfirmedPopulated() to decide whether a resume cursor is safe to
+  // send. Populated = an in-session reconnect (state survives in memory);
+  // empty/absent = a cold start.
+  state: {
+    confirmedState: { workspaces: Record<string, unknown>, nodes: Record<string, unknown>, tabs: Record<string, unknown>, floatingWindows: Record<string, unknown> }
+    resumeWatermark?: { physical: bigint, logical: bigint, clientId: string }
+    currentEpoch: bigint
+  }
 }
 
-function makeFakePending(opts?: { droppedPending?: boolean }): FakePending {
+function makeFakePending(opts?: {
+  droppedPending?: boolean
+  populated?: boolean
+  populateMap?: 'workspaces' | 'nodes' | 'tabs' | 'floatingWindows'
+  /** The in-memory resume cursor. This IS the only cursor source now. */
+  watermark?: { physical: bigint, logical: bigint, clientId: string }
+  epoch?: bigint
+}): FakePending {
+  // `populated` simulates an in-session reconnect: confirmedState already
+  // holds an entity, so the refresh-guard sends the resume cursor. `populateMap`
+  // targets a specific map (defaults to workspaces) so the OR over all four
+  // maps (now centralized in isConfirmedPopulated) can be pinned per-map.
+  const map = opts?.populateMap ?? 'workspaces'
+  const entry = opts?.populated ? { x1: {} } : {}
+  const confirmedState = {
+    workspaces: map === 'workspaces' ? entry : {},
+    nodes: map === 'nodes' ? entry : {},
+    tabs: map === 'tabs' ? entry : {},
+    floatingWindows: map === 'floatingWindows' ? entry : {},
+  }
   return {
     bootstrap: vi.fn(),
     consumeRemote: vi.fn(),
     consumeEntityMaterialized: vi.fn(),
     consumeEntityRemoved: vi.fn(() => ({ droppedPending: opts?.droppedPending ?? false })),
+    applyDelta: vi.fn(() => ({ droppedPending: opts?.droppedPending ?? false })),
+    consumeBatchEnd: vi.fn(),
     clock: { observe: vi.fn() },
+    // Delegates to the PRODUCTION predicate rather than re-implementing it.
+    // A hand-copied mirror meant every cursor-suppression case below asserted
+    // against the fake's own branch: the real rule could gain a fifth map or
+    // invert a condition and this suite would stay green while the refresh
+    // guard it exists to pin was broken.
+    isConfirmedPopulated: () => isStatePopulated(confirmedState),
+    state: {
+      confirmedState,
+      // Carried on the fake because production always carries them: every path
+      // that populates confirmedState (bootstrap, hydrate, an applied frame)
+      // also seeds the watermark and epoch. A fake that omitted them described a
+      // state the app never reaches, and let a cursor-source test pass against a
+      // shape that could not occur.
+      resumeWatermark: opts?.watermark,
+      currentEpoch: opts?.epoch ?? 0n,
+    },
   }
 }
 
@@ -170,6 +226,7 @@ beforeEach(() => {
   bridge.openCalls = 0
   bridge.closeCalls = 0
   bridge.openedRelayIds.length = 0
+  bridge.openedResumeTokens.length = 0
   bridge.closedRelayIds.length = 0
   bridge.deferOnEvent = false
   bridge.pendingOnEvent.length = 0
@@ -192,7 +249,7 @@ async function flushEffects(): Promise<void> {
   await Promise.resolve()
 }
 
-describe('useuserevents (websocket dispatch)', () => {
+describe('useUserEvents (websocket dispatch)', () => {
   it('opens a single socket when userId becomes non-empty', async () => {
     await createRoot(async (dispose) => {
       const [userId] = createSignal('user-1')
@@ -225,6 +282,198 @@ describe('useuserevents (websocket dispatch)', () => {
       })
       await flushEffects()
       expect(FakeSocket.instances).toHaveLength(0)
+      dispose()
+    })
+  })
+
+  it('does not open a socket until the `ready` hydration gate flips true', async () => {
+    // useCrdtRuntime passes `ready: hydrated` so the WS open effect waits for
+    // the persisted checkpoint + op-log to be loaded + replayed before opening.
+    // The resume cursor must resolve against hydrated confirmedState (the tight
+    // T_now), not empty state — so the socket must not open while ready() is
+    // false, then open once it flips true (re-firing the effect via the dep).
+    await createRoot(async (dispose) => {
+      const [userId] = createSignal('user-1')
+      const [ready, setReady] = createSignal(false)
+      const pending = makeFakePending({ populated: true })
+      useUserEvents({
+        userId,
+        activeClient: createActiveClientStore(),
+        pending: () => pending as never,
+        ready,
+        buildWsUrl: ws => `ws://test/userevents?w=${ws.join(',')}`,
+      })
+      await flushEffects()
+      // Hydration not complete: no socket yet even though userId is set.
+      expect(FakeSocket.instances).toHaveLength(0)
+      setReady(true)
+      await flushEffects()
+      expect(FakeSocket.instances).toHaveLength(1)
+      dispose()
+    })
+  })
+
+  it('opens immediately when no `ready` gate is supplied (prior behavior)', async () => {
+    // Callers that don't wire hydration get readyGate = () => true, so the
+    // socket opens as soon as userId is truthy — the pre-hydration behavior.
+    await createRoot(async (dispose) => {
+      const [userId] = createSignal('user-1')
+      const pending = makeFakePending()
+      useUserEvents({
+        userId,
+        activeClient: createActiveClientStore(),
+        pending: () => pending as never,
+        buildWsUrl: ws => `ws://test/userevents?w=${ws.join(',')}`,
+      })
+      await flushEffects()
+      expect(FakeSocket.instances).toHaveLength(1)
+      dispose()
+    })
+  })
+
+  it('threads the resume watermark into the URL builder', async () => {
+    await createRoot(async (dispose) => {
+      const [userId] = createSignal('user-1')
+      // populated = an in-session reconnect: confirmedState holds a workspace,
+      // so the refresh-guard sends the cursor.
+      const pending = makeFakePending({
+        populated: true,
+        watermark: { physical: 1754100000000n, logical: 3n, clientId: 'c-abc' },
+        epoch: 7n,
+      })
+      let captured: { hlc: { physical: bigint, logical: bigint, clientId: string }, epoch: bigint } | null | undefined
+      useUserEvents({
+        userId,
+        activeClient: createActiveClientStore(),
+        pending: () => pending as never,
+        buildWsUrl: (ws, resume) => {
+          captured = resume
+          return `ws://test/userevents?w=${ws.join(',')}`
+        },
+      })
+      await flushEffects()
+      expect(captured).toBeDefined()
+      expect(captured!.hlc.physical).toBe(1754100000000n)
+      expect(captured!.hlc.clientId).toBe('c-abc')
+      expect(captured!.epoch).toBe(7n)
+      dispose()
+    })
+  })
+
+  it('suppresses the resume cursor when confirmedState is empty even though a watermark exists', async () => {
+    // Hydration that found no checkpoint leaves confirmedState empty. Sending a
+    // cursor then would make the hub ship a delta the client folds onto empty
+    // maps (a partial result), so the guard suppresses it and takes a full
+    // snapshot instead.
+    await createRoot(async (dispose) => {
+      const [userId] = createSignal('user-cold')
+      const pending = makeFakePending({
+        watermark: { physical: 999n, logical: 0n, clientId: 'c-stale' },
+        epoch: 3n,
+      }) // empty confirmedState (cold start)
+      let captured: unknown = 'unset'
+      useUserEvents({
+        userId,
+        activeClient: createActiveClientStore(),
+        pending: () => pending as never,
+        buildWsUrl: (_ws, resume) => {
+          captured = resume
+          return 'ws://test/userevents'
+        },
+      })
+      await flushEffects()
+      expect(captured).toBeNull()
+      dispose()
+    })
+  })
+
+  it('sends the resume cursor when confirmedState has only nodes (not workspaces)', async () => {
+    // The refresh-guard treats ANY of workspaces/nodes/tabs as "populated".
+    // Pin the OR per-map so a future change that narrowed the check to just
+    // workspaces (and regressed the transient nodes-but-no-workspace-record
+    // case) would fail loudly.
+    await createRoot(async (dispose) => {
+      const [userId] = createSignal('user-nodes-only')
+      const pending = makeFakePending({ populated: true, populateMap: 'nodes', watermark: { physical: 500n, logical: 1n, clientId: 'c-n' }, epoch: 2n })
+      let captured: unknown = 'unset'
+      useUserEvents({
+        userId,
+        activeClient: createActiveClientStore(),
+        pending: () => pending as never,
+        buildWsUrl: (_ws, resume) => {
+          captured = resume
+          return 'ws://test/userevents'
+        },
+      })
+      await flushEffects()
+      expect(captured).not.toBeNull()
+      dispose()
+    })
+  })
+
+  it('sends the resume cursor when confirmedState has only floating windows', async () => {
+    // The refresh-guard enumerates EVERY top-level map of confirmedState,
+    // including floatingWindows (a user whose only state is a detached floating
+    // window must still count as populated). Pin it so a future map addition
+    // or a narrowing to just workspaces/nodes/tabs fails loudly.
+    await createRoot(async (dispose) => {
+      const [userId] = createSignal('user-fw-only')
+      const pending = makeFakePending({ populated: true, populateMap: 'floatingWindows', watermark: { physical: 600n, logical: 0n, clientId: 'c-fw' }, epoch: 4n })
+      let captured: unknown = 'unset'
+      useUserEvents({
+        userId,
+        activeClient: createActiveClientStore(),
+        pending: () => pending as never,
+        buildWsUrl: (_ws, resume) => {
+          captured = resume
+          return 'ws://test/userevents'
+        },
+      })
+      await flushEffects()
+      expect(captured).not.toBeNull()
+      dispose()
+    })
+  })
+
+  it('suppresses the resume cursor when pending() returns null (no manager yet)', async () => {
+    // The manager can be null briefly before the userId effect constructs it.
+    // A watermark present during that window must not crash the guard (it
+    // reads pending()?.state) and must yield a null cursor.
+    await createRoot(async (dispose) => {
+      const [userId] = createSignal('user-null-pending')
+      let captured: unknown = 'unset'
+      useUserEvents({
+        userId,
+        activeClient: createActiveClientStore(),
+        pending: () => null as never,
+        buildWsUrl: (_ws, resume) => {
+          captured = resume
+          return 'ws://test/userevents'
+        },
+      })
+      await flushEffects()
+      expect(captured).toBeNull()
+      dispose()
+    })
+  })
+
+  it('passes a null resume token when there is no watermark', async () => {
+    // No watermark on the manager: nothing to resume from.
+    await createRoot(async (dispose) => {
+      const [userId] = createSignal('user-no-wm')
+      const pending = makeFakePending()
+      let captured: unknown = 'unset'
+      useUserEvents({
+        userId,
+        activeClient: createActiveClientStore(),
+        pending: () => pending as never,
+        buildWsUrl: (_ws, resume) => {
+          captured = resume
+          return 'ws://test/userevents'
+        },
+      })
+      await flushEffects()
+      expect(captured).toBeNull()
       dispose()
     })
   })
@@ -498,6 +747,236 @@ describe('useuserevents (websocket dispatch)', () => {
     })
   })
 
+  // The `delta` arm is now the normal COLD-START path (a refreshed page hydrates
+  // from IndexedDB and resumes rather than bootstrapping), so everything the
+  // `initial` arm establishes has to be established here too. Two things were
+  // missing and are pinned below.
+  it('adopts the subscriber client id and refreshes the workspace list on a delta', async () => {
+    await createRoot(async (dispose) => {
+      const [userId] = createSignal('user-1')
+      const pending = makeFakePending({ populated: true })
+      const onSubscriberClientId = vi.fn()
+      const onWorkspaceLifecycleChanged = vi.fn()
+      useUserEvents({
+        userId,
+        activeClient: createActiveClientStore(),
+        pending: () => pending as never,
+        onSubscriberClientId,
+        onWorkspaceLifecycleChanged,
+        buildWsUrl: () => 'ws://test/userevents',
+      })
+      await flushEffects()
+      const sock = FakeSocket.instances[0]!
+
+      sock.sendEvent(create(WatchUserEventSchema, {
+        event: {
+          case: 'delta',
+          value: {
+            frames: [],
+            maxHlc: create(HLCSchema, { physical: 300n, logical: 0n, clientId: 'hub' }),
+            currentEpoch: 2n,
+            subscriberClientId: 'client-from-hub',
+          },
+        },
+      }))
+
+      expect(pending.applyDelta).toHaveBeenCalledTimes(1)
+      // Without this the active-client gate compares against '' for the life of
+      // the page, which disables it outright -- every refreshed tab would play
+      // the turn-end sound regardless of which client is active.
+      expect(onSubscriberClientId).toHaveBeenCalledWith('client-from-hub')
+      // Workspace lifecycle frames are not replayed in a delta, and the sidebar
+      // list comes from a separate listWorkspaces driven by this callback -- so
+      // without it a create/rename/delete during the gap never reaches the UI.
+      expect(onWorkspaceLifecycleChanged).toHaveBeenCalledTimes(1)
+      dispose()
+    })
+  })
+
+  // The third thing the `initial` arm establishes that the `delta` arm did not:
+  // a tenancy check. `initial` refuses a foreign UserMaterialized, and the
+  // cold-start hydration path refuses a foreign checkpoint; the delta arm --
+  // now the normal cold start -- failed OPEN, and could not have done otherwise
+  // because ResumeDelta carried no user_id to compare. Adopting one would fold
+  // another tenant's records into confirmedState AND, via the op-log observer,
+  // into this device's IndexedDB checkpoint, where they survive refreshes.
+  it('refuses a delta that names a different tenant', async () => {
+    await createRoot(async (dispose) => {
+      const [userId] = createSignal('user-1')
+      const pending = makeFakePending({ populated: true })
+      const onSubscriberClientId = vi.fn()
+      useUserEvents({
+        userId,
+        activeClient: createActiveClientStore(),
+        pending: () => pending as never,
+        onSubscriberClientId,
+        buildWsUrl: () => 'ws://test/userevents',
+      })
+      await flushEffects()
+      const sock = FakeSocket.instances[0]!
+
+      sock.sendEvent(create(WatchUserEventSchema, {
+        event: {
+          case: 'delta',
+          value: {
+            frames: [],
+            maxHlc: create(HLCSchema, { physical: 300n, logical: 0n, clientId: 'hub' }),
+            currentEpoch: 2n,
+            subscriberClientId: 'client-from-hub',
+            userId: 'someone-else',
+          },
+        },
+      }))
+
+      expect(pending.applyDelta).not.toHaveBeenCalled()
+      // Nothing downstream of the refusal may run either -- adopting the hub's
+      // subscriber identity from a frame we just rejected would be incoherent.
+      expect(onSubscriberClientId).not.toHaveBeenCalled()
+      dispose()
+    })
+  })
+
+  // `initial` and `delta` are the two bootstrap-bearing arms, and they adopt
+  // the SAME four things in the SAME order. They used to hand-copy that tail
+  // and had drifted twice -- the delta arm shipped without the subscriber-id
+  // adoption and without the workspace-list refresh. This pins both halves:
+  // the sequence each arm runs, and that the two are identical.
+  it('runs the same adoption sequence for the initial and the delta arm', async () => {
+    interface AdoptionTrace {
+      /** Callback names in fire order. */
+      order: string[]
+      /** `bootstrapped()` / `clock()` sampled from inside each callback. */
+      liveAtSubscriber: { bootstrapped: boolean, clock: boolean }
+      liveAtLifecycle: { bootstrapped: boolean, clock: boolean }
+    }
+
+    const traceFor = (arm: 'initial' | 'delta'): Promise<AdoptionTrace> =>
+      createRoot(async (dispose) => {
+        const [userId] = createSignal('user-1')
+        const pending = makeFakePending({ populated: true })
+        const trace: AdoptionTrace = {
+          order: [],
+          liveAtSubscriber: { bootstrapped: false, clock: false },
+          liveAtLifecycle: { bootstrapped: false, clock: false },
+        }
+        // Assigned before any frame can arrive; the callbacks below only run
+        // from a socket message, which the test drives after `useUserEvents`
+        // has returned.
+        let hook: UserEventsHook | undefined
+        const sample = (): { bootstrapped: boolean, clock: boolean } => ({
+          bootstrapped: hook?.bootstrapped() ?? false,
+          clock: (hook?.clock() ?? null) !== null,
+        })
+        hook = useUserEvents({
+          userId,
+          activeClient: createActiveClientStore(),
+          pending: () => pending as never,
+          onSubscriberClientId: () => {
+            trace.order.push('subscriber')
+            trace.liveAtSubscriber = sample()
+          },
+          onWorkspaceLifecycleChanged: () => {
+            trace.order.push('lifecycle')
+            trace.liveAtLifecycle = sample()
+          },
+          buildWsUrl: () => 'ws://test/userevents',
+        })
+        await flushEffects()
+        const sock = FakeSocket.instances.at(-1)!
+
+        sock.sendEvent(create(WatchUserEventSchema, arm === 'initial'
+          ? {
+              event: {
+                case: 'initial',
+                value: create(UserMaterializedSchema, {
+                  userId: 'user-1',
+                  subscriberClientId: 'client-from-hub',
+                  currentEpoch: 2n,
+                  maxHlc: create(HLCSchema, { physical: 300n, logical: 0n, clientId: 'hub' }),
+                }),
+              },
+            }
+          : {
+              event: {
+                case: 'delta',
+                value: {
+                  frames: [],
+                  maxHlc: create(HLCSchema, { physical: 300n, logical: 0n, clientId: 'hub' }),
+                  currentEpoch: 2n,
+                  subscriberClientId: 'client-from-hub',
+                  userId: 'user-1',
+                },
+              },
+            }))
+
+        dispose()
+        return trace
+      })
+
+    const initial = await traceFor('initial')
+    const delta = await traceFor('delta')
+    expect(initial).toEqual(delta)
+    // ...and it is the RIGHT sequence, not two identical wrong ones. The
+    // subscriber id is adopted BEFORE the shell is told the CRDT is live, so
+    // nothing downstream of `bootstrapped` can read a '' identity; the
+    // workspace refresh fires LAST, once the clock and the flag are both set.
+    expect(initial.order).toEqual(['subscriber', 'lifecycle'])
+    expect(initial.liveAtSubscriber).toEqual({ bootstrapped: false, clock: false })
+    expect(initial.liveAtLifecycle).toEqual({ bootstrapped: true, clock: true })
+  })
+
+  it('accepts a delta whose user_id matches', async () => {
+    await createRoot(async (dispose) => {
+      const [userId] = createSignal('user-1')
+      const pending = makeFakePending({ populated: true })
+      useUserEvents({
+        userId,
+        activeClient: createActiveClientStore(),
+        pending: () => pending as never,
+        buildWsUrl: () => 'ws://test/userevents',
+      })
+      await flushEffects()
+      const sock = FakeSocket.instances[0]!
+
+      sock.sendEvent(create(WatchUserEventSchema, {
+        event: {
+          case: 'delta',
+          value: {
+            frames: [],
+            maxHlc: create(HLCSchema, { physical: 300n, logical: 0n, clientId: 'hub' }),
+            currentEpoch: 2n,
+            userId: 'user-1',
+          },
+        },
+      }))
+
+      expect(pending.applyDelta).toHaveBeenCalledTimes(1)
+      dispose()
+    })
+  })
+
+  it('routes a batchEnd frame to the manager (the only watermark-advance point)', async () => {
+    await createRoot(async (dispose) => {
+      const [userId] = createSignal('user-1')
+      const pending = makeFakePending()
+      useUserEvents({
+        userId,
+        activeClient: createActiveClientStore(),
+        pending: () => pending as never,
+        buildWsUrl: () => 'ws://test/userevents',
+      })
+      await flushEffects()
+      const sock = FakeSocket.instances[0]!
+
+      const atHlc = create(HLCSchema, { physical: 400n, logical: 2n, clientId: 'hub' })
+      sock.sendEvent(create(WatchUserEventSchema, { event: { case: 'batchEnd', value: { atHlc } } }))
+
+      expect(pending.consumeBatchEnd).toHaveBeenCalledTimes(1)
+      expect(pending.consumeBatchEnd.mock.calls[0][0]).toMatchObject({ physical: 400n, logical: 2n })
+      dispose()
+    })
+  })
+
   it('ignores a message that arrives on a socket superseded by teardown', async () => {
     await createRoot(async (dispose) => {
       const [userId, setUserId] = createSignal('user-1')
@@ -724,7 +1203,7 @@ describe('useuserevents (websocket dispatch)', () => {
   })
 })
 
-describe('useuserevents (desktop bridge path)', () => {
+describe('useUserEvents (desktop bridge path)', () => {
   // Flush the effect, the onEvent Promise.all, and the .then that opens the
   // relay -- the desktop path is several microtasks deep before it is live.
   async function settleBridge(): Promise<void> {
@@ -745,6 +1224,55 @@ describe('useuserevents (desktop bridge path)', () => {
       expect(bridge.openCalls).toBe(1)
       expect(bridge.handlers.has('userevents:message')).toBe(true)
       expect(bridge.handlers.has('userevents:close')).toBe(true)
+      dispose()
+    })
+  })
+
+  // The browser branch's cursor threading is covered via the buildWsUrl
+  // override, but the DESKTOP branch hands the token to the sidecar as an RPC
+  // argument -- a second serialization hop with its own chance to drop it.
+  // Nothing asserted that hop, so removing the third argument at the
+  // openUserEventsRelay call site would have shipped green.
+  it('threads the resume watermark into the relay open', async () => {
+    bridge.isTauri = true
+    await createRoot(async (dispose) => {
+      const [userId] = createSignal('user-1')
+      useUserEvents({
+        userId,
+        activeClient: createActiveClientStore(),
+        // populated => an in-session reconnect, so the cursor is sent.
+        pending: () => makeFakePending({
+          populated: true,
+          watermark: { physical: 1754100000000n, logical: 3n, clientId: 'c-abc' },
+          epoch: 7n,
+        }) as never,
+      })
+      await settleBridge()
+      expect(bridge.openCalls).toBe(1)
+      const resume = bridge.openedResumeTokens[0] as {
+        hlc: { physical: bigint, logical: bigint, clientId: string }
+        epoch: bigint
+      } | null
+      expect(resume).toBeTruthy()
+      expect(resume!.hlc.physical).toBe(1754100000000n)
+      expect(resume!.hlc.clientId).toBe('c-abc')
+      expect(resume!.epoch).toBe(7n)
+      dispose()
+    })
+  })
+
+  it('passes a null resume token to the relay open when there is no watermark', async () => {
+    bridge.isTauri = true
+    await createRoot(async (dispose) => {
+      const [userId] = createSignal('user-1')
+      useUserEvents({
+        userId,
+        activeClient: createActiveClientStore(),
+        pending: () => makeFakePending({ populated: true }) as never,
+      })
+      await settleBridge()
+      expect(bridge.openCalls).toBe(1)
+      expect(bridge.openedResumeTokens[0] ?? null).toBeNull()
       dispose()
     })
   })
@@ -918,7 +1446,7 @@ describe('useuserevents (desktop bridge path)', () => {
 // bootstrap. The persisted high-water mark is what carries the ordering through
 // a reload. The mark is a plain monotonic counter (NOT the wall clock), so the
 // ordering holds regardless of any clock step between page loads.
-describe('nextusereventsrelayid', () => {
+describe('nextUserEventsRelayId', () => {
   it('hands out strictly increasing ids and persists the high-water mark', () => {
     const first = nextUserEventsRelayId()
     const markAfterFirst = localStorageGet<number>(KEY_USER_EVENTS_RELAY_SEQ)

--- a/frontend/src/components/shell/useUserEvents.ts
+++ b/frontend/src/components/shell/useUserEvents.ts
@@ -1,4 +1,4 @@
-import type { UserMaterialized } from '~/generated/leapmux/v1/user_crdt_pb'
+import type { HLC, UserMaterialized } from '~/generated/leapmux/v1/user_crdt_pb'
 import type { WatchUserEvent } from '~/generated/leapmux/v1/user_ops_pb'
 import type { HLCClock, PendingOpsManager } from '~/lib/crdt'
 import type { ActiveClientStore } from '~/lib/presence/activeClient'
@@ -9,11 +9,36 @@ import { WatchUserEventSchema } from '~/generated/leapmux/v1/user_ops_pb'
 import { base64ToUint8Array } from '~/lib/base64'
 import { KEY_USER_EVENTS_RELAY_SEQ } from '~/lib/browserStorage'
 import { unframeBytes } from '~/lib/channelFraming'
+import { formatHlcWire, parseHlcWire } from '~/lib/crdt/hlc'
 import { createLogger } from '~/lib/logger'
 import { createPersistedSeq } from '~/lib/persistedSeq'
 import { createExponentialBackoff } from '~/lib/retry'
 
 const log = createLogger('useUserEvents')
+
+/**
+ * Whether a hub payload naming `frameUserID` may be adopted by a session whose
+ * own id is `ownUserID`.
+ *
+ * FAIL-CLOSED and defined ONCE. Both adoption points -- the `initial`
+ * UserMaterialized and the `delta` ResumeDelta -- must refuse a payload that
+ * names another tenant, and `loadHydrationState` applies the same rule to the
+ * persisted checkpoint. Two hand-copied predicates meant a change to this
+ * security-relevant rule was one edit away from covering only one frame kind;
+ * they had already drifted to logging through different channels.
+ *
+ * An unknown local id refuses rather than adopts. A payload that names NO
+ * tenant is allowed through: proto3 normalizes an unset string to "", and the
+ * per-socket generation guard already answers "is this frame stale?" -- this
+ * one only answers "is this frame mine?".
+ */
+function isOwnTenant(ownUserID: string, frameUserID: string, what: string): boolean {
+  if (!ownUserID || (frameUserID && frameUserID !== ownUserID)) {
+    log.warn(`refusing a ${what} for another tenant`, { expected: ownUserID, got: frameUserID })
+    return false
+  }
+  return true
+}
 
 const RECONNECT_BASE_DELAY_MS = 250
 const RECONNECT_MAX_DELAY_MS = 5_000
@@ -38,6 +63,38 @@ function isTerminalCloseCode(code: number): boolean {
   return TERMINAL_CLOSE_CODES.has(code)
 }
 
+/**
+ * Round-trip a resume watermark through the wire codec and return the PARSED
+ * value, or undefined when it is absent or unusable.
+ *
+ * Two things this settles that a bare truthiness check did not. First, the
+ * value that goes on the wire is now the one the validator approved: the caller
+ * used to evaluate `parseHlcWire(formatHlcWire(watermark))` purely for its
+ * truthiness, discard it, and send the unvalidated sibling. They are equal
+ * today (the round trip is idempotent for a well-formed HLC), but only by
+ * assumption, and the parsed value has the further benefit of being a fresh
+ * message rather than a live reference into the manager's state.
+ *
+ * Second, it actually degrades. formatHlcWire THROWS a TypeError on a
+ * non-string clientId by design -- so a non-proto caller fails loudly -- and
+ * calling it bare from inside the WS-open effect meant that throw escaped the
+ * reactive computation AFTER the teardown, killing the subscription for the
+ * rest of the page session. That is the opposite of the "degrade to a
+ * full-snapshot reconnect" the call site promised.
+ */
+function validateResumeHlc(watermark: HLC | undefined): HLC | undefined {
+  if (!watermark)
+    return undefined
+  try {
+    return parseHlcWire(formatHlcWire(watermark)) ?? undefined
+  }
+  catch {
+    // Malformed beyond what the wire format can express: no cursor, so the
+    // connect takes a full snapshot.
+    return undefined
+  }
+}
+
 // Ids for the desktop sidecar's userevents relay, handed out in dispatch order: the
 // sidecar compares them to ignore a close whose relay a later open already replaced,
 // and to ignore an open a later one has superseded. A stale-looking open matters
@@ -48,6 +105,17 @@ function isTerminalCloseCode(code: number): boolean {
 // already holds.
 /** Exported for tests; production code reaches it only through useUserEvents. */
 export const nextUserEventsRelayId = createPersistedSeq(KEY_USER_EVENTS_RELAY_SEQ)
+
+/**
+ * The resume cursor this client presents on reconnect: its highest applied
+ * canonical HLC plus the epoch it was seen under. Sent on the /ws/userevents
+ * URL so the hub can ship a ResumeDelta instead of a full snapshot. Resolved
+ * from the per-user persisted watermark at socket-open.
+ */
+export interface ResumeToken {
+  hlc: HLC
+  epoch: bigint
+}
 
 /**
  * useUserEvents opens a single per-user WebSocket connection at
@@ -79,8 +147,17 @@ export interface UseUserEventsOpts {
   activeClient: ActiveClientStore
   /** PendingOpsManager that owns confirmed + speculative state. */
   pending: () => PendingOpsManager | null
+  /**
+   * Gate accessor for the WS open effect: the effect will not open the socket
+   * until this returns true. useCrdtRuntime sets it once hydration (loading +
+   * replaying the persisted checkpoint + op-log) has completed, so the resume
+   * cursor resolves against hydrated confirmedState rather than empty state.
+   * Undefined/always-true preserves the pre-hydration behavior (open as soon
+   * as userId is truthy).
+   */
+  ready?: () => boolean
   /** Optional override for the WebSocket URL builder (tests). */
-  buildWsUrl?: (workspaceIds: string[]) => string
+  buildWsUrl?: (workspaceIds: string[], resume: ResumeToken | null) => string
   /** Called when an EntityRemoved drops a pending op (caller may toast). */
   onPendingDropped?: () => void
   /**
@@ -221,21 +298,78 @@ export function useUserEvents(opts: UseUserEventsOpts): UserEventsHook {
   // The effect depends on both userId AND reconnectKey so that
   // calling `reconnect()` re-runs the WebSocket setup even when the
   // user's identity hasn't changed.
-  createEffect(on([opts.userId, reconnectKey], ([userId]) => {
+  // readyGate defaults to always-true when the caller doesn't wire hydration,
+  // preserving the prior "open as soon as userId is truthy" behavior. Included
+  // in the WS effect's deps so a late hydration completion re-fires the effect
+  // and opens the socket against the now-hydrated confirmedState.
+  const readyGate = opts.ready ?? (() => true)
+  createEffect(on([opts.userId, reconnectKey, readyGate], ([userId]) => {
     tearDown()
     if (!userId)
       return
+    // Hydration gate: do not open the socket (or resolve the resume cursor)
+    // until useCrdtRuntime signals the persisted checkpoint + op-log have
+    // been loaded and replayed. Without this, a cold reload would resolve
+    // the cursor against empty confirmedState and force a full snapshot even
+    // when a valid checkpoint exists.
+    if (!readyGate())
+      return
     const generation = connectionGeneration
 
+    // Resolve the resume cursor ONCE per connect attempt from the per-user
+    // persisted watermark. The hub decides RESUME vs FALLBACK server-side from
+    // this; a missing/stale cursor just yields a full snapshot (today's
+    // behavior). Resolved here (not inside each transport branch) so the native
+    // WS URL and the desktop sidecar RPC carry the same token.
+    //
+    // Refresh guard: a delta is only correct folded onto NON-EMPTY confirmed
+    // state (the delta is a catch-up over the current visible set, not a full
+    // replacement). Across a page refresh/restart, useCrdtRuntime now hydrates
+    // confirmedState from the persisted checkpoint + op-log (checkpointStore.ts)
+    // BEFORE this effect opens the socket (the `ready` gate), so confirmedState
+    // is populated on a cold reload too and a delta lands on a non-empty base.
+    // When hydration found no checkpoint (or the store is unavailable / the
+    // pair failed to parse and was wiped), confirmedState stays empty and the
+    // guard suppresses the cursor — sending it would make the hub resume a
+    // delta the client folds onto empty maps, yielding partial state. So only
+    // send the cursor when the live confirmedState is actually populated.
+    const pendingMgr = opts.pending()
+    const pendingState = pendingMgr?.state
+    // A delta is only correct folded onto NON-EMPTY confirmed state, and the
+    // populated check is authored on PendingOpsManager (next to the state whose
+    // shape it describes) so it stays correct as the schema grows. Null
+    // manager (briefly, before the userId effect constructs it) counts as
+    // empty — a cold start.
+    // The cursor is the manager's IN-MEMORY watermark, and only that.
+    //
+    // A cold reload gets it from the IndexedDB checkpoint (useCrdtRuntime gates
+    // this effect on hydration completing), and an in-session reconnect from
+    // live state -- so there is no case where confirmedState is populated but
+    // the watermark is missing, and hence nothing for a second persisted copy
+    // to rescue. There used to be one in localStorage; it could never be the
+    // source, because the token below requires confirmedPopulated and every
+    // path that populates confirmedState also seeds the watermark.
+    //
+    // The confirmedPopulated guard stays: a cursor is only meaningful if the
+    // state it describes is actually loaded, or the hub's delta would fold onto
+    // empty maps.
+    const confirmedPopulated = pendingMgr?.isConfirmedPopulated() ?? false
+    const validated = confirmedPopulated ? validateResumeHlc(pendingState?.resumeWatermark) : undefined
+    const resume: ResumeToken | null
+      = pendingState && validated
+        ? { hlc: validated, epoch: pendingState.currentEpoch }
+        : null
+
     // Decode one relay frame and dispatch it, resetting the reconnect streak on
-    // the bootstrap (initial) frame. Shared by the desktop-bridge and native
-    // WebSocket transports so the initial-frame backoff-reset rule can't drift
-    // between them.
+    // the bootstrap frame. Shared by the desktop-bridge and native WebSocket
+    // transports so the bootstrap-frame backoff-reset rule can't drift between
+    // them. A successful resume arrives as `delta` (not `initial`), but it is
+    // equally a completed bootstrap, so the streak resets on either.
     const handleFrame = (raw: Uint8Array) => {
       const evt = decodeFrame(raw)
       if (!evt)
         return
-      if (evt.event.case === 'initial')
+      if (evt.event.case === 'initial' || evt.event.case === 'delta')
         reconnectBackoff.reset(RECONNECT_KEY)
       dispatchEvent(opts, evt, setBootstrapped, setClock)
     }
@@ -306,7 +440,7 @@ export function useUserEvents(opts: UseUserEventsOpts): UserEventsHook {
             unsubClose?.()
             return
           }
-          return platformBridge.openUserEventsRelay(relayId, workspaceIds)
+          return platformBridge.openUserEventsRelay(relayId, workspaceIds, resume)
         })
         .catch(() => {
           scheduleReconnect(userId, generation)
@@ -324,7 +458,7 @@ export function useUserEvents(opts: UseUserEventsOpts): UserEventsHook {
     }
 
     const builder = opts.buildWsUrl ?? defaultBuildWsUrl
-    const url = builder(opts.allowedWorkspaceIds?.() ?? [])
+    const url = builder(opts.allowedWorkspaceIds?.() ?? [], resume)
     let ws: WebSocket
     try {
       ws = new WebSocket(url, ['userevents-relay'])
@@ -404,11 +538,21 @@ export function useUserEvents(opts: UseUserEventsOpts): UserEventsHook {
 // session implies the user — no user_id query parameter. The browser cannot
 // import Go, so it keeps its own copy -- like channel.ts's channel framing --
 // and the two must stay in lockstep.
-function defaultBuildWsUrl(workspaceIds: string[]): string {
+//
+// `resume`, when present, appends `resume_after_hlc=<physical>.<logical>.<client_id>`
+// (via the shared formatHlcWire so the wire shape is authored once per language)
+// and `resume_epoch=<epoch>` so the hub can attempt a delta resume. The hub
+// falls back to a full snapshot if the cursor is stale, so sending it is always
+// safe; omitted when there is no watermark (first connect, cleared storage).
+function defaultBuildWsUrl(workspaceIds: string[], resume: ResumeToken | null): string {
   const base = window.location.origin.replace(/^http/, 'ws')
   const params = new URLSearchParams()
   if (workspaceIds.length > 0)
     params.set('workspace_ids', workspaceIds.join(','))
+  if (resume) {
+    params.set('resume_after_hlc', formatHlcWire(resume.hlc))
+    params.set('resume_epoch', resume.epoch.toString())
+  }
   const qs = params.toString()
   return `${base}/ws/userevents${qs ? `?${qs}` : ''}`
 }
@@ -420,36 +564,68 @@ function dispatchEvent(
   setClock: (c: HLCClock | null) => void,
 ): void {
   const e = evt.event
+  // Resolve the manager ONCE. Exactly one arm runs per call, and this executes
+  // from a WS listener with no tracking scope, so re-reading the accessor per
+  // arm (five copies of `const pending = opts.pending()`) bought nothing. The
+  // per-arm `if (pending)` guards stay: the manager is null until the userId
+  // effect constructs it, and `presence` / `created` / `renamed` / `deleted`
+  // must keep running while it is.
+  const pending = opts.pending()
   switch (e.case) {
     case 'initial':
-      // Only mark bootstrapped when the payload was actually adopted. A frame
-      // refused for naming another tenant must not flip this flag: downstream
-      // reads it as "the CRDT is live", so a refused bootstrap would look
-      // identical to a successful one while the shell held no state at all.
-      if (applyMaterialized(opts, e.value, setClock))
-        setBootstrapped(true)
+      // Only adopt when the payload was actually accepted. A frame refused for
+      // naming another tenant must not reach the adoption tail: downstream
+      // reads `bootstrapped` as "the CRDT is live", so a refused bootstrap
+      // would look identical to a successful one while the shell held no state
+      // at all.
+      if (pending && applyMaterialized(opts, pending, e.value))
+        adoptBootstrapFrame(opts, pending, e.value.subscriberClientId, setBootstrapped, setClock)
       break
-    case 'batch': {
-      const pending = opts.pending()
+    case 'delta': {
+      // A successful resume: the hub shipped the ordered frame stream (the
+      // post-cursor tail plus materialized/removed visibility transitions)
+      // instead of a full snapshot. applyDelta folds it into the EXISTING
+      // confirmedState (no wholesale replace), so the UI does not blank on
+      // reconnect. The hub falls back to `initial` (handled above) when the
+      // cursor is at/below the compaction watermark or the epoch is stale, in
+      // which case applyMaterialized re-seeds the watermark from the snapshot.
+      if (!pending)
+        break
+      // Refuse a delta that is not this tenant's, the same fail-closed check
+      // applyMaterialized applies to `initial` and loadHydrationState applies
+      // to the persisted checkpoint. A resume is now the normal cold start
+      // and was the only one of the three adoption points that failed open.
+      // The per-socket generation guard answers "is this frame stale?", not
+      // "is this frame mine?".
+      if (!isOwnTenant(opts.userId(), e.value.userId, 'resume delta'))
+        break
+      if (pending.applyDelta(e.value).droppedPending)
+        opts.onPendingDropped?.()
+      // Same adoption tail as the `initial` arm, and deliberately the same
+      // CALL: a resume is the normal cold start now, so anything `initial`
+      // establishes has to be established here too. The two arms hand-copied
+      // this sequence and had already drifted apart twice.
+      adoptBootstrapFrame(opts, pending, e.value.subscriberClientId, setBootstrapped, setClock)
+      break
+    }
+    case 'batch':
       if (pending)
         pending.consumeRemote(e.value)
       break
-    }
-    case 'entityMaterialized': {
-      const pending = opts.pending()
+    case 'entityMaterialized':
       if (pending)
         pending.consumeEntityMaterialized(e.value)
       break
-    }
-    case 'entityRemoved': {
-      const pending = opts.pending()
-      if (pending) {
-        const result = pending.consumeEntityRemoved(e.value)
-        if (result.droppedPending)
-          opts.onPendingDropped?.()
-      }
+    case 'batchEnd':
+      // Closes a batch's frame sequence and is the ONLY point the resume
+      // cursor advances -- see the BatchEnd proto doc.
+      if (pending)
+        pending.consumeBatchEnd(e.value.atHlc)
       break
-    }
+    case 'entityRemoved':
+      if (pending && pending.consumeEntityRemoved(e.value).droppedPending)
+        opts.onPendingDropped?.()
+      break
     case 'presence':
       opts.activeClient.update(e.value.workspaceId, e.value.activeClientId)
       break
@@ -485,15 +661,62 @@ function dispatchEvent(
   }
 }
 
-/** Returns true when the payload was adopted; false when it was refused. */
+/**
+ * The tail both bootstrap-bearing frames run once their payload is accepted:
+ * an `initial` UserMaterialized and a `delta` ResumeDelta.
+ *
+ * ONE sequence, in one place, because the two arms establish the same four
+ * things and a resume is now the normal cold start — a client that keeps
+ * resuming may never see an `initial` frame at all. Hand-copied, the tail had
+ * already drifted twice: the delta arm reached production without adopting the
+ * hub's subscriber identity (so the active-client gate compared against '' for
+ * the life of the page) and without the workspace-list refresh.
+ *
+ * `subscriberClientId` is empty when the hub named none; proto3 normalizes an
+ * unset string to "", and adopting "" would overwrite a good identity with
+ * nothing.
+ */
+function adoptBootstrapFrame(
+  opts: UseUserEventsOpts,
+  pending: PendingOpsManager,
+  subscriberClientId: string,
+  setBootstrapped: (b: boolean) => void,
+  setClock: (c: HLCClock | null) => void,
+): void {
+  // The hub derives this from the authenticated session; the active-client gate
+  // compares broadcast `active_client_id` against it, never against the local
+  // random nanoid.
+  if (subscriberClientId)
+    opts.onSubscriberClientId?.(subscriberClientId)
+  setClock(pending.clock)
+  setBootstrapped(true)
+  // Refresh the workspace list on EVERY bootstrap. Workspace lifecycle
+  // (`created`/`renamed`/`deleted`) is delivered as its own frame on the live
+  // stream, and the sidebar list comes from a separate `listWorkspaces` call
+  // driven solely by this callback — so a create, rename or delete that
+  // happened while this client was disconnected reaches it through NEITHER
+  // path: the gap's lifecycle frames were never sent, and neither
+  // `UserMaterialized` nor `ResumeDelta` carries them (ResumeDelta carries
+  // entity_materialized|batch|entity_removed|batch_end -- entity data and batch
+  // boundaries, never workspace lifecycle). Without this, a reconnect leaves
+  // the sidebar showing a deleted workspace, a stale title, or missing a new
+  // one indefinitely.
+  opts.onWorkspaceLifecycleChanged?.()
+}
+
+/**
+ * Install an `initial` snapshot into `pending`. Returns true when the payload
+ * was adopted; false when it was refused for naming another tenant, in which
+ * case the caller must NOT run the adoption tail.
+ *
+ * Takes the already-resolved manager rather than re-reading `opts.pending()`:
+ * dispatchEvent resolves it once for every arm.
+ */
 function applyMaterialized(
   opts: UseUserEventsOpts,
+  pending: PendingOpsManager,
   materialized: UserMaterialized,
-  setClock: (c: HLCClock | null) => void,
 ): boolean {
-  const pending = opts.pending()
-  if (!pending)
-    return false
   // Refuse a payload that names another tenant. UserMaterialized carries its
   // OWN user_id, so adopting it unconditionally would let the frame -- not the
   // socket it arrived on -- decide whose workspaces, tiles and tabs this shell
@@ -503,14 +726,8 @@ function applyMaterialized(
   // "is this frame stale?" and not "is this frame mine?".
   //
   // Fail closed: an unknown local id refuses rather than adopts.
-  const ownUserID = opts.userId()
-  if (!ownUserID || (materialized.userId && materialized.userId !== ownUserID)) {
-    console.warn('[userevents] refusing a materialized payload for another tenant', {
-      expected: ownUserID,
-      got: materialized.userId,
-    })
+  if (!isOwnTenant(opts.userId(), materialized.userId, 'materialized payload'))
     return false
-  }
   pending.bootstrap({
     userId: materialized.userId,
     nodes: materialized.nodes as never,
@@ -520,8 +737,5 @@ function applyMaterialized(
     maxHlc: materialized.maxHlc as never,
     currentEpoch: materialized.currentEpoch,
   })
-  if (materialized.subscriberClientId)
-    opts.onSubscriberClientId?.(materialized.subscriberClientId)
-  setClock(pending.clock)
   return true
 }

--- a/frontend/src/lib/crdt/bridge.test.ts
+++ b/frontend/src/lib/crdt/bridge.test.ts
@@ -20,6 +20,7 @@ describe('withBridgeAndState', () => {
     return {
       workspaceId: () => 'ws-1',
       enqueue: batch => batch.batchId,
+      flushNow: () => {},
       clock: () => clock,
       originClientId: () => 'origin-1',
       speculativeState: () => state,
@@ -63,6 +64,7 @@ describe('withBridgeAndState', () => {
     const bridge: CRDTBridge = {
       workspaceId: () => 'ws-2',
       enqueue: batch => batch.batchId,
+      flushNow: () => {},
       clock: () => new HLCClock('client-2'),
       originClientId: () => 'unique-origin-xyz',
       speculativeState: () => create(UserCrdtStateSchema, { userId: 'user-2' }),
@@ -85,6 +87,7 @@ describe('ctxFromBridge', () => {
     return {
       workspaceId: () => 'ws',
       enqueue: batch => batch.batchId,
+      flushNow: () => {},
       clock: () => clock,
       originClientId: () => 'origin',
       speculativeState: () => null,

--- a/frontend/src/lib/crdt/bridge.ts
+++ b/frontend/src/lib/crdt/bridge.ts
@@ -46,6 +46,24 @@ export interface CRDTBridge {
    */
   enqueue: (batch: OpBatch) => string
   /**
+   * Send everything queued NOW, for a page-unload handler.
+   *
+   * `enqueue` only queues and arms a ~16 ms timer, and on a real unload
+   * (Cmd+R, tab close) that timer never fires -- so a store that materializes a
+   * debounced gesture on `pagehide` still loses it. Calling this immediately
+   * afterwards, in the SAME handler, is what gets it onto the wire: the request
+   * goes out over a `keepalive` transport, which survives the document being
+   * torn down.
+   *
+   * In one handler rather than a second `pagehide` listener in the runtime,
+   * because listener order would otherwise decide it: DOM listeners on one
+   * target fire in registration order, the runtime mounts BEFORE the stores, and
+   * a microtask defer does not help (the checkpoint runs after each callback,
+   * not after all of them). Sequential statements in one handler need no
+   * ordering argument at all.
+   */
+  flushNow: () => void
+  /**
    * Mint advisory client_hlcs from the same monotonic stream the
    * pending manager uses.
    *

--- a/frontend/src/lib/crdt/checkpointChunks.test.ts
+++ b/frontend/src/lib/crdt/checkpointChunks.test.ts
@@ -1,0 +1,318 @@
+import type { applyOp } from './apply'
+import type { UserCrdtState } from '~/generated/leapmux/v1/user_crdt_pb'
+import { create, toBinary } from '@bufbuild/protobuf'
+import { describe, expect, it } from 'vitest'
+import {
+  NodeRecordSchema,
+  UserCrdtStateSchema,
+  WorkspaceContentsRecordSchema,
+} from '~/generated/leapmux/v1/user_crdt_pb'
+import { WatchUserEventSchema } from '~/generated/leapmux/v1/user_ops_pb'
+import {
+  applyChunk,
+  CHUNK_KINDS,
+  entityKey,
+  framedEntityKeys,
+  fullCheckpointDelta,
+  isChunkKind,
+  keysRemovedSince,
+  parseEntityKey,
+  parseHeader,
+  serializeEntity,
+  serializeHeader,
+  snapshotEntityKeys,
+} from './checkpointChunks'
+
+const HLC = { physical: 10n, logical: 1n, clientId: 'c' }
+
+function state(): UserCrdtState {
+  return create(UserCrdtStateSchema, {
+    userId: 'u',
+    currentEpoch: 4n,
+    maxHlc: HLC,
+    compactionWatermark: { physical: 3n, logical: 0n, clientId: 'c' },
+    opRetentionWatermark: { physical: 1n, logical: 0n, clientId: 'c' },
+    nodes: { n1: { nodeId: 'n1', parentId: 'root', position: { value: 'a', hlc: HLC } } },
+    tabs: { t1: { tabId: 't1', tabType: 1, position: { value: 'b', hlc: HLC } } },
+    floatingWindows: { w1: { windowId: 'w1', rootNodeId: 'n1' } },
+    workspaces: { ws1: { workspaceId: 'ws1', rootNodeId: 'n1' } },
+  })
+}
+
+/** Round-trip a state through the header + chunk split, as hydrate would. */
+function rebuild(source: UserCrdtState): UserCrdtState {
+  const delta = fullCheckpointDelta(source)
+  const rebuilt = parseHeader(delta.headerBytes)
+  for (const chunk of delta.upserts) {
+    // The store treats `kind` as an opaque string, so hydrate has to re-narrow
+    // it -- exactly as loadHydrationState does before applying a chunk.
+    if (!isChunkKind(chunk.kind))
+      throw new Error(`unexpected chunk kind: ${chunk.kind}`)
+    applyChunk(rebuilt, chunk.kind, chunk.entityId, chunk.bytes)
+  }
+  return rebuilt
+}
+
+function frame(init: Parameters<typeof create<typeof WatchUserEventSchema>>[1]) {
+  return create(WatchUserEventSchema, init)
+}
+
+describe('serializeHeader', () => {
+  it('drops every entity map but keeps every scalar', () => {
+    const header = parseHeader(serializeHeader(state()))
+    expect(header.nodes).toEqual({})
+    expect(header.tabs).toEqual({})
+    expect(header.floatingWindows).toEqual({})
+    expect(header.workspaces).toEqual({})
+    expect(header.userId).toBe('u')
+    expect(header.currentEpoch).toBe(4n)
+    expect(header.maxHlc).toEqual(create(UserCrdtStateSchema, { maxHlc: HLC }).maxHlc)
+    expect(header.compactionWatermark?.physical).toBe(3n)
+    expect(header.opRetentionWatermark?.physical).toBe(1n)
+  })
+
+  it('does not mutate the state it serializes', () => {
+    // A shallow spread with blanked maps, not an edit of the live object -- the
+    // recorder calls this on `mgr.state.confirmedState` itself.
+    const s = state()
+    serializeHeader(s)
+    expect(Object.keys(s.nodes)).toEqual(['n1'])
+    expect(Object.keys(s.workspaces)).toEqual(['ws1'])
+  })
+
+  it('is O(1) in account size: the header does not grow with the maps', () => {
+    const small = state()
+    const large = state()
+    for (let i = 0; i < 500; i++)
+      large.nodes[`n${i}`] = create(NodeRecordSchema, { nodeId: `n${i}` })
+    expect(serializeHeader(large).byteLength).toBe(serializeHeader(small).byteLength)
+    // ...while the monolithic blob it replaces very much does.
+    expect(toBinary(UserCrdtStateSchema, large).byteLength)
+      .toBeGreaterThan(toBinary(UserCrdtStateSchema, small).byteLength)
+  })
+})
+
+describe('fullCheckpointDelta', () => {
+  it('round-trips a state through header + chunks', () => {
+    const source = state()
+    expect(rebuild(source)).toEqual(source)
+  })
+
+  it('emits one chunk per entity, across every kind', () => {
+    const delta = fullCheckpointDelta(state())
+    expect(delta.full).toBe(true)
+    expect(delta.deletes).toEqual([])
+    expect(delta.upserts.map(c => `${c.kind}:${c.entityId}`).sort())
+      .toEqual(['fw:w1', 'node:n1', 'tab:t1', 'ws:ws1'])
+  })
+
+  it('emits nothing but a header for an empty state', () => {
+    const empty = create(UserCrdtStateSchema, { userId: 'u' })
+    const delta = fullCheckpointDelta(empty)
+    expect(delta.upserts).toEqual([])
+    expect(rebuild(empty)).toEqual(empty)
+  })
+
+  it('round-trips an entity id containing a colon', () => {
+    // Entity ids are opaque and the dirty-set key is `kind:id`, so the split
+    // has to take the FIRST colon only.
+    const source = state()
+    source.workspaces['ws:with:colons'] = create(WorkspaceContentsRecordSchema, { workspaceId: 'ws:with:colons' })
+    expect(rebuild(source)).toEqual(source)
+    expect(parseEntityKey(entityKey('ws', 'ws:with:colons')))
+      .toEqual({ kind: 'ws', entityId: 'ws:with:colons' })
+  })
+})
+
+describe('applyChunk', () => {
+  it('keys the record by the ROW id, matching how the map was keyed before', () => {
+    const rebuilt = parseHeader(serializeHeader(state()))
+    const bytes = serializeEntity(state(), { kind: 'node', entityId: 'n1' })!
+    applyChunk(rebuilt, 'node', 'renamed', bytes)
+    expect(Object.keys(rebuilt.nodes)).toEqual(['renamed'])
+  })
+
+  it('throws on an undecodable blob, so the caller can wipe and cold-start', () => {
+    const rebuilt = parseHeader(serializeHeader(state()))
+    expect(() => applyChunk(rebuilt, 'node', 'n1', new Uint8Array([0xFF, 0xFE, 0xFD]))).toThrow()
+  })
+})
+
+describe('serializeEntity', () => {
+  it('returns undefined for an entity that is not in the state', () => {
+    // The signal the recorder turns into a chunk DELETE.
+    expect(serializeEntity(state(), { kind: 'node', entityId: 'gone' })).toBeUndefined()
+  })
+
+  it('serializes each kind with its own record schema', () => {
+    const s = state()
+    for (const kind of CHUNK_KINDS)
+      expect(serializeEntity(s, { kind, entityId: { node: 'n1', tab: 't1', fw: 'w1', ws: 'ws1' }[kind] })).toBeDefined()
+  })
+})
+
+describe('isChunkKind', () => {
+  it('accepts every declared kind and rejects anything else', () => {
+    for (const kind of CHUNK_KINDS)
+      expect(isChunkKind(kind)).toBe(true)
+    expect(isChunkKind('nodes')).toBe(false)
+    expect(isChunkKind('')).toBe(false)
+    // Not fooled by Object.prototype members: a row claiming kind
+    // "constructor" must be corruption, not a shard.
+    expect(isChunkKind('constructor')).toBe(false)
+    expect(isChunkKind('toString')).toBe(false)
+  })
+})
+
+describe('parseEntityKey', () => {
+  it('rejects a key with no separator or an unknown kind', () => {
+    expect(parseEntityKey('node')).toBeUndefined()
+    expect(parseEntityKey('bogus:x')).toBeUndefined()
+  })
+
+  it('accepts an empty entity id', () => {
+    expect(parseEntityKey('ws:')).toEqual({ kind: 'ws', entityId: '' })
+  })
+})
+
+describe('snapshotEntityKeys and keysRemovedSince', () => {
+  it('reports nothing removed when the state is unchanged', () => {
+    const s = state()
+    expect(keysRemovedSince(snapshotEntityKeys(s), s)).toEqual([])
+  })
+
+  it('reports exactly the entities deleted since the snapshot', () => {
+    // The recorder brackets `compactTombstones()` with this, because the prune
+    // drops shells whose tombstoning op may have been recorded MANY checkpoints
+    // ago -- so the dirty set alone cannot see them, and their chunks would be
+    // resurrected by the next cold start.
+    const s = state()
+    const before = snapshotEntityKeys(s)
+    delete s.nodes.n1
+    delete s.workspaces.ws1
+    expect(keysRemovedSince(before, s).map(r => entityKey(r.kind, r.entityId)).sort())
+      .toEqual(['node:n1', 'ws:ws1'])
+  })
+
+  it('ignores entities ADDED since the snapshot', () => {
+    const s = state()
+    const before = snapshotEntityKeys(s)
+    s.nodes.n2 = create(NodeRecordSchema, { nodeId: 'n2' })
+    expect(keysRemovedSince(before, s)).toEqual([])
+  })
+
+  it('is unaffected by the snapshot being taken on the same live object', () => {
+    // snapshotEntityKeys returns key ARRAYS, not a view: mutating the maps
+    // afterwards must not retroactively change what was snapshotted.
+    const s = state()
+    const before = snapshotEntityKeys(s)
+    delete s.tabs.t1
+    expect(before.tab).toEqual(['t1'])
+  })
+})
+
+describe('framedEntityKeys', () => {
+  it('reports the entity a batch\'s ops touch, for every op arm', () => {
+    const cases: Array<[Parameters<typeof applyOp>[1]['body'], string]> = [
+      [{ case: 'setNodeRegister', value: { nodeId: 'n' } }, 'node:n'],
+      [{ case: 'tombstoneNode', value: { nodeId: 'n' } }, 'node:n'],
+      [{ case: 'setTabRegister', value: { tabId: 't' } }, 'tab:t'],
+      [{ case: 'tombstoneTab', value: { tabId: 't' } }, 'tab:t'],
+      [{ case: 'setFloatingWindowRegister', value: { windowId: 'w' } }, 'fw:w'],
+      [{ case: 'tombstoneFloatingWindow', value: { windowId: 'w' } }, 'fw:w'],
+      [{ case: 'setWorkspaceRootNode', value: { workspaceId: 'ws' } }, 'ws:ws'],
+      [{ case: 'setWorkspaceRegister', value: { workspaceId: 'ws' } }, 'ws:ws'],
+      [{ case: 'tombstoneWorkspace', value: { workspaceId: 'ws' } }, 'ws:ws'],
+    ] as never
+    for (const [body, expected] of cases) {
+      const f = frame({ event: { case: 'batch', value: { batchId: 'b', ops: [{ body }] } } } as never)
+      expect(framedEntityKeys(f), `${(body as { case: string }).case}`).toEqual(new Set([expected]))
+    }
+  })
+
+  it('unions every op in one batch', () => {
+    const f = frame({
+      event: {
+        case: 'batch',
+        value: {
+          batchId: 'b',
+          ops: [
+            { body: { case: 'setNodeRegister', value: { nodeId: 'n1' } } },
+            { body: { case: 'setTabRegister', value: { tabId: 't1' } } },
+            { body: { case: 'setNodeRegister', value: { nodeId: 'n1' } } },
+          ],
+        },
+      },
+    } as never)
+    expect(framedEntityKeys(f)).toEqual(new Set(['node:n1', 'tab:t1']))
+  })
+
+  it('reports the entity an entityMaterialized frame installs', () => {
+    expect(framedEntityKeys(frame({
+      event: { case: 'entityMaterialized', value: { entity: { case: 'tab', value: { tabId: 't9' } } } },
+    } as never))).toEqual(new Set(['tab:t9']))
+    expect(framedEntityKeys(frame({
+      event: { case: 'entityMaterialized', value: { entity: { case: 'node', value: { nodeId: 'n9' } } } },
+    } as never))).toEqual(new Set(['node:n9']))
+    expect(framedEntityKeys(frame({
+      event: { case: 'entityMaterialized', value: { entity: { case: 'floatingWindow', value: { windowId: 'w9' } } } },
+    } as never))).toEqual(new Set(['fw:w9']))
+  })
+
+  it('reports the entity an entityRemoved frame evicts', () => {
+    expect(framedEntityKeys(frame({
+      event: { case: 'entityRemoved', value: { entity: { case: 'tab', value: { tabId: 't9' } } } },
+    } as never))).toEqual(new Set(['tab:t9']))
+    expect(framedEntityKeys(frame({
+      event: { case: 'entityRemoved', value: { entity: { case: 'nodeId', value: 'n9' } } },
+    } as never))).toEqual(new Set(['node:n9']))
+    expect(framedEntityKeys(frame({
+      event: { case: 'entityRemoved', value: { entity: { case: 'windowId', value: 'w9' } } },
+    } as never))).toEqual(new Set(['fw:w9']))
+  })
+
+  it('reports nothing for a batchEnd, which only moves the watermark', () => {
+    // The watermark rides in the header, and every rewrite re-serializes that.
+    expect(framedEntityKeys(frame({ event: { case: 'batchEnd', value: { atHlc: HLC } } } as never)))
+      .toEqual(new Set())
+  })
+
+  it('reports nothing for an op or entity oneof that is EMPTY', () => {
+    // applyOp / applyMaterializedCore fall through their switches and install
+    // nothing, so nothing is dirtied.
+    expect(framedEntityKeys(frame({ event: { case: 'batch', value: { batchId: 'b', ops: [{}] } } } as never)))
+      .toEqual(new Set())
+    expect(framedEntityKeys(frame({ event: { case: 'entityRemoved', value: {} } } as never)))
+      .toEqual(new Set())
+  })
+
+  it('refuses to guess for a frame arm it does not understand', () => {
+    // null forces the caller's FULL rewrite. Under-reporting is the one
+    // unrecoverable direction: an entity whose chunk is stale on disk but
+    // absent from the dirty set is never rewritten, so the next cold start
+    // silently resurrects the pre-change record.
+    expect(framedEntityKeys(frame({ event: { case: 'presence', value: {} } } as never))).toBeNull()
+    expect(framedEntityKeys(frame({}))).toBeNull()
+    expect(framedEntityKeys({ event: { case: 'somethingNew', value: {} } } as never)).toBeNull()
+  })
+
+  it('refuses to guess when ONE op of a batch is unrecognized', () => {
+    // A future op arm this build has no case for. Patched in AFTER `create`,
+    // which silently drops an unknown oneof case rather than storing it.
+    const f = frame({
+      event: {
+        case: 'batch',
+        value: {
+          batchId: 'b',
+          ops: [
+            { body: { case: 'setNodeRegister', value: { nodeId: 'n1' } } },
+            { body: { case: 'setTabRegister', value: { tabId: 't1' } } },
+          ],
+        },
+      },
+    } as never)
+    const ops = (f.event as { value: { ops: Array<{ body: unknown }> } }).value.ops
+    ops[1]!.body = { case: 'somethingNew', value: {} }
+    expect(framedEntityKeys(f)).toBeNull()
+  })
+})

--- a/frontend/src/lib/crdt/checkpointChunks.ts
+++ b/frontend/src/lib/crdt/checkpointChunks.ts
@@ -1,0 +1,373 @@
+import type { DescMessage, Message } from '@bufbuild/protobuf'
+import type { CheckpointDelta } from './checkpointStore'
+import type { OpEntityKind } from './ops'
+import type { UserCrdtState } from '~/generated/leapmux/v1/user_crdt_pb'
+import type { CrdtOp, EntityMaterialized, EntityRemoved, WatchUserEvent } from '~/generated/leapmux/v1/user_ops_pb'
+import { fromBinary, toBinary } from '@bufbuild/protobuf'
+import {
+  FloatingWindowRecordSchema,
+  NodeRecordSchema,
+  TabRecordSchema,
+  UserCrdtStateSchema,
+  WorkspaceContentsRecordSchema,
+} from '~/generated/leapmux/v1/user_crdt_pb'
+import { opTarget } from './ops'
+
+// ---------------------------------------------------------------------------
+// Sharding UserCrdtState into a header + one chunk per entity
+//
+// The checkpoint used to be ONE blob: `toBinary(UserCrdtStateSchema,
+// confirmedState)` over the whole account, re-run on the main thread every 256
+// confirmed frames. That cost scales with the ACCOUNT, while the delta that
+// triggered it is 256 ops on one or two entities -- measured at 3.4 ms for 400
+// nodes / 600 tabs and 29.6 ms for 2400 / 4800, landing mid-drag.
+//
+// So the persisted checkpoint is split:
+//
+//   - the HEADER: the state with every entity map emptied. Scalars only
+//     (user id, max/compaction/op-retention HLCs, epoch), so it is O(1) in
+//     account size and cheap to rewrite on every checkpoint.
+//   - one CHUNK per entity, `(kind, entityId) -> serialized record`. A rewrite
+//     re-serializes only the entities that actually changed.
+//
+// This module owns the split and its inverse, and is the ONLY place that knows
+// which record schema each kind carries. The recorder serializes through it,
+// hydrate reassembles through it, and checkpointStore stays a pure blob store
+// that treats `kind` / `entityId` / `bytes` as opaque.
+// ---------------------------------------------------------------------------
+
+/**
+ * The map fields of `UserCrdtState` — everything sharded into chunks.
+ *
+ * Derived from the generated type rather than listed by hand, so the
+ * exhaustiveness assertion below is checked against the proto itself.
+ */
+type ShardedField = {
+  [K in keyof UserCrdtState]-?: UserCrdtState[K] extends Record<string, Message> ? K : never
+}[keyof UserCrdtState]
+
+/** One kind's wiring: which map it lives in and which schema its records use. */
+interface ShardSpec {
+  field: ShardedField
+  schema: DescMessage
+  /** Whether records of this kind can carry a `tombstone_at`. */
+  tombstoned: boolean
+}
+
+/**
+ * Entity kinds. The `kind:id` vocabulary is shared with `opTarget` (ops.ts), so
+ * the recorder's dirty keys, these chunk keys and the tombstone pin's keys are
+ * all the same strings; `_everyOpKindIsSharded` below proves the two
+ * declarations agree.
+ *
+ * The tombstone pin ignores `ws` (workspace records carry no tombstone, so they
+ * are never pruned), but it is a map field of UserCrdtState and therefore must
+ * be sharded here.
+ */
+const SHARDS = {
+  // Each schema is widened to the non-generic `DescMessage` on purpose: the
+  // codecs below are driven by a runtime lookup, so a per-kind message TYPE
+  // would only push a cast to every call site.
+  //
+  // `tombstoned` says whether records of this kind can carry a `tombstone_at`,
+  // and therefore whether the client-side GC has anything to collect from it.
+  // Declared HERE rather than as a list beside the GC so a new kind states its
+  // own answer once, next to its field and schema.
+  node: { field: 'nodes', schema: NodeRecordSchema as DescMessage, tombstoned: true },
+  tab: { field: 'tabs', schema: TabRecordSchema as DescMessage, tombstoned: true },
+  fw: { field: 'floatingWindows', schema: FloatingWindowRecordSchema as DescMessage, tombstoned: true },
+  ws: { field: 'workspaces', schema: WorkspaceContentsRecordSchema as DescMessage, tombstoned: false },
+} as const satisfies Record<string, ShardSpec>
+
+export type ChunkKind = keyof typeof SHARDS
+
+/** Every kind, for whole-state walks. */
+export const CHUNK_KINDS = Object.keys(SHARDS) as ChunkKind[]
+
+/**
+ * The kinds whose records can carry a tombstone — the only ones the client-side
+ * tombstone GC has to walk. Derived from SHARDS so it cannot fall out of step
+ * with it.
+ */
+export const TOMBSTONED_CHUNK_KINDS = CHUNK_KINDS.filter(kind => SHARDS[kind].tombstoned)
+
+/**
+ * The entity map `kind` shards, as a plain record.
+ *
+ * One home for the `state[SHARDS[kind].field]` lookup and its cast, which five
+ * call sites in this module were each spelling out — and which the tombstone GC
+ * in pendingOps.ts was open-coding as its own kind->map table entirely.
+ */
+export function entityMapFor(state: UserCrdtState, kind: ChunkKind): Record<string, unknown> {
+  return state[SHARDS[kind].field] as Record<string, unknown>
+}
+
+/**
+ * Compile-time proof that every map field of `UserCrdtState` is claimed by a
+ * kind above. Add a map to the proto without adding a shard for it and this
+ * fails to typecheck -- which is the point: an unsharded map would silently
+ * ride along in the HEADER and put the whole-account serialize this module
+ * exists to remove straight back on the checkpoint hot path.
+ */
+type ClaimedField = (typeof SHARDS)[ChunkKind]['field']
+const _everyMapIsSharded: ShardedField extends ClaimedField ? true : never = true
+void _everyMapIsSharded
+
+/** True when `kind` names a shard this build knows. */
+export function isChunkKind(kind: string): kind is ChunkKind {
+  return Object.hasOwn(SHARDS, kind)
+}
+
+/** One entity's identity within an owner's checkpoint. */
+export interface EntityRef {
+  kind: ChunkKind
+  entityId: string
+}
+
+/** One entity's persisted chunk. */
+export interface EntityChunk extends EntityRef {
+  /** `toBinary(<kind's record schema>, record)`. */
+  bytes: Uint8Array
+}
+
+/** The `kind:id` key the dirty set and the tombstone diff both speak. */
+export function entityKey(kind: ChunkKind, entityId: string): string {
+  return `${kind}:${entityId}`
+}
+
+/**
+ * Split a `kind:id` key. Returns undefined for a key naming an unknown kind.
+ *
+ * Splits at the FIRST colon only: entity ids may contain colons, kinds may not.
+ */
+export function parseEntityKey(key: string): EntityRef | undefined {
+  const sep = key.indexOf(':')
+  if (sep < 0)
+    return undefined
+  const kind = key.slice(0, sep)
+  return isChunkKind(kind) ? { kind, entityId: key.slice(sep + 1) } : undefined
+}
+
+/**
+ * Serialize the checkpoint HEADER: the state with every sharded map emptied.
+ *
+ * A shallow spread of the message object, so a scalar field added to
+ * `UserCrdtState` rides along with no change here, and only the maps named by
+ * `SHARDS` are blanked (the assertion above is what keeps that list complete).
+ * The spread is not a deep clone, but nothing mutates the copy -- it exists
+ * only to be handed to `toBinary` in this same synchronous call.
+ */
+export function serializeHeader(state: UserCrdtState): Uint8Array {
+  const header = { ...state } as UserCrdtState
+  for (const { field } of Object.values(SHARDS)) {
+    // One narrow cast: `field` is a union of four map keys, so a direct
+    // assignment would demand a value assignable to all four at once.
+    ;(header as unknown as Record<string, unknown>)[field] = {}
+  }
+  return toBinary(UserCrdtStateSchema, header)
+}
+
+/**
+ * Serialize ONE entity, or undefined when it is absent from `state` (removed by
+ * an op or by the tombstone prune — the caller turns that into a chunk delete).
+ */
+export function serializeEntity(state: UserCrdtState, ref: EntityRef): Uint8Array | undefined {
+  const spec = SHARDS[ref.kind]
+  const record = (state[spec.field] as Record<string, Message>)[ref.entityId]
+  return record === undefined ? undefined : toBinary(spec.schema, record)
+}
+
+/** Every entity in `state`, as chunks — the payload of a FULL rewrite. */
+function serializeAllEntities(state: UserCrdtState): EntityChunk[] {
+  const chunks: EntityChunk[] = []
+  for (const kind of CHUNK_KINDS) {
+    const spec = SHARDS[kind]
+    for (const [entityId, record] of Object.entries(state[spec.field] as Record<string, Message>))
+      chunks.push({ kind, entityId, bytes: toBinary(spec.schema, record) })
+  }
+  return chunks
+}
+
+/**
+ * The delta that rewrites an owner's checkpoint from scratch: the header plus
+ * every entity, with `full` set so the store drops whatever chunks the owner
+ * already had.
+ *
+ * The bootstrap / lineage-reset payload, and the only shape a fresh owner can
+ * be given -- an incremental delta is meaningless without a base.
+ */
+export function fullCheckpointDelta(state: UserCrdtState): CheckpointDelta {
+  return { headerBytes: serializeHeader(state), upserts: serializeAllEntities(state), deletes: [], full: true }
+}
+
+/** Parse a header blob back into a `UserCrdtState` with empty entity maps. */
+export function parseHeader(bytes: Uint8Array): UserCrdtState {
+  const state = fromBinary(UserCrdtStateSchema, bytes)
+  // A header written by `serializeHeader` encodes no map entries, so the
+  // decoded maps are already empty; assigning fresh objects only guards against
+  // a blob written before this module existed (or by a hand-edited row).
+  state.nodes = {}
+  state.tabs = {}
+  state.floatingWindows = {}
+  state.workspaces = {}
+  return state
+}
+
+/**
+ * Merge one chunk into `state`, keyed by the ROW's entity id.
+ *
+ * The row key is authoritative, exactly as the map key was in the monolithic
+ * blob: a proto map entry's key is serialized independently of any id field
+ * inside its value, so keying off the row reproduces the old behaviour rather
+ * than adding a new way for a valid state to be rejected.
+ *
+ * Throws on an undecodable blob; the caller's corruption policy decides what
+ * that means (hydrate wipes and cold-starts).
+ */
+export function applyChunk(state: UserCrdtState, kind: ChunkKind, entityId: string, bytes: Uint8Array): void {
+  const spec = SHARDS[kind]
+  ;(state[spec.field] as Record<string, Message>)[entityId] = fromBinary(spec.schema, bytes)
+}
+
+/**
+ * Every entity key currently present in `state`, grouped by kind.
+ *
+ * Taken before `compactTombstones()` so the recorder can diff it against the
+ * post-prune maps: the prune drops tombstone shells whose tombstoning op may
+ * have been recorded MANY checkpoints ago, so the dirty set alone cannot see
+ * them and their chunks would be resurrected by the next cold start.
+ *
+ * O(entities) in `Object.keys` calls only — no per-entity allocation beyond the
+ * key arrays, which reuse the map's existing string references. That is roughly
+ * two orders of magnitude below the whole-account `toBinary` this module
+ * replaces, and the prune it brackets is already an O(entities) walk.
+ */
+export function snapshotEntityKeys(state: UserCrdtState): Record<ChunkKind, string[]> {
+  const snapshot = {} as Record<ChunkKind, string[]>
+  for (const kind of CHUNK_KINDS)
+    snapshot[kind] = Object.keys(state[SHARDS[kind].field])
+  return snapshot
+}
+
+/** Keys in `snapshot` that are no longer present in `state`. */
+export function keysRemovedSince(snapshot: Record<ChunkKind, string[]>, state: UserCrdtState): EntityRef[] {
+  const removed: EntityRef[] = []
+  for (const kind of CHUNK_KINDS) {
+    const map = state[SHARDS[kind].field] as Record<string, unknown>
+    for (const entityId of snapshot[kind]) {
+      if (!Object.hasOwn(map, entityId))
+        removed.push({ kind, entityId })
+    }
+  }
+  return removed
+}
+
+/**
+ * The entity keys one confirmed frame touches, or `null` when the frame's shape
+ * is not understood.
+ *
+ * `null` means "assume everything" — the caller must fall back to a FULL
+ * rewrite. That is the safe direction and the reason this returns a nullable
+ * rather than an empty set: an entity whose chunk is stale on disk but absent
+ * from the dirty set is never rewritten, so the next cold start resurrects the
+ * pre-change record silently. Under-reporting corrupts; over-reporting only
+ * costs one extra serialize.
+ */
+export function framedEntityKeys(frame: WatchUserEvent): Set<string> | null {
+  const event = frame.event
+  switch (event.case) {
+    case 'batch': {
+      const keys = new Set<string>()
+      for (const op of event.value.ops) {
+        const opKeys = opEntityKeys(op)
+        if (opKeys === null)
+          return null
+        for (const key of opKeys)
+          keys.add(key)
+      }
+      return keys
+    }
+    case 'entityMaterialized':
+    case 'entityRemoved': {
+      const keys = entityRefKeys(event.value.entity)
+      return keys === null ? null : new Set(keys)
+    }
+    case 'batchEnd':
+      // Advances the resume watermark only; the watermark rides in the header,
+      // which every rewrite re-serializes unconditionally.
+      return new Set()
+    default:
+      // `initial` / `delta` / `presence` / workspace-lifecycle notices, an empty
+      // oneof, or an arm added after this switch was written. `applyFrames`
+      // installs nothing for any of them today, but a NEW arm that does would
+      // be invisible here -- so refuse to guess.
+      return null
+  }
+}
+
+/**
+ * The entity keys a single op targets — one key, or none for an op that
+ * installs nothing.
+ *
+ * A thin adapter over `opTarget` (ops.ts), which owns the mapping and is shared
+ * with the tombstone pin so the two cannot disagree about a newly added op
+ * kind. `unknown` becomes null here, which forces the caller's full-rewrite
+ * fallback; the pin degrades in its own direction (prune nothing).
+ */
+function opEntityKeys(op: CrdtOp): readonly string[] | null {
+  const target = opTarget(op)
+  switch (target.case) {
+    case 'entity':
+      return [entityKey(target.kind, target.id)]
+    case 'none':
+      return []
+    default:
+      return null
+  }
+}
+
+/**
+ * Compile-time proof that every kind `opTarget` can name has a shard here. The
+ * two vocabularies are declared independently -- `OpEntityKind` beside the op
+ * builders, `ChunkKind` from the SHARDS table above -- so this is what keeps
+ * them one vocabulary rather than two that happen to match today. Adding a kind
+ * to either without the other fails to typecheck, which is the whole point of
+ * routing `opEntityKeys` through `opTarget`.
+ */
+const _everyOpKindIsSharded: OpEntityKind extends ChunkKind ? true : never = true
+void _everyOpKindIsSharded
+
+/**
+ * The entity keys an `EntityMaterialized` / `EntityRemoved` frame names. The two
+ * oneofs differ in shape -- materialized carries the whole record, removed
+ * carries just an identifier -- but name the same three kinds.
+ */
+function entityRefKeys(entity: EntityMaterialized['entity'] | EntityRemoved['entity']): readonly string[] | null {
+  switch (entity.case) {
+    case 'tab':
+      return [entityKey('tab', entity.value.tabId)]
+    case 'node':
+      return [entityKey('node', entity.value.nodeId)]
+    case 'floatingWindow':
+      return [entityKey('fw', entity.value.windowId)]
+    case 'nodeId':
+      return [entityKey('node', entity.value)]
+    case 'windowId':
+      return [entityKey('fw', entity.value)]
+    case undefined:
+      // Empty oneof: `applyMaterializedCore` / `applyRemovedCore` install and
+      // evict nothing, so nothing is dirtied.
+      return []
+    default: {
+      // Unreachable today, and PROVEN so -- the same treatment `opEntityKeys`
+      // gets from `_everyOpKindIsSharded`. Without it, adding a kind to either
+      // oneof lands here silently, and `null` is not a free fallback: it makes
+      // `framedEntityKeys` report "assume everything changed", which forces a
+      // full O(account) re-serialize on every such frame -- precisely the cost
+      // this module exists to remove. A build error is the cheaper failure.
+      const exhaustive: never = entity
+      void exhaustive
+      return null
+    }
+  }
+}

--- a/frontend/src/lib/crdt/checkpointRecorder.test.ts
+++ b/frontend/src/lib/crdt/checkpointRecorder.test.ts
@@ -1,0 +1,751 @@
+import type { CheckpointDelta } from './checkpointStore'
+import type { HlcShape } from './hlc'
+import type { PendingOpsManager } from './pendingOps'
+import type { UserCrdtState } from '~/generated/leapmux/v1/user_crdt_pb'
+import type { WatchUserEvent } from '~/generated/leapmux/v1/user_ops_pb'
+import { create, toBinary } from '@bufbuild/protobuf'
+import { IDBFactory, IDBKeyRange } from 'fake-indexeddb'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { NodeRecordSchema, UserCrdtStateSchema } from '~/generated/leapmux/v1/user_crdt_pb'
+import { WatchUserEventSchema } from '~/generated/leapmux/v1/user_ops_pb'
+import { fullCheckpointDelta } from './checkpointChunks'
+import { createCheckpointRecorder } from './checkpointRecorder'
+import {
+  _resetCheckpointStoreForTest,
+  appendOpLogSegment,
+  readCheckpoint,
+  writeCheckpointAndTruncateOpLog,
+} from './checkpointStore'
+import { hlcClone } from './hlc'
+import { pruneTombstonesAtOrBelow } from './pendingOps'
+
+// What the recorder ASKS the store to write is the observation that matters:
+// a full rewrite and an incremental one leave byte-identical rows behind, so
+// comparing the persisted result cannot tell them apart. The wrapper delegates
+// to the real store, so everything else in this file still exercises real IDB.
+const storeSpy = vi.hoisted(() => ({ deltas: [] as CheckpointDelta[], appends: 0 }))
+vi.mock('./checkpointStore', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./checkpointStore')>()
+  return {
+    ...actual,
+    writeCheckpointAndTruncateOpLog: (
+      userId: string,
+      clientId: string,
+      delta: CheckpointDelta,
+      ...rest: [HlcShape, bigint, number?]
+    ) => {
+      storeSpy.deltas.push(delta)
+      return actual.writeCheckpointAndTruncateOpLog(userId, clientId, delta, ...rest)
+    },
+    // Counted, not stubbed: whether the op-log write HAPPENS is the whole
+    // observation for the compaction-skip case, and it is invisible in the
+    // persisted result (the rewrite truncates the log either way).
+    appendOpLogSegment: (...args: Parameters<typeof actual.appendOpLogSegment>) => {
+      storeSpy.appends++
+      return actual.appendOpLogSegment(...args)
+    },
+  }
+})
+
+/** The delta of the LAST rewrite the recorder issued. */
+function lastDelta(): CheckpointDelta {
+  const delta = storeSpy.deltas.at(-1)
+  if (!delta)
+    throw new Error('no checkpoint rewrite was issued')
+  return delta
+}
+
+/** `kind:id` keys of a delta's upserts / deletes, sorted. */
+function keysOf(refs: readonly { kind: string, entityId: string }[]): string[] {
+  return refs.map(r => `${r.kind}:${r.entityId}`).sort()
+}
+
+beforeEach(() => {
+  storeSpy.deltas = []
+  storeSpy.appends = 0
+  vi.stubGlobal('indexedDB', new IDBFactory())
+  vi.stubGlobal('IDBKeyRange', IDBKeyRange)
+  _resetCheckpointStoreForTest()
+})
+afterEach(() => {
+  _resetCheckpointStoreForTest()
+  vi.unstubAllGlobals()
+})
+
+const USER = 'u'
+const CLIENT = 'tab-1'
+const WM = { physical: 10n, logical: 0n, clientId: 'hub' }
+
+/**
+ * A stand-in for PendingOpsManager exposing only what the recorder touches:
+ * confirmedState, resumeWatermark, currentEpoch, and the pre-write compaction
+ * step. Keeping it this small is itself the point of extracting the recorder --
+ * the policy is testable without a Solid root or a real manager.
+ *
+ * `compactTombstones` calls the PRODUCTION `pruneTombstonesAtOrBelow` rather
+ * than stubbing it out, so a change to what the real method prunes shows up
+ * here instead of being mocked away.
+ */
+function fakeMgr(overrides: { watermark?: { physical: bigint, logical: bigint, clientId: string } | undefined } = {}) {
+  const state = {
+    confirmedState: create(UserCrdtStateSchema, { userId: USER, currentEpoch: 1n }),
+    resumeWatermark: 'watermark' in overrides ? overrides.watermark : WM,
+    currentEpoch: 1n,
+  }
+  return {
+    state,
+    compactTombstones: () => pruneTombstonesAtOrBelow(state.confirmedState, hlcClone(state.resumeWatermark)),
+  } as unknown as PendingOpsManager
+}
+
+function confirmed(mgr: PendingOpsManager): UserCrdtState {
+  return mgr.state.confirmedState
+}
+
+function frame(batchId: string) {
+  return create(WatchUserEventSchema, { event: { case: 'batch', value: { batchId, ops: [] } } })
+}
+
+/** A frame whose single op touches `node:<id>`, so it dirties exactly one chunk. */
+function nodeFrame(batchId: string, nodeId: string): WatchUserEvent {
+  return create(WatchUserEventSchema, {
+    event: {
+      case: 'batch',
+      value: { batchId, ops: [{ body: { case: 'setNodeRegister', value: { nodeId } } }] },
+    },
+  } as never)
+}
+
+/** Put a node record into confirmedState, as applyOp would. */
+function putNode(mgr: PendingOpsManager, nodeId: string, position: string): void {
+  confirmed(mgr).nodes[nodeId] = create(NodeRecordSchema, {
+    nodeId,
+    position: { value: position, hlc: { physical: 1n, logical: 0n, clientId: 'c' } },
+  })
+}
+
+/** Let the queued microtask flush and its IDB write settle. */
+async function settle(): Promise<void> {
+  for (let i = 0; i < 5; i++)
+    await new Promise(resolve => setTimeout(resolve, 0))
+}
+
+/** Seed a checkpoint so reads return `ok` rather than `miss`. */
+async function writeBase(state?: UserCrdtState): Promise<void> {
+  await writeCheckpointAndTruncateOpLog(
+    USER,
+    CLIENT,
+    fullCheckpointDelta(state ?? create(UserCrdtStateSchema, { userId: USER })),
+    { physical: 1n, logical: 0n, clientId: 'hub' },
+    1n,
+  )
+}
+
+/** The owner's persisted chunks as `kind:id -> serialized bytes`, order-free. */
+async function persistedChunks(): Promise<Map<string, string>> {
+  const read = await readCheckpoint(USER, CLIENT)
+  if (read.status !== 'ok')
+    throw new Error(`expected a readable checkpoint, got ${read.status}`)
+  return new Map(read.chunks.map(c => [`${c.kind}:${c.entityId}`, c.bytes.join(',')]))
+}
+
+describe('createCheckpointRecorder', () => {
+  it('coalesces a burst of frames into ONE op-log segment', async () => {
+    // The append is microtask-coalesced so a drag (~120 frames/sec, half of them
+    // self-traffic) costs one IDB transaction per burst rather than one per
+    // frame.
+    const recorder = createCheckpointRecorder({ userId: USER, clientId: CLIENT, mgr: fakeMgr() })
+    await writeBase()
+
+    recorder.record(frame('a'))
+    recorder.record(frame('b'))
+    recorder.record(frame('c'))
+    await settle()
+
+    const read = await readCheckpoint(USER, CLIENT)
+    expect(read.status).toBe('ok')
+    if (read.status !== 'ok')
+      return
+    expect(read.opLogFrames).toHaveLength(3)
+    await recorder.dispose()
+  })
+
+  it('rewrites the checkpoint and truncates once the threshold is crossed', async () => {
+    await writeBase()
+    await appendOpLogSegment(USER, CLIENT, [toBinary(WatchUserEventSchema, frame('stale'))], 0)
+
+    const recorder = createCheckpointRecorder({
+      userId: USER,
+      clientId: CLIENT,
+      mgr: fakeMgr(),
+      threshold: 2,
+      hydratedFrom: { frames: [], nextOrdinal: 0 },
+    })
+    recorder.record(frame('a'))
+    recorder.record(frame('b'))
+    await settle()
+
+    const read = await readCheckpoint(USER, CLIENT)
+    expect(read.status).toBe('ok')
+    if (read.status !== 'ok')
+      return
+    // Compaction ran: the log is empty and the counter is back to zero.
+    expect(read.opLogFrames).toEqual([])
+    expect(recorder.opLogCount).toBe(0)
+    await recorder.dispose()
+  })
+
+  it('counts frames already on disk toward the threshold', async () => {
+    // Seeding with what hydrate replayed is what drains a log grown by a run of
+    // short sessions that each resume via `delta` (no bootstrap, hence no
+    // truncate) and append fewer than a threshold's worth of frames.
+    await writeBase()
+    const recorder = createCheckpointRecorder({
+      userId: USER,
+      clientId: CLIENT,
+      mgr: fakeMgr(),
+      threshold: 10,
+      hydratedFrom: { frames: Array.from({ length: 9 }, (_, i) => frame(`replayed-${i}`)), nextOrdinal: 0 },
+    })
+    expect(recorder.opLogCount).toBe(9)
+
+    recorder.record(frame('one-more'))
+    await settle()
+
+    expect(recorder.opLogCount).toBe(0)
+    await recorder.dispose()
+  })
+
+  it('backs off instead of re-serializing on every flush when it cannot compact', async () => {
+    // With no watermark there is nothing to pin a checkpoint at. The counter
+    // stays above the threshold, so without a backoff EVERY subsequent flush
+    // re-attempts a serialization that is already known to fail.
+    const mgr = fakeMgr({ watermark: undefined })
+    const recorder = createCheckpointRecorder({ userId: USER, clientId: CLIENT, mgr, threshold: 1 })
+
+    recorder.record(frame('a'))
+    await settle()
+    expect(recorder.opLogCount).toBe(1)
+
+    // The next flush must NOT retry -- the retry point moved out by a threshold.
+    recorder.record(frame('b'))
+    await settle()
+    expect(recorder.opLogCount).toBe(2)
+    await recorder.dispose()
+  })
+
+  it('drops a frame that fails to serialize instead of throwing', async () => {
+    // record() runs inside the manager's confirmed-mutation pipeline; a throw
+    // would propagate back into the consume* entry points and interrupt their
+    // post-record work.
+    const recorder = createCheckpointRecorder({ userId: USER, clientId: CLIENT, mgr: fakeMgr() })
+    const bad = { event: { case: 'batch', value: { batchId: 1 as never, ops: [] } } } as never
+    expect(() => recorder.record(bad)).not.toThrow()
+    await recorder.dispose()
+  })
+
+  it('does not throw when the confirmed state fails to serialize', async () => {
+    // The sibling of the guard above, on the larger of the two payloads. This
+    // one runs synchronously inside bootstrap()'s reset observer, so an
+    // unguarded throw escaped through applyMaterialized into the WebSocket
+    // message handler -- skipping setBootstrapped and every other
+    // post-bootstrap step while the socket stayed healthy and reported nothing.
+    const mgr = fakeMgr()
+    ;(mgr.state as { confirmedState: unknown }).confirmedState = { not: 'a message' }
+    const recorder = createCheckpointRecorder({ userId: USER, clientId: CLIENT, mgr })
+    expect(() => recorder.onCheckpointReset()).not.toThrow()
+    await recorder.dispose()
+  })
+
+  it('stops recording after dispose', async () => {
+    await writeBase()
+    const recorder = createCheckpointRecorder({ userId: USER, clientId: CLIENT, mgr: fakeMgr() })
+    await recorder.dispose()
+
+    recorder.record(frame('after-dispose'))
+    await settle()
+
+    const read = await readCheckpoint(USER, CLIENT)
+    expect(read.status).toBe('ok')
+    if (read.status !== 'ok')
+      return
+    expect(read.opLogFrames).toEqual([])
+  })
+
+  it('dispose() resolves only after the in-flight write settles', async () => {
+    // This ordering is what lets the caller clear the account's rows on logout
+    // without an append landing after the wipe -- which would leave a previous
+    // account's frames on a shared device, in rows nothing ever reads or
+    // truncates because their checkpoint is gone.
+    await writeBase()
+    const recorder = createCheckpointRecorder({ userId: USER, clientId: CLIENT, mgr: fakeMgr() })
+    recorder.record(frame('a'))
+    // Let the microtask flush fire (arming the IDB write) but do NOT settle it.
+    await Promise.resolve()
+
+    await recorder.dispose()
+
+    const read = await readCheckpoint(USER, CLIENT)
+    expect(read.status).toBe('ok')
+    if (read.status !== 'ok')
+      return
+    // Whatever the append did, it is DONE: no write can now land behind us.
+    expect(read.opLogFrames.length).toBeLessThanOrEqual(1)
+  })
+})
+
+// The point of the sharded checkpoint: a routine rewrite costs the DELTA, not
+// the account. The whole-state `toBinary` this replaces ran on the main thread
+// every 256 confirmed frames -- mid-drag -- and measured 7 ms at 400 nodes /
+// 600 tabs and 57 ms at 2400 / 4800 in this suite's environment.
+describe('createCheckpointRecorder incremental rewrites', () => {
+  it('rewrites ONLY the chunks its frames touched', async () => {
+    const mgr = fakeMgr()
+    putNode(mgr, 'untouched', 'original')
+    putNode(mgr, 'edited', 'original')
+    await writeBase(confirmed(mgr))
+
+    const recorder = createCheckpointRecorder({
+      userId: USER,
+      clientId: CLIENT,
+      mgr,
+      threshold: 1,
+      hydratedFrom: { frames: [], nextOrdinal: 0 },
+    })
+    putNode(mgr, 'edited', 'changed')
+    recorder.record(nodeFrame('b1', 'edited'))
+    await settle()
+
+    // The write ASKED for is the observation: a full rewrite would leave
+    // byte-identical rows behind, so the persisted result cannot tell the two
+    // apart -- only the request can.
+    const delta = lastDelta()
+    expect(delta.full).toBe(false)
+    expect(keysOf(delta.upserts)).toEqual(['node:edited'])
+    expect(delta.deletes).toEqual([])
+    // ...and the value on disk really did move.
+    expect((await persistedChunks()).get('node:untouched')).toBeDefined()
+    await recorder.dispose()
+  })
+
+  it('does not grow the write as the untouched account grows', async () => {
+    // The whole point: the cost of a routine checkpoint tracks the DELTA, not
+    // the account. 500 extra nodes must not appear in the upserts.
+    const mgr = fakeMgr()
+    for (let i = 0; i < 500; i++)
+      putNode(mgr, `bulk-${i}`, 'v1')
+    await writeBase(confirmed(mgr))
+
+    const recorder = createCheckpointRecorder({
+      userId: USER,
+      clientId: CLIENT,
+      mgr,
+      threshold: 1,
+      hydratedFrom: { frames: [], nextOrdinal: 0 },
+    })
+    putNode(mgr, 'bulk-3', 'v2')
+    recorder.record(nodeFrame('b1', 'bulk-3'))
+    await settle()
+
+    expect(lastDelta().upserts).toHaveLength(1)
+    await recorder.dispose()
+  })
+
+  it('tracks exactly the entities its frames name', async () => {
+    const mgr = fakeMgr()
+    const recorder = createCheckpointRecorder({ userId: USER, clientId: CLIENT, mgr, hydratedFrom: { frames: [], nextOrdinal: 0 } })
+
+    recorder.record(nodeFrame('b1', 'n1'))
+    recorder.record(nodeFrame('b2', 'n2'))
+    recorder.record(nodeFrame('b3', 'n1'))
+
+    expect([...recorder.dirtyKeys].sort()).toEqual(['node:n1', 'node:n2'])
+    expect(recorder.needsFullRewrite).toBe(false)
+    await recorder.dispose()
+  })
+
+  it('clears the dirty set only once the write lands', async () => {
+    const mgr = fakeMgr()
+    await writeBase(confirmed(mgr))
+    const recorder = createCheckpointRecorder({
+      userId: USER,
+      clientId: CLIENT,
+      mgr,
+      threshold: 1,
+      hydratedFrom: { frames: [], nextOrdinal: 0 },
+    })
+
+    putNode(mgr, 'n1', 'v1')
+    recorder.record(nodeFrame('b1', 'n1'))
+    expect(recorder.dirtyKeys.has('node:n1')).toBe(true)
+    await settle()
+    expect([...recorder.dirtyKeys]).toEqual([])
+    await recorder.dispose()
+  })
+
+  it('deletes the chunk of an entity that left the state', async () => {
+    const mgr = fakeMgr()
+    putNode(mgr, 'doomed', 'v1')
+    await writeBase(confirmed(mgr))
+    expect((await persistedChunks()).has('node:doomed')).toBe(true)
+
+    const recorder = createCheckpointRecorder({
+      userId: USER,
+      clientId: CLIENT,
+      mgr,
+      threshold: 1,
+      hydratedFrom: { frames: [], nextOrdinal: 0 },
+    })
+    delete confirmed(mgr).nodes.doomed
+    recorder.record(nodeFrame('b1', 'doomed'))
+    await settle()
+
+    expect(keysOf(lastDelta().deletes)).toEqual(['node:doomed'])
+    expect((await persistedChunks()).has('node:doomed')).toBe(false)
+    await recorder.dispose()
+  })
+
+  it('deletes the chunks the tombstone prune collected, even unnamed by any frame', async () => {
+    // The prune drops shells whose tombstoning op may have been recorded MANY
+    // checkpoints ago, so the dirty set alone cannot see them. Without the key
+    // snapshot bracketing compactTombstones, their chunks survive on disk and
+    // the next cold start resurrects every shell the prune just collected.
+    const mgr = fakeMgr()
+    confirmed(mgr).nodes.tombstoned = create(NodeRecordSchema, {
+      nodeId: 'tombstoned',
+      tombstoneAt: { physical: 2n, logical: 0n, clientId: 'c' },
+    })
+    putNode(mgr, 'alive', 'v1')
+    await writeBase(confirmed(mgr))
+    expect((await persistedChunks()).has('node:tombstoned')).toBe(true)
+
+    const recorder = createCheckpointRecorder({
+      userId: USER,
+      clientId: CLIENT,
+      mgr,
+      threshold: 1,
+      hydratedFrom: { frames: [], nextOrdinal: 0 },
+    })
+    // A frame about a COMPLETELY DIFFERENT entity triggers the rewrite. The
+    // watermark (physical 10) is past the tombstone (physical 2), so
+    // compactTombstones collects it inside the rewrite.
+    recorder.record(nodeFrame('b1', 'alive'))
+    await settle()
+
+    expect(keysOf(lastDelta().deletes)).toEqual(['node:tombstoned'])
+    const chunks = await persistedChunks()
+    expect(chunks.has('node:tombstoned')).toBe(false)
+    expect(chunks.has('node:alive')).toBe(true)
+    // The prune-derived key was WRITTEN, so it must be cleared with the rest.
+    // Left resident it would re-emit a delete for an already-deleted chunk on
+    // every later rewrite, and the set would grow for the session's lifetime.
+    expect([...recorder.dirtyKeys]).toEqual([])
+    await recorder.dispose()
+  })
+
+  it('keeps entities dirtied WHILE a write was in flight', async () => {
+    // The write's success handler clears only the keys it actually serialized.
+    // Clearing the whole set would strand an entity changed between the
+    // serialize and the IDB commit -- its chunk stale on disk, and nothing left
+    // to say so.
+    const mgr = fakeMgr()
+    await writeBase(confirmed(mgr))
+    const recorder = createCheckpointRecorder({
+      userId: USER,
+      clientId: CLIENT,
+      mgr,
+      threshold: 1,
+      hydratedFrom: { frames: [], nextOrdinal: 0 },
+    })
+
+    putNode(mgr, 'first', 'v1')
+    recorder.record(nodeFrame('b1', 'first'))
+    // The flush + rewrite are armed but their IDB write has not settled.
+    await Promise.resolve()
+    putNode(mgr, 'second', 'v1')
+    recorder.record(nodeFrame('b2', 'second'))
+    await settle()
+
+    expect(recorder.dirtyKeys.has('node:first')).toBe(false)
+    expect(recorder.dirtyKeys.has('node:second')).toBe(true)
+    await recorder.dispose()
+  })
+
+  it('starts with a FULL rewrite when nothing was hydrated', async () => {
+    // A cold start (or a wiped poison record) has no base to be incremental
+    // against, so the first rewrite must persist every entity.
+    const mgr = fakeMgr()
+    putNode(mgr, 'a', 'v1')
+    putNode(mgr, 'b', 'v1')
+    const recorder = createCheckpointRecorder({ userId: USER, clientId: CLIENT, mgr, threshold: 1 })
+    expect(recorder.needsFullRewrite).toBe(true)
+
+    recorder.record(nodeFrame('b1', 'a'))
+    await settle()
+
+    expect(lastDelta().full).toBe(true)
+    expect([...(await persistedChunks()).keys()].sort()).toEqual(['node:a', 'node:b'])
+    expect(recorder.needsFullRewrite).toBe(false)
+    await recorder.dispose()
+  })
+
+  it('seeds the dirty set from the frames hydration replayed', async () => {
+    // Those frames moved the state PAST the persisted chunks, so the entities
+    // they name are exactly the chunks that no longer match.
+    const recorder = createCheckpointRecorder({
+      userId: USER,
+      clientId: CLIENT,
+      mgr: fakeMgr(),
+      hydratedFrom: { frames: [nodeFrame('r1', 'replayed-a'), nodeFrame('r2', 'replayed-b')], nextOrdinal: 0 },
+    })
+    expect([...recorder.dirtyKeys].sort()).toEqual(['node:replayed-a', 'node:replayed-b'])
+    expect(recorder.needsFullRewrite).toBe(false)
+    await recorder.dispose()
+  })
+
+  it('falls back to a FULL rewrite for a structurally malformed frame', async () => {
+    // `framedEntityKeys` reads the frame directly, so a frame broken enough
+    // (here: a batch whose `ops` is not iterable) makes it THROW rather than
+    // return null. record() promises never to throw, and a frame it cannot
+    // describe must not leave the dirty set silently short.
+    const mgr = fakeMgr({ watermark: undefined })
+    const recorder = createCheckpointRecorder({ userId: USER, clientId: CLIENT, mgr, hydratedFrom: { frames: [], nextOrdinal: 0 } })
+
+    expect(() => recorder.record({ event: { case: 'batch', value: { batchId: 'b' } } } as never)).not.toThrow()
+
+    expect(recorder.needsFullRewrite).toBe(true)
+    await recorder.dispose()
+  })
+
+  it('falls back to a FULL rewrite for a frame shape it cannot describe', async () => {
+    // Under-reporting the dirty set is the one unrecoverable direction: a chunk
+    // stale on disk but absent from the set is never rewritten again.
+    const mgr = fakeMgr()
+    const recorder = createCheckpointRecorder({ userId: USER, clientId: CLIENT, mgr, hydratedFrom: { frames: [], nextOrdinal: 0 } })
+    expect(recorder.needsFullRewrite).toBe(false)
+
+    recorder.record(create(WatchUserEventSchema, { event: { case: 'presence', value: {} } } as never))
+
+    expect(recorder.needsFullRewrite).toBe(true)
+    await recorder.dispose()
+  })
+
+  it('re-bases with a FULL rewrite after a bootstrap reset', async () => {
+    // A bootstrap replaced confirmedState wholesale, so every chunk of the
+    // previous lineage is invalid -- leaving one behind would resurrect a
+    // record the fresh snapshot does not contain.
+    const mgr = fakeMgr()
+    putNode(mgr, 'from-old-lineage', 'v1')
+    await writeBase(confirmed(mgr))
+
+    const recorder = createCheckpointRecorder({ userId: USER, clientId: CLIENT, mgr, hydratedFrom: { frames: [], nextOrdinal: 0 } })
+    // The bootstrap replaces the state, then fires the reset observer.
+    ;(mgr.state as { confirmedState: UserCrdtState }).confirmedState
+      = create(UserCrdtStateSchema, { userId: USER, currentEpoch: 1n })
+    putNode(mgr, 'from-new-lineage', 'v1')
+    recorder.onCheckpointReset()
+    await settle()
+
+    expect(lastDelta().full).toBe(true)
+    expect([...(await persistedChunks()).keys()]).toEqual(['node:from-new-lineage'])
+    await recorder.dispose()
+  })
+})
+
+// A rewrite is best-effort: it early-returns while another write is in flight or
+// before a watermark exists, and its IDB write can resolve false. So a recorder
+// that has dropped a frame -- or whose lineage a bootstrap replaced -- must not
+// resume appending until a rewrite has actually LANDED, or the persisted log
+// mixes two lineages (or spans a hole) and its trailing batchEnd frames advance
+// the replayed cursor past ops the hub will never re-send.
+describe('createCheckpointRecorder write-side bounds', () => {
+  // A resume delta carries up to MaxResumeDeltaOps (5000) frames in one burst,
+  // ~20x the threshold, so the flush that receives it trips compaction on its
+  // own. Appending first writes bytes whose only reader is the truncate that
+  // lands microseconds later -- on the reconnect path #267 exists to make cheap.
+  it('skips the append when the same flush will trip compaction', async () => {
+    const mgr = fakeMgr()
+    await writeBase()
+    const recorder = createCheckpointRecorder({
+      userId: USER,
+      clientId: CLIENT,
+      mgr,
+      threshold: 2,
+      hydratedFrom: { frames: [], nextOrdinal: 0 },
+    })
+
+    recorder.record(frame('a'))
+    recorder.record(frame('b'))
+    await settle()
+
+    // The rewrite ran (it truncates, so the log is empty either way) -- what
+    // must NOT have happened is the segment write that preceded it.
+    const read = await readCheckpoint(USER, CLIENT)
+    expect(read.status).toBe('ok')
+    if (read.status !== 'ok')
+      return
+    expect(read.opLogFrames).toEqual([])
+    // The persisted result cannot distinguish the two paths -- the rewrite
+    // truncates either way -- so assert on the call that must not have been made.
+    expect(storeSpy.appends).toBe(0)
+    await recorder.dispose()
+  })
+
+  // Frames still reach disk when the flush is NOT the one that compacts, so the
+  // skip above cannot be mistaken for "appends stopped working".
+  it('still appends a flush that does not trip compaction', async () => {
+    const mgr = fakeMgr()
+    await writeBase()
+    const recorder = createCheckpointRecorder({
+      userId: USER,
+      clientId: CLIENT,
+      mgr,
+      threshold: 100,
+      hydratedFrom: { frames: [], nextOrdinal: 0 },
+    })
+
+    recorder.record(frame('a'))
+    await settle()
+
+    const read = await readCheckpoint(USER, CLIENT)
+    expect(read.status).toBe('ok')
+    if (read.status !== 'ok')
+      return
+    expect(read.opLogFrames).toHaveLength(1)
+    expect(storeSpy.appends).toBe(1)
+    await recorder.dispose()
+  })
+})
+
+describe('createCheckpointRecorder rebase gating', () => {
+  it('stops appending after a dropped frame until a rewrite lands', async () => {
+    // No watermark, so every rewriteCheckpoint attempt early-returns and the
+    // rebase can never land.
+    const mgr = fakeMgr({ watermark: undefined })
+    const recorder = createCheckpointRecorder({ userId: USER, clientId: CLIENT, mgr })
+    await writeBase()
+
+    recorder.record(frame('before'))
+    await settle()
+    const afterFirst = await readCheckpoint(USER, CLIENT)
+    if (afterFirst.status !== 'ok')
+      throw new Error('expected a readable checkpoint')
+    const baseline = afterFirst.opLogFrames.length
+
+    // A frame that cannot be serialized: the oneof value is not a valid message.
+    recorder.record({ event: { case: 'batch', value: { batchId: 1 } } } as never)
+    await settle()
+
+    recorder.record(frame('after-1'))
+    recorder.record(frame('after-2'))
+    await settle()
+
+    const read = await readCheckpoint(USER, CLIENT)
+    expect(read.status).toBe('ok')
+    if (read.status !== 'ok')
+      return
+    expect(read.opLogFrames).toHaveLength(baseline)
+  })
+
+  it('does not zero the frame counter until the truncate actually lands', () => {
+    // onCheckpointReset with no watermark cannot rewrite, so the rows it wanted
+    // to truncate are still on disk -- the counter must keep reporting them, or
+    // the next compaction attempt is pushed a full threshold away.
+    const mgr = fakeMgr({ watermark: undefined })
+    const recorder = createCheckpointRecorder({
+      userId: USER,
+      clientId: CLIENT,
+      mgr,
+      hydratedFrom: { frames: Array.from({ length: 9 }, (_, i) => frame(`f${i}`)), nextOrdinal: 0 },
+    })
+
+    recorder.onCheckpointReset()
+    expect(recorder.opLogCount).toBe(9)
+  })
+
+  it('drops frames already QUEUED when the lineage is invalidated', async () => {
+    // record() blocks new appends the moment needsRebase is set, but frames
+    // queued in the same turn are flushed one microtask later -- and appending
+    // them puts old-lineage rows on disk AFTER the rebase was decided.
+    const mgr = fakeMgr({ watermark: undefined })
+    await writeBase()
+    const recorder = createCheckpointRecorder({ userId: USER, clientId: CLIENT, mgr })
+
+    recorder.record(frame('queued-1'))
+    recorder.record(frame('queued-2'))
+    // Same synchronous turn: the microtask flush has not run yet.
+    recorder.onCheckpointReset()
+    await settle()
+
+    const read = await readCheckpoint(USER, CLIENT)
+    expect(read.status).toBe('ok')
+    if (read.status !== 'ok')
+      return
+    expect(read.opLogFrames).toEqual([])
+    await recorder.dispose()
+  })
+
+  it('keeps a frame recorded DURING a rebase write out of neither store', async () => {
+    // The rebase rewrite serializes its delta from confirmedState and THEN
+    // awaits IDB. A frame arriving in that window is blocked from the op-log
+    // (correctly -- the rows are stale), is not in the already-serialized
+    // bytes, and its write's success handler clears needsRebase/fullRewrite
+    // because `lineage` still matches. Unless the frame is dirty-marked, the
+    // entity is left stale on disk with nothing to rewrite it, while the next
+    // rewrite pins a watermark PAST its ops -- which the hub never re-ships.
+    const mgr = fakeMgr()
+    putNode(mgr, 'N', 'P0')
+    await writeBase(confirmed(mgr))
+    const recorder = createCheckpointRecorder({
+      userId: USER,
+      clientId: CLIENT,
+      mgr,
+      threshold: 1,
+      hydratedFrom: { frames: [], nextOrdinal: 0 },
+    })
+    const before = (await persistedChunks()).get('node:N')
+    expect(before).toBeDefined()
+
+    // Raises needsRebase and issues a rewrite that serializes P0 synchronously,
+    // then awaits IDB. Everything below runs while that write is in flight.
+    recorder.onCheckpointReset()
+    putNode(mgr, 'N', 'P1')
+    recorder.record(nodeFrame('during-rebase', 'N'))
+    await settle()
+
+    // Trip one more rewrite so the dirty set is drained to disk.
+    putNode(mgr, 'M', 'Q0')
+    recorder.record(nodeFrame('after', 'M'))
+    await settle()
+
+    expect(keysOf(lastDelta().upserts)).toContain('node:N')
+    expect((await persistedChunks()).get('node:N')).not.toBe(before)
+    await recorder.dispose()
+  })
+
+  it('does not let an in-flight write clear a rebase raised after it serialized', async () => {
+    // The write's blob describes the lineage as it was when it serialized. A
+    // bootstrap landing while it was in flight makes that blob stale, so
+    // clearing needsRebase on its success resumed appending onto a checkpoint
+    // of the WRONG lineage -- the precise failure the flag exists to prevent.
+    const mgr = fakeMgr()
+    await writeBase()
+    const recorder = createCheckpointRecorder({
+      userId: USER,
+      clientId: CLIENT,
+      mgr,
+      threshold: 1,
+      hydratedFrom: { frames: [], nextOrdinal: 0 },
+    })
+
+    recorder.record(frame('a'))
+    // Arm the flush + rewrite, then invalidate before the IDB write settles.
+    await Promise.resolve()
+    recorder.onCheckpointReset()
+    await settle()
+
+    // The rebase must still be pending, so the next rewrite is FULL.
+    expect(recorder.needsFullRewrite).toBe(true)
+    await recorder.dispose()
+  })
+})

--- a/frontend/src/lib/crdt/checkpointRecorder.ts
+++ b/frontend/src/lib/crdt/checkpointRecorder.ts
@@ -1,0 +1,554 @@
+import type { CheckpointDelta, ChunkRef, ChunkUpsert } from './checkpointStore'
+import type { PendingOpsManager } from './pendingOps'
+import type { UserCrdtState } from '~/generated/leapmux/v1/user_crdt_pb'
+import type { WatchUserEvent } from '~/generated/leapmux/v1/user_ops_pb'
+import { toBinary } from '@bufbuild/protobuf'
+import { WatchUserEventSchema } from '~/generated/leapmux/v1/user_ops_pb'
+import { createLogger } from '~/lib/logger'
+import {
+  entityKey,
+  framedEntityKeys,
+  fullCheckpointDelta,
+  keysRemovedSince,
+  parseEntityKey,
+  serializeEntity,
+  serializeHeader,
+  snapshotEntityKeys,
+} from './checkpointChunks'
+import { appendOpLogSegment, MAX_OPLOG_READ_FRAMES, writeCheckpointAndTruncateOpLog } from './checkpointStore'
+
+// ---------------------------------------------------------------------------
+// Checkpoint recorder: the client's half of the compaction loop
+//
+// Owns everything between "a confirmed frame was applied" and "the persisted
+// checkpoint + op-log reflect it": the serialize, the coalesced append, the
+// frame counter, the compaction threshold, and the checkpoint rewrite.
+//
+// It is a plain object, not a Solid primitive, so the policy is testable
+// without a reactive root — and, more to the point, so the counter and the
+// microtask that drives it live in ONE scope. They were previously spread
+// across three (a hook-scope record, a closure inside the manager installer,
+// and a free function), which had already produced two shipped bugs: a shared
+// generation counter that let a routine checkpoint flush cancel an unrelated
+// in-flight hydration, and one that invalidated its own hydration on a direct
+// user switch.
+//
+// THE REWRITE IS INCREMENTAL. It used to re-serialize the WHOLE
+// `confirmedState` on every threshold trip — synchronously, on the main thread,
+// every 256 confirmed frames, i.e. mid-drag: 3.4 ms at 400 nodes / 600 tabs and
+// 29.6 ms at 2400 / 4800, to persist ops that touched one or two entities. So
+// the recorder now tracks WHICH entities each confirmed frame touched and
+// rewrites only those chunks (see checkpointChunks.ts for the split). The cost
+// of a routine checkpoint is the delta plus an O(1) header, not the account.
+// ---------------------------------------------------------------------------
+
+const log = createLogger('checkpointRecorder')
+
+/**
+ * Frames appended since the last checkpoint before a rewrite is triggered.
+ * Bounds the cold-reload replay, mirroring Manager.maybeCompact on the hub.
+ */
+export const CHECKPOINT_OP_LOG_THRESHOLD = 256
+
+export interface CheckpointRecorderOptions {
+  userId: string
+  /** Per-tab CRDT client id; the checkpoint and op-log are scoped to it. */
+  clientId: string
+  mgr: PendingOpsManager
+  /**
+   * The persisted checkpoint this recorder inherits, when hydration replayed
+   * one. ABSENT means the store holds nothing usable for this owner (a cold
+   * start, or a wipe after a corrupt record), so the first rewrite must be FULL.
+   */
+  hydratedFrom?: {
+    /**
+     * The op-log frames hydrate() replayed on top of the persisted chunks.
+     *
+     * They serve two purposes. (1) They are already ON DISK -- only a
+     * checkpoint rewrite truncates the log -- so seeding the frame counter with
+     * them is what makes the threshold trip and drain a log grown by a run of
+     * short delta-resumed sessions that never bootstrap. (2) They are exactly
+     * what moved the state past the persisted chunks, so the entities they
+     * touched are the recorder's initial DIRTY SET.
+     */
+    frames: readonly WatchUserEvent[]
+    /**
+     * The ordinal the next appended segment must carry, from the store's read.
+     * Seeding it is what keeps the persisted log's ordinal sequence contiguous
+     * across a reload -- otherwise the first post-hydrate append would restart
+     * at 0 behind segments already numbered 0..N-1, and the next cold start
+     * would read that as a hole and discard a log that was in fact intact.
+     */
+    nextOrdinal: number
+  }
+  /** Test seam; defaults to CHECKPOINT_OP_LOG_THRESHOLD. */
+  threshold?: number
+}
+
+export interface CheckpointRecorder {
+  /** Persist one confirmed frame. Best-effort; never throws. */
+  record: (frame: WatchUserEvent) => void
+  /**
+   * A bootstrap replaced confirmedState wholesale, so the snapshot IS a perfect
+   * checkpoint base and every accumulated frame describes discarded state.
+   * Re-bases immediately, with a FULL rewrite — the previous lineage's chunks
+   * are all invalid.
+   */
+  onCheckpointReset: () => void
+  /** Rewrite the checkpoint now (used after a truncated or oversized replay). */
+  rewriteNow: () => void
+  /**
+   * Stop recording and resolve once any in-flight IDB write has settled.
+   *
+   * Awaiting matters: the caller clears this account's rows on logout, and both
+   * that clear and a queued append are unawaited IDB work against the same
+   * cached connection. Without ordering them, an append armed just before the
+   * logout could land AFTER the wipe and leave orphaned frames of a previous
+   * account on a shared device — rows nothing would ever read or truncate,
+   * since their checkpoint is gone.
+   */
+  dispose: () => Promise<void>
+  /** Visible for testing: frames counted since the last successful rewrite. */
+  readonly opLogCount: number
+  /** Visible for testing: entity keys awaiting a chunk rewrite. */
+  readonly dirtyKeys: ReadonlySet<string>
+  /** Visible for testing: whether the next rewrite re-serializes everything. */
+  readonly needsFullRewrite: boolean
+}
+
+export function createCheckpointRecorder(opts: CheckpointRecorderOptions): CheckpointRecorder {
+  const { userId, clientId, mgr } = opts
+  const threshold = opts.threshold ?? CHECKPOINT_OP_LOG_THRESHOLD
+
+  const pendingFrames: Uint8Array[] = []
+  let appendScheduled = false
+  let disposed = false
+  let opLogCount = opts.hydratedFrom?.frames.length ?? 0
+  /**
+   * Ordinal for the next op-log segment. Advanced per ATTEMPTED flush, never per
+   * successful one: numbering on success would give the next segment the number
+   * a failed append would have used, sealing the gap that is the only evidence
+   * the append was lost. Reset to 0 exactly where `opLogCount` is -- when a
+   * checkpoint write RESOLVES ok, which is when the log on disk is actually
+   * empty.
+   */
+  let nextOrdinal = opts.hydratedFrom?.nextOrdinal ?? 0
+  /**
+   * Entity keys (`kind:id`, the vocabulary checkpointChunks speaks) whose
+   * persisted chunk no longer matches confirmedState. A rewrite serializes
+   * exactly these — or deletes their chunk, when the entity is gone.
+   */
+  const dirty = new Set<string>()
+  /**
+   * True while the persisted chunks cannot be trusted as a base, so the next
+   * rewrite must re-serialize EVERY entity and drop whatever else is on disk.
+   *
+   * It starts true unless hydration handed over a checkpoint: with nothing
+   * persisted (or a wiped poison record) there is no base to be incremental
+   * against. It is raised again by `invalidateLineage`.
+   */
+  let fullRewrite = opts.hydratedFrom === undefined
+  /**
+   * Frame count at which the next compaction is attempted. Pushed out by a
+   * whole threshold whenever a rewrite is skipped or fails, so a store that
+   * CANNOT compact (quota exhausted, private browsing) stops re-serializing on
+   * every subsequent flush. Without it the counter stays above the threshold
+   * forever and each flush re-runs a serialization that is already known to
+   * fail.
+   */
+  let nextCompactAt = threshold
+  /**
+   * True from the moment a rewrite starts until its IDB write settles. The
+   * counter is only cleared on success, so releasing the trigger earlier let
+   * every flush in that window schedule ANOTHER serialization — several
+   * back-to-back per threshold trip during a drag.
+   */
+  let writing = false
+  /**
+   * True while the persisted log is known NOT to describe the current lineage,
+   * and no rewrite has yet succeeded in re-basing it. Blocks appends outright.
+   *
+   * Two producers, one hazard. (1) A frame that fails to serialize is dropped,
+   * so everything after it would sit above a hole. (2) A bootstrap replaced
+   * confirmedState wholesale, so the surviving log prefix describes the
+   * DISCARDED lineage. In both cases appending the next frame onto the old rows
+   * builds a log whose replay is a mix of two states, and whose trailing
+   * `batchEnd` frames advance the replayed cursor past ops the hub -- which
+   * ships only what is strictly after the cursor -- will never re-send.
+   *
+   * `rewriteCheckpoint` is best-effort: it early-returns while another write is
+   * in flight or before a watermark exists, and its IDB write can resolve false
+   * (quota, private browsing). So "we asked for a rebase" is not "the log is
+   * clean"; only a write that RESOLVES ok clears this. Until then, dropping
+   * frames is the safe direction -- the persisted pair stays older but
+   * self-consistent, so the next cold start simply resumes from further back and
+   * the hub fills the gap. Appending would instead produce a cursor that lies.
+   */
+  let needsRebase = false
+  /**
+   * Bumped every time the persisted lineage is invalidated. A rewrite captures
+   * it before serializing, so a write that RESOLVES after an invalidation
+   * cannot clear the flags that invalidation raised -- its blob describes the
+   * superseded lineage. Without it, a bootstrap landing while a rewrite was in
+   * flight had its `needsRebase` cleared by that write's success handler, and
+   * the recorder resumed appending onto a checkpoint of the wrong lineage: the
+   * precise failure the flag exists to prevent.
+   */
+  let lineage = 0
+  /**
+   * Every unsettled IDB write, so dispose() can order the caller's logout wipe
+   * after ALL of them. A single slot was not enough: flushAppend assigns the
+   * append and may then start a checkpoint rewrite, and the next flush would
+   * overwrite the slot and orphan that rewrite -- whose `put` could then land
+   * AFTER the wipe, leaving a serialized UserCrdtState for a logged-out
+   * account on a shared device, with no op-log and nothing that would ever
+   * truncate it.
+   */
+  let inFlight: Promise<unknown> = Promise.resolve()
+  function track(write: Promise<unknown>): void {
+    inFlight = Promise.allSettled([inFlight, write])
+  }
+
+  /**
+   * The persisted pair no longer describes the live lineage: block appends,
+   * force the next rewrite to be FULL, and supersede any write already in
+   * flight.
+   *
+   * All three together, always. A dropped frame technically invalidates only
+   * the log, but its entity keys may be exactly what could not be read off the
+   * frame -- so a full rewrite is the honest recovery, and tying the three
+   * makes "an invalidated lineage can never be re-based incrementally" true by
+   * construction rather than by case analysis.
+   */
+  function invalidateLineage(): void {
+    needsRebase = true
+    fullRewrite = true
+    lineage++
+  }
+
+  /** Mark every entity `frame` touched, or the whole state if its shape is unknown. */
+  function markDirty(frame: WatchUserEvent): void {
+    let keys: Set<string> | null
+    try {
+      keys = framedEntityKeys(frame)
+    }
+    catch {
+      // A structurally malformed frame -- an `ops` field that is not iterable,
+      // a oneof value that is not a message. `framedEntityKeys` reads it
+      // directly, and record() promises never to throw, so a frame this broken
+      // is treated exactly like one whose shape is not understood.
+      keys = null
+    }
+    if (keys === null) {
+      // Under-reporting is the one unrecoverable direction: an entity whose
+      // chunk is stale on disk but absent from the dirty set is never
+      // rewritten, so the next cold start resurrects the pre-change record
+      // silently. A frame shape this build does not understand therefore costs
+      // one full rewrite rather than a guess.
+      invalidateLineage()
+      return
+    }
+    for (const key of keys)
+      dirty.add(key)
+  }
+
+  /**
+   * The chunk writes and deletes that bring the persisted shards up to `state`,
+   * or null when a dirty key cannot be resolved to a chunk — the caller then
+   * falls back to a full rewrite, since an unresolvable key is exactly "one of
+   * the shards changed and this pass cannot say which".
+   */
+  function incrementalDelta(state: UserCrdtState, keys: Iterable<string>): CheckpointDelta | null {
+    const upserts: ChunkUpsert[] = []
+    const deletes: ChunkRef[] = []
+    for (const key of keys) {
+      const ref = parseEntityKey(key)
+      if (!ref)
+        return null
+      const bytes = serializeEntity(state, ref)
+      // Absent from the state: removed by an op or collected by the tombstone
+      // prune, so its chunk has to go with it.
+      if (bytes === undefined)
+        deletes.push(ref)
+      else
+        upserts.push({ ...ref, bytes })
+    }
+    return { headerBytes: serializeHeader(state), upserts, deletes, full: false }
+  }
+
+  /** Returns whether a checkpoint write was actually ISSUED. */
+  function rewriteCheckpoint(): boolean {
+    if (disposed || writing)
+      return false
+    const wm = mgr.state.resumeWatermark
+    if (!wm) {
+      // Nothing to pin the checkpoint at yet. Back off rather than re-checking
+      // on every single flush.
+      nextCompactAt = opLogCount + threshold
+      return false
+    }
+    // Captured BEFORE the serialize: anything that invalidates the lineage from
+    // here on -- including during `compactTombstones` -- must supersede the
+    // write this call is about to issue, not be cleared by it.
+    const writtenLineage = lineage
+    let delta: CheckpointDelta
+    try {
+      // Guarded for the same reason the frame serializer is: this runs
+      // synchronously inside the manager's bootstrap reset observer, so a throw
+      // would propagate out through bootstrap() -> applyMaterialized() -> the
+      // WebSocket message handler, skipping setBootstrapped and every other
+      // post-bootstrap step while the socket stays healthy and reports nothing.
+      // Best-effort is what this function promises; the guard is what makes it
+      // true.
+      //
+      // Prune first, so the chunks about to be written describe the SMALLER
+      // state. This is the client's compaction step and it is paired with the
+      // checkpoint rewrite exactly as the hub pairs PruneTombstonesAtOrBelow
+      // with its state_payload write -- pruning without persisting would be
+      // undone by the next cold reload, which replays from the persisted state.
+      //
+      // The prune drops tombstone shells whose tombstoning op may have been
+      // recorded many checkpoints ago, so the dirty set cannot see them. The
+      // key snapshot bracketing it is what turns those removals into chunk
+      // DELETES; without it their chunks would survive on disk and the next
+      // cold start would resurrect every shell this prune just collected.
+      const before = fullRewrite ? null : snapshotEntityKeys(mgr.state.confirmedState)
+      mgr.compactTombstones()
+      const state = mgr.state.confirmedState
+      if (before) {
+        for (const ref of keysRemovedSince(before, state))
+          dirty.add(entityKey(ref.kind, ref.entityId))
+      }
+      const incremental = fullRewrite ? null : incrementalDelta(state, dirty)
+      if (incremental) {
+        delta = incremental
+      }
+      else {
+        // Either the lineage was already invalidated, or a dirty key could not
+        // be resolved -- both mean the persisted shards cannot be brought up to
+        // date one entity at a time.
+        if (!fullRewrite) {
+          log.warn('a dirty entity key could not be resolved; rewriting the whole checkpoint')
+          fullRewrite = true
+          dirty.clear()
+        }
+        delta = fullCheckpointDelta(state)
+      }
+    }
+    catch (err) {
+      log.warn('failed to serialize confirmed state for checkpoint; skipping', { err })
+      nextCompactAt = opLogCount + threshold
+      return false
+    }
+    // Captured AFTER the delta is built, so it covers the keys the tombstone
+    // diff just added. Taken before the serialize it left them resident for the
+    // rest of the session, re-emitting a delete for an already-deleted chunk on
+    // every subsequent rewrite and growing the set without bound.
+    const writtenKeys = [...dirty]
+    writing = true
+    track(writeCheckpointAndTruncateOpLog(userId, clientId, delta, wm, mgr.state.currentEpoch)
+      .then((ok) => {
+        writing = false
+        if (!ok) {
+          // Nothing landed: the dirty set and the full-rewrite flag must stay
+          // exactly as they were, or the entities this attempt described would
+          // never be written again.
+          nextCompactAt = opLogCount + threshold
+          return
+        }
+        // The truncate landed, so the on-disk log is empty whichever lineage
+        // the chunks describe. This is the ONLY place that becomes true, which
+        // is why the counter is not zeroed anywhere else.
+        opLogCount = 0
+        nextOrdinal = 0
+        nextCompactAt = threshold
+        if (lineage !== writtenLineage) {
+          // Invalidated after this write serialized. Its chunks describe the
+          // superseded lineage, so leave needsRebase and fullRewrite standing
+          // and let the retry re-base with a FULL rewrite.
+          return
+        }
+        needsRebase = false
+        fullRewrite = false
+        // Only the keys this write actually serialized. Frames recorded WHILE
+        // it was in flight dirtied entities the chunks on disk do not describe,
+        // so clearing the whole set would strand them.
+        for (const key of writtenKeys)
+          dirty.delete(key)
+      })
+      .catch(() => {
+        writing = false
+        nextCompactAt = opLogCount + threshold
+      }))
+    return true
+  }
+
+  function flushAppend(): void {
+    appendScheduled = false
+    if (disposed)
+      return
+    if (needsRebase) {
+      // The lineage was invalidated after these frames were queued but before
+      // the microtask ran. Appending them now would put frames of the old
+      // lineage on disk AFTER the rebase was decided -- exactly what
+      // `needsRebase` blocks in `record`, reached one turn later.
+      pendingFrames.length = 0
+      return
+    }
+    const batch = pendingFrames.splice(0)
+    if (batch.length === 0)
+      return
+    // When THIS flush alone trips compaction, skip the append entirely: the
+    // rewrite about to run serializes confirmedState -- which already includes
+    // every one of these frames' effects, since `record` runs after apply -- and
+    // truncates the log in the same transaction. Appending first would write
+    // bytes whose only reader is a truncate microseconds later.
+    //
+    // That is not a rare corner. A resume delta carries up to MaxResumeDeltaOps
+    // (5000) frames in one burst, ~20x the 256-frame threshold, so the reconnect
+    // path -- the one #267 exists to make cheap -- paid ~11 ms of synchronous
+    // main-thread `toBinary` plus a ~191 KiB IDB write, both immediately
+    // discarded.
+    //
+    // Safe when the rewrite's write LATER fails: nothing truncates, so the
+    // persisted pair stays at its previous, self-consistent point, and the next
+    // cold start simply resumes from further back with the hub filling the gap.
+    // That is the same trailing-staleness the ordinal contract already permits
+    // -- unlike a HOLE, which is what appending-then-failing would risk.
+    if (opLogCount + batch.length >= nextCompactAt && rewriteCheckpoint())
+      return
+    // One flush = one op-log SEGMENT row (mirroring the backend's
+    // one-row-per-batch), so a burst of N frames is 1 IDB transaction + 1 row,
+    // not N.
+    //
+    // Bounded at WRITE time, not just at read time. `MAX_OPLOG_READ_FRAMES` is
+    // enforced by the reader, so a log past it is guaranteed to be truncated on
+    // the next cold start -- every row beyond the ceiling is storage written to
+    // be discarded. The regime that reaches it is real: a profile at quota where
+    // small `add`s keep succeeding while the multi-megabyte checkpoint `put`
+    // keeps failing, so the back-off only pushes `nextCompactAt` out and the log
+    // grows a threshold's worth per failed retry, forever.
+    if (opLogCount >= MAX_OPLOG_READ_FRAMES) {
+      log.warn('op-log is past the read ceiling and the checkpoint will not write; dropping appends until it does', { opLogCount })
+      rewriteCheckpoint()
+      return
+    }
+    track(appendOpLogSegment(userId, clientId, batch, nextOrdinal++))
+    opLogCount += batch.length
+    if (opLogCount >= nextCompactAt)
+      rewriteCheckpoint()
+  }
+
+  if (opts.hydratedFrom) {
+    // The persisted chunks are the state hydrate() started from; these frames
+    // are everything that moved it since, so their entities are the chunks that
+    // no longer match. A frame whose shape is not understood invalidates the
+    // lineage here exactly as it would live, forcing the first rewrite to be
+    // full.
+    for (const frame of opts.hydratedFrom.frames)
+      markDirty(frame)
+  }
+
+  return {
+    record(frame: WatchUserEvent): void {
+      if (disposed)
+        return
+      // Dirty-mark FIRST, and UNCONDITIONALLY -- before the `needsRebase` gate,
+      // not after it. The frame's effect is already in confirmedState, so its
+      // entities' chunks are stale regardless of whether the frame itself can
+      // be appended to the op-log, and regardless of whether a rebase is
+      // pending.
+      //
+      // Returning early without marking lost the frame outright. A rebase
+      // rewrite serializes its delta from confirmedState, THEN awaits IDB; a
+      // frame arriving in that window was neither in the serialized bytes nor
+      // in `dirty` nor in the op-log (blocked below), yet the write's success
+      // handler cleared `needsRebase`/`fullRewrite` because its `lineage` still
+      // matched. The entity then sat stale on disk with nothing left to rewrite
+      // it, while the next rewrite pinned a watermark PAST the lost ops -- which
+      // the hub never re-ships, since it sends only what is strictly after the
+      // cursor. A tile split or tab move made in the milliseconds after a
+      // reconnect FALLBACK vanished on the next page load and never came back.
+      //
+      // Marking here is sufficient because the write's success handler deletes
+      // only `writtenKeys` -- the set captured BEFORE it serialized -- so keys
+      // dirtied while it was in flight survive and are picked up by the next
+      // incremental rewrite. That mechanism already existed; this gate was
+      // routing around it.
+      markDirty(frame)
+      if (needsRebase) {
+        // Either the log was already known stale, or `markDirty` could not
+        // describe this frame and just invalidated the lineage. Same exit
+        // either way: do NOT append onto stale rows, and keep retrying the
+        // rebase (it may have been blocked by an in-flight write or a missing
+        // watermark). A checkpoint written at the CURRENT confirmedState
+        // already includes this frame's effect.
+        pendingFrames.length = 0
+        rewriteCheckpoint()
+        return
+      }
+      // Serialize synchronously so the persisted bytes are a stable snapshot of
+      // the frame as applied. A throw here would propagate back through
+      // record() into the consume* entry points and interrupt their post-record
+      // work (consumeBatchCommitted splices its pending batch AFTER record, so a
+      // throw would strand it), hence the guard.
+      let bytes: Uint8Array
+      try {
+        bytes = toBinary(WatchUserEventSchema, frame)
+      }
+      catch (err) {
+        // Dropping the frame and carrying on would leave the persisted log
+        // holding frames from BOTH sides of the gap, and the post-gap
+        // `batchEnd` frames would advance the replayed cursor past the ops that
+        // went missing -- which the hub never re-ships, because it sends only
+        // what is strictly after the cursor. Stop appending and re-base
+        // instead: a checkpoint written at the CURRENT confirmedState already
+        // includes this frame's effect, so it is the self-healing exit.
+        log.warn('failed to serialize confirmed frame for op-log; re-basing the checkpoint', { err })
+        pendingFrames.length = 0
+        invalidateLineage()
+        rewriteCheckpoint()
+        return
+      }
+      pendingFrames.push(bytes)
+      if (!appendScheduled) {
+        appendScheduled = true
+        queueMicrotask(flushAppend)
+      }
+    },
+    onCheckpointReset(): void {
+      if (disposed)
+        return
+      // Do NOT zero opLogCount here. The rows are still on disk until the
+      // truncating write resolves ok, and the counter is the only trigger for
+      // the next compaction attempt -- zeroing it up front hid N real rows and
+      // pushed the retry a full threshold away, so a client whose writes keep
+      // failing grew a log far past its bound while reporting none. The write's
+      // own handler already applies the correct rule.
+      //
+      // The dirty set is not cleared either, for the same reason: it is
+      // subsumed by the full rewrite `invalidateLineage` forces, and clearing
+      // it would matter only if that rewrite failed -- exactly when the stale
+      // chunks it names are still on disk.
+      invalidateLineage()
+      rewriteCheckpoint()
+    },
+    rewriteNow(): void {
+      rewriteCheckpoint()
+    },
+    async dispose(): Promise<void> {
+      disposed = true
+      pendingFrames.length = 0
+      await inFlight.catch(() => {})
+    },
+    get opLogCount(): number {
+      return opLogCount
+    },
+    get dirtyKeys(): ReadonlySet<string> {
+      return dirty
+    },
+    get needsFullRewrite(): boolean {
+      return fullRewrite
+    },
+  }
+}

--- a/frontend/src/lib/crdt/checkpointStore.test.ts
+++ b/frontend/src/lib/crdt/checkpointStore.test.ts
@@ -1,0 +1,813 @@
+import type { CheckpointDelta, ChunkRef, ChunkUpsert } from './checkpointStore'
+import { IDBFactory, IDBKeyRange } from 'fake-indexeddb'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createOpLogAppender } from '~/test-support/opLog'
+import {
+  _resetCheckpointStoreForTest,
+  appendOpLogSegment,
+  CHECKPOINT_TTL_MS,
+  clearCheckpointAndOpLog,
+  clearOwnerCheckpointAndOpLog,
+  isCheckpointStoreAvailable,
+  MAX_OPLOG_READ_BYTES,
+  MAX_OPLOG_READ_FRAMES,
+  OWNER_LIVENESS_WINDOW_MS,
+  readCheckpoint,
+  sweepAbandonedCheckpoints,
+  touchOwner,
+  writeCheckpointAndTruncateOpLog,
+} from './checkpointStore'
+
+const opLog = createOpLogAppender()
+
+// A fresh IndexedDB universe per test, mirroring renderArtifactStore.test.ts.
+// The store caches its connection, so _resetCheckpointStoreForTest must run
+// alongside the factory swap or it would hold a handle into the old universe.
+beforeEach(() => {
+  vi.stubGlobal('indexedDB', new IDBFactory())
+  // fake-indexeddb provides IDBKeyRange alongside IDBFactory; jsdom has neither
+  // by default, so stub it for the store's index range queries.
+  vi.stubGlobal('IDBKeyRange', IDBKeyRange)
+  _resetCheckpointStoreForTest()
+  opLog.reset()
+})
+afterEach(() => {
+  _resetCheckpointStoreForTest()
+  vi.unstubAllGlobals()
+})
+
+// This module is a PURE BLOB STORE: `headerBytes`, a chunk's `kind` /
+// `entityId` / `bytes`, and an op-log frame are all opaque to it. So these
+// cases use plain text rather than proto, which keeps them about the store's
+// own contract -- the sharding itself is covered in checkpointChunks.test.ts
+// and the parse policy in hydrate.test.ts.
+const enc = new TextEncoder()
+const dec = new TextDecoder()
+
+function bytes(text: string): Uint8Array {
+  return enc.encode(text)
+}
+
+function text(b: Uint8Array): string {
+  return dec.decode(b)
+}
+
+/** A FULL delta carrying `header` plus one chunk per `kind:id -> body` entry. */
+function fullDelta(header: string, entities: Record<string, string> = {}): CheckpointDelta {
+  return { headerBytes: bytes(header), upserts: chunksOf(entities), deletes: [], full: true }
+}
+
+/** An INCREMENTAL delta: only the named chunks move. */
+function incrementalDelta(
+  header: string,
+  entities: Record<string, string> = {},
+  deletes: string[] = [],
+): CheckpointDelta {
+  return {
+    headerBytes: bytes(header),
+    upserts: chunksOf(entities),
+    deletes: deletes.map(refOf),
+    full: false,
+  }
+}
+
+function chunksOf(entities: Record<string, string>): ChunkUpsert[] {
+  return Object.entries(entities).map(([key, body]) => ({ ...refOf(key), bytes: bytes(body) }))
+}
+
+function refOf(key: string): ChunkRef {
+  const [kind, entityId] = key.split(':')
+  return { kind: kind!, entityId: entityId! }
+}
+
+/** Read and assert the owner has a checkpoint, returning the ok-shaped result. */
+async function readOk(userId: string, clientId: string) {
+  const read = await readCheckpoint(userId, clientId)
+  expect(read.status).toBe('ok')
+  if (read.status !== 'ok')
+    throw new Error('unreachable')
+  return read
+}
+
+/** An owner's chunks as a `kind:id -> body` record, order-independent. */
+async function chunkMap(userId: string, clientId: string): Promise<Record<string, string>> {
+  const read = await readOk(userId, clientId)
+  return Object.fromEntries(read.chunks.map(c => [`${c.kind}:${c.entityId}`, text(c.bytes)]))
+}
+
+/** Frame byte arrays, comparable with toEqual. */
+function asText(frames: Uint8Array[]): string[] {
+  return frames.map(text)
+}
+
+const WM = { physical: 5n, logical: 0n, clientId: 'c' }
+
+describe('checkpointStore', () => {
+  describe('isCheckpointStoreAvailable', () => {
+    it('returns true when indexedDB is defined', () => {
+      expect(isCheckpointStoreAvailable()).toBe(true)
+    })
+
+    it('returns false when indexedDB is undefined (SSR / jsdom without the stub)', () => {
+      vi.unstubAllGlobals()
+      expect(isCheckpointStoreAvailable()).toBe(false)
+    })
+  })
+
+  describe('readCheckpoint', () => {
+    it('reports a miss when nothing is persisted', async () => {
+      expect((await readCheckpoint('user-1', 'tab-1')).status).toBe('miss')
+    })
+
+    it('reports a miss when the store is unavailable', async () => {
+      vi.unstubAllGlobals()
+      expect((await readCheckpoint('user-1', 'tab-1')).status).toBe('miss')
+    })
+  })
+
+  describe('writeCheckpointAndTruncateOpLog + readCheckpoint round-trip', () => {
+    it('persists and reads back the header + watermark + epoch', async () => {
+      const ok = await writeCheckpointAndTruncateOpLog(
+        'user-1',
+        'tab-1',
+        fullDelta('header-v1'),
+        { physical: 100n, logical: 5n, clientId: 'c1' },
+        3n,
+      )
+      expect(ok).toBe(true)
+
+      const read = await readOk('user-1', 'tab-1')
+      // Structured-clone returns a fresh Uint8Array; compare bytes, not refs.
+      expect(text(read.checkpoint.headerBytes)).toBe('header-v1')
+      expect(read.checkpoint.watermark).toEqual({ physical: 100n, logical: 5n, clientId: 'c1' })
+      expect(read.checkpoint.currentEpoch).toBe(3n)
+      expect(read.chunks).toEqual([])
+      expect(read.opLogFrames).toEqual([])
+      expect(read.opLogTruncated).toBe(false)
+    })
+
+    it('persists and reads back every entity chunk', async () => {
+      await writeCheckpointAndTruncateOpLog(
+        'u',
+        'c',
+        fullDelta('header', { 'node:n1': 'N1', 'tab:t1': 'T1', 'ws:w1': 'W1' }),
+        WM,
+        1n,
+      )
+      expect(await chunkMap('u', 'c')).toEqual({ 'node:n1': 'N1', 'tab:t1': 'T1', 'ws:w1': 'W1' })
+    })
+
+    it('keeps checkpoints per-user isolated', async () => {
+      await writeCheckpointAndTruncateOpLog('user-a', 'tab-1', fullDelta('a'), { physical: 1n, logical: 0n, clientId: 'a' }, 1n)
+      await writeCheckpointAndTruncateOpLog('user-b', 'tab-1', fullDelta('b'), { physical: 2n, logical: 0n, clientId: 'b' }, 2n)
+
+      expect((await readOk('user-a', 'tab-1')).checkpoint.watermark.clientId).toBe('a')
+      expect((await readOk('user-b', 'tab-1')).checkpoint.watermark.clientId).toBe('b')
+      expect((await readCheckpoint('user-c', 'tab-1')).status).toBe('miss')
+    })
+  })
+
+  // The entire point of the redesign: a routine rewrite must move only the
+  // entities that changed, and must leave the rest of the account alone.
+  describe('an incremental delta', () => {
+    async function seedThreeEntities(): Promise<void> {
+      await writeCheckpointAndTruncateOpLog(
+        'u',
+        'c',
+        fullDelta('header@1', { 'node:n1': 'N1', 'node:n2': 'N2', 'tab:t1': 'T1' }),
+        WM,
+        1n,
+      )
+    }
+
+    it('rewrites only the named chunks and leaves the others untouched', async () => {
+      await seedThreeEntities()
+      await writeCheckpointAndTruncateOpLog('u', 'c', incrementalDelta('header@2', { 'node:n2': 'N2-updated' }), WM, 1n)
+
+      expect(await chunkMap('u', 'c')).toEqual({
+        'node:n1': 'N1',
+        'node:n2': 'N2-updated',
+        'tab:t1': 'T1',
+      })
+      expect(text((await readOk('u', 'c')).checkpoint.headerBytes)).toBe('header@2')
+    })
+
+    it('deletes the chunks it names', async () => {
+      await seedThreeEntities()
+      await writeCheckpointAndTruncateOpLog('u', 'c', incrementalDelta('header@2', {}, ['node:n1', 'tab:t1']), WM, 1n)
+
+      expect(await chunkMap('u', 'c')).toEqual({ 'node:n2': 'N2' })
+    })
+
+    it('tolerates a delete for a chunk that is already gone', async () => {
+      await seedThreeEntities()
+      const ok = await writeCheckpointAndTruncateOpLog('u', 'c', incrementalDelta('h', {}, ['node:nope']), WM, 1n)
+      expect(ok).toBe(true)
+      expect(Object.keys(await chunkMap('u', 'c'))).toHaveLength(3)
+    })
+
+    it('distinguishes the same entity id across kinds', async () => {
+      // The chunk key is (owner, KIND, entityId): the three record maps are
+      // keyed independently, so an id may repeat across them.
+      await writeCheckpointAndTruncateOpLog('u', 'c', fullDelta('h', { 'node:x': 'as-node', 'tab:x': 'as-tab' }), WM, 1n)
+      await writeCheckpointAndTruncateOpLog('u', 'c', incrementalDelta('h', {}, ['node:x']), WM, 1n)
+
+      expect(await chunkMap('u', 'c')).toEqual({ 'tab:x': 'as-tab' })
+    })
+  })
+
+  describe('a full delta', () => {
+    it('drops chunks the new state no longer has', async () => {
+      // A bootstrap replaced confirmedState wholesale, so every chunk of the
+      // previous lineage is invalid. Leaving one behind would resurrect a
+      // record the snapshot does not contain on the next cold start.
+      await writeCheckpointAndTruncateOpLog('u', 'c', fullDelta('h1', { 'node:old-a': 'A', 'node:old-b': 'B' }), WM, 1n)
+      await writeCheckpointAndTruncateOpLog('u', 'c', fullDelta('h2', { 'node:fresh': 'F' }), WM, 1n)
+
+      expect(await chunkMap('u', 'c')).toEqual({ 'node:fresh': 'F' })
+    })
+
+    it('keeps a chunk that the new state still has, with the NEW bytes', async () => {
+      // The delete walk and the puts share one transaction, and a cursor sees
+      // writes made in its own transaction -- so a put issued while the walk
+      // was still advancing would be deleted the moment the cursor reached it.
+      await writeCheckpointAndTruncateOpLog('u', 'c', fullDelta('h1', { 'node:keep': 'OLD', 'node:drop': 'D' }), WM, 1n)
+      await writeCheckpointAndTruncateOpLog('u', 'c', fullDelta('h2', { 'node:keep': 'NEW' }), WM, 1n)
+
+      expect(await chunkMap('u', 'c')).toEqual({ 'node:keep': 'NEW' })
+    })
+
+    it('does not disturb another owner\'s chunks', async () => {
+      await writeCheckpointAndTruncateOpLog('u', 'tab-1', fullDelta('h', { 'node:a': 'A' }), WM, 1n)
+      await writeCheckpointAndTruncateOpLog('u', 'tab-2', fullDelta('h', { 'node:b': 'B' }), WM, 1n)
+
+      await writeCheckpointAndTruncateOpLog('u', 'tab-1', fullDelta('h2', {}), WM, 1n)
+
+      expect(await chunkMap('u', 'tab-1')).toEqual({})
+      expect(await chunkMap('u', 'tab-2')).toEqual({ 'node:b': 'B' })
+    })
+  })
+
+  // The reason the rows are keyed by (user, client) rather than by user alone.
+  describe('per-tab isolation', () => {
+    it('gives each client of one user its own checkpoint', async () => {
+      await writeCheckpointAndTruncateOpLog('u', 'tab-1', fullDelta('h'), { physical: 10n, logical: 0n, clientId: 'tab-1' }, 1n)
+      await writeCheckpointAndTruncateOpLog('u', 'tab-2', fullDelta('h'), { physical: 20n, logical: 0n, clientId: 'tab-2' }, 1n)
+
+      expect((await readOk('u', 'tab-1')).checkpoint.watermark.physical).toBe(10n)
+      expect((await readOk('u', 'tab-2')).checkpoint.watermark.physical).toBe(20n)
+    })
+
+    it('does not let one tab truncate another tab\'s op-log', async () => {
+      // The permanent-data-loss case. A backgrounded tab whose confirmedState
+      // lags used to write its stale checkpoint and delete EVERY op-log row for
+      // the user, including the segments the foreground tab had appended for
+      // later frames. The next cold reload then replayed the stale base plus
+      // only the post-truncate frames, and the batch_end frames in that tail
+      // advanced the resume cursor straight past the hole -- which the hub never
+      // re-sends, because it ships only what is strictly after the cursor.
+      await writeCheckpointAndTruncateOpLog('u', 'tab-1', fullDelta('h'), WM, 1n)
+      await writeCheckpointAndTruncateOpLog('u', 'tab-2', fullDelta('h'), WM, 1n)
+
+      const foreground = [bytes('fg-1'), bytes('fg-2')]
+      await opLog.append('u', 'tab-2', foreground)
+      expect((await readOk('u', 'tab-2')).opLogFrames.length).toBe(2)
+
+      // The lagging tab compacts. Only its OWN (empty) log may be affected.
+      await writeCheckpointAndTruncateOpLog('u', 'tab-1', fullDelta('h'), WM, 1n)
+
+      expect(asText((await readOk('u', 'tab-2')).opLogFrames)).toEqual(['fg-1', 'fg-2'])
+    })
+
+    it('keeps each tab\'s op-log to itself on read', async () => {
+      await writeCheckpointAndTruncateOpLog('u', 'tab-1', fullDelta('h'), WM, 1n)
+      await writeCheckpointAndTruncateOpLog('u', 'tab-2', fullDelta('h'), WM, 1n)
+      await opLog.append('u', 'tab-1', [bytes('one')])
+      await opLog.append('u', 'tab-2', [bytes('two')])
+
+      expect(asText((await readOk('u', 'tab-1')).opLogFrames)).toEqual(['one'])
+      expect(asText((await readOk('u', 'tab-2')).opLogFrames)).toEqual(['two'])
+    })
+  })
+
+  describe('appendOpLogSegment', () => {
+    it('writes one segment and reads its frames back in apply order', async () => {
+      await writeCheckpointAndTruncateOpLog('u', 'c', fullDelta('h'), WM, 1n)
+      await opLog.append('u', 'c', [bytes('b1'), bytes('b2'), bytes('b3')])
+
+      expect(asText((await readOk('u', 'c')).opLogFrames)).toEqual(['b1', 'b2', 'b3'])
+    })
+
+    it('flattens multiple segments in append order on read', async () => {
+      // The generator assigns seq, so this also pins that a store-wide
+      // autoIncrement key still orders ONE owner's segments by append time --
+      // the index cursor yields equal-index-key records in primary-key order.
+      await writeCheckpointAndTruncateOpLog('u', 'c', fullDelta('h'), WM, 1n)
+      await opLog.append('u', 'c', [bytes('b1'), bytes('b2')])
+      await opLog.append('u', 'c', [bytes('b3')])
+
+      expect(asText((await readOk('u', 'c')).opLogFrames)).toEqual(['b1', 'b2', 'b3'])
+    })
+
+    it('interleaves segments from two owners without disturbing either order', async () => {
+      await writeCheckpointAndTruncateOpLog('u', 'tab-1', fullDelta('h'), WM, 1n)
+      await writeCheckpointAndTruncateOpLog('u', 'tab-2', fullDelta('h'), WM, 1n)
+
+      await opLog.append('u', 'tab-1', [bytes('a1')])
+      await opLog.append('u', 'tab-2', [bytes('b1')])
+      await opLog.append('u', 'tab-1', [bytes('a2')])
+      await opLog.append('u', 'tab-2', [bytes('b2')])
+
+      expect(asText((await readOk('u', 'tab-1')).opLogFrames)).toEqual(['a1', 'a2'])
+      expect(asText((await readOk('u', 'tab-2')).opLogFrames)).toEqual(['b1', 'b2'])
+    })
+
+    it('a single-frame segment round-trips (the cold-start first-frame case)', async () => {
+      await writeCheckpointAndTruncateOpLog('u', 'c', fullDelta('h'), WM, 1n)
+      await opLog.append('u', 'c', [bytes('solo')])
+      expect(asText((await readOk('u', 'c')).opLogFrames)).toEqual(['solo'])
+    })
+
+    it('an empty frame list is a no-op', async () => {
+      await writeCheckpointAndTruncateOpLog('u', 'c', fullDelta('h'), WM, 1n)
+      await opLog.append('u', 'c', [])
+      expect((await readOk('u', 'c')).opLogFrames).toEqual([])
+    })
+
+    it('is best-effort: drops silently when the store is unavailable', async () => {
+      vi.unstubAllGlobals()
+      await expect(appendOpLogSegment('u', 'c', [new Uint8Array([1, 2, 3])], 0)).resolves.toBeUndefined()
+    })
+  })
+
+  describe('writeCheckpointAndTruncateOpLog truncates the op-log', () => {
+    it('clears the op-log atomically when rewriting the checkpoint', async () => {
+      await writeCheckpointAndTruncateOpLog('u', 'c', fullDelta('h'), WM, 1n)
+      await opLog.append('u', 'c', [bytes('b1'), bytes('b2')])
+      expect((await readOk('u', 'c')).opLogFrames.length).toBe(2)
+
+      // Rewrite the checkpoint at a newer watermark — the op-log must clear.
+      await writeCheckpointAndTruncateOpLog('u', 'c', incrementalDelta('h2'), { physical: 99n, logical: 0n, clientId: 'c' }, 1n)
+      const read = await readOk('u', 'c')
+      expect(read.opLogFrames).toEqual([])
+      expect(read.checkpoint.watermark.physical).toBe(99n)
+    })
+  })
+
+  // The op-log is appended on the confirmed hot path (~120 frames/sec during a
+  // drag) and drained only by a checkpoint rewrite, which backs off whenever
+  // the write fails. So an unbounded read materializes an unbounded log into
+  // memory on the very cold start the feature exists to make cheap. The caps
+  // are enforced AT the cursor; `truncated` routes to the caller's rewrite,
+  // which is what actually drains the log.
+  describe('the op-log read caps', () => {
+    it('stops at MAX_OPLOG_READ_FRAMES and reports truncated', async () => {
+      await writeCheckpointAndTruncateOpLog('u', 'c', fullDelta('h'), WM, 1n)
+      await opLog.append('u', 'c', Array.from({ length: MAX_OPLOG_READ_FRAMES + 1 }, () => bytes('f')))
+
+      const read = await readOk('u', 'c')
+      expect(read.opLogFrames).toHaveLength(MAX_OPLOG_READ_FRAMES)
+      expect(read.opLogTruncated).toBe(true)
+    })
+
+    it('does not report truncated at exactly the frame cap', async () => {
+      // Boundary: the cap is a ceiling on frames RETURNED, so a log sitting
+      // exactly on it is complete and must not trigger a needless rewrite.
+      await writeCheckpointAndTruncateOpLog('u', 'c', fullDelta('h'), WM, 1n)
+      await opLog.append('u', 'c', Array.from({ length: MAX_OPLOG_READ_FRAMES }, () => bytes('f')))
+
+      const read = await readOk('u', 'c')
+      expect(read.opLogFrames).toHaveLength(MAX_OPLOG_READ_FRAMES)
+      expect(read.opLogTruncated).toBe(false)
+    })
+
+    it('stops at MAX_OPLOG_READ_BYTES even when far under the frame cap', async () => {
+      // A frame cap alone bounds nothing: 100 frames of 64 KiB each is 6 MiB.
+      const big = new Uint8Array(64 * 1024)
+      const perSegment = 8
+      const segments = Math.ceil(MAX_OPLOG_READ_BYTES / (big.byteLength * perSegment)) + 1
+      await writeCheckpointAndTruncateOpLog('u', 'c', fullDelta('h'), WM, 1n)
+      for (let i = 0; i < segments; i++)
+        await opLog.append('u', 'c', Array.from<Uint8Array>({ length: perSegment }).fill(big))
+
+      const read = await readOk('u', 'c')
+      expect(read.opLogTruncated).toBe(true)
+      expect(read.opLogFrames.length).toBeLessThan(MAX_OPLOG_READ_FRAMES)
+      const totalBytes = read.opLogFrames.reduce((sum, f) => sum + f.byteLength, 0)
+      expect(totalBytes).toBeLessThanOrEqual(MAX_OPLOG_READ_BYTES)
+    })
+
+    it('cuts mid-segment, so the result is still a strict PREFIX', async () => {
+      await writeCheckpointAndTruncateOpLog('u', 'c', fullDelta('h'), WM, 1n)
+      // One segment that alone exceeds the frame cap.
+      await opLog.append('u', 'c', Array.from({ length: MAX_OPLOG_READ_FRAMES + 10 }, (_, i) => bytes(`f${i}`)))
+
+      const read = await readOk('u', 'c')
+      expect(read.opLogFrames).toHaveLength(MAX_OPLOG_READ_FRAMES)
+      expect(text(read.opLogFrames[0]!)).toBe('f0')
+      expect(text(read.opLogFrames[MAX_OPLOG_READ_FRAMES - 1]!)).toBe(`f${MAX_OPLOG_READ_FRAMES - 1}`)
+    })
+  })
+
+  // A malformed segment must STOP the read, not be skipped.
+  //
+  // Skipping it returned frames from BOTH sides of the gap and still reported
+  // the read complete. hydrate replays them in order and the `batchEnd` frames
+  // among them advance the resume cursor, so the cursor would land PAST the ops
+  // in the hole -- which the hub never re-ships, because it sends only what is
+  // strictly after the cursor. Reporting a prefix instead routes to the
+  // caller's checkpoint rewrite, which drops the bad tail from disk.
+  describe('a malformed op-log segment', () => {
+    async function seedWithBadSegment(): Promise<void> {
+      await writeCheckpointAndTruncateOpLog('u', 'c', fullDelta('h'), WM, 1n)
+      await opLog.append('u', 'c', [bytes('before-1'), bytes('before-2')])
+      // A row whose framesBytes is not an array (a partial write, or a quota
+      // abort mid-row). Written directly so the store's own guards are bypassed.
+      const db = await openDbRaw()
+      await new Promise<void>((resolve) => {
+        const tx = db.transaction('opLog', 'readwrite')
+        tx.objectStore('opLog').add({ userId: 'u', clientId: 'c', ordinal: 1, framesBytes: undefined })
+        tx.oncomplete = () => resolve()
+      })
+      db.close()
+      await appendOpLogSegment('u', 'c', [bytes('after')], 2)
+    }
+
+    it('returns the PREFIX before it, never frames from past the gap', async () => {
+      await seedWithBadSegment()
+      expect(asText((await readOk('u', 'c')).opLogFrames)).toEqual(['before-1', 'before-2'])
+    })
+
+    it('reports the read as truncated so the caller rewrites the checkpoint', async () => {
+      await seedWithBadSegment()
+      expect((await readOk('u', 'c')).opLogTruncated).toBe(true)
+    })
+
+    // A segment that never landed at all -- the append's write failed and was
+    // swallowed, or two tabs sharing one clientId interleaved into one log.
+    // Nothing in the ROW is malformed here; the only evidence is the gap in the
+    // per-owner ordinal sequence, which is why `seq` (store-wide) cannot see it:
+    // another owner's rows legitimately consume seq values, so a gap there means
+    // nothing. Without the ordinal, `readOpLogFrames` returned frames from BOTH
+    // sides and the post-hole `batchEnd` frames advanced the resume cursor past
+    // the missing ops -- which the hub never re-ships, since it sends only what
+    // is strictly after the cursor.
+    it('stops at a MISSING segment, even though every row is well-formed', async () => {
+      await writeCheckpointAndTruncateOpLog('u', 'c', fullDelta('h'), WM, 1n)
+      await appendOpLogSegment('u', 'c', [bytes('kept-1')], 0)
+      await appendOpLogSegment('u', 'c', [bytes('kept-2')], 1)
+      // ordinal 2 never landed.
+      await appendOpLogSegment('u', 'c', [bytes('past-the-hole')], 3)
+
+      const read = await readOk('u', 'c')
+      expect(asText(read.opLogFrames)).toEqual(['kept-1', 'kept-2'])
+      expect(read.opLogTruncated).toBe(true)
+    })
+
+    it('reports the ordinal to continue from, so a reload does not restart at 0', async () => {
+      // Restarting the sequence behind segments already numbered 0..N-1 would
+      // make the NEXT cold start read a well-formed log as holed and discard it.
+      await writeCheckpointAndTruncateOpLog('u', 'c', fullDelta('h'), WM, 1n)
+      await appendOpLogSegment('u', 'c', [bytes('a')], 0)
+      await appendOpLogSegment('u', 'c', [bytes('b')], 1)
+
+      const read = await readOk('u', 'c')
+      expect(read.opLogNextOrdinal).toBe(2)
+      expect(read.opLogTruncated).toBe(false)
+    })
+
+    it('restarts the ordinal at 0 after a checkpoint write truncates the log', async () => {
+      await writeCheckpointAndTruncateOpLog('u', 'c', fullDelta('h'), WM, 1n)
+      await appendOpLogSegment('u', 'c', [bytes('a')], 0)
+      await writeCheckpointAndTruncateOpLog('u', 'c', fullDelta('h2'), WM, 1n)
+
+      const read = await readOk('u', 'c')
+      expect(read.opLogFrames).toEqual([])
+      expect(read.opLogNextOrdinal).toBe(0)
+    })
+
+    it('keeps the checkpoint itself usable', async () => {
+      // The op-log is a rebuildable tail OVER the checkpoint, so one bad segment
+      // must not cost the base -- discarding it would force the full-snapshot
+      // projection scan the whole feature exists to avoid.
+      await seedWithBadSegment()
+      const read = await readOk('u', 'c')
+      expect(text(read.checkpoint.headerBytes)).toBe('h')
+    })
+  })
+
+  describe('clearCheckpointAndOpLog', () => {
+    it('removes every client\'s rows for the named user, and only that user', async () => {
+      // Logout promises "forget this device's state for this account", so it
+      // must span the other tabs' rows too -- otherwise a second tab's
+      // checkpoint outlives the logout that was supposed to erase it.
+      await writeCheckpointAndTruncateOpLog('user-a', 'tab-1', fullDelta('h', { 'node:a1': 'A1' }), WM, 1n)
+      await writeCheckpointAndTruncateOpLog('user-a', 'tab-2', fullDelta('h', { 'node:a2': 'A2' }), WM, 1n)
+      await writeCheckpointAndTruncateOpLog('user-b', 'tab-1', fullDelta('h', { 'node:b1': 'B1' }), { physical: 3n, logical: 0n, clientId: 'b' }, 1n)
+      await opLog.append('user-a', 'tab-1', [bytes('b1')])
+      await opLog.append('user-a', 'tab-2', [bytes('b2')])
+      await opLog.append('user-b', 'tab-1', [bytes('b3')])
+
+      await clearCheckpointAndOpLog('user-a')
+
+      expect((await readCheckpoint('user-a', 'tab-1')).status).toBe('miss')
+      expect((await readCheckpoint('user-a', 'tab-2')).status).toBe('miss')
+      expect(await countChunkRows()).toBe(1)
+      const survivor = await readOk('user-b', 'tab-1')
+      expect(survivor.checkpoint.watermark.clientId).toBe('b')
+      expect(survivor.opLogFrames.length).toBe(1)
+      expect(await chunkMap('user-b', 'tab-1')).toEqual({ 'node:b1': 'B1' })
+    })
+  })
+
+  describe('clearOwnerCheckpointAndOpLog', () => {
+    it('removes one owner\'s metadata, chunks and op-log, and nothing else', async () => {
+      await writeCheckpointAndTruncateOpLog('u', 'tab-bad', fullDelta('h', { 'node:x': 'X', 'tab:y': 'Y' }), WM, 1n)
+      await writeCheckpointAndTruncateOpLog('u', 'tab-good', fullDelta('h', { 'node:z': 'Z' }), WM, 1n)
+      await opLog.append('u', 'tab-bad', [bytes('f')])
+      await opLog.append('u', 'tab-good', [bytes('g')])
+
+      await clearOwnerCheckpointAndOpLog('u', 'tab-bad')
+
+      expect((await readCheckpoint('u', 'tab-bad')).status).toBe('miss')
+      // Chunks must go with the metadata: an orphaned chunk is unreachable
+      // storage that the next full rewrite would have to delete anyway.
+      expect(await countChunkRows()).toBe(1)
+      expect(await chunkMap('u', 'tab-good')).toEqual({ 'node:z': 'Z' })
+      expect(asText((await readOk('u', 'tab-good')).opLogFrames)).toEqual(['g'])
+    })
+  })
+})
+
+// Nothing else ever reclaims an abandoned owner's rows. The client id lives in
+// sessionStorage, so it dies with the tab: every closed tab strands a
+// (userId, clientId) row holding a serialized UserCrdtState plus its op-log,
+// unreachable by any later session and deleted only by a logout many users
+// never perform. Left alone the origin's quota is eventually exhausted, writes
+// start failing, the checkpoint stops being refreshed, and every refresh falls
+// back to the full projection snapshot #267 exists to remove.
+describe('sweepAbandonedCheckpoints', () => {
+  /** No tab answers the roll-call: every row is a collection candidate. */
+
+  async function seedOwner(userId: string, clientId: string, at: number): Promise<void> {
+    await writeCheckpointAndTruncateOpLog(
+      userId,
+      clientId,
+      fullDelta('h', { [`node:${clientId}`]: 'N' }),
+      { physical: 1n, logical: 0n, clientId },
+      1n,
+      at,
+    )
+    await opLog.append(userId, clientId, [bytes(`f-${clientId}`)])
+  }
+
+  it('collects owners past the TTL, with their chunks and op-logs, and never this tab', async () => {
+    await seedOwner('u', 'live-tab', 1_000)
+    await seedOwner('u', 'dead-tab', 1_000)
+
+    // Far enough past the stamps that both rows are expired -- but `live-tab`
+    // is this tab, so it is exempt however stale its last write looks.
+    const collected = await sweepAbandonedCheckpoints('u', 'live-tab', {
+      now: 1_000 + CHECKPOINT_TTL_MS + 1,
+    })
+
+    expect(collected).toBe(1)
+    expect((await readCheckpoint('u', 'dead-tab')).status).toBe('miss')
+    const survivor = await readOk('u', 'live-tab')
+    // The op-log and the chunks went with the metadata row: a segment or a
+    // chunk orphaned from its base is unreplayable, and would just accumulate.
+    expect(survivor.opLogFrames.length).toBe(1)
+    expect(await countChunkRows()).toBe(1)
+  })
+
+  it('keeps a fresh owner inside the TTL', async () => {
+    await seedOwner('u', 'live-tab', 1_000)
+    await seedOwner('u', 'other-tab', 1_000)
+
+    const collected = await sweepAbandonedCheckpoints('u', 'live-tab', {
+      now: 1_000 + CHECKPOINT_TTL_MS - 1,
+    })
+    expect(collected).toBe(0)
+    expect((await readCheckpoint('u', 'other-tab')).status).toBe('ok')
+  })
+
+  it('caps retained owners oldest-first even when none has expired', async () => {
+    // The TTL alone does not bound a user who opens tabs faster than they age
+    // out, so the cap is a second, independent bound.
+    for (let i = 0; i < 6; i++)
+      await seedOwner('u', `tab-${i}`, 1_000 + i)
+
+    // maxOwners counts THIS tab too, so 3 means "me plus two others".
+    const collected = await sweepAbandonedCheckpoints('u', 'tab-5', {
+      // Far past the liveness window (so none reads as running) but still
+      // inside the TTL, which is what isolates the cap arm from the TTL arm.
+      now: 1_000 + CHECKPOINT_TTL_MS - 1,
+      maxOwners: 3,
+    })
+
+    expect(collected).toBe(3)
+    expect((await readCheckpoint('u', 'tab-5')).status).toBe('ok')
+    // The two youngest others survived; the three oldest went.
+    expect((await readCheckpoint('u', 'tab-0')).status).toBe('miss')
+    expect((await readCheckpoint('u', 'tab-4')).status).toBe('ok')
+  })
+
+  // ALTITUDE-9. The walk visits every row in the global writtenAt index and
+  // used to discard any row belonging to another user -- so an account signed
+  // out of without an explicit logout left rows NOTHING would ever reclaim.
+  // Applying the TTL to them is safe because CHECKPOINT_TTL_MS is comfortably
+  // longer than the hub's op-retention window: an expired checkpoint could not
+  // delta-resume even if its tab came back.
+  describe('other accounts\' rows', () => {
+    it('collects a foreign owner that is past the TTL', async () => {
+      await seedOwner('u', 'live-tab', 1_000)
+      await seedOwner('other-user', 'tab-x', 1_000)
+
+      const collected = await sweepAbandonedCheckpoints('u', 'live-tab', {
+        now: 1_000 + CHECKPOINT_TTL_MS + 1,
+      })
+
+      expect(collected).toBe(1)
+      expect((await readCheckpoint('other-user', 'tab-x')).status).toBe('miss')
+      expect(await countChunkRows()).toBe(1)
+    })
+
+    it('deletes the FOREIGN owner, not a same-clientId row of this user', async () => {
+      // The delete must be keyed off the victim's user id. Keyed off the
+      // sweeping user's, an expired foreign row would delete whatever this
+      // account happens to have under the same client id -- here, a live tab.
+      await seedOwner('u', 'shared-id', 1_000 + CHECKPOINT_TTL_MS)
+      await seedOwner('other-user', 'shared-id', 1_000)
+
+      await sweepAbandonedCheckpoints('u', 'my-tab', {
+        now: 1_000 + CHECKPOINT_TTL_MS + 1,
+      })
+
+      expect((await readCheckpoint('other-user', 'shared-id')).status).toBe('miss')
+      expect((await readCheckpoint('u', 'shared-id')).status).toBe('ok')
+    })
+
+    it('leaves a FRESH foreign owner alone', async () => {
+      await seedOwner('u', 'live-tab', 1_000)
+      await seedOwner('other-user', 'tab-x', 1_000)
+
+      const collected = await sweepAbandonedCheckpoints('u', 'live-tab', {
+        now: 1_000 + CHECKPOINT_TTL_MS - 1,
+      })
+
+      expect(collected).toBe(0)
+      expect((await readCheckpoint('other-user', 'tab-x')).status).toBe('ok')
+    })
+
+    it('never applies the per-user CAP across accounts', async () => {
+      // "This account has too many tabs" says nothing about how many rows
+      // another account may keep, so the cap arm stays scoped to `userId`.
+      for (let i = 0; i < 6; i++)
+        await seedOwner('other-user', `tab-${i}`, 1_000 + i)
+      await seedOwner('u', 'my-tab', 1_500)
+
+      const collected = await sweepAbandonedCheckpoints('u', 'my-tab', {
+        now: 2_000,
+        maxOwners: 2,
+      })
+
+      expect(collected).toBe(0)
+      expect((await readCheckpoint('other-user', 'tab-0')).status).toBe('ok')
+    })
+  })
+
+  // SWEEP-2. `writtenAt` moves only on a REWRITE -- once per 256 confirmed
+  // frames -- so a quiet but LIVE sibling tab looks arbitrarily stale. The cap
+  // arm used to delete its checkpoint and entire op-log out from under it, and
+  // that tab then kept appending under an owner key with no base.
+  describe('liveness', () => {
+    it('reserves a live sibling from the cap arm', async () => {
+      for (let i = 0; i < 6; i++)
+        await seedOwner('u', `tab-${i}`, 1_000 + i)
+
+      await touchOwner('u', 'tab-0', 1_000 + CHECKPOINT_TTL_MS - 2)
+      const collected = await sweepAbandonedCheckpoints('u', 'tab-5', {
+        // Far past the liveness window (so none reads as running) but still
+        // inside the TTL, which is what isolates the cap arm from the TTL arm.
+        now: 1_000 + CHECKPOINT_TTL_MS - 1,
+        maxOwners: 3,
+      })
+
+      // tab-0 is live, so it is neither collected nor free budget: the cap of
+      // 3 covers this tab, tab-0, and one more.
+      expect((await readCheckpoint('u', 'tab-0')).status).toBe('ok')
+      expect((await readCheckpoint('u', 'tab-4')).status).toBe('ok')
+      expect(collected).toBe(3)
+    })
+
+    it('reserves a recently-touched owner from the TTL arm too', async () => {
+      // A tab open far longer than the TTL without a checkpoint REWRITE is
+      // stale-looking and very much alive -- which is exactly why liveness now
+      // reads lastSeenAt (refreshed by touchOwner) rather than writtenAt.
+      const now = 1_000 + CHECKPOINT_TTL_MS + 1
+      await seedOwner('u', 'quiet-but-open', 1_000)
+      await seedOwner('u', 'really-dead', 1_000)
+      expect(await touchOwner('u', 'quiet-but-open', now - 1)).toBe(true)
+
+      const collected = await sweepAbandonedCheckpoints('u', 'my-tab', { now })
+
+      expect(collected).toBe(1)
+      expect((await readCheckpoint('u', 'quiet-but-open')).status).toBe('ok')
+      expect((await readCheckpoint('u', 'really-dead')).status).toBe('miss')
+    })
+
+    it('reserves a recently-touched FOREIGN owner as well', async () => {
+      // Liveness is origin-wide: a running tab signed into another account is
+      // still a running tab, and its rows are not ours to collect.
+      const now = 1_000 + CHECKPOINT_TTL_MS + 1
+      await seedOwner('other-user', 'their-live-tab', 1_000)
+      await touchOwner('other-user', 'their-live-tab', now - 1)
+
+      const collected = await sweepAbandonedCheckpoints('u', 'my-tab', { now })
+
+      expect(collected).toBe(0)
+      expect((await readCheckpoint('other-user', 'their-live-tab')).status).toBe('ok')
+    })
+
+    it('collects an owner that stopped being touched, and never this tab', async () => {
+      // Three missed touch intervals is the whole liveness signal; past that an
+      // owner is collectable. The sweeping tab is exempt regardless.
+      await seedOwner('u', 'my-tab', 1_000)
+      await seedOwner('u', 'went-away', 1_000)
+
+      const collected = await sweepAbandonedCheckpoints('u', 'my-tab', {
+        now: 1_000 + CHECKPOINT_TTL_MS + 1,
+      })
+
+      expect(collected).toBe(1)
+      expect((await readCheckpoint('u', 'my-tab')).status).toBe('ok')
+      expect((await readCheckpoint('u', 'went-away')).status).toBe('miss')
+    })
+
+    it('treats an owner inside the liveness window as running even when the TTL has passed', async () => {
+      await seedOwner('u', 'just-touched', 1_000)
+      const collected = await sweepAbandonedCheckpoints('u', 'my-tab', {
+        now: 1_000 + OWNER_LIVENESS_WINDOW_MS - 1,
+        ttlMs: 1,
+      })
+      expect(collected).toBe(0)
+      expect((await readCheckpoint('u', 'just-touched')).status).toBe('ok')
+    })
+  })
+
+  describe('touchOwner', () => {
+    it('moves lastSeenAt without disturbing the checkpoint payload', async () => {
+      await seedOwner('u', 'tab', 1_000)
+      const before = await readCheckpoint('u', 'tab')
+      expect(before.status).toBe('ok')
+
+      expect(await touchOwner('u', 'tab', 9_999)).toBe(true)
+
+      const after = await readCheckpoint('u', 'tab')
+      expect(after.status).toBe('ok')
+      if (before.status !== 'ok' || after.status !== 'ok')
+        return
+      expect(after.checkpoint.watermark).toEqual(before.checkpoint.watermark)
+      expect(after.checkpoint.currentEpoch).toBe(before.checkpoint.currentEpoch)
+      expect(after.checkpoint.headerBytes).toEqual(before.checkpoint.headerBytes)
+      expect(after.checkpoint.lastSeenAt).toBe(9_999)
+      expect(after.checkpoint.writtenAt).toBe(before.checkpoint.writtenAt)
+    })
+
+    it('is a no-op for an owner with no checkpoint, and does not create one', async () => {
+      expect(await touchOwner('u', 'never-wrote', 9_999)).toBe(false)
+      expect((await readCheckpoint('u', 'never-wrote')).status).toBe('miss')
+    })
+  })
+
+  it('is a no-op without a user id', async () => {
+    await seedOwner('u', 'tab', 1_000)
+    expect(await sweepAbandonedCheckpoints('', 'tab', { now: 2_000 })).toBe(0)
+    expect((await readCheckpoint('u', 'tab')).status).toBe('ok')
+  })
+})
+
+/** Open the raw IDB for direct row manipulation / counting in tests. */
+async function openDbRaw(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    // NO version argument: a versionless open attaches to whatever version
+    // exists, so this neither triggers a spurious version-change transaction
+    // against the connection the store holds nor has to be kept in step with
+    // DB_VERSION by hand.
+    const r = indexedDB.open('leapmux-crdt-state')
+    r.onsuccess = () => resolve(r.result)
+    r.onerror = () => reject(r.error)
+  })
+}
+
+/** Total chunk rows across every owner — the orphan check. */
+async function countChunkRows(): Promise<number> {
+  const db = await openDbRaw()
+  const count = await new Promise<number>((resolve, reject) => {
+    const req = db.transaction('checkpointChunks', 'readonly').objectStore('checkpointChunks').count()
+    req.onsuccess = () => resolve(req.result)
+    req.onerror = () => reject(req.error)
+  })
+  db.close()
+  return count
+}

--- a/frontend/src/lib/crdt/checkpointStore.ts
+++ b/frontend/src/lib/crdt/checkpointStore.ts
@@ -1,0 +1,923 @@
+import type { HlcShape } from './hlc'
+import type { IdbSchema } from '~/lib/idb'
+import {
+  createIdbConnection,
+  forEachCursor,
+  forEachCursorWhile,
+  isIndexedDbAvailable,
+  requestToPromise,
+  selectSweepVictims,
+  txToPromise,
+} from '~/lib/idb'
+import { createLogger } from '~/lib/logger'
+
+// ---------------------------------------------------------------------------
+// Persistent (IndexedDB) CRDT checkpoint + op-log store
+//
+// Delta-resume across a page refresh / app restart needs the materialized
+// `confirmedState` to survive the JS heap being discarded, plus the confirmed
+// frames applied since the checkpoint so the client can re-reach the tight
+// resume cursor `T_now`. This store persists both, mirroring the hub's
+// `user_state` (the checkpoint) + `user_op_batches` (the op log) pair.
+//
+// Three object stores in one DB:
+//   - `checkpoints` (one row per OWNER): the checkpoint's METADATA at
+//     checkpoint time T_c -- the serialized state HEADER (scalars only), the
+//     resume watermark pinned to T_c, and the epoch. On cold reload, hydrate()
+//     restores this plus the chunks below as the base the op-log replays onto.
+//   - `checkpointChunks` (one row per ENTITY of an owner): one serialized
+//     record each. The state is sharded rather than stored as one blob so a
+//     rewrite costs the DELTA, not the account: the old design re-ran
+//     `toBinary` over the whole UserCrdtState on the main thread every 256
+//     confirmed frames (3.4 ms at 400 nodes / 600 tabs, 29.6 ms at 2400 /
+//     4800), landing mid-drag, to persist a change to one or two entities.
+//   - `opLog` (one row per SEGMENT since the checkpoint): each row holds the
+//     batch of confirmed WatchUserEvent frames appended in one flush, in apply
+//     order. Coalescing a flush's N frames into one row (rather than N) cuts
+//     the per-burst IDB transaction + row count to 1, which matters on the
+//     confirmed-mutation hot path (a drag is ~120 frames/sec, half of them
+//     self-traffic) and on the truncate path.
+//
+// AN OWNER IS A (user, client) PAIR, NOT A USER.
+//
+// Keying by user alone made every tab of that user share one checkpoint and one
+// op-log, with no leader election and no lock. `writeCheckpointAndTruncateOpLog`
+// deletes the whole log, so a BACKGROUNDED tab -- whose confirmedState lags,
+// because throttled timers delay nothing about the frames it has yet to apply --
+// could write its stale state@T1 and delete the segments a foreground tab had
+// appended for frames after T1. The next cold reload then replays state@T1 plus
+// only the post-truncate frames, with the T1..T2 range gone, and the `batchEnd`
+// frames in that replayed tail advance the resume cursor straight past the
+// hole. The hub ships only what is strictly after the cursor, so the lost ops
+// are never re-sent: silent, permanent divergence. (The mirror direction is
+// worse in kind: `entityRemoved` is applied wholesale with no HLC compare, so a
+// stale one replayed over a newer checkpoint deletes a live record.)
+//
+// The client id is per-tab (sessionStorage) and SURVIVES a refresh, so scoping
+// per tab keeps the case #356 exists for -- reload the same tab, resume from
+// its own checkpoint -- while making cross-tab clobber UNLIKELY. Not
+// impossible: browsers COPY sessionStorage into a duplicated tab, so two live
+// tabs can hold the same id, and the only thing that separates them again is
+// clientIdentity.ts's asynchronous BroadcastChannel handshake, which re-mints
+// AFTER the fact and is unavailable in older Safari and some embedded webviews
+// -- where the duplicate keeps the incumbent's owner key for good.
+//
+// The cost is one checkpoint (header plus its chunks) per open tab. The
+// alternatives -- a Web Locks leader, or HLC-bounded truncation with a
+// monotonic compare-and-set checkpoint -- buy SHARED storage instead. That is
+// no longer a question of whether a cross-tab protocol is affordable (this
+// branch added one, and the sweep now consults it for liveness); it is that
+// neither survives the unguarded `entityRemoved` replay above.
+//
+// A genuinely NEW tab therefore has no checkpoint of its own, sends no resume
+// cursor, and cold-starts with a full snapshot -- which is the last common
+// connect still paying the projection-lock scan #267 exists to remove. The
+// clobber above is a WRITE hazard, so a new tab could safely SEED from a
+// sibling's checkpoint read-only and resume, writing only ever under its own
+// id. Tracked in https://github.com/leapmux/leapmux/issues/358, which also
+// records why #267's other two mitigations were rejected. Measure before
+// building it.
+//
+// The store is a PURE BLOB STORE: it returns raw `Uint8Array` and never
+// deserializes proto here -- a chunk's `kind` and `entityId` are opaque strings
+// to it, and checkpointChunks.ts owns what they mean. The corruption policy
+// lives in hydrate.ts, isolating the proto-coupling upstream so this module
+// stays proto-agnostic and the parse/replay path is unit-testable without IDB.
+//
+// Every operation is best-effort and no-throw: without indexedDB (jsdom, SSR,
+// private browsing) or when it fails (quota), reads miss and writes drop. A
+// miss always degrades to a full snapshot — the correct fallback. The open /
+// cache / upgrade / test-reset scaffold is shared with the app's other IDB
+// store via `~/lib/idb` (no `idb` dependency).
+// ---------------------------------------------------------------------------
+
+const log = createLogger('checkpointStore')
+
+const DB_NAME = 'leapmux-crdt-state'
+// A CONSTANT. Schema changes land by editing SCHEMA below, not by bumping this:
+// the scaffold checks every opened database against that declaration and
+// rebuilds any that does not match. See ~/lib/idb's header for why recreating
+// rather than migrating is the permanent policy -- these stores are a cache
+// over state the hub owns and re-syncs, so a rebuild costs one cold start.
+const DB_VERSION = 1
+const CHECKPOINT_STORE = 'checkpoints'
+const CHUNK_STORE = 'checkpointChunks'
+const OPLOG_STORE = 'opLog'
+/** Index over the owning (user, client) pair — the replay and truncate path. */
+const BY_OWNER_INDEX = 'byOwner'
+/** Index over the user alone — the logout wipe, which spans every client. */
+const BY_USER_INDEX = 'byUserId'
+/**
+ * Index over `lastSeenAt` — the abandoned-owner sweep.
+ *
+ * Indexed rather than read off the records because the sweep must NOT
+ * materialize what it is deciding about: a checkpoint row carries the state
+ * header, so walking the rows to read a timestamp would deserialize every
+ * abandoned tab's payload just to decide to delete it. An index key cursor
+ * yields (lastSeenAt, [userId, clientId]) and touches no value at all. That
+ * matters less than it did when the row held the WHOLE state, but the sweep is
+ * still the one caller with no reason to read a value at all.
+ */
+const BY_LAST_SEEN_INDEX = 'byLastSeenAt'
+
+/**
+ * Owners whose checkpoint has not been rewritten within this window are swept.
+ * Comfortably longer than the hub's op-retention window, so an expired
+ * checkpoint could not have delta-resumed anyway — which is what makes the TTL
+ * arm safe to apply to EVERY account's rows, not just the signed-in one's.
+ *
+ * A tab that is still open is exempt regardless of age; see the liveness probe
+ * in `sweepAbandonedCheckpoints`.
+ */
+export const CHECKPOINT_TTL_MS = 14 * 24 * 60 * 60 * 1000
+
+/**
+ * Cap on retained owners per user, enforced oldest-first. The TTL alone does
+ * not bound a user who opens tabs faster than they expire.
+ */
+export const CHECKPOINT_MAX_OWNERS = 8
+
+/**
+ * How often a running tab refreshes its own `lastSeenAt`.
+ *
+ * This is a single-row `put` on the metadata row -- no header, no chunks -- so
+ * it is orders of magnitude cheaper than a checkpoint rewrite and can run on a
+ * timer without touching the interaction path.
+ */
+export const OWNER_TOUCH_INTERVAL_MS = 60 * 1000
+
+/**
+ * How recently an owner must have been touched to count as RUNNING.
+ *
+ * Three touch intervals, so a tab has to miss three in a row before the sweep
+ * may collect it. Browsers throttle timers in background tabs (and stop them
+ * entirely for a frozen or bfcached page), and the cost of guessing wrong is
+ * asymmetric: treating a live tab as dead destroys its checkpoint and op-log,
+ * while treating a dead one as live only defers its reclamation by a few
+ * minutes. The margin buys the cheap error.
+ */
+export const OWNER_LIVENESS_WINDOW_MS = 3 * OWNER_TOUCH_INTERVAL_MS
+
+/**
+ * Ceilings on ONE op-log read, mirroring the hub's MaxResumeDeltaOps (5000) and
+ * MaxResumeDeltaBytes (4 MiB) so both halves of the resume path bound the same
+ * quantities.
+ *
+ * Enforced AT THE CURSOR, not after it. The log is appended on the confirmed
+ * hot path (~120 frames/sec during a drag) and drained only by a checkpoint
+ * rewrite, which backs off whenever the write fails (quota, private browsing)
+ * or no watermark exists yet -- so an unbounded read materializes an unbounded
+ * log into memory on the very cold start that is meant to be cheap. Stopping
+ * short reports `truncated`, which routes to the caller's checkpoint rewrite
+ * and is exactly what drains the oversized log.
+ */
+export const MAX_OPLOG_READ_FRAMES = 5000
+export const MAX_OPLOG_READ_BYTES = 4 * 1024 * 1024
+
+/** On-disk shape of a checkpoint METADATA row (one per (user, client) pair). */
+export interface CheckpointRecord {
+  /** Owning user; also the logout-wipe key. */
+  userId: string
+  /** Owning tab's CRDT client id (per-tab, survives refresh). */
+  clientId: string
+  /**
+   * The serialized state HEADER at T_c: `UserCrdtState` with every entity map
+   * emptied (see checkpointChunks.serializeHeader). O(1) in account size, so
+   * every rewrite can afford to re-serialize it; the entities live in
+   * `checkpointChunks` rows and are rewritten only when they change.
+   */
+  headerBytes: Uint8Array
+  /** The resume watermark pinned at checkpoint write time (T_c). */
+  watermark: HlcShape
+  /** The epoch the watermark was seen under. */
+  currentEpoch: bigint
+  /** Wall-clock time (ms) of the checkpoint WRITE itself. Diagnostics only. */
+  writtenAt: number
+  /**
+   * Wall-clock time (ms) this owner was last known to be RUNNING.
+   *
+   * Deliberately separate from `writtenAt`, which moves only on a rewrite --
+   * i.e. once per CHECKPOINT_OP_LOG_THRESHOLD confirmed frames. That made it a
+   * bad liveness proxy: a quiet but live sibling tab looked arbitrarily stale,
+   * and the sweep's cap arm deleted its checkpoint and op-log out from under
+   * it. `touchOwner` refreshes this on a short interval and at hydration, so a
+   * running tab is recent by construction and the sweep can decide liveness
+   * from data it already reads instead of from a cross-tab round trip that a
+   * backgrounded or frozen tab could never answer in time.
+   *
+   * It is also the right clock for the abandonment TTL: "this owner has not
+   * been USED in 14 days" is the question the TTL means to ask, and `writtenAt`
+   * answered a different one.
+   */
+  lastSeenAt: number
+}
+
+/** On-disk shape of one entity chunk row. */
+export interface CheckpointChunkRecord {
+  userId: string
+  clientId: string
+  /** Opaque to this module; checkpointChunks.ts maps it to a record schema. */
+  kind: string
+  /** The entity's map key within its kind. */
+  entityId: string
+  /** `toBinary(<kind's record schema>, record)`. */
+  bytes: Uint8Array
+}
+
+/** One chunk's identity within an owner's checkpoint. */
+export interface ChunkRef {
+  kind: string
+  entityId: string
+}
+
+/** A chunk to write. */
+export interface ChunkUpsert extends ChunkRef {
+  bytes: Uint8Array
+}
+
+/**
+ * What one checkpoint rewrite changes: the (always re-written) header, plus the
+ * chunks that moved since the last one.
+ *
+ * `full` is the bootstrap / lineage-reset arm: every chunk the owner already
+ * has is dropped before the upserts land, so the persisted shards describe
+ * exactly the state that produced them and no record of a discarded lineage can
+ * survive. An incremental rewrite instead leaves untouched chunks alone, which
+ * is the entire point -- the write scales with the delta, not the account.
+ */
+export interface CheckpointDelta {
+  headerBytes: Uint8Array
+  upserts: readonly ChunkUpsert[]
+  deletes: readonly ChunkRef[]
+  full: boolean
+}
+
+/** On-disk shape of one op-log SEGMENT row (one per flush since checkpoint). */
+interface OpLogRecord {
+  /**
+   * Generator-assigned, store-wide monotonic sequence. It does NOT need to be
+   * per-owner contiguous: replay walks the byOwner index, and an index cursor
+   * yields equal-index-key records in PRIMARY-KEY order, so a globally
+   * increasing seq still orders one owner's segments by append time. Letting
+   * the store assign it removes the read-modify-write (a reverse cursor to find
+   * the current max) that the append path used to pay on every flush, and with
+   * it the prose argument for why that read and its write were atomic.
+   */
+  seq?: number
+  userId: string
+  clientId: string
+  /**
+   * Per-owner position of this segment, 0-based and CONTIGUOUS, restarting at 0
+   * after each successful checkpoint write (which truncates the log).
+   *
+   * `seq` orders segments but cannot detect a MISSING one — it is store-wide, so
+   * any gap in an owner's subsequence is indistinguishable from another owner's
+   * rows having taken those numbers. That made a hole undetectable at replay,
+   * and a hole is not a benign staleness: `readOpLogFrames` would return frames
+   * from both sides of it, and the post-hole `batchEnd` frames advance the
+   * resume cursor past the ops in the gap, which the hub never re-ships because
+   * it sends only what is strictly after the cursor. Silent, permanent
+   * divergence.
+   *
+   * The writer increments this per ATTEMPTED flush, never per successful one:
+   * numbering on success would hand the next segment the number the failed one
+   * would have used, closing the gap and hiding exactly the event this exists to
+   * expose.
+   */
+  ordinal: number
+  /** The batch of confirmed frame byte-blobs appended in one flush, in order. */
+  framesBytes: Uint8Array[]
+}
+
+/**
+ * Result of reading an owner's persisted pair.
+ *
+ * `miss` and `failed` are deliberately distinct. Collapsing them (the store
+ * returning `undefined` for both) meant a single unreadable op-log row --
+ * a malformed `framesBytes` that throws when flattened, or any transient
+ * cursor error -- was reported as "there is no checkpoint", so hydrate.ts's
+ * corruption policy never saw it and could not apply the prefix-truncate arm it
+ * was written for. The checkpoint got discarded and the connect took the full
+ * projection scan #267 exists to avoid.
+ *
+ * The arms are:
+ *   - `miss`   — nothing persisted for this owner.
+ *   - `failed` — the checkpoint metadata row or its chunks could not be read;
+ *     the base is unusable, so the caller wipes and cold-starts. The chunks
+ *     belong to this arm and NOT to the op-log's: they are half the base, and a
+ *     partially-read chunk set would hydrate a state missing entities the
+ *     resume cursor claims are present.
+ *   - `ok`     — the checkpoint is valid. `opLogTruncated` then says whether
+ *     `opLogFrames` is the WHOLE log or only a (possibly empty) prefix -- a
+ *     prefix because a segment was unreadable, or because the read hit
+ *     MAX_OPLOG_READ_FRAMES / MAX_OPLOG_READ_BYTES. Either way the caller
+ *     should rewrite the checkpoint, which drops the rest from disk rather
+ *     than re-failing (or re-truncating) every reload.
+ */
+export type CheckpointRead
+  = | { status: 'miss' }
+    | { status: 'failed' }
+    | {
+      status: 'ok'
+      checkpoint: CheckpointRecord
+      /** Every entity chunk for this owner, in no particular order. */
+      chunks: CheckpointChunkRecord[]
+      opLogFrames: Uint8Array[]
+      opLogTruncated: boolean
+      /**
+       * The ordinal the NEXT appended segment must carry — one past the last
+       * contiguously-read one, or 0 when nothing was read. The recorder seeds
+       * its counter from this so numbering survives a reload without the append
+       * path having to read the log back.
+       */
+      opLogNextOrdinal: number
+    }
+
+/** Whether persistence can work here at all — callers short-circuit synchronously on false. */
+export function isCheckpointStoreAvailable(): boolean {
+  return isIndexedDbAvailable()
+}
+
+/**
+ * The database's shape, in one place.
+ *
+ * Both halves of the scaffold's schema handling derive from this: it builds the
+ * stores on creation, and an opened database that does not match it is deleted
+ * and rebuilt. Add an index here and existing local databases repair themselves
+ * on the next open -- there is no second list to remember to update, and no
+ * version to bump.
+ */
+const SCHEMA: IdbSchema = {
+  [CHECKPOINT_STORE]: {
+    // The owner tuple IS the primary key, so an owner-scoped read or delete
+    // needs no index.
+    keyPath: ['userId', 'clientId'],
+    indexes: {
+      [BY_USER_INDEX]: 'userId',
+      [BY_LAST_SEEN_INDEX]: 'lastSeenAt',
+    },
+  },
+  [CHUNK_STORE]: {
+    // (owner, kind, entityId): a single chunk is addressed by primary key, so
+    // an incremental rewrite needs no index at all for its puts and deletes.
+    // The two index-driven walks below mirror the op-log's exactly -- an
+    // owner-scoped drop (a FULL rewrite, corruption recovery, the sweep) and a
+    // user-scoped drop (logout).
+    keyPath: ['userId', 'clientId', 'kind', 'entityId'],
+    indexes: {
+      [BY_OWNER_INDEX]: ['userId', 'clientId'],
+      [BY_USER_INDEX]: 'userId',
+    },
+  },
+  [OPLOG_STORE]: {
+    // autoIncrement: the store assigns seq, so append is a single `add` and
+    // segment ordering is a property the store guarantees rather than one the
+    // append path has to argue for.
+    keyPath: 'seq',
+    autoIncrement: true,
+    indexes: {
+      [BY_OWNER_INDEX]: ['userId', 'clientId'],
+      [BY_USER_INDEX]: 'userId',
+    },
+  },
+}
+
+const connection = createIdbConnection(DB_NAME, DB_VERSION, SCHEMA)
+
+const openDb = connection.open
+
+/** Visible for testing: forget the cached connection (e.g. after swapping the IDBFactory). */
+export function _resetCheckpointStoreForTest(): void {
+  connection.reset()
+}
+
+/**
+ * Read the checkpoint metadata, its entity chunks and its op-log for one owner.
+ * Never throws; see CheckpointRead for how a miss, a failed base read, and a
+ * partially readable op-log are told apart.
+ */
+export async function readCheckpoint(userId: string, clientId: string): Promise<CheckpointRead> {
+  if (!isCheckpointStoreAvailable())
+    return { status: 'miss' }
+  let db: IDBDatabase
+  let checkpoint: CheckpointRecord | undefined
+  let chunks: CheckpointChunkRecord[]
+  let tx: IDBTransaction
+  try {
+    db = await openDb()
+    // Read the metadata row, its chunks and the op-log in ONE transaction so
+    // the three stay consistent: a concurrent writeCheckpointAndTruncateOpLog
+    // cannot land between the reads and leave a header describing chunks that
+    // have moved, or a checkpoint whose op-log was just truncated.
+    //
+    // Every await below is on a request belonging to THIS transaction, which is
+    // what keeps it active across the microtask checkpoint (a transaction stays
+    // active while its own requests are outstanding). Do NOT introduce an await
+    // on anything else between here and the op-log read: that would let the
+    // transaction auto-commit, and the next objectStore() call would throw.
+    tx = db.transaction([CHECKPOINT_STORE, CHUNK_STORE, OPLOG_STORE], 'readonly')
+    checkpoint = await requestToPromise<CheckpointRecord | undefined>(
+      tx.objectStore(CHECKPOINT_STORE).get([userId, clientId]),
+    )
+    if (checkpoint === undefined)
+      return { status: 'miss' }
+    // The chunks are the other half of the BASE, so an unreadable one is fatal
+    // in exactly the way an unreadable header is: a partial entity set is a
+    // state that silently lost records the resume cursor claims are present.
+    chunks = []
+    await forEachCursor(
+      tx.objectStore(CHUNK_STORE).index(BY_OWNER_INDEX).openCursor(IDBKeyRange.only([userId, clientId])),
+      cursor => chunks.push(cursor.value as CheckpointChunkRecord),
+    )
+  }
+  catch {
+    return { status: 'failed' }
+  }
+
+  // The op-log is a separate failure domain: it is a rebuildable tail over a
+  // checkpoint that has already been read successfully, so a failure here
+  // truncates the replay instead of discarding the base.
+  try {
+    const { frames, truncated, nextOrdinal } = await readOpLogFrames(tx.objectStore(OPLOG_STORE), userId, clientId)
+    if (truncated)
+      log.warn('op-log read stopped early; replaying the prefix and rewriting the checkpoint')
+    return { status: 'ok', checkpoint, chunks, opLogFrames: frames, opLogTruncated: truncated, opLogNextOrdinal: nextOrdinal }
+  }
+  catch {
+    log.warn('op-log unreadable; replaying nothing onto the checkpoint and rewriting it')
+    return { status: 'ok', checkpoint, chunks, opLogFrames: [], opLogTruncated: true, opLogNextOrdinal: 0 }
+  }
+}
+
+/** Frames read from an owner's op-log, plus whether the read stopped early. */
+interface OpLogRead {
+  frames: Uint8Array[]
+  /** True when the read stopped early, so `frames` is a strict PREFIX. */
+  truncated: boolean
+  /** Ordinal the next appended segment must carry. See OpLogRecord.ordinal. */
+  nextOrdinal: number
+}
+
+async function readOpLogFrames(store: IDBObjectStore, userId: string, clientId: string): Promise<OpLogRead> {
+  // Cursor over the byOwner index for this (user, client). The index yields
+  // equal-key records in primary-key (seq) order = append order.
+  //
+  // The walk STOPS at the first segment that breaks the read, rather than
+  // collecting every segment and deciding afterwards: the caps exist to bound
+  // memory on a cold start, and a decision taken after the flatten has already
+  // paid for what it was meant to refuse.
+  const frames: Uint8Array[] = []
+  let bytes = 0
+  let truncated = false
+  let nextOrdinal = 0
+  await forEachCursorWhile(
+    store.index(BY_OWNER_INDEX).openCursor(IDBKeyRange.only([userId, clientId])),
+    (cursor) => {
+      const seg = cursor.value as OpLogRecord
+      // STOP at the first ordinal that is not the one expected next. This is the
+      // hole check, and it is the only one that catches an append that never
+      // landed: a swallowed write failure, or two tabs that ended up sharing one
+      // clientId and interleaved segments into a single owner's log. Everything
+      // below is built on a strict PREFIX, so stopping here (rather than
+      // skipping the row) keeps the contract and routes the bad tail to the
+      // caller's rewrite.
+      if (seg?.ordinal !== nextOrdinal) {
+        truncated = true
+        return false
+      }
+      // STOP at a malformed row -- do not skip it and keep reading. Everything
+      // downstream is built on a strict-PREFIX contract: hydrate replays the
+      // frames in order and the `batchEnd` frames among them advance the resume
+      // cursor, so returning frames from BOTH sides of a gap would push the
+      // cursor past the ops in the hole. The hub ships only what is strictly
+      // after the cursor, so those ops would never be re-sent -- the same
+      // silent, permanent divergence the per-(user, client) re-key above exists
+      // to prevent, reached from the read side. A prefix plus `truncated`
+      // routes to the caller's rewrite, which drops the bad tail from disk.
+      if (!Array.isArray(seg?.framesBytes)) {
+        truncated = true
+        return false
+      }
+      for (const frame of seg.framesBytes) {
+        // A segment may straddle a cap, so the cut is per FRAME: a prefix of a
+        // segment is still a prefix of the log.
+        const size = frame?.byteLength ?? 0
+        if (frames.length >= MAX_OPLOG_READ_FRAMES || bytes + size > MAX_OPLOG_READ_BYTES) {
+          truncated = true
+          return false
+        }
+        frames.push(frame)
+        bytes += size
+      }
+      // Advanced only for a segment accepted WHOLE. A segment cut short by a cap
+      // is a prefix, and the caller rewrites rather than appending after it, so
+      // claiming its ordinal was consumed would be wrong.
+      nextOrdinal++
+      return true
+    },
+  )
+  return { frames, truncated, nextOrdinal }
+}
+
+/**
+ * Append a batch of confirmed frames to this owner's op-log as ONE segment row.
+ * Mirrors the backend's one-row-per-batch: a flush of N frames writes 1 row
+ * holding all N, not N rows.
+ *
+ * `ordinal` is this segment's per-owner position and MUST come from a counter
+ * the caller advances per attempted flush (see OpLogRecord.ordinal).
+ *
+ * Best-effort, and a failure still drops silently -- but it is no longer
+ * SILENT-AND-INVISIBLE. A segment that does not land leaves a gap in the
+ * ordinal sequence, and `readOpLogFrames` stops there, so the next cold start
+ * replays the prefix up to the hole and rewrites. That is what makes the old
+ * claim ("a missed segment only means a slightly staler log, still correct")
+ * true: it held for a TRAILING segment and was false for a middle one, whose
+ * post-hole `batchEnd` frames advanced the resume cursor past ops the hub would
+ * never re-ship.
+ */
+export async function appendOpLogSegment(userId: string, clientId: string, framesBytes: Uint8Array[], ordinal: number): Promise<void> {
+  if (!isCheckpointStoreAvailable() || framesBytes.length === 0)
+    return
+  try {
+    const db = await openDb()
+    const tx = db.transaction(OPLOG_STORE, 'readwrite')
+    // `add`, not `put`: the key is generator-assigned, so a duplicate is
+    // impossible by construction and an accidental overwrite should fail loud.
+    tx.objectStore(OPLOG_STORE).add({ userId, clientId, ordinal, framesBytes } satisfies OpLogRecord)
+    await txToPromise(tx, 'appendOpLogSegment')
+  }
+  catch {
+    // Quota/private-browsing failures: persistence is an optimization only.
+  }
+}
+
+/**
+ * Atomically apply `delta` to this owner's checkpoint AND truncate its op-log.
+ *
+ * Every write shares ONE transaction, which is what keeps the pair consistent
+ * in both directions: after this resolves the header, the chunks and the empty
+ * op-log all describe the same instant, and a crash part-way rolls the whole
+ * thing back rather than leaving the metadata row's watermark ahead of the
+ * chunks it claims to describe. Mirrors the hub's CompactBatch.
+ *
+ * Best-effort; failures drop silently and return false (a failed compaction
+ * only means the next cold reload replays a longer log, still correct) — and
+ * the caller MUST keep its dirty set on a false, since none of the delta
+ * landed.
+ */
+export async function writeCheckpointAndTruncateOpLog(
+  userId: string,
+  clientId: string,
+  delta: CheckpointDelta,
+  watermark: HlcShape,
+  currentEpoch: bigint,
+  now = Date.now(),
+): Promise<boolean> {
+  if (!isCheckpointStoreAvailable())
+    return false
+  try {
+    const db = await openDb()
+    const tx = db.transaction([CHECKPOINT_STORE, CHUNK_STORE, OPLOG_STORE], 'readwrite')
+    // Registered in the same task that created the transaction, per txToPromise.
+    const settled = txToPromise(tx, 'writeCheckpoint')
+    const writes = (async () => {
+      const chunks = tx.objectStore(CHUNK_STORE)
+      const owner: [string, string] = [userId, clientId]
+      if (delta.full) {
+        // AWAITED before the upserts below. A cursor sees writes made in its
+        // own transaction, so a chunk `put` issued while this walk is still
+        // advancing would be deleted again the moment the cursor reached its
+        // key. Awaiting a request of THIS transaction keeps it active across
+        // the microtask checkpoint (see readCheckpoint).
+        await deleteIndexRange(chunks, BY_OWNER_INDEX, IDBKeyRange.only(owner))
+      }
+      for (const chunk of delta.upserts) {
+        chunks.put({
+          userId,
+          clientId,
+          kind: chunk.kind,
+          entityId: chunk.entityId,
+          bytes: chunk.bytes,
+        } satisfies CheckpointChunkRecord)
+      }
+      // Keyed deletes: the owner tuple is part of the primary key, so an
+      // entity that left the state needs no index walk.
+      for (const ref of delta.deletes)
+        chunks.delete([userId, clientId, ref.kind, ref.entityId])
+      tx.objectStore(CHECKPOINT_STORE).put({
+        userId,
+        clientId,
+        headerBytes: delta.headerBytes,
+        watermark,
+        currentEpoch,
+        writtenAt: now,
+        lastSeenAt: now,
+      } satisfies CheckpointRecord)
+      // Truncate only THIS owner's log. The walk's own promise settles when it
+      // has issued every delete; `settled` waits for durability, and a cursor
+      // error aborts the transaction, which rejects it.
+      await deleteIndexRange(tx.objectStore(OPLOG_STORE), BY_OWNER_INDEX, IDBKeyRange.only(owner))
+    })()
+    // Both are passed to Promise.all so neither can reject unobserved when the
+    // other fails first.
+    await Promise.all([writes, settled])
+    return true
+  }
+  catch {
+    log.warn('checkpoint write failed (quota exceeded / private mode); cold reloads will replay the existing op-log')
+    return false
+  }
+}
+
+/**
+ * Refresh this owner's `lastSeenAt`, so the sweep can tell a quiet-but-running
+ * tab from an abandoned one.
+ *
+ * A read-modify-write of the ONE metadata row, in a single transaction: it must
+ * not resurrect a row the sweep just collected, and it must not clobber the
+ * header/watermark a concurrent rewrite wrote, so it re-reads the record and
+ * puts back exactly what it found with one field moved. A missing row is a
+ * no-op -- an owner with no checkpoint has nothing for the sweep to protect,
+ * and `keepClientId` already covers the sweeping tab itself.
+ *
+ * Best-effort and no-throw, like every operation in this module.
+ */
+export async function touchOwner(userId: string, clientId: string, now = Date.now()): Promise<boolean> {
+  if (!isCheckpointStoreAvailable() || !userId || !clientId)
+    return false
+  try {
+    const db = await openDb()
+    const tx = db.transaction(CHECKPOINT_STORE, 'readwrite')
+    const settled = txToPromise(tx, 'touchOwner')
+    const store = tx.objectStore(CHECKPOINT_STORE)
+    const existing = await requestToPromise<CheckpointRecord | undefined>(
+      store.get([userId, clientId]) as IDBRequest<CheckpointRecord | undefined>,
+    )
+    if (existing === undefined) {
+      // Nothing to touch. Let the transaction finish rather than abandoning it.
+      await settled
+      return false
+    }
+    store.put({ ...existing, lastSeenAt: now } satisfies CheckpointRecord)
+    await settled
+    return true
+  }
+  catch {
+    return false
+  }
+}
+
+/** Which rows a clear covers. See the two exported wrappers below. */
+type ClearScope
+  = | { kind: 'user', userId: string }
+    | { kind: 'owner', userId: string, clientId: string }
+
+/**
+ * Delete the checkpoint metadata, chunk and op-log rows in `scope`, in one
+ * transaction.
+ *
+ * Shared by both wrappers so they cannot drift on the transaction mechanics;
+ * the scope is the entire difference between them. Best-effort: a failed clear
+ * only leaves a stale record that will fail to parse on the next reload and
+ * trigger another wipe attempt.
+ */
+async function clearScope(scope: ClearScope): Promise<boolean> {
+  if (!isCheckpointStoreAvailable())
+    return false
+  try {
+    const db = await openDb()
+    const tx = db.transaction([CHECKPOINT_STORE, CHUNK_STORE, OPLOG_STORE], 'readwrite')
+    const settled = txToPromise(tx, 'clearCheckpoint')
+    const checkpoints = tx.objectStore(CHECKPOINT_STORE)
+    const chunks = tx.objectStore(CHUNK_STORE)
+    const opLog = tx.objectStore(OPLOG_STORE)
+    // The checkpoint store's PRIMARY KEY is the owner tuple, so an owner-scoped
+    // metadata clear is a single keyed delete and needs no index. The chunk and
+    // op-log keys carry more than the owner (kind + entity id; a
+    // generator-assigned `seq`), so both always walk an index.
+    let walks: Promise<unknown>
+    if (scope.kind === 'owner') {
+      const owner: [string, string] = [scope.userId, scope.clientId]
+      checkpoints.delete(owner)
+      walks = Promise.all([
+        deleteIndexRange(chunks, BY_OWNER_INDEX, IDBKeyRange.only(owner)),
+        deleteIndexRange(opLog, BY_OWNER_INDEX, IDBKeyRange.only(owner)),
+      ])
+    }
+    else {
+      const range = IDBKeyRange.only(scope.userId)
+      walks = Promise.all([
+        forEachCursor(
+          checkpoints.index(BY_USER_INDEX).openKeyCursor(range),
+          cursor => checkpoints.delete(cursor.primaryKey),
+        ),
+        deleteIndexRange(chunks, BY_USER_INDEX, range),
+        deleteIndexRange(opLog, BY_USER_INDEX, range),
+      ])
+    }
+    await Promise.all([walks, settled])
+    return true
+  }
+  catch {
+    // Still swallowed -- a wipe is best-effort and no caller can do better than
+    // carry on. But it now REPORTS, because "the wipe happened" and "the wipe
+    // silently did not" are not interchangeable: hydrate.ts's corruption policy
+    // is only self-healing if the poison record is actually gone, and a
+    // versionchange from a peer tab or a quota abort on the readwrite tx makes
+    // it not gone. Without a return value that is indistinguishable from
+    // success, and the user pays a failed read plus a full projection snapshot
+    // on every reload forever with nothing logged.
+    return false
+  }
+}
+
+/**
+ * Delete the checkpoint, chunks and op-log for EVERY client of `userId`. Used
+ * on logout / user switch, where the promise is "forget this device's state for
+ * this account" — so it must span the other tabs' rows too, not just this one's.
+ *
+ * NOT for corruption recovery: a blob that failed to parse belongs to exactly
+ * one `(userId, clientId)` owner, and wiping user-wide there would destroy
+ * every OTHER tab's checkpoint too — a cross-tab clobber inflicted by the
+ * recovery path itself, on tabs whose own records are fine. Use
+ * `clearOwnerCheckpointAndOpLog` for that.
+ */
+export function clearCheckpointAndOpLog(userId: string): Promise<boolean> {
+  return clearScope({ kind: 'user', userId })
+}
+
+/**
+ * Delete the checkpoint, chunks and op-log for ONE `(userId, clientId)` owner,
+ * leaving every other tab's rows untouched.
+ *
+ * This is the corruption-recovery scope. A record that fails to parse, names a
+ * foreign tenant, or carries an out-of-range watermark/epoch is this owner's
+ * problem alone; wiping it self-heals the next reload of THIS tab without
+ * forcing every other tab into a full-snapshot cold start.
+ */
+export function clearOwnerCheckpointAndOpLog(userId: string, clientId: string): Promise<boolean> {
+  return clearScope({ kind: 'owner', userId, clientId })
+}
+
+/** One checkpoint row as the sweep sees it: identity plus recency, no payload. */
+interface SweepCandidate {
+  userId: string
+  clientId: string
+  /** `lastSeenAt`, named `at` so `selectSweepVictims` can consume it. */
+  at: number
+}
+
+/** Options for `sweepAbandonedCheckpoints`; every one is a test seam. */
+export interface SweepOptions {
+  now?: number
+  ttlMs?: number
+  maxOwners?: number
+  /**
+   * How recently an owner must have been touched to count as a RUNNING tab.
+   * Defaults to OWNER_LIVENESS_WINDOW_MS.
+   */
+  livenessWindowMs?: number
+}
+
+/**
+ * Delete the checkpoints + chunks + op-logs of this device's ABANDONED owners:
+ * any row not TOUCHED within `ttlMs`, plus `userId`'s oldest rows beyond
+ * `maxOwners`. Returns how many owners were collected.
+ *
+ * Nothing else ever reclaims them. The client id lives in sessionStorage, so it
+ * dies with the tab: every closed tab strands a `(userId, clientId)` row holding
+ * a serialized `UserCrdtState` -- header plus one chunk per entity -- and its
+ * op-log segments, unreachable by any later session and deleted only by a logout
+ * many users never perform. Left alone the origin's quota is eventually
+ * exhausted, `writeCheckpointAndTruncateOpLog` starts returning false, the
+ * checkpoint stops being refreshed, and every refresh falls back to the full
+ * projection snapshot #267 exists to remove — while the browser reports large
+ * and growing site storage.
+ *
+ * TWO ARMS, TWO SCOPES.
+ *
+ * The TTL arm applies to EVERY row the walk visits, including other accounts'.
+ * It has to: an account signed out of without an explicit logout leaves rows no
+ * later session ever addresses, so scoping the TTL to the signed-in user meant
+ * nothing at all reclaimed them. It is safe because CHECKPOINT_TTL_MS is
+ * comfortably longer than the hub's op-retention window -- a checkpoint that
+ * old could not delta-resume even if its tab came back.
+ *
+ * The CAP arm stays scoped to `userId`. "This account has more tabs than the
+ * cap" is a statement about this account's rows and says nothing about how many
+ * another account may keep.
+ *
+ * LIVENESS is read from `lastSeenAt`, which every running tab refreshes on a
+ * short interval (see `touchOwner`), so a row touched within
+ * OWNER_LIVENESS_WINDOW_MS belongs to a tab that is still running. Both arms
+ * skip those.
+ *
+ * This replaced a BroadcastChannel roll-call, and the reason is worth keeping:
+ * a roll-call asks a question a backgrounded, frozen or bfcached tab CANNOT
+ * answer, so no timeout value made it correct -- a short one killed live tabs
+ * and a long one outlived the page that started the sweep. A timestamp the live
+ * tab wrote for itself has no such window. It also inverts the default in the
+ * right direction for a destructive operation: a row is kept on POSITIVE proof
+ * of recency rather than on the absence of a reply.
+ *
+ * This is the counterpart the sibling store on the same `~/lib/idb` scaffold
+ * already had (`sweepArtifacts`, TTL + entry cap); both now share the selection
+ * arithmetic itself (`selectSweepVictims`).
+ *
+ * Best-effort and no-throw, like every operation in this module.
+ */
+export async function sweepAbandonedCheckpoints(
+  userId: string,
+  keepClientId: string,
+  opts: SweepOptions = {},
+): Promise<number> {
+  if (!isCheckpointStoreAvailable() || !userId)
+    return 0
+  const now = opts.now ?? Date.now()
+  const ttlMs = opts.ttlMs ?? CHECKPOINT_TTL_MS
+  const maxOwners = opts.maxOwners ?? CHECKPOINT_MAX_OWNERS
+  try {
+    const db = await openDb()
+    // Key-only walk, UNRANGED. The index key is writtenAt and the primary key
+    // is [userId, clientId], so this reads no header or chunk bytes at all --
+    // and a compound [userId, writtenAt] index, which would let the walk skip
+    // other accounts' rows, is deliberately NOT added: those rows are exactly
+    // the ones nothing else can reach, so making them cheap to skip would make
+    // them permanently unreclaimable. The population this walks is capped at
+    // ~maxOwners per account by this very sweep.
+    const rows: SweepCandidate[] = []
+    const readTx = db.transaction(CHECKPOINT_STORE, 'readonly')
+    await forEachCursor(
+      readTx.objectStore(CHECKPOINT_STORE).index(BY_LAST_SEEN_INDEX).openKeyCursor(),
+      (cursor) => {
+        const [rowUser, rowClient] = cursor.primaryKey as [string, string]
+        rows.push({ userId: rowUser, clientId: rowClient, at: cursor.key as number })
+      },
+    )
+    if (rows.length === 0)
+      return 0
+
+    // A row touched within the liveness window belongs to a running tab. The
+    // sweeping tab is live by definition even if it has not written a row yet.
+    const livenessWindowMs = opts.livenessWindowMs ?? OWNER_LIVENESS_WINDOW_MS
+    const isLive = (row: SweepCandidate): boolean =>
+      row.clientId === keepClientId || now - row.at < livenessWindowMs
+    // The index yields lastSeenAt-ascending, so both partitions stay oldest-first.
+    const candidates = rows.filter(row => !isLive(row))
+    const mine = candidates.filter(row => row.userId === userId)
+    const foreign = candidates.filter(row => row.userId !== userId)
+    // This tab occupies a slot in its own account's budget whether or not it
+    // has written a row yet, and so does every live sibling that has one.
+    const reserved = 1 + rows.filter(row => row.userId === userId
+      && row.clientId !== keepClientId
+      && isLive(row)).length
+    const victims = [
+      ...selectSweepVictims(foreign, { now, ttlMs }),
+      ...selectSweepVictims(mine, { now, ttlMs, maxEntries: maxOwners, reserved }),
+    ]
+    if (victims.length === 0)
+      return 0
+
+    const tx = db.transaction([CHECKPOINT_STORE, CHUNK_STORE, OPLOG_STORE], 'readwrite')
+    const settled = txToPromise(tx, 'sweepAbandonedCheckpoints')
+    const checkpoints = tx.objectStore(CHECKPOINT_STORE)
+    const chunks = tx.objectStore(CHUNK_STORE)
+    const opLog = tx.objectStore(OPLOG_STORE)
+    const walks = victims.flatMap((victim) => {
+      // Keyed off the VICTIM's user, not the sweeping one: the TTL arm reaches
+      // across accounts, so the closure's `userId` is the wrong key for a
+      // foreign row and would delete some other owner entirely.
+      const owner: [string, string] = [victim.userId, victim.clientId]
+      checkpoints.delete(owner)
+      return [
+        deleteIndexRange(chunks, BY_OWNER_INDEX, IDBKeyRange.only(owner)),
+        deleteIndexRange(opLog, BY_OWNER_INDEX, IDBKeyRange.only(owner)),
+      ]
+    })
+    await Promise.all([Promise.all(walks), settled])
+    return victims.length
+  }
+  catch {
+    // Best-effort: a failed sweep just leaves the rows for the next attempt.
+    return 0
+  }
+}
+
+/**
+ * Delete every row of `store` matching `range` on `indexName`, by walking the
+ * index and deleting each primary key. Runs within the caller's readwrite
+ * transaction; resolves once the walk has issued every delete (the caller
+ * awaits tx.oncomplete for durability).
+ *
+ * Index-driven rather than a primary-key range because neither store this
+ * serves is keyed by the owner alone: the op-log's key is the
+ * generator-assigned `seq`, which carries no owner information at all, and a
+ * chunk's key carries the owner plus a kind and an entity id.
+ */
+function deleteIndexRange(store: IDBObjectStore, indexName: string, range: IDBKeyRange): Promise<void> {
+  return forEachCursor(
+    store.index(indexName).openKeyCursor(range),
+    cursor => store.delete(cursor.primaryKey),
+  )
+}

--- a/frontend/src/lib/crdt/clientIdentity.test.ts
+++ b/frontend/src/lib/crdt/clientIdentity.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { KEY_CLIENT_ID, sessionStorageGet, sessionStorageSet } from '~/lib/browserStorage'
+import { createClientIdentity } from './clientIdentity'
+
+/**
+ * An in-process BroadcastChannel that delivers BREADTH-FIRST, in FIFO order.
+ *
+ * Delivery stays synchronous (the real one posts on a task, which would make
+ * every assertion here a timing race), but a message posted from inside a
+ * handler is QUEUED behind the messages already in flight rather than delivered
+ * re-entrantly. That is the one property worth modelling: real channels queue
+ * per destination, so a reply cannot overtake a message that was already
+ * pending at its recipient.
+ *
+ * A depth-first fake makes the handshake look correct when it is not. Three
+ * tabs sharing an id: duplicate B claims, and depth-first the incumbent A's
+ * reply is delivered to B and fully processed BEFORE the second duplicate C has
+ * even seen B's claim -- so C's own reply, the one the incumbent would have
+ * mistaken for a verdict on itself, is never produced. FIFO reproduces it.
+ */
+class FakeBroadcastChannel {
+  static open: FakeBroadcastChannel[] = []
+  private static queue: { to: FakeBroadcastChannel, data: unknown }[] = []
+  private static draining = false
+  onmessage: ((ev: MessageEvent<unknown>) => void) | null = null
+  closed = false
+  constructor(readonly name: string) {
+    FakeBroadcastChannel.open.push(this)
+  }
+
+  /**
+   * When false, `postMessage` only enqueues and a test drives delivery with
+   * `flush()`. Real delivery is asynchronous, so several tabs can load — and
+   * each post its `claim` — before any of them receives anything. Draining
+   * inside the constructor makes that unrepresentable: each new tab's handshake
+   * fully resolves before the next one exists, so no two duplicates are ever
+   * live under the same id at once, which is the only state the three-tab
+   * defect needs.
+   */
+  static autoDrain = true
+
+  static reset(): void {
+    FakeBroadcastChannel.open = []
+    FakeBroadcastChannel.queue = []
+    FakeBroadcastChannel.draining = false
+    FakeBroadcastChannel.autoDrain = true
+  }
+
+  static flush(): void {
+    if (FakeBroadcastChannel.draining)
+      return
+    FakeBroadcastChannel.draining = true
+    try {
+      for (let next = FakeBroadcastChannel.queue.shift(); next; next = FakeBroadcastChannel.queue.shift()) {
+        if (!next.to.closed)
+          next.to.onmessage?.({ data: next.data } as MessageEvent<unknown>)
+      }
+    }
+    finally {
+      FakeBroadcastChannel.draining = false
+    }
+  }
+
+  postMessage(data: unknown): void {
+    for (const peer of FakeBroadcastChannel.open) {
+      if (peer === this || peer.closed || peer.name !== this.name)
+        continue
+      FakeBroadcastChannel.queue.push({ to: peer, data })
+    }
+    // A nested post (one made from inside a handler) only enqueues; the
+    // outermost call owns the drain, which is what makes this breadth-first.
+    if (FakeBroadcastChannel.autoDrain)
+      FakeBroadcastChannel.flush()
+  }
+
+  close(): void {
+    this.closed = true
+    FakeBroadcastChannel.open = FakeBroadcastChannel.open.filter(c => c !== this)
+  }
+}
+
+beforeEach(() => {
+  FakeBroadcastChannel.reset()
+  vi.stubGlobal('BroadcastChannel', FakeBroadcastChannel)
+})
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('createClientIdentity', () => {
+  it('reuses the id already in sessionStorage, so a refresh resumes its own checkpoint', () => {
+    sessionStorageSet(KEY_CLIENT_ID, 'c-existing')
+    const identity = createClientIdentity()
+    expect(identity.clientId()).toBe('c-existing')
+    identity.dispose()
+  })
+
+  it('mints and persists an id when there is none', () => {
+    const identity = createClientIdentity()
+    expect(identity.clientId()).toMatch(/^c-/)
+    expect(sessionStorageGet<string>(KEY_CLIENT_ID)).toBe(identity.clientId())
+    identity.dispose()
+  })
+
+  // THE case this handshake exists for. Browsers COPY sessionStorage into a
+  // duplicated tab ("Duplicate tab", "Reopen closed tab"), so two LIVE tabs end
+  // up holding the same client id -- and therefore the same checkpoint owner
+  // key. Each one's writeCheckpointAndTruncateOpLog deletes the whole owner
+  // range, so they truncate each other's op-log segments; the next reload
+  // replays a checkpoint plus a tail with a hole in it, and the batchEnd frames
+  // in that tail advance the resume cursor straight past the missing ops. The
+  // hub only ships what is strictly after the cursor, so they are never re-sent.
+  it('re-mints in the DUPLICATE when a live tab already holds the id', () => {
+    sessionStorageSet(KEY_CLIENT_ID, 'c-shared')
+    const incumbent = createClientIdentity()
+    expect(incumbent.clientId()).toBe('c-shared')
+
+    // The duplicate loads with the cloned sessionStorage value.
+    const duplicate = createClientIdentity()
+
+    expect(incumbent.clientId()).toBe('c-shared')
+    expect(duplicate.clientId()).not.toBe('c-shared')
+    expect(duplicate.clientId()).toMatch(/^c-/)
+    // ...and the duplicate persisted its replacement, so ITS next refresh is
+    // stable rather than colliding again.
+    expect(sessionStorageGet<string>(KEY_CLIENT_ID)).toBe(duplicate.clientId())
+
+    incumbent.dispose()
+    duplicate.dispose()
+  })
+
+  // The two-tab case above passes even with a broadcast `held`, because there is
+  // only ever one answerer. Add a THIRD tab holding the same id -- duplicating a
+  // tab twice in quick succession, or restoring a session that reopens several
+  // clones -- and every holder answers every claim. Unaddressed, the incumbent
+  // hears the OTHER duplicate's answer and re-mints itself: the checkpoint is
+  // keyed (userId, clientId), so the tab that owns the persisted state loses it,
+  // misses on hydrate, and cold-starts with the full projection snapshot this
+  // whole branch exists to avoid -- while its rows are orphaned until the sweep.
+  it('keeps the incumbent\'s id when TWO duplicates race', () => {
+    sessionStorageSet(KEY_CLIENT_ID, 'c-shared')
+    const incumbent = createClientIdentity()
+    expect(incumbent.clientId()).toBe('c-shared')
+
+    // Hold delivery so both duplicates load — and post their claims — before
+    // either handshake resolves. That is what puts three tabs on one id at the
+    // same instant; with delivery inline, each duplicate re-mints before the
+    // next is constructed and they are never concurrently live.
+    FakeBroadcastChannel.autoDrain = false
+    sessionStorageSet(KEY_CLIENT_ID, 'c-shared')
+    const dupA = createClientIdentity()
+    sessionStorageSet(KEY_CLIENT_ID, 'c-shared')
+    const dupB = createClientIdentity()
+    FakeBroadcastChannel.autoDrain = true
+    FakeBroadcastChannel.flush()
+
+    expect(incumbent.clientId()).toBe('c-shared')
+    expect(dupA.clientId()).not.toBe('c-shared')
+    expect(dupB.clientId()).not.toBe('c-shared')
+    // And the two duplicates did not collide with each other on the way out.
+    expect(dupA.clientId()).not.toBe(dupB.clientId())
+
+    incumbent.dispose()
+    dupA.dispose()
+    dupB.dispose()
+  })
+
+  it('leaves distinct ids alone', () => {
+    sessionStorageSet(KEY_CLIENT_ID, 'c-one')
+    const a = createClientIdentity()
+    sessionStorageSet(KEY_CLIENT_ID, 'c-two')
+    const b = createClientIdentity()
+
+    expect(a.clientId()).toBe('c-one')
+    expect(b.clientId()).toBe('c-two')
+    a.dispose()
+    b.dispose()
+  })
+
+  // A closed tab must stop defending its id, or the next tab to legitimately
+  // inherit it (same sessionStorage, tab reopened) would be told to re-mint by
+  // a peer that no longer exists.
+  it('stops answering once disposed', () => {
+    sessionStorageSet(KEY_CLIENT_ID, 'c-gone')
+    const departed = createClientIdentity()
+    departed.dispose()
+
+    const successor = createClientIdentity()
+    expect(successor.clientId()).toBe('c-gone')
+    successor.dispose()
+  })
+
+  it('uses the stored id unchanged where BroadcastChannel is unavailable', () => {
+    vi.stubGlobal('BroadcastChannel', undefined)
+    sessionStorageSet(KEY_CLIENT_ID, 'c-no-channel')
+    const identity = createClientIdentity()
+    expect(identity.clientId()).toBe('c-no-channel')
+    identity.dispose()
+  })
+})
+
+// The checkpoint sweep's liveness oracle. `writtenAt` moves only on a REWRITE
+// -- once per 256 confirmed frames -- so a quiet but LIVE sibling tab looks
+// arbitrarily stale, and the sweep used to delete its checkpoint and entire
+// op-log out from under it. Asking who is actually running is the fix, and the
+// claim/held handshake above already knows.

--- a/frontend/src/lib/crdt/clientIdentity.ts
+++ b/frontend/src/lib/crdt/clientIdentity.ts
@@ -1,0 +1,171 @@
+import { createSignal } from 'solid-js'
+import { KEY_CLIENT_ID, sessionStorageGet, sessionStorageSet } from '~/lib/browserStorage'
+import { randomUUID } from '~/lib/idGenerator'
+import { createLogger } from '~/lib/logger'
+
+const log = createLogger('clientIdentity')
+
+// ---------------------------------------------------------------------------
+// Per-tab CRDT client identity, with a liveness handshake
+//
+// The client id is the HLC author, the op_id salt, and — since the client
+// checkpoint landed — the second half of the `(userId, clientId)` key that owns
+// a persisted checkpoint + op-log. It lives in sessionStorage so it SURVIVES A
+// REFRESH, which is what makes cross-refresh delta-resume work: reload the same
+// tab, find your own checkpoint, resume from it.
+//
+// THE PROBLEM sessionStorage alone does not solve: browsers COPY sessionStorage
+// into a duplicated tab. "Duplicate tab" (Chrome/Edge), "Reopen closed tab", and
+// Firefox/Safari's equivalents all clone it, so two LIVE tabs end up holding the
+// same id. They then own the same checkpoint row, and
+// `writeCheckpointAndTruncateOpLog` deletes the whole owner range — so each
+// tab's rewrite truncates the other's op-log segments. The next reload replays
+// state@T1 plus only the post-truncate tail, with T1..T2 gone, and the
+// `batchEnd` frames in that tail advance the resume cursor straight past the
+// hole. The hub ships only what is strictly after the cursor, so those ops are
+// never re-sent: silent, permanent divergence. This handshake is what narrows
+// that window; it does not close it (see below), which is why
+// checkpointStore's header calls the per-tab key "unlikely" rather than
+// "unrepresentable".
+//
+// THE HANDSHAKE. Every tab announces `claim` for the id it holds, tagged with a
+// per-PAGE-LOAD instance token (which sessionStorage duplication cannot clone —
+// it is minted in memory, after the copy). A tab that hears a `claim` for the id
+// it is currently using, from a different instance, answers `held` ADDRESSED TO
+// THAT CLAIMANT. A tab that hears a `held` addressed to itself knows it is the
+// duplicate and re-mints.
+//
+// The incumbent wins because it is the one already listening: the duplicate
+// necessarily loads later, so its `claim` reaches a live incumbent while the
+// incumbent's original `claim` predates the duplicate entirely — and because
+// only the claimant acts on the answer. Addressing is load-bearing, not
+// tidiness: with a broadcast `held`, a THIRD tab holding the same id answers a
+// duplicate's claim and the incumbent reads that answer as a verdict on itself,
+// so duplicating a tab twice in quick succession re-mints the ORIGINAL. See
+// ClaimMessage.replyTo.
+//
+// Reassignment is REACTIVE, not fatal: `clientId` is a signal, the runtime's
+// hydration effect reads it, and the duplicate simply re-hydrates under its
+// fresh id — a checkpoint miss, so it cold-starts with one full snapshot. That
+// is the correct outcome for a tab that has applied nothing of its own, and it
+// costs the duplicate a snapshot rather than costing BOTH tabs their history.
+//
+// Degrades cleanly: without BroadcastChannel (older Safari, some embedded
+// webviews) the id is used as-is, which is exactly today's behavior.
+// ---------------------------------------------------------------------------
+
+const CHANNEL_NAME = 'leapmux:crdt-client-id'
+
+interface ClaimMessage {
+  type: 'claim' | 'held'
+  /** The id being claimed or held. */
+  clientId: string
+  /** Per-page-load token. Distinguishes a duplicated tab from its source. */
+  instance: string
+  /**
+   * On a `held`, the `instance` of the claimant it answers. ADDRESSED, not
+   * broadcast: only that tab may treat it as evidence against its own id.
+   *
+   * Without it a `held` is heard by every tab holding the id, and with THREE
+   * such tabs the incumbent loses. A duplicate B claims X; both the incumbent A
+   * and a second duplicate C still hold X, so both answer `held(X)`; A then
+   * sees C's answer, reads it as "someone else owns my id", and re-mints
+   * itself. The header's argument that "the incumbent always wins because it is
+   * the one already listening" holds only while at most one other tab holds the
+   * id -- it is an argument about who ANSWERS, and says nothing about who the
+   * answer is FOR.
+   */
+  replyTo?: string
+}
+
+export interface ClientIdentity {
+  /**
+   * The id this tab owns. A SIGNAL because a duplicate tab re-mints after the
+   * handshake resolves; readers that key persistent state on it (the checkpoint
+   * owner, the HLC author) must re-run when it changes.
+   */
+  clientId: () => string
+  /** Release the channel. Idempotent. */
+  dispose: () => void
+}
+
+function mintClientId(): string {
+  const fresh = `c-${randomUUID()}`
+  sessionStorageSet(KEY_CLIENT_ID, fresh)
+  return fresh
+}
+
+/**
+ * Resolve this tab's client id and defend it against a duplicated tab.
+ *
+ * Returns immediately with the stored (or freshly minted) id — the handshake is
+ * asynchronous and only ever *narrows* to a new id, so no caller has to wait.
+ */
+export function createClientIdentity(): ClientIdentity {
+  const [clientId, setClientId] = createSignal(sessionStorageGet<string>(KEY_CLIENT_ID) || mintClientId())
+
+  if (typeof BroadcastChannel === 'undefined')
+    return { clientId, dispose: () => {} }
+
+  // Minted in memory AFTER any sessionStorage copy, so a duplicated tab and its
+  // source always disagree here even though they agree on clientId.
+  const instance = randomUUID()
+  let channel: BroadcastChannel | null
+  try {
+    channel = new BroadcastChannel(CHANNEL_NAME)
+  }
+  catch {
+    // Some webviews expose the constructor but refuse to construct it.
+    return { clientId, dispose: () => {} }
+  }
+
+  const post = (type: ClaimMessage['type'], replyTo?: string): void => {
+    try {
+      channel?.postMessage({ type, clientId: clientId(), instance, replyTo } satisfies ClaimMessage)
+    }
+    catch {
+      // A closed channel or a structured-clone failure: the id stays as-is,
+      // which is the pre-handshake behavior.
+    }
+  }
+
+  channel.onmessage = (event: MessageEvent<ClaimMessage>) => {
+    const msg = event.data
+    // Ignore our own echo.
+    if (!msg || msg.instance === instance)
+      return
+    // Every message is about one specific id; ignore it unless it is ours.
+    if (msg.clientId !== clientId())
+      return
+    if (msg.type === 'claim') {
+      // We were here first and are still using this id. Say so, addressed to
+      // the claimant so no OTHER holder mistakes this for a verdict on itself.
+      post('held', msg.instance)
+      return
+    }
+    // msg.type === 'held'. Only the tab that asked may act on the answer.
+    // Ignoring the rest is what keeps the incumbent's id stable when two or
+    // more duplicates race: each duplicate re-mints in response to its own
+    // claim, and the tab that claimed X before any of them existed never sees
+    // an answer addressed to itself.
+    if (msg.replyTo !== instance)
+      return
+    // Someone else already owns this id, so we are the duplicate. Re-mint and
+    // claim the new one.
+    const previous = clientId()
+    const replacement = mintClientId()
+    setClientId(replacement)
+    log.warn('client id collided with a live tab (duplicated tab?); re-minted', { previous, replacement })
+    post('claim')
+  }
+
+  post('claim')
+
+  return {
+    clientId,
+    dispose: () => {
+      channel?.close()
+      channel = null
+    },
+  }
+}

--- a/frontend/src/lib/crdt/coalesce.test.ts
+++ b/frontend/src/lib/crdt/coalesce.test.ts
@@ -1,0 +1,296 @@
+import type { CrdtOp, OpBatch } from '~/generated/leapmux/v1/user_ops_pb'
+import { describe, expect, it } from 'vitest'
+import { coalesceQueuedBatches, REGISTER_POLICIES, registerKey, supersededParkedBatchIds } from './coalesce'
+
+function setFwOpacity(opId: string, windowId: string, opacity: number): CrdtOp {
+  return {
+    opId,
+    body: { case: 'setFloatingWindowRegister', value: { windowId, field: { case: 'opacity', value: opacity } } },
+  } as unknown as CrdtOp
+}
+
+function setFwX(opId: string, windowId: string, x: number): CrdtOp {
+  return {
+    opId,
+    body: { case: 'setFloatingWindowRegister', value: { windowId, field: { case: 'x', value: x } } },
+  } as unknown as CrdtOp
+}
+
+function setFwRootNode(opId: string, windowId: string, rootNodeId: string): CrdtOp {
+  return {
+    opId,
+    body: { case: 'setFloatingWindowRegister', value: { windowId, field: { case: 'rootNodeId', value: rootNodeId } } },
+  } as unknown as CrdtOp
+}
+
+function setFwWorkspace(opId: string, windowId: string, workspaceId: string): CrdtOp {
+  return {
+    opId,
+    body: { case: 'setFloatingWindowRegister', value: { windowId, field: { case: 'workspaceId', value: workspaceId } } },
+  } as unknown as CrdtOp
+}
+
+function setTabTile(opId: string, tabId: string, tileId: string): CrdtOp {
+  return {
+    opId,
+    body: { case: 'setTabRegister', value: { tabId, tabType: 1, field: { case: 'tileId', value: tileId } } },
+  } as unknown as CrdtOp
+}
+
+function tombstoneFw(opId: string, windowId: string): CrdtOp {
+  return {
+    opId,
+    body: { case: 'tombstoneFloatingWindow', value: { windowId } },
+  } as unknown as CrdtOp
+}
+
+function batch(batchId: string, ops: CrdtOp[]): OpBatch {
+  return { batchId, ops } as unknown as OpBatch
+}
+
+function opIds(batches: OpBatch[]): string[] {
+  return batches.flatMap(b => b.ops.map(o => o.opId))
+}
+
+describe('registerKey', () => {
+  it('separates fields of the same entity', () => {
+    expect(registerKey(setFwX('a', 'w1', 1))).not.toBe(registerKey(setFwOpacity('b', 'w1', 0.5)))
+  })
+
+  it('separates the same field of different entities', () => {
+    expect(registerKey(setFwOpacity('a', 'w1', 0.5))).not.toBe(registerKey(setFwOpacity('b', 'w2', 0.5)))
+  })
+
+  it('matches the same field of the same entity', () => {
+    expect(registerKey(setFwOpacity('a', 'w1', 0.5))).toBe(registerKey(setFwOpacity('b', 'w1', 0.9)))
+  })
+
+  it('returns null for a tombstone', () => {
+    expect(registerKey(tombstoneFw('a', 'w1'))).toBeNull()
+  })
+
+  it('returns null for set-once and creation-completeness fields', () => {
+    // These are what make "a creation is just register sets" true in this CRDT,
+    // so the allowlist has to name them out rather than infer them.
+    expect(registerKey(setFwRootNode('a', 'w1', 'n1'))).toBeNull()
+    expect(registerKey(setFwWorkspace('a', 'w1', 'ws1'))).toBeNull()
+  })
+})
+
+describe('coalesceQueuedBatches', () => {
+  it('keeps only the last write to a register', () => {
+    const result = coalesceQueuedBatches([
+      batch('b1', [setFwOpacity('o1', 'w1', 0.9)]),
+      batch('b2', [setFwOpacity('o2', 'w1', 0.8)]),
+      batch('b3', [setFwOpacity('o3', 'w1', 0.7)]),
+    ])
+    expect(opIds(result.batches)).toEqual(['o3'])
+    expect(result.droppedBatchIds).toEqual(['b1', 'b2'])
+    expect(result.droppedOps).toBe(2)
+  })
+
+  it('keeps writes to different registers of the same entity', () => {
+    const result = coalesceQueuedBatches([
+      batch('b1', [setFwX('o1', 'w1', 1), setFwOpacity('o2', 'w1', 0.5)]),
+    ])
+    expect(opIds(result.batches)).toEqual(['o1', 'o2'])
+    expect(result.droppedOps).toBe(0)
+  })
+
+  it('keeps writes to the same register of different entities', () => {
+    const result = coalesceQueuedBatches([
+      batch('b1', [setFwOpacity('o1', 'w1', 0.5)]),
+      batch('b2', [setFwOpacity('o2', 'w2', 0.5)]),
+    ])
+    expect(opIds(result.batches)).toEqual(['o1', 'o2'])
+    expect(result.droppedBatchIds).toEqual([])
+  })
+
+  it('never trims a batch: a partially superseded batch is sent INTACT', () => {
+    // The hub validates a batch as a unit -- a record must be COMPLETE when its
+    // creation batch commits -- so removing one op from a batch is how a new
+    // window or tile split gets rejected wholesale. Not trimming makes that
+    // unreachable without the client re-deriving the server's completeness
+    // rules.
+    const result = coalesceQueuedBatches([
+      batch('b1', [setFwX('o1', 'w1', 1), setFwOpacity('o2', 'w1', 0.5)]),
+      batch('b2', [setFwOpacity('o3', 'w1', 0.9)]),
+    ])
+    // o2 IS superseded by o3, but o1 is not, so b1 goes out whole.
+    expect(opIds(result.batches)).toEqual(['o1', 'o2', 'o3'])
+    expect(result.droppedBatchIds).toEqual([])
+    expect(result.droppedOps).toBe(0)
+  })
+
+  // The reason rule 2 is an allowlist and not "register sets are safe".
+  it('never drops a creation batch, whose ops are all register sets', () => {
+    // A floating window is CREATED by writing root_node_id, workspace_id and
+    // its geometry. A rule phrased as "creations are excluded, register sets
+    // are eligible" would exclude nothing here, and dropping this batch would
+    // lose the window entirely.
+    const creation = batch('create', [
+      setFwRootNode('c1', 'w1', 'n1'),
+      setFwWorkspace('c2', 'w1', 'ws1'),
+      setFwX('c3', 'w1', 0.1),
+      setFwOpacity('c4', 'w1', 1),
+    ])
+    const result = coalesceQueuedBatches([
+      creation,
+      // A later gesture rewrites every geometry register the creation set.
+      batch('drag', [setFwX('d1', 'w1', 0.5), setFwOpacity('d2', 'w1', 0.4)]),
+    ])
+    expect(result.droppedBatchIds).toEqual([])
+    expect(result.batches).toHaveLength(2)
+  })
+
+  it('does not treat a set-once field as supersedable', () => {
+    // root_node_id is write-once, so a later write does not supersede an
+    // earlier one and the earlier op is not redundant.
+    const result = coalesceQueuedBatches([
+      batch('b1', [setFwRootNode('o1', 'w1', 'n1')]),
+      batch('b2', [setFwRootNode('o2', 'w1', 'n2')]),
+    ])
+    expect(result.droppedBatchIds).toEqual([])
+  })
+
+  it('is a no-op on an empty queue', () => {
+    const result = coalesceQueuedBatches([])
+    expect(result.batches).toEqual([])
+    expect(result.droppedBatchIds).toEqual([])
+    expect(result.droppedOps).toBe(0)
+  })
+
+  it('returns the ORIGINAL batch object when nothing was trimmed', () => {
+    // Identity matters: the retry paths re-queue these objects, and a needless
+    // copy would break the batchId-keyed retry bookkeeping's assumptions about
+    // what it is holding.
+    const b1 = batch('b1', [setFwX('o1', 'w1', 1)])
+    const result = coalesceQueuedBatches([b1])
+    expect(result.batches[0]).toBe(b1)
+  })
+
+  // A 60-frame drag scrub is the case this exists for.
+  it('collapses a gesture-shaped burst to one op per register', () => {
+    const queued = Array.from({ length: 60 }, (_, i) => batch(`b${i}`, [setFwX(`o${i}`, 'w1', i)]))
+    const result = coalesceQueuedBatches(queued)
+    expect(opIds(result.batches)).toEqual(['o59'])
+    expect(result.droppedBatchIds).toHaveLength(59)
+  })
+})
+
+describe('supersededParkedBatchIds', () => {
+  it('reports a parked batch whose register a newer write rewrites', () => {
+    // The hazard: the parked batch left the queue on a transport failure, so
+    // the hub never saw it and dedup will not apply. Its retry would commit
+    // with a FRESH canonical HLC -- newer than the write below -- and the stale
+    // value would win LWW on the hub and every peer.
+    const parked = [batch('parked', [setFwX('p1', 'w1', 0.1)])]
+    const outgoing = [batch('now', [setFwX('o1', 'w1', 0.9)])]
+    expect(supersededParkedBatchIds(parked, outgoing)).toEqual(['parked'])
+  })
+
+  it('leaves a parked batch alone when the newer write touches another register', () => {
+    const parked = [batch('parked', [setFwX('p1', 'w1', 0.1)])]
+    const outgoing = [batch('now', [setFwOpacity('o1', 'w1', 0.5)])]
+    expect(supersededParkedBatchIds(parked, outgoing)).toEqual([])
+  })
+
+  it('leaves a parked batch alone when the newer write targets another window', () => {
+    const parked = [batch('parked', [setFwX('p1', 'w1', 0.1)])]
+    const outgoing = [batch('now', [setFwX('o1', 'w2', 0.9)])]
+    expect(supersededParkedBatchIds(parked, outgoing)).toEqual([])
+  })
+
+  it('requires EVERY op to be superseded, not just some', () => {
+    // A partially-superseded parked batch still carries a write nothing else
+    // will make, so cancelling it would lose that edit outright.
+    const parked = [batch('parked', [setFwX('p1', 'w1', 0.1), setFwOpacity('p2', 'w1', 0.3)])]
+    const outgoing = [batch('now', [setFwX('o1', 'w1', 0.9)])]
+    expect(supersededParkedBatchIds(parked, outgoing)).toEqual([])
+  })
+
+  it('never cancels a parked creation batch', () => {
+    const parked = [batch('create', [setFwRootNode('c1', 'w1', 'n1'), setFwX('c2', 'w1', 0.1)])]
+    const outgoing = [batch('now', [setFwX('o1', 'w1', 0.9)])]
+    expect(supersededParkedBatchIds(parked, outgoing)).toEqual([])
+  })
+
+  it('is a no-op when nothing is going out', () => {
+    const parked = [batch('parked', [setFwX('p1', 'w1', 0.1)])]
+    expect(supersededParkedBatchIds(parked, [])).toEqual([])
+  })
+
+  // The move registers are EXCLUDED from the coalescing table (dropping an
+  // intermediate move loses it), but they are plain LWW on the hub, and the hub
+  // re-stamps canonical_hlc on a parked retry. So a stale parked move commits
+  // NEWER than the move that replaced it and wins -- the one case where
+  // cancelling is not an optimization but the thing that stops a user's move
+  // from being silently undone. Keyed on the LWW-mutable table, not the
+  // coalescable one.
+  it('cancels a parked tile move superseded by a newer move of the same tab', () => {
+    const parked = [batch('parked', [setTabTile('p1', 't1', 'tile-old')])]
+    const outgoing = [batch('now', [setTabTile('o1', 't1', 'tile-new')])]
+    expect(supersededParkedBatchIds(parked, outgoing)).toEqual(['parked'])
+  })
+
+  it('cancels a parked window workspace move superseded by a newer one', () => {
+    const parked = [batch('parked', [setFwWorkspace('p1', 'w1', 'ws-old')])]
+    const outgoing = [batch('now', [setFwWorkspace('o1', 'w1', 'ws-new')])]
+    expect(supersededParkedBatchIds(parked, outgoing)).toEqual(['parked'])
+  })
+
+  it('still refuses to cancel a set-once register', () => {
+    // rootNodeId is set-once on the hub, so a later write does NOT supersede the
+    // parked one -- the parked write is the only one that will ever land.
+    const parked = [batch('parked', [setFwRootNode('p1', 'w1', 'n1')])]
+    const outgoing = [batch('now', [setFwRootNode('o1', 'w1', 'n2')])]
+    expect(supersededParkedBatchIds(parked, outgoing)).toEqual([])
+  })
+
+  it('does not widen coalesceQueuedBatches to the move registers', () => {
+    // Same two ops, but through the flush-time coalescer: dropping an
+    // intermediate move on the wire is still a lost move, so both batches ship.
+    const result = coalesceQueuedBatches([
+      batch('b1', [setTabTile('a', 't1', 'tile-old')]),
+      batch('b2', [setTabTile('b', 't1', 'tile-new')]),
+    ])
+    expect(result.droppedBatchIds).toEqual([])
+    expect(result.batches).toHaveLength(2)
+  })
+})
+
+// The two questions this module answers are related, and the relation is a
+// SAFETY property: anything droppable must also be supersedable. When they were
+// two boolean tables the relation was maintained by eye -- `Record<FieldCase>`
+// forced both entries to exist but never to agree -- and the illegal pairing is
+// the dangerous one: a SET_ONCE register marked coalescable drops a write the
+// hub accepts only once, which is precisely what excluding parentId/rootNodeId
+// is for. The enum makes that pairing unspellable; this pins that it stays so.
+describe('register policies', () => {
+  const every = Object.values(REGISTER_POLICIES).flatMap(table => Object.entries(table))
+
+  it('covers a field in every kind', () => {
+    expect(every.length).toBeGreaterThan(0)
+  })
+
+  it('never marks a set-once register coalescable', () => {
+    const offenders = every.filter(([, policy]) => policy === 'SET_ONCE' && isCoalescableForTest(policy))
+    expect(offenders).toEqual([])
+  })
+
+  it('makes everything coalescable also LWW-mutable', () => {
+    const offenders = every.filter(([field, policy]) =>
+      isCoalescableForTest(policy) && !isLwwMutableForTest(policy) ? field : null,
+    )
+    expect(offenders).toEqual([])
+  })
+})
+
+// Mirrors of the module-private predicates, kept as literal comparisons so the
+// assertions above cannot be satisfied by the same bug in a shared helper.
+function isCoalescableForTest(policy: string): boolean {
+  return policy === 'LWW_COALESCABLE'
+}
+function isLwwMutableForTest(policy: string): boolean {
+  return policy !== 'SET_ONCE'
+}

--- a/frontend/src/lib/crdt/coalesce.ts
+++ b/frontend/src/lib/crdt/coalesce.ts
@@ -1,0 +1,346 @@
+import type {
+  CrdtOp,
+  OpBatch,
+  SetFloatingWindowRegisterOp,
+  SetNodeRegisterOp,
+  SetTabRegisterOp,
+} from '~/generated/leapmux/v1/user_ops_pb'
+
+// ---------------------------------------------------------------------------
+// Last-writer-wins coalescing of queued ops
+//
+// High-frequency gestures (drag, resize, opacity scrub, tile-ratio drag) emit
+// the SAME register over and over. Every one of those writes is an LWW register
+// set, so within a group of ops about to be sent together, only the LAST write
+// to a given register can survive the merge -- on this client, on the hub, and
+// on every peer. The earlier ones are pure wire, storage and fan-out cost.
+//
+// This does NOT replace the gesture overrides in the floating-window and tiling
+// stores: an override suppresses ops for a whole GESTURE, while this merges only
+// what lands in one flush window, so a gesture emitting per frame still costs
+// ~1 op per flush rather than 1 per gesture. What it buys is that the next
+// high-frequency register is cheap by default instead of needing a fourth
+// bespoke override.
+//
+// TWO RULES KEEP IT SAFE. Both are deliberately conservative, because the cost
+// of being wrong is a rejected batch, and the upside is only saved bandwidth.
+//
+//  1. WHOLE BATCHES ONLY -- a batch is either sent intact or dropped intact,
+//     never trimmed. The hub validates a batch as a unit: a record must be
+//     COMPLETE when its creation batch commits (BATCH_REJECTION_INCOMPLETE_RECORD),
+//     so removing one op from a batch that creates an entity makes the hub reject
+//     the whole thing and the user's new window or tile split silently reverts.
+//     Not trimming makes that unreachable without the client having to model the
+//     server's completeness rules -- which would be a second source of truth for
+//     an invariant the validator already owns.
+//
+//  2. ONLY EXPLICITLY COALESCABLE FIELDS COUNT (see COALESCABLE_FIELDS). It is
+//     tempting to phrase this as "register sets are safe, creations are not",
+//     but in this CRDT a creation IS a set of register sets: a floating window is
+//     created by writing root_node_id, workspace_id, x, y, width, height and
+//     opacity, and a node by writing kind, parent_id and position. A rule keyed on
+//     "is this a register op" would therefore exclude nothing at all. Some of
+//     those fields are also set-once (parent_id, root_node_id) and so are not
+//     LWW-redundant in the first place. An allowlist of the mutable, genuinely
+//     high-frequency fields is the honest shape.
+//
+// Together the rules mean a creation batch can never be dropped: it always
+// carries at least one op outside the allowlist, so it is never fully
+// superseded.
+//
+// The dropped ops never reach the hub, so they never enter its journal, and the
+// client's own op-log records CONFIRMED frames (what the hub committed) rather
+// than pending ops -- so delta-resume replay sees the same history either way.
+//
+// ONE BEHAVIOUR DIFFERENCE, stated precisely because the earlier draft of this
+// comment overclaimed: dropping is equivalent to the un-coalesced stream when
+// the surviving batch COMMITS. If the surviving batch is instead rejected while
+// an earlier one commits, the register settles at its pre-gesture value rather
+// than at the dropped intermediate value. Both are states the hub actually
+// holds, and for a gesture the all-or-nothing outcome is the better of the two,
+// but it is not literally "as if nothing were dropped".
+// ---------------------------------------------------------------------------
+
+/**
+ * The oneof case union of an op's `field`, from the GENERATED type.
+ *
+ * Keying the policy tables on this rather than a `Set<string>` is load-bearing,
+ * not stylistic: a string set infers `Set<string>`, so `'positon'` type-checks
+ * and a typo or proto rename silently disables coalescing with no compile error
+ * and no failing test -- exactly the wrong default for a module whose stated
+ * purpose is that the next high-frequency register is cheap BY DEFAULT.
+ */
+type FieldCase<T extends { field: { case?: string } }> = Exclude<T['field']['case'], undefined>
+
+/**
+ * What the hub's register semantics make TRUE of one field, in one value.
+ *
+ * There used to be two boolean tables per op kind -- `*_COALESCABLE` and
+ * `*_LWW_MUTABLE` -- declared ~60 lines apart over the identical field set, and
+ * the safety relation between them (`coalescable` implies `lwwMutable`) was
+ * maintained purely by eye. `Record<FieldCase<...>, boolean>` forces both
+ * entries to be PRESENT; nothing forced them to be CONSISTENT, and the illegal
+ * combination is the dangerous one: marking a SET-ONCE register coalescable
+ * silently drops a write the hub would only ever accept once -- exactly the
+ * loss `parentId` / `rootNodeId` are excluded to prevent.
+ *
+ * Three states, and the fourth is unrepresentable rather than merely absent:
+ *
+ *   - SET_ONCE           the hub writes the slot only while empty, so a later
+ *                        write cannot supersede an earlier one. Never
+ *                        coalescable (dropping it drops a write that must
+ *                        land), never LWW-mutable.
+ *   - LWW_NOT_COALESCED  plain LWW on the hub, so a later write DOES supersede
+ *                        it -- but dropping an intermediate is not lossless
+ *                        (a move), or simply has not been enabled yet.
+ *   - LWW_COALESCABLE    plain LWW, and an intermediate write carries no
+ *                        information the next one does not.
+ *
+ * `tsc` still reports a rename as TS2561 and a NEW field as TS2739, so adding a
+ * register forces an explicit policy rather than an accidental opt-out.
+ */
+type RegisterPolicy = 'SET_ONCE' | 'LWW_NOT_COALESCED' | 'LWW_COALESCABLE'
+
+/** "Is dropping an intermediate write to this register lossless?" — bandwidth. */
+function isCoalescable(policy: RegisterPolicy): boolean {
+  return policy === 'LWW_COALESCABLE'
+}
+
+/**
+ * "Does a LATER write to this register supersede this one?" — ORDERING, and a
+ * strictly wider set than the above. Reusing the bandwidth answer here left
+ * every excluded-but-LWW register unprotected, which is backwards: those are
+ * exactly the moves whose inversion is permanent. The hub re-stamps
+ * canonical_hlc on a retry (Manager.commit ticks the clock after a dedup MISS),
+ * so a parked `tileId` write lands with a FRESHER HLC than the newer move that
+ * superseded it and wins LWW on every peer. Cancelling it is not an
+ * optimization; it keeps the move the user actually made from being undone
+ * minutes later.
+ *
+ * That `isCoalescable` implies `isLwwMutable` is now a property of the enum --
+ * only SET_ONCE is excluded here, and SET_ONCE is never coalescable -- rather
+ * than an invariant across two tables that nothing checked.
+ */
+function isLwwMutable(policy: RegisterPolicy): boolean {
+  return policy !== 'SET_ONCE'
+}
+
+const NODE_POLICY: Record<FieldCase<SetNodeRegisterOp>, RegisterPolicy> = {
+  position: 'LWW_COALESCABLE',
+  ratios: 'LWW_COALESCABLE',
+  kind: 'LWW_NOT_COALESCED',
+  direction: 'LWW_NOT_COALESCED',
+  rows: 'LWW_NOT_COALESCED',
+  cols: 'LWW_NOT_COALESCED',
+  // Grid row/column ratios are dragged exactly like `ratios` and are the obvious
+  // next candidates, but enabling them CHANGES what goes on the wire, so they
+  // stay LWW_NOT_COALESCED until that is deliberately chosen.
+  rowRatios: 'LWW_NOT_COALESCED',
+  colRatios: 'LWW_NOT_COALESCED',
+  // Set-once on the hub: written only while the slot is empty.
+  parentId: 'SET_ONCE',
+}
+
+const TAB_POLICY: Record<FieldCase<SetTabRegisterOp>, RegisterPolicy> = {
+  position: 'LWW_COALESCABLE',
+  // A MOVE, not a redundant write: dropping an intermediate loses the move
+  // outright. See supersededParkedBatchIds for why that matters on retry.
+  tileId: 'LWW_NOT_COALESCED',
+  workerId: 'LWW_NOT_COALESCED',
+  displayMode: 'LWW_NOT_COALESCED',
+  fileViewMode: 'LWW_NOT_COALESCED',
+  fileDiffBase: 'LWW_NOT_COALESCED',
+}
+
+const FLOATING_WINDOW_POLICY: Record<FieldCase<SetFloatingWindowRegisterOp>, RegisterPolicy> = {
+  x: 'LWW_COALESCABLE',
+  y: 'LWW_COALESCABLE',
+  width: 'LWW_COALESCABLE',
+  height: 'LWW_COALESCABLE',
+  opacity: 'LWW_COALESCABLE',
+  // Also a move between workspaces, not a redundant write.
+  workspaceId: 'LWW_NOT_COALESCED',
+  // Set-once on the hub.
+  rootNodeId: 'SET_ONCE',
+}
+
+/**
+ * The policy tables, exported for the co-located suite ONLY so it can assert
+ * the relation between the two questions across every field at once. Nothing
+ * else imports them; the two key functions are the public surface.
+ */
+export const REGISTER_POLICIES = { node: NODE_POLICY, tab: TAB_POLICY, fw: FLOATING_WINDOW_POLICY } as const
+
+/**
+ * Identify the LWW register an op writes, as a stable string key, or null when
+ * the op is not an eligible coalescing target (see COALESCABLE_FIELDS).
+ *
+ * The key includes the entity identity AND the field, so two ops touching
+ * different fields of one entity never coalesce with each other.
+ */
+export function registerKey(op: CrdtOp): string | null {
+  return registerKeyIn(op, isCoalescable)
+}
+
+/**
+ * Same key, but keyed on the LWW-MUTABLE tables: "a later write to this register
+ * supersedes this one", regardless of whether dropping it would be lossless.
+ * See the comment above the tables for why the two questions need two answers.
+ */
+export function lwwRegisterKey(op: CrdtOp): string | null {
+  return registerKeyIn(op, isLwwMutable)
+}
+
+/**
+ * `admits` selects WHICH question is being asked of each field's policy. One
+ * predicate argument, not three positionally-interchangeable tables: the old
+ * signature took `(op, nodeTable, tabTable, floatingWindowTable)`, all typed
+ * `Record<string, boolean>`, so transposing two of them compiled cleanly and
+ * silently swapped the bandwidth rule for the ordering rule.
+ */
+function registerKeyIn(op: CrdtOp, admits: (policy: RegisterPolicy) => boolean): string | null {
+  const body = op.body
+  switch (body.case) {
+    case 'setNodeRegister':
+      return policyKey(NODE_POLICY, admits, body.value.field.case, `node:${body.value.nodeId}`)
+    case 'setTabRegister':
+      return policyKey(TAB_POLICY, admits, body.value.field.case, `tab:${body.value.tabType}:${body.value.tabId}`)
+    case 'setFloatingWindowRegister':
+      return policyKey(FLOATING_WINDOW_POLICY, admits, body.value.field.case, `fw:${body.value.windowId}`)
+    default:
+      // Tombstones and workspace wiring are never LWW-redundant.
+      return null
+  }
+}
+
+/**
+ * The one policy-lookup + key-format rule the three op kinds share. They differ
+ * ONLY in their table and in how their identity spells itself, so the caller
+ * pre-formats the entity part and this owns the rest.
+ *
+ * The key format is free to change: it never leaves the process and is only
+ * ever compared to other keys, never to a literal.
+ */
+function policyKey(
+  table: Record<string, RegisterPolicy>,
+  admits: (policy: RegisterPolicy) => boolean,
+  field: string | undefined,
+  entity: string,
+): string | null {
+  if (!field)
+    return null
+  const policy = table[field]
+  return policy && admits(policy) ? `${entity}:${field}` : null
+}
+
+/**
+ * Of the batches PARKED in a retry backoff, which are fully superseded by the
+ * batches about to be sent.
+ *
+ * A parked batch is invisible to the flush queue, and that is a hazard on its
+ * own: it left the queue on a transport failure, so the hub never saw it, so
+ * dedup will not apply when its timer fires. It is then committed with a FRESH
+ * canonical HLC -- newer than the write that superseded it in the meantime --
+ * and the stale value wins LWW on the hub and every peer. A drag that hit one
+ * dropped request lands the window back at a mid-gesture position, permanently.
+ *
+ * A parked batch is strictly OLDER than this flush, so an outgoing op on the
+ * same register supersedes it. Cancelling is only sound when EVERY op is
+ * superseded (a partially-superseded batch still carries writes nothing else
+ * will make), which the whole-batch rule already guarantees.
+ *
+ * Keyed on lwwRegisterKey, NOT registerKey: this is an ordering question, and
+ * the move-defining registers the coalescing table excludes are precisely the
+ * ones whose inversion is permanent. See the LWW-MUTABLE tables above.
+ */
+export function supersededParkedBatchIds(parked: Iterable<OpBatch>, outgoing: OpBatch[]): string[] {
+  const outgoingKeys = new Set<string>()
+  for (const batch of outgoing) {
+    for (const op of batch.ops) {
+      const key = lwwRegisterKey(op)
+      if (key !== null)
+        outgoingKeys.add(key)
+    }
+  }
+  if (outgoingKeys.size === 0)
+    return []
+  const out: string[] = []
+  for (const batch of parked) {
+    if (batchFullySuperseded(batch, lwwRegisterKey, key => outgoingKeys.has(key)))
+      out.push(batch.batchId)
+  }
+  return out
+}
+
+/**
+ * Whether EVERY op in `batch` writes a coalescable register that `isSuperseded`
+ * says something later already rewrote.
+ *
+ * This is rule 1 from the module header — whole batches only — and it lives in
+ * one place because it is the safety property, not a convenience: a batch is
+ * dropped intact or kept intact, never trimmed, so the hub's
+ * record-completeness validation cannot be broken by a partial drop. Both
+ * callers apply the identical rule and differ ONLY in which register table they
+ * key on (coalescable vs LWW-mutable) and in what counts as superseded (a later
+ * batch index vs membership in the outgoing key set).
+ *
+ * An EMPTY batch is never superseded: `every` is vacuously true on it, which
+ * would drop a batch carrying no ops at all rather than passing it through.
+ */
+function batchFullySuperseded(
+  batch: OpBatch,
+  keyOf: (op: CrdtOp) => string | null,
+  isSuperseded: (key: string) => boolean,
+): boolean {
+  return batch.ops.length > 0 && batch.ops.every((op) => {
+    const key = keyOf(op)
+    return key !== null && isSuperseded(key)
+  })
+}
+
+export interface CoalesceResult {
+  /** The batches to send, in the original order, each intact. */
+  batches: OpBatch[]
+  /**
+   * Batch ids dropped entirely and not being sent. The caller MUST drop each
+   * one's pending entry: no BatchResult will ever arrive for a batch the hub
+   * never saw, so the optimistic overlay would otherwise wait on it forever.
+   */
+  droppedBatchIds: string[]
+  /** How many ops were removed, for diagnostics. */
+  droppedOps: number
+}
+
+/**
+ * Drop batches whose every op is overwritten by a later op in the same flush.
+ *
+ * Order is preserved and nothing is rewritten: a batch is passed through by
+ * reference or omitted. A batch survives unless ALL of its ops are coalescable
+ * (rule 2) and each is superseded by a later op writing the same register.
+ */
+export function coalesceQueuedBatches(batches: OpBatch[]): CoalesceResult {
+  // Last position of each register key across the whole flush. Positions are
+  // batch indices: an op is superseded only by an op in a LATER batch, since
+  // within one batch every op is kept or dropped together.
+  const lastBatchFor = new Map<string, number>()
+  batches.forEach((batch, i) => {
+    for (const op of batch.ops) {
+      const key = registerKey(op)
+      if (key !== null)
+        lastBatchFor.set(key, i)
+    }
+  })
+
+  const out: OpBatch[] = []
+  const droppedBatchIds: string[] = []
+  let droppedOps = 0
+  batches.forEach((batch, i) => {
+    if (batchFullySuperseded(batch, registerKey, key => lastBatchFor.get(key) !== i)) {
+      droppedBatchIds.push(batch.batchId)
+      droppedOps += batch.ops.length
+      return
+    }
+    out.push(batch)
+  })
+  return { batches: out, droppedBatchIds, droppedOps }
+}

--- a/frontend/src/lib/crdt/hlc.test.ts
+++ b/frontend/src/lib/crdt/hlc.test.ts
@@ -1,7 +1,10 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { create } from '@bufbuild/protobuf'
 import { describe, expect, it } from 'vitest'
 import { HLCSchema } from '~/generated/leapmux/v1/user_crdt_pb'
-import { HLCClock, hlcCmp, hlcIsZero } from './hlc'
+import { formatHlcWire, HLCClock, hlcCmp, hlcIsZero, parseHlcWire } from './hlc'
 
 function hlc(physical: bigint, logical: bigint, clientId: string) {
   return create(HLCSchema, { physical, logical, clientId })
@@ -43,7 +46,7 @@ describe('hlcIsZero', () => {
   })
 })
 
-describe('hLCClock', () => {
+describe('class HLCClock', () => {
   it('tick produces strictly increasing HLCs (logical bumps within same physical)', () => {
     const c = new HLCClock('client-1')
     const a = c.tick(100)
@@ -68,4 +71,97 @@ describe('hLCClock', () => {
     expect(next.physical).toBe(500n)
     expect(next.logical).toBe(8n)
   })
+})
+
+describe('formatHlcWire / parseHlcWire', () => {
+  // The load-bearing property is that parseHlcWire mirrors the Go
+  // channelwire.DecodeResumeHLC rules EXACTLY. The round-trip cursor
+  // validation at useUserEvents (`parseHlcWire(formatHlcWire(sourceHlc))`)
+  // exists to drop a malformed persisted value before it reaches the hub as a
+  // 400 the browser surfaces as a non-terminal 1006 close (→ infinite
+  // reconnect storm). If TS accepts a value the Go decoder rejects, the guard
+  // is bypassed and the storm returns. These cases pin every Go rejection rule
+  // the prior TS parser was missing (logical sign, clientId length, int64
+  // range) plus the empty-segment guard.
+  it('round-trips a well-formed HLC', () => {
+    const original = hlc(1754100000000n, 42n, 'c-abc')
+    const wire = formatHlcWire(original)
+    expect(wire).toBe('1754100000000.42.c-abc')
+    const parsed = parseHlcWire(wire)
+    expect(parsed).toBeDefined()
+    expect(parsed!.physical).toBe(1754100000000n)
+    expect(parsed!.logical).toBe(42n)
+    expect(parsed!.clientId).toBe('c-abc')
+  })
+
+  it('formatHlcWire accepts the minimal structural shape (no proto $typeName)', () => {
+    // The desktop bridge holds only {physical, logical, clientId}; the helper
+    // must not require the full proto HLC type.
+    const wire = formatHlcWire({ physical: 5n, logical: 1n, clientId: 'c' })
+    expect(wire).toBe('5.1.c')
+  })
+
+  it('parseHlcWire rejects a negative logical (mirrors Go logical < 0)', () => {
+    // Pre-fix this passed TS validation and was rejected by the hub → storm.
+    expect(parseHlcWire('100.-5.c')).toBeUndefined()
+  })
+
+  it('parseHlcWire rejects a clientId longer than 128 chars (mirrors Go bound)', () => {
+    expect(parseHlcWire(`100.0.${'x'.repeat(129)}`)).toBeUndefined()
+    // 128 is the boundary: accepted.
+    expect(parseHlcWire(`100.0.${'x'.repeat(128)}`)).toBeDefined()
+  })
+
+  it('parseHlcWire rejects physical/logical outside int64 range (mirrors Go ParseInt)', () => {
+    // BigInt is unbounded; Go's strconv.ParseInt(..., 10, 64) overflows.
+    const over = 2n ** 63n // int64 max + 1
+    expect(parseHlcWire(`${over}.0.c`)).toBeUndefined()
+    expect(parseHlcWire(`100.${over}.c`)).toBeUndefined()
+  })
+
+  it('parseHlcWire rejects an empty logical segment ("100..c")', () => {
+    // Pins the fixed d2 guard: previously d2<=0 was dead code (absolute index)
+    // and this was saved only by BigInt("") throwing.
+    expect(parseHlcWire('100..c')).toBeUndefined()
+  })
+
+  it('parseHlcWire never throws on garbage (corrupted persisted value)', () => {
+    // A corrupted persisted watermark must degrade to undefined, not throw out
+    // of the socket-open effect.
+    expect(() => parseHlcWire('not.an.hlc.at.all')).not.toThrow()
+    expect(() => parseHlcWire('abc.def')).not.toThrow()
+    expect(() => parseHlcWire('')).not.toThrow()
+    expect(parseHlcWire('garbage')).toBeUndefined()
+  })
+})
+
+// Cross-language conformance corpus: parseHlcWire must agree with the Go hub's
+// channelwire.DecodeResumeHLC on every case in testdata/hlc_wire_corpus.json.
+// Both decoders parse the SAME resume-cursor wire format, and the client
+// pre-validates a persisted cursor before sending so a value the hub would 400
+// never leaves the browser (otherwise: non-terminal 1006 close → tight reconnect
+// loop). A rule added/tightened on one side but not the other reddens CI here
+// (and in backend/channelwire/wire_test.go) instead of drifting back into that
+// storm. Mirrors the cross-language pattern channel.wire-limits.test.ts uses.
+describe('parseHlcWire cross-language corpus', () => {
+  const data = JSON.parse(
+    readFileSync(
+      resolve(dirname(fileURLToPath(import.meta.url)), '../../../../testdata/hlc_wire_corpus.json'),
+      'utf8',
+    ),
+  ) as { cases: Array<{ raw: string, ok: boolean, physical?: string, logical?: string, clientId?: string }> }
+
+  for (const c of data.cases) {
+    it(`parses ${JSON.stringify(c.raw)} -> ${c.ok ? 'ok' : 'reject'}`, () => {
+      const got = parseHlcWire(c.raw)
+      if (!c.ok) {
+        expect(got).toBeUndefined()
+        return
+      }
+      expect(got).toBeDefined()
+      expect(got!.physical).toBe(BigInt(c.physical!))
+      expect(got!.logical).toBe(BigInt(c.logical!))
+      expect(got!.clientId).toBe(c.clientId)
+    })
+  }
 })

--- a/frontend/src/lib/crdt/hlc.ts
+++ b/frontend/src/lib/crdt/hlc.ts
@@ -32,11 +32,173 @@ export function hlcIsZero(h: HLC | undefined | null): boolean {
   return h.physical === 0n && h.logical === 0n && h.clientId === ''
 }
 
-/** Deep-clone an HLC. */
-export function hlcClone(h: HLC | undefined | null): HLC | undefined {
+/**
+ * Structural HLC shape — accepts a plain object without the proto `$typeName`
+ * brand. Used by callers that hold only the three wire fields (e.g. a
+ * checkpoint watermark deserialized from IDB structured clone, which never
+ * carries the proto brand). Equivalent to the structural shape `formatHlcWire`
+ * already accepts. The proto `HLC` type satisfies this shape structurally, so
+ * `HlcShape` is the canonical parameter type for HLC helpers that don't need
+ * the brand (hlcClone, formatHlcWire).
+ */
+export interface HlcShape { physical: bigint, logical: bigint, clientId: string }
+
+/**
+ * Deep-clone an HLC. Accepts the structural `HlcShape` (which the proto `HLC`
+ * satisfies), so callers holding either a branded proto HLC or a plain object
+ * literal (e.g. a checkpoint watermark from IDB structured clone) share one
+ * clone path.
+ */
+export function hlcClone(h: HlcShape | undefined | null): HLC | undefined {
   if (!h)
     return undefined
   return create(HLCSchema, { physical: h.physical, logical: h.logical, clientId: h.clientId })
+}
+
+/**
+ * Format an HLC as the "<physical>.<logical>.<client_id>" wire string the
+ * Go side parses (see channelwire.EncodeResumeHLC). The single canonical
+ * author of the resume_after_hlc query-param / sidecar-RPC shape — every TS
+ * callsite that puts an HLC on the wire goes through here so the format can't
+ * drift between the URL builder, the desktop bridge, and the persisted
+ * watermark.
+ *
+ * Accepts the minimal structural shape (not the full proto `HLC` type) so a
+ * callsite that holds only the three wire fields — e.g. the desktop bridge's
+ * Tauri-IPC payload, which never carries the proto `$typeName` — can format
+ * without an `as never` cast.
+ */
+export function formatHlcWire(hlc: { physical: bigint, logical: bigint, clientId: string }): string {
+  // Guard against a corrupted input whose clientId is undefined/null: the
+  // template literal would otherwise stringify it as the literal "undefined"
+  // / "null", which parseHlcWire accepts (non-empty, ≤128 chars) and the hub's
+  // DecodeResumeHLC mirrors — silently shipping a cursor with a bogus client_id
+  // that mis-filters the journal scan. proto3 normalizes an unset string to "",
+  // which parseHlcWire rejects, so this only fires for non-proto paths; treat
+  // it as a programmer error (throw) rather than silently degrading.
+  if (typeof hlc.clientId !== 'string')
+    throw new TypeError('formatHlcWire: clientId must be a string')
+  return `${hlc.physical}.${hlc.logical}.${hlc.clientId}`
+}
+
+/**
+ * Parse the "<physical>.<logical>.<client_id>" wire string back into an HLC.
+ * Returns undefined on any malformed shape (missing delimiters, non-numeric
+ * physical/logical, empty client id) — never throws — so a corrupted persisted
+ * value degrades to "no watermark" (a full-snapshot reconnect) rather than
+ * crashing the socket-open effect.
+ *
+ * Mirrors the Go `channelwire.DecodeResumeHLC` rules EXACTLY so the round-trip
+ * cursor validation at useUserEvents (`parseHlcWire(formatHlcWire(sourceHlc))`)
+ * drops anything the hub would reject — otherwise a corrupted persisted value
+ * passes client validation, the hub returns 400, the browser surfaces a
+ * non-terminal 1006 close, and the client reconnects in a tight loop (the
+ * exact storm the validation exists to prevent). The mirrored rules:
+ *   - physical/logical must be base-10 integers within int64 range (BigInt is
+ *     unbounded; Go's strconv.ParseInt(..., 10, 64) overflows and rejects);
+ *   - physical must be > 0 (matches Go's `physical <= 0` rejection);
+ *   - logical must be >= 0 (matches Go's `logical < 0` rejection);
+ *   - clientId must be non-empty and ≤ 128 BYTES under UTF-8 (matches Go's
+ *     `len(clientID) > 128`, which counts bytes -- NOT `.length`, which counts
+ *     UTF-16 code units and diverges for every non-ASCII id).
+ */
+export function parseHlcWire(raw: string): HLC | undefined {
+  // `indexOf` returns an absolute index. The first dot must be non-leading
+  // (a non-empty physical segment); the second dot must be STRICTLY after the
+  // first (a non-empty logical segment). d2 === d1 + 1 means an empty logical
+  // segment ("100..c") — reject it explicitly rather than relying on BigInt("")
+  // throwing, so the guard is not dead code checking the wrong condition.
+  const d1 = raw.indexOf('.')
+  if (d1 <= 0)
+    return undefined
+  const d2 = raw.indexOf('.', d1 + 1)
+  // d2 is an absolute index. No second dot → d2 === -1 → reject. Empty logical
+  // segment ("100..c") → d2 === d1 + 1 → reject explicitly, mirroring Go's
+  // relative `dot2 <= 0` check (Go slices raw[dot1+1:] first, so its `dot2`
+  // for an empty logical segment is 0). BigInt("") returns 0n (does not throw)
+  // in this engine, so without this guard the empty segment would silently
+  // parse as logical=0 — a value Go rejects, reopening the reconnect storm.
+  if (d2 < 0 || d2 <= d1 + 1)
+    return undefined
+  const physicalRaw = raw.slice(0, d1)
+  const logicalRaw = raw.slice(d1 + 1, d2)
+  // Mirror the STRICTNESS of the Go decoder, not just its range. BigInt is more
+  // permissive than the wire format in two ways: it accepts surrounding
+  // whitespace (" 123" → 123n) and a leading `+` ("+123" → 123n). Go's
+  // strconv.ParseInt rejects the whitespace but ACCEPTS the `+`, so neither
+  // engine's default is the contract — both sides converge on this regex
+  // instead: an optional leading `-`, then bare digits. (`channelwire`
+  // rejects `+` explicitly for the same reason; see plusSigned there.)
+  //
+  // The sign is allowed through here so the `<= 0` / `< 0` range checks below
+  // remain the ONLY sign rejection, keeping one reason-for-rejection per rule.
+  // Leading zeros ("0012") are accepted by both sides and stay accepted.
+  // Pinned from both languages by testdata/hlc_wire_corpus.json.
+  if (!/^-?\d+$/.test(physicalRaw) || !/^-?\d+$/.test(logicalRaw))
+    return undefined
+  let physical: bigint
+  let logical: bigint
+  try {
+    physical = BigInt(physicalRaw)
+    logical = BigInt(logicalRaw)
+  }
+  catch {
+    return undefined
+  }
+  // Mirror Go's strconv.ParseInt(..., 10, 64): reject values outside int64
+  // range, so a corrupted > int64 field cannot round-trip through TS and then
+  // fail the hub's int64-bounded decoder.
+  if (!inInt64Range(physical) || !inInt64Range(logical))
+    return undefined
+  if (physical <= 0n || logical < 0n)
+    return undefined
+  const clientId = raw.slice(d2 + 1)
+  // BYTES, not UTF-16 code units. Go's `len(clientID) > 128` counts bytes, so
+  // `clientId.length` diverged for any non-ASCII id: ~60 CJK characters is 60
+  // units but 180 bytes, which passed here and 400'd at the hub -- and since
+  // 1006 is not a terminal close code, the client would reconnect with the same
+  // persisted cursor and 400 again, forever. That is precisely the storm this
+  // round-trip validation exists to prevent, so the doc's claim to mirror the Go
+  // rules EXACTLY has to hold for every input, not just ASCII ones.
+  if (!clientId || utf8Length(clientId) > 128)
+    return undefined
+  return create(HLCSchema, { physical, logical, clientId })
+}
+
+/**
+ * Byte length of `s` under UTF-8 — what Go's `len(string)` returns.
+ *
+ * Shared encoder instance: this runs on the socket-open path and TextEncoder
+ * construction is not free.
+ */
+const utf8Encoder = new TextEncoder()
+function utf8Length(s: string): number {
+  return utf8Encoder.encode(s).length
+}
+
+// INT64_MIN/MAX as bigints, for the int64-range check that mirrors Go's
+// strconv.ParseInt(..., 10, 64). BigInt itself is unbounded; without this a
+// corrupted persisted value outside int64 range round-trips through TS and then
+// fails the hub's decoder.
+const INT64_MIN = -(2n ** 63n)
+const INT64_MAX = 2n ** 63n - 1n
+
+/** True when `n` fits in a signed int64 (Go strconv.ParseInt bitSize 64). */
+export function inInt64Range(n: bigint): boolean {
+  return n >= INT64_MIN && n <= INT64_MAX
+}
+
+/**
+ * Return the lex-greater of two HLCs (undefined if both are). Used to advance
+ * the resume watermark: it is a max over the canonical HLCs applied, so it
+ * monotonically tracks how far confirmedState has caught up.
+ */
+export function hlcMax(a: HLC | undefined, b: HLC | undefined): HLC | undefined {
+  if (!a)
+    return b ? hlcClone(b) : undefined
+  if (!b)
+    return hlcClone(a)
+  return hlcCmp(a, b) >= 0 ? hlcClone(a) : hlcClone(b)
 }
 
 /**

--- a/frontend/src/lib/crdt/hydrate.test.ts
+++ b/frontend/src/lib/crdt/hydrate.test.ts
@@ -1,0 +1,374 @@
+import type { CheckpointDelta } from './checkpointStore'
+import type { UserCrdtState } from '~/generated/leapmux/v1/user_crdt_pb'
+import { create, toBinary } from '@bufbuild/protobuf'
+import { IDBFactory, IDBKeyRange } from 'fake-indexeddb'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { NodeRecordSchema, TabRecordSchema, UserCrdtStateSchema } from '~/generated/leapmux/v1/user_crdt_pb'
+import { WatchUserEventSchema } from '~/generated/leapmux/v1/user_ops_pb'
+import { createOpLogAppender } from '~/test-support/opLog'
+import { fullCheckpointDelta, serializeHeader } from './checkpointChunks'
+import {
+  _resetCheckpointStoreForTest,
+  MAX_OPLOG_READ_FRAMES,
+  writeCheckpointAndTruncateOpLog,
+} from './checkpointStore'
+import { loadHydrationState } from './hydrate'
+
+const opLog = createOpLogAppender()
+
+beforeEach(() => {
+  vi.stubGlobal('indexedDB', new IDBFactory())
+  vi.stubGlobal('IDBKeyRange', IDBKeyRange)
+  _resetCheckpointStoreForTest()
+  opLog.reset()
+})
+afterEach(() => {
+  _resetCheckpointStoreForTest()
+  vi.unstubAllGlobals()
+})
+
+/**
+ * Every case here exercises ONE owner: the (user, client) key scoping itself is
+ * covered in checkpointStore.test.ts, so binding the client id once keeps these
+ * cases about hydration policy.
+ */
+const CLIENT = 'tab-1'
+const WM = { physical: 5n, logical: 0n, clientId: 'c' }
+
+function stateOf(userId: string, maxPhysical = 10n): UserCrdtState {
+  return create(UserCrdtStateSchema, {
+    userId,
+    nodes: { n1: { nodeId: 'n1' }, n2: { nodeId: 'n2' } },
+    tabs: { t1: { tabId: 't1', tabType: 1 } },
+    floatingWindows: {},
+    workspaces: { ws1: { workspaceId: 'ws1', rootNodeId: 'n1' } },
+    maxHlc: { physical: maxPhysical, logical: 0n, clientId: 'c' },
+    currentEpoch: 1n,
+  })
+}
+
+function batchFrame(batchId: string): Uint8Array {
+  return toBinary(WatchUserEventSchema, create(WatchUserEventSchema, {
+    event: { case: 'batch', value: { batchId, ops: [] } },
+  }))
+}
+
+/** Seed `client`'s checkpoint from a whole state, as a bootstrap rewrite would. */
+function seed(userId: string, client: string, state: UserCrdtState, wm = WM, epoch = 1n): Promise<boolean> {
+  return writeCheckpointAndTruncateOpLog(userId, client, fullCheckpointDelta(state), wm, epoch)
+}
+
+/** Seed with a hand-built delta, for the corruption arms. */
+function seedDelta(userId: string, client: string, delta: CheckpointDelta, wm = WM): Promise<boolean> {
+  return writeCheckpointAndTruncateOpLog(userId, client, delta, wm, 1n)
+}
+
+describe('loadHydrationState', () => {
+  it('returns null when no checkpoint exists', async () => {
+    expect(await loadHydrationState('user-1', CLIENT)).toBeNull()
+  })
+
+  it('returns null when the store is unavailable', async () => {
+    vi.unstubAllGlobals()
+    expect(await loadHydrationState('user-1', CLIENT)).toBeNull()
+  })
+
+  it('returns null for an empty userId', async () => {
+    expect(await loadHydrationState('', CLIENT)).toBeNull()
+  })
+
+  it('returns null for an empty clientId', async () => {
+    expect(await loadHydrationState('u', '')).toBeNull()
+  })
+
+  // The corruption wipe is OWNER-scoped. Every failure this module detects
+  // belongs to one (userId, clientId) record, but the wipe used to call the
+  // user-wide clearCheckpointAndOpLog(userId), which walks byUserId on every
+  // store -- so one tab's undecodable blob deleted every other tab's
+  // checkpoint AND op-log. Those tabs then cold-started with the full
+  // projection snapshot #267 exists to avoid: the exact cross-tab clobber the
+  // (user, client) key was introduced to narrow.
+  it('wipes only the failing tab, leaving a sibling tab hydratable', async () => {
+    // A healthy sibling tab.
+    await seed('u', 'tab-good', stateOf('u', 5n))
+    await opLog.append('u', 'tab-good', [batchFrame('b-good')])
+    // ...and a tab whose header blob does not deserialize.
+    await seedDelta('u', 'tab-bad', {
+      headerBytes: new Uint8Array([0xFF, 0xFF, 0xFF]),
+      upserts: [],
+      deletes: [],
+      full: true,
+    })
+
+    expect(await loadHydrationState('u', 'tab-bad')).toBeNull()
+
+    const survivor = await loadHydrationState('u', 'tab-good')
+    expect(survivor).not.toBeNull()
+    expect(survivor!.frames).toHaveLength(1)
+    expect(Object.keys(survivor!.state.nodes).sort()).toEqual(['n1', 'n2'])
+    // And the bad row really is gone, so the next reload of that tab is a miss
+    // rather than another failed parse.
+    expect(await loadHydrationState('u', 'tab-bad')).toBeNull()
+  })
+
+  it('round-trips a well-formed checkpoint + op-log', async () => {
+    const source = stateOf('u', 5n)
+    await seed('u', CLIENT, source)
+    await opLog.append('u', CLIENT, [batchFrame('b1')])
+    await opLog.append('u', CLIENT, [batchFrame('b2')])
+
+    const payload = await loadHydrationState('u', CLIENT)
+    expect(payload).not.toBeNull()
+    expect(payload!.watermark).toEqual(WM)
+    expect(payload!.currentEpoch).toBe(1n)
+    expect(payload!.frames).toHaveLength(2)
+    expect(payload!.frames[0].event.case).toBe('batch')
+    expect(payload!.frames[0].event.case === 'batch' && payload!.frames[0].event.value.batchId).toBe('b1')
+    expect(payload!.frames[1].event.case === 'batch' && payload!.frames[1].event.value.batchId).toBe('b2')
+  })
+
+  // The checkpoint is sharded across a header row plus one chunk per entity, so
+  // hydration has to reassemble it. Anything less than EVERY chunk landing is a
+  // state silently missing records -- with a resume cursor riding on it.
+  describe('re-assembling the sharded state', () => {
+    it('restores every entity map from the chunks, byte-identically', async () => {
+      const source = stateOf('u', 5n)
+      await seed('u', CLIENT, source)
+
+      const payload = await loadHydrationState('u', CLIENT)
+      expect(payload!.state).toEqual(source)
+    })
+
+    it('restores a state whose maps are all empty', async () => {
+      const source = create(UserCrdtStateSchema, { userId: 'u', currentEpoch: 1n })
+      await seed('u', CLIENT, source)
+
+      const payload = await loadHydrationState('u', CLIENT)
+      expect(payload!.state).toEqual(source)
+    })
+
+    it('wipes and returns null when a chunk fails to deserialize', async () => {
+      // NOT a partial state: a chunk that cannot be read means the base is
+      // short by exactly one record while the header's watermark still claims
+      // to describe it. Wiping is the only self-healing answer.
+      const source = stateOf('u', 5n)
+      await seedDelta('u', CLIENT, {
+        headerBytes: serializeHeader(source),
+        upserts: [
+          { kind: 'node', entityId: 'n1', bytes: toBinary(NodeRecordSchema, source.nodes.n1!) },
+          { kind: 'tab', entityId: 't1', bytes: new Uint8Array([0xFF, 0xFE, 0xFD]) },
+        ],
+        deletes: [],
+        full: true,
+      })
+
+      expect(await loadHydrationState('u', CLIENT)).toBeNull()
+      expect(await loadHydrationState('u', CLIENT)).toBeNull()
+    })
+
+    it('wipes and returns null when a chunk names an unknown kind', async () => {
+      // A row written by a build that shards something this one does not know.
+      const source = stateOf('u', 5n)
+      await seedDelta('u', CLIENT, {
+        headerBytes: serializeHeader(source),
+        upserts: [{ kind: 'gizmo', entityId: 'g1', bytes: toBinary(TabRecordSchema, source.tabs.t1!) }],
+        deletes: [],
+        full: true,
+      })
+
+      expect(await loadHydrationState('u', CLIENT)).toBeNull()
+    })
+
+    it('never returns a PARTIAL state — the wipe arm wins over a short one', async () => {
+      const source = stateOf('u', 5n)
+      await seedDelta('u', CLIENT, {
+        headerBytes: serializeHeader(source),
+        upserts: [
+          { kind: 'node', entityId: 'n1', bytes: toBinary(NodeRecordSchema, source.nodes.n1!) },
+          { kind: 'node', entityId: 'n2', bytes: new Uint8Array([0x08, 0xFF]) },
+        ],
+        deletes: [],
+        full: true,
+      })
+
+      const payload = await loadHydrationState('u', CLIENT)
+      // Never a state carrying n1 alone.
+      expect(payload).toBeNull()
+    })
+  })
+
+  it('returns a payload with empty frames when the checkpoint has no op-log', async () => {
+    await seed('u', CLIENT, stateOf('u', 5n))
+    const payload = await loadHydrationState('u', CLIENT)
+    expect(payload).not.toBeNull()
+    expect(payload!.frames).toEqual([])
+  })
+
+  it('wipes both stores and returns null when the checkpoint header is unparseable', async () => {
+    await seed('u', CLIENT, stateOf('u', 5n))
+    await opLog.append('u', CLIENT, [batchFrame('b1')])
+    // Now corrupt the header in place via a direct rewrite.
+    await seedDelta('u', CLIENT, {
+      headerBytes: new Uint8Array([0xFF, 0xFE, 0xFD]),
+      upserts: [],
+      deletes: [],
+      full: true,
+    })
+    await opLog.append('u', CLIENT, [batchFrame('b2')])
+
+    expect(await loadHydrationState('u', CLIENT)).toBeNull()
+    // The pair was wiped: a second load also returns null (no poison record).
+    expect(await loadHydrationState('u', CLIENT)).toBeNull()
+  })
+
+  it('keeps the checkpoint and replays the decodable prefix when an op-log frame is unparseable', async () => {
+    await seed('u', CLIENT, stateOf('u', 5n))
+    // One good frame, then a corrupt frame, then another good one that must NOT
+    // be replayed (it sits after the break, so its ordering context is lost).
+    await opLog.append('u', CLIENT, [batchFrame('good')])
+    await opLog.append('u', CLIENT, [new Uint8Array([0xFF, 0xFE, 0xFD])])
+    await opLog.append('u', CLIENT, [batchFrame('after-corrupt')])
+
+    const payload = await loadHydrationState('u', CLIENT)
+    // The checkpoint is independently valid, so it survives: discarding it
+    // would force the full-snapshot projection scan #267 exists to avoid.
+    expect(payload).not.toBeNull()
+    expect(payload!.truncated).toBe(true)
+    expect(payload!.frames).toHaveLength(1)
+    expect(payload!.frames[0].event.case).toBe('batch')
+    // The checkpoint itself is untouched, so a second load still finds it.
+    expect(await loadHydrationState('u', CLIENT)).not.toBeNull()
+  })
+
+  it('reports truncated=false when every op-log frame decodes', async () => {
+    await seed('u', CLIENT, stateOf('u', 5n))
+    await opLog.append('u', CLIENT, [batchFrame('a'), batchFrame('b')])
+
+    const payload = await loadHydrationState('u', CLIENT)
+    expect(payload).not.toBeNull()
+    expect(payload!.truncated).toBe(false)
+    expect(payload!.frames).toHaveLength(2)
+  })
+
+  it('wipes both stores and returns null when the checkpoint names another tenant', async () => {
+    // A blob keyed under 'u' but carrying another user's state must be refused
+    // the same way the wire path refuses a foreign-tenant UserMaterialized --
+    // otherwise the persisted record, not the session, decides what is rendered.
+    await seed('u', CLIENT, stateOf('other-user', 5n))
+    await opLog.append('u', CLIENT, [batchFrame('b1')])
+
+    expect(await loadHydrationState('u', CLIENT)).toBeNull()
+    // Wiped, so the poison record cannot be re-adopted on the next reload.
+    expect(await loadHydrationState('u', CLIENT)).toBeNull()
+  })
+
+  it('wipes both stores and returns null when the checkpoint names NO tenant', async () => {
+    // The one blob whose provenance is completely unknown. Guarding the tenant
+    // check with `state.userId && …` short-circuits past exactly this record,
+    // adopting it as the session's own state -- while every other validation
+    // here (watermark, epoch, chunk kind) treats absent as fatal. No writer
+    // produces one, which is precisely why a row that has one is corrupt.
+    await seed('u', CLIENT, stateOf('', 5n))
+    await opLog.append('u', CLIENT, [batchFrame('b1')])
+
+    expect(await loadHydrationState('u', CLIENT)).toBeNull()
+    expect(await loadHydrationState('u', CLIENT)).toBeNull()
+  })
+
+  // The epoch two lines below this check has always been range-checked; the
+  // watermark was type-checked only, even though the surrounding comments (and
+  // the module header) promise "in-range" for both. An out-of-range physical
+  // survives hydration and then fails `validateResumeHlc` at every socket open,
+  // so the client silently full-snapshots on every connect until some bootstrap
+  // happens to overwrite it.
+  it('wipes when the persisted watermark is out of int64 range', async () => {
+    await seed('u', CLIENT, stateOf('u', 5n), { physical: 2n ** 63n, logical: 0n, clientId: 'c' })
+
+    expect(await loadHydrationState('u', CLIENT)).toBeNull()
+    expect(await loadHydrationState('u', CLIENT)).toBeNull()
+  })
+
+  it('carries the store\'s over-cap truncation through to the caller', async () => {
+    // The frame and byte ceilings are enforced at the store's CURSOR, not here:
+    // a bound checked after the whole log has been flattened into memory has
+    // already paid the cost it exists to refuse. What hydrate owes is passing
+    // `truncated` on, since that is what makes the caller rewrite the
+    // checkpoint -- the only thing that actually drains the log.
+    await seed('u', CLIENT, stateOf('u', 5n))
+    await opLog.append('u', CLIENT, Array.from({ length: MAX_OPLOG_READ_FRAMES + 1 }, (_, i) => batchFrame(`b${i}`)))
+
+    const payload = await loadHydrationState('u', CLIENT)
+    expect(payload).not.toBeNull()
+    expect(payload!.frames).toHaveLength(MAX_OPLOG_READ_FRAMES)
+    expect(payload!.truncated).toBe(true)
+  })
+
+  it('does not report truncated at exactly the cap', async () => {
+    await seed('u', CLIENT, stateOf('u', 5n))
+    await opLog.append('u', CLIENT, Array.from({ length: MAX_OPLOG_READ_FRAMES }, (_, i) => batchFrame(`b${i}`)))
+
+    const payload = await loadHydrationState('u', CLIENT)
+    expect(payload!.frames).toHaveLength(MAX_OPLOG_READ_FRAMES)
+    expect(payload!.truncated).toBe(false)
+  })
+
+  it('wipes both stores and returns null when the watermark is missing', async () => {
+    // Seed a valid checkpoint + op-log, then overwrite the metadata row with a
+    // malformed watermark via a direct IDB put (bypassing the validator).
+    await seed('u', CLIENT, stateOf('u', 5n))
+    await opLog.append('u', CLIENT, [batchFrame('b1')])
+    const db = await openDbRaw()
+    await new Promise<void>((resolve) => {
+      const tx = db.transaction('checkpoints', 'readwrite')
+      tx.objectStore('checkpoints').put({
+        userId: 'u',
+        clientId: CLIENT,
+        headerBytes: serializeHeader(stateOf('u', 5n)),
+        watermark: { physical: 5n, logical: 0n, clientId: 123 as never },
+        currentEpoch: 1n,
+        writtenAt: 0,
+      })
+      tx.oncomplete = () => resolve()
+    })
+    db.close()
+
+    expect(await loadHydrationState('u', CLIENT)).toBeNull()
+  })
+
+  it('wipes both stores and returns null when the epoch is out of range', async () => {
+    await seed('u', CLIENT, stateOf('u', 5n))
+    await opLog.append('u', CLIENT, [batchFrame('b1')])
+    // Overwrite with an out-of-int64 epoch.
+    const db = await openDbRaw()
+    await new Promise<void>((resolve) => {
+      const tx = db.transaction('checkpoints', 'readwrite')
+      tx.objectStore('checkpoints').put({
+        userId: 'u',
+        clientId: CLIENT,
+        headerBytes: serializeHeader(stateOf('u', 5n)),
+        watermark: { physical: 5n, logical: 0n, clientId: 'c' },
+        currentEpoch: 2n ** 63n, // out of int64 range
+        writtenAt: 0,
+      })
+      tx.oncomplete = () => resolve()
+    })
+    db.close()
+
+    expect(await loadHydrationState('u', CLIENT)).toBeNull()
+  })
+})
+
+/** Open the raw IDB for direct row manipulation in tests. */
+async function openDbRaw(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    // NO version argument: a versionless open attaches to whatever version
+    // exists, so this neither triggers a spurious version-change transaction
+    // against the connection the store holds nor has to be kept in step with
+    // DB_VERSION by hand (pinning it meant every bump silently broke these
+    // cases with a VersionError). The store's own open, which the callers above
+    // have already performed, is what creates the schema.
+    const r = indexedDB.open('leapmux-crdt-state')
+    r.onsuccess = () => resolve(r.result)
+    r.onerror = () => reject(r.error)
+  })
+}

--- a/frontend/src/lib/crdt/hydrate.ts
+++ b/frontend/src/lib/crdt/hydrate.ts
@@ -1,0 +1,262 @@
+import type { ChunkKind } from './checkpointChunks'
+import type { HlcShape } from './hlc'
+import type { UserCrdtState } from '~/generated/leapmux/v1/user_crdt_pb'
+import type { WatchUserEvent } from '~/generated/leapmux/v1/user_ops_pb'
+import { fromBinary } from '@bufbuild/protobuf'
+import { WatchUserEventSchema } from '~/generated/leapmux/v1/user_ops_pb'
+import { createLogger } from '~/lib/logger'
+import { applyChunk, isChunkKind, parseHeader } from './checkpointChunks'
+import { clearOwnerCheckpointAndOpLog, isCheckpointStoreAvailable, readCheckpoint } from './checkpointStore'
+import { inInt64Range } from './hlc'
+
+const log = createLogger('crdtHydrate')
+
+// ---------------------------------------------------------------------------
+// Hydration: load + validate a persisted checkpoint + op-log for cold reload
+//
+// This module owns the DESERIALIZATION-FAILURE POLICY in one place, and the
+// policy differs by WHICH half failed:
+//
+//   - CHECKPOINT unusable (bad header blob, an undecodable or unknown-kind
+//     entity chunk, foreign tenant, missing/out-of-range watermark or epoch) →
+//     WIPE BOTH and return null. There is no base to replay onto, so the pair
+//     is worthless as a unit. This self-heals (a corrupt record would otherwise
+//     fail every subsequent refresh) and triggers the full-snapshot path —
+//     empty manager → bootstrap() from UserMaterialized → first checkpoint
+//     write rebuilds a known-good store.
+//
+//     The chunks belong to THIS arm and not the op-log's, even though there are
+//     many of them and each parses independently: a partially-assembled state
+//     is not an older state, it is a state silently missing records, and the
+//     resume cursor rides on it. Partial is the one outcome that must stay
+//     impossible.
+//   - OP-LOG frame unusable → keep the checkpoint and replay the decodable
+//     PREFIX, reporting `truncated` so the caller rewrites the checkpoint and
+//     drops the bad tail. The log is an ordered cache OVER the checkpoint, so
+//     one bad frame invalidates only what follows it; discarding the whole
+//     base would force exactly the full snapshot this feature exists to avoid.
+//
+// The store (checkpointStore.ts) stays a pure blob store (returns raw
+// Uint8Array, never deserializes), so this module and checkpointChunks.ts are
+// the only places proto coupling lands and the parse/replay path is
+// unit-testable without IDB.
+// ---------------------------------------------------------------------------
+
+/**
+ * The validated hydration payload handed to PendingOpsManager.hydrate: the
+ * parsed checkpoint state, the op-log frames to replay (in apply order), the
+ * resume watermark pinned at checkpoint time, and the epoch. All proto objects
+ * are already parsed and validated — hydrate() applies them without touching
+ * IDB or proto codecs.
+ */
+export interface HydrationPayload {
+  /** The full UserCrdtState at checkpoint time T_c (the replay base). */
+  state: UserCrdtState
+  /** Confirmed WatchUserEvent frames to replay onto `state` (T_c → T_now). */
+  frames: WatchUserEvent[]
+  /** The resume watermark pinned at checkpoint write time. */
+  watermark: HlcShape
+  /** The epoch the watermark was seen under. */
+  currentEpoch: bigint
+  /**
+   * True when `frames` is a PREFIX of the persisted op-log — because a frame
+   * failed to decode and the replay stopped there, or because the store's read
+   * hit its own frame/byte ceiling. The hydrated state is consistent (just
+   * older); the caller should rewrite the checkpoint at the post-replay
+   * watermark so the rest is dropped from disk -- otherwise every reload
+   * re-truncates at the same place.
+   */
+  truncated: boolean
+  /**
+   * Ordinal the next appended op-log segment must carry, so the recorder can
+   * continue the persisted sequence instead of restarting at 0 behind segments
+   * that already hold 0..N-1 — which the next cold start would read as a hole
+   * and discard an intact log for. See `OpLogRecord.ordinal`.
+   */
+  nextOpLogOrdinal: number
+}
+
+/**
+ * Wrap fromBinary in a never-throw parse: a corrupt or truncated blob returns
+ * undefined instead of propagating the decode error. Callers treat undefined
+ * as "unusable, wipe and fall back."
+ */
+function tryFromBinary<T>(decode: (bytes: Uint8Array) => T, bytes: Uint8Array): T | undefined {
+  try {
+    return decode(bytes)
+  }
+  catch {
+    return undefined
+  }
+}
+
+/**
+ * Merge one entity chunk into `state`, reporting failure rather than throwing.
+ * The sibling of `tryFromBinary` for the sharded half of the checkpoint.
+ */
+function tryApplyChunk(state: UserCrdtState, kind: ChunkKind, entityId: string, bytes: Uint8Array): boolean {
+  try {
+    applyChunk(state, kind, entityId, bytes)
+    return true
+  }
+  catch {
+    return false
+  }
+}
+
+/**
+ * Wipe this owner's persisted pair and report a cold start.
+ *
+ * OWNER-scoped, not user-scoped, and that is the whole point. Every failure
+ * this module detects — an unreadable row, an undecodable blob, a foreign
+ * tenant, an out-of-range watermark or epoch — belongs to exactly one
+ * `(userId, clientId)` record. Wiping user-wide would delete every OTHER open
+ * tab's checkpoint and op-log as collateral, forcing each of them to cold-start
+ * with the full projection snapshot #267 exists to avoid — the cross-tab
+ * clobber the per-owner key exists to make unlikely (it cannot make it
+ * impossible; see checkpointStore's header on duplicated tabs).
+ * `clearCheckpointAndOpLog` (user-wide) stays for logout / user switch, where
+ * spanning every tab is the intent.
+ */
+async function wipeAndFail(userId: string, clientId: string): Promise<null> {
+  // A wipe that did not happen leaves the poison record in place, so the next
+  // reload reads it, fails identically, and pays a full projection snapshot --
+  // forever, and silently. The wipe is still best-effort (there is nothing
+  // better to do here), but "self-healing" is a claim this module makes in its
+  // own header, and an unobservable failure makes that claim unfalsifiable.
+  if (!await clearOwnerCheckpointAndOpLog(userId, clientId))
+    log.warn('could not wipe the corrupt checkpoint; the next reload will re-read it', { clientId })
+  return null
+}
+
+/**
+ * Load and validate the persisted checkpoint + op-log for `userId`. Returns
+ * null when there is nothing usable to hydrate from:
+ *   - the store is unavailable (no indexedDB),
+ *   - no checkpoint exists,
+ *   - the checkpoint header blob fails to deserialize,
+ *   - the header names a different tenant,
+ *   - the watermark/epoch is missing or out of range,
+ *   - an entity chunk names an unknown kind or fails to deserialize.
+ *
+ * Each of those wipes THIS OWNER's pair (see wipeAndFail) so the next reload
+ * isn't poisoned by the same corrupt record, and returns null — routing the
+ * caller to the full-snapshot cold-start path.
+ *
+ * An undecodable OP-LOG frame is NOT fatal: the returned payload carries the
+ * decodable prefix with `truncated: true`, and the caller rewrites the
+ * checkpoint to drop the bad tail.
+ */
+export async function loadHydrationState(userId: string, clientId: string): Promise<HydrationPayload | null> {
+  if (!isCheckpointStoreAvailable() || !userId || !clientId)
+    return null
+
+  const read = await readCheckpoint(userId, clientId)
+  if (read.status === 'miss')
+    return null
+  if (read.status === 'failed') {
+    // Distinct from a miss on purpose. A checkpoint row that EXISTS but cannot
+    // be read (a structured-clone failure on the stored bytes, a corrupt key
+    // entry) would otherwise survive every reload: each one pays the failed
+    // read, cold-starts, and re-fails identically. Wiping is what makes the
+    // policy in this module's header self-healing rather than a loop.
+    return wipeAndFail(userId, clientId)
+  }
+  const { checkpoint, chunks, opLogFrames, opLogTruncated } = read
+
+  // (1) The checkpoint header blob must deserialize into a UserCrdtState.
+  const state = tryFromBinary(parseHeader, checkpoint.headerBytes)
+  if (!state) {
+    return wipeAndFail(userId, clientId)
+  }
+
+  // (1b) The blob must name THIS tenant. UserCrdtState carries its own user_id,
+  // so adopting it on the strength of the row key alone would let a persisted
+  // record -- not the authenticated session -- decide whose workspaces, tiles
+  // and tabs this shell renders. The wire path refuses a foreign-tenant
+  // UserMaterialized for exactly this reason (see applyMaterialized, the client
+  // half of crdt.Manager.requireOwnState); the cold-start path must fail closed
+  // the same way. Wipe rather than merely skip: a row keyed under this user but
+  // carrying another user's state is corrupt by construction.
+  //
+  // A MISSING user_id is corrupt too, and is checked by the same comparison
+  // rather than short-circuited past it. Guarding with `state.userId &&` would
+  // admit the one blob that names no tenant at all -- the only record here whose
+  // provenance is completely unknown -- while every other validation in this
+  // function (watermark, epoch, chunk kind) treats absent as fatal. No writer
+  // produces one: `newState(userId)` seeds even the cold-start manager, a
+  // bootstrap copies `materialized.userId`, and a checkpoint is only ever
+  // written once a watermark exists, which requires one of those two.
+  if (state.userId !== userId) {
+    return wipeAndFail(userId, clientId)
+  }
+
+  // (2) The watermark and epoch must be present and in-range. An out-of-range
+  // epoch would 400 at the hub on the resume URL, and a missing watermark
+  // leaves no cursor to send — both degrade to a full snapshot, but a stale
+  // record left in the store would re-fail every reload, so wipe it.
+  const wm = checkpoint.watermark
+  if (!wm || typeof wm.physical !== 'bigint' || typeof wm.logical !== 'bigint' || typeof wm.clientId !== 'string') {
+    return wipeAndFail(userId, clientId)
+  }
+  // RANGE, not just type -- the comment above says "in-range" and the epoch two
+  // lines down enforces it, but the watermark used to be type-checked only. An
+  // out-of-range physical/logical survives here and then fails
+  // `validateResumeHlc` at every socket open, so the client silently takes a
+  // full snapshot on every connect instead of resuming. It self-heals after one
+  // bootstrap (which overwrites the watermark and rewrites the pair), but a
+  // wipe here turns one silent degraded connect into zero.
+  if (!inInt64Range(wm.physical) || !inInt64Range(wm.logical)) {
+    return wipeAndFail(userId, clientId)
+  }
+  const epoch = checkpoint.currentEpoch
+  if (typeof epoch !== 'bigint' || !inInt64Range(epoch)) {
+    return wipeAndFail(userId, clientId)
+  }
+
+  // (2b) Re-assemble the entity maps from the chunks. EVERY chunk must land:
+  // one that names a kind this build does not know, or that fails to decode,
+  // yields a state missing exactly that record while the header's watermark
+  // still claims to describe it -- and the resume cursor would then be sent
+  // for a base that is silently short. That is worse than no checkpoint at
+  // all, so it takes the same wipe-and-cold-start arm as a bad header.
+  for (const chunk of chunks) {
+    if (!isChunkKind(chunk.kind))
+      return wipeAndFail(userId, clientId)
+    const applied = tryApplyChunk(state, chunk.kind, chunk.entityId, chunk.bytes)
+    if (!applied)
+      return wipeAndFail(userId, clientId)
+  }
+
+  // (3) Replay the op-log as far as it decodes. A bad frame invalidates only
+  // the frames AFTER it: applying a strict PREFIX is coherent because hydrate()
+  // advances the watermark per applied frame, so stopping at frame i leaves
+  // exactly (state = T_c + frames[0..i), watermark = max over those) -- an
+  // older cursor, but one that truthfully describes the state it labels, which
+  // is all the hub's delta path needs.
+  //
+  // Wiping the pair here instead would throw away a checkpoint that steps (1)
+  // and (2) just proved valid, forcing the full-snapshot projection scan that
+  // issue #267 exists to avoid -- in the one case where a cheap recovery
+  // matters most. The caller drops the undecodable tail from disk (see
+  // `truncated`).
+  const frames: WatchUserEvent[] = []
+  // An op-log the store could only partially read is already a prefix, so it
+  // carries the same "rewrite the checkpoint to drop the rest" obligation as an
+  // undecodable frame. The frame and byte CEILINGS live at the store's cursor
+  // (MAX_OPLOG_READ_FRAMES / MAX_OPLOG_READ_BYTES, which mirror the hub's
+  // MaxResumeDeltaOps / MaxResumeDeltaBytes) rather than here: a bound checked
+  // after the whole log has been flattened into memory has already paid the
+  // cost it exists to refuse.
+  let truncated = opLogTruncated
+  for (const frameBytes of opLogFrames) {
+    const frame = tryFromBinary(bytes => fromBinary(WatchUserEventSchema, bytes), frameBytes)
+    if (!frame) {
+      truncated = true
+      break
+    }
+    frames.push(frame)
+  }
+
+  return { state, frames, watermark: wm, currentEpoch: epoch, truncated, nextOpLogOrdinal: read.opLogNextOrdinal }
+}

--- a/frontend/src/lib/crdt/ops.test.ts
+++ b/frontend/src/lib/crdt/ops.test.ts
@@ -4,6 +4,8 @@ import { HLCClock, hlcCmp } from './hlc'
 import {
   generateId,
   newBatch,
+  opTarget,
+  opTargetKey,
   setFloatingHeight,
   setFloatingRootNodeId,
   setFloatingWidth,
@@ -173,5 +175,41 @@ describe('newBatch', () => {
     const a = newBatch([])
     const b = newBatch([])
     expect(a.batchId).not.toBe(b.batchId)
+  })
+})
+
+// opTarget is the SINGLE op -> entity mapping on the client (mirroring the hub's
+// crdt.OpTarget). It had been copied into the checkpoint dirty-set and the
+// tombstone pin, which then disagreed about what an unrecognized body means --
+// the pin's fail-OPEN reading is what would re-arm the ghost-record bug for any
+// op kind added later. These pin the three-valued contract that makes the two
+// callers degrade in their own safe directions.
+describe('opTarget', () => {
+  const ctx = { originClientId: 'c1', clock: new HLCClock('c1') }
+
+  it('names the entity for every op kind that installs one', () => {
+    expect(opTarget(setNodePosition(ctx, 'n1', 'p'))).toEqual({ case: 'entity', kind: 'node', id: 'n1' })
+    expect(opTarget(tombstoneNode(ctx, 'n1'))).toEqual({ case: 'entity', kind: 'node', id: 'n1' })
+    expect(opTarget(setTabTileId(ctx, TabType.AGENT, 't1', 'tile'))).toEqual({ case: 'entity', kind: 'tab', id: 't1' })
+    expect(opTarget(tombstoneTab(ctx, TabType.AGENT, 't1'))).toEqual({ case: 'entity', kind: 'tab', id: 't1' })
+    expect(opTarget(setFloatingX(ctx, 'w1', 1))).toEqual({ case: 'entity', kind: 'fw', id: 'w1' })
+    expect(opTarget(tombstoneFloatingWindow(ctx, 'w1'))).toEqual({ case: 'entity', kind: 'fw', id: 'w1' })
+  })
+
+  it('reports an empty body as provably targeting nothing', () => {
+    expect(opTarget({ body: { case: undefined } } as never)).toEqual({ case: 'none' })
+  })
+
+  it('reports an unrecognized body as unknown, not as nothing', () => {
+    // The distinction the two consumers turn on: `none` means "safe to ignore",
+    // `unknown` means "this build cannot enumerate what changed".
+    expect(opTarget({ body: { case: 'someOpFromANewerBuild', value: {} } } as never))
+      .toEqual({ case: 'unknown' })
+  })
+
+  it('spells an entity target as the shared kind:id key, and the others as null', () => {
+    expect(opTargetKey({ case: 'entity', kind: 'tab', id: 't1' })).toBe('tab:t1')
+    expect(opTargetKey({ case: 'none' })).toBeNull()
+    expect(opTargetKey({ case: 'unknown' })).toBeNull()
   })
 })

--- a/frontend/src/lib/crdt/ops.ts
+++ b/frontend/src/lib/crdt/ops.ts
@@ -20,6 +20,85 @@ import { hlcIsZero } from './hlc'
 import { cmpStr } from './project'
 
 /**
+ * The entity kinds an op can target, spelled as the `kind` half of the
+ * `kind:id` keys the checkpoint chunks and the tombstone pin both use.
+ */
+export type OpEntityKind = 'node' | 'tab' | 'fw' | 'ws'
+
+/**
+ * What `opTarget` found. THREE outcomes, not two -- collapsing the last into
+ * the middle is what made the tombstone-pin and the checkpoint dirty-set
+ * disagree about a future op kind:
+ *
+ *  - `entity` -- this op installs into `kind`'s map under `id`.
+ *  - `none`   -- this op provably installs nothing (an empty body; `applyOp`
+ *                falls through its switch).
+ *  - `unknown` -- this build does not recognize the body. Callers MUST degrade
+ *                conservatively in their own direction; see `opTarget`.
+ */
+export type OpTarget
+  = | { case: 'entity', kind: OpEntityKind, id: string }
+    | { case: 'none' }
+    | { case: 'unknown' }
+
+/**
+ * The entity an op targets. The SINGLE source of the op -> entity mapping on
+ * the client, mirroring the hub's `crdt.OpTarget` (`backend/internal/hub/crdt/
+ * op.go`), which likewise lives beside the op definitions rather than with any
+ * one consumer.
+ *
+ * It had been copied into two consumers that then drifted in the dangerous
+ * direction: the checkpoint's dirty-set treated an unrecognized body as "assume
+ * everything changed" (fail-safe), while the tombstone pin treated it as "this
+ * op targets nothing" (fail-OPEN) -- so a newly added op kind would leave its
+ * entity unpinned, `pruneTombstonesAtOrBelow` would drop the shell that is the
+ * only thing suppressing a later write, and `recomputeSpeculative` would
+ * resurrect the entity as a live record. One mapping, and an `unknown` the
+ * callers cannot ignore, is what keeps that from coming back.
+ *
+ * The `default` arm below is a COMPILE-TIME exhaustiveness check: adding a case
+ * to `CrdtOp.body` without adding an arm here is a type error, not a silent
+ * runtime fallthrough. It still returns `unknown` at runtime, because a peer on
+ * a newer build can put a body on the wire that this build genuinely has no arm
+ * for.
+ */
+export function opTarget(op: CrdtOp): OpTarget {
+  const body = op.body
+  switch (body.case) {
+    case 'setNodeRegister':
+      return { case: 'entity', kind: 'node', id: body.value.nodeId }
+    case 'tombstoneNode':
+      return { case: 'entity', kind: 'node', id: body.value.nodeId }
+    case 'setTabRegister':
+      return { case: 'entity', kind: 'tab', id: body.value.tabId }
+    case 'tombstoneTab':
+      return { case: 'entity', kind: 'tab', id: body.value.tabId }
+    case 'setFloatingWindowRegister':
+      return { case: 'entity', kind: 'fw', id: body.value.windowId }
+    case 'tombstoneFloatingWindow':
+      return { case: 'entity', kind: 'fw', id: body.value.windowId }
+    case 'setWorkspaceRootNode':
+      return { case: 'entity', kind: 'ws', id: body.value.workspaceId }
+    case 'setWorkspaceRegister':
+      return { case: 'entity', kind: 'ws', id: body.value.workspaceId }
+    case 'tombstoneWorkspace':
+      return { case: 'entity', kind: 'ws', id: body.value.workspaceId }
+    case undefined:
+      return { case: 'none' }
+    default: {
+      const exhaustive: never = body
+      void exhaustive
+      return { case: 'unknown' }
+    }
+  }
+}
+
+/** `opTarget`'s entity spelled as the shared `kind:id` key. */
+export function opTargetKey(target: OpTarget): string | null {
+  return target.case === 'entity' ? `${target.kind}:${target.id}` : null
+}
+
+/**
  * generateId mints a 48-character alphanumeric nanoid that matches
  * the Go-side `util/id.Generate()` shape. Used for op_id, batch_id,
  * node_id, tab_id, and window_id wherever the frontend needs a fresh
@@ -170,9 +249,19 @@ export function tombstoneFloatingWindow(ctx: OpBuilderCtx, windowId: string): Cr
   })
 }
 
-/** Bundle a list of ops into a fresh OpBatch. */
-export function newBatch(ops: CrdtOp[]): OpBatch {
-  return create(OpBatchSchema, { batchId: generateId(), ops })
+/**
+ * Bundle a list of ops into a fresh OpBatch.
+ *
+ * `batchId` is a test seam; it defaults to a fresh `generateId()` and every
+ * production call site omits it. `batch_id` is the hub's dedup key -- it
+ * matches a SubmitOps echo back to its pending batch here, and keys the
+ * own-echo suppression in the op-log recorder -- so a deterministic id is what
+ * lets a test name the batch it is asserting about. Reusing one is not a silent
+ * merge: the hub rejects a replayed batch_id whose body differs with
+ * BATCH_REJECTION_OP_ID_COLLISION rather than dropping the ops.
+ */
+export function newBatch(ops: CrdtOp[], batchId?: string): OpBatch {
+  return create(OpBatchSchema, { batchId: batchId ?? generateId(), ops })
 }
 
 /**

--- a/frontend/src/lib/crdt/pendingOps.test.ts
+++ b/frontend/src/lib/crdt/pendingOps.test.ts
@@ -1,6 +1,9 @@
+import type { HydrationPayload } from './hydrate'
+import type { UserCrdtState } from '~/generated/leapmux/v1/user_crdt_pb'
+import type { WatchUserEvent } from '~/generated/leapmux/v1/user_ops_pb'
 import { create } from '@bufbuild/protobuf'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { HLCSchema, NodeKind } from '~/generated/leapmux/v1/user_crdt_pb'
+import { HLCSchema, NodeKind, NodeRecordSchema, UserCrdtStateSchema } from '~/generated/leapmux/v1/user_crdt_pb'
 import {
   BatchCommittedSchema,
   BatchRejectionReason,
@@ -8,12 +11,15 @@ import {
   CommittedOpSchema,
   EntityMaterializedSchema,
   EntityRemovedSchema,
+  OpBatchSchema,
+  ResumeDeltaSchema,
   TabIdentSchema,
+  WatchUserEventSchema,
 } from '~/generated/leapmux/v1/user_ops_pb'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
 import { HLCClock } from './hlc'
 import { newBatch, setNodeKind, setTabTileId, tombstoneTab } from './ops'
-import { PendingOpsManager } from './pendingOps'
+import { MAX_OWN_ECHO_BATCH_IDS, PendingOpsManager, pruneTombstonesAtOrBelow } from './pendingOps'
 
 function makeMgr(notify?: () => void) {
   const clock = new HLCClock('clientA')
@@ -61,6 +67,198 @@ describe('pendingOpsManager', () => {
     expect(mgr.state.speculativeState.nodes['remote-node']?.kind?.value).toBe(NodeKind.SPLIT)
   })
 
+  it('applyDelta folds the tail into confirmed WITHOUT a wholesale reset, advances the watermark, and keeps pendingBatches', () => {
+    // Seed confirmed state + a watermark via bootstrap so applyDelta has a
+    // baseline to fold onto (not replace).
+    mgr.bootstrap({
+      userId: 'user',
+      nodes: { exist: create(NodeRecordSchema, { nodeId: 'exist' }) },
+      tabs: {},
+      floatingWindows: {},
+      workspaces: {},
+      maxHlc: create(HLCSchema, { physical: 100n, logical: 0n, clientId: 'hub' }),
+      currentEpoch: 5n,
+    })
+    // A locally-pending optimistic batch must survive a delta (same as it
+    // survives a full-snapshot re-bootstrap).
+    const ctx = { originClientId: 'clientA', clock: mgr.clock }
+    const pending = newBatch([setNodeKind(ctx, 'pending-node', NodeKind.LEAF)])
+    mgr.submit(pending)
+    expect(mgr.state.pendingBatches).toHaveLength(1)
+
+    const deltaOp = setNodeKind({ originClientId: 'other', clock: new HLCClock('other') }, 'delta-node', NodeKind.GRID)
+    deltaOp.canonicalHlc = create(HLCSchema, { physical: 300n, logical: 0n, clientId: 'hub' })
+    mgr.applyDelta(create(ResumeDeltaSchema, {
+      frames: [create(WatchUserEventSchema, { event: { case: 'batch', value: newBatch([deltaOp]) } })],
+      maxHlc: create(HLCSchema, { physical: 300n, logical: 0n, clientId: 'hub' }),
+      currentEpoch: 5n,
+    }))
+
+    // The delta op folded onto confirmed; the pre-existing bootstrap node is
+    // STILL there (no wholesale replace).
+    expect(mgr.state.confirmedState.nodes['delta-node']?.kind?.value).toBe(NodeKind.GRID)
+    expect(mgr.state.confirmedState.nodes.exist).toBeDefined()
+    // Pending batch survived.
+    expect(mgr.state.pendingBatches).toHaveLength(1)
+    // Watermark advanced to the delta's max op (300), and the epoch the hub
+    // reported is reflected in currentEpoch (which doubles as the resume epoch).
+    expect(mgr.state.resumeWatermark?.physical).toBe(300n)
+    expect(mgr.state.currentEpoch).toBe(5n)
+  })
+
+  it('applyDelta observes delta.maxHlc into the clock so the local clock does not lag the resume high-water mark', () => {
+    // The delta's max_hlc is the filtered tail's max op, which the hub reports
+    // from the subscriber's allowed set. If the op that advanced the state's
+    // true max sat in a filtered-out workspace, the tail's maxHlc still
+    // reflects the allowed tail, and the client's HLC clock must observe it so
+    // a subsequent local submit() does not mint a client_hlc below the resume
+    // point. Mirrors bootstrap's clock.observe(snapshot.maxHlc).
+    //
+    // The resume watermark must ALSO adopt max_hlc (ResumeDelta wire contract),
+    // not only per-frame HLCs — otherwise a max_hlc ahead of applied frame HLCs
+    // leaves the next reconnect re-pulling an already-covered gap.
+    mgr.bootstrap({
+      userId: 'user',
+      nodes: {},
+      tabs: {},
+      floatingWindows: {},
+      workspaces: {},
+      maxHlc: create(HLCSchema, { physical: 100n, logical: 0n, clientId: 'hub' }),
+      currentEpoch: 1n,
+    })
+    // A delta tail op at physical=200; delta.maxHlc at physical=500 (simulating
+    // the state's true max sitting above the tail, e.g. an op the filter kept).
+    const deltaOp = setNodeKind({ originClientId: 'other', clock: new HLCClock('other') }, 'delta-node', NodeKind.LEAF)
+    deltaOp.canonicalHlc = create(HLCSchema, { physical: 200n, logical: 0n, clientId: 'hub' })
+    mgr.applyDelta(create(ResumeDeltaSchema, {
+      frames: [create(WatchUserEventSchema, { event: { case: 'batch', value: newBatch([deltaOp]) } })],
+      maxHlc: create(HLCSchema, { physical: 500n, logical: 0n, clientId: 'hub' }),
+      currentEpoch: 1n,
+    }))
+    // The clock observed the delta's max (500), not just the tail op (200), so
+    // current().physical is at least 500 — a later tick() can only go higher.
+    expect(mgr.clock.current().physical).toBe(500n)
+    expect(mgr.state.resumeWatermark?.physical).toBe(500n)
+  })
+
+  it('applyDelta dedups a batch already applied (echo of a pending batch) by batch_id', () => {
+    mgr.bootstrap({
+      userId: 'user',
+      nodes: {},
+      tabs: {},
+      floatingWindows: {},
+      workspaces: {},
+      maxHlc: create(HLCSchema, { physical: 100n, logical: 0n, clientId: 'hub' }),
+      currentEpoch: 1n,
+    })
+    const ctx = { originClientId: 'clientA', clock: mgr.clock }
+    const pending = newBatch([setNodeKind(ctx, 'echoed', NodeKind.LEAF)])
+    mgr.submit(pending)
+    // The same batch_id arrives in a delta (an echo): it is dropped from
+    // pending and NOT double-applied (the op is still applied once, matching
+    // consumeRemote's echo semantics).
+    const echoOp = pending.ops[0]
+    echoOp.canonicalHlc = create(HLCSchema, { physical: 150n, logical: 0n, clientId: 'hub' })
+    mgr.applyDelta(create(ResumeDeltaSchema, {
+      frames: [create(WatchUserEventSchema, {
+        event: { case: 'batch', value: create(OpBatchSchema, { batchId: pending.batchId, ops: [echoOp] }) },
+      })],
+      maxHlc: create(HLCSchema, { physical: 150n, logical: 0n, clientId: 'hub' }),
+      currentEpoch: 1n,
+    }))
+    expect(mgr.state.pendingBatches).toHaveLength(0)
+    expect(mgr.state.confirmedState.nodes.echoed?.kind?.value).toBe(NodeKind.LEAF)
+  })
+
+  it('applyDelta evicts an entity via a removed frame and reports droppedPending', () => {
+    // #357: the resume delta now carries materialized/removed frames. A removed
+    // frame evicts the entity from confirmedState AND drops any pending op on it
+    // (otherwise a pending mutation would resurrect a redacted entity). applyDelta
+    // aggregates droppedPending across frames so a single warn-toast covers the
+    // whole delta — mirroring consumeEntityRemoved's live-broadcast behavior.
+    mgr.bootstrap({
+      userId: 'user',
+      nodes: {},
+      tabs: { tA: { tabId: 'tA', tabType: TabType.AGENT } },
+      floatingWindows: {},
+      workspaces: {},
+      maxHlc: create(HLCSchema, { physical: 100n, logical: 0n, clientId: 'hub' }),
+      currentEpoch: 1n,
+    })
+    // A pending op on tA that the removed frame must drop.
+    const ctx = { originClientId: 'clientA', clock: mgr.clock }
+    mgr.submit(newBatch([setTabTileId(ctx, TabType.AGENT, 'tA', 'tile')]))
+    expect(mgr.state.pendingBatches).toHaveLength(1)
+
+    const result = mgr.applyDelta(create(ResumeDeltaSchema, {
+      frames: [create(WatchUserEventSchema, {
+        event: {
+          case: 'entityRemoved',
+          value: create(EntityRemovedSchema, {
+            atHlc: create(HLCSchema, { physical: 200n, logical: 0n, clientId: 'hub' }),
+            entity: { case: 'tab', value: create(TabIdentSchema, { tabType: TabType.AGENT, tabId: 'tA' }) },
+          }),
+        },
+      })],
+      maxHlc: create(HLCSchema, { physical: 200n, logical: 0n, clientId: 'hub' }),
+      currentEpoch: 1n,
+    }))
+    // The tab was evicted from confirmedState...
+    expect(mgr.state.confirmedState.tabs.tA).toBeUndefined()
+    // ...and the pending op touching it was dropped, with the flag surfaced so
+    // the caller (useUserEvents) can fire onPendingDropped.
+    expect(mgr.state.pendingBatches).toHaveLength(0)
+    expect(result.droppedPending).toBe(true)
+  })
+
+  it('applyDelta installs an entity via a materialized frame', () => {
+    // #357 symmetric case: an entity that crossed INTO the subscriber's allowed
+    // set during the gap arrives as a materialized frame carrying the full
+    // record (not a raw move op that would leak pre-state from a hidden
+    // workspace). applyDelta installs it into confirmedState.
+    mgr.bootstrap({
+      userId: 'user',
+      nodes: {},
+      tabs: {},
+      floatingWindows: {},
+      workspaces: {},
+      maxHlc: create(HLCSchema, { physical: 100n, logical: 0n, clientId: 'hub' }),
+      currentEpoch: 1n,
+    })
+    mgr.applyDelta(create(ResumeDeltaSchema, {
+      frames: [create(WatchUserEventSchema, {
+        event: {
+          case: 'entityMaterialized',
+          value: create(EntityMaterializedSchema, {
+            atHlc: create(HLCSchema, { physical: 200n, logical: 0n, clientId: 'hub' }),
+            entity: { case: 'tab', value: { tabId: 'tNew', tabType: TabType.AGENT } },
+          }),
+        },
+      })],
+      maxHlc: create(HLCSchema, { physical: 200n, logical: 0n, clientId: 'hub' }),
+      currentEpoch: 1n,
+    }))
+    expect(mgr.state.confirmedState.tabs.tNew?.tabId).toBe('tNew')
+  })
+
+  it('isConfirmedPopulated is false before bootstrap and true once any entity map holds a record', () => {
+    // The resume refresh-guard uses this to decide whether a delta is safe to
+    // fold onto existing state. It must count ANY top-level entity map as
+    // populated (not just workspaces), so a state whose only record is, e.g.,
+    // a floating window still counts.
+    expect(mgr.isConfirmedPopulated()).toBe(false)
+    mgr.bootstrap({
+      userId: 'user',
+      nodes: {},
+      tabs: {},
+      floatingWindows: { fw1: { windowId: 'fw1' } },
+      workspaces: {},
+      maxHlc: create(HLCSchema, { physical: 1n, logical: 0n, clientId: 'hub' }),
+      currentEpoch: 1n,
+    })
+    expect(mgr.isConfirmedPopulated()).toBe(true)
+  })
+
   it('consumeBatchCommitted replaces clientHlc with canonicalHlc and applies to confirmed', () => {
     const ctx = { originClientId: 'clientA', clock: mgr.clock }
     const batch = newBatch([setNodeKind(ctx, 'n1', NodeKind.GRID)])
@@ -77,6 +275,28 @@ describe('pendingOpsManager', () => {
     expect(mgr.state.currentEpoch).toBe(7n)
     // Pending batch consumed.
     expect(mgr.state.pendingBatches.length).toBe(0)
+  })
+
+  it('consumeBatchCommitted refreshes currentEpoch even when no pending batch matches (idx < 0)', () => {
+    // Covers the EPOCH_REQUIRED-recovery branch: a batch reverted client-side
+    // (or one that originated on another client) has no entry in pendingBatches,
+    // but the hub's committed echo still carries the authoritative epoch. Skipping
+    // the refresh would leave currentEpoch stale so the next SubmitOps gets
+    // STALE_EPOCH and re-triggers a reconnect cycle. The branch also notifies
+    // (so the persistence effect re-evaluates) without touching confirmedState.
+    expect(mgr.state.currentEpoch).toBe(1n)
+    mgr.consumeBatchCommitted('batch-this-client-never-submitted', create(BatchCommittedSchema, {
+      committed: [],
+      maxHlc: create(HLCSchema, { physical: 1n, logical: 0n, clientId: 'hub' }),
+      epoch: 42n,
+    }))
+    // Epoch is authoritative regardless of whether the batch was pending here.
+    expect(mgr.state.currentEpoch).toBe(42n)
+    // No pending batch to consume, confirmedState untouched.
+    expect(mgr.state.pendingBatches.length).toBe(0)
+    // The resume watermark must NOT advance from a committed echo for a batch
+    // this client never held (no canonical op was applied here).
+    expect(mgr.state.resumeWatermark).toBeUndefined()
   })
 
   it('consumeBatchRejected drops the batch and reports retryable=false for non-retryable reasons', () => {
@@ -525,5 +745,825 @@ describe('pendingOpsManager', () => {
       mgr.submit(batch)
       expect(mgr.state.speculativeState.nodes.n1).toBeUndefined()
     })
+  })
+
+  describe('hydrate + confirmed-mutation observer (cross-refresh checkpoint)', () => {
+    /**
+     * Build a HydrationPayload mirroring what loadHydrationState would produce:
+     * a checkpoint UserCrdtState + op-log frames to replay. The checkpoint
+     * carries one node at physical 100; the op-log replays a batch that lands
+     * a second node at physical 200, advancing the watermark from T_c (100) to
+     * T_now (200).
+     */
+    function buildPayload(): HydrationPayload {
+      const state = create(UserCrdtStateSchema, {
+        userId: 'user',
+        nodes: { base: create(NodeRecordSchema, { nodeId: 'base' }) },
+        tabs: {},
+        floatingWindows: {},
+        workspaces: {},
+        maxHlc: create(HLCSchema, { physical: 100n, logical: 0n, clientId: 'hub' }),
+        currentEpoch: 5n,
+      })
+      const deltaOp = setNodeKind({ originClientId: 'other', clock: new HLCClock('other') }, 'replayed', NodeKind.GRID)
+      deltaOp.canonicalHlc = create(HLCSchema, { physical: 200n, logical: 0n, clientId: 'hub' })
+      const frame = create(WatchUserEventSchema, { event: { case: 'batch', value: newBatch([deltaOp]) } })
+      // A recorded op-log holds COMPLETE batch sequences: the batch frame plus
+      // the batch_end that closes it. The watermark advances only on batch_end,
+      // so a fixture without one would replay the ops but leave the cursor at
+      // T_c -- which is exactly the mid-sequence-drop case, not a normal log.
+      const end = create(WatchUserEventSchema, {
+        event: { case: 'batchEnd', value: { atHlc: create(HLCSchema, { physical: 200n, logical: 0n, clientId: 'hub' }) } },
+      })
+      return {
+        state,
+        frames: [frame, end],
+        watermark: create(HLCSchema, { physical: 100n, logical: 0n, clientId: 'hub' }),
+        currentEpoch: 5n,
+        truncated: false,
+        nextOpLogOrdinal: 0,
+      }
+    }
+
+    it('hydrate installs the checkpoint state and replays the op-log to T_now', () => {
+      const mgr = makeMgr()
+      const payload = buildPayload()
+      mgr.hydrate(payload)
+
+      // The checkpoint base node survives.
+      expect(mgr.state.confirmedState.nodes.base).toBeDefined()
+      // The replayed op landed on confirmedState.
+      expect(mgr.state.confirmedState.nodes.replayed?.kind?.value).toBe(NodeKind.GRID)
+      // Watermark advanced from T_c (100) to T_now (200) via the replay.
+      expect(mgr.state.resumeWatermark?.physical).toBe(200n)
+      expect(mgr.state.currentEpoch).toBe(5n)
+      // isConfirmedPopulated is true after hydrate — the refresh guard flows
+      // the watermark as the resume cursor.
+      expect(mgr.isConfirmedPopulated()).toBe(true)
+      // Speculative re-derived from the hydrated confirmed.
+      expect(mgr.state.speculativeState.nodes.replayed).toBeDefined()
+    })
+
+    it('hydrate with an empty op-log keeps the watermark at T_c', () => {
+      const mgr = makeMgr()
+      const payload = buildPayload()
+      mgr.hydrate({ ...payload, frames: [] })
+      expect(mgr.state.confirmedState.nodes.base).toBeDefined()
+      expect(mgr.state.resumeWatermark?.physical).toBe(100n)
+    })
+
+    it('hydrate disables recording during replay so replayed frames are not re-logged', () => {
+      const mgr = makeMgr()
+      const recorded: unknown[] = []
+      mgr.attachRecorder({
+        record: (frame: WatchUserEvent) => {
+          recorded.push(frame)
+        },
+        onCheckpointReset: () => {},
+      })
+      mgr.hydrate(buildPayload())
+      // The replayed frame must NOT be recorded (it's already in the op-log).
+      expect(recorded).toHaveLength(0)
+    })
+
+    it('the observer records confirmed frames after recording is enabled', () => {
+      const mgr = makeMgr()
+      const recorded: string[] = []
+      mgr.attachRecorder({
+        record: (frame: WatchUserEvent) => {
+          if (frame.event.case)
+            recorded.push(frame.event.case)
+        },
+        onCheckpointReset: () => {},
+      })
+
+      // bootstrap must NOT be recorded (it's a checkpoint reset, not an op).
+      mgr.bootstrap({
+        userId: 'user',
+        nodes: {},
+        tabs: {},
+        floatingWindows: {},
+        workspaces: {},
+        maxHlc: create(HLCSchema, { physical: 1n, logical: 0n, clientId: 'hub' }),
+        currentEpoch: 1n,
+      })
+      expect(recorded).toHaveLength(0)
+
+      // A confirmed remote batch IS recorded.
+      const op = setNodeKind({ originClientId: 'other', clock: new HLCClock('other') }, 'n1', NodeKind.LEAF)
+      op.canonicalHlc = create(HLCSchema, { physical: 2n, logical: 0n, clientId: 'hub' })
+      mgr.consumeRemote(newBatch([op]))
+      expect(recorded).toHaveLength(1)
+      expect(recorded[0]).toBe('batch')
+
+      // A speculative submit is NOT recorded.
+      const ctx = { originClientId: 'clientA', clock: mgr.clock }
+      mgr.submit(newBatch([setNodeKind(ctx, 'spec', NodeKind.LEAF)]))
+      expect(recorded).toHaveLength(1)
+    })
+
+    // This used to read "recording defaults to off, so an observer installed
+    // before setRecording records nothing" -- a state that no longer exists.
+    // Recording was gated by a separate boolean, so "hooks attached but
+    // recording off" was spellable and had to be asserted; attaching IS
+    // enabling now, and detaching is the only off switch. What still needs
+    // pinning is that a manager with NOTHING attached records nothing, and that
+    // detaching actually stops it.
+    it('records nothing with no recorder attached, and stops when one detaches', () => {
+      const mgr = makeMgr()
+      const recorded: unknown[] = []
+      const remote = (nodeId: string, at: number) => {
+        const op = setNodeKind({ originClientId: 'other', clock: new HLCClock('other') }, nodeId, NodeKind.LEAF)
+        op.canonicalHlc = create(HLCSchema, { physical: BigInt(at), logical: 0n, clientId: 'hub' })
+        return newBatch([op])
+      }
+
+      mgr.consumeRemote(remote('n1', 2))
+      expect(recorded).toHaveLength(0)
+
+      mgr.attachRecorder({
+        record: (frame: WatchUserEvent) => {
+          recorded.push(frame)
+        },
+        onCheckpointReset: () => {},
+      })
+      mgr.consumeRemote(remote('n2', 3))
+      expect(recorded).toHaveLength(1)
+
+      mgr.attachRecorder(null)
+      mgr.consumeRemote(remote('n3', 4))
+      expect(recorded).toHaveLength(1)
+    })
+
+    it('a delta received after hydrate folds onto the hydrated state', () => {
+      const mgr = makeMgr()
+      mgr.hydrate(buildPayload())
+      // Watermark is at 200 after hydrate. A delta at 300 must fold on top.
+      const deltaOp = setNodeKind({ originClientId: 'other', clock: new HLCClock('other') }, 'post-resume', NodeKind.SPLIT)
+      deltaOp.canonicalHlc = create(HLCSchema, { physical: 300n, logical: 0n, clientId: 'hub' })
+      mgr.applyDelta(create(ResumeDeltaSchema, {
+        frames: [create(WatchUserEventSchema, { event: { case: 'batch', value: newBatch([deltaOp]) } })],
+        maxHlc: create(HLCSchema, { physical: 300n, logical: 0n, clientId: 'hub' }),
+        currentEpoch: 5n,
+      }))
+      expect(mgr.state.confirmedState.nodes['post-resume']?.kind?.value).toBe(NodeKind.SPLIT)
+      expect(mgr.state.resumeWatermark?.physical).toBe(300n)
+      // The hydrated base + replayed nodes are still present.
+      expect(mgr.state.confirmedState.nodes.base).toBeDefined()
+      expect(mgr.state.confirmedState.nodes.replayed).toBeDefined()
+    })
+
+    it('consumeBatchCommitted then the echoed consumeRemote record the own batch ONCE (no double-record)', () => {
+      // The hub broadcasts every committed batch to ALL subscribers including
+      // the originator, so an originating client receives its own batch again
+      // via consumeRemote. Without the dedup key, the own batch would land in
+      // the op-log twice. This test pins the single-record contract.
+      const mgr = makeMgr()
+      const recorded: string[] = []
+      mgr.attachRecorder({
+        record: (frame: WatchUserEvent) => {
+          if (frame.event.case === 'batch')
+            recorded.push(frame.event.value.batchId)
+        },
+        onCheckpointReset: () => {},
+      })
+
+      // Seed a pending batch, then commit it (the SubmitOps echo path).
+      const ctx = { originClientId: 'clientA', clock: mgr.clock }
+      const op = setNodeKind(ctx, 'ownNode', NodeKind.LEAF)
+      const batch = newBatch([op], 'own-batch-1')
+      mgr.submit(batch)
+      mgr.consumeBatchCommitted('own-batch-1', create(BatchCommittedSchema, {
+        committed: [create(CommittedOpSchema, {
+          opId: op.opId,
+          canonicalHlc: create(HLCSchema, { physical: 2n, logical: 0n, clientId: 'hub' }),
+        })],
+        maxHlc: create(HLCSchema, { physical: 2n, logical: 0n, clientId: 'hub' }),
+        epoch: 1n,
+      }))
+      expect(recorded).toEqual(['own-batch-1'])
+
+      // The hub now broadcasts the same batch back (originator echo). The dedup
+      // key must suppress the second recording — the op-log already holds it.
+      const echoOp = setNodeKind(ctx, 'ownNode', NodeKind.LEAF)
+      echoOp.canonicalHlc = create(HLCSchema, { physical: 2n, logical: 0n, clientId: 'hub' })
+      mgr.consumeRemote(newBatch([echoOp], 'own-batch-1'))
+      expect(recorded).toEqual(['own-batch-1'])
+
+      // A genuinely remote batch (different batchId) records normally.
+      const remoteOp = setNodeKind({ originClientId: 'other', clock: new HLCClock('other') }, 'remoteNode', NodeKind.GRID)
+      remoteOp.canonicalHlc = create(HLCSchema, { physical: 3n, logical: 0n, clientId: 'hub' })
+      mgr.consumeRemote(newBatch([remoteOp], 'remote-batch-1'))
+      expect(recorded).toEqual(['own-batch-1', 'remote-batch-1'])
+    })
+
+    it('does not re-record an own batch the resume tail re-ships', () => {
+      // A socket drop can land between the SubmitOps response (which
+      // consumeBatchCommitted already logged) and the hub's broadcast of the
+      // same batch. The reconnect's resume tail then re-ships it -- the hub
+      // applies no origin filter to a tail -- so without the same dedup
+      // consumeRemote applies, the op-log ends up holding two frames for one
+      // batch_id, and every cold reload replays the batch twice.
+      const mgr = makeMgr()
+      const recorded: string[] = []
+      mgr.attachRecorder({
+        record: (frame: WatchUserEvent) => {
+          if (frame.event.case === 'batch')
+            recorded.push(frame.event.value.batchId)
+        },
+        onCheckpointReset: () => {},
+      })
+
+      const ctx = { originClientId: 'clientA', clock: mgr.clock }
+      const op = setNodeKind(ctx, 'ownNode', NodeKind.LEAF)
+      mgr.submit(newBatch([op], 'own-batch-1'))
+      mgr.consumeBatchCommitted('own-batch-1', create(BatchCommittedSchema, {
+        committed: [create(CommittedOpSchema, {
+          opId: op.opId,
+          canonicalHlc: create(HLCSchema, { physical: 2n, logical: 0n, clientId: 'hub' }),
+        })],
+        maxHlc: create(HLCSchema, { physical: 2n, logical: 0n, clientId: 'hub' }),
+        epoch: 1n,
+      }))
+      expect(recorded).toEqual(['own-batch-1'])
+
+      // The resume tail carries the lost echo AND a genuinely remote batch.
+      const echoOp = setNodeKind(ctx, 'ownNode', NodeKind.LEAF)
+      echoOp.canonicalHlc = create(HLCSchema, { physical: 2n, logical: 0n, clientId: 'hub' })
+      const remoteOp = setNodeKind({ originClientId: 'other', clock: new HLCClock('other') }, 'remoteNode', NodeKind.GRID)
+      remoteOp.canonicalHlc = create(HLCSchema, { physical: 3n, logical: 0n, clientId: 'hub' })
+      mgr.applyDelta(create(ResumeDeltaSchema, {
+        frames: [
+          create(WatchUserEventSchema, { event: { case: 'batch', value: newBatch([echoOp], 'own-batch-1') } }),
+          create(WatchUserEventSchema, { event: { case: 'batch', value: newBatch([remoteOp], 'remote-batch-1') } }),
+        ],
+        maxHlc: create(HLCSchema, { physical: 3n, logical: 0n, clientId: 'hub' }),
+        currentEpoch: 1n,
+      }))
+
+      // The own batch is logged once in total; the peer's is logged normally.
+      expect(recorded).toEqual(['own-batch-1', 'remote-batch-1'])
+      // Suppressing the RECORD never suppresses the APPLY: both batches landed.
+      expect(mgr.state.confirmedState.nodes.ownNode?.kind?.value).toBe(NodeKind.LEAF)
+      expect(mgr.state.confirmedState.nodes.remoteNode?.kind?.value).toBe(NodeKind.GRID)
+    })
+
+    it('records a tail-only batch that has no own-echo marker', () => {
+      // The other half of the dedup: a resume tail is mostly peer traffic and
+      // must still be logged, or a cold reload would replay a truncated log.
+      const mgr = makeMgr()
+      const recorded: string[] = []
+      mgr.attachRecorder({
+        record: (frame: WatchUserEvent) => {
+          if (frame.event.case)
+            recorded.push(frame.event.case)
+        },
+        onCheckpointReset: () => {},
+      })
+
+      const remoteOp = setNodeKind({ originClientId: 'other', clock: new HLCClock('other') }, 'peerNode', NodeKind.LEAF)
+      remoteOp.canonicalHlc = create(HLCSchema, { physical: 5n, logical: 0n, clientId: 'hub' })
+      mgr.applyDelta(create(ResumeDeltaSchema, {
+        frames: [
+          create(WatchUserEventSchema, { event: { case: 'batch', value: newBatch([remoteOp], 'peer-batch-1') } }),
+          create(WatchUserEventSchema, {
+            event: { case: 'batchEnd', value: { atHlc: create(HLCSchema, { physical: 5n, logical: 0n, clientId: 'hub' }) } },
+          }),
+        ],
+        maxHlc: create(HLCSchema, { physical: 5n, logical: 0n, clientId: 'hub' }),
+        currentEpoch: 1n,
+      }))
+
+      expect(recorded).toEqual(['batch', 'batchEnd'])
+    })
+
+    it('bounds the own-echo dedup set, evicting the oldest ids first', () => {
+      // bootstrap and hydrate are the only wholesale clears, and a client that
+      // keeps resuming runs neither -- so an id whose echo genuinely never
+      // arrives would otherwise be resident for the life of the page. Past the
+      // cap the oldest go first, and an evicted id costs exactly one duplicate
+      // op-log frame (harmless: re-applying a batch at the same canonical HLC
+      // fails shouldWrite's strict-greater compare).
+      const mgr = makeMgr()
+      const recorded: string[] = []
+      mgr.attachRecorder({
+        record: (frame: WatchUserEvent) => {
+          if (frame.event.case === 'batch')
+            recorded.push(frame.event.value.batchId)
+        },
+        onCheckpointReset: () => {},
+      })
+
+      const ctx = { originClientId: 'clientA', clock: mgr.clock }
+      const hlcAt = (n: number) => create(HLCSchema, { physical: BigInt(n), logical: 0n, clientId: 'hub' })
+      // One more commit than the cap holds, with NO echo arriving for any.
+      const overflow = MAX_OWN_ECHO_BATCH_IDS + 1
+      for (let i = 0; i < overflow; i++) {
+        const op = setNodeKind(ctx, `n${i}`, NodeKind.LEAF)
+        mgr.submit(newBatch([op], `b${i}`))
+        mgr.consumeBatchCommitted(`b${i}`, create(BatchCommittedSchema, {
+          committed: [create(CommittedOpSchema, { opId: op.opId, canonicalHlc: hlcAt(i + 1) })],
+          maxHlc: hlcAt(i + 1),
+          epoch: 1n,
+        }))
+      }
+      expect(recorded).toHaveLength(overflow)
+      recorded.length = 0
+
+      const echoOf = (i: number) => {
+        const op = setNodeKind(ctx, `n${i}`, NodeKind.LEAF)
+        op.canonicalHlc = hlcAt(i + 1)
+        return newBatch([op], `b${i}`)
+      }
+      // b0 was evicted as the oldest, so its late echo records a second time.
+      mgr.consumeRemote(echoOf(0))
+      expect(recorded).toEqual(['b0'])
+      // Everything still resident -- the new oldest and the newest -- dedups.
+      mgr.consumeRemote(echoOf(1))
+      mgr.consumeRemote(echoOf(overflow - 1))
+      expect(recorded).toEqual(['b0'])
+    })
+
+    it('advances the resume watermark ONLY at the batch boundary', () => {
+      // Every frame of one batch carries the SAME at_hlc (the batch's last-op
+      // HLC). Advancing per frame moved the cursor to the batch's max as soon as
+      // the FIRST frame landed, so a socket drop mid-sequence left the persisted
+      // cursor above ops that were never applied -- and the resume scan is
+      // strictly-greater, so the hub would never re-send them.
+      const mgr = makeMgr()
+      mgr.bootstrap({
+        userId: 'user',
+        nodes: {},
+        tabs: {},
+        floatingWindows: {},
+        workspaces: {},
+        maxHlc: create(HLCSchema, { physical: 100n, logical: 0n, clientId: 'hub' }),
+        currentEpoch: 1n,
+      })
+      const atHlc = create(HLCSchema, { physical: 300n, logical: 0n, clientId: 'hub' })
+
+      // Leading materialized frame of the batch's sequence: applied, but the
+      // cursor must NOT move -- the batch's own ops have not arrived yet.
+      mgr.consumeEntityMaterialized(create(EntityMaterializedSchema, {
+        atHlc,
+        entity: { case: 'node', value: create(NodeRecordSchema, { nodeId: 'crossed-in' }) },
+      }))
+      expect(mgr.state.confirmedState.nodes['crossed-in']).toBeDefined()
+      expect(mgr.state.resumeWatermark?.physical).toBe(100n)
+
+      // The batch frame lands. Still no advance: a trailing entity_removed for
+      // the same batch may yet follow, and losing it would leave a redacted
+      // entity rendered with the cursor already past the batch.
+      const op = setNodeKind({ originClientId: 'other', clock: new HLCClock('other') }, 'edited', NodeKind.GRID)
+      op.canonicalHlc = atHlc
+      mgr.consumeRemote(newBatch([op], 'seq-batch'))
+      expect(mgr.state.confirmedState.nodes.edited?.kind?.value).toBe(NodeKind.GRID)
+      expect(mgr.state.resumeWatermark?.physical).toBe(100n)
+
+      // The boundary closes the sequence: now, and only now, the cursor moves.
+      mgr.consumeBatchEnd(atHlc)
+      expect(mgr.state.resumeWatermark?.physical).toBe(300n)
+    })
+
+    it('does not advance the resume watermark on the SubmitOps echo', () => {
+      // The echo arrives over the Connect RPC, a transport wholly separate from
+      // the WS the hub's frames ride, so its ordering against a peer's in-flight
+      // batch is unconstrained. Advancing here moved the cursor past ops still
+      // sitting unread in the socket buffer; a drop then stranded them above a
+      // strictly-greater cursor forever. The hub does not suppress self-echo, so
+      // the batch's own batch_end still advances the cursor -- just at the
+      // boundary, where it is safe.
+      const mgr = makeMgr()
+      mgr.bootstrap({
+        userId: 'user',
+        nodes: {},
+        tabs: {},
+        floatingWindows: {},
+        workspaces: {},
+        maxHlc: create(HLCSchema, { physical: 100n, logical: 0n, clientId: 'hub' }),
+        currentEpoch: 1n,
+      })
+
+      const ctx = { originClientId: 'clientA', clock: mgr.clock }
+      const op = setNodeKind(ctx, 'ownNode', NodeKind.LEAF)
+      mgr.submit(newBatch([op], 'own-batch'))
+      mgr.consumeBatchCommitted('own-batch', create(BatchCommittedSchema, {
+        committed: [create(CommittedOpSchema, {
+          opId: op.opId,
+          canonicalHlc: create(HLCSchema, { physical: 500n, logical: 0n, clientId: 'hub' }),
+        })],
+        maxHlc: create(HLCSchema, { physical: 500n, logical: 0n, clientId: 'hub' }),
+        epoch: 1n,
+      }))
+
+      // The ops ARE applied to confirmedState -- only the cursor is withheld.
+      expect(mgr.state.confirmedState.nodes.ownNode?.kind?.value).toBe(NodeKind.LEAF)
+      expect(mgr.state.resumeWatermark?.physical).toBe(100n)
+
+      // The hub's broadcast of the same batch closes it, and the cursor moves.
+      mgr.consumeBatchEnd(create(HLCSchema, { physical: 500n, logical: 0n, clientId: 'hub' }))
+      expect(mgr.state.resumeWatermark?.physical).toBe(500n)
+    })
+
+    it('holds the cursor behind a peer batch that lost the race with the echo', () => {
+      // The concrete divergence the rule above prevents. Peer batch P commits at
+      // 400 and is queued on this client's socket; this client's own batch
+      // commits at 500 and its SubmitOps response is processed first. If the
+      // echo advanced the cursor to 500, a drop before P was read would leave a
+      // persisted cursor above P -- and ListUserOpBatchesAfter is
+      // strictly-greater, so P would never be re-sent.
+      const mgr = makeMgr()
+      mgr.bootstrap({
+        userId: 'user',
+        nodes: {},
+        tabs: {},
+        floatingWindows: {},
+        workspaces: {},
+        maxHlc: create(HLCSchema, { physical: 100n, logical: 0n, clientId: 'hub' }),
+        currentEpoch: 1n,
+      })
+
+      const ctx = { originClientId: 'clientA', clock: mgr.clock }
+      const own = setNodeKind(ctx, 'ownNode', NodeKind.LEAF)
+      mgr.submit(newBatch([own], 'own-batch'))
+      mgr.consumeBatchCommitted('own-batch', create(BatchCommittedSchema, {
+        committed: [create(CommittedOpSchema, {
+          opId: own.opId,
+          canonicalHlc: create(HLCSchema, { physical: 500n, logical: 0n, clientId: 'hub' }),
+        })],
+        maxHlc: create(HLCSchema, { physical: 500n, logical: 0n, clientId: 'hub' }),
+        epoch: 1n,
+      }))
+
+      // The socket drops here. The cursor must still be behind the peer's
+      // batch at 400, so the resume re-requests it.
+      expect(mgr.state.resumeWatermark?.physical).toBeLessThan(400n)
+    })
+
+    it('records each batch of a MULTI-batch submit exactly once across their echoes', () => {
+      // useOpsSubmitter aggregates over a 16ms window, so one SubmitOps commonly
+      // carries several batches and its response drives one
+      // consumeBatchCommitted per batch. A single-slot dedup key kept only the
+      // LAST id, so submitting {A, B} left the slot at B and A's echo recorded A
+      // a SECOND time -- every multi-batch submit double-logged all but its
+      // final batch, tripping the checkpoint threshold early and lengthening
+      // every cold-reload replay.
+      const mgr = makeMgr()
+      const recorded: string[] = []
+      mgr.attachRecorder({
+        record: (frame: WatchUserEvent) => {
+          if (frame.event.case === 'batch')
+            recorded.push(frame.event.value.batchId)
+        },
+        onCheckpointReset: () => {},
+      })
+
+      const ctx = { originClientId: 'clientA', clock: mgr.clock }
+      const opA = setNodeKind(ctx, 'nodeA', NodeKind.LEAF)
+      const opB = setNodeKind(ctx, 'nodeB', NodeKind.LEAF)
+      mgr.submit(newBatch([opA], 'multi-a'))
+      mgr.submit(newBatch([opB], 'multi-b'))
+
+      const commit = (opId: string, physical: bigint) => create(BatchCommittedSchema, {
+        committed: [create(CommittedOpSchema, {
+          opId,
+          canonicalHlc: create(HLCSchema, { physical, logical: 0n, clientId: 'hub' }),
+        })],
+        maxHlc: create(HLCSchema, { physical, logical: 0n, clientId: 'hub' }),
+        epoch: 1n,
+      })
+      mgr.consumeBatchCommitted('multi-a', commit(opA.opId, 2n))
+      mgr.consumeBatchCommitted('multi-b', commit(opB.opId, 3n))
+      expect(recorded).toEqual(['multi-a', 'multi-b'])
+
+      // Both echoes arrive; NEITHER may be recorded again.
+      const echo = (nodeId: string, batchId: string, physical: bigint) => {
+        const op = setNodeKind(ctx, nodeId, NodeKind.LEAF)
+        op.canonicalHlc = create(HLCSchema, { physical, logical: 0n, clientId: 'hub' })
+        return newBatch([op], batchId)
+      }
+      mgr.consumeRemote(echo('nodeA', 'multi-a', 2n))
+      mgr.consumeRemote(echo('nodeB', 'multi-b', 3n))
+      expect(recorded).toEqual(['multi-a', 'multi-b'])
+    })
+
+    it('bootstrap fires the checkpoint-reset observer and clears pending batches', () => {
+      // A bootstrap wholesale-replaces confirmedState from a fresh snapshot,
+      // so the persisted checkpoint+op-log MUST re-base. bootstrap fires the
+      // checkpoint-reset observer (wired by useCrdtRuntime to rewrite the
+      // checkpoint) and clears any in-flight speculative edits (the snapshot
+      // supersedes them).
+      const mgr = makeMgr()
+      let resets = 0
+      mgr.attachRecorder({
+        record: () => {},
+        onCheckpointReset: () => {
+          resets++
+        },
+      })
+
+      // Seed a pending batch against the pre-bootstrap state.
+      const ctx = { originClientId: 'clientA', clock: mgr.clock }
+      mgr.submit(newBatch([setNodeKind(ctx, 'speculative', NodeKind.LEAF)], 'pending-1'))
+      expect(mgr.state.pendingBatches).toHaveLength(1)
+
+      mgr.bootstrap({
+        userId: 'user',
+        nodes: {},
+        tabs: {},
+        floatingWindows: {},
+        workspaces: {},
+        maxHlc: create(HLCSchema, { physical: 1n, logical: 0n, clientId: 'hub' }),
+        currentEpoch: 1n,
+      })
+      expect(resets).toBe(1)
+      // The pending batch is cleared — the snapshot is authoritative.
+      expect(mgr.state.pendingBatches).toHaveLength(0)
+    })
+
+    it('hydrate clears pending batches and the own-batch dedup key', () => {
+      // A cold reload dies the old JS heap, so any in-flight speculative edits
+      // and the dedup key from the prior session are gone. hydrate resets them
+      // so a freshly-echoed batch isn't suppressed by a stale id.
+      const mgr = makeMgr()
+      mgr.submit(newBatch([setNodeKind({ originClientId: 'clientA', clock: mgr.clock }, 's', NodeKind.LEAF)], 'stale-1'))
+      expect(mgr.state.pendingBatches).toHaveLength(1)
+
+      mgr.hydrate(buildPayload())
+      expect(mgr.state.pendingBatches).toHaveLength(0)
+
+      // After hydrate, a consumeBatchCommitted for the stale id records (the
+      // dedup key was cleared) — though in practice the prior session's pending
+      // batch can't commit post-reload. This pins the "hydrate is a fresh
+      // lineage" contract.
+      const recorded: string[] = []
+      mgr.attachRecorder({
+        record: (frame: WatchUserEvent) => {
+          if (frame.event.case === 'batch')
+            recorded.push(frame.event.value.batchId)
+        },
+        onCheckpointReset: () => {},
+      })
+      // consumeRemote of a remote batch records (dedup key is null post-hydrate).
+      const remoteOp = setNodeKind({ originClientId: 'other', clock: new HLCClock('other') }, 'n', NodeKind.GRID)
+      remoteOp.canonicalHlc = create(HLCSchema, { physical: 250n, logical: 0n, clientId: 'hub' })
+      mgr.consumeRemote(newBatch([remoteOp], 'fresh-remote-1'))
+      expect(recorded).toEqual(['fresh-remote-1'])
+    })
+  })
+})
+
+// Client-side tombstone GC. Delta-resume removed the only one the client ever
+// had: applyOp installs a tombstone SHELL rather than deleting, and
+// materializedLocked omits tombstoned records, so every full-snapshot bootstrap
+// used to reset confirmedState to a tombstone-free base. A client that keeps
+// resuming never bootstraps, so from that point every closed tab, tile and
+// window stayed in confirmedState -- and in the serialized checkpoint blob --
+// forever. The hub never propagates its own pruning (PruneTombstonesAtOrBelow
+// edits server state and emits no ops).
+describe('pruneTombstonesAtOrBelow', () => {
+  function stateWithTombstones(): UserCrdtState {
+    return create(UserCrdtStateSchema, {
+      userId: 'u',
+      nodes: {
+        // No tombstoneAt at all -- a live record.
+        live: {},
+        old: { tombstoneAt: { physical: 5n, logical: 0n, clientId: 'hub' } },
+        atFloor: { tombstoneAt: { physical: 10n, logical: 0n, clientId: 'hub' } },
+        recent: { tombstoneAt: { physical: 20n, logical: 0n, clientId: 'hub' } },
+      },
+    })
+  }
+
+  it('drops tombstones at or below the floor and keeps everything else', () => {
+    const state = stateWithTombstones()
+    const pruned = pruneTombstonesAtOrBelow(state, create(HLCSchema, { physical: 10n, logical: 0n, clientId: 'hub' }))
+
+    expect(pruned).toBe(2)
+    // AT the floor goes too -- the hub's rule is "at or below".
+    expect(Object.keys(state.nodes).sort()).toEqual(['live', 'recent'])
+  })
+
+  it('is a no-op without a floor, so an un-watermarked client never prunes', () => {
+    const state = stateWithTombstones()
+    expect(pruneTombstonesAtOrBelow(state, undefined)).toBe(0)
+    expect(pruneTombstonesAtOrBelow(state, create(HLCSchema, {}))).toBe(0)
+    expect(Object.keys(state.nodes)).toHaveLength(4)
+  })
+
+  it('never drops a live record, whatever the floor', () => {
+    const state = stateWithTombstones()
+    pruneTombstonesAtOrBelow(state, create(HLCSchema, { physical: 1_000n, logical: 0n, clientId: 'hub' }))
+    expect(Object.keys(state.nodes)).toEqual(['live'])
+  })
+
+  it('keeps a pinned shell even when it is below the floor', () => {
+    const state = stateWithTombstones()
+    const pruned = pruneTombstonesAtOrBelow(
+      state,
+      create(HLCSchema, { physical: 1_000n, logical: 0n, clientId: 'hub' }),
+      new Set(['node:old']),
+    )
+    expect(pruned).toBe(2)
+    expect(Object.keys(state.nodes).sort()).toEqual(['live', 'old'])
+  })
+
+  it('pins by kind, so an id shared across maps is not over-pinned', () => {
+    const state = create(UserCrdtStateSchema, {
+      userId: 'u',
+      nodes: { shared: { tombstoneAt: { physical: 5n, logical: 0n, clientId: 'hub' } } },
+      tabs: { shared: { tombstoneAt: { physical: 5n, logical: 0n, clientId: 'hub' } } },
+    })
+    pruneTombstonesAtOrBelow(
+      state,
+      create(HLCSchema, { physical: 1_000n, logical: 0n, clientId: 'hub' }),
+      new Set(['node:shared']),
+    )
+    expect(Object.keys(state.nodes)).toEqual(['shared'])
+    expect(Object.keys(state.tabs)).toEqual([])
+  })
+})
+
+// A tombstone shell is the ONLY thing that makes apply.ts drop a later register
+// write, and compactTombstones re-derives speculativeState right after pruning.
+// Without pinning, that replay lands an unconfirmed local batch on the pruned
+// entity and `applyOp` lazily re-creates it as a LIVE record -- a ghost tab in
+// the tab bar that the checkpoint then serializes to disk.
+describe('pendingOpsManager compactTombstones with unconfirmed local ops', () => {
+  it('does not resurrect an entity a pending batch still targets', () => {
+    const mgr = makeMgr()
+    const ctx = { originClientId: 'clientA', clock: mgr.clock }
+
+    // A local drag that has not been confirmed yet.
+    mgr.submit(newBatch([setTabTileId(ctx, TabType.AGENT, 'tA', 'tile-b')]))
+    expect(mgr.state.pendingBatches).toHaveLength(1)
+
+    // A peer closes the tab, and batch_end moves the watermark past the
+    // tombstone so it becomes eligible for pruning.
+    const peerTombstone = tombstoneTab(
+      { originClientId: 'peer', clock: new HLCClock('peer') },
+      TabType.AGENT,
+      'tA',
+    )
+    peerTombstone.canonicalHlc = create(HLCSchema, { physical: 500n, logical: 0n, clientId: 'peer' })
+    mgr.consumeRemote(create(OpBatchSchema, { batchId: 'peer-batch', ops: [peerTombstone] }))
+    mgr.consumeBatchEnd(create(HLCSchema, { physical: 500n, logical: 0n, clientId: 'peer' }))
+
+    expect(mgr.state.confirmedState.tabs.tA?.tombstoneAt).toBeDefined()
+
+    mgr.compactTombstones()
+
+    // The shell survives, so the pending write is still suppressed and the
+    // speculative replay cannot re-create the tab as a live record.
+    expect(mgr.state.confirmedState.tabs.tA).toBeDefined()
+    expect(mgr.state.speculativeState.tabs.tA?.tombstoneAt).toBeDefined()
+    expect(mgr.state.speculativeState.tabs.tA?.tileId).not.toBe('tile-b')
+  })
+
+  // The SubmitOps echo rides the Connect RPC while the epoch also advances over
+  // the WS, with no ordering between the two transports and no in-flight guard
+  // in useOpsSubmitter. A response minted under the OLD epoch can therefore land
+  // after a bootstrap installed the new one; decideResume requires an EXACT
+  // epoch match, so regressing it costs a full projection snapshot on the next
+  // reconnect.
+  it('never regresses currentEpoch from a late SubmitOps echo', () => {
+    const mgr = makeMgr()
+    mgr.state.currentEpoch = 6n
+
+    mgr.consumeBatchCommitted('no-such-batch', create(BatchCommittedSchema, {
+      epoch: 5n,
+    }))
+    expect(mgr.state.currentEpoch).toBe(6n)
+
+    mgr.consumeBatchCommitted('no-such-batch', create(BatchCommittedSchema, {
+      epoch: 7n,
+    }))
+    expect(mgr.state.currentEpoch).toBe(7n)
+  })
+
+  it('still prunes once the pending batch is gone', () => {
+    const mgr = makeMgr()
+    const peerTombstone = tombstoneTab(
+      { originClientId: 'peer', clock: new HLCClock('peer') },
+      TabType.AGENT,
+      'tA',
+    )
+    peerTombstone.canonicalHlc = create(HLCSchema, { physical: 500n, logical: 0n, clientId: 'peer' })
+    mgr.consumeRemote(create(OpBatchSchema, { batchId: 'peer-batch', ops: [peerTombstone] }))
+    mgr.consumeBatchEnd(create(HLCSchema, { physical: 500n, logical: 0n, clientId: 'peer' }))
+
+    expect(mgr.compactTombstones()).toBe(1)
+    expect(mgr.state.confirmedState.tabs.tA).toBeUndefined()
+  })
+})
+
+// The two batch-boundary paths -- consumeBatchEnd (live) and applyFrames'
+// `batchEnd` arm (cold-reload replay / resume tail) -- are one rule now, and
+// these pin the half where they had ALREADY drifted: consumeBatchEnd refused a
+// missing at_hlc while applyFrames observed and advanced unguarded, so a
+// malformed frame moved the resume cursor on one path and not the other.
+describe('batch-end boundary', () => {
+  it('advances the watermark identically on the live and replay paths', () => {
+    const atHlc = create(HLCSchema, { physical: 42n, logical: 3n, clientId: 'hub' })
+
+    const live = makeMgr()
+    live.consumeBatchEnd(atHlc)
+
+    // The replay path reaches the same arm through hydrate(), which is how a
+    // cold reload re-applies the persisted op-log.
+    const replay = makeMgr()
+    replay.hydrate({
+      state: create(UserCrdtStateSchema, { userId: 'u' }),
+      frames: [create(WatchUserEventSchema, { event: { case: 'batchEnd', value: { atHlc } } })],
+      watermark: { physical: 1n, logical: 0n, clientId: 'hub' },
+      currentEpoch: 1n,
+      truncated: false,
+      nextOpLogOrdinal: 0,
+    })
+
+    expect(live.state.resumeWatermark?.physical).toBe(42n)
+    expect(replay.state.resumeWatermark?.physical).toBe(42n)
+    expect(replay.state.resumeWatermark?.logical).toBe(live.state.resumeWatermark?.logical)
+  })
+
+  it('refuses a batch_end with no at_hlc on BOTH paths', () => {
+    const live = makeMgr()
+    live.consumeBatchEnd(undefined)
+
+    // Hydrate pins the checkpoint watermark first, so the assertion is that the
+    // malformed frame does not move it OFF that pinned value.
+    const replay = makeMgr()
+    replay.hydrate({
+      state: create(UserCrdtStateSchema, { userId: 'u' }),
+      frames: [create(WatchUserEventSchema, { event: { case: 'batchEnd', value: {} } })],
+      watermark: { physical: 7n, logical: 0n, clientId: 'hub' },
+      currentEpoch: 1n,
+      truncated: false,
+      nextOpLogOrdinal: 0,
+    })
+
+    // A frame naming no boundary must not move the cursor: advancing on one
+    // would skip whatever the hub ships strictly after it, permanently.
+    expect(live.state.resumeWatermark).toBeUndefined()
+    expect(replay.state.resumeWatermark?.physical).toBe(7n)
+  })
+})
+
+describe('pendingOpsManager compactTombstones', () => {
+  it('prunes shells below the resume cursor and re-derives the projection base', () => {
+    const mgr = makeMgr()
+    mgr.state.confirmedState = create(UserCrdtStateSchema, {
+      userId: 'u',
+      nodes: {
+        live: {},
+        gone: { tombstoneAt: { physical: 5n, logical: 0n, clientId: 'hub' } },
+      },
+    })
+    mgr.state.resumeWatermark = create(HLCSchema, { physical: 9n, logical: 0n, clientId: 'hub' })
+
+    expect(mgr.compactTombstones()).toBe(1)
+    expect(Object.keys(mgr.state.confirmedState.nodes)).toEqual(['live'])
+    // speculativeState aliases confirmedState with no pending batches, so the
+    // prune must be visible through the projection source too.
+    expect(Object.keys(mgr.state.speculativeState.nodes)).toEqual(['live'])
+  })
+
+  it('prunes nothing before the client has a resume cursor', () => {
+    const mgr = makeMgr()
+    mgr.state.confirmedState = create(UserCrdtStateSchema, {
+      userId: 'u',
+      nodes: { gone: { tombstoneAt: { physical: 5n, logical: 0n, clientId: 'hub' } } },
+    })
+    mgr.state.resumeWatermark = undefined
+
+    expect(mgr.compactTombstones()).toBe(0)
+    expect(Object.keys(mgr.state.confirmedState.nodes)).toEqual(['gone'])
+  })
+})
+
+// The pin's fail-safe direction. An op body this build cannot map to an entity
+// means the pin set cannot be enumerated -- and an unpinned shell is exactly
+// what lets recomputeSpeculative resurrect a tombstoned record. So the whole
+// prune pass is skipped rather than run with a partial pin set.
+describe('pendingOpsManager compactTombstones with an unrecognized op', () => {
+  it('prunes nothing rather than pruning with a partial pin set', () => {
+    const mgr = makeMgr()
+    const peerTombstone = tombstoneTab(
+      { originClientId: 'peer', clock: new HLCClock('peer') },
+      TabType.AGENT,
+      'tA',
+    )
+    peerTombstone.canonicalHlc = create(HLCSchema, { physical: 500n, logical: 0n, clientId: 'peer' })
+    mgr.consumeRemote(create(OpBatchSchema, { batchId: 'peer-batch', ops: [peerTombstone] }))
+    mgr.consumeBatchEnd(create(HLCSchema, { physical: 500n, logical: 0n, clientId: 'peer' }))
+
+    // A pending batch carrying a body from a hypothetical newer build.
+    mgr.state.pendingBatches.push({
+      batchId: 'from-the-future',
+      ops: [{ opId: 'x', body: { case: 'someOpFromANewerBuild', value: {} } }],
+    } as never)
+
+    expect(mgr.compactTombstones()).toBe(0)
+    expect(mgr.state.confirmedState.tabs.tA).toBeDefined()
   })
 })

--- a/frontend/src/lib/crdt/pendingOps.ts
+++ b/frontend/src/lib/crdt/pendingOps.ts
@@ -1,5 +1,7 @@
+import type { MessageInitShape } from '@bufbuild/protobuf'
 import type { HLCClock } from './hlc'
-import type { FloatingWindowRecord, NodeRecord, TabRecord, UserCrdtState, WorkspaceContentsRecord } from '~/generated/leapmux/v1/user_crdt_pb'
+import type { HydrationPayload } from './hydrate'
+import type { FloatingWindowRecord, HLC, NodeRecord, TabRecord, UserCrdtState, WorkspaceContentsRecord } from '~/generated/leapmux/v1/user_crdt_pb'
 import type {
   BatchCommitted,
   BatchRejection,
@@ -8,6 +10,8 @@ import type {
   EntityMaterialized,
   EntityRemoved,
   OpBatch,
+  ResumeDelta,
+  WatchUserEvent,
 } from '~/generated/leapmux/v1/user_ops_pb'
 import { clone, create } from '@bufbuild/protobuf'
 import {
@@ -17,9 +21,11 @@ import {
   UserCrdtStateSchema,
   WorkspaceContentsRecordSchema,
 } from '~/generated/leapmux/v1/user_crdt_pb'
-import { BatchRejectionReason } from '~/generated/leapmux/v1/user_ops_pb'
+import { BatchRejectionReason, WatchUserEventSchema } from '~/generated/leapmux/v1/user_ops_pb'
 import { applyOp, newState } from './apply'
-import { hlcClone } from './hlc'
+import { entityKey, entityMapFor, TOMBSTONED_CHUNK_KINDS } from './checkpointChunks'
+import { hlcClone, hlcCmp, hlcIsZero, hlcMax } from './hlc'
+import { opTarget, opTargetKey } from './ops'
 
 /**
  * PendingOpsState captures the local layered view: confirmed (from
@@ -31,7 +37,31 @@ export interface PendingOpsState {
   confirmedState: UserCrdtState
   speculativeState: UserCrdtState
   pendingBatches: OpBatch[]
+  /**
+   * The epoch the hub most recently reported (bootstrap snapshot, ResumeDelta,
+   * or a BatchCommitted echo). The resume watermark is sent under THIS epoch,
+   * so the two are one value — there is no separate "resume epoch" that could
+   * drift out of lockstep.
+   */
   currentEpoch: bigint
+  /**
+   * The resume cursor: the highest canonical HLC this client is willing to
+   * assert it has applied EVERYTHING at or below. useUserEvents sends it on
+   * reconnect (alongside currentEpoch) so the hub can ship a delta instead of a
+   * full snapshot, and the checkpoint persists it across refreshes.
+   *
+   * It advances ONLY at a batch boundary — the `batch_end` frame — plus the two
+   * whole-state installs that define a boundary by construction (`bootstrap`'s
+   * snapshot max, `hydrate`'s checkpoint watermark, and `applyDelta`'s
+   * `max_hlc`). Individual remote ops, entity_materialized and entity_removed
+   * frames observe their HLC into the clock but deliberately do NOT move this;
+   * see the BatchEnd proto doc for why a mid-batch cursor strands the rest of
+   * that batch's frames above a strictly-greater watermark forever.
+   *
+   * Never advanced by speculative local client_hlc from submit(), which the hub
+   * does not know about.
+   */
+  resumeWatermark?: HLC
 }
 
 /**
@@ -62,6 +92,187 @@ const EPOCH_REFRESH_REJECTIONS = new Set<BatchRejectionReason>([
   BatchRejectionReason.BATCH_REJECTION_STALE_EPOCH,
 ])
 
+/**
+ * Hard cap on `PendingOpsManager.pendingOwnEchoBatchIds`, the set of batch_ids
+ * awaiting their own broadcast echo. A JS Set iterates in insertion order, so
+ * the overflow eviction is oldest-first.
+ *
+ * An echo follows its commit within a round trip, and a reconnect's resume tail
+ * re-delivers the ones a socket drop lost, so an id still resident 512 submits
+ * later is one whose echo is never coming -- orders of magnitude above what the
+ * submitter can have in flight (one SubmitOps per 16ms flush window, a handful
+ * of batches each). The cap is what makes the set BOUNDED rather than merely
+ * usually-small: bootstrap and hydrate clear it wholesale, but a session that
+ * keeps resuming runs neither, so without a cap the residue would grow for the
+ * life of the page.
+ */
+export const MAX_OWN_ECHO_BATCH_IDS = 512
+
+/**
+ * A confirmed-mutation observer. Fires per confirmed WatchUserEvent frame
+ * applied to confirmedState (live broadcast batch/entity frames, a resume
+ * delta's frames, or a synthesized batch frame from a SubmitOps echo). Used by
+ * useCrdtRuntime to append each frame to the persisted op-log so a cold reload
+ * can replay the post-checkpoint frames and re-reach the tight resume cursor.
+ *
+ * ONCE per batch_id, not once per frame carrying it: the hub echoes a batch
+ * this client submitted back to it, on the live broadcast and again on a resume
+ * tail, and consumeBatchCommitted already recorded that batch when the SubmitOps
+ * response landed. Those echoes are suppressed (see pendingOwnEchoBatchIds).
+ *
+ * The frame passed is the SAME WatchUserEvent the hub sent (for wire-origin
+ * frames) or a synthesized `batch` frame carrying the canonical-HLC-stamped ops
+ * (for consumeBatchCommitted, which has no inbound wire frame). bootstrap is
+ * NOT recorded — it is a checkpoint reset, not an incremental op.
+ *
+ * Recording is on for as long as a recorder is attached (see attachRecorder),
+ * and suppressed only while hydrate() replays the
+ * op-log through the same consume* handlers and MUST NOT re-record those
+ * frames, or the log would grow by N entries on every cold reload.
+ */
+export type ConfirmedMutationObserver = (frame: WatchUserEvent) => void
+
+/**
+ * Optional callback fired when a `bootstrap()` wholesale-replaces confirmedState
+ * from a fresh hub snapshot. A bootstrap is a checkpoint RESET — the snapshot's
+ * state@maxHlc is a perfect checkpoint base, and any op-log frames accumulated
+ * since the last checkpoint describe the now-discarded state. useCrdtRuntime
+ * wires this to rewrite the checkpoint (establishing the new base) and truncate
+ * the op-log, so the persisted pair can never drift from the live state across
+ * a FALLBACK (which arrives as `initial` → bootstrap). Without this, a FALLBACK
+ * after hydration leaves the persisted pair stale while recording keeps
+ * appending to it, so the next cold reload replays a stale log onto a stale
+ * base and re-triggers the FALLBACK in a loop.
+ */
+export type CheckpointResetObserver = () => void
+
+/**
+ * The persistence hooks a checkpoint recorder installs, as ONE value.
+ *
+ * They are always installed together, torn down together, and come from the
+ * same recorder -- so passing them as a pair is what makes "an observer with no
+ * recorder" and "a recorder with only half its hooks" unspellable.
+ */
+export interface RecorderHooks {
+  record: ConfirmedMutationObserver
+  onCheckpointReset: CheckpointResetObserver
+}
+
+/**
+ * Whether a confirmed state holds any entity at all.
+ *
+ * The rule the resume refresh-guard turns on, factored out of
+ * `PendingOpsManager.isConfirmedPopulated` so a TEST DOUBLE can call the real
+ * predicate instead of hand-copying it. A fake that re-implements the branch
+ * under test asserts against its own copy: the production rule could gain a
+ * fifth map or invert a condition and every cursor-suppression case would stay
+ * green. One definition, two callers, no drift.
+ */
+export function isStatePopulated(state: {
+  workspaces?: Record<string, unknown>
+  nodes?: Record<string, unknown>
+  tabs?: Record<string, unknown>
+  floatingWindows?: Record<string, unknown>
+}): boolean {
+  return Object.keys(state.workspaces ?? {}).length > 0
+    || Object.keys(state.nodes ?? {}).length > 0
+    || Object.keys(state.tabs ?? {}).length > 0
+    || Object.keys(state.floatingWindows ?? {}).length > 0
+}
+
+/**
+ * Drop every node / tab / floating-window record whose `tombstoneAt` is at or
+ * below `floor`. Mutates `state` in place; returns how many records went.
+ *
+ * The client mirror of the hub's `PruneTombstonesAtOrBelow`, and it exists
+ * because delta-resume removed the only GC the client ever had. `applyOp`
+ * installs a tombstone SHELL rather than deleting (so a late op cannot resurrect
+ * the record), and `materializedLocked` omits tombstoned records — so every
+ * full-snapshot bootstrap used to reset `confirmedState` to a tombstone-free
+ * base. A client that keeps resuming never bootstraps, so from that point on
+ * every tab, tile and window it ever closed stayed in `confirmedState` forever,
+ * and since the checkpoint serializes exactly that state, the persisted blob and
+ * the cold-start replay grew without bound. The hub never propagates its own
+ * pruning either: `PruneTombstonesAtOrBelow` edits server state and emits no ops.
+ *
+ * SAFETY mirrors the hub's argument, but needs ONE extra precondition the hub
+ * gets for free. Canonical HLCs are monotonic and frames arrive in commit order,
+ * so once the resume watermark reaches W every REMOTE frame this client will
+ * ever see afterwards carries an HLC strictly above W, and a tombstone at or
+ * below W can never be contradicted by one.
+ *
+ * Local pending ops are not remote frames. `applyOp` lazily creates a missing
+ * record, and the tombstone SHELL is the only thing that makes
+ * `applySetTabRegister` and friends drop a write — so deleting the shell while a
+ * batch targeting that entity is still unconfirmed lets `recomputeSpeculative`
+ * replay that batch onto nothing and resurrect the entity as a LIVE record. The
+ * hub has no speculative layer, which is why its own PruneTombstonesAtOrBelow
+ * needs no such guard.
+ *
+ * `pinned` is that precondition: entity keys (see `opTargetKey`) whose shells
+ * must survive this pass. Callers with unconfirmed local state MUST pass it.
+ * Nothing is lost by keeping a shell one round longer — the next compaction
+ * collects it once the batch settles.
+ */
+export function pruneTombstonesAtOrBelow(
+  state: UserCrdtState,
+  floor: HLC | undefined,
+  pinned?: ReadonlySet<string>,
+): number {
+  if (!floor || hlcIsZero(floor))
+    return 0
+  let pruned = 0
+  // Driven by the SHARDS table and keyed with `entityKey`, rather than a
+  // hand-written kind->map list and an inline `${kind}:${id}` template. Those
+  // were a third copy of a vocabulary `checkpointChunks` (SHARDS / entityKey)
+  // and `ops` (opTarget / opTargetKey) already own, and the copy was the one
+  // nothing checked: a new tombstoned entity kind added to the proto is forced
+  // into SHARDS by `_everyMapIsSharded`, but a hand-written list here would
+  // simply never see it -- and this is the ONLY client-side GC for tombstone
+  // shells, so the miss is silent and unbounded.
+  for (const kind of TOMBSTONED_CHUNK_KINDS) {
+    const map = entityMapFor(state, kind)
+    for (const [id, record] of Object.entries(map)) {
+      const ts = (record as { tombstoneAt?: HLC }).tombstoneAt
+      if (!ts || hlcIsZero(ts))
+        continue
+      if (pinned?.has(entityKey(kind, id)))
+        continue
+      if (hlcCmp(ts, floor) <= 0) {
+        delete map[id]
+        pruned++
+      }
+    }
+  }
+  return pruned
+}
+
+/**
+ * Every entity key any op across `batches` targets, or `null` when some op's
+ * body this build does not recognize.
+ *
+ * `null` means "cannot enumerate", and the only safe response is to prune
+ * NOTHING this round -- the caller's contract. Returning a partial set instead
+ * would leave the unrecognized op's entity unpinned, and an unpinned shell is
+ * exactly what lets `recomputeSpeculative` resurrect a tombstoned record. The
+ * mapping itself lives in `opTarget` (ops.ts), shared with the checkpoint's
+ * dirty-set so the two cannot disagree about a newly added op kind.
+ */
+export function pendingEntityKeys(batches: readonly { ops: CrdtOp[] }[]): Set<string> | null {
+  const keys = new Set<string>()
+  for (const batch of batches) {
+    for (const op of batch.ops) {
+      const target = opTarget(op)
+      if (target.case === 'unknown')
+        return null
+      const key = opTargetKey(target)
+      if (key !== null)
+        keys.add(key)
+    }
+  }
+  return keys
+}
+
 /** PendingOpsManager is the local CRDT-aware queue. */
 export class PendingOpsManager {
   state: PendingOpsState
@@ -73,6 +284,55 @@ export class PendingOpsManager {
    * mutation; callers are responsible for batching if needed.
    */
   private readonly notify?: () => void
+  /**
+   * Optional confirmed-mutation observer. When set AND `recording` is true,
+   * each confirmed entry point (consumeRemote / consumeBatchCommitted /
+   * consumeEntityMaterialized / consumeEntityRemoved / applyDelta) records its
+   * WatchUserEvent frame. See ConfirmedMutationObserver.
+   */
+  private attached?: RecorderHooks
+  /**
+   * Suppresses recording during hydrate()'s own op-log replay, so the frames
+   * being replayed are not appended back onto the log they came from.
+   *
+   * PRIVATE, and the only remaining gate. There used to be a public
+   * `setRecording` as well, giving four states across two nullable observers
+   * and a boolean when only two are meaningful -- `record` had to test
+   * `this.recording && this.observeConfirmed` precisely because "observer
+   * installed but recording off" and "recording on with no observer" were both
+   * spellable. Attaching a recorder now IS enabling recording.
+   */
+  private replaying = false
+  /**
+   * batch_ids recorded via consumeBatchCommitted whose wire echo has not yet
+   * arrived. The hub broadcasts every committed batch back to ALL subscribers
+   * including the originator, so an originating client receives its own batch
+   * again through consumeRemote — without this dedup the originator's own batch
+   * would be recorded twice (once synthesized by consumeBatchCommitted, once
+   * from the wire echo), doubling op-log growth for self-traffic.
+   *
+   * A SET, not a single slot: one SubmitOps carries every batch the submitter's
+   * flush window aggregated, and its response drives one consumeBatchCommitted
+   * per batch. A single slot kept only the LAST id, so submitting {A, B} left
+   * the slot at B and A's echo re-recorded A — every multi-batch submit
+   * double-logged all but its final batch, tripping the checkpoint threshold
+   * early and lengthening every cold-reload replay.
+   *
+   * An id is removed when its echo lands, on EITHER path that can carry it: the
+   * live broadcast (consumeRemote) or, when a socket drop lost that broadcast,
+   * the reconnect's resume tail (applyFrames' `batch` arm), which re-ships the
+   * same batch_id because the hub applies no origin filter.
+   *
+   * bootstrap and hydrate clear the whole set, but neither is guaranteed to run
+   * again -- a client that keeps resuming never bootstraps -- so those are not
+   * the bound. MAX_OWN_ECHO_BATCH_IDS is: the residue no echo ever reaches (the
+   * hub redacted every op of a self-originated batch, so no batch frame carries
+   * the id back) is evicted oldest-first, and an evicted id is merely a batch
+   * whose echo would be logged twice. Harmless on replay -- re-applying a batch
+   * at the same canonical HLC fails `shouldWrite`'s strict-greater compare --
+   * and the op-log is bounded by the checkpoint rewrite either way.
+   */
+  private readonly pendingOwnEchoBatchIds = new Set<string>()
 
   constructor(
     // Seeds the pre-bootstrap placeholder state only, and is deliberately NOT
@@ -94,6 +354,68 @@ export class PendingOpsManager {
     this.notify = notify
   }
 
+  /**
+   * Attach the persistence hooks, or `null` to detach.
+   *
+   * ONE call rather than three setters. The two hooks are always installed
+   * together from the same recorder and always torn down together, and
+   * recording is on for exactly as long as one is attached -- so the previous
+   * three-knob API could express two states that mean nothing, and the ordering
+   * contract between them lived only in the caller's comments.
+   */
+  attachRecorder(hooks: RecorderHooks | null): void {
+    this.attached = hooks ?? undefined
+  }
+
+  /** Record a confirmed frame, unless this is hydrate() replaying the log. */
+  private record(frame: WatchUserEvent): void {
+    if (!this.replaying)
+      this.attached?.record(frame)
+  }
+
+  /**
+   * Wrap one oneof arm in a WatchUserEvent and record it. Every confirmed entry
+   * point persists its frame in exactly this shape, so the envelope is built in
+   * one place rather than five.
+   *
+   * Takes the INIT shape, not `WatchUserEvent['event']`: the latter demands
+   * fully-constructed messages (`$typeName` and all), while these call sites
+   * pass partial initializers like `{ atHlc }`.
+   */
+  private recordFrame(event: MessageInitShape<typeof WatchUserEventSchema>['event']): void {
+    this.record(create(WatchUserEventSchema, { event }))
+  }
+
+  /**
+   * Advance the resume watermark to the max of itself and `hlc`.
+   *
+   * Callers are exactly the batch-boundary sites: the `batch_end` frame arm of
+   * applyFrames, consumeBatchEnd, and applyDelta's `max_hlc`. (bootstrap and
+   * hydrate assign `resumeWatermark` outright rather than coming through here,
+   * because they REPLACE confirmedState instead of advancing over it.) Never
+   * called with a speculative client_hlc. The watermark is always read
+   * alongside currentEpoch (the epoch the hub reported it under), so callers do
+   * not pass an epoch here.
+   */
+  private advanceWatermark(hlc: HLC | undefined): void {
+    this.state.resumeWatermark = hlcMax(this.state.resumeWatermark, hlc)
+  }
+
+  /**
+   * True iff confirmedState holds at least one record in any of its top-level
+   * entity maps. The resume refresh-guard uses this to decide whether a delta
+   * is safe to fold onto the existing state (a delta is a catch-up over the
+   * current visible set, not a full replacement, so folding it onto empty
+   * state — a cold start / page refresh — would yield partial state).
+   * Authoring the populated check here (next to the state whose shape it
+   * describes) keeps the "what counts as populated" knowledge with the schema,
+   * so a future top-level map addition is naturally covered by updating one
+   * place rather than every caller re-enumerating the maps.
+   */
+  isConfirmedPopulated(): boolean {
+    return isStatePopulated(this.state.confirmedState)
+  }
+
   /** Seed the confirmed + speculative state from a fresh UserMaterialized. */
   bootstrap(materialized: { userId: string, nodes: Record<string, unknown>, tabs: Record<string, unknown>, floatingWindows: Record<string, unknown>, workspaces: Record<string, WorkspaceContentsRecord>, maxHlc?: { physical: bigint, logical: bigint, clientId: string }, currentEpoch: bigint }): void {
     const confirmed = create(UserCrdtStateSchema, {
@@ -103,13 +425,191 @@ export class PendingOpsManager {
       floatingWindows: materialized.floatingWindows as never,
       workspaces: materialized.workspaces as never,
       maxHlc: hlcClone(materialized.maxHlc as never),
-      currentEpoch: materialized.currentEpoch,
     })
     this.state.confirmedState = confirmed
+    // currentEpoch has ONE authoritative home on PendingOpsState: it is read by
+    // useOpsSubmitter (SubmitOps) and useUserEvents (the resume cursor). The
+    // confirmedState.currentEpoch proto field is NOT mirrored here, because
+    // applyDelta / consumeBatchCommitted advance ONLY this.state.currentEpoch
+    // and a mirrored copy would silently drift until the next bootstrap.
     this.state.currentEpoch = materialized.currentEpoch
+    // A full bootstrap RESETS the watermark: confirmedState is now exactly at
+    // the snapshot's max_hlc under its epoch, so that is the new resume point
+    // (overwriting any stale pre-reconnect value). This also covers the FALLBACK
+    // path: when the hub could not resume, it sent `initial`, and the client's
+    // watermark is re-seeded here from the fresh snapshot.
+    this.state.resumeWatermark = hlcClone(materialized.maxHlc as never)
+    // A bootstrap discards every pre-existing confirmed-state lineage: clear the
+    // own-batch dedup key so a freshly-echoed batch isn't suppressed by an id
+    // carried over from before the reset, and clear any pending batches (the
+    // fresh snapshot supersedes speculative edits in flight against the discarded
+    // state — the hub's authoritative view is now confirmedState).
+    this.pendingOwnEchoBatchIds.clear()
+    this.state.pendingBatches = []
     this.recomputeSpeculative()
     this.clock.observe(materialized.maxHlc as never)
     this.notify?.()
+    // The snapshot IS a perfect checkpoint base (state@maxHlc under its epoch),
+    // so fire the reset observer: useCrdtRuntime rewrites the checkpoint +
+    // truncates the op-log so the persisted pair matches the live state. Without
+    // this, a FALLBACK after hydration (the hub sends `initial` because it could
+    // not resume the hydrated cursor) leaves the persisted pair stale while
+    // recording keeps appending, and the next cold reload replays a stale log
+    // onto a stale base, re-triggering the FALLBACK in a loop.
+    this.attached?.onCheckpointReset()
+  }
+
+  /**
+   * Hydrate confirmedState from a persisted checkpoint + op-log on a cold
+   * reload. Unlike bootstrap() (which RESETS the watermark from a fresh hub
+   * snapshot), hydrate pins the watermark to the checkpoint's `T_c` and then
+   * replays the op-log frames through the SAME consume* handlers a live
+   * broadcast uses — so confirmedState advances from T_c to T_now and the
+   * watermark advances to T_now, letting the client present the TIGHT resume
+   * cursor and receive a minimal delta. Recording is disabled during replay
+   * so the replayed frames are not re-appended to the op-log.
+   *
+   * Pure: takes already-parsed objects (no IDB, no proto codecs), so the
+   * hydration policy (wipe-both-on-parse-failure) lives in hydrate.ts and this
+   * method is unit-testable in isolation.
+   */
+  hydrate(payload: HydrationPayload): void {
+    // Install the checkpoint base. The state already carries its own maxHlc
+    // (serialized in the blob), so no re-derive is needed — observe it into
+    // the clock so the next Tick is strictly greater.
+    this.state.confirmedState = payload.state
+    this.state.currentEpoch = payload.currentEpoch
+    this.state.resumeWatermark = hlcClone(payload.watermark)
+    if (payload.state.maxHlc)
+      this.clock.observe(payload.state.maxHlc)
+    // A fresh hydrate clears the pending set + own-batch dedup key: the
+    // checkpoint+op-log lineage is authoritative, and any in-flight speculative
+    // edits from a prior (pre-reload) session died with the old JS heap.
+    this.state.pendingBatches = []
+    this.pendingOwnEchoBatchIds.clear()
+
+    // Replay the op-log through the SAME frame dispatch a ResumeDelta uses,
+    // WITHOUT recording (these frames are already persisted; re-recording would
+    // duplicate them on the next cold reload).
+    const wasReplaying = this.replaying
+    this.replaying = true
+    try {
+      // droppedPending is structurally always false here: pendingBatches was
+      // just cleared above, so dropPendingByPredicate has nothing to drop.
+      this.applyFrames(payload.frames)
+    }
+    finally {
+      this.replaying = wasReplaying
+    }
+    this.recomputeSpeculative()
+    this.notify?.()
+  }
+
+  /**
+   * Apply an ordered WatchUserEvent stream to confirmedState, recording each
+   * frame (subject to the replay suppression and the own-echo dedup below). The
+   * SINGLE dispatch shared by the cold-reload op-log replay (`hydrate`) and the
+   * resume tail (`applyDelta`), so the two cannot drift on a newly-added frame
+   * arm — they previously kept two hand-synced copies of this switch.
+   *
+   * Returns whether any pending batch was dropped by an `entityRemoved` frame,
+   * which the caller surfaces as a user-visible "pending edit dropped" notice.
+   */
+  private applyFrames(frames: readonly WatchUserEvent[]): { droppedPending: boolean } {
+    let droppedPending = false
+    for (const frame of frames) {
+      // Whether this frame still needs appending to the op-log. Only the `batch`
+      // arm can answer no -- see below.
+      let unlogged = true
+      switch (frame.event.case) {
+        case 'entityMaterialized':
+          this.applyMaterializedCore(frame.event.value)
+          break
+        case 'batch':
+          this.applyRemoteBatch(frame.event.value)
+          // The SAME own-echo dedup consumeRemote applies, because the hub
+          // applies no origin filter to a resume tail either: a batch this
+          // client submitted and consumeBatchCommitted already logged comes
+          // back down the tail whenever the live broadcast was lost to the
+          // socket drop that caused the resume. Recording it again would put
+          // two frames for one batch_id in the op-log.
+          unlogged = !this.pendingOwnEchoBatchIds.delete(frame.event.value.batchId)
+          break
+        case 'entityRemoved':
+          if (this.applyRemovedCore(frame.event.value).droppedPending)
+            droppedPending = true
+          break
+        case 'batchEnd':
+          this.applyBatchEndCore(frame.event.value.atHlc)
+          break
+        default:
+          // Empty / unknown / bootstrap-only arms (initial, delta, presence):
+          // skip. Do not advance the watermark on a frame that installed
+          // nothing.
+          break
+      }
+      // Record each applied frame — a resume delta's frames advanced
+      // confirmedState, so a cold reload must replay them too. hydrate()
+      // disables recording during ITS replay so these aren't double-logged.
+      if (unlogged)
+        this.record(frame)
+    }
+    return { droppedPending }
+  }
+
+  /**
+   * Fold a remote (or echoed) batch into confirmedState: observe + apply each
+   * op's canonical HLC, and drop any locally-pending batch with the same id
+   * (the canonical echo replaces the
+   * speculative client_hlc). Shared by `applyDelta` (a ResumeDelta's tail) and
+   * `consumeRemote` (a live broadcast) so the two catch-up paths cannot drift
+   * on the observe/apply rule — they previously hand-duplicated this loop and
+   * had already diverged on whether the watermark advanced per-op.
+   *
+   * It does NOT advance the resume watermark; `batch_end` is the sole advance
+   * point (see advanceWatermark). Every frame of a batch carries the same
+   * at_hlc, so advancing here would jump the cursor to the batch max on its
+   * FIRST frame, and a socket drop mid-sequence would strand the rest above a
+   * strictly-greater cursor the hub never re-ships -- now persisted into the
+   * checkpoint, so it would survive refreshes too.
+   */
+  private applyRemoteBatch(batch: OpBatch): void {
+    const idx = this.state.pendingBatches.findIndex(b => b.batchId === batch.batchId)
+    for (const op of batch.ops) {
+      this.clock.observe(op.canonicalHlc)
+      applyOp(this.state.confirmedState, op)
+    }
+    // No watermark advance here either: an entity_removed frame for the same
+    // batch may still follow, and losing it would leave a redacted entity
+    // rendered with the cursor already past the batch. `batchEnd` closes it.
+    if (idx >= 0)
+      this.state.pendingBatches.splice(idx, 1)
+  }
+
+  /**
+   * Apply a ResumeDelta: the ordered WatchUserEvent frame stream the hub
+   * shipped instead of a full snapshot on a successful resume. Frames use the
+   * SAME envelope live Send uses (entityMaterialized | batch | entityRemoved),
+   * so this dispatches each through the SAME handler a live broadcast uses
+   * (applyMaterializedCore / applyRemoteBatch / applyRemovedCore), WITHOUT the
+   * wholesale confirmedState replace bootstrap performs, and WITHOUT disturbing
+   * pendingBatches beyond dropping any batch whose id the tail echoes back.
+   * Observes max_hlc into the clock AND advances the resume watermark to it.
+   *
+   * Note: a repeated batch frame is RE-APPLIED, not skipped — re-application is
+   * a no-op because `shouldWrite` is a strict-greater LWW compare on the same
+   * canonical HLC. The batch_id dedup on this path governs RECORDING only: a
+   * self-originated batch consumeBatchCommitted already appended to the op-log
+   * is not appended a second time when the tail re-ships it.
+   */
+  applyDelta(delta: ResumeDelta): { droppedPending: boolean } {
+    const { droppedPending } = this.applyFrames(delta.frames)
+    this.state.currentEpoch = delta.currentEpoch
+    this.clock.observe(delta.maxHlc)
+    this.advanceWatermark(delta.maxHlc)
+    this.recomputeSpeculative()
+    this.notify?.()
+    return { droppedPending }
   }
 
   /** Push a fresh local batch and apply it speculatively. */
@@ -154,22 +654,91 @@ export class PendingOpsManager {
    * the hub emits BEFORE this one precisely so the result is consistent.
    */
   consumeRemote(batch: OpBatch): void {
-    const idx = this.state.pendingBatches.findIndex(b => b.batchId === batch.batchId)
-    for (const op of batch.ops) {
-      this.clock.observe(op.canonicalHlc)
-      applyOp(this.state.confirmedState, op)
-    }
-    if (idx >= 0)
-      this.state.pendingBatches.splice(idx, 1)
+    this.applyRemoteBatch(batch)
     this.recomputeSpeculative()
+    // The hub broadcasts every committed batch to ALL subscribers including the
+    // originator, so an originating client receives its own batch again here
+    // AFTER consumeBatchCommitted already recorded it (the SubmitOps echo fires
+    // before the WS broadcast). Skip the duplicate recording: the op-log already
+    // holds a frame for this batchId with the canonical-HLC-stamped ops. A
+    // genuine remote batch (different batchId) records normally. Consume the
+    // id so a later batch reusing it (impossible in practice) is not swallowed.
+    if (!this.pendingOwnEchoBatchIds.delete(batch.batchId))
+      this.recordFrame({ case: 'batch', value: batch })
     this.notify?.()
+  }
+
+  /**
+   * The batch-boundary rule, shared by the live path (`consumeBatchEnd`) and
+   * the replay/resume path (`applyFrames`' `batchEnd` arm) — the last frame
+   * kind that still had two hand-written implementations, and they had ALREADY
+   * drifted: `applyFrames` observed and advanced unguarded while
+   * `consumeBatchEnd` refused a missing `at_hlc`, so a malformed frame moved
+   * the cursor on one path and not the other. Its `*Core` siblings
+   * (`applyMaterializedCore`, `applyRemovedCore`, `applyRemoteBatch`) already
+   * work this way.
+   *
+   * This is the ONLY watermark-advance point. Every frame of a batch carries
+   * the same `at_hlc`, so advancing per frame moved the cursor to the batch's
+   * max on its FIRST frame; a drop before the rest of the sequence then
+   * stranded those ops above the cursor permanently. Advancing only at the
+   * boundary means a mid-sequence drop re-ships the whole batch, which is
+   * idempotent under strict-greater LWW.
+   *
+   * Returns whether the boundary was applied, so a caller can skip work that
+   * only makes sense for a real boundary.
+   */
+  private applyBatchEndCore(atHlc: HLC | undefined): boolean {
+    if (!atHlc)
+      return false
+    this.clock.observe(atHlc)
+    this.advanceWatermark(atHlc)
+    return true
+  }
+
+  /**
+   * Apply a live `batch_end` frame: the boundary at which a batch's catch-up
+   * sequence is complete and the resume cursor may move. See the BatchEnd proto
+   * doc for why this is the only advance point.
+   */
+  consumeBatchEnd(atHlc: HLC | undefined): void {
+    if (!this.applyBatchEndCore(atHlc))
+      return
+    // record() must stay: a cold reload replays the op-log through these same
+    // handlers, and without the batch_end frame the replayed watermark would
+    // stop at the checkpoint.
+    this.recordFrame({ case: 'batchEnd', value: { atHlc } })
+    // No notify(): this mutates only the clock and the resume watermark, and
+    // project() reads neither. crdtState is declared `{ equals: false }`, so a
+    // tick here would re-run the whole projection traversal and hand back an
+    // identical Projection -- doubling the settled-tick cost of every remote
+    // batch (consumeRemote already ticked) for no observable change.
   }
 
   /** Apply a BatchCommitted: replace pending batch's HLCs with canonical and apply to confirmed. */
   consumeBatchCommitted(batchId: string, committed: BatchCommitted): void {
     const idx = this.state.pendingBatches.findIndex(b => b.batchId === batchId)
-    if (idx < 0)
+    // Refresh the epoch even when this client has no pending batch with the id
+    // (the batch was reverted client-side after an EPOCH_REQUIRED give-up, or
+    // never originated here): the hub's epoch is authoritative, and skipping it
+    // would leave currentEpoch stale so the next SubmitOps gets STALE_EPOCH and
+    // re-triggers a reconnect cycle.
+    //
+    // Monotonic, because this arrives over the Connect RPC while the epoch also
+    // advances over the WS, and the two transports have no ordering between
+    // them. useOpsSubmitter holds no in-flight guard (flush clears its timer
+    // before awaiting, so an enqueue mid-await starts a second RPC), so a
+    // response minted under the OLD epoch can land after a bootstrap already
+    // installed the new one. Assigning unconditionally would regress the epoch,
+    // and decideResume requires an EXACT match -- so the next reconnect would
+    // fail the resume gate and pay the full projection snapshot this branch
+    // exists to avoid.
+    if (committed.epoch > this.state.currentEpoch)
+      this.state.currentEpoch = committed.epoch
+    if (idx < 0) {
+      this.notify?.()
       return
+    }
     const batch = this.state.pendingBatches[idx]
     const byOpId = new Map<string, CommittedOp>()
     for (const c of committed.committed) byOpId.set(c.opId, c)
@@ -180,9 +749,47 @@ export class PendingOpsManager {
       op.canonicalHlc = c.canonicalHlc
       this.clock.observe(c.canonicalHlc)
       applyOp(this.state.confirmedState, op)
+      // Deliberately NO advanceWatermark here. This is the SubmitOps echo,
+      // which arrives over the Connect RPC -- a transport entirely separate
+      // from the WS the hub's frames ride. Advancing per committed op moved the
+      // cursor on THIS batch's canonical HLC while a peer's earlier batch could
+      // still be sitting unread in the socket buffer; if the socket then
+      // dropped, the reconnect presented a cursor above ops it had never
+      // applied, ListUserOpBatchesAfter is strictly-greater so they were never
+      // re-sent, and since the checkpoint landed the bad cursor survived
+      // refreshes too. The hub does NOT suppress self-echo -- it broadcasts
+      // this batch and its batch_end back to the originator like any other
+      // subscriber -- so the cursor still advances, just at the batch boundary
+      // where it is safe. A cursor that lags only costs idempotent
+      // re-delivery, which is exactly the trade the BatchEnd proto doc names.
     }
+    // Record the canonical-HLC-stamped batch as a synthesized `batch` frame.
+    // consumeBatchCommitted has no inbound wire frame (it fires from the
+    // SubmitOps echo), but the ops just landed on confirmedState, so a cold
+    // reload must replay them. The batch's ops now carry canonicalHlc, which is
+    // exactly what applyRemoteBatch reads on replay. The observer serializes
+    // the frame to bytes immediately (synchronously, before splice), so sharing
+    // the ops reference is safe — and after splice nothing else mutates these
+    // op objects.
+    //
+    // Mark the id so the hub's echo of THIS batch -- the live broadcast via
+    // consumeRemote, or the resume tail via applyFrames when a drop lost that
+    // broadcast -- is not recorded a second time. The echo carries the same
+    // batchId and would otherwise double every self-originated batch in the
+    // op-log. A Set, so a multi-batch SubmitOps marks EVERY one of its batches
+    // rather than only the last.
+    this.pendingOwnEchoBatchIds.add(batch.batchId)
+    // Evict oldest-first past the cap, so the set stays bounded even in a
+    // session that resumes forever and therefore never clears it wholesale.
+    // Deleting the entry the for-of is standing on is well-defined for a Set:
+    // already-visited entries do not affect the remaining iteration.
+    for (const oldest of this.pendingOwnEchoBatchIds) {
+      if (this.pendingOwnEchoBatchIds.size <= MAX_OWN_ECHO_BATCH_IDS)
+        break
+      this.pendingOwnEchoBatchIds.delete(oldest)
+    }
+    this.recordFrame({ case: 'batch', value: { batchId: batch.batchId, ops: batch.ops } })
     this.state.pendingBatches.splice(idx, 1)
-    this.state.currentEpoch = committed.epoch
     this.recomputeSpeculative()
     this.notify?.()
   }
@@ -192,10 +799,25 @@ export class PendingOpsManager {
    *
    * A RETRYABLE rejection (EPOCH_REQUIRED) is NOT terminal -- the submitter
    * requeues the batch -- so its optimistic ops are KEPT in the pending list and
-   * stay applied to speculativeState: the edit remains visible across the
-   * reconnect+retry window (no revert-then-reapply flicker, no transient
-   * worker/CRDT divergence), and the retry's BatchCommitted reconciles it just
-   * like any in-flight batch. A non-retryable rejection (a permanent denial,
+   * stay applied to speculativeState, and the retry's BatchCommitted reconciles
+   * it just like any in-flight batch.
+   *
+   * That keeps the edit visible across the reconnect+retry window ONLY when the
+   * reconnect resumes. EPOCH_REQUIRED is the one retryable reason, and an epoch
+   * bump fails `decideResume`'s epoch-equality test, so the hub always answers
+   * with a full snapshot -- whose `bootstrap()` clears `pendingBatches`
+   * outright, since the snapshot is the hub's authoritative view and supersedes
+   * speculative edits made against the state it replaced. On that path the edit
+   * DOES visibly revert and re-apply, and `revertPendingBatch` becomes a no-op
+   * because there is no longer a pending entry to revert.
+   *
+   * No ops are lost either way: the submitter still holds the batch in its own
+   * queue, and `applyRemoteBatch` applies the hub's echo unconditionally, before
+   * the pending-index lookup. What is lost is the overlay, and with it the
+   * flicker-free property -- so this path is a UI cost, not a correctness one.
+   * See the matching note in `useOpsSubmitter.rescheduleForWireRetry`.
+   *
+   * A non-retryable rejection (a permanent denial,
    * STALE_EPOCH, or a transport give-up passing reason 0) IS terminal, so the
    * batch is dropped and its optimistic ops reverted. If the submitter later
    * gives up on a kept retryable batch (retry cap, or no reconnect handler to
@@ -237,6 +859,27 @@ export class PendingOpsManager {
    * client.
    */
   consumeEntityMaterialized(evt: EntityMaterialized): void {
+    this.applyMaterializedCore(evt)
+    this.recomputeSpeculative()
+    this.recordFrame({ case: 'entityMaterialized', value: evt })
+    this.notify?.()
+  }
+
+  /**
+   * applyMaterializedCore is the state-mutation half of
+   * consumeEntityMaterialized (observe atHlc + install the record),
+   * WITHOUT recomputeSpeculative/notify. applyDelta calls it per frame
+   * so a delta with many materialized frames does one recompute/notify
+   * at the end instead of one per frame. Mirrors applyRemoteBatch's
+   * "core only" split from consumeRemote.
+   */
+  private applyMaterializedCore(evt: EntityMaterialized): void {
+    // Observe the HLC into the clock, but do NOT advance the resume watermark:
+    // that happens only on the batch's `batchEnd` frame. Every frame of one
+    // batch carries the SAME at_hlc (the batch's last-op HLC), so advancing
+    // here would jump the cursor to the batch's max on its FIRST frame -- and a
+    // socket drop before the rest of the sequence would strand the remaining
+    // ops above the cursor forever (the resume scan is strictly-greater).
     if (evt.atHlc)
       this.clock.observe(evt.atHlc)
     const entity = evt.entity
@@ -256,9 +899,14 @@ export class PendingOpsManager {
         this.state.confirmedState.nodes[n.nodeId] = n
         break
       }
+      default:
+        // Empty / unknown entity oneof. Nothing was installed into
+        // confirmedState; fall through to return. The resume cursor is not
+        // stalled by dropping this frame because it does not move here at all:
+        // the batch's own `batch_end` is what advances it, and that arrives
+        // whether or not this arm was understood.
+        break
     }
-    this.recomputeSpeculative()
-    this.notify?.()
   }
 
   /**
@@ -273,9 +921,27 @@ export class PendingOpsManager {
    * surface a warn-toast when the dropped op was active-tab-related.
    */
   consumeEntityRemoved(evt: EntityRemoved): { droppedPending: boolean } {
+    const result = this.applyRemovedCore(evt)
+    this.recomputeSpeculative()
+    this.recordFrame({ case: 'entityRemoved', value: evt })
+    this.notify?.()
+    return result
+  }
+
+  /**
+   * applyRemovedCore is the state-mutation half of consumeEntityRemoved
+   * (observe atHlc + delete + dropPendingByPredicate), WITHOUT
+   * recomputeSpeculative/notify. applyDelta calls it per frame so a
+   * delta with many removed frames does one recompute/notify at the end
+   * and aggregates the droppedPending flag across them. Mirrors
+   * applyMaterializedCore's split.
+   */
+  private applyRemovedCore(evt: EntityRemoved): { droppedPending: boolean } {
+    let droppedPending = false
+    // Observe only; the watermark advances on `batchEnd`. See
+    // applyMaterializedCore for why per-frame advancing is unsafe.
     if (evt.atHlc)
       this.clock.observe(evt.atHlc)
-    let droppedPending = false
     const entity = evt.entity
     switch (entity.case) {
       case 'tab': {
@@ -311,9 +977,12 @@ export class PendingOpsManager {
         })
         break
       }
+      default:
+        // Empty / unknown entity oneof: nothing was evicted and no pending op
+        // was dropped. As in applyMaterializedCore, the resume cursor is
+        // unaffected -- it advances on the batch's `batch_end`, not here.
+        return { droppedPending: false }
     }
-    this.recomputeSpeculative()
-    this.notify?.()
     return { droppedPending }
   }
 
@@ -341,6 +1010,44 @@ export class PendingOpsManager {
    * guaranteed equal. `submit` detaches the alias before its first
    * mutation so the alias never escapes as a writable reference.
    */
+  /**
+   * Drop tombstone shells the resume cursor has already moved past, then
+   * re-derive speculativeState. Returns how many records went.
+   *
+   * The client's half of what `Manager.maybeCompact` does server-side: prune
+   * tombstones and rewrite the checkpoint together. It runs from the checkpoint
+   * rewrite for exactly that reason -- pruning is only worth anything if the
+   * smaller state is what gets persisted, and pairing them means the two can
+   * never disagree about which shells the blob still carries. See
+   * `pruneTombstonesAtOrBelow` for why the resume watermark is a safe floor.
+   *
+   * Shells of entities an unconfirmed local batch still targets are PINNED: this
+   * method re-derives speculativeState immediately below, and that replay would
+   * otherwise resurrect the pruned entity as a live record (`applyOp` lazily
+   * creates what it cannot find, and the shell is the only thing that makes the
+   * register writes drop).
+   */
+  compactTombstones(): number {
+    const pinned = pendingEntityKeys(this.state.pendingBatches)
+    if (pinned === null) {
+      // A pending op this build cannot map to an entity. Pruning now could drop
+      // the very shell that op's replay needs to be suppressed by, so skip the
+      // whole pass -- shells cost bytes, a resurrected record costs correctness.
+      // The next compaction retries once the batch settles.
+      return 0
+    }
+    const pruned = pruneTombstonesAtOrBelow(
+      this.state.confirmedState,
+      this.state.resumeWatermark,
+      pinned,
+    )
+    if (pruned > 0) {
+      this.recomputeSpeculative()
+      this.notify?.()
+    }
+    return pruned
+  }
+
   recomputeSpeculative(): void {
     if (this.state.pendingBatches.length === 0) {
       this.state.speculativeState = this.state.confirmedState
@@ -454,6 +1161,7 @@ function cloneStateForBatches(state: UserCrdtState, batches: OpBatch[]): UserCrd
     workspaces,
     maxHlc: hlcClone(state.maxHlc),
     compactionWatermark: hlcClone(state.compactionWatermark),
+    opRetentionWatermark: hlcClone(state.opRetentionWatermark),
     currentEpoch: state.currentEpoch,
     epochStartedAt: state.epochStartedAt,
   })

--- a/frontend/src/lib/crdt/project.ts
+++ b/frontend/src/lib/crdt/project.ts
@@ -191,27 +191,29 @@ interface CachedWorkspace {
  *
  * Register identity is one-directional, though: an LWW write that stores the
  * SAME value under a newer HLC produces a fresh register object, so the inputs
- * say "changed" when nothing did. That is not a rare shape -- it is what the
- * `BatchCommitted` echo behind EVERY drag frame looks like, so roughly half of
- * all drag ticks are it. So a miss falls through to a second question: the
- * rebuilt object is compared BY VALUE against the previous one, and the previous
- * one is kept when they match (see `rebuildTree`). Inputs decide whether to
- * rebuild; the output decides whether anyone downstream hears about it.
+ * say "changed" when nothing did. That is not a rare shape -- it is what a
+ * `BatchCommitted` echo looks like whenever a local edit's optimistic submit is
+ * confirmed by the hub's canonical version (same value, newer HLC), which
+ * happens on every confirmed mutation. So a miss falls through to a second
+ * question: the rebuilt object is compared BY VALUE against the previous one,
+ * and the previous one is kept when they match (see `rebuildTree`). Inputs
+ * decide whether to rebuild; the output decides whether anyone downstream hears
+ * about it.
  *
  * WHAT it buys, and what it does NOT. The TRAVERSAL is unchanged -- validating a
  * node needs its children's subtrees, so there is nothing to skip, and
  * `seen`-based cycle breaking keeps its exact semantics. For the tree walk the
  * comparison costs about what the allocation it replaces did, so that part of
  * the call is no faster; the value-compare above is a further ~6-10% ON TOP,
- * paid on every tick to make roughly half of them free downstream. The one
+ * paid on every tick to make the no-op-echo ticks free downstream. The one
  * arithmetic win is `sortedTabs`: ordering both tab arrays by id is over half a
  * settled tick at 300 tabs, and identity makes it skippable. Net, on a
  * 10-workspace / 300-tab account, a settled call goes ~0.09ms -> ~0.05ms.
  *
  * What it buys is IDENTITY, and therefore the absence of downstream work. The
  * caller is a memo over an `{ equals: false }` state accessor, so it runs on
- * every CRDT tick -- ~2x the frame rate while a tile is dragged, because each
- * frame's optimistic `submit` is followed by the `BatchCommitted` that triggers
+ * every CRDT tick -- twice per confirmed mutation, because each optimistic
+ * `submit` is followed by the `BatchCommitted` echo that triggers
  * `recomputeSpeculative`. Every one of those used to hand the whole app a fresh
  * graph:
  *
@@ -224,7 +226,7 @@ interface CachedWorkspace {
  *     object, so no projection-derived memo in the app re-runs at all.
  *
  * End to end (same account, sidebar-shaped consumers over every workspace) that
- * is 0.26ms -> 0.11ms per drag frame.
+ * is 0.26ms -> 0.11ms per confirmed-mutation tick.
  *
  * Reuse is expressed as memoize-style methods that take the build thunk, so
  * consulting an entry without writing the next generation's -- which would

--- a/frontend/src/lib/crdt/seedTab.test.ts
+++ b/frontend/src/lib/crdt/seedTab.test.ts
@@ -27,6 +27,7 @@ function installBridge(wsId: string, rootNodeId: string | null) {
       enqueued.push(batch)
       return batch.batchId
     },
+    flushNow: () => {},
     clock: () => new HLCClock('c-1'),
     originClientId: () => 'c-1',
     speculativeState: () => state,

--- a/frontend/src/lib/idb.test.ts
+++ b/frontend/src/lib/idb.test.ts
@@ -1,0 +1,479 @@
+import type { IdbSchema } from './idb'
+import { IDBFactory, IDBKeyRange } from 'fake-indexeddb'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  createIdbConnection,
+  forEachCursor,
+  forEachCursorWhile,
+  isIndexedDbAvailable,
+  requestToPromise,
+  selectSweepVictims,
+} from './idb'
+
+beforeEach(() => {
+  vi.stubGlobal('indexedDB', new IDBFactory())
+  vi.stubGlobal('IDBKeyRange', IDBKeyRange)
+})
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+const STORE = 'rows'
+
+const SCHEMA: IdbSchema = { [STORE]: { keyPath: 'k' } }
+
+/** Open `name` at `version` with the baseline single-store schema. */
+function connect(name: string, version = 1, schema: IdbSchema = SCHEMA) {
+  return createIdbConnection(name, version, schema)
+}
+
+async function putRow(conn: ReturnType<typeof connect>, k: string): Promise<void> {
+  const db = await conn.open()
+  await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction(STORE, 'readwrite')
+    tx.objectStore(STORE).put({ k })
+    tx.oncomplete = () => resolve()
+    tx.onerror = () => reject(tx.error)
+  })
+}
+
+async function countRows(conn: ReturnType<typeof connect>): Promise<number> {
+  const db = await conn.open()
+  return requestToPromise(db.transaction(STORE, 'readonly').objectStore(STORE).count())
+}
+
+describe('createIdbConnection', () => {
+  it('creates the schema on a first open', async () => {
+    const conn = connect('fresh', 1)
+    const db = await conn.open()
+    expect(db.objectStoreNames.contains(STORE)).toBe(true)
+    conn.reset()
+  })
+
+  it('caches the connection across calls', async () => {
+    const conn = connect('cached', 1)
+    const [a, b] = await Promise.all([conn.open(), conn.open()])
+    expect(a).toBe(b)
+    conn.reset()
+  })
+
+  // A version bump REBUILDS rather than migrates. There is no upgrade callback
+  // to hand a versionchange transaction to, because there is no migration to
+  // write: these databases are caches over state the hub owns, so the shape is
+  // rebuilt from the declaration and the rows are simply gone. See ~/lib/idb's
+  // header.
+  it('rebuilds the stores on a version bump instead of migrating them', async () => {
+    const v1 = connect('bumped', 1)
+    await putRow(v1, 'stale-a')
+    await putRow(v1, 'stale-b')
+    expect(await countRows(v1)).toBe(2)
+    // Release the v1 handle; a held connection would block the version change.
+    ;(await v1.open()).close()
+    v1.reset()
+
+    const v2 = connect('bumped', 2)
+    await expect(v2.open()).resolves.toBeDefined()
+    expect(await countRows(v2)).toBe(0)
+    v2.reset()
+  })
+
+  it('drops the cached promise on a failed open so a later call retries', async () => {
+    // An unusable key path makes createObjectStore throw inside the upgrade,
+    // which aborts it and fails the open.
+    const openSpy = vi.spyOn(indexedDB, 'open')
+    const conn = connect('upgrade-throws', 1, { [STORE]: { keyPath: '!!not a key path' } })
+
+    await expect(conn.open()).rejects.toBeDefined()
+    // A retry must produce a fresh request rather than replay the cached
+    // rejection forever; it fails again for the same reason, but it is a NEW
+    // attempt, which is what lets a transient failure (quota, blocked) recover.
+    await expect(conn.open()).rejects.toBeDefined()
+    expect(openSpy).toHaveBeenCalledTimes(2)
+    openSpy.mockRestore()
+    conn.reset()
+  })
+
+  // IndexedDB has no downgrade: opening below the stored version fails the
+  // request with a VersionError. Left alone, that silently and PERMANENTLY
+  // disables persistence for the profile, because every call site swallows.
+  // It is routine, not exotic -- a deploy rollback, a stale cached bundle, or
+  // an older desktop build launched after a newer one all produce it.
+  describe('when the stored database is NEWER than this build', () => {
+    it('recreates it rather than failing forever', async () => {
+      const v2 = connect('newer', 2)
+      await putRow(v2, 'from-the-newer-build')
+      ;(await v2.open()).close()
+      v2.reset()
+
+      // The older build opens successfully...
+      const v1 = connect('newer', 1)
+      const db = await v1.open()
+      expect(db.version).toBe(1)
+      // ...against a fresh database. Both stores behind this scaffold are pure
+      // caches over rebuildable data, so discarding the newer schema costs a
+      // cold start and nothing else.
+      expect(await countRows(v1)).toBe(0)
+      v1.reset()
+    })
+
+    it('leaves the database alone on a non-version failure', async () => {
+      // Only a VersionError recreates, and only a schema MISMATCH rebuilds. A
+      // transient open failure -- quota, a browser refusing the request -- must
+      // not be an excuse to destroy the cache.
+      const seeded = connect('non-version', 1)
+      await putRow(seeded, 'keep-me')
+      ;(await seeded.open()).close()
+      seeded.reset()
+
+      const openSpy = vi.spyOn(indexedDB, 'open').mockImplementation(() => {
+        const request = {
+          error: new DOMException('simulated quota failure', 'QuotaExceededError'),
+        } as unknown as IDBOpenDBRequest & { onerror?: () => void }
+        queueMicrotask(() => request.onerror?.())
+        return request
+      })
+      const failing = connect('non-version', 1)
+      await expect(failing.open()).rejects.toBeDefined()
+      openSpy.mockRestore()
+      failing.reset()
+
+      const reader = connect('non-version', 1)
+      expect(await countRows(reader)).toBe(1)
+      reader.reset()
+    })
+  })
+})
+
+describe('forEachCursor', () => {
+  async function seed(conn: ReturnType<typeof connect>, keys: string[]): Promise<void> {
+    for (const k of keys)
+      await putRow(conn, k)
+  }
+
+  it('visits every row in key order', async () => {
+    const conn = connect('walk', 1)
+    await seed(conn, ['c', 'a', 'b'])
+    const db = await conn.open()
+
+    const seen: string[] = []
+    const tx = db.transaction(STORE, 'readonly')
+    await forEachCursor(tx.objectStore(STORE).openCursor(), (cursor) => {
+      seen.push((cursor.value as { k: string }).k)
+    })
+    expect(seen).toEqual(['a', 'b', 'c'])
+    conn.reset()
+  })
+
+  it('resolves immediately on an empty range', async () => {
+    const conn = connect('walk-empty', 1)
+    const db = await conn.open()
+    const tx = db.transaction(STORE, 'readonly')
+    let visits = 0
+    await forEachCursor(tx.objectStore(STORE).openCursor(), () => {
+      visits++
+    })
+    expect(visits).toBe(0)
+    conn.reset()
+  })
+
+  it('supports a delete-while-walking key cursor', async () => {
+    // The shape deleteOpLogRange uses: openKeyCursor + delete by primary key.
+    const conn = connect('walk-delete', 1)
+    await seed(conn, ['a', 'b', 'c'])
+    const db = await conn.open()
+
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE, 'readwrite')
+      const store = tx.objectStore(STORE)
+      void forEachCursor(store.openKeyCursor(), (cursor) => {
+        store.delete(cursor.primaryKey)
+      })
+      tx.oncomplete = () => resolve()
+      tx.onerror = () => reject(tx.error)
+    })
+
+    expect(await countRows(conn)).toBe(0)
+    conn.reset()
+  })
+})
+
+describe('forEachCursorWhile', () => {
+  async function seed(conn: ReturnType<typeof connect>, keys: string[]): Promise<void> {
+    for (const k of keys)
+      await putRow(conn, k)
+  }
+
+  it('stops the walk as soon as visit returns false', async () => {
+    // The bound the op-log read depends on. Collecting everything and cutting
+    // afterwards has already paid the memory the cap exists to refuse, so the
+    // cut has to happen AT the cursor -- which means the rows past it must
+    // never be materialized at all.
+    const conn = connect('while-stop', 1)
+    await seed(conn, ['a', 'b', 'c', 'd'])
+    const db = await conn.open()
+
+    const seen: string[] = []
+    const tx = db.transaction(STORE, 'readonly')
+    await forEachCursorWhile(tx.objectStore(STORE).openCursor(), (cursor) => {
+      seen.push((cursor.value as { k: string }).k)
+      return seen.length < 2
+    })
+    expect(seen).toEqual(['a', 'b'])
+    conn.reset()
+  })
+
+  it('walks to exhaustion while visit keeps returning true', async () => {
+    const conn = connect('while-all', 1)
+    await seed(conn, ['a', 'b', 'c'])
+    const db = await conn.open()
+
+    const seen: string[] = []
+    const tx = db.transaction(STORE, 'readonly')
+    await forEachCursorWhile(tx.objectStore(STORE).openCursor(), (cursor) => {
+      seen.push((cursor.value as { k: string }).k)
+      return true
+    })
+    expect(seen).toEqual(['a', 'b', 'c'])
+    conn.reset()
+  })
+
+  it('resolves without visiting anything on an empty range', async () => {
+    const conn = connect('while-empty', 1)
+    const db = await conn.open()
+    const tx = db.transaction(STORE, 'readonly')
+    let visits = 0
+    await forEachCursorWhile(tx.objectStore(STORE).openCursor(), () => {
+      visits++
+      return true
+    })
+    expect(visits).toBe(0)
+    conn.reset()
+  })
+})
+
+// The TTL + entry-cap arithmetic both IDB stores sweep on. It was hand-written
+// twice and was provably the same modulo the reserved term, so the two copies
+// could only drift.
+describe('selectSweepVictims', () => {
+  const ttlMs = 1000
+  const now = 10_000
+
+  function at(...values: number[]): Array<{ at: number }> {
+    return values.map(v => ({ at: v }))
+  }
+
+  it('selects nothing from an empty list', () => {
+    expect(selectSweepVictims([], { now, ttlMs, maxEntries: 3 })).toEqual([])
+  })
+
+  it('selects every entry at or before the cutoff', () => {
+    // 9000 is exactly `now - ttlMs`: the boundary is INCLUSIVE, matching the
+    // `at <= cutoff` both stores documented.
+    expect(selectSweepVictims(at(1000, 9000, 9001), { now, ttlMs })).toEqual(at(1000, 9000))
+  })
+
+  it('keeps everything when nothing has expired and the cap is not reached', () => {
+    expect(selectSweepVictims(at(9500, 9600, 9700), { now, ttlMs, maxEntries: 5 })).toEqual([])
+  })
+
+  it('trims the oldest survivors down to the cap', () => {
+    expect(selectSweepVictims(at(9500, 9600, 9700, 9800), { now, ttlMs, maxEntries: 2 }))
+      .toEqual(at(9500, 9600))
+  })
+
+  it('counts reserved entries against the cap', () => {
+    // Two reserved slots (the sweeping tab plus one live sibling) leave room
+    // for one collectable survivor out of three.
+    expect(selectSweepVictims(at(9500, 9600, 9700), { now, ttlMs, maxEntries: 3, reserved: 2 }))
+      .toEqual(at(9500, 9600))
+  })
+
+  it('applies the TTL alone when maxEntries is omitted', () => {
+    // The checkpoint sweep's foreign-account arm: expired rows go, but "this
+    // account has too many tabs" says nothing about another account's rows.
+    expect(selectSweepVictims(at(1000, 2000, 9500, 9600), { now, ttlMs }))
+      .toEqual(at(1000, 2000))
+  })
+
+  it('combines both arms into one ascending prefix', () => {
+    expect(selectSweepVictims(at(1000, 9500, 9600, 9700), { now, ttlMs, maxEntries: 2 }))
+      .toEqual(at(1000, 9500))
+  })
+
+  it('never selects more than the whole list', () => {
+    expect(selectSweepVictims(at(9500, 9600), { now, ttlMs, maxEntries: 0, reserved: 10 }))
+      .toEqual(at(9500, 9600))
+  })
+
+  it('does not mutate its input', () => {
+    const input = at(1000, 9500)
+    selectSweepVictims(input, { now, ttlMs, maxEntries: 1 })
+    expect(input).toEqual(at(1000, 9500))
+  })
+})
+
+// An open connection MUST yield when another tab upgrades, or it blocks that
+// tab's versionchange forever -- which the blocked side only ever sees as
+// `onblocked`, so it degrades silently.
+//
+// These cases drive the yield with an explicit version bump because that is the
+// cheapest way to provoke `versionchange` in a test. In PRODUCTION the trigger
+// is the schema-repair `deleteDatabase()`, not a bump: `version` is a constant
+// by design and both stores pass the same literal.
+describe('createIdbConnection version-change handling', () => {
+  it('does not block another opener\'s upgrade', async () => {
+    const v1 = connect('yield', 1)
+    const held = await v1.open()
+    expect(held.objectStoreNames.contains(STORE)).toBe(true)
+
+    // Without onversionchange this open is BLOCKED by the connection above --
+    // the scaffold's onblocked arm rejects it, and the second tab silently
+    // loses persistence for the rest of its life.
+    const v2 = connect('yield', 2)
+    await expect(v2.open()).resolves.toBeDefined()
+
+    v1.reset()
+    v2.reset()
+  })
+
+  it('drops the cached promise so the closed handle is never handed out again', async () => {
+    // db.close() only sets the close-pending flag; the cached promise has to go
+    // too, or every later open() returns this now-closed handle and its
+    // transaction() throws InvalidStateError -- swallowed by every call site,
+    // so both stores would go quietly dead for the page's lifetime.
+    const v1 = connect('drop-cache', 1)
+    const held = await v1.open()
+    const v2 = connect('drop-cache', 2)
+    await v2.open()
+
+    // The handle we were holding is closed, so a transaction on it throws...
+    expect(() => held.transaction(STORE, 'readonly')).toThrow()
+    // ...and the connection no longer caches it: opening at the CURRENT version
+    // yields a usable handle.
+    const v2b = connect('drop-cache', 2)
+    const fresh = await v2b.open()
+    expect(fresh).not.toBe(held)
+    await expect(
+      requestToPromise(fresh.transaction(STORE, 'readonly').objectStore(STORE).count()),
+    ).resolves.toBeTypeOf('number')
+
+    v1.reset()
+    v2.reset()
+    v2b.reset()
+  })
+})
+
+// An IDBOpenDBRequest cannot be cancelled. `onblocked` rejects the promise, but
+// the request stays live: once the blocking connection closes, that SAME request
+// still fires onupgradeneeded and onsuccess. The handle it produces is reachable
+// from nothing — the promise it would have resolved is already rejected — so
+// without an explicit close it stays open for the page's lifetime, and its
+// `versionchange` handler goes on mutating the shared cached promise.
+describe('createIdbConnection when an open is blocked', () => {
+  it('closes the connection the blocked request eventually opens', async () => {
+    // A raw handle with NO onversionchange, standing in for another tab that
+    // does not yield. The scaffold's own connections always yield, so this
+    // cannot be built with `connect`.
+    const stubborn = await new Promise<IDBDatabase>((resolve) => {
+      const r = indexedDB.open('orphan', 1)
+      r.onupgradeneeded = () => {
+        r.result.createObjectStore(STORE, { keyPath: 'k' })
+      }
+      r.onsuccess = () => resolve(r.result)
+    })
+
+    const v2 = connect('orphan', 2)
+    await expect(v2.open()).rejects.toThrow(/blocked/)
+
+    // Now the other tab goes away, which unblocks the request we already gave
+    // up on. Count closes from this point: the only one that can occur is the
+    // scaffold closing the handle nothing else can reach.
+    // jsdom exposes no IDBDatabase global; reach the fake's prototype through
+    // an instance so the spy covers the orphan too.
+    const dbProto = Object.getPrototypeOf(stubborn) as { close: () => void }
+    const closeSpy = vi.spyOn(dbProto, 'close')
+    stubborn.close()
+    closeSpy.mockClear()
+    // The deferred upgrade + success run across several turns, and how many
+    // depends on how loaded the runner is -- poll rather than assuming one.
+    for (let i = 0; i < 50 && closeSpy.mock.calls.length === 0; i++)
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(closeSpy).toHaveBeenCalled()
+    closeSpy.mockRestore()
+    v2.reset()
+  })
+})
+
+// Schema repair, the alternative to bumping `version` on a store whose schema is
+// still moving. It also covers what a version number CANNOT: a database left
+// half-built by an upgrade that aborted partway carries the right version and
+// the wrong stores, so no future bump would ever revisit it.
+describe('createIdbConnection schema verification', () => {
+  const INDEXED: IdbSchema = { [STORE]: { keyPath: 'k', indexes: { byAt: 'at' } } }
+
+  /** Build a database at v1 with `schema`, then release it. */
+  async function seedWith(name: string, schema: IdbSchema): Promise<void> {
+    const conn = connect(name, 1, schema)
+    ;(await conn.open()).close()
+    conn.reset()
+  }
+
+  // The mechanism that replaces version bumps. Editing the declaration is the
+  // whole change: an existing database that no longer matches is deleted and
+  // rebuilt on next open, so no migration is written and no version moves.
+  it('recreates a database missing an index the declaration adds', async () => {
+    await seedWith('drifted', { [STORE]: { keyPath: 'k' } })
+
+    const conn = connect('drifted', 1, INDEXED)
+    const db = await conn.open()
+
+    expect(db.version).toBe(1)
+    expect(db.transaction(STORE, 'readonly').objectStore(STORE).indexNames.contains('byAt')).toBe(true)
+    conn.reset()
+  })
+
+  it('recreates a database whose key path no longer matches', async () => {
+    await seedWith('rekeyed', { [STORE]: { keyPath: 'k' } })
+
+    const conn = connect('rekeyed', 1, { [STORE]: { keyPath: 'id' } })
+    const db = await conn.open()
+
+    expect(db.transaction(STORE, 'readonly').objectStore(STORE).keyPath).toBe('id')
+    conn.reset()
+  })
+
+  it('recreates a database carrying a store the declaration dropped', async () => {
+    // Left over from an earlier shape. Keeping it would let the database
+    // accumulate every store the app ever had.
+    await seedWith('orphaned', { [STORE]: { keyPath: 'k' }, leftover: { keyPath: 'k' } })
+
+    const conn = connect('orphaned', 1, { [STORE]: { keyPath: 'k' } })
+    const db = await conn.open()
+
+    expect(Array.from(db.objectStoreNames)).toEqual([STORE])
+    conn.reset()
+  })
+
+  it('leaves a conforming database alone, data and all', async () => {
+    const seed = connect('conforming', 1, INDEXED)
+    await putRow(seed, 'keep-me')
+    ;(await seed.open()).close()
+    seed.reset()
+
+    const conn = connect('conforming', 1, INDEXED)
+    expect(await countRows(conn)).toBe(1)
+    conn.reset()
+  })
+})
+
+describe('isIndexedDbAvailable', () => {
+  it('is true when indexedDB is defined', () => {
+    expect(isIndexedDbAvailable()).toBe(true)
+  })
+
+  it('is false without indexedDB (SSR / jsdom without the stub)', () => {
+    vi.stubGlobal('indexedDB', undefined)
+    expect(isIndexedDbAvailable()).toBe(false)
+  })
+})

--- a/frontend/src/lib/idb.ts
+++ b/frontend/src/lib/idb.ts
@@ -1,0 +1,436 @@
+// ---------------------------------------------------------------------------
+// Shared IndexedDB connection scaffold
+//
+// Every IDB-backed store in the app needs the same four things: an
+// availability probe, a lazily-opened singleton connection whose promise is
+// dropped on failure so a later call retries, a request->promise adapter, and
+// a test hook to forget the cached connection after the IDBFactory is swapped.
+// This module owns that skeleton so each store only declares its own schema.
+//
+// SCHEMA CHANGES RECREATE THE DATABASE. THERE ARE NO MIGRATIONS.
+//
+// This is the permanent policy, not a pre-release shortcut. Every database
+// behind this scaffold is a CACHE over state the hub owns and re-syncs, so the
+// worst a recreate can cost is one cold start -- and buying data-preserving
+// migrations with that would mean writing, testing and forever maintaining an
+// upgrade path per revision to protect data that is already safe elsewhere.
+//
+// So a store declares its shape ONCE, as an `IdbSchema`, and this module
+// derives both halves from it:
+//
+//   - the upgrade, which builds exactly those stores and indexes, and
+//   - the check, which asserts an opened database still matches and otherwise
+//     deletes and rebuilds it.
+//
+// Deriving both from one declaration is the point. When they were two
+// hand-written functions, adding an index meant remembering to update the
+// checker too, and forgetting made the repair silently stop repairing -- the
+// database would open, be wrong, and fail at the first cursor instead.
+//
+// This also catches what a version number CANNOT. A database left half-built
+// by an aborted upgrade (a tab killed mid-versionchange, a quota failure part
+// way) carries the RIGHT version and the wrong stores, so no future bump would
+// ever revisit it; a shape check sees it immediately. `version` is therefore a
+// constant that never has to move, and the VersionError arm below still handles
+// the reverse case -- a database left NEWER by a rollback or a stale bundle.
+// ---------------------------------------------------------------------------
+
+/** Whether persistence can work here at all -- callers short-circuit synchronously on false. */
+export function isIndexedDbAvailable(): boolean {
+  return typeof indexedDB !== 'undefined'
+}
+
+/** Adapt a one-shot IDBRequest to a promise. */
+export function requestToPromise<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result)
+    request.onerror = () => reject(request.error ?? new Error('indexedDB request failed'))
+  })
+}
+
+/**
+ * Walk a cursor request, calling `visit` for each position until it returns
+ * false or the cursor is exhausted.
+ *
+ * The stopping form exists because an unbounded walk is a hazard in its own
+ * right: a store whose rows are appended faster than they are compacted grows
+ * without bound, and a walk that only decides what to keep AFTER materializing
+ * everything has already paid the memory it was meant to cap. Callers that
+ * genuinely want the whole range use `forEachCursor` below.
+ *
+ * `C` infers per call site: `openCursor()` is `IDBRequest<IDBCursorWithValue |
+ * null>` (so `visit` sees `.value`), `openKeyCursor()` is
+ * `IDBRequest<IDBCursor | null>` (primary keys only).
+ *
+ * Resolves when the walk ends (exhausted or stopped). Rejects on a cursor
+ * error, which inside a readwrite transaction leaves that transaction to abort
+ * as usual.
+ */
+export function forEachCursorWhile<C extends IDBCursor>(
+  request: IDBRequest<C | null>,
+  visit: (cursor: C) => boolean,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    request.onsuccess = () => {
+      const cursor = request.result
+      if (!cursor || !visit(cursor)) {
+        resolve()
+        return
+      }
+      cursor.continue()
+    }
+    request.onerror = () => reject(request.error ?? new Error('indexedDB cursor failed'))
+  })
+}
+
+/**
+ * Walk a cursor request to exhaustion, calling `visit` for each position.
+ *
+ * The `onsuccess` / `cursor.continue()` / `onerror`-reject dance is identical
+ * for every cursor walk and differs only in the loop body, so it lives here
+ * next to `requestToPromise` rather than being hand-rolled per store. Callers
+ * keep their own accumulator (push into a local array) or side effect (delete
+ * by primary key); the key range stays in the request the caller builds, so
+ * this needs no options.
+ *
+ * `visit`'s return value is ignored — deliberately typed `void` so a concise
+ * arrow body (`cursor => rows.push(cursor.value)`, which returns a number) is
+ * accepted. Use `forEachCursorWhile` when the walk needs to stop early.
+ */
+export function forEachCursor<C extends IDBCursor>(
+  request: IDBRequest<C | null>,
+  visit: (cursor: C) => void,
+): Promise<void> {
+  return forEachCursorWhile(request, (cursor) => {
+    visit(cursor)
+    return true
+  })
+}
+
+/**
+ * Pick the entries a TTL + entry-cap sweep should delete, from a
+ * recency-ASCENDING list.
+ *
+ * Both IDB stores behind this scaffold sweep on the same two rules, and both
+ * read their candidates off a `writtenAt`/`at` index key cursor, which yields
+ * exactly that ascending order:
+ *
+ *   - TTL — anything last touched at or before `now - ttlMs` goes.
+ *   - CAP — of the survivors, the oldest go until at most `maxEntries` remain,
+ *     counting `reserved` entries that are exempt from collection but still
+ *     occupy the budget (the sweeping tab's own row, its live siblings').
+ *
+ * Because the input is ascending, both arms select a PREFIX: every expired
+ * entry precedes every fresh one, and the over-cap victims are the oldest of
+ * what is left. So the result is `ascending.slice(0, ttlVictims + capVictims)`,
+ * which is also why the two stores' hand-written arithmetic was provably the
+ * same modulo the `reserved` term.
+ *
+ * Omit `maxEntries` to apply the TTL alone (the checkpoint sweep does this for
+ * other accounts' rows: "this user has too many tabs" says nothing about how
+ * many rows another account may keep).
+ */
+export function selectSweepVictims<T extends { at: number }>(
+  ascending: readonly T[],
+  opts: { now: number, ttlMs: number, maxEntries?: number, reserved?: number },
+): T[] {
+  const cutoff = opts.now - opts.ttlMs
+  let expired = 0
+  while (expired < ascending.length && ascending[expired]!.at <= cutoff)
+    expired++
+  const fresh = ascending.length - expired
+  const overCap = opts.maxEntries === undefined
+    ? 0
+    : Math.max(0, fresh + (opts.reserved ?? 0) - opts.maxEntries)
+  return ascending.slice(0, expired + overCap)
+}
+
+/**
+ * Adapt a transaction's terminal events to a promise: resolves on `complete`,
+ * rejects on `error` or `abort`.
+ *
+ * Every readwrite transaction needs the identical three-handler dance and they
+ * differ only in the label that names the failure, so it lives here beside
+ * `requestToPromise` and `forEachCursor` rather than being hand-rolled per
+ * store.
+ *
+ * Register this in the SAME task that created the transaction — an `await`
+ * before it lets the transaction auto-deactivate at the microtask checkpoint
+ * and the `complete` event can be missed entirely.
+ */
+export function txToPromise(tx: IDBTransaction, label: string): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    tx.oncomplete = () => resolve()
+    tx.onerror = () => reject(tx.error ?? new Error(`indexedDB ${label} failed`))
+    tx.onabort = () => reject(tx.error ?? new Error(`indexedDB ${label} aborted`))
+  })
+}
+
+/** One object store's shape. */
+export interface IdbStoreSchema {
+  /** Primary key path. Omit for an out-of-line key. */
+  keyPath?: string | string[]
+  /** Whether the store assigns the primary key. */
+  autoIncrement?: boolean
+  /** Index name -> its key path. */
+  indexes?: Record<string, string | string[]>
+}
+
+/** A database's whole shape: object-store name -> that store's schema. */
+export type IdbSchema = Record<string, IdbStoreSchema>
+
+/**
+ * Build every store and index in `schema`, dropping whatever is already there.
+ *
+ * Runs inside the versionchange transaction. Recreating rather than reconciling
+ * is the module's policy (see the header): these databases are caches, so a
+ * rebuild costs a cold start and nothing else, and it makes the resulting shape
+ * a function of the declaration alone rather than of the path taken to reach it.
+ *
+ * Stores NOT in the schema are dropped too -- they are leftovers from an earlier
+ * shape, and keeping them would let the database accumulate every store the app
+ * ever had.
+ */
+function applySchema(db: IDBDatabase, schema: IdbSchema): void {
+  for (const existing of Array.from(db.objectStoreNames))
+    db.deleteObjectStore(existing)
+  for (const [name, spec] of Object.entries(schema)) {
+    const store = db.createObjectStore(name, {
+      keyPath: spec.keyPath,
+      autoIncrement: spec.autoIncrement ?? false,
+    })
+    for (const [indexName, indexKeyPath] of Object.entries(spec.indexes ?? {}))
+      store.createIndex(indexName, indexKeyPath)
+  }
+}
+
+/** Key paths compare structurally: IndexedDB returns a string or a string[]. */
+function samePath(a: string | string[] | null, b: string | string[] | undefined): boolean {
+  if (Array.isArray(a) || Array.isArray(b))
+    return Array.isArray(a) && Array.isArray(b) && a.length === b.length && a.every((v, i) => v === b[i])
+  return (a ?? undefined) === b
+}
+
+/**
+ * Whether `db` matches `schema` exactly -- same stores, same key paths, same
+ * indexes. A false answer deletes and rebuilds the database.
+ *
+ * Derived from the SAME declaration `applySchema` builds from, so the two
+ * cannot disagree about what the schema is.
+ */
+function schemaMatches(db: IDBDatabase, schema: IdbSchema): boolean {
+  const expected = Object.keys(schema)
+  if (db.objectStoreNames.length !== expected.length)
+    return false
+  if (!expected.every(name => db.objectStoreNames.contains(name)))
+    return false
+  // indexNames and keyPath are only reachable through an object store, which is
+  // only reachable through a transaction. Read-only and request-free, so it
+  // commits on its own without touching a row.
+  const tx = db.transaction(expected, 'readonly')
+  return expected.every((name) => {
+    const spec = schema[name]!
+    const store = tx.objectStore(name)
+    if (!samePath(store.keyPath, spec.keyPath) || store.autoIncrement !== (spec.autoIncrement ?? false))
+      return false
+    const indexes = Object.entries(spec.indexes ?? {})
+    if (store.indexNames.length !== indexes.length)
+      return false
+    return indexes.every(([indexName, indexKeyPath]) =>
+      store.indexNames.contains(indexName) && samePath(store.index(indexName).keyPath, indexKeyPath),
+    )
+  })
+}
+
+/** A lazily-opened, cached connection to one database. */
+export interface IdbConnection {
+  /** Open (or reuse) the connection. Rejects on open failure; the cache is cleared so a later call retries. */
+  open: () => Promise<IDBDatabase>
+  /** Visible for testing: forget the cached connection (e.g. after swapping the IDBFactory). */
+  reset: () => void
+}
+
+/**
+ * Create a cached connection to `name` at `version`, built from `schema`.
+ *
+ * `schema` is the single declaration of the database's shape: it builds the
+ * stores on creation AND is checked against every handle handed out, so a
+ * database that does not match is deleted and rebuilt. Change the schema and
+ * existing databases repair themselves on next open -- `version` does not have
+ * to move. See the module header for why that is the permanent policy here.
+ *
+ * A rejected open drops the cached promise, so the next call retries rather
+ * than latching the failure for the page's lifetime.
+ */
+export function createIdbConnection(
+  name: string,
+  version: number,
+  schema: IdbSchema,
+): IdbConnection {
+  let dbPromise: Promise<IDBDatabase> | null = null
+
+  /**
+   * Delete the database outright. Best-effort: every outcome resolves, because
+   * the only caller is already on a degraded path and a failed delete just
+   * means the retry below fails too.
+   *
+   * `blocked` fires when another connection (another tab) still holds the
+   * database. We do NOT wait for it: that tab is running the newer build and
+   * will keep the handle open indefinitely, so blocking here would hang the
+   * open forever instead of degrading to a full snapshot.
+   */
+  function deleteDatabase(): Promise<void> {
+    return new Promise<void>((resolve) => {
+      const request = indexedDB.deleteDatabase(name)
+      request.onsuccess = () => resolve()
+      request.onerror = () => resolve()
+      request.onblocked = () => resolve()
+    })
+  }
+
+  /**
+   * One open attempt. `invalidate` drops the cached promise IF it still refers
+   * to the attempt that owns this handle -- see `open()` for why the identity
+   * check is load-bearing.
+   */
+  function openOnce(invalidate: () => void): Promise<IDBDatabase> {
+    return new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open(name, version)
+      // An IDBOpenDBRequest cannot be cancelled. `onblocked` below rejects, but
+      // the request stays LIVE: once the other tab yields its connection, the
+      // very same request goes on to fire onupgradeneeded and then onsuccess.
+      // Without this flag that late success resolves an already-settled promise
+      // (a no-op) while leaving a real IDBDatabase that nothing captures and
+      // nothing ever closes -- one leaked connection per blocked open, each of
+      // which still answers `versionchange` and would null the SHARED cached
+      // promise. Closing it here is the only handle we will ever have on it.
+      let settled = false
+      request.onupgradeneeded = () => {
+        // Builds the declared shape from scratch, whether this is a first
+        // creation or a rebuild after a mismatch. No migration path exists to
+        // get wrong -- see the module header.
+        applySchema(request.result, schema)
+      }
+      request.onsuccess = () => {
+        const db = request.result
+        if (settled) {
+          db.close()
+          return
+        }
+        settled = true
+        // Yield when ANOTHER tab starts an upgrade. Without this, our open
+        // connection blocks that tab's versionchange forever -- it only sees
+        // `onblocked` below and gives up, which silently disables persistence
+        // for it.
+        //
+        // In production that upgrade is NOT a version bump: `version` is a
+        // constant here by design (see the module header), and both stores pass
+        // the same literal. The trigger is the `deleteDatabase()` in the
+        // schema-repair path below -- a peer tab that opened this database,
+        // found a stale schema, and is dropping it to rebuild. So this handler
+        // is on the normal repair route, not a someday-migration route.
+        //
+        // Dropping the cached promise is REQUIRED, not tidiness: db.close()
+        // only sets the close-pending flag (in-flight transactions still run
+        // to completion, so nothing is aborted), but every later open() would
+        // otherwise hand back this now-closed handle, whose transaction()
+        // throws InvalidStateError -- and every caller here swallows, so both
+        // stores would go quietly dead for the page's lifetime.
+        db.onversionchange = () => {
+          db.close()
+          invalidate()
+        }
+        resolve(db)
+      }
+      request.onerror = () => {
+        if (settled)
+          return
+        settled = true
+        reject(request.error ?? new Error('indexedDB open failed'))
+      }
+      // Blocked by another tab holding an older connection: degrade now; the
+      // cached promise is dropped below so a later call retries. With
+      // onversionchange in place above, that retry now succeeds once the
+      // other tab yields, instead of re-blocking forever.
+      request.onblocked = () => {
+        if (settled)
+          return
+        settled = true
+        reject(new Error('indexedDB open blocked'))
+      }
+    })
+  }
+
+  function open(): Promise<IDBDatabase> {
+    if (!dbPromise) {
+      // Every path that drops the cache compares against THIS attempt first.
+      // Nulling the shared variable unconditionally let a stale attempt clobber
+      // a newer, healthy connection: a rejection (or a `versionchange` on a
+      // superseded handle) settling after `reset()` had already installed a
+      // different promise would drop that one instead, and the next caller
+      // reopened for no reason while the discarded handle stayed open.
+      let attempt: Promise<IDBDatabase>
+      const invalidate = (): void => {
+        if (dbPromise === attempt)
+          dbPromise = null
+      }
+      /**
+       * Hand back a database that matches the declaration, rebuilding it if the
+       * one we opened does not. This is how a schema change lands without a
+       * version bump; see the module header for why that is the policy.
+       *
+       * Exactly ONE retry. A freshly built database that still fails the check
+       * means applySchema and schemaMatches disagree about the same
+       * declaration, which is a bug in this module -- and no amount of deleting
+       * fixes it, so spinning would just hang every caller.
+       */
+      const ensureSchema = async (db: IDBDatabase): Promise<IDBDatabase> => {
+        if (schemaMatches(db, schema))
+          return db
+        db.close()
+        await deleteDatabase()
+        const fresh = await openOnce(invalidate)
+        if (schemaMatches(fresh, schema))
+          return fresh
+        fresh.close()
+        throw new Error(`indexedDB ${name}: schema still unusable after recreate`)
+      }
+      attempt = openOnce(invalidate).catch(async (err: unknown) => {
+        // The stored database is NEWER than the version this build asks for.
+        //
+        // IndexedDB does not downgrade: opening at a lower version fails the
+        // request outright with a VersionError, and because every call site
+        // here swallows, persistence would be silently and PERMANENTLY off for
+        // that profile. It is a routine situation, not an exotic one -- a
+        // rollback to a previous deploy, a stale cached bundle, or an older
+        // desktop build launched after a newer one all produce it.
+        //
+        // Both databases behind this scaffold are pure caches over data that
+        // can be rebuilt (render artifacts re-render; the CRDT checkpoint
+        // re-fetches as one full snapshot), so discarding the newer schema
+        // costs a cold start and nothing else -- strictly better than running
+        // with persistence dead. It is the same reasoning as the schema-mismatch
+        // rebuild above: no database here holds anything the hub cannot re-supply.
+        //
+        // NOTE this is deliberately NOT an unconditional retry: only a
+        // VersionError is recreated from. A quota failure or a genuine open
+        // error still rejects, so a transient problem does not destroy the
+        // cache.
+        if ((err as DOMException | undefined)?.name !== 'VersionError')
+          throw err
+        await deleteDatabase()
+        return openOnce(invalidate)
+      }).then(ensureSchema)
+      void attempt.catch(invalidate)
+      dbPromise = attempt
+    }
+    return dbPromise
+  }
+
+  function reset(): void {
+    void dbPromise?.then(db => db.close()).catch(() => {})
+    dbPromise = null
+  }
+
+  return { open, reset }
+}

--- a/frontend/src/lib/renderArtifactStore.ts
+++ b/frontend/src/lib/renderArtifactStore.ts
@@ -1,3 +1,5 @@
+import type { IdbSchema } from './idb'
+import { createIdbConnection, forEachCursor, isIndexedDbAvailable, requestToPromise, selectSweepVictims } from './idb'
 import { fnv1a32Hex } from './stringDigest'
 
 // ---------------------------------------------------------------------------
@@ -72,6 +74,10 @@ export const ARTIFACT_TOUCH_INTERVAL_MS = 60 * 60 * 1000
 export const ARTIFACT_MAX_ENTRIES = 2000
 
 const DB_NAME = 'leapmux-render-cache'
+// A CONSTANT. Schema changes land by editing SCHEMA below, not by bumping this:
+// the scaffold rebuilds any database that does not match the declaration. See
+// ~/lib/idb's header for why recreating rather than migrating is the policy --
+// this store is a cache over artifacts the app can always re-render.
 const DB_VERSION = 1
 const STORE_NAME = 'artifacts'
 const AT_INDEX = 'at'
@@ -88,7 +94,7 @@ interface ArtifactRecord {
 
 /** Whether persistence can work here at all — callers short-circuit synchronously on false. */
 export function isArtifactStoreAvailable(): boolean {
-  return typeof indexedDB !== 'undefined'
+  return isIndexedDbAvailable()
 }
 
 /**
@@ -100,43 +106,26 @@ function artifactKey(ns: string, source: string): string {
   return `${ns}:${fnv1a32Hex(source)}:${source.length.toString(36)}`
 }
 
-let dbPromise: Promise<IDBDatabase> | null = null
+/**
+ * The database's shape, in one place. Builds the store on creation and is
+ * checked against every opened database, which is rebuilt if it does not match
+ * -- see ~/lib/idb's header. `AT_INDEX` carries the sweep's recency ordering,
+ * so a database missing it would throw on first use rather than degrade.
+ */
+const SCHEMA: IdbSchema = {
+  [STORE_NAME]: {
+    keyPath: 'k',
+    indexes: { [AT_INDEX]: 'at' },
+  },
+}
+
+const connection = createIdbConnection(DB_NAME, DB_VERSION, SCHEMA)
+
+const openDb = connection.open
 
 /** Visible for testing: forget the cached connection (e.g. after swapping the IDBFactory). */
 export function _resetArtifactStoreForTest(): void {
-  void dbPromise?.then(db => db.close()).catch(() => {})
-  dbPromise = null
-}
-
-function openDb(): Promise<IDBDatabase> {
-  if (!dbPromise) {
-    dbPromise = new Promise<IDBDatabase>((resolve, reject) => {
-      const request = indexedDB.open(DB_NAME, DB_VERSION)
-      request.onupgradeneeded = () => {
-        const db = request.result
-        if (!db.objectStoreNames.contains(STORE_NAME)) {
-          const store = db.createObjectStore(STORE_NAME, { keyPath: 'k' })
-          store.createIndex(AT_INDEX, 'at')
-        }
-      }
-      request.onsuccess = () => resolve(request.result)
-      request.onerror = () => reject(request.error ?? new Error('indexedDB open failed'))
-      // Blocked by another tab holding an older connection: degrade to a miss
-      // now; the cached promise is dropped below so a later call retries.
-      request.onblocked = () => reject(new Error('indexedDB open blocked'))
-    })
-    void dbPromise.catch(() => {
-      dbPromise = null
-    })
-  }
-  return dbPromise
-}
-
-function requestToPromise<T>(request: IDBRequest<T>): Promise<T> {
-  return new Promise<T>((resolve, reject) => {
-    request.onsuccess = () => resolve(request.result)
-    request.onerror = () => reject(request.error ?? new Error('indexedDB request failed'))
-  })
+  connection.reset()
 }
 
 function putRecord(db: IDBDatabase, record: ArtifactRecord): Promise<void> {
@@ -220,32 +209,21 @@ export async function sweepArtifacts(opts: { ttlMs?: number, maxEntries?: number
     const db = await openDb()
     // Key-only cursor over the recency index (ascending = oldest first):
     // collect [primaryKey, at] without materializing values.
-    const entries = await new Promise<Array<{ key: IDBValidKey, at: number }>>((resolve, reject) => {
-      const collected: Array<{ key: IDBValidKey, at: number }> = []
-      const cursorRequest = db.transaction(STORE_NAME, 'readonly')
-        .objectStore(STORE_NAME)
-        .index(AT_INDEX)
-        .openKeyCursor()
-      cursorRequest.onsuccess = () => {
-        const cursor = cursorRequest.result
-        if (!cursor) {
-          resolve(collected)
-          return
-        }
-        collected.push({ key: cursor.primaryKey, at: cursor.key as number })
-        cursor.continue()
-      }
-      cursorRequest.onerror = () => reject(cursorRequest.error ?? new Error('indexedDB cursor failed'))
-    })
-    const expiredCount = entries.filter(e => e.at <= now - ttlMs).length
-    const freshCount = entries.length - expiredCount
-    // entries is at-ascending, so the first `expiredCount + overCap` are the victims.
-    const deleteCount = expiredCount + Math.max(0, freshCount - maxEntries)
-    if (deleteCount === 0)
+    const entries: Array<{ key: IDBValidKey, at: number }> = []
+    await forEachCursor(
+      db.transaction(STORE_NAME, 'readonly').objectStore(STORE_NAME).index(AT_INDEX).openKeyCursor(),
+      cursor => entries.push({ key: cursor.primaryKey, at: cursor.key as number }),
+    )
+    // `entries` is at-ascending (the index cursor's order), which is the
+    // precondition selectSweepVictims is written against. No entry is reserved
+    // here: unlike the checkpoint store, this cache has no "current" row that a
+    // sweep must keep. See ~/lib/idb for the shared TTL + cap arithmetic.
+    const victims = selectSweepVictims(entries, { now, ttlMs, maxEntries })
+    if (victims.length === 0)
       return 0
     const store = db.transaction(STORE_NAME, 'readwrite').objectStore(STORE_NAME)
-    await Promise.all(entries.slice(0, deleteCount).map(e => requestToPromise(store.delete(e.key))))
-    return deleteCount
+    await Promise.all(victims.map(e => requestToPromise(store.delete(e.key))))
+    return victims.length
   }
   catch {
     return 0

--- a/frontend/src/stores/floatingWindow.store.crdt.test.ts
+++ b/frontend/src/stores/floatingWindow.store.crdt.test.ts
@@ -1,8 +1,8 @@
 import type { TestBridgeHandle } from '~/test-support/crdtBridge'
 import { createEffect, createRoot } from 'solid-js'
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ctxFromBridge, getCRDTBridge, newBatch, renderTreeToLocal, setCRDTBridge, setFloatingWorkspaceId, sharedTrees } from '~/lib/crdt'
-import { createFloatingWindowStore, MIN_WINDOW_DIMENSION } from '~/stores/floatingWindow.store'
+import { createFloatingWindowStore, createKeyedOverrides, MIN_WINDOW_DIMENSION } from '~/stores/floatingWindow.store'
 import { seedWorkspace, withTestBridge } from '~/test-support/crdtBridge'
 import { createTestFloatingWindowStore, projectionMemo } from '~/test-support/tabStores'
 
@@ -86,40 +86,79 @@ describe('createFloatingWindowStore (projection-driven)', () => {
     }, { rootTileId: 'main' })
   })
 
-  it('updatePosition emits a 2-op batch (x + y) and reflects in the projection', () => {
+  // These pin what the DRAG path emits, which is what the UI actually calls.
+  // They used to target `updatePosition` / `updateGeometry` / `updateOpacity` --
+  // immediate setters that this branch's own refactor left with zero production
+  // callers, so the assertions described a path nothing takes.
+  it('a committed MOVE emits a 2-op batch (x + y) and reflects in the projection', () => {
     withTestBridge((harness) => {
       const store = createTestFloatingWindowStore()
       const { windowId } = store.addWindow({ x: 0.1, y: 0.1, width: 0.3, height: 0.3 })!
       const before = harness.pending.state.pendingBatches.length
 
-      store.updatePosition(windowId, 0.5, 0.6)
+      store.updateDragMove(windowId, 0.5, 0.6)
+      store.commitDragGeometry(windowId)
       const lastBatch = harness.pending.state.pendingBatches.at(-1)
       expect(harness.pending.state.pendingBatches.length - before).toBe(1)
+      // x + y ONLY. A move that also wrote width/height would clobber a
+      // concurrent peer resize with the pointer-down snapshot.
       expect(lastBatch?.ops.length).toBe(2)
       expect(store.state.windows[0]!.x).toBeCloseTo(0.5, 6)
       expect(store.state.windows[0]!.y).toBeCloseTo(0.6, 6)
     }, { rootTileId: 'main' })
   })
 
-  it('updatePosition is a no-op when the coordinates haven’t changed', () => {
+  it('a committed MOVE back to the starting position is a no-op', () => {
     withTestBridge((harness) => {
       const store = createTestFloatingWindowStore()
       const { windowId } = store.addWindow({ x: 0.1, y: 0.2, width: 0.3, height: 0.3 })!
       const before = harness.pending.state.pendingBatches.length
 
-      store.updatePosition(windowId, 0.1, 0.2)
+      store.updateDragMove(windowId, 0.1, 0.2)
+      store.commitDragGeometry(windowId)
       expect(harness.pending.state.pendingBatches.length).toBe(before)
     }, { rootTileId: 'main' })
   })
 
-  it('updateGeometry emits a 4-op batch and clamps below MIN_WINDOW_DIMENSION', () => {
+  // The regression this fix exists for: a MOVE must not write width/height at
+  // all. It committed all four fields using the dimensions captured at
+  // pointer-down, so a peer that resized the window while the pointer was down
+  // had its resize overwritten by stale numbers under a NEWER HLC -- reverted on
+  // every client, permanently. Here the peer's resize is simulated by moving the
+  // window's CRDT width away from the drag's captured value.
+  it('a committed MOVE does not emit width/height, so a concurrent resize survives', () => {
+    withTestBridge((harness) => {
+      const store = createTestFloatingWindowStore()
+      const { windowId } = store.addWindow({ x: 0.1, y: 0.1, width: 0.3, height: 0.3 })!
+
+      // Pointer-down captures 0.3 x 0.3, then a "peer" resizes to 0.5 x 0.5
+      // mid-drag (a resize gesture standing in for the remote op).
+      store.updateDragResize(windowId, 0.1, 0.1, 0.5, 0.5)
+      store.commitDragGeometry(windowId)
+      expect(store.state.windows[0]!.width).toBeCloseTo(0.5, 6)
+
+      const before = harness.pending.state.pendingBatches.length
+      store.updateDragMove(windowId, 0.7, 0.8)
+      store.commitDragGeometry(windowId)
+
+      const lastBatch = harness.pending.state.pendingBatches.at(-1)
+      expect(harness.pending.state.pendingBatches.length - before).toBe(1)
+      expect(lastBatch?.ops.length).toBe(2)
+      expect(store.state.windows[0]!.x).toBeCloseTo(0.7, 6)
+      expect(store.state.windows[0]!.width).toBeCloseTo(0.5, 6)
+      expect(store.state.windows[0]!.height).toBeCloseTo(0.5, 6)
+    }, { rootTileId: 'main' })
+  })
+
+  it('a committed RESIZE emits a 4-op batch and clamps below MIN_WINDOW_DIMENSION', () => {
     withTestBridge((harness) => {
       const store = createTestFloatingWindowStore()
       const { windowId } = store.addWindow({ x: 0.1, y: 0.1, width: 0.4, height: 0.4 })!
       const before = harness.pending.state.pendingBatches.length
 
-      // Pass a width below the floor; store must clamp before emitting.
-      store.updateGeometry(windowId, 0.2, 0.3, 0.001, 0.7)
+      // Pass a width below the floor; the store must clamp before emitting.
+      store.updateDragResize(windowId, 0.2, 0.3, 0.001, 0.7)
+      store.commitDragGeometry(windowId)
       const lastBatch = harness.pending.state.pendingBatches.at(-1)
       expect(harness.pending.state.pendingBatches.length - before).toBe(1)
       expect(lastBatch?.ops.length).toBe(4)
@@ -128,40 +167,178 @@ describe('createFloatingWindowStore (projection-driven)', () => {
     }, { rootTileId: 'main' })
   })
 
-  it('updateOpacity clamps the value into [0.2, 1.0] and emits a single-op batch', () => {
+  it('updateOpacityDebounced clamps the value into [0.2, 1.0] and emits a single-op batch', () => {
     withTestBridge((harness) => {
       const store = createTestFloatingWindowStore()
       const { windowId } = store.addWindow()!
 
       // Start by dropping below 1.0 so the next bump shows the clamp
       // change (default 1.0 == clamp(5) == 1.0, which would no-op).
-      expect(store.updateOpacity(windowId, 0.6)).toBe(true)
+      expect(store.updateOpacityDebounced(windowId, 0.6)).toBe(true)
+      store.flushOpacity(windowId)
       const before = harness.pending.state.pendingBatches.length
 
       // Out-of-range high → clamped to 1.0.
-      const changed = store.updateOpacity(windowId, 5)
-      expect(changed).toBe(true)
+      expect(store.updateOpacityDebounced(windowId, 5)).toBe(true)
+      store.flushOpacity(windowId)
       const lastBatch = harness.pending.state.pendingBatches.at(-1)
       expect(harness.pending.state.pendingBatches.length - before).toBe(1)
       expect(lastBatch?.ops.length).toBe(1)
       expect(store.state.windows[0]!.opacity).toBe(1)
 
       // Out-of-range low (zero / negative) → clamped to 0.2.
-      expect(store.updateOpacity(windowId, -10)).toBe(true)
+      expect(store.updateOpacityDebounced(windowId, -10)).toBe(true)
+      store.flushOpacity(windowId)
       expect(store.state.windows[0]!.opacity).toBe(0.2)
     }, { rootTileId: 'main' })
   })
 
-  it('updateOpacity at the same clamped value is a no-op', () => {
+  it('updateOpacityDebounced at the same clamped value is a no-op', () => {
     withTestBridge((harness) => {
       const store = createTestFloatingWindowStore()
       const { windowId } = store.addWindow()!
       // Window default opacity is 1.0; resetting to 1.0 is a no-op.
       const before = harness.pending.state.pendingBatches.length
-      const changed = store.updateOpacity(windowId, 1)
-      expect(changed).toBe(false)
+      expect(store.updateOpacityDebounced(windowId, 1)).toBe(false)
+      store.flushOpacity(windowId)
       expect(harness.pending.state.pendingBatches.length).toBe(before)
     }, { rootTileId: 'main' })
+  })
+
+  describe('drag-override (commit-on-drop)', () => {
+    // updateDragMove / updateDragResize write the live preview into a LOCAL
+    // override (no CRDT op); commitDragGeometry emits exactly ONE op batch on
+    // drop. This cuts a per-drag op storm from ~60-120 (one per frame) down to 1.
+
+    it('updateDragResize moves the projected window WITHOUT emitting a batch', () => {
+      withTestBridge((harness) => {
+        const store = createTestFloatingWindowStore()
+        const { windowId } = store.addWindow({ x: 0.1, y: 0.1, width: 0.4, height: 0.4 })!
+        const before = harness.pending.state.pendingBatches.length
+
+        store.updateDragResize(windowId, 0.5, 0.6, 0.4, 0.4)
+        // No CRDT op was emitted — the override is local-only.
+        expect(harness.pending.state.pendingBatches.length).toBe(before)
+        // The projected window reflects the live preview geometry.
+        expect(store.state.windows[0]!.x).toBeCloseTo(0.5, 6)
+        expect(store.state.windows[0]!.y).toBeCloseTo(0.6, 6)
+      }, { rootTileId: 'main' })
+    })
+
+    it('commitDragGeometry emits a single batch on drop and clears the override', () => {
+      withTestBridge((harness) => {
+        const store = createTestFloatingWindowStore()
+        const { windowId } = store.addWindow({ x: 0.1, y: 0.1, width: 0.4, height: 0.4 })!
+        const before = harness.pending.state.pendingBatches.length
+
+        // A drag: several override updates, then one commit.
+        store.updateDragResize(windowId, 0.2, 0.2, 0.4, 0.4)
+        store.updateDragResize(windowId, 0.3, 0.3, 0.4, 0.4)
+        store.updateDragResize(windowId, 0.4, 0.4, 0.4, 0.4)
+        expect(harness.pending.state.pendingBatches.length).toBe(before)
+
+        store.commitDragGeometry(windowId)
+        // Exactly ONE op batch for the whole drag.
+        expect(harness.pending.state.pendingBatches.length - before).toBe(1)
+        // The geometry persisted at the override's final value.
+        expect(store.state.windows[0]!.x).toBeCloseTo(0.4, 6)
+        expect(store.state.windows[0]!.y).toBeCloseTo(0.4, 6)
+      }, { rootTileId: 'main' })
+    })
+
+    it('commitDragGeometry is a no-op when no drag is in flight (bare click)', () => {
+      withTestBridge((harness) => {
+        const store = createTestFloatingWindowStore()
+        const { windowId } = store.addWindow({ x: 0.1, y: 0.1, width: 0.4, height: 0.4 })!
+        const before = harness.pending.state.pendingBatches.length
+
+        store.commitDragGeometry(windowId)
+        expect(harness.pending.state.pendingBatches.length).toBe(before)
+      }, { rootTileId: 'main' })
+    })
+
+    it('commitDragGeometry is a no-op when the override matches the CRDT geometry (drag returned to start)', () => {
+      withTestBridge((harness) => {
+        const store = createTestFloatingWindowStore()
+        const { windowId } = store.addWindow({ x: 0.1, y: 0.1, width: 0.4, height: 0.4 })!
+        const before = harness.pending.state.pendingBatches.length
+
+        // Drag back to the same geometry, then commit — should emit nothing.
+        store.updateDragResize(windowId, 0.1, 0.1, 0.4, 0.4)
+        store.commitDragGeometry(windowId)
+        expect(harness.pending.state.pendingBatches.length).toBe(before)
+      }, { rootTileId: 'main' })
+    })
+
+    it('cancelDragGeometry snaps the projection back to CRDT geometry without committing', () => {
+      withTestBridge((harness) => {
+        const store = createTestFloatingWindowStore()
+        const { windowId } = store.addWindow({ x: 0.1, y: 0.1, width: 0.4, height: 0.4 })!
+        const before = harness.pending.state.pendingBatches.length
+
+        store.updateDragResize(windowId, 0.5, 0.6, 0.4, 0.4)
+        // The override is live.
+        expect(store.state.windows[0]!.x).toBeCloseTo(0.5, 6)
+        // Cancel — no op, snaps back.
+        store.cancelDragGeometry(windowId)
+        expect(harness.pending.state.pendingBatches.length).toBe(before)
+        expect(store.state.windows[0]!.x).toBeCloseTo(0.1, 6)
+        expect(store.state.windows[0]!.y).toBeCloseTo(0.1, 6)
+      }, { rootTileId: 'main' })
+    })
+
+    // Two windows dragged at once must BOTH survive.
+    //
+    // The override used to be a single slot, justified by a comment claiming
+    // `useWindowPointerDrag` serialized drags. It does not: every
+    // FloatingWindowContainer constructs its OWN controller, so `cancel()` only
+    // supersedes a gesture on the same window, and the hook uses document-level
+    // listeners rather than `setPointerCapture`. Two pointers on two title bars
+    // (touch, or a second button) run two live drags. The second
+    // `updateDrag*` then evicted the first, so w1 snapped back to CRDT geometry
+    // mid-gesture and `commitDragGeometry(w1)` returned early on the id
+    // mismatch -- the entire drag discarded, no op, no error path. This case
+    // previously asserted that loss as if it were the intended contract.
+    it('keeps a per-window override so two simultaneous drags both commit', () => {
+      withTestBridge((harness) => {
+        const store = createTestFloatingWindowStore()
+        const w1 = store.addWindow({ x: 0.1, y: 0.1, width: 0.3, height: 0.3 })!.windowId
+        const w2 = store.addWindow({ x: 0.5, y: 0.5, width: 0.3, height: 0.3 })!.windowId
+
+        // Both pointers move before either lifts.
+        store.updateDragResize(w1, 0.2, 0.2, 0.3, 0.3)
+        store.updateDragResize(w2, 0.6, 0.6, 0.3, 0.3)
+
+        // Each window renders at its OWN live override.
+        expect(store.state.windows.find(w => w.id === w1)!.x).toBeCloseTo(0.2, 6)
+        expect(store.state.windows.find(w => w.id === w2)!.x).toBeCloseTo(0.6, 6)
+
+        // And each drop commits its own op batch.
+        const before = harness.pending.state.pendingBatches.length
+        store.commitDragGeometry(w1)
+        expect(harness.pending.state.pendingBatches.length - before).toBe(1)
+        store.commitDragGeometry(w2)
+        expect(harness.pending.state.pendingBatches.length - before).toBe(2)
+        expect(store.state.windows.find(w => w.id === w1)!.x).toBeCloseTo(0.2, 6)
+        expect(store.state.windows.find(w => w.id === w2)!.x).toBeCloseTo(0.6, 6)
+      }, { rootTileId: 'main' })
+    })
+
+    // Cancelling one gesture must not disturb the other's override.
+    it('cancelDragGeometry clears only the named window', () => {
+      withTestBridge((_harness) => {
+        const store = createTestFloatingWindowStore()
+        const w1 = store.addWindow({ x: 0.1, y: 0.1, width: 0.3, height: 0.3 })!.windowId
+        const w2 = store.addWindow({ x: 0.5, y: 0.5, width: 0.3, height: 0.3 })!.windowId
+
+        store.updateDragResize(w1, 0.2, 0.2, 0.3, 0.3)
+        store.updateDragResize(w2, 0.6, 0.6, 0.3, 0.3)
+        store.cancelDragGeometry(w1)
+
+        expect(store.state.windows.find(w => w.id === w1)!.x).toBeCloseTo(0.1, 6)
+        expect(store.state.windows.find(w => w.id === w2)!.x).toBeCloseTo(0.6, 6)
+      }, { rootTileId: 'main' })
+    })
   })
 
   it('bringToFront reorders the projection without emitting a batch (z-order is local)', () => {
@@ -475,12 +652,13 @@ describe('createFloatingWindowStore (projection-driven)', () => {
         await new Promise<void>(queueMicrotask)
         const before = store.getWindowTileIdSet(windowId)
         expect(before).not.toBeNull()
-        // 20-frame scrub mimicking a real drag: 20 updatePosition
-        // calls, each bumping the bridge version signal. None of them
-        // change the window's tile membership.
+        // 20-frame scrub down the path the UI actually takes: each frame
+        // writes the drag override (bumping the bridge version signal), and the
+        // drop commits once. None of them change the window's tile membership.
         for (let i = 0; i < 20; i++) {
-          store.updatePosition(windowId, 0.1 + i * 0.01, 0.1 + i * 0.01)
+          store.updateDragMove(windowId, 0.1 + i * 0.01, 0.1 + i * 0.01)
         }
+        store.commitDragGeometry(windowId)
         await new Promise<void>(queueMicrotask)
         const after = store.getWindowTileIdSet(windowId)
         // Same Set ref across the scrub — the structural equality
@@ -500,8 +678,9 @@ describe('createFloatingWindowStore (projection-driven)', () => {
         // 20-frame resize scrub: width + height change every frame,
         // tile membership doesn't.
         for (let i = 0; i < 20; i++) {
-          store.updateGeometry(windowId, 0.1, 0.1, 0.3 + i * 0.01, 0.3 + i * 0.01)
+          store.updateDragResize(windowId, 0.1, 0.1, 0.3 + i * 0.01, 0.3 + i * 0.01)
         }
+        store.commitDragGeometry(windowId)
         await new Promise<void>(queueMicrotask)
         const after = store.getWindowTileIdSet(windowId)
         expect(after).toBe(before)
@@ -574,7 +753,8 @@ describe('createFloatingWindowStore (projection-driven)', () => {
         // unguarded join the tab view would rebuild every frame. Either way
         // the effect would run 50 times despite no membership / tab change.
         for (let i = 0; i < 50; i++)
-          store.updatePosition(windowId, 0.1 + i * 0.005, 0.1 + i * 0.005)
+          store.updateDragMove(windowId, 0.1 + i * 0.005, 0.1 + i * 0.005)
+        store.commitDragGeometry(windowId)
         await new Promise<void>(queueMicrotask)
 
         expect(effectRuns).toBe(baseline)
@@ -599,9 +779,12 @@ describe('createFloatingWindowStore (projection-driven)', () => {
         // same ref — that's the contract the structural-equality
         // memo relies on for the geometry-hot path.
         for (let i = 0; i < 10; i++) {
-          store.updateGeometry(a.windowId, 0.1, 0.1, 0.2 + i * 0.01, 0.2 + i * 0.01)
-          store.updateGeometry(b.windowId, 0.3, 0.3, 0.2 + i * 0.01, 0.2 + i * 0.01)
-          store.updateGeometry(c.windowId, 0.5, 0.5, 0.2 + i * 0.01, 0.2 + i * 0.01)
+          store.updateDragResize(a.windowId, 0.1, 0.1, 0.2 + i * 0.01, 0.2 + i * 0.01)
+          store.commitDragGeometry(a.windowId)
+          store.updateDragResize(b.windowId, 0.3, 0.3, 0.2 + i * 0.01, 0.2 + i * 0.01)
+          store.commitDragGeometry(b.windowId)
+          store.updateDragResize(c.windowId, 0.5, 0.5, 0.2 + i * 0.01, 0.2 + i * 0.01)
+          store.commitDragGeometry(c.windowId)
         }
         await new Promise<void>(queueMicrotask)
         expect(store.getWindowTileIdSet(a.windowId)).toBe(beforeA)
@@ -663,7 +846,8 @@ describe('createFloatingWindowStore (projection-driven)', () => {
         const baseline = bgRuns
 
         for (let i = 0; i < 10; i++)
-          store.updatePosition(active.windowId, 0.1 + i * 0.01, 0.1 + i * 0.01)
+          store.updateDragMove(active.windowId, 0.1 + i * 0.01, 0.1 + i * 0.01)
+        store.commitDragGeometry(active.windowId)
         await new Promise<void>(queueMicrotask)
 
         expect(bgRuns, 'ten drag frames in another workspace notify this one zero times').toBe(baseline)
@@ -690,7 +874,8 @@ describe('createFloatingWindowStore (projection-driven)', () => {
         await new Promise<void>(queueMicrotask)
         const before = store.state.windows[0]!
         const beforeId = before.id
-        store.updatePosition(created.windowId, 0.3, 0.4)
+        store.updateDragMove(created.windowId, 0.3, 0.4)
+        store.commitDragGeometry(created.windowId)
         await new Promise<void>(queueMicrotask)
         const after = store.state.windows[0]!
         // Same store-proxy ref (proves <For> won't remount).
@@ -897,6 +1082,449 @@ describe('cross-workspace floating tile lookups', () => {
 
       moveWindowToWorkspace(background.windowId, 'ws-active')
       expect(store.state.windows[0]?.focusedTileId).toBe(second)
+    })
+  })
+})
+
+describe('createFloatingWindowStore — debounced opacity (title-bar wheel)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  // updateOpacityDebounced writes the live value to a local override (instant
+  // feedback) and arms a trailing debounce that emits ONE op when scrolling
+  // pauses. A whole scroll gesture collapses to a single op instead of one
+  // per wheel tick.
+
+  it('writes the override immediately without emitting a batch', () => {
+    withTestBridge((harness) => {
+      const store = createTestFloatingWindowStore()
+      const { windowId } = store.addWindow()!
+      const before = harness.pending.state.pendingBatches.length
+
+      const changed = store.updateOpacityDebounced(windowId, 0.6)
+      expect(changed).toBe(true)
+      // No CRDT op yet — the override is local-only.
+      expect(harness.pending.state.pendingBatches.length).toBe(before)
+      // The projected opacity reflects the live override immediately.
+      expect(store.state.windows[0]!.opacity).toBeCloseTo(0.6, 6)
+    }, { rootTileId: 'main' })
+  })
+
+  it('emits exactly one op after the quiet period, coalescing a scroll gesture', () => {
+    withTestBridge((harness) => {
+      const store = createTestFloatingWindowStore()
+      const { windowId } = store.addWindow()!
+      const before = harness.pending.state.pendingBatches.length
+
+      // A scroll gesture: many wheel ticks, each advancing the override.
+      store.updateOpacityDebounced(windowId, 0.9)
+      store.updateOpacityDebounced(windowId, 0.8)
+      store.updateOpacityDebounced(windowId, 0.7)
+      store.updateOpacityDebounced(windowId, 0.6)
+      expect(harness.pending.state.pendingBatches.length).toBe(before)
+      expect(store.state.windows[0]!.opacity).toBeCloseTo(0.6, 6)
+
+      // Advance just short of the delay — still no op.
+      vi.advanceTimersByTime(599)
+      expect(harness.pending.state.pendingBatches.length).toBe(before)
+
+      // Cross the delay: exactly ONE op fires with the final value.
+      vi.advanceTimersByTime(1)
+      expect(harness.pending.state.pendingBatches.length - before).toBe(1)
+      expect(store.state.windows[0]!.opacity).toBeCloseTo(0.6, 6)
+    }, { rootTileId: 'main' })
+  })
+
+  // The flush used to re-read the projection to decide whether the value had
+  // changed. That read is unavailable on exactly the paths the flush exists to
+  // serve: at store disposal Solid has already disposed the createComputed that
+  // maintains the projection, and on a workspace switch the window has already
+  // left the active-workspace slice. Both made the guard swallow the op. The
+  // gesture now carries the CRDT baseline it started from.
+  it('still emits when the window is no longer in the projection', () => {
+    withTestBridge((harness) => {
+      const store = createTestFloatingWindowStore()
+      const { windowId } = store.addWindow()!
+
+      store.updateOpacityDebounced(windowId, 0.6)
+      // Move the window to another workspace, so it leaves the projected slice
+      // exactly as it does on a workspace switch mid-gesture.
+      const bridge = getCRDTBridge()!
+      bridge.enqueue(newBatch([setFloatingWorkspaceId(ctxFromBridge(bridge), windowId, 'ws-elsewhere')]))
+      expect(store.state.windows.some(w => w.id === windowId)).toBe(false)
+
+      // Count from AFTER the move, so only the flush's own op is measured.
+      const before = harness.pending.state.pendingBatches.length
+      store.flushOpacity(windowId)
+      expect(harness.pending.state.pendingBatches.length - before).toBe(1)
+    }, { rootTileId: 'main' })
+  })
+
+  it('does not emit when the gesture ends back at its starting value', () => {
+    withTestBridge((harness) => {
+      const store = createTestFloatingWindowStore()
+      const { windowId } = store.addWindow()!
+      const before = harness.pending.state.pendingBatches.length
+
+      // Default opacity is 1.0: scrub away and back.
+      store.updateOpacityDebounced(windowId, 0.6)
+      store.updateOpacityDebounced(windowId, 1)
+      store.flushOpacity(windowId)
+      expect(harness.pending.state.pendingBatches.length).toBe(before)
+    }, { rootTileId: 'main' })
+  })
+
+  it('re-arms the timer on each tick so a continuous scroll stays one op', () => {
+    withTestBridge((harness) => {
+      const store = createTestFloatingWindowStore()
+      const { windowId } = store.addWindow()!
+      const before = harness.pending.state.pendingBatches.length
+
+      // Tick, advance partway, tick again — the timer should reset.
+      store.updateOpacityDebounced(windowId, 0.7)
+      vi.advanceTimersByTime(400)
+      store.updateOpacityDebounced(windowId, 0.6)
+      vi.advanceTimersByTime(400)
+      // 400 + 400 = 800 > 600, but the second tick re-armed at t=400, so the
+      // timer fires at t=1000, not t=600. No op yet at t=800.
+      expect(harness.pending.state.pendingBatches.length).toBe(before)
+
+      // Cross the re-armed delay: one op.
+      vi.advanceTimersByTime(200)
+      expect(harness.pending.state.pendingBatches.length - before).toBe(1)
+    }, { rootTileId: 'main' })
+  })
+
+  // The pending edit is keyed BY WINDOW. It used to be a single global slot,
+  // borrowed from the drag override -- which is safe there only because pointer
+  // capture serializes drags. Wheel events need no capture, every visible window
+  // binds its own title-bar listener, so two windows can have gestures in flight
+  // at once.
+  it('scrolling a second window does not discard the first window\'s pending opacity', () => {
+    withTestBridge((harness) => {
+      const store = createTestFloatingWindowStore()
+      const a = store.addWindow({ x: 0.1, y: 0.1, width: 0.2, height: 0.2 })!
+      const b = store.addWindow({ x: 0.4, y: 0.4, width: 0.2, height: 0.2 })!
+      const before = harness.pending.state.pendingBatches.length
+
+      // Scroll A, then B within the debounce window. A single slot cleared A's
+      // timer and replaced A's override, so A's op was NEVER emitted and its
+      // rendered opacity silently snapped back -- the whole gesture lost, with
+      // no error path.
+      store.updateOpacityDebounced(a.windowId, 0.7)
+      store.updateOpacityDebounced(b.windowId, 0.5)
+
+      vi.advanceTimersByTime(1000)
+
+      expect(harness.pending.state.pendingBatches.length - before).toBe(2)
+      const byId = new Map(store.state.windows.map(w => [w.id, w.opacity]))
+      expect(byId.get(a.windowId)).toBeCloseTo(0.7, 6)
+      expect(byId.get(b.windowId)).toBeCloseTo(0.5, 6)
+    }, { rootTileId: 'main' })
+  })
+
+  it('flushOpacity(id) flushes only that window, leaving another gesture armed', () => {
+    withTestBridge((harness) => {
+      const store = createTestFloatingWindowStore()
+      const a = store.addWindow({ x: 0.1, y: 0.1, width: 0.2, height: 0.2 })!
+      const b = store.addWindow({ x: 0.4, y: 0.4, width: 0.2, height: 0.2 })!
+      const before = harness.pending.state.pendingBatches.length
+
+      store.updateOpacityDebounced(a.windowId, 0.7)
+      store.updateOpacityDebounced(b.windowId, 0.5)
+
+      // B unmounts (closed, or a workspace switch) mid-gesture. Its teardown
+      // must commit ITS value only -- unscoped, it committed whichever window
+      // happened to be pending, splitting A's single gesture into two ops.
+      store.flushOpacity(b.windowId)
+      expect(harness.pending.state.pendingBatches.length - before).toBe(1)
+
+      // A's gesture is still armed and fires on its own schedule.
+      vi.advanceTimersByTime(1000)
+      expect(harness.pending.state.pendingBatches.length - before).toBe(2)
+      const byId = new Map(store.state.windows.map(w => [w.id, w.opacity]))
+      expect(byId.get(a.windowId)).toBeCloseTo(0.7, 6)
+    }, { rootTileId: 'main' })
+  })
+
+  it('same-value tick (pinned at clamp floor) is a no-op and does not re-arm', () => {
+    withTestBridge((harness) => {
+      const store = createTestFloatingWindowStore()
+      // Drop to 0.2 (the clamp floor) and flush so the CRDT value is 0.2.
+      const { windowId } = store.addWindow()!
+      store.updateOpacityDebounced(windowId, 0.2)
+      store.flushOpacity(windowId)
+      const before = harness.pending.state.pendingBatches.length
+
+      // Scrolling further down clamps to 0.2 again — no change, no re-arm.
+      const changed = store.updateOpacityDebounced(windowId, 0.1)
+      expect(changed).toBe(false)
+      // Advance past the delay: still no op (timer was never armed).
+      vi.advanceTimersByTime(1000)
+      expect(harness.pending.state.pendingBatches.length).toBe(before)
+    }, { rootTileId: 'main' })
+  })
+
+  it('flushOpacity emits the pending op immediately and clears the timer', () => {
+    withTestBridge((harness) => {
+      const store = createTestFloatingWindowStore()
+      const { windowId } = store.addWindow()!
+      const before = harness.pending.state.pendingBatches.length
+
+      store.updateOpacityDebounced(windowId, 0.5)
+      store.flushAllOpacity()
+      expect(harness.pending.state.pendingBatches.length - before).toBe(1)
+      // A second flush is a no-op.
+      store.flushAllOpacity()
+      expect(harness.pending.state.pendingBatches.length - before).toBe(1)
+      // Advancing time does not fire a stale op.
+      vi.advanceTimersByTime(1000)
+      expect(harness.pending.state.pendingBatches.length - before).toBe(1)
+    }, { rootTileId: 'main' })
+  })
+
+  it('an unscoped flush emits one op per window with a real change', () => {
+    withTestBridge((harness) => {
+      const store = createTestFloatingWindowStore()
+      const a = store.addWindow({ x: 0.1, y: 0.1, width: 0.2, height: 0.2 })!
+      const b = store.addWindow({ x: 0.4, y: 0.4, width: 0.2, height: 0.2 })!
+      const c = store.addWindow({ x: 0.7, y: 0.7, width: 0.2, height: 0.2 })!
+      store.updateOpacityDebounced(a.windowId, 0.7)
+      store.updateOpacityDebounced(b.windowId, 0.5)
+      // C's gesture ends back where it started, so it must emit nothing even
+      // though the sweep drops its entry alongside the other two.
+      store.updateOpacityDebounced(c.windowId, 0.4)
+      store.updateOpacityDebounced(c.windowId, 1)
+      const before = harness.pending.state.pendingBatches.length
+
+      // The store's own disposal hook and the pagehide listener take this path:
+      // every window is going away, so every gesture flushes at once.
+      store.flushAllOpacity()
+
+      expect(harness.pending.state.pendingBatches.length - before).toBe(2)
+      const byId = new Map(store.state.windows.map(w => [w.id, w.opacity]))
+      expect(byId.get(a.windowId)).toBeCloseTo(0.7, 6)
+      expect(byId.get(b.windowId)).toBeCloseTo(0.5, 6)
+      expect(byId.get(c.windowId)).toBeCloseTo(1, 6)
+      // Every timer was cleared, so nothing fires late.
+      vi.advanceTimersByTime(1000)
+      expect(harness.pending.state.pendingBatches.length - before).toBe(2)
+    }, { rootTileId: 'main' })
+  })
+
+  // A browser unload runs NO Solid cleanup, so neither disposal hook fires on a
+  // refresh or a tab close. Before the debounce existed the op was emitted
+  // synchronously; without this listener a scrub finished inside the 600ms
+  // window is lost outright, and the op-log cannot recover an op that was never
+  // created.
+  it('flushes on pagehide, which no Solid cleanup covers', () => {
+    withTestBridge((harness) => {
+      const store = createTestFloatingWindowStore()
+      const { windowId } = store.addWindow()!
+      store.updateOpacityDebounced(windowId, 0.6)
+      const before = harness.pending.state.pendingBatches.length
+
+      window.dispatchEvent(new Event('pagehide'))
+
+      expect(harness.pending.state.pendingBatches.length - before).toBe(1)
+      // The timer was cleared with the gesture, so nothing fires late.
+      vi.advanceTimersByTime(1000)
+      expect(harness.pending.state.pendingBatches.length - before).toBe(1)
+    }, { rootTileId: 'main' })
+  })
+
+  // Creating the op is only HALF the job, and the half this test used to stop
+  // at. `bridge.enqueue` pushes onto the submitter's queue and arms a ~16 ms
+  // timer; on a real unload -- Cmd+R, tab close, the case this listener exists
+  // for -- the page is gone before it fires, so the op was created and then
+  // dropped. Only `flushNow` (keepalive transport) actually sends it.
+  //
+  // Both steps must happen in ONE handler, in this order. Splitting the send
+  // into its own `pagehide` listener would make the outcome depend on
+  // registration order, and the runtime mounts BEFORE the stores -- so its
+  // listener would flush an empty queue and then the store would create the op
+  // with nothing left to send it.
+  it('sends on pagehide, not merely enqueues', () => {
+    withTestBridge((harness) => {
+      const store = createTestFloatingWindowStore()
+      const { windowId } = store.addWindow()!
+      store.updateOpacityDebounced(windowId, 0.6)
+      const before = harness.pending.state.pendingBatches.length
+
+      window.dispatchEvent(new Event('pagehide'))
+
+      // The LAST call is this store's: earlier cases in this file create stores
+      // without disposing them, so their listeners are still attached and fire
+      // first (registration order). Theirs have no gesture to flush.
+      expect(harness.flushNowCalls.length).toBeGreaterThan(0)
+      // The count AT FLUSH TIME proves the op was created first: a flush that
+      // ran before the gesture materialized would see the pre-gesture count.
+      expect(harness.flushNowCalls.at(-1)).toBe(before + 1)
+    }, { rootTileId: 'main' })
+  })
+
+  it('removes its pagehide listener when the store is disposed', () => {
+    // Left attached, the listener would keep a disposed store's closure alive
+    // and flush into a torn-down bridge on every later unload.
+    let disposedStore!: ReturnType<typeof createTestFloatingWindowStore>
+    withTestBridge((harness) => {
+      disposedStore = createTestFloatingWindowStore()
+      const { windowId } = disposedStore.addWindow()!
+      disposedStore.updateOpacityDebounced(windowId, 0.6)
+      // Leaving the root disposes the store, whose own cleanup already flushed.
+      expect(harness.pending.state.pendingBatches.length).toBeGreaterThanOrEqual(0)
+    }, { rootTileId: 'main' })
+
+    // No throw, and nothing to flush: the listener is gone with the store.
+    expect(() => window.dispatchEvent(new Event('pagehide'))).not.toThrow()
+  })
+
+  it('drops every gesture in ONE map rebuild when flushed unscoped', () => {
+    withTestBridge((harness) => {
+      // `rawProjection` reads `opts.projection()` exactly once per run, so
+      // counting the reads counts the rebuilds the flush costs.
+      const { projection } = projectionMemo()
+      let projectionReads = 0
+      const store = createFloatingWindowStore({
+        getWorkspaceId: () => harness.workspaceId,
+        projection: () => {
+          projectionReads++
+          return projection()
+        },
+      })
+      const ids = [
+        store.addWindow({ x: 0.1, y: 0.1, width: 0.2, height: 0.2 })!.windowId,
+        store.addWindow({ x: 0.4, y: 0.4, width: 0.2, height: 0.2 })!.windowId,
+        store.addWindow({ x: 0.7, y: 0.7, width: 0.2, height: 0.2 })!.windowId,
+      ]
+      // Park every gesture back at its CRDT baseline, so the flush emits NO ops
+      // and the map rebuild is the only thing it can cost.
+      for (const id of ids) {
+        store.updateOpacityDebounced(id, 0.5)
+        store.updateOpacityDebounced(id, 1)
+      }
+      const batchesBefore = harness.pending.state.pendingBatches.length
+
+      projectionReads = 0
+      store.flushAllOpacity()
+
+      expect(harness.pending.state.pendingBatches.length).toBe(batchesBefore)
+      // ONE rebuild for the whole sweep. Clearing per victim inside the emit
+      // loop rebuilt the map -- re-running every downstream projection -- once
+      // per window, so this was 3.
+      expect(projectionReads).toBe(1)
+      expect(store.state.windows.every(w => w.opacity === 1)).toBe(true)
+    }, { rootTileId: 'main' })
+  })
+})
+
+// The store's own keyed-override primitive, behind the drag preview, the
+// debounced-opacity gesture and per-window focus. Two rules are load-bearing
+// and used to be re-derived by hand at six sites: a write must not mutate the
+// previous Map (the projection memo and Solid's `<For>` key on its identity),
+// and a removal that removes nothing must hand back the SAME reference, since
+// that is the only thing that makes Solid's setSignal suppress the notify.
+describe('createKeyedOverrides', () => {
+  it('rebuilds on set, leaving the previous snapshot untouched', () => {
+    createRoot((dispose) => {
+      const overrides = createKeyedOverrides<number>()
+      const empty = overrides.snapshot()
+      overrides.set('a', 1)
+      const afterFirst = overrides.snapshot()
+      expect(afterFirst).not.toBe(empty)
+      // Copy-on-write: the map a consumer already read is never scribbled on.
+      expect(empty.size).toBe(0)
+
+      overrides.set('b', 2)
+      expect(overrides.snapshot()).not.toBe(afterFirst)
+      expect(afterFirst.has('b')).toBe(false)
+      expect([...overrides.snapshot()]).toEqual([['a', 1], ['b', 2]])
+      expect(overrides.get('a')).toBe(1)
+      expect(overrides.get('missing')).toBeUndefined()
+      dispose()
+    })
+  })
+
+  it('clear drops exactly one key, and keeps the reference when there is none', () => {
+    createRoot((dispose) => {
+      const overrides = createKeyedOverrides<number>()
+      overrides.set('a', 1)
+      overrides.set('b', 2)
+      const before = overrides.snapshot()
+
+      overrides.clear('absent')
+      expect(overrides.snapshot()).toBe(before)
+
+      overrides.clear('a')
+      expect(overrides.snapshot()).not.toBe(before)
+      expect([...overrides.snapshot().keys()]).toEqual(['b'])
+      expect(before.has('a')).toBe(true)
+      dispose()
+    })
+  })
+
+  it('clearAll empties in one rebuild and no-ops on an already-empty map', () => {
+    createRoot((dispose) => {
+      const overrides = createKeyedOverrides<number>()
+      overrides.set('a', 1)
+      overrides.set('b', 2)
+      const populated = overrides.snapshot()
+
+      overrides.clearAll()
+      const emptied = overrides.snapshot()
+      expect(emptied.size).toBe(0)
+      expect(emptied).not.toBe(populated)
+      expect(populated.size).toBe(2)
+
+      // A second clearAll must not notify — the disposal hook and the pagehide
+      // listener both reach it with nothing left to drop.
+      overrides.clearAll()
+      expect(overrides.snapshot()).toBe(emptied)
+      dispose()
+    })
+  })
+
+  it('retain drops only rejected keys, and keeps the reference when all survive', () => {
+    createRoot((dispose) => {
+      const overrides = createKeyedOverrides<number>()
+      overrides.set('live-1', 1)
+      overrides.set('dead', 2)
+      overrides.set('live-2', 3)
+      const before = overrides.snapshot()
+
+      // The GC's shape: a sweep that finds nothing stale must hand back the
+      // same map, or every membership change would re-run the projection.
+      overrides.retain(() => true)
+      expect(overrides.snapshot()).toBe(before)
+
+      overrides.retain(key => key !== 'dead')
+      const after = overrides.snapshot()
+      expect(after).not.toBe(before)
+      expect([...after.keys()]).toEqual(['live-1', 'live-2'])
+      expect(before.has('dead')).toBe(true)
+
+      // Rejecting everything empties it in one pass.
+      overrides.retain(() => false)
+      expect(overrides.snapshot().size).toBe(0)
+      dispose()
+    })
+  })
+
+  it('stores null as a value distinct from an absent key', () => {
+    // `focusByWindow` instantiates T as `string | null`: a recorded "no focused
+    // tile" has to stay distinguishable from "never recorded", which falls back
+    // to the window's first leaf.
+    createRoot((dispose) => {
+      const overrides = createKeyedOverrides<string | null>()
+      overrides.set('w1', null)
+      expect(overrides.get('w1')).toBeNull()
+      expect(overrides.snapshot().has('w1')).toBe(true)
+      expect(overrides.get('w2')).toBeUndefined()
+      dispose()
     })
   })
 })

--- a/frontend/src/stores/floatingWindow.store.ts
+++ b/frontend/src/stores/floatingWindow.store.ts
@@ -1,7 +1,7 @@
 import type { CloseTileResult, GridAxis, LayoutNodeLocal, SplitOrientation } from './layout.store'
 import type { LayoutOwner } from './layoutOwner'
 import type { CRDTBridge, LocalTreeCache, Projection, RenderedFloatingWindow } from '~/lib/crdt'
-import { createComputed, createEffect, createMemo, createSignal, mapArray, on } from 'solid-js'
+import { createComputed, createEffect, createMemo, createSignal, mapArray, on, onCleanup } from 'solid-js'
 import { createStore, reconcile } from 'solid-js/store'
 import { renderTreeToLocal, withBridge } from '~/lib/crdt'
 import { sameKeys } from '~/lib/sameKeys'
@@ -47,9 +47,12 @@ export interface FloatingWindowStoreState {
 
 /**
  * Floor for a floating window's `width` and `height`, expressed as a fraction
- * of the parent container. Both the store's `updateGeometry` clamp and the
+ * of the parent container. Both the store's `updateDragResize` clamp and the
  * chrome resize handle reference this so the window can't be dragged below
  * 5% of the viewport in either dimension.
+ *
+ * `updateDragResize` is the ONLY entry point that can set a window's size, so
+ * clamping there covers every path: `updateDragMove` takes no dimensions at all.
  */
 export const MIN_WINDOW_DIMENSION = 0.05
 
@@ -119,6 +122,75 @@ function windowLayoutRoot(rendered: RenderedFloatingWindow, cache: LocalTreeCach
 }
 
 /**
+ * A per-window local overlay: `Map<string, T>` behind a Solid signal, rebuilt
+ * copy-on-write on every write that actually changes something.
+ *
+ * Three of this store's overlays are exactly this shape -- the drag preview,
+ * the debounced-opacity gesture, and per-window focus -- and each used to hand-
+ * write its own updater, six copies in all, two of them byte-identical apart
+ * from the signal name. Each copy also had to re-derive the same two rules by
+ * eye: a write must not mutate the previous Map (the projection memo and
+ * Solid's `<For>` key on its identity), and a removal that removes nothing must
+ * hand back the PREVIOUS reference, because that is the only thing that makes
+ * `setSignal` suppress the notify. Every mutator below obeys both.
+ *
+ * `clearAll` and `retain` exist because a bulk edit expressed as a loop of
+ * per-key `clear` calls rebuilds the whole map -- and re-runs every downstream
+ * projection -- once per key removed.
+ *
+ * This store's private primitive despite being exported: the export exists so
+ * the co-located suite can pin the two rules above directly, rather than
+ * inferring them from three overlays' behaviour. Nothing else imports it.
+ */
+export interface KeyedOverrides<T> {
+  /** `key`'s override, or undefined when it has none. */
+  get: (key: string) => T | undefined
+  /** Install (or replace) `key`'s override. */
+  set: (key: string, value: T) => void
+  /** Drop `key`'s override. No rebuild and no notify when it has none. */
+  clear: (key: string) => void
+  /** Drop every override, in ONE rebuild. */
+  clearAll: () => void
+  /** Keep only the keys `keep` accepts, in ONE rebuild. */
+  retain: (keep: (key: string) => boolean) => void
+  /** The whole map, for consumers that iterate it or read many keys per pass. */
+  snapshot: () => ReadonlyMap<string, T>
+}
+
+export function createKeyedOverrides<T>(): KeyedOverrides<T> {
+  const [overrides, setOverrides] = createSignal<ReadonlyMap<string, T>>(new Map())
+  return {
+    get: key => overrides().get(key),
+    set: (key, value) => setOverrides((prev) => {
+      const next = new Map(prev)
+      next.set(key, value)
+      return next
+    }),
+    clear: key => setOverrides((prev) => {
+      if (!prev.has(key))
+        return prev
+      const next = new Map(prev)
+      next.delete(key)
+      return next
+    }),
+    clearAll: () => setOverrides(prev => prev.size === 0 ? prev : new Map()),
+    retain: keep => setOverrides((prev) => {
+      // Copy lazily, on the first key that actually goes: a sweep that finds
+      // nothing stale must hand back `prev` so no consumer re-derives.
+      let next: Map<string, T> | undefined
+      for (const key of prev.keys()) {
+        if (keep(key))
+          continue
+        next ??= new Map(prev)
+        next.delete(key)
+      }
+      return next ?? prev
+    }),
+    snapshot: overrides,
+  }
+}
+
+/**
  * createFloatingWindowStore — projection-driven floating-window store.
  * Window list + inner trees derive from `project(bridge.speculativeState())
  * [bridge.workspaceId()].floatingWindows`. Z-order is local-only (a
@@ -150,8 +222,188 @@ export function createFloatingWindowStore(opts: CreateFloatingWindowStoreOpts) {
   // Z-order: the array of window ids in render order (last = topmost).
   // Local-only — z-order isn't a CRDT register.
   const [zOrder, setZOrder] = createSignal<string[]>([])
-  // Per-window local focus state.
-  const [focusByWindow, setFocusByWindow] = createSignal<Map<string, string | null>>(new Map())
+  // Per-window local focus state. `null` is a RECORDED "no focused tile",
+  // distinct from an absent entry (which falls back to the window's first leaf).
+  const focusByWindow = createKeyedOverrides<string | null>()
+
+  // Local-only geometry override for the window currently being dragged /
+  // resized. During a drag the container writes the live preview here so the
+  // window renders at the pointer WITHOUT emitting a per-frame CRDT op (peers
+  // see the window jump to its final position on drop, matching the splitter
+  // drag's existing design). `commitDragGeometry` emits the single op on drop
+  // and clears the override; `cancelDragGeometry` clears it without committing
+  // (used when the container unmounts mid-gesture — see its doc).
+  //
+  // KEYED BY WINDOW, like the opacity override below, and for the same reason.
+  // Nothing serializes drags ACROSS windows: each FloatingWindowContainer
+  // constructs its OWN `useWindowPointerDrag` controller, so that controller's
+  // `cancel()` only supersedes a gesture on the SAME window, and the hook
+  // deliberately uses document-level listeners rather than `setPointerCapture`.
+  // Two pointers on two title bars (touch, or a second button) therefore run two
+  // live drags. With a single slot the second `updateDrag*` call replaced the
+  // first, so the first window snapped back to CRDT geometry mid-gesture and its
+  // `commitDragGeometry` returned early on the id mismatch -- discarding the
+  // whole drag with no op and no error path.
+  //
+  // This override still earns its keep alongside `~/lib/crdt/coalesce`, which
+  // merges same-register writes inside the submitter's 16ms flush window: that
+  // gives ~1 op per FLUSH, while the override gives 1 op per GESTURE and, more
+  // importantly, 0 ops during it. Coalescing is the floor for any register that
+  // has no override; this is the ceiling for one that does.
+  // A REAL discriminated union: a move override has no width/height at all.
+  //
+  // The two gestures commit DIFFERENT register sets. A resize legitimately
+  // writes all four; a MOVE must write x/y only. When a move override still
+  // carried width/height, those were the values captured at pointer-down, so a
+  // peer that resized the window mid-drag had its resize overwritten by stale
+  // numbers under a newer HLC -- reverted on every client, permanently. Making
+  // the fields absent rather than present-but-ignored means the projection and
+  // the commit path cannot read them by mistake; `override.width` on a move is
+  // a type error instead of a stale number.
+  type DragOverride
+    = | { kind: 'move', x: number, y: number }
+      | { kind: 'resize', x: number, y: number, width: number, height: number }
+  const dragOverrides = createKeyedOverrides<DragOverride>()
+
+  // Local-only opacity overrides, keyed BY WINDOW. The wheel fires dozens of
+  // times per scroll gesture; writing each tick to the override gives instant
+  // visual feedback, and a trailing debounce emits ONE op when scrolling pauses.
+  // Without this, a single scroll emitted one SetFloatingWindowRegister(opacity)
+  // op per wheel tick that changed the clamped value.
+  //
+  // A MAP, like the drag override above, and for the same reason: nothing
+  // serializes WHEEL events either. They need no pointer capture, every visible
+  // window binds its own title-bar listener, and scrolling window A and then
+  // window B within the debounce window used to clear A's timer and replace A's
+  // override -- so A's op was never emitted and its rendered opacity silently
+  // snapped back. The whole gesture was lost, with no error path.
+  //
+  // ONE record per window holding BOTH the pending value and its timer. They are
+  // written and cleared together at every site, so splitting them across two
+  // maps keyed by the same id made two broken states representable: an override
+  // with no timer (never flushed -- the opacity sticks at a value no op will
+  // ever carry) and a timer with no override (fires and emits nothing). Pairing
+  // them means neither can be constructed.
+  //
+  // `base` is the CRDT-side opacity captured when the gesture STARTED, and it is
+  // what the flush compares against. Re-reading the projection at flush time was
+  // wrong on both teardown paths: Solid's cleanNode disposes `owned` (including
+  // the createComputed that maintains storeState.list) BEFORE running the
+  // owner's cleanups, so the disposal flush saw the override value and its
+  // same-value guard swallowed the op; and on a workspace switch the <For> item
+  // cleanup runs after the window already left the active-workspace slice, so
+  // findWindow returned null and the `!w` guard dropped it. Capturing the
+  // baseline up front makes the flush independent of the projection's lifetime.
+  interface OpacityGesture { value: number, base: number | undefined, timer: ReturnType<typeof setTimeout> }
+  const opacityGestures = createKeyedOverrides<OpacityGesture>()
+  const OPACITY_FLUSH_DELAY_MS = 600
+
+  /**
+   * Emit `id`'s pending debounced-opacity op NOW and clear its timer, or every
+   * window's when `id` is omitted. Idempotent if nothing is pending. Declared
+   * as a free function (rather than only as a store method) so the disposal
+   * hook and the `pagehide` listener below can call it — both are registered
+   * before the store object exists.
+   *
+   * PASS THE ID from a per-window teardown. Unscoped, a container unmounting
+   * for its own reasons flushed whichever window happened to have a gesture in
+   * flight -- so closing window B mid-scroll of window A committed A's
+   * half-finished value and split A's single gesture into two ops. The store's
+   * disposal hook and the unload listener are the legitimate unscoped callers:
+   * there, every window really is going away.
+   */
+  function flushAllOpacity(): void {
+    flushGestures(undefined)
+  }
+
+  function flushOpacity(id: string): void {
+    flushGestures(id)
+  }
+
+  function flushGestures(id: string | undefined): void {
+    const gestures = opacityGestures.snapshot()
+    // Take the victims and drop their entries in ONE map rebuild, BEFORE
+    // emitting. Clearing per victim inside the emit loop rebuilt the whole map
+    // -- re-running every projection consumer -- once per window flushed.
+    const victims: [string, OpacityGesture][] = []
+    if (id === undefined) {
+      victims.push(...gestures)
+      opacityGestures.clearAll()
+    }
+    else {
+      const gesture = gestures.get(id)
+      if (!gesture)
+        return
+      victims.push([id, gesture])
+      opacityGestures.clear(id)
+    }
+    for (const [wid, gesture] of victims) {
+      // A no-op when the timer already fired (this IS its callback).
+      clearTimeout(gesture.timer)
+      // Compare against the gesture's captured baseline, NOT a fresh projection
+      // read: this runs from teardown paths where the projection is already
+      // torn down or no longer carries this window. See OpacityGesture.base.
+      if (gesture.value === gesture.base)
+        continue
+      withBridge(bridge => emitUpdateOpacity(bridge, wid, gesture.value), undefined as void)
+    }
+  }
+
+  // Disposal hook. Two jobs, both of which were previously mis-handled:
+  //
+  //  - FLUSH the pending debounced-opacity op. This block used to only
+  //    clearTimeout, silently DROPPING the op despite a comment claiming it
+  //    flushed. In practice FloatingWindowContainer's own cleanup runs first
+  //    (Solid disposes the <For> item roots before the owner's cleanups), so
+  //    the op survived — but the store must not depend on that ordering.
+  //  - CLEAR any drag override. `useWindowPointerDrag`'s cleanup calls stop(),
+  //    which deliberately fires no onUp, so a container torn down mid-gesture
+  //    left that window's override set forever. The projection reads overrides
+  //    by id, so that window rendered frozen at never-committed geometry AND
+  //    masked incoming CRDT geometry until some later drag on it replaced the
+  //    entry. The whole store is going away here, so every entry goes.
+  onCleanup(() => {
+    flushAllOpacity()
+    dragOverrides.clearAll()
+  })
+
+  // A browser unload runs NO Solid cleanup, so neither hook above fires on a
+  // refresh or a tab close. Before the debounce existed the op was emitted
+  // synchronously and only the submitter's 16ms window was at risk; now a scrub
+  // finished within OPACITY_FLUSH_DELAY_MS of Cmd+R is lost outright -- the op is
+  // never created, so the checkpoint/op-log cannot recover it either.
+  //
+  // `pagehide` rather than `beforeunload`: it fires for bfcache navigations too,
+  // and does not risk the unload-blocking prompt.
+  //
+  // WHAT THIS DOES AND DOES NOT CLOSE. The flush CREATES the op and hands it to
+  // `useOpsSubmitter.enqueue`, which pushes it on the queue and arms a 16 ms
+  // `setTimeout`. On a bfcache navigation that timer survives (the page is
+  // frozen, then resumed) and the op is sent on restore. On a REAL unload --
+  // Cmd+R, tab close, the case this listener was written for -- the timer never
+  // fires and the op is still lost, just one step later than before.
+  //
+  // Getting the rest requires sending from the unload handler itself, which
+  // means a transport that survives it (`fetch(..., {keepalive: true})` or
+  // `navigator.sendBeacon`); `useOpsSubmitter` already exports `flush` for this
+  // and has no production caller. That belongs at the submission layer, not
+  // here: this listener can only rescue the ONE gesture that registered it,
+  // while the drag override (discarded outright by `cancelDragGeometry`) and
+  // every future debounced gesture have the same hole.
+  // https://github.com/leapmux/leapmux/issues/359
+  if (typeof window !== 'undefined') {
+    const flushOnUnload = (): void => {
+      // Two steps, in this order, in ONE handler. The first CREATES the op from
+      // the in-flight debounced gesture; the second SENDS it. Creating it alone
+      // was never enough -- `enqueue` only queues and arms a ~16 ms timer, and
+      // on a real unload that timer never fires -- and splitting the send into
+      // its own listener would make the outcome depend on registration order.
+      flushAllOpacity()
+      withBridge(bridge => bridge.flushNow(), undefined as void)
+    }
+    window.addEventListener('pagehide', flushOnUnload)
+    onCleanup(() => window.removeEventListener('pagehide', flushOnUnload))
+  }
 
   /**
    * This store's OWN `RenderTree` -> `LayoutNodeLocal` conversions, kept out of
@@ -177,7 +429,16 @@ export function createFloatingWindowStore(opts: CreateFloatingWindowStoreOpts) {
     if (!proj || !wsId)
       return []
     const result: FloatingWindowState[] = []
-    const focusMap = focusByWindow()
+    const focusMap = focusByWindow.snapshot()
+    // Local drag/resize preview override: when a drag is in flight, render the
+    // window at the live pointer geometry instead of the CRDT-projected one, so
+    // the drag feels responsive without emitting a per-frame op. Peers see the
+    // final geometry land in one op on drop (matching the splitter drag).
+    const overrides = dragOverrides.snapshot()
+    // Local opacity override: title-bar scrolling writes the live value here so
+    // the window's opacity tracks the wheel instantly; one op is emitted when
+    // scrolling pauses (trailing debounce).
+    const opGestures = opacityGestures.snapshot()
     // Straight off the shared projection: `project()` already resolved every
     // window's geometry and inner tree. It used to be re-derived here from raw
     // state, which walked the whole state again per tick AND was a second
@@ -186,13 +447,20 @@ export function createFloatingWindowStore(opts: CreateFloatingWindowStoreOpts) {
       const layoutRoot = windowLayoutRoot(rendered, windowTrees)
       const fallbackFocus = firstLeafId(layoutRoot) ?? null
       const localFocus = focusMap.get(rendered.windowId)
+      const override = overrides.get(rendered.windowId)
+      // A MOVE override owns x/y only -- exactly the registers commitDragGeometry
+      // emits for it -- so a peer's resize landing mid-drag stays visible
+      // instead of being masked by the pointer-down size until the drop. The
+      // union makes that structural: a move override has no width/height to read.
+      const size = override?.kind === 'resize' ? override : undefined
+      const opOverride = opGestures.get(rendered.windowId)?.value
       result.push({
         id: rendered.windowId,
-        x: rendered.x,
-        y: rendered.y,
-        width: rendered.width,
-        height: rendered.height,
-        opacity: rendered.opacity,
+        x: override ? override.x : rendered.x,
+        y: override ? override.y : rendered.y,
+        width: size ? size.width : rendered.width,
+        height: size ? size.height : rendered.height,
+        opacity: opOverride ?? rendered.opacity,
         layoutRoot,
         focusedTileId: localFocus !== undefined ? localFocus : fallbackFocus,
       })
@@ -221,13 +489,13 @@ export function createFloatingWindowStore(opts: CreateFloatingWindowStoreOpts) {
   }, [])
 
   // Store-backed projection. Solid's `<For>` keys by REFERENCE identity
-  // and the CRDT bridge bumps `pendingVersion` on every mutation —
-  // including high-frequency events like pointermove-driven
-  // `updatePosition` calls during a drag. If we returned `rawProjection`
-  // directly to `<For>`, every drag frame would produce a new array of
-  // fresh objects and `<For>` would unmount + remount every container
-  // (and its inner TilingLayout / TabBar / Terminal subtree). The
-  // result was visibly sluggish drag and resize.
+  // and the CRDT bridge bumps `pendingVersion` on every mutation — and the
+  // drag/resize override signal (`dragOverrides`) flips on every pointermove
+  // during a floating-window drag. If we returned `rawProjection` directly to
+  // `<For>`, every drag frame would produce a new array of fresh objects and
+  // `<For>` would unmount + remount every container (and its inner
+  // TilingLayout / TabBar / Terminal subtree). The result was visibly sluggish
+  // drag and resize.
   //
   // `reconcile` keyed by `id` mutates the existing store entries in place when
   // ids match — same array element ref across frames, but individual fields
@@ -420,22 +688,10 @@ export function createFloatingWindowStore(opts: CreateFloatingWindowStoreOpts) {
       const current = zOrder()
       if (current.some(id => !live.has(id)))
         setZOrder(current.filter(id => live.has(id)))
-      const focusMap = focusByWindow()
-      let stale = false
-      for (const id of focusMap.keys()) {
-        if (!live.has(id)) {
-          stale = true
-          break
-        }
-      }
-      if (stale) {
-        const next = new Map(focusMap)
-        for (const id of focusMap.keys()) {
-          if (!live.has(id))
-            next.delete(id)
-        }
-        setFocusByWindow(next)
-      }
+      // `retain` is itself the "nothing stale" short-circuit: it hands back the
+      // previous Map untouched when every key survives, so a sweep that finds
+      // nothing notifies nobody.
+      focusByWindow.retain(id => live.has(id))
     }),
   )
 
@@ -470,14 +726,9 @@ export function createFloatingWindowStore(opts: CreateFloatingWindowStoreOpts) {
     // window the user never brought to front or focused) hits this
     // common case; without the guards, every empty-window cleanup
     // would re-trigger `projectedWindows` even when nothing changed.
+    // (`focusByWindow.clear` carries its own; only zOrder needs one here.)
     setZOrder(z => z.includes(id) ? z.filter(x => x !== id) : z)
-    setFocusByWindow((m) => {
-      if (!m.has(id))
-        return m
-      const next = new Map(m)
-      next.delete(id)
-      return next
-    })
+    focusByWindow.clear(id)
   }
 
   const splitTile = (windowId: string, tileId: string, direction: SplitOrientation): string | null =>
@@ -584,35 +835,138 @@ export function createFloatingWindowStore(opts: CreateFloatingWindowStoreOpts) {
       }, undefined as void)
     },
 
-    updatePosition(id: string, x: number, y: number) {
+    /**
+     * Write the opacity to the LOCAL override immediately (instant visual
+     * feedback) and arm a trailing debounce that emits ONE CRDT op when the
+     * wheel pauses for OPACITY_FLUSH_DELAY_MS. Each tick re-arms the timer, so
+     * a continuous scroll collapses to a single op regardless of how many
+     * wheel events it produced. Returns whether the clamped value actually
+     * moved — compared against the EFFECTIVE opacity (this window's pending
+     * override if a scroll is in flight, else the CRDT-projected value), so the
+     * short-circuit stays accurate mid-gesture and a wheel parked at the clamp
+     * floor stops re-arming the timer. Used by the title-bar wheel handler —
+     * without this, a single scroll emitted one op per wheel tick.
+     */
+    updateOpacityDebounced(id: string, opacity: number): boolean {
+      const clamped = Math.max(0.2, Math.min(1, opacity))
+      // Read the EFFECTIVE opacity (override if a scroll is in flight, else
+      // CRDT-projected) so the same-value short-circuit is accurate mid-gesture.
+      const current = opacityGestures.get(id)?.value ?? findWindow(id)?.opacity
+      if (current === undefined || current === clamped)
+        return false
+      // Re-arm only THIS window's timer; another window's pending gesture is
+      // untouched.
+      const existing = opacityGestures.get(id)
+      if (existing !== undefined)
+        clearTimeout(existing.timer)
+      // Keep the ORIGINAL CRDT baseline across re-arms: a continuing gesture
+      // must still be compared against where it started, not against its own
+      // previous intermediate value (which would make every flush look like a
+      // change).
+      const base = existing !== undefined ? existing.base : findWindow(id)?.opacity
+      // The debounce fires the SAME scoped `flushOpacity` the per-window teardown
+      // store method call, rather than re-implementing its body here -- a
+      // second copy would drift from its same-value short-circuit. The third
+      // setTimeout argument is passed through as `id`, so the timer flushes
+      // THIS window only.
+      const timer = setTimeout(flushOpacity, OPACITY_FLUSH_DELAY_MS, id)
+      opacityGestures.set(id, { value: clamped, base, timer })
+      return true
+    },
+
+    /**
+     * Flush `id`'s pending debounced-opacity op immediately, or every window's
+     * when `id` is omitted. Used on teardown so a scroll in flight when the
+     * window unmounts isn't lost. See the free function for the per-window
+     * scoping rule callers have to honour.
+     */
+    flushOpacity,
+    flushAllOpacity,
+
+    /**
+     * Begin / continue a drag-MOVE: write the live position into `id`'s local
+     * override WITHOUT emitting a CRDT op. The projection returns this position
+     * for the window so the container renders at the pointer. One op is emitted
+     * on drop via `commitDragGeometry`.
+     *
+     * Takes NO width/height, which is the point: a move commits x/y only, and a
+     * size it never receives is a size it can never write over a peer's
+     * concurrent resize. Overrides are per window, so dragging a second window
+     * does not disturb this one's gesture.
+     */
+    updateDragMove(id: string, x: number, y: number) {
+      dragOverrides.set(id, { kind: 'move', x, y })
+    },
+
+    /**
+     * Begin / continue a drag-RESIZE. Same override-then-commit contract as
+     * `updateDragMove`, but this gesture owns all four registers, so the
+     * override carries the size and the projection renders it.
+     *
+     * Width/height are clamped to MIN_WINDOW_DIMENSION here, at the only entry
+     * point that can set them.
+     */
+    updateDragResize(id: string, x: number, y: number, width: number, height: number) {
+      dragOverrides.set(id, {
+        kind: 'resize',
+        x,
+        y,
+        width: Math.max(width, MIN_WINDOW_DIMENSION),
+        height: Math.max(height, MIN_WINDOW_DIMENSION),
+      })
+    },
+
+    /**
+     * End a drag by emitting ONE CRDT op for the final geometry and clearing
+     * the local override. Idempotent if no drag is in flight (a pointercancel
+     * that already cleared it, or a drop with no movement). Compares against
+     * the CRDT-projected geometry (not the override) so a drag that returned
+     * to its start emits nothing.
+     */
+    commitDragGeometry(id: string) {
+      const override = dragOverrides.get(id)
+      if (!override)
+        return
+      dragOverrides.clear(id)
+      // Read the CRDT-projected geometry to short-circuit a no-op drag.
       withBridge((bridge) => {
         const w = findWindow(id)
-        if (!w || (w.x === x && w.y === y))
+        if (!w)
           return
-        emitUpdatePosition(bridge, id, x, y)
+        if (override.kind === 'move') {
+          // A move touches only x/y. Emitting width/height too would write the
+          // pointer-down snapshot over whatever the register holds NOW, which is
+          // a concurrent peer's resize whenever one landed during the drag.
+          if (w.x === override.x && w.y === override.y)
+            return
+          emitUpdatePosition(bridge, id, override.x, override.y)
+          return
+        }
+        if (w.x === override.x && w.y === override.y && w.width === override.width && w.height === override.height)
+          return
+        // emitUpdateGeometry writes four registers (x, y, width, height) in one
+        // batch; opacity is a separate emitter.
+        emitUpdateGeometry(bridge, id, override.x, override.y, override.width, override.height)
       }, undefined as void)
     },
 
-    updateGeometry(id: string, x: number, y: number, width: number, height: number) {
-      withBridge((bridge) => {
-        const clampedW = Math.max(width, MIN_WINDOW_DIMENSION)
-        const clampedH = Math.max(height, MIN_WINDOW_DIMENSION)
-        const w = findWindow(id)
-        if (!w || (w.x === x && w.y === y && w.width === clampedW && w.height === clampedH))
-          return
-        emitUpdateGeometry(bridge, id, x, y, clampedW, clampedH)
-      }, undefined as void)
-    },
-
-    updateOpacity(id: string, opacity: number): boolean {
-      return withBridge((bridge) => {
-        const clamped = Math.max(0.2, Math.min(1, opacity))
-        const w = findWindow(id)
-        if (!w || w.opacity === clamped)
-          return false
-        emitUpdateOpacity(bridge, id, clamped)
-        return true
-      }, false)
+    /**
+     * Abort an in-flight drag WITHOUT committing: clear the override so the
+     * window snaps back to its CRDT-projected geometry.
+     *
+     * Used when the container UNMOUNTS mid-gesture (a workspace switch or a
+     * peer closing the window while the pointer is down). `useWindowPointerDrag`
+     * responds to unmount by calling stop(), which deliberately fires no onUp,
+     * so nothing else clears the override and the window would otherwise render
+     * frozen at geometry that was never committed.
+     *
+     * NOT used on pointercancel: `windowPointerDrag` routes pointercancel
+     * through the same handleUp as pointerup, so an OS-interrupted drag COMMITS
+     * its partial motion. (That is a deliberate product choice — matching a
+     * clean drop — not an oversight; this doc previously claimed the opposite.)
+     */
+    cancelDragGeometry(id: string) {
+      dragOverrides.clear(id)
     },
 
     /**
@@ -660,15 +1014,11 @@ export function createFloatingWindowStore(opts: CreateFloatingWindowStoreOpts) {
       // one, else the same first-leaf fallback the projection applies — so the
       // no-op check answers the same question for an off-screen window as for
       // an on-screen one.
-      const recorded = focusByWindow().get(windowId)
+      const recorded = focusByWindow.get(windowId)
       const effective = recorded !== undefined ? recorded : firstLeafId(root)
       if (effective === tileId)
         return
-      setFocusByWindow((m) => {
-        const next = new Map(m)
-        next.set(windowId, tileId)
-        return next
-      })
+      focusByWindow.set(windowId, tileId)
     },
 
     splitTile,

--- a/frontend/src/test-support/crdtBridge.ts
+++ b/frontend/src/test-support/crdtBridge.ts
@@ -31,6 +31,16 @@ export interface TestBridgeHandle {
   rootTileId: string
   userId: string
   workspaceId: string
+  /**
+   * One entry per `bridge.flushNow()`, each holding `pendingBatches.length` at
+   * the moment of the call.
+   *
+   * The COUNT AT CALL TIME is the point: a store's unload handler must create
+   * its op and then send it, in that order and in one handler, and a growing
+   * pending list only proves the first half. Recording the count lets a test
+   * pin the ordering without reaching into listener registration.
+   */
+  flushNowCalls: number[]
   /** Manually unwire — ordinarily the test framework's afterEach handles this. */
   dispose: () => void
 }
@@ -88,11 +98,19 @@ export function installTestBridge(opts?: {
   // projection's `registeredRoots` lookup will then find the
   // workspace's root and the projected tree will be a single LEAF.
   seedWorkspace({ pending }, workspaceId, rootTileId)
+  const flushNowCalls: number[] = []
   setCRDTBridge({
     workspaceId: () => workspaceId,
     enqueue: (batch) => {
       pending.submit(batch)
       return batch.batchId
+    },
+    // Recorded, not stubbed: the store's unload handler must both CREATE the
+    // op and SEND it, and only the second half was ever asserted by accident
+    // (a growing pendingBatches proves creation alone). Capturing the pending
+    // count AT CALL TIME is what pins the ORDER within the one handler.
+    flushNow: () => {
+      flushNowCalls.push(pending.state.pendingBatches.length)
     },
     clock: () => clock,
     originClientId: () => ownClient,
@@ -109,6 +127,8 @@ export function installTestBridge(opts?: {
     rootTileId,
     userId,
     workspaceId,
+    /** One entry per `bridge.flushNow()`, holding the pending count at that moment. */
+    flushNowCalls,
     dispose: () => setCRDTBridge(null),
   }
 }

--- a/frontend/src/test-support/opLog.ts
+++ b/frontend/src/test-support/opLog.ts
@@ -1,0 +1,38 @@
+import { appendOpLogSegment } from '~/lib/crdt/checkpointStore'
+
+/**
+ * Append an op-log segment with the next per-owner ordinal, the way the
+ * production recorder does.
+ *
+ * `appendOpLogSegment` takes the ordinal as a required argument rather than
+ * assigning one itself: it is a per-OWNER sequence and the store would have to
+ * read the log back to derive it, which is the read-modify-write the segment
+ * design exists to avoid. The recorder holds the counter instead.
+ *
+ * Tests that hand-pick ordinals (to plant a hole, or to assert the read stops at
+ * one) should call `appendOpLogSegment` directly. This helper is for the many
+ * that only need a well-formed, contiguous log.
+ */
+export function createOpLogAppender() {
+  const next = new Map<string, number>()
+  return {
+    /** Append `frames` as the next contiguous segment for this owner. */
+    append(userId: string, clientId: string, frames: Uint8Array[]): Promise<void> {
+      // A space separator, written literally -- never a control byte. A NUL
+      // would make git treat this file as binary and hide its diffs (see
+      // noControlBytesInSource.test.ts). Any separator that cannot occur in
+      // either id works; it keeps ('ab','c') and ('a','bc') distinct owners.
+      const key = `${userId} ${clientId}`
+      const ordinal = next.get(key) ?? 0
+      next.set(key, ordinal + 1)
+      return appendOpLogSegment(userId, clientId, frames, ordinal)
+    },
+    /**
+     * Forget every owner's position — mirrors a checkpoint write, which
+     * truncates the log and restarts the sequence at 0.
+     */
+    reset(): void {
+      next.clear()
+    },
+  }
+}

--- a/proto/leapmux/desktop/v1/frame.proto
+++ b/proto/leapmux/desktop/v1/frame.proto
@@ -116,6 +116,14 @@ message CliInstallSymlinkRequest {
 message OpenUserEventsRelayRequest {
   uint64 relay_id = 1;
   repeated string workspace_ids = 2;
+  // Resume cursor for a reconnecting client: the last-applied canonical HLC
+  // ("<physical>.<logical>.<client_id>") plus the epoch it was seen under. The
+  // sidecar threads these into the /ws/userevents URL so the hub can ship a
+  // ResumeDelta instead of a full snapshot. Both are strings (Tauri IPC +
+  // protobuf-over-sidecar carry no bigint); absent on a first connect, which
+  // the hub treats as a full-snapshot connect.
+  optional string resume_hlc = 3;
+  optional string resume_epoch = 4;
 }
 
 message CloseUserEventsRelayRequest {

--- a/proto/leapmux/v1/user_crdt.proto
+++ b/proto/leapmux/v1/user_crdt.proto
@@ -110,10 +110,25 @@ message UserCrdtState {
   map<string, TabRecord>                    tabs                 = 3;
   map<string, FloatingWindowRecord>         floating_windows     = 4;
   map<string, WorkspaceContentsRecord>      workspaces           = 5;
-  HLC                                       compaction_watermark = 6;
-  HLC                                       max_hlc              = 7;
-  int64                                     current_epoch        = 8;
-  google.protobuf.Timestamp                 epoch_started_at     = 9;
+  HLC                                       compaction_watermark   = 6;
+  HLC                                       max_hlc                = 7;
+  int64                                     current_epoch          = 8;
+  google.protobuf.Timestamp                 epoch_started_at       = 9;
+  // Lagging floor for op-batch DELETION. Op batches whose last canonical
+  // HLC is ≤ this watermark may be deleted by maybeCompact; tombstones are
+  // pruned at the tighter compaction_watermark. The two diverge on purpose:
+  // tombstone pruning is load-bearing for correctness (HLC monotonicity,
+  // bounded user_state growth), while op-batch deletion is pure storage
+  // optimization — the op log is an append-only history and replaying a
+  // longer tail is sound (each op is idempotent under the CRDT merge), so it
+  // can live longer than the tombstone-prune window. resume (decideResume)
+  // gates on THIS watermark, not compaction_watermark, because it is the
+  // "can the server still reconstruct the delta?" test: a cursor above it
+  // means the journal still holds every batch the client needs.
+  // Invariant: op_retention_watermark ≤ compaction_watermark ≤ max_hlc.
+  // Left zero on a fresh state (same as compaction_watermark); maybeCompact
+  // is the sole writer.
+  HLC                                       op_retention_watermark = 10;
 }
 
 // UserMaterialized is the public projection sent to a subscriber on

--- a/proto/leapmux/v1/user_ops.proto
+++ b/proto/leapmux/v1/user_ops.proto
@@ -247,6 +247,128 @@ message WatchUserEvent {
     WorkspaceRenamed     renamed             = 6;
     WorkspaceCreated     created             = 7;
     WorkspaceDeleted     deleted             = 8;
+    // Sent instead of `initial` when a reconnect's resume cursor is still
+    // within the hub's op-retention window (see ResumeDelta). Either
+    // `initial` or `delta` is the first frame; never both.
+    ResumeDelta          delta               = 9;
+    // Terminates one committed batch's catch-up sequence. See BatchEnd.
+    BatchEnd             batch_end           = 10;
+  }
+}
+
+// BatchEnd closes the frame sequence a single committed batch produces, so a
+// client can tell "I have all of batch B" from "I have some of batch B".
+//
+// One batch fans out as up to three separate frames -- entity_materialized*,
+// then batch, then entity_removed* -- and every one of them carries the SAME
+// at_hlc (the batch's last-op canonical HLC). A client that advanced its resume
+// watermark on each frame therefore reached the batch's max HLC as soon as the
+// FIRST frame landed. If the socket then dropped mid-sequence, the persisted
+// cursor sat above ops that were never applied, and because the resume scan is
+// strictly-greater the hub would never re-send them: a silent, permanent
+// divergence (now also written into the client's IndexedDB checkpoint).
+//
+// So the watermark advances HERE and nowhere else. A drop mid-sequence leaves
+// the cursor at the previous batch, and the whole batch is re-sent on resume --
+// harmless, because every op re-applies under the same canonical HLC and the
+// client's LWW compare is strictly-greater.
+//
+// Emitted for EVERY batch a subscriber is sent, including one whose ops are all
+// filtered out of that subscriber's view. That is deliberate: it lets a
+// narrowly-filtered subscriber advance past traffic it cannot see instead of
+// re-scanning the same journal tail on every reconnect. It is safe because an
+// entity that later becomes visible arrives as a full EntityMaterialized
+// record, never as its historical ops.
+message BatchEnd {
+  HLC at_hlc = 1;  // the batch's last-op canonical HLC; the client's new watermark
+}
+
+// ResumeDelta is the resume counterpart to UserMaterialized: the post-cursor
+// op tail a reconnecting client needs to catch up, rather than the full
+// materialized snapshot. Sent as the first (and only bootstrap) frame on a
+// successful resume (see Manager.SubscribeWithACL). max_hlc is the max HLC the
+// client adopts as its new watermark -- the max over every emitted frame's own
+// HLC (visible-op canonical HLCs AND the at_hlc of each materialized/removed
+// transition frame), NOT the live state max, so the watermark is always an HLC
+// the client genuinely received. The client MUST advance its resume watermark
+// to max_hlc (in addition to observing it into the HLC clock), matching how
+// bootstrap adopts UserMaterialized.max_hlc.
+//
+// frames carries the ordered stream the subscriber missed as WatchUserEvent
+// values — the SAME envelope live Send uses (entity_materialized | batch |
+// entity_removed | batch_end). For each tail batch, in commit order, the hub emits
+// frames in the SAME materialized → batch → removed order a live broadcast
+// uses (see emitCatchUpFrames), filtered by the SAME pre/post stable-
+// visibility rule. The client dispatches each frame through the SAME handlers
+// a live broadcast uses, so the two catch-up paths cannot drift. An entity
+// that crossed IN arrives as entity_materialized carrying its BATCH-ERA full
+// record (BatchTransition.record), not a live current-state clone.
+message ResumeDelta {
+  repeated WatchUserEvent frames = 1;  // ordered catch-up stream (entity_materialized|batch|entity_removed|batch_end)
+  HLC              max_hlc     = 2;  // max HLC over every emitted frame (client's new watermark)
+  int64            current_epoch = 3;  // for SubmitOps epoch echo
+  // Hub-derived identity of THIS subscriber -- same value and purpose as
+  // UserMaterialized.subscriber_client_id, carried here because a resume is now
+  // the normal COLD-START path: the client hydrates confirmedState from its
+  // IndexedDB checkpoint and resumes instead of bootstrapping, so a freshly
+  // loaded page has no earlier `initial` frame to have learned it from.
+  // Leaving it unset made the frontend's active-client gate compare against an
+  // empty string, which disables the gate outright (every refreshed tab plays
+  // the turn-end sound regardless of which client is active).
+  string           subscriber_client_id = 4;
+  // Owning tenant, mirroring UserMaterialized.user_id, so the client can refuse
+  // a delta that is not its own.
+  //
+  // The `initial` arm has always fail-closed on this (applyMaterialized, the
+  // client half of crdt.Manager.requireOwnState), and so does the cold-start
+  // hydration path. A resume is now the NORMAL cold start, and was the only one
+  // of the three that fails OPEN: with no tenant on the message the check was
+  // not merely skipped, it was inexpressible, so a delta was adopted on the
+  // strength of the socket alone -- and, via the op-log observer, written into
+  // the device's IndexedDB checkpoint where it survives refreshes. The hub
+  // cannot mis-route today (the manager is keyed by the authenticated user id),
+  // which makes this defence in depth rather than a live bug; it is here so all
+  // three adoption points answer "is this mine?" the same way.
+  string           user_id = 5;
+}
+
+// BatchTransitions is the per-batch, per-entity workspace-transition log the
+// hub persists alongside each OpBatch so the resume path can replay the SAME
+// pre/post stable-visibility classification the live broadcast applies. It is
+// the wire encoding of ValidationResult.AffectedEntities
+// (map[EntityRef]EntityWorkspaceTransition): one entry per entity the batch
+// touched, each carrying its pre- and post-batch owning workspace. This is a
+// STORAGE-ONLY message: it never crosses a client-facing wire surface.
+message BatchTransitions {
+  repeated BatchTransition entries = 1;
+}
+
+// BatchTransition is one entity's pre/post-batch workspace. Exactly one
+// identity arm is set (a oneof, so multi-kind rows are unrepresentable), and
+// its arm implies the EntityKind (Node / Tab / FloatingWindow / WorkspaceRoot)
+// -- mirroring the EntityKind the Go-side EntityRef carries. The optional
+// `record` oneof carries the entity's POST-batch record snapshot, captured at
+// commit time when Pre != Post (a visibility-crossing candidate), so the
+// resume path can build a materialized frame from the batch-era record instead
+// of reading CURRENT live state (which a later tail batch may have
+// edited/tombstoned). Only set for entity kinds that have a materialized frame
+// (Node / Tab / FloatingWindow); absent for WorkspaceRoot (no
+// EntityMaterialized variant), stable-visibility edits (Pre == Post), and
+// tombstoned records (a tombstone is projection-ignored, so no frame is
+// materialized for it -- matching live buildEntityMaterializedEvent).
+message BatchTransition {
+  oneof identity {
+    string node_id      = 1;  // EntityKindNode
+    TabIdent tab        = 2;  // EntityKindTab
+    string window_id    = 3;  // EntityKindFloatingWindow
+    string workspace_id = 4;  // EntityKindWorkspaceRoot
+  }
+  string pre_workspace  = 5;
+  string post_workspace = 6;
+  oneof record {              // post-batch record snapshot (omitted => no materialized frame for this entry)
+    NodeRecord           node_record           = 7;
+    TabRecord            tab_record            = 8;
+    FloatingWindowRecord floating_window_record = 9;
   }
 }
 

--- a/testdata/hlc_wire_corpus.json
+++ b/testdata/hlc_wire_corpus.json
@@ -1,0 +1,152 @@
+{
+  "_readme": "Cross-language resume-cursor HLC wire format. The Go hub (channelwire.EncodeResumeHLC / DecodeResumeHLC / ParseResumeCursor) and the TypeScript client (hlc.ts formatHlcWire / parseHlcWire) parse the SAME '<physical>.<logical>.<client_id>' triple, and the client pre-validates a persisted cursor with parseHlcWire(formatHlcWire(x)) before sending so a corrupted value the hub would 400 never leaves the browser (otherwise the browser surfaces a non-terminal 1006 close and reconnects in a tight loop). The two decoders are hand-mirrored by a prose contract; this fixture is the single source both sides assert against so a rule added or tightened on one side but not the other reddens CI here (backend/channelwire/wire_test.go and frontend/src/lib/crdt/hlc.test.ts) instead of drifting back into the reconnect storm the validation exists to prevent. Each case is a raw wire string plus the expected decode: ok=true with physical/logical/clientId, or ok=false (decoder must reject, returning nil/undefined). physical must be > 0 and int64-bounded; logical must be >= 0 and int64-bounded; clientId must be non-empty and <= 128 chars; all three segments must be present.",
+  "cases": [
+    {
+      "raw": "1754100000000.3.c-abc",
+      "ok": true,
+      "physical": "1754100000000",
+      "logical": "3",
+      "clientId": "c-abc"
+    },
+    {
+      "raw": "1.0.c",
+      "ok": true,
+      "physical": "1",
+      "logical": "0",
+      "clientId": "c"
+    },
+    {
+      "raw": "9223372036854775807.9223372036854775807.client",
+      "ok": true,
+      "physical": "9223372036854775807",
+      "logical": "9223372036854775807",
+      "clientId": "client"
+    },
+    {
+      "raw": "",
+      "ok": false
+    },
+    {
+      "raw": "123",
+      "ok": false
+    },
+    {
+      "raw": "123.4",
+      "ok": false
+    },
+    {
+      "raw": "123.4.",
+      "ok": false
+    },
+    {
+      "raw": "abc.4.c",
+      "ok": false
+    },
+    {
+      "raw": "123.abc.c",
+      "ok": false
+    },
+    {
+      "raw": "0.4.c",
+      "ok": false
+    },
+    {
+      "raw": "-5.4.c",
+      "ok": false
+    },
+    {
+      "raw": "123.-1.c",
+      "ok": false
+    },
+    {
+      "raw": "123.4..",
+      "ok": true,
+      "physical": "123",
+      "logical": "4",
+      "clientId": "."
+    },
+    {
+      "raw": "123..c",
+      "ok": false
+    },
+    {
+      "raw": "9223372036854775808.4.c",
+      "ok": false
+    },
+    {
+      "raw": "123.9223372036854775808.c",
+      "ok": false
+    },
+    {
+      "raw": "123.4.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      "ok": false,
+      "_note": "129 bytes: one over the bound. The previous fixture was NAMED \"ExactlyOneHundredAndTwentyEight\" but was 141 chars, so neither edge of the bound was pinned."
+    },
+    {
+      "raw": "123.4.dot.in.client",
+      "ok": true,
+      "physical": "123",
+      "logical": "4",
+      "clientId": "dot.in.client"
+    },
+    {
+      "raw": " 123.4.c",
+      "ok": false,
+      "_note": "leading whitespace: Go ParseInt rejects, TS BigInt accepts without the strict-digit guard"
+    },
+    {
+      "raw": "+123.4.c",
+      "ok": false,
+      "_note": "explicit plus sign: Go ParseInt ACCEPTS it, TS /^-?\\d+$/ rejects it, and neither encoder emits it -- the Go decoder rejects explicitly (plusSigned) so both sides agree"
+    },
+    {
+      "raw": "123.+4.c",
+      "ok": false,
+      "_note": "plus sign on the logical segment, same rule as above"
+    },
+    {
+      "raw": "0012.4.c",
+      "ok": true,
+      "physical": "12",
+      "logical": "4",
+      "clientId": "c",
+      "_note": "leading zeros: both Go ParseInt and TS BigInt accept; pinned as the agreed contract so neither side tightens it unilaterally"
+    },
+    {
+      "raw": "123.4.c ",
+      "ok": true,
+      "physical": "123",
+      "logical": "4",
+      "clientId": "c ",
+      "_note": "trailing whitespace in clientId — both sides accept (only length/empty checked); pinned as current contract"
+    },
+    {
+      "raw": "123.4.c",
+      "ok": true,
+      "physical": "123",
+      "logical": "4",
+      "clientId": "c"
+    },
+    {
+      "raw": "123.4.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      "ok": true,
+      "physical": "123",
+      "logical": "4",
+      "clientId": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      "_note": "exactly 128 bytes: the largest ACCEPTED client id. Guards the accept side, which Go had no case for -- flipping `> 128` to `>= 128` there used to leave both this corpus and the Go suite green."
+    },
+    {
+      "raw": "123.4.éééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééé",
+      "ok": true,
+      "physical": "123",
+      "logical": "4",
+      "clientId": "éééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééé",
+      "_note": "64 two-byte characters = 128 BYTES, 64 UTF-16 units. Accepted. Pins that both decoders measure the same quantity."
+    },
+    {
+      "raw": "123.4.ééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééé",
+      "ok": false,
+      "_note": "65 two-byte characters = 130 BYTES but only 65 UTF-16 units. REJECTED. A TS decoder counting .length would accept this and the hub would answer 400, and since 1006 is not terminal the client would reconnect with the same cursor forever."
+    }
+  ]
+}


### PR DESCRIPTION
## Motivation

Every `/ws/userevents` connect shipped a full `UserMaterialized` snapshot,
built by scanning the account's whole CRDT state under `m.projection` —
the same lock every commit and broadcast for that user also takes. The
scan is O(all the user's entities) while the send is O(the subscribed
ones, and the browser subscribes to all of them), so a reconnect stalled
that user's own commit and broadcast pipeline, worst case a reconnect
storm after a deploy. A page refresh always paid for one.
([#267](https://github.com/leapmux/leapmux/issues/267))

Two further problems had to be solved for a delta to be correct rather
than merely cheaper.

A delta only pays off across a refresh if the client still holds the
state the cursor describes. The frontend persisted nothing, so after a
reload the cursor survived but the state it pointed at was gone, and the
only safe action was to ignore it — the feature helped in-session
reconnects and did nothing for the case users actually hit.
([#356](https://github.com/leapmux/leapmux/issues/356))

And a delta filtered on CURRENT visibility is not the same rule a live
broadcast applies. An entity that moved out of the subscriber's allowed
workspaces during the gap had its move op filtered out and no
`EntityRemoved` sent, so the client kept a ghost record that never
cleared — permanently, because the entity was now stably invisible and no
future broadcast would ever mention it again.
([#357](https://github.com/leapmux/leapmux/issues/357))

## Modifications

- `SubscribeWithACL` branches RESUME vs FALLBACK via `decideResume`, keyed
  on the client's cursor HLC + epoch. RESUME registers the subscriber,
  releases both `subscribeExpandMu` and `m.projection`, then runs a
  lock-free budget-capped tail scan of the op journal and ships a
  `ResumeDelta` instead of a full snapshot.
- `emitCatchUpFrames` + `visibilityScope` become the single
  implementation of the pre/post stable-visibility rule, shared by live
  broadcast (`liveCatchUpSink`) and resume (`resumeCatchUpSink`), so the
  two paths cannot drift. `Manager.commit` persists per-batch
  `BatchTransitions` (commit-time affected entities plus post-batch record
  snapshots) so a resume reconstructs the judgment the ORIGINAL broadcast
  made rather than re-evaluating gap batches against a since-changed ACL.
- Two-tier retention: the tight `compaction_watermark` (tombstone pruning,
  correctness-bound) splits from a new TTL-lagging
  `op_retention_watermark` (op-batch deletion floor), widening the
  resumable gap from one compaction tick to 24h. Op-count and byte budgets
  force FALLBACK when the tail — or the built frame, measured against the
  socket's own read limit — would be too large.
- Client persistence: a new IndexedDB layer (`idb.ts`,
  `checkpointStore.ts`, `checkpointChunks.ts`, `checkpointRecorder.ts`,
  `hydrate.ts`) mirrors the hub's `user_state` + `user_op_batches` pair. The
  checkpoint is sharded into a scalar header plus one row per entity, so a
  rewrite costs the delta rather than re-serializing the account on the
  main thread mid-drag. Rows are keyed per `(user, client)`, and
  `hydrate.ts` owns the corruption policy: an unusable checkpoint wipes and
  cold-starts, an unusable op-log replays its decodable prefix.
- `pendingOps.ts` gains a resume watermark advanced strictly at batch
  boundaries, one frame-dispatch path shared by hydrate/resume/live, and a
  client-side tombstone GC — needed because a client that keeps resuming
  never bootstraps, and bootstrap used to be its only GC.
- Store layer, three dialects in lockstep: new `transitions_payload` on
  `user_op_batches`, new `compaction_physical_ms` projected onto
  `user_state`, and a cross-user `DeleteUserOpBatchesBeforePhysical` sweep
  on the shared cleanup schedule. The sweep's predicate is byte-identical
  across dialects; only its batching FORM differs (sqlite `rowid`, postgres
  the PK tuple — deliberately not `ctid`, which YugabyteDB rejects — mysql
  a bare `LIMIT`).
- Hardening found along the way: `ValidateBatch` rejects an op whose target
  has no identity (such an op used to commit and broadcast normally, then
  permanently disable resume for that user); every hub Connect handler now
  caps request size, closing unbounded buffering that let one oversized
  `SubmitOps` stall a user's single-writer goroutine; and the resume
  cursor's wire format is pinned by a corpus shared between the Go and
  TypeScript decoders.
- Client surfaces: the desktop sidecar threads the cursor through its
  relay and rejects a malformed one rather than degrading silently;
  floating-window drag/resize/opacity move to
  local-override-then-commit-on-drop via a new `createKeyedOverrides<T>`
  primitive; and `leapmux events` renders the two new frame kinds instead
  of printing `unknown` once per user edit.
- No breaking changes. This is a pre-release project, so the initial
  migrations and protos are edited in place; the `Journal` interface and
  several internal Go/TS signatures changed, and every call site in the
  repo was updated in this same change.

## Result

- Closes #267
- Closes #356
- Closes #357

- A reconnect ships a bounded op delta instead of re-scanning and
  re-sending the whole per-user projection, and no longer contends for the
  lock that commits and broadcasts take.
- A page refresh resumes from a local checkpoint instead of cold-starting,
  which is the case that previously always paid for a full snapshot.
- The resumable gap widens from one compaction tick (~60s) to 24h before a
  client falls back.
- An entity that leaves your allowed workspaces while you are disconnected
  now disappears when you reconnect, instead of lingering as a record that
  never clears.
- An oversized `SubmitOps` can no longer stall your other tabs' writes.
- Dormant accounts stop accumulating op batches forever.
- Dragging, resizing or scrubbing a floating window's opacity emits far
  fewer ops, and a gesture finished just before a refresh is no longer
  silently lost.
