### PR TITLE
perf(crdt): Seed a new tab's checkpoint and unlock the fallback

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -709,6 +709,19 @@ tasks:
       - task: lint-backend
       - cd backend && go tool gotestsum --format pkgname-and-test-fails -- -tags integration {{.CLI_ARGS | default "./..."}}
 
+  test-backend-race:
+    desc: Run backend tests under the race detector (defaults to the CRDT + hub service packages)
+    cmds:
+      - task: prepare-backend
+      # The CRDT manager's whole concurrency story -- published generations that
+      # readers walk lock-free, a fallback baseline built off the manager
+      # goroutine, a compaction that prunes a private clone -- is only ASSERTED
+      # by the detector. TestFallbackBaselineRacesCompaction in particular
+      # exists to fail when an in-place prune is reinstated, and without -race
+      # it passes no matter what, so a suite that never runs this target is a
+      # suite where that test proves nothing.
+      - cd backend && go tool gotestsum --format pkgname-and-test-fails -- -race -count=1 {{.CLI_ARGS | default "./internal/hub/crdt/... ./internal/hub/service/..."}}
+
   test-backend-no-docker:
     desc: Run backend tests, excluding Docker-backed storage backends
     cmds:
@@ -737,6 +750,12 @@ tasks:
       - task: prepare-frontend
       - task: lint-frontend
       - cd frontend && bun run test:e2e {{.CLI_ARGS}}
+
+  bench-backend:
+    desc: Run backend benchmarks (defaults to the CRDT package)
+    cmds:
+      - task: prepare-backend
+      - cd backend && go test -run '^$' -bench . -benchmem {{.CLI_ARGS | default "./internal/hub/crdt/"}}
 
   # --- Linting ---
 

--- a/backend/internal/hub/crdt/manager.go
+++ b/backend/internal/hub/crdt/manager.go
@@ -216,7 +216,7 @@ type Manager struct {
 	// m.mu (RWMutex) guards m.state only against the RLock readers
 	// (Materialized, currentEpoch, broadcast, WithStateRLock) and the commit
 	// swap (m.state = working). The lone non-production writer is
-	// SeedStateForTest, which also runs on the manager goroutine (via seedCh)
+	// SeedStateForTest, which also runs on the manager goroutine (via taskCh)
 	// so it cannot race those bare reads; see its doc.
 	subscribers *SubscriberController
 	projection  sync.Mutex
@@ -290,6 +290,12 @@ type Manager struct {
 	// fixture.
 	maxResumeDeltaFrameBytes int
 
+	// materialize builds the FALLBACK baseline. Always materializedFromState in
+	// production; WithMaterializerForTest swaps it so a test can hold a baseline
+	// mid-flight and assert nothing is stalled behind it. Set in NewManager, so
+	// it is never nil.
+	materialize BaselineBuilder
+
 	// reconcileNudger, when set, is told which workers hosted a tab a batch
 	// just tombstoned, so each can converge immediately instead of waiting out
 	// its reconciler interval. Nil disables the nudge.
@@ -297,11 +303,15 @@ type Manager struct {
 
 	submitCh   chan submitJob
 	internalCh chan submitJob
-	// seedCh carries SeedStateForTest closures to the manager goroutine, so
-	// test seeds of m.state run on the sole writer (see seedJob). Unbuffered:
-	// SeedStateForTest blocks until the goroutine services the job, giving the
-	// seed a happens-before edge against any later submit's bare reads.
-	seedCh chan seedJob
+	// taskCh carries caller-driven work (SeedStateForTest's seed closure,
+	// TickHousekeeping's forced pass) to the manager goroutine, so both run on
+	// the sole writer (see managerTask). Both PUBLISH new state generations --
+	// the seed's clone, compaction's pruned clone, the epoch bump -- and a
+	// publish from any other goroutine would clobber a commit that landed after
+	// the clone was taken. Unbuffered: the caller blocks until the goroutine
+	// services the task, giving it a happens-before edge against anything it
+	// does next, including a later submit's bare reads.
+	taskCh chan managerTask
 	// startedOnce closes startedChan exactly once, the first time Start runs,
 	// BEFORE the select loop begins servicing jobs. startedChan is the readiness
 	// signal the registry waits on before handing the manager out, so any caller
@@ -449,17 +459,28 @@ type Subscriber struct {
 	RequestedWorkspaceIDs map[string]bool
 	Filter                SubscriberFilter
 	// resumeSuppressThrough, when non-nil, is the register-time MaxHlc
-	// high-water for a RESUME subscribe. Live batch broadcasts whose
-	// last-op HLC is <= this value are skipped for this subscriber: those
-	// batches are owned by the ResumeDelta journal scan, and delivering
-	// them via broadcast as well would dual-deliver the same catch-up
-	// frames. Set atomically with registration under m.projection (see
-	// SubscribeWithACL); left set for the life of the connection (later
-	// commits always have a strictly greater HLC). Presence / lifecycle
-	// frames bypass this gate (they go through broadcastTo, not sendTo).
+	// high-water for this subscription. Live batch broadcasts whose last-op HLC
+	// is <= this value are skipped for this subscriber, because they are
+	// already covered by whatever bootstrap frame the register window chose:
+	//
+	//   - RESUME: the ResumeDelta's journal scan ships everything in
+	//     (cursor, until], so broadcasting those batches too would
+	//     dual-deliver the same catch-up frames.
+	//   - FALLBACK: the baseline is built from the generation whose max_hlc
+	//     THIS value is, so every batch at or below it is already folded into
+	//     the snapshot. Re-delivering one would replay an entity_materialized /
+	//     entity_removed the client applies WHOLESALE onto a newer baseline.
+	//
+	// So the gate is owned by whichever bootstrap established the baseline, not
+	// by the resume path specifically. Set atomically with registration under
+	// m.projection (see registerForResume / registerForFallback); left set for
+	// the life of the connection (later commits always have a strictly greater
+	// HLC). Presence / lifecycle frames bypass it (they go through broadcastTo,
+	// not sendTo).
 	resumeSuppressThrough *leapmuxv1.HLC
 	// Overflowed, when set, reports that the transport could not buffer a frame
-	// while the resume scan was running.
+	// while the bootstrap frame was still being built -- a resume's journal scan
+	// or a fallback's baseline walk, both of which run registered and unlocked.
 	//
 	// The transport used to answer that by tearing the connection down, which
 	// sent the client back with the SAME cursor to rebuild the SAME multi-page
@@ -468,28 +489,32 @@ type Subscriber struct {
 	// trips MaxResumeDeltaOps and FALLBACKs anyway), but every round is a wasted
 	// multi-page journal scan on a hub already under the load that triggered it.
 	// buildResumeDelta consults this instead and converts the overflow into ONE
-	// snapshot.
+	// snapshot; fallbackOutcome consults it to retry its baseline at a newer
+	// generation (see the park-overflow ladder).
 	//
 	// A CALLBACK, like OnRebaseline, rather than a flag on this struct: the
 	// state belongs to the transport's queue, and Subscriber is copied by value
 	// (see cloneSubscriber), which no synchronisation primitive survives.
 	Overflowed func() bool
-	// OnRebaseline, when set, is called at the moment a RESUME registration is
-	// replaced by a FALLBACK one (resumeFallback), while m.projection is held
-	// and BEFORE the materialized baseline is taken.
+	// OnRebaseline, when set, is called at the moment a registration is REPLACED
+	// by a fresh one -- a RESUME that gave up, or a FALLBACK
+	// retrying after its park buffer overflowed -- while m.projection is held
+	// and BEFORE the new baseline's generation is captured.
 	//
 	// It exists because the transport buffers frames it has not written yet.
-	// During the resume scan the subscriber is registered, so live broadcasts
-	// enqueue normally; if the scan then gives up, the snapshot is computed at a
-	// LATER point than those queued frames. Writing them after the snapshot
-	// would apply older entity records on top of newer ones -- and unlike batch
-	// ops, entity_materialized / entity_removed are applied wholesale by the
-	// client with no HLC compare, so nothing corrects it afterwards.
+	// While a bootstrap frame is being built the subscriber is registered, so
+	// live broadcasts enqueue normally; if that attempt is then abandoned, the
+	// replacement baseline is taken at a LATER point than those queued frames.
+	// Writing them after it would apply older entity records on top of newer
+	// ones -- and unlike batch ops, entity_materialized / entity_removed are
+	// applied wholesale by the client with no HLC compare, so nothing corrects
+	// it afterwards.
 	//
 	// Called under m.projection precisely so no broadcast can interleave: every
-	// frame queued before this point is superseded by the snapshot, and every
-	// frame after it is newer than the snapshot. Implementations must not block
-	// or re-enter the manager.
+	// frame queued before this point is superseded by the new baseline, and
+	// every frame after it is newer. Implementations must not block or re-enter
+	// the manager, and must also clear whatever Overflowed reports -- the frames
+	// that flag refers to are exactly the ones just discarded.
 	OnRebaseline func()
 	// Send delivers one event to this subscriber.
 	//
@@ -570,12 +595,21 @@ type submitResponse struct {
 	err     error
 }
 
-// seedJob carries a SeedStateForTest closure through the manager goroutine.
-// Running the seed on that goroutine makes the write mechanically
-// single-writer: it cannot race the goroutine's bare m.state reads in
-// ValidateBatch / DiffProjectionForBatch. done is closed once fn has run.
-type seedJob struct {
-	fn   func(*leapmuxv1.UserCrdtState)
+// managerTask carries caller-driven work onto the manager goroutine, so it runs
+// on the sole writer exactly as the loop's own arms do. Running there is what
+// makes a write mechanically single-writer: it cannot race the goroutine's bare
+// m.state reads in ValidateBatch / DiffProjectionForBatch, and — since both
+// current users PUBLISH a new generation — a publish from the caller's
+// goroutine would silently discard any commit that landed between the clone and
+// the swap.
+//
+// One task type rather than one per caller (a seedJob and a housekeepJob were
+// byte-for-byte the same handshake) so the subtle part — the started/stopped/
+// pre-Start negotiation in runOnManagerGoroutine — has exactly one home. Each
+// task closes over whatever it needs, including the caller's ctx. done is
+// closed once run has returned.
+type managerTask struct {
+	run  func()
 	done chan struct{}
 }
 
@@ -659,6 +693,29 @@ func WithMaxResumeDeltaFrameBytes(n int) ManagerOption {
 	return func(m *Manager) { m.maxResumeDeltaFrameBytes = n }
 }
 
+// BaselineBuilder builds a FALLBACK subscriber's full snapshot from a captured
+// state generation. Named only so WithMaterializerForTest can be spelled as a
+// decorator.
+type BaselineBuilder func(state *leapmuxv1.UserCrdtState, filter SubscriberFilter) *leapmuxv1.UserMaterialized
+
+// WithMaterializerForTest DECORATES the FALLBACK baseline builder.
+//
+// TEST-ONLY. It exists because the property the FALLBACK rework is FOR --
+// "building an O(all-entities) baseline no longer stalls commits, broadcasts,
+// expands or Materialized()" -- can only be asserted while a baseline is
+// actually in flight, and the real builder offers nothing to block on. The
+// RESUME arm's equivalent test blocks inside the fake journal's
+// ListBatchesAfter; there is no journal call on this path, so the seam has to
+// be the builder itself.
+//
+// A DECORATOR rather than a replacement: `decorate` receives the real builder
+// and is expected to call it, so the test blocks around production behaviour
+// instead of standing in for it. That also keeps materializedFromState
+// unexported.
+func WithMaterializerForTest(decorate func(next BaselineBuilder) BaselineBuilder) ManagerOption {
+	return func(m *Manager) { m.materialize = decorate(m.materialize) }
+}
+
 // truncateRunes returns the first n runes of s, never splitting one.
 func truncateRunes(s string, n int) string {
 	if len(s) <= n {
@@ -704,9 +761,10 @@ func NewManager(owner userid.UserID, journal Journal, auth AuthChecker, logger *
 		clearGrace:               PresenceClearGrace,
 		opRetentionTTL:           OpRetentionTTL,
 		maxResumeDeltaFrameBytes: MaxResumeDeltaFrameBytes,
+		materialize:              materializedFromState,
 		submitCh:                 make(chan submitJob, 64),
 		internalCh:               make(chan submitJob, 16),
-		seedCh:                   make(chan seedJob),
+		taskCh:                   make(chan managerTask),
 		startedChan:              make(chan struct{}),
 		stop:                     make(chan struct{}),
 		done:                     make(chan struct{}),
@@ -818,7 +876,7 @@ func (m *Manager) requireOwnState(state *leapmuxv1.UserCrdtState) error {
 func (m *Manager) Start(ctx context.Context) error {
 	// Signal readiness exactly once, before the loop begins servicing jobs.
 	// The registry waits on started() before handing this manager out, so any
-	// caller observing the manager post-Get routes its seed through seedCh (the
+	// caller observing the manager post-Get routes its seed through taskCh (the
 	// sole writer) instead of the pre-Start direct-write branch -- closing the
 	// race the old atomic.Bool left open (Get spawned `go Start()` and returned
 	// before Start had set the flag).
@@ -844,26 +902,25 @@ func (m *Manager) Start(ctx context.Context) error {
 			job.respCh <- m.processSubmit(ctx, job)
 		case job := <-m.internalCh:
 			job.respCh <- m.processSubmit(ctx, job)
-		case job := <-m.seedCh:
-			// SeedStateForTest seed: run on this goroutine (the sole writer).
-			// The race-safety against processSubmit / DiffProjectionForBatch
-			// comes from same-goroutine sequencing (these are select cases on
-			// one loop, so the goroutine is never mid-ValidateBatch while
-			// servicing a seed); m.mu.Lock additionally excludes the
-			// cross-goroutine RLock readers (Materialized, currentEpoch,
-			// broadcast) while the maps change. Deferred unlock + close(done)
-			// so a panicking test seed neither leaves m.mu locked for the RLock
-			// readers nor wedges the caller on <-done; the panic itself still
-			// propagates (crashing the goroutine) so a buggy seed is visible,
-			// but Start's defer close(m.done) runs first so Stop's waiter and
-			// the caller's <-done both release.
+		case task := <-m.taskCh:
+			// A caller-driven pass (SeedStateForTest, TickHousekeeping) run on
+			// this goroutine -- the sole writer. Race-safety against
+			// processSubmit / DiffProjectionForBatch comes from same-goroutine
+			// sequencing (these are select cases on one loop, so the goroutine
+			// is never mid-ValidateBatch while servicing a task);
+			// commitState's swap additionally excludes the cross-goroutine
+			// RLock readers (Materialized, currentEpoch, broadcast) for the
+			// pointer write. A seed runs against a CLONE and is PUBLISHED, so a
+			// published generation stays immutable for the lock-free readers
+			// that captured it. Deferred close(done) so a panicking task does
+			// not wedge the caller on <-done; the panic itself still propagates
+			// (crashing the goroutine) so a buggy task is visible, but Start's
+			// defer close(m.done) runs first so Stop's waiter and the caller's
+			// <-done both release. A seed that panics leaves the live state
+			// untouched, since nothing is published until fn returns.
 			func() {
-				defer func() {
-					m.mu.Unlock()
-					close(job.done)
-				}()
-				m.mu.Lock()
-				job.fn(m.state)
+				defer close(task.done)
+				task.run()
 			}()
 		case <-ticker.C:
 			m.tickHousekeeping(ctx)
@@ -1010,24 +1067,49 @@ func (m *Manager) HeartbeatPresence(ctx context.Context, workspaceID, clientID s
 }
 
 // Materialized returns the public projection filtered to a given
-// allowed-set (used by tests / one-shot callers).
+// allowed-set (used by the GetMaterialized RPC, tests and one-shot callers).
+//
+// Only the generation CAPTURE is under m.mu; the O(all-entities) walk runs
+// lock-free against it. See materializedFromState.
 func (m *Manager) Materialized(filter SubscriberFilter) *leapmuxv1.UserMaterialized {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	return m.materializedLocked(filter)
+	return materializedFromState(m.capturedState(), filter)
 }
 
-func (m *Manager) materializedLocked(filter SubscriberFilter) *leapmuxv1.UserMaterialized {
+// materializedFromState builds the public projection of `state`, filtered to
+// `filter`'s allowed workspaces.
+//
+// IT HOLDS NO MANAGER LOCK, and it does not need one: `state` is a PUBLISHED
+// GENERATION, which is immutable (see commitState). A caller captures the
+// pointer under a brief m.mu.RLock and then pays the O(all-entities) walk with
+// nothing held -- which is the whole point, because that walk used to run under
+// m.projection AND m.mu.RLock, stalling every commit and broadcast for that
+// user for its duration (issue #267).
+//
+// A FREE FUNCTION, not a method, so the type system says so: there is no
+// receiver to reach m.state through, hence no way to accidentally read the LIVE
+// state half-way through a walk of a captured one.
+//
+// The per-record proto.Clone below is NOT redundant with generation
+// immutability, and must stay. Two concurrent connects would otherwise share
+// record pointers, and proto.Marshal / proto.Size write each message's
+// sizeCache non-atomically -- a real data race, detector or no detector. (The
+// resume path DOES alias a record, at buildResumeDelta; that one is safe only
+// because its records come from a per-call proto.Unmarshal and are never shared
+// across subscribers. Do not generalize from it.)
+func materializedFromState(state *leapmuxv1.UserCrdtState, filter SubscriberFilter) *leapmuxv1.UserMaterialized {
 	out := &leapmuxv1.UserMaterialized{
-		UserId:          m.state.GetUserId(),
+		UserId:          state.GetUserId(),
 		Nodes:           map[string]*leapmuxv1.NodeRecord{},
 		Tabs:            map[string]*leapmuxv1.TabRecord{},
 		FloatingWindows: map[string]*leapmuxv1.FloatingWindowRecord{},
 		Workspaces:      map[string]*leapmuxv1.WorkspaceContentsRecord{},
-		MaxHlc:          HLCClone(m.state.GetMaxHlc()),
-		CurrentEpoch:    m.state.GetCurrentEpoch(),
+		// Read from the SAME generation as the entities below, so the snapshot
+		// and the HLC that labels it are a consistent point-in-time pair by
+		// construction rather than by both happening under one lock.
+		MaxHlc:       HLCClone(state.GetMaxHlc()),
+		CurrentEpoch: state.GetCurrentEpoch(),
 	}
-	roots := registeredRoots(m.state)
+	roots := registeredRoots(state)
 	// Build node→workspace once via BFS from each filter-allowed root,
 	// avoiding the per-entry O(depth) walks that nodeWorkspace /
 	// resolveTileWorkspace would otherwise do for every node and every
@@ -1035,9 +1117,9 @@ func (m *Manager) materializedLocked(filter SubscriberFilter) *leapmuxv1.UserMat
 	// preserves nodeWorkspace's existing behaviour where a live node
 	// whose intermediate ancestor is tombstoned still resolves to the
 	// registered-root workspace above it.
-	nodeWS := buildNodeWorkspaceMap(m.state, roots, filter)
+	nodeWS := buildNodeWorkspaceMap(state, roots, filter)
 
-	for wsID, ws := range m.state.GetWorkspaces() {
+	for wsID, ws := range state.GetWorkspaces() {
 		if !filter.IsAllowed(wsID) {
 			continue
 		}
@@ -1046,7 +1128,7 @@ func (m *Manager) materializedLocked(filter SubscriberFilter) *leapmuxv1.UserMat
 			RootNodeId:  ws.GetRootNodeId(),
 		}
 	}
-	for id, n := range m.state.GetNodes() {
+	for id, n := range state.GetNodes() {
 		if !HLCIsZero(n.GetTombstoneAt()) {
 			continue
 		}
@@ -1054,12 +1136,12 @@ func (m *Manager) materializedLocked(filter SubscriberFilter) *leapmuxv1.UserMat
 			out.Nodes[id] = cloneNode(n)
 		}
 	}
-	for id, t := range m.state.GetTabs() {
+	for id, t := range state.GetTabs() {
 		if _, ok := nodeWS[t.GetTileId().GetValue()]; ok {
 			out.Tabs[id] = cloneTab(t)
 		}
 	}
-	for id, fw := range m.state.GetFloatingWindows() {
+	for id, fw := range state.GetFloatingWindows() {
 		ws := fw.GetWorkspaceId().GetValue()
 		if ws != "" && filter.IsAllowed(ws) {
 			out.FloatingWindows[id] = cloneFloatingWindow(fw)
@@ -1440,33 +1522,91 @@ func (m *Manager) commit(ctx context.Context, in SubmitInput, batch *leapmuxv1.O
 // under m.mu.Lock, excluding the RLock readers (Materialized, currentEpoch,
 // broadcast, WithStateRLock) for the duration of the pointer swap. Routing
 // every state replacement through this one method makes the single-writer
-// invariant structurally visible -- the only places that assign m.state are
-// Bootstrap (pre-Start, before the goroutine exists) and commit (on the
-// manager goroutine, after a validated batch). A future debug path that tried
-// to assign m.state directly would have to add a third call site here, which
-// is exactly the review checkpoint the invariant needs.
+// invariant structurally visible -- `m.state = ` appears exactly once in the
+// package, on the line below, and every publisher (Bootstrap, commit,
+// compaction, the epoch bump, housekeeping, SeedStateForTest) reaches it
+// through here. A future debug path that tried to assign m.state directly would
+// have to add a SECOND assignment, which is exactly the review checkpoint the
+// invariant needs -- and, because generations share maps (see below), exactly
+// the change that would break the lock-free readers.
+//
+// A PUBLISHED GENERATION IS NEVER MUTATED. Every state change builds a new
+// generation and swaps it in here: commit via CloneStateForBatch, compaction
+// and the epoch bump via CloneState / nextStateGeneration, SeedStateForTest via
+// CloneState. Nothing writes through the live pointer.
+//
+// That is a load-bearing guarantee, not tidiness. It is what lets a reader
+// capture the generation pointer under a brief RLock and then walk it holding
+// NO lock at all -- which is how a cold /ws/userevents connect builds its
+// O(all-entities) baseline without stalling the commit pipeline (see
+// materializedFromState and registerForFallback), and what manager_audit.go's
+// "once stored in m.state's history it's immutable" already assumes.
+//
+// The subtle half is that generations SHARE maps: CloneStateForBatch aliases
+// the entity map of any kind a batch does not touch, and nextStateGeneration
+// aliases all four. So an in-place `delete` on the current generation mutates
+// older ones too. That is why compaction publishes its pruned clone rather than
+// re-pruning the live state.
 func (m *Manager) commitState(state *leapmuxv1.UserCrdtState) {
 	m.mu.Lock()
 	m.state = state
 	m.mu.Unlock()
 }
 
-// State returns a deep clone of the current state. Used by tests +
-// callers that need to retain the state past the manager's RLock
-// window (e.g. send it across a goroutine boundary). Hot-path readers
-// that just walk the state during one synchronous pass should prefer
-// WithStateRLock to avoid the per-call clone.
-func (m *Manager) State() *leapmuxv1.UserCrdtState {
+// capturedState returns the current published generation.
+//
+// This is THE read for anything that wants to walk the state without holding a
+// lock across the walk: a published generation is never mutated (see
+// commitState), so the returned pointer is a stable point-in-time value rather
+// than a live view. It is O(1) — no clone — and the only lock it takes is the
+// RLock around the pointer read itself.
+//
+// A named operation rather than three hand-spelled copies of
+// `m.mu.RLock(); s := m.state; m.mu.RUnlock()`, which is what capture-the-
+// generation had become. It deliberately does NOT cover a window that captures
+// AND does something else under the same RLock — registerForFallbackLocked's
+// does, and that atomicity is exactly what its no-gap/no-duplicate proof rests
+// on, so it keeps its own explicit lock.
+//
+// The caller MUST NOT mutate what it gets back; one that needs a writable copy
+// takes State(), which deep-clones.
+func (m *Manager) capturedState() *leapmuxv1.UserCrdtState {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	return CloneState(m.state)
+	return m.state
+}
+
+// State returns a deep clone of the current state.
+//
+// TEST-ONLY: `rg '\.State\(\)' backend/ --glob '!*_test.go'` finds no production
+// caller. Its historical reason for existing — "callers that need to retain the
+// state past the manager's RLock window" — was retired by the generation-
+// immutability invariant: capturedState() retains a generation for free, and
+// what remains here is a genuinely WRITABLE copy, which is what tests take it
+// for. The clone runs outside the lock for the same reason; only the pointer
+// read needs one.
+func (m *Manager) State() *leapmuxv1.UserCrdtState {
+	return CloneState(m.capturedState())
 }
 
 // WithStateRLock runs `fn` against the live in-memory state under
 // m.mu.RLock so the caller avoids a multi-MB CloneState allocation when
 // it only needs a synchronous walk (enumeration, projection,
-// computation). The state pointer MUST NOT escape `fn` — callers that
-// need to hold the state past the call should use State() instead.
+// computation).
+//
+// The pointer MAY escape `fn` — a published generation is immutable, so what
+// escapes is a stable point-in-time value, not a live view (see commitState).
+// The same guarantee is what lets registerForFallback capture the generation
+// under its own m.mu.RLock and then build an O(all-entities) baseline from it
+// holding no lock at all; among this helper's own callers, the immutability
+// suite's captureGeneration is the one that relies on the escape. What must NOT
+// happen is MUTATING the escaped state; a caller that needs a writable copy
+// takes State(), which deep-clones.
+//
+// Note the pointer stops tracking the manager the moment it escapes: a later
+// commit publishes a new generation and the captured one keeps the shape it had.
+// That is the point on the baseline path, and a bug for a caller that wanted
+// "current" — such a caller should re-enter rather than cache.
 func (m *Manager) WithStateRLock(fn func(state *leapmuxv1.UserCrdtState)) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -1502,9 +1642,10 @@ func (m *Manager) currentEpoch() int64 {
 	return m.state.GetCurrentEpoch()
 }
 
-// SeedStateForTest runs fn against m.state as the sole writer, so the write
-// cannot race the manager goroutine's bare m.state reads in ValidateBatch /
-// DiffProjectionForBatch. It is a TEST-ONLY seam for seeds that genuinely
+// SeedStateForTest runs fn against a CLONE of m.state as the sole writer and
+// publishes the result, so the write cannot race the manager goroutine's bare
+// m.state reads in ValidateBatch / DiffProjectionForBatch. It is a TEST-ONLY
+// seam for seeds that genuinely
 // cannot be a valid op batch — e.g. bumping CurrentEpoch to exercise a
 // stale-epoch gate (no op writes CurrentEpoch; only maybeAdvanceEpoch does) or
 // constructing a record with hand-picked LWW HLCs that bypass the LWW-merge
@@ -1512,47 +1653,82 @@ func (m *Manager) currentEpoch() int64 {
 // SubmitInternal as a SetWorkspaceRegisterOp, mirroring the production
 // lifecycle create path.
 //
-// Once Start has been called, fn runs ON the manager goroutine (via seedCh)
-// under m.mu.Lock — the same goroutine that owns the bare reads, so there is
+// fn receives a CLONE, not the live generation, and the clone is published via
+// commitState. A published generation is immutable (see commitState), and a
+// seed that edited m.state in place would break that for every reader that
+// captured the pointer — including a cold subscriber building its baseline
+// lock-free. The clone also means a seed that panics part-way leaves the live
+// state untouched instead of half-written.
+//
+// Once Start has been called, fn runs ON the manager goroutine (via taskCh),
+// the same goroutine that owns the bare reads, so there is
 // no cross-goroutine write to race them. The registry waits on started()
 // before handing the manager out, so any caller that observes the manager via
 // Get routes its seed through the goroutine (closing the race an off-goroutine
 // pre-Start write would otherwise open). Before Start has been called (the
 // registry-factory shape, where the seed runs inside the factory closure
-// before Get spawns the goroutine), fn runs directly under m.mu.Lock,
+// before Get spawns the goroutine), fn runs on the calling goroutine,
 // mirroring Bootstrap's no-concurrent-reader assumption.
 //
-// fn MUST NOT call back into Submit / SubmitInternal / SeedStateForTest: those
-// channel sends would be made from the manager goroutine that is supposed to
-// receive on them, deadlocking the sole consumer.
+// fn MUST NOT call back into Submit / SubmitInternal / SeedStateForTest /
+// TickHousekeeping: those channel sends would be made from the manager
+// goroutine that is supposed to receive on them, deadlocking the sole consumer.
+// (TickHousekeeping joined that list when it started routing through taskCh.)
 //
-// After Stop, the goroutine has exited and the seedCh send falls through to
-// <-m.done, so a post-Stop SeedStateForTest returns without running fn (it
-// cannot race, but it also cannot seed) rather than wedging the caller.
+// After Stop, the goroutine has exited and the send falls through to <-m.done,
+// so a post-Stop SeedStateForTest returns without running fn (it cannot race,
+// but it also cannot seed) rather than wedging the caller.
 //
 // Test-only: production state writes flow exclusively through SubmitInternal.
 func (m *Manager) SeedStateForTest(fn func(state *leapmuxv1.UserCrdtState)) {
+	m.runOnManagerGoroutine(func() {
+		next := CloneState(m.state)
+		fn(next)
+		m.commitState(next)
+	})
+}
+
+// runOnManagerGoroutine runs `run` on the manager goroutine and returns once it
+// has completed, so a caller can rely on its effects.
+//
+// This is the one home for the started/stopped/pre-Start negotiation that both
+// caller-driven passes need (SeedStateForTest and TickHousekeeping), rather
+// than a copy each:
+//
+//   - Started: hand the task to the goroutine and wait. The select on m.done
+//     returns if the goroutine has since exited (Stop) instead of wedging the
+//     caller on the unbuffered channel.
+//   - Not started: no manager goroutine exists to race, so run inline (mirrors
+//     Bootstrap). Safe only from the registry-factory shape, where this runs
+//     inside the factory closure before Get spawns Start; a direct caller that
+//     spawned `go Start()` and then reached this branch would race the
+//     goroutine it just launched, because startedChan is closed INSIDE Start --
+//     an open channel does not prove no goroutine exists. Route through the
+//     registry instead.
+//
+// `run` executes on the sole writer, so it may read m.state bare and publish
+// through commitState; it MUST NOT send on submitCh / internalCh / taskCh,
+// which would deadlock the consumer it is running on.
+//
+// The same rule binds the CALLER, and that half is easier to miss: this
+// function is itself a taskCh send, so calling it FROM the manager goroutine
+// deadlocks it permanently -- no commits, no broadcasts, no subscribes for that
+// user, and Stop never returns, because the goroutine is blocked in the send
+// and can never reach the receive. The `<-m.done` escape does not help; that
+// arm only fires once the goroutine has already exited. The ticker arm inside
+// Start is correct precisely because it calls the unexported tickHousekeeping
+// directly rather than coming back through here.
+func (m *Manager) runOnManagerGoroutine(run func()) {
 	select {
 	case <-m.startedChan:
-		// Start has been called: route through the manager goroutine (the sole
-		// writer). The select on m.done returns if the goroutine has since
-		// exited (Stop) instead of wedging the caller on the unbuffered seedCh.
 		done := make(chan struct{})
 		select {
-		case m.seedCh <- seedJob{fn: fn, done: done}:
+		case m.taskCh <- managerTask{run: run, done: done}:
 			<-done
 		case <-m.done:
 		}
 	default:
-		// Start has not been called: no manager goroutine exists to race, so
-		// run fn directly under m.mu (mirrors Bootstrap). Safe only from the
-		// registry-factory shape, where this runs inside the factory closure
-		// before Get spawns Start; a direct caller that spawned `go Start()`
-		// and then reached this branch would race the goroutine it just
-		// launched -- route through the registry instead.
-		m.mu.Lock()
-		defer m.mu.Unlock()
-		fn(m.state)
+		run()
 	}
 }
 

--- a/backend/internal/hub/crdt/manager_compaction.go
+++ b/backend/internal/hub/crdt/manager_compaction.go
@@ -11,9 +11,37 @@ import (
 // TickHousekeeping runs one pass of the dedup-cleanup + epoch-advance
 // + compaction cycle. Identical to what the 60s ticker inside Start
 // triggers; exported so admin tooling and integration tests can force
-// a deterministic pass without waiting on the ticker.
+// a deterministic pass without waiting on the ticker. It returns once the
+// pass has completed, so a caller can assert on its effects.
+//
+// The pass is ROUTED THROUGH the manager goroutine, the same way
+// SeedStateForTest is and for the same reason: both maybeCompact and
+// maybeAdvanceEpoch now PUBLISH a new state generation, and a publish from the
+// caller's goroutine would discard any commit that landed between the clone and
+// the swap. Running inline was tolerable only while the writeback stamped a
+// couple of watermark fields onto whatever generation was live at the time.
+// runOnManagerGoroutine carries the started/stopped/pre-Start negotiation,
+// including why the pre-Start branch is safe only from the registry-factory
+// shape.
+//
+// ctx bounds the JOURNAL WORK, not the wait: it is captured by the closure and
+// consulted by the cleanup/compaction/epoch calls once the goroutine picks the
+// task up. A caller that cancels while the task is still queued (or already
+// running) still blocks until the pass returns. That is deliberate -- the pass
+// publishes a state generation, so abandoning the wait would let the caller
+// proceed against state that is about to change under it -- but it means a
+// deadline'd caller can wait past its deadline if the goroutine is inside a
+// slow submit.
+//
+// After Stop the goroutine has exited and the send falls through to <-m.done,
+// so a post-Stop call returns without running the pass rather than wedging.
+//
+// MUST NOT be called FROM the manager goroutine -- it is a taskCh send, so the
+// goroutine would be waiting on itself. See runOnManagerGoroutine. The 60s
+// ticker inside Start calls the unexported tickHousekeeping instead, for
+// exactly this reason.
 func (m *Manager) TickHousekeeping(ctx context.Context) {
-	m.tickHousekeeping(ctx)
+	m.runOnManagerGoroutine(func() { m.tickHousekeeping(ctx) })
 }
 
 // tickHousekeeping runs dedup-table cleanup, lazy compaction, and
@@ -45,10 +73,14 @@ func (m *Manager) maybeAdvanceEpoch(ctx context.Context) {
 		m.logger.Warn("advance epoch", "err", err)
 		return
 	}
-	m.mu.Lock()
-	m.state.CurrentEpoch = newEpoch
-	m.state.EpochStartedAt = timestamppb.New(m.now())
-	m.mu.Unlock()
+	// PUBLISH a new generation rather than editing the live one: a published
+	// generation is immutable (see commitState), which is what lets a cold
+	// subscriber capture the pointer and build its baseline lock-free. The
+	// entity maps are aliased, so this stays O(1).
+	next := nextStateGeneration(m.state)
+	next.CurrentEpoch = newEpoch
+	next.EpochStartedAt = timestamppb.New(m.now())
+	m.commitState(next)
 }
 
 func (m *Manager) maybeCompact(ctx context.Context) {
@@ -69,9 +101,14 @@ func (m *Manager) maybeCompact(ctx context.Context) {
 		m.mu.RUnlock()
 		return
 	}
-	// Snapshot the in-memory state under the manager mutex so the
-	// compaction walks a stable view.
-	state := CloneState(m.state)
+	// Build the generation this pass will publish. The prune below only ADDS
+	// OR REMOVES map entries -- it never writes a record field -- and the two
+	// watermark stamps are header fields, so copying the maps and sharing the
+	// records is sufficient. A full CloneState here deep-cloned every node, tab,
+	// window and workspace through protobuf reflection on the manager goroutine,
+	// once per tick on any active account, for a pass that then deletes a
+	// handful of entries.
+	state := nextStateGenerationWithOwnMaps(m.state)
 	m.mu.RUnlock()
 
 	// Per-batch dedup rows are already in user_recent_batch_ids when
@@ -130,16 +167,16 @@ func (m *Manager) maybeCompact(ctx context.Context) {
 		m.logger.Warn("compaction", "err", err)
 		return
 	}
-	m.mu.Lock()
-	m.state.CompactionWatermark = HLCClone(state.GetCompactionWatermark())
-	m.state.OpRetentionWatermark = HLCClone(state.GetOpRetentionWatermark())
-	if prunedCount > 0 {
-		// Apply the same prune to the in-memory state under the write
-		// lock so reads after compaction see the pruned shape without
-		// waiting for a journal reload.
-		_ = PruneTombstonesAtOrBelow(m.state, m.state.GetCompactionWatermark())
-	}
-	m.mu.Unlock()
+	// PUBLISH the clone we just persisted, rather than replaying the watermark
+	// writes and the prune onto the live generation. `state` already carries
+	// both watermarks and the pruned shape, and this runs on the manager
+	// goroutine -- the sole writer -- so nothing can have touched m.state
+	// between the CloneState above and here. Publishing is both less code and
+	// the only version that upholds commitState's immutability invariant: the
+	// prune DELETES map entries, and CloneStateForBatch shares untouched maps
+	// across generations, so an in-place prune mutated older generations too --
+	// which a lock-free reader (materializedFromState) would race.
+	m.commitState(state)
 	if prunedCount > 0 {
 		m.logger.Debug("compaction pruned tombstones", "count", prunedCount)
 	}

--- a/backend/internal/hub/crdt/manager_fallback_test.go
+++ b/backend/internal/hub/crdt/manager_fallback_test.go
@@ -1,0 +1,583 @@
+package crdt_test
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/hub/crdt"
+)
+
+// The FALLBACK arm's lock plan: an O(all-entities) baseline built with NO
+// manager lock held, over a captured immutable generation, with
+// resumeSuppressThrough closing the dual-delivery straddle in place of the
+// projection hold that used to.
+//
+// The sibling suite for the RESUME arm is in manager_subscribe_test.go; this
+// file is the FALLBACK half, including the analogue of
+// TestSubscribeWithACL_NeitherExpandNorBroadcastStalledDuringScan.
+
+// heldBaseline is the FALLBACK counterpart of the fake journal's
+// listHold/listReached pair. The resume arm can block inside ListBatchesAfter;
+// the fallback makes no journal call, so the seam is the builder itself.
+//
+// Only the `nth` baseline is held, so a test can register warm-up subscribers
+// freely and then block exactly the connect under test.
+type heldBaseline struct {
+	reached chan struct{}
+	release chan struct{}
+
+	mu        sync.Mutex
+	calls     int
+	unblocked bool
+}
+
+// runHeldBaselineManager builds a manager whose Nth FALLBACK baseline blocks
+// until released, and registers the release so it runs BEFORE the manager's
+// Stop.
+//
+// The release itself is what keeps a failing assertion from hanging the
+// package: a t.Fatal returns without unblocking the builder, leaving that
+// goroutine parked forever, and Stop waits for the manager goroutine that is
+// wedged behind it. But t.Cleanup is LIFO, so registering the release first --
+// which every caller did, since it had to build the option before the manager
+// -- ran it LAST, after Stop, and the hang happened anyway. Doing both here, in
+// this order, is what makes "a regression in the lock plan FAILS these tests
+// rather than hanging them" a property of the helper instead of a rule each
+// caller has to get right.
+func runHeldBaselineManager(t *testing.T, nth int) (*heldBaseline, *crdt.Manager) {
+	t.Helper()
+	h, opt := newHeldBaseline(nth)
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 230_000, opt)
+	t.Cleanup(h.unblock)
+	return h, mgr
+}
+
+// newHeldBaseline returns the hold and the ManagerOption that installs it.
+// Callers go through runHeldBaselineManager, which owns the cleanup ordering.
+func newHeldBaseline(nth int) (*heldBaseline, crdt.ManagerOption) {
+	h := &heldBaseline{reached: make(chan struct{}), release: make(chan struct{})}
+	opt := crdt.WithMaterializerForTest(func(next crdt.BaselineBuilder) crdt.BaselineBuilder {
+		return func(state *leapmuxv1.UserCrdtState, filter crdt.SubscriberFilter) *leapmuxv1.UserMaterialized {
+			h.mu.Lock()
+			h.calls++
+			hold := h.calls == nth
+			h.mu.Unlock()
+			if hold {
+				close(h.reached)
+				<-h.release
+			}
+			// Delegates, so what is under test is the LOCK PLAN around the
+			// builder rather than a stand-in for it.
+			return next(state, filter)
+		}
+	})
+	return h, opt
+}
+
+// waitReached blocks until the held baseline has started, or fails the test.
+func (h *heldBaseline) waitReached(t *testing.T) {
+	t.Helper()
+	select {
+	case <-h.reached:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the fallback baseline never started")
+	}
+}
+
+// unblock is idempotent so a test can release explicitly AND leave the
+// cleanup's release in place as the safety net.
+func (h *heldBaseline) unblock() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.unblocked {
+		return
+	}
+	h.unblocked = true
+	close(h.release)
+}
+
+// TestSubscribeWithACL_FallbackStallsNothingDuringBaseline is the whole point
+// of the FALLBACK rework, stated as a test.
+//
+// While a cold connect's baseline is in flight, NONE of the things it used to
+// block may be blocked: a workspace expand (subscribeExpandMu), a commit and
+// its broadcast to another subscriber (m.mu.Lock, then m.projection), or a
+// Materialized() read (m.mu.RLock).
+//
+// The commit arm is the one that fails outright before this change: the old
+// shape held m.mu.RLock across the whole walk, and commitState needs
+// m.mu.Lock.
+func TestSubscribeWithACL_FallbackStallsNothingDuringBaseline(t *testing.T) {
+	held, mgr := runHeldBaselineManager(t, 2)
+	seedRootInternal(t, mgr, "w1", "root1")
+
+	// Warm-up subscriber (baseline #1, not held), so a commit's broadcast has
+	// somewhere to land while the connect under test is stuck.
+	warm := &captureSubscriber{}
+	warmOut, err := mgr.SubscribeWithACL(context.Background(), &crdt.Subscriber{UserID: "user-1", Send: warm.send}, nil, 0, resolveAll)
+	require.NoError(t, err)
+	defer warmOut.Unsub()()
+	warmBefore := len(warm.snapshot())
+
+	// The connect under test: baseline #2, held.
+	//
+	// The error is carried back to the test goroutine rather than asserted here:
+	// require's FailNow is runtime.Goexit, which is only defined on the test
+	// goroutine. Called here it would skip the Unsub below, leaking a registered
+	// subscriber and its presence refcount into assertions (a)-(d).
+	heldDone := make(chan struct{})
+	heldErr := make(chan error, 1)
+	go func() {
+		defer close(heldDone)
+		out, err := mgr.SubscribeWithACL(context.Background(),
+			&crdt.Subscriber{UserID: "user-1", Send: (&captureSubscriber{}).send}, nil, 0, resolveAll)
+		heldErr <- err
+		if err == nil {
+			out.Unsub()()
+		}
+	}()
+	held.waitReached(t)
+
+	// (a) subscribeExpandMu: a workspace-create expand must not stall.
+	expandDone := make(chan error, 1)
+	go func() { expandDone <- mgr.ExpandSubscribersForWorkspace(context.Background(), "w1") }()
+	select {
+	case err := <-expandDone:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("ExpandSubscribersForWorkspace stalled behind a fallback baseline — subscribeExpandMu held across it")
+	}
+
+	// (b) m.mu.Lock: the commit itself. This is the arm the old shape failed.
+	committed := make(chan struct{})
+	go func() {
+		defer close(committed)
+		submitNodePositionBatch(t, mgr, "during-baseline", "root1", "live")
+	}()
+	select {
+	case <-committed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("a commit stalled behind a fallback baseline — m.mu held across the walk")
+	}
+
+	// (c) m.projection: and its broadcast reached the warm subscriber.
+	waitFor(t, func() bool { return len(warm.snapshot()) > warmBefore },
+		"a broadcast stalled behind a fallback baseline — m.projection held across the walk")
+
+	// (d) m.mu.RLock readers are not queued behind a waiting writer either.
+	readDone := make(chan struct{})
+	go func() {
+		defer close(readDone)
+		_ = mgr.Materialized(crdt.SubscriberFilter{})
+	}()
+	select {
+	case <-readDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Materialized() stalled behind a fallback baseline")
+	}
+
+	held.unblock()
+	<-heldDone
+	require.NoError(t, <-heldErr, "the held connect itself must succeed")
+}
+
+// TestSubscribeWithACL_FallbackExcludesAndDeliversPostBaselineCommits is the
+// no-gap / no-duplicate proof in behavioural form: a batch committed while the
+// baseline is in flight is NOT in the snapshot, and IS delivered live, exactly
+// once.
+func TestSubscribeWithACL_FallbackExcludesAndDeliversPostBaselineCommits(t *testing.T) {
+	held, mgr := runHeldBaselineManager(t, 1)
+	seedRootInternal(t, mgr, "w1", "root1")
+	submitNodePositionBatch(t, mgr, "pre-baseline", "root1", "before")
+
+	cap := &captureSubscriber{}
+	done := make(chan crdt.SubscribeOutcome, 1)
+	go func() {
+		out, err := mgr.SubscribeWithACL(context.Background(),
+			&crdt.Subscriber{UserID: "user-1", Send: cap.send}, nil, 0, resolveAll)
+		require.NoError(t, err)
+		done <- out
+	}()
+	held.waitReached(t)
+
+	// Commits strictly after the generation the baseline captured.
+	submitNodePositionBatch(t, mgr, "post-baseline", "root1", "after")
+	held.unblock()
+	out := <-done
+	defer out.Unsub()()
+
+	initial := out.Initial()
+	require.NotNil(t, initial)
+	assert.Equal(t, "before", initial.GetNodes()["root1"].GetPosition().GetValue(),
+		"the baseline must reflect the generation it captured, not a commit that landed during the walk")
+	waitFor(t, func() bool { return countBatchFrames(cap) == 1 },
+		"the post-baseline commit must be delivered live exactly once")
+	assert.Equal(t, 1, countBatchFrames(cap),
+		"and not twice -- it is above the suppress gate, so exactly one copy reaches the client")
+}
+
+// TestSubscribeWithACL_FallbackSuppressesPreBaselineBroadcasts is the other
+// direction: a batch that committed BEFORE the captured generation is already
+// folded into the baseline, so re-delivering it would replay an
+// entity_materialized / entity_removed the client applies wholesale onto newer
+// state. The suppress gate must drop it.
+func TestSubscribeWithACL_FallbackSuppressesPreBaselineBroadcasts(t *testing.T) {
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 230_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+	submitNodePositionBatch(t, mgr, "pre-baseline", "root1", "before")
+
+	cap := &captureSubscriber{}
+	out, err := mgr.SubscribeWithACL(context.Background(),
+		&crdt.Subscriber{UserID: "user-1", Send: cap.send}, nil, 0, resolveAll)
+	require.NoError(t, err)
+	defer out.Unsub()()
+	require.Equal(t, "before", out.Initial().GetNodes()["root1"].GetPosition().GetValue())
+
+	// Nothing has been broadcast to this subscriber: everything it can see is
+	// in the baseline it just received.
+	assert.Equal(t, 0, countBatchFrames(cap))
+
+	// A commit after registration is above the gate and IS delivered.
+	submitNodePositionBatch(t, mgr, "after", "root1", "later")
+	waitFor(t, func() bool { return countBatchFrames(cap) == 1 },
+		"a commit after the baseline must still be delivered")
+}
+
+// TestSubscribeWithACL_ColdFallbackDoesNotRebaseline pins the enum: a first
+// connect was never registered, so there is nothing parked and firing the
+// discard would be meaningless. A transposed fallbackCold/fallbackRebaseline
+// would still pass every other test in this file.
+func TestSubscribeWithACL_ColdFallbackDoesNotRebaseline(t *testing.T) {
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 230_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+
+	rebaselines := 0
+	out, err := mgr.SubscribeWithACL(context.Background(), &crdt.Subscriber{
+		UserID:       "user-1",
+		Send:         (&captureSubscriber{}).send,
+		OnRebaseline: func() { rebaselines++ },
+	}, nil, 0, resolveAll)
+	require.NoError(t, err)
+	defer out.Unsub()()
+	assert.Equal(t, 0, rebaselines, "a cold fallback has nothing parked to discard")
+}
+
+// TestSubscribeWithACL_ParkOverflowDuringBaselineRetriesThenSucceeds covers the
+// hazard the lock-free baseline introduces: the subscriber is registered while
+// the walk runs, so live frames park and can overflow the transport's buffer.
+//
+// The first attempt reports an overflow; the ladder must rebaseline (which
+// discards the buffer and clears the flag) and return a complete snapshot
+// rather than shipping one alongside a hole.
+func TestSubscribeWithACL_ParkOverflowDuringBaselineRetriesThenSucceeds(t *testing.T) {
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 230_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+
+	var (
+		mu          sync.Mutex
+		overflowed  = true
+		rebaselines int
+	)
+	sub := &crdt.Subscriber{
+		UserID: "user-1",
+		Send:   (&captureSubscriber{}).send,
+		Overflowed: func() bool {
+			mu.Lock()
+			defer mu.Unlock()
+			return overflowed
+		},
+		OnRebaseline: func() {
+			mu.Lock()
+			defer mu.Unlock()
+			rebaselines++
+			// The real queue clears the flag here (see
+			// subscriberQueue.Rebaseline); a fake that did not would be
+			// asserting against a transport that does not exist.
+			overflowed = false
+		},
+	}
+	out, err := mgr.SubscribeWithACL(context.Background(), sub, nil, 0, resolveAll)
+	require.NoError(t, err)
+	defer out.Unsub()()
+
+	require.Equal(t, crdt.SubscribeInitial, out.Mode())
+	assert.Equal(t, crdt.SubscribeReasonParkOverflow, out.Reason(),
+		"the overflow is the operative cause of this snapshot, not whatever sent us here first")
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 1, rebaselines, "one retry should have been enough")
+	assert.NotNil(t, out.Initial().GetNodes()["root1"], "the retried baseline must still be complete")
+}
+
+// TestSubscribeWithACL_ParkOverflowLadderTerminates is the liveness half: a
+// transport that reports an overflow forever must not spin. The ladder is
+// bounded, and its last rung holds m.projection -- where no broadcast can
+// interleave, so no overflow is possible.
+func TestSubscribeWithACL_ParkOverflowLadderTerminates(t *testing.T) {
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 230_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+
+	var (
+		mu          sync.Mutex
+		rebaselines int
+	)
+	sub := &crdt.Subscriber{
+		UserID:     "user-1",
+		Send:       (&captureSubscriber{}).send,
+		Overflowed: func() bool { return true },
+		OnRebaseline: func() {
+			mu.Lock()
+			defer mu.Unlock()
+			rebaselines++
+		},
+	}
+
+	// The error travels back to the test goroutine rather than being asserted in
+	// the spawned one: require's FailNow is runtime.Goexit, defined only on the
+	// test goroutine. Called here it would skip the `done` send, so a plain
+	// subscribe error would surface as the 5s "ladder did not terminate"
+	// timeout below -- reporting a liveness bug for what is really an error
+	// return, and hiding the actual cause.
+	type ladderResult struct {
+		out crdt.SubscribeOutcome
+		err error
+	}
+	done := make(chan ladderResult, 1)
+	go func() {
+		out, err := mgr.SubscribeWithACL(context.Background(), sub, nil, 0, resolveAll)
+		done <- ladderResult{out: out, err: err}
+	}()
+	select {
+	case res := <-done:
+		require.NoError(t, res.err)
+		defer res.out.Unsub()()
+		assert.Equal(t, crdt.SubscribeInitial, res.out.Mode())
+		assert.NotNil(t, res.out.Initial().GetNodes()["root1"],
+			"the locked last rung must still produce a complete baseline")
+	case <-time.After(5 * time.Second):
+		t.Fatal("the park-overflow ladder did not terminate")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	// The FIRST attempt enters cold (nothing parked, so no discard); each
+	// subsequent lock-free attempt rebaselines, and so does the locked rung.
+	// That is (attempts - 1) + 1 = attempts discards for a cold entry.
+	assert.Equal(t, crdt.FallbackLockFreeAttemptsForTest, rebaselines,
+		"the ladder must be bounded, not open-ended")
+}
+
+// TestSubscribeWithACL_LockedRungReleasesTheLifecycleLock pins the one lock the
+// ladder's TERMINAL rung must not hold across its walk.
+//
+// That rung holds m.projection on purpose -- it is what makes a broadcast (and
+// therefore an overflow) impossible while the baseline is taken, which is what
+// makes the ladder finite. subscribeExpandMu is a different matter: it covers
+// only the resolve->register TOCTOU, and the lifecycle RPCs it serializes take
+// it WITHOUT ever taking m.projection. Holding it across an O(all-entities)
+// walk therefore stalls this user's workspace create/delete for the duration
+// and buys nothing -- and the escalated rung reached that walk under exactly
+// the sustained load where a stalled lifecycle RPC hurts most.
+//
+// The lock-free rungs are covered by
+// TestSubscribeWithACL_FallbackStallsNothingDuringBaseline; this is the arm
+// that hand-rolled its own locking and so did not inherit that guarantee.
+func TestSubscribeWithACL_LockedRungReleasesTheLifecycleLock(t *testing.T) {
+	// Builds 1..N are the lock-free attempts; the NEXT one is the escalated
+	// rung, which is the only build under test here.
+	held, mgr := runHeldBaselineManager(t, crdt.FallbackLockFreeAttemptsForTest+1)
+	seedRootInternal(t, mgr, "w1", "root1")
+
+	// Permanently overflowed, so every lock-free attempt gives up and the
+	// ladder runs all the way to the locked rung.
+	sub := &crdt.Subscriber{
+		UserID:       "user-1",
+		Send:         (&captureSubscriber{}).send,
+		Overflowed:   func() bool { return true },
+		OnRebaseline: func() {},
+	}
+	connectErr := make(chan error, 1)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		out, err := mgr.SubscribeWithACL(context.Background(), sub, nil, 0, resolveAll)
+		connectErr <- err
+		if err == nil {
+			out.Unsub()()
+		}
+	}()
+	held.waitReached(t)
+
+	expandDone := make(chan error, 1)
+	go func() { expandDone <- mgr.ExpandSubscribersForWorkspace(context.Background(), "w1") }()
+	select {
+	case err := <-expandDone:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("ExpandSubscribersForWorkspace stalled behind the LOCKED rung's baseline — subscribeExpandMu held across the walk")
+	}
+
+	held.unblock()
+	<-done
+	require.NoError(t, <-connectErr, "the escalated connect itself must still succeed")
+}
+
+// TestSubscribeWithACL_FallbackReasonsAreDistinguishable pins that each
+// non-resumable verdict reports its OWN reason. Without it the metric would be
+// a single undifferentiated "initial" bucket, which is what it was before --
+// and "why is this deployment full-snapshotting?" would stay unanswerable.
+func TestSubscribeWithACL_FallbackReasonsAreDistinguishable(t *testing.T) {
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 230_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+	submitNodePositionBatch(t, mgr, "b1", "root1", "p1")
+	snap := mgr.Materialized(crdt.SubscriberFilter{})
+	cursor, epoch := snap.GetMaxHlc(), snap.GetCurrentEpoch()
+
+	t.Run("no cursor", func(t *testing.T) {
+		assert.Equal(t, crdt.SubscribeReasonNoCursor, subscribeOnce(t, mgr, nil, 0).Reason())
+	})
+	t.Run("stale epoch", func(t *testing.T) {
+		assert.Equal(t, crdt.SubscribeReasonStaleEpoch,
+			subscribeOnce(t, mgr, crdt.HLCClone(cursor), epoch+1).Reason())
+	})
+	t.Run("below the retention floor", func(t *testing.T) {
+		// Needs its OWN manager with a zero retention TTL. On the shared one
+		// the wall-clock floor is (now - 24h), which is negative for a fixture
+		// clock seeded at 230s and therefore clamps to zero -- so every
+		// non-zero cursor resumes and this case could never fire.
+		zeroTTL, _, _ := runManager(t, "user-1", allowAll{}, 230_000, crdt.WithOpRetentionTTL(0))
+		seedRootInternal(t, zeroTTL, "w1", "root1")
+		submitNodePositionBatch(t, zeroTTL, "b1", "root1", "p1")
+		snap := zeroTTL.Materialized(crdt.SubscriberFilter{})
+		assert.Equal(t, crdt.SubscribeReasonBelowRetentionFloor,
+			subscribeOnce(t, zeroTTL, &leapmuxv1.HLC{Physical: 1}, snap.GetCurrentEpoch()).Reason())
+	})
+	t.Run("resumed", func(t *testing.T) {
+		submitNodePositionBatch(t, mgr, "tail", "root1", "p2")
+		out := subscribeOnce(t, mgr, crdt.HLCClone(cursor), epoch)
+		require.Equal(t, crdt.SubscribeDelta, out.Mode())
+		assert.Equal(t, crdt.SubscribeReasonResumed, out.Reason())
+	})
+}
+
+func subscribeOnce(t *testing.T, mgr *crdt.Manager, cursor *leapmuxv1.HLC, epoch int64) crdt.SubscribeOutcome {
+	t.Helper()
+	sub := &crdt.Subscriber{UserID: "user-1", Send: (&captureSubscriber{}).send}
+	out, err := mgr.SubscribeWithACL(context.Background(), sub, cursor, epoch, resolveAll)
+	require.NoError(t, err)
+	t.Cleanup(out.Unsub())
+	return out
+}
+
+// countBatchFrames counts the `batch` frames a capture subscriber received.
+func countBatchFrames(c *captureSubscriber) int {
+	n := 0
+	for _, evt := range c.snapshot() {
+		if evt.GetBatch() != nil {
+			n++
+		}
+	}
+	return n
+}
+
+// waitFor polls `cond` until it holds, failing with `msg` after two seconds.
+func waitFor(t *testing.T, cond func() bool, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal(msg)
+}
+
+// TestFallbackBaselineRacesCompaction is the test that PROVES the
+// copy-on-write change in A1 was necessary, and it only means anything under
+// -race.
+//
+// Cold connects build their baselines from captured generations holding no
+// lock, while housekeeping compacts. Before published generations were made
+// immutable, compaction's PruneTombstonesAtOrBelow deleted entries from
+// m.state's maps IN PLACE -- and CloneStateForBatch shares the entity map of
+// any kind a batch does not touch, so that delete reached back into every
+// older generation a baseline might still be walking. The detector fires on
+// `delete(state.GetNodes(), id)` versus the walk's range.
+func TestFallbackBaselineRacesCompaction(t *testing.T) {
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 230_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// A FRESH tombstone every pass, not a fixed seed set.
+	//
+	// Seeding four tombstones once and then churning position ops gave the
+	// detector a single burst of deletes to catch: PruneTombstonesAtOrBelow
+	// removes all four on the first compaction, and SetNodeRegister ops create
+	// no more, so every later pass pruned zero entries and issued no `delete` at
+	// all. The window this test exists to hit was one early moment rather than
+	// the whole run. Tombstoning a new tab each iteration keeps a delete racing
+	// the baseline walks for the full 200ms.
+	//
+	// Tombstoning also advances max_hlc, which is what keeps maybeCompact's
+	// pre-check from short-circuiting.
+	churnErr := make(chan error, 1)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			if err := submitTombstonedTab(t, context.Background(), mgr, "churn-"+strconv.Itoa(i)); err != nil {
+				select {
+				case churnErr <- err:
+				default:
+				}
+				return
+			}
+			mgr.TickHousekeeping(context.Background())
+		}
+	}()
+
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				sub := &crdt.Subscriber{UserID: "user-1", Send: (&captureSubscriber{}).send}
+				out, err := mgr.SubscribeWithACL(context.Background(), sub, nil, 0, resolveAll)
+				if err != nil {
+					continue
+				}
+				out.Unsub()()
+			}
+		}()
+	}
+
+	time.Sleep(200 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+	select {
+	case err := <-churnErr:
+		// Without this the churn goroutine could die on its first submit and the
+		// test would still pass, having raced nothing at all.
+		t.Fatalf("the compaction churn stopped early, so nothing was raced: %v", err)
+	default:
+	}
+}

--- a/backend/internal/hub/crdt/manager_integration_test.go
+++ b/backend/internal/hub/crdt/manager_integration_test.go
@@ -22,7 +22,10 @@ import (
 // context. The injected `now` advances by 1ms per call so every
 // heartbeat / submit gets a strictly-fresh timestamp; this keeps the
 // presence-leader logic (which requires strict-ahead) deterministic.
-func runManager(t *testing.T, userID string, auth crdt.AuthChecker, nowSeed int64, opts ...crdt.ManagerOption) (*crdt.Manager, *fakeJournal, context.CancelFunc) {
+// Takes testing.TB rather than *testing.T so the benchmarks in
+// manager_subscribe_bench_test.go drive the same harness the tests do; every
+// call below (Helper, Cleanup, require) is satisfied by the interface.
+func runManager(t testing.TB, userID string, auth crdt.AuthChecker, nowSeed int64, opts ...crdt.ManagerOption) (*crdt.Manager, *fakeJournal, context.CancelFunc) {
 	t.Helper()
 	j := newFakeJournal()
 	var (
@@ -66,7 +69,7 @@ func runManager(t *testing.T, userID string, auth crdt.AuthChecker, nowSeed int6
 // same shape as the production applyLifecycleCreate seed. Routing the record
 // seed through SubmitInternal keeps the manager goroutine the sole writer of
 // m.state (no off-goroutine MutateInternal write).
-func seedRootInternal(t *testing.T, mgr *crdt.Manager, workspaceID, rootID string) {
+func seedRootInternal(t testing.TB, mgr *crdt.Manager, workspaceID, rootID string) {
 	t.Helper()
 	setRegister := &leapmuxv1.CrdtOp{
 		OpId: "seed-workspace-register-" + workspaceID,
@@ -257,7 +260,7 @@ func TestManager_SeedStateForTest_RunsOnManagerGoroutine(t *testing.T) {
 	// manager goroutine — serialized with the client submits, never racing them.
 	// The final iteration leaves a sentinel workspace in place (no paired
 	// delete) so the post-condition assertion below is non-tautological: a
-	// buggy seedCh arm that silently dropped fn would leave the sentinel
+	// buggy taskCh arm that silently dropped fn would leave the sentinel
 	// absent, failing the test, instead of the absence-of-churned check
 	// passing whether or not seeds applied.
 	const sentinel = "seed-sentinel"
@@ -293,7 +296,7 @@ func TestManager_SeedStateForTest_RunsOnManagerGoroutine(t *testing.T) {
 }
 
 // TestManager_SeedStateForTest_PreStart covers the pre-Start branch
-// (started=false): SeedStateForTest runs fn directly under m.mu.Lock, mirroring
+// (started=false): SeedStateForTest runs fn on the calling goroutine, against a clone it then publishes, mirroring
 // Bootstrap's no-concurrent-reader assumption. This is the registry-factory
 // shape, where state is seeded before the goroutine launches.
 func TestManager_SeedStateForTest_PreStart(t *testing.T) {

--- a/backend/internal/hub/crdt/manager_lifecycle.go
+++ b/backend/internal/hub/crdt/manager_lifecycle.go
@@ -369,16 +369,22 @@ func (m *Manager) applyLifecycleDelete(ctx context.Context, row LifecycleOutboxR
 	// deleted (Rule 15 — every live parentless node must be a
 	// registered root).
 	wsID := p.WorkspaceID
-	// Walk the live state under m.mu.RLock — the enumeration is a
-	// single synchronous pass, so the lock is held only for the walk
-	// itself. A bare read of m.state from this (request-handler)
-	// goroutine would race with the manager goroutine's writes under
-	// m.mu.Lock(); cloning via m.State() would allocate a multi-MB copy
-	// of every workspace just to enumerate one.
-	var enumOps []*leapmuxv1.CrdtOp
-	m.WithStateRLock(func(state *leapmuxv1.UserCrdtState) {
-		enumOps = enumerateWorkspaceDeleteOps(state, wsID)
-	})
+	// CAPTURE the published generation, then walk it holding NOTHING.
+	//
+	// The enumeration is O(all the user's entities) — BuildLiveChildrenIndex
+	// ranges every node, and the sweeps under it range every tab and floating
+	// window — and it runs on a request-handler goroutine. Holding m.mu.RLock
+	// across it blocks commitState (which takes m.mu.Lock), i.e. the manager
+	// goroutine: the same stall the FALLBACK baseline was restructured to
+	// remove, on a rarer path.
+	//
+	// The capture is safe for the same reason that one is: a PUBLISHED
+	// generation is never mutated (see commitState), so what escapes is a
+	// stable point-in-time value rather than a live view, and this walk is
+	// strictly read-only over it. A bare read of m.state would still race the
+	// manager's writes; State() would deep-clone every workspace just to
+	// enumerate one.
+	enumOps := enumerateWorkspaceDeleteOps(m.capturedState(), wsID)
 	combined := make([]*leapmuxv1.CrdtOp, 0, len(ops)+len(enumOps)+1)
 	combined = append(combined, ops...)
 	combined = append(combined, enumOps...)

--- a/backend/internal/hub/crdt/manager_registry.go
+++ b/backend/internal/hub/crdt/manager_registry.go
@@ -153,10 +153,10 @@ func (r *Registry) Get(ctx context.Context, userID string) (*Manager, error) {
 	}()
 	// Wait until the goroutine has started servicing the select loop before
 	// handing the manager out. SeedStateForTest's post-Start branch routes a
-	// seed through seedCh, which only the manager goroutine drains -- without
+	// seed through taskCh, which only the manager goroutine drains -- without
 	// this wait, Get would return with the goroutine spawned but not yet
 	// servicing, and a caller that won the race to read started()==closed
-	// (set inside Start) could route through seedCh before the receiver
+	// (set inside Start) could route through taskCh before the receiver
 	// existed. The wait also guarantees any caller observing the manager
 	// post-Get sees started() closed, so its SeedStateForTest takes the
 	// goroutine-routed branch instead of the pre-Start direct-write branch

--- a/backend/internal/hub/crdt/manager_subscribe.go
+++ b/backend/internal/hub/crdt/manager_subscribe.go
@@ -43,9 +43,8 @@ import (
 // resolve's error is returned unregistered so the caller can reject the
 // connection before streaming any events. Lock order
 // subscribeExpandMu -> projection -> m.mu is preserved on every path where
-// more than one is held (the FALLBACK arms hold subscribeExpandMu + projection
-// across the register; Subscribe, called from the FALLBACK seam, takes only
-// projection and m.mu).
+// more than one is held (both arms hold subscribeExpandMu across a register
+// window that itself takes projection and then m.mu).
 //
 // RESUME: when the cursor is non-zero, above op_retention_watermark (the
 // lagging floor below which op batches may have been deleted), and the
@@ -101,7 +100,38 @@ import (
 // delta exceeds MaxResumeDeltaFrameBytes (the wire-frame gate in
 // buildResumeDelta), this returns a SubscribeOutcome whose Mode is
 // SubscribeInitial (carrying the full UserMaterialized snapshot the caller sends
-// as the `initial` frame).
+// as the `initial` frame). SubscribeOutcome.Reason() names which of those fired.
+//
+// The FALLBACK arm holds NO manager lock across its O(all-entities) baseline
+// either. registerForFallback takes m.projection and m.mu.RLock for an O(1)
+// window -- register the subscriber, capture the published generation, set
+// resumeSuppressThrough from that generation's max_hlc -- and releases both;
+// materializedFromState then walks the captured generation, which is immutable
+// (see commitState), holding nothing. registerForFallback's doc carries the
+// no-gap / no-duplicate proof.
+//
+// The one exception is the park-overflow ladder's terminal rung
+// (lockedFallbackOutcome), which holds m.projection across its walk on purpose:
+// that is what makes overflow impossible there and the ladder finite. It is
+// reached only after fallbackLockFreeAttempts consecutive overflows.
+//
+// subscribeExpandMu is likewise released after the register, not held across
+// the baseline. A concurrent lifecycle op can then mutate sub.Filter while the
+// baseline is being built from the Add-captured copy, and both directions are
+// still correct:
+//
+//   - CREATE expands filters BEFORE broadcasting the seed batch
+//     (applyLifecycleCreate), and we registered first, so the expand sees us.
+//     The seed batch's HLC is above the captured generation's max_hlc, so it
+//     arrives live. The baseline omits the new workspace, which is right --
+//     it had no pre-existing entities.
+//   - DELETE submits and broadcasts the tombstone batch and only then contracts
+//     (applyLifecycleDelete). A tombstone below the baseline is already
+//     reflected in it; one above it is broadcast to us.
+//
+// SubscriberFilter's replace-don't-mutate discipline plus cloneSubscriber's
+// deep copy make the captured filter a private, race-free value -- the same
+// argument the RESUME arm already relies on.
 func (m *Manager) SubscribeWithACL(
 	ctx context.Context,
 	sub *Subscriber,
@@ -112,82 +142,74 @@ func (m *Manager) SubscribeWithACL(
 	// Lock plan (release order matters — see the lock-ordering note on the
 	// type). subscribeExpandMu closes the resolve→register TOCTOU with
 	// ExpandSubscribersForWorkspace; it is needed ONLY across resolve + the
-	// register/FALLBACK decision, then RELEASED before the RESUME tail read so
-	// a reconnect's (potentially multi-page) DB scan does not stall that
-	// user's workspace-create/delete lifecycle RPCs. m.projection serializes
-	// the FALLBACK arm's register+materialized-baseline against broadcasts
-	// (the Subscribe invariant), and on the RESUME arm is held only across the
-	// brief until-capture+register window (so broadcastBatch cannot dual-
-	// deliver a batch that also lands inside until). The RESUME scan itself
-	// does NOT hold m.projection — registration order plus
-	// resumeSuppressThrough close the straddle, and releasing projection for
-	// the scan means a reconnect no longer stalls every other tab's live
-	// commit broadcasts for the scan's duration.
-	// The locked section is a closure so its unlocks run via defer. resolve()
-	// reaches the store, and net/http RECOVERS a handler panic and keeps the
-	// process serving -- so a panic under subscribeExpandMu would leak it and
-	// wedge every later /ws/userevents connect plus every workspace
-	// create/delete for this user, silently and until restart. Explicit unlocks
-	// cover the return paths; only defer covers the unwind.
-	// out stays at its zero value (mode subscribeModeInvalid) unless the FALLBACK
-	// arm fills it in, so its mode IS the record of which arm ran -- no separate
-	// bool to keep in step with it.
-	var (
-		out    SubscribeOutcome
-		until  *leapmuxv1.HLC
-		filter SubscriberFilter
-	)
+	// register window, then RELEASED before the expensive part of EITHER arm --
+	// the RESUME tail read and the FALLBACK baseline build -- so neither stalls
+	// that user's workspace-create/delete lifecycle RPCs.
+	//
+	// m.projection is likewise held only across a brief register window on both
+	// arms: the until-capture+register on RESUME, and the
+	// generation-capture+register on FALLBACK (plus, on a rebaseline, the
+	// discard of the superseded parked frames). Neither the tail read nor the
+	// baseline build holds it -- except on the park-overflow ladder's terminal
+	// rung, which holds m.projection deliberately; see fallbackOutcome. On both
+	// arms the straddle is closed by
+	// REGISTRATION ORDER plus resumeSuppressThrough rather than by holding the
+	// lock, which is what keeps a connect from stalling every other tab's live
+	// commit broadcasts for its duration.
+	// The RESUME arm's locked section below is a closure so its unlock runs via
+	// defer (the FALLBACK arm's lives in resolveAndRegisterForFallback, which
+	// does the same). resolve() reaches the store, and net/http RECOVERS a
+	// handler panic and keeps the process serving -- so a panic under
+	// subscribeExpandMu would leak it and wedge every later /ws/userevents
+	// connect plus every workspace create/delete for this user, silently and
+	// until restart.
+	//
+	// The verdict reads only m.state, so it needs neither subscribeExpandMu nor
+	// the resolved filter. Deciding first lets the FALLBACK arm delegate the
+	// whole lock dance -- resolve, register, release, build -- to fallbackOutcome,
+	// which is also where the RESUME->FALLBACK re-entry lands, so both fallbacks
+	// go through one seam with one lock plan instead of two.
+	if resume, reason := m.decideResume(cursor, clientEpoch); !resume {
+		return m.fallbackOutcome(sub, resolve, fallbackCold, reason)
+	}
+
+	var reg registration
 	if err := func() error {
 		m.subscribeExpandMu.Lock()
 		defer m.subscribeExpandMu.Unlock()
 
-		allowed, err := resolve()
-		if err != nil {
+		// Through the same helper both FALLBACK rungs use, so all THREE
+		// resolve-then-install sites have one spelling and the "caller MUST hold
+		// subscribeExpandMu" contract has one home.
+		if err := m.resolveFilter(sub, resolve); err != nil {
 			return err
 		}
-		sub.Filter = NewSubscriberFilter(allowed)
 
-		if !m.decideResume(cursor, clientEpoch) {
-			// FALLBACK: identical to Subscribe (full snapshot under projection +
-			// m.mu.RLock). subscribeLocked needs m.projection held across the
-			// register+materialized clone so the baseline cannot straddle a
-			// concurrent broadcast's filter mutation — the same reason Subscribe
-			// holds it. subscribeExpandMu stays held through the register to keep
-			// the expand TOCTOU closed. LIFO defer order preserves the
-			// projection-then-expand release order the lock plan requires.
-			m.projection.Lock()
-			defer m.projection.Unlock()
-			out = m.fallbackOutcome(sub)
-			return nil
-		}
-
-		// RESUME: register the subscriber via the same seam Subscribe/FALLBACK
-		// use (so the presence-refcount invariant has one home), then build the
-		// delta. subscribeLocked would also compute a materialized snapshot the
-		// resume does not need, so call only its register half.
+		// RESUME: register the subscriber via the same seam the FALLBACK arm
+		// uses (so the presence-refcount invariant has one home), then build the
+		// delta. The FALLBACK seam would also compute a materialized baseline
+		// the resume does not need, so call only its register half.
 		// subscribeExpandMu is still held so the register stays serialized
 		// against a concurrent expand; it is released on return from this
 		// closure, before buildResumeDelta's DB scan.
-		until, filter = m.registerForResume(sub)
+		reg = m.registerForResume(sub)
 		return nil
 	}(); err != nil {
 		return SubscribeOutcome{}, err
 	}
-	if out.Mode() == SubscribeInitial {
-		return out, nil
-	}
 
-	// buildResumeDelta owns the unsub handle (makeUnsub is idempotent, so it
-	// doubles as teardown for the FALLBACK re-entry the caller performs).
-	// buildResumeDelta returns a resumeScanResult; the caller (this function)
-	// owns the FALLBACK re-entry, so buildResumeDelta no longer takes the
-	// resolve/unsub teardown callbacks.
+	// The register window owns the unsub handle and hands it over (makeUnsub is
+	// idempotent, so it doubles as teardown for the FALLBACK re-entry the caller
+	// performs). buildResumeDelta returns a resumeScanResult; the caller (this
+	// function) owns the FALLBACK re-entry, so buildResumeDelta no longer takes
+	// the resolve/unsub teardown callbacks.
 	req := resumeRequest{
 		sub:         sub,
-		filter:      filter,
+		filter:      reg.filter,
 		cursor:      cursor,
-		until:       until,
+		until:       reg.maxHLC,
 		clientEpoch: clientEpoch,
+		unsub:       reg.unsub,
 	}
 	res := m.buildResumeDelta(ctx, req)
 	switch res.kind {
@@ -197,7 +219,7 @@ func (m *Manager) SubscribeWithACL(
 		// buildResumeDelta signaled FALLBACK (over-budget / corrupt / post-scan
 		// compaction-or-epoch drift). It already tore down the registration;
 		// re-enter the FALLBACK seam, which re-resolves + re-registers fresh.
-		return m.resumeFallback(sub, resolve)
+		return m.fallbackOutcome(sub, resolve, fallbackRebaseline, res.reason)
 	case resumeScanError:
 		// The registration is already torn down (unsub fired inside
 		// buildResumeDelta); surface the connect failure.
@@ -209,7 +231,8 @@ func (m *Manager) SubscribeWithACL(
 	}
 }
 
-// decideResume is the RESUME-vs-FALLBACK verdict against live state: the cursor
+// decideResume is the RESUME-vs-FALLBACK verdict against live state, plus the
+// REASON it said no: the cursor
 // is non-zero, strictly above op_retention_watermark (the lagging floor below
 // which op batches may have been deleted, so the journal can no longer
 // reconstruct the delta), and the client's epoch matches the live epoch.
@@ -222,9 +245,22 @@ func (m *Manager) SubscribeWithACL(
 // runs at compaction_watermark). Read under a brief m.mu.RLock; the post-scan
 // re-check in buildResumeDelta re-validates because the unlocked scan can race
 // a compaction or epoch bump (see buildResumeDelta).
-func (m *Manager) decideResume(cursor *leapmuxv1.HLC, clientEpoch int64) bool {
+//
+// The reason exists because the predicate used to be one collapsed boolean,
+// which meant the production answer to "why is this deployment
+// full-snapshotting?" was unobtainable: a no-cursor first connect, a client
+// dormant past the retention floor and a stale epoch are three different
+// operational stories with three different fixes, and they were
+// indistinguishable. It rides on SubscribeOutcome to the service layer, which
+// labels the metric. The verdict itself is unchanged.
+//
+// This name is the codebase's canonical term for the predicate — it is cited by
+// name from the journal wire format, the op-batch SQL, the retention sweep and
+// the frontend's pendingOps/checkpointStore — so it stays attached to the code
+// that actually implements it rather than to a wrapper.
+func (m *Manager) decideResume(cursor *leapmuxv1.HLC, clientEpoch int64) (bool, SubscribeReason) {
 	if cursor == nil || HLCIsZero(cursor) {
-		return false
+		return false, SubscribeReasonNoCursor
 	}
 	// Retention floor, applied ALONGSIDE the stored watermark.
 	//
@@ -242,8 +278,13 @@ func (m *Manager) decideResume(cursor *leapmuxv1.HLC, clientEpoch int64) bool {
 	//
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	return HLCCmp(cursor, m.opRetentionFloorLocked()) > 0 &&
-		clientEpoch == m.state.GetCurrentEpoch()
+	if HLCCmp(cursor, m.opRetentionFloorLocked()) <= 0 {
+		return false, SubscribeReasonBelowRetentionFloor
+	}
+	if clientEpoch != m.state.GetCurrentEpoch() {
+		return false, SubscribeReasonStaleEpoch
+	}
+	return true, SubscribeReasonResumed
 }
 
 // opRetentionFloorLocked returns the effective HLC floor a resume cursor must
@@ -315,23 +356,10 @@ func (m *Manager) opRetentionFloorLocked() *leapmuxv1.HLC {
 // high-water and a snapshot of the subscriber's filter safe to hand to the
 // (lock-free) resume scan (SubscriberFilter is immutable after install — see
 // its type doc).
-func (m *Manager) registerForResume(sub *Subscriber) (until *leapmuxv1.HLC, filter SubscriberFilter) {
+func (m *Manager) registerForResume(sub *Subscriber) registration {
 	m.projection.Lock()
 	defer m.projection.Unlock()
-	// BOTH unlocks are deferred, for the reason SubscribeWithACL's lock plan
-	// gives: a recovered handler panic leaves the process serving, so a read
-	// lock leaked while unwinding out of registerSubscriber (which reaches
-	// subscribers.Add and presenceCtl.OnConnect) would block every later
-	// commitState, decideResume and materializedLocked for this user forever.
-	func() {
-		m.mu.RLock()
-		defer m.mu.RUnlock()
-		until = HLCClone(m.state.GetMaxHlc())
-		sub.resumeSuppressThrough = until
-		m.registerSubscriber(sub)
-	}()
-	filter = sub.Filter
-	return until, filter
+	return m.registerLocked(sub)
 }
 
 // resumeRequest bundles the lock-free resume scan's inputs, keeping the
@@ -343,6 +371,12 @@ type resumeRequest struct {
 	cursor      *leapmuxv1.HLC
 	until       *leapmuxv1.HLC
 	clientEpoch int64
+	// unsub is the register window's handle, carried rather than re-minted.
+	// makeUnsub returns a FRESH sync.Once per call, so two handles over one
+	// subscriber would each be free to decrement the presence refcount -- the
+	// underflow makeUnsub's own idempotence exists to prevent, reintroduced by
+	// having two of them.
+	unsub func()
 }
 
 // resumeScanKind discriminates the three outcomes buildResumeDelta can report.
@@ -371,9 +405,30 @@ const (
 // buildResumeDelta has already torn the registration down, and the caller
 // re-resolves and re-registers from scratch).
 type resumeScanResult struct {
-	kind    resumeScanKind
+	kind resumeScanKind
+	// reason is set on resumeScanFallback and names which of the four post-scan
+	// give-ups fired, so the caller can label the FALLBACK it re-enters. Unset
+	// on the other kinds, which carry their verdict in `outcome` / `err`.
+	//
+	// Always populate it via newResumeScanFallback, never by struct literal.
+	reason  SubscribeReason
 	outcome SubscribeOutcome
 	err     error
+}
+
+// newResumeScanFallback is the ONLY way to build a resumeScanFallback result.
+//
+// It exists because the reason is the whole point of the enum and a struct
+// literal makes it optional: an arm that omitted `reason:` compiled fine and
+// shipped the zero subscribeReasonInvalid all the way to
+// leapmux_userevents_subscribe_total{reason="invalid"} — an unnamed bucket for
+// the exact defect class the label was added to surface, indistinguishable from
+// a construction bug. Requiring it as an ARGUMENT makes that omission a compile
+// error at every one of the four give-up arms instead of a silent mislabel.
+// (newSubscribeInitialOutcome takes its reason the same way, for the same
+// reason.)
+func newResumeScanFallback(reason SubscribeReason) resumeScanResult {
+	return resumeScanResult{kind: resumeScanFallback, reason: reason}
 }
 
 // buildResumeDelta constructs the RESUME outcome for an already-registered
@@ -392,11 +447,11 @@ type resumeScanResult struct {
 // over-budget / corrupt / post-scan compaction-or-epoch invalidation / a built
 // delta over MaxResumeDeltaFrameBytes, this tears down the registration (unsub)
 // and returns a bare resumeScanFallback (which carries no payload -- the caller
-// re-resolves and re-registers from scratch through resumeFallback); on a hard
+// re-resolves and re-registers from scratch through fallbackOutcome); on a hard
 // tail-read error it tears down + returns the error; on success it returns the
 // delta outcome.
 func (m *Manager) buildResumeDelta(ctx context.Context, req resumeRequest) resumeScanResult {
-	unsub := makeUnsub(req.sub, m)
+	unsub := req.unsub
 	// Page the post-cursor tail out of the journal, capped at the register-time
 	// high-water (`until`). ctx is the request context: a client disconnect
 	// cancels it and aborts the (potentially multi-page, up to MaxResumeDeltaOps)
@@ -433,9 +488,13 @@ func (m *Manager) buildResumeDelta(ctx context.Context, req resumeRequest) resum
 	// checkpoint). A snapshot is always complete.
 	if errors.Is(tailErr, ErrDeltaTooLarge) || errors.Is(tailErr, ErrResumeCorrupt) {
 		// Signal FALLBACK to the caller, which owns re-entry. Tear down first
-		// so resumeFallback's re-register does not double-register.
+		// so the fallback seam's re-register does not double-register.
+		reason := SubscribeReasonTailOverBudget
+		if errors.Is(tailErr, ErrResumeCorrupt) {
+			reason = SubscribeReasonCorruptRow
+		}
 		unsub()
-		return resumeScanResult{kind: resumeScanFallback}
+		return newResumeScanFallback(reason)
 	}
 	if tailErr != nil {
 		unsub()
@@ -447,9 +506,17 @@ func (m *Manager) buildResumeDelta(ctx context.Context, req resumeRequest) resum
 	// client would adopt max_hlc while missing compacted-away ops. Re-check the
 	// resumable predicate against live state; if the cursor is no longer above
 	// the watermark (or the epoch moved), signal FALLBACK.
-	if !m.decideResume(req.cursor, req.clientEpoch) {
+	if resume, drifted := m.decideResume(req.cursor, req.clientEpoch); !resume {
+		// The LABEL stays post_scan_drift -- "the verdict was invalidated during
+		// the unlocked scan" is a different operational story from a verdict
+		// that was already stale when it was taken, and collapsing them would
+		// lose that. But WHICH way it drifted (a compaction ate the tail, or the
+		// epoch bumped) has different fixes, so it is logged rather than
+		// discarded. This is also the only give-up arm that logged nothing.
+		m.logger.Warn("resume verdict drifted during the tail scan; falling back to a snapshot",
+			"drifted_to", drifted, "client_id", req.sub.ClientID)
 		unsub()
-		return resumeScanResult{kind: resumeScanFallback}
+		return newResumeScanFallback(SubscribeReasonPostScanDrift)
 	}
 	// The transport could not buffer a live frame while this scan ran, so the
 	// delta it is about to ship would be missing whatever it dropped. FALLBACK
@@ -458,14 +525,19 @@ func (m *Manager) buildResumeDelta(ctx context.Context, req resumeRequest) resum
 	// rebuild the same multi-page scan under the same load.
 	//
 	// Checked HERE, after the scan and before any frame is built, because
-	// resumeFallback re-registers and calls OnRebaseline -- which discards the
+	// the fallback seam re-registers and calls OnRebaseline -- which discards the
 	// parked buffer -- before taking the snapshot baseline. A frame dropped
 	// during the scan is therefore superseded by that snapshot, not lost.
+	//
+	// The reason must be stated HERE and cannot be re-derived downstream:
+	// fallbackOutcome's own overflow re-check runs AFTER registerForFallback has
+	// called OnRebaseline, and the real transport's Rebaseline clears the flag —
+	// so by the time that check runs, the drop this arm observed is invisible.
 	if req.sub.overflowed() {
 		m.logger.Warn("resume subscriber overflowed its park buffer during the scan; falling back to a snapshot",
 			"client_id", req.sub.ClientID)
 		unsub()
-		return resumeScanResult{kind: resumeScanFallback}
+		return newResumeScanFallback(SubscribeReasonParkOverflow)
 	}
 
 	// Build the ordered resume frame stream via the SAME emitCatchUpFrames
@@ -539,7 +611,7 @@ func (m *Manager) buildResumeDelta(ctx context.Context, req resumeRequest) resum
 		// Same teardown as the over-budget scan arm: the caller owns FALLBACK
 		// re-entry and re-registers from scratch.
 		unsub()
-		return resumeScanResult{kind: resumeScanFallback}
+		return newResumeScanFallback(SubscribeReasonDeltaOverFrameCeiling)
 	}
 	return resumeScanResult{kind: resumeScanDelta, outcome: newSubscribeDeltaOutcome(delta, unsub)}
 }
@@ -607,42 +679,49 @@ func (m *Manager) departedWorkspaces(filter SubscriberFilter, requested map[stri
 	return candidates
 }
 
-// resumeFallback re-enters the FALLBACK seam (full snapshot) after a resume
-// scan gave up. buildResumeDelta has ALREADY torn down the RESUME registration
-// on every path that reaches here, so this only re-registers.
+// resolveAndRegisterForFallback is one register window of the FALLBACK seam:
+// resolve the ACL and register, atomically with respect to a concurrent
+// ExpandSubscribersForWorkspace, then RELEASE subscribeExpandMu so the caller
+// can build the baseline without it.
 //
-// resolve runs again under subscribeExpandMu so the snapshot filter reflects
-// the current ACL — the filter installed at the earlier resolve may have been
-// expand/contract-mutated while the subscriber was registered, and a stale copy
-// must not seed the FALLBACK baseline.
-func (m *Manager) resumeFallback(
+// resolve runs on EVERY attempt, not once: the filter installed by an earlier
+// resolve may have been expand/contract-mutated while the subscriber was
+// registered, and a stale copy must not seed the baseline. It is also what
+// keeps the resolve→register TOCTOU closed on a ladder RETRY, which unregisters
+// and re-registers -- a window an expand would otherwise slip through.
+//
+// The lock is taken here rather than by the caller so the whole loop in
+// fallbackOutcome cannot accidentally hold it across a baseline: there is no
+// call path that holds subscribeExpandMu on entry.
+func (m *Manager) resolveAndRegisterForFallback(
 	sub *Subscriber,
 	resolve func() (map[string]bool, error),
-) (SubscribeOutcome, error) {
+	entry fallbackEntry,
+) (registration, error) {
 	// Same panic-safety reasoning as SubscribeWithACL: resolve() reaches the
-	// store and a recovered handler panic must not leak either lock.
+	// store and a recovered handler panic must not leak the lock.
 	m.subscribeExpandMu.Lock()
 	defer m.subscribeExpandMu.Unlock()
 
+	if err := m.resolveFilter(sub, resolve); err != nil {
+		return registration{}, err
+	}
+	return m.registerForFallback(sub, entry), nil
+}
+
+// resolveFilter re-resolves the ACL and installs it on sub.
+//
+// Caller MUST hold subscribeExpandMu — that is what makes resolve→register
+// atomic against a concurrent ExpandSubscribersForWorkspace. Split out so all
+// three resolve-then-register sites -- the RESUME arm and the fallback ladder's
+// lock-free and escalated rungs -- share one spelling of the pair.
+func (m *Manager) resolveFilter(sub *Subscriber, resolve func() (map[string]bool, error)) error {
 	allowed, err := resolve()
 	if err != nil {
-		return SubscribeOutcome{}, err
+		return err
 	}
 	sub.Filter = NewSubscriberFilter(allowed)
-	// Clear the resume suppress gate: FALLBACK re-registers fresh and must
-	// receive every live broadcast after the snapshot baseline.
-	sub.resumeSuppressThrough = nil
-	m.projection.Lock()
-	defer m.projection.Unlock()
-	// Discard anything the transport queued during the resume scan BEFORE the
-	// baseline is taken. Those frames predate the snapshot, and the client
-	// applies entity_materialized / entity_removed wholesale, so writing them
-	// after it would resurrect stale records permanently. Both calls sit under
-	// m.projection, so no broadcast can slip between the discard and the clone.
-	if sub.OnRebaseline != nil {
-		sub.OnRebaseline()
-	}
-	return m.fallbackOutcome(sub), nil
+	return nil
 }
 
 // SubscribeMode discriminates which bootstrap frame SubscribeOutcome carries.
@@ -674,6 +753,149 @@ const (
 	SubscribeInitial
 )
 
+// SubscribeReason says WHY a connect got the bootstrap arm it did.
+//
+// Mode alone answers "snapshot or delta"; this answers "and why", which is the
+// question an operator actually has. The two are carried together on
+// SubscribeOutcome so the service layer can label one metric with both without
+// re-deriving anything, and so a fallback whose cause is a corrupt journal row
+// is distinguishable from one whose cause is a client that was simply away for
+// two days.
+type SubscribeReason int
+
+const (
+	// subscribeReasonInvalid is the ZERO VALUE and deliberately not a real
+	// reason, for the same purpose as subscribeModeInvalid and
+	// resumeScanInvalid: a construction path that forgets to set the reason
+	// reports "invalid" rather than silently claiming the first real arm.
+	subscribeReasonInvalid SubscribeReason = iota
+	// SubscribeReasonResumed: the cursor was honored and a delta shipped.
+	SubscribeReasonResumed
+	// SubscribeReasonNoCursor: no cursor presented (a first-ever connect, or a
+	// client whose confirmed state is empty so its cursor would be meaningless).
+	SubscribeReasonNoCursor
+	// SubscribeReasonBelowRetentionFloor: the cursor sits at or below
+	// op_retention_watermark, so the journal can no longer reconstruct the
+	// delta. The dormant-client case.
+	SubscribeReasonBelowRetentionFloor
+	// SubscribeReasonStaleEpoch: the client's epoch no longer matches the hub's.
+	SubscribeReasonStaleEpoch
+	// SubscribeReasonTailOverBudget: the post-cursor tail exceeded
+	// MaxResumeDeltaOps / MaxResumeDeltaBytes.
+	SubscribeReasonTailOverBudget
+	// SubscribeReasonDeltaOverFrameCeiling: the BUILT delta exceeded
+	// MaxResumeDeltaFrameBytes, the wire-frame gate.
+	SubscribeReasonDeltaOverFrameCeiling
+	// SubscribeReasonCorruptRow: a journal row in the tail failed to decode.
+	SubscribeReasonCorruptRow
+	// SubscribeReasonPostScanDrift: a compaction or epoch bump landed during
+	// the (lock-free) tail scan and invalidated the verdict.
+	SubscribeReasonPostScanDrift
+	// SubscribeReasonParkOverflow: the transport dropped a frame parked during
+	// the resume scan, so the delta would have shipped over a hole.
+	SubscribeReasonParkOverflow
+
+	// subscribeReasonMax is a NON-REASON sentinel and MUST stay last. Add new
+	// reasons above it.
+	//
+	// It exists so the vocabulary test can walk every declared member without
+	// restating whichever one is currently last. Bounding that walk by the last
+	// real member made it blind to the normal way the enum grows: a reason
+	// APPENDED after the bound was never visited, so forgetting its String() arm
+	// left the test green and shipped "SubscribeReason(10)" as a Prometheus
+	// label value that no dashboard matches.
+	subscribeReasonMax
+)
+
+// Label is the metric-label spelling of the reason: a stable, lowercase,
+// snake_case vocabulary. These ARE Prometheus label values, so renaming one
+// breaks dashboards.
+//
+// Separate from String() for the same reason SubscribeMode.Label() is, and the
+// separation matters more here. String() is what %v and slog reach for
+// implicitly, so while the vocabulary lived on String() a purely cosmetic edit
+// to how a reason PRINTS would silently rename a dashboard label -- exactly the
+// coupling SubscribeMode.Label() was introduced to break, left in place on the
+// enum with eight arms and the one that will grow.
+func (r SubscribeReason) Label() string {
+	switch r {
+	case subscribeReasonInvalid:
+		return "invalid"
+	case SubscribeReasonResumed:
+		return "resumed"
+	case SubscribeReasonNoCursor:
+		return "no_cursor"
+	case SubscribeReasonBelowRetentionFloor:
+		return "below_retention_floor"
+	case SubscribeReasonStaleEpoch:
+		return "stale_epoch"
+	case SubscribeReasonTailOverBudget:
+		return "tail_over_budget"
+	case SubscribeReasonDeltaOverFrameCeiling:
+		return "delta_over_frame_ceiling"
+	case SubscribeReasonCorruptRow:
+		return "corrupt_row"
+	case SubscribeReasonPostScanDrift:
+		return "post_scan_drift"
+	case SubscribeReasonParkOverflow:
+		return "park_overflow"
+	default:
+		return fmt.Sprintf("reason_%d", int(r))
+	}
+}
+
+// String names the Go constant, so a log line or a %v reads
+// "SubscribeReasonNoCursor" beside "SubscribeInitial" rather than mixing a
+// metric vocabulary into Go-facing text. One rule across both enums: String()
+// is Go-facing, Label() is metric-facing.
+func (r SubscribeReason) String() string {
+	switch r {
+	case subscribeReasonInvalid:
+		return "SubscribeReason(invalid)"
+	case SubscribeReasonResumed:
+		return "SubscribeReasonResumed"
+	case SubscribeReasonNoCursor:
+		return "SubscribeReasonNoCursor"
+	case SubscribeReasonBelowRetentionFloor:
+		return "SubscribeReasonBelowRetentionFloor"
+	case SubscribeReasonStaleEpoch:
+		return "SubscribeReasonStaleEpoch"
+	case SubscribeReasonTailOverBudget:
+		return "SubscribeReasonTailOverBudget"
+	case SubscribeReasonDeltaOverFrameCeiling:
+		return "SubscribeReasonDeltaOverFrameCeiling"
+	case SubscribeReasonCorruptRow:
+		return "SubscribeReasonCorruptRow"
+	case SubscribeReasonPostScanDrift:
+		return "SubscribeReasonPostScanDrift"
+	case SubscribeReasonParkOverflow:
+		return "SubscribeReasonParkOverflow"
+	default:
+		return fmt.Sprintf("SubscribeReason(%d)", int(r))
+	}
+}
+
+// Label is the metric-label spelling of the arm, in the same lowercase
+// vocabulary SubscribeReason.String() uses.
+//
+// Separate from String() on purpose: String() feeds the wrong-access panic
+// messages, which read better naming the Go constant ("Delta() called in
+// SubscribeInitial mode"), while this feeds a Prometheus label, where a Go
+// identifier would be out of place next to reason="no_cursor". Renaming either
+// one must not silently rename the other -- a label rename breaks dashboards.
+func (m SubscribeMode) Label() string {
+	switch m {
+	case SubscribeDelta:
+		return "delta"
+	case SubscribeInitial:
+		return "initial"
+	case subscribeModeInvalid:
+		return "invalid"
+	default:
+		return fmt.Sprintf("mode_%d", int(m))
+	}
+}
+
 // String names the arm so a wrong-access panic (Delta()/Initial() on the
 // non-matching arm) reports the arm textually instead of an opaque integer.
 func (m SubscribeMode) String() string {
@@ -699,6 +921,7 @@ func (m SubscribeMode) String() string {
 // contract lived in prose rather than the type.
 type SubscribeOutcome struct {
 	mode    SubscribeMode
+	reason  SubscribeReason
 	delta   *leapmuxv1.ResumeDelta
 	initial *leapmuxv1.UserMaterialized
 	unsub   func()
@@ -706,6 +929,10 @@ type SubscribeOutcome struct {
 
 // Mode reports which bootstrap arm this outcome selected.
 func (o SubscribeOutcome) Mode() SubscribeMode { return o.mode }
+
+// Reason reports WHY that arm was selected. Zero-valued (invalid) on the error
+// outcomes, which carry no arm at all.
+func (o SubscribeOutcome) Reason() SubscribeReason { return o.reason }
 
 // Unsub returns the idempotent unsubscribe handle for the registered
 // subscriber. The caller MUST defer it on a non-error outcome (the error path
@@ -772,23 +999,120 @@ func (o SubscribeOutcome) Bootstrap(subscriberClientID, userID string) *leapmuxv
 }
 
 func newSubscribeDeltaOutcome(delta *leapmuxv1.ResumeDelta, unsub func()) SubscribeOutcome {
-	return SubscribeOutcome{mode: SubscribeDelta, delta: delta, unsub: unsub}
+	return SubscribeOutcome{mode: SubscribeDelta, reason: SubscribeReasonResumed, delta: delta, unsub: unsub}
 }
 
-func newSubscribeInitialOutcome(initial *leapmuxv1.UserMaterialized, unsub func()) SubscribeOutcome {
-	return SubscribeOutcome{mode: SubscribeInitial, initial: initial, unsub: unsub}
+func newSubscribeInitialOutcome(initial *leapmuxv1.UserMaterialized, reason SubscribeReason, unsub func()) SubscribeOutcome {
+	return SubscribeOutcome{mode: SubscribeInitial, reason: reason, initial: initial, unsub: unsub}
 }
 
-// fallbackOutcome is the FALLBACK seam shared by SubscribeWithACL's two FALLBACK
-// triggers (a non-resumable verdict and an over-budget tail): register + full
-// materialized snapshot via subscribeLocked, wrapped in a SubscribeInitial
-// outcome with a fresh idempotent unsub. MUST be called with m.projection held
-// (subscribeLocked requires it). Folding the two identical call sites into one
-// seam keeps the "FALLBACK always re-registers fresh via subscribeLocked"
-// invariant in one readable expression.
-func (m *Manager) fallbackOutcome(sub *Subscriber) SubscribeOutcome {
-	initial := m.subscribeLocked(sub)
-	return newSubscribeInitialOutcome(initial, makeUnsub(sub, m))
+// fallbackLockFreeAttempts bounds the lock-free arm of fallbackOutcome before
+// it escalates to the locked one. See fallbackOutcome for why the ladder
+// terminates.
+const fallbackLockFreeAttempts = 2
+
+// FallbackLockFreeAttemptsForTest exposes the ladder's bound so the
+// termination test asserts against the constant rather than restating it -- a
+// restated 2 would silently stop testing the bound the day it changes.
+const FallbackLockFreeAttemptsForTest = fallbackLockFreeAttempts
+
+// fallbackOutcome is the FALLBACK seam shared by SubscribeWithACL's two
+// triggers (a non-resumable verdict and an abandoned resume): register, build
+// the full materialized baseline, and wrap it as a SubscribeInitial outcome.
+//
+// Caller MUST NOT hold subscribeExpandMu OR m.projection. This seam takes
+// subscribeExpandMu itself, once per attempt, via resolveAndRegisterForFallback
+// (and via lockedFallbackOutcome on the terminal rung) — sync.Mutex is not
+// reentrant, so a caller that "helpfully" held it would deadlock this user's
+// every later connect and workspace lifecycle RPC.
+//
+// THE PARK-OVERFLOW LADDER. The baseline is now built with the subscriber
+// already registered and the transport still parking (Release happens only
+// after the bootstrap frame is on the wire), so a slow build racing fast
+// commits can overflow subscriberQueue's parkedFrameCap. That drops a frame,
+// and liveCatchUpSink discards the send error -- so the frame is simply lost.
+// It cannot happen today only because the old shape held m.projection across
+// the build and stopped broadcasts entirely.
+//
+// So: retry on overflow via fallbackRebaseline, which discards the parked
+// buffer (clearing the flag) and re-registers at a newer generation. After
+// fallbackLockFreeAttempts, register and build INSIDE the m.projection hold --
+// the pre-#267 shape, where no broadcast can interleave and overflow is
+// therefore impossible. Termination is structural (a fixed count ending in an
+// arm that cannot fail), not probabilistic.
+func (m *Manager) fallbackOutcome(
+	sub *Subscriber,
+	resolve func() (map[string]bool, error),
+	entry fallbackEntry,
+	reason SubscribeReason,
+) (SubscribeOutcome, error) {
+	for attempt := range fallbackLockFreeAttempts {
+		reg, err := m.resolveAndRegisterForFallback(sub, resolve, entry)
+		if err != nil {
+			// Returned UNREGISTERED, so the caller can reject the connection
+			// before streaming anything.
+			return SubscribeOutcome{}, err
+		}
+		initial := m.materialize(reg.state, reg.filter)
+		if !sub.overflowed() {
+			return newSubscribeInitialOutcome(initial, reason, reg.unsub), nil
+		}
+		// The overflow is now the operative cause of this snapshot, whatever
+		// sent us here originally -- the retry below re-derives the baseline,
+		// so attributing it to the earlier reason would hide the drop.
+		reason = SubscribeReasonParkOverflow
+		// The parked buffer has a hole, so this baseline cannot be shipped with
+		// it. Tear down and retry; the next pass rebaselines, which drops the
+		// buffer and clears the flag.
+		reg.unsub()
+		entry = fallbackRebaseline
+		m.logger.Warn("userevents: park buffer overflowed during the fallback baseline; retrying",
+			"attempt", attempt+1, "client_id", sub.ClientID)
+	}
+	// Last resort: hold m.projection across register + build so nothing can be
+	// broadcast (and therefore nothing parked) while the baseline is taken.
+	// This reinstates the BROADCAST stall this seam exists to remove, for this
+	// one connect, which is strictly better than shipping a baseline with a hole.
+	m.logger.Warn("userevents: fallback baseline escalating to the locked path after repeated park overflow",
+		"client_id", sub.ClientID)
+	return m.lockedFallbackOutcome(sub, resolve, entry, reason)
+}
+
+// lockedFallbackOutcome is the ladder's terminal rung: register AND build the
+// baseline inside one m.projection hold, so no broadcast can interleave and the
+// park buffer cannot overflow. That is what makes the ladder terminate.
+//
+// It holds m.projection across the O(all-entities) walk deliberately. It does
+// NOT hold subscribeExpandMu across it: that lock covers only the
+// resolve→register TOCTOU, and the lifecycle RPCs it serializes
+// (ExpandSubscribersForWorkspace / contractSubscribersForWorkspace) take it
+// without ever taking m.projection, so releasing it the moment the register
+// window closes keeps this user's workspace create/delete off the walk while
+// leaving the fence argument untouched. The acquisition order is still
+// subscribeExpandMu → projection → m.mu; only the RELEASE is early.
+func (m *Manager) lockedFallbackOutcome(
+	sub *Subscriber,
+	resolve func() (map[string]bool, error),
+	entry fallbackEntry,
+	reason SubscribeReason,
+) (SubscribeOutcome, error) {
+	// Idempotent so the deferred release is a panic-safety net rather than a
+	// second unlock: resolve() reaches the store, and a recovered handler panic
+	// must not leave this user's lifecycle lock held forever. sync.OnceFunc
+	// rather than a hand-rolled bool-plus-closure -- "runs at most once" is that
+	// primitive's entire contract, so it needs no reading to verify.
+	m.subscribeExpandMu.Lock()
+	releaseExpand := sync.OnceFunc(m.subscribeExpandMu.Unlock)
+	defer releaseExpand()
+
+	if err := m.resolveFilter(sub, resolve); err != nil {
+		return SubscribeOutcome{}, err
+	}
+	m.projection.Lock()
+	defer m.projection.Unlock()
+	reg := m.registerForFallbackLocked(sub, entry)
+	releaseExpand()
+	return newSubscribeInitialOutcome(m.materialize(reg.state, reg.filter), reason, reg.unsub), nil
 }
 
 // Subscribe attaches a new subscriber. Returns an unsubscribe
@@ -798,11 +1122,11 @@ func (m *Manager) fallbackOutcome(sub *Subscriber) SubscribeOutcome {
 // TEST-ONLY as of the resume extraction: `rg '\.Subscribe\(' --glob '!*_test.go'`
 // finds no production caller. The userevents path goes through
 // SubscribeWithACL, which reaches the SAME registerSubscriber/makeUnsub seam
-// via subscribeLocked and registerForResume while holding subscribeExpandMu, so
-// a concurrent workspace-create expansion cannot leave a straggler with a stale
-// pre-commit filter (see SubscribeWithACL). This wrapper only adds the
-// projection lock around that seam and does NOT get the subscribeExpandMu
-// guarantee -- so a fix made here alone does not reach production.
+// via registerForFallback and registerForResume while holding subscribeExpandMu,
+// so a concurrent workspace-create expansion cannot leave a straggler with a
+// stale pre-commit filter (see SubscribeWithACL). This wrapper reaches
+// registerForFallback WITHOUT that subscribeExpandMu guarantee -- so a fix made
+// here alone does not reach production.
 //
 // Subscribers with a non-empty ClientID contribute to a refcount keyed
 // on that id. The first Subscribe cancels any pending deferred clear;
@@ -810,52 +1134,164 @@ func (m *Manager) fallbackOutcome(sub *Subscriber) SubscribeOutcome {
 // reconnect inside the grace window keeps the client's presence
 // entries intact so the active-client gate doesn't flicker.
 func (m *Manager) Subscribe(sub *Subscriber) (initial *leapmuxv1.UserMaterialized, unsub func()) {
-	// The whole sequence runs under m.projection -- the same lock broadcasts
-	// take -- so a subscriber's registration + initial snapshot are atomic with
-	// respect to any concurrent broadcast: the filter captured by Add and the
-	// materialized baseline can never straddle a filter mutation. (The
-	// production path must go through SubscribeWithACL rather than resolving a
-	// filter and Adding it here unserialized -- a workspace-create expansion
-	// only visits already-registered subscribers; see SubscribeWithACL.) The
-	// cost is that the O(N) materializedLocked clone below is serialized
-	// against broadcasts for that duration (a large-user-doc connect briefly stalls
-	// the user's commit/broadcast pipeline); relaxing it -- computing the
-	// snapshot outside m.projection -- would reopen exactly that straddle
-	// window, so it is held deliberately.
+	// Reaches the same seam SubscribeWithACL's FALLBACK arm does, so the
+	// register/baseline ordering has one home. fallbackCold because a fresh
+	// subscriber has nothing parked to discard.
 	//
-	// Within that, m.mu is only RLocked for the clone. materializedLocked walks
-	// every visible node/tab/floating-window for the subscriber's filter; taking
-	// the state write lock would block every concurrent commit, whereas the RLock
-	// only contends the brief state-swap. Subscriber visibility is identical
-	// either way: by the time we take the state RLock the subscriber is in
-	// subscribers, so it sees the next broadcast, and the initial snapshot
-	// computed under RLock is strictly newer-than-or-equal to whatever a commit
-	// that lost the race would have produced.
+	// (The production path must go through SubscribeWithACL rather than
+	// resolving a filter and Adding it here unserialized -- a workspace-create
+	// expansion only visits already-registered subscribers; see
+	// SubscribeWithACL.)
+	reg := m.registerForFallback(sub, fallbackCold)
+	return m.materialize(reg.state, reg.filter), reg.unsub
+}
+
+// fallbackEntry says WHICH fallback a registration is, and both per-path
+// answers derive from it: whether the transport has frames parked from a
+// just-abandoned resume scan that the new baseline supersedes.
+//
+// An enum rather than a bool for the reason journalScan carries a scanMode:
+// the two arms differ in what they must do, not merely in a flag's value.
+type fallbackEntry int
+
+const (
+	// fallbackCold is a first bootstrap decision. The subscriber was never
+	// registered, so nothing can be parked.
+	fallbackCold fallbackEntry = iota
+	// fallbackRebaseline is a RESUME that gave up. The subscriber WAS
+	// registered during the (lock-free) journal scan, so live frames parked in
+	// the transport; the new baseline supersedes them and they must be dropped
+	// before it is taken.
+	fallbackRebaseline
+)
+
+// registration is what the O(1) register window hands to the lock-free work
+// that follows it -- a FALLBACK baseline build, or a RESUME tail scan.
+type registration struct {
+	// state is the published generation the baseline must be built from. It is
+	// immutable (see commitState), which is what makes the build lock-free.
+	state *leapmuxv1.UserCrdtState
+	// maxHLC is that generation's max_hlc, cloned once. It IS
+	// sub.resumeSuppressThrough -- the same value, not a second read -- and on
+	// the RESUME arm it is also the scan's `until` high-water. One field rather
+	// than two reads is what makes "the gate, the baseline and the tail bound
+	// are one point in time" true by construction instead of by argument.
+	maxHLC *leapmuxv1.HLC
+	// filter is the private copy SubscriberController.Add captured -- the exact
+	// filter every broadcast to this subscriber will be evaluated against.
+	filter SubscriberFilter
+	unsub  func()
+}
+
+// registerForFallback is the FALLBACK arm's counterpart to registerForResume:
+// the O(1) window that registers the subscriber and captures the generation its
+// baseline will be built from. The caller then builds that baseline holding
+// NOTHING.
+//
+// Caller MUST hold subscribeExpandMu (the resolve→register TOCTOU) and MUST NOT
+// hold m.projection; this takes and releases m.projection and m.mu.RLock.
+//
+// WHY THERE IS NEITHER A GAP NOR A DUPLICATE. commitState takes m.mu.Lock, so
+// it is atomic with respect to the RLock below and every batch falls on exactly
+// one side of it:
+//
+//   - commitState(B) BEFORE the RLock: B's ops are in reg.state, and
+//     at >= B.hlc. If broadcastBatch(B) lands after the Add, sendTo's
+//     resumeSuppressThrough gate drops it. Not delivered twice.
+//   - commitState(B) AFTER the RUnlock: B is not in reg.state, and
+//     broadcastBatch(B) follows commitState(B), which follows the Add and its
+//     atomic snapshot publish -- so B is delivered live, and at < B.hlc leaves
+//     the gate open. Not lost.
+//   - There is no third case.
+//
+// resumeSuppressThrough is therefore set from the SAME generation the baseline
+// is built from, and the invariant is one comparison:
+// sub.resumeSuppressThrough == initial.MaxHlc.
+//
+// It must be assigned BEFORE registerSubscriber, because Add publishes a deep
+// CLONE of the subscriber and sendTo reads the clone.
+//
+// m.projection is held here not for the baseline but as the REBASELINE FENCE.
+// m.subscribers.Remove takes only the controller mutex while broadcastBatch
+// loads the atomic snapshot after taking m.projection, so after a resume's
+// unsub() an in-flight fan-out can still park a frame. Acquiring m.projection
+// afterwards is a complete fence -- a fan-out either finished before we got it
+// or starts after we release -- and holding it across {discard, register,
+// capture} makes "discard and re-register are atomic with respect to broadcast"
+// one statement rather than a fence plus an ordering argument. The whole window
+// is O(1), so the cold path pays nothing for sharing it.
+func (m *Manager) registerForFallback(sub *Subscriber, entry fallbackEntry) registration {
 	m.projection.Lock()
-	initial = m.subscribeLocked(sub)
-	m.projection.Unlock()
-	return initial, makeUnsub(sub, m)
+	defer m.projection.Unlock()
+	return m.registerForFallbackLocked(sub, entry)
 }
 
-// subscribeLocked is the register+snapshot core shared by Subscribe and
-// SubscribeWithACL's FALLBACK path. It MUST be called with m.projection held; it
-// takes m.mu.RLock for the materialized clone itself. It registers the
-// subscriber (Add + presence refcount) and returns the full UserMaterialized
-// baseline. SubscribeWithACL's RESUME path does NOT call this -- it calls only
-// registerSubscriber (to skip the materialized clone it does not need) and
-// builds a ResumeDelta instead of the snapshot.
-func (m *Manager) subscribeLocked(sub *Subscriber) *leapmuxv1.UserMaterialized {
-	initialFilter := m.registerSubscriber(sub)
-	m.mu.RLock()
-	initial := m.materializedLocked(initialFilter)
-	m.mu.RUnlock()
-	return initial
+// registerForFallbackLocked is registerForFallback's body, with m.projection
+// left to the caller.
+//
+// It exists because the ladder's terminal rung must keep m.projection held
+// ACROSS the baseline build (that is what makes overflow impossible there),
+// while every other caller wants it released as soon as the window closes.
+// Splitting the hold from the window keeps ONE copy of what the window
+// captures: the whole no-gap/no-duplicate argument above is stated once and
+// applies to both rungs. Hand-mirroring it in the escalated arm is what let the
+// two copies drift apart — that arm had stopped honouring `entry` at all.
+//
+// Caller MUST hold m.projection and MUST NOT hold m.mu.
+func (m *Manager) registerForFallbackLocked(sub *Subscriber, entry fallbackEntry) registration {
+	if entry == fallbackRebaseline && sub.OnRebaseline != nil {
+		sub.OnRebaseline()
+	}
+	return m.registerLocked(sub)
 }
 
-// registerSubscriber is the register half of subscribeLocked: Add + presence
-// refcount. Split out so SubscribeWithACL's RESUME path registers through the SAME
-// seam as Subscribe/FALLBACK instead of hand-mirroring the Add+OnConnect pair,
-// keeping the presence-refcount invariant in one place. The matching teardown
+// registerLocked is THE register window, shared by both arms: capture the
+// published generation, set the suppress gate from it, register the subscriber,
+// and mint the one unsub handle for that registration.
+//
+// One implementation rather than two, because the no-gap/no-duplicate proof
+// above is a property of this exact sequence and the RESUME arm depends on it
+// just as much: its `until` high-water and the live path's suppress gate must be
+// the same point in time or the tail and the broadcast stream can overlap or
+// gap. Two hand-mirrored copies made that a coincidence of two independent reads
+// of m.state; one copy makes it the same field.
+//
+// It also mints the unsub ONCE. makeUnsub returns a fresh sync.Once per call,
+// so a second handle over the same subscriber would be free to decrement the
+// presence refcount again -- the underflow makeUnsub's idempotence exists to
+// prevent, reached by having two of them rather than by calling one twice.
+//
+// Caller MUST hold m.projection and MUST NOT hold m.mu.
+func (m *Manager) registerLocked(sub *Subscriber) registration {
+	var reg registration
+	// BOTH unlocks are deferred, for the reason SubscribeWithACL's lock plan
+	// gives: a recovered handler panic leaves the process serving, so a read
+	// lock leaked while unwinding out of registerSubscriber (which reaches
+	// subscribers.Add and presenceCtl.OnConnect) would block every later
+	// commitState, decideResume and Materialized for this user forever.
+	func() {
+		m.mu.RLock()
+		defer m.mu.RUnlock()
+		reg.state = m.state
+		reg.maxHLC = HLCClone(reg.state.GetMaxHlc())
+		sub.resumeSuppressThrough = reg.maxHLC
+		// Take the filter registerSubscriber RETURNS -- the private deep copy
+		// SubscriberController.Add captured, which is the exact value every
+		// broadcast to this subscriber is evaluated against. Reading sub.Filter
+		// back afterwards would be value-equal today (both windows run under
+		// subscribeExpandMu, the same lock contract/expand mutate it under), but
+		// it sources the work's filter from the mutable field rather than from
+		// the published copy.
+		reg.filter = m.registerSubscriber(sub)
+	}()
+	reg.unsub = makeUnsub(sub, m)
+	return reg
+}
+
+// registerSubscriber is the register half of both register windows
+// (registerForFallback / registerForResume): Add + presence refcount. Split out
+// so every arm registers through the SAME seam instead of hand-mirroring the
+// Add+OnConnect pair, keeping the presence-refcount invariant in one place. The matching teardown
 // is makeUnsub (idempotent) — call it on any error path between a successful
 // register and the return of a makeUnsub the caller will defer.
 func (m *Manager) registerSubscriber(sub *Subscriber) SubscriberFilter {
@@ -871,8 +1307,7 @@ func (m *Manager) registerSubscriber(sub *Subscriber) SubscriberFilter {
 // refcount twice -- that would underflow the count and prematurely clear a
 // client that still has live connections, flickering the active-client gate.
 // It is also the teardown registerForResume+error paths reach for directly
-// (before re-entering subscribeLocked on a FALLBACK), since calling it twice is
-// safe.
+// (before re-entering the FALLBACK seam), since calling it twice is safe.
 func makeUnsub(sub *Subscriber, m *Manager) func() {
 	var unsubOnce sync.Once
 	return func() {

--- a/backend/internal/hub/crdt/manager_subscribe_bench_test.go
+++ b/backend/internal/hub/crdt/manager_subscribe_bench_test.go
@@ -1,0 +1,296 @@
+package crdt_test
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/hub/crdt"
+)
+
+// Benchmarks for the /ws/userevents connect path.
+//
+// WHICH NUMBER MATTERS. The FALLBACK baseline is an O(all the user's entities)
+// walk plus a proto.Clone of every visible record, and that cost does not go
+// away -- the client still needs the bytes. What matters is whether it is paid
+// WHILE HOLDING the locks the commit/broadcast pipeline needs. So
+// BenchmarkMaterializedFromState and BenchmarkSubscribeWithACL_Fallback are
+// recorded as controls that should stay FLAT across the lock rework (a flat
+// line there is the expected result, not a null result), and
+// BenchmarkCommitLatencyDuringFallbackConnect is the one that must move: it
+// reports how long a commit is stalled behind a cold connect.
+//
+// Sizes mirror the frontend's published checkpoint figures (see
+// frontend/src/lib/crdt/checkpointStore.ts) so the two halves of #358 are
+// measured against the same two accounts.
+
+// benchAccountSizes are the (nodes, tabs) fixtures every benchmark here runs.
+var benchAccountSizes = []struct {
+	name  string
+	nodes int
+	tabs  int
+}{
+	{"400x600", 400, 600},
+	{"2400x4800", 2400, 4800},
+}
+
+// benchSeedAccount installs `nodes` live nodes and `tabs` live tabs under
+// workspace "w1"'s root, directly into the manager's state.
+//
+// SeedStateForTest rather than SubmitInternal: this is exactly the case its doc
+// reserves -- a fixture that cannot practically be expressed as a valid op
+// batch, since 2400 nodes through the validator would take longer to build than
+// the benchmark takes to run, and the shape (not the provenance) is what is
+// being measured.
+//
+// The tree is a chain of SPLIT parents each carrying a fanout of LEAF children,
+// so buildNodeWorkspaceMap's BFS actually has to descend rather than resolving
+// every node from the root in one hop.
+func benchSeedAccount(tb testing.TB, mgr *crdt.Manager, rootID string, nodes, tabs int) {
+	tb.Helper()
+	const fanout = 8
+	// A SPLIT is INCOMPLETE without direction + ratios (completenessCheck in
+	// validate.go), and every later real batch re-validates the whole live
+	// record set -- so a seeded shortcut here would reject the first commit
+	// against this fixture, not just the seed.
+	split := func() *leapmuxv1.NodeRecord {
+		ratios := make([]float64, fanout)
+		for i := range ratios {
+			ratios[i] = 1.0 / float64(fanout)
+		}
+		return &leapmuxv1.NodeRecord{
+			Kind:      &leapmuxv1.LWWNodeKind{Value: leapmuxv1.NodeKind_NODE_KIND_SPLIT},
+			Direction: &leapmuxv1.LWWDirection{Value: leapmuxv1.SplitDirection_SPLIT_DIRECTION_HORIZONTAL},
+			Ratios:    &leapmuxv1.LWWDoubles{Value: &leapmuxv1.DoubleList{Values: ratios}},
+		}
+	}
+	mgr.SeedStateForTest(func(state *leapmuxv1.UserCrdtState) {
+		// The root gains children below, so it can no longer be the LEAF
+		// seedRootInternal registered.
+		root := split()
+		root.NodeId = rootID
+		state.Nodes[rootID] = root
+
+		leaves := make([]string, 0, nodes)
+		parent := rootID
+		for i := range nodes {
+			id := fmt.Sprintf("n%05d", i)
+			rec := &leapmuxv1.NodeRecord{
+				NodeId:   id,
+				Kind:     &leapmuxv1.LWWNodeKind{Value: leapmuxv1.NodeKind_NODE_KIND_LEAF},
+				Position: &leapmuxv1.LWWString{Value: fmt.Sprintf("p%05d", i)},
+			}
+			// Every `fanout`th node becomes the next SPLIT parent, so the tree
+			// has depth ~nodes/fanout instead of being one flat layer and the
+			// projection's BFS actually has to descend.
+			if i%fanout == fanout-1 {
+				rec = split()
+				rec.NodeId = id
+				rec.Position = &leapmuxv1.LWWString{Value: fmt.Sprintf("p%05d", i)}
+			}
+			rec.ParentId = parent
+			state.Nodes[id] = rec
+			if rec.GetKind().GetValue() == leapmuxv1.NodeKind_NODE_KIND_SPLIT {
+				parent = id
+			} else {
+				leaves = append(leaves, id)
+			}
+		}
+		if len(leaves) == 0 {
+			leaves = append(leaves, rootID)
+		}
+		for i := range tabs {
+			id := fmt.Sprintf("t%05d", i)
+			state.Tabs[id] = &leapmuxv1.TabRecord{
+				TabType:  leapmuxv1.TabType_TAB_TYPE_AGENT,
+				TabId:    id,
+				TileId:   &leapmuxv1.LWWString{Value: leaves[i%len(leaves)]},
+				Position: &leapmuxv1.LWWString{Value: fmt.Sprintf("q%05d", i)},
+				WorkerId: &leapmuxv1.LWWString{Value: "worker-1"},
+			}
+		}
+	})
+}
+
+// benchManager builds a started manager seeded with `nodes`/`tabs` under "w1".
+func benchManager(tb testing.TB, nodes, tabs int) *crdt.Manager {
+	tb.Helper()
+	mgr, _, _ := runManager(tb, "user-1", allowAll{}, 230_000)
+	seedRootInternal(tb, mgr, "w1", "root1")
+	benchSeedAccount(tb, mgr, "root1", nodes, tabs)
+	return mgr
+}
+
+// BenchmarkMaterializedFromState measures the projection build alone.
+//
+// CONTROL, expected to stay flat: the walk and the per-record clone are the
+// cost the client's snapshot is made of, and moving them off the manager's
+// locks does not make them cheaper.
+func BenchmarkMaterializedFromState(b *testing.B) {
+	for _, size := range benchAccountSizes {
+		b.Run(size.name, func(b *testing.B) {
+			mgr := benchManager(b, size.nodes, size.tabs)
+			filter := crdt.SubscriberFilter{WorkspaceIDs: map[string]bool{"w1": true}}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				_ = mgr.Materialized(filter)
+			}
+		})
+	}
+}
+
+// BenchmarkSubscribeWithACL_Fallback measures one full cold connect (no
+// cursor). CONTROL, expected to stay flat -- same reason as above.
+func BenchmarkSubscribeWithACL_Fallback(b *testing.B) {
+	for _, size := range benchAccountSizes {
+		b.Run(size.name, func(b *testing.B) {
+			mgr := benchManager(b, size.nodes, size.tabs)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				sub := &crdt.Subscriber{UserID: "user-1", Send: (&captureSubscriber{}).send}
+				out, err := mgr.SubscribeWithACL(context.Background(), sub, nil, 0, resolveAll)
+				if err != nil {
+					b.Fatalf("subscribe: %v", err)
+				}
+				out.Unsub()()
+			}
+		})
+	}
+}
+
+// BenchmarkSubscribeWithACL_Resume is the contrast: the same connect with a
+// live cursor, which ships a delta instead of a snapshot. It is what a seeded
+// new tab (issue #358's client half) pays instead of the fallback above.
+func BenchmarkSubscribeWithACL_Resume(b *testing.B) {
+	for _, size := range benchAccountSizes {
+		b.Run(size.name, func(b *testing.B) {
+			mgr := benchManager(b, size.nodes, size.tabs)
+			submitNodePositionBatch(b, mgr, "cursor-batch", "n00000", "c0")
+			snap := mgr.Materialized(crdt.SubscriberFilter{})
+			cursor, epoch := snap.GetMaxHlc(), snap.GetCurrentEpoch()
+			submitNodePositionBatch(b, mgr, "tail-batch", "n00000", "c1")
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				sub := &crdt.Subscriber{UserID: "user-1", Send: (&captureSubscriber{}).send}
+				out, err := mgr.SubscribeWithACL(context.Background(), sub, crdt.HLCClone(cursor), epoch, resolveAll)
+				if err != nil {
+					b.Fatalf("subscribe: %v", err)
+				}
+				if out.Mode() != crdt.SubscribeDelta {
+					b.Fatalf("wanted a delta, got %v", out.Mode())
+				}
+				out.Unsub()()
+			}
+		})
+	}
+}
+
+// BenchmarkCommitLatencyDuringFallbackConnect is THE number.
+//
+// A background goroutine commits 1-op batches continuously while the benchmark
+// body runs cold connects, and the reported metrics are that committer's
+// latency -- p99 and max. A commit that lands while a FALLBACK baseline is
+// being built waits for it: `commitState` needs m.mu.Lock and `broadcastBatch`
+// needs m.projection, and today the baseline holds both.
+//
+// So `max-commit-ms` is the stall this change exists to remove. It should fall
+// from roughly the baseline-build time to roughly a 1-op commit.
+func BenchmarkCommitLatencyDuringFallbackConnect(b *testing.B) {
+	for _, size := range benchAccountSizes {
+		b.Run(size.name, func(b *testing.B) {
+			mgr := benchManager(b, size.nodes, size.tabs)
+
+			var (
+				mu       sync.Mutex
+				samples  []time.Duration
+				firstErr error
+			)
+			stop := make(chan struct{})
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				for i := 0; ; i++ {
+					select {
+					case <-stop:
+						return
+					default:
+					}
+					start := time.Now()
+					_, err := mgr.SubmitInternal(context.Background(), crdt.SubmitInput{
+						Batches: []*leapmuxv1.OpBatch{{
+							BatchId: fmt.Sprintf("bench-commit-%d", i),
+							Ops: []*leapmuxv1.CrdtOp{{
+								OpId: fmt.Sprintf("bench-op-%d", i),
+								Body: &leapmuxv1.CrdtOp_SetNodeRegister{SetNodeRegister: &leapmuxv1.SetNodeRegisterOp{
+									NodeId: "n00000",
+									Field:  &leapmuxv1.SetNodeRegisterOp_Position{Position: fmt.Sprintf("z%06d", i)},
+								}},
+							}},
+						}},
+					})
+					elapsed := time.Since(start)
+					mu.Lock()
+					if err != nil {
+						// Remembered, not swallowed: a committer that fails on
+						// every call would otherwise produce zero samples and be
+						// reported as a SKIP, quietly deleting the one number
+						// this benchmark exists for.
+						if firstErr == nil {
+							firstErr = err
+						}
+					} else {
+						samples = append(samples, elapsed)
+					}
+					mu.Unlock()
+				}
+			}()
+
+			b.ResetTimer()
+			for range b.N {
+				sub := &crdt.Subscriber{UserID: "user-1", Send: (&captureSubscriber{}).send}
+				out, err := mgr.SubscribeWithACL(context.Background(), sub, nil, 0, resolveAll)
+				if err != nil {
+					b.Fatalf("subscribe: %v", err)
+				}
+				out.Unsub()()
+			}
+			b.StopTimer()
+
+			close(stop)
+			<-done
+			mu.Lock()
+			collected := append([]time.Duration(nil), samples...)
+			commitErr := firstErr
+			mu.Unlock()
+			// FAIL rather than skip. max-commit-ms is the number the whole
+			// server-side change is justified by, and a skip reads like an
+			// environment problem -- so a change that made every background
+			// commit invalid (a mid-run epoch bump, a tightened validator, a
+			// batch-id collision) would silently remove the measurement instead
+			// of showing a regression.
+			if len(collected) == 0 {
+				b.Fatalf("the background committer produced no samples; first error: %v", commitErr)
+			}
+			sort.Slice(collected, func(i, j int) bool { return collected[i] < collected[j] })
+			// NEAREST-RANK, and only once there are enough samples for a 99th
+			// percentile to mean anything. `collected[(n*99)/100]` is n-1 --
+			// the maximum -- for every n <= 100, so on a short run (a low b.N,
+			// or the -benchtime=1x sanity check) the p99 and max columns were
+			// the same number with nothing saying so, and the tail-vs-typical
+			// contrast the reader is invited to draw did not exist.
+			if len(collected) >= 100 {
+				p99 := collected[(len(collected)*99+99)/100-1]
+				b.ReportMetric(float64(p99.Microseconds())/1000, "p99-commit-ms")
+			}
+			b.ReportMetric(float64(collected[len(collected)-1].Microseconds())/1000, "max-commit-ms")
+			b.ReportMetric(float64(len(collected)), "commits")
+		})
+	}
+}

--- a/backend/internal/hub/crdt/manager_subscribe_expand_test.go
+++ b/backend/internal/hub/crdt/manager_subscribe_expand_test.go
@@ -313,3 +313,53 @@ func TestSubscribeWithACL_ResumeFilterImmutableNoRaceWithExpand(t *testing.T) {
 	close(stop)
 	wg.Wait()
 }
+
+// TestFallbackWithACL_ExpandProceedsDuringBaselineAndStillVisitsUs is the
+// argument for RELEASING subscribeExpandMu before the FALLBACK baseline.
+//
+// The lock is what closes the resolve→register TOCTOU, so it must cover
+// resolve+register -- but not the O(all-entities) baseline that follows, or
+// every cold connect would serialize that user's workspace lifecycle RPCs
+// behind it (and, under a reconnect storm, all of them behind each other).
+//
+// Releasing it is safe because we register FIRST: a concurrent expand
+// therefore SEES the subscriber and widens its filter, and the new workspace's
+// seed batch has an HLC above the captured generation, so it arrives on the
+// live stream. The baseline omitting the new workspace is correct -- it had no
+// pre-existing entities.
+func TestFallbackWithACL_ExpandProceedsDuringBaselineAndStillVisitsUs(t *testing.T) {
+	held, mgr := runHeldBaselineManager(t, 1)
+	seedRootInternal(t, mgr, "w1", "root1")
+
+	cap := &captureSubscriber{}
+	sub := &crdt.Subscriber{UserID: "user-1", Send: cap.send}
+	done := make(chan crdt.SubscribeOutcome, 1)
+	go func() {
+		// Resolves to NOTHING, so only the concurrent expand below can put w1
+		// into this subscriber's filter.
+		out, err := mgr.SubscribeWithACL(context.Background(), sub, nil, 0, func() (map[string]bool, error) {
+			return map[string]bool{}, nil
+		})
+		require.NoError(t, err)
+		done <- out
+	}()
+	held.waitReached(t)
+
+	expandDone := make(chan error, 1)
+	go func() { expandDone <- mgr.ExpandSubscribersForWorkspace(context.Background(), "w1") }()
+	select {
+	case err := <-expandDone:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("the expand stalled behind a fallback baseline -- subscribeExpandMu is still held across it")
+	}
+
+	held.unblock()
+	out := <-done
+	defer out.Unsub()()
+
+	assert.True(t, sub.Filter.IsAllowed("w1"),
+		"we registered before the baseline, so the concurrent expand must have visited us")
+	assert.NotContains(t, out.Initial().GetWorkspaces(), "w1",
+		"the baseline is built from the Add-captured filter, which predates the expand")
+}

--- a/backend/internal/hub/crdt/manager_subscribe_test.go
+++ b/backend/internal/hub/crdt/manager_subscribe_test.go
@@ -14,6 +14,7 @@ import (
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/hub/crdt"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // submitNodeBatch commits a SetNodeRegister (parent_id + kind) for `nodeID`
@@ -26,7 +27,7 @@ import (
 // the op survives the resume visibility filter (workspaceForEntity resolves it
 // to an allowed workspace). Used to advance the journal so a resume has a
 // post-cursor tail that is NOT filtered out.
-func submitNodePositionBatch(t *testing.T, mgr *crdt.Manager, batchID, nodeID, position string) {
+func submitNodePositionBatch(t testing.TB, mgr *crdt.Manager, batchID, nodeID, position string) {
 	t.Helper()
 	res, err := mgr.SubmitInternal(context.Background(), crdt.SubmitInput{
 		Batches: []*leapmuxv1.OpBatch{{BatchId: batchID, Ops: []*leapmuxv1.CrdtOp{{
@@ -352,6 +353,8 @@ func TestSubscribeWithACL_TailOverBudget_FallsBack(t *testing.T) {
 	require.NoError(t, err, "an over-budget tail is recoverable, not a connect failure")
 	require.Equal(t, crdt.SubscribeInitial, out.Mode(),
 		"an over-budget tail must FALLBACK to a full snapshot")
+	assert.Equal(t, crdt.SubscribeReasonTailOverBudget, out.Reason(),
+		"and must say so, or the metric cannot tell this apart from a first connect")
 	defer out.Unsub()()
 	require.NotNil(t, out.Initial(), "the FALLBACK arm must carry a materialized snapshot")
 }
@@ -412,6 +415,8 @@ func TestSubscribeWithACL_BuiltDeltaOverFrameCeiling_FallsBack(t *testing.T) {
 	out, cap := resumeOnce(t, mgr, cursor, epoch)
 	require.Equal(t, crdt.SubscribeInitial, out.Mode(),
 		"a delta past the client's frame ceiling must FALLBACK, never ship")
+	assert.Equal(t, crdt.SubscribeReasonDeltaOverFrameCeiling, out.Reason(),
+		"a delta too big for the wire is its own operational story, not a generic fallback")
 	defer out.Unsub()()
 	snap := out.Initial()
 	require.NotNil(t, snap, "the FALLBACK arm must carry a materialized snapshot")
@@ -671,6 +676,8 @@ func TestSubscribeWithACL_CorruptRowFallsBackWithoutLosingOps(t *testing.T) {
 	require.NoError(t, err, "a corrupt row is recoverable: it must not surface a connect error")
 	require.Equal(t, crdt.SubscribeInitial, out.Mode(),
 		"a corrupt row must FALLBACK; shipping the good tail around it would strand the corrupt batch's ops forever")
+	assert.Equal(t, crdt.SubscribeReasonCorruptRow, out.Reason(),
+		"storage damage must be distinguishable in the metric from an ordinary cold connect")
 	defer out.Unsub()()
 
 	// The whole point of falling back: the snapshot carries BOTH post-cursor
@@ -687,7 +694,7 @@ func TestSubscribeWithACL_CorruptRowFallsBackWithoutLosingOps(t *testing.T) {
 // TestSubscribeWithACL_OverBudgetFallbackRegistersExactlyOnce pins the
 // register→undo→re-register churn on the ErrDeltaTooLarge FALLBACK path. After
 // the over-budget tail read, SubscribeWithACL calls unsub() (tearing down the
-// RESUME registration) then subscribeLocked (re-registering via the FALLBACK
+// RESUME registration) then the FALLBACK seam (re-registering via
 // seam). The subscriber must end up registered EXACTLY ONCE: a subsequent
 // broadcast must deliver exactly one frame, not two (double-registration) or
 // zero (the unsub tore down the wrong handle). The over-budget path is driven
@@ -702,7 +709,7 @@ func TestSubscribeWithACL_OverBudgetFallbackRegistersExactlyOnce(t *testing.T) {
 
 	// Force the resume tail read to hit the ErrDeltaTooLarge ceiling so
 	// SubscribeWithACL takes the FALLBACK-reentry path (register → unsub →
-	// subscribeLocked → re-register) rather than the plain RESUME arm.
+	// fallbackOutcome → re-register) rather than the plain RESUME arm.
 	j.listErr = crdt.ErrDeltaTooLarge
 	cap := &captureSubscriber{}
 	sub := &crdt.Subscriber{UserID: "user-1", Send: cap.send}
@@ -823,7 +830,7 @@ func TestSubscribeWithACL_NeitherExpandNorBroadcastStalledDuringScan(t *testing.
 // TestSubscribeOutcome_ZeroValueIsNotAReadyDelta pins the zero-value guard on
 // SubscribeMode.
 //
-// Every error return in SubscribeWithACL / resumeFallback is
+// Every error return in SubscribeWithACL / fallbackOutcome is
 // `SubscribeOutcome{}, err`. While SubscribeDelta was the iota-zero arm, that
 // value read as "delta ready" carrying a nil *ResumeDelta: today's sole caller
 // checks err first, but a second caller -- or a refactor that logs Mode()
@@ -964,6 +971,65 @@ func TestSubscribeWithACL_CompactionDuringScan_StillResumes(t *testing.T) {
 	require.Equal(t, crdt.SubscribeDelta, r.out.Mode(),
 		"a compaction tick during the scan must not invalidate a cursor inside the retention window")
 	require.NotNil(t, r.out.Delta())
+}
+
+// TestSubscribeWithACL_PostScanDriftFallsBackWithItsOwnReason is the behavioural
+// counterpart to the case above: when the drift DOES invalidate the verdict, the
+// connect must fall back AND say so.
+//
+// The re-check at the end of the unlocked scan (buildResumeDelta's decideResume)
+// was the one give-up arm with no behavioural test -- it was referenced only as a
+// key in the String() vocabulary map, which pins spelling and nothing else. That
+// is the same gap that let the sibling park-overflow arm ship the zero reason:
+// with no test driving the arm, a refactor that dropped or mislabelled `reason`
+// publishes reason="invalid" and an operator can no longer tell "compaction
+// raced the scan" from a construction bug.
+//
+// The epoch bump is forced from INSIDE the scan's hold, so the verdict is
+// genuinely computed before the drift and re-computed after it.
+func TestSubscribeWithACL_PostScanDriftFallsBackWithItsOwnReason(t *testing.T) {
+	mgr, j, _ := runManager(t, "user-1", allowAll{}, 230_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+	submitNodePositionBatch(t, mgr, "cursor-batch", "root1", "c0")
+	cursor := mgr.Materialized(crdt.SubscriberFilter{}).GetMaxHlc()
+	require.NotNil(t, cursor)
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+	submitNodePositionBatch(t, mgr, "tail-batch", "root1", "t0")
+
+	listHold := make(chan struct{})
+	listReached := make(chan struct{})
+	j.listHold = listHold
+	j.listReached = listReached
+
+	type res struct {
+		out crdt.SubscribeOutcome
+		err error
+	}
+	resCh := make(chan res, 1)
+	sub := &crdt.Subscriber{UserID: "user-1", Send: (&captureSubscriber{}).send}
+	go func() {
+		out, err := mgr.SubscribeWithACL(context.Background(), sub, crdt.HLCClone(cursor), epoch, resolveAll)
+		resCh <- res{out, err}
+	}()
+
+	<-listReached
+	// Age the epoch past EpochDuration and force the bump, so the post-scan
+	// re-check sees an epoch the client's no longer matches.
+	mgr.SeedStateForTest(func(state *leapmuxv1.UserCrdtState) {
+		state.EpochStartedAt = timestamppb.New(time.UnixMilli(0).Add(-2 * crdt.EpochDuration))
+	})
+	mgr.TickHousekeeping(context.Background())
+	require.Greater(t, mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch(), epoch,
+		"the fixture must actually drift the epoch, or this tests nothing")
+	close(listHold)
+
+	r := <-resCh
+	require.NoError(t, r.err)
+	defer r.out.Unsub()()
+	assert.Equal(t, crdt.SubscribeInitial, r.out.Mode(),
+		"a verdict invalidated during the scan must ship a complete snapshot")
+	assert.Equal(t, crdt.SubscribeReasonPostScanDrift, r.out.Reason(),
+		"the fallback must name the drift, not an unlabelled 'invalid'")
 }
 
 // TestDecideResume_WallClockFloorFallsBack pins the floor that makes the
@@ -1118,17 +1184,37 @@ func TestSubscribeWithACL_TransportOverflowDuringScanFallsBack(t *testing.T) {
 	// and FALLBACK is a decision rather than the only option.
 	submitNodePositionBatch(t, mgr, "tail-batch", "root1", "t0")
 
+	// Model the REAL transport: subscriberQueue.Rebaseline clears the overflow
+	// flag along with the frames that set it, and the manager calls it through
+	// OnRebaseline. A fake that stayed permanently overflowed would drive the
+	// park-overflow LADDER -- two retries then the locked rung, three baselines
+	// -- which is a different code path from the one production takes here, and
+	// it would assert SubscribeReasonParkOverflow via a re-derivation inside
+	// fallbackOutcome instead of via the scan arm that actually observed the
+	// drop. That is what let the scan arm ship the zero reason unnoticed.
+	//
+	// With the flag cleared on rebaseline, this exercises production's shape:
+	// ONE snapshot, and the reason must survive from the scan arm.
 	overflowed := true
+	rebaselines := 0
 	sub := &crdt.Subscriber{
 		UserID:     "user-1",
 		Send:       (&captureSubscriber{}).send,
 		Overflowed: func() bool { return overflowed },
+		OnRebaseline: func() {
+			rebaselines++
+			overflowed = false
+		},
 	}
 	out, err := mgr.SubscribeWithACL(context.Background(), sub, crdt.HLCClone(cursor), epoch, resolveAll)
 	require.NoError(t, err)
 	defer out.Unsub()()
 	assert.Equal(t, crdt.SubscribeInitial, out.Mode(),
 		"a transport that dropped a frame mid-scan must get a complete snapshot")
+	assert.Equal(t, crdt.SubscribeReasonParkOverflow, out.Reason(),
+		"the reason must come from the scan arm that saw the drop, not from a ladder retry")
+	assert.Equal(t, 1, rebaselines,
+		"FALLBACK converts the overflow into exactly one snapshot, not a ladder of them")
 	// Not asserting out.Delta() is nil: SubscribeOutcome PANICS on a Delta()
 	// read in any mode but SubscribeDelta, which is the stronger guarantee.
 }

--- a/backend/internal/hub/crdt/resume_suppress_internal_test.go
+++ b/backend/internal/hub/crdt/resume_suppress_internal_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/util/userid"
 )
 
 // TestSendTo_ResumeSuppressThrough pins the live-path half of the
@@ -66,4 +67,60 @@ func TestSendTo_ResumeSuppressThrough(t *testing.T) {
 	fan.atHLC = newer
 	fan.sendTo(sub)
 	require.Greater(t, sends.Load(), int32(0), "batches above resumeSuppressThrough must still live-send")
+}
+
+// TestRegisterForFallback_SuppressGateIsTheBaselineGeneration is the FALLBACK
+// arm's no-duplicate invariant, reduced to ONE comparison.
+//
+// The gate and the baseline are read from the same captured generation under
+// one m.mu.RLock, so "every batch at or below the baseline is suppressed on the
+// live path, and every batch above it is delivered" holds by construction --
+// provided these two values are literally the same HLC. A future change that
+// re-read live state for either one would open the straddle again, silently,
+// and this is what catches it.
+func TestRegisterForFallback_SuppressGateIsTheBaselineGeneration(t *testing.T) {
+	m := NewManager(userid.MustNew("user-1"), nil, nil, nil, nil)
+	m.state = NewState(m.owner.String())
+	m.state.MaxHlc = &leapmuxv1.HLC{Physical: 77, Logical: 3, ClientId: "hub"}
+
+	sub := &Subscriber{UserID: m.owner.String(), Send: func(*MarshaledEvent) error { return nil }}
+	reg := m.registerForFallback(sub, fallbackCold)
+	t.Cleanup(reg.unsub)
+
+	require.NotNil(t, sub.resumeSuppressThrough)
+	assert.Equal(t, 0, HLCCmp(sub.resumeSuppressThrough, reg.state.GetMaxHlc()),
+		"the suppress gate must be the captured generation's max_hlc")
+	assert.Equal(t, 0, HLCCmp(sub.resumeSuppressThrough, materializedFromState(reg.state, reg.filter).GetMaxHlc()),
+		"...which is the same value the baseline advertises")
+	assert.NotSame(t, sub.resumeSuppressThrough, reg.state.GetMaxHlc(),
+		"and a CLONE, so a later commit mutating the field in place could not move the gate")
+}
+
+// TestRegisterForResume_SuppressGateIsTheCapturedGeneration is the RESUME arm's
+// half of the same invariant, and the reason the two register windows are one
+// function.
+//
+// The scan's `until` high-water and the live path's suppress gate must be the
+// SAME point in time: a tail bounded above `until` while the gate sat below it
+// would ship a batch twice, and the reverse would drop one. Two hand-mirrored
+// windows made that a coincidence of two independent reads of m.state; sharing
+// registerLocked makes it one field, which is what this asserts.
+func TestRegisterForResume_SuppressGateIsTheCapturedGeneration(t *testing.T) {
+	m := NewManager(userid.MustNew("user-1"), nil, nil, nil, nil)
+	m.state = NewState(m.owner.String())
+	m.state.MaxHlc = &leapmuxv1.HLC{Physical: 77, Logical: 3, ClientId: "hub"}
+
+	sub := &Subscriber{UserID: m.owner.String(), Send: func(*MarshaledEvent) error { return nil }}
+	reg := m.registerForResume(sub)
+	t.Cleanup(reg.unsub)
+
+	assert.Same(t, reg.maxHLC, sub.resumeSuppressThrough,
+		"the scan's `until` and the live-path suppress gate must be ONE value, not two reads")
+	assert.Equal(t, 0, HLCCmp(reg.maxHLC, reg.state.GetMaxHlc()),
+		"...read from the generation captured under the same RLock")
+	assert.NotSame(t, reg.maxHLC, reg.state.GetMaxHlc(),
+		"and a CLONE, so a later commit mutating the field in place could not move the gate")
+	require.NotNil(t, reg.unsub,
+		"the register window owns the ONE unsub handle for this registration; a second makeUnsub "+
+			"would be a fresh sync.Once, free to decrement the presence refcount again")
 }

--- a/backend/internal/hub/crdt/state.go
+++ b/backend/internal/hub/crdt/state.go
@@ -14,8 +14,21 @@ import (
 // in place; returns the number of records pruned across all three
 // kinds.
 //
-// Safety: callers MUST hold the manager mutex (write lock) AND must
-// only invoke this with `watermark <= state.CompactionWatermark`.
+// Safety: callers MUST pass a PRIVATE, UNPUBLISHED state -- a fresh
+// CloneState, never `m.state` -- AND must only invoke this with
+// `watermark <= state.CompactionWatermark`.
+//
+// The private-clone precondition replaced "hold the manager mutex (write
+// lock)", which was correct only while every reader held m.mu.RLock for the
+// whole of its read. It no longer is: a reader may capture the generation
+// pointer and walk it lock-free (materializedFromState), because a PUBLISHED
+// generation is never mutated -- see commitState. Deleting from a published
+// generation would break that for every such reader, and the damage is not
+// confined to the current one: CloneStateForBatch aliases untouched entity maps
+// and nextStateGeneration aliases all four, so a delete here reaches back into
+// every older generation sharing that map. maybeCompact therefore prunes the
+// clone it is about to publish, holding nothing.
+//
 // Pruning is safe under those preconditions because:
 //
 //   - HLC monotonicity: new ops carry canonical HLCs strictly above
@@ -444,6 +457,89 @@ func CloneState(state *leapmuxv1.UserCrdtState) *leapmuxv1.UserCrdtState {
 	return out
 }
 
+// nextStateGeneration returns a new state header whose entity maps ALIAS
+// `s`'s. It is the O(1) copy-on-write publish for a mutation that touches only
+// header fields (the epoch, the watermarks) and no record.
+//
+// It exists because a published generation must never be mutated in place --
+// see commitState's doc for the invariant and who depends on it. Writing
+// `m.state.CurrentEpoch = n` under m.mu.Lock is correct only against readers
+// that hold m.mu.RLock for their whole read; a reader that captures the
+// generation pointer and walks it lock-free (materializedFromState) would race.
+//
+// Aliasing the maps is safe for THIS caller class and only this one: a
+// header-only change writes no entry, so the shared maps are read-only from
+// both generations. A mutation that adds, removes or replaces a record must go
+// through CloneState / CloneStateForBatch instead, which is what every op does.
+func nextStateGeneration(s *leapmuxv1.UserCrdtState) *leapmuxv1.UserCrdtState {
+	if s == nil {
+		return nil
+	}
+	out := newStateHeader(s)
+	out.Nodes = s.GetNodes()
+	out.Tabs = s.GetTabs()
+	out.FloatingWindows = s.GetFloatingWindows()
+	out.Workspaces = s.GetWorkspaces()
+	return out
+}
+
+// nextStateGenerationWithOwnMaps returns a new generation whose four entity
+// maps are the new generation's OWN, holding the same record pointers.
+//
+// It is the publish for a mutation that ADDS OR REMOVES entries but never
+// touches a record's fields -- today that is compaction's tombstone prune, and
+// nothing else. The cost is one pointer copy per entity, against
+// `CloneState`'s protobuf-reflective deep clone of every record: ~7k pointer
+// copies rather than ~60k message allocations on a 2400-node / 4800-tab
+// account, paid on the manager goroutine (compaction shares the select loop
+// with submitCh / internalCh / taskCh, so every queued submit waits it out).
+//
+// Sharing the RECORDS is what makes it cheap and is safe for the same reason
+// CloneStateForBatch's aliasing of untouched records is: nothing mutates a
+// record in place. Copying the MAPS is what makes it correct where
+// nextStateGeneration would not be -- a delete on an aliased map reaches back
+// into every older generation sharing it, including one a lock-free reader
+// (materializedFromState) is walking right now.
+//
+// nil maps stay nil: maps.Clone(nil) is nil, and a caller that only deletes
+// never needs an allocated one.
+func nextStateGenerationWithOwnMaps(s *leapmuxv1.UserCrdtState) *leapmuxv1.UserCrdtState {
+	if s == nil {
+		return nil
+	}
+	out := newStateHeader(s)
+	out.Nodes = maps.Clone(s.GetNodes())
+	out.Tabs = maps.Clone(s.GetTabs())
+	out.FloatingWindows = maps.Clone(s.GetFloatingWindows())
+	out.Workspaces = maps.Clone(s.GetWorkspaces())
+	return out
+}
+
+// newStateHeader returns a fresh generation carrying `src`'s NON-ENTITY fields
+// and no records; the caller supplies the four entity maps, aliased or cloned
+// as its copy semantics require.
+//
+// One home for the header field list because there are two hand-written
+// generation builders (nextStateGeneration and CloneStateForBatch — CloneState
+// uses proto.Clone and tracks new fields automatically). A field added to
+// UserCrdtState had to be remembered in both, and being forgotten in either
+// silently drops it from every commit or every epoch bump, with no test that
+// would notice. Extending this one function is now the whole change.
+//
+// The HLC fields are deep-cloned because a caller may bump max_hlc while
+// compaction advances the watermarks concurrently; EpochStartedAt is a
+// timestamp that is only ever replaced wholesale, never mutated in place.
+func newStateHeader(src *leapmuxv1.UserCrdtState) *leapmuxv1.UserCrdtState {
+	return &leapmuxv1.UserCrdtState{
+		UserId:               src.GetUserId(),
+		MaxHlc:               HLCClone(src.GetMaxHlc()),
+		CompactionWatermark:  HLCClone(src.GetCompactionWatermark()),
+		OpRetentionWatermark: HLCClone(src.GetOpRetentionWatermark()),
+		CurrentEpoch:         src.GetCurrentEpoch(),
+		EpochStartedAt:       src.GetEpochStartedAt(),
+	}
+}
+
 // CloneStateForBatch returns a working copy of `pre` suitable for the
 // validator's Apply pass. The cost scales with the *kinds* of entities
 // the batch touches — not the full state — because Apply only writes
@@ -472,14 +568,7 @@ func CloneStateForBatch(pre *leapmuxv1.UserCrdtState, batch []*leapmuxv1.CrdtOp)
 		return nil
 	}
 	touched := batchTouchedIDs(batch)
-	out := &leapmuxv1.UserCrdtState{
-		UserId:               pre.GetUserId(),
-		MaxHlc:               HLCClone(pre.GetMaxHlc()),
-		CompactionWatermark:  HLCClone(pre.GetCompactionWatermark()),
-		OpRetentionWatermark: HLCClone(pre.GetOpRetentionWatermark()),
-		CurrentEpoch:         pre.GetCurrentEpoch(),
-		EpochStartedAt:       pre.GetEpochStartedAt(),
-	}
+	out := newStateHeader(pre)
 
 	if len(touched.nodes) == 0 {
 		out.Nodes = pre.GetNodes()

--- a/backend/internal/hub/crdt/state_generation_test.go
+++ b/backend/internal/hub/crdt/state_generation_test.go
@@ -1,0 +1,266 @@
+package crdt_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/hub/crdt"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// The published-generation immutability invariant (see Manager.commitState).
+//
+// Everything that reads state without holding m.mu for the whole read depends
+// on it: materializedFromState builds a cold subscriber's whole baseline from a
+// captured generation holding NO lock, and manager_audit.go asserts the same
+// property in prose. These tests are the executable half of that claim, and the
+// analogue of state_clone_for_batch_test.go for the manager-level paths.
+
+// captureGeneration returns the live generation pointer.
+//
+// Escaping the pointer out of WithStateRLock is deliberate and is precisely
+// what is under test: if generations are immutable, an escaped pointer is a
+// stable point-in-time value.
+func captureGeneration(mgr *crdt.Manager) *leapmuxv1.UserCrdtState {
+	var out *leapmuxv1.UserCrdtState
+	mgr.WithStateRLock(func(state *leapmuxv1.UserCrdtState) { out = state })
+	return out
+}
+
+// TestCommitState_PublishedGenerationIsNeverMutated runs every writer the
+// manager has -- a commit, a housekeeping pass (compaction + epoch), and a test
+// seed -- against a generation captured beforehand, and asserts that generation
+// is byte-identical afterwards.
+//
+// The compaction arm is the one that used to fail: PruneTombstonesAtOrBelow
+// DELETES map entries, and CloneStateForBatch shares the entity map of any kind
+// a batch does not touch, so an in-place prune reached back into every older
+// generation that still aliased that map.
+func TestCommitState_PublishedGenerationIsNeverMutated(t *testing.T) {
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 230_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+	// A tombstoned tab, so the housekeeping pass below has something to prune.
+	addAndTombstoneTab(t, mgr, "tA")
+
+	gen := captureGeneration(mgr)
+	require.NotNil(t, gen)
+	before := proto.Clone(gen).(*leapmuxv1.UserCrdtState)
+	require.NotNil(t, before.GetTabs()["tA"], "fixture: the tombstoned tab must still be present pre-prune")
+
+	submitNodePositionBatch(t, mgr, "after-capture", "root1", "z0")
+	mgr.TickHousekeeping(context.Background())
+	mgr.SeedStateForTest(func(state *leapmuxv1.UserCrdtState) {
+		state.Nodes["seeded"] = &leapmuxv1.NodeRecord{NodeId: "seeded"}
+	})
+
+	assert.True(t, proto.Equal(before, gen),
+		"a published generation must be immutable; it changed under a commit, a compaction and a seed")
+	// And the invariant has to be load-bearing, not vacuous: the manager really
+	// did move on from that generation.
+	live := captureGeneration(mgr)
+	assert.NotSame(t, gen, live, "the manager should have published new generations")
+	assert.NotNil(t, gen.GetTabs()["tA"],
+		"the captured generation must still hold the record compaction pruned from the live one")
+	assert.NotContains(t, live.GetTabs(), "tA",
+		"fixture: compaction must actually have pruned it from the live generation")
+}
+
+// TestMaybeCompact_PublishesANewGeneration pins that compaction swaps rather
+// than edits, and that the prune lands on the new generation only.
+func TestMaybeCompact_PublishesANewGeneration(t *testing.T) {
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 230_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+	addAndTombstoneTab(t, mgr, "tA")
+
+	before := captureGeneration(mgr)
+	require.NotNil(t, before.GetTabs()["tA"])
+
+	mgr.TickHousekeeping(context.Background())
+
+	after := captureGeneration(mgr)
+	assert.NotSame(t, before, after, "compaction must publish a new generation")
+	assert.NotNil(t, before.GetTabs()["tA"], "the prune must not reach the old generation")
+	assert.NotContains(t, after.GetTabs(), "tA", "the prune must land on the published generation")
+	assert.False(t, crdt.HLCIsZero(after.GetCompactionWatermark()),
+		"the published generation carries the new watermark")
+	// Compaction publishes a generation that owns its entity MAPS outright -- it
+	// does not alias the ones it superseded. That is the property the in-place
+	// prune violated: aliased maps are what let a delete reach backwards into a
+	// generation a reader was still walking.
+	//
+	// It is also sameNodeMap's negative case. Its only other use asserts the
+	// helper returns TRUE, which two nil maps would satisfy just as well; this
+	// pins that it can distinguish, so the aliasing assertion elsewhere is not
+	// reading a constant.
+	assert.False(t, sameNodeMap(before, after),
+		"the published generation must own its entity maps, not the old one's")
+	// ...while SHARING the records, which is the whole point of copying the maps
+	// instead of deep-cloning the account. A prune adds and removes entries and
+	// never writes a record field, so a full CloneState re-allocated every node,
+	// tab, window and workspace through protobuf reflection on the manager
+	// goroutine -- once per tick on any active account -- to delete a handful.
+	survivor := before.GetNodes()["root1"]
+	require.NotNil(t, survivor, "fixture: the root node must survive the prune")
+	assert.Same(t, survivor, after.GetNodes()["root1"],
+		"an untouched record must be shared with the superseded generation, not re-cloned")
+}
+
+// TestMaybeAdvanceEpoch_PublishesANewGenerationSharingEntityMaps pins both
+// halves of nextStateGeneration: it publishes (so the old generation keeps its
+// epoch) and it is O(1) (so the entity maps are aliased, not copied).
+func TestMaybeAdvanceEpoch_PublishesANewGenerationSharingEntityMaps(t *testing.T) {
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 230_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+	// Drain compaction FIRST, so the tick under test does the epoch bump and
+	// nothing else. maybeCompact's pre-check early-returns while max_hlc has
+	// not moved past compaction_watermark, and neither the seed below nor the
+	// epoch bump moves max_hlc -- so the only generation the tick publishes is
+	// nextStateGeneration's, which is what this test is about. (Without this,
+	// maybeCompact's full CloneState publishes right after and the assertion
+	// would be reading its fresh maps.)
+	mgr.TickHousekeeping(context.Background())
+
+	before := captureGeneration(mgr)
+	beforeEpoch := before.GetCurrentEpoch()
+	// Age the epoch past EpochDuration so the next pass advances it. The
+	// manager's injected clock only moves 1ms per call, so move the START back
+	// rather than waiting.
+	mgr.SeedStateForTest(func(state *leapmuxv1.UserCrdtState) {
+		state.EpochStartedAt = timestamppb.New(time.UnixMilli(0).Add(-2 * crdt.EpochDuration))
+	})
+	seeded := captureGeneration(mgr)
+
+	mgr.TickHousekeeping(context.Background())
+
+	after := captureGeneration(mgr)
+	require.Equal(t, beforeEpoch+1, after.GetCurrentEpoch(), "the epoch should have advanced")
+	assert.Equal(t, beforeEpoch, before.GetCurrentEpoch(), "the old generation keeps its epoch")
+	// The epoch bump touches no record, so the entity maps are shared with the
+	// generation it superseded -- that sharing is what makes it O(1), and it is
+	// also exactly why an in-place delete on one generation would corrupt
+	// another (see commitState).
+	assert.True(t, sameNodeMap(seeded, after), "nextStateGeneration must alias the entity maps, not copy them")
+}
+
+// TestRunOnManagerGoroutine_ReturnsAfterStopInsteadOfWedging pins the escape
+// hatch shared by every caller-driven pass.
+//
+// Both SeedStateForTest and TickHousekeeping hand their work to the manager
+// goroutine over an UNBUFFERED channel and then wait for it. Once Stop has run
+// that goroutine is gone, so without the `<-m.done` arm the send has no
+// receiver and the caller blocks forever -- a deadlock, not a failed call, and
+// one that takes the whole test binary with it. The two used to spell this
+// handshake out separately; they now share one, so a regression here wedges
+// both at once and this is the only test that would say so.
+//
+// A post-Stop call is a no-op by design: it cannot run the pass, but it must
+// return.
+func TestRunOnManagerGoroutine_ReturnsAfterStopInsteadOfWedging(t *testing.T) {
+	mgr, _, cancel := runManager(t, "user-1", allowAll{}, 230_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+	cancel()
+	mgr.Stop()
+
+	// Asserted with a deadline rather than by simply calling them: the failure
+	// mode is a hang, and an ordinary call would take the package down with it
+	// instead of reporting.
+	returned := make(chan struct{})
+	go func() {
+		defer close(returned)
+		mgr.TickHousekeeping(context.Background())
+		mgr.SeedStateForTest(func(state *leapmuxv1.UserCrdtState) {
+			state.Nodes["after-stop"] = &leapmuxv1.NodeRecord{NodeId: "after-stop"}
+		})
+	}()
+	select {
+	case <-returned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("a caller-driven pass wedged after Stop; the manager goroutine is gone and nothing drains the channel")
+	}
+
+	// ...and it really was a no-op: the seed had no sole writer to run on, so
+	// nothing was published. Silently dropping the work is the deliberate
+	// trade -- a post-Stop write could not be ordered against anything.
+	assert.NotContains(t, captureGeneration(mgr).GetNodes(), "after-stop",
+		"a post-Stop seed must not publish; there is no goroutine to serialize it against")
+}
+
+// TestSeedStateForTest_PublishesANewGeneration covers the started branch; the
+// pre-Start branch is exercised by every runManager call, which seeds through
+// Bootstrap before Start.
+func TestSeedStateForTest_PublishesANewGeneration(t *testing.T) {
+	mgr, _, _ := runManager(t, "user-1", allowAll{}, 230_000)
+	seedRootInternal(t, mgr, "w1", "root1")
+
+	before := captureGeneration(mgr)
+	mgr.SeedStateForTest(func(state *leapmuxv1.UserCrdtState) {
+		state.Nodes["seeded"] = &leapmuxv1.NodeRecord{NodeId: "seeded"}
+	})
+	after := captureGeneration(mgr)
+
+	assert.NotSame(t, before, after, "a seed must publish a new generation")
+	assert.Nil(t, before.GetNodes()["seeded"], "the seed must not reach back into the old generation")
+	assert.NotNil(t, after.GetNodes()["seeded"], "the seed must land on the published generation")
+}
+
+// addAndTombstoneTab commits a tab under root1 and then tombstones it in a
+// SEPARATE batch (so the tombstone carries a later canonical HLC), leaving a
+// record that the next compaction pass will prune.
+func addAndTombstoneTab(t *testing.T, mgr *crdt.Manager, tabID string) {
+	t.Helper()
+	require.NoError(t, submitTombstonedTab(t, t.Context(), mgr, tabID))
+}
+
+// submitTombstonedTab is addAndTombstoneTab's assertion-free core, returning the
+// error instead of asserting it.
+//
+// It exists so a SPAWNED goroutine can drive the same seed: require's FailNow is
+// runtime.Goexit, which is only defined on the test goroutine, so calling it off
+// one silently skips the rest of that goroutine instead of failing the test.
+// (t.Helper() is safe anywhere; it is only the assertion that is not.)
+func submitTombstonedTab(t *testing.T, ctx context.Context, mgr *crdt.Manager, tabID string) error {
+	t.Helper()
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+	if _, err := mgr.Submit(ctx, crdt.SubmitInput{
+		Epoch: epoch, PrincipalID: "user", OriginClient: "c1",
+		Batches: []*leapmuxv1.OpBatch{addTabBatch(t, "add-"+tabID, tabID, "root1", "wkr", "p1")},
+	}); err != nil {
+		return err
+	}
+	_, err := mgr.Submit(ctx, crdt.SubmitInput{
+		Epoch: epoch, PrincipalID: "user", OriginClient: "c1",
+		Batches: []*leapmuxv1.OpBatch{{
+			BatchId: "tomb-" + tabID,
+			Ops: []*leapmuxv1.CrdtOp{{
+				OpId: "op-tomb-" + tabID,
+				Body: &leapmuxv1.CrdtOp_TombstoneTab{TombstoneTab: &leapmuxv1.TombstoneTabOp{
+					TabType: leapmuxv1.TabType_TAB_TYPE_AGENT,
+					TabId:   tabID,
+				}},
+			}},
+		}},
+	})
+	return err
+}
+
+// sameNodeMap reports whether two generations share one Nodes map object.
+//
+// Go cannot compare maps with ==, so this compares the identity of the map
+// headers they point at. The obvious alternative -- write a probe key through
+// one and look for it in the other -- is NOT usable here: at least one argument
+// is always the manager's LIVE generation, so the probe would be an
+// unsynchronized write to a map the manager goroutine reads (housekeeping, a
+// queued submit, a concurrent baseline walk). That is a data race by
+// construction, and Go's map detector can turn it into a hard "concurrent map
+// read and map write" panic -- an intermittent failure in the very suite that
+// exists to prove generations are safe to share.
+func sameNodeMap(a, b *leapmuxv1.UserCrdtState) bool {
+	return reflect.ValueOf(a.GetNodes()).Pointer() == reflect.ValueOf(b.GetNodes()).Pointer()
+}

--- a/backend/internal/hub/crdt/state_header_internal_test.go
+++ b/backend/internal/hub/crdt/state_header_internal_test.go
@@ -1,0 +1,117 @@
+package crdt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+)
+
+// TestStateGenerationBuildersCarryEveryUserCrdtStateField is a TRIPWIRE on the
+// hand-maintained header field list.
+//
+// Two of the three generation builders spell the header out by hand:
+// nextStateGeneration (via newStateHeader) and CloneStateForBatch. Only
+// CloneState uses proto.Clone and so tracks new fields automatically. A field
+// added to UserCrdtState in the proto is therefore silently DROPPED on every
+// epoch bump and every commit unless someone remembers to extend newStateHeader
+// — and the loss is invisible: maybeCompact deep-clones the truncated
+// generation and persists it, so the field is gone from disk with every test
+// still green.
+//
+// Driving the check off the DESCRIPTOR rather than a restated field list is the
+// whole point: a list here would need the same maintenance it exists to police.
+// Same idea as validate_tab_tripwire_internal_test.go and journal_shape_test.go.
+func TestStateGenerationBuildersCarryEveryUserCrdtStateField(t *testing.T) {
+	src := &leapmuxv1.UserCrdtState{}
+	populateEveryField(t, src.ProtoReflect(), 2)
+
+	// Anti-vacuity guard. If populateEveryField ever fails to set a field, the
+	// round-trip assertions below would pass on a field neither side carries —
+	// the tripwire would be green precisely when it stopped working.
+	fields := src.ProtoReflect().Descriptor().Fields()
+	for i := range fields.Len() {
+		f := fields.Get(i)
+		require.True(t, src.ProtoReflect().Has(f),
+			"fixture: populateEveryField left %s unset, so this test would not notice it being dropped", f.Name())
+	}
+
+	assert.True(t, proto.Equal(src, nextStateGeneration(src)),
+		"nextStateGeneration dropped a UserCrdtState field; add it to newStateHeader")
+	assert.True(t, proto.Equal(src, CloneStateForBatch(src, nil)),
+		"CloneStateForBatch dropped a UserCrdtState field; add it to newStateHeader")
+}
+
+// populateEveryField sets every field of `m` to a non-zero value, recursing into
+// message fields until `depth` is exhausted.
+//
+// It fails the test on a field kind it does not know how to set, so the day
+// UserCrdtState grows one this test says so instead of quietly skipping it —
+// which would reopen exactly the hole it exists to close.
+func populateEveryField(t *testing.T, m protoreflect.Message, depth int) {
+	t.Helper()
+	fields := m.Descriptor().Fields()
+	for i := range fields.Len() {
+		f := fields.Get(i)
+		switch {
+		case f.IsMap():
+			mp := m.Mutable(f).Map()
+			key := protoreflect.ValueOfString("k").MapKey()
+			val := mp.NewValue()
+			if f.MapValue().Kind() == protoreflect.MessageKind && depth > 0 {
+				populateEveryField(t, val.Message(), depth-1)
+			}
+			mp.Set(key, val)
+		case f.IsList():
+			lst := m.Mutable(f).List()
+			lst.Append(scalarValue(t, f, lst.NewElement()))
+		case f.Kind() == protoreflect.MessageKind:
+			// Mutable() establishes presence even at depth 0, so a nested
+			// message still counts as SET for the anti-vacuity guard.
+			msg := m.Mutable(f).Message()
+			if depth > 0 {
+				populateEveryField(t, msg, depth-1)
+			}
+		default:
+			m.Set(f, scalarValue(t, f, m.NewField(f)))
+		}
+	}
+}
+
+// scalarValue returns a non-zero value for `f`. `zero` is the field's own
+// freshly-created value, used only for kinds that need one (enums, messages).
+func scalarValue(t *testing.T, f protoreflect.FieldDescriptor, zero protoreflect.Value) protoreflect.Value {
+	t.Helper()
+	switch f.Kind() {
+	case protoreflect.StringKind:
+		return protoreflect.ValueOfString("x")
+	case protoreflect.BoolKind:
+		return protoreflect.ValueOfBool(true)
+	case protoreflect.BytesKind:
+		return protoreflect.ValueOfBytes([]byte{1})
+	case protoreflect.Int32Kind, protoreflect.Sint32Kind, protoreflect.Sfixed32Kind:
+		return protoreflect.ValueOfInt32(7)
+	case protoreflect.Uint32Kind, protoreflect.Fixed32Kind:
+		return protoreflect.ValueOfUint32(7)
+	case protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Sfixed64Kind:
+		return protoreflect.ValueOfInt64(7)
+	case protoreflect.Uint64Kind, protoreflect.Fixed64Kind:
+		return protoreflect.ValueOfUint64(7)
+	case protoreflect.FloatKind:
+		return protoreflect.ValueOfFloat32(1.5)
+	case protoreflect.DoubleKind:
+		return protoreflect.ValueOfFloat64(1.5)
+	case protoreflect.EnumKind:
+		return protoreflect.ValueOfEnum(1)
+	case protoreflect.MessageKind, protoreflect.GroupKind:
+		return zero
+	default:
+		t.Fatalf("populateEveryField: unhandled kind %v for field %s -- extend it rather than skipping, "+
+			"or this tripwire silently stops covering that field", f.Kind(), f.Name())
+		return zero
+	}
+}

--- a/backend/internal/hub/crdt/subscribe_outcome_internal_test.go
+++ b/backend/internal/hub/crdt/subscribe_outcome_internal_test.go
@@ -29,7 +29,7 @@ func TestSubscribeOutcome_Bootstrap_StampsBothArms(t *testing.T) {
 	})
 
 	t.Run("initial", func(t *testing.T) {
-		out := newSubscribeInitialOutcome(&leapmuxv1.UserMaterialized{}, func() {})
+		out := newSubscribeInitialOutcome(&leapmuxv1.UserMaterialized{}, SubscribeReasonNoCursor, func() {})
 		evt := out.Bootstrap("client-7", "user-9")
 
 		initial := evt.GetInitial()
@@ -49,4 +49,76 @@ func TestSubscribeOutcome_Bootstrap_PanicsOnInvalidMode(t *testing.T) {
 	assert.Panics(t, func() {
 		_ = SubscribeOutcome{}.Bootstrap("c", "u")
 	})
+}
+
+// Both constructors must set a reason. It is a metric label, so a construction
+// path that forgot one would silently publish a series named "invalid" rather
+// than fail -- which is exactly the class of bug subscribeReasonInvalid exists
+// to make visible, and this is what keeps it visible at authoring time.
+func TestSubscribeOutcome_ConstructorsAlwaysSetAReason(t *testing.T) {
+	assert.Equal(t, SubscribeReasonResumed,
+		newSubscribeDeltaOutcome(&leapmuxv1.ResumeDelta{}, func() {}).Reason(),
+		"a delta outcome is resumed by definition")
+	assert.Equal(t, SubscribeReasonStaleEpoch,
+		newSubscribeInitialOutcome(&leapmuxv1.UserMaterialized{}, SubscribeReasonStaleEpoch, func() {}).Reason())
+	assert.Equal(t, subscribeReasonInvalid, SubscribeOutcome{}.Reason(),
+		"the zero outcome carries no arm, so it carries no reason either")
+}
+
+// The Label() values are metric LABEL values, so they are part of the
+// interface a dashboard is written against. Pinning them here makes a rename a
+// deliberate act rather than a silent break of every existing query.
+//
+// They live on Label() rather than String() precisely so a cosmetic edit to how
+// a reason PRINTS cannot reach them -- String() is what %v and slog invoke
+// implicitly, and while the vocabulary rode on it, "make the logs nicer" and
+// "rename every dashboard label" were the same edit.
+func TestSubscribeReason_LabelIsAStableMetricVocabulary(t *testing.T) {
+	assert.Equal(t, map[SubscribeReason]string{
+		subscribeReasonInvalid:               "invalid",
+		SubscribeReasonResumed:               "resumed",
+		SubscribeReasonNoCursor:              "no_cursor",
+		SubscribeReasonBelowRetentionFloor:   "below_retention_floor",
+		SubscribeReasonStaleEpoch:            "stale_epoch",
+		SubscribeReasonTailOverBudget:        "tail_over_budget",
+		SubscribeReasonDeltaOverFrameCeiling: "delta_over_frame_ceiling",
+		SubscribeReasonCorruptRow:            "corrupt_row",
+		SubscribeReasonPostScanDrift:         "post_scan_drift",
+		SubscribeReasonParkOverflow:          "park_overflow",
+	}, allSubscribeReasonLabels())
+	assert.Equal(t, "reason_99", SubscribeReason(99).Label(),
+		"an unnamed value must still produce a label, not a blank one")
+	assert.Equal(t, "SubscribeReason(99)", SubscribeReason(99).String(),
+		"...and must still be printable Go-side")
+	// The two are DIFFERENT vocabularies, which is the whole point of the split:
+	// a test that passed with String() aliased to Label() would pin nothing.
+	assert.Equal(t, "SubscribeReasonNoCursor", SubscribeReasonNoCursor.String(),
+		"String() names the Go constant, Label() names the metric value")
+}
+
+// allSubscribeReasonLabels walks every declared reason so a NEW member with no
+// Label() arm shows up as an unnamed value in the map above rather than going
+// unnoticed.
+//
+// The walk deliberately runs PAST the last declared member instead of stopping
+// at it. Bounding the loop by the current last member (`r <=
+// SubscribeReasonParkOverflow`) made it blind to exactly the change it is meant
+// to catch: a reason APPENDED to the iota block -- the normal way to extend it
+// -- was never visited, so a missing String() arm left the map unchanged and
+// the test green while the new reason shipped to Prometheus as
+// "reason_10", a label no dashboard matches. Only a mid-block insertion was
+// caught, and the literal above would have caught that anyway.
+//
+// The bound is now the subscribeReasonMax sentinel, which sits last in the iota
+// block, so an appended member is walked automatically and shows up here as its
+// unnamed "reason_N" -- failing the comparison above until it gets both a
+// Label() arm and an entry in the literal. golangci-lint's exhaustive check
+// cannot cover this: SubscribeReason.Label() has a default arm, and the repo
+// sets default-signifies-exhaustive.
+func allSubscribeReasonLabels() map[SubscribeReason]string {
+	out := map[SubscribeReason]string{}
+	for r := subscribeReasonInvalid; r < subscribeReasonMax; r++ {
+		out[r] = r.Label()
+	}
+	return out
 }

--- a/backend/internal/hub/crdt/validate.go
+++ b/backend/internal/hub/crdt/validate.go
@@ -496,15 +496,37 @@ func completenessCheck(state *leapmuxv1.UserCrdtState, roots rootSet) string {
 		if n.GetKind() == nil {
 			return id
 		}
-		// Non-root nodes must have a parent_id and a position.
+		// Non-root nodes must have a parent_id and a position, and that
+		// parent must itself be LIVE.
 		if n.GetParentId() == "" {
 			// Allowed only when registered as a workspace or
 			// floating-window root.
 			if _, isRoot := roots.roots[id]; !isRoot {
 				return id
 			}
-		} else if n.GetPosition() == nil {
-			return id
+		} else {
+			if n.GetPosition() == nil {
+				return id
+			}
+			// A parent that is tombstoned (or gone entirely) leaves this node
+			// live and unreachable from any registered root -- the same Rule 15
+			// violation the parentless case above rejects, one link down.
+			//
+			// It is not hypothetical. applyLifecycleDelete enumerates a
+			// workspace's entities from a captured generation and only then
+			// submits, so a node created in that window is tombstoned nowhere:
+			// its parent goes, it does not, and nothing ever collects it --
+			// compaction prunes only tombstoned records, and the workspace
+			// record is gone so no later enumeration reaches it. The sibling
+			// race on TABS is already caught here's neighbour
+			// (tabPlacementCheck's full walk rejects a tab over a tombstoned
+			// tile), which is what makes this the right altitude: the two races
+			// then share one mechanism and one recovery -- the batch is
+			// rejected, applyLifecycleDelete returns an error, and the outbox
+			// row is retried against the newer state.
+			if parent, ok := state.GetNodes()[n.GetParentId()]; !ok || !HLCIsZero(parent.GetTombstoneAt()) {
+				return id
+			}
 		}
 		switch n.GetKind().GetValue() {
 		case leapmuxv1.NodeKind_NODE_KIND_SPLIT:

--- a/backend/internal/hub/crdt/validate_extra_test.go
+++ b/backend/internal/hub/crdt/validate_extra_test.go
@@ -388,3 +388,35 @@ func TestValidate_PureDelete_OnlyPreWorkspacePermissionRequired(t *testing.T) {
 	require.Equal(t, leapmuxv1.BatchRejectionReason_BATCH_REJECTION_UNSPECIFIED, res.Reason,
 		"pure-delete should only require pre-workspace write; got %v at %q", res.Reason, res.OffendingOpID)
 }
+
+// TestValidate_IncompleteRecord_LiveNodeUnderATombstonedParent covers the
+// Rule-15 arm that the workspace-delete race actually reaches.
+//
+// applyLifecycleDelete enumerates a workspace's entities from a captured
+// generation and only then submits, so a node created in that window is
+// tombstoned nowhere: its parent goes, it does not. It has a parent_id and a
+// position, so every OTHER completeness rule passes -- and it is then live and
+// unreachable from any registered root, which compaction never collects
+// (it prunes only tombstoned records) and no later enumeration reaches (the
+// workspace record is gone).
+//
+// The sibling race on TABS was already caught, by tabPlacementCheck's full walk.
+// Rejecting here gives the node race the same mechanism and the same recovery:
+// the batch is rejected, applyLifecycleDelete returns an error, and the outbox
+// row is retried against the newer state.
+func TestValidate_IncompleteRecord_LiveNodeUnderATombstonedParent(t *testing.T) {
+	pre := seedWorkspaceWithRoot("w1", "root1")
+	// The node the delete's enumeration never saw: complete in every other
+	// respect, and parented to a node the same batch is about to tombstone.
+	pre.Nodes["late-child"] = &leapmuxv1.NodeRecord{
+		NodeId:   "late-child",
+		ParentId: "root1",
+		Kind:     &leapmuxv1.LWWNodeKind{Value: leapmuxv1.NodeKind_NODE_KIND_LEAF, Hlc: hlcAt(2, 0, "a")},
+		Position: &leapmuxv1.LWWString{Value: "p", Hlc: hlcAt(2, 1, "a")},
+	}
+
+	tombstoneParent := stamped(&leapmuxv1.TombstoneNodeOp{NodeId: "root1"}, hlcAt(10, 0, "a"))
+	res, _ := crdt.ValidateBatch(context.Background(), pre, []*leapmuxv1.CrdtOp{tombstoneParent}, true, "p1", allowAll{})
+	assert.Equal(t, leapmuxv1.BatchRejectionReason_BATCH_REJECTION_INCOMPLETE_RECORD, res.Reason,
+		"a live node left under a tombstoned parent is unreachable from every root and must reject")
+}

--- a/backend/internal/hub/service/channel_service_test.go
+++ b/backend/internal/hub/service/channel_service_test.go
@@ -981,10 +981,18 @@ func TestOpenChannel_ClosesWhenCredentialExpires(t *testing.T) {
 	_, _ = env.worker.Register(conn)
 
 	channelSvc := service.NewChannelService(env.store, env.worker, env.channels, env.pending, allowAllAuthFreshness{})
+	// The deadline has to clear the OpenChannel round trip below (a worker
+	// registration, a pending ChannelOpen request/response, and a store read)
+	// and still land well inside the one-second Eventually that follows. 50ms
+	// cleared neither reliably: OpenChannel itself returned "authentication
+	// expired" once this package ran under -race, where every one of those steps
+	// is several times slower, and the test then failed at its FIRST require --
+	// reporting a broken expiry path for what was really a stopwatch. 300ms
+	// keeps roughly a 3x margin on both sides.
 	ctx := auth.WithUser(context.Background(), &auth.UserInfo{
 		ID:                  userid.MustNew(env.user.ID),
 		Username:            env.user.Username,
-		CredentialExpiresAt: auth.DeadlineAt(time.Now().Add(50 * time.Millisecond)),
+		CredentialExpiresAt: auth.DeadlineAt(time.Now().Add(300 * time.Millisecond)),
 	})
 	resp, err := channelSvc.OpenChannel(ctx, connect.NewRequest(&leapmuxv1.OpenChannelRequest{
 		WorkerId:         env.workerID,

--- a/backend/internal/hub/service/crdt_service_test.go
+++ b/backend/internal/hub/service/crdt_service_test.go
@@ -32,6 +32,12 @@ type memJournal struct {
 	transitions []*leapmuxv1.BatchTransitions
 	dedup       map[string]crdt.RecentBatchRecord
 	commitErr   error
+	// listErr, when set, makes the resume tail read fail hard. Mirrors the
+	// crdt_test fakeJournal's field of the same name; it is what lets a
+	// service-level test drive SubscribeWithACL's ERROR return, which is
+	// otherwise unreachable from here (the ACL resolve filters inaccessible
+	// workspaces rather than rejecting them).
+	listErr error
 }
 
 func newMemJournal() *memJournal { return &memJournal{dedup: map[string]crdt.RecentBatchRecord{}} }
@@ -49,6 +55,9 @@ func (j *memJournal) LoadState(_ context.Context, _ string) (*leapmuxv1.UserCrdt
 func (j *memJournal) ListBatchesAfter(_ context.Context, _ string, cursor, until *leapmuxv1.HLC, maxOps, _ int) ([]crdt.ResumeBatch, []crdt.CorruptRow, error) {
 	j.mu.Lock()
 	defer j.mu.Unlock()
+	if j.listErr != nil {
+		return nil, nil, j.listErr
+	}
 	out := []crdt.ResumeBatch{}
 	ops := 0
 	for i, b := range j.batches {

--- a/backend/internal/hub/service/subscriber_queue.go
+++ b/backend/internal/hub/service/subscriber_queue.go
@@ -12,9 +12,23 @@ import (
 //
 // Under a reconnect storm (a hub restart, say) a slow multi-page resume scan
 // racing fast incoming broadcasts could otherwise grow it without bound and OOM
-// the hub. Well above any realistic burst during a scan that is itself bounded
-// at MaxResumeDeltaOps frames.
+// the hub. It is an OOM bound, not a tuning knob: overflow is a correctness
+// event the fallback ladder handles, not a condition to be sized away.
+//
+// TWO phases park, not one. The resume scan does (bounded at MaxResumeDeltaOps
+// source frames), and so does the FALLBACK baseline walk, which registers the
+// subscriber before building and is bounded only by the account's entity count.
+// The baseline walk is the shorter of the two in practice -- an in-memory walk
+// of a captured generation, against a multi-page journal read -- but it is the
+// one whose duration grows with the account.
 const parkedFrameCap = 256
+
+// ParkedFrameCapForTest exposes the bound so an external test can state its
+// precondition AS the bound rather than as a round number beside it -- a guard
+// written as "> 100" passes at 101 commits, where nothing overflows, and the
+// test then fails forty lines later at the overflow assertion, reporting a
+// broken feature for what is really a short burst.
+const ParkedFrameCapForTest = parkedFrameCap
 
 // liveQueueDepth is the steady-state bounded channel depth, i.e. how far a
 // subscriber may fall behind the manager goroutine before it is dropped.
@@ -68,8 +82,13 @@ func (q *subscriberQueue) Send(ctx context.Context, evt *crdt.MarshaledEvent) er
 	q.mu.Lock()
 	if !q.released {
 		if len(q.parked) >= parkedFrameCap {
-			q.mu.Unlock()
+			// Set INSIDE q.mu, paired with Rebaseline's clear, so the two stores
+			// are ordered by the same mutex that orders the frames they describe.
+			// Both callers happen to hold m.projection today, which already
+			// serializes them; relying on that would make this correct only for
+			// as long as no Send path escapes the projection hold.
 			q.overflowed.Store(true)
+			q.mu.Unlock()
 			return crdt.ErrSubscriberSlow
 		}
 		q.parked = append(q.parked, evt)
@@ -95,32 +114,57 @@ func (q *subscriberQueue) Send(ctx context.Context, evt *crdt.MarshaledEvent) er
 	}
 }
 
-// Rebaseline discards everything parked so far.
+// Rebaseline discards everything parked so far, and forgets any overflow those
+// frames caused.
 //
-// A resume that gives up re-registers and takes a snapshot at a LATER point
-// than anything parked during the scan, so those frames are superseded by it.
-// Replaying them over the snapshot would reinstate stale entity records for
+// A resume or a fallback that gives up re-registers and takes a baseline at a
+// LATER point than anything parked before it, so those frames are superseded.
+// Replaying them over the baseline would reinstate stale entity records for
 // good — the client applies materialized / removed wholesale, with no HLC
-// compare. The manager calls this under its projection lock at exactly that
-// moment, so this drops precisely the superseded frames and nothing newer.
+// compare. The manager calls this inside the same projection hold that
+// registers and captures the generation (registerForFallback), so this drops
+// precisely the superseded frames and nothing newer.
+//
+// Clearing `overflowed` is part of the same statement, not a separate courtesy:
+// the flag means "a frame that mattered was dropped", and every frame it could
+// refer to has just been superseded by a newer baseline. Leaving it set would
+// make the fallback ladder read a resume scan's old overflow as an overflow of
+// the baseline it is about to build, burning a retry — and, on the last rung,
+// escalating to the locked path for a hole that no longer exists.
 func (q *subscriberQueue) Rebaseline() {
 	q.mu.Lock()
+	defer q.mu.Unlock()
 	q.parked = nil
-	q.mu.Unlock()
+	// Cleared under q.mu, paired with Send's set: see the note there.
+	q.overflowed.Store(false)
 }
 
-// Release ends the parking phase and returns the frames to flush, in order.
+// Release ends the parking phase and returns the frames to flush, in order,
+// plus whether anything was DROPPED while parking.
 //
 // Called once, by the writer loop, immediately after the bootstrap frame is on
 // the wire. Everything Send accepts afterwards goes to the live queue, so the
 // returned slice is complete: no frame can be both flushed here and streamed.
-func (q *subscriberQueue) Release() []*crdt.MarshaledEvent {
+//
+// `dropped` is not redundant with the manager's own Overflowed() check. That
+// one runs before the bootstrap frame is BUILT; the parking window then stays
+// open across the whole bootstrap WRITE, which is bounded only by
+// relayWriteTimeout and is the longest stretch of it on a large account. An
+// overflow in that stretch is invisible to the manager and, without this
+// verdict, invisible to everyone: liveCatchUpSink discards the send error, so
+// the flush below would simply be short and the subscriber would stream on,
+// permanently missing whatever was dropped.
+//
+// Read under the SAME q.mu that Send sets the flag under, and in the same
+// statement that flips the phase, so no frame can be dropped between the
+// verdict and the flush.
+func (q *subscriberQueue) Release() (flush []*crdt.MarshaledEvent, dropped bool) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	toFlush := q.parked
 	q.parked = nil
 	q.released = true
-	return toFlush
+	return toFlush, q.overflowed.Load()
 }
 
 // Released reports whether the parking phase has ended.

--- a/backend/internal/hub/service/subscriber_queue_internal_test.go
+++ b/backend/internal/hub/service/subscriber_queue_internal_test.go
@@ -2,13 +2,17 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/hub/auth"
 	"github.com/leapmux/leapmux/internal/hub/crdt"
+	"github.com/leapmux/leapmux/internal/util/id"
+	"github.com/leapmux/leapmux/internal/util/userid"
 )
 
 // The park/flush/overflow policy had NO direct coverage before this type
@@ -35,7 +39,7 @@ func TestSubscriberQueue(t *testing.T) {
 		// Nothing reaches the live queue while parked.
 		assert.Empty(t, q.Live())
 
-		flushed := q.Release()
+		flushed, _ := q.Release()
 		require.Len(t, flushed, 2)
 		assert.Equal(t, "a", flushed[0].Event.GetBatch().GetBatchId())
 		assert.Equal(t, "b", flushed[1].Event.GetBatch().GetBatchId())
@@ -44,7 +48,8 @@ func TestSubscriberQueue(t *testing.T) {
 	t.Run("streams to the live queue after release", func(t *testing.T) {
 		t.Parallel()
 		q := newSubscriberQueue()
-		assert.Empty(t, q.Release())
+		flushedEmpty, _ := q.Release()
+		assert.Empty(t, flushedEmpty)
 
 		require.NoError(t, q.Send(ctx, evt("live")))
 		select {
@@ -60,9 +65,10 @@ func TestSubscriberQueue(t *testing.T) {
 	t.Run("release is one-way, so a later frame is never parked again", func(t *testing.T) {
 		t.Parallel()
 		q := newSubscriberQueue()
-		q.Release()
+		_, _ = q.Release()
 		require.NoError(t, q.Send(ctx, evt("after")))
-		assert.Empty(t, q.Release(), "nothing may park once released")
+		afterRelease, _ := q.Release()
+		assert.Empty(t, afterRelease, "nothing may park once released")
 		assert.Len(t, q.Live(), 1)
 	})
 
@@ -74,13 +80,44 @@ func TestSubscriberQueue(t *testing.T) {
 		}
 		assert.ErrorIs(t, q.Send(ctx, evt("overflow")), crdt.ErrSubscriberSlow)
 		// The cap holds: overflow must not grow the buffer past it.
-		assert.Len(t, q.Release(), parkedFrameCap)
+		capped, _ := q.Release()
+		assert.Len(t, capped, parkedFrameCap)
+	})
+
+	// The parking window stays open across the BOOTSTRAP WRITE, which is the
+	// stretch the manager's own Overflowed() check cannot see -- it runs before
+	// the frame is even built. Release is therefore the last place a drop in
+	// that window can be noticed, and liveCatchUpSink discards the send error,
+	// so without this verdict the flush is simply short and the subscriber
+	// streams on missing whatever went away.
+	t.Run("release reports a drop that happened while parking", func(t *testing.T) {
+		t.Parallel()
+		q := newSubscriberQueue()
+		for range parkedFrameCap {
+			require.NoError(t, q.Send(ctx, evt("x")))
+		}
+		require.ErrorIs(t, q.Send(ctx, evt("dropped")), crdt.ErrSubscriberSlow)
+
+		flushed, dropped := q.Release()
+		assert.True(t, dropped, "a frame was lost during parking and Release must say so")
+		assert.Len(t, flushed, parkedFrameCap, "the survivors are still returned")
+	})
+
+	t.Run("release reports no drop when every parked frame fit", func(t *testing.T) {
+		t.Parallel()
+		q := newSubscriberQueue()
+		require.NoError(t, q.Send(ctx, evt("a")))
+		require.NoError(t, q.Send(ctx, evt("b")))
+
+		flushed, dropped := q.Release()
+		assert.False(t, dropped)
+		assert.Len(t, flushed, 2)
 	})
 
 	t.Run("reports ErrSubscriberSlow when the live queue is full", func(t *testing.T) {
 		t.Parallel()
 		q := newSubscriberQueue()
-		q.Release()
+		_, _ = q.Release()
 		for i := range liveQueueDepth {
 			require.NoError(t, q.Send(ctx, evt("x")), "frame %d is within the depth", i)
 		}
@@ -98,7 +135,7 @@ func TestSubscriberQueue(t *testing.T) {
 		q.Rebaseline()
 
 		require.NoError(t, q.Send(ctx, evt("kept")))
-		flushed := q.Release()
+		flushed, _ := q.Release()
 		require.Len(t, flushed, 1, "only frames after the rebaseline survive")
 		assert.Equal(t, "kept", flushed[0].Event.GetBatch().GetBatchId())
 	})
@@ -110,7 +147,7 @@ func TestSubscriberQueue(t *testing.T) {
 	t.Run("a cancelled context does not preempt a send the queue can take", func(t *testing.T) {
 		t.Parallel()
 		q := newSubscriberQueue()
-		q.Release()
+		_, _ = q.Release()
 		cancelled, cancel := context.WithCancel(context.Background())
 		cancel()
 		for i := range liveQueueDepth {
@@ -132,4 +169,74 @@ func TestSubscriberQueue(t *testing.T) {
 		require.ErrorIs(t, q.Send(ctx, evt("overflow")), crdt.ErrSubscriberSlow)
 		assert.True(t, q.Overflowed(), "the resume scan must be able to see the drop")
 	})
+
+	// Rebaseline discards the parked frames AND the overflow they caused. The
+	// flag means "a frame that mattered was dropped", and every frame it could
+	// refer to has just been superseded by a newer baseline.
+	//
+	// Leaving it set is not cosmetic: fallbackOutcome's ladder would read a
+	// resume scan's stale overflow as an overflow of the baseline it is about
+	// to build, burn a retry, and on the last rung escalate to the locked path
+	// for a hole that no longer exists.
+	t.Run("rebaseline clears the parked frames and the overflow they caused", func(t *testing.T) {
+		t.Parallel()
+		q := newSubscriberQueue()
+		for range parkedFrameCap {
+			require.NoError(t, q.Send(ctx, evt("x")))
+		}
+		require.ErrorIs(t, q.Send(ctx, evt("overflow")), crdt.ErrSubscriberSlow)
+		require.True(t, q.Overflowed())
+
+		q.Rebaseline()
+
+		assert.False(t, q.Overflowed(), "the dropped frames are superseded, so the drop is too")
+		// And there is room again, so the next baseline's live traffic parks
+		// normally rather than immediately re-overflowing.
+		require.NoError(t, q.Send(ctx, evt("after")))
+		flushed, _ := q.Release()
+		require.Len(t, flushed, 1, "the superseded frames must be gone, leaving only the new one")
+		assert.Equal(t, "after", flushed[0].Event.GetBatch().GetBatchId())
+	})
+}
+
+// The OVERFLOW POLICY -- which of two very different answers a dropped frame
+// gets -- is what newUserEventsSubscriber was extracted for.
+//
+// Inline it was an anonymous closure inside a struct literal inside a 280-line
+// HTTP handler, so exercising it meant httptest.NewServer plus a real
+// websocket.Dial plus a burst large enough to fill 256 slots. As a named unit
+// the two arms are three lines each to assert, and the difference between them
+// -- whether the connection is torn down -- is directly observable.
+func TestNewUserEventsSubscriber_OverflowPolicyDiffersByPhase(t *testing.T) {
+	user := &auth.UserInfo{ID: userid.MustNew(id.Generate())}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	sub, queue := newUserEventsSubscriber(ctx, cancel, user, "client-1", nil)
+	require.Equal(t, "client-1", sub.ClientID)
+
+	// PRE-BOOTSTRAP: fill the park buffer, then overflow it.
+	for i := range parkedFrameCap {
+		require.NoError(t, sub.Send(evt(fmt.Sprintf("parked-%d", i))))
+	}
+	require.ErrorIs(t, sub.Send(evt("overflows")), crdt.ErrSubscriberSlow)
+	// Flagged for the manager's ladder, and the connection is left ALIVE -- a
+	// teardown here would send the client back with the same cursor to redo the
+	// work, under the load that caused the overflow.
+	assert.True(t, sub.Overflowed(), "a park overflow must be visible to the fallback ladder")
+	require.NoError(t, ctx.Err(), "the pre-bootstrap arm must NOT tear the connection down")
+
+	// A rebaseline supersedes those frames and clears the flag, which is what
+	// lets the ladder retry rather than escalate for a hole that is gone.
+	sub.OnRebaseline()
+	assert.False(t, sub.Overflowed(), "Rebaseline must clear the flag alongside the frames")
+
+	// STEADY STATE: past Release there is no scan to fall back from.
+	_, dropped := queue.Release()
+	require.False(t, dropped, "the rebaseline cleared the earlier drop")
+	for range liveQueueDepth {
+		require.NoError(t, sub.Send(evt("live")))
+	}
+	require.ErrorIs(t, sub.Send(evt("over-live")), crdt.ErrSubscriberSlow)
+	assert.Error(t, ctx.Err(), "the steady-state arm must cancel, dropping the subscriber")
 }

--- a/backend/internal/hub/service/ws_userevents.go
+++ b/backend/internal/hub/service/ws_userevents.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/coder/websocket"
@@ -15,6 +16,7 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/auth"
 	"github.com/leapmux/leapmux/internal/hub/crdt"
 	"github.com/leapmux/leapmux/internal/hub/store"
+	"github.com/leapmux/leapmux/internal/metrics"
 )
 
 // UserEventsHandler upgrades to a WebSocket and streams `WatchUserEvent`
@@ -72,6 +74,99 @@ func (h *UserEventsHandler) WithTokenValidator(v *auth.TokenValidator) *UserEven
 	return h
 }
 
+// countConnectWithoutBootstrap counts an authenticated connect that failed
+// before SubscribeWithACL could select a bootstrap arm.
+//
+// The labels are read off a ZERO SubscribeOutcome rather than written as the
+// string literals "invalid", "invalid": those values are Prometheus label
+// values, so the vocabulary needs exactly one producer -- the enums' own
+// String()/Label(), which a dashboard-breaking rename would have to go through.
+func countConnectWithoutBootstrap() {
+	var none crdt.SubscribeOutcome
+	metrics.UserEventsSubscribeTotal.WithLabelValues(none.Mode().Label(), none.Reason().Label()).Inc()
+}
+
+// newUserEventsSubscriber builds this connection's crdt.Subscriber: its
+// identity, its transport queue, and the two-phase OVERFLOW POLICY.
+//
+// The policy is the reason this is a function. It is a real decision -- which of
+// two very different answers a dropped frame gets, depending on whether the
+// bootstrap frame is on the wire yet -- and inline it was an anonymous closure
+// inside a struct literal inside a 280-line HTTP handler, reachable only through
+// httptest.NewServer plus a real websocket.Dial. That is the same untestability
+// subscriberQueue's own doc gives as the reason IT was extracted, one layer up.
+//
+// `cancel` is the connection's, not the request's: the steady-state arm uses it
+// to tear the connection down, which exits the writer loop and fires the
+// deferred unsub.
+func newUserEventsSubscriber(
+	ctx context.Context,
+	cancel context.CancelFunc,
+	user *auth.UserInfo,
+	clientID string,
+	requested map[string]bool,
+) (*crdt.Subscriber, *subscriberQueue) {
+	// 64-deep buffer covers the steady-state burst window after bootstrap.
+	// During SubscribeWithACL's RESUME path the subscriber is registered
+	// before the writer loop starts, and live broadcasts enqueue via Send
+	// while the journal scan runs — parking those frames in a slice (instead
+	// of the bounded channel) so a multi-page scan under load cannot trip
+	// ErrSubscriberSlow and drop the reconnect. The two phases, the cap, the
+	// mutex and the buffers all live in subscriberQueue -- see its doc for why
+	// they are one value rather than five locals mutated from three places.
+	queue := newSubscriberQueue()
+	sub := &crdt.Subscriber{
+		UserID:                user.ID.String(),
+		ClientID:              clientID,
+		RequestedWorkspaceIDs: requested,
+		// Filter is resolved and installed under subscribeExpandMu by
+		// SubscribeWithACL below (see the resolve-then-register TOCTOU it closes).
+		Send: func(evt *crdt.MarshaledEvent) error {
+			err := queue.Send(ctx, evt)
+			if !errors.Is(err, crdt.ErrSubscriberSlow) {
+				return err
+			}
+			// The two phases overflow for different reasons and deserve
+			// different answers.
+			if !queue.Released() {
+				// PRE-BOOTSTRAP: the bootstrap frame is still being built --
+				// either a resume's journal scan or a fallback's baseline walk,
+				// both of which now run with this subscriber registered and no
+				// manager lock held. Tearing down here sent the client back with
+				// the same cursor to rebuild the same work, under the load that
+				// caused the overflow. Flag it instead: the manager consults
+				// Overflowed() after each, and rebaselines (which discards the
+				// parked buffer AND clears this flag) before taking a fresh
+				// baseline -- so the frame this call could not hold is
+				// superseded rather than lost.
+				slog.Warn("userevents: park buffer full while building the bootstrap frame, falling back to a snapshot",
+					"user_id", user.ID, "client_id", clientID)
+				return err
+			}
+			// STEADY STATE: there is no scan to fall back from, so drop the
+			// subscriber rather than block the manager goroutine. Cancelling ctx
+			// exits the writer loop below and fires the deferred unsub, so later
+			// broadcasts skip us.
+			slog.Warn("userevents: subscriber buffer full, dropping connection",
+				"user_id", user.ID, "client_id", clientID)
+			cancel()
+			return err
+		},
+		// A resume that gives up, or a fallback whose park buffer overflowed,
+		// re-registers and takes a baseline at a LATER point than anything
+		// parked before it. Those parked frames are superseded by the baseline,
+		// and replaying them over it would reinstate stale entity records for
+		// good (the client applies materialized / removed wholesale, with no HLC
+		// compare). The manager calls this inside the same projection hold that
+		// re-registers and captures the generation (registerForFallback), so
+		// dropping the buffer here discards precisely the superseded frames and
+		// nothing newer.
+		OnRebaseline: queue.Rebaseline,
+		Overflowed:   queue.Overflowed,
+	}
+	return sub, queue
+}
+
 func (h *UserEventsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	user, err := h.authenticate(r)
 	if err != nil {
@@ -103,12 +198,40 @@ func (h *UserEventsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// resume_after_hlc is likewise malformed.
 	resumeCursor, resumeEpoch, resumeErr := channelwire.ParseResumeCursorFromQuery(r.URL.Query())
 	if resumeErr != nil {
+		countConnectWithoutBootstrap()
 		http.Error(w, resumeErr.Error(), http.StatusBadRequest)
+		return
+	}
+	// A NARROWED subscription may not present a cursor, and the hub is where
+	// that is enforced -- not the client.
+	//
+	// The persisted cursor is per-USER, not per-filter, so one minted under a
+	// narrow filter and replayed under a wider one can miss ops (see
+	// SubscribeWithACL's max_hlc paragraph). Since the checkpoint seed landed,
+	// cursors are cross-TAB as well, so two tabs need not even agree on what the
+	// filter was. The browser already refuses the pairing, but leaving it there
+	// makes a correctness invariant the property of one client out of three: a
+	// future desktop bridge or a CLI that persists a cursor would violate it
+	// silently and lose ops with nothing server-side to say so.
+	//
+	// REJECTED rather than silently degraded to a snapshot, for the reason the
+	// malformed-cursor arm above gives: degradation masks the bug and lets a
+	// broken client limp along forever. Nothing in tree sends this pairing --
+	// remoteipc's hub_stream and the remote CLI both pass their workspace ids
+	// with a nil cursor -- so this narrows the contract without breaking a
+	// caller. Permitting a SAFE narrowed resume needs the mint-time filter
+	// carried alongside the cursor and re-checked here, which this deliberately
+	// leaves open rather than pre-empting.
+	if len(workspaceIDs) > 0 && resumeCursor != nil {
+		countConnectWithoutBootstrap()
+		http.Error(w, "resume_after_hlc is not accepted with workspace_ids: a cursor minted under a "+
+			"narrower filter cannot be replayed under a wider one", http.StatusBadRequest)
 		return
 	}
 
 	mgr, err := h.registry.Get(r.Context(), userID)
 	if err != nil {
+		countConnectWithoutBootstrap()
 		http.Error(w, "registry get: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -125,6 +248,7 @@ func (h *UserEventsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Subprotocols: []string{"userevents-relay"},
 	})
 	if err != nil {
+		countConnectWithoutBootstrap()
 		slog.Error("userevents websocket upgrade failed", "user_id", user.ID, "error", err)
 		return
 	}
@@ -137,6 +261,7 @@ func (h *UserEventsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	ctx, cleanupLease, current := h.authLease.bind(r.Context(), user, wsConn)
 	if !current {
+		countConnectWithoutBootstrap()
 		return
 	}
 	defer cleanupLease()
@@ -151,51 +276,11 @@ func (h *UserEventsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// ErrSubscriberSlow and drop the reconnect. The two phases, the cap, the
 	// mutex and the buffers all live in subscriberQueue -- see its doc for why
 	// they are one value rather than five locals mutated from three places here.
-	queue := newSubscriberQueue()
-	sub := &crdt.Subscriber{
-		UserID:                user.ID.String(),
-		ClientID:              presenceClientID(user),
-		RequestedWorkspaceIDs: requested,
-		// Filter is resolved and installed under subscribeExpandMu by
-		// SubscribeWithACL below (see the resolve-then-register TOCTOU it closes).
-		Send: func(evt *crdt.MarshaledEvent) error {
-			err := queue.Send(ctx, evt)
-			if !errors.Is(err, crdt.ErrSubscriberSlow) {
-				return err
-			}
-			// The two phases overflow for different reasons and deserve
-			// different answers.
-			if !queue.Released() {
-				// PRE-BOOTSTRAP: a resume scan is still running. Tearing down
-				// here sent the client back with the same cursor to rebuild the
-				// same multi-page scan, under the load that caused the overflow.
-				// Flag it instead: the manager's post-scan check turns this into
-				// ONE snapshot, and resumeFallback's OnRebaseline discards the
-				// parked buffer before taking the baseline, so the frame this
-				// call could not hold is superseded rather than lost.
-				slog.Warn("userevents: park buffer full during resume, falling back to a snapshot",
-					"user_id", user.ID, "client_id", presenceClientID(user))
-				return err
-			}
-			// STEADY STATE: there is no scan to fall back from, so drop the
-			// subscriber rather than block the manager goroutine. Cancelling ctx
-			// exits the writer loop below and fires the deferred unsub, so later
-			// broadcasts skip us.
-			slog.Warn("userevents: subscriber buffer full, dropping connection",
-				"user_id", user.ID, "client_id", presenceClientID(user))
-			cancel()
-			return err
-		},
-		// A resume that gives up re-registers and takes a snapshot at a LATER
-		// point than anything parked during the scan. Those parked frames are
-		// superseded by the snapshot, and replaying them over it would reinstate
-		// stale entity records for good (the client applies materialized /
-		// removed wholesale, with no HLC compare). The manager calls this under
-		// its projection lock at exactly that moment, so dropping the buffer
-		// here discards precisely the superseded frames and nothing newer.
-		OnRebaseline: queue.Rebaseline,
-		Overflowed:   queue.Overflowed,
-	}
+	// Derived ONCE, and used both to register and to log. Recomputing it per log
+	// site let a line name an identity the registered subscriber does not have
+	// if the derivation ever grew a condition.
+	clientID := presenceClientID(user)
+	sub, queue := newUserEventsSubscriber(ctx, cancel, user, clientID, requested)
 	// Resolve the workspace filter and register the subscriber atomically under
 	// the manager's subscribe/expand lock. This closes the resolve-then-register
 	// window: a workspace create that commits while this connection is being set
@@ -221,7 +306,31 @@ func (h *UserEventsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	resolve := func() (map[string]bool, error) {
 		return resolveAllowedWorkspacesSetForUser(ctx, h.store, workspaceIDs, user)
 	}
+	subscribeStart := time.Now()
 	out, err := mgr.SubscribeWithACL(ctx, sub, resumeCursor, resumeEpoch, resolve)
+	elapsed := time.Since(subscribeStart)
+	// Labelled here rather than inside crdt: that package has no
+	// internal/metrics edge, and Reason() exists precisely so the service layer
+	// can label without re-deriving the verdict.
+	//
+	// Counted on BOTH arms so the series is a complete partition of connect
+	// outcomes. Counting only successes made the metric drop silently exactly
+	// when it mattered -- a deployment whose ACL resolve started erroring showed
+	// a fall in subscribe volume indistinguishable from a fall in traffic, with
+	// no error series to explain it. A failed connect selected no bootstrap arm,
+	// so it is labelled with the zero mode/reason, both of which already spell
+	// themselves "invalid".
+	//
+	// "Complete" means every AUTHENTICATED connect: the earlier returns above --
+	// a malformed cursor, a registry bootstrap failure, a refused upgrade, a
+	// superseded auth lease -- count too, through countConnectWithoutBootstrap.
+	// Without them the very failure this comment names was still invisible:
+	// registry.Get is where the manager loads its state from the journal, so a
+	// hub whose user_state read starts failing returns before this line for
+	// every connect, and the series falls to zero with nothing to explain it.
+	mode := out.Mode().Label()
+	metrics.UserEventsSubscribeTotal.WithLabelValues(mode, out.Reason().Label()).Inc()
+	metrics.UserEventsSubscribeDuration.WithLabelValues(mode).Observe(elapsed.Seconds())
 	if err != nil {
 		if connect.CodeOf(err) == connect.CodePermissionDenied {
 			_ = wsConn.Close(websocket.StatusPolicyViolation, "forbidden")
@@ -231,6 +340,17 @@ func (h *UserEventsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+	slog.Debug("userevents: subscribed",
+		"user_id", user.ID,
+		"client_id", clientID,
+		"mode", out.Mode(),
+		"reason", out.Reason(),
+		// MICROseconds, for the reason the histogram beside it has hand-picked
+		// buckets: a resume is microseconds against a fallback baseline's
+		// milliseconds, so an int64 millisecond truncation reported every single
+		// resume as 0 -- and this line is the only place the number is
+		// attributable to a user_id and client_id.
+		"duration_us", elapsed.Microseconds())
 	defer out.Unsub()()
 
 	defer func() {
@@ -264,7 +384,36 @@ func (h *UserEventsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Open the bounded live queue and flush frames that parked during the
 	// subscribe/scan window (before this writer loop). Order: bootstrap
 	// frame (above) → parked live catch-up → steady-state live queue.
-	for _, evt := range queue.Release() {
+	parked, dropped := queue.Release()
+	if dropped {
+		// The park buffer overflowed after the manager's last Overflowed()
+		// check -- i.e. during the bootstrap WRITE, which on a large account is
+		// the longest stretch of the parking window. Flushing what survived
+		// would leave this connection permanently short of whatever was
+		// dropped, silently and for its whole session, because liveCatchUpSink
+		// discards the send error and nothing downstream re-checks.
+		//
+		// Dropping the connection is the recovery, not just the alarm: every
+		// parked BATCH frame is strictly above the bootstrap's max_hlc (that is
+		// what sendTo's resumeSuppressThrough gate guarantees), so the client
+		// reconnects with that cursor and delta-resumes exactly the span this
+		// connection could not deliver. The deferred Close below fires on
+		// return, the same teardown the steady-state overflow arm already uses.
+		//
+		// The buffer also holds PRESENCE and WORKSPACE-LIFECYCLE frames, which
+		// broadcastTo sends outside that gate and which no ResumeDelta replays --
+		// so the delta argument above does not cover them. The reconnect does:
+		// the client re-derives workspace membership from the bootstrap frame
+		// (adoptBootstrapFrame fires onWorkspaceLifecycleChanged on EVERY
+		// bootstrap, for exactly this reason) and presence from the heartbeat it
+		// pings on the bootstrapped edge. Excluding those frames from parking
+		// instead would trade a bounded drop-and-rebootstrap for a silent
+		// per-frame loss, which is strictly worse.
+		slog.Warn("userevents: park buffer overflowed while writing the bootstrap frame; dropping the connection to force a re-bootstrap",
+			"user_id", user.ID, "client_id", clientID)
+		return
+	}
+	for _, evt := range parked {
 		if err := writeUserEvent(ctx, wsConn, evt); err != nil {
 			slog.Debug("userevents: write parked event failed", "user_id", user.ID, "error", err)
 			return

--- a/backend/internal/hub/service/ws_userevents_test.go
+++ b/backend/internal/hub/service/ws_userevents_test.go
@@ -2,12 +2,17 @@ package service_test
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/coder/websocket"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
@@ -19,9 +24,66 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/store"
 	"github.com/leapmux/leapmux/internal/hub/store/storetest"
 	hubtestutil "github.com/leapmux/leapmux/internal/hub/testutil"
+	"github.com/leapmux/leapmux/internal/metrics"
 	"github.com/leapmux/leapmux/internal/util/id"
 	"github.com/leapmux/leapmux/internal/util/userid"
 )
+
+// delegationBearer is everything a /ws/userevents test needs to dial with a
+// delegation Bearer: the validator to hand the handler, the session cache to
+// mount it against (and to evict through), and the minted credential.
+type delegationBearer struct {
+	tv           *auth.TokenValidator
+	sessionCache *auth.AuthContextRegistry
+	tokenID      string
+	secret       string
+}
+
+// authHeader is the Authorization header for this bearer.
+func (b delegationBearer) authHeader() http.Header {
+	hdr := http.Header{}
+	hdr.Set("Authorization", "Bearer "+auth.FormatBearer(auth.BearerKindDelegation, b.tokenID, b.secret))
+	return hdr
+}
+
+// newDelegationBearer registers a worker, wires a token validator with its
+// session cache, and mints a delegation token for `userID` -- the whole
+// preamble a /ws/userevents test needs before it can dial.
+//
+// Extracted because the three tests in this file that need one had it
+// character-for-character identical, so a field added to CreateWorkerParams or
+// CreateDelegationTokenParams had to be found in three places to stay
+// compiling.
+func newDelegationBearer(t *testing.T, st store.Store, userID string) delegationBearer {
+	t.Helper()
+	workerID := id.Generate()
+	require.NoError(t, st.Workers().Create(context.Background(), store.CreateWorkerParams{
+		ID:              workerID,
+		AuthToken:       id.Generate(),
+		RegisteredBy:    userid.MustNew(userID),
+		PublicKey:       []byte("test-x25519-key-32-bytes-padding"),
+		MlkemPublicKey:  []byte("mlkem"),
+		SlhdsaPublicKey: []byte("slhdsa"),
+	}))
+
+	tv, err := auth.NewTokenValidator(st, []byte("0123456789abcdef0123456789abcdef"))
+	require.NoError(t, err)
+	_, sessionCache := auth.NewInterceptorWithTokens(st, nil, tv, false, false)
+	t.Cleanup(sessionCache.Stop)
+
+	tokenID := id.Generate()
+	secret := auth.MintAccessSecret()
+	require.NoError(t, st.DelegationTokens().Create(context.Background(), store.CreateDelegationTokenParams{
+		ID:               tokenID,
+		UserID:           userid.MustNew(userID),
+		WorkerID:         workerID,
+		IssuedForTabID:   "tab-1",
+		IssuedForTabType: int32(leapmuxv1.TabType_TAB_TYPE_AGENT),
+		SecretHash:       tv.HashSecret(secret),
+		ExpiresAt:        time.Now().Add(time.Hour),
+	}))
+	return delegationBearer{tv: tv, sessionCache: sessionCache, tokenID: tokenID, secret: secret}
+}
 
 // TestUserEventsHandler_RevokingTheBearerClosesTheSubscription is the surviving
 // half of a test deleted with the workspace scope axis.
@@ -42,31 +104,7 @@ func TestUserEventsHandler_RevokingTheBearerClosesTheSubscription(t *testing.T) 
 	st := hubtestutil.OpenTestStore(t)
 	user := storetest.SeedUser(t, st, "alice")
 	workspaceID := storetest.SeedWorkspace(t, st, user.ID, "Allowed")
-	workerID := id.Generate()
-	require.NoError(t, st.Workers().Create(context.Background(), store.CreateWorkerParams{
-		ID:              workerID,
-		AuthToken:       id.Generate(),
-		RegisteredBy:    userid.MustNew(user.ID),
-		PublicKey:       []byte("test-x25519-key-32-bytes-padding"),
-		MlkemPublicKey:  []byte("mlkem"),
-		SlhdsaPublicKey: []byte("slhdsa"),
-	}))
-
-	tv, err := auth.NewTokenValidator(st, []byte("0123456789abcdef0123456789abcdef"))
-	require.NoError(t, err)
-	_, sessionCache := auth.NewInterceptorWithTokens(st, nil, tv, false, false)
-	t.Cleanup(sessionCache.Stop)
-	tokenID := id.Generate()
-	secret := auth.MintAccessSecret()
-	require.NoError(t, st.DelegationTokens().Create(context.Background(), store.CreateDelegationTokenParams{
-		ID:               tokenID,
-		UserID:           userid.MustNew(user.ID),
-		WorkerID:         workerID,
-		IssuedForTabID:   "tab-1",
-		IssuedForTabType: int32(leapmuxv1.TabType_TAB_TYPE_AGENT),
-		SecretHash:       tv.HashSecret(secret),
-		ExpiresAt:        time.Now().Add(time.Hour),
-	}))
+	bearer := newDelegationBearer(t, st, user.ID)
 
 	j := newMemJournal()
 	registry := crdt.NewRegistry(func(ctx context.Context, want userid.UserID) (*crdt.Manager, error) {
@@ -82,14 +120,13 @@ func TestUserEventsHandler_RevokingTheBearerClosesTheSubscription(t *testing.T) 
 	}, nil)
 	t.Cleanup(func() { registry.Shutdown(2 * time.Second) })
 
-	srv := httptest.NewServer(service.NewUserEventsHandler(st, registry, sessionCache, nil, false).
-		WithTokenValidator(tv))
+	srv := httptest.NewServer(service.NewUserEventsHandler(st, registry, bearer.sessionCache, nil, false).
+		WithTokenValidator(bearer.tv))
 	t.Cleanup(srv.Close)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	hdr := http.Header{}
-	hdr.Set("Authorization", "Bearer "+auth.FormatBearer(auth.BearerKindDelegation, tokenID, secret))
+	hdr := bearer.authHeader()
 	conn, _, err := websocket.Dial(ctx, "ws"+srv.URL[len("http"):], &websocket.DialOptions{HTTPHeader: hdr})
 	require.NoError(t, err)
 	defer func() { _ = conn.Close(websocket.StatusNormalClosure, "") }()
@@ -103,7 +140,7 @@ func TestUserEventsHandler_RevokingTheBearerClosesTheSubscription(t *testing.T) 
 	require.NotNil(t, event.GetInitial())
 	require.Contains(t, event.GetInitial().GetWorkspaces(), workspaceID)
 
-	sessionCache.EvictBearer(auth.NewBearerRef(auth.BearerKindDelegation, tokenID))
+	bearer.sessionCache.EvictBearer(auth.NewBearerRef(auth.BearerKindDelegation, bearer.tokenID))
 
 	readCtx, cancelRead := context.WithTimeout(context.Background(), time.Second)
 	defer cancelRead()
@@ -113,4 +150,362 @@ func TestUserEventsHandler_RevokingTheBearerClosesTheSubscription(t *testing.T) 
 	// failure: the lease was cancelled and the stream stayed open.
 	require.NotErrorIs(t, err, context.DeadlineExceeded,
 		"the user-event subscription remained open after its authenticated lease was cancelled")
+}
+
+// TestUserEventsHandler_AFailedSubscribeIsStillCounted pins that
+// leapmux_userevents_subscribe_total is a COMPLETE partition of connect
+// outcomes, not just the successful ones.
+//
+// The counter was originally incremented inside an `if err == nil` guard, which
+// made the failure arm invisible: a deployment whose ACL resolve started
+// erroring showed a FALL in subscribe volume, indistinguishable from a fall in
+// traffic, with no error series to explain it -- the metric going quiet exactly
+// when an operator reaches for it. A connect that selects no bootstrap arm is
+// labelled with the zero mode and reason, both of which spell themselves
+// "invalid".
+//
+// The failure is driven through the resume tail read, which is the reachable
+// hard-error return: the ACL resolve FILTERS workspaces the user cannot see
+// rather than rejecting them, so a forbidden workspace_ids yields an empty
+// filter and a perfectly successful connect.
+func TestUserEventsHandler_AFailedSubscribeIsStillCounted(t *testing.T) {
+	st := hubtestutil.OpenTestStore(t)
+	user := storetest.SeedUser(t, st, "alice")
+
+	bearer := newDelegationBearer(t, st, user.ID)
+
+	j := newMemJournal()
+	j.listErr = errors.New("journal unavailable")
+	// Built here rather than inside the factory so the cursor below can be
+	// minted against this manager's LIVE epoch. A mismatched epoch (or a cursor
+	// under the 24h retention floor) is a perfectly ordinary FALLBACK, which
+	// succeeds -- and would never reach the tail read this test fails.
+	mgr := crdt.NewManager(userid.MustNew(user.ID), j, allowAllAuth{}, nil, time.Now)
+	require.NoError(t, mgr.Bootstrap(context.Background()))
+	epoch := mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch()
+	registry := crdt.NewRegistry(func(_ context.Context, _ userid.UserID) (*crdt.Manager, error) {
+		return mgr, nil
+	}, nil)
+	t.Cleanup(func() { registry.Shutdown(2 * time.Second) })
+
+	srv := httptest.NewServer(service.NewUserEventsHandler(st, registry, bearer.sessionCache, nil, false).
+		WithTokenValidator(bearer.tv))
+	t.Cleanup(srv.Close)
+
+	before := testutil.ToFloat64(metrics.UserEventsSubscribeTotal.WithLabelValues("invalid", "invalid"))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	hdr := bearer.authHeader()
+	// A cursor is what selects the RESUME arm, whose tail read the journal above
+	// fails. It must be recent enough to clear the retention floor and carry the
+	// live epoch, or the connect FALLBACKs instead and succeeds.
+	cursor := channelwire.EncodeResumeHLC(&leapmuxv1.HLC{
+		Physical: time.Now().UnixMilli(), Logical: 0, ClientId: "c1",
+	})
+	conn, _, dialErr := websocket.Dial(ctx,
+		"ws"+srv.URL[len("http"):]+
+			"?resume_after_hlc="+cursor+
+			"&resume_epoch="+strconv.FormatInt(epoch, 10),
+		&websocket.DialOptions{HTTPHeader: hdr})
+	if dialErr == nil {
+		// The handler upgrades before subscribing, so the failure arrives as a
+		// close frame rather than a failed dial.
+		_, readErr := channelwire.ReadFramedBytes(ctx, conn)
+		require.Error(t, readErr, "a failed subscribe must not stream a bootstrap frame")
+		_ = conn.Close(websocket.StatusNormalClosure, "")
+	}
+
+	after := testutil.ToFloat64(metrics.UserEventsSubscribeTotal.WithLabelValues("invalid", "invalid"))
+	require.Equal(t, before+1, after,
+		"a failed connect must still be counted, or the metric has no denominator for failures")
+}
+
+// TestUserEventsHandler_ParkOverflowDuringTheBootstrapWriteDropsTheConnection
+// covers the last stretch of the parking window: the bootstrap WRITE.
+//
+// The manager checks Overflowed() before it builds the bootstrap frame, and the
+// subscriber stays registered (and therefore parking) until Release() runs after
+// that frame is on the wire. On a large account the write is the longest part of
+// that window and is bounded only by relayWriteTimeout, so a burst of commits
+// can fill the 256-slot park buffer inside it. Every further Send returns
+// ErrSubscriberSlow, which liveCatchUpSink DISCARDS -- so before this fix the
+// handler flushed whatever survived and streamed on, leaving the tab
+// permanently missing that span with nothing logged and nothing to recover from.
+//
+// The connection must be dropped instead: every parked batch frame is strictly
+// above the bootstrap's max_hlc, so the client reconnects with that cursor and
+// delta-resumes exactly what was lost.
+func TestUserEventsHandler_ParkOverflowDuringTheBootstrapWriteDropsTheConnection(t *testing.T) {
+	st := hubtestutil.OpenTestStore(t)
+	user := storetest.SeedUser(t, st, "alice")
+	workspaceID := storetest.SeedWorkspace(t, st, user.ID, "Big")
+
+	bearer := newDelegationBearer(t, st, user.ID)
+
+	// Big enough that the bootstrap frame takes long enough to write that the
+	// commits below land inside the window.
+	j := newMemJournal()
+	var mgr *crdt.Manager
+	registry := crdt.NewRegistry(func(ctx context.Context, want userid.UserID) (*crdt.Manager, error) {
+		m := crdt.NewManager(want, j, allowAllAuth{}, nil, time.Now)
+		require.NoError(t, m.Bootstrap(ctx))
+		m.SeedStateForTest(func(s *leapmuxv1.UserCrdtState) {
+			s.Workspaces[workspaceID] = &leapmuxv1.WorkspaceContentsRecord{
+				WorkspaceId: workspaceID, RootNodeId: "root",
+			}
+			s.Nodes["root"] = &leapmuxv1.NodeRecord{
+				NodeId: "root",
+				Kind:   &leapmuxv1.LWWNodeKind{Value: leapmuxv1.NodeKind_NODE_KIND_LEAF},
+			}
+			// Padded so the bootstrap frame is multi-MB and its write is long
+			// enough for the burst below to land inside the parking window.
+			// Every field completenessCheck requires must be present, or the
+			// burst is rejected INCOMPLETE_RECORD and nothing is broadcast.
+			pad := strings.Repeat("p", 512)
+			for i := range 8000 {
+				tabID := fmt.Sprintf("tab-%05d", i)
+				s.Tabs[tabID] = &leapmuxv1.TabRecord{
+					TabId: tabID, TabType: leapmuxv1.TabType_TAB_TYPE_AGENT,
+					TileId:       &leapmuxv1.LWWString{Value: "root"},
+					WorkerId:     &leapmuxv1.LWWString{Value: "wkr"},
+					Position:     &leapmuxv1.LWWString{Value: "p1"},
+					FileDiffBase: &leapmuxv1.LWWString{Value: pad},
+				}
+			}
+		})
+		mgr = m
+		return m, nil
+	}, nil)
+	t.Cleanup(func() { registry.Shutdown(2 * time.Second) })
+
+	srv := httptest.NewServer(service.NewUserEventsHandler(st, registry, bearer.sessionCache, nil, false).
+		WithTokenValidator(bearer.tv))
+	t.Cleanup(srv.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	hdr := bearer.authHeader()
+	conn, _, err := websocket.Dial(ctx, "ws"+srv.URL[len("http"):], &websocket.DialOptions{HTTPHeader: hdr})
+	require.NoError(t, err)
+	defer func() { _ = conn.Close(websocket.StatusNormalClosure, "") }()
+	conn.SetReadLimit(64 << 20)
+
+	// Do NOT read yet: the handler blocks in writeUserEvent on the multi-MB
+	// bootstrap frame, which holds the parking window open.
+	time.Sleep(500 * time.Millisecond)
+	require.NotNil(t, mgr, "the registry factory must have run")
+	// Overflow the 256-slot park buffer from inside that window.
+	committed := 0
+	for i := range 150 {
+		res, subErr := mgr.SubmitInternal(context.Background(), crdt.SubmitInput{
+			Batches: []*leapmuxv1.OpBatch{{
+				BatchId: fmt.Sprintf("burst-%d", i),
+				Ops: []*leapmuxv1.CrdtOp{{
+					OpId: fmt.Sprintf("op-burst-%d", i),
+					Body: &leapmuxv1.CrdtOp_SetNodeRegister{SetNodeRegister: &leapmuxv1.SetNodeRegisterOp{
+						NodeId: "root",
+						Field:  &leapmuxv1.SetNodeRegisterOp_Position{Position: fmt.Sprintf("z%04d", i)},
+					}},
+				}},
+			}},
+		})
+		if subErr == nil && len(res) == 1 && res[0].GetCommitted() != nil {
+			committed++
+		}
+	}
+	// Each committed batch broadcasts TWO frames -- the batch itself and its
+	// batch_end boundary -- so the park buffer only overflows past
+	// parkedFrameCap/2 commits. Stating the precondition as that arithmetic
+	// rather than as a round number below it is what keeps a partially-
+	// committing burst from failing at the overflow assertion instead, with a
+	// diagnosis that blames the feature.
+	require.Greater(t, committed*2, service.ParkedFrameCapForTest,
+		"the burst must commit enough batches to overflow the park buffer, or there is nothing to drop")
+
+	// The bootstrap frame itself still arrives.
+	payload, err := channelwire.ReadFramedBytes(ctx, conn)
+	require.NoError(t, err)
+	event := &leapmuxv1.WatchUserEvent{}
+	require.NoError(t, proto.Unmarshal(payload, event))
+	require.NotNil(t, event.GetInitial(), "the bootstrap frame is written before the drop is noticed")
+
+	// ...and then the socket CLOSES rather than flushing a park buffer with a
+	// hole in it. Before the fix a parked frame arrived here instead, and the
+	// dropped span was gone for the life of the connection.
+	_, err = channelwire.ReadFramedBytes(ctx, conn)
+	require.Error(t, err,
+		"a park-buffer overflow during the bootstrap write must drop the connection, not flush over the hole")
+	require.NotErrorIs(t, err, context.DeadlineExceeded,
+		"the socket must be closed, not merely quiet")
+}
+
+// TestUserEventsHandler_CountsTheSuccessArmsAndTheDuration pins the label pair
+// the metric is actually queried by.
+//
+// Only the {invalid, invalid} cell had coverage, and that cell is the one a
+// dashboard never graphs. The join of Mode().Label() with Reason().String()
+// happens HERE, in the service layer -- crdt's vocabulary test pins the strings
+// but not which one goes in which position -- so a refactor that swapped the two
+// WithLabelValues arguments, or dropped the Observe, shipped a series no
+// dashboard matches with the whole suite green.
+func TestUserEventsHandler_CountsTheSuccessArmsAndTheDuration(t *testing.T) {
+	st := hubtestutil.OpenTestStore(t)
+	user := storetest.SeedUser(t, st, "alice")
+	workspaceID := storetest.SeedWorkspace(t, st, user.ID, "Allowed")
+
+	j := newMemJournal()
+	registry := crdt.NewRegistry(func(ctx context.Context, want userid.UserID) (*crdt.Manager, error) {
+		mgr := crdt.NewManager(want, j, allowAllAuth{}, nil, time.Now)
+		require.NoError(t, mgr.Bootstrap(ctx))
+		mgr.SeedStateForTest(func(s *leapmuxv1.UserCrdtState) {
+			s.Workspaces[workspaceID] = &leapmuxv1.WorkspaceContentsRecord{
+				WorkspaceId: workspaceID, RootNodeId: "root",
+			}
+			s.Nodes["root"] = &leapmuxv1.NodeRecord{NodeId: "root"}
+			// A non-zero max_hlc, so the snapshot below carries a cursor the
+			// second connect can actually resume from -- decideResume refuses a
+			// zero one, and the arm under test would never be reached.
+			s.MaxHlc = &leapmuxv1.HLC{Physical: time.Now().UnixMilli(), Logical: 0, ClientId: "hub"}
+		})
+		return mgr, nil
+	}, nil)
+	t.Cleanup(func() { registry.Shutdown(2 * time.Second) })
+
+	bearer := newDelegationBearer(t, st, user.ID)
+	srv := httptest.NewServer(service.NewUserEventsHandler(st, registry, bearer.sessionCache, nil, false).
+		WithTokenValidator(bearer.tv))
+	t.Cleanup(srv.Close)
+
+	// A first connect presents no cursor, so it takes the FALLBACK arm.
+	coldBefore := testutil.ToFloat64(metrics.UserEventsSubscribeTotal.WithLabelValues("initial", "no_cursor"))
+	observedBefore := testutil.CollectAndCount(metrics.UserEventsSubscribeDuration)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, _, err := websocket.Dial(ctx, "ws"+srv.URL[len("http"):], &websocket.DialOptions{HTTPHeader: bearer.authHeader()})
+	require.NoError(t, err)
+	payload, err := channelwire.ReadFramedBytes(ctx, conn)
+	require.NoError(t, err)
+	event := &leapmuxv1.WatchUserEvent{}
+	require.NoError(t, proto.Unmarshal(payload, event))
+	require.NotNil(t, event.GetInitial(), "a cursorless connect must take the snapshot arm")
+	maxHlc := event.GetInitial().GetMaxHlc()
+	epoch := event.GetInitial().GetCurrentEpoch()
+	_ = conn.Close(websocket.StatusNormalClosure, "")
+
+	require.Equal(t, coldBefore+1, testutil.ToFloat64(metrics.UserEventsSubscribeTotal.WithLabelValues("initial", "no_cursor")),
+		"a cursorless connect must land in {initial, no_cursor}, not some other cell")
+	require.Greater(t, testutil.CollectAndCount(metrics.UserEventsSubscribeDuration), observedBefore-1,
+		"the duration histogram must be observed at all")
+
+	// ...and a connect that presents that snapshot's own cursor RESUMEs.
+	require.NotNil(t, maxHlc, "fixture: the snapshot must carry a max_hlc to resume from")
+	deltaBefore := testutil.ToFloat64(metrics.UserEventsSubscribeTotal.WithLabelValues("delta", "resumed"))
+	resumed, _, err := websocket.Dial(ctx,
+		"ws"+srv.URL[len("http"):]+
+			"?resume_after_hlc="+channelwire.EncodeResumeHLC(maxHlc)+
+			"&resume_epoch="+strconv.FormatInt(epoch, 10),
+		&websocket.DialOptions{HTTPHeader: bearer.authHeader()})
+	require.NoError(t, err)
+	payload, err = channelwire.ReadFramedBytes(ctx, resumed)
+	require.NoError(t, err)
+	event = &leapmuxv1.WatchUserEvent{}
+	require.NoError(t, proto.Unmarshal(payload, event))
+	require.NotNil(t, event.GetDelta(), "fixture: the cursor must be honored, or the label under test is not reached")
+	_ = resumed.Close(websocket.StatusNormalClosure, "")
+
+	require.Equal(t, deltaBefore+1, testutil.ToFloat64(metrics.UserEventsSubscribeTotal.WithLabelValues("delta", "resumed")),
+		"a resumed connect must land in {delta, resumed}")
+}
+
+// TestUserEventsHandler_CountsAConnectThatNeverReachedSubscribe closes the hole
+// the counter's own doc names.
+//
+// registry.Get is where the manager loads its state from the journal, so a hub
+// whose user_state read starts failing returns BEFORE the subscribe -- and while
+// that return was uncounted, the series fell to zero across the fleet with no
+// error cell to explain it, which is exactly the "indistinguishable from a fall
+// in traffic" pathology the mode=invalid arm was added for.
+func TestUserEventsHandler_CountsAConnectThatNeverReachedSubscribe(t *testing.T) {
+	st := hubtestutil.OpenTestStore(t)
+	user := storetest.SeedUser(t, st, "alice")
+
+	registry := crdt.NewRegistry(func(context.Context, userid.UserID) (*crdt.Manager, error) {
+		return nil, errors.New("user_state read failed")
+	}, nil)
+	t.Cleanup(func() { registry.Shutdown(2 * time.Second) })
+
+	bearer := newDelegationBearer(t, st, user.ID)
+	srv := httptest.NewServer(service.NewUserEventsHandler(st, registry, bearer.sessionCache, nil, false).
+		WithTokenValidator(bearer.tv))
+	t.Cleanup(srv.Close)
+
+	before := testutil.ToFloat64(metrics.UserEventsSubscribeTotal.WithLabelValues("invalid", "invalid"))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, _, err := websocket.Dial(ctx, "ws"+srv.URL[len("http"):], &websocket.DialOptions{HTTPHeader: bearer.authHeader()})
+	require.Error(t, err, "the upgrade must fail when the manager cannot be built")
+
+	require.Equal(t, before+1, testutil.ToFloat64(metrics.UserEventsSubscribeTotal.WithLabelValues("invalid", "invalid")),
+		"a connect that failed before the subscribe must still be counted")
+}
+
+// TestUserEventsHandler_RefusesACursorUnderANarrowedFilter pins the hub-side
+// half of the narrow-mint/wide-replay invariant.
+//
+// The persisted cursor is per-USER and, since the checkpoint seed, cross-TAB --
+// so one minted under a narrow workspace filter and replayed under a wider one
+// can miss ops. The browser already refuses the pairing, but that made a
+// correctness invariant the property of one client out of three; enforcing it
+// here makes it unspellable for every client, including ones not written yet.
+//
+// REJECTED, not silently degraded to a snapshot: the malformed-cursor arm
+// immediately above takes the same position, and for the same reason.
+func TestUserEventsHandler_RefusesACursorUnderANarrowedFilter(t *testing.T) {
+	st := hubtestutil.OpenTestStore(t)
+	user := storetest.SeedUser(t, st, "alice")
+	workspaceID := storetest.SeedWorkspace(t, st, user.ID, "Allowed")
+
+	j := newMemJournal()
+	registry := crdt.NewRegistry(func(ctx context.Context, want userid.UserID) (*crdt.Manager, error) {
+		mgr := crdt.NewManager(want, j, allowAllAuth{}, nil, time.Now)
+		require.NoError(t, mgr.Bootstrap(ctx))
+		return mgr, nil
+	}, nil)
+	t.Cleanup(func() { registry.Shutdown(2 * time.Second) })
+
+	bearer := newDelegationBearer(t, st, user.ID)
+	srv := httptest.NewServer(service.NewUserEventsHandler(st, registry, bearer.sessionCache, nil, false).
+		WithTokenValidator(bearer.tv))
+	t.Cleanup(srv.Close)
+
+	before := testutil.ToFloat64(metrics.UserEventsSubscribeTotal.WithLabelValues("invalid", "invalid"))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cursor := channelwire.EncodeResumeHLC(&leapmuxv1.HLC{
+		Physical: time.Now().UnixMilli(), Logical: 0, ClientId: "c1",
+	})
+	_, _, err := websocket.Dial(ctx,
+		"ws"+srv.URL[len("http"):]+
+			"?workspace_ids="+workspaceID+
+			"&resume_after_hlc="+cursor+
+			"&resume_epoch=1",
+		&websocket.DialOptions{HTTPHeader: bearer.authHeader()})
+	require.Error(t, err, "workspace_ids together with a resume cursor must be refused, not served")
+	require.Contains(t, err.Error(), "400",
+		"...loudly, as a client bug, rather than degraded to a snapshot")
+
+	// Counted like every other authenticated connect that selects no arm.
+	require.Equal(t, before+1, testutil.ToFloat64(metrics.UserEventsSubscribeTotal.WithLabelValues("invalid", "invalid")))
+
+	// The SAME narrowed connect without a cursor is still perfectly legal --
+	// the guard is on the pairing, not on narrowing.
+	conn, _, err := websocket.Dial(ctx,
+		"ws"+srv.URL[len("http"):]+"?workspace_ids="+workspaceID,
+		&websocket.DialOptions{HTTPHeader: bearer.authHeader()})
+	require.NoError(t, err, "a narrowed connect with NO cursor must still be served")
+	_ = conn.Close(websocket.StatusNormalClosure, "")
 }

--- a/backend/internal/metrics/metrics.go
+++ b/backend/internal/metrics/metrics.go
@@ -52,6 +52,37 @@ var (
 	})
 )
 
+// User-event subscribe metrics.
+//
+// The RESUME-vs-FALLBACK ratio and, when it is FALLBACK, the reason, are the
+// only way to tell from outside whether delta-resume is doing its job for a
+// given deployment: a fleet that is mostly `no_cursor` has clients that are not
+// persisting checkpoints, one that is mostly `below_retention_floor` has an
+// op-retention window that is too short for how its users work, and
+// `corrupt_row` / `park_overflow` are defects. Labelled from the service layer,
+// which reads crdt.SubscribeOutcome's Mode and Reason.
+//
+// Every connect attempt is counted, successful or not, so the series is a
+// complete partition of outcomes: a failed connect selected no bootstrap arm
+// and lands in mode="invalid", reason="invalid". Without that arm a deployment
+// whose ACL resolve started failing would show a DROP in subscribe volume,
+// indistinguishable from a drop in traffic.
+var (
+	UserEventsSubscribeTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "leapmux_userevents_subscribe_total",
+		Help: "Total /ws/userevents subscribe attempts, by bootstrap mode and the reason for it. A failed connect is mode=invalid.",
+	}, []string{"mode", "reason"})
+
+	UserEventsSubscribeDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "leapmux_userevents_subscribe_duration_seconds",
+		Help: "Time to resolve the ACL, register, and build the bootstrap frame for a /ws/userevents connect.",
+		// A fallback baseline is milliseconds on a large account while a resume
+		// is microseconds, so the default buckets (which start at 5ms) put both
+		// in the first bucket and answer nothing.
+		Buckets: []float64{.0001, .00025, .0005, .001, .0025, .005, .01, .025, .05, .1, .25, .5, 1},
+	}, []string{"mode"})
+)
+
 // WebSocket metrics.
 var (
 	WSConnectionsActive = promauto.NewGauge(prometheus.GaugeOpts{

--- a/frontend/src/components/shell/useCrdtRuntime.test.ts
+++ b/frontend/src/components/shell/useCrdtRuntime.test.ts
@@ -11,12 +11,24 @@ import { fullCheckpointDelta } from '~/lib/crdt/checkpointChunks'
 import { CHECKPOINT_OP_LOG_THRESHOLD } from '~/lib/crdt/checkpointRecorder'
 import {
   _resetCheckpointStoreForTest,
+  adoptCheckpoint,
+  CHECKPOINT_MAX_OWNERS,
+  CHECKPOINT_TTL_MS,
   readCheckpoint,
+  SEED_CANDIDATE_MAX_AGE_MS,
   writeCheckpointAndTruncateOpLog,
 } from '~/lib/crdt/checkpointStore'
+
 import { createActiveClientStore } from '~/lib/presence/activeClient'
 import { createOpLogAppender } from '~/test-support/opLog'
 import { useCrdtRuntime } from './useCrdtRuntime'
+
+// Partially mocked so ONE case can force the sibling adoption to fail; every
+// other export, adoptCheckpoint included, stays the real implementation.
+vi.mock('~/lib/crdt/checkpointStore', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/lib/crdt/checkpointStore')>()
+  return { ...actual, adoptCheckpoint: vi.fn(actual.adoptCheckpoint) }
+})
 
 const opLog = createOpLogAppender()
 
@@ -59,12 +71,24 @@ vi.mock('~/lib/crdt/checkpointRecorder', async (importOriginal) => {
   }
 })
 
-const hydrateSpy = vi.hoisted(() => ({ throwOnNextRead: false, hangNextRead: false }))
+const hydrateSpy = vi.hoisted(() => ({
+  throwOnNextRead: false,
+  hangNextRead: false,
+  // The options the runtime actually handed the read, so a test can invoke the
+  // supersession predicate itself. Recorded even on the hang path, which is the
+  // only one that reaches the deadline.
+  lastOpts: undefined as { superseded?: () => boolean } | undefined,
+}))
 vi.mock('~/lib/crdt/hydrate', async (importOriginal) => {
   const actual = await importOriginal<typeof import('~/lib/crdt/hydrate')>()
   return {
     ...actual,
-    loadHydrationState: async (userId: string, clientId: string) => {
+    // Signature MIRRORED via Parameters<>, not restated. A hand-written
+    // (userId, clientId) pair silently DROPPED the options argument the moment
+    // loadHydrationState grew one -- which would have disabled the seed's
+    // supersession guard in every test in this file while they all still passed.
+    loadHydrationState: async (...args: Parameters<typeof actual.loadHydrationState>) => {
+      hydrateSpy.lastOpts = args[2]
       if (hydrateSpy.throwOnNextRead) {
         hydrateSpy.throwOnNextRead = false
         throw new Error('hydration read blew up')
@@ -74,7 +98,7 @@ vi.mock('~/lib/crdt/hydrate', async (importOriginal) => {
         // Never settles -- the one shape a try/catch cannot see.
         return new Promise(() => {})
       }
-      return actual.loadHydrationState(userId, clientId)
+      return actual.loadHydrationState(...args)
     },
   }
 })
@@ -91,6 +115,21 @@ async function settle(): Promise<void> {
 }
 
 /**
+ * The supersession predicate the runtime actually handed `loadHydrationState`,
+ * failing loudly if it handed none.
+ *
+ * A function rather than a direct `hydrateSpy.lastOpts` read so the caller gets
+ * the DECLARED type: reading the property in a test body that also assigns to it
+ * lets control-flow analysis narrow it to `undefined`.
+ */
+function handedSupersessionGuard(): () => boolean {
+  const opts = hydrateSpy.lastOpts
+  if (!opts?.superseded)
+    throw new Error('loadHydrationState was called without a supersession guard')
+  return opts.superseded
+}
+
+/**
  * Settle until `until` holds, or give up after a bounded number of turns.
  *
  * Positive assertions ("the gate opened") must poll rather than take a fixed
@@ -102,6 +141,17 @@ async function settle(): Promise<void> {
  */
 async function settleUntil(until: () => boolean): Promise<void> {
   for (let i = 0; i < 200 && !until(); i++)
+    await new Promise(resolve => setTimeout(resolve, 0))
+}
+
+/**
+ * settleUntil for a predicate that must AWAIT (an IDB read, say). Separate
+ * rather than widening settleUntil's type: a sync predicate accidentally passed
+ * to an async-aware loop would be awaited as a non-promise and pass on its
+ * first truthy value, which is the same shape of bug in reverse.
+ */
+async function settleUntilAsync(until: () => Promise<boolean>): Promise<void> {
+  for (let i = 0; i < 200 && !(await until()); i++)
     await new Promise(resolve => setTimeout(resolve, 0))
 }
 
@@ -290,6 +340,54 @@ describe('useCrdtRuntime hydration gate', () => {
     }
   })
 
+  // The WIRING of the supersession guard, which nothing else covers.
+  //
+  // hydrate.test.ts proves the option's own behaviour (superseded() true => no
+  // write). What it cannot see is whether this file ever passes one, or whether
+  // the thing that is supposed to flip it on the deadline is connected: every
+  // other test here runs with cancelled === false and deadlineMissed === false,
+  // so deleting `onTimeout?.()` from withTimeout, dropping its third argument,
+  // or removing `superseded:` from the call left all of them green -- while
+  // reopening the hazard the guard exists for. A late adoption landing after the
+  // cold start has rewritten the checkpoint leaves a hole in the op-log whose
+  // replayed batchEnd frames advance the resume cursor straight past it.
+  it('flips the supersession guard it handed the read once the deadline wins', async () => {
+    vi.useFakeTimers()
+    try {
+      hydrateSpy.hangNextRead = true
+      const { dispose } = mountRuntime(() => 'user-superseded')
+      await vi.advanceTimersByTimeAsync(0)
+
+      const superseded = handedSupersessionGuard()
+      expect(superseded(), 'nothing has superseded the run yet').toBe(false)
+
+      // Past the watchdog deadline: the run is abandoned but NOT cancelled, so
+      // the predicate is the only thing standing between a late seed and a
+      // checkpoint the cold start has already rewritten.
+      await vi.advanceTimersByTimeAsync(10_001)
+      expect(superseded(), 'the deadline must mark the run superseded').toBe(true)
+      dispose()
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+
+  // The other supersession cause: the effect re-running or the owner being
+  // disposed, which must mark the in-flight read superseded even though no
+  // deadline fired.
+  it('flips the supersession guard when the run is disposed mid-read', async () => {
+    hydrateSpy.hangNextRead = true
+    const { dispose } = mountRuntime(() => 'user-disposed')
+    await settle()
+
+    const superseded = handedSupersessionGuard()
+    expect(superseded()).toBe(false)
+
+    dispose()
+    expect(superseded(), 'disposal must mark the run superseded').toBe(true)
+  })
+
   it('keeps the ready gate shut with no user id', async () => {
     const { dispose } = mountRuntime(() => '')
     await settle()
@@ -458,7 +556,9 @@ describe('useCrdtRuntime recorder seeding', () => {
     await settleUntil(() => userEventsSpy.ready!())
 
     const recorder = recorderSpy.instances.at(-1)!
-    expect(recorderSpy.options.at(-1)!.hydratedFrom!.frames).toHaveLength(2)
+    // Awaited because the option is a value on the SELF path and a promise on
+    // the seed path; `await` reads both.
+    expect((await recorderSpy.options.at(-1)!.hydratedFrom)!.frames).toHaveLength(2)
     // Counted, so the threshold measures the WHOLE persisted log, not just
     // post-hydration appends.
     expect(recorder.opLogCount).toBe(2)
@@ -591,5 +691,183 @@ describe('useCrdtRuntime when the hydration chain throws', () => {
     expect(userEventsSpy.ready!()).toBe(true)
     expect(runtime.crdtState()).not.toBeNull()
     dispose()
+  })
+})
+
+// Seeding a NEW tab from a sibling's checkpoint. The runtime's client id is
+// pinned to CLIENT, so a row written under any OTHER id is a sibling's.
+describe('useCrdtRuntime sibling seeding', () => {
+  beforeEach(() => {
+    vi.stubGlobal('indexedDB', new IDBFactory())
+    vi.stubGlobal('IDBKeyRange', IDBKeyRange)
+    sessionStorageSet(KEY_CLIENT_ID, CLIENT)
+    _resetCheckpointStoreForTest()
+    userEventsSpy.ready = null
+    recorderSpy.options = []
+    recorderSpy.instances = []
+    recorderSpy.failNextConstruction = false
+    hydrateSpy.throwOnNextRead = false
+    hydrateSpy.hangNextRead = false
+  })
+  afterEach(() => {
+    _resetCheckpointStoreForTest()
+    vi.unstubAllGlobals()
+  })
+
+  /** Seed a sibling owner (a client id that is NOT this tab's). */
+  function seedSibling(userId: string, clientId: string, lastSeenAt?: number): Promise<boolean> {
+    return writeCheckpointAndTruncateOpLog(
+      userId,
+      clientId,
+      fullCheckpointDelta(seededState(userId)),
+      WM,
+      1n,
+      lastSeenAt,
+    )
+  }
+
+  it('opens the ready gate with the sibling\'s state when this tab has no checkpoint', async () => {
+    await seedSibling('user-1', 'c-other-tab')
+    const { runtime, dispose } = mountRuntime(() => 'user-1')
+    try {
+      await settleUntil(() => userEventsSpy.ready!())
+      expect(userEventsSpy.ready!()).toBe(true)
+      // Asserting on the STATE, not just the gate: the gate opens on every cold
+      // start too, so it alone cannot tell a seed from a full-snapshot start.
+      expect(runtime.crdtState()!.workspaces['ws-1']).toBeDefined()
+    }
+    finally {
+      dispose()
+    }
+  })
+
+  it('writes the copy under THIS tab\'s client id and leaves the sibling\'s row', async () => {
+    await seedSibling('user-1', 'c-other-tab')
+    const before = await readCheckpoint('user-1', 'c-other-tab')
+    const { dispose } = mountRuntime(() => 'user-1')
+    try {
+      await settleUntil(() => userEventsSpy.ready!())
+      await settleUntilAsync(async () => (await readCheckpoint('user-1', CLIENT)).status === 'ok')
+
+      expect((await readCheckpoint('user-1', CLIENT)).status).toBe('ok')
+      expect(await readCheckpoint('user-1', 'c-other-tab')).toEqual(before)
+    }
+    finally {
+      dispose()
+    }
+  })
+
+  it('hands the recorder the seeded base, so its first rewrite is INCREMENTAL', async () => {
+    await seedSibling('user-1', 'c-other-tab')
+    const { dispose } = mountRuntime(() => 'user-1')
+    try {
+      await settleUntil(() => userEventsSpy.ready!())
+      expect(recorderSpy.options.at(-1)!.clientId).toBe(CLIENT)
+
+      // The ready gate does NOT wait for the adoption -- that is the point of
+      // handing the recorder a promise -- so settle until the base lands before
+      // asking what the recorder made of it.
+      await recorderSpy.options.at(-1)!.hydratedFrom
+      await settleUntil(() => !recorderSpy.instances.at(-1)!.needsFullRewrite)
+      expect(recorderSpy.instances.at(-1)!.needsFullRewrite).toBe(false)
+    }
+    finally {
+      dispose()
+    }
+  })
+
+  // THE WIN, pinned: the /ws/userevents connect is gated on `ready`, and `ready`
+  // must not wait out an adoption that writes one row per entity. Before the
+  // recorder learned to hold its own appends, hydrateAndInstall awaited the
+  // whole adopt transaction before opening the gate.
+  it('opens the ready gate while the adoption is still committing', async () => {
+    await seedSibling('user-1', 'c-other-tab')
+    let resolveAdopt: (nextOrdinal: number | null) => void = () => {}
+    vi.mocked(adoptCheckpoint).mockImplementationOnce(
+      () => new Promise<number | null>((resolve) => { resolveAdopt = resolve }),
+    )
+    const { dispose } = mountRuntime(() => 'user-1')
+    try {
+      await settleUntil(() => userEventsSpy.ready!())
+      // Open, with the adoption still in flight.
+      expect(userEventsSpy.ready!()).toBe(true)
+      // ...and the recorder is HOLDING rather than guessing: it has no base yet,
+      // so it must not have decided the chunks are a valid incremental one.
+      expect(recorderSpy.instances.at(-1)!.needsFullRewrite).toBe(true)
+
+      resolveAdopt(1)
+      await settleUntil(() => !recorderSpy.instances.at(-1)!.needsFullRewrite)
+      expect(recorderSpy.instances.at(-1)!.needsFullRewrite).toBe(false)
+    }
+    finally {
+      dispose()
+    }
+  })
+
+  // The write-side half of the corruption policy: an incremental rewrite is
+  // only sound over chunks that are actually on disk.
+  it('gives the recorder NO base when the adoption write did not land', async () => {
+    await seedSibling('user-1', 'c-other-tab')
+    vi.mocked(adoptCheckpoint).mockResolvedValueOnce(null)
+    const { runtime, dispose } = mountRuntime(() => 'user-1')
+    try {
+      await settleUntil(() => userEventsSpy.ready!())
+      // Still hydrated -- the state is correct in memory, so the tab resumes.
+      expect(runtime.crdtState()!.workspaces['ws-1']).toBeDefined()
+      // ...but its persistence restarts from a FULL rewrite.
+      expect(recorderSpy.instances.at(-1)!.needsFullRewrite).toBe(true)
+      // `needsFullRewrite` alone cannot say WHICH: it is `base !== 'ready'`, so
+      // it is equally true while the recorder is still HOLDING -- the sibling
+      // test above asserts exactly that. So pin the discriminating half: the
+      // recorder must be out of the hold and writing. A regression that never
+      // routed the failed adoption into adoptBase would leave it pending
+      // forever -- every append held, nothing persisted for the session -- and
+      // the assertion above would still pass.
+      const recorder = recorderSpy.instances.at(-1)!
+      recorder.rewriteNow()
+      await settleUntilAsync(async () =>
+        (await readCheckpoint('user-1', recorderSpy.options.at(-1)!.clientId)).status === 'ok')
+      const own = await readCheckpoint('user-1', recorderSpy.options.at(-1)!.clientId)
+      expect(own.status).toBe('ok')
+    }
+    finally {
+      dispose()
+    }
+  })
+
+  it('cold-starts when the only sibling is past the retention window', async () => {
+    await seedSibling('user-1', 'c-other-tab', Date.now() - SEED_CANDIDATE_MAX_AGE_MS - 1)
+    const { runtime, dispose } = mountRuntime(() => 'user-1')
+    try {
+      await settleUntil(() => userEventsSpy.ready!())
+      expect(userEventsSpy.ready!()).toBe(true)
+      // Cold-started: an EMPTY manager, not the sibling's state. (crdtState is
+      // non-null on this path -- the manager exists, it just has nothing in it.)
+      expect(runtime.crdtState()!.workspaces['ws-1']).toBeUndefined()
+      expect(recorderSpy.instances.at(-1)!.needsFullRewrite).toBe(true)
+    }
+    finally {
+      dispose()
+    }
+  })
+
+  // The sweep runs AFTER the adoption, and must not collect the row this tab
+  // just wrote: isLive short-circuits on keepClientId, and `reserved` excludes
+  // it before adding the 1, so it is not double-counted against the cap.
+  it('keeps the freshly seeded row when the post-install sweep runs', async () => {
+    for (let i = 0; i < CHECKPOINT_MAX_OWNERS + 1; i++)
+      await seedSibling('user-1', `c-stale-${i}`, Date.now() - CHECKPOINT_TTL_MS - 1)
+    // One fresh sibling to actually seed from.
+    await seedSibling('user-1', 'c-other-tab')
+
+    const { dispose } = mountRuntime(() => 'user-1')
+    try {
+      await settleUntil(() => userEventsSpy.ready!())
+      await settleUntilAsync(async () => (await readCheckpoint('user-1', CLIENT)).status === 'ok')
+      expect((await readCheckpoint('user-1', CLIENT)).status).toBe('ok')
+    }
+    finally {
+      dispose()
+    }
   })
 })

--- a/frontend/src/components/shell/useCrdtRuntime.ts
+++ b/frontend/src/components/shell/useCrdtRuntime.ts
@@ -1,8 +1,8 @@
 import type { UserCrdtState } from '~/generated/leapmux/v1/user_crdt_pb'
 import type { WatchUserEvent } from '~/generated/leapmux/v1/user_ops_pb'
 import type { Projection } from '~/lib/crdt'
-import type { CheckpointRecorder, CheckpointRecorderOptions } from '~/lib/crdt/checkpointRecorder'
-import type { HydrationPayload } from '~/lib/crdt/hydrate'
+import type { CheckpointRecorder, CheckpointRecorderOptions, HydratedBase } from '~/lib/crdt/checkpointRecorder'
+import type { HydrationPayload, PersistedBase } from '~/lib/crdt/hydrate'
 import type { createActiveClientStore } from '~/lib/presence/activeClient'
 import { createEffect, createMemo, createSignal, onCleanup } from 'solid-js'
 import { showWarnToast } from '~/components/common/Toast'
@@ -210,11 +210,18 @@ export function useCrdtRuntime(opts: UseCrdtRuntimeOpts): CrdtRuntime {
    * Deliberately does NOT reject on timeout: every caller here treats a missing
    * payload as "cold-start", so surfacing the deadline as an error would only
    * route it through a catch that does the same thing.
+   *
+   * `onTimeout` fires when the deadline WINS. It is not decoration: losing the
+   * race does not cancel the promise behind it, and the hydration read now has
+   * a WRITE half (the sibling seed's adoption). Marking the run superseded is
+   * what stops that write landing after the cold start has already rewritten
+   * the checkpoint -- see HydrationOptions.superseded.
    */
-  function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T | null> {
+  function withTimeout<T>(promise: Promise<T>, ms: number, onTimeout?: () => void): Promise<T | null> {
     return new Promise<T | null>((resolve) => {
       const timer = setTimeout(() => {
         log.warn('hydration read did not settle; cold-starting', { ms })
+        onTimeout?.()
         resolve(null)
       }, ms)
       promise.then(
@@ -296,6 +303,10 @@ export function useCrdtRuntime(opts: UseCrdtRuntimeOpts): CrdtRuntime {
     // constructs an empty manager — today's cold-start behavior.
     const hydrateAndInstall = async (): Promise<void> => {
       let payload: HydrationPayload | null = null
+      // Set when the deadline below WINS. Distinct from `cancelled` (which the
+      // effect's own cleanup sets) only in cause; both mean the same thing to
+      // the read: this run's result is no longer wanted, so it must not write.
+      let deadlineMissed = false
       try {
         // RACED against a deadline, not merely try/caught. Every arm that
         // THROWS or REJECTS already lands on the cold-start path -- but a read
@@ -311,8 +322,20 @@ export function useCrdtRuntime(opts: UseCrdtRuntimeOpts): CrdtRuntime {
         // versionchange in another window), and every in-code path is already
         // closed -- so a timeout is the only remaining defence. Losing the race
         // costs one full snapshot, which is exactly what a cold start does
-        // anyway; the read may still land afterwards and is simply ignored.
-        payload = await withTimeout(loadHydrationState(uid, clientId), HYDRATION_TIMEOUT_MS)
+        // anyway.
+        //
+        // The late read is IGNORED but no longer harmless on its own: seeding
+        // from a sibling WRITES (it adopts that sibling's bytes under our own
+        // owner key), and an adoption landing after this run has cold-started
+        // and begun appending its own op-log ordinals would leave the sibling's
+        // older header over our newer log -- a hole whose replayed batchEnd
+        // frames advance the resume cursor straight past it. `superseded` is
+        // what makes the late read drop its write instead of just its result.
+        payload = await withTimeout(
+          loadHydrationState(uid, clientId, { superseded: () => cancelled || deadlineMissed }),
+          HYDRATION_TIMEOUT_MS,
+          () => { deadlineMissed = true },
+        )
       }
       catch (err) {
         // loadHydrationState is written to never throw. If it ever does, that
@@ -438,19 +461,48 @@ export function useCrdtRuntime(opts: UseCrdtRuntimeOpts): CrdtRuntime {
       void clearOwnerCheckpointAndOpLog(uid, clientId)
       return false
     }
-    // Hand the recorder the frames hydrate() replayed. They are already ON DISK
-    // -- only a checkpoint rewrite truncates the log -- so they seed the frame
-    // counter (starting from 0 would make the threshold measure post-hydration
-    // appends only, and a run of short sessions that each resume via `delta`
-    // grew the persisted log without bound), and they are exactly what moved
-    // the state past the persisted chunks, so they seed the DIRTY SET the next
-    // incremental rewrite works from.
-    installObserverAndManager(mgr, uid, clientId, { frames: payload.frames, nextOrdinal: payload.nextOpLogOrdinal })
+    // Hand the recorder the frames hydrate() replayed -- but ONLY when the base
+    // they sit on is really on disk under this owner's key.
+    //
+    // When it is, they seed the frame counter (starting from 0 would make the
+    // threshold measure post-hydration appends only, and a run of short
+    // sessions that each resume via `delta` grew the persisted log without
+    // bound), and they are exactly what moved the state past the persisted
+    // chunks, so they seed the DIRTY SET the next incremental rewrite works
+    // from.
+    //
+    // When it is NOT -- a sibling seed whose adoption write failed, or one
+    // abandoned because the run was superseded -- the recorder must get NO
+    // base, so its first rewrite is FULL. An incremental one would land a
+    // header plus a handful of shards with nothing underneath, and the next
+    // cold start would hydrate a state silently missing almost every record
+    // with the resume cursor riding on it. The state itself is still correct in
+    // memory, so this tab still resumes; only its persistence restarts.
+    // A promise here is the SEED path deliberately not waiting: its adoption is
+    // still committing, and the recorder holds its appends until it lands
+    // rather than the whole gate holding for it. Mapped, not awaited -- awaiting
+    // would put the wait straight back.
+    //
+    // Written ONCE, as `toBase`, and applied to whichever arm the union turns
+    // out to be: spelling the recorder's base shape separately per arm is how
+    // the two would drift on which fields it carries.
+    const toBase = (settled: PersistedBase | null): HydratedBase | undefined =>
+      settled ? { frames: payload.frames, nextOrdinal: settled.nextOpLogOrdinal } : undefined
+    const base = payload.persistedBase
+    installObserverAndManager(mgr, uid, clientId, base instanceof Promise ? base.then(toBase) : toBase(base))
     // Compact now when the persisted log was truncated, or is already at/over
-    // the threshold. The truncated case is the important one: the poison frame
-    // (or the unreadable/over-cap tail) stays on disk otherwise, so every future
-    // reload replays the same prefix and stops at the same place. Rewriting
-    // pins a fresh checkpoint at the post-replay watermark and drops the log.
+    // the threshold. The truncated case is the important one: whatever cut the
+    // replay short -- an undecodable frame on our own path, or the source's
+    // over-cap tail on the seed path -- leaves the checkpoint pinned further
+    // back than the state we just hydrated, so every future reload replays the
+    // same prefix and stops at the same place. Rewriting pins a fresh
+    // checkpoint at the post-replay watermark and drops the log.
+    //
+    // On the seed path this necessarily lands while the recorder is still
+    // holding for the adoption, so the request is DEFERRED there and re-issued
+    // when the base settles -- see the recorder's `heldRewrite`. It used to be
+    // refused outright, which meant a seeded tab never performed the one repair
+    // this call exists for.
     if (payload.truncated || payload.frames.length >= CHECKPOINT_OP_LOG_THRESHOLD)
       recorder?.rewriteNow()
     return true

--- a/frontend/src/components/shell/useUserEvents.test.ts
+++ b/frontend/src/components/shell/useUserEvents.test.ts
@@ -360,6 +360,46 @@ describe('useUserEvents (websocket dispatch)', () => {
     })
   })
 
+  // A NARROWED subscription must present no cursor. The persisted cursor is
+  // per-user, and since the checkpoint seed landed it is cross-tab too, so
+  // replaying one minted under a narrow filter against a wider one can miss ops
+  // -- the hazard SubscribeWithACL documents. Enforcing it here makes the bad
+  // pairing unspellable instead of a comment a future producer of
+  // `allowedWorkspaceIds` has to notice.
+  it('suppresses the resume cursor when the subscription is narrowed by workspace_ids', async () => {
+    await createRoot(async (dispose) => {
+      const [userId] = createSignal('user-narrowed')
+      // Everything the cursor needs is present: populated confirmedState AND a
+      // valid watermark. The ONLY reason it must be withheld is the narrowing.
+      const pending = makeFakePending({
+        populated: true,
+        watermark: { physical: 1754100000000n, logical: 0n, clientId: 'c-w' },
+        epoch: 3n,
+      })
+      let captured: unknown = 'unset'
+      let capturedWorkspaceIds: string[] = []
+      useUserEvents({
+        userId,
+        allowedWorkspaceIds: () => ['w1', 'w2'],
+        activeClient: createActiveClientStore(),
+        pending: () => pending as never,
+        buildWsUrl: (ws, resume) => {
+          captured = resume
+          capturedWorkspaceIds = [...ws]
+          return `ws://test/userevents?w=${ws.join(',')}`
+        },
+      })
+      await flushEffects()
+      expect(captured).toBeNull()
+      // ...and the narrowing itself still reaches the URL. The suppression
+      // reads the SAME accessor value the builder is handed (one read per
+      // connect, not three), so a refactor that decoupled them could silently
+      // drop the filter while this test still saw a null cursor.
+      expect(capturedWorkspaceIds).toEqual(['w1', 'w2'])
+      dispose()
+    })
+  })
+
   it('suppresses the resume cursor when confirmedState is empty even though a watermark exists', async () => {
     // Hydration that found no checkpoint leaves confirmedState empty. Sending a
     // cursor then would make the hub ship a delta the client folds onto empty

--- a/frontend/src/components/shell/useUserEvents.ts
+++ b/frontend/src/components/shell/useUserEvents.ts
@@ -141,7 +141,39 @@ export interface ResumeToken {
 export interface UseUserEventsOpts {
   /** Reactive accessor for the user id. Empty disables the connection. */
   userId: () => string
-  /** Reactive accessor for workspace_ids the caller may read; empty array = all. */
+  /**
+   * Reactive accessor for workspace_ids the caller may read; empty array = all.
+   *
+   * NOTHING IN THE APP PASSES THIS, and wiring it needs care. The hub documents
+   * a constraint on `SubscribeWithACL`: a cursor minted under a NARROW filter
+   * and replayed under a WIDER one can miss ops, because the persisted cursor is
+   * per-user, not per-filter. It has no producer today precisely because every
+   * browser subscription resolves to all owned workspaces.
+   *
+   * Since the checkpoint seed landed, cursors are also CROSS-TAB -- a new tab
+   * adopts a sibling's -- so a per-tab workspace filter would let two tabs
+   * disagree about the filter a cursor was minted under, which is exactly the
+   * pairing that constraint warns about.
+   *
+   * A non-empty value here therefore suppresses the resume cursor, so a
+   * narrowed subscription always takes a full snapshot. That closes the URL
+   * half, and only the URL half -- it is NOT the whole invariant, and a producer
+   * cannot be wired on the strength of it alone.
+   *
+   * The half still open is the CHECKPOINT. A narrowed tab's confirmed state
+   * holds only its own workspaces, but the watermark it persists beside them is
+   * the hub's GLOBAL max_hlc (materializedFromState stamps `state.max_hlc` on
+   * every snapshot, filtered or not). A sibling with no filter can adopt that
+   * pair and RESUME on it -- validateCheckpoint checks the tenant and the
+   * ranges, and has no filter to check against -- and the hub then ships only
+   * what is strictly after a cursor that already sits above every entity the
+   * narrowed writer filtered out. Those entities never arrive.
+   *
+   * So wiring a producer needs one of: the mint-time filter carried alongside
+   * the cursor and re-checked by the hub (what SubscribeWithACL's doc calls for),
+   * or a narrowed tab excluded from writing an adoptable checkpoint at all.
+   * Until then this option has no producer on purpose.
+   */
   allowedWorkspaceIds?: () => string[]
   /** Active-client store fed by PresenceUpdate events. */
   activeClient: ActiveClientStore
@@ -354,7 +386,25 @@ export function useUserEvents(opts: UseUserEventsOpts): UserEventsHook {
     // state it describes is actually loaded, or the hub's delta would fold onto
     // empty maps.
     const confirmedPopulated = pendingMgr?.isConfirmedPopulated() ?? false
-    const validated = confirmedPopulated ? validateResumeHlc(pendingState?.resumeWatermark) : undefined
+    // A NARROWED subscription presents NO cursor.
+    //
+    // The persisted cursor is per-USER, not per-filter (see the hub's
+    // SubscribeWithACL), and since the checkpoint seed landed it is CROSS-TAB
+    // too -- a new tab adopts a sibling's. So a cursor minted under one filter
+    // and replayed under a wider one can miss ops, and with cross-tab cursors
+    // two tabs need not even agree on what the filter was. Suppressing the
+    // cursor costs one full snapshot and removes the URL half of that pairing.
+    // It is also what both in-tree Go narrowing callers already do: remoteipc's
+    // hub_stream and the remote CLI client each pass their workspace ids with a
+    // nil cursor.
+    //
+    // It is NOT the whole invariant -- a narrowed tab's CHECKPOINT still carries
+    // the hub's global max_hlc over a filtered entity set, and a sibling can
+    // adopt it. See allowedWorkspaceIds' doc for what a producer would also need.
+    const workspaceIds = opts.allowedWorkspaceIds?.() ?? []
+    const validated = confirmedPopulated && workspaceIds.length === 0
+      ? validateResumeHlc(pendingState?.resumeWatermark)
+      : undefined
     const resume: ResumeToken | null
       = pendingState && validated
         ? { hlc: validated, epoch: pendingState.currentEpoch }
@@ -380,7 +430,6 @@ export function useUserEvents(opts: UseUserEventsOpts): UserEventsHook {
     // event. Skip this branch when a `buildWsUrl` override is
     // supplied (tests intentionally drive a real WebSocket).
     if (isTauriApp() && !opts.buildWsUrl) {
-      const workspaceIds = opts.allowedWorkspaceIds?.() ?? []
       // One id per attempt, shared by this attempt's open and its close, so the
       // sidecar can tell the two apart from a successor's.
       const relayId = nextUserEventsRelayId()
@@ -458,7 +507,7 @@ export function useUserEvents(opts: UseUserEventsOpts): UserEventsHook {
     }
 
     const builder = opts.buildWsUrl ?? defaultBuildWsUrl
-    const url = builder(opts.allowedWorkspaceIds?.() ?? [], resume)
+    const url = builder(workspaceIds, resume)
     let ws: WebSocket
     try {
       ws = new WebSocket(url, ['userevents-relay'])

--- a/frontend/src/lib/crdt/checkpointRecorder.test.ts
+++ b/frontend/src/lib/crdt/checkpointRecorder.test.ts
@@ -3,7 +3,7 @@ import type { HlcShape } from './hlc'
 import type { PendingOpsManager } from './pendingOps'
 import type { UserCrdtState } from '~/generated/leapmux/v1/user_crdt_pb'
 import type { WatchUserEvent } from '~/generated/leapmux/v1/user_ops_pb'
-import { create, toBinary } from '@bufbuild/protobuf'
+import { create, fromBinary, toBinary } from '@bufbuild/protobuf'
 import { IDBFactory, IDBKeyRange } from 'fake-indexeddb'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { NodeRecordSchema, UserCrdtStateSchema } from '~/generated/leapmux/v1/user_crdt_pb'
@@ -23,7 +23,7 @@ import { pruneTombstonesAtOrBelow } from './pendingOps'
 // a full rewrite and an incremental one leave byte-identical rows behind, so
 // comparing the persisted result cannot tell them apart. The wrapper delegates
 // to the real store, so everything else in this file still exercises real IDB.
-const storeSpy = vi.hoisted(() => ({ deltas: [] as CheckpointDelta[], appends: 0 }))
+const storeSpy = vi.hoisted(() => ({ deltas: [] as CheckpointDelta[], appends: 0, ordinals: [] as number[] }))
 vi.mock('./checkpointStore', async (importOriginal) => {
   const actual = await importOriginal<typeof import('./checkpointStore')>()
   return {
@@ -42,6 +42,10 @@ vi.mock('./checkpointStore', async (importOriginal) => {
     // persisted result (the rewrite truncates the log either way).
     appendOpLogSegment: (...args: Parameters<typeof actual.appendOpLogSegment>) => {
       storeSpy.appends++
+      // The ORDINAL each segment carries, which is the whole observation for a
+      // base that lands late: it must continue the adopted sequence, not
+      // restart at 0 behind rows the adoption just wrote.
+      storeSpy.ordinals.push(args[3])
       return actual.appendOpLogSegment(...args)
     },
   }
@@ -63,6 +67,7 @@ function keysOf(refs: readonly { kind: string, entityId: string }[]): string[] {
 beforeEach(() => {
   storeSpy.deltas = []
   storeSpy.appends = 0
+  storeSpy.ordinals = []
   vi.stubGlobal('indexedDB', new IDBFactory())
   vi.stubGlobal('IDBKeyRange', IDBKeyRange)
   _resetCheckpointStoreForTest()
@@ -501,6 +506,299 @@ describe('createCheckpointRecorder incremental rewrites', () => {
     expect([...recorder.dirtyKeys].sort()).toEqual(['node:replayed-a', 'node:replayed-b'])
     expect(recorder.needsFullRewrite).toBe(false)
     await recorder.dispose()
+  })
+
+  // A base that is still being WRITTEN (the sibling seed's adoption, which the
+  // caller deliberately leaves in flight so its ready gate can open) puts the
+  // recorder in a third state: it does not yet know whether the chunks under it
+  // are a valid incremental base, and it must not guess in either direction.
+  describe('a base that is still in flight', () => {
+    /** A promise plus its resolver, so a test can decide when the base lands. */
+    function deferredBase() {
+      let settle: (b: { frames: WatchUserEvent[], nextOrdinal: number } | undefined) => void = () => {}
+      let reject: (err: unknown) => void = () => {}
+      const promise = new Promise<{ frames: WatchUserEvent[], nextOrdinal: number } | undefined>((res, rej) => {
+        settle = res
+        reject = rej
+      })
+      return { promise, settle, reject }
+    }
+
+    it('holds appends until the base lands, then writes them at its ordinal', async () => {
+      // The hazard this exists for: appending now would mint ordinal 0 against
+      // a log the adoption is about to truncate and re-seed at ordinal 0, and
+      // the reader's contiguity check silently truncates at a duplicate.
+      const base = deferredBase()
+      const mgr = fakeMgr()
+      const recorder = createCheckpointRecorder({
+        userId: USER,
+        clientId: CLIENT,
+        mgr,
+        hydratedFrom: base.promise,
+      })
+      putNode(mgr, 'a', 'v1')
+      recorder.record(nodeFrame('b1', 'a'))
+      await settle()
+      expect(storeSpy.appends).toBe(0)
+
+      base.settle({ frames: [], nextOrdinal: 7 })
+      await settle()
+
+      // Released, not dropped -- and at the base's ordinal, not at 0.
+      expect(storeSpy.appends).toBe(1)
+      expect(storeSpy.ordinals).toEqual([7])
+      await recorder.dispose()
+    })
+
+    it('does not lose a frame recorded while it was holding', async () => {
+      // The frames' effects are already in confirmedState and the hub ships
+      // only what is strictly after the cursor, so a dropped one never comes
+      // back. Its ENTITY must be dirty either way.
+      const base = deferredBase()
+      const mgr = fakeMgr()
+      const recorder = createCheckpointRecorder({
+        userId: USER,
+        clientId: CLIENT,
+        mgr,
+        hydratedFrom: base.promise,
+      })
+      putNode(mgr, 'held', 'v1')
+      recorder.record(nodeFrame('b1', 'held'))
+      await settle()
+      expect([...recorder.dirtyKeys]).toEqual(['node:held'])
+
+      base.settle({ frames: [], nextOrdinal: 0 })
+      await settle()
+      expect(storeSpy.appends).toBe(1)
+      await recorder.dispose()
+    })
+
+    it('holds a rewrite until the base lands', async () => {
+      // A rewrite would serialize a base the adoption is about to replace
+      // wholesale, and its truncate would race the adoption's own.
+      const base = deferredBase()
+      const mgr = fakeMgr()
+      putNode(mgr, 'a', 'v1')
+      const recorder = createCheckpointRecorder({
+        userId: USER,
+        clientId: CLIENT,
+        mgr,
+        hydratedFrom: base.promise,
+        threshold: 1,
+      })
+      recorder.rewriteNow()
+      await settle()
+      expect(storeSpy.deltas).toHaveLength(0)
+
+      // DEFERRED, not dropped: the base landing re-issues it with no second
+      // rewriteNow() from the caller. hydrateInto's one-shot repair call (fired
+      // when the replayed log was truncated or already over the threshold)
+      // ALWAYS lands inside this hold on the seed path, so a dropped request
+      // meant a seeded tab never performed that repair at all.
+      base.settle(undefined)
+      await settle()
+      expect(storeSpy.deltas).toHaveLength(1)
+      await recorder.dispose()
+    })
+
+    it('does not re-issue a rewrite nobody asked for while it was holding', async () => {
+      // The flip side: the hold must not manufacture a rewrite. Only a request
+      // that was actually refused is owed one.
+      const base = deferredBase()
+      const mgr = fakeMgr()
+      putNode(mgr, 'a', 'v1')
+      const recorder = createCheckpointRecorder({
+        userId: USER,
+        clientId: CLIENT,
+        mgr,
+        hydratedFrom: base.promise,
+      })
+      base.settle({ frames: [], nextOrdinal: 0 })
+      await settle()
+      expect(storeSpy.deltas).toHaveLength(0)
+      await recorder.dispose()
+    })
+
+    it('drops frames it was holding when a bootstrap supersedes the lineage', async () => {
+      // The hazard: the pending HOLD parks frames instead of appending them, so
+      // unlike every other queue-clearing path they are still sitting there when
+      // onCheckpointReset invalidates the lineage. Once the bootstrap's own
+      // rewrite lands (needsRebase cleared, log truncated), the NEXT recorded
+      // frame would splice those pre-bootstrap bytes onto the fresh log at
+      // ordinal 0 -- and the client replays materialized / removed WHOLESALE,
+      // with no HLC compare, so the next cold start reinstates discarded records.
+      const base = deferredBase()
+      const mgr = fakeMgr()
+      putNode(mgr, 'a', 'v1')
+      const recorder = createCheckpointRecorder({
+        userId: USER,
+        clientId: CLIENT,
+        mgr,
+        hydratedFrom: base.promise,
+      })
+      recorder.record(nodeFrame('pre-bootstrap', 'a'))
+      await settle()
+      expect(storeSpy.appends).toBe(0)
+
+      recorder.onCheckpointReset()
+      await settle()
+      base.settle(undefined)
+      await settle()
+
+      recorder.record(nodeFrame('post-bootstrap', 'a'))
+      await settle()
+
+      const read = await readCheckpoint(USER, CLIENT)
+      expect(read.status).toBe('ok')
+      if (read.status !== 'ok')
+        return
+      const batchIds = read.opLogFrames
+        .map(b => fromBinary(WatchUserEventSchema, b))
+        .map(f => (f.event.case === 'batch' ? f.event.value.batchId : ''))
+      expect(batchIds).toEqual(['post-bootstrap'])
+      await recorder.dispose()
+    })
+
+    it('releases the hold even when it refuses the base', async () => {
+      // The refusal path returned before flushAppend, and every held flush had
+      // already cleared `appendScheduled` -- so on a tab that went quiet after
+      // its reconnect burst nothing was left to revisit the queue at all.
+      const base = deferredBase()
+      const mgr = fakeMgr()
+      putNode(mgr, 'a', 'v1')
+      const recorder = createCheckpointRecorder({
+        userId: USER,
+        clientId: CLIENT,
+        mgr,
+        hydratedFrom: base.promise,
+      })
+      recorder.record(nodeFrame('held', 'a'))
+      await settle()
+
+      // Invalidate, so the settle below takes adoptBase's refusal arm...
+      recorder.onCheckpointReset()
+      await settle()
+      base.settle({ frames: [], nextOrdinal: 4 })
+      await settle()
+
+      // ...and nothing is left queued: no later frame can carry it onto disk.
+      recorder.record(nodeFrame('after', 'a'))
+      await settle()
+      const read = await readCheckpoint(USER, CLIENT)
+      expect(read.status).toBe('ok')
+      if (read.status !== 'ok')
+        return
+      expect(read.opLogFrames).toHaveLength(1)
+      // The refused base's ordinal was not adopted either.
+      expect(storeSpy.ordinals).toEqual([0])
+      await recorder.dispose()
+    })
+
+    it('reports a FULL rewrite while it is still waiting', async () => {
+      // Never "incremental against chunks we have not confirmed": until the
+      // adoption commits there may be nothing underneath at all.
+      const base = deferredBase()
+      const recorder = createCheckpointRecorder({
+        userId: USER,
+        clientId: CLIENT,
+        mgr: fakeMgr(),
+        hydratedFrom: base.promise,
+      })
+      expect(recorder.needsFullRewrite).toBe(true)
+
+      base.settle({ frames: [], nextOrdinal: 0 })
+      await settle()
+      expect(recorder.needsFullRewrite).toBe(false)
+      await recorder.dispose()
+    })
+
+    it('takes a base that resolves undefined as NO base', async () => {
+      // The adoption did not commit, so there are no chunks to be incremental
+      // against -- an incremental rewrite would persist a header plus a few
+      // shards over nothing.
+      const base = deferredBase()
+      const mgr = fakeMgr()
+      putNode(mgr, 'a', 'v1')
+      const recorder = createCheckpointRecorder({
+        userId: USER,
+        clientId: CLIENT,
+        mgr,
+        hydratedFrom: base.promise,
+        threshold: 1,
+      })
+      base.settle(undefined)
+      await settle()
+      expect(recorder.needsFullRewrite).toBe(true)
+
+      recorder.record(nodeFrame('b1', 'a'))
+      await settle()
+      expect(lastDelta().full).toBe(true)
+      await recorder.dispose()
+    })
+
+    it('takes a REJECTED base as NO base rather than holding forever', async () => {
+      // Staying held would silently stop persisting for the whole session.
+      const base = deferredBase()
+      const mgr = fakeMgr()
+      putNode(mgr, 'a', 'v1')
+      const recorder = createCheckpointRecorder({
+        userId: USER,
+        clientId: CLIENT,
+        mgr,
+        hydratedFrom: base.promise,
+        threshold: 1,
+      })
+      base.reject(new Error('adopt blew up'))
+      await settle()
+      expect(recorder.needsFullRewrite).toBe(true)
+
+      recorder.record(nodeFrame('b1', 'a'))
+      await settle()
+      expect(lastDelta().full).toBe(true)
+      await recorder.dispose()
+    })
+
+    it('refuses a base that lands after a bootstrap superseded it', async () => {
+      // onCheckpointReset invalidates the lineage; the in-flight adoption
+      // describes the DISCARDED one, so installing it would re-arm incremental
+      // rewrites against chunks the bootstrap already replaced.
+      const base = deferredBase()
+      const mgr = fakeMgr()
+      putNode(mgr, 'a', 'v1')
+      const recorder = createCheckpointRecorder({
+        userId: USER,
+        clientId: CLIENT,
+        mgr,
+        hydratedFrom: base.promise,
+        threshold: 1,
+      })
+      recorder.onCheckpointReset()
+      await settle()
+
+      base.settle({ frames: [nodeFrame('r1', 'stale')], nextOrdinal: 9 })
+      await settle()
+
+      expect(recorder.dirtyKeys.has('node:stale')).toBe(false)
+      // The bootstrap's own FULL rewrite is what re-establishes the base.
+      expect(lastDelta().full).toBe(true)
+      await recorder.dispose()
+    })
+
+    it('does not install a base after dispose', async () => {
+      const base = deferredBase()
+      const recorder = createCheckpointRecorder({
+        userId: USER,
+        clientId: CLIENT,
+        mgr: fakeMgr(),
+        hydratedFrom: base.promise,
+      })
+      await recorder.dispose()
+      base.settle({ frames: [nodeFrame('r1', 'late')], nextOrdinal: 3 })
+      await settle()
+
+      expect(recorder.dirtyKeys.has('node:late')).toBe(false)
+      expect(storeSpy.appends).toBe(0)
+    })
   })
 
   it('falls back to a FULL rewrite for a structurally malformed frame', async () => {

--- a/frontend/src/lib/crdt/checkpointRecorder.ts
+++ b/frontend/src/lib/crdt/checkpointRecorder.ts
@@ -56,33 +56,48 @@ export interface CheckpointRecorderOptions {
   clientId: string
   mgr: PendingOpsManager
   /**
-   * The persisted checkpoint this recorder inherits, when hydration replayed
-   * one. ABSENT means the store holds nothing usable for this owner (a cold
-   * start, or a wipe after a corrupt record), so the first rewrite must be FULL.
+   * The persisted checkpoint this recorder inherits.
+   *
+   *   - A VALUE: hydration replayed a base that is already durable under this
+   *     owner's key, so the first rewrite may be incremental against it.
+   *   - A PROMISE: the base is being written right now (the sibling seed's
+   *     adoption). The recorder HOLDS every append and rewrite until it
+   *     settles -- see the `base` phase below for why that is not optional --
+   *     and treats a resolved `undefined`, or a rejection, as "no base".
+   *   - ABSENT: the store holds nothing usable for this owner (a cold start, or
+   *     a wipe after a corrupt record), so the first rewrite must be FULL.
+   *
+   * Accepting the promise HERE, rather than exposing an `installBase()` the
+   * caller must remember to call, is what makes the held window impossible to
+   * skip: there is no way to construct a recorder over an in-flight base and
+   * forget to tell it when the base lands.
    */
-  hydratedFrom?: {
-    /**
-     * The op-log frames hydrate() replayed on top of the persisted chunks.
-     *
-     * They serve two purposes. (1) They are already ON DISK -- only a
-     * checkpoint rewrite truncates the log -- so seeding the frame counter with
-     * them is what makes the threshold trip and drain a log grown by a run of
-     * short delta-resumed sessions that never bootstrap. (2) They are exactly
-     * what moved the state past the persisted chunks, so the entities they
-     * touched are the recorder's initial DIRTY SET.
-     */
-    frames: readonly WatchUserEvent[]
-    /**
-     * The ordinal the next appended segment must carry, from the store's read.
-     * Seeding it is what keeps the persisted log's ordinal sequence contiguous
-     * across a reload -- otherwise the first post-hydrate append would restart
-     * at 0 behind segments already numbered 0..N-1, and the next cold start
-     * would read that as a hole and discard a log that was in fact intact.
-     */
-    nextOrdinal: number
-  }
+  hydratedFrom?: HydratedBase | Promise<HydratedBase | undefined>
   /** Test seam; defaults to CHECKPOINT_OP_LOG_THRESHOLD. */
   threshold?: number
+}
+
+/** A durable checkpoint base the recorder can rewrite incrementally against. */
+export interface HydratedBase {
+  /**
+   * The op-log frames hydrate() replayed on top of the persisted chunks.
+   *
+   * They serve two purposes. (1) They are already ON DISK -- only a checkpoint
+   * rewrite truncates the log -- so seeding the frame counter with them is what
+   * makes the threshold trip and drain a log grown by a run of short
+   * delta-resumed sessions that never bootstrap. (2) They are exactly what
+   * moved the state past the persisted chunks, so the entities they touched are
+   * the recorder's initial DIRTY SET.
+   */
+  frames: readonly WatchUserEvent[]
+  /**
+   * The ordinal the next appended segment must carry, from the store's read.
+   * Seeding it is what keeps the persisted log's ordinal sequence contiguous
+   * across a reload -- otherwise the first post-hydrate append would restart at
+   * 0 behind segments already numbered 0..N-1, and the next cold start would
+   * read that as a hole and discard a log that was in fact intact.
+   */
+  nextOrdinal: number
 }
 
 export interface CheckpointRecorder {
@@ -123,7 +138,7 @@ export function createCheckpointRecorder(opts: CheckpointRecorderOptions): Check
   const pendingFrames: Uint8Array[] = []
   let appendScheduled = false
   let disposed = false
-  let opLogCount = opts.hydratedFrom?.frames.length ?? 0
+  let opLogCount = 0
   /**
    * Ordinal for the next op-log segment. Advanced per ATTEMPTED flush, never per
    * successful one: numbering on success would give the next segment the number
@@ -132,7 +147,7 @@ export function createCheckpointRecorder(opts: CheckpointRecorderOptions): Check
    * checkpoint write RESOLVES ok, which is when the log on disk is actually
    * empty.
    */
-  let nextOrdinal = opts.hydratedFrom?.nextOrdinal ?? 0
+  let nextOrdinal = 0
   /**
    * Entity keys (`kind:id`, the vocabulary checkpointChunks speaks) whose
    * persisted chunk no longer matches confirmedState. A rewrite serializes
@@ -140,14 +155,44 @@ export function createCheckpointRecorder(opts: CheckpointRecorderOptions): Check
    */
   const dirty = new Set<string>()
   /**
-   * True while the persisted chunks cannot be trusted as a base, so the next
-   * rewrite must re-serialize EVERY entity and drop whatever else is on disk.
+   * What the persisted chunks are worth as a rewrite base. ONE variable with
+   * three phases, not a pair of booleans, so the contradictory combination
+   * ("still waiting for the base" AND "the base is good") cannot be written.
    *
-   * It starts true unless hydration handed over a checkpoint: with nothing
-   * persisted (or a wiped poison record) there is no base to be incremental
-   * against. It is raised again by `invalidateLineage`.
+   *   - `ready`  — the chunks on disk match a known point in this lineage, so
+   *                the next rewrite may be INCREMENTAL against them.
+   *   - `none`   — there is nothing usable underneath (a cold start, a wiped
+   *                poison record, a failed adoption) or the lineage was
+   *                invalidated, so the next rewrite must re-serialize EVERY
+   *                entity and drop whatever else is on disk.
+   *   - `pending` — a base is being written RIGHT NOW and we do not yet know
+   *                which of the two it will become. Every append and every
+   *                rewrite is HELD, because both would race that write: an
+   *                append would mint ordinal 0 against a log the adoption is
+   *                about to truncate and re-seed at ordinal 0 (two rows at the
+   *                same ordinal, which the reader's contiguity check silently
+   *                truncates at), and a rewrite would serialize a base the
+   *                adoption is about to replace wholesale.
+   *
+   * Held frames are BUFFERED, never dropped -- see flushAppend. `pending` is
+   * therefore a delay, not a data loss, and it ends on the first settle.
    */
-  let fullRewrite = opts.hydratedFrom === undefined
+  let base: 'pending' | 'none' | 'ready'
+  /**
+   * A rewrite was asked for while `base` was `pending`, and still owes an
+   * answer.
+   *
+   * The hold has to DEFER the request, not drop it, and the two are easy to
+   * confuse because the threshold-driven trigger re-arms itself on the next
+   * flush. The one-shot triggers do not: `hydrateInto` calls `rewriteNow()`
+   * exactly once, when the replayed log was truncated or already over the
+   * threshold, and on the seed path that call lands while the adoption is still
+   * in flight by construction. Without this flag it was refused and never
+   * re-issued, so a seeded tab kept an over-ceiling log -- and, before the
+   * validated-prefix copy, a poison tail -- on disk for its whole session,
+   * re-truncating at the same frame on every later reload.
+   */
+  let heldRewrite = false
   /**
    * Frame count at which the next compaction is attempted. Pushed out by a
    * whole threshold whenever a rewrite is skipped or fails, so a store that
@@ -222,7 +267,25 @@ export function createCheckpointRecorder(opts: CheckpointRecorderOptions): Check
    */
   function invalidateLineage(): void {
     needsRebase = true
-    fullRewrite = true
+    // Also ABANDONS a pending base: whatever that write lands is superseded by
+    // definition, and adoptBase refuses to install over a phase it no longer
+    // owns. Appends stay blocked by needsRebase until a full rewrite succeeds,
+    // so ending the hold early cannot let one race the adoption.
+    base = 'none'
+    // And DROPS whatever is queued, because those frames describe the lineage
+    // this call just invalidated. Both `record` arms already cleared the queue
+    // before reaching here; the arm that did not is `onCheckpointReset`, whose
+    // frames could be sitting in the buffer because the `pending` HOLD parked
+    // them there rather than appending them. Leaving them meant the next
+    // recorded frame spliced pre-bootstrap bytes onto a log the bootstrap's own
+    // rewrite had just truncated -- and the client applies materialized /
+    // removed WHOLESALE, with no HLC compare, so replaying them on the next
+    // cold start reinstates discarded records for good.
+    //
+    // Clearing HERE rather than at each caller is what makes "an invalidated
+    // lineage can never be re-based incrementally" cover the queue too, by
+    // construction instead of by case analysis.
+    pendingFrames.length = 0
     lineage++
   }
 
@@ -276,10 +339,84 @@ export function createCheckpointRecorder(opts: CheckpointRecorderOptions): Check
     return { headerBytes: serializeHeader(state), upserts, deletes, full: false }
   }
 
+  /**
+   * Compact, then decide what the next checkpoint write should contain: an
+   * incremental delta over the persisted chunks, or a full re-serialization.
+   * Returns null when nothing can be built, and the caller backs off.
+   *
+   * Extracted because the PRUNE and the KEY SNAPSHOT BRACKETING IT are the
+   * subtlest coupling in this file, and inline they read as two of six things
+   * `rewriteCheckpoint` was doing. The prune drops tombstone shells whose
+   * tombstoning op may have been recorded many checkpoints ago, so the dirty set
+   * cannot see them -- the bracket is the only thing that turns those removals
+   * into chunk DELETES, and without it their chunks survive on disk and the next
+   * cold start resurrects every shell the prune just collected. Naming the unit
+   * gives that pairing one place to be got right.
+   *
+   * NOT pure, and deliberately not pretending to be: it runs the compaction and
+   * it may demote `base` and clear `dirty` when a key will not resolve. What it
+   * does not do is issue the write or touch anything the write's resolution
+   * owns (`writing`, `nextCompactAt`, `needsRebase`).
+   */
+  function buildDelta(): CheckpointDelta | null {
+    try {
+      // Guarded for the same reason the frame serializer is: this runs
+      // synchronously inside the manager's bootstrap reset observer, so a throw
+      // would propagate out through bootstrap() -> applyMaterialized() -> the
+      // WebSocket message handler, skipping setBootstrapped and every other
+      // post-bootstrap step while the socket stays healthy and reports nothing.
+      // Best-effort is what the caller promises; the guard is what makes it
+      // true.
+      //
+      // Prune first, so the chunks about to be written describe the SMALLER
+      // state. This is the client's compaction step and it is paired with the
+      // checkpoint rewrite exactly as the hub pairs PruneTombstonesAtOrBelow
+      // with its state_payload write -- pruning without persisting would be
+      // undone by the next cold reload, which replays from the persisted state.
+      const before = base === 'ready' ? snapshotEntityKeys(mgr.state.confirmedState) : null
+      mgr.compactTombstones()
+      const state = mgr.state.confirmedState
+      if (before) {
+        for (const ref of keysRemovedSince(before, state))
+          dirty.add(entityKey(ref.kind, ref.entityId))
+      }
+      const incremental = base === 'ready' ? incrementalDelta(state, dirty) : null
+      if (incremental)
+        return incremental
+      // Either the lineage was already invalidated, or a dirty key could not
+      // be resolved -- both mean the persisted shards cannot be brought up to
+      // date one entity at a time.
+      if (base === 'ready') {
+        log.warn('a dirty entity key could not be resolved; rewriting the whole checkpoint')
+        base = 'none'
+        dirty.clear()
+      }
+      return fullCheckpointDelta(state)
+    }
+    catch (err) {
+      log.warn('failed to serialize confirmed state for checkpoint; skipping', { err })
+      return null
+    }
+  }
+
   /** Returns whether a checkpoint write was actually ISSUED. */
   function rewriteCheckpoint(): boolean {
     if (disposed || writing)
       return false
+    if (base === 'pending') {
+      // A rewrite would serialize a base the in-flight adoption is about to
+      // replace wholesale, and its truncate would race the adoption's own.
+      // DEFER it rather than drop it -- adoptBase re-issues whatever this flag
+      // still owes. The threshold-driven trigger would re-arm itself on the
+      // next flush, but the one-shot `rewriteNow()` hydrateInto fires for a
+      // truncated or over-threshold log would not, and that is precisely the
+      // call the seed path makes while this hold is up.
+      heldRewrite = true
+      return false
+    }
+    // Past the hold: whatever was owed is being answered now, whether this
+    // attempt issues a write or backs off below.
+    heldRewrite = false
     const wm = mgr.state.resumeWatermark
     if (!wm) {
       // Nothing to pin the checkpoint at yet. Back off rather than re-checking
@@ -291,52 +428,8 @@ export function createCheckpointRecorder(opts: CheckpointRecorderOptions): Check
     // here on -- including during `compactTombstones` -- must supersede the
     // write this call is about to issue, not be cleared by it.
     const writtenLineage = lineage
-    let delta: CheckpointDelta
-    try {
-      // Guarded for the same reason the frame serializer is: this runs
-      // synchronously inside the manager's bootstrap reset observer, so a throw
-      // would propagate out through bootstrap() -> applyMaterialized() -> the
-      // WebSocket message handler, skipping setBootstrapped and every other
-      // post-bootstrap step while the socket stays healthy and reports nothing.
-      // Best-effort is what this function promises; the guard is what makes it
-      // true.
-      //
-      // Prune first, so the chunks about to be written describe the SMALLER
-      // state. This is the client's compaction step and it is paired with the
-      // checkpoint rewrite exactly as the hub pairs PruneTombstonesAtOrBelow
-      // with its state_payload write -- pruning without persisting would be
-      // undone by the next cold reload, which replays from the persisted state.
-      //
-      // The prune drops tombstone shells whose tombstoning op may have been
-      // recorded many checkpoints ago, so the dirty set cannot see them. The
-      // key snapshot bracketing it is what turns those removals into chunk
-      // DELETES; without it their chunks would survive on disk and the next
-      // cold start would resurrect every shell this prune just collected.
-      const before = fullRewrite ? null : snapshotEntityKeys(mgr.state.confirmedState)
-      mgr.compactTombstones()
-      const state = mgr.state.confirmedState
-      if (before) {
-        for (const ref of keysRemovedSince(before, state))
-          dirty.add(entityKey(ref.kind, ref.entityId))
-      }
-      const incremental = fullRewrite ? null : incrementalDelta(state, dirty)
-      if (incremental) {
-        delta = incremental
-      }
-      else {
-        // Either the lineage was already invalidated, or a dirty key could not
-        // be resolved -- both mean the persisted shards cannot be brought up to
-        // date one entity at a time.
-        if (!fullRewrite) {
-          log.warn('a dirty entity key could not be resolved; rewriting the whole checkpoint')
-          fullRewrite = true
-          dirty.clear()
-        }
-        delta = fullCheckpointDelta(state)
-      }
-    }
-    catch (err) {
-      log.warn('failed to serialize confirmed state for checkpoint; skipping', { err })
+    const delta = buildDelta()
+    if (!delta) {
       nextCompactAt = opLogCount + threshold
       return false
     }
@@ -364,12 +457,12 @@ export function createCheckpointRecorder(opts: CheckpointRecorderOptions): Check
         nextCompactAt = threshold
         if (lineage !== writtenLineage) {
           // Invalidated after this write serialized. Its chunks describe the
-          // superseded lineage, so leave needsRebase and fullRewrite standing
+          // superseded lineage, so leave needsRebase and the base phase standing
           // and let the retry re-base with a FULL rewrite.
           return
         }
         needsRebase = false
-        fullRewrite = false
+        base = 'ready'
         // Only the keys this write actually serialized. Frames recorded WHILE
         // it was in flight dirtied entities the chunks on disk do not describe,
         // so clearing the whole set would strand them.
@@ -387,6 +480,15 @@ export function createCheckpointRecorder(opts: CheckpointRecorderOptions): Check
     appendScheduled = false
     if (disposed)
       return
+    if (base === 'pending') {
+      // HOLD, do not clear: unlike the needsRebase arm below, these frames are
+      // not describing a superseded lineage -- we simply do not know their
+      // ordinal yet. adoptBase re-enters here the moment the base settles, and
+      // dropping them instead would lose ops that are already in confirmedState
+      // and will never be re-sent (the hub ships only what is strictly after
+      // the cursor).
+      return
+    }
     if (needsRebase) {
       // The lineage was invalidated after these frames were queued but before
       // the microtask ran. Appending them now would put frames of the old
@@ -439,14 +541,72 @@ export function createCheckpointRecorder(opts: CheckpointRecorderOptions): Check
       rewriteCheckpoint()
   }
 
-  if (opts.hydratedFrom) {
-    // The persisted chunks are the state hydrate() started from; these frames
-    // are everything that moved it since, so their entities are the chunks that
-    // no longer match. A frame whose shape is not understood invalidates the
-    // lineage here exactly as it would live, forcing the first rewrite to be
-    // full.
-    for (const frame of opts.hydratedFrom.frames)
-      markDirty(frame)
+  /**
+   * Install (or refuse) the base once it is durable, then release everything
+   * that was held while we waited.
+   *
+   * Refuses to INSTALL when the phase is no longer `pending`: an
+   * invalidateLineage in the meantime means this base describes a superseded
+   * lineage, and installing it would re-arm incremental rewrites against chunks
+   * a bootstrap already discarded.
+   *
+   * The RELEASE runs either way, and that separation is the point. Returning
+   * early on the refusal left the queue neither appended nor cleared and
+   * nothing scheduled to revisit it -- every held flush had already set
+   * `appendScheduled = false` -- so on a tab that went quiet after its
+   * reconnect burst the bytes simply sat there for the session.
+   */
+  function adoptBase(settled: HydratedBase | undefined): void {
+    if (disposed)
+      return
+    // `base === 'pending'` is an EXACT proxy for "nothing invalidated the
+    // lineage since this base was claimed", and that is provable locally rather
+    // than by inspection: only the two constructor arms ever assign `pending`,
+    // so the phase is never re-entered, and `rewriteCheckpoint` refuses to issue
+    // while it holds -- so no write-success handler can be in flight to promote
+    // or demote it either. `invalidateLineage` is the single transition out.
+    if (base === 'pending') {
+      if (settled) {
+        opLogCount = settled.frames.length
+        nextOrdinal = settled.nextOrdinal
+        // The persisted chunks are the state hydrate() started from; these
+        // frames are everything that moved it since, so their entities are the
+        // chunks that no longer match. A frame whose shape is not understood
+        // invalidates the lineage here exactly as it would live -- which is why
+        // this runs BEFORE the phase is promoted, so that invalidation wins.
+        for (const frame of settled.frames)
+          markDirty(frame)
+      }
+      if (base === 'pending')
+        base = settled ? 'ready' : 'none'
+    }
+    // Release the held frames. Safe on BOTH arms: with a base, they continue
+    // its ordinal sequence; without one, the adoption wrote nothing at all
+    // (its transaction aborted), so the log is empty and ordinal 0 is free.
+    flushAppend()
+    // Then answer any rewrite the hold deferred. AFTER flushAppend, because
+    // that call may already have tripped the threshold and issued one -- in
+    // which case the flag is clear and this is a no-op.
+    if (heldRewrite)
+      rewriteCheckpoint()
+  }
+
+  if (opts.hydratedFrom instanceof Promise) {
+    base = 'pending'
+    void opts.hydratedFrom.then(adoptBase, (err: unknown) => {
+      // A base write that REJECTED is a base that is not there. Treated exactly
+      // like a resolved `undefined`: the alternative -- leaving the recorder
+      // held forever -- would silently stop persisting for the whole session.
+      log.warn('the persisted base never landed; recording against a full rewrite', { err })
+      adoptBase(undefined)
+    })
+  }
+  else if (opts.hydratedFrom) {
+    base = 'pending'
+    adoptBase(opts.hydratedFrom)
+  }
+  else {
+    base = 'none'
   }
 
   return {
@@ -463,7 +623,7 @@ export function createCheckpointRecorder(opts: CheckpointRecorderOptions): Check
       // rewrite serializes its delta from confirmedState, THEN awaits IDB; a
       // frame arriving in that window was neither in the serialized bytes nor
       // in `dirty` nor in the op-log (blocked below), yet the write's success
-      // handler cleared `needsRebase`/`fullRewrite` because its `lineage` still
+      // handler cleared `needsRebase` and promoted the base because its `lineage` still
       // matched. The entity then sat stale on disk with nothing left to rewrite
       // it, while the next rewrite pinned a watermark PAST the lost ops -- which
       // the hub never re-ships, since it sends only what is strictly after the
@@ -505,7 +665,8 @@ export function createCheckpointRecorder(opts: CheckpointRecorderOptions): Check
         // instead: a checkpoint written at the CURRENT confirmedState already
         // includes this frame's effect, so it is the self-healing exit.
         log.warn('failed to serialize confirmed frame for op-log; re-basing the checkpoint', { err })
-        pendingFrames.length = 0
+        // invalidateLineage drops the queue: these frames belong to the lineage
+        // this drop just invalidated.
         invalidateLineage()
         rewriteCheckpoint()
         return
@@ -548,7 +709,7 @@ export function createCheckpointRecorder(opts: CheckpointRecorderOptions): Check
       return dirty
     },
     get needsFullRewrite(): boolean {
-      return fullRewrite
+      return base !== 'ready'
     },
   }
 }

--- a/frontend/src/lib/crdt/checkpointStore.test.ts
+++ b/frontend/src/lib/crdt/checkpointStore.test.ts
@@ -4,11 +4,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createOpLogAppender } from '~/test-support/opLog'
 import {
   _resetCheckpointStoreForTest,
+  adoptCheckpoint,
   appendOpLogSegment,
   CHECKPOINT_TTL_MS,
   clearCheckpointAndOpLog,
   clearOwnerCheckpointAndOpLog,
   isCheckpointStoreAvailable,
+  listSeedCandidates,
   MAX_OPLOG_READ_BYTES,
   MAX_OPLOG_READ_FRAMES,
   OWNER_LIVENESS_WINDOW_MS,
@@ -811,3 +813,233 @@ async function countChunkRows(): Promise<number> {
   db.close()
   return count
 }
+
+// The seed scan: how a tab with no checkpoint of its own finds a sibling to
+// adopt. Key-only and descending, so ranking costs no header bytes.
+describe('listSeedCandidates', () => {
+  const now = 1_000_000_000
+
+  /** Write `client`'s checkpoint and pin its lastSeenAt. */
+  async function owner(userId: string, clientId: string, lastSeenAt: number) {
+    await writeCheckpointAndTruncateOpLog(userId, clientId, fullDelta(clientId), WM, 1n, lastSeenAt)
+  }
+
+  it('returns this user\'s other owners, most recently seen first', async () => {
+    await owner('u', 'old', now - 3000)
+    await owner('u', 'new', now - 1000)
+    await owner('u', 'mid', now - 2000)
+
+    expect(await listSeedCandidates('u', 'me', { now })).toEqual([
+      { clientId: 'new', lastSeenAt: now - 1000 },
+      { clientId: 'mid', lastSeenAt: now - 2000 },
+      { clientId: 'old', lastSeenAt: now - 3000 },
+    ])
+  })
+
+  // After a wipe that FAILED, this tab's own poison row is still on disk, and
+  // picking it as "the sibling" would re-read the corruption the wipe was
+  // trying to escape.
+  it('excludes the calling client\'s own row', async () => {
+    await owner('u', 'me', now - 1000)
+    await owner('u', 'other', now - 2000)
+
+    expect(await listSeedCandidates('u', 'me', { now })).toEqual([
+      { clientId: 'other', lastSeenAt: now - 2000 },
+    ])
+  })
+
+  it('excludes other users\' owners', async () => {
+    await owner('other-user', 'theirs', now - 1000)
+    await owner('u', 'mine', now - 2000)
+
+    expect(await listSeedCandidates('u', 'me', { now })).toEqual([
+      { clientId: 'mine', lastSeenAt: now - 2000 },
+    ])
+  })
+
+  // Ranking is lastSeenAt, not writtenAt: writtenAt moves only once per
+  // checkpoint rewrite, so a quiet-but-live tab would rank arbitrarily stale.
+  it('ranks by lastSeenAt, not by write order', async () => {
+    await owner('u', 'written-first', now - 5000)
+    await owner('u', 'written-second', now - 4000)
+    // The older-written owner is the one still running.
+    await touchOwner('u', 'written-first', now - 100)
+
+    const got = await listSeedCandidates('u', 'me', { now })
+    expect(got.map(c => c.clientId)).toEqual(['written-first', 'written-second'])
+  })
+
+  // The walk is globally descending, so the cutoff is a STOP: everything past
+  // the first stale row is staler still, for every account.
+  it('stops at the first owner past the age cutoff', async () => {
+    await owner('u', 'fresh', now - 1000)
+    await owner('u', 'ancient', now - 99_999_999)
+
+    expect(await listSeedCandidates('u', 'me', { now, maxAgeMs: 5000 }))
+      .toEqual([{ clientId: 'fresh', lastSeenAt: now - 1000 }])
+  })
+
+  it('stops at a FOREIGN owner past the cutoff too', async () => {
+    await owner('u', 'fresh', now - 1000)
+    await owner('other-user', 'ancient', now - 50_000)
+    // Older than the foreign row, so a per-user filter that merely SKIPPED the
+    // stale foreign row would still reach this one.
+    await owner('u', 'behind-the-wall', now - 60_000)
+
+    expect(await listSeedCandidates('u', 'me', { now, maxAgeMs: 5000 }))
+      .toEqual([{ clientId: 'fresh', lastSeenAt: now - 1000 }])
+  })
+
+  // `lastSeenAt` is wall-clock, so a session that ran while the device clock was
+  // ahead leaves rows dated after `now`. Their age is negative, so they clear
+  // the cutoff, sort FIRST in the descending walk, and would otherwise consume
+  // every slot the limit allows -- leaving the usable siblings unreachable.
+  it('skips owners stamped in the future without giving up the walk', async () => {
+    await owner('u', 'clock-was-ahead', now + 60_000)
+    await owner('u', 'clock-was-way-ahead', now + 120_000)
+    await owner('u', 'usable', now - 1000)
+
+    expect(await listSeedCandidates('u', 'me', { now, limit: 2 }))
+      .toEqual([{ clientId: 'usable', lastSeenAt: now - 1000 }])
+  })
+
+  it('honours the limit, keeping the most recent', async () => {
+    await owner('u', 'a', now - 1000)
+    await owner('u', 'b', now - 2000)
+    await owner('u', 'c', now - 3000)
+
+    const got = await listSeedCandidates('u', 'me', { now, limit: 2 })
+    expect(got.map(c => c.clientId)).toEqual(['a', 'b'])
+  })
+
+  it('returns an empty list when the user has no other owner', async () => {
+    await owner('u', 'me', now - 1000)
+    expect(await listSeedCandidates('u', 'me', { now })).toEqual([])
+  })
+
+  it('returns an empty list when the store is unavailable', async () => {
+    vi.unstubAllGlobals()
+    expect(await listSeedCandidates('u', 'me', { now })).toEqual([])
+  })
+})
+
+// Adoption: installing a validated sibling's BYTES under this owner's key.
+describe('adoptCheckpoint', () => {
+  const snapshotOf = (header: string, entities: Record<string, string>, frames: string[] = []) => ({
+    headerBytes: bytes(header),
+    chunks: chunksOf(entities),
+    watermark: WM,
+    currentEpoch: 7n,
+    opLogFrames: frames.map(bytes),
+  })
+
+  it('installs the header, watermark, epoch and every chunk', async () => {
+    // With no frames the log is left empty, so the next segment is ordinal 0.
+    const nextOrdinal = await adoptCheckpoint('u', 'me', snapshotOf('h', { 'node:n1': 'A', 'tab:t1': 'B' }))
+    expect(nextOrdinal).toBe(0)
+
+    const read = await readOk('u', 'me')
+    expect(text(read.checkpoint.headerBytes)).toBe('h')
+    expect(read.checkpoint.watermark).toEqual(WM)
+    expect(read.checkpoint.currentEpoch).toBe(7n)
+    expect(read.chunks.map(c => text(c.bytes)).sort()).toEqual(['A', 'B'])
+  })
+
+  // The op-log's ordinal is a PER-OWNER sequence that restarts at 0 after every
+  // checkpoint write, so a copy that preserved the source's numbering would
+  // leave this owner's log starting at N with 0..N-1 absent -- a hole.
+  it('seeds the op-log as ONE segment at ordinal 0', async () => {
+    await adoptCheckpoint('u', 'me', snapshotOf('h', {}, ['f1', 'f2', 'f3']))
+
+    const read = await readOk('u', 'me')
+    expect(read.opLogFrames.map(text)).toEqual(['f1', 'f2', 'f3'])
+    expect(read.opLogNextOrdinal).toBe(1)
+  })
+
+  it('reports ordinal 0 when the snapshot carries no frames', async () => {
+    await adoptCheckpoint('u', 'me', snapshotOf('h', {}))
+
+    const read = await readOk('u', 'me')
+    expect(read.opLogFrames).toEqual([])
+    expect(read.opLogNextOrdinal).toBe(0)
+  })
+
+  // A cursor sees writes made in its own transaction, so a segment added before
+  // the truncate walk was awaited would be deleted the moment it reached it.
+  it('adds the seeded segment AFTER truncating what this owner had', async () => {
+    await writeCheckpointAndTruncateOpLog('u', 'me', fullDelta('old'), WM, 1n)
+    await opLog.append('u', 'me', [bytes('stale-1')])
+    await opLog.append('u', 'me', [bytes('stale-2')])
+
+    await adoptCheckpoint('u', 'me', snapshotOf('h', {}, ['fresh']))
+
+    const read = await readOk('u', 'me')
+    expect(read.opLogFrames.map(text)).toEqual(['fresh'])
+  })
+
+  // REPLACE, not merge. An adoption can follow a wipe that FAILED, and an
+  // additive copy would leave one lineage's header over an entity set
+  // assembled from two.
+  it('replaces whatever this owner already had, chunks included', async () => {
+    await writeCheckpointAndTruncateOpLog('u', 'me', fullDelta('old', { 'node:leftover': 'X' }), WM, 1n)
+
+    await adoptCheckpoint('u', 'me', snapshotOf('h', { 'node:n1': 'A' }))
+
+    const read = await readOk('u', 'me')
+    expect(text(read.checkpoint.headerBytes)).toBe('h')
+    expect(read.chunks.map(c => c.entityId)).toEqual(['n1'])
+  })
+
+  it('leaves the source owner untouched', async () => {
+    await writeCheckpointAndTruncateOpLog('u', 'source', fullDelta('src', { 'node:n1': 'A' }), WM, 1n)
+    await opLog.append('u', 'source', [bytes('their-frame')])
+    const before = await readCheckpoint('u', 'source')
+
+    await adoptCheckpoint('u', 'me', snapshotOf('h', { 'node:n2': 'B' }, ['mine']))
+
+    expect(await readCheckpoint('u', 'source')).toEqual(before)
+  })
+
+  it('stamps writtenAt and lastSeenAt at the adoption', async () => {
+    await adoptCheckpoint('u', 'me', snapshotOf('h', {}), 123_456)
+
+    const read = await readOk('u', 'me')
+    expect(read.checkpoint.writtenAt).toBe(123_456)
+    // lastSeenAt must be NOW, not the source's: this row belongs to a live tab,
+    // and the sweep's only liveness signal is this field.
+    expect(read.checkpoint.lastSeenAt).toBe(123_456)
+  })
+
+  it('returns null when the store is unavailable', async () => {
+    vi.unstubAllGlobals()
+    expect(await adoptCheckpoint('u', 'me', snapshotOf('h', {}))).toBeNull()
+  })
+
+  it('returns null for empty ids', async () => {
+    expect(await adoptCheckpoint('', 'me', snapshotOf('h', {}))).toBeNull()
+    expect(await adoptCheckpoint('u', '', snapshotOf('h', {}))).toBeNull()
+  })
+
+  // The ordinal is reported by the writer rather than re-derived by the caller,
+  // so the two cannot disagree by one and mint the very hole the per-owner
+  // sequence exists to detect.
+  it('reports ordinal 1 when it seeded a segment, and 0 when it did not', async () => {
+    expect(await adoptCheckpoint('u', 'with-log', snapshotOf('h', {}, ['f1', 'f2']))).toBe(1)
+    expect(await adoptCheckpoint('u', 'no-log', snapshotOf('h', {}))).toBe(0)
+  })
+
+  // `abort` is the guard the CALLER's own supersession check cannot reach: it
+  // runs before this call, while `await openDb()` can take a whole task if a
+  // peer tab's schema repair dropped the cached connection.
+  it('writes nothing when abort() answers true before the transaction is created', async () => {
+    await adoptCheckpoint('u', 'me', snapshotOf('first', { 'node:n1': 'A' }))
+
+    const refused = await adoptCheckpoint('u', 'me', snapshotOf('second', { 'node:n2': 'B' }), undefined, () => true)
+    expect(refused).toBeNull()
+
+    // The earlier row is untouched -- a replace that never opened its transaction.
+    const read = await readOk('u', 'me')
+    expect(text(read.checkpoint.headerBytes)).toBe('first')
+    expect(read.chunks.map(c => text(c.bytes))).toEqual(['A'])
+  })
+})

--- a/frontend/src/lib/crdt/checkpointStore.ts
+++ b/frontend/src/lib/crdt/checkpointStore.ts
@@ -69,14 +69,23 @@ import { createLogger } from '~/lib/logger'
 // branch added one, and the sweep now consults it for liveness); it is that
 // neither survives the unguarded `entityRemoved` replay above.
 //
-// A genuinely NEW tab therefore has no checkpoint of its own, sends no resume
-// cursor, and cold-starts with a full snapshot -- which is the last common
-// connect still paying the projection-lock scan #267 exists to remove. The
-// clobber above is a WRITE hazard, so a new tab could safely SEED from a
-// sibling's checkpoint read-only and resume, writing only ever under its own
-// id. Tracked in https://github.com/leapmux/leapmux/issues/358, which also
-// records why #267's other two mitigations were rejected. Measure before
-// building it.
+// A genuinely NEW tab therefore has no checkpoint of its own -- so it would
+// send no resume cursor and cold-start on a full snapshot. The clobber above is
+// a WRITE hazard, and a READER has none, so it instead SEEDS: it picks the
+// freshest sibling owner (listSeedCandidates), reads that owner's pair, and
+// ADOPTS it by copying the already-serialized bytes under its OWN id
+// (adoptCheckpoint). It never writes under, and never deletes, another owner's
+// key -- so the single-writer-per-owner rule the paragraphs above establish is
+// untouched, and the cost is one extra owner row that the sweep reclaims.
+//
+// hydrate.ts owns the policy half (which candidate, and what to do with a
+// corrupt one); this module only enumerates and copies bytes.
+//
+// That covers more than the new tab it was written for: the first tab after a
+// browser RESTART (sessionStorage died, but the dead siblings' rows survive up
+// to CHECKPOINT_TTL_MS), a duplicate tab whose id clientIdentity.ts re-minted,
+// and this tab's OWN checkpoint turning out to be corrupt -- every one of which
+// used to mean a full projection snapshot.
 //
 // The store is a PURE BLOB STORE: it returns raw `Uint8Array` and never
 // deserializes proto here -- a chunk's `kind` and `entityId` are opaque strings
@@ -173,6 +182,40 @@ export const OWNER_LIVENESS_WINDOW_MS = 3 * OWNER_TOUCH_INTERVAL_MS
  */
 export const MAX_OPLOG_READ_FRAMES = 5000
 export const MAX_OPLOG_READ_BYTES = 4 * 1024 * 1024
+
+/**
+ * How stale an owner may be and still be worth SEEDING a new tab from,
+ * mirroring the hub's OpRetentionTTL (24h) exactly as MAX_OPLOG_READ_FRAMES
+ * mirrors MaxResumeDeltaOps.
+ *
+ * A cursor below the hub's retention floor FALLBACKs anyway (decideResume
+ * applies a WALL-CLOCK `now - OpRetentionTTL` floor alongside the stored
+ * watermark, so a dormant account does not retain forever), so adopting an
+ * older pair would pay a read plus a full-chunk copy for a snapshot the hub is
+ * going to send regardless.
+ *
+ * The test is sound only in the SAFE direction, which is the one that matters:
+ * a tab last seen at L cannot have applied ops after L, so `L < now - 24h`
+ * implies its cursor is below the floor. The converse does not hold -- a fresh
+ * `lastSeenAt` on an otherwise dormant account can still FALLBACK -- and costs
+ * one wasted read, which is exactly what a refresh of that same tab already
+ * does today.
+ *
+ * Deliberately much shorter than CHECKPOINT_TTL_MS (14 days): the sweep's job
+ * is reclaiming storage, this one's is "is a resume still possible", and those
+ * are different questions with different right answers.
+ */
+export const SEED_CANDIDATE_MAX_AGE_MS = 24 * 60 * 60 * 1000
+
+/**
+ * How many candidates one seed attempt reads before giving up.
+ *
+ * Bounded because each attempt is a full read of a checkpoint plus its chunks,
+ * on the cold-start critical path. A corrupt sibling is rare; three of them in
+ * a row means something is wrong with the device's storage, and one full
+ * snapshot is a better answer than a fourth read.
+ */
+export const SEED_MAX_CANDIDATES = 3
 
 /** On-disk shape of a checkpoint METADATA row (one per (user, client) pair). */
 export interface CheckpointRecord {
@@ -581,44 +624,7 @@ export async function writeCheckpointAndTruncateOpLog(
     const tx = db.transaction([CHECKPOINT_STORE, CHUNK_STORE, OPLOG_STORE], 'readwrite')
     // Registered in the same task that created the transaction, per txToPromise.
     const settled = txToPromise(tx, 'writeCheckpoint')
-    const writes = (async () => {
-      const chunks = tx.objectStore(CHUNK_STORE)
-      const owner: [string, string] = [userId, clientId]
-      if (delta.full) {
-        // AWAITED before the upserts below. A cursor sees writes made in its
-        // own transaction, so a chunk `put` issued while this walk is still
-        // advancing would be deleted again the moment the cursor reached its
-        // key. Awaiting a request of THIS transaction keeps it active across
-        // the microtask checkpoint (see readCheckpoint).
-        await deleteIndexRange(chunks, BY_OWNER_INDEX, IDBKeyRange.only(owner))
-      }
-      for (const chunk of delta.upserts) {
-        chunks.put({
-          userId,
-          clientId,
-          kind: chunk.kind,
-          entityId: chunk.entityId,
-          bytes: chunk.bytes,
-        } satisfies CheckpointChunkRecord)
-      }
-      // Keyed deletes: the owner tuple is part of the primary key, so an
-      // entity that left the state needs no index walk.
-      for (const ref of delta.deletes)
-        chunks.delete([userId, clientId, ref.kind, ref.entityId])
-      tx.objectStore(CHECKPOINT_STORE).put({
-        userId,
-        clientId,
-        headerBytes: delta.headerBytes,
-        watermark,
-        currentEpoch,
-        writtenAt: now,
-        lastSeenAt: now,
-      } satisfies CheckpointRecord)
-      // Truncate only THIS owner's log. The walk's own promise settles when it
-      // has issued every delete; `settled` waits for durability, and a cursor
-      // error aborts the transaction, which rejects it.
-      await deleteIndexRange(tx.objectStore(OPLOG_STORE), BY_OWNER_INDEX, IDBKeyRange.only(owner))
-    })()
+    const writes = writeDeltaInto(tx, userId, clientId, delta, watermark, currentEpoch, now)
     // Both are passed to Promise.all so neither can reject unobserved when the
     // other fails first.
     await Promise.all([writes, settled])
@@ -627,6 +633,284 @@ export async function writeCheckpointAndTruncateOpLog(
   catch {
     log.warn('checkpoint write failed (quota exceeded / private mode); cold reloads will replay the existing op-log')
     return false
+  }
+}
+
+/**
+ * Apply `delta` to `(userId, clientId)`'s checkpoint and truncate its op-log,
+ * within the caller's readwrite transaction.
+ *
+ * Extracted so `writeCheckpointAndTruncateOpLog` and `adoptCheckpoint` cannot
+ * drift on the ORDERING rule below, which is the part that is easy to get
+ * wrong and impossible to notice: both writers do delete-then-upsert against
+ * the same three stores, and only one of them is exercised on the hot path.
+ *
+ * Resolves once every write has been ISSUED; the caller awaits the transaction
+ * for durability.
+ */
+async function writeDeltaInto(
+  tx: IDBTransaction,
+  userId: string,
+  clientId: string,
+  delta: CheckpointDelta,
+  watermark: HlcShape,
+  currentEpoch: bigint,
+  now: number,
+): Promise<void> {
+  const chunks = tx.objectStore(CHUNK_STORE)
+  const owner: [string, string] = [userId, clientId]
+  if (delta.full) {
+    // AWAITED before the upserts below. A cursor sees writes made in its
+    // own transaction, so a chunk `put` issued while this walk is still
+    // advancing would be deleted again the moment the cursor reached its
+    // key. Awaiting a request of THIS transaction keeps it active across
+    // the microtask checkpoint (see readCheckpoint).
+    await deleteIndexRange(chunks, BY_OWNER_INDEX, IDBKeyRange.only(owner))
+  }
+  for (const chunk of delta.upserts) {
+    chunks.put({
+      userId,
+      clientId,
+      kind: chunk.kind,
+      entityId: chunk.entityId,
+      bytes: chunk.bytes,
+    } satisfies CheckpointChunkRecord)
+  }
+  // Keyed deletes: the owner tuple is part of the primary key, so an
+  // entity that left the state needs no index walk.
+  for (const ref of delta.deletes)
+    chunks.delete([userId, clientId, ref.kind, ref.entityId])
+  tx.objectStore(CHECKPOINT_STORE).put({
+    userId,
+    clientId,
+    headerBytes: delta.headerBytes,
+    watermark,
+    currentEpoch,
+    writtenAt: now,
+    lastSeenAt: now,
+  } satisfies CheckpointRecord)
+  // Truncate only THIS owner's log. The walk's own promise settles when it
+  // has issued every delete; the caller's `settled` waits for durability, and a
+  // cursor error aborts the transaction, which rejects it.
+  await deleteIndexRange(tx.objectStore(OPLOG_STORE), BY_OWNER_INDEX, IDBKeyRange.only(owner))
+}
+
+/** One sibling owner as the seed scan sees it: identity plus recency, no payload. */
+export interface SeedCandidate {
+  clientId: string
+  /** `lastSeenAt` — when this owner was last known to be RUNNING. */
+  lastSeenAt: number
+}
+
+/** Options for `listSeedCandidates`; every one is a test seam. */
+export interface SeedCandidateOptions {
+  now?: number
+  maxAgeMs?: number
+  limit?: number
+}
+
+/**
+ * This user's OTHER owners, most-recently-seen FIRST.
+ *
+ * A genuinely new tab has no checkpoint of its own -- the client id lives in
+ * sessionStorage -- so it would send no resume cursor and cold-start on a full
+ * projection snapshot. The WRITE clobber that forces the per-tab key (see this
+ * module's header) is a hazard for WRITERS only, so a new tab may read a
+ * sibling's pair and adopt it. This is how it finds one.
+ *
+ * A key-only DESCENDING walk of byLastSeenAt: the cursor yields
+ * (lastSeenAt, [userId, clientId]) and touches NO value at all, so ranking eight
+ * owners costs zero header bytes. `byUserId` cannot serve this -- its key is the
+ * user alone, so ranking through it would have to read every candidate's VALUE,
+ * which is exactly the header materialization BY_LAST_SEEN_INDEX exists to
+ * avoid.
+ *
+ * `lastSeenAt`, not the checkpoint's watermark, is the ranking key, and not
+ * merely because it is the free one: a LIVE sibling's watermark is pinned at
+ * its last rewrite (once per CHECKPOINT_OP_LOG_THRESHOLD frames) while its
+ * op-log carries it arbitrarily further forward, so the watermark understates
+ * exactly the candidates worth having. Recency of the TAB is the better proxy
+ * for recency of its log.
+ *
+ * Because the walk is globally descending, the age cutoff is a STOP, not a
+ * filter: the first row past it is followed only by older ones, for every
+ * account.
+ *
+ * Excludes `excludeClientId` -- after a wipe that FAILED
+ * (clearOwnerCheckpointAndOpLog can return false), this tab's own poison row is
+ * still there, and picking it as "the sibling" would re-read the corruption the
+ * wipe was trying to escape.
+ *
+ * Best-effort and no-throw, like every operation in this module.
+ */
+export async function listSeedCandidates(
+  userId: string,
+  excludeClientId: string,
+  opts: SeedCandidateOptions = {},
+): Promise<SeedCandidate[]> {
+  if (!isCheckpointStoreAvailable() || !userId)
+    return []
+  const now = opts.now ?? Date.now()
+  const maxAgeMs = opts.maxAgeMs ?? SEED_CANDIDATE_MAX_AGE_MS
+  const limit = opts.limit ?? SEED_MAX_CANDIDATES
+  if (limit <= 0)
+    return []
+  try {
+    const db = await openDb()
+    const tx = db.transaction(CHECKPOINT_STORE, 'readonly')
+    const out: SeedCandidate[] = []
+    await forEachCursorWhile(
+      tx.objectStore(CHECKPOINT_STORE).index(BY_LAST_SEEN_INDEX).openKeyCursor(null, 'prev'),
+      (cursor) => {
+        const lastSeenAt = cursor.key as number
+        const age = now - lastSeenAt
+        // SKIP a row stamped in the FUTURE, and keep walking.
+        //
+        // `lastSeenAt` is wall-clock, so a session that ran while the device
+        // clock was ahead (or one corrected backwards afterwards) leaves rows
+        // dated after `now`. Their age is NEGATIVE, so without this they clear
+        // the cutoff below, sort FIRST in a descending walk, and consume every
+        // one of the `limit` slots -- and if they are also stale, every new tab
+        // in that profile reads three checkpoints, copies one, presents a cursor
+        // the hub refuses, and takes the full snapshot anyway. Seeding would be
+        // silently dead for the profile until the sweep's TTL reclaimed them.
+        //
+        // Skipping, not stopping: they sort ABOVE the usable rows, so stopping
+        // here would discard the very candidates the walk is for.
+        if (age < 0)
+          return true
+        // STOP, not skip: the walk is descending over EVERY account's rows, so
+        // everything after this point is older still.
+        if (age >= maxAgeMs)
+          return false
+        const [rowUser, rowClient] = cursor.primaryKey as [string, string]
+        if (rowUser !== userId || rowClient === excludeClientId)
+          return true
+        out.push({ clientId: rowClient, lastSeenAt })
+        return out.length < limit
+      },
+    )
+    return out
+  }
+  catch {
+    // Best-effort: no candidates just means today's full-snapshot cold start.
+    return []
+  }
+}
+
+/**
+ * One owner's persisted pair as BYTES — the payload of an adoption.
+ *
+ * Every field is opaque here; the caller (hydrate.ts) has already parsed and
+ * validated it, which is what keeps this module a pure blob store.
+ */
+export interface CheckpointSnapshot {
+  headerBytes: Uint8Array
+  chunks: readonly ChunkUpsert[]
+  watermark: HlcShape
+  currentEpoch: bigint
+  /**
+   * Frames to seed the adopting owner's log with, written as ONE segment at
+   * ordinal 0.
+   *
+   * The SOURCE's ordinals are deliberately NOT preserved. The sequence is
+   * per-owner and restarts at 0 after every checkpoint write, so a copy that
+   * inherited them would leave the adopter's log starting at N with 0..N-1
+   * absent -- which readOpLogFrames reads as a HOLE, discarding a log that is
+   * in fact intact.
+   *
+   * Must be the frames the caller actually VALIDATED, not everything the read
+   * returned. A source log that stops decoding part-way is replayed as a strict
+   * prefix, and copying the undecodable remainder would make this owner's row a
+   * second durable copy of the corruption -- one that every later cold start of
+   * THIS tab re-reads, re-truncates at the same frame, and resumes from a
+   * watermark that keeps rewinding.
+   */
+  opLogFrames: readonly Uint8Array[]
+}
+
+/**
+ * Install `snapshot` as `(userId, clientId)`'s checkpoint + op-log, REPLACING
+ * whatever that owner had, in one transaction.
+ *
+ * This is how a new tab adopts a sibling's base: by COPY, not by re-serializing
+ * its own state. Rebuilding instead would run `fullCheckpointDelta` ->
+ * `serializeAllEntities`, one main-thread `toBinary` PER ENTITY (56.7 ms at
+ * 2400 nodes / 4800 tabs), for exactly the same number of IDB puts. The copy
+ * pays the puts and zero proto work.
+ *
+ * REPLACING, not merging, and that is load-bearing: an adoption can run after
+ * this owner's own corrupt checkpoint was wiped, and that wipe can FAIL. An
+ * additive copy over surviving rows would leave a header from one lineage over
+ * an entity set assembled from two -- a state silently missing or gaining
+ * records, with the resume cursor riding on it.
+ *
+ * Returns the ordinal the adopting owner's NEXT appended segment must carry, or
+ * null when the transaction did not commit. The caller must not read a null as
+ * "probably fine": the recorder's incremental rewrites are only sound over
+ * chunks that are actually on disk (see HydrationPayload.persistedBase).
+ *
+ * The ordinal is reported rather than left for the caller to re-derive, because
+ * deriving it means restating THIS function's segment layout ("one segment, at
+ * ordinal 0, and only when there are frames") at a distance. A producer and a
+ * consumer that disagree by one mint exactly the hole the per-owner sequence
+ * exists to detect: a log starting at 1 with 0 absent, which readOpLogFrames
+ * reads as truncated and discards.
+ *
+ * `abort` is consulted once, immediately before the transaction is CREATED,
+ * which is the point the caller's own supersession check cannot reach. That
+ * check runs before this call, and the `await openDb()` below is a no-op
+ * microtask only while the cached connection is live -- a peer tab's
+ * schema-repair `deleteDatabase()` nulls it (see idb.ts's `onversionchange`),
+ * and the reopen that follows is a whole task, long enough for the caller's
+ * deadline to fire, its run to cold-start, and its recorder to begin numbering
+ * a log this replace would then truncate underneath it.
+ */
+export async function adoptCheckpoint(
+  userId: string,
+  clientId: string,
+  snapshot: CheckpointSnapshot,
+  now = Date.now(),
+  abort?: () => boolean,
+): Promise<number | null> {
+  if (!isCheckpointStoreAvailable() || !userId || !clientId)
+    return null
+  try {
+    const db = await openDb()
+    if (abort?.())
+      return null
+    const tx = db.transaction([CHECKPOINT_STORE, CHUNK_STORE, OPLOG_STORE], 'readwrite')
+    const settled = txToPromise(tx, 'adoptCheckpoint')
+    const writes = (async () => {
+      // `full: true` is what makes this a replace: writeDeltaInto clears this
+      // owner's chunk range first, and truncates its op-log last.
+      await writeDeltaInto(
+        tx,
+        userId,
+        clientId,
+        { headerBytes: snapshot.headerBytes, upserts: snapshot.chunks, deletes: [], full: true },
+        snapshot.watermark,
+        snapshot.currentEpoch,
+        now,
+      )
+      // AFTER writeDeltaInto's truncate walk has been awaited -- a cursor sees
+      // writes made in its own transaction, so a segment added first would be
+      // deleted the moment that walk reached it.
+      if (snapshot.opLogFrames.length > 0) {
+        tx.objectStore(OPLOG_STORE).add({
+          userId,
+          clientId,
+          ordinal: 0,
+          framesBytes: [...snapshot.opLogFrames],
+        } satisfies OpLogRecord)
+      }
+    })()
+    await Promise.all([writes, settled])
+    return snapshot.opLogFrames.length > 0 ? 1 : 0
+  }
+  catch {
+    log.warn('checkpoint adoption failed (quota exceeded / private mode); this tab will cold-start its own checkpoint')
+    return null
   }
 }
 
@@ -839,13 +1123,15 @@ export async function sweepAbandonedCheckpoints(
   const maxOwners = opts.maxOwners ?? CHECKPOINT_MAX_OWNERS
   try {
     const db = await openDb()
-    // Key-only walk, UNRANGED. The index key is writtenAt and the primary key
+    // Key-only walk, UNRANGED. The index key is lastSeenAt and the primary key
     // is [userId, clientId], so this reads no header or chunk bytes at all --
-    // and a compound [userId, writtenAt] index, which would let the walk skip
+    // and a compound [userId, lastSeenAt] index, which would let the walk skip
     // other accounts' rows, is deliberately NOT added: those rows are exactly
     // the ones nothing else can reach, so making them cheap to skip would make
     // them permanently unreclaimable. The population this walks is capped at
-    // ~maxOwners per account by this very sweep.
+    // ~maxOwners per account by this very sweep. (listSeedCandidates walks the
+    // same unranged index, filtering to one user in memory, for the same
+    // reason: the population is small and bounded by this sweep.)
     const rows: SweepCandidate[] = []
     const readTx = db.transaction(CHECKPOINT_STORE, 'readonly')
     await forEachCursor(

--- a/frontend/src/lib/crdt/hydrate.test.ts
+++ b/frontend/src/lib/crdt/hydrate.test.ts
@@ -9,10 +9,24 @@ import { createOpLogAppender } from '~/test-support/opLog'
 import { fullCheckpointDelta, serializeHeader } from './checkpointChunks'
 import {
   _resetCheckpointStoreForTest,
+  adoptCheckpoint,
+  appendOpLogSegment,
   MAX_OPLOG_READ_FRAMES,
+  readCheckpoint,
+  SEED_CANDIDATE_MAX_AGE_MS,
+  touchOwner,
   writeCheckpointAndTruncateOpLog,
 } from './checkpointStore'
 import { loadHydrationState } from './hydrate'
+
+// Partially mocked so ONE case can force the adoption write to fail. Every
+// other export -- and adoptCheckpoint itself, unless a test overrides it --
+// is the real implementation, so the rest of this file still exercises the
+// store rather than a stand-in.
+vi.mock('./checkpointStore', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./checkpointStore')>()
+  return { ...actual, adoptCheckpoint: vi.fn(actual.adoptCheckpoint) }
+})
 
 const opLog = createOpLogAppender()
 
@@ -88,7 +102,7 @@ describe('loadHydrationState', () => {
   // checkpoint AND op-log. Those tabs then cold-started with the full
   // projection snapshot #267 exists to avoid: the exact cross-tab clobber the
   // (user, client) key was introduced to narrow.
-  it('wipes only the failing tab, leaving a sibling tab hydratable', async () => {
+  it('wipes only the failing tab, leaving the sibling\'s rows intact', async () => {
     // A healthy sibling tab.
     await seed('u', 'tab-good', stateOf('u', 5n))
     await opLog.append('u', 'tab-good', [batchFrame('b-good')])
@@ -100,15 +114,48 @@ describe('loadHydrationState', () => {
       full: true,
     })
 
+    const before = await readCheckpoint('u', 'tab-good')
+    expect(before.status).toBe('ok')
+
+    await loadHydrationState('u', 'tab-bad')
+
+    // Asserted against the STORE, not against a second loadHydrationState call:
+    // since the seed path landed, a load for 'tab-good' would also succeed by
+    // adopting some other owner, so it can no longer distinguish "this tab's
+    // rows survived" from "some rows survived somewhere".
+    expect(await readCheckpoint('u', 'tab-good')).toEqual(before)
+    // And the poison row really is gone from disk, so the next reload of that
+    // tab does not pay another failed parse. (It is not a MISS: having wiped
+    // its own row, the tab went on to adopt the sibling's -- see the seeding
+    // block below. What matters here is that the undecodable header is gone.)
+    const rebuilt = await readCheckpoint('u', 'tab-bad')
+    expect(rebuilt.status).toBe('ok')
+    expect(rebuilt.status === 'ok' && rebuilt.checkpoint.headerBytes)
+      .not
+      .toEqual(new Uint8Array([0xFF, 0xFF, 0xFF]))
+  })
+
+  // The case above cannot see the wipe: with a sibling present, the adoption's
+  // full-replace write leaves 'tab-bad' readable whether or not the wipe ran.
+  // With NO sibling to adopt, the wipe is the only thing that can change what is
+  // on disk -- so this is the case that actually pins it.
+  it('wipes its own corrupt row even when there is no sibling to adopt', async () => {
+    await seedDelta('u', 'tab-bad', {
+      headerBytes: new Uint8Array([0xFF, 0xFF, 0xFF]),
+      upserts: [],
+      deletes: [],
+      full: true,
+    })
+    await opLog.append('u', 'tab-bad', [batchFrame('b-bad')])
+    expect((await readCheckpoint('u', 'tab-bad')).status).toBe('ok')
+
     expect(await loadHydrationState('u', 'tab-bad')).toBeNull()
 
-    const survivor = await loadHydrationState('u', 'tab-good')
-    expect(survivor).not.toBeNull()
-    expect(survivor!.frames).toHaveLength(1)
-    expect(Object.keys(survivor!.state.nodes).sort()).toEqual(['n1', 'n2'])
-    // And the bad row really is gone, so the next reload of that tab is a miss
-    // rather than another failed parse.
-    expect(await loadHydrationState('u', 'tab-bad')).toBeNull()
+    // GONE, not merely unusable. A wipe that silently did nothing would leave
+    // the undecodable header in place, and every later reload would re-pay the
+    // failed parse and cold-start again -- forever, and invisibly. That is what
+    // the module header's "self-heals" claim rests on.
+    expect((await readCheckpoint('u', 'tab-bad')).status).toBe('miss')
   })
 
   it('round-trips a well-formed checkpoint + op-log', async () => {
@@ -372,3 +419,260 @@ async function openDbRaw(): Promise<IDBDatabase> {
     r.onerror = () => reject(r.error)
   })
 }
+
+// Seeding: a tab with nothing usable of its own adopts a SIBLING's pair rather
+// than cold-starting on a full projection snapshot. The write clobber that
+// forces the per-(user, client) key is a hazard for WRITERS; a reader has none.
+describe('loadHydrationState seeding from a sibling', () => {
+  it('seeds from the only sibling when this tab has no checkpoint', async () => {
+    await seed('u', 'tab-old', stateOf('u', 5n))
+    await opLog.append('u', 'tab-old', [batchFrame('b1')])
+
+    const payload = await loadHydrationState('u', 'tab-new')
+
+    expect(payload).not.toBeNull()
+    expect(Object.keys(payload!.state.nodes).sort()).toEqual(['n1', 'n2'])
+    expect(payload!.frames).toHaveLength(1)
+    expect(await payload!.persistedBase).not.toBeNull()
+  })
+
+  it('prefers this tab\'s own checkpoint over a fresher sibling', async () => {
+    await seed('u', CLIENT, stateOf('u', 5n))
+    await seed('u', 'tab-other', stateOf('u', 99n))
+    await touchOwner('u', 'tab-other', Date.now() + 1000)
+
+    const payload = await loadHydrationState('u', CLIENT)
+
+    expect(payload!.state.maxHlc!.physical).toBe(5n)
+  })
+
+  it('copies the sibling\'s header, chunks and op-log under THIS tab\'s owner key', async () => {
+    await seed('u', 'tab-old', stateOf('u', 5n))
+    await opLog.append('u', 'tab-old', [batchFrame('b1'), batchFrame('b2')])
+
+    await loadHydrationState('u', 'tab-new')
+
+    const mine = await readCheckpoint('u', 'tab-new')
+    expect(mine.status).toBe('ok')
+    const theirs = await readCheckpoint('u', 'tab-old')
+    expect(mine.status === 'ok' && theirs.status === 'ok'
+      && mine.checkpoint.headerBytes).toEqual(theirs.status === 'ok' ? theirs.checkpoint.headerBytes : null)
+    expect(mine.status === 'ok' && mine.chunks).toHaveLength(theirs.status === 'ok' ? theirs.chunks.length : -1)
+    expect(mine.status === 'ok' && mine.opLogFrames).toHaveLength(2)
+  })
+
+  it('leaves the sibling\'s rows byte-identical', async () => {
+    await seed('u', 'tab-old', stateOf('u', 5n))
+    await opLog.append('u', 'tab-old', [batchFrame('b1')])
+    const before = await readCheckpoint('u', 'tab-old')
+
+    await loadHydrationState('u', 'tab-new')
+
+    expect(await readCheckpoint('u', 'tab-old')).toEqual(before)
+  })
+
+  // The single easiest way to get the adoption wrong. The op-log's `ordinal` is
+  // PER OWNER and restarts at 0 after every checkpoint write, so inheriting the
+  // source's counter would leave our log starting at N with 0..N-1 absent --
+  // which readOpLogFrames reads as a hole and discards an intact log for.
+  it('numbers the copied log from 0, not from the sibling\'s next ordinal', async () => {
+    await seed('u', 'tab-old', stateOf('u', 5n))
+    await opLog.append('u', 'tab-old', [batchFrame('b1')])
+    await opLog.append('u', 'tab-old', [batchFrame('b2')])
+    await opLog.append('u', 'tab-old', [batchFrame('b3')])
+    // The source is three segments in, so a naive copy would hand us 3.
+    expect((await readCheckpoint('u', 'tab-old')).status === 'ok'
+      && (await readCheckpoint('u', 'tab-old') as { opLogNextOrdinal: number }).opLogNextOrdinal).toBe(3)
+
+    const payload = await loadHydrationState('u', 'tab-new')
+    const settled = await payload!.persistedBase
+    expect(settled?.nextOpLogOrdinal).toBe(1)
+
+    // And appending at that ordinal really does keep the sequence contiguous:
+    // a later cold start reads the whole log, not a prefix ending at a hole.
+    // Direct, not via the opLog helper: this test hand-picks the ordinal, which
+    // is exactly the case that helper's doc reserves for the raw call.
+    await appendOpLogSegment('u', 'tab-new', [batchFrame('b4')], settled!.nextOpLogOrdinal)
+    const next = await loadHydrationState('u', 'tab-new')
+    expect(next!.frames).toHaveLength(4)
+    expect(next!.truncated).toBe(false)
+  })
+
+  it('picks the most recently seen sibling when several exist', async () => {
+    await seed('u', 'tab-a', stateOf('u', 5n))
+    await seed('u', 'tab-b', stateOf('u', 9n))
+    // Recency is lastSeenAt, not the checkpoint's watermark: a live tab's
+    // watermark is pinned at its last rewrite while its op-log runs on ahead.
+    // So tab-a must win despite the LOWER watermark. Age tab-b backwards rather
+    // than stamping tab-a into the future -- a future `lastSeenAt` is a clock
+    // artefact the scan now skips outright, so the shortcut would test the skip
+    // instead of the ranking.
+    await touchOwner('u', 'tab-b', Date.now() - 5000)
+
+    const payload = await loadHydrationState('u', 'tab-new')
+
+    expect(payload!.state.maxHlc!.physical).toBe(5n)
+  })
+
+  it('skips a corrupt sibling and tries the next one', async () => {
+    await seedDelta('u', 'tab-bad', {
+      headerBytes: new Uint8Array([0xFF, 0xFF, 0xFF]),
+      upserts: [],
+      deletes: [],
+      full: true,
+    })
+    await seed('u', 'tab-good', stateOf('u', 5n))
+    // Make the CORRUPT one the freshest, so it is tried first.
+    await touchOwner('u', 'tab-bad', Date.now() + 5000)
+
+    const payload = await loadHydrationState('u', 'tab-new')
+
+    expect(payload).not.toBeNull()
+    expect(Object.keys(payload!.state.nodes).sort()).toEqual(['n1', 'n2'])
+  })
+
+  // The safety property the whole seed path rests on. A sibling's recorder
+  // believes its chunks are on disk and rewrites INCREMENTALLY against them, so
+  // deleting them would leave it writing a header plus a few shards over
+  // nothing -- inflicted on a tab whose own records were fine.
+  it('never deletes a skipped sibling\'s rows', async () => {
+    await seedDelta('u', 'tab-bad', {
+      headerBytes: new Uint8Array([0xFF, 0xFF, 0xFF]),
+      upserts: [],
+      deletes: [],
+      full: true,
+    })
+    const before = await readCheckpoint('u', 'tab-bad')
+    expect(before.status).toBe('ok')
+
+    expect(await loadHydrationState('u', 'tab-new')).toBeNull()
+
+    expect(await readCheckpoint('u', 'tab-bad')).toEqual(before)
+  })
+
+  it('gives up after the candidate cap rather than reading every owner', async () => {
+    for (const id of ['s1', 's2', 's3', 's4']) {
+      await seedDelta('u', id, {
+        headerBytes: new Uint8Array([0xFF, 0xFF, 0xFF]),
+        upserts: [],
+        deletes: [],
+        full: true,
+      })
+    }
+    // A healthy one, but oldest, so it sits past the cap.
+    await seed('u', 'tab-good', stateOf('u', 5n))
+    await touchOwner('u', 'tab-good', Date.now() - 1000)
+
+    expect(await loadHydrationState('u', 'tab-new', { limit: 2 })).toBeNull()
+  })
+
+  it('returns null when there is no sibling at all', async () => {
+    expect(await loadHydrationState('u', 'tab-new')).toBeNull()
+  })
+
+  it('never seeds from another user\'s owner', async () => {
+    await seed('other-user', 'tab-theirs', stateOf('other-user', 5n))
+
+    expect(await loadHydrationState('u', 'tab-new')).toBeNull()
+  })
+
+  it('does not seed from an owner last seen beyond the retention window', async () => {
+    await seed('u', 'tab-ancient', stateOf('u', 5n))
+    await touchOwner('u', 'tab-ancient', Date.now() - SEED_CANDIDATE_MAX_AGE_MS - 1)
+
+    expect(await loadHydrationState('u', 'tab-new')).toBeNull()
+  })
+
+  it('carries a sibling\'s truncated op-log through as truncated', async () => {
+    await seed('u', 'tab-old', stateOf('u', 5n))
+    await opLog.append('u', 'tab-old', [batchFrame('b1')])
+    // A frame that will not decode: the replay stops at it, and the payload is
+    // a strict prefix.
+    await opLog.append('u', 'tab-old', [new Uint8Array([0xFF, 0xFF, 0xFF])])
+
+    const payload = await loadHydrationState('u', 'tab-new')
+
+    expect(payload!.truncated).toBe(true)
+    expect(payload!.frames).toHaveLength(1)
+  })
+
+  // ...and copies ONLY that prefix. Adopting the raw list would make this
+  // owner's row a second durable copy of the sibling's corruption -- one that
+  // every later cold start of THIS tab re-reads and re-truncates at, resuming
+  // from a watermark that keeps rewinding.
+  it('adopts only the frames it validated, never the sibling\'s poison tail', async () => {
+    await seed('u', 'tab-old', stateOf('u', 5n))
+    await opLog.append('u', 'tab-old', [batchFrame('b1')])
+    await opLog.append('u', 'tab-old', [new Uint8Array([0xFF, 0xFF, 0xFF])])
+
+    const payload = await loadHydrationState('u', 'tab-new')
+    expect(await payload!.persistedBase).toEqual({ nextOpLogOrdinal: 1 })
+
+    // Our own row is now self-consistent: what is on disk is exactly what was
+    // replayed, so re-reading it is not truncated at all.
+    const mine = await readCheckpoint('u', 'tab-new')
+    expect(mine.status).toBe('ok')
+    if (mine.status !== 'ok')
+      return
+    expect(mine.opLogFrames).toHaveLength(1)
+    expect(mine.opLogTruncated).toBe(false)
+    // And the sibling's own row still holds both frames, untouched -- the seed
+    // reads it and never writes to it. (The store returns both: it deals in
+    // bytes, and only the DECODE in validateCheckpoint can tell them apart.)
+    const theirs = await readCheckpoint('u', 'tab-old')
+    expect(theirs.status).toBe('ok')
+    if (theirs.status === 'ok')
+      expect(theirs.opLogFrames).toHaveLength(2)
+  })
+
+  // persistedBase is what stops the recorder writing a silently-short
+  // checkpoint: an incremental rewrite is only sound over chunks that really
+  // are on disk.
+  it('reports no persisted base when the adoption write fails, and still returns the state', async () => {
+    await seed('u', 'tab-old', stateOf('u', 5n))
+    await opLog.append('u', 'tab-old', [batchFrame('b1')])
+    vi.mocked(adoptCheckpoint).mockResolvedValueOnce(null)
+
+    const payload = await loadHydrationState('u', 'tab-new')
+
+    expect(payload).not.toBeNull()
+    expect(Object.keys(payload!.state.nodes).sort()).toEqual(['n1', 'n2'])
+    expect(payload!.frames).toHaveLength(1)
+    expect(await payload!.persistedBase).toBeNull()
+  })
+
+  // useCrdtRuntime's deadline resolves null WITHOUT cancelling the read behind
+  // it, so a late adoption would replace a freshly bootstrapped checkpoint with
+  // the sibling's older one while the recorder kept appending its own ordinals.
+  it('writes nothing when the run was superseded before the adoption', async () => {
+    await seed('u', 'tab-old', stateOf('u', 5n))
+
+    const payload = await loadHydrationState('u', 'tab-new', { superseded: () => true })
+
+    expect(await payload!.persistedBase).toBeNull()
+    expect((await readCheckpoint('u', 'tab-new')).status).toBe('miss')
+  })
+
+  // The WIPE is the other write on this path, and the more destructive one: a
+  // superseded run has already cold-started, bootstrapped, and had its recorder
+  // write a fresh checkpoint under this same owner key with a `ready` base, so
+  // a late wipe deletes those rows while the recorder goes on rewriting
+  // INCREMENTALLY against chunks that are no longer there.
+  it('does not wipe its own corrupt row when the run was superseded', async () => {
+    await seedDelta('u', 'tab-new', {
+      headerBytes: new Uint8Array([0xFF, 0xFF, 0xFF]),
+      upserts: [],
+      deletes: [],
+      full: true,
+    })
+    await seed('u', 'tab-old', stateOf('u', 5n))
+
+    expect(await loadHydrationState('u', 'tab-new', { superseded: () => true })).toBeNull()
+
+    // Still there -- untouched, and not seeded over either.
+    const mine = await readCheckpoint('u', 'tab-new')
+    expect(mine.status).toBe('ok')
+    if (mine.status === 'ok')
+      expect([...mine.checkpoint.headerBytes]).toEqual([0xFF, 0xFF, 0xFF])
+  })
+})

--- a/frontend/src/lib/crdt/hydrate.ts
+++ b/frontend/src/lib/crdt/hydrate.ts
@@ -1,4 +1,5 @@
 import type { ChunkKind } from './checkpointChunks'
+import type { CheckpointRead } from './checkpointStore'
 import type { HlcShape } from './hlc'
 import type { UserCrdtState } from '~/generated/leapmux/v1/user_crdt_pb'
 import type { WatchUserEvent } from '~/generated/leapmux/v1/user_ops_pb'
@@ -6,7 +7,13 @@ import { fromBinary } from '@bufbuild/protobuf'
 import { WatchUserEventSchema } from '~/generated/leapmux/v1/user_ops_pb'
 import { createLogger } from '~/lib/logger'
 import { applyChunk, isChunkKind, parseHeader } from './checkpointChunks'
-import { clearOwnerCheckpointAndOpLog, isCheckpointStoreAvailable, readCheckpoint } from './checkpointStore'
+import {
+  adoptCheckpoint,
+  clearOwnerCheckpointAndOpLog,
+  isCheckpointStoreAvailable,
+  listSeedCandidates,
+  readCheckpoint,
+} from './checkpointStore'
 import { inInt64Range } from './hlc'
 
 const log = createLogger('crdtHydrate')
@@ -68,6 +75,37 @@ export interface HydrationPayload {
    */
   truncated: boolean
   /**
+   * The persisted base this payload sits on: a value when it is already durable
+   * under this owner's key, a PROMISE of one while it is still being written,
+   * or null when there is none. Present (eventually) means the recorder may
+   * rewrite INCREMENTALLY against it.
+   *
+   * Already settled on the self-hydration path — the caller read those bytes
+   * back off disk. A promise on the SEED path, where the adoption is left in
+   * flight on purpose so the caller can open its ready gate (and so the
+   * /ws/userevents connect and first render) without waiting out a write of one
+   * row per entity. It resolves null when the adoption did NOT commit: the
+   * state and frames are still usable in memory, so the tab still presents a
+   * cursor and RESUMEs, but the recorder must then be given no base at all. An
+   * incremental rewrite over chunks that are not there writes a header plus a
+   * handful of shards and nothing underneath, which the next cold start
+   * hydrates as a state silently missing almost every record -- with the resume
+   * cursor riding on it. That is the one outcome hydrate's corruption policy
+   * exists to make impossible, reached from the write side.
+   *
+   * NESTED rather than a `basePersisted` boolean beside a flat
+   * `nextOpLogOrdinal`: the two are one fact, and split apart the type could
+   * express "no base on disk, but resume the log at ordinal 7" -- a producer
+   * that cleared the flag and forgot to zero the ordinal. `frames` stays
+   * top-level because it is consumed unconditionally (the in-memory replay
+   * happens whether or not anything was persisted).
+   */
+  persistedBase: PersistedBase | null | Promise<PersistedBase | null>
+}
+
+/** Where the recorder must continue the persisted op-log sequence. */
+export interface PersistedBase {
+  /**
    * Ordinal the next appended op-log segment must carry, so the recorder can
    * continue the persisted sequence instead of restarting at 0 behind segments
    * that already hold 0..N-1 — which the next cold start would read as a hole
@@ -105,7 +143,15 @@ function tryApplyChunk(state: UserCrdtState, kind: ChunkKind, entityId: string, 
 }
 
 /**
- * Wipe this owner's persisted pair and report a cold start.
+ * Wipe this owner's persisted pair.
+ *
+ * It reports NOTHING about what to do next. It used to return `Promise<null>`
+ * and be named `wipeAndFail`, because a wipe WAS the cold-start decision at all
+ * eight call sites that returned its result directly. It no longer is: the sole
+ * caller now falls through to the sibling seed, and a name that still advertises
+ * the old control flow invites the next failure arm to write
+ * `return wipeAndFail(...)` and silently reinstate the unconditional cold start
+ * the seed path exists to remove.
  *
  * OWNER-scoped, not user-scoped, and that is the whole point. Every failure
  * this module detects — an unreadable row, an undecodable blob, a foreign
@@ -118,7 +164,7 @@ function tryApplyChunk(state: UserCrdtState, kind: ChunkKind, entityId: string, 
  * `clearCheckpointAndOpLog` (user-wide) stays for logout / user switch, where
  * spanning every tab is the intent.
  */
-async function wipeAndFail(userId: string, clientId: string): Promise<null> {
+async function wipeOwnCheckpoint(userId: string, clientId: string): Promise<void> {
   // A wipe that did not happen leaves the poison record in place, so the next
   // reload reads it, fails identically, and pays a full projection snapshot --
   // forever, and silently. The wipe is still best-effort (there is nothing
@@ -126,48 +172,100 @@ async function wipeAndFail(userId: string, clientId: string): Promise<null> {
   // own header, and an unobservable failure makes that claim unfalsifiable.
   if (!await clearOwnerCheckpointAndOpLog(userId, clientId))
     log.warn('could not wipe the corrupt checkpoint; the next reload will re-read it', { clientId })
-  return null
 }
 
 /**
- * Load and validate the persisted checkpoint + op-log for `userId`. Returns
- * null when there is nothing usable to hydrate from:
- *   - the store is unavailable (no indexedDB),
- *   - no checkpoint exists,
+ * Load and validate the persisted checkpoint + op-log for `userId`.
+ *
+ * It tries THIS OWNER first, and falls through to a SIBLING owner when this one
+ * has nothing usable -- either because there is no row at all (a genuinely new
+ * tab, the first tab after a browser restart, a re-minted duplicate), or
+ * because this owner's row failed validation:
  *   - the checkpoint header blob fails to deserialize,
  *   - the header names a different tenant,
  *   - the watermark/epoch is missing or out of range,
  *   - an entity chunk names an unknown kind or fails to deserialize.
  *
- * Each of those wipes THIS OWNER's pair (see wipeAndFail) so the next reload
- * isn't poisoned by the same corrupt record, and returns null — routing the
- * caller to the full-snapshot cold-start path.
+ * Each of THOSE wipes THIS OWNER's pair (see wipeOwnCheckpoint) so the next
+ * reload isn't poisoned by the same corrupt record. The wipe and the seed are separate
+ * decisions: the wipe is about our own bad row, the seed about finding a good
+ * one. See seedFromSibling, which never deletes a row it does not own.
+ *
+ * Returns null -- routing the caller to the full-snapshot cold-start path --
+ * only when the store is unavailable, the ids are empty, or no sibling
+ * qualifies either.
  *
  * An undecodable OP-LOG frame is NOT fatal: the returned payload carries the
  * decodable prefix with `truncated: true`, and the caller rewrites the
  * checkpoint to drop the bad tail.
  */
-export async function loadHydrationState(userId: string, clientId: string): Promise<HydrationPayload | null> {
+export async function loadHydrationState(
+  userId: string,
+  clientId: string,
+  opts: HydrationOptions = {},
+): Promise<HydrationPayload | null> {
   if (!isCheckpointStoreAvailable() || !userId || !clientId)
     return null
 
   const read = await readCheckpoint(userId, clientId)
   if (read.status === 'miss')
+    return seedFromSibling(userId, clientId, opts)
+  const payload = validateCheckpoint(userId, read)
+  if (payload)
+    return payload
+  // Our own record is unusable. Wipe it so the next reload is not poisoned by
+  // the same corruption, then try a sibling: recovering from OUR OWN bad
+  // checkpoint is one more case the seed path covers, and it is strictly better
+  // than the full projection snapshot this used to mean.
+  //
+  // Checked HERE too, not only before the seed's adoption: the wipe is the
+  // OTHER write on this path, and the more destructive one. A run that lost the
+  // caller's deadline has already cold-started, bootstrapped, and had its
+  // recorder write a fresh checkpoint under this same owner key with
+  // `base = 'ready'` -- so a late wipe deletes those rows while the recorder
+  // goes on rewriting INCREMENTALLY against chunks that are no longer there,
+  // landing a header plus a handful of shards over nothing. That is this
+  // module's own "partial is the one outcome that must stay impossible",
+  // reached from the write side.
+  if (opts.superseded?.())
     return null
-  if (read.status === 'failed') {
-    // Distinct from a miss on purpose. A checkpoint row that EXISTS but cannot
-    // be read (a structured-clone failure on the stored bytes, a corrupt key
-    // entry) would otherwise survive every reload: each one pays the failed
-    // read, cold-starts, and re-fails identically. Wiping is what makes the
-    // policy in this module's header self-healing rather than a loop.
-    return wipeAndFail(userId, clientId)
-  }
+  await wipeOwnCheckpoint(userId, clientId)
+  return seedFromSibling(userId, clientId, opts)
+}
+
+/**
+ * Validate an already-read checkpoint into a HydrationPayload, or null when the
+ * pair is unusable.
+ *
+ * PURE and side-effect-free: it decides only WHETHER the pair is usable, never
+ * what to do about it. The recovery differs by owner and so cannot live here --
+ * wiping is correct for YOUR OWN row and catastrophic for a sibling's, whose
+ * recorder believes its chunks are on disk and rewrites INCREMENTALLY against
+ * them. Being pure also means one definition of the policy serves both entry
+ * points, which is the whole reason the seed path can be trusted to reject
+ * exactly what the self path rejects.
+ *
+ * Nullable rather than a three-arm 'miss' | 'corrupt' | 'ok' union: no caller
+ * ever distinguished the first two. loadHydrationState has already returned on
+ * a miss before it gets here, and the seed skips the candidate either way -- so
+ * the discriminant was an arm every reader had to check was handled and then
+ * find was not.
+ */
+function validateCheckpoint(userId: string, read: CheckpointRead): HydrationPayload | null {
+  // A 'failed' read is NOT the same as a miss to the CALLER, which wipes on the
+  // former: a checkpoint row that EXISTS but cannot be read (a structured-clone
+  // failure on the stored bytes, a corrupt key entry) would otherwise survive
+  // every reload, each one paying the failed read, cold-starting, and re-failing
+  // identically. Wiping is what makes the policy in this module's header
+  // self-healing rather than a loop. Both are simply "unusable" HERE.
+  if (read.status !== 'ok')
+    return null
   const { checkpoint, chunks, opLogFrames, opLogTruncated } = read
 
   // (1) The checkpoint header blob must deserialize into a UserCrdtState.
   const state = tryFromBinary(parseHeader, checkpoint.headerBytes)
   if (!state) {
-    return wipeAndFail(userId, clientId)
+    return null
   }
 
   // (1b) The blob must name THIS tenant. UserCrdtState carries its own user_id,
@@ -188,7 +286,7 @@ export async function loadHydrationState(userId: string, clientId: string): Prom
   // bootstrap copies `materialized.userId`, and a checkpoint is only ever
   // written once a watermark exists, which requires one of those two.
   if (state.userId !== userId) {
-    return wipeAndFail(userId, clientId)
+    return null
   }
 
   // (2) The watermark and epoch must be present and in-range. An out-of-range
@@ -197,7 +295,7 @@ export async function loadHydrationState(userId: string, clientId: string): Prom
   // record left in the store would re-fail every reload, so wipe it.
   const wm = checkpoint.watermark
   if (!wm || typeof wm.physical !== 'bigint' || typeof wm.logical !== 'bigint' || typeof wm.clientId !== 'string') {
-    return wipeAndFail(userId, clientId)
+    return null
   }
   // RANGE, not just type -- the comment above says "in-range" and the epoch two
   // lines down enforces it, but the watermark used to be type-checked only. An
@@ -207,11 +305,11 @@ export async function loadHydrationState(userId: string, clientId: string): Prom
   // bootstrap (which overwrites the watermark and rewrites the pair), but a
   // wipe here turns one silent degraded connect into zero.
   if (!inInt64Range(wm.physical) || !inInt64Range(wm.logical)) {
-    return wipeAndFail(userId, clientId)
+    return null
   }
   const epoch = checkpoint.currentEpoch
   if (typeof epoch !== 'bigint' || !inInt64Range(epoch)) {
-    return wipeAndFail(userId, clientId)
+    return null
   }
 
   // (2b) Re-assemble the entity maps from the chunks. EVERY chunk must land:
@@ -222,10 +320,10 @@ export async function loadHydrationState(userId: string, clientId: string): Prom
   // all, so it takes the same wipe-and-cold-start arm as a bad header.
   for (const chunk of chunks) {
     if (!isChunkKind(chunk.kind))
-      return wipeAndFail(userId, clientId)
+      return null
     const applied = tryApplyChunk(state, chunk.kind, chunk.entityId, chunk.bytes)
     if (!applied)
-      return wipeAndFail(userId, clientId)
+      return null
   }
 
   // (3) Replay the op-log as far as it decodes. A bad frame invalidates only
@@ -258,5 +356,174 @@ export async function loadHydrationState(userId: string, clientId: string): Prom
     frames.push(frame)
   }
 
-  return { state, frames, watermark: wm, currentEpoch: epoch, truncated, nextOpLogOrdinal: read.opLogNextOrdinal }
+  return {
+    state,
+    frames,
+    watermark: wm,
+    currentEpoch: epoch,
+    truncated,
+    // Present by definition on this path: the caller read these bytes back OUT
+    // of this owner's own rows, so they are on disk under this owner's key.
+    // The seed path overrides it.
+    persistedBase: { nextOpLogOrdinal: read.opLogNextOrdinal },
+  }
+}
+
+/** Options for `loadHydrationState`; every one is a test seam or a guard. */
+export interface HydrationOptions {
+  /**
+   * True once this hydration run has been SUPERSEDED -- its effect re-ran, its
+   * owner was disposed, or the caller's deadline elapsed.
+   *
+   * Checked immediately before the seed's adoption, which is the only WRITE on
+   * this path. useCrdtRuntime races the read against a deadline and, on losing,
+   * cold-starts WITHOUT cancelling the promise behind it -- harmless while this
+   * was a pure read, and fatal the moment it is not. The sequence to prevent:
+   * deadline fires, the tab cold-starts, bootstrap() rewrites the checkpoint,
+   * the recorder begins appending ordinals 0,1,2..., and only THEN the seed's
+   * adoption lands -- replacing the fresh checkpoint with the sibling's older
+   * header and the log with one segment at ordinal 0. Disk then holds a hole
+   * whose replayed batchEnd frames advance the resume cursor straight past it,
+   * and the hub ships only what is strictly after the cursor. Silent, permanent
+   * divergence.
+   */
+  superseded?: () => boolean
+  /**
+   * Test seam: how many candidates to try before giving up.
+   *
+   * Named to match `SeedCandidateOptions.limit`, which it is forwarded to
+   * verbatim one call later -- one knob should not have two names a single hop
+   * apart. (A sibling `now`/`maxAgeMs` pair was declared here too and deleted:
+   * nothing ever set `now`, and `maxAgeMs` was never forwarded at all, so the
+   * age cutoff was unreachable through this entry point. `listSeedCandidates`
+   * takes both directly and is tested through them.)
+   */
+  limit?: number
+}
+
+/**
+ * Seed this tab from a SIBLING tab's persisted checkpoint.
+ *
+ * Checkpoints are per-(user, client) because of a WRITE clobber (see
+ * checkpointStore's header); a READER has no such hazard, so a tab with nothing
+ * usable of its own -- a genuinely new tab, the first tab after a browser
+ * restart, a duplicate whose id was re-minted, or one whose own checkpoint just
+ * failed validation -- may adopt a sibling's base and RESUME instead of paying a
+ * full projection snapshot.
+ *
+ * IT NEVER DELETES ANYTHING. A corrupt candidate is SKIPPED, not wiped, even
+ * one that looks abandoned. Wiping a LIVE sibling is catastrophic in a way the
+ * self path is not: that tab's recorder believes its chunks are on disk and
+ * rewrites INCREMENTALLY against them, so removing them leaves it writing a
+ * header plus a few shards over nothing -- the "partial is the one outcome that
+ * must stay impossible" hazard in this module's header, inflicted on a tab
+ * whose own records were fine. And "abandoned" is not provable here:
+ * OWNER_LIVENESS_WINDOW_MS is a heuristic a frozen or bfcached page fails.
+ * sweepAbandonedCheckpoints already owns reclamation, and one destructive
+ * policy over rows we do not own is enough.
+ */
+async function seedFromSibling(
+  userId: string,
+  clientId: string,
+  opts: HydrationOptions,
+): Promise<HydrationPayload | null> {
+  const candidates = await listSeedCandidates(userId, clientId, { limit: opts.limit })
+  for (const candidate of candidates) {
+    const read = await readCheckpoint(userId, candidate.clientId)
+    // Narrow ONCE, here, so everything below reads the candidate's bytes off a
+    // `read` the type system has already proven to be present.
+    //
+    // The alternative -- re-testing `read.status === 'ok'` at each use with a
+    // fallback -- looked defensive and was the opposite: the fallbacks
+    // (`new Uint8Array()`, `[]`) are unreachable today, and the only behaviour
+    // they COULD ever produce is adopting an empty header with zero chunks
+    // under our own key, which adoptCheckpoint's full-replace write would make
+    // durable. That is precisely "a state silently missing almost every record,
+    // with the resume cursor riding on it" -- the one outcome this module's
+    // header calls impossible.
+    if (read.status !== 'ok')
+      continue
+    const payload = validateCheckpoint(userId, read)
+    if (!payload)
+      continue
+    // Checked HERE, and again inside adoptCheckpoint immediately before its
+    // transaction is created.
+    //
+    // One check would be sufficient IF the adopt transaction were always
+    // CREATED in this same task -- everything that could supersede us
+    // (withTimeout's deadline, Solid's cleanup) runs in a LATER one, and
+    // IndexedDB starts overlapping-scope readwrite transactions in creation
+    // order, so an adoption created here always commits before any write the
+    // resulting cold start issues, and that cold start's full rewrite lands on
+    // top of it rather than interleaving with it.
+    //
+    // But adoptCheckpoint's `await openDb()` is a no-op microtask only while
+    // the cached connection is live. A peer tab's schema-repair
+    // `deleteDatabase()` nulls it (idb.ts's `onversionchange` handler), and the
+    // reopen that follows is a whole task -- which is exactly long enough for
+    // the ordering argument to lapse. So the guard is re-consulted at the point
+    // the transaction is actually created, where it needs no ordering argument
+    // at all.
+    if (opts.superseded?.()) {
+      // Write NOTHING, and tell the caller its recorder has no base on disk.
+      //
+      // The payload is still returned rather than null because it is correct in
+      // memory and costs nothing to hand back. No CURRENT caller observes it --
+      // withTimeout has already resolved null on the deadline path, and
+      // hydrateAndInstall returns at its `cancelled` guard on the other -- so
+      // this is the contract, not a live behaviour: whoever does consume it gets
+      // a usable state with no base, which is exactly what a failed adoption
+      // reports below.
+      return { ...payload, persistedBase: null }
+    }
+    // NOT awaited. The adoption is one IDB `put` per entity, and nothing the
+    // caller does next needs it: the state and frames above are already in
+    // memory, so the ready gate -- and with it the /ws/userevents connect, the
+    // resume cursor and the first render -- can open while this write is still
+    // committing. Only the RECORDER needs the result, and it holds its appends
+    // and rewrites until this settles (see CheckpointRecorderOptions).
+    //
+    // Copy the VALIDATED PREFIX, not everything the read returned.
+    //
+    // `payload.frames` is where validateCheckpoint stopped -- it decodes one raw
+    // frame per entry, in order, and breaks on the first failure -- so
+    // `read.opLogFrames` beyond that length is either undecodable or past the
+    // store's own read ceiling. Copying it would make this owner's row a second
+    // durable copy of the source's corruption, and the one-shot repair the
+    // caller asks for (`rewriteNow` on `truncated`) is issued while the recorder
+    // is still holding for this very adoption.
+    //
+    // Taking the prefix instead makes the adopted pair self-consistent by
+    // construction: the frames on disk are exactly the frames that produced the
+    // watermark in the header beside them, so `opLogCount` matches the row and
+    // the read ceiling is armed against the true length.
+    const adoptedFrames = read.opLogFrames.slice(0, payload.frames.length)
+    // The ordinal comes back FROM the adoption rather than being re-derived
+    // here: it is a fact about the segment layout adoptCheckpoint chose, and a
+    // producer and a consumer that disagree by one mint exactly the hole the
+    // per-owner sequence exists to detect. Nesting it under the base is what
+    // removes the second `adopted &&` guard this expression used to need -- an
+    // ordinal cannot outlive the base it counts.
+    const persistedBase = adoptCheckpoint(
+      userId,
+      clientId,
+      {
+        headerBytes: read.checkpoint.headerBytes,
+        chunks: read.chunks,
+        watermark: payload.watermark,
+        currentEpoch: payload.currentEpoch,
+        opLogFrames: adoptedFrames,
+      },
+      undefined,
+      opts.superseded,
+    ).then((nextOpLogOrdinal) => {
+      log.info('seeded this tab from a sibling checkpoint', {
+        from: candidate.clientId,
+        adopted: nextOpLogOrdinal !== null,
+      })
+      return nextOpLogOrdinal === null ? null : { nextOpLogOrdinal }
+    })
+    return { ...payload, persistedBase }
+  }
+  return null
 }

--- a/frontend/src/lib/crdt/pendingOps.test.ts
+++ b/frontend/src/lib/crdt/pendingOps.test.ts
@@ -781,7 +781,7 @@ describe('pendingOpsManager', () => {
         watermark: create(HLCSchema, { physical: 100n, logical: 0n, clientId: 'hub' }),
         currentEpoch: 5n,
         truncated: false,
-        nextOpLogOrdinal: 0,
+        persistedBase: { nextOpLogOrdinal: 0 },
       }
     }
 
@@ -1315,7 +1315,7 @@ describe('pendingOpsManager', () => {
 
 // Client-side tombstone GC. Delta-resume removed the only one the client ever
 // had: applyOp installs a tombstone SHELL rather than deleting, and
-// materializedLocked omits tombstoned records, so every full-snapshot bootstrap
+// materializedFromState omits tombstoned records, so every full-snapshot bootstrap
 // used to reset confirmedState to a tombstone-free base. A client that keeps
 // resuming never bootstraps, so from that point every closed tab, tile and
 // window stayed in confirmedState -- and in the serialized checkpoint blob --
@@ -1478,7 +1478,7 @@ describe('batch-end boundary', () => {
       watermark: { physical: 1n, logical: 0n, clientId: 'hub' },
       currentEpoch: 1n,
       truncated: false,
-      nextOpLogOrdinal: 0,
+      persistedBase: { nextOpLogOrdinal: 0 },
     })
 
     expect(live.state.resumeWatermark?.physical).toBe(42n)
@@ -1499,7 +1499,7 @@ describe('batch-end boundary', () => {
       watermark: { physical: 7n, logical: 0n, clientId: 'hub' },
       currentEpoch: 1n,
       truncated: false,
-      nextOpLogOrdinal: 0,
+      persistedBase: { nextOpLogOrdinal: 0 },
     })
 
     // A frame naming no boundary must not move the cursor: advancing on one

--- a/frontend/src/lib/crdt/pendingOps.ts
+++ b/frontend/src/lib/crdt/pendingOps.ts
@@ -187,7 +187,7 @@ export function isStatePopulated(state: {
  * The client mirror of the hub's `PruneTombstonesAtOrBelow`, and it exists
  * because delta-resume removed the only GC the client ever had. `applyOp`
  * installs a tombstone SHELL rather than deleting (so a late op cannot resurrect
- * the record), and `materializedLocked` omits tombstoned records — so every
+ * the record), and `materializedFromState` omits tombstoned records — so every
  * full-snapshot bootstrap used to reset `confirmedState` to a tombstone-free
  * base. A client that keeps resuming never bootstraps, so from that point on
  * every tab, tile and window it ever closed stayed in `confirmedState` forever,

--- a/frontend/tests/e2e/162-new-tab-seeds-from-sibling.spec.ts
+++ b/frontend/tests/e2e/162-new-tab-seeds-from-sibling.spec.ts
@@ -1,0 +1,142 @@
+import type { Page } from '@playwright/test'
+import { expect, test } from './fixtures'
+import { createWorkspaceViaAPI, deleteWorkspaceViaAPI } from './helpers/api'
+import { gotoWorkspace, openWorkspace } from './helpers/ui'
+
+/**
+ * A new tab resumes from a sibling tab's persisted checkpoint (issue #358).
+ *
+ * ONE browser context, TWO pages, and that is the whole point: IndexedDB is
+ * per-ORIGIN, so both tabs see the same checkpoint store, while sessionStorage
+ * is per-TAB, so the second tab mints a fresh CRDT client id and finds no
+ * checkpoint under it. Before this change that meant no resume cursor and a
+ * full `UserMaterialized` snapshot on every new tab; now it seeds from the
+ * sibling and RESUMEs.
+ *
+ * Two separate contexts -- which 150-crdt-convergence and 151-active-client-ding
+ * use -- have separate IndexedDB and could never exercise this.
+ *
+ * What is asserted is that the new tab PRESENTS A CURSOR (`resume_after_hlc` on
+ * its `/ws/userevents` URL). Whether the hub then honours it is
+ * `SubscribeWithACL`'s decision and is covered by hub tests; the contract this
+ * change owns is the client half.
+ */
+
+/** Collect every `/ws/userevents` URL this page opens, from now on. */
+function userEventsUrls(page: Page): string[] {
+  const urls: string[] = []
+  page.on('websocket', (ws) => {
+    if (ws.url().includes('/ws/userevents'))
+      urls.push(ws.url())
+  })
+  return urls
+}
+
+/**
+ * Wait until this origin's checkpoint store holds at least `n` owner rows.
+ *
+ * The write is asynchronous and off the interaction path, so a tab can be fully
+ * interactive before its checkpoint lands. Polling the store beats a sleep: it
+ * waits for the actual precondition (a sibling row exists to seed FROM) rather
+ * than for a guess at how long that takes.
+ */
+async function waitForCheckpointOwners(page: Page, n: number): Promise<void> {
+  await expect.poll(async () => page.evaluate(async () => {
+    return await new Promise<number>((resolve) => {
+      const open = indexedDB.open('leapmux-crdt-state')
+      open.onerror = () => resolve(-1)
+      open.onsuccess = () => {
+        const db = open.result
+        if (!db.objectStoreNames.contains('checkpoints')) {
+          db.close()
+          resolve(-1)
+          return
+        }
+        const req = db.transaction('checkpoints', 'readonly').objectStore('checkpoints').count()
+        req.onerror = () => {
+          db.close()
+          resolve(-1)
+        }
+        req.onsuccess = () => {
+          db.close()
+          resolve(req.result)
+        }
+      }
+    })
+  })).toBeGreaterThanOrEqual(n)
+}
+
+test.describe('new-tab checkpoint seeding', () => {
+  test('a second tab in the same profile resumes from its sibling\'s checkpoint', async ({ browser, leapmuxServer }) => {
+    const { hubUrl, adminToken } = leapmuxServer
+    const wsId = await createWorkspaceViaAPI(hubUrl, adminToken, 'New Tab Seeding')
+
+    const context = await browser.newContext({ baseURL: hubUrl })
+    const pageA = await context.newPage()
+
+    try {
+      await gotoWorkspace(pageA, adminToken, wsId)
+      await expect(pageA.locator('[data-testid="tile"]')).toHaveCount(1)
+      // A mutation, so the CRDT holds something a seeded tab can be seen to
+      // have received rather than rebuilt.
+      await pageA.locator('[data-testid="split-horizontal"]').first().click()
+      await expect(pageA.locator('[data-testid="tile"]')).toHaveCount(2)
+
+      // Tab A's checkpoint must exist before tab B can seed from it.
+      await waitForCheckpointOwners(pageA, 1)
+
+      // Tab B: same context (shared IndexedDB), fresh sessionStorage.
+      const pageB = await context.newPage()
+      const urlsB = userEventsUrls(pageB)
+      await openWorkspace(pageB, wsId)
+      await expect(pageB.locator('[data-testid="tile"]')).toHaveCount(2)
+
+      await expect.poll(() => urlsB.at(0) ?? '').toContain('resume_after_hlc=')
+
+      // TWO owner rows, not one: B copied the checkpoint under its OWN client
+      // id rather than adopting A's key, which is what keeps one writer per
+      // owner and leaves A's own persistence untouched.
+      await waitForCheckpointOwners(pageB, 2)
+
+      // And A is unharmed -- it still converges with B afterwards.
+      await pageB.locator('[data-testid="split-vertical"]').nth(1).click()
+      await expect(pageB.locator('[data-testid="tile"]')).toHaveCount(3)
+      await expect(pageA.locator('[data-testid="tile"]')).toHaveCount(3)
+    }
+    finally {
+      await context.close()
+      await deleteWorkspaceViaAPI(hubUrl, adminToken, wsId)
+    }
+  })
+
+  test('a tab opened after its sibling closed still seeds from the dead row', async ({ browser, leapmuxServer }) => {
+    // The browser-restart case: sessionStorage died with the tab, but the
+    // checkpoint rows survive in IndexedDB. The issue's trigger table listed
+    // this separately from "new tab"; one mechanism covers both.
+    const { hubUrl, adminToken } = leapmuxServer
+    const wsId = await createWorkspaceViaAPI(hubUrl, adminToken, 'Dead Sibling Seeding')
+
+    const context = await browser.newContext({ baseURL: hubUrl })
+    const pageA = await context.newPage()
+
+    try {
+      await gotoWorkspace(pageA, adminToken, wsId)
+      await expect(pageA.locator('[data-testid="tile"]')).toHaveCount(1)
+      await pageA.locator('[data-testid="split-horizontal"]').first().click()
+      await expect(pageA.locator('[data-testid="tile"]')).toHaveCount(2)
+      await waitForCheckpointOwners(pageA, 1)
+      await pageA.close()
+
+      const pageC = await context.newPage()
+      const urlsC = userEventsUrls(pageC)
+      await openWorkspace(pageC, wsId)
+      await expect(pageC.locator('[data-testid="tile"]')).toHaveCount(2)
+
+      await expect.poll(() => urlsC.at(0) ?? '').toContain('resume_after_hlc=')
+    }
+    finally {
+      await context.close()
+      await deleteWorkspaceViaAPI(hubUrl, adminToken, wsId)
+    }
+  })
+})


### PR DESCRIPTION
Closes #358.

## Motivation

A `/ws/userevents` connect that cannot RESUME builds a full `UserMaterialized` — an O(all the user's entities) walk plus a `proto.Clone` per record — and it did so holding **both** `m.projection` (the lock every broadcast takes) and `m.mu.RLock` (which blocks `commitState`). `commitState` runs on the manager goroutine, so a single cold connect stalled that user's entire commit and broadcast pipeline for its duration: **6.2 ms** on a 2400-node / 4800-tab account.

Delta-resume (#267) removed that cost from reconnects and refreshes. Two places were left paying it:

1. **Opening a new tab.** The IndexedDB checkpoint is keyed `(userId, clientId)` and the client id lives in `sessionStorage`, so a genuinely new tab found no checkpoint, sent no cursor, and cold-started.
2. **The fallback itself**, which no client-side change can reach — a first-ever visit, a client dormant past the retention floor, an over-budget tail, a corrupt journal row, IndexedDB unavailable.

Issue #358 proposed only (1), and explicitly rejected (2) as a bad risk trade. This does both. The issue underweighted that the walk is also under `m.mu.RLock` — the lock that actually blocks commits — so removing only `m.projection` would have bought almost nothing. (The issue also says "the `byWrittenAt` index already exists"; it does not. This uses the existing `byLastSeenAt`, which is the better selector anyway: it is the liveness heartbeat, whereas a live tab's checkpoint watermark is pinned at its last rewrite while its op-log runs on ahead.)

## Modifications

### Client — a new tab seeds from a sibling

The write clobber that forces the per-tab key is a hazard for **writers** only, so a tab with nothing usable of its own now picks the freshest sibling owner and **adopts** it by copying the already-serialized bytes under its own id.

- **Copy, not re-serialize.** Rebuilding would run one main-thread `toBinary` per entity (56.7 ms at 2400/4800) for the same number of IDB puts.
- **Only the validated prefix** of the source log is copied, so a sibling whose log stops decoding part-way cannot become a second durable copy of that corruption.
- **Never deletes a row it does not own.** A corrupt candidate is skipped, not wiped — a sibling's recorder rewrites incrementally against chunks it believes are on disk, and "abandoned" is not provable from a liveness heuristic a frozen page fails.
- **The op-log is renumbered from 0, and the adoption reports that ordinal** rather than leaving the caller to re-derive its segment layout.
- **Left in flight, not awaited**, so the ready gate — and with it the connect, the resume cursor and the first render — does not wait out one IDB put per entity. The recorder therefore takes its base as a promise and **holds** appends and rewrites until it settles, deferring (not dropping) a rewrite requested during the hold.
- Both writes on the hydration path are guarded against supersession, with the adoption's guard consulted immediately before its transaction is created rather than resting on a transaction-ordering argument that a peer tab's schema repair can invalidate.

This covers more than the new tab it was written for: the first tab after a browser restart, a duplicate whose client id was re-minted, and recovery from this tab's own corrupt checkpoint.

### Server — the fallback baseline holds no manager lock

- **Published state generations are now immutable.** Compaction publishes the pruned generation it built, the epoch bump publishes an O(1) copy-on-write header, and `SeedStateForTest` publishes a clone. An in-place prune deletes map entries, and `CloneStateForBatch` shares untouched maps across generations, so it reached back into every older generation a reader might be walking.
- `materializedFromState` is a free function over a captured generation and holds nothing. **One register window** serves both arms — register, capture the generation, set `resumeSuppressThrough` from that generation's `max_hlc` — so "the suppress gate, the baseline, and the resume scan's high-water are one point in time" is one field rather than a coincidence of two independent reads.
- Because the subscriber is registered before the walk, live frames park during it. A park-buffer overflow retries at a newer generation and, after a bounded number of attempts, builds under `m.projection`, where no broadcast can interleave — so the ladder cannot loop.
- **A park overflow during the bootstrap write now drops the connection** rather than flushing over the hole. `liveCatchUpSink` discards the send error, so the alternative was a tab silently missing that span for its whole session.
- Compaction copies the four entity **maps** and shares the records instead of deep-cloning the account: a prune adds and removes entries and writes no record field, so the deep clone was ~60k message allocations per tick on the manager goroutine to delete a handful of tombstones.
- `completenessCheck` now rejects a live node left under a **tombstoned parent** — unreachable from every root, collected by nothing. The sibling race on tabs was already caught, so both now share one recovery: the batch is rejected and the outbox row retried.
- The hub refuses a resume cursor presented with `workspace_ids`. That cursor is per-user and now cross-tab, so one minted under a narrower filter cannot be replayed under a wider one — an invariant that was the property of one client out of three until it moved server-side.

### Observability

`SubscribeOutcome` carries a `Reason`, so a fallback's cause is distinguishable (`no_cursor`, `below_retention_floor`, `stale_epoch`, `tail_over_budget`, `delta_over_frame_ceiling`, `corrupt_row`, `post_scan_drift`, `park_overflow`). Every give-up arm names its cause through a constructor that requires one. New series `leapmux_userevents_subscribe_total{mode,reason}` and `leapmux_userevents_subscribe_duration_seconds{mode}`, labelled from the service layer and counted on **every authenticated connect** — including the ones that fail before a bootstrap arm is selected, since a hub whose state read starts failing returns before the subscribe and would otherwise take the series quiet exactly when an operator reaches for it.

The metric vocabulary lives on `Label()`, not `String()`: `String()` is what `%v` and slog reach for implicitly, so while the label values rode on it, a cosmetic edit to how a reason *prints* would have silently renamed every dashboard label.

## Result

Measured on 400 nodes / 600 tabs and 2400 / 4800 (`task bench-backend`):

| Metric | 400×600 | 2400×4800 |
|---|---|---|
| Worst commit latency during a cold connect | 1.92 ms → **0.33 ms** | 6.24 ms → **0.97 ms** |
| Commits landed during that window | 67 → **1811** | 67 → **1811** |
| Baseline build itself | — | 1.79 ms → 1.77 ms |

The pipeline is no longer serialized behind the connect at all. The baseline build is unchanged, which is the expected result — the walk was moved, not made cheaper. A resume costs 1.5 µs against that 1.77 ms.

No wire change: the bootstrap stays exactly one frame, `SubscribeOutcome` keeps its two-arm union, and `Bootstrap()` is untouched. Verified zero-change consumers: `ws_userevents.go`, `desktop/go/userevents_relay.go`, `remoteipc.HubEventStreamer`, `backend/internal/cli/remote/cmd/events.go`, and the frontend's `dispatchEvent`/`applyDelta`.

### Behavior changes worth flagging

- `/ws/userevents` now returns **400** for `workspace_ids` + `resume_after_hlc` together. No in-tree caller sends that pairing — `remoteipc`'s hub stream and the remote CLI both pass their workspace ids with a nil cursor.
- `completenessCheck` rejects a live node whose `parent_id` names a tombstoned or absent node. The full suite passes unchanged, so no legal batch shape relies on it.
- `TickHousekeeping` now routes through the manager goroutine and must not be called *from* it.

### Testing

`task lint` · `task test-backend` (8635) · new `task test-backend-race` (962, CRDT + hub service under the detector — nothing ran `-race` before, which left the test that exists to fail when an in-place prune returns proving nothing) · `task test-frontend` (7855) · E2E `162-new-tab-seeds-from-sibling` and `150-crdt-convergence`.

Also fixed a pre-existing timing fragility the new `-race` target exposed: `TestOpenChannel_ClosesWhenCredentialExpires` gave its credential 50 ms and then required a full `OpenChannel` round trip to finish inside it, so under the detector it failed at its *first* assertion — reporting a broken expiry path for what was really a stopwatch.