### PR TITLE
fix(solo): Stop misattributing Hub startup failures to the Worker

### DIFF
--- a/backend/cmd/leapmux/solo.go
+++ b/backend/cmd/leapmux/solo.go
@@ -8,7 +8,6 @@ import (
 	"os/signal"
 	"syscall"
 
-	hubconfig "github.com/leapmux/leapmux/internal/hub/config"
 	"github.com/leapmux/leapmux/solo"
 	"github.com/leapmux/leapmux/util/version"
 )
@@ -21,48 +20,20 @@ func runSolo(args []string, soloMode bool) error {
 		}
 	}
 
-	modeName := "solo"
-	defaultListen := "127.0.0.1:4327"
-	if !soloMode {
-		modeName = "dev"
-		defaultListen = ":4327"
-	}
-	configDir := "~/.config/leapmux/" + modeName
-	configFile := configDir + "/" + modeName + ".yaml"
-
-	cliFlags := []string{
-		"listen", "data-dir", "dev-frontend",
-		"storage-sqlite-max-conns",
-		"api-timeout-seconds", "agent-startup-timeout-seconds", "worktree-create-timeout-seconds",
-		"log-level", "use-login-shell",
-	}
-	if !soloMode {
-		cliFlags = append(cliFlags, "public-url")
-	}
-	// Worker-scoped knobs for the embedded worker; see solo.defaultExtraFlags for
-	// why max-incomplete-chunked is an extra rather than a hub flag. These mirror
-	// solo.defaultExtraFlags (the desktop-oriented default) so a `leapmux solo`/
-	// `leapmux dev` invocation exposes the same worker knobs the desktop launcher
-	// does -- without this, --use-login-shell=false is parsed by neither list and
-	// is silently dropped on the floor (the worker keeps wrapping claude in the
-	// login shell against the explicit flag).
-	extraFlags := []hubconfig.ExtraFlagDef{
-		{Name: "encryption-mode", KoanfKey: "encryption_mode", Usage: "encryption mode (classic, post-quantum)", StrDefault: "post-quantum"},
-		{Name: "use-login-shell", KoanfKey: "use_login_shell", Usage: "wrap claude invocation in user's login shell", StrDefault: "true"},
-		{Name: "max-incomplete-chunked", KoanfKey: "max_incomplete_chunked", Usage: "maximum in-flight chunked sequences per channel for the embedded worker (default 4)", StrDefault: "0", Category: "Timeout and limit options"},
-	}
-
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
+	// Everything but Args and DevMode is left unset, so solo.Start derives it from
+	// DevMode: the listen address, the config dir and file, the CLI flag allowlist
+	// and the worker-scoped extra flags. This file used to spell all of it out, and
+	// the flag lists DRIFTED -- defaultCLIFlags gained max-connections-per-user,
+	// max-workers-per-user and the two sqlite sizing knobs, the copy here did not,
+	// and `leapmux solo --max-connections-per-user=64` answered "flag provided but
+	// not defined" while solo's own test asserted the flag was exposed. One source
+	// of truth, in the package whose comments explain why each default is what it is.
 	inst, err := solo.Start(ctx, solo.Config{
-		Listen:     defaultListen,
-		ConfigDir:  configDir,
-		ConfigFile: configFile,
-		Args:       args,
-		CLIFlags:   cliFlags,
-		ExtraFlags: extraFlags,
-		DevMode:    !soloMode,
+		Args:    args,
+		DevMode: !soloMode,
 	})
 	if err != nil {
 		return err

--- a/backend/hub/server.go
+++ b/backend/hub/server.go
@@ -674,8 +674,22 @@ func (s *Server) Serve(ctx context.Context) error {
 		watcherCloseCtx, cancelWatcherClose := context.WithTimeout(context.Background(), 10*time.Second)
 		watcherCloseErr := s.revocationWatcher.Close(watcherCloseCtx)
 		cancelWatcherClose()
+		// A cancel landing here is an exit somebody ASKED for, not a failure to
+		// report. NewServer binds BOTH listeners before Serve runs, so a caller's
+		// connect-and-close readiness probe succeeds -- and its Stop can arrive --
+		// while this seed is still in flight. Reporting it made `leapmux hub` and
+		// `leapmux solo` exit NON-ZERO on an ordinary Ctrl-C during startup,
+		// printing "seed revocation watcher: ... context canceled" -- or, when the
+		// store aborted first, modernc sqlite's "interrupted (9)", which wraps no
+		// context error and so slips through every errors.Is(err, context.Canceled)
+		// filter downstream. The teardown below still runs, and a genuine failure
+		// in it is still reported.
+		primary := fmt.Errorf("seed revocation watcher: %w", err)
+		if serveCtx.Err() != nil {
+			primary = nil
+		}
 		return serverTeardownErrors{
-			primary:       fmt.Errorf("seed revocation watcher: %w", err),
+			primary:       primary,
 			tcpListener:   closeServerListener(tcpLn),
 			localListener: closeServerListener(localLn),
 			httpClose:     s.server.Close(),

--- a/backend/solo/solo.go
+++ b/backend/solo/solo.go
@@ -60,6 +60,28 @@ var workerDrainTimeout = 5 * time.Second
 // were passing on a NewServer failure instead.
 var serveHub = func(ctx context.Context, s *hub.Server) error { return s.Serve(ctx) }
 
+// bringUpWorker brings the local Worker up. A var so a test can park bring-up
+// mid-flight and kill the Hub underneath it.
+//
+// It has to be a seam for the same reason serveHub does: nothing reaches the case
+// from outside. Every real way to fail bring-up -- no admin user yet, an
+// unreadable state file, a store error -- fails AT ONCE, at the first statement
+// that touches the database or the disk, so no fixture can hold Start inside the
+// bring-up window long enough for the Hub to die there. Without this, the gate
+// that keeps a dead Hub from being blamed on the Worker, and the one that stops
+// Start returning a healthy Instance for a Hub that already exited, both had no
+// coverage at all.
+//
+// A package var rather than an Instance field because Start constructs the
+// Instance itself: at the point a test would have to inject, there is nothing to
+// inject into.
+//
+// bringUpLocalWorker stays directly callable, and
+// TestSolo_AHubThatDiesWhileServingTearsTheInstanceDownWithoutReporting and
+// TestSolo_AStopRequestedHubErrorIsReportedOnlyByStop drive Start through the
+// real implementation, so the seam cannot drift away from what production does.
+var bringUpWorker = bringUpLocalWorker
+
 // nonLoopbackListenWarnMsg is the security warning emitted when solo mode
 // binds to a non-loopback address. Solo mode injects a soloUser into the
 // auth interceptor (see hub.NewServer and auth.NewInterceptor), so every
@@ -235,8 +257,55 @@ func (i *Instance) join() {
 	}
 }
 
+// hubFailure reports the startup error to attribute to a Hub that has already
+// exited, or nil if it was still serving when asked. stage names the startup
+// window, for the case where the Hub exited without an error of its own.
+//
+// It exists because "has the Hub already exited?" has to be asked at the STAGE
+// BOUNDARIES of startup, not inside the arms of a select or a switch: hub.NewServer
+// binds both listeners before Serve is ever called, so a bare connect-and-close
+// readiness probe succeeds against a Hub whose Serve has already returned an error,
+// and every arm that asked the question separately answered it differently.
+//
+// It is TOTAL once hubDone is closed: it never returns nil for an exited Hub. The
+// readiness select relies on that, so its hubDone arm can decide only to stop
+// waiting and carry no error of its own.
+//
+// Reading hubErr after observing hubDone needs no further synchronisation: the Hub
+// goroutine assigns it before closing hubDone. A nil hubDone reads as "still
+// serving", which keeps this usable on a half-built Instance for the same reason
+// shutdown and join are.
+//
+// This is a SAMPLE, not a guarantee: a Hub that exits a moment later still yields a
+// healthy Instance, which is Wait's job to report. It closes the wide windows, not
+// every window.
+func (i *Instance) hubFailure(ctx context.Context, stage string) error {
+	select {
+	case <-i.hubDone:
+	default:
+		return nil
+	}
+	// hubErr first, deliberately: a genuine teardown failure (lease release, store
+	// close) that coincides with a cancel is more information than context.Canceled,
+	// and %w keeps errors.Is(err, context.Canceled) working for a caller that wants
+	// to tell the two apart.
+	if i.hubErr != nil {
+		return fmt.Errorf("hub serve: %w", i.hubErr)
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("hub shut down %s: %w", stage, err)
+	}
+	return fmt.Errorf("hub serve exited %s", stage)
+}
+
 // Start launches a Hub and Worker in-process. It returns an Instance that
 // can stop the services and report their terminal cleanup error.
+//
+// A nil error means the Hub had not exited by the time Start returned -- not that
+// it is still alive. Nothing can promise the latter: the Hub can fail one
+// instruction after the return. Once Start has succeeded, Wait and Stop are the
+// reporters of a Hub that dies; see the watcher goroutine below for why they are
+// the only ones.
 func Start(ctx context.Context, cfg Config) (*Instance, error) {
 	logging.Setup()
 
@@ -386,34 +455,47 @@ func Start(ctx context.Context, cfg Config) (*Instance, error) {
 		inst.shutdown()
 	}()
 
-	// Wait for Hub's local listener (unix socket or named pipe). Race
-	// against inst.hubDone so that if Serve returns before the listener
-	// is ready, we surface the underlying Serve error (e.g. "bind:
-	// invalid argument") instead of the generic "not ready" timeout.
+	// Wait for Hub's local listener (unix socket or named pipe). The hubDone arm
+	// is what keeps a Hub that failed instantly from paying out WaitReady's whole
+	// 5s budget: hub.NewServer has already bound both listeners, so the probe
+	// CONNECTS to a Hub whose Serve has returned and the wait would otherwise
+	// succeed on a corpse.
+	//
+	// The select is a pure wait -- the same division waitSolo draws: both arms
+	// choose WHEN to stop, never WHAT to report. That matters because both can be
+	// ready at once for exactly the reason above, and Go picks between ready arms
+	// arbitrarily; putting the verdict AFTER the select is what makes the pick
+	// irrelevant. readyCh is buffered so the abandoned probe, which only cancelHub
+	// inside join unblocks, cannot leak on its send.
+	//
+	// The verdict is hubFailure alone, with no "unless hubErr is context.Canceled"
+	// carve-out. That guard dated from when hubCtx was a child of ctx and a parent
+	// cancel hit Serve instantly; hubCtx is detached now, so hubErr can only be
+	// context.Canceled in a microsecond window -- and when the guard did fire it
+	// returned a nil Instance, making hubErr permanently unreachable and discarding
+	// any non-ctx cause joined into it.
 	readyCh := make(chan error, 1)
 	go func() { readyCh <- locallisten.WaitReady(hubCtx, listenURL) }()
+	var readyErr error
 	select {
-	case err := <-readyCh:
-		if err != nil {
-			inst.join()
-			if inst.hubErr != nil && !errors.Is(inst.hubErr, context.Canceled) {
-				return nil, fmt.Errorf("hub serve: %w", inst.hubErr)
-			}
-			return nil, fmt.Errorf("wait for hub local listener: %w", err)
-		}
+	case readyErr = <-readyCh:
 	case <-inst.hubDone:
+		// No error of its own: hubFailure is total once hubDone is closed.
+	}
+	if hubErr := inst.hubFailure(ctx, "before the listener became ready"); hubErr != nil {
 		inst.join()
-		if inst.hubErr != nil {
-			return nil, fmt.Errorf("hub serve: %w", inst.hubErr)
-		}
-		return nil, errors.New("hub serve exited before listener became ready")
+		return nil, hubErr
+	}
+	if readyErr != nil {
+		inst.join()
+		return nil, fmt.Errorf("wait for hub local listener: %w", readyErr)
 	}
 
 	// In dev mode the first admin may not exist yet; defer worker bringup
 	// until /setup completes.
 	statePath := filepath.Join(workerDataDir, "state.json")
 	setupWorker := func(ctx context.Context) error {
-		return bringUpLocalWorker(ctx, &inst.workerWork, &inst.workerDrained, server, statePath, workerDataDir, hubCfg, listenURL, modeName)
+		return bringUpWorker(ctx, &inst.workerWork, &inst.workerDrained, server, statePath, workerDataDir, hubCfg, listenURL, modeName)
 	}
 	// Hold a Worker-side token ACROSS bring-up. Without it a caller cancelling
 	// during setup lets the watcher's shutdown sample an idle counter, cancel
@@ -425,6 +507,35 @@ func Start(ctx context.Context, cfg Config) (*Instance, error) {
 	inst.workerWork.Add()
 	inst.workerDrained.Add()
 	err = setupWorker(workerCtx)
+
+	// One spelling of "give the bring-up tokens back and tear the half-built
+	// instance down", for the same reason join is one spelling of the wait set.
+	// The Done()s have to precede join, or join's workerWork.DoneChan() never
+	// closes and the teardown parks forever on tokens only this frame holds.
+	failBringUp := func(cause error) (*Instance, error) {
+		inst.workerDrained.Done()
+		inst.workerWork.Done()
+		inst.join()
+		return nil, cause
+	}
+
+	// Bring-up is the only slow statement between the readiness verdict and the
+	// return: SQLite, state-file I/O, and on a first launch ML-KEM + SLH-DSA
+	// keygen. So it is the window in which a Serve failure most plausibly lands,
+	// and the one place a Hub that died would otherwise be reported as the
+	// Worker's fault -- the watcher cancels workerCtx, so bring-up comes back
+	// saying "context canceled" -- or, when bring-up happened to succeed anyway,
+	// not reported at all.
+	//
+	// Before the switch, so it covers all three arms, the dev-mode deferral
+	// included: a poller must not be launched against a Hub that is already gone.
+	// What remains after it is a go statement, two counter releases and a log
+	// line -- no wait -- so a Hub dying past this point is indistinguishable from
+	// one dying an instruction after Start returns, which Wait and Stop report.
+	if hubErr := inst.hubFailure(ctx, "while the worker was starting"); hubErr != nil {
+		return failBringUp(hubErr)
+	}
+
 	switch {
 	case err == nil:
 		// Worker is up.
@@ -438,10 +549,7 @@ func Start(ctx context.Context, cfg Config) (*Instance, error) {
 		inst.workerDrained.Add()
 		go pollForDeferredWorkerSetup(workerCtx, &inst.workerWork, &inst.workerDrained, setupWorker)
 	default:
-		inst.workerDrained.Done()
-		inst.workerWork.Done()
-		inst.join()
-		return nil, fmt.Errorf("auto-register worker: %w", err)
+		return failBringUp(fmt.Errorf("auto-register worker: %w", err))
 	}
 	inst.workerDrained.Done()
 	inst.workerWork.Done()

--- a/backend/solo/solo.go
+++ b/backend/solo/solo.go
@@ -32,7 +32,12 @@ import (
 // workerSetupPollInterval is how often dev mode re-checks whether the first
 // admin user has completed the /setup flow so the auto-registered local
 // worker can come online.
-const workerSetupPollInterval = 2 * time.Second
+//
+// A var so tests can shorten it, matching workerDrainTimeout below: at 2s a test
+// that needs the poller to be mid-setup when a teardown lands would have to sleep
+// through a tick, and the alternative to shortening it is the timing dependency
+// this package deliberately avoids.
+var workerSetupPollInterval = 2 * time.Second
 
 // workerDrainTimeout bounds how long the ordered shutdown waits for the Worker
 // to finish draining before it stops holding the Hub open for it. See
@@ -74,12 +79,16 @@ var serveHub = func(ctx context.Context, s *hub.Server) error { return s.Serve(c
 //
 // A package var rather than an Instance field because Start constructs the
 // Instance itself: at the point a test would have to inject, there is nothing to
-// inject into.
+// inject into. Config is not the place either -- it is exported API, and a test
+// seam does not belong in the surface a caller configures.
 //
-// bringUpLocalWorker stays directly callable, and
+// bringUpLocalWorker stays directly callable, which is what keeps the seam honest:
 // TestSolo_AHubThatDiesWhileServingTearsTheInstanceDownWithoutReporting and
-// TestSolo_AStopRequestedHubErrorIsReportedOnlyByStop drive Start through the
-// real implementation, so the seam cannot drift away from what production does.
+// TestSolo_AStopRequestedHubErrorIsReportedOnlyByStop drive Start straight through
+// the real implementation, and
+// TestSoloStart_TearsDownARealWorkerLaunchedJustBeforeTheHubDied wraps it rather
+// than replacing it, so the token accounting under the gate is exercised against
+// the Worker goroutine production actually launches.
 var bringUpWorker = bringUpLocalWorker
 
 // nonLoopbackListenWarnMsg is the security warning emitted when solo mode
@@ -148,11 +157,18 @@ type Instance struct {
 	// spawned waiter that leaks when the wait is abandoned -- the leak the
 	// sidecar already retired under issue #297.
 	workerWork drain.Counter
-	// workerDrained reports the narrower thing the HUB actually has to outlive:
-	// the goodbye broadcast and the outbound flush, announced by worker.Run's
-	// Drained hook before its local teardown. Waiting on workerWork instead
-	// would hold the Hub up for a database close it has no stake in, and report
-	// a slow one as a worker that "did not finish draining".
+	// workerDrained reports the worker-side work the HUB has to outlive. For a
+	// RUNNING Worker that is the narrow thing -- the goodbye broadcast and the
+	// outbound flush, announced by worker.Run's Drained hook before its local
+	// teardown. Waiting on workerWork instead would hold the Hub up for a database
+	// close it has no stake in, and report a slow one as a worker that failed to
+	// drain.
+	//
+	// Start and the dev-mode poller hold a token here too, for the window in which
+	// no Worker exists YET: bring-up can still Add (drain.Counter's
+	// no-add-after-sample contract), so cancelHub must not run until that window
+	// closes. The backstop warning therefore names bring-up as well as the drain --
+	// it can fire with no Worker goroutine in existence.
 	workerDrained drain.Counter
 	listenURL     string
 	hubErr        error         // set before hubDone is closed
@@ -172,9 +188,13 @@ func (i *Instance) LocalListenURL() string {
 	return i.listenURL
 }
 
-// Wait blocks until the Hub exits (either via Stop or because it failed
-// on its own) and returns its terminal error. Returns nil on clean
-// shutdown or http.ErrServerClosed. Safe to call multiple times.
+// Wait blocks until the Hub exits (either via Stop or because it failed on its
+// own) and returns its terminal error, verbatim. Safe to call multiple times.
+//
+// It filters nothing itself. A clean shutdown reports nil because Serve's
+// recordListenerResult drops http.ErrServerClosed before it can become hubErr --
+// so the nil arrives from the Hub, not from here. waitSolo re-filters it
+// belt-and-braces; a new caller should not assume this method does.
 func (i *Instance) Wait() error {
 	<-i.hubDone
 	return i.hubErr
@@ -209,7 +229,7 @@ func (i *Instance) shutdown() {
 		// frame is away. Stop still joins the full exit afterwards, unbounded;
 		// see its doc for why the database close is not optional.
 		i.workerDrained.Wait(workerDrainTimeout,
-			"worker did not report draining before the hub shutdown deadline; stopping the hub anyway")
+			"worker bring-up or drain did not finish before the hub shutdown deadline; stopping the hub anyway")
 		if i.cancelHub != nil {
 			i.cancelHub()
 		}
@@ -257,19 +277,29 @@ func (i *Instance) join() {
 	}
 }
 
-// hubFailure reports the startup error to attribute to a Hub that has already
-// exited, or nil if it was still serving when asked. stage names the startup
-// window, for the case where the Hub exited without an error of its own.
+// startupFailure reports the error to attribute to a startup that is already
+// over, or nil if it was still on its way up when asked. stage names the startup
+// window, for the cases where nothing carries an error of its own.
 //
-// It exists because "has the Hub already exited?" has to be asked at the STAGE
-// BOUNDARIES of startup, not inside the arms of a select or a switch: hub.NewServer
-// binds both listeners before Serve is ever called, so a bare connect-and-close
+// It exists because "is this startup still going?" has to be asked at the STAGE
+// BOUNDARIES, not inside the arms of a select or a switch: hub.NewServer binds
+// both listeners before Serve is ever called, so a bare connect-and-close
 // readiness probe succeeds against a Hub whose Serve has already returned an error,
 // and every arm that asked the question separately answered it differently.
 //
-// It is TOTAL once hubDone is closed: it never returns nil for an exited Hub. The
-// readiness select relies on that, so its hubDone arm can decide only to stop
-// waiting and carry no error of its own.
+// It covers BOTH of the watcher's triggers, because both reach the caller the same
+// way -- through a workerCtx the watcher has already cancelled, which makes the
+// Worker report "context canceled" for something that is not its fault:
+//
+//   - The Hub exited. hubDone is closed, and hubErr is the cause.
+//   - The CALLER cancelled. hubDone is still OPEN -- shutdown() cancels the Worker
+//     and then parks in workerDrained.Wait, held by the token Start carries across
+//     bring-up, so cancelHub has not run yet -- and ctx is the cause. Asking only
+//     about hubDone here left this half blaming the Worker.
+//
+// It is TOTAL once either has happened: it never returns nil for a startup that is
+// over. The readiness select relies on that, so its hubDone arm can decide only to
+// stop waiting and carry no error of its own.
 //
 // Reading hubErr after observing hubDone needs no further synchronisation: the Hub
 // goroutine assigns it before closing hubDone. A nil hubDone reads as "still
@@ -278,44 +308,89 @@ func (i *Instance) join() {
 //
 // This is a SAMPLE, not a guarantee: a Hub that exits a moment later still yields a
 // healthy Instance, which is Wait's job to report. It closes the wide windows, not
-// every window.
-func (i *Instance) hubFailure(ctx context.Context, stage string) error {
+// every window. It must NOT be asked after join(), which closes hubDone itself --
+// there it would report every healthy Hub as exited.
+func (i *Instance) startupFailure(ctx context.Context, stage string) error {
 	select {
 	case <-i.hubDone:
+		// hubErr first, deliberately: a genuine teardown failure (lease release,
+		// store close) that coincides with a cancel is more information than
+		// context.Canceled, and %w keeps errors.Is(err, context.Canceled) working
+		// for a caller that wants to tell the two apart.
+		if i.hubErr != nil {
+			return fmt.Errorf("hub serve exited %s: %w", stage, i.hubErr)
+		}
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("hub shut down %s: %w", stage, err)
+		}
+		return fmt.Errorf("hub serve exited %s", stage)
 	default:
-		return nil
-	}
-	// hubErr first, deliberately: a genuine teardown failure (lease release, store
-	// close) that coincides with a cancel is more information than context.Canceled,
-	// and %w keeps errors.Is(err, context.Canceled) working for a caller that wants
-	// to tell the two apart.
-	if i.hubErr != nil {
-		return fmt.Errorf("hub serve: %w", i.hubErr)
 	}
 	if err := ctx.Err(); err != nil {
-		return fmt.Errorf("hub shut down %s: %w", stage, err)
+		return fmt.Errorf("solo startup cancelled %s: %w", stage, err)
 	}
-	return fmt.Errorf("hub serve exited %s", stage)
+	return nil
+}
+
+// failStartup tears a half-built instance down and returns the error Start should
+// report: cause, plus the Hub's terminal error when the teardown produced one.
+//
+// The join is what makes the second half necessary. It cancels the Hub, so the
+// error Serve returns lands AFTER cause was decided -- and because Start returns a
+// nil Instance on every path through here, Wait and Stop can never be called and
+// the watcher deliberately logs nothing, so this is that error's only reporter. A
+// runtime lease left believed-held, or a store that failed to close, would
+// otherwise vanish silently. Instance.Stop's doc promises exactly this error to
+// the caller that got an Instance; a caller that did not get one is owed it too.
+//
+// It joins rather than asks startupFailure again: post-join hubDone is ALWAYS
+// closed, so the predicate's "the Hub exited" fallback would fire for a Hub that
+// was perfectly healthy until the join stopped it, and outrank a genuine Worker
+// failure. Only a non-nil hubErr means anything here.
+//
+// A cancellation inside hubErr is discarded for the same reason. The join is what
+// cancelled hubCtx, so a Serve still working through its own startup returns the
+// cancel we just issued -- today, "seed revocation watcher: ... context canceled",
+// because hub.NewServer binds the listeners before Serve seeds the revocation
+// cursor. Joining that into a Worker's bring-up failure would blame the Hub for
+// obeying us. What survives the filter is a genuine cleanup failure.
+func (i *Instance) failStartup(cause error) error {
+	i.join()
+	if i.hubErr == nil || errors.Is(i.hubErr, context.Canceled) {
+		return cause
+	}
+	if errors.Is(cause, i.hubErr) {
+		// cause already IS the Hub's error -- startupFailure read it before the
+		// join. Joining it again would print the same failure twice.
+		return cause
+	}
+	return errors.Join(cause, fmt.Errorf("hub serve: %w", i.hubErr))
 }
 
 // Start launches a Hub and Worker in-process. It returns an Instance that
 // can stop the services and report their terminal cleanup error.
 //
-// A nil error means the Hub had not exited by the time Start returned -- not that
-// it is still alive. Nothing can promise the latter: the Hub can fail one
-// instruction after the return. Once Start has succeeded, Wait and Stop are the
-// reporters of a Hub that dies; see the watcher goroutine below for why they are
-// the only ones.
-func Start(ctx context.Context, cfg Config) (*Instance, error) {
-	logging.Setup()
-
+// A nil error means the startup was still on its way up when Start returned --
+// not that the Hub is still alive. Nothing can promise the latter: the Hub can
+// fail one instruction after the return. Once Start has succeeded, Wait and Stop
+// are the reporters of a Hub that dies; see the watcher goroutine below for why
+// they are the only ones.
+// soloLoadOptions derives the hub-config load options for a solo or dev launch:
+// the mode name, the listen/config-dir/config-file defaults, and the two flag
+// lists. Everything here is a pure function of Config -- no logging, no banner, no
+// filesystem -- which is what lets it be table-tested without binding a listener.
+//
+// It is the SINGLE source of truth for those defaults. `leapmux solo` used to
+// spell its own copies, and the flag lists drifted until
+// `--max-connections-per-user` stopped parsing while solo's own test asserted it
+// was exposed.
+func soloLoadOptions(cfg Config) (hubconfig.LoadOptions, string) {
 	modeName := "solo"
 	description := "Run Hub + Worker locally for single-user use."
 	if cfg.DevMode {
 		modeName = "dev"
 		description = "Run Hub + Worker together for development."
 	}
-	flagSetName := "leapmux " + modeName
 
 	defaultListen := cfg.Listen
 	if defaultListen == "" {
@@ -344,16 +419,26 @@ func Start(ctx context.Context, cfg Config) (*Instance, error) {
 		extraFlags = defaultExtraFlags()
 	}
 
-	hubCfg, _, err := hubconfig.LoadWithOptions(cfg.Args, hubconfig.LoadOptions{
+	return hubconfig.LoadOptions{
 		DefaultListen:     defaultListen,
 		DefaultConfigDir:  configDir,
 		DefaultConfigFile: configFile,
-		FlagSetName:       flagSetName,
+		FlagSetName:       "leapmux " + modeName,
 		Description:       description,
 		CLIFlags:          cliFlags,
 		ExtraFlags:        extraFlags,
 		SoloMode:          !cfg.DevMode,
-	})
+	}, modeName
+}
+
+func Start(ctx context.Context, cfg Config) (*Instance, error) {
+	logging.Setup()
+
+	// The side effects below stay HERE, in this order: the banner is printed
+	// before the data dir is created, and the log level is applied before either.
+	// Only the pure derivation moved out.
+	opts, modeName := soloLoadOptions(cfg)
+	hubCfg, _, err := hubconfig.LoadWithOptions(cfg.Args, opts)
 	if err != nil {
 		return nil, fmt.Errorf("load hub config: %w", err)
 	}
@@ -465,37 +550,47 @@ func Start(ctx context.Context, cfg Config) (*Instance, error) {
 	// choose WHEN to stop, never WHAT to report. That matters because both can be
 	// ready at once for exactly the reason above, and Go picks between ready arms
 	// arbitrarily; putting the verdict AFTER the select is what makes the pick
-	// irrelevant. readyCh is buffered so the abandoned probe, which only cancelHub
-	// inside join unblocks, cannot leak on its send.
+	// irrelevant. readyCh is buffered so the abandoned probe cannot leak on its
+	// send, whichever way it ends: usually at once and on its own, because the
+	// listeners are bound and the dial succeeds for the reason above; otherwise
+	// when cancelHub inside join reaches it, or when WaitReady's own 5s budget
+	// expires.
 	//
-	// The verdict is hubFailure alone, with no "unless hubErr is context.Canceled"
-	// carve-out. That guard dated from when hubCtx was a child of ctx and a parent
-	// cancel hit Serve instantly; hubCtx is detached now, so hubErr can only be
-	// context.Canceled in a microsecond window -- and when the guard did fire it
-	// returned a nil Instance, making hubErr permanently unreachable and discarding
-	// any non-ctx cause joined into it.
+	// The verdict is startupFailure alone, with no "unless hubErr is
+	// context.Canceled" carve-out. That guard dated from when hubCtx was a child of
+	// ctx and a parent cancel hit Serve instantly; hubCtx is detached now, so hubErr
+	// can only be context.Canceled in a microsecond window -- and when the guard did
+	// fire it returned a nil Instance, making hubErr permanently unreachable and
+	// discarding any non-ctx cause joined into it.
 	readyCh := make(chan error, 1)
 	go func() { readyCh <- locallisten.WaitReady(hubCtx, listenURL) }()
 	var readyErr error
 	select {
 	case readyErr = <-readyCh:
 	case <-inst.hubDone:
-		// No error of its own: hubFailure is total once hubDone is closed.
+		// No error of its own: startupFailure is total once hubDone is closed.
 	}
-	if hubErr := inst.hubFailure(ctx, "before the listener became ready"); hubErr != nil {
-		inst.join()
-		return nil, hubErr
+	if startErr := inst.startupFailure(ctx, "before the listener became ready"); startErr != nil {
+		return nil, inst.failStartup(startErr)
 	}
 	if readyErr != nil {
-		inst.join()
-		return nil, fmt.Errorf("wait for hub local listener: %w", readyErr)
+		return nil, inst.failStartup(fmt.Errorf("wait for hub local listener: %w", readyErr))
 	}
 
 	// In dev mode the first admin may not exist yet; defer worker bringup
 	// until /setup completes.
 	statePath := filepath.Join(workerDataDir, "state.json")
 	setupWorker := func(ctx context.Context) error {
-		return bringUpWorker(ctx, &inst.workerWork, &inst.workerDrained, server, statePath, workerDataDir, hubCfg, listenURL, modeName)
+		return bringUpWorker(ctx, workerBringUp{
+			work:          &inst.workerWork,
+			drained:       &inst.workerDrained,
+			server:        server,
+			statePath:     statePath,
+			workerDataDir: workerDataDir,
+			hubCfg:        hubCfg,
+			listenURL:     listenURL,
+			modeName:      modeName,
+		})
 	}
 	// Hold a Worker-side token ACROSS bring-up. Without it a caller cancelling
 	// during setup lets the watcher's shutdown sample an idle counter, cancel
@@ -506,40 +601,57 @@ func Start(ctx context.Context, cfg Config) (*Instance, error) {
 	// drain.Counter's no-add-after-sample contract holds by construction.
 	inst.workerWork.Add()
 	inst.workerDrained.Add()
+
+	// One release, reached from every exit. The deferred call covers any future
+	// return added inside this window; the explicit calls before failStartup are
+	// what the failure paths need, because join waits on workerWork and would park
+	// forever on tokens only this frame holds. sync.Once makes the pair idempotent,
+	// so the two spellings cannot double-release and panic the counter -- the same
+	// guard bringUpLocalWorker already uses for its own drain token.
+	var releaseOnce sync.Once
+	releaseBringUp := func() {
+		releaseOnce.Do(func() {
+			inst.workerDrained.Done()
+			inst.workerWork.Done()
+		})
+	}
+	defer releaseBringUp()
+
 	err = setupWorker(workerCtx)
 
-	// One spelling of "give the bring-up tokens back and tear the half-built
-	// instance down", for the same reason join is one spelling of the wait set.
-	// The Done()s have to precede join, or join's workerWork.DoneChan() never
-	// closes and the teardown parks forever on tokens only this frame holds.
-	failBringUp := func(cause error) (*Instance, error) {
-		inst.workerDrained.Done()
-		inst.workerWork.Done()
-		inst.join()
-		return nil, cause
-	}
-
-	// Bring-up is the only slow statement between the readiness verdict and the
-	// return: SQLite, state-file I/O, and on a first launch ML-KEM + SLH-DSA
-	// keygen. So it is the window in which a Serve failure most plausibly lands,
-	// and the one place a Hub that died would otherwise be reported as the
-	// Worker's fault -- the watcher cancels workerCtx, so bring-up comes back
-	// saying "context canceled" -- or, when bring-up happened to succeed anyway,
-	// not reported at all.
+	// Bring-up is the only statement in this window with real work in it -- it
+	// reads and rewrites the state file, registers a worker (a DB write) and, on a
+	// first launch, generates an ML-KEM + SLH-DSA keypair, some ten milliseconds
+	// against microseconds for everything around it. So it is the window in which
+	// a teardown most plausibly lands, and the one place a startup that was already
+	// over would otherwise be reported as the Worker's fault: whichever trigger
+	// fired, the watcher cancels workerCtx, so bring-up comes back saying "context
+	// canceled" for something that is not its doing -- or, when bring-up happened
+	// to succeed anyway, the launch went unreported entirely.
 	//
 	// Before the switch, so it covers all three arms, the dev-mode deferral
-	// included: a poller must not be launched against a Hub that is already gone.
-	// What remains after it is a go statement, two counter releases and a log
-	// line -- no wait -- so a Hub dying past this point is indistinguishable from
-	// one dying an instruction after Start returns, which Wait and Stop report.
-	if hubErr := inst.hubFailure(ctx, "while the worker was starting"); hubErr != nil {
-		return failBringUp(hubErr)
+	// included: a poller must not be launched against a startup that is over.
+	// What remains after it is a go statement, a counter release and a log line --
+	// no wait -- so a Hub dying past this point is indistinguishable from one dying
+	// an instruction after Start returns, which Wait and Stop report.
+	if startErr := inst.startupFailure(ctx, "while the worker was starting"); startErr != nil {
+		releaseBringUp()
+		// A worker failure in the same window is usually the teardown's own echo --
+		// the watcher cancelled workerCtx, so bring-up says "context canceled" -- and
+		// reporting that is the misattribution this gate exists to stop. But an
+		// INDEPENDENT failure (a locked database, an unreadable state file) is a
+		// second fact the operator needs: dropping it sends them back for a relaunch
+		// that hits the same wall with nothing in the logs from the first attempt.
+		if err != nil && !errors.Is(err, context.Canceled) {
+			startErr = errors.Join(startErr, fmt.Errorf("worker bring-up: %w", err))
+		}
+		return nil, inst.failStartup(startErr)
 	}
 
 	switch {
 	case err == nil:
 		// Worker is up.
-	case errors.Is(err, store.ErrNotFound) && cfg.DevMode:
+	case errors.Is(err, errNoAdminYet) && cfg.DevMode:
 		slog.Info("dev mode: deferring worker auto-registration until first admin signs up via /setup")
 		// Counted with the Worker, not the Hub: it is the thing that brings the
 		// Worker up, so the ordered shutdown has to wait it out before it can
@@ -549,10 +661,10 @@ func Start(ctx context.Context, cfg Config) (*Instance, error) {
 		inst.workerDrained.Add()
 		go pollForDeferredWorkerSetup(workerCtx, &inst.workerWork, &inst.workerDrained, setupWorker)
 	default:
-		return failBringUp(fmt.Errorf("auto-register worker: %w", err))
+		releaseBringUp()
+		return nil, inst.failStartup(fmt.Errorf("auto-register worker: %w", err))
 	}
-	inst.workerDrained.Done()
-	inst.workerWork.Done()
+	releaseBringUp()
 
 	slog.Info("leapmux "+modeName+" listening", "listen", hubCfg.Listen)
 
@@ -572,8 +684,16 @@ type soloState struct {
 	SlhdsaPrivateKey string `json:"slhdsa_private_key,omitempty"`
 }
 
+// errNoAdminYet means no admin user exists yet, so the local worker has nobody to
+// register under until somebody completes the /setup flow. It is the ONLY
+// condition dev mode defers on, and it is a distinct sentinel rather than a bare
+// store.ErrNotFound because that error reaches bring-up from several lookups --
+// deferring on any of them would turn a real registration failure into a launch
+// that reports success and polls forever.
+var errNoAdminYet = errors.New("no admin user yet")
+
 // pollForDeferredWorkerSetup retries setupWorker on a ticker until it succeeds,
-// the context is cancelled, or a non-ErrNotFound error occurs. Must be invoked
+// the context is cancelled, or a non-errNoAdminYet error occurs. Must be invoked
 // as `go pollForDeferredWorkerSetup(...)` with work.Add() and drained.Add()
 // already called — this function releases both on exit.
 func pollForDeferredWorkerSetup(ctx context.Context, work, drained *drain.Counter, setupWorker func(context.Context) error) {
@@ -594,28 +714,48 @@ func pollForDeferredWorkerSetup(ctx context.Context, work, drained *drain.Counte
 		if err == nil {
 			return
 		}
-		if errors.Is(err, store.ErrNotFound) {
+		if errors.Is(err, errNoAdminYet) {
 			continue
+		}
+		if ctx.Err() != nil {
+			// The teardown cancelled us mid-setup, so this error is the shutdown
+			// wearing the Worker's wrapper -- the same misattribution Start's stage
+			// gates exist to retire, at the one place they cannot reach. Logging it
+			// would also make this a SECOND reporter of a shutdown Stop already
+			// reports, which is exactly what the watcher stays silent to avoid.
+			return
 		}
 		slog.Error("deferred worker setup failed", "error", err)
 		return
 	}
 }
 
+// workerBringUp is the production wiring bringUpLocalWorker needs.
+//
+// A struct rather than nine positional parameters because two adjacent pairs
+// shared a type -- statePath/workerDataDir and listenURL/modeName -- so a
+// transposition compiled silently and wrote the state file into the data dir, or
+// logged the listen URL as the mode name. Named fields make that a compile error,
+// and the seam var, the call site and the test stubs stop restating a signature
+// they can each get wrong independently.
+type workerBringUp struct {
+	work, drained *drain.Counter
+	server        *hub.Server
+	statePath     string
+	workerDataDir string
+	hubCfg        *hubconfig.Config
+	listenURL     string
+	modeName      string
+}
+
 // bringUpLocalWorker loads (or creates, then persists) the local worker's
-// registration state, ensures the composite E2EE keypair is present, and
-// launches the worker goroutine under wg. It returns store.ErrNotFound if no
-// admin user exists yet; the caller is expected to retry after the first
-// /setup signup completes.
-func bringUpLocalWorker(
-	ctx context.Context,
-	work, drained *drain.Counter,
-	server *hub.Server,
-	statePath, workerDataDir string,
-	hubCfg *hubconfig.Config,
-	listenURL, modeName string,
-) error {
-	state, err := loadOrCreateWorkerState(ctx, server, statePath, workerDataDir)
+// registration state, ensures the composite E2EE keypair is present, and launches
+// the worker goroutine under work/drained. It returns errNoAdminYet if no admin
+// user exists yet; the caller is expected to retry after the first /setup signup
+// completes. Callers must key on THAT sentinel, not on the store.ErrNotFound
+// underneath it, which also reaches here from lookups that are real failures.
+func bringUpLocalWorker(ctx context.Context, p workerBringUp) error {
+	state, err := loadOrCreateWorkerState(ctx, p.server, p.statePath, p.workerDataDir)
 	if err != nil {
 		return err
 	}
@@ -636,54 +776,68 @@ func bringUpLocalWorker(
 		state.MlkemPrivateKey = base64.StdEncoding.EncodeToString(ck.MlkemDecapsulationKey.Bytes())
 		state.SlhdsaPublicKey = base64.StdEncoding.EncodeToString(slhdsaPub)
 		state.SlhdsaPrivateKey = base64.StdEncoding.EncodeToString(slhdsaPriv)
-		if err := persistState(statePath, state); err != nil {
+		if err := persistState(p.statePath, state); err != nil {
 			slog.Warn("failed to save keypair", "error", err)
 		}
 	}
 
+	keyFields := []struct {
+		name  string
+		value string
+	}{
+		{"public_key", state.PublicKey},
+		{"private_key", state.PrivateKey},
+		{"mlkem_private_key", state.MlkemPrivateKey},
+		{"slhdsa_public_key", state.SlhdsaPublicKey},
+		{"slhdsa_private_key", state.SlhdsaPrivateKey},
+	}
+	decoded := make([][]byte, len(keyFields))
+	for i, f := range keyFields {
+		b, err := decode64(f.name, f.value)
+		if err != nil {
+			return fmt.Errorf("read saved worker keypair from %s: %w", p.statePath, err)
+		}
+		decoded[i] = b
+	}
 	compositeKey, ckErr := noiseutil.RestoreCompositeKeypair(
-		mustDecode64(state.PublicKey),
-		mustDecode64(state.PrivateKey),
-		mustDecode64(state.MlkemPrivateKey),
-		mustDecode64(state.SlhdsaPublicKey),
-		mustDecode64(state.SlhdsaPrivateKey),
+		decoded[0], decoded[1], decoded[2], decoded[3], decoded[4],
 	)
 	if ckErr != nil {
 		return fmt.Errorf("restore composite keypair: %w", ckErr)
 	}
 
-	slog.Info(modeName+" worker registered",
+	slog.Info(p.modeName+" worker registered",
 		"worker_id", state.WorkerID,
-		"local", listenURL,
+		"local", p.listenURL,
 	)
 
-	work.Add()
-	drained.Add()
+	p.work.Add()
+	p.drained.Add()
 	// Guarded so the drain signal is released exactly once whether the Worker
 	// reports draining or dies before it ever gets there -- an unreleased token
 	// would make every shutdown pay the full backstop.
 	var drainedOnce sync.Once
-	releaseDrained := func() { drainedOnce.Do(drained.Done) }
+	releaseDrained := func() { drainedOnce.Do(p.drained.Done) }
 	go func() {
-		defer work.Done()
+		defer p.work.Done()
 		defer releaseDrained()
 		if wErr := worker.Run(ctx, worker.RunConfig{
 			Drained:      releaseDrained,
-			HubURL:       listenURL,
-			DataDir:      workerDataDir,
+			HubURL:       p.listenURL,
+			DataDir:      p.workerDataDir,
 			AuthToken:    state.AuthToken,
 			CompositeKey: compositeKey,
 			WorkerID:     state.WorkerID,
-			DBMaxConns:   hubCfg.Storage.SQLite.MaxConns,
-			DBCacheSize:  hubCfg.Storage.SQLite.CacheSize,
-			DBMmapSize:   hubCfg.Storage.SQLite.MmapSize,
+			DBMaxConns:   p.hubCfg.Storage.SQLite.MaxConns,
+			DBCacheSize:  p.hubCfg.Storage.SQLite.CacheSize,
+			DBMmapSize:   p.hubCfg.Storage.SQLite.MmapSize,
 			// 0 (the default) lets the worker apply channelwire.DefaultMaxIncompleteChunked.
-			MaxIncompleteChunked: parseInt(hubCfg.Extras["max_incomplete_chunked"], 0),
-			MaxMessageSize:       hubCfg.MaxMessageSize,
-			AgentStartupTimeout:  hubCfg.AgentStartupTimeout(),
-			APITimeout:           hubCfg.APITimeout(),
-			EncryptionMode:       workerconfig.ParseEncryptionMode(hubCfg.Extras["encryption_mode"]),
-			UseLoginShell:        parseBool(hubCfg.Extras["use_login_shell"], true),
+			MaxIncompleteChunked: parseInt(p.hubCfg.Extras["max_incomplete_chunked"], 0),
+			MaxMessageSize:       p.hubCfg.MaxMessageSize,
+			AgentStartupTimeout:  p.hubCfg.AgentStartupTimeout(),
+			APITimeout:           p.hubCfg.APITimeout(),
+			EncryptionMode:       workerconfig.ParseEncryptionMode(p.hubCfg.Extras["encryption_mode"]),
+			UseLoginShell:        parseBool(p.hubCfg.Extras["use_login_shell"], true),
 			RegisteredBy:         state.RegisteredBy,
 		}); wErr != nil {
 			slog.Error("worker error", "error", wErr)
@@ -785,12 +939,20 @@ func loadOrCreateWorkerState(ctx context.Context, server workerRegistrar, stateP
 
 	userID, err := server.GetAdminUser(ctx)
 	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			// The ONE condition dev mode defers on. Tagged here, at the only lookup
+			// that can mean it, so the deferral arm does not have to key on a bare
+			// store.ErrNotFound from anywhere under bring-up -- a not-found from the
+			// registration below would otherwise be misread as "waiting for /setup",
+			// and the launch would report success and poll forever instead of failing.
+			return nil, fmt.Errorf("%w: %w", errNoAdminYet, err)
+		}
 		return nil, err
 	}
 
 	creds, err := server.RegisterWorker(ctx, userID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("register worker for admin %q: %w", userID, err)
 	}
 
 	state := &soloState{
@@ -860,14 +1022,37 @@ func persistState(statePath string, s *soloState) error {
 // launch to warn about again, which is still better than silently overwriting.
 func preserveCorruptState(statePath string, data []byte) {
 	sidecar := fmt.Sprintf("%s.corrupt-%d", statePath, time.Now().UnixNano())
+	// RENAME, not copy. A copy leaves the unreadable file exactly where the next
+	// load will read it again, and the dev-mode poller re-enters this path every
+	// tick until somebody completes /setup -- re-logging the orphaning and writing
+	// a fresh sidecar each time, unbounded. Moving it aside makes the next load see
+	// os.ErrNotExist and re-register once.
+	//
+	// Best-effort, and the fallback still copies: leaving the bytes in place for
+	// the next launch to warn about again beats losing them.
+	if err := os.Rename(statePath, sidecar); err == nil {
+		return
+	}
 	if err := os.WriteFile(sidecar, data, 0o600); err != nil {
 		slog.Warn("could not preserve corrupt worker state for forensics", "sidecar", sidecar, "err", err)
 	}
 }
 
-func mustDecode64(s string) []byte {
-	b, _ := base64.StdEncoding.DecodeString(s)
-	return b
+// decode64 decodes a base64 field of the saved worker state, reporting which
+// field failed.
+//
+// It replaces a mustDecode64 that discarded the error and, despite the name,
+// never panicked. The keypair-repair guard above only fires on EMPTY fields, so a
+// non-empty but mangled key reached RestoreCompositeKeypair as truncated bytes and
+// failed the launch with an opaque parse error -- forever, since nothing
+// re-registers or preserves the file. Naming the field is what turns that into
+// something an operator can act on.
+func decode64(field, s string) ([]byte, error) {
+	b, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return nil, fmt.Errorf("decode %s: %w", field, err)
+	}
+	return b, nil
 }
 
 // shouldWarnNonLoopback reports whether solo.Start should emit the
@@ -931,6 +1116,12 @@ func defaultExtraFlags() []hubconfig.ExtraFlagDef {
 // 32 is well under 16 tabs. A user who hits it is told to close a tab, which is
 // the one piece of advice a --help with no such flag cannot act on.
 //
+// use-login-shell is deliberately absent even though `leapmux solo
+// --use-login-shell=false` works: this list names HUB flags, and that one is an
+// ExtraFlag (see defaultExtraFlags), which LoadWithOptions registers unconditionally
+// without consulting this list. Listing it here was inert -- it matched no hub flag
+// -- and implied the wrong home for it.
+//
 // The three queue budgets are deliberately NOT here. They auto-size off this
 // machine's memory limit, which is almost always the right answer on a laptop,
 // and a config file still reaches them for the rare case it is not.
@@ -939,7 +1130,7 @@ func defaultCLIFlags(devMode bool) []string {
 		"listen", "data-dir", "dev-frontend",
 		"storage-sqlite-max-conns", "storage-sqlite-cache-size", "storage-sqlite-mmap-size",
 		"api-timeout-seconds", "agent-startup-timeout-seconds", "worktree-create-timeout-seconds",
-		"log-level", "use-login-shell",
+		"log-level",
 		"max-connections-per-user", "max-workers-per-user",
 	}
 	if devMode {

--- a/backend/solo/solo.go
+++ b/backend/solo/solo.go
@@ -54,42 +54,44 @@ var workerSetupPollInterval = 2 * time.Second
 // relayDrainTimeout in the desktop sidecar.
 var workerDrainTimeout = 5 * time.Second
 
-// serveHub runs the Hub. A var so tests can make Serve fail or exit on demand.
+// deps are the two collaborators Start would otherwise reach for directly. They
+// are PER-CALL rather than package vars so a test's substitute cannot outlive its
+// own test: the previous package-var seams were written by t.Cleanup while a
+// leaked Start goroutine could still be reading them, which is a data race the
+// tests had to avoid by discipline alone -- and which silently forbade
+// t.Parallel() on every test that stubs one.
 //
-// It has to be a seam because hub.NewServer binds BOTH listeners before Serve is
-// ever called, so no fixture can induce a Serve-TIME failure by occupying an
-// address or pointing at an unwritable path -- every such attempt fails earlier,
-// in NewServer, on a path that never reaches the watcher. Without this, the
-// "the Hub died while serving" arm and the gate that stops a startup failure
-// from being reported twice both had no coverage, and two tests aimed at them
-// were passing on a NewServer failure instead.
-var serveHub = func(ctx context.Context, s *hub.Server) error { return s.Serve(ctx) }
+// Both have to be seams at all because no fixture reaches their failure modes
+// from outside:
+//
+//   - serveHub: hub.NewServer binds BOTH listeners before Serve is ever called,
+//     so no fixture can induce a Serve-TIME failure by occupying an address or
+//     pointing at an unwritable path -- every such attempt fails earlier, in
+//     NewServer, on a path that never reaches the watcher. Without it, the "the
+//     Hub died while serving" arm and the gate that stops a startup failure being
+//     reported twice had no coverage, and two tests aimed at them were passing on
+//     a NewServer failure instead.
+//   - bringUpWorker: every real way to fail bring-up -- no admin user yet, an
+//     unreadable state file, a store error -- fails AT ONCE, at the first
+//     statement that touches the database or the disk, so nothing can hold Start
+//     inside the bring-up window long enough for the startup to end there.
+//
+// defaultDeps names the real implementations, and both stay directly callable,
+// which is what keeps the seams honest: several tests drive Start straight
+// through them, and TestSoloStart_TearsDownARealWorkerLaunchedJustBeforeTheHubDied
+// WRAPS bringUpLocalWorker rather than replacing it, so the token accounting under
+// the gate is exercised against the Worker goroutine production actually launches.
+type deps struct {
+	serveHub      func(ctx context.Context, s *hub.Server) error
+	bringUpWorker func(ctx context.Context, p workerBringUp) error
+}
 
-// bringUpWorker brings the local Worker up. A var so a test can park bring-up
-// mid-flight and kill the Hub underneath it.
-//
-// It has to be a seam for the same reason serveHub does: nothing reaches the case
-// from outside. Every real way to fail bring-up -- no admin user yet, an
-// unreadable state file, a store error -- fails AT ONCE, at the first statement
-// that touches the database or the disk, so no fixture can hold Start inside the
-// bring-up window long enough for the Hub to die there. Without this, the gate
-// that keeps a dead Hub from being blamed on the Worker, and the one that stops
-// Start returning a healthy Instance for a Hub that already exited, both had no
-// coverage at all.
-//
-// A package var rather than an Instance field because Start constructs the
-// Instance itself: at the point a test would have to inject, there is nothing to
-// inject into. Config is not the place either -- it is exported API, and a test
-// seam does not belong in the surface a caller configures.
-//
-// bringUpLocalWorker stays directly callable, which is what keeps the seam honest:
-// TestSolo_AHubThatDiesWhileServingTearsTheInstanceDownWithoutReporting and
-// TestSolo_AStopRequestedHubErrorIsReportedOnlyByStop drive Start straight through
-// the real implementation, and
-// TestSoloStart_TearsDownARealWorkerLaunchedJustBeforeTheHubDied wraps it rather
-// than replacing it, so the token accounting under the gate is exercised against
-// the Worker goroutine production actually launches.
-var bringUpWorker = bringUpLocalWorker
+func defaultDeps() deps {
+	return deps{
+		serveHub:      func(ctx context.Context, s *hub.Server) error { return s.Serve(ctx) },
+		bringUpWorker: bringUpLocalWorker,
+	}
+}
 
 // nonLoopbackListenWarnMsg is the security warning emitted when solo mode
 // binds to a non-loopback address. Solo mode injects a soloUser into the
@@ -432,6 +434,10 @@ func soloLoadOptions(cfg Config) (hubconfig.LoadOptions, string) {
 }
 
 func Start(ctx context.Context, cfg Config) (*Instance, error) {
+	return start(ctx, cfg, defaultDeps())
+}
+
+func start(ctx context.Context, cfg Config, d deps) (*Instance, error) {
 	logging.Setup()
 
 	// The side effects below stay HERE, in this order: the banner is printed
@@ -514,7 +520,7 @@ func Start(ctx context.Context, cfg Config) (*Instance, error) {
 	serving := make(chan struct{})
 	go func() {
 		close(serving)
-		inst.hubErr = serveHub(hubCtx, server)
+		inst.hubErr = d.serveHub(hubCtx, server)
 		close(inst.hubDone)
 	}()
 	<-serving
@@ -581,7 +587,7 @@ func Start(ctx context.Context, cfg Config) (*Instance, error) {
 	// until /setup completes.
 	statePath := filepath.Join(workerDataDir, "state.json")
 	setupWorker := func(ctx context.Context) error {
-		return bringUpWorker(ctx, workerBringUp{
+		return d.bringUpWorker(ctx, workerBringUp{
 			work:          &inst.workerWork,
 			drained:       &inst.workerDrained,
 			server:        server,

--- a/backend/solo/solo_integration_test.go
+++ b/backend/solo/solo_integration_test.go
@@ -278,7 +278,7 @@ func TestSoloStart_SurfacesHubBindError(t *testing.T) {
 // This covers the pre-Instance half only -- the failure happens inside
 // hub.NewServer, so no watcher has been installed yet. The half where the
 // watcher DOES exist and has to stay quiet is
-// TestSoloStart_DoesNotAlsoLogAServeTimeStartupFailure, which reaches it via the
+// TestSoloStart_DoesNotAlsoLogAServeTimeFailure, which reaches it via the
 // serveHub seam.
 func TestSoloStart_DoesNotAlsoLogANewServerFailure(t *testing.T) {
 	if runtime.GOOS == "windows" {

--- a/backend/solo/solo_test.go
+++ b/backend/solo/solo_test.go
@@ -3,6 +3,7 @@ package solo
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,8 +17,10 @@ import (
 
 	"github.com/leapmux/leapmux/hub"
 	hubconfig "github.com/leapmux/leapmux/internal/hub/config"
+	"github.com/leapmux/leapmux/internal/hub/store"
 	"github.com/leapmux/leapmux/internal/util/testutil"
 	"github.com/leapmux/leapmux/locallisten/locallistentest"
+	"github.com/leapmux/leapmux/util/drain"
 )
 
 // soloLoadOptions builds the options Start would pass, with the config file
@@ -300,12 +303,82 @@ func TestParseIntReadsTheStringTypedExtras(t *testing.T) {
 	}
 }
 
+// soloTestTimeout bounds every wait in this file that could otherwise hang: the
+// contexts handed to Start, and the hang detectors on the goroutine-driven tests.
+// It is a BACKSTOP, never a timing assertion -- each of those waits also has an
+// explicit signal that arrives in microseconds on a working tree, so a run that
+// reaches this budget has already failed.
+const soloTestTimeout = 60 * time.Second
+
 // stubServeHub swaps the Hub-serving seam for the duration of the test.
 func stubServeHub(t *testing.T, fn func(context.Context, *hub.Server) error) {
 	t.Helper()
 	prev := serveHub
 	serveHub = fn
 	t.Cleanup(func() { serveHub = prev })
+}
+
+// stubWorkerBringUp swaps the Worker bring-up seam, absorbing the seven
+// production-wiring parameters so each test states only what it does with the
+// context and what it reports.
+func stubWorkerBringUp(t *testing.T, fn func(context.Context) error) {
+	t.Helper()
+	prev := bringUpWorker
+	bringUpWorker = func(ctx context.Context, _, _ *drain.Counter, _ *hub.Server,
+		_, _ string, _ *hubconfig.Config, _, _ string) error {
+		return fn(ctx)
+	}
+	t.Cleanup(func() { bringUpWorker = prev })
+}
+
+// serveUntilKilled stubs serveHub with a REAL s.Serve that runs until kill(),
+// and reports serveErr once it has stopped.
+//
+// This is what makes the startup-window tests ORDERED rather than raced: the Hub
+// is provably serving when Start passes readiness, and provably finished
+// afterwards. A stub that failed immediately could not distinguish "the gate saw
+// a dead Hub" from "the gate was never reached".
+//
+// kill is idempotent and never blocks, and t.Cleanup calls it, so a failed
+// assertion cannot leave a Hub serving behind the test.
+func serveUntilKilled(t *testing.T, serveErr error) (kill func()) {
+	t.Helper()
+	killed := make(chan struct{})
+	stubServeHub(t, func(ctx context.Context, s *hub.Server) error {
+		inner, cancel := context.WithCancel(ctx)
+		defer cancel()
+		go func() {
+			select {
+			case <-killed:
+				cancel()
+			case <-inner.Done():
+				// Serve stopped on its own (or the Hub was cancelled); nothing to do.
+			}
+		}()
+		_ = s.Serve(inner)
+		return serveErr
+	})
+	var once sync.Once
+	kill = func() { once.Do(func() { close(killed) }) }
+	t.Cleanup(kill)
+	return kill
+}
+
+// awaitBringUp blocks until Start has entered the bring-up seam.
+//
+// Its two failure arms are diagnostics, not assertions: done closing first means
+// Start ran the REAL bring-up (the seam is not wired), and the budget expiring
+// means Start never got there at all. Both would otherwise present as a test that
+// hangs until the package deadline.
+func awaitBringUp(t *testing.T, entered, done <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-entered:
+	case <-done:
+		t.Fatal("Start finished without reaching bring-up (is the seam wired?)")
+	case <-time.After(soloTestTimeout):
+		t.Fatal("Start never reached bring-up")
+	}
 }
 
 // startFailureEnv points Start at a throwaway home with no TCP listener, so it
@@ -331,6 +404,18 @@ func startFailureEnv(t *testing.T) Config {
 		CLIFlags: append(defaultCLIFlags(false), "local-listen"),
 		Args:     []string{"--local-listen=" + locallistentest.UniqueListenURL(t, "leapmux-hub-solo")},
 	}
+}
+
+// devStartFailureEnv is startFailureEnv in DEV mode, which is where the
+// deferral arm lives: dev uses real password auth rather than solo's injected
+// soloUser, so on a fresh install there is no admin for the Worker to register
+// under until somebody completes /setup.
+func devStartFailureEnv(t *testing.T) Config {
+	t.Helper()
+	cfg := startFailureEnv(t)
+	cfg.DevMode = true
+	cfg.CLIFlags = append(defaultCLIFlags(true), "local-listen")
+	return cfg
 }
 
 // A Hub that dies WHILE SERVING is surfaced by Start with the "hub serve:"
@@ -423,7 +508,7 @@ func TestSolo_AHubThatDiesWhileServingTearsTheInstanceDownWithoutReporting(t *te
 // The other half of the report gate: an exit somebody ASKED for. Stop hands that
 // error straight back and waitSolo documents itself as its single reporter, so
 // logging it here as well would restore -- at the far end of the lifecycle --
-// exactly the duplicate report startupDone removes for startup.
+// exactly the duplicate report the watcher's silence removes for startup.
 func TestSolo_AStopRequestedHubErrorIsReportedOnlyByStop(t *testing.T) {
 	cfg := startFailureEnv(t)
 
@@ -447,6 +532,341 @@ func TestSolo_AStopRequestedHubErrorIsReportedOnlyByStop(t *testing.T) {
 	assert.ErrorIs(t, stopErr, wantErr, "Stop must still hand the error back")
 	assert.NotContains(t, out, "hub error",
 		"an exit Stop asked for must not also be logged; captured:\n"+out)
+}
+
+// hubFailure is the ONE predicate Start asks at every stage boundary, so an
+// exited Hub outranks whatever that stage happened to observe. The property
+// under test is TOTALITY: once hubDone is closed it never returns nil. The
+// readiness select leans on that -- its hubDone arm carries no error of its own
+// -- so a hole here silently turns a dead Hub back into a healthy Instance.
+//
+// This is also where the readiness race is pinned. The race itself cannot be
+// forced end-to-end: nothing observable sits between the Hub goroutine's start
+// and the select, so no test can guarantee hubDone is closed AT the select
+// without a sleep. The fix does not win that race, it makes the arm choice
+// irrelevant -- which is a local property, testable exactly here.
+func TestHubFailure_AnExitedHubOutranksWhateverTheStageSaw(t *testing.T) {
+	t.Parallel()
+
+	closedChan := func() chan struct{} {
+		ch := make(chan struct{})
+		close(ch)
+		return ch
+	}
+	hubErr := errors.New("revocation watcher seed failed")
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tests := []struct {
+		name string
+		// The literals are bare on purpose, like TestInstanceStopReturnsHubError's:
+		// hubFailure must be safe on the zero-value Instance every shutdown trigger
+		// can reach.
+		inst    *Instance
+		ctx     context.Context
+		want    string
+		wantIs  error
+		wantNil bool
+	}{
+		{
+			// Half-built Instances are reachable from every shutdown trigger, so
+			// this must answer rather than block, like shutdown and join do.
+			name:    "a nil hubDone reads as still serving",
+			inst:    &Instance{},
+			ctx:     context.Background(),
+			wantNil: true,
+		},
+		{
+			// hubErr is set and must still be ignored: the gate is hubDone, because
+			// only hubDone orders the read of hubErr.
+			name:    "an open hubDone outranks an already-set hubErr",
+			inst:    &Instance{hubDone: make(chan struct{}), hubErr: hubErr},
+			ctx:     context.Background(),
+			wantNil: true,
+		},
+		{
+			name:   "an exited hub reports its own error",
+			inst:   &Instance{hubDone: closedChan(), hubErr: hubErr},
+			ctx:    context.Background(),
+			want:   "hub serve: revocation watcher seed failed",
+			wantIs: hubErr,
+		},
+		{
+			// Totality: no error of its own, no cancelled caller, and it STILL must
+			// not return nil. This is the case the empty select arm depends on.
+			name: "an exited hub with no error of its own names the stage",
+			inst: &Instance{hubDone: closedChan()},
+			ctx:  context.Background(),
+			want: "hub serve exited while the worker was starting",
+		},
+		{
+			// hubErr is nil here, so the cancelled caller is the best cause
+			// available; %w keeps errors.Is reaching it.
+			name:   "a cancelled caller is reported as the cause when the hub had none",
+			inst:   &Instance{hubDone: closedChan()},
+			ctx:    cancelledCtx,
+			want:   "hub shut down while the worker was starting: context canceled",
+			wantIs: context.Canceled,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.inst.hubFailure(tt.ctx, "while the worker was starting")
+			if tt.wantNil {
+				assert.NoError(t, got)
+				return
+			}
+			require.Error(t, got, "hubFailure must be total once hubDone is closed")
+			assert.Equal(t, tt.want, got.Error())
+			if tt.wantIs != nil {
+				assert.ErrorIs(t, got, tt.wantIs)
+			}
+		})
+	}
+}
+
+// What the readiness gate buys over the bring-up gate downstream, which would
+// catch the same dead Hub a moment later: bring-up is not cheap. It opens SQLite,
+// registers a worker (a DB WRITE), writes a state file and, on a first launch,
+// generates an ML-KEM + SLH-DSA keypair -- seconds of work aimed at a Hub that is
+// already shutting down, every bit of it discarded. A Hub known to be gone must
+// stop the launch where it is discovered.
+//
+// The ordering is Start's own `serving` handshake, not a timing assumption: the
+// Hub goroutine runs close(serving), the stub's immediate return and
+// close(hubDone) consecutively, so hubDone is closed before the readiness verdict
+// -- which in turn waits out a connect syscall.
+func TestSoloStart_DoesNotBringTheWorkerUpAgainstAHubThatAlreadyExited(t *testing.T) {
+	cfg := startFailureEnv(t)
+	wantErr := errors.New("revocation watcher seed failed")
+	stubServeHub(t, func(context.Context, *hub.Server) error { return wantErr })
+
+	var broughtUp atomic.Bool
+	stubWorkerBringUp(t, func(context.Context) error {
+		broughtUp.Store(true)
+		return nil
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), soloTestTimeout)
+	defer cancel()
+	inst, err := Start(ctx, cfg)
+
+	require.Error(t, err)
+	require.Nil(t, inst)
+	assert.ErrorIs(t, err, wantErr)
+	assert.False(t, broughtUp.Load(),
+		"a Hub already known to be gone must not have a Worker brought up against it")
+}
+
+// The literal macOS CI failure from PR #364: a Hub that dies while the Worker is
+// coming up was reported as "auto-register worker: create worker: context
+// canceled". The Worker only said that BECAUSE the Hub died -- the watcher
+// cancels workerCtx the moment it observes hubDone -- so blaming it sends every
+// reader after the wrong bug.
+func TestSoloStart_AHubThatDiesDuringBringUpIsNotBlamedOnTheWorker(t *testing.T) {
+	cfg := startFailureEnv(t)
+	wantErr := errors.New("revocation watcher seed failed")
+	kill := serveUntilKilled(t, wantErr)
+
+	entered := make(chan struct{})
+	stubWorkerBringUp(t, func(ctx context.Context) error {
+		close(entered)
+		// Returns only once the watcher has cancelled workerCtx, which it does
+		// after observing hubDone -- so the gate provably runs against a Hub that
+		// has already exited, with no sleep and no race.
+		<-ctx.Done()
+		return fmt.Errorf("create worker: %w", ctx.Err())
+	})
+
+	var inst *Instance
+	var err error
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ctx, cancel := context.WithTimeout(context.Background(), soloTestTimeout)
+		defer cancel()
+		inst, err = Start(ctx, cfg)
+	}()
+
+	awaitBringUp(t, entered, done)
+	kill()
+	<-done
+
+	require.Error(t, err)
+	require.Nil(t, inst)
+	assert.ErrorIs(t, err, wantErr)
+	assert.True(t, strings.HasPrefix(err.Error(), "hub serve:"),
+		"the Hub's death must be attributed to the Hub; got: "+err.Error())
+	assert.NotContains(t, err.Error(), "auto-register worker",
+		"the Worker only failed because the Hub did; got: "+err.Error())
+}
+
+// A Hub that dies during bring-up must not yield an Instance, even when bring-up
+// itself succeeds -- the case with no reporter at all on the desktop path, whose
+// soloInstance interface is LocalListenURL/Stop with no Wait. There, Start
+// returning nil means the sidecar announces a successful launch, installs its
+// webview log handler, and the UI then fails to connect with nothing attributing
+// it to the Hub.
+func TestSoloStart_DoesNotReturnAnInstanceForAHubThatDiedDuringBringUp(t *testing.T) {
+	tests := []struct {
+		name     string
+		serveErr error
+	}{
+		{"a hub that failed", errors.New("revocation watcher seed failed")},
+		// The only place the stage string is observable: no hubErr, no cancelled
+		// caller, so the message is all that is left to say the Hub is gone.
+		{"a hub that merely exited", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := startFailureEnv(t)
+			kill := serveUntilKilled(t, tt.serveErr)
+
+			entered := make(chan struct{})
+			stubWorkerBringUp(t, func(ctx context.Context) error {
+				close(entered)
+				<-ctx.Done()
+				// Bring-up SUCCEEDED -- from a window in which the Hub had already
+				// died. Nothing downstream of here asks again, so without the gate
+				// Start hands back a healthy Instance for a stopped Hub.
+				return nil
+			})
+
+			var inst *Instance
+			var err error
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				ctx, cancel := context.WithTimeout(context.Background(), soloTestTimeout)
+				defer cancel()
+				inst, err = Start(ctx, cfg)
+			}()
+
+			awaitBringUp(t, entered, done)
+			kill()
+			<-done
+
+			require.Error(t, err, "a dead Hub must not be reported as a successful launch")
+			require.Nil(t, inst)
+			if tt.serveErr != nil {
+				assert.ErrorIs(t, err, tt.serveErr)
+				assert.True(t, strings.HasPrefix(err.Error(), "hub serve:"),
+					"got: "+err.Error())
+			} else {
+				assert.Equal(t, "hub serve exited while the worker was starting", err.Error())
+			}
+		})
+	}
+}
+
+// The deferral arm, which had no coverage at all before the bring-up seam
+// existed: in dev mode a missing admin is what /setup is for, so the launch must
+// SUCCEED and leave a poller behind rather than fail.
+func TestSoloStart_DevModeDefersWorkerRegistrationUntilAnAdminExists(t *testing.T) {
+	cfg := devStartFailureEnv(t)
+	// A real Serve, but with its terminal error pinned to nil. With bring-up
+	// stubbed, Start returns fast enough that Stop's cancel can land inside the
+	// Hub's OWN startup -- seeding the revocation cursor, which surfaces as a
+	// SQLite "interrupted" -- and that race has nothing to do with the arm under
+	// test. Pinning it keeps the Stop assertion below about token accounting.
+	serveUntilKilled(t, nil)
+	// Re-entrant: the poller calls this again on every tick.
+	stubWorkerBringUp(t, func(context.Context) error { return store.ErrNotFound })
+
+	var inst *Instance
+	var err error
+	out := testutil.CaptureStderr(t, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), soloTestTimeout)
+		defer cancel()
+		inst, err = Start(ctx, cfg)
+	})
+
+	require.NoError(t, err, "a missing admin defers the Worker; it does not fail the launch; captured:\n"+out)
+	require.NotNil(t, inst)
+	assert.Contains(t, out, "deferring worker auto-registration",
+		"the deferral is the user-visible half of this arm; captured:\n"+out)
+	// Stop is the token-accounting assertion: the deferral hands a second worker
+	// token pair to the poller while Start still holds its own, and an imbalance
+	// on either side either wedges the teardown or trips drain.Counter's
+	// negative-counter panic.
+	assert.NoError(t, inst.Stop())
+}
+
+// The gate sits BEFORE the switch, so it covers the deferral arm too. Without
+// that placement a dev-mode launch whose Hub died during bring-up would return a
+// healthy Instance AND leave a poller ticking every 2s against a Hub that is
+// already gone.
+func TestSoloStart_DoesNotDeferWorkerSetupOntoAHubThatDied(t *testing.T) {
+	cfg := devStartFailureEnv(t)
+	wantErr := errors.New("revocation watcher seed failed")
+	kill := serveUntilKilled(t, wantErr)
+
+	entered := make(chan struct{})
+	stubWorkerBringUp(t, func(ctx context.Context) error {
+		close(entered)
+		<-ctx.Done()
+		// The arm that would defer, if the gate let it get that far.
+		return store.ErrNotFound
+	})
+
+	var inst *Instance
+	var err error
+	done := make(chan struct{})
+	out := testutil.CaptureStderr(t, func() {
+		go func() {
+			defer close(done)
+			ctx, cancel := context.WithTimeout(context.Background(), soloTestTimeout)
+			defer cancel()
+			inst, err = Start(ctx, cfg)
+		}()
+		awaitBringUp(t, entered, done)
+		kill()
+		<-done
+	})
+
+	require.Error(t, err)
+	require.Nil(t, inst)
+	assert.ErrorIs(t, err, wantErr)
+	assert.True(t, strings.HasPrefix(err.Error(), "hub serve:"), "got: "+err.Error())
+	assert.NotContains(t, out, "deferring worker auto-registration",
+		"a Hub that is gone has nothing to defer to; captured:\n"+out)
+}
+
+// The over-reach guard on the gate above, and the first coverage of the switch's
+// default arm: with the Hub still serving, a bring-up failure is still the
+// Worker's, reported with the Worker's attribution.
+func TestSoloStart_AWorkerBringUpFailureIsStillTheWorkers(t *testing.T) {
+	tests := []struct {
+		name       string
+		bringUpErr error
+	}{
+		{"a generic failure", errors.New("generate composite keypair: no entropy")},
+		// Outside dev mode there is nothing to defer to: no /setup flow will ever
+		// create the admin this is waiting for, so it must fail the launch rather
+		// than fall into the deferral arm.
+		{"no admin user outside dev mode", store.ErrNotFound},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// No serveHub stub: the Hub is real and still serving, which is the
+			// whole point -- the gate must not claim a failure that is not its own.
+			cfg := startFailureEnv(t)
+			stubWorkerBringUp(t, func(context.Context) error { return tt.bringUpErr })
+
+			ctx, cancel := context.WithTimeout(context.Background(), soloTestTimeout)
+			defer cancel()
+			inst, err := Start(ctx, cfg)
+
+			require.Error(t, err)
+			require.Nil(t, inst)
+			assert.ErrorIs(t, err, tt.bringUpErr)
+			assert.True(t, strings.HasPrefix(err.Error(), "auto-register worker:"),
+				"a live Hub leaves the failure the Worker's; got: "+err.Error())
+			assert.NotContains(t, err.Error(), "hub serve",
+				"the Hub was still serving; got: "+err.Error())
+		})
+	}
 }
 
 // The point of the drain signal: the Hub stops as soon as the last frame is

--- a/backend/solo/solo_test.go
+++ b/backend/solo/solo_test.go
@@ -179,6 +179,8 @@ func TestListenIsNonLoopback(t *testing.T) {
 // dereferenced a field Start had not filled in would wedge or panic on the
 // startup failure paths that shut down a half-built instance.
 func TestInstanceStopReturnsHubError(t *testing.T) {
+	t.Parallel()
+
 	wantErr := errors.New("lease release failed")
 	hubDone := make(chan struct{})
 	close(hubDone)
@@ -211,6 +213,8 @@ func (o *orderLog) snapshot() []string {
 }
 
 func TestInstanceShutdown_DrainsTheWorkerBeforeStoppingTheHub(t *testing.T) {
+	t.Parallel()
+
 	var order orderLog
 	hubDone := make(chan struct{})
 	close(hubDone)
@@ -310,6 +314,8 @@ func TestInstanceShutdown_DoesNotBlameAWorkerThatNeverExisted(t *testing.T) {
 }
 
 func TestInstanceShutdown_IsIdempotent(t *testing.T) {
+	t.Parallel()
+
 	hubDone := make(chan struct{})
 	close(hubDone)
 	var workerCancels, hubCancels atomic.Int32
@@ -337,6 +343,8 @@ func TestInstanceShutdown_IsIdempotent(t *testing.T) {
 // drops out of this list again, `leapmux solo -max-incomplete-chunked=N` starts
 // failing with "flag provided but not defined" while the docs still advertise it.
 func TestDefaultExtraFlagsCarryWorkerScopedKnobs(t *testing.T) {
+	t.Parallel()
+
 	byName := map[string]hubconfig.ExtraFlagDef{}
 	for _, ef := range defaultExtraFlags() {
 		byName[ef.Name] = ef
@@ -362,6 +370,8 @@ func TestDefaultExtraFlagsCarryWorkerScopedKnobs(t *testing.T) {
 // is string-typed (koanf reads every extra with k.String), so a malformed or absent
 // value must degrade to the default rather than silently becoming 0-and-meaningful.
 func TestParseIntReadsTheStringTypedExtras(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name       string
 		in         string
@@ -401,11 +411,11 @@ const soloTestTimeout = 60 * time.Second
 // gives them back. Every such test leaked an open SQLite pool and a bound socket
 // or pipe handle for the life of the test binary, which on Windows also defeats
 // the sandbox temp-dir cleanup.
-func serveFailsImmediately(t *testing.T, serveErr error) {
+func serveFailsImmediately(t *testing.T, d *testDeps, serveErr error) {
 	t.Helper()
 	var releasing atomic.Bool
 	released := make(chan struct{})
-	stubServeHub(t, func(ctx context.Context, s *hub.Server) error {
+	d.stubServeHub(func(ctx context.Context, s *hub.Server) error {
 		dead, cancel := context.WithCancel(ctx)
 		cancel()
 		// On the SIDE, so this stub still returns at once: the tests that use it
@@ -430,22 +440,33 @@ func serveFailsImmediately(t *testing.T, serveErr error) {
 	})
 }
 
-// stubServeHub swaps the Hub-serving seam for the duration of the test.
-func stubServeHub(t *testing.T, fn func(context.Context, *hub.Server) error) {
-	t.Helper()
-	prev := serveHub
-	serveHub = fn
-	t.Cleanup(func() { serveHub = prev })
+// testDeps accumulates the seam substitutions for one test. It is passed to
+// start() rather than written to package state, so a stub cannot outlive the test
+// that installed it -- which is what the package-var seams could not promise: a
+// leaked Start goroutine could still be reading one while t.Cleanup wrote it back.
+//
+// It does NOT make the Hub-starting tests parallel, and that is not what it is
+// for. Those call soloStartEnv -> SandboxHome -> t.Setenv, which Go refuses to
+// combine with t.Parallel at all, and several also swap os.Stderr through
+// CaptureStderr. The seams were never the binding constraint; process-global HOME
+// is. What this buys is that a stub is now scoped to the test that made it,
+// mechanically rather than by discipline.
+type testDeps struct {
+	deps
+}
+
+func newTestDeps() *testDeps { return &testDeps{deps: defaultDeps()} }
+
+// stubServeHub swaps the Hub-serving seam.
+func (d *testDeps) stubServeHub(fn func(context.Context, *hub.Server) error) {
+	d.serveHub = fn
 }
 
 // stubWorkerBringUp swaps the Worker bring-up seam, discarding the production
 // wiring so each test states only what it does with the context and what it
 // reports.
-func stubWorkerBringUp(t *testing.T, fn func(context.Context) error) {
-	t.Helper()
-	prev := bringUpWorker
-	bringUpWorker = func(ctx context.Context, _ workerBringUp) error { return fn(ctx) }
-	t.Cleanup(func() { bringUpWorker = prev })
+func (d *testDeps) stubWorkerBringUp(fn func(context.Context) error) {
+	d.bringUpWorker = func(ctx context.Context, _ workerBringUp) error { return fn(ctx) }
 }
 
 // serveUntilKilled stubs serveHub with a REAL s.Serve that runs until kill(),
@@ -464,11 +485,11 @@ func stubWorkerBringUp(t *testing.T, fn func(context.Context) error) {
 //
 // kill is idempotent and never blocks, and t.Cleanup calls it, so a failed
 // assertion cannot leave a Hub serving behind the test.
-func serveUntilKilled(t *testing.T, serveErr error) (kill func()) {
+func serveUntilKilled(t *testing.T, d *testDeps, serveErr error) (kill func()) {
 	t.Helper()
 	killed := make(chan struct{})
 	var servedEarly atomic.Pointer[error]
-	stubServeHub(t, func(ctx context.Context, s *hub.Server) error {
+	d.stubServeHub(func(ctx context.Context, s *hub.Server) error {
 		inner, cancel := context.WithCancel(ctx)
 		defer cancel()
 		go func() {
@@ -523,23 +544,23 @@ func serveUntilKilled(t *testing.T, serveErr error) (kill func()) {
 // the REAL bring-up (the seam is not wired), and the budget expiring means Start
 // never got there at all. Both would otherwise present as a test that hangs until
 // the package deadline.
-func startWhileHubDies(t *testing.T, cfg Config, entered <-chan struct{}, endHub func()) (*Instance, error) {
+func startWhileHubDies(t *testing.T, d *testDeps, cfg Config, entered <-chan struct{}, endHub func()) (*Instance, error) {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), soloTestTimeout)
 	t.Cleanup(cancel)
-	return startUntilTornDown(t, ctx, cfg, entered, endHub)
+	return startUntilTornDown(t, ctx, d, cfg, entered, endHub)
 }
 
 // startUntilTornDown is startWhileHubDies with the caller's context under the
 // test's control, for the OTHER way a startup ends: the caller cancelling.
-func startUntilTornDown(t *testing.T, ctx context.Context, cfg Config, entered <-chan struct{}, tearDown func()) (*Instance, error) {
+func startUntilTornDown(t *testing.T, ctx context.Context, d *testDeps, cfg Config, entered <-chan struct{}, tearDown func()) (*Instance, error) {
 	t.Helper()
 	var inst *Instance
 	var err error
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		inst, err = Start(ctx, cfg)
+		inst, err = start(ctx, cfg, d.deps)
 	}()
 
 	select {
@@ -603,12 +624,13 @@ func soloStartEnv(t *testing.T, devMode bool) Config {
 // contain the substring "hub serve".
 func TestSoloStart_SurfacesAServeTimeFailure(t *testing.T) {
 	cfg := startFailureEnv(t)
+	d := newTestDeps()
 	wantErr := errors.New("revocation watcher seed failed")
-	serveFailsImmediately(t, wantErr)
+	serveFailsImmediately(t, d, wantErr)
 
 	ctx, cancel := context.WithTimeout(context.Background(), soloTestTimeout)
 	defer cancel()
-	inst, err := Start(ctx, cfg)
+	inst, err := start(ctx, cfg, d.deps)
 
 	require.Error(t, err)
 	require.Nil(t, inst)
@@ -623,7 +645,8 @@ func TestSoloStart_SurfacesAServeTimeFailure(t *testing.T) {
 // every failed launch is reported twice.
 func TestSoloStart_DoesNotAlsoLogAServeTimeFailure(t *testing.T) {
 	cfg := startFailureEnv(t)
-	serveFailsImmediately(t, errors.New("revocation watcher seed failed"))
+	d := newTestDeps()
+	serveFailsImmediately(t, d, errors.New("revocation watcher seed failed"))
 
 	// Stderr, not slog.Default(): Start's own logging.Setup installs a fresh
 	// default logger, so a captured handler would be replaced before the line
@@ -632,7 +655,7 @@ func TestSoloStart_DoesNotAlsoLogAServeTimeFailure(t *testing.T) {
 	out := testutil.CaptureStderr(t, func() {
 		ctx, cancel := context.WithTimeout(context.Background(), soloTestTimeout)
 		defer cancel()
-		_, err = Start(ctx, cfg)
+		_, err = start(ctx, cfg, d.deps)
 	})
 
 	require.Error(t, err)
@@ -647,11 +670,12 @@ func TestSoloStart_DoesNotAlsoLogAServeTimeFailure(t *testing.T) {
 // reporter.
 func TestSolo_AHubThatDiesWhileServingTearsTheInstanceDownWithoutReporting(t *testing.T) {
 	cfg := startFailureEnv(t)
+	d := newTestDeps()
 
 	wantErr := errors.New("hub died mid-session")
 	serving := make(chan struct{})
 	var killHub atomic.Pointer[context.CancelFunc]
-	stubServeHub(t, func(ctx context.Context, s *hub.Server) error {
+	d.stubServeHub(func(ctx context.Context, s *hub.Server) error {
 		inner, cancel := context.WithCancel(ctx)
 		killHub.Store(&cancel)
 		close(serving)
@@ -664,7 +688,7 @@ func TestSolo_AHubThatDiesWhileServingTearsTheInstanceDownWithoutReporting(t *te
 		ctx, cancel := context.WithTimeout(context.Background(), soloTestTimeout)
 		defer cancel()
 		var err error
-		inst, err = Start(ctx, cfg)
+		inst, err = start(ctx, cfg, d.deps)
 		require.NoError(t, err, "the Hub must come up before this test can kill it")
 
 		<-serving
@@ -686,9 +710,10 @@ func TestSolo_AHubThatDiesWhileServingTearsTheInstanceDownWithoutReporting(t *te
 // exactly the duplicate report the watcher's silence removes for startup.
 func TestSolo_AStopRequestedHubErrorIsReportedOnlyByStop(t *testing.T) {
 	cfg := startFailureEnv(t)
+	d := newTestDeps()
 
 	wantErr := errors.New("lease release failed")
-	stubServeHub(t, func(ctx context.Context, s *hub.Server) error {
+	d.stubServeHub(func(ctx context.Context, s *hub.Server) error {
 		_ = s.Serve(ctx)
 		// The shape of a real teardown cleanup failure: Serve returns non-nil
 		// after an ordinary, requested shutdown.
@@ -699,7 +724,7 @@ func TestSolo_AStopRequestedHubErrorIsReportedOnlyByStop(t *testing.T) {
 	out := testutil.CaptureStderr(t, func() {
 		ctx, cancel := context.WithTimeout(context.Background(), soloTestTimeout)
 		defer cancel()
-		inst, err := Start(ctx, cfg)
+		inst, err := start(ctx, cfg, d.deps)
 		require.NoError(t, err)
 		stopErr = inst.Stop()
 	})
@@ -826,18 +851,19 @@ func TestHubFailure_AnExitedHubOutranksWhateverTheStageSaw(t *testing.T) {
 // -- which in turn waits out a connect syscall.
 func TestSoloStart_DoesNotBringTheWorkerUpAgainstAHubThatAlreadyExited(t *testing.T) {
 	cfg := startFailureEnv(t)
+	d := newTestDeps()
 	wantErr := errors.New("revocation watcher seed failed")
-	serveFailsImmediately(t, wantErr)
+	serveFailsImmediately(t, d, wantErr)
 
 	var broughtUp atomic.Bool
-	stubWorkerBringUp(t, func(context.Context) error {
+	d.stubWorkerBringUp(func(context.Context) error {
 		broughtUp.Store(true)
 		return nil
 	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), soloTestTimeout)
 	defer cancel()
-	inst, err := Start(ctx, cfg)
+	inst, err := start(ctx, cfg, d.deps)
 
 	require.Error(t, err)
 	require.Nil(t, inst)
@@ -853,11 +879,12 @@ func TestSoloStart_DoesNotBringTheWorkerUpAgainstAHubThatAlreadyExited(t *testin
 // reader after the wrong bug.
 func TestSoloStart_AHubThatDiesDuringBringUpIsNotBlamedOnTheWorker(t *testing.T) {
 	cfg := startFailureEnv(t)
+	d := newTestDeps()
 	wantErr := errors.New("revocation watcher seed failed")
-	kill := serveUntilKilled(t, wantErr)
+	kill := serveUntilKilled(t, d, wantErr)
 
 	entered := make(chan struct{})
-	stubWorkerBringUp(t, func(ctx context.Context) error {
+	d.stubWorkerBringUp(func(ctx context.Context) error {
 		close(entered)
 		// Returns only once the watcher has cancelled workerCtx, which it does
 		// after observing hubDone -- so the gate provably runs against a Hub that
@@ -866,7 +893,7 @@ func TestSoloStart_AHubThatDiesDuringBringUpIsNotBlamedOnTheWorker(t *testing.T)
 		return fmt.Errorf("create worker: %w", ctx.Err())
 	})
 
-	inst, err := startWhileHubDies(t, cfg, entered, kill)
+	inst, err := startWhileHubDies(t, d, cfg, entered, kill)
 
 	require.Error(t, err)
 	require.Nil(t, inst)
@@ -884,6 +911,7 @@ func TestSoloStart_AHubThatDiesDuringBringUpIsNotBlamedOnTheWorker(t *testing.T)
 // webview log handler, and the UI then fails to connect with nothing attributing
 // it to the Hub.
 func TestSoloStart_DoesNotReturnAnInstanceForAHubThatDiedDuringBringUp(t *testing.T) {
+	d := newTestDeps()
 	tests := []struct {
 		name     string
 		serveErr error
@@ -896,10 +924,10 @@ func TestSoloStart_DoesNotReturnAnInstanceForAHubThatDiedDuringBringUp(t *testin
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := startFailureEnv(t)
-			kill := serveUntilKilled(t, tt.serveErr)
+			kill := serveUntilKilled(t, d, tt.serveErr)
 
 			entered := make(chan struct{})
-			stubWorkerBringUp(t, func(ctx context.Context) error {
+			d.stubWorkerBringUp(func(ctx context.Context) error {
 				close(entered)
 				<-ctx.Done()
 				// Bring-up SUCCEEDED -- from a window in which the Hub had already
@@ -908,7 +936,7 @@ func TestSoloStart_DoesNotReturnAnInstanceForAHubThatDiedDuringBringUp(t *testin
 				return nil
 			})
 
-			inst, err := startWhileHubDies(t, cfg, entered, kill)
+			inst, err := startWhileHubDies(t, d, cfg, entered, kill)
 
 			require.Error(t, err, "a dead Hub must not be reported as a successful launch")
 			require.Nil(t, inst)
@@ -935,9 +963,10 @@ func TestSoloStart_DoesNotReturnAnInstanceForAHubThatDiedDuringBringUp(t *testin
 // hub.Server up.
 func TestHubServe_ACancelDuringItsOwnStartupIsACleanExit(t *testing.T) {
 	cfg := startFailureEnv(t)
+	d := newTestDeps()
 
 	served := make(chan error, 1)
-	stubServeHub(t, func(ctx context.Context, s *hub.Server) error {
+	d.stubServeHub(func(ctx context.Context, s *hub.Server) error {
 		// Already cancelled, so Serve fails inside SeedCursor deterministically
 		// rather than racing it. The real Serve still unwinds there, releasing
 		// what NewServer acquired.
@@ -950,7 +979,7 @@ func TestHubServe_ACancelDuringItsOwnStartupIsACleanExit(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), soloTestTimeout)
 	defer cancel()
-	inst, _ := Start(ctx, cfg)
+	inst, _ := start(ctx, cfg, d.deps)
 	// Whether Start notices is deliberately NOT asserted: a clean exit is exactly
 	// what its gates cannot distinguish from a Hub still coming up, and Serve's
 	// unwind can outlast the whole launch. Start's own doc says as much -- the
@@ -975,6 +1004,7 @@ func TestHubServe_ACancelDuringItsOwnStartupIsACleanExit(t *testing.T) {
 // SUCCEED and leave a poller behind rather than fail.
 func TestSoloStart_DevModeDefersWorkerRegistrationUntilAnAdminExists(t *testing.T) {
 	cfg := soloStartEnv(t, true)
+	d := newTestDeps()
 	// A real Serve, whose terminal error is a SENTINEL rather than nil: Stop must
 	// hand back exactly the Hub's error, and pinning it to nil would make the
 	// assertion below hold no matter what Stop did. It also keeps the Hub's own
@@ -982,10 +1012,10 @@ func TestSoloStart_DevModeDefersWorkerRegistrationUntilAnAdminExists(t *testing.
 	// enough that Stop's cancel can land inside SeedCursor and surface as a SQLite
 	// "interrupted", a race that has nothing to do with the arm under test.
 	wantStopErr := errors.New("lease release failed")
-	serveUntilKilled(t, wantStopErr)
+	serveUntilKilled(t, d, wantStopErr)
 	// Re-entrant: the poller calls this again on every tick.
 	var bringUps atomic.Int32
-	stubWorkerBringUp(t, func(context.Context) error {
+	d.stubWorkerBringUp(func(context.Context) error {
 		bringUps.Add(1)
 		return errNoAdminYet
 	})
@@ -995,7 +1025,7 @@ func TestSoloStart_DevModeDefersWorkerRegistrationUntilAnAdminExists(t *testing.
 	out := testutil.CaptureStderr(t, func() {
 		ctx, cancel := context.WithTimeout(context.Background(), soloTestTimeout)
 		defer cancel()
-		inst, err = Start(ctx, cfg)
+		inst, err = start(ctx, cfg, d.deps)
 	})
 	// Unconditional, and BEFORE the requires below: workerCtx is detached from the
 	// caller's, so nothing but Stop ever cancels the poller. A require that fired
@@ -1028,11 +1058,12 @@ func TestSoloStart_DevModeDefersWorkerRegistrationUntilAnAdminExists(t *testing.
 // already gone.
 func TestSoloStart_DoesNotDeferWorkerSetupOntoAHubThatDied(t *testing.T) {
 	cfg := soloStartEnv(t, true)
+	d := newTestDeps()
 	wantErr := errors.New("revocation watcher seed failed")
-	kill := serveUntilKilled(t, wantErr)
+	kill := serveUntilKilled(t, d, wantErr)
 
 	entered := make(chan struct{})
-	stubWorkerBringUp(t, func(ctx context.Context) error {
+	d.stubWorkerBringUp(func(ctx context.Context) error {
 		close(entered)
 		<-ctx.Done()
 		// The arm that would defer, if the gate let it get that far.
@@ -1042,7 +1073,7 @@ func TestSoloStart_DoesNotDeferWorkerSetupOntoAHubThatDied(t *testing.T) {
 	var inst *Instance
 	var err error
 	out := testutil.CaptureStderr(t, func() {
-		inst, err = startWhileHubDies(t, cfg, entered, kill)
+		inst, err = startWhileHubDies(t, d, cfg, entered, kill)
 	})
 
 	require.Error(t, err)
@@ -1063,15 +1094,16 @@ func TestSoloStart_DoesNotDeferWorkerSetupOntoAHubThatDied(t *testing.T) {
 // answered nil here and let the switch blame the Worker for a Ctrl-C.
 func TestSoloStart_ACallerCancelDuringBringUpIsNotBlamedOnTheWorker(t *testing.T) {
 	cfg := soloStartEnv(t, false)
+	d := newTestDeps()
 	// A real, LIVE Hub for the whole test: the point is that the Hub is healthy
 	// and the startup still has to end.
-	serveUntilKilled(t, nil)
+	serveUntilKilled(t, d, nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), soloTestTimeout)
 	t.Cleanup(cancel)
 
 	entered := make(chan struct{})
-	stubWorkerBringUp(t, func(bringUpCtx context.Context) error {
+	d.stubWorkerBringUp(func(bringUpCtx context.Context) error {
 		close(entered)
 		// Returns only once the watcher has cancelled workerCtx in response to the
 		// caller's cancel -- the exact shape bringUpLocalWorker produces when a
@@ -1080,7 +1112,7 @@ func TestSoloStart_ACallerCancelDuringBringUpIsNotBlamedOnTheWorker(t *testing.T
 		return fmt.Errorf("create worker: %w", bringUpCtx.Err())
 	})
 
-	inst, err := startUntilTornDown(t, ctx, cfg, entered, cancel)
+	inst, err := startUntilTornDown(t, ctx, d, cfg, entered, cancel)
 
 	require.Error(t, err)
 	require.Nil(t, inst)
@@ -1096,17 +1128,18 @@ func TestSoloStart_ACallerCancelDuringBringUpIsNotBlamedOnTheWorker(t *testing.T
 // watcher is deliberately silent. It has to ride out with the cause.
 func TestSoloStart_ReportsACleanupFailureFromTheTeardownItTriggered(t *testing.T) {
 	cfg := soloStartEnv(t, false)
+	d := newTestDeps()
 	// The shape of a real teardown cleanup failure: Serve returns non-nil after an
 	// ordinary, requested shutdown -- here the one failStartup's join asks for.
 	leaseErr := errors.New("release runtime lease failed")
-	serveUntilKilled(t, leaseErr)
+	serveUntilKilled(t, d, leaseErr)
 
 	bringUpErr := errors.New("generate composite keypair: no entropy")
-	stubWorkerBringUp(t, func(context.Context) error { return bringUpErr })
+	d.stubWorkerBringUp(func(context.Context) error { return bringUpErr })
 
 	ctx, cancel := context.WithTimeout(context.Background(), soloTestTimeout)
 	defer cancel()
-	inst, err := Start(ctx, cfg)
+	inst, err := start(ctx, cfg, d.deps)
 
 	require.Error(t, err)
 	require.Nil(t, inst)
@@ -1121,15 +1154,16 @@ func TestSoloStart_ReportsACleanupFailureFromTheTeardownItTriggered(t *testing.T
 // the Worker's real failure under it.
 func TestSoloStart_DoesNotReportTheCancellationItsOwnTeardownCaused(t *testing.T) {
 	cfg := soloStartEnv(t, false)
+	d := newTestDeps()
 	// No serveHub stub: the REAL Serve, whose startup (seeding the revocation
 	// cursor) is still in flight when the join cancels it, and which therefore
 	// returns a context.Canceled-rooted error on a perfectly ordinary teardown.
 	bringUpErr := errors.New("generate composite keypair: no entropy")
-	stubWorkerBringUp(t, func(context.Context) error { return bringUpErr })
+	d.stubWorkerBringUp(func(context.Context) error { return bringUpErr })
 
 	ctx, cancel := context.WithTimeout(context.Background(), soloTestTimeout)
 	defer cancel()
-	inst, err := Start(ctx, cfg)
+	inst, err := start(ctx, cfg, d.deps)
 
 	require.Error(t, err)
 	require.Nil(t, inst)
@@ -1145,12 +1179,13 @@ func TestSoloStart_DoesNotReportTheCancellationItsOwnTeardownCaused(t *testing.T
 // watcher stays silent to avoid.
 func TestSoloStart_TheDeferredPollerStaysQuietWhenTheTeardownCancelsIt(t *testing.T) {
 	cfg := soloStartEnv(t, true)
-	serveUntilKilled(t, nil)
+	d := newTestDeps()
+	serveUntilKilled(t, d, nil)
 
 	// First call defers (no admin yet); every later call is the poller's, and it
 	// parks until the teardown cancels it -- the window the guard covers.
 	var calls atomic.Int32
-	stubWorkerBringUp(t, func(ctx context.Context) error {
+	d.stubWorkerBringUp(func(ctx context.Context) error {
 		if calls.Add(1) == 1 {
 			return errNoAdminYet
 		}
@@ -1167,7 +1202,7 @@ func TestSoloStart_TheDeferredPollerStaysQuietWhenTheTeardownCancelsIt(t *testin
 	out := testutil.CaptureStderr(t, func() {
 		ctx, cancel := context.WithTimeout(context.Background(), soloTestTimeout)
 		defer cancel()
-		inst, err = Start(ctx, cfg)
+		inst, err = start(ctx, cfg, d.deps)
 		require.NoError(t, err)
 		require.NotNil(t, inst)
 		// Wait for the poller to be parked inside setupWorker, so Stop's cancel
@@ -1190,24 +1225,24 @@ func TestSoloStart_TheDeferredPollerStaysQuietWhenTheTeardownCancelsIt(t *testin
 // panic the counter.
 func TestSoloStart_TearsDownARealWorkerLaunchedJustBeforeTheHubDied(t *testing.T) {
 	cfg := soloStartEnv(t, false)
+	d := newTestDeps()
 	wantErr := errors.New("revocation watcher seed failed")
-	kill := serveUntilKilled(t, wantErr)
+	kill := serveUntilKilled(t, d, wantErr)
 
 	entered := make(chan struct{})
-	prev := bringUpWorker
-	bringUpWorker = func(ctx context.Context, p workerBringUp) error {
+	real := d.bringUpWorker
+	d.bringUpWorker = func(ctx context.Context, p workerBringUp) error {
 		// The REAL implementation, so the Worker goroutine and its own token pair
 		// exist; then hold Start inside the window until the Hub is gone.
-		if err := prev(ctx, p); err != nil {
+		if err := real(ctx, p); err != nil {
 			return err
 		}
 		close(entered)
 		<-ctx.Done()
 		return nil
 	}
-	t.Cleanup(func() { bringUpWorker = prev })
 
-	inst, err := startWhileHubDies(t, cfg, entered, kill)
+	inst, err := startWhileHubDies(t, d, cfg, entered, kill)
 
 	// Reaching here at all is half the assertion: failStartup's join waits out the
 	// real worker.Run unwind, so a mislaid token would hang the test rather than
@@ -1222,6 +1257,7 @@ func TestSoloStart_TearsDownARealWorkerLaunchedJustBeforeTheHubDied(t *testing.T
 // default arm: with the Hub still serving, a bring-up failure is still the
 // Worker's, reported with the Worker's attribution.
 func TestSoloStart_AWorkerBringUpFailureIsStillTheWorkers(t *testing.T) {
+	d := newTestDeps()
 	tests := []struct {
 		name       string
 		bringUpErr error
@@ -1239,12 +1275,12 @@ func TestSoloStart_AWorkerBringUpFailureIsStillTheWorkers(t *testing.T) {
 			// Hub's own error unpinned would let a spontaneous startup failure in
 			// this window flip the assertion below into a false red.
 			cfg := startFailureEnv(t)
-			serveUntilKilled(t, nil)
-			stubWorkerBringUp(t, func(context.Context) error { return tt.bringUpErr })
+			serveUntilKilled(t, d, nil)
+			d.stubWorkerBringUp(func(context.Context) error { return tt.bringUpErr })
 
 			ctx, cancel := context.WithTimeout(context.Background(), soloTestTimeout)
 			defer cancel()
-			inst, err := Start(ctx, cfg)
+			inst, err := start(ctx, cfg, d.deps)
 
 			require.Error(t, err)
 			require.Nil(t, inst)

--- a/backend/solo/solo_test.go
+++ b/backend/solo/solo_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -18,23 +19,67 @@ import (
 	"github.com/leapmux/leapmux/hub"
 	hubconfig "github.com/leapmux/leapmux/internal/hub/config"
 	"github.com/leapmux/leapmux/internal/hub/store"
+	"github.com/leapmux/leapmux/internal/logging"
 	"github.com/leapmux/leapmux/internal/util/testutil"
 	"github.com/leapmux/leapmux/locallisten/locallistentest"
-	"github.com/leapmux/leapmux/util/drain"
 )
 
-// soloLoadOptions builds the options Start would pass, with the config file
-// pointed at a path that does not exist so a real one on the developer's machine
-// cannot reach the assertions.
-func soloLoadOptions(t *testing.T, devMode bool) hubconfig.LoadOptions {
+// testLoadOptions builds the options Start would pass, through the PRODUCTION
+// derivation, with the config file pointed at a path that does not exist so a real
+// one on the developer's machine cannot reach the assertions.
+//
+// It delegates rather than restating the option construction: a hand-rolled copy
+// is what let the CLI's flag list drift out from under these very assertions.
+func testLoadOptions(t *testing.T, devMode bool) hubconfig.LoadOptions {
 	t.Helper()
-	return hubconfig.LoadOptions{
-		CLIFlags:          defaultCLIFlags(devMode),
-		ExtraFlags:        defaultExtraFlags(),
-		DefaultConfigDir:  t.TempDir(),
-		DefaultConfigFile: filepath.Join(t.TempDir(), "absent.yaml"),
-		SoloMode:          !devMode,
-	}
+	opts, _ := soloLoadOptions(Config{
+		DevMode:    devMode,
+		ConfigDir:  t.TempDir(),
+		ConfigFile: filepath.Join(t.TempDir(), "absent.yaml"),
+	})
+	return opts
+}
+
+// soloLoadOptions is the single source of truth for what `leapmux solo` and
+// `leapmux dev` default to. It became one because the CLI carried a second copy
+// that drifted until --max-connections-per-user stopped parsing; a table test is
+// what makes the next drift a red build instead of a support question.
+func TestSoloLoadOptionsDerivesEachModesDefaults(t *testing.T) {
+	t.Parallel()
+
+	solo, soloMode := soloLoadOptions(Config{})
+	assert.Equal(t, "solo", soloMode)
+	assert.Equal(t, "127.0.0.1:4327", solo.DefaultListen, "solo binds loopback only")
+	assert.Equal(t, "~/.config/leapmux/solo", solo.DefaultConfigDir)
+	assert.Equal(t, "~/.config/leapmux/solo/solo.yaml", solo.DefaultConfigFile)
+	assert.Equal(t, "leapmux solo", solo.FlagSetName)
+	assert.True(t, solo.SoloMode, "solo mode injects the soloUser; dev does not")
+
+	dev, devMode := soloLoadOptions(Config{DevMode: true})
+	assert.Equal(t, "dev", devMode)
+	assert.Equal(t, ":4327", dev.DefaultListen, "dev serves a frontend from another origin")
+	assert.Equal(t, "~/.config/leapmux/dev/dev.yaml", dev.DefaultConfigFile)
+	assert.False(t, dev.SoloMode)
+
+	// The lists the CLI used to duplicate. Asserting them HERE is what makes the
+	// binary and the library provably the same, now that runSolo passes neither.
+	assert.Equal(t, defaultCLIFlags(false), solo.CLIFlags)
+	assert.Equal(t, defaultCLIFlags(true), dev.CLIFlags)
+	assert.Equal(t, defaultExtraFlags(), solo.ExtraFlags)
+
+	// An explicit Config still wins over every derived default.
+	custom, _ := soloLoadOptions(Config{
+		Listen:     "0.0.0.0:9999",
+		ConfigDir:  "/tmp/cd",
+		ConfigFile: "/tmp/cf.yaml",
+		CLIFlags:   []string{"listen"},
+		ExtraFlags: []hubconfig.ExtraFlagDef{},
+	})
+	assert.Equal(t, "0.0.0.0:9999", custom.DefaultListen)
+	assert.Equal(t, "/tmp/cd", custom.DefaultConfigDir)
+	assert.Equal(t, "/tmp/cf.yaml", custom.DefaultConfigFile)
+	assert.Equal(t, []string{"listen"}, custom.CLIFlags)
+	assert.Empty(t, custom.ExtraFlags, "an explicit empty list is not 'unset'")
 }
 
 // TestSoloExposesThePerUserCapsOnTheCommandLine pins the two knobs a solo user can
@@ -51,7 +96,7 @@ func TestSoloExposesThePerUserCapsOnTheCommandLine(t *testing.T) {
 
 	cfg, _, err := hubconfig.LoadWithOptions(
 		[]string{"--max-connections-per-user=64", "--max-workers-per-user=8"},
-		soloLoadOptions(t, false))
+		testLoadOptions(t, false))
 	require.NoError(t, err, "solo must accept the per-user caps as CLI flags")
 	assert.Equal(t, int64(64), cfg.MaxConnectionsPerUser)
 	assert.Equal(t, int64(8), cfg.MaxWorkersPerUser)
@@ -69,14 +114,14 @@ func TestSoloKeepsTheQueueBudgetsOutOfHelpButReachableInConfig(t *testing.T) {
 		"the budgets auto-size off this machine; they do not belong in solo's --help")
 
 	_, _, err := hubconfig.LoadWithOptions(
-		[]string{"--relay-queue-memory-budget=268435456"}, soloLoadOptions(t, false))
+		[]string{"--relay-queue-memory-budget=268435456"}, testLoadOptions(t, false))
 	require.Error(t, err, "a flag outside the allowlist must not parse")
 
 	path := filepath.Join(t.TempDir(), "config.yaml")
 	require.NoError(t, os.WriteFile(path,
 		[]byte("relay_queue_memory_budget: 268435456\n"), 0o600))
 
-	opts := soloLoadOptions(t, false)
+	opts := testLoadOptions(t, false)
 	opts.DefaultConfigFile = path
 	cfg, _, err := hubconfig.LoadWithOptions(nil, opts)
 	require.NoError(t, err)
@@ -228,6 +273,42 @@ func TestInstanceShutdown_StopsTheHubWhenTheWorkerWillNotDrain(t *testing.T) {
 		"a worker that never reports draining must not keep the hub up past the backstop")
 }
 
+// The backstop warning can fire with NO Worker in existence: Start holds a
+// workerDrained token across bring-up, and the dev-mode poller holds one for its
+// whole life, both covering a window in which no worker.Run has been launched.
+// Naming the Worker there sends the reader hunting a goroutine never created.
+func TestInstanceShutdown_DoesNotBlameAWorkerThatNeverExisted(t *testing.T) {
+	orig := workerDrainTimeout
+	workerDrainTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { workerDrainTimeout = orig })
+
+	hubDone := make(chan struct{})
+	close(hubDone)
+	inst := &Instance{
+		cancelWorker: func() {},
+		cancelHub:    func() {},
+		hubDone:      hubDone,
+	}
+	// Exactly the token Start carries across setupWorker -- and nothing else, so
+	// the backstop expires with no Worker goroutine to attribute it to.
+	inst.workerDrained.Add()
+
+	// logging.Setup INSIDE the capture: it binds a fresh handler to os.Stderr at
+	// call time, and the package-init default still points at the real one, so a
+	// capture without it reads empty -- and every assertion on it passes
+	// vacuously.
+	logs := testutil.CaptureStderr(t, func() {
+		logging.Setup()
+		inst.shutdown()
+	})
+
+	assert.Contains(t, logs, "did not finish before the hub shutdown deadline",
+		"the backstop must still report that it gave up")
+	assert.NotContains(t, logs, "worker did not report draining",
+		"no Worker exists here; blaming one sends the reader after a goroutine "+
+			"that was never launched; captured:\n"+logs)
+}
+
 func TestInstanceShutdown_IsIdempotent(t *testing.T) {
 	hubDone := make(chan struct{})
 	close(hubDone)
@@ -310,6 +391,45 @@ func TestParseIntReadsTheStringTypedExtras(t *testing.T) {
 // reaches this budget has already failed.
 const soloTestTimeout = 60 * time.Second
 
+// serveFailsImmediately stubs serveHub with a Serve that returns serveErr at once
+// -- but still RUNS s.Serve, against an already-cancelled context, so it unwinds
+// and releases what NewServer acquired.
+//
+// Returning without calling Serve at all is the obvious spelling and the wrong
+// one: hub.NewServer has already bound both listeners, opened the store and
+// loaded the keystore, and hub.Server exposes no Close, so only Serve's unwind
+// gives them back. Every such test leaked an open SQLite pool and a bound socket
+// or pipe handle for the life of the test binary, which on Windows also defeats
+// the sandbox temp-dir cleanup.
+func serveFailsImmediately(t *testing.T, serveErr error) {
+	t.Helper()
+	var releasing atomic.Bool
+	released := make(chan struct{})
+	stubServeHub(t, func(ctx context.Context, s *hub.Server) error {
+		dead, cancel := context.WithCancel(ctx)
+		cancel()
+		// On the SIDE, so this stub still returns at once: the tests that use it
+		// need hubDone closed before Start reaches its readiness verdict, and
+		// Serve's unwind is not instant.
+		releasing.Store(true)
+		go func() {
+			defer close(released)
+			_ = s.Serve(dead)
+		}()
+		return serveErr
+	})
+	t.Cleanup(func() {
+		if !releasing.Load() {
+			return // Serve was never reached; nothing was acquired past NewServer.
+		}
+		select {
+		case <-released:
+		case <-time.After(soloTestTimeout):
+			t.Error("the hub never finished releasing its listeners and store")
+		}
+	})
+}
+
 // stubServeHub swaps the Hub-serving seam for the duration of the test.
 func stubServeHub(t *testing.T, fn func(context.Context, *hub.Server) error) {
 	t.Helper()
@@ -318,16 +438,13 @@ func stubServeHub(t *testing.T, fn func(context.Context, *hub.Server) error) {
 	t.Cleanup(func() { serveHub = prev })
 }
 
-// stubWorkerBringUp swaps the Worker bring-up seam, absorbing the seven
-// production-wiring parameters so each test states only what it does with the
-// context and what it reports.
+// stubWorkerBringUp swaps the Worker bring-up seam, discarding the production
+// wiring so each test states only what it does with the context and what it
+// reports.
 func stubWorkerBringUp(t *testing.T, fn func(context.Context) error) {
 	t.Helper()
 	prev := bringUpWorker
-	bringUpWorker = func(ctx context.Context, _, _ *drain.Counter, _ *hub.Server,
-		_, _ string, _ *hubconfig.Config, _, _ string) error {
-		return fn(ctx)
-	}
+	bringUpWorker = func(ctx context.Context, _ workerBringUp) error { return fn(ctx) }
 	t.Cleanup(func() { bringUpWorker = prev })
 }
 
@@ -339,11 +456,18 @@ func stubWorkerBringUp(t *testing.T, fn func(context.Context) error) {
 // afterwards. A stub that failed immediately could not distinguish "the gate saw
 // a dead Hub" from "the gate was never reached".
 //
+// It FAILS THE TEST if Serve returned before kill() -- pinning serveErr would
+// otherwise hide a Hub that never served behind exactly the error the test
+// expects, which is the trap serveHub exists to close (see its doc: two tests
+// once passed on a NewServer failure instead). A cleanup-time check rather than
+// an inline one, because Serve returns on its own goroutine.
+//
 // kill is idempotent and never blocks, and t.Cleanup calls it, so a failed
 // assertion cannot leave a Hub serving behind the test.
 func serveUntilKilled(t *testing.T, serveErr error) (kill func()) {
 	t.Helper()
 	killed := make(chan struct{})
+	var servedEarly atomic.Pointer[error]
 	stubServeHub(t, func(ctx context.Context, s *hub.Server) error {
 		inner, cancel := context.WithCancel(ctx)
 		defer cancel()
@@ -355,30 +479,84 @@ func serveUntilKilled(t *testing.T, serveErr error) (kill func()) {
 				// Serve stopped on its own (or the Hub was cancelled); nothing to do.
 			}
 		}()
-		_ = s.Serve(inner)
+		realErr := s.Serve(inner)
+		select {
+		case <-killed:
+		default:
+			// ctx is hubCtx: once it is cancelled somebody legitimately asked the
+			// Hub to stop (Stop, or a failure arm's join), which ends Serve just as
+			// kill() would. Only a Serve that returned while nobody had asked means
+			// the Hub was never really up.
+			//
+			// Records rather than fails: t.Error/t.Fatal from a non-test goroutine
+			// is not safe, and this one is Start's Hub goroutine.
+			if ctx.Err() == nil {
+				servedEarly.Store(&realErr)
+			}
+		}
 		return serveErr
 	})
 	var once sync.Once
 	kill = func() { once.Do(func() { close(killed) }) }
-	t.Cleanup(kill)
+	t.Cleanup(func() {
+		kill()
+		if early := servedEarly.Load(); early != nil {
+			t.Errorf("the hub stopped serving before the test killed it, so this test "+
+				"proved nothing about a Hub that was up; Serve returned: %v", *early)
+		}
+	})
 	return kill
 }
 
-// awaitBringUp blocks until Start has entered the bring-up seam.
+// startWhileHubDies runs Start in a goroutine, waits until it has entered the
+// bring-up seam, then ends the Hub with endHub and returns what Start reported.
 //
-// Its two failure arms are diagnostics, not assertions: done closing first means
-// Start ran the REAL bring-up (the seam is not wired), and the budget expiring
-// means Start never got there at all. Both would otherwise present as a test that
-// hangs until the package deadline.
-func awaitBringUp(t *testing.T, entered, done <-chan struct{}) {
+// It owns the goroutine so no caller can leak one. That matters more than the
+// deduplication: a leaked Start keeps reading the serveHub/bringUpWorker package
+// vars, which stubServeHub's and stubWorkerBringUp's cleanups WRITE at teardown,
+// and -- since none of these tests are parallel -- it can still be running when
+// the next test re-stubs them. Under -race that surfaces as a data race on the
+// globals, masking whatever regression was actually being diagnosed. So even the
+// two diagnostic arms below join before failing.
+//
+// Those arms are diagnostics, not assertions: done closing first means Start ran
+// the REAL bring-up (the seam is not wired), and the budget expiring means Start
+// never got there at all. Both would otherwise present as a test that hangs until
+// the package deadline.
+func startWhileHubDies(t *testing.T, cfg Config, entered <-chan struct{}, endHub func()) (*Instance, error) {
 	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), soloTestTimeout)
+	t.Cleanup(cancel)
+	return startUntilTornDown(t, ctx, cfg, entered, endHub)
+}
+
+// startUntilTornDown is startWhileHubDies with the caller's context under the
+// test's control, for the OTHER way a startup ends: the caller cancelling.
+func startUntilTornDown(t *testing.T, ctx context.Context, cfg Config, entered <-chan struct{}, tearDown func()) (*Instance, error) {
+	t.Helper()
+	var inst *Instance
+	var err error
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		inst, err = Start(ctx, cfg)
+	}()
+
 	select {
 	case <-entered:
 	case <-done:
 		t.Fatal("Start finished without reaching bring-up (is the seam wired?)")
 	case <-time.After(soloTestTimeout):
+		// tearDown unblocks a Start parked anywhere past the Hub goroutine, so the
+		// join below terminates instead of hanging out the package deadline.
+		tearDown()
+		<-done
 		t.Fatal("Start never reached bring-up")
 	}
+
+	tearDown()
+	<-done
+	return inst, err
 }
 
 // startFailureEnv points Start at a throwaway home with no TCP listener, so it
@@ -395,27 +573,25 @@ func awaitBringUp(t *testing.T, entered, done <-chan struct{}) {
 // while passing on a developer's Unix machine.
 func startFailureEnv(t *testing.T) Config {
 	t.Helper()
+	return soloStartEnv(t, false)
+}
+
+// soloStartEnv builds that environment for either mode. devMode is where the
+// deferral arm lives: dev uses real password auth rather than solo's injected
+// soloUser, so on a fresh install there is no admin for the Worker to register
+// under until somebody completes /setup.
+func soloStartEnv(t *testing.T, devMode bool) Config {
+	t.Helper()
 	locallistentest.SandboxHome(t)
 	return Config{
 		SkipBanner: true,
 		NoTCP:      true,
+		DevMode:    devMode,
 		// local-listen is not in solo's own --help allowlist, so the test has to
 		// widen it to reach the flag.
-		CLIFlags: append(defaultCLIFlags(false), "local-listen"),
+		CLIFlags: append(defaultCLIFlags(devMode), "local-listen"),
 		Args:     []string{"--local-listen=" + locallistentest.UniqueListenURL(t, "leapmux-hub-solo")},
 	}
-}
-
-// devStartFailureEnv is startFailureEnv in DEV mode, which is where the
-// deferral arm lives: dev uses real password auth rather than solo's injected
-// soloUser, so on a fresh install there is no admin for the Worker to register
-// under until somebody completes /setup.
-func devStartFailureEnv(t *testing.T) Config {
-	t.Helper()
-	cfg := startFailureEnv(t)
-	cfg.DevMode = true
-	cfg.CLIFlags = append(defaultCLIFlags(true), "local-listen")
-	return cfg
 }
 
 // A Hub that dies WHILE SERVING is surfaced by Start with the "hub serve:"
@@ -428,17 +604,18 @@ func devStartFailureEnv(t *testing.T) Config {
 func TestSoloStart_SurfacesAServeTimeFailure(t *testing.T) {
 	cfg := startFailureEnv(t)
 	wantErr := errors.New("revocation watcher seed failed")
-	stubServeHub(t, func(context.Context, *hub.Server) error { return wantErr })
+	serveFailsImmediately(t, wantErr)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), soloTestTimeout)
 	defer cancel()
 	inst, err := Start(ctx, cfg)
 
 	require.Error(t, err)
 	require.Nil(t, inst)
 	assert.ErrorIs(t, err, wantErr)
-	assert.True(t, strings.HasPrefix(err.Error(), "hub serve:"),
-		"the Serve arm must attribute the failure, not merely mention it; got: "+err.Error())
+	assert.True(t, strings.HasPrefix(err.Error(), "hub serve exited "),
+		"the Serve arm must attribute the failure and name the stage that saw it, "+
+			"not merely mention it; got: "+err.Error())
 }
 
 // A Hub that dies on its way up has exactly ONE reporter: Start, which RETURNS
@@ -446,16 +623,14 @@ func TestSoloStart_SurfacesAServeTimeFailure(t *testing.T) {
 // every failed launch is reported twice.
 func TestSoloStart_DoesNotAlsoLogAServeTimeFailure(t *testing.T) {
 	cfg := startFailureEnv(t)
-	stubServeHub(t, func(context.Context, *hub.Server) error {
-		return errors.New("revocation watcher seed failed")
-	})
+	serveFailsImmediately(t, errors.New("revocation watcher seed failed"))
 
 	// Stderr, not slog.Default(): Start's own logging.Setup installs a fresh
 	// default logger, so a captured handler would be replaced before the line
 	// under test could reach it and this would assert on an empty buffer.
 	var err error
 	out := testutil.CaptureStderr(t, func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), soloTestTimeout)
 		defer cancel()
 		_, err = Start(ctx, cfg)
 	})
@@ -486,7 +661,7 @@ func TestSolo_AHubThatDiesWhileServingTearsTheInstanceDownWithoutReporting(t *te
 
 	var inst *Instance
 	out := testutil.CaptureStderr(t, func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), soloTestTimeout)
 		defer cancel()
 		var err error
 		inst, err = Start(ctx, cfg)
@@ -522,7 +697,7 @@ func TestSolo_AStopRequestedHubErrorIsReportedOnlyByStop(t *testing.T) {
 
 	var stopErr error
 	out := testutil.CaptureStderr(t, func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), soloTestTimeout)
 		defer cancel()
 		inst, err := Start(ctx, cfg)
 		require.NoError(t, err)
@@ -534,7 +709,7 @@ func TestSolo_AStopRequestedHubErrorIsReportedOnlyByStop(t *testing.T) {
 		"an exit Stop asked for must not also be logged; captured:\n"+out)
 }
 
-// hubFailure is the ONE predicate Start asks at every stage boundary, so an
+// startupFailure is the ONE predicate Start asks at every stage boundary, so an
 // exited Hub outranks whatever that stage happened to observe. The property
 // under test is TOTALITY: once hubDone is closed it never returns nil. The
 // readiness select leans on that -- its hubDone arm carries no error of its own
@@ -560,7 +735,7 @@ func TestHubFailure_AnExitedHubOutranksWhateverTheStageSaw(t *testing.T) {
 	tests := []struct {
 		name string
 		// The literals are bare on purpose, like TestInstanceStopReturnsHubError's:
-		// hubFailure must be safe on the zero-value Instance every shutdown trigger
+		// startupFailure must be safe on the zero-value Instance every shutdown trigger
 		// can reach.
 		inst    *Instance
 		ctx     context.Context
@@ -588,7 +763,7 @@ func TestHubFailure_AnExitedHubOutranksWhateverTheStageSaw(t *testing.T) {
 			name:   "an exited hub reports its own error",
 			inst:   &Instance{hubDone: closedChan(), hubErr: hubErr},
 			ctx:    context.Background(),
-			want:   "hub serve: revocation watcher seed failed",
+			want:   "hub serve exited while the worker was starting: revocation watcher seed failed",
 			wantIs: hubErr,
 		},
 		{
@@ -608,16 +783,28 @@ func TestHubFailure_AnExitedHubOutranksWhateverTheStageSaw(t *testing.T) {
 			want:   "hub shut down while the worker was starting: context canceled",
 			wantIs: context.Canceled,
 		},
+		{
+			// The OTHER watcher trigger, and the half that used to be unreachable:
+			// the caller cancelled, the watcher already cancelled workerCtx, and the
+			// Hub is still serving because shutdown parks in workerDrained.Wait
+			// before it ever reaches cancelHub. Answering nil here is what let the
+			// Worker be blamed for the caller's Ctrl-C.
+			name:   "a cancelled caller is reported even while the hub still serves",
+			inst:   &Instance{hubDone: make(chan struct{})},
+			ctx:    cancelledCtx,
+			want:   "solo startup cancelled while the worker was starting: context canceled",
+			wantIs: context.Canceled,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := tt.inst.hubFailure(tt.ctx, "while the worker was starting")
+			got := tt.inst.startupFailure(tt.ctx, "while the worker was starting")
 			if tt.wantNil {
 				assert.NoError(t, got)
 				return
 			}
-			require.Error(t, got, "hubFailure must be total once hubDone is closed")
+			require.Error(t, got, "startupFailure must be total once hubDone is closed")
 			assert.Equal(t, tt.want, got.Error())
 			if tt.wantIs != nil {
 				assert.ErrorIs(t, got, tt.wantIs)
@@ -640,7 +827,7 @@ func TestHubFailure_AnExitedHubOutranksWhateverTheStageSaw(t *testing.T) {
 func TestSoloStart_DoesNotBringTheWorkerUpAgainstAHubThatAlreadyExited(t *testing.T) {
 	cfg := startFailureEnv(t)
 	wantErr := errors.New("revocation watcher seed failed")
-	stubServeHub(t, func(context.Context, *hub.Server) error { return wantErr })
+	serveFailsImmediately(t, wantErr)
 
 	var broughtUp atomic.Bool
 	stubWorkerBringUp(t, func(context.Context) error {
@@ -679,25 +866,13 @@ func TestSoloStart_AHubThatDiesDuringBringUpIsNotBlamedOnTheWorker(t *testing.T)
 		return fmt.Errorf("create worker: %w", ctx.Err())
 	})
 
-	var inst *Instance
-	var err error
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		ctx, cancel := context.WithTimeout(context.Background(), soloTestTimeout)
-		defer cancel()
-		inst, err = Start(ctx, cfg)
-	}()
-
-	awaitBringUp(t, entered, done)
-	kill()
-	<-done
+	inst, err := startWhileHubDies(t, cfg, entered, kill)
 
 	require.Error(t, err)
 	require.Nil(t, inst)
 	assert.ErrorIs(t, err, wantErr)
-	assert.True(t, strings.HasPrefix(err.Error(), "hub serve:"),
-		"the Hub's death must be attributed to the Hub; got: "+err.Error())
+	assert.True(t, strings.HasPrefix(err.Error(), "hub serve exited while the worker was starting:"),
+		"the Hub's death must be attributed to the Hub, at the stage that saw it; got: "+err.Error())
 	assert.NotContains(t, err.Error(), "auto-register worker",
 		"the Worker only failed because the Hub did; got: "+err.Error())
 }
@@ -733,25 +908,13 @@ func TestSoloStart_DoesNotReturnAnInstanceForAHubThatDiedDuringBringUp(t *testin
 				return nil
 			})
 
-			var inst *Instance
-			var err error
-			done := make(chan struct{})
-			go func() {
-				defer close(done)
-				ctx, cancel := context.WithTimeout(context.Background(), soloTestTimeout)
-				defer cancel()
-				inst, err = Start(ctx, cfg)
-			}()
-
-			awaitBringUp(t, entered, done)
-			kill()
-			<-done
+			inst, err := startWhileHubDies(t, cfg, entered, kill)
 
 			require.Error(t, err, "a dead Hub must not be reported as a successful launch")
 			require.Nil(t, inst)
 			if tt.serveErr != nil {
 				assert.ErrorIs(t, err, tt.serveErr)
-				assert.True(t, strings.HasPrefix(err.Error(), "hub serve:"),
+				assert.True(t, strings.HasPrefix(err.Error(), "hub serve exited while the worker was starting:"),
 					"got: "+err.Error())
 			} else {
 				assert.Equal(t, "hub serve exited while the worker was starting", err.Error())
@@ -760,19 +923,72 @@ func TestSoloStart_DoesNotReturnAnInstanceForAHubThatDiedDuringBringUp(t *testin
 	}
 }
 
+// A Serve cancelled while it is still STARTING is an exit somebody asked for.
+// hub.NewServer binds both listeners before Serve runs, so a caller's readiness
+// probe succeeds -- and its Stop can land -- while Serve is still seeding the
+// revocation cursor. Reporting that seed failure made `leapmux hub` and `leapmux
+// solo` exit non-zero on an ordinary Ctrl-C during startup, and the sqlite
+// spelling of it ("interrupted (9)") wraps no context error, so no downstream
+// errors.Is filter could have caught it either.
+//
+// solo is where this lives because it is the only package that stands a real
+// hub.Server up.
+func TestHubServe_ACancelDuringItsOwnStartupIsACleanExit(t *testing.T) {
+	cfg := startFailureEnv(t)
+
+	served := make(chan error, 1)
+	stubServeHub(t, func(ctx context.Context, s *hub.Server) error {
+		// Already cancelled, so Serve fails inside SeedCursor deterministically
+		// rather than racing it. The real Serve still unwinds there, releasing
+		// what NewServer acquired.
+		dead, cancel := context.WithCancel(ctx)
+		cancel()
+		err := s.Serve(dead)
+		served <- err
+		return err
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), soloTestTimeout)
+	defer cancel()
+	inst, _ := Start(ctx, cfg)
+	// Whether Start notices is deliberately NOT asserted: a clean exit is exactly
+	// what its gates cannot distinguish from a Hub still coming up, and Serve's
+	// unwind can outlast the whole launch. Start's own doc says as much -- the
+	// gates close the wide windows, not every window. The property under test is
+	// the Hub's, one layer down.
+	if inst != nil {
+		t.Cleanup(func() { _ = inst.Stop() })
+	}
+
+	select {
+	case serveErr := <-served:
+		assert.NoError(t, serveErr,
+			"a Serve cancelled during its own startup must report a clean exit, not a "+
+				"seed failure the user's Ctrl-C caused")
+	case <-time.After(soloTestTimeout):
+		t.Fatal("the hub goroutine never reported")
+	}
+}
+
 // The deferral arm, which had no coverage at all before the bring-up seam
 // existed: in dev mode a missing admin is what /setup is for, so the launch must
 // SUCCEED and leave a poller behind rather than fail.
 func TestSoloStart_DevModeDefersWorkerRegistrationUntilAnAdminExists(t *testing.T) {
-	cfg := devStartFailureEnv(t)
-	// A real Serve, but with its terminal error pinned to nil. With bring-up
-	// stubbed, Start returns fast enough that Stop's cancel can land inside the
-	// Hub's OWN startup -- seeding the revocation cursor, which surfaces as a
-	// SQLite "interrupted" -- and that race has nothing to do with the arm under
-	// test. Pinning it keeps the Stop assertion below about token accounting.
-	serveUntilKilled(t, nil)
+	cfg := soloStartEnv(t, true)
+	// A real Serve, whose terminal error is a SENTINEL rather than nil: Stop must
+	// hand back exactly the Hub's error, and pinning it to nil would make the
+	// assertion below hold no matter what Stop did. It also keeps the Hub's own
+	// startup out of the result -- with bring-up stubbed, Start returns fast
+	// enough that Stop's cancel can land inside SeedCursor and surface as a SQLite
+	// "interrupted", a race that has nothing to do with the arm under test.
+	wantStopErr := errors.New("lease release failed")
+	serveUntilKilled(t, wantStopErr)
 	// Re-entrant: the poller calls this again on every tick.
-	stubWorkerBringUp(t, func(context.Context) error { return store.ErrNotFound })
+	var bringUps atomic.Int32
+	stubWorkerBringUp(t, func(context.Context) error {
+		bringUps.Add(1)
+		return errNoAdminYet
+	})
 
 	var inst *Instance
 	var err error
@@ -781,16 +997,29 @@ func TestSoloStart_DevModeDefersWorkerRegistrationUntilAnAdminExists(t *testing.
 		defer cancel()
 		inst, err = Start(ctx, cfg)
 	})
+	// Unconditional, and BEFORE the requires below: workerCtx is detached from the
+	// caller's, so nothing but Stop ever cancels the poller. A require that fired
+	// first would leave it ticking against a deleted temp dir for the rest of the
+	// run, racing every later test's stub.
+	t.Cleanup(func() {
+		if inst != nil {
+			_ = inst.Stop()
+		}
+	})
 
 	require.NoError(t, err, "a missing admin defers the Worker; it does not fail the launch; captured:\n"+out)
 	require.NotNil(t, inst)
 	assert.Contains(t, out, "deferring worker auto-registration",
 		"the deferral is the user-visible half of this arm; captured:\n"+out)
-	// Stop is the token-accounting assertion: the deferral hands a second worker
-	// token pair to the poller while Start still holds its own, and an imbalance
-	// on either side either wedges the teardown or trips drain.Counter's
+	assert.Equal(t, int32(1), bringUps.Load(),
+		"the launch itself attempts bring-up exactly once; the retries are the poller's")
+
+	// Stop is also the token-accounting assertion: the deferral hands a second
+	// worker token pair to the poller while Start still holds its own, and an
+	// imbalance on either side either wedges the teardown or trips drain.Counter's
 	// negative-counter panic.
-	assert.NoError(t, inst.Stop())
+	assert.ErrorIs(t, inst.Stop(), wantStopErr,
+		"Stop must hand back exactly the Hub's terminal error")
 }
 
 // The gate sits BEFORE the switch, so it covers the deferral arm too. Without
@@ -798,7 +1027,7 @@ func TestSoloStart_DevModeDefersWorkerRegistrationUntilAnAdminExists(t *testing.
 // healthy Instance AND leave a poller ticking every 2s against a Hub that is
 // already gone.
 func TestSoloStart_DoesNotDeferWorkerSetupOntoAHubThatDied(t *testing.T) {
-	cfg := devStartFailureEnv(t)
+	cfg := soloStartEnv(t, true)
 	wantErr := errors.New("revocation watcher seed failed")
 	kill := serveUntilKilled(t, wantErr)
 
@@ -807,30 +1036,186 @@ func TestSoloStart_DoesNotDeferWorkerSetupOntoAHubThatDied(t *testing.T) {
 		close(entered)
 		<-ctx.Done()
 		// The arm that would defer, if the gate let it get that far.
-		return store.ErrNotFound
+		return errNoAdminYet
 	})
 
 	var inst *Instance
 	var err error
-	done := make(chan struct{})
 	out := testutil.CaptureStderr(t, func() {
-		go func() {
-			defer close(done)
-			ctx, cancel := context.WithTimeout(context.Background(), soloTestTimeout)
-			defer cancel()
-			inst, err = Start(ctx, cfg)
-		}()
-		awaitBringUp(t, entered, done)
-		kill()
-		<-done
+		inst, err = startWhileHubDies(t, cfg, entered, kill)
 	})
 
 	require.Error(t, err)
 	require.Nil(t, inst)
 	assert.ErrorIs(t, err, wantErr)
-	assert.True(t, strings.HasPrefix(err.Error(), "hub serve:"), "got: "+err.Error())
+	assert.True(t, strings.HasPrefix(err.Error(), "hub serve exited while the worker was starting:"),
+		"got: "+err.Error())
 	assert.NotContains(t, out, "deferring worker auto-registration",
 		"a Hub that is gone has nothing to defer to; captured:\n"+out)
+}
+
+// The OTHER half of the same misattribution, and the one the first fix missed: a
+// caller who cancels during bring-up. The watcher cancels workerCtx on EITHER
+// trigger, so bring-up reports "context canceled" either way -- but on this path
+// the Hub is still serving, because shutdown cancels the Worker and then parks in
+// workerDrained.Wait behind the token Start holds across bring-up, so cancelHub
+// has not run and hubDone is still open. A gate that asked only about hubDone
+// answered nil here and let the switch blame the Worker for a Ctrl-C.
+func TestSoloStart_ACallerCancelDuringBringUpIsNotBlamedOnTheWorker(t *testing.T) {
+	cfg := soloStartEnv(t, false)
+	// A real, LIVE Hub for the whole test: the point is that the Hub is healthy
+	// and the startup still has to end.
+	serveUntilKilled(t, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), soloTestTimeout)
+	t.Cleanup(cancel)
+
+	entered := make(chan struct{})
+	stubWorkerBringUp(t, func(bringUpCtx context.Context) error {
+		close(entered)
+		// Returns only once the watcher has cancelled workerCtx in response to the
+		// caller's cancel -- the exact shape bringUpLocalWorker produces when a
+		// store call is interrupted mid-registration.
+		<-bringUpCtx.Done()
+		return fmt.Errorf("create worker: %w", bringUpCtx.Err())
+	})
+
+	inst, err := startUntilTornDown(t, ctx, cfg, entered, cancel)
+
+	require.Error(t, err)
+	require.Nil(t, inst)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.NotContains(t, err.Error(), "auto-register worker",
+		"the Worker only failed because the caller cancelled; got: "+err.Error())
+	assert.Contains(t, err.Error(), "solo startup cancelled",
+		"a cancelled startup must say so; got: "+err.Error())
+}
+
+// A genuine cleanup failure during the teardown Start itself triggers has no other
+// reporter: Start returns a nil Instance, so Wait and Stop are unreachable and the
+// watcher is deliberately silent. It has to ride out with the cause.
+func TestSoloStart_ReportsACleanupFailureFromTheTeardownItTriggered(t *testing.T) {
+	cfg := soloStartEnv(t, false)
+	// The shape of a real teardown cleanup failure: Serve returns non-nil after an
+	// ordinary, requested shutdown -- here the one failStartup's join asks for.
+	leaseErr := errors.New("release runtime lease failed")
+	serveUntilKilled(t, leaseErr)
+
+	bringUpErr := errors.New("generate composite keypair: no entropy")
+	stubWorkerBringUp(t, func(context.Context) error { return bringUpErr })
+
+	ctx, cancel := context.WithTimeout(context.Background(), soloTestTimeout)
+	defer cancel()
+	inst, err := Start(ctx, cfg)
+
+	require.Error(t, err)
+	require.Nil(t, inst)
+	assert.ErrorIs(t, err, bringUpErr, "the Worker's failure is still the cause")
+	assert.ErrorIs(t, err, leaseErr,
+		"the cleanup failure has no other reporter once Start returns a nil Instance")
+}
+
+// The cancellation the teardown itself issues must NOT be reported. failStartup's
+// join is what cancels the Hub, so a Serve still working through its own startup
+// comes back with that very cancel -- blaming the Hub for obeying us, and burying
+// the Worker's real failure under it.
+func TestSoloStart_DoesNotReportTheCancellationItsOwnTeardownCaused(t *testing.T) {
+	cfg := soloStartEnv(t, false)
+	// No serveHub stub: the REAL Serve, whose startup (seeding the revocation
+	// cursor) is still in flight when the join cancels it, and which therefore
+	// returns a context.Canceled-rooted error on a perfectly ordinary teardown.
+	bringUpErr := errors.New("generate composite keypair: no entropy")
+	stubWorkerBringUp(t, func(context.Context) error { return bringUpErr })
+
+	ctx, cancel := context.WithTimeout(context.Background(), soloTestTimeout)
+	defer cancel()
+	inst, err := Start(ctx, cfg)
+
+	require.Error(t, err)
+	require.Nil(t, inst)
+	assert.ErrorIs(t, err, bringUpErr)
+	assert.NotContains(t, err.Error(), "hub serve",
+		"the Hub was still serving until our own join stopped it; got: "+err.Error())
+}
+
+// The deferral poller is the one place the stage gates cannot reach: it outlives
+// Start. When the teardown cancels it mid-setup, the error it gets back is the
+// shutdown wearing the Worker's wrapper -- and logging it would make the poller a
+// SECOND reporter of a shutdown Stop already reports, which is exactly what the
+// watcher stays silent to avoid.
+func TestSoloStart_TheDeferredPollerStaysQuietWhenTheTeardownCancelsIt(t *testing.T) {
+	cfg := soloStartEnv(t, true)
+	serveUntilKilled(t, nil)
+
+	// First call defers (no admin yet); every later call is the poller's, and it
+	// parks until the teardown cancels it -- the window the guard covers.
+	var calls atomic.Int32
+	stubWorkerBringUp(t, func(ctx context.Context) error {
+		if calls.Add(1) == 1 {
+			return errNoAdminYet
+		}
+		<-ctx.Done()
+		return fmt.Errorf("look up saved worker owner: %w", ctx.Err())
+	})
+
+	orig := workerSetupPollInterval
+	workerSetupPollInterval = time.Millisecond
+	t.Cleanup(func() { workerSetupPollInterval = orig })
+
+	var inst *Instance
+	var err error
+	out := testutil.CaptureStderr(t, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), soloTestTimeout)
+		defer cancel()
+		inst, err = Start(ctx, cfg)
+		require.NoError(t, err)
+		require.NotNil(t, inst)
+		// Wait for the poller to be parked inside setupWorker, so Stop's cancel
+		// lands mid-call rather than on the ticker select -- an explicit signal,
+		// not a sleep.
+		for calls.Load() < 2 {
+			runtime.Gosched()
+		}
+		_ = inst.Stop()
+	})
+
+	assert.NotContains(t, out, "deferred worker setup failed",
+		"a poller the teardown cancelled must not report it as a Worker failure; captured:\n"+out)
+}
+
+// The gate can fire when bring-up SUCCEEDED, and the real bringUpLocalWorker adds
+// a SECOND token pair and launches worker.Run on that path. Everything else here
+// stubs bring-up, so nothing else proves the release accounting survives a real
+// Worker under the gate -- a leak would wedge join forever, a double release would
+// panic the counter.
+func TestSoloStart_TearsDownARealWorkerLaunchedJustBeforeTheHubDied(t *testing.T) {
+	cfg := soloStartEnv(t, false)
+	wantErr := errors.New("revocation watcher seed failed")
+	kill := serveUntilKilled(t, wantErr)
+
+	entered := make(chan struct{})
+	prev := bringUpWorker
+	bringUpWorker = func(ctx context.Context, p workerBringUp) error {
+		// The REAL implementation, so the Worker goroutine and its own token pair
+		// exist; then hold Start inside the window until the Hub is gone.
+		if err := prev(ctx, p); err != nil {
+			return err
+		}
+		close(entered)
+		<-ctx.Done()
+		return nil
+	}
+	t.Cleanup(func() { bringUpWorker = prev })
+
+	inst, err := startWhileHubDies(t, cfg, entered, kill)
+
+	// Reaching here at all is half the assertion: failStartup's join waits out the
+	// real worker.Run unwind, so a mislaid token would hang the test rather than
+	// fail it.
+	require.Error(t, err)
+	require.Nil(t, inst)
+	assert.ErrorIs(t, err, wantErr)
+	assert.NotContains(t, err.Error(), "auto-register worker", "got: "+err.Error())
 }
 
 // The over-reach guard on the gate above, and the first coverage of the switch's
@@ -849,9 +1234,12 @@ func TestSoloStart_AWorkerBringUpFailureIsStillTheWorkers(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// No serveHub stub: the Hub is real and still serving, which is the
-			// whole point -- the gate must not claim a failure that is not its own.
+			// A real Serve that keeps serving, with its terminal error pinned: the
+			// gate must not claim a failure that is not its own, and leaving the
+			// Hub's own error unpinned would let a spontaneous startup failure in
+			// this window flip the assertion below into a false red.
 			cfg := startFailureEnv(t)
+			serveUntilKilled(t, nil)
 			stubWorkerBringUp(t, func(context.Context) error { return tt.bringUpErr })
 
 			ctx, cancel := context.WithTimeout(context.Background(), soloTestTimeout)
@@ -905,11 +1293,16 @@ func TestInstanceShutdown_StopsTheHubOnTheDrainNotTheWorkersFullExit(t *testing.
 	}()
 
 	start := time.Now()
-	logs := testutil.CaptureStderr(t, func() { inst.shutdown() })
+	// logging.Setup inside the capture, or the handler still points at the real
+	// stderr and the NotContains below holds no matter what shutdown logs.
+	logs := testutil.CaptureStderr(t, func() {
+		logging.Setup()
+		inst.shutdown()
+	})
 
 	assert.True(t, hubCancelled.Load())
 	assert.Less(t, time.Since(start), workerDrainTimeout,
 		"the hub must stop on the drain signal, not wait out the backstop for a teardown it has no stake in")
-	assert.NotContains(t, logs, "did not report draining",
+	assert.NotContains(t, logs, "did not finish before the hub shutdown deadline",
 		"a worker that drained promptly must not be reported as failing to")
 }

--- a/backend/solo/worker_state_test.go
+++ b/backend/solo/worker_state_test.go
@@ -2,10 +2,12 @@ package solo
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,11 +19,13 @@ import (
 
 // fakeRegistrar stands in for *hub.Server, recording what the loader asked of it.
 type fakeRegistrar struct {
-	owner      string
-	ownerErr   error
-	adminID    string
-	registered int
-	newWorker  hub.WorkerCredentials
+	owner       string
+	ownerErr    error
+	adminID     string
+	adminErr    error
+	registerErr error
+	registered  int
+	newWorker   hub.WorkerCredentials
 }
 
 func (f *fakeRegistrar) GetWorkerOwner(context.Context, string) (string, error) {
@@ -29,11 +33,14 @@ func (f *fakeRegistrar) GetWorkerOwner(context.Context, string) (string, error) 
 }
 
 func (f *fakeRegistrar) GetAdminUser(context.Context) (string, error) {
-	return f.adminID, nil
+	return f.adminID, f.adminErr
 }
 
 func (f *fakeRegistrar) RegisterWorker(context.Context, string) (*hub.WorkerCredentials, error) {
 	f.registered++
+	if f.registerErr != nil {
+		return nil, f.registerErr
+	}
 	c := f.newWorker
 	return &c, nil
 }
@@ -209,4 +216,89 @@ func TestPersistState_RoundTripsAndLeavesNoTempRemnants(t *testing.T) {
 	tmpRemnants, err := filepath.Glob(filepath.Join(dir, ".worker-state-*.tmp"))
 	require.NoError(t, err)
 	assert.Empty(t, tmpRemnants, "a successful atomic write must not leave temp files behind")
+}
+
+// The deferral arm's discriminator. "No admin has completed /setup yet" is the ONE
+// condition dev mode waits on, and it reaches the switch as errNoAdminYet -- so a
+// store.ErrNotFound from anywhere ELSE under bring-up must NOT wear that sentinel,
+// or a real registration failure becomes a launch that reports success and polls
+// forever against a Worker that is never coming.
+func TestLoadOrCreateWorkerState_OnlyTheMissingAdminIsDeferrable(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	t.Run("a missing admin is deferrable", func(t *testing.T) {
+		t.Parallel()
+		reg := &fakeRegistrar{adminErr: store.ErrNotFound}
+		_, err := loadOrCreateWorkerState(t.Context(), reg, filepath.Join(t.TempDir(), "state.json"), t.TempDir())
+		require.Error(t, err)
+		assert.ErrorIs(t, err, errNoAdminYet, "dev mode waits for /setup on exactly this")
+		assert.ErrorIs(t, err, store.ErrNotFound, "the underlying cause stays reachable")
+	})
+
+	t.Run("a not-found from registration is not", func(t *testing.T) {
+		t.Parallel()
+		reg := &fakeRegistrar{adminID: "u1", registerErr: store.ErrNotFound}
+		_, err := loadOrCreateWorkerState(t.Context(), reg, filepath.Join(t.TempDir(), "state.json"), t.TempDir())
+		require.Error(t, err)
+		assert.NotErrorIs(t, err, errNoAdminYet,
+			"the admin existed; a not-found here is a real failure, not something to wait out")
+		assert.ErrorIs(t, err, store.ErrNotFound)
+	})
+
+	t.Run("a non-not-found admin lookup failure is not", func(t *testing.T) {
+		t.Parallel()
+		boom := errors.New("database is locked")
+		reg := &fakeRegistrar{adminErr: boom}
+		_, err := loadOrCreateWorkerState(t.Context(), reg, filepath.Join(dir, "locked.json"), t.TempDir())
+		require.Error(t, err)
+		assert.ErrorIs(t, err, boom)
+		assert.NotErrorIs(t, err, errNoAdminYet)
+	})
+}
+
+// An unreadable state file must be MOVED aside, not copied. A copy leaves it
+// exactly where the next load reads it, and dev mode's poller re-enters that path
+// every tick until somebody completes /setup -- re-logging the orphaning and
+// writing a fresh sidecar each time, without bound.
+func TestPreserveCorruptState_MovesTheFileAsideSoTheNextLoadCannotSeeIt(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+	require.NoError(t, os.WriteFile(path, []byte("{ this is not json"), 0o600))
+
+	preserveCorruptState(path, []byte("{ this is not json"))
+
+	_, err := os.Stat(path)
+	assert.ErrorIs(t, err, os.ErrNotExist,
+		"the corrupt file must not be left where the next load will read it again")
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	var sidecars int
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".corrupt-") {
+			sidecars++
+			data, readErr := os.ReadFile(filepath.Join(dir, e.Name()))
+			require.NoError(t, readErr)
+			assert.Equal(t, "{ this is not json", string(data), "the bytes must survive for forensics")
+		}
+	}
+	assert.Equal(t, 1, sidecars)
+}
+
+// decode64 replaced a mustDecode64 that swallowed the error and never panicked
+// despite its name, so a mangled key reached RestoreCompositeKeypair as truncated
+// bytes and failed every launch with an opaque parse error.
+func TestDecode64NamesTheFieldThatFailed(t *testing.T) {
+	t.Parallel()
+
+	got, err := decode64("mlkem_private_key", base64.StdEncoding.EncodeToString([]byte("hello")))
+	require.NoError(t, err)
+	assert.Equal(t, []byte("hello"), got)
+
+	_, err = decode64("mlkem_private_key", "not!valid!base64")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mlkem_private_key",
+		"an operator has to be told WHICH field is unreadable")
 }

--- a/desktop/go/app_test.go
+++ b/desktop/go/app_test.go
@@ -224,6 +224,7 @@ type recordingSoloInstance struct {
 }
 
 func (*recordingSoloInstance) LocalListenURL() string { return "" }
+func (*recordingSoloInstance) Wait() error            { return nil }
 func (s *recordingSoloInstance) Stop() error {
 	s.stops++
 	return nil
@@ -237,6 +238,7 @@ type inspectingSoloInstance struct {
 }
 
 func (*inspectingSoloInstance) LocalListenURL() string { return "" }
+func (*inspectingSoloInstance) Wait() error            { return nil }
 func (s *inspectingSoloInstance) Stop() error {
 	if s.onStop != nil {
 		s.onStop()

--- a/desktop/go/rpc_test.go
+++ b/desktop/go/rpc_test.go
@@ -293,6 +293,7 @@ type slowFailingSoloInstance struct {
 }
 
 func (slowFailingSoloInstance) LocalListenURL() string { return "" }
+func (slowFailingSoloInstance) Wait() error            { return nil }
 func (s slowFailingSoloInstance) Stop() error {
 	time.Sleep(s.delay)
 	return s.err

--- a/desktop/go/signal_shutdown_test.go
+++ b/desktop/go/signal_shutdown_test.go
@@ -18,6 +18,7 @@ type failingSoloInstance struct {
 }
 
 func (f failingSoloInstance) LocalListenURL() string { return "" }
+func (f failingSoloInstance) Wait() error            { return f.err }
 func (f failingSoloInstance) Stop() error            { return f.err }
 
 func TestAppShutdownReturnsSoloError(t *testing.T) {
@@ -53,6 +54,7 @@ type blockingSoloInstance struct {
 }
 
 func (b blockingSoloInstance) LocalListenURL() string { return "" }
+func (b blockingSoloInstance) Wait() error            { return nil }
 func (b blockingSoloInstance) Stop() error {
 	close(b.entered)
 	<-b.release

--- a/desktop/go/solo.go
+++ b/desktop/go/solo.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"log/slog"
+	"sync"
 
 	"github.com/leapmux/leapmux/solo"
 )
@@ -10,11 +11,38 @@ import (
 type soloInstance interface {
 	LocalListenURL() string
 	Stop() error
+	// Wait blocks until the Hub's serve loop ends and returns its terminal error.
+	// It is what gives a Hub that dies ON ITS OWN a reporter: Stop only covers the
+	// teardowns this process asked for.
+	Wait() error
 }
 
 type soloRuntime struct {
 	instance           soloInstance
 	previousLogHandler slog.Handler
+	// stopping is closed by stopSolo BEFORE it calls instance.Stop, so the watcher
+	// below can tell a Hub that died from one this process asked to stop. Without
+	// that distinction the watcher would re-report every ordinary shutdown, which
+	// is the duplicate report solo's own watcher and the CLI's waitSolo are both
+	// silent to avoid.
+	//
+	// Usable at its ZERO VALUE, which is what the tests need: they build bare
+	// soloRuntime literals with only an instance, and only defaultStartSolo ever
+	// launches a watcher to silence. A nil channel also reads correctly in the
+	// watcher's select -- it can never be ready, so nothing is ever mistaken for a
+	// requested teardown.
+	stopping     chan struct{}
+	stoppingOnce sync.Once
+}
+
+// silenceWatcher tells watchSoloInstance that what follows is a teardown this
+// process asked for. Idempotent and nil-safe: Shutdown and SwitchMode both reach
+// stopSolo, and a runtime built without a watcher has nothing to silence.
+func (rt *soloRuntime) silenceWatcher() {
+	if rt.stopping == nil {
+		return
+	}
+	rt.stoppingOnce.Do(func() { close(rt.stopping) })
 }
 
 // defaultStartSolo launches a Hub and Worker in-process via the solo package.
@@ -35,7 +63,40 @@ func (a *App) defaultStartSolo(ctx context.Context) (*soloRuntime, error) {
 	prevHandler := slog.Default().Handler()
 	logHandler := newWebviewHandler(prevHandler, a.EmitEvent)
 	slog.SetDefault(slog.New(logHandler))
-	return &soloRuntime{instance: inst, previousLogHandler: prevHandler}, nil
+	rt := &soloRuntime{
+		instance:           inst,
+		previousLogHandler: prevHandler,
+		stopping:           make(chan struct{}),
+	}
+
+	go watchSoloInstance(rt)
+	return rt, nil
+}
+
+// watchSoloInstance is the desktop's only reporter for a Hub that dies ON ITS
+// OWN. solo.Start returns once the startup is past its gates, and from then on
+// the CLI learns of a Hub failure through waitSolo -- but this process had no
+// equivalent, so the sidecar announced a successful launch and the UI then failed
+// to connect with nothing naming the Hub.
+//
+// It reports NOTHING for a teardown this process asked for: stopSolo closes
+// rt.stopping before it calls Stop, and Stop's return is that error's single
+// reporter. Logging here as well would restore exactly the duplicate report
+// solo's own watcher and the CLI's waitSolo are both silent to avoid.
+//
+// slog rather than a desktop event because the handler defaultStartSolo installs
+// forwards it to the webview, so it lands in the app's own log with no new
+// plumbing.
+func watchSoloInstance(rt *soloRuntime) {
+	err := rt.instance.Wait()
+	select {
+	case <-rt.stopping:
+		return
+	default:
+	}
+	if err != nil {
+		slog.Error("the local hub stopped", "error", err)
+	}
 }
 
 // stopSolo shuts down the in-process Worker and Hub, in that order. It is
@@ -48,6 +109,9 @@ func stopSolo(runtime *soloRuntime) error {
 	if runtime == nil {
 		return nil
 	}
+	// Before Stop, so the watcher goroutine can never mistake this teardown for a
+	// Hub that failed on its own: Stop's return is this error's single reporter.
+	runtime.silenceWatcher()
 	err := runtime.instance.Stop()
 
 	// Restore original log handler to stop forwarding to the WebView.

--- a/desktop/go/solo_watch_test.go
+++ b/desktop/go/solo_watch_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// waitingSoloInstance reports a terminal error from Wait, standing in for a Hub
+// that died on its own after the launch succeeded.
+type waitingSoloInstance struct {
+	err error
+}
+
+func (waitingSoloInstance) LocalListenURL() string { return "" }
+func (waitingSoloInstance) Stop() error            { return nil }
+func (w waitingSoloInstance) Wait() error          { return w.err }
+
+// captureSlog points the default logger at a buffer for the duration of fn.
+func captureSlog(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	fn()
+	return buf.String()
+}
+
+// A Hub that dies on its own is the case with no other reporter: soloInstance
+// had no Wait, so the sidecar reported a successful launch and the UI's connect
+// failure was never attributed to the Hub.
+func TestWatchSoloInstance_ReportsAHubThatDiedOnItsOwn(t *testing.T) {
+	wantErr := errors.New("revocation watcher failed")
+	rt := &soloRuntime{
+		instance: waitingSoloInstance{err: wantErr},
+		stopping: make(chan struct{}),
+	}
+
+	out := captureSlog(t, func() { watchSoloInstance(rt) })
+
+	assert.Contains(t, out, "the local hub stopped")
+	assert.Contains(t, out, wantErr.Error())
+}
+
+// The other half, and the reason the guard exists: stopSolo already returns this
+// error, and waitSolo documents itself as its single reporter. A second one here
+// is the duplicate report the whole shutdown design removes.
+func TestWatchSoloInstance_StaysQuietForATeardownWeAskedFor(t *testing.T) {
+	rt := &soloRuntime{
+		instance: waitingSoloInstance{err: errors.New("lease release failed")},
+		stopping: make(chan struct{}),
+	}
+	close(rt.stopping) // what stopSolo does before calling Stop
+
+	out := captureSlog(t, func() { watchSoloInstance(rt) })
+
+	assert.Empty(t, out, "Stop owns this error; captured:\n"+out)
+}
+
+// A clean exit says nothing either way.
+func TestWatchSoloInstance_SaysNothingForACleanExit(t *testing.T) {
+	rt := &soloRuntime{
+		instance: waitingSoloInstance{},
+		stopping: make(chan struct{}),
+	}
+
+	out := captureSlog(t, func() { watchSoloInstance(rt) })
+
+	assert.Empty(t, out)
+}
+
+// A soloRuntime built without a watcher -- which is every one the tests construct,
+// since only defaultStartSolo launches one -- must survive stopSolo. Closing a nil
+// channel panics, and stopSolo is reached from both Shutdown and SwitchMode.
+func TestStopSolo_IsSafeOnARuntimeWithNoWatcher(t *testing.T) {
+	rt := &soloRuntime{instance: waitingSoloInstance{}}
+
+	require.NotPanics(t, func() { _ = stopSolo(rt) })
+	require.NotPanics(t, func() { _ = stopSolo(rt) }, "both Shutdown and SwitchMode reach here")
+}
+
+// Silencing is idempotent: Shutdown and SwitchMode can both tear the same runtime
+// down, and a second close of the same channel panics.
+func TestStopSolo_SilencingTwiceDoesNotPanic(t *testing.T) {
+	rt := &soloRuntime{
+		instance: waitingSoloInstance{},
+		stopping: make(chan struct{}),
+	}
+
+	require.NotPanics(t, func() { _ = stopSolo(rt) })
+	require.NotPanics(t, func() { _ = stopSolo(rt) })
+}
+
+// stopSolo must close stopping BEFORE Stop, or the watcher races the teardown and
+// reports an exit this process asked for.
+func TestStopSolo_SilencesTheWatcherBeforeStopping(t *testing.T) {
+	rt := &soloRuntime{
+		instance: waitingSoloInstance{err: errors.New("lease release failed")},
+		stopping: make(chan struct{}),
+	}
+
+	require.NoError(t, stopSolo(rt))
+
+	select {
+	case <-rt.stopping:
+	default:
+		t.Fatal("stopSolo must close stopping so the watcher knows the teardown was requested")
+	}
+}


### PR DESCRIPTION
## Motivation

PR #364's macOS CI failure exposed a mis-blame bug: when the in-process Hub died while `solo.Start` was still coming up, the failure was reported as `auto-register worker: create worker: context canceled`, pointing at the Worker instead of the Hub. The root cause was structural — "has the Hub exited?" was asked independently inside separate `select`/`switch` arms rather than once at defined stage boundaries, so the answer depended on which arm won a race. Because `hub.NewServer` binds both listeners before `Serve` runs, a connect-and-close readiness probe succeeds against an already-dead Hub, letting that race go the wrong way.

A second, related bug misattributed a *caller* cancellation (Ctrl-C) during bring-up to the Worker as well. On that path `shutdown()` parks in `workerDrained.Wait` behind a token `Start` holds across bring-up, so `cancelHub` never runs and `hubDone` never closes — a check that asked only "did `hubDone` close?" missed it entirely, and produced the exact string the first fix existed to retire.

Fixing the attribution surfaced several adjacent bugs on the same paths. The dev-mode "defer until /setup" signal was an overloaded `store.ErrNotFound`, so a genuine registration failure was indistinguishable from "no admin yet" and polled forever. Corrupt worker-state files were copied rather than renamed, so the dev poller re-logged the orphaning and wrote an unbounded stream of `.corrupt-*` sidecars, one per tick. `mustDecode64` discarded the decode error and, despite its name, never panicked, so a mangled saved key failed every launch with an opaque parse error and nothing to act on.

Separately, `runSolo` maintained hand-copied `defaultListen`/`configDir`/`configFile`/`cliFlags`/`extraFlags` in parallel with `solo.Start`'s own derivation. That second source of truth had already drifted: `defaultCLIFlags` gained `max-connections-per-user`, `max-workers-per-user` and two sqlite sizing flags that the CLI copy never received, so `leapmux solo --max-connections-per-user=64` answered "flag provided but not defined" while solo's own test asserted the flag was exposed.

Finally, `hub.Server.Serve` seeds the revocation-watcher cursor before starting its listeners, and reported a cancellation landing in that window as a failure. Since the listeners are already bound, a readiness probe succeeds and a Stop can arrive mid-seed — so an ordinary Ctrl-C during startup made `leapmux hub` and `leapmux solo` exit non-zero. The sqlite spelling of it, `interrupted (9)`, wraps no context error, so no downstream `errors.Is` filter could have caught it. On the desktop side, a Hub that died on its own had no reporter at all: the sidecar announced a successful launch while the UI's connect attempt failed with nothing pointing at the Hub.

## Modifications

- `backend/solo/solo.go`: adds `Instance.startupFailure(ctx, stage)` as one total predicate consulted at both the readiness gate and the bring-up gate — the latter placed before the `switch`, so it also covers the dev-mode deferral arm — and consulting `ctx.Err()` on both sides of the `hubDone` gate so it is total over both teardown triggers. Adds `Instance.failStartup(cause)` to surface a genuine teardown-triggered cleanup failure (lease release, store close) that otherwise had no reporter, since `Start` returns a nil `Instance` on those paths; it filters the cancellation the teardown itself issued and never double-reports a cause the predicate already carried. The bring-up drain tokens gain a single `sync.Once` release reached from every exit.
- `errNoAdminYet` replaces the overloaded `store.ErrNotFound` as the dev-mode defer signal; `preserveCorruptState` renames instead of copying; `mustDecode64` becomes `decode64(field, s)`, naming the field that failed. The deferral poller stays quiet when the teardown cancels it mid-setup, rather than logging a shutdown as a Worker failure and becoming a second reporter of it.
- `soloLoadOptions(cfg Config) (hubconfig.LoadOptions, string)` is extracted as a pure function and is now the single, directly table-tested source of truth for solo/dev defaults. `bringUpLocalWorker` takes a `workerBringUp` struct instead of nine positional parameters, two adjacent same-type pairs of which were transposable compile-clean.
- `backend/cmd/leapmux/solo.go`: `runSolo` sets only `Args` and `DevMode`, letting `solo.Start` derive the rest, retiring the drifted copy.
- `backend/hub/server.go`: `Serve` reports no primary error when the revocation-watcher seed fails *because* the caller cancelled. Genuine seed failures are still reported, and the rest of the teardown is unaffected.
- `desktop/go/solo.go`: `soloInstance` gains `Wait() error`, and a `watchSoloInstance` goroutine logs `the local hub stopped` for an unrequested exit. `soloRuntime` gains a `stopping` channel that `stopSolo` closes *before* `Stop()`, so the watcher cannot duplicate the error `Stop` already returns; `silenceWatcher()` is nil-safe and idempotent, since `stopSolo` is reachable from both `Shutdown` and `SwitchMode`.
- Test seams (`serveHub`, `bringUpWorker`) move from package vars into a `deps` struct threaded through an unexported `start(ctx, cfg, deps)`, so a stub cannot outlive the test that installed it. This does **not** make the Hub-starting tests parallel — they call `SandboxHome`, hence `t.Setenv`, which Go refuses to combine with `t.Parallel` at all; process-global `HOME` was the binding constraint, not the seams. The 11 tests that touch no global state now say `t.Parallel()`.
- Also: the drain backstop no longer warns "worker did not report draining" when no Worker was ever launched, and a pre-existing assertion that could never fail now binds its log handler to the pipe it reads. 24 tests were added across `backend/solo` and `desktop/go`.

No wire-format changes and no exported-API changes; `solo.Start`'s signature and contract are unchanged.

## Result

- A Hub that dies while starting up is reported as a Hub failure, at the stage that saw it, rather than as `auto-register worker: create worker: context canceled`.
- Pressing Ctrl-C during Worker bring-up reports a cancelled startup instead of a spurious Worker error, and no longer hands back a healthy `Instance` for a startup that is already being torn down.
- `leapmux hub` and `leapmux solo` no longer exit non-zero on an ordinary Ctrl-C that lands while the Hub is still seeding its revocation cursor.
- `leapmux solo --max-connections-per-user=64` parses, along with `--max-workers-per-user` and the two sqlite sizing flags, instead of failing with "flag provided but not defined".
- A dev-mode launch that hits a real registration failure fails the launch instead of polling `/setup` forever, and a corrupt worker-state file stops accumulating a fresh `.corrupt-*` sidecar every two seconds.
- A worker state file with a mangled key names the field that could not be decoded, instead of failing every launch with an opaque parse error.
- The desktop app logs `the local hub stopped` when the local Hub exits on its own, instead of leaving a connect failure with nothing attributing it to the Hub.
