### PR TITLE
fix(chat): Correct anchor drift the re-pin left permanently on screen

### DIFF
--- a/frontend/src/components/chat/chatScrollAnchorRepin.test.ts
+++ b/frontend/src/components/chat/chatScrollAnchorRepin.test.ts
@@ -20,7 +20,6 @@ function setup(geometry: { scrollTop?: number, clientHeight?: number, scrollHeig
   const velocity = {
     isFling: vi.fn(() => false),
     isActivelyFlinging: vi.fn(() => false),
-    hasRecentMomentumInput: vi.fn(() => false),
   }
   const virt = {
     anchorAt: vi.fn((top: number): ScrollAnchor | null => anchorAt(`top@${top}`)),
@@ -61,7 +60,7 @@ function setup(geometry: { scrollTop?: number, clientHeight?: number, scrollHeig
   }
 }
 
-describe('createanchorrepin state machine', () => {
+describe('createAnchorRepin state machine', () => {
   it('starts following the tail with no anchor', () => {
     const { repin } = setup()
     expect(repin.isFollowing()).toBe(true)
@@ -255,7 +254,7 @@ describe('createanchorrepin state machine', () => {
   })
 })
 
-describe('createanchorrepin edge-aware capture', () => {
+describe('createAnchorRepin edge-aware capture', () => {
   // captureViewportAnchor pins the NEARER edge's row when at an edge, else the midpoint, so a
   // far-side row growing past its estimate can't drift the pin off that edge. anchorAt returns
   // `top@<offset>`, so the captured anchor id reveals which viewport line (scrollTop + ratio*ch)
@@ -292,7 +291,7 @@ describe('createanchorrepin edge-aware capture', () => {
   })
 })
 
-describe('createanchorrepin row-top hold', () => {
+describe('createAnchorRepin row-top hold', () => {
   it('captureRowTopAnchor arms the hold; releaseRowTopHold downgrades it but KEEPS the anchor', () => {
     const { repin, el, virt } = setup({ clientHeight: 500 })
     el.scrollTop = 100
@@ -353,7 +352,7 @@ describe('createanchorrepin row-top hold', () => {
   })
 })
 
-describe('createanchorrepin repintoanchor decision', () => {
+describe('createAnchorRepin repinToAnchor decision', () => {
   it('does nothing while following the tail (no anchor to pin)', () => {
     const { repin, writes, virt } = setup()
     repin.repinToAnchor()
@@ -434,17 +433,16 @@ describe('createanchorrepin repintoanchor decision', () => {
     expect(flingSettle.accumulate).toHaveBeenCalledWith(-82)
   })
 
-  it('writes a small correction once momentum has stopped, even within the input-grace window', () => {
+  it('writes a small correction once momentum stops', () => {
     // The post-fling SETTLE: momentum is no longer moving the viewport (isActivelyFlinging
-    // false), but the 750ms momentum-input grace still holds and the velocity sample has
-    // gone stale (isFling's idle default -> true). A look-ahead premeasure lands here and
-    // shrinks content above the anchor. Because the viewport is STATIONARY, a scrollTop
-    // write cancels no momentum -- so correct it immediately (an off-screen, invisible
-    // shift) rather than deferring it into drift that accumulates across the settle burst
-    // (the observed run of deferred-fling WARNs climbing to ~176px at a fixed scrollTop).
+    // false) and the velocity sample has gone stale (isFling's idle default -> true). A
+    // look-ahead premeasure lands here and shrinks content above the anchor. Because the
+    // viewport is STATIONARY, a scrollTop write cancels no momentum -- so correct it
+    // immediately (an off-screen, invisible shift) rather than deferring it into drift that
+    // accumulates across the settle burst (the observed run of deferred-fling WARNs climbing
+    // to ~176px at a fixed scrollTop).
     const { repin, el, writes, virt, velocity, flingSettle } = setup({ clientHeight: 733, scrollHeight: 6000 })
     velocity.isActivelyFlinging.mockReturnValue(false)
-    velocity.hasRecentMomentumInput.mockReturnValue(true)
     velocity.isFling.mockReturnValue(true)
     el.scrollTop = 4606
     repin.setAnchor(anchorAt('m1')) // captured at the live position -> viewport stationary
@@ -456,26 +454,12 @@ describe('createanchorrepin repintoanchor decision', () => {
     expect(flingSettle.accumulate).not.toHaveBeenCalled()
   })
 
-  it('does not write a momentum-tail correction after the scroll handler returns', () => {
-    const { repin, el, writes, virt, velocity, flingSettle } = setup({ clientHeight: 733 })
-    velocity.hasRecentMomentumInput.mockReturnValue(true)
-    el.scrollTop = 2677
-    repin.setAnchor(anchorAt('m1'))
-    virt.scrollTopForAnchor.mockReturnValue(2651) // low-velocity momentum tail measurement
-
-    repin.repinToAnchor()
-
-    expect(writes).toEqual([])
-    expect(repin.currentAnchor()).toEqual(anchorAt('top@3043.5'))
-    expect(flingSettle.reset).toHaveBeenCalled()
-  })
-
-  it('re-anchors instead of writing a small correction during a slow user scroll', () => {
+  it('re-anchors instead of writing an imperceptible correction during a slow user scroll', () => {
     const { repin, el, writes, virt, flingSettle, setUserScrolling } = setup()
     setUserScrolling(true)
     el.scrollTop = 100
     repin.setAnchor(anchorAt('m1')) // captured at scrollTop 100
-    virt.scrollTopForAnchor.mockReturnValue(116) // a small measurement correction above the anchor
+    virt.scrollTopForAnchor.mockReturnValue(107) // 7px: under the absorb cap
 
     repin.repinToAnchor()
 
@@ -484,17 +468,49 @@ describe('createanchorrepin repintoanchor decision', () => {
     expect(flingSettle.reset).toHaveBeenCalled()
   })
 
-  it('re-anchors instead of writing a medium estimate correction during a slow native scroll', () => {
+  it('writes a correction AT the absorb cap during a slow user scroll', () => {
+    // The bound is STRICT, and this pins that. VISIBLE_ANCHOR_JUMP_PX is also 8, and its own
+    // doc calls a shift of exactly 8px the point where the row visibly jumps -- so absorbing
+    // one permanently is exactly what the cap exists to prevent. An off-by-one here is
+    // invisible in review and permanent on screen.
+    const { repin, el, writes, virt, setUserScrolling } = setup()
+    setUserScrolling(true)
+    el.scrollTop = 100
+    repin.setAnchor(anchorAt('m1'))
+    virt.scrollTopForAnchor.mockReturnValue(108) // 8px: AT the cap
+
+    repin.repinToAnchor()
+
+    expect(writes).toEqual([108])
+    expect(repin.currentAnchor()).toEqual(anchorAt('m1')) // corrected, so the pin is kept
+  })
+
+  it('writes a correction over the absorb cap during a slow user scroll', () => {
+    const { repin, el, writes, virt, setUserScrolling } = setup()
+    setUserScrolling(true)
+    el.scrollTop = 100
+    repin.setAnchor(anchorAt('m1'))
+    virt.scrollTopForAnchor.mockReturnValue(109) // 9px
+
+    repin.repinToAnchor()
+
+    expect(writes).toEqual([109])
+    expect(repin.currentAnchor()).toEqual(anchorAt('m1')) // corrected, so the pin is kept
+  })
+
+  it('writes a medium estimate correction during a slow native scroll', () => {
+    // A tool row measuring 78px shorter than its estimate, above the anchor -- the magnitude
+    // the drift WARNs reported. Absorbing it left the whole 78px on screen as a jump.
     const { repin, el, writes, virt, flingSettle, setUserScrolling } = setup({ clientHeight: 733, scrollHeight: 6000 })
     setUserScrolling(true)
     el.scrollTop = 4397
     repin.setAnchor(anchorAt('m1')) // captured at the live viewport position
-    virt.scrollTopForAnchor.mockReturnValue(4319) // 78px, like a tool row measuring shorter
+    virt.scrollTopForAnchor.mockReturnValue(4319)
 
     repin.repinToAnchor()
 
-    expect(writes).toEqual([])
-    expect(repin.currentAnchor()).toEqual(anchorAt('top@4763.5'))
+    expect(writes).toEqual([4319])
+    expect(repin.currentAnchor()).toEqual(anchorAt('m1'))
     expect(flingSettle.reset).toHaveBeenCalled()
   })
 
@@ -554,7 +570,7 @@ describe('createanchorrepin repintoanchor decision', () => {
   })
 })
 
-describe('createanchorrepin deferred-during-animation', () => {
+describe('createAnchorRepin deferred-during-animation', () => {
   it('defers a re-pin while an animation is running and applies it on a mid-flight cancel', () => {
     const { repin, el, writes, virt, setAnimating } = setup()
     el.scrollTop = 0
@@ -586,7 +602,7 @@ describe('createanchorrepin deferred-during-animation', () => {
   })
 })
 
-describe('createanchorrepin clamp reporting (onrepinclamp)', () => {
+describe('createAnchorRepin clamp reporting (onRepinClamp)', () => {
   it('reports a top-edge clamp: the keep-position target went negative and the row jumped up', () => {
     const { repin, el, writes, virt, onRepinClamp } = setup({ clientHeight: 500, scrollHeight: 5000 })
     el.scrollTop = 200
@@ -644,21 +660,23 @@ describe('createanchorrepin clamp reporting (onrepinclamp)', () => {
   })
 })
 
-describe('createanchorrepin drift reporting (onanchordrift)', () => {
+describe('createAnchorRepin drift reporting (onAnchorDrift)', () => {
   it('reports an ABSORBED slow-scroll correction (uncorrected on-screen shift)', () => {
     const { repin, el, writes, virt, onAnchorDrift, setUserScrolling } = setup({ clientHeight: 500 })
     el.scrollTop = 200
     repin.setAnchor(anchorAt('m'), 200, 0) // captured at the viewport top (ratio 0)
-    virt.scrollTopForAnchor.mockReturnValue(250) // row top now 250 -> ideal 250, a +50px correction
+    virt.scrollTopForAnchor.mockReturnValue(206) // row top now 206 -> ideal 206, a +6px correction
     setUserScrolling(true) // a slow user scroll is in progress
     repin.repinToAnchor()
-    // The 50px correction (<= the small-absorb cap) is ABSORBED, not written: the anchored
-    // row is left displaced 50px on-screen, reported as drift.
+    // The 6px correction (<= the small-absorb cap) is ABSORBED, not written: the anchored
+    // row is left displaced 6px on-screen, reported as drift. The engine reports every
+    // absorbed shift; the emission policy applies its own visible-px floor on top (the
+    // absorb cap now sits under that floor, so this is a tripwire for a raised cap).
     expect(writes).toEqual([])
     expect(onAnchorDrift).toHaveBeenCalledTimes(1)
     expect(onAnchorDrift).toHaveBeenCalledWith(expect.objectContaining({
       anchorId: 'm',
-      residualPx: 50,
+      residualPx: 6,
       reason: 'absorbed',
       fromTop: 200,
       clientHeight: 500,
@@ -689,5 +707,45 @@ describe('createanchorrepin drift reporting (onanchordrift)', () => {
     repin.repinToAnchor()
     expect(writes).toEqual([250]) // corrected, so the row stays on its line -- no drift
     expect(onAnchorDrift).not.toHaveBeenCalled()
+  })
+
+  it('writes a premeasure correction that lands during a SLOW scroll after the handler returns', () => {
+    // The reported "anchored content drifted without correction" WARN. The reader scrolls UP
+    // slowly, so the premeasure bands measure rows ABOVE the viewport-midpoint anchor and the
+    // offset map contracts there. The commit lands on the next frame -- OUTSIDE handleScroll
+    // (isUserScrolling false) -- while the 750ms wheel grace still holds, but the viewport is
+    // NOT flinging: the velocity sample is fresh and below the fling threshold. There is no
+    // momentum for a write to cancel, so the correction MUST be written. Dropping it leaves
+    // the whole 74px on-screen as a jump.
+    const { repin, el, writes, virt, velocity, flingSettle, onAnchorDrift } = setup({ clientHeight: 732, scrollHeight: 13367 })
+    velocity.isFling.mockReturnValue(false) // a fresh, slow sample -- not a fling
+    velocity.isActivelyFlinging.mockReturnValue(false) // momentum does not move the viewport
+    el.scrollTop = 10918
+    repin.setAnchor(anchorAt('m1'), 10918, 0.5) // captured at the live position
+    virt.scrollTopForAnchor.mockReturnValue(11210) // idealTop = 11210 - 366 = 10844, a -74px shift
+
+    repin.repinToAnchor()
+
+    expect(writes).toEqual([10844])
+    expect(repin.currentAnchor()).toEqual(anchorAt('m1')) // still pinned to the same row
+    expect(onAnchorDrift).not.toHaveBeenCalled()
+    expect(flingSettle.accumulate).not.toHaveBeenCalled()
+  })
+
+  it('still defers a correction that lands during LIVE momentum after the handler returns', () => {
+    // The counterpart the fix must not break: same async arrival, but momentum DOES move the
+    // viewport. A write cancels it, so the correction defers into the fling-settle instead.
+    const { repin, el, writes, virt, velocity, flingSettle, onAnchorDrift } = setup({ clientHeight: 732, scrollHeight: 13367 })
+    velocity.isActivelyFlinging.mockReturnValue(true)
+    velocity.isFling.mockReturnValue(true)
+    el.scrollTop = 10918
+    repin.setAnchor(anchorAt('m1'), 10918, 0.5)
+    virt.scrollTopForAnchor.mockReturnValue(11210)
+
+    repin.repinToAnchor()
+
+    expect(writes).toEqual([])
+    expect(flingSettle.accumulate).toHaveBeenCalledWith(-74)
+    expect(onAnchorDrift).toHaveBeenCalledWith(expect.objectContaining({ reason: 'deferred-fling' }))
   })
 })

--- a/frontend/src/components/chat/chatScrollAnchorRepin.ts
+++ b/frontend/src/components/chat/chatScrollAnchorRepin.ts
@@ -15,11 +15,25 @@ interface AnchorRepinFlingSettle {
   rebase: () => void
 }
 
-/** The velocity read the re-pin uses to tell a momentum fling from a deliberate scroll. */
+/**
+ * The velocity read the re-pin uses to tell a momentum fling from a deliberate scroll.
+ *
+ * `isActivelyFlinging` must mean "momentum moves the viewport, and a scrollTop write would
+ * CANCEL it". That is not the same as speed: a fast finger or scrollbar drag measures like a
+ * coast but carries no inertia, and a write during one costs nothing. The caller composes
+ * that distinction (see the velocity deps in useChatScroll) and this engine only reads the
+ * answer.
+ *
+ * Deliberately NO `hasRecentMomentumInput`, and the caller must not fold that 750ms input
+ * grace into either member. It marks that the user touched the surface recently, which is
+ * neither question, and it is wrong at both ends: it outlasts a real coast by ~600ms, and a
+ * bare coast stops refreshing it while the viewport still moves. Suppressing ON the grace
+ * made every premeasure inside it a permanent uncorrected shift; narrowing a suppression BY
+ * the grace made the engine write into live momentum and cancel it.
+ */
 interface AnchorRepinVelocity {
   isFling: () => boolean
   isActivelyFlinging: () => boolean
-  hasRecentMomentumInput: () => boolean
 }
 
 export interface AnchorRepinDeps {
@@ -76,14 +90,16 @@ export interface AnchorRepinDeps {
    * correction we withheld). This is the OUTCOME-based counterpart to onRepinClamp: it
    * catches a content shift that produces NO scroll event, so the hook's scroll-event
    * detector can't see it. Two reasons:
-   *  - 'absorbed': a small estimate->measure correction arrived during a slow/tailing
-   *    scroll and we re-anchored to the shifted position instead of snapping back (a
-   *    PERMANENT accepted shift, up to the small-absorb cap).
-   *  - 'deferred-fling': a correction was deferred mid-fling as drift (transient -- the
-   *    fling-settle re-anchors it when momentum stops).
-   * The engine stays mechanical; the hook owns the WARN policy (a visible-px floor, and
-   * ignoring the fast-fling frames where the shift blends into momentum). Optional: unit
-   * tests omit it.
+   *  - 'absorbed': a small estimate->measure correction arrived INSIDE the scroll handler,
+   *    during a slow user scroll, and we re-anchored to the shifted position instead of
+   *    snapping back (a PERMANENT accepted shift, under the small-absorb cap). A correction
+   *    that lands after the handler returns is never absorbed -- see the branch below.
+   *  - 'deferred-fling': the engine deferred a correction mid-fling as drift, so the
+   *    fling-settle owns it. Also permanent, because the settle drops the drift and
+   *    re-anchors; the reader watched the viewport coast there under their own gesture.
+   * The engine stays mechanical; the hook owns the WARN policy (which reasons to surface, a
+   * cumulative visible-px floor, and ignoring the fast-fling frames where the shift blends
+   * into momentum). Optional: unit tests omit it.
    */
   onAnchorDrift?: (info: {
     anchorId: string
@@ -99,8 +115,24 @@ export interface AnchorRepinDeps {
  * deltas this small, re-anchor to the live viewport and let the user's scroll trajectory
  * win. Larger shifts are structural enough (prepend/trim/tall outlier) that preserving
  * the existing anchor is less surprising than silently absorbing the movement.
+ *
+ * The bound is STRICT (`delta <` below), so an absorbed shift stays under the smallest one
+ * the diagnostics call perceptible: VISIBLE_ANCHOR_JUMP_PX, also 8, whose own doc reads
+ * "below this the shift is imperceptible; at or above it the row visibly jumps". The two
+ * numbers are a documented relationship rather than an import, because they answer different
+ * questions -- what the engine may permanently leave on screen, and what a WARN reports --
+ * and each must stay free to move without dragging the other.
+ *
+ * Absorbing is permanent: the engine leaves the row displaced and re-anchors it there, so
+ * this cap is the largest on-screen jump the engine may accept in exchange for not writing
+ * scrollTop. It was 128px -- a sixth of a laptop viewport, and the size of the drift WARNs
+ * that a premeasure band above the anchor produced. Anything the reader can see is worth one
+ * corrected frame instead.
+ *
+ * Absorbed shifts still ACCUMULATE, because each one re-anchors at the displaced position.
+ * Detector C therefore gates on their running sum, not on one event (see ANCHOR_DRIFT_WARN_PX).
  */
-const SMALL_USER_SCROLL_REPIN_ABSORB_PX = 128
+const SMALL_USER_SCROLL_REPIN_ABSORB_PX = 8
 const VIEWPORT_MIDPOINT_RATIO = 0.5
 
 /**
@@ -416,10 +448,13 @@ export function createAnchorRepin(deps: AnchorRepinDeps) {
           // by that much would be worse than one interrupted fling -- and supersedes any
           // deferred drift.
           const flingSuppressPx = el.clientHeight / 2
+          // The Math.min is inert at any real pane size: it binds only under a 16px viewport,
+          // and clientHeight 0 already returned above. It stays as a MECHANICAL bound -- a
+          // permanent absorb may never exceed the fling-suppress half-viewport, whatever the
+          // constant becomes -- rather than a rule that holds only while the constant is 8.
           const smallUserScrollAbsorbPx = Math.min(SMALL_USER_SCROLL_REPIN_ABSORB_PX, flingSuppressPx)
           const flingLike = deps.velocity.isFling()
           const activeFling = deps.velocity.isActivelyFlinging()
-          const recentMomentumInput = deps.velocity.hasRecentMomentumInput()
           // How far the viewport has moved since this anchor was captured. Large only when a
           // fling outran the per-scroll-event captures (see anchorCaptureTop) -- a
           // keep-position prepend/trim leaves the viewport in place, so this stays ~0 for
@@ -448,13 +483,33 @@ export function createAnchorRepin(deps: AnchorRepinDeps) {
             // falls through to the immediate-write branch below.
             reanchorAndDropDrift()
           }
-          else if ((deps.isUserScrolling() || recentMomentumInput) && !flingLike && delta <= smallUserScrollAbsorbPx) {
-            // A small estimate->measure correction arrived while the user is slowly
-            // scrolling, or during the low-velocity tail just after the scroll handler
-            // returned. Writing scrollTop here fights the native momentum event and
-            // shows up as a tiny backward/forward bounce. Absorb the correction by making
-            // the current viewport row the new anchor; large structural shifts still fall
-            // through and preserve the old anchor.
+          else if (deps.isUserScrolling() && !flingLike && delta < smallUserScrollAbsorbPx) {
+            // A small estimate->measure correction arrived INSIDE handleScroll, while the
+            // user scrolls slowly. Absorb it by making the current viewport row the new
+            // anchor; a larger correction falls through and preserves the old anchor.
+            //
+            // The bound is STRICT so an absorbed shift stays under the perceptible floor, not
+            // at it: absorbing is permanent, so a shift the reader can see must never take
+            // this branch. What the absorb buys is silence for the shifts BELOW that floor --
+            // a scrollTop write is not free even when it is invisible, because it dispatches
+            // an echo scroll event the handler must classify, and doing that per mounting row
+            // through a whole page of history is noise for a shift nobody can perceive.
+            //
+            // Scoped to the scroll handler ON PURPOSE. The gate was once
+            // `isUserScrolling() || hasRecentMomentumInput()`, which extended this permanent
+            // absorb across the whole 750ms wheel grace -- so a premeasure band landing on
+            // the next frame, with the viewport already stationary, dropped its correction
+            // and left the shift on screen (the "anchored content drifted without correction"
+            // WARNs, 60-90px each, while scrollTop barely moved). Outside the handler the only
+            // reason not to write is LIVE momentum, which the branch below owns; when there is
+            // none, the else branch corrects immediately and invisibly.
+            //
+            // KNOWN GAP: the branch below owns momentum only at or above the fling threshold
+            // (FLING_VELOCITY_THRESHOLD_PX_PER_MS, 1 px/ms). A coast that decays under it
+            // still moves the viewport, and no branch withholds the write there. The velocity
+            // tracker cannot separate that decaying coast from a genuinely slow deliberate
+            // scroll, where writing IS correct, so closing the gap needs a motion signal the
+            // tracker does not have today -- not a wider threshold.
             //
             // The anchored row is `signed` off its captured line and we are NOT correcting
             // it -- an on-screen content shift with no scroll event. Report it (BEFORE the
@@ -468,16 +523,23 @@ export function createAnchorRepin(deps: AnchorRepinDeps) {
             // returns, so outside the handler we gate on `activeFling` -- isActivelyFlinging,
             // which is TRUE only while momentum is genuinely moving the viewport (a write
             // would cancel it) and FALSE once it has stopped. It is deliberately NOT the
-            // 750ms momentum-input grace: that grace outlasts the momentum by ~600ms, and
-            // deferring through it meant a look-ahead premeasure landing during the post-fling
-            // SETTLE (viewport already stationary) accumulated as drift instead of correcting
-            // -- the observed run of deferred-fling WARNs climbing to ~176px at a fixed
-            // scrollTop. Once momentum stops, the viewport is stationary, so the else branch
-            // below writes the (off-screen, invisible) correction immediately and the anchor
-            // never drifts. Slow/manual scrolls are absorbed by the branch above.
-            // The row is `signed` off its line this frame -- transient drift the settle
-            // re-anchors when momentum stops. Report it; the hook ignores the fast-fling
-            // frames (where it blends into momentum) and surfaces only a lingering shift.
+            // 750ms momentum-input grace, in EITHER direction. The grace outlasts a real
+            // coast by ~600ms, so deferring through it left a look-ahead premeasure that
+            // landed during the post-fling settle (viewport already stationary) accumulating
+            // as drift instead of correcting. And a bare coast stops refreshing the grace
+            // while it is still moving, so narrowing this predicate BY the grace made the
+            // engine write into live momentum and cancel it -- which is why the hook passes
+            // the tracker's raw read (see the velocity deps in useChatScroll).
+            //
+            // Once momentum stops, the viewport is stationary, so the else branch below writes
+            // the (off-screen, invisible) correction immediately and the anchor never drifts.
+            // A slow/manual scroll inside the handler is absorbed by the branch above, but
+            // only below the imperceptible cap.
+            //
+            // The row is `signed` off its line this frame. Report it, though the hook does NOT
+            // surface this reason today: the settle drops the drift and re-anchors, so the
+            // shift is permanent, but the reader watched the viewport coast there under their
+            // own gesture (see Detector C's reason filter for why that is not an anomaly).
             reportDrift('deferred-fling')
             deps.flingSettle().accumulate(signed)
           }

--- a/frontend/src/components/chat/chatScrollDiagnostics.test.ts
+++ b/frontend/src/components/chat/chatScrollDiagnostics.test.ts
@@ -2,7 +2,7 @@ import type { AnchorDriftInfo, RepinClampInfo, UnexplainedJumpInfo, UnexplainedJ
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { ANCHOR_DRIFT_WARN_PX, classifyUnexplainedJump, createScrollDiagnostics, UNEXPLAINED_JUMP_MIN_PX, VISIBLE_ANCHOR_JUMP_PX } from './chatScrollDiagnostics'
 
-describe('chatscrolldiagnostics classifyunexplainedjump', () => {
+describe('chatScrollDiagnostics classifyUnexplainedJump', () => {
   /** A mid-list teleport from rest with every exclusion off -- the base unexplained case. */
   function teleport(overrides: Partial<UnexplainedJumpParams> = {}): UnexplainedJumpParams {
     return {
@@ -68,37 +68,37 @@ describe('chatscrolldiagnostics classifyunexplainedjump', () => {
   })
 })
 
-describe('chatscrolldiagnostics createscrolldiagnostics', () => {
+describe('chatScrollDiagnostics createScrollDiagnostics', () => {
   afterEach(() => {
     vi.restoreAllMocks()
   })
 
-  // A configurable emitter over spyable deps: tests flip hasOlder/hasNewer/flinging and
-  // read back the exact WARN payload the logger forwards to console.warn.
+  // A configurable emitter over spyable deps: tests flip hasOlder/hasNewer and read back the
+  // exact WARN payload the logger forwards to console.warn.
   function makeDiagnostics(overrides: Partial<{
     hasOlder: boolean
     hasNewer: boolean
-    flinging: boolean
     dom: Record<string, unknown> | undefined
     measurement: unknown
+    batch: unknown
     markers: unknown
   }> = {}) {
     const state = {
       hasOlder: false,
       hasNewer: false,
-      flinging: false,
       dom: { scrollTop: 7 } as Record<string, unknown> | undefined,
       measurement: { delta: 5 } as unknown,
+      batch: { commits: 1, deltaSum: 5, totalHeightDelta: 5 } as unknown,
       markers: ['marker'] as unknown,
       ...overrides,
     }
     const diag = createScrollDiagnostics({
       domSnapshot: () => state.dom,
       lastMeasurement: () => state.measurement,
+      measurementBatch: () => state.batch,
       debugMarkers: () => state.markers,
       hasOlderMessages: () => state.hasOlder,
       hasNewerMessages: () => state.hasNewer,
-      isActivelyFlinging: () => state.flinging,
     })
     return { diag, state }
   }
@@ -115,7 +115,7 @@ describe('chatscrolldiagnostics createscrolldiagnostics', () => {
     return { deltaFromLast: 300, scrollTop: 300, lastScrollTop: 0, msSinceLastScrollEvent: 20, speedPxPerMs: 0, wasActivelyFlinging: false, ...overrides }
   }
 
-  describe('emitrepinclamp (detector a)', () => {
+  describe('emitRepinClamp (detector a)', () => {
     it('warns clampedAt top when a top clamp still had older history to hold the row', () => {
       const warn = spyWarn()
       const { diag } = makeDiagnostics({ hasOlder: true, dom: { scrollTop: 5 } })
@@ -146,6 +146,26 @@ describe('chatscrolldiagnostics createscrolldiagnostics', () => {
       expect(warn).not.toHaveBeenCalled()
     })
 
+    it('names the geometry change that caused the clamp', () => {
+      const warn = spyWarn()
+      // A clamp is the downstream effect of a flush moving the map, so the payload has to
+      // say which commit did it -- the same correlation the drift and jump payloads carry.
+      const { diag } = makeDiagnostics({
+        hasOlder: true,
+        measurement: { id: 'r', delta: -300 },
+        batch: { commits: 4, deltaSum: -300, totalHeightDelta: -300 },
+      })
+      diag.emitRepinClamp(clampInfo({ clampPx: 200 }))
+      expect(warn).toHaveBeenCalledWith(
+        '[chatScroll]',
+        expect.stringContaining('anchor re-pin clamped'),
+        expect.objectContaining({
+          measurement: { id: 'r', delta: -300 },
+          batch: { commits: 4, deltaSum: -300, totalHeightDelta: -300 },
+        }),
+      )
+    })
+
     it('warns exactly at the visible-jump floor but not one px below it', () => {
       const warn = spyWarn()
       const { diag } = makeDiagnostics({ hasOlder: true })
@@ -156,8 +176,8 @@ describe('chatscrolldiagnostics createscrolldiagnostics', () => {
     })
   })
 
-  describe('emitanchordrift (detector c)', () => {
-    it('warns on an absorbed drift above the floor with zeroed aggregates + measurement', () => {
+  describe('emitAnchorDrift (detector c)', () => {
+    it('warns on an absorbed drift above the floor, with the running total + measurement', () => {
       const warn = spyWarn()
       const { diag } = makeDiagnostics({ measurement: { commit: 9 }, dom: { scrollTop: 3 } })
       diag.emitAnchorDrift(driftInfo({ residualPx: 40 }), 1000)
@@ -166,60 +186,141 @@ describe('chatscrolldiagnostics createscrolldiagnostics', () => {
         expect.stringContaining('drifted without correction'),
         expect.objectContaining({
           residualPx: 40,
-          suppressedSinceLastWarn: 0,
-          suppressedResidualPxSum: 0,
+          driftPxSinceLastWarn: 40,
+          absorbsSinceLastWarn: 1,
           measurement: { commit: 9 },
           dom: { scrollTop: 3 },
         }),
       )
     })
 
-    it('ignores a transient deferred-fling drift', () => {
+    it('accumulates sub-floor absorbs until their SUM crosses the floor', () => {
+      // The regression this detector exists for, and the one a per-event floor cannot see.
+      // The engine's absorb cap (8px) sits UNDER this floor (16px) by design, so no single
+      // absorb it can produce ever reaches the floor -- gating per event made the detector
+      // permanently silent while content kept moving. Each absorb re-anchors at the displaced
+      // position, so the displacement is retained and the shifts add up.
       const warn = spyWarn()
       const { diag } = makeDiagnostics()
-      diag.emitAnchorDrift(driftInfo({ reason: 'deferred-fling', residualPx: 400 }), 1000)
+      diag.emitAnchorDrift(driftInfo({ residualPx: 6 }), 1000)
+      diag.emitAnchorDrift(driftInfo({ residualPx: 6 }), 1001)
+      expect(warn).not.toHaveBeenCalled() // 12px so far: still under the floor
+      diag.emitAnchorDrift(driftInfo({ residualPx: 6 }), 1002)
+      expect(warn).toHaveBeenCalledWith(
+        '[chatScroll]',
+        expect.stringContaining('drifted without correction'),
+        expect.objectContaining({
+          residualPx: 6, // the single absorb that crossed it -- individually imperceptible
+          driftPxSinceLastWarn: 18,
+          absorbsSinceLastWarn: 3,
+        }),
+      )
+    })
+
+    it('nets opposing absorbs, so shifts that cancel never warn', () => {
+      // The sum is SIGNED on purpose: a shift up followed by an equal shift down leaves the
+      // content where it started, which is not drift. Summing magnitudes would WARN on it.
+      const warn = spyWarn()
+      const { diag } = makeDiagnostics()
+      for (const px of [7, -7, 7, -7, 7, -7])
+        diag.emitAnchorDrift(driftInfo({ residualPx: px }), 1000)
       expect(warn).not.toHaveBeenCalled()
     })
 
-    it('ignores a sub-floor drift but warns exactly at the floor', () => {
+    it('resets the running total after a warn', () => {
+      const warn = spyWarn()
+      const { diag } = makeDiagnostics()
+      diag.emitAnchorDrift(driftInfo({ residualPx: 20 }), 0) // warns
+      warn.mockClear()
+      diag.emitAnchorDrift(driftInfo({ residualPx: 6 }), 2000)
+      expect(warn).not.toHaveBeenCalled() // the total restarted at 0, so 6px is under the floor
+      diag.emitAnchorDrift(driftInfo({ residualPx: 12 }), 4000)
+      expect(warn).toHaveBeenCalledWith(
+        '[chatScroll]',
+        expect.stringContaining('drifted without correction'),
+        expect.objectContaining({ driftPxSinceLastWarn: 18, absorbsSinceLastWarn: 2 }),
+      )
+    })
+
+    it('carries the whole flush\'s commit totals, not only the last commit', () => {
+      const warn = spyWarn()
+      // The reported shape: a batched premeasure whose FINAL row measured exactly at its
+      // estimate (delta 0), while the flush as a whole shrank the map by 74px. Without the
+      // batch totals the payload says the geometry moved for no reason.
+      const { diag } = makeDiagnostics({
+        measurement: { delta: 0, commitSeq: 257 },
+        batch: { commits: 9, deltaSum: -68, totalHeightDelta: -74 },
+      })
+      diag.emitAnchorDrift(driftInfo({ residualPx: -74 }), 1000)
+      expect(warn).toHaveBeenCalledWith(
+        '[chatScroll]',
+        expect.stringContaining('drifted without correction'),
+        expect.objectContaining({
+          measurement: { delta: 0, commitSeq: 257 },
+          batch: { commits: 9, deltaSum: -68, totalHeightDelta: -74 },
+        }),
+      )
+    })
+
+    it('never reports a deferred-fling drift, whatever its size', () => {
+      // NOT because it is transient -- the fling-settle drops the drift and re-anchors, so it
+      // is permanent too. It is excluded because the reader watched the viewport coast to that
+      // position under their own gesture, which makes landing there expected, not an anomaly.
+      const warn = spyWarn()
+      const { diag } = makeDiagnostics()
+      for (let i = 0; i < 5; i++)
+        diag.emitAnchorDrift(driftInfo({ reason: 'deferred-fling', residualPx: 400 }), 1000 + i)
+      expect(warn).not.toHaveBeenCalled()
+    })
+
+    it('does not let a deferred-fling drift feed the absorbed running total', () => {
+      // The reason filter runs BEFORE the accumulator. If it did not, one deferred fling would
+      // push the sum past the floor and make the next unrelated absorb warn for it.
+      const warn = spyWarn()
+      const { diag } = makeDiagnostics()
+      diag.emitAnchorDrift(driftInfo({ reason: 'deferred-fling', residualPx: 400 }), 1000)
+      diag.emitAnchorDrift(driftInfo({ residualPx: 6 }), 2000)
+      expect(warn).not.toHaveBeenCalled()
+    })
+
+    it('warns exactly at the floor, not below it', () => {
       const warn = spyWarn()
       const { diag } = makeDiagnostics()
       diag.emitAnchorDrift(driftInfo({ residualPx: ANCHOR_DRIFT_WARN_PX - 1 }), 1000)
       expect(warn).not.toHaveBeenCalled()
-      diag.emitAnchorDrift(driftInfo({ residualPx: ANCHOR_DRIFT_WARN_PX }), 5000)
+      const { diag: fresh } = makeDiagnostics()
+      fresh.emitAnchorDrift(driftInfo({ residualPx: ANCHOR_DRIFT_WARN_PX }), 1000)
       expect(warn).toHaveBeenCalledTimes(1)
     })
 
-    it('ignores a drift while the tracker still reports an active fling', () => {
-      const warn = spyWarn()
-      const { diag } = makeDiagnostics({ flinging: true })
-      diag.emitAnchorDrift(driftInfo({ residualPx: 400 }), 1000)
-      expect(warn).not.toHaveBeenCalled()
-    })
-
-    it('rate-limits within the window and carries the suppressed count + residual sum forward', () => {
+    it('rate-limits within the window and keeps accumulating across it', () => {
       const warn = spyWarn()
       const { diag } = makeDiagnostics()
-      diag.emitAnchorDrift(driftInfo({ residualPx: 40 }), 0) // warns, resets counters
+      diag.emitAnchorDrift(driftInfo({ residualPx: 40 }), 0) // warns, resets the total
       warn.mockClear()
       // The window is measured from the LAST WARN (0), not the last event.
-      diag.emitAnchorDrift(driftInfo({ residualPx: 40 }), 500) // suppressed
-      diag.emitAnchorDrift(driftInfo({ residualPx: -30 }), 900) // suppressed
+      diag.emitAnchorDrift(driftInfo({ residualPx: 40 }), 500) // over the floor, but rate-limited
+      diag.emitAnchorDrift(driftInfo({ residualPx: -30 }), 900) // still inside the window
       expect(warn).not.toHaveBeenCalled()
       diag.emitAnchorDrift(driftInfo({ residualPx: 50 }), 1100) // 1100 - 0 > 1000 -> warns
       expect(warn).toHaveBeenCalledWith(
         '[chatScroll]',
         expect.stringContaining('drifted without correction'),
-        // Math.round(40 + -30) = 10; the aggregate rides along, then resets.
-        expect.objectContaining({ residualPx: 50, suppressedSinceLastWarn: 2, suppressedResidualPxSum: 10 }),
+        // 40 - 30 + 50: nothing the rate limit held back is lost from the total.
+        expect.objectContaining({ residualPx: 50, driftPxSinceLastWarn: 60, absorbsSinceLastWarn: 3 }),
       )
     })
   })
 
-  describe('emitunexplainedjump (detector b)', () => {
+  describe('emitUnexplainedJump (detector b)', () => {
     it('warns on the first jump and assembles the full payload', () => {
       const warn = spyWarn()
-      const { diag } = makeDiagnostics({ measurement: { m: 1 }, markers: ['echo'], dom: { scrollTop: 2 } })
+      const { diag } = makeDiagnostics({
+        measurement: { m: 1 },
+        batch: { commits: 3, deltaSum: -12, totalHeightDelta: -40 },
+        markers: ['echo'],
+        dom: { scrollTop: 2 },
+      })
       diag.emitUnexplainedJump(
         jumpInfo({ deltaFromLast: 300, scrollTop: 300, lastScrollTop: 0, msSinceLastScrollEvent: 20, speedPxPerMs: 1.5, wasActivelyFlinging: false }),
         5000,
@@ -236,6 +337,9 @@ describe('chatscrolldiagnostics createscrolldiagnostics', () => {
           wasActivelyFlinging: false,
           suppressedSinceLastWarn: 0,
           measurement: { m: 1 },
+          // A jump that coincides with a geometry flush points at a render cause rather than
+          // momentum, so Detector B carries the same batch totals as the drift payload.
+          batch: { commits: 3, deltaSum: -12, totalHeightDelta: -40 },
           markers: ['echo'],
           dom: { scrollTop: 2 },
         }),

--- a/frontend/src/components/chat/chatScrollDiagnostics.ts
+++ b/frontend/src/components/chat/chatScrollDiagnostics.ts
@@ -41,10 +41,16 @@ export const UNEXPLAINED_JUMP_MIN_PX = 32
  */
 export const VISIBLE_ANCHOR_JUMP_PX = 8
 /**
- * Detector C floor: a re-pin that leaves the anchored row displaced on-screen instead of
- * correcting it (an ABSORBED slow-scroll correction -- see useChatScroll's onAnchorDrift)
- * shifts content with no scroll event, so Detector B can't see it. Below this the shift
- * is imperceptible; at or above it the reader notices content move.
+ * Detector C floor, applied to the CUMULATIVE absorbed shift since the last WARN. A re-pin
+ * that leaves the anchored row displaced instead of correcting it (an ABSORBED slow-scroll
+ * correction -- see useChatScroll's onAnchorDrift) shifts content with no scroll event, so
+ * Detector B can't see it, and the engine re-anchors at the displaced position, so each
+ * absorb keeps its displacement and the next one adds to it.
+ *
+ * The sum is what the reader perceives, so the sum is what this gates. Testing it per event
+ * instead reports nothing at all whenever the engine's absorb cap sits below this number
+ * (it is 8px today), while the content still moves a whole screen, one imperceptible step at
+ * a time.
  */
 export const ANCHOR_DRIFT_WARN_PX = 16
 /**
@@ -208,16 +214,25 @@ export interface UnexplainedJumpInfo {
 export interface ScrollDiagnosticsDeps {
   /** WARN-payload DOM snapshot; undefined when the list isn't mounted. Sampled lazily per WARN. */
   domSnapshot: () => Record<string, unknown> | undefined
-  /** The virtualizer's last geometry commit, correlated into the drift / jump payloads. */
+  /** The virtualizer's last geometry commit, correlated into every detector's payload. */
   lastMeasurement: () => unknown
+  /**
+   * The whole flush's commit totals, beside lastMeasurement. A batched premeasure commits a
+   * band at once and keeps only the LAST commit in lastMeasurement, so its `delta` routinely
+   * fails to account for the residual (the reported drifts carried `delta: 0` against a 74px
+   * shift). See MeasurementBatchInfo.
+   *
+   * The caller must stamp the totals with an `ageMs`, because two of the three detectors can
+   * fire outside a geometry flush and would otherwise print an unrelated older flush as this
+   * event's cause. See useChatScroll's measurementBatchPayload.
+   */
+  measurementBatch: () => unknown
   /** The programmatic-guard marker trail, for the Detector B payload. */
   debugMarkers: () => unknown
   /** Whether older history still exists past the loaded TOP edge (Detector A: was the clamp avoidable?). */
   hasOlderMessages: () => boolean
   /** Whether newer history still exists past the loaded BOTTOM edge (Detector A). */
   hasNewerMessages: () => boolean
-  /** Whether the velocity tracker currently reports an active fling (Detector C skips those frames). */
-  isActivelyFlinging: () => boolean
 }
 
 export interface ScrollDiagnostics {
@@ -248,11 +263,24 @@ export function createScrollDiagnostics(deps: ScrollDiagnosticsDeps): ScrollDiag
   // zero epoch (a monotonic clock starts near 0 at page load).
   let lastUnexplainedJumpAt = Number.NEGATIVE_INFINITY
   let unexplainedJumpsSuppressed = 0
-  // Detector C rate-limit bookkeeping (FIXED window from the last emitted WARN, see
-  // ANCHOR_DRIFT_REWARN_MS): the count and signed residual sum of the shifts absorbed since.
+  // Detector C bookkeeping: the count and signed sum of every shift absorbed since the last
+  // emitted WARN. This is the QUANTITY the detector tests, not a by-product of the rate limit
+  // (see emitAnchorDrift), plus the fixed re-warn window (ANCHOR_DRIFT_REWARN_MS).
   let lastAnchorDriftWarnAt = Number.NEGATIVE_INFINITY
-  let anchorDriftWarnsSuppressed = 0
-  let anchorDriftSuppressedPxSum = 0
+  let absorbsSinceLastWarn = 0
+  let absorbedPxSinceLastWarn = 0
+
+  // What every WARN owes about the geometry underneath it: which commit moved the offset map
+  // last, what the whole flush totalled (a batched premeasure commits a band at once, so one
+  // commit rarely explains the residual), and the DOM at WARN time. Built in ONE place so the
+  // next correlation field is added once rather than three times -- adding `batch` had to
+  // touch all three payloads, and the clamp payload had been missing both fields until then.
+  // A thunk, so every emitter's early returns still run before any snapshot is taken.
+  const causationContext = () => ({
+    measurement: deps.lastMeasurement(),
+    batch: deps.measurementBatch(),
+    dom: deps.domSnapshot(),
+  })
 
   // Detector A: a keep-position re-pin clamped against a scroll boundary, so the
   // anchored row jumped by the clamp amount. WARN only when the shift is visible AND
@@ -268,47 +296,51 @@ export function createScrollDiagnostics(deps: ScrollDiagnosticsDeps): ScrollDiag
       scrollLog.warn('anchor re-pin clamped at a loaded edge -- anchored row jumped', {
         ...info,
         clampedAt: info.clampPx > 0 ? 'top' : 'bottom',
-        dom: deps.domSnapshot(),
+        ...causationContext(),
       })
     }
   }
 
-  // Detector C (outcome-based): the re-pin left the anchored row displaced by
-  // residualPx instead of correcting it -- a content shift that produces NO scroll
-  // event, so Detector B can't see it. Only an ABSORBED shift is reported: it is a
-  // permanent, user-visible displacement. A 'deferred-fling' shift is transient by
-  // construction -- the engine defers only under a live (or cold-seed presumed) fling
-  // and the fling-settle re-anchors it once momentum stops. Surface absorbed shifts above
-  // the visible floor, skip the fast-fling frames (isActivelyFlinging -- the shift blends
-  // into momentum there), and rate-limit the rest (see ANCHOR_DRIFT_REWARN_MS): what
-  // survives is an aggregate of the shifts the reader perceives while scrolling slowly or
-  // just after stopping.
+  // Detector C (outcome-based): the re-pin left the anchored row displaced instead of
+  // correcting it -- a content shift that produces NO scroll event, so Detector B can't see
+  // it. Only an ABSORBED shift is reported. It is permanent: the engine re-anchors AT the
+  // displaced position, so the displacement stays and the next absorb adds to it.
+  //
+  // The tested quantity is therefore the RUNNING SUM since the last WARN, not one event. A
+  // per-event floor missed the real harm and, once the engine's absorb cap dropped under this
+  // floor, missed every absorb: no single shift can reach 16px when the cap is 8, so the
+  // detector fell permanently silent while content still moved. Forty 6px absorbs move the
+  // content a quarter of a screen, and each one alone is imperceptible.
+  //
+  // A 'deferred-fling' shift is NOT reported here, but not because it is transient: the
+  // fling-settle drops the accumulated correction and re-anchors, so that shift is permanent
+  // too. It is excluded because the reader watched the viewport coast to that position under
+  // their own gesture, which is the one case where landing at the shifted position is what
+  // they expect. Only the drop-with-no-gesture case is an anomaly.
   const emitAnchorDrift = (info: AnchorDriftInfo, now: number): void => {
-    if (info.reason !== 'absorbed'
-      || Math.abs(info.residualPx) < ANCHOR_DRIFT_WARN_PX
-      || deps.isActivelyFlinging()) {
+    if (info.reason !== 'absorbed')
       return
-    }
-    if (now - lastAnchorDriftWarnAt <= ANCHOR_DRIFT_REWARN_MS) {
-      anchorDriftWarnsSuppressed += 1
-      anchorDriftSuppressedPxSum += info.residualPx
+    absorbsSinceLastWarn += 1
+    absorbedPxSinceLastWarn += info.residualPx
+    // No fast-fling skip here, because an absorbed shift can never BE a fast-fling frame: the
+    // engine produces 'absorbed' only when isFling() is false, which requires a fresh sample
+    // BELOW the fling threshold -- the exact complement of isActivelyFlinging(). A guard on it
+    // would read as protection and suppress nothing.
+    if (Math.abs(absorbedPxSinceLastWarn) < ANCHOR_DRIFT_WARN_PX)
       return
-    }
+    if (now - lastAnchorDriftWarnAt <= ANCHOR_DRIFT_REWARN_MS)
+      return
     lastAnchorDriftWarnAt = now
     scrollLog.warn('anchored content drifted without correction', {
       ...info,
-      // Absorbed shifts rate-limited away since the previous WARN (count + signed sum),
-      // so the aggregate drift is still visible in the emitted stream.
-      suppressedSinceLastWarn: anchorDriftWarnsSuppressed,
-      suppressedResidualPxSum: Math.round(anchorDriftSuppressedPxSum),
-      // The measurement that moved the geometry this re-pin absorbed: firstMeasure + delta
-      // tell whether it was an estimate->real correction or a re-measure, and whether this
-      // single commit's delta accounts for residualPx or a batch did.
-      measurement: deps.lastMeasurement(),
-      dom: deps.domSnapshot(),
+      // The accumulated shift this WARN reports, and how many absorbs built it (this one
+      // included). `residualPx` above is only the single absorb that crossed the floor.
+      driftPxSinceLastWarn: Math.round(absorbedPxSinceLastWarn),
+      absorbsSinceLastWarn,
+      ...causationContext(),
     })
-    anchorDriftWarnsSuppressed = 0
-    anchorDriftSuppressedPxSum = 0
+    absorbsSinceLastWarn = 0
+    absorbedPxSinceLastWarn = 0
   }
 
   // Detector B: warn on an unexplained teleport between two consecutive scroll events (the
@@ -337,9 +369,8 @@ export function createScrollDiagnostics(deps: ScrollDiagnosticsDeps): ScrollDiag
       wasActivelyFlinging: info.wasActivelyFlinging,
       // Unexplained events burst-suppressed since the previous emitted WARN.
       suppressedSinceLastWarn: unexplainedJumpsSuppressed,
-      measurement: deps.lastMeasurement(),
       markers: deps.debugMarkers(),
-      dom: deps.domSnapshot(),
+      ...causationContext(),
     })
     unexplainedJumpsSuppressed = 0
   }

--- a/frontend/src/components/chat/chatScrollVelocity.test.ts
+++ b/frontend/src/components/chat/chatScrollVelocity.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { createScrollVelocity } from './chatScrollVelocity'
 
-describe('chatscrollvelocity', () => {
+describe('createScrollVelocity', () => {
   it('measures the sample after a programmatic write over the interval since the WRITE, not the last real sample', () => {
     let clock = 0
     const v = createScrollVelocity({ now: () => clock, thresholdPxPerMs: 1, idleMs: 100 })
@@ -63,5 +63,115 @@ describe('chatscrollvelocity', () => {
     clock = 11
     v.sample(5100)
     expect(v.speed()).toBeCloseTo(5000, 5)
+  })
+
+  describe('isCoasting', () => {
+    const make = (now: () => number) => createScrollVelocity({ now, thresholdPxPerMs: 1, idleMs: 100 })
+
+    it('stays latched through the decaying tail a speed test calls stopped', () => {
+      // The whole reason this predicate exists. Momentum decays continuously, so the coast
+      // crosses below the fling threshold while the viewport still plainly moves. A scrollTop
+      // write in that window kills the coast under the reader's finger.
+      let clock = 0
+      const v = make(() => clock)
+      v.sample(0)
+      clock = 10
+      v.sample(100) // 10 px/ms: a fling, which latches the coast
+      expect(v.isCoasting()).toBe(true)
+      expect(v.isActivelyFlinging()).toBe(true)
+
+      clock = 20
+      v.sample(105) // 0.5 px/ms: under the threshold, but still 5px of real motion
+      expect(v.isActivelyFlinging()).toBe(false) // the speed test gives up here
+      expect(v.isCoasting()).toBe(true) // ...and this is why it must not decide
+
+      clock = 30
+      v.sample(107) // 0.2 px/ms: slower still, and still moving
+      expect(v.isCoasting()).toBe(true)
+    })
+
+    it('clears once the motion actually stops', () => {
+      let clock = 0
+      const v = make(() => clock)
+      v.sample(0)
+      clock = 10
+      v.sample(100)
+      expect(v.isCoasting()).toBe(true)
+      clock = 20
+      v.sample(100) // the viewport came to rest: zero displacement
+      expect(v.isCoasting()).toBe(false)
+    })
+
+    it('clears when the samples go stale, so a resumed gesture starts clean', () => {
+      let clock = 0
+      const v = make(() => clock)
+      v.sample(0)
+      clock = 10
+      v.sample(100)
+      expect(v.isCoasting()).toBe(true)
+      clock = 200 // past idleMs with no sample: the motion ended
+      expect(v.isCoasting()).toBe(false)
+      // A slow gesture that resumes after the gap must not inherit the old latch.
+      v.sample(150)
+      clock = 400
+      v.sample(160) // 0.05 px/ms
+      expect(v.isCoasting()).toBe(false)
+    })
+
+    it('never latches on a slow deliberate scroll', () => {
+      // Where an immediate correction is the CORRECT behavior. Latching here would defer
+      // corrections that should be written, which is the bug in the other direction.
+      let clock = 0
+      const v = make(() => clock)
+      v.sample(0)
+      for (const [t, pos] of [[100, 10], [200, 20], [300, 30]] as const) {
+        clock = t
+        v.sample(pos) // 0.1 px/ms throughout
+      }
+      expect(v.isCoasting()).toBe(false)
+    })
+
+    it('is false before a fling establishes it, even on the unknown cold seed', () => {
+      const clock = 0
+      const v = make(() => clock)
+      expect(v.isCoasting()).toBe(false) // unseeded
+      v.sample(0)
+      // One sample cannot establish a speed (velocity is the Infinity seed), and isFling's
+      // defer-bias reports true here -- isCoasting must not inherit that bias.
+      expect(v.isFling()).toBe(true)
+      expect(v.isCoasting()).toBe(false)
+    })
+
+    it('drops the latch when the user supplies a fresh wheel notch', () => {
+      // A brisk deliberate wheel scroll can cross the threshold for one sample. Without
+      // noteUserInput that sample would latch a coast that never happens, and every slower
+      // sample after it would hold the latch for the rest of the gesture.
+      let clock = 0
+      const v = make(() => clock)
+      v.sample(0)
+      clock = 10
+      v.sample(100) // one brisk notch measures as a fling
+      expect(v.isCoasting()).toBe(true)
+      v.noteUserInput() // ...but the user drove it, so it is not inertia
+      expect(v.isCoasting()).toBe(false)
+      clock = 20
+      v.sample(105) // the gesture continues slowly and must not re-latch
+      expect(v.isCoasting()).toBe(false)
+    })
+
+    it('re-latches from a real coast\'s own samples after the last wheel notch', () => {
+      // The counterpart: a trackpad flick ends with a wheel event, then the OS drives the
+      // coast with bare scroll events. Those fast samples must latch it again.
+      let clock = 0
+      const v = make(() => clock)
+      v.sample(0)
+      v.noteUserInput() // finger-on wheel event
+      clock = 16
+      v.sample(120) // 7.5 px/ms, driven by the OS -- no further wheel input
+      expect(v.isCoasting()).toBe(true)
+      clock = 32
+      v.sample(150) // 1.875 px/ms, decaying
+      expect(v.isCoasting()).toBe(true)
+    })
   })
 })

--- a/frontend/src/components/chat/chatScrollVelocity.ts
+++ b/frontend/src/components/chat/chatScrollVelocity.ts
@@ -25,6 +25,11 @@ export function createScrollVelocity(deps: {
   let lastWriteTime = -1
   // px/ms over the last inter-event gap; Infinity until two samples establish it.
   let velocity = Number.POSITIVE_INFINITY
+  // Whether INERTIA currently carries the viewport (see isCoasting). A latch, not a speed
+  // test: momentum decays continuously, so the instant it drops under thresholdPxPerMs it is
+  // still moving the viewport, and a speed test calls that stopped. A fling LATCHES this; the
+  // motion itself clears it.
+  let coasting = false
   return {
     /** Record a scroll event at position `pos` (px). Call once per real (non-echo) scroll. */
     sample(pos: number) {
@@ -50,13 +55,35 @@ export function createScrollVelocity(deps: {
         // tail that coalesces can't hold a stale-high velocity past its real momentum.
         if (dt <= 0)
           return
-        velocity = Math.abs(pos - lastPos) / dt
+        const displacement = Math.abs(pos - lastPos)
+        velocity = displacement / dt
+        // Maintain the coast latch from DISPLACEMENT, not from the speed test. The previous
+        // motion already stopped if this sample arrives past the idle window, so any earlier
+        // coast ended and this is a new gesture. A sample that moved nothing means the
+        // viewport came to rest. Otherwise a fling-speed sample latches the coast, and every
+        // slower sample after it keeps the latch while the viewport still moves -- which is
+        // the whole point, because that decaying tail is exactly what a speed test misses.
+        if (t - lastTime > deps.idleMs || displacement === 0)
+          coasting = false
+        else if (velocity >= deps.thresholdPxPerMs)
+          coasting = true
       }
       seeded = true
       lastPos = pos
       lastTime = t
       // A real sample supersedes any pending programmatic-write baseline.
       lastWriteTime = -1
+    },
+    /**
+     * Report that the user supplied a fresh scroll increment (a wheel notch). A scroll the
+     * user drives right now is not inertia, however fast it measures, so this clears the coast
+     * latch. It exists because a brisk deliberate wheel scroll can cross thresholdPxPerMs for
+     * one sample, and without this that sample would latch a coast that never happens. A real
+     * momentum coast re-latches immediately from its own fast samples, because the OS drives
+     * it with bare scroll events and sends no further wheel input.
+     */
+    noteUserInput() {
+      coasting = false
     },
     /**
      * Advance the position baseline to `pos` for a PROGRAMMATIC scroll write (a re-pin
@@ -102,6 +129,25 @@ export function createScrollVelocity(deps: {
       if (deps.now() - lastTime > deps.idleMs)
         return false
       return Number.isFinite(velocity) && velocity >= deps.thresholdPxPerMs
+    },
+    /**
+     * Whether INERTIA still carries the viewport: momentum began and the motion has not
+     * stopped. This is the question "would a scrollTop write cancel the user's scroll?", and
+     * isActivelyFlinging does NOT answer it. That one asks how fast the viewport moves right
+     * now, and momentum decays continuously: the last few hundred ms of a trackpad coast run
+     * under thresholdPxPerMs while the viewport plainly still moves. A write there kills the
+     * coast under the reader's finger, and a speed test cannot see it coming.
+     *
+     * FALSE while idle (the sample went stale, so the motion stopped -> a write is safe) and
+     * FALSE before a fling establishes the latch, so a slow deliberate scroll -- where an
+     * immediate correction is correct -- never reads as inertia.
+     */
+    isCoasting(): boolean {
+      if (!seeded)
+        return false
+      if (deps.now() - lastTime > deps.idleMs)
+        return false
+      return coasting
     },
     /**
      * The current scroll speed in px/ms, for the render-ahead overscan that paints

--- a/frontend/src/components/chat/useChatScroll.anchorRepin.test.ts
+++ b/frontend/src/components/chat/useChatScroll.anchorRepin.test.ts
@@ -6,11 +6,11 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { FLING_SETTLE_MS } from './chatScrollFlingSettle'
 import { useChatScroll } from './useChatScroll'
-import { installScrollTestEnv, makeFakeScrollDiv, measurementDeferralNoOps } from './useChatScroll.testkit'
+import { installScrollTestEnv, makeFakeScrollDiv, makeShiftingVirtualizer, virtualizerNoOps } from './useChatScroll.testkit'
 
 installScrollTestEnv()
 
-describe('usechatscroll scroll coordinate normalization', () => {
+describe('useChatScroll scroll coordinate normalization', () => {
   it('uses clamped scrollTop for viewport and anchor logic during rubber-band overscroll', () =>
     new Promise<void>((resolve, reject) => {
       createRoot(async (dispose) => {
@@ -23,7 +23,7 @@ describe('usechatscroll scroll coordinate normalization', () => {
           const updateViewport = vi.fn()
           const anchorAt = vi.fn((top: number): ScrollAnchor => ({ id: `top@${top}`, offsetWithinRow: 0 }))
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => 5000,
             geometryVersion: () => 0,
             updateViewport,
@@ -62,7 +62,7 @@ describe('usechatscroll scroll coordinate normalization', () => {
     }))
 })
 
-describe('usechatscroll anchor re-pin', () => {
+describe('useChatScroll anchor re-pin', () => {
   // A controllable virtualizer where the anchored row sits at `rowOffset`.
   // `prepend(px)` simulates older history landing above it: the row's offset
   // and the total height both grow, which should re-pin scrollTop so the row
@@ -72,7 +72,7 @@ describe('usechatscroll anchor re-pin', () => {
     let rowOffset = 90
     const [version, setVersion] = createSignal(0)
     const virt: ChatScrollVirtualizer = {
-      ...measurementDeferralNoOps(),
+      ...virtualizerNoOps(),
       totalHeight: () => {
         version()
         return total
@@ -367,6 +367,13 @@ describe('usechatscroll anchor re-pin', () => {
   it('tracks the latest captured anchor across consecutive geometry changes', () =>
     new Promise<void>((resolve, reject) => {
       createRoot(async (dispose) => {
+        // A controlled clock, so the gesture below is the SLOW scroll this test means to
+        // exercise. Two onScroll() calls back to back land microseconds apart under the real
+        // clock, which makes 180px of displacement measure as an ~18000 px/ms fling and routes
+        // the correction into the deferral instead of the write this asserts on. The anchor
+        // bookkeeping under test is independent of that; the timing must not decide it.
+        let clock = 1000
+        const nowSpy = vi.spyOn(performance, 'now').mockImplementation(() => clock)
         try {
           const div = makeFakeScrollDiv()
           div.setScrollHeight(5000)
@@ -396,7 +403,9 @@ describe('usechatscroll anchor re-pin', () => {
           expect(div.getScrollTop()).toBe(300)
 
           // User scrolls up again; the anchor must re-capture to the NEW position
-          // (not the stale one), so the next correction tracks it.
+          // (not the stale one), so the next correction tracks it. 180px over 500ms is
+          // 0.36 px/ms -- a slow deliberate gesture, well under the fling threshold.
+          clock += 500
           div.setScrollTop(120)
           hook.handlers.onScroll()
           ctrl.prepend(100) // rowOffset 190 -> 290
@@ -404,10 +413,12 @@ describe('usechatscroll anchor re-pin', () => {
           await Promise.resolve()
           // New anchor (offsetWithinRow 120 - 190 = -70): 290 + (-70).
           expect(div.getScrollTop()).toBe(220)
+          nowSpy.mockRestore()
           dispose()
           resolve()
         }
         catch (e) {
+          nowSpy.mockRestore()
           dispose()
           reject(e instanceof Error ? e : new Error(String(e)))
         }
@@ -1013,7 +1024,7 @@ describe('usechatscroll anchor re-pin', () => {
           let rowOffset = 290
           const [version, setVersion] = createSignal(0)
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => {
               version()
               return 5000
@@ -1086,35 +1097,7 @@ describe('usechatscroll anchor re-pin', () => {
           // after it a tall row occupies the space above, so the SAME (un-
           // corrected) scrollTop now maps to a different row ('tall-row').
           const SHIFT = 3000
-          const ANCHOR_OFFSET = 290
-          let armed = false
-          let shifted = false
-          const [version, setVersion] = createSignal(0)
-          const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
-            totalHeight: () => {
-              version()
-              return shifted ? 8000 + SHIFT : 8000
-            },
-            geometryVersion: version,
-            updateViewport: () => {
-              if (armed && !shifted) {
-                shifted = true
-                setVersion(v => v + 1)
-              }
-            },
-            anchorAt: scrollTop => shifted
-              ? { id: 'tall-row', offsetWithinRow: scrollTop }
-              : { id: 'anchored-row', offsetWithinRow: scrollTop - ANCHOR_OFFSET },
-            scrollTopNearAnchor: () => null,
-            scrollTopForAnchor: (a) => {
-              if (a.id === 'anchored-row')
-                return (shifted ? ANCHOR_OFFSET + SHIFT : ANCHOR_OFFSET) + a.offsetWithinRow
-              // The wrong anchor (captured against the shifted map) resolves back
-              // to the un-corrected scrollTop -> the visible jump.
-              return a.offsetWithinRow
-            },
-          }
+          const { virt, arm } = makeShiftingVirtualizer(SHIFT, { reanchorWhenShifted: true })
 
           const hook = useChatScroll({ virtualizer: virt, messages, streamingText })
           hook.attachListRef(div.el)
@@ -1130,7 +1113,7 @@ describe('usechatscroll anchor re-pin', () => {
           // spacer, so scrollTop tracks to 300 + 3000. Capturing the anchor after
           // the shift leaves the re-pin with no usable anchor, so scrollTop stays
           // at 300 and the content jumps (the tall row fills the viewport).
-          armed = true
+          arm()
           div.setScrollTop(300)
           hook.handlers.onScroll()
           await Promise.resolve()
@@ -1162,7 +1145,7 @@ describe('usechatscroll anchor re-pin', () => {
           // A measurement below the midpoint anchor: scrollTopForAnchor resolves to within
           // a sub-pixel of the current viewport midpoint (the anchor didn't move).
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => {
               version()
               return 5000
@@ -1213,37 +1196,13 @@ describe('usechatscroll anchor re-pin', () => {
           // Visible-row measurements use a separate deferral queue; this stub pins
           // the re-pin policy for geometry that has already committed.
           const SHIFT = 100
-          const ANCHOR_OFFSET = 290
-          let armed = false
-          let shifted = false
-          const [version, setVersion] = createSignal(0)
-          const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
-            totalHeight: () => {
-              version()
-              return shifted ? 8000 + SHIFT : 8000
-            },
-            geometryVersion: version,
-            updateViewport: () => {
-              if (armed && !shifted) {
-                shifted = true
-                setVersion(v => v + 1)
-              }
-            },
-            anchorAt: scrollTop => shifted
-              ? { id: 'tall-row', offsetWithinRow: scrollTop }
-              : { id: 'anchored-row', offsetWithinRow: scrollTop - ANCHOR_OFFSET },
-            scrollTopNearAnchor: () => null,
-            scrollTopForAnchor: a => (a.id === 'anchored-row'
-              ? (shifted ? ANCHOR_OFFSET + SHIFT : ANCHOR_OFFSET) + a.offsetWithinRow
-              : a.offsetWithinRow),
-          }
+          const { virt, arm } = makeShiftingVirtualizer(SHIFT, { reanchorWhenShifted: true })
           const hook = useChatScroll({ virtualizer: virt, messages, streamingText })
           hook.attachListRef(div.el)
           await Promise.resolve()
           await Promise.resolve()
 
-          armed = true
+          arm()
           div.setScrollTop(300)
           hook.handlers.onScroll()
           await Promise.resolve()
@@ -1261,7 +1220,7 @@ describe('usechatscroll anchor re-pin', () => {
       })
     }))
 
-  it('absorbs a medium re-pin correction during a slow native scroll', () =>
+  it('corrects a medium re-pin correction during a slow native scroll', () =>
     new Promise<void>((resolve, reject) => {
       // Fake performance.now too, so the velocity tracker sees a controllable,
       // genuinely-slow cadence instead of two same-tick (Infinity) samples.
@@ -1275,34 +1234,10 @@ describe('usechatscroll anchor re-pin', () => {
           const [messages] = createSignal<AgentChatMessage[]>([])
           const [streamingText] = createSignal('')
           // Same 100px under-estimate shift the fling test defers -- but reached by a
-          // SLOW native scroll. It is still a browser-owned scroll event, so writing
-          // scrollTop here fights the user's trajectory; absorb/re-anchor instead.
+          // SLOW native scroll. There is no momentum for a write to cancel, and 100px is
+          // far past what the reader can miss, so the re-pin compensates it.
           const SHIFT = 100
-          const ANCHOR_OFFSET = 290
-          let armed = false
-          let shifted = false
-          const [version, setVersion] = createSignal(0)
-          const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
-            totalHeight: () => {
-              version()
-              return shifted ? 8000 + SHIFT : 8000
-            },
-            geometryVersion: version,
-            updateViewport: () => {
-              if (armed && !shifted) {
-                shifted = true
-                setVersion(v => v + 1)
-              }
-            },
-            anchorAt: scrollTop => shifted
-              ? { id: 'tall-row', offsetWithinRow: scrollTop }
-              : { id: 'anchored-row', offsetWithinRow: scrollTop - ANCHOR_OFFSET },
-            scrollTopNearAnchor: () => null,
-            scrollTopForAnchor: a => (a.id === 'anchored-row'
-              ? (shifted ? ANCHOR_OFFSET + SHIFT : ANCHOR_OFFSET) + a.offsetWithinRow
-              : a.offsetWithinRow),
-          }
+          const { virt, arm } = makeShiftingVirtualizer(SHIFT, { reanchorWhenShifted: true })
           const hook = useChatScroll({ virtualizer: virt, messages, streamingText })
           hook.attachListRef(div.el)
           await Promise.resolve()
@@ -1315,16 +1250,16 @@ describe('usechatscroll anchor re-pin', () => {
           await Promise.resolve()
 
           // 100ms later, a 10px nudge = 0.1 px/ms, far below the fling threshold.
-          // The row mounts+shifts during THIS event, so the re-pin fires. A medium
-          // estimate correction is absorbed rather than written (310 -> 410 would
-          // be a visible bounce in the slow tail of a trackpad scroll).
+          // The row mounts+shifts during THIS event, so the re-pin fires. Absorbing the
+          // correction would leave the anchored row displaced 100px on screen for good;
+          // writing it keeps the row on the line the reader reads.
           vi.advanceTimersByTime(100)
-          armed = true
+          arm()
           div.setScrollTop(310)
           hook.handlers.onScroll()
           await Promise.resolve()
           await Promise.resolve()
-          expect(div.getScrollTop()).toBe(310)
+          expect(div.getScrollTop()).toBe(410)
 
           vi.useRealTimers()
           dispose()
@@ -1355,37 +1290,13 @@ describe('usechatscroll anchor re-pin', () => {
           // deferred during the fling. Once momentum stops, the current visual
           // position wins; the settle re-anchors there instead of snapping by 100px.
           const SHIFT = 100
-          const ANCHOR_OFFSET = 290
-          let armed = false
-          let shifted = false
-          const [version, setVersion] = createSignal(0)
-          const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
-            totalHeight: () => {
-              version()
-              return shifted ? 8000 + SHIFT : 8000
-            },
-            geometryVersion: version,
-            updateViewport: () => {
-              if (armed && !shifted) {
-                shifted = true
-                setVersion(v => v + 1)
-              }
-            },
-            anchorAt: scrollTop => shifted
-              ? { id: 'tall-row', offsetWithinRow: scrollTop }
-              : { id: 'anchored-row', offsetWithinRow: scrollTop - ANCHOR_OFFSET },
-            scrollTopNearAnchor: () => null,
-            scrollTopForAnchor: a => (a.id === 'anchored-row'
-              ? (shifted ? ANCHOR_OFFSET + SHIFT : ANCHOR_OFFSET) + a.offsetWithinRow
-              : a.offsetWithinRow),
-          }
+          const { virt, arm } = makeShiftingVirtualizer(SHIFT, { reanchorWhenShifted: true })
           const hook = useChatScroll({ virtualizer: virt, messages, streamingText })
           hook.attachListRef(div.el)
           await Promise.resolve()
           await Promise.resolve()
 
-          armed = true
+          arm()
           div.setScrollTop(300)
           hook.handlers.onScroll()
           await Promise.resolve()
@@ -1426,33 +1337,13 @@ describe('usechatscroll anchor re-pin', () => {
           // via a discrete keyboard PageDown rather than momentum. A discrete page
           // must apply the correction immediately, not defer it as fling drift.
           const SHIFT = 100
-          const ANCHOR_OFFSET = 290
-          let armed = false
-          let shifted = false
-          const [version, setVersion] = createSignal(0)
-          const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
-            totalHeight: () => {
-              version()
-              return shifted ? 8000 + SHIFT : 8000
-            },
-            geometryVersion: version,
-            updateViewport: () => {
-              if (armed && !shifted) {
-                shifted = true
-                setVersion(v => v + 1)
-              }
-            },
-            anchorAt: scrollTop => ({ id: 'anchored-row', offsetWithinRow: scrollTop - ANCHOR_OFFSET }),
-            scrollTopNearAnchor: () => null,
-            scrollTopForAnchor: a => (shifted ? ANCHOR_OFFSET + SHIFT : ANCHOR_OFFSET) + a.offsetWithinRow,
-          }
+          const { virt, arm } = makeShiftingVirtualizer(SHIFT)
           const hook = useChatScroll({ virtualizer: virt, messages, streamingText })
           hook.attachListRef(div.el)
           await Promise.resolve()
           await Promise.resolve()
 
-          armed = true
+          arm()
           div.setScrollTop(300) // re-seat after mount effects settle scrollTop
           // PageDown advances scrollTop by clientHeight - overlap (452) -> 752 and
           // flags the resulting scroll event as a discrete page.
@@ -1497,33 +1388,13 @@ describe('usechatscroll anchor re-pin', () => {
           // while a pointer is DOWN (a scrollbar drag). A drag has no momentum to
           // protect, so the correction must apply immediately, not defer.
           const SHIFT = 100
-          const ANCHOR_OFFSET = 290
-          let armed = false
-          let shifted = false
-          const [version, setVersion] = createSignal(0)
-          const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
-            totalHeight: () => {
-              version()
-              return shifted ? 8000 + SHIFT : 8000
-            },
-            geometryVersion: version,
-            updateViewport: () => {
-              if (armed && !shifted) {
-                shifted = true
-                setVersion(v => v + 1)
-              }
-            },
-            anchorAt: scrollTop => ({ id: 'anchored-row', offsetWithinRow: scrollTop - ANCHOR_OFFSET }),
-            scrollTopNearAnchor: () => null,
-            scrollTopForAnchor: a => (shifted ? ANCHOR_OFFSET + SHIFT : ANCHOR_OFFSET) + a.offsetWithinRow,
-          }
+          const { virt, arm } = makeShiftingVirtualizer(SHIFT)
           const hook = useChatScroll({ virtualizer: virt, messages, streamingText })
           hook.attachListRef(div.el)
           await Promise.resolve()
           await Promise.resolve()
 
-          armed = true
+          arm()
           div.setScrollTop(300) // re-seat after mount effects settle scrollTop
           // A scrollbar drag: the pointer is down while the scroll fires.
           hook.handlers.onPointerDown({ pointerType: 'mouse', clientY: 0, pointerId: 1, isPrimary: true } as PointerEvent)
@@ -1562,33 +1433,13 @@ describe('usechatscroll anchor re-pin', () => {
           const [messages] = createSignal<AgentChatMessage[]>([])
           const [streamingText] = createSignal('')
           const SHIFT = 100
-          const ANCHOR_OFFSET = 290
-          let armed = false
-          let shifted = false
-          const [version, setVersion] = createSignal(0)
-          const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
-            totalHeight: () => {
-              version()
-              return shifted ? 8000 + SHIFT : 8000
-            },
-            geometryVersion: version,
-            updateViewport: () => {
-              if (armed && !shifted) {
-                shifted = true
-                setVersion(v => v + 1)
-              }
-            },
-            anchorAt: scrollTop => ({ id: 'anchored-row', offsetWithinRow: scrollTop - ANCHOR_OFFSET }),
-            scrollTopNearAnchor: () => null,
-            scrollTopForAnchor: a => (shifted ? ANCHOR_OFFSET + SHIFT : ANCHOR_OFFSET) + a.offsetWithinRow,
-          }
+          const { virt, arm } = makeShiftingVirtualizer(SHIFT)
           const hook = useChatScroll({ virtualizer: virt, messages, streamingText })
           hook.attachListRef(div.el)
           await Promise.resolve()
           await Promise.resolve()
 
-          armed = true
+          arm()
           div.setScrollTop(300)
           // A pointer goes down (drag) but its pointerup is DROPPED (pointer-capture
           // transfer / gesture intercept) -- with a hand-balanced counter this would
@@ -1635,27 +1486,7 @@ describe('usechatscroll anchor re-pin', () => {
           const [messages] = createSignal<AgentChatMessage[]>([])
           const [streamingText] = createSignal('')
           const SHIFT = 100
-          const ANCHOR_OFFSET = 290
-          let armed = false
-          let shifted = false
-          const [version, setVersion] = createSignal(0)
-          const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
-            totalHeight: () => {
-              version()
-              return shifted ? 8000 + SHIFT : 8000
-            },
-            geometryVersion: version,
-            updateViewport: () => {
-              if (armed && !shifted) {
-                shifted = true
-                setVersion(v => v + 1)
-              }
-            },
-            anchorAt: scrollTop => ({ id: 'anchored-row', offsetWithinRow: scrollTop - ANCHOR_OFFSET }),
-            scrollTopNearAnchor: () => null,
-            scrollTopForAnchor: a => (shifted ? ANCHOR_OFFSET + SHIFT : ANCHOR_OFFSET) + a.offsetWithinRow,
-          }
+          const { virt, arm } = makeShiftingVirtualizer(SHIFT)
           // touchActive is derived from the live touch list, so lifting ONE finger of
           // a two-finger gesture must keep it active (a finger remains) -- the drag
           // correction stays immediate until the last finger lifts.
@@ -1665,7 +1496,7 @@ describe('usechatscroll anchor re-pin', () => {
           await Promise.resolve()
           await Promise.resolve()
 
-          armed = true
+          arm()
           div.setScrollTop(300)
           hook.handlers.onTouchStart(touchEvent(1)) // first finger
           hook.handlers.onTouchStart(touchEvent(2)) // second finger
@@ -1700,33 +1531,13 @@ describe('usechatscroll anchor re-pin', () => {
           const [messages] = createSignal<AgentChatMessage[]>([])
           const [streamingText] = createSignal('')
           const SHIFT = 100
-          const ANCHOR_OFFSET = 290
-          let armed = false
-          let shifted = false
-          const [version, setVersion] = createSignal(0)
-          const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
-            totalHeight: () => {
-              version()
-              return shifted ? 8000 + SHIFT : 8000
-            },
-            geometryVersion: version,
-            updateViewport: () => {
-              if (armed && !shifted) {
-                shifted = true
-                setVersion(v => v + 1)
-              }
-            },
-            anchorAt: scrollTop => ({ id: 'anchored-row', offsetWithinRow: scrollTop - ANCHOR_OFFSET }),
-            scrollTopNearAnchor: () => null,
-            scrollTopForAnchor: a => (shifted ? ANCHOR_OFFSET + SHIFT : ANCHOR_OFFSET) + a.offsetWithinRow,
-          }
+          const { virt, arm } = makeShiftingVirtualizer(SHIFT)
           const hook = useChatScroll({ virtualizer: virt, messages, streamingText })
           hook.attachListRef(div.el)
           await Promise.resolve()
           await Promise.resolve()
 
-          armed = true
+          arm()
           div.setScrollTop(300) // re-seat after mount effects settle scrollTop
           // PageDown arms the discrete page targeting scrollTop 752.
           hook.handlers.onKeyDown(new KeyboardEvent('keydown', { key: 'PageDown', cancelable: true }))
@@ -1765,37 +1576,13 @@ describe('usechatscroll anchor re-pin', () => {
           const [messages] = createSignal<AgentChatMessage[]>([])
           const [streamingText] = createSignal('')
           const SHIFT = 100
-          const ANCHOR_OFFSET = 290
-          let armed = false
-          let shifted = false
-          const [version, setVersion] = createSignal(0)
-          const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
-            totalHeight: () => {
-              version()
-              return shifted ? 8000 + SHIFT : 8000
-            },
-            geometryVersion: version,
-            updateViewport: () => {
-              if (armed && !shifted) {
-                shifted = true
-                setVersion(v => v + 1)
-              }
-            },
-            anchorAt: scrollTop => shifted
-              ? { id: 'tall-row', offsetWithinRow: scrollTop }
-              : { id: 'anchored-row', offsetWithinRow: scrollTop - ANCHOR_OFFSET },
-            scrollTopNearAnchor: () => null,
-            scrollTopForAnchor: a => (a.id === 'anchored-row'
-              ? (shifted ? ANCHOR_OFFSET + SHIFT : ANCHOR_OFFSET) + a.offsetWithinRow
-              : a.offsetWithinRow),
-          }
+          const { virt, arm } = makeShiftingVirtualizer(SHIFT, { reanchorWhenShifted: true })
           const hook = useChatScroll({ virtualizer: virt, messages, streamingText })
           hook.attachListRef(div.el)
           await Promise.resolve()
           await Promise.resolve()
 
-          armed = true
+          arm()
           div.setScrollTop(300)
           hook.handlers.onScroll() // defers 100px; arms the settle
           await Promise.resolve()
@@ -1844,7 +1631,7 @@ describe('usechatscroll anchor re-pin', () => {
             return true
           })
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => 8000,
             geometryVersion: () => 0,
             updateViewport: () => {},
@@ -1899,7 +1686,7 @@ describe('usechatscroll anchor re-pin', () => {
           const setFastScrollActive = vi.fn()
           const setVisibleMeasurementDeferral = vi.fn()
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => 8000,
             geometryVersion: () => 0,
             updateViewport: () => {},
@@ -1956,7 +1743,7 @@ describe('usechatscroll anchor re-pin', () => {
           const [streamingText] = createSignal('')
           const setFastScrollActive = vi.fn()
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => 8000,
             geometryVersion: () => 0,
             updateViewport: () => {},
@@ -2005,7 +1792,7 @@ describe('usechatscroll anchor re-pin', () => {
           const [streamingText] = createSignal('')
           const setFastScrollActive = vi.fn()
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => 8000,
             geometryVersion: () => 0,
             updateViewport: () => {},
@@ -2052,37 +1839,13 @@ describe('usechatscroll anchor re-pin', () => {
           const [messages] = createSignal<AgentChatMessage[]>([])
           const [streamingText] = createSignal('')
           const SHIFT = 100
-          const ANCHOR_OFFSET = 290
-          let armed = false
-          let shifted = false
-          const [version, setVersion] = createSignal(0)
-          const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
-            totalHeight: () => {
-              version()
-              return shifted ? 8000 + SHIFT : 8000
-            },
-            geometryVersion: version,
-            updateViewport: () => {
-              if (armed && !shifted) {
-                shifted = true
-                setVersion(v => v + 1)
-              }
-            },
-            anchorAt: scrollTop => shifted
-              ? { id: 'tall-row', offsetWithinRow: scrollTop }
-              : { id: 'anchored-row', offsetWithinRow: scrollTop - ANCHOR_OFFSET },
-            scrollTopNearAnchor: () => null,
-            scrollTopForAnchor: a => (a.id === 'anchored-row'
-              ? (shifted ? ANCHOR_OFFSET + SHIFT : ANCHOR_OFFSET) + a.offsetWithinRow
-              : a.offsetWithinRow),
-          }
+          const { virt, arm } = makeShiftingVirtualizer(SHIFT, { reanchorWhenShifted: true })
           const hook = useChatScroll({ virtualizer: virt, messages, streamingText })
           hook.attachListRef(div.el)
           await Promise.resolve()
           await Promise.resolve()
 
-          armed = true
+          arm()
           div.setScrollTop(300)
           hook.handlers.onScroll() // defers 100px; arms the settle
           await Promise.resolve()
@@ -2120,37 +1883,13 @@ describe('usechatscroll anchor re-pin', () => {
           const [messages] = createSignal<AgentChatMessage[]>([])
           const [streamingText] = createSignal('')
           const SHIFT = 100
-          const ANCHOR_OFFSET = 290
-          let armed = false
-          let shifted = false
-          const [version, setVersion] = createSignal(0)
-          const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
-            totalHeight: () => {
-              version()
-              return shifted ? 8000 + SHIFT : 8000
-            },
-            geometryVersion: version,
-            updateViewport: () => {
-              if (armed && !shifted) {
-                shifted = true
-                setVersion(v => v + 1)
-              }
-            },
-            anchorAt: scrollTop => shifted
-              ? { id: 'tall-row', offsetWithinRow: scrollTop }
-              : { id: 'anchored-row', offsetWithinRow: scrollTop - ANCHOR_OFFSET },
-            scrollTopNearAnchor: () => null,
-            scrollTopForAnchor: a => (a.id === 'anchored-row'
-              ? (shifted ? ANCHOR_OFFSET + SHIFT : ANCHOR_OFFSET) + a.offsetWithinRow
-              : a.offsetWithinRow),
-          }
+          const { virt, arm } = makeShiftingVirtualizer(SHIFT, { reanchorWhenShifted: true })
           const hook = useChatScroll({ virtualizer: virt, messages, streamingText })
           hook.attachListRef(div.el)
           await Promise.resolve()
           await Promise.resolve()
 
-          armed = true
+          arm()
           div.setScrollTop(300)
           hook.handlers.onScroll() // defers 100px; arms the settle
           await Promise.resolve()
@@ -2193,37 +1932,13 @@ describe('usechatscroll anchor re-pin', () => {
           // anchored row stationary would pull scrollTop DOWN by 100 — deferred
           // during the fling (|100| < clientHeight/2). flingDrift = -100.
           const SHIFT = -100
-          const ANCHOR_OFFSET = 290
-          let armed = false
-          let shifted = false
-          const [version, setVersion] = createSignal(0)
-          const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
-            totalHeight: () => {
-              version()
-              return shifted ? 8000 + SHIFT : 8000
-            },
-            geometryVersion: version,
-            updateViewport: () => {
-              if (armed && !shifted) {
-                shifted = true
-                setVersion(v => v + 1)
-              }
-            },
-            anchorAt: scrollTop => shifted
-              ? { id: 'tall-row', offsetWithinRow: scrollTop }
-              : { id: 'anchored-row', offsetWithinRow: scrollTop - ANCHOR_OFFSET },
-            scrollTopNearAnchor: () => null,
-            scrollTopForAnchor: a => (a.id === 'anchored-row'
-              ? (shifted ? ANCHOR_OFFSET + SHIFT : ANCHOR_OFFSET) + a.offsetWithinRow
-              : a.offsetWithinRow),
-          }
+          const { virt, arm } = makeShiftingVirtualizer(SHIFT, { reanchorWhenShifted: true })
           const hook = useChatScroll({ virtualizer: virt, messages, streamingText })
           hook.attachListRef(div.el)
           await Promise.resolve()
           await Promise.resolve()
 
-          armed = true
+          arm()
           div.setScrollTop(300)
           hook.handlers.onScroll() // defers -100; arms the settle
           await Promise.resolve()
@@ -2272,7 +1987,7 @@ describe('usechatscroll anchor re-pin', () => {
           let trimmed = false
           const [version, setVersion] = createSignal(0)
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => {
               version()
               return shifted ? 8000 + SHIFT : 8000
@@ -2355,7 +2070,7 @@ describe('usechatscroll anchor re-pin', () => {
           const SMALL = 100
           const [version, setVersion] = createSignal(0)
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => {
               version()
               return 40000
@@ -2417,35 +2132,13 @@ describe('usechatscroll anchor re-pin', () => {
           const [messages] = createSignal<AgentChatMessage[]>([])
           const [streamingText] = createSignal('')
           const SHIFT = -100
-          const ANCHOR_OFFSET = 290
-          let armed = false
-          let shifted = false
-          const [version, setVersion] = createSignal(0)
-          const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
-            totalHeight: () => {
-              version()
-              return shifted ? 8000 + SHIFT : 8000
-            },
-            geometryVersion: version,
-            updateViewport: () => {
-              if (armed && !shifted) {
-                shifted = true
-                setVersion(v => v + 1)
-              }
-            },
-            anchorAt: scrollTop => ({ id: 'anchored-row', offsetWithinRow: scrollTop - ANCHOR_OFFSET }),
-            scrollTopNearAnchor: () => null,
-            scrollTopForAnchor: a => (a.id === 'anchored-row'
-              ? (shifted ? ANCHOR_OFFSET + SHIFT : ANCHOR_OFFSET) + a.offsetWithinRow
-              : a.offsetWithinRow),
-          }
+          const { virt, arm } = makeShiftingVirtualizer(SHIFT)
           const hook = useChatScroll({ virtualizer: virt, messages, streamingText })
           hook.attachListRef(div.el)
           await Promise.resolve()
           await Promise.resolve()
 
-          armed = true
+          arm()
           div.setScrollTop(300)
           hook.handlers.onScroll() // defers -100; arms the settle
           await Promise.resolve()
@@ -2459,7 +2152,7 @@ describe('usechatscroll anchor re-pin', () => {
           // The user scrolls away from the bottom again BEFORE the settle fires,
           // re-capturing a fresh anchor (no further geometry shift). Without the
           // stick-time reset, the stale -100 would land on THIS anchor at settle.
-          armed = false
+          // The stub shifts once only, so no further geometry change lands here.
           div.setScrollTop(20000)
           hook.handlers.onScroll() // re-anchors at 20000, re-arms the settle
           await Promise.resolve()
@@ -2500,7 +2193,7 @@ describe('usechatscroll anchor re-pin', () => {
           let shiftLevel = 0
           const [version, setVersion] = createSignal(0)
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => {
               version()
               return 8000 + shiftLevel * SHIFT
@@ -2572,7 +2265,7 @@ describe('usechatscroll anchor re-pin', () => {
           let shiftB = false
           const [version, setVersion] = createSignal(0)
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => {
               version()
               return 8000 + (shiftA ? 50 : 0) + (shiftB ? 30 : 0)
@@ -2626,6 +2319,243 @@ describe('usechatscroll anchor re-pin', () => {
         catch (e) {
           dispose()
           vi.useRealTimers()
+          reject(e instanceof Error ? e : new Error(String(e)))
+        }
+      })
+    }))
+
+  it('defers a correction in the DECAYING tail of a coast, below the fling threshold', () =>
+    new Promise<void>((resolve, reject) => {
+      // Momentum decays continuously, so a coast spends its last few hundred ms under the
+      // 1 px/ms fling threshold while the viewport still plainly moves. A speed test reports
+      // "stopped" there and the engine wrote scrollTop into it, killing the coast under the
+      // reader's finger. The tracker latches the coast on the fling and clears it when the
+      // motion stops, so the tail is covered too.
+      vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
+      createRoot(async (dispose) => {
+        try {
+          const div = makeFakeScrollDiv()
+          div.setScrollHeight(40000)
+          div.setClientHeight(500)
+          div.setScrollTop(0)
+          const [messages] = createSignal<AgentChatMessage[]>([])
+          const [streamingText] = createSignal('')
+          const ctrl = makeControllableVirtualizer()
+          const hook = useChatScroll({ virtualizer: ctrl.virt, messages, streamingText })
+          hook.attachListRef(div.el)
+          await Promise.resolve()
+          await Promise.resolve()
+
+          div.setScrollTop(0)
+          hook.handlers.onScroll()
+          hook.handlers.onWheel({ deltaY: 200, deltaX: 0, ctrlKey: false } as WheelEvent)
+
+          // The flick, then a decelerating coast: 120px per frame down to 6px per frame.
+          // The last steps are 0.375 px/ms -- well UNDER the threshold, still real motion.
+          let top = 0
+          for (const step of [120, 120, 90, 60, 30, 12, 6]) {
+            vi.advanceTimersByTime(16)
+            top += step
+            div.setScrollTop(top)
+            hook.handlers.onScroll()
+          }
+          await Promise.resolve()
+          await Promise.resolve()
+          const beforeShift = div.getScrollTop()
+
+          // A premeasure lands in the tail. Inertia still carries the viewport, so the
+          // correction must be deferred, not written.
+          ctrl.shiftWithoutTotalChange(60)
+          await Promise.resolve()
+          await Promise.resolve()
+
+          expect(div.getScrollTop()).toBe(beforeShift)
+
+          vi.useRealTimers()
+          dispose()
+          resolve()
+        }
+        catch (e) {
+          vi.useRealTimers()
+          dispose()
+          reject(e instanceof Error ? e : new Error(String(e)))
+        }
+      })
+    }))
+
+  it('writes a correction once the coast comes to rest', () =>
+    new Promise<void>((resolve, reject) => {
+      // The other side of the latch: once the motion stops there is nothing left to cancel,
+      // so the correction must apply immediately. A latch that never cleared would turn every
+      // post-coast correction into permanent drift -- the bug this engine exists to avoid.
+      vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
+      createRoot(async (dispose) => {
+        try {
+          const div = makeFakeScrollDiv()
+          div.setScrollHeight(40000)
+          div.setClientHeight(500)
+          div.setScrollTop(0)
+          const [messages] = createSignal<AgentChatMessage[]>([])
+          const [streamingText] = createSignal('')
+          const ctrl = makeControllableVirtualizer()
+          const hook = useChatScroll({ virtualizer: ctrl.virt, messages, streamingText })
+          hook.attachListRef(div.el)
+          await Promise.resolve()
+          await Promise.resolve()
+
+          div.setScrollTop(0)
+          hook.handlers.onScroll()
+          hook.handlers.onWheel({ deltaY: 200, deltaX: 0, ctrlKey: false } as WheelEvent)
+          let top = 0
+          for (const step of [120, 120, 60]) {
+            vi.advanceTimersByTime(16)
+            top += step
+            div.setScrollTop(top)
+            hook.handlers.onScroll()
+          }
+          // The coast ends: no further scroll events, so the samples go stale.
+          vi.advanceTimersByTime(FLING_SETTLE_MS + 100)
+          await Promise.resolve()
+          await Promise.resolve()
+          const beforeShift = div.getScrollTop()
+
+          ctrl.shiftWithoutTotalChange(60)
+          await Promise.resolve()
+          await Promise.resolve()
+
+          expect(div.getScrollTop()).toBe(beforeShift + 60) // corrected, invisibly
+
+          vi.useRealTimers()
+          dispose()
+          resolve()
+        }
+        catch (e) {
+          vi.useRealTimers()
+          dispose()
+          reject(e instanceof Error ? e : new Error(String(e)))
+        }
+      })
+    }))
+
+  it('applies a re-pin correction during a FAST pointer drag, which measures like a fling', () =>
+    new Promise<void>((resolve, reject) => {
+      // The sibling drag tests fire a single scroll event, so the velocity tracker is still on
+      // its cold Infinity seed and reports no active fling whatever the wiring says. This one
+      // drives TWO events at a fling cadence with the pointer DOWN, so the speed predicate is
+      // genuinely true and only the direct-manipulation term can keep the drag out of the
+      // deferral. That matters: handleScroll schedules the fling-settle for momentum scrolls
+      // only, so a correction deferred by a drag is stranded with nothing to apply it.
+      vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
+      createRoot(async (dispose) => {
+        try {
+          const div = makeFakeScrollDiv()
+          div.setClientHeight(500)
+          div.setScrollHeight(40000)
+          div.setScrollTop(0)
+          const [messages] = createSignal<AgentChatMessage[]>([])
+          const [streamingText] = createSignal('')
+          const ctrl = makeControllableVirtualizer()
+          const hook = useChatScroll({ virtualizer: ctrl.virt, messages, streamingText })
+          hook.attachListRef(div.el)
+          await Promise.resolve()
+          await Promise.resolve()
+
+          // Pointer down on the scrollbar thumb, then drag fast: 120px per 16ms frame is
+          // 7.5 px/ms, well over the 1 px/ms fling threshold.
+          hook.handlers.onPointerDown({ pointerId: 1, pointerType: 'mouse' } as PointerEvent)
+          div.setScrollTop(0)
+          hook.handlers.onScroll() // seeds the tracker
+          vi.advanceTimersByTime(16)
+          div.setScrollTop(120)
+          hook.handlers.onScroll() // now the tracker measures a fling-speed cadence
+          vi.advanceTimersByTime(16)
+          div.setScrollTop(240)
+          hook.handlers.onScroll()
+          await Promise.resolve()
+          await Promise.resolve()
+          const beforeShift = div.getScrollTop()
+
+          // A row above grows by 60px mid-drag. A drag carries no inertia, so the correction
+          // must be WRITTEN now, keeping the anchored row under the reader's cursor.
+          ctrl.shiftWithoutTotalChange(60)
+          await Promise.resolve()
+          await Promise.resolve()
+
+          expect(div.getScrollTop()).toBe(beforeShift + 60)
+
+          vi.useRealTimers()
+          dispose()
+          resolve()
+        }
+        catch (e) {
+          vi.useRealTimers()
+          dispose()
+          reject(e instanceof Error ? e : new Error(String(e)))
+        }
+      })
+    }))
+
+  it('defers a correction during a trackpad coast that outlived the 750ms input grace', () =>
+    new Promise<void>((resolve, reject) => {
+      // The engine's isActivelyFlinging must be the tracker's RAW read. The tracker already
+      // bounds it by its own 150ms idle window, so it cannot go stale -- but the hook once
+      // ANDed the 750ms momentum-input grace onto it. A macOS trackpad coast is driven by bare
+      // scroll events with no fresh wheel input, so the grace lapses while the viewport still
+      // moves; the composed predicate then read false, the engine skipped its deferral, and it
+      // wrote scrollTop into live momentum, which cancels the coast under the reader's finger.
+      vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
+      createRoot(async (dispose) => {
+        try {
+          const div = makeFakeScrollDiv()
+          div.setScrollHeight(40000)
+          div.setClientHeight(500)
+          div.setScrollTop(0)
+          const [messages] = createSignal<AgentChatMessage[]>([])
+          const [streamingText] = createSignal('')
+          const ctrl = makeControllableVirtualizer()
+          const hook = useChatScroll({ virtualizer: ctrl.virt, messages, streamingText })
+          hook.attachListRef(div.el)
+          await Promise.resolve()
+          await Promise.resolve()
+
+          // Finger-on: one wheel event marks momentum input, then the OS drives the coast.
+          div.setScrollTop(0)
+          hook.handlers.onScroll()
+          hook.handlers.onWheel({ deltaY: 200, deltaX: 0, ctrlKey: false } as WheelEvent)
+          // Bare scroll events, ~120px per frame (7.5 px/ms, well over the 1 px/ms threshold),
+          // with NO further wheel events. Run past 750ms so the input grace lapses.
+          let top = 0
+          for (let t = 0; t < 900; t += 16) {
+            vi.advanceTimersByTime(16)
+            top += 120
+            div.setScrollTop(top)
+            hook.handlers.onScroll()
+          }
+          await Promise.resolve()
+          await Promise.resolve()
+          const beforeShift = div.getScrollTop()
+
+          // A premeasure lands now: momentum is genuinely live (fresh, fast samples), so the
+          // correction must be DEFERRED into the fling-settle, never written.
+          ctrl.shiftWithoutTotalChange(60)
+          await Promise.resolve()
+          await Promise.resolve()
+
+          expect(div.getScrollTop()).toBe(beforeShift) // momentum survives; nothing written
+
+          // Once the coast stops, the settle re-anchors at the live position rather than
+          // snapping the deferred 60px onto the screen.
+          vi.advanceTimersByTime(FLING_SETTLE_MS + 50)
+          await Promise.resolve()
+          expect(div.getScrollTop()).toBe(beforeShift)
+
+          vi.useRealTimers()
+          dispose()
+          resolve()
+        }
+        catch (e) {
+          vi.useRealTimers()
+          dispose()
           reject(e instanceof Error ? e : new Error(String(e)))
         }
       })

--- a/frontend/src/components/chat/useChatScroll.diagnostics.test.ts
+++ b/frontend/src/components/chat/useChatScroll.diagnostics.test.ts
@@ -5,11 +5,11 @@ import { createRoot, createSignal } from 'solid-js'
 import { describe, expect, it, vi } from 'vitest'
 
 import { useChatScroll } from './useChatScroll'
-import { installScrollTestEnv, makeFakeScrollDiv, makeGrowableVirtualizer, makeStubVirtualizer, measurementDeferralNoOps } from './useChatScroll.testkit'
+import { installScrollTestEnv, makeFakeScrollDiv, makeGrowableVirtualizer, makeShiftingVirtualizer, makeStubVirtualizer, SHIFT_ANCHOR_OFFSET, virtualizerNoOps } from './useChatScroll.testkit'
 
 installScrollTestEnv()
 
-describe('usechatscroll stall indicators', () => {
+describe('useChatScroll stall indicators', () => {
   // Content 5000 / viewport 500 => max scrollTop 4500: scrollTop 0 is the top edge,
   // 4500 the bottom edge (distFromBottom 0). Fetch flags are signals so a test can
   // flip a fetch mid-flight; load handlers are no-ops (the in-flight guard already
@@ -128,7 +128,7 @@ describe('usechatscroll stall indicators', () => {
     }))
 })
 
-describe('usechatscroll scroll-anomaly warnings', () => {
+describe('useChatScroll scroll-anomaly warnings', () => {
   // A controllable virtualizer with a single anchored row whose content-Y top is
   // `rowTop`. `moveRowTop` shifts that row and bumps geometryVersion, driving the real
   // geometry re-pin (repinToAnchor) -- so a re-pin can be made to clamp against an edge.
@@ -138,7 +138,7 @@ describe('usechatscroll scroll-anomaly warnings', () => {
     let rowTop = initialRowTop
     const [version, setVersion] = createSignal(0)
     const virt: ChatScrollVirtualizer = {
-      ...measurementDeferralNoOps(),
+      ...virtualizerNoOps(),
       totalHeight: () => 100000,
       geometryVersion: version,
       updateViewport: () => {},
@@ -199,6 +199,121 @@ describe('usechatscroll scroll-anomaly warnings', () => {
           resolve()
         }
         catch (e) {
+          dispose()
+          reject(e instanceof Error ? e : new Error(String(e)))
+        }
+      })
+    }))
+
+  it('carries the flush\'s measurement batch, sampled before the re-pin runs', () =>
+    new Promise<void>((resolve, reject) => {
+      createRoot(async (dispose) => {
+        try {
+          const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+          const div = makeFakeScrollDiv()
+          div.setScrollHeight(5000)
+          div.setClientHeight(500)
+          div.setScrollTop(100)
+          const { virt: base, moveRowTop } = makeAnchorVirtualizer(90)
+          // Count the calls INTO the returned totals. The hook holds `{commits: 0, ...}` until
+          // it samples, so a WARN carrying commits 1 proves the sample ran in this flush and
+          // BEFORE the re-pin that emitted it -- move the call after repinToAnchor() and the
+          // payload falls back to the initial zeroes.
+          let batchCalls = 0
+          const virt: ChatScrollVirtualizer = {
+            ...base,
+            takeMeasurementBatch: () => ({ commits: ++batchCalls, deltaSum: -7, totalHeightDelta: -300 }),
+          }
+          const [messages] = createSignal<AgentChatMessage[]>([])
+          const [streamingText] = createSignal('')
+          const [hasOlder] = createSignal<boolean | undefined>(true)
+          const hook = useChatScroll({ virtualizer: virt, messages, streamingText, hasOlderMessages: hasOlder })
+          hook.attachListRef(div.el)
+          await Promise.resolve()
+          await Promise.resolve()
+
+          div.setScrollTop(100)
+          hook.handlers.onScroll()
+          warn.mockClear()
+          expect(batchCalls).toBe(0) // no geometry flush yet
+
+          moveRowTop(-300)
+          await Promise.resolve()
+          await Promise.resolve()
+
+          expect(warn).toHaveBeenCalledWith(
+            '[chatScroll]',
+            expect.stringContaining('anchor re-pin clamped'),
+            expect.objectContaining({
+              batch: { commits: 1, deltaSum: -7, totalHeightDelta: -300, ageMs: expect.any(Number) },
+            }),
+          )
+          dispose()
+          resolve()
+        }
+        catch (e) {
+          dispose()
+          reject(e instanceof Error ? e : new Error(String(e)))
+        }
+      })
+    }))
+
+  it('ages the measurement batch, so a WARN with no flush of its own cannot read as caused by one', () =>
+    new Promise<void>((resolve, reject) => {
+      createRoot(async (dispose) => {
+        let clock = 1000
+        const nowSpy = vi.spyOn(performance, 'now').mockImplementation(() => clock)
+        try {
+          const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+          const div = makeFakeScrollDiv()
+          div.setScrollHeight(5000)
+          div.setClientHeight(500)
+          div.setScrollTop(0)
+          const [messages] = createSignal<AgentChatMessage[]>([])
+          const [streamingText] = createSignal('')
+          const { virt: base, setTotal } = makeGrowableVirtualizer()
+          const virt: ChatScrollVirtualizer = {
+            ...base,
+            takeMeasurementBatch: () => ({ commits: 9, deltaSum: -68, totalHeightDelta: -74 }),
+          }
+          const hook = useChatScroll({ virtualizer: virt, messages, streamingText })
+          hook.attachListRef(div.el)
+          await Promise.resolve()
+          await Promise.resolve()
+
+          // A geometry flush samples the batch. ONLY the re-pin effect refreshes it.
+          setTotal(6000)
+          await Promise.resolve()
+          await Promise.resolve()
+
+          div.setScrollTop(0)
+          hook.handlers.onScroll() // seed lastScrollTop, and open the mount-restick burst
+          warn.mockClear()
+          clock += 1500
+
+          // Five seconds later, Detector B fires from the scroll handler -- a teleport from
+          // rest, an event with no geometry flush of its own. It still prints the batch above,
+          // because nothing refreshed it. Without an age, `commits: 9, totalHeightDelta: -74`
+          // reads as the cause of a 3000px jump it had nothing to do with; that is the same
+          // misattribution this field family exists to remove, pointed the other way.
+          clock += 5000
+          div.setScrollTop(3000)
+          hook.handlers.onScroll()
+
+          expect(warn).toHaveBeenCalledWith(
+            '[chatScroll]',
+            expect.stringContaining('unexpected scroll jump'),
+            expect.objectContaining({
+              deltaFromLast: 3000,
+              batch: { commits: 9, deltaSum: -68, totalHeightDelta: -74, ageMs: 6500 },
+            }),
+          )
+          nowSpy.mockRestore()
+          dispose()
+          resolve()
+        }
+        catch (e) {
+          nowSpy.mockRestore()
           dispose()
           reject(e instanceof Error ? e : new Error(String(e)))
         }
@@ -466,7 +581,7 @@ describe('usechatscroll scroll-anomaly warnings', () => {
           // budget -- simulated by advancing the clock inside updateViewport (the synchronous
           // mount of entering rows + the premeasure computed run here in the real code).
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             ...makeStubVirtualizer(),
             updateViewport: () => { clock += 60 },
           }
@@ -513,7 +628,7 @@ describe('usechatscroll scroll-anomaly warnings', () => {
           const [streamingText] = createSignal('')
           // A normal (fast, sub-budget) render cascade: 10ms, under the 50ms threshold.
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             ...makeStubVirtualizer(),
             updateViewport: () => { clock += 10 },
           }
@@ -736,33 +851,34 @@ describe('usechatscroll scroll-anomaly warnings', () => {
 
   // A virtualizer whose anchored row grows `shift` px taller the first time updateViewport
   // runs (a late estimate->measured correction), so a scroll event's own refreshViewport
-  // triggers the keep-position re-pin to ABSORB the correction -- the on-screen content
-  // shift with no scroll event that Detector C surfaces. Mirrors the sibling absorb test.
-  function makeAbsorbingVirtualizer(shift: number) {
-    const ANCHOR_OFFSET = 290
+  // triggers the keep-position re-pin from inside the scroll handler. The re-pin either
+  // corrects the shift or absorbs it, by size -- the two tests below drive both sides.
+
+  // Like makeShiftingVirtualizer, but every arm() shifts AGAIN, so a test can drive a run of
+  // absorbs the way slow-scrolling through never-measured history does -- one estimate->measure
+  // correction per mounting row. The anchored row keeps resolving, because the engine
+  // re-anchors at the displaced position after each absorb.
+  function makeRepeatingShiftVirtualizer(shift: number) {
     let armed = false
-    let shifted = false
+    let shifts = 0
     const [version, setVersion] = createSignal(0)
     const virt: ChatScrollVirtualizer = {
-      ...measurementDeferralNoOps(),
+      ...virtualizerNoOps(),
       totalHeight: () => {
         version()
-        return shifted ? 8000 + shift : 8000
+        return 8000 + shifts * shift
       },
       geometryVersion: version,
       updateViewport: () => {
-        if (armed && !shifted) {
-          shifted = true
+        if (armed) {
+          armed = false
+          shifts += 1
           setVersion(v => v + 1)
         }
       },
-      anchorAt: scrollTop => (shifted
-        ? { id: 'tall-row', offsetWithinRow: scrollTop }
-        : { id: 'anchored-row', offsetWithinRow: scrollTop - ANCHOR_OFFSET }),
+      anchorAt: scrollTop => ({ id: 'anchored-row', offsetWithinRow: scrollTop - (SHIFT_ANCHOR_OFFSET + shifts * shift) }),
       scrollTopNearAnchor: () => null,
-      scrollTopForAnchor: a => (a.id === 'anchored-row'
-        ? (shifted ? ANCHOR_OFFSET + shift : ANCHOR_OFFSET) + a.offsetWithinRow
-        : a.offsetWithinRow),
+      scrollTopForAnchor: a => SHIFT_ANCHOR_OFFSET + shifts * shift + a.offsetWithinRow,
     }
     return {
       virt,
@@ -772,8 +888,13 @@ describe('usechatscroll scroll-anomaly warnings', () => {
     }
   }
 
-  it('warns when a slow-scroll estimate correction is absorbed as anchor drift (Detector C)', () =>
+  it('warns once a run of imperceptible absorbs adds up to a visible shift (Detector C)', () =>
     new Promise<void>((resolve, reject) => {
+      // The end-to-end wiring: engine absorb -> onAnchorDrift -> emitAnchorDrift -> WARN. No
+      // single absorb can reach the WARN floor, because the engine's cap (8px) sits under it
+      // (16px) by design -- so this fires only because the emitter accumulates. It is also the
+      // only test that proves the hook's onAnchorDrift callback is connected at all: while the
+      // floor was per-event, deleting that line from useChatScroll failed nothing.
       vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
       createRoot(async (dispose) => {
         try {
@@ -784,35 +905,39 @@ describe('usechatscroll scroll-anomaly warnings', () => {
           div.setScrollTop(300)
           const [messages] = createSignal<AgentChatMessage[]>([])
           const [streamingText] = createSignal('')
-          const { virt, arm } = makeAbsorbingVirtualizer(100) // a 100px correction
+          const { virt, arm } = makeRepeatingShiftVirtualizer(6) // 6px: inside the absorb cap
           const hook = useChatScroll({ virtualizer: virt, messages, streamingText })
           hook.attachListRef(div.el)
           await Promise.resolve()
           await Promise.resolve()
 
-          // Seed velocity at a slow cadence.
           div.setScrollTop(300)
-          hook.handlers.onScroll()
+          hook.handlers.onScroll() // seed a slow cadence
           await Promise.resolve()
           await Promise.resolve()
           warn.mockClear()
 
-          // 100ms later, a 10px nudge = 0.1 px/ms (slow, not a fling). The row above
-          // measures 100px taller during this event; the re-pin ABSORBS the correction
-          // (re-anchors instead of snapping back), leaving content shifted 100px on-screen
-          // with no scroll event -- exactly what Detector C exists to catch.
-          vi.advanceTimersByTime(100)
-          arm()
-          div.setScrollTop(310)
-          hook.handlers.onScroll()
-          await Promise.resolve()
-          await Promise.resolve()
+          // Three slow scroll events, each mounting a row that measures 6px taller than its
+          // estimate. Each is absorbed: no write, and the row is left displaced.
+          let top = 300
+          for (let i = 0; i < 3; i++) {
+            vi.advanceTimersByTime(100) // 10px / 100ms = 0.1 px/ms, a deliberate scroll
+            arm()
+            top += 10
+            div.setScrollTop(top)
+            hook.handlers.onScroll()
+            await Promise.resolve()
+            await Promise.resolve()
+          }
 
-          expect(div.getScrollTop()).toBe(310) // absorbed, not corrected
           expect(warn).toHaveBeenCalledWith(
             '[chatScroll]',
             expect.stringContaining('anchored content drifted'),
-            expect.objectContaining({ reason: 'absorbed', residualPx: 100 }),
+            expect.objectContaining({
+              reason: 'absorbed',
+              driftPxSinceLastWarn: 18, // 3 x 6px, none of which is individually visible
+              absorbsSinceLastWarn: 3,
+            }),
           )
           vi.useRealTimers()
           dispose()
@@ -826,7 +951,7 @@ describe('usechatscroll scroll-anomaly warnings', () => {
       })
     }))
 
-  it('does not warn on an absorbed correction below the drift floor (~10px)', () =>
+  it('corrects a perceptible slow-scroll estimate correction instead of drifting', () =>
     new Promise<void>((resolve, reject) => {
       vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
       createRoot(async (dispose) => {
@@ -838,7 +963,59 @@ describe('usechatscroll scroll-anomaly warnings', () => {
           div.setScrollTop(300)
           const [messages] = createSignal<AgentChatMessage[]>([])
           const [streamingText] = createSignal('')
-          const { virt, arm } = makeAbsorbingVirtualizer(10) // a 10px correction, below the floor
+          const { virt, arm } = makeShiftingVirtualizer(100, { reanchorWhenShifted: true }) // a 100px correction
+          const hook = useChatScroll({ virtualizer: virt, messages, streamingText })
+          hook.attachListRef(div.el)
+          await Promise.resolve()
+          await Promise.resolve()
+
+          // Seed velocity at a slow cadence.
+          div.setScrollTop(300)
+          hook.handlers.onScroll()
+          await Promise.resolve()
+          await Promise.resolve()
+          warn.mockClear()
+
+          // 100ms later, a 10px nudge = 0.1 px/ms (slow, not a fling). The row above
+          // measures 100px taller during this event. A shift this large is what the reader
+          // sees jump, so the re-pin writes scrollTop to keep the anchored row put instead
+          // of re-anchoring to the displaced position and reporting the drift.
+          vi.advanceTimersByTime(100)
+          arm()
+          div.setScrollTop(310)
+          hook.handlers.onScroll()
+          await Promise.resolve()
+          await Promise.resolve()
+
+          expect(div.getScrollTop()).toBe(410) // corrected: the row kept its viewport line
+          expect(warn).not.toHaveBeenCalled()
+          vi.useRealTimers()
+          dispose()
+          resolve()
+        }
+        catch (e) {
+          vi.useRealTimers()
+          dispose()
+          reject(e instanceof Error ? e : new Error(String(e)))
+        }
+      })
+    }))
+
+  it('absorbs an imperceptible slow-scroll correction without warning', () =>
+    new Promise<void>((resolve, reject) => {
+      vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
+      createRoot(async (dispose) => {
+        try {
+          const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+          const div = makeFakeScrollDiv()
+          div.setClientHeight(500)
+          div.setScrollHeight(40000)
+          div.setScrollTop(300)
+          const [messages] = createSignal<AgentChatMessage[]>([])
+          const [streamingText] = createSignal('')
+          // 6px: inside the absorb cap, so the re-pin still declines to fight the native
+          // scroll event -- and the shift stays under the drift floor, so it stays silent.
+          const { virt, arm } = makeShiftingVirtualizer(6, { reanchorWhenShifted: true })
           const hook = useChatScroll({ virtualizer: virt, messages, streamingText })
           hook.attachListRef(div.el)
           await Promise.resolve()
@@ -857,8 +1034,8 @@ describe('usechatscroll scroll-anomaly warnings', () => {
           await Promise.resolve()
           await Promise.resolve()
 
-          expect(div.getScrollTop()).toBe(310) // still absorbed
-          expect(warn).not.toHaveBeenCalled() // 10px < the 16px drift floor
+          expect(div.getScrollTop()).toBe(310) // absorbed, no write against the scroll event
+          expect(warn).not.toHaveBeenCalled() // 6px < the 16px drift floor
           vi.useRealTimers()
           dispose()
           resolve()
@@ -1024,92 +1201,12 @@ describe('usechatscroll scroll-anomaly warnings', () => {
       })
     }))
 
-  it('rate-limits absorbed-drift warns to one per window and aggregates the folded residuals', () =>
-    new Promise<void>((resolve, reject) => {
-      vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
-      createRoot(async (dispose) => {
-        try {
-          const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
-          const div = makeFakeScrollDiv()
-          div.setClientHeight(500)
-          div.setScrollHeight(40000)
-          div.setScrollTop(300)
-          const [messages] = createSignal<AgentChatMessage[]>([])
-          const [streamingText] = createSignal('')
-          // Like makeAbsorbingVirtualizer, but re-armable: each arm() shifts the anchored
-          // row once more on the next updateViewport, so consecutive scroll events each
-          // absorb a fresh 100px correction (a slow scroll through mis-estimated rows).
-          let rowBase = 290
-          let armed = false
-          const [version, setVersion] = createSignal(0)
-          const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
-            totalHeight: () => {
-              version()
-              return 8000 + (rowBase - 290)
-            },
-            geometryVersion: version,
-            updateViewport: () => {
-              if (armed) {
-                armed = false
-                rowBase += 100
-                setVersion(v => v + 1)
-              }
-            },
-            anchorAt: (scrollTop: number): ScrollAnchor => ({ id: 'row', offsetWithinRow: scrollTop - rowBase }),
-            scrollTopNearAnchor: () => null,
-            scrollTopForAnchor: (a: ScrollAnchor): number => rowBase + a.offsetWithinRow,
-          }
-          const hook = useChatScroll({ virtualizer: virt, messages, streamingText })
-          hook.attachListRef(div.el)
-          await Promise.resolve()
-          await Promise.resolve()
-
-          div.setScrollTop(300)
-          hook.handlers.onScroll() // seed a slow cadence
-          await Promise.resolve()
-          warn.mockClear()
-
-          const driftWarns = () => warn.mock.calls.filter(c => String(c[1]).includes('anchored content drifted'))
-
-          // Absorb #1: warns (the window opens here).
-          vi.advanceTimersByTime(100)
-          armed = true
-          div.setScrollTop(310)
-          hook.handlers.onScroll()
-          await Promise.resolve()
-          expect(driftWarns()).toHaveLength(1)
-
-          // Absorb #2, 100ms later: inside the window -- folded, not re-warned.
-          vi.advanceTimersByTime(100)
-          armed = true
-          div.setScrollTop(320)
-          hook.handlers.onScroll()
-          await Promise.resolve()
-          expect(driftWarns()).toHaveLength(1)
-
-          // Absorb #3, past the window: warns again, carrying the folded aggregate.
-          vi.advanceTimersByTime(1100)
-          armed = true
-          div.setScrollTop(330)
-          hook.handlers.onScroll()
-          await Promise.resolve()
-          expect(driftWarns()).toHaveLength(2)
-          expect(driftWarns()[1][2]).toMatchObject({
-            suppressedSinceLastWarn: 1,
-            suppressedResidualPxSum: 100,
-          })
-          vi.useRealTimers()
-          dispose()
-          resolve()
-        }
-        catch (e) {
-          vi.useRealTimers()
-          dispose()
-          reject(e instanceof Error ? e : new Error(String(e)))
-        }
-      })
-    }))
+  // The absorbed-drift rate limit (one WARN per window, carrying the folded count and
+  // residual sum) is covered in chatScrollDiagnostics.test.ts against the emitter directly.
+  // It cannot be driven through the hook any more: the re-pin absorbs only shifts under the
+  // imperceptible cap, and every one of those falls below the WARN's own visible-px floor,
+  // so no sequence of hook-level absorbs reaches the rate limiter. That silence is the point
+  // of the fix -- an absorbed shift the reader can see is now corrected instead.
 
   it('advances the direction baseline AT WRITE TIME for a restick, without waiting for its echo', () =>
     new Promise<void>((resolve, reject) => {
@@ -1176,7 +1273,7 @@ describe('usechatscroll scroll-anomaly warnings', () => {
           div.setScrollTop(300)
           const [messages] = createSignal<AgentChatMessage[]>([])
           const [streamingText] = createSignal('')
-          const { virt, arm } = makeAbsorbingVirtualizer(100)
+          const { virt, arm } = makeShiftingVirtualizer(100, { reanchorWhenShifted: true })
           const hook = useChatScroll({ virtualizer: virt, messages, streamingText })
           hook.attachListRef(div.el)
           await Promise.resolve()

--- a/frontend/src/components/chat/useChatScroll.input.test.ts
+++ b/frontend/src/components/chat/useChatScroll.input.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest'
 import { AgentStatus } from '~/generated/leapmux/v1/agent_pb'
 
 import { useChatScroll } from './useChatScroll'
-import { installScrollTestEnv, makeFakeScrollDiv, makeRowVirtualizer, makeStubVirtualizer, measurementDeferralNoOps } from './useChatScroll.testkit'
+import { installScrollTestEnv, makeFakeScrollDiv, makeRowVirtualizer, makeStubVirtualizer, virtualizerNoOps } from './useChatScroll.testkit'
 
 installScrollTestEnv()
 
@@ -432,7 +432,7 @@ describe('usechatscroll down-jump on a small scroll-down', () => {
     let rowOffset = rowOffset0
     const [version, setVersion] = createSignal(0)
     const virt: ChatScrollVirtualizer = {
-      ...measurementDeferralNoOps(),
+      ...virtualizerNoOps(),
       totalHeight: () => {
         version()
         return total
@@ -514,7 +514,7 @@ describe('usechatscroll down-jump on a small scroll-down', () => {
           // -- isolating the follow path.
           const [total, setTotal] = createSignal(1000)
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => total(),
             geometryVersion: () => 0,
             updateViewport: () => {},

--- a/frontend/src/components/chat/useChatScroll.pagination.test.ts
+++ b/frontend/src/components/chat/useChatScroll.pagination.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest'
 
 import { maxScrollTopOf } from './chatScrollGeometry'
 import { useChatScroll } from './useChatScroll'
-import { installScrollTestEnv, makeFakeScrollDiv, makeGrowableVirtualizer, makeRowVirtualizer, makeStubVirtualizer, measurementDeferralNoOps } from './useChatScroll.testkit'
+import { installScrollTestEnv, makeFakeScrollDiv, makeGrowableVirtualizer, makeRowVirtualizer, makeStubVirtualizer, virtualizerNoOps } from './useChatScroll.testkit'
 
 installScrollTestEnv()
 
@@ -335,7 +335,7 @@ describe('usechatscroll auto-load through hidden-only window pages', () => {
           div.setScrollTop(200) // visible buffer ABOVE = 200, well under 1500; BELOW = 200
           const [total, setTotal] = createSignal(900)
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => total(),
             geometryVersion: () => 0,
             updateViewport: () => {},
@@ -410,7 +410,7 @@ describe('usechatscroll auto-load through hidden-only window pages', () => {
           div.setScrollHeight(1000) // scrollable (maxScrollTop = 500)
           div.setScrollTop(500) // pinned at the bottom -- distFromBottom = 0
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => 1000,
             geometryVersion: () => 0,
             updateViewport: () => {},
@@ -474,7 +474,7 @@ describe('usechatscroll auto-load through hidden-only window pages', () => {
           div.setScrollTop(0)
           const [total, setTotal] = createSignal(0)
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => total(),
             geometryVersion: () => 0,
             updateViewport: () => {},
@@ -543,7 +543,7 @@ describe('usechatscroll auto-load through hidden-only window pages', () => {
           div.setScrollTop(20)
           const [total, setTotal] = createSignal(520)
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => total(),
             geometryVersion: () => 0,
             updateViewport: () => {},
@@ -607,7 +607,7 @@ describe('usechatscroll auto-load through hidden-only window pages', () => {
           div.setScrollHeight(1000) // scrollable (maxScrollTop = 500)
           div.setScrollTop(500) // at the loaded bottom -- distFromBottom = 0
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => 1000,
             geometryVersion: () => 0,
             updateViewport: () => {},
@@ -661,7 +661,7 @@ describe('usechatscroll auto-load through hidden-only window pages', () => {
           div.setScrollHeight(700)
           div.setScrollTop(200) // a deficient above-buffer were the tab visible
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => 700,
             geometryVersion: () => 0,
             updateViewport: () => {},
@@ -709,7 +709,7 @@ describe('usechatscroll auto-load through hidden-only window pages', () => {
           div.setScrollTop(1600) // buffer ABOVE = 1600 (>= 1500, satisfied); BELOW = 100
           const [total, setTotal] = createSignal(2200)
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => total(),
             geometryVersion: () => 0,
             updateViewport: () => {},
@@ -774,7 +774,7 @@ describe('usechatscroll auto-load through hidden-only window pages', () => {
           // totalHeight never grows: every older page is hidden (no visible height).
           const [total] = createSignal(900)
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => total(),
             geometryVersion: () => 0,
             updateViewport: () => {},
@@ -835,7 +835,7 @@ describe('usechatscroll auto-load through hidden-only window pages', () => {
           div.setScrollHeight(900)
           div.setScrollTop(200) // buffer above 200 < 1500 -> deficient, would pre-fetch
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => 900,
             geometryVersion: () => 0,
             updateViewport: () => {},
@@ -898,7 +898,7 @@ describe('usechatscroll auto-load through hidden-only window pages', () => {
           div.setScrollHeight(300)
           div.setScrollTop(0) // non-scrollable (maxScrollTop 0); older buffer deficient
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => 300,
             geometryVersion: () => 0,
             updateViewport: () => {},

--- a/frontend/src/components/chat/useChatScroll.seek.test.ts
+++ b/frontend/src/components/chat/useChatScroll.seek.test.ts
@@ -5,7 +5,7 @@ import { createRoot, createSignal } from 'solid-js'
 import { describe, expect, it, vi } from 'vitest'
 import { MessageSource } from '~/generated/leapmux/v1/agent_pb'
 import { useChatScroll } from './useChatScroll'
-import { installScrollTestEnv, makeFakeScrollDiv, measurementDeferralNoOps } from './useChatScroll.testkit'
+import { installScrollTestEnv, makeFakeScrollDiv, virtualizerNoOps } from './useChatScroll.testkit'
 
 installScrollTestEnv()
 
@@ -16,7 +16,7 @@ function mkMsgs(seqs: number[]): AgentChatMessage[] {
 /** A virtualizer stub that resolves an anchor to `Number(seq) * 200` scrollTop. */
 function seekVirt(): ChatScrollVirtualizer {
   return {
-    ...measurementDeferralNoOps(),
+    ...virtualizerNoOps(),
     totalHeight: () => 5000,
     geometryVersion: () => 0,
     updateViewport: () => {},

--- a/frontend/src/components/chat/useChatScroll.stickyBottom.test.ts
+++ b/frontend/src/components/chat/useChatScroll.stickyBottom.test.ts
@@ -7,7 +7,7 @@ import {
   triggerResizeObserversSync,
 } from '~/test-support/resizeObserverStub'
 import { useChatScroll } from './useChatScroll'
-import { installScrollTestEnv, makeFakeScrollDiv, makeGrowableVirtualizer, makeStubVirtualizer, measurementDeferralNoOps } from './useChatScroll.testkit'
+import { installScrollTestEnv, makeFakeScrollDiv, makeGrowableVirtualizer, makeStubVirtualizer, virtualizerNoOps } from './useChatScroll.testkit'
 
 installScrollTestEnv()
 
@@ -306,7 +306,7 @@ describe('usechatscroll resize sticky-bottom', () => {
           // totalHeight()===0) stays out of this test; we want only the explicit
           // scroll events to dispatch pagination.
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => 5000,
             geometryVersion: () => 0,
             updateViewport: () => {},
@@ -372,7 +372,7 @@ describe('usechatscroll resize sticky-bottom', () => {
           const [streamingText] = createSignal('')
           let newerLoads = 0
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => 5000.4,
             geometryVersion: () => 0,
             updateViewport: () => {},
@@ -426,7 +426,7 @@ describe('usechatscroll resize sticky-bottom', () => {
           const [streamingText] = createSignal('')
           let updateViewportCalls = 0
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => 0,
             geometryVersion: () => 0,
             updateViewport: () => { updateViewportCalls += 1 },

--- a/frontend/src/components/chat/useChatScroll.testkit.ts
+++ b/frontend/src/components/chat/useChatScroll.testkit.ts
@@ -5,6 +5,7 @@ import { createSignal } from 'solid-js'
 import { afterEach, beforeAll, vi } from 'vitest'
 import { installControllableResizeObserver } from '~/test-support/resizeObserverStub'
 import { anchorAtOffset, resolveAnchorScrollTop, resolveNearestAnchorScrollTop } from './chatScrollAnchor'
+import { EMPTY_MEASUREMENT_BATCH } from './useChatVirtualizer'
 
 /**
  * Shared test kit for the useChatScroll suites. The suite was split out of a
@@ -13,16 +14,20 @@ import { anchorAtOffset, resolveAnchorScrollTop, resolveNearestAnchorScrollTop }
  */
 
 /**
- * The measurement-deferral half of the virtualizer surface, defaulted to no-ops.
- * ChatScrollVirtualizer requires these members (an optional surface let a caller
- * silently disable the fling deferral machinery); the stubs spread this so each
- * builder stays focused on the geometry it fakes. Tests that exercise the deferral
- * or the row-top hold release override the members they assert on.
+ * Every member of the virtualizer surface that the geometry builders below do NOT supply,
+ * defaulted to no-ops. ChatScrollVirtualizer requires all of them (an optional surface let a
+ * caller silently disable the fling deferral machinery); the stubs spread this so each
+ * builder stays focused on the geometry it fakes. Tests that exercise the deferral, the
+ * measurement diagnostics, or the row-top hold release override the members they assert on.
+ *
+ * Derived by SUBTRACTION from ChatScrollVirtualizer, not by re-listing the members. A hand
+ * written second list drifts silently: it is why one new virtualizer member had to be typed
+ * into the Pick in useChatScroll.ts AND into this file. With the Omit, a new member widens
+ * this type on its own and fails to compile in exactly one place -- the literal below.
  */
-export function measurementDeferralNoOps(): Pick<
+export function virtualizerNoOps(): Omit<
   ChatScrollVirtualizer,
-  'setVisibleMeasurementDeferral' | 'hasDeferredMeasurements' | 'flushDeferredMeasurements' | 'lastMeasurement' | 'hasMeasuredHeight'
-  | 'setFastScrollActive'
+  'totalHeight' | 'geometryVersion' | 'updateViewport' | 'anchorAt' | 'scrollTopNearAnchor' | 'scrollTopForAnchor'
 > {
   return {
     setVisibleMeasurementDeferral: () => {},
@@ -30,6 +35,7 @@ export function measurementDeferralNoOps(): Pick<
     hasDeferredMeasurements: () => false,
     flushDeferredMeasurements: () => false,
     lastMeasurement: () => undefined,
+    takeMeasurementBatch: () => EMPTY_MEASUREMENT_BATCH,
     hasMeasuredHeight: () => false,
   }
 }
@@ -48,7 +54,7 @@ export function makeStubVirtualizer(): ChatScrollVirtualizer {
     anchorAt: () => null,
     scrollTopNearAnchor: () => null,
     scrollTopForAnchor: () => null,
-    ...measurementDeferralNoOps(),
+    ...virtualizerNoOps(),
   }
 }
 
@@ -89,9 +95,60 @@ export function makeGrowableVirtualizer() {
     anchorAt: () => null,
     scrollTopNearAnchor: () => null,
     scrollTopForAnchor: () => null,
-    ...measurementDeferralNoOps(),
+    ...virtualizerNoOps(),
   }
   return { virt, setTotal }
+}
+
+/** The viewport line the shifting stub's anchored row is captured on. */
+export const SHIFT_ANCHOR_OFFSET = 290
+
+/**
+ * Virtualizer stub for the re-pin decision tests: one row above the anchor grows by `shift`
+ * on the next updateViewport after `arm()`, so a single scroll event delivers an
+ * already-committed geometry change of a known size. The anchored row sits at
+ * SHIFT_ANCHOR_OFFSET, and the total height moves with it, which is what drives the re-pin
+ * effect. A negative `shift` models a row that measured SHORTER than its estimate.
+ *
+ * `reanchorWhenShifted` covers the case where the shift also changes which row sits at the
+ * viewport midpoint: anchorAt then returns a different id, so a re-pin that re-anchors
+ * resolves the NEW row and the old anchor's displacement is gone. Tests that assert on
+ * re-anchoring need it; tests that assert the anchored row is held do not.
+ */
+export function makeShiftingVirtualizer(shift: number, opts: { reanchorWhenShifted?: boolean } = {}) {
+  let armed = false
+  let shifted = false
+  const [version, setVersion] = createSignal(0)
+  const virt: ChatScrollVirtualizer = {
+    ...virtualizerNoOps(),
+    totalHeight: () => {
+      version()
+      return shifted ? 8000 + shift : 8000
+    },
+    geometryVersion: version,
+    updateViewport: () => {
+      if (armed && !shifted) {
+        shifted = true
+        setVersion(v => v + 1)
+      }
+    },
+    anchorAt: scrollTop => (opts.reanchorWhenShifted && shifted
+      ? { id: 'tall-row', offsetWithinRow: scrollTop }
+      // The wrong anchor (one captured against the shifted map) resolves back to the
+      // un-corrected scrollTop below, which is the visible jump those tests assert on.
+      : { id: 'anchored-row', offsetWithinRow: scrollTop - SHIFT_ANCHOR_OFFSET }),
+    scrollTopNearAnchor: () => null,
+    scrollTopForAnchor: a => (a.id === 'anchored-row'
+      ? (shifted ? SHIFT_ANCHOR_OFFSET + shift : SHIFT_ANCHOR_OFFSET) + a.offsetWithinRow
+      : a.offsetWithinRow),
+  }
+  return {
+    virt,
+    /** Let the NEXT updateViewport commit the shift. */
+    arm: () => {
+      armed = true
+    },
+  }
 }
 
 /**
@@ -172,7 +229,7 @@ export function makeRowVirtualizer(initialHeights: number[]) {
     anchorAt: (y: number): ScrollAnchor | null => anchorAtOffset(geometry(), y),
     scrollTopNearAnchor: (anchor: ScrollAnchor): number | null => resolveNearestAnchorScrollTop(geometry(), anchor),
     scrollTopForAnchor: (anchor: ScrollAnchor): number | null => resolveAnchorScrollTop(geometry(), anchor),
-    ...measurementDeferralNoOps(),
+    ...virtualizerNoOps(),
   }
   const setRowHeight = (idx: number, h: number) => {
     setHeights((prev) => {

--- a/frontend/src/components/chat/useChatScroll.ts
+++ b/frontend/src/components/chat/useChatScroll.ts
@@ -1,5 +1,5 @@
 import type { Accessor } from 'solid-js'
-import type { UseChatVirtualizerResult, ViewportLead } from './useChatVirtualizer'
+import type { MeasurementBatchInfo, UseChatVirtualizerResult, ViewportLead } from './useChatVirtualizer'
 import type { AgentChatMessage, AgentStatus } from '~/generated/leapmux/v1/agent_pb'
 import type { SavedViewportScroll, ScrollAnchor } from '~/stores/chatTypes'
 import { createEffect, createMemo, createSignal, on, onCleanup, onMount, untrack } from 'solid-js'
@@ -20,6 +20,7 @@ import { createStickyBottom } from './chatScrollSticky'
 import { createScrollVelocity } from './chatScrollVelocity'
 import { createViewportRestore } from './chatScrollViewportRestore'
 import { createChatSeek } from './chatSeek'
+import { EMPTY_MEASUREMENT_BATCH } from './useChatVirtualizer'
 
 /** Saved/queried scroll position — anchored to a message, see SavedViewportScroll. */
 export type ChatScrollState = SavedViewportScroll
@@ -40,7 +41,7 @@ export type ChatScrollVirtualizer = Pick<
   UseChatVirtualizerResult,
   'totalHeight' | 'updateViewport' | 'anchorAt' | 'scrollTopForAnchor' | 'scrollTopNearAnchor' | 'geometryVersion'
   | 'setVisibleMeasurementDeferral' | 'hasDeferredMeasurements' | 'flushDeferredMeasurements' | 'lastMeasurement' | 'hasMeasuredHeight'
-  | 'setFastScrollActive'
+  | 'setFastScrollActive' | 'takeMeasurementBatch'
 >
 
 /**
@@ -117,12 +118,13 @@ if (import.meta.hot) {
  * Scroll speed (px/ms) at or above which a wheel/trackpad scroll counts as an
  * inertial FLING whose momentum a scrollTop write would cancel -- so the geometry
  * re-pin defers a small correction into flingSettle instead of writing it. Below
- * it the scroll is a slow DELIBERATE gesture: medium estimate corrections are
- * absorbed by re-anchoring to the live viewport, while large structural shifts
- * still write immediately. A fling fires events tens of px apart every ~16ms
- * (well above 1 px/ms); a deliberate scroll creeps a few px per event.
- * Unknown/idle velocity is treated as a fling (defer), so the prior always-defer
- * behavior holds until a slow cadence is established.
+ * it the scroll is a slow DELIBERATE gesture. The re-pin then absorbs a correction
+ * only when it is imperceptible AND arrives inside the scroll handler (see
+ * SMALL_USER_SCROLL_REPIN_ABSORB_PX); every larger correction writes immediately.
+ * A fling fires events tens of px apart every ~16ms (well above 1 px/ms); a
+ * deliberate scroll creeps a few px per event. The tracker reports an unknown or
+ * idle velocity as a fling (defer), so the prior always-defer behavior holds until
+ * the tracker measures a slow cadence.
  */
 const FLING_VELOCITY_THRESHOLD_PX_PER_MS = 1
 /**
@@ -523,6 +525,23 @@ export function useChatScroll(opts: UseChatScrollOptions): UseChatScrollResult {
   let lastNativeKeyScrollAt = Number.NEGATIVE_INFINITY
   const hasRecentKeyboardScroll = () => monotonicNow() - lastNativeKeyScrollAt <= KEYBOARD_SCROLL_GRACE_MS
 
+  // The height commits of the geometry flush that the re-pin effect below reacts to (see
+  // MeasurementBatchInfo). The effect samples it, and a WARN reads it here: `lastMeasurement`
+  // alone names only the final row of a batched premeasure, so a drift it cannot explain
+  // reads as "the geometry moved for no reason".
+  //
+  // Only that effect refreshes it, and two callers reach a WARN without passing through it:
+  // Detector B fires from handleScroll (a scroll event carries no flush of its own), and
+  // applyDeferredRepinOnCancel / the viewport restore re-pin directly. Each would print an
+  // older flush as this event's cause, so every payload carries `ageMs` beside the totals.
+  // A batch that is hundreds of ms old did not cause the event you are reading.
+  let measurementBatch: MeasurementBatchInfo = EMPTY_MEASUREMENT_BATCH
+  let measurementBatchAt = Number.NEGATIVE_INFINITY
+  const measurementBatchPayload = () => ({
+    ...measurementBatch,
+    ageMs: measurementBatchAt === Number.NEGATIVE_INFINITY ? null : Math.round(monotonicNow() - measurementBatchAt),
+  })
+
   const scrollDomDebugSnapshot = () => {
     const el = messageListRef
     if (!el)
@@ -548,10 +567,10 @@ export function useChatScroll(opts: UseChatScrollOptions): UseChatScrollResult {
   const diagnostics = createScrollDiagnostics({
     domSnapshot: scrollDomDebugSnapshot,
     lastMeasurement: () => virt.lastMeasurement(),
+    measurementBatch: measurementBatchPayload,
     debugMarkers: () => progGuard.debugMarkers(),
     hasOlderMessages: () => !!opts.hasOlderMessages?.(),
     hasNewerMessages: () => !!opts.hasNewerMessages?.(),
-    isActivelyFlinging: () => scrollVelocity.isActivelyFlinging(),
   })
 
   // True only while a USER scroll event is refreshing newly revealed rows (inside
@@ -664,8 +683,24 @@ export function useChatScroll(opts: UseChatScrollOptions): UseChatScrollResult {
     writeScrollTop: writeScrollTopProgrammatically,
     velocity: {
       isFling: () => scrollVelocity.isFling(),
-      isActivelyFlinging: () => scrollVelocity.isActivelyFlinging() && hasRecentMomentumInput(),
-      hasRecentMomentumInput,
+      // The engine asks ONE question here: would a scrollTop write cancel INERTIA? Two facts
+      // answer it, and neither alone does.
+      //
+      // isCoasting, not isActivelyFlinging: momentum decays continuously, so a speed test
+      // reports "stopped" for the last few hundred ms of a coast that still visibly moves,
+      // and the engine then wrote into it. The tracker latches the coast on a measured fling
+      // and clears it when the motion stops, so the whole coast is covered, tail included.
+      //
+      // AND no direct manipulation: a fast finger or scrollbar drag measures like a coast and
+      // carries no inertia, so a write during one costs nothing. It must not defer either --
+      // handleScroll schedules the fling-settle for momentum scrolls only, so a correction
+      // deferred by a drag has nothing to apply it, ever.
+      //
+      // NOT hasRecentMomentumInput(). That 750ms grace stands in for both facts and is wrong
+      // about both: it lapses mid-coast (the OS drives a coast with bare scroll events), and
+      // it is false for a whole drag (markMomentumInput fires on a wheel event and on
+      // touch-END only), so it kept drags out of the deferral only by accident.
+      isActivelyFlinging: () => scrollVelocity.isCoasting() && !isScrollInputActive(),
     },
     flingSettle: () => flingSettle,
     isUserScrolling: () => userScrolling,
@@ -1346,6 +1381,12 @@ export function useChatScroll(opts: UseChatScrollOptions): UseChatScrollResult {
   // `defer:true` so the first render doesn't re-pin before anything has been
   // measured.
   createEffect(on([() => virt.totalHeight(), () => virt.geometryVersion()], () => {
+    // Close the measurement batch FIRST: every commit of this flush already landed, and
+    // nothing below read the new geometry yet, so these totals describe exactly the geometry
+    // change the re-pin is about to compensate. `on(...)` runs this body untracked, so the
+    // totalHeight read inside takeMeasurementBatch adds no dependency.
+    measurementBatch = virt.takeMeasurementBatch()
+    measurementBatchAt = monotonicNow()
     // Correct scrollTop synchronously (same paint as the row transforms — no
     // wiggle), but defer the slice recompute to the next frame so mounting rows
     // never re-enters the in-progress ResizeObserver delivery (no RO loop).
@@ -1968,8 +2009,15 @@ export function useChatScroll(opts: UseChatScrollOptions): UseChatScrollResult {
       onScroll: handleScroll,
       onWheel: (event) => {
         releaseRowTopHold()
-        if (!event.ctrlKey && Math.abs(event.deltaY) > Math.abs(event.deltaX) && event.deltaY !== 0)
+        if (!event.ctrlKey && Math.abs(event.deltaY) > Math.abs(event.deltaX) && event.deltaY !== 0) {
           markMomentumInput()
+          // The user drives this increment, so the scroll it produces is not inertia however
+          // fast it measures. Clear the coast latch, or one brisk wheel notch over the fling
+          // threshold would mark a coast that never happens and defer corrections through the
+          // rest of a deliberate scroll. A real coast re-latches from its own samples, because
+          // the OS drives it with bare scroll events and sends no further wheel input.
+          scrollVelocity.noteUserInput()
+        }
         handleWheel(event)
       },
       onKeyDown: (event) => {

--- a/frontend/src/components/chat/useChatScroll.viewportRestore.test.ts
+++ b/frontend/src/components/chat/useChatScroll.viewportRestore.test.ts
@@ -7,7 +7,7 @@ import {
   triggerResizeObserversSync,
 } from '~/test-support/resizeObserverStub'
 import { useChatScroll } from './useChatScroll'
-import { installScrollTestEnv, makeFakeScrollDiv, makeRowVirtualizer, makeStubVirtualizer, measurementDeferralNoOps } from './useChatScroll.testkit'
+import { installScrollTestEnv, makeFakeScrollDiv, makeRowVirtualizer, makeStubVirtualizer, virtualizerNoOps } from './useChatScroll.testkit'
 
 installScrollTestEnv()
 
@@ -136,7 +136,7 @@ describe('usechatscroll viewport restore', () => {
             hasMoreNewer: false,
           })
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => 5000,
             geometryVersion: () => 0,
             updateViewport: () => {},
@@ -202,7 +202,7 @@ describe('usechatscroll viewport restore', () => {
             hasMoreNewer: true,
           })
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => 1000,
             geometryVersion: () => 0,
             updateViewport: () => {},
@@ -269,7 +269,7 @@ describe('usechatscroll viewport restore', () => {
             hasMoreNewer: false,
           })
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => 5000,
             geometryVersion: () => 0,
             updateViewport: () => {},
@@ -335,7 +335,7 @@ describe('usechatscroll viewport restore', () => {
             hasMoreNewer: false,
           })
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => 5000,
             geometryVersion: () => 0,
             updateViewport: () => {},
@@ -403,7 +403,7 @@ describe('usechatscroll viewport restore', () => {
           const [total, setTotal] = createSignal(5000)
           const [geom, setGeom] = createSignal(0)
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => total(),
             geometryVersion: () => geom(),
             updateViewport: () => {},
@@ -481,7 +481,7 @@ describe('usechatscroll viewport restore', () => {
             hasMoreNewer: false,
           })
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => 5000,
             geometryVersion: () => 0,
             updateViewport: () => {},
@@ -599,7 +599,7 @@ describe('usechatscroll viewport restore', () => {
           })
           let olderLoads = 0
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => 3000, // virtual rows exist now
             geometryVersion: () => 0,
             updateViewport: () => {},
@@ -668,7 +668,7 @@ describe('usechatscroll viewport restore', () => {
           })
           let olderLoads = 0
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => total(),
             geometryVersion: () => 0,
             updateViewport: () => {},

--- a/frontend/src/components/chat/useChatScroll.window.test.ts
+++ b/frontend/src/components/chat/useChatScroll.window.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { MAX_LOADED_CHAT_MESSAGES } from '~/stores/chat.store'
 
 import { FLING_OVERSCAN_HARD_CAP_PX, flingOverscanCapPx, useChatScroll } from './useChatScroll'
-import { installScrollTestEnv, makeFakeScrollDiv, makeGrowableVirtualizer, measurementDeferralNoOps } from './useChatScroll.testkit'
+import { installScrollTestEnv, makeFakeScrollDiv, makeGrowableVirtualizer, virtualizerNoOps } from './useChatScroll.testkit'
 
 installScrollTestEnv()
 
@@ -41,7 +41,7 @@ describe('usechatscroll render-ahead overscan', () => {
           let lastLeadPx = -1
           let lastLeadDir: 'older' | 'newer' | undefined = 'newer'
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => 50000,
             geometryVersion: () => 0,
             updateViewport: (_st, _ch, lead) => {
@@ -100,7 +100,7 @@ describe('usechatscroll render-ahead overscan', () => {
           let lastLeadPx = -1
           let lastLeadDir: 'older' | 'newer' | undefined = 'older'
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => 50000,
             geometryVersion: () => 0,
             updateViewport: (_st, _ch, lead) => {
@@ -159,7 +159,7 @@ describe('usechatscroll render-ahead overscan', () => {
           let lastLeadPx = -1
           let lastLeadDir: 'older' | 'newer' | undefined
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => 50000,
             geometryVersion: () => 0,
             updateViewport: (_st, _ch, lead) => {
@@ -448,7 +448,7 @@ describe('usechatscroll windowing trim', () => {
           // A virtualizer that pins the viewport midpoint to row 'm50' (the reader
           // scrolled up to it). totalHeight constant so the geometry effect is quiet.
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => 5000,
             geometryVersion: () => 0,
             updateViewport: () => {},
@@ -509,7 +509,7 @@ describe('usechatscroll windowing trim', () => {
           const [messages, setMessages] = createSignal<AgentChatMessage[]>(mkMsgs(MAX_LOADED_CHAT_MESSAGES))
           const [streamingText] = createSignal('')
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => 5000,
             geometryVersion: () => 0,
             updateViewport: () => {},
@@ -567,7 +567,7 @@ describe('usechatscroll windowing trim', () => {
           // The captured anchor row is NOT present in the window (deleted / reseq'd
           // out between capture and the trim), so findIndex returns -1.
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => 5000,
             geometryVersion: () => 0,
             updateViewport: () => {},
@@ -625,7 +625,7 @@ describe('usechatscroll windowing trim', () => {
           // MIDDLE row m10 once m1 is gone -- modelling an optimistic local that
           // reconciled to a server echo under a new id between capture and trim.
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => 5000,
             geometryVersion: () => 0,
             updateViewport: () => {},
@@ -691,7 +691,7 @@ describe('usechatscroll windowing trim', () => {
           // (rows are rowH tall), so the buffer-top anchor (bufferTargetPx above the
           // viewport top) resolves to a row STRICTLY above the viewport anchor.
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => 40000,
             geometryVersion: () => 0,
             updateViewport: () => {},
@@ -754,7 +754,7 @@ describe('usechatscroll windowing trim', () => {
           const [messages, setMessages] = createSignal<AgentChatMessage[]>(mkIdMsgs(MAX_LOADED_CHAT_MESSAGES))
           const [streamingText] = createSignal('')
           const virt: ChatScrollVirtualizer = {
-            ...measurementDeferralNoOps(),
+            ...virtualizerNoOps(),
             totalHeight: () => 5000,
             geometryVersion: () => 0,
             updateViewport: () => {},

--- a/frontend/src/components/chat/useChatVirtualizer.geometry.test.ts
+++ b/frontend/src/components/chat/useChatVirtualizer.geometry.test.ts
@@ -5,7 +5,7 @@ import { MAX_LOADED_CHAT_MESSAGES_CEILING } from '~/stores/chat.store'
 import { HEIGHT_CACHE_MAX, sameVirtualItems, useChatVirtualizer } from './useChatVirtualizer'
 import { fakeRow, makeItems, plainItems, setup } from './useChatVirtualizer.testkit'
 
-describe('usechatvirtualizer geometry', () => {
+describe('useChatVirtualizer geometry', () => {
   it('computes estimate-only offsets and total height', () => {
     createRoot((dispose) => {
       const { virt } = setup(plainItems(5))
@@ -249,6 +249,135 @@ describe('usechatvirtualizer geometry', () => {
       })
       // commitSeq advances, so two consecutive drift WARNs reveal commits between them.
       expect(reMeasure?.commitSeq ?? 0).toBeGreaterThan(seqAfterFirst)
+      dispose()
+    })
+  })
+
+  it('totals a whole flush of commits, which the last commit alone cannot explain', () => {
+    createRoot((dispose) => {
+      // Three unmeasured tool_result rows plus one that will be committed. The per-kind
+      // median re-prices the unmeasured ones, so committing a row AT the current estimate
+      // (delta 0 -- the shape the reported drift WARNs carried) can still move the map.
+      const items: VirtualItem[] = [
+        { id: 'a', hasSpanLines: false, kind: 'tool_result' },
+        { id: 'b', hasSpanLines: false, kind: 'tool_result' },
+        { id: 'c', hasSpanLines: false, kind: 'tool_result' },
+        { id: 'd', hasSpanLines: false, kind: 'tool_result' },
+      ]
+      const [list] = createSignal(items)
+      const virt = useChatVirtualizer({
+        items: list,
+        overscanPx: 0,
+        estimateHeight: 100,
+        gapSmallPx: 0,
+        gapLargePx: 0,
+      })
+      // Seed the baseline: the first call reports a 0 delta rather than the whole height.
+      expect(virt.takeMeasurementBatch()).toEqual({ commits: 0, deltaSum: 0, totalHeightDelta: 0 })
+      expect(virt.totalHeight()).toBe(400) // 4 x the 100 seed
+
+      // One flush, two commits. 'a' at 40 drops the tool_result median to 40, which re-prices
+      // b/c/d; 'd' then commits AT that median, so its own delta is 0.
+      virt.measure('a', 40)
+      virt.measure('d', 40)
+      expect(virt.lastMeasurement()).toMatchObject({ id: 'd', delta: 0 })
+      expect(virt.totalHeight()).toBe(160) // 4 x 40
+
+      const batch = virt.takeMeasurementBatch()
+      expect(batch.commits).toBe(2)
+      expect(batch.deltaSum).toBe(-60) // only 'a' moved its own row: (40 - 100) + (40 - 40)
+      // The map moved 240px, four times what the commits' own deltas account for -- the rest
+      // is the median re-pricing b and c. This is what the last commit cannot report.
+      expect(batch.totalHeightDelta).toBe(-240)
+
+      // Taking the batch RESETS it, so the next flush starts clean.
+      expect(virt.takeMeasurementBatch()).toEqual({ commits: 0, deltaSum: 0, totalHeightDelta: 0 })
+      dispose()
+    })
+  })
+
+  it('counts only the commits that reached the offset map, never a rejected one', () => {
+    createRoot((dispose) => {
+      const items: VirtualItem[] = [{ id: 'a', hasSpanLines: false, heightKey: 'k1' }]
+      const [list] = createSignal(items)
+      const virt = useChatVirtualizer({
+        items: list,
+        overscanPx: 0,
+        estimateHeight: 100,
+        gapSmallPx: 0,
+        gapLargePx: 0,
+      })
+      virt.takeMeasurementBatch() // seed the baseline
+
+      // Each of these is refused BEFORE the commit lands, so none may inflate the totals --
+      // a count that drifts from the real commits makes the WARN attribution a lie.
+      expect(virt.measure('a', 0)).toBe(false) // non-positive: would poison the offset map
+      expect(virt.measure('a', Number.NaN)).toBe(false) // NaN
+      expect(virt.measure('a', Number.POSITIVE_INFINITY)).toBe(false) // Infinity
+      expect(virt.primeHeight('a', 250, 'stale-key')).toBe(false) // heightKey mismatch
+      expect(virt.takeMeasurementBatch()).toEqual({ commits: 0, deltaSum: 0, totalHeightDelta: 0 })
+
+      expect(virt.measure('a', 250)).toBe(true)
+      // A re-measure inside the epsilon changes no offset, so it is not a commit either.
+      expect(virt.measure('a', 250.2)).toBe(false)
+      expect(virt.takeMeasurementBatch()).toEqual({ commits: 1, deltaSum: 150, totalHeightDelta: 150 })
+      dispose()
+    })
+  })
+
+  it('reports the FIRST take as an empty batch, not as the startup pass', () => {
+    createRoot((dispose) => {
+      const items: VirtualItem[] = [
+        { id: 'a', hasSpanLines: false, kind: 'tool_result' },
+        { id: 'b', hasSpanLines: false, kind: 'tool_result' },
+      ]
+      const [list] = createSignal(items)
+      const virt = useChatVirtualizer({
+        items: list,
+        overscanPx: 0,
+        estimateHeight: 100,
+        gapSmallPx: 0,
+        gapLargePx: 0,
+      })
+
+      // Commits that land before anyone takes a batch belong to the initial mount pass -- the
+      // row-height persistence primes whole pages of heights, and the consuming effect is
+      // `defer: true`, so it never runs at creation to separate them. No flush boundary exists
+      // to attribute them to.
+      virt.measure('a', 40)
+      virt.measure('b', 40)
+      expect(virt.totalHeight()).toBe(80)
+
+      // Reporting them as one flush produced a payload that contradicted itself: a real commit
+      // count against a zero map movement, because only the height baseline was seeded lazily.
+      // All three fields must agree that nothing was measured yet.
+      expect(virt.takeMeasurementBatch()).toEqual({ commits: 0, deltaSum: 0, totalHeightDelta: 0 })
+
+      // And the seeding call must not swallow the NEXT flush, which is a real one.
+      virt.measure('a', 90)
+      expect(virt.takeMeasurementBatch()).toEqual({ commits: 1, deltaSum: 50, totalHeightDelta: 50 })
+      dispose()
+    })
+  })
+
+  it('reports zero commits when the geometry moved without one (a prepend)', () => {
+    createRoot((dispose) => {
+      const [list, setList] = createSignal<VirtualItem[]>([{ id: 'b', hasSpanLines: false }])
+      const virt = useChatVirtualizer({
+        items: list,
+        overscanPx: 0,
+        estimateHeight: 100,
+        gapSmallPx: 0,
+        gapLargePx: 0,
+      })
+      virt.takeMeasurementBatch() // seed the baseline
+      expect(virt.totalHeight()).toBe(100)
+
+      // A prepend moves the offset map with no height commit at all. `commits: 0` beside a
+      // non-zero totalHeightDelta is what tells a drift WARN that no measurement caused it.
+      setList([{ id: 'a', hasSpanLines: false }, { id: 'b', hasSpanLines: false }])
+      expect(virt.totalHeight()).toBe(200)
+      expect(virt.takeMeasurementBatch()).toEqual({ commits: 0, deltaSum: 0, totalHeightDelta: 100 })
       dispose()
     })
   })
@@ -515,7 +644,7 @@ describe('usechatvirtualizer geometry', () => {
     })
   })
 
-  describe('heightdebugofid (raw-json debug surface)', () => {
+  describe('heightDebugOfId (raw-json debug surface)', () => {
     it('returns measured undefined before the row is measured', () => {
       createRoot((dispose) => {
         const { virt } = setup(plainItems(2))
@@ -555,7 +684,7 @@ describe('usechatvirtualizer geometry', () => {
   })
 })
 
-describe('samevirtualitems geometry equality', () => {
+describe('sameVirtualItems geometry equality', () => {
   const base: VirtualItem = { id: 'm1', hasSpanLines: false, heightKey: 'k1', seq: 1n, kind: 'user_text' }
 
   it('is true for arrays equal on the geometry fields', () => {
@@ -585,7 +714,7 @@ describe('samevirtualitems geometry equality', () => {
   })
 })
 
-describe('primeheights bulk hydration and snapshotheights', () => {
+describe('primeHeights bulk hydration and snapshotheights', () => {
   it('commits a whole batch with ONE geometryVersion bump', () => {
     createRoot((dispose) => {
       const { virt } = setup(plainItems(4))

--- a/frontend/src/components/chat/useChatVirtualizer.ts
+++ b/frontend/src/components/chat/useChatVirtualizer.ts
@@ -177,6 +177,37 @@ export interface MeasurementCommitInfo {
   commitSeq: number
 }
 
+/**
+ * Every height commit of ONE geometry flush, totalled. It is what makes the companion
+ * `lastMeasurement` readable, because a flush is rarely one commit.
+ *
+ * The hidden premeasure pipeline reads a whole band's rects,
+ * then commits them inside a single `batch()` (see chatHiddenPremeasure's shared frame), so
+ * the consumer's effect runs ONCE for N commits while `lastMeasurement` keeps only the LAST
+ * of them. A drift WARN carrying `delta: 0` and a 74px residual is that gap, not a
+ * contradiction: the final row of the batch happened to measure exactly at its estimate.
+ */
+export interface MeasurementBatchInfo {
+  /** Commits in this flush. 0 when the geometry moved with no commit at all (a prepend/trim). */
+  readonly commits: number
+  /** Signed sum of every commit's own `delta`. */
+  readonly deltaSum: number
+  /**
+   * How far the whole offset map actually moved. This is NOT `deltaSum`, because a commit
+   * also feeds the per-kind median, and a median that steps re-prices every still-unmeasured
+   * row of that kind in the window. So the map can move while `deltaSum` is 0.
+   *
+   * The gap between the two is that re-pricing PLUS anything else that moved the map in the
+   * same flush: a list mutation (prepend, append, trim), a height-cache eviction that reverts
+   * a row to its estimate, or a stale-key prune. Read it beside `commits`: `commits: 0` with
+   * a non-zero delta means no measurement caused the move at all.
+   */
+  readonly totalHeightDelta: number
+}
+
+/** The zero batch: no flush sampled yet, or a flush that carried no commit and moved nothing. */
+export const EMPTY_MEASUREMENT_BATCH: MeasurementBatchInfo = { commits: 0, deltaSum: 0, totalHeightDelta: 0 }
+
 export interface UseChatVirtualizerOptions {
   /** Reactive list of rows to virtualize, in display order. */
   items: Accessor<VirtualItem[]>
@@ -289,6 +320,13 @@ export interface UseChatVirtualizerResult {
   estimateHeight: Accessor<number>
   /** Diagnostic: the most recent geometry-changing height commit, for drift-WARN attribution. */
   lastMeasurement: () => MeasurementCommitInfo | undefined
+  /**
+   * Diagnostic: the commits accumulated since the previous call, and reset. Call ONCE per
+   * geometry flush, from the effect that reacts to it and BEFORE anything reads the new
+   * geometry -- that call boundary is what makes the totals mean "this flush" (see
+   * MeasurementBatchInfo). A caller that never calls it just leaves the totals accumulating.
+   */
+  takeMeasurementBatch: () => MeasurementBatchInfo
   /**
    * Compute (without committing) the visible slice for a given scroll position.
    * `lead` extends the overscan in its `dir` (the fling direction) so a fast
@@ -519,6 +557,12 @@ export function useChatVirtualizer(opts: UseChatVirtualizerOptions): UseChatVirt
   // Non-reactive -- read at WARN time, never a render input.
   let lastMeasurement: MeasurementCommitInfo | undefined
   let measurementCommitSeq = 0
+  // Diagnostic-only: the commits since the last takeMeasurementBatch, and the total height at
+  // that call. `undefined` until the first call, so the first flush reports a 0 delta instead
+  // of the whole initial content height.
+  let batchCommits = 0
+  let batchDeltaSum = 0
+  let batchBaseTotalHeight: number | undefined
   // Per-kind median of measured heights. An unmeasured row uses the median for its OWN
   // kind (falling back to the global median, then the seed) until visible or hidden DOM
   // measurement commits its real height -- see createPerKindHeightEstimate.
@@ -876,6 +920,9 @@ export function useChatVirtualizer(opts: UseChatVirtualizerOptions): UseChatVirt
     // Record the commit that is about to move the offset map, so a re-pin drift the
     // resulting totalHeight change triggers can name its cause (see MeasurementCommitInfo).
     measurementCommitSeq += 1
+    // One binding for both readers below: lastMeasurement reports this commit's own delta and
+    // the batch sums it, so a later clamp or rounding on one must not miss the other.
+    const delta = height - assumedHeight
     lastMeasurement = {
       id,
       kind,
@@ -883,9 +930,13 @@ export function useChatVirtualizer(opts: UseChatVirtualizerOptions): UseChatVirt
       firstMeasure: isFirst,
       assumedHeight,
       newHeight: height,
-      delta: height - assumedHeight,
+      delta,
       commitSeq: measurementCommitSeq,
     }
+    // Total this commit into the current flush's batch as well: a batched premeasure
+    // overwrites lastMeasurement per row, so only these survive the whole batch.
+    batchCommits += 1
+    batchDeltaSum += delta
     return true
   }
   const commitMeasuredHeight = (
@@ -993,6 +1044,29 @@ export function useChatVirtualizer(opts: UseChatVirtualizerOptions): UseChatVirt
     return committed
   }
 
+  // Close the flush: report the commits that accumulated since the previous call, plus how
+  // far the offset map actually moved across them, then reset. `totalHeight()` reads the
+  // memo, so the caller must be untracked (useChatScroll's re-pin effect uses `on(...)`,
+  // whose body runs untracked) or it would subscribe to geometry it only means to sample.
+  const takeMeasurementBatch = (): MeasurementBatchInfo => {
+    const total = totalHeight()
+    const base = batchBaseTotalHeight
+    batchBaseTotalHeight = total
+    const commits = batchCommits
+    const deltaSum = batchDeltaSum
+    batchCommits = 0
+    batchDeltaSum = 0
+    // The FIRST call is a seeding call, not a flush report. Every counter above it belongs to
+    // the initial mount pass, which no flush boundary separates: the consumer's effect is
+    // `defer: true`, so it never runs at creation, and the row-height persistence load primes
+    // whole pages of heights before it. Reporting those as one flush produced a payload that
+    // contradicted itself -- `commits: 140` beside `totalHeightDelta: 0`, because only the
+    // height baseline was seeded lazily. Report the zero batch and start clean.
+    if (base === undefined)
+      return EMPTY_MEASUREMENT_BATCH
+    return { commits, deltaSum, totalHeightDelta: total - base }
+  }
+
   return {
     range,
     geometryVersion: geomVersion,
@@ -1009,6 +1083,7 @@ export function useChatVirtualizer(opts: UseChatVirtualizerOptions): UseChatVirt
     heightDebugOfId,
     estimateHeight,
     lastMeasurement: () => lastMeasurement,
+    takeMeasurementBatch,
     computeRange,
     updateViewport,
     measure,


### PR DESCRIPTION
## Motivation
The browser console showed WARN messages in production: "anchored content drifted without correction", reason `absorbed`, with residuals of -62, -74, and -88 px. The messages appeared while a reader scrolled up through chat history. `scrollTop` stayed almost stationary during each event.

The re-pin engine left the anchored row displaced on screen. It re-anchored the row at the displaced position instead of correcting it. The shift became permanent.

The root cause is the gate on the engine's ABSORB branch. That branch skips the `scrollTop` write and re-anchors at the displaced position instead. The gate combined `isUserScrolling()` with `hasRecentMomentumInput()`, a 750ms grace period that every vertical wheel event arms. `hasRecentMomentumInput()` reports that the user touched the surface recently. It does not report that momentum still moves the viewport, and it outlasts a real coast by about 600ms. A hidden premeasure band that committed on the next frame, over an already-stationary viewport, had its correction absorbed instead of written.

Two further problems surfaced while correcting that one, and this PR fixes them together.

The engine's other suppression branch tests the opposite condition, and it was wrong in the opposite direction. It asks whether a `scrollTop` write would cancel the user's momentum. Speed cannot answer that. Momentum decays continuously, so the last few hundred ms of a trackpad coast run below the fling threshold while the viewport still plainly moves, and a write there stops the scroll under the reader's finger.

The absorb cap also had to drop for the first fix, from 128px to 8px. That change alone would have killed the very diagnostic that surfaced this bug. Detector C compared each event's own residual against a 16px floor, so with an 8px cap no absorbed shift could ever reach it and the detector would fall permanently silent.

This is a frontend-only, internal change. It changes no public API, no protocol, and no persisted format.

## Modifications
- **Re-pin engine** (`chatScrollAnchorRepin.ts`): Scope the ABSORB gate to `isUserScrolling()` alone; remove `hasRecentMomentumInput()` from it. Cut `SMALL_USER_SCROLL_REPIN_ABSORB_PX` from 128 to 8 and make the comparison strict, so an absorbed shift stays under `VISIBLE_ANCHOR_JUMP_PX` (also 8), the threshold the project already defines as visible. Remove `hasRecentMomentumInput` from the `AnchorRepinVelocity` interface; its doc now states that no caller may fold that grace into `isFling` or `isActivelyFlinging`.
- **Velocity tracker** (`chatScrollVelocity.ts`): Add `isCoasting()` and `noteUserInput()`. `isCoasting()` is a latch driven by displacement, not by speed: a fling-speed sample sets it, and a zero-displacement sample or a gap past the idle window clears it. It covers a coast's decaying tail, where speed drops below the fling threshold while the viewport still moves — a gap that `isFling()` and `isActivelyFlinging()` miss. `noteUserInput()` clears the latch on every wheel notch, so one fast deliberate notch cannot mark a coast the user does not actually drive. `isFling()`, `isActivelyFlinging()`, and `speed()` stay unchanged.
- **Diagnostics** (`chatScrollDiagnostics.ts`): Detector C now compares the signed running sum of drift since the last WARN against the floor, instead of one event's residual. This keeps the detector alive under the smaller absorb cap, and it also matches the real harm, because each absorb re-anchors at the displaced position and the shifts accumulate. Opposing shifts net out and correctly stay silent. Remove Detector C's fast-fling skip and its `isActivelyFlinging` dependency; they suppressed nothing, because a shift is only ever `'absorbed'` when `isFling()` is false. Rename the WARN payload fields `suppressedSinceLastWarn` → `absorbsSinceLastWarn` and `suppressedResidualPxSum` → `driftPxSinceLastWarn`; both now report the full running total, including the triggering event. Detector B keeps its own `suppressedSinceLastWarn`.
- **Virtualizer** (`useChatVirtualizer.ts`): Add `takeMeasurementBatch()` and `MeasurementBatchInfo {commits, deltaSum, totalHeightDelta}`. The hidden premeasure pipeline commits a whole band inside one `batch()`; the consuming effect used to run once for the whole batch while `lastMeasurement` kept only the last commit, which is why a WARN could report `delta: 0` next to a 74px residual. All three detectors now share one `causationContext()` thunk for `{measurement, batch, dom}`, so their cause snapshots stay consistent; it stays a thunk so an emitter's early return still runs before it takes the snapshot. Detector A's clamp payload carried neither field before this.
- **Hook** (`useChatScroll.ts`): Supply the engine a new expression for `isActivelyFlinging`: `() => scrollVelocity.isCoasting() && !isScrollInputActive()`. Both terms matter. `isCoasting()` covers the coast's decaying tail. `!isScrollInputActive()` excludes a fast pointer drag or a scrollbar drag, which measures like a coast but carries no inertia — `handleScroll` only schedules the fling-settle for momentum scrolls, so a correction deferred during a drag would have nothing to apply it. Add a `measurementBatch` mailbox, sampled once per geometry flush and stamped with `ageMs`, so a detector that fires with no flush of its own does not report an unrelated older flush as its cause. Rename `measurementDeferralNoOps` to `virtualizerNoOps` and change its type from a hand-listed `Pick<>` to an `Omit<>` derived by subtraction, so a new virtualizer member fails the build in one place instead of silently missing a stub.
- **Test kit and tests**: Add `makeShiftingVirtualizer(shift, opts)`, replacing 17 near-identical inline stub copies; two call sites keep their own stub because they model different fixtures — an anchor that stops resolving after a trim, and two shifts committed inside one flush. Add tests for: a correction deferred through a coast's decaying tail and written once the coast stops; a correction written during a fast pointer drag; a deferral that outlives the 750ms grace; the strict absorb bound on both sides; Detector C's cumulative floor and sign cancellation; the batch `ageMs`; and the seeding take. Deleting the hook's `onAnchorDrift` wiring now fails a test.

## Result
A reader who scrolls up through chat history no longer sees anchored rows drift or jump while `scrollTop` stays still. Any correction the engine still withholds stays under 8px, the threshold the project defines as imperceptible.

A real momentum fling coasts to rest without interruption, including its slow tail, where a `scrollTop` write used to stop it under the reader's finger. A fast pointer drag or scrollbar drag still receives its correction immediately, rather than deferring it to a fling-settle that a drag never schedules.

Detector C stays alive under the smaller absorb cap, and it now reports accumulated drift rather than single events. A future regression here produces a console WARN instead of silence, and every WARN names the geometry flush that caused it.
