### PR TITLE
fix: Keep the sidebar and the worktree correct on a branch delete

### DIFF
--- a/backend/internal/worker/service/orphan_reconciler.go
+++ b/backend/internal/worker/service/orphan_reconciler.go
@@ -58,6 +58,12 @@ type OrphanReconciler struct {
 	// reconcileWorktrees removes it, so a transient zero-live window during
 	// startup or worktree reuse is never mistaken for a strand.
 	prevOrphanWorktrees map[string]time.Time
+	// prevOrphanTabs maps a reconcilable tab to when it FIRST looked absent from
+	// the hub's owned-tab list. A tab must stay absent for tabGrace before any
+	// arm tears it down. See orphanTabGrace for what that window bounds.
+	prevOrphanTabs map[ownedTabKey]time.Time
+	// tabGrace is orphanTabGrace unless a caller overrode it.
+	tabGrace time.Duration
 }
 
 // OrphanReconcilerOptions configures NewOrphanReconciler.
@@ -70,6 +76,13 @@ type OrphanReconcilerOptions struct {
 	Interval time.Duration
 	Now      func() time.Time
 	Logger   *slog.Logger
+	// TabGrace overrides orphanTabGrace, the delay between a tab first looking
+	// absent from the hub and an arm tearing it down. Zero selects the default.
+	// A negative value disables the grace, which only a test that drives the
+	// real Run loop in real time should choose -- production must keep the
+	// window, because it is what stops a nudge-driven pass from preempting the
+	// close RPC that is still in flight.
+	TabGrace time.Duration
 	// ReapWorktree, when set, enables the orphan-worktree GC pass: it is
 	// invoked for each worktree confirmed orphaned across two consecutive
 	// reconcile passes. Wire it to (*Service).ReapOrphanWorktree.
@@ -109,6 +122,9 @@ func NewOrphanReconciler(queries *db.Queries, files *FileTabPathStore, listFn fu
 	if opts.Now == nil {
 		opts.Now = time.Now
 	}
+	if opts.TabGrace == 0 {
+		opts.TabGrace = orphanTabGrace
+	}
 	if opts.Logger == nil {
 		opts.Logger = slog.Default()
 	}
@@ -133,6 +149,8 @@ func NewOrphanReconciler(queries *db.Queries, files *FileTabPathStore, listFn fu
 		reapWorktree:        opts.ReapWorktree,
 		closeTab:            opts.CloseTab,
 		prevOrphanWorktrees: make(map[string]time.Time),
+		prevOrphanTabs:      make(map[ownedTabKey]time.Time),
+		tabGrace:            opts.TabGrace,
 	}
 }
 
@@ -143,6 +161,25 @@ func NewOrphanReconciler(queries *db.Queries, files *FileTabPathStore, listFn fu
 // magnitude, deliberately: over-waiting costs a directory a later pass reclaims,
 // while under-waiting destroys a live tab's worktree.
 const orphanWorktreeGrace = 2 * time.Minute
+
+// orphanTabGrace is how long a locally open tab must stay absent from the hub's
+// owned-tab list before an arm tears it down.
+//
+// It bounds the window that a client's OWN close opens. The client emits the
+// CRDT TombstoneTab first and sends the close RPC second, on a different
+// transport, and the hub nudges this worker the moment it applies that
+// tombstone. So a nudge-driven pass can see the absence while the close that
+// carries the user's WorktreeAction is still in flight. A reap in that window
+// runs the KEEP-shaped convergence teardown, which drops the tab's
+// worktree_tabs link; the real REMOVE close then finds no link, degrades to
+// KEEP, and leaves the worktree on disk with nothing left to reclaim it -- a
+// zero-link worktree is excluded from ListOrphanCandidateWorktrees forever.
+//
+// The measured window is 2-6 ms in a single-process `leapmux dev`, so this is
+// generous by three orders of magnitude, deliberately: over-waiting delays a
+// teardown that a later pass performs anyway, while under-waiting silently
+// downgrades every online worktree-removing close.
+const orphanTabGrace = 10 * time.Second
 
 // Trigger schedules an immediate reconciliation pass. Non-blocking;
 // duplicate triggers coalesce.
@@ -309,10 +346,45 @@ func (r *OrphanReconciler) reconcileOnce(ctx context.Context) bool {
 	// side ever needed one), so their rows can be attributed to no owner and
 	// excluded from no scope; the only scope check available to them is the
 	// mint gate above.
-	r.reconcileFileTabs(ctx, hubByKey, owner)
-	r.reconcileAgents(ctx, hubByKey)
-	r.reconcileTerminals(ctx, hubByKey)
+	now := r.now()
+	next := make(map[ownedTabKey]time.Time)
+	r.reconcileFileTabs(ctx, hubByKey, owner, now, next)
+	r.reconcileAgents(ctx, hubByKey, now, next)
+	r.reconcileTerminals(ctx, hubByKey, now, next)
+	// Assigned ONLY here, on the path where all three arms ran. Every early
+	// return above learned nothing about absence, so overwriting the map there
+	// would restart each tab's clock and defeat the grace.
+	r.prevOrphanTabs = next
+	if len(next) > 0 {
+		// A deferred reap is unfinished business, not convergence. Report it so
+		// Run re-arms its retry backoff and a later pass performs the teardown,
+		// instead of leaving it to the hourly tick.
+		converged = false
+	}
 	return converged
+}
+
+// reapDue records that k looked absent on this pass, and reports whether it
+// looked absent for longer than orphanTabGrace.
+//
+// A key the hub lists again simply never reaches here, so it drops out of
+// `next` and its clock restarts on the following absence. That is what makes a
+// transient absence -- the close-RPC race that orphanTabGrace exists for -- cost
+// one deferred pass rather than a destructive teardown.
+func (r *OrphanReconciler) reapDue(k ownedTabKey, now time.Time, next map[ownedTabKey]time.Time) bool {
+	if r.tabGrace < 0 {
+		return true
+	}
+	firstSeen, seen := r.prevOrphanTabs[k]
+	if !seen {
+		next[k] = now
+		return false
+	}
+	if now.Sub(firstSeen) < r.tabGrace {
+		next[k] = firstSeen
+		return false
+	}
+	return true
 }
 
 // hasAnyLocalRows reports whether at least one of the three reconciled local
@@ -423,7 +495,7 @@ func (r *OrphanReconciler) reconcileWorktrees(ctx context.Context) bool {
 // and stating that at the destructive line is what keeps a future reader from
 // widening the read and silently widening the reap with it. Pinned by
 // TestOrphanReconciler_FileTab_SharedTabIDStaysWithItsOwner.
-func (r *OrphanReconciler) reconcileFileTabs(ctx context.Context, hubByKey map[ownedTabKey]*leapmuxv1.OwnedTab, owner userid.UserID) {
+func (r *OrphanReconciler) reconcileFileTabs(ctx context.Context, hubByKey map[ownedTabKey]*leapmuxv1.OwnedTab, owner userid.UserID, now time.Time, next map[ownedTabKey]time.Time) {
 	rows, err := r.queries.ListAllWorkerFileTabs(ctx)
 	if err != nil {
 		r.logger.Warn("orphan reconciler: list worker_file_tabs", "err", err)
@@ -455,6 +527,11 @@ func (r *OrphanReconciler) reconcileFileTabs(ctx context.Context, hubByKey map[o
 			if !owner.Matches(row.UserID) {
 				continue
 			}
+			// Grace comes AFTER the owner check, so a row belonging to another
+			// owner never enters the map and never starts a clock.
+			if !r.reapDue(k, now, next) {
+				continue
+			}
 			// Route through the SAME teardown the AGENT and TERMINAL arms use,
 			// with the keep-the-link policy.
 			//
@@ -476,7 +553,7 @@ func (r *OrphanReconciler) reconcileFileTabs(ctx context.Context, hubByKey map[o
 
 // reconcileAgents iterates every locally-known agent and absorbs the
 // hub's view: hub-absent -> stop the subprocess and close the row locally.
-func (r *OrphanReconciler) reconcileAgents(ctx context.Context, hubByKey map[ownedTabKey]*leapmuxv1.OwnedTab) {
+func (r *OrphanReconciler) reconcileAgents(ctx context.Context, hubByKey map[ownedTabKey]*leapmuxv1.OwnedTab, now time.Time, next map[ownedTabKey]time.Time) {
 	// OPEN rows only. A closed row has already been torn down, so comparing it
 	// against the hub's live list only re-ran the full teardown -- cancelAndClear,
 	// StopAgent, ClearAgentRuntimeState, the registered cleanups -- and re-logged
@@ -497,6 +574,12 @@ func (r *OrphanReconciler) reconcileAgents(ctx context.Context, hubByKey map[own
 	for _, agentID := range rows {
 		k := newOwnedTabKey(leapmuxv1.TabType_TAB_TYPE_AGENT, agentID, "")
 		if _, ok := hubByKey[k]; !ok {
+			// Absent, but not yet for long enough. The client's own close
+			// tombstones the tab before its RPC lands, so an immediate reap
+			// here would drop the worktree link that close is about to use.
+			if !r.reapDue(k, now, next) {
+				continue
+			}
 			// Unlike the file-tab loop this absence is NOT owner-checked --
 			// see the note in reconcileOnce: there is no owner to check it
 			// against on either side of this comparison (the key normalizes to
@@ -527,7 +610,7 @@ func (r *OrphanReconciler) reconcileAgents(ctx context.Context, hubByKey map[own
 }
 
 // reconcileTerminals does the same for terminals.
-func (r *OrphanReconciler) reconcileTerminals(ctx context.Context, hubByKey map[ownedTabKey]*leapmuxv1.OwnedTab) {
+func (r *OrphanReconciler) reconcileTerminals(ctx context.Context, hubByKey map[ownedTabKey]*leapmuxv1.OwnedTab, now time.Time, next map[ownedTabKey]time.Time) {
 	// OPEN rows only, for the same reasons as reconcileAgents.
 	rows, err := r.queries.ListAllOpenTerminalIDs(ctx)
 	if err != nil {
@@ -537,6 +620,11 @@ func (r *OrphanReconciler) reconcileTerminals(ctx context.Context, hubByKey map[
 	for _, row := range rows {
 		k := newOwnedTabKey(leapmuxv1.TabType_TAB_TYPE_TERMINAL, row, "")
 		if _, ok := hubByKey[k]; !ok {
+			// Same grace as reconcileAgents: a close RPC still in flight must
+			// not lose its worktree link to this pass.
+			if !r.reapDue(k, now, next) {
+				continue
+			}
 			// Owner-blind for the same reason as reconcileAgents.
 			// Symmetric to reconcileAgents: SQLite close + send a
 			// stop signal to the in-memory terminal manager so the

--- a/backend/internal/worker/service/orphan_reconciler_gc_test.go
+++ b/backend/internal/worker/service/orphan_reconciler_gc_test.go
@@ -257,8 +257,11 @@ func TestReconcileFileTabs_RoutesThroughSharedTeardownHonouringKeep(t *testing.T
 	listFn := func(context.Context) (*leapmuxv1.ListOwnedTabsForWorkerResponse, error) {
 		return &leapmuxv1.ListOwnedTabsForWorkerResponse{OwnerUserId: "user-1"}, nil
 	}
+	// TabGrace -1: this test asserts WHAT the teardown does, not when it is due.
+	// TestReconcileTabs_* below covers the grace itself.
 	rec := NewOrphanReconciler(q, svc.FileTabPaths, listFn, OrphanReconcilerOptions{
 		CloseTab: svc.CloseTabForReconcile,
+		TabGrace: -1,
 	})
 	rec.reconcileOnce(ctx)
 
@@ -376,4 +379,136 @@ func TestReconcileOnce_LocalProbeFailureIsNotConvergence(t *testing.T) {
 
 	assert.False(t, rec.reconcileOnce(ctx),
 		"a pass whose local probes all errored has NOT converged and must be retried")
+}
+
+// The tab arms carry the same shape of elapsed-time grace as the worktree GC
+// above, for a sharper reason: a client tombstones its tab over the CRDT
+// transport BEFORE it sends the close RPC over the channel, and the hub nudges
+// this worker the moment it applies that tombstone. A pass that reaps on the
+// first absence therefore preempts the user's own close -- and because the
+// convergence teardown drops the tab's worktree_tabs link, the REMOVE that
+// close carries then finds no link and degrades to KEEP. The worktree survives
+// with zero links, which excludes it from ListOrphanCandidateWorktrees forever.
+
+// TestReconcileTabs_DefersTheReapUntilTheGraceElapses pins that one pass is not
+// enough to tear a tab down, and that a later pass past the window still does.
+func TestReconcileTabs_DefersTheReapUntilTheGraceElapses(t *testing.T) {
+	t.Parallel()
+
+	svc, _, _ := setupTestService(t)
+	q := svc.Queries
+	ctx := context.Background()
+
+	require.NoError(t, q.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "racing-agent", AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX,
+	}))
+	// The hub already applied the client's TombstoneTab, so its owned-tab list
+	// no longer names this agent. That is exactly what the nudge delivers.
+	listFn := func(context.Context) (*leapmuxv1.ListOwnedTabsForWorkerResponse, error) {
+		return &leapmuxv1.ListOwnedTabsForWorkerResponse{OwnerUserId: "user-1"}, nil
+	}
+	clock := time.Now()
+	rec := NewOrphanReconciler(q, svc.FileTabPaths, listFn, OrphanReconcilerOptions{
+		CloseTab: svc.CloseTabForReconcile,
+		Now:      func() time.Time { return clock },
+		TabGrace: 10 * time.Second,
+	})
+
+	assert.False(t, rec.reconcileOnce(ctx),
+		"a deferred reap is outstanding work, so the pass has NOT converged")
+	row, err := q.GetAgentByID(ctx, "racing-agent")
+	require.NoError(t, err)
+	require.False(t, row.ClosedAt.Valid,
+		"the first pass must not preempt the close RPC that is still in flight")
+
+	clock = clock.Add(11 * time.Second)
+	assert.True(t, rec.reconcileOnce(ctx), "the reap is due, so this pass converges")
+	row, err = q.GetAgentByID(ctx, "racing-agent")
+	require.NoError(t, err)
+	assert.True(t, row.ClosedAt.Valid, "a tab absent past the grace is still reaped")
+}
+
+// TestReconcileTabs_RestartsTheClockWhenTheHubListsTheTabAgain pins that the
+// grace measures CONTINUOUS absence. A tab the hub names again has to serve a
+// fresh window, so a flapping list can never accumulate its way to a reap.
+func TestReconcileTabs_RestartsTheClockWhenTheHubListsTheTabAgain(t *testing.T) {
+	t.Parallel()
+
+	svc, _, _ := setupTestService(t)
+	q := svc.Queries
+	ctx := context.Background()
+
+	require.NoError(t, q.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "flapping-agent", AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX,
+	}))
+	present := false
+	listFn := func(context.Context) (*leapmuxv1.ListOwnedTabsForWorkerResponse, error) {
+		resp := &leapmuxv1.ListOwnedTabsForWorkerResponse{OwnerUserId: "user-1"}
+		if present {
+			resp.Tabs = []*leapmuxv1.OwnedTab{{
+				TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: "flapping-agent",
+			}}
+		}
+		return resp, nil
+	}
+	clock := time.Now()
+	rec := NewOrphanReconciler(q, svc.FileTabPaths, listFn, OrphanReconcilerOptions{
+		CloseTab: svc.CloseTabForReconcile,
+		Now:      func() time.Time { return clock },
+		TabGrace: 10 * time.Second,
+	})
+
+	rec.reconcileOnce(ctx) // absent: starts the clock
+	present = true
+	clock = clock.Add(6 * time.Second)
+	rec.reconcileOnce(ctx) // present: drops out of the map
+	present = false
+	clock = clock.Add(6 * time.Second)
+	rec.reconcileOnce(ctx) // absent again: 12s total elapsed, but only 0s continuous
+
+	row, err := q.GetAgentByID(ctx, "flapping-agent")
+	require.NoError(t, err)
+	assert.False(t, row.ClosedAt.Valid,
+		"the clock restarts on every reappearance, so accumulated absence must not reap")
+}
+
+// TestReconcileTabs_RemoveCloseKeepsItsWorktreeLinkAcrossARacingPass is the
+// regression for the production failure: an in-flight CloseAgent(REMOVE) whose
+// CRDT tombstone already reached the hub must still find its worktree link.
+func TestReconcileTabs_RemoveCloseKeepsItsWorktreeLinkAcrossARacingPass(t *testing.T) {
+	t.Parallel()
+
+	svc, _, _ := setupTestService(t)
+	q := svc.Queries
+	ctx := context.Background()
+
+	_, cwErr := q.CreateWorktree(ctx, db.CreateWorktreeParams{
+		ID: "wt-racing", WorktreePath: "/r/racing", RepoRoot: "/r", BranchName: "doomed",
+	})
+	require.NoError(t, cwErr)
+	require.NoError(t, q.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "racing-agent", AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX,
+	}))
+	svc.registerTabForWorktree("wt-racing", leapmuxv1.TabType_TAB_TYPE_AGENT, "racing-agent")
+
+	listFn := func(context.Context) (*leapmuxv1.ListOwnedTabsForWorkerResponse, error) {
+		return &leapmuxv1.ListOwnedTabsForWorkerResponse{OwnerUserId: "user-1"}, nil
+	}
+	clock := time.Now()
+	rec := NewOrphanReconciler(q, svc.FileTabPaths, listFn, OrphanReconcilerOptions{
+		CloseTab: svc.CloseTabForReconcile,
+		Now:      func() time.Time { return clock },
+		TabGrace: 10 * time.Second,
+	})
+
+	rec.reconcileOnce(ctx)
+
+	// The link survives, so the REMOVE that follows can still ref-count to zero
+	// and reclaim the worktree. Without the grace this count is 0, the close
+	// degrades to KEEP, and the directory is stranded with no link to make it a
+	// GC candidate.
+	remaining, err := q.CountWorktreeTabs(ctx, "wt-racing")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), remaining,
+		"a racing pass must not drop the worktree link the in-flight REMOVE needs")
 }

--- a/backend/internal/worker/service/orphan_reconciler_test.go
+++ b/backend/internal/worker/service/orphan_reconciler_test.go
@@ -64,6 +64,13 @@ func newOrphanReconcilerHarness(t *testing.T, opts service.OrphanReconcilerOptio
 	if opts.CloseTab == nil {
 		opts.CloseTab = teardown.closeTab
 	}
+	// These tests assert WHAT a reap does, not WHEN it is due, and they drive
+	// single passes on a real clock. Disable the grace so each one still reaps
+	// in one pass. The grace itself has its own tests, which drive a fake clock
+	// across the window: see TestReconcileTabs_* in orphan_reconciler_gc_test.go.
+	if opts.TabGrace == 0 {
+		opts.TabGrace = -1
+	}
 	rec := service.NewOrphanReconciler(q, files, listFn, opts)
 	setFake := func(ownerUserID string, tabs []*leapmuxv1.OwnedTab, err error) {
 		fakeMu.Lock()

--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -1135,14 +1135,13 @@ export const AppShell: Component = () => {
 
       <AppShellDialogs
         dialogs={dialogs}
-        onBranchChanged={(workerId, gitToplevel, newBranch) => handleBranchChanged(
+        onBranchChanged={(repo, newBranch) => handleBranchChanged(
           {
             target: tabStampTarget(tabView, tabMetadata),
             gitFileStatusStore,
             getCurrentTabContext,
           },
-          workerId,
-          gitToplevel,
+          repo,
           newBranch,
         )}
         activeWorkspace={activeWorkspace}

--- a/frontend/src/components/shell/AppShellDialogs.test.tsx
+++ b/frontend/src/components/shell/AppShellDialogs.test.tsx
@@ -8,7 +8,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as workerRpc from '~/api/workerRpc'
 import { showWarnToast } from '~/components/common/Toast'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
-import { createDialogState, createToggleDialog } from '~/hooks/createDialogState'
+import { createDialogState, createToggleDialog, createUpdatableDialogState } from '~/hooks/createDialogState'
 import { makeInspectResp } from '~/test-support/gitBranchFixtures'
 import { AppShellDialogs } from './AppShellDialogs'
 
@@ -84,7 +84,7 @@ function makeDialogs(): AppShellDialogStates {
     newWorkspace: createDialogState(),
     confirmDeleteWs: createDialogState(),
     confirmArchiveWs: createDialogState(),
-    lastTabConfirm: createDialogState(),
+    lastTabConfirm: createUpdatableDialogState(),
     keyPinConfirm: createDialogState(),
     changeBranch: createDialogState(),
     deleteBranch: createDialogState(),
@@ -165,7 +165,7 @@ describe('appShellDialogs branch dialogs', () => {
     await chooseSwitchToAndConfirm('main')
 
     await waitFor(() => expect(onBranchChanged).toHaveBeenCalledTimes(1))
-    expect(onBranchChanged).toHaveBeenCalledWith('w1', '/repo', 'main')
+    expect(onBranchChanged).toHaveBeenCalledWith(expect.objectContaining({ workerId: 'w1', gitToplevel: '/repo' }), 'main')
     expect(showWarnToast).not.toHaveBeenCalled()
     // The dialog still closes: the notify must not prevent the close.
     await waitFor(() => expect(dialogs.deleteBranch.value()).toBeNull())
@@ -196,7 +196,7 @@ describe('appShellDialogs branch dialogs', () => {
     await chooseSwitchToAndConfirm('main')
 
     await waitFor(() => expect(onBranchChanged).toHaveBeenCalledTimes(1))
-    expect(onBranchChanged).toHaveBeenCalledWith('w9', '/second-repo', 'main')
+    expect(onBranchChanged).toHaveBeenCalledWith(expect.objectContaining({ workerId: 'w9', gitToplevel: '/second-repo' }), 'main')
   })
 
   it('delete branch: a replacing open() re-points the dialog at the new repo', async () => {
@@ -224,7 +224,7 @@ describe('appShellDialogs branch dialogs', () => {
     await chooseSwitchToAndConfirm('main')
 
     await waitFor(() => expect(onBranchChanged).toHaveBeenCalledTimes(1))
-    expect(onBranchChanged).toHaveBeenCalledWith('w9', '/second-repo', 'main')
+    expect(onBranchChanged).toHaveBeenCalledWith(expect.objectContaining({ workerId: 'w9', gitToplevel: '/second-repo' }), 'main')
     expect(vi.mocked(workerRpc.deleteBranch).mock.calls[0][1]).toMatchObject({ path: '/second-repo' })
   })
 
@@ -276,8 +276,59 @@ describe('appShellDialogs branch dialogs', () => {
     fireEvent.click(await screen.findByTestId('change-branch-stub'))
 
     expect(onBranchChanged).toHaveBeenCalledTimes(1)
-    expect(onBranchChanged).toHaveBeenCalledWith('w2', '/other', 'main')
+    expect(onBranchChanged).toHaveBeenCalledWith(expect.objectContaining({ workerId: 'w2', gitToplevel: '/other' }), 'main')
     expect(dialogs.changeBranch.value()).toBeNull()
+  })
+
+  // Every payload slot renders under a keyed <Show>, so its callbacks hold
+  // the payload itself rather than an accessor the close disposes. These pin
+  // the two slots where a stale read would strand a promise forever: the
+  // workspace confirms resolve a `new Promise` that AppShell awaits with no
+  // timeout, and keyPinConfirm's resolve gates every later key-pin prompt
+  // through KeyPinStore's confirm chain. Both call resolve NEXT TO their
+  // close, so before keyed they were correct only by statement order.
+  it.each([
+    ['confirmDeleteWs', true],
+    ['confirmDeleteWs', false],
+    ['confirmArchiveWs', true],
+    ['confirmArchiveWs', false],
+  ] as const)('%s resolves its promise when the user answers %s', async (which, answer) => {
+    const { dialogs } = renderDialogs()
+    const resolve = vi.fn()
+    dialogs[which].open({ workspaceId: 'ws-1', resolve })
+
+    if (!answer) {
+      fireEvent.click(await screen.findByRole('button', { name: 'Cancel' }))
+    }
+    else if (which === 'confirmDeleteWs') {
+      // The delete confirm is `danger`, so ConfirmDialog wraps it in a
+      // ConfirmButton: it arms on the first click and fires on the second.
+      fireEvent.click(await screen.findByRole('button', { name: 'Delete' }))
+      fireEvent.click(await screen.findByRole('button', { name: 'Confirm?' }))
+    }
+    else {
+      fireEvent.click(await screen.findByRole('button', { name: 'Archive' }))
+    }
+
+    expect(resolve).toHaveBeenCalledTimes(1)
+    expect(resolve).toHaveBeenCalledWith(answer)
+    expect(dialogs[which].value()).toBeNull()
+  })
+
+  it('keyPinConfirm resolves its decision, so the confirm chain is not stranded', async () => {
+    const { dialogs } = renderDialogs()
+    const resolve = vi.fn()
+    dialogs.keyPinConfirm.open({
+      workerId: 'w1',
+      expectedFingerprint: 'aa:bb',
+      actualFingerprint: 'cc:dd',
+      resolve,
+    })
+
+    fireEvent.click(await screen.findByRole('button', { name: /Reject/i }))
+
+    expect(resolve).toHaveBeenCalledTimes(1)
+    expect(dialogs.keyPinConfirm.value()).toBeNull()
   })
 
   // The workspace guard on onAgentCreated / onTerminalCreated had no

--- a/frontend/src/components/shell/AppShellDialogs.test.tsx
+++ b/frontend/src/components/shell/AppShellDialogs.test.tsx
@@ -1,0 +1,317 @@
+/// <reference types="vitest/globals" />
+import type { ComponentProps } from 'solid-js'
+import type { AppShellDialogStates } from './AppShellDialogs'
+import type { useTabOperations } from './useTabOperations'
+import type { Tab } from '~/stores/tab.types'
+import { fireEvent, render, screen, waitFor } from '@solidjs/testing-library'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as workerRpc from '~/api/workerRpc'
+import { showWarnToast } from '~/components/common/Toast'
+import { TabType } from '~/generated/leapmux/v1/workspace_pb'
+import { createDialogState, createToggleDialog } from '~/hooks/createDialogState'
+import { makeInspectResp } from '~/test-support/gitBranchFixtures'
+import { AppShellDialogs } from './AppShellDialogs'
+
+// Replace the module wholesale, like the sibling DeleteBranchDialog suite.
+// A spread of the real module would pull the whole channel and Noise stack
+// plus five generated protobuf modules into this file's graph, for roughly
+// 250 ms of extra transform and import work per run. Vitest raises a
+// missing export on property ACCESS, not at link time, and no dialog in
+// this suite reaches another workerRpc call.
+vi.mock('~/api/workerRpc', () => ({
+  inspectBranchDeletion: vi.fn(),
+  deleteBranch: vi.fn(),
+  pushBranch: vi.fn(),
+}))
+
+vi.mock('~/components/common/Toast', () => ({
+  showInfoToast: vi.fn(),
+  showWarnToast: vi.fn(),
+  showErrorToast: vi.fn(),
+}))
+
+// This stub replaces the ChangeBranch slot, so a test can fire its callbacks
+// in the HOSTILE order (close, then notify). The stub does not drive that
+// dialog's git-mode UI. The point under test is the parent closure, not the
+// child dialog. The second button covers the workspace guard on
+// onTerminalCreated, which the real dialog reaches only after a worktree
+// create.
+vi.mock('~/components/workspace/ChangeBranchDialog', () => ({
+  ChangeBranchDialog: (props: {
+    onBranchChanged?: (branch: string) => void
+    onTerminalCreated?: (terminalId: string, workerId: string, workingDir: string, title: string) => void
+    onClose: () => void
+  }) => (
+    <>
+      <button
+        type="button"
+        data-testid="change-branch-stub"
+        onClick={() => {
+          props.onClose()
+          props.onBranchChanged?.('main')
+        }}
+      >
+        stub
+      </button>
+      <button
+        type="button"
+        data-testid="change-branch-terminal-stub"
+        onClick={() => props.onTerminalCreated?.('t1', 'w2', '/other', 'bash')}
+      >
+        terminal
+      </button>
+    </>
+  ),
+}))
+
+function makeTab(): Tab {
+  return {
+    type: TabType.AGENT,
+    id: 'a1',
+    title: 'a1',
+    tileId: 'tile-1',
+    position: '0',
+    workerId: 'w1',
+    workingDir: '/repo',
+    gitToplevel: '/repo',
+  } as Tab
+}
+
+function makeDialogs(): AppShellDialogStates {
+  return {
+    newAgent: createToggleDialog(),
+    newTerminal: createToggleDialog(),
+    newWorkspace: createDialogState(),
+    confirmDeleteWs: createDialogState(),
+    confirmArchiveWs: createDialogState(),
+    lastTabConfirm: createDialogState(),
+    keyPinConfirm: createDialogState(),
+    changeBranch: createDialogState(),
+    deleteBranch: createDialogState(),
+  }
+}
+
+function renderDialogs(activeWorkspace: () => { id: string } | null = () => null) {
+  const dialogs = makeDialogs()
+  const onBranchChanged = vi.fn()
+  const closeWorktreeTabs = vi.fn().mockResolvedValue({
+    removed: true,
+    failed: false,
+    stillReferenced: false,
+    unknown: false,
+  })
+  const focusedTileId = vi.fn(() => '')
+  // `satisfies` type-checks the fields this fixture DOES fill, so a rename
+  // of `closeWorktreeTabs` or a change to the TabContext shape fails to
+  // compile. The one widening cast stays at the render call, because each
+  // test makes only the branch dialogs' <Show> conditions truthy, so every
+  // other dialog's props stay unread. The alternative constructs eight
+  // operational stores (agentOps / termOps / view / metadata / …) that the
+  // closed dialogs never ask for.
+  const tabOps = { closeWorktreeTabs } satisfies Pick<ReturnType<typeof useTabOperations>, 'closeWorktreeTabs'>
+  const props = {
+    dialogs,
+    onBranchChanged,
+    tabOps: tabOps as unknown as ReturnType<typeof useTabOperations>,
+    activeWorkspace,
+    layoutStore: { focusedTileId } as unknown as ComponentProps<typeof AppShellDialogs>['layoutStore'],
+    getCurrentTabContext: () => ({
+      workerId: 'w1',
+      workingDir: '/repo',
+      homeDir: '/home/u',
+      gitToplevel: '/repo',
+    }),
+  } satisfies Partial<ComponentProps<typeof AppShellDialogs>>
+  render(() => <AppShellDialogs {...(props as unknown as ComponentProps<typeof AppShellDialogs>)} />)
+  return { dialogs, onBranchChanged, closeWorktreeTabs, focusedTileId }
+}
+
+async function chooseSwitchToAndConfirm(branch: string) {
+  await waitFor(() => expect(screen.getByText(/Switch this working directory to:/)).toBeInTheDocument())
+  const select = screen.getAllByRole('combobox')[0] as HTMLSelectElement
+  fireEvent.change(select, { target: { value: branch } })
+  // ConfirmButton arms on the first click and fires on the second.
+  fireEvent.click(screen.getByRole('button', { name: 'Delete branch' }))
+  await waitFor(() => expect(screen.getByRole('button', { name: 'Confirm?' })).toBeInTheDocument())
+  fireEvent.click(screen.getByRole('button', { name: 'Confirm?' }))
+}
+
+describe('appShellDialogs branch dialogs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(workerRpc.inspectBranchDeletion).mockResolvedValue(makeInspectResp())
+    vi.mocked(workerRpc.deleteBranch).mockResolvedValue({ $typeName: 'leapmux.v1.DeleteBranchResponse' })
+  })
+
+  // Regression: a delete of the checked-out branch left the deleted branch's
+  // label on the sidebar, next to a warn toast. Only a page reload repaired
+  // it. The dialog closed BEFORE it notified the parent. The parent's
+  // callback then read the <Show> children accessor that the close disposed.
+  // Solid throws "Stale read from <Show>" there, so the stamp and the
+  // git-status refresh never ran.
+  //
+  // Only a test that drives the dialog THROUGH AppShellDialogs reaches this
+  // bug. The dialog's own suite supplies a plain vi.fn(), so it reports
+  // success while the real composition stays broken.
+  it('delete branch: notifies the parent with the repo identity and shows no warning', async () => {
+    const { dialogs, onBranchChanged } = renderDialogs()
+    dialogs.deleteBranch.open({
+      workerId: 'w1',
+      gitToplevel: '/repo',
+      branchName: 'doomed',
+      tabs: [makeTab()],
+    })
+
+    await chooseSwitchToAndConfirm('main')
+
+    await waitFor(() => expect(onBranchChanged).toHaveBeenCalledTimes(1))
+    expect(onBranchChanged).toHaveBeenCalledWith('w1', '/repo', 'main')
+    expect(showWarnToast).not.toHaveBeenCalled()
+    // The dialog still closes: the notify must not prevent the close.
+    await waitFor(() => expect(dialogs.deleteBranch.value()).toBeNull())
+  })
+
+  it('delete branch: a reopen with a different repo uses the NEW identity', async () => {
+    // A keyed <Show> re-runs its children function on every payload identity
+    // change, so each open renders against its own payload. If it did not,
+    // the second dialog would notify the parent with the first repo's
+    // identity. It would also stamp the branch onto the wrong tabs. That is
+    // a worse bug than the one that this commit fixes.
+    const { dialogs, onBranchChanged } = renderDialogs()
+    dialogs.deleteBranch.open({
+      workerId: 'w1',
+      gitToplevel: '/repo',
+      branchName: 'doomed',
+      tabs: [makeTab()],
+    })
+    await waitFor(() => expect(screen.getByText(/Switch this working directory to:/)).toBeInTheDocument())
+    dialogs.deleteBranch.close()
+
+    dialogs.deleteBranch.open({
+      workerId: 'w9',
+      gitToplevel: '/second-repo',
+      branchName: 'doomed',
+      tabs: [makeTab()],
+    })
+    await chooseSwitchToAndConfirm('main')
+
+    await waitFor(() => expect(onBranchChanged).toHaveBeenCalledTimes(1))
+    expect(onBranchChanged).toHaveBeenCalledWith('w9', '/second-repo', 'main')
+  })
+
+  it('delete branch: a replacing open() re-points the dialog at the new repo', async () => {
+    // `createDialogState.open()` replaces a payload without a null step, and
+    // its own suite names this consumer. A keyed <Show> re-runs the children
+    // function on that identity change, so the second repo's dialog reports
+    // the second repo. A non-keyed <Show> would keep the first payload,
+    // because its condition memo collapses every truthy value to one.
+    const { dialogs, onBranchChanged } = renderDialogs()
+    dialogs.deleteBranch.open({
+      workerId: 'w1',
+      gitToplevel: '/repo',
+      branchName: 'doomed',
+      tabs: [makeTab()],
+    })
+    await waitFor(() => expect(screen.getByText(/Switch this working directory to:/)).toBeInTheDocument())
+
+    // No close in between.
+    dialogs.deleteBranch.open({
+      workerId: 'w9',
+      gitToplevel: '/second-repo',
+      branchName: 'doomed',
+      tabs: [makeTab()],
+    })
+    await chooseSwitchToAndConfirm('main')
+
+    await waitFor(() => expect(onBranchChanged).toHaveBeenCalledTimes(1))
+    expect(onBranchChanged).toHaveBeenCalledWith('w9', '/second-repo', 'main')
+    expect(vi.mocked(workerRpc.deleteBranch).mock.calls[0][1]).toMatchObject({ path: '/second-repo' })
+  })
+
+  it('delete branch: the worktree path forwards the payload\'s tab snapshot', async () => {
+    // The worktree path is the only consumer that reads `tabs` after an
+    // await. Pin that it still receives exactly the tabs that the sidebar
+    // opened the dialog with, by identity and not by value.
+    vi.mocked(workerRpc.inspectBranchDeletion).mockResolvedValue(
+      makeInspectResp({ isWorktree: true, worktreePath: '/wt' }),
+    )
+    const { dialogs, closeWorktreeTabs, onBranchChanged } = renderDialogs()
+    const tabs = [makeTab()]
+    dialogs.deleteBranch.open({
+      workerId: 'w1',
+      gitToplevel: '/repo',
+      branchName: 'doomed',
+      tabs,
+    })
+
+    await waitFor(() => expect(screen.getByText(/Worktree:/)).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'Delete branch' }))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Confirm?' })).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm?' }))
+
+    await waitFor(() => expect(closeWorktreeTabs).toHaveBeenCalledWith(tabs))
+    expect(closeWorktreeTabs.mock.calls[0][0]).toBe(tabs)
+    // The worktree path removes the tabs outright. There is no branch to
+    // stamp, so the dialog must not tell the parent that a branch changed.
+    await waitFor(() => expect(dialogs.deleteBranch.value()).toBeNull())
+    expect(onBranchChanged).not.toHaveBeenCalled()
+  })
+
+  it('delete branch: the parent callback survives a notify that arrives after the close', async () => {
+    // Independent of the dialog's call order. A keyed <Show> hands the
+    // children function the payload itself, so no callback holds an accessor
+    // that the close can dispose. Even a child that closes first and
+    // notifies afterwards must therefore reach the parent. This is the half
+    // of the fix that makes the class of bug impossible rather than merely
+    // absent today.
+    const { dialogs, onBranchChanged } = renderDialogs()
+    dialogs.changeBranch.open({
+      workerId: 'w2',
+      gitToplevel: '/other',
+      workspaceId: 'ws1',
+      branchName: 'feature',
+      isWorktree: false,
+    })
+
+    fireEvent.click(await screen.findByTestId('change-branch-stub'))
+
+    expect(onBranchChanged).toHaveBeenCalledTimes(1)
+    expect(onBranchChanged).toHaveBeenCalledWith('w2', '/other', 'main')
+    expect(dialogs.changeBranch.value()).toBeNull()
+  })
+
+  // The workspace guard on onAgentCreated / onTerminalCreated had no
+  // coverage: every test left `activeWorkspace` null, so the true branch was
+  // unreachable and an inverted comparison would have stayed green. A tab
+  // may only join the focused tile when the dialog's own workspace IS the
+  // active one; otherwise it lands in the wrong workspace's tree.
+  it('change branch: inserts a created tab only when the dialog targets the active workspace', async () => {
+    const { dialogs, focusedTileId } = renderDialogs(() => ({ id: 'ws1' }))
+    dialogs.changeBranch.open({
+      workerId: 'w2',
+      gitToplevel: '/other',
+      workspaceId: 'ws1',
+      branchName: 'feature',
+      isWorktree: false,
+    })
+
+    fireEvent.click(await screen.findByTestId('change-branch-terminal-stub'))
+
+    expect(focusedTileId).toHaveBeenCalled()
+  })
+
+  it('change branch: skips the tab insertion when the dialog targets another workspace', async () => {
+    const { dialogs, focusedTileId } = renderDialogs(() => ({ id: 'another-ws' }))
+    dialogs.changeBranch.open({
+      workerId: 'w2',
+      gitToplevel: '/other',
+      workspaceId: 'ws1',
+      branchName: 'feature',
+      isWorktree: false,
+    })
+
+    fireEvent.click(await screen.findByTestId('change-branch-terminal-stub'))
+
+    expect(focusedTileId).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/shell/AppShellDialogs.tsx
+++ b/frontend/src/components/shell/AppShellDialogs.tsx
@@ -5,28 +5,28 @@ import type { useAgentOperations } from './useAgentOperations'
 import type { useTabOperations } from './useTabOperations'
 import type { useTerminalOperations } from './useTerminalOperations'
 import type { AgentInfo, AgentProvider } from '~/generated/leapmux/v1/agent_pb'
-import type { DialogState, ToggleDialogState } from '~/hooks/createDialogState'
+import type { DialogState, ToggleDialogState, UpdatableDialogState } from '~/hooks/createDialogState'
 import type { KeyPinDecision } from '~/lib/keyPinStore'
 import type { createLayoutStore } from '~/stores/layout.store'
 import type { createSectionStore } from '~/stores/section.store'
+import type { RepoRef } from '~/stores/tab.helpers'
 import type { Tab } from '~/stores/tab.types'
 import type { TabMetadataStore } from '~/stores/tabMetadata.store'
 import type { TabSelectionStore } from '~/stores/tabSelection.store'
 import type { TabView } from '~/stores/tabView'
 import { Show } from 'solid-js'
-import { sectionClient } from '~/api/clients'
 import { ConfirmDialog } from '~/components/common/ConfirmDialog'
 import { KeyPinMismatchDialog } from '~/components/common/KeyPinMismatchDialog'
 import { ChangeBranchDialog } from '~/components/workspace/ChangeBranchDialog'
 import { DeleteBranchDialog } from '~/components/workspace/DeleteBranchDialog'
 import { NewWorkspaceDialog } from '~/components/workspace/NewWorkspaceDialog'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
-import { mid } from '~/lib/lexorank'
 import { openedTerminalMetadata, protoToAgentTabFields } from '~/stores/tab.helpers'
 import { LastTabCloseDialog } from './LastTabCloseDialog'
 import { NewAgentDialog } from './NewAgentDialog'
 import { NewTerminalDialog } from './NewTerminalDialog'
 import { openTabInFocusedTile } from './openTabInFocusedTile'
+import { placeWorkspaceInSection } from './placeWorkspaceInSection'
 
 export interface KeyPinConfirmState {
   workerId: string
@@ -35,14 +35,7 @@ export interface KeyPinConfirmState {
   resolve: (decision: KeyPinDecision) => void
 }
 
-export interface ChangeBranchState {
-  workerId: string
-  /**
-   * `git rev-parse --show-toplevel` of the branch group's working dir.
-   * For a main repo this is the repo root; for a linked worktree it's
-   * the worktree root. Matches `Tab.gitToplevel`.
-   */
-  gitToplevel: string
+export interface ChangeBranchState extends RepoRef {
   workspaceId: string
   /**
    * Current branch label on the row that opened the dialog. Threaded so
@@ -63,10 +56,7 @@ export interface ChangeBranchState {
   isWorktree: boolean
 }
 
-export interface DeleteBranchState {
-  workerId: string
-  /** See ChangeBranchState.gitToplevel. */
-  gitToplevel: string
+export interface DeleteBranchState extends RepoRef {
   /**
    * Current branch label, threaded so the dialog can seed its path-info
    * snapshot and skip the mount-time getGitInfo probe. `null` when the
@@ -106,7 +96,9 @@ export interface AppShellDialogStates {
   newWorkspace: DialogState<NewWorkspacePayload>
   confirmDeleteWs: DialogState<WorkspaceConfirmPayload>
   confirmArchiveWs: DialogState<WorkspaceConfirmPayload>
-  lastTabConfirm: DialogState<LastTabConfirmState>
+  // The only updatable one: LastTabCloseDialog patches its own payload after
+  // a status refresh. That capability is what keeps its <Show> non-keyed.
+  lastTabConfirm: UpdatableDialogState<LastTabConfirmState>
   keyPinConfirm: DialogState<KeyPinConfirmState>
   changeBranch: DialogState<ChangeBranchState>
   deleteBranch: DialogState<DeleteBranchState>
@@ -121,7 +113,7 @@ interface AppShellDialogsProps {
    * label and, if that repo is the active tab's repo, refreshes the
    * gitFileStatusStore so diff stats track the new HEAD.
    */
-  onBranchChanged?: (workerId: string, gitToplevel: string, newBranch: string) => void
+  onBranchChanged?: (repo: RepoRef, newBranch: string) => void
   activeWorkspace: () => { id: string } | null
   getCurrentTabContext: () => TabContext
   agentOps: ReturnType<typeof useAgentOperations>
@@ -192,37 +184,36 @@ export const AppShellDialogs: Component<AppShellDialogsProps> = (props) => {
         />
       </Show>
 
-      <Show when={props.dialogs.newWorkspace.value()}>
+      {/* Every payload dialog below renders under a KEYED <Show>, and that is
+          load-bearing rather than stylistic. A non-keyed <Show> hands the
+          children function an accessor that throws "Stale read from <Show>"
+          on any read after the condition goes falsy — which every `close`
+          below does. Each of these dialogs reads its payload from inside a
+          callback that fires next to that close, so the accessor form leaves
+          them correct only by statement order. `keyed` hands over the payload
+          itself, so there is nothing left to go stale. It also re-runs the
+          children on a payload identity change, so a replacing `open()`
+          re-points the dialog instead of freezing on the first payload.
+
+          `lastTabConfirm` is the ONE exception and stays non-keyed: it is the
+          only dialog whose payload is patched in place, and `keyed` would
+          remount its native <dialog> on every refresh. The type system
+          enforces that split — `update` lives on UpdatableDialogState, which
+          only that dialog is declared with. */}
+      <Show when={props.dialogs.newWorkspace.value()} keyed>
         {payload => (
           <NewWorkspaceDialog
             metadata={props.metadata}
-            preselectedWorkerId={payload().preselectedWorkerId}
+            preselectedWorkerId={payload.preselectedWorkerId}
             availableProviders={props.availableProviders}
             onRefreshProviders={props.onRefreshProviders}
             onCreated={(workspaceId) => {
-              const targetSectionId = payload().targetSectionId ?? null
               props.dialogs.newWorkspace.close()
-              const refreshWorkspaces = props.loadWorkspaces
-              if (targetSectionId) {
-                // Append past the section's existing items so the new
-                // workspace gets a unique lexorank rather than colliding
-                // with whichever item already sits at lexorank.first()
-                // ("n"). A hardcoded 'N' position would land every new
-                // workspace at the same rank, and the SQL planner would
-                // then shuffle the tied rows on every page refresh.
-                const lastItem = props.sectionStore.getItemsForSection(targetSectionId).at(-1)
-                const position = lastItem ? mid(lastItem.position, '') : mid('', '')
-                sectionClient.moveWorkspace({
-                  workspaceId,
-                  sectionId: targetSectionId,
-                  position,
-                }).catch(() => {}).finally(() => {
-                  refreshWorkspaces()
-                })
-              }
-              else {
-                refreshWorkspaces()
-              }
+              placeWorkspaceInSection(
+                { sectionStore: props.sectionStore, loadWorkspaces: props.loadWorkspaces },
+                workspaceId,
+                payload.targetSectionId ?? null,
+              )
               props.onSelectWorkspace(workspaceId)
             }}
             onClose={() => props.dialogs.newWorkspace.close()}
@@ -230,18 +221,18 @@ export const AppShellDialogs: Component<AppShellDialogsProps> = (props) => {
         )}
       </Show>
 
-      <Show when={props.dialogs.confirmDeleteWs.value()}>
+      <Show when={props.dialogs.confirmDeleteWs.value()} keyed>
         {state => (
           <ConfirmDialog
             title="Delete workspace"
             confirmLabel="Delete"
             danger
             onConfirm={() => {
-              state().resolve(true)
+              state.resolve(true)
               props.dialogs.confirmDeleteWs.close()
             }}
             onCancel={() => {
-              state().resolve(false)
+              state.resolve(false)
               props.dialogs.confirmDeleteWs.close()
             }}
           >
@@ -250,17 +241,17 @@ export const AppShellDialogs: Component<AppShellDialogsProps> = (props) => {
         )}
       </Show>
 
-      <Show when={props.dialogs.confirmArchiveWs.value()}>
+      <Show when={props.dialogs.confirmArchiveWs.value()} keyed>
         {state => (
           <ConfirmDialog
             title="Archive workspace"
             confirmLabel="Archive"
             onConfirm={() => {
-              state().resolve(true)
+              state.resolve(true)
               props.dialogs.confirmArchiveWs.close()
             }}
             onCancel={() => {
-              state().resolve(false)
+              state.resolve(false)
               props.dialogs.confirmArchiveWs.close()
             }}
           >
@@ -269,6 +260,9 @@ export const AppShellDialogs: Component<AppShellDialogsProps> = (props) => {
         )}
       </Show>
 
+      {/* NOT keyed — see the block comment above. This is the only dialog
+          that patches its payload in place, and keyed would remount it on
+          every in-place refresh. */}
       <Show when={props.dialogs.lastTabConfirm.value()}>
         {confirm => (
           <LastTabCloseDialog
@@ -279,33 +273,20 @@ export const AppShellDialogs: Component<AppShellDialogsProps> = (props) => {
         )}
       </Show>
 
-      <Show when={props.dialogs.keyPinConfirm.value()}>
+      <Show when={props.dialogs.keyPinConfirm.value()} keyed>
         {state => (
           <KeyPinMismatchDialog
-            workerId={state().workerId}
-            expectedFingerprint={state().expectedFingerprint}
-            actualFingerprint={state().actualFingerprint}
+            workerId={state.workerId}
+            expectedFingerprint={state.expectedFingerprint}
+            actualFingerprint={state.actualFingerprint}
             resolve={(decision) => {
-              state().resolve(decision)
+              state.resolve(decision)
               props.dialogs.keyPinConfirm.close()
             }}
           />
         )}
       </Show>
 
-      {/* `keyed` hands the children function the payload itself, not an
-          accessor. A non-keyed <Show> hands over an accessor that throws
-          "Stale read from <Show>" on every read after the condition goes
-          falsy — which `onClose` does. A callback that fires in the same
-          turn as the close, or after it, would then throw and not run. The
-          throw silently drops the sidebar refresh that the callback exists
-          to trigger. With `keyed` no accessor exists, so no callback can
-          read disposed state. `keyed` also re-runs the children function on
-          every payload identity change, so a replacing `open()` re-points
-          the dialog at the new repo. `lastTabConfirm` above stays non-keyed
-          because it is the only dialog that calls createDialogState's
-          `update`, and `keyed` would remount its native <dialog> on every
-          in-place refresh. */}
       <Show when={props.dialogs.changeBranch.value()} keyed>
         {state => (
           <ChangeBranchDialog
@@ -316,7 +297,7 @@ export const AppShellDialogs: Component<AppShellDialogsProps> = (props) => {
             isWorktree={state.isWorktree}
             availableProviders={props.availableProviders}
             onRefreshProviders={props.onRefreshProviders}
-            onBranchChanged={newBranch => props.onBranchChanged?.(state.workerId, state.gitToplevel, newBranch)}
+            onBranchChanged={newBranch => props.onBranchChanged?.(state, newBranch)}
             // Local-UI tab insertion only applies when the dialog's
             // target workspace IS the active one — addAgentTabToFocusedTile
             // and addTerminalTabToFocusedTile place the tab on the ACTIVE
@@ -340,7 +321,6 @@ export const AppShellDialogs: Component<AppShellDialogsProps> = (props) => {
         )}
       </Show>
 
-      {/* `keyed` for the same reason as the ChangeBranch dialog above. */}
       <Show when={props.dialogs.deleteBranch.value()} keyed>
         {state => (
           <DeleteBranchDialog
@@ -349,7 +329,7 @@ export const AppShellDialogs: Component<AppShellDialogsProps> = (props) => {
             branchName={state.branchName}
             tabs={state.tabs}
             closeWorktreeTabs={props.tabOps.closeWorktreeTabs}
-            onBranchChanged={newBranch => props.onBranchChanged?.(state.workerId, state.gitToplevel, newBranch)}
+            onBranchChanged={newBranch => props.onBranchChanged?.(state, newBranch)}
             onClose={() => props.dialogs.deleteBranch.close()}
           />
         )}

--- a/frontend/src/components/shell/AppShellDialogs.tsx
+++ b/frontend/src/components/shell/AppShellDialogs.tsx
@@ -293,17 +293,30 @@ export const AppShellDialogs: Component<AppShellDialogsProps> = (props) => {
         )}
       </Show>
 
-      <Show when={props.dialogs.changeBranch.value()}>
+      {/* `keyed` hands the children function the payload itself, not an
+          accessor. A non-keyed <Show> hands over an accessor that throws
+          "Stale read from <Show>" on every read after the condition goes
+          falsy — which `onClose` does. A callback that fires in the same
+          turn as the close, or after it, would then throw and not run. The
+          throw silently drops the sidebar refresh that the callback exists
+          to trigger. With `keyed` no accessor exists, so no callback can
+          read disposed state. `keyed` also re-runs the children function on
+          every payload identity change, so a replacing `open()` re-points
+          the dialog at the new repo. `lastTabConfirm` above stays non-keyed
+          because it is the only dialog that calls createDialogState's
+          `update`, and `keyed` would remount its native <dialog> on every
+          in-place refresh. */}
+      <Show when={props.dialogs.changeBranch.value()} keyed>
         {state => (
           <ChangeBranchDialog
-            workerId={state().workerId}
-            gitToplevel={state().gitToplevel}
-            workspaceId={state().workspaceId}
-            branchName={state().branchName}
-            isWorktree={state().isWorktree}
+            workerId={state.workerId}
+            gitToplevel={state.gitToplevel}
+            workspaceId={state.workspaceId}
+            branchName={state.branchName}
+            isWorktree={state.isWorktree}
             availableProviders={props.availableProviders}
             onRefreshProviders={props.onRefreshProviders}
-            onBranchChanged={newBranch => props.onBranchChanged?.(state().workerId, state().gitToplevel, newBranch)}
+            onBranchChanged={newBranch => props.onBranchChanged?.(state.workerId, state.gitToplevel, newBranch)}
             // Local-UI tab insertion only applies when the dialog's
             // target workspace IS the active one — addAgentTabToFocusedTile
             // and addTerminalTabToFocusedTile place the tab on the ACTIVE
@@ -315,11 +328,11 @@ export const AppShellDialogs: Component<AppShellDialogsProps> = (props) => {
             // immediate local UI write is needed (and the user isn't
             // looking at that workspace's tile to feel the latency).
             onAgentCreated={(agent) => {
-              if (state().workspaceId === props.activeWorkspace()?.id)
+              if (state.workspaceId === props.activeWorkspace()?.id)
                 addAgentTabToFocusedTile(agent)
             }}
             onTerminalCreated={(terminalId, workerId, workingDir, title) => {
-              if (state().workspaceId === props.activeWorkspace()?.id)
+              if (state.workspaceId === props.activeWorkspace()?.id)
                 addTerminalTabToFocusedTile(terminalId, workerId, workingDir, title)
             }}
             onClose={() => props.dialogs.changeBranch.close()}
@@ -327,15 +340,16 @@ export const AppShellDialogs: Component<AppShellDialogsProps> = (props) => {
         )}
       </Show>
 
-      <Show when={props.dialogs.deleteBranch.value()}>
+      {/* `keyed` for the same reason as the ChangeBranch dialog above. */}
+      <Show when={props.dialogs.deleteBranch.value()} keyed>
         {state => (
           <DeleteBranchDialog
-            workerId={state().workerId}
-            gitToplevel={state().gitToplevel}
-            branchName={state().branchName}
-            tabs={state().tabs}
+            workerId={state.workerId}
+            gitToplevel={state.gitToplevel}
+            branchName={state.branchName}
+            tabs={state.tabs}
             closeWorktreeTabs={props.tabOps.closeWorktreeTabs}
-            onBranchChanged={newBranch => props.onBranchChanged?.(state().workerId, state().gitToplevel, newBranch)}
+            onBranchChanged={newBranch => props.onBranchChanged?.(state.workerId, state.gitToplevel, newBranch)}
             onClose={() => props.dialogs.deleteBranch.close()}
           />
         )}

--- a/frontend/src/components/shell/handleBranchChanged.test.ts
+++ b/frontend/src/components/shell/handleBranchChanged.test.ts
@@ -70,8 +70,7 @@ describe('handleBranchChanged', () => {
 
     handleBranchChanged(
       { target, gitFileStatusStore: fakeGitStore({}), getCurrentTabContext: () => ({} as never) },
-      'w1',
-      '/repo',
+      { workerId: 'w1', gitToplevel: '/repo' },
       'feature',
     )
 
@@ -94,8 +93,7 @@ describe('handleBranchChanged', () => {
 
     handleBranchChanged(
       { target, gitFileStatusStore: store, getCurrentTabContext: () => ({ workerId: 'w1', gitToplevel: '/repo' } as never) },
-      'w1',
-      '/repo',
+      { workerId: 'w1', gitToplevel: '/repo' },
       'feature',
     )
     await flush()
@@ -128,8 +126,7 @@ describe('handleBranchChanged', () => {
 
     expect(() => handleBranchChanged(
       { target, gitFileStatusStore: store, getCurrentTabContext: () => ({ workerId: 'w1', gitToplevel: '/repo' } as never) },
-      'w1',
-      '/repo',
+      { workerId: 'w1', gitToplevel: '/repo' },
       'feature',
     )).not.toThrow()
     await flush()
@@ -145,8 +142,7 @@ describe('handleBranchChanged', () => {
     handleBranchChanged(
       // The user is looking at a DIFFERENT repo.
       { target, gitFileStatusStore: store, getCurrentTabContext: () => ({ workerId: 'w1', gitToplevel: '/elsewhere' } as never) },
-      'w1',
-      '/repo',
+      { workerId: 'w1', gitToplevel: '/repo' },
       'feature',
     )
     await flush()
@@ -164,8 +160,7 @@ describe('handleBranchChanged', () => {
 
     handleBranchChanged(
       { target, gitFileStatusStore: fakeGitStore({}), getCurrentTabContext: () => ({} as never) },
-      'w1',
-      '',
+      { workerId: 'w1', gitToplevel: '' },
       'feature',
     )
     await flush()
@@ -179,8 +174,7 @@ describe('handleBranchChanged', () => {
 
     expect(() => handleBranchChanged(
       { target, gitFileStatusStore: fakeGitStore({}), getCurrentTabContext: () => ({} as never) },
-      'w1',
-      '/repo',
+      { workerId: 'w1', gitToplevel: '/repo' },
       'feature',
     )).not.toThrow()
     await flush()

--- a/frontend/src/components/shell/handleBranchChanged.ts
+++ b/frontend/src/components/shell/handleBranchChanged.ts
@@ -1,6 +1,7 @@
 import type { TabStampTarget } from './syncGitStatusToTabs'
 import type { TabContext } from './tabContext'
 import type { createGitFileStatusStore } from '~/stores/gitFileStatus.store'
+import type { RepoRef } from '~/stores/tab.helpers'
 import { getGitFileStatus } from '~/api/workerRpc'
 import { createLogger } from '~/lib/logger'
 import { isSameRepo } from '~/stores/tab.helpers'
@@ -46,14 +47,13 @@ export interface BranchChangedDeps {
 
 export function handleBranchChanged(
   deps: BranchChangedDeps,
-  workerId: string,
-  gitToplevel: string,
+  repo: RepoRef,
   newBranch: string,
 ): void {
-  stampBranchOnTabs(deps.target, workerId, gitToplevel, newBranch)
+  stampBranchOnTabs(deps.target, repo, newBranch)
 
-  if (isSameRepo(deps.getCurrentTabContext(), workerId, gitToplevel)) {
-    void deps.gitFileStatusStore.refresh(workerId, gitToplevel)
+  if (isSameRepo(deps.getCurrentTabContext(), repo)) {
+    void deps.gitFileStatusStore.refresh(repo.workerId, repo.gitToplevel)
       .then(() => {
         // Reuse the singleton's freshly-refreshed state rather than firing a
         // second getGitFileStatus.
@@ -70,14 +70,14 @@ export function handleBranchChanged(
     return
   }
 
-  void getGitFileStatus(workerId, { workerId, path: gitToplevel })
+  void getGitFileStatus(repo.workerId, { workerId: repo.workerId, path: repo.gitToplevel })
     .then((resp) => {
       // `toplevel` is authoritative: the worker sets it on every success path
       // (`git.go` queryGitPathInfo), and a non-repo path returns it empty
       // alongside an empty repo_root. An empty value therefore means "no
       // working tree", which `applyGitStatusToTabs` correctly declines to stamp.
       applyGitStatusToTabs(deps.target, {
-        workerId,
+        workerId: repo.workerId,
         toplevel: resp.toplevel,
         originUrl: resp.originUrl,
         currentBranch: resp.currentBranch,

--- a/frontend/src/components/shell/placeWorkspaceInSection.test.ts
+++ b/frontend/src/components/shell/placeWorkspaceInSection.test.ts
@@ -1,0 +1,94 @@
+/// <reference types="vitest/globals" />
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { sectionClient } from '~/api/clients'
+import { showWarnToast } from '~/components/common/Toast'
+import { placeWorkspaceInSection } from './placeWorkspaceInSection'
+
+vi.mock('~/api/clients', () => ({
+  sectionClient: { moveWorkspace: vi.fn() },
+}))
+
+vi.mock('~/components/common/Toast', () => ({
+  showInfoToast: vi.fn(),
+  showWarnToast: vi.fn(),
+  showErrorToast: vi.fn(),
+}))
+
+function makeDeps(items: { position: string }[] = []) {
+  return {
+    sectionStore: { getItemsForSection: vi.fn(() => items) },
+    loadWorkspaces: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+/** Lets a test resolve or reject the in-flight move RPC by hand. */
+function deferredMove() {
+  let settle!: (err?: Error) => void
+  vi.mocked(sectionClient.moveWorkspace).mockReturnValue(
+    new Promise((resolve, reject) => {
+      settle = err => (err ? reject(err) : resolve({} as never))
+    }) as never,
+  )
+  return () => settle
+}
+
+describe('placeWorkspaceInSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(sectionClient.moveWorkspace).mockResolvedValue({} as never)
+  })
+
+  it('refreshes without an RPC when there is no target section', async () => {
+    // The shortcut path: no section was preselected, so the workspace stays
+    // where CreateWorkspace put it and there is nothing to move.
+    const deps = makeDeps()
+    placeWorkspaceInSection(deps, 'ws-1', null)
+
+    expect(sectionClient.moveWorkspace).not.toHaveBeenCalled()
+    expect(deps.loadWorkspaces).toHaveBeenCalledTimes(1)
+  })
+
+  it('appends past the section\'s last item so the rank cannot collide', async () => {
+    const deps = makeDeps([{ position: 'n' }, { position: 'u' }])
+    placeWorkspaceInSection(deps, 'ws-1', 'sec-1')
+
+    await vi.waitFor(() => expect(deps.loadWorkspaces).toHaveBeenCalled())
+    const arg = vi.mocked(sectionClient.moveWorkspace).mock.calls[0][0]
+    expect(arg).toMatchObject({ workspaceId: 'ws-1', sectionId: 'sec-1' })
+    expect((arg.position ?? '') > 'u', 'the new rank must sort after the last item').toBe(true)
+  })
+
+  it('gives an empty section a valid rank rather than an empty string', async () => {
+    const deps = makeDeps([])
+    placeWorkspaceInSection(deps, 'ws-1', 'sec-1')
+
+    await vi.waitFor(() => expect(deps.loadWorkspaces).toHaveBeenCalled())
+    expect(vi.mocked(sectionClient.moveWorkspace).mock.calls[0][0].position).not.toBe('')
+  })
+
+  it('warns when the move fails, and still refreshes', async () => {
+    // Regression: this call used to swallow its rejection with
+    // `.catch(() => {})`, so a workspace could land in the default section
+    // instead of the one the user clicked "+" in, with nothing on screen to
+    // say so. Its two sibling copies in useWorkspaceOperations both warn.
+    const settle = deferredMove()
+    const deps = makeDeps([])
+    placeWorkspaceInSection(deps, 'ws-1', 'sec-1')
+    settle()(new Error('move failed'))
+
+    await vi.waitFor(() => expect(showWarnToast).toHaveBeenCalledTimes(1))
+    expect(showWarnToast).toHaveBeenCalledWith(
+      'Failed to move the workspace into its section',
+      expect.any(Error),
+    )
+    expect(deps.loadWorkspaces).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not warn when the move succeeds', async () => {
+    const deps = makeDeps([])
+    placeWorkspaceInSection(deps, 'ws-1', 'sec-1')
+
+    await vi.waitFor(() => expect(deps.loadWorkspaces).toHaveBeenCalled())
+    expect(showWarnToast).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/shell/placeWorkspaceInSection.ts
+++ b/frontend/src/components/shell/placeWorkspaceInSection.ts
@@ -1,0 +1,59 @@
+import { sectionClient } from '~/api/clients'
+import { showWarnToast } from '~/components/common/Toast'
+import { appendPosition } from '~/lib/lexorank'
+
+/**
+ * What has to happen after CreateWorkspace when the user opened the dialog
+ * from a specific section's "+" button: move the fresh workspace into that
+ * section, then refresh the workspace list.
+ *
+ * `targetSectionId` null means the shortcut path (no preselection), which
+ * only refreshes — there is no section to move into, and the workspace
+ * already lives in the default one.
+ *
+ * A failed move warn-toasts rather than passing silently. The two sibling
+ * copies of this same RPC in `useWorkspaceOperations` ("Failed to move
+ * workspace", "Failed to reorder workspace") already did; this one swallowed
+ * its rejection, so a workspace could land in the default section instead of
+ * the section the user clicked, with nothing on screen to say so.
+ *
+ * The refresh runs on both paths. The move is fire-and-forget by design: the
+ * caller navigates to the new workspace immediately, and the section
+ * placement converges on the refresh rather than blocking that navigation.
+ *
+ * Extracted from a closure inline in an `AppShellDialogs` JSX prop, where it
+ * combined lexorank math, an RPC, a refresh and navigation in one 25-line
+ * block reachable only by rendering the dialog. `handleBranchChanged` is the
+ * same seam, taken from the same position for the same reason.
+ */
+export interface PlaceWorkspaceDeps {
+  /**
+   * Narrowed to the one field `appendPosition` reads, rather than the whole
+   * `SectionItem`. The real store satisfies it structurally, and a test can
+   * supply a two-field fixture instead of a full section item.
+   */
+  sectionStore: { getItemsForSection: (sectionId: string) => readonly { position: string }[] }
+  loadWorkspaces: () => Promise<void>
+}
+
+export function placeWorkspaceInSection(
+  deps: PlaceWorkspaceDeps,
+  workspaceId: string,
+  targetSectionId: string | null,
+): void {
+  if (!targetSectionId) {
+    void deps.loadWorkspaces()
+    return
+  }
+  // Append past the section's existing items so the new workspace gets a
+  // unique lexorank rather than colliding with whichever item already sits
+  // at the head.
+  const position = appendPosition(deps.sectionStore.getItemsForSection(targetSectionId))
+  sectionClient.moveWorkspace({ workspaceId, sectionId: targetSectionId, position })
+    .catch((err) => {
+      showWarnToast('Failed to move the workspace into its section', err)
+    })
+    .finally(() => {
+      void deps.loadWorkspaces()
+    })
+}

--- a/frontend/src/components/shell/stampBranchOnTabs.ts
+++ b/frontend/src/components/shell/stampBranchOnTabs.ts
@@ -1,4 +1,5 @@
 import type { TabStampTarget } from './syncGitStatusToTabs'
+import type { RepoRef } from '~/stores/tab.helpers'
 import { isSameRepo } from '~/stores/tab.helpers'
 
 /**
@@ -25,14 +26,13 @@ import { isSameRepo } from '~/stores/tab.helpers'
  */
 export function stampBranchOnTabs(
   target: TabStampTarget,
-  workerId: string,
-  repoToplevel: string,
+  repo: RepoRef,
   newBranch: string,
 ): boolean {
-  if (!workerId)
+  if (!repo.workerId)
     return false
   const matches = target.tabs.filter(
-    t => isSameRepo(t, workerId, repoToplevel) && t.gitBranch !== newBranch,
+    t => isSameRepo(t, repo) && t.gitBranch !== newBranch,
   )
   if (matches.length === 0)
     return false

--- a/frontend/src/components/shell/useTabOperations.ts
+++ b/frontend/src/components/shell/useTabOperations.ts
@@ -21,7 +21,7 @@ import { awaitCloseResult, warnWorktreeUnreachable } from '~/components/shell/cl
 import { getTerminalInstance } from '~/components/terminal/TerminalView'
 import { WorktreeAction, WorktreeRemovalOutcome } from '~/generated/leapmux/v1/common_pb'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
-import { createDialogState } from '~/hooks/createDialogState'
+import { createUpdatableDialogState } from '~/hooks/createDialogState'
 import { makeIdGenerator } from '~/lib/idGenerator'
 import { basename } from '~/lib/paths'
 import { MAX_BACKGROUND_CHAT_MESSAGES } from '~/stores/chat.store'
@@ -91,7 +91,7 @@ export function useTabOperations(opts: UseTabOperationsOpts) {
 
   const [closingTabKeys, setClosingTabKeys] = createSignal<Set<string>>(new Set())
 
-  const lastTabConfirmDialog = createDialogState<LastTabConfirmState>()
+  const lastTabConfirmDialog = createUpdatableDialogState<LastTabConfirmState>()
 
   let isTabEditing: () => boolean = () => false
 

--- a/frontend/src/components/shell/useWorkspaceOperations.ts
+++ b/frontend/src/components/shell/useWorkspaceOperations.ts
@@ -7,7 +7,7 @@ import { sectionClient, workspaceClient } from '~/api/clients'
 import * as workerRpc from '~/api/workerRpc'
 import { showWarnToast } from '~/components/common/Toast'
 import { SectionType } from '~/generated/leapmux/v1/section_pb'
-import { mid } from '~/lib/lexorank'
+import { appendPosition, mid } from '~/lib/lexorank'
 import { isWorkspaceSection } from './sectionUtils'
 
 export interface SectionGroup {
@@ -183,8 +183,7 @@ export function useWorkspaceOperations(props: UseWorkspaceOperationsProps) {
 
   const moveWorkspace = async (workspaceId: string, sectionId: string) => {
     const sectionItems = store.getItemsForSection(sectionId)
-    const lastItem = sectionItems.at(-1)
-    const position = lastItem ? mid(lastItem.position, '') : mid('', '')
+    const position = appendPosition(sectionItems)
     const done = startWorkspaceLoading(workspaceId)
     try {
       await sectionClient.moveWorkspace({ workspaceId, sectionId, position })
@@ -308,8 +307,7 @@ export function useWorkspaceOperations(props: UseWorkspaceOperationsProps) {
       .filter(i => i.workspaceId !== wsId)
     const targetIdx = items.findIndex(i => i.workspaceId === targetWsId)
     if (targetIdx < 0) {
-      const lastItem = items.at(-1)
-      return lastItem ? mid(lastItem.position, '') : mid('', '')
+      return appendPosition(items)
     }
     if (direction === 'after') {
       const prevPos = items[targetIdx].position
@@ -357,8 +355,7 @@ export function useWorkspaceOperations(props: UseWorkspaceOperationsProps) {
       if (fromSectionId === targetSectionId)
         return
       const items = store.getItemsForSection(targetSectionId)
-      const lastItem = items.at(-1)
-      position = lastItem ? mid(lastItem.position, '') : mid('', '')
+      position = appendPosition(items)
     }
     else {
       return

--- a/frontend/src/components/workspace/DeleteBranchDialog.test.tsx
+++ b/frontend/src/components/workspace/DeleteBranchDialog.test.tsx
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as workerRpc from '~/api/workerRpc'
 import { showInfoToast, showWarnToast } from '~/components/common/Toast'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
+import { makeInspectResp } from '~/test-support/gitBranchFixtures'
 import { DeleteBranchDialog, worktreeRemovalToast } from './DeleteBranchDialog'
 
 vi.mock('~/api/workerRpc', () => ({
@@ -19,72 +20,6 @@ vi.mock('~/components/common/Toast', () => ({
   showWarnToast: vi.fn(),
   showErrorToast: vi.fn(),
 }))
-
-function makeBranches(names: string[]): GitBranchEntry[] {
-  return names.map(name => ({
-    $typeName: 'leapmux.v1.GitBranchEntry',
-    name,
-    isRemote: false,
-  } as GitBranchEntry))
-}
-
-function makeInspectResp(overrides: Partial<InspectBranchDeletionResponse> & Partial<{
-  diffAdded: number
-  diffDeleted: number
-  diffUntracked: number
-  unpushedCommitCount: number
-  hasUncommittedChanges: boolean
-  upstreamExists: boolean
-  remoteBranchMissing: boolean
-  originExists: boolean
-  canPush: boolean
-  /** Convenience: pass branch names; converted to GitBranchEntry rows. */
-  branchNames: string[]
-}> = {}): InspectBranchDeletionResponse {
-  const {
-    diffAdded = 0,
-    diffDeleted = 0,
-    diffUntracked = 0,
-    unpushedCommitCount = 0,
-    hasUncommittedChanges = false,
-    upstreamExists = true,
-    remoteBranchMissing = false,
-    originExists = true,
-    canPush = false,
-    gitState,
-    branchNames,
-    branches,
-    ...rest
-  } = overrides
-  // Default non-worktree responses include a picker list (the doomed
-  // branch is in there too — the dialog filters it out). The worktree
-  // path leaves `branches` empty to mirror the worker's contract.
-  const isWorktree = rest.isWorktree ?? false
-  const defaultBranches: GitBranchEntry[] = isWorktree ? [] : makeBranches(['main', 'doomed'])
-  return {
-    $typeName: 'leapmux.v1.InspectBranchDeletionResponse',
-    isWorktree,
-    worktreePath: '',
-    // Worktree responses thread the DB row id so the dialog can tell a
-    // tracked worktree from an untracked one; non-worktree leaves it empty.
-    worktreeId: isWorktree ? 'wt-1' : '',
-    branchName: 'doomed',
-    branches: branches ?? (branchNames ? makeBranches(branchNames) : defaultBranches),
-    gitState: gitState ?? ({
-      $typeName: 'leapmux.v1.BranchGitState',
-      diffAdded,
-      diffDeleted,
-      diffUntracked,
-      unpushedCommitCount,
-      hasUncommittedChanges,
-      upstreamExists,
-      remoteBranchMissing,
-      originExists,
-      canPush,
-    } as InspectBranchDeletionResponse['gitState']),
-    ...rest,
-  } as InspectBranchDeletionResponse
-}
 
 function makeAgentTab(id: string): Tab {
   return {
@@ -190,6 +125,31 @@ describe('deleteBranchDialog', () => {
     expect(closeWorktreeTabs).toHaveBeenCalledWith(tabs)
     await waitFor(() => expect(props.onClose).toHaveBeenCalledTimes(1))
     expect(showInfoToast).toHaveBeenCalledWith('Worktree removed')
+  })
+
+  it('worktree variant: toasts the outcome BEFORE onClose', async () => {
+    // Both handlers close LAST — do the work, notify, toast, then close.
+    // The worktree path used to close in the middle of its sequence, which
+    // left the file with two opposite orders while a comment below declared
+    // one of them load-bearing. Nothing in the file may do work after the
+    // close, because the close disposes the subtree that owns this dialog.
+    vi.mocked(workerRpc.inspectBranchDeletion).mockResolvedValue(
+      makeInspectResp({ isWorktree: true, worktreePath: '/wt' }),
+    )
+    const calls: string[] = []
+    vi.mocked(showInfoToast).mockImplementation(() => {
+      calls.push('toast')
+    })
+    const onClose = vi.fn(() => {
+      calls.push('onClose')
+    })
+    renderDialog({ closeWorktreeTabs: makeCloseWorktreeTabs({ removed: true }), onClose })
+    await waitFor(() => expect(screen.getByText(/Worktree:/)).toBeInTheDocument())
+
+    await clickDelete()
+
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1))
+    expect(calls).toEqual(['toast', 'onClose'])
   })
 
   it('worktree variant closes a FILE-only group through closeWorktreeTabs', async () => {
@@ -355,6 +315,50 @@ describe('deleteBranchDialog', () => {
     // on the new branch — unlike the worktree path, it must NOT close any
     // tab. Pins the worktree-vs-branch behavioral split from the branch side.
     expect(closeWorktreeTabs).not.toHaveBeenCalled()
+  })
+
+  it('non-worktree variant: notifies onBranchChanged BEFORE onClose', async () => {
+    // The order changes the behavior; it is not cosmetic. `onClose` tears
+    // down the subtree that owns this dialog in AppShellDialogs. A parent
+    // callback that runs after the close can read disposed state, and Solid
+    // answers such a read with a thrown string. The close ran first, so it
+    // swallowed the sidebar stamp and the git-status refresh. The deleted
+    // branch's label stayed on screen until a reload.
+    //
+    // The dialog's own try/catch — not this order — is what keeps a
+    // callback throw out of `run`'s "Delete failed" banner.
+    vi.mocked(workerRpc.inspectBranchDeletion).mockResolvedValue(makeInspectResp())
+    const calls: string[] = []
+    const onBranchChanged = vi.fn(() => {
+      calls.push('onBranchChanged')
+    })
+    const onClose = vi.fn(() => {
+      calls.push('onClose')
+    })
+    renderDialog({ onBranchChanged, onClose })
+    await waitFor(() => expect(screen.getByText(/Switch this working directory to:/)).toBeInTheDocument())
+    const select = screen.getAllByRole('combobox')[0] as HTMLSelectElement
+    fireEvent.change(select, { target: { value: 'main' } })
+
+    await clickDelete()
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1))
+    expect(calls).toEqual(['onBranchChanged', 'onClose'])
+  })
+
+  it('non-worktree variant: closes even when no onBranchChanged is supplied', async () => {
+    // `onBranchChanged` is optional, and the close now runs AFTER it. An
+    // absent callback must therefore still reach `props.onClose()`. The
+    // optional call must not drop the close.
+    vi.mocked(workerRpc.inspectBranchDeletion).mockResolvedValue(makeInspectResp())
+    const props = renderDialog({ onBranchChanged: undefined })
+    await waitFor(() => expect(screen.getByText(/Switch this working directory to:/)).toBeInTheDocument())
+    const select = screen.getAllByRole('combobox')[0] as HTMLSelectElement
+    fireEvent.change(select, { target: { value: 'main' } })
+
+    await clickDelete()
+    await waitFor(() => expect(props.onClose).toHaveBeenCalledTimes(1))
+    expect(showInfoToast).toHaveBeenCalledWith('Branch deleted')
+    expect(showWarnToast).not.toHaveBeenCalled()
   })
 
   it('non-worktree variant: stamps the local name when switching to a remote-tracking ref', async () => {
@@ -721,6 +725,30 @@ describe('deleteBranchDialog', () => {
     expect(closeWorktreeTabs).not.toHaveBeenCalled()
   })
 
+  it('disables Cancel while DeleteBranch is in flight', async () => {
+    // The Dialog `busy` flag gates Escape, the backdrop click, and the X
+    // button, but it never reaches a custom footer button. Without an
+    // explicit `disabled` the user can dismiss the dialog mid-delete: the
+    // RPC keeps running, and a failure then calls setError on a disposed
+    // dialog, so the user sees no error at all for a delete that did not
+    // happen. DialogFormFooter's own Cancel carries the same gate.
+    vi.mocked(workerRpc.inspectBranchDeletion).mockResolvedValue(makeInspectResp())
+    // Never resolves: holds the dialog in its submitting state.
+    vi.mocked(workerRpc.deleteBranch).mockReturnValue(new Promise<DeleteBranchResponse>(() => {}))
+    const props = renderDialog()
+    await waitFor(() => expect(screen.getByText(/Switch this working directory to:/)).toBeInTheDocument())
+    const select = screen.getAllByRole('combobox')[0] as HTMLSelectElement
+    fireEvent.change(select, { target: { value: 'main' } })
+
+    await clickDelete()
+    await waitFor(() => expect(workerRpc.deleteBranch).toHaveBeenCalledTimes(1))
+
+    const cancel = screen.getByRole('button', { name: 'Cancel' }) as HTMLButtonElement
+    expect(cancel.disabled).toBe(true)
+    fireEvent.click(cancel)
+    expect(props.onClose).not.toHaveBeenCalled()
+  })
+
   it('renders affected-tab counts based on the tabs prop', async () => {
     vi.mocked(workerRpc.inspectBranchDeletion).mockResolvedValue(
       makeInspectResp({ isWorktree: true, worktreePath: '/wt' }),
@@ -865,9 +893,9 @@ describe('deleteBranchDialog', () => {
   it('non-worktree variant: a throwing onBranchChanged does not masquerade as a delete failure', async () => {
     // The delete succeeded on the worker; onBranchChanged only stamps the
     // sidebar label. A throw from it must NOT propagate into the dialog's
-    // error sink and show "Delete failed" for an op that worked — success
-    // is committed (toast + onClose) before the isolated stamp, and the
-    // stamp failure surfaces as its own warn toast. (S11)
+    // error sink and show "Delete failed" for a delete that worked. The
+    // try/catch around the stamp is what guarantees that, and the stamp
+    // failure surfaces as its own warn toast. (S11)
     vi.mocked(workerRpc.inspectBranchDeletion).mockResolvedValue(makeInspectResp())
     const onBranchChanged = vi.fn(() => {
       throw new Error('stamp boom')

--- a/frontend/src/components/workspace/DeleteBranchDialog.tsx
+++ b/frontend/src/components/workspace/DeleteBranchDialog.tsx
@@ -230,13 +230,13 @@ export const DeleteBranchDialog: Component<DeleteBranchDialogProps> = (props) =>
       // soft-delete once the LAST referencing tab closes, serializing
       // concurrent closes per worktree so there is no double-remove.
       const outcome = await props.closeWorktreeTabs(props.tabs)
-      props.onClose()
       // Toast the REAL outcome. worktreeRemovalToast owns the precedence
       // (ground truth over the stale inspect-time worktreeId snapshot);
       // null means stay silent because a FAILED close already warned.
       const message = worktreeRemovalToast(outcome, Boolean(i.worktreeId))
       if (message)
         showInfoToast(message)
+      props.onClose()
     })
   }
 
@@ -255,23 +255,34 @@ export const DeleteBranchDialog: Component<DeleteBranchDialogProps> = (props) =>
         branchToDelete: i.branchName,
         switchToBranch: target,
       })
-      // The delete succeeded on the worker. Surface success and close
-      // BEFORE the stamp so a throw from onBranchChanged can't propagate
-      // into `run`'s catch and masquerade as a "Delete failed" — leaving
-      // the user staring at a failure banner for an op that worked.
+      // The delete succeeded on the worker. Surface success first, so the
+      // user sees it even if the stamp below warns.
       showInfoToast('Branch deleted')
-      props.onClose()
       // deleteBranchInDir routes through checkoutBranchInDir, which resolves
       // a remote ref like 'origin/foo' to the local branch 'foo' before
       // deleting. Stamp the local name so the sidebar label matches HEAD.
-      // ChangeBranchDialog stamps via the same helper. Isolated because
-      // the stamp is cosmetic (sidebar label) and must not undo success.
+      // ChangeBranchDialog stamps via the same helper. The try/catch
+      // isolates the stamp, because the stamp is cosmetic (the sidebar
+      // label) and must not undo the success. The try/catch — NOT the call
+      // order — keeps a throw here out of `run`'s catch. `run`'s catch
+      // shows a "Delete failed" banner, which is incorrect for a delete
+      // that worked.
+      //
+      // Both handlers here close LAST: do the work, notify the parent,
+      // toast, then `props.onClose()`. onClose disposes the subtree that
+      // owns this dialog, so anything after it runs against a disposed
+      // owner. AppShellDialogs renders this dialog under a keyed <Show>,
+      // which hands its children the payload itself, so its callbacks hold
+      // no accessor to go stale. This order keeps every other parent safe
+      // also. An earlier close-first order swallowed the stamp, and the
+      // sidebar kept the deleted branch's label until a page reload.
       try {
         props.onBranchChanged?.(resolveStampedBranch(target, i.branches))
       }
       catch (err) {
         showWarnToast('Branch deleted, but failed to update the sidebar label', err)
       }
+      props.onClose()
     })
   }
 
@@ -297,7 +308,13 @@ export const DeleteBranchDialog: Component<DeleteBranchDialogProps> = (props) =>
       compact
       footer={(
         <>
-          <button type="button" class="outline" onClick={() => props.onClose()}>
+          {/* `disabled` while submitting, to match DialogFormFooter's own
+              Cancel. The Dialog `busy` flag gates only Escape, the backdrop
+              click, and the X button; it never reaches a custom footer
+              button, which calls `props.onClose()` directly. Without this
+              gate the user can dismiss the dialog while DeleteBranch is in
+              flight, and a failure then has nowhere to render. */}
+          <button type="button" class="outline" disabled={submitting.loading()} onClick={() => props.onClose()}>
             Cancel
           </button>
           {/* The `pushWorkingDir` gate covers the edge where no tab in the

--- a/frontend/src/components/workspace/branchUpdate.test.tsx
+++ b/frontend/src/components/workspace/branchUpdate.test.tsx
@@ -72,7 +72,7 @@ describe('branchUpdate (change branch → sidebar reflects new label)', () => {
       makeAgentTab('other', { workerId: 'w2', gitToplevel: '/other' }),
     ])
 
-    expect(stampBranchOnTabs(stamp, 'w1', '/repo', 'B')).toBe(true)
+    expect(stampBranchOnTabs(stamp, { workerId: 'w1', gitToplevel: '/repo' }, 'B')).toBe(true)
 
     expect(branchOf(state, 'a1')).toBe('B')
     expect(branchOf(state, 'a2')).toBe('B')
@@ -95,7 +95,7 @@ describe('branchUpdate (change branch → sidebar reflects new label)', () => {
       },
     }
 
-    expect(stampBranchOnTabs(counting, 'w1', '/repo', 'A')).toBe(false)
+    expect(stampBranchOnTabs(counting, { workerId: 'w1', gitToplevel: '/repo' }, 'A')).toBe(false)
     expect(updates).toBe(0)
     expect(branchOf(state, 'a1')).toBe('A')
   })
@@ -113,7 +113,7 @@ describe('branchUpdate (change branch → sidebar reflects new label)', () => {
       expect(tree().groups[0].branches[0].tabs.map(t => t.id).toSorted()).toEqual(['a1', 'a2'])
 
       // Switch both tabs to branch "B" the same way AppShell does.
-      stampBranchOnTabs(stamp, 'w1', '/repo', 'B')
+      stampBranchOnTabs(stamp, { workerId: 'w1', gitToplevel: '/repo' }, 'B')
 
       // The memo must have re-run and produced a single group with the
       // new branch label.
@@ -138,7 +138,7 @@ describe('branchUpdate (change branch → sidebar reflects new label)', () => {
       makeAgentTab('a2', { gitToplevel: undefined, gitOriginUrl: 'https://github.com/o/r2.git' }),
     ])
 
-    expect(stampBranchOnTabs(stamp, 'w1', '', 'B')).toBe(false)
+    expect(stampBranchOnTabs(stamp, { workerId: 'w1', gitToplevel: '' }, 'B')).toBe(false)
     expect(branchOf(state, 'a1')).toBe('A')
     expect(branchOf(state, 'a2')).toBe('A')
   })
@@ -152,7 +152,7 @@ describe('branchUpdate (change branch → sidebar reflects new label)', () => {
       makeAgentTab('a2', { workerId: 'w1', gitToplevel: '/repo' }),
     ])
 
-    expect(stampBranchOnTabs(stamp, '', '/repo', 'B')).toBe(false)
+    expect(stampBranchOnTabs(stamp, { workerId: '', gitToplevel: '/repo' }, 'B')).toBe(false)
     expect(branchOf(state, 'a1')).toBe('A')
     expect(branchOf(state, 'a2')).toBe('A')
   })
@@ -165,7 +165,7 @@ describe('branchUpdate (change branch → sidebar reflects new label)', () => {
       makeAgentTab('a2', { workspaceId: 'ws-2', tileId: 'tile-2' }),
     ])
 
-    stampBranchOnTabs(stamp, 'w1', '/repo', 'B')
+    stampBranchOnTabs(stamp, { workerId: 'w1', gitToplevel: '/repo' }, 'B')
 
     expect(branchOf(state, 'a1')).toBe('B')
     expect(branchOf(state, 'a2')).toBe('B')
@@ -181,7 +181,7 @@ describe('branchUpdate (change branch → sidebar reflects new label)', () => {
       makeAgentTab('a2'),
     ])
 
-    stampBranchOnTabs(stamp, 'w1', '/repo', 'B')
+    stampBranchOnTabs(stamp, { workerId: 'w1', gitToplevel: '/repo' }, 'B')
 
     expect(state.tabs.map(t => [tabKey(t), t.gitBranch])).toEqual([
       [tabKey(state.tabs[0]), 'B'],

--- a/frontend/src/hooks/createDialogState.test.ts
+++ b/frontend/src/hooks/createDialogState.test.ts
@@ -1,6 +1,6 @@
 import { createEffect, createRoot } from 'solid-js'
 import { describe, expect, it, vi } from 'vitest'
-import { createDialogState, createToggleDialog } from '~/hooks/createDialogState'
+import { createDialogState, createToggleDialog, createUpdatableDialogState } from '~/hooks/createDialogState'
 import { flush } from '~/test-support/async'
 
 describe('createDialogState', () => {
@@ -93,9 +93,29 @@ describe('createDialogState', () => {
     // protects callbacks (resolve, onDismiss) from being clobbered by
     // an accidental field-collision spread.
 
+    it('is unreachable on the narrow handle, which is the point of the split', () => {
+      // Whether a payload changes in place decides how AppShellDialogs
+      // renders the dialog: an open/close-only payload goes under a keyed
+      // <Show>, which hands the children the payload itself and so leaves
+      // no accessor for a post-close callback to read. `update` breaks
+      // that, because keyed re-creates the subtree on every payload
+      // identity change and would remount the native <dialog>. This
+      // assertion is the guarantee: a dialog cannot silently gain `update`
+      // and invalidate its parent's render form. The runtime object DOES
+      // carry the method -- createDialogState narrows by return type only
+      // -- so the type error is the whole test, and `@ts-expect-error`
+      // fails the typecheck if the field ever becomes reachable.
+      createRoot((dispose) => {
+        const d = createDialogState<{ id: string }>()
+        // @ts-expect-error -- `update` must not exist on DialogState.
+        expect(d.update).toBeDefined()
+        dispose()
+      })
+    })
+
     it('returns false and does not write when the dialog is closed', () => {
       createRoot((dispose) => {
-        const d = createDialogState<{ id: string, label: string }>()
+        const d = createUpdatableDialogState<{ id: string, label: string }>()
         const wrote = d.update({ label: 'new' })
         expect(wrote).toBe(false)
         expect(d.value()).toBeNull()
@@ -105,7 +125,7 @@ describe('createDialogState', () => {
 
     it('returns true and merges patch into the current payload', () => {
       createRoot((dispose) => {
-        const d = createDialogState<{ id: string, label: string, count: number }>()
+        const d = createUpdatableDialogState<{ id: string, label: string, count: number }>()
         d.open({ id: 'one', label: 'first', count: 1 })
         const wrote = d.update({ label: 'updated' })
         expect(wrote).toBe(true)
@@ -121,7 +141,7 @@ describe('createDialogState', () => {
       createRoot((dispose) => {
         const resolve = vi.fn()
         interface State { id: string, resolve: () => void, gitState: { dirty: boolean } | null }
-        const d = createDialogState<State>()
+        const d = createUpdatableDialogState<State>()
         d.open({ id: 'one', resolve, gitState: null })
         d.update({ gitState: { dirty: true } })
         const after = d.value()
@@ -134,7 +154,7 @@ describe('createDialogState', () => {
 
     it('subsequent updates compound (each merges on top of the previous result)', () => {
       createRoot((dispose) => {
-        const d = createDialogState<{ a: number, b: number, c: number }>()
+        const d = createUpdatableDialogState<{ a: number, b: number, c: number }>()
         d.open({ a: 1, b: 1, c: 1 })
         d.update({ a: 2 })
         d.update({ b: 3 })
@@ -152,7 +172,7 @@ describe('createDialogState', () => {
       // shape) can't quietly mask a refresh.
       await new Promise<void>((done) => {
         createRoot(async (dispose) => {
-          const d = createDialogState<{ a: number }>()
+          const d = createUpdatableDialogState<{ a: number }>()
           d.open({ a: 1 })
           let runs = 0
           createEffect(() => {
@@ -179,7 +199,7 @@ describe('createDialogState', () => {
       // <Show when={value()}> to unmount the dialog. update must not.
       await new Promise<void>((done) => {
         createRoot(async (dispose) => {
-          const d = createDialogState<{ a: number }>()
+          const d = createUpdatableDialogState<{ a: number }>()
           d.open({ a: 1 })
           const seen: (number | null)[] = []
           createEffect(() => {
@@ -205,7 +225,7 @@ describe('createDialogState', () => {
       // are unchanged — useful so a "no-op refresh" call site doesn't
       // accidentally close the dialog.
       createRoot((dispose) => {
-        const d = createDialogState<{ a: number }>()
+        const d = createUpdatableDialogState<{ a: number }>()
         d.open({ a: 1 })
         const wrote = d.update({})
         expect(wrote).toBe(true)

--- a/frontend/src/hooks/createDialogState.ts
+++ b/frontend/src/hooks/createDialogState.ts
@@ -4,26 +4,47 @@ import { createSignal } from 'solid-js'
 /**
  * Imperative handle for a dialog that carries a payload while open. `open`
  * stores the payload; `close` resets to null; `value` is the reactive
- * payload (null when closed — `<Show when={state.value()}>` is the typical
- * consumer pattern). `update` merges a partial patch into the current
- * payload without going through close/reopen — keeps the dialog's
- * lifecycle stable for in-place refreshes (e.g. re-running an inspect
- * RPC while the user is staring at the result).
+ * payload (null when closed — `<Show when={state.value()} keyed>` is the
+ * typical consumer pattern).
  *
  * The shape collapses the show-flag + payload + setter triple that parents
  * used to thread through props. Use {@link ToggleDialogState} for
- * payload-less dialogs.
+ * payload-less dialogs, and {@link UpdatableDialogState} for a dialog whose
+ * payload is patched in place.
+ *
+ * There is deliberately NO `update` here. Whether a payload can change
+ * while the dialog stays open decides how the consumer renders it: a
+ * payload that only ever arrives through `open` can be rendered under a
+ * keyed `<Show>`, which hands the children the payload itself and so has no
+ * accessor for a post-close callback to read. An in-place `update` breaks
+ * that, because keyed re-creates the subtree on every payload identity
+ * change and would remount the native `<dialog>` on each refresh. Splitting
+ * the two capabilities across two types puts that rule in the type system
+ * rather than in a comment, so a dialog cannot silently gain `update` and
+ * invalidate its parent's render form.
  */
 export interface DialogState<T> {
   open: (value: T) => void
   close: () => void
+  value: Accessor<T | null>
+}
+
+/**
+ * A {@link DialogState} whose payload can also be patched in place, for a
+ * dialog that refreshes its own contents while the user is staring at them
+ * (re-running an inspect RPC, for example).
+ *
+ * Render one of these under a NON-keyed `<Show>`: keyed would tear the
+ * dialog down and rebuild it on every patch. That is the whole reason this
+ * is a separate type — see {@link DialogState}.
+ */
+export interface UpdatableDialogState<T> extends DialogState<T> {
   /**
    * Merge `patch` into the current payload. No-op when the dialog is
    * closed (the caller should `open` first). Returns whether a write
    * was performed.
    */
   update: (patch: Partial<T>) => boolean
-  value: Accessor<T | null>
 }
 
 /**
@@ -37,7 +58,7 @@ export interface ToggleDialogState {
   isOpen: Accessor<boolean>
 }
 
-export function createDialogState<T>(): DialogState<T> {
+export function createUpdatableDialogState<T>(): UpdatableDialogState<T> {
   const [value, setValue] = createSignal<T | null>(null)
   return {
     open: v => setValue(() => v),
@@ -51,6 +72,15 @@ export function createDialogState<T>(): DialogState<T> {
     },
     value,
   }
+}
+
+/**
+ * The open/close-only handle. Built on the updatable one and narrowed by the
+ * return type, so a caller cannot reach `update` — which is the point: see
+ * {@link DialogState} for why that capability decides the render form.
+ */
+export function createDialogState<T>(): DialogState<T> {
+  return createUpdatableDialogState<T>()
 }
 
 export function createToggleDialog(): ToggleDialogState {

--- a/frontend/src/lib/lexorank.test.ts
+++ b/frontend/src/lib/lexorank.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { after, first, mid, positionAtInsertIdx } from '~/lib/lexorank'
+import { after, appendPosition, first, mid, positionAtInsertIdx } from '~/lib/lexorank'
 
 describe('lexorank', () => {
   describe('first', () => {
@@ -123,5 +123,27 @@ describe('lexorank', () => {
       expect(headResult < 'n').toBe(true)
       expect(headResult.length).toBeGreaterThan(0)
     })
+  })
+})
+
+describe('appendPosition', () => {
+  it('sorts after the last item', () => {
+    expect(appendPosition([{ position: 'n' }, { position: 'u' }]) > 'u').toBe(true)
+  })
+
+  it('returns the first rank for an empty list', () => {
+    expect(appendPosition([])).toBe(first())
+  })
+
+  it('keeps producing distinct ranks when appended repeatedly', () => {
+    // The collision this replaced: three call sites each computed the append
+    // rank by hand, and a hardcoded constant would have landed every new item
+    // on the same position, leaving the SQL planner to shuffle the tied rows.
+    const items: { position: string }[] = []
+    for (let i = 0; i < 8; i++)
+      items.push({ position: appendPosition(items) })
+    const ranks = items.map(i => i.position)
+    expect(new Set(ranks).size).toBe(ranks.length)
+    expect([...ranks].sort()).toEqual(ranks)
   })
 })

--- a/frontend/src/lib/lexorank.ts
+++ b/frontend/src/lib/lexorank.ts
@@ -34,6 +34,20 @@ export function mid(a: string, b: string): string {
 }
 
 /**
+ * Returns a LexoRank position that appends past every item in `items`.
+ *
+ * `mid(last, '')` and `mid('', '')` already cover the tail and the
+ * empty-list cases, so this is the two-line fold three workspace call sites
+ * each wrote out. A hardcoded position would collide instead: every append
+ * would land on the same rank, and the SQL planner would then shuffle the
+ * tied rows on each page refresh.
+ */
+export function appendPosition(items: readonly { position: string }[]): string {
+  const lastItem = items.at(-1)
+  return lastItem ? mid(lastItem.position, '') : mid('', '')
+}
+
+/**
  * Returns a LexoRank position for inserting a new item at index `insertIdx`
  * within an ordered list of items that each carry an optional `position`.
  * Reads the previous and next neighbours' positions and folds them through

--- a/frontend/src/stores/tab.helpers.test.ts
+++ b/frontend/src/stores/tab.helpers.test.ts
@@ -103,17 +103,17 @@ describe('tabDisplayLabel', () => {
 // every behavior listed here represents a contract those callers rely on.
 describe('isSameRepo', () => {
   it('matches when workerId and gitToplevel both equal', () => {
-    expect(isSameRepo({ workerId: 'w1', gitToplevel: '/repo' }, 'w1', '/repo')).toBe(true)
+    expect(isSameRepo({ workerId: 'w1', gitToplevel: '/repo' }, { workerId: 'w1', gitToplevel: '/repo' })).toBe(true)
   })
 
   it('rejects when workerId differs (cross-worker leakage guard)', () => {
     // A branch change on worker A must never trigger a stamp on a tab
     // hosted by worker B even if both happen to share a repo path.
-    expect(isSameRepo({ workerId: 'wA', gitToplevel: '/repo' }, 'wB', '/repo')).toBe(false)
+    expect(isSameRepo({ workerId: 'wA', gitToplevel: '/repo' }, { workerId: 'wB', gitToplevel: '/repo' })).toBe(false)
   })
 
   it('rejects when gitToplevel differs (cross-repo guard)', () => {
-    expect(isSameRepo({ workerId: 'w1', gitToplevel: '/repo-a' }, 'w1', '/repo-b')).toBe(false)
+    expect(isSameRepo({ workerId: 'w1', gitToplevel: '/repo-a' }, { workerId: 'w1', gitToplevel: '/repo-b' })).toBe(false)
   })
 
   it('rejects an empty workerId instead of matching every unresolved tab', () => {
@@ -122,9 +122,9 @@ describe('isSameRepo', () => {
     // the symmetric half of the empty-toplevel wildcard below. The guard used
     // to live at one call site (`stampBranchOnTabs`), so the predicate itself
     // answered `('' === '')` -> true and every other caller was on its own.
-    expect(isSameRepo({ gitToplevel: '/repo' }, '', '/repo')).toBe(false)
-    expect(isSameRepo({ workerId: '', gitToplevel: '/repo' }, '', '/repo')).toBe(false)
-    expect(isSameRepo({ gitToplevel: '/repo' }, 'w1', '/repo')).toBe(false)
+    expect(isSameRepo({ gitToplevel: '/repo' }, { workerId: '', gitToplevel: '/repo' })).toBe(false)
+    expect(isSameRepo({ workerId: '', gitToplevel: '/repo' }, { workerId: '', gitToplevel: '/repo' })).toBe(false)
+    expect(isSameRepo({ gitToplevel: '/repo' }, { workerId: 'w1', gitToplevel: '/repo' })).toBe(false)
   })
 
   // Regression guard, and the reason an empty `repoToplevel` is rejected
@@ -134,32 +134,32 @@ describe('isSameRepo', () => {
   // un-stamped repo on the same worker — and since the stamp now spans every
   // workspace rather than just the active one, across the whole account.
   it('never matches an empty repoToplevel, even against an unresolved tab', () => {
-    expect(isSameRepo({ workerId: 'w1' }, 'w1', '')).toBe(false)
-    expect(isSameRepo({ workerId: 'w1', gitToplevel: '' }, 'w1', '')).toBe(false)
-    expect(isSameRepo({ workerId: 'w1' }, 'w1', '/repo')).toBe(false)
+    expect(isSameRepo({ workerId: 'w1' }, { workerId: 'w1', gitToplevel: '' })).toBe(false)
+    expect(isSameRepo({ workerId: 'w1', gitToplevel: '' }, { workerId: 'w1', gitToplevel: '' })).toBe(false)
+    expect(isSameRepo({ workerId: 'w1' }, { workerId: 'w1', gitToplevel: '/repo' })).toBe(false)
   })
 
   it('rejects an empty repoToplevel before the workerId comparison', () => {
     // Not reachable via a workerId mismatch — the guard has to fire on its
     // own, or a same-worker query would still leak.
-    expect(isSameRepo({ workerId: 'w1', gitToplevel: '/repo' }, 'w1', '')).toBe(false)
+    expect(isSameRepo({ workerId: 'w1', gitToplevel: '/repo' }, { workerId: 'w1', gitToplevel: '' })).toBe(false)
   })
 
   it('returns false for null / undefined input', () => {
-    expect(isSameRepo(null, 'w1', '/repo')).toBe(false)
-    expect(isSameRepo(undefined, 'w1', '/repo')).toBe(false)
+    expect(isSameRepo(null, { workerId: 'w1', gitToplevel: '/repo' })).toBe(false)
+    expect(isSameRepo(undefined, { workerId: 'w1', gitToplevel: '/repo' })).toBe(false)
   })
 
   it('returns false when only one side is unset (no accidental empty-empty matches)', () => {
-    expect(isSameRepo({ workerId: 'w1' }, '', '/repo')).toBe(false)
-    expect(isSameRepo({ gitToplevel: '/repo' }, 'w1', '')).toBe(false)
+    expect(isSameRepo({ workerId: 'w1' }, { workerId: '', gitToplevel: '/repo' })).toBe(false)
+    expect(isSameRepo({ gitToplevel: '/repo' }, { workerId: 'w1', gitToplevel: '' })).toBe(false)
   })
 
   it('does not perform substring matching on gitToplevel', () => {
     // Regression guard: `/repo` must not match `/repo-other` even
     // though one is a prefix of the other.
-    expect(isSameRepo({ workerId: 'w1', gitToplevel: '/repo-other' }, 'w1', '/repo')).toBe(false)
-    expect(isSameRepo({ workerId: 'w1', gitToplevel: '/repo' }, 'w1', '/repo-other')).toBe(false)
+    expect(isSameRepo({ workerId: 'w1', gitToplevel: '/repo-other' }, { workerId: 'w1', gitToplevel: '/repo' })).toBe(false)
+    expect(isSameRepo({ workerId: 'w1', gitToplevel: '/repo' }, { workerId: 'w1', gitToplevel: '/repo-other' })).toBe(false)
   })
 
   it('accepts a full Tab object (the common production call shape)', () => {
@@ -170,7 +170,7 @@ describe('isSameRepo', () => {
       workerId: 'w1',
       gitToplevel: '/repo',
     }
-    expect(isSameRepo(tab, 'w1', '/repo')).toBe(true)
+    expect(isSameRepo(tab, { workerId: 'w1', gitToplevel: '/repo' })).toBe(true)
   })
 })
 

--- a/frontend/src/stores/tab.helpers.ts
+++ b/frontend/src/stores/tab.helpers.ts
@@ -20,8 +20,28 @@ import { isTerminalTab } from './tab.types'
 type ProtoTerminal = Awaited<ReturnType<typeof listTerminals>>['terminals'][number]
 
 /**
- * Repository-identity equality for matching a (workerId, repoToplevel)
- * pair against a Tab-shaped value. Used by:
+ * The identity of one repository checkout on one worker.
+ *
+ * The two fields travel together through the whole branch flow — the sidebar
+ * row that opens a dialog, the dialog's payload, `onBranchChanged`,
+ * `handleBranchChanged`, `stampBranchOnTabs` and `isSameRepo`. As two
+ * adjacent same-typed strings they were transposable at every hop, and a
+ * transposition compiles and then matches nothing, so the branch stamp
+ * silently reaches zero tabs. One parameter makes that mistake
+ * unrepresentable.
+ */
+export interface RepoRef {
+  workerId: string
+  /**
+   * `git rev-parse --show-toplevel`. For a main repo this is the repo root;
+   * for a linked worktree it is the worktree root. Matches `Tab.gitToplevel`.
+   */
+  gitToplevel: string
+}
+
+/**
+ * Repository-identity equality for matching a {@link RepoRef} against a
+ * Tab-shaped value. Used by:
  *  - AppShell's branch-changed routing to decide whether to refresh the
  *    gitFileStatusStore singleton (only when the changed repo is the
  *    active tab's repo).
@@ -43,12 +63,11 @@ type ProtoTerminal = Awaited<ReturnType<typeof listTerminals>>['terminals'][numb
  */
 export function isSameRepo(
   tabLike: { workerId?: string, gitToplevel?: string } | null | undefined,
-  workerId: string,
-  repoToplevel: string,
+  repo: RepoRef,
 ): boolean {
-  if (!tabLike || !workerId || !repoToplevel)
+  if (!tabLike || !repo.workerId || !repo.gitToplevel)
     return false
-  return (tabLike.workerId ?? '') === workerId && (tabLike.gitToplevel ?? '') === repoToplevel
+  return (tabLike.workerId ?? '') === repo.workerId && (tabLike.gitToplevel ?? '') === repo.gitToplevel
 }
 
 /**

--- a/frontend/src/test-support/gitBranchFixtures.ts
+++ b/frontend/src/test-support/gitBranchFixtures.ts
@@ -1,0 +1,78 @@
+import type { GitBranchEntry, InspectBranchDeletionResponse } from '~/generated/leapmux/v1/git_pb'
+
+/**
+ * Fixtures for the branch dialogs' `InspectBranchDeletion` responses.
+ *
+ * Two suites drive the same RPC shape: `DeleteBranchDialog.test.tsx` renders
+ * the dialog directly, and `AppShellDialogs.test.tsx` renders it through the
+ * real `<Show>` composition. They held byte-identical copies of these
+ * builders, and the second copy dropped the worktree conventions that the
+ * first one documents, so each suite had to re-encode them at the call site.
+ * One home keeps the worker contract in one place.
+ */
+
+export function makeBranches(names: string[]): GitBranchEntry[] {
+  return names.map(name => ({
+    $typeName: 'leapmux.v1.GitBranchEntry',
+    name,
+    isRemote: false,
+  } as GitBranchEntry))
+}
+
+export function makeInspectResp(overrides: Partial<InspectBranchDeletionResponse> & Partial<{
+  diffAdded: number
+  diffDeleted: number
+  diffUntracked: number
+  unpushedCommitCount: number
+  hasUncommittedChanges: boolean
+  upstreamExists: boolean
+  remoteBranchMissing: boolean
+  originExists: boolean
+  canPush: boolean
+  /** Convenience: pass branch names; converted to GitBranchEntry rows. */
+  branchNames: string[]
+}> = {}): InspectBranchDeletionResponse {
+  const {
+    diffAdded = 0,
+    diffDeleted = 0,
+    diffUntracked = 0,
+    unpushedCommitCount = 0,
+    hasUncommittedChanges = false,
+    upstreamExists = true,
+    remoteBranchMissing = false,
+    originExists = true,
+    canPush = false,
+    gitState,
+    branchNames,
+    branches,
+    ...rest
+  } = overrides
+  // Default non-worktree responses include a picker list (the doomed
+  // branch is in there too — the dialog filters it out). The worktree
+  // path leaves `branches` empty to mirror the worker's contract.
+  const isWorktree = rest.isWorktree ?? false
+  const defaultBranches: GitBranchEntry[] = isWorktree ? [] : makeBranches(['main', 'doomed'])
+  return {
+    $typeName: 'leapmux.v1.InspectBranchDeletionResponse',
+    isWorktree,
+    worktreePath: '',
+    // Worktree responses thread the DB row id so the dialog can tell a
+    // tracked worktree from an untracked one; non-worktree leaves it empty.
+    worktreeId: isWorktree ? 'wt-1' : '',
+    branchName: 'doomed',
+    branches: branches ?? (branchNames ? makeBranches(branchNames) : defaultBranches),
+    gitState: gitState ?? ({
+      $typeName: 'leapmux.v1.BranchGitState',
+      diffAdded,
+      diffDeleted,
+      diffUntracked,
+      unpushedCommitCount,
+      hasUncommittedChanges,
+      upstreamExists,
+      remoteBranchMissing,
+      originExists,
+      canPush,
+    } as InspectBranchDeletionResponse['gitState']),
+    ...rest,
+  } as InspectBranchDeletionResponse
+}

--- a/frontend/tests/e2e/067-file-tab-close.spec.ts
+++ b/frontend/tests/e2e/067-file-tab-close.spec.ts
@@ -1,11 +1,12 @@
 import { execSync } from 'node:child_process'
 import { existsSync, realpathSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
+import { TabType } from '../../src/generated/leapmux/v1/workspace_pb'
 import { expect, test } from './fixtures'
 import { createWorkspaceViaAPI, deleteWorkspaceViaAPI, openAgentViaAPI } from './helpers/api'
 import { clearRecordedToasts, getRecordedToasts, installToastRecorder } from './helpers/toast'
 import { loginViaToken, openWorkspace } from './helpers/ui'
-import { createGitRepo, createWorkspaceWithWorktreeViaAPI, waitForAgentStartupViaAPI } from './helpers/worktree'
+import { createGitRepo, createWorkspaceWithWorktreeViaAPI, inspectLastTabCloseViaAPI, waitForAgentStartupViaAPI } from './helpers/worktree'
 
 /**
  * How long to let a toast show up before concluding none is coming. The close
@@ -177,6 +178,28 @@ test.describe('file tab close', () => {
       await agentTab.locator('[data-testid="tab-close"]').click()
       await expect(agentTab).toHaveCount(0)
       await expect(page.getByRole('dialog')).toHaveCount(0)
+
+      // The tab count above is OPTIMISTIC local state: the CRDT tombstone
+      // applies speculatively, so the tab leaves the bar while CloseAgent is
+      // still running its teardown on the worker. The next close asks the
+      // WORKER whether a sibling tab still holds this branch, and an agent
+      // row that is not closed YET answers yes -- which takes the no-prompt
+      // fast path in inspectLastTabClose's hasOtherNonWorktreeTabOnBranch.
+      // The hub's tab list cannot answer this, because the tombstone clears
+      // it the instant it applies; only the worker knows when its own row
+      // closed. Poll the worker's own verdict for this file tab, so the
+      // assertion below tests the UI rather than racing the previous close.
+      const fileTabId = await fileTab.getAttribute('data-tab-id')
+      expect(fileTabId, 'the file tab must carry its id for the worker probe').toBeTruthy()
+      await expect
+        .poll(async () => (await inspectLastTabCloseViaAPI(
+          hubUrl,
+          adminToken,
+          workerId,
+          TabType.FILE,
+          fileTabId!,
+        )).shouldPrompt)
+        .toBe(true)
 
       // Now it IS the last tab, on a branch with uncommitted work.
       await fileTab.locator('[data-testid="tab-close"]').click()

--- a/frontend/tests/e2e/159-branch-context-menu.spec.ts
+++ b/frontend/tests/e2e/159-branch-context-menu.spec.ts
@@ -1,12 +1,24 @@
+import type { Page } from '@playwright/test'
+import { execSync } from 'node:child_process'
 import { existsSync, realpathSync } from 'node:fs'
 import { join } from 'node:path'
 import { expect, test } from './fixtures'
+import { createWorkspaceViaAPI, openAgentViaAPI } from './helpers/api'
+import { getRecordedToasts } from './helpers/toast'
 import { branchGroupRow, clickBranchMenuItem, loginViaToken, openBranchMenu, openWorkspace } from './helpers/ui'
 import {
   branchExists,
   createGitRepo,
   createWorkspaceWithWorktreeViaAPI,
+  expectRepoBranch,
+  waitForAgentStartupViaAPI,
 } from './helpers/worktree'
+
+/** ConfirmButton arms on the first click and fires on the second. */
+async function confirmDeleteBranch(page: Page) {
+  await page.getByRole('button', { name: 'Delete branch' }).click()
+  await page.getByRole('button', { name: 'Confirm?' }).click()
+}
 
 test.describe('Branch context menu', () => {
   test('three-dot menu opens with Change and Delete items', async ({
@@ -54,6 +66,13 @@ test.describe('Branch context menu', () => {
       'delete-branch',
     )
     expect(existsSync(worktreeDir)).toBe(true)
+    // `createWorkspaceWithWorktreeViaAPI` waits only for the worktree
+    // DIRECTORY. The worker writes the `worktree_tabs` row later, on the same
+    // async startup goroutine, and the REMOVE below reclaims the worktree only
+    // when the last row that references it goes. `waitForAgentStartupViaAPI`
+    // is what that helper's own comment prescribes for a test that closes a
+    // tab and expects a worktree effect.
+    await waitForAgentStartupViaAPI(hubUrl, adminToken, workerId, workspaceId)
 
     await loginViaToken(page, adminToken)
     await openWorkspace(page, workspaceId)
@@ -65,9 +84,7 @@ test.describe('Branch context menu', () => {
     // Worktree variant: dialog shows the worktree path.
     await expect(page.getByRole('dialog').getByText(/branch-delete-repo-worktrees\/delete-branch/)).toBeVisible()
 
-    // ConfirmButton arms on first click, fires on second.
-    await page.getByRole('button', { name: 'Delete branch' }).click()
-    await page.getByRole('button', { name: 'Confirm?' }).click()
+    await confirmDeleteBranch(page)
 
     // The dialog holds open under its busy overlay until the coupled tab
     // closes report back, then dismisses.
@@ -80,6 +97,69 @@ test.describe('Branch context menu', () => {
       expect(existsSync(worktreeDir)).toBe(false)
       expect(branchExists(repoDir, 'delete-branch')).toBe(false)
     }).toPass()
+  })
+
+  test('delete branch (in-place variant) relabels the sidebar without a reload', async ({
+    page,
+    leapmuxServer,
+  }) => {
+    const { hubUrl, adminToken, workerId, dataDir } = leapmuxServer
+    const repoDir = createGitRepo(dataDir, 'branch-delete-inplace-repo')
+    // A plain repo checked out on the doomed branch -- no worktree. That is
+    // what puts the dialog on its non-worktree path. The user picks a
+    // switch-to branch, and the worker then runs checkout and `git branch
+    // -D` in place. Every tab stays on the new branch.
+    // `createGitRepo` already persists `core.fsmonitor false` into this
+    // repo's config, so this command needs no `-c` override.
+    execSync('git checkout -b doomed-branch', { cwd: repoDir })
+
+    const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, 'Branch Delete In Place WS')
+    await openAgentViaAPI(hubUrl, adminToken, workerId, workspaceId, repoDir)
+    // Wait for the agent to leave STARTING before the browser subscribes.
+    // `activeTabReady` keys AppShell's git-status effect, so a STARTING to
+    // ACTIVE flip that lands AFTER the delete re-runs that effect and
+    // relabels the sidebar on its own -- which would let this test pass
+    // against the broken code. The ACTIVE broadcast also carries the git
+    // snapshot taken at phase 1, so a late one reverts the label to
+    // `doomed-branch` and would fail the test against the FIXED code. One
+    // wait closes both directions.
+    await waitForAgentStartupViaAPI(hubUrl, adminToken, workerId, workspaceId)
+
+    await loginViaToken(page, adminToken)
+    await openWorkspace(page, workspaceId)
+
+    await expect(branchGroupRow(page)).toContainText('doomed-branch')
+
+    await clickBranchMenuItem(page, branchGroupRow(page), 'Delete branch...')
+    await expect(page.getByRole('heading', { name: 'Delete branch' })).toBeVisible()
+
+    const dialog = page.getByRole('dialog')
+    await expect(dialog.getByText('Switch this working directory to:')).toBeVisible()
+    await dialog.getByRole('combobox').first().selectOption('main')
+
+    await confirmDeleteBranch(page)
+    await expect(page.getByRole('heading', { name: 'Delete branch' })).not.toBeVisible()
+
+    // The worker did the work.
+    await expectRepoBranch(repoDir, 'main')
+    expect(branchExists(repoDir, 'doomed-branch')).toBe(false)
+
+    // The regression this pins: the sidebar kept the DELETED branch's label
+    // (plus a warn toast) until the user reloaded the page. The dialog closed
+    // before it notified the shell. The callback then read the <Show> state
+    // that the close disposed, so the branch stamp and the git-status
+    // refresh never ran.
+    await expect(branchGroupRow(page)).toContainText('main')
+    await expect(branchGroupRow(page)).not.toContainText('doomed-branch')
+
+    // The broken path caught the throw and warned instead. The absence of
+    // that warning is the race-free half of this assertion, because the
+    // dialog raises it before `onClose`, which the wait above already
+    // covers.
+    const toasts = await getRecordedToasts(page)
+    expect(toasts.map(t => t.message)).not.toContain(
+      'Branch deleted, but failed to update the sidebar label',
+    )
   })
 
   test('change branch dialog opens in switch-to mode with all git options', async ({


### PR DESCRIPTION
## Motivation
Deleting a branch triggered two independent races that share one shape: state was read or torn down before the operation that should have gone first had finished.

On the frontend, every payload dialog in `AppShellDialogs` rendered under a non-keyed `<Show>`. A handler that called `onClose()` before notifying its parent disposed the `<Show>` subtree first, so the parent's later read of the now-disposed accessor threw solid-js's `"Stale read from <Show>."`. The dialog caught it and degraded to a warn toast, so the branch-label stamp and the git-status refresh never ran: the sidebar kept showing the deleted branch until a full page reload. Three sibling dialogs (workspace delete, workspace archive, key-pin confirm) carry the identical latent bug and were correct only by statement order — a stale read in either workspace confirm strands the promise `AppShell` awaits, and in key-pin confirm it blocks every later prompt for the page lifetime.

On the backend, the client emits a CRDT `TombstoneTab` before it sends the close RPC, over a separate transport. The hub nudges the worker's orphan reconciler the moment it applies that tombstone, so a reconcile pass landing in that window saw the tab as absent and reaped it immediately, deleting its `worktree_tabs` link. The real close then found no link and silently downgraded from `REMOVE` to `KEEP`, stranding the worktree directory with zero links — which excludes it from `ListOrphanCandidateWorktrees` permanently. Measured at 2-6 ms between the tombstone commit and the reap in a single-process `leapmux dev`, so machine load decided the outcome. This downgraded every online worktree-removing close, not only delete-branch.

## Modifications
- `AppShellDialogs.tsx`: every payload dialog except `lastTabConfirm` renders under a **keyed** `<Show>`, so its children callback receives the payload itself rather than a disposable accessor. That makes the stale-read class unrepresentable instead of merely absent for today's call order. `lastTabConfirm` stays non-keyed because it patches its payload in place, and keyed would remount its native `<dialog>` on every refresh.
- `createDialogState.ts` splits into `DialogState<T>` (open/close/value) and `UpdatableDialogState<T>` (adds `update`). Whether a payload changes in place is exactly what decides keyed versus non-keyed, so the rule now lives in the type system rather than a comment; a `@ts-expect-error` test fails the typecheck if `update` becomes reachable on the narrow handle.
- `DeleteBranchDialog.tsx`: both handlers call `props.onClose()` last, after the parent notify and the outcome toast. The custom footer's Cancel button now disables while the delete RPC is in flight — `Dialog`'s `busy` flag gates Escape, the backdrop and the X button, but never a custom footer button, so a mid-delete cancel dismissed the dialog while the RPC kept running and a later failure called `setError` on a disposed dialog, showing the user nothing.
- `orphan_reconciler.go`: an absent tab must stay continuously absent for `orphanTabGrace` (10 s) before any arm reaps it. A new `prevOrphanTabs` map mirrors the existing worktree-GC pattern, a new `reapDue` helper centralizes the check, and a reappearance resets the clock so flapping never accumulates into a reap. `reconcileOnce` reports `converged = false` while a reap is deferred, so `Run`'s retry backoff re-fires instead of waiting for the hourly tick.
- `ChangeBranchState`/`DeleteBranchState` extend a shared `RepoRef { workerId, gitToplevel }`; `onBranchChanged`, `handleBranchChanged`, `stampBranchOnTabs` and `isSameRepo` take one `RepoRef` instead of two positional strings. The two adjacent same-typed strings were transposable at every hop, and a transposition compiles and then matches nothing, so the branch stamp silently reached zero tabs.
- Extracted `placeWorkspaceInSection` from a 25-line closure inside a JSX prop. Its swallowed `.catch(() => {})` on the `moveWorkspace` RPC becomes a warn toast, matching the two sibling call sites that already warned.
- Four call sites now share `appendPosition` (new in `lexorank.ts`) instead of hand-duplicating the append-rank fold.
- New `gitBranchFixtures.ts` shares the branch-dialog fixtures; the second copy had already drifted and dropped the worktree conventions the original documented.
- Breaking changes: internal signatures only. Callers of `onBranchChanged`, `handleBranchChanged`, `stampBranchOnTabs` and `isSameRepo` pass a `RepoRef`; callers of `createDialogState(...).update()` switch to `createUpdatableDialogState`. `OrphanReconcilerOptions.TabGrace` is new and optional — its zero value keeps the default. Nothing externally facing changes.

## Result
- Deleting the checked-out branch in place relabels the sidebar and refreshes its git status immediately, with no reload and no warn toast.
- A worktree-removing close now actually removes the worktree instead of degrading to keep and stranding the directory with no link left to reclaim it.
- The Delete Branch dialog's Cancel is inert while a delete is in flight, so a failure can no longer be dismissed into silence.
- A workspace that fails to move into the section you clicked "+" in now says so instead of landing quietly in the default section.
- The workspace delete/archive and key-pin confirmations can no longer strand their promise if a future edit reorders their callback.
