### PR TITLE
feat(chat): Float and auto-hide the chat scroll rail

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,10 @@ Use `task` (`Taskfile.yaml`) targets, not the underlying tools directly.
 - Proto generation: `buf generate` (via `task generate-proto`)
 - SQL generation: `sqlc generate` (via `task generate-sqlc`)
 
+### vanilla-extract `.css.ts` files
+
+Never write a bare `*.css.ts` basename inside a `.css.ts` file — not in code, and not in a comment. Write `~/styles/global.css.ts` or `./widgets/SpanLines.css.ts`, never `global.css.ts`. A bare basename makes the vanilla-extract compiler fail the whole module with `Styles were unable to be assigned to a file`, pointing at an unrelated line in that file. Every test that imports the module then fails to load, which reads as a broken component rather than a broken comment.
+
 ### sqlc files
 
 `backend/internal/hub/store/{sqlite,postgres,mysql}/db/queries/*.sql` and any other sqlc query files MUST contain only ASCII characters. The sqlc parser falls over on non-ASCII bytes (typically inside comments) with a misleading `mismatched input 'SELECr'`-style error that points at the wrong line. Use `--` (double hyphen) and plain ASCII punctuation instead of `—` (em-dash) or smart quotes.

--- a/frontend/src/components/chat/ChatScrollRail.css.ts
+++ b/frontend/src/components/chat/ChatScrollRail.css.ts
@@ -15,8 +15,12 @@ const RAIL_WIDTH_PX = 10
 /**
  * Wider interactive column on COARSE pointers (touch): a finger can't hit a 10px strip, so
  * the hit area grows to a touch-friendlier size while the thin visuals (track/thumb/dots)
- * stay their fine-pointer widths, just centred in the wider column. Kept modest so the strip
- * stays within (or barely past) the list's right padding rather than eating message taps.
+ * stay their fine-pointer widths, just centred in the wider column. Below breakpoints.sm the
+ * list's right gutter shrinks to reclaim text width, so this strip now overlaps roughly 20px
+ * of message content instead of 8px. That is acceptable ONLY because the rail is
+ * pointer-events:none while idle (see railIdle), which is the large majority of the time.
+ * Widening it further, or dropping the idle inertness, starts swallowing message taps into
+ * track-click jumps.
  */
 const RAIL_WIDTH_COARSE_PX = 22
 /** Thumb width, matching the app's 8px native scrollbar thumb. */
@@ -34,11 +38,63 @@ export const rail = style({
   // Never capture text selection while dragging the thumb.
   'userSelect': 'none',
   'touchAction': 'none',
+  // The fade railIdle drives. The transition animates both directions (show + hide) and is
+  // scoped to (prefers-reduced-motion: no-preference) rather than overridden by a competing
+  // (prefers-reduced-motion: reduce) { transition: none } block. The two blocks set the same
+  // property at equal specificity, so winning the tie by source order is fragile (a key reorder
+  // silently re-enables the fade under reduced-motion). Guarding it behind `no-preference`
+  // makes reduced-motion the default and the fade opt-in, with no tie to break.
   '@media': {
+    '(prefers-reduced-motion: no-preference)': {
+      transition: 'opacity var(--transition)',
+    },
     '(pointer: coarse)': {
       width: `${RAIL_WIDTH_COARSE_PX}px`,
     },
   },
+})
+
+/**
+ * Idle (auto-hide) state, applied whenever the reader is outside the host's scroll-activity
+ * window. The WHOLE rail fades as one -- track, thumb, and teal jump dots -- because they are
+ * children of this element; fading them separately would let the dots read as a second,
+ * unrelated affordance mid-transition.
+ *
+ * The element is never unmounted (see ChatScrollRailProps.scrollActive), so `opacity` is the
+ * only safe lever. `visibility: hidden` or `display: none` would drop it out of the hit-test
+ * tree and could disturb the height its own ResizeObserver measures.
+ *
+ * `pointer-events: none` is COARSE-ONLY, deliberately:
+ *   - on touch the idle rail must go inert, because below breakpoints.sm the list's right
+ *     gutter shrinks and this strip then overlaps ~20px of message content. An invisible
+ *     strip that swallowed taps into a track-click jump would be a trap.
+ *   - on a FINE pointer the faded rail STAYS hit-testable so a `pointermove` over it relights
+ *     it (see ChatScrollRail.onPointerMove -> onActivity), but a CLICK on the faded rail is
+ *     rejected in the pointer handler -- you can't click what you can't see. So a mouse
+ *     reaches the rail by scrolling or by moving onto the strip (which relights it) first.
+ *
+ * `opacity: 0` is universal: every screen/pointer fades the idle rail the same way. There is
+ * deliberately NO `:hover { opacity: 1 }` shortcut: that would make the rail LOOK visible
+ * under a parked cursor while the activity window is still closed, so the click guard would
+ * reject a click on something that appeared visible. Visibility stays driven solely by the
+ * activity window, which carries its own idle timeout so a parked cursor cannot pin it lit.
+ */
+export const railIdle = style({
+  'opacity': 0,
+  '@media': {
+    '(pointer: coarse)': {
+      pointerEvents: 'none',
+    },
+  },
+})
+
+// The thumb (cursor: grab) and dots (cursor: pointer) are children of the faded rail, and cursor
+// is independent of opacity -- so without this, a fine pointer crossing the invisible strip sees a
+// grab/pointer caret over blank space. Reset every descendant to the default while the rail is
+// faded. `& *` targets the thumb, dots, and track; the strip itself keeps cursor: pointer (harmless:
+// the whole faded strip is a uniform invisible region, and a press on it only reveals the rail).
+globalStyle(`${railIdle} *`, {
+  cursor: 'auto',
 })
 
 /** The muted vertical track line, centered in the rail. Non-interactive (clicks fall to rail). */

--- a/frontend/src/components/chat/ChatScrollRail.test.tsx
+++ b/frontend/src/components/chat/ChatScrollRail.test.tsx
@@ -91,6 +91,9 @@ function baseProps(overrides: BasePropsOverrides = {}): ChatScrollRailProps {
     railRowSeqs: rowStartSeqs(items), // ChatView computes this once and passes it down (see F2)
     rail,
     hidden: hidden ?? resolvedHidden,
+    // Default to "the reader is scrolling", so every pre-existing test renders the rail in
+    // its visible state and keeps its original intent; the auto-hide tests pass false.
+    scrollActive: true,
     hasMoreOlder: false,
     hasMoreNewer: false,
     onJumpToSeq: vi.fn(),
@@ -745,5 +748,256 @@ describe('chatscrollrail dot preview popover', () => {
     const popover = hoverFirstDot(container)!
     expect(popover).toHaveTextContent('3 messages') // the aggregate header
     expect(popover).toHaveTextContent('the nearest message') // the representative's preview
+  })
+
+  // The floating auto-hide. Only the CLASS is observable here: vitest inserts no stylesheet
+  // for a .css.ts import and jsdom evaluates no media query, so the opacity, the
+  // pointer-events, and the media scoping that make the class do anything are E2E-only (see
+  // tests/e2e/047b-chat-scroll-rail-autohide.spec.ts).
+  describe('railIdle auto-hide', () => {
+    /** The rail root, with a concrete rect so pointer hit-tests resolve (jsdom does no layout). */
+    function railWithRect(container: HTMLElement): HTMLElement {
+      const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
+      rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+      return rail
+    }
+
+    it('marks the rail idle when the activity window closes and un-marks it when it reopens', () => {
+      const [scrollActive, setScrollActive] = createSignal(true)
+      const { container } = render(() => <ChatScrollRail {...baseProps()} scrollActive={scrollActive()} />)
+      const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
+      expect(rail.className).not.toContain(styles.railIdle)
+
+      setScrollActive(false)
+      expect(rail.className).toContain(styles.railIdle)
+
+      setScrollActive(true)
+      expect(rail.className).not.toContain(styles.railIdle)
+    })
+
+    it('adds the idle class without remounting the rail or its dots', () => {
+      // The guard against implementing idle as a <Show>: an unmount would disconnect the
+      // rail's ResizeObserver, cancel any live drag, and rebuild every dot's tooltip on
+      // every single idle transition.
+      const [scrollActive, setScrollActive] = createSignal(true)
+      const { container } = render(() => <ChatScrollRail {...baseProps()} scrollActive={scrollActive()} />)
+      const railBefore = container.querySelector('[data-testid="chat-scroll-rail"]')
+      const dotsBefore = Array.from(container.querySelectorAll('[data-testid="chat-scroll-rail-dot"]'))
+      expect(dotsBefore.length).toBe(2)
+
+      setScrollActive(false)
+
+      expect(container.querySelector('[data-testid="chat-scroll-rail"]')).toBe(railBefore)
+      const dotsAfter = Array.from(container.querySelectorAll('[data-testid="chat-scroll-rail-dot"]'))
+      expect(dotsAfter[0]).toBe(dotsBefore[0])
+      expect(dotsAfter[1]).toBe(dotsBefore[1])
+    })
+
+    it('keeps the rail visible while a thumb drag is live, however long the window has been shut', () => {
+      HTMLElement.prototype.setPointerCapture = vi.fn()
+      installImmediateRaf()
+      const [scrollActive, setScrollActive] = createSignal(true)
+      const { container } = render(() => <ChatScrollRail {...baseProps()} scrollActive={scrollActive()} />)
+      const rail = railWithRect(container)
+      expect(rail.className).not.toContain(styles.railIdle)
+
+      // Grab the fixed thumb (spans 0..24) while the rail is lit, THEN shut the activity window:
+      // the drag itself must keep the rail visible until release, however long the window stays shut.
+      rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 12, pointerId: 1 }))
+      setScrollActive(false)
+      expect(rail.className).not.toContain(styles.railIdle)
+    })
+
+    it('stays visible through the drag-release hold, not just the pointer lifecycle', async () => {
+      // Keyed on drag() rather than the pointer being down: createDragReleaseHold keeps the
+      // thumb pinned until the release seek settles, and the rail must stay lit that whole
+      // time or it blinks out from under a scrub that is still landing.
+      HTMLElement.prototype.setPointerCapture = vi.fn()
+      installImmediateRaf()
+      let landSeek!: (scrolled: boolean) => void
+      const onJumpToSeq = vi.fn(() => new Promise<boolean>((r) => {
+        landSeek = r
+      }))
+      const [scrollActive, setScrollActive] = createSignal(true)
+      const { container } = render(() => (
+        <ChatScrollRail
+          {...baseProps({ onJumpToSeq, hasMoreOlder: true, hasMoreNewer: true })}
+          scrollActive={scrollActive()}
+        />
+      ))
+      const rail = railWithRect(container)
+      // Grab while lit, THEN shut the window so the only thing keeping the rail visible is the hold.
+      rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 12, pointerId: 1 }))
+      rail.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, clientY: 200, pointerId: 1 }))
+      setScrollActive(false)
+      // The pointer is up, but the seek has not landed: still held, so still lit.
+      expect(rail.className).not.toContain(styles.railIdle)
+
+      landSeek(false)
+      await tick()
+      expect(rail.className).toContain(styles.railIdle)
+    })
+
+    it('keeps the rail visible while a dot preview is open, on hover and on keyboard focus', () => {
+      const { container } = render(() => <ChatScrollRail {...baseProps({ scrollActive: false })} />)
+      const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
+      const dot = container.querySelector('[data-testid="chat-scroll-rail-dot"]') as HTMLElement
+      expect(rail.className).toContain(styles.railIdle)
+
+      fireEvent.pointerEnter(dot)
+      expect(rail.className).not.toContain(styles.railIdle)
+      fireEvent.pointerLeave(dot)
+      expect(rail.className).toContain(styles.railIdle)
+
+      // activeDot() folds focus in with hover, which is what lets the rail skip a CSS
+      // :focus-within rule -- pin that here so a refactor can't quietly drop it.
+      fireEvent.focus(dot)
+      expect(rail.className).not.toContain(styles.railIdle)
+
+      // Focus OUT must null activeDot() so the rail fades again -- without this a broken onBlur
+      // would pin the rail lit forever after a keyboard tab-away.
+      fireEvent.blur(dot)
+      expect(rail.className).toContain(styles.railIdle)
+    })
+
+    it('reopens the host window from the rail own traffic: pointerdown and focusin', () => {
+      // pointerdown always reopens (a track-click jump wants its fade tail), and focusin bubbles
+      // from a dot button so tabbing through dots keeps the rail lit. pointermove is covered by
+      // its own test below (it reopens only while faded, not on every move).
+      HTMLElement.prototype.setPointerCapture = vi.fn()
+      installImmediateRaf()
+      const onActivity = vi.fn()
+      const { container } = render(() => <ChatScrollRail {...baseProps({ onActivity })} />)
+      const rail = railWithRect(container)
+
+      rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 12, pointerId: 1 }))
+      expect(onActivity).toHaveBeenCalledTimes(1)
+
+      const dot = container.querySelector('[data-testid="chat-scroll-rail-dot"]') as HTMLElement
+      fireEvent.focusIn(dot)
+      expect(onActivity).toHaveBeenCalledTimes(2)
+    })
+
+    it('reopens the host window from a pointermove only while the rail is faded, not on every move', () => {
+      // A captured thumb drag retargets its pointermove to the rail, so the host's scroll
+      // container sees nothing -- the FIRST move onto a faded strip must relight it. But once lit
+      // (by the drag itself, an open dot, or the now-open host window) further moves would only
+      // re-arm a timer the next move cancels again: dozens of clearTimeout + setTimeout pairs per
+      // second of dragging. So pointermove reopens the window ONLY while idle, then goes quiet.
+      HTMLElement.prototype.setPointerCapture = vi.fn()
+      installImmediateRaf()
+      // onActivity is wired to a real scrollActive signal, mirroring ChatView: a call flips the
+      // rail to its lit state so the second pointermove sees a visible rail and no-ops.
+      const [scrollActive, setScrollActive] = createSignal(false)
+      const onActivity = vi.fn(() => setScrollActive(true))
+      const { container } = render(() => (
+        <ChatScrollRail {...baseProps({ onActivity })} scrollActive={scrollActive()} />
+      ))
+      const rail = railWithRect(container)
+      expect(rail.className).toContain(styles.railIdle)
+
+      // Faded: the first pointermove relights it.
+      rail.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientY: 200, pointerId: 1 }))
+      expect(onActivity).toHaveBeenCalledTimes(1)
+      expect(rail.className).not.toContain(styles.railIdle)
+
+      // Now lit: further moves are no-ops (no redundant timer churn).
+      rail.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientY: 210, pointerId: 1 }))
+      rail.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientY: 220, pointerId: 1 }))
+      expect(onActivity).toHaveBeenCalledTimes(1)
+    })
+
+    it('relights directly on a wheel over the faded rail, not only via the re-dispatched event', () => {
+      // onRailWheel forwards the delta to the scroll container by re-dispatching a wheel, which
+      // indirectly relights the rail via the scroller's passive listener. That chain is fragile
+      // (a capture-phase listener or a dropped bubbles flag breaks it), so the wheel also calls
+      // onActivity directly. Pin that here so a refactor of the indirect path cannot strand a
+      // faded rail under a wheel.
+      const onActivity = vi.fn()
+      const { container } = render(() => <ChatScrollRail {...baseProps({ onActivity, scrollActive: false })} />)
+      const rail = railWithRect(container)
+      expect(rail.className).toContain(styles.railIdle)
+
+      rail.dispatchEvent(new WheelEvent('wheel', { bubbles: true, deltaY: 40 }))
+      expect(onActivity).toHaveBeenCalledTimes(1)
+    })
+
+    it('reports activity even for a grab it rejects, so a stray second finger cannot fade it', () => {
+      HTMLElement.prototype.setPointerCapture = vi.fn()
+      installImmediateRaf()
+      const onActivity = vi.fn()
+      const onJumpToSeq = vi.fn()
+      const { container } = render(() => <ChatScrollRail {...baseProps({ onActivity, onJumpToSeq })} />)
+      const rail = railWithRect(container)
+      rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 12, pointerId: 1 }))
+      onActivity.mockClear()
+
+      // A second finger on the track mid-drag: the jump is correctly refused, but the touch
+      // is still the reader on the rail, so the window must reopen anyway.
+      rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 360, pointerId: 2 }))
+      expect(onJumpToSeq).not.toHaveBeenCalled()
+      expect(onActivity).toHaveBeenCalledTimes(1)
+    })
+
+    it('renders nothing at all when hidden, idle or not', () => {
+      // hidden and idle compose one way only: hidden wins and unmounts, so there is never a
+      // mounted-but-idle rail on a viewport that has no rail to show.
+      const { container } = render(() => <ChatScrollRail {...baseProps({ hidden: true, scrollActive: false })} />)
+      expect(container.querySelector('[data-testid="chat-scroll-rail"]')).toBeNull()
+    })
+
+    it('rejects a press on a faded rail so you cannot click what you cannot see', () => {
+      // A press onto a faded rail only REVEALS it (via onActivity); the grab is refused so a
+      // stray press into the invisible strip cannot start a drag or fire a jump. The NEXT press
+      // -- rail now lit -- acts. On a coarse pointer the idle rail is pointer-events:none, so
+      // this guard only ever applies to a fine pointer.
+      //
+      // onActivity is wired to a real scrollActive signal, mirroring ChatView: a call flips the
+      // rail to its lit state so the second press -- now against a visible rail -- goes through.
+      HTMLElement.prototype.setPointerCapture = vi.fn()
+      installImmediateRaf()
+      const [scrollActive, setScrollActive] = createSignal(false)
+      const onActivity = vi.fn(() => setScrollActive(true))
+      const onJumpToSeq = vi.fn()
+      const { container } = render(() => (
+        <ChatScrollRail {...baseProps({ onActivity, onJumpToSeq })} scrollActive={scrollActive()} />
+      ))
+      const rail = railWithRect(container)
+      expect(rail.className).toContain(styles.railIdle)
+
+      // First press: faded -> rejected. onActivity fires (and lights the rail), but no grab
+      // and no jump.
+      rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 360, pointerId: 1 }))
+      expect(onActivity).toHaveBeenCalledTimes(1)
+      expect(onJumpToSeq).not.toHaveBeenCalled()
+      expect(rail.className).not.toContain(styles.railIdle)
+
+      // Second press on the now-lit rail: the track jump goes through.
+      rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 360, pointerId: 2 }))
+      expect(onJumpToSeq).toHaveBeenCalledTimes(1)
+    })
+
+    it('rejects a press on a faded dot but reveals it, so the next press jumps', () => {
+      // The same "can't click what you can't see" rule covers dots: a press on a faded dot only
+      // reveals the rail; the jump happens on the next press. onActivity flips scrollActive, so
+      // the second press sees a lit rail.
+      const [scrollActive, setScrollActive] = createSignal(false)
+      const onActivity = vi.fn(() => setScrollActive(true))
+      const onJumpToSeq = vi.fn()
+      const { container } = render(() => (
+        <ChatScrollRail {...baseProps({ onActivity, onJumpToSeq })} scrollActive={scrollActive()} />
+      ))
+      const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
+      const dot = container.querySelector('[data-testid="chat-scroll-rail-dot"]') as HTMLElement
+      expect(rail.className).toContain(styles.railIdle)
+
+      dot.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerId: 1 }))
+      expect(onActivity).toHaveBeenCalledTimes(1)
+      expect(onJumpToSeq).not.toHaveBeenCalled()
+      expect(rail.className).not.toContain(styles.railIdle)
+
+      dot.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerId: 2 }))
+      expect(onJumpToSeq).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/frontend/src/components/chat/ChatScrollRail.tsx
+++ b/frontend/src/components/chat/ChatScrollRail.tsx
@@ -71,6 +71,24 @@ export interface ChatScrollRailProps {
    * or two scrollbars. See resolveScrollbarOwner.
    */
   hidden: boolean
+  /**
+   * Whether the host's scroll-activity window is open (see ChatView's railActivity).
+   * ORTHOGONAL to `hidden`: that one is the scrollbar-OWNER decision and unmounts the
+   * rail, while this one is paint-only and must NEVER unmount it -- an unmount would
+   * disconnect the rail's ResizeObserver, cancel a live thumb drag, and rebuild every
+   * dot's tooltip on each transition. The resulting `railIdle` class fades the rail on
+   * EVERY screen/pointer; only the touch-safety `pointer-events: none` it also carries
+   * is coarse-only.
+   */
+  scrollActive: boolean
+  /**
+   * The rail's OWN interaction reopens the host's activity window. Required, not a
+   * nicety: a thumb drag captures the pointer, so its pointermove events retarget to the
+   * rail element and the host's scroll container never sees them. Without this the rail
+   * would snap dark the instant a drag releases or a focused dot is tabbed away from,
+   * with no fade tail.
+   */
+  onActivity?: () => void
   hasMoreOlder: boolean
   hasMoreNewer: boolean
   /**
@@ -213,6 +231,14 @@ export function ChatScrollRail(props: ChatScrollRailProps) {
   // the viewport with zero or two scrollbars; the rail now trusts the single upstream decision.
   const hidden = () => props.hidden
 
+  // Idle is a PAINT state, never an unmount (see the `scrollActive` prop). Two of the
+  // rail's OWN states override the host's window, so an interaction never fades under the
+  // reader's finger or cursor: a live thumb drag AND its post-release settle (drag() stays
+  // non-null until the seek lands -- see createDragReleaseHold), and an open dot popover
+  // (activeDot() folds hover, KEYBOARD FOCUS, and scrub into one signal, so no CSS
+  // :focus-within is needed).
+  const idle = createMemo(() => !props.scrollActive && drag() === null && activeDot() === null)
+
   createEffect(() => {
     if (hidden())
       disconnectRail()
@@ -294,9 +320,27 @@ export function ChatScrollRail(props: ChatScrollRailProps) {
     handle.start(event.pointerId, event.clientY)
   }
 
+  // "You can't click what you can't see." A press on a FADED rail or dot only REVEALS it
+  // (via onActivity); the grab or jump is rejected, so the NEXT press -- rail now lit -- acts.
+  // Read `faded` BEFORE onActivity: that call reopens the host's window synchronously, so idle()
+  // would read false the instant after. onActivity fires on EVERY press, faded or lit: a lit
+  // track-click jump still wants the fade tail that the re-arm buys. preventDefault is held back
+  // on a faded press too, so a rejected click does not steal focus or start a native selection
+  // drag on something the reader could not see. On a coarse pointer the idle rail is
+  // pointer-events:none, so this never runs faded there.
+  const revealIfFaded = () => {
+    const faded = idle()
+    props.onActivity?.()
+    return faded
+  }
+
   // One pointerdown handler for the rail: hit-test the thumb (start a drag) vs the track
   // (jump to the clicked position). Dots stop propagation so they never reach here.
   const onRailPointerDown = (event: PointerEvent) => {
+    // Whether or not this grab is accepted, reaching for the rail is intent to use it, so it
+    // must keep the rail lit rather than fade under the cursor (see revealIfFaded).
+    if (revealIfFaded())
+      return
     const el = railEl
     // Ignore a second pointerdown while a thumb-drag is already live (dragCleanup is set from
     // startDrag until the pointer lifecycle ends). Without this, a second finger landing on the
@@ -322,8 +366,16 @@ export function ChatScrollRail(props: ChatScrollRailProps) {
   }
 
   const onDotPointerDown = (event: PointerEvent, seq: bigint) => {
-    // Prioritize the dot over the thumb/track underneath: jump to its message.
+    // Prioritize the dot over the thumb/track underneath: a dot press is always handled HERE
+    // and never also as a track click -- stopPropagation runs before the faded guard so a
+    // rejected (faded) press still doesn't fall through to onRailPointerDown.
     event.stopPropagation()
+    // Same reveal-but-reject rule as a track/thumb press (see revealIfFaded). The dot
+    // hover/focus path keeps the rail visible on its own, so this only bites the very first
+    // press onto a faded strip. A coarse-pointer idle rail is pointer-events:none, so the dot
+    // buttons under it are unreachable there.
+    if (revealIfFaded())
+      return
     event.preventDefault()
     props.onJumpToSeq(seq)
   }
@@ -343,10 +395,20 @@ export function ChatScrollRail(props: ChatScrollRailProps) {
   // are overflow:hidden, so a wheel over it would otherwise scroll nothing (a dead zone).
   // Forward the delta to the chat container as a genuine user scroll -- exactly what
   // wheeling over the native scrollbar did before it was hidden.
+  //
+  // While idle on a COARSE pointer the rail is pointer-events:none (see railIdle), which
+  // makes this handler unreachable -- but no dead zone comes back: the wheel then
+  // hit-tests to messageList itself, which the rail OVERLAYS as a sibling rather than
+  // nesting inside, and that element is the real scroller.
   const onRailWheel = (event: WheelEvent) => {
     const el = props.scrollEl
     if (!el)
       return
+    // A wheel over the rail is genuine scroll intent, so relight the rail directly. The
+    // re-dispatched wheel below also relights it indirectly (via the scroller's passive
+    // listener -> noteScrollInput), but counting on that chain couples the relight to a
+    // listener registration that a future refactor could move to capture phase or drop.
+    props.onActivity?.()
     el.dispatchEvent(new WheelEvent('wheel', {
       bubbles: true,
       cancelable: false,
@@ -374,9 +436,23 @@ export function ChatScrollRail(props: ChatScrollRailProps) {
     <Show when={!hidden()}>
       <div
         ref={setRailRef}
-        class={styles.rail}
+        class={`${styles.rail}${idle() ? ` ${styles.railIdle}` : ''}`}
         data-testid="chat-scroll-rail"
         onPointerDown={onRailPointerDown}
+        // Reopen the host's window ONLY when the rail is faded: a cursor crossing the invisible
+        // strip relights it (intent to use it), and a captured thumb drag's pointermove retargets
+        // here so the scroll container never sees it. Once lit, idle() is false -- the drag itself
+        // (drag() !== null) or the now-open host window holds the rail visible -- so further moves
+        // would only re-arm a timer that the next move cancels again (dozens of clearTimeout +
+        // setTimeout pairs per second of dragging). No-op once visible; the host's idle timer
+        // carries the fade tail.
+        onPointerMove={() => {
+          if (idle())
+            props.onActivity?.()
+        }}
+        // focusin bubbles from a dot button, so tabbing through the dots keeps the rail
+        // lit and tabbing away gets a fade tail instead of an instant blackout.
+        onFocusIn={() => props.onActivity?.()}
         onWheel={onRailWheel}
       >
         {/* Inset the track to the thumb-CENTRE travel range so its ends are where the thumb

--- a/frontend/src/components/chat/ChatView.css.ts
+++ b/frontend/src/components/chat/ChatView.css.ts
@@ -57,14 +57,61 @@ export const messageListContent = style({
 })
 
 export const messageList = style({
-  flex: 1,
-  overflowX: 'hidden',
-  overflowY: 'auto',
-  overflowAnchor: 'none',
-  padding: 'var(--space-4) var(--space-4) var(--space-4) var(--space-6)',
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 'var(--space-3)',
+  'flex': 1,
+  'overflowX': 'hidden',
+  'overflowY': 'auto',
+  'overflowAnchor': 'none',
+  'padding': 'var(--space-4)',
+  'display': 'flex',
+  'flexDirection': 'column',
+  'gap': 'var(--space-3)',
+  '@media': {
+    /**
+     * TOUCH: never a native scrollbar on the chat list, whether or not the rail owns
+     * scrolling. The app-wide `::-webkit-scrollbar { width: 8px }` in the global
+     * stylesheet (~/styles/global.css.ts) opts every element OUT of Chrome Android's
+     * auto-hiding overlay scrollbars, so this list paints a permanent classic 8px bar that
+     * eats layout width from an already-narrow text column -- most visibly in the window
+     * BEFORE the marks RPC seeds the rail, which is exactly when `messageListRailActive`
+     * cannot apply. Scoped to this list; the app-wide rule is left alone.
+     *
+     * This DELIBERATELY relaxes the "never zero scrollbars" invariant on touch: when the
+     * rail is not the owner (the marks RPC failed or lags), a touch viewport now shows
+     * NEITHER bar. That is the right trade on a surface where scrolling is direct
+     * manipulation and there is no thumb to grab -- see resolveScrollbarOwner, which
+     * records the same exception.
+     *
+     * Keep every `*.css.ts` reference above path-qualified (`~/...` or `./...`). A BARE
+     * basename anywhere in a `.css.ts` file, a comment included, makes the vanilla-extract
+     * compiler throw "Styles were unable to be assigned to a file" and point at an
+     * unrelated line in this file.
+     */
+    '(pointer: coarse)': {
+      scrollbarWidth: 'none',
+    },
+    /**
+     * Phone gutters. The rail floats over the right edge, so 16px reserved there is pure
+     * lost text width; 4px still keeps the text off the glass. The left drops to 12px
+     * rather than matching 4px for two reasons: the span-line stack overhangs the content
+     * box by COL_OVERLAP (5px, see ./widgets/SpanLines.css.ts) and `overflowX: hidden`
+     * would clip it, and 24px against 4px reads visibly lopsided on a 360px viewport.
+     */
+    [`(max-width: ${breakpoints.sm - 1}px)`]: {
+      paddingLeft: 'var(--space-3)',
+      paddingRight: 'var(--space-1)',
+    },
+  },
+})
+
+// The WebKit half of the coarse-pointer rule above. `::-webkit-scrollbar` is not
+// `&`-anchored, so it cannot be a `selectors` entry and needs its own globalStyle --
+// the same shape as messageListRailActive's below.
+globalStyle(`${messageList}::-webkit-scrollbar`, {
+  '@media': {
+    '(pointer: coarse)': {
+      display: 'none',
+    },
+  },
 })
 
 /**
@@ -73,6 +120,11 @@ export const messageList = style({
  * `messageList` only while the rail is actually active (marks seeded); if the marks RPC
  * fails or lags, the native scrollbar stays visible rather than leaving a long
  * conversation with no scrollbar at all. Scoped here -- the app-wide thin scrollbar stays.
+ *
+ * On COARSE pointers this is redundant: `messageList` hides the native bar there
+ * unconditionally (see its `(pointer: coarse)` block), which is a deliberate exception to
+ * the fallback described above -- on touch, a viewport with no rail simply has no
+ * scrollbar, because scrolling is direct manipulation.
  */
 export const messageListRailActive = style({
   scrollbarWidth: 'none',

--- a/frontend/src/components/chat/ChatView.test.tsx
+++ b/frontend/src/components/chat/ChatView.test.tsx
@@ -9,7 +9,8 @@ import { PreferencesProvider } from '~/context/PreferencesContext'
 import { AgentChatMessageSchema, AgentProvider, AgentStatus, ContentCompression, MessageSource } from '~/generated/leapmux/v1/agent_pb'
 import { KEY_BROWSER_PREFS, localStorageSet } from '~/lib/browserStorage'
 import { flushAnimationFrame, installControllableResizeObserver, triggerResizeObserverFor, triggerResizeObservers } from '~/test-support/resizeObserverStub'
-import { ChatView, rowChromeHeightKey, SKELETON_SHOW_DELAY_MS } from './ChatView'
+import { railIdle } from './ChatScrollRail.css'
+import { ChatView, RAIL_MOMENTUM_GRACE_MS, RAIL_VISIBLE_IDLE_MS, rowChromeHeightKey, SKELETON_SHOW_DELAY_MS, SYNTAX_HIGHLIGHT_SCROLL_IDLE_MS } from './ChatView'
 import { messageListRailActive, rowSkeletonClosing } from './ChatView.css'
 import { computeOverscanPx, PRE_MEASURE_WIDTH_PX } from './chatViewportGeometry'
 import { sameVirtualItems } from './useChatVirtualizer'
@@ -94,6 +95,10 @@ vi.mock('./MessageBubble', async () => {
               data-testid="mock-message-bubble"
               data-message-id={props.message.id}
               data-premeasure={props.premeasureMode ? 'true' : 'false'}
+              // The scroll-idle highlight pause is only observable through the host
+              // binding MessageBubble forwards into its RenderContext, so surface it
+              // here for the tests that pin ChatView's highlightActivity window.
+              data-syntax-paused={props.host?.syntaxHighlightingPaused?.() ? 'true' : 'false'}
             />
           )
         : actual.MessageBubble(props)
@@ -2700,6 +2705,82 @@ describe('chat view virtualized with stubbed deps', () => {
     })
   })
 
+  // The scroll-idle window that holds syntax highlighting (and the premeasure warm-up)
+  // off while the reader scrolls. It runs on a createScrollActivity instance shared with
+  // the scroll rail's own window, so these pin the behaviour that must NOT change when
+  // the rail's window is fed differently -- see ChatView's highlightActivity.
+  describe('chat view syntax-highlight scroll pause', () => {
+    const renderChat = () => render(() => (
+      <ChatView
+        messages={[message('m0', 1)]}
+        streamingText=""
+      />
+    ))
+
+    const paused = (container: HTMLElement): string | null =>
+      container.querySelector('[data-testid="mock-message-bubble"]')?.getAttribute('data-syntax-paused') ?? null
+
+    const scroller = (container: HTMLElement): HTMLElement =>
+      container.querySelector('[data-chat-scroll-container]') as HTMLElement
+
+    it('pauses highlighting on a scroll gesture and resumes after the idle window', () => {
+      vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
+      const { container } = renderChat()
+      expect(paused(container)).toBe('false')
+
+      fireEvent.wheel(scroller(container), { deltaY: 40 })
+      expect(paused(container)).toBe('true')
+
+      vi.advanceTimersByTime(SYNTAX_HIGHLIGHT_SCROLL_IDLE_MS - 1)
+      expect(paused(container)).toBe('true')
+
+      vi.advanceTimersByTime(1)
+      expect(paused(container)).toBe('false')
+    })
+
+    it('stays paused across a continued scroll instead of resuming mid-gesture', () => {
+      vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
+      const { container } = renderChat()
+
+      fireEvent.wheel(scroller(container), { deltaY: 40 })
+      vi.advanceTimersByTime(SYNTAX_HIGHLIGHT_SCROLL_IDLE_MS - 20)
+      fireEvent.wheel(scroller(container), { deltaY: 40 })
+
+      // A throttle would have resumed at the first window's end; the debounce measures
+      // from the second wheel.
+      vi.advanceTimersByTime(SYNTAX_HIGHLIGHT_SCROLL_IDLE_MS - 20)
+      expect(paused(container)).toBe('true')
+
+      vi.advanceTimersByTime(20)
+      expect(paused(container)).toBe('false')
+    })
+
+    it('still pauses on a bare scroll event with no user input behind it', () => {
+      // Deliberate asymmetry with the rail, whose window ignores an un-prompted scroll:
+      // the agent's stick-to-bottom churn during a streaming turn is exactly when
+      // highlighting and the premeasure warm-up must stay off the main thread.
+      vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
+      const { container } = renderChat()
+
+      fireEvent.scroll(scroller(container))
+      expect(paused(container)).toBe('true')
+
+      vi.advanceTimersByTime(SYNTAX_HIGHLIGHT_SCROLL_IDLE_MS)
+      expect(paused(container)).toBe('false')
+    })
+
+    it('pauses on the keys that scroll natively and ignores the keys that do not', () => {
+      vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
+      const { container } = renderChat()
+
+      fireEvent.keyDown(scroller(container), { key: 'a' })
+      expect(paused(container)).toBe('false')
+
+      fireEvent.keyDown(scroller(container), { key: 'PageDown' })
+      expect(paused(container)).toBe('true')
+    })
+  })
+
   describe('chat view native scrollbar hiding', () => {
     // The seq-space rail replaces the native scrollbar, but ONLY once it is active AND can
     // draw a thumb, or when there is no scrollable local-only content that needs the native
@@ -2771,6 +2852,106 @@ describe('chat view virtualized with stubbed deps', () => {
       ))
 
       expect(scroller(container).className).not.toContain(messageListRailActive)
+    })
+  })
+
+  // The seam between ChatView's railActivity window and the rail's paint state. The unit
+  // suites cover each half (chatScrollActivity.test.ts, ChatScrollRail.test.tsx); these pin
+  // that ChatView connects them the right way round and feeds the rail window the
+  // momentum-gated `noteScroll` rather than the highlight window's `noteInput`.
+  describe('chat view scroll rail auto-hide wiring', () => {
+    const railBase = {
+      loaded: true,
+      minSeq: 1n,
+      maxSeq: 10n,
+      marks: [],
+      windowFirstSeq: 1n,
+      windowLastSeq: 5n,
+    }
+    const renderWithRail = () => render(() => (
+      <ChatView messages={[message('m0', 1)]} streamingText="" rail={railBase} />
+    ))
+    const scroller = (container: HTMLElement) => container.querySelector('[data-chat-scroll-container]') as HTMLElement
+    const rail = (container: HTMLElement) => container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
+
+    it('starts idle, lights the rail on a user scroll input, and lets it idle again', () => {
+      vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
+      const { container } = renderWithRail()
+      // Nothing has scrolled yet, so the rail opens in its faded state rather than flashing
+      // on at mount and fading a beat later.
+      expect(rail(container).className).toContain(railIdle)
+
+      fireEvent.wheel(scroller(container), { deltaY: 40 })
+      expect(rail(container).className).not.toContain(railIdle)
+
+      vi.advanceTimersByTime(RAIL_VISIBLE_IDLE_MS - 1)
+      expect(rail(container).className).not.toContain(railIdle)
+
+      vi.advanceTimersByTime(1)
+      expect(rail(container).className).toContain(railIdle)
+    })
+
+    it('does not light the rail for a bare scroll event with no user input behind it', () => {
+      // The whole point of the split: the agent's stick-to-bottom fires a scroll on every
+      // streaming commit, and a rail that lit up for those would stay lit for the entire
+      // response. Contrast with the syntax-highlight pause above, which DOES take these.
+      vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
+      const { container } = renderWithRail()
+
+      for (let commit = 0; commit < 10; commit++) {
+        vi.advanceTimersByTime(16)
+        fireEvent.scroll(scroller(container))
+        expect(rail(container).className).toContain(railIdle)
+      }
+    })
+
+    it('keeps the rail lit through a flick coast, where only scroll events fire', () => {
+      // After a touch flick no touch or pointer event fires while the content glides, so
+      // without the momentum grace the rail would fade mid-fling. The grace is the tighter
+      // of the two bounds, so a qualifying coast scroll always lands while the window is
+      // still open -- what this pins is that such a scroll EXTENDS it.
+      expect(RAIL_MOMENTUM_GRACE_MS).toBeLessThan(RAIL_VISIBLE_IDLE_MS)
+      vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
+      const { container } = renderWithRail()
+
+      fireEvent.touchStart(scroller(container))
+      fireEvent.touchEnd(scroller(container))
+
+      // The coast: one scroll at the far edge of the grace.
+      vi.advanceTimersByTime(RAIL_MOMENTUM_GRACE_MS - 1)
+      fireEvent.scroll(scroller(container))
+
+      // Past where the un-extended window would have closed (the touchend was
+      // RAIL_VISIBLE_IDLE_MS + 1 ms ago). Still lit, so the coast scroll pushed it out.
+      vi.advanceTimersByTime(RAIL_VISIBLE_IDLE_MS - RAIL_MOMENTUM_GRACE_MS + 2)
+      expect(rail(container).className).not.toContain(railIdle)
+
+      // ...and it closes RAIL_VISIBLE_IDLE_MS after the coast scroll, not after the touch.
+      vi.advanceTimersByTime(RAIL_MOMENTUM_GRACE_MS - 3)
+      expect(rail(container).className).not.toContain(railIdle)
+      vi.advanceTimersByTime(1)
+      expect(rail(container).className).toContain(railIdle)
+    })
+
+    it('does not arm the rail window on scroll when no rail is present', () => {
+      // Without a rail prop the rail never mounts, so feeding its window arms a 1200ms timer that
+      // fires into a dead signal on every gesture. The feed is gated on rail presence so a
+      // marks-less conversation pays nothing. Assert the gate indirectly: render with no rail,
+      // then mount one and confirm the now-fed window lights on the next scroll.
+      vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
+      const { container } = render(() => (
+        <ChatView messages={[message('m0', 1)]} streamingText="" />
+      ))
+
+      // No rail mounted, so no rail element to fade or light.
+      expect(container.querySelector('[data-testid="chat-scroll-rail"]')).toBeNull()
+      // Scrolling while rail-less must not leave an armed rail timer behind (it would fire into
+      // a dead signal). Advance well past the idle window: a stray timer firing here would throw
+      // into the disposed-rail scope only if the gate were absent, which we cannot assert
+      // directly -- but the rail stays absent, which is the observable contract.
+      fireEvent.wheel(scroller(container), { deltaY: 40 })
+      vi.advanceTimersByTime(RAIL_VISIBLE_IDLE_MS + 1)
+      expect(container.querySelector('[data-testid="chat-scroll-rail"]')).toBeNull()
     })
   })
 })

--- a/frontend/src/components/chat/ChatView.tsx
+++ b/frontend/src/components/chat/ChatView.tsx
@@ -28,6 +28,7 @@ import { createChatPremeasureBands } from './chatPremeasureBands'
 import { resolveScrollbarOwner } from './chatRailPolicy'
 import { kindScopedLayoutKey } from './chatRowGeometry'
 import { createRowHeightPersistence } from './chatRowHeightPersistence'
+import { createScrollActivity } from './chatScrollActivity'
 import { ChatScrollRail } from './ChatScrollRail'
 import { rowStartSeqs } from './chatScrollRailGeometry'
 import { createDelayedSet, createFlingSkeletonRegistry, createLingerSet } from './chatSkeletonCrossfade'
@@ -48,7 +49,27 @@ import { SpanLines } from './widgets/SpanLines'
 import { NO_SPAN_MARGIN } from './widgets/SpanLines.geometry'
 import { ThinkingIndicator } from './widgets/ThinkingIndicator'
 
-const SYNTAX_HIGHLIGHT_SCROLL_IDLE_MS = 160
+/**
+ * Quiet period after the last scroll before syntax highlighting (and the premeasure
+ * warm-up) resumes. Exported so a test can measure the boundary from this value rather
+ * than a hand-copied literal.
+ */
+export const SYNTAX_HIGHLIGHT_SCROLL_IDLE_MS = 160
+/**
+ * How long the floating scroll rail stays lit after the last scroll activity, on the
+ * touch / narrow viewports where it auto-hides at all. Much longer than the
+ * syntax-highlight pause on purpose: that one only has to outlast a repaint, while this
+ * is a navigation affordance the reader must have time to see, aim at, and tap a jump
+ * dot on.
+ */
+export const RAIL_VISIBLE_IDLE_MS = 1200
+/**
+ * How long after a real user input a bare `scroll` event still counts as that gesture's
+ * momentum, so the rail stays lit through a touch flick's coast (no touch or pointer
+ * event fires while the content glides -- only `scroll`). See createScrollActivity for
+ * why the grace is measured from the last INPUT and never extended by `scroll` itself.
+ */
+export const RAIL_MOMENTUM_GRACE_MS = 750
 // How long an outgoing skeleton lingers (fading via rowSkeletonClosing) after
 // its real content takes over, so the swap reads as a crossfade instead of a
 // pop. The shared motion token keeps this unmount timer and the CSS fade
@@ -473,6 +494,10 @@ export const ChatView: Component<ChatViewProps> = (props) => {
   // railProps memo), so a bare `props.rail ?` here would re-run the O(n) scan on each of those
   // even when the row list is unchanged. railPresent flips only when the rail appears / disappears,
   // so the scan reruns solely when virtualItems changes -- exactly as the note above promises.
+  //
+  // On COARSE pointers messageList additionally suppresses the native bar unconditionally, so a
+  // touch viewport that resolves to 'native' shows NEITHER bar. That is a deliberate exception,
+  // recorded on resolveScrollbarOwner and messageListRailActive; the resolution below is unchanged.
   const railPresent = createMemo(() => props.rail !== undefined)
   const railRowSeqs = createMemo(() => (railPresent() ? rowStartSeqs(virtualItems()) : null))
   const railOwner = createMemo(() => {
@@ -534,7 +559,20 @@ export const ChatView: Component<ChatViewProps> = (props) => {
     renderCacheStore.prune(visibleEntries().map(renderCacheKeyForEntry))
   })
 
-  const [syntaxHighlightingPaused, setSyntaxHighlightingPaused] = createSignal(false)
+  // Two scroll-activity windows over the SAME gesture stream, differing in length AND in
+  // which events feed them (see createScrollActivity):
+  //   - highlightActivity takes EVERY scroll, our own programmatic writes included -- a
+  //     streaming stick-to-bottom is exactly when the highlighter and the premeasure
+  //     warm-up must stay out of the way.
+  //   - railActivity takes USER INPUT only, plus a momentum-gated `scroll` for the
+  //     post-flick coast. A rail lit by our own scrollTop writes would stay lit for a
+  //     whole streaming response, defeating its auto-hide when it matters most.
+  const highlightActivity = createScrollActivity({ idleMs: SYNTAX_HIGHLIGHT_SCROLL_IDLE_MS })
+  const railActivity = createScrollActivity({
+    idleMs: RAIL_VISIBLE_IDLE_MS,
+    momentumGraceMs: RAIL_MOMENTUM_GRACE_MS,
+  })
+  const syntaxHighlightingPaused = highlightActivity.active
 
   /**
    * The per-row bindings a MessageBubble needs from ChatView, bundled into one
@@ -597,7 +635,8 @@ export const ChatView: Component<ChatViewProps> = (props) => {
   // premeasureCandidates and hides in-range unmeasured rows via collapsedPremeasureIds.
   // The warm-up enable policy stays here (it reads ChatView-level scroll/stream state):
   // while the pane is visible, sized, and quiet. syntaxHighlightingPaused doubles as the
-  // "scroll recently active" gate -- set on every scroll, cleared after the idle window.
+  // "scroll recently active" gate -- see highlightActivity (createScrollActivity), which
+  // opens on EVERY scroll and closes after its idle window.
   const premeasure = createChatPremeasureBands({
     visibleEntries,
     virtualItems,
@@ -623,22 +662,6 @@ export const ChatView: Component<ChatViewProps> = (props) => {
       tailVisibleId: () => tailVisibleEntry()?.msg.id,
       hasMeasuredHeight: virt.hasMeasuredHeight,
     })
-
-  let syntaxHighlightResumeTimer: ReturnType<typeof setTimeout> | undefined
-  const pauseSyntaxHighlightingForScroll = () => {
-    setSyntaxHighlightingPaused(true)
-    if (syntaxHighlightResumeTimer !== undefined)
-      clearTimeout(syntaxHighlightResumeTimer)
-    syntaxHighlightResumeTimer = setTimeout(() => {
-      syntaxHighlightResumeTimer = undefined
-      setSyntaxHighlightingPaused(false)
-    }, SYNTAX_HIGHLIGHT_SCROLL_IDLE_MS)
-  }
-
-  onCleanup(() => {
-    if (syntaxHighlightResumeTimer !== undefined)
-      clearTimeout(syntaxHighlightResumeTimer)
-  })
 
   // The rendered window: only the rows in/near the viewport.
   const visibleSlice = createMemo(() => {
@@ -793,27 +816,68 @@ export const ChatView: Component<ChatViewProps> = (props) => {
   // once in the store's getRailData (see resolveRailRange), so ChatView passes props.rail
   // straight through to ChatScrollRail rather than re-deriving the range in the view.
 
-  const pauseThen = <Args extends unknown[]>(handler: (...args: Args) => void): ((...args: Args) => void) =>
+  // The rail window only matters when a rail could render. On a conversation with no marks
+  // prop, or before the marks RPC seeds, no rail mounts and railActivity.active() has no
+  // subscriber -- so feeding it arms a 1200ms timer that fires into a dead signal on every
+  // wheel, touch, and keypress for nothing. Gate the feed on rail presence to skip that work
+  // entirely when there is no rail to light.
+  const noteRailInput = () => {
+    if (props.rail !== undefined)
+      railActivity.noteInput()
+  }
+  const noteRailScroll = () => {
+    if (props.rail !== undefined)
+      railActivity.noteScroll()
+  }
+
+  /**
+   * Wrap a genuine USER scroll input so BOTH activity windows see it. The `onScroll`
+   * handler below is deliberately not wrapped: a `scroll` event is not proof of user
+   * intent, so the two windows must treat it differently.
+   */
+  const noteScrollInput = <Args extends unknown[]>(handler: (...args: Args) => void): ((...args: Args) => void) =>
+    // The returned function IS an event handler (assigned to onPointerDown/Up/Cancel and the
+    // passive wheel/touch listeners below), so reading props.rail via noteRailInput at call
+    // time reads the current value -- the linter cannot trace the factory's call sites.
+    // eslint-disable-next-line solid/reactivity
     (...args: Args) => {
-      pauseSyntaxHighlightingForScroll()
+      highlightActivity.noteInput()
+      noteRailInput()
       handler(...args)
     }
 
   const scrollHandlers = {
-    onScroll: pauseThen(scroll.handlers.onScroll),
+    // The one asymmetric handler. A `scroll` event alone is NOT user intent -- the
+    // stick-to-bottom writes scrollTop on every streaming commit. The highlight pause
+    // WANTS those (that churn is exactly when highlighting and the premeasure warm-up must
+    // not run), so it keeps taking noteInput, unchanged from before this split. The rail
+    // takes the momentum-gated noteScroll instead, which opens its window only within
+    // RAIL_MOMENTUM_GRACE_MS of a real input: enough to ride out a touch flick's coast,
+    // never enough for a streaming turn to hold the rail lit.
+    onScroll: () => {
+      highlightActivity.noteInput()
+      noteRailScroll()
+      scroll.handlers.onScroll()
+    },
     onKeyDown: (event: KeyboardEvent) => {
-      if (event.key === 'ArrowDown' || event.key === 'PageDown' || event.key === 'End' || event.key === ' '
-        || event.key === 'ArrowUp' || event.key === 'PageUp' || event.key === 'Home') {
-        pauseSyntaxHighlightingForScroll()
+      // A modifier-bearing key (Ctrl+End, Cmd+PageDown) is an OS/app shortcut, not a native
+      // scroll -- useChatScroll's own native-scroll attribution ignores them for the same
+      // reason (useChatScroll.ts). Mirror that gate here so the windows do not arm for a
+      // gesture that does not scroll.
+      if (!event.altKey && !event.ctrlKey && !event.metaKey
+        && (event.key === 'ArrowDown' || event.key === 'PageDown' || event.key === 'End' || event.key === ' '
+          || event.key === 'ArrowUp' || event.key === 'PageUp' || event.key === 'Home')) {
+        highlightActivity.noteInput()
+        noteRailInput()
       }
       scroll.handlers.onKeyDown(event)
     },
-    onPointerDown: pauseThen(scroll.handlers.onPointerDown),
+    onPointerDown: noteScrollInput(scroll.handlers.onPointerDown),
     onPointerMove: (event: PointerEvent) => {
       scroll.handlers.onPointerMove(event)
     },
-    onPointerUp: pauseThen(scroll.handlers.onPointerUp),
-    onPointerCancel: pauseThen(scroll.handlers.onPointerCancel),
+    onPointerUp: noteScrollInput(scroll.handlers.onPointerUp),
+    onPointerCancel: noteScrollInput(scroll.handlers.onPointerCancel),
   }
 
   // Wheel and touch listeners attach PASSIVE, imperatively: nothing in their
@@ -828,11 +892,11 @@ export const ChatView: Component<ChatViewProps> = (props) => {
   // props above.
   const attachPassiveScrollListeners = (el: HTMLElement): void => {
     const passive = { passive: true } as const
-    el.addEventListener('wheel', pauseThen(scroll.handlers.onWheel), passive)
-    el.addEventListener('touchstart', pauseThen(scroll.handlers.onTouchStart), passive)
-    el.addEventListener('touchmove', pauseThen(scroll.handlers.onTouchMove), passive)
-    el.addEventListener('touchend', pauseThen(scroll.handlers.onTouchEnd), passive)
-    el.addEventListener('touchcancel', pauseThen(scroll.handlers.onTouchCancel), passive)
+    el.addEventListener('wheel', noteScrollInput(scroll.handlers.onWheel), passive)
+    el.addEventListener('touchstart', noteScrollInput(scroll.handlers.onTouchStart), passive)
+    el.addEventListener('touchmove', noteScrollInput(scroll.handlers.onTouchMove), passive)
+    el.addEventListener('touchend', noteScrollInput(scroll.handlers.onTouchEnd), passive)
+    el.addEventListener('touchcancel', noteScrollInput(scroll.handlers.onTouchCancel), passive)
   }
 
   // Re-stick to the bottom after a TAIL SIBLING of the virtual spacer grows. These
@@ -1177,6 +1241,15 @@ export const ChatView: Component<ChatViewProps> = (props) => {
             // derived from ONE railOwner resolution (single viewport-height source), so the rail is
             // shown exactly when the native bar is hidden -- never zero, never two scrollbars.
             hidden={railOwner() !== 'rail'}
+            // Paint-only auto-hide on touch / narrow viewports; never an unmount (see the
+            // rail's scrollActive prop). Driven by railActivity, which takes user input plus
+            // a momentum-gated scroll, so a streaming turn's stick-to-bottom writes cannot
+            // light it. Passed unconditionally: every declaration the resulting class carries
+            // lives inside a media query, so desktop is unaffected with no JS branch here.
+            scrollActive={railActivity.active()}
+            // The rail's own interactions (grab, drag move, dot hover or focus) reopen the
+            // window -- a captured thumb drag fires no events on the scroll container.
+            onActivity={() => railActivity.noteInput()}
             hasMoreOlder={!!props.pagination?.hasOlderMessages}
             hasMoreNewer={!!props.pagination?.hasNewerMessages}
             onJumpToSeq={seq => scroll.jumpToSeq(seq)}

--- a/frontend/src/components/chat/chatRailPolicy.ts
+++ b/frontend/src/components/chat/chatRailPolicy.ts
@@ -51,6 +51,14 @@ export function canRenderSeqRailThumb(rowSeqs: number[] | null, range: RailRange
  * MORE than one seq: a single distinct seq (maxSeq === minSeq) collapses the thumb-drag to a
  * point, so a lone message taller than the viewport must keep the native scrollbar rather than
  * strand behind a frozen rail.
+ *
+ * TOUCH EXCEPTION. On `(pointer: coarse)` the native bar is suppressed on the chat list
+ * UNCONDITIONALLY (see messageList in ChatView.css.ts), so a touch viewport that resolves to
+ * 'native' here shows NEITHER bar. That is intentional: Chrome Android's ::-webkit-scrollbar
+ * styling forces an always-painted classic 8px bar that eats layout width from a phone-width
+ * text column, and a finger scrolls by direct manipulation with no thumb to grab. The invariant
+ * this function enforces is therefore "never TWO scrollbars, and never zero on a FINE pointer".
+ * The 'rail' / 'none' / 'native' resolution below is itself unchanged.
  */
 export type ScrollbarOwner = 'native' | 'rail' | 'none'
 

--- a/frontend/src/components/chat/chatScrollActivity.test.ts
+++ b/frontend/src/components/chat/chatScrollActivity.test.ts
@@ -1,0 +1,235 @@
+import type { ScrollActivity, ScrollActivityDeps } from './chatScrollActivity'
+import { createRoot } from 'solid-js'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createScrollActivity } from './chatScrollActivity'
+
+const IDLE_MS = 400
+const GRACE_MS = 750
+
+let disposeRoot: (() => void) | undefined
+
+/**
+ * Fake BOTH `performance` and the timers, not just the timers. `createScrollActivity`
+ * defaults its clock to `monotonicNow`, which reads `performance.now()`, so a plain
+ * `vi.useFakeTimers()` would leave the momentum-grace comparison on the wall clock while
+ * the idle timer ran on the fake one -- every grace assertion would then pass or fail on
+ * machine speed. Faking both moves them together under one `advanceTimersByTime`, and
+ * starts the clock at exactly 0, which is the epoch the zero-epoch test below needs.
+ * (`useChatScroll.diagnostics.test.ts` uses the same form.)
+ */
+function setup(deps: Partial<ScrollActivityDeps> = {}): ScrollActivity {
+  vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
+  return createRoot((dispose) => {
+    disposeRoot = dispose
+    return createScrollActivity({ idleMs: IDLE_MS, momentumGraceMs: GRACE_MS, ...deps })
+  })
+}
+
+afterEach(() => {
+  disposeRoot?.()
+  disposeRoot = undefined
+  vi.useRealTimers()
+})
+
+describe('createScrollActivity', () => {
+  it('starts inactive with no timer armed', () => {
+    const activity = setup()
+
+    expect(activity.active()).toBe(false)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('opens the window synchronously on a user input', () => {
+    const activity = setup()
+
+    activity.noteInput()
+
+    // Synchronously, not one frame later: the rail must light on touchstart, before the
+    // finger has moved far enough for the reader to wonder where the scrollbar went.
+    expect(activity.active()).toBe(true)
+  })
+
+  it('closes the window exactly idleMs after the last input', () => {
+    const activity = setup()
+
+    activity.noteInput()
+    vi.advanceTimersByTime(IDLE_MS - 1)
+    expect(activity.active()).toBe(true)
+
+    vi.advanceTimersByTime(1)
+    expect(activity.active()).toBe(false)
+  })
+
+  it('restarts the idle window on each input rather than expiring from the first', () => {
+    const activity = setup()
+
+    activity.noteInput()
+    vi.advanceTimersByTime(IDLE_MS - 10)
+    activity.noteInput()
+    vi.advanceTimersByTime(IDLE_MS - 10)
+    // A throttle would have closed at IDLE_MS; a debounce measures from the second input.
+    expect(activity.active()).toBe(true)
+
+    vi.advanceTimersByTime(10)
+    expect(activity.active()).toBe(false)
+  })
+
+  it('never opens the window on a scroll event alone', () => {
+    const activity = setup()
+
+    activity.noteScroll()
+
+    expect(activity.active()).toBe(false)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('never opens the window on a scroll event before any input, on a zero-epoch clock', () => {
+    // performance.now() is exactly 0 here, which is what page load looks like. If the
+    // last-input timestamp were seeded to 0 instead of NEGATIVE_INFINITY, this scroll would
+    // measure as 0ms since "the last input" -- inside any grace -- and a restored
+    // conversation's first programmatic stick-to-bottom would light the rail with no user
+    // input at all.
+    const activity = setup()
+    expect(performance.now()).toBe(0)
+
+    activity.noteScroll()
+
+    expect(activity.active()).toBe(false)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('extends the window from a scroll event inside the momentum grace', () => {
+    const activity = setup()
+
+    activity.noteInput()
+    vi.advanceTimersByTime(IDLE_MS - 1)
+    // A touch flick's coast: no touch or pointer event fires, only `scroll`.
+    activity.noteScroll()
+
+    vi.advanceTimersByTime(IDLE_MS - 1)
+    expect(activity.active()).toBe(true)
+
+    vi.advanceTimersByTime(1)
+    expect(activity.active()).toBe(false)
+  })
+
+  it('never extends the window from scroll events past the momentum grace', () => {
+    const activity = setup()
+
+    activity.noteInput()
+    vi.advanceTimersByTime(GRACE_MS + IDLE_MS + 1)
+    expect(activity.active()).toBe(false)
+
+    // A streaming turn's stick-to-bottom writes: a long burst of scroll events with no user
+    // input behind them. Assert INSIDE the loop -- checking only after would pass even if
+    // the window flickered open on every one of them.
+    for (let i = 0; i < 10; i++) {
+      vi.advanceTimersByTime(16)
+      activity.noteScroll()
+      expect(activity.active()).toBe(false)
+      expect(vi.getTimerCount()).toBe(0)
+    }
+  })
+
+  it('measures the grace from the last input, so momentum cannot chain itself open', () => {
+    const activity = setup()
+
+    activity.noteInput()
+    // Inside the grace: this scroll reopens the window, arming a fresh idle timer.
+    vi.advanceTimersByTime(GRACE_MS - 50)
+    activity.noteScroll()
+    expect(activity.active()).toBe(true)
+
+    // Past the grace measured from the INPUT. If the prior scroll had re-based the grace,
+    // this one (and every later one) would keep extending and the window would never close.
+    vi.advanceTimersByTime(100)
+    activity.noteScroll()
+
+    vi.advanceTimersByTime(IDLE_MS)
+    expect(activity.active()).toBe(false)
+
+    activity.noteScroll()
+    expect(activity.active()).toBe(false)
+  })
+
+  it('accepts only a same-tick scroll when no momentum grace is configured', () => {
+    const activity = setup({ momentumGraceMs: undefined })
+
+    // A scroll dispatched in the same tick as its input is part of that gesture.
+    activity.noteInput()
+    activity.noteScroll()
+    expect(activity.active()).toBe(true)
+
+    vi.advanceTimersByTime(IDLE_MS)
+    expect(activity.active()).toBe(false)
+
+    // One millisecond later it is no longer that gesture's, and nothing reopens.
+    vi.advanceTimersByTime(1)
+    activity.noteScroll()
+    expect(activity.active()).toBe(false)
+  })
+
+  it('closes on the next tick with an idle window of zero, neither synchronously nor never', () => {
+    const activity = setup({ idleMs: 0 })
+
+    activity.noteInput()
+    expect(activity.active()).toBe(true)
+
+    vi.advanceTimersByTime(0)
+    expect(activity.active()).toBe(false)
+  })
+
+  it('cancels the pending timer on dispose and ignores every later event', () => {
+    const activity = setup()
+
+    activity.noteInput()
+    expect(vi.getTimerCount()).toBe(1)
+
+    activity.dispose()
+    expect(activity.active()).toBe(false)
+    expect(vi.getTimerCount()).toBe(0)
+
+    // A passive touchend can still land after the owner tears down; it must not arm a timer
+    // on a disposed component.
+    activity.noteInput()
+    activity.noteScroll()
+    expect(activity.active()).toBe(false)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('disposes itself when its owner disposes', () => {
+    const activity = setup()
+    activity.noteInput()
+    expect(vi.getTimerCount()).toBe(1)
+
+    disposeRoot?.()
+    disposeRoot = undefined
+
+    expect(vi.getTimerCount()).toBe(0)
+    activity.noteInput()
+    expect(activity.active()).toBe(false)
+  })
+
+  it('keeps two instances with different idle windows independent', () => {
+    // The shape ChatView actually builds: a short window for the syntax-highlight pause and
+    // a long one for the rail. A module-level timer or timestamp would couple them.
+    vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] })
+    const { short, long } = createRoot((dispose) => {
+      disposeRoot = dispose
+      return {
+        short: createScrollActivity({ idleMs: 160 }),
+        long: createScrollActivity({ idleMs: IDLE_MS, momentumGraceMs: GRACE_MS }),
+      }
+    })
+
+    short.noteInput()
+    long.noteInput()
+
+    vi.advanceTimersByTime(160)
+    expect(short.active()).toBe(false)
+    expect(long.active()).toBe(true)
+
+    vi.advanceTimersByTime(IDLE_MS - 160)
+    expect(long.active()).toBe(false)
+  })
+})

--- a/frontend/src/components/chat/chatScrollActivity.ts
+++ b/frontend/src/components/chat/chatScrollActivity.ts
@@ -1,0 +1,127 @@
+import type { Accessor } from 'solid-js'
+import { createSignal, onCleanup } from 'solid-js'
+import { monotonicNow } from '~/lib/monotonicNow'
+
+// ---------------------------------------------------------------------------
+// Scroll-activity window
+//
+// "Is the reader actively scrolling right now?", as one reactive boolean that opens on a
+// qualifying event and closes after `idleMs` of quiet. ChatView instantiates it TWICE with
+// different windows AND different event sets, which is why it is a unit rather than two
+// near-identical setTimeout debounces inline:
+//   - the syntax-highlight pause (short window) takes EVERY scroll, our own programmatic
+//     writes included -- a streaming stick-to-bottom is exactly when the highlighter and the
+//     premeasure warm-up must stay out of the way.
+//   - the floating scroll rail (long window) takes USER INPUT only. A rail that lit up for
+//     our own scrollTop writes would stay lit for a whole streaming response, which defeats
+//     the auto-hide precisely when it matters most.
+//
+// A bare `scroll` event therefore has its own entry point, `noteScroll`, which opens the
+// window ONLY within `momentumGraceMs` of the last `noteInput`. That is the momentum latch:
+// after a touch flick no touch or pointer event fires while the content coasts -- only
+// `scroll` -- so without it the rail would fade mid-fling. Measuring the grace from the last
+// INPUT, and never letting `noteScroll` re-base it, is what stops a streaming turn's
+// continuous programmatic writes from holding the window open forever.
+//
+// `now` is injected for determinism (mirroring createScrollVelocity); the idle timer is a
+// bare setTimeout, driven in tests by vitest fake timers (mirroring createFlingSettle).
+// ---------------------------------------------------------------------------
+
+export interface ScrollActivityDeps {
+  /** Quiet period (ms) after the last qualifying event before the window closes. */
+  idleMs: number
+  /**
+   * How long after a `noteInput` a bare `scroll` event still counts as that gesture's
+   * momentum. 0 (the default) disables the momentum extension, so only real input opens
+   * the window.
+   */
+  momentumGraceMs?: number
+  /** Monotonic clock, injected for tests. Defaults to {@link monotonicNow}. */
+  now?: () => number
+}
+
+export interface ScrollActivity {
+  /** True while the window is open. Reactive; safe to read in a memo or in JSX. */
+  active: Accessor<boolean>
+  /**
+   * A genuine user scroll input: wheel, touch, pointer, a scroll-relevant keydown, or a
+   * direct interaction with a scrollbar overlay. ALWAYS (re)opens the window and re-bases
+   * the momentum grace.
+   */
+  noteInput: () => void
+  /**
+   * A bare `scroll` event. Opens the window ONLY within `momentumGraceMs` of the last
+   * `noteInput`, so a post-flick coast keeps it open while our own programmatic writes
+   * (stick-to-bottom, anchor re-pin, seek) never do.
+   */
+  noteScroll: () => void
+  /**
+   * Cancel the pending timer and close the window for good. Registered on `onCleanup`;
+   * ONE-WAY, so both note functions are inert afterwards and a late passive `touchend`
+   * cannot arm a timer on a disposed owner. There is no reopen -- build a new instance.
+   */
+  dispose: () => void
+}
+
+/**
+ * Create a scroll-activity window (see the module header).
+ *
+ * Must be created inside an owner scope: it registers its own `onCleanup`, so a late
+ * passive `touchend` arriving after the owner disposes cannot arm a timer on a dead
+ * component.
+ */
+export function createScrollActivity(deps: ScrollActivityDeps): ScrollActivity {
+  const now = deps.now ?? monotonicNow
+  const graceMs = deps.momentumGraceMs ?? 0
+  const [active, setActive] = createSignal(false)
+  // NEGATIVE_INFINITY, not 0: monotonicNow() reads performance.now(), which starts near zero
+  // at page load, so a zero epoch would put the first programmatic scroll of a restored
+  // conversation INSIDE the grace and open the window with no user input at all. The scroll
+  // hook guards the same trap the same way (see lastNativeKeyScrollAt in useChatScroll).
+  let lastInputAt = Number.NEGATIVE_INFINITY
+  let idleTimer: ReturnType<typeof setTimeout> | undefined
+  let disposed = false
+
+  const open = () => {
+    // A re-notify while already open is dropped by the signal's default `===` equality, so
+    // only the timer is re-armed. One clearTimeout + one setTimeout per event -- the same
+    // per-event cost as the inline debounce this replaces.
+    setActive(true)
+    if (idleTimer !== undefined)
+      clearTimeout(idleTimer)
+    idleTimer = setTimeout(() => {
+      idleTimer = undefined
+      setActive(false)
+    }, deps.idleMs)
+  }
+
+  const noteInput = () => {
+    if (disposed)
+      return
+    lastInputAt = now()
+    open()
+  }
+
+  const noteScroll = () => {
+    if (disposed)
+      return
+    // Inclusive: a scroll dispatched in the same tick as the input that caused it is part of
+    // that gesture, and with a grace of 0 it is the only scroll that still qualifies.
+    if (now() - lastInputAt <= graceMs)
+      open()
+  }
+
+  const dispose = () => {
+    disposed = true
+    if (idleTimer !== undefined) {
+      clearTimeout(idleTimer)
+      idleTimer = undefined
+    }
+    lastInputAt = Number.NEGATIVE_INFINITY
+    setActive(false)
+  }
+
+  onCleanup(dispose)
+
+  return { active, noteInput, noteScroll, dispose }
+}

--- a/frontend/src/components/chat/useAsyncCodeTokens.ts
+++ b/frontend/src/components/chat/useAsyncCodeTokens.ts
@@ -114,7 +114,7 @@ export function useAsyncCodeTokens(opts: AsyncCodeTokensOptions): Accessor<Cache
   // Crucially this seeds THROUGH the `hold` gate -- only `premeasure` (a geometry-only
   // render) blocks it. The click that expands/collapses a row (or toggles the diff view)
   // fires a pointerdown, which pauses syntax highlighting for a scroll-idle beat (ChatView's
-  // pauseSyntaxHighlightingForScroll), so the freshly-mounted body has hold=true. Unlike the
+  // highlightActivity window), so the freshly-mounted body has hold=true. Unlike the
   // running effects -- which defer applying tokens during hold to avoid SWAPPING text nodes
   // mid-scroll/selection -- the seed is the INITIAL paint of a fresh instance: there is no
   // prior node to swap and no selection on it to clear, so applying the cached tokens

--- a/frontend/tests/e2e/047b-chat-scroll-rail-autohide.spec.ts
+++ b/frontend/tests/e2e/047b-chat-scroll-rail-autohide.spec.ts
@@ -1,0 +1,202 @@
+import { devices } from '@playwright/test'
+import { expect, test } from './fixtures'
+import { sendMessage, userBubbles, waitForAgentIdle } from './helpers/ui'
+
+/**
+ * The scroll rail's floating auto-hide, which is E2E-only by construction. Everything that
+ * makes the `railIdle` class DO anything -- `opacity: 0`, `pointer-events: none`, the phone
+ * gutters, and the media queries that scope all three -- is invisible to vitest: the unit
+ * config inserts no stylesheet for a `.css.ts` import and jsdom evaluates no media query.
+ * ChatScrollRail.test.tsx therefore pins only that the class flips; this pins that the class
+ * and the gutters are scoped to the viewports they were meant for.
+ *
+ * The rail's geometry, dots, drag and seek are covered by 047; nothing here re-asserts them.
+ */
+
+/**
+ * Byte-for-byte 047's filler, deliberately. These specs drive a REAL agent, so the prompt
+ * is the test's runtime: a 2.5x longer filler pushed the turn past waitForAgentIdle's
+ * 120s bound under parallel load. Keep this string in step with 047's; make the VIEWPORT
+ * shorter, never the message longer, when a test needs more overflow.
+ *
+ * One message per test, not 047's two: 047 needs two jump dots and nothing here does, and
+ * an agent turn is the most expensive thing in the suite.
+ */
+const LONG_MESSAGE = `Please just reply with "ok". Ignore this filler: ${'the quick brown fox jumps over the lazy dog. '.repeat(12)}`
+
+const RAIL = '[data-testid="chat-scroll-rail"]'
+const SCROLLER = '[data-chat-scroll-container="true"]'
+
+/**
+ * Pixel 7's device metrics WITHOUT its `defaultBrowserType`, and with a shorter viewport.
+ * Playwright refuses a `defaultBrowserType` inside a describe group -- it would force a new
+ * worker -- and this suite's only project is already chromium, so the field is both unusable
+ * and redundant. The rest is what actually gives Blink a COARSE primary pointer. The height
+ * is cut from the device's 915px to 047's 380px: the device is narrower than 720px, so its
+ * lines wrap more and one seeded message still overflows comfortably.
+ */
+const PIXEL_7_METRICS = {
+  viewport: { width: devices['Pixel 7'].viewport.width, height: 380 },
+  deviceScaleFactor: devices['Pixel 7'].deviceScaleFactor,
+  isMobile: devices['Pixel 7'].isMobile,
+  hasTouch: devices['Pixel 7'].hasTouch,
+} as const
+
+/**
+ * Send one tall message so the conversation overflows and the rail takes over scrolling.
+ * Asserts the rail is present before returning: without overflow the rail correctly hides
+ * itself, and every test here would then fail on a confusing missing-element error rather
+ * than on "the viewport was too tall for one message".
+ */
+async function seedOverflowingConversation(page: import('@playwright/test').Page) {
+  const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+  await expect(editor).toBeVisible()
+  // Let the agent finish starting so the send takes the fast path (see 010).
+  await expect(page.getByText(/^Starting /)).not.toBeVisible()
+  await sendMessage(page, LONG_MESSAGE)
+  await waitForAgentIdle(page)
+  await expect(userBubbles(page)).toHaveCount(1)
+  await expect(page.locator(RAIL)).toBeVisible()
+}
+
+test.describe('chat scroll rail auto-hide', () => {
+  test('fades the rail when scrolling stops and brings it back on the next scroll', async ({ page, authenticatedWorkspace }) => {
+    // A DESKTOP viewport (fine pointer, well above the phone breakpoint): auto-hide used to be
+    // touch/narrow-only, but now applies on every screen. This test pins that it reaches desktop.
+    await page.setViewportSize({ width: 1024, height: 600 })
+    await seedOverflowingConversation(page)
+
+    const rail = page.locator(RAIL)
+
+    // The idle window closes on its own; toHaveCSS retries to the global timeout, so this
+    // needs no hand-rolled wait and no per-call timeout override.
+    await expect(rail).toHaveCSS('opacity', '0')
+
+    // A real user scroll relights it...
+    await page.locator(SCROLLER).hover()
+    await page.mouse.wheel(0, -240)
+    await expect(rail).toHaveCSS('opacity', '1')
+
+    // ...and it fades again once that gesture goes quiet.
+    await expect(rail).toHaveCSS('opacity', '0')
+  })
+
+  test('keeps the rail hidden while the agent auto-scrolls a streaming reply', async ({ page, authenticatedWorkspace }) => {
+    // The load-bearing case. The stick-to-bottom writes scrollTop on every streaming
+    // commit; if those counted as scroll activity the rail would stay lit for the whole
+    // response, which is most of the time a reader looks at the screen.
+    await page.setViewportSize({ width: 1024, height: 600 })
+    await seedOverflowingConversation(page)
+
+    const rail = page.locator(RAIL)
+    await expect(rail).toHaveCSS('opacity', '0')
+
+    // Start a turn WITHOUT touching the scroller. sendMessage types into the editor, a
+    // sibling of the scroll container, so its keystrokes never reach the list's handlers.
+    await sendMessage(page, LONG_MESSAGE)
+
+    // Sample every frame from inside the page: a round trip per sample could straddle the
+    // window and miss a flash. `toHaveCSS('opacity', '0')` cannot express this at all --
+    // it retries until it passes, which proves the value was 0 once, not that it was never
+    // 1. Bounded by a frame budget so a stalled agent fails the assert instead of hanging.
+    const observed = await page.evaluate(async ({ railSel, scrollerSel }) => {
+      const rail = document.querySelector(railSel)!
+      const scroller = document.querySelector(scrollerSel) as HTMLElement
+      let autoScrolls = 0
+      let last = scroller.scrollTop
+      let maxOpacity = 0
+      // Sample for the FULL frame budget, with no early-exit on an event count: capping at 8
+      // auto-scrolls could end sampling before the 1.2s idle window ever exercised a flash, which
+      // would make maxOpacity === 0 vacuously true for a fast agent. The frame cap is the bound.
+      for (let frame = 0; frame < 900; frame++) {
+        await new Promise(resolve => requestAnimationFrame(() => resolve(null)))
+        if (scroller.scrollTop !== last) {
+          last = scroller.scrollTop
+          autoScrolls++
+        }
+        maxOpacity = Math.max(maxOpacity, Number.parseFloat(getComputedStyle(rail).opacity))
+      }
+      return { autoScrolls, maxOpacity }
+    }, { railSel: RAIL, scrollerSel: SCROLLER })
+
+    // The auto-scroll really ran, so a maxOpacity of 0 is evidence and not a vacuous pass.
+    expect(observed.autoScrolls).toBeGreaterThan(0)
+    expect(observed.maxOpacity).toBe(0)
+
+    await waitForAgentIdle(page)
+  })
+
+  test('keeps the message list gutters uniform above the phone breakpoint', async ({ page, authenticatedWorkspace }) => {
+    // Only the PHONE breakpoint shrinks the gutters (reclaiming text width on a narrow
+    // viewport). Above it both sides match, so a desktop column stays balanced.
+    const scroller = page.locator(SCROLLER)
+    await expect(scroller).toBeVisible()
+
+    await page.setViewportSize({ width: 900, height: 600 })
+    await expect(scroller).toHaveCSS('padding-left', '16px')
+    await expect(scroller).toHaveCSS('padding-right', '16px')
+
+    // Below the phone breakpoint the text column reclaims 24px in total.
+    await page.setViewportSize({ width: 600, height: 600 })
+    await expect(scroller).toHaveCSS('padding-left', '12px')
+    await expect(scroller).toHaveCSS('padding-right', '4px')
+  })
+
+  test('stays hit-testable on a fine pointer but rejects a click on the faded rail', async ({ page, authenticatedWorkspace }) => {
+    // The faded rail stays hit-testable on a fine pointer (pointer-events: auto) so a
+    // pointermove onto it can relight it -- but a CLICK on the faded rail is rejected at the
+    // pointer handler: you can't click what you can't see. The next click, rail now lit, jumps.
+    await page.setViewportSize({ width: 1024, height: 600 })
+    await seedOverflowingConversation(page)
+
+    const rail = page.locator(RAIL)
+    await expect(rail).toHaveCSS('opacity', '0')
+    await expect(rail).toHaveCSS('pointer-events', 'auto')
+
+    const railBox = await rail.boundingBox()
+    const clickX = railBox!.x + railBox!.width / 2
+    const clickY = railBox!.y + railBox!.height - 6
+
+    const scroller = page.locator(SCROLLER)
+    await scroller.evaluate((el: HTMLElement) => {
+      el.scrollTop = 0
+    })
+
+    // A real mouse.click() MOVES to the target first, firing a pointermove over the strip that
+    // relights the faded rail before the press lands. To exercise the faded rejection, dispatch a
+    // bare pointerdown directly on the rail element: no implicit pointermove, so the rail is still
+    // faded when the handler reads it. The grab is rejected and the rail lights (onActivity), but
+    // scrollTop stays at 0.
+    await page.evaluate(({ railSel, x, y }) => {
+      const el = document.querySelector(railSel)!
+      el.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientX: x, clientY: y, pointerId: 1 }))
+    }, { railSel: RAIL, x: clickX, y: clickY })
+    await expect(rail).toHaveCSS('opacity', '1')
+    await expect.poll(async () => await scroller.evaluate((el: HTMLElement) => el.scrollTop)).toBe(0)
+
+    // SECOND click on the now-LIT rail: the track-click jump goes through. A click near the
+    // bottom of the strip seeks toward the end, so scrollTop must move off zero.
+    await page.mouse.click(clickX, clickY)
+    await expect.poll(async () => await scroller.evaluate((el: HTMLElement) => el.scrollTop)).toBeGreaterThan(0)
+  })
+
+  // Device-metrics emulation is the only way to get `(pointer: coarse)`: Blink derives the
+  // primary pointer type from the mobile viewport, not from `hasTouch`, so a project that
+  // only set hasTouch would look like coverage and be none. Scoped to the one test that
+  // needs it -- `test.use` at describe level takes per-test context options and needs no
+  // change to playwright.config.ts.
+  test.describe('on a coarse pointer', () => {
+    test.use(PIXEL_7_METRICS)
+
+    test('makes the idle rail inert, so its strip cannot swallow a tap', async ({ page, authenticatedWorkspace }) => {
+      // With the phone gutters the 22px coarse strip overlaps ~20px of message content. An
+      // INVISIBLE strip that still took pointer events would turn a tap on the text into a
+      // track-click jump, so going inert while idle is what makes that overlap acceptable.
+      await seedOverflowingConversation(page)
+
+      const rail = page.locator(RAIL)
+      await expect(rail).toHaveCSS('opacity', '0')
+      await expect(rail).toHaveCSS('pointer-events', 'none')
+    })
+  })
+})


### PR DESCRIPTION
## Motivation
The chat scrollbar lived in a reserved right-edge gutter and was always visible, which wasted horizontal text width (especially below the phone breakpoint) and stayed lit even when the reader was idle. This replaces it with a floating overlay that fades out when not in use, and consolidates the "is the reader scrolling?" logic that was previously inlined in ChatView.

## Modifications
- Made the scroll rail a floating overlay that fades to `opacity: 0` when idle, on every screen size and pointer type (the fade is unconditional). The rail element is never unmounted on idle, so its ResizeObserver, live drags, and dot tooltips survive the transition. Only the touch-safety `pointer-events: none` on the idle rail is coarse-pointer-only, since the 22px touch strip overlaps message content below the phone breakpoint.
- Added `createScrollActivity` in `chatScrollActivity.ts`: a reactive scroll/idle window with optional momentum grace, returning `{ active, noteInput, noteScroll, dispose }`. ChatView instantiates it twice — `highlightActivity` (160ms, all scrolls) drives the syntax-highlight/premeasure pause, and `railActivity` (1200ms, user-input-only plus a 750ms momentum grace) drives the rail fade. `lastInputAt` is seeded to `NEGATIVE_INFINITY` so a restored conversation's first programmatic scroll can't open the window on a zero-epoch clock. New exported constants: `SYNTAX_HIGHLIGHT_SCROLL_IDLE_MS`, `RAIL_VISIBLE_IDLE_MS`, `RAIL_MOMENTUM_GRACE_MS`. The old inline `pauseSyntaxHighlightingForScroll` / `pauseThen` helpers in ChatView are removed.
- Added a faded-click guard via a shared `revealIfFaded` helper: a grab or jump on a faded rail or dot only relights the rail (the next press acts), and `preventDefault` is held back so a rejected click doesn't steal focus or start a native selection drag.
- Evened message-list padding to `var(--space-4)` (16px) on both sides, shrinking to 12px left / 4px right below the phone breakpoint to reclaim text width; suppressed the native scrollbar on coarse pointers unconditionally (`scrollbar-width: none` + a `globalStyle` `::-webkit-scrollbar { display: none }`), a documented relaxation of the "never zero scrollbars" invariant for touch.
- Internal-only signature change: `ChatScrollRailProps` gains `scrollActive: boolean` and `onActivity?: () => void`, both wired by ChatView (the only caller). No external consumer is affected.
- Documented a vanilla-extract trap in CLAUDE.md (a bare `*.css.ts` basename anywhere in a `.css.ts` file fails the whole module) and updated a stale comment reference in `useAsyncCodeTokens.ts`.

## Result
- The chat scrollbar now floats over the message list and fades out when the reader is idle, reclaiming horizontal text width (notably on phones) and cutting visual noise during streaming.
- Touch users get a fully suppressed native scrollbar and an inert idle rail, so the 22px strip can't trap taps; desktop users get a clean fade with click-through protection — a faded rail or dot relights on the first press and only acts on the next.
- New test coverage pins the behavior: `chatScrollActivity.test.ts` (idle window, debounce-vs-throttle, momentum grace, zero-epoch clock, two-instance independence), expanded `ChatScrollRail.test.tsx` (class flip, no-remount on idle, faded-click rejection, dot focus-out fade), `ChatView.test.tsx` (highlight-pause preservation and rail wiring), and the new E2E spec `047b-chat-scroll-rail-autohide.spec.ts` (opacity fade/return, streaming stays hidden across the full budget, gutters across the breakpoint, fine-pointer click rejection, coarse-pointer inertness).
