### PR TITLE
feat(acp): Advertise and host ACP terminal sessions

### DIFF
--- a/backend/internal/hub/service/worker_registration_test.go
+++ b/backend/internal/hub/service/worker_registration_test.go
@@ -2,6 +2,8 @@ package service_test
 
 import (
 	"context"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"runtime"
@@ -844,9 +846,18 @@ func TestConnect_FencedRegistryRefusesWithUnavailable(t *testing.T) {
 	defer cancel()
 	stream := connectorClient.Connect(ctx)
 	stream.RequestHeader().Set("Authorization", "Bearer "+worker.AuthToken)
-	require.NoError(t, stream.Send(&leapmuxv1.ConnectRequest{
+	// ConnectRPC documents that when the server returns an error, the client's
+	// first Send may wrap io.EOF and Receive carries the real status. Fencing
+	// is the cheapest refuse path (no greeting enqueue), so on a fast runner
+	// the Hub often closes before the heartbeat envelope finishes writing —
+	// requiring Send to succeed flakes as "unknown: write envelope: EOF".
+	err = stream.Send(&leapmuxv1.ConnectRequest{
 		Payload: &leapmuxv1.ConnectRequest_Heartbeat{Heartbeat: &leapmuxv1.Heartbeat{}},
-	}))
+	})
+	if err != nil {
+		require.ErrorIs(t, err, io.EOF,
+			"server may close before the first Send finishes; got %v", err)
+	}
 
 	_, err = stream.Receive()
 	require.Error(t, err, "a fenced registry must refuse the connection, not hold the stream open")
@@ -909,11 +920,15 @@ func TestConnect_RefusesWhenTheAccountIsAtItsLiveWorkerCap(t *testing.T) {
 
 	// openStream starts a Connect stream and returns the Hub's first frame. The
 	// worker speaks first because ConnectRPC only sends headers on the first Send.
+	// When the Hub refuses immediately, Send may wrap io.EOF; Receive carries
+	// the status (see BidiStreamForClient.Send docs).
 	openStream := func(t *testing.T, authToken string) (*workerStream, *leapmuxv1.ConnectResponse, error) {
 		t.Helper()
 		stream := connectorClient.Connect(ctx)
 		stream.RequestHeader().Set("Authorization", "Bearer "+authToken)
-		require.NoError(t, stream.Send(heartbeat))
+		if err := stream.Send(heartbeat); err != nil && !errors.Is(err, io.EOF) {
+			return stream, nil, err
+		}
 		first, err := stream.Receive()
 		return stream, first, err
 	}

--- a/backend/internal/worker/agent/acp_common.go
+++ b/backend/internal/worker/agent/acp_common.go
@@ -41,6 +41,14 @@ const (
 	// (e.g. OpenCode/Kilo "effort", Copilot "reasoning_effort"/"allow_all") that have
 	// no dedicated set_model/set_mode channel.
 	acpMethodSessionSetConfigOption = "session/set_config_option"
+
+	// ACP host terminal methods (agent → client). Advertised via
+	// clientCapabilities.terminal; see acp_terminal.go.
+	acpMethodTerminalCreate      = "terminal/create"
+	acpMethodTerminalOutput      = "terminal/output"
+	acpMethodTerminalWaitForExit = "terminal/wait_for_exit"
+	acpMethodTerminalKill        = "terminal/kill"
+	acpMethodTerminalRelease     = "terminal/release"
 )
 
 // ACP session update type constants.
@@ -227,6 +235,12 @@ type acpBase struct {
 	// thinking-indicator counter. Fed from both the reader and the prompt-response
 	// goroutines, so it self-locks; see thinkingTokenEstimator and thinkingResetSink.
 	thinkingTokens thinkingTokenEstimator
+
+	// terminals holds live ACP host terminal sessions keyed by terminalId.
+	// Guarded by terminalsMu (not b.mu) so wait_for_exit / output readers are
+	// not serialized behind the agent state lock. Tear down in Stop.
+	terminalsMu sync.Mutex
+	terminals   map[string]*acpTerminalSession
 }
 
 // handleACPPromptResponse extracts accumulated turn text, persists the prompt
@@ -968,17 +982,25 @@ func acpApplySetting(providerName, agentID, name, value string, apply func(strin
 }
 
 // acpStandardInitParams marshals the standard ACP "initialize" params shared by
-// OpenCode, Kilo, Copilot, Goose, and Cursor: protocol version 1, the LeapMux
-// clientInfo, and empty capabilities.
+// OpenCode, Kilo, Copilot, Goose, Cursor, and Reasonix: protocol version 1, the
+// LeapMux clientInfo, and clientCapabilities.
 //
-// LeapMux does not advertise the ACP `terminal` capability, so Goose/Reasonix
-// run shells agent-side and no background-shell rows exist for them. See
-// https://github.com/leapmux/leapmux/issues/370.
+// clientCapabilities.terminal is true so agents that honor the ACP host
+// terminal capability (Goose, Reasonix) route shells through terminal/*;
+// handlers live in acp_terminal.go and surface KindShell background-task
+// rows. fs.* stays false until separate host filesystem support lands.
+// See https://github.com/leapmux/leapmux/issues/370.
 func acpStandardInitParams() (json.RawMessage, error) {
 	params, err := json.Marshal(map[string]interface{}{
 		"protocolVersion": 1,
 		"clientInfo":      map[string]string{"name": "leapmux", "title": "LeapMux", "version": version.Value},
-		"capabilities":    map[string]interface{}{},
+		"clientCapabilities": map[string]interface{}{
+			"fs": map[string]bool{
+				"readTextFile":  false,
+				"writeTextFile": false,
+			},
+			"terminal": true,
+		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("marshal initialize params: %w", err)
@@ -1181,9 +1203,11 @@ func (b *acpBase) SendInput(content string, attachments []*leapmuxv1.Attachment)
 	return b.enqueueOrSendPrompt(content, attachments)
 }
 
-// Stop clears the prompt queue and terminates the process.
+// Stop clears the prompt queue, tears down host terminals, and terminates the
+// agent process.
 func (b *acpBase) Stop() {
 	b.clearPromptQueue()
+	b.releaseAllTerminals()
 	b.processBase.Stop()
 }
 
@@ -3202,6 +3226,12 @@ func (b *acpBase) handleACPOutput(line *parsedLine, extraSessionUpdate acpSessio
 		b.handleACPSessionUpdate(line.Params, extraSessionUpdate)
 	case acpMethodSessionRequestPermission:
 		b.handleRequestPermission(line.IDString(), line.Raw)
+	case acpMethodTerminalCreate,
+		acpMethodTerminalOutput,
+		acpMethodTerminalWaitForExit,
+		acpMethodTerminalKill,
+		acpMethodTerminalRelease:
+		b.handleTerminalMethod(line)
 	default:
 		if extraMethod != nil && extraMethod(line) {
 			return

--- a/backend/internal/worker/agent/acp_common.go
+++ b/backend/internal/worker/agent/acp_common.go
@@ -238,9 +238,12 @@ type acpBase struct {
 
 	// terminals holds live ACP host terminal sessions keyed by terminalId.
 	// Guarded by terminalsMu (not b.mu) so wait_for_exit / output readers are
-	// not serialized behind the agent state lock. Tear down in Stop.
-	terminalsMu sync.Mutex
-	terminals   map[string]*acpTerminalSession
+	// not serialized behind the agent state lock. Tear down in Stop/Wait.
+	// terminalsClosed latches after Stop/Wait so a racing terminal/create
+	// cannot re-seed the map and orphan processes after teardown.
+	terminalsMu     sync.Mutex
+	terminals       map[string]*acpTerminalSession
+	terminalsClosed bool
 }
 
 // handleACPPromptResponse extracts accumulated turn text, persists the prompt
@@ -367,6 +370,11 @@ func (b *acpBase) handleACPSessionUpdate(params json.RawMessage, extra acpSessio
 // created, the reapplySettings callback (if set) re-applies provider-
 // specific settings such as model and permission mode.
 func (b *acpBase) ClearContext() (string, bool) {
+	// Host terminals are bound to the outgoing sessionId; release them before
+	// the swap so requireSession cannot strand them under a mismatch. Do not
+	// latch the store closed — the new session may create terminals again.
+	b.releaseSessionTerminals()
+
 	sessionID, resp, ok := b.newSessionLocked()
 	if !ok {
 		return "", false
@@ -1209,6 +1217,15 @@ func (b *acpBase) Stop() {
 	b.clearPromptQueue()
 	b.releaseAllTerminals()
 	b.processBase.Stop()
+}
+
+// Wait blocks until the agent process exits, then tears down any host
+// terminals that survived a crash/natural exit (Stop already released them
+// on the intentional-stop path; releaseAllTerminals is idempotent).
+func (b *acpBase) Wait() error {
+	err := b.processBase.Wait()
+	b.releaseAllTerminals()
+	return err
 }
 
 // stopAndWait stops the agent process and blocks until it exits. Used by the

--- a/backend/internal/worker/agent/acp_terminal.go
+++ b/backend/internal/worker/agent/acp_terminal.go
@@ -11,15 +11,24 @@ import (
 	"path/filepath"
 	"runtime"
 	"sync"
+	"time"
 	"unicode/utf8"
 
+	"github.com/leapmux/leapmux/internal/util/envutil"
 	utilid "github.com/leapmux/leapmux/internal/util/id"
 	"github.com/leapmux/leapmux/internal/worker/bgtask"
+	"github.com/leapmux/leapmux/util/procutil"
 )
 
 // Default retained output size when terminal/create omits outputByteLimit.
-// Matches Reasonix's host-terminal cap (1 MiB).
+// Matches Reasonix's host-terminal cap (1 MiB). Explicit 0 means retain
+// nothing (still reports truncated when any bytes were produced).
 const acpDefaultOutputByteLimit = 1 << 20
+
+// How long release/Stop waits for a killed terminal's wait goroutine before
+// giving up. Tree-kill should make this unnecessary; the bound keeps Stop
+// from hanging the agent lifecycle if a descendant still refuses to die.
+const acpTerminalReleaseWait = 10 * time.Second
 
 // acpTerminalEnvVar is one ACP EnvVariable entry on terminal/create.
 type acpTerminalEnvVar struct {
@@ -58,6 +67,11 @@ type acpTerminalSession struct {
 	exitCode       *int
 	signal         *string
 	registryClosed bool
+	// killed is set when the host intentionally terminates the process
+	// (terminal/kill, release, Stop, ClearContext). Registry status then
+	// becomes StatusStopped rather than Failed.
+	killed    bool
+	jobObject *procutil.JobObject
 
 	// done is closed once the process has exited and exit fields are set.
 	done chan struct{}
@@ -69,8 +83,14 @@ func (s *acpTerminalSession) appendOutput(p []byte) {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.byteLimit == 0 {
+		// Explicit retain-nothing: discard bytes but mark truncated so
+		// agents know output existed.
+		s.truncated = true
+		return
+	}
 	s.buf = append(s.buf, p...)
-	if s.byteLimit > 0 && len(s.buf) > s.byteLimit {
+	if len(s.buf) > s.byteLimit {
 		s.truncated = true
 		s.buf = truncateACPTerminalOutput(s.buf, s.byteLimit)
 	}
@@ -78,8 +98,12 @@ func (s *acpTerminalSession) appendOutput(p []byte) {
 
 // truncateACPTerminalOutput drops the oldest bytes so retained is at most
 // limit bytes, cutting at a UTF-8 character boundary (ACP requirement).
+// limit == 0 retains nothing.
 func truncateACPTerminalOutput(buf []byte, limit int) []byte {
-	if limit <= 0 || len(buf) <= limit {
+	if limit == 0 {
+		return nil
+	}
+	if limit < 0 || len(buf) <= limit {
 		return buf
 	}
 	start := len(buf) - limit
@@ -113,6 +137,9 @@ func exitStatusFromProcessState(ps *os.ProcessState) (exitCode *int, signal *str
 	if ps == nil {
 		return nil, nil
 	}
+	if code, sig, ok := exitStatusFromWaitStatus(ps); ok {
+		return code, sig
+	}
 	code := ps.ExitCode()
 	if code >= 0 {
 		c := code
@@ -128,17 +155,37 @@ func exitStatusFromProcessState(ps *os.ProcessState) (exitCode *int, signal *str
 func (s *acpTerminalSession) kill() {
 	s.mu.Lock()
 	exited := s.exited
+	if !exited {
+		s.killed = true
+	}
 	cancel := s.cancel
+	job := s.jobObject
 	cmd := s.cmd
 	s.mu.Unlock()
 	if exited {
 		return
 	}
+	// Tree-kill first so grandchildren holding the pipes die before we
+	// wait on stdout/stderr readers.
+	if err := job.Terminate(); err != nil {
+		slog.Debug("acp terminal job terminate failed", "terminal_id", s.id, "error", err)
+	}
 	if cancel != nil {
 		cancel()
 	}
-	if cmd != nil && cmd.Process != nil {
+	if job == nil && cmd != nil && cmd.Process != nil {
 		_ = cmd.Process.Kill()
+	}
+}
+
+func (s *acpTerminalSession) waitDone(timeout time.Duration) {
+	select {
+	case <-s.done:
+	case <-time.After(timeout):
+		slog.Warn("acp terminal wait timed out after kill",
+			"terminal_id", s.id,
+			"timeout", timeout,
+		)
 	}
 }
 
@@ -210,6 +257,21 @@ func (b *acpBase) getTerminal(terminalID string) (*acpTerminalSession, bool) {
 	return s, ok
 }
 
+// terminalBaseEnv returns the environment the host command should inherit.
+// Prefer the agent process env (already FinalizeAgentEnv + AppImage-scrubbed
+// at launch) so GIT_OPTIONAL_LOCKS, LEAPMUX_WORKER, ExtraEnv, and identity
+// scrubbing match the agent. Fall back to FinalizeAgentEnv(os.Environ())
+// when no agent cmd is attached (unit tests).
+func (b *acpBase) terminalBaseEnv() []string {
+	var base []string
+	if b.cmd != nil {
+		base = append([]string(nil), b.cmd.Environ()...)
+	} else {
+		base = FinalizeAgentEnv(os.Environ(), Options{})
+	}
+	return envutil.ScrubAppImageEnvSlice(base)
+}
+
 func (b *acpBase) terminalCreate(id json.RawMessage, rawParams json.RawMessage) {
 	var params acpTerminalCreateParams
 	if err := json.Unmarshal(rawParams, &params); err != nil {
@@ -247,10 +309,19 @@ func (b *acpBase) terminalCreate(id json.RawMessage, rawParams json.RawMessage) 
 		limit = *params.OutputByteLimit
 	}
 
+	b.terminalsMu.Lock()
+	closed := b.terminalsClosed
+	b.terminalsMu.Unlock()
+	if closed {
+		b.terminalError(id, -32603, "agent is stopped")
+		return
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	cmd := buildACPTerminalCmd(ctx, params.Command, params.Args)
+	configureACPTerminalCmd(cmd)
 	cmd.Dir = cwd
-	cmd.Env = mergeACPTerminalEnv(os.Environ(), params.Env)
+	cmd.Env = mergeACPTerminalEnv(b.terminalBaseEnv(), params.Env)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -271,6 +342,14 @@ func (b *acpBase) terminalCreate(id json.RawMessage, rawParams json.RawMessage) 
 		return
 	}
 
+	job, jobErr := procutil.AssignPID(cmd.Process.Pid)
+	if jobErr != nil {
+		slog.Warn("acp terminal attach job object failed",
+			"agent_id", b.agentID,
+			"error", jobErr,
+		)
+	}
+
 	termID := "term_" + utilid.Generate()
 	sess := &acpTerminalSession{
 		id:        termID,
@@ -278,16 +357,26 @@ func (b *acpBase) terminalCreate(id json.RawMessage, rawParams json.RawMessage) 
 		cmd:       cmd,
 		cancel:    cancel,
 		byteLimit: limit,
+		jobObject: job,
 		done:      make(chan struct{}),
 	}
 
 	b.terminalsMu.Lock()
+	if b.terminalsClosed {
+		b.terminalsMu.Unlock()
+		sess.kill()
+		sess.waitDone(acpTerminalReleaseWait)
+		b.terminalError(id, -32603, "agent is stopped")
+		return
+	}
 	if b.terminals == nil {
 		b.terminals = make(map[string]*acpTerminalSession)
 	}
 	b.terminals[termID] = sess
 	b.terminalsMu.Unlock()
 
+	// Upsert before starting the waiters/reply so CloseBackgroundTask on a
+	// fast-exiting command cannot land before the Running row exists.
 	title := bgtask.FirstLine(params.Command)
 	if title == "" {
 		title = "shell"
@@ -297,7 +386,6 @@ func (b *acpBase) terminalCreate(id json.RawMessage, rawParams json.RawMessage) 
 		Kind:          bgtask.KindShell,
 		ParentAgentID: b.agentID,
 		Title:         title,
-		Description:   title,
 		Status:        bgtask.StatusRunning,
 	}); err != nil {
 		slog.Warn("acp terminal upsert failed", "agent_id", b.agentID, "terminal_id", termID, "error", err)
@@ -353,10 +441,14 @@ func (b *acpBase) closeTerminalRegistry(sess *acpTerminalSession) {
 	}
 	sess.registryClosed = true
 	exitCode := sess.exitCode
+	killed := sess.killed
 	sess.mu.Unlock()
 
 	status := bgtask.StatusCompleted
-	if exitCode == nil || *exitCode != 0 {
+	switch {
+	case killed:
+		status = bgtask.StatusStopped
+	case exitCode == nil || *exitCode != 0:
 		status = bgtask.StatusFailed
 	}
 	if err := b.sink.CloseBackgroundTask(sess.id, status); err != nil {
@@ -463,18 +555,35 @@ func (b *acpBase) terminalRelease(id json.RawMessage, rawParams json.RawMessage)
 	}
 
 	// Kill + wait off the read loop so a still-running command cannot stall
-	// further agent→client requests. Response fires once resources are free.
+	// further agent→client requests. Response fires once resources are free
+	// (or the bounded wait expires).
 	go func() {
 		sess.kill()
-		<-sess.done
+		sess.waitDone(acpTerminalReleaseWait)
 		b.closeTerminalRegistry(sess)
 		b.terminalOK(id, map[string]interface{}{})
 	}()
 }
 
-// releaseAllTerminals kills and forgets every host terminal. Called from Stop.
+// releaseAllTerminals kills and forgets every host terminal and latches the
+// store closed so a racing terminal/create cannot re-seed orphans after Stop.
+// Called from Stop and Wait (agent crash / natural exit).
 func (b *acpBase) releaseAllTerminals() {
+	b.releaseTerminals(true)
+}
+
+// releaseSessionTerminals kills host terminals bound to the outgoing ACP
+// session without latching the store closed — ClearContext may create new
+// terminals under the replacement sessionId.
+func (b *acpBase) releaseSessionTerminals() {
+	b.releaseTerminals(false)
+}
+
+func (b *acpBase) releaseTerminals(closeLatch bool) {
 	b.terminalsMu.Lock()
+	if closeLatch {
+		b.terminalsClosed = true
+	}
 	sessions := make([]*acpTerminalSession, 0, len(b.terminals))
 	for _, s := range b.terminals {
 		sessions = append(sessions, s)
@@ -484,13 +593,13 @@ func (b *acpBase) releaseAllTerminals() {
 
 	for _, s := range sessions {
 		s.kill()
-		<-s.done
+		s.waitDone(acpTerminalReleaseWait)
 		b.closeTerminalRegistry(s)
 	}
 }
 
 // buildACPTerminalCmd builds the process for a terminal/create request.
-// Goose and Reasonix pass a full shell string with empty args; ACP also
+// Agents typically pass a full shell string with empty args; ACP also
 // allows an argv-style command+args pair.
 func buildACPTerminalCmd(ctx context.Context, command string, args []string) *exec.Cmd {
 	if len(args) == 0 {
@@ -506,26 +615,19 @@ func mergeACPTerminalEnv(base []string, overrides []acpTerminalEnvVar) []string 
 	if len(overrides) == 0 {
 		return base
 	}
-	env := append([]string(nil), base...)
-	index := make(map[string]int, len(env))
-	for i, kv := range env {
-		if name, _, ok := splitEnvKV(kv); ok {
-			index[name] = i
-		}
-	}
+	// Pin each override so a duplicate inherited key is replaced rather than
+	// layered (exec last-wins, but tests and introspection see one entry).
+	assignments := make([]string, 0, len(overrides))
 	for _, o := range overrides {
 		if o.Name == "" {
 			continue
 		}
-		entry := o.Name + "=" + o.Value
-		if i, ok := index[o.Name]; ok {
-			env[i] = entry
-			continue
-		}
-		index[o.Name] = len(env)
-		env = append(env, entry)
+		assignments = append(assignments, o.Name+"="+o.Value)
 	}
-	return env
+	if len(assignments) == 0 {
+		return base
+	}
+	return envutil.PinEnv(base, assignments...)
 }
 
 func splitEnvKV(kv string) (name, value string, ok bool) {

--- a/backend/internal/worker/agent/acp_terminal.go
+++ b/backend/internal/worker/agent/acp_terminal.go
@@ -1,0 +1,538 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"unicode/utf8"
+
+	utilid "github.com/leapmux/leapmux/internal/util/id"
+	"github.com/leapmux/leapmux/internal/worker/bgtask"
+)
+
+// Default retained output size when terminal/create omits outputByteLimit.
+// Matches Reasonix's host-terminal cap (1 MiB).
+const acpDefaultOutputByteLimit = 1 << 20
+
+// acpTerminalEnvVar is one ACP EnvVariable entry on terminal/create.
+type acpTerminalEnvVar struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+type acpTerminalCreateParams struct {
+	SessionID       string              `json:"sessionId"`
+	Command         string              `json:"command"`
+	Args            []string            `json:"args"`
+	Cwd             string              `json:"cwd"`
+	Env             []acpTerminalEnvVar `json:"env"`
+	OutputByteLimit *int                `json:"outputByteLimit"`
+}
+
+type acpTerminalIDParams struct {
+	SessionID  string `json:"sessionId"`
+	TerminalID string `json:"terminalId"`
+}
+
+// acpTerminalSession is one host-run ACP terminal command. It is not a
+// LeapMux interactive PTY tab — just a process + retained output buffer
+// that agents poll via terminal/output and wait_for_exit.
+type acpTerminalSession struct {
+	id      string
+	command string
+	cmd     *exec.Cmd
+	cancel  context.CancelFunc
+
+	mu             sync.Mutex
+	buf            []byte
+	truncated      bool
+	byteLimit      int
+	exited         bool
+	exitCode       *int
+	signal         *string
+	registryClosed bool
+
+	// done is closed once the process has exited and exit fields are set.
+	done chan struct{}
+}
+
+func (s *acpTerminalSession) appendOutput(p []byte) {
+	if len(p) == 0 {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.buf = append(s.buf, p...)
+	if s.byteLimit > 0 && len(s.buf) > s.byteLimit {
+		s.truncated = true
+		s.buf = truncateACPTerminalOutput(s.buf, s.byteLimit)
+	}
+}
+
+// truncateACPTerminalOutput drops the oldest bytes so retained is at most
+// limit bytes, cutting at a UTF-8 character boundary (ACP requirement).
+func truncateACPTerminalOutput(buf []byte, limit int) []byte {
+	if limit <= 0 || len(buf) <= limit {
+		return buf
+	}
+	start := len(buf) - limit
+	for start < len(buf) && !utf8.RuneStart(buf[start]) {
+		start++
+	}
+	if start >= len(buf) {
+		return nil
+	}
+	out := make([]byte, len(buf)-start)
+	copy(out, buf[start:])
+	return out
+}
+
+func (s *acpTerminalSession) snapshot() (output string, truncated bool, exitCode *int, signal *string, exited bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return string(s.buf), s.truncated, s.exitCode, s.signal, s.exited
+}
+
+func (s *acpTerminalSession) recordExit(ps *os.ProcessState) {
+	code, sig := exitStatusFromProcessState(ps)
+	s.mu.Lock()
+	s.exited = true
+	s.exitCode = code
+	s.signal = sig
+	s.mu.Unlock()
+}
+
+func exitStatusFromProcessState(ps *os.ProcessState) (exitCode *int, signal *string) {
+	if ps == nil {
+		return nil, nil
+	}
+	code := ps.ExitCode()
+	if code >= 0 {
+		c := code
+		return &c, nil
+	}
+	// Negative ExitCode means the process was stopped by a signal (Unix) or
+	// never produced a normal exit code. Report a signal token so agents can
+	// tell timeout/kill apart from a numeric failure.
+	sig := "terminated"
+	return nil, &sig
+}
+
+func (s *acpTerminalSession) kill() {
+	s.mu.Lock()
+	exited := s.exited
+	cancel := s.cancel
+	cmd := s.cmd
+	s.mu.Unlock()
+	if exited {
+		return
+	}
+	if cancel != nil {
+		cancel()
+	}
+	if cmd != nil && cmd.Process != nil {
+		_ = cmd.Process.Kill()
+	}
+}
+
+// handleTerminalMethod dispatches an inbound ACP terminal/* JSON-RPC request.
+// wait_for_exit replies asynchronously so the stdout read loop is never blocked.
+func (b *acpBase) handleTerminalMethod(line *parsedLine) {
+	if !line.HasID() {
+		slog.Warn("acp terminal method missing id", "agent_id", b.agentID, "method", line.Method)
+		return
+	}
+	id := line.ID
+
+	switch line.Method {
+	case acpMethodTerminalCreate:
+		b.terminalCreate(id, line.Params)
+	case acpMethodTerminalOutput:
+		b.terminalOutput(id, line.Params)
+	case acpMethodTerminalWaitForExit:
+		b.terminalWaitForExit(id, line.Params)
+	case acpMethodTerminalKill:
+		b.terminalKill(id, line.Params)
+	case acpMethodTerminalRelease:
+		b.terminalRelease(id, line.Params)
+	}
+}
+
+func (b *acpBase) terminalError(id json.RawMessage, code int, message string) {
+	if err := b.sendErrorResponse(id, code, message); err != nil {
+		slog.Warn("acp terminal error response", "agent_id", b.agentID, "error", err)
+	}
+}
+
+func (b *acpBase) terminalOK(id json.RawMessage, result any) {
+	if result == nil {
+		result = map[string]interface{}{}
+	}
+	if err := b.sendResponse(id, result); err != nil {
+		slog.Warn("acp terminal response", "agent_id", b.agentID, "error", err)
+	}
+}
+
+func (b *acpBase) currentSessionID() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.sessionID
+}
+
+func (b *acpBase) currentWorkingDir() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.workingDir
+}
+
+func (b *acpBase) requireSession(paramsSessionID string) error {
+	current := b.currentSessionID()
+	if current == "" {
+		return fmt.Errorf("no active session")
+	}
+	if paramsSessionID != "" && paramsSessionID != current {
+		return fmt.Errorf("sessionId mismatch")
+	}
+	return nil
+}
+
+func (b *acpBase) getTerminal(terminalID string) (*acpTerminalSession, bool) {
+	b.terminalsMu.Lock()
+	defer b.terminalsMu.Unlock()
+	s, ok := b.terminals[terminalID]
+	return s, ok
+}
+
+func (b *acpBase) terminalCreate(id json.RawMessage, rawParams json.RawMessage) {
+	var params acpTerminalCreateParams
+	if err := json.Unmarshal(rawParams, &params); err != nil {
+		b.terminalError(id, -32602, "invalid terminal/create params")
+		return
+	}
+	if err := b.requireSession(params.SessionID); err != nil {
+		b.terminalError(id, -32602, err.Error())
+		return
+	}
+	if params.Command == "" {
+		b.terminalError(id, -32602, "command is required")
+		return
+	}
+
+	cwd := params.Cwd
+	if cwd == "" {
+		cwd = b.currentWorkingDir()
+	}
+	if cwd == "" {
+		b.terminalError(id, -32602, "cwd is required")
+		return
+	}
+	if !filepath.IsAbs(cwd) {
+		b.terminalError(id, -32602, "cwd must be an absolute path")
+		return
+	}
+
+	limit := acpDefaultOutputByteLimit
+	if params.OutputByteLimit != nil {
+		if *params.OutputByteLimit < 0 {
+			b.terminalError(id, -32602, "outputByteLimit must be non-negative")
+			return
+		}
+		limit = *params.OutputByteLimit
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := buildACPTerminalCmd(ctx, params.Command, params.Args)
+	cmd.Dir = cwd
+	cmd.Env = mergeACPTerminalEnv(os.Environ(), params.Env)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		cancel()
+		b.terminalError(id, -32603, "stdout pipe: "+err.Error())
+		return
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		cancel()
+		b.terminalError(id, -32603, "stderr pipe: "+err.Error())
+		return
+	}
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		b.terminalError(id, -32603, "start command: "+err.Error())
+		return
+	}
+
+	termID := "term_" + utilid.Generate()
+	sess := &acpTerminalSession{
+		id:        termID,
+		command:   params.Command,
+		cmd:       cmd,
+		cancel:    cancel,
+		byteLimit: limit,
+		done:      make(chan struct{}),
+	}
+
+	b.terminalsMu.Lock()
+	if b.terminals == nil {
+		b.terminals = make(map[string]*acpTerminalSession)
+	}
+	b.terminals[termID] = sess
+	b.terminalsMu.Unlock()
+
+	title := bgtask.FirstLine(params.Command)
+	if title == "" {
+		title = "shell"
+	}
+	if err := b.sink.UpsertBackgroundTask(bgtask.Upsert{
+		RowKey:        termID,
+		Kind:          bgtask.KindShell,
+		ParentAgentID: b.agentID,
+		Title:         title,
+		Description:   title,
+		Status:        bgtask.StatusRunning,
+	}); err != nil {
+		slog.Warn("acp terminal upsert failed", "agent_id", b.agentID, "terminal_id", termID, "error", err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		b.copyTerminalOutput(sess, stdout)
+	}()
+	go func() {
+		defer wg.Done()
+		b.copyTerminalOutput(sess, stderr)
+	}()
+	go func() {
+		wg.Wait()
+		waitErr := cmd.Wait()
+		var ps *os.ProcessState
+		if cmd.ProcessState != nil {
+			ps = cmd.ProcessState
+		} else if waitErr != nil {
+			if ee, ok := waitErr.(*exec.ExitError); ok {
+				ps = ee.ProcessState
+			}
+		}
+		sess.recordExit(ps)
+		close(sess.done)
+		b.closeTerminalRegistry(sess)
+	}()
+
+	b.terminalOK(id, map[string]interface{}{"terminalId": termID})
+}
+
+func (b *acpBase) copyTerminalOutput(sess *acpTerminalSession, r io.Reader) {
+	buf := make([]byte, 32*1024)
+	for {
+		n, err := r.Read(buf)
+		if n > 0 {
+			sess.appendOutput(buf[:n])
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+func (b *acpBase) closeTerminalRegistry(sess *acpTerminalSession) {
+	sess.mu.Lock()
+	if sess.registryClosed {
+		sess.mu.Unlock()
+		return
+	}
+	sess.registryClosed = true
+	exitCode := sess.exitCode
+	sess.mu.Unlock()
+
+	status := bgtask.StatusCompleted
+	if exitCode == nil || *exitCode != 0 {
+		status = bgtask.StatusFailed
+	}
+	if err := b.sink.CloseBackgroundTask(sess.id, status); err != nil {
+		slog.Warn("acp terminal close registry failed", "agent_id", b.agentID, "terminal_id", sess.id, "error", err)
+	}
+}
+
+func (b *acpBase) terminalOutput(id json.RawMessage, rawParams json.RawMessage) {
+	var params acpTerminalIDParams
+	if err := json.Unmarshal(rawParams, &params); err != nil {
+		b.terminalError(id, -32602, "invalid terminal/output params")
+		return
+	}
+	if err := b.requireSession(params.SessionID); err != nil {
+		b.terminalError(id, -32602, err.Error())
+		return
+	}
+	sess, ok := b.getTerminal(params.TerminalID)
+	if !ok {
+		b.terminalError(id, -32602, "unknown terminalId")
+		return
+	}
+	output, truncated, exitCode, signal, exited := sess.snapshot()
+	result := map[string]interface{}{
+		"output":    output,
+		"truncated": truncated,
+	}
+	if exited {
+		result["exitStatus"] = map[string]interface{}{
+			"exitCode": exitCode,
+			"signal":   signal,
+		}
+	}
+	b.terminalOK(id, result)
+}
+
+func (b *acpBase) terminalWaitForExit(id json.RawMessage, rawParams json.RawMessage) {
+	var params acpTerminalIDParams
+	if err := json.Unmarshal(rawParams, &params); err != nil {
+		b.terminalError(id, -32602, "invalid terminal/wait_for_exit params")
+		return
+	}
+	if err := b.requireSession(params.SessionID); err != nil {
+		b.terminalError(id, -32602, err.Error())
+		return
+	}
+	sess, ok := b.getTerminal(params.TerminalID)
+	if !ok {
+		b.terminalError(id, -32602, "unknown terminalId")
+		return
+	}
+
+	// Reply on a goroutine: the caller runs on the agent stdout read loop and
+	// must not block waiting for the child process.
+	go func() {
+		<-sess.done
+		_, _, exitCode, signal, _ := sess.snapshot()
+		b.terminalOK(id, map[string]interface{}{
+			"exitCode": exitCode,
+			"signal":   signal,
+		})
+	}()
+}
+
+func (b *acpBase) terminalKill(id json.RawMessage, rawParams json.RawMessage) {
+	var params acpTerminalIDParams
+	if err := json.Unmarshal(rawParams, &params); err != nil {
+		b.terminalError(id, -32602, "invalid terminal/kill params")
+		return
+	}
+	if err := b.requireSession(params.SessionID); err != nil {
+		b.terminalError(id, -32602, err.Error())
+		return
+	}
+	sess, ok := b.getTerminal(params.TerminalID)
+	if !ok {
+		b.terminalError(id, -32602, "unknown terminalId")
+		return
+	}
+	sess.kill()
+	b.terminalOK(id, map[string]interface{}{})
+}
+
+func (b *acpBase) terminalRelease(id json.RawMessage, rawParams json.RawMessage) {
+	var params acpTerminalIDParams
+	if err := json.Unmarshal(rawParams, &params); err != nil {
+		b.terminalError(id, -32602, "invalid terminal/release params")
+		return
+	}
+	if err := b.requireSession(params.SessionID); err != nil {
+		b.terminalError(id, -32602, err.Error())
+		return
+	}
+
+	b.terminalsMu.Lock()
+	sess, ok := b.terminals[params.TerminalID]
+	if ok {
+		delete(b.terminals, params.TerminalID)
+	}
+	b.terminalsMu.Unlock()
+	if !ok {
+		b.terminalError(id, -32602, "unknown terminalId")
+		return
+	}
+
+	// Kill + wait off the read loop so a still-running command cannot stall
+	// further agent→client requests. Response fires once resources are free.
+	go func() {
+		sess.kill()
+		<-sess.done
+		b.closeTerminalRegistry(sess)
+		b.terminalOK(id, map[string]interface{}{})
+	}()
+}
+
+// releaseAllTerminals kills and forgets every host terminal. Called from Stop.
+func (b *acpBase) releaseAllTerminals() {
+	b.terminalsMu.Lock()
+	sessions := make([]*acpTerminalSession, 0, len(b.terminals))
+	for _, s := range b.terminals {
+		sessions = append(sessions, s)
+	}
+	b.terminals = nil
+	b.terminalsMu.Unlock()
+
+	for _, s := range sessions {
+		s.kill()
+		<-s.done
+		b.closeTerminalRegistry(s)
+	}
+}
+
+// buildACPTerminalCmd builds the process for a terminal/create request.
+// Goose and Reasonix pass a full shell string with empty args; ACP also
+// allows an argv-style command+args pair.
+func buildACPTerminalCmd(ctx context.Context, command string, args []string) *exec.Cmd {
+	if len(args) == 0 {
+		if runtime.GOOS == "windows" {
+			return exec.CommandContext(ctx, "cmd", "/C", command)
+		}
+		return exec.CommandContext(ctx, "/bin/sh", "-c", command)
+	}
+	return exec.CommandContext(ctx, command, args...)
+}
+
+func mergeACPTerminalEnv(base []string, overrides []acpTerminalEnvVar) []string {
+	if len(overrides) == 0 {
+		return base
+	}
+	env := append([]string(nil), base...)
+	index := make(map[string]int, len(env))
+	for i, kv := range env {
+		if name, _, ok := splitEnvKV(kv); ok {
+			index[name] = i
+		}
+	}
+	for _, o := range overrides {
+		if o.Name == "" {
+			continue
+		}
+		entry := o.Name + "=" + o.Value
+		if i, ok := index[o.Name]; ok {
+			env[i] = entry
+			continue
+		}
+		index[o.Name] = len(env)
+		env = append(env, entry)
+	}
+	return env
+}
+
+func splitEnvKV(kv string) (name, value string, ok bool) {
+	for i := 0; i < len(kv); i++ {
+		if kv[i] == '=' {
+			return kv[:i], kv[i+1:], true
+		}
+	}
+	return "", "", false
+}

--- a/backend/internal/worker/agent/acp_terminal_proc_unix.go
+++ b/backend/internal/worker/agent/acp_terminal_proc_unix.go
@@ -1,0 +1,41 @@
+//go:build unix
+
+package agent
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// configureACPTerminalCmd puts the child in its own process group so later
+// kill/Stop can reap grandchildren that inherit the pipes (Setpgid + group
+// SIGTERM, then WaitDelay force-kill). Without this, Process.Kill only hits
+// /bin/sh and a still-running child holds stdout/stderr open forever.
+func configureACPTerminalCmd(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
+	}
+	cmd.WaitDelay = 5 * time.Second
+}
+
+func exitStatusFromWaitStatus(ps *os.ProcessState) (exitCode *int, signal *string, ok bool) {
+	ws, ok := ps.Sys().(syscall.WaitStatus)
+	if !ok {
+		return nil, nil, false
+	}
+	if ws.Signaled() {
+		sig := ws.Signal().String()
+		return nil, &sig, true
+	}
+	if ws.Exited() {
+		c := ws.ExitStatus()
+		return &c, nil, true
+	}
+	return nil, nil, false
+}

--- a/backend/internal/worker/agent/acp_terminal_proc_windows.go
+++ b/backend/internal/worker/agent/acp_terminal_proc_windows.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+package agent
+
+import (
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/leapmux/leapmux/util/procutil"
+)
+
+// configureACPTerminalCmd suppresses the console window and bounds
+// CommandContext teardown. Tree kill on Windows is via the JobObject
+// attached after Start (see attachACPTerminalJob).
+func configureACPTerminalCmd(cmd *exec.Cmd) {
+	procutil.HideConsoleWindow(cmd)
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		return cmd.Process.Kill()
+	}
+	cmd.WaitDelay = 5 * time.Second
+}
+
+func exitStatusFromWaitStatus(*os.ProcessState) (exitCode *int, signal *string, ok bool) {
+	return nil, nil, false
+}

--- a/backend/internal/worker/agent/acp_terminal_test.go
+++ b/backend/internal/worker/agent/acp_terminal_test.go
@@ -1,0 +1,628 @@
+//go:build unix
+
+package agent
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/leapmux/leapmux/internal/worker/bgtask"
+)
+
+func TestBuildACPTerminalCmd_ShellVsArgv(t *testing.T) {
+	cmd := buildACPTerminalCmd(t.Context(), "echo hi", nil)
+	require.NotNil(t, cmd)
+	assert.Contains(t, cmd.Path, "sh")
+	assert.Equal(t, []string{"-c", "echo hi"}, cmd.Args[1:])
+
+	cmd = buildACPTerminalCmd(t.Context(), "echo", []string{"hi"})
+	require.NotNil(t, cmd)
+	assert.Equal(t, []string{"hi"}, cmd.Args[1:])
+}
+
+// responseRecorder captures JSON-RPC responses written to an agent's stdin.
+type responseRecorder struct {
+	mu   sync.Mutex
+	bufs [][]byte
+	ch   chan struct{}
+}
+
+func (r *responseRecorder) Write(p []byte) (int, error) {
+	r.mu.Lock()
+	r.bufs = append(r.bufs, append([]byte(nil), p...))
+	r.mu.Unlock()
+	select {
+	case r.ch <- struct{}{}:
+	default:
+	}
+	return len(p), nil
+}
+
+func (r *responseRecorder) Close() error { return nil }
+
+func (r *responseRecorder) wait(t *testing.T, n int, timeout time.Duration) []map[string]interface{} {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		r.mu.Lock()
+		got := len(r.bufs)
+		r.mu.Unlock()
+		if got >= n {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %d responses (got %d)", n, got)
+		}
+		select {
+		case <-r.ch:
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]map[string]interface{}, 0, len(r.bufs))
+	for _, b := range r.bufs {
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(bytes.TrimSpace(b), &m))
+		out = append(out, m)
+	}
+	return out
+}
+
+func newTerminalTestBase(t *testing.T, sink *testSink) (*acpBase, *responseRecorder) {
+	t.Helper()
+	rec := &responseRecorder{ch: make(chan struct{}, 8)}
+	b := &acpBase{
+		jsonrpcBase: jsonrpcBase{
+			processBase: processBase{
+				agentID:      "agent-1",
+				providerName: "goose",
+				stdin:        rec,
+			},
+		},
+		sink:       sink,
+		sessionID:  "sess-1",
+		workingDir: t.TempDir(),
+	}
+	return b, rec
+}
+
+func dispatchTerminal(b *acpBase, method string, rpcID int, params any) {
+	rawParams, _ := json.Marshal(params)
+	line, _ := json.Marshal(map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      rpcID,
+		"method":  method,
+		"params":  json.RawMessage(rawParams),
+	})
+	b.handleACPOutput(parseLine(line), nil, nil)
+}
+
+func TestACPTerminal_CreateWaitOutputRelease(t *testing.T) {
+	sink := &testSink{}
+	b, rec := newTerminalTestBase(t, sink)
+
+	dispatchTerminal(b, acpMethodTerminalCreate, 1, map[string]interface{}{
+		"sessionId": "sess-1",
+		"command":   "printf 'hello-acp'",
+		"cwd":       b.workingDir,
+	})
+	resps := rec.wait(t, 1, 3*time.Second)
+	require.Nil(t, resps[0]["error"])
+	result := resps[0]["result"].(map[string]interface{})
+	termID, _ := result["terminalId"].(string)
+	require.NotEmpty(t, termID)
+
+	sink.bgTasksMu.Lock()
+	row, ok := sink.bgTasks[termID]
+	sink.bgTasksMu.Unlock()
+	require.True(t, ok)
+	assert.Equal(t, bgtask.KindShell, row.Kind)
+	assert.Equal(t, bgtask.StatusRunning, row.Status)
+	assert.Equal(t, "printf 'hello-acp'", row.Title)
+
+	dispatchTerminal(b, acpMethodTerminalWaitForExit, 2, map[string]interface{}{
+		"sessionId":  "sess-1",
+		"terminalId": termID,
+	})
+	resps = rec.wait(t, 2, 5*time.Second)
+	waitResult := resps[1]["result"].(map[string]interface{})
+	assert.EqualValues(t, 0, waitResult["exitCode"])
+
+	dispatchTerminal(b, acpMethodTerminalOutput, 3, map[string]interface{}{
+		"sessionId":  "sess-1",
+		"terminalId": termID,
+	})
+	resps = rec.wait(t, 3, 3*time.Second)
+	outResult := resps[2]["result"].(map[string]interface{})
+	assert.Contains(t, outResult["output"], "hello-acp")
+	assert.Equal(t, false, outResult["truncated"])
+	exitStatus, ok := outResult["exitStatus"].(map[string]interface{})
+	require.True(t, ok)
+	assert.EqualValues(t, 0, exitStatus["exitCode"])
+
+	dispatchTerminal(b, acpMethodTerminalRelease, 4, map[string]interface{}{
+		"sessionId":  "sess-1",
+		"terminalId": termID,
+	})
+	_ = rec.wait(t, 4, 3*time.Second)
+
+	sink.bgTasksMu.Lock()
+	row = sink.bgTasks[termID]
+	sink.bgTasksMu.Unlock()
+	assert.Equal(t, bgtask.StatusCompleted, row.Status)
+
+	b.terminalsMu.Lock()
+	_, still := b.terminals[termID]
+	b.terminalsMu.Unlock()
+	assert.False(t, still)
+}
+
+func TestACPTerminal_KillThenWait(t *testing.T) {
+	sink := &testSink{}
+	b, rec := newTerminalTestBase(t, sink)
+
+	dispatchTerminal(b, acpMethodTerminalCreate, 1, map[string]interface{}{
+		"sessionId": "sess-1",
+		"command":   "sleep 30",
+		"cwd":       b.workingDir,
+	})
+	resps := rec.wait(t, 1, 3*time.Second)
+	termID := resps[0]["result"].(map[string]interface{})["terminalId"].(string)
+
+	dispatchTerminal(b, acpMethodTerminalKill, 2, map[string]interface{}{
+		"sessionId":  "sess-1",
+		"terminalId": termID,
+	})
+	_ = rec.wait(t, 2, 3*time.Second)
+
+	dispatchTerminal(b, acpMethodTerminalWaitForExit, 3, map[string]interface{}{
+		"sessionId":  "sess-1",
+		"terminalId": termID,
+	})
+	resps = rec.wait(t, 3, 5*time.Second)
+	waitResult := resps[2]["result"].(map[string]interface{})
+	// Killed process reports a signal (or non-zero) rather than success.
+	if waitResult["exitCode"] != nil {
+		assert.NotEqualValues(t, 0, waitResult["exitCode"])
+	} else {
+		assert.NotNil(t, waitResult["signal"])
+	}
+
+	dispatchTerminal(b, acpMethodTerminalRelease, 4, map[string]interface{}{
+		"sessionId":  "sess-1",
+		"terminalId": termID,
+	})
+	_ = rec.wait(t, 4, 3*time.Second)
+
+	sink.bgTasksMu.Lock()
+	row := sink.bgTasks[termID]
+	sink.bgTasksMu.Unlock()
+	assert.Equal(t, bgtask.StatusFailed, row.Status)
+}
+
+func TestACPTerminal_OutputByteLimitTruncates(t *testing.T) {
+	sink := &testSink{}
+	b, rec := newTerminalTestBase(t, sink)
+	limit := 8
+
+	dispatchTerminal(b, acpMethodTerminalCreate, 1, map[string]interface{}{
+		"sessionId":       "sess-1",
+		"command":         "printf 'abcdefghijklmnop'",
+		"cwd":             b.workingDir,
+		"outputByteLimit": limit,
+	})
+	resps := rec.wait(t, 1, 3*time.Second)
+	termID := resps[0]["result"].(map[string]interface{})["terminalId"].(string)
+
+	dispatchTerminal(b, acpMethodTerminalWaitForExit, 2, map[string]interface{}{
+		"sessionId":  "sess-1",
+		"terminalId": termID,
+	})
+	_ = rec.wait(t, 2, 5*time.Second)
+
+	dispatchTerminal(b, acpMethodTerminalOutput, 3, map[string]interface{}{
+		"sessionId":  "sess-1",
+		"terminalId": termID,
+	})
+	resps = rec.wait(t, 3, 3*time.Second)
+	outResult := resps[2]["result"].(map[string]interface{})
+	assert.Equal(t, true, outResult["truncated"])
+	out := outResult["output"].(string)
+	assert.LessOrEqual(t, len(out), limit)
+	assert.True(t, len(out) > 0)
+
+	dispatchTerminal(b, acpMethodTerminalRelease, 4, map[string]interface{}{
+		"sessionId":  "sess-1",
+		"terminalId": termID,
+	})
+	_ = rec.wait(t, 4, 3*time.Second)
+}
+
+func TestACPTerminal_UnknownTerminalID(t *testing.T) {
+	sink := &testSink{}
+	b, rec := newTerminalTestBase(t, sink)
+
+	dispatchTerminal(b, acpMethodTerminalOutput, 1, map[string]interface{}{
+		"sessionId":  "sess-1",
+		"terminalId": "term_missing",
+	})
+	resps := rec.wait(t, 1, 3*time.Second)
+	errObj := resps[0]["error"].(map[string]interface{})
+	assert.EqualValues(t, -32602, errObj["code"])
+}
+
+func TestACPTerminal_RelativeCwdRejected(t *testing.T) {
+	sink := &testSink{}
+	b, rec := newTerminalTestBase(t, sink)
+
+	dispatchTerminal(b, acpMethodTerminalCreate, 1, map[string]interface{}{
+		"sessionId": "sess-1",
+		"command":   "echo hi",
+		"cwd":       "relative/path",
+	})
+	resps := rec.wait(t, 1, 3*time.Second)
+	errObj := resps[0]["error"].(map[string]interface{})
+	assert.EqualValues(t, -32602, errObj["code"])
+}
+
+func TestACPTerminal_ReleaseAllOnStop(t *testing.T) {
+	sink := &testSink{}
+	b, rec := newTerminalTestBase(t, sink)
+	// Stop closes stdin; give it a writer that swallows the close.
+	pr, pw := io.Pipe()
+	go func() { _, _ = io.Copy(io.Discard, pr) }()
+	t.Cleanup(func() { _ = pw.Close(); _ = pr.Close() })
+	b.stdin = struct {
+		io.Writer
+		io.Closer
+	}{Writer: io.MultiWriter(rec, pw), Closer: pw}
+	b.processDone = make(chan struct{})
+	close(b.processDone) // Stop's grace wait sees a finished "process"
+
+	dispatchTerminal(b, acpMethodTerminalCreate, 1, map[string]interface{}{
+		"sessionId": "sess-1",
+		"command":   "sleep 30",
+		"cwd":       b.workingDir,
+	})
+	resps := rec.wait(t, 1, 3*time.Second)
+	termID := resps[0]["result"].(map[string]interface{})["terminalId"].(string)
+
+	b.Stop()
+
+	b.terminalsMu.Lock()
+	assert.Empty(t, b.terminals)
+	b.terminalsMu.Unlock()
+
+	sink.bgTasksMu.Lock()
+	row := sink.bgTasks[termID]
+	sink.bgTasksMu.Unlock()
+	assert.True(t, row.Status.IsTerminal())
+}
+
+func TestACPTerminal_DefaultCwdFromWorkingDir(t *testing.T) {
+	sink := &testSink{}
+	b, rec := newTerminalTestBase(t, sink)
+	marker := filepath.Join(b.workingDir, "marker.txt")
+	require.NoError(t, os.WriteFile(marker, []byte("x"), 0o644))
+
+	dispatchTerminal(b, acpMethodTerminalCreate, 1, map[string]interface{}{
+		"sessionId": "sess-1",
+		"command":   "test -f marker.txt && echo found",
+		// cwd omitted — must use workingDir
+	})
+	resps := rec.wait(t, 1, 3*time.Second)
+	termID := resps[0]["result"].(map[string]interface{})["terminalId"].(string)
+
+	dispatchTerminal(b, acpMethodTerminalWaitForExit, 2, map[string]interface{}{
+		"sessionId":  "sess-1",
+		"terminalId": termID,
+	})
+	resps = rec.wait(t, 2, 5*time.Second)
+	assert.EqualValues(t, 0, resps[1]["result"].(map[string]interface{})["exitCode"])
+
+	dispatchTerminal(b, acpMethodTerminalOutput, 3, map[string]interface{}{
+		"sessionId":  "sess-1",
+		"terminalId": termID,
+	})
+	resps = rec.wait(t, 3, 3*time.Second)
+	assert.Contains(t, resps[2]["result"].(map[string]interface{})["output"], "found")
+
+	dispatchTerminal(b, acpMethodTerminalRelease, 4, map[string]interface{}{
+		"sessionId":  "sess-1",
+		"terminalId": termID,
+	})
+	_ = rec.wait(t, 4, 3*time.Second)
+}
+
+func TestACPTerminal_EmptyCommandRejected(t *testing.T) {
+	sink := &testSink{}
+	b, rec := newTerminalTestBase(t, sink)
+
+	dispatchTerminal(b, acpMethodTerminalCreate, 1, map[string]interface{}{
+		"sessionId": "sess-1",
+		"command":   "",
+		"cwd":       b.workingDir,
+	})
+	resps := rec.wait(t, 1, 3*time.Second)
+	errObj := resps[0]["error"].(map[string]interface{})
+	assert.EqualValues(t, -32602, errObj["code"])
+	assert.Contains(t, errObj["message"], "command is required")
+}
+
+func TestACPTerminal_SessionIDMismatch(t *testing.T) {
+	sink := &testSink{}
+	b, rec := newTerminalTestBase(t, sink)
+
+	dispatchTerminal(b, acpMethodTerminalCreate, 1, map[string]interface{}{
+		"sessionId": "other-session",
+		"command":   "echo hi",
+		"cwd":       b.workingDir,
+	})
+	resps := rec.wait(t, 1, 3*time.Second)
+	errObj := resps[0]["error"].(map[string]interface{})
+	assert.EqualValues(t, -32602, errObj["code"])
+	assert.Contains(t, errObj["message"], "sessionId mismatch")
+}
+
+func TestACPTerminal_NoActiveSession(t *testing.T) {
+	sink := &testSink{}
+	b, rec := newTerminalTestBase(t, sink)
+	b.sessionID = ""
+
+	dispatchTerminal(b, acpMethodTerminalCreate, 1, map[string]interface{}{
+		"sessionId": "",
+		"command":   "echo hi",
+		"cwd":       b.workingDir,
+	})
+	resps := rec.wait(t, 1, 3*time.Second)
+	errObj := resps[0]["error"].(map[string]interface{})
+	assert.EqualValues(t, -32602, errObj["code"])
+	assert.Contains(t, errObj["message"], "no active session")
+}
+
+func TestACPTerminal_NegativeOutputByteLimitRejected(t *testing.T) {
+	sink := &testSink{}
+	b, rec := newTerminalTestBase(t, sink)
+
+	dispatchTerminal(b, acpMethodTerminalCreate, 1, map[string]interface{}{
+		"sessionId":       "sess-1",
+		"command":         "echo hi",
+		"cwd":             b.workingDir,
+		"outputByteLimit": -1,
+	})
+	resps := rec.wait(t, 1, 3*time.Second)
+	errObj := resps[0]["error"].(map[string]interface{})
+	assert.EqualValues(t, -32602, errObj["code"])
+	assert.Contains(t, errObj["message"], "outputByteLimit")
+}
+
+func TestACPTerminal_ArgvStyleCommand(t *testing.T) {
+	sink := &testSink{}
+	b, rec := newTerminalTestBase(t, sink)
+
+	dispatchTerminal(b, acpMethodTerminalCreate, 1, map[string]interface{}{
+		"sessionId": "sess-1",
+		"command":   "printf",
+		"args":      []string{"argv-ok"},
+		"cwd":       b.workingDir,
+	})
+	resps := rec.wait(t, 1, 3*time.Second)
+	require.Nil(t, resps[0]["error"])
+	termID := resps[0]["result"].(map[string]interface{})["terminalId"].(string)
+
+	dispatchTerminal(b, acpMethodTerminalWaitForExit, 2, map[string]interface{}{
+		"sessionId":  "sess-1",
+		"terminalId": termID,
+	})
+	_ = rec.wait(t, 2, 5*time.Second)
+
+	dispatchTerminal(b, acpMethodTerminalOutput, 3, map[string]interface{}{
+		"sessionId":  "sess-1",
+		"terminalId": termID,
+	})
+	resps = rec.wait(t, 3, 3*time.Second)
+	assert.Contains(t, resps[2]["result"].(map[string]interface{})["output"], "argv-ok")
+
+	dispatchTerminal(b, acpMethodTerminalRelease, 4, map[string]interface{}{
+		"sessionId":  "sess-1",
+		"terminalId": termID,
+	})
+	_ = rec.wait(t, 4, 3*time.Second)
+}
+
+func TestACPTerminal_EnvOverridesApplied(t *testing.T) {
+	sink := &testSink{}
+	b, rec := newTerminalTestBase(t, sink)
+
+	dispatchTerminal(b, acpMethodTerminalCreate, 1, map[string]interface{}{
+		"sessionId": "sess-1",
+		"command":   "printf '%s' \"$LEAPMUX_ACP_TERM_TEST\"",
+		"cwd":       b.workingDir,
+		"env": []map[string]string{
+			{"name": "LEAPMUX_ACP_TERM_TEST", "value": "from-host"},
+		},
+	})
+	resps := rec.wait(t, 1, 3*time.Second)
+	termID := resps[0]["result"].(map[string]interface{})["terminalId"].(string)
+
+	dispatchTerminal(b, acpMethodTerminalWaitForExit, 2, map[string]interface{}{
+		"sessionId":  "sess-1",
+		"terminalId": termID,
+	})
+	_ = rec.wait(t, 2, 5*time.Second)
+
+	dispatchTerminal(b, acpMethodTerminalOutput, 3, map[string]interface{}{
+		"sessionId":  "sess-1",
+		"terminalId": termID,
+	})
+	resps = rec.wait(t, 3, 3*time.Second)
+	assert.Contains(t, resps[2]["result"].(map[string]interface{})["output"], "from-host")
+
+	dispatchTerminal(b, acpMethodTerminalRelease, 4, map[string]interface{}{
+		"sessionId":  "sess-1",
+		"terminalId": termID,
+	})
+	_ = rec.wait(t, 4, 3*time.Second)
+}
+
+func TestACPTerminal_NonZeroExitMarksFailed(t *testing.T) {
+	sink := &testSink{}
+	b, rec := newTerminalTestBase(t, sink)
+
+	dispatchTerminal(b, acpMethodTerminalCreate, 1, map[string]interface{}{
+		"sessionId": "sess-1",
+		"command":   "exit 7",
+		"cwd":       b.workingDir,
+	})
+	resps := rec.wait(t, 1, 3*time.Second)
+	termID := resps[0]["result"].(map[string]interface{})["terminalId"].(string)
+
+	dispatchTerminal(b, acpMethodTerminalWaitForExit, 2, map[string]interface{}{
+		"sessionId":  "sess-1",
+		"terminalId": termID,
+	})
+	resps = rec.wait(t, 2, 5*time.Second)
+	assert.EqualValues(t, 7, resps[1]["result"].(map[string]interface{})["exitCode"])
+
+	sink.bgTasksMu.Lock()
+	row := sink.bgTasks[termID]
+	sink.bgTasksMu.Unlock()
+	assert.Equal(t, bgtask.StatusFailed, row.Status)
+
+	dispatchTerminal(b, acpMethodTerminalRelease, 3, map[string]interface{}{
+		"sessionId":  "sess-1",
+		"terminalId": termID,
+	})
+	_ = rec.wait(t, 3, 3*time.Second)
+}
+
+func TestACPTerminal_OutputBeforeExitOmitsExitStatus(t *testing.T) {
+	sink := &testSink{}
+	b, rec := newTerminalTestBase(t, sink)
+
+	dispatchTerminal(b, acpMethodTerminalCreate, 1, map[string]interface{}{
+		"sessionId": "sess-1",
+		"command":   "sleep 30",
+		"cwd":       b.workingDir,
+	})
+	resps := rec.wait(t, 1, 3*time.Second)
+	termID := resps[0]["result"].(map[string]interface{})["terminalId"].(string)
+
+	dispatchTerminal(b, acpMethodTerminalOutput, 2, map[string]interface{}{
+		"sessionId":  "sess-1",
+		"terminalId": termID,
+	})
+	resps = rec.wait(t, 2, 3*time.Second)
+	outResult := resps[1]["result"].(map[string]interface{})
+	_, hasExit := outResult["exitStatus"]
+	assert.False(t, hasExit, "in-flight terminals must omit exitStatus")
+
+	dispatchTerminal(b, acpMethodTerminalRelease, 3, map[string]interface{}{
+		"sessionId":  "sess-1",
+		"terminalId": termID,
+	})
+	_ = rec.wait(t, 3, 5*time.Second)
+}
+
+func TestACPTerminal_WaitForExitDoesNotBlockCaller(t *testing.T) {
+	sink := &testSink{}
+	b, rec := newTerminalTestBase(t, sink)
+
+	dispatchTerminal(b, acpMethodTerminalCreate, 1, map[string]interface{}{
+		"sessionId": "sess-1",
+		"command":   "sleep 1",
+		"cwd":       b.workingDir,
+	})
+	resps := rec.wait(t, 1, 3*time.Second)
+	termID := resps[0]["result"].(map[string]interface{})["terminalId"].(string)
+
+	// Dispatch kill immediately after wait_for_exit to prove the read-loop
+	// handler returned without waiting for the sleep to finish.
+	dispatchTerminal(b, acpMethodTerminalWaitForExit, 2, map[string]interface{}{
+		"sessionId":  "sess-1",
+		"terminalId": termID,
+	})
+	dispatchTerminal(b, acpMethodTerminalKill, 3, map[string]interface{}{
+		"sessionId":  "sess-1",
+		"terminalId": termID,
+	})
+	resps = rec.wait(t, 3, 5*time.Second)
+	ids := make([]float64, 0, 2)
+	for _, r := range resps[1:] {
+		ids = append(ids, r["id"].(float64))
+	}
+	assert.Contains(t, ids, float64(3), "kill must be handled while wait_for_exit is outstanding")
+
+	dispatchTerminal(b, acpMethodTerminalRelease, 4, map[string]interface{}{
+		"sessionId":  "sess-1",
+		"terminalId": termID,
+	})
+	_ = rec.wait(t, 4, 5*time.Second)
+}
+
+func TestACPTerminal_KillAndReleaseUnknownID(t *testing.T) {
+	sink := &testSink{}
+	b, rec := newTerminalTestBase(t, sink)
+
+	dispatchTerminal(b, acpMethodTerminalKill, 1, map[string]interface{}{
+		"sessionId":  "sess-1",
+		"terminalId": "term_gone",
+	})
+	dispatchTerminal(b, acpMethodTerminalRelease, 2, map[string]interface{}{
+		"sessionId":  "sess-1",
+		"terminalId": "term_gone",
+	})
+	resps := rec.wait(t, 2, 3*time.Second)
+	assert.EqualValues(t, -32602, resps[0]["error"].(map[string]interface{})["code"])
+	assert.EqualValues(t, -32602, resps[1]["error"].(map[string]interface{})["code"])
+}
+
+func TestACPTerminal_MalformedParams(t *testing.T) {
+	sink := &testSink{}
+	b, rec := newTerminalTestBase(t, sink)
+
+	line, _ := json.Marshal(map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  acpMethodTerminalCreate,
+		"params":  "not-an-object",
+	})
+	b.handleACPOutput(parseLine(line), nil, nil)
+	resps := rec.wait(t, 1, 3*time.Second)
+	assert.EqualValues(t, -32602, resps[0]["error"].(map[string]interface{})["code"])
+}
+
+func TestACPTerminal_MissingJSONRPCIDIsIgnored(t *testing.T) {
+	sink := &testSink{}
+	b, rec := newTerminalTestBase(t, sink)
+
+	line, _ := json.Marshal(map[string]interface{}{
+		"jsonrpc": "2.0",
+		"method":  acpMethodTerminalCreate,
+		"params": map[string]interface{}{
+			"sessionId": "sess-1",
+			"command":   "echo hi",
+			"cwd":       b.workingDir,
+		},
+	})
+	b.handleACPOutput(parseLine(line), nil, nil)
+
+	select {
+	case <-rec.ch:
+		t.Fatal("expected no JSON-RPC response when id is missing")
+	case <-time.After(100 * time.Millisecond):
+	}
+	b.terminalsMu.Lock()
+	assert.Empty(t, b.terminals)
+	b.terminalsMu.Unlock()
+}

--- a/backend/internal/worker/agent/acp_terminal_test.go
+++ b/backend/internal/worker/agent/acp_terminal_test.go
@@ -4,6 +4,7 @@ package agent
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"os"
@@ -207,7 +208,7 @@ func TestACPTerminal_KillThenWait(t *testing.T) {
 	sink.bgTasksMu.Lock()
 	row := sink.bgTasks[termID]
 	sink.bgTasksMu.Unlock()
-	assert.Equal(t, bgtask.StatusFailed, row.Status)
+	assert.Equal(t, bgtask.StatusStopped, row.Status, "host kill must map to StatusStopped")
 }
 
 func TestACPTerminal_OutputByteLimitTruncates(t *testing.T) {
@@ -404,6 +405,42 @@ func TestACPTerminal_NegativeOutputByteLimitRejected(t *testing.T) {
 	errObj := resps[0]["error"].(map[string]interface{})
 	assert.EqualValues(t, -32602, errObj["code"])
 	assert.Contains(t, errObj["message"], "outputByteLimit")
+}
+
+func TestACPTerminal_ZeroOutputByteLimitRetainsNothing(t *testing.T) {
+	sink := &testSink{}
+	b, rec := newTerminalTestBase(t, sink)
+	limit := 0
+
+	dispatchTerminal(b, acpMethodTerminalCreate, 1, map[string]interface{}{
+		"sessionId":       "sess-1",
+		"command":         "printf 'abcdefgh'",
+		"cwd":             b.workingDir,
+		"outputByteLimit": limit,
+	})
+	resps := rec.wait(t, 1, 3*time.Second)
+	termID := resps[0]["result"].(map[string]interface{})["terminalId"].(string)
+
+	dispatchTerminal(b, acpMethodTerminalWaitForExit, 2, map[string]interface{}{
+		"sessionId":  "sess-1",
+		"terminalId": termID,
+	})
+	_ = rec.wait(t, 2, 5*time.Second)
+
+	dispatchTerminal(b, acpMethodTerminalOutput, 3, map[string]interface{}{
+		"sessionId":  "sess-1",
+		"terminalId": termID,
+	})
+	resps = rec.wait(t, 3, 3*time.Second)
+	outResult := resps[2]["result"].(map[string]interface{})
+	assert.Equal(t, true, outResult["truncated"])
+	assert.Equal(t, "", outResult["output"])
+
+	dispatchTerminal(b, acpMethodTerminalRelease, 4, map[string]interface{}{
+		"sessionId":  "sess-1",
+		"terminalId": termID,
+	})
+	_ = rec.wait(t, 4, 3*time.Second)
 }
 
 func TestACPTerminal_ArgvStyleCommand(t *testing.T) {
@@ -625,4 +662,178 @@ func TestACPTerminal_MissingJSONRPCIDIsIgnored(t *testing.T) {
 	b.terminalsMu.Lock()
 	assert.Empty(t, b.terminals)
 	b.terminalsMu.Unlock()
+}
+
+func TestACPTerminal_StopReapsLongLivedChild(t *testing.T) {
+	sink := &testSink{}
+	b, rec := newTerminalTestBase(t, sink)
+	pr, pw := io.Pipe()
+	go func() { _, _ = io.Copy(io.Discard, pr) }()
+	t.Cleanup(func() { _ = pw.Close(); _ = pr.Close() })
+	b.stdin = struct {
+		io.Writer
+		io.Closer
+	}{Writer: io.MultiWriter(rec, pw), Closer: pw}
+	b.processDone = make(chan struct{})
+	close(b.processDone)
+
+	dispatchTerminal(b, acpMethodTerminalCreate, 1, map[string]interface{}{
+		"sessionId": "sess-1",
+		// sleep inherits the host pipes; without process-group kill, Stop
+		// would hang waiting for stdout EOF after killing only /bin/sh.
+		"command": "sleep 60",
+		"cwd":     b.workingDir,
+	})
+	_ = rec.wait(t, 1, 3*time.Second)
+
+	done := make(chan struct{})
+	go func() {
+		b.Stop()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(8 * time.Second):
+		t.Fatal("Stop hung waiting for ACP terminal teardown")
+	}
+
+	b.terminalsMu.Lock()
+	assert.True(t, b.terminalsClosed)
+	assert.Empty(t, b.terminals)
+	b.terminalsMu.Unlock()
+}
+
+func TestACPTerminal_CreateRejectedAfterStop(t *testing.T) {
+	sink := &testSink{}
+	b, rec := newTerminalTestBase(t, sink)
+	pr, pw := io.Pipe()
+	go func() { _, _ = io.Copy(io.Discard, pr) }()
+	t.Cleanup(func() { _ = pw.Close(); _ = pr.Close() })
+	b.stdin = struct {
+		io.Writer
+		io.Closer
+	}{Writer: io.MultiWriter(rec, pw), Closer: pw}
+	b.processDone = make(chan struct{})
+	close(b.processDone)
+
+	b.Stop()
+
+	dispatchTerminal(b, acpMethodTerminalCreate, 1, map[string]interface{}{
+		"sessionId": "sess-1",
+		"command":   "echo hi",
+		"cwd":       b.workingDir,
+	})
+	resps := rec.wait(t, 1, 3*time.Second)
+	errObj := resps[0]["error"].(map[string]interface{})
+	assert.EqualValues(t, -32603, errObj["code"])
+	assert.Contains(t, errObj["message"], "stopped")
+}
+
+func TestACPTerminal_ReleaseSessionOnClearContext(t *testing.T) {
+	sink := &testSink{}
+	b, rec := newTerminalTestBase(t, sink)
+	// newSessionLocked needs a cancelled ctx so sendRequest fails fast after
+	// releaseSessionTerminals has already run.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	b.ctx = ctx
+	b.processDone = make(chan struct{})
+	close(b.processDone)
+
+	dispatchTerminal(b, acpMethodTerminalCreate, 1, map[string]interface{}{
+		"sessionId": "sess-1",
+		"command":   "sleep 30",
+		"cwd":       b.workingDir,
+	})
+	resps := rec.wait(t, 1, 3*time.Second)
+	termID := resps[0]["result"].(map[string]interface{})["terminalId"].(string)
+
+	_, ok := b.ClearContext()
+	assert.False(t, ok, "session/new must fail without a live agent")
+
+	b.terminalsMu.Lock()
+	_, still := b.terminals[termID]
+	closed := b.terminalsClosed
+	b.terminalsMu.Unlock()
+	assert.False(t, still)
+	assert.False(t, closed, "ClearContext must not latch terminals closed")
+
+	sink.bgTasksMu.Lock()
+	row := sink.bgTasks[termID]
+	sink.bgTasksMu.Unlock()
+	assert.Equal(t, bgtask.StatusStopped, row.Status)
+}
+
+func TestACPTerminal_BaseEnvPinsWorkerMarker(t *testing.T) {
+	sink := &testSink{}
+	b, rec := newTerminalTestBase(t, sink)
+	t.Setenv("LEAPMUX_WORKER", "0")
+	t.Setenv("GOOSE_TERMINAL", "1")
+
+	dispatchTerminal(b, acpMethodTerminalCreate, 1, map[string]interface{}{
+		"sessionId": "sess-1",
+		"command":   `printf '%s|%s' "$LEAPMUX_WORKER" "${GOOSE_TERMINAL-}"`,
+		"cwd":       b.workingDir,
+	})
+	resps := rec.wait(t, 1, 3*time.Second)
+	termID := resps[0]["result"].(map[string]interface{})["terminalId"].(string)
+
+	dispatchTerminal(b, acpMethodTerminalWaitForExit, 2, map[string]interface{}{
+		"sessionId":  "sess-1",
+		"terminalId": termID,
+	})
+	_ = rec.wait(t, 2, 5*time.Second)
+
+	dispatchTerminal(b, acpMethodTerminalOutput, 3, map[string]interface{}{
+		"sessionId":  "sess-1",
+		"terminalId": termID,
+	})
+	resps = rec.wait(t, 3, 3*time.Second)
+	out := resps[2]["result"].(map[string]interface{})["output"].(string)
+	assert.Equal(t, "1|", out, "FinalizeAgentEnv must pin LEAPMUX_WORKER and scrub GOOSE_TERMINAL")
+
+	dispatchTerminal(b, acpMethodTerminalRelease, 4, map[string]interface{}{
+		"sessionId":  "sess-1",
+		"terminalId": termID,
+	})
+	_ = rec.wait(t, 4, 3*time.Second)
+}
+
+func TestACPTerminal_KillReportsSignalName(t *testing.T) {
+	sink := &testSink{}
+	b, rec := newTerminalTestBase(t, sink)
+
+	dispatchTerminal(b, acpMethodTerminalCreate, 1, map[string]interface{}{
+		"sessionId": "sess-1",
+		"command":   "sleep 30",
+		"cwd":       b.workingDir,
+	})
+	resps := rec.wait(t, 1, 3*time.Second)
+	termID := resps[0]["result"].(map[string]interface{})["terminalId"].(string)
+
+	dispatchTerminal(b, acpMethodTerminalKill, 2, map[string]interface{}{
+		"sessionId":  "sess-1",
+		"terminalId": termID,
+	})
+	_ = rec.wait(t, 2, 3*time.Second)
+
+	dispatchTerminal(b, acpMethodTerminalWaitForExit, 3, map[string]interface{}{
+		"sessionId":  "sess-1",
+		"terminalId": termID,
+	})
+	resps = rec.wait(t, 3, 5*time.Second)
+	waitResult := resps[2]["result"].(map[string]interface{})
+	if waitResult["exitCode"] != nil {
+		t.Logf("got exitCode=%v (acceptable if shell reports numeric)", waitResult["exitCode"])
+	} else {
+		sig, _ := waitResult["signal"].(string)
+		require.NotEmpty(t, sig)
+		assert.NotEqual(t, "terminated", sig, "should report the real WaitStatus signal when available")
+	}
+
+	dispatchTerminal(b, acpMethodTerminalRelease, 4, map[string]interface{}{
+		"sessionId":  "sess-1",
+		"terminalId": termID,
+	})
+	_ = rec.wait(t, 4, 3*time.Second)
 }

--- a/backend/internal/worker/agent/acp_terminal_unit_test.go
+++ b/backend/internal/worker/agent/acp_terminal_unit_test.go
@@ -41,7 +41,7 @@ func TestTruncateACPTerminalOutput_AllGOOS(t *testing.T) {
 
 	hello := []byte("hello")
 	assert.Equal(t, hello, truncateACPTerminalOutput(hello, 10))
-	assert.Equal(t, hello, truncateACPTerminalOutput(hello, 0))
+	assert.Nil(t, truncateACPTerminalOutput(hello, 0), "limit 0 retains nothing")
 }
 
 func TestMergeACPTerminalEnv_AllGOOS(t *testing.T) {
@@ -51,12 +51,21 @@ func TestMergeACPTerminalEnv_AllGOOS(t *testing.T) {
 		{Name: "BAZ", Value: "z"},
 		{Name: "", Value: "ignored"},
 	})
-	assert.Equal(t, []string{"PATH=/bin", "FOO=9", "BAR=2", "BAZ=z"}, out)
+	// PinEnv drops overridden keys then appends assignments.
+	assert.Equal(t, []string{"PATH=/bin", "BAR=2", "FOO=9", "BAZ=z"}, out)
 	assert.Equal(t, base, []string{"PATH=/bin", "FOO=1", "BAR=2"}, "base must not be mutated")
 
 	same := mergeACPTerminalEnv(base, nil)
 	assert.Equal(t, base, same)
 	assert.Equal(t, base, mergeACPTerminalEnv(base, []acpTerminalEnvVar{}))
+}
+
+func TestAppendOutput_ZeroByteLimitDiscards(t *testing.T) {
+	sess := &acpTerminalSession{byteLimit: 0}
+	sess.appendOutput([]byte("hello"))
+	out, truncated, _, _, _ := sess.snapshot()
+	assert.Equal(t, "", out)
+	assert.True(t, truncated)
 }
 
 func TestExitStatusFromProcessState_Nil(t *testing.T) {

--- a/backend/internal/worker/agent/acp_terminal_unit_test.go
+++ b/backend/internal/worker/agent/acp_terminal_unit_test.go
@@ -1,0 +1,84 @@
+package agent
+
+import (
+	"encoding/json"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Init / buffer helpers run on all platforms (no process spawn).
+func TestAcpStandardInitParams_ClientCapabilitiesTerminal_AllGOOS(t *testing.T) {
+	raw, err := acpStandardInitParams()
+	require.NoError(t, err)
+
+	var params map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &params))
+
+	_, hasLegacy := params["capabilities"]
+	assert.False(t, hasLegacy, "legacy capabilities key must not be sent")
+
+	caps, ok := params["clientCapabilities"].(map[string]interface{})
+	require.True(t, ok, "clientCapabilities must be present")
+	assert.Equal(t, true, caps["terminal"])
+
+	fs, ok := caps["fs"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, false, fs["readTextFile"])
+	assert.Equal(t, false, fs["writeTextFile"])
+}
+
+func TestTruncateACPTerminalOutput_AllGOOS(t *testing.T) {
+	// "xy" + "é" (2-byte UTF-8) + "abc". Keeping the last 4 bytes starts on
+	// the trailing byte of "é"; truncation must advance to the next rune
+	// start, retaining "abc" rather than a broken leading byte.
+	in := append([]byte("xy"), []byte("éabc")...)
+	out := truncateACPTerminalOutput(in, 4)
+	assert.Equal(t, "abc", string(out))
+	assert.True(t, utf8.Valid(out))
+
+	hello := []byte("hello")
+	assert.Equal(t, hello, truncateACPTerminalOutput(hello, 10))
+	assert.Equal(t, hello, truncateACPTerminalOutput(hello, 0))
+}
+
+func TestMergeACPTerminalEnv_AllGOOS(t *testing.T) {
+	base := []string{"PATH=/bin", "FOO=1", "BAR=2"}
+	out := mergeACPTerminalEnv(base, []acpTerminalEnvVar{
+		{Name: "FOO", Value: "9"},
+		{Name: "BAZ", Value: "z"},
+		{Name: "", Value: "ignored"},
+	})
+	assert.Equal(t, []string{"PATH=/bin", "FOO=9", "BAR=2", "BAZ=z"}, out)
+	assert.Equal(t, base, []string{"PATH=/bin", "FOO=1", "BAR=2"}, "base must not be mutated")
+
+	same := mergeACPTerminalEnv(base, nil)
+	assert.Equal(t, base, same)
+	assert.Equal(t, base, mergeACPTerminalEnv(base, []acpTerminalEnvVar{}))
+}
+
+func TestExitStatusFromProcessState_Nil(t *testing.T) {
+	code, sig := exitStatusFromProcessState(nil)
+	assert.Nil(t, code)
+	assert.Nil(t, sig)
+}
+
+func TestTruncateACPTerminalOutput_DropsIncompleteTrailingStart(t *testing.T) {
+	// A lone continuation byte at the cut point advances past the whole
+	// buffer when nothing remains that starts a rune.
+	in := []byte{0x80, 0x80, 0x80}
+	out := truncateACPTerminalOutput(in, 2)
+	assert.Nil(t, out)
+}
+
+func TestSplitEnvKV(t *testing.T) {
+	name, value, ok := splitEnvKV("FOO=bar=baz")
+	assert.True(t, ok)
+	assert.Equal(t, "FOO", name)
+	assert.Equal(t, "bar=baz", value)
+
+	_, _, ok = splitEnvKV("NOEQUALS")
+	assert.False(t, ok)
+}

--- a/backend/internal/worker/hub/client.go
+++ b/backend/internal/worker/hub/client.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -352,6 +353,11 @@ func (c *Client) Connect(ctx context.Context, authToken string) error {
 	// Send an initial heartbeat INLINE on the stream before the writer exists.
 	// ConnectRPC with gRPC protocol only sends HTTP/2 headers on the first
 	// Send(), and nothing else may enqueue until the writer is published.
+	//
+	// When the Hub refuses before that write finishes (fenced registry, worker
+	// cap, …), Send wraps io.EOF and Receive carries the real status — see
+	// connect.BidiStreamForClient.Send. Surface that status so reconnect logic
+	// sees Unavailable/ResourceExhausted instead of a bare Unknown/EOF.
 	if err := stream.Send(&leapmuxv1.ConnectRequest{
 		Payload: &leapmuxv1.ConnectRequest_Heartbeat{
 			Heartbeat: &leapmuxv1.Heartbeat{
@@ -362,6 +368,11 @@ func (c *Client) Connect(ctx context.Context, authToken string) error {
 			},
 		},
 	}); err != nil {
+		if errors.Is(err, io.EOF) {
+			if _, recvErr := stream.Receive(); recvErr != nil {
+				return fmt.Errorf("initial heartbeat: %w", recvErr)
+			}
+		}
 		return fmt.Errorf("initial heartbeat: %w", err)
 	}
 

--- a/backend/internal/worker/service/watch_events_terminal_test.go
+++ b/backend/internal/worker/service/watch_events_terminal_test.go
@@ -225,17 +225,20 @@ func TestWatchEvents_Terminal_ColdSubscribeAfterRingWrap(t *testing.T) {
 	svc, d, _ := setupTestService(t)
 	startTestTerminal(t, svc, ctx, "t-wrap")
 
-	// Inject >100KB synthetic output directly so we don't have to wait on
-	// the shell to produce it. AppendOutput goes through the same write
-	// path as PTY output.
-	big := make([]byte, 150*1024)
-	for i := range big {
-		big[i] = 'x'
-	}
+	// Freeze before injecting. A live shell — especially Windows ConPTY —
+	// keeps emitting mode/title sequences that leave modeTracker
+	// non-default. SnapshotSince correctly prepends a restore prefix for
+	// that state; leaving the PTY live races those bytes into the ring
+	// fill and makes a naive len(data)<=ringSize assertion flake.
+	baseline := testutil.FreezeTerminalOutput(t, svc.Terminals, "t-wrap")
+
+	const ringSize = 100 * 1024 // matches terminal.screenBufferSize
+	big := bytes.Repeat([]byte{'x'}, ringSize+50*1024)
 	require.True(t, svc.Terminals.AppendOutput("t-wrap", big))
+	wantEnd := baseline + int64(len(big))
 	testutil.AssertEventually(t, func() bool {
 		_, off, _ := svc.Terminals.ScreenSnapshotSince("t-wrap", 0)
-		return off >= int64(len(big))
+		return off >= wantEnd
 	}, "appended bytes arrived")
 
 	// Cold subscribe — after_offset=0 is now well below the retained
@@ -256,9 +259,17 @@ func TestWatchEvents_Terminal_ColdSubscribeAfterRingWrap(t *testing.T) {
 	require.NotNil(t, snap)
 	assert.True(t, snap.GetIsSnapshot(),
 		"fell-behind-ring cold subscribe must be flagged as snapshot so the frontend resets")
-	// Delta size is bounded by the 100KB ring, even though the PTY has
-	// emitted ~150KB.
-	assert.LessOrEqual(t, len(snap.GetData()), 100*1024)
-	assert.Greater(t, snap.GetEndOffset(), int64(100*1024),
+
+	data := snap.GetData()
+	// Retained ring is ringSize bytes. Fallen-behind snapshots may also
+	// prepend a synthesized mode-restore prefix that does NOT count
+	// toward end_offset, so len(data) can exceed ringSize (the failure
+	// mode that used to flake this test on Windows at 102432 > 102400).
+	require.GreaterOrEqual(t, len(data), ringSize)
+	assert.True(t, bytes.HasSuffix(data, bytes.Repeat([]byte{'x'}, ringSize)),
+		"snapshot body must be the retained ring (last %d injected bytes)", ringSize)
+	assert.Equal(t, wantEnd, snap.GetEndOffset(),
+		"end_offset is the cumulative counter, not truncated to the ring")
+	assert.Greater(t, snap.GetEndOffset(), int64(ringSize),
 		"end_offset reflects the cumulative counter, which is > ring size once the ring has wrapped")
 }

--- a/frontend/src/components/chat/providers/acp/extractors/execute.test.ts
+++ b/frontend/src/components/chat/providers/acp/extractors/execute.test.ts
@@ -42,4 +42,22 @@ describe('acpExecuteFromToolCall', () => {
     expect(source?.isError).toBe(true)
     expect(source?.exitCode).toBe(5)
   })
+
+  it('still extracts text when a terminal content block is also present', () => {
+    const source = acpExecuteFromToolCall({
+      kind: 'execute',
+      status: 'completed',
+      rawInput: { command: 'echo hi' },
+      rawOutput: { metadata: { exit: 0 } },
+      content: [
+        { type: 'terminal', terminalId: 'term_abc' },
+        { type: 'content', content: { text: 'hi\n' } },
+      ],
+    })
+    expect(source).toEqual({
+      output: 'hi\n',
+      exitCode: 0,
+      isError: false,
+    })
+  })
 })

--- a/frontend/src/components/chat/providers/acp/extractors/terminal.test.ts
+++ b/frontend/src/components/chat/providers/acp/extractors/terminal.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { acpTerminalFromToolCallContent } from './terminal'
+
+describe('acpTerminalFromToolCallContent', () => {
+  it('returns null for null/undefined/non-array', () => {
+    expect(acpTerminalFromToolCallContent(null)).toBeNull()
+    expect(acpTerminalFromToolCallContent(undefined)).toBeNull()
+    expect(acpTerminalFromToolCallContent('nope')).toBeNull()
+    expect(acpTerminalFromToolCallContent({})).toBeNull()
+  })
+
+  it('extracts the first terminal entry', () => {
+    expect(acpTerminalFromToolCallContent([
+      { type: 'content', content: { text: 'noise' } },
+      { type: 'terminal', terminalId: 'term_abc' },
+      { type: 'terminal', terminalId: 'term_later' },
+    ])).toEqual({ terminalId: 'term_abc' })
+  })
+
+  it('skips terminal entries without a terminalId', () => {
+    expect(acpTerminalFromToolCallContent([
+      { type: 'terminal' },
+      { type: 'terminal', terminalId: '' },
+      { type: 'terminal', terminalId: 'term_ok' },
+    ])).toEqual({ terminalId: 'term_ok' })
+  })
+
+  it('returns null when no terminal entry is present', () => {
+    expect(acpTerminalFromToolCallContent([
+      { type: 'diff', path: 'a.ts', oldText: '', newText: 'x' },
+      { type: 'content', content: { text: 'hi' } },
+    ])).toBeNull()
+  })
+
+  it('skips non-object entries in the content array', () => {
+    expect(acpTerminalFromToolCallContent([
+      null,
+      'terminal',
+      42,
+      { type: 'terminal', terminalId: 'term_after_noise' },
+    ])).toEqual({ terminalId: 'term_after_noise' })
+  })
+})

--- a/frontend/src/components/chat/providers/acp/extractors/terminal.ts
+++ b/frontend/src/components/chat/providers/acp/extractors/terminal.ts
@@ -2,8 +2,8 @@ import { isObject, pickString } from '~/lib/jsonPick'
 
 /**
  * First ACP tool-call content entry of `{ type: 'terminal', terminalId }`.
- * Goose embeds this while a host terminal runs so the client can correlate
- * the tool call with a live terminal session. Returns null when absent.
+ * ACP agents embed this while a host terminal runs so the client can
+ * correlate the tool call with the session. Returns null when absent.
  */
 export function acpTerminalFromToolCallContent(
   content: unknown,

--- a/frontend/src/components/chat/providers/acp/extractors/terminal.ts
+++ b/frontend/src/components/chat/providers/acp/extractors/terminal.ts
@@ -1,0 +1,25 @@
+import { isObject, pickString } from '~/lib/jsonPick'
+
+/**
+ * First ACP tool-call content entry of `{ type: 'terminal', terminalId }`.
+ * Goose embeds this while a host terminal runs so the client can correlate
+ * the tool call with a live terminal session. Returns null when absent.
+ */
+export function acpTerminalFromToolCallContent(
+  content: unknown,
+): { terminalId: string } | null {
+  if (!Array.isArray(content))
+    return null
+  for (const entry of content) {
+    if (!isObject(entry))
+      continue
+    const obj = entry as Record<string, unknown>
+    if (obj.type !== 'terminal')
+      continue
+    const terminalId = pickString(obj, 'terminalId')
+    if (!terminalId)
+      continue
+    return { terminalId }
+  }
+  return null
+}

--- a/frontend/src/components/chat/providers/acp/renderers/toolCallUpdate.tsx
+++ b/frontend/src/components/chat/providers/acp/renderers/toolCallUpdate.tsx
@@ -6,6 +6,7 @@ import type { ReadFileResultSource } from '../../../results/readFileResult'
 import type { SearchResultSource } from '../../../results/searchResult'
 import type { WebFetchResultSource } from '../../../results/webFetchResult'
 import CircleAlert from 'lucide-solid/icons/circle-alert'
+import Terminal from 'lucide-solid/icons/terminal'
 import { createMemo, Show } from 'solid-js'
 import { useCopyButton } from '~/hooks/useCopyButton'
 import { pickFirstString, pickNumber, pickObject, pickString } from '~/lib/jsonPick'
@@ -30,6 +31,7 @@ import { acpExecuteFromToolCall } from '../extractors/execute'
 import { acpFileEditFromToolCallContent, acpFileEditFromToolCallRawInput } from '../extractors/fileEdit'
 import { acpReadFromToolCall } from '../extractors/read'
 import { acpSearchFromToolCall } from '../extractors/search'
+import { acpTerminalFromToolCallContent } from '../extractors/terminal'
 import { acpWebFetchFromToolCall } from '../extractors/webFetch'
 import { ACP_FILE_PATH_KEYS, collectAcpToolText } from '../rendering'
 import { kindIcon, kindLabel } from './helpers'
@@ -218,6 +220,14 @@ export function ToolCallUpdateMessage(props: {
   // Execute-specific: hide summary when expanded + expandable command.
   const displaySummary = () => expanded() && commandExpandable() ? undefined : summary(!expanded())
 
+  // Goose embeds `{ type: 'terminal', terminalId }` while a host terminal runs.
+  // Badge only — no live streaming in this PR.
+  const terminalRef = createMemo(() => {
+    const context = props.context
+    const toolUse = props.toolUse
+    return cachedRenderValue(context, 'acp.toolCallUpdate.terminal', () => acpTerminalFromToolCallContent(toolUse.content))
+  })
+
   return (
     <ToolUseLayout
       icon={icon()}
@@ -235,6 +245,12 @@ export function ToolCallUpdateMessage(props: {
       }}
       alwaysVisible
     >
+      <Show when={terminalRef()}>
+        {ref => (
+          <ToolHeaderRow icon={Terminal} title={`Terminal ${ref().terminalId}`} />
+        )}
+      </Show>
+
       {/* Execute: full command (when expanded) */}
       <Show when={kind() === ACP_TOOL_KIND.EXECUTE && expanded() && commandExpandable()}>
         <CommandInputBody command={command()} context={props.context} />

--- a/frontend/src/components/chat/providers/acp/renderers/toolCallUpdate.tsx
+++ b/frontend/src/components/chat/providers/acp/renderers/toolCallUpdate.tsx
@@ -220,7 +220,7 @@ export function ToolCallUpdateMessage(props: {
   // Execute-specific: hide summary when expanded + expandable command.
   const displaySummary = () => expanded() && commandExpandable() ? undefined : summary(!expanded())
 
-  // Goose embeds `{ type: 'terminal', terminalId }` while a host terminal runs.
+  // ACP `{ type: 'terminal', terminalId }` content while a host terminal runs.
   // Badge only — no live streaming in this PR.
   const terminalRef = createMemo(() => {
     const context = props.context

--- a/frontend/src/components/chat/providers/commandRendering.test.tsx
+++ b/frontend/src/components/chat/providers/commandRendering.test.tsx
@@ -241,6 +241,23 @@ describe('canonical command status label across providers', () => {
     expect(container.textContent ?? '').toContain('Error (exit 5)')
   })
 
+  it('openCode execute with terminal content block shows a Terminal badge', () => {
+    const { container } = renderOpenCodeUpdate({
+      sessionUpdate: 'tool_call_update',
+      kind: 'execute',
+      status: 'completed',
+      title: 'Run something',
+      rawInput: { command: 'echo hi' },
+      rawOutput: { metadata: { exit: 0 } },
+      content: [
+        { type: 'terminal', terminalId: 'term_abc123' },
+        { type: 'content', content: { text: 'hi\n' } },
+      ],
+    })
+    expect(container.textContent ?? '').toContain('Terminal term_abc123')
+    expect(container.textContent ?? '').toContain('hi')
+  })
+
   it('uses the ACP tool-call expanded key for delegated execute output', () => {
     const output = Array.from({ length: 8 }, (_, i) => `output line ${i + 1}`).join('\n')
     const [expanded, setExpanded] = createSignal(false)


### PR DESCRIPTION
## Motivation

Agents that speak ACP (Goose, Reasonix, and others) expect the host to advertise `clientCapabilities.terminal` and implement `terminal/*` so shell work runs as host-managed command sessions. LeapMux was sending a non-standard empty `capabilities` object and had no host for those RPCs, so agent shells could not surface in Background tasks. Follow-up CI failures on this branch were unrelated flakes/brittle assertions that blocked merge.

## Modifications

- Advertise ACP-standard `clientCapabilities` with `terminal: true` (fs left false) and host `terminal/create|output|wait_for_exit|kill|release`, wiring KindShell Background-task rows and a basic chat badge for `{ type: "terminal", terminalId }`.
- Harden host-terminal lifecycle: process-group/JobObject teardown, bounded Stop waits, closed latch after Stop/Wait, ClearContext release, agent env inheritance, `outputByteLimit: 0` retain-nothing, kill→`StatusStopped`, real WaitStatus signals.
- Unblock CI on this PR: freeze PTY and allow mode-restore prefix in `TestWatchEvents_Terminal_ColdSubscribeAfterRingWrap`; tolerate ConnectRPC `io.EOF` on first Send when the Hub refuses (fenced-registry / worker-cap tests and worker client).

## Result

ACP agents can run host command sessions in LeapMux and see them as shell Background tasks with a chat badge. Host teardown no longer hangs or orphans processes across Stop/crash/ClearContext. Windows ring-wrap and linux-arm64 fenced-Connect checks on this PR pass under the corrected contracts.

Closes #370