### PR TITLE
fix(auth)!: Slide a session before it can expire, and take units

### DIFF
--- a/backend/cmd/leapmux/worker.go
+++ b/backend/cmd/leapmux/worker.go
@@ -166,8 +166,8 @@ func runWorker(args []string) error {
 		DataDir:              cfg.DataDir,
 		HubURL:               cfg.HubURL,
 		AuthToken:            state.AuthToken,
-		AgentStartupTimeout:  cfg.AgentStartupTimeout(),
-		APITimeout:           cfg.APITimeout(),
+		AgentStartupTimeout:  cfg.AgentStartupTimeout,
+		APITimeout:           cfg.APITimeout,
 		UseLoginShell:        cfg.UseLoginShell,
 		WakeLock:             wakeLockTracker,
 	})

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.20.0
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-sql-driver/mysql v1.10.0
+	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/klauspost/compress v1.19.2
@@ -141,7 +142,6 @@ require (
 	github.com/go-toolsmith/astp v1.1.0 // indirect
 	github.com/go-toolsmith/strparse v1.1.0 // indirect
 	github.com/go-toolsmith/typep v1.1.0 // indirect
-	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/go-xmlfmt/xmlfmt v1.1.3 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/godoc-lint/godoc-lint v0.11.2 // indirect

--- a/backend/hub/server.go
+++ b/backend/hub/server.go
@@ -302,7 +302,7 @@ func NewServer(cfg *config.Config, opts ...ServerOption) (*Server, error) {
 
 	logQueueMemoryBudgets(slog.Default(), queueBasis,
 		relayBudget, workerBudget, userEventsBudget)
-	pendingReqs := workermgr.NewPendingRequests(cfg.APITimeout)
+	pendingReqs := workermgr.NewPendingRequests(func() time.Duration { return cfg.APITimeout })
 
 	apiTokenPepper := ks.Pepper()
 	tokenValidator, tvErr := auth.NewTokenValidator(st, apiTokenPepper[:])
@@ -316,7 +316,7 @@ func NewServer(cfg *config.Config, opts ...ServerOption) (*Server, error) {
 		TokenValidator:            tokenValidator,
 		SecureCookies:             cfg.SecureCookies,
 		EmailVerificationRequired: cfg.EmailVerificationRequired,
-		SessionDuration:           cfg.SessionDuration(),
+		SessionDuration:           cfg.SessionDuration,
 	})
 	acquired.authContexts = authContexts
 	// Let a sliding cookie session (and a rotated bearer, via the credential
@@ -336,7 +336,7 @@ func NewServer(cfg *config.Config, opts ...ServerOption) (*Server, error) {
 	connectOpts := connectOptions(
 		auth.NewShutdownInterceptor(shutdownCh),
 		metrics.NewInterceptor(),
-		auth.NewTimeoutInterceptor(cfg.APITimeout),
+		auth.NewTimeoutInterceptor(func() time.Duration { return cfg.APITimeout }),
 		authInterceptor,
 	)
 

--- a/backend/hub/server.go
+++ b/backend/hub/server.go
@@ -310,7 +310,14 @@ func NewServer(cfg *config.Config, opts ...ServerOption) (*Server, error) {
 		return nil, acquired.close(
 			fmt.Errorf("create token validator: %w", tvErr))
 	}
-	authInterceptor, authContexts := auth.NewInterceptorWithTokens(st, soloUser, tokenValidator, cfg.SecureCookies, cfg.EmailVerificationRequired)
+	authInterceptor, authContexts := auth.NewInterceptor(auth.InterceptorOptions{
+		Store:                     st,
+		SoloUser:                  soloUser,
+		TokenValidator:            tokenValidator,
+		SecureCookies:             cfg.SecureCookies,
+		EmailVerificationRequired: cfg.EmailVerificationRequired,
+		SessionDuration:           cfg.SessionDuration(),
+	})
 	acquired.authContexts = authContexts
 	// Let a sliding cookie session (and a rotated bearer, via the credential
 	// lifecycle) extend its already-open channels' expiry, not just its leases

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/knadh/koanf/maps"
 	"github.com/knadh/koanf/v2"
 )
 
@@ -150,6 +151,10 @@ func ExtractConfigFlag(args []string, defaultPath string) string {
 	return defaultPath
 }
 
+// Delim is the koanf path separator. Every koanf instance in this repo takes
+// it, and FlagProvider splits a nested key on it, so the two cannot disagree.
+const Delim = "."
+
 // FlagProvider is a koanf.Provider that reads only explicitly-set flags from a FlagSet.
 // Unlike basicflag, it uses fs.Visit (not fs.VisitAll) so default values are not loaded.
 type FlagProvider struct {
@@ -169,6 +174,14 @@ func (f *FlagProvider) ReadBytes() ([]byte, error) {
 }
 
 // Read returns a map of only explicitly-set flags mapped to their koanf keys.
+//
+// The result is nested, not a flat map of dotted keys. koanf.Load does not
+// split a key on the delimiter -- only a provider that takes one, such as
+// confmap, does -- so a flat "storage.postgres.dsn" would land as a top-level
+// key whose name merely contains dots. Get would still find it, because the
+// lookup index is flat either way, and Unmarshal would not, because it walks
+// the nested map, where "storage" holds only what the defaults put there. Every
+// storage flag then parsed, reported no error, and was ignored.
 func (f *FlagProvider) Read() (map[string]interface{}, error) {
 	out := make(map[string]interface{})
 	f.fs.Visit(func(fl *flag.Flag) {
@@ -178,7 +191,7 @@ func (f *FlagProvider) Read() (map[string]interface{}, error) {
 		}
 		out[key] = fl.Value.String()
 	})
-	return out, nil
+	return maps.Unflatten(out, Delim), nil
 }
 
 // ResolveDataDir resolves a relative data_dir against the config file's directory.

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -134,6 +134,56 @@ func TestFlagProvider(t *testing.T) {
 			"listen": ":9999",
 		}, m)
 	})
+
+	// A nested key must arrive nested. koanf.Load does not split a key on the
+	// delimiter, so a flat "storage.postgres.dsn" lands as a top-level key whose
+	// name merely contains dots: Get finds it, because the lookup index is flat
+	// either way, and Unmarshal does not, because it walks the nested map. Every
+	// storage flag parsed, reported no error, and was then ignored.
+	t.Run("nests a dotted key", func(t *testing.T) {
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		fs.String("storage-type", "", "storage type")
+		fs.String("storage-postgres-dsn", "", "postgres dsn")
+		fs.Int("storage-postgres-max-conns", 25, "postgres max conns")
+
+		require.NoError(t, fs.Parse([]string{
+			"-storage-type", "postgres",
+			"-storage-postgres-dsn", "postgres://example/db",
+			"-storage-postgres-max-conns", "77",
+		}))
+
+		fp := NewFlagProvider(fs, map[string]string{
+			"storage-type":               "storage.type",
+			"storage-postgres-dsn":       "storage.postgres.dsn",
+			"storage-postgres-max-conns": "storage.postgres.max_conns",
+		})
+		m, err := fp.Read()
+		require.NoError(t, err)
+
+		assert.Equal(t, map[string]interface{}{
+			"storage": map[string]interface{}{
+				"type": "postgres",
+				"postgres": map[string]interface{}{
+					"dsn":       "postgres://example/db",
+					"max_conns": "77",
+				},
+			},
+		}, m)
+	})
+
+	// A key with no delimiter must stay exactly where it was, so the nesting
+	// above cannot change how a flat key reaches the config.
+	t.Run("leaves a flat key at the top level", func(t *testing.T) {
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		fs.String("log-level", "info", "log level")
+
+		require.NoError(t, fs.Parse([]string{"-log-level", "debug"}))
+
+		m, err := NewFlagProvider(fs, map[string]string{"log-level": "log_level"}).Read()
+		require.NoError(t, err)
+
+		assert.Equal(t, map[string]interface{}{"log_level": "debug"}, m)
+	})
 }
 
 func TestExpandHome(t *testing.T) {

--- a/backend/internal/config/duration.go
+++ b/backend/internal/config/duration.go
@@ -1,0 +1,315 @@
+package config
+
+import (
+	"flag"
+	"fmt"
+	"math"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-viper/mapstructure/v2"
+	"github.com/knadh/koanf/v2"
+)
+
+// UnitSyntax describes the spellings ParseDuration accepts. Put it in the help
+// text of every duration flag, so the CLI states the syntax once per flag and
+// the operator never has to find this package.
+//
+// The backquoted word is the placeholder that flag.UnquoteUsage lifts into the
+// flag's help line, which would otherwise read the bare "value" that the flag
+// package prints for every flag.Value.
+const UnitSyntax = "Takes a `duration` suffix: ns, us, ms, s, m, h, d, w. A bare number is seconds."
+
+// extendedUnits holds the two units that time.ParseDuration does not know.
+// Everything else goes to the standard parser unchanged, so a duration this
+// package accepts keeps the exact meaning the Go documentation gives it.
+//
+// A day is 24 hours and a week is 7 days, with no daylight-saving correction: a
+// session lifetime and a connection lifetime are elapsed time, not calendar
+// time, and the code that consumes them adds them to an instant.
+var extendedUnits = map[string]time.Duration{
+	"d": 24 * time.Hour,
+	"w": 7 * 24 * time.Hour,
+}
+
+// ParseDuration parses a duration that a configuration source supplies: a
+// config-file value, an environment variable, or a CLI flag.
+//
+// It accepts everything time.ParseDuration accepts ("500ms", "1h30m",
+// "1.5h"), adds the d and w units that the standard parser rejects ("7d",
+// "2w3d"), and reads a bare number as a count of seconds ("3600"), which is the
+// spelling every one of these options carried before it took a unit.
+//
+// A number with no unit is only valid as the WHOLE value. "1d30" is an error
+// rather than a day and thirty seconds, because a reader cannot tell that
+// trailing number from a typing error in the unit.
+//
+// The result never overflows: a value past the range of a time.Duration
+// (approximately 292 years) fails here rather than wrapping to a negative or a
+// tiny duration at the multiplication.
+func ParseDuration(s string) (time.Duration, error) {
+	text := strings.TrimSpace(s)
+	if text == "" {
+		return 0, fmt.Errorf("parse duration %q: the value is empty", s)
+	}
+
+	negative := false
+	switch text[0] {
+	case '+':
+		text = text[1:]
+	case '-':
+		negative = true
+		text = text[1:]
+	}
+	if text == "" {
+		return 0, fmt.Errorf("parse duration %q: the value has a sign and no number", s)
+	}
+
+	var total time.Duration
+	var parts int
+	for text != "" {
+		number, rest := splitNumber(text)
+		if number == "" {
+			return 0, fmt.Errorf("parse duration %q: expected a number at %q (%s)", s, text, UnitSyntax)
+		}
+		unit, remainder := splitUnit(rest)
+
+		var part time.Duration
+		var err error
+		switch {
+		case unit == "":
+			// A bare number is a count of seconds, and only as the whole value.
+			if parts > 0 || remainder != "" {
+				return 0, fmt.Errorf("parse duration %q: %q has no unit (%s)", s, number, UnitSyntax)
+			}
+			part, err = scale(number, time.Second)
+		case extendedUnits[unit] != 0:
+			part, err = scale(number, extendedUnits[unit])
+		default:
+			// The standard parser owns every remaining unit, so it also owns the
+			// message for a unit that nothing knows.
+			part, err = time.ParseDuration(number + unit)
+			if err != nil {
+				err = fmt.Errorf("%q is not a duration (%s)", number+unit, UnitSyntax)
+			}
+		}
+		if err != nil {
+			return 0, fmt.Errorf("parse duration %q: %w", s, err)
+		}
+
+		total, err = add(total, part)
+		if err != nil {
+			return 0, fmt.Errorf("parse duration %q: %w", s, err)
+		}
+		text = remainder
+		parts++
+	}
+
+	if negative {
+		return -total, nil
+	}
+	return total, nil
+}
+
+// FormatDuration writes d in the shortest exact spelling that ParseDuration
+// reads back. It is what a CLI flag reports as its default and what the flag
+// hands to the configuration loader, so an inexact form would change the value
+// that the operator sees or the value that the Hub loads.
+//
+// Weeks are deliberately absent: "7d" states a session lifetime more plainly
+// than "1w", and both parse.
+func FormatDuration(d time.Duration) string {
+	// Zero is "0" rather than "0s" so the flag package still recognizes it as a
+	// zero default and leaves it out of the help text.
+	if d == 0 {
+		return "0"
+	}
+	// The most negative duration has no positive counterpart, so it cannot take
+	// the sign-and-magnitude path below.
+	if d == math.MinInt64 {
+		return d.String()
+	}
+
+	sign := ""
+	magnitude := d
+	if magnitude < 0 {
+		sign = "-"
+		magnitude = -magnitude
+	}
+	for _, unit := range []struct {
+		size   time.Duration
+		suffix string
+	}{
+		{24 * time.Hour, "d"},
+		{time.Hour, "h"},
+		{time.Minute, "m"},
+		{time.Second, "s"},
+	} {
+		if magnitude%unit.size == 0 {
+			return sign + strconv.FormatInt(int64(magnitude/unit.size), 10) + unit.suffix
+		}
+	}
+	return d.String()
+}
+
+// splitNumber cuts the leading number from s.
+func splitNumber(s string) (number, rest string) {
+	i := 0
+	for i < len(s) && (s[i] >= '0' && s[i] <= '9' || s[i] == '.') {
+		i++
+	}
+	return s[:i], s[i:]
+}
+
+// splitUnit cuts the leading unit from s. The scan ends at the next digit
+// rather than at the next ASCII letter, so a multi-byte unit such as "µs"
+// stays whole.
+func splitUnit(s string) (unit, rest string) {
+	for i, r := range s {
+		if r >= '0' && r <= '9' || r == '.' {
+			return s[:i], s[i:]
+		}
+	}
+	return s, ""
+}
+
+// scale multiplies a non-negative number by a unit and fails on overflow.
+func scale(number string, unit time.Duration) (time.Duration, error) {
+	if !strings.Contains(number, ".") {
+		v, err := strconv.ParseInt(number, 10, 64)
+		if err != nil || v > math.MaxInt64/int64(unit) {
+			return 0, fmt.Errorf("%s%s is out of range (the maximum is about 292 years)", number, unitSuffix(unit))
+		}
+		return time.Duration(v) * unit, nil
+	}
+	v, err := strconv.ParseFloat(number, 64)
+	if err != nil {
+		return 0, fmt.Errorf("%q is not a number", number)
+	}
+	scaled := v * float64(unit)
+	if scaled > math.MaxInt64 {
+		return 0, fmt.Errorf("%s%s is out of range (the maximum is about 292 years)", number, unitSuffix(unit))
+	}
+	return time.Duration(scaled), nil
+}
+
+// unitSuffix gives a unit its spelling again, for an error message about the
+// component that overflowed.
+func unitSuffix(unit time.Duration) string {
+	for suffix, size := range extendedUnits {
+		if size == unit {
+			return suffix
+		}
+	}
+	return "s"
+}
+
+// add sums two non-negative durations and fails on overflow.
+func add(a, b time.Duration) (time.Duration, error) {
+	if a > math.MaxInt64-b {
+		return 0, fmt.Errorf("the total is out of range (the maximum is about 292 years)")
+	}
+	return a + b, nil
+}
+
+// DurationFlag adapts a time.Duration to the flag package, so a CLI flag reads
+// the same spellings as the config file and the environment variable. The
+// standard flag.Duration accepts neither the bare seconds count nor the d and w
+// units, so a flag registered with it would refuse a value that the same key
+// takes in the config file.
+type DurationFlag struct {
+	target *time.Duration
+}
+
+// NewDurationFlag returns a flag.Value that writes into target, and sets target
+// to def so the flag reports the default before Parse runs.
+func NewDurationFlag(target *time.Duration, def time.Duration) *DurationFlag {
+	*target = def
+	return &DurationFlag{target: target}
+}
+
+// String reports the current value. The flag package builds a zero DurationFlag
+// by reflection to recognize a zero default, so this must answer on a value
+// that carries no target.
+func (f *DurationFlag) String() string {
+	if f == nil || f.target == nil {
+		return "0"
+	}
+	return FormatDuration(*f.target)
+}
+
+// Set parses and stores one flag occurrence.
+func (f *DurationFlag) Set(s string) error {
+	d, err := ParseDuration(s)
+	if err != nil {
+		return err
+	}
+	*f.target = d
+	return nil
+}
+
+// Get satisfies flag.Getter, which the help printer uses to decide whether a
+// default needs quotation marks.
+func (f *DurationFlag) Get() any {
+	if f == nil || f.target == nil {
+		return time.Duration(0)
+	}
+	return *f.target
+}
+
+var _ flag.Getter = (*DurationFlag)(nil)
+
+// toDurationHookFunc converts a configured value to a time.Duration.
+//
+// It replaces mapstructure's own StringToTimeDurationHookFunc, which calls
+// time.ParseDuration and so rejects both the bare seconds count and the d and w
+// units. Leaving that hook in place would make a duration key mean one thing
+// from a CLI flag and another from a config file.
+//
+// A number needs the same treatment as a string, and for a reason that is easy
+// to miss: a YAML parser reads `api_timeout: 10` as an int, so that value never
+// reaches the string arm. Without the number arm mapstructure would convert it
+// as a raw int64 count of NANOSECONDS, and every config file that spells a
+// timeout the way this key has always taken would silently become a timeout of
+// a few microseconds.
+func toDurationHookFunc() mapstructure.DecodeHookFuncType {
+	durationType := reflect.TypeOf(time.Duration(0))
+	return func(from, to reflect.Type, data any) (any, error) {
+		if to != durationType {
+			return data, nil
+		}
+		switch from.Kind() {
+		case reflect.String:
+			return ParseDuration(data.(string))
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+			reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+			reflect.Float32, reflect.Float64:
+			// Route it through the same parser, so a number out of range fails
+			// here rather than wrapping, exactly as the text form does.
+			return ParseDuration(fmt.Sprintf("%v", data))
+		default:
+			return data, nil
+		}
+	}
+}
+
+// Unmarshal decodes the loaded configuration into out.
+//
+// Every config package goes through this rather than koanf's own Unmarshal, so
+// one set of decode rules covers the Hub and the Worker. It keeps koanf's
+// defaults that the configuration depends on -- the koanf struct tag and weakly
+// typed input, which every string-valued source needs to reach an int or a bool
+// field -- and replaces koanf's duration hook with ours.
+func Unmarshal(k *koanf.Koanf, out any) error {
+	return k.UnmarshalWithConf("", out, koanf.UnmarshalConf{
+		DecoderConfig: &mapstructure.DecoderConfig{
+			DecodeHook: mapstructure.ComposeDecodeHookFunc(
+				toDurationHookFunc(),
+				mapstructure.TextUnmarshallerHookFunc(),
+			),
+			WeaklyTypedInput: true,
+		},
+	})
+}

--- a/backend/internal/config/duration_test.go
+++ b/backend/internal/config/duration_test.go
@@ -1,0 +1,300 @@
+package config
+
+import (
+	"flag"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/knadh/koanf/providers/confmap"
+	"github.com/knadh/koanf/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseDuration(t *testing.T) {
+	cases := []struct {
+		in   string
+		want time.Duration
+	}{
+		// A bare number is the seconds count every one of these keys carried
+		// before it took a unit.
+		{"0", 0},
+		{"1", time.Second},
+		{"3600", time.Hour},
+		{"691200", 8 * 24 * time.Hour},
+		// The units time.ParseDuration already knows.
+		{"500ms", 500 * time.Millisecond},
+		{"30s", 30 * time.Second},
+		{"90m", 90 * time.Minute},
+		{"1h30m", 90 * time.Minute},
+		{"1.5h", 90 * time.Minute},
+		{"250us", 250 * time.Microsecond},
+		{"250µs", 250 * time.Microsecond},
+		{"100ns", 100 * time.Nanosecond},
+		// The units this package adds.
+		{"1d", 24 * time.Hour},
+		{"7d", 7 * 24 * time.Hour},
+		{"1w", 7 * 24 * time.Hour},
+		{"2w", 14 * 24 * time.Hour},
+		{"1.5d", 36 * time.Hour},
+		// Several components, in either order, mixing the added units with the
+		// standard ones.
+		{"2w3d", 17 * 24 * time.Hour},
+		{"1d12h", 36 * time.Hour},
+		{"1w2d3h4m5s", 9*24*time.Hour + 3*time.Hour + 4*time.Minute + 5*time.Second},
+		{"12h1d", 36 * time.Hour},
+		// Signs and surrounding space.
+		{"+30s", 30 * time.Second},
+		{"-30s", -30 * time.Second},
+		{"-1d", -24 * time.Hour},
+		{"  7d  ", 7 * 24 * time.Hour},
+		{"\t3600\n", time.Hour},
+		{"-3600", -time.Hour},
+		// The boundary of the representable range, from both units that reach it.
+		{"9223372036s", 9223372036 * time.Second},
+		{"106751d", 106751 * 24 * time.Hour},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			got, err := ParseDuration(c.in)
+			require.NoError(t, err)
+			assert.Equal(t, c.want, got)
+		})
+	}
+}
+
+func TestParseDurationRejects(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{"empty", ""},
+		{"space only", "   "},
+		{"sign only", "-"},
+		{"plus only", "+"},
+		{"no number", "d"},
+		{"letters", "abc"},
+		{"unknown unit", "30x"},
+		{"unknown long unit", "5min"},
+		{"two decimal points", "1..5s"},
+		{"trailing bare number", "1d30"},
+		{"leading bare number", "30 1d"},
+		{"space before the unit", "30 d"},
+		{"unit before number", "d30"},
+		{"seconds overflow", "9223372037"},
+		{"seconds unit overflow", "9223372037s"},
+		{"days overflow", "106752d"},
+		{"weeks overflow", "15251w"},
+		{"sum overflow", "106751d24h"},
+		{"huge integer", "99999999999999999999999"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := ParseDuration(c.in)
+			require.Error(t, err)
+		})
+	}
+}
+
+// TestParseDurationNeverOverflows is the property that makes an unbounded
+// duration option safe: no input reaches a consumer as a wrapped negative or a
+// tiny positive. Before this parser the seconds count was multiplied by
+// time.Second with no check, so an operator's typing error became a session
+// that expired before the response left the Hub.
+func TestParseDurationNeverOverflows(t *testing.T) {
+	for _, in := range []string{
+		"9223372037",
+		"9223372037s",
+		"153722868m",
+		"2562048h",
+		"106752d",
+		"15251w",
+		"106751d23h60m",
+		"1.0e19",
+	} {
+		t.Run(in, func(t *testing.T) {
+			got, err := ParseDuration(in)
+			require.Error(t, err, "want a range error, got %s", got)
+			assert.Zero(t, got)
+		})
+	}
+}
+
+func TestFormatDuration(t *testing.T) {
+	cases := []struct {
+		in   time.Duration
+		want string
+	}{
+		{0, "0"},
+		{time.Second, "1s"},
+		{30 * time.Second, "30s"},
+		{time.Minute, "1m"},
+		{5 * time.Minute, "5m"},
+		{time.Hour, "1h"},
+		{24 * time.Hour, "1d"},
+		// Seven days is "7d" and never "1w": a lifetime reads more plainly in
+		// days, and both spellings parse.
+		{7 * 24 * time.Hour, "7d"},
+		{14 * 24 * time.Hour, "14d"},
+		{90 * time.Minute, "90m"},
+		{-30 * time.Second, "-30s"},
+		{-7 * 24 * time.Hour, "-7d"},
+		{500 * time.Millisecond, "500ms"},
+		{time.Second + 500*time.Millisecond, "1.5s"},
+		{math.MinInt64, time.Duration(math.MinInt64).String()},
+	}
+	for _, c := range cases {
+		t.Run(c.want, func(t *testing.T) {
+			assert.Equal(t, c.want, FormatDuration(c.in))
+		})
+	}
+}
+
+// TestFormatDurationRoundTrips pins the property the CLI depends on: a flag
+// reports its value with FormatDuration and the loader reads that text back
+// with ParseDuration, so an inexact spelling would change the loaded value.
+func TestFormatDurationRoundTrips(t *testing.T) {
+	for _, d := range []time.Duration{
+		0,
+		time.Nanosecond,
+		500 * time.Millisecond,
+		time.Second,
+		90 * time.Second,
+		10 * time.Minute,
+		time.Hour,
+		36 * time.Hour,
+		7 * 24 * time.Hour,
+		365 * 24 * time.Hour,
+		-42 * time.Second,
+		time.Duration(math.MaxInt64),
+	} {
+		t.Run(FormatDuration(d), func(t *testing.T) {
+			got, err := ParseDuration(FormatDuration(d))
+			require.NoError(t, err)
+			assert.Equal(t, d, got)
+		})
+	}
+}
+
+func TestDurationFlag(t *testing.T) {
+	t.Run("reports the default before Parse", func(t *testing.T) {
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		var d time.Duration
+		fs.Var(NewDurationFlag(&d, 7*24*time.Hour), "session-duration", "usage")
+		assert.Equal(t, 7*24*time.Hour, d)
+		assert.Equal(t, "7d", fs.Lookup("session-duration").DefValue)
+	})
+
+	t.Run("accepts every spelling the config file accepts", func(t *testing.T) {
+		for _, c := range []struct {
+			arg  string
+			want time.Duration
+		}{
+			{"1h", time.Hour},
+			{"3600", time.Hour},
+			{"2d", 48 * time.Hour},
+			{"1w", 7 * 24 * time.Hour},
+		} {
+			fs := flag.NewFlagSet("test", flag.ContinueOnError)
+			var d time.Duration
+			fs.Var(NewDurationFlag(&d, time.Minute), "session-duration", "usage")
+			require.NoError(t, fs.Parse([]string{"-session-duration", c.arg}))
+			assert.Equal(t, c.want, d, "arg %q", c.arg)
+		}
+	})
+
+	t.Run("rejects a value the parser refuses", func(t *testing.T) {
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		fs.SetOutput(nopWriter{})
+		var d time.Duration
+		fs.Var(NewDurationFlag(&d, time.Minute), "session-duration", "usage")
+		require.Error(t, fs.Parse([]string{"-session-duration", "30x"}))
+	})
+
+	// FlagProvider hands the loader fl.Value.String(), so a flag that a user set
+	// has to survive the format-then-parse trip unchanged.
+	t.Run("round trips through the flag provider", func(t *testing.T) {
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		var d time.Duration
+		fs.Var(NewDurationFlag(&d, time.Minute), "session-duration", "usage")
+		require.NoError(t, fs.Parse([]string{"-session-duration", "90"}))
+
+		out, err := NewFlagProvider(fs, map[string]string{"session-duration": "session_duration"}).Read()
+		require.NoError(t, err)
+		got, err := ParseDuration(out["session_duration"].(string))
+		require.NoError(t, err)
+		assert.Equal(t, 90*time.Second, got)
+	})
+
+	// The flag package builds a zero value by reflection to decide whether a
+	// default belongs in the help text, so String must answer without a target.
+	t.Run("String answers on a zero value", func(t *testing.T) {
+		assert.Equal(t, "0", (&DurationFlag{}).String())
+		assert.Equal(t, "0", (*DurationFlag)(nil).String())
+		assert.Equal(t, time.Duration(0), (&DurationFlag{}).Get())
+	})
+}
+
+func TestUnmarshalDuration(t *testing.T) {
+	type cfg struct {
+		SessionDuration time.Duration `koanf:"session_duration"`
+		APITimeout      time.Duration `koanf:"api_timeout"`
+		MaxConns        int           `koanf:"max_conns"`
+		Enabled         bool          `koanf:"enabled"`
+	}
+
+	t.Run("reads a duration from every source shape", func(t *testing.T) {
+		k := koanf.New(".")
+		require.NoError(t, k.Load(confmap.Provider(map[string]any{
+			// A typed default, as the defaults map supplies it.
+			"session_duration": 7 * 24 * time.Hour,
+			// A string, as a config file, an environment variable, and a CLI
+			// flag all supply it.
+			"api_timeout": "90s",
+			// Weakly typed input still has to reach a non-duration field.
+			"max_conns": "25",
+			"enabled":   "true",
+		}, "."), nil))
+
+		var got cfg
+		require.NoError(t, Unmarshal(k, &got))
+		assert.Equal(t, 7*24*time.Hour, got.SessionDuration)
+		assert.Equal(t, 90*time.Second, got.APITimeout)
+		assert.Equal(t, 25, got.MaxConns)
+		assert.True(t, got.Enabled)
+	})
+
+	// The reason this package replaces koanf's own duration hook: koanf composes
+	// mapstructure.StringToTimeDurationHookFunc, which calls time.ParseDuration
+	// and so rejects both of these.
+	t.Run("reads the spellings time.ParseDuration rejects", func(t *testing.T) {
+		for _, c := range []struct {
+			text string
+			want time.Duration
+		}{
+			{"7d", 7 * 24 * time.Hour},
+			{"1w", 7 * 24 * time.Hour},
+			{"3600", time.Hour},
+		} {
+			k := koanf.New(".")
+			require.NoError(t, k.Load(confmap.Provider(map[string]any{"session_duration": c.text}, "."), nil))
+			var got cfg
+			require.NoError(t, Unmarshal(k, &got), "text %q", c.text)
+			assert.Equal(t, c.want, got.SessionDuration, "text %q", c.text)
+		}
+	})
+
+	t.Run("fails loudly on a value nobody meant", func(t *testing.T) {
+		k := koanf.New(".")
+		require.NoError(t, k.Load(confmap.Provider(map[string]any{"session_duration": "30x"}, "."), nil))
+		var got cfg
+		require.Error(t, Unmarshal(k, &got))
+	})
+}
+
+// nopWriter discards a FlagSet's error output, so a test for a rejected flag
+// does not print a usage message.
+type nopWriter struct{}
+
+func (nopWriter) Write(p []byte) (int, error) { return len(p), nil }

--- a/backend/internal/hub/auth/auth.go
+++ b/backend/internal/hub/auth/auth.go
@@ -15,8 +15,27 @@ import (
 	"github.com/leapmux/leapmux/internal/util/userid"
 )
 
-// SessionDuration is the lifetime of a user session.
-const SessionDuration = 24 * time.Hour
+// DefaultSessionDuration is the minimum time a session stays valid after the
+// user's last request, when the operator configures no other value.
+// config.DefaultSessionDurationSeconds derives from it, so the flag default and
+// this one cannot drift.
+//
+// CreateSession sets the first expiry to now + the lifetime that the caller
+// gives, and each later authenticated request slides that expiry forward (see
+// touchSession in interceptor.go). A session therefore ends one lifetime after
+// the last request, not one lifetime after the login.
+const DefaultSessionDuration = 8 * 24 * time.Hour
+
+// sessionLifetime resolves a configured session lifetime. Zero or less falls
+// back to DefaultSessionDuration. One home for that fallback, so the first
+// expiry that CreateSession writes and the slide that the interceptor writes
+// cannot disagree about how long an unconfigured session lives.
+func sessionLifetime(configured time.Duration) time.Duration {
+	if configured <= 0 {
+		return DefaultSessionDuration
+	}
+	return configured
+}
 
 type contextKey int
 
@@ -159,9 +178,10 @@ func LoadSoloUser(ctx context.Context, st store.Store) (*UserInfo, error) {
 	}, nil
 }
 
-// Login validates credentials and creates a new session token.
+// Login validates credentials and creates a new session token. lifetime is the
+// session's minimum life past the user's last request; see CreateSession.
 // Returns the session ID, user, session expiry time, and any error.
-func Login(ctx context.Context, st store.Store, username, password string) (string, *store.User, time.Time, error) {
+func Login(ctx context.Context, st store.Store, username, password string, lifetime time.Duration) (string, *store.User, time.Time, error) {
 	var zero time.Time
 	user, err := st.Users().GetByUsername(ctx, username)
 	if err != nil {
@@ -227,7 +247,7 @@ func Login(ctx context.Context, st store.Store, username, password string) (stri
 		if !sessMintOK {
 			return connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("invalid credentials"))
 		}
-		sessionID, expiresAt, err = CreateSession(ctx, tx, sessUID)
+		sessionID, expiresAt, err = CreateSession(ctx, tx, sessUID, lifetime)
 		if err != nil {
 			return err
 		}
@@ -255,7 +275,12 @@ type SessionMeta struct {
 
 // CreateSession creates a new user session and returns the session ID and
 // expiry time.
-func CreateSession(ctx context.Context, st store.Store, userID userid.UserID, meta ...SessionMeta) (string, time.Time, error) {
+//
+// lifetime is the session's minimum life past the user's last request. Zero or
+// less falls back to DefaultSessionDuration: a caller that has no configured
+// value must still issue a usable session, not one that expired before the
+// response left the Hub.
+func CreateSession(ctx context.Context, st store.Store, userID userid.UserID, lifetime time.Duration, meta ...SessionMeta) (string, time.Time, error) {
 	// A session for nobody is worse than no session: it would authenticate as a
 	// blank id, which every predicate then has to refuse individually. Refuse to
 	// write the row at all.
@@ -263,7 +288,7 @@ func CreateSession(ctx context.Context, st store.Store, userID userid.UserID, me
 		return "", time.Time{}, fmt.Errorf("create session: user id is required")
 	}
 	sessionID := id.Generate()
-	expiresAt := time.Now().Add(SessionDuration).UTC()
+	expiresAt := time.Now().Add(sessionLifetime(lifetime)).UTC()
 	params := store.CreateSessionParams{
 		ID:        sessionID,
 		UserID:    userID,

--- a/backend/internal/hub/auth/auth.go
+++ b/backend/internal/hub/auth/auth.go
@@ -16,15 +16,55 @@ import (
 )
 
 // DefaultSessionDuration is the minimum time a session stays valid after the
-// user's last request, when the operator configures no other value.
-// config.DefaultSessionDurationSeconds derives from it, so the flag default and
-// this one cannot drift.
+// user's last request, when the operator configures no other value. The
+// session_duration flag registers it, so the flag default and this one cannot
+// drift.
 //
-// CreateSession sets the first expiry to now + the lifetime that the caller
-// gives, and each later authenticated request slides that expiry forward (see
-// touchSession in interceptor.go). A session therefore ends one lifetime after
-// the last request, not one lifetime after the login.
-const DefaultSessionDuration = 8 * 24 * time.Hour
+// CreateSession sets the first expiry through sessionExpiry, and each later
+// authenticated request slides that expiry forward (see touchSession in
+// interceptor.go). A session therefore ends one lifetime after the last
+// request, not one lifetime after the login.
+const DefaultSessionDuration = 7 * 24 * time.Hour
+
+// MinSessionDuration is the shortest session the Hub can honestly enforce.
+//
+// Two mechanisms keep a session alive past its written expiry, and the floor
+// caps what they cost together:
+//
+//   - The Hub serves a validated session from an in-memory cache for
+//     sessionCacheTTL, so a request succeeds up to that long after the row
+//     expired. That window is a constant, so it is the term that decides the
+//     floor.
+//   - A slide is throttled, so the row can carry up to one throttle window more
+//     than the configured duration. touchThreshold keeps that window at a
+//     tenth of the session, so it scales instead of dominating.
+//
+// At touchSlideDivisor times the cache TTL, the two together are at most a
+// fifth of the configured duration. Below that, "expired" stops describing when
+// the user is signed out. ValidateSessionDuration rejects a shorter
+// configuration rather than accept a policy the Hub cannot keep.
+const MinSessionDuration = touchSlideDivisor * sessionCacheTTL
+
+// ValidateSessionDuration reports whether an operator's session lifetime is one
+// the Hub can enforce. The rule lives here, next to the two constants that set
+// the floor, so a change to either cannot leave the check behind. The caller
+// adds the name of the setting.
+//
+// There is no upper bound: a long session is a policy an operator may hold, and
+// the slide makes it an idle timeout rather than an unbounded credential.
+func ValidateSessionDuration(d time.Duration) error {
+	switch {
+	case d < 0:
+		return fmt.Errorf("must not be negative, got %s", d)
+	case d < MinSessionDuration:
+		return fmt.Errorf(
+			"must be at least %s, got %s: the Hub serves a validated session from "+
+				"an in-memory cache for %s, so a shorter session stays usable for a "+
+				"large share of its own life",
+			MinSessionDuration, d, sessionCacheTTL)
+	}
+	return nil
+}
 
 // sessionLifetime resolves a configured session lifetime. Zero or less falls
 // back to DefaultSessionDuration. One home for that fallback, so the first
@@ -35,6 +75,36 @@ func sessionLifetime(configured time.Duration) time.Duration {
 		return DefaultSessionDuration
 	}
 	return configured
+}
+
+// touchSlideDivisor sets how much of a session's life may pass before the Hub
+// slides it again. A tenth keeps the DB write rate low on a long session and
+// still slides a short one often enough that the configured duration describes
+// it.
+const touchSlideDivisor = 10
+
+// touchThreshold returns how long the Hub waits before it slides a session
+// again. It is a tenth of the session, and never more than
+// sessionTouchThreshold, which caps the write rate for a long session.
+//
+// The fixed ceiling alone was wrong for a short session: at a five-minute
+// throttle a session shorter than five minutes expired before its first slide
+// could land, so it ended at the login deadline however active the user was --
+// the absolute timeout that the slide exists to remove.
+func touchThreshold(lifetime time.Duration) time.Duration {
+	return min(sessionTouchThreshold, sessionLifetime(lifetime)/touchSlideDivisor)
+}
+
+// sessionExpiry returns the expiry to write for a session whose lifetime is
+// lifetime. Both writers use it -- CreateSession at the login and touchSession
+// at each slide -- so the row always carries the same promise.
+//
+// The extra touchThreshold is what keeps that promise. A request inside the
+// throttle window writes no row, so an expiry of exactly now + lifetime would
+// end the session up to one throttle window before the lifetime passed since
+// the last request.
+func sessionExpiry(now time.Time, lifetime time.Duration) time.Time {
+	return now.Add(sessionLifetime(lifetime) + touchThreshold(lifetime)).UTC()
 }
 
 type contextKey int
@@ -288,7 +358,7 @@ func CreateSession(ctx context.Context, st store.Store, userID userid.UserID, li
 		return "", time.Time{}, fmt.Errorf("create session: user id is required")
 	}
 	sessionID := id.Generate()
-	expiresAt := time.Now().Add(sessionLifetime(lifetime)).UTC()
+	expiresAt := sessionExpiry(time.Now(), lifetime)
 	params := store.CreateSessionParams{
 		ID:        sessionID,
 		UserID:    userID,

--- a/backend/internal/hub/auth/auth_test.go
+++ b/backend/internal/hub/auth/auth_test.go
@@ -66,7 +66,7 @@ func TestLogin_StampsTheGivenLifetime(t *testing.T) {
 	before := time.Now()
 	token, _, expiresAt, err := auth.Login(ctx, st, "testuser", "password123", lifetime)
 	require.NoError(t, err)
-	assert.WithinDuration(t, before.Add(lifetime), expiresAt, time.Minute)
+	hubtestutil.AssertSessionLifetime(t, before, lifetime, expiresAt)
 
 	sess, err := st.Sessions().GetByID(ctx, token)
 	require.NoError(t, err)
@@ -91,7 +91,7 @@ func TestCreateSession_NonPositiveLifetimeFallsBackToDefault(t *testing.T) {
 			before := time.Now()
 			_, expiresAt, err := auth.CreateSession(ctx, st, userID, lifetime)
 			require.NoError(t, err)
-			assert.WithinDuration(t, before.Add(auth.DefaultSessionDuration), expiresAt, time.Minute)
+			hubtestutil.AssertSessionLifetime(t, before, auth.DefaultSessionDuration, expiresAt)
 		})
 	}
 
@@ -101,7 +101,7 @@ func TestCreateSession_NonPositiveLifetimeFallsBackToDefault(t *testing.T) {
 		before := time.Now()
 		_, expiresAt, err := auth.CreateSession(ctx, st, userID, time.Hour)
 		require.NoError(t, err)
-		assert.WithinDuration(t, before.Add(time.Hour), expiresAt, time.Minute)
+		hubtestutil.AssertSessionLifetime(t, before, time.Hour, expiresAt)
 	})
 }
 

--- a/backend/internal/hub/auth/auth_test.go
+++ b/backend/internal/hub/auth/auth_test.go
@@ -48,10 +48,61 @@ func TestLogin_Success(t *testing.T) {
 	userID := createTestUser(t, st)
 	ctx := context.Background()
 
-	token, user, _, err := auth.Login(ctx, st, "testuser", "password123")
+	token, user, _, err := auth.Login(ctx, st, "testuser", "password123", auth.DefaultSessionDuration)
 	require.NoError(t, err)
 	assert.NotEmpty(t, token)
 	assert.Equal(t, userID, user.ID)
+}
+
+// Login must pass its lifetime through to the session it creates. It threads the
+// value across a transaction boundary, where dropping it would leave every login
+// on the default and no caller any the wiser.
+func TestLogin_StampsTheGivenLifetime(t *testing.T) {
+	st := setupStore(t)
+	createTestUser(t, st)
+	ctx := context.Background()
+
+	const lifetime = 90 * time.Minute
+	before := time.Now()
+	token, _, expiresAt, err := auth.Login(ctx, st, "testuser", "password123", lifetime)
+	require.NoError(t, err)
+	assert.WithinDuration(t, before.Add(lifetime), expiresAt, time.Minute)
+
+	sess, err := st.Sessions().GetByID(ctx, token)
+	require.NoError(t, err)
+	assert.WithinDuration(t, expiresAt, sess.ExpiresAt, time.Second,
+		"the returned expiry and the stored row must be the same deadline")
+}
+
+// CreateSession states that a lifetime of zero or less falls back to the
+// default. The fallback is what keeps a caller that has no configured value --
+// a test, a tool, a path that forgets the argument -- from writing a session
+// that expired before the response left the Hub.
+func TestCreateSession_NonPositiveLifetimeFallsBackToDefault(t *testing.T) {
+	st := setupStore(t)
+	userID := userid.MustNew(createTestUser(t, st))
+	ctx := context.Background()
+
+	for name, lifetime := range map[string]time.Duration{
+		"zero":     0,
+		"negative": -time.Hour,
+	} {
+		t.Run(name, func(t *testing.T) {
+			before := time.Now()
+			_, expiresAt, err := auth.CreateSession(ctx, st, userID, lifetime)
+			require.NoError(t, err)
+			assert.WithinDuration(t, before.Add(auth.DefaultSessionDuration), expiresAt, time.Minute)
+		})
+	}
+
+	// Control: a real lifetime is used as given, so the cases above prove the
+	// fallback rather than that CreateSession ignores the argument entirely.
+	t.Run("positive is honoured", func(t *testing.T) {
+		before := time.Now()
+		_, expiresAt, err := auth.CreateSession(ctx, st, userID, time.Hour)
+		require.NoError(t, err)
+		assert.WithinDuration(t, before.Add(time.Hour), expiresAt, time.Minute)
+	})
 }
 
 // Workspace access is owner-only: no other user may read someone else's workspace.
@@ -225,7 +276,7 @@ func TestLogin_InvalidPassword(t *testing.T) {
 	createTestUser(t, st)
 	ctx := context.Background()
 
-	_, _, _, err := auth.Login(ctx, st, "testuser", "wrongpassword")
+	_, _, _, err := auth.Login(ctx, st, "testuser", "wrongpassword", auth.DefaultSessionDuration)
 	require.Error(t, err)
 }
 
@@ -233,7 +284,7 @@ func TestLogin_UnknownUser(t *testing.T) {
 	st := setupStore(t)
 	ctx := context.Background()
 
-	_, _, _, err := auth.Login(ctx, st, "nonexistent", "password")
+	_, _, _, err := auth.Login(ctx, st, "nonexistent", "password", auth.DefaultSessionDuration)
 	require.Error(t, err)
 }
 
@@ -246,7 +297,7 @@ func TestLogin_HashUnchangedAfterLogin(t *testing.T) {
 	require.NoError(t, err)
 	originalHash := user.PasswordHash
 
-	_, _, _, err = auth.Login(ctx, st, "testuser", "password123")
+	_, _, _, err = auth.Login(ctx, st, "testuser", "password123", auth.DefaultSessionDuration)
 	require.NoError(t, err)
 
 	user, err = st.Users().GetByUsername(ctx, "testuser")
@@ -290,7 +341,7 @@ func TestLogin_RejectsOldPasswordRotatedAtTransactionBoundary(t *testing.T) {
 		},
 	}
 
-	_, _, _, err = auth.Login(ctx, hooked, "testuser", "password123")
+	_, _, _, err = auth.Login(ctx, hooked, "testuser", "password123", auth.DefaultSessionDuration)
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
 	sessions := storetest.ListAllSessions(t, st, userID)
@@ -320,7 +371,7 @@ func TestLogin_AcceptsNewPasswordRotatedAtTransactionBoundary(t *testing.T) {
 		},
 	}
 
-	sessionID, user, _, err := auth.Login(ctx, hooked, "testuser", "new-password123")
+	sessionID, user, _, err := auth.Login(ctx, hooked, "testuser", "new-password123", auth.DefaultSessionDuration)
 	require.NoError(t, err)
 	assert.NotEmpty(t, sessionID)
 	assert.Equal(t, userID, user.ID)
@@ -334,7 +385,7 @@ func TestCredentialCreationOrdersAgainstUserRevocation(t *testing.T) {
 		userID := createTestUser(t, st)
 		ctx := context.Background()
 
-		sessionID, _, err := auth.CreateSession(ctx, st, userid.MustNew(userID))
+		sessionID, _, err := auth.CreateSession(ctx, st, userid.MustNew(userID), auth.DefaultSessionDuration)
 		require.NoError(t, err)
 		require.NoError(t, st.RunInTransaction(ctx, func(tx store.Store) error {
 			_, _, err := auth.RevokeAllUserCredentials(ctx, tx, userid.MustNew(userID))
@@ -355,7 +406,7 @@ func TestCredentialCreationOrdersAgainstUserRevocation(t *testing.T) {
 			_, _, err := auth.RevokeAllUserCredentials(ctx, tx, userid.MustNew(userID))
 			return err
 		}))
-		sessionID, _, err := auth.CreateSession(ctx, st, userid.MustNew(userID))
+		sessionID, _, err := auth.CreateSession(ctx, st, userid.MustNew(userID), auth.DefaultSessionDuration)
 		require.NoError(t, err)
 
 		info, err := auth.ValidateToken(ctx, st, sessionID)
@@ -425,7 +476,7 @@ func TestValidateToken_Success(t *testing.T) {
 	createTestUser(t, st)
 	ctx := context.Background()
 
-	token, _, _, err := auth.Login(ctx, st, "testuser", "password123")
+	token, _, _, err := auth.Login(ctx, st, "testuser", "password123", auth.DefaultSessionDuration)
 	require.NoError(t, err)
 
 	info, err := auth.ValidateToken(ctx, st, token)
@@ -593,7 +644,7 @@ func TestLogin_BlankUserIDRowIsRefusedNotPanicked(t *testing.T) {
 	}
 
 	require.NotPanics(t, func() {
-		sessionID, user, _, loginErr := auth.Login(context.Background(), wrapped, "blank", "correct-horse-battery")
+		sessionID, user, _, loginErr := auth.Login(context.Background(), wrapped, "blank", "correct-horse-battery", auth.DefaultSessionDuration)
 		require.Error(t, loginErr)
 		assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(loginErr),
 			"a blank-id row is refused as bad credentials, not surfaced as an internal error")

--- a/backend/internal/hub/auth/bearer_cache_gen_test.go
+++ b/backend/internal/hub/auth/bearer_cache_gen_test.go
@@ -280,7 +280,7 @@ func TestAuthenticateUsesTouchedSessionExpiry(t *testing.T) {
 		state: &authState{},
 	}
 
-	ctx, err := a.authenticate(
+	ctx, refresh, err := a.authenticate(
 		context.Background(), "/private",
 		CookieName+"=session", "",
 	)
@@ -291,6 +291,9 @@ func TestAuthenticateUsesTouchedSessionExpiry(t *testing.T) {
 	touchedAt, atOK := user.CredentialExpiresAt.At()
 	require.True(t, atOK)
 	assert.True(t, touchedAt.After(oldExpiry))
+	// The refreshed cookie must name the same session and the same slid expiry
+	// the row now carries, or the browser's copy expires before the row does.
+	assert.Equal(t, sessionRefresh{sessionID: "session", expiresAt: sessions.touched.ExpiresAt}, refresh)
 }
 
 // TestZeroRowTouchDoesNotExtendSessionExpiry pins the C1 guard: when the
@@ -311,7 +314,7 @@ func TestZeroRowTouchDoesNotExtendSessionExpiry(t *testing.T) {
 		state: &authState{},
 	}
 
-	ctx, err := a.authenticate(
+	ctx, refresh, err := a.authenticate(
 		context.Background(), "/private",
 		CookieName+"=session", "",
 	)
@@ -320,6 +323,8 @@ func TestZeroRowTouchDoesNotExtendSessionExpiry(t *testing.T) {
 	require.NotNil(t, user)
 	assert.Equal(t, DeadlineAt(oldExpiry), user.CredentialExpiresAt,
 		"a zero-row touch must not extend the in-memory session expiry")
+	assert.Equal(t, sessionRefresh{}, refresh,
+		"a zero-row touch must not re-issue a cookie carrying an expiry the row does not have")
 }
 
 func TestUnrelatedSessionEvictionDoesNotReloadWarmCacheEntry(t *testing.T) {
@@ -555,8 +560,9 @@ func TestSoloAuthenticationAdvancesPastUserRevocation(t *testing.T) {
 	cache := &AuthContextRegistry{state: state}
 
 	cache.RevokeUserAuthContextAtGeneration("solo", 2)
-	ctx, err := a.authenticate(context.Background(), "/private", "", "")
+	ctx, refresh, err := a.authenticate(context.Background(), "/private", "", "")
 	require.NoError(t, err)
+	assert.Equal(t, sessionRefresh{}, refresh, "solo mode holds no session cookie to refresh")
 	current := GetUser(ctx)
 	require.NotNil(t, current)
 	assert.Equal(t, int64(2), current.UserAuthGeneration)
@@ -892,7 +898,7 @@ func TestAuthContextRegistry_EvictsBumpGen(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, sc := NewInterceptorWithTokens(nil, nil, nil, false, false)
+			_, sc := NewInterceptor(InterceptorOptions{})
 			t.Cleanup(sc.Stop)
 			before := sc.state.revocationGen.Load()
 			tc.fn(sc)
@@ -934,7 +940,7 @@ func TestDelegationAllowedProcedures_FailClosed(t *testing.T) {
 }
 
 func TestAuthContextRegistry_IsAuthContextCurrentIsScoped(t *testing.T) {
-	_, sc := NewInterceptorWithTokens(nil, nil, nil, false, false)
+	_, sc := NewInterceptor(InterceptorOptions{})
 	t.Cleanup(sc.Stop)
 
 	gen := sc.state.revocationGen.Load()
@@ -1148,7 +1154,9 @@ func TestAuthInterceptor_SweepsExpiredBearerExpiries(t *testing.T) {
 
 func TestAuthInterceptor_SweepsBearerAndRevocationCaches(t *testing.T) {
 	a := &authInterceptor{state: &authState{}}
-	old := time.Now().Add(-SessionDuration - time.Minute)
+	// Past the sweep cutoff, which is the slide duration (the session duration
+	// plus the touch threshold) rather than the session duration alone.
+	old := time.Now().Add(-DefaultSessionDuration - 2*sessionTouchThreshold)
 
 	a.state.bearers.Store(bearerCacheKey(BearerKindAPI, "tok-1", []byte("secret-hash")), cachedSession{
 		user:     &UserInfo{ID: userid.MustNew("u-1")},
@@ -1178,7 +1186,7 @@ func TestAuthInterceptor_SweepsBearerAndRevocationCaches(t *testing.T) {
 
 func TestStaleCacheSweepDoesNotDeleteFreshReplacements(t *testing.T) {
 	caches := &credentialCaches{}
-	oldTime := time.Now().Add(-SessionDuration)
+	oldTime := time.Now().Add(-DefaultSessionDuration)
 	freshTime := time.Now()
 	caches.lastTouch.Store("session", freshTime)
 	caches.deleteStaleLastTouch("session", oldTime)
@@ -1212,7 +1220,7 @@ func TestStaleCredentialCacheSweepSerializesWithValidation(t *testing.T) {
 		user:     &UserInfo{ID: userid.MustNew("user")},
 		cachedAt: time.Now().Add(-2 * sessionCacheTTL),
 	}
-	state.lastTouch.Store("touch", time.Now().Add(-2*SessionDuration))
+	state.lastTouch.Store("touch", time.Now().Add(-2*DefaultSessionDuration))
 	state.sessions.Store("session", stale)
 	indexSyncMap(&state.userSessions, "user", "session")
 

--- a/backend/internal/hub/auth/bearer_cache_gen_test.go
+++ b/backend/internal/hub/auth/bearer_cache_gen_test.go
@@ -56,6 +56,11 @@ type touchRecordingSessionStore struct {
 	// session was touched within the threshold). Default false = one row
 	// matched.
 	touchMissed bool
+	// touchErr simulates a store that cannot answer, and touchCalls counts how
+	// often the UPDATE was attempted -- which is what tells a retry storm apart
+	// from a throttled request.
+	touchErr   error
+	touchCalls int
 }
 
 func (s *touchRecordingSessionStore) ValidateWithUser(context.Context, string) (*store.SessionWithUser, error) {
@@ -64,6 +69,10 @@ func (s *touchRecordingSessionStore) ValidateWithUser(context.Context, string) (
 
 func (s *touchRecordingSessionStore) Touch(_ context.Context, p store.TouchSessionParams) (int64, error) {
 	s.touched = p
+	s.touchCalls++
+	if s.touchErr != nil {
+		return 0, s.touchErr
+	}
 	if s.touchMissed {
 		return 0, nil
 	}
@@ -291,7 +300,7 @@ func TestAuthenticateUsesTouchedSessionExpiry(t *testing.T) {
 	touchedAt, atOK := user.CredentialExpiresAt.At()
 	require.True(t, atOK)
 	assert.True(t, touchedAt.After(oldExpiry))
-	// The refreshed cookie must name the same session and the same slid expiry
+	// The refreshed cookie must carry the same session and the same slid expiry
 	// the row now carries, or the browser's copy expires before the row does.
 	assert.Equal(t, sessionRefresh{sessionID: "session", expiresAt: sessions.touched.ExpiresAt}, refresh)
 }

--- a/backend/internal/hub/auth/cookie.go
+++ b/backend/internal/hub/auth/cookie.go
@@ -1,8 +1,11 @@
 package auth
 
 import (
+	"errors"
 	"net/http"
 	"time"
+
+	"connectrpc.com/connect"
 )
 
 const (
@@ -43,22 +46,68 @@ type sessionRefresh struct {
 	expiresAt time.Time
 }
 
-// applyTo writes the refreshed session cookie into h, unless the handler wrote a
-// Set-Cookie of its own.
+// applyTo writes the refreshed session cookie into h, unless the handler already
+// wrote a session cookie of its own.
 //
-// Skipping a handler-written cookie is what makes the refresh safe to run on
-// every response. A browser applies several Set-Cookie headers for one name in
-// order and keeps the last, so a refresh appended after Logout's clearing cookie
-// leaves a live session cookie in the browser -- the user stays signed in. The
-// handlers that write this cookie (login, sign-up, OAuth signup completion, the
-// OAuth callback, logout) each name the session that the response established,
-// and that is always newer than the slide the interceptor observed on the way
-// in.
+// Standing back from a handler's own cookie is what makes the refresh safe to
+// run on every response. A browser applies several Set-Cookie headers for one
+// name in order and keeps the last, so a refresh appended after Logout's
+// clearing cookie leaves a live session cookie in the browser -- the user stays
+// signed in. The handlers that write this cookie (login, sign-up, OAuth signup
+// completion, the OAuth callback, logout) each specify the session that the
+// response established, and that is always newer than the slide the interceptor
+// observed on the way in.
+//
+// The test is the cookie's NAME, not the presence of any cookie at all. A
+// browser keeps the last cookie per name, so only a cookie of this name can
+// overwrite this one. A guard that stood back from every Set-Cookie would stop
+// refreshing the session on the first response that also carried an unrelated
+// cookie, silently and with nothing to point at the cause.
 func (r sessionRefresh) applyTo(h http.Header, secure bool) {
-	if r.sessionID == "" || len(h.Values("Set-Cookie")) > 0 {
+	if r.sessionID == "" {
 		return
 	}
+	name := cookieName(secure)
+	for _, line := range h.Values("Set-Cookie") {
+		c, err := http.ParseSetCookie(line)
+		// An unparseable cookie counts as a collision. The handler wrote
+		// something this code cannot read, and losing one refresh costs a
+		// throttle window, where overwriting a cookie meant for the browser
+		// could sign a user in again after a logout.
+		if err != nil || c.Name == name {
+			return
+		}
+	}
 	h.Add("Set-Cookie", BuildSessionCookie(r.sessionID, r.expiresAt, secure).String())
+}
+
+// applyToError writes the refreshed session cookie into err's metadata and
+// returns the error to answer with.
+//
+// A ConnectRPC unary handler that fails has no response to carry a header, but
+// connect-go merges a *connect.Error's metadata into the response header before
+// it writes the status, so the cookie still reaches the browser.
+//
+// An error of any other type passes through untouched, and loses this one
+// refresh. Wrapping it to give it metadata would decide its status code here,
+// and connect.CodeOf answers CodeUnknown for a context.Canceled that connect-go
+// itself reports as CodeCanceled -- so the wrapper would change what the client
+// sees for every cancelled request that happened to slide. The cookie is worth
+// less than the code: the row already slid, and the next slide re-issues it.
+//
+// A stream cannot use this: connect-go puts a stream error's metadata in the
+// body trailer, where a browser ignores Set-Cookie. WrapStreamingHandler writes
+// the cookie to the response header instead.
+func (r sessionRefresh) applyToError(err error, secure bool) error {
+	if err == nil || r.sessionID == "" {
+		return err
+	}
+	var connectErr *connect.Error
+	if !errors.As(err, &connectErr) {
+		return err
+	}
+	r.applyTo(connectErr.Meta(), secure)
+	return err
 }
 
 // ClearSessionCookie creates a cookie that clears the session.

--- a/backend/internal/hub/auth/cookie.go
+++ b/backend/internal/hub/auth/cookie.go
@@ -34,6 +34,33 @@ func BuildSessionCookie(sessionID string, expiresAt time.Time, secure bool) *htt
 	}
 }
 
+// sessionRefresh carries a session slide from the auth interceptor to the
+// response, so the cookie's own Expires attribute tracks the slid DB expiry.
+// The zero value means that nothing slid on this request and no cookie is
+// written.
+type sessionRefresh struct {
+	sessionID string
+	expiresAt time.Time
+}
+
+// applyTo writes the refreshed session cookie into h, unless the handler wrote a
+// Set-Cookie of its own.
+//
+// Skipping a handler-written cookie is what makes the refresh safe to run on
+// every response. A browser applies several Set-Cookie headers for one name in
+// order and keeps the last, so a refresh appended after Logout's clearing cookie
+// leaves a live session cookie in the browser -- the user stays signed in. The
+// handlers that write this cookie (login, sign-up, OAuth signup completion, the
+// OAuth callback, logout) each name the session that the response established,
+// and that is always newer than the slide the interceptor observed on the way
+// in.
+func (r sessionRefresh) applyTo(h http.Header, secure bool) {
+	if r.sessionID == "" || len(h.Values("Set-Cookie")) > 0 {
+		return
+	}
+	h.Add("Set-Cookie", BuildSessionCookie(r.sessionID, r.expiresAt, secure).String())
+}
+
 // ClearSessionCookie creates a cookie that clears the session.
 func ClearSessionCookie(secure bool) *http.Cookie {
 	return &http.Cookie{

--- a/backend/internal/hub/auth/cookie_internal_test.go
+++ b/backend/internal/hub/auth/cookie_internal_test.go
@@ -1,9 +1,13 @@
 package auth
 
 import (
+	"context"
+	"errors"
 	"net/http"
 	"testing"
 	"time"
+
+	"connectrpc.com/connect"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -63,28 +67,198 @@ func TestSessionRefreshApplyTo_KeepsHandlerCookie(t *testing.T) {
 	assert.Negative(t, parsed.MaxAge, "the clearing cookie must survive the refresh")
 }
 
-// The refresh must not resurrect a session cookie for an unrelated cookie the
-// handler set (an OAuth state cookie, say). The skip is deliberately blind to
-// the name: a handler that writes any Set-Cookie owns the response's cookies.
-func TestSessionRefreshApplyTo_SkipsWhenAnyCookieWritten(t *testing.T) {
+// Only a cookie of the SAME name can overwrite the session cookie in a browser,
+// so an unrelated cookie must not stop the refresh. A guard that stood back from
+// every Set-Cookie would silently stop refreshing the session on each response
+// that also carried, say, an OAuth state cookie.
+func TestSessionRefreshApplyTo_WritesAlongsideAnUnrelatedCookie(t *testing.T) {
 	h := http.Header{}
 	h.Add("Set-Cookie", "oauth-state=abc; Path=/")
 
 	sessionRefresh{sessionID: "sess-123", expiresAt: time.Now().Add(time.Hour)}.applyTo(h, false)
 
-	assert.Len(t, h.Values("Set-Cookie"), 1)
+	values := h.Values("Set-Cookie")
+	require.Len(t, values, 2, "the unrelated cookie must not suppress the refresh")
+	parsed, err := http.ParseSetCookie(values[1])
+	require.NoError(t, err)
+	assert.Equal(t, CookieName, parsed.Name)
+	assert.Equal(t, "sess-123", parsed.Value)
 }
 
-// The slide must exceed the configured session duration by at least the touch
-// throttle. Otherwise a request inside the throttle window leaves the session
-// ending before that duration passed since the request -- the guarantee the
-// session duration states.
+// A cookie this code cannot read counts as a collision. Losing one refresh
+// costs a throttle window; overwriting a cookie meant for the browser could
+// sign a user in again after a logout.
+func TestSessionRefreshApplyTo_StandsBackFromAnUnreadableCookie(t *testing.T) {
+	h := http.Header{}
+	h.Add("Set-Cookie", "this is not a cookie")
+
+	sessionRefresh{sessionID: "sess-123", expiresAt: time.Now().Add(time.Hour)}.applyTo(h, false)
+
+	assert.Len(t, h.Values("Set-Cookie"), 1, "an unparseable cookie must fail closed")
+}
+
+// The secure name is a different name, so a handler's plain-name cookie must not
+// stop a secure refresh, and the reverse.
+func TestSessionRefreshApplyTo_MatchesTheNameInUse(t *testing.T) {
+	h := http.Header{}
+	h.Add("Set-Cookie", ClearSessionCookie(false).String())
+
+	sessionRefresh{sessionID: "sess-123", expiresAt: time.Now().Add(time.Hour)}.applyTo(h, true)
+
+	values := h.Values("Set-Cookie")
+	require.Len(t, values, 2, "the __Host- cookie is a separate name and must still be written")
+	parsed, err := http.ParseSetCookie(values[1])
+	require.NoError(t, err)
+	assert.Equal(t, SecureCookieName, parsed.Name)
+}
+
+// A failed unary call still has to carry the cookie. The slide already
+// committed to the row, and the throttle blocks every other request for a whole
+// window, so a client whose calls keep failing would never receive one.
+func TestSessionRefreshApplyToError_AttachesToConnectError(t *testing.T) {
+	expires := time.Now().Add(time.Hour).UTC().Truncate(time.Second)
+	refresh := sessionRefresh{sessionID: "sess-123", expiresAt: expires}
+
+	t.Run("a connect error keeps its code and message", func(t *testing.T) {
+		orig := connect.NewError(connect.CodePermissionDenied, errors.New("nope"))
+		out := refresh.applyToError(orig, false)
+
+		var connectErr *connect.Error
+		require.ErrorAs(t, out, &connectErr)
+		assert.Equal(t, connect.CodePermissionDenied, connectErr.Code())
+		assert.Contains(t, connectErr.Message(), "nope")
+		parsed, err := http.ParseSetCookie(connectErr.Meta().Get("Set-Cookie"))
+		require.NoError(t, err)
+		assert.Equal(t, "sess-123", parsed.Value)
+	})
+
+	// Wrapping a plain error to give it metadata would decide its status code
+	// here, and connect.CodeOf answers CodeUnknown for a context.Canceled that
+	// connect-go itself reports as CodeCanceled. Losing one refresh costs a
+	// throttle window; changing the code a client sees for every cancelled
+	// request costs more.
+	t.Run("a plain error passes through untouched", func(t *testing.T) {
+		sentinel := errors.New("boom")
+		out := refresh.applyToError(sentinel, false)
+
+		assert.Equal(t, sentinel, out, "the error must reach connect-go's own mapping unchanged")
+		var connectErr *connect.Error
+		assert.False(t, errors.As(out, &connectErr), "it must not become a connect.Error here")
+	})
+
+	t.Run("a context cancellation keeps the code connect-go gives it", func(t *testing.T) {
+		out := refresh.applyToError(context.Canceled, false)
+
+		assert.ErrorIs(t, out, context.Canceled)
+		assert.Equal(t, context.Canceled, out,
+			"wrapping would report CodeUnknown where connect-go reports CodeCanceled")
+	})
+
+	t.Run("a request that slid nothing adds no cookie", func(t *testing.T) {
+		orig := connect.NewError(connect.CodeUnauthenticated, errors.New("no"))
+		out := sessionRefresh{}.applyToError(orig, false)
+
+		var connectErr *connect.Error
+		require.ErrorAs(t, out, &connectErr)
+		assert.Empty(t, connectErr.Meta().Get("Set-Cookie"))
+	})
+
+	t.Run("no error stays no error", func(t *testing.T) {
+		assert.NoError(t, refresh.applyToError(nil, false))
+	})
+}
+
+// A session must be able to slide BEFORE it expires. This is the property a
+// fixed five-minute throttle broke: a session shorter than the throttle expired
+// with the user still active, because no request in its whole life was ever
+// allowed to write the slide. The floor alone does not save it -- the throttle
+// has to scale with the session.
+func TestTouchThresholdAlwaysLeavesRoomToSlide(t *testing.T) {
+	for _, configured := range []time.Duration{
+		0, -time.Hour,
+		MinSessionDuration,
+		MinSessionDuration + time.Second,
+		6 * time.Minute,
+		time.Hour,
+		DefaultSessionDuration,
+		365 * 24 * time.Hour,
+	} {
+		lifetime := sessionLifetime(configured)
+		threshold := touchThreshold(configured)
+
+		assert.Positive(t, threshold, "configured=%s", configured)
+		assert.Less(t, threshold, lifetime,
+			"configured=%s: a session that expires before its first slide is an absolute timeout", configured)
+		assert.LessOrEqual(t, threshold, sessionTouchThreshold,
+			"configured=%s: the ceiling caps the DB write rate on a long session", configured)
+	}
+}
+
+// The slide must exceed the configured session duration by exactly the throttle
+// window. A request inside that window writes no row, so a shorter expiry would
+// end the session before the configured duration passed since the last request.
 func TestSlideDurationCoversTouchThrottle(t *testing.T) {
-	for _, configured := range []time.Duration{0, -time.Hour, time.Minute, 30 * 24 * time.Hour} {
+	for _, configured := range []time.Duration{0, -time.Hour, MinSessionDuration, time.Hour, 30 * 24 * time.Hour} {
 		a := &authInterceptor{sessionDuration: configured}
-		assert.GreaterOrEqual(t, a.slideDuration()-sessionLifetime(configured), sessionTouchThreshold,
+		assert.Equal(t, sessionLifetime(configured)+touchThreshold(configured), a.slideDuration(),
+			"configured=%s", configured)
+		assert.Greater(t, a.slideDuration(), sessionLifetime(configured), "configured=%s", configured)
+	}
+}
+
+// The login path and the slide path must write the same expiry. They disagreed
+// once, and the first window after a login was short by a whole throttle
+// window -- at the floor, the entire session.
+func TestSessionExpiryMatchesTheSlide(t *testing.T) {
+	for _, configured := range []time.Duration{0, MinSessionDuration, DefaultSessionDuration} {
+		now := time.Now()
+		a := &authInterceptor{sessionDuration: configured}
+		assert.Equal(t, now.Add(a.slideDuration()).UTC(), sessionExpiry(now, configured),
 			"configured=%s", configured)
 	}
+}
+
+// The floor exists to keep what the two overshoot sources cost together a small
+// share of the session. The throttle scales with the session; the validation
+// cache TTL does not, so it is the term that decides the floor.
+func TestMinSessionDurationBoundsTheOvershoot(t *testing.T) {
+	overshoot := touchThreshold(MinSessionDuration) + sessionCacheTTL
+	assert.LessOrEqual(t, overshoot, MinSessionDuration/5,
+		"at the floor a session must not outlive its configured duration by more than a fifth")
+
+	// And the floor must sit above the window a request can be served from the
+	// cache after the row expired, or "expired" describes nothing.
+	assert.Greater(t, MinSessionDuration, sessionCacheTTL)
+}
+
+// The lastTouch map is the DB rate-limiter and nothing else reads it, so an
+// entry older than one throttle window changes no decision. Sweeping it at the
+// session's whole life instead retained one entry per session the process ever
+// authenticated -- seven days of them by default, and however long an operator
+// configured otherwise.
+func TestSweepDropsLastTouchOnceTheThrottleWindowPassed(t *testing.T) {
+	a := &authInterceptor{sessionDuration: DefaultSessionDuration, state: &authState{}}
+	threshold := a.touchThreshold()
+
+	a.state.lastTouch.Store("fresh", time.Now())
+	a.state.lastTouch.Store("stale", time.Now().Add(-threshold-time.Minute))
+
+	a.sweepCachesOnce()
+
+	_, freshKept := a.state.lastTouch.Load("fresh")
+	assert.True(t, freshKept, "an entry inside the throttle window still gates a DB write")
+	_, staleKept := a.state.lastTouch.Load("stale")
+	assert.False(t, staleKept, "an entry past the throttle window gates nothing and must not be retained")
+}
+
+func TestValidateSessionDuration(t *testing.T) {
+	assert.NoError(t, ValidateSessionDuration(MinSessionDuration), "the minimum itself must be allowed")
+	assert.NoError(t, ValidateSessionDuration(DefaultSessionDuration))
+	assert.NoError(t, ValidateSessionDuration(365*24*time.Hour), "a long session is a policy an operator may hold")
+
+	require.Error(t, ValidateSessionDuration(MinSessionDuration-time.Second))
+	require.Error(t, ValidateSessionDuration(time.Second))
+	require.Error(t, ValidateSessionDuration(-time.Second))
 }
 
 // A non-positive configured duration must resolve to the default everywhere,

--- a/backend/internal/hub/auth/cookie_internal_test.go
+++ b/backend/internal/hub/auth/cookie_internal_test.go
@@ -1,0 +1,105 @@
+package auth
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionRefreshApplyTo_WritesSlidExpiry(t *testing.T) {
+	expires := time.Now().Add(DefaultSessionDuration).UTC().Truncate(time.Second)
+	h := http.Header{}
+
+	sessionRefresh{sessionID: "sess-123", expiresAt: expires}.applyTo(h, false)
+
+	values := h.Values("Set-Cookie")
+	require.Len(t, values, 1)
+	parsed, err := http.ParseSetCookie(values[0])
+	require.NoError(t, err)
+	assert.Equal(t, CookieName, parsed.Name)
+	assert.Equal(t, "sess-123", parsed.Value)
+	assert.True(t, parsed.HttpOnly)
+	assert.Equal(t, expires, parsed.Expires.UTC())
+	assert.Positive(t, parsed.MaxAge, "the browser must keep the cookie, not drop it at the end of the browser session")
+}
+
+func TestSessionRefreshApplyTo_UsesSecureCookieName(t *testing.T) {
+	h := http.Header{}
+
+	sessionRefresh{sessionID: "sess-123", expiresAt: time.Now().Add(time.Hour)}.applyTo(h, true)
+
+	parsed, err := http.ParseSetCookie(h.Get("Set-Cookie"))
+	require.NoError(t, err)
+	assert.Equal(t, SecureCookieName, parsed.Name)
+	assert.True(t, parsed.Secure)
+}
+
+func TestSessionRefreshApplyTo_ZeroValueWritesNothing(t *testing.T) {
+	h := http.Header{}
+
+	sessionRefresh{}.applyTo(h, false)
+
+	assert.Empty(t, h.Values("Set-Cookie"), "a request that slid nothing must not touch the browser's cookie")
+}
+
+// A handler that wrote its own session cookie is authoritative. Logout is the
+// case that matters: a browser applies both Set-Cookie headers for one name in
+// order and keeps the last, so appending a refresh after the clearing cookie
+// would leave the user signed in.
+func TestSessionRefreshApplyTo_KeepsHandlerCookie(t *testing.T) {
+	h := http.Header{}
+	h.Set("Set-Cookie", ClearSessionCookie(false).String())
+
+	sessionRefresh{sessionID: "sess-123", expiresAt: time.Now().Add(time.Hour)}.applyTo(h, false)
+
+	values := h.Values("Set-Cookie")
+	require.Len(t, values, 1, "the refresh must not append a second cookie for the same name")
+	parsed, err := http.ParseSetCookie(values[0])
+	require.NoError(t, err)
+	assert.Empty(t, parsed.Value)
+	assert.Negative(t, parsed.MaxAge, "the clearing cookie must survive the refresh")
+}
+
+// The refresh must not resurrect a session cookie for an unrelated cookie the
+// handler set (an OAuth state cookie, say). The skip is deliberately blind to
+// the name: a handler that writes any Set-Cookie owns the response's cookies.
+func TestSessionRefreshApplyTo_SkipsWhenAnyCookieWritten(t *testing.T) {
+	h := http.Header{}
+	h.Add("Set-Cookie", "oauth-state=abc; Path=/")
+
+	sessionRefresh{sessionID: "sess-123", expiresAt: time.Now().Add(time.Hour)}.applyTo(h, false)
+
+	assert.Len(t, h.Values("Set-Cookie"), 1)
+}
+
+// The slide must exceed the configured session duration by at least the touch
+// throttle. Otherwise a request inside the throttle window leaves the session
+// ending before that duration passed since the request -- the guarantee the
+// session duration states.
+func TestSlideDurationCoversTouchThrottle(t *testing.T) {
+	for _, configured := range []time.Duration{0, -time.Hour, time.Minute, 30 * 24 * time.Hour} {
+		a := &authInterceptor{sessionDuration: configured}
+		assert.GreaterOrEqual(t, a.slideDuration()-sessionLifetime(configured), sessionTouchThreshold,
+			"configured=%s", configured)
+	}
+}
+
+// A non-positive configured duration must resolve to the default everywhere,
+// including on a hand-built interceptor: a five-minute slide (the throttle
+// alone) would sign every user out through the day.
+func TestSlideDurationFallsBackToDefault(t *testing.T) {
+	a := &authInterceptor{}
+	assert.Equal(t, DefaultSessionDuration+sessionTouchThreshold, a.slideDuration())
+}
+
+// The configured duration, not the default, is what a slide writes.
+func TestSlideDurationHonoursConfiguredValue(t *testing.T) {
+	configured := 36 * time.Hour
+	interceptor, registry := NewInterceptor(InterceptorOptions{SessionDuration: configured})
+	t.Cleanup(registry.Stop)
+
+	assert.Equal(t, configured+sessionTouchThreshold, interceptor.(*authInterceptor).slideDuration())
+}

--- a/backend/internal/hub/auth/empty_userid_test.go
+++ b/backend/internal/hub/auth/empty_userid_test.go
@@ -132,13 +132,13 @@ func TestZeroUserIDDenies(t *testing.T) {
 				// requires it to state a contract: a session must never be
 				// written for an id that names no user -- that row would then
 				// authenticate as blank on every subsequent request.
-				_, _, err := auth.CreateSession(ctx, st, zero)
+				_, _, err := auth.CreateSession(ctx, st, zero, auth.DefaultSessionDuration)
 				require.Error(t, err, "a zero UserID must not create a session")
 				// Control, per this test's own contract: without it the case
 				// passes if CreateSession ever starts erroring for an unrelated
 				// reason (a schema change, a newly-required column), proving
 				// nothing about the zero id.
-				_, _, err = auth.CreateSession(ctx, st, ownerID)
+				_, _, err = auth.CreateSession(ctx, st, ownerID, auth.DefaultSessionDuration)
 				require.NoError(t, err, "control: a real user's session is created")
 			case "WorkerCanUse":
 				w, ok, err := auth.WorkerCanUse(ctx, st, worker.ID, ownerID)
@@ -250,9 +250,9 @@ func TestZeroUserIDDenies(t *testing.T) {
 // case" becomes a recorded judgment rather than an omission. Moving a function
 // here is the deliberate act; forgetting it entirely is a failure.
 var zeroUserIDNonDeciders = map[string]string{
-	"WithUser":                 "stores the principal on a context; the predicates that read it are the deciders",
-	"NewInterceptor":           "constructor; it authenticates requests rather than authorizing a principal it was handed",
-	"NewInterceptorWithTokens": "constructor; same as NewInterceptor",
+	"WithUser":         "stores the principal on a context; the predicates that read it are the deciders",
+	"NewInterceptor":   "constructor; it authenticates requests rather than authorizing a principal it was handed",
+	"AuthenticateHTTP": "the HTTP twin of the interceptor: it resolves a caller from the request's own credentials, and the *UserInfo it carries is the configured solo identity, not a principal a caller asserted",
 	"(*AuthContextRegistry).RegisterAuthenticatedLease": "refuses on a per-user quota keyed on the id, but a zero id could only share the leasesByUser[\"\"] bucket and over-refuse; it never widens reach. Unreachable besides -- every AuthenticateHTTP arm mints through userid.New and refuses a blank",
 	"(*AuthContextRegistry).CurrentSyntheticUser":       "returns the configured solo identity; it answers no question about the caller",
 	"(*AuthContextRegistry).IsAuthContextCurrent":       "compares cache generations, not identities -- a zero id is stale-vs-current, not allowed-vs-denied",
@@ -275,6 +275,8 @@ func TestEveryUserIDCarryingFuncIsClassified(t *testing.T) {
 	dir, err := os.Getwd()
 	require.NoError(t, err)
 
+	identityStructs := identityStructTypes(t, dir)
+
 	var found []string
 	testutil.ForEachPackageSourceFile(t, dir, func(_ *token.FileSet, file *ast.File) {
 		// Resolved from the import PATH, not assumed to be the identifier
@@ -287,7 +289,7 @@ func TestEveryUserIDCarryingFuncIsClassified(t *testing.T) {
 			if !ok || fn.Name == nil || !fn.Name.IsExported() || fn.Type.Params == nil {
 				continue
 			}
-			if hasIdentityParam(useridAlias, fn.Type.Params) {
+			if hasIdentityParam(useridAlias, identityStructs, fn.Type.Params) {
 				// Receiver-qualified so two same-named methods on different
 				// types cannot share one classification.
 				found = append(found, testutil.QualifiedFuncName(fn))
@@ -305,23 +307,100 @@ func TestEveryUserIDCarryingFuncIsClassified(t *testing.T) {
 
 // hasIdentityParam reports whether params includes a parameter that carries a
 // caller identity: a userid.UserID -- directly, or behind a slice / array /
-// pointer / variadic / map value -- or a *UserInfo, which holds one.
+// pointer / variadic / map value -- a *UserInfo, which holds one, or one of the
+// package's own structs that holds either (identityStructs).
 //
-// Both shapes need the same net. The batch predicates take []userid.UserID and
-// need the zero-deny contract just as much as the single-id ones (a zero entry
-// must be dropped, not matched). And matching only the bare type would leave
-// every *UserInfo-taking predicate outside the table -- the delegation-scope
-// decisions among them -- which is the blind spot this test exists to close.
-func hasIdentityParam(useridAlias string, params *ast.FieldList) bool {
+// All three shapes need the same net. The batch predicates take
+// []userid.UserID and need the zero-deny contract just as much as the single-id
+// ones (a zero entry must be dropped, not matched). Matching only the bare type
+// would leave every *UserInfo-taking predicate outside the table -- the
+// delegation-scope decisions among them -- which is the blind spot this test
+// exists to close. And an options struct closes the same hole again from the
+// other side: moving a parameter into one is a refactor nobody would call a
+// security change, and it took NewInterceptor's *UserInfo out of this net
+// without touching a single predicate.
+func hasIdentityParam(useridAlias string, identityStructs map[string]bool, params *ast.FieldList) bool {
 	if params == nil {
 		return false
 	}
 	for _, field := range params.List {
-		if carriesUserID(useridAlias, field.Type) || carriesUserInfo(field.Type) {
+		if carriesUserID(useridAlias, field.Type) ||
+			carriesUserInfo(field.Type) ||
+			carriesNamedStruct(identityStructs, field.Type) {
 			return true
 		}
 	}
 	return false
+}
+
+// identityStructTypes returns the package's struct type names that name a
+// caller identity in a field of their own.
+//
+// One level deep, deliberately. The shape this must catch is the options struct
+// -- a parameter whose fields are what the caller would otherwise have passed
+// positionally. Chasing further, through a field that points at a package's
+// internal state, reaches every type that transitively holds a *UserInfo:
+// AuthContextRegistry holds leases, so every constructor handed a registry
+// would land in the table as a "not a decider" entry, and a table that lists
+// everything classifies nothing.
+func identityStructTypes(t *testing.T, dir string) map[string]bool {
+	t.Helper()
+
+	type declaredStruct struct {
+		spec        *ast.StructType
+		useridAlias string // resolved per file, as in the scan above
+	}
+	declared := map[string]declaredStruct{}
+	testutil.ForEachPackageSourceFile(t, dir, func(_ *token.FileSet, file *ast.File) {
+		useridAlias, _ := testutil.ImportedAs(file, useridPkgPath)
+		for _, decl := range file.Decls {
+			gen, ok := decl.(*ast.GenDecl)
+			if !ok || gen.Tok != token.TYPE {
+				continue
+			}
+			for _, spec := range gen.Specs {
+				ts, ok := spec.(*ast.TypeSpec)
+				if !ok {
+					continue
+				}
+				st, ok := ts.Type.(*ast.StructType)
+				if !ok || st.Fields == nil {
+					continue
+				}
+				declared[ts.Name.Name] = declaredStruct{spec: st, useridAlias: useridAlias}
+			}
+		}
+	})
+
+	carries := map[string]bool{}
+	for name, d := range declared {
+		for _, field := range d.spec.Fields.List {
+			if carriesUserID(d.useridAlias, field.Type) || carriesUserInfo(field.Type) {
+				carries[name] = true
+				break
+			}
+		}
+	}
+	return carries
+}
+
+// carriesNamedStruct unwraps the same type constructors as its siblings and
+// reports whether one of the named structs sits at the bottom.
+func carriesNamedStruct(named map[string]bool, expr ast.Expr) bool {
+	switch t := expr.(type) {
+	case *ast.Ident:
+		return named[t.Name]
+	case *ast.ArrayType:
+		return carriesNamedStruct(named, t.Elt)
+	case *ast.StarExpr:
+		return carriesNamedStruct(named, t.X)
+	case *ast.Ellipsis:
+		return carriesNamedStruct(named, t.Elt)
+	case *ast.MapType:
+		return carriesNamedStruct(named, t.Key) || carriesNamedStruct(named, t.Value)
+	default:
+		return false
+	}
 }
 
 // carriesUserID unwraps the type constructors a UserID can hide behind and
@@ -372,6 +451,55 @@ func carriesUserInfo(expr ast.Expr) bool {
 // own stale-entry half, which fires solely because those names happen to be
 // listed today. A NEW predicate in such a file would have been born
 // unclassified and green.
+// TestIdentityStructTypes_ScopesToOptionsStructs pins the boundary the scan
+// draws: a struct that names an identity in a field of its own is in, and a
+// type that merely holds internal state that eventually holds one is out.
+//
+// Both halves are load-bearing. Without the first, moving a *UserInfo parameter
+// into an options struct takes its function out of the classification table
+// silently -- which is exactly what the InterceptorOptions refactor did. Without
+// the second, every constructor handed an AuthContextRegistry joins the table,
+// and a table that lists everything classifies nothing.
+func TestIdentityStructTypes_ScopesToOptionsStructs(t *testing.T) {
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+
+	carries := identityStructTypes(t, dir)
+
+	assert.True(t, carries["InterceptorOptions"], "it names SoloUser *UserInfo")
+	assert.True(t, carries["HTTPAuthOpts"], "it names SoloUser *UserInfo")
+	assert.True(t, carries["UserInfo"], "it names ID userid.UserID")
+	assert.False(t, carries["AuthContextRegistry"], "it reaches a *UserInfo only through internal state")
+	assert.False(t, carries["SessionMeta"], "it carries a user agent and an IP address, no identity")
+}
+
+func TestCarriesNamedStruct(t *testing.T) {
+	named := map[string]bool{"InterceptorOptions": true}
+	for name, tc := range map[string]struct {
+		expr string
+		want bool
+	}{
+		"bare":                       {"InterceptorOptions", true},
+		"behind a pointer":           {"*InterceptorOptions", true},
+		"behind a slice":             {"[]InterceptorOptions", true},
+		"as a map value":             {"map[string]InterceptorOptions", true},
+		"a struct that carries none": {"SessionMeta", false},
+		"a plain string":             {"string", false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			expr, err := parser.ParseExpr(tc.expr)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, carriesNamedStruct(named, expr))
+		})
+	}
+
+	// `...T` is not an expression, so the variadic arm needs the node built by
+	// hand rather than parsed.
+	t.Run("variadic", func(t *testing.T) {
+		assert.True(t, carriesNamedStruct(named, &ast.Ellipsis{Elt: ast.NewIdent("InterceptorOptions")}))
+	})
+}
+
 func TestCarriesUserID_KeysOnTheImportedIdentifier(t *testing.T) {
 	for name, tc := range map[string]struct {
 		alias string

--- a/backend/internal/hub/auth/empty_userid_test.go
+++ b/backend/internal/hub/auth/empty_userid_test.go
@@ -333,7 +333,7 @@ func hasIdentityParam(useridAlias string, identityStructs map[string]bool, param
 	return false
 }
 
-// identityStructTypes returns the package's struct type names that name a
+// identityStructTypes returns the package's struct type names that declare a
 // caller identity in a field of their own.
 //
 // One level deep, deliberately. The shape this must catch is the options struct
@@ -442,17 +442,8 @@ func carriesUserInfo(expr ast.Expr) bool {
 	}
 }
 
-// TestCarriesUserID_KeysOnTheImportedIdentifier pins the alias resolution that
-// decides which declarations this net can even see.
-//
-// Keying on the literal identifier "userid" meant a file spelling
-// `uid "…/internal/util/userid"` took every predicate it declares outside the
-// net at once -- and the only thing that would have complained is the table's
-// own stale-entry half, which fires solely because those names happen to be
-// listed today. A NEW predicate in such a file would have been born
-// unclassified and green.
 // TestIdentityStructTypes_ScopesToOptionsStructs pins the boundary the scan
-// draws: a struct that names an identity in a field of its own is in, and a
+// draws: a struct that declares an identity in a field of its own is in, and a
 // type that merely holds internal state that eventually holds one is out.
 //
 // Both halves are load-bearing. Without the first, moving a *UserInfo parameter
@@ -466,9 +457,9 @@ func TestIdentityStructTypes_ScopesToOptionsStructs(t *testing.T) {
 
 	carries := identityStructTypes(t, dir)
 
-	assert.True(t, carries["InterceptorOptions"], "it names SoloUser *UserInfo")
-	assert.True(t, carries["HTTPAuthOpts"], "it names SoloUser *UserInfo")
-	assert.True(t, carries["UserInfo"], "it names ID userid.UserID")
+	assert.True(t, carries["InterceptorOptions"], "it declares SoloUser *UserInfo")
+	assert.True(t, carries["HTTPAuthOpts"], "it declares SoloUser *UserInfo")
+	assert.True(t, carries["UserInfo"], "it declares ID userid.UserID")
 	assert.False(t, carries["AuthContextRegistry"], "it reaches a *UserInfo only through internal state")
 	assert.False(t, carries["SessionMeta"], "it carries a user agent and an IP address, no identity")
 }
@@ -500,6 +491,15 @@ func TestCarriesNamedStruct(t *testing.T) {
 	})
 }
 
+// TestCarriesUserID_KeysOnTheImportedIdentifier pins the alias resolution that
+// decides which declarations this net can even see.
+//
+// Keying on the literal identifier "userid" meant a file spelling
+// `uid "…/internal/util/userid"` took every predicate it declares outside the
+// net at once -- and the only thing that would have complained is the table's
+// own stale-entry half, which fires solely because those names happen to be
+// listed today. A NEW predicate in such a file would have been born
+// unclassified and green.
 func TestCarriesUserID_KeysOnTheImportedIdentifier(t *testing.T) {
 	for name, tc := range map[string]struct {
 		alias string

--- a/backend/internal/hub/auth/interceptor.go
+++ b/backend/internal/hub/auth/interceptor.go
@@ -88,16 +88,6 @@ var unverifiedAllowedProcedures = map[string]bool{
 // revocation (logout) evicts the entry immediately via AuthContextRegistry.Evict.
 const sessionCacheTTL = 30 * time.Second
 
-// MinSessionDuration is the shortest session the Hub can honestly enforce.
-//
-// A validated session stays in the in-memory cache for sessionCacheTTL, so a
-// request is served up to that long after the session expired. At twice the
-// cache TTL that overshoot is a small share of the session's life. Below it,
-// "expired" stops describing when the user is signed out. The Hub configuration
-// rejects a configured duration under this rather than accept a policy it
-// cannot keep.
-const MinSessionDuration = 2 * sessionCacheTTL
-
 // cachedSession holds a validated UserInfo with its cache time and the
 // revocation sequence observed before validation. Cache reads compare that
 // sequence only with marks for the same session, bearer, or user, so unrelated
@@ -169,10 +159,12 @@ type authInterceptor struct {
 	emailVerificationRequired bool
 	soloUser                  *UserInfo
 	tokenValidator            *TokenValidator
-	// sessionDuration is InterceptorOptions.SessionDuration, resolved through
-	// sessionLifetime by the constructor. slideDuration resolves it again rather
-	// than trusting that, because the package's own tests build this struct
-	// directly and a zero there must mean the default, not a five-minute session.
+	// sessionDuration is InterceptorOptions.SessionDuration exactly as the caller
+	// gave it, so zero still means "unset" here. Every reader resolves it through
+	// sessionLifetime. One rule, applied at each read, rather than a value that a
+	// reader has to know the history of: the package's own tests build this
+	// struct directly, and a zero there must mean the default and not an
+	// instantly expired session.
 	sessionDuration time.Duration
 	// state holds the shared caches, lease registry, and revocation ledger.
 	// Its revocationGen is the monotonic ordering clock shared by validation
@@ -188,20 +180,25 @@ type authInterceptor struct {
 	bearerFlight singleflight.Group
 }
 
-// InterceptorOptions carries what the auth interceptor needs. Every field is
-// optional; the zero value gives cookie-only multi-user auth with the default
-// session duration.
+// InterceptorOptions carries what the auth interceptor needs. Store is what a
+// working interceptor requires; every other field is optional, and the rest of
+// the zero value gives cookie-only multi-user auth with the default session
+// duration.
 //
 // A struct rather than a parameter list: the settings are three flags of the
 // same shape (two bools and a duration) whose meaning no call site would state,
 // and a transposed pair compiles and then authenticates wrongly.
 type InterceptorOptions struct {
+	// Store validates a session cookie and a bearer credential. A nil Store
+	// gives an interceptor that can do neither, which is useful only for the
+	// AuthContextRegistry that the constructor returns beside it -- a request
+	// that presents a cookie reaches the store and panics.
 	Store store.Store
 	// SoloUser enables solo mode, in which every request is automatically
 	// authenticated as that user. Nil gives normal multi-user auth.
 	SoloUser *UserInfo
 	// TokenValidator accepts Authorization: Bearer lmx_... credentials alongside
-	// the cookie path. Nil keeps cookie-only behaviour.
+	// the cookie path. Nil keeps cookie-only behavior.
 	TokenValidator *TokenValidator
 	// SecureCookies selects the __Host- prefixed cookie name, which the Hub uses
 	// behind TLS.
@@ -230,7 +227,7 @@ func NewInterceptor(opts InterceptorOptions) (connect.Interceptor, *AuthContextR
 		emailVerificationRequired: opts.EmailVerificationRequired,
 		soloUser:                  opts.SoloUser,
 		tokenValidator:            opts.TokenValidator,
-		sessionDuration:           sessionLifetime(opts.SessionDuration),
+		sessionDuration:           opts.SessionDuration,
 		state:                     state,
 	}
 	sweepCtx, cancel := context.WithCancel(context.Background())
@@ -728,13 +725,24 @@ func (a *authInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 	return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
 		ctx, refresh, err := a.authenticate(ctx, req.Spec().Procedure, req.Header().Get("Cookie"), req.Header().Get("Authorization"))
 		if err != nil {
-			return nil, err
+			// authenticate rejects an authenticated request too -- an unverified
+			// user reaches the email-verification gate after the slide committed --
+			// so this rejection carries the cookie for the same reason the handler's
+			// does below.
+			return nil, refresh.applyToError(err, a.secureCookie)
 		}
 		resp, err := next(ctx, req)
-		// A failed call answers with a connect.Error and no response to hang a
-		// header on. The DB row already slid, so the next call that succeeds
-		// carries the cookie.
-		if err != nil || resp == nil {
+		if err != nil {
+			// A failed call has no response to hang a header on, but a
+			// connect.Error carries its own metadata, and connect-go merges that
+			// into the response header before it writes the status. Without this
+			// arm a client whose calls keep failing -- a permission denial, a
+			// validation error, a procedure that is briefly unwell -- slides the
+			// row on every request and is still signed out at the login deadline,
+			// because the throttle gives the cookie no other request to ride.
+			return nil, refresh.applyToError(err, a.secureCookie)
+		}
+		if resp == nil {
 			return resp, err
 		}
 		refresh.applyTo(resp.Header(), a.secureCookie)
@@ -749,13 +757,15 @@ func (a *authInterceptor) WrapStreamingClient(next connect.StreamingClientFunc) 
 func (a *authInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
 	return func(ctx context.Context, conn connect.StreamingHandlerConn) error {
 		ctx, refresh, err := a.authenticate(ctx, conn.Spec().Procedure, conn.RequestHeader().Get("Cookie"), conn.RequestHeader().Get("Authorization"))
+		// Before the handler runs, not after: the response header of a stream
+		// goes out with the first message, and a long-lived stream sends that
+		// message long before it returns. The write happens on the rejection path
+		// too, because a stream carries an error in its body and not in the
+		// header, so the header is the only place a cookie can travel either way.
+		refresh.applyTo(conn.ResponseHeader(), a.secureCookie)
 		if err != nil {
 			return err
 		}
-		// Before the handler runs, not after: the response header of a stream
-		// goes out with the first message, and a long-lived stream sends that
-		// message long before it returns.
-		refresh.applyTo(conn.ResponseHeader(), a.secureCookie)
 		return next(ctx, conn)
 	}
 }
@@ -811,8 +821,14 @@ func (a *authInterceptor) authenticate(ctx context.Context, procedure, cookieHea
 
 	ctx = WithUser(ctx, userInfo)
 
+	// The refresh travels with the rejection, not only with a success. The slide
+	// above already committed to the row, and the throttle then blocks every
+	// other request for a whole window, so a user whose calls are refused here --
+	// an unverified user waiting to verify, whose every non-allowlisted procedure
+	// is denied -- would slide the row again and again and never receive a cookie
+	// for it.
 	if err := a.enforceEmailVerification(procedure, userInfo); err != nil {
-		return ctx, noRefresh, err
+		return ctx, refresh, err
 	}
 
 	return ctx, refresh, nil
@@ -1036,21 +1052,26 @@ func (a *authInterceptor) bearerRevoked(key bearerCacheKeyParts, user *UserInfo,
 		userRevokedAfter(&a.state.userRevocations, user, validationGen)
 }
 
+// sessionTouchThreshold caps how long the Hub waits before it slides a session
+// again. touchThreshold shortens it for a session whose whole life is shorter,
+// so this constant is the ceiling and not the interval itself.
 const sessionTouchThreshold = 5 * time.Minute
 
-// slideDuration is the expiry that a touch writes. The extra
-// sessionTouchThreshold keeps the promise that the configured session duration
-// makes. A request inside the throttle window writes nothing, so an expiry of
-// exactly now + sessionDuration would end the session up to
-// sessionTouchThreshold before that duration passed since the last request. It
-// is also the longest that a session row can outlive its last touch, which is
-// the span the cache sweep cutoffs measure.
+// touchThreshold is this interceptor's slide interval. It is also the longest
+// that a session row can outlive its last touch, which is the span the mark
+// sweep cutoff measures.
+func (a *authInterceptor) touchThreshold() time.Duration {
+	return touchThreshold(a.sessionDuration)
+}
+
+// slideDuration is how far past now a touch writes the expiry. See
+// sessionExpiry, which the login path uses for the same span.
 func (a *authInterceptor) slideDuration() time.Duration {
-	return sessionLifetime(a.sessionDuration) + sessionTouchThreshold
+	return sessionLifetime(a.sessionDuration) + a.touchThreshold()
 }
 
 // touchSession slides the session expiry to now + slideDuration if the last
-// touch was more than sessionTouchThreshold ago. An in-memory map gates the
+// touch was more than touchThreshold ago. An in-memory map gates the
 // check so that most requests skip the DB call entirely — only the first
 // request after the threshold elapses hits SQLite.
 //
@@ -1062,27 +1083,35 @@ func (a *authInterceptor) slideDuration() time.Duration {
 // one session duration after the login however active they were.
 func (a *authInterceptor) touchSession(ctx context.Context, sessionID string, user *UserInfo) time.Time {
 	now := time.Now()
+	threshold := a.touchThreshold()
 	if v, ok := a.state.lastTouch.Load(sessionID); ok {
-		if now.Sub(v.(time.Time)) < sessionTouchThreshold {
+		if now.Sub(v.(time.Time)) < threshold {
 			return time.Time{}
 		}
 	}
 
+	// Record the attempt before the UPDATE runs, and whatever the UPDATE
+	// answers: lastTouch is the per-process DB rate-limiter. A zero-row match
+	// means the session was already touched within the threshold, and an error
+	// means the store is unwell -- in both cases the next request must wait
+	// rather than retry at once, which a store that keeps failing would turn
+	// into one UPDATE for every authenticated request.
+	a.state.lastTouch.Store(sessionID, now)
+
 	newExpiry := now.Add(a.slideDuration()).UTC()
-	threshold := now.Add(-sessionTouchThreshold).UTC()
 	rows, err := a.store.Sessions().Touch(ctx, store.TouchSessionParams{
 		ID:           sessionID,
 		ExpiresAt:    newExpiry,
-		LastActiveAt: threshold,
+		LastActiveAt: now.Add(-threshold).UTC(),
 	})
 	if err != nil {
+		// Nothing above this call reports the failure, and the caller cannot
+		// tell it apart from a throttled request. Log it, or a store that
+		// refuses every touch signs each user out at their login deadline with
+		// no operator-visible cause.
+		slog.WarnContext(ctx, "failed to slide session expiry", "error", err)
 		return time.Time{}
 	}
-	// Record the attempt regardless of whether a row matched: lastTouch is the
-	// per-process DB rate-limiter, and a zero-row match means the session was
-	// already touched within the threshold, so the next request should still
-	// wait before retrying the UPDATE.
-	a.state.lastTouch.Store(sessionID, now)
 	if rows == 0 {
 		// The conditional UPDATE (WHERE last_active_at < threshold) matched no
 		// row, so the DB expiry was NOT advanced -- most commonly on a freshly
@@ -1124,11 +1153,15 @@ const touchSweepInterval = 10 * time.Minute
 
 // sweepCachesOnce removes stale entries from the lastTouch, session, and bearer
 // caches and from the revocation/invalidation mark maps. Touch entries older
-// than slideDuration are removed since those sessions have expired -- that
-// span, not the session duration alone, is the longest a session row can
-// outlive its last touch. Session and bearer cache entries older than sessionCacheTTL
-// are removed to avoid unbounded growth, and revocation/invalidation marks older
-// than slideDuration are swept under revocationMu.
+// than touchThreshold are removed because the throttle is the only thing that
+// reads them, and it treats an entry older than one window as absent: the
+// deletion changes no decision, and holding the entry for the session's whole
+// life retains one map entry per session that the process ever authenticated.
+// Session and bearer cache entries older than sessionCacheTTL are removed to
+// avoid unbounded growth, and revocation/invalidation marks older than
+// slideDuration are swept under revocationMu -- those must outlive the request
+// snapshots that they invalidate, which is the session's life and not the
+// throttle window.
 //
 // The session/bearer cache SCAN runs lock-free (like lastTouch and bearerExpiries
 // above) so the O(cache size) walk does not stall every hot-path acquirer of
@@ -1137,7 +1170,7 @@ const touchSweepInterval = 10 * time.Minute
 // delete is unconditional -- see below).
 func (a *authInterceptor) sweepCachesOnce() {
 	now := time.Now()
-	touchCutoff := now.Add(-a.slideDuration())
+	touchCutoff := now.Add(-a.touchThreshold())
 	a.state.lastTouch.Range(func(key, value any) bool {
 		if value.(time.Time).Before(touchCutoff) {
 			a.state.deleteStaleLastTouch(key, value)

--- a/backend/internal/hub/auth/interceptor.go
+++ b/backend/internal/hub/auth/interceptor.go
@@ -88,6 +88,16 @@ var unverifiedAllowedProcedures = map[string]bool{
 // revocation (logout) evicts the entry immediately via AuthContextRegistry.Evict.
 const sessionCacheTTL = 30 * time.Second
 
+// MinSessionDuration is the shortest session the Hub can honestly enforce.
+//
+// A validated session stays in the in-memory cache for sessionCacheTTL, so a
+// request is served up to that long after the session expired. At twice the
+// cache TTL that overshoot is a small share of the session's life. Below it,
+// "expired" stops describing when the user is signed out. The Hub configuration
+// rejects a configured duration under this rather than accept a policy it
+// cannot keep.
+const MinSessionDuration = 2 * sessionCacheTTL
+
 // cachedSession holds a validated UserInfo with its cache time and the
 // revocation sequence observed before validation. Cache reads compare that
 // sequence only with marks for the same session, bearer, or user, so unrelated
@@ -159,6 +169,11 @@ type authInterceptor struct {
 	emailVerificationRequired bool
 	soloUser                  *UserInfo
 	tokenValidator            *TokenValidator
+	// sessionDuration is InterceptorOptions.SessionDuration, resolved through
+	// sessionLifetime by the constructor. slideDuration resolves it again rather
+	// than trusting that, because the package's own tests build this struct
+	// directly and a zero there must mean the default, not a five-minute session.
+	sessionDuration time.Duration
 	// state holds the shared caches, lease registry, and revocation ledger.
 	// Its revocationGen is the monotonic ordering clock shared by validation
 	// snapshots and identity-scoped revocation/invalidation marks.
@@ -173,31 +188,49 @@ type authInterceptor struct {
 	bearerFlight singleflight.Group
 }
 
+// InterceptorOptions carries what the auth interceptor needs. Every field is
+// optional; the zero value gives cookie-only multi-user auth with the default
+// session duration.
+//
+// A struct rather than a parameter list: the settings are three flags of the
+// same shape (two bools and a duration) whose meaning no call site would state,
+// and a transposed pair compiles and then authenticates wrongly.
+type InterceptorOptions struct {
+	Store store.Store
+	// SoloUser enables solo mode, in which every request is automatically
+	// authenticated as that user. Nil gives normal multi-user auth.
+	SoloUser *UserInfo
+	// TokenValidator accepts Authorization: Bearer lmx_... credentials alongside
+	// the cookie path. Nil keeps cookie-only behaviour.
+	TokenValidator *TokenValidator
+	// SecureCookies selects the __Host- prefixed cookie name, which the Hub uses
+	// behind TLS.
+	SecureCookies bool
+	// EmailVerificationRequired refuses an unverified, non-admin user every
+	// procedure outside the pre-verification allowlist.
+	EmailVerificationRequired bool
+	// SessionDuration is the minimum time a session stays valid after the user's
+	// last request. Zero or less falls back to DefaultSessionDuration.
+	SessionDuration time.Duration
+}
+
 // NewInterceptor creates a ConnectRPC interceptor that validates session cookies
 // and attaches user info to the context. Public procedures (login, worker
-// registration) are exempt from auth checks. Pass a non-nil soloUser to enable
-// solo mode, in which all requests are automatically authenticated as that
-// user; pass nil for normal multi-user auth.
+// registration) are exempt from auth checks.
 //
 // The returned AuthContextRegistry can be used to evict entries from the in-memory
 // touch throttle (e.g., on logout). Call AuthContextRegistry.Stop to terminate the
 // background sweep goroutine.
-func NewInterceptor(st store.Store, soloUser *UserInfo, secureCookie bool, emailVerificationRequired bool) (connect.Interceptor, *AuthContextRegistry) {
-	return NewInterceptorWithTokens(st, soloUser, nil, secureCookie, emailVerificationRequired)
-}
-
-// NewInterceptorWithTokens is the variant that wires in a TokenValidator
-// so Authorization: Bearer lmx_... credentials are accepted alongside
-// the cookie path. Pass nil for tokenValidator to keep cookie-only
-// behaviour (tests that don't need bearer auth).
-func NewInterceptorWithTokens(st store.Store, soloUser *UserInfo, tokenValidator *TokenValidator, secureCookie bool, emailVerificationRequired bool) (connect.Interceptor, *AuthContextRegistry) {
+func NewInterceptor(opts InterceptorOptions) (connect.Interceptor, *AuthContextRegistry) {
+	st := opts.Store
 	state := &authState{}
 	a := &authInterceptor{
 		store:                     st,
-		secureCookie:              secureCookie,
-		emailVerificationRequired: emailVerificationRequired,
-		soloUser:                  soloUser,
-		tokenValidator:            tokenValidator,
+		secureCookie:              opts.SecureCookies,
+		emailVerificationRequired: opts.EmailVerificationRequired,
+		soloUser:                  opts.SoloUser,
+		tokenValidator:            opts.TokenValidator,
+		sessionDuration:           sessionLifetime(opts.SessionDuration),
 		state:                     state,
 	}
 	sweepCtx, cancel := context.WithCancel(context.Background())
@@ -693,11 +726,19 @@ func (c *AuthContextRegistry) Stop() {
 
 func (a *authInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 	return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
-		ctx, err := a.authenticate(ctx, req.Spec().Procedure, req.Header().Get("Cookie"), req.Header().Get("Authorization"))
+		ctx, refresh, err := a.authenticate(ctx, req.Spec().Procedure, req.Header().Get("Cookie"), req.Header().Get("Authorization"))
 		if err != nil {
 			return nil, err
 		}
-		return next(ctx, req)
+		resp, err := next(ctx, req)
+		// A failed call answers with a connect.Error and no response to hang a
+		// header on. The DB row already slid, so the next call that succeeds
+		// carries the cookie.
+		if err != nil || resp == nil {
+			return resp, err
+		}
+		refresh.applyTo(resp.Header(), a.secureCookie)
+		return resp, nil
 	}
 }
 
@@ -707,10 +748,14 @@ func (a *authInterceptor) WrapStreamingClient(next connect.StreamingClientFunc) 
 
 func (a *authInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
 	return func(ctx context.Context, conn connect.StreamingHandlerConn) error {
-		ctx, err := a.authenticate(ctx, conn.Spec().Procedure, conn.RequestHeader().Get("Cookie"), conn.RequestHeader().Get("Authorization"))
+		ctx, refresh, err := a.authenticate(ctx, conn.Spec().Procedure, conn.RequestHeader().Get("Cookie"), conn.RequestHeader().Get("Authorization"))
 		if err != nil {
 			return err
 		}
+		// Before the handler runs, not after: the response header of a stream
+		// goes out with the first message, and a long-lived stream sends that
+		// message long before it returns.
+		refresh.applyTo(conn.ResponseHeader(), a.secureCookie)
 		return next(ctx, conn)
 	}
 }
@@ -719,48 +764,58 @@ func (a *authInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc
 // Public procedures pass through with optional solo-mode user. Authenticated
 // requests are checked for email verification when required. Bearer tokens
 // (Authorization: Bearer lmx_...) are accepted alongside the cookie path.
-func (a *authInterceptor) authenticate(ctx context.Context, procedure, cookieHeader, authHeader string) (context.Context, error) {
+//
+// The second result is the session slide that this request caused, which the
+// caller writes to the response as a refreshed cookie. It is the zero value on
+// every path that slides nothing: solo mode, a public procedure, and bearer
+// auth all hold no session cookie to refresh.
+func (a *authInterceptor) authenticate(ctx context.Context, procedure, cookieHeader, authHeader string) (context.Context, sessionRefresh, error) {
+	var noRefresh sessionRefresh
+
 	// Solo mode authenticates every procedure -- public or not -- as the
 	// synthetic user and short-circuits the bearer/cookie paths.
 	if a.soloUser != nil {
-		return WithUser(ctx, a.state.currentSyntheticUser(a.soloUser)), nil
+		return WithUser(ctx, a.state.currentSyntheticUser(a.soloUser)), noRefresh, nil
 	}
 
 	if publicProcedures[procedure] {
-		return ctx, nil
+		return ctx, noRefresh, nil
 	}
 
 	if userInfo, ok, err := a.tryAuthenticateBearer(ctx, authHeader); err != nil {
-		return ctx, err
+		return ctx, noRefresh, err
 	} else if ok {
 		ctx = WithUser(ctx, userInfo)
 		if userInfo.Credential.IsDelegation() && !delegationAllowedProcedures[procedure] {
-			return ctx, connect.NewError(connect.CodePermissionDenied, fmt.Errorf("delegation token cannot call this procedure"))
+			return ctx, noRefresh, connect.NewError(connect.CodePermissionDenied, fmt.Errorf("delegation token cannot call this procedure"))
 		}
 		if err := a.enforceEmailVerification(procedure, userInfo); err != nil {
-			return ctx, err
+			return ctx, noRefresh, err
 		}
-		return ctx, nil
+		return ctx, noRefresh, nil
 	}
 
 	token := SessionIDFromHeader(cookieHeader, a.secureCookie)
 	if token == "" {
-		return ctx, connect.NewError(connect.CodeUnauthenticated, nil)
+		return ctx, noRefresh, connect.NewError(connect.CodeUnauthenticated, nil)
 	}
 
 	userInfo, err := a.validateTokenCached(ctx, token)
 	if err != nil {
-		return ctx, err
+		return ctx, noRefresh, err
 	}
-	a.touchSession(ctx, token, userInfo)
+	refresh := noRefresh
+	if slidTo := a.touchSession(ctx, token, userInfo); !slidTo.IsZero() {
+		refresh = sessionRefresh{sessionID: token, expiresAt: slidTo}
+	}
 
 	ctx = WithUser(ctx, userInfo)
 
 	if err := a.enforceEmailVerification(procedure, userInfo); err != nil {
-		return ctx, err
+		return ctx, noRefresh, err
 	}
 
-	return ctx, nil
+	return ctx, refresh, nil
 }
 
 // enforceEmailVerification rejects a request from an unverified, non-admin user
@@ -983,19 +1038,37 @@ func (a *authInterceptor) bearerRevoked(key bearerCacheKeyParts, user *UserInfo,
 
 const sessionTouchThreshold = 5 * time.Minute
 
-// touchSession extends the session expiry by SessionDuration if the last
+// slideDuration is the expiry that a touch writes. The extra
+// sessionTouchThreshold keeps the promise that the configured session duration
+// makes. A request inside the throttle window writes nothing, so an expiry of
+// exactly now + sessionDuration would end the session up to
+// sessionTouchThreshold before that duration passed since the last request. It
+// is also the longest that a session row can outlive its last touch, which is
+// the span the cache sweep cutoffs measure.
+func (a *authInterceptor) slideDuration() time.Duration {
+	return sessionLifetime(a.sessionDuration) + sessionTouchThreshold
+}
+
+// touchSession slides the session expiry to now + slideDuration if the last
 // touch was more than sessionTouchThreshold ago. An in-memory map gates the
 // check so that most requests skip the DB call entirely — only the first
 // request after the threshold elapses hits SQLite.
-func (a *authInterceptor) touchSession(ctx context.Context, sessionID string, user *UserInfo) {
+//
+// Returns the new expiry, or the zero time when nothing slid. The caller
+// re-issues the session cookie with that expiry. The cookie carries its own
+// Expires attribute, so a browser drops it at the deadline that the last
+// Set-Cookie named; without the re-issue the slide extends a row that the
+// browser stops sending a cookie for, and the user is signed out
+// one session duration after the login however active they were.
+func (a *authInterceptor) touchSession(ctx context.Context, sessionID string, user *UserInfo) time.Time {
 	now := time.Now()
 	if v, ok := a.state.lastTouch.Load(sessionID); ok {
 		if now.Sub(v.(time.Time)) < sessionTouchThreshold {
-			return
+			return time.Time{}
 		}
 	}
 
-	newExpiry := now.Add(SessionDuration).UTC()
+	newExpiry := now.Add(a.slideDuration()).UTC()
 	threshold := now.Add(-sessionTouchThreshold).UTC()
 	rows, err := a.store.Sessions().Touch(ctx, store.TouchSessionParams{
 		ID:           sessionID,
@@ -1003,7 +1076,7 @@ func (a *authInterceptor) touchSession(ctx context.Context, sessionID string, us
 		LastActiveAt: threshold,
 	})
 	if err != nil {
-		return
+		return time.Time{}
 	}
 	// Record the attempt regardless of whether a row matched: lastTouch is the
 	// per-process DB rate-limiter, and a zero-row match means the session was
@@ -1015,9 +1088,10 @@ func (a *authInterceptor) touchSession(ctx context.Context, sessionID string, us
 		// row, so the DB expiry was NOT advanced -- most commonly on a freshly
 		// (re)started Hub whose lastTouch map is empty but whose session was
 		// touched moments ago. Do not slide the in-memory credential / lease /
-		// channel deadlines past the un-advanced DB value; a later touch past
-		// the threshold advances DB and memory together.
-		return
+		// channel deadlines past the un-advanced DB value, and do not re-issue a
+		// cookie for a deadline that the row does not carry; a later touch past
+		// the threshold advances DB, memory, and cookie together.
+		return time.Time{}
 	}
 	// The slid DB expiry is authoritative and finite; carry it as a deadline for
 	// the in-memory credential / lease / channel arms.
@@ -1043,16 +1117,18 @@ func (a *authInterceptor) touchSession(ctx context.Context, sessionID string, us
 	if rp := a.state.channelRescheduler.Load(); rp != nil {
 		(*rp).RescheduleExpiryBySession(sessionID, newDeadline)
 	}
+	return newExpiry
 }
 
 const touchSweepInterval = 10 * time.Minute
 
 // sweepCachesOnce removes stale entries from the lastTouch, session, and bearer
 // caches and from the revocation/invalidation mark maps. Touch entries older
-// than SessionDuration are removed since those sessions have expired. Session
-// and bearer cache entries older than sessionCacheTTL are removed to avoid
-// unbounded growth, and revocation/invalidation marks older than SessionDuration
-// are swept under revocationMu.
+// than slideDuration are removed since those sessions have expired -- that
+// span, not the session duration alone, is the longest a session row can
+// outlive its last touch. Session and bearer cache entries older than sessionCacheTTL
+// are removed to avoid unbounded growth, and revocation/invalidation marks older
+// than slideDuration are swept under revocationMu.
 //
 // The session/bearer cache SCAN runs lock-free (like lastTouch and bearerExpiries
 // above) so the O(cache size) walk does not stall every hot-path acquirer of
@@ -1061,7 +1137,7 @@ const touchSweepInterval = 10 * time.Minute
 // delete is unconditional -- see below).
 func (a *authInterceptor) sweepCachesOnce() {
 	now := time.Now()
-	touchCutoff := now.Add(-SessionDuration)
+	touchCutoff := now.Add(-a.slideDuration())
 	a.state.lastTouch.Range(func(key, value any) bool {
 		if value.(time.Time).Before(touchCutoff) {
 			a.state.deleteStaleLastTouch(key, value)
@@ -1124,7 +1200,7 @@ func (a *authInterceptor) sweepCachesOnce() {
 	// uses an unconditional Delete (no CAS), so a lock-free scan could drop a fresh
 	// re-revocation mark stored for the same key in the scan->delete gap -- a
 	// security regression. These maps are also far smaller than the caches.
-	revocationCutoff := now.Add(-SessionDuration)
+	revocationCutoff := now.Add(-a.slideDuration())
 	sweepRevocationMarks(&a.state.sessionRevocations, revocationCutoff)
 	sweepRevocationMarks(&a.state.userRevocations, revocationCutoff)
 	sweepRevocationMarks(&a.state.userInvalidations, revocationCutoff)

--- a/backend/internal/hub/auth/interceptor_refresh_internal_test.go
+++ b/backend/internal/hub/auth/interceptor_refresh_internal_test.go
@@ -1,0 +1,142 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/leapmux/leapmux/internal/hub/store"
+)
+
+// slidingInterceptor builds an interceptor over a session store whose Touch
+// always reports one updated row, so every request slides and the refresh is
+// observable without waiting out the throttle.
+func slidingInterceptor(t *testing.T, sessionDuration time.Duration) *authInterceptor {
+	t.Helper()
+	sessions := &touchRecordingSessionStore{row: &store.SessionWithUser{
+		UserID: "user", Username: "user",
+		CreatedAt: time.Now().Add(-time.Hour), ExpiresAt: time.Now().Add(time.Minute),
+	}}
+	return &authInterceptor{
+		store:           sessionValidationOverrideStore{sessions: sessions},
+		state:           &authState{},
+		sessionDuration: sessionDuration,
+	}
+}
+
+func cookieRequest() connect.AnyRequest {
+	req := connect.NewRequest(&struct{}{})
+	req.Header().Set("Cookie", CookieName+"=session")
+	return req
+}
+
+// A streaming handler must carry the refreshed cookie too. Its response header
+// is written with the FIRST message, so the interceptor sets the cookie before
+// the handler runs -- a long-lived stream would otherwise return hours after
+// the header went out, and the refresh would never reach the browser.
+func TestWrapStreamingHandler_SlideRefreshesCookie(t *testing.T) {
+	a := slidingInterceptor(t, 36*time.Hour)
+	conn := &fakeStreamingConn{requestHeader: http.Header{"Cookie": []string{CookieName + "=session"}}}
+
+	var headerAtHandler http.Header
+	before := time.Now()
+	err := a.WrapStreamingHandler(func(context.Context, connect.StreamingHandlerConn) error {
+		// Snapshot inside the handler: a cookie written after next() returns is
+		// too late for a stream that already sent its header.
+		headerAtHandler = conn.ResponseHeader().Clone()
+		return nil
+	})(context.Background(), conn)
+	require.NoError(t, err)
+
+	parsed, parseErr := http.ParseSetCookie(headerAtHandler.Get("Set-Cookie"))
+	require.NoError(t, parseErr, "the stream's response header must carry the refreshed cookie")
+	assert.Equal(t, "session", parsed.Value)
+	assert.True(t, parsed.Expires.After(before.Add(36*time.Hour)),
+		"the refreshed cookie must outlive the configured duration from this request")
+}
+
+// A refused stream must not hand back a cookie: the interceptor never reaches
+// the refresh, so the browser keeps whatever deadline it had.
+func TestWrapStreamingHandler_UnauthenticatedWritesNoCookie(t *testing.T) {
+	a := slidingInterceptor(t, 36*time.Hour)
+	conn := &fakeStreamingConn{requestHeader: http.Header{}}
+
+	err := a.WrapStreamingHandler(func(context.Context, connect.StreamingHandlerConn) error {
+		return errors.New("the handler must not run")
+	})(context.Background(), conn)
+
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+	assert.Empty(t, conn.ResponseHeader().Values("Set-Cookie"))
+}
+
+// A handler that fails answers with a connect.Error and no response to hang a
+// header on. The slide already reached the store, so the refresh is dropped
+// rather than forced onto a nil response -- and the handler's error reaches the
+// caller unchanged.
+func TestWrapUnary_HandlerErrorDropsRefresh(t *testing.T) {
+	a := slidingInterceptor(t, 36*time.Hour)
+	handlerErr := connect.NewError(connect.CodeInternal, errors.New("boom"))
+
+	resp, err := a.WrapUnary(func(context.Context, connect.AnyRequest) (connect.AnyResponse, error) {
+		return nil, handlerErr
+	})(context.Background(), cookieRequest())
+
+	require.ErrorIs(t, err, handlerErr)
+	assert.Nil(t, resp)
+}
+
+// A handler that returns neither a response nor an error is a contract
+// violation somewhere below, but the interceptor must not turn it into a nil
+// dereference on the way out.
+func TestWrapUnary_NilResponseWithoutErrorDoesNotPanic(t *testing.T) {
+	a := slidingInterceptor(t, 36*time.Hour)
+
+	resp, err := a.WrapUnary(func(context.Context, connect.AnyRequest) (connect.AnyResponse, error) {
+		return nil, nil
+	})(context.Background(), cookieRequest())
+
+	require.NoError(t, err)
+	assert.Nil(t, resp)
+}
+
+// fakeStreamingConn is the smallest connect.StreamingHandlerConn that carries a
+// request header in and a response header out, which is all the auth
+// interceptor touches.
+type fakeStreamingConn struct {
+	requestHeader   http.Header
+	responseHeader  http.Header
+	responseTrailer http.Header
+}
+
+func (c *fakeStreamingConn) Spec() connect.Spec { return connect.Spec{Procedure: "/private"} }
+func (c *fakeStreamingConn) Peer() connect.Peer { return connect.Peer{} }
+func (c *fakeStreamingConn) Receive(any) error  { return nil }
+func (c *fakeStreamingConn) Send(any) error     { return nil }
+
+func (c *fakeStreamingConn) RequestHeader() http.Header {
+	if c.requestHeader == nil {
+		c.requestHeader = http.Header{}
+	}
+	return c.requestHeader
+}
+
+func (c *fakeStreamingConn) ResponseHeader() http.Header {
+	if c.responseHeader == nil {
+		c.responseHeader = http.Header{}
+	}
+	return c.responseHeader
+}
+
+func (c *fakeStreamingConn) ResponseTrailer() http.Header {
+	if c.responseTrailer == nil {
+		c.responseTrailer = http.Header{}
+	}
+	return c.responseTrailer
+}

--- a/backend/internal/hub/auth/interceptor_refresh_internal_test.go
+++ b/backend/internal/hub/auth/interceptor_refresh_internal_test.go
@@ -30,6 +30,35 @@ func slidingInterceptor(t *testing.T, sessionDuration time.Duration) *authInterc
 	}
 }
 
+// A store that cannot answer must not be asked again on the very next request.
+// touchSession records the throttle BEFORE it runs the UPDATE, so a store that
+// refuses every touch costs one attempt per throttle window; recording it after
+// the error return would have made every authenticated request retry, turning a
+// database hiccup into a write storm against the database that is already
+// unwell.
+func TestTouchSession_StoreErrorIsThrottledLikeAnySlide(t *testing.T) {
+	sessions := &touchRecordingSessionStore{
+		row: &store.SessionWithUser{
+			UserID: "user", Username: "user",
+			CreatedAt: time.Now().Add(-time.Hour), ExpiresAt: time.Now().Add(time.Minute),
+		},
+		touchErr: errors.New("database is down"),
+	}
+	a := &authInterceptor{
+		store:           sessionValidationOverrideStore{sessions: sessions},
+		state:           &authState{},
+		sessionDuration: 36 * time.Hour,
+	}
+
+	first := a.touchSession(context.Background(), "session", nil)
+	second := a.touchSession(context.Background(), "session", nil)
+
+	assert.True(t, first.IsZero(), "a failed touch slid nothing")
+	assert.True(t, second.IsZero())
+	assert.Equal(t, 1, sessions.touchCalls,
+		"the second request must wait out the throttle rather than retry the failing UPDATE")
+}
+
 func cookieRequest() connect.AnyRequest {
 	req := connect.NewRequest(&struct{}{})
 	req.Header().Set("Cookie", CookieName+"=session")
@@ -76,20 +105,74 @@ func TestWrapStreamingHandler_UnauthenticatedWritesNoCookie(t *testing.T) {
 	assert.Empty(t, conn.ResponseHeader().Values("Set-Cookie"))
 }
 
-// A handler that fails answers with a connect.Error and no response to hang a
-// header on. The slide already reached the store, so the refresh is dropped
-// rather than forced onto a nil response -- and the handler's error reaches the
-// caller unchanged.
-func TestWrapUnary_HandlerErrorDropsRefresh(t *testing.T) {
+// A handler that fails has no response to hang a header on, but a connect.Error
+// carries metadata that connect-go merges into the response header. The slide
+// already reached the store, so the cookie travels with the rejection -- a
+// client whose calls keep failing would otherwise slide the row on every request
+// and still be signed out at the login deadline, because the throttle gives the
+// cookie no other request to ride.
+func TestWrapUnary_HandlerErrorStillCarriesRefresh(t *testing.T) {
 	a := slidingInterceptor(t, 36*time.Hour)
 	handlerErr := connect.NewError(connect.CodeInternal, errors.New("boom"))
 
+	before := time.Now()
 	resp, err := a.WrapUnary(func(context.Context, connect.AnyRequest) (connect.AnyResponse, error) {
 		return nil, handlerErr
 	})(context.Background(), cookieRequest())
 
-	require.ErrorIs(t, err, handlerErr)
+	require.ErrorIs(t, err, handlerErr, "the handler's error must reach the caller unchanged")
 	assert.Nil(t, resp)
+
+	var connectErr *connect.Error
+	require.ErrorAs(t, err, &connectErr)
+	assert.Equal(t, connect.CodeInternal, connectErr.Code())
+	parsed, parseErr := http.ParseSetCookie(connectErr.Meta().Get("Set-Cookie"))
+	require.NoError(t, parseErr, "a failed call must still carry the refreshed cookie")
+	assert.Equal(t, "session", parsed.Value)
+	assert.True(t, parsed.Expires.After(before.Add(36*time.Hour)))
+}
+
+// The same for a rejection the interceptor itself issues after the slide
+// committed. An unverified user waiting to verify has every non-allowlisted
+// procedure denied, and the slide runs before that gate -- so without this the
+// row would keep moving while the browser's cookie stayed at the login
+// deadline, for as long as the user kept being refused.
+func TestWrapUnary_EmailVerificationDenialCarriesRefresh(t *testing.T) {
+	a := slidingInterceptor(t, 36*time.Hour)
+	a.emailVerificationRequired = true
+
+	resp, err := a.WrapUnary(func(context.Context, connect.AnyRequest) (connect.AnyResponse, error) {
+		return nil, errors.New("the handler must not run")
+	})(context.Background(), cookieRequest())
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+
+	var connectErr *connect.Error
+	require.ErrorAs(t, err, &connectErr)
+	parsed, parseErr := http.ParseSetCookie(connectErr.Meta().Get("Set-Cookie"))
+	require.NoError(t, parseErr, "the denial must carry the cookie for the slide it already made")
+	assert.Equal(t, "session", parsed.Value)
+}
+
+// A request the interceptor refuses BEFORE it authenticates anything must not
+// hand back a cookie. There is no slide to report, and a cookie on an
+// unauthenticated answer would be a session the caller never presented.
+func TestWrapUnary_UnauthenticatedWritesNoCookie(t *testing.T) {
+	a := slidingInterceptor(t, 36*time.Hour)
+
+	resp, err := a.WrapUnary(func(context.Context, connect.AnyRequest) (connect.AnyResponse, error) {
+		return nil, errors.New("the handler must not run")
+	})(context.Background(), connect.NewRequest(&struct{}{}))
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+
+	var connectErr *connect.Error
+	require.ErrorAs(t, err, &connectErr)
+	assert.Empty(t, connectErr.Meta().Get("Set-Cookie"))
 }
 
 // A handler that returns neither a response nor an error is a contract

--- a/backend/internal/hub/auth/interceptor_test.go
+++ b/backend/internal/hub/auth/interceptor_test.go
@@ -36,7 +36,7 @@ func setupInterceptorTestServer(t *testing.T) leapmuxv1connect.AuthServiceClient
 	hubtestutil.CreateTestAdmin(t, st)
 
 	mux := http.NewServeMux()
-	interceptor, _ := auth.NewInterceptor(auth.InterceptorOptions{Store: st})
+	interceptor, _ := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st})
 	interceptors := connect.WithInterceptors(interceptor)
 	authSvc := service.NewAuthService(st, &config.Config{}, auth.NewCredentialLifecycleEffects(nil, nil, nil), nil, mail.NewStubSender(), mail.Renderer{})
 	path, handler := leapmuxv1connect.NewAuthServiceHandler(authSvc, interceptors)
@@ -109,7 +109,7 @@ func TestInterceptor_SoloMode_AutoAuthenticated(t *testing.T) {
 	require.NoError(t, err)
 
 	mux := http.NewServeMux()
-	interceptor, _ := auth.NewInterceptor(auth.InterceptorOptions{Store: st, SoloUser: soloUser})
+	interceptor, _ := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st, SoloUser: soloUser})
 	interceptors := connect.WithInterceptors(interceptor)
 	authSvc := service.NewAuthService(st, &config.Config{SoloMode: true}, auth.NewCredentialLifecycleEffects(nil, nil, nil), nil, mail.NewStubSender(), mail.Renderer{})
 	path, handler := leapmuxv1connect.NewAuthServiceHandler(authSvc, interceptors)
@@ -168,7 +168,7 @@ func setupInterceptorTestServerWithBearerSupport(t *testing.T) (leapmuxv1connect
 	require.NoError(t, err)
 
 	mux := http.NewServeMux()
-	interceptor, _ := auth.NewInterceptor(auth.InterceptorOptions{Store: st, TokenValidator: tv})
+	interceptor, _ := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st, TokenValidator: tv})
 	interceptors := connect.WithInterceptors(interceptor)
 	authSvc := service.NewAuthService(st, &config.Config{}, auth.NewCredentialLifecycleEffects(nil, nil, nil), nil, mail.NewStubSender(), mail.Renderer{})
 	path, handler := leapmuxv1connect.NewAuthServiceHandler(authSvc, interceptors)
@@ -301,7 +301,7 @@ func TestInterceptor_LeapMuxBearer_CacheEvictedOnRevoke(t *testing.T) {
 	require.NoError(t, err)
 
 	mux := http.NewServeMux()
-	interceptor, sc := auth.NewInterceptor(auth.InterceptorOptions{Store: st, TokenValidator: tv})
+	interceptor, sc := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st, TokenValidator: tv})
 	t.Cleanup(sc.Stop)
 	interceptors := connect.WithInterceptors(interceptor)
 	authSvc := service.NewAuthService(st, &config.Config{}, auth.NewCredentialLifecycleEffects(sc, nil, nil), nil, mail.NewStubSender(), mail.Renderer{})
@@ -578,9 +578,9 @@ func setupSessionDurationTestServer(t *testing.T, sessionDuration time.Duration)
 
 	hubtestutil.CreateTestAdmin(t, st)
 
-	cfg := &config.Config{SessionDurationSeconds: int(sessionDuration / time.Second)}
+	cfg := &config.Config{SessionDuration: sessionDuration}
 	mux := http.NewServeMux()
-	interceptor, sc := auth.NewInterceptor(auth.InterceptorOptions{Store: st, SessionDuration: cfg.SessionDuration()})
+	interceptor, sc := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st, SessionDuration: cfg.SessionDuration})
 	t.Cleanup(sc.Stop)
 	interceptors := connect.WithInterceptors(interceptor)
 	authSvc := service.NewAuthService(st, cfg, auth.NewCredentialLifecycleEffects(sc, nil, nil), nil, mail.NewStubSender(), mail.Renderer{})
@@ -634,7 +634,7 @@ func backdateLastActive(t *testing.T, st store.Store, sessionID string) {
 }
 
 // A slide must re-issue the cookie. The cookie carries its own Expires, so a
-// browser drops it at the deadline the login named however far the row slid --
+// browser drops it at the deadline the login set however far the row slid --
 // which would sign an active user out one session duration after the login.
 //
 // The configured duration, not the default, is what both ends must carry.
@@ -681,7 +681,7 @@ func TestLogin_UsesConfiguredSessionDuration(t *testing.T) {
 
 	sess, err := st.Sessions().GetByID(context.Background(), token)
 	require.NoError(t, err)
-	assert.WithinDuration(t, before.Add(configured), sess.ExpiresAt, time.Minute)
+	hubtestutil.AssertSessionLifetime(t, before, configured, sess.ExpiresAt)
 }
 
 // An unconfigured Hub issues the default, so an operator who sets nothing gets
@@ -694,7 +694,7 @@ func TestLogin_UnconfiguredUsesDefaultSessionDuration(t *testing.T) {
 
 	sess, err := st.Sessions().GetByID(context.Background(), token)
 	require.NoError(t, err)
-	assert.WithinDuration(t, before.Add(auth.DefaultSessionDuration), sess.ExpiresAt, time.Minute)
+	hubtestutil.AssertSessionLifetime(t, before, auth.DefaultSessionDuration, sess.ExpiresAt)
 }
 
 // The throttle governs the cookie too: a request that writes no row must not

--- a/backend/internal/hub/auth/interceptor_test.go
+++ b/backend/internal/hub/auth/interceptor_test.go
@@ -36,7 +36,7 @@ func setupInterceptorTestServer(t *testing.T) leapmuxv1connect.AuthServiceClient
 	hubtestutil.CreateTestAdmin(t, st)
 
 	mux := http.NewServeMux()
-	interceptor, _ := auth.NewInterceptor(st, nil, false, false)
+	interceptor, _ := auth.NewInterceptor(auth.InterceptorOptions{Store: st})
 	interceptors := connect.WithInterceptors(interceptor)
 	authSvc := service.NewAuthService(st, &config.Config{}, auth.NewCredentialLifecycleEffects(nil, nil, nil), nil, mail.NewStubSender(), mail.Renderer{})
 	path, handler := leapmuxv1connect.NewAuthServiceHandler(authSvc, interceptors)
@@ -109,7 +109,7 @@ func TestInterceptor_SoloMode_AutoAuthenticated(t *testing.T) {
 	require.NoError(t, err)
 
 	mux := http.NewServeMux()
-	interceptor, _ := auth.NewInterceptor(st, soloUser, false, false)
+	interceptor, _ := auth.NewInterceptor(auth.InterceptorOptions{Store: st, SoloUser: soloUser})
 	interceptors := connect.WithInterceptors(interceptor)
 	authSvc := service.NewAuthService(st, &config.Config{SoloMode: true}, auth.NewCredentialLifecycleEffects(nil, nil, nil), nil, mail.NewStubSender(), mail.Renderer{})
 	path, handler := leapmuxv1connect.NewAuthServiceHandler(authSvc, interceptors)
@@ -168,7 +168,7 @@ func setupInterceptorTestServerWithBearerSupport(t *testing.T) (leapmuxv1connect
 	require.NoError(t, err)
 
 	mux := http.NewServeMux()
-	interceptor, _ := auth.NewInterceptorWithTokens(st, nil, tv, false, false)
+	interceptor, _ := auth.NewInterceptor(auth.InterceptorOptions{Store: st, TokenValidator: tv})
 	interceptors := connect.WithInterceptors(interceptor)
 	authSvc := service.NewAuthService(st, &config.Config{}, auth.NewCredentialLifecycleEffects(nil, nil, nil), nil, mail.NewStubSender(), mail.Renderer{})
 	path, handler := leapmuxv1connect.NewAuthServiceHandler(authSvc, interceptors)
@@ -301,7 +301,7 @@ func TestInterceptor_LeapMuxBearer_CacheEvictedOnRevoke(t *testing.T) {
 	require.NoError(t, err)
 
 	mux := http.NewServeMux()
-	interceptor, sc := auth.NewInterceptorWithTokens(st, nil, tv, false, false)
+	interceptor, sc := auth.NewInterceptor(auth.InterceptorOptions{Store: st, TokenValidator: tv})
 	t.Cleanup(sc.Stop)
 	interceptors := connect.WithInterceptors(interceptor)
 	authSvc := service.NewAuthService(st, &config.Config{}, auth.NewCredentialLifecycleEffects(sc, nil, nil), nil, mail.NewStubSender(), mail.Renderer{})
@@ -563,16 +563,27 @@ func newTestTokenID() string {
 // returns the store for DB inspection.
 func setupInterceptorTestServerWithCache(t *testing.T) (leapmuxv1connect.AuthServiceClient, store.Store) {
 	t.Helper()
+	return setupSessionDurationTestServer(t, 0)
+}
+
+// setupSessionDurationTestServer builds that server with a configured session
+// duration; zero leaves the default. One config.Config feeds both the service
+// that stamps the first expiry at login and the interceptor that slides it, so
+// a test that pins a non-default duration exercises the whole wiring rather
+// than one half of it.
+func setupSessionDurationTestServer(t *testing.T, sessionDuration time.Duration) (leapmuxv1connect.AuthServiceClient, store.Store) {
+	t.Helper()
 
 	st := hubtestutil.OpenTestStore(t)
 
 	hubtestutil.CreateTestAdmin(t, st)
 
+	cfg := &config.Config{SessionDurationSeconds: int(sessionDuration / time.Second)}
 	mux := http.NewServeMux()
-	interceptor, sc := auth.NewInterceptor(st, nil, false, false)
+	interceptor, sc := auth.NewInterceptor(auth.InterceptorOptions{Store: st, SessionDuration: cfg.SessionDuration()})
 	t.Cleanup(sc.Stop)
 	interceptors := connect.WithInterceptors(interceptor)
-	authSvc := service.NewAuthService(st, &config.Config{}, auth.NewCredentialLifecycleEffects(sc, nil, nil), nil, mail.NewStubSender(), mail.Renderer{})
+	authSvc := service.NewAuthService(st, cfg, auth.NewCredentialLifecycleEffects(sc, nil, nil), nil, mail.NewStubSender(), mail.Renderer{})
 	path, handler := leapmuxv1connect.NewAuthServiceHandler(authSvc, interceptors)
 	mux.Handle(path, handler)
 
@@ -608,6 +619,146 @@ func TestTouchSession_ThrottledWithinThreshold(t *testing.T) {
 	t2 := sess2.LastActiveAt
 
 	assert.Equal(t, t1, t2, "last_active_at should not change on rapid successive requests (throttled)")
+}
+
+// backdateLastActive puts a session's last_active_at an hour in the past, past
+// any touch throttle, so the next authenticated request slides the expiry. The
+// throttle is what makes a slide unobservable in a test that only logs in: the
+// row is created with last_active_at = now, so the conditional UPDATE matches
+// no row until the threshold passes.
+func backdateLastActive(t *testing.T, st store.Store, sessionID string) {
+	t.Helper()
+	testable, ok := st.(store.TestableStore)
+	require.True(t, ok, "the test store must expose the test helper")
+	require.NoError(t, testable.TestHelper().SetLastActiveAt(context.Background(), sessionID, time.Now().Add(-time.Hour)))
+}
+
+// A slide must re-issue the cookie. The cookie carries its own Expires, so a
+// browser drops it at the deadline the login named however far the row slid --
+// which would sign an active user out one session duration after the login.
+//
+// The configured duration, not the default, is what both ends must carry.
+func TestTouchSession_SlideRefreshesCookie(t *testing.T) {
+	const configured = 36 * time.Hour
+	client, st := setupSessionDurationTestServer(t, configured)
+
+	token := loginAdmin(t, client)
+	backdateLastActive(t, st, token)
+
+	req := connect.NewRequest(&leapmuxv1.GetCurrentUserRequest{})
+	req.Header().Set("Cookie", auth.CookieName+"="+token)
+	before := time.Now()
+	resp, err := client.GetCurrentUser(context.Background(), req)
+	require.NoError(t, err)
+
+	setCookie := resp.Header().Get("Set-Cookie")
+	require.NotEmpty(t, setCookie, "a slid session must re-issue its cookie")
+	parsed, err := http.ParseSetCookie(setCookie)
+	require.NoError(t, err)
+	assert.Equal(t, auth.CookieName, parsed.Name)
+	assert.Equal(t, token, parsed.Value, "the refresh must re-issue the same session, not mint one")
+	assert.True(t, parsed.HttpOnly)
+	assert.True(t, parsed.Expires.After(before.Add(configured)),
+		"the browser's copy must outlive the configured duration measured from this request")
+	assert.WithinDuration(t, before.Add(configured), parsed.Expires, 15*time.Minute,
+		"the slide must follow the configured duration, not the default")
+
+	sess, err := st.Sessions().GetByID(context.Background(), token)
+	require.NoError(t, err)
+	assert.WithinDuration(t, sess.ExpiresAt, parsed.Expires, time.Second,
+		"the cookie and the row must expire together, or one outlives the other silently")
+}
+
+// Login stamps the first expiry from the same configured duration. Without
+// this, a configured value would take effect only at the first slide -- five
+// minutes into the session, and never for a user who signs in and leaves.
+func TestLogin_UsesConfiguredSessionDuration(t *testing.T) {
+	const configured = 36 * time.Hour
+	client, st := setupSessionDurationTestServer(t, configured)
+
+	before := time.Now()
+	token := loginAdmin(t, client)
+
+	sess, err := st.Sessions().GetByID(context.Background(), token)
+	require.NoError(t, err)
+	assert.WithinDuration(t, before.Add(configured), sess.ExpiresAt, time.Minute)
+}
+
+// An unconfigured Hub issues the default, so an operator who sets nothing gets
+// the documented lifetime rather than whatever the zero value would mean.
+func TestLogin_UnconfiguredUsesDefaultSessionDuration(t *testing.T) {
+	client, st := setupInterceptorTestServerWithCache(t)
+
+	before := time.Now()
+	token := loginAdmin(t, client)
+
+	sess, err := st.Sessions().GetByID(context.Background(), token)
+	require.NoError(t, err)
+	assert.WithinDuration(t, before.Add(auth.DefaultSessionDuration), sess.ExpiresAt, time.Minute)
+}
+
+// The throttle governs the cookie too: a request that writes no row must not
+// hand the browser an expiry the row does not carry.
+func TestTouchSession_ThrottledRequestSendsNoCookie(t *testing.T) {
+	client, _ := setupInterceptorTestServerWithCache(t)
+
+	token := loginAdmin(t, client)
+
+	// No backdating: login stamped last_active_at, so this request is inside the
+	// throttle window and the conditional UPDATE matches no row.
+	req := connect.NewRequest(&leapmuxv1.GetCurrentUserRequest{})
+	req.Header().Set("Cookie", auth.CookieName+"="+token)
+	resp, err := client.GetCurrentUser(context.Background(), req)
+	require.NoError(t, err)
+
+	assert.Empty(t, resp.Header().Values("Set-Cookie"))
+}
+
+// Logout writes the clearing cookie itself. A refresh must not follow it: a
+// browser keeps the last Set-Cookie for a name, so the user would stay signed
+// in on a session the Hub deleted.
+func TestLogout_SlideDoesNotResurrectCookie(t *testing.T) {
+	client, st := setupInterceptorTestServerWithCache(t)
+
+	token := loginAdmin(t, client)
+	backdateLastActive(t, st, token)
+
+	logoutReq := connect.NewRequest(&leapmuxv1.LogoutRequest{})
+	logoutReq.Header().Set("Cookie", auth.CookieName+"="+token)
+	resp, err := client.Logout(context.Background(), logoutReq)
+	require.NoError(t, err)
+
+	values := resp.Header().Values("Set-Cookie")
+	require.Len(t, values, 1, "logout must answer with exactly one session cookie")
+	parsed, err := http.ParseSetCookie(values[0])
+	require.NoError(t, err)
+	assert.Empty(t, parsed.Value)
+	assert.Negative(t, parsed.MaxAge, "the clearing cookie must survive the slide's refresh")
+}
+
+// A bearer holds no session cookie, so a bearer-authenticated call must never
+// answer with one -- that would hand a CLI or an agent a browser credential.
+func TestBearerRequest_SendsNoSessionCookie(t *testing.T) {
+	client, st, tv := setupInterceptorTestServerWithBearerSupport(t)
+	userID := adminUserID(t, st)
+
+	tokenID := newTestTokenID()
+	secret := auth.MintAccessSecret()
+	require.NoError(t, st.APITokens().Create(context.Background(), store.CreateAPITokenParams{
+		ID:         tokenID,
+		UserID:     userid.MustNew(userID),
+		ClientType: "cli",
+		ClientName: "test",
+		SecretHash: tv.HashSecret(secret),
+		Scope:      "remote:*",
+	}))
+
+	req := connect.NewRequest(&leapmuxv1.GetCurrentUserRequest{})
+	req.Header().Set("Authorization", "Bearer "+auth.FormatBearer(auth.BearerKindAPI, tokenID, secret))
+	resp, err := client.GetCurrentUser(context.Background(), req)
+	require.NoError(t, err)
+
+	assert.Empty(t, resp.Header().Values("Set-Cookie"))
 }
 
 func TestLogout_EvictsSessionFromCache(t *testing.T) {

--- a/backend/internal/hub/config/config.go
+++ b/backend/internal/hub/config/config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/knadh/koanf/v2"
 	"github.com/leapmux/leapmux/channelwire"
 	internalconfig "github.com/leapmux/leapmux/internal/config"
+	"github.com/leapmux/leapmux/internal/hub/auth"
 	"github.com/leapmux/leapmux/internal/hub/crdt"
 	"github.com/leapmux/leapmux/internal/metrics"
 	"github.com/leapmux/leapmux/internal/sendq"
@@ -155,6 +156,18 @@ const (
 	DefaultAPITimeoutSeconds            = 10
 	DefaultAgentStartupTimeoutSeconds   = 300
 	DefaultWorktreeCreateTimeoutSeconds = 60
+
+	// DefaultSessionDurationSeconds is the default for session_duration_seconds.
+	// Derived from auth.DefaultSessionDuration rather than written again here,
+	// so the flag default and the value the auth package falls back to are one
+	// number.
+	DefaultSessionDurationSeconds = int(auth.DefaultSessionDuration / time.Second)
+	// MinSessionDurationSeconds is the shortest session an operator may
+	// configure. Derived from auth.MinSessionDuration, which states the reason:
+	// the Hub serves a validated session from an in-memory cache for a short
+	// window, so a shorter session outlives its own expiry by a large share of
+	// its life.
+	MinSessionDurationSeconds = int(auth.MinSessionDuration / time.Second)
 )
 
 // Config holds the hub's runtime configuration.
@@ -167,6 +180,7 @@ type Config struct {
 	LogLevel                     string `koanf:"log_level"`
 	SignupEnabled                bool   `koanf:"signup_enabled"`
 	EmailVerificationRequired    bool   `koanf:"email_verification_required"`
+	SessionDurationSeconds       int    `koanf:"session_duration_seconds"`
 	SmtpHost                     string `koanf:"smtp_host"`
 	SmtpPort                     int    `koanf:"smtp_port"`
 	SmtpUsername                 string `koanf:"smtp_username"`
@@ -277,6 +291,18 @@ type MySQLConfig struct {
 	MaxIdleConns           int    `koanf:"max_idle_conns"`             // Maximum idle connections. Default: 5.
 	ConnMaxLifetimeSeconds int    `koanf:"conn_max_lifetime_seconds"`  // Maximum connection lifetime. Default: 3600.
 	ConnMaxIdleTimeSeconds int    `koanf:"conn_max_idle_time_seconds"` // Maximum idle time per connection. Default: 300.
+}
+
+// SessionDuration returns how long a user session stays valid after the user's
+// last request. Each authenticated request slides the expiry forward, so this
+// is an idle timeout and not a cap on how long a signed-in user may stay signed
+// in.
+func (c *Config) SessionDuration() time.Duration {
+	v := c.SessionDurationSeconds
+	if v <= 0 {
+		v = DefaultSessionDurationSeconds
+	}
+	return time.Duration(v) * time.Second
 }
 
 // APITimeout returns the general API timeout as a duration.
@@ -754,6 +780,7 @@ func LoadWithOptions(args []string, opts LoadOptions) (*Config, bool, error) {
 		strFlag("log-level", "log_level", "Server options", "log level (debug, info, warn, error)", defaultLogLevel),
 		boolFlag("signup-enabled", "signup_enabled", "Auth options", "enable user sign-up", false),
 		boolFlag("email-verification-required", "email_verification_required", "Auth options", "require email verification on sign-up", false),
+		intFlag("session-duration-seconds", "session_duration_seconds", "Auth options", "how long a session stays valid after the user's last request, in seconds; each request slides the expiry forward", DefaultSessionDurationSeconds),
 		strFlag("smtp-host", "smtp_host", "SMTP options", "SMTP server host", ""),
 		intFlag("smtp-port", "smtp_port", "SMTP options", "SMTP server port", 587),
 		strFlag("smtp-username", "smtp_username", "SMTP options", "SMTP username", ""),
@@ -1016,7 +1043,38 @@ func (c *Config) Validate() error {
 	if err := c.validateMaxConnectionsPerUser(); err != nil {
 		return err
 	}
+	if err := c.validateSessionDuration(); err != nil {
+		return err
+	}
 
+	return nil
+}
+
+// validateSessionDuration rejects a session lifetime nobody meant.
+//
+// Zero means "use the default". Flag parsing writes the default number itself,
+// so a zero reaches this only from a config built in code, and SessionDuration
+// reads it as the default there too. A negative is not a shorter session, so it
+// fails loudly rather than being silently read as the default. A value under
+// MinSessionDurationSeconds signs users out later than it promises; see
+// auth.MinSessionDuration. There is no upper bound: a long session is a policy
+// an operator may hold, and the slide makes it an idle timeout rather than an
+// unbounded credential.
+func (c *Config) validateSessionDuration() error {
+	switch {
+	case c.SessionDurationSeconds < 0:
+		return fmt.Errorf("session_duration_seconds must not be negative, got %d (0 = default)",
+			c.SessionDurationSeconds)
+	case c.SessionDurationSeconds == 0:
+		return nil
+	case c.SessionDurationSeconds < MinSessionDurationSeconds:
+		return fmt.Errorf(
+			"session_duration_seconds must be 0 (default) or at least %d, got %d: "+
+				"the Hub serves a validated session from an in-memory cache for a "+
+				"short window, so a shorter session stays usable for a large share "+
+				"of its own life",
+			MinSessionDurationSeconds, c.SessionDurationSeconds)
+	}
 	return nil
 }
 

--- a/backend/internal/hub/config/config.go
+++ b/backend/internal/hub/config/config.go
@@ -153,44 +153,48 @@ const (
 	// genuinely want more set the key.
 	MaxQueueMemoryBudget = 8 << 30 // 8 GiB
 
-	DefaultAPITimeoutSeconds            = 10
-	DefaultAgentStartupTimeoutSeconds   = 300
-	DefaultWorktreeCreateTimeoutSeconds = 60
-
-	// DefaultSessionDurationSeconds is the default for session_duration_seconds.
-	// Derived from auth.DefaultSessionDuration rather than written again here,
-	// so the flag default and the value the auth package falls back to are one
-	// number.
-	DefaultSessionDurationSeconds = int(auth.DefaultSessionDuration / time.Second)
-	// MinSessionDurationSeconds is the shortest session an operator may
-	// configure. Derived from auth.MinSessionDuration, which states the reason:
-	// the Hub serves a validated session from an in-memory cache for a short
-	// window, so a shorter session outlives its own expiry by a large share of
-	// its life.
-	MinSessionDurationSeconds = int(auth.MinSessionDuration / time.Second)
+	// The timeout defaults. Each is the value that its flag registers and the
+	// value that applyDurationDefaults restores when a source leaves the key at
+	// zero, so each default is one number and not one per reader.
+	//
+	// The session duration is not here: auth.DefaultSessionDuration is the one
+	// default, because the auth package also has to answer for a session that a
+	// caller mints with no configured lifetime.
+	DefaultAPITimeout            = 10 * time.Second
+	DefaultAgentStartupTimeout   = 5 * time.Minute
+	DefaultWorktreeCreateTimeout = time.Minute
 )
 
 // Config holds the hub's runtime configuration.
 type Config struct {
-	Listen                       string `koanf:"listen"`
-	LocalListen                  string `koanf:"local_listen"`
-	PublicURL                    string `koanf:"public_url"`
-	DataDir                      string `koanf:"data_dir"`
-	DevFrontend                  string `koanf:"dev_frontend"`
-	LogLevel                     string `koanf:"log_level"`
-	SignupEnabled                bool   `koanf:"signup_enabled"`
-	EmailVerificationRequired    bool   `koanf:"email_verification_required"`
-	SessionDurationSeconds       int    `koanf:"session_duration_seconds"`
-	SmtpHost                     string `koanf:"smtp_host"`
-	SmtpPort                     int    `koanf:"smtp_port"`
-	SmtpUsername                 string `koanf:"smtp_username"`
-	SmtpPassword                 string `koanf:"smtp_password"`
-	SmtpFromAddress              string `koanf:"smtp_from_address"`
-	SmtpTLSMode                  string `koanf:"smtp_tls_mode"` // See SmtpTLSMode* constants for valid values.
-	APITimeoutSeconds            int    `koanf:"api_timeout_seconds"`
-	AgentStartupTimeoutSeconds   int    `koanf:"agent_startup_timeout_seconds"`
-	WorktreeCreateTimeoutSeconds int    `koanf:"worktree_create_timeout_seconds"`
-	MaxMessageSize               int    `koanf:"max_message_size"`
+	Listen                    string `koanf:"listen"`
+	LocalListen               string `koanf:"local_listen"`
+	PublicURL                 string `koanf:"public_url"`
+	DataDir                   string `koanf:"data_dir"`
+	DevFrontend               string `koanf:"dev_frontend"`
+	LogLevel                  string `koanf:"log_level"`
+	SignupEnabled             bool   `koanf:"signup_enabled"`
+	EmailVerificationRequired bool   `koanf:"email_verification_required"`
+	SmtpHost                  string `koanf:"smtp_host"`
+	SmtpPort                  int    `koanf:"smtp_port"`
+	SmtpUsername              string `koanf:"smtp_username"`
+	SmtpPassword              string `koanf:"smtp_password"`
+	SmtpFromAddress           string `koanf:"smtp_from_address"`
+	SmtpTLSMode               string `koanf:"smtp_tls_mode"` // See SmtpTLSMode* constants for valid values.
+	// The durations below, and every other duration key, accept a unit suffix
+	// and read a bare number as seconds -- see internalconfig.ParseDuration.
+	// LoadWithOptions resolves a zero to the matching Default* constant, so a
+	// loaded Config always carries a usable value and no reader repeats the
+	// fallback.
+	//
+	// SessionDuration is how long a session stays valid after the user's last
+	// request. Each authenticated request slides the expiry forward, so it is an
+	// idle timeout and not a cap on how long a signed-in user may stay signed in.
+	SessionDuration       time.Duration `koanf:"session_duration"`
+	APITimeout            time.Duration `koanf:"api_timeout"`
+	AgentStartupTimeout   time.Duration `koanf:"agent_startup_timeout"`
+	WorktreeCreateTimeout time.Duration `koanf:"worktree_create_timeout"`
+	MaxMessageSize        int           `koanf:"max_message_size"`
 	// The queue budgets are int64, not int, for the reason sendq.PoolConfig
 	// states about its own Capacity: MaxQueueMemoryBudget is 8 GiB, which does
 	// not fit an int on a 32-bit build. Typed narrower here, an operator's
@@ -275,61 +279,52 @@ type SQLiteConfig struct {
 // PostgresConfig holds PostgreSQL-specific storage configuration.
 // Also used by CockroachDB and YugabyteDB (wire-compatible).
 type PostgresConfig struct {
-	DSN                      string `koanf:"dsn"`                         // Connection string (required).
-	MaxConns                 int    `koanf:"max_conns"`                   // Maximum open connections. Default: 25.
-	MinConns                 int    `koanf:"min_conns"`                   // Minimum pool connections kept alive. Default: 5.
-	ConnMaxLifetimeSeconds   int    `koanf:"conn_max_lifetime_seconds"`   // Maximum connection lifetime. Default: 3600.
-	MaxConnIdleTimeSeconds   int    `koanf:"max_conn_idle_time_seconds"`  // Maximum idle time per connection. Default: 300.
-	HealthCheckPeriodSeconds int    `koanf:"health_check_period_seconds"` // Pool health check period. Default: 30.
+	DSN      string `koanf:"dsn"`       // Connection string (required).
+	MaxConns int    `koanf:"max_conns"` // Maximum open connections. Default: 25.
+	MinConns int    `koanf:"min_conns"` // Minimum pool connections kept alive. Default: 5.
+	// The pool durations keep their own meaning for zero -- leave the driver
+	// default alone -- so applyDurationDefaults does not touch them.
+	ConnMaxLifetime   time.Duration `koanf:"conn_max_lifetime"`   // Maximum connection lifetime. Default: 1h.
+	MaxConnIdleTime   time.Duration `koanf:"max_conn_idle_time"`  // Maximum idle time per connection. Default: 5m.
+	HealthCheckPeriod time.Duration `koanf:"health_check_period"` // Pool health check period. Default: 30s.
 }
 
 // MySQLConfig holds MySQL-specific storage configuration.
 // Also used by TiDB (wire-compatible).
 type MySQLConfig struct {
-	DSN                    string `koanf:"dsn"`                        // Connection string (required).
-	MaxConns               int    `koanf:"max_conns"`                  // Maximum open connections. Default: 25.
-	MaxIdleConns           int    `koanf:"max_idle_conns"`             // Maximum idle connections. Default: 5.
-	ConnMaxLifetimeSeconds int    `koanf:"conn_max_lifetime_seconds"`  // Maximum connection lifetime. Default: 3600.
-	ConnMaxIdleTimeSeconds int    `koanf:"conn_max_idle_time_seconds"` // Maximum idle time per connection. Default: 300.
+	DSN          string `koanf:"dsn"`            // Connection string (required).
+	MaxConns     int    `koanf:"max_conns"`      // Maximum open connections. Default: 25.
+	MaxIdleConns int    `koanf:"max_idle_conns"` // Maximum idle connections. Default: 5.
+	// Zero leaves the driver default alone -- see PostgresConfig.
+	ConnMaxLifetime time.Duration `koanf:"conn_max_lifetime"`  // Maximum connection lifetime. Default: 1h.
+	ConnMaxIdleTime time.Duration `koanf:"conn_max_idle_time"` // Maximum idle time per connection. Default: 5m.
 }
 
-// SessionDuration returns how long a user session stays valid after the user's
-// last request. Each authenticated request slides the expiry forward, so this
-// is an idle timeout and not a cap on how long a signed-in user may stay signed
-// in.
-func (c *Config) SessionDuration() time.Duration {
-	v := c.SessionDurationSeconds
-	if v <= 0 {
-		v = DefaultSessionDurationSeconds
+// applyDurationDefaults restores the default for each timeout that a source
+// left at zero, so every reader of a loaded Config finds a usable value and
+// none of them repeats the fallback.
+//
+// A source reaches zero two ways: it omits the key, and the defaults map has
+// already answered; or it writes an explicit 0, which the operator docs define
+// as "the default". A negative value never arrives here, because Validate
+// rejects it first.
+//
+// The storage pool durations are deliberately absent. Zero has its own meaning
+// there -- leave the driver default alone -- and the pool code tests for it.
+func (c *Config) applyDurationDefaults() {
+	for _, d := range []struct {
+		target   *time.Duration
+		fallback time.Duration
+	}{
+		{&c.SessionDuration, auth.DefaultSessionDuration},
+		{&c.APITimeout, DefaultAPITimeout},
+		{&c.AgentStartupTimeout, DefaultAgentStartupTimeout},
+		{&c.WorktreeCreateTimeout, DefaultWorktreeCreateTimeout},
+	} {
+		if *d.target == 0 {
+			*d.target = d.fallback
+		}
 	}
-	return time.Duration(v) * time.Second
-}
-
-// APITimeout returns the general API timeout as a duration.
-func (c *Config) APITimeout() time.Duration {
-	v := c.APITimeoutSeconds
-	if v <= 0 {
-		v = DefaultAPITimeoutSeconds
-	}
-	return time.Duration(v) * time.Second
-}
-
-// AgentStartupTimeout returns the agent startup/resume timeout as a duration.
-func (c *Config) AgentStartupTimeout() time.Duration {
-	v := c.AgentStartupTimeoutSeconds
-	if v <= 0 {
-		v = DefaultAgentStartupTimeoutSeconds
-	}
-	return time.Duration(v) * time.Second
-}
-
-// WorktreeCreateTimeout returns the worktree creation timeout as a duration.
-func (c *Config) WorktreeCreateTimeout() time.Duration {
-	v := c.WorktreeCreateTimeoutSeconds
-	if v <= 0 {
-		v = DefaultWorktreeCreateTimeoutSeconds
-	}
-	return time.Duration(v) * time.Second
 }
 
 // The Resolve*QueueMemoryBudget accessors return the bytes each outbound queue
@@ -652,6 +647,20 @@ func boolFlag(name, koanfKey, category, usage string, def bool) flagDef {
 	return flagDef{name: name, koanfKey: koanfKey, category: category, usage: usage, value: def}
 }
 
+// durationFlag registers a duration, not an int of seconds. The flag then takes
+// the same spellings that the config file and the environment variable take,
+// and the seconds count that the key carried before keeps working as the
+// bare-number form. usage gains the syntax, so -help states it at each flag.
+func durationFlag(name, koanfKey, category, usage string, def time.Duration) flagDef {
+	return flagDef{
+		name:     name,
+		koanfKey: koanfKey,
+		category: category,
+		usage:    usage + ". " + internalconfig.UnitSyntax,
+		value:    def,
+	}
+}
+
 // register defines this flag on fs. The default arm panics rather than skipping:
 // a kind nothing handles used to mean the flag silently vanished from -help and
 // from the defaults map, with no compile or test signal, which is exactly how
@@ -666,6 +675,10 @@ func (fd flagDef) register(fs *flag.FlagSet) {
 		fs.Int64(fd.name, v, fd.usage)
 	case bool:
 		fs.Bool(fd.name, v, fd.usage)
+	case time.Duration:
+		// The FlagProvider reads a set flag back through Value.String(), so the
+		// destination only has to outlive this call, not be reachable from here.
+		fs.Var(internalconfig.NewDurationFlag(new(time.Duration), v), fd.name, fd.usage)
 	default:
 		panic(fmt.Sprintf("config: flag %q has an unsupported default type %T", fd.name, fd.value))
 	}
@@ -759,16 +772,16 @@ func LoadWithOptions(args []string, opts LoadOptions) (*Config, bool, error) {
 		strFlag("dsn", "dsn", "", "{name} connection string", ""),
 		intFlag("max-conns", "max_conns", "", "{name} maximum open connections", 25),
 		intFlag("min-conns", "min_conns", "", "{name} minimum pool connections kept alive", 5),
-		intFlag("conn-max-lifetime-seconds", "conn_max_lifetime_seconds", "", "{name} connection max lifetime in seconds", 3600),
-		intFlag("max-conn-idle-time-seconds", "max_conn_idle_time_seconds", "", "{name} max idle time per connection in seconds", 300),
-		intFlag("health-check-period-seconds", "health_check_period_seconds", "", "{name} pool health check period in seconds", 30),
+		durationFlag("conn-max-lifetime", "conn_max_lifetime", "", "{name} connection max lifetime", time.Hour),
+		durationFlag("max-conn-idle-time", "max_conn_idle_time", "", "{name} max idle time per connection", 5*time.Minute),
+		durationFlag("health-check-period", "health_check_period", "", "{name} pool health check period", 30*time.Second),
 	}
 	mysqlBaseFlags := []flagDef{
 		strFlag("dsn", "dsn", "", "{name} connection string", ""),
 		intFlag("max-conns", "max_conns", "", "{name} maximum open connections", 25),
 		intFlag("max-idle-conns", "max_idle_conns", "", "{name} maximum idle connections", 5),
-		intFlag("conn-max-lifetime-seconds", "conn_max_lifetime_seconds", "", "{name} connection max lifetime in seconds", 3600),
-		intFlag("conn-max-idle-time-seconds", "conn_max_idle_time_seconds", "", "{name} max idle time per connection in seconds", 300),
+		durationFlag("conn-max-lifetime", "conn_max_lifetime", "", "{name} connection max lifetime", time.Hour),
+		durationFlag("conn-max-idle-time", "conn_max_idle_time", "", "{name} max idle time per connection", 5*time.Minute),
 	}
 
 	allFlags := []flagDef{
@@ -780,16 +793,16 @@ func LoadWithOptions(args []string, opts LoadOptions) (*Config, bool, error) {
 		strFlag("log-level", "log_level", "Server options", "log level (debug, info, warn, error)", defaultLogLevel),
 		boolFlag("signup-enabled", "signup_enabled", "Auth options", "enable user sign-up", false),
 		boolFlag("email-verification-required", "email_verification_required", "Auth options", "require email verification on sign-up", false),
-		intFlag("session-duration-seconds", "session_duration_seconds", "Auth options", "how long a session stays valid after the user's last request, in seconds; each request slides the expiry forward", DefaultSessionDurationSeconds),
+		durationFlag("session-duration", "session_duration", "Auth options", "how long a session stays valid after the user's last request; each request slides the expiry forward", auth.DefaultSessionDuration),
 		strFlag("smtp-host", "smtp_host", "SMTP options", "SMTP server host", ""),
 		intFlag("smtp-port", "smtp_port", "SMTP options", "SMTP server port", 587),
 		strFlag("smtp-username", "smtp_username", "SMTP options", "SMTP username", ""),
 		strFlag("smtp-password", "smtp_password", "SMTP options", "SMTP password", ""),
 		strFlag("smtp-from-address", "smtp_from_address", "SMTP options", "SMTP from address", ""),
 		strFlag("smtp-tls-mode", "smtp_tls_mode", "SMTP options", "SMTP TLS mode ("+validSmtpTLSModes+")", SmtpTLSModeSTARTTLS),
-		intFlag("api-timeout-seconds", "api_timeout_seconds", "Timeout and limit options", "general API timeout in seconds", DefaultAPITimeoutSeconds),
-		intFlag("agent-startup-timeout-seconds", "agent_startup_timeout_seconds", "Timeout and limit options", "agent startup timeout in seconds", DefaultAgentStartupTimeoutSeconds),
-		intFlag("worktree-create-timeout-seconds", "worktree_create_timeout_seconds", "Timeout and limit options", "worktree creation timeout in seconds", DefaultWorktreeCreateTimeoutSeconds),
+		durationFlag("api-timeout", "api_timeout", "Timeout and limit options", "general API timeout", DefaultAPITimeout),
+		durationFlag("agent-startup-timeout", "agent_startup_timeout", "Timeout and limit options", "agent startup timeout", DefaultAgentStartupTimeout),
+		durationFlag("worktree-create-timeout", "worktree_create_timeout", "Timeout and limit options", "worktree creation timeout", DefaultWorktreeCreateTimeout),
 		intFlag("max-message-size", "max_message_size", "Timeout and limit options", "maximum application payload size in bytes (0 = 16 MiB default); reassembled ceiling is this plus 64 KiB headroom", 0),
 		int64Flag("relay-queue-memory-budget", "relay_queue_memory_budget", "Timeout and limit options", "bytes the Hub's browser channel relays may queue between them (0 = auto-size from the process memory limit)", int64(0)),
 		int64Flag("worker-queue-memory-budget", "worker_queue_memory_budget", "Timeout and limit options", "bytes the Hub's Worker connections may queue between them (0 = auto-size from the process memory limit)", int64(0)),
@@ -873,7 +886,7 @@ func LoadWithOptions(args []string, opts LoadOptions) (*Config, bool, error) {
 		return nil, true, nil
 	}
 
-	k := koanf.New(".")
+	k := koanf.New(internalconfig.Delim)
 	fp := internalconfig.NewFlagProvider(fs, fieldMap)
 
 	if err := internalconfig.Load(k, defaults, configPath, "LEAPMUX_HUB_", fp); err != nil {
@@ -881,9 +894,13 @@ func LoadWithOptions(args []string, opts LoadOptions) (*Config, bool, error) {
 	}
 
 	var cfg Config
-	if err := k.Unmarshal("", &cfg); err != nil {
+	if err := internalconfig.Unmarshal(k, &cfg); err != nil {
 		return nil, false, fmt.Errorf("unmarshal config: %w", err)
 	}
+
+	// Resolve the timeouts before anything reads one. A negative survives this
+	// step untouched, so Validate still sees what the operator wrote.
+	cfg.applyDurationDefaults()
 
 	// Validate --local-listen early: malformed values should surface at
 	// startup with a clear error rather than failing later inside Serve.
@@ -1052,28 +1069,18 @@ func (c *Config) Validate() error {
 
 // validateSessionDuration rejects a session lifetime nobody meant.
 //
-// Zero means "use the default". Flag parsing writes the default number itself,
-// so a zero reaches this only from a config built in code, and SessionDuration
-// reads it as the default there too. A negative is not a shorter session, so it
-// fails loudly rather than being silently read as the default. A value under
-// MinSessionDurationSeconds signs users out later than it promises; see
-// auth.MinSessionDuration. There is no upper bound: a long session is a policy
-// an operator may hold, and the slide makes it an idle timeout rather than an
-// unbounded credential.
+// The rule itself lives in auth.ValidateSessionDuration, next to the two
+// constants that set the floor. This adds only the key name, which auth cannot
+// know.
+//
+// Zero reaches this only from a Config built in code, because
+// applyDurationDefaults already replaced a loaded zero with the default.
 func (c *Config) validateSessionDuration() error {
-	switch {
-	case c.SessionDurationSeconds < 0:
-		return fmt.Errorf("session_duration_seconds must not be negative, got %d (0 = default)",
-			c.SessionDurationSeconds)
-	case c.SessionDurationSeconds == 0:
+	if c.SessionDuration == 0 {
 		return nil
-	case c.SessionDurationSeconds < MinSessionDurationSeconds:
-		return fmt.Errorf(
-			"session_duration_seconds must be 0 (default) or at least %d, got %d: "+
-				"the Hub serves a validated session from an in-memory cache for a "+
-				"short window, so a shorter session stays usable for a large share "+
-				"of its own life",
-			MinSessionDurationSeconds, c.SessionDurationSeconds)
+	}
+	if err := auth.ValidateSessionDuration(c.SessionDuration); err != nil {
+		return fmt.Errorf("session_duration: %w", err)
 	}
 	return nil
 }

--- a/backend/internal/hub/config/config_test.go
+++ b/backend/internal/hub/config/config_test.go
@@ -8,8 +8,10 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/leapmux/leapmux/channelwire"
+	"github.com/leapmux/leapmux/internal/hub/auth"
 	"github.com/leapmux/leapmux/internal/hub/crdt"
 	"github.com/leapmux/leapmux/internal/sendq"
 	"github.com/leapmux/leapmux/internal/util/memlimit"
@@ -1265,5 +1267,68 @@ func TestMaxConnectionsPerUser(t *testing.T) {
 		err := cfg.Validate()
 		require.Error(t, err, "a sign typo must not silently disable the cap")
 		assert.Contains(t, err.Error(), "max_connections_per_user")
+	})
+}
+
+func TestSessionDuration(t *testing.T) {
+	t.Run("defaults to the built-in duration", func(t *testing.T) {
+		cfg, _, err := Load(nil)
+		require.NoError(t, err)
+		assert.Equal(t, auth.DefaultSessionDuration, cfg.SessionDuration(),
+			"an operator who sets nothing must get the documented lifetime")
+	})
+
+	// The same three wiring mistakes each other settable key is pinned against:
+	// a missing fieldMap entry, a koanf tag that does not match the key, and an
+	// env-name mismatch all present as "the value I set was ignored".
+	t.Run("is settable from the command line", func(t *testing.T) {
+		cfg, _, err := Load([]string{"-session-duration-seconds", "3600"})
+		require.NoError(t, err)
+		assert.Equal(t, time.Hour, cfg.SessionDuration())
+	})
+
+	t.Run("is settable from the config file", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "hub.yaml")
+		require.NoError(t, os.WriteFile(path, []byte("session_duration_seconds: 3600\n"), 0o644))
+		cfg, _, err := Load([]string{"-config", path})
+		require.NoError(t, err)
+		assert.Equal(t, time.Hour, cfg.SessionDuration())
+	})
+
+	t.Run("is settable from the environment", func(t *testing.T) {
+		t.Setenv("LEAPMUX_HUB_SESSION_DURATION_SECONDS", "3600")
+		cfg, _, err := Load(nil)
+		require.NoError(t, err)
+		assert.Equal(t, time.Hour, cfg.SessionDuration())
+	})
+
+	t.Run("zero reads as the default", func(t *testing.T) {
+		cfg := &Config{Listen: ":4327", DataDir: t.TempDir(), SessionDurationSeconds: 0}
+		assert.NoError(t, cfg.Validate())
+		assert.Equal(t, auth.DefaultSessionDuration, cfg.SessionDuration())
+	})
+
+	// Below the floor the Hub cannot honestly enforce the value it was given:
+	// a validated session stays cached in memory for 30 seconds, so a session
+	// of a few seconds is served well past its own expiry. That fails at
+	// startup naming the key rather than as a mystery at runtime.
+	t.Run("rejects a duration under the floor", func(t *testing.T) {
+		for _, tooShort := range []int{1, 30, MinSessionDurationSeconds - 1} {
+			cfg := &Config{Listen: ":4327", DataDir: t.TempDir(), SessionDurationSeconds: tooShort}
+			err := cfg.Validate()
+			require.Error(t, err, "duration %d must be rejected", tooShort)
+			assert.Contains(t, err.Error(), "session_duration_seconds")
+		}
+
+		ok := &Config{Listen: ":4327", DataDir: t.TempDir(), SessionDurationSeconds: MinSessionDurationSeconds}
+		assert.NoError(t, ok.Validate(), "the minimum itself must be allowed")
+	})
+
+	t.Run("rejects a negative rather than reading it as the default", func(t *testing.T) {
+		cfg := &Config{Listen: ":4327", DataDir: t.TempDir(), SessionDurationSeconds: -1}
+		err := cfg.Validate()
+		require.Error(t, err, "a sign typo must not silently restore the default")
+		assert.Contains(t, err.Error(), "session_duration_seconds")
 	})
 }

--- a/backend/internal/hub/config/config_test.go
+++ b/backend/internal/hub/config/config_test.go
@@ -358,7 +358,7 @@ func TestHubHelpGroupsStorageOptions(t *testing.T) {
 	for i := 1; i < len(sections); i++ {
 		assert.Less(t, strings.Index(output, sections[i-1]), strings.Index(output, sections[i]))
 	}
-	assert.Contains(t, output, "\nTimeout and limit options:\n\n  -agent-startup-timeout-seconds int")
+	assert.Contains(t, output, "\nTimeout and limit options:\n\n  -agent-startup-timeout duration")
 	assert.Contains(t, output, "\nStorage common options:\n\n  -storage-type string")
 	assert.Contains(t, output, "\nSQLite storage options:\n\n  -storage-sqlite-cache-size int")
 }
@@ -1274,7 +1274,7 @@ func TestSessionDuration(t *testing.T) {
 	t.Run("defaults to the built-in duration", func(t *testing.T) {
 		cfg, _, err := Load(nil)
 		require.NoError(t, err)
-		assert.Equal(t, auth.DefaultSessionDuration, cfg.SessionDuration(),
+		assert.Equal(t, auth.DefaultSessionDuration, cfg.SessionDuration,
 			"an operator who sets nothing must get the documented lifetime")
 	})
 
@@ -1282,31 +1282,87 @@ func TestSessionDuration(t *testing.T) {
 	// a missing fieldMap entry, a koanf tag that does not match the key, and an
 	// env-name mismatch all present as "the value I set was ignored".
 	t.Run("is settable from the command line", func(t *testing.T) {
-		cfg, _, err := Load([]string{"-session-duration-seconds", "3600"})
+		cfg, _, err := Load([]string{"-session-duration", "1h"})
 		require.NoError(t, err)
-		assert.Equal(t, time.Hour, cfg.SessionDuration())
+		assert.Equal(t, time.Hour, cfg.SessionDuration)
 	})
 
 	t.Run("is settable from the config file", func(t *testing.T) {
 		dir := t.TempDir()
 		path := filepath.Join(dir, "hub.yaml")
-		require.NoError(t, os.WriteFile(path, []byte("session_duration_seconds: 3600\n"), 0o644))
+		require.NoError(t, os.WriteFile(path, []byte("session_duration: 1h\n"), 0o644))
 		cfg, _, err := Load([]string{"-config", path})
 		require.NoError(t, err)
-		assert.Equal(t, time.Hour, cfg.SessionDuration())
+		assert.Equal(t, time.Hour, cfg.SessionDuration)
 	})
 
 	t.Run("is settable from the environment", func(t *testing.T) {
-		t.Setenv("LEAPMUX_HUB_SESSION_DURATION_SECONDS", "3600")
+		t.Setenv("LEAPMUX_HUB_SESSION_DURATION", "1h")
 		cfg, _, err := Load(nil)
 		require.NoError(t, err)
-		assert.Equal(t, time.Hour, cfg.SessionDuration())
+		assert.Equal(t, time.Hour, cfg.SessionDuration)
+	})
+
+	// Every duration key reads a unit suffix and reads a bare number as
+	// seconds, from every source. The bare number is what the key took before
+	// it had units, and an operator who carried that spelling over must get the
+	// same session they had.
+	t.Run("reads every spelling from every source", func(t *testing.T) {
+		for _, c := range []struct {
+			text string
+			want time.Duration
+		}{
+			{"3600", time.Hour},
+			{"1h", time.Hour},
+			{"90m", 90 * time.Minute},
+			{"7d", 7 * 24 * time.Hour},
+			{"2w", 14 * 24 * time.Hour},
+		} {
+			t.Run("flag "+c.text, func(t *testing.T) {
+				cfg, _, err := Load([]string{"-session-duration", c.text})
+				require.NoError(t, err)
+				assert.Equal(t, c.want, cfg.SessionDuration)
+			})
+
+			t.Run("file "+c.text, func(t *testing.T) {
+				path := filepath.Join(t.TempDir(), "hub.yaml")
+				require.NoError(t, os.WriteFile(path, []byte("session_duration: "+c.text+"\n"), 0o644))
+				cfg, _, err := Load([]string{"-config", path})
+				require.NoError(t, err)
+				assert.Equal(t, c.want, cfg.SessionDuration)
+			})
+
+			t.Run("env "+c.text, func(t *testing.T) {
+				t.Setenv("LEAPMUX_HUB_SESSION_DURATION", c.text)
+				cfg, _, err := Load(nil)
+				require.NoError(t, err)
+				assert.Equal(t, c.want, cfg.SessionDuration)
+			})
+		}
+	})
+
+	t.Run("rejects a value that is not a duration", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "hub.yaml")
+		require.NoError(t, os.WriteFile(path, []byte("session_duration: 30x\n"), 0o644))
+		_, _, err := Load([]string{"-config", path})
+		require.Error(t, err, "a typed unit must fail at startup, not read as zero")
+	})
+
+	// The whole reason this key parses rather than multiplies: a seconds count
+	// large enough to overflow an int64 of nanoseconds used to wrap, and the
+	// operator who asked for a very long session silently got a very short one.
+	t.Run("rejects a value past the representable range", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "hub.yaml")
+		require.NoError(t, os.WriteFile(path, []byte("session_duration: 18446744075\n"), 0o644))
+		_, _, err := Load([]string{"-config", path})
+		require.Error(t, err, "an out-of-range value must fail rather than wrap")
 	})
 
 	t.Run("zero reads as the default", func(t *testing.T) {
-		cfg := &Config{Listen: ":4327", DataDir: t.TempDir(), SessionDurationSeconds: 0}
+		cfg, _, err := Load([]string{"-session-duration", "0"})
+		require.NoError(t, err)
 		assert.NoError(t, cfg.Validate())
-		assert.Equal(t, auth.DefaultSessionDuration, cfg.SessionDuration())
+		assert.Equal(t, auth.DefaultSessionDuration, cfg.SessionDuration)
 	})
 
 	// Below the floor the Hub cannot honestly enforce the value it was given:
@@ -1314,21 +1370,105 @@ func TestSessionDuration(t *testing.T) {
 	// of a few seconds is served well past its own expiry. That fails at
 	// startup naming the key rather than as a mystery at runtime.
 	t.Run("rejects a duration under the floor", func(t *testing.T) {
-		for _, tooShort := range []int{1, 30, MinSessionDurationSeconds - 1} {
-			cfg := &Config{Listen: ":4327", DataDir: t.TempDir(), SessionDurationSeconds: tooShort}
+		for _, tooShort := range []time.Duration{time.Second, 30 * time.Second, auth.MinSessionDuration - 1} {
+			cfg := &Config{Listen: ":4327", DataDir: t.TempDir(), SessionDuration: tooShort}
 			err := cfg.Validate()
-			require.Error(t, err, "duration %d must be rejected", tooShort)
-			assert.Contains(t, err.Error(), "session_duration_seconds")
+			require.Error(t, err, "duration %s must be rejected", tooShort)
+			assert.Contains(t, err.Error(), "session_duration")
 		}
 
-		ok := &Config{Listen: ":4327", DataDir: t.TempDir(), SessionDurationSeconds: MinSessionDurationSeconds}
+		ok := &Config{Listen: ":4327", DataDir: t.TempDir(), SessionDuration: auth.MinSessionDuration}
 		assert.NoError(t, ok.Validate(), "the minimum itself must be allowed")
 	})
 
 	t.Run("rejects a negative rather than reading it as the default", func(t *testing.T) {
-		cfg := &Config{Listen: ":4327", DataDir: t.TempDir(), SessionDurationSeconds: -1}
+		cfg := &Config{Listen: ":4327", DataDir: t.TempDir(), SessionDuration: -time.Second}
 		err := cfg.Validate()
 		require.Error(t, err, "a sign typo must not silently restore the default")
-		assert.Contains(t, err.Error(), "session_duration_seconds")
+		assert.Contains(t, err.Error(), "session_duration")
 	})
+}
+
+// TestDurationOptionsShareTheParser pins the property that made this one
+// change rather than four: every duration key takes the same spellings. A key
+// that a later change registers with fs.Int again would read "5m" as a parse
+// error and "3600" as 3600 nanoseconds.
+func TestDurationOptionsShareTheParser(t *testing.T) {
+	cfg, _, err := Load([]string{
+		"-session-duration", "2h",
+		"-api-timeout", "45s",
+		"-agent-startup-timeout", "10m",
+		"-worktree-create-timeout", "90",
+		"-storage-postgres-conn-max-lifetime", "1d",
+		"-storage-mysql-conn-max-idle-time", "30s",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2*time.Hour, cfg.SessionDuration)
+	assert.Equal(t, 45*time.Second, cfg.APITimeout)
+	assert.Equal(t, 10*time.Minute, cfg.AgentStartupTimeout)
+	assert.Equal(t, 90*time.Second, cfg.WorktreeCreateTimeout, "a bare number is still seconds")
+	assert.Equal(t, 24*time.Hour, cfg.Storage.Postgres.ConnMaxLifetime)
+	assert.Equal(t, 30*time.Second, cfg.Storage.MySQL.ConnMaxIdleTime)
+}
+
+// A flag whose koanf key is nested must reach the config. Every storage flag is
+// nested, and each one parsed, reported no error, and was then dropped: the
+// provider handed koanf a flat "storage.postgres.dsn", which is a top-level key
+// whose name contains dots, and Unmarshal walks the nested map instead.
+func TestNestedFlagsReachTheConfig(t *testing.T) {
+	cfg, _, err := Load([]string{
+		"-storage-type", "postgres",
+		"-storage-postgres-dsn", "postgres://example/db",
+		"-storage-postgres-max-conns", "77",
+		"-storage-sqlite-path", "/tmp/hub.db",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, StorageTypePostgres, cfg.Storage.Type)
+	assert.Equal(t, "postgres://example/db", cfg.Storage.Postgres.DSN)
+	assert.Equal(t, 77, cfg.Storage.Postgres.MaxConns)
+	assert.Equal(t, "/tmp/hub.db", cfg.Storage.SQLite.Path)
+
+	// A nested flag must still lose to nothing else: the default fills what the
+	// command line left alone.
+	assert.Equal(t, 5, cfg.Storage.Postgres.MinConns)
+}
+
+// TestTimeoutsDefaultWhenUnset covers the keys whose read-time fallback this
+// change removed: the loader now resolves them, so a caller that reads the
+// field directly must still find a usable timeout.
+func TestTimeoutsDefaultWhenUnset(t *testing.T) {
+	cfg, _, err := Load(nil)
+	require.NoError(t, err)
+	assert.Equal(t, DefaultAPITimeout, cfg.APITimeout)
+	assert.Equal(t, DefaultAgentStartupTimeout, cfg.AgentStartupTimeout)
+	assert.Equal(t, DefaultWorktreeCreateTimeout, cfg.WorktreeCreateTimeout)
+
+	// An explicit zero means the default too, and never "no timeout at all",
+	// which would make every context deadline expire at once.
+	zeroed, _, err := Load([]string{"-api-timeout", "0", "-agent-startup-timeout", "0"})
+	require.NoError(t, err)
+	assert.Equal(t, DefaultAPITimeout, zeroed.APITimeout)
+	assert.Equal(t, DefaultAgentStartupTimeout, zeroed.AgentStartupTimeout)
+}
+
+// The database pool durations keep their own meaning for zero -- leave the
+// driver's own default alone -- so the timeout resolver must not touch them.
+// The pool code tests for zero (`if cfg.ConnMaxLifetime > 0`), so filling one in
+// here would silently start pinning a lifetime the operator never asked for.
+func TestPoolDurationsKeepTheirOwnZero(t *testing.T) {
+	cfg, _, err := Load([]string{
+		"-storage-postgres-conn-max-lifetime", "0",
+		"-storage-mysql-conn-max-idle-time", "0",
+	})
+	require.NoError(t, err)
+	assert.Zero(t, cfg.Storage.Postgres.ConnMaxLifetime,
+		"an explicit zero must reach the pool as zero, not as the default")
+	assert.Zero(t, cfg.Storage.MySQL.ConnMaxIdleTime)
+
+	// The flag default still applies when the operator sets nothing, so zero
+	// only ever arrives because someone asked for it.
+	unset, _, err := Load(nil)
+	require.NoError(t, err)
+	assert.Equal(t, time.Hour, unset.Storage.Postgres.ConnMaxLifetime)
+	assert.Equal(t, 5*time.Minute, unset.Storage.MySQL.ConnMaxIdleTime)
 }

--- a/backend/internal/hub/notifier/notifier.go
+++ b/backend/internal/hub/notifier/notifier.go
@@ -66,7 +66,7 @@ func New(st store.Store, wMgr workerRegistry, pr *workermgr.PendingRequests, cfg
 func (n *Notifier) SendOrQueue(ctx context.Context, workerID string, notificationType leapmuxv1.NotificationType, payload string, msg *leapmuxv1.ConnectResponse) error {
 	conn := n.workerMgr.ConnForTrustedPath(workerID)
 	if conn != nil {
-		sendCtx, cancel := context.WithTimeout(ctx, n.cfg.APITimeout())
+		sendCtx, cancel := context.WithTimeout(ctx, n.cfg.APITimeout)
 		defer cancel()
 
 		_, err := n.pending.SendAndWait(sendCtx, conn, msg)
@@ -110,7 +110,7 @@ func (n *Notifier) ProcessPendingNotifications(ctx context.Context, workerID str
 			continue
 		}
 
-		sendCtx, cancel := context.WithTimeout(ctx, n.cfg.APITimeout())
+		sendCtx, cancel := context.WithTimeout(ctx, n.cfg.APITimeout)
 		_, sendErr := n.pending.SendAndWait(sendCtx, conn, msg)
 		cancel()
 

--- a/backend/internal/hub/notifier/notifier_test.go
+++ b/backend/internal/hub/notifier/notifier_test.go
@@ -3,6 +3,7 @@ package notifier
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -55,7 +56,7 @@ func TestSendOrQueue_OfflineWorkerPersistsToQueue(t *testing.T) {
 	// conn == nil is the offline case.
 	reg := &fakeRegistry{}
 	cfg := &config.Config{}
-	n := New(st, reg, workermgr.NewPendingRequests(cfg.APITimeout), cfg)
+	n := New(st, reg, workermgr.NewPendingRequests(func() time.Duration { return cfg.APITimeout }), cfg)
 
 	err := n.SendOrQueue(ctx, worker, leapmuxv1.NotificationType_NOTIFICATION_TYPE_UNSPECIFIED,
 		`{"hello":"world"}`, &leapmuxv1.ConnectResponse{})
@@ -91,7 +92,7 @@ func TestSendDeregister_MarksDeregisteringAndDoesNotClear(t *testing.T) {
 
 	reg := &fakeRegistry{} // offline, so the notification queues
 	cfg := &config.Config{}
-	n := New(st, reg, workermgr.NewPendingRequests(cfg.APITimeout), cfg)
+	n := New(st, reg, workermgr.NewPendingRequests(func() time.Duration { return cfg.APITimeout }), cfg)
 
 	require.NoError(t, n.SendDeregister(ctx, worker))
 

--- a/backend/internal/hub/revocationwatcher/watcher_test.go
+++ b/backend/internal/hub/revocationwatcher/watcher_test.go
@@ -33,7 +33,7 @@ func newBearerAuthHub(
 ) (leapmuxv1connect.AuthServiceClient, *auth.AuthContextRegistry) {
 	t.Helper()
 	mux := http.NewServeMux()
-	interceptor, cache := auth.NewInterceptor(auth.InterceptorOptions{Store: st, TokenValidator: validator})
+	interceptor, cache := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st, TokenValidator: validator})
 	t.Cleanup(cache.Stop)
 	authService := service.NewAuthService(st, &config.Config{}, auth.NewCredentialLifecycleEffects(cache, nil, nil), nil, mail.NewStubSender(), mail.Renderer{})
 	path, handler := leapmuxv1connect.NewAuthServiceHandler(authService, connect.WithInterceptors(interceptor))
@@ -155,7 +155,7 @@ func setupUnseededWithOptions(t *testing.T, opts ...revocationwatcher.Option) *e
 	t.Helper()
 	st := hubtestutil.OpenTestStore(t)
 	hubtestutil.CreateTestAdmin(t, st)
-	_, sc := auth.NewInterceptor(auth.InterceptorOptions{Store: st})
+	_, sc := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st})
 	t.Cleanup(sc.Stop)
 
 	closer := &fakeCloser{}

--- a/backend/internal/hub/revocationwatcher/watcher_test.go
+++ b/backend/internal/hub/revocationwatcher/watcher_test.go
@@ -33,7 +33,7 @@ func newBearerAuthHub(
 ) (leapmuxv1connect.AuthServiceClient, *auth.AuthContextRegistry) {
 	t.Helper()
 	mux := http.NewServeMux()
-	interceptor, cache := auth.NewInterceptorWithTokens(st, nil, validator, false, false)
+	interceptor, cache := auth.NewInterceptor(auth.InterceptorOptions{Store: st, TokenValidator: validator})
 	t.Cleanup(cache.Stop)
 	authService := service.NewAuthService(st, &config.Config{}, auth.NewCredentialLifecycleEffects(cache, nil, nil), nil, mail.NewStubSender(), mail.Renderer{})
 	path, handler := leapmuxv1connect.NewAuthServiceHandler(authService, connect.WithInterceptors(interceptor))
@@ -155,7 +155,7 @@ func setupUnseededWithOptions(t *testing.T, opts ...revocationwatcher.Option) *e
 	t.Helper()
 	st := hubtestutil.OpenTestStore(t)
 	hubtestutil.CreateTestAdmin(t, st)
-	_, sc := auth.NewInterceptor(st, nil, false, false)
+	_, sc := auth.NewInterceptor(auth.InterceptorOptions{Store: st})
 	t.Cleanup(sc.Stop)
 
 	closer := &fakeCloser{}
@@ -399,7 +399,7 @@ func TestWatcher_PublishesGaplessSeqAndAppliesEvents(t *testing.T) {
 	env := setup(t)
 	apiToken := env.seedAPIToken(t)
 	delegationToken := env.seedDelegationToken(t)
-	sessionID, _, _, err := auth.Login(context.Background(), env.st, "admin", hubtestutil.TestAdminPassword)
+	sessionID, _, _, err := auth.Login(context.Background(), env.st, "admin", hubtestutil.TestAdminPassword, auth.DefaultSessionDuration)
 	require.NoError(t, err)
 
 	_, err = env.st.APITokens().Revoke(context.Background(), apiToken)

--- a/backend/internal/hub/service/api_auth_handler_test.go
+++ b/backend/internal/hub/service/api_auth_handler_test.go
@@ -140,7 +140,7 @@ func setupAPIAuth(t *testing.T) *apiAuthEnv {
 	// AuthContextRegistry is needed by the handler to evict revoked bearers; we
 	// don't run it through the interceptor, so just construct the bare
 	// interceptor for its cache side-effect and stop the sweeper.
-	_, sc := auth.NewInterceptor(auth.InterceptorOptions{Store: st})
+	_, sc := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st})
 	t.Cleanup(sc.Stop)
 
 	mux := http.NewServeMux()
@@ -1923,7 +1923,7 @@ func TestAPIAuth_AuthorizationCode_BlankUserIDIsInvalidGrantNotPanic(t *testing.
 
 	tv, err := auth.NewTokenValidator(st, []byte("0123456789abcdef0123456789abcdef"))
 	require.NoError(t, err)
-	_, sc := auth.NewInterceptor(auth.InterceptorOptions{Store: st})
+	_, sc := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st})
 	t.Cleanup(sc.Stop)
 
 	verifier, challenge := pkceVerifierAndChallenge()

--- a/backend/internal/hub/service/api_auth_handler_test.go
+++ b/backend/internal/hub/service/api_auth_handler_test.go
@@ -140,7 +140,7 @@ func setupAPIAuth(t *testing.T) *apiAuthEnv {
 	// AuthContextRegistry is needed by the handler to evict revoked bearers; we
 	// don't run it through the interceptor, so just construct the bare
 	// interceptor for its cache side-effect and stop the sweeper.
-	_, sc := auth.NewInterceptor(st, nil, false, false)
+	_, sc := auth.NewInterceptor(auth.InterceptorOptions{Store: st})
 	t.Cleanup(sc.Stop)
 
 	mux := http.NewServeMux()
@@ -171,7 +171,7 @@ func setupAPIAuth(t *testing.T) *apiAuthEnv {
 // that gate on `requireSession` see an authenticated browser session.
 func (e *apiAuthEnv) adminCookie(t *testing.T) *http.Cookie {
 	t.Helper()
-	tok, _, _, err := auth.Login(context.Background(), e.store, hubtestutil.TestAdminUsername, hubtestutil.TestAdminPassword)
+	tok, _, _, err := auth.Login(context.Background(), e.store, hubtestutil.TestAdminUsername, hubtestutil.TestAdminPassword, auth.DefaultSessionDuration)
 	require.NoError(t, err)
 	return &http.Cookie{Name: auth.CookieName, Value: tok}
 }
@@ -1923,7 +1923,7 @@ func TestAPIAuth_AuthorizationCode_BlankUserIDIsInvalidGrantNotPanic(t *testing.
 
 	tv, err := auth.NewTokenValidator(st, []byte("0123456789abcdef0123456789abcdef"))
 	require.NoError(t, err)
-	_, sc := auth.NewInterceptor(st, nil, false, false)
+	_, sc := auth.NewInterceptor(auth.InterceptorOptions{Store: st})
 	t.Cleanup(sc.Stop)
 
 	verifier, challenge := pkceVerifierAndChallenge()

--- a/backend/internal/hub/service/auth_service.go
+++ b/backend/internal/hub/service/auth_service.go
@@ -61,7 +61,7 @@ func (s *AuthService) checkHasAnyUser(ctx context.Context) (bool, error) {
 }
 
 func (s *AuthService) Login(ctx context.Context, req *connect.Request[leapmuxv1.LoginRequest]) (*connect.Response[leapmuxv1.LoginResponse], error) {
-	token, user, expiresAt, err := auth.Login(ctx, s.store, req.Msg.GetUsername(), req.Msg.GetPassword())
+	token, user, expiresAt, err := auth.Login(ctx, s.store, req.Msg.GetUsername(), req.Msg.GetPassword(), s.cfg.SessionDuration())
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +227,7 @@ func (s *AuthService) SignUp(ctx context.Context, req *connect.Request[leapmuxv1
 		if mintErr != nil {
 			return nil, mintErr
 		}
-		sessionID, sessionExpires, err := auth.CreateSession(ctx, s.store, uid)
+		sessionID, sessionExpires, err := auth.CreateSession(ctx, s.store, uid, s.cfg.SessionDuration())
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("create session: %w", err))
 		}
@@ -304,7 +304,7 @@ func (s *AuthService) signUpResponse(ctx context.Context, user *store.User) (*co
 	if err != nil {
 		return nil, err
 	}
-	sessionID, expiresAt, err := auth.CreateSession(ctx, s.store, loginUID)
+	sessionID, expiresAt, err := auth.CreateSession(ctx, s.store, loginUID, s.cfg.SessionDuration())
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("create session: %w", err))
 	}
@@ -571,7 +571,7 @@ func (s *AuthService) CompleteOAuthSignup(ctx context.Context, req *connect.Requ
 	if mintErr != nil {
 		return nil, mintErr
 	}
-	sessionID, expiresAt, sessionErr := auth.CreateSession(ctx, s.store, finalUID)
+	sessionID, expiresAt, sessionErr := auth.CreateSession(ctx, s.store, finalUID, s.cfg.SessionDuration())
 	if sessionErr != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("create session: %w", sessionErr))
 	}

--- a/backend/internal/hub/service/auth_service.go
+++ b/backend/internal/hub/service/auth_service.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"sync/atomic"
 	"time"
 
@@ -60,8 +61,21 @@ func (s *AuthService) checkHasAnyUser(ctx context.Context) (bool, error) {
 	return false, nil
 }
 
+// setSessionCookie writes the cookie for a session that this response
+// established. One helper for the four mint paths -- login, both sign-up
+// branches, and the OAuth signup completion -- so the secure-name choice and
+// the header write cannot drift apart between them.
+//
+// Set, not Add: this cookie is the response's answer about the session, and it
+// replaces anything already written for that name. The interceptor's slide
+// refresh stands back from a response that already carries a session cookie,
+// which is what keeps these two writers from fighting.
+func (s *AuthService) setSessionCookie(h http.Header, sessionID string, expiresAt time.Time) {
+	h.Set("Set-Cookie", auth.BuildSessionCookie(sessionID, expiresAt, s.cfg.SecureCookies).String())
+}
+
 func (s *AuthService) Login(ctx context.Context, req *connect.Request[leapmuxv1.LoginRequest]) (*connect.Response[leapmuxv1.LoginResponse], error) {
-	token, user, expiresAt, err := auth.Login(ctx, s.store, req.Msg.GetUsername(), req.Msg.GetPassword(), s.cfg.SessionDuration())
+	token, user, expiresAt, err := auth.Login(ctx, s.store, req.Msg.GetUsername(), req.Msg.GetPassword(), s.cfg.SessionDuration)
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +83,7 @@ func (s *AuthService) Login(ctx context.Context, req *connect.Request[leapmuxv1.
 	resp := connect.NewResponse(&leapmuxv1.LoginResponse{
 		User: userToProto(user),
 	})
-	resp.Header().Set("Set-Cookie", auth.BuildSessionCookie(token, expiresAt, s.cfg.SecureCookies).String())
+	s.setSessionCookie(resp.Header(), token, expiresAt)
 	return resp, nil
 }
 
@@ -227,7 +241,7 @@ func (s *AuthService) SignUp(ctx context.Context, req *connect.Request[leapmuxv1
 		if mintErr != nil {
 			return nil, mintErr
 		}
-		sessionID, sessionExpires, err := auth.CreateSession(ctx, s.store, uid, s.cfg.SessionDuration())
+		sessionID, sessionExpires, err := auth.CreateSession(ctx, s.store, uid, s.cfg.SessionDuration)
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("create session: %w", err))
 		}
@@ -236,7 +250,7 @@ func (s *AuthService) SignUp(ctx context.Context, req *connect.Request[leapmuxv1
 			VerificationRequired:  true,
 			VerificationEmailSent: emailSent,
 		})
-		resp.Header().Set("Set-Cookie", auth.BuildSessionCookie(sessionID, sessionExpires, s.cfg.SecureCookies).String())
+		s.setSessionCookie(resp.Header(), sessionID, sessionExpires)
 		return resp, nil
 	}
 
@@ -304,7 +318,7 @@ func (s *AuthService) signUpResponse(ctx context.Context, user *store.User) (*co
 	if err != nil {
 		return nil, err
 	}
-	sessionID, expiresAt, err := auth.CreateSession(ctx, s.store, loginUID, s.cfg.SessionDuration())
+	sessionID, expiresAt, err := auth.CreateSession(ctx, s.store, loginUID, s.cfg.SessionDuration)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("create session: %w", err))
 	}
@@ -312,7 +326,7 @@ func (s *AuthService) signUpResponse(ctx context.Context, user *store.User) (*co
 	resp := connect.NewResponse(&leapmuxv1.SignUpResponse{
 		User: userToProto(user),
 	})
-	resp.Header().Set("Set-Cookie", auth.BuildSessionCookie(sessionID, expiresAt, s.cfg.SecureCookies).String())
+	s.setSessionCookie(resp.Header(), sessionID, expiresAt)
 	return resp, nil
 }
 
@@ -571,7 +585,7 @@ func (s *AuthService) CompleteOAuthSignup(ctx context.Context, req *connect.Requ
 	if mintErr != nil {
 		return nil, mintErr
 	}
-	sessionID, expiresAt, sessionErr := auth.CreateSession(ctx, s.store, finalUID, s.cfg.SessionDuration())
+	sessionID, expiresAt, sessionErr := auth.CreateSession(ctx, s.store, finalUID, s.cfg.SessionDuration)
 	if sessionErr != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("create session: %w", sessionErr))
 	}
@@ -581,7 +595,7 @@ func (s *AuthService) CompleteOAuthSignup(ctx context.Context, req *connect.Requ
 		VerificationRequired:  pendingEmail != "",
 		VerificationEmailSent: emailSent,
 	})
-	resp.Header().Set("Set-Cookie", auth.BuildSessionCookie(sessionID, expiresAt, s.cfg.SecureCookies).String())
+	s.setSessionCookie(resp.Header(), sessionID, expiresAt)
 	return resp, nil
 }
 

--- a/backend/internal/hub/service/auth_service_test.go
+++ b/backend/internal/hub/service/auth_service_test.go
@@ -35,7 +35,7 @@ func setupAuthTestServerBase(t *testing.T, cfg *config.Config, closers ...auth.C
 	st := hubtestutil.OpenTestStore(t)
 
 	mux := http.NewServeMux()
-	interceptor, sc := auth.NewInterceptor(st, nil, false, false)
+	interceptor, sc := auth.NewInterceptor(auth.InterceptorOptions{Store: st})
 	t.Cleanup(sc.Stop)
 	opts := connect.WithInterceptors(interceptor)
 	var closer auth.CredentialChannelCloser
@@ -205,6 +205,73 @@ func TestAuthService_SignUp_WhenEnabled(t *testing.T) {
 	assert.Contains(t, setCookie, "HttpOnly")
 }
 
+// Every path that mints a session must stamp the configured duration, not only
+// login. Each one calls CreateSession separately, so one left on the default is
+// a silent split: those users get the built-in lifetime and nothing reports it.
+// The verification-required branch mints its own session (the user needs one to
+// call VerifyEmail), which is why it is exercised apart from the plain sign-up.
+func TestAuthService_SessionMintPathsUseConfiguredDuration(t *testing.T) {
+	t.Parallel()
+
+	const configured = 90 * time.Minute
+	signUp := func(t *testing.T, cfg *config.Config, username string) (*connect.Response[leapmuxv1.SignUpResponse], store.Store, string) {
+		t.Helper()
+		cfg.SessionDurationSeconds = int(configured / time.Second)
+		client, st := setupAuthTestServer(t, cfg)
+		resp, err := client.SignUp(context.Background(), connect.NewRequest(&leapmuxv1.SignUpRequest{
+			Username:    username,
+			Password:    "newpass123",
+			DisplayName: "New User",
+			Email:       username + "@example.com",
+		}))
+		require.NoError(t, err)
+		return resp, st, sessionFromCookie(t, resp.Header().Get("Set-Cookie"))
+	}
+
+	assertExpiry := func(t *testing.T, st store.Store, sessionID string, before time.Time) {
+		t.Helper()
+		sess, err := st.Sessions().GetByID(context.Background(), sessionID)
+		require.NoError(t, err)
+		assert.WithinDuration(t, before.Add(configured), sess.ExpiresAt, time.Minute)
+	}
+
+	t.Run("sign-up", func(t *testing.T) {
+		t.Parallel()
+		before := time.Now()
+		resp, st, sessionID := signUp(t, testConfigWithSignup(), "newuser")
+		require.False(t, resp.Msg.GetVerificationRequired(), "control: this is the plain branch")
+		assertExpiry(t, st, sessionID, before)
+	})
+
+	t.Run("sign-up with verification required", func(t *testing.T) {
+		t.Parallel()
+		cfg := testConfigWithSMTP()
+		cfg.SignupEnabled = true
+		cfg.EmailVerificationRequired = true
+		before := time.Now()
+		resp, st, sessionID := signUp(t, cfg, "unverified")
+		// Without this the subtest would silently repeat the branch above, and
+		// the second CreateSession call site would go unexercised.
+		require.True(t, resp.Msg.GetVerificationRequired(), "this must take the verification branch")
+		assertExpiry(t, st, sessionID, before)
+	})
+
+	t.Run("login", func(t *testing.T) {
+		t.Parallel()
+		cfg := testConfig()
+		cfg.SessionDurationSeconds = int(configured / time.Second)
+		client, st := setupAuthTestServer(t, cfg)
+
+		before := time.Now()
+		resp, err := client.Login(context.Background(), connect.NewRequest(&leapmuxv1.LoginRequest{
+			Username: hubtestutil.TestAdminUsername,
+			Password: hubtestutil.TestAdminPassword,
+		}))
+		require.NoError(t, err)
+		assertExpiry(t, st, sessionFromCookie(t, resp.Header().Get("Set-Cookie")), before)
+	})
+}
+
 func TestAuthService_SignUp_WhenDisabled(t *testing.T) {
 	t.Parallel()
 
@@ -255,7 +322,7 @@ func TestAuthService_ChangePassword_WrongOldPassword(t *testing.T) {
 
 	// Set up a UserService client using the same queries and auth interceptor.
 	mux := http.NewServeMux()
-	interceptor, _ := auth.NewInterceptor(st, nil, false, false)
+	interceptor, _ := auth.NewInterceptor(auth.InterceptorOptions{Store: st})
 	opts := connect.WithInterceptors(interceptor)
 	userSvc := service.NewUserService(st, testConfig(), auth.NewCredentialLifecycleEffects(nil, nil, nil), mail.NewStubSender(), mail.Renderer{})
 	path, handler := leapmuxv1connect.NewUserServiceHandler(userSvc, opts)
@@ -454,7 +521,7 @@ func setupVerificationGatingTestServer(t *testing.T, emailVerificationRequired b
 	hubtestutil.CreateTestAdmin(t, st)
 
 	mux := http.NewServeMux()
-	interceptor, _ := auth.NewInterceptor(st, nil, false, emailVerificationRequired)
+	interceptor, _ := auth.NewInterceptor(auth.InterceptorOptions{Store: st, EmailVerificationRequired: emailVerificationRequired})
 	opts := connect.WithInterceptors(interceptor)
 
 	cfg := testConfig()
@@ -496,7 +563,7 @@ func TestVerificationGating_UnverifiedBlocked(t *testing.T) {
 	})
 	// email_verified defaults to 0 in the DB.
 
-	token, _, _, err := auth.Login(context.Background(), st, "unverified", "testpass")
+	token, _, _, err := auth.Login(context.Background(), st, "unverified", "testpass", auth.DefaultSessionDuration)
 	require.NoError(t, err)
 
 	// Try UpdateProfile — should be blocked by verification gating.
@@ -515,7 +582,7 @@ func TestVerificationGating_AdminExempt(t *testing.T) {
 
 	// The bootstrap admin has email_verified=0 by default (no email set).
 	// Verify the admin can still call protected RPCs.
-	adminToken, _, _, err := auth.Login(context.Background(), st, "admin", "admin123")
+	adminToken, _, _, err := auth.Login(context.Background(), st, "admin", "admin123", auth.DefaultSessionDuration)
 	require.NoError(t, err)
 
 	// Admin should be able to call UpdateProfile even with email_verified=0.
@@ -545,7 +612,7 @@ func TestVerificationGating_ConfigOff_NotBlocked(t *testing.T) {
 	})
 	// email_verified defaults to 0 — but gating is OFF.
 
-	token, _, _, err := auth.Login(context.Background(), st, "nogate", "testpass")
+	token, _, _, err := auth.Login(context.Background(), st, "nogate", "testpass", auth.DefaultSessionDuration)
 	require.NoError(t, err)
 
 	// Unverified user should be able to call UpdateProfile when gating is off.
@@ -623,7 +690,7 @@ func TestVerificationGating_LogoutAllowed(t *testing.T) {
 	})
 	// email_verified defaults to 0.
 
-	token, _, _, err := auth.Login(context.Background(), st, "logoutgating", "testpass")
+	token, _, _, err := auth.Login(context.Background(), st, "logoutgating", "testpass", auth.DefaultSessionDuration)
 	require.NoError(t, err)
 
 	// Logout should be allowed for unverified users.
@@ -654,7 +721,7 @@ func TestVerificationGating_RequestEmailChangeAllowed(t *testing.T) {
 	})
 	// email_verified defaults to 0.
 
-	token, _, _, err := auth.Login(context.Background(), st, "emailchangegate", "testpass")
+	token, _, _, err := auth.Login(context.Background(), st, "emailchangegate", "testpass", auth.DefaultSessionDuration)
 	require.NoError(t, err)
 
 	// RequestEmailChange should be allowed for unverified users
@@ -736,7 +803,7 @@ func TestAuthService_LogoutDeleteFailureReturnsInternal(t *testing.T) {
 	}
 
 	mux := http.NewServeMux()
-	interceptor, sc := auth.NewInterceptor(wrapped, nil, false, false)
+	interceptor, sc := auth.NewInterceptor(auth.InterceptorOptions{Store: wrapped})
 	t.Cleanup(sc.Stop)
 	opts := connect.WithInterceptors(interceptor)
 	authSvc := service.NewAuthService(wrapped, testConfig(), auth.NewCredentialLifecycleEffects(sc, nil, nil), nil, mail.NewStubSender(), mail.Renderer{})
@@ -882,7 +949,7 @@ func TestSetupSignUp_RejectedInSoloMode(t *testing.T) {
 	// No solo user is seeded — the test asserts that AuthService rejects setup
 	// signup in solo mode at the service layer, independent of the interceptor.
 	mux := http.NewServeMux()
-	interceptor, sc := auth.NewInterceptor(st, nil, false, false)
+	interceptor, sc := auth.NewInterceptor(auth.InterceptorOptions{Store: st})
 	t.Cleanup(sc.Stop)
 	opts := connect.WithInterceptors(interceptor)
 	authSvc := service.NewAuthService(st, cfg, auth.NewCredentialLifecycleEffects(sc, nil, nil), nil, mail.NewStubSender(), mail.Renderer{})

--- a/backend/internal/hub/service/auth_service_test.go
+++ b/backend/internal/hub/service/auth_service_test.go
@@ -35,7 +35,7 @@ func setupAuthTestServerBase(t *testing.T, cfg *config.Config, closers ...auth.C
 	st := hubtestutil.OpenTestStore(t)
 
 	mux := http.NewServeMux()
-	interceptor, sc := auth.NewInterceptor(auth.InterceptorOptions{Store: st})
+	interceptor, sc := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st})
 	t.Cleanup(sc.Stop)
 	opts := connect.WithInterceptors(interceptor)
 	var closer auth.CredentialChannelCloser
@@ -216,7 +216,7 @@ func TestAuthService_SessionMintPathsUseConfiguredDuration(t *testing.T) {
 	const configured = 90 * time.Minute
 	signUp := func(t *testing.T, cfg *config.Config, username string) (*connect.Response[leapmuxv1.SignUpResponse], store.Store, string) {
 		t.Helper()
-		cfg.SessionDurationSeconds = int(configured / time.Second)
+		cfg.SessionDuration = configured
 		client, st := setupAuthTestServer(t, cfg)
 		resp, err := client.SignUp(context.Background(), connect.NewRequest(&leapmuxv1.SignUpRequest{
 			Username:    username,
@@ -232,7 +232,7 @@ func TestAuthService_SessionMintPathsUseConfiguredDuration(t *testing.T) {
 		t.Helper()
 		sess, err := st.Sessions().GetByID(context.Background(), sessionID)
 		require.NoError(t, err)
-		assert.WithinDuration(t, before.Add(configured), sess.ExpiresAt, time.Minute)
+		hubtestutil.AssertSessionLifetime(t, before, configured, sess.ExpiresAt)
 	}
 
 	t.Run("sign-up", func(t *testing.T) {
@@ -259,7 +259,7 @@ func TestAuthService_SessionMintPathsUseConfiguredDuration(t *testing.T) {
 	t.Run("login", func(t *testing.T) {
 		t.Parallel()
 		cfg := testConfig()
-		cfg.SessionDurationSeconds = int(configured / time.Second)
+		cfg.SessionDuration = configured
 		client, st := setupAuthTestServer(t, cfg)
 
 		before := time.Now()
@@ -322,7 +322,7 @@ func TestAuthService_ChangePassword_WrongOldPassword(t *testing.T) {
 
 	// Set up a UserService client using the same queries and auth interceptor.
 	mux := http.NewServeMux()
-	interceptor, _ := auth.NewInterceptor(auth.InterceptorOptions{Store: st})
+	interceptor, _ := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st})
 	opts := connect.WithInterceptors(interceptor)
 	userSvc := service.NewUserService(st, testConfig(), auth.NewCredentialLifecycleEffects(nil, nil, nil), mail.NewStubSender(), mail.Renderer{})
 	path, handler := leapmuxv1connect.NewUserServiceHandler(userSvc, opts)
@@ -521,7 +521,7 @@ func setupVerificationGatingTestServer(t *testing.T, emailVerificationRequired b
 	hubtestutil.CreateTestAdmin(t, st)
 
 	mux := http.NewServeMux()
-	interceptor, _ := auth.NewInterceptor(auth.InterceptorOptions{Store: st, EmailVerificationRequired: emailVerificationRequired})
+	interceptor, _ := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st, EmailVerificationRequired: emailVerificationRequired})
 	opts := connect.WithInterceptors(interceptor)
 
 	cfg := testConfig()
@@ -803,7 +803,7 @@ func TestAuthService_LogoutDeleteFailureReturnsInternal(t *testing.T) {
 	}
 
 	mux := http.NewServeMux()
-	interceptor, sc := auth.NewInterceptor(auth.InterceptorOptions{Store: wrapped})
+	interceptor, sc := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: wrapped})
 	t.Cleanup(sc.Stop)
 	opts := connect.WithInterceptors(interceptor)
 	authSvc := service.NewAuthService(wrapped, testConfig(), auth.NewCredentialLifecycleEffects(sc, nil, nil), nil, mail.NewStubSender(), mail.Renderer{})
@@ -949,7 +949,7 @@ func TestSetupSignUp_RejectedInSoloMode(t *testing.T) {
 	// No solo user is seeded — the test asserts that AuthService rejects setup
 	// signup in solo mode at the service layer, independent of the interceptor.
 	mux := http.NewServeMux()
-	interceptor, sc := auth.NewInterceptor(auth.InterceptorOptions{Store: st})
+	interceptor, sc := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st})
 	t.Cleanup(sc.Stop)
 	opts := connect.WithInterceptors(interceptor)
 	authSvc := service.NewAuthService(st, cfg, auth.NewCredentialLifecycleEffects(sc, nil, nil), nil, mail.NewStubSender(), mail.Renderer{})

--- a/backend/internal/hub/service/channel_service_delegation_test.go
+++ b/backend/internal/hub/service/channel_service_delegation_test.go
@@ -54,10 +54,10 @@ func setupBearerChannelEnv(t *testing.T) *bearerChannelEnv {
 
 	wMgr := workermgr.New(service.NewWorkerReachAuthorizer(st))
 	cMgr := channelmgr.New(0)
-	pendingReqs := workermgr.NewPendingRequests(testConfig().APITimeout)
+	pendingReqs := workermgr.NewPendingRequests(func() time.Duration { return testConfig().APITimeout })
 
 	mux := http.NewServeMux()
-	interceptor, sc := auth.NewInterceptor(auth.InterceptorOptions{Store: st, TokenValidator: tv})
+	interceptor, sc := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st, TokenValidator: tv})
 	t.Cleanup(sc.Stop)
 	opts := connect.WithInterceptors(interceptor)
 

--- a/backend/internal/hub/service/channel_service_delegation_test.go
+++ b/backend/internal/hub/service/channel_service_delegation_test.go
@@ -57,7 +57,7 @@ func setupBearerChannelEnv(t *testing.T) *bearerChannelEnv {
 	pendingReqs := workermgr.NewPendingRequests(testConfig().APITimeout)
 
 	mux := http.NewServeMux()
-	interceptor, sc := auth.NewInterceptorWithTokens(st, nil, tv, false, false)
+	interceptor, sc := auth.NewInterceptor(auth.InterceptorOptions{Store: st, TokenValidator: tv})
 	t.Cleanup(sc.Stop)
 	opts := connect.WithInterceptors(interceptor)
 

--- a/backend/internal/hub/service/channel_service_test.go
+++ b/backend/internal/hub/service/channel_service_test.go
@@ -60,10 +60,10 @@ func setupChannelTestServer(t *testing.T) *channelTestEnv {
 	cfg := testConfig()
 	wMgr := workermgr.New(service.NewWorkerReachAuthorizer(st))
 	cMgr := channelmgr.New(0)
-	pendingReqs := workermgr.NewPendingRequests(cfg.APITimeout)
+	pendingReqs := workermgr.NewPendingRequests(func() time.Duration { return cfg.APITimeout })
 
 	mux := http.NewServeMux()
-	interceptor, sc := auth.NewInterceptor(auth.InterceptorOptions{Store: st})
+	interceptor, sc := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st})
 	t.Cleanup(sc.Stop)
 	opts := connect.WithInterceptors(interceptor)
 

--- a/backend/internal/hub/service/channel_service_test.go
+++ b/backend/internal/hub/service/channel_service_test.go
@@ -63,7 +63,7 @@ func setupChannelTestServer(t *testing.T) *channelTestEnv {
 	pendingReqs := workermgr.NewPendingRequests(cfg.APITimeout)
 
 	mux := http.NewServeMux()
-	interceptor, sc := auth.NewInterceptor(st, nil, false, false)
+	interceptor, sc := auth.NewInterceptor(auth.InterceptorOptions{Store: st})
 	t.Cleanup(sc.Stop)
 	opts := connect.WithInterceptors(interceptor)
 
@@ -1369,7 +1369,7 @@ func (e *channelTestEnv) createSecondUser(t *testing.T) (userID, token string) {
 		PasswordSet:  true,
 		IsAdmin:      false,
 	})
-	token, _, _, loginErr := auth.Login(ctx, e.store, "user2", "testpass2")
+	token, _, _, loginErr := auth.Login(ctx, e.store, "user2", "testpass2", auth.DefaultSessionDuration)
 	require.NoError(t, loginErr)
 	return
 }

--- a/backend/internal/hub/service/channel_teardown_test.go
+++ b/backend/internal/hub/service/channel_teardown_test.go
@@ -56,10 +56,10 @@ func setupTeardownEnv(t *testing.T) *teardownEnv {
 
 	wMgr := workermgr.New(service.NewWorkerReachAuthorizer(st))
 	cMgr := channelmgr.New(0)
-	pendingReqs := workermgr.NewPendingRequests(testConfig().APITimeout)
+	pendingReqs := workermgr.NewPendingRequests(func() time.Duration { return testConfig().APITimeout })
 
 	mux := http.NewServeMux()
-	_, sc := auth.NewInterceptor(auth.InterceptorOptions{Store: st, TokenValidator: tv})
+	_, sc := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st, TokenValidator: tv})
 	t.Cleanup(sc.Stop)
 
 	channelSvc := service.NewChannelService(st, wMgr, cMgr, pendingReqs, sc)

--- a/backend/internal/hub/service/channel_teardown_test.go
+++ b/backend/internal/hub/service/channel_teardown_test.go
@@ -59,7 +59,7 @@ func setupTeardownEnv(t *testing.T) *teardownEnv {
 	pendingReqs := workermgr.NewPendingRequests(testConfig().APITimeout)
 
 	mux := http.NewServeMux()
-	_, sc := auth.NewInterceptorWithTokens(st, nil, tv, false, false)
+	_, sc := auth.NewInterceptor(auth.InterceptorOptions{Store: st, TokenValidator: tv})
 	t.Cleanup(sc.Stop)
 
 	channelSvc := service.NewChannelService(st, wMgr, cMgr, pendingReqs, sc)

--- a/backend/internal/hub/service/local_socket_auth_test.go
+++ b/backend/internal/hub/service/local_socket_auth_test.go
@@ -87,7 +87,7 @@ func TestLocalSocket_MultiUser_RejectsUnauthenticated(t *testing.T) {
 	st := hubtestutil.OpenTestStore(t)
 	hubtestutil.CreateTestAdmin(t, st)
 
-	interceptor, _ := auth.NewInterceptor(auth.InterceptorOptions{Store: st})
+	interceptor, _ := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st})
 	client := newUnixSocketAuthClient(t, st, interceptor)
 
 	// No cookie, no bearer — multi-user hub on a unix socket must reject.
@@ -104,7 +104,7 @@ func TestLocalSocket_SoloMode_AutoAuths(t *testing.T) {
 	soloUser, err := auth.LoadSoloUser(context.Background(), st)
 	require.NoError(t, err)
 
-	interceptor, _ := auth.NewInterceptor(auth.InterceptorOptions{Store: st, SoloUser: soloUser})
+	interceptor, _ := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st, SoloUser: soloUser})
 	client := newUnixSocketAuthClient(t, st, interceptor)
 
 	resp, err := client.GetCurrentUser(context.Background(), connect.NewRequest(&leapmuxv1.GetCurrentUserRequest{}))
@@ -127,7 +127,7 @@ func TestLocalSocket_MultiUser_AcceptsBearer(t *testing.T) {
 	tv, err := auth.NewTokenValidator(st, pepper)
 	require.NoError(t, err)
 
-	interceptor, _ := auth.NewInterceptor(auth.InterceptorOptions{Store: st, TokenValidator: tv})
+	interceptor, _ := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st, TokenValidator: tv})
 	client := newUnixSocketAuthClient(t, st, interceptor)
 
 	u, err := st.Users().GetByUsername(context.Background(), "admin")
@@ -160,7 +160,7 @@ func TestLocalSocket_MultiUser_RejectsRevokedBearer(t *testing.T) {
 	tv, err := auth.NewTokenValidator(st, pepper)
 	require.NoError(t, err)
 
-	interceptor, _ := auth.NewInterceptor(auth.InterceptorOptions{Store: st, TokenValidator: tv})
+	interceptor, _ := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st, TokenValidator: tv})
 	client := newUnixSocketAuthClient(t, st, interceptor)
 
 	u, err := st.Users().GetByUsername(context.Background(), "admin")

--- a/backend/internal/hub/service/local_socket_auth_test.go
+++ b/backend/internal/hub/service/local_socket_auth_test.go
@@ -87,7 +87,7 @@ func TestLocalSocket_MultiUser_RejectsUnauthenticated(t *testing.T) {
 	st := hubtestutil.OpenTestStore(t)
 	hubtestutil.CreateTestAdmin(t, st)
 
-	interceptor, _ := auth.NewInterceptor(st, nil, false, false)
+	interceptor, _ := auth.NewInterceptor(auth.InterceptorOptions{Store: st})
 	client := newUnixSocketAuthClient(t, st, interceptor)
 
 	// No cookie, no bearer — multi-user hub on a unix socket must reject.
@@ -104,7 +104,7 @@ func TestLocalSocket_SoloMode_AutoAuths(t *testing.T) {
 	soloUser, err := auth.LoadSoloUser(context.Background(), st)
 	require.NoError(t, err)
 
-	interceptor, _ := auth.NewInterceptor(st, soloUser, false, false)
+	interceptor, _ := auth.NewInterceptor(auth.InterceptorOptions{Store: st, SoloUser: soloUser})
 	client := newUnixSocketAuthClient(t, st, interceptor)
 
 	resp, err := client.GetCurrentUser(context.Background(), connect.NewRequest(&leapmuxv1.GetCurrentUserRequest{}))
@@ -127,7 +127,7 @@ func TestLocalSocket_MultiUser_AcceptsBearer(t *testing.T) {
 	tv, err := auth.NewTokenValidator(st, pepper)
 	require.NoError(t, err)
 
-	interceptor, _ := auth.NewInterceptorWithTokens(st, nil, tv, false, false)
+	interceptor, _ := auth.NewInterceptor(auth.InterceptorOptions{Store: st, TokenValidator: tv})
 	client := newUnixSocketAuthClient(t, st, interceptor)
 
 	u, err := st.Users().GetByUsername(context.Background(), "admin")
@@ -160,7 +160,7 @@ func TestLocalSocket_MultiUser_RejectsRevokedBearer(t *testing.T) {
 	tv, err := auth.NewTokenValidator(st, pepper)
 	require.NoError(t, err)
 
-	interceptor, _ := auth.NewInterceptorWithTokens(st, nil, tv, false, false)
+	interceptor, _ := auth.NewInterceptor(auth.InterceptorOptions{Store: st, TokenValidator: tv})
 	client := newUnixSocketAuthClient(t, st, interceptor)
 
 	u, err := st.Users().GetByUsername(context.Background(), "admin")

--- a/backend/internal/hub/service/oauth_handler.go
+++ b/backend/internal/hub/service/oauth_handler.go
@@ -294,7 +294,7 @@ func (h *OAuthHandler) loginOAuthUser(w http.ResponseWriter, r *http.Request, us
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
-	sessionID, expiresAt, sessionErr := auth.CreateSession(ctx, h.store, loginUID, auth.SessionMeta{
+	sessionID, expiresAt, sessionErr := auth.CreateSession(ctx, h.store, loginUID, h.cfg.SessionDuration(), auth.SessionMeta{
 		UserAgent: r.UserAgent(),
 		IPAddress: r.RemoteAddr,
 	})

--- a/backend/internal/hub/service/oauth_handler.go
+++ b/backend/internal/hub/service/oauth_handler.go
@@ -182,7 +182,7 @@ func (h *OAuthHandler) handleCallback(w http.ResponseWriter, r *http.Request, pr
 	// hung IdP during NORMAL operation would otherwise park it for the process's
 	// life). This per-leg deadline bounds exactly that: a slow or wedged IdP
 	// while the hub is healthy.
-	exchangeCtx, cancelExchange := context.WithTimeout(ctx, h.cfg.APITimeout())
+	exchangeCtx, cancelExchange := context.WithTimeout(ctx, h.cfg.APITimeout)
 	defer cancelExchange()
 	tokenSet, claims, err := provider.Exchange(exchangeCtx, code, oauthState.PkceVerifier)
 	if err != nil {
@@ -294,7 +294,7 @@ func (h *OAuthHandler) loginOAuthUser(w http.ResponseWriter, r *http.Request, us
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
-	sessionID, expiresAt, sessionErr := auth.CreateSession(ctx, h.store, loginUID, h.cfg.SessionDuration(), auth.SessionMeta{
+	sessionID, expiresAt, sessionErr := auth.CreateSession(ctx, h.store, loginUID, h.cfg.SessionDuration, auth.SessionMeta{
 		UserAgent: r.UserAgent(),
 		IPAddress: r.RemoteAddr,
 	})

--- a/backend/internal/hub/service/oauth_handler_internal_test.go
+++ b/backend/internal/hub/service/oauth_handler_internal_test.go
@@ -71,7 +71,7 @@ func TestLoginOAuthUser_UsesConfiguredSessionDuration(t *testing.T) {
 	ks, err := keystore.New(map[uint32][32]byte{1: key})
 	require.NoError(t, err)
 
-	h := NewOAuthHandler(st, &config.Config{SessionDurationSeconds: int(configured / time.Second)}, ks)
+	h := NewOAuthHandler(st, &config.Config{SessionDuration: configured}, ks)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/auth/oauth/test/callback", nil)
@@ -84,7 +84,7 @@ func TestLoginOAuthUser_UsesConfiguredSessionDuration(t *testing.T) {
 	require.Equal(t, http.StatusFound, rec.Code)
 	parsed, err := http.ParseSetCookie(rec.Header().Get("Set-Cookie"))
 	require.NoError(t, err, "the callback must set a session cookie")
-	assert.WithinDuration(t, before.Add(configured), parsed.Expires, time.Minute)
+	hubtestutil.AssertSessionLifetime(t, before, configured, parsed.Expires)
 
 	sess, err := st.Sessions().GetByID(context.Background(), parsed.Value)
 	require.NoError(t, err)

--- a/backend/internal/hub/service/oauth_handler_internal_test.go
+++ b/backend/internal/hub/service/oauth_handler_internal_test.go
@@ -1,9 +1,21 @@
 package service
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/leapmux/leapmux/internal/hub/config"
+	"github.com/leapmux/leapmux/internal/hub/keystore"
+	huboauth "github.com/leapmux/leapmux/internal/hub/oauth"
+	"github.com/leapmux/leapmux/internal/hub/store"
+	hubtestutil "github.com/leapmux/leapmux/internal/hub/testutil"
+	"github.com/leapmux/leapmux/internal/util/id"
 )
 
 func TestSanitizeRedirectURI(t *testing.T) {
@@ -33,4 +45,49 @@ func TestSanitizeRedirectURI(t *testing.T) {
 			assert.Equal(t, tt.want, sanitizeRedirectURI(tt.uri))
 		})
 	}
+}
+
+// The OAuth callback logs an already-linked user in through its own
+// CreateSession call, which no RPC reaches: the exported route needs a real
+// token exchange with an identity provider. Calling the login step directly is
+// what keeps that fifth mint path from being the one left on the built-in
+// default while every other path follows the operator's setting.
+func TestLoginOAuthUser_UsesConfiguredSessionDuration(t *testing.T) {
+	t.Parallel()
+
+	const configured = 90 * time.Minute
+	st := hubtestutil.OpenTestStore(t)
+	userID := id.Generate()
+	require.NoError(t, st.Users().Create(context.Background(), store.CreateUserParams{
+		ID:           userID,
+		Username:     "oauthuser",
+		PasswordHash: "hash",
+		DisplayName:  "OAuth User",
+		Email:        "oauth@example.com",
+	}))
+
+	key, err := keystore.GenerateKey()
+	require.NoError(t, err)
+	ks, err := keystore.New(map[uint32][32]byte{1: key})
+	require.NoError(t, err)
+
+	h := NewOAuthHandler(st, &config.Config{SessionDurationSeconds: int(configured / time.Second)}, ks)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/auth/oauth/test/callback", nil)
+	before := time.Now()
+	h.loginOAuthUser(rec, req, userID, "", &huboauth.TokenSet{
+		AccessToken: "access", RefreshToken: "refresh", TokenType: "bearer",
+		ExpiresAt: time.Now().Add(time.Hour),
+	}, "")
+
+	require.Equal(t, http.StatusFound, rec.Code)
+	parsed, err := http.ParseSetCookie(rec.Header().Get("Set-Cookie"))
+	require.NoError(t, err, "the callback must set a session cookie")
+	assert.WithinDuration(t, before.Add(configured), parsed.Expires, time.Minute)
+
+	sess, err := st.Sessions().GetByID(context.Background(), parsed.Value)
+	require.NoError(t, err)
+	assert.WithinDuration(t, sess.ExpiresAt, parsed.Expires, time.Second,
+		"the cookie and the row must carry the same deadline")
 }

--- a/backend/internal/hub/service/oauth_handler_test.go
+++ b/backend/internal/hub/service/oauth_handler_test.go
@@ -335,7 +335,7 @@ func setupOAuthTestServerWithAuthService(t *testing.T) (
 	oauthHandler.RegisterRoutes(mux)
 
 	// Register AuthService ConnectRPC routes.
-	interceptor, _ := auth.NewInterceptor(auth.InterceptorOptions{Store: st})
+	interceptor, _ := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st})
 	opts := connect.WithInterceptors(interceptor)
 	authSvc := service.NewAuthService(st, cfg, auth.NewCredentialLifecycleEffects(nil, nil, nil), ks, mail.NewStubSender(), mail.Renderer{})
 	path, handler := leapmuxv1connect.NewAuthServiceHandler(authSvc, opts)
@@ -467,7 +467,7 @@ func TestCompleteOAuthSignup_UsesConfiguredSessionDuration(t *testing.T) {
 
 	const configured = 90 * time.Minute
 	_, client, st, ks, cfg := setupOAuthTestServerWithAuthService(t)
-	cfg.SessionDurationSeconds = int(configured / time.Second)
+	cfg.SessionDuration = configured
 	providerID := createTestProvider(t, st, ks)
 	signupToken := id.Generate()
 
@@ -484,7 +484,7 @@ func TestCompleteOAuthSignup_UsesConfiguredSessionDuration(t *testing.T) {
 	sessionID := sessionFromCookie(t, resp.Header().Get("Set-Cookie"))
 	sess, err := st.Sessions().GetByID(context.Background(), sessionID)
 	require.NoError(t, err)
-	assert.WithinDuration(t, before.Add(configured), sess.ExpiresAt, time.Minute)
+	hubtestutil.AssertSessionLifetime(t, before, configured, sess.ExpiresAt)
 }
 
 func TestCompleteOAuthSignup_UsesProviderEmail_IgnoresRequestEmail(t *testing.T) {

--- a/backend/internal/hub/service/oauth_handler_test.go
+++ b/backend/internal/hub/service/oauth_handler_test.go
@@ -335,7 +335,7 @@ func setupOAuthTestServerWithAuthService(t *testing.T) (
 	oauthHandler.RegisterRoutes(mux)
 
 	// Register AuthService ConnectRPC routes.
-	interceptor, _ := auth.NewInterceptor(st, nil, false, false)
+	interceptor, _ := auth.NewInterceptor(auth.InterceptorOptions{Store: st})
 	opts := connect.WithInterceptors(interceptor)
 	authSvc := service.NewAuthService(st, cfg, auth.NewCredentialLifecycleEffects(nil, nil, nil), ks, mail.NewStubSender(), mail.Renderer{})
 	path, handler := leapmuxv1connect.NewAuthServiceHandler(authSvc, opts)
@@ -456,6 +456,35 @@ func TestCompleteOAuthSignup_Success(t *testing.T) {
 	// Verify pending signup was consumed.
 	_, err = st.PendingOAuthSignups().Get(context.Background(), signupToken)
 	require.Error(t, err)
+}
+
+// The OAuth sign-up mints its own session, so it must stamp the configured
+// duration like every other mint path. Its own CreateSession call is the one
+// that would otherwise leave OAuth users on the built-in default while password
+// users follow the operator's setting.
+func TestCompleteOAuthSignup_UsesConfiguredSessionDuration(t *testing.T) {
+	t.Parallel()
+
+	const configured = 90 * time.Minute
+	_, client, st, ks, cfg := setupOAuthTestServerWithAuthService(t)
+	cfg.SessionDurationSeconds = int(configured / time.Second)
+	providerID := createTestProvider(t, st, ks)
+	signupToken := id.Generate()
+
+	insertPendingSignup(t, st, ks, providerID, signupToken, "dana@example.com", "Dana", "sub-dana", time.Now().Add(5*time.Minute).UTC())
+
+	before := time.Now()
+	resp, err := client.CompleteOAuthSignup(context.Background(), connect.NewRequest(&leapmuxv1.CompleteOAuthSignupRequest{
+		SignupToken: signupToken,
+		Username:    "danauser",
+		DisplayName: "Dana User",
+	}))
+	require.NoError(t, err)
+
+	sessionID := sessionFromCookie(t, resp.Header().Get("Set-Cookie"))
+	sess, err := st.Sessions().GetByID(context.Background(), sessionID)
+	require.NoError(t, err)
+	assert.WithinDuration(t, before.Add(configured), sess.ExpiresAt, time.Minute)
 }
 
 func TestCompleteOAuthSignup_UsesProviderEmail_IgnoresRequestEmail(t *testing.T) {

--- a/backend/internal/hub/service/section_service_test.go
+++ b/backend/internal/hub/service/section_service_test.go
@@ -45,7 +45,7 @@ func setupSectionTest(t *testing.T) *sectionTestEnv {
 	sectionSvc := service.NewSectionService(st)
 
 	mux := http.NewServeMux()
-	interceptor, _ := auth.NewInterceptor(st, nil, false, false)
+	interceptor, _ := auth.NewInterceptor(auth.InterceptorOptions{Store: st})
 	opts := connect.WithInterceptors(interceptor)
 	path, handler := leapmuxv1connect.NewSectionServiceHandler(sectionSvc, opts)
 	mux.Handle(path, handler)
@@ -77,7 +77,7 @@ func setupSectionTest(t *testing.T) *sectionTestEnv {
 	require.NoError(t, err)
 	userID := user.ID
 
-	token, _, _, err := auth.Login(context.Background(), st, "testuser", "testpass")
+	token, _, _, err := auth.Login(context.Background(), st, "testuser", "testpass", auth.DefaultSessionDuration)
 	require.NoError(t, err)
 
 	return &sectionTestEnv{

--- a/backend/internal/hub/service/section_service_test.go
+++ b/backend/internal/hub/service/section_service_test.go
@@ -17,6 +17,7 @@ import (
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/generated/proto/leapmux/v1/leapmuxv1connect"
 	"github.com/leapmux/leapmux/internal/hub/auth"
+	hubtestutil "github.com/leapmux/leapmux/internal/hub/testutil"
 
 	"github.com/leapmux/leapmux/internal/hub/service"
 	"github.com/leapmux/leapmux/internal/hub/store"
@@ -45,7 +46,7 @@ func setupSectionTest(t *testing.T) *sectionTestEnv {
 	sectionSvc := service.NewSectionService(st)
 
 	mux := http.NewServeMux()
-	interceptor, _ := auth.NewInterceptor(auth.InterceptorOptions{Store: st})
+	interceptor, _ := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st})
 	opts := connect.WithInterceptors(interceptor)
 	path, handler := leapmuxv1connect.NewSectionServiceHandler(sectionSvc, opts)
 	mux.Handle(path, handler)
@@ -204,7 +205,7 @@ func TestSectionService_ListSections_NeverWrites(t *testing.T) {
 		DisplayName:  "Unseeded",
 		PasswordSet:  true,
 	}))
-	bareToken, _, _, err := auth.Login(ctx, env.store, "unseeded", "testpass")
+	bareToken, _, _, err := auth.Login(ctx, env.store, "unseeded", "testpass", auth.DefaultSessionDuration)
 	require.NoError(t, err)
 	userID := userid.MustNew(bareID)
 

--- a/backend/internal/hub/service/test_helpers_test.go
+++ b/backend/internal/hub/service/test_helpers_test.go
@@ -26,9 +26,9 @@ func sessionFromCookie(t *testing.T, setCookie string) string {
 
 func testConfig() *config.Config {
 	return &config.Config{
-		APITimeoutSeconds:            config.DefaultAPITimeoutSeconds,
-		AgentStartupTimeoutSeconds:   config.DefaultAgentStartupTimeoutSeconds,
-		WorktreeCreateTimeoutSeconds: config.DefaultWorktreeCreateTimeoutSeconds,
+		APITimeout:            config.DefaultAPITimeout,
+		AgentStartupTimeout:   config.DefaultAgentStartupTimeout,
+		WorktreeCreateTimeout: config.DefaultWorktreeCreateTimeout,
 	}
 }
 

--- a/backend/internal/hub/service/user_service.go
+++ b/backend/internal/hub/service/user_service.go
@@ -533,9 +533,9 @@ func (s *UserService) GetTimeouts(ctx context.Context, req *connect.Request[leap
 	}
 
 	return connect.NewResponse(&leapmuxv1.GetTimeoutsResponse{
-		ApiTimeoutSeconds:            int32(s.cfg.APITimeout().Seconds()),
-		AgentStartupTimeoutSeconds:   int32(s.cfg.AgentStartupTimeout().Seconds()),
-		WorktreeCreateTimeoutSeconds: int32(s.cfg.WorktreeCreateTimeout().Seconds()),
+		ApiTimeoutSeconds:            int32(s.cfg.APITimeout.Seconds()),
+		AgentStartupTimeoutSeconds:   int32(s.cfg.AgentStartupTimeout.Seconds()),
+		WorktreeCreateTimeoutSeconds: int32(s.cfg.WorktreeCreateTimeout.Seconds()),
 	}), nil
 }
 

--- a/backend/internal/hub/service/user_service_test.go
+++ b/backend/internal/hub/service/user_service_test.go
@@ -48,7 +48,7 @@ func setupUserTest(t *testing.T) *userTestEnv {
 	require.NoError(t, err)
 
 	mux := http.NewServeMux()
-	interceptor, contexts := auth.NewInterceptor(auth.InterceptorOptions{Store: st})
+	interceptor, contexts := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st})
 	t.Cleanup(contexts.Stop)
 	userSvc := service.NewUserService(st, testConfig(), auth.NewCredentialLifecycleEffects(contexts, nil, nil), mail.NewStubSender(), mail.Renderer{})
 	opts := connect.WithInterceptors(interceptor)
@@ -103,7 +103,7 @@ func setupOAuthUserTest(t *testing.T) *userTestEnv {
 	userSvc := service.NewUserService(st, testConfig(), auth.NewCredentialLifecycleEffects(nil, nil, nil), mail.NewStubSender(), mail.Renderer{})
 
 	mux := http.NewServeMux()
-	interceptor, contexts := auth.NewInterceptor(auth.InterceptorOptions{Store: st})
+	interceptor, contexts := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st})
 	t.Cleanup(contexts.Stop)
 	opts := connect.WithInterceptors(interceptor)
 	path, handler := leapmuxv1connect.NewUserServiceHandler(userSvc, opts)
@@ -566,7 +566,7 @@ func setupVerificationUserTestServer(t *testing.T, emailVerificationRequired boo
 	hubtestutil.CreateTestAdmin(t, st)
 
 	mux := http.NewServeMux()
-	interceptor, contexts := auth.NewInterceptor(auth.InterceptorOptions{Store: st, EmailVerificationRequired: true})
+	interceptor, contexts := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st, EmailVerificationRequired: true})
 	t.Cleanup(contexts.Stop)
 	opts := connect.WithInterceptors(interceptor)
 
@@ -835,7 +835,7 @@ func setupResendUserTest(t *testing.T) (*userTestEnv, *recordingSender) {
 	userSvc := service.NewUserService(st, testConfig(), auth.NewCredentialLifecycleEffects(nil, nil, nil), rec, mail.Renderer{})
 
 	mux := http.NewServeMux()
-	interceptor, contexts := auth.NewInterceptor(auth.InterceptorOptions{Store: st})
+	interceptor, contexts := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st})
 	t.Cleanup(contexts.Stop)
 	opts := connect.WithInterceptors(interceptor)
 	path, handler := leapmuxv1connect.NewUserServiceHandler(userSvc, opts)
@@ -1110,7 +1110,7 @@ func TestChangePassword_ToleratesConcurrentActingSessionDeletion(t *testing.T) {
 	}}
 
 	mux := http.NewServeMux()
-	interceptor, contexts := auth.NewInterceptor(auth.InterceptorOptions{Store: st})
+	interceptor, contexts := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st})
 	t.Cleanup(contexts.Stop)
 	userSvc := service.NewUserService(hooked, testConfig(), auth.NewCredentialLifecycleEffects(contexts, nil, nil), mail.NewStubSender(), mail.Renderer{})
 	path, handler := leapmuxv1connect.NewUserServiceHandler(userSvc, connect.WithInterceptors(interceptor))

--- a/backend/internal/hub/service/user_service_test.go
+++ b/backend/internal/hub/service/user_service_test.go
@@ -48,7 +48,7 @@ func setupUserTest(t *testing.T) *userTestEnv {
 	require.NoError(t, err)
 
 	mux := http.NewServeMux()
-	interceptor, contexts := auth.NewInterceptor(st, nil, false, false)
+	interceptor, contexts := auth.NewInterceptor(auth.InterceptorOptions{Store: st})
 	t.Cleanup(contexts.Stop)
 	userSvc := service.NewUserService(st, testConfig(), auth.NewCredentialLifecycleEffects(contexts, nil, nil), mail.NewStubSender(), mail.Renderer{})
 	opts := connect.WithInterceptors(interceptor)
@@ -78,7 +78,7 @@ func setupUserTest(t *testing.T) *userTestEnv {
 		IsAdmin:      true,
 	})
 
-	token, _, _, err := auth.Login(context.Background(), st, "testuser", "testpass")
+	token, _, _, err := auth.Login(context.Background(), st, "testuser", "testpass", auth.DefaultSessionDuration)
 	require.NoError(t, err)
 
 	return &userTestEnv{
@@ -103,7 +103,7 @@ func setupOAuthUserTest(t *testing.T) *userTestEnv {
 	userSvc := service.NewUserService(st, testConfig(), auth.NewCredentialLifecycleEffects(nil, nil, nil), mail.NewStubSender(), mail.Renderer{})
 
 	mux := http.NewServeMux()
-	interceptor, contexts := auth.NewInterceptor(st, nil, false, false)
+	interceptor, contexts := auth.NewInterceptor(auth.InterceptorOptions{Store: st})
 	t.Cleanup(contexts.Stop)
 	opts := connect.WithInterceptors(interceptor)
 	path, handler := leapmuxv1connect.NewUserServiceHandler(userSvc, opts)
@@ -132,7 +132,7 @@ func setupOAuthUserTest(t *testing.T) *userTestEnv {
 		IsAdmin:      true,
 	})
 
-	token, _, _, err := auth.Login(context.Background(), st, "testuser", "testpass")
+	token, _, _, err := auth.Login(context.Background(), st, "testuser", "testpass", auth.DefaultSessionDuration)
 	require.NoError(t, err)
 
 	return &userTestEnv{
@@ -225,11 +225,11 @@ func TestUserService_ChangePassword(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify login works with new password.
-	_, _, _, err = auth.Login(context.Background(), env.store, "testuser", "newpass123")
+	_, _, _, err = auth.Login(context.Background(), env.store, "testuser", "newpass123", auth.DefaultSessionDuration)
 	assert.NoError(t, err)
 
 	// Verify login with old password fails.
-	_, _, _, err = auth.Login(context.Background(), env.store, "testuser", "testpass")
+	_, _, _, err = auth.Login(context.Background(), env.store, "testuser", "testpass", auth.DefaultSessionDuration)
 	require.Error(t, err)
 }
 
@@ -500,7 +500,7 @@ func TestRequestEmailChange_NonAdmin_VerificationNotRequired_LandsUnverified(t *
 		ID:            userID,
 	}))
 
-	userToken, _, _, err := auth.Login(context.Background(), st, "plainuser", "userpass")
+	userToken, _, _, err := auth.Login(context.Background(), st, "plainuser", "userpass", auth.DefaultSessionDuration)
 	require.NoError(t, err)
 
 	resp, err := client.RequestEmailChange(context.Background(), authedReq(&leapmuxv1.RequestEmailChangeRequest{
@@ -566,7 +566,7 @@ func setupVerificationUserTestServer(t *testing.T, emailVerificationRequired boo
 	hubtestutil.CreateTestAdmin(t, st)
 
 	mux := http.NewServeMux()
-	interceptor, contexts := auth.NewInterceptor(st, nil, false, true)
+	interceptor, contexts := auth.NewInterceptor(auth.InterceptorOptions{Store: st, EmailVerificationRequired: true})
 	t.Cleanup(contexts.Stop)
 	opts := connect.WithInterceptors(interceptor)
 
@@ -583,7 +583,7 @@ func setupVerificationUserTestServer(t *testing.T, emailVerificationRequired boo
 	client := leapmuxv1connect.NewUserServiceClient(server.Client(), server.URL)
 
 	// Log in as admin (bootstrap user).
-	token, _, _, err := auth.Login(context.Background(), st, "admin", "admin123")
+	token, _, _, err := auth.Login(context.Background(), st, "admin", "admin123", auth.DefaultSessionDuration)
 	require.NoError(t, err)
 
 	return client, st, token
@@ -616,7 +616,7 @@ func TestRequestEmailChange_ConfigOn_PendingEmail(t *testing.T) {
 	require.NoError(t, err)
 
 	// Log in as the non-admin user.
-	userToken, _, _, err := auth.Login(context.Background(), st, "verifyuser", "userpass")
+	userToken, _, _, err := auth.Login(context.Background(), st, "verifyuser", "userpass", auth.DefaultSessionDuration)
 	require.NoError(t, err)
 
 	// Request email change.
@@ -835,7 +835,7 @@ func setupResendUserTest(t *testing.T) (*userTestEnv, *recordingSender) {
 	userSvc := service.NewUserService(st, testConfig(), auth.NewCredentialLifecycleEffects(nil, nil, nil), rec, mail.Renderer{})
 
 	mux := http.NewServeMux()
-	interceptor, contexts := auth.NewInterceptor(st, nil, false, false)
+	interceptor, contexts := auth.NewInterceptor(auth.InterceptorOptions{Store: st})
 	t.Cleanup(contexts.Stop)
 	opts := connect.WithInterceptors(interceptor)
 	path, handler := leapmuxv1connect.NewUserServiceHandler(userSvc, opts)
@@ -854,7 +854,7 @@ func setupResendUserTest(t *testing.T) (*userTestEnv, *recordingSender) {
 		ID: userID, Username: "resender", PasswordHash: hash,
 		DisplayName: "Resender", PasswordSet: true,
 	})
-	token, _, _, err := auth.Login(context.Background(), st, "resender", "testpass")
+	token, _, _, err := auth.Login(context.Background(), st, "resender", "testpass", auth.DefaultSessionDuration)
 	require.NoError(t, err)
 
 	return &userTestEnv{client: client, store: st, token: token, userID: userID}, rec
@@ -1014,7 +1014,7 @@ func TestVerifyEmail_CrossUser_NoOracle(t *testing.T) {
 		PendingEmailExpiresAt: ptrTime(time.Now().Add(1 * time.Hour).UTC()),
 		ID:                    attackerID,
 	}))
-	attackerToken, _, _, err := auth.Login(context.Background(), env.store, "attacker", "testpass2")
+	attackerToken, _, _, err := auth.Login(context.Background(), env.store, "attacker", "testpass2", auth.DefaultSessionDuration)
 	require.NoError(t, err)
 
 	_, err = env.client.VerifyEmail(context.Background(), authedReq(&leapmuxv1.VerifyEmailRequest{
@@ -1031,7 +1031,7 @@ func TestChangePassword_InvalidatesOtherSessions(t *testing.T) {
 	env := setupUserTest(t)
 
 	// Create a second session for the same user (simulates another device).
-	otherSession, _, err := auth.CreateSession(context.Background(), env.store, userid.MustNew(env.userID))
+	otherSession, _, err := auth.CreateSession(context.Background(), env.store, userid.MustNew(env.userID), auth.DefaultSessionDuration)
 	require.NoError(t, err)
 
 	// Verify both sessions are valid.
@@ -1093,7 +1093,7 @@ func TestChangePassword_ToleratesConcurrentActingSessionDeletion(t *testing.T) {
 		DisplayName: "Test User", PasswordSet: true,
 	}))
 
-	token, _, _, err := auth.Login(ctx, st, "testuser", "testpass")
+	token, _, _, err := auth.Login(ctx, st, "testuser", "testpass", auth.DefaultSessionDuration)
 	require.NoError(t, err)
 	userInfo, err := auth.ValidateToken(ctx, st, token)
 	require.NoError(t, err)
@@ -1110,7 +1110,7 @@ func TestChangePassword_ToleratesConcurrentActingSessionDeletion(t *testing.T) {
 	}}
 
 	mux := http.NewServeMux()
-	interceptor, contexts := auth.NewInterceptor(st, nil, false, false)
+	interceptor, contexts := auth.NewInterceptor(auth.InterceptorOptions{Store: st})
 	t.Cleanup(contexts.Stop)
 	userSvc := service.NewUserService(hooked, testConfig(), auth.NewCredentialLifecycleEffects(contexts, nil, nil), mail.NewStubSender(), mail.Renderer{})
 	path, handler := leapmuxv1connect.NewUserServiceHandler(userSvc, connect.WithInterceptors(interceptor))
@@ -1131,9 +1131,9 @@ func TestChangePassword_ToleratesConcurrentActingSessionDeletion(t *testing.T) {
 
 	// The password actually changed: the old one no longer authenticates and the
 	// new one does.
-	_, _, _, err = auth.Login(ctx, st, "testuser", "testpass")
+	_, _, _, err = auth.Login(ctx, st, "testuser", "testpass", auth.DefaultSessionDuration)
 	require.Error(t, err, "old password must be rejected after the change")
-	_, _, _, err = auth.Login(ctx, st, "testuser", "newpass123")
+	_, _, _, err = auth.Login(ctx, st, "testuser", "newpass123", auth.DefaultSessionDuration)
 	require.NoError(t, err, "new password must authenticate after the change")
 }
 
@@ -1157,7 +1157,7 @@ func TestChangePassword_OAuthUser_CanSetWithoutCurrentPassword(t *testing.T) {
 	assert.True(t, user.PasswordSet)
 
 	// Verify the new password works via login.
-	_, _, _, err = auth.Login(context.Background(), env.store, "testuser", "newpass123")
+	_, _, _, err = auth.Login(context.Background(), env.store, "testuser", "newpass123", auth.DefaultSessionDuration)
 	require.NoError(t, err)
 }
 

--- a/backend/internal/hub/service/worker_delegation_handler_test.go
+++ b/backend/internal/hub/service/worker_delegation_handler_test.go
@@ -83,7 +83,7 @@ func setupDelegation(t *testing.T) *delegationEnv {
 	pepper := []byte("0123456789abcdef0123456789abcdef")
 	tv, err := auth.NewTokenValidator(st, pepper)
 	require.NoError(t, err)
-	_, sc := auth.NewInterceptor(auth.InterceptorOptions{Store: st})
+	_, sc := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st})
 	t.Cleanup(sc.Stop)
 
 	mux := http.NewServeMux()

--- a/backend/internal/hub/service/worker_delegation_handler_test.go
+++ b/backend/internal/hub/service/worker_delegation_handler_test.go
@@ -83,7 +83,7 @@ func setupDelegation(t *testing.T) *delegationEnv {
 	pepper := []byte("0123456789abcdef0123456789abcdef")
 	tv, err := auth.NewTokenValidator(st, pepper)
 	require.NoError(t, err)
-	_, sc := auth.NewInterceptor(st, nil, false, false)
+	_, sc := auth.NewInterceptor(auth.InterceptorOptions{Store: st})
 	t.Cleanup(sc.Stop)
 
 	mux := http.NewServeMux()

--- a/backend/internal/hub/service/worker_reconciler_service_test.go
+++ b/backend/internal/hub/service/worker_reconciler_service_test.go
@@ -107,7 +107,7 @@ func TestListOwnedTabsForWorker_ReachableThroughTheAuthInterceptor(t *testing.T)
 		TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabID: "agent-live", TileID: "tile", Position: "a0",
 	}))
 
-	interceptor, _ := auth.NewInterceptor(st, nil, false, false)
+	interceptor, _ := auth.NewInterceptor(auth.InterceptorOptions{Store: st})
 	mux := http.NewServeMux()
 	path, handler := leapmuxv1connect.NewWorkerReconcilerServiceHandler(
 		service.NewWorkerReconcilerService(st), connect.WithInterceptors(interceptor))
@@ -136,7 +136,7 @@ func TestListOwnedTabsForWorker_InterceptorStillRejectsAStranger(t *testing.T) {
 
 	st := hubtestutil.OpenTestStore(t)
 
-	interceptor, _ := auth.NewInterceptor(st, nil, false, false)
+	interceptor, _ := auth.NewInterceptor(auth.InterceptorOptions{Store: st})
 	mux := http.NewServeMux()
 	path, handler := leapmuxv1connect.NewWorkerReconcilerServiceHandler(
 		service.NewWorkerReconcilerService(st), connect.WithInterceptors(interceptor))

--- a/backend/internal/hub/service/worker_reconciler_service_test.go
+++ b/backend/internal/hub/service/worker_reconciler_service_test.go
@@ -107,7 +107,7 @@ func TestListOwnedTabsForWorker_ReachableThroughTheAuthInterceptor(t *testing.T)
 		TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabID: "agent-live", TileID: "tile", Position: "a0",
 	}))
 
-	interceptor, _ := auth.NewInterceptor(auth.InterceptorOptions{Store: st})
+	interceptor, _ := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st})
 	mux := http.NewServeMux()
 	path, handler := leapmuxv1connect.NewWorkerReconcilerServiceHandler(
 		service.NewWorkerReconcilerService(st), connect.WithInterceptors(interceptor))
@@ -136,7 +136,7 @@ func TestListOwnedTabsForWorker_InterceptorStillRejectsAStranger(t *testing.T) {
 
 	st := hubtestutil.OpenTestStore(t)
 
-	interceptor, _ := auth.NewInterceptor(auth.InterceptorOptions{Store: st})
+	interceptor, _ := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st})
 	mux := http.NewServeMux()
 	path, handler := leapmuxv1connect.NewWorkerReconcilerServiceHandler(
 		service.NewWorkerReconcilerService(st), connect.WithInterceptors(interceptor))

--- a/backend/internal/hub/service/worker_registration_test.go
+++ b/backend/internal/hub/service/worker_registration_test.go
@@ -91,7 +91,7 @@ func setupRegKeyEnvWithCfg(t *testing.T, cfg *config.Config) *regKeyEnv {
 	pendingReqs := workermgr.NewPendingRequests(cfg.APITimeout)
 
 	mux := http.NewServeMux()
-	interceptor, sc := auth.NewInterceptor(st, nil, false, false)
+	interceptor, sc := auth.NewInterceptor(auth.InterceptorOptions{Store: st})
 	t.Cleanup(sc.Stop)
 	opts := connect.WithInterceptors(interceptor)
 

--- a/backend/internal/hub/service/worker_registration_test.go
+++ b/backend/internal/hub/service/worker_registration_test.go
@@ -88,10 +88,10 @@ func setupRegKeyEnvWithCfg(t *testing.T, cfg *config.Config) *regKeyEnv {
 
 	wMgr := workermgr.New(service.NewWorkerReachAuthorizer(st))
 	cMgr := channelmgr.New(0)
-	pendingReqs := workermgr.NewPendingRequests(cfg.APITimeout)
+	pendingReqs := workermgr.NewPendingRequests(func() time.Duration { return cfg.APITimeout })
 
 	mux := http.NewServeMux()
-	interceptor, sc := auth.NewInterceptor(auth.InterceptorOptions{Store: st})
+	interceptor, sc := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st})
 	t.Cleanup(sc.Stop)
 	opts := connect.WithInterceptors(interceptor)
 

--- a/backend/internal/hub/service/ws_channel_relay_test.go
+++ b/backend/internal/hub/service/ws_channel_relay_test.go
@@ -32,7 +32,7 @@ import (
 
 func newTestAuthContexts(t *testing.T) *auth.AuthContextRegistry {
 	t.Helper()
-	_, registry := auth.NewInterceptor(auth.InterceptorOptions{})
+	_, registry := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{})
 	t.Cleanup(registry.Stop)
 	return registry
 }
@@ -426,7 +426,7 @@ func TestChannelRelay_BearerRevocationClosesLiveConnection(t *testing.T) {
 	hubtestutil.CreateTestAdmin(t, st)
 	tv, err := auth.NewTokenValidator(st, []byte("0123456789abcdef0123456789abcdef"))
 	require.NoError(t, err)
-	_, cache := auth.NewInterceptor(auth.InterceptorOptions{Store: st, TokenValidator: tv})
+	_, cache := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st, TokenValidator: tv})
 	t.Cleanup(cache.Stop)
 
 	cm := channelmgr.New(0)

--- a/backend/internal/hub/service/ws_channel_relay_test.go
+++ b/backend/internal/hub/service/ws_channel_relay_test.go
@@ -32,7 +32,7 @@ import (
 
 func newTestAuthContexts(t *testing.T) *auth.AuthContextRegistry {
 	t.Helper()
-	_, registry := auth.NewInterceptor(nil, nil, false, false)
+	_, registry := auth.NewInterceptor(auth.InterceptorOptions{})
 	t.Cleanup(registry.Stop)
 	return registry
 }
@@ -426,7 +426,7 @@ func TestChannelRelay_BearerRevocationClosesLiveConnection(t *testing.T) {
 	hubtestutil.CreateTestAdmin(t, st)
 	tv, err := auth.NewTokenValidator(st, []byte("0123456789abcdef0123456789abcdef"))
 	require.NoError(t, err)
-	_, cache := auth.NewInterceptorWithTokens(st, nil, tv, false, false)
+	_, cache := auth.NewInterceptor(auth.InterceptorOptions{Store: st, TokenValidator: tv})
 	t.Cleanup(cache.Stop)
 
 	cm := channelmgr.New(0)

--- a/backend/internal/hub/service/ws_userevents_test.go
+++ b/backend/internal/hub/service/ws_userevents_test.go
@@ -72,7 +72,7 @@ func newDelegationBearer(t *testing.T, st store.Store, userID string) delegation
 
 	tv, err := auth.NewTokenValidator(st, []byte("0123456789abcdef0123456789abcdef"))
 	require.NoError(t, err)
-	_, sessionCache := auth.NewInterceptor(auth.InterceptorOptions{Store: st, TokenValidator: tv})
+	_, sessionCache := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st, TokenValidator: tv})
 	t.Cleanup(sessionCache.Stop)
 
 	tokenID := id.Generate()

--- a/backend/internal/hub/service/ws_userevents_test.go
+++ b/backend/internal/hub/service/ws_userevents_test.go
@@ -72,7 +72,7 @@ func newDelegationBearer(t *testing.T, st store.Store, userID string) delegation
 
 	tv, err := auth.NewTokenValidator(st, []byte("0123456789abcdef0123456789abcdef"))
 	require.NoError(t, err)
-	_, sessionCache := auth.NewInterceptorWithTokens(st, nil, tv, false, false)
+	_, sessionCache := auth.NewInterceptor(auth.InterceptorOptions{Store: st, TokenValidator: tv})
 	t.Cleanup(sessionCache.Stop)
 
 	tokenID := id.Generate()

--- a/backend/internal/hub/store/mysql/db/queries/user_sessions.sql
+++ b/backend/internal/hub/store/mysql/db/queries/user_sessions.sql
@@ -14,10 +14,14 @@ INSERT INTO user_sessions (
 SELECT * FROM user_sessions WHERE id = ? AND expires_at > NOW(3);
 
 -- name: TouchUserSession :execrows
+-- The expires_at predicate is what keeps an expired session dead. The Hub
+-- serves a validated session from an in-memory cache for a short window, so a
+-- request can reach this UPDATE after the row expired; without the predicate
+-- that request would slide a dead session forward and revive it.
 UPDATE user_sessions
 SET last_active_at = NOW(3),
     expires_at = ?
-WHERE id = ? AND last_active_at < ?;
+WHERE id = ? AND last_active_at < ? AND expires_at > NOW(3);
 
 -- name: GetUserSessionForUpdate :one
 SELECT id, user_id FROM user_sessions

--- a/backend/internal/hub/store/mysql/mysql.go
+++ b/backend/internal/hub/store/mysql/mysql.go
@@ -58,11 +58,11 @@ func Open(cfg config.MySQLConfig) (store.Store, error) {
 	if cfg.MaxIdleConns > 0 {
 		sqlDB.SetMaxIdleConns(cfg.MaxIdleConns)
 	}
-	if cfg.ConnMaxLifetimeSeconds > 0 {
-		sqlDB.SetConnMaxLifetime(time.Duration(cfg.ConnMaxLifetimeSeconds) * time.Second)
+	if cfg.ConnMaxLifetime > 0 {
+		sqlDB.SetConnMaxLifetime(cfg.ConnMaxLifetime)
 	}
-	if cfg.ConnMaxIdleTimeSeconds > 0 {
-		sqlDB.SetConnMaxIdleTime(time.Duration(cfg.ConnMaxIdleTimeSeconds) * time.Second)
+	if cfg.ConnMaxIdleTime > 0 {
+		sqlDB.SetConnMaxIdleTime(cfg.ConnMaxIdleTime)
 	}
 
 	if err := sqlDB.Ping(); err != nil {

--- a/backend/internal/hub/store/postgres/db/queries/user_sessions.sql
+++ b/backend/internal/hub/store/postgres/db/queries/user_sessions.sql
@@ -14,10 +14,14 @@ INSERT INTO user_sessions (
 SELECT * FROM user_sessions WHERE id = $1 AND expires_at > NOW();
 
 -- name: TouchUserSession :execrows
+-- The expires_at predicate is what keeps an expired session dead. The Hub
+-- serves a validated session from an in-memory cache for a short window, so a
+-- request can reach this UPDATE after the row expired; without the predicate
+-- that request would slide a dead session forward and revive it.
 UPDATE user_sessions
 SET last_active_at = NOW(),
     expires_at = $1
-WHERE id = $2 AND last_active_at < $3;
+WHERE id = $2 AND last_active_at < $3 AND expires_at > NOW();
 
 -- name: DeleteUserSession :one
 DELETE FROM user_sessions WHERE id = $1 RETURNING id, user_id;

--- a/backend/internal/hub/store/postgres/postgres.go
+++ b/backend/internal/hub/store/postgres/postgres.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -52,14 +51,14 @@ func Open(ctx context.Context, cfg config.PostgresConfig) (store.Store, error) {
 	if cfg.MinConns > 0 {
 		poolCfg.MinConns = int32(cfg.MinConns)
 	}
-	if cfg.ConnMaxLifetimeSeconds > 0 {
-		poolCfg.MaxConnLifetime = time.Duration(cfg.ConnMaxLifetimeSeconds) * time.Second
+	if cfg.ConnMaxLifetime > 0 {
+		poolCfg.MaxConnLifetime = cfg.ConnMaxLifetime
 	}
-	if cfg.MaxConnIdleTimeSeconds > 0 {
-		poolCfg.MaxConnIdleTime = time.Duration(cfg.MaxConnIdleTimeSeconds) * time.Second
+	if cfg.MaxConnIdleTime > 0 {
+		poolCfg.MaxConnIdleTime = cfg.MaxConnIdleTime
 	}
-	if cfg.HealthCheckPeriodSeconds > 0 {
-		poolCfg.HealthCheckPeriod = time.Duration(cfg.HealthCheckPeriodSeconds) * time.Second
+	if cfg.HealthCheckPeriod > 0 {
+		poolCfg.HealthCheckPeriod = cfg.HealthCheckPeriod
 	}
 
 	pool, err := pgxpool.NewWithConfig(ctx, poolCfg)

--- a/backend/internal/hub/store/sqlite/sessions.go
+++ b/backend/internal/hub/store/sqlite/sessions.go
@@ -79,7 +79,8 @@ func (s *sessionStore) Touch(ctx context.Context, p store.TouchSessionParams) (i
 		`UPDATE user_sessions
 		 SET last_active_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
 		     expires_at = ?
-		 WHERE id = ? AND last_active_at < ?`,
+		 WHERE id = ? AND last_active_at < ?
+		   AND expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`,
 		sqltime.NewSQLiteTime(p.ExpiresAt), p.ID, sqltime.NewSQLiteTime(p.LastActiveAt),
 	)
 	if err != nil {

--- a/backend/internal/hub/store/storetest/test_sessions.go
+++ b/backend/internal/hub/store/storetest/test_sessions.go
@@ -299,6 +299,36 @@ func (s *Suite) testSessions(t *testing.T) {
 		assert.WithinDuration(t, newExpiry, after2.ExpiresAt, time.Second)
 	})
 
+	// An expired session must stay expired. The Hub serves a validated session
+	// from an in-memory cache for a short window, so a request can reach Touch
+	// after the row expired; without the expiry predicate that request would
+	// slide the dead session forward, and the re-issued cookie would hand the
+	// caller a live session again.
+	t.Run("touch does not revive an expired session", func(t *testing.T) {
+		st := s.NewStore(t)
+		user := SeedUser(t, st, "touch-expired-user")
+
+		sessID := id.Generate()
+		require.NoError(t, st.Sessions().Create(ctx, store.CreateSessionParams{
+			ID:        sessID,
+			UserID:    userid.MustNew(user.ID),
+			ExpiresAt: time.Now().Add(-time.Minute),
+			UserAgent: "test-agent",
+			IPAddress: "127.0.0.1",
+		}))
+
+		n, err := st.Sessions().Touch(ctx, store.TouchSessionParams{
+			ID:           sessID,
+			ExpiresAt:    time.Now().Add(48 * time.Hour),
+			LastActiveAt: time.Now().Add(time.Minute),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), n, "an expired session must match no row")
+
+		_, err = st.Sessions().ValidateWithUser(ctx, sessID)
+		assert.ErrorIs(t, err, store.ErrNotFound, "the session must still be dead after the touch")
+	})
+
 	t.Run("touch non-existent", func(t *testing.T) {
 		st := s.NewStore(t)
 

--- a/backend/internal/hub/testutil/interceptor.go
+++ b/backend/internal/hub/testutil/interceptor.go
@@ -1,0 +1,33 @@
+package testutil
+
+import (
+	"testing"
+
+	"connectrpc.com/connect"
+
+	"github.com/leapmux/leapmux/internal/hub/auth"
+	"github.com/leapmux/leapmux/internal/hub/store"
+)
+
+// NewAuthInterceptor builds an auth interceptor for a test and stops its
+// background sweep when the test ends.
+//
+// auth.NewInterceptor starts a goroutine that lives until AuthContextRegistry
+// .Stop runs, and most call sites discarded the registry entirely, so every
+// test that built one leaked a sweeper for the rest of the run. Routing through
+// this helper makes the cleanup a property of asking for an interceptor rather
+// than a line each caller has to remember.
+func NewAuthInterceptor(t *testing.T, opts auth.InterceptorOptions) (connect.Interceptor, *auth.AuthContextRegistry) {
+	t.Helper()
+	interceptor, registry := auth.NewInterceptor(opts)
+	t.Cleanup(registry.Stop)
+	return interceptor, registry
+}
+
+// NewStoreAuthInterceptor is NewAuthInterceptor for the common case: cookie
+// auth against a store, with every other option left at its default.
+func NewStoreAuthInterceptor(t *testing.T, st store.Store) connect.Interceptor {
+	t.Helper()
+	interceptor, _ := NewAuthInterceptor(t, auth.InterceptorOptions{Store: st})
+	return interceptor
+}

--- a/backend/internal/hub/testutil/session.go
+++ b/backend/internal/hub/testutil/session.go
@@ -1,0 +1,38 @@
+package testutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// AssertSessionLifetime pins the contract that both writers of a session expiry
+// keep -- CreateSession at the login and the interceptor at each slide.
+//
+// The lower bound is the promise the setting makes: the session lasts at least
+// the configured lifetime past the request that wrote the expiry. The upper
+// bound is what the slide throttle costs, and it is stated as a fraction rather
+// than as the throttle constant, which the auth package keeps to itself: a
+// slide waits at most a tenth of the session, so the row can carry at most a
+// tenth more than the configured value.
+//
+// Stated as a range rather than as a formula, on purpose. A formula copied from
+// the code under test passes whatever that code does, including passing the
+// wrong lifetime through; this range fails the moment a mint site drops its
+// argument and falls back to the default.
+func AssertSessionLifetime(t *testing.T, before time.Time, lifetime time.Duration, expiresAt time.Time) {
+	t.Helper()
+
+	earliest := before.Add(lifetime)
+	assert.False(t, expiresAt.Before(earliest),
+		"a session must last at least its configured lifetime (%s) past the request that wrote it: want no earlier than %s, got %s",
+		lifetime, earliest, expiresAt)
+
+	// One minute of slack for the test's own clock, which reads `before` before
+	// the call and cannot see the instant the row was written.
+	latest := before.Add(lifetime + lifetime/10 + time.Minute)
+	assert.True(t, expiresAt.Before(latest),
+		"a session must not outlive its configured lifetime (%s) by more than the slide throttle: want before %s, got %s",
+		lifetime, latest, expiresAt)
+}

--- a/backend/internal/worker/agent/factory.go
+++ b/backend/internal/worker/agent/factory.go
@@ -43,7 +43,7 @@ const (
 
 // DefaultAPITimeout is the fallback timeout for JSON-RPC requests to the
 // agent process, used when no configured value is provided.
-const DefaultAPITimeout = time.Duration(config.DefaultAPITimeoutSeconds) * time.Second
+const DefaultAPITimeout = config.DefaultAPITimeout
 
 // EffortAuto is the LeapMux-side sentinel meaning "let the CLI pick its own
 // default reasoning effort". When an agent's Effort is this value, the
@@ -142,7 +142,7 @@ func (o Options) startupTimeout() time.Duration {
 	if o.StartupTimeout > 0 {
 		return o.StartupTimeout
 	}
-	return time.Duration(config.DefaultAgentStartupTimeoutSeconds) * time.Second
+	return config.DefaultAgentStartupTimeout
 }
 
 func (o Options) apiTimeout() time.Duration {

--- a/backend/internal/worker/config/config.go
+++ b/backend/internal/worker/config/config.go
@@ -25,15 +25,15 @@ const (
 	defaultConfigFile = "~/.config/leapmux/worker/worker.yaml"
 	defaultLogLevel   = "info"
 
-	// DefaultAgentStartupTimeoutSeconds is the default timeout (in seconds) for
-	// agent startup handshake. Must match the hub's default. Sized for agents
-	// that initialize slow MCP servers during the handshake (e.g. Claude Code
-	// loading a workspace .mcp.json with multiple servers).
-	DefaultAgentStartupTimeoutSeconds = 300
+	// DefaultAgentStartupTimeout is the default timeout for the agent startup
+	// handshake. Must match the hub's default. Sized for agents that initialize
+	// slow MCP servers during the handshake (e.g. Claude Code loading a
+	// workspace .mcp.json with multiple servers).
+	DefaultAgentStartupTimeout = 5 * time.Minute
 
-	// DefaultAPITimeoutSeconds is the default timeout (in seconds) for
-	// JSON-RPC requests to agent processes (e.g. turn/start, session/new).
-	DefaultAPITimeoutSeconds = 10
+	// DefaultAPITimeout is the default timeout for JSON-RPC requests to agent
+	// processes (e.g. turn/start, session/new).
+	DefaultAPITimeout = 10 * time.Second
 )
 
 // Config holds the worker's runtime configuration.
@@ -42,19 +42,22 @@ type Config struct {
 	// RegistrationKey is the bearer credential the worker presents to
 	// WorkerConnectorService.Register. Required on first run; ignored on
 	// subsequent runs if the worker is already registered. Not persisted.
-	RegistrationKey            string `koanf:"registration_key" json:"-"`
-	Name                       string `koanf:"name" json:"name"`
-	DataDir                    string `koanf:"data_dir" json:"data_dir"`
-	DBMaxConns                 int    `koanf:"db_max_conns" json:"db_max_conns"`
-	DBCacheSize                int    `koanf:"db_cache_size" json:"db_cache_size"`
-	DBMmapSize                 int    `koanf:"db_mmap_size" json:"db_mmap_size"`
-	MaxIncompleteChunked       int    `koanf:"max_incomplete_chunked" json:"max_incomplete_chunked"`
-	MaxMessageSize             int    `koanf:"max_message_size" json:"max_message_size"`
-	AgentStartupTimeoutSeconds int    `koanf:"agent_startup_timeout_seconds" json:"agent_startup_timeout_seconds"`
-	APITimeoutSeconds          int    `koanf:"api_timeout_seconds" json:"api_timeout_seconds"`
-	LogLevel                   string `koanf:"log_level" json:"log_level"`
-	EncryptionMode             string `koanf:"encryption_mode" json:"encryption_mode"`
-	UseLoginShell              bool   `koanf:"use_login_shell" json:"use_login_shell"`
+	RegistrationKey      string `koanf:"registration_key" json:"-"`
+	Name                 string `koanf:"name" json:"name"`
+	DataDir              string `koanf:"data_dir" json:"data_dir"`
+	DBMaxConns           int    `koanf:"db_max_conns" json:"db_max_conns"`
+	DBCacheSize          int    `koanf:"db_cache_size" json:"db_cache_size"`
+	DBMmapSize           int    `koanf:"db_mmap_size" json:"db_mmap_size"`
+	MaxIncompleteChunked int    `koanf:"max_incomplete_chunked" json:"max_incomplete_chunked"`
+	MaxMessageSize       int    `koanf:"max_message_size" json:"max_message_size"`
+	// Both durations accept a unit suffix and read a bare number as seconds --
+	// see internalconfig.ParseDuration. Load resolves a zero to the matching
+	// Default* constant.
+	AgentStartupTimeout time.Duration `koanf:"agent_startup_timeout" json:"agent_startup_timeout"`
+	APITimeout          time.Duration `koanf:"api_timeout" json:"api_timeout"`
+	LogLevel            string        `koanf:"log_level" json:"log_level"`
+	EncryptionMode      string        `koanf:"encryption_mode" json:"encryption_mode"`
+	UseLoginShell       bool          `koanf:"use_login_shell" json:"use_login_shell"`
 }
 
 // EncryptionModeProto returns the protobuf EncryptionMode value.
@@ -74,22 +77,16 @@ func ParseEncryptionMode(s string) leapmuxv1.EncryptionMode {
 	}
 }
 
-// AgentStartupTimeout returns the agent startup timeout as a duration.
-func (c *Config) AgentStartupTimeout() time.Duration {
-	v := c.AgentStartupTimeoutSeconds
-	if v <= 0 {
-		v = DefaultAgentStartupTimeoutSeconds
+// applyDurationDefaults restores the default for each timeout that a source
+// left at zero, so every reader of a loaded Config finds a usable value and
+// none of them repeats the fallback.
+func (c *Config) applyDurationDefaults() {
+	if c.AgentStartupTimeout == 0 {
+		c.AgentStartupTimeout = DefaultAgentStartupTimeout
 	}
-	return time.Duration(v) * time.Second
-}
-
-// APITimeout returns the JSON-RPC request timeout as a duration.
-func (c *Config) APITimeout() time.Duration {
-	v := c.APITimeoutSeconds
-	if v <= 0 {
-		v = DefaultAPITimeoutSeconds
+	if c.APITimeout == 0 {
+		c.APITimeout = DefaultAPITimeout
 	}
-	return time.Duration(v) * time.Second
 }
 
 // State holds the worker's persistent state (saved to disk after registration).
@@ -172,29 +169,31 @@ func Load(args []string) (*Config, bool, error) {
 	fs.Int("db-mmap-size", 0, "SQLite memory-mapped I/O size in bytes (0 = disabled)")
 	fs.Int("max-incomplete-chunked", 0, "maximum in-flight chunked sequences per channel (default 4)")
 	fs.Int("max-message-size", 0, "maximum application payload size in bytes (0 = 16 MiB default); reassembled ceiling is this plus 64 KiB headroom")
-	fs.Int("agent-startup-timeout-seconds", DefaultAgentStartupTimeoutSeconds, "agent startup timeout in seconds")
-	fs.Int("api-timeout-seconds", DefaultAPITimeoutSeconds, "JSON-RPC request timeout in seconds")
+	fs.Var(internalconfig.NewDurationFlag(new(time.Duration), DefaultAgentStartupTimeout),
+		"agent-startup-timeout", "agent startup timeout. "+internalconfig.UnitSyntax)
+	fs.Var(internalconfig.NewDurationFlag(new(time.Duration), DefaultAPITimeout),
+		"api-timeout", "JSON-RPC request timeout. "+internalconfig.UnitSyntax)
 	fs.String("log-level", defaultLogLevel, "log level (debug, info, warn, error)")
 	fs.String("encryption-mode", "post-quantum", "encryption mode (classic, post-quantum)")
 	fs.Bool("use-login-shell", true, "wrap claude invocation in user's login shell")
 	showVersion := fs.Bool("version", false, "print version and exit")
 	usageCategories := map[string]string{
-		"config":                        "Common options",
-		"version":                       "Common options",
-		"hub":                           "Worker options",
-		"registration-key":              "Worker options",
-		"name":                          "Worker options",
-		"data-dir":                      "Worker options",
-		"log-level":                     "Worker options",
-		"encryption-mode":               "Worker options",
-		"use-login-shell":               "Worker options",
-		"max-incomplete-chunked":        "Timeout and limit options",
-		"max-message-size":              "Timeout and limit options",
-		"agent-startup-timeout-seconds": "Timeout and limit options",
-		"api-timeout-seconds":           "Timeout and limit options",
-		"db-max-conns":                  "SQLite database options",
-		"db-cache-size":                 "SQLite database options",
-		"db-mmap-size":                  "SQLite database options",
+		"config":                 "Common options",
+		"version":                "Common options",
+		"hub":                    "Worker options",
+		"registration-key":       "Worker options",
+		"name":                   "Worker options",
+		"data-dir":               "Worker options",
+		"log-level":              "Worker options",
+		"encryption-mode":        "Worker options",
+		"use-login-shell":        "Worker options",
+		"max-incomplete-chunked": "Timeout and limit options",
+		"max-message-size":       "Timeout and limit options",
+		"agent-startup-timeout":  "Timeout and limit options",
+		"api-timeout":            "Timeout and limit options",
+		"db-max-conns":           "SQLite database options",
+		"db-cache-size":          "SQLite database options",
+		"db-mmap-size":           "SQLite database options",
 	}
 	if err := internalconfig.ConfigureAndParse(fs, args, "Run a Worker connected to a Hub.", usageCategories, workerFlagCategoryOrder); err != nil {
 		return nil, false, err
@@ -206,40 +205,40 @@ func Load(args []string) (*Config, bool, error) {
 
 	// Flag name -> koanf key mapping.
 	fieldMap := map[string]string{
-		"hub":                           "hub",
-		"registration-key":              "registration_key",
-		"name":                          "name",
-		"data-dir":                      "data_dir",
-		"db-max-conns":                  "db_max_conns",
-		"db-cache-size":                 "db_cache_size",
-		"db-mmap-size":                  "db_mmap_size",
-		"max-incomplete-chunked":        "max_incomplete_chunked",
-		"max-message-size":              "max_message_size",
-		"agent-startup-timeout-seconds": "agent_startup_timeout_seconds",
-		"api-timeout-seconds":           "api_timeout_seconds",
-		"log-level":                     "log_level",
-		"encryption-mode":               "encryption_mode",
-		"use-login-shell":               "use_login_shell",
+		"hub":                    "hub",
+		"registration-key":       "registration_key",
+		"name":                   "name",
+		"data-dir":               "data_dir",
+		"db-max-conns":           "db_max_conns",
+		"db-cache-size":          "db_cache_size",
+		"db-mmap-size":           "db_mmap_size",
+		"max-incomplete-chunked": "max_incomplete_chunked",
+		"max-message-size":       "max_message_size",
+		"agent-startup-timeout":  "agent_startup_timeout",
+		"api-timeout":            "api_timeout",
+		"log-level":              "log_level",
+		"encryption-mode":        "encryption_mode",
+		"use-login-shell":        "use_login_shell",
 	}
 
 	defaults := map[string]interface{}{
-		"hub":                           defaultHubURL,
-		"registration_key":              "",
-		"name":                          "",
-		"data_dir":                      ".",
-		"db_max_conns":                  sqlitedb.DefaultMaxConns,
-		"db_cache_size":                 0,
-		"db_mmap_size":                  0,
-		"max_incomplete_chunked":        0,
-		"max_message_size":              0,
-		"agent_startup_timeout_seconds": DefaultAgentStartupTimeoutSeconds,
-		"api_timeout_seconds":           DefaultAPITimeoutSeconds,
-		"log_level":                     defaultLogLevel,
-		"encryption_mode":               "post-quantum",
-		"use_login_shell":               true,
+		"hub":                    defaultHubURL,
+		"registration_key":       "",
+		"name":                   "",
+		"data_dir":               ".",
+		"db_max_conns":           sqlitedb.DefaultMaxConns,
+		"db_cache_size":          0,
+		"db_mmap_size":           0,
+		"max_incomplete_chunked": 0,
+		"max_message_size":       0,
+		"agent_startup_timeout":  DefaultAgentStartupTimeout,
+		"api_timeout":            DefaultAPITimeout,
+		"log_level":              defaultLogLevel,
+		"encryption_mode":        "post-quantum",
+		"use_login_shell":        true,
 	}
 
-	k := koanf.New(".")
+	k := koanf.New(internalconfig.Delim)
 	fp := internalconfig.NewFlagProvider(fs, fieldMap)
 
 	if err := internalconfig.Load(k, defaults, configPath, "LEAPMUX_WORKER_", fp); err != nil {
@@ -247,9 +246,12 @@ func Load(args []string) (*Config, bool, error) {
 	}
 
 	var cfg Config
-	if err := k.Unmarshal("", &cfg); err != nil {
+	if err := internalconfig.Unmarshal(k, &cfg); err != nil {
 		return nil, false, fmt.Errorf("unmarshal config: %w", err)
 	}
+
+	// Resolve the timeouts before anything reads one.
+	cfg.applyDurationDefaults()
 
 	// Resolve relative data_dir against config file directory.
 	cfg.DataDir = internalconfig.ResolveDataDir(cfg.DataDir, configPath, defaultConfigDir)

--- a/backend/internal/worker/config/config_test.go
+++ b/backend/internal/worker/config/config_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/leapmux/leapmux/channelwire"
 	"github.com/leapmux/leapmux/internal/util/sqlitedb"
@@ -127,6 +128,73 @@ log_level: "warn"
 	})
 }
 
+// The Worker's two timeouts take the same spellings as the Hub's, from every
+// source. They are registered separately from the Hub's, so nothing but a test
+// keeps the two flag sets speaking the same language.
+func TestTimeoutDurations(t *testing.T) {
+	t.Run("default when unset", func(t *testing.T) {
+		cfg, _, err := Load(nil)
+		require.NoError(t, err)
+		assert.Equal(t, DefaultAgentStartupTimeout, cfg.AgentStartupTimeout)
+		assert.Equal(t, DefaultAPITimeout, cfg.APITimeout)
+	})
+
+	t.Run("an explicit zero means the default", func(t *testing.T) {
+		cfg, _, err := Load([]string{"-agent-startup-timeout", "0", "-api-timeout", "0"})
+		require.NoError(t, err)
+		assert.Equal(t, DefaultAgentStartupTimeout, cfg.AgentStartupTimeout,
+			"a zero timeout would make every agent handshake fail at once")
+		assert.Equal(t, DefaultAPITimeout, cfg.APITimeout)
+	})
+
+	for _, c := range []struct {
+		text string
+		want time.Duration
+	}{
+		// A bare number is the seconds count this key took before it had units.
+		{"600", 10 * time.Minute},
+		{"90s", 90 * time.Second},
+		{"10m", 10 * time.Minute},
+		{"2h", 2 * time.Hour},
+		{"1d", 24 * time.Hour},
+	} {
+		t.Run("flag "+c.text, func(t *testing.T) {
+			cfg, _, err := Load([]string{"-agent-startup-timeout", c.text})
+			require.NoError(t, err)
+			assert.Equal(t, c.want, cfg.AgentStartupTimeout)
+		})
+
+		t.Run("config file "+c.text, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "worker.yaml")
+			require.NoError(t, os.WriteFile(path, []byte("agent_startup_timeout: "+c.text+"\n"), 0o644))
+			cfg, _, err := Load([]string{"-config", path})
+			require.NoError(t, err)
+			assert.Equal(t, c.want, cfg.AgentStartupTimeout)
+		})
+
+		t.Run("env "+c.text, func(t *testing.T) {
+			t.Setenv("LEAPMUX_WORKER_AGENT_STARTUP_TIMEOUT", c.text)
+			cfg, _, err := Load(nil)
+			require.NoError(t, err)
+			assert.Equal(t, c.want, cfg.AgentStartupTimeout)
+		})
+	}
+
+	t.Run("rejects a value that is not a duration", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "worker.yaml")
+		require.NoError(t, os.WriteFile(path, []byte("api_timeout: 30x\n"), 0o644))
+		_, _, err := Load([]string{"-config", path})
+		require.Error(t, err, "a typed unit must fail at startup, not read as zero")
+	})
+
+	t.Run("rejects a value past the representable range", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "worker.yaml")
+		require.NoError(t, os.WriteFile(path, []byte("api_timeout: 18446744075\n"), 0o644))
+		_, _, err := Load([]string{"-config", path})
+		require.Error(t, err, "an out-of-range value must fail rather than wrap")
+	})
+}
+
 func TestLoadRejectsPositionalArguments(t *testing.T) {
 	cases := []struct {
 		name string
@@ -169,11 +237,11 @@ func TestWorkerHelpGroupsOptions(t *testing.T) {
 	// noisy churn. Assert that the section header is followed by *some*
 	// flag instead.
 	assert.Contains(t, output, "\nWorker options:\n\n  -")
-	assert.Contains(t, output, "\nTimeout and limit options:\n\n  -agent-startup-timeout-seconds int")
+	assert.Contains(t, output, "\nTimeout and limit options:\n\n  -agent-startup-timeout duration")
 	assert.Contains(t, output, "\nSQLite database options:\n\n  -db-cache-size int")
 	assert.Contains(t, output, "  -data-dir string")
 	assert.Contains(t, output, "  -hub string")
-	assert.Contains(t, output, "  -api-timeout-seconds int")
+	assert.Contains(t, output, "  -api-timeout duration")
 	assert.Contains(t, output, "  -db-cache-size int")
 }
 

--- a/backend/internal/worker/service/service.go
+++ b/backend/internal/worker/service/service.go
@@ -357,7 +357,7 @@ func (svc *Service) agentStartupTimeout() time.Duration {
 	if svc.AgentStartupTimeout > 0 {
 		return svc.AgentStartupTimeout
 	}
-	return time.Duration(config.DefaultAgentStartupTimeoutSeconds) * time.Second
+	return config.DefaultAgentStartupTimeout
 }
 
 // agentAPITimeout returns the configured API timeout, or the default if not set.

--- a/backend/solo/solo.go
+++ b/backend/solo/solo.go
@@ -840,8 +840,8 @@ func bringUpLocalWorker(ctx context.Context, p workerBringUp) error {
 			// 0 (the default) lets the worker apply channelwire.DefaultMaxIncompleteChunked.
 			MaxIncompleteChunked: parseInt(p.hubCfg.Extras["max_incomplete_chunked"], 0),
 			MaxMessageSize:       p.hubCfg.MaxMessageSize,
-			AgentStartupTimeout:  p.hubCfg.AgentStartupTimeout(),
-			APITimeout:           p.hubCfg.APITimeout(),
+			AgentStartupTimeout:  p.hubCfg.AgentStartupTimeout,
+			APITimeout:           p.hubCfg.APITimeout,
 			EncryptionMode:       workerconfig.ParseEncryptionMode(p.hubCfg.Extras["encryption_mode"]),
 			UseLoginShell:        parseBool(p.hubCfg.Extras["use_login_shell"], true),
 			RegisteredBy:         state.RegisteredBy,
@@ -1132,8 +1132,8 @@ func defaultExtraFlags() []hubconfig.ExtraFlagDef {
 // machine's memory limit, which is almost always the right answer on a laptop,
 // and a config file still reaches them for the rare case it is not.
 //
-// session-duration-seconds is dev-only, alongside public-url, because solo mode
-// has no session to expire: its interceptor authenticates every request as the
+// session-duration is dev-only, alongside public-url, because solo mode has no
+// session to expire: its interceptor authenticates every request as the
 // synthetic local user and mints no session row. Dev mode runs the full
 // sign-up-and-cookie path, so the flag is the one place a short session is
 // worth asking for -- testing the signed-out path needs minutes, not days.
@@ -1141,12 +1141,12 @@ func defaultCLIFlags(devMode bool) []string {
 	flags := []string{
 		"listen", "data-dir", "dev-frontend",
 		"storage-sqlite-max-conns", "storage-sqlite-cache-size", "storage-sqlite-mmap-size",
-		"api-timeout-seconds", "agent-startup-timeout-seconds", "worktree-create-timeout-seconds",
+		"api-timeout", "agent-startup-timeout", "worktree-create-timeout",
 		"log-level",
 		"max-connections-per-user", "max-workers-per-user",
 	}
 	if devMode {
-		flags = append(flags, "public-url", "session-duration-seconds")
+		flags = append(flags, "public-url", "session-duration")
 	}
 	return flags
 }

--- a/backend/solo/solo.go
+++ b/backend/solo/solo.go
@@ -1131,6 +1131,12 @@ func defaultExtraFlags() []hubconfig.ExtraFlagDef {
 // The three queue budgets are deliberately NOT here. They auto-size off this
 // machine's memory limit, which is almost always the right answer on a laptop,
 // and a config file still reaches them for the rare case it is not.
+//
+// session-duration-seconds is dev-only, alongside public-url, because solo mode
+// has no session to expire: its interceptor authenticates every request as the
+// synthetic local user and mints no session row. Dev mode runs the full
+// sign-up-and-cookie path, so the flag is the one place a short session is
+// worth asking for -- testing the signed-out path needs minutes, not days.
 func defaultCLIFlags(devMode bool) []string {
 	flags := []string{
 		"listen", "data-dir", "dev-frontend",
@@ -1140,7 +1146,7 @@ func defaultCLIFlags(devMode bool) []string {
 		"max-connections-per-user", "max-workers-per-user",
 	}
 	if devMode {
-		flags = append(flags, "public-url")
+		flags = append(flags, "public-url", "session-duration-seconds")
 	}
 	return flags
 }

--- a/backend/solo/solo_test.go
+++ b/backend/solo/solo_test.go
@@ -141,6 +141,36 @@ func TestDevModeAddsPublicURL(t *testing.T) {
 		"dev must not lose the caps when it gains public-url")
 }
 
+// TestDevModeAddsSessionDuration guards the other dev-only flag. Dev runs the
+// full sign-up-and-cookie path, so a short session is worth asking for on the
+// command line; solo authenticates every request as the synthetic local user
+// and mints no session, which would make the flag inert in its --help.
+func TestDevModeAddsSessionDuration(t *testing.T) {
+	t.Parallel()
+
+	assert.Contains(t, defaultCLIFlags(true), "session-duration-seconds")
+	assert.NotContains(t, defaultCLIFlags(false), "session-duration-seconds")
+
+	cfg, _, err := hubconfig.LoadWithOptions(
+		[]string{"--session-duration-seconds=3600"}, testLoadOptions(t, true))
+	require.NoError(t, err, "dev must accept the session duration as a CLI flag")
+	assert.Equal(t, time.Hour, cfg.SessionDuration())
+
+	_, _, err = hubconfig.LoadWithOptions(
+		[]string{"--session-duration-seconds=3600"}, testLoadOptions(t, false))
+	require.Error(t, err, "solo must not offer a flag it has no session to apply it to")
+
+	// The key stays reachable where the flag is not, the same contract the
+	// queue budgets hold: CLIFlags decides only what earns a line in --help.
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("session_duration_seconds: 3600\n"), 0o600))
+	opts := testLoadOptions(t, false)
+	opts.DefaultConfigFile = path
+	cfg, _, err = hubconfig.LoadWithOptions(nil, opts)
+	require.NoError(t, err)
+	assert.Equal(t, time.Hour, cfg.SessionDuration())
+}
+
 func TestListenIsNonLoopback(t *testing.T) {
 	t.Parallel()
 	cases := []struct {

--- a/backend/solo/solo_test.go
+++ b/backend/solo/solo_test.go
@@ -148,27 +148,27 @@ func TestDevModeAddsPublicURL(t *testing.T) {
 func TestDevModeAddsSessionDuration(t *testing.T) {
 	t.Parallel()
 
-	assert.Contains(t, defaultCLIFlags(true), "session-duration-seconds")
-	assert.NotContains(t, defaultCLIFlags(false), "session-duration-seconds")
+	assert.Contains(t, defaultCLIFlags(true), "session-duration")
+	assert.NotContains(t, defaultCLIFlags(false), "session-duration")
 
 	cfg, _, err := hubconfig.LoadWithOptions(
-		[]string{"--session-duration-seconds=3600"}, testLoadOptions(t, true))
+		[]string{"--session-duration=1h"}, testLoadOptions(t, true))
 	require.NoError(t, err, "dev must accept the session duration as a CLI flag")
-	assert.Equal(t, time.Hour, cfg.SessionDuration())
+	assert.Equal(t, time.Hour, cfg.SessionDuration)
 
 	_, _, err = hubconfig.LoadWithOptions(
-		[]string{"--session-duration-seconds=3600"}, testLoadOptions(t, false))
+		[]string{"--session-duration=1h"}, testLoadOptions(t, false))
 	require.Error(t, err, "solo must not offer a flag it has no session to apply it to")
 
 	// The key stays reachable where the flag is not, the same contract the
 	// queue budgets hold: CLIFlags decides only what earns a line in --help.
 	path := filepath.Join(t.TempDir(), "config.yaml")
-	require.NoError(t, os.WriteFile(path, []byte("session_duration_seconds: 3600\n"), 0o600))
+	require.NoError(t, os.WriteFile(path, []byte("session_duration: 1h\n"), 0o600))
 	opts := testLoadOptions(t, false)
 	opts.DefaultConfigFile = path
 	cfg, _, err = hubconfig.LoadWithOptions(nil, opts)
 	require.NoError(t, err)
-	assert.Equal(t, time.Hour, cfg.SessionDuration())
+	assert.Equal(t, time.Hour, cfg.SessionDuration)
 }
 
 func TestListenIsNonLoopback(t *testing.T) {

--- a/frontend/src/components/chat/AgentInfoCard.test.tsx
+++ b/frontend/src/components/chat/AgentInfoCard.test.tsx
@@ -68,6 +68,67 @@ describe('agent info card session ID row', () => {
   })
 })
 
+// The Directory and Plan File rows abbreviate the worker's home directory to
+// `~` for reading, and copy the absolute path for pasting. Both halves need
+// pinning, and the display half especially: tildify returns its input unchanged
+// when homeDir is absent, so losing the home directory degrades to a full path
+// that still looks perfectly plausible on screen.
+describe('agent info card path rows', () => {
+  const HOME = '/Users/me'
+
+  function withPaths(fields: Partial<AgentInfo>): AgentInfo {
+    return { agentProvider: AgentProvider.CLAUDE_CODE, agentSessionId: 'sid', ...fields } as AgentInfo
+  }
+
+  beforeEach(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    })
+  })
+
+  it('abbreviates the working directory but copies the absolute path', () => {
+    const workingDir = `${HOME}/projects/app`
+    render(() => <InfoCardContent agent={withPaths({ workingDir, homeDir: HOME })} />)
+
+    expect(screen.getByTestId('info-row-directory')).toHaveTextContent('~/projects/app')
+    expect(screen.getByTestId('info-row-directory')).not.toHaveTextContent(HOME)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy directory path' }))
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(workingDir)
+  })
+
+  it('abbreviates the plan file path but copies the absolute path', () => {
+    const planFilePath = `${HOME}/projects/app/PLAN.md`
+    render(() => (
+      <InfoCardContent
+        agent={withPaths({ workingDir: `${HOME}/projects/app`, homeDir: HOME })}
+        agentSessionInfo={{ planFilePath }}
+      />
+    ))
+
+    expect(screen.getByTestId('info-row-plan-file')).toHaveTextContent('~/projects/app/PLAN.md')
+    expect(screen.getByTestId('info-row-plan-file')).not.toHaveTextContent(HOME)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy plan file path' }))
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(planFilePath)
+  })
+
+  // Not a repeat of tildify's own cases (paths.test.ts covers the abbreviation
+  // itself). This is the wiring: the card must hand the worker's home directory
+  // to tildify rather than call it with nothing, and a worker that reported no
+  // home directory must still show a usable path.
+  it('shows the absolute path when the worker reported no home directory', () => {
+    const workingDir = `${HOME}/projects/app`
+    render(() => <InfoCardContent agent={withPaths({ workingDir })} />)
+
+    expect(screen.getByTestId('info-row-directory')).toHaveTextContent(workingDir)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy directory path' }))
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(workingDir)
+  })
+})
+
 describe('agent info card rate-limit rows', () => {
   // Unix seconds in the future, for a deterministically-positive reset countdown.
   const future = (secs: number): number => Math.floor(Date.now() / 1000) + secs

--- a/frontend/src/lib/paths.test.ts
+++ b/frontend/src/lib/paths.test.ts
@@ -230,6 +230,21 @@ describe('tildify', () => {
     expect(tildify('/opt/data', '/home/alice')).toBe('/opt/data')
   })
 
+  // The home directory is a path prefix, not a string prefix. A naive
+  // startsWith would abbreviate a sibling whose name merely begins with it,
+  // and print the nonsense '~server/proj' for a real directory.
+  it('leaves a sibling whose name starts with homeDir alone', () => {
+    expect(tildify('/home/aliceserver/proj', '/home/alice')).toBe('/home/aliceserver/proj')
+    expect(tildify('C:\\Users\\aliceserver\\proj', 'C:\\Users\\alice')).toBe('C:\\Users\\aliceserver\\proj')
+  })
+
+  // A configured home directory that carries a trailing separator must abbreviate
+  // the same way, or the same worker reports two spellings for one directory.
+  it('ignores a trailing separator on homeDir', () => {
+    expect(tildify('/home/alice/proj', '/home/alice/')).toBe('~/proj')
+    expect(tildify('C:\\Users\\alice\\proj', 'C:\\Users\\alice\\')).toBe('~\\proj')
+  })
+
   it('is a no-op when homeDir is omitted', () => {
     expect(tildify('/home/alice/proj')).toBe('/home/alice/proj')
   })

--- a/site/content/docs/operating/configuration.md
+++ b/site/content/docs/operating/configuration.md
@@ -167,6 +167,7 @@ Env prefix: `LEAPMUX_HUB_`. Defaults shown are the built-in values. Each key's C
 | --- | --- | --- |
 | `signup_enabled` | `false` | Enable user sign-up. |
 | `email_verification_required` | `false` | Require email verification on sign-up. Requires `smtp_host`. |
+| `session_duration_seconds` | `691200` (8 days) | How long a session stays valid after the user's last request. Each request slides the expiry forward, so this is an idle timeout, not a cap on how long a signed-in user may stay signed in. `0` means the default; a value under `60` is rejected. |
 
 See [Accounts & Authentication](/docs/using/accounts/) for the sign-up/verification flows, and [Authentication Providers](/docs/operating/authentication-providers/) for OAuth/OIDC.
 
@@ -544,6 +545,7 @@ log_level: info
 
 signup_enabled: true
 email_verification_required: true
+session_duration_seconds: 86400   # sign an idle user out after a day
 
 smtp_host: "smtp.example.com"
 smtp_port: 587

--- a/site/content/docs/operating/configuration.md
+++ b/site/content/docs/operating/configuration.md
@@ -107,6 +107,31 @@ export LEAPMUX_HUB_PUBLIC_URL="https://hub.example.com"
 leapmux hub
 ```
 
+## Duration values
+
+Every key that holds a duration — `session_duration`, each timeout, and each database pool setting, in both the Hub and the Worker — takes the same spellings.
+
+| Unit | Meaning | Example |
+| --- | --- | --- |
+| `ns`, `us`, `ms` | Nanoseconds, microseconds, milliseconds | `500ms` |
+| `s`, `m`, `h` | Seconds, minutes, hours | `90s`, `30m`, `2h` |
+| `d` | Days (24 hours) | `7d` |
+| `w` | Weeks (7 days) | `2w` |
+
+Parts combine, in any order: `1h30m`, `1w2d`, `2d12h`.
+
+**A bare number is a count of seconds.** That is what these keys took before they had units, so `api_timeout: 10` still means ten seconds and an existing config file keeps working. A number only means seconds when it is the whole value — `1d30` is rejected rather than read as a day and thirty seconds.
+
+The same spellings work everywhere a key can be set: the config file, the environment variable, and the CLI flag. `0` means "use the default" for the Hub and Worker timeouts, and "leave the database driver's own default alone" for the pool settings.
+
+A value that cannot be read, or one past roughly 292 years (the largest duration LeapMux can represent), fails at startup naming the key, rather than silently becoming a duration nobody meant.
+
+```yaml
+session_duration: 7d
+api_timeout: 10s
+agent_startup_timeout: 5m
+```
+
 ## Listen addresses
 
 LeapMux uses two kinds of listen addresses.
@@ -163,11 +188,13 @@ Env prefix: `LEAPMUX_HUB_`. Defaults shown are the built-in values. Each key's C
 
 ### Auth options
 
+`session_duration` takes a unit suffix; see [Duration values](#duration-values).
+
 | Config key | Default | Meaning |
 | --- | --- | --- |
 | `signup_enabled` | `false` | Enable user sign-up. |
 | `email_verification_required` | `false` | Require email verification on sign-up. Requires `smtp_host`. |
-| `session_duration_seconds` | `691200` (8 days) | How long a session stays valid after the user's last request. Each request slides the expiry forward, so this is an idle timeout, not a cap on how long a signed-in user may stay signed in. `0` means the default; a value under `60` is rejected. |
+| `session_duration` | `7d` | How long a session stays valid after the user's last request. Each request slides the expiry forward, so this is an idle timeout, not a cap on how long a signed-in user may stay signed in. `0` means the default; a value under `5m` is rejected, because the Hub serves a validated session from an in-memory cache for a short window and cannot enforce a shorter policy honestly. |
 
 See [Accounts & Authentication](/docs/using/accounts/) for the sign-up/verification flows, and [Authentication Providers](/docs/operating/authentication-providers/) for OAuth/OIDC.
 
@@ -192,11 +219,13 @@ The TLS modes:
 
 ### Timeout and limit options
 
+Every timeout below takes a unit suffix; see [Duration values](#duration-values).
+
 | Config key | Default | Meaning |
 | --- | --- | --- |
-| `api_timeout_seconds` | `10` | General API timeout in seconds (`<=0` falls back to 10). |
-| `agent_startup_timeout_seconds` | `300` | Agent startup timeout in seconds (`<=0` falls back to 300). |
-| `worktree_create_timeout_seconds` | `60` | Worktree creation timeout in seconds (`<=0` falls back to 60). |
+| `api_timeout` | `10s` | General API timeout. `0` means the default. |
+| `agent_startup_timeout` | `5m` | Agent startup timeout. `0` means the default. |
+| `worktree_create_timeout` | `1m` | Worktree creation timeout. `0` means the default. |
 | `max_message_size` | `0` | Maximum application payload size in bytes (`0` = 16 MiB default). Clients derive the reassembled send/receive ceiling as this plus 64 KiB of envelope headroom — the wire field on `OpenChannel` / `OpenChannelResponse` is the payload budget, not the reassembled ceiling. Must be between one Noise plaintext chunk (~64 KiB) and 64 MiB when set. Effective per channel is `min(hub, worker)`. Clients (browser, CLI tunnel) do not configure this — they adopt the payload budget from `OpenChannel`. |
 | `relay_queue_memory_budget` | `0` | Bytes the Hub's browser channel relays may queue between them (`0` = auto-size). See [Outbound queue memory](#outbound-queue-memory). |
 | `worker_queue_memory_budget` | `0` | Bytes the Hub's Worker connections may queue between them (`0` = auto-size). See [Outbound queue memory](#outbound-queue-memory). |
@@ -380,12 +409,14 @@ Env prefix: `LEAPMUX_WORKER_`. A Worker connects to a Hub over a URL; it does no
 
 ### Timeout and limit options
 
+Every timeout below takes a unit suffix; see [Duration values](#duration-values).
+
 | Config key | Default | Meaning |
 | --- | --- | --- |
 | `max_incomplete_chunked` | `0` | Maximum in-flight chunked sequences per channel (`0` = 4 default). |
 | `max_message_size` | `0` | Maximum application payload size in bytes (`0` = 16 MiB default). Negotiated per channel as `min(hub, worker)`; the reassembled ceiling is this plus 64 KiB of envelope headroom. |
-| `agent_startup_timeout_seconds` | `300` | Agent startup timeout in seconds (`<=0` falls back to 300). |
-| `api_timeout_seconds` | `10` | JSON-RPC request timeout in seconds (`<=0` falls back to 10). |
+| `agent_startup_timeout` | `5m` | Agent startup timeout. `0` means the default. |
+| `api_timeout` | `10s` | JSON-RPC request timeout. `0` means the default. |
 
 ### SQLite database options
 
@@ -459,14 +490,16 @@ storage:
 
 These three share the same driver, config block layout, and pool defaults. Only the config-block name and the flag prefix differ: `storage.postgres.*` / `--storage-postgres-*`, `storage.cockroachdb.*` / `--storage-cockroachdb-*`, `storage.yugabytedb.*` / `--storage-yugabytedb-*`.
 
+Every duration below takes a unit suffix; see [Duration values](#duration-values).
+
 | Config key (under `storage.<name>`) | Default | Meaning |
 | --- | --- | --- |
 | `dsn` | *(empty, required)* | Connection string (URL form). |
 | `max_conns` | `25` | Maximum open connections. |
 | `min_conns` | `5` | Minimum pool connections kept alive. |
-| `conn_max_lifetime_seconds` | `3600` | Connection max lifetime in seconds. |
-| `max_conn_idle_time_seconds` | `300` | Max idle time per connection in seconds. |
-| `health_check_period_seconds` | `30` | Pool health-check period in seconds. |
+| `conn_max_lifetime` | `1h` | Connection max lifetime. |
+| `max_conn_idle_time` | `5m` | Max idle time per connection. |
+| `health_check_period` | `30s` | Pool health-check period. |
 
 DSN formats (the `dsn` is parsed as a connection URL):
 
@@ -482,9 +515,9 @@ storage:
     dsn: "postgres://leapmux:secret@db.internal:5432/leapmux?sslmode=require"
     max_conns: 25
     min_conns: 5
-    conn_max_lifetime_seconds: 3600
-    max_conn_idle_time_seconds: 300
-    health_check_period_seconds: 30
+    conn_max_lifetime: 1h
+    max_conn_idle_time: 5m
+    health_check_period: 30s
 ```
 
 > **Tip:** `sslmode=disable` is fine for local testing but you should use `sslmode=require` (or stronger) for any networked database. CockroachDB and YugabyteDB use the same config block shape — just set `type: cockroachdb` / `type: yugabytedb` and fill in `storage.cockroachdb` / `storage.yugabytedb`.
@@ -493,13 +526,15 @@ storage:
 
 MySQL and TiDB share the MySQL driver, config layout, and pool defaults. Prefixes are `storage.mysql.*` / `--storage-mysql-*` and `storage.tidb.*` / `--storage-tidb-*`.
 
+Every duration below takes a unit suffix; see [Duration values](#duration-values).
+
 | Config key (under `storage.<name>`) | Default | Meaning |
 | --- | --- | --- |
 | `dsn` | *(empty, required)* | Connection string (go-sql-driver DSN). |
 | `max_conns` | `25` | Maximum open connections. |
 | `max_idle_conns` | `5` | Maximum idle connections. |
-| `conn_max_lifetime_seconds` | `3600` | Connection max lifetime in seconds. |
-| `conn_max_idle_time_seconds` | `300` | Max idle time per connection in seconds. |
+| `conn_max_lifetime` | `1h` | Connection max lifetime. |
+| `conn_max_idle_time` | `5m` | Max idle time per connection. |
 
 DSN formats:
 
@@ -514,8 +549,8 @@ storage:
     dsn: "leapmux:secret@tcp(db.internal:3306)/leapmux?parseTime=true"
     max_conns: 25
     max_idle_conns: 5
-    conn_max_lifetime_seconds: 3600
-    conn_max_idle_time_seconds: 300
+    conn_max_lifetime: 1h
+    conn_max_idle_time: 5m
 ```
 
 > **Warning:** MySQL and TiDB DSNs **must** include `parseTime=true`, or time columns will fail to decode. For TiDB, the store best-effort enables foreign-key support on connect (a no-op on real MySQL, which already enforces them).
@@ -545,7 +580,7 @@ log_level: info
 
 signup_enabled: true
 email_verification_required: true
-session_duration_seconds: 86400   # sign an idle user out after a day
+session_duration: 1d              # sign an idle user out after a day
 
 smtp_host: "smtp.example.com"
 smtp_port: 587

--- a/site/content/docs/operating/running-leapmux.md
+++ b/site/content/docs/operating/running-leapmux.md
@@ -47,7 +47,7 @@ Solo mode accepts a subset of the Hub's flags plus an `--encryption-mode` flag f
 | `-encryption-mode` | `post-quantum` | `classic` or `post-quantum` |
 | `-config` | `~/.config/leapmux/solo/solo.yaml` | Config file path |
 
-Solo also accepts the SQLite, chunked-reassembly, message-size, and timeout tuning flags (`-storage-sqlite-max-conns`, `-max-incomplete-chunked`, `-max-message-size`, `-api-timeout-seconds`, `-agent-startup-timeout-seconds`, `-worktree-create-timeout-seconds`) plus `-dev-frontend`; see [Configuration](/docs/operating/configuration/) for those.
+Solo also accepts the SQLite, chunked-reassembly, message-size, and timeout tuning flags (`-storage-sqlite-max-conns`, `-max-incomplete-chunked`, `-max-message-size`, `-api-timeout`, `-agent-startup-timeout`, `-worktree-create-timeout`) plus `-dev-frontend`; see [Configuration](/docs/operating/configuration/) for those.
 
 > **Note:** `--public-url` is **not** available in solo mode. If you set `public_url` by any means, solo mode rejects it with `public_url is not supported in solo mode`. Reverse-proxy fronting is a job for `hub` or `dev`.
 
@@ -71,6 +71,7 @@ A fresh Hub has no users and (by default) sign-up disabled. To allow accounts to
 | `-data-dir` | `.` (resolves to `~/.config/leapmux/hub`) | Data directory |
 | `-signup-enabled` | `false` | Allow user sign-up |
 | `-email-verification-required` | `false` | Require email verification on sign-up (needs SMTP configured) |
+| `-session-duration` | `7d` | How long a session stays valid after the user's last request; each request slides the expiry forward |
 | `-storage-type` | empty (= `sqlite`) | `sqlite`, `postgres`, `mysql`, `cockroachdb`, `yugabytedb`, or `tidb` |
 | `-log-level` | `info` | Log level |
 | `-config` | `~/.config/leapmux/hub/hub.yaml` | Config file path |
@@ -122,13 +123,13 @@ leapmux dev -listen :4327
 
 Because dev mode uses real authentication, it bootstraps its first admin through the `/setup` flow rather than auto-authenticating. The in-process Worker's auto-registration is deferred until that first admin signs up; until then the log shows *"dev mode: deferring worker auto-registration until first admin signs up via /setup"*. Open the URL, complete `/setup` to create the admin, and the bundled Worker comes online.
 
-Dev mode accepts the same flags as solo, plus `--public-url` and `--session-duration-seconds`, which solo does not have. The most important dev flags:
+Dev mode accepts the same flags as solo, plus `--public-url` and `--session-duration`, which solo does not have. The most important dev flags:
 
 | Flag | Default | Meaning |
 |------|---------|---------|
 | `-listen` | `:4327` | TCP listen address |
 | `-public-url` | empty | Public base URL when behind a reverse proxy |
-| `-session-duration-seconds` | `691200` (8 days) | Session lifetime after the user's last request; shorten it to exercise the signed-out path |
+| `-session-duration` | `7d` | Session lifetime after the user's last request; shorten it to exercise the signed-out path, as in `-session-duration 5m`, which is the minimum ([duration syntax](/docs/operating/configuration/#duration-values)) |
 | `-data-dir` | `.` (resolves to `~/.config/leapmux/dev`) | Data directory |
 | `-log-level` | `info` | Log level |
 | `-encryption-mode` | `post-quantum` | `classic` or `post-quantum` |

--- a/site/content/docs/operating/running-leapmux.md
+++ b/site/content/docs/operating/running-leapmux.md
@@ -122,12 +122,13 @@ leapmux dev -listen :4327
 
 Because dev mode uses real authentication, it bootstraps its first admin through the `/setup` flow rather than auto-authenticating. The in-process Worker's auto-registration is deferred until that first admin signs up; until then the log shows *"dev mode: deferring worker auto-registration until first admin signs up via /setup"*. Open the URL, complete `/setup` to create the admin, and the bundled Worker comes online.
 
-Dev mode accepts the same flags as solo, plus `--public-url`, which solo does not have. The most important dev flags:
+Dev mode accepts the same flags as solo, plus `--public-url` and `--session-duration-seconds`, which solo does not have. The most important dev flags:
 
 | Flag | Default | Meaning |
 |------|---------|---------|
 | `-listen` | `:4327` | TCP listen address |
 | `-public-url` | empty | Public base URL when behind a reverse proxy |
+| `-session-duration-seconds` | `691200` (8 days) | Session lifetime after the user's last request; shorten it to exercise the signed-out path |
 | `-data-dir` | `.` (resolves to `~/.config/leapmux/dev`) | Data directory |
 | `-log-level` | `info` | Log level |
 | `-encryption-mode` | `post-quantum` | `classic` or `post-quantum` |

--- a/site/content/docs/reference/cli-reference.md
+++ b/site/content/docs/reference/cli-reference.md
@@ -105,6 +105,7 @@ This table lists the most common flags. The full set — including all PostgreSQ
 |------|---------|---------|
 | `-signup-enabled` | `false` | Enable user sign-up |
 | `-email-verification-required` | `false` | Require email verification on sign-up (needs `-smtp-host`) |
+| `-session-duration-seconds` | `691200` (8 days) | How long a session stays valid after the user's last request; each request slides the expiry forward |
 
 **SMTP options**
 
@@ -225,11 +226,12 @@ Run a Hub and a Worker in one process with **real** password authentication — 
 leapmux dev [flags]
 ```
 
-Dev mode uses the **same flag set as solo**, with one addition:
+Dev mode uses the **same flag set as solo**, with two additions:
 
 | Flag | Default | Meaning |
 |------|---------|---------|
 | `-public-url` | empty | Public base URL when behind a reverse proxy |
+| `-session-duration-seconds` | `691200` (8 days) | How long a session stays valid after the user's last request. Solo has no session to expire, so the flag is dev-only; shorten it to exercise the signed-out path. |
 
 The other differences from solo: the default `-listen` is `:4327` (all interfaces), the config/data location is `~/.config/leapmux/dev/`, and the bundled Worker's auto-registration is deferred until the first admin completes `/setup`.
 

--- a/site/content/docs/reference/cli-reference.md
+++ b/site/content/docs/reference/cli-reference.md
@@ -51,6 +51,8 @@ Notes on dispatch:
 
 > **Tip:** Flags accept both single- and double-hyphen forms (`-listen` and `--listen` are equivalent). This chapter uses the single-hyphen form, matching the binary's help output.
 
+> **Durations.** Every flag whose default is shown as a duration (`7d`, `10s`, `5m`, …) takes a unit suffix — `ns`, `us`, `ms`, `s`, `m`, `h`, `d`, `w` — and combines parts, as in `-session-duration 1w2d`. A bare number is a count of **seconds**, so `-api-timeout 10` means ten seconds. See [Duration values](/docs/operating/configuration/#duration-values).
+
 ## solo
 
 Run a Hub and a Worker in one process on loopback, with no login (every request is auto-authenticated as the admin). See [Running LeapMux](/docs/operating/running-leapmux/#solo-mode) for details.
@@ -68,9 +70,9 @@ leapmux solo [flags]
 | `-storage-sqlite-max-conns` | `4` | SQLite max open connections |
 | `-max-incomplete-chunked` | `0` (= 4) | Max in-flight chunked sequences per channel (for the bundled Worker) |
 | `-max-message-size` | `0` (= 16 MiB) | Max application payload size in bytes; reassembled ceiling adds 64 KiB headroom |
-| `-api-timeout-seconds` | `10` | General API timeout |
-| `-agent-startup-timeout-seconds` | `300` | Agent startup timeout |
-| `-worktree-create-timeout-seconds` | `60` | Worktree creation timeout |
+| `-api-timeout` | `10s` | General API timeout |
+| `-agent-startup-timeout` | `5m` | Agent startup timeout |
+| `-worktree-create-timeout` | `1m` | Worktree creation timeout |
 | `-encryption-mode` | `post-quantum` | `classic` or `post-quantum` (for the bundled Worker) |
 | `-log-level` | `info` | `debug`, `info`, `warn`, `error` |
 | `-config` | `~/.config/leapmux/solo/solo.yaml` | Config file path |
@@ -105,7 +107,7 @@ This table lists the most common flags. The full set — including all PostgreSQ
 |------|---------|---------|
 | `-signup-enabled` | `false` | Enable user sign-up |
 | `-email-verification-required` | `false` | Require email verification on sign-up (needs `-smtp-host`) |
-| `-session-duration-seconds` | `691200` (8 days) | How long a session stays valid after the user's last request; each request slides the expiry forward |
+| `-session-duration` | `7d` | How long a session stays valid after the user's last request; each request slides the expiry forward |
 
 **SMTP options**
 
@@ -122,9 +124,9 @@ This table lists the most common flags. The full set — including all PostgreSQ
 
 | Flag | Default | Meaning |
 |------|---------|---------|
-| `-api-timeout-seconds` | `10` | General API timeout |
-| `-agent-startup-timeout-seconds` | `300` | Agent startup timeout |
-| `-worktree-create-timeout-seconds` | `60` | Worktree creation timeout |
+| `-api-timeout` | `10s` | General API timeout |
+| `-agent-startup-timeout` | `5m` | Agent startup timeout |
+| `-worktree-create-timeout` | `1m` | Worktree creation timeout |
 | `-max-message-size` | `0` (= 16 MiB) | Max application payload size in bytes; reassembled ceiling adds 64 KiB headroom |
 
 **Storage options**
@@ -180,8 +182,8 @@ leapmux worker -hub https://hub.example.com
 |------|---------|---------|
 | `-max-incomplete-chunked` | `0` (= 4) | Max in-flight chunked sequences per channel |
 | `-max-message-size` | `0` (= 16 MiB) | Max application payload size in bytes; reassembled ceiling adds 64 KiB headroom |
-| `-agent-startup-timeout-seconds` | `300` | Agent startup timeout |
-| `-api-timeout-seconds` | `10` | JSON-RPC request timeout |
+| `-agent-startup-timeout` | `5m` | Agent startup timeout |
+| `-api-timeout` | `10s` | JSON-RPC request timeout |
 
 **SQLite database options**
 
@@ -231,7 +233,7 @@ Dev mode uses the **same flag set as solo**, with two additions:
 | Flag | Default | Meaning |
 |------|---------|---------|
 | `-public-url` | empty | Public base URL when behind a reverse proxy |
-| `-session-duration-seconds` | `691200` (8 days) | How long a session stays valid after the user's last request. Solo has no session to expire, so the flag is dev-only; shorten it to exercise the signed-out path. |
+| `-session-duration` | `7d` | How long a session stays valid after the user's last request. Solo has no session to expire, so the flag is dev-only; shorten it to exercise the signed-out path (the minimum is `5m`). |
 
 The other differences from solo: the default `-listen` is `:4327` (all interfaces), the config/data location is `~/.config/leapmux/dev/`, and the bundled Worker's auto-registration is deferred until the first admin completes `/setup`.
 

--- a/site/content/docs/reference/troubleshooting.md
+++ b/site/content/docs/reference/troubleshooting.md
@@ -312,12 +312,12 @@ Install the agent's own CLI on the **Worker** machine (not where the browser run
 The chat pane shows a centered error titled **"&lt;Provider&gt; failed to start"** (e.g. "Claude Code failed to start") with an error message from the Worker.
 
 **Cause**
-The agent subprocess couldn't be launched or didn't complete its startup handshake. Common reasons: the CLI binary isn't actually runnable on the Worker (wrong version, broken install, missing auth), the working directory is invalid, or startup exceeded the timeout (`--agent-startup-timeout-seconds`, default **300**).
+The agent subprocess couldn't be launched or didn't complete its startup handshake. Common reasons: the CLI binary isn't actually runnable on the Worker (wrong version, broken install, missing auth), the working directory is invalid, or startup exceeded the timeout (`--agent-startup-timeout`, default **5m**).
 
 **Fix**
 - Read the error text shown in the pane — it comes straight from the Worker and usually names the cause.
 - On the Worker, run the agent's CLI directly (e.g. `claude --version`) to confirm it works and is authenticated.
-- If startup is legitimately slow, raise the timeout: `leapmux worker --agent-startup-timeout-seconds 600` (or the equivalent key in config). This flag exists on the Worker and on `hub`/`solo`/`dev` modes. See [Configuration](/docs/operating/configuration/).
+- If startup is legitimately slow, raise the timeout: `leapmux worker --agent-startup-timeout 10m` (or the equivalent key in config). This flag exists on the Worker and on `hub`/`solo`/`dev` modes. See [Configuration](/docs/operating/configuration/).
 - Reopen the agent once the underlying CLI issue is fixed.
 
 ### A model, effort, or permission-mode change seems to "reset" the agent

--- a/site/content/docs/using/accounts.md
+++ b/site/content/docs/using/accounts.md
@@ -193,9 +193,11 @@ When you log in, LeapMux issues a session and stores it in a secure, `HttpOnly` 
 
 | Property | Value |
 | --- | --- |
-| Session lifetime | **24 hours** |
+| Session lifetime | **8 days after your last activity** (operators can change this — see [`session_duration_seconds`](/docs/operating/configuration/)) |
 | Cookie name | `leapmux-session` (or `__Host-leapmux-session` when the operator enables secure cookies behind TLS) |
 | Cookie flags | `HttpOnly`, `Path=/`, `SameSite=Lax` |
+
+**The clock runs from your last activity, not from your login.** Every request you make slides the expiry forward and refreshes the cookie, so a session you keep using never runs out. The lifetime is an idle timeout: stay away for the whole period without touching LeapMux and you are signed out.
 
 **Staying signed in.** As long as your session has not expired, reloading the page keeps you logged in — LeapMux restores your session on load. If your session has expired or been revoked, a failed request quietly signs you out (no error is shown); just log in again.
 

--- a/site/content/docs/using/accounts.md
+++ b/site/content/docs/using/accounts.md
@@ -193,11 +193,11 @@ When you log in, LeapMux issues a session and stores it in a secure, `HttpOnly` 
 
 | Property | Value |
 | --- | --- |
-| Session lifetime | **8 days after your last activity** (operators can change this — see [`session_duration_seconds`](/docs/operating/configuration/)) |
+| Session lifetime | **7 days after your last activity** (operators can change this — see [`session_duration`](/docs/operating/configuration/)) |
 | Cookie name | `leapmux-session` (or `__Host-leapmux-session` when the operator enables secure cookies behind TLS) |
 | Cookie flags | `HttpOnly`, `Path=/`, `SameSite=Lax` |
 
-**The clock runs from your last activity, not from your login.** Every request you make slides the expiry forward and refreshes the cookie, so a session you keep using never runs out. The lifetime is an idle timeout: stay away for the whole period without touching LeapMux and you are signed out.
+**The clock runs from your last activity, not from your login.** Each action you take in the app slides the expiry forward and refreshes the cookie, so a session you keep using does not run out. The lifetime is an idle timeout: stay away for the whole period without touching LeapMux and you are signed out.
 
 **Staying signed in.** As long as your session has not expired, reloading the page keeps you logged in — LeapMux restores your session on load. If your session has expired or been revoked, a failed request quietly signs you out (no error is shown); just log in again.
 


### PR DESCRIPTION
## Motivation

Sliding sessions exist to remove the absolute-timeout behavior of a fixed lifetime, but several bugs conspired to reintroduce exactly that behavior:

- The slide throttle was a fixed 5 minutes, so any session shorter than that expired before its first slide could ever land. It behaved as a hard timeout from login no matter how active the user was.
- `MinSessionDuration` floored at 2x the validation-cache TTL (60s), which sat below the throttle window, leaving the whole 60s-300s band broken — and the docs actively steered operators into it.
- `CreateSession` (login) and `touchSession` (slide) computed the expiry independently and disagreed by a whole throttle window.
- A slide that a *rejected* call earned was thrown away. The DB row did slide, but the refreshed cookie was discarded, and the throttle then blocked every other request for a window — so a user whose calls kept failing (an unverified user at the email gate, a permission-denied loop) slid the row repeatedly and was still signed out at the login deadline.
- The cookie-refresh guard backed off from *any* `Set-Cookie` already on the response, so an unrelated cookie would silently disable the refresh.
- Session `Touch` had no expiry predicate in its `UPDATE`, so a request that reached the store after the row had already expired (served from the in-memory validation cache in that window) revived a dead session and re-issued a cookie for it. This is the security-relevant fix in this PR.

Chasing these required durations to be handled consistently end to end. Every duration-shaped config value in the Hub and the Worker was a bare integer named `*_seconds`, so the unit lived only in the field name, and an out-of-range value silently overflowed into a session lasting microseconds instead of failing. Separately, `FlagProvider.Read` returned a flat map with dotted keys (`storage.postgres.dsn`) instead of a nested one; koanf's `Get` still found the value, which masked the bug, but `Unmarshal` walks the nested map and never saw it — so every nested CLI flag parsed, reported no error, and was silently dropped.

## Modifications

- **Breaking:** every duration config key is renamed (drops `_seconds`) and retyped to `time.Duration`, in both the Hub and the Worker: `api_timeout_seconds`→`api_timeout`, `agent_startup_timeout_seconds`→`agent_startup_timeout`, `worktree_create_timeout_seconds`→`worktree_create_timeout`, `conn_max_lifetime_seconds`→`conn_max_lifetime`, `max_conn_idle_time_seconds`→`max_conn_idle_time`, `health_check_period_seconds`→`health_check_period`, `conn_max_idle_time_seconds`→`conn_max_idle_time`; new key `session_duration`. The CLI flag and env var follow each rename. **An old CLI flag name now fails loudly** (`flag provided but not defined: -api-timeout-seconds`), while **an old key in a YAML file or an env var is silently ignored** and the default applies — the two failure modes differ and both matter on upgrade. A bare number is still read as seconds, so only the key needs renaming, not its value. Durations also accept `d` (24h) and `w` (7d) plus combined and fractional forms (`1h30m`, `1.5h`).
- **Breaking:** `auth.SessionDuration` (a fixed 24h constant) is replaced by `DefaultSessionDuration` (7 days), plus `MinSessionDuration` (10x the validation-cache TTL, i.e. 5 minutes) and `ValidateSessionDuration`.
- **Breaking:** `NewInterceptor`/`NewInterceptorWithTokens`, which took positional bool/duration arguments, collapse into `NewInterceptor(InterceptorOptions{...})`. `Login`/`CreateSession` gain a `lifetime` parameter.
- The slide throttle scales with the session: `min(sessionTouchThreshold, lifetime/10)`, so a session slides after at most a tenth of its life and never waits more than 5 minutes. `sessionExpiry(now, lifetime)` is now the single function both `CreateSession` and `touchSession` use. The `lastTouch` sweep cutoff moves to the throttle window it actually protects, instead of the full session lifetime. A failed `Sessions().Touch` is logged, and the throttle is recorded before the `UPDATE`, so a failing store costs one attempt per window instead of one per request.
- The refresh now rides on a rejection: a `*connect.Error` carries the cookie in its metadata, which connect-go merges into the response header. An error of any other type passes through untouched, on purpose — wrapping it would report `CodeUnknown` where connect-go reports `CodeCanceled` for a cancelled request.
- The cookie-refresh guard matches the session cookie by name; an unparseable cookie is treated as a collision (fails closed).
- Session `Touch` gains an expiry predicate (`AND expires_at > NOW()` / `NOW(3)` / the SQLite strftime form) in all three dialects, covered by a new cross-dialect test in the shared `storetest` suite.
- `internal/config`: new shared `ParseDuration`, `FormatDuration`, `DurationFlag`, and an `Unmarshal` decode hook used by every source — including the number arm, since a YAML `api_timeout: 10` arrives as an int and would otherwise mean 10 nanoseconds. Values past the representable range (~292 years) are rejected instead of overflowing. Pool durations are deliberately excluded from the once-at-load default resolution, because zero there means "leave the driver default alone".
- Fixed `FlagProvider.Read` to return a nested map via `maps.Unflatten`, so nested CLI flags are honored again.
- A new `setSessionCookie` helper replaces four duplicated `Set-Cookie` writes. The `session-duration` flag is exposed in dev mode but not solo, since solo authenticates every request as the synthetic local user and mints no session row.
- New test helpers: `testutil/interceptor.go` (registers `t.Cleanup(registry.Stop)`; 13 call sites were leaking the interceptor's sweep goroutine) and `testutil/session.go` (`AssertSessionLifetime`, a range check rather than a formula copied from the code under test).
- Docs: a new "Duration values" reference section in `configuration.md`, pointers to it from the auth, timeout, pool and CLI tables, every renamed key and default updated, and a corrected statement in `accounts.md`.
- Frontend: test-only. No production frontend behavior changed; new tests pin the agent-info popover's `~`-abbreviated display and absolute-path copy, plus two uncovered `tildify` edge cases.

## Result

An active user's session no longer expires mid-use: the slide keeps pace with usage instead of being blocked by a fixed window, and it now reaches the browser even when the call is rejected. A configured duration under 5 minutes is refused at startup with a message naming the key, rather than accepted and quietly broken. A dead session can no longer be revived by a request that reaches the store just after expiry.

Operators write durations with units (`10s`, `1h30m`, `2d`) or keep a bare number, which still means seconds. On upgrade, a stale CLI flag stops the process at startup, but a stale YAML key or env var falls back to the default silently — so configs need checking against the new names, not just command lines. Nested CLI flags (`-storage-type`, DSNs, pool settings) are honored again instead of being silently dropped. The session lifetime is 7 days from last activity, not 24 hours from login.
