### PR TITLE
fix(ui): Clip sidebar row text to one line, tooltip when clipped

### DIFF
--- a/frontend/src/components/backgroundtasks/BackgroundTaskList.css.ts
+++ b/frontend/src/components/backgroundtasks/BackgroundTaskList.css.ts
@@ -30,9 +30,8 @@ export const sidebarRoot = style({
  *
  * The DropdownMenu card sizes to its content, so capping the list is what caps
  * the card. Both axes need a cap, for different reasons: a long registry
- * overflowed the card vertically, and one long shell command -- the rows wrap,
- * but the flex column still sizes to the widest unbroken run -- stretched it
- * sideways.
+ * overflows the card vertically, and a row holds each of its two lines on one
+ * line, so a long shell command asks for the full width of the command.
  *
  * Neither cap restates the VIEWPORT clamp: `popoverCard` in
  * `~/styles/popover.css.ts` already holds the card inside the viewport on both
@@ -44,13 +43,22 @@ export const popoverRoot = style({
   maxWidth: '360px',
 })
 
-/** The scrolling region the kind tabs swap. */
+/**
+ * The scrolling region the kind tabs swap.
+ *
+ * `overflow-x: hidden` is declared, not left out. `overflow-y: auto` alone makes
+ * CSS compute the other axis from `visible` to `auto`, so this box grew a
+ * horizontal scrollbar for any descendant that exceeded it. Every row now clips
+ * its own text, and this makes that structural: no descendant added later can
+ * bring the sideways scroll back.
+ */
 export const rows = style({
   display: 'flex',
   flexDirection: 'column',
   gap: '2px',
   padding: 'var(--space-1) var(--space-2)',
   overflowY: 'auto',
+  overflowX: 'hidden',
   minHeight: 0,
 })
 
@@ -70,7 +78,16 @@ export const loadFailedMessage = style({
   color: 'var(--danger)',
 })
 
+// Decoration only. `ClippedText` owns the clipping rule -- see
+// `~/components/common/ClippedText.tsx`.
+//
+// `display: block` is defensive, not load-bearing. The header is a <span>, and
+// an inline box would drop the vertical padding below; but the header renders
+// into `rows`, which is a flex container, and CSS blockifies a flex item
+// already. This declaration only holds the padding if `rows` stops being a flex
+// container.
 export const groupHeader = style({
+  display: 'block',
   padding: 'var(--space-1) 0',
   fontSize: 'var(--text-8)',
   fontWeight: 600,
@@ -125,33 +142,10 @@ const dotPulse = keyframes({
   '50%': { opacity: 0.35 },
 })
 
-/**
- * The status dot, FLOATED right inside the title.
- *
- * Float, not a flex sibling: the dot belongs at the right end of the title's
- * FIRST line, and a flex row would centre it against the whole wrapped block
- * instead. A right float sits at the top-right of its container, and because
- * the dot is only 8px tall in a ~17px line box, it shortens exactly that first
- * line -- every line below it, and the secondary line in the block underneath,
- * run the full width.
- *
- * 8px matches the workers section's dot (~/components/workers/workerSection.css.ts), so the two
- * sidebar sections read as one vocabulary.
- */
-export const statusDot = style({
-  float: 'right',
-  width: 8,
-  height: 8,
-  borderRadius: '50%',
-  flexShrink: 0,
-  marginLeft: 'var(--space-2)',
-  // Centres the dot on the first line's box. In em so it tracks the font size
-  // rather than needing a second magic number per variant.
-  marginTop: '0.35em',
-})
-
 // Status is carried by the dot's COLOR, so every row keeps the same shape and
-// the column reads as a status light rather than a set of glyphs to learn.
+// the column reads as a status light rather than a set of glyphs to learn. The
+// shape itself is the shared dot in `~/styles/shared.css.ts`, which the workers
+// section uses as well; only this palette is specific to the section.
 export const statusDotActive = style({
   'background': 'var(--primary)',
   '@media': {
@@ -183,45 +177,49 @@ export const taskBody = style({
   gap: '0',
 })
 
+/**
+ * The title line: the title itself, then the status dot at its right end.
+ *
+ * The dot is a flex sibling of the title, not a float inside it. The title is
+ * one clipped line now, so there is no wrapped block for a float to sit above
+ * -- a flex row centres the dot on that single line and needs no offset.
+ */
+export const titleRow = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 'var(--space-2)',
+  minWidth: 0,
+})
+
+// Decoration only. `ClippedText` owns the clipping rule -- see
+// `~/components/common/ClippedText.tsx`.
+//
+// `flex: 1` gives the title every pixel the dot does not take, which is what
+// puts the ellipsis at the right edge of the row rather than at the end of the
+// text. The component supplies the `min-width: 0` that lets it shrink that far.
 export const taskTitle = style({
-  // break-word + hyphens, NOT `anywhere`: the browser hyphenates at real
-  // syllable boundaries (the document is lang="en"), and only falls back to a
-  // hard mid-word break for a token it cannot hyphenate. `anywhere` would win
-  // every time and hyphenation would never run.
-  overflowWrap: 'break-word',
-  hyphens: 'auto',
+  flex: 1,
 })
 
 /**
- * A shell task's title is its COMMAND, so it is set in the monospace face and
- * wrapped like code, not like prose: hyphenation off (a hyphen inserted into a
- * path or a flag reads as part of the command), and breaking allowed anywhere
- * so a long `/path/like/this` wraps at the edge instead of pushing the whole
- * token to the next line and leaving the first one half empty.
+ * A shell task's title is its COMMAND, so it is set in the monospace face.
+ *
+ * Same size as any other title: the monospace face alone marks it as code, and
+ * stepping it down to the secondary line's size would flatten the
+ * title/subtitle hierarchy.
  */
 export const taskTitleCommand = style({
   fontFamily: 'var(--font-mono)',
-  // Same size as any other title: the monospace face alone marks it as code,
-  // and stepping it down to the secondary line's size would flatten the
-  // title/subtitle hierarchy. `anywhere` is what actually buys the width back
-  // -- it is whole-token wrapping, not the font size, that was leaving a line
-  // half empty in front of a long path.
-  overflowWrap: 'anywhere',
-  hyphens: 'none',
 })
 
-// Wraps rather than ellipsizing on one line. The activity text a provider
-// reports ("Running <what>", a tool name, a token tally) is the only thing that
-// says WHAT the subagent is doing, and the sidebar is narrow enough that a
-// single nowrap line cut almost all of it. Capped at three lines so one verbose
-// row cannot push the rest of the registry off screen.
+// Decoration only. `ClippedText` owns the clipping rule -- see
+// `~/components/common/ClippedText.tsx`.
+//
+// One clipped line, like the title. The activity text a provider reports
+// ("Running <what>", a tool name, a token tally) is often longer than the
+// sidebar is wide, so the full string is on the tooltip that ClippedText
+// attaches -- see renderSecondary in the component.
 export const taskSecondary = style({
   fontSize: 'var(--text-8)',
   color: 'var(--muted-foreground)',
-  overflow: 'hidden',
-  display: '-webkit-box',
-  WebkitBoxOrient: 'vertical',
-  WebkitLineClamp: 3,
-  overflowWrap: 'break-word',
-  hyphens: 'auto',
 })

--- a/frontend/src/components/backgroundtasks/BackgroundTaskList.test.tsx
+++ b/frontend/src/components/backgroundtasks/BackgroundTaskList.test.tsx
@@ -3,6 +3,9 @@ import { fireEvent, render } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
 import { BackgroundTaskList } from '~/components/backgroundtasks/BackgroundTaskList'
 import * as styles from '~/components/backgroundtasks/BackgroundTaskList.css'
+import { clippedText } from '~/styles/shared.css'
+import { hoverForTooltip, stubClipped, stubFitting } from '~/test-support/clipStub'
+import { classSelector } from '~/test-support/composedClass'
 
 function row(over: Partial<BackgroundTaskItem> & { rowKey: string }): BackgroundTaskItem {
   return {
@@ -33,6 +36,19 @@ function rowsText(container: HTMLElement): string {
   return container.querySelector('[role="tabpanel"]')!.textContent ?? ''
 }
 
+/** The class tokens on the element, so a test asserts membership, not a substring. */
+function classes(el: Element): string[] {
+  return el.className.trim().split(/\s+/)
+}
+
+function titles(container: HTMLElement): HTMLElement[] {
+  return [...container.querySelectorAll<HTMLElement>(classSelector(styles.taskTitle))]
+}
+
+function secondaries(container: HTMLElement): HTMLElement[] {
+  return [...container.querySelectorAll<HTMLElement>(classSelector(styles.taskSecondary))]
+}
+
 describe('backgroundTaskList', () => {
   it('renders a status glyph + title + activity for a running subagent', () => {
     const { container } = renderList({
@@ -47,18 +63,24 @@ describe('backgroundTaskList', () => {
     expect(container.textContent).toContain('running Bash')
   })
 
-  // The dot lives INSIDE the title, not as a sibling column: that is what lets
-  // it float to the right end of the title's first line while the secondary
-  // line below runs the full width.
-  it('puts the status dot inside the title, not beside it', () => {
+  // The dot is a SIBLING of the title on the title line, not a child of it. A
+  // child would count toward the title's own overflow, and the title is the
+  // element whose clipping decides whether its tooltip appears at all.
+  it('puts the status dot beside the title, on the title line', () => {
     const { container } = renderList({
       tasks: [row({ rowKey: 't1', title: 'Spawned agent', activity: 'running Bash' })],
     })
     const dot = container.querySelector('[data-testid="bg-task-status-dot"]')!
-    const title = container.querySelector(`.${styles.taskTitle}`)!
-    expect(title.contains(dot)).toBe(true)
-    // ...and NOT inside the secondary line, whose width it must not affect.
-    expect(container.querySelector(`.${styles.taskSecondary}`)!.contains(dot)).toBe(false)
+    const title = titles(container)[0]
+    expect(title.contains(dot)).toBe(false)
+    // Both sit on the title line...
+    const titleRow = container.querySelector(classSelector(styles.titleRow))!
+    expect(titleRow.contains(title)).toBe(true)
+    expect(titleRow.contains(dot)).toBe(true)
+    // ...and the dot follows the title, so it lands at the row's right end.
+    expect(title.compareDocumentPosition(dot) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    // The secondary line is a separate block and never holds the dot.
+    expect(secondaries(container)[0].contains(dot)).toBe(false)
   })
 
   // Code type follows the PROVIDER's claim, not the row's kind. A shell row
@@ -73,7 +95,7 @@ describe('backgroundTaskList', () => {
       ],
     })
     const titleOf = (text: string) =>
-      [...container.querySelectorAll(`.${styles.taskTitle}`)].find(t => t.textContent?.includes(text))!
+      titles(container).find(t => t.textContent?.includes(text))!
     expect(titleOf('go test').className).toContain(styles.taskTitleCommand)
     expect(titleOf('Run the worker').className).not.toContain(styles.taskTitleCommand)
     expect(titleOf('Review').className).not.toContain(styles.taskTitleCommand)
@@ -304,6 +326,120 @@ describe('backgroundTaskList kind tabs', () => {
     expect(rowsText(container)).toContain('my workflow')
     fireEvent.click(getByTestId('bg-task-filter-shell'))
     expect(rowsText(container)).not.toContain('my workflow')
+  })
+})
+
+/**
+ * Every line of a row is held to ONE line and clipped, and gives its full text
+ * back on hover. Wrapping made the sidebar section scroll sideways, because a
+ * label with no break opportunity escaped the box and `rows` computes its
+ * horizontal overflow to `auto`.
+ */
+describe('backgroundTaskList clipping', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  const hover = (el: Element): string | null => hoverForTooltip(el)?.textContent ?? null
+
+  it('clips the title and the secondary line to one line', () => {
+    const { container } = renderList({
+      tasks: [row({ rowKey: 't1', title: 'Spawned agent', activity: 'running Bash' })],
+    })
+    // Token membership, not a substring: a future class whose own name merely
+    // CONTAINS "clippedText" would satisfy a regex and prove nothing.
+    expect(classes(titles(container)[0])).toContain(clippedText)
+    expect(classes(secondaries(container)[0])).toContain(clippedText)
+  })
+
+  it('clips a group header, which had no wrapping rule at all', () => {
+    const { container } = renderList({
+      tasks: [row({ rowKey: 'g1', groupKey: 'wf:x', groupLabel: 'find-flaky-tests-and-fix-them' })],
+    })
+    const header = container.querySelector(classSelector(styles.groupHeader))!
+    expect(header.textContent).toBe('find-flaky-tests-and-fix-them')
+    expect(classes(header)).toContain(clippedText)
+  })
+
+  // The header had no tooltip at all before it was clipped, so the hover route
+  // is the whole of what replaced a label the reader could simply see.
+  it('gives the full group label on hover once the header is clipped', () => {
+    const label = 'find-flaky-tests-and-fix-them-across-every-package'
+    const { container } = renderList({
+      tasks: [row({ rowKey: 'g1', groupKey: 'wf:x', groupLabel: label })],
+    })
+    const header = container.querySelector<HTMLElement>(classSelector(styles.groupHeader))!
+    stubClipped(header)
+    expect(hover(header)).toBe(label)
+  })
+
+  it('gives the full title on hover once the title is clipped', () => {
+    const long = 'go test ./internal/worker/service/... -run TestEverything -count=1'
+    const { container } = renderList({
+      tasks: [row({ rowKey: 'cmd', kind: 'shell', title: long, titleIsCommand: true })],
+    })
+    const title = titles(container)[0]
+    stubClipped(title)
+    expect(hover(title)).toBe(long)
+  })
+
+  it('shows no title tooltip while the title fits', () => {
+    const { container } = renderList({ tasks: [row({ rowKey: 't1', title: 'Short' })] })
+    const title = titles(container)[0]
+    stubFitting(title)
+    expect(hover(title)).toBeNull()
+  })
+
+  it('gives the full activity on hover once the secondary line is clipped', () => {
+    const activity = 'Running Bash(git log --oneline --format=%H%x09%s -n 200)'
+    const { container } = renderList({
+      tasks: [row({ rowKey: 't1', title: 'Spawned agent', status: 'running', activity })],
+    })
+    const secondary = secondaries(container)[0]
+    stubClipped(secondary)
+    expect(hover(secondary)).toBe(activity)
+  })
+
+  // A finished status carries an explanation the label cannot: "Interrupted"
+  // does not say that a worker restart cut the task off. The explanation is
+  // ADDED to the label, never put in its place, so a label that clips keeps its
+  // own route back. It shows while the label fits too, because it carries what
+  // the label cannot.
+  it('adds an explanation to a finished status without losing its label', () => {
+    const { container } = renderList({ tasks: [row({ rowKey: 't1', status: 'interrupted' })] })
+    const secondary = secondaries(container)[0]
+    expect(secondary.textContent).toBe('Interrupted')
+    const tip = hover(secondary)
+    expect(tip).toContain('Interrupted')
+    expect(tip).toContain('stopped by a worker restart')
+  })
+
+  // The label stays reachable even when the row carries an explanation AND the
+  // label is too long for its box -- the case the previous shape lost.
+  it('keeps a clipped label reachable beside its explanation', () => {
+    const { container } = renderList({ tasks: [row({ rowKey: 't1', status: 'interrupted' })] })
+    const secondary = secondaries(container)[0]
+    stubClipped(secondary)
+    const tip = hover(secondary)
+    expect(tip).toContain('Interrupted')
+    expect(tip).toContain('stopped by a worker restart')
+  })
+
+  // ...and a finished status with no explanation falls back to the clipped
+  // behaviour, rather than losing its tooltip entirely.
+  it('falls back to the label for a finished status with no explanation', () => {
+    const { container } = renderList({ tasks: [row({ rowKey: 't1', status: 'failed' })] })
+    const secondary = secondaries(container)[0]
+    expect(secondary.textContent).toBe('Failed')
+    stubFitting(secondary)
+    expect(hover(secondary)).toBeNull()
+    stubClipped(secondary)
+    expect(hover(secondary)).toBe('Failed')
   })
 })
 

--- a/frontend/src/components/backgroundtasks/BackgroundTaskList.tsx
+++ b/frontend/src/components/backgroundtasks/BackgroundTaskList.tsx
@@ -4,8 +4,9 @@ import type { BackgroundTaskItem, BackgroundTaskKindFilter } from '~/stores/chat
 import Bot from 'lucide-solid/icons/bot'
 import Terminal from 'lucide-solid/icons/terminal'
 import { createMemo, createSignal, createUniqueId, For, Show } from 'solid-js'
+import { ClippedText } from '~/components/common/ClippedText'
 import { FilterTabBar } from '~/components/common/FilterTabBar'
-import { Tooltip } from '~/components/common/Tooltip'
+import { StatusDot } from '~/components/common/StatusDot'
 import {
   backgroundTaskEndLabel,
   backgroundTaskEndTooltip,
@@ -67,6 +68,46 @@ const KIND_TABS: readonly FilterTab<BackgroundTaskKindFilter>[]
  */
 const LOAD_FAILED_MESSAGE = 'Could not load background tasks from the worker'
 
+// The row's first line. Shared by the renderer and by the echo guard below, so
+// the guard compares against the string the row ACTUALLY shows: two copies of
+// this fallback chain could drift and silently disable the guard.
+function rowTitle(item: BackgroundTaskItem): string {
+  return item.title || item.description || item.rowKey
+}
+
+// Code type only for a title the PROVIDER says is a verbatim command. Not every
+// shell row has one: Claude sends `description || command`, so its title is the
+// model's prose whenever it wrote any, and setting that in the monospace face
+// reads worse than setting a command in the normal one.
+function titleClass(item: BackgroundTaskItem): string {
+  return item.titleIsCommand
+    ? `${styles.taskTitle} ${styles.taskTitleCommand}`
+    : styles.taskTitle
+}
+
+// The row's second line. It must never repeat the first: a provider whose spawn
+// payload carries one string for both (Claude's local_bash gives the command as
+// the description, which is already the title) otherwise rendered the same text
+// twice. Neutral guard here rather than per provider, so the next one to do it
+// is covered too.
+//
+// Compared trimmed, because a provider that pads or wraps its copy produces a
+// string that is visibly the same echo but not `===` to the title.
+function secondary(item: BackgroundTaskItem): string {
+  const text = isActiveBackgroundTaskStatus(item.status)
+    ? item.activity || item.description || ''
+    : backgroundTaskEndLabel(item.status)
+  return text.trim() === rowTitle(item).trim() ? '' : text
+}
+
+// Explanatory tooltip for a final status whose bare label is ambiguous
+// (e.g. "Interrupted" really means the worker/agent process restarted).
+function secondaryTooltip(item: BackgroundTaskItem): string | undefined {
+  if (isActiveBackgroundTaskStatus(item.status))
+    return undefined
+  return backgroundTaskEndTooltip(item.status)
+}
+
 /** The status palette: queued, in progress, succeeded, failed. */
 function statusDotClass(status: BackgroundTaskItem['status']): string {
   switch (status) {
@@ -95,8 +136,9 @@ function statusDotClass(status: BackgroundTaskItem['status']): string {
  * section and the ThinkingIndicator popover. Shared by both surfaces. Filters
  * by kind through its own tab bar, sorts active-first (running before pending),
  * groups by workflow/phase, and renders a kind icon, a title with its status dot
- * floated to the end of the first line, and a secondary line. Subagent rows with
- * a childAgentId are clickable buttons; shell rows are static.
+ * at the end of the title line, and a secondary line. Each line is held to one
+ * line and clipped, and gives its full text on hover. Subagent rows with a
+ * childAgentId are clickable buttons; shell rows are static.
  */
 export const BackgroundTaskList: Component<BackgroundTaskListProps> = (props) => {
   // Per mount, not shared: the sidebar section and the popover are separate
@@ -126,27 +168,18 @@ export const BackgroundTaskList: Component<BackgroundTaskListProps> = (props) =>
   // state. Six shapes made the column a legend to memorize; one dot in the
   // status palette (in progress / succeeded / failed) is legible at a glance,
   // and an in-progress dot pulses so activity is visible without a spinner.
-  // The exact state stays available as the dot's tooltip and as the row's
-  // `data-status`, which is what tests and E2E select on.
+  // The exact state stays available as the dot's accessible name and tooltip,
+  // and as the row's `data-status`, which is what tests and E2E select on.
   //
-  // Rendered INSIDE the title so it can float to the right end of the title's
-  // first line -- see statusDot in the stylesheet for why a float and not a
-  // flex sibling.
-  //
-  // role="img" is load-bearing, not decoration. Tooltip puts its ariaLabel on
-  // this element, and `aria-label` is PROHIBITED on an element with no role (it
-  // maps to ARIA's `generic`), so a screen reader may drop it -- and a static
-  // row is a plain <div>, with no enclosing button to compute a name from its
-  // contents. Without the role the status of a shell row would be carried by
-  // colour alone.
-  const statusDot = (item: BackgroundTaskItem): JSX.Element => (
-    <Tooltip text={backgroundTaskStatusLabel(item.status)} ariaLabel>
-      <span
-        class={`${styles.statusDot} ${statusDotClass(item.status)}`}
-        data-testid="bg-task-status-dot"
-        role="img"
-      />
-    </Tooltip>
+  // Rendered at the right end of the title line, as a flex sibling of the
+  // title -- see titleRow in the stylesheet.
+  const renderStatusDot = (item: BackgroundTaskItem): JSX.Element => (
+    <StatusDot
+      class={statusDotClass(item.status)}
+      label={backgroundTaskStatusLabel(item.status)}
+      tooltip
+      testId="bg-task-status-dot"
+    />
   )
 
   const kindIcon = (item: BackgroundTaskItem): JSX.Element => {
@@ -155,55 +188,21 @@ export const BackgroundTaskList: Component<BackgroundTaskListProps> = (props) =>
     return <Bot class={styles.taskIcon} size={14} />
   }
 
-  // The row's first line. Shared by the renderer and by the echo guard below,
-  // so the guard compares against the string the row ACTUALLY shows: two copies
-  // of this fallback chain could drift and silently disable the guard.
-  const rowTitle = (item: BackgroundTaskItem): string =>
-    item.title || item.description || item.rowKey
-
-  // Code type only for a title the PROVIDER says is a verbatim command. Not
-  // every shell row has one: Claude sends `description || command`, so its
-  // title is the model's prose whenever it wrote any, and setting that in the
-  // monospace face reads worse than setting a command in the normal one.
-  const titleClass = (item: BackgroundTaskItem): string =>
-    item.titleIsCommand
-      ? `${styles.taskTitle} ${styles.taskTitleCommand}`
-      : styles.taskTitle
-
-  // The row's second line. It must never repeat the first: a provider whose
-  // spawn payload carries one string for both (Claude's local_bash gives the
-  // command as the description, which is already the title) otherwise rendered
-  // the same text twice. Neutral guard here rather than per provider, so the
-  // next one to do it is covered too.
-  //
-  // Compared trimmed, because a provider that pads or wraps its copy produces a
-  // string that is visibly the same echo but not `===` to the title.
-  const secondary = (item: BackgroundTaskItem): string => {
-    const text = isActiveBackgroundTaskStatus(item.status)
-      ? item.activity || item.description || ''
-      : backgroundTaskEndLabel(item.status)
-    return text.trim() === rowTitle(item).trim() ? '' : text
-  }
-
-  // Explanatory tooltip for a final status whose bare label is ambiguous
-  // (e.g. "Interrupted" really means the worker/agent process restarted).
-  const secondaryTooltip = (item: BackgroundTaskItem): string | undefined => {
-    if (isActiveBackgroundTaskStatus(item.status))
-      return undefined
-    return backgroundTaskEndTooltip(item.status)
-  }
-
+  // The line is clipped to one line, so ClippedText offers the full string on
+  // hover. An explanatory tip is passed as the DETAIL, so it stands under the
+  // label rather than in its place -- a clipped label keeps its route back even
+  // when the row also has an explanation. A detail also shows while the label
+  // fits, because it carries what the label cannot.
   const renderSecondary = (item: BackgroundTaskItem): JSX.Element => {
     const text = secondary(item)
     if (!text)
       return null
-    const tip = secondaryTooltip(item)
-    if (!tip)
-      return <span class={styles.taskSecondary}>{text}</span>
     return (
-      <Tooltip text={tip}>
-        <span class={styles.taskSecondary}>{text}</span>
-      </Tooltip>
+      <ClippedText
+        text={text}
+        class={styles.taskSecondary}
+        detail={secondaryTooltip(item)}
+      />
     )
   }
 
@@ -214,12 +213,9 @@ export const BackgroundTaskList: Component<BackgroundTaskListProps> = (props) =>
     <>
       {kindIcon(item)}
       <div class={styles.taskBody}>
-        {/* The dot comes FIRST in source order: a right float is placed against
-            the top of the block it opens, so anything before it on that line
-            would push it down to the next one. */}
-        <div class={titleClass(item)}>
-          {statusDot(item)}
-          {rowTitle(item)}
+        <div class={styles.titleRow}>
+          <ClippedText text={rowTitle(item)} class={titleClass(item)} />
+          {renderStatusDot(item)}
         </div>
         {renderSecondary(item)}
       </div>
@@ -292,7 +288,7 @@ export const BackgroundTaskList: Component<BackgroundTaskListProps> = (props) =>
           <For each={grouped().groups}>
             {group => (
               <>
-                <div class={styles.groupHeader}>{group.label}</div>
+                <ClippedText text={group.label} class={styles.groupHeader} />
                 <For each={group.items}>{item => renderRow(item)}</For>
               </>
             )}

--- a/frontend/src/components/chat/AttachmentStrip.css.ts
+++ b/frontend/src/components/chat/AttachmentStrip.css.ts
@@ -28,12 +28,6 @@ export const pill = style({
   flexShrink: 0,
 })
 
-export const pillFilename = style({
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap',
-})
-
 export const pillIcon = style({
   flexShrink: 0,
   color: 'var(--muted-foreground)',

--- a/frontend/src/components/chat/AttachmentStrip.test.tsx
+++ b/frontend/src/components/chat/AttachmentStrip.test.tsx
@@ -3,6 +3,9 @@ import { render } from '@solidjs/testing-library'
 import { createSignal } from 'solid-js'
 import { describe, expect, it, vi } from 'vitest'
 import { AttachmentStrip } from '~/components/chat/AttachmentStrip'
+import { clippedText } from '~/styles/shared.css'
+import { hoverForTooltip, stubClipped, stubFitting } from '~/test-support/clipStub'
+import { classSelector } from '~/test-support/composedClass'
 
 function makeAttachment(overrides: Partial<FileAttachment> = {}): FileAttachment {
   return {
@@ -63,6 +66,50 @@ describe('attachmentStrip', () => {
     const filename = container.querySelector('[data-testid="attachment-pill"] > span:nth-of-type(2) > span') as HTMLSpanElement
     expect(filename).toBeInTheDocument()
     expect(filename).toHaveTextContent('very/long/nested/path/to/screenshot.png')
+  })
+
+  /**
+   * The pill caps at 200px, so a long file name clips and the tooltip is the
+   * only route to the rest. It used to show that tooltip UNCONDITIONALLY, which
+   * repeated a name the reader could already see in full.
+   */
+  describe('filename tooltip', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+      vi.restoreAllMocks()
+    })
+
+    function labelOf(container: HTMLElement): HTMLElement {
+      return container.querySelector<HTMLElement>(classSelector(clippedText))!
+    }
+
+    it('gives the full filename on hover once the pill clips it', () => {
+      const [attachments] = createSignal<FileAttachment[]>([
+        makeAttachment({ id: 'a1', filename: 'a-screenshot-with-a-name-far-wider-than-the-pill.png' }),
+      ])
+      const { container } = render(() => (
+        <AttachmentStrip attachments={attachments} onRemove={() => {}} />
+      ))
+      const label = labelOf(container)
+      stubClipped(label)
+      expect(hoverForTooltip(label)?.textContent).toBe('a-screenshot-with-a-name-far-wider-than-the-pill.png')
+    })
+
+    it('shows no tooltip while the filename fits', () => {
+      const [attachments] = createSignal<FileAttachment[]>([
+        makeAttachment({ id: 'a1', filename: 'a.png' }),
+      ])
+      const { container } = render(() => (
+        <AttachmentStrip attachments={attachments} onRemove={() => {}} />
+      ))
+      const label = labelOf(container)
+      stubFitting(label)
+      expect(hoverForTooltip(label)).toBeNull()
+    })
   })
 
   it('calls onRemove with the correct id when remove button is clicked', () => {

--- a/frontend/src/components/chat/AttachmentStrip.tsx
+++ b/frontend/src/components/chat/AttachmentStrip.tsx
@@ -4,6 +4,7 @@ import FileIcon from 'lucide-solid/icons/file'
 import FileImageIcon from 'lucide-solid/icons/file-image'
 import X from 'lucide-solid/icons/x'
 import { For, Show } from 'solid-js'
+import { ClippedText } from '~/components/common/ClippedText'
 import { Icon } from '~/components/common/Icon'
 import { Tooltip } from '~/components/common/Tooltip'
 import { isImageMimeType } from './attachments'
@@ -41,9 +42,7 @@ export const AttachmentStrip: Component<AttachmentStripProps> = (props) => {
                   size="xs"
                 />
               </span>
-              <Tooltip text={attachment.filename}>
-                <span class={styles.pillFilename}>{attachment.filename}</span>
-              </Tooltip>
+              <ClippedText text={attachment.filename} />
               <Tooltip text="Remove attachment" ariaLabel>
                 <button
                   class={styles.removeButton}

--- a/frontend/src/components/chat/ToolUseLayout.test.tsx
+++ b/frontend/src/components/chat/ToolUseLayout.test.tsx
@@ -5,6 +5,7 @@ import { beforeAll, describe, expect, it, vi } from 'vitest'
 import { ToolUseLayout } from '~/components/chat/toolRenderers'
 import { toolBodyBorder, toolBodyContent, toolInputText } from '~/components/chat/toolStyles.css'
 import { PreferencesProvider } from '~/context/PreferencesContext'
+import { classSelector } from '~/test-support/composedClass'
 
 // jsdom does not provide ResizeObserver
 beforeAll(() => {
@@ -205,6 +206,26 @@ describe('toolUseLayout', () => {
     expect(customIcon?.parentElement?.querySelector('svg')).toBeNull()
   })
 
+  // The positive control for the test below. Without it, an absence assertion
+  // proves nothing: a selector that matches no element ANYWHERE passes it. This
+  // pins that the selector does find the wrapper when the title is a string.
+  it('wraps a string title in a toolInputText span', () => {
+    const { container } = render(() => (
+      <PreferencesProvider>
+        <ToolUseLayout
+          icon={ListTodo}
+          toolName="TestTool"
+          title="3 tasks"
+          context={makeContext()}
+        />
+      </PreferencesProvider>
+    ))
+
+    const wrapper = container.querySelector(classSelector(toolInputText))
+    expect(wrapper).toBeInTheDocument()
+    expect(wrapper).toHaveTextContent('3 tasks')
+  })
+
   it('renders JSX title without toolInputText wrapper', () => {
     const { container } = render(() => (
       <PreferencesProvider>
@@ -219,8 +240,11 @@ describe('toolUseLayout', () => {
 
     expect(screen.getByTestId('custom-title')).toBeInTheDocument()
     expect(container).toHaveTextContent('Custom JSX')
-    // Should NOT wrap JSX title in toolInputText span
-    const toolInputTextSpan = container.querySelector(`.${toolInputText}`)
+    // `classSelector`, not `.${toolInputText}`: the style composes `clippedText`,
+    // so it exports two space-separated class names and the template form is a
+    // descendant selector that matches nothing and passes this assertion for
+    // the wrong reason.
+    const toolInputTextSpan = container.querySelector(classSelector(toolInputText))
     expect(toolInputTextSpan).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/components/chat/composer/composer.css.ts
+++ b/frontend/src/components/chat/composer/composer.css.ts
@@ -1,6 +1,6 @@
 import { globalStyle, style } from '@vanilla-extract/css'
 import { popoverColumnClamp } from '~/styles/popover.css'
-import { chipBase } from '~/styles/shared.css'
+import { chipBase, clippedText } from '~/styles/shared.css'
 import { breakpoints } from '~/styles/tokens'
 
 /**
@@ -76,11 +76,13 @@ export const axisChip = style([chipBase, {
   userSelect: 'none',
 }])
 
-export const axisChipLabel = style({
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
+// `clippedText` restates the `nowrap` that `axisChip` above already passes down
+// by inheritance, and adds the `min-width: 0` this was missing. The chip is a
+// flex container, so without it the label kept the width of its own text and
+// the ellipsis declared here waited on `max-width` alone to trigger.
+export const axisChipLabel = style([clippedText, {
   maxWidth: '14em',
-})
+}])
 
 // --- Popovers ---
 
@@ -156,15 +158,11 @@ export const subTrigger = style({
  * (the branch item). `subTrigger` pushes its two children apart, so the icon and
  * the text need one box between them or the chevron separates them instead.
  */
-export const subTriggerLabel = style({
+export const subTriggerLabel = style([clippedText, {
   display: 'inline-flex',
   alignItems: 'center',
   gap: 'var(--space-2)',
-  minWidth: 0,
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap',
-})
+}])
 
 export const subPopover = style([composerMenuPopover, {
   padding: 'var(--space-1)',

--- a/frontend/src/components/chat/markdownEditor/markdownContent.css.ts
+++ b/frontend/src/components/chat/markdownEditor/markdownContent.css.ts
@@ -110,6 +110,12 @@ globalStyle(`.${BLOCKED_IMAGE_CHIP_CLASS}`, {
 
 // The author's alt text (or the URL when there is no alt). Clickable only when the
 // sibling link-hardening pass kept it an <a> (http(s) srcs); otherwise it is plain text.
+//
+// The clipping is spelled out rather than composed from `clippedText` in
+// `~/styles/shared.css.ts`. A composition applies to a `style()`, and this is a
+// `globalStyle` keyed on a FIXED class name that the rehype plugin writes into
+// the rendered HTML. Reaching the shared rule would mean the plugin emitting the
+// hashed class too, which couples a markdown transform to a stylesheet.
 globalStyle(`.${BLOCKED_IMAGE_LABEL_CLASS}`, {
   overflow: 'hidden',
   textOverflow: 'ellipsis',

--- a/frontend/src/components/chat/results/webSearchResults.test.tsx
+++ b/frontend/src/components/chat/results/webSearchResults.test.tsx
@@ -1,0 +1,73 @@
+import { render } from '@solidjs/testing-library'
+import { describe, expect, it, vi } from 'vitest'
+import { clippedText } from '~/styles/shared.css'
+import { hoverForTooltip, stubClipped, stubFitting } from '~/test-support/clipStub'
+import { classSelector } from '~/test-support/composedClass'
+import { WebSearchResultsBody } from './webSearchResults'
+
+const LONG_TITLE = 'How to configure a reverse proxy for a self-hosted service without breaking websockets'
+
+function renderResults(title = LONG_TITLE) {
+  return render(() => (
+    <WebSearchResultsBody
+      source={{
+        links: [{ title, url: 'https://example.com/a/deep/path' }],
+        summary: '',
+      }}
+    />
+  ))
+}
+
+describe('webSearchResultsBody', () => {
+  it('renders the link title and its domain', () => {
+    const { container } = renderResults()
+    expect(container.textContent).toContain(LONG_TITLE)
+    expect(container.textContent).toContain('example.com')
+  })
+
+  /**
+   * A search-result title runs far past this panel, so the ellipsis is
+   * guaranteed and the tooltip is the only route to the rest.
+   *
+   * The clip stays on the SPAN, not on the <a> it holds: an inline
+   * non-replaced box ignores `overflow`, so moving it would lose the ellipsis.
+   * That is also why this site keeps a hand-built `Tooltip` instead of
+   * `ClippedText`, which renders a plain string and cannot hold the link.
+   */
+  describe('title clipping', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+      vi.restoreAllMocks()
+    })
+
+    function labelOf(container: HTMLElement): HTMLElement {
+      return container.querySelector<HTMLElement>(classSelector(clippedText))!
+    }
+
+    it('keeps the clip on the span that holds the link', () => {
+      const { container } = renderResults()
+      const label = labelOf(container)
+      expect(label.tagName).toBe('SPAN')
+      expect(label.querySelector('a')).toBeTruthy()
+      expect(label.querySelector('a')!.className).not.toMatch(/clippedText/)
+    })
+
+    it('gives the full title on hover once it is clipped', () => {
+      const { container } = renderResults()
+      const label = labelOf(container)
+      stubClipped(label)
+      expect(hoverForTooltip(label)?.textContent).toBe(LONG_TITLE)
+    })
+
+    it('shows no tooltip while the title fits', () => {
+      const { container } = renderResults('Short')
+      const label = labelOf(container)
+      stubFitting(label)
+      expect(hoverForTooltip(label)).toBeNull()
+    })
+  })
+})

--- a/frontend/src/components/chat/results/webSearchResults.tsx
+++ b/frontend/src/components/chat/results/webSearchResults.tsx
@@ -2,9 +2,11 @@ import type { JSX } from 'solid-js'
 import type { RenderContext } from '../messageRenderers'
 import type { WebSearchLink } from './webSearchExtract'
 import { For, Show } from 'solid-js'
+import { Tooltip } from '~/components/common/Tooltip'
 import { cachedInnerHtml } from '~/lib/htmlFragmentCache'
 import { pluralize } from '~/lib/plural'
 import { extractDomain } from '~/lib/url'
+import { clippedText } from '~/styles/shared.css'
 import { getToolResultExpanded, renderMarkdownForContext } from '../messageRenderers'
 import {
   toolMessage,
@@ -14,7 +16,6 @@ import {
   webSearchLink,
   webSearchLinkDomain,
   webSearchLinkList,
-  webSearchLinkTitle,
 } from '../toolStyles.css'
 import { useCollapsedItems } from './useCollapsedLines'
 
@@ -45,9 +46,17 @@ export function WebSearchResultsBody(props: {
           <For each={displayLinks()}>
             {link => (
               <div class={webSearchLink}>
-                <span class={webSearchLinkTitle}>
-                  <a href={link.url} target="_blank" rel="noopener noreferrer nofollow">{link.title}</a>
-                </span>
+                {/* The raw style plus a hand-built `Tooltip`, not `ClippedText`:
+                    the label has to hold the <a>, and `ClippedText` renders a
+                    plain string. The clip must stay on the SPAN, because an
+                    inline non-replaced box like the <a> ignores `overflow` and
+                    would lose the ellipsis. A search result title runs far past
+                    this panel, so the tooltip is the only route to the rest. */}
+                <Tooltip text={link.title} showWhen="clipped">
+                  <span class={clippedText}>
+                    <a href={link.url} target="_blank" rel="noopener noreferrer nofollow">{link.title}</a>
+                  </span>
+                </Tooltip>
                 <span class={webSearchLinkDomain}>{extractDomain(link.url)}</span>
               </div>
             )}

--- a/frontend/src/components/chat/todoListMessage.test.tsx
+++ b/frontend/src/components/chat/todoListMessage.test.tsx
@@ -1,0 +1,61 @@
+import type { TodoItem } from '~/stores/chatTodos'
+import { render } from '@solidjs/testing-library'
+import { beforeAll, describe, expect, it } from 'vitest'
+import { TodoListMessage } from '~/components/chat/todoListMessage'
+import * as todoStyles from '~/components/todo/TodoList.css'
+import { PreferencesProvider } from '~/context/PreferencesContext'
+import { clippedText } from '~/styles/shared.css'
+import { classSelector } from '~/test-support/composedClass'
+
+// jsdom does not provide ResizeObserver, which ToolUseLayout observes with.
+beforeAll(() => {
+  globalThis.ResizeObserver ??= class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver
+})
+
+const LONG = 'Investigate why the worker channel drops after the hub restarts and add a reconnect test'
+
+function renderMessage(todos: TodoItem[]) {
+  return render(() => (
+    <PreferencesProvider>
+      <TodoListMessage source={{ toolName: 'TodoWrite', title: '1 task', todos }} />
+    </PreferencesProvider>
+  ))
+}
+
+describe('todoListMessage', () => {
+  /**
+   * The transcript's tool card stretches to the tile, so it has the room to
+   * show a whole to-do. The sidebar section (~208px) does not, which is why the
+   * list clips there and must NOT clip here.
+   */
+  it('renders the to-do list in its wrapping variant', () => {
+    const { container } = renderMessage([
+      { id: '1', content: LONG, status: 'pending', activeForm: '' },
+    ])
+
+    const list = container.querySelector(classSelector(todoStyles.todoList))!
+    expect(list.className).toMatch(/todoListWrapping/)
+  })
+
+  // The label still routes through ClippedText, so the wrapping variant turns
+  // the clip off through CSS rather than by rendering a different element.
+  it('keeps the label on the shared clipping element', () => {
+    const { container } = renderMessage([
+      { id: '1', content: LONG, status: 'pending', activeForm: '' },
+    ])
+
+    const label = container.querySelector(classSelector(todoStyles.todoText))!
+    expect(label.textContent).toBe(LONG)
+    expect(label.className.trim().split(/\s+/)).toContain(clippedText)
+  })
+
+  it('falls back to the cleared placeholder for an empty list', () => {
+    const { container } = renderMessage([])
+
+    expect(container.querySelector(classSelector(todoStyles.todoList))).toBeNull()
+  })
+})

--- a/frontend/src/components/chat/todoListMessage.tsx
+++ b/frontend/src/components/chat/todoListMessage.tsx
@@ -56,7 +56,9 @@ export function TodoListMessage(props: {
           markdownCopied: copied(),
         }}
       >
-        <TodoList todos={todos()} />
+        {/* `full`: a tool card stretches to the tile, so it has the room to
+            show a whole to-do. The sidebar section and the popover do not. */}
+        <TodoList todos={todos()} variant="full" />
       </ToolUseLayout>
     </Show>
   )

--- a/frontend/src/components/chat/toolStyles.css.ts
+++ b/frontend/src/components/chat/toolStyles.css.ts
@@ -1,6 +1,7 @@
 import { globalStyle, style } from '@vanilla-extract/css'
 import { todoList } from '~/components/todo/TodoList.css'
 import { codeTypography, codeWrap } from '~/styles/codeBlock'
+import { clippedText } from '~/styles/shared.css'
 import { shikiDualThemeColors } from './shikiTokenColors.css'
 import { LINE_THICKNESS, TOOL_BODY_INDENT } from './widgets/SpanLines.geometry'
 
@@ -170,24 +171,16 @@ shikiDualThemeColors(`${toolInputSummary} pre.shiki span`, { bg: true })
 shikiDualThemeColors(`${toolInputSummary} span[data-shiki-token]`, { bg: true })
 
 // Tool input detail text (natural language: descriptions, URLs, queries)
-export const toolInputText = style({
+export const toolInputText = style([clippedText, {
   color: 'var(--foreground)',
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap',
-  minWidth: 0,
-})
+}])
 
 // Tool input code text (commands, patterns — monospaced)
-export const toolInputCode = style({
+export const toolInputCode = style([clippedText, {
   color: 'var(--foreground)',
   fontFamily: 'var(--font-mono)',
   fontVariantLigatures: 'none',
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap',
-  minWidth: 0,
-})
+}])
 
 // File path display in tool messages
 export const toolInputPath = style({
@@ -267,13 +260,6 @@ export const webSearchLink = style({
   fontSize: 'var(--text-8)',
   lineHeight: 1.5,
   overflow: 'hidden',
-})
-
-export const webSearchLinkTitle = style({
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap',
-  minWidth: 0,
 })
 
 export const webSearchLinkDomain = style({

--- a/frontend/src/components/common/ClippedText.css.ts
+++ b/frontend/src/components/common/ClippedText.css.ts
@@ -1,0 +1,12 @@
+import { style } from '@vanilla-extract/css'
+
+/**
+ * The explanation line inside the tooltip, under the label it explains.
+ *
+ * Set apart from the label above it, so the reader sees which line repeats the
+ * row and which line adds to it.
+ */
+export const detailLine = style({
+  fontSize: 'var(--text-8)',
+  color: 'var(--muted-foreground)',
+})

--- a/frontend/src/components/common/ClippedText.test.tsx
+++ b/frontend/src/components/common/ClippedText.test.tsx
@@ -1,0 +1,175 @@
+import { render, screen } from '@solidjs/testing-library'
+import { createSignal } from 'solid-js'
+import { describe, expect, it, vi } from 'vitest'
+import { clippedText } from '~/styles/shared.css'
+import { hoverForTooltip, stubClipped, stubFitting } from '~/test-support/clipStub'
+import { ClippedText } from './ClippedText'
+
+function label(container: HTMLElement): HTMLElement {
+  const el = container.querySelector('span[class]')
+  expect(el).toBeTruthy()
+  return el as HTMLElement
+}
+
+/** The class tokens on the element, so a test asserts membership, not a substring. */
+function classes(el: Element): string[] {
+  return el.className.trim().split(/\s+/)
+}
+
+describe('clippedText', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('renders the text in a single span carrying the clipping style', () => {
+    const { container } = render(() => <ClippedText text="a worker name" />)
+
+    // Tooltip resolves its target as the ONE direct element child of its
+    // display:contents wrapper, so a second element here would disable it.
+    const wrapper = container.firstElementChild!
+    expect(wrapper.childElementCount).toBe(1)
+    const el = label(container)
+    expect(el.tagName).toBe('SPAN')
+    expect(el.textContent).toBe('a worker name')
+    expect(classes(el)).toContain(clippedText)
+  })
+
+  // Tooltip's wrapper must stay transparent to layout. Every clipped label is a
+  // flex item that needs `min-width: 0` to shrink, which only holds while the
+  // wrapper does not become a box of its own between the row and the label.
+  it('leaves the tooltip wrapper transparent to layout', () => {
+    const { container } = render(() => <ClippedText text="x" />)
+
+    expect((container.firstElementChild as HTMLElement).style.display).toBe('contents')
+  })
+
+  it('merges an extra class after the clipping style', () => {
+    const { container } = render(() => <ClippedText text="x" class="taskSecondary" />)
+
+    const el = label(container)
+    expect(classes(el)).toContain(clippedText)
+    expect(classes(el)).toContain('taskSecondary')
+  })
+
+  it('applies testId to the span itself, not to the wrapper', () => {
+    const { container } = render(() => <ClippedText text="w1" testId="worker-name" />)
+
+    const el = screen.getByTestId('worker-name')
+    expect(el).toBe(label(container))
+  })
+
+  it('suppresses the tooltip while the label fits', () => {
+    const { container } = render(() => <ClippedText text="short" />)
+
+    const el = label(container)
+    stubFitting(el)
+
+    expect(hoverForTooltip(el)).toBeNull()
+    expect(el).not.toHaveAttribute('aria-describedby')
+  })
+
+  it('shows the full text once the label is clipped', () => {
+    const { container } = render(() => (
+      <ClippedText text="a label far wider than the row that holds it" />
+    ))
+
+    const el = label(container)
+    stubClipped(el)
+
+    expect(hoverForTooltip(el)?.textContent).toBe('a label far wider than the row that holds it')
+  })
+
+  // The point of `detail`: the explanation is ADDED to the label, never put in
+  // its place. A caller that supplies an explanation must not thereby spend the
+  // clipped label's own route back.
+  it('shows the label above its detail, not in place of it', () => {
+    const { container } = render(() => (
+      <ClippedText text="Interrupted" detail="stopped by a worker restart" />
+    ))
+
+    const el = label(container)
+    stubClipped(el)
+
+    const tip = hoverForTooltip(el)!
+    expect(tip.textContent).toContain('Interrupted')
+    expect(tip.textContent).toContain('stopped by a worker restart')
+  })
+
+  // A detail carries what the label CANNOT, so clipping is not its trigger.
+  it('shows a detail while the label fits', () => {
+    const { container } = render(() => (
+      <ClippedText text="Write the docs" detail="Describe every flag" />
+    ))
+
+    const el = label(container)
+    stubFitting(el)
+
+    expect(hoverForTooltip(el)?.textContent).toContain('Describe every flag')
+  })
+
+  // An EMPTY detail is an absent one. It must not force the tooltip open on a
+  // label that fits, and it must not render a blank second line.
+  it('treats an empty detail as absent', () => {
+    const { container } = render(() => <ClippedText text="the full label" detail="" />)
+
+    const el = label(container)
+    stubFitting(el)
+    expect(hoverForTooltip(el)).toBeNull()
+
+    stubClipped(el)
+    expect(hoverForTooltip(el)?.textContent).toBe('the full label')
+  })
+
+  it('obeys an explicit showWhen over the default that detail sets', () => {
+    const { container } = render(() => (
+      <ClippedText text="Task" detail="why it matters" showWhen="clipped" />
+    ))
+
+    const el = label(container)
+    stubFitting(el)
+
+    expect(hoverForTooltip(el)).toBeNull()
+  })
+
+  it('renders no tooltip for an empty label', () => {
+    const { container } = render(() => <ClippedText text="" />)
+
+    const el = label(container)
+    stubClipped(el)
+
+    expect(hoverForTooltip(el)).toBeNull()
+  })
+
+  it('tracks a changing text in both the label and its tooltip', () => {
+    const [text, setText] = createSignal('first')
+    const { container } = render(() => <ClippedText text={text()} />)
+
+    const el = label(container)
+    expect(el.textContent).toBe('first')
+
+    setText('second')
+    expect(el.textContent).toBe('second')
+
+    stubClipped(el)
+    expect(hoverForTooltip(el)?.textContent).toBe('second')
+  })
+
+  // A detail that arrives after the first render must start to show the
+  // tooltip, so the prop has to stay inside a tracked scope.
+  it('tracks a detail that appears later', () => {
+    const [detail, setDetail] = createSignal<string | undefined>()
+    const { container } = render(() => <ClippedText text="Run tests" detail={detail()} />)
+
+    const el = label(container)
+    stubFitting(el)
+    expect(hoverForTooltip(el)).toBeNull()
+
+    setDetail('the whole suite')
+    expect(hoverForTooltip(el)?.textContent).toContain('the whole suite')
+  })
+})

--- a/frontend/src/components/common/ClippedText.tsx
+++ b/frontend/src/components/common/ClippedText.tsx
@@ -1,0 +1,83 @@
+import type { JSX } from 'solid-js'
+import { Tooltip } from '~/components/common/Tooltip'
+import { clippedText } from '~/styles/shared.css'
+import { detailLine } from './ClippedText.css'
+
+export interface ClippedTextProps {
+  /** The one-line label. */
+  text: string
+  /**
+   * An explanation that the label cannot carry: a description the row has no
+   * room for, or the meaning of a terse status.
+   *
+   * The tooltip then shows ALWAYS, because an explanation is not recoverable in
+   * any other way, and it renders the label ABOVE the explanation. The
+   * explanation adds to the label; it never replaces it. A label that clips
+   * therefore keeps its route back even when it also carries an explanation.
+   *
+   * An empty string counts as absent.
+   */
+  detail?: string
+  /**
+   * Overrides when the tooltip appears. The default is `'clipped'`, or
+   * `'always'` when {@link ClippedTextProps.detail} is set. Pass this only to
+   * override that rule.
+   */
+  showWhen?: 'always' | 'clipped'
+  /** Extra classes for the span: the font face, the colour, the flex sizing. */
+  class?: string
+  /** `data-testid` for the span, so a test can select the label itself. */
+  testId?: string
+}
+
+/**
+ * A label held to ONE line, clipped with an ellipsis, with the full text on
+ * hover once it is actually clipped.
+ *
+ * The two halves belong together: an ellipsis hides text, and the tooltip is
+ * the only way the reader gets it back. Keeping them in one component is what
+ * makes "clipped with no way to read the rest" impossible to write by accident.
+ * `detail` follows the same rule: it is added ABOVE its explanation rather than
+ * put in its place, so a caller cannot spend the label's own route back.
+ *
+ * This component is the SOLE owner of the clipping rule. A caller passes
+ * decoration only -- the font face, the colour, the flex sizing -- and must not
+ * compose `clippedText` into that class, because a second owner makes the
+ * removal of either one invisible.
+ *
+ * One authorized override exists: `todoListWrapping` in
+ * `~/components/todo/TodoList.css.ts` turns the clip back off for the chat
+ * transcript, where the card is wide enough to show the whole label. It wins on
+ * specificity, not on stylesheet order.
+ *
+ * Renders exactly one element, because `Tooltip` resolves its target as the
+ * single direct element child of its wrapper and disables itself otherwise.
+ */
+export function ClippedText(props: ClippedTextProps) {
+  const spanClass = () => (props.class ? `${clippedText} ${props.class}` : clippedText)
+  // An EMPTY explanation is no explanation. It must not force the tooltip open
+  // on a label that fits, and it must not render a blank second line.
+  const detail = () => props.detail || undefined
+  const content = (): JSX.Element | undefined => {
+    const explanation = detail()
+    if (!explanation)
+      return undefined
+    return (
+      <>
+        <div>{props.text}</div>
+        <div class={detailLine}>{explanation}</div>
+      </>
+    )
+  }
+  return (
+    <Tooltip
+      text={props.text}
+      content={content()}
+      showWhen={props.showWhen ?? (detail() ? 'always' : 'clipped')}
+    >
+      <span class={spanClass()} data-testid={props.testId}>
+        {props.text}
+      </span>
+    </Tooltip>
+  )
+}

--- a/frontend/src/components/common/DropdownMenu.tsx
+++ b/frontend/src/components/common/DropdownMenu.tsx
@@ -4,7 +4,7 @@ import { createEffect, createSignal, createUniqueId, on, onCleanup, Show } from 
 import { Dynamic } from 'solid-js/web'
 import { calcPopoverPosition } from '~/lib/popoverPosition'
 import { popoverCard } from '~/styles/popover.css'
-import { menuItemContent, menuItemLabel, menuItemShortcut } from '~/styles/shared.css'
+import { clippedText, menuItemContent, menuItemShortcut } from '~/styles/shared.css'
 
 /**
  * Marks a dropdown's trigger element. An enclosing popover's dismiss handler
@@ -114,7 +114,12 @@ export interface DropdownMenuItemContentProps {
 export function DropdownMenuItemContent(props: DropdownMenuItemContentProps) {
   return (
     <span class={menuItemContent}>
-      <span class={menuItemLabel}>{props.label}</span>
+      {/* The raw style, not `ClippedText`: `label` is arbitrary JSX, and
+          `ClippedText` renders a plain string. Every live caller passes one
+          today, so narrowing `label` to `string` would let this take the
+          component -- that changes a shared prop contract, so it is the
+          author's call, not a mechanical swap. */}
+      <span class={clippedText}>{props.label}</span>
       <Show when={props.shortcut}>
         {shortcut => <span class={menuItemShortcut}>{shortcut()}</span>}
       </Show>
@@ -173,7 +178,13 @@ export function DropdownMenuCheckableItem(props: DropdownMenuCheckableItemProps)
     >
       <span class={menuItemContent}>
         <input type={props.kind} checked={props.checked} disabled aria-hidden="true" style={{ 'pointer-events': 'none' }} />
-        <span class={menuItemLabel}>{props.label}</span>
+        {/* The raw style, not `ClippedText`, although `label` is a string. A
+            caller already wraps this whole button in a `Tooltip` that carries
+            the option's DESCRIPTION. A second tooltip inside it would dismiss
+            that one -- `Tooltip` keeps at most one open -- and replace the
+            description with a verbatim repeat of the label, which is a net
+            loss. The fix is one tooltip chosen by the item, not two nested. */}
+        <span class={clippedText}>{props.label}</span>
       </span>
     </button>
   )

--- a/frontend/src/components/common/SelectionQuotePopover.css.ts
+++ b/frontend/src/components/common/SelectionQuotePopover.css.ts
@@ -10,7 +10,7 @@ export const popover = style({
   'boxShadow': '0 2px 8px rgba(0, 0, 0, 0.15)',
   'opacity': 0.9,
   // Counter-translate body's `--vv-offset` mitigation (see
-  // `global.css.ts`). Body uses `transform: translateY(-vv-offset)` to
+  // `~/styles/global.css.ts`). Body uses `transform: translateY(-vv-offset)` to
   // cancel the iOS-26 stuck visualViewport offset, which incidentally
   // makes body the containing block for descendants like this popover.
   // Without the counter-translate, the JS-computed (viewport-relative)

--- a/frontend/src/components/common/StatusDot.test.tsx
+++ b/frontend/src/components/common/StatusDot.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@solidjs/testing-library'
+import { describe, expect, it, vi } from 'vitest'
+import { statusDot } from '~/styles/shared.css'
+import { hoverForTooltip } from '~/test-support/clipStub'
+import { StatusDot } from './StatusDot'
+
+describe('statusDot', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  function dotOf(container: HTMLElement): HTMLElement {
+    return container.querySelector<HTMLElement>('[role="img"]')!
+  }
+
+  // The state is carried by the dot's COLOUR, which reaches nobody who cannot
+  // see it. `role="img"` is what lets `aria-label` attach at all: the attribute
+  // is prohibited on an element with no role.
+  it('names the state for a reader who cannot see the colour', () => {
+    const { container } = render(() => <StatusDot label="Connected" />)
+
+    const dot = dotOf(container)
+    expect(dot.getAttribute('role')).toBe('img')
+    expect(dot.getAttribute('aria-label')).toBe('Connected')
+  })
+
+  it('carries the shared shape plus the palette class', () => {
+    const { container } = render(() => <StatusDot label="Failed" class="danger" />)
+
+    const classes = dotOf(container).className.trim().split(/\s+/)
+    expect(classes).toContain(statusDot)
+    expect(classes).toContain('danger')
+  })
+
+  it('applies status and testId to the dot itself', () => {
+    render(() => <StatusDot label="Connected" status="connected" testId="worker-dot" />)
+
+    const dot = screen.getByTestId('worker-dot')
+    expect(dot.getAttribute('data-status')).toBe('connected')
+  })
+
+  it('shows the label on hover when a tooltip is asked for', () => {
+    const { container } = render(() => <StatusDot label="Running" tooltip />)
+
+    expect(hoverForTooltip(dotOf(container))?.textContent).toBe('Running')
+  })
+
+  // A dot inside `actionSlot` is `pointer-events: none`, so a tooltip there
+  // could never fire. Leaving it out keeps the accessible name and drops the
+  // machinery that would do nothing.
+  it('renders no tooltip by default', () => {
+    const { container } = render(() => <StatusDot label="Connected" />)
+
+    expect(hoverForTooltip(dotOf(container))).toBeNull()
+  })
+
+  it('renders exactly one element, as Tooltip requires of its child', () => {
+    const { container } = render(() => <StatusDot label="Running" tooltip />)
+
+    expect(container.firstElementChild!.childElementCount).toBe(1)
+  })
+})

--- a/frontend/src/components/common/StatusDot.tsx
+++ b/frontend/src/components/common/StatusDot.tsx
@@ -1,0 +1,61 @@
+import { Show } from 'solid-js'
+import { Tooltip } from '~/components/common/Tooltip'
+import { statusDot } from '~/styles/shared.css'
+
+export interface StatusDotProps {
+  /** The palette class that colours the dot for this state. */
+  class?: string
+  /**
+   * What the colour MEANS, in words.
+   *
+   * Required, because the dot carries its state as colour alone. It becomes the
+   * element's accessible name, and the hover text when {@link StatusDotProps.tooltip}
+   * is set.
+   */
+  label: string
+  /**
+   * Also show {@link StatusDotProps.label} on hover.
+   *
+   * Leave it off for a dot that cannot receive pointer events. A dot inside an
+   * `actionSlot` carries `actionSlotResting`, which sets `pointer-events: none`
+   * so it does not swallow the click aimed at the menu trigger it shares a cell
+   * with -- a tooltip there would never fire.
+   */
+  tooltip?: boolean
+  /** `data-status`, which the tests and the E2E specs select on. */
+  status?: string
+  testId?: string
+}
+
+/**
+ * The small round status light that a sidebar row carries at its right end.
+ *
+ * Pairs the shape with a text alternative, the way `ClippedText` pairs a clip
+ * with its tooltip: a state carried by COLOUR alone reaches nobody who cannot
+ * see the colour, so `label` is required rather than optional. Each section
+ * still supplies its own palette through `class`, because the states differ --
+ * a worker is connected or disconnected, a background task is queued, running,
+ * succeeded, failed, or stopped.
+ *
+ * `role="img"` is load-bearing, not decoration. `aria-label` is PROHIBITED on
+ * an element with no role, because such an element maps to ARIA's `generic`,
+ * and a screen reader may drop the label.
+ */
+export function StatusDot(props: StatusDotProps) {
+  const dot = () => (
+    <span
+      class={props.class ? `${statusDot} ${props.class}` : statusDot}
+      role="img"
+      aria-label={props.label}
+      data-status={props.status}
+      data-testid={props.testId}
+    />
+  )
+  return (
+    <Show when={props.tooltip} fallback={dot()}>
+      <Tooltip text={props.label} ariaLabel>
+        {dot()}
+      </Tooltip>
+    </Show>
+  )
+}

--- a/frontend/src/components/common/Tooltip.test.tsx
+++ b/frontend/src/components/common/Tooltip.test.tsx
@@ -214,6 +214,107 @@ describe('tooltip', () => {
 
       expect(screen.getByRole('tooltip', { hidden: true })).toBeInTheDocument()
     })
+
+    // A row scrolled part-way out of a vertical list FITS its own box. Treating
+    // that as clipped would show a tooltip that repeats the visible label, on
+    // every sidebar row that happens to sit at the edge of its scroller.
+    it('ignores an ancestor that cuts the target vertically only', () => {
+      render(() => (
+        <div style={{ 'overflow-x': 'hidden', 'overflow-y': 'auto', 'height': '30px' }}>
+          <Tooltip text="Tooltip text" showWhen="clipped">
+            <button type="button">Row label</button>
+          </Tooltip>
+        </div>
+      ))
+
+      const button = screen.getByRole('button')
+      const container = button.closest('div')!
+      // The target sits ABOVE the scroller's client box, and fits it sideways.
+      stubRect(button, { left: 10, top: 10, right: 60, bottom: 30, width: 50, height: 20 })
+      stubRect(container, { left: 0, top: 20, right: 100, bottom: 50, width: 100, height: 30 })
+      Object.defineProperty(container, 'clientLeft', { value: 0, configurable: true })
+      Object.defineProperty(container, 'clientTop', { value: 0, configurable: true })
+      Object.defineProperty(container, 'clientWidth', { value: 100, configurable: true })
+      Object.defineProperty(container, 'clientHeight', { value: 30, configurable: true })
+
+      fireEvent.mouseEnter(button)
+      vi.advanceTimersByTime(700)
+
+      expect(screen.queryByRole('tooltip', { hidden: true })).toBeNull()
+    })
+  })
+
+  /**
+   * A tap must reach a clipped label's tooltip. Hover cannot: a tap synthesizes
+   * `mouseenter` and then `click`, and the `click` handler dismisses long
+   * before the 700 ms hover timer, so nothing ever appeared on a touch screen.
+   */
+  describe('touch', () => {
+    const tap = (el: Element) => {
+      fireEvent(el, new PointerEvent('pointerup', { pointerType: 'touch', bubbles: true }))
+      fireEvent.click(el)
+    }
+
+    it('opens on a tap, with no hover delay', () => {
+      render(() => (
+        <Tooltip text="Tooltip text">
+          <button type="button">Trigger</button>
+        </Tooltip>
+      ))
+
+      tap(screen.getByRole('button', { name: 'Trigger' }))
+
+      // No timer advance: a tap is deliberate and needs no delay to prove it.
+      expect(screen.getByRole('tooltip', { hidden: true })).toBeInTheDocument()
+    })
+
+    it('closes on the next press outside the trigger', () => {
+      render(() => (
+        <Tooltip text="Tooltip text">
+          <button type="button">Trigger</button>
+        </Tooltip>
+      ))
+
+      const button = screen.getByRole('button', { name: 'Trigger' })
+      tap(button)
+      expect(screen.getByRole('tooltip', { hidden: true })).toBeInTheDocument()
+
+      // The trigger's rect is 0x0 in jsdom, so any coordinate is outside it.
+      fireEvent(document, new PointerEvent('pointerdown', { clientX: 500, clientY: 500, bubbles: true }))
+
+      expect(screen.queryByRole('tooltip', { hidden: true })).toBeNull()
+    })
+
+    it('stays closed on a tap when the label is not clipped', () => {
+      render(() => (
+        <Tooltip text="Tooltip text" showWhen="clipped">
+          <button type="button">Trigger</button>
+        </Tooltip>
+      ))
+
+      // A mouse click dismisses; a tap that opens nothing must do the same, so
+      // the swallow-the-click guard must not latch on a suppressed tooltip.
+      tap(screen.getByRole('button', { name: 'Trigger' }))
+
+      expect(screen.queryByRole('tooltip', { hidden: true })).toBeNull()
+    })
+
+    it('leaves a mouse click dismissing the tooltip', () => {
+      render(() => (
+        <Tooltip text="Tooltip text">
+          <button type="button">Trigger</button>
+        </Tooltip>
+      ))
+
+      const button = screen.getByRole('button', { name: 'Trigger' })
+      fireEvent.mouseEnter(button)
+      vi.advanceTimersByTime(700)
+      expect(screen.getByRole('tooltip', { hidden: true })).toBeInTheDocument()
+
+      fireEvent.click(button)
+
+      expect(screen.queryByRole('tooltip', { hidden: true })).toBeNull()
+    })
   })
 
   it('warns and leaves invalid children unchanged', () => {

--- a/frontend/src/components/common/Tooltip.tsx
+++ b/frontend/src/components/common/Tooltip.tsx
@@ -3,8 +3,10 @@ import { createEffect, createSignal, createUniqueId, getOwner, onCleanup, onMoun
 import { Portal } from 'solid-js/web'
 import * as styles from './Tooltip.css'
 
-const SHOW_DELAY_MS = 700
-const HIDE_DELAY_MS = 100
+/** Exported so a test advances its fake timers by the real delay. */
+export const SHOW_DELAY_MS = 700
+/** Exported so a test advances its fake timers by the real delay. */
+export const HIDE_DELAY_MS = 100
 /** Extra margin around trigger rect for the pointermove hit-test. */
 const HOVER_MARGIN_PX = 4
 /** Sub-pixel slack when comparing rects/scroll sizes for clip detection. */
@@ -68,7 +70,10 @@ function clipsOverflow(el: Element): boolean {
  * 1. If the target itself has non-visible overflow on an axis where its
  *    scroll size exceeds its client size, it's truncating its own content.
  * 2. Otherwise, walk parent elements; for each one whose computed overflow
- *    isn't `visible`, check whether the target's rect extends past it.
+ *    isn't `visible`, check whether the target's rect extends past it
+ *    HORIZONTALLY. The vertical axis is deliberately not tested: a row
+ *    scrolled part-way out of a list fits its own box, and treating that as
+ *    clipped shows a tooltip that only repeats the visible label.
  * 3. Finally, treat the viewport edges as a clipping boundary.
  *
  * Limitation: this walks `parentElement`, not containing-block ancestors,
@@ -95,16 +100,19 @@ function isTargetClipped(target: Element): boolean {
     // Use the client box (border-inside, scrollbar-excluded) instead of the
     // bounding rect, so a target hidden behind the ancestor's scrollbar
     // still counts as clipped.
+    //
+    // The HORIZONTAL axis only. A container that deliberately runs past its
+    // scroller (`sectionItems` is `width: max-content`) hides text that no
+    // ellipsis marks, and this walk is the only detector for it. The vertical
+    // axis carries no such case: a row scrolled half out of a list FITS its own
+    // box, and reporting it as clipped shows a tooltip that repeats a label the
+    // reader can already read.
     const ar = ancestor.getBoundingClientRect()
     const visibleLeft = ar.left + ancestor.clientLeft
-    const visibleTop = ar.top + ancestor.clientTop
     const visibleRight = visibleLeft + ancestor.clientWidth
-    const visibleBottom = visibleTop + ancestor.clientHeight
     if (
       rect.left < visibleLeft - CLIP_TOLERANCE_PX
-      || rect.top < visibleTop - CLIP_TOLERANCE_PX
       || rect.right > visibleRight + CLIP_TOLERANCE_PX
-      || rect.bottom > visibleBottom + CLIP_TOLERANCE_PX
     ) {
       return true
     }
@@ -154,6 +162,8 @@ export function Tooltip(props: TooltipProps) {
   let showTimer: ReturnType<typeof setTimeout> | undefined
   let hideTimer: ReturnType<typeof setTimeout> | undefined
   let warnedInvalidChild = false
+  /** True while a tap opened this tooltip, so its own `click` does not close it. */
+  let openedByTouch = false
 
   const resolveTargetEl = (): TooltipTarget | undefined => {
     const node = triggerWrapperEl?.firstElementChild
@@ -179,11 +189,30 @@ export function Tooltip(props: TooltipProps) {
   /** Dismiss this tooltip immediately. */
   const dismiss = () => {
     clearTimers()
+    openedByTouch = false
     if (activeHide === dismiss)
       activeHide = undefined
     // eslint-disable-next-line ts/no-use-before-define -- mutual recursion between dismiss and onPointerMove
     document.removeEventListener('pointermove', onPointerMove)
+    // eslint-disable-next-line ts/no-use-before-define -- mutual recursion between dismiss and onOutsidePointerDown
+    document.removeEventListener('pointerdown', onOutsidePointerDown)
     setVisible(false)
+  }
+
+  /**
+   * Dismisses a tooltip that a TAP opened, on the next press outside the
+   * trigger. `onPointerMove` cannot do this: a touch pointer reports no
+   * movement between taps, so nothing would ever close it.
+   */
+  const onOutsidePointerDown = (e: PointerEvent) => {
+    const rect = getTriggerRect()
+    if (!rect) {
+      dismiss()
+      return
+    }
+    const { clientX: x, clientY: y } = e
+    if (x < rect.left || x > rect.right || y < rect.top || y > rect.bottom)
+      dismiss()
   }
 
   /**
@@ -208,50 +237,93 @@ export function Tooltip(props: TooltipProps) {
     }
   }
 
+  /**
+   * Show the tooltip now, if it has content and passes the clip test.
+   *
+   * Returns whether it became visible, which the touch path below uses to
+   * decide whether the tap opened anything.
+   */
+  const present = (): boolean => {
+    const target = targetEl()
+    const rect = target?.getBoundingClientRect()
+    if (!target || !rect)
+      return false
+
+    if (props.showWhen === 'clipped' && !isTargetClipped(target))
+      return false
+
+    // Dismiss any other visible tooltip first.
+    activeHide?.()
+    activeHide = dismiss
+
+    // Position above the trigger, centered horizontally.
+    // transform: translate(-50%, -100%) places the tooltip's
+    // bottom-center at this point.
+    setPos({ top: rect.top - 6, left: rect.left + rect.width / 2 })
+    setVisible(true)
+
+    // Start watching pointer position as a fallback for mouseleave.
+    document.addEventListener('pointermove', onPointerMove)
+    document.addEventListener('pointerdown', onOutsidePointerDown)
+
+    // Clamp to viewport after the tooltip renders.
+    requestAnimationFrame(() => {
+      if (!tooltipEl)
+        return
+      const tr = tooltipEl.getBoundingClientRect()
+      let { top, left } = pos()
+      // Clamp horizontally
+      const halfW = tr.width / 2
+      if (left - halfW < 4)
+        left = halfW + 4
+      else if (left + halfW > window.innerWidth - 4)
+        left = window.innerWidth - 4 - halfW
+      // If tooltip would go above viewport, flip below the trigger
+      if (tr.top < 4)
+        top = rect.bottom + 6 + tr.height
+      setPos({ top, left })
+    })
+    return true
+  }
+
   const show = () => {
     if (!props.text && !props.content)
       return
     clearTimers()
-    showTimer = setTimeout(() => {
-      const target = targetEl()
-      const rect = target?.getBoundingClientRect()
-      if (!target || !rect)
-        return
+    showTimer = setTimeout(present, SHOW_DELAY_MS)
+  }
 
-      if (props.showWhen === 'clipped' && !isTargetClipped(target))
-        return
+  /**
+   * The touch path: a TAP opens the tooltip, with no hover delay.
+   *
+   * Without this a clipped label is unreadable on a touch screen. A tap
+   * synthesizes `mouseenter` and then `click`; the `click` handler below
+   * dismisses, and it lands well before the 700 ms hover timer, so the tooltip
+   * never appeared. A tap is deliberate, unlike a pointer crossing a row, so it
+   * needs no delay to prove intent.
+   */
+  const showOnTouch = (e: PointerEvent) => {
+    if (e.pointerType !== 'touch')
+      return
+    if (!props.text && !props.content)
+      return
+    clearTimers()
+    // Only swallow the following `click` when the tap actually opened
+    // something. A label that fits still dismisses on tap, as a mouse does.
+    openedByTouch = present()
+  }
 
-      // Dismiss any other visible tooltip first.
-      activeHide?.()
-      activeHide = dismiss
-
-      // Position above the trigger, centered horizontally.
-      // transform: translate(-50%, -100%) places the tooltip's
-      // bottom-center at this point.
-      setPos({ top: rect.top - 6, left: rect.left + rect.width / 2 })
-      setVisible(true)
-
-      // Start watching pointer position as a fallback for mouseleave.
-      document.addEventListener('pointermove', onPointerMove)
-
-      // Clamp to viewport after the tooltip renders.
-      requestAnimationFrame(() => {
-        if (!tooltipEl)
-          return
-        const tr = tooltipEl.getBoundingClientRect()
-        let { top, left } = pos()
-        // Clamp horizontally
-        const halfW = tr.width / 2
-        if (left - halfW < 4)
-          left = halfW + 4
-        else if (left + halfW > window.innerWidth - 4)
-          left = window.innerWidth - 4 - halfW
-        // If tooltip would go above viewport, flip below the trigger
-        if (tr.top < 4)
-          top = rect.bottom + 6 + tr.height
-        setPos({ top, left })
-      })
-    }, SHOW_DELAY_MS)
+  /**
+   * `click` dismisses, EXCEPT the one that completes the tap which just opened
+   * this tooltip. A tap fires `pointerup` and then `click`, so without this the
+   * tooltip would close in the same gesture that opened it.
+   */
+  const dismissOnClick = () => {
+    if (openedByTouch) {
+      openedByTouch = false
+      return
+    }
+    dismiss()
   }
 
   const hide = () => {
@@ -281,13 +353,21 @@ export function Tooltip(props: TooltipProps) {
     // Clicking (or activating via Space/Enter) means the user is taking an
     // action — dismiss immediately so the tooltip doesn't linger over a
     // menu or state change. `click` fires for both mouse and keyboard.
-    const handleDismiss = wrapInOwner(dismiss)
+    const handleDismiss = wrapInOwner(dismissOnClick)
+    const handleTouch = (e: PointerEvent) => {
+      const run = () => showOnTouch(e)
+      if (tooltipOwner)
+        runWithOwner(tooltipOwner, run)
+      else
+        run()
+    }
 
     target.addEventListener('mouseenter', handleShow)
     target.addEventListener('mouseleave', handleHide)
     target.addEventListener('focusin', handleShow)
     target.addEventListener('focusout', handleHide)
     target.addEventListener('click', handleDismiss)
+    target.addEventListener('pointerup', handleTouch as EventListener)
 
     onCleanup(() => {
       target.removeEventListener('mouseenter', handleShow)
@@ -295,6 +375,7 @@ export function Tooltip(props: TooltipProps) {
       target.removeEventListener('focusin', handleShow)
       target.removeEventListener('focusout', handleHide)
       target.removeEventListener('click', handleDismiss)
+      target.removeEventListener('pointerup', handleTouch as EventListener)
     })
   })
 

--- a/frontend/src/components/filebrowser/FileBrowser.css.ts
+++ b/frontend/src/components/filebrowser/FileBrowser.css.ts
@@ -72,11 +72,12 @@ export const dirIcon = style([fileIcon, {
   color: 'var(--primary)',
 }])
 
+// Decoration only. `ClippedText` owns the clipping rule -- see
+// `~/components/common/ClippedText.tsx`. It also supplies the `min-width: 0`
+// this was missing: without it a `flex: 1` item keeps the width of its own
+// text, so a long file name widened the row and the ellipsis never appeared.
 export const fileName = style({
   flex: 1,
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap',
 })
 
 export const fileSize = style({

--- a/frontend/src/components/filebrowser/FileBrowser.test.tsx
+++ b/frontend/src/components/filebrowser/FileBrowser.test.tsx
@@ -3,7 +3,11 @@ import { create } from '@bufbuild/protobuf'
 import { render, screen } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
 import { FileBrowser } from '~/components/filebrowser/FileBrowser'
+import * as styles from '~/components/filebrowser/FileBrowser.css'
 import { FileInfoSchema } from '~/generated/leapmux/v1/file_pb'
+import { clippedText } from '~/styles/shared.css'
+import { hoverForTooltip, stubClipped, stubFitting } from '~/test-support/clipStub'
+import { classSelector } from '~/test-support/composedClass'
 
 function makeEntry(name: string, isDir: boolean, size: bigint = 0n): FileInfo {
   return create(FileInfoSchema, {
@@ -29,6 +33,60 @@ describe('fileBrowser', () => {
       />
     ))
     expect(screen.getByText('Empty directory')).toBeInTheDocument()
+  })
+
+  const LONG_NAME = 'a-file-name-far-wider-than-the-browser-column.tsx'
+
+  function renderWithLongName() {
+    return render(() => (
+      <FileBrowser
+        currentPath="."
+        entries={[makeEntry(LONG_NAME, false, 10n)]}
+        loading={false}
+        error={null}
+        onNavigate={() => {}}
+        onFileSelect={() => {}}
+      />
+    ))
+  }
+
+  // The name clips to one line. It declared the ellipsis before but not the
+  // `min-width: 0` a `flex: 1` item needs to shrink past its own text, so a long
+  // name widened the row instead. `ClippedText` supplies both.
+  it('clips a file name to one line', () => {
+    const { container } = renderWithLongName()
+    const name = container.querySelector(classSelector(styles.fileName))!
+    expect(name.textContent).toBe(LONG_NAME)
+    // Token membership, not a substring: a future class whose own name merely
+    // CONTAINS "clippedText" would satisfy a regex and prove nothing.
+    expect(name.className.trim().split(/\s+/)).toContain(clippedText)
+  })
+
+  // The clip alone would leave the rest of the name unreachable, which is the
+  // pairing the shared component exists to enforce.
+  describe('clipped name tooltip', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+      vi.restoreAllMocks()
+    })
+
+    it('gives the full file name on hover once it is clipped', () => {
+      const { container } = renderWithLongName()
+      const name = container.querySelector<HTMLElement>(classSelector(styles.fileName))!
+      stubClipped(name)
+      expect(hoverForTooltip(name)?.textContent).toBe(LONG_NAME)
+    })
+
+    it('shows no tooltip while the file name fits', () => {
+      const { container } = renderWithLongName()
+      const name = container.querySelector<HTMLElement>(classSelector(styles.fileName))!
+      stubFitting(name)
+      expect(hoverForTooltip(name)).toBeNull()
+    })
   })
 
   it('renders loading state', () => {

--- a/frontend/src/components/filebrowser/FileBrowser.tsx
+++ b/frontend/src/components/filebrowser/FileBrowser.tsx
@@ -1,6 +1,7 @@
 import type { Component } from 'solid-js'
 import type { FileInfo } from '~/generated/leapmux/v1/file_pb'
 import { createMemo, For, Show } from 'solid-js'
+import { ClippedText } from '~/components/common/ClippedText'
 import { formatBytes } from '~/lib/formatBytes'
 import { detectFlavor, parentDirectory, pathSegments, sep } from '~/lib/paths'
 import { emptyState } from '~/styles/shared.css'
@@ -95,7 +96,7 @@ export const FileBrowser: Component<FileBrowserProps> = (props) => {
                   <span class={entry.isDir ? styles.dirIcon : styles.fileIcon}>
                     {entry.isDir ? 'D' : 'F'}
                   </span>
-                  <span class={styles.fileName}>{entry.name}</span>
+                  <ClippedText text={entry.name} class={styles.fileName} />
                   <Show when={!entry.isDir}>
                     <span class={styles.fileSize}>{formatBytes(entry.size)}</span>
                   </Show>

--- a/frontend/src/components/shell/AgentProviderSelector.css.ts
+++ b/frontend/src/components/shell/AgentProviderSelector.css.ts
@@ -37,12 +37,6 @@ export const triggerValue = style({
   minWidth: 0,
 })
 
-export const triggerLabel = style({
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap',
-})
-
 export const triggerChevron = style({
   color: 'var(--muted-foreground)',
   flexShrink: 0,

--- a/frontend/src/components/shell/AgentProviderSelector.test.tsx
+++ b/frontend/src/components/shell/AgentProviderSelector.test.tsx
@@ -4,6 +4,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { AgentProviderSelector } from '~/components/shell/AgentProviderSelector'
 import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import { sortAgentProvidersByName } from '~/lib/agentProviders'
+import { clippedText } from '~/styles/shared.css'
+import { hoverForTooltip, stubClipped } from '~/test-support/clipStub'
+import { classSelector } from '~/test-support/composedClass'
 
 vi.mock('~/components/common/DropdownMenu', () => ({
   DropdownMenu: (props: any) => (
@@ -50,6 +53,65 @@ describe('agentProviderSelector', () => {
     const trigger = screen.getByTestId('agent-provider-selector-trigger')
     expect(trigger).toHaveTextContent('No agents available')
     expect(trigger).toBeDisabled()
+  })
+
+  /**
+   * The trigger caps its width, so a provider name can clip. The label is a
+   * plain string on an ENABLED control, so the tooltip is reachable and the
+   * clipping belongs to `ClippedText`.
+   */
+  describe('trigger label clipping', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+      vi.restoreAllMocks()
+    })
+
+    // Scoped to the TRIGGER: the same provider name also labels its menu item.
+    function labelOf(): HTMLElement {
+      const trigger = screen.getByTestId('agent-provider-selector-trigger')
+      return trigger.querySelector<HTMLElement>(classSelector(clippedText))!
+    }
+
+    it('holds the provider name to one clipped line', () => {
+      const [value] = createSignal(AgentProvider.CLAUDE_CODE)
+      render(() => (
+        <AgentProviderSelector value={value} onChange={() => {}} availableProviders={[AgentProvider.CLAUDE_CODE]} />
+      ))
+
+      expect(labelOf().textContent).toBe('Claude Code')
+    })
+
+    it('gives the full provider name on hover once it is clipped', () => {
+      const [value] = createSignal(AgentProvider.CLAUDE_CODE)
+      render(() => (
+        <AgentProviderSelector value={value} onChange={() => {}} availableProviders={[AgentProvider.CLAUDE_CODE]} />
+      ))
+
+      const label = labelOf()
+      stubClipped(label)
+      expect(hoverForTooltip(label)?.textContent).toBe('Claude Code')
+    })
+
+    // The empty state's label sits under `disabled`, which receives no pointer
+    // events, so it keeps the raw style and gets no tooltip. Pinning that keeps
+    // the exception deliberate rather than an oversight.
+    it('leaves the disabled empty-state label without a tooltip', () => {
+      const [value] = createSignal(AgentProvider.CLAUDE_CODE)
+      const { container } = render(() => (
+        <AgentProviderSelector value={value} onChange={() => {}} availableProviders={[]} />
+      ))
+
+      const label = screen.getByText('No agents available')
+      expect(label.className.trim().split(/\s+/)).toContain(clippedText)
+      // No Tooltip wrapper: the label is a direct child of the trigger's value
+      // span, not of a `display: contents` wrapper.
+      expect((label.parentElement as HTMLElement).style.display).not.toBe('contents')
+      expect(container.querySelector('[role="tooltip"]')).toBeNull()
+    })
   })
 
   it('renders icon-capable trigger and updates selection', async () => {

--- a/frontend/src/components/shell/AgentProviderSelector.tsx
+++ b/frontend/src/components/shell/AgentProviderSelector.tsx
@@ -4,12 +4,14 @@ import Check from 'lucide-solid/icons/check'
 import ChevronDown from 'lucide-solid/icons/chevron-down'
 import { createMemo, For, Show } from 'solid-js'
 import { AgentProviderIcon, agentProviderLabel } from '~/components/common/AgentProviderIcon'
+import { ClippedText } from '~/components/common/ClippedText'
 import { labelRow } from '~/components/common/Dialog.css'
 import { DropdownMenu } from '~/components/common/DropdownMenu'
 import { Icon } from '~/components/common/Icon'
 import { RefreshButton } from '~/components/common/RefreshButton'
 import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import { getAvailableAgentProviders, sortAgentProvidersByName } from '~/lib/agentProviders'
+import { clippedText } from '~/styles/shared.css'
 import * as styles from './AgentProviderSelector.css'
 
 interface AgentProviderSelectorProps {
@@ -52,7 +54,11 @@ export function AgentProviderSelector(props: AgentProviderSelectorProps) {
           >
             <span class={styles.triggerValue}>
               <Icon icon={Bot} size="sm" />
-              <span class={styles.triggerLabel}>No agents available</span>
+              {/* The raw style, not `ClippedText`: this button is `disabled`,
+                  and a disabled element receives no pointer events, so a
+                  tooltip on the label could never fire. The text is also a
+                  fixed literal that the trigger's width always holds. */}
+              <span class={clippedText}>No agents available</span>
             </span>
           </button>
         )}
@@ -72,7 +78,7 @@ export function AgentProviderSelector(props: AgentProviderSelectorProps) {
             >
               <span class={styles.triggerValue}>
                 <AgentProviderIcon provider={currentProvider()} size={16} />
-                <span class={styles.triggerLabel}>{agentProviderLabel(currentProvider())}</span>
+                <ClippedText text={agentProviderLabel(currentProvider())} />
               </span>
               <ChevronDown size={16} class={styles.triggerChevron} />
             </button>

--- a/frontend/src/components/shell/AppShell.css.ts
+++ b/frontend/src/components/shell/AppShell.css.ts
@@ -236,7 +236,7 @@ export const mobileTabBar = style({
 // out of flow (`position: absolute; inset: 0`) and only the tab bar +
 // composer end up in mobileCenter's flex flow — collapsing the composer
 // up against the tab bar at the top of the viewport. Mirrors the desktop
-// `tileContent` style at `Tile.css.ts`.
+// `tileContent` style at `./Tile.css.ts`.
 export const mobileTilePaneSlot = style({
   flex: 1,
   minHeight: 0,
@@ -259,5 +259,7 @@ export const dragPreviewTooltip = style({
   whiteSpace: 'nowrap',
   maxWidth: '180px',
   overflow: 'hidden',
-  textOverflow: 'ellipsis',
+  // No `text-overflow` here: this box is a flex container, and the property
+  // acts on a block container's own inline content, never on a flex item. The
+  // label inside carries `clippedText` and ellipsizes itself.
 })

--- a/frontend/src/components/shell/CustomTitlebar.css.ts
+++ b/frontend/src/components/shell/CustomTitlebar.css.ts
@@ -1,4 +1,5 @@
 import { style } from '@vanilla-extract/css'
+import { clippedText } from '~/styles/shared.css'
 import { headerHeight } from '~/styles/tokens'
 
 export const titlebar = style({
@@ -21,14 +22,11 @@ export const dragRegion = style({
   WebkitAppRegion: 'drag',
 } as any)
 
-export const titleText = style({
+export const titleText = style([clippedText, {
   position: 'absolute',
   left: '50%',
   transform: 'translateX(-50%)',
   maxWidth: '50%',
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap',
   pointerEvents: 'none',
   userSelect: 'none',
   WebkitAppRegion: 'drag',
@@ -36,7 +34,7 @@ export const titleText = style({
   fontWeight: 'var(--font-bold)',
   letterSpacing: '0.02em',
   color: 'var(--text-secondary)',
-} as any)
+} as any])
 
 export const windowControls = style({
   display: 'flex',

--- a/frontend/src/components/shell/FloatingWindowContainer.css.ts
+++ b/frontend/src/components/shell/FloatingWindowContainer.css.ts
@@ -29,12 +29,13 @@ export const titleBarDragging = style({
   cursor: 'grabbing',
 })
 
+// Decoration only. `ClippedText` owns the clipping rule -- see
+// `~/components/common/ClippedText.tsx`. It also supplies the `min-width: 0`
+// this was missing, which is what lets a `flex: 1` item shrink past its own
+// text and reach the ellipsis.
 export const titleText = style({
   fontSize: '12px',
   fontWeight: 'var(--font-normal)',
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap',
   flex: 1,
   color: 'var(--foreground)',
 })

--- a/frontend/src/components/shell/FloatingWindowContainer.test.tsx
+++ b/frontend/src/components/shell/FloatingWindowContainer.test.tsx
@@ -1,6 +1,8 @@
 import { fireEvent, render, screen } from '@solidjs/testing-library'
 import { createSignal } from 'solid-js'
 import { describe, expect, it, vi } from 'vitest'
+import { clippedText } from '~/styles/shared.css'
+import { hoverForTooltip, stubClipped, stubFitting } from '~/test-support/clipStub'
 import { createTestFloatingWindowStore } from '~/test-support/tabStores'
 import { FloatingWindowContainer, resolveParentSize, snapPosition } from './FloatingWindowContainer'
 
@@ -198,6 +200,47 @@ describe('floatingWindowContainer', () => {
     const { windowId } = renderContainer()
     const win = screen.getByTestId('floating-window')
     expect(win.getAttribute('data-window-id')).toBe(windowId)
+  })
+
+  /**
+   * The title is `flex: 1` in a fixed-height bar. It declared an ellipsis but
+   * not the `min-width: 0` a flex item needs to shrink past its own text, so it
+   * never clipped -- it pushed the close button instead. It clips now, which
+   * makes the tooltip the only route to the rest of the title.
+   */
+  describe('title clipping', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+      vi.restoreAllMocks()
+    })
+
+    function titleOf(): HTMLElement {
+      return screen.getByText('My Window')
+    }
+
+    it('holds the title to one clipped line', () => {
+      renderContainer({ title: 'My Window' })
+      const title = titleOf()
+      expect(title.className.trim().split(/\s+/)).toContain(clippedText)
+    })
+
+    it('gives the full title on hover once it is clipped', () => {
+      renderContainer({ title: 'My Window' })
+      const title = titleOf()
+      stubClipped(title)
+      expect(hoverForTooltip(title)?.textContent).toBe('My Window')
+    })
+
+    it('shows no tooltip while the title fits', () => {
+      renderContainer({ title: 'My Window' })
+      const title = titleOf()
+      stubFitting(title)
+      expect(hoverForTooltip(title)).toBeNull()
+    })
   })
 
   it('invokes onClose when the close button is clicked', () => {

--- a/frontend/src/components/shell/FloatingWindowContainer.tsx
+++ b/frontend/src/components/shell/FloatingWindowContainer.tsx
@@ -2,6 +2,7 @@ import type { Component, JSX } from 'solid-js'
 import type { FloatingWindowStoreType } from '~/stores/floatingWindow.store'
 import X from 'lucide-solid/icons/x'
 import { For, onCleanup, onMount } from 'solid-js'
+import { ClippedText } from '~/components/common/ClippedText'
 import { IconButton } from '~/components/common/IconButton'
 import { MIN_WINDOW_DIMENSION } from '~/stores/floatingWindow.store'
 import * as styles from './FloatingWindowContainer.css'
@@ -296,7 +297,7 @@ export const FloatingWindowContainer: Component<FloatingWindowContainerProps> = 
         data-testid="floating-window-titlebar"
         onPointerDown={handleDragStart}
       >
-        <span class={styles.titleText}>{props.title}</span>
+        <ClippedText text={props.title} class={styles.titleText} />
         <IconButton
           icon={X}
           size="sm"

--- a/frontend/src/components/shell/OpenInEditorButton.css.ts
+++ b/frontend/src/components/shell/OpenInEditorButton.css.ts
@@ -66,7 +66,7 @@ export const chevronFace = style({
   },
 })
 
-// Menu visual language mirrors `AgentProviderSelector.css.ts`. We don't import
+// Menu visual language mirrors `./AgentProviderSelector.css.ts`. We don't import
 // from there — the trigger styling above is bespoke to the split-button — but
 // the popover / item look is intentionally identical so the two selectors
 // feel like the same family.

--- a/frontend/src/components/shell/TabBar.css.ts
+++ b/frontend/src/components/shell/TabBar.css.ts
@@ -1,4 +1,5 @@
 import { globalStyle, style } from '@vanilla-extract/css'
+import { clippedText } from '~/styles/shared.css'
 import { headerHeightPx } from '~/styles/tokens'
 
 export const tooltipTrigger = style({
@@ -116,10 +117,19 @@ export const tabIcon = style({
   marginTop: '2px',
 })
 
-export const tabText = style({
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-})
+/**
+ * The tab label, clipped to one line.
+ *
+ * `clippedText` also supplies the `min-width: 0` this was missing, which is what
+ * lets the label shrink inside the tab's 200px cap and reach the ellipsis; the
+ * `nowrap` it adds restates what `tab` above already passes down.
+ *
+ * Composed with an EMPTY rule on purpose. The empty object keeps `tabText` its
+ * own class, and the tile-size rules further down hide the label by targeting
+ * it. Assigning `clippedText` here instead would point those rules at every
+ * clipped label in the app.
+ */
+export const tabText = style([clippedText, {}])
 
 export const tabDragging = style({
   opacity: 0.4,

--- a/frontend/src/components/shell/TabDragContext.test.tsx
+++ b/frontend/src/components/shell/TabDragContext.test.tsx
@@ -1,0 +1,39 @@
+import { render } from '@solidjs/testing-library'
+import { describe, expect, it } from 'vitest'
+import { clippedText } from '~/styles/shared.css'
+import { classSelector } from '~/test-support/composedClass'
+import { dragPreviewTooltip } from './AppShell.css'
+import { renderSidebarTabOverlay } from './TabDragContext'
+
+const LONG_TITLE = 'a-terminal-tab-title-far-wider-than-the-drag-preview-can-show'
+
+describe('renderSidebarTabOverlay', () => {
+  it('shows the tab title', () => {
+    const { container } = render(() => renderSidebarTabOverlay('My tab'))
+    expect(container.textContent).toBe('My tab')
+  })
+
+  it('wears the shared drag-preview chrome instead of an inline copy', () => {
+    const { container } = render(() => renderSidebarTabOverlay('My tab'))
+    expect(container.querySelector(classSelector(dragPreviewTooltip))).toBeTruthy()
+  })
+
+  /**
+   * The clip belongs to the LABEL, not to the box around it.
+   *
+   * The inline copy this replaced put `text-overflow: ellipsis` on the flex
+   * container, where the property does nothing -- it acts on a block
+   * container's own inline content, never on a flex item. A long title was
+   * therefore cut with no ellipsis to mark it.
+   */
+  it('puts the clip on the label, not on the flex container', () => {
+    const { container } = render(() => renderSidebarTabOverlay(LONG_TITLE))
+
+    const box = container.querySelector(classSelector(dragPreviewTooltip))!
+    expect(box.className).not.toMatch(/clippedText/)
+
+    const label = container.querySelector(classSelector(clippedText))!
+    expect(label.tagName).toBe('SPAN')
+    expect(label.textContent).toBe(LONG_TITLE)
+  })
+})

--- a/frontend/src/components/shell/TabDragContext.tsx
+++ b/frontend/src/components/shell/TabDragContext.tsx
@@ -1,6 +1,8 @@
 import type { JSX } from 'solid-js'
 import { createSignal, onCleanup, useContext } from 'solid-js'
 import { createStableContext } from '~/lib/createStableContext'
+import { clippedText } from '~/styles/shared.css'
+import { dragPreviewTooltip } from './AppShell.css'
 import { useOptionalSectionDrag } from './SectionDragContext'
 
 /** Prefix used for tab-bar zone droppable IDs. */
@@ -11,6 +13,28 @@ export const WORKSPACE_DROP_PREFIX = 'workspace-drop:'
 
 /** Prefix used for draggable sidebar tab tree leaves. Format: `sidebar-tab:{workspaceId}:{tabType}:{tabId}` */
 export const SIDEBAR_TAB_PREFIX = 'sidebar-tab:'
+
+/**
+ * The drag image for a sidebar tab, built from the draggable's own data.
+ *
+ * A sidebar tab can belong to a workspace that is not the active one, so its
+ * title comes from the drag payload rather than from the tab store.
+ *
+ * Wears the same chrome as the tile drag preview, from the same style. That
+ * chrome used to be an inline copy here, and it carried `text-overflow` on the
+ * flex container, where the property does nothing -- so a long title was cut
+ * with no ellipsis. The LABEL carries the clipping, as it does there.
+ *
+ * Exported for its test: the renderer that calls it is a closure that only the
+ * drag provider registers.
+ */
+export function renderSidebarTabOverlay(title: string): JSX.Element {
+  return (
+    <div class={dragPreviewTooltip}>
+      <span class={clippedText}>{title}</span>
+    </div>
+  )
+}
 
 interface TabDragState {
   /** Tile ID where the drag started. */
@@ -218,28 +242,8 @@ function DelegatingTabDragProvider(props: TabDragProviderProps & { sectionDrag: 
       return null
     // Sidebar tab drag — render overlay from draggable data since the tab
     // may not be in the active workspace's store.
-    if (id.startsWith(SIDEBAR_TAB_PREFIX)) {
-      const title = String(draggable.data?.title || 'Tab')
-      return (
-        <div style={{
-          'display': 'flex',
-          'align-items': 'center',
-          'padding': '4px 6px',
-          'font-size': '13px',
-          'background': 'var(--card)',
-          'border': '1px solid var(--border)',
-          'border-radius': '4px',
-          'box-shadow': '0 2px 8px rgba(0,0,0,0.15)',
-          'white-space': 'nowrap',
-          'max-width': '180px',
-          'overflow': 'hidden',
-          'text-overflow': 'ellipsis',
-        }}
-        >
-          <span>{title}</span>
-        </div>
-      )
-    }
+    if (id.startsWith(SIDEBAR_TAB_PREFIX))
+      return renderSidebarTabOverlay(String(draggable.data?.title || 'Tab'))
     return props.renderDragOverlay(id)
   })
   /* eslint-enable solid/reactivity */

--- a/frontend/src/components/shell/useTileDragDrop.tsx
+++ b/frontend/src/components/shell/useTileDragDrop.tsx
@@ -5,6 +5,7 @@ import type { TabView } from '~/stores/tabView'
 import { positionAtInsertIdx } from '~/lib/lexorank'
 import { tabDisplayLabel, tabKey } from '~/stores/tab.helpers'
 import { emitReorderTabs, emitSetTabPosition } from '~/stores/tabOps'
+import { clippedText } from '~/styles/shared.css'
 import * as styles from './AppShell.css'
 import { useTileMove } from './useTileMove'
 
@@ -74,9 +75,12 @@ export function useTileDragDrop(opts: UseTileDragDropOpts) {
     const tab = view.get(key)
     if (!tab)
       return <></>
+    // The raw style, not `ClippedText`: this is the drag image, which follows
+    // the pointer and is destroyed when the drag ends. A tooltip needs 700ms of
+    // still hover to appear, so one here could never show.
     return (
       <div class={styles.dragPreviewTooltip}>
-        <span>{tabDisplayLabel(tab)}</span>
+        <span class={clippedText}>{tabDisplayLabel(tab)}</span>
       </div>
     )
   }

--- a/frontend/src/components/todo/TodoList.css.ts
+++ b/frontend/src/components/todo/TodoList.css.ts
@@ -1,4 +1,4 @@
-import { style } from '@vanilla-extract/css'
+import { globalStyle, style } from '@vanilla-extract/css'
 
 export const todoList = style({
   display: 'flex',
@@ -7,9 +7,12 @@ export const todoList = style({
   padding: 'var(--space-1) var(--space-2)',
 })
 
+// `center`, because the label is one clipped line: it centres against the
+// checkbox rather than sitting at the top of the taller icon box. The wrapping
+// variant below puts it back to `flex-start`.
 export const todoItem = style({
   display: 'flex',
-  alignItems: 'flex-start',
+  alignItems: 'center',
   gap: 'var(--space-2)',
   padding: '3px 0',
   fontSize: 'var(--text-7)',
@@ -33,12 +36,48 @@ export const todoIcon = style({
   flexShrink: 0,
   width: '18px',
   height: '20px',
-  // Nudges the 1rem checkbox down a sub-pixel so it visually sits on
-  // the text baseline of the adjacent label instead of floating above it.
-  marginTop: '0.25px',
 })
 
+// Decoration only. `ClippedText` owns the clipping rule and supplies the
+// `min-width: 0` that lets this `flex: 1` item shrink past its own text -- see
+// `~/components/common/ClippedText.tsx`, which is the sole owner so that
+// removing the rule from either place stays visible.
 export const todoText = style({
   flex: 1,
-  wordBreak: 'break-word',
+})
+
+/**
+ * The WRAPPING variant, for a surface with room to show the whole label.
+ *
+ * The compact rule above suits the sidebar section (~208px) and the
+ * ThinkingIndicator popover, which the card width caps. It does not suit the
+ * chat transcript: a tool card stretches to the tile, so a to-do that used to
+ * wrap and read in full was clipped to one line for no gain.
+ *
+ * These two rules are the ONE authorized override of the clipping that
+ * `ClippedText` otherwise owns. They win on specificity -- (0,2,0) against the
+ * shared rule's (0,1,0) -- and not on the order the bundler emits the two
+ * stylesheets, which is what makes a cross-stylesheet override fragile.
+ */
+export const todoListWrapping = style({})
+
+globalStyle(`${todoListWrapping} ${todoText}`, {
+  whiteSpace: 'normal',
+  overflow: 'visible',
+  textOverflow: 'clip',
+  // `anywhere`, not `break-word`: a to-do label can hold a path or an
+  // identifier that no space breaks.
+  overflowWrap: 'anywhere',
+})
+
+// A wrapped label is taller than the checkbox, so the checkbox sits against the
+// FIRST line rather than the middle of the block.
+globalStyle(`${todoListWrapping} ${todoItem}`, {
+  alignItems: 'flex-start',
+})
+
+// Puts the 1rem checkbox down a sub-pixel so it sits on the first line's
+// baseline instead of floating above it. Needed only under `flex-start`.
+globalStyle(`${todoListWrapping} ${todoIcon}`, {
+  marginTop: '0.25px',
 })

--- a/frontend/src/components/todo/TodoList.test.tsx
+++ b/frontend/src/components/todo/TodoList.test.tsx
@@ -1,6 +1,12 @@
+import type { TodoItem } from '~/stores/chatTodos'
 import { render } from '@solidjs/testing-library'
-import { describe, expect, it } from 'vitest'
+import { createStore } from 'solid-js/store'
+import { describe, expect, it, vi } from 'vitest'
 import { TodoList } from '~/components/todo/TodoList'
+import * as styles from '~/components/todo/TodoList.css'
+import { clippedText } from '~/styles/shared.css'
+import { hoverForTooltip, stubClipped, stubFitting, unhoverTooltip } from '~/test-support/clipStub'
+import { classSelector } from '~/test-support/composedClass'
 
 describe('todoList', () => {
   it('renders the deleted checkbox + strike-through for a deleted row', () => {
@@ -42,44 +48,66 @@ describe('todoList', () => {
     expect(container.querySelectorAll('[data-task-checkbox="deleted"]')).toHaveLength(1)
   })
 
+  /**
+   * A to-do is a Solid store proxy, so every read of it belongs in a tracked
+   * scope. The row's `classList` reads `status` that way, and so does the label
+   * through `todoDisplayLabel`.
+   *
+   * The label was ALREADY tracked before the clipping change: `{todoDisplayLabel(todo)}`
+   * in JSX compiles to a lazy accessor, so hoisting the surrounding element into
+   * a `const` never froze it. This case therefore passes either way and only
+   * guards against a future regression -- see the description case below for the
+   * read that genuinely was not tracked.
+   */
+  it('follows an in-place status change into the label and the row class', () => {
+    const [todos, setTodos] = createStore<TodoItem[]>([
+      { id: '1', content: 'Run tests', status: 'pending', activeForm: 'Running tests' },
+    ])
+    const { container } = render(() => <TodoList todos={todos} />)
+    expect(container.textContent).toContain('Run tests')
+
+    setTodos(0, 'status', 'in_progress')
+
+    const row = container.querySelector('[data-task-checkbox="in_progress"]')?.closest('div')?.parentElement
+    expect(row?.className).toMatch(/todoInProgress/)
+    expect(container.textContent).toContain('Running tests')
+    expect(container.textContent).not.toContain('Run tests')
+  })
+
   it('renders the empty state as an empty wrapper for an empty list', () => {
     const { container } = render(() => <TodoList todos={[]} />)
     expect(container.querySelectorAll('[data-task-checkbox]')).toHaveLength(0)
   })
 
-  it('attaches a tooltip carrying the description when a task has one', () => {
+  // The label is one clipped line on every surface, so the tooltip is the only
+  // route to a description and to a label the row had to clip.
+  it('clips the label to one line', () => {
     const { container } = render(() => (
-      <TodoList
-        todos={[
-          { id: '1', content: 'Task with details', status: 'pending', activeForm: '', description: 'Long-form explanation' },
-        ]}
-      />
+      <TodoList todos={[{ id: '1', content: 'A label wider than the sidebar', status: 'pending', activeForm: '' }]} />
     ))
-    // Tooltip sets aria-describedby / data-tooltip on the trigger row.
-    // We don't rely on the popover rendering (it's portal-based and
-    // delayed); the wrapper presence is enough to prove the description
-    // is surfaced.
-    const row = container.querySelector('[data-task-checkbox="pending"]')?.closest('div')?.parentElement
-    expect(row).toBeTruthy()
-    // The Tooltip wraps the row; the wrapped row should have an
-    // associated tooltip attribute set by the Tooltip primitive.
-    const wrapper = row?.parentElement
-    expect(wrapper).toBeTruthy()
+    const text = container.querySelector(classSelector(styles.todoText))!
+    expect(text.textContent).toBe('A label wider than the sidebar')
+    // Token membership, not a substring: a future class whose own name merely
+    // CONTAINS "clippedText" would satisfy a regex and prove nothing.
+    expect(text.className.trim().split(/\s+/)).toContain(clippedText)
   })
 
-  it('does not wrap rows without a description in a Tooltip', () => {
-    const { container } = render(() => (
-      <TodoList
-        todos={[
-          { id: '1', content: 'No details', status: 'pending', activeForm: '' },
-        ]}
-      />
-    ))
-    // No description → row sits directly under todoList, no tooltip
-    // wrapper element. Structure: todoList > todoItem (no extra wrapper).
-    const todoListEl = container.firstElementChild
-    expect(todoListEl?.children).toHaveLength(1)
-    expect(todoListEl?.children[0].className).toMatch(/todoItem/)
+  /**
+   * The wrapping variant, for the chat transcript's tool card.
+   *
+   * The card stretches to the tile, so it has the room to show a whole to-do.
+   * The sidebar section (~208px) does not, which is why `compact` is the
+   * default. jsdom loads no stylesheet, so the modifier class on the root is
+   * what a unit test can see; the rules it selects are asserted in the browser.
+   */
+  it('marks the list for wrapping only in the full variant', () => {
+    const todos: TodoItem[] = [{ id: '1', content: 'Run tests', status: 'pending', activeForm: '' }]
+
+    const compact = render(() => <TodoList todos={todos} />)
+    expect(compact.container.firstElementChild!.className).not.toMatch(/todoListWrapping/)
+
+    const full = render(() => <TodoList todos={todos} variant="full" />)
+    expect(full.container.firstElementChild!.className).toMatch(/todoListWrapping/)
   })
 
   // Sorting lives in TodoList, so EVERY surface that renders a to-do list --
@@ -114,5 +142,107 @@ describe('todoList', () => {
     const labels = [...container.querySelectorAll('[data-task-checkbox]')]
       .map(el => el.closest('div')?.parentElement?.textContent ?? '')
     expect(labels).toEqual(['first', 'second', 'third'])
+  })
+})
+
+/**
+ * The tooltip on the label, which carries two things the row cannot show: a
+ * description, and the rest of a label the row had to clip.
+ *
+ * The hover target is the LABEL, not the whole row. `showWhen` measures its
+ * target, so the tooltip has to hang off the element that does the clipping.
+ */
+describe('todoList label tooltip', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  function labelOf(container: HTMLElement): HTMLElement {
+    return container.querySelector<HTMLElement>(classSelector(styles.todoText))!
+  }
+
+  const hover = hoverForTooltip
+
+  it('shows the label and its description together when a task has one', () => {
+    const { container } = render(() => (
+      <TodoList
+        todos={[{ id: '1', content: 'Task with details', status: 'pending', activeForm: '', description: 'Long-form explanation' }]}
+      />
+    ))
+    // Shown although the label fits: the description is the part the row
+    // cannot show at all, so clipping is not the trigger for it.
+    const tip = hover(labelOf(container))!
+    expect(tip.textContent).toContain('Task with details')
+    expect(tip.textContent).toContain('Long-form explanation')
+  })
+
+  it('uses the in-progress label, not the content, in that tooltip', () => {
+    const { container } = render(() => (
+      <TodoList
+        todos={[{ id: '2', content: 'Run tests', status: 'in_progress', activeForm: 'Running tests', description: 'The whole suite' }]}
+      />
+    ))
+    const tip = hover(labelOf(container))!
+    expect(tip.textContent).toContain('Running tests')
+    expect(tip.textContent).not.toContain('Run tests')
+  })
+
+  // An EMPTY description is an absent one. It must not force the tooltip open
+  // on a label that fits, and it must not render a blank second line.
+  it('treats an empty description as absent', () => {
+    const { container } = render(() => (
+      <TodoList todos={[{ id: '1', content: 'Short', status: 'pending', activeForm: '', description: '' }]} />
+    ))
+    const label = labelOf(container)
+    stubFitting(label)
+    expect(hover(label)).toBeNull()
+
+    stubClipped(label)
+    expect(hover(label)!.textContent).toBe('Short')
+  })
+
+  // Before the labels were clipped, a task with no description had no tooltip
+  // at all. Now it gets one, but only once its label is actually clipped.
+  it('gives a task without a description the full label once it is clipped', () => {
+    const { container } = render(() => (
+      <TodoList todos={[{ id: '1', content: 'A label far wider than this row', status: 'pending', activeForm: '' }]} />
+    ))
+    const label = labelOf(container)
+    stubFitting(label)
+    expect(hover(label)).toBeNull()
+
+    stubClipped(label)
+    expect(hover(label)!.textContent).toBe('A label far wider than this row')
+  })
+
+  /**
+   * The read that genuinely was NOT tracked before this change.
+   *
+   * The old row chose between a wrapped and an unwrapped element with a plain
+   * `todo.description ? … : …` in the `<For>` body, which runs once per row. An
+   * in-place write to `description` therefore never added or removed the
+   * tooltip. The description now reaches the label as a prop, so the read sits
+   * inside a tracked scope and the tooltip follows it.
+   */
+  it('follows an in-place description change', () => {
+    const [todos, setTodos] = createStore<TodoItem[]>([
+      { id: '1', content: 'Run tests', status: 'pending', activeForm: '' },
+    ])
+    const { container } = render(() => <TodoList todos={todos} />)
+    const label = labelOf(container)
+    stubFitting(label)
+    expect(hover(label)).toBeNull()
+
+    setTodos(0, 'description', 'the whole suite')
+    expect(hover(label)?.textContent).toContain('the whole suite')
+    unhoverTooltip(label)
+
+    setTodos(0, 'description', undefined)
+    expect(hover(label)).toBeNull()
   })
 })

--- a/frontend/src/components/todo/TodoList.tsx
+++ b/frontend/src/components/todo/TodoList.tsx
@@ -1,13 +1,22 @@
 import type { Component } from 'solid-js'
 import type { TodoItem } from '~/stores/chatTodos'
 import { createMemo, For } from 'solid-js'
-import { Tooltip } from '~/components/common/Tooltip'
+import { ClippedText } from '~/components/common/ClippedText'
 import { isFinishedTodoStatus, sortTodos, todoDisplayLabel } from '~/stores/chatTodos'
 import { TaskCheckbox } from './TaskCheckbox'
 import * as styles from './TodoList.css'
 
 interface TodoListProps {
   todos: TodoItem[]
+  /**
+   * How much room the surface has.
+   *
+   * `compact` (the default) holds each label to one clipped line, which is what
+   * the sidebar section and the ThinkingIndicator popover have room for.
+   * `full` lets the label wrap, for the chat transcript's tool card, which
+   * stretches to the tile and can show the whole to-do.
+   */
+  variant?: 'compact' | 'full'
 }
 
 export const TodoList: Component<TodoListProps> = (props) => {
@@ -15,10 +24,27 @@ export const TodoList: Component<TodoListProps> = (props) => {
   // ThinkingIndicator popover, and the chat cards all read in the same order.
   const ordered = createMemo(() => sortTodos(props.todos))
   return (
-    <div class={styles.todoList}>
+    <div
+      class={styles.todoList}
+      classList={{ [styles.todoListWrapping]: props.variant === 'full' }}
+    >
       <For each={ordered()}>
         {(todo) => {
-          const row = (
+          // Accessors, not hoisted values. A to-do is a Solid store proxy, so
+          // these reads have to stay inside a tracked scope: a plain `const`
+          // here would freeze the label while the sibling `classList` below
+          // kept tracking the same status.
+          const label = () => todoDisplayLabel(todo)
+          const description = () => todo.description
+          // The compact list (sidebar + TodoWrite / Codex / OpenCode chat
+          // cards) doesn't have room for a description line, so surface it in
+          // the tooltip under the label it explains. That tooltip shows even
+          // while the label fits, because the description is the part the row
+          // cannot show at all.
+          //
+          // The hover target is the LABEL, not the whole row: the tooltip has
+          // to hang off the clipped element for `showWhen` to measure it.
+          return (
             <div
               class={styles.todoItem}
               classList={{
@@ -29,15 +55,13 @@ export const TodoList: Component<TodoListProps> = (props) => {
               <div class={styles.todoIcon}>
                 <TaskCheckbox status={todo.status} />
               </div>
-              <span class={styles.todoText}>{todoDisplayLabel(todo)}</span>
+              <ClippedText
+                text={label()}
+                class={styles.todoText}
+                detail={description()}
+              />
             </div>
           )
-          // The compact list (sidebar + TodoWrite / Codex / OpenCode
-          // chat cards) doesn't have room for a description line, so
-          // surface it via the Tooltip component when present.
-          return todo.description
-            ? <Tooltip text={todo.description}>{row}</Tooltip>
-            : row
         }}
       </For>
     </div>

--- a/frontend/src/components/workers/WorkerSectionContent.test.tsx
+++ b/frontend/src/components/workers/WorkerSectionContent.test.tsx
@@ -7,10 +7,19 @@ import { create } from '@bufbuild/protobuf'
 import { render, screen } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
 import { actionSlot, actionSlotResting } from '~/components/tree/sidebarActions.css'
+import * as listStyles from '~/components/workspace/workspaceList.css'
 import { TunnelProvider } from '~/context/TunnelContext'
 import { WorkerSchema } from '~/generated/leapmux/v1/worker_pb'
 import { createTunnelStore } from '~/stores/tunnel.store'
+import { clippedText } from '~/styles/shared.css'
+import { hoverForTooltip, stubClipped, stubFitting } from '~/test-support/clipStub'
+import { classSelector } from '~/test-support/composedClass'
 import { WorkerSectionContent } from './WorkerSectionContent'
+
+/** A port-forward tunnel, whose label is the one that carries the arrow. */
+function portForward(): TunnelInfo {
+  return { id: 't1', workerId: 'w1', type: 'port_forward', bindAddr: '127.0.0.1', bindPort: 3000, targetAddr: '10.0.0.1', targetPort: 8080 }
+}
 
 vi.mock('~/api/platformBridge', async (importOriginal) => {
   const actual = await importOriginal<typeof import('~/api/platformBridge')>()
@@ -149,6 +158,82 @@ describe('workerSectionContent', () => {
     const { container } = renderSection()
     const dot = container.querySelector(`.${actionSlot} [data-status]`)!
     expect(dot.className).toContain(actionSlotResting)
+  })
+
+  /**
+   * The list fills the section width so a row CLIPS its name.
+   *
+   * It used to render into `sectionItems`, which sizes to its widest row so the
+   * workspace tree can scroll sideways to reveal a deep path. That width made
+   * the ellipsis on a worker name unreachable and scrolled the sidebar instead.
+   * jsdom loads no stylesheet, so the class is what a unit test can see.
+   */
+  it('renders into the workers list container, not the workspace one', () => {
+    const { container } = renderSection()
+    expect(container.firstElementChild!.className).toMatch(/workerItems/)
+    expect(container.firstElementChild!.className).not.toMatch(/sectionItems/)
+  })
+
+  it('clips the worker name and keeps its test id on the label', () => {
+    renderSection()
+    const name = screen.getByTestId('worker-name')
+    expect(name.textContent).toBe('test-worker')
+    // Token membership, not a substring: a future class whose own name merely
+    // CONTAINS "clippedText" would satisfy a regex and prove nothing.
+    expect(name.className.trim().split(/\s+/)).toContain(clippedText)
+    expect(name.className).toMatch(/itemTitle/)
+  })
+
+  it('clips a tunnel label the same way', () => {
+    const { container } = renderSection({ tunnels: [portForward()] })
+    const label = [...container.querySelectorAll(classSelector(listStyles.itemTitle))]
+      .find(el => el.textContent?.includes('→'))!
+    expect(label.className.trim().split(/\s+/)).toContain(clippedText)
+  })
+
+  // The class alone does not prove the reader can recover the name. These pin
+  // the other half of the pairing: once the label is clipped, the full string
+  // is on the tooltip, and while it fits there is no tooltip to read.
+  describe('clipped label tooltip', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+      vi.restoreAllMocks()
+    })
+
+    it('gives the full worker name on hover once the label is clipped', () => {
+      renderSection()
+      const name = screen.getByTestId('worker-name')
+      stubClipped(name)
+      expect(hoverForTooltip(name)?.textContent).toBe('test-worker')
+    })
+
+    it('shows no tooltip while the worker name fits', () => {
+      renderSection()
+      const name = screen.getByTestId('worker-name')
+      stubFitting(name)
+      expect(hoverForTooltip(name)).toBeNull()
+    })
+
+    it('gives the full tunnel label on hover once it is clipped', () => {
+      const { container } = renderSection({ tunnels: [portForward()] })
+      const label = [...container.querySelectorAll<HTMLElement>(classSelector(listStyles.itemTitle))]
+        .find(el => el.textContent?.includes('→'))!
+      stubClipped(label)
+      expect(hoverForTooltip(label)?.textContent).toBe('127.0.0.1:3000 → 10.0.0.1:8080')
+    })
+  })
+
+  // The dot carries the channel state as COLOUR, so it needs a text
+  // alternative; `aria-label` needs a role to attach to.
+  it('gives the status dot an accessible name, not colour alone', () => {
+    const { container } = renderSection()
+    const dot = container.querySelector('[data-status]')!
+    expect(dot.getAttribute('role')).toBe('img')
+    expect(dot.getAttribute('aria-label')).toBe('Connected')
   })
 
   it('shows dash when workerInfo is null', () => {

--- a/frontend/src/components/workers/WorkerSectionContent.tsx
+++ b/frontend/src/components/workers/WorkerSectionContent.tsx
@@ -7,8 +7,9 @@ import ArrowBigRightDash from 'lucide-solid/icons/arrow-big-right-dash'
 import ChevronRight from 'lucide-solid/icons/chevron-right'
 import ChevronsLeftRightEllipsis from 'lucide-solid/icons/chevrons-left-right-ellipsis'
 import { createMemo, createSignal, For, Show } from 'solid-js'
+import { ClippedText } from '~/components/common/ClippedText'
 import { ConfirmDialog } from '~/components/common/ConfirmDialog'
-import { Tooltip } from '~/components/common/Tooltip'
+import { StatusDot } from '~/components/common/StatusDot'
 import * as shared from '~/components/tree/sharedTree.css'
 import { actionSlot, actionSlotResting, sidebarActions } from '~/components/tree/sidebarActions.css'
 import * as listStyles from '~/components/workspace/workspaceList.css'
@@ -28,6 +29,12 @@ export interface WorkerSectionContentProps {
 const statusClass: Record<ChannelStatus, string> = {
   connected: styles.statusConnected,
   disconnected: styles.statusDisconnected,
+}
+
+/** What the dot's colour means. The dot has no other way to say it. */
+const statusLabel: Record<ChannelStatus, string> = {
+  connected: 'Connected',
+  disconnected: 'Disconnected',
 }
 
 export const WorkerSectionContent: Component<WorkerSectionContentProps> = (props) => {
@@ -58,7 +65,7 @@ export const WorkerSectionContent: Component<WorkerSectionContentProps> = (props
   }
 
   return (
-    <div class={listStyles.sectionItems}>
+    <div class={styles.workerItems}>
       <Show
         when={props.workers.length > 0}
         fallback={<div class={listStyles.emptySection}>No workers</div>}
@@ -79,19 +86,23 @@ export const WorkerSectionContent: Component<WorkerSectionContentProps> = (props
                     size={14}
                     class={`${shared.chevron} ${isExpanded(worker.id) ? shared.chevronExpanded : ''}`}
                   />
-                  <Tooltip text={workerName()} showWhen="clipped">
-                    <span class={listStyles.itemTitle} data-testid="worker-name">
-                      {workerName()}
-                    </span>
-                  </Tooltip>
+                  <ClippedText
+                    text={workerName()}
+                    class={listStyles.itemTitle}
+                    testId="worker-name"
+                  />
                   <div class={sidebarActions}>
                     {/* The dot and the three-dot trigger share one cell: the
                         dot rests at the row's right edge and the trigger takes
                         its place on hover, so the row's width never shifts. */}
                     <div class={actionSlot}>
-                      <div
-                        class={`${styles.statusDot} ${actionSlotResting} ${statusClass[status()]}`}
-                        data-status={status()}
+                      {/* No tooltip: `actionSlotResting` is `pointer-events:
+                          none`, so a hover on this dot never reaches it. The
+                          accessible name carries the state instead. */}
+                      <StatusDot
+                        class={`${actionSlotResting} ${statusClass[status()]}`}
+                        label={statusLabel[status()]}
+                        status={status()}
                       />
                       <WorkerContextMenu
                         workerInfo={props.workerInfo(worker.id)}
@@ -115,11 +126,7 @@ export const WorkerSectionContent: Component<WorkerSectionContentProps> = (props
                               {t.type === 'socks5'
                                 ? <ChevronsLeftRightEllipsis size={14} class={styles.tunnelIcon} />
                                 : <ArrowBigRightDash size={14} class={styles.tunnelIcon} />}
-                              <Tooltip text={label} showWhen="clipped">
-                                <span class={listStyles.itemTitle}>
-                                  {label}
-                                </span>
-                              </Tooltip>
+                              <ClippedText text={label} class={listStyles.itemTitle} />
                               <div class={sidebarActions}>
                                 <TunnelContextMenu onDelete={() => setDeleteTunnelTarget(t)} />
                               </div>

--- a/frontend/src/components/workers/workerSection.css.ts
+++ b/frontend/src/components/workers/workerSection.css.ts
@@ -1,12 +1,23 @@
 import { style } from '@vanilla-extract/css'
 
-export const statusDot = style({
-  width: 8,
-  height: 8,
-  borderRadius: '50%',
-  flexShrink: 0,
+/**
+ * The workers list fills the width of its section, so a row clips its name.
+ *
+ * `sectionItems` in `~/components/workspace/workspaceList.css.ts` sizes to its
+ * widest row instead, which lets the workspace tree scroll sideways to reveal a
+ * deep path. A worker row has no depth to reveal that way, and that width made
+ * the ellipsis on the name unreachable. This is a separate declaration rather
+ * than an override of `sectionItems`, because a rule that overrides a rule in
+ * another stylesheet wins or loses on the order the bundler emits them.
+ */
+export const workerItems = style({
+  display: 'flex',
+  flexDirection: 'column',
+  width: '100%',
 })
 
+// The dot's shape is the shared one in `~/styles/shared.css.ts`, which the
+// background tasks section uses as well. Only this palette is specific here.
 export const statusConnected = style({
   background: 'var(--success)',
 })

--- a/frontend/src/components/workspace/workspaceList.css.ts
+++ b/frontend/src/components/workspace/workspaceList.css.ts
@@ -1,5 +1,6 @@
 import { globalStyle, style } from '@vanilla-extract/css'
 import { menuTrigger, sidebarActions } from '~/components/tree/sidebarActions.css'
+import { clippedText } from '~/styles/shared.css'
 import { iconSize } from '~/styles/tokens'
 
 export const list = style({
@@ -35,18 +36,14 @@ export const sectionChevronOpen = style([sectionChevron, {
   transform: 'rotate(90deg)',
 }])
 
-export const sectionName = style({
+export const sectionName = style([clippedText, {
   flex: 1,
   fontSize: 'var(--text-8)',
   fontWeight: 'var(--font-bold)',
   color: 'var(--muted-foreground)',
   textTransform: 'uppercase',
   letterSpacing: '0.5px',
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap',
-  minWidth: 0,
-})
+}])
 
 export const sectionActions = style({
   display: 'flex',
@@ -92,6 +89,19 @@ export const sectionAddButton = style({
   },
 })
 
+/**
+ * The workspace tree's row container, which sizes to its WIDEST row.
+ *
+ * `width: max-content` is deliberate: the tab tree indents each level, so a deep
+ * branch runs past the sidebar, and the enclosing scroller must be able to
+ * reveal it sideways.
+ *
+ * A section whose rows should CLIP must not use this container. The width makes
+ * the row grow instead of the label shrinking, so the ellipsis never appears and
+ * the whole section scrolls sideways -- which is what the workers list did while
+ * it rendered in here. It has its own container now: `workerItems` in
+ * `~/components/workers/workerSection.css.ts`.
+ */
 export const sectionItems = style({
   display: 'flex',
   flexDirection: 'column',
@@ -143,15 +153,11 @@ export const itemLabel = style({
   overflow: 'hidden',
 })
 
-export const itemTitle = style({
+export const itemTitle = style([clippedText, {
   fontSize: 'var(--text-7)',
   fontWeight: 'var(--font-normal)',
   color: 'var(--foreground)',
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap',
-  minWidth: 0,
-})
+}])
 
 export const itemRenameInput = style({
   'flex': 1,
@@ -199,7 +205,7 @@ export const sectionHeaderDropTarget = style({
   backgroundColor: 'var(--secondary)',
 })
 
-export const dragOverlay = style({
+export const dragOverlay = style([clippedText, {
   padding: 'var(--space-1) var(--space-3)',
   paddingLeft: 'var(--space-4)',
   fontSize: 'var(--text-7)',
@@ -209,8 +215,5 @@ export const dragOverlay = style({
   border: '1px solid var(--border)',
   borderRadius: 'var(--radius-small)',
   boxShadow: 'var(--shadow-large)',
-  whiteSpace: 'nowrap',
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
   maxWidth: '200px',
-})
+}])

--- a/frontend/src/components/workspace/workspaceTabTree.css.ts
+++ b/frontend/src/components/workspace/workspaceTabTree.css.ts
@@ -1,4 +1,5 @@
 import { style } from '@vanilla-extract/css'
+import { clippedText } from '~/styles/shared.css'
 import { node } from '../tree/sharedTree.css'
 
 export const treeWrapper = style({
@@ -36,10 +37,7 @@ export const tabIcon = style({
   flexShrink: 0,
 })
 
-export const tabLabel = style({
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap',
+export const tabLabel = style([clippedText, {
   // Natural content width (capped by row via flex-shrink) — not flex: 1 —
   // so getBoundingClientRect on this span reflects where the text actually
   // is. The tooltip centers over the rect; flex: 1 would stretch this into
@@ -47,8 +45,7 @@ export const tabLabel = style({
   // close button in sidebarActions still sits flush-right via margin-left:
   // auto, so no layout shift.
   flex: '0 1 auto',
-  minWidth: 0,
-})
+}])
 
 export const leafActions = style({
   minWidth: 0,

--- a/frontend/src/styles/shared.css.ts
+++ b/frontend/src/styles/shared.css.ts
@@ -48,6 +48,55 @@ export const emptyState = style({
   fontStyle: 'italic',
 })
 
+/**
+ * A label that stays on ONE line: the overflow is clipped at the right edge and
+ * marked with an ellipsis.
+ *
+ * `min-width: 0` is what lets a flex item shrink below the width of its own
+ * text. Without it the item keeps its content width, the row grows instead, and
+ * the ellipsis never appears -- the container scrolls sideways.
+ *
+ * Clipping HIDES text, so the full string needs another route to the reader.
+ * Pair this with `<Tooltip showWhen="clipped">`, which shows the tooltip only
+ * while the label is actually clipped. `ClippedText` in
+ * `~/components/common/ClippedText` pairs the two, and is what a caller should
+ * reach for.
+ *
+ * Take this style directly in these three cases only, and record which one
+ * applies at the site:
+ * 1. The label is not a plain string. It is arbitrary JSX, or it must hold a
+ *    child element such as a link.
+ * 2. A tooltip cannot fire. The label sits under a `disabled` ancestor, which
+ *    receives no pointer events, or it is a drag image.
+ * 3. The rule must reach an element that `ClippedText` does not render -- a
+ *    `globalStyle` on a class that a rehype plugin emits, for example.
+ *
+ * A caller that renders through `ClippedText` must NOT compose this style into
+ * the class it passes. The component already applies it, and a second owner
+ * makes the removal of either one invisible.
+ */
+export const clippedText = style({
+  minWidth: 0,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+})
+
+/**
+ * The small round status light that a sidebar row carries at its right end.
+ *
+ * Shape only. Each section supplies its own palette, because the states differ:
+ * a worker is connected or disconnected, a background task is queued, running,
+ * succeeded, failed, or stopped. The SHAPE is shared so that the two sections
+ * read as one vocabulary rather than as two similar dots that drift apart.
+ */
+export const statusDot = style({
+  width: 8,
+  height: 8,
+  borderRadius: '50%',
+  flexShrink: 0,
+})
+
 // Menu utilities
 
 export const dangerMenuItem = style({
@@ -68,13 +117,6 @@ export const menuItemContent = style({
   gap: 'var(--space-2)',
   width: '100%',
   minWidth: 0,
-})
-
-export const menuItemLabel = style({
-  minWidth: 0,
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap',
 })
 
 export const menuItemShortcut = style({

--- a/frontend/src/test-support/clipStub.ts
+++ b/frontend/src/test-support/clipStub.ts
@@ -1,0 +1,77 @@
+import { fireEvent } from '@solidjs/testing-library'
+import { vi } from 'vitest'
+import { HIDE_DELAY_MS, SHOW_DELAY_MS } from '~/components/common/Tooltip'
+
+/**
+ * Helpers that make a label report itself as clipped, or as fitting, under
+ * jsdom.
+ *
+ * `Tooltip`'s clip detection reads live layout, and jsdom measures every box as
+ * 0. It also loads no vanilla-extract rule, so the `overflow: hidden` that
+ * `clippedText` declares is invisible to `getComputedStyle`. Each helper below
+ * therefore states all three inputs that `isTargetClipped` reads: the rect,
+ * `scrollWidth`, and `clientWidth`. The overflow longhands go on the element as
+ * an INLINE style, and BOTH are set, because jsdom does not expand the
+ * `overflow` shorthand.
+ */
+
+/** A zero-filled `DOMRect` with `rect` written over it. */
+export function stubRect(el: Element, rect: Partial<DOMRect>): void {
+  const base: DOMRect = {
+    x: 0,
+    y: 0,
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    width: 0,
+    height: 0,
+    toJSON: () => '',
+  }
+  Object.defineProperty(el, 'getBoundingClientRect', {
+    value: () => ({ ...base, ...rect }),
+    configurable: true,
+  })
+}
+
+/** The rect both helpers below use: on screen, and well inside the viewport. */
+const ON_SCREEN: Partial<DOMRect> = { top: 10, left: 10, right: 70, bottom: 30, width: 60, height: 20 }
+
+/** Makes the label report clipped text, so `showWhen: 'clipped'` lets it through. */
+export function stubClipped(el: HTMLElement): void {
+  el.setAttribute('style', 'overflow-x: hidden; overflow-y: hidden')
+  stubRect(el, ON_SCREEN)
+  Object.defineProperty(el, 'scrollWidth', { value: 400, configurable: true })
+  Object.defineProperty(el, 'clientWidth', { value: 60, configurable: true })
+}
+
+/** Makes the label report that its text fits. */
+export function stubFitting(el: HTMLElement): void {
+  stubRect(el, ON_SCREEN)
+  Object.defineProperty(el, 'scrollWidth', { value: 60, configurable: true })
+  Object.defineProperty(el, 'clientWidth', { value: 60, configurable: true })
+}
+
+/**
+ * Hovers the element, runs out the show delay, and gives the tooltip.
+ *
+ * Needs `vi.useFakeTimers()`. Gives `null` when no tooltip appeared, which is
+ * what a label that fits looks like under `showWhen: 'clipped'`.
+ */
+export function hoverForTooltip(el: Element): HTMLElement | null {
+  fireEvent.mouseEnter(el)
+  vi.advanceTimersByTime(SHOW_DELAY_MS)
+  return document.querySelector<HTMLElement>('[role="tooltip"]')
+}
+
+/**
+ * Leaves the element and runs out the hide delay.
+ *
+ * Call this between two hovers of the SAME element. A visible tooltip stays
+ * visible, so a second `hoverForTooltip` would report the tooltip that the first
+ * one opened and never test the new state.
+ */
+export function unhoverTooltip(el: Element): void {
+  fireEvent.mouseLeave(el)
+  vi.advanceTimersByTime(HIDE_DELAY_MS)
+}

--- a/frontend/src/test-support/composedClass.test.ts
+++ b/frontend/src/test-support/composedClass.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { classSelector } from './composedClass'
+
+describe('classSelector', () => {
+  it('builds a plain selector for one class', () => {
+    expect(classSelector('itemTitle_abc')).toBe('.itemTitle_abc')
+  })
+
+  // The case this helper exists for: a composed style exports two names, and
+  // `.${style}` would be a descendant selector that matches nothing.
+  it('joins a composed class list into one compound selector', () => {
+    expect(classSelector('taskTitle_abc clippedText_def'))
+      .toBe('.taskTitle_abc.clippedText_def')
+  })
+
+  it('ignores the surrounding and repeated whitespace a class list can carry', () => {
+    expect(classSelector('  a_1   b_2  ')).toBe('.a_1.b_2')
+  })
+
+  // `''.split(/\s+/)` gives `['']`, which builds the selector `.` --
+  // `querySelector` then raises a SyntaxError that names neither this helper
+  // nor its caller.
+  it('throws a named error for an empty class name', () => {
+    expect(() => classSelector('')).toThrow('classSelector: the class name is empty')
+    expect(() => classSelector('   ')).toThrow('classSelector: the class name is empty')
+  })
+})

--- a/frontend/src/test-support/composedClass.ts
+++ b/frontend/src/test-support/composedClass.ts
@@ -1,0 +1,19 @@
+/**
+ * A CSS selector that matches every class in a vanilla-extract style.
+ *
+ * A composed style (`style([base, {...}])`) exports SPACE-SEPARATED class
+ * names, so `.${style}` is a DESCENDANT selector whose right side is a bare
+ * type selector. It parses cleanly and matches nothing, so `querySelector`
+ * returns `null` and an assertion that expects absence passes for the wrong
+ * reason. This joins the names into one compound selector instead.
+ *
+ * Throws on an empty class name. `''.split(/\s+/)` gives `['']`, which builds
+ * the selector `.` -- `querySelector` then raises a `SyntaxError` that names
+ * neither this helper nor the caller.
+ */
+export function classSelector(className: string): string {
+  const classes = className.trim().split(/\s+/).filter(Boolean)
+  if (classes.length === 0)
+    throw new Error('classSelector: the class name is empty')
+  return classes.map(c => `.${c}`).join('')
+}

--- a/frontend/tests/e2e/020-worker-management.spec.ts
+++ b/frontend/tests/e2e/020-worker-management.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from './fixtures'
+import { expectClipsLongText, expectClipsToOneLine } from './helpers/ui'
 
 test.describe('Worker Management', () => {
   test('should show Workers section with registered worker', async ({ page, authenticatedWorkspace }) => {
@@ -25,5 +26,34 @@ test.describe('Worker Management', () => {
 
     // The status dot should indicate "connected"
     await expect(workersSection.locator('[data-status="connected"]')).toBeVisible()
+  })
+
+  /**
+   * A worker row clips its name rather than widening the list.
+   *
+   * The list used to render into the workspace list's container, which sizes to
+   * its widest row so a deep path can be scrolled into view. A worker row has
+   * no such depth, and that width made the ellipsis unreachable: a long name
+   * scrolled the whole sidebar section sideways instead of clipping.
+   *
+   * The dev worker is called `Local`, which fits any sidebar width, and the
+   * name already declared the whole clipping quartet before the container was
+   * fixed. So the declarations pass on the broken code too, and only a name
+   * longer than its box tells the two containers apart --
+   * `expectClipsLongText` supplies one.
+   */
+  test('clips the worker name and never scrolls the section sideways', async ({ page, authenticatedWorkspace }) => {
+    void authenticatedWorkspace
+    const workersSection = page.getByTestId('section-header-workers')
+    await expect(workersSection).toBeVisible()
+
+    const isOpen = await workersSection.evaluate(el => !el.hasAttribute('data-closed'))
+    if (!isOpen)
+      await workersSection.locator('> [role="button"]').click()
+
+    const name = workersSection.getByTestId('worker-name').filter({ hasText: 'Local' })
+    await expect(name).toBeVisible()
+    await expectClipsToOneLine(name)
+    await expectClipsLongText(name)
   })
 })

--- a/frontend/tests/e2e/021-worker-deregistration.spec.ts
+++ b/frontend/tests/e2e/021-worker-deregistration.spec.ts
@@ -29,8 +29,10 @@ async function openWorkersSidebar(page: import('@playwright/test').Page) {
   const isOpen = await workersSection.evaluate(el => !el.hasAttribute('data-closed'))
   if (!isOpen)
     await workersSection.locator('> [role="button"]').click()
-  // Wait for content to be visible
-  await expect(workersSection.locator('[class*="sectionItems"]')).toBeVisible()
+  // Wait for content to be visible. The workers list has its own container
+  // (`workerItems`): it fills the section width so a row clips its name, unlike
+  // the workspace list's `sectionItems`, which sizes to its widest row.
+  await expect(workersSection.locator('[class*="workerItems"]')).toBeVisible()
   return workersSection
 }
 

--- a/frontend/tests/e2e/038-attachment-support.spec.ts
+++ b/frontend/tests/e2e/038-attachment-support.spec.ts
@@ -3,6 +3,7 @@ import { writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { expect, test } from './fixtures'
+import { expectClipsToOneLine } from './helpers/ui'
 
 /** Create a minimal 1x1 PNG file in a temp directory and return its path. */
 function createTestPng(name = 'test.png'): string {
@@ -45,6 +46,15 @@ test.describe('Attachment Support', () => {
     const pill = page.locator('[data-testid="attachment-pill"]')
     await expect(pill).toHaveCount(1)
     await expect(pill).toContainText('screenshot.png')
+
+    // The file name clips to one line inside the pill's 200px cap. It declared
+    // the ellipsis before but not the `min-width: 0` a flex item needs to shrink
+    // past its own text; only a real browser resolves the composed rules.
+    //
+    // `span[class]` selects the LABEL. Tooltip wraps its child in a bare
+    // `display: contents` span, which also holds the text and comes first, so a
+    // plain `span` locator resolves to that wrapper instead.
+    await expectClipsToOneLine(pill.locator('span[class]').filter({ hasText: 'screenshot.png' }))
   })
 
   test('remove attachment via X button', async ({ page, authenticatedWorkspace }) => {

--- a/frontend/tests/e2e/170-claude-subagent-background-tasks.spec.ts
+++ b/frontend/tests/e2e/170-claude-subagent-background-tasks.spec.ts
@@ -21,7 +21,7 @@ import {
   openChildTabFromRow,
   requireRegistryRow,
 } from './helpers/subagentRegistry'
-import { sendMessage, waitForAgentIdle } from './helpers/ui'
+import { expectClipsLongText, expectClipsToOneLine, sendMessage, waitForAgentIdle } from './helpers/ui'
 
 test.describe('Claude subagent background tasks', () => {
   test('subagent spawn creates a registry row, a child tab, and isolates the transcript', async ({
@@ -144,5 +144,19 @@ test.describe('Claude subagent background tasks', () => {
     // A static row is a <div>. It must render at the same weight as the
     // clickable <button> row that this spec's first test pins.
     await expect(shellRow!).toHaveCSS('font-weight', '400')
+
+    // A shell row's title is a COMMAND, which is long and rarely breakable, so
+    // this is where the section used to grow a horizontal scrollbar. The title
+    // is clipped now, and nothing above it scrolls sideways. The composed
+    // vanilla-extract rules only resolve in a real browser, so a unit test can
+    // see the classes but never this outcome.
+    //
+    // The declarations alone discriminate here -- the title WRAPPED before, so
+    // it declared no `nowrap` -- and `expectClipsLongText` then measures the
+    // outcome under a title long enough to reach the edge whatever the model
+    // sent.
+    const title = shellRow!.locator('[class*="taskTitle"]').first()
+    await expectClipsToOneLine(title)
+    await expectClipsLongText(title)
   })
 })

--- a/frontend/tests/e2e/helpers/ui.ts
+++ b/frontend/tests/e2e/helpers/ui.ts
@@ -20,6 +20,85 @@ export async function expectAnyVisible(...locators: Locator[]) {
 }
 
 // ──────────────────────────────────────────────
+// Sidebar text clipping
+// ──────────────────────────────────────────────
+
+/**
+ * Assert that a sidebar label declares the one-line clip.
+ *
+ * Only a real browser resolves this. The rules arrive through a COMPOSED
+ * vanilla-extract style (`style([clippedText, …])`), so the element carries two
+ * class names and the declarations come from two rules; jsdom loads no
+ * stylesheet at all, so a unit test can see the class but never the outcome.
+ *
+ * `min-width` is asserted with the rest, because it is the one that decides
+ * whether the ellipsis ever fires: a flex item defaults to `min-width: auto`
+ * and keeps the width of its own text, so the other three declarations sit
+ * there and do nothing. Several labels shipped exactly that way.
+ *
+ * This states what the label DECLARES. Pair it with {@link expectClipsLongText},
+ * which measures what the label DOES.
+ *
+ * Pass the LABEL, not an ancestor. A clipped label usually sits inside
+ * `Tooltip`, which wraps its child in a bare `display: contents` span; that
+ * wrapper holds the same text and comes first, so a loose `span` locator
+ * resolves to it and reports `text-overflow: clip`.
+ */
+export async function expectClipsToOneLine(label: Locator) {
+  await expect(label).toHaveCSS('white-space', 'nowrap')
+  await expect(label).toHaveCSS('text-overflow', 'ellipsis')
+  await expect(label).toHaveCSS('overflow-x', 'hidden')
+  await expect(label).toHaveCSS('min-width', '0px')
+}
+
+/**
+ * Assert that a LONG label clips itself and widens no scroller above it.
+ *
+ * The declarations alone prove nothing. A worker name already declared the
+ * whole quartet while the ellipsis still never fired, because the list's
+ * container sized to its widest row; only a label longer than its box separates
+ * the two containers. No fixture can give the dev worker a long name, so this
+ * writes one into the text node and restores it inside ONE synchronous block.
+ * The write forces the reflow that the reads below need, and Solid keeps its
+ * reference to the text node because the node itself is reused.
+ *
+ * A scroller is a box whose computed `overflow-x` is `auto` or `scroll`.
+ * Testing that is what separates "an ancestor grew a scrollbar" from "the label
+ * clips its own text" -- a clipped label reports `scrollWidth > clientWidth` BY
+ * CONSTRUCTION, which is the same measurement the ellipsis is made of.
+ *
+ * A 1px tolerance absorbs sub-pixel layout rounding, which reports a scrollable
+ * width larger than the client width on a box that shows no scrollbar.
+ */
+export async function expectClipsLongText(label: Locator) {
+  const measured = await label.evaluate((el) => {
+    const node = el.firstChild
+    if (!(node instanceof Text))
+      throw new TypeError('expectClipsLongText needs a label whose first child is its text')
+    const original = node.nodeValue
+    // A repeated letter has no break opportunity, which is the input that
+    // escaped its box and grew the sideways scrollbar in the first place.
+    node.nodeValue = 'W'.repeat(200)
+    try {
+      const scrolling: string[] = []
+      for (let box: Element | null = el; box && box !== document.body; box = box.parentElement) {
+        const { overflowX } = getComputedStyle(box)
+        if (overflowX !== 'auto' && overflowX !== 'scroll')
+          continue
+        if (box.scrollWidth - box.clientWidth > 1)
+          scrolling.push(`${box.tagName.toLowerCase()}.${box.getAttribute('class') ?? ''} (${box.scrollWidth} > ${box.clientWidth})`)
+      }
+      return { clipped: el.scrollWidth - el.clientWidth > 1, scrolling }
+    }
+    finally {
+      node.nodeValue = original
+    }
+  })
+  expect(measured.clipped, 'the label must clip its own text').toBe(true)
+  expect(measured.scrolling, 'no ancestor should scroll horizontally').toEqual([])
+}
+
+// ──────────────────────────────────────────────
 // Common UI interaction helpers
 // ──────────────────────────────────────────────
 


### PR DESCRIPTION
## Motivation
Several sidebar rows and chat elements had broken text overflow. Background-task rows wrapped a long unbreakable string across up to three hyphenated lines instead of clipping it, and a status dot floated inside that wrapped title. Because the row's container set `overflow-y: auto`, the browser computed the other axis to `auto` too, so a wide wrapped title grew a horizontal scrollbar in the sidebar.

Elsewhere, clipping was declared but silently inert. The worker list rendered into the workspace tree's `sectionItems` style, which sizes to its widest row to support deep tab-tree indentation — so a worker name's ellipsis never had room to fire. Several `flex: 1` sites (the file browser, the floating window title) omitted `min-width: 0`, so the item could never shrink past its own text and the ellipsis never appeared. `AppShell.css.ts`'s drag-preview tooltip and the sidebar-tab drag overlay applied `text-overflow: ellipsis` to a flex container, where the property has no effect, because it acts only on a block container's own inline content.

The `Tooltip` component made this worse in two ways: it detected clipping on both axes, so a sidebar row that scrolled partway out of a vertical list produced a false-positive tooltip that only repeated the visible label, and it had no touch support, because the synthetic `click` a tap generates dismissed the tooltip before the 700 ms hover timer could open it.

A `TodoList` row had a Solid reactivity bug: the code chose between a `Tooltip`-wrapped row and a bare row with `todo.description ? … : …` evaluated once inside a `<For>` body, so editing `description` in place never added or removed the tooltip after the initial render.

## Modifications
- Added `ClippedText` (`frontend/src/components/common/ClippedText.tsx`), a shared component that clips a label to one line and shows a tooltip only when the text is actually clipped. Backed by the shared `clippedText` style in `frontend/src/styles/shared.css.ts`, which replaces the deleted `menuItemLabel` (an exact duplicate). Adopted in `BackgroundTaskList`, `WorkerSectionContent`, `FileBrowser`, `TodoList`, `AttachmentStrip`, `AgentProviderSelector`, and `FloatingWindowContainer`. The component is the sole owner of the clipping rule, so a caller passes decoration only; an explanation stands above the label rather than in its place, and a row that carries both keeps the label's own route back.
- Added `StatusDot` (`frontend/src/components/common/StatusDot.tsx`), a shared sidebar-row status dot with a required `label` (`role="img"` + `aria-label`, since state was previously colour-only) and an optional `tooltip` for dots that receive pointer events. Adopted by the background-task and worker sections, replacing the CSS-floated dot with a flex sibling in a new `titleRow` container.
- Narrowed `Tooltip`'s overflow-clip detection to the horizontal axis only, fixing the false-positive tooltip on vertically scrolled sidebar rows.
- Added touch support to `Tooltip`: a `pointerup` with `pointerType: 'touch'` opens it immediately, and a press outside closes it. `SHOW_DELAY_MS`/`HIDE_DELAY_MS` are now exported for tests.
- Gave the worker list its own `workerItems` container (`frontend/src/components/workers/workerSection.css.ts`) instead of sharing `workspaceList.css.ts`'s `sectionItems`, so a worker name's ellipsis has room to fire without disturbing the tab tree's indentation sizing. `sectionItems` now records the `max-content` trap at the container that has it.
- Added `min-width: 0` to several `flex: 1` sites (file browser row, floating window title) that had never clipped before; each site that gains clipping for the first time also gains a tooltip so the now-hidden text stays reachable.
- Fixed `AppShell.css.ts`'s `dragPreviewTooltip` and the sidebar-tab drag overlay in `TabDragContext.tsx`: moved `text-overflow: ellipsis` off the flex container and onto an inner label span, where it takes effect. Extracted the inline overlay, which duplicated the drag-preview chrome, into an exported `renderSidebarTabOverlay(title)`.
- Added a `variant?: 'compact' | 'full'` prop to `TodoList` (default `compact`, so no existing caller changes behavior); `todoListMessage.tsx` passes `full` so the wider chat-transcript tool card wraps long labels instead of clipping them.
- Fixed the `TodoList` reactivity bug: the description is now read through a tracked accessor prop instead of a one-time ternary inside the `<For>` body, so an in-place edit correctly adds or removes the tooltip.
- `AttachmentStrip` now uses `ClippedText` instead of an always-on `Tooltip` with a manually clipped span, so the tooltip no longer appears for filenames that already fit.
- Four sites deliberately keep the raw `clippedText` style instead of `ClippedText`, each for a recorded reason: `DropdownMenu` (an arbitrary-JSX label, and a label already wrapped in an outer tooltip that a nested one would dismiss), `AgentProviderSelector`'s disabled empty state, `TabDragContext` and `useTileDragDrop` (drag images, destroyed before a hover tooltip could show), and `webSearchResults` (its label must hold an `<a>`, and the clip must stay on the inline span because an inline non-replaced box ignores `overflow`).
- Added `classSelector` (`frontend/src/test-support/composedClass.ts`) and routed the suites through it. A template class selector on a composed vanilla-extract style is a descendant selector that silently matches nothing, which had already turned an absence assertion in `ToolUseLayout.test.tsx` into a no-op. Shared jsdom clip stubs live beside it in `frontend/src/test-support/clipStub.ts`.
- Extended the E2E helpers (`frontend/tests/e2e/helpers/ui.ts`) with `expectClipsToOneLine` (asserts the resolved CSS, including the `min-width: 0` that decides whether the ellipsis ever fires) and `expectClipsLongText` (asserts the outcome by temporarily rewriting the label to 200 `W` characters and checking that it clips without growing a scrollbar on any auto/scroll ancestor). Both are needed: the dev worker is named `Local` and the worker name already declared the whole clipping quartet, so a declaration-only assertion passed against the unfixed container. Updated `021-worker-deregistration.spec.ts` to the new `workerItems` locator, and extended `020-worker-management`, `038-attachment-support`, and `170-claude-subagent-background-tasks`.

## Result
Long titles in the sidebar (background tasks, workers) clip to one line with a tooltip on hover, instead of wrapping into a multi-line block that forces a horizontal scrollbar. Worker names, file-browser rows, and floating-window titles clip and truncate correctly where their ellipsis was previously inert. Drag previews show a real ellipsis instead of a silently ignored CSS property. Tooltips no longer fire spuriously when a sidebar row scrolls partway out of view, and a clipped label is now reachable on a touch screen, where a tap previously dismissed the tooltip before it could open. Editing a to-do's description live shows or hides its tooltip correctly. The chat transcript's to-do card wraps its text instead of clipping it, matching the width it actually has. No user-facing breaking changes.
