### PR TITLE
feat(spans): Stop opening a span for a subagent spawn

### DIFF
--- a/backend/internal/worker/agent/acp_common.go
+++ b/backend/internal/worker/agent/acp_common.go
@@ -65,6 +65,12 @@ const (
 	acpUpdateConfigOptionUpdate      = "config_option_update"
 )
 
+// acpToolKindExecute is the ACP tool_call kind for running a command. A
+// provider's spawn detector must never strip the span off one of these: a
+// backgrounded shell is an ordinary tool span, not a subagent spawn, and it
+// keeps its rail even when the detector fires on it.
+const acpToolKindExecute = "execute"
+
 // acpPendingInput holds a user message queued while a prompt is in flight.
 type acpPendingInput struct {
 	content     string
@@ -1545,6 +1551,14 @@ func (b *acpBase) handleToolCall(update json.RawMessage) {
 		spanType = acpUpdateToolCall
 	}
 
+	// Ask the provider's detector BEFORE persisting, so a spawn it recognizes
+	// here never reserves a color and never opens a span. The observation is
+	// applied further down, at the point it was applied before.
+	var obs *acpSubagentObservation
+	if b.subagentFromToolCall != nil {
+		obs = b.subagentFromToolCall(tc)
+	}
+
 	// Tool calls that arrive already final (completed/failed/cancelled)
 	// are persisted as closing spans immediately — no open/close cycle.
 	if tc.Status == "completed" || tc.Status == "failed" || tc.Status == "cancelled" {
@@ -1553,23 +1567,30 @@ func (b *acpBase) handleToolCall(update json.RawMessage) {
 		}); err != nil {
 			slog.Error("persist final acp tool_call", "agent_id", b.agentID, "kind", tc.Kind, "status", tc.Status, "error", err)
 		}
-		if b.subagentFromToolCall != nil {
-			b.applySubagentObservation(b.subagentFromToolCall(tc))
-		}
+		b.applySubagentObservation(obs)
 		return
 	}
 
-	spanColor := b.sink.ReserveSpanColor(tc.ToolCallID, "")
+	// A subagent spawn owns no span: its output lands in its own child
+	// transcript, so a rail held open for the whole subagent run only pushes
+	// every concurrent tool one column right.
+	spawns := acpObservationIsSpawn(obs) && spanType != acpToolKindExecute
+	var spanColor int32
+	if !spawns {
+		spanColor = b.sink.ReserveSpanColor(tc.ToolCallID, "")
+	}
 	if err := b.sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, update, SpanInfo{
 		SpanID: tc.ToolCallID, SpanType: spanType, SpanColor: spanColor,
 	}); err != nil {
 		slog.Error("persist acp tool_call", "agent_id", b.agentID, "kind", tc.Kind, "error", err)
 	}
+	// The span type is recorded either way: the closing tool_call_update reads
+	// it back to persist span_type.
 	b.sink.SetSpanType(tc.ToolCallID, spanType)
-	b.sink.OpenSpan(tc.ToolCallID, "")
-	if b.subagentFromToolCall != nil {
-		b.applySubagentObservation(b.subagentFromToolCall(tc))
+	if !spawns {
+		b.sink.OpenSpan(tc.ToolCallID, "")
 	}
+	b.applySubagentObservation(obs)
 }
 
 func (b *acpBase) handleToolCallUpdate(update json.RawMessage) {
@@ -1588,6 +1609,15 @@ func (b *acpBase) handleToolCallUpdate(update json.RawMessage) {
 	if b.subagentFromToolCallUpdate != nil {
 		if obs := b.subagentFromToolCallUpdate(tcu); obs != nil {
 			b.applySubagentObservation(obs)
+			// A spawn recognized only HERE already opened a span at its
+			// tool_call, so take that span back now. Kilo is why: it opens the
+			// spawn with `rawInput: {}` and fills the spawn shape only on the
+			// first in-progress update. A no-op for every provider whose
+			// detector already fired at the tool_call, and for a shell, whose
+			// span must survive a detector that misfires on it.
+			if acpObservationIsSpawn(obs) && b.sink.GetSpanType(tcu.ToolCallID) != acpToolKindExecute {
+				b.sink.DiscardSpan(tcu.ToolCallID)
+			}
 		}
 	}
 
@@ -1625,6 +1655,19 @@ func (b *acpBase) handleToolCallUpdate(update json.RawMessage) {
 		b.sink.BroadcastStreamEnd(tcu.ToolCallID)
 		b.sink.CloseSpan(tcu.ToolCallID)
 	}
+}
+
+// acpObservationIsSpawn reports whether an observation announces a subagent
+// that is starting or running, as opposed to one that only ends a row. It is
+// the exact condition under which applySubagentObservation upserts a running
+// registry row, so the span decision and the registry decision cannot drift:
+// a close-only observation (Goose's and Cursor's closing hooks fire for EVERY
+// tool_call) and a rename+close (OpenCode learns the child session id on the
+// final update) both operate on a row that already exists, and neither says
+// "this tool call spawns a subagent".
+func acpObservationIsSpawn(obs *acpSubagentObservation) bool {
+	return obs != nil && obs.RowKey != "" &&
+		obs.Mode != acpModeCloseOnly && obs.RenameFrom == ""
 }
 
 // applySubagentObservation translates a provider hook's neutral observation

--- a/backend/internal/worker/agent/acp_common.go
+++ b/backend/internal/worker/agent/acp_common.go
@@ -1658,16 +1658,22 @@ func (b *acpBase) handleToolCallUpdate(update json.RawMessage) {
 }
 
 // acpObservationIsSpawn reports whether an observation announces a subagent
-// that is starting or running, as opposed to one that only ends a row. It is
-// the exact condition under which applySubagentObservation upserts a running
-// registry row, so the span decision and the registry decision cannot drift:
-// a close-only observation (Goose's and Cursor's closing hooks fire for EVERY
-// tool_call) and a rename+close (OpenCode learns the child session id on the
-// final update) both operate on a row that already exists, and neither says
-// "this tool call spawns a subagent".
+// that is starting or running, as opposed to one that only ends a row or one
+// that describes a shell. It tracks the condition under which
+// applySubagentObservation upserts a running registry row, so the span decision
+// and the registry decision cannot drift: a close-only observation (Goose's and
+// Cursor's closing hooks fire for EVERY tool_call) and a rename+close (OpenCode
+// learns the child session id on the final update) both operate on a row that
+// already exists, and neither says "this tool call spawns a subagent".
+//
+// A KindShell observation (Cursor's backgrounded non-task tools) is a
+// background process with no transcript, so it keeps its span like any other
+// tool. A blank kind means subagent, matching the default that
+// applySubagentObservation applies.
 func acpObservationIsSpawn(obs *acpSubagentObservation) bool {
 	return obs != nil && obs.RowKey != "" &&
-		obs.Mode != acpModeCloseOnly && obs.RenameFrom == ""
+		obs.Mode != acpModeCloseOnly && obs.RenameFrom == "" &&
+		obs.Kind != bgtask.KindShell
 }
 
 // applySubagentObservation translates a provider hook's neutral observation

--- a/backend/internal/worker/agent/acp_common.go
+++ b/backend/internal/worker/agent/acp_common.go
@@ -65,12 +65,6 @@ const (
 	acpUpdateConfigOptionUpdate      = "config_option_update"
 )
 
-// acpToolKindExecute is the ACP tool_call kind for running a command. A
-// provider's spawn detector must never strip the span off one of these: a
-// backgrounded shell is an ordinary tool span, not a subagent spawn, and it
-// keeps its rail even when the detector fires on it.
-const acpToolKindExecute = "execute"
-
 // acpPendingInput holds a user message queued while a prompt is in flight.
 type acpPendingInput struct {
 	content     string
@@ -119,8 +113,8 @@ const (
 	modeChannelPrimaryAgent
 )
 
-// acpBase extends jsonrpcBase with fields and methods shared by all ACP
-// agents (OpenCodeAgent, CopilotCLIAgent, CursorCLIAgent) but not CodexAgent.
+// acpBase extends jsonrpcBase with fields and methods shared by every ACP agent
+// (OpenCode, Kilo, Cursor, Copilot, Goose, Reasonix) but not CodexAgent.
 type acpBase struct {
 	jsonrpcBase
 	sink               OutputSink
@@ -129,11 +123,15 @@ type acpBase struct {
 	// subagentFromToolCall / subagentFromToolCallUpdate are optional
 	// provider-specific hooks that translate a tool_call / tool_call_update
 	// into a neutral acpSubagentObservation driving the background-task
-	// registry (and, for Goose, a best-effort tool-request transcript). nil
-	// for providers that surface no subagent activity over ACP (Cursor,
-	// Copilot) -- the plumbing is inert. Membership is decided per provider in
-	// its configure (the registration site), keeping provider-specific
+	// registry (and, for Goose, a best-effort tool-request transcript). nil for
+	// a provider that surfaces no subagent activity over ACP (Copilot) -- the
+	// plumbing is then inert. Membership is decided per provider in its
+	// configure (the registration site), keeping provider-specific
 	// names/shapes out of this shared file.
+	//
+	// A hook may not be a pure function of its envelope: Cursor binds both to
+	// its agent, because the closing update cannot tell a backgrounded task
+	// from a backgrounded shell without what the spawn recorded.
 	subagentFromToolCall       func(tc acpToolCallEnvelope) *acpSubagentObservation
 	subagentFromToolCallUpdate func(tcu acpToolCallUpdateEnvelope) *acpSubagentObservation
 	// subagentPrompts holds each spawn's prompt until the child transcript that
@@ -190,14 +188,20 @@ type acpBase struct {
 	// as internal pseudo-agents to hide from the picker (OpenCode's
 	// compaction/title/summary). Applied wherever the primary-agent list is built.
 	primaryAgentHiddenFilter func(string) bool
-	reapplySettings          func()                // called by ClearContext after session/new to re-apply model, mode, etc.
-	refreshFromSession       func(json.RawMessage) // called by ClearContext after reapplySettings to sync state from the session response
-	sessionID                string
-	workingDir               string
-	model                    string
-	permissionMode           string
-	currentPrimaryAgent      string
-	availableModels          []*ModelInfo
+	// spawnSpansReleased holds the tool calls whose span was already given back
+	// by the late-spawn path, so a re-reported spawn does not re-run the release
+	// on every update. Keyed by toolCallId, dropped when the call ends and
+	// cleared with the session. Guarded by mu.
+	spawnSpansReleased  map[string]struct{}
+	clearProviderState  func()                // called by ClearContext to drop provider state keyed by the OUTGOING session's tool-call ids
+	reapplySettings     func()                // called by ClearContext after session/new to re-apply model, mode, etc.
+	refreshFromSession  func(json.RawMessage) // called by ClearContext after reapplySettings to sync state from the session response
+	sessionID           string
+	workingDir          string
+	model               string
+	permissionMode      string
+	currentPrimaryAgent string
+	availableModels     []*ModelInfo
 	// modelsFieldInfos holds the models reported through the SessionModelState
 	// `models` field at the last full session response (handshake or ClearContext).
 	// A runtime config_option_update carries only the configOptions `model` select,
@@ -399,6 +403,16 @@ func (b *acpBase) ClearContext() (string, bool) {
 	// ever reuses the tool-call id, it would open the next transcript on the
 	// previous session's instruction. Codex clears its equivalent map here too.
 	b.subagentPrompts.clear()
+	// Same for the late-spawn notes: they are keyed by the OUTGOING session's
+	// tool-call ids, which will never report again.
+	b.mu.Lock()
+	clear(b.spawnSpansReleased)
+	b.mu.Unlock()
+	// A provider that keys its own state by tool-call id has the same exposure,
+	// for the same reason, so it clears that state here.
+	if b.clearProviderState != nil {
+		b.clearProviderState()
+	}
 
 	b.sink.UpdateSessionID(sessionID)
 
@@ -1519,6 +1533,16 @@ type acpSubagentObservation struct {
 	// CloseRow true => give a final status to the row after the upsert (Status carries
 	// the final status).
 	CloseRow bool
+	// Spawns true => this tool call STARTS a subagent, so it owns no span: the
+	// subagent's output lands in its own child transcript, and a rail held open
+	// for the whole run only pushes every concurrent tool one column right.
+	//
+	// Only a detector that recognizes its provider's spawn payload sets this. A
+	// progress observation, a tool-request observation, and a closing
+	// observation all leave it false, because each one describes a row that
+	// already exists. The provider states the fact; shared code must not infer
+	// it from which registry fields happen to be filled.
+	Spawns bool
 	// Mode selects close-only vs upsert. Defaults to acpModeUpsert (zero value);
 	// set acpModeCloseOnly explicitly when the observation carries no descriptive
 	// fields and should close an existing row without creating one.
@@ -1561,7 +1585,7 @@ func (b *acpBase) handleToolCall(update json.RawMessage) {
 
 	// Tool calls that arrive already final (completed/failed/cancelled)
 	// are persisted as closing spans immediately — no open/close cycle.
-	if tc.Status == "completed" || tc.Status == "failed" || tc.Status == "cancelled" {
+	if acpStatusIsFinal(tc.Status) {
 		if err := b.sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, update, SpanInfo{
 			SpanID: tc.ToolCallID, SpanType: spanType, Closing: true,
 		}); err != nil {
@@ -1574,21 +1598,9 @@ func (b *acpBase) handleToolCall(update json.RawMessage) {
 	// A subagent spawn owns no span: its output lands in its own child
 	// transcript, so a rail held open for the whole subagent run only pushes
 	// every concurrent tool one column right.
-	spawns := acpObservationIsSpawn(obs) && spanType != acpToolKindExecute
-	var spanColor int32
-	if !spawns {
-		spanColor = b.sink.ReserveSpanColor(tc.ToolCallID, "")
-	}
-	if err := b.sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, update, SpanInfo{
-		SpanID: tc.ToolCallID, SpanType: spanType, SpanColor: spanColor,
-	}); err != nil {
+	spawns := acpObservationIsSpawn(obs)
+	if err := openToolSpan(b.sink, update, tc.ToolCallID, spanType, spawns); err != nil {
 		slog.Error("persist acp tool_call", "agent_id", b.agentID, "kind", tc.Kind, "error", err)
-	}
-	// The span type is recorded either way: the closing tool_call_update reads
-	// it back to persist span_type.
-	b.sink.SetSpanType(tc.ToolCallID, spanType)
-	if !spawns {
-		b.sink.OpenSpan(tc.ToolCallID, "")
 	}
 	b.applySubagentObservation(obs)
 }
@@ -1610,13 +1622,26 @@ func (b *acpBase) handleToolCallUpdate(update json.RawMessage) {
 		if obs := b.subagentFromToolCallUpdate(tcu); obs != nil {
 			b.applySubagentObservation(obs)
 			// A spawn recognized only HERE already opened a span at its
-			// tool_call, so take that span back now. Kilo is why: it opens the
+			// tool_call, so give that span back now. Kilo is why: it opens the
 			// spawn with `rawInput: {}` and fills the spawn shape only on the
-			// first in-progress update. A no-op for every provider whose
-			// detector already fired at the tool_call, and for a shell, whose
-			// span must survive a detector that misfires on it.
-			if acpObservationIsSpawn(obs) && b.sink.GetSpanType(tcu.ToolCallID) != acpToolKindExecute {
-				b.sink.DiscardSpan(tcu.ToolCallID)
+			// first in-progress update. CloseSpan frees the column although the
+			// subagent keeps running; the recorded span type survives it, so the
+			// closing arm below still persists the real kind.
+			//
+			// Only before the final status. Freeing the column removes it from
+			// the active set, so the closing arm would find nothing to mark
+			// connector_end: the rail drawn for the whole call would stop
+			// mid-transcript instead of ending. A spawn learned that late keeps
+			// its span and closes it once, below.
+			//
+			// Only ONCE per tool call. The detector re-runs on every update, and
+			// a provider that echoes its rawInput re-reports the spawn on each
+			// one; without the note every later update would take the tracker
+			// mutex and re-scan the active set to remove a span that is already
+			// gone, for the whole subagent run.
+			if !acpStatusIsFinal(tcu.Status) && acpObservationIsSpawn(obs) &&
+				b.markSpawnSpanReleased(tcu.ToolCallID) {
+				b.sink.CloseSpan(tcu.ToolCallID)
 			}
 		}
 	}
@@ -1642,6 +1667,7 @@ func (b *acpBase) handleToolCallUpdate(update json.RawMessage) {
 		b.turnToolUses++
 		b.mu.Unlock()
 		b.clearCumulativeDelta(tcu.ToolCallID)
+		b.forgetSpawnSpanReleased(tcu.ToolCallID)
 
 		spanType := b.sink.GetSpanType(tcu.ToolCallID)
 		if spanType == "" {
@@ -1657,23 +1683,21 @@ func (b *acpBase) handleToolCallUpdate(update json.RawMessage) {
 	}
 }
 
-// acpObservationIsSpawn reports whether an observation announces a subagent
-// that is starting or running, as opposed to one that only ends a row or one
-// that describes a shell. It tracks the condition under which
-// applySubagentObservation upserts a running registry row, so the span decision
-// and the registry decision cannot drift: a close-only observation (Goose's and
-// Cursor's closing hooks fire for EVERY tool_call) and a rename+close (OpenCode
-// learns the child session id on the final update) both operate on a row that
-// already exists, and neither says "this tool call spawns a subagent".
+// acpObservationIsSpawn reports whether an observation announces that this tool
+// call STARTS a subagent. Each provider's detector states the fact directly, so
+// shared code reads one field instead of inferring the answer from which
+// registry fields happen to be filled.
 //
-// A KindShell observation (Cursor's backgrounded non-task tools) is a
-// background process with no transcript, so it keeps its span like any other
-// tool. A blank kind means subagent, matching the default that
-// applySubagentObservation applies.
+// The earlier inference asked whether the observation upserts a RUNNING row,
+// which is a different question and gave the wrong answer: Goose's
+// subagent_tool_request update reports on a subagent that already runs, upserts
+// a running row, and so read as a spawn -- which took the span away from the
+// tool call it rode on.
+//
+// The RowKey guard stays: an observation that names no row writes nothing, so
+// it must not take a span either.
 func acpObservationIsSpawn(obs *acpSubagentObservation) bool {
-	return obs != nil && obs.RowKey != "" &&
-		obs.Mode != acpModeCloseOnly && obs.RenameFrom == "" &&
-		obs.Kind != bgtask.KindShell
+	return obs != nil && obs.RowKey != "" && obs.Spawns
 }
 
 // applySubagentObservation translates a provider hook's neutral observation
@@ -1776,6 +1800,38 @@ func (b *acpBase) applySubagentObservation(obs *acpSubagentObservation) {
 			b.sink.CleanupChildAgent(childAgentID)
 		}
 	}
+}
+
+// markSpawnSpanReleased records that this tool call's span was given back, and
+// reports whether THIS call is the one that did it. Only the first caller gets
+// true, so the release runs once however many times the detector re-reports the
+// spawn.
+func (b *acpBase) markSpawnSpanReleased(toolCallID string) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.spawnSpansReleased == nil {
+		b.spawnSpansReleased = make(map[string]struct{})
+	}
+	if _, done := b.spawnSpansReleased[toolCallID]; done {
+		return false
+	}
+	b.spawnSpansReleased[toolCallID] = struct{}{}
+	return true
+}
+
+// forgetSpawnSpanReleased drops the note when the tool call ends, mirroring the
+// per-tool-call cleanup of cumulativeBroadcast beside it.
+func (b *acpBase) forgetSpawnSpanReleased(toolCallID string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	delete(b.spawnSpansReleased, toolCallID)
+}
+
+// acpStatusIsFinal reports whether an ACP tool_call status ends the call. These
+// are the three statuses acpFinalStatus below maps; a tool call that reaches one
+// of them sends no further update.
+func acpStatusIsFinal(s string) bool {
+	return s == "completed" || s == "failed" || s == "cancelled"
 }
 
 // acpFinalStatus maps an ACP tool_call status to the registry final

--- a/backend/internal/worker/agent/acp_subagent_test.go
+++ b/backend/internal/worker/agent/acp_subagent_test.go
@@ -339,16 +339,99 @@ func TestACP_CursorSubagentFromToolCallUpdate_FinalCloses(t *testing.T) {
 	}
 }
 
-func TestACP_CursorSubagentFromToolCallUpdate_BackgroundNotesActivity(t *testing.T) {
+// A backgrounded call that is NOT the task tool is a shell. The neutral layer
+// defaults a blank kind to Subagent, so leaving it blank put a shell in the
+// sidebar under a Bot icon, in the subagent filter tab, labelled with its raw
+// toolCallId.
+func TestACP_CursorSubagentFromToolCallUpdate_BackgroundShellIsAShellRow(t *testing.T) {
 	tcu := acpToolCallUpdateEnvelope{
 		ToolCallID: "call-bg-0",
+		Title:      "npm run dev",
 		Status:     "completed",
+		RawInput:   json.RawMessage(`{"_toolName":"shell","command":"npm run dev"}`),
 		RawOutput:  json.RawMessage(`{"durationMs":5000,"isBackground":true}`),
 	}
 	obs := cursorSubagentFromToolCallUpdate(tcu)
 	if assert.NotNil(t, obs) {
 		assert.Equal(t, "background task", obs.Activity)
+		assert.Equal(t, bgtask.KindShell, obs.Kind, "a backgrounded shell is not a subagent")
+		assert.Equal(t, "npm run dev", obs.Title,
+			"this update is the row's only event, so it must carry the label")
+		assert.Equal(t, acpModeUpsert, obs.Mode)
+		assert.True(t, obs.CloseRow)
 	}
+}
+
+// Cursor does not always echo the input on an update. With nothing to say it
+// was the task tool, a backgrounded call is still a shell -- that is the case
+// this bug was reported for.
+func TestACP_CursorSubagentFromToolCallUpdate_BackgroundWithoutInputIsAShellRow(t *testing.T) {
+	tcu := acpToolCallUpdateEnvelope{
+		ToolCallID: "call-bg-1",
+		Status:     "completed",
+		RawOutput:  json.RawMessage(`{"isBackground":true}`),
+	}
+	obs := cursorSubagentFromToolCallUpdate(tcu)
+	if assert.NotNil(t, obs) {
+		assert.Equal(t, bgtask.KindShell, obs.Kind)
+	}
+}
+
+// A backgrounded TASK tool is still a subagent. Its kind and title stay blank
+// so Item.PreservingBlanksFrom keeps what the spawn observation already wrote:
+// setting them here would flip the row to a shell and overwrite its trimmed
+// title with the raw "Task: ..." string.
+func TestACP_CursorSubagentFromToolCallUpdate_BackgroundTaskStaysASubagent(t *testing.T) {
+	tcu := acpToolCallUpdateEnvelope{
+		ToolCallID: "call-abc-0",
+		Title:      "Task: build the feature",
+		Status:     "completed",
+		RawInput:   json.RawMessage(`{"_toolName":"task","prompt":"do it"}`),
+		RawOutput:  json.RawMessage(`{"isBackground":true}`),
+	}
+	obs := cursorSubagentFromToolCallUpdate(tcu)
+	if assert.NotNil(t, obs) {
+		assert.Equal(t, "background task", obs.Activity)
+		assert.Equal(t, bgtask.KindUnspecified, obs.Kind, "blank keeps the spawn row's kind")
+		assert.Empty(t, obs.Title, "blank keeps the spawn row's trimmed title")
+	}
+}
+
+// A finished FOREGROUND tool creates no row at all, so it must not carry a kind
+// that a stray upsert could write.
+func TestACP_CursorSubagentFromToolCallUpdate_ForegroundCarriesNoKind(t *testing.T) {
+	tcu := acpToolCallUpdateEnvelope{
+		ToolCallID: "call-fg-0",
+		Title:      "Read file",
+		Status:     "completed",
+		RawOutput:  json.RawMessage(`{"isBackground":false}`),
+	}
+	obs := cursorSubagentFromToolCallUpdate(tcu)
+	if assert.NotNil(t, obs) {
+		assert.Equal(t, acpModeCloseOnly, obs.Mode)
+		assert.Equal(t, bgtask.KindUnspecified, obs.Kind)
+		assert.Empty(t, obs.Title)
+	}
+}
+
+func TestACP_CursorToolCallIsTaskTool(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, cursorToolCallIsTaskTool(json.RawMessage(`{"_toolName":"task"}`)))
+	assert.False(t, cursorToolCallIsTaskTool(json.RawMessage(`{"_toolName":"shell"}`)))
+	assert.False(t, cursorToolCallIsTaskTool(json.RawMessage(`{}`)))
+	assert.False(t, cursorToolCallIsTaskTool(json.RawMessage(`not json`)))
+	assert.False(t, cursorToolCallIsTaskTool(nil), "an absent input is not known to be the task tool")
+}
+
+func TestACP_CursorToolCallRanInBackground(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, cursorToolCallRanInBackground(json.RawMessage(`{"isBackground":true}`)))
+	assert.False(t, cursorToolCallRanInBackground(json.RawMessage(`{"isBackground":false}`)))
+	assert.False(t, cursorToolCallRanInBackground(json.RawMessage(`{}`)))
+	assert.False(t, cursorToolCallRanInBackground(json.RawMessage(`not json`)))
+	assert.False(t, cursorToolCallRanInBackground(nil))
 }
 
 func TestACP_CursorSubagentFromToolCallUpdate_InProgressReturnsNil(t *testing.T) {
@@ -937,4 +1020,76 @@ func TestACP_CursorClosingUpdateDoesNotDiscardAPlainToolSpan(t *testing.T) {
 
 	assert.Empty(t, sink.DiscardedSpans(), "a close-only observation discards nothing")
 	assert.Equal(t, []string{"call-read"}, sink.ClosedSpans(), "the span closes normally")
+}
+
+// End to end through the neutral layer: a Cursor background shell lands in the
+// registry as a SHELL row with a readable title, not as a subagent.
+func TestACP_CursorBackgroundShellLandsAsAShellRow(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	b := &acpBase{
+		sink:                       sink,
+		subagentFromToolCall:       cursorSubagentFromToolCall,
+		subagentFromToolCallUpdate: cursorSubagentFromToolCallUpdate,
+	}
+
+	b.handleToolCall(json.RawMessage(`{"toolCallId":"call-sh","kind":"execute","title":"npm run dev","rawInput":{"_toolName":"shell","command":"npm run dev"}}`))
+	b.handleToolCallUpdate(json.RawMessage(`{"toolCallId":"call-sh","status":"completed","title":"npm run dev","rawInput":{"_toolName":"shell"},"rawOutput":{"isBackground":true}}`))
+
+	tasks := sink.BackgroundTasks()
+	require.Len(t, tasks, 1)
+	assert.Equal(t, "call-sh", tasks[0].RowKey)
+	assert.Equal(t, bgtask.KindShell, tasks[0].Kind,
+		"a backgrounded shell must not render under the Bot icon in the subagent tab")
+	assert.Equal(t, "npm run dev", tasks[0].Title,
+		"without a title the sidebar falls back to the raw toolCallId")
+	assert.False(t, tasks[0].TitleIsCommand,
+		"Cursor's title is a label, not a verbatim command, so it stays in the normal face")
+	assert.Empty(t, tasks[0].ChildAgentID, "a shell has no transcript to open")
+
+	// A shell is an ordinary tool span: it opens one and closes it normally.
+	// Two guards keep it that way here -- the kind is not a spawn, and an
+	// `execute` tool call is exempt anyway. TestACP_ObservationIsSpawnExcludesAShell
+	// isolates the first one.
+	assert.Empty(t, sink.DiscardedSpans(), "a shell row is not a spawn")
+	assert.Equal(t, []string{"call-sh"}, sink.ClosedSpans())
+}
+
+// The task tool's row survives its own closing update: still a subagent, still
+// carrying the trimmed title the spawn gave it.
+func TestACP_CursorTaskRowStaysASubagentThroughItsClose(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	b := &acpBase{
+		sink:                       sink,
+		subagentFromToolCall:       cursorSubagentFromToolCall,
+		subagentFromToolCallUpdate: cursorSubagentFromToolCallUpdate,
+	}
+
+	b.handleToolCall(json.RawMessage(`{"toolCallId":"call-task","kind":"other","title":"Task: build the feature","rawInput":{"_toolName":"task","prompt":"do it"}}`))
+	b.handleToolCallUpdate(json.RawMessage(`{"toolCallId":"call-task","status":"completed","title":"Task: build the feature","rawInput":{"_toolName":"task"},"rawOutput":{"isBackground":true}}`))
+
+	tasks := sink.BackgroundTasks()
+	require.Len(t, tasks, 1)
+	assert.Equal(t, bgtask.KindSubagent, tasks[0].Kind)
+	assert.Equal(t, "build the feature", tasks[0].Title,
+		"the closing update must not overwrite the spawn's trimmed title")
+	assert.Equal(t, bgtask.StatusCompleted, tasks[0].Status)
+}
+
+// A shell observation is not a spawn, so it never reaches DiscardSpan.
+func TestACP_ObservationIsSpawnExcludesAShell(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, acpObservationIsSpawn(&acpSubagentObservation{
+		RowKey: "call-sh", Kind: bgtask.KindShell, Status: bgtask.StatusCompleted,
+	}), "a shell is a background process with no transcript, so it keeps its span")
+	assert.True(t, acpObservationIsSpawn(&acpSubagentObservation{
+		RowKey: "call-task", Kind: bgtask.KindSubagent,
+	}))
+	assert.True(t, acpObservationIsSpawn(&acpSubagentObservation{
+		RowKey: "call-task",
+	}), "a blank kind means subagent, matching applySubagentObservation's default")
 }

--- a/backend/internal/worker/agent/acp_subagent_test.go
+++ b/backend/internal/worker/agent/acp_subagent_test.go
@@ -743,3 +743,198 @@ func TestACP_OpenCodeFinalUpdateStillClosesAndRekeys(t *testing.T) {
 	assert.Equal(t, "call-1", obs.RenameFrom)
 	assert.Equal(t, bgtask.StatusCompleted, obs.Status)
 }
+
+// --- A subagent spawn owns no span ---
+
+func TestACP_ObservationIsSpawn(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, acpObservationIsSpawn(nil), "no observation, no spawn")
+	assert.False(t, acpObservationIsSpawn(&acpSubagentObservation{}), "an empty row key names nothing")
+	assert.False(t, acpObservationIsSpawn(&acpSubagentObservation{
+		RowKey: "call-1", Mode: acpModeCloseOnly,
+	}), "a close-only observation ends a row; it does not announce a spawn")
+	assert.False(t, acpObservationIsSpawn(&acpSubagentObservation{
+		RowKey: "ses-child", RenameFrom: "call-1",
+	}), "a rename+close operates on a row that already exists")
+	assert.True(t, acpObservationIsSpawn(&acpSubagentObservation{
+		RowKey: "call-1", Status: bgtask.StatusRunning,
+	}))
+}
+
+// Every ACP provider whose detector fires at the tool_call opens no span for a
+// spawn, and still opens one for an ordinary tool call.
+func TestACP_SpawnToolCallOpensNoSpan(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		provider  string
+		hook      func(acpToolCallEnvelope) *acpSubagentObservation
+		spawnCall string
+		plainCall string
+	}{
+		{
+			provider:  "cursor",
+			hook:      cursorSubagentFromToolCall,
+			spawnCall: `{"toolCallId":"call-spawn","kind":"other","title":"Task: explore","rawInput":{"_toolName":"task"}}`,
+			plainCall: `{"toolCallId":"call-plain","kind":"read","title":"Read","rawInput":{"_toolName":"read","path":"/tmp/a"}}`,
+		},
+		{
+			provider:  "opencode",
+			hook:      openCodeSubagentFromToolCall,
+			spawnCall: `{"toolCallId":"call-spawn","kind":"other","title":"explore","rawInput":{"description":"explore","prompt":"go","subagent_type":"general"}}`,
+			plainCall: `{"toolCallId":"call-plain","kind":"read","title":"Read","rawInput":{"filePath":"/tmp/a"}}`,
+		},
+		{
+			provider:  "goose",
+			hook:      gooseSubagentFromToolCall,
+			spawnCall: `{"toolCallId":"call-spawn","kind":"other","title":"Goose subagent","rawInput":{"instructions":"go"},"_meta":{"goose":{"toolCall":{"toolName":"delegate","extensionName":"summon"}}}}`,
+			plainCall: `{"toolCallId":"call-plain","kind":"read","title":"Read","_meta":{"goose":{"toolCall":{"toolName":"text_editor","extensionName":"developer"}}}}`,
+		},
+		{
+			provider:  "reasonix",
+			hook:      reasonixSubagentFromToolCall,
+			spawnCall: `{"toolCallId":"call-spawn","kind":"other","title":"task","rawInput":{"description":"explore","prompt":"go"}}`,
+			plainCall: `{"toolCallId":"call-plain","kind":"read","title":"Read","rawInput":{"path":"/tmp/a"}}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.provider, func(t *testing.T) {
+			t.Parallel()
+
+			sink := &testSink{}
+			b := &acpBase{sink: sink, subagentFromToolCall: tc.hook}
+
+			b.handleToolCall(json.RawMessage(tc.spawnCall))
+			assert.Empty(t, sink.OpenSpans(), "a spawn opens no span")
+			assert.Empty(t, sink.ReservedColorSpans(), "and reserves no color")
+			assert.Equal(t, "other", sink.GetSpanType("call-spawn"),
+				"the span type is still recorded for the closing update")
+
+			b.handleToolCall(json.RawMessage(tc.plainCall))
+			open := sink.OpenSpans()
+			require.Len(t, open, 1, "an ordinary tool call still opens a span")
+			assert.Equal(t, "call-plain", open[0].SpanID)
+			assert.Equal(t, []string{"call-plain"}, sink.ReservedColorSpans())
+
+			// The spawn row was persisted before the plain call, so it drew no
+			// rail; the plain row persists before its own span opens, so it
+			// draws none either.
+			msgs := sink.Messages()
+			require.Len(t, msgs, 2)
+			assert.Empty(t, msgs[0].SpansOpenAtPersist)
+			assert.Equal(t, "call-spawn", msgs[0].SpanID)
+		})
+	}
+}
+
+// Kilo opens its spawn with `rawInput: {}` and reveals the spawn shape only on
+// the first in-progress update, so the span is already open by then. The update
+// takes it back with DiscardSpan -- which, unlike CloseSpan, keeps the recorded
+// span type that the closing update reads back.
+func TestACP_KiloLateSpawnDiscardsTheSpan(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	b := &acpBase{
+		sink:                       sink,
+		subagentFromToolCall:       openCodeSubagentFromToolCall,
+		subagentFromToolCallUpdate: openCodeSubagentFromToolCallUpdate,
+	}
+
+	b.handleToolCall(json.RawMessage(`{"toolCallId":"call-spawn","kind":"other","title":"new_task","rawInput":{}}`))
+	require.Len(t, sink.OpenSpans(), 1, "the empty rawInput hides the spawn, so a span opens")
+
+	b.handleToolCallUpdate(json.RawMessage(
+		`{"toolCallId":"call-spawn","status":"in_progress","rawInput":{"description":"explore","prompt":"go","subagent_type":"general"}}`))
+
+	assert.Equal(t, []string{"call-spawn"}, sink.DiscardedSpans())
+	assert.Empty(t, sink.ClosedSpans(), "discarded, not closed -- the subagent is still running")
+	assert.Equal(t, "other", sink.GetSpanType("call-spawn"),
+		"a discard keeps the type the closing update reads back")
+
+	// A tool call that starts after the discard sits at column 0, not column 1.
+	b.handleToolCall(json.RawMessage(`{"toolCallId":"call-plain","kind":"read","title":"Read"}`))
+	msgs := sink.Messages()
+	require.Len(t, msgs, 2)
+	assert.Empty(t, msgs[1].SpansOpenAtPersist, "the spawn rail is gone")
+
+	// The closing update persists the recorded kind, not the "tool_call"
+	// fallback -- this is what DiscardSpan buys over CloseSpan.
+	b.handleToolCallUpdate(json.RawMessage(`{"toolCallId":"call-spawn","status":"completed","rawOutput":{"metadata":{"sessionId":"ses-child"}}}`))
+	msgs = sink.Messages()
+	require.Len(t, msgs, 3)
+	assert.Equal(t, "other", msgs[2].SpanType)
+	assert.True(t, msgs[2].Closing)
+}
+
+// A backgrounded shell is an ordinary tool span. Even when a provider's spawn
+// detector fires on it, an `execute` tool call KEEPS its rail.
+func TestACP_ExecuteKindKeepsItsSpanEvenWhenDetectedAsASpawn(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	b := &acpBase{
+		sink:                       sink,
+		subagentFromToolCall:       openCodeSubagentFromToolCall,
+		subagentFromToolCallUpdate: openCodeSubagentFromToolCallUpdate,
+	}
+
+	// Spawn-shaped rawInput on an execute call: the detector fires, the span stays.
+	spawnShaped := `"rawInput":{"description":"run it","prompt":"go","subagent_type":"general"}`
+	b.handleToolCall(json.RawMessage(`{"toolCallId":"call-sh","kind":"execute","title":"bash",` + spawnShaped + `}`))
+
+	open := sink.OpenSpans()
+	require.Len(t, open, 1, "an execute call keeps its span")
+	assert.Equal(t, "call-sh", open[0].SpanID)
+	assert.Equal(t, []string{"call-sh"}, sink.ReservedColorSpans())
+
+	// And the late path does not take it away either.
+	b.handleToolCallUpdate(json.RawMessage(`{"toolCallId":"call-sh","status":"in_progress",` + spawnShaped + `}`))
+	assert.Empty(t, sink.DiscardedSpans())
+}
+
+// A tool_call that arrives already final never opened a span, so the spawn
+// detector must not disturb it -- it only feeds the registry.
+func TestACP_FinalToolCallSpawnStillFeedsTheRegistry(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	b := &acpBase{sink: sink, subagentFromToolCall: openCodeSubagentFromToolCall}
+
+	b.handleToolCall(json.RawMessage(
+		`{"toolCallId":"call-spawn","kind":"other","status":"completed","title":"explore","rawInput":{"description":"explore","prompt":"go","subagent_type":"general"}}`))
+
+	assert.Empty(t, sink.OpenSpans())
+	assert.Empty(t, sink.DiscardedSpans())
+	tasks := sink.BackgroundTasks()
+	require.Len(t, tasks, 1, "the registry row is still upserted")
+	assert.Equal(t, "call-spawn", tasks[0].RowKey)
+
+	msgs := sink.Messages()
+	require.Len(t, msgs, 1)
+	assert.True(t, msgs[0].Closing)
+}
+
+// Cursor's closing hook fires for EVERY finished tool call. Its close-only
+// observation must not be read as a spawn, or an ordinary tool would lose the
+// span it is about to close.
+func TestACP_CursorClosingUpdateDoesNotDiscardAPlainToolSpan(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	b := &acpBase{
+		sink:                       sink,
+		subagentFromToolCall:       cursorSubagentFromToolCall,
+		subagentFromToolCallUpdate: cursorSubagentFromToolCallUpdate,
+	}
+
+	b.handleToolCall(json.RawMessage(`{"toolCallId":"call-read","kind":"read","title":"Read","rawInput":{"_toolName":"read"}}`))
+	require.Len(t, sink.OpenSpans(), 1)
+
+	b.handleToolCallUpdate(json.RawMessage(`{"toolCallId":"call-read","status":"completed"}`))
+
+	assert.Empty(t, sink.DiscardedSpans(), "a close-only observation discards nothing")
+	assert.Equal(t, []string{"call-read"}, sink.ClosedSpans(), "the span closes normally")
+}

--- a/backend/internal/worker/agent/acp_subagent_test.go
+++ b/backend/internal/worker/agent/acp_subagent_test.go
@@ -301,6 +301,34 @@ func TestACP_ReasonixSubagentFromToolCall_NonSpawnReturnsNil(t *testing.T) {
 	assert.Nil(t, reasonixSubagentFromToolCall(tc))
 }
 
+// The prompt is the only discriminator Reasonix supplies, so it is required.
+// A `description` is an ordinary tool argument: treating one as a spawn used to
+// add a false sidebar row, and now also strips that tool's span, so its card
+// loses its border and its result row loses the connector back to the call.
+func TestACP_ReasonixSubagentFromToolCall_DescriptionAloneIsNotASpawn(t *testing.T) {
+	t.Parallel()
+
+	for _, rawInput := range []string{
+		`{"description":"add the guard","path":"/a.go"}`,
+		`{"description":"run it","prompt":null}`,
+		`{"description":"x","prompt":""}`,
+	} {
+		assert.Nil(t, reasonixSubagentFromToolCall(acpToolCallEnvelope{
+			ToolCallID: "tc-rx-desc",
+			Kind:       "edit",
+			RawInput:   json.RawMessage(rawInput),
+		}), "a tool argument named description does not spawn: %s", rawInput)
+	}
+
+	// The recorded spawn shape still fires.
+	assert.NotNil(t, reasonixSubagentFromToolCall(acpToolCallEnvelope{
+		ToolCallID: "tc-rx-spawn",
+		Kind:       "other",
+		Title:      "task",
+		RawInput:   json.RawMessage(`{"description":"explore","prompt":"go"}`),
+	}))
+}
+
 func TestACP_CursorSubagentFromToolCall_TaskToolNameDetectsSpawn(t *testing.T) {
 	tc := acpToolCallEnvelope{
 		ToolCallID: "call-abc-0",
@@ -331,7 +359,7 @@ func TestACP_CursorSubagentFromToolCallUpdate_FinalCloses(t *testing.T) {
 		Status:     "completed",
 		RawOutput:  json.RawMessage(`{"durationMs":1200,"isBackground":false}`),
 	}
-	obs := cursorSubagentFromToolCallUpdate(tcu)
+	obs := cursorSubagentFromToolCallUpdate(tcu, false)
 	if assert.NotNil(t, obs) {
 		assert.True(t, obs.CloseRow)
 		assert.Equal(t, bgtask.StatusCompleted, obs.Status)
@@ -351,7 +379,7 @@ func TestACP_CursorSubagentFromToolCallUpdate_BackgroundShellIsAShellRow(t *test
 		RawInput:   json.RawMessage(`{"_toolName":"shell","command":"npm run dev"}`),
 		RawOutput:  json.RawMessage(`{"durationMs":5000,"isBackground":true}`),
 	}
-	obs := cursorSubagentFromToolCallUpdate(tcu)
+	obs := cursorSubagentFromToolCallUpdate(tcu, false)
 	if assert.NotNil(t, obs) {
 		assert.Equal(t, "background task", obs.Activity)
 		assert.Equal(t, bgtask.KindShell, obs.Kind, "a backgrounded shell is not a subagent")
@@ -371,7 +399,7 @@ func TestACP_CursorSubagentFromToolCallUpdate_BackgroundWithoutInputIsAShellRow(
 		Status:     "completed",
 		RawOutput:  json.RawMessage(`{"isBackground":true}`),
 	}
-	obs := cursorSubagentFromToolCallUpdate(tcu)
+	obs := cursorSubagentFromToolCallUpdate(tcu, false)
 	if assert.NotNil(t, obs) {
 		assert.Equal(t, bgtask.KindShell, obs.Kind)
 	}
@@ -389,7 +417,7 @@ func TestACP_CursorSubagentFromToolCallUpdate_BackgroundTaskStaysASubagent(t *te
 		RawInput:   json.RawMessage(`{"_toolName":"task","prompt":"do it"}`),
 		RawOutput:  json.RawMessage(`{"isBackground":true}`),
 	}
-	obs := cursorSubagentFromToolCallUpdate(tcu)
+	obs := cursorSubagentFromToolCallUpdate(tcu, true)
 	if assert.NotNil(t, obs) {
 		assert.Equal(t, "background task", obs.Activity)
 		assert.Equal(t, bgtask.KindUnspecified, obs.Kind, "blank keeps the spawn row's kind")
@@ -406,7 +434,7 @@ func TestACP_CursorSubagentFromToolCallUpdate_ForegroundCarriesNoKind(t *testing
 		Status:     "completed",
 		RawOutput:  json.RawMessage(`{"isBackground":false}`),
 	}
-	obs := cursorSubagentFromToolCallUpdate(tcu)
+	obs := cursorSubagentFromToolCallUpdate(tcu, false)
 	if assert.NotNil(t, obs) {
 		assert.Equal(t, acpModeCloseOnly, obs.Mode)
 		assert.Equal(t, bgtask.KindUnspecified, obs.Kind)
@@ -436,7 +464,7 @@ func TestACP_CursorToolCallRanInBackground(t *testing.T) {
 
 func TestACP_CursorSubagentFromToolCallUpdate_InProgressReturnsNil(t *testing.T) {
 	tcu := acpToolCallUpdateEnvelope{ToolCallID: "tc-c2", Status: "in_progress"}
-	assert.Nil(t, cursorSubagentFromToolCallUpdate(tcu))
+	assert.Nil(t, cursorSubagentFromToolCallUpdate(tcu, false))
 }
 
 // --- Wire-JSON decode tests ---
@@ -835,14 +863,92 @@ func TestACP_ObservationIsSpawn(t *testing.T) {
 	assert.False(t, acpObservationIsSpawn(nil), "no observation, no spawn")
 	assert.False(t, acpObservationIsSpawn(&acpSubagentObservation{}), "an empty row key names nothing")
 	assert.False(t, acpObservationIsSpawn(&acpSubagentObservation{
-		RowKey: "call-1", Mode: acpModeCloseOnly,
-	}), "a close-only observation ends a row; it does not announce a spawn")
+		RowKey: "call-1", Spawns: false, Status: bgtask.StatusRunning,
+	}), "a running row is not a spawn unless the provider says so")
 	assert.False(t, acpObservationIsSpawn(&acpSubagentObservation{
-		RowKey: "ses-child", RenameFrom: "call-1",
-	}), "a rename+close operates on a row that already exists")
+		Spawns: true,
+	}), "an observation that names no row must not take a span either")
 	assert.True(t, acpObservationIsSpawn(&acpSubagentObservation{
-		RowKey: "call-1", Status: bgtask.StatusRunning,
+		RowKey: "call-1", Spawns: true,
 	}))
+}
+
+// Every ACP detector that recognizes its provider's spawn payload states it, and
+// every other observation leaves the field false. Asserted over the real hooks,
+// because a hand-built struct proves only what the test author believed.
+func TestACP_OnlyTheSpawnDetectorsClaimASpawn(t *testing.T) {
+	t.Parallel()
+
+	spawns := []struct {
+		provider string
+		obs      *acpSubagentObservation
+	}{
+		{"cursor", cursorSubagentFromToolCall(acpToolCallEnvelope{
+			ToolCallID: "c", Title: "Task: go", RawInput: json.RawMessage(`{"_toolName":"task"}`)})},
+		{"opencode", openCodeSubagentFromToolCall(acpToolCallEnvelope{
+			ToolCallID: "o", RawInput: json.RawMessage(`{"prompt":"go","subagent_type":"general"}`)})},
+		{"goose", gooseSubagentFromToolCall(acpToolCallEnvelope{
+			ToolCallID: "g", Title: "Goose subagent", RawInput: json.RawMessage(`{"instructions":"go"}`),
+			Meta: json.RawMessage(`{"goose":{"toolCall":{"toolName":"delegate","extensionName":"summon"}}}`)})},
+		{"reasonix", reasonixSubagentFromToolCall(acpToolCallEnvelope{
+			ToolCallID: "r", Title: "task", RawInput: json.RawMessage(`{"description":"d","prompt":"go"}`)})},
+	}
+	for _, s := range spawns {
+		if assert.NotNil(t, s.obs, "%s detector fires on its spawn payload", s.provider) {
+			assert.True(t, s.obs.Spawns, "%s spawn observation claims the spawn", s.provider)
+		}
+	}
+
+	// A progress or closing observation describes a row that already exists.
+	notSpawns := []struct {
+		what string
+		obs  *acpSubagentObservation
+	}{
+		{"goose tool request", gooseSubagentFromToolCallUpdate(acpToolCallUpdateEnvelope{
+			ToolCallID: "g", Status: "in_progress",
+			Meta: json.RawMessage(`{"toolNotification":{"type":"message","params":{"data":{"type":"subagent_tool_request","subagent_id":"s1","tool_call":{"name":"grep"}}}}}`)})},
+		{"goose close", gooseSubagentFromToolCallUpdate(acpToolCallUpdateEnvelope{
+			ToolCallID: "g", Status: "completed"})},
+		{"cursor close", cursorSubagentFromToolCallUpdate(acpToolCallUpdateEnvelope{
+			ToolCallID: "c", Status: "completed"}, false)},
+		{"cursor background shell", cursorSubagentFromToolCallUpdate(acpToolCallUpdateEnvelope{
+			ToolCallID: "c", Title: "npm run dev", Status: "completed",
+			RawOutput: json.RawMessage(`{"isBackground":true}`)}, false)},
+		{"opencode close", openCodeSubagentFromToolCallUpdate(acpToolCallUpdateEnvelope{
+			ToolCallID: "o", Status: "completed"})},
+	}
+	for _, n := range notSpawns {
+		if assert.NotNil(t, n.obs, "%s still produces an observation", n.what) {
+			assert.False(t, n.obs.Spawns, "%s is not a spawn", n.what)
+			assert.False(t, acpObservationIsSpawn(n.obs), "%s must not take a span", n.what)
+		}
+	}
+}
+
+// Goose's subagent_tool_request rides an in-progress update and reports on a
+// subagent that ALREADY runs. The old inference read "upserts a running row" as
+// "spawns a subagent", so it took the span off the tool call the update rode on.
+func TestACP_GooseToolRequestDoesNotDiscardTheToolsSpan(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	b := &acpBase{sink: sink, subagentFromToolCallUpdate: gooseSubagentFromToolCallUpdate}
+
+	b.handleToolCall(json.RawMessage(`{"toolCallId":"call-x","kind":"read","title":"Read"}`))
+	require.Len(t, sink.OpenSpans(), 1, "an ordinary tool call opens a span")
+
+	b.handleToolCallUpdate(json.RawMessage(
+		`{"toolCallId":"call-x","status":"in_progress","_meta":{"toolNotification":{"type":"message","params":{"data":{"type":"subagent_tool_request","subagent_id":"s1","tool_call":{"name":"grep"}}}}}}`))
+
+	assert.Empty(t, sink.ClosedSpans(),
+		"a tool-request observation reports progress on a running subagent, not a spawn")
+
+	// The tool keeps its rail: a row persisted now still draws its column.
+	b.handleToolCall(json.RawMessage(`{"toolCallId":"call-y","kind":"read","title":"Read again"}`))
+	msgs := sink.Messages()
+	require.Len(t, msgs, 2)
+	require.Len(t, msgs[1].SpansOpenAtPersist, 1, "the first tool's rail survived the update")
+	assert.Equal(t, "call-x", msgs[1].SpansOpenAtPersist[0].SpanID)
 }
 
 // Every ACP provider whose detector fires at the tool_call opens no span for a
@@ -914,9 +1020,9 @@ func TestACP_SpawnToolCallOpensNoSpan(t *testing.T) {
 
 // Kilo opens its spawn with `rawInput: {}` and reveals the spawn shape only on
 // the first in-progress update, so the span is already open by then. The update
-// takes it back with DiscardSpan -- which, unlike CloseSpan, keeps the recorded
+// gives it back with CloseSpan, which frees the column but keeps the recorded
 // span type that the closing update reads back.
-func TestACP_KiloLateSpawnDiscardsTheSpan(t *testing.T) {
+func TestACP_KiloLateSpawnGivesItsSpanBack(t *testing.T) {
 	t.Parallel()
 
 	sink := &testSink{}
@@ -932,10 +1038,17 @@ func TestACP_KiloLateSpawnDiscardsTheSpan(t *testing.T) {
 	b.handleToolCallUpdate(json.RawMessage(
 		`{"toolCallId":"call-spawn","status":"in_progress","rawInput":{"description":"explore","prompt":"go","subagent_type":"general"}}`))
 
-	assert.Equal(t, []string{"call-spawn"}, sink.DiscardedSpans())
-	assert.Empty(t, sink.ClosedSpans(), "discarded, not closed -- the subagent is still running")
+	assert.Equal(t, []string{"call-spawn"}, sink.ClosedSpans(),
+		"the span is given back although the subagent keeps running")
 	assert.Equal(t, "other", sink.GetSpanType("call-spawn"),
-		"a discard keeps the type the closing update reads back")
+		"and the recorded type survives, so the closing update reads it back")
+
+	// The detector re-runs on every update, and Kilo keeps echoing its rawInput,
+	// so it re-reports the spawn. The release must not repeat: each repeat would
+	// take the tracker mutex and re-scan the active set for a span already gone.
+	b.handleToolCallUpdate(json.RawMessage(
+		`{"toolCallId":"call-spawn","status":"in_progress","rawInput":{"description":"explore","prompt":"go","subagent_type":"general"}}`))
+	assert.Equal(t, []string{"call-spawn"}, sink.ClosedSpans(), "released once, not once per update")
 
 	// A tool call that starts after the discard sits at column 0, not column 1.
 	b.handleToolCall(json.RawMessage(`{"toolCallId":"call-plain","kind":"read","title":"Read"}`))
@@ -944,7 +1057,7 @@ func TestACP_KiloLateSpawnDiscardsTheSpan(t *testing.T) {
 	assert.Empty(t, msgs[1].SpansOpenAtPersist, "the spawn rail is gone")
 
 	// The closing update persists the recorded kind, not the "tool_call"
-	// fallback -- this is what DiscardSpan buys over CloseSpan.
+	// fallback -- the span type outlives the close that freed the column.
 	b.handleToolCallUpdate(json.RawMessage(`{"toolCallId":"call-spawn","status":"completed","rawOutput":{"metadata":{"sessionId":"ses-child"}}}`))
 	msgs = sink.Messages()
 	require.Len(t, msgs, 3)
@@ -952,9 +1065,15 @@ func TestACP_KiloLateSpawnDiscardsTheSpan(t *testing.T) {
 	assert.True(t, msgs[2].Closing)
 }
 
-// A backgrounded shell is an ordinary tool span. Even when a provider's spawn
-// detector fires on it, an `execute` tool call KEEPS its rail.
-func TestACP_ExecuteKindKeepsItsSpanEvenWhenDetectedAsASpawn(t *testing.T) {
+// A backgrounded shell keeps its rail because no detector claims it as a spawn
+// -- not because the shared layer exempts its tool kind. The `execute` carve-out
+// that used to spare it is gone: it second-guessed a provider that had already
+// stated the answer, and it half-obeyed, suppressing the span while still
+// upserting a subagent row.
+//
+// Driven through the real OpenCode hooks on an `execute` call, which is the kind
+// a shell arrives under.
+func TestACP_ABackgroundShellKeepsItsSpanWithNoKindExemption(t *testing.T) {
 	t.Parallel()
 
 	sink := &testSink{}
@@ -964,18 +1083,20 @@ func TestACP_ExecuteKindKeepsItsSpanEvenWhenDetectedAsASpawn(t *testing.T) {
 		subagentFromToolCallUpdate: openCodeSubagentFromToolCallUpdate,
 	}
 
-	// Spawn-shaped rawInput on an execute call: the detector fires, the span stays.
-	spawnShaped := `"rawInput":{"description":"run it","prompt":"go","subagent_type":"general"}`
-	b.handleToolCall(json.RawMessage(`{"toolCallId":"call-sh","kind":"execute","title":"bash",` + spawnShaped + `}`))
+	// A real shell payload: a command, and none of the spawn discriminators.
+	shell := `"rawInput":{"command":"npm run dev"}`
+	b.handleToolCall(json.RawMessage(`{"toolCallId":"call-sh","kind":"execute","title":"bash",` + shell + `}`))
 
 	open := sink.OpenSpans()
-	require.Len(t, open, 1, "an execute call keeps its span")
+	require.Len(t, open, 1, "the detector does not fire, so the shell keeps its span")
 	assert.Equal(t, "call-sh", open[0].SpanID)
 	assert.Equal(t, []string{"call-sh"}, sink.ReservedColorSpans())
 
-	// And the late path does not take it away either.
-	b.handleToolCallUpdate(json.RawMessage(`{"toolCallId":"call-sh","status":"in_progress",` + spawnShaped + `}`))
-	assert.Empty(t, sink.DiscardedSpans())
+	b.handleToolCallUpdate(json.RawMessage(`{"toolCallId":"call-sh","status":"in_progress",` + shell + `}`))
+	require.Len(t, sink.OpenSpans(), 1, "and the update leaves it alone")
+
+	b.handleToolCallUpdate(json.RawMessage(`{"toolCallId":"call-sh","status":"completed",` + shell + `}`))
+	assert.Equal(t, []string{"call-sh"}, sink.ClosedSpans(), "it closes normally")
 }
 
 // A tool_call that arrives already final never opened a span, so the spawn
@@ -990,7 +1111,7 @@ func TestACP_FinalToolCallSpawnStillFeedsTheRegistry(t *testing.T) {
 		`{"toolCallId":"call-spawn","kind":"other","status":"completed","title":"explore","rawInput":{"description":"explore","prompt":"go","subagent_type":"general"}}`))
 
 	assert.Empty(t, sink.OpenSpans())
-	assert.Empty(t, sink.DiscardedSpans())
+	assert.Empty(t, sink.ClosedSpans())
 	tasks := sink.BackgroundTasks()
 	require.Len(t, tasks, 1, "the registry row is still upserted")
 	assert.Equal(t, "call-spawn", tasks[0].RowKey)
@@ -1000,6 +1121,19 @@ func TestACP_FinalToolCallSpawnStillFeedsTheRegistry(t *testing.T) {
 	assert.True(t, msgs[0].Closing)
 }
 
+// newCursorTestAgent wires a CursorCLIAgent exactly as StartCursorCLI does, so
+// the two hooks share the per-agent note about which tool calls are the `task`
+// tool. Building a bare acpBase from the package-level functions instead would
+// drop that note and test a wiring production never uses.
+func newCursorTestAgent(sink OutputSink) *CursorCLIAgent {
+	a := &CursorCLIAgent{}
+	a.sink = sink
+	a.subagentFromToolCall = a.spawnObservation
+	a.subagentFromToolCallUpdate = a.finishedObservation
+	a.clearProviderState = a.clearTaskToolCalls
+	return a
+}
+
 // Cursor's closing hook fires for EVERY finished tool call. Its close-only
 // observation must not be read as a spawn, or an ordinary tool would lose the
 // span it is about to close.
@@ -1007,19 +1141,21 @@ func TestACP_CursorClosingUpdateDoesNotDiscardAPlainToolSpan(t *testing.T) {
 	t.Parallel()
 
 	sink := &testSink{}
-	b := &acpBase{
-		sink:                       sink,
-		subagentFromToolCall:       cursorSubagentFromToolCall,
-		subagentFromToolCallUpdate: cursorSubagentFromToolCallUpdate,
-	}
+	b := &newCursorTestAgent(sink).acpBase
 
 	b.handleToolCall(json.RawMessage(`{"toolCallId":"call-read","kind":"read","title":"Read","rawInput":{"_toolName":"read"}}`))
 	require.Len(t, sink.OpenSpans(), 1)
 
 	b.handleToolCallUpdate(json.RawMessage(`{"toolCallId":"call-read","status":"completed"}`))
 
-	assert.Empty(t, sink.DiscardedSpans(), "a close-only observation discards nothing")
-	assert.Equal(t, []string{"call-read"}, sink.ClosedSpans(), "the span closes normally")
+	// Closed exactly ONCE, by the closing arm. A close-only observation read as
+	// a spawn would take the span EARLY, before that arm persists the row, and
+	// the result row would lose its connector_end.
+	assert.Equal(t, []string{"call-read"}, sink.ClosedSpans(), "the span closes once, normally")
+	require.Len(t, sink.Messages(), 2)
+	assert.True(t, sink.Messages()[1].Closing)
+	require.Len(t, sink.Messages()[1].SpansOpenAtPersist, 1,
+		"the closing row persists while its own span is still open, so it can draw connector_end")
 }
 
 // End to end through the neutral layer: a Cursor background shell lands in the
@@ -1028,11 +1164,7 @@ func TestACP_CursorBackgroundShellLandsAsAShellRow(t *testing.T) {
 	t.Parallel()
 
 	sink := &testSink{}
-	b := &acpBase{
-		sink:                       sink,
-		subagentFromToolCall:       cursorSubagentFromToolCall,
-		subagentFromToolCallUpdate: cursorSubagentFromToolCallUpdate,
-	}
+	b := &newCursorTestAgent(sink).acpBase
 
 	b.handleToolCall(json.RawMessage(`{"toolCallId":"call-sh","kind":"execute","title":"npm run dev","rawInput":{"_toolName":"shell","command":"npm run dev"}}`))
 	b.handleToolCallUpdate(json.RawMessage(`{"toolCallId":"call-sh","status":"completed","title":"npm run dev","rawInput":{"_toolName":"shell"},"rawOutput":{"isBackground":true}}`))
@@ -1049,11 +1181,123 @@ func TestACP_CursorBackgroundShellLandsAsAShellRow(t *testing.T) {
 	assert.Empty(t, tasks[0].ChildAgentID, "a shell has no transcript to open")
 
 	// A shell is an ordinary tool span: it opens one and closes it normally.
-	// Two guards keep it that way here -- the kind is not a spawn, and an
-	// `execute` tool call is exempt anyway. TestACP_ObservationIsSpawnExcludesAShell
-	// isolates the first one.
-	assert.Empty(t, sink.DiscardedSpans(), "a shell row is not a spawn")
-	assert.Equal(t, []string{"call-sh"}, sink.ClosedSpans())
+	// One rule keeps it that way -- neither Cursor hook ever claims a spawn for
+	// a backgrounded shell. TestACP_OnlyTheSpawnDetectorsClaimASpawn isolates it.
+	assert.Equal(t, []string{"call-sh"}, sink.ClosedSpans(),
+		"a shell is not a spawn, so it closes once on its own closing update")
+}
+
+// The same row, when the closing update omits rawInput. Cursor does not always
+// echo the input on an update, and a backgrounded task then looks exactly like
+// a backgrounded shell on the wire. The spawn's note is what tells them apart.
+//
+// Reading the identity off the update alone took the shell arm here, and a
+// non-blank Kind and Title win in Item.PreservingBlanksFrom -- so the live
+// subagent row turned into a shell row under the Bot icon's replacement, and
+// its trimmed title was overwritten with the raw envelope title.
+func TestACP_CursorBackgroundTaskWithoutInputStaysASubagent(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	b := &newCursorTestAgent(sink).acpBase
+
+	b.handleToolCall(json.RawMessage(`{"toolCallId":"call-task","kind":"other","title":"Task: build the feature","rawInput":{"_toolName":"task","prompt":"do it"}}`))
+	// No rawInput on the close, and isBackground true.
+	b.handleToolCallUpdate(json.RawMessage(`{"toolCallId":"call-task","status":"completed","title":"Task: build the feature","rawOutput":{"isBackground":true}}`))
+
+	tasks := sink.BackgroundTasks()
+	require.Len(t, tasks, 1)
+	assert.Equal(t, bgtask.KindSubagent, tasks[0].Kind,
+		"the spawn's note outranks an absent rawInput")
+	assert.Equal(t, "build the feature", tasks[0].Title,
+		"the closing update must not overwrite the spawn's trimmed title")
+	assert.Equal(t, bgtask.StatusCompleted, tasks[0].Status)
+}
+
+// A backgrounded SHELL with no rawInput is still a shell: the spawn hook left
+// no note for it, which is the reported bug's case.
+func TestACP_CursorBackgroundShellWithoutInputIsStillAShell(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	b := &newCursorTestAgent(sink).acpBase
+
+	b.handleToolCall(json.RawMessage(`{"toolCallId":"call-sh","kind":"execute","title":"npm run dev","rawInput":{"_toolName":"shell","command":"npm run dev"}}`))
+	b.handleToolCallUpdate(json.RawMessage(`{"toolCallId":"call-sh","status":"completed","title":"npm run dev","rawOutput":{"isBackground":true}}`))
+
+	tasks := sink.BackgroundTasks()
+	require.Len(t, tasks, 1)
+	assert.Equal(t, bgtask.KindShell, tasks[0].Kind)
+	assert.Equal(t, "npm run dev", tasks[0].Title)
+}
+
+// The note is per tool call and is dropped when the call ends, so a later tool
+// call that reuses nothing of it is classified on its own evidence.
+func TestACP_CursorTaskNoteDoesNotOutliveItsToolCall(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newCursorTestAgent(sink)
+	b := &a.acpBase
+
+	b.handleToolCall(json.RawMessage(`{"toolCallId":"call-1","kind":"other","title":"Task: go","rawInput":{"_toolName":"task"}}`))
+	b.handleToolCallUpdate(json.RawMessage(`{"toolCallId":"call-1","status":"completed","rawOutput":{"isBackground":true}}`))
+
+	a.mu.Lock()
+	remaining := len(a.taskToolCalls)
+	a.mu.Unlock()
+	assert.Zero(t, remaining, "the note is dropped when the call ends")
+}
+
+// A tool_call that arrives ALREADY final is applied and returns, so no closing
+// update ever follows to drop a note. Writing one there left it for the life of
+// the agent -- a session/load replay of a finished task is exactly that shape --
+// and a later call that reused the id would read it and file a backgrounded
+// shell as a subagent.
+func TestACP_CursorAlreadyFinalTaskCallLeavesNoNote(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newCursorTestAgent(sink)
+	b := &a.acpBase
+
+	b.handleToolCall(json.RawMessage(`{"toolCallId":"call-task","kind":"other","status":"completed","title":"Task: go","rawInput":{"_toolName":"task"}}`))
+
+	require.Len(t, sink.BackgroundTasks(), 1, "the registry row is still upserted")
+	a.mu.Lock()
+	remaining := len(a.taskToolCalls)
+	a.mu.Unlock()
+	assert.Zero(t, remaining, "an already-final call has no later update to read a note")
+
+	// A later backgrounded SHELL that reuses the id is still a shell.
+	b.handleToolCallUpdate(json.RawMessage(`{"toolCallId":"call-task","status":"completed","title":"npm run dev","rawOutput":{"isBackground":true}}`))
+	tasks := sink.BackgroundTasks()
+	require.Len(t, tasks, 1)
+	assert.Equal(t, bgtask.KindShell, tasks[0].Kind, "no stale note reclassified it")
+}
+
+// ClearContext replaces the session, so every note is keyed by a tool call that
+// will never report again. acpBase clears its own subagentPrompts there for the
+// same reason.
+func TestACP_CursorClearProviderStateDropsTheNotes(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newCursorTestAgent(sink)
+
+	a.handleToolCall(json.RawMessage(`{"toolCallId":"call-task","kind":"other","title":"Task: go","rawInput":{"_toolName":"task"}}`))
+	a.mu.Lock()
+	before := len(a.taskToolCalls)
+	a.mu.Unlock()
+	require.Equal(t, 1, before, "the in-flight task left a note")
+
+	require.NotNil(t, a.clearProviderState, "Cursor registers the ClearContext hook")
+	a.clearProviderState()
+
+	a.mu.Lock()
+	after := len(a.taskToolCalls)
+	a.mu.Unlock()
+	assert.Zero(t, after, "the outgoing session's notes are gone")
 }
 
 // The task tool's row survives its own closing update: still a subagent, still
@@ -1062,11 +1306,7 @@ func TestACP_CursorTaskRowStaysASubagentThroughItsClose(t *testing.T) {
 	t.Parallel()
 
 	sink := &testSink{}
-	b := &acpBase{
-		sink:                       sink,
-		subagentFromToolCall:       cursorSubagentFromToolCall,
-		subagentFromToolCallUpdate: cursorSubagentFromToolCallUpdate,
-	}
+	b := &newCursorTestAgent(sink).acpBase
 
 	b.handleToolCall(json.RawMessage(`{"toolCallId":"call-task","kind":"other","title":"Task: build the feature","rawInput":{"_toolName":"task","prompt":"do it"}}`))
 	b.handleToolCallUpdate(json.RawMessage(`{"toolCallId":"call-task","status":"completed","title":"Task: build the feature","rawInput":{"_toolName":"task"},"rawOutput":{"isBackground":true}}`))
@@ -1079,17 +1319,7 @@ func TestACP_CursorTaskRowStaysASubagentThroughItsClose(t *testing.T) {
 	assert.Equal(t, bgtask.StatusCompleted, tasks[0].Status)
 }
 
-// A shell observation is not a spawn, so it never reaches DiscardSpan.
-func TestACP_ObservationIsSpawnExcludesAShell(t *testing.T) {
-	t.Parallel()
-
-	assert.False(t, acpObservationIsSpawn(&acpSubagentObservation{
-		RowKey: "call-sh", Kind: bgtask.KindShell, Status: bgtask.StatusCompleted,
-	}), "a shell is a background process with no transcript, so it keeps its span")
-	assert.True(t, acpObservationIsSpawn(&acpSubagentObservation{
-		RowKey: "call-task", Kind: bgtask.KindSubagent,
-	}))
-	assert.True(t, acpObservationIsSpawn(&acpSubagentObservation{
-		RowKey: "call-task",
-	}), "a blank kind means subagent, matching applySubagentObservation's default")
-}
+// The shell case now lives in TestACP_OnlyTheSpawnDetectorsClaimASpawn, which
+// asserts it over the REAL Cursor hook: the backgrounded-shell arm never claims
+// a spawn. The kind of a row no longer decides, so a struct built by hand can no
+// longer state the case.

--- a/backend/internal/worker/agent/agent.go
+++ b/backend/internal/worker/agent/agent.go
@@ -223,6 +223,14 @@ type OutputSink interface {
 	PersistTurnEnd(content []byte, span SpanInfo) error
 	OpenSpan(spanID string, parentSpanID string)
 	CloseSpan(spanID string)
+	// DiscardSpan removes an open span WITHOUT ending it: the tool call keeps
+	// running, but no later message connects to its column and no message draws
+	// its rail. A subagent spawn owns no span, and a provider that states the
+	// spawn only AFTER the tool call started (Kilo's first in-progress
+	// tool_call_update, Claude's task_started for a Workflow run) calls this to
+	// take back the span it already opened. Unlike CloseSpan it keeps the
+	// recorded span type, which the closing message still reads back.
+	DiscardSpan(spanID string)
 	ResetSpans()
 	SetSpanType(spanID, spanType string)
 	GetSpanType(spanID string) string

--- a/backend/internal/worker/agent/agent.go
+++ b/backend/internal/worker/agent/agent.go
@@ -172,6 +172,44 @@ type SpanInfo struct {
 	// as a scroll-rail jump target. Zero value (MARK_TYPE_UNSPECIFIED) leaves the
 	// row unmarked, so existing SpanInfo{...} literals need no change.
 	MarkType leapmuxv1.MarkType
+	// NoSpan marks a row that carries a SpanID but deliberately owns no span --
+	// a subagent spawn. Its SpanColor of 0 is the ANSWER, not a gap to fill, so
+	// the persist path must not substitute the connector's color for it. Without
+	// this the spawn card takes a rail color that matches no rail anywhere,
+	// whenever its ParentSpanID happens to name a span that is still open.
+	NoSpan bool
+}
+
+// openToolSpan persists a tool call's opening row and opens its span.
+//
+// A call that spawns a subagent owns no span: it reserves no color and opens
+// nothing, so it draws no rail and its card takes the neutral border. It still
+// records its span type, which a provider's closing message reads back.
+//
+// Each provider decides `spawns` itself, from its own wire shape -- that
+// decision must not move into shared code. What lives here is the ORDER the
+// decision drives, which every provider needs identically: reserve before the
+// persist so the row carries the color its rail will use, persist before the
+// open so the row sits at the parent's depth, record the type either way.
+//
+// The parent span id is empty at every call site: a provider's tool calls are
+// flat in the transcript that holds them.
+//
+// A failed persist is logged by the caller and does NOT stop the span from
+// opening, which is what each of these call sites did before.
+func openToolSpan(sink OutputSink, content []byte, spanID, spanType string, spawns bool) error {
+	var spanColor int32
+	if !spawns {
+		spanColor = sink.ReserveSpanColor(spanID, "")
+	}
+	err := sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, content, SpanInfo{
+		SpanID: spanID, SpanType: spanType, SpanColor: spanColor, NoSpan: spawns,
+	})
+	sink.SetSpanType(spanID, spanType)
+	if !spawns {
+		sink.OpenSpan(spanID, "")
+	}
+	return err
 }
 
 type AutoContinueReason string
@@ -222,15 +260,13 @@ type OutputSink interface {
 	// specific side effects are explicit at the call site.
 	PersistTurnEnd(content []byte, span SpanInfo) error
 	OpenSpan(spanID string, parentSpanID string)
+	// CloseSpan frees a span's column. The recorded span type SURVIVES it (only
+	// ResetSpans clears types), because a provider's closing message reads that
+	// type back through GetSpanType. A provider that states a spawn only AFTER
+	// its tool call started (Kilo's first in-progress tool_call_update, Claude's
+	// task_started for a Workflow run) calls this to give back the span it
+	// already opened, while the call itself keeps running.
 	CloseSpan(spanID string)
-	// DiscardSpan removes an open span WITHOUT ending it: the tool call keeps
-	// running, but no later message connects to its column and no message draws
-	// its rail. A subagent spawn owns no span, and a provider that states the
-	// spawn only AFTER the tool call started (Kilo's first in-progress
-	// tool_call_update, Claude's task_started for a Workflow run) calls this to
-	// take back the span it already opened. Unlike CloseSpan it keeps the
-	// recorded span type, which the closing message still reads back.
-	DiscardSpan(spanID string)
 	ResetSpans()
 	SetSpanType(spanID, spanType string)
 	GetSpanType(spanID string) string

--- a/backend/internal/worker/agent/agent_test.go
+++ b/backend/internal/worker/agent/agent_test.go
@@ -1,0 +1,129 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+)
+
+// openToolSpan holds the order every provider's tool call needs: reserve before
+// the persist, persist before the open, record the type either way. Each
+// provider still decides `spawns` from its own wire shape.
+func TestOpenToolSpan_OrdinaryToolReservesPersistsAndOpens(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	require.NoError(t, openToolSpan(sink, []byte(`{"type":"tool_call"}`), "tc-read", "read", false))
+
+	assert.Equal(t, []string{"tc-read"}, sink.ReservedColorSpans())
+	open := sink.OpenSpans()
+	require.Len(t, open, 1)
+	assert.Equal(t, "tc-read", open[0].SpanID)
+	assert.Empty(t, open[0].ParentSpanID, "a provider's tool calls are flat")
+	assert.Equal(t, "read", sink.GetSpanType("tc-read"))
+
+	// The row persisted BEFORE its own span opened, so it draws no rail of its
+	// own. Reversing the two would give every tool call a self-connector.
+	msgs := sink.Messages()
+	require.Len(t, msgs, 1)
+	assert.Empty(t, msgs[0].SpansOpenAtPersist)
+	assert.Equal(t, "tc-read", msgs[0].SpanID)
+}
+
+// A spawn reserves nothing and opens nothing, and still records its type.
+func TestOpenToolSpan_SpawnOpensNothingButRecordsItsType(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	require.NoError(t, openToolSpan(sink, []byte(`{"type":"tool_call"}`), "tc-spawn", "Agent", true))
+
+	assert.Empty(t, sink.ReservedColorSpans(), "a spawn blocks no color")
+	assert.Empty(t, sink.OpenSpans(), "and draws no rail")
+	assert.Equal(t, "Agent", sink.GetSpanType("tc-spawn"),
+		"the closing message still reads the type back")
+
+	msgs := sink.Messages()
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "tc-spawn", msgs[0].SpanID, "the row still carries the span id")
+}
+
+// A spawn takes no column, so a tool that starts next sits where the spawn
+// would have been rather than one column right of it.
+func TestOpenToolSpan_ASpawnLeavesTheNextToolAtTheSameDepth(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	require.NoError(t, openToolSpan(sink, []byte(`{}`), "tc-spawn", "Agent", true))
+	require.NoError(t, openToolSpan(sink, []byte(`{}`), "tc-read", "read", false))
+
+	msgs := sink.Messages()
+	require.Len(t, msgs, 2)
+	assert.Empty(t, msgs[1].SpansOpenAtPersist, "the spawn contributes no rail to draw")
+}
+
+// testSink delegates its span bookkeeping to the REAL engine, so the geometry a
+// provider test asserts is the geometry production computes. It kept its own
+// copy before, and drifted from the engine twice.
+func TestTestSink_SpanStateComesFromTheRealEngine(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	// A reservation the tracker really parks: the color is a palette entry, not
+	// a constant, and it is the one the matching open consumes.
+	reserved := sink.ReserveSpanColor("tu-a", "")
+	require.NotZero(t, reserved, "the real tracker never reserves color 0")
+	sink.OpenSpan("tu-a", "")
+	sink.OpenSpan("tu-b", "tu-a")
+
+	require.NoError(t, sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT,
+		[]byte(`{}`), SpanInfo{SpanID: "tu-c"}))
+	msgs := sink.Messages()
+	require.Len(t, msgs, 1)
+	// Column order, and the parentage the engine recorded -- neither of which a
+	// hand-kept slice reproduced.
+	assert.Equal(t, []testSinkSpanOpen{
+		{SpanID: "tu-a", ParentSpanID: ""},
+		{SpanID: "tu-b", ParentSpanID: "tu-a"},
+	}, msgs[0].SpansOpenAtPersist)
+
+	// The engine's type lifetime, not the double's: a close keeps the type and
+	// only a reset clears it.
+	sink.SetSpanType("tu-a", "Read")
+	sink.CloseSpan("tu-a")
+	assert.Equal(t, "Read", sink.GetSpanType("tu-a"))
+	sink.ResetSpans()
+	assert.Empty(t, sink.GetSpanType("tu-a"))
+	assert.Empty(t, sink.liveSpansLocked(), "a reset empties the active set")
+}
+
+// A failed persist is reported to the caller, which logs it -- but the span
+// still opens, so a later closing message finds a column to end.
+func TestOpenToolSpan_ReturnsThePersistErrorAndStillOpensTheSpan(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{persistErr: assert.AnError}
+	err := openToolSpan(sink, []byte(`{}`), "tc-read", "read", false)
+
+	require.ErrorIs(t, err, assert.AnError, "the caller logs this")
+	open := sink.OpenSpans()
+	require.Len(t, open, 1, "the span opens anyway, as every call site did before")
+	assert.Equal(t, "tc-read", open[0].SpanID)
+}
+
+// acpStatusIsFinal decides three things: whether a tool_call is persisted as an
+// immediate closer, whether a late spawn may give its span back, and whether a
+// provider hook produces a closing observation. An unknown status is NOT final,
+// so an unrecognized state leaves the call open rather than closing it early.
+func TestACPStatusIsFinal(t *testing.T) {
+	t.Parallel()
+
+	for _, s := range []string{"completed", "failed", "cancelled"} {
+		assert.True(t, acpStatusIsFinal(s), "%q ends the call", s)
+	}
+	for _, s := range []string{"", "pending", "in_progress", "Completed", "completed "} {
+		assert.False(t, acpStatusIsFinal(s), "%q does not end the call", s)
+	}
+}

--- a/backend/internal/worker/agent/claude_output.go
+++ b/backend/internal/worker/agent/claude_output.go
@@ -370,6 +370,81 @@ func (a *ClaudeCodeAgent) processAssistantBlocks(env *messageEnvelope) {
 	}
 }
 
+// claudeSpanForEnvelope resolves which span a Claude envelope belongs to.
+//
+// An assistant envelope takes the FIRST tool_use block's id and tool name; a
+// user envelope takes the first tool_result's tool_use_id and looks its type up
+// through spanTypeFor, which is the tracker of whichever transcript the row
+// lands in. Every other envelope belongs to no span.
+func claudeSpanForEnvelope(msgType string, env *messageEnvelope, spanTypeFor func(string) string) (spanID, spanType string, closing bool) {
+	switch msgType {
+	case claudeMsgTypeAssistant:
+		for _, block := range env.ContentBlocks() {
+			if block.Type == "tool_use" && block.ID != "" {
+				return block.ID, block.Name, false
+			}
+		}
+	case claudeMsgTypeUser:
+		for _, block := range env.ContentBlocks() {
+			if block.Type == "tool_result" && block.ToolUseID != "" {
+				return block.ToolUseID, spanTypeFor(block.ToolUseID), true
+			}
+		}
+	}
+	return "", "", false
+}
+
+// claudeSpanInfoFor builds the SpanInfo a Claude envelope persists with, and
+// reserves the tool_use row's color against sink.
+//
+// Reserving (not opening) is what makes the color available at persist time
+// while the span is still closed, so the tool_use row can carry the color its
+// rail will use without yet drawing that rail.
+//
+// A subagent spawn reserves nothing: it opens no span, so it draws no rail and
+// its card takes the neutral border. Reserving anyway would also block that
+// color from the next real span until the spawn's tool_result landed. NoSpan
+// then tells the persist path that the resulting color 0 is the answer.
+//
+// Shared by the parent transcript (handlePersistableMessage) and the child one
+// (routeSubagentMessage), which differ only in the sink and the parent span id.
+// They held two copies of this rule, so the spawn guard had to be written twice.
+func claudeSpanInfoFor(sink OutputSink, msgType string, env *messageEnvelope, parentSpanID string) SpanInfo {
+	spanID, spanType, closing := claudeSpanForEnvelope(msgType, env, sink.GetSpanType)
+	spawns := spanID != "" && claudeToolSpawnsSubagent(spanType)
+
+	var spanColor int32
+	if msgType == claudeMsgTypeAssistant && spanID != "" && !spawns {
+		spanColor = sink.ReserveSpanColor(spanID, parentSpanID)
+	}
+	// A self-displaying control tool (AskUserQuestion/ExitPlanMode) forwarded as
+	// a tool_result gets its CONTROL_RESPONSE scroll-rail mark.
+	var markType leapmuxv1.MarkType
+	if msgType == claudeMsgTypeUser {
+		markType = claudeUserEnvelopeBlocksMarkType(env.ContentBlocks(), sink.GetSpanType)
+	}
+	return SpanInfo{
+		ParentSpanID: parentSpanID,
+		SpanID:       spanID,
+		SpanType:     spanType,
+		SpanColor:    spanColor,
+		Closing:      closing,
+		MarkType:     markType,
+		NoSpan:       spawns,
+	}
+}
+
+// claudeCloseToolResultSpans closes the span of EVERY tool_result in a user
+// envelope. One user message can carry parallel tool calls, so closing only the
+// first would leak the rest until the turn's bulk ResetSpans.
+func claudeCloseToolResultSpans(sink OutputSink, env *messageEnvelope) {
+	for _, block := range env.ContentBlocks() {
+		if block.Type == "tool_result" && block.ToolUseID != "" {
+			sink.CloseSpan(block.ToolUseID)
+		}
+	}
+}
+
 // handlePersistableMessage handles assistant, system, user, and result messages.
 //
 // Source for persistence is derived from msgType: USER for the `user`
@@ -453,29 +528,6 @@ func (a *ClaudeCodeAgent) handlePersistableMessage(content []byte, msgType strin
 		parentSpanID = env.ToolUseID
 	}
 
-	// Determine span ID and span type: for tool_use messages use the block ID
-	// and tool name, for tool_result messages use the tool_use_id reference
-	// and look up the tool name from the span tracker.
-	var spanID, spanType string
-	if msgType == claudeMsgTypeAssistant {
-		for _, block := range env.ContentBlocks() {
-			if block.Type == "tool_use" && block.ID != "" {
-				spanID, spanType = block.ID, block.Name
-				break
-			}
-		}
-	} else if msgType == claudeMsgTypeUser {
-		for _, block := range env.ContentBlocks() {
-			if block.Type == "tool_result" && block.ToolUseID != "" {
-				spanID = block.ToolUseID
-				break
-			}
-		}
-		if spanID != "" {
-			spanType = a.sink.GetSpanType(spanID)
-		}
-	}
-
 	// Detect plan mode from tool_result messages.
 	if msgType == claudeMsgTypeUser {
 		a.detectPlanModeFromToolResult(&env)
@@ -486,33 +538,14 @@ func (a *ClaudeCodeAgent) handlePersistableMessage(content []byte, msgType strin
 		content = a.enrichResultWithToolUses(content)
 	}
 
-	// Reserve the span color for tool_use messages (assistant with a spanID)
-	// so it is available at persist time, before the span is actually opened.
-	// A subagent spawn reserves nothing: it opens no span, so it draws no rail
-	// and its card takes the neutral border. Reserving anyway would also block
-	// that color from the next real span until the spawn's tool_result landed.
-	var spanColor int32
-	if msgType == claudeMsgTypeAssistant && spanID != "" && !claudeToolSpawnsSubagent(spanType) {
-		spanColor = a.sink.ReserveSpanColor(spanID, parentSpanID)
-	}
+	// Resolve the span metadata and reserve the tool_use row's color. Shared
+	// with the child-transcript path in routeSubagentMessage.
+	spanInfo := claudeSpanInfoFor(a.sink, msgType, &env, parentSpanID)
+	spanID, spanType := spanInfo.SpanID, spanInfo.SpanType
 
 	// Persist as a standalone message with hierarchy metadata.
 	// This MUST happen before processAssistantBlocks (which opens spans)
 	// so the assistant message stays at the parent depth.
-	// closing is true when this is a tool_result that will close its span.
-	closing := msgType == claudeMsgTypeUser && spanID != ""
-	var markType leapmuxv1.MarkType
-	if msgType == claudeMsgTypeUser {
-		markType = claudeUserEnvelopeBlocksMarkType(env.ContentBlocks(), a.sink.GetSpanType)
-	}
-	spanInfo := SpanInfo{
-		ParentSpanID: parentSpanID,
-		SpanID:       spanID,
-		SpanType:     spanType,
-		SpanColor:    spanColor,
-		Closing:      closing,
-		MarkType:     markType,
-	}
 	var persistErr error
 	if msgType == claudeMsgTypeResult {
 		// Terminal turn-end envelope — routes through PersistTurnEnd so
@@ -537,14 +570,8 @@ func (a *ClaudeCodeAgent) handlePersistableMessage(content []byte, msgType strin
 		a.processAssistantBlocks(&env)
 	}
 
-	// A single user message may contain multiple tool_result blocks
-	// (parallel tool calls), so close all of them.
 	if msgType == claudeMsgTypeUser {
-		for _, block := range env.ContentBlocks() {
-			if block.Type == "tool_result" && block.ToolUseID != "" {
-				a.sink.CloseSpan(block.ToolUseID)
-			}
-		}
+		claudeCloseToolResultSpans(a.sink, &env)
 	}
 
 	if msgType == claudeMsgTypeResult {

--- a/backend/internal/worker/agent/claude_output.go
+++ b/backend/internal/worker/agent/claude_output.go
@@ -312,7 +312,12 @@ func (a *ClaudeCodeAgent) processAssistantBlocks(env *messageEnvelope) {
 				a.sink.StorePlanModeToolUse(block.ID, PermissionModeDefault)
 			}
 
-			a.sink.OpenSpan(block.ID, parentSpanID)
+			// A subagent spawn opens no span (claudeToolSpawnsSubagent). Its
+			// span type is still recorded above, because the tool_result path
+			// reads it back through GetSpanType to persist span_type.
+			if !claudeToolSpawnsSubagent(block.Name) {
+				a.sink.OpenSpan(block.ID, parentSpanID)
+			}
 		}
 
 		// Plan file path tracking (Write/Edit to ~/.claude/plans/).
@@ -483,8 +488,11 @@ func (a *ClaudeCodeAgent) handlePersistableMessage(content []byte, msgType strin
 
 	// Reserve the span color for tool_use messages (assistant with a spanID)
 	// so it is available at persist time, before the span is actually opened.
+	// A subagent spawn reserves nothing: it opens no span, so it draws no rail
+	// and its card takes the neutral border. Reserving anyway would also block
+	// that color from the next real span until the spawn's tool_result landed.
 	var spanColor int32
-	if msgType == claudeMsgTypeAssistant && spanID != "" {
+	if msgType == claudeMsgTypeAssistant && spanID != "" && !claudeToolSpawnsSubagent(spanType) {
 		spanColor = a.sink.ReserveSpanColor(spanID, parentSpanID)
 	}
 

--- a/backend/internal/worker/agent/claude_output_test.go
+++ b/backend/internal/worker/agent/claude_output_test.go
@@ -24,9 +24,10 @@ type spanRecord struct {
 type outputTestSink struct {
 	testSink
 
-	spanMu      sync.Mutex
-	openedSpans []spanRecord
-	closedSpans []string
+	spanMu         sync.Mutex
+	openedSpans    []spanRecord
+	closedSpans    []string
+	discardedSpans []string
 
 	modeMu          sync.Mutex
 	permissionModes []string
@@ -51,6 +52,12 @@ func (s *outputTestSink) CloseSpan(spanID string) {
 	s.closedSpans = append(s.closedSpans, spanID)
 }
 
+func (s *outputTestSink) DiscardSpan(spanID string) {
+	s.spanMu.Lock()
+	defer s.spanMu.Unlock()
+	s.discardedSpans = append(s.discardedSpans, spanID)
+}
+
 func (s *outputTestSink) UpdatePermissionMode(mode string) {
 	s.modeMu.Lock()
 	defer s.modeMu.Unlock()
@@ -67,6 +74,12 @@ func (s *outputTestSink) ClosedSpans() []string {
 	s.spanMu.Lock()
 	defer s.spanMu.Unlock()
 	return append([]string(nil), s.closedSpans...)
+}
+
+func (s *outputTestSink) DiscardedSpans() []string {
+	s.spanMu.Lock()
+	defer s.spanMu.Unlock()
+	return append([]string(nil), s.discardedSpans...)
 }
 
 func (s *outputTestSink) PermissionModes() []string {

--- a/backend/internal/worker/agent/claude_output_test.go
+++ b/backend/internal/worker/agent/claude_output_test.go
@@ -14,20 +14,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// spanRecord captures an OpenSpan call.
-type spanRecord struct {
-	SpanID       string
-	ParentSpanID string
-}
-
-// outputTestSink extends testSink to record spans and permission mode updates.
+// outputTestSink extends testSink with permission mode and plan updates. It
+// deliberately does NOT override OpenSpan or CloseSpan: testSink already records
+// both AND mirrors the real SpanTracker's active set and its span types, so an
+// override here would leave both stale -- which is what it did, until every
+// assertion that read them through this double had become vacuous.
 type outputTestSink struct {
 	testSink
-
-	spanMu         sync.Mutex
-	openedSpans    []spanRecord
-	closedSpans    []string
-	discardedSpans []string
 
 	modeMu          sync.Mutex
 	permissionModes []string
@@ -40,46 +33,10 @@ type planUpdateCall struct {
 	Title string
 }
 
-func (s *outputTestSink) OpenSpan(spanID, parentSpanID string) {
-	s.spanMu.Lock()
-	defer s.spanMu.Unlock()
-	s.openedSpans = append(s.openedSpans, spanRecord{SpanID: spanID, ParentSpanID: parentSpanID})
-}
-
-func (s *outputTestSink) CloseSpan(spanID string) {
-	s.spanMu.Lock()
-	defer s.spanMu.Unlock()
-	s.closedSpans = append(s.closedSpans, spanID)
-}
-
-func (s *outputTestSink) DiscardSpan(spanID string) {
-	s.spanMu.Lock()
-	defer s.spanMu.Unlock()
-	s.discardedSpans = append(s.discardedSpans, spanID)
-}
-
 func (s *outputTestSink) UpdatePermissionMode(mode string) {
 	s.modeMu.Lock()
 	defer s.modeMu.Unlock()
 	s.permissionModes = append(s.permissionModes, mode)
-}
-
-func (s *outputTestSink) OpenedSpans() []spanRecord {
-	s.spanMu.Lock()
-	defer s.spanMu.Unlock()
-	return append([]spanRecord(nil), s.openedSpans...)
-}
-
-func (s *outputTestSink) ClosedSpans() []string {
-	s.spanMu.Lock()
-	defer s.spanMu.Unlock()
-	return append([]string(nil), s.closedSpans...)
-}
-
-func (s *outputTestSink) DiscardedSpans() []string {
-	s.spanMu.Lock()
-	defer s.spanMu.Unlock()
-	return append([]string(nil), s.discardedSpans...)
 }
 
 func (s *outputTestSink) PermissionModes() []string {
@@ -98,6 +55,42 @@ func (s *outputTestSink) PlanCalls() []planUpdateCall {
 	s.planMu.Lock()
 	defer s.planMu.Unlock()
 	return append([]planUpdateCall(nil), s.planCalls...)
+}
+
+// outputTestSink must behave exactly like the double it extends. It shadowed the
+// span methods before, so its active set stayed empty and every assertion that
+// read one through this double held no matter what the code did.
+func TestOutputTestSink_MirrorsTheSpanBookkeepingItExtends(t *testing.T) {
+	t.Parallel()
+
+	sink := &outputTestSink{}
+	sink.SetSpanType("span-close", "Read")
+	sink.SetSpanType("span-kept", "Agent")
+	sink.OpenSpan("span-close", "parent-1")
+	sink.OpenSpan("span-kept", "")
+
+	assert.Equal(t, []testSinkSpanOpen{
+		{SpanID: "span-close", ParentSpanID: "parent-1"},
+		{SpanID: "span-kept", ParentSpanID: ""},
+	}, sink.OpenSpans(), "an open reaches the embedded double, parentage included")
+
+	sink.CloseSpan("span-close")
+	sink.CloseSpan("span-kept")
+
+	assert.Equal(t, []string{"span-close", "span-kept"}, sink.ClosedSpans())
+	assert.Equal(t, "Read", sink.GetSpanType("span-close"),
+		"a closed span KEEPS its type, exactly as the real tracker keeps it")
+	assert.Equal(t, "Agent", sink.GetSpanType("span-kept"))
+
+	sink.ResetSpans()
+	assert.Empty(t, sink.GetSpanType("span-close"), "only the turn boundary clears types")
+
+	// Both left the active set, so a row persisted now draws no rail.
+	require.NoError(t, sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT,
+		[]byte(`{"type":"assistant"}`), SpanInfo{SpanID: "span-next"}))
+	msgs := sink.Messages()
+	require.Len(t, msgs, 1)
+	assert.Empty(t, msgs[0].SpansOpenAtPersist)
 }
 
 // newTestAgent creates a minimal ClaudeCodeAgent for unit-testing HandleOutput.
@@ -454,7 +447,7 @@ func TestHandleOutput_AssistantNoToolUse(t *testing.T) {
 	assert.Equal(t, "", msgs[0].ParentSpanID)
 
 	// No spans opened.
-	assert.Empty(t, sink.OpenedSpans())
+	assert.Empty(t, sink.OpenSpans())
 	assert.Equal(t, 0, agent.turnToolUses)
 }
 
@@ -914,7 +907,7 @@ func TestHandleOutput_MultipleToolUses(t *testing.T) {
 	assert.Equal(t, "Read", msgs[0].SpanType)
 
 	// Both tool_use blocks should open spans.
-	spans := sink.OpenedSpans()
+	spans := sink.OpenSpans()
 	require.Len(t, spans, 2)
 	assert.Equal(t, "tu-a", spans[0].SpanID)
 	assert.Equal(t, "tu-b", spans[1].SpanID)
@@ -2250,4 +2243,79 @@ func TestHandleOutput_SubagentResultRoutesAsChildTurnEnd(t *testing.T) {
 	tasks := sink.BackgroundTasks()
 	require.Len(t, tasks, 1)
 	assert.Equal(t, bgtask.StatusCompleted, tasks[0].Status, "subagent result closes the registry row")
+}
+
+// claudeSpanForEnvelope is the one place both transcripts resolve which span a
+// Claude envelope belongs to. An envelope with no tool block belongs to none --
+// plain assistant text, a result, and an unknown type all persist unattached.
+func TestClaudeSpanForEnvelope(t *testing.T) {
+	t.Parallel()
+
+	spanTypeFor := func(id string) string {
+		if id == "tu-known" {
+			return "Read"
+		}
+		return ""
+	}
+	parse := func(t *testing.T, raw string) *messageEnvelope {
+		t.Helper()
+		var env messageEnvelope
+		require.NoError(t, json.Unmarshal([]byte(raw), &env))
+		return &env
+	}
+
+	t.Run("assistant takes the first tool_use", func(t *testing.T) {
+		env := parse(t, `{"message":{"content":[
+			{"type":"text","text":"hi"},
+			{"type":"tool_use","id":"tu-a","name":"Read"},
+			{"type":"tool_use","id":"tu-b","name":"Bash"}
+		]}}`)
+		id, typ, closing := claudeSpanForEnvelope(claudeMsgTypeAssistant, env, spanTypeFor)
+		assert.Equal(t, "tu-a", id, "the FIRST tool_use decides the row's span")
+		assert.Equal(t, "Read", typ)
+		assert.False(t, closing)
+	})
+
+	t.Run("user takes the first tool_result and looks its type up", func(t *testing.T) {
+		env := parse(t, `{"message":{"content":[{"type":"tool_result","tool_use_id":"tu-known"}]}}`)
+		id, typ, closing := claudeSpanForEnvelope(claudeMsgTypeUser, env, spanTypeFor)
+		assert.Equal(t, "tu-known", id)
+		assert.Equal(t, "Read", typ, "the type comes from the transcript's own tracker")
+		assert.True(t, closing, "a tool_result closes its span")
+	})
+
+	t.Run("an unknown tool_use_id yields a blank type, not a guess", func(t *testing.T) {
+		env := parse(t, `{"message":{"content":[{"type":"tool_result","tool_use_id":"tu-gone"}]}}`)
+		id, typ, closing := claudeSpanForEnvelope(claudeMsgTypeUser, env, spanTypeFor)
+		assert.Equal(t, "tu-gone", id)
+		assert.Empty(t, typ)
+		assert.True(t, closing)
+	})
+
+	t.Run("no tool block means no span", func(t *testing.T) {
+		for name, raw := range map[string]string{
+			"plain text":      `{"message":{"content":[{"type":"text","text":"hi"}]}}`,
+			"empty content":   `{"message":{"content":[]}}`,
+			"blank tool id":   `{"message":{"content":[{"type":"tool_use","id":"","name":"Read"}]}}`,
+			"blank result id": `{"message":{"content":[{"type":"tool_result","tool_use_id":""}]}}`,
+		} {
+			t.Run(name, func(t *testing.T) {
+				msgType := claudeMsgTypeAssistant
+				if name == "blank result id" {
+					msgType = claudeMsgTypeUser
+				}
+				id, typ, closing := claudeSpanForEnvelope(msgType, parse(t, raw), spanTypeFor)
+				assert.Empty(t, id)
+				assert.Empty(t, typ)
+				assert.False(t, closing)
+			})
+		}
+	})
+
+	t.Run("a result envelope belongs to no span", func(t *testing.T) {
+		env := parse(t, `{"message":{"content":[{"type":"tool_use","id":"tu-a","name":"Read"}]}}`)
+		id, _, closing := claudeSpanForEnvelope(claudeMsgTypeResult, env, spanTypeFor)
+		assert.Empty(t, id, "a turn-end envelope is not a tool row")
+		assert.False(t, closing)
+	})
 }

--- a/backend/internal/worker/agent/claude_subagent.go
+++ b/backend/internal/worker/agent/claude_subagent.go
@@ -28,11 +28,21 @@ const (
 //
 // The Workflow tool is also a spawn but is NOT matched here. It sits behind the
 // CLI's WORKFLOW_SCRIPTS feature flag, so its wire name is not a stable thing to
-// match; handleClaudeTaskStarted discards its span off the authoritative
+// match; handleClaudeTaskStarted gives its span back off the authoritative
 // task_started event instead.
 func claudeToolSpawnsSubagent(toolName string) bool {
 	return toolName == ToolNameClaudeAgent || toolName == ToolNameClaudeTask
 }
+
+// The task_type values a Claude task_started event carries. local_bash is a
+// backgrounded shell; local_agent is a Task subagent; local_workflow is a
+// Workflow run. Only local_bash is NOT a spawn, so the code tests for that one
+// and treats every other value -- including one this list does not name -- as a
+// spawn that owns no span and gets a child transcript.
+const (
+	claudeTaskTypeBash     = "local_bash"
+	claudeTaskTypeWorkflow = "local_workflow"
+)
 
 // claudeTaskEnvelope is the parsed shape of a Claude system event of subtype
 // task_started / task_progress / task_notification / task_updated /
@@ -130,7 +140,7 @@ func (a *ClaudeCodeAgent) handleClaudeTaskStarted(ev *claudeTaskEnvelope) {
 		a.taskKind = make(map[string]bgtask.Kind)
 	}
 	startedKind := bgtask.KindSubagent
-	if ev.TaskType == "local_bash" {
+	if ev.TaskType == claudeTaskTypeBash {
 		startedKind = bgtask.KindShell
 	}
 	a.taskKind[ev.TaskID] = startedKind
@@ -185,23 +195,29 @@ func (a *ClaudeCodeAgent) handleClaudeTaskStarted(ev *claudeTaskEnvelope) {
 		slog.Warn("claude task_started upsert failed", "task_id", ev.TaskID, "error", err)
 	}
 
-	// A Workflow run spawns a fleet of agents and blocks until the last one
-	// ends, so it is a spawn and owns no span. Its tool_use already opened one:
-	// claudeToolSpawnsSubagent cannot match the Workflow tool by name (the CLI
-	// keeps it behind the WORKFLOW_SCRIPTS feature flag), and this event is the
-	// first authoritative word that the call is a workflow. Take the span back
-	// now.
+	// task_started is the authority on which Claude tool calls own a span. A
+	// backgrounded shell is a plain Bash span whose tool_result returns at once,
+	// so it keeps its rail; every other task type starts a subagent and owns no
+	// span. The same startedKind that classifies the registry row above decides
+	// it here, so a task type nobody matched by name is still handled.
 	//
-	// local_bash must NOT reach this: a backgrounded shell is a plain Bash span
-	// whose tool_result returns at once, and it keeps its rail.
-	if ev.TaskType == "local_workflow" && ev.ToolUseID != "" {
-		a.sink.DiscardSpan(ev.ToolUseID)
+	// A spawn that claudeToolSpawnsSubagent already matched never opened a span,
+	// so this is a no-op for it. A Workflow run is why the call exists: the CLI
+	// keeps that tool behind the WORKFLOW_SCRIPTS feature flag, so its wire name
+	// is not a stable thing to match, and this event is the first authoritative
+	// word that the call is a workflow.
+	if startedKind != bgtask.KindShell && ev.ToolUseID != "" {
+		// CloseSpan, although the subagent keeps running: the call frees the
+		// column and nothing downstream distinguishes "ended" from "given back".
+		// The recorded span type survives it, so the tool_result still persists
+		// the real tool name.
+		a.sink.CloseSpan(ev.ToolUseID)
 	}
 
 	// Pre-create the child transcript for a Task subagent (local_agent), keyed
 	// by its spawning tool_use id. local_bash (shell) and local_workflow have no
 	// transcript; their envelopes are never forwarded.
-	if ev.TaskType != "local_bash" && ev.TaskType != "local_workflow" && ev.ToolUseID != "" {
+	if ev.TaskType != claudeTaskTypeBash && ev.TaskType != claudeTaskTypeWorkflow && ev.ToolUseID != "" {
 		childID, err := a.sink.EnsureChildAgent(ev.ToolUseID, ev.TaskID, title)
 		if err != nil {
 			slog.Warn("claude task_started ensure child failed", "task_id", ev.TaskID, "error", err)
@@ -345,62 +361,17 @@ func (a *ClaudeCodeAgent) routeSubagentMessage(content []byte, msgType string, e
 		return
 	}
 
-	// Resolve the child span id / type with the same per-block logic the main
-	// path uses, but against the CHILD sink's span tracker.
-	var spanID, spanType string
-	closing := false
-	if msgType == claudeMsgTypeAssistant {
-		for _, block := range env.ContentBlocks() {
-			if block.Type == "tool_use" && block.ID != "" {
-				spanID, spanType = block.ID, block.Name
-				break
-			}
-		}
-	} else if msgType == claudeMsgTypeUser {
-		for _, block := range env.ContentBlocks() {
-			if block.Type == "tool_result" && block.ToolUseID != "" {
-				spanID = block.ToolUseID
-				closing = true
-				break
-			}
-		}
-	}
-
-	// Look up the tool name for a tool_result, and reserve the tool_use's color.
-	// The span itself opens only AFTER the persist below -- see the ordering note
-	// there.
+	// Resolve the span metadata and reserve the tool_use's color with the SAME
+	// helper the parent transcript uses, but against the CHILD sink's tracker
+	// and under the spawn span as the parent. The span itself opens only AFTER
+	// the persist below -- see the ordering note there.
 	childSink := a.sink.ChildSink(childID)
-	if spanType == "" && spanID != "" {
-		spanType = childSink.GetSpanType(spanID)
-	}
-	var spanColor int32
-	if msgType == claudeMsgTypeAssistant && spanID != "" && !claudeToolSpawnsSubagent(spanType) {
-		// Reserving (not opening) is what makes the color available at persist
-		// time while the span is still closed, so the tool_use row can carry the
-		// color its rail will use without yet drawing that rail. A subagent this
-		// subagent spawns in turn owns no span, so it reserves nothing either.
-		spanColor = childSink.ReserveSpanColor(spanID, spawnSpanID)
-	}
+	spanInfo := claudeSpanInfoFor(childSink, msgType, env, spawnSpanID)
+	spanID, spanType := spanInfo.SpanID, spanInfo.SpanType
 
 	source := leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT
 	if msgType == claudeMsgTypeUser {
 		source = leapmuxv1.MessageSource_MESSAGE_SOURCE_USER
-	}
-
-	// Match the main path's markType derivation for user tool_results so a
-	// self-displaying control tool (AskUserQuestion/ExitPlanMode) forwarded into
-	// the child transcript gets its CONTROL_RESPONSE scroll-rail mark.
-	var markType leapmuxv1.MarkType
-	if msgType == claudeMsgTypeUser {
-		markType = claudeUserEnvelopeBlocksMarkType(env.ContentBlocks(), childSink.GetSpanType)
-	}
-	spanInfo := SpanInfo{
-		ParentSpanID: spawnSpanID,
-		SpanID:       spanID,
-		SpanType:     spanType,
-		SpanColor:    spanColor,
-		Closing:      closing,
-		MarkType:     markType,
 	}
 
 	if msgType == claudeMsgTypeResult {
@@ -466,11 +437,7 @@ func (a *ClaudeCodeAgent) routeSubagentMessage(content []byte, msgType string, e
 	// A user envelope may close multiple parallel tool_result spans in the
 	// child transcript.
 	if msgType == claudeMsgTypeUser {
-		for _, block := range env.ContentBlocks() {
-			if block.Type == "tool_result" && block.ToolUseID != "" {
-				childSink.CloseSpan(block.ToolUseID)
-			}
-		}
+		claudeCloseToolResultSpans(childSink, env)
 	}
 }
 

--- a/backend/internal/worker/agent/claude_subagent.go
+++ b/backend/internal/worker/agent/claude_subagent.go
@@ -10,6 +10,30 @@ import (
 	"github.com/leapmux/leapmux/internal/worker/bgtask"
 )
 
+// The Claude tool names that spawn a subagent. `Agent` is the current name and
+// `Task` is the legacy wire name for the SAME tool, which the CLI still emits
+// for permission rules, hooks, and resumed sessions
+// (src/tools/AgentTool/constants.ts: AGENT_TOOL_NAME / LEGACY_AGENT_TOOL_NAME).
+// The to-do tools TaskCreate/TaskUpdate/TaskGet/TaskList/TaskOutput/TaskStop
+// are separate names and are NOT spawns.
+const (
+	ToolNameClaudeAgent = "Agent"
+	ToolNameClaudeTask  = "Task"
+)
+
+// claudeToolSpawnsSubagent reports whether a Claude tool_use block starts a
+// subagent. A spawn owns no span: the subagent's own output lands in its child
+// transcript, so a rail held open for the whole run only pushes every
+// concurrent tool one column further right.
+//
+// The Workflow tool is also a spawn but is NOT matched here. It sits behind the
+// CLI's WORKFLOW_SCRIPTS feature flag, so its wire name is not a stable thing to
+// match; handleClaudeTaskStarted discards its span off the authoritative
+// task_started event instead.
+func claudeToolSpawnsSubagent(toolName string) bool {
+	return toolName == ToolNameClaudeAgent || toolName == ToolNameClaudeTask
+}
+
 // claudeTaskEnvelope is the parsed shape of a Claude system event of subtype
 // task_started / task_progress / task_notification / task_updated /
 // background_tasks_changed. Every field is optional; unknown subtypes are
@@ -161,8 +185,21 @@ func (a *ClaudeCodeAgent) handleClaudeTaskStarted(ev *claudeTaskEnvelope) {
 		slog.Warn("claude task_started upsert failed", "task_id", ev.TaskID, "error", err)
 	}
 
-	// Pre-create the child transcript for a Task subagent (local_agent) that
-	// owns a tool_use span. local_bash (shell) and local_workflow have no
+	// A Workflow run spawns a fleet of agents and blocks until the last one
+	// ends, so it is a spawn and owns no span. Its tool_use already opened one:
+	// claudeToolSpawnsSubagent cannot match the Workflow tool by name (the CLI
+	// keeps it behind the WORKFLOW_SCRIPTS feature flag), and this event is the
+	// first authoritative word that the call is a workflow. Take the span back
+	// now.
+	//
+	// local_bash must NOT reach this: a backgrounded shell is a plain Bash span
+	// whose tool_result returns at once, and it keeps its rail.
+	if ev.TaskType == "local_workflow" && ev.ToolUseID != "" {
+		a.sink.DiscardSpan(ev.ToolUseID)
+	}
+
+	// Pre-create the child transcript for a Task subagent (local_agent), keyed
+	// by its spawning tool_use id. local_bash (shell) and local_workflow have no
 	// transcript; their envelopes are never forwarded.
 	if ev.TaskType != "local_bash" && ev.TaskType != "local_workflow" && ev.ToolUseID != "" {
 		childID, err := a.sink.EnsureChildAgent(ev.ToolUseID, ev.TaskID, title)
@@ -337,10 +374,11 @@ func (a *ClaudeCodeAgent) routeSubagentMessage(content []byte, msgType string, e
 		spanType = childSink.GetSpanType(spanID)
 	}
 	var spanColor int32
-	if msgType == claudeMsgTypeAssistant && spanID != "" {
+	if msgType == claudeMsgTypeAssistant && spanID != "" && !claudeToolSpawnsSubagent(spanType) {
 		// Reserving (not opening) is what makes the color available at persist
 		// time while the span is still closed, so the tool_use row can carry the
-		// color its rail will use without yet drawing that rail.
+		// color its rail will use without yet drawing that rail. A subagent this
+		// subagent spawns in turn owns no span, so it reserves nothing either.
 		spanColor = childSink.ReserveSpanColor(spanID, spawnSpanID)
 	}
 
@@ -412,11 +450,16 @@ func (a *ClaudeCodeAgent) routeSubagentMessage(content []byte, msgType string, e
 	//
 	// Every tool_use block opens, not just the first: one assistant message can
 	// carry parallel tool calls, and the user envelope below closes all of them.
+	// The one exception is a nested spawn -- a subagent spawning a subagent of
+	// its own -- which owns no span here for the same reason it owns none in the
+	// parent transcript: its output goes to a transcript of its own.
 	if msgType == claudeMsgTypeAssistant {
 		for _, block := range env.ContentBlocks() {
 			if block.Type == "tool_use" && block.ID != "" {
 				childSink.SetSpanType(block.ID, block.Name)
-				childSink.OpenSpan(block.ID, spawnSpanID)
+				if !claudeToolSpawnsSubagent(block.Name) {
+					childSink.OpenSpan(block.ID, spawnSpanID)
+				}
 			}
 		}
 	}

--- a/backend/internal/worker/agent/claude_subagent_test.go
+++ b/backend/internal/worker/agent/claude_subagent_test.go
@@ -244,3 +244,316 @@ func TestClaude_ReplayedTaskStartedDoesNotDuplicateThePrompt(t *testing.T) {
 	require.True(t, ok)
 	assert.Len(t, child.Messages(), 1)
 }
+
+// --- A subagent spawn owns no span ---
+
+func TestClaude_ToolSpawnsSubagent(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, claudeToolSpawnsSubagent(ToolNameClaudeAgent))
+	assert.True(t, claudeToolSpawnsSubagent(ToolNameClaudeTask),
+		"Task is the legacy wire name for the SAME Agent tool")
+
+	// The to-do tools merely share the "Task" prefix; none of them spawns.
+	for _, name := range []string{
+		"Read", "Bash", "TaskCreate", "TaskUpdate", "TaskGet",
+		"TaskList", "TaskOutput", "TaskStop", "AgentTool", "",
+	} {
+		assert.False(t, claudeToolSpawnsSubagent(name), "%q does not spawn", name)
+	}
+}
+
+// The spawn's tool_use opens no span and reserves no color. It still carries
+// the span id (the frontend pairs it with the tool_result by that id) and the
+// span type (the tool_result reads it back through GetSpanType).
+func TestClaude_AgentToolUseOpensNoSpan(t *testing.T) {
+	t.Parallel()
+
+	for _, toolName := range []string{ToolNameClaudeAgent, ToolNameClaudeTask} {
+		t.Run(toolName, func(t *testing.T) {
+			t.Parallel()
+
+			sink := &testSink{}
+			a := newTestAgent(sink)
+			a.HandleOutput([]byte(`{
+				"type": "assistant",
+				"message": {"role": "assistant", "content": [
+					{"type": "tool_use", "id": "tu-spawn", "name": "` + toolName + `",
+					 "input": {"description": "explore", "prompt": "look around"}}
+				]}
+			}`))
+
+			assert.Empty(t, sink.OpenSpans(), "a spawn opens no span")
+			assert.Empty(t, sink.ReservedColorSpans(),
+				"a spawn reserves no color, so none is blocked while it runs")
+			assert.Equal(t, toolName, sink.GetSpanType("tu-spawn"),
+				"the span type is still recorded for the tool_result")
+
+			msgs := sink.Messages()
+			require.Len(t, msgs, 1)
+			assert.Equal(t, "tu-spawn", msgs[0].SpanID, "the row still carries the span id")
+			assert.Empty(t, msgs[0].SpansOpenAtPersist, "nothing else was open, so no rail")
+		})
+	}
+}
+
+// The guard is not too wide: an ordinary tool still opens a span and reserves
+// a color.
+func TestClaude_OrdinaryToolUseStillOpensASpan(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	a.HandleOutput([]byte(`{
+		"type": "assistant",
+		"message": {"role": "assistant", "content": [
+			{"type": "tool_use", "id": "tu-read", "name": "Read", "input": {"file_path": "/tmp/a"}}
+		]}
+	}`))
+
+	open := sink.OpenSpans()
+	require.Len(t, open, 1)
+	assert.Equal(t, "tu-read", open[0].SpanID)
+	assert.Equal(t, []string{"tu-read"}, sink.ReservedColorSpans())
+}
+
+// One assistant envelope can carry parallel tool calls. The spawn among them
+// opens nothing while its siblings still open their spans.
+func TestClaude_ParallelBlocksOpenOnlyTheNonSpawns(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	a.HandleOutput([]byte(`{
+		"type": "assistant",
+		"message": {"role": "assistant", "content": [
+			{"type": "tool_use", "id": "tu-spawn", "name": "Agent", "input": {"prompt": "go"}},
+			{"type": "tool_use", "id": "tu-read", "name": "Read", "input": {"file_path": "/tmp/a"}}
+		]}
+	}`))
+
+	open := sink.OpenSpans()
+	require.Len(t, open, 1, "only the Read opens a span")
+	assert.Equal(t, "tu-read", open[0].SpanID)
+	// spanID/spanColor come from the FIRST tool_use block, which is the spawn,
+	// so no color is reserved for this row at all.
+	assert.Empty(t, sink.ReservedColorSpans())
+}
+
+// The spawn's tool_result closes nothing and draws no rail of its own.
+func TestClaude_AgentToolResultDrawsNoRail(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	a.HandleOutput([]byte(`{
+		"type": "assistant",
+		"message": {"role": "assistant", "content": [
+			{"type": "tool_use", "id": "tu-spawn", "name": "Agent", "input": {"prompt": "go"}}
+		]}
+	}`))
+	a.HandleOutput([]byte(`{
+		"type": "user",
+		"message": {"role": "user", "content": [
+			{"type": "tool_result", "tool_use_id": "tu-spawn", "content": "the finding"}
+		]}
+	}`))
+
+	msgs := sink.Messages()
+	require.Len(t, msgs, 2)
+	assert.True(t, msgs[1].Closing, "the tool_result is still a closer")
+	assert.Equal(t, ToolNameClaudeAgent, msgs[1].SpanType,
+		"span_type survives because the spawn never closed a span to forget it")
+	assert.Empty(t, msgs[1].SpansOpenAtPersist, "and it draws no rail")
+	assert.Empty(t, sink.OpenSpans())
+}
+
+// The user's second example: a spawn that starts while a Read is running draws
+// exactly the Read's rail -- one column, not two.
+func TestClaude_SpawnInsideOpenReadDrawsOneColumn(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	a.HandleOutput([]byte(`{
+		"type": "assistant",
+		"message": {"role": "assistant", "content": [
+			{"type": "tool_use", "id": "tu-read", "name": "Read", "input": {"file_path": "/tmp/a"}}
+		]}
+	}`))
+	a.HandleOutput([]byte(`{
+		"type": "assistant",
+		"message": {"role": "assistant", "content": [
+			{"type": "tool_use", "id": "tu-spawn", "name": "Agent", "input": {"prompt": "go"}}
+		]}
+	}`))
+	a.HandleOutput([]byte(`{
+		"type": "user",
+		"message": {"role": "user", "content": [
+			{"type": "tool_result", "tool_use_id": "tu-spawn", "content": "the finding"}
+		]}
+	}`))
+
+	msgs := sink.Messages()
+	require.Len(t, msgs, 3)
+	for i, msg := range msgs[1:] {
+		require.Len(t, msg.SpansOpenAtPersist, 1, "spawn row %d draws exactly one column", i)
+		assert.Equal(t, "tu-read", msg.SpansOpenAtPersist[0].SpanID)
+	}
+	// The Read span outlives both spawn rows and is still the only one open.
+	// The spawn's tool_result does call CloseSpan -- that is how the recorded
+	// span type is freed -- but with no span of its own to remove it cannot
+	// disturb the Read's column.
+	assert.Equal(t, []string{"tu-spawn"}, sink.ClosedSpans())
+	open := sink.OpenSpans()
+	require.Len(t, open, 1)
+	assert.Equal(t, "tu-read", open[0].SpanID)
+	assert.Empty(t, sink.DiscardedSpans())
+}
+
+// A Workflow run spawns a fleet of agents and blocks until the last one ends,
+// so it is a spawn too. Its tool_use already opened a span -- the CLI keeps the
+// Workflow tool behind a feature flag, so its name is not matched -- and
+// task_started is the first authoritative word. Take the span back there.
+func TestClaude_WorkflowTaskStartedDiscardsTheSpan(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	a.HandleOutput([]byte(`{
+		"type": "assistant",
+		"message": {"role": "assistant", "content": [
+			{"type": "tool_use", "id": "tu-wf", "name": "Workflow", "input": {"name": "review"}}
+		]}
+	}`))
+	require.Len(t, sink.OpenSpans(), 1, "the tool_use opened one before we knew")
+
+	a.HandleOutput([]byte(`{
+		"type": "system",
+		"subtype": "task_started",
+		"task_id": "task-wf",
+		"tool_use_id": "tu-wf",
+		"task_type": "local_workflow",
+		"workflow_name": "review"
+	}`))
+
+	assert.Equal(t, []string{"tu-wf"}, sink.DiscardedSpans())
+	assert.Empty(t, sink.ClosedSpans(), "discarded, not closed -- the run is still going")
+	assert.Equal(t, "Workflow", sink.GetSpanType("tu-wf"),
+		"a discard keeps the type the tool_result reads back")
+
+	// A tool row persisted after the discard draws no rail.
+	a.HandleOutput([]byte(`{
+		"type": "assistant",
+		"message": {"role": "assistant", "content": [
+			{"type": "tool_use", "id": "tu-read", "name": "Read", "input": {"file_path": "/tmp/a"}}
+		]}
+	}`))
+	msgs := sink.Messages()
+	require.Len(t, msgs, 2)
+	assert.Empty(t, msgs[1].SpansOpenAtPersist, "the workflow rail is gone")
+}
+
+// A backgrounded shell is an ordinary Bash span whose tool_result returns at
+// once. It reports task_started too, and it must KEEP its rail.
+func TestClaude_BackgroundShellTaskStartedKeepsTheSpan(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	a.HandleOutput([]byte(`{
+		"type": "assistant",
+		"message": {"role": "assistant", "content": [
+			{"type": "tool_use", "id": "tu-bash", "name": "Bash", "input": {"command": "sleep 100"}}
+		]}
+	}`))
+	a.HandleOutput([]byte(`{
+		"type": "system",
+		"subtype": "task_started",
+		"task_id": "task-sh",
+		"tool_use_id": "tu-bash",
+		"task_type": "local_bash",
+		"description": "sleep 100"
+	}`))
+
+	assert.Empty(t, sink.DiscardedSpans(), "a background shell keeps its span")
+	open := sink.OpenSpans()
+	require.Len(t, open, 1)
+	assert.Equal(t, "tu-bash", open[0].SpanID)
+}
+
+// A local_agent Task never opened a span, so its task_started has nothing to
+// discard.
+func TestClaude_AgentTaskStartedDiscardsNothing(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	a.HandleOutput([]byte(`{
+		"type": "assistant",
+		"message": {"role": "assistant", "content": [
+			{"type": "tool_use", "id": "tu-spawn", "name": "Agent", "input": {"prompt": "go"}}
+		]}
+	}`))
+	a.HandleOutput([]byte(`{
+		"type": "system",
+		"subtype": "task_started",
+		"task_id": "task-1",
+		"tool_use_id": "tu-spawn",
+		"task_type": "local_agent",
+		"prompt": "go"
+	}`))
+
+	assert.Empty(t, sink.OpenSpans())
+	assert.Empty(t, sink.DiscardedSpans())
+}
+
+// A workflow event without a tool_use_id has no span to name, so it discards
+// nothing rather than discarding the empty id.
+func TestClaude_WorkflowTaskStartedWithoutToolUseIDDiscardsNothing(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	a.HandleOutput([]byte(`{
+		"type": "system",
+		"subtype": "task_started",
+		"task_id": "task-wf",
+		"task_type": "local_workflow",
+		"workflow_name": "review"
+	}`))
+
+	assert.Empty(t, sink.DiscardedSpans())
+}
+
+// A subagent can spawn a subagent of its own. That nested spawn owns no span in
+// the CHILD transcript either, for the same reason: its output goes to a
+// transcript of its own.
+func TestClaude_NestedSpawnOpensNoSpanInTheChildTranscript(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	// A forwarded envelope carries the spawning tool_use id, which routes it to
+	// the child transcript.
+	a.HandleOutput([]byte(`{
+		"type": "assistant",
+		"parent_tool_use_id": "tu-spawn",
+		"message": {"role": "assistant", "content": [
+			{"type": "tool_use", "id": "tu-nested", "name": "Agent", "input": {"prompt": "go deeper"}},
+			{"type": "tool_use", "id": "tu-read", "name": "Read", "input": {"file_path": "/tmp/a"}}
+		]}
+	}`))
+
+	assert.Empty(t, sink.OpenSpans(), "the parent transcript is untouched")
+
+	child, ok := sink.ChildSink("child-of-tu-spawn").(*testSink)
+	require.True(t, ok)
+	open := child.OpenSpans()
+	require.Len(t, open, 1, "only the Read opens a span in the child transcript")
+	assert.Equal(t, "tu-read", open[0].SpanID)
+	assert.Empty(t, child.ReservedColorSpans(),
+		"the row's color comes from the first block, which is the nested spawn")
+	assert.Equal(t, ToolNameClaudeAgent, child.GetSpanType("tu-nested"),
+		"the nested spawn's type is still recorded for its tool_result")
+}

--- a/backend/internal/worker/agent/claude_subagent_test.go
+++ b/backend/internal/worker/agent/claude_subagent_test.go
@@ -401,21 +401,21 @@ func TestClaude_SpawnInsideOpenReadDrawsOneColumn(t *testing.T) {
 		assert.Equal(t, "tu-read", msg.SpansOpenAtPersist[0].SpanID)
 	}
 	// The Read span outlives both spawn rows and is still the only one open.
-	// The spawn's tool_result does call CloseSpan -- that is how the recorded
-	// span type is freed -- but with no span of its own to remove it cannot
-	// disturb the Read's column.
+	// The spawn's tool_result does call CloseSpan, but with no span of its own
+	// to remove it cannot disturb the Read's column.
 	assert.Equal(t, []string{"tu-spawn"}, sink.ClosedSpans())
 	open := sink.OpenSpans()
-	require.Len(t, open, 1)
+	require.Len(t, open, 1, "the Read is still the only span that ever opened")
 	assert.Equal(t, "tu-read", open[0].SpanID)
-	assert.Empty(t, sink.DiscardedSpans())
+	assert.Equal(t, ToolNameClaudeAgent, sink.GetSpanType("tu-spawn"),
+		"the close kept the recorded type, so the tool_result persisted the real name")
 }
 
 // A Workflow run spawns a fleet of agents and blocks until the last one ends,
 // so it is a spawn too. Its tool_use already opened a span -- the CLI keeps the
 // Workflow tool behind a feature flag, so its name is not matched -- and
-// task_started is the first authoritative word. Take the span back there.
-func TestClaude_WorkflowTaskStartedDiscardsTheSpan(t *testing.T) {
+// task_started is the first authoritative word. Discard the span there.
+func TestClaude_WorkflowTaskStartedGivesTheSpanBack(t *testing.T) {
 	t.Parallel()
 
 	sink := &testSink{}
@@ -437,10 +437,10 @@ func TestClaude_WorkflowTaskStartedDiscardsTheSpan(t *testing.T) {
 		"workflow_name": "review"
 	}`))
 
-	assert.Equal(t, []string{"tu-wf"}, sink.DiscardedSpans())
-	assert.Empty(t, sink.ClosedSpans(), "discarded, not closed -- the run is still going")
+	assert.Equal(t, []string{"tu-wf"}, sink.ClosedSpans(),
+		"the span is given back although the workflow run keeps going")
 	assert.Equal(t, "Workflow", sink.GetSpanType("tu-wf"),
-		"a discard keeps the type the tool_result reads back")
+		"and the recorded type survives, so the tool_result reads it back")
 
 	// A tool row persisted after the discard draws no rail.
 	a.HandleOutput([]byte(`{
@@ -476,15 +476,17 @@ func TestClaude_BackgroundShellTaskStartedKeepsTheSpan(t *testing.T) {
 		"description": "sleep 100"
 	}`))
 
-	assert.Empty(t, sink.DiscardedSpans(), "a background shell keeps its span")
+	assert.Empty(t, sink.ClosedSpans(), "a background shell keeps its span")
 	open := sink.OpenSpans()
 	require.Len(t, open, 1)
 	assert.Equal(t, "tu-bash", open[0].SpanID)
 }
 
-// A local_agent Task never opened a span, so its task_started has nothing to
-// discard.
-func TestClaude_AgentTaskStartedDiscardsNothing(t *testing.T) {
+// A local_agent Task never opened a span, because claudeToolSpawnsSubagent
+// matched its tool_use by name. Its task_started still runs the discard -- the
+// predicate is the task type, not the tool name -- and that discard changes
+// nothing: no span was open, and no later row draws a rail.
+func TestClaude_AgentTaskStartedLeavesNoSpanOpen(t *testing.T) {
 	t.Parallel()
 
 	sink := &testSink{}
@@ -505,12 +507,63 @@ func TestClaude_AgentTaskStartedDiscardsNothing(t *testing.T) {
 	}`))
 
 	assert.Empty(t, sink.OpenSpans())
-	assert.Empty(t, sink.DiscardedSpans())
+
+	a.HandleOutput([]byte(`{
+		"type": "assistant",
+		"message": {"role": "assistant", "content": [
+			{"type": "tool_use", "id": "tu-read", "name": "Read", "input": {"file_path": "/tmp/a"}}
+		]}
+	}`))
+	msgs := sink.Messages()
+	require.Len(t, msgs, 2)
+	assert.Empty(t, msgs[1].SpansOpenAtPersist, "the spawn left no rail behind")
+}
+
+// task_started is the authority, so a task type this code does not name is
+// still a spawn and still gives its span back. Matching only the tool name left
+// such a run's rail open for the whole child run -- the exact defect the change
+// removes for the names it does know.
+func TestClaude_UnknownTaskTypeGivesTheSpanBack(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	// A spawning tool whose wire name is in no list, so its tool_use opens a span.
+	a.HandleOutput([]byte(`{
+		"type": "assistant",
+		"message": {"role": "assistant", "content": [
+			{"type": "tool_use", "id": "tu-x", "name": "Delegate", "input": {"prompt": "go"}}
+		]}
+	}`))
+	require.Len(t, sink.OpenSpans(), 1, "the unknown name opened one before we knew")
+
+	a.HandleOutput([]byte(`{
+		"type": "system",
+		"subtype": "task_started",
+		"task_id": "task-x",
+		"tool_use_id": "tu-x",
+		"task_type": "local_fleet",
+		"prompt": "go"
+	}`))
+
+	assert.Equal(t, []string{"tu-x"}, sink.ClosedSpans())
+	assert.Equal(t, "Delegate", sink.GetSpanType("tu-x"),
+		"the recorded type survives, so the tool_result reads it back")
+
+	a.HandleOutput([]byte(`{
+		"type": "assistant",
+		"message": {"role": "assistant", "content": [
+			{"type": "tool_use", "id": "tu-read", "name": "Read", "input": {"file_path": "/tmp/a"}}
+		]}
+	}`))
+	msgs := sink.Messages()
+	require.Len(t, msgs, 2)
+	assert.Empty(t, msgs[1].SpansOpenAtPersist, "the unknown spawn's rail is gone")
 }
 
 // A workflow event without a tool_use_id has no span to name, so it discards
 // nothing rather than discarding the empty id.
-func TestClaude_WorkflowTaskStartedWithoutToolUseIDDiscardsNothing(t *testing.T) {
+func TestClaude_WorkflowTaskStartedWithoutToolUseIDClosesNothing(t *testing.T) {
 	t.Parallel()
 
 	sink := &testSink{}
@@ -523,7 +576,66 @@ func TestClaude_WorkflowTaskStartedWithoutToolUseIDDiscardsNothing(t *testing.T)
 		"workflow_name": "review"
 	}`))
 
-	assert.Empty(t, sink.DiscardedSpans())
+	assert.Empty(t, sink.ClosedSpans())
+}
+
+// The child transcript reserves its tool_use color under the SPAWN span, not at
+// the root: the reservation's parent decides the column it is computed for, so
+// a child tool would otherwise be coloured as if it sat in the parent's
+// transcript. The shared claudeSpanInfoFor takes that parent from its caller,
+// which is the one thing the two transcripts do differently.
+func TestClaude_ChildTranscriptReservesUnderTheSpawnSpan(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	a.HandleOutput([]byte(`{
+		"type": "assistant",
+		"parent_tool_use_id": "tu-spawn",
+		"message": {"role": "assistant", "content": [
+			{"type": "tool_use", "id": "tu-read", "name": "Read", "input": {"file_path": "/tmp/a"}}
+		]}
+	}`))
+
+	child, ok := sink.ChildSink("child-of-tu-spawn").(*testSink)
+	require.True(t, ok)
+	assert.Equal(t, []testSinkSpanOpen{{SpanID: "tu-read", ParentSpanID: "tu-spawn"}},
+		child.ReservedColors(), "the child reserves under the spawn span")
+	assert.Empty(t, sink.ReservedColors(), "and nothing is reserved in the parent transcript")
+}
+
+// A spawn row reports span_color 0 as its ANSWER, so the persist path must not
+// fill it from the connector. Claude resolves a top-level envelope's parent span
+// from its own tool_use_id, so a spawn CAN carry a ParentSpanID naming a span
+// that is still open -- and the connector-colour fallback would then tint the
+// spawn card with a colour no rail anywhere draws.
+func TestClaude_SpawnRowUnderAnOpenParentStillTakesTheNeutralBorder(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	a.HandleOutput([]byte(`{
+		"type": "assistant",
+		"message": {"role": "assistant", "content": [
+			{"type": "tool_use", "id": "tu-read", "name": "Read", "input": {"file_path": "/tmp/a"}}
+		]}
+	}`))
+	// A top-level envelope carrying tool_use_id: the parent span resolves to it.
+	a.HandleOutput([]byte(`{
+		"type": "assistant",
+		"tool_use_id": "tu-read",
+		"message": {"role": "assistant", "content": [
+			{"type": "tool_use", "id": "tu-spawn", "name": "Agent", "input": {"prompt": "go"}}
+		]}
+	}`))
+
+	msgs := sink.Messages()
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "tu-read", msgs[1].ParentSpanID, "the spawn row does sit under the open Read")
+	assert.True(t, msgs[1].NoSpan,
+		"and it is marked as owning no span, so nothing substitutes a colour for its 0")
+	assert.Equal(t, []string{"tu-read"}, sink.ReservedColorSpans(),
+		"only the Read reserved a colour; the spawn reserved none")
 }
 
 // A subagent can spawn a subagent of its own. That nested spawn owns no span in

--- a/backend/internal/worker/agent/codex_output.go
+++ b/backend/internal/worker/agent/codex_output.go
@@ -425,19 +425,8 @@ func (a *CodexAgent) handleItemStarted(raw []byte, params json.RawMessage) {
 		// transcripts.
 		collab := parseCollabToolCall(item)
 		spawns := collab != nil && collab.Tool == codexCollabToolSpawnAgent
-		var spanColor int32
-		if !spawns {
-			spanColor = a.sink.ReserveSpanColor(itemID, "")
-		}
-		if err := a.sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, params, SpanInfo{
-			SpanID: itemID, SpanType: itemType, SpanColor: spanColor,
-		}); err != nil {
+		if err := openToolSpan(a.sink, params, itemID, itemType, spawns); err != nil {
 			slog.Error("codex persist collabAgentToolCall/started", "agent_id", a.agentID, "error", err)
-		}
-		// The span type is recorded either way: item/completed reads it back.
-		a.sink.SetSpanType(itemID, itemType)
-		if !spawns {
-			a.sink.OpenSpan(itemID, "")
 		}
 		if collab != nil {
 			for _, receiverID := range collab.ReceiverThreadIds {
@@ -1091,14 +1080,9 @@ func (a *CodexAgent) persistItemCompletedChild(childID string, params json.RawMe
 func persistToolItemStarted(sink OutputSink, params json.RawMessage, itemType, itemID, agentID string) {
 	switch itemType {
 	case "commandExecution", "fileChange", "mcpToolCall", "dynamicToolCall":
-		spanColor := sink.ReserveSpanColor(itemID, "")
-		if err := sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, params, SpanInfo{
-			SpanID: itemID, SpanType: itemType, SpanColor: spanColor,
-		}); err != nil {
+		if err := openToolSpan(sink, params, itemID, itemType, false); err != nil {
 			slog.Error("codex persist item/started", "agent_id", agentID, "type", itemType, "error", err)
 		}
-		sink.SetSpanType(itemID, itemType)
-		sink.OpenSpan(itemID, "")
 	}
 }
 

--- a/backend/internal/worker/agent/codex_output.go
+++ b/backend/internal/worker/agent/codex_output.go
@@ -415,19 +415,31 @@ func (a *CodexAgent) handleItemStarted(raw []byte, params json.RawMessage) {
 	case "commandExecution", "fileChange", "mcpToolCall", "dynamicToolCall":
 		persistToolItemStarted(a.sink, params, itemType, itemID, a.agentID)
 	case "collabAgentToolCall":
-		// The spawn tool_call stays in the parent transcript as a flat tool
-		// span (children no longer nest under it). Register receiver threads
-		// as the child index so later child-thread items route to child
+		// Every collab tool_call stays in the parent transcript as a flat tool
+		// span (children no longer nest under it) -- EXCEPT spawnAgent, which
+		// owns no span at all. A spawn's output lives in the child transcript,
+		// so a rail held open for the whole subagent run only pushes every
+		// concurrent tool one column right. The other collab tools (wait,
+		// sendInput, resumeAgent, closeAgent) keep their span. Register receiver
+		// threads as the child index so later child-thread items route to child
 		// transcripts.
-		spanColor := a.sink.ReserveSpanColor(itemID, "")
+		collab := parseCollabToolCall(item)
+		spawns := collab != nil && collab.Tool == codexCollabToolSpawnAgent
+		var spanColor int32
+		if !spawns {
+			spanColor = a.sink.ReserveSpanColor(itemID, "")
+		}
 		if err := a.sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, params, SpanInfo{
 			SpanID: itemID, SpanType: itemType, SpanColor: spanColor,
 		}); err != nil {
 			slog.Error("codex persist collabAgentToolCall/started", "agent_id", a.agentID, "error", err)
 		}
+		// The span type is recorded either way: item/completed reads it back.
 		a.sink.SetSpanType(itemID, itemType)
-		a.sink.OpenSpan(itemID, "")
-		if collab := parseCollabToolCall(item); collab != nil {
+		if !spawns {
+			a.sink.OpenSpan(itemID, "")
+		}
+		if collab != nil {
 			for _, receiverID := range collab.ReceiverThreadIds {
 				a.registerCollabReceiver(receiverID, itemID)
 				a.collabChildPrompts.remember(receiverID, collab.Prompt)
@@ -493,15 +505,13 @@ func (a *CodexAgent) handleItemCompleted(params json.RawMessage) {
 		a.mu.Unlock()
 		persistToolItemCompleted(a.sink, params, itemType, itemID, a.agentID)
 	case "collabAgentToolCall":
-		// Every collab tool_call (spawnAgent, wait, sendInput, resumeAgent,
-		// closeAgent) is a flat tool span in the parent transcript that CLOSES at
-		// completion. Children no longer nest under the spawn span -- they route
-		// to their own transcripts -- so leaving any of these open leaks a span
-		// until the next turn's bulk ResetSpans.
-		var collab *codexCollabAgentToolCall
-		if itemType == "collabAgentToolCall" {
-			collab = parseCollabToolCall(item)
-		}
+		// wait, sendInput, resumeAgent and closeAgent are flat tool spans in the
+		// parent transcript that CLOSE at completion. Children no longer nest
+		// under the spawn span -- they route to their own transcripts -- so
+		// leaving any of these open leaks a span until the next turn's bulk
+		// ResetSpans. spawnAgent never opened one (item/started skips it), and
+		// the close below is a harmless no-op for it.
+		collab := parseCollabToolCall(item)
 		if err := a.sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, params, SpanInfo{
 			SpanID: itemID, SpanType: itemType, Closing: true,
 		}); err != nil {
@@ -515,7 +525,7 @@ func (a *CodexAgent) handleItemCompleted(params json.RawMessage) {
 				a.registerCollabReceiver(receiverID, itemID)
 				a.collabChildPrompts.remember(receiverID, collab.Prompt)
 			}
-			if collab.Tool == "spawnAgent" {
+			if collab.Tool == codexCollabToolSpawnAgent {
 				if sp := collab.Prompt; sp != "" {
 					for _, rid := range collab.ReceiverThreadIds {
 						a.recordCollabChildTitle(rid, sp)
@@ -964,6 +974,12 @@ func codexWindowToType(mins int) string {
 		return fmt.Sprintf("%d_hour", hours)
 	}
 }
+
+// codexCollabToolSpawnAgent is the one collabAgentToolCall tool that starts a
+// subagent. Codex declares the whole set as spawnAgent, sendInput, resumeAgent,
+// wait, closeAgent (CollabAgentTool in the app-server protocol); only the spawn
+// owns no span.
+const codexCollabToolSpawnAgent = "spawnAgent"
 
 type codexCollabAgentState struct {
 	Status string `json:"status"`

--- a/backend/internal/worker/agent/codex_output_test.go
+++ b/backend/internal/worker/agent/codex_output_test.go
@@ -587,7 +587,12 @@ func TestHandleCodexOutput_TurnCompletedSuccessCancelsAPIError(t *testing.T) {
 	require.Equal(t, AutoContinueReasonAPIError, sink.LastAutoCancel())
 }
 
-func TestHandleCodexOutput_SpawnAgentStartedOpensFlatSpan(t *testing.T) {
+// A spawnAgent tool call owns NO span: the subagent's output lives in its own
+// child transcript, so a rail held open for the whole run would only push every
+// concurrent tool one column right. The row still carries the span id (the
+// frontend pairs the started and completed rows by it) and the span type (which
+// item/completed reads back).
+func TestHandleCodexOutput_SpawnAgentStartedOpensNoSpan(t *testing.T) {
 	t.Parallel()
 
 	sink := &testSink{}
@@ -596,11 +601,59 @@ func TestHandleCodexOutput_SpawnAgentStartedOpensFlatSpan(t *testing.T) {
 	input := `{"method":"item/started","params":{"threadId":"main-thread","turnId":"turn1","item":{"type":"collabAgentToolCall","id":"call-1","tool":"spawnAgent","status":"inProgress","senderThreadId":"main-thread","receiverThreadIds":["child-1"],"prompt":"do work","model":"gpt-5.4","reasoningEffort":"medium","agentsStates":{}}}}`
 	handleCodexOutput(agent, parseLine([]byte(input)))
 
-	got := sink.OpenSpans()
-	require.Len(t, got, 1)
-	require.Equal(t, "call-1", got[0].SpanID)
-	require.Equal(t, "", got[0].ParentSpanID, "spawn span is flat (no parent)")
-	require.Equal(t, 0, sink.ClosedSpanCount())
+	assert.Empty(t, sink.OpenSpans(), "a spawn opens no span")
+	assert.Equal(t, 0, sink.ClosedSpanCount())
+	assert.Equal(t, "collabAgentToolCall", sink.GetSpanType("call-1"), "the span type is still recorded")
+
+	messages := sink.Messages()
+	require.Len(t, messages, 1)
+	assert.Equal(t, "call-1", messages[0].SpanID, "the row still carries the span id")
+	assert.Empty(t, messages[0].SpansOpenAtPersist, "nothing else was open, so the row draws no rail")
+}
+
+// The spawn's completed row closes nothing and still draws no rail.
+func TestHandleCodexOutput_SpawnAgentCompletedLeavesNoSpan(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink)
+
+	started := `{"method":"item/started","params":{"threadId":"main-thread","turnId":"turn1","item":{"type":"collabAgentToolCall","id":"call-1","tool":"spawnAgent","status":"inProgress","senderThreadId":"main-thread","receiverThreadIds":["child-1"],"prompt":"do work","model":"gpt-5.4","reasoningEffort":"medium","agentsStates":{}}}}`
+	completed := `{"method":"item/completed","params":{"threadId":"main-thread","turnId":"turn1","item":{"type":"collabAgentToolCall","id":"call-1","tool":"spawnAgent","status":"completed","senderThreadId":"main-thread","receiverThreadIds":["child-1"],"prompt":"do work","model":"gpt-5.4","reasoningEffort":"medium","agentsStates":{"child-1":{"status":"completed","message":"done"}}}}}`
+
+	handleCodexOutput(agent, parseLine([]byte(started)))
+	handleCodexOutput(agent, parseLine([]byte(completed)))
+
+	assert.Empty(t, sink.OpenSpans(), "neither row opens a span")
+
+	messages := sink.Messages()
+	require.Len(t, messages, 2)
+	assert.True(t, messages[1].Closing, "the completed row is still a closer")
+	assert.Empty(t, messages[1].SpansOpenAtPersist, "and it draws no rail")
+}
+
+// A subagent spawn that starts while an unrelated command is running draws that
+// command's rail and nothing more -- one column, not two.
+func TestHandleCodexOutput_SpawnInsideOpenCommandDrawsOneColumn(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink)
+
+	cmdStarted := `{"method":"item/started","params":{"threadId":"main-thread","turnId":"turn1","item":{"type":"commandExecution","id":"cmd-1","status":"inProgress","command":"ls","cwd":"/tmp","processId":"123","commandActions":[]}}}`
+	spawnStarted := `{"method":"item/started","params":{"threadId":"main-thread","turnId":"turn1","item":{"type":"collabAgentToolCall","id":"call-1","tool":"spawnAgent","status":"inProgress","senderThreadId":"main-thread","receiverThreadIds":["child-1"],"prompt":"do work","model":"gpt-5.4","reasoningEffort":"medium","agentsStates":{}}}}`
+
+	handleCodexOutput(agent, parseLine([]byte(cmdStarted)))
+	handleCodexOutput(agent, parseLine([]byte(spawnStarted)))
+
+	open := sink.OpenSpans()
+	require.Len(t, open, 1)
+	assert.Equal(t, "cmd-1", open[0].SpanID, "only the command owns a span")
+
+	messages := sink.Messages()
+	require.Len(t, messages, 2)
+	require.Len(t, messages[1].SpansOpenAtPersist, 1, "the spawn row draws exactly the command's rail")
+	assert.Equal(t, "cmd-1", messages[1].SpansOpenAtPersist[0].SpanID)
 }
 
 func TestHandleCodexOutput_WaitIsAFlatToolSpan(t *testing.T) {
@@ -622,6 +675,17 @@ func TestHandleCodexOutput_WaitIsAFlatToolSpan(t *testing.T) {
 	// wait is a flat tool span: no parent nesting, no connector.
 	require.Equal(t, "", messages[1].ParentSpanID, "wait started is flat")
 	require.Equal(t, "", messages[2].ParentSpanID, "wait completed is flat")
+
+	// Only the spawn loses its span. wait blocks on the subagent but stays an
+	// ordinary tool span, so it opens one and closes it at completion.
+	open := sink.OpenSpans()
+	require.Len(t, open, 1, "the spawn opens nothing; wait opens one span")
+	assert.Equal(t, "call-2", open[0].SpanID)
+	assert.Equal(t, []string{"call-2"}, sink.ClosedSpans())
+	// The closing row persists while its own span is still open, so it can draw
+	// the connector_end on that column. The spawn contributes no second column.
+	require.Len(t, messages[2].SpansOpenAtPersist, 1)
+	assert.Equal(t, "call-2", messages[2].SpansOpenAtPersist[0].SpanID)
 }
 
 func TestHandleCodexOutput_SubagentCommandRoutesToChildTranscript(t *testing.T) {

--- a/backend/internal/worker/agent/cursor.go
+++ b/backend/internal/worker/agent/cursor.go
@@ -270,13 +270,7 @@ func init() {
 // keys before use, so no fixup is needed here. Registry-only: Cursor surfaces
 // no metadata/child linkage.
 func cursorSubagentFromToolCall(tc acpToolCallEnvelope) *acpSubagentObservation {
-	if len(tc.RawInput) == 0 {
-		return nil
-	}
-	var input struct {
-		ToolName string `json:"_toolName"`
-	}
-	if err := json.Unmarshal(tc.RawInput, &input); err != nil || input.ToolName != "task" {
+	if !cursorToolCallIsTaskTool(tc.RawInput) {
 		return nil
 	}
 	title := strings.TrimPrefix(tc.Title, "Task: ")
@@ -290,35 +284,76 @@ func cursorSubagentFromToolCall(tc acpToolCallEnvelope) *acpSubagentObservation 
 	}
 }
 
-// cursorSubagentFromToolCallUpdate maps Cursor's task tool_call status
-// transitions to finished registry rows. The final update fires for EVERY
-// finished tool_call (not just spawns); a plain tool (isBackground absent) is
-// a close-only observation so it does not create a spurious row. A background
-// task carries an activity line and upserts before closing.
+// cursorToolCallIsTaskTool reports whether a Cursor tool call is the `task`
+// delegation tool, which is the only Cursor tool that spawns a subagent. Both
+// hooks below key off this one definition: the spawn hook to open the row, the
+// closing hook to keep itself from reclassifying that row as a shell.
+//
+// Returns false for an absent rawInput, which is the honest answer -- Cursor
+// does not always echo the input on an update, and "not known to be the task
+// tool" is what the callers need.
+func cursorToolCallIsTaskTool(rawInput json.RawMessage) bool {
+	if len(rawInput) == 0 {
+		return false
+	}
+	var input struct {
+		ToolName string `json:"_toolName"`
+	}
+	return json.Unmarshal(rawInput, &input) == nil && input.ToolName == "task"
+}
+
+// cursorToolCallRanInBackground reports whether a finished Cursor tool call was
+// backgrounded, which Cursor states as rawOutput.isBackground.
+func cursorToolCallRanInBackground(rawOutput json.RawMessage) bool {
+	if len(rawOutput) == 0 {
+		return false
+	}
+	var out struct {
+		IsBackground bool `json:"isBackground"`
+	}
+	return json.Unmarshal(rawOutput, &out) == nil && out.IsBackground
+}
+
+// cursorSubagentFromToolCallUpdate maps Cursor's finished tool_call updates to
+// registry rows. The final update fires for EVERY finished tool_call (not just
+// spawns); a plain foreground tool is a close-only observation, so it does not
+// create a spurious row. A backgrounded call carries an activity line and
+// upserts before closing.
+//
+// A backgrounded call is a SHELL unless the input says it is the `task` tool.
+// Cursor's other tools are not subagents, and the neutral layer defaults a
+// blank kind to Subagent -- so leaving the kind blank here put a shell in the
+// sidebar under a Bot icon, in the subagent filter tab, labelled with its raw
+// toolCallId. The task-tool arm leaves BOTH the kind and the title blank on
+// purpose: the spawn observation already set them, and Item.PreservingBlanksFrom
+// keeps an existing value only for a blank incoming one. Writing them here
+// would flip a real subagent row to a shell and overwrite its trimmed title
+// with the raw "Task: ..." string.
 func cursorSubagentFromToolCallUpdate(tcu acpToolCallUpdateEnvelope) *acpSubagentObservation {
 	switch tcu.Status {
 	case "completed", "failed", "cancelled":
 	default:
 		return nil
 	}
-	activity := ""
-	if len(tcu.RawOutput) > 0 {
-		var out struct {
-			IsBackground bool `json:"isBackground"`
-		}
-		if json.Unmarshal(tcu.RawOutput, &out) == nil && out.IsBackground {
-			activity = "background task"
-		}
-	}
-	mode := acpModeCloseOnly
-	if activity != "" {
-		mode = acpModeUpsert
-	}
-	return &acpSubagentObservation{
+	obs := &acpSubagentObservation{
 		RowKey:   tcu.ToolCallID,
-		Activity: activity,
 		Status:   acpFinalStatus(tcu.Status),
 		CloseRow: true,
-		Mode:     mode,
+		Mode:     acpModeCloseOnly,
 	}
+	if !cursorToolCallRanInBackground(tcu.RawOutput) {
+		return obs
+	}
+	obs.Mode = acpModeUpsert
+	obs.Activity = "background task"
+	if !cursorToolCallIsTaskTool(tcu.RawInput) {
+		obs.Kind = bgtask.KindShell
+		// This update is the row's only event, so it is also the only chance to
+		// give it a readable label. Without one the sidebar shows the raw
+		// toolCallId. The row's TitleIsCommand stays false (no observation sets
+		// it): Cursor's title is a label, not a verbatim command, and prose in
+		// the monospace face reads worse than a command in the normal one.
+		obs.Title = tcu.Title
+	}
+	return obs
 }

--- a/backend/internal/worker/agent/cursor.go
+++ b/backend/internal/worker/agent/cursor.go
@@ -23,6 +23,79 @@ const (
 // CursorCLIAgent manages a single Cursor CLI ACP process.
 type CursorCLIAgent struct {
 	acpBase
+
+	// taskToolCalls holds the toolCallId of every `task` tool call the spawn
+	// hook claimed. The closing hook needs it: Cursor reports "this ran in the
+	// background" only in the final update's rawOutput, and the tool's identity
+	// only in rawInput, which that update does not always carry. Without the
+	// note, a backgrounded task and a backgrounded shell are the same wire
+	// shape.
+	//
+	// Guarded by acpBase's mu, which neither handleToolCall nor
+	// handleToolCallUpdate holds while it calls a hook, so the hooks can take it.
+	// An entry is dropped on the final update. A `task` call that never reaches
+	// one keeps its entry -- one bool and one id -- for the life of the agent,
+	// which matches how acpBase's subagentPrompts holds a spawn's prompt.
+	taskToolCalls map[string]bool
+}
+
+// clearTaskToolCalls drops every note. ClearContext calls it: the notes are
+// keyed by the OUTGOING session's tool-call ids, which send no closing update
+// once that session is gone, and a new session that reuses an id would read a
+// stale note and file a backgrounded shell as a subagent.
+func (a *CursorCLIAgent) clearTaskToolCalls() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	clear(a.taskToolCalls)
+}
+
+// rememberTaskToolCall notes that toolCallID is Cursor's `task` tool.
+func (a *CursorCLIAgent) rememberTaskToolCall(toolCallID string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.taskToolCalls == nil {
+		a.taskToolCalls = make(map[string]bool)
+	}
+	a.taskToolCalls[toolCallID] = true
+}
+
+// forgetTaskToolCall drops the note for toolCallID and reports whether one was
+// there. The call is over when this runs, so the entry cannot accumulate.
+func (a *CursorCLIAgent) forgetTaskToolCall(toolCallID string) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	was := a.taskToolCalls[toolCallID]
+	delete(a.taskToolCalls, toolCallID)
+	return was
+}
+
+// spawnObservation runs Cursor's spawn detector and remembers what it claimed,
+// so the closing hook does not have to ask the wire a second time.
+//
+// A tool call that arrives ALREADY final gets no note. handleToolCall applies
+// this observation and returns, so no closing update follows to drop one --
+// a `session/load` replay of a finished task would leave an entry for the life
+// of the agent, and a later call that reuses the id would read it and file a
+// backgrounded shell as a subagent. The note has no reader on that path either:
+// this observation already carries the kind and the title.
+func (a *CursorCLIAgent) spawnObservation(tc acpToolCallEnvelope) *acpSubagentObservation {
+	obs := cursorSubagentFromToolCall(tc)
+	if obs != nil && !acpStatusIsFinal(tc.Status) {
+		a.rememberTaskToolCall(tc.ToolCallID)
+	}
+	return obs
+}
+
+// finishedObservation answers "was this the task tool" from the tool call
+// itself, and falls back to the note the spawn left when this update carries no
+// input of its own.
+func (a *CursorCLIAgent) finishedObservation(tcu acpToolCallUpdateEnvelope) *acpSubagentObservation {
+	wasTaskTool := cursorToolCallIsTaskTool(tcu.RawInput)
+	// The row is over on a final status, so drop the note whatever it said.
+	if acpStatusIsFinal(tcu.Status) && a.forgetTaskToolCall(tcu.ToolCallID) {
+		wasTaskTool = true
+	}
+	return cursorSubagentFromToolCallUpdate(tcu, wasTaskTool)
 }
 
 // StartCursorCLI starts a Cursor CLI ACP agent process and performs the handshake.
@@ -52,8 +125,9 @@ func StartCursorCLI(ctx context.Context, opts Options, sink OutputSink) (Agent, 
 			// Registry-only -- Cursor exposes no child-session metadata. The observed
 			// toolCallId can contain an embedded newline; the neutral layer sanitizes
 			// the row key.
-			a.subagentFromToolCall = cursorSubagentFromToolCall
-			a.subagentFromToolCallUpdate = cursorSubagentFromToolCallUpdate
+			a.subagentFromToolCall = a.spawnObservation
+			a.subagentFromToolCallUpdate = a.finishedObservation
+			a.clearProviderState = a.clearTaskToolCalls
 		},
 		afterHandshake: func(a *CursorCLIAgent, handshake *acpSessionResult, opts Options) error {
 			return a.applyPermissionModeStartup(handshake, opts, CursorCLIModeAgent, normalizeCursorModelID(opts.Model()))
@@ -281,17 +355,19 @@ func cursorSubagentFromToolCall(tc acpToolCallEnvelope) *acpSubagentObservation 
 		RowKey: tc.ToolCallID,
 		Title:  title,
 		Status: bgtask.StatusRunning,
+		Spawns: true,
 	}
 }
 
 // cursorToolCallIsTaskTool reports whether a Cursor tool call is the `task`
-// delegation tool, which is the only Cursor tool that spawns a subagent. Both
-// hooks below key off this one definition: the spawn hook to open the row, the
-// closing hook to keep itself from reclassifying that row as a shell.
+// delegation tool, which is the only Cursor tool that spawns a subagent. It
+// reads ONE payload, so it answers only for a payload that carries the input.
 //
-// Returns false for an absent rawInput, which is the honest answer -- Cursor
-// does not always echo the input on an update, and "not known to be the task
-// tool" is what the callers need.
+// An absent rawInput gives false, which means "this payload does not say it is
+// the task tool" and NOT "this call is not the task tool". Cursor does not
+// always echo the input on an update, so the closing hook must not treat the
+// two as the same: finishedObservation falls back to the note the spawn left
+// (taskToolCalls) before it classifies a backgrounded call as a shell.
 func cursorToolCallIsTaskTool(rawInput json.RawMessage) bool {
 	if len(rawInput) == 0 {
 		return false
@@ -320,19 +396,22 @@ func cursorToolCallRanInBackground(rawOutput json.RawMessage) bool {
 // create a spurious row. A backgrounded call carries an activity line and
 // upserts before closing.
 //
-// A backgrounded call is a SHELL unless the input says it is the `task` tool.
-// Cursor's other tools are not subagents, and the neutral layer defaults a
-// blank kind to Subagent -- so leaving the kind blank here put a shell in the
-// sidebar under a Bot icon, in the subagent filter tab, labelled with its raw
-// toolCallId. The task-tool arm leaves BOTH the kind and the title blank on
-// purpose: the spawn observation already set them, and Item.PreservingBlanksFrom
-// keeps an existing value only for a blank incoming one. Writing them here
-// would flip a real subagent row to a shell and overwrite its trimmed title
-// with the raw "Task: ..." string.
-func cursorSubagentFromToolCallUpdate(tcu acpToolCallUpdateEnvelope) *acpSubagentObservation {
-	switch tcu.Status {
-	case "completed", "failed", "cancelled":
-	default:
+// A backgrounded call is a SHELL unless it is the `task` tool. Cursor's other
+// tools are not subagents, and the neutral layer defaults a blank kind to
+// Subagent -- so leaving the kind blank here put a shell in the sidebar under a
+// Bot icon, in the subagent filter tab, labelled with its raw toolCallId. The
+// task-tool arm leaves BOTH the kind and the title blank on purpose: the spawn
+// observation already set them, and Item.PreservingBlanksFrom keeps an existing
+// value only for a blank incoming one. Writing them here would flip a real
+// subagent row to a shell and overwrite its trimmed title with the raw
+// "Task: ..." string.
+//
+// wasTaskTool comes from the caller, not from tcu, because this update does not
+// always carry rawInput. Reading the identity off tcu alone made an absent
+// rawInput mean "not the task tool", so a backgrounded task whose final update
+// omitted its input took the shell arm and flipped its own live row.
+func cursorSubagentFromToolCallUpdate(tcu acpToolCallUpdateEnvelope, wasTaskTool bool) *acpSubagentObservation {
+	if !acpStatusIsFinal(tcu.Status) {
 		return nil
 	}
 	obs := &acpSubagentObservation{
@@ -346,7 +425,7 @@ func cursorSubagentFromToolCallUpdate(tcu acpToolCallUpdateEnvelope) *acpSubagen
 	}
 	obs.Mode = acpModeUpsert
 	obs.Activity = "background task"
-	if !cursorToolCallIsTaskTool(tcu.RawInput) {
+	if !wasTaskTool {
 		obs.Kind = bgtask.KindShell
 		// This update is the row's only event, so it is also the only chance to
 		// give it a readable label. Without one the sidebar shows the raw

--- a/backend/internal/worker/agent/cursor_test.go
+++ b/backend/internal/worker/agent/cursor_test.go
@@ -463,3 +463,70 @@ func TestPiNonReasoningEffortsUseSharedLabels(t *testing.T) {
 		assert.Equal(t, effortLabel(tier.Id), tier.Name, "effort %q must use the shared label", tier.Id)
 	}
 }
+
+// ClearContext replaces the session, so every note keyed by the OUTGOING
+// session's tool-call ids must go with it. A surviving note would classify a
+// backgrounded shell in the NEW session as a subagent, if that session ever
+// reused the id.
+//
+// Driven through the real ClearContext rather than by calling the hook
+// directly, because the wiring -- Cursor registering clearProviderState, and
+// acpBase invoking it -- is the part that can silently go missing.
+func TestCursorClearContextDropsTheTaskToolNotes(t *testing.T) {
+	t.Parallel()
+
+	agent, _ := newCursorAgentForRPCWithResponder(t, func(method string) json.RawMessage {
+		if method == acpMethodSessionNew {
+			return json.RawMessage(`{"sessionId": "session-2"}`)
+		}
+		return json.RawMessage(`{}`)
+	})
+	agent.sink = &testSink{}
+	agent.subagentFromToolCall = agent.spawnObservation
+	agent.subagentFromToolCallUpdate = agent.finishedObservation
+	agent.clearProviderState = agent.clearTaskToolCalls
+
+	// A task tool call is in flight when the user clears the context.
+	agent.handleToolCall(json.RawMessage(`{"toolCallId":"call-task","kind":"other","title":"Task: go","rawInput":{"_toolName":"task"}}`))
+	agent.mu.Lock()
+	before := len(agent.taskToolCalls)
+	agent.mu.Unlock()
+	require.Equal(t, 1, before, "the in-flight task left a note")
+
+	sessionID, ok := agent.ClearContext()
+	require.True(t, ok)
+	require.Equal(t, "session-2", sessionID)
+
+	agent.mu.Lock()
+	after := len(agent.taskToolCalls)
+	agent.mu.Unlock()
+	assert.Zero(t, after, "the outgoing session's notes went with it")
+}
+
+// The same clear must not run when the session was NOT replaced: a failed
+// session/new leaves the old session live, and its in-flight task calls still
+// report against the notes.
+func TestCursorFailedClearContextKeepsTheTaskToolNotes(t *testing.T) {
+	t.Parallel()
+
+	agent, _ := newCursorAgentForRPC(t)
+	agent.sink = &testSink{}
+	agent.subagentFromToolCall = agent.spawnObservation
+	agent.clearProviderState = agent.clearTaskToolCalls
+	agent.handleToolCall(json.RawMessage(`{"toolCallId":"call-task","kind":"other","title":"Task: go","rawInput":{"_toolName":"task"}}`))
+
+	// A cancelled context makes session/new fail, so the session survives.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	agent.ctx = ctx
+	agent.processDone = make(chan struct{})
+	close(agent.processDone)
+
+	_, ok := agent.ClearContext()
+	require.False(t, ok, "session/new must fail without a live agent")
+
+	agent.mu.Lock()
+	after := len(agent.taskToolCalls)
+	agent.mu.Unlock()
+	assert.Equal(t, 1, after, "the session was not replaced, so the note still applies")
+}

--- a/backend/internal/worker/agent/goose.go
+++ b/backend/internal/worker/agent/goose.go
@@ -99,6 +99,7 @@ func gooseSubagentFromToolCall(tc acpToolCallEnvelope) *acpSubagentObservation {
 		RowKey: tc.ToolCallID,
 		Title:  title,
 		Status: bgtask.StatusRunning,
+		Spawns: true,
 		// Goose's delegate tool puts its task text in `instructions`, not `prompt`
 		// (crates/goose/src/agents/platform_extensions/summon.rs). The child
 		// transcript is created later, on the first forwarded tool request, so
@@ -143,7 +144,7 @@ func gooseSubagentFromToolCallUpdate(tcu acpToolCallUpdateEnvelope) *acpSubagent
 	// (by the tool_call or a tool-request) under this toolCallId, so closing on
 	// the final update is correct. CloseRow is idempotent: a plain tool with
 	// no registry row is a no-op (the upsert path finds no row to close).
-	if tcu.Status == "completed" || tcu.Status == "failed" || tcu.Status == "cancelled" {
+	if acpStatusIsFinal(tcu.Status) {
 		return &acpSubagentObservation{
 			RowKey:   tcu.ToolCallID,
 			Status:   acpFinalStatus(tcu.Status),

--- a/backend/internal/worker/agent/opencode.go
+++ b/backend/internal/worker/agent/opencode.go
@@ -126,6 +126,7 @@ func openCodeSpawnObservation(toolCallID, callTitle string, rawInput json.RawMes
 		RowKey: toolCallID,
 		Title:  title,
 		Status: bgtask.StatusRunning,
+		Spawns: true,
 	}
 }
 
@@ -135,7 +136,7 @@ func openCodeSpawnObservation(toolCallID, callTitle string, rawInput json.RawMes
 // The spawn row was opened under the toolCallId, so SpawnRowKey carries it to
 // keep the close from leaking it as a Running row.
 func openCodeSubagentFromToolCallUpdate(tcu acpToolCallUpdateEnvelope) *acpSubagentObservation {
-	if tcu.Status != "completed" && tcu.Status != "failed" && tcu.Status != "cancelled" {
+	if !acpStatusIsFinal(tcu.Status) {
 		// Not final: this is where Kilo first reveals the spawn shape (its
 		// tool_call carries `rawInput: {}`), so run the same detection here.
 		// Without it a Kilo spawn produced no registry row at all -- the

--- a/backend/internal/worker/agent/pi_output.go
+++ b/backend/internal/worker/agent/pi_output.go
@@ -267,22 +267,13 @@ func (a *PiAgent) handlePiToolExecutionStart(raw []byte) {
 	// A subagent spawn owns no span, so it reserves no color either. The
 	// subagent's output lands in its own child transcript, so a rail held open
 	// for the whole run only pushes every concurrent tool one column right.
+	//
+	// Pi never reads the recorded span type back -- tool_execution_end carries
+	// its own toolName -- but openToolSpan records it for every provider, so a
+	// closing message that DOES read it (Claude, ACP) finds it.
 	spawns := env.ToolName == PiToolAgent
-	var spanColor int32
-	if !spawns {
-		spanColor = a.sink.ReserveSpanColor(env.ToolCallID, "")
-	}
-	if err := a.sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, raw, SpanInfo{
-		SpanID:    env.ToolCallID,
-		SpanType:  env.ToolName,
-		SpanColor: spanColor,
-	}); err != nil {
+	if err := openToolSpan(a.sink, raw, env.ToolCallID, env.ToolName, spawns); err != nil {
 		slog.Error("pi persist tool_execution_start", "agent_id", a.agentID, "error", err)
-	}
-	// The span type is recorded either way: tool_execution_end reads it back.
-	a.sink.SetSpanType(env.ToolCallID, env.ToolName)
-	if !spawns {
-		a.sink.OpenSpan(env.ToolCallID, "")
 	}
 }
 

--- a/backend/internal/worker/agent/pi_output.go
+++ b/backend/internal/worker/agent/pi_output.go
@@ -264,7 +264,14 @@ func (a *PiAgent) handlePiToolExecutionStart(raw []byte) {
 		a.mu.Unlock()
 	}
 
-	spanColor := a.sink.ReserveSpanColor(env.ToolCallID, "")
+	// A subagent spawn owns no span, so it reserves no color either. The
+	// subagent's output lands in its own child transcript, so a rail held open
+	// for the whole run only pushes every concurrent tool one column right.
+	spawns := env.ToolName == PiToolAgent
+	var spanColor int32
+	if !spawns {
+		spanColor = a.sink.ReserveSpanColor(env.ToolCallID, "")
+	}
 	if err := a.sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, raw, SpanInfo{
 		SpanID:    env.ToolCallID,
 		SpanType:  env.ToolName,
@@ -272,8 +279,11 @@ func (a *PiAgent) handlePiToolExecutionStart(raw []byte) {
 	}); err != nil {
 		slog.Error("pi persist tool_execution_start", "agent_id", a.agentID, "error", err)
 	}
+	// The span type is recorded either way: tool_execution_end reads it back.
 	a.sink.SetSpanType(env.ToolCallID, env.ToolName)
-	a.sink.OpenSpan(env.ToolCallID, "")
+	if !spawns {
+		a.sink.OpenSpan(env.ToolCallID, "")
+	}
 }
 
 // handlePiToolExecutionUpdate ships only the new text added since the

--- a/backend/internal/worker/agent/pi_output_test.go
+++ b/backend/internal/worker/agent/pi_output_test.go
@@ -813,7 +813,7 @@ func TestHandlePiOutput_ToolUpdateDetailsUpsertsSubagentActivity(t *testing.T) {
 	// A tool_execution_start records the spawn prompt as the title (read from
 	// the `input` field) so the subagent row has a label.
 	handlePiOutput(a, parseLine([]byte(
-		`{"type":"tool_execution_start","toolCallId":"call-sub-1","toolName":"Task","input":{"description":"build the feature","prompt":"build it"}}`)))
+		`{"type":"tool_execution_start","toolCallId":"call-sub-1","toolName":"Agent","input":{"description":"build the feature","prompt":"build it"}}`)))
 
 	// An update whose partialResult.details carries the subagent shape.
 	handlePiOutput(a, parseLine([]byte(
@@ -838,7 +838,7 @@ func TestHandlePiOutput_ToolUpdateDetails_FallsBackToToolCallID(t *testing.T) {
 	a := newPiAgentWithSink(sink)
 
 	handlePiOutput(a, parseLine([]byte(
-		`{"type":"tool_execution_start","toolCallId":"call-no-id","toolName":"Task","input":{"description":"work"}}`)))
+		`{"type":"tool_execution_start","toolCallId":"call-no-id","toolName":"Agent","input":{"description":"work"}}`)))
 
 	handlePiOutput(a, parseLine([]byte(
 		`{"type":"tool_execution_update","toolCallId":"call-no-id","partialResult":{"content":[{"type":"text","text":"x\n"}],"details":{"status":"running","activity":"thinking"}}}`)))
@@ -860,7 +860,7 @@ func TestHandlePiOutput_ToolEndBackgroundRekeysToAgentID(t *testing.T) {
 
 	// Seed a running row keyed by toolCallId.
 	handlePiOutput(a, parseLine([]byte(
-		`{"type":"tool_execution_start","toolCallId":"call-bg","toolName":"Task","input":{"description":"bg work"}}`)))
+		`{"type":"tool_execution_start","toolCallId":"call-bg","toolName":"Agent","input":{"description":"bg work"}}`)))
 	handlePiOutput(a, parseLine([]byte(
 		`{"type":"tool_execution_update","toolCallId":"call-bg","partialResult":{"content":[{"type":"text","text":"x\n"}],"details":{"status":"running","activity":"starting"}}}`)))
 
@@ -868,7 +868,7 @@ func TestHandlePiOutput_ToolEndBackgroundRekeysToAgentID(t *testing.T) {
 	// status:"background" + agentId. piApplySubagentEnd unmarshals the result
 	// directly as the details shape.
 	handlePiOutput(a, parseLine([]byte(
-		`{"type":"tool_execution_end","toolCallId":"call-bg","toolName":"Task","result":{"status":"background","agentId":"agent-bg-1"}}`)))
+		`{"type":"tool_execution_end","toolCallId":"call-bg","toolName":"Agent","result":{"status":"background","agentId":"agent-bg-1"}}`)))
 
 	tasks := sink.BackgroundTasks()
 	// Two rows: the old toolCallId row closed (Completed) and the new
@@ -906,7 +906,7 @@ func TestHandlePiOutput_SubagentNotificationMessageClosesRegistryEntry(t *testin
 	// Seed a running subagent row keyed by agentId (the notification carries
 	// agentId, not toolCallId).
 	handlePiOutput(a, parseLine([]byte(
-		`{"type":"tool_execution_start","toolCallId":"call-notif","toolName":"Task","args":{"description":"notif task"}}`)))
+		`{"type":"tool_execution_start","toolCallId":"call-notif","toolName":"Agent","args":{"description":"notif task"}}`)))
 	handlePiOutput(a, parseLine([]byte(
 		`{"type":"tool_execution_update","toolCallId":"call-notif","partialResult":{"content":[{"type":"text","text":"x\n"}],"details":{"status":"running","activity":"busy","agentId":"agent-notif-1"}}}`)))
 	require.Len(t, sink.BackgroundTasks(), 1)

--- a/backend/internal/worker/agent/pi_output_test.go
+++ b/backend/internal/worker/agent/pi_output_test.go
@@ -274,6 +274,11 @@ func TestHandlePiOutput_ToolExecutionLifecycle(t *testing.T) {
 	endRaw := []byte(`{"type":"tool_execution_end","toolCallId":"call-1","toolName":"bash","result":{"content":[{"type":"text","text":"file1\nfile2\n"}],"details":{"exitCode":0}},"isError":false}`)
 
 	handlePiOutput(a, parseLine(startRaw))
+	// SetSpanType is recorded at the start, and asserted here rather than at the
+	// end of the test: the close below ends the span, and an ended span forgets
+	// its type.
+	assert.Equal(t, "bash", sink.GetSpanType("call-1"))
+
 	handlePiOutput(a, parseLine(updateRaw))
 	handlePiOutput(a, parseLine(endRaw))
 
@@ -299,9 +304,6 @@ func TestHandlePiOutput_ToolExecutionLifecycle(t *testing.T) {
 	assert.Equal(t, "file1\n", string(chunk.Content))
 	assert.Equal(t, 1, sink.StreamEndCount())
 	assert.Equal(t, "call-1", sink.LastStreamEnd())
-
-	// SetSpanType recorded.
-	assert.Equal(t, "bash", sink.GetSpanType("call-1"))
 
 	// Tool count incremented.
 	a.mu.Lock()

--- a/backend/internal/worker/agent/pi_protocol.go
+++ b/backend/internal/worker/agent/pi_protocol.go
@@ -69,6 +69,13 @@ const (
 	PiToolWrite = "write"
 )
 
+// PiToolAgent is the tool the pi-subagents extension registers to spawn a
+// subagent (SUBAGENT_TOOL_NAMES.AGENT in its src/agent-runner.ts; its nested
+// variant in src/nested-tools.ts reuses the same name). The extension's two
+// other tools, get_subagent_result and steer_subagent, act on an agent that
+// already runs and are ordinary tool spans, so they need no constant here.
+const PiToolAgent = "Agent"
+
 // Pi RPC command methods — the "type" field on JSONL commands the
 // worker writes to Pi's stdin. Pi replies with a matching {type:
 // "response", id} envelope.

--- a/backend/internal/worker/agent/pi_subagent_test.go
+++ b/backend/internal/worker/agent/pi_subagent_test.go
@@ -204,3 +204,77 @@ func TestPi_ApplySubagentEnd_FinalStatusWritesNoPrompt(t *testing.T) {
 	require.True(t, ok)
 	assert.Empty(t, child.Messages())
 }
+
+// --- A subagent spawn owns no span ---
+
+// pi-subagents registers its spawn tool as `Agent` (SUBAGENT_TOOL_NAMES.AGENT).
+// That call owns no span: the subagent's output lands in its own child
+// transcript, so a rail held open for the whole run only pushes every
+// concurrent tool one column right.
+func TestPi_AgentToolStartOpensNoSpan(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newPiAgentWithSink(sink)
+	handlePiOutput(a, parseLine([]byte(
+		`{"type":"tool_execution_start","toolCallId":"tc-spawn","toolName":"Agent","input":{"description":"explore","prompt":"look around"}}`)))
+
+	assert.Empty(t, sink.OpenSpans(), "a spawn opens no span")
+	assert.Empty(t, sink.ReservedColorSpans(), "and reserves no color")
+	assert.Equal(t, PiToolAgent, sink.GetSpanType("tc-spawn"),
+		"the span type is still recorded for tool_execution_end")
+
+	msgs := sink.Messages()
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "tc-spawn", msgs[0].SpanID, "the row still carries the span id")
+	assert.Empty(t, msgs[0].SpansOpenAtPersist, "nothing else was open, so no rail")
+}
+
+// Only the spawn loses its span. Every other Pi tool -- including the two
+// subagent-control tools, which act on an agent that already runs -- keeps one.
+func TestPi_NonSpawnToolsStillOpenASpan(t *testing.T) {
+	t.Parallel()
+
+	for _, toolName := range []string{PiToolBash, PiToolRead, "get_subagent_result", "steer_subagent"} {
+		t.Run(toolName, func(t *testing.T) {
+			t.Parallel()
+
+			sink := &testSink{}
+			a := newPiAgentWithSink(sink)
+			handlePiOutput(a, parseLine([]byte(
+				`{"type":"tool_execution_start","toolCallId":"tc-1","toolName":"`+toolName+`","input":{"prompt":"x"}}`)))
+
+			open := sink.OpenSpans()
+			require.Len(t, open, 1)
+			assert.Equal(t, "tc-1", open[0].SpanID)
+			assert.Equal(t, []string{"tc-1"}, sink.ReservedColorSpans())
+		})
+	}
+}
+
+// A spawn that starts while a bash call is running draws that call's rail and
+// nothing more -- one column, not two.
+func TestPi_SpawnInsideOpenToolDrawsOneColumn(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newPiAgentWithSink(sink)
+	handlePiOutput(a, parseLine([]byte(
+		`{"type":"tool_execution_start","toolCallId":"tc-bash","toolName":"bash","input":{"command":"ls"}}`)))
+	handlePiOutput(a, parseLine([]byte(
+		`{"type":"tool_execution_start","toolCallId":"tc-spawn","toolName":"Agent","input":{"prompt":"go"}}`)))
+	handlePiOutput(a, parseLine([]byte(
+		`{"type":"tool_execution_end","toolCallId":"tc-spawn","toolName":"Agent","result":{"status":"completed"}}`)))
+
+	msgs := sink.Messages()
+	require.Len(t, msgs, 3)
+	for i, msg := range msgs[1:] {
+		require.Len(t, msg.SpansOpenAtPersist, 1, "spawn row %d draws exactly one column", i)
+		assert.Equal(t, "tc-bash", msg.SpansOpenAtPersist[0].SpanID)
+	}
+	assert.True(t, msgs[2].Closing, "the end row is still a closer")
+
+	open := sink.OpenSpans()
+	require.Len(t, open, 1, "only the bash call ever opened a span")
+	assert.Equal(t, "tc-bash", open[0].SpanID)
+}

--- a/backend/internal/worker/agent/reasonix.go
+++ b/backend/internal/worker/agent/reasonix.go
@@ -130,8 +130,17 @@ func reasonixSubagentFromToolCall(tc acpToolCallEnvelope) *acpSubagentObservatio
 	if err := json.Unmarshal(tc.RawInput, &input); err != nil {
 		return nil
 	}
-	// Spawn shape = a prompt (optionally a description). No subagent_type.
-	if len(input.Prompt) == 0 && input.Description == "" {
+	// Spawn shape = a prompt (optionally a description). No subagent_type, so
+	// the prompt is the ONLY discriminator Reasonix supplies and it is required.
+	// Accepting a description alone made every ordinary tool that carries one a
+	// spawn, which now costs that tool its span as well as adding a false
+	// sidebar row.
+	//
+	// The raw form is tested, not the length: an absent prompt gives no bytes,
+	// but an explicit `null` gives four and an empty string gives two, and
+	// neither of those is a prompt.
+	switch string(input.Prompt) {
+	case "", "null", `""`:
 		return nil
 	}
 	title := tc.Title
@@ -150,5 +159,6 @@ func reasonixSubagentFromToolCall(tc acpToolCallEnvelope) *acpSubagentObservatio
 		RowKey: tc.ToolCallID,
 		Title:  title,
 		Status: bgtask.StatusRunning,
+		Spawns: true,
 	}
 }

--- a/backend/internal/worker/agent/sink_test.go
+++ b/backend/internal/worker/agent/sink_test.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"encoding/json"
-	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -10,6 +9,7 @@ import (
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/util/optionmap"
 	"github.com/leapmux/leapmux/internal/worker/bgtask"
+	"github.com/leapmux/leapmux/internal/worker/spantrack"
 )
 
 // testSinkSettingsRefreshed records the args of a PersistSettingsRefresh call.
@@ -28,6 +28,9 @@ type testSinkModeChange struct {
 
 // testSink is a test implementation of OutputSink that records calls.
 type testSink struct {
+	// persistErr, when set, is what PersistMessage returns. Read without the
+	// lock: a test sets it at construction and never changes it afterwards.
+	persistErr         error
 	mu                 sync.Mutex
 	messages           []testSinkMessage
 	notifications      []testSinkMessage
@@ -38,14 +41,12 @@ type testSink struct {
 	modeChanges        []testSinkModeChange
 	settingsRefreshes  []testSinkSettingsRefreshed
 	sessionInfos       []map[string]interface{}
-	spanTypes          map[string]string
 	openSpans          []testSinkSpanOpen
 	closedSpans        []string
-	discardedSpans     []string
-	reservedColorSpans []string
-	// liveSpans is the CURRENTLY-open subset of openSpans (a close, a discard,
-	// or a reset removes entries), mirroring the real SpanTracker's active set.
-	liveSpans        []testSinkSpanOpen
+	reservedColorSpans []testSinkSpanOpen
+	// tracker is the REAL span engine. Delegating to it is what keeps this
+	// double from drifting from the behavior it stands in for.
+	tracker          spantrack.SpanTracker
 	resetSpanCount   int
 	statusActives    []string
 	autoSchedules    []AutoContinueSchedule
@@ -75,7 +76,12 @@ type testSinkMessage struct {
 	SpanID          string
 	SpanType        string
 	Closing         bool
+	SpanColor       int32
 	MarkType        leapmuxv1.MarkType
+	// NoSpan mirrors SpanInfo.NoSpan: the row carries a span id but owns no
+	// span, so its span_color of 0 is the answer and the persist path must not
+	// fill it from the connector.
+	NoSpan bool
 	// TurnEnd is set on entries recorded by PersistTurnEnd so tests can
 	// distinguish the turn-end divider from regular AGENT messages
 	// without inspecting the inner content.
@@ -99,20 +105,30 @@ type testSinkSpanOpen struct {
 	ParentSpanID string
 }
 
-// liveSpansLocked copies the spans currently open on this sink. Must be called
-// with s.mu held.
+// liveSpansLocked snapshots the spans the REAL tracker holds open, in column
+// order. The service layer derives a row's span_lines from exactly that state,
+// so this is the observable that pins the ordering rule a provider must follow.
 func (s *testSink) liveSpansLocked() []testSinkSpanOpen {
-	if len(s.liveSpans) == 0 {
+	active := s.tracker.ActiveSpans()
+	if len(active) == 0 {
 		return nil
 	}
-	return append([]testSinkSpanOpen(nil), s.liveSpans...)
+	open := make([]testSinkSpanOpen, 0, len(active))
+	for _, a := range active {
+		open = append(open, testSinkSpanOpen{SpanID: a.SpanID, ParentSpanID: s.tracker.ParentOf(a.SpanID)})
+	}
+	return open
 }
 
+// PersistMessage records the row. Set persistErr to make it fail, which is the
+// only way to exercise a caller's error path: every caller LOGS the error and
+// carries on, so a test that cannot make the persist fail cannot tell "carries
+// on" from "returns early".
 func (s *testSink) PersistMessage(source leapmuxv1.MessageSource, content []byte, span SpanInfo) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.messages = append(s.messages, testSinkMessage{Source: source, Content: append([]byte(nil), content...), ParentSpanID: span.ParentSpanID, ConnectorSpanID: span.ConnectorSpanID, SpanID: span.SpanID, SpanType: span.SpanType, Closing: span.Closing, MarkType: span.MarkType, SpansOpenAtPersist: s.liveSpansLocked()})
-	return nil
+	s.messages = append(s.messages, testSinkMessage{Source: source, Content: append([]byte(nil), content...), ParentSpanID: span.ParentSpanID, ConnectorSpanID: span.ConnectorSpanID, SpanID: span.SpanID, SpanType: span.SpanType, Closing: span.Closing, SpanColor: span.SpanColor, MarkType: span.MarkType, NoSpan: span.NoSpan, SpansOpenAtPersist: s.liveSpansLocked()})
+	return s.persistErr
 }
 
 func (s *testSink) PersistTurnEnd(content []byte, span SpanInfo) error {
@@ -140,71 +156,76 @@ func (s *testSink) PersistNotification(source leapmuxv1.MessageSource, content [
 	return !s.notifSuppressBroadcast, nil
 }
 
+// The span methods DELEGATE to a real SpanTracker rather than re-implementing
+// it. The double used to keep its own active set and span-type map, which drifted
+// from the engine twice: a closed span kept its type here after the tracker
+// stopped keeping it, and again after it started. Recording slices stay
+// alongside, because a test still wants to assert WHICH calls were made.
 func (s *testSink) OpenSpan(spanID string, parentSpanID string) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-	open := testSinkSpanOpen{SpanID: spanID, ParentSpanID: parentSpanID}
-	s.openSpans = append(s.openSpans, open)
-	// liveSpans mirrors the real SpanTracker's active set (open minus close
-	// minus reset), which is what SpansOpenAtPersist snapshots. openSpans stays
-	// a cumulative log so existing assertions about "was ever opened" hold.
-	s.liveSpans = append(s.liveSpans, open)
-}
-func (s *testSink) CloseSpan(spanID string) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.closedSpans = append(s.closedSpans, spanID)
-	s.liveSpans = slices.DeleteFunc(s.liveSpans, func(o testSinkSpanOpen) bool {
-		return o.SpanID == spanID
-	})
+	s.openSpans = append(s.openSpans, testSinkSpanOpen{SpanID: spanID, ParentSpanID: parentSpanID})
+	s.mu.Unlock()
+	s.tracker.OpenSpan(spanID, parentSpanID)
 }
 
-// DiscardSpan mirrors the real tracker: the span leaves the active set but its
-// recorded type survives, unlike CloseSpan.
-func (s *testSink) DiscardSpan(spanID string) {
+func (s *testSink) CloseSpan(spanID string) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.discardedSpans = append(s.discardedSpans, spanID)
-	s.liveSpans = slices.DeleteFunc(s.liveSpans, func(o testSinkSpanOpen) bool {
-		return o.SpanID == spanID
-	})
+	s.closedSpans = append(s.closedSpans, spanID)
+	s.mu.Unlock()
+	s.tracker.CloseSpan(spanID)
 }
+
 func (s *testSink) ResetSpans() {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	s.resetSpanCount++
-	s.liveSpans = nil
+	s.mu.Unlock()
+	s.tracker.Reset()
 }
+
 func (s *testSink) SetSpanType(spanID, spanType string) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.spanTypes == nil {
-		s.spanTypes = make(map[string]string)
-	}
-	s.spanTypes[spanID] = spanType
+	s.tracker.SetSpanType(spanID, spanType)
 }
 
 func (s *testSink) GetSpanType(spanID string) string {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.spanTypes[spanID]
+	return s.tracker.GetSpanType(spanID)
 }
 
-// ReserveSpanColor records which spans asked for a color. A span that never
-// opens must never reserve one either: the real tracker parks the reservation
-// on its single pending slot, which blocks that color from the next real span.
+// ReserveSpanColor records which spans asked for a color, and under which
+// parent. A span that never opens must never reserve one either: the real
+// tracker parks the reservation on its single pending slot, which blocks that
+// color from the next real span. The parent is recorded because it decides the
+// column the reservation is computed for, and the child transcript reserves
+// under the spawn span rather than at the root.
 func (s *testSink) ReserveSpanColor(spanID, parentSpanID string) int32 {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.reservedColorSpans = append(s.reservedColorSpans, spanID)
-	return 0
+	s.reservedColorSpans = append(s.reservedColorSpans, testSinkSpanOpen{SpanID: spanID, ParentSpanID: parentSpanID})
+	s.mu.Unlock()
+	// Delegated, so the reservation really is parked on the tracker's single
+	// pending slot: a span that reserves and never opens then blocks that color
+	// exactly as it would in production.
+	return s.tracker.ReserveSpanColor(spanID, parentSpanID)
 }
 
 // ReservedColorSpans returns a copy of the span IDs that reserved a color.
 func (s *testSink) ReservedColorSpans() []string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return append([]string(nil), s.reservedColorSpans...)
+	ids := make([]string, 0, len(s.reservedColorSpans))
+	for _, r := range s.reservedColorSpans {
+		ids = append(ids, r.SpanID)
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	return ids
+}
+
+// ReservedColors returns each reservation with the parent span it was made
+// under.
+func (s *testSink) ReservedColors() []testSinkSpanOpen {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]testSinkSpanOpen(nil), s.reservedColorSpans...)
 }
 
 func (s *testSink) BroadcastStreamChunk(content []byte, spanID string, method string) {
@@ -669,13 +690,6 @@ func (s *testSink) ClosedSpanCount() int {
 	return len(s.closedSpans)
 }
 
-// DiscardedSpans returns a copy of all discarded span IDs.
-func (s *testSink) DiscardedSpans() []string {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return append([]string(nil), s.discardedSpans...)
-}
-
 func (s *testSink) ResetSpanCount() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -717,7 +731,6 @@ func (noopSink) PersistTurnEnd([]byte, SpanInfo) error                          
 func (noopSink) PersistNotification(leapmuxv1.MessageSource, []byte) (bool, error) { return true, nil }
 func (noopSink) OpenSpan(string, string)                                           {}
 func (noopSink) CloseSpan(string)                                                  {}
-func (noopSink) DiscardSpan(string)                                                {}
 func (noopSink) ResetSpans()                                                       {}
 func (noopSink) SetSpanType(string, string)                                        {}
 func (noopSink) GetSpanType(string) string                                         { return "" }

--- a/backend/internal/worker/agent/sink_test.go
+++ b/backend/internal/worker/agent/sink_test.go
@@ -28,21 +28,23 @@ type testSinkModeChange struct {
 
 // testSink is a test implementation of OutputSink that records calls.
 type testSink struct {
-	mu                sync.Mutex
-	messages          []testSinkMessage
-	notifications     []testSinkMessage
-	streamChunks      []testSinkStreamChunk
-	streamEnds        []string
-	sessionIDs        []string
-	permissionModes   []string
-	modeChanges       []testSinkModeChange
-	settingsRefreshes []testSinkSettingsRefreshed
-	sessionInfos      []map[string]interface{}
-	spanTypes         map[string]string
-	openSpans         []testSinkSpanOpen
-	closedSpans       []string
-	// liveSpans is the CURRENTLY-open subset of openSpans (a close or a reset
-	// removes entries), mirroring the real SpanTracker's active set.
+	mu                 sync.Mutex
+	messages           []testSinkMessage
+	notifications      []testSinkMessage
+	streamChunks       []testSinkStreamChunk
+	streamEnds         []string
+	sessionIDs         []string
+	permissionModes    []string
+	modeChanges        []testSinkModeChange
+	settingsRefreshes  []testSinkSettingsRefreshed
+	sessionInfos       []map[string]interface{}
+	spanTypes          map[string]string
+	openSpans          []testSinkSpanOpen
+	closedSpans        []string
+	discardedSpans     []string
+	reservedColorSpans []string
+	// liveSpans is the CURRENTLY-open subset of openSpans (a close, a discard,
+	// or a reset removes entries), mirroring the real SpanTracker's active set.
 	liveSpans        []testSinkSpanOpen
 	resetSpanCount   int
 	statusActives    []string
@@ -156,6 +158,17 @@ func (s *testSink) CloseSpan(spanID string) {
 		return o.SpanID == spanID
 	})
 }
+
+// DiscardSpan mirrors the real tracker: the span leaves the active set but its
+// recorded type survives, unlike CloseSpan.
+func (s *testSink) DiscardSpan(spanID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.discardedSpans = append(s.discardedSpans, spanID)
+	s.liveSpans = slices.DeleteFunc(s.liveSpans, func(o testSinkSpanOpen) bool {
+		return o.SpanID == spanID
+	})
+}
 func (s *testSink) ResetSpans() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -177,7 +190,22 @@ func (s *testSink) GetSpanType(spanID string) string {
 	return s.spanTypes[spanID]
 }
 
-func (s *testSink) ReserveSpanColor(spanID, parentSpanID string) int32 { return 0 }
+// ReserveSpanColor records which spans asked for a color. A span that never
+// opens must never reserve one either: the real tracker parks the reservation
+// on its single pending slot, which blocks that color from the next real span.
+func (s *testSink) ReserveSpanColor(spanID, parentSpanID string) int32 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.reservedColorSpans = append(s.reservedColorSpans, spanID)
+	return 0
+}
+
+// ReservedColorSpans returns a copy of the span IDs that reserved a color.
+func (s *testSink) ReservedColorSpans() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.reservedColorSpans...)
+}
 
 func (s *testSink) BroadcastStreamChunk(content []byte, spanID string, method string) {
 	s.mu.Lock()
@@ -641,6 +669,13 @@ func (s *testSink) ClosedSpanCount() int {
 	return len(s.closedSpans)
 }
 
+// DiscardedSpans returns a copy of all discarded span IDs.
+func (s *testSink) DiscardedSpans() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.discardedSpans...)
+}
+
 func (s *testSink) ResetSpanCount() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -682,6 +717,7 @@ func (noopSink) PersistTurnEnd([]byte, SpanInfo) error                          
 func (noopSink) PersistNotification(leapmuxv1.MessageSource, []byte) (bool, error) { return true, nil }
 func (noopSink) OpenSpan(string, string)                                           {}
 func (noopSink) CloseSpan(string)                                                  {}
+func (noopSink) DiscardSpan(string)                                                {}
 func (noopSink) ResetSpans()                                                       {}
 func (noopSink) SetSpanType(string, string)                                        {}
 func (noopSink) GetSpanType(string) string                                         { return "" }

--- a/backend/internal/worker/service/connector_span_test.go
+++ b/backend/internal/worker/service/connector_span_test.go
@@ -1,0 +1,85 @@
+package service
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// resolveConnectorSpanID stays in this package: it decides which span a
+// persisted row visually connects to, which is a persist-path concern rather
+// than span-engine state. Its tests followed it here when the engine moved to
+// the spantrack package.
+
+func TestSpanTracker_ToolUseConnectorInSubagent(t *testing.T) {
+	t.Parallel()
+
+	// When a tool_use message is emitted inside a subagent, the tool_use's
+	// own span hasn't been opened yet (it opens after persist). The parent
+	// subagent span IS active. The span line for the subagent should render
+	// as "connector" (├), not "active" (│).
+	tracker := &SpanTracker{}
+	tracker.OpenSpan("subagent", "")
+
+	// Simulate persistAndBroadcast for a tool_use inside the subagent:
+	//   span.SpanID       = "tool-1"  (not yet open)
+	//   span.ParentSpanID = "subagent" (already open)
+	//   span.Closing      = false
+	connectorSpanID := resolveConnectorSpanID("tool-1", "", "subagent", false)
+	_, lines, _ := tracker.Snapshot("subagent", connectorSpanID, false)
+
+	var parsed []*SpanLine
+	require.NoError(t, json.Unmarshal([]byte(lines), &parsed))
+	require.Len(t, parsed, 1)
+	assert.Equal(t, SpanLineConnector, parsed[0].Type,
+		"tool_use inside subagent should show connector to parent span")
+}
+
+func TestSpanTracker_ToolResultConnectorInSubagent(t *testing.T) {
+	t.Parallel()
+
+	// A tool_result (closing) message should still connect to the tool's
+	// own span, not the parent — the span is open at this point.
+	tracker := &SpanTracker{}
+	tracker.OpenSpan("subagent", "")
+	tracker.OpenSpan("tool-1", "subagent")
+
+	connectorSpanID := resolveConnectorSpanID("tool-1", "", "subagent", true)
+	_, lines, _ := tracker.Snapshot("subagent", connectorSpanID, true)
+
+	var parsed []*SpanLine
+	require.NoError(t, json.Unmarshal([]byte(lines), &parsed))
+	require.Len(t, parsed, 2)
+	assert.Equal(t, SpanLineActive, parsed[0].Type)
+	assert.Equal(t, SpanLineConnectorEnd, parsed[1].Type,
+		"tool_result should show connector_end on its own span")
+}
+
+func TestSpanTracker_TopLevelToolUseNoConnector(t *testing.T) {
+	t.Parallel()
+
+	// A top-level tool_use (no parent span) should have no connector.
+	tracker := &SpanTracker{}
+
+	connectorSpanID := resolveConnectorSpanID("tool-1", "", "", false)
+	_, lines, _ := tracker.Snapshot("", connectorSpanID, false)
+	assert.Equal(t, "[]", lines)
+}
+
+func TestSpanTracker_ExplicitClosingConnectorUsesOverride(t *testing.T) {
+	t.Parallel()
+
+	tracker := &SpanTracker{}
+	tracker.OpenSpan("subagent", "")
+
+	connectorSpanID := resolveConnectorSpanID("wait-1", "subagent", "", true)
+	_, lines, _ := tracker.Snapshot("", connectorSpanID, true)
+
+	var parsed []*SpanLine
+	require.NoError(t, json.Unmarshal([]byte(lines), &parsed))
+	require.Len(t, parsed, 1)
+	assert.Equal(t, SpanLineConnectorEnd, parsed[0].Type,
+		"explicit connector override should let a spanless message close its parent span")
+}

--- a/backend/internal/worker/service/output.go
+++ b/backend/internal/worker/service/output.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"math/rand/v2"
 	"os"
 	"slices"
 	"sort"
@@ -28,480 +27,28 @@ import (
 	"github.com/leapmux/leapmux/internal/worker/agent"
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
 	"github.com/leapmux/leapmux/internal/worker/gitutil"
+	"github.com/leapmux/leapmux/internal/worker/spantrack"
 	"github.com/leapmux/leapmux/internal/worker/todoevents"
 	"github.com/leapmux/leapmux/internal/worker/wakelock"
 )
 
-// --- Span Tracker ---
-
-// ActiveSpan tracks a single open subagent span.
-type ActiveSpan struct {
-	SpanID     string
-	ColorIndex int
-	Column     int
-}
-
-// SpanLineType describes how the frontend should render a span line column.
-type SpanLineType string
-
-const (
-	SpanLineActive            SpanLineType = "active"             // Vertical line only.
-	SpanLineConnector         SpanLineType = "connector"          // Vertical + horizontal branch to the message (├).
-	SpanLineConnectorEnd      SpanLineType = "connector_end"      // Bottom-corner + horizontal branch (└), span closes after this.
-	SpanLinePassthrough       SpanLineType = "passthrough"        // Horizontal line only (empty slot after connector).
-	SpanLineActivePassthrough SpanLineType = "active_passthrough" // Vertical + horizontal passthrough.
+// The span engine lives in its own package (see spantrack) so the agent
+// package's test double can delegate to the real thing instead of
+// re-implementing it. These aliases keep this package's API unchanged for its
+// callers and its tests.
+type (
+	SpanTracker  = spantrack.SpanTracker
+	SpanLine     = spantrack.SpanLine
+	SpanLineType = spantrack.SpanLineType
+	ActiveSpan   = spantrack.ActiveSpan
 )
 
-// SpanLine represents a single span line entry in the JSON array.
-type SpanLine struct {
-	SpanID           string       `json:"span_id"`
-	Color            int          `json:"color"`
-	Type             SpanLineType `json:"type"`
-	PassthroughColor int          `json:"passthrough_color,omitempty"`
-}
-
-// spanPaletteSize is the number of colors in the frontend span palette.
-// Color indices are 1-based and wrap around within [1, spanPaletteSize].
-const spanPaletteSize = 8
-
-// pendingSpan holds the color reserved for a span by ReserveSpanColor that
-// hasn't yet been committed by OpenSpan. Treated as "in use" by chooseColor
-// so a back-to-back reservation cannot pick the same color.
-type pendingSpan struct {
-	spanID string
-	color  int
-}
-
-// SpanTracker manages hierarchical span state for an agent's message threading.
-type SpanTracker struct {
-	mu        sync.Mutex
-	spans     []ActiveSpan
-	spanTypes map[string]string // spanID → span type (tool name / item type)
-	parentMap map[string]string // spanID → parentSpanID (persists after close for ancestry lookups)
-	pending   *pendingSpan      // color reserved by ReserveSpanColor; consumed by matching OpenSpan.
-	rng       *rand.Rand        // lazy-initialized random source for color choice; tests inject directly.
-	deck      []int             // shuffled draw pile for primary-rule color selection; refilled when empty.
-}
-
-// randIntn returns a random integer in [0, n) from the tracker's RNG, lazy
-// initializing it on first use. Must be called with t.mu held.
-func (t *SpanTracker) randIntn(n int) int {
-	t.ensureRNG()
-	return t.rng.IntN(n)
-}
-
-func (t *SpanTracker) ensureRNG() {
-	if t.rng == nil {
-		t.rng = rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64()))
-	}
-}
-
-// refillDeck repopulates the draw pile with a freshly shuffled palette.
-// Must be called with t.mu held.
-func (t *SpanTracker) refillDeck() {
-	t.ensureRNG()
-	if cap(t.deck) < spanPaletteSize {
-		t.deck = make([]int, spanPaletteSize)
-	} else {
-		t.deck = t.deck[:spanPaletteSize]
-	}
-	for i := 0; i < spanPaletteSize; i++ {
-		t.deck[i] = i + 1
-	}
-	t.rng.Shuffle(len(t.deck), func(i, j int) {
-		t.deck[i], t.deck[j] = t.deck[j], t.deck[i]
-	})
-}
-
-// drawFromDeck returns the first color in the deck that is not blocked,
-// popping it from the pile. If no remaining card is eligible, the deck is
-// refilled and the search retried — guaranteeing every "round" of 8 picks
-// without external blocking constraints visits all 8 palette colors before
-// any repeats. Caller is expected to ensure at least one of
-// {1..spanPaletteSize} is not blocked; if every color is blocked anyway,
-// returns a uniformly random palette color so output keeps flowing.
-// Must be called with t.mu held.
-func (t *SpanTracker) drawFromDeck(blocked map[int]bool) int {
-	if len(t.deck) == 0 {
-		t.refillDeck()
-	}
-	for i, c := range t.deck {
-		if !blocked[c] {
-			t.deck = slices.Delete(t.deck, i, i+1)
-			return c
-		}
-	}
-	// Every remaining card is blocked. Refill once: with a fresh shuffled
-	// deck of all 8 cards, an unblocked color will be found unless the
-	// caller has every palette color blocked.
-	t.refillDeck()
-	for i, c := range t.deck {
-		if !blocked[c] {
-			t.deck = slices.Delete(t.deck, i, i+1)
-			return c
-		}
-	}
-	// Defensive: caller is supposed to fall back to chooseColor's saturated
-	// branch when every color is in use. If we end up here anyway, pick a
-	// random palette color so output keeps flowing rather than crashing.
-	slog.Warn("span color deck exhausted with all colors blocked; using random fallback")
-	return 1 + t.randIntn(spanPaletteSize)
-}
-
-// resolveColumn computes the column index a new span with the given parent
-// would receive if opened now. Mirrors the logic in OpenSpan so that
-// ReserveSpanColor can pre-compute adjacency at peek time without committing
-// any state. Must be called with t.mu held.
-func (t *SpanTracker) resolveColumn(parentSpanID string) int {
-	// Single pass: find parent column, build used-column set, and track the
-	// rightmost active column for minCol computation below.
-	parentCol := -1
-	maxCol := -1
-	used := make(map[int]bool, len(t.spans))
-	for _, s := range t.spans {
-		used[s.Column] = true
-		if s.Column > maxCol {
-			maxCol = s.Column
-		}
-		if s.SpanID == parentSpanID {
-			parentCol = s.Column
-		}
-	}
-
-	// Find the minimum starting column. When a parent is known, place the
-	// new child to the right of all active spans that are to the right of
-	// the parent so it doesn't reuse a column freed by a closed span,
-	// which would place the connector_end at a position with no preceding
-	// vertical line. Root-level spans opened while other spans are active
-	// append to the right of the current active set instead of reusing a
-	// left gap, keeping connector_end rendering aligned.
-	minCol := parentCol + 1
-	if parentCol >= 0 {
-		if maxCol >= parentCol {
-			minCol = maxCol + 1
-		}
-	} else if len(t.spans) > 0 {
-		minCol = maxCol + 1
-	}
-
-	// Find first free column starting from minCol.
-	for i := minCol; ; i++ {
-		if !used[i] {
-			return i
-		}
-	}
-}
-
-// chooseColor picks a color for a new span using the two-tier rule:
-//
-//  1. Primary: draw the next eligible color from a shuffled deck of the
-//     full palette, skipping any deck card currently in use by an active
-//     span or pending reservation. The deck is refilled (reshuffled) when
-//     emptied, so any 8-pick window with no blocking constraints visits
-//     every palette color exactly once before any repeats.
-//  2. Fallback (only when every palette color is in use): pick uniformly
-//     at random from colors that are not the parent's, not the
-//     column-immediately-left active span's, and not the
-//     column-immediately-right active span's.
-//
-// Must be called with t.mu held.
-func (t *SpanTracker) chooseColor(parentSpanID string, newColumn int) int {
-	inUse := make(map[int]bool, len(t.spans)+1)
-	allInUse := true
-	for _, s := range t.spans {
-		inUse[s.ColorIndex] = true
-	}
-	if t.pending != nil {
-		inUse[t.pending.color] = true
-	}
-	for c := 1; c <= spanPaletteSize; c++ {
-		if !inUse[c] {
-			allInUse = false
-			break
-		}
-	}
-	if !allInUse {
-		return t.drawFromDeck(inUse)
-	}
-
-	// Saturated palette: relax exclusion to parent + adjacents only.
-	parentColor := 0
-	leftCol := -1
-	leftColor := 0
-	rightCol := -1
-	rightColor := 0
-	for _, s := range t.spans {
-		if s.SpanID == parentSpanID {
-			parentColor = s.ColorIndex
-		}
-		if s.Column < newColumn && s.Column > leftCol {
-			leftCol = s.Column
-			leftColor = s.ColorIndex
-		}
-		if s.Column > newColumn && (rightCol == -1 || s.Column < rightCol) {
-			rightCol = s.Column
-			rightColor = s.ColorIndex
-		}
-	}
-
-	excluded := make(map[int]bool, 3)
-	if parentColor != 0 {
-		excluded[parentColor] = true
-	}
-	if leftColor != 0 {
-		excluded[leftColor] = true
-	}
-	if rightColor != 0 {
-		excluded[rightColor] = true
-	}
-
-	candidates := make([]int, 0, spanPaletteSize)
-	for c := 1; c <= spanPaletteSize; c++ {
-		if !excluded[c] {
-			candidates = append(candidates, c)
-		}
-	}
-	// At most 3 exclusions vs 8 colors, so candidates is always non-empty.
-	return candidates[t.randIntn(len(candidates))]
-}
-
-// OpenSpan registers a new subagent span.
-func (t *SpanTracker) OpenSpan(spanID, parentSpanID string) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	// Record parentage (persists after close for ancestry lookups).
-	if t.parentMap == nil {
-		t.parentMap = make(map[string]string)
-	}
-	t.parentMap[spanID] = parentSpanID
-
-	column := t.resolveColumn(parentSpanID)
-
-	// Honor a pending reservation for this exact span so the persisted
-	// span_color matches the rendered span color.
-	var color int
-	if t.pending != nil && t.pending.spanID == spanID {
-		color = t.pending.color
-		t.pending = nil
-	} else {
-		color = t.chooseColor(parentSpanID, column)
-	}
-
-	t.spans = append(t.spans, ActiveSpan{
-		SpanID:     spanID,
-		ColorIndex: color,
-		Column:     column,
-	})
-}
-
-// depthOf returns the nesting depth for a span by walking the parentMap.
-// Returns 0 for unknown or root-level ("") spans. Must be called with t.mu held.
-func (t *SpanTracker) depthOf(spanID string) int {
-	depth := 0
-	current := spanID
-	for current != "" {
-		depth++
-		current = t.parentMap[current]
-	}
-	return depth
-}
-
-// Reset clears all span tracking state, returning the tracker to its
-// initial empty state. Used when the agent's context is cleared or interrupted.
-func (t *SpanTracker) Reset() {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	t.spans = nil
-	t.pending = nil
-	t.deck = t.deck[:0]
-	clear(t.spanTypes)
-	clear(t.parentMap)
-}
-
-// removeSpanLocked drops a span from the active set, freeing its column and
-// its color. Shared by CloseSpan and DiscardSpan, which differ only in what
-// they do to the recorded span type. Must be called with t.mu held.
-func (t *SpanTracker) removeSpanLocked(spanID string) {
-	t.spans = slices.DeleteFunc(t.spans, func(s ActiveSpan) bool {
-		return s.SpanID == spanID
-	})
-	// Defensive: if a reservation for this exact span was never consumed by
-	// OpenSpan, drop it so the color goes back to Free.
-	if t.pending != nil && t.pending.spanID == spanID {
-		t.pending = nil
-	}
-	if len(t.spans) == 0 {
-		clear(t.parentMap)
-	}
-}
-
-// CloseSpan removes a span, freeing its column. The span ended, so its type is
-// forgotten too.
-func (t *SpanTracker) CloseSpan(spanID string) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	t.removeSpanLocked(spanID)
-	if t.spanTypes != nil {
-		delete(t.spanTypes, spanID)
-	}
-}
-
-// DiscardSpan removes an open span WITHOUT ending it: the tool call keeps
-// running, but no later message connects to its column and no message draws
-// its rail.
-//
-// A subagent spawn owns no span (its output lives in the child transcript, so
-// a rail that stays open for the whole subagent run only adds depth). Most
-// providers state at the tool call that the call is a spawn and simply never
-// open one. Two learn late -- Kilo fills its spawn rawInput only on the first
-// in-progress tool_call_update, and Claude reports a Workflow run only in the
-// task_started that follows the tool_use -- and this is what those call.
-//
-// Unlike CloseSpan it KEEPS the recorded span type, because the provider's own
-// closing message still reads that type back through GetSpanType to persist
-// span_type. Closing here instead would degrade the finished row to the
-// provider's fallback type.
-func (t *SpanTracker) DiscardSpan(spanID string) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	t.removeSpanLocked(spanID)
-}
-
-// SetSpanType records the type (tool name / item type) for a span ID.
-func (t *SpanTracker) SetSpanType(spanID, spanType string) {
-	if spanID == "" || spanType == "" {
-		return
-	}
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	if t.spanTypes == nil {
-		t.spanTypes = make(map[string]string)
-	}
-	t.spanTypes[spanID] = spanType
-}
-
-// GetSpanType returns the stored type for a span ID, or "".
-func (t *SpanTracker) GetSpanType(spanID string) string {
-	if spanID == "" {
-		return ""
-	}
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	return t.spanTypes[spanID]
-}
-
-// ReserveSpanColor commits to the color that the next OpenSpan(spanID,
-// parentSpanID) call will receive, so the caller can persist the color into
-// a message before the span itself opens. The reservation is held on the
-// tracker's pending slot and consumed when OpenSpan is called for the same
-// spanID. Subsequent calls with the same spanID are idempotent and return
-// the cached color; calls with a different spanID overwrite the slot.
-//
-// Safe to call only when output processing is sequential per agent (which
-// it is for all Claude/Codex/ACP handlers).
-func (t *SpanTracker) ReserveSpanColor(spanID, parentSpanID string) int32 {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	if t.pending != nil && t.pending.spanID == spanID {
-		return int32(t.pending.color)
-	}
-	column := t.resolveColumn(parentSpanID)
-	color := t.chooseColor(parentSpanID, column)
-	t.pending = &pendingSpan{spanID: spanID, color: color}
-	return int32(color)
-}
-
-// Snapshot returns the depth and span lines for a given parentSpanID in a single
-// atomic operation. connectorSpanID identifies the span this message connects to
-// (used to compute passthrough hints for columns to the right of the connector).
-// When closing is true, the connector column renders as └ instead of ├.
-// This avoids the TOCTOU risk of calling DepthFor and SpanLines separately,
-// and reduces mutex acquisitions.
-func (t *SpanTracker) Snapshot(parentSpanID, connectorSpanID string, closing bool) (depth int32, spanLines string, connectorColorOut int32) {
-	connectorColorOut = 0 // no connector found
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	// Span lines serialization.
-	if len(t.spans) == 0 {
-		// Depth lookup (no spans to search).
-		return depth, "[]", connectorColorOut
-	}
-
-	// Depth lookup via parent chain; single pass for maxCol.
-	if parentSpanID != "" {
-		depth = int32(t.depthOf(parentSpanID))
-	}
-	maxCol := 0
-	for _, s := range t.spans {
-		if s.Column > maxCol {
-			maxCol = s.Column
-		}
-	}
-
-	lines := make([]*SpanLine, maxCol+1)
-	for _, s := range t.spans {
-		lines[s.Column] = &SpanLine{
-			SpanID: s.SpanID,
-			Color:  s.ColorIndex,
-			Type:   SpanLineActive,
-		}
-	}
-
-	// Find the connector column and apply rendering hints.
-	connectorCol := -1
-	connectorColor := 0
-	if connectorSpanID != "" {
-		for col, l := range lines {
-			if l != nil && l.SpanID == connectorSpanID {
-				connectorCol = col
-				connectorColor = l.Color
-				connectorColorOut = int32(l.Color)
-				if closing {
-					l.Type = SpanLineConnectorEnd
-				} else {
-					l.Type = SpanLineConnector
-				}
-				break
-			}
-		}
-	}
-
-	// Mark columns to the right of the connector as passthrough.
-	if connectorCol >= 0 {
-		for col := connectorCol + 1; col < len(lines); col++ {
-			if lines[col] == nil {
-				lines[col] = &SpanLine{
-					Type:             SpanLinePassthrough,
-					PassthroughColor: connectorColor,
-				}
-			} else {
-				lines[col].Type = SpanLineActivePassthrough
-				lines[col].PassthroughColor = connectorColor
-			}
-		}
-	}
-
-	data, err := json.Marshal(lines)
-	if err != nil {
-		slog.Warn("marshal span lines", "error", err)
-		return depth, "[]", connectorColorOut
-	}
-	return depth, string(data), connectorColorOut
-}
-
-// ShouldBroadcastStreamChunk reports whether a live stream chunk should be
-// broadcast. To keep the live UI uncluttered, all live deltas are suppressed
-// whenever any span is active.
-func (t *SpanTracker) ShouldBroadcastStreamChunk() bool {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	return len(t.spans) == 0
-}
+const (
+	SpanLineActive       = spantrack.SpanLineActive
+	SpanLineConnector    = spantrack.SpanLineConnector
+	SpanLineConnectorEnd = spantrack.SpanLineConnectorEnd
+	SpanLinePassthrough  = spantrack.SpanLinePassthrough
+)
 
 // resolveConnectorSpanID determines which span a message should visually
 // connect to. For span closers (tool_result), the span is already open so
@@ -1107,10 +654,6 @@ func (s *agentOutputSink) CloseSpan(spanID string) {
 	s.tracker.CloseSpan(spanID)
 }
 
-func (s *agentOutputSink) DiscardSpan(spanID string) {
-	s.tracker.DiscardSpan(spanID)
-}
-
 func (s *agentOutputSink) ResetSpans() {
 	s.tracker.Reset()
 }
@@ -1128,7 +671,7 @@ func (s *agentOutputSink) ReserveSpanColor(spanID, parentSpanID string) int32 {
 }
 
 func (s *agentOutputSink) BroadcastStreamChunk(content []byte, spanID string, method string) {
-	if !s.tracker.ShouldBroadcastStreamChunk() {
+	if !s.tracker.ShouldBroadcastStreamChunk(spanID) {
 		return
 	}
 	s.h.watcher.BroadcastAgentEvent(s.agentID, &leapmuxv1.AgentEvent{
@@ -1928,8 +1471,12 @@ func (h *OutputHandler) persistAndBroadcast(agentID string, agentProvider leapmu
 
 	// Resolve span color: if the span is already active (e.g. tool_result
 	// inside an open span), use the connector color from the snapshot.
+	//
+	// NoSpan opts out. A row that owns no span reports color 0 as its answer,
+	// so filling it from the connector would tint a subagent spawn card with a
+	// color no rail anywhere draws.
 	spanColor := span.SpanColor
-	if span.SpanID != "" && spanColor == 0 && connectorColor > 0 {
+	if span.SpanID != "" && spanColor == 0 && connectorColor > 0 && !span.NoSpan {
 		spanColor = connectorColor
 	}
 

--- a/backend/internal/worker/service/output.go
+++ b/backend/internal/worker/service/output.go
@@ -320,17 +320,13 @@ func (t *SpanTracker) Reset() {
 	clear(t.parentMap)
 }
 
-// CloseSpan removes a span, freeing its column.
-func (t *SpanTracker) CloseSpan(spanID string) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
+// removeSpanLocked drops a span from the active set, freeing its column and
+// its color. Shared by CloseSpan and DiscardSpan, which differ only in what
+// they do to the recorded span type. Must be called with t.mu held.
+func (t *SpanTracker) removeSpanLocked(spanID string) {
 	t.spans = slices.DeleteFunc(t.spans, func(s ActiveSpan) bool {
 		return s.SpanID == spanID
 	})
-	if t.spanTypes != nil {
-		delete(t.spanTypes, spanID)
-	}
 	// Defensive: if a reservation for this exact span was never consumed by
 	// OpenSpan, drop it so the color goes back to Free.
 	if t.pending != nil && t.pending.spanID == spanID {
@@ -339,6 +335,40 @@ func (t *SpanTracker) CloseSpan(spanID string) {
 	if len(t.spans) == 0 {
 		clear(t.parentMap)
 	}
+}
+
+// CloseSpan removes a span, freeing its column. The span ended, so its type is
+// forgotten too.
+func (t *SpanTracker) CloseSpan(spanID string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.removeSpanLocked(spanID)
+	if t.spanTypes != nil {
+		delete(t.spanTypes, spanID)
+	}
+}
+
+// DiscardSpan removes an open span WITHOUT ending it: the tool call keeps
+// running, but no later message connects to its column and no message draws
+// its rail.
+//
+// A subagent spawn owns no span (its output lives in the child transcript, so
+// a rail that stays open for the whole subagent run only adds depth). Most
+// providers state at the tool call that the call is a spawn and simply never
+// open one. Two learn late -- Kilo fills its spawn rawInput only on the first
+// in-progress tool_call_update, and Claude reports a Workflow run only in the
+// task_started that follows the tool_use -- and this is what those call.
+//
+// Unlike CloseSpan it KEEPS the recorded span type, because the provider's own
+// closing message still reads that type back through GetSpanType to persist
+// span_type. Closing here instead would degrade the finished row to the
+// provider's fallback type.
+func (t *SpanTracker) DiscardSpan(spanID string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.removeSpanLocked(spanID)
 }
 
 // SetSpanType records the type (tool name / item type) for a span ID.
@@ -1075,6 +1105,10 @@ func (s *agentOutputSink) OpenSpan(spanID, parentSpanID string) {
 
 func (s *agentOutputSink) CloseSpan(spanID string) {
 	s.tracker.CloseSpan(spanID)
+}
+
+func (s *agentOutputSink) DiscardSpan(spanID string) {
+	s.tracker.DiscardSpan(spanID)
 }
 
 func (s *agentOutputSink) ResetSpans() {

--- a/backend/internal/worker/service/output_spawn_span_lines_test.go
+++ b/backend/internal/worker/service/output_spawn_span_lines_test.go
@@ -1,0 +1,142 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/worker/agent"
+	db "github.com/leapmux/leapmux/internal/worker/generated/db"
+)
+
+// streamChunkDeltas returns every stream-chunk delta broadcast on the watcher
+// stream, in order.
+func streamChunkDeltas(t *testing.T, w *testResponseWriter) []string {
+	t.Helper()
+	var deltas []string
+	for _, stream := range w.streamsSnapshot() {
+		chunk := decodeWatchAgentEvent(t, stream).GetStreamChunk()
+		if chunk == nil {
+			continue
+		}
+		deltas = append(deltas, string(chunk.GetDelta()))
+	}
+	return deltas
+}
+
+// A subagent spawn owns no span, so both of its rows persist at root depth with
+// no span lines at all. This is the first shape in the design: the spawn card
+// and its result sit flush against the left edge.
+func TestSpawnRowsCarryNoSpanLinesWhenNothingElseIsOpen(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc, _, w := setupTestService(t)
+	sink := setupAgentWithWatcher(t, svc, w, "agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)
+
+	// The tool_use of a spawn: it carries a span id but opens no span.
+	require.NoError(t, sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT,
+		[]byte(`{"type":"assistant"}`),
+		agent.SpanInfo{SpanID: "tu-spawn", SpanType: "Agent"}))
+	// Its tool_result closes a span that was never opened.
+	require.NoError(t, sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_USER,
+		[]byte(`{"type":"user"}`),
+		agent.SpanInfo{SpanID: "tu-spawn", SpanType: "Agent", Closing: true}))
+
+	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{
+		AgentID: "agent-1", Seq: 0, Limit: 10,
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	for i, row := range rows {
+		assert.Equal(t, "[]", row.SpanLines, "spawn row %d draws no rail", i)
+		assert.Equal(t, int64(0), row.Depth, "spawn row %d stays at root depth", i)
+		assert.Equal(t, int64(0), row.SpanColor, "spawn row %d takes the neutral border", i)
+		assert.Equal(t, row.SpanLines, broadcastSpanLinesByID(t, w, row.ID),
+			"the broadcast must match the persisted row")
+	}
+}
+
+// The second shape in the design: a spawn that starts while a Read is running
+// draws the Read's rail and nothing more -- one column, not two -- and the
+// Read's own result still closes its column with a connector_end.
+func TestSpawnInsideAnOpenSpanDrawsExactlyOneColumn(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc, _, w := setupTestService(t)
+	sink := setupAgentWithWatcher(t, svc, w, "agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)
+
+	// Read's tool_use persists first, then opens its span (the provider order).
+	readColor := sink.ReserveSpanColor("tu-read", "")
+	require.NoError(t, sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT,
+		[]byte(`{"type":"assistant"}`),
+		agent.SpanInfo{SpanID: "tu-read", SpanType: "Read", SpanColor: readColor}))
+	sink.SetSpanType("tu-read", "Read")
+	sink.OpenSpan("tu-read", "")
+
+	// The spawn's two rows land inside that open span.
+	require.NoError(t, sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT,
+		[]byte(`{"type":"assistant"}`),
+		agent.SpanInfo{SpanID: "tu-spawn", SpanType: "Agent"}))
+	require.NoError(t, sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_USER,
+		[]byte(`{"type":"user"}`),
+		agent.SpanInfo{SpanID: "tu-spawn", SpanType: "Agent", Closing: true}))
+
+	// Read's result closes its own span.
+	require.NoError(t, sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_USER,
+		[]byte(`{"type":"user"}`),
+		agent.SpanInfo{SpanID: "tu-read", SpanType: "Read", Closing: true}))
+	sink.CloseSpan("tu-read")
+
+	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{
+		AgentID: "agent-1", Seq: 0, Limit: 10,
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, 4)
+
+	// Row 0 (Read's tool_use) persisted before its span opened, so it has none.
+	assert.Equal(t, "[]", rows[0].SpanLines)
+
+	// Rows 1 and 2 (the spawn) each draw one plain vertical for the Read.
+	for i, row := range rows[1:3] {
+		lines := parseSpanLinesJSON(t, row.SpanLines)
+		require.Len(t, lines, 1, "spawn row %d draws exactly one column", i)
+		require.NotNil(t, lines[0])
+		assert.Equal(t, "tu-read", lines[0].SpanID)
+		assert.Equal(t, SpanLineActive, lines[0].Type,
+			"a plain vertical: the spawn connects to nothing")
+		assert.Equal(t, int64(0), row.SpanColor, "the spawn takes no rail color of its own")
+	}
+
+	// Row 3 (Read's result) closes its column.
+	closing := parseSpanLinesJSON(t, rows[3].SpanLines)
+	require.Len(t, closing, 1)
+	require.NotNil(t, closing[0])
+	assert.Equal(t, SpanLineConnectorEnd, closing[0].Type)
+	assert.Equal(t, "tu-read", closing[0].SpanID)
+}
+
+// Live deltas are suppressed while any span is open. A spawn opens none, so the
+// parent keeps streaming for the whole subagent run.
+func TestStreamChunksFlowWhileASpawnRunsAndStopWhileASpanIsOpen(t *testing.T) {
+	t.Parallel()
+
+	svc, _, w := setupTestService(t)
+	sink := setupAgentWithWatcher(t, svc, w, "agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)
+
+	// A spawn is running: nothing is open, so the delta reaches the watcher.
+	require.NoError(t, sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT,
+		[]byte(`{"type":"assistant"}`),
+		agent.SpanInfo{SpanID: "tu-spawn", SpanType: "Agent"}))
+	sink.BroadcastStreamChunk([]byte("while the subagent runs"), "", "")
+
+	// An ordinary tool span opens: deltas are suppressed again.
+	sink.OpenSpan("tu-read", "")
+	sink.BroadcastStreamChunk([]byte("while a tool runs"), "", "")
+
+	assert.Equal(t, []string{"while the subagent runs"}, streamChunkDeltas(t, w))
+}

--- a/backend/internal/worker/service/output_spawn_span_lines_test.go
+++ b/backend/internal/worker/service/output_spawn_span_lines_test.go
@@ -120,6 +120,46 @@ func TestSpawnInsideAnOpenSpanDrawsExactlyOneColumn(t *testing.T) {
 	assert.Equal(t, "tu-read", closing[0].SpanID)
 }
 
+// A spawn row's span_color of 0 is its ANSWER, not a gap. When the row sits
+// under a span that is still open, the connector-colour fallback would fill it
+// in and tint the spawn card with a colour no rail anywhere draws. NoSpan opts
+// the row out of that fallback.
+func TestSpawnRowUnderAnOpenParentKeepsTheNeutralColor(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc, _, w := setupTestService(t)
+	sink := setupAgentWithWatcher(t, svc, w, "agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)
+
+	readColor := sink.ReserveSpanColor("tu-read", "")
+	require.NotZero(t, readColor)
+	require.NoError(t, sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT,
+		[]byte(`{"type":"assistant"}`),
+		agent.SpanInfo{SpanID: "tu-read", SpanType: "Read", SpanColor: readColor}))
+	sink.OpenSpan("tu-read", "")
+
+	// The spawn row names the open Read as its parent and owns no span.
+	require.NoError(t, sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT,
+		[]byte(`{"type":"assistant"}`),
+		agent.SpanInfo{SpanID: "tu-spawn", SpanType: "Agent", ParentSpanID: "tu-read", NoSpan: true}))
+
+	// An ordinary row with no span of its own still inherits, which is what the
+	// fallback exists for (a tool_result inside its own open span).
+	require.NoError(t, sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_USER,
+		[]byte(`{"type":"user"}`),
+		agent.SpanInfo{SpanID: "tu-read", SpanType: "Read", Closing: true}))
+
+	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{
+		AgentID: "agent-1", Seq: 0, Limit: 10,
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, 3)
+	assert.Equal(t, int64(0), rows[1].SpanColor,
+		"the spawn card takes the neutral border although its parent span is open")
+	assert.Equal(t, int64(readColor), rows[2].SpanColor,
+		"a row that does own its span still inherits the connector colour")
+}
+
 // Live deltas are suppressed while any span is open. A spawn opens none, so the
 // parent keeps streaming for the whole subagent run.
 func TestStreamChunksFlowWhileASpawnRunsAndStopWhileASpanIsOpen(t *testing.T) {
@@ -128,15 +168,37 @@ func TestStreamChunksFlowWhileASpawnRunsAndStopWhileASpanIsOpen(t *testing.T) {
 	svc, _, w := setupTestService(t)
 	sink := setupAgentWithWatcher(t, svc, w, "agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)
 
-	// A spawn is running: nothing is open, so the delta reaches the watcher.
+	// A spawn runs: nothing is open, so the delta reaches the watcher.
 	require.NoError(t, sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT,
 		[]byte(`{"type":"assistant"}`),
 		agent.SpanInfo{SpanID: "tu-spawn", SpanType: "Agent"}))
 	sink.BroadcastStreamChunk([]byte("while the subagent runs"), "", "")
 
-	// An ordinary tool span opens: deltas are suppressed again.
+	// An ordinary tool span opens: the agent's free-form text waits for it.
 	sink.OpenSpan("tu-read", "")
 	sink.BroadcastStreamChunk([]byte("while a tool runs"), "", "")
 
 	assert.Equal(t, []string{"while the subagent runs"}, streamChunkDeltas(t, w))
+}
+
+// A tool's OWN output streams while that tool runs. It is emitted while its span
+// is open by construction, so gating it on "any span open" dropped every one:
+// per-tool live output never reached the UI, for any provider.
+func TestStreamChunksOfARunningToolReachTheWatcher(t *testing.T) {
+	t.Parallel()
+
+	svc, _, w := setupTestService(t)
+	sink := setupAgentWithWatcher(t, svc, w, "agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)
+
+	sink.OpenSpan("tu-bash", "")
+	sink.BroadcastStreamChunk([]byte("bash output"), "tu-bash", "")
+	// A second concurrent tool streams its own output too.
+	sink.OpenSpan("tu-grep", "")
+	sink.BroadcastStreamChunk([]byte("grep output"), "tu-grep", "")
+	// The agent's free-form text still waits while a tool runs.
+	sink.BroadcastStreamChunk([]byte("agent prose"), "", "")
+	// So does a chunk naming a span that never opened.
+	sink.BroadcastStreamChunk([]byte("spawn output"), "tu-spawn", "")
+
+	assert.Equal(t, []string{"bash output", "grep output"}, streamChunkDeltas(t, w))
 }

--- a/backend/internal/worker/service/span_tracker_test.go
+++ b/backend/internal/worker/service/span_tracker_test.go
@@ -307,6 +307,141 @@ func TestSpanTracker_ConnectorEnd(t *testing.T) {
 	assert.Equal(t, SpanLineConnector, parsed[0].Type)
 }
 
+// DiscardSpan and CloseSpan both free the column; only CloseSpan forgets the
+// recorded type. Asserted as a pair so the one difference between them cannot
+// regress unnoticed.
+func TestSpanTracker_DiscardSpanKeepsTypeAndCloseSpanDropsIt(t *testing.T) {
+	t.Parallel()
+
+	tracker := &SpanTracker{}
+	tracker.SetSpanType("span-discard", "task")
+	tracker.SetSpanType("span-close", "read")
+	tracker.OpenSpan("span-discard", "")
+	tracker.OpenSpan("span-close", "")
+
+	tracker.DiscardSpan("span-discard")
+	tracker.CloseSpan("span-close")
+
+	_, lines, _ := tracker.Snapshot("", "", false)
+	assert.Equal(t, "[]", lines, "both spans left the active set")
+	assert.Equal(t, "task", tracker.GetSpanType("span-discard"),
+		"a discarded span keeps its type: the closing message still reads it back")
+	assert.Empty(t, tracker.GetSpanType("span-close"), "a closed span forgets its type")
+}
+
+// A discarded span frees its column, so the next span starts at column 0 rather
+// than being pushed right by a rail nobody draws.
+func TestSpanTracker_DiscardSpanFreesTheColumn(t *testing.T) {
+	t.Parallel()
+
+	tracker := &SpanTracker{}
+	tracker.OpenSpan("span-spawn", "")
+	tracker.DiscardSpan("span-spawn")
+	tracker.OpenSpan("span-next", "")
+
+	_, lines, _ := tracker.Snapshot("", "", false)
+	var parsed []*SpanLine
+	require.NoError(t, json.Unmarshal([]byte(lines), &parsed))
+	require.Len(t, parsed, 1, "the next span reuses column 0")
+	assert.Equal(t, "span-next", parsed[0].SpanID)
+}
+
+// A reservation that OpenSpan never consumed must not survive a discard, or its
+// color stays blocked for the rest of the turn.
+func TestSpanTracker_DiscardSpanDropsAnUnconsumedReservation(t *testing.T) {
+	t.Parallel()
+
+	tracker := &SpanTracker{}
+	reserved := tracker.ReserveSpanColor("span-spawn", "")
+	require.NotZero(t, reserved)
+
+	tracker.DiscardSpan("span-spawn")
+
+	// With the reservation gone, the whole palette is free again, so a span that
+	// opens now can draw the color the discarded one had reserved. Sample until
+	// it does; a surviving reservation would block it forever.
+	drewReservedColor := false
+	for i := 0; i < 200 && !drewReservedColor; i++ {
+		id := fmt.Sprintf("span-%d", i)
+		tracker.OpenSpan(id, "")
+		drewReservedColor = snapshotColor(t, tracker, id) == int(reserved)
+		tracker.CloseSpan(id)
+	}
+	assert.True(t, drewReservedColor, "the reserved color returned to the pool")
+}
+
+// Discarding the last span clears the parent chain, exactly as closing it does.
+func TestSpanTracker_DiscardSpanClearsParentageWhenLast(t *testing.T) {
+	t.Parallel()
+
+	tracker := &SpanTracker{}
+	tracker.OpenSpan("span-parent", "")
+	tracker.OpenSpan("span-child", "span-parent")
+	tracker.CloseSpan("span-child")
+	tracker.DiscardSpan("span-parent")
+
+	depth, lines, _ := tracker.Snapshot("span-child", "", false)
+	assert.Equal(t, "[]", lines)
+	assert.Equal(t, int32(0), depth, "the parent chain is gone, so nothing is nested")
+}
+
+func TestSpanTracker_DiscardSpanUnknownIDIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	tracker := &SpanTracker{}
+	tracker.OpenSpan("span-A", "")
+	tracker.DiscardSpan("span-nope")
+
+	_, lines, _ := tracker.Snapshot("", "", false)
+	var parsed []*SpanLine
+	require.NoError(t, json.Unmarshal([]byte(lines), &parsed))
+	require.Len(t, parsed, 1)
+	assert.Equal(t, "span-A", parsed[0].SpanID)
+}
+
+// The rendering contract for a subagent spawn: a closing row whose span was
+// never opened draws no connector_end, and every other column stays a plain
+// vertical. This is the "spawn nested inside an open Read" shape.
+func TestSpanTracker_SnapshotClosingUnopenedSpanDrawsNoConnector(t *testing.T) {
+	t.Parallel()
+
+	tracker := &SpanTracker{}
+	tracker.OpenSpan("span-read", "")
+
+	// "span-spawn" was never opened -- it is the spawn's tool_result closing.
+	depth, lines, connectorColor := tracker.Snapshot("", "span-spawn", true)
+	assert.Equal(t, int32(0), depth)
+	assert.Equal(t, int32(0), connectorColor, "no connector column was found")
+
+	var parsed []*SpanLine
+	require.NoError(t, json.Unmarshal([]byte(lines), &parsed))
+	require.Len(t, parsed, 1, "only the Read column")
+	assert.Equal(t, SpanLineActive, parsed[0].Type, "a plain vertical, not a connector_end")
+	assert.Equal(t, "span-read", parsed[0].SpanID)
+}
+
+// With nothing else open, a spawn row carries no span lines at all.
+func TestSpanTracker_SnapshotUnopenedSpanAloneIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	tracker := &SpanTracker{}
+
+	depth, lines, connectorColor := tracker.Snapshot("", "span-spawn", true)
+	assert.Equal(t, int32(0), depth)
+	assert.Equal(t, "[]", lines)
+	assert.Equal(t, int32(0), connectorColor)
+}
+
+// A spawn opens no span, so live deltas keep flowing while the subagent runs.
+func TestSpanTracker_ShouldBroadcastStreamChunk_AllowsWhileASpawnRuns(t *testing.T) {
+	t.Parallel()
+
+	tracker := &SpanTracker{}
+	// The spawn's tool_use only records a type; it never opens a span.
+	tracker.SetSpanType("span-spawn", "Agent")
+	assert.True(t, tracker.ShouldBroadcastStreamChunk())
+}
+
 func TestSpanTracker_ShouldBroadcastStreamChunk_AllowsWhenNoSpansActive(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/worker/spantrack/spantrack.go
+++ b/backend/internal/worker/spantrack/spantrack.go
@@ -1,0 +1,516 @@
+// Package spantrack owns the span engine behind the chat transcript's rails:
+// which spans are open, which column and palette color each one holds, and the
+// per-row span_lines the frontend renders from.
+//
+// It lives in its own package so both the service layer (which drives it) and
+// the agent package's tests (which must behave like it) can import it. The
+// agent package cannot import service -- service imports agent -- so a test
+// double there used to re-implement this engine, and drifted from it.
+package spantrack
+
+import (
+	"encoding/json"
+	"log/slog"
+	"math/rand/v2"
+	"slices"
+	"sync"
+)
+
+// --- Span Tracker ---
+
+// ActiveSpan tracks a single open subagent span.
+type ActiveSpan struct {
+	SpanID     string
+	ColorIndex int
+	Column     int
+}
+
+// SpanLineType describes how the frontend should render a span line column.
+type SpanLineType string
+
+const (
+	SpanLineActive            SpanLineType = "active"             // Vertical line only.
+	SpanLineConnector         SpanLineType = "connector"          // Vertical + horizontal branch to the message (├).
+	SpanLineConnectorEnd      SpanLineType = "connector_end"      // Bottom-corner + horizontal branch (└), span closes after this.
+	SpanLinePassthrough       SpanLineType = "passthrough"        // Horizontal line only (empty slot after connector).
+	SpanLineActivePassthrough SpanLineType = "active_passthrough" // Vertical + horizontal passthrough.
+)
+
+// SpanLine represents a single span line entry in the JSON array.
+type SpanLine struct {
+	SpanID           string       `json:"span_id"`
+	Color            int          `json:"color"`
+	Type             SpanLineType `json:"type"`
+	PassthroughColor int          `json:"passthrough_color,omitempty"`
+}
+
+// spanPaletteSize is the number of colors in the frontend span palette.
+// Color indices are 1-based and wrap around within [1, spanPaletteSize].
+const spanPaletteSize = 8
+
+// pendingSpan holds the color reserved for a span by ReserveSpanColor that
+// hasn't yet been committed by OpenSpan. Treated as "in use" by chooseColor
+// so a back-to-back reservation cannot pick the same color.
+type pendingSpan struct {
+	spanID string
+	color  int
+}
+
+// SpanTracker manages hierarchical span state for an agent's message threading.
+type SpanTracker struct {
+	mu        sync.Mutex
+	spans     []ActiveSpan
+	spanTypes map[string]string // spanID → span type (tool name / item type)
+	parentMap map[string]string // spanID → parentSpanID (persists after close for ancestry lookups)
+	pending   *pendingSpan      // color reserved by ReserveSpanColor; consumed by matching OpenSpan.
+	rng       *rand.Rand        // lazy-initialized random source for color choice; tests inject directly.
+	deck      []int             // shuffled draw pile for primary-rule color selection; refilled when empty.
+}
+
+// randIntn returns a random integer in [0, n) from the tracker's RNG, lazy
+// initializing it on first use. Must be called with t.mu held.
+func (t *SpanTracker) randIntn(n int) int {
+	t.ensureRNG()
+	return t.rng.IntN(n)
+}
+
+func (t *SpanTracker) ensureRNG() {
+	if t.rng == nil {
+		t.rng = rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64()))
+	}
+}
+
+// refillDeck repopulates the draw pile with a freshly shuffled palette.
+// Must be called with t.mu held.
+func (t *SpanTracker) refillDeck() {
+	t.ensureRNG()
+	if cap(t.deck) < spanPaletteSize {
+		t.deck = make([]int, spanPaletteSize)
+	} else {
+		t.deck = t.deck[:spanPaletteSize]
+	}
+	for i := 0; i < spanPaletteSize; i++ {
+		t.deck[i] = i + 1
+	}
+	t.rng.Shuffle(len(t.deck), func(i, j int) {
+		t.deck[i], t.deck[j] = t.deck[j], t.deck[i]
+	})
+}
+
+// drawFromDeck returns the first color in the deck that is not blocked,
+// popping it from the pile. If no remaining card is eligible, the deck is
+// refilled and the search retried — guaranteeing every "round" of 8 picks
+// without external blocking constraints visits all 8 palette colors before
+// any repeats. Caller is expected to ensure at least one of
+// {1..spanPaletteSize} is not blocked; if every color is blocked anyway,
+// returns a uniformly random palette color so output keeps flowing.
+// Must be called with t.mu held.
+func (t *SpanTracker) drawFromDeck(blocked map[int]bool) int {
+	if len(t.deck) == 0 {
+		t.refillDeck()
+	}
+	for i, c := range t.deck {
+		if !blocked[c] {
+			t.deck = slices.Delete(t.deck, i, i+1)
+			return c
+		}
+	}
+	// Every remaining card is blocked. Refill once: with a fresh shuffled
+	// deck of all 8 cards, an unblocked color will be found unless the
+	// caller has every palette color blocked.
+	t.refillDeck()
+	for i, c := range t.deck {
+		if !blocked[c] {
+			t.deck = slices.Delete(t.deck, i, i+1)
+			return c
+		}
+	}
+	// Defensive: caller is supposed to fall back to chooseColor's saturated
+	// branch when every color is in use. If we end up here anyway, pick a
+	// random palette color so output keeps flowing rather than crashing.
+	slog.Warn("span color deck exhausted with all colors blocked; using random fallback")
+	return 1 + t.randIntn(spanPaletteSize)
+}
+
+// resolveColumn computes the column index a new span with the given parent
+// would receive if opened now. Mirrors the logic in OpenSpan so that
+// ReserveSpanColor can pre-compute adjacency at peek time without committing
+// any state. Must be called with t.mu held.
+func (t *SpanTracker) resolveColumn(parentSpanID string) int {
+	// Single pass: find parent column, build used-column set, and track the
+	// rightmost active column for minCol computation below.
+	parentCol := -1
+	maxCol := -1
+	used := make(map[int]bool, len(t.spans))
+	for _, s := range t.spans {
+		used[s.Column] = true
+		if s.Column > maxCol {
+			maxCol = s.Column
+		}
+		if s.SpanID == parentSpanID {
+			parentCol = s.Column
+		}
+	}
+
+	// Find the minimum starting column. When a parent is known, place the
+	// new child to the right of all active spans that are to the right of
+	// the parent so it doesn't reuse a column freed by a closed span,
+	// which would place the connector_end at a position with no preceding
+	// vertical line. Root-level spans opened while other spans are active
+	// append to the right of the current active set instead of reusing a
+	// left gap, keeping connector_end rendering aligned.
+	minCol := parentCol + 1
+	if parentCol >= 0 {
+		if maxCol >= parentCol {
+			minCol = maxCol + 1
+		}
+	} else if len(t.spans) > 0 {
+		minCol = maxCol + 1
+	}
+
+	// Find first free column starting from minCol.
+	for i := minCol; ; i++ {
+		if !used[i] {
+			return i
+		}
+	}
+}
+
+// chooseColor picks a color for a new span using the two-tier rule:
+//
+//  1. Primary: draw the next eligible color from a shuffled deck of the
+//     full palette, skipping any deck card currently in use by an active
+//     span or pending reservation. The deck is refilled (reshuffled) when
+//     emptied, so any 8-pick window with no blocking constraints visits
+//     every palette color exactly once before any repeats.
+//  2. Fallback (only when every palette color is in use): pick uniformly
+//     at random from colors that are not the parent's, not the
+//     column-immediately-left active span's, and not the
+//     column-immediately-right active span's.
+//
+// Must be called with t.mu held.
+func (t *SpanTracker) chooseColor(parentSpanID string, newColumn int) int {
+	inUse := make(map[int]bool, len(t.spans)+1)
+	allInUse := true
+	for _, s := range t.spans {
+		inUse[s.ColorIndex] = true
+	}
+	if t.pending != nil {
+		inUse[t.pending.color] = true
+	}
+	for c := 1; c <= spanPaletteSize; c++ {
+		if !inUse[c] {
+			allInUse = false
+			break
+		}
+	}
+	if !allInUse {
+		return t.drawFromDeck(inUse)
+	}
+
+	// Saturated palette: relax exclusion to parent + adjacents only.
+	parentColor := 0
+	leftCol := -1
+	leftColor := 0
+	rightCol := -1
+	rightColor := 0
+	for _, s := range t.spans {
+		if s.SpanID == parentSpanID {
+			parentColor = s.ColorIndex
+		}
+		if s.Column < newColumn && s.Column > leftCol {
+			leftCol = s.Column
+			leftColor = s.ColorIndex
+		}
+		if s.Column > newColumn && (rightCol == -1 || s.Column < rightCol) {
+			rightCol = s.Column
+			rightColor = s.ColorIndex
+		}
+	}
+
+	excluded := make(map[int]bool, 3)
+	if parentColor != 0 {
+		excluded[parentColor] = true
+	}
+	if leftColor != 0 {
+		excluded[leftColor] = true
+	}
+	if rightColor != 0 {
+		excluded[rightColor] = true
+	}
+
+	candidates := make([]int, 0, spanPaletteSize)
+	for c := 1; c <= spanPaletteSize; c++ {
+		if !excluded[c] {
+			candidates = append(candidates, c)
+		}
+	}
+	// At most 3 exclusions vs 8 colors, so candidates is always non-empty.
+	return candidates[t.randIntn(len(candidates))]
+}
+
+// OpenSpan registers a new subagent span.
+func (t *SpanTracker) OpenSpan(spanID, parentSpanID string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	// Record parentage (persists after close for ancestry lookups).
+	if t.parentMap == nil {
+		t.parentMap = make(map[string]string)
+	}
+	t.parentMap[spanID] = parentSpanID
+
+	column := t.resolveColumn(parentSpanID)
+
+	// Honor a pending reservation for this exact span so the persisted
+	// span_color matches the rendered span color.
+	var color int
+	if t.pending != nil && t.pending.spanID == spanID {
+		color = t.pending.color
+		t.pending = nil
+	} else {
+		color = t.chooseColor(parentSpanID, column)
+	}
+
+	t.spans = append(t.spans, ActiveSpan{
+		SpanID:     spanID,
+		ColorIndex: color,
+		Column:     column,
+	})
+}
+
+// depthOf returns the nesting depth for a span by walking the parentMap.
+// Returns 0 for unknown or root-level ("") spans. Must be called with t.mu held.
+func (t *SpanTracker) depthOf(spanID string) int {
+	depth := 0
+	current := spanID
+	for current != "" {
+		depth++
+		current = t.parentMap[current]
+	}
+	return depth
+}
+
+// Reset clears all span tracking state, returning the tracker to its
+// initial empty state. Used when the agent's context is cleared or interrupted.
+func (t *SpanTracker) Reset() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.spans = nil
+	t.pending = nil
+	t.deck = t.deck[:0]
+	clear(t.spanTypes)
+	clear(t.parentMap)
+}
+
+// removeSpanLocked drops a span from the active set, freeing its column and
+// its color. The recorded span type is NOT touched: only Reset clears types.
+// Must be called with t.mu held.
+func (t *SpanTracker) removeSpanLocked(spanID string) {
+	t.spans = slices.DeleteFunc(t.spans, func(s ActiveSpan) bool {
+		return s.SpanID == spanID
+	})
+	// Defensive: if a reservation for this exact span was never consumed by
+	// OpenSpan, drop it so the color goes back to Free.
+	if t.pending != nil && t.pending.spanID == spanID {
+		t.pending = nil
+	}
+	if len(t.spans) == 0 {
+		clear(t.parentMap)
+	}
+}
+
+// CloseSpan removes a span, freeing its column and its color.
+//
+// The recorded span type SURVIVES, and Reset clears it at the turn boundary.
+// Every reader wants the type after the span leaves the active set: a provider's
+// closing message reads it back through GetSpanType to persist span_type, and an
+// ACP history replay re-delivers that closing message long afterwards. Deleting
+// it here degraded the replayed row to the provider's fallback type, and it
+// forced a second removal method for the callers that must keep it.
+//
+// A caller that takes a span back while its tool call KEEPS RUNNING -- a spawn
+// recognized late -- calls this too. The column is freed either way; nothing
+// downstream distinguishes "ended" from "given back".
+func (t *SpanTracker) CloseSpan(spanID string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.removeSpanLocked(spanID)
+}
+
+// ActiveSpans returns the spans currently open, ordered by column. The service
+// layer derives a persisted row's span_lines from this state, so a test double
+// that must mirror the real geometry reads it here instead of keeping its own.
+func (t *SpanTracker) ActiveSpans() []ActiveSpan {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if len(t.spans) == 0 {
+		return nil
+	}
+	out := append([]ActiveSpan(nil), t.spans...)
+	slices.SortFunc(out, func(a, b ActiveSpan) int { return a.Column - b.Column })
+	return out
+}
+
+// ParentOf returns the parent recorded for a span, or "" when it is a root span
+// or unknown. Parentage outlives a close until the active set empties.
+func (t *SpanTracker) ParentOf(spanID string) string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.parentMap[spanID]
+}
+
+// SetSpanType records the type (tool name / item type) for a span ID.
+func (t *SpanTracker) SetSpanType(spanID, spanType string) {
+	if spanID == "" || spanType == "" {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.spanTypes == nil {
+		t.spanTypes = make(map[string]string)
+	}
+	t.spanTypes[spanID] = spanType
+}
+
+// GetSpanType returns the stored type for a span ID, or "".
+func (t *SpanTracker) GetSpanType(spanID string) string {
+	if spanID == "" {
+		return ""
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.spanTypes[spanID]
+}
+
+// ReserveSpanColor commits to the color that the next OpenSpan(spanID,
+// parentSpanID) call will receive, so the caller can persist the color into
+// a message before the span itself opens. The reservation is held on the
+// tracker's pending slot and consumed when OpenSpan is called for the same
+// spanID. Subsequent calls with the same spanID are idempotent and return
+// the cached color; calls with a different spanID overwrite the slot.
+//
+// Safe to call only when output processing is sequential per agent (which
+// it is for all Claude/Codex/ACP handlers).
+func (t *SpanTracker) ReserveSpanColor(spanID, parentSpanID string) int32 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.pending != nil && t.pending.spanID == spanID {
+		return int32(t.pending.color)
+	}
+	column := t.resolveColumn(parentSpanID)
+	color := t.chooseColor(parentSpanID, column)
+	t.pending = &pendingSpan{spanID: spanID, color: color}
+	return int32(color)
+}
+
+// Snapshot returns the depth and span lines for a given parentSpanID in a single
+// atomic operation. connectorSpanID identifies the span this message connects to
+// (used to compute passthrough hints for columns to the right of the connector).
+// When closing is true, the connector column renders as └ instead of ├.
+// This avoids the TOCTOU risk of calling DepthFor and SpanLines separately,
+// and reduces mutex acquisitions.
+func (t *SpanTracker) Snapshot(parentSpanID, connectorSpanID string, closing bool) (depth int32, spanLines string, connectorColorOut int32) {
+	connectorColorOut = 0 // no connector found
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	// Span lines serialization.
+	if len(t.spans) == 0 {
+		// Depth lookup (no spans to search).
+		return depth, "[]", connectorColorOut
+	}
+
+	// Depth lookup via parent chain; single pass for maxCol.
+	if parentSpanID != "" {
+		depth = int32(t.depthOf(parentSpanID))
+	}
+	maxCol := 0
+	for _, s := range t.spans {
+		if s.Column > maxCol {
+			maxCol = s.Column
+		}
+	}
+
+	lines := make([]*SpanLine, maxCol+1)
+	for _, s := range t.spans {
+		lines[s.Column] = &SpanLine{
+			SpanID: s.SpanID,
+			Color:  s.ColorIndex,
+			Type:   SpanLineActive,
+		}
+	}
+
+	// Find the connector column and apply rendering hints.
+	connectorCol := -1
+	connectorColor := 0
+	if connectorSpanID != "" {
+		for col, l := range lines {
+			if l != nil && l.SpanID == connectorSpanID {
+				connectorCol = col
+				connectorColor = l.Color
+				connectorColorOut = int32(l.Color)
+				if closing {
+					l.Type = SpanLineConnectorEnd
+				} else {
+					l.Type = SpanLineConnector
+				}
+				break
+			}
+		}
+	}
+
+	// Mark columns to the right of the connector as passthrough.
+	if connectorCol >= 0 {
+		for col := connectorCol + 1; col < len(lines); col++ {
+			if lines[col] == nil {
+				lines[col] = &SpanLine{
+					Type:             SpanLinePassthrough,
+					PassthroughColor: connectorColor,
+				}
+			} else {
+				lines[col].Type = SpanLineActivePassthrough
+				lines[col].PassthroughColor = connectorColor
+			}
+		}
+	}
+
+	data, err := json.Marshal(lines)
+	if err != nil {
+		slog.Warn("marshal span lines", "error", err)
+		return depth, "[]", connectorColorOut
+	}
+	return depth, string(data), connectorColorOut
+}
+
+// ShouldBroadcastStreamChunk reports whether a live stream chunk should be
+// broadcast. spanID is the span the chunk belongs to, or "" for the agent's
+// free-form text.
+//
+// A chunk that belongs to an ACTIVE span is its own tool's live output, and the
+// frontend routes it to that tool's card, so it always goes. Testing only
+// "is any span open" suppressed every one of them: a tool's output delta is
+// emitted while that tool's span is open by construction, so the whole
+// per-tool live stream never reached the UI for any provider.
+//
+// Free-form text (spanID "") stays suppressed while any span is active, which
+// is what the suppression was written for -- it keeps the agent's prose from
+// interleaving with a running tool.
+//
+// A chunk naming a span that is NOT active (already closed, or a spawn that
+// owns none) falls under the same free-form rule: with nothing open it goes,
+// otherwise it waits.
+func (t *SpanTracker) ShouldBroadcastStreamChunk(spanID string) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if spanID != "" {
+		for _, s := range t.spans {
+			if s.SpanID == spanID {
+				return true
+			}
+		}
+	}
+	return len(t.spans) == 0
+}

--- a/backend/internal/worker/spantrack/spantrack_test.go
+++ b/backend/internal/worker/spantrack/spantrack_test.go
@@ -1,9 +1,10 @@
-package service
+package spantrack
 
 import (
 	"encoding/json"
 	"fmt"
 	"math/rand/v2"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -307,36 +308,41 @@ func TestSpanTracker_ConnectorEnd(t *testing.T) {
 	assert.Equal(t, SpanLineConnector, parsed[0].Type)
 }
 
-// DiscardSpan and CloseSpan both free the column; only CloseSpan forgets the
-// recorded type. Asserted as a pair so the one difference between them cannot
-// regress unnoticed.
-func TestSpanTracker_DiscardSpanKeepsTypeAndCloseSpanDropsIt(t *testing.T) {
+// CloseSpan frees the column but KEEPS the recorded type; only Reset clears
+// types, at the turn boundary. Every reader wants the type after the span leaves
+// the active set -- a provider's closing message reads it back to persist
+// span_type, and an ACP history replay re-delivers that message much later.
+func TestSpanTracker_CloseSpanKeepsTheTypeAndResetClearsIt(t *testing.T) {
 	t.Parallel()
 
 	tracker := &SpanTracker{}
-	tracker.SetSpanType("span-discard", "task")
-	tracker.SetSpanType("span-close", "read")
-	tracker.OpenSpan("span-discard", "")
-	tracker.OpenSpan("span-close", "")
+	tracker.SetSpanType("span-a", "task")
+	tracker.SetSpanType("span-b", "read")
+	tracker.OpenSpan("span-a", "")
+	tracker.OpenSpan("span-b", "")
 
-	tracker.DiscardSpan("span-discard")
-	tracker.CloseSpan("span-close")
+	tracker.CloseSpan("span-a")
+	tracker.CloseSpan("span-b")
 
 	_, lines, _ := tracker.Snapshot("", "", false)
 	assert.Equal(t, "[]", lines, "both spans left the active set")
-	assert.Equal(t, "task", tracker.GetSpanType("span-discard"),
-		"a discarded span keeps its type: the closing message still reads it back")
-	assert.Empty(t, tracker.GetSpanType("span-close"), "a closed span forgets its type")
+	assert.Equal(t, "task", tracker.GetSpanType("span-a"),
+		"a closed span keeps its type: a replayed closing message still reads it")
+	assert.Equal(t, "read", tracker.GetSpanType("span-b"))
+
+	tracker.Reset()
+	assert.Empty(t, tracker.GetSpanType("span-a"), "the turn boundary clears types")
+	assert.Empty(t, tracker.GetSpanType("span-b"))
 }
 
-// A discarded span frees its column, so the next span starts at column 0 rather
+// Closing a span frees its column, so the next span starts at column 0 rather
 // than being pushed right by a rail nobody draws.
-func TestSpanTracker_DiscardSpanFreesTheColumn(t *testing.T) {
+func TestSpanTracker_CloseSpanFreesTheColumn(t *testing.T) {
 	t.Parallel()
 
 	tracker := &SpanTracker{}
 	tracker.OpenSpan("span-spawn", "")
-	tracker.DiscardSpan("span-spawn")
+	tracker.CloseSpan("span-spawn")
 	tracker.OpenSpan("span-next", "")
 
 	_, lines, _ := tracker.Snapshot("", "", false)
@@ -346,19 +352,19 @@ func TestSpanTracker_DiscardSpanFreesTheColumn(t *testing.T) {
 	assert.Equal(t, "span-next", parsed[0].SpanID)
 }
 
-// A reservation that OpenSpan never consumed must not survive a discard, or its
+// A reservation that OpenSpan never consumed must not survive the close, or its
 // color stays blocked for the rest of the turn.
-func TestSpanTracker_DiscardSpanDropsAnUnconsumedReservation(t *testing.T) {
+func TestSpanTracker_CloseSpanDropsAnUnconsumedReservation(t *testing.T) {
 	t.Parallel()
 
 	tracker := &SpanTracker{}
 	reserved := tracker.ReserveSpanColor("span-spawn", "")
 	require.NotZero(t, reserved)
 
-	tracker.DiscardSpan("span-spawn")
+	tracker.CloseSpan("span-spawn")
 
 	// With the reservation gone, the whole palette is free again, so a span that
-	// opens now can draw the color the discarded one had reserved. Sample until
+	// opens now can draw the color that the discarded one reserved. Sample until
 	// it does; a surviving reservation would block it forever.
 	drewReservedColor := false
 	for i := 0; i < 200 && !drewReservedColor; i++ {
@@ -370,27 +376,27 @@ func TestSpanTracker_DiscardSpanDropsAnUnconsumedReservation(t *testing.T) {
 	assert.True(t, drewReservedColor, "the reserved color returned to the pool")
 }
 
-// Discarding the last span clears the parent chain, exactly as closing it does.
-func TestSpanTracker_DiscardSpanClearsParentageWhenLast(t *testing.T) {
+// Closing the last span clears the parent chain.
+func TestSpanTracker_CloseSpanClearsParentageWhenLast(t *testing.T) {
 	t.Parallel()
 
 	tracker := &SpanTracker{}
 	tracker.OpenSpan("span-parent", "")
 	tracker.OpenSpan("span-child", "span-parent")
 	tracker.CloseSpan("span-child")
-	tracker.DiscardSpan("span-parent")
+	tracker.CloseSpan("span-parent")
 
 	depth, lines, _ := tracker.Snapshot("span-child", "", false)
 	assert.Equal(t, "[]", lines)
 	assert.Equal(t, int32(0), depth, "the parent chain is gone, so nothing is nested")
 }
 
-func TestSpanTracker_DiscardSpanUnknownIDIsNoOp(t *testing.T) {
+func TestSpanTracker_CloseSpanUnknownIDIsNoOp(t *testing.T) {
 	t.Parallel()
 
 	tracker := &SpanTracker{}
 	tracker.OpenSpan("span-A", "")
-	tracker.DiscardSpan("span-nope")
+	tracker.CloseSpan("span-nope")
 
 	_, lines, _ := tracker.Snapshot("", "", false)
 	var parsed []*SpanLine
@@ -432,38 +438,80 @@ func TestSpanTracker_SnapshotUnopenedSpanAloneIsEmpty(t *testing.T) {
 	assert.Equal(t, int32(0), connectorColor)
 }
 
-// A spawn opens no span, so live deltas keep flowing while the subagent runs.
-func TestSpanTracker_ShouldBroadcastStreamChunk_AllowsWhileASpawnRuns(t *testing.T) {
+// A spawn recognized late opened a span, so deltas were suppressed; giving the
+// span back must restore them for the rest of the subagent's run.
+//
+// Recording a span type alone would prove nothing here -- SetSpanType never
+// touches the active set, so the assertion would hold whatever the code did.
+// Only a real open and a real close exercise this.
+func TestSpanTracker_ShouldBroadcastStreamChunk_ResumesWhenASpawnGivesItsSpanBack(t *testing.T) {
 	t.Parallel()
 
 	tracker := &SpanTracker{}
-	// The spawn's tool_use only records a type; it never opens a span.
 	tracker.SetSpanType("span-spawn", "Agent")
-	assert.True(t, tracker.ShouldBroadcastStreamChunk())
+	tracker.OpenSpan("span-spawn", "")
+	require.False(t, tracker.ShouldBroadcastStreamChunk(""),
+		"an open span suppresses the agent's free-form text")
+
+	tracker.CloseSpan("span-spawn")
+
+	assert.True(t, tracker.ShouldBroadcastStreamChunk(""),
+		"the spawn gave its span back, so the parent streams for the rest of the run")
+	assert.Equal(t, "Agent", tracker.GetSpanType("span-spawn"),
+		"and the close kept the type the closing message reads back")
+}
+
+// A chunk that belongs to an ACTIVE span is that tool's own live output. It was
+// suppressed by the "any span open" test, and a tool's output delta is emitted
+// while its own span is open by construction -- so per-tool live output never
+// reached the UI, for any provider.
+func TestSpanTracker_ShouldBroadcastStreamChunk_AllowsASpansOwnOutput(t *testing.T) {
+	t.Parallel()
+
+	tracker := &SpanTracker{}
+	tracker.OpenSpan("span-A", "")
+
+	assert.True(t, tracker.ShouldBroadcastStreamChunk("span-A"),
+		"a tool streams its own output while it runs")
+	assert.False(t, tracker.ShouldBroadcastStreamChunk(""),
+		"the agent's free-form text still waits for the tool")
+	assert.False(t, tracker.ShouldBroadcastStreamChunk("span-other"),
+		"a chunk for a span that is not active follows the free-form rule")
+
+	// A second concurrent tool streams its own output too.
+	tracker.OpenSpan("span-B", "")
+	assert.True(t, tracker.ShouldBroadcastStreamChunk("span-A"))
+	assert.True(t, tracker.ShouldBroadcastStreamChunk("span-B"))
+
+	tracker.CloseSpan("span-A")
+	assert.False(t, tracker.ShouldBroadcastStreamChunk("span-A"),
+		"once closed, its late chunks follow the free-form rule again")
 }
 
 func TestSpanTracker_ShouldBroadcastStreamChunk_AllowsWhenNoSpansActive(t *testing.T) {
 	t.Parallel()
 
 	tracker := &SpanTracker{}
-	assert.True(t, tracker.ShouldBroadcastStreamChunk())
+	assert.True(t, tracker.ShouldBroadcastStreamChunk(""))
+	assert.True(t, tracker.ShouldBroadcastStreamChunk("span-unknown"),
+		"nothing is open, so a chunk for an unknown span goes too")
 }
 
-func TestSpanTracker_ShouldBroadcastStreamChunk_HidesWhenSpanActive(t *testing.T) {
+func TestSpanTracker_ShouldBroadcastStreamChunk_HidesFreeFormWhenSpanActive(t *testing.T) {
 	t.Parallel()
 
 	tracker := &SpanTracker{}
 	tracker.OpenSpan("span-A", "")
-	assert.False(t, tracker.ShouldBroadcastStreamChunk())
+	assert.False(t, tracker.ShouldBroadcastStreamChunk(""))
 }
 
-func TestSpanTracker_ShouldBroadcastStreamChunk_HidesWhenMultipleSpansActive(t *testing.T) {
+func TestSpanTracker_ShouldBroadcastStreamChunk_HidesFreeFormWhenMultipleSpansActive(t *testing.T) {
 	t.Parallel()
 
 	tracker := &SpanTracker{}
 	tracker.OpenSpan("span-A", "")
 	tracker.OpenSpan("span-B", "")
-	assert.False(t, tracker.ShouldBroadcastStreamChunk())
+	assert.False(t, tracker.ShouldBroadcastStreamChunk(""))
 }
 
 func TestSpanTracker_PassthroughWithNullSlot(t *testing.T) {
@@ -803,82 +851,13 @@ func TestSpanTracker_SpanType(t *testing.T) {
 	tracker.SetSpanType("span-2", "")
 	assert.Equal(t, "", tracker.GetSpanType("span-2"))
 
-	// CloseSpan removes the span type.
+	// CloseSpan KEEPS the span type; only Reset clears it.
 	tracker.SetSpanType("span-3", "Read")
 	assert.Equal(t, "Read", tracker.GetSpanType("span-3"))
 	tracker.CloseSpan("span-3")
+	assert.Equal(t, "Read", tracker.GetSpanType("span-3"))
+	tracker.Reset()
 	assert.Equal(t, "", tracker.GetSpanType("span-3"))
-}
-
-func TestSpanTracker_ToolUseConnectorInSubagent(t *testing.T) {
-	t.Parallel()
-
-	// When a tool_use message is emitted inside a subagent, the tool_use's
-	// own span hasn't been opened yet (it opens after persist). The parent
-	// subagent span IS active. The span line for the subagent should render
-	// as "connector" (├), not "active" (│).
-	tracker := &SpanTracker{}
-	tracker.OpenSpan("subagent", "")
-
-	// Simulate persistAndBroadcast for a tool_use inside the subagent:
-	//   span.SpanID       = "tool-1"  (not yet open)
-	//   span.ParentSpanID = "subagent" (already open)
-	//   span.Closing      = false
-	connectorSpanID := resolveConnectorSpanID("tool-1", "", "subagent", false)
-	_, lines, _ := tracker.Snapshot("subagent", connectorSpanID, false)
-
-	var parsed []*SpanLine
-	require.NoError(t, json.Unmarshal([]byte(lines), &parsed))
-	require.Len(t, parsed, 1)
-	assert.Equal(t, SpanLineConnector, parsed[0].Type,
-		"tool_use inside subagent should show connector to parent span")
-}
-
-func TestSpanTracker_ToolResultConnectorInSubagent(t *testing.T) {
-	t.Parallel()
-
-	// A tool_result (closing) message should still connect to the tool's
-	// own span, not the parent — the span is open at this point.
-	tracker := &SpanTracker{}
-	tracker.OpenSpan("subagent", "")
-	tracker.OpenSpan("tool-1", "subagent")
-
-	connectorSpanID := resolveConnectorSpanID("tool-1", "", "subagent", true)
-	_, lines, _ := tracker.Snapshot("subagent", connectorSpanID, true)
-
-	var parsed []*SpanLine
-	require.NoError(t, json.Unmarshal([]byte(lines), &parsed))
-	require.Len(t, parsed, 2)
-	assert.Equal(t, SpanLineActive, parsed[0].Type)
-	assert.Equal(t, SpanLineConnectorEnd, parsed[1].Type,
-		"tool_result should show connector_end on its own span")
-}
-
-func TestSpanTracker_TopLevelToolUseNoConnector(t *testing.T) {
-	t.Parallel()
-
-	// A top-level tool_use (no parent span) should have no connector.
-	tracker := &SpanTracker{}
-
-	connectorSpanID := resolveConnectorSpanID("tool-1", "", "", false)
-	_, lines, _ := tracker.Snapshot("", connectorSpanID, false)
-	assert.Equal(t, "[]", lines)
-}
-
-func TestSpanTracker_ExplicitClosingConnectorUsesOverride(t *testing.T) {
-	t.Parallel()
-
-	tracker := &SpanTracker{}
-	tracker.OpenSpan("subagent", "")
-
-	connectorSpanID := resolveConnectorSpanID("wait-1", "subagent", "", true)
-	_, lines, _ := tracker.Snapshot("", connectorSpanID, true)
-
-	var parsed []*SpanLine
-	require.NoError(t, json.Unmarshal([]byte(lines), &parsed))
-	require.Len(t, parsed, 1)
-	assert.Equal(t, SpanLineConnectorEnd, parsed[0].Type,
-		"explicit connector override should let a spanless message close its parent span")
 }
 
 func TestSpanTracker_ParentMapClearedOnAllClose(t *testing.T) {
@@ -1173,4 +1152,58 @@ func TestSpanTracker_CloseClearsPendingForSameSpan(t *testing.T) {
 
 	tracker.CloseSpan("a")
 	assert.Nil(t, tracker.pending, "CloseSpan for the pending span must clear pending")
+}
+
+// ActiveSpans is the read side the agent package's test double delegates to. It
+// reports each open span WITH its column, in column order, which is the order
+// the service layer renders span_lines in.
+//
+// resolveColumn happens to assign columns in increasing order today, so the
+// tracker's own slice is already sorted; ActiveSpans sorts anyway so its
+// contract does not rest on that. The assertion below states the contract, not
+// the coincidence.
+func TestSpanTracker_ActiveSpansReportsOpenSpansByColumn(t *testing.T) {
+	t.Parallel()
+
+	tracker := &SpanTracker{}
+	assert.Empty(t, tracker.ActiveSpans(), "an empty tracker holds nothing")
+
+	tracker.OpenSpan("span-A", "")       // col 0
+	tracker.OpenSpan("span-B", "span-A") // col 1
+	tracker.OpenSpan("span-C", "")       // col 2
+	tracker.CloseSpan("span-B")          // frees col 1, leaving a gap
+
+	active := tracker.ActiveSpans()
+	require.Len(t, active, 2, "a closed span is gone from the active set")
+	assert.Equal(t, "span-A", active[0].SpanID)
+	assert.Equal(t, 0, active[0].Column)
+	assert.Equal(t, "span-C", active[1].SpanID)
+	assert.Equal(t, 2, active[1].Column, "the gap the close left is preserved")
+	assert.True(t, slices.IsSortedFunc(active, func(a, b ActiveSpan) int { return a.Column - b.Column }))
+
+	// The returned slice is a copy: mutating it must not corrupt the tracker.
+	active[0].SpanID = "clobbered"
+	assert.Equal(t, "span-A", tracker.ActiveSpans()[0].SpanID)
+}
+
+// ParentOf exposes the parentage the tracker records. It outlives a close, so a
+// row persisted after its parent closed still reports the chain it belonged to;
+// emptying the active set clears it.
+func TestSpanTracker_ParentOf(t *testing.T) {
+	t.Parallel()
+
+	tracker := &SpanTracker{}
+	assert.Empty(t, tracker.ParentOf("unknown"), "an unknown span has no parent")
+
+	tracker.OpenSpan("span-A", "")
+	tracker.OpenSpan("span-B", "span-A")
+	assert.Empty(t, tracker.ParentOf("span-A"), "a root span reports no parent")
+	assert.Equal(t, "span-A", tracker.ParentOf("span-B"))
+
+	tracker.CloseSpan("span-B")
+	assert.Equal(t, "span-A", tracker.ParentOf("span-B"),
+		"parentage outlives a close while any span is still active")
+
+	tracker.CloseSpan("span-A")
+	assert.Empty(t, tracker.ParentOf("span-B"), "the last close clears the chain")
 }

--- a/frontend/src/components/chat/ChatView.test.tsx
+++ b/frontend/src/components/chat/ChatView.test.tsx
@@ -2954,4 +2954,42 @@ describe('chat view virtualized with stubbed deps', () => {
       expect(container.querySelector('[data-testid="chat-scroll-rail"]')).toBeNull()
     })
   })
+  describe('data-span-columns row hook', () => {
+    // Every span-line column class is a hashed vanilla-extract name, so
+    // data-span-columns is the only stable way for an e2e spec to read how many
+    // rails one row draws. It must be present on BOTH branches, including the
+    // zero case -- that is the case a subagent spawn produces.
+    const withSpanLines = (id: string, lines: unknown[]): AgentChatMessage => ({
+      ...makeMessage('assistant', `row ${id}`, id),
+      spanLines: JSON.stringify(lines),
+    } as AgentChatMessage)
+
+    it('reports 0 for a row that draws no rail', () => {
+      const { container } = render(() => (
+        <PreferencesProvider>
+          <ChatView messages={[withSpanLines('m1', [])]} streamingText="" />
+        </PreferencesProvider>
+      ))
+      const rows = container.querySelectorAll('[data-span-columns]')
+      expect(rows.length).toBeGreaterThan(0)
+      rows.forEach(row => expect(row.getAttribute('data-span-columns')).toBe('0'))
+    })
+
+    it('reports the column count for a row that draws rails', () => {
+      const { container } = render(() => (
+        <PreferencesProvider>
+          <ChatView
+            messages={[withSpanLines('m1', [
+              { span_id: 'span-A', color: 1, type: 'active' },
+              { span_id: 'span-B', color: 2, type: 'connector_end' },
+            ])]}
+            streamingText=""
+          />
+        </PreferencesProvider>
+      ))
+      const rows = container.querySelectorAll('[data-span-columns]')
+      expect(rows.length).toBeGreaterThan(0)
+      rows.forEach(row => expect(row.getAttribute('data-span-columns')).toBe('2'))
+    })
+  })
 })

--- a/frontend/src/components/chat/ChatView.tsx
+++ b/frontend/src/components/chat/ChatView.tsx
@@ -1118,7 +1118,7 @@ export const ChatView: Component<ChatViewProps> = (props) => {
                                   */}
                                   <Show
                                     when={parsedSpanLines.length > 0}
-                                    fallback={<div data-span-columns="0" style={{ 'margin-left': `${NO_SPAN_MARGIN}px` }}>{bubble}</div>}
+                                    fallback={<div data-span-columns={parsedSpanLines.length} style={{ 'margin-left': `${NO_SPAN_MARGIN}px` }}>{bubble}</div>}
                                   >
                                     <div class={styles.messageRow} data-span-columns={parsedSpanLines.length}>
                                       <SpanLines lines={parsedSpanLines} />

--- a/frontend/src/components/chat/ChatView.tsx
+++ b/frontend/src/components/chat/ChatView.tsx
@@ -1108,15 +1108,20 @@ export const ChatView: Component<ChatViewProps> = (props) => {
                               const bubble = renderMessageBubble(entry)
                               return (
                                 <>
+                                  {/*
+                                    data-span-columns carries how many rails
+                                    this row draws (0 when it draws none, e.g. a
+                                    subagent spawn with nothing else open). Every
+                                    column class is a hashed vanilla-extract
+                                    name, so an e2e spec has no other stable way
+                                    to read the rail count of one row.
+                                  */}
                                   <Show
                                     when={parsedSpanLines.length > 0}
-                                    fallback={<div style={{ 'margin-left': `${NO_SPAN_MARGIN}px` }}>{bubble}</div>}
+                                    fallback={<div data-span-columns="0" style={{ 'margin-left': `${NO_SPAN_MARGIN}px` }}>{bubble}</div>}
                                   >
-                                    <div class={styles.messageRow}>
-                                      <SpanLines
-                                        lines={parsedSpanLines}
-                                        spanOpener={!!msg.spanId}
-                                      />
+                                    <div class={styles.messageRow} data-span-columns={parsedSpanLines.length}>
+                                      <SpanLines lines={parsedSpanLines} />
                                       <div class={styles.messageRowContent}>
                                         {bubble}
                                       </div>

--- a/frontend/src/components/chat/widgets/SpanLines.css.ts
+++ b/frontend/src/components/chat/widgets/SpanLines.css.ts
@@ -45,17 +45,13 @@ import {
 // ─── Styles ─────────────────────────────────────────────────────────
 
 /** Container for all span line columns. */
-const spanLinesContainerBase = style({
+export const spanLinesContainer = style({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'stretch',
   flexShrink: 0,
   paddingRight: `${CONTAINER_PAD_RIGHT}px`,
 })
-
-export const spanLinesContainer = style([spanLinesContainerBase])
-
-export const spanLinesContainerSpanOpener = style([spanLinesContainerBase])
 
 /** Base style for a single span line column. */
 const spanLineColumnBase = style({

--- a/frontend/src/components/chat/widgets/SpanLines.test.tsx
+++ b/frontend/src/components/chat/widgets/SpanLines.test.tsx
@@ -18,7 +18,6 @@ describe('spanLines', () => {
     const { container } = render(() => (
       <SpanLines
         lines={[{ span_id: 'span-A', color: 0, type: 'active' }]}
-        spanOpener
       />
     ))
     // Should render a container div with one child (the column).
@@ -31,7 +30,6 @@ describe('spanLines', () => {
     const { container } = render(() => (
       <SpanLines
         lines={[{ span_id: 'span-A', color: 0, type: 'active' }, null, { span_id: 'span-B', color: 1, type: 'active' }]}
-        spanOpener
       />
     ))
     const wrapper = container.firstElementChild
@@ -48,7 +46,6 @@ describe('spanLines', () => {
           { span_id: 'span-B', color: 1, type: 'active' },
           { span_id: 'span-C', color: 2, type: 'active' },
         ]}
-        spanOpener={false}
       />
     ))
     const wrapper = container.firstElementChild

--- a/frontend/src/components/chat/widgets/SpanLines.tsx
+++ b/frontend/src/components/chat/widgets/SpanLines.tsx
@@ -10,7 +10,6 @@ import {
   spanLineEmpty,
   spanLinePassthrough,
   spanLinesContainer,
-  spanLinesContainerSpanOpener,
   spanPassthroughColors,
 } from './SpanLines.css'
 
@@ -33,7 +32,6 @@ export interface SpanLine {
 
 interface SpanLinesProps {
   lines: (SpanLine | null)[]
-  spanOpener?: boolean
 }
 
 const TYPE_STYLES: Record<SpanLine['type'], string> = {
@@ -106,11 +104,9 @@ export function shouldConnectSpanLineTop(line: SpanLine | null, previousLine: Sp
 }
 
 export const SpanLines: Component<SpanLinesProps> = (props) => {
-  const containerClass = () => props.spanOpener ? spanLinesContainerSpanOpener : spanLinesContainer
-
   return (
     <Show when={props.lines && props.lines.length > 0}>
-      <div class={containerClass()}>
+      <div class={spanLinesContainer}>
         {/*
           <Index> keys columns by position (the array is positional plain data),
           so re-parsing span_lines updates each column's class in place instead

--- a/frontend/tests/e2e/119-opencode-tool-execution.spec.ts
+++ b/frontend/tests/e2e/119-opencode-tool-execution.spec.ts
@@ -13,10 +13,15 @@ opencodeTest.describe('OpenCode Tool Execution', () => {
     await sendMessage(page, 'Use your shell tool to run `ls` in the current directory and report the output. You must call the tool — do not describe what ls would do.')
     await waitForAgentIdle(page, 180_000)
 
-    // A successful tool dispatch renders at least one thread-line. If the
-    // agent answers without ever invoking a tool, that is the regression
-    // this test was added to catch.
-    const toolBubbles = page.locator('[data-testid="thread-line-connector"], [data-testid="thread-line-active"]')
-    await expect(toolBubbles.first()).toBeVisible()
+    // A successful tool dispatch renders at least one row that draws a span
+    // rail. If the agent answers without ever invoking a tool, that is the
+    // regression this test was added to catch.
+    //
+    // data-span-columns is the count of rails on one row; a row that draws none
+    // reports "0". The previous locator here named two data-testids that no
+    // component has ever emitted, so it could only pass while the whole spec
+    // was skipped.
+    const railedRows = page.locator('[data-span-columns]:not([data-span-columns="0"]):visible')
+    await expect(railedRows.first()).toBeVisible()
   })
 })

--- a/frontend/tests/e2e/119-opencode-tool-execution.spec.ts
+++ b/frontend/tests/e2e/119-opencode-tool-execution.spec.ts
@@ -18,7 +18,7 @@ opencodeTest.describe('OpenCode Tool Execution', () => {
     // regression this test was added to catch.
     //
     // data-span-columns is the count of rails on one row; a row that draws none
-    // reports "0". The previous locator here named two data-testids that no
+    // reports "0". The previous locator here specified two data-testids that no
     // component has ever emitted, so it could only pass while the whole spec
     // was skipped.
     const railedRows = page.locator('[data-span-columns]:not([data-span-columns="0"]):visible')

--- a/frontend/tests/e2e/178-subagent-spawn-has-no-span.spec.ts
+++ b/frontend/tests/e2e/178-subagent-spawn-has-no-span.spec.ts
@@ -1,0 +1,70 @@
+/**
+ * 178 — A subagent spawn draws no span rail.
+ *
+ * A spawn used to open a span that stayed open for the subagent's whole run, so
+ * every concurrent tool was pushed one column right and the transcript filled
+ * with deep rails that carried no information. The spawn now owns no span: its
+ * tool_use row and its tool_result row draw whatever rail the OTHER open spans
+ * draw, and nothing more.
+ *
+ * The exact geometry is pinned by the Go unit tests (claude_subagent_test.go,
+ * span_tracker_test.go, output_spawn_span_lines_test.go), which script the
+ * envelope order directly. This spec is the whole-stack smoke test: it drives a
+ * REAL Claude CLI, so it asserts only what holds however the model behaves —
+ * that the spawn rows carry no rail of their own, and that an ordinary tool in
+ * the same transcript still draws one.
+ *
+ * data-span-columns is the rail count of one row ("0" when it draws none). Every
+ * span-line column class is a hashed vanilla-extract name, so it is the only
+ * stable hook for this.
+ *
+ * The model may decline to spawn at all, which is its discretion rather than a
+ * defect, so requireRegistryRow skips instead of failing.
+ */
+import { expect, test } from './fixtures'
+import { requireRegistryRow } from './helpers/subagentRegistry'
+import { sendMessage, waitForAgentIdle } from './helpers/ui'
+
+/** The Claude Agent tool's result header: "Agent <id> completed". */
+const AGENT_RESULT_HEADER = /Agent \S+ (completed|failed|launched asynchronously)/
+/** The Agent tool's own card title, which carries the subagent type. */
+const AGENT_TYPE = 'general-purpose'
+
+test.describe('subagent spawn has no span', () => {
+  test('the spawn rows draw no rail of their own', async ({ authenticatedWorkspace, page }) => {
+    void authenticatedWorkspace
+
+    // Directive about the TOOL as well as the outcome: spec 170 found that a
+    // task the model can shortcut with Bash produces a shell row and covers
+    // nothing. Writing prose is something Bash cannot do.
+    const MARKER = 'SPAN-SPAWN-MARKER'
+    await sendMessage(page, `You MUST use the Task tool. Spawn exactly one general-purpose subagent and give it this prompt verbatim: "Write one sentence about the tide, then end your reply with the token ${MARKER}." Do not answer it yourself and do not use Bash. Wait for the subagent to finish, then tell me what it wrote.`)
+    await waitForAgentIdle(page, 180_000)
+
+    // Skips when the model declined to spawn.
+    await requireRegistryRow(test, page)
+
+    // Rows are scoped to :visible — ChatView renders every unmeasured row twice
+    // and the sidebar is mounted twice, so an unscoped locator picks the wrong
+    // copy.
+    const spawnResultRow = page
+      .locator('[data-span-columns]:visible')
+      .filter({ hasText: AGENT_RESULT_HEADER })
+      .first()
+    await expect(spawnResultRow).toBeVisible()
+
+    // The spawn's own result draws no rail. Any column it DOES show would have
+    // to come from another tool that is still running, and this prompt asks for
+    // no other tool.
+    await expect(spawnResultRow).toHaveAttribute('data-span-columns', '0')
+
+    // Its tool_use card -- the row titled with the subagent type -- draws none
+    // either. Before the change this row was the one that opened the rail.
+    const spawnCardRow = page
+      .locator('[data-span-columns]:visible')
+      .filter({ hasText: AGENT_TYPE })
+      .first()
+    await expect(spawnCardRow).toBeVisible()
+    await expect(spawnCardRow).toHaveAttribute('data-span-columns', '0')
+  })
+})

--- a/frontend/tests/e2e/178-subagent-spawn-has-no-span.spec.ts
+++ b/frontend/tests/e2e/178-subagent-spawn-has-no-span.spec.ts
@@ -23,7 +23,7 @@
  */
 import { expect, test } from './fixtures'
 import { requireRegistryRow } from './helpers/subagentRegistry'
-import { sendMessage, waitForAgentIdle } from './helpers/ui'
+import { ASSISTANT_BUBBLE_SELECTOR, sendMessage, waitForAgentIdle } from './helpers/ui'
 
 /** The Claude Agent tool's result header: "Agent <id> completed". */
 const AGENT_RESULT_HEADER = /Agent \S+ (completed|failed|launched asynchronously)/
@@ -60,8 +60,14 @@ test.describe('subagent spawn has no span', () => {
 
     // Its tool_use card -- the row titled with the subagent type -- draws none
     // either. Before the change this row was the one that opened the rail.
+    //
+    // Restricted to an AGENT row: the prompt above contains the literal
+    // "general-purpose", so the user's own message row matches AGENT_TYPE too,
+    // and it sits FIRST. Without this filter the assertion reads that row,
+    // which never draws a rail, and passes however the spawn card renders.
     const spawnCardRow = page
       .locator('[data-span-columns]:visible')
+      .filter({ has: page.locator(ASSISTANT_BUBBLE_SELECTOR) })
       .filter({ hasText: AGENT_TYPE })
       .first()
     await expect(spawnCardRow).toBeVisible()


### PR DESCRIPTION
## Motivation

A subagent-spawning tool call opened the same kind of span as any other tool. That span then stayed open for the whole life of the child agent, and the rail it drew carried no information: the subagent's own output already lives in its child transcript tab. Several subagents running at once stacked several columns, and every unrelated tool that started in that window was pushed one column further right. The open span also suppressed the parent's live deltas for the entire run.

Making a spawn own no span means deciding "is this tool call a spawn" in five providers with five different wire shapes. Doing that exposed a set of pre-existing defects in how each provider answered that question, and in how `SpanTracker` handled a span's recorded type and its interaction with streaming. Fixing them was a prerequisite for the feature to be correct on every provider, not an unrelated cleanup.

## Modifications

Detection stays inside each provider's own translator; the shared code learns no provider's tool names.

- **Claude**: `claudeToolSpawnsSubagent` matches `Agent` and its legacy wire name `Task`, but not the `TaskCreate`/`TaskUpdate`/… to-do tools that merely share the prefix. `handleClaudeTaskStarted` gives a span back for every `startedKind != bgtask.KindShell` rather than matching the single literal `"local_workflow"` — the Workflow tool sits behind a CLI feature flag, so it cannot be matched by name at the tool_use site, and the literal left any unrecognized `task_type` with its span open for the child's whole run. Span resolution shared by the parent and child transcript paths moved into `claudeSpanForEnvelope`, `claudeSpanInfoFor` and `claudeCloseToolResultSpans`; the two paths each held their own copy, so the spawn guard had to be written twice at the reserve site and twice at the open site.
- **Codex and Pi**: a new shared `openToolSpan` helper owns the order every provider needs — reserve a colour before the persist, persist before the open, record the span type either way — and skips the reserve and the open for a spawn. Codex keys on `codexCollabToolSpawnAgent`; `wait`, `sendInput`, `resumeAgent` and `closeAgent` keep their spans. Pi keys on `PiToolAgent`.
- **ACP providers**: `acpObservationIsSpawn` used to infer spawn-ness from the shape of the registry write. "Upserts a running row" is not "starts a subagent", and Goose proves the gap — its `subagent_tool_request` update reports on a subagent that already runs, so it was read as a spawn and took the span away from whichever ordinary tool call it rode on. A provider now states the fact through a new `Spawns` field. Cursor keeps a per-agent note of which calls are the `task` tool, because its closing update does not always echo `rawInput` and cannot otherwise tell a backgrounded task from a backgrounded shell; the note is cleared with the session through a new `clearProviderState` hook. Reasonix now requires a real `prompt` instead of accepting any `description`. `acpStatusIsFinal` replaces three copies of the same finished-status check.
- **`spantrack` (new package)**: the `SpanTracker` engine moved out of `service/output.go`, which keeps type aliases so its API is unchanged. The `agent` package cannot import `service` — that would be a cycle — so its test double had to re-implement the engine, and had drifted from it; the double now delegates to the real thing. `resolveConnectorSpanID` stays in `service`, because which span a persisted row connects to is a persist-path concern rather than engine state.
- **Span type lifetime**: `CloseSpan` no longer forgets a span's recorded type; only `Reset` clears types at the turn boundary. Every reader wants the type after the span leaves the active set — a provider's closing message reads it back to persist `span_type`, and an ACP history replay redelivers that message much later, where the old behaviour degraded the row to a fallback type. That removed the reason `DiscardSpan` existed, so it is deleted and both callers use `CloseSpan`.
- **Live output**: `ShouldBroadcastStreamChunk` now takes the chunk's span id. It suppressed every delta while any span was open, but a tool's own output delta is emitted while that tool's span is open by construction, so per-tool live output never reached the UI for any provider. A chunk belonging to an active span now goes; the agent's free-form text still waits.
- **Frontend**: each message row carries `data-span-columns`, the rail count including the zero case, because every span-line column class is a hashed vanilla-extract name and an e2e spec had no other stable hook. The dead `spanOpener` prop is removed — both container styles it chose between were identical. Spec 119's old locator named two `data-testid`s that no component emits, so it could only pass while the spec was skipped; new spec 178 drives a real Claude CLI and asserts a spawn's two rows draw no rail.

No breaking changes: the `service` package's exported surface is preserved by aliases, and nothing here touches a wire format or a database schema.

## Result

- A subagent spawn draws no rail of its own, and its card takes the neutral border. Concurrent tools keep their columns instead of being pushed one to the right for as long as a subagent runs.
- The parent keeps streaming while a subagent runs. Its deltas were suppressed for the whole run by the span the spawn used to hold open.
- Per-tool live output now reaches the UI at all, on every provider. A running tool's own output was previously buffered until its finished row persisted, because the tool's own open span suppressed it.
- A Cursor backgrounded shell lands in the sidebar as a shell row with a readable title, instead of under the subagent filter labelled with its raw `toolCallId` — and a backgrounded `task` call no longer flips the other way, losing its kind and its trimmed title, when its closing update omits `rawInput`.
- A Goose subagent's tool request no longer makes the tool call it arrives on lose its rail mid-run, and Reasonix no longer creates a phantom subagent row for an ordinary tool that happens to carry a `description` argument.
- A Claude task type that no name list matches is handled by the general path, instead of leaving a rail open for the child's whole run.
