### PR TITLE
feat(chat): Rebuild the scroll rail's scrub, preview, and seeks

### DIFF
--- a/frontend/src/api/workerRpc.ts
+++ b/frontend/src/api/workerRpc.ts
@@ -350,8 +350,8 @@ export function listAgents(workerId: string, req: MessageInitShape<typeof ListAg
   return callWorker(workerId, 'ListAgents', ListAgentsRequestSchema, ListAgentsResponseSchema, req)
 }
 
-export function listAgentMessages(workerId: string, req: MessageInitShape<typeof ListAgentMessagesRequestSchema>): Promise<ListAgentMessagesResponse> {
-  return callWorker(workerId, 'ListAgentMessages', ListAgentMessagesRequestSchema, ListAgentMessagesResponseSchema, req)
+export function listAgentMessages(workerId: string, req: MessageInitShape<typeof ListAgentMessagesRequestSchema>, opts?: { signal?: AbortSignal }): Promise<ListAgentMessagesResponse> {
+  return callWorker(workerId, 'ListAgentMessages', ListAgentMessagesRequestSchema, ListAgentMessagesResponseSchema, req, opts)
 }
 
 export function listMessageMarks(workerId: string, req: MessageInitShape<typeof ListMessageMarksRequestSchema>, opts?: { signal?: AbortSignal }): Promise<ListMessageMarksResponse> {

--- a/frontend/src/components/chat/ChatScrollRail.css.ts
+++ b/frontend/src/components/chat/ChatScrollRail.css.ts
@@ -1,14 +1,19 @@
 import { globalStyle, style } from '@vanilla-extract/css'
+import { floatingCardSurface } from '~/styles/popover.css'
 
 // Fixed px here are scrollbar-like dimensions (rail/thumb/dot widths, thumb radius),
 // NOT spacing-scale values -- see CLAUDE.md. The top/bottom insets use the spacing scale.
 
 /**
- * Max height of the preview popover (px). Exported so ChatScrollRail's vertical clamp (which
- * keeps a near-edge popover from clipping against the overflow-hidden wrapper) reads the SAME
- * value the CSS enforces, rather than a hand-synced literal that could drift from this one.
+ * Max height of the preview card (px): the point at which a long preview stops growing the card
+ * and starts scrolling inside it.
+ *
+ * The cap only. The vertical clamp in `cardTopPx` (`./chatDotPreview.ts`) deliberately does NOT
+ * read this: it clamps against the card's MEASURED height, because most previews are far shorter
+ * than the cap and clamping them as though they were 200px tall pushed a one-line card up to
+ * ~90px away from the dot it describes.
  */
-export const PREVIEW_POPOVER_MAX_H_PX = 200
+const PREVIEW_CARD_MAX_H_PX = 200
 
 /** Width of the rail overlay column (a touch wider than the 8px native scrollbar). */
 const RAIL_WIDTH_PX = 10
@@ -157,16 +162,25 @@ export const dot = style({
   boxShadow: '0 0 0 1px var(--background)',
   transition: 'background-color 0.12s ease',
   selectors: {
-    // Recolor on hover so the dot the tooltip describes is visually distinct.
+    // Recolor on hover so the dot the preview card describes is visually distinct.
     '&:hover': {
       backgroundColor: 'var(--accent)',
     },
   },
 })
 
-// Coarse-pointer (touch) hit expander: a transparent ~24px circle centred on the 6px dot,
-// so a finger tap within range still hits the button. A pseudo-element leaves the dot's
-// visual fill + ring at 6px (unlike padding, which would enlarge them or the box-shadow).
+/**
+ * Diameter (px) of the coarse-pointer hit circle around a dot. Exported because the scrub-preview
+ * range in `./chatDotPreview.ts` is derived from it rather than hand-synced: a finger presses
+ * anywhere inside this circle, and the preview card that press opens is resolved by distance from
+ * the dot's rail-Y, so a range narrower than this circle's radius leaves a rim of the hit area
+ * that jumps but shows no preview. Same reason PREVIEW_CARD_MAX_H_PX is exported above.
+ */
+export const DOT_COARSE_HIT_PX = 24
+
+// Coarse-pointer (touch) hit expander: a transparent circle centred on the 6px dot, so a finger
+// tap within range still hits the button. A pseudo-element leaves the dot's visual fill + ring at
+// 6px (unlike padding, which would enlarge them or the box-shadow).
 globalStyle(`${dot}::before`, {
   '@media': {
     '(pointer: coarse)': {
@@ -175,8 +189,8 @@ globalStyle(`${dot}::before`, {
       top: '50%',
       left: '50%',
       transform: 'translate(-50%, -50%)',
-      width: '24px',
-      height: '24px',
+      width: `${DOT_COARSE_HIT_PX}px`,
+      height: `${DOT_COARSE_HIT_PX}px`,
       borderRadius: '50%',
     },
   },
@@ -192,23 +206,23 @@ export const dotCluster = style({
   boxShadow: '0 0 0 1px var(--background), 0 0 0 2.5px var(--primary)',
 })
 
-/** Small muted header in a cluster's tooltip: how many messages it stands for. */
+/** Small muted header in a cluster's preview card: how many messages it stands for. */
 export const dotPreviewCount = style({
-  fontSize: '0.75rem',
+  fontSize: 'var(--text-8)',
   opacity: 0.7,
   marginBottom: 'var(--space-1)',
 })
 
-/** Placeholder line shown in the dot tooltip while its preview is being fetched. */
+/** Placeholder line shown in the dot's preview card while its preview is still in flight. */
 export const dotPreviewLoading = style({
   opacity: 0.7,
   fontStyle: 'italic',
 })
 
 /**
- * Wraps the markdown-rendered preview inside the dot tooltip. The markdown renderer
+ * Wraps the markdown-rendered preview inside the dot's preview card. The markdown renderer
  * emits block elements (paragraphs, blockquotes, lists) with their own vertical
- * margins; strip the outer ones so the preview sits flush against the tooltip padding.
+ * margins; strip the outer ones so the preview sits flush against the card's inset.
  */
 export const dotPreviewMarkdown = style({})
 
@@ -221,26 +235,52 @@ globalStyle(`${dotPreviewMarkdown} > * > :last-child`, { marginBottom: 0 })
 /**
  * The single live preview card shown to the LEFT of the rail for the ACTIVE dot -- whether
  * it's hovered/focused or under the dragging thumb (scrub). One element for both cases, so a
- * hover and a scrub can never show two popovers at once. Its top is set inline (clamped to
+ * hover and a scrub can never show two cards at once. Its top is set inline (clamped to
  * the rail so it never clips against the overflow-hidden wrapper); translateY(-50%) centres
- * it on that Y. Non-interactive so it never intercepts a drag or a click.
+ * it on that Y.
+ *
+ * The card is INTERACTIVE on a fine pointer: the reader moves onto it to select or to scroll its
+ * text, and the close delay in createDotPreview buys them the time to get there. It is inert on a
+ * COARSE pointer, for the same reason railIdle goes inert there. A touch has no hover, so the card
+ * outlives by that delay the gesture that opened it, and a 280px interactive card lying over the
+ * message list would swallow the reader's next tap. A finger reads the card during the scrub and
+ * dismisses it by lifting; it never moves onto it. DotPreviewCard keeps the card's own pointer and
+ * wheel traffic off the rail's handlers, which is what makes the fine-pointer case safe.
+ *
+ * The cost of that reach is that an open card is a hit target: on a fine pointer it covers up to
+ * 280x200px of the message list, and a click there lands on the card rather than on the message
+ * under it. That is the trade a reachable card makes -- the card cannot both accept the reader's
+ * selection drag and pass their click through -- and the close delay bounds it: move off the card
+ * and the region accepts clicks again a moment later.
+ *
+ * Its whole surface -- Oat's card fill, border and radius, the compact inset, and the lift that
+ * separates it from the transcript -- comes from the shared `floatingCardSurface` in
+ * `~/styles/popover.css.ts`, the same class `~/components/common/Tooltip.css.ts` carries. Every
+ * one of those declarations used to be written out here, and the copies had already drifted: this
+ * card filled `var(--background)` while every other floating surface filled `var(--card)`, so the
+ * one card that lay OVER the reader's work was the one painted the page's own colour.
  */
-export const previewPopover = style({
-  position: 'absolute',
-  right: 'calc(100% + var(--space-2))',
-  transform: 'translateY(-50%)',
-  width: 'max-content',
-  maxWidth: '280px',
-  maxHeight: `${PREVIEW_POPOVER_MAX_H_PX}px`,
-  overflowY: 'auto',
-  padding: 'var(--space-2) var(--space-3)',
-  borderRadius: '6px',
-  backgroundColor: 'var(--background)',
-  border: '1px solid var(--border)',
-  boxShadow: '0 2px 8px rgba(0, 0, 0, 0.15)',
-  fontSize: '0.8125rem',
-  lineHeight: 1.4,
-  color: 'var(--text)',
-  pointerEvents: 'none',
-  zIndex: 20,
-})
+export const previewCard = style([floatingCardSurface, {
+  'position': 'absolute',
+  'right': 'calc(100% + var(--space-2))',
+  'transform': 'translateY(-50%)',
+  'width': 'max-content',
+  'maxWidth': '280px',
+  'maxHeight': `${PREVIEW_CARD_MAX_H_PX}px`,
+  'overflowY': 'auto',
+  // On Oat's type scale, and on the same step as the app's other floating surface. The 0.8125rem
+  // this used to specify sat between two steps of that scale and matched nothing else.
+  'fontSize': 'var(--text-8)',
+  'zIndex': 20,
+  'pointerEvents': 'auto',
+  // The rail sets user-select:none (so a thumb drag never selects text) and cursor:pointer, and
+  // both inherit into this card. Undo them here: the card's text is meant to be read, selected,
+  // and copied, and the card itself is not a control.
+  'userSelect': 'text',
+  'cursor': 'auto',
+  '@media': {
+    '(pointer: coarse)': {
+      pointerEvents: 'none',
+    },
+  },
+}])

--- a/frontend/src/components/chat/ChatScrollRail.test.tsx
+++ b/frontend/src/components/chat/ChatScrollRail.test.tsx
@@ -5,7 +5,8 @@ import { fireEvent, render } from '@solidjs/testing-library'
 import { createSignal } from 'solid-js'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { MarkType } from '~/generated/leapmux/v1/agent_pb'
-import { SCRUB_WARM_DEBOUNCE_MS } from './chatDotPreview'
+import { popoverCardPadding } from '~/styles/popover.css'
+import { POINTER_CLOSE_DELAY_MS, SCRUB_WARM_DEBOUNCE_MS } from './chatDotPreview'
 import { resolveScrollbarOwner } from './chatRailPolicy'
 import { ChatScrollRail } from './ChatScrollRail'
 import * as styles from './ChatScrollRail.css'
@@ -115,7 +116,7 @@ function baseProps(overrides: BasePropsOverrides = {}): ChatScrollRailProps {
   }
 }
 
-describe('chatscrollrail', () => {
+describe('chatScrollRail', () => {
   it('renders nothing when not loaded', () => {
     const { container } = render(() => <ChatScrollRail {...baseProps({ loaded: false })} />)
     expect(container.querySelector('[data-testid="chat-scroll-rail"]')).toBeNull()
@@ -311,9 +312,9 @@ describe('chatscrollrail', () => {
     expect(event.defaultPrevented).toBe(false)
   })
 
-  it('claims a press it REJECTS, so a rival press cannot focus a dot and strand its popover', () => {
+  it('claims a press it REJECTS, so a rival press cannot focus a dot and strand its card', () => {
     // A rejected dot press that keeps its default focuses the dot button, and the focus opens the
-    // dot's preview popover -- with no pointerleave on touch to ever close it. That pins
+    // dot's preview card -- with no pointerleave on touch to ever close it. That pins
     // activeDot() non-null, which holds the whole rail lit for the rest of the session.
     HTMLElement.prototype.setPointerCapture = vi.fn()
     installImmediateRaf()
@@ -719,7 +720,7 @@ describe('chatscrollrail', () => {
   })
 
   it('opens the dot preview on a dot press, with no hover to open it', () => {
-    // A touch has no hover: the popover must come from the press itself (the thumb lands on the
+    // A touch has no hover: the card must come from the press itself (the thumb lands on the
     // dot, so the scrub target resolves to it) or a finger would never see a preview.
     HTMLElement.prototype.setPointerCapture = vi.fn()
     installImmediateRaf()
@@ -907,7 +908,7 @@ describe('chatscrollrail', () => {
     expect(capture).toHaveBeenCalledTimes(2)
   })
 
-  it('reveals the preview popover for the dot the thumb passes over while dragging, and warms it after it settles', () => {
+  it('reveals the preview card for the dot the thumb passes over while dragging, and warms it after it settles', () => {
     HTMLElement.prototype.setPointerCapture = vi.fn()
     vi.useFakeTimers()
     installImmediateRaf() // override the faked rAF with a synchronous one for the drag frames
@@ -915,13 +916,13 @@ describe('chatscrollrail', () => {
     const previewFor = (seq: bigint) => (seq === 2n ? 'scrubbed message two' : undefined)
     const { container } = render(() => <ChatScrollRail {...baseProps({ warmPreview, previewFor })} />)
     const rail = railWithRect(container)
-    // No popover until a drag is in progress (and nothing is hovered).
+    // No card until a drag is in progress (and nothing is hovered).
     expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).toBeNull()
     // Grab the fixed thumb, then scrub to the seq-2 dot at y=125.
     rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 12, pointerId: 1 }))
     rail.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientY: 125, pointerId: 1 }))
     const preview = container.querySelectorAll('[data-testid="chat-scroll-rail-preview"]')
-    expect(preview.length).toBe(1) // never two popovers
+    expect(preview.length).toBe(1) // never two cards
     expect(preview[0]).toHaveTextContent('scrubbed message two')
     // The scrub warm is DEBOUNCED: nothing is fetched until the thumb settles on the dot, so a
     // fast fly-over doesn't fire a GetAgentMessage RPC per dot crossed.
@@ -958,7 +959,7 @@ describe('chatscrollrail', () => {
     expect(warmPreview).toHaveBeenCalledWith(4n) // only the settled dot, never the flown-over seq-2
   })
 
-  it('shows no preview popover when the dragging thumb is between dots', () => {
+  it('shows no preview card when the dragging thumb is between dots', () => {
     HTMLElement.prototype.setPointerCapture = vi.fn()
     installImmediateRaf()
     const { container } = render(() => <ChatScrollRail {...baseProps()} />)
@@ -969,7 +970,7 @@ describe('chatscrollrail', () => {
     expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).toBeNull()
   })
 
-  it('shows ONE popover (the scrub target wins) when a dot is hovered while scrubbing', () => {
+  it('shows ONE card (the scrub target wins) when a dot is hovered while scrubbing', () => {
     HTMLElement.prototype.setPointerCapture = vi.fn()
     installImmediateRaf()
     const previewFor = (seq: bigint) => (seq === 2n ? 'scrub target two' : seq === 4n ? 'hovered four' : undefined)
@@ -981,7 +982,7 @@ describe('chatscrollrail', () => {
     const dot4 = container.querySelector('[data-testid="chat-scroll-rail-dot"][data-seq="4"]') as HTMLElement
     fireEvent.pointerEnter(dot4)
     const previews = container.querySelectorAll('[data-testid="chat-scroll-rail-preview"]')
-    expect(previews.length).toBe(1) // exactly one popover, no double
+    expect(previews.length).toBe(1) // exactly one card, no double
     expect(previews[0]).toHaveTextContent('scrub target two') // scrub wins over the hover
     expect(previews[0]).not.toHaveTextContent('hovered four')
   })
@@ -999,6 +1000,27 @@ describe('chatscrollrail', () => {
     const dots = container.querySelectorAll('[data-testid="chat-scroll-rail-dot"]')
     expect(dots[0].getAttribute('aria-label')).toBe('Your message')
     expect(dots[1].getAttribute('aria-label')).toBe('Your response')
+  })
+
+  it('describes a focused dot by the preview card its focus opened', () => {
+    const previewFor = (seq: bigint) => (seq === 2n ? 'the first message' : undefined)
+    const { container } = render(() => <ChatScrollRail {...baseProps({ previewFor })} />)
+    const dots = container.querySelectorAll('[data-testid="chat-scroll-rail-dot"]')
+    expect(dots[0].getAttribute('aria-describedby')).toBeNull()
+
+    // This rail gives FOCUS its own open channel, so the card is a surface the keyboard reaches by
+    // design. Without the description a screen-reader user hears "Your message" and never the
+    // message -- the whole content the feature exists to show.
+    fireEvent.focus(dots[0])
+    const card = container.querySelector('[data-testid="chat-scroll-rail-preview"]')!
+    expect(card.id).not.toBe('')
+    expect(dots[0].getAttribute('aria-describedby')).toBe(card.id)
+    expect(card.textContent).toContain('the first message')
+    // Only the dot the card actually describes claims it.
+    expect(dots[1].getAttribute('aria-describedby')).toBeNull()
+
+    fireEvent.blur(dots[0])
+    expect(dots[0].getAttribute('aria-describedby')).toBeNull()
   })
 
   it('hides the rail when the whole conversation is loaded and fits (thumb would be full)', () => {
@@ -1076,48 +1098,567 @@ describe('chatscrollrail', () => {
   })
 })
 
-describe('chatscrollrail dot preview popover', () => {
-  /** Hover the first dot -- the popover opens IMMEDIATELY (no show-delay), and returns it. */
+describe('chatScrollRail dot preview card', () => {
+  /** Hover the first dot -- the card opens IMMEDIATELY (no show-delay), and returns it. */
   function hoverFirstDot(container: HTMLElement): HTMLElement | null {
     const dot = container.querySelector('[data-testid="chat-scroll-rail-dot"]') as HTMLElement
     fireEvent.pointerEnter(dot)
     return container.querySelector('[data-testid="chat-scroll-rail-preview"]')
   }
 
-  it('clamps the popover into the rail so a dot near the top edge does not clip past it', () => {
-    // With the fixed 24px thumb, the seq-1 dot sits at ~12px,
-    // above the popover's clamp floor. The popover top is pinned down to keep the card visible.
+  it('insets the preview card by the shared popover-card padding, not by a copy of it', () => {
+    // This card is where that value came from, and every card popover in the app now carries
+    // the same class. A literal here instead would be the second source of truth that the
+    // shared class exists to remove. jsdom loads no stylesheet, so the class list is the only
+    // thing a unit test can see -- the resolved pixels are asserted in
+    // tests/e2e/036-dropdown-popover.spec.ts.
+    expect(styles.previewCard.split(' ')).toContain(popoverCardPadding)
+  })
+
+  it('places the card on the Y the controller resolved for its dot', () => {
+    // The clamp that keeps a near-edge card off the overflow-hidden wrapper reads the card's
+    // MEASURED height, and jsdom implements neither layout nor ResizeObserver -- so here the card
+    // reports height 0 and the clamp correctly resolves to the dot's own Y. What this pins is the
+    // WIRING: the rail hands cardTopPx to the card and the card writes it. The clamp's own
+    // arithmetic, which needs a height to be worth asserting, is unit-tested against injected
+    // heights in chatDotPreview.test.ts.
     const marks = [{ seq: 1n, type: MarkType.USER_MESSAGE }]
     const { container } = render(() => <ChatScrollRail {...baseProps({ minSeq: 1n, maxSeq: 100_000n, marks })} />)
     const dot = container.querySelector('[data-testid="chat-scroll-rail-dot"]') as HTMLElement
-    expect(dot.style.top).toBe('12px') // the dot itself is near the top
+    expect(dot.style.top).toBe('12px') // with the fixed 24px thumb, the seq-1 dot sits at ~12px
     fireEvent.pointerEnter(dot)
-    const popover = container.querySelector('[data-testid="chat-scroll-rail-preview"]') as HTMLElement
-    expect(popover.style.top).toBe('100px') // clamped down from 12 (rail 400, half-height 100)
+    const card = container.querySelector('[data-testid="chat-scroll-rail-preview"]') as HTMLElement
+    expect(card.style.top).toBe('12px')
   })
 
-  it('opens the popover immediately on hover and renders the resolved preview as markdown', () => {
+  it('opens the card immediately on hover and renders the resolved preview as markdown', () => {
     const previewFor = (seq: bigint) => (seq === 2n ? '**jump** to this message' : undefined)
     const { container } = render(() => <ChatScrollRail {...baseProps({ previewFor })} />)
-    const popover = hoverFirstDot(container)! // no timers advanced -- it's immediate
-    expect(popover).toHaveTextContent('jump to this message')
+    const card = hoverFirstDot(container)! // no timers advanced -- it's immediate
+    expect(card).toHaveTextContent('jump to this message')
     // The markdown is rendered, not shown as raw source: **jump** becomes a bold element.
-    const strong = popover.querySelector('strong, b')
+    const strong = card.querySelector('strong, b')
     expect(strong?.textContent).toBe('jump')
-    expect(popover.textContent).not.toContain('**')
+    expect(card.textContent).not.toContain('**')
   })
 
-  it('closes the popover when the pointer leaves the dot', () => {
+  it('keeps the card open for the close delay after the pointer leaves the dot, then closes it', () => {
+    vi.useFakeTimers()
     const previewFor = (seq: bigint) => (seq === 2n ? 'hi there' : undefined)
     const { container } = render(() => <ChatScrollRail {...baseProps({ previewFor })} />)
     const dot = container.querySelector('[data-testid="chat-scroll-rail-dot"]') as HTMLElement
     fireEvent.pointerEnter(dot)
     expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).not.toBeNull()
     fireEvent.pointerLeave(dot)
+    // The card sits a gutter away from the rail, so the pointer is over neither for a moment.
+    // Closing on the leave would put the card's selectable text out of reach.
+    vi.advanceTimersByTime(POINTER_CLOSE_DELAY_MS - 1)
+    expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).not.toBeNull()
+    vi.advanceTimersByTime(1)
     expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).toBeNull()
   })
 
-  it('closes the popover when the hovered dot disappears', async () => {
+  it('keeps the card open while the pointer rests on it, and closes it a delay after it leaves', () => {
+    vi.useFakeTimers()
+    const previewFor = (seq: bigint) => (seq === 2n ? 'hi there' : undefined)
+    const { container } = render(() => <ChatScrollRail {...baseProps({ previewFor })} />)
+    const dot = container.querySelector('[data-testid="chat-scroll-rail-dot"]') as HTMLElement
+    fireEvent.pointerEnter(dot)
+    const card = container.querySelector('[data-testid="chat-scroll-rail-preview"]') as HTMLElement
+    // The pointer crosses to the card: leave the dot, arrive on the card.
+    fireEvent.pointerLeave(dot)
+    fireEvent.pointerEnter(card)
+    vi.advanceTimersByTime(POINTER_CLOSE_DELAY_MS * 10) // a reader takes as long as they like
+    expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).not.toBeNull()
+
+    fireEvent.pointerLeave(card)
+    vi.advanceTimersByTime(POINTER_CLOSE_DELAY_MS - 1)
+    expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).not.toBeNull()
+    vi.advanceTimersByTime(1)
+    expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).toBeNull()
+  })
+
+  it('holds the card open while a press inside it drags a selection past its edge', () => {
+    vi.useFakeTimers()
+    const previewFor = (seq: bigint) => (seq === 2n ? 'select me' : undefined)
+    const { container } = render(() => <ChatScrollRail {...baseProps({ previewFor })} />)
+    const { card } = cardUnderPointer(container)
+    // Press inside the card, then drag out of it -- what selecting to the end of a line does.
+    fireEvent.pointerDown(card)
+    fireEvent.pointerLeave(card)
+    vi.advanceTimersByTime(POINTER_CLOSE_DELAY_MS * 10)
+    // Closing here would destroy the selection the reader is still making.
+    expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).not.toBeNull()
+
+    // The button comes up outside the card, so nothing holds it: the usual delay, then closed.
+    fireEvent.pointerUp(window)
+    vi.advanceTimersByTime(POINTER_CLOSE_DELAY_MS - 1)
+    expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).not.toBeNull()
+    vi.advanceTimersByTime(1)
+    expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).toBeNull()
+  })
+
+  it('keeps a FOCUSED dot card open when the pointer visits the card and leaves again', () => {
+    vi.useFakeTimers()
+    const previewFor = (seq: bigint) => (seq === 2n ? 'hi there' : undefined)
+    const { container } = render(() => <ChatScrollRail {...baseProps({ previewFor })} />)
+    const dot = container.querySelector('[data-testid="chat-scroll-rail-dot"]') as HTMLElement
+    // A keyboard reader tabbed to the dot, then reached for the mouse.
+    fireEvent.focus(dot)
+    const card = container.querySelector('[data-testid="chat-scroll-rail-preview"]') as HTMLElement
+    fireEvent.pointerEnter(card)
+    fireEvent.pointerLeave(card)
+    // The pointer let go, but focus never did. One shared channel would have closed the card
+    // here and left a focused dot with nothing to show.
+    vi.advanceTimersByTime(POINTER_CLOSE_DELAY_MS * 10)
+    expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).not.toBeNull()
+
+    fireEvent.blur(dot)
+    expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).toBeNull()
+  })
+
+  it('a press inside the card selects text instead of starting a rail drag', () => {
+    const capture = vi.fn()
+    HTMLElement.prototype.setPointerCapture = capture
+    const onJumpToSeq = vi.fn()
+    const previewFor = (seq: bigint) => (seq === 2n ? 'select me' : undefined)
+    const { container } = render(() => <ChatScrollRail {...baseProps({ previewFor, onJumpToSeq })} />)
+    railWithRect(container)
+    const dot = container.querySelector('[data-testid="chat-scroll-rail-dot"]') as HTMLElement
+    fireEvent.pointerEnter(dot)
+    const card = container.querySelector('[data-testid="chat-scroll-rail-preview"]') as HTMLElement
+    // The card renders INSIDE the rail, so an unhandled press here would reach the rail's own
+    // pointerdown and grab the thumb at the card's Y.
+    const press = new PointerEvent('pointerdown', { bubbles: true, cancelable: true, clientY: 40, pointerId: 1 })
+    card.dispatchEvent(press)
+    expect(capture).not.toHaveBeenCalled()
+    expect(onJumpToSeq).not.toHaveBeenCalled()
+    // And the default stands, because the default here IS the text selection.
+    expect(press.defaultPrevented).toBe(false)
+  })
+
+  /** Open the first dot's card, then move the pointer across the gutter onto the card. */
+  function cardUnderPointer(container: HTMLElement): { dot: HTMLElement, card: HTMLElement } {
+    const dot = container.querySelector('[data-testid="chat-scroll-rail-dot"]') as HTMLElement
+    fireEvent.pointerEnter(dot)
+    const card = container.querySelector('[data-testid="chat-scroll-rail-preview"]') as HTMLElement
+    fireEvent.pointerLeave(dot)
+    fireEvent.pointerEnter(card)
+    return { dot, card }
+  }
+
+  /** The first text node inside `el` -- the only kind of node a selection can anchor in. */
+  function textNodeIn(el: HTMLElement): Node {
+    const node = document.createTreeWalker(el, NodeFilter.SHOW_TEXT).nextNode()
+    if (!node)
+      throw new Error('the element holds no text to select')
+    return node
+  }
+
+  /** A message in the transcript the card floats over: real text, outside the rail. */
+  function transcriptText(container: HTMLElement): HTMLElement {
+    const el = document.createElement('p')
+    el.textContent = 'a message the card lies over'
+    container.append(el)
+    return el
+  }
+
+  /**
+   * Put a real, non-collapsed document selection anchored in `from`'s text and reaching `to`'s.
+   *
+   * Both ends are given, because WHERE a drag starts and ends is the whole question here. The
+   * browser extends a selection to wherever the pointer goes, so a select-to-the-end-of-a-line
+   * drag that starts in the card routinely ENDS outside it.
+   *
+   * setBaseAndExtent, not a Range: a Range must run forwards in document order, and it silently
+   * COLLAPSES when it does not -- which would leave these tests asserting against an empty
+   * selection that holds nothing, whichever way the code behaved. A real drag has no such rule,
+   * and anchor-then-focus is the shape the card's own hold reads.
+   */
+  function selectTextFrom(from: HTMLElement, to: HTMLElement = from) {
+    const anchor = textNodeIn(from)
+    const focus = textNodeIn(to)
+    const selection = document.getSelection()!
+    selection.setBaseAndExtent(anchor, 0, focus, focus.textContent!.length)
+    expect(selection.isCollapsed, 'the test needs a real, non-empty selection').toBe(false)
+    fireEvent(document, new Event('selectionchange'))
+  }
+
+  /** Collapse the document selection, as the reader's next click anywhere would. */
+  function clearSelection() {
+    document.getSelection()!.removeAllRanges()
+    fireEvent(document, new Event('selectionchange'))
+  }
+
+  it('opens no press hold for a SECONDARY button, whose pointerup a context menu can swallow', () => {
+    vi.useFakeTimers()
+    const previewFor = (seq: bigint) => (seq === 2n ? 'select me' : undefined)
+    const { container } = render(() => <ChatScrollRail {...baseProps({ previewFor })} />)
+    const { card } = cardUnderPointer(container)
+
+    // A right-press to reach the browser's own "Copy". The native menu regularly eats the matching
+    // pointerup, so a hold opened here would never end -- pinning the card over the transcript and
+    // the whole rail lit for the rest of the session. beginRailPress guards the rail the same way.
+    card.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, cancelable: true, button: 2, pointerId: 1 }))
+    fireEvent.pointerLeave(card)
+    vi.advanceTimersByTime(POINTER_CLOSE_DELAY_MS)
+    expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).toBeNull()
+  })
+
+  it('ignores a rival pointer\'s release while THIS pointer is still selecting', () => {
+    vi.useFakeTimers()
+    const previewFor = (seq: bigint) => (seq === 2n ? 'select me' : undefined)
+    const { container } = render(() => <ChatScrollRail {...baseProps({ previewFor })} />)
+    const { card } = cardUnderPointer(container)
+    card.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, cancelable: true, button: 0, pointerId: 1 }))
+    fireEvent.pointerLeave(card)
+
+    // A pen tap or a second finger elsewhere, on the hybrid devices where the card stays
+    // interactive. Its release must not end a press it never started, or the card closes under a
+    // selection drag that pointer 1 is still making.
+    window.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, pointerId: 2 }))
+    vi.advanceTimersByTime(POINTER_CLOSE_DELAY_MS * 10)
+    expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).not.toBeNull()
+
+    window.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, pointerId: 1 }))
+    vi.advanceTimersByTime(POINTER_CLOSE_DELAY_MS)
+    expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).toBeNull()
+  })
+
+  it('takes the hold from a PRESS on a card that opened under a stationary cursor', () => {
+    vi.useFakeTimers()
+    const previewFor = (seq: bigint) => (seq === 2n ? 'select me' : undefined)
+    const { container } = render(() => <ChatScrollRail {...baseProps({ previewFor })} />)
+    // A keyboard reader tabs to the dot; the card mounts under a cursor that is ALREADY parked
+    // where it appears, so no pointerenter ever fires and the card never learns it is hovered.
+    const dot = container.querySelector('[data-testid="chat-scroll-rail-dot"]') as HTMLElement
+    fireEvent.focus(dot)
+    const card = container.querySelector('[data-testid="chat-scroll-rail-preview"]') as HTMLElement
+
+    // The press is the first evidence the pointer is on the card. Without it the card takes no
+    // hold, so the blur below drops the only channel holding it and the card goes mid-selection.
+    fireEvent.pointerDown(card)
+    fireEvent.blur(dot)
+    vi.advanceTimersByTime(POINTER_CLOSE_DELAY_MS * 10)
+    expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).not.toBeNull()
+
+    // And the press must leave the card HOVERED, not merely re-opened: releasing without moving
+    // leaves the pointer sitting on the card, and a card that forgot that would close under it.
+    fireEvent.pointerUp(window)
+    vi.advanceTimersByTime(POINTER_CLOSE_DELAY_MS * 10)
+    expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).not.toBeNull()
+
+    // Leaving is what releases it, exactly as for a card the pointer arrived on normally.
+    fireEvent.pointerLeave(card)
+    vi.advanceTimersByTime(POINTER_CLOSE_DELAY_MS)
+    expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).toBeNull()
+  })
+
+  it('holds the card for as long as it holds the reader\'s SELECTION, not for a fixed delay', () => {
+    vi.useFakeTimers()
+    const previewFor = (seq: bigint) => (seq === 2n ? 'select me' : undefined)
+    const { container } = render(() => <ChatScrollRail {...baseProps({ previewFor })} />)
+    const { card } = cardUnderPointer(container)
+
+    // Select to the end of a line: press inside, drag past the card's edge, release outside. The
+    // browser extends the selection to where the pointer went, so it ENDS on the rail outside the
+    // card -- a hold that demanded both ends inside would miss the very drag it exists for.
+    fireEvent.pointerDown(card)
+    selectTextFrom(card, transcriptText(container))
+    fireEvent.pointerLeave(card)
+    fireEvent.pointerUp(window)
+
+    // Closing on that release would destroy the selection with the text nodes it points at,
+    // before the reader could reach a keyboard and copy it.
+    vi.advanceTimersByTime(POINTER_CLOSE_DELAY_MS * 10)
+    expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).not.toBeNull()
+
+    // The reader's next click anywhere collapses the selection, and the card lets go.
+    clearSelection()
+    vi.advanceTimersByTime(POINTER_CLOSE_DELAY_MS - 1)
+    expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).not.toBeNull()
+    vi.advanceTimersByTime(1)
+    expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).toBeNull()
+  })
+
+  it('takes no selection hold from a selection that started somewhere else', () => {
+    vi.useFakeTimers()
+    const previewFor = (seq: bigint) => (seq === 2n ? 'select me' : undefined)
+    const { container } = render(() => <ChatScrollRail {...baseProps({ previewFor })} />)
+    const { card } = cardUnderPointer(container)
+
+    // A selection made in the transcript can sweep across an open card, and its range then covers
+    // the card's text. That is the reader selecting the MESSAGE, not the card, so the card must
+    // still close when they leave it -- keying on the anchor rather than the range is what
+    // separates the two.
+    fireEvent.pointerDown(card)
+    selectTextFrom(transcriptText(container), card)
+    fireEvent.pointerLeave(card)
+    fireEvent.pointerUp(window)
+    vi.advanceTimersByTime(POINTER_CLOSE_DELAY_MS)
+    expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).toBeNull()
+  })
+
+  it('closes on a release that left NO selection behind, with no extra hold to wait out', () => {
+    vi.useFakeTimers()
+    const previewFor = (seq: bigint) => (seq === 2n ? 'select me' : undefined)
+    const { container } = render(() => <ChatScrollRail {...baseProps({ previewFor })} />)
+    const { card } = cardUnderPointer(container)
+
+    // A plain click inside the card selects nothing. The selection hold must not latch on an
+    // empty selection, or a card would outlive every press that merely touched it.
+    fireEvent.pointerDown(card)
+    fireEvent.pointerLeave(card)
+    fireEvent.pointerUp(window)
+    vi.advanceTimersByTime(POINTER_CLOSE_DELAY_MS)
+    expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).toBeNull()
+  })
+
+  it('keeps the card on ITS dot while a selection drag crosses the dots beside it', () => {
+    const previewFor = (seq: bigint) => (seq === 2n ? 'message two' : seq === 4n ? 'message four' : undefined)
+    const { container } = render(() => <ChatScrollRail {...baseProps({ previewFor })} />)
+    const dots = container.querySelectorAll('[data-testid="chat-scroll-rail-dot"]')
+    fireEvent.pointerEnter(dots[0])
+    const card = container.querySelector('[data-testid="chat-scroll-rail-preview"]') as HTMLElement
+    fireEvent.pointerLeave(dots[0])
+    fireEvent.pointerEnter(card)
+
+    fireEvent.pointerDown(card)
+    // The card's right edge is a gutter away from the dots, so selecting to the end of a line
+    // drags the pointer straight across them. Re-targeting the card here would swap its body under
+    // the reader's own selection -- and the selection dies with the text nodes it pointed at.
+    fireEvent.pointerLeave(card)
+    fireEvent.pointerEnter(dots[1])
+    expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).toHaveTextContent('message two')
+    expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).not.toHaveTextContent('message four')
+
+    // Once the press ends the dots have their say again, so this is a hold, not a permanent lock.
+    fireEvent.pointerUp(window)
+    fireEvent.pointerEnter(dots[1])
+    expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).toHaveTextContent('message four')
+  })
+
+  it('switches the card to another dot at once, with no close delay in between', () => {
+    vi.useFakeTimers()
+    const previewFor = (seq: bigint) => (seq === 2n ? 'message two' : seq === 4n ? 'message four' : undefined)
+    const { container } = render(() => <ChatScrollRail {...baseProps({ previewFor })} />)
+    const dots = container.querySelectorAll('[data-testid="chat-scroll-rail-dot"]')
+    fireEvent.pointerEnter(dots[0])
+    fireEvent.pointerLeave(dots[0])
+    fireEvent.pointerEnter(dots[1])
+    const cards = container.querySelectorAll('[data-testid="chat-scroll-rail-preview"]')
+    expect(cards.length).toBe(1) // never two, and never the old one for a moment longer
+    expect(cards[0]).toHaveTextContent('message four')
+    // The first dot's pending close must not take the second dot's card down with it.
+    vi.advanceTimersByTime(POINTER_CLOSE_DELAY_MS * 10)
+    expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).toHaveTextContent('message four')
+  })
+
+  it('moves the SAME card element to the new dot\'s Y, and sends its scroll back to the top', () => {
+    const previewFor = (seq: bigint) => (seq === 2n ? 'message two' : seq === 4n ? 'message four' : undefined)
+    const { container } = render(() => <ChatScrollRail {...baseProps({ previewFor })} />)
+    const dots = container.querySelectorAll('[data-testid="chat-scroll-rail-dot"]')
+    fireEvent.pointerEnter(dots[0])
+    const card = container.querySelector('[data-testid="chat-scroll-rail-preview"]') as HTMLElement
+    expect(card.style.top).toBe('125px')
+    card.scrollTop = 150 // the reader scrolled deep into this dot's preview
+
+    fireEvent.pointerLeave(dots[0])
+    fireEvent.pointerEnter(dots[1])
+
+    // <Show> is not keyed, so the same element carries the next dot. Both of these would pass
+    // silently if the card froze its props at creation: the card would sit at the first dot's Y,
+    // still scrolled into the first dot's text, describing the second dot's message.
+    expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).toBe(card)
+    expect(card).toHaveTextContent('message four')
+    expect(card.style.top).toBe('275px')
+    expect(card.scrollTop).toBe(0)
+  })
+
+  it('leaves the card\'s scroll alone when a streaming turn re-anchors the SAME dot', async () => {
+    const previewFor = (seq: bigint) => (seq === 2n ? 'message two' : undefined)
+    const [marks, setMarks] = createSignal([{ seq: 2n, type: MarkType.USER_MESSAGE }])
+    const { container } = render(() => <ChatScrollRail {...baseProps({ marks: marks(), previewFor })} />)
+    fireEvent.pointerEnter(container.querySelector('[data-testid="chat-scroll-rail-dot"]') as HTMLElement)
+    const card = container.querySelector('[data-testid="chat-scroll-rail-preview"]') as HTMLElement
+    card.scrollTop = 150
+
+    // The same seq re-clusters to a fresh object as maxSeq ticks (see chatDotPreview.reanchor).
+    setMarks([{ seq: 2n, type: MarkType.CONTROL_RESPONSE }])
+    await tick()
+
+    // Resetting here would yank the card out from under a reader who is mid-read, once per
+    // persisted row of a streaming turn. The reset keys on the SEQ for exactly this reason.
+    expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).toBe(card)
+    expect(card.scrollTop).toBe(150)
+  })
+
+  /** Open the first dot's card and give it a scroll geometry jsdom cannot supply. */
+  function cardWithScrollHeight(container: HTMLElement, scrollHeight: number): HTMLElement {
+    fireEvent.pointerEnter(container.querySelector('[data-testid="chat-scroll-rail-dot"]') as HTMLElement)
+    const card = container.querySelector('[data-testid="chat-scroll-rail-preview"]') as HTMLElement
+    // clientHeight comes from the file-wide prototype spy (400), so scrollHeight above it means
+    // "the preview is taller than the card" and below it means "the preview fits".
+    Object.defineProperty(card, 'scrollHeight', { value: scrollHeight, configurable: true })
+    return card
+  }
+
+  it('scrolls the preview card, not the transcript, when the card has room to scroll', () => {
+    const scrollEl = makeScrollEl(100, 5000)
+    const previewFor = (seq: bigint) => (seq === 2n ? 'a long preview' : undefined)
+    const { container } = render(() => <ChatScrollRail {...baseProps({ scrollEl, previewFor })} />)
+    const forwarded = vi.fn()
+    scrollEl.addEventListener('wheel', forwarded)
+    const card = cardWithScrollHeight(container, 1000) // taller than the 400px card -> 600px of room
+
+    card.dispatchEvent(new WheelEvent('wheel', { bubbles: true, cancelable: true, deltaY: 100 }))
+
+    // The rail's wheel forwarder never sees it, so the transcript stays where the reader left it
+    // instead of scrolling out from under the card they are reading.
+    expect(forwarded).not.toHaveBeenCalled()
+    expect(scrollEl.scrollTop).toBe(100)
+  })
+
+  it('forwards the wheel to the transcript when the preview card has nothing left to scroll', () => {
+    const scrollEl = makeScrollEl(100, 5000)
+    const previewFor = (seq: bigint) => (seq === 2n ? 'a short preview' : undefined)
+    const { container } = render(() => <ChatScrollRail {...baseProps({ scrollEl, previewFor })} />)
+    const card = cardWithScrollHeight(container, 200) // shorter than the card -> the preview fits
+
+    card.dispatchEvent(new WheelEvent('wheel', { bubbles: true, cancelable: true, deltaY: 100 }))
+
+    // A card that is not a scroller must not become a dead zone -- the same reason the rail
+    // forwards a wheel over its own strip.
+    expect(scrollEl.scrollTop).toBe(200)
+  })
+
+  it('measures the card room in the direction the wheel actually goes', () => {
+    // The two directions read DIFFERENT room. A card scrolled to its bottom has none left
+    // downward but plenty upward, and one formula for both would either trap the wheel at an end
+    // or hand the transcript a wheel the card could still use.
+    const scrollEl = makeScrollEl(100, 5000)
+    const previewFor = (seq: bigint) => (seq === 2n ? 'a long preview' : undefined)
+    const { container } = render(() => <ChatScrollRail {...baseProps({ scrollEl, previewFor })} />)
+    const card = cardWithScrollHeight(container, 600) // 600 - 400 = 200px of travel
+    card.scrollTop = 200 // ...and the reader is already at the bottom of it
+
+    // Down: nothing left, so the transcript takes it.
+    card.dispatchEvent(new WheelEvent('wheel', { bubbles: true, cancelable: true, deltaY: 100 }))
+    expect(scrollEl.scrollTop).toBe(200)
+
+    // Up: 200px of room back to the top, so the card keeps it.
+    card.dispatchEvent(new WheelEvent('wheel', { bubbles: true, cancelable: true, deltaY: -100 }))
+    expect(scrollEl.scrollTop).toBe(200)
+  })
+
+  it('keeps a purely horizontal wheel off the rail, which could only swallow it', () => {
+    const scrollEl = makeScrollEl(100, 5000)
+    const previewFor = (seq: bigint) => (seq === 2n ? 'a long preview' : undefined)
+    const { container } = render(() => <ChatScrollRail {...baseProps({ scrollEl, previewFor })} />)
+    const forwarded = vi.fn()
+    scrollEl.addEventListener('wheel', forwarded)
+    const card = cardWithScrollHeight(container, 200) // a preview that FITS -- no vertical room at all
+
+    const sideways = new WheelEvent('wheel', { bubbles: true, cancelable: true, deltaX: 100, deltaY: 0 })
+    card.dispatchEvent(sideways)
+
+    // The card scrolls on one axis only, so it has nothing to do with a sideways wheel -- but
+    // handing it to the rail's forwarder is strictly worse than keeping it. That forwarder applies
+    // deltaY ONLY and calls preventDefault, so the wheel would move nothing AND lose the browser's
+    // own horizontal scroll of the wide content under the card. Stop it here instead.
+    expect(forwarded).not.toHaveBeenCalled()
+    expect(scrollEl.scrollTop).toBe(100) // the transcript stays exactly where the reader left it
+    expect(sideways.defaultPrevented).toBe(false) // and the browser keeps its own sideways scroll
+  })
+
+  it('ends the press hold on a pointercancel, not only on a pointerup', () => {
+    vi.useFakeTimers()
+    const previewFor = (seq: bigint) => (seq === 2n ? 'select me' : undefined)
+    const { container } = render(() => <ChatScrollRail {...baseProps({ previewFor })} />)
+    const { card } = cardUnderPointer(container)
+    fireEvent.pointerDown(card)
+    fireEvent.pointerLeave(card)
+
+    // A system gesture takes the pointer away mid-selection. No pointerup will ever arrive, so a
+    // hold that waited only for one would pin the card open for the rest of the session.
+    fireEvent.pointerCancel(window)
+    vi.advanceTimersByTime(POINTER_CLOSE_DELAY_MS)
+    expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).toBeNull()
+  })
+
+  it('drops its window press listeners when the card is torn down mid-press', async () => {
+    const previewFor = (seq: bigint) => (seq === 2n ? 'select me' : undefined)
+    const [marks, setMarks] = createSignal([{ seq: 2n, type: MarkType.USER_MESSAGE }])
+    const { container } = render(() => <ChatScrollRail {...baseProps({ marks: marks(), previewFor })} />)
+    fireEvent.pointerEnter(container.querySelector('[data-testid="chat-scroll-rail-dot"]') as HTMLElement)
+    const card = container.querySelector('[data-testid="chat-scroll-rail-preview"]') as HTMLElement
+
+    // Spy across ONE step at a time and restore immediately, so this asserts the identity of the
+    // card's own handler rather than a count of every window listener in the app -- a count would
+    // break the day anything else registers one, and a spy left installed would follow the rest
+    // of this file (the project sets no restoreMocks).
+    const handlersFor = (spy: { mock: { calls: unknown[][] } }) =>
+      spy.mock.calls.filter(([type]) => type === 'pointerup').map(([, fn]) => fn)
+
+    const added = vi.spyOn(window, 'addEventListener')
+    fireEvent.pointerDown(card)
+    const pressHandlers = handlersFor(added)
+    added.mockRestore()
+    expect(pressHandlers).toHaveLength(1)
+
+    // The pressed mark's message is deleted, so the card unmounts under the finger and no
+    // pointerup of its own ever runs. Its listener must not outlive it.
+    const removed = vi.spyOn(window, 'removeEventListener')
+    setMarks([])
+    await Promise.resolve()
+    const droppedHandlers = handlersFor(removed)
+    removed.mockRestore()
+
+    expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).toBeNull()
+    expect(droppedHandlers).toContain(pressHandlers[0])
+  })
+
+  it('gives the dots back to the pointer when the card is torn down mid-press', async () => {
+    const previewFor = (seq: bigint) => (seq === 2n ? 'select me' : seq === 4n ? 'message four' : undefined)
+    const [marks, setMarks] = createSignal([
+      { seq: 2n, type: MarkType.USER_MESSAGE },
+      { seq: 4n, type: MarkType.USER_MESSAGE },
+    ])
+    const { container } = render(() => <ChatScrollRail {...baseProps({ marks: marks(), previewFor })} />)
+    const dots = container.querySelectorAll('[data-testid="chat-scroll-rail-dot"]')
+    fireEvent.pointerEnter(dots[0])
+    const card = container.querySelector('[data-testid="chat-scroll-rail-preview"]') as HTMLElement
+    fireEvent.pointerDown(card)
+
+    // The pressed mark's message is deleted, so the card unmounts under the finger and no
+    // pointerup of its own ever runs. The press LOCK it took on the rail's dots must come off with
+    // it -- otherwise the dots stand down for a press that can never end, and the rail stops
+    // showing any card at all for the rest of the session.
+    setMarks([{ seq: 4n, type: MarkType.USER_MESSAGE }])
+    await tick()
+    expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).toBeNull()
+
+    fireEvent.pointerEnter(container.querySelector('[data-testid="chat-scroll-rail-dot"]') as HTMLElement)
+    expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).toHaveTextContent('message four')
+  })
+
+  it('opens ONE press hold however many times the press repeats', () => {
+    const previewFor = (seq: bigint) => (seq === 2n ? 'select me' : undefined)
+    const { container } = render(() => <ChatScrollRail {...baseProps({ previewFor })} />)
+    const { card } = cardUnderPointer(container)
+
+    // A pen and a mouse can both be down on the card at once, and the browser is free to deliver
+    // a second pointerdown. A second hold would register a second listener pair that the first
+    // release never drops, and the card would stay held by a press nothing can end.
+    const added = vi.spyOn(window, 'addEventListener')
+    fireEvent.pointerDown(card)
+    fireEvent.pointerDown(card)
+    const pressHandlers = added.mock.calls.filter(([type]) => type === 'pointerup')
+    added.mockRestore()
+    expect(pressHandlers).toHaveLength(1)
+  })
+
+  it('closes the card when the hovered dot disappears', async () => {
     const previewFor = (seq: bigint) => (seq === 2n ? 'stale preview' : undefined)
     const [marks, setMarks] = createSignal([{ seq: 2n, type: MarkType.USER_MESSAGE }])
     const { container } = render(() => <ChatScrollRail {...baseProps({ marks: marks(), previewFor })} />)
@@ -1154,9 +1695,9 @@ describe('chatscrollrail dot preview popover', () => {
     ]
     const previewFor = (seq: bigint) => (seq === 502n ? 'the nearest message' : undefined)
     const { container } = render(() => <ChatScrollRail {...baseProps({ minSeq: 1n, maxSeq: 100_000n, marks, previewFor })} />)
-    const popover = hoverFirstDot(container)!
-    expect(popover).toHaveTextContent('3 messages') // the aggregate header
-    expect(popover).toHaveTextContent('the nearest message') // the representative's preview
+    const card = hoverFirstDot(container)!
+    expect(card).toHaveTextContent('3 messages') // the aggregate header
+    expect(card).toHaveTextContent('the nearest message') // the representative's preview
   })
 
   // The floating auto-hide. Only the CLASS is observable here: vitest inserts no stylesheet
@@ -1242,6 +1783,7 @@ describe('chatscrollrail dot preview popover', () => {
     })
 
     it('keeps the rail visible while a dot preview is open, on hover and on keyboard focus', () => {
+      vi.useFakeTimers()
       const { container } = render(() => <ChatScrollRail {...baseProps({ scrollActive: false })} />)
       const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
       const dot = container.querySelector('[data-testid="chat-scroll-rail-dot"]') as HTMLElement
@@ -1250,6 +1792,10 @@ describe('chatscrollrail dot preview popover', () => {
       fireEvent.pointerEnter(dot)
       expect(rail.className).not.toContain(styles.railIdle)
       fireEvent.pointerLeave(dot)
+      // The card is still open for the close delay, and the rail must not fade out from under it
+      // -- the reader is on their way to the card the whole time.
+      expect(rail.className).not.toContain(styles.railIdle)
+      vi.advanceTimersByTime(POINTER_CLOSE_DELAY_MS)
       expect(rail.className).toContain(styles.railIdle)
 
       // activeDot() folds focus in with hover, which is what lets the rail skip a CSS
@@ -1258,7 +1804,8 @@ describe('chatscrollrail dot preview popover', () => {
       expect(rail.className).not.toContain(styles.railIdle)
 
       // Focus OUT must null activeDot() so the rail fades again -- without this a broken onBlur
-      // would pin the rail lit forever after a keyboard tab-away.
+      // would pin the rail lit forever after a keyboard tab-away. No delay on this one: focus
+      // moves in discrete steps, so there is no gap for the reader to cross.
       fireEvent.blur(dot)
       expect(rail.className).toContain(styles.railIdle)
     })
@@ -1333,11 +1880,12 @@ describe('chatscrollrail dot preview popover', () => {
       expect(onActivity).toHaveBeenCalledTimes(1)
     })
 
-    it('reopens the host window when a dot popover closes, so tabbing away gets a fade tail too', async () => {
-      // The popover is the third state that outranks the host's window (see idle()), and it can
+    it('reopens the host window when a dot card closes, so tabbing away gets a fade tail too', async () => {
+      // The card is the third state that outranks the host's window (see idle()), and it can
       // stay open past the idle timeout just as easily as a drag can. The re-arm keys on the
       // whole override set, so this needs no separate wiring -- which is the point of keying it
       // there rather than on the pointer lifecycle.
+      vi.useFakeTimers()
       const onActivity = vi.fn()
       const { container } = render(() => <ChatScrollRail {...baseProps({ onActivity })} />)
       const dot = container.querySelector('[data-testid="chat-scroll-rail-dot"]') as HTMLElement
@@ -1346,7 +1894,11 @@ describe('chatscrollrail dot preview popover', () => {
       expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).not.toBeNull()
       onActivity.mockClear()
       fireEvent.pointerLeave(dot)
-      await tick()
+      // The re-arm keys on the card actually CLOSING, not on the pointer leaving the dot: the
+      // close delay is one more stretch during which the rail holds itself lit.
+      await vi.advanceTimersByTimeAsync(POINTER_CLOSE_DELAY_MS - 1)
+      expect(onActivity).not.toHaveBeenCalled()
+      await vi.advanceTimersByTimeAsync(1)
       expect(onActivity).toHaveBeenCalledTimes(1)
     })
 

--- a/frontend/src/components/chat/ChatScrollRail.test.tsx
+++ b/frontend/src/components/chat/ChatScrollRail.test.tsx
@@ -41,6 +41,18 @@ afterEach(() => {
   vi.unstubAllGlobals()
 })
 
+/**
+ * The rail element with a rect jsdom cannot supply: top 0, height 400 (== VIEWPORT_H), so a
+ * pointer's clientY maps 1:1 onto the rail-relative Y every press handler computes from it.
+ * Every test that dispatches a pointer event at the rail needs this, so it lives at file scope
+ * rather than being re-inlined per test.
+ */
+function railWithRect(container: HTMLElement): HTMLElement {
+  const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
+  rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+  return rail
+}
+
 /** A scroll container with defined scroll geometry (clientHeight comes from the prototype spy). */
 function makeScrollEl(scrollTop = 0, scrollHeight = 500): HTMLDivElement {
   const el = document.createElement('div')
@@ -234,6 +246,105 @@ describe('chatscrollrail', () => {
     expect(onJumpToSeq).toHaveBeenCalledTimes(2) // an unrelated key does nothing
   })
 
+  it('attaches a rejection handler to a keyboard seek, so that path cannot leak one', async () => {
+    // Every seek in the component goes through one normalising entry point. The keyboard path
+    // discards the result, so a RAW call here would leave a rejected promise with no handler --
+    // a console error for the reader, and an unhandled-rejection failure for any suite that
+    // stubs onJumpToSeq to reject (which this file's pointer-path tests already do).
+    //
+    // Asserted on the thenable rather than on a real rejection: Promise.resolve() assimilates a
+    // thenable by calling its `then` with BOTH callbacks, so a non-undefined second argument is
+    // direct proof that a rejection handler exists. Waiting for Node to report a real unhandled
+    // rejection would pass whether or not the handler is there, which proves nothing.
+    const then = vi.fn()
+    const onJumpToSeq = vi.fn(() => ({ then } as unknown as Promise<boolean>))
+    const { container } = render(() => <ChatScrollRail {...baseProps({ onJumpToSeq })} />)
+    const dot = container.querySelector('[data-testid="chat-scroll-rail-dot"]') as HTMLElement
+
+    dot.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    expect(onJumpToSeq).toHaveBeenCalledWith(2n)
+    await tick()
+    expect(then).toHaveBeenCalledTimes(1)
+    expect(typeof then.mock.calls[0][1]).toBe('function') // the onRejected half
+  })
+
+  it('ignores a keyboard activation while a drag is live (no rival seek)', () => {
+    // A dot keeps keyboard focus while a pointer scrubs the rail, so Enter mid-scrub would fire
+    // exactly the rival jump the two press paths already guard against -- racing the drag's
+    // live-scroll and its release seek.
+    HTMLElement.prototype.setPointerCapture = vi.fn()
+    installImmediateRaf()
+    const onJumpToSeq = vi.fn()
+    const { container } = render(() => <ChatScrollRail {...baseProps({ onJumpToSeq })} />)
+    const rail = railWithRect(container)
+    const dot = container.querySelector('[data-testid="chat-scroll-rail-dot"]') as HTMLElement
+
+    rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 300, pointerId: 1 }))
+    onJumpToSeq.mockClear()
+    dot.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    expect(onJumpToSeq).not.toHaveBeenCalled()
+
+    // The guard lifts with the drag: the next activation jumps normally.
+    rail.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, clientY: 300, pointerId: 1 }))
+    dot.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    expect(onJumpToSeq).toHaveBeenCalledWith(2n)
+  })
+
+  it.each([
+    ['the track', (c: HTMLElement) => railWithRect(c)],
+    ['a dot', (c: HTMLElement) => c.querySelector('[data-testid="chat-scroll-rail-dot"]') as HTMLElement],
+  ])('ignores a SECONDARY-button press on %s', (_name, target) => {
+    // Every press now captures the pointer and owns the rail until its pointerup -- and a context
+    // menu can swallow the pointerup of a right press, which would leave the rail owned by a
+    // gesture that never ends and reject every later press. A secondary press must not start one,
+    // and must keep its default so the context menu still opens.
+    const setPointerCapture = vi.fn()
+    HTMLElement.prototype.setPointerCapture = setPointerCapture
+    const onJumpToSeq = vi.fn()
+    const { container } = render(() => <ChatScrollRail {...baseProps({ onJumpToSeq })} />)
+    const el = target(container)
+
+    const event = new PointerEvent('pointerdown', { bubbles: true, cancelable: true, button: 2, clientY: 300, pointerId: 1 })
+    el.dispatchEvent(event)
+    expect(onJumpToSeq).not.toHaveBeenCalled()
+    expect(setPointerCapture).not.toHaveBeenCalled()
+    expect(event.defaultPrevented).toBe(false)
+  })
+
+  it('claims a press it REJECTS, so a rival press cannot focus a dot and strand its popover', () => {
+    // A rejected dot press that keeps its default focuses the dot button, and the focus opens the
+    // dot's preview popover -- with no pointerleave on touch to ever close it. That pins
+    // activeDot() non-null, which holds the whole rail lit for the rest of the session.
+    HTMLElement.prototype.setPointerCapture = vi.fn()
+    installImmediateRaf()
+    const { container } = render(() => <ChatScrollRail {...baseProps()} />)
+    const rail = railWithRect(container)
+    const dot = container.querySelector('[data-testid="chat-scroll-rail-dot"]') as HTMLElement
+
+    rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 300, pointerId: 1 }))
+    const rival = new PointerEvent('pointerdown', { bubbles: true, cancelable: true, clientY: 120, pointerId: 2 })
+    dot.dispatchEvent(rival)
+    expect(rival.defaultPrevented).toBe(true)
+  })
+
+  it('frees the rail for the next press when a drag loses pointer capture', () => {
+    // The pointerup of a captured drag does not always come back to the rail (a context menu
+    // takes it, or the browser revokes the capture). Without a lostpointercapture teardown the
+    // "a drag is live" guard would then reject every later press for the life of the component.
+    HTMLElement.prototype.setPointerCapture = vi.fn()
+    installImmediateRaf()
+    const onJumpToSeq = vi.fn()
+    const { container } = render(() => <ChatScrollRail {...baseProps({ onJumpToSeq })} />)
+    const rail = railWithRect(container)
+
+    rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 300, pointerId: 1 }))
+    rail.dispatchEvent(new PointerEvent('lostpointercapture', { bubbles: true, clientY: 300, pointerId: 1 }))
+    onJumpToSeq.mockClear()
+
+    rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 300, pointerId: 2 }))
+    expect(onJumpToSeq).toHaveBeenCalledTimes(1) // the rail still works
+  })
+
   it('renders the thumb from the computed seq-space rect', () => {
     const { container } = render(() => <ChatScrollRail {...baseProps()} />)
     const thumb = container.querySelector('[data-testid="chat-scroll-rail-thumb"]') as HTMLElement
@@ -273,9 +384,7 @@ describe('chatscrollrail', () => {
   it('maps a track click (below the thumb) to a seq via onJumpToSeq', () => {
     const onJumpToSeq = vi.fn()
     const { container } = render(() => <ChatScrollRail {...baseProps({ onJumpToSeq })} />)
-    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
-    // Give the rail a concrete rect (jsdom returns zeros otherwise).
-    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    const rail = railWithRect(container)
     // The thumb spans 0..24px, so click at y=360 (track region) maps near the bottom -> seq 5.
     rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 360 }))
     expect(onJumpToSeq).toHaveBeenCalledWith(5n)
@@ -330,10 +439,7 @@ describe('chatscrollrail', () => {
     const { container } = render(() => (
       <ChatScrollRail {...baseProps({ previewScrollTo, onJumpToSeq })} />
     ))
-    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
-    // Concrete rail rect (top 0, height 400). The fixed thumb spans 0..24px at the top,
-    // so its CENTRE axis is [12, 388].
-    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    const rail = railWithRect(container)
     rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 12, pointerId: 1 }))
     previewScrollTo.mockClear()
     rail.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientY: 200, pointerId: 1 }))
@@ -352,14 +458,13 @@ describe('chatscrollrail', () => {
     const { container } = render(() => (
       <ChatScrollRail {...baseProps({ onSeekInterrupt })} />
     ))
-    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
-    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    const rail = railWithRect(container)
     // Every press is a grab now, so every press abandons a PRIOR release's still-fetching
     // out-of-window seek -- it must not land and yank the viewport under this gesture.
     rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 360, pointerId: 1 }))
     expect(onSeekInterrupt).toHaveBeenCalledTimes(1)
     // Dragging past the slop abandons a second seek: the one THIS press just issued, which the
-    // reader has now scrubbed away from.
+    // reader now scrubbed away from.
     rail.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientY: 200, pointerId: 1 }))
     expect(onSeekInterrupt).toHaveBeenCalledTimes(2)
     // Engaging is one-way: later moves do not keep re-firing it.
@@ -373,8 +478,7 @@ describe('chatscrollrail', () => {
     const previewScrollTo = vi.fn()
     const onJumpToSeq = vi.fn()
     const { container } = render(() => <ChatScrollRail {...baseProps({ previewScrollTo, onJumpToSeq })} />)
-    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
-    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    const rail = railWithRect(container)
     // Press the bare track near the bottom (the thumb spans 0..24) -> jump to seq 5 at once.
     rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 360, pointerId: 1 }))
     expect(onJumpToSeq).toHaveBeenCalledWith(5n)
@@ -400,8 +504,7 @@ describe('chatscrollrail', () => {
     installImmediateRaf()
     const onJumpToSeq = vi.fn()
     const { container } = render(() => <ChatScrollRail {...baseProps({ onJumpToSeq })} />)
-    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
-    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    const rail = railWithRect(container)
     rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 360, pointerId: 1 }))
     // A finger drifts a pixel or two as it lifts; that is still a tap, not a scrub.
     rail.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientY: 363, pointerId: 1 }))
@@ -426,8 +529,7 @@ describe('chatscrollrail', () => {
     const { container } = render(() => (
       <ChatScrollRail {...baseProps({ onJumpToSeq, hasMoreOlder: true, hasMoreNewer: true })} />
     ))
-    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
-    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    const rail = railWithRect(container)
     // Tap the track: press and release on the same pixel.
     rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 360, pointerId: 1 }))
     rail.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, clientY: 360, pointerId: 1 }))
@@ -435,7 +537,7 @@ describe('chatscrollrail', () => {
     expect(thumb.className).toContain(styles.thumbDragging) // pinned while the fetch is in flight
     expect(thumb.style.top).toBe('348px') // and pinned on the TAPPED point
     expect(onJumpToSeq).toHaveBeenCalledTimes(1) // the release added no second seek
-    // The pin SURVIVES the settle a resolved seek would have cleared on: it is waiting for the
+    // The pin SURVIVES the settle a resolved seek clears on: it still waits for the
     // press's fetch, not clearing itself the moment the pointer lifted.
     await tick()
     expect(thumb.className).toContain(styles.thumbDragging)
@@ -447,7 +549,7 @@ describe('chatscrollrail', () => {
   })
 
   it('hands the thumb off ONE FRAME after a seek that reports it scrolled', async () => {
-    // A seek that scrolled is followed by a landing, so the pin must survive until the
+    // A landing follows a seek that scrolled, so the pin must survive until the
     // metrics-derived thumb has caught up to it -- one animation frame. Clearing on the seek's
     // microtask instead would flash the thumb back for that frame.
     HTMLElement.prototype.setPointerCapture = vi.fn()
@@ -460,8 +562,7 @@ describe('chatscrollrail', () => {
     const { container } = render(() => (
       <ChatScrollRail {...baseProps({ onJumpToSeq, hasMoreOlder: true, hasMoreNewer: true })} />
     ))
-    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
-    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    const rail = railWithRect(container)
     // Grab the thumb and release far away: the release position alone engages the scrub.
     rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 12, pointerId: 1 }))
     rail.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, clientY: 200, pointerId: 1 }))
@@ -485,8 +586,7 @@ describe('chatscrollrail', () => {
     const { container } = render(() => (
       <ChatScrollRail {...baseProps({ onJumpToSeq, hasMoreOlder: true, hasMoreNewer: true })} />
     ))
-    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
-    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    const rail = railWithRect(container)
     // A TAP on the track: the hold waits on the PRESS's seek, which is the one that rejects.
     rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 360, pointerId: 1 }))
     rail.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, clientY: 360, pointerId: 1 }))
@@ -523,8 +623,7 @@ describe('chatscrollrail', () => {
       })}
       />
     ))
-    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
-    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    const rail = railWithRect(container)
     rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 12, pointerId: 1 }))
     flushRaf()
     rail.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientY: 200, pointerId: 1 }))
@@ -550,8 +649,7 @@ describe('chatscrollrail', () => {
     installImmediateRaf()
     const onJumpToSeq = vi.fn()
     const { container } = render(() => <ChatScrollRail {...baseProps({ onJumpToSeq })} />)
-    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
-    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    const rail = railWithRect(container)
     expect(() => {
       rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 360, pointerId: 1 }))
     }).not.toThrow()
@@ -561,7 +659,7 @@ describe('chatscrollrail', () => {
     expect(onJumpToSeq).toHaveBeenCalledTimes(2)
   })
 
-  it('a dot press jumps to the dot seq, centres the thumb on the dot, and scrubs on', () => {
+  it('a dot press jumps to the dot seq, centres the thumb on the FINGER, and scrubs on', () => {
     // On a coarse pointer each dot carries a 24px hit circle, so on a marked conversation most
     // of the rail is dot rather than track. A dot press that could not scrub would leave a
     // finger with nowhere to start the gesture.
@@ -569,19 +667,42 @@ describe('chatscrollrail', () => {
     installImmediateRaf()
     const onJumpToSeq = vi.fn()
     const { container } = render(() => <ChatScrollRail {...baseProps({ onJumpToSeq })} />)
-    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
-    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    const rail = railWithRect(container)
     const dot = container.querySelector('[data-testid="chat-scroll-rail-dot"][data-seq="2"]') as HTMLElement
     // Press the dot slightly off its centre (a fingertip is wider than the 6px dot).
     dot.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 131, pointerId: 1 }))
     // The jump takes the dot's OWN seq, not the fraction under the finger.
     expect(onJumpToSeq).toHaveBeenCalledWith(2n)
     const thumb = container.querySelector('[data-testid="chat-scroll-rail-thumb"]') as HTMLElement
-    expect(thumb.style.top).toBe('113px') // the dot sits at 125; the thumb centre lands on it
+    // The thumb centres on the PRESS (131), not on the dot it hit (125). The drag keeps the
+    // finger-to-thumb offset it starts with, so centring on the dot would hold the thumb 6px off
+    // the finger for the whole scrub below -- and up to 12px, half a coarse hit circle, in
+    // general. Only a dot press could do that, so it also gave one gesture two different feels.
+    expect(thumb.style.top).toBe('119px') // 131 - half the 24px thumb
     // The same press scrubs on to the other dot and lands there.
     rail.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientY: 281, pointerId: 1 }))
     rail.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, clientY: 281, pointerId: 1 }))
     expect(onJumpToSeq).toHaveBeenLastCalledWith(4n)
+  })
+
+  it('tracks the finger 1:1 after a dot press, with no residual offset from the dot', () => {
+    // The regression this guards: the thumb used to anchor on the dot while the grab offset
+    // anchored on the finger, so every later frame of the scrub stayed off by the gap between
+    // them. Press well off the dot centre, then move a known distance and check the thumb moved
+    // exactly that far AND sits under the finger -- which pins both halves at once.
+    HTMLElement.prototype.setPointerCapture = vi.fn()
+    installImmediateRaf()
+    const { container } = render(() => <ChatScrollRail {...baseProps()} />)
+    const rail = railWithRect(container)
+    const dot = container.querySelector('[data-testid="chat-scroll-rail-dot"][data-seq="2"]') as HTMLElement
+    // Read the top as a NUMBER: the pixel goes through a [0,1] fraction and back, so the
+    // round-trip lands a float ULP off the whole pixel it means.
+    const thumbTop = () => Number.parseFloat((container.querySelector('[data-testid="chat-scroll-rail-thumb"]') as HTMLElement).style.top)
+
+    dot.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 137, pointerId: 1 }))
+    expect(thumbTop()).toBeCloseTo(125, 6) // 137 - 12: under the finger, 12px below the dot at 125
+    rail.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientY: 237, pointerId: 1 }))
+    expect(thumbTop()).toBeCloseTo(225, 6) // moved exactly the finger's 100px, still centred on it
   })
 
   it('a dot press released without a scrub seeks its dot exactly once', () => {
@@ -589,8 +710,7 @@ describe('chatscrollrail', () => {
     installImmediateRaf()
     const onJumpToSeq = vi.fn()
     const { container } = render(() => <ChatScrollRail {...baseProps({ onJumpToSeq })} />)
-    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
-    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    const rail = railWithRect(container)
     const dot = container.querySelector('[data-testid="chat-scroll-rail-dot"][data-seq="2"]') as HTMLElement
     dot.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 125, pointerId: 1 }))
     rail.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, clientY: 125, pointerId: 1 }))
@@ -605,8 +725,7 @@ describe('chatscrollrail', () => {
     installImmediateRaf()
     const previewFor = (seq: bigint) => (seq === 2n ? 'pressed message two' : undefined)
     const { container } = render(() => <ChatScrollRail {...baseProps({ previewFor })} />)
-    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
-    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    railWithRect(container) // the component reads the rail's rect on the dot press below
     expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).toBeNull()
     const dot = container.querySelector('[data-testid="chat-scroll-rail-dot"][data-seq="2"]') as HTMLElement
     dot.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 125, pointerId: 1 }))
@@ -620,8 +739,7 @@ describe('chatscrollrail', () => {
     installImmediateRaf()
     const onJumpToSeq = vi.fn()
     const { container } = render(() => <ChatScrollRail {...baseProps({ onJumpToSeq })} />)
-    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
-    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    const rail = railWithRect(container)
     // A first pointer grabs the thumb (spans 0..24) -> a live drag is in progress.
     rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 12, pointerId: 1 }))
     // A SECOND finger lands on a dot mid-drag: without the guard it would fire a rival jump
@@ -650,8 +768,7 @@ describe('chatscrollrail', () => {
       })}
       />
     ))
-    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
-    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    const rail = railWithRect(container)
     rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 12, pointerId: 1 }))
     onJumpToSeq.mockClear() // the grab itself is a thumb grab: it jumps nowhere
     rail.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientY: 200, pointerId: 1 }))
@@ -673,8 +790,7 @@ describe('chatscrollrail', () => {
     const { container } = render(() => (
       <ChatScrollRail {...baseProps({ onJumpToSeq })} />
     ))
-    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
-    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    const rail = railWithRect(container)
     // A first pointer grabs the thumb (spans 0..24) -> a live drag is in progress.
     rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 12, pointerId: 1 }))
     // A SECOND pointer lands on the TRACK (below the thumb) mid-drag: without the drag guard it
@@ -700,8 +816,7 @@ describe('chatscrollrail', () => {
     const { container } = render(() => (
       <ChatScrollRail {...baseProps({ scrollEl, onJumpToSeq, hasMoreOlder: true, hasMoreNewer: true })} geometryVersion={geometryVersion()} />
     ))
-    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
-    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    const rail = railWithRect(container)
     // Grab the fixed thumb (spans 0..24) and release at a DIFFERENT position.
     rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 12, pointerId: 1 }))
     rail.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, clientY: 200, pointerId: 1 }))
@@ -732,8 +847,7 @@ describe('chatscrollrail', () => {
     const { container } = render(() => (
       <ChatScrollRail {...baseProps({ scrollEl, onJumpToSeq, hasMoreOlder: true, hasMoreNewer: true })} />
     ))
-    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
-    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    const rail = railWithRect(container)
     rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 12, pointerId: 1 }))
     rail.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, clientY: 200, pointerId: 1 }))
     const thumb = container.querySelector('[data-testid="chat-scroll-rail-thumb"]') as HTMLElement
@@ -750,8 +864,7 @@ describe('chatscrollrail', () => {
     const capture = vi.fn()
     HTMLElement.prototype.setPointerCapture = capture
     const { container } = render(() => <ChatScrollRail {...baseProps({ hasMoreOlder: true, hasMoreNewer: true })} />)
-    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
-    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    const rail = railWithRect(container)
     // First grab on the fixed thumb (spans 0..24) captures pointer 1.
     rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 12, pointerId: 1 }))
     expect(capture).toHaveBeenCalledTimes(1)
@@ -775,8 +888,7 @@ describe('chatscrollrail', () => {
     const { container } = render(() => (
       <ChatScrollRail {...base} hidden={hidden()} />
     ))
-    let rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
-    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    let rail = railWithRect(container)
 
     rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 12, pointerId: 1 }))
     expect(capture).toHaveBeenCalledTimes(1)
@@ -790,8 +902,7 @@ describe('chatscrollrail', () => {
     setHidden(false)
     await Promise.resolve()
 
-    rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
-    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    rail = railWithRect(container)
     rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 12, pointerId: 2 }))
     expect(capture).toHaveBeenCalledTimes(2)
   })
@@ -803,8 +914,7 @@ describe('chatscrollrail', () => {
     const warmPreview = vi.fn()
     const previewFor = (seq: bigint) => (seq === 2n ? 'scrubbed message two' : undefined)
     const { container } = render(() => <ChatScrollRail {...baseProps({ warmPreview, previewFor })} />)
-    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
-    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    const rail = railWithRect(container)
     // No popover until a drag is in progress (and nothing is hovered).
     expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).toBeNull()
     // Grab the fixed thumb, then scrub to the seq-2 dot at y=125.
@@ -833,8 +943,7 @@ describe('chatscrollrail', () => {
     const flushRaf = () => rafQueue.splice(0).forEach(cb => cb(0))
     const warmPreview = vi.fn()
     const { container } = render(() => <ChatScrollRail {...baseProps({ warmPreview })} />)
-    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
-    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    const rail = railWithRect(container)
     // Grab the thumb, pass OVER the seq-2 dot (y=125), then move on to seq-4 (y=275) BEFORE the
     // debounce elapses -- the second move supersedes the first dot's pending warm.
     rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 12, pointerId: 1 }))
@@ -853,8 +962,7 @@ describe('chatscrollrail', () => {
     HTMLElement.prototype.setPointerCapture = vi.fn()
     installImmediateRaf()
     const { container } = render(() => <ChatScrollRail {...baseProps()} />)
-    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
-    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    const rail = railWithRect(container)
     // y=200 -> thumb centre 200; dots sit at 125 and 275, both >12px away -> no scrub target.
     rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 12, pointerId: 1 }))
     rail.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientY: 200, pointerId: 1 }))
@@ -866,8 +974,7 @@ describe('chatscrollrail', () => {
     installImmediateRaf()
     const previewFor = (seq: bigint) => (seq === 2n ? 'scrub target two' : seq === 4n ? 'hovered four' : undefined)
     const { container } = render(() => <ChatScrollRail {...baseProps({ previewFor })} />)
-    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
-    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    const rail = railWithRect(container)
     // Scrub over the seq-2 dot (thumb centre 125), then also hover the seq-4 dot.
     rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 12, pointerId: 1 }))
     rail.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientY: 125, pointerId: 1 }))
@@ -1058,12 +1165,6 @@ describe('chatscrollrail dot preview popover', () => {
   // tests/e2e/047b-chat-scroll-rail-autohide.spec.ts).
   describe('railIdle auto-hide', () => {
     /** The rail root, with a concrete rect so pointer hit-tests resolve (jsdom does no layout). */
-    function railWithRect(container: HTMLElement): HTMLElement {
-      const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
-      rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
-      return rail
-    }
-
     it('marks the rail idle when the activity window closes and un-marks it when it reopens', () => {
       const [scrollActive, setScrollActive] = createSignal(true)
       const { container } = render(() => <ChatScrollRail {...baseProps()} scrollActive={scrollActive()} />)
@@ -1180,7 +1281,7 @@ describe('chatscrollrail dot preview popover', () => {
       expect(onActivity).toHaveBeenCalledTimes(2)
     })
 
-    it('reopens the host window when a drag ENDS, so a long scrub still gets a fade tail', () => {
+    it('reopens the host window when a drag ENDS, so a long scrub still gets a fade tail', async () => {
       // The window the grab opened has a fixed idle timeout, and nothing re-arms it mid-drag: the
       // pointer is captured (the scroll container sees nothing), the rail's own pointermove
       // relight is inert while idle() is false, and the drag's live-scroll writes are
@@ -1197,6 +1298,55 @@ describe('chatscrollrail dot preview popover', () => {
       rail.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientY: 200, pointerId: 1 }))
       expect(onActivity).not.toHaveBeenCalled() // no per-move timer churn
       rail.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, clientY: 200, pointerId: 1 }))
+      // The re-arm keys on the rail releasing ITSELF, not on the pointer lifting: the release
+      // hold outlives the pointer, and it is one of the states that outrank the host's window.
+      await tick()
+      expect(onActivity).toHaveBeenCalledTimes(1)
+    })
+
+    it('defers the reopen until a SLOW release seek lands, so a fetch cannot outlast the window', async () => {
+      // The case a re-arm at pointerup gets wrong. An out-of-window release seek fetches a page,
+      // and the rail holds itself lit for the whole fetch (the release hold keeps drag()
+      // non-null). A window re-armed when the finger lifted would already be closing by the time
+      // that hold clears, so the rail would snap dark with no fade tail -- the very failure the
+      // re-arm exists to prevent, just moved later. Re-arm when the hold ends instead.
+      HTMLElement.prototype.setPointerCapture = vi.fn()
+      installImmediateRaf()
+      const onActivity = vi.fn()
+      let landSeek: (scrolled: boolean) => void = () => {}
+      const onJumpToSeq = vi.fn(() => new Promise<boolean>((resolve) => {
+        landSeek = resolve
+      }))
+      const { container } = render(() => <ChatScrollRail {...baseProps({ onActivity, onJumpToSeq })} />)
+      const rail = railWithRect(container)
+
+      rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 12, pointerId: 1 }))
+      rail.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientY: 200, pointerId: 1 }))
+      onActivity.mockClear()
+      rail.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, clientY: 200, pointerId: 1 }))
+      await tick()
+      // Still fetching: the rail holds itself lit, so a window opened now would only burn down.
+      expect(onActivity).not.toHaveBeenCalled()
+
+      landSeek(false) // resolved with no landing scroll -> the hold clears at once
+      await tick()
+      expect(onActivity).toHaveBeenCalledTimes(1)
+    })
+
+    it('reopens the host window when a dot popover closes, so tabbing away gets a fade tail too', async () => {
+      // The popover is the third state that outranks the host's window (see idle()), and it can
+      // stay open past the idle timeout just as easily as a drag can. The re-arm keys on the
+      // whole override set, so this needs no separate wiring -- which is the point of keying it
+      // there rather than on the pointer lifecycle.
+      const onActivity = vi.fn()
+      const { container } = render(() => <ChatScrollRail {...baseProps({ onActivity })} />)
+      const dot = container.querySelector('[data-testid="chat-scroll-rail-dot"]') as HTMLElement
+
+      fireEvent.pointerEnter(dot)
+      expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).not.toBeNull()
+      onActivity.mockClear()
+      fireEvent.pointerLeave(dot)
+      await tick()
       expect(onActivity).toHaveBeenCalledTimes(1)
     })
 

--- a/frontend/src/components/chat/ChatScrollRail.test.tsx
+++ b/frontend/src/components/chat/ChatScrollRail.test.tsx
@@ -9,6 +9,7 @@ import { SCRUB_WARM_DEBOUNCE_MS } from './chatDotPreview'
 import { resolveScrollbarOwner } from './chatRailPolicy'
 import { ChatScrollRail } from './ChatScrollRail'
 import * as styles from './ChatScrollRail.css'
+import { SCRUB_SEEK_DEBOUNCE_MS } from './chatScrollRailDrag'
 import { rowStartSeqs } from './chatScrollRailGeometry'
 
 // jsdom does no layout, so clientHeight is 0 everywhere. Force a fixed viewport height
@@ -344,7 +345,7 @@ describe('chatscrollrail', () => {
     expect(onJumpToSeq).toHaveBeenCalledWith(3n)
   })
 
-  it('fires onSeekInterrupt on a thumb grab (abandon a prior seek) but NOT on a track click', () => {
+  it('fires onSeekInterrupt on every grab, and again once the press becomes a scrub', () => {
     HTMLElement.prototype.setPointerCapture = vi.fn()
     installImmediateRaf()
     const onSeekInterrupt = vi.fn()
@@ -353,14 +354,315 @@ describe('chatscrollrail', () => {
     ))
     const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
     rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
-    // A track click (below the thumb at 0..24) supersedes any pending seek via its own jump,
-    // so it must NOT also fire onSeekInterrupt.
+    // Every press is a grab now, so every press abandons a PRIOR release's still-fetching
+    // out-of-window seek -- it must not land and yank the viewport under this gesture.
     rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 360, pointerId: 1 }))
-    expect(onSeekInterrupt).not.toHaveBeenCalled()
-    // A thumb grab (on the thumb at y=12) is manual control: abandon a prior release's
-    // still-fetching out-of-window seek so it can't yank the viewport mid-scrub.
-    rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 12, pointerId: 2 }))
     expect(onSeekInterrupt).toHaveBeenCalledTimes(1)
+    // Dragging past the slop abandons a second seek: the one THIS press just issued, which the
+    // reader has now scrubbed away from.
+    rail.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientY: 200, pointerId: 1 }))
+    expect(onSeekInterrupt).toHaveBeenCalledTimes(2)
+    // Engaging is one-way: later moves do not keep re-firing it.
+    rail.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientY: 150, pointerId: 1 }))
+    expect(onSeekInterrupt).toHaveBeenCalledTimes(2)
+  })
+
+  it('a track press jumps to the pressed point AND scrubs on from there', () => {
+    HTMLElement.prototype.setPointerCapture = vi.fn()
+    installImmediateRaf()
+    const previewScrollTo = vi.fn()
+    const onJumpToSeq = vi.fn()
+    const { container } = render(() => <ChatScrollRail {...baseProps({ previewScrollTo, onJumpToSeq })} />)
+    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
+    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    // Press the bare track near the bottom (the thumb spans 0..24) -> jump to seq 5 at once.
+    rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 360, pointerId: 1 }))
+    expect(onJumpToSeq).toHaveBeenCalledWith(5n)
+    // The thumb centres UNDER the press (top = 360 - half the 24px thumb), rather than holding a
+    // within-thumb offset the way a thumb grab does -- the reader pressed a position.
+    const thumb = container.querySelector('[data-testid="chat-scroll-rail-thumb"]') as HTMLElement
+    expect(thumb.style.top).toBe('348px')
+    // Without lifting: the same press now scrubs. This is the gesture a finger has no way to
+    // spend two presses on.
+    previewScrollTo.mockClear()
+    rail.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientY: 200, pointerId: 1 }))
+    expect(thumb.style.top).toBe('188px') // follows the pointer
+    expect(previewScrollTo).toHaveBeenCalledWith(200) // seq 3 is in-window -> live-scroll
+    // The release lands on the scrubbed-to position, not on the pressed one.
+    rail.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, clientY: 200, pointerId: 1 }))
+    expect(onJumpToSeq).toHaveBeenLastCalledWith(3n)
+    expect(onJumpToSeq).toHaveBeenCalledTimes(2)
+  })
+
+  it('a track press released without a scrub seeks exactly once', () => {
+    // The press already jumped. A second seek from the release would fetch the same page twice.
+    HTMLElement.prototype.setPointerCapture = vi.fn()
+    installImmediateRaf()
+    const onJumpToSeq = vi.fn()
+    const { container } = render(() => <ChatScrollRail {...baseProps({ onJumpToSeq })} />)
+    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
+    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 360, pointerId: 1 }))
+    // A finger drifts a pixel or two as it lifts; that is still a tap, not a scrub.
+    rail.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientY: 363, pointerId: 1 }))
+    rail.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, clientY: 363, pointerId: 1 }))
+    expect(onJumpToSeq).toHaveBeenCalledTimes(1)
+    expect(onJumpToSeq).toHaveBeenCalledWith(5n)
+    // And the thumb stays on the point the press jumped to, rather than sliding to the drift.
+    const thumb = container.querySelector('[data-testid="chat-scroll-rail-thumb"]') as HTMLElement
+    expect(thumb.style.top).toBe('348px')
+  })
+
+  it('holds a tapped thumb until the PRESS jump lands, without seeking again', async () => {
+    // A tap fires no release seek, so the hold has to pin the thumb on the press's own jump
+    // instead. Without that, the thumb would snap back to its pre-tap position the instant the
+    // finger lifts and then jump again when the fetch landed -- two moves for one tap.
+    HTMLElement.prototype.setPointerCapture = vi.fn()
+    installImmediateRaf()
+    let landSeek!: (scrolled: boolean) => void
+    const onJumpToSeq = vi.fn(() => new Promise<boolean>((r) => {
+      landSeek = r
+    }))
+    const { container } = render(() => (
+      <ChatScrollRail {...baseProps({ onJumpToSeq, hasMoreOlder: true, hasMoreNewer: true })} />
+    ))
+    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
+    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    // Tap the track: press and release on the same pixel.
+    rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 360, pointerId: 1 }))
+    rail.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, clientY: 360, pointerId: 1 }))
+    const thumb = container.querySelector('[data-testid="chat-scroll-rail-thumb"]') as HTMLElement
+    expect(thumb.className).toContain(styles.thumbDragging) // pinned while the fetch is in flight
+    expect(thumb.style.top).toBe('348px') // and pinned on the TAPPED point
+    expect(onJumpToSeq).toHaveBeenCalledTimes(1) // the release added no second seek
+    // The pin SURVIVES the settle a resolved seek would have cleared on: it is waiting for the
+    // press's fetch, not clearing itself the moment the pointer lifted.
+    await tick()
+    expect(thumb.className).toContain(styles.thumbDragging)
+    // The press's own seek resolves, so the pin hands off rather than sticking forever.
+    landSeek(false)
+    await tick()
+    expect(thumb.className).not.toContain(styles.thumbDragging)
+    expect(onJumpToSeq).toHaveBeenCalledTimes(1)
+  })
+
+  it('hands the thumb off ONE FRAME after a seek that reports it scrolled', async () => {
+    // A seek that scrolled is followed by a landing, so the pin must survive until the
+    // metrics-derived thumb has caught up to it -- one animation frame. Clearing on the seek's
+    // microtask instead would flash the thumb back for that frame.
+    HTMLElement.prototype.setPointerCapture = vi.fn()
+    // A DEFERRED rAF: the hold's hand-off frame must be observable as a separate step.
+    const rafQueue: FrameRequestCallback[] = []
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => rafQueue.push(cb))
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+    const flushRaf = () => rafQueue.splice(0).forEach(cb => cb(0))
+    const onJumpToSeq = vi.fn(() => Promise.resolve(true)) // the landing scrolled
+    const { container } = render(() => (
+      <ChatScrollRail {...baseProps({ onJumpToSeq, hasMoreOlder: true, hasMoreNewer: true })} />
+    ))
+    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
+    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    // Grab the thumb and release far away: the release position alone engages the scrub.
+    rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 12, pointerId: 1 }))
+    rail.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, clientY: 200, pointerId: 1 }))
+    const thumb = container.querySelector('[data-testid="chat-scroll-rail-thumb"]') as HTMLElement
+    expect(thumb.className).toContain(styles.thumbDragging)
+    await tick()
+    // The seek resolved, but the hand-off waits for the frame -- unlike a seek that scrolled
+    // NOWHERE, which clears on the spot (covered by its own test below).
+    expect(thumb.className).toContain(styles.thumbDragging)
+    flushRaf()
+    expect(thumb.className).not.toContain(styles.thumbDragging)
+  })
+
+  it('clears the pinned thumb when a seek REJECTS, instead of sticking in the dragging state', async () => {
+    // A rejected jump (the fetch failed, the tab went away mid-flight) resolves the hold's
+    // hand-off to "did not scroll". Without that the thumb would stay pinned at the release
+    // position for the rest of the session, and the rejection would go unhandled.
+    HTMLElement.prototype.setPointerCapture = vi.fn()
+    installImmediateRaf()
+    const onJumpToSeq = vi.fn(() => Promise.reject(new Error('fetch failed')))
+    const { container } = render(() => (
+      <ChatScrollRail {...baseProps({ onJumpToSeq, hasMoreOlder: true, hasMoreNewer: true })} />
+    ))
+    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
+    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    // A TAP on the track: the hold waits on the PRESS's seek, which is the one that rejects.
+    rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 360, pointerId: 1 }))
+    rail.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, clientY: 360, pointerId: 1 }))
+    const thumb = container.querySelector('[data-testid="chat-scroll-rail-thumb"]') as HTMLElement
+    expect(thumb.className).toContain(styles.thumbDragging)
+    await tick()
+    expect(thumb.className).not.toContain(styles.thumbDragging)
+  })
+
+  it('survives a settle seek that rejects, and keeps scrubbing', async () => {
+    // The settle seek is fire-and-forget -- no hold awaits it -- so it is the one seek whose
+    // rejection nothing else would handle. An unhandled rejection here would surface as a
+    // console error mid-scrub (and fails this suite outright), and the scrub must carry on.
+    HTMLElement.prototype.setPointerCapture = vi.fn()
+    vi.useFakeTimers()
+    // A DEFERRED rAF (drained by flushRaf), not installImmediateRaf: this test dispatches two
+    // moves, and a synchronous rAF leaves the coalescer's rafId set from its own return value,
+    // which swallows the second push. See the fast-scrub coalescing test below.
+    const rafQueue: FrameRequestCallback[] = []
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => rafQueue.push(cb))
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+    const flushRaf = () => rafQueue.splice(0).forEach(cb => cb(0))
+    const onJumpToSeq = vi.fn(() => Promise.reject(new Error('fetch failed')))
+    const previewScrollTo = vi.fn()
+    const { container } = render(() => (
+      <ChatScrollRail {...baseProps({
+        onJumpToSeq,
+        previewScrollTo,
+        maxSeq: 100_000n,
+        marks: [],
+        windowFirstSeq: 99_000n,
+        windowLastSeq: 100_000n,
+        hasMoreOlder: true,
+      })}
+      />
+    ))
+    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
+    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 12, pointerId: 1 }))
+    flushRaf()
+    rail.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientY: 200, pointerId: 1 }))
+    flushRaf()
+    vi.advanceTimersByTime(SCRUB_SEEK_DEBOUNCE_MS)
+    expect(onJumpToSeq).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(0) // let the rejection settle
+    // The scrub is unharmed: the thumb still tracks the pointer.
+    const thumb = container.querySelector('[data-testid="chat-scroll-rail-thumb"]') as HTMLElement
+    const beforeTop = thumb.style.top
+    rail.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientY: 300, pointerId: 1 }))
+    flushRaf()
+    expect(thumb.style.top).not.toBe(beforeTop)
+  })
+
+  it('still jumps when the browser refuses pointer capture', () => {
+    // The press action stands on its own. A browser that rejects setPointerCapture (an
+    // already-released pointer, a stale id) loses the SCRUB, but a press that stopped jumping
+    // as well would leave the rail with no working press at all.
+    HTMLElement.prototype.setPointerCapture = vi.fn(() => {
+      throw new DOMException('pointer is no longer active', 'NotFoundError')
+    })
+    installImmediateRaf()
+    const onJumpToSeq = vi.fn()
+    const { container } = render(() => <ChatScrollRail {...baseProps({ onJumpToSeq })} />)
+    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
+    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    expect(() => {
+      rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 360, pointerId: 1 }))
+    }).not.toThrow()
+    expect(onJumpToSeq).toHaveBeenCalledWith(5n)
+    // The failed grab also freed the guard, so the NEXT press is not locked out.
+    rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 360, pointerId: 2 }))
+    expect(onJumpToSeq).toHaveBeenCalledTimes(2)
+  })
+
+  it('a dot press jumps to the dot seq, centres the thumb on the dot, and scrubs on', () => {
+    // On a coarse pointer each dot carries a 24px hit circle, so on a marked conversation most
+    // of the rail is dot rather than track. A dot press that could not scrub would leave a
+    // finger with nowhere to start the gesture.
+    HTMLElement.prototype.setPointerCapture = vi.fn()
+    installImmediateRaf()
+    const onJumpToSeq = vi.fn()
+    const { container } = render(() => <ChatScrollRail {...baseProps({ onJumpToSeq })} />)
+    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
+    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    const dot = container.querySelector('[data-testid="chat-scroll-rail-dot"][data-seq="2"]') as HTMLElement
+    // Press the dot slightly off its centre (a fingertip is wider than the 6px dot).
+    dot.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 131, pointerId: 1 }))
+    // The jump takes the dot's OWN seq, not the fraction under the finger.
+    expect(onJumpToSeq).toHaveBeenCalledWith(2n)
+    const thumb = container.querySelector('[data-testid="chat-scroll-rail-thumb"]') as HTMLElement
+    expect(thumb.style.top).toBe('113px') // the dot sits at 125; the thumb centre lands on it
+    // The same press scrubs on to the other dot and lands there.
+    rail.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientY: 281, pointerId: 1 }))
+    rail.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, clientY: 281, pointerId: 1 }))
+    expect(onJumpToSeq).toHaveBeenLastCalledWith(4n)
+  })
+
+  it('a dot press released without a scrub seeks its dot exactly once', () => {
+    HTMLElement.prototype.setPointerCapture = vi.fn()
+    installImmediateRaf()
+    const onJumpToSeq = vi.fn()
+    const { container } = render(() => <ChatScrollRail {...baseProps({ onJumpToSeq })} />)
+    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
+    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    const dot = container.querySelector('[data-testid="chat-scroll-rail-dot"][data-seq="2"]') as HTMLElement
+    dot.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 125, pointerId: 1 }))
+    rail.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, clientY: 125, pointerId: 1 }))
+    expect(onJumpToSeq).toHaveBeenCalledTimes(1)
+    expect(onJumpToSeq).toHaveBeenCalledWith(2n)
+  })
+
+  it('opens the dot preview on a dot press, with no hover to open it', () => {
+    // A touch has no hover: the popover must come from the press itself (the thumb lands on the
+    // dot, so the scrub target resolves to it) or a finger would never see a preview.
+    HTMLElement.prototype.setPointerCapture = vi.fn()
+    installImmediateRaf()
+    const previewFor = (seq: bigint) => (seq === 2n ? 'pressed message two' : undefined)
+    const { container } = render(() => <ChatScrollRail {...baseProps({ previewFor })} />)
+    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
+    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    expect(container.querySelector('[data-testid="chat-scroll-rail-preview"]')).toBeNull()
+    const dot = container.querySelector('[data-testid="chat-scroll-rail-dot"][data-seq="2"]') as HTMLElement
+    dot.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 125, pointerId: 1 }))
+    const previews = container.querySelectorAll('[data-testid="chat-scroll-rail-preview"]')
+    expect(previews.length).toBe(1)
+    expect(previews[0]).toHaveTextContent('pressed message two')
+  })
+
+  it('ignores a dot press while a drag is live (no rival seek)', () => {
+    HTMLElement.prototype.setPointerCapture = vi.fn()
+    installImmediateRaf()
+    const onJumpToSeq = vi.fn()
+    const { container } = render(() => <ChatScrollRail {...baseProps({ onJumpToSeq })} />)
+    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
+    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    // A first pointer grabs the thumb (spans 0..24) -> a live drag is in progress.
+    rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 12, pointerId: 1 }))
+    // A SECOND finger lands on a dot mid-drag: without the guard it would fire a rival jump
+    // that races the drag's live-scroll and its release seek.
+    const dot = container.querySelector('[data-testid="chat-scroll-rail-dot"][data-seq="4"]') as HTMLElement
+    dot.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 275, pointerId: 2 }))
+    expect(onJumpToSeq).not.toHaveBeenCalled()
+  })
+
+  it('seeks an out-of-window position the scrub settles on, so the view follows the thumb', () => {
+    // Out of the loaded window there is nothing to live-scroll to. Without the settle seek the
+    // thumb and the dot preview would move over a transcript that never follows.
+    HTMLElement.prototype.setPointerCapture = vi.fn()
+    vi.useFakeTimers()
+    installImmediateRaf()
+    const onJumpToSeq = vi.fn()
+    // A long history whose loaded window holds only its tail (seqs 1..5 of 1..100000).
+    const { container } = render(() => (
+      <ChatScrollRail {...baseProps({
+        onJumpToSeq,
+        maxSeq: 100_000n,
+        marks: [],
+        windowFirstSeq: 99_000n,
+        windowLastSeq: 100_000n,
+        hasMoreOlder: true,
+      })}
+      />
+    ))
+    const rail = container.querySelector('[data-testid="chat-scroll-rail"]') as HTMLElement
+    rail.getBoundingClientRect = () => ({ top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) })
+    rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 12, pointerId: 1 }))
+    onJumpToSeq.mockClear() // the grab itself is a thumb grab: it jumps nowhere
+    rail.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientY: 200, pointerId: 1 }))
+    expect(onJumpToSeq).not.toHaveBeenCalled() // a fly-over must not fetch
+    vi.advanceTimersByTime(SCRUB_SEEK_DEBOUNCE_MS)
+    // Rail fraction 0.5 over [1, 100000] -> seq 50000ish; assert it landed inside the history
+    // rather than pinning an exact rounding.
+    expect(onJumpToSeq).toHaveBeenCalledTimes(1)
+    const [seq] = onJumpToSeq.mock.calls[0] as [bigint]
+    expect(seq).toBeGreaterThan(49_000n)
+    expect(seq).toBeLessThan(51_000n)
   })
 
   it('ignores a second pointerdown on the track while a thumb-drag is live (no rival seek)', () => {
@@ -876,6 +1178,39 @@ describe('chatscrollrail dot preview popover', () => {
       const dot = container.querySelector('[data-testid="chat-scroll-rail-dot"]') as HTMLElement
       fireEvent.focusIn(dot)
       expect(onActivity).toHaveBeenCalledTimes(2)
+    })
+
+    it('reopens the host window when a drag ENDS, so a long scrub still gets a fade tail', () => {
+      // The window the grab opened has a fixed idle timeout, and nothing re-arms it mid-drag: the
+      // pointer is captured (the scroll container sees nothing), the rail's own pointermove
+      // relight is inert while idle() is false, and the drag's live-scroll writes are
+      // programmatic. A touch scrub easily outlasts that timeout, so without a relight at the end
+      // the rail would fade out from under the finger the moment it lifts.
+      HTMLElement.prototype.setPointerCapture = vi.fn()
+      installImmediateRaf()
+      const onActivity = vi.fn()
+      const { container } = render(() => <ChatScrollRail {...baseProps({ onActivity })} />)
+      const rail = railWithRect(container)
+
+      rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 12, pointerId: 1 }))
+      onActivity.mockClear()
+      rail.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientY: 200, pointerId: 1 }))
+      expect(onActivity).not.toHaveBeenCalled() // no per-move timer churn
+      rail.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, clientY: 200, pointerId: 1 }))
+      expect(onActivity).toHaveBeenCalledTimes(1)
+    })
+
+    it('reopens the host window when a drag is CANCELLED (a system gesture stole the pointer)', () => {
+      HTMLElement.prototype.setPointerCapture = vi.fn()
+      installImmediateRaf()
+      const onActivity = vi.fn()
+      const { container } = render(() => <ChatScrollRail {...baseProps({ onActivity })} />)
+      const rail = railWithRect(container)
+
+      rail.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientY: 12, pointerId: 1 }))
+      onActivity.mockClear()
+      rail.dispatchEvent(new PointerEvent('pointercancel', { bubbles: true, clientY: 200, pointerId: 1 }))
+      expect(onActivity).toHaveBeenCalledTimes(1)
     })
 
     it('reopens the host window from a pointermove only while the rail is faded, not on every move', () => {

--- a/frontend/src/components/chat/ChatScrollRail.tsx
+++ b/frontend/src/components/chat/ChatScrollRail.tsx
@@ -18,7 +18,7 @@ import {
   railYToSeq,
 } from './chatScrollRailGeometry'
 import { createRailMetrics } from './chatScrollRailMetrics'
-import { dotLabel, DotPreview } from './ChatScrollRailPreview'
+import { DOT_PREVIEW_CARD_ID, dotLabel, DotPreviewCard } from './ChatScrollRailPreview'
 
 // ---------------------------------------------------------------------------
 // Seq-space scroll rail
@@ -30,7 +30,8 @@ import { dotLabel, DotPreview } from './ChatScrollRailPreview'
 //   - chatScrollRailGeometry -- pure seq<->pixel math, the thumb rect, and dot clustering.
 //   - createThumbDrag        -- the pointer-capture drag lifecycle.
 //   - createDragReleaseHold  -- pins the thumb at its release fraction until the seek settles.
-//   - ChatScrollRailPreview  -- the dot hover/scrub tooltip presentation.
+//   - createDotPreview       -- which dot the one preview card describes, and when it opens/closes.
+//   - ChatScrollRailPreview  -- the dot hover/scrub preview card itself.
 //
 // EVERY press on the rail starts a drag, whatever it lands on and whatever the pointer type.
 // A press on the track or a dot ALSO jumps at once, then scrubs on from the pressed point if
@@ -84,7 +85,7 @@ export interface ChatScrollRailProps {
    * ORTHOGONAL to `hidden`: that one is the scrollbar-OWNER decision and unmounts the
    * rail, while this one is paint-only and must NEVER unmount it -- an unmount would
    * disconnect the rail's ResizeObserver, cancel a live thumb drag, and rebuild every
-   * dot's tooltip on each transition. The resulting `railIdle` class fades the rail on
+   * dot on each transition. The resulting `railIdle` class fades the rail on
    * EVERY screen/pointer; only the touch-safety `pointer-events: none` it also carries
    * is coarse-only.
    */
@@ -172,7 +173,7 @@ export function ChatScrollRail(props: ChatScrollRailProps) {
   // layout keeps the SAME array reference: maxSeq ticks up on every persisted row during a
   // streaming turn, but on a long conversation a +1 seq shift rounds to the same clusters, so
   // recomputing would otherwise hand <For> a fresh array each frame and tear down + rebuild
-  // every dot's tooltip (3 effects + 5 listeners each) for no visual change.
+  // every dot button (and the listeners on each) for no visual change.
   const dots = createMemo<DotCluster[]>(
     // props.rail is a ChatRailData -- a structural superset of RailRange -- so pass it straight
     // through as the range rather than re-flattening {minSeq, maxSeq} (which the two would then
@@ -185,13 +186,24 @@ export function ChatScrollRail(props: ChatScrollRailProps) {
   // The dot-preview state machine (which dot the single popover describes, its placement, and when
   // to warm its preview) extracted into its own unit alongside createRailMetrics /
   // createDragReleaseHold / createThumbDrag, so this component owns only the wiring + render.
-  const { activeDot, popoverTopPx, setHoverDot } = createDotPreview({
+  // The open card's measured height, reported by the card itself. The card's Y is clamped against
+  // it (see cardTopPx), so the clamp holds a SHORT card near its own dot instead of pushing every
+  // card half the max-height cap away from the dot it points at.
+  const [cardHeightPx, setCardHeightPx] = createSignal(0)
+
+  const { activeDot, cardTopPx, openDot, closeSoon, abandonDot, focusDot, blurDot, closeNow } = createDotPreview({
     dots,
     drag,
     railHeight,
     thumbHeightPx: thumbHeightNow,
+    cardHeightPx,
     warmPreview: seq => props.warmPreview?.(seq),
   })
+
+  // A press inside the preview card is live, so the card owns the pointer and the dots stand down
+  // (see the dot's pointer handlers). Not a signal: nothing renders from it, and the dot handlers
+  // that read it run outside any tracking scope.
+  let cardPressed = false
 
   const cancelActiveDrag = () => {
     const cleanup = dragCleanup
@@ -205,7 +217,10 @@ export function ChatScrollRail(props: ChatScrollRailProps) {
     railResizeObserver = undefined
     railEl = undefined
     setRailHeight(0)
-    setHoverDot(null)
+    // No close delay here: the rail is going away, so there is no card left to move onto. The
+    // press lock needs no reset: the card clears it from its own cleanup as it unmounts, which
+    // keeps the card the single owner of its press lifecycle.
+    closeNow()
   }
 
   const setRailRef = (el: HTMLDivElement) => {
@@ -408,7 +423,14 @@ export function ChatScrollRail(props: ChatScrollRailProps) {
       // The grab became a scrub: the reader took manual control of the thumb, so this press's own
       // jump (issued a moment ago, possibly still fetching) is stale and must not land under them.
       // The settle seeks drive the view from here on.
-      onEngage: () => props.onSeekInterrupt?.(),
+      onEngage: () => {
+        props.onSeekInterrupt?.()
+        // The press started ON a dot, so the pointer channel holds that dot, and the captured drag
+        // fires no pointerleave to release it. Drop it now that the gesture owns the card: the
+        // scrub target describes the card from here, and without this the card springs back to the
+        // pressed dot the moment the drag ends -- pointing at a dot the reader scrubbed away from.
+        abandonDot()
+      },
       onRelease: releaseDrag,
       // The pointer lifecycle ended (release/cancel/unmount): free the "drag active" guard so
       // the next grab can start. Fires before onRelease, so the release's preview-hold is intact.
@@ -639,24 +661,54 @@ export function ChatScrollRail(props: ChatScrollRailProps) {
               data-mark-type={d.type}
               data-count={d.count}
               aria-label={dotLabel(d)}
+              // The open card describes the dot it belongs to, so a screen reader reads the
+              // message preview and not just "Your message" -- the same shape Tooltip.tsx uses (a
+              // stable id on the surface, aria-describedby on the target only while it is up).
+              // Matched on the SEQ, because a re-anchor hands over a fresh cluster for the same
+              // dot, and only for the dot the card actually describes: a scrub target outranks a
+              // focused dot, so the focused one must not claim a card that moved elsewhere.
+              aria-describedby={activeDot()?.seq === d.seq ? DOT_PREVIEW_CARD_ID : undefined}
               style={{ top: `${d.topPx}px` }}
-              // Set/clear the active dot so the shared popover opens immediately on hover AND
-              // keyboard focus (the warm effect on activeDot fills it in).
-              onPointerEnter={() => setHoverDot(d)}
-              onPointerLeave={() => setHoverDot(null)}
-              onFocus={() => setHoverDot(d)}
-              onBlur={() => setHoverDot(null)}
+              // Open the shared card immediately on hover AND keyboard focus (the warm effect on
+              // activeDot fills it in). A pointer LEAVING only starts the close delay, which is
+              // the window the reader crosses to reach the card; another dot opened in the
+              // meantime cancels it. Focus is its own channel with no delay, and it TAKES the card
+              // from the pointer, so tabbing along the dots is not masked by a parked cursor. See
+              // POINTER_CLOSE_DELAY_MS.
+              //
+              // Both pointer handlers stand down while a press inside the card is live. The card
+              // sits a gutter away from these dots, so selecting to the end of a line drags the
+              // pointer across them; re-targeting the card there would swap its body under the
+              // reader's own selection and collapse it.
+              onPointerEnter={() => {
+                if (!cardPressed)
+                  openDot(d)
+              }}
+              onPointerLeave={() => {
+                if (!cardPressed)
+                  closeSoon()
+              }}
+              onFocus={() => focusDot(d)}
+              onBlur={() => blurDot()}
               onPointerDown={e => onDotPointerDown(e, d)}
               onKeyDown={e => onDotKeyDown(e, d.seq)}
             />
           )}
         </For>
-        {/* ONE preview popover for the active dot (hover/focus OR scrub) -- never two. */}
+        {/* ONE preview card for the active dot (hover/focus OR scrub) -- never two. */}
         <Show when={activeDot()}>
           {d => (
-            <div class={styles.previewPopover} data-testid="chat-scroll-rail-preview" style={{ top: `${popoverTopPx()}px` }}>
-              <DotPreview previewFor={() => props.previewFor?.(d().seq)} markType={d().type} count={d().count} />
-            </div>
+            <DotPreviewCard
+              topPx={cardTopPx()}
+              dot={d()}
+              previewFor={seq => props.previewFor?.(seq)}
+              // The card holds ITSELF open while the reader is on it, and re-declares the dot it
+              // shows -- so a card that a scrub opened stays when the scrub ends.
+              onHoldStart={() => openDot(d())}
+              onHoldEnd={closeSoon}
+              onPressChange={(down) => { cardPressed = down }}
+              onHeightChange={setCardHeightPx}
+            />
           )}
         </Show>
       </div>

--- a/frontend/src/components/chat/ChatScrollRail.tsx
+++ b/frontend/src/components/chat/ChatScrollRail.tsx
@@ -92,9 +92,10 @@ export interface ChatScrollRailProps {
   /**
    * The rail's OWN interaction reopens the host's activity window. Required, not a
    * nicety: a thumb drag captures the pointer, so its pointermove events retarget to the
-   * rail element and the host's scroll container never sees them. Without this the rail
-   * would snap dark the instant a drag releases or a focused dot is tabbed away from,
-   * with no fade tail.
+   * rail element and the host's scroll container never sees them. The rail calls it on its
+   * own traffic (a press, a wheel, focus reaching a dot) and again whenever it stops holding
+   * ITSELF lit -- a drag, its release hold, or a dot popover ending. Without the second one,
+   * any of those outlasting the host's idle timeout snaps the rail dark with no fade tail.
    */
   onActivity?: () => void
   hasMoreOlder: boolean
@@ -109,10 +110,12 @@ export interface ChatScrollRailProps {
   previewScrollTo: (top: number) => void
   /**
    * Abandon the host's in-flight out-of-window seek, so its late fetch can't yank the viewport
-   * mid-scrub -- the rail's own scroll writes are programmatic and never trip the host's
-   * user-scroll cancellation. Called twice over one gesture, for two different stale seeks: at
-   * the grab (a PRIOR release's seek) and again when the grab becomes a scrub (THIS press's own
-   * jump, which the reader has now scrubbed away from). Optional.
+   * -- the rail's own scroll writes are programmatic and never trip the host's user-scroll
+   * cancellation, so nothing else drops one. One rule drives every call: a gesture abandons
+   * each seek it issued and did not choose to land. That covers the grab (a PRIOR release's
+   * seek), the moment the grab becomes a scrub (THIS press's own jump), each moment a scrub
+   * leaves the position a settle seek asked for, and an aborted gesture, which drops the lot.
+   * Optional.
    */
   onSeekInterrupt?: () => void
   /**
@@ -248,6 +251,25 @@ export function ChatScrollRail(props: ChatScrollRailProps) {
   // :focus-within is needed).
   const idle = createMemo(() => !props.scrollActive && drag() === null && activeDot() === null)
 
+  // Re-open the host's activity window on the FALLING edge of the rail's OWN overrides -- the
+  // live drag, its post-release hold, and the open dot popover that idle() above lets outrank
+  // the host's window. Each of them holds the rail lit while nothing re-arms that window: a
+  // captured drag's pointermove retargets to the rail, so the host's scroll container never
+  // sees it, and the rail's own onPointerMove relight is inert for the whole time (idle() is
+  // false). So without this, any override outlasting the host's idle timeout ends by snapping
+  // the rail dark instead of fading it. Keying the re-arm on the overrides rather than on the
+  // pointer lifecycle is what covers all three: a release whose out-of-window seek outlives the
+  // window re-arms when the hold clears, not when the finger lifts.
+  let railHeldLit = false
+  createEffect(() => {
+    const heldLit = drag() !== null || activeDot() !== null
+    // Not while hidden: the rail that just stopped rendering must not re-arm a window for
+    // itself. Hiding tears the drag down (below), which is a falling edge of its own.
+    if (railHeldLit && !heldLit && !hidden())
+      props.onActivity?.()
+    railHeldLit = heldLit
+  })
+
   createEffect(() => {
     if (hidden())
       disconnectRail()
@@ -272,16 +294,33 @@ export function ChatScrollRail(props: ChatScrollRailProps) {
   })
 
   /**
-   * Normalise a seek's result to the boolean the drag-release hold reads: `true` only when the
-   * seek reported that it scrolled. A seek that returns nothing, or that rejects, resolves
-   * `false` here -- so a caller that ignores the result can never leak an unhandled rejection,
-   * and the hold clears the thumb at once when no landing will follow.
+   * The ONE way this component seeks. Every path goes through here -- a track or dot press, a
+   * scrub's settle, a scrub release, and a keyboard activation -- so the seek contract is a
+   * property of the code rather than of whichever call site remembered it:
+   *
+   *   - The result is normalised to the boolean the drag-release hold reads: `true` only when
+   *     the seek reported that it scrolled. A seek that returns nothing resolves `false`, so
+   *     the hold clears the thumb at once when no landing will follow.
+   *   - A seek that rejects, or that throws synchronously, also resolves `false`. Thus a caller
+   *     that ignores the result can never leak an unhandled rejection, and a throw from inside
+   *     `onJumpToSeq` can never escape a pointer handler or a settle timer.
+   *
+   * A failure is degraded, not hidden: `false` is the honest answer for the hold (no landing
+   * will follow, so release the thumb now), and the warn keeps the cause visible instead of
+   * turning a broken seek into a thumb that silently springs back.
    */
-  const normalizeSeek = (result: ReturnType<ChatScrollRailProps['onJumpToSeq']>): Promise<boolean> =>
-    Promise.resolve(result).then(scrolled => scrolled === true, () => false)
-
-  /** Seek to a seq now, with the result normalised for the hold. */
-  const seekTo = (seq: bigint): Promise<boolean> => normalizeSeek(props.onJumpToSeq(seq))
+  const seekTo = (seq: bigint): Promise<boolean> => {
+    const failed = (err: unknown): boolean => {
+      console.warn('chat scroll rail: seek failed', { seq: seq.toString(), err })
+      return false
+    }
+    try {
+      return Promise.resolve(props.onJumpToSeq(seq)).then(scrolled => scrolled === true, failed)
+    }
+    catch (err) {
+      return Promise.resolve(failed(err))
+    }
+  }
 
   // The seek the PRESS issued, kept for the length of one grab. A track or dot press jumps
   // immediately (see pressJumpAndScrub); a thumb grab jumps nowhere and leaves this undefined.
@@ -306,8 +345,12 @@ export function ChatScrollRail(props: ChatScrollRailProps) {
       dragHold.release(fraction, () => {})
       return
     }
-    const jump = props.onJumpToSeq
-    dragHold.release(fraction, () => normalizeSeek(jump(seq)))
+    // Seek EAGERLY and hand the hold the promise, exactly as the tap branch hands it the press's.
+    // The hold invokes its thunk synchronously anyway, so this changes no ordering the reader can
+    // see -- and it keeps the reactive `props.onJumpToSeq` read out of a deferred callback, where
+    // it would be a stale-closure hazard rather than the release-time read this needs.
+    const jumped = seekTo(seq)
+    dragHold.release(fraction, () => jumped)
   }
 
   /**
@@ -357,6 +400,11 @@ export function ChatScrollRail(props: ChatScrollRailProps) {
       // page it needs -- otherwise a scrub across a long history moves the thumb and the dot
       // preview over a transcript that never follows.
       scrubSeek: (seq) => { void seekTo(seq) },
+      // Abandon a seek this gesture issued and no longer points at, so its late fetch cannot
+      // land under the reader (see ThumbDragDeps.abandonSeeks for each moment it fires). The
+      // host's own user-scroll cancellation never covers these: the drag scrolls only
+      // programmatically, so nothing it does looks like a gesture to the host.
+      abandonSeeks: () => props.onSeekInterrupt?.(),
       // The grab became a scrub: the reader took manual control of the thumb, so this press's own
       // jump (issued a moment ago, possibly still fetching) is stale and must not land under them.
       // The settle seeks drive the view from here on.
@@ -367,11 +415,6 @@ export function ChatScrollRail(props: ChatScrollRailProps) {
       onEnd: () => {
         dragCleanup = undefined
         dragHold.end()
-        // Re-open the host's activity window so the rail keeps its fade tail after the drag. A
-        // captured pointer reaches no other listener, and the rail's own onPointerMove relight is
-        // inert while dragging (idle() is false for the whole drag) -- so without this, any drag
-        // longer than the host's idle timeout ends with the rail fading out under the finger.
-        props.onActivity?.()
       },
     })
     // Teardown for an unmount that lands mid-drag (onCleanup below); idempotent, so a
@@ -387,8 +430,15 @@ export function ChatScrollRail(props: ChatScrollRailProps) {
    * centres on `centreY` -- the reader pressed a position, so the thumb belongs under it -- and
    * the grab carries the engage slop, which is what keeps the jump the only seek of a plain tap.
    */
-  const pressJumpAndScrub = (event: PointerEvent, rect: DOMRect, seq: bigint | null, centreY: number) => {
-    const grabThumbTopPx = centreY - thumbHeightNow() / 2
+  const pressJumpAndScrub = (event: PointerEvent, rect: DOMRect, seq: bigint | null) => {
+    // Centre the thumb on the PRESSED POINT -- for a dot press exactly as for a track press. The
+    // jump still goes to the seq the caller resolved (a dot passes its OWN seq, not the wide
+    // fraction under the finger), but the thumb belongs under the finger, because the drag keeps
+    // whatever finger-to-thumb offset it starts with for its whole length. Anchoring a dot press
+    // on the dot instead left that offset at up to half a coarse hit circle (12px), so the thumb,
+    // the dot preview it resolves against, and the release landing all sat that far from the
+    // point the reader was pointing at -- and only for a dot press, so one gesture had two feels.
+    const grabThumbTopPx = (event.clientY - rect.top) - thumbHeightNow() / 2
     if (!startDrag(event, rect, { grabThumbTopPx, engageSlopPx: SCRUB_ENGAGE_SLOP_PX }))
       return
     if (seq !== null)
@@ -409,23 +459,50 @@ export function ChatScrollRail(props: ChatScrollRailProps) {
     return faded
   }
 
+  /**
+   * The prelude EVERY press on the rail runs, whatever it lands on: reject a press the rail
+   * cannot serve, reveal a faded rail instead of acting on it, and claim the press from the
+   * browser. Returns the rail's rect for the caller's hit-test, or null when the press is
+   * rejected. One home for the rule, so a guard added later cannot reach the track press and
+   * miss the dot press.
+   */
+  const beginRailPress = (event: PointerEvent): DOMRect | null => {
+    // Only the primary button opens a gesture, and this runs FIRST so a secondary press neither
+    // relights the rail nor loses its default. Every press now CAPTURES the pointer and owns the
+    // rail until its pointerup, and a context menu can swallow the pointerup of a right press --
+    // which would leave the rail owned by a gesture that never ends. (lostpointercapture in
+    // createThumbDrag recovers from the capture losses this cannot exclude.)
+    if (event.button !== 0)
+      return null
+    // Whether or not this grab is accepted, reaching for the rail is intent to use it, so it
+    // must keep the rail lit rather than fade under the cursor (see revealIfFaded).
+    if (revealIfFaded())
+      return null
+    const el = railEl
+    if (!el || hidden())
+      return null
+    // A LIT rail owns this press even when it rejects it below, so preventDefault comes BEFORE
+    // the rival-drag test rather than after: without it, a second finger landing on a dot
+    // focuses that dot's button, and the focus opens the dot's preview popover with no
+    // pointerleave to ever close it -- which pins activeDot() non-null and holds the whole rail
+    // lit for the rest of the session.
+    event.preventDefault()
+    // Ignore a second pointerdown while a drag is already live (dragCleanup is set from
+    // startDrag until the pointer lifecycle ends). Without this, a second finger landing on the
+    // TRACK or a DOT would fire a rival onJumpToSeq that races the in-progress drag's
+    // live-scroll and its eventual release seek.
+    if (dragCleanup)
+      return null
+    return el.getBoundingClientRect()
+  }
+
   // One pointerdown handler for the rail: hit-test the thumb (grab it where it lies) vs the
   // track (jump to the pressed position, then scrub). Dots stop propagation so they never
   // reach here.
   const onRailPointerDown = (event: PointerEvent) => {
-    // Whether or not this grab is accepted, reaching for the rail is intent to use it, so it
-    // must keep the rail lit rather than fade under the cursor (see revealIfFaded).
-    if (revealIfFaded())
+    const rect = beginRailPress(event)
+    if (!rect)
       return
-    const el = railEl
-    // Ignore a second pointerdown while a thumb-drag is already live (dragCleanup is set from
-    // startDrag until the pointer lifecycle ends). Without this, a second finger landing on the
-    // TRACK -- the thumb branch is already guarded by dragHold.begin() -- would fire a rival
-    // onJumpToSeq that races the in-progress drag's live-scroll and its eventual release seek.
-    if (!el || hidden() || dragCleanup)
-      return
-    event.preventDefault()
-    const rect = el.getBoundingClientRect()
     const y = event.clientY - rect.top
     const tp = thumbPx()
     // On the thumb -> drag it from where it was grabbed (the pointer keeps its within-thumb
@@ -436,7 +513,7 @@ export function ChatScrollRail(props: ChatScrollRailProps) {
       return
     }
     // On the bare track -> jump to the pressed position and scrub on from there.
-    pressJumpAndScrub(event, rect, railYToSeq(y, rect.height, thumbHeightNow(), props.rail), y)
+    pressJumpAndScrub(event, rect, railYToSeq(y, rect.height, thumbHeightNow(), props.rail))
   }
 
   const onDotPointerDown = (event: PointerEvent, d: DotCluster) => {
@@ -444,34 +521,36 @@ export function ChatScrollRail(props: ChatScrollRailProps) {
     // and never also as a track click -- stopPropagation runs before the faded guard so a
     // rejected (faded) press still doesn't fall through to onRailPointerDown.
     event.stopPropagation()
-    // Same reveal-but-reject rule as a track/thumb press (see revealIfFaded). The dot
-    // hover/focus path keeps the rail visible on its own, so this only bites the very first
-    // press onto a faded strip. A coarse-pointer idle rail is pointer-events:none, so the dot
-    // buttons under it are unreachable there.
-    if (revealIfFaded())
+    // The same prelude the track press runs -- the reveal-but-reject rule, the primary-button
+    // test, and the rival-drag guard (see beginRailPress). The dot hover/focus path keeps the
+    // rail visible on its own, so the faded rejection only bites the very first press onto a
+    // faded strip; a coarse-pointer idle rail is pointer-events:none, so the dot buttons under
+    // it are unreachable there.
+    const rect = beginRailPress(event)
+    if (!rect)
       return
-    const el = railEl
-    // The same rival-grab and disconnected-rail guards the track press carries: a second finger
-    // landing on a dot mid-scrub must not fire a jump that races the live drag.
-    if (!el || hidden() || dragCleanup)
-      return
-    event.preventDefault()
     // Jump to the dot's OWN seq (not the fraction under the finger, which on a long history is
     // hundreds of seqs wide) and scrub on from the dot's position. On a coarse pointer each dot
     // carries a 24px hit circle, so on a marked conversation most of the rail is dot rather than
     // track -- without this, most of a finger's presses could jump but never scrub.
-    pressJumpAndScrub(event, el.getBoundingClientRect(), d.seq, d.topPx)
+    pressJumpAndScrub(event, rect, d.seq)
   }
 
   // Keyboard activation of a focused dot. Pointer devices jump on pointerdown (above) and
   // never fire keydown; the keyboard never fires pointerdown -- so exactly one jump per
-  // activation, and the button's inert native click can't double it. preventDefault stops
-  // Space from also page-scrolling.
+  // activation, and the button's inert native click can't double it.
   const onDotKeyDown = (event: KeyboardEvent, seq: bigint) => {
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault()
-      props.onJumpToSeq(seq)
-    }
+    if (event.key !== 'Enter' && event.key !== ' ')
+      return
+    // preventDefault stops Space from also page-scrolling.
+    event.preventDefault()
+    // The rival-drag guard both press paths carry (see beginRailPress). A dot keeps keyboard
+    // focus while a pointer scrubs the rail, so without this an Enter mid-scrub fires exactly
+    // the rival jump those guards exist to stop.
+    if (hidden() || dragCleanup)
+      return
+    // Through seekTo like every other seek, so this path cannot leak an unhandled rejection.
+    void seekTo(seq)
   }
 
   // The rail overlays the strip where the native scrollbar used to be, and its ancestors

--- a/frontend/src/components/chat/ChatScrollRail.tsx
+++ b/frontend/src/components/chat/ChatScrollRail.tsx
@@ -7,7 +7,7 @@ import { createDotPreview } from './chatDotPreview'
 import { clusterMarks, dotClustersEqual } from './chatRailPolicy'
 import { clampScrollTop } from './chatScrollGeometry'
 import * as styles from './ChatScrollRail.css'
-import { createThumbDrag } from './chatScrollRailDrag'
+import { createThumbDrag, SCRUB_ENGAGE_SLOP_PX } from './chatScrollRailDrag'
 import { createDragReleaseHold } from './chatScrollRailDragHold'
 import {
   computeSeqThumb,
@@ -31,6 +31,14 @@ import { dotLabel, DotPreview } from './ChatScrollRailPreview'
 //   - createThumbDrag        -- the pointer-capture drag lifecycle.
 //   - createDragReleaseHold  -- pins the thumb at its release fraction until the seek settles.
 //   - ChatScrollRailPreview  -- the dot hover/scrub tooltip presentation.
+//
+// EVERY press on the rail starts a drag, whatever it lands on and whatever the pointer type.
+// A press on the track or a dot ALSO jumps at once, then scrubs on from the pressed point if
+// the pointer travels; a press on the thumb only grabs it. That one rule is what makes the rail
+// usable by a finger -- a touch has no hover to aim with and no second press to spend, so the
+// press that reveals a position must be the same press that scrubs from it -- and it is exactly
+// how a native scrollbar track already behaves under a mouse, so there is no pointer-type
+// branch anywhere below.
 // ---------------------------------------------------------------------------
 
 /** Wheel-line height (px) used to translate line/page wheel deltas into pixels. */
@@ -92,18 +100,19 @@ export interface ChatScrollRailProps {
   hasMoreOlder: boolean
   hasMoreNewer: boolean
   /**
-   * Seek to a seq (dot click, track click, thumb release). May resolve to whether the seek
-   * actually moved the view -- the thumb-drag release awaits this to time its preview
-   * hand-off; the dot/track callers ignore the result.
+   * Seek to a seq: a press on a dot or the track, a scrub that settles on an out-of-window
+   * position, or a scrub release. May resolve to whether the seek actually moved the view --
+   * the drag-release hold awaits that to time its thumb hand-off.
    */
   onJumpToSeq: (seq: bigint) => void | Promise<boolean>
   /** Guard-marked programmatic scroll write for in-window thumb-drag live-scrolling. */
   previewScrollTo: (top: number) => void
   /**
-   * A fresh thumb-drag grab began. Lets the host abandon an in-flight out-of-window seek
-   * (from a PRIOR release) so its late fetch can't yank the viewport mid-scrub -- the
-   * drag's own scroll writes are programmatic and never trip the host's user-scroll
-   * cancellation. Optional; the dot/track jump paths supersede the seek on their own.
+   * Abandon the host's in-flight out-of-window seek, so its late fetch can't yank the viewport
+   * mid-scrub -- the rail's own scroll writes are programmatic and never trip the host's
+   * user-scroll cancellation. Called twice over one gesture, for two different stale seeks: at
+   * the grab (a PRIOR release's seek) and again when the grab becomes a scrub (THIS press's own
+   * jump, which the reader has now scrubbed away from). Optional.
    */
   onSeekInterrupt?: () => void
   /**
@@ -262,27 +271,63 @@ export function ChatScrollRail(props: ChatScrollRailProps) {
     return projectThumbPx(rect, rh, THUMB_HEIGHT_PX)
   })
 
-  // Land a thumb release: seek to the mapped seq while the hold keeps the thumb pinned at the
-  // release fraction until the seek settles (see createDragReleaseHold.release). The seq and
-  // the jump callback are resolved synchronously here so the seek thunk closes over locals,
-  // not reactive props -- the release runs from a pointer handler, not a tracked scope.
-  const releaseDragAt = (fraction: number) => {
+  /**
+   * Normalise a seek's result to the boolean the drag-release hold reads: `true` only when the
+   * seek reported that it scrolled. A seek that returns nothing, or that rejects, resolves
+   * `false` here -- so a caller that ignores the result can never leak an unhandled rejection,
+   * and the hold clears the thumb at once when no landing will follow.
+   */
+  const normalizeSeek = (result: ReturnType<ChatScrollRailProps['onJumpToSeq']>): Promise<boolean> =>
+    Promise.resolve(result).then(scrolled => scrolled === true, () => false)
+
+  /** Seek to a seq now, with the result normalised for the hold. */
+  const seekTo = (seq: bigint): Promise<boolean> => normalizeSeek(props.onJumpToSeq(seq))
+
+  // The seek the PRESS issued, kept for the length of one grab. A track or dot press jumps
+  // immediately (see pressJumpAndScrub); a thumb grab jumps nowhere and leaves this undefined.
+  // A release that never became a scrub hands this promise to the hold instead of seeking again.
+  let pressSeek: Promise<boolean> | undefined
+
+  // Land a rail release. A SCRUB seeks to the mapped seq while the hold keeps the thumb pinned at
+  // the release fraction until that seek settles (see createDragReleaseHold.release). A TAP --
+  // the pointer never left the engage slop -- seeks NOTHING: its press already jumped, so the
+  // hold just pins the thumb on the pressed point until THAT jump lands. Firing a second seek
+  // there would fetch the same page twice and, on a dot, land on the fraction under the finger
+  // instead of the dot's own seq. The seq is resolved synchronously here so the seek thunk closes
+  // over locals -- the release runs from a pointer handler, not a tracked scope.
+  const releaseDrag = (fraction: number, engaged: boolean) => {
+    if (!engaged) {
+      const pressed = pressSeek
+      dragHold.release(fraction, () => pressed)
+      return
+    }
     const seq = fractionToSeq(fraction, props.rail.minSeq, props.rail.maxSeq)
     if (seq === null) {
       dragHold.release(fraction, () => {})
       return
     }
     const jump = props.onJumpToSeq
-    dragHold.release(fraction, () => jump(seq))
+    dragHold.release(fraction, () => normalizeSeek(jump(seq)))
   }
 
-  const startDrag = (event: PointerEvent, rect: DOMRect, thumbTopPx: number) => {
+  /**
+   * Begin a grab on the rail. Returns false ONLY when a rival drag already owns it -- the caller
+   * must then drop its press action too, so a second finger can't fire a jump that races the live
+   * drag. Returns true otherwise, INCLUDING when the browser refuses pointer capture: the press
+   * action stands on its own, and must not depend on a capture that never happened.
+   */
+  const startDrag = (
+    event: PointerEvent,
+    rect: DOMRect,
+    opts: { grabThumbTopPx: number, engageSlopPx: number },
+  ): boolean => {
     const el = railEl
     // Ignore a second concurrent grab while a drag is live (begin() returns false) -- it would
     // add a rival listener set and orphan the first's on the rail. begin() also claims the
     // preview so a prior release's async settle can't clear THIS drag mid-way.
     if (!el || !dragHold.begin())
-      return
+      return false
+    pressSeek = undefined
     // A fresh grab is manual control: abandon a prior release's still-fetching out-of-window
     // seek so it can't land and yank the viewport while this drag scrubs (the drag scrolls
     // only programmatically, so the host's user-scroll seek-cancel never fires for it).
@@ -293,9 +338,11 @@ export function ChatScrollRail(props: ChatScrollRailProps) {
     const handle = createThumbDrag({
       el,
       rect,
-      // The thumb's resting top at grab, so the drag holds the pointer's within-thumb offset
-      // (no jump-on-grab) rather than recentering the thumb on the cursor.
-      grabThumbTopPx: thumbTopPx,
+      // Where the thumb sits at grab. A thumb grab passes the thumb's own resting top, so the
+      // drag holds the pointer's within-thumb offset (no jump-on-grab); a track or dot press
+      // passes the pressed point, so the thumb centres there (see pressJumpAndScrub).
+      grabThumbTopPx: opts.grabThumbTopPx,
+      engageSlopPx: opts.engageSlopPx,
       minSeq: () => props.rail.minSeq,
       maxSeq: () => props.rail.maxSeq,
       windowFirstSeq: () => props.rail.windowFirstSeq,
@@ -306,18 +353,46 @@ export function ChatScrollRail(props: ChatScrollRailProps) {
       thumbHeightPx: thumbHeightNow,
       setDrag: dragHold.preview,
       previewScrollTo: top => props.previewScrollTo(top),
-      onRelease: releaseDragAt,
+      // Out of the loaded window there is nothing to live-scroll to, so a settled thumb pulls the
+      // page it needs -- otherwise a scrub across a long history moves the thumb and the dot
+      // preview over a transcript that never follows.
+      scrubSeek: (seq) => { void seekTo(seq) },
+      // The grab became a scrub: the reader took manual control of the thumb, so this press's own
+      // jump (issued a moment ago, possibly still fetching) is stale and must not land under them.
+      // The settle seeks drive the view from here on.
+      onEngage: () => props.onSeekInterrupt?.(),
+      onRelease: releaseDrag,
       // The pointer lifecycle ended (release/cancel/unmount): free the "drag active" guard so
       // the next grab can start. Fires before onRelease, so the release's preview-hold is intact.
       onEnd: () => {
         dragCleanup = undefined
         dragHold.end()
+        // Re-open the host's activity window so the rail keeps its fade tail after the drag. A
+        // captured pointer reaches no other listener, and the rail's own onPointerMove relight is
+        // inert while dragging (idle() is false for the whole drag) -- so without this, any drag
+        // longer than the host's idle timeout ends with the rail fading out under the finger.
+        props.onActivity?.()
       },
     })
     // Teardown for an unmount that lands mid-drag (onCleanup below); idempotent, so a
     // normal release leaving this set is harmless.
     dragCleanup = () => handle.cancel()
     handle.start(event.pointerId, event.clientY)
+    return true
+  }
+
+  /**
+   * A press on a POSITION (the bare track, or a dot): jump there at once AND scrub on from there,
+   * so one press serves both the tap a mouse expects and the drag a finger expects. The thumb
+   * centres on `centreY` -- the reader pressed a position, so the thumb belongs under it -- and
+   * the grab carries the engage slop, which is what keeps the jump the only seek of a plain tap.
+   */
+  const pressJumpAndScrub = (event: PointerEvent, rect: DOMRect, seq: bigint | null, centreY: number) => {
+    const grabThumbTopPx = centreY - thumbHeightNow() / 2
+    if (!startDrag(event, rect, { grabThumbTopPx, engageSlopPx: SCRUB_ENGAGE_SLOP_PX }))
+      return
+    if (seq !== null)
+      pressSeek = seekTo(seq)
   }
 
   // "You can't click what you can't see." A press on a FADED rail or dot only REVEALS it
@@ -334,8 +409,9 @@ export function ChatScrollRail(props: ChatScrollRailProps) {
     return faded
   }
 
-  // One pointerdown handler for the rail: hit-test the thumb (start a drag) vs the track
-  // (jump to the clicked position). Dots stop propagation so they never reach here.
+  // One pointerdown handler for the rail: hit-test the thumb (grab it where it lies) vs the
+  // track (jump to the pressed position, then scrub). Dots stop propagation so they never
+  // reach here.
   const onRailPointerDown = (event: PointerEvent) => {
     // Whether or not this grab is accepted, reaching for the rail is intent to use it, so it
     // must keep the rail lit rather than fade under the cursor (see revealIfFaded).
@@ -352,20 +428,18 @@ export function ChatScrollRail(props: ChatScrollRailProps) {
     const rect = el.getBoundingClientRect()
     const y = event.clientY - rect.top
     const tp = thumbPx()
-    // On the thumb -> drag (holding the pointer's within-thumb offset, no jump-on-grab); on the
-    // bare track -> jump to the clicked position.
+    // On the thumb -> drag it from where it was grabbed (the pointer keeps its within-thumb
+    // offset, so there is no jump-on-grab) and engage on the FIRST pixel of travel: a press on
+    // the thumb has no competing tap meaning, and a scrollbar thumb that waited would feel stuck.
     if (tp && y >= tp.topPx && y <= tp.topPx + tp.heightPx) {
-      startDrag(event, rect, tp.topPx)
+      startDrag(event, rect, { grabThumbTopPx: tp.topPx, engageSlopPx: 0 })
+      return
     }
-    else {
-      const seq = railYToSeq(y, rect.height, thumbHeightNow(), props.rail)
-      if (seq !== null) {
-        props.onJumpToSeq(seq)
-      }
-    }
+    // On the bare track -> jump to the pressed position and scrub on from there.
+    pressJumpAndScrub(event, rect, railYToSeq(y, rect.height, thumbHeightNow(), props.rail), y)
   }
 
-  const onDotPointerDown = (event: PointerEvent, seq: bigint) => {
+  const onDotPointerDown = (event: PointerEvent, d: DotCluster) => {
     // Prioritize the dot over the thumb/track underneath: a dot press is always handled HERE
     // and never also as a track click -- stopPropagation runs before the faded guard so a
     // rejected (faded) press still doesn't fall through to onRailPointerDown.
@@ -376,8 +450,17 @@ export function ChatScrollRail(props: ChatScrollRailProps) {
     // buttons under it are unreachable there.
     if (revealIfFaded())
       return
+    const el = railEl
+    // The same rival-grab and disconnected-rail guards the track press carries: a second finger
+    // landing on a dot mid-scrub must not fire a jump that races the live drag.
+    if (!el || hidden() || dragCleanup)
+      return
     event.preventDefault()
-    props.onJumpToSeq(seq)
+    // Jump to the dot's OWN seq (not the fraction under the finger, which on a long history is
+    // hundreds of seqs wide) and scrub on from the dot's position. On a coarse pointer each dot
+    // carries a 24px hit circle, so on a marked conversation most of the rail is dot rather than
+    // track -- without this, most of a finger's presses could jump but never scrub.
+    pressJumpAndScrub(event, el.getBoundingClientRect(), d.seq, d.topPx)
   }
 
   // Keyboard activation of a focused dot. Pointer devices jump on pointerdown (above) and
@@ -484,7 +567,7 @@ export function ChatScrollRail(props: ChatScrollRailProps) {
               onPointerLeave={() => setHoverDot(null)}
               onFocus={() => setHoverDot(d)}
               onBlur={() => setHoverDot(null)}
-              onPointerDown={e => onDotPointerDown(e, d.seq)}
+              onPointerDown={e => onDotPointerDown(e, d)}
               onKeyDown={e => onDotKeyDown(e, d.seq)}
             />
           )}

--- a/frontend/src/components/chat/ChatScrollRailPreview.test.tsx
+++ b/frontend/src/components/chat/ChatScrollRailPreview.test.tsx
@@ -1,0 +1,89 @@
+import type { DotCluster } from './chatRailPolicy'
+import { render } from '@solidjs/testing-library'
+import { describe, expect, it, vi } from 'vitest'
+import { MarkType } from '~/generated/leapmux/v1/agent_pb'
+import { DotPreviewCard } from './ChatScrollRailPreview'
+
+// The card's pointer, wheel and selection behaviour is driven end-to-end through the real rail in
+// ChatScrollRail.test.tsx, because all of it is a conversation between the card and the rail's dot
+// handlers. What is left here is the card's own reporting contract, which is easier to observe
+// with the callbacks in hand than through the component that owns them.
+
+function dot(seq: bigint, count = 1): DotCluster {
+  return { seq, topPx: 100, type: MarkType.USER_MESSAGE, count }
+}
+
+function cardProps(overrides: Partial<Parameters<typeof DotPreviewCard>[0]> = {}) {
+  return {
+    topPx: 100,
+    dot: dot(2n),
+    previewFor: () => 'a preview',
+    onHoldStart: vi.fn(),
+    onHoldEnd: vi.fn(),
+    onPressChange: vi.fn(),
+    onHeightChange: vi.fn(),
+    ...overrides,
+  }
+}
+
+describe('dotPreviewCard height reporting', () => {
+  it('reports its height as soon as it mounts, before any resize', () => {
+    // The rail clamps the card's Y against this. Without the report the clamp has nothing to work
+    // with for the card's whole life, because jsdom fires no resize and a card that never changes
+    // size never would either -- so the mount-time report is not an optimisation, it is the only
+    // measurement a short-lived card ever makes.
+    const onHeightChange = vi.fn()
+    render(() => <DotPreviewCard {...cardProps({ onHeightChange })} />)
+    expect(onHeightChange).toHaveBeenCalledTimes(1)
+    // jsdom does no layout, so the value is 0 here; that it ARRIVES is what this pins. The clamp
+    // arithmetic itself is unit-tested against injected heights in chatDotPreview.test.ts.
+    expect(onHeightChange).toHaveBeenCalledWith(0)
+  })
+
+  it('retracts its height when it unmounts, so the next card is not clamped against it', () => {
+    const onHeightChange = vi.fn()
+    const { unmount } = render(() => <DotPreviewCard {...cardProps({ onHeightChange })} />)
+    onHeightChange.mockClear()
+
+    unmount()
+
+    // A height left behind belongs to a card that no longer exists. The next card would be
+    // clamped against it on its very first frame -- placed for a tall card while it renders a
+    // one-line preview, or the reverse.
+    expect(onHeightChange).toHaveBeenCalledWith(0)
+  })
+})
+
+describe('dotPreviewCard rendering', () => {
+  it('renders the preview for the dot it was handed, resolved by that dot\'s seq', () => {
+    // The card takes `(seq) => text` and the whole cluster, rather than a thunk closed over one
+    // dot: it must ask for ITS dot's preview, not for whichever dot the closure captured.
+    const previewFor = vi.fn((seq: bigint) => (seq === 7n ? 'the seventh message' : 'the wrong one'))
+    const { getByTestId } = render(() => <DotPreviewCard {...cardProps({ dot: dot(7n), previewFor })} />)
+    expect(previewFor).toHaveBeenCalledWith(7n)
+    expect(getByTestId('chat-scroll-rail-preview')).toHaveTextContent('the seventh message')
+  })
+
+  it('shows a loading line while the preview is still resolving, and the mark label when it resolves empty', () => {
+    // Three states, and `''` is the one a falsy check gets wrong: it means "resolved, and this
+    // mark has no previewable text", which must show the label rather than the loading line.
+    const { getByTestId, unmount } = render(() => (
+      <DotPreviewCard {...cardProps({ previewFor: () => undefined })} />
+    ))
+    expect(getByTestId('chat-scroll-rail-preview')).toHaveTextContent('Loading preview')
+    unmount()
+
+    const resolved = render(() => <DotPreviewCard {...cardProps({ previewFor: () => '' })} />)
+    expect(resolved.getByTestId('chat-scroll-rail-preview')).toHaveTextContent('Your message')
+    expect(resolved.getByTestId('chat-scroll-rail-preview')).not.toHaveTextContent('Loading preview')
+  })
+
+  it('heads a CLUSTER card with its member count, and a single-mark card with none', () => {
+    const cluster = render(() => <DotPreviewCard {...cardProps({ dot: dot(2n, 4) })} />)
+    expect(cluster.getByTestId('chat-scroll-rail-preview')).toHaveTextContent('4 messages')
+    cluster.unmount()
+
+    const single = render(() => <DotPreviewCard {...cardProps({ dot: dot(2n, 1) })} />)
+    expect(single.getByTestId('chat-scroll-rail-preview')).not.toHaveTextContent('messages')
+  })
+})

--- a/frontend/src/components/chat/ChatScrollRailPreview.tsx
+++ b/frontend/src/components/chat/ChatScrollRailPreview.tsx
@@ -1,57 +1,308 @@
 import type { DotCluster } from './chatRailPolicy'
-import { Show } from 'solid-js'
+import { createEffect, createMemo, on, onCleanup, onMount, Show } from 'solid-js'
 import { MarkType } from '~/generated/leapmux/v1/agent_pb'
+import { createRafResizeObserver } from '~/lib/resizeObserver'
+import { hasScrollRoom } from './chatScrollGeometry'
 import * as styles from './ChatScrollRail.css'
 import { MarkdownText } from './messageRenderers'
 
 // ---------------------------------------------------------------------------
 // Scroll-rail dot preview presentation
 //
-// The tooltip/label surface for a rail jump dot, split from ChatScrollRail so the component
-// is left to own geometry + interaction. Pure presentation: the "which dot is active" and
-// "warm its preview" wiring stays in the rail.
+// The preview-card surface for a rail jump dot, split from ChatScrollRail so the component
+// is left to own geometry + interaction. The card owns its own pointer and wheel traffic (it
+// renders INSIDE the rail, so untouched traffic reaches the rail's handlers) and reports when
+// the reader holds it; the "which dot is active", "how long a released card stays open", and
+// "warm its preview" decisions stay in createDotPreview.
 // ---------------------------------------------------------------------------
 
-/** Fallback tooltip label for a mark whose content has no previewable text. */
+/** Fallback label for a mark whose content has no previewable text. */
 function markLabel(type: number): string {
   return type === MarkType.CONTROL_RESPONSE ? 'Your response' : 'Your message'
 }
 
-/** "N messages" wording shared by a cluster dot's aria-label and its tooltip header. */
+/** "N messages" wording shared by a cluster dot's aria-label and its card header. */
 function clusterCountLabel(count: number): string {
   return `${count} messages`
 }
 
-/** Accessible label / tooltip fallback for a dot: a count for a cluster, else the mark type. */
+/** Accessible label / card fallback for a dot: a count for a cluster, else the mark type. */
 export function dotLabel(cluster: DotCluster): string {
   return cluster.count > 1 ? clusterCountLabel(cluster.count) : markLabel(cluster.type)
 }
 
 /**
- * Tooltip body for a jump dot: an aggregate "N messages" header when the dot is a cluster,
- * then the representative's preview -- rendered markdown (the marked message's content is
- * markdown), a mark-type label when there's no previewable text, or a loading line while the
- * fetch is in flight. Reads `previewFor` reactively so a slow fetch that lands after the
- * tooltip opens still fills it in. The preview string is already length-bounded upstream
- * (truncatePreview), so rendered markdown stays small.
+ * The id a focused dot's `aria-describedby` points at, so the card its focus opened becomes that
+ * dot's description. Without it a screen-reader user tabbing the rail hears only "Your message"
+ * while a sighted reader gets the preview -- and this rail gave focus its own open channel, so the
+ * card is a surface the keyboard reaches by design.
+ *
+ * ONE constant rather than createUniqueId: the rail renders at most one card at a time (a single
+ * <Show>), so a per-instance id would buy nothing and would have to be lifted into the rail to be
+ * handed back to the dots. A dot whose card is not open points at nothing, which is valid and
+ * resolves to no description.
  */
-export function DotPreview(props: { previewFor: () => string | undefined, markType: number, count: number }) {
-  const preview = () => props.previewFor()
+export const DOT_PREVIEW_CARD_ID = 'chat-scroll-rail-preview-card'
+
+export interface DotPreviewCardProps {
+  /** The card's rail-Y, already clamped by the rail so a near-edge card is not clipped. */
+  topPx: number
+  /**
+   * The dot the card describes. Passed WHOLE rather than re-flattened into a mark type and a
+   * count, so the card cannot be handed a type and a count that belong to different dots, and so
+   * `type` keeps its MarkType enum instead of widening to a bare number at this boundary.
+   */
+  dot: DotCluster
+  /**
+   * Reactive read of a mark's preview text: undefined = still resolving, '' = resolved with no
+   * previewable text (show the mark-type label), else the snippet. The SAME `(seq) => text` shape
+   * the rail takes from its own host, rather than a thunk that closes over one dot.
+   */
+  previewFor: (seq: bigint) => string | undefined
+  /** The reader holds the card: the pointer arrived on it, or pressed inside it. */
+  onHoldStart: () => void
+  /**
+   * Nothing holds the card anymore: the pointer left it, no press is down inside it, and it holds
+   * no selection.
+   */
+  onHoldEnd: () => void
+  /**
+   * A press inside the card went down (true) or ended (false). While it is down the card owns the
+   * pointer outright: the rail must not let a dot that the selection drag crosses re-target the
+   * card, because re-rendering the body under a live selection collapses it.
+   */
+  onPressChange: (down: boolean) => void
+  /**
+   * The card's rendered height (px), reported on mount and whenever it changes. The rail clamps
+   * the card's Y against this, so it must be the real height and not the max-height cap -- and it
+   * must keep coming, because the preview arrives after a fetch and the markdown reflows when it
+   * lands.
+   */
+  onHeightChange: (px: number) => void
+}
+
+/**
+ * The preview card for the active jump dot: an aggregate "N messages" header when the dot is a
+ * cluster, then the representative's preview -- rendered markdown (the marked message's content
+ * is markdown), a mark-type label when there's no previewable text, or a loading line while the
+ * fetch is in flight. Reads `previewFor` reactively so a slow fetch that lands after the card
+ * opens still fills it in. The preview string is already length-bounded upstream
+ * (truncatePreview), so rendered markdown stays small.
+ *
+ * The card is a PLACE the reader goes, not only a label: its text is selectable, and it scrolls
+ * when the preview is taller than the card. That is what the hold callbacks are for. The card
+ * reports "the reader holds me" and "nothing holds me anymore", and createDotPreview turns the
+ * second one into a DELAYED close (see POINTER_CLOSE_DELAY_MS), which is what gives the reader
+ * time to cross the gutter between the dot and the card.
+ *
+ * Three separate things hold it, and it reports the end only when all three let go. The HOVER is
+ * the obvious one. The PRESS matters as much: selecting to the end of a line commonly drags the
+ * pointer past the card's edge, and the pointerleave that fires there would otherwise close the
+ * card and destroy the selection with it. The SELECTION outlives both: the release that ends a
+ * drag-out selection regularly lands outside the card, so a card that closed on it would take the
+ * reader's finished selection with it, a delay later, before they could copy it.
+ */
+export function DotPreviewCard(props: DotPreviewCardProps) {
+  const preview = () => props.previewFor(props.dot.seq)
+
+  let cardEl: HTMLDivElement | undefined
+
+  // The three holds on the card, all of which must let go before it reports a hold end: the
+  // pointer is over it, a press inside it is still down, and the reader's SELECTION is still
+  // inside it. Plain locals rather than signals -- nothing renders from them.
+  let hovered = false
+  let pressPointerId: number | undefined
+  let pressEnd: ((event: PointerEvent) => void) | undefined
+  let selectionEnd: (() => void) | undefined
+
+  const dropPressListeners = () => {
+    if (pressEnd === undefined)
+      return
+    window.removeEventListener('pointerup', pressEnd)
+    window.removeEventListener('pointercancel', pressEnd)
+    pressEnd = undefined
+    pressPointerId = undefined
+    props.onPressChange(false)
+  }
+
+  const dropSelectionListener = () => {
+    if (selectionEnd === undefined)
+      return
+    document.removeEventListener('selectionchange', selectionEnd)
+    selectionEnd = undefined
+  }
+
+  // A card torn down mid-press (its dot's message was deleted) must not leave its listeners on the
+  // window, and must not leave the rail's dots standing down for a press that can no longer end.
+  // dropPressListeners reports the press end for that reason; nothing reports a HOLD end, because
+  // the card is already gone and there is nothing left to close.
+  onCleanup(() => {
+    dropPressListeners()
+    dropSelectionListener()
+    // The measured height belongs to THIS card. Retract it, or the next card's very first frame is
+    // clamped against a height it does not have. A dot-to-dot swap keeps the same element and
+    // never reaches here, so its observer reports the new height instead.
+    props.onHeightChange(0)
+  })
+
+  /**
+   * True while a non-empty document selection STARTED inside this card.
+   *
+   * The anchor is the test, not the whole range. The case this hold exists for is a drag that
+   * leaves the card -- selecting to the end of a line runs the pointer out past the right edge --
+   * and the browser extends the selection to wherever the pointer went, so its end regularly lands
+   * in the transcript underneath. Requiring both ends inside would fail on exactly the drag it is
+   * meant to protect. The anchor is where the reader began, so it also keeps the card OUT of a
+   * selection that started in the transcript and merely swept across it.
+   */
+  const holdsSelection = (): boolean => {
+    const selection = document.getSelection()
+    if (!cardEl || !selection || selection.isCollapsed)
+      return false
+    return cardEl.contains(selection.anchorNode)
+  }
+
+  const releaseIfFree = () => {
+    if (hovered || pressEnd !== undefined || selectionEnd !== undefined)
+      return
+    props.onHoldEnd()
+  }
+
+  /**
+   * Take the SELECTION hold if the reader left a selection behind in the card.
+   *
+   * The press hold alone is not enough. Selecting to the end of a line drags the pointer past the
+   * card's edge, so the release regularly lands outside, and closing on that release destroys the
+   * selection with the text nodes it points at -- before the reader can reach a keyboard and copy
+   * it. Hold the card for exactly as long as the selection lives instead of for a fixed delay, and
+   * let the `selectionchange` that collapses it (the reader's next click anywhere) release it.
+   */
+  const holdSelectionIfAny = () => {
+    if (selectionEnd !== undefined || !holdsSelection())
+      return
+    const end = () => {
+      if (holdsSelection())
+        return
+      dropSelectionListener()
+      releaseIfFree()
+    }
+    selectionEnd = end
+    document.addEventListener('selectionchange', end)
+  }
+
+  const onPointerDown = (event: PointerEvent) => {
+    // The card renders inside the rail, so without this a press to select text bubbles to the
+    // rail's own pointerdown and starts a thumb drag from the card's Y. preventDefault is
+    // deliberately NOT called: that default action IS the text selection the card exists to allow.
+    event.stopPropagation()
+    // Only the primary button opens a press hold, for the reason beginRailPress states for the
+    // rail itself: a context menu can swallow the pointerup of a secondary press, and a hold that
+    // never ends would pin the card open (and the whole rail lit) with no way back.
+    if (event.button !== 0 || pressEnd !== undefined)
+      return
+    // The press is held on the WINDOW, not on the card: the pointerup that ends a selection drag
+    // regularly lands outside the card, and a listener on the card would never see it. It is
+    // keyed to THIS pointer, so a second pointer's release (a pen tap while a mouse selects, on
+    // the hybrid devices where the card stays interactive) cannot end a press it never started.
+    const end = (ended: PointerEvent) => {
+      if (ended.pointerId !== pressPointerId)
+        return
+      dropPressListeners()
+      holdSelectionIfAny()
+      releaseIfFree()
+    }
+    pressPointerId = event.pointerId
+    pressEnd = end
+    window.addEventListener('pointerup', end)
+    window.addEventListener('pointercancel', end)
+    props.onPressChange(true)
+    // A card that opened under a stationary cursor fires no pointerenter, so a press can be the
+    // FIRST evidence that the reader is on the card. Report the hold, or the card closes under a
+    // selection drag that started without one.
+    hovered = true
+    props.onHoldStart()
+  }
+
+  /**
+   * A wheel over the card. The card renders inside the rail, so the wheel would otherwise reach
+   * the rail's forwarder and scroll the TRANSCRIPT out from under the card the reader is reading.
+   * Keep the delta here while the card still has room to scroll that way, and let it through when
+   * it does not -- a card whose preview fits is not a scroller, and swallowing the wheel there
+   * would make it the dead zone that the rail's forwarder exists to remove.
+   *
+   * A wheel with NO vertical component is let through for the same reason, but the rail's
+   * forwarder cannot serve it: that forwarder applies deltaY only, and it calls preventDefault, so
+   * a sideways wheel reaching it moves nothing AND loses the browser's own horizontal scroll of
+   * whatever lies under the card. Stop it here instead of handing it on to be swallowed.
+   */
+  const onWheel = (event: WheelEvent & { currentTarget: HTMLDivElement }) => {
+    if (event.deltaY === 0 || hasScrollRoom(event.currentTarget, event.deltaY))
+      event.stopPropagation()
+  }
+
+  // The card element OUTLIVES the dot it describes: <Show> is not keyed, so moving from one dot to
+  // the next swaps the props and leaves the same scroller in place. Send it back to the top, or a
+  // reader who scrolled deep into one preview opens the next one already scrolled past its header
+  // and its first line.
+  //
+  // Keyed on the seq through a MEMO, not on `props.dot` and not on a bare `() => props.dot.seq`.
+  // `on` re-runs whenever its source notifies, whatever the value, and a streaming turn hands over
+  // a fresh cluster object for the SAME seq on every persisted row (see chatDotPreview.reanchor) --
+  // so either of those would reset the scroll under a reader who is mid-read, several times a
+  // second. The memo notifies only when the seq itself changes, which is the one moment the card
+  // starts describing a different message.
+  const shownSeq = createMemo(() => props.dot.seq)
+  createEffect(on(shownSeq, () => {
+    if (cardEl)
+      cardEl.scrollTop = 0
+  }, { defer: true }))
+
+  // Report the card's real height so the rail can centre it on its dot without clipping. An
+  // observer rather than a one-shot measure: the preview arrives from a fetch after the card
+  // opens, and the markdown reflows the card when it lands. The rAF-batched wrapper is the house
+  // one -- a raw ResizeObserver callback that drives a reactive write can resize another observed
+  // element inside the same delivery, which is the "undelivered notifications" loop.
+  onMount(() => {
+    const el = cardEl
+    if (!el)
+      return
+    props.onHeightChange(el.offsetHeight)
+    const observer = createRafResizeObserver(() => props.onHeightChange(el.offsetHeight))
+    observer?.observe(el)
+    onCleanup(() => observer?.disconnect())
+  })
+
   return (
-    <>
-      <Show when={props.count > 1}>
-        <div class={styles.dotPreviewCount}>{clusterCountLabel(props.count)}</div>
+    <div
+      ref={cardEl}
+      id={DOT_PREVIEW_CARD_ID}
+      class={styles.previewCard}
+      data-testid="chat-scroll-rail-preview"
+      style={{ top: `${props.topPx}px` }}
+      onPointerEnter={() => {
+        hovered = true
+        props.onHoldStart()
+      }}
+      onPointerLeave={() => {
+        hovered = false
+        releaseIfFree()
+      }}
+      onPointerDown={onPointerDown}
+      onWheel={onWheel}
+    >
+      <Show when={props.dot.count > 1}>
+        <div class={styles.dotPreviewCount}>{clusterCountLabel(props.dot.count)}</div>
       </Show>
       <Show
         when={preview() !== undefined}
         fallback={<span class={styles.dotPreviewLoading}>Loading preview…</span>}
       >
-        <Show when={preview()} fallback={<span>{markLabel(props.markType)}</span>}>
+        <Show when={preview()} fallback={<span>{markLabel(props.dot.type)}</span>}>
           <div class={styles.dotPreviewMarkdown}>
             <MarkdownText text={preview()!} />
           </div>
         </Show>
       </Show>
-    </>
+    </div>
   )
 }

--- a/frontend/src/components/chat/ChatView.tsx
+++ b/frontend/src/components/chat/ChatView.tsx
@@ -817,7 +817,7 @@ export const ChatView: Component<ChatViewProps> = (props) => {
     onLoadNewerMessages: () => props.pagination?.onLoadNewerMessages?.(),
     onJumpToLatest: () => props.pagination?.onJumpToLatest?.(),
     onJumpToOldest: () => props.pagination?.onJumpToOldest?.(),
-    onJumpToSeq: seq => props.pagination?.onJumpToSeq?.(seq),
+    onJumpToSeq: (seq, signal) => props.pagination?.onJumpToSeq?.(seq, signal),
     virtualizer: virt,
     savedViewportScroll: () => props.savedViewportScroll,
     onClearSavedViewportScroll: () => props.onClearSavedViewportScroll?.(),

--- a/frontend/src/components/chat/chatDotPreview.test.ts
+++ b/frontend/src/components/chat/chatDotPreview.test.ts
@@ -1,88 +1,180 @@
 import type { DotCluster } from './chatRailPolicy'
 import { createRoot, createSignal } from 'solid-js'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { MarkType } from '~/generated/leapmux/v1/agent_pb'
-import { createDotPreview } from './chatDotPreview'
-import * as styles from './ChatScrollRail.css'
+import { createDotPreview, POINTER_CLOSE_DELAY_MS } from './chatDotPreview'
 
 // Flush queued Solid effects (the stale-hover re-anchor effect is not a pull-based memo).
 const tick = () => new Promise<void>(resolve => setTimeout(resolve, 0))
 
-// activeDot / popoverTopPx are memos (pull-based), so these read synchronously after a signal
+// activeDot / cardTopPx are memos (pull-based), so these read synchronously after a signal
 // write -- no effect flush needed. The scrub-warm DEBOUNCE effect (instant-hover vs settled-scrub
 // timing) is exercised end-to-end by ChatScrollRail.test.tsx; here we pin the pure reactive
-// selection + placement the component delegates to this unit.
+// selection + placement the component delegates to this unit, plus the open/close policy (which
+// needs fake timers for the close delay).
+
+afterEach(() => {
+  vi.useRealTimers()
+})
 
 function dot(seq: bigint, topPx: number, count = 1): DotCluster {
   return { seq, topPx, type: MarkType.USER_MESSAGE, count }
 }
 
-describe('createdotpreview', () => {
+describe('createDotPreview', () => {
   it('activeDot is the hovered dot when not dragging', () =>
     createRoot((dispose) => {
       const [dots] = createSignal<DotCluster[]>([dot(5n, 100)])
       const [drag] = createSignal<number | null>(null)
       const [railHeight] = createSignal(200)
       const [thumbHeightPx] = createSignal(24)
-      const p = createDotPreview({ dots, drag, railHeight, thumbHeightPx })
+      const [cardHeightPx] = createSignal(0)
+      const p = createDotPreview({ dots, drag, railHeight, thumbHeightPx, cardHeightPx })
       expect(p.activeDot()).toBeNull()
-      p.setHoverDot(dot(5n, 100))
+      p.openDot(dot(5n, 100))
       expect(p.activeDot()?.seq).toBe(5n)
       dispose()
     }))
 
-  it('a scrub target takes precedence over a hovered dot (one popover, never two)', () =>
+  it('a scrub target takes precedence over a hovered dot (one card, never two)', () =>
     createRoot((dispose) => {
       // centerAxisY(0.5, 200, 24) = 12 + 0.5*176 = 100, so the dot at topPx 100 is under the thumb
-      // centre while dragging; hovering a DIFFERENT dot must not open a rival popover.
+      // centre while dragging; hovering a DIFFERENT dot must not open a rival card.
       const [dots] = createSignal<DotCluster[]>([dot(5n, 100), dot(9n, 20)])
       const [drag] = createSignal<number | null>(0.5)
       const [railHeight] = createSignal(200)
       const [thumbHeightPx] = createSignal(24)
-      const p = createDotPreview({ dots, drag, railHeight, thumbHeightPx })
-      p.setHoverDot(dot(9n, 20))
+      const [cardHeightPx] = createSignal(0)
+      const p = createDotPreview({ dots, drag, railHeight, thumbHeightPx, cardHeightPx })
+      p.openDot(dot(9n, 20))
       expect(p.activeDot()?.seq).toBe(5n) // the scrub target wins over the hover
       dispose()
     }))
 
-  it('activeDot falls back to the hovered dot when the scrub is between dots', () =>
+  it('a scrub that abandons the pressed dot shows no card while the thumb is between dots', () =>
     createRoot((dispose) => {
       const [dots] = createSignal<DotCluster[]>([dot(9n, 20)]) // topPx 20 is far from the thumb centre (100)
       const [drag] = createSignal<number | null>(0.5)
       const [railHeight] = createSignal(200)
       const [thumbHeightPx] = createSignal(24)
-      const p = createDotPreview({ dots, drag, railHeight, thumbHeightPx })
-      p.setHoverDot(dot(9n, 20))
-      expect(p.activeDot()?.seq).toBe(9n) // no dot within scrub range -> the hover shows
+      const [cardHeightPx] = createSignal(0)
+      const p = createDotPreview({ dots, drag, railHeight, thumbHeightPx, cardHeightPx })
+      // A mouse press starts ON a dot, so the pointer channel holds that dot for the whole
+      // gesture: the captured drag fires no pointerleave to release it. The rail ABANDONS the
+      // channel when the grab becomes a scrub, which is what stops the card pointing at a dot the
+      // reader scrubbed away from.
+      p.openDot(dot(9n, 20))
+      p.abandonDot()
+      expect(p.activeDot()).toBeNull()
       dispose()
     }))
 
-  it('popoverTopPx clamps a top/bottom dot inside the rail so the card is not clipped', () =>
+  it('leaves an abandoned pointer channel closed when the drag ends, rather than springing back', () =>
+    createRoot((dispose) => {
+      const [dots] = createSignal<DotCluster[]>([dot(9n, 20)])
+      const [drag, setDrag] = createSignal<number | null>(0.5)
+      const [railHeight] = createSignal(200)
+      const [thumbHeightPx] = createSignal(24)
+      const [cardHeightPx] = createSignal(0)
+      const p = createDotPreview({ dots, drag, railHeight, thumbHeightPx, cardHeightPx })
+      p.openDot(dot(9n, 20))
+      p.abandonDot() // the grab became a scrub
+      setDrag(null) // ...and the drag ended between dots
+      // The pressed dot must NOT come back. A mask that only hid it would hand it straight back
+      // here, pointing at a dot the reader scrubbed away from.
+      expect(p.activeDot()).toBeNull()
+      dispose()
+    }))
+
+  it('shows a dot the pointer reaches DURING the post-release hold, which drag() keeps open', () =>
+    createRoot((dispose) => {
+      const [dots] = createSignal<DotCluster[]>([dot(9n, 20)])
+      // A release lands between dots and the hold pins the thumb there while an out-of-window
+      // seek fetches -- drag() stays non-null for all of it, with the pointer already up.
+      const [drag] = createSignal<number | null>(0.5)
+      const [railHeight] = createSignal(200)
+      const [thumbHeightPx] = createSignal(24)
+      const [cardHeightPx] = createSignal(0)
+      const p = createDotPreview({ dots, drag, railHeight, thumbHeightPx, cardHeightPx })
+      p.openDot(dot(9n, 20)) // the reader hovers a dot while the fetch is still in flight
+      // Masking the hover channel for as long as drag() is non-null would show nothing at all
+      // here, for as long as the fetch took.
+      expect(p.activeDot()?.seq).toBe(9n)
+      dispose()
+    }))
+
+  it('cardTopPx clamps a top/bottom dot inside the rail so the card is not clipped', () =>
     createRoot((dispose) => {
       const [dots] = createSignal<DotCluster[]>([dot(1n, 0), dot(2n, 200)])
       const [drag] = createSignal<number | null>(null)
       const [railHeight] = createSignal(200)
       const [thumbHeightPx] = createSignal(24)
-      const p = createDotPreview({ dots, drag, railHeight, thumbHeightPx })
-      const half = Math.min(styles.PREVIEW_POPOVER_MAX_H_PX / 2, 200 / 2)
-      p.setHoverDot(dot(1n, 0)) // a dot at the very top
-      expect(p.popoverTopPx()).toBe(half)
-      p.setHoverDot(dot(2n, 200)) // a dot at the very bottom
-      expect(p.popoverTopPx()).toBe(200 - half)
+      const [cardHeightPx] = createSignal(120)
+      const p = createDotPreview({ dots, drag, railHeight, thumbHeightPx, cardHeightPx })
+      p.openDot(dot(1n, 0)) // a dot at the very top
+      expect(p.cardTopPx()).toBe(60) // pushed down by its own half-height, not past the wrapper
+      p.openDot(dot(2n, 200)) // a dot at the very bottom
+      expect(p.cardTopPx()).toBe(140)
       dispose()
     }))
 
-  it('re-anchors the hovered popover to the same-seq dot when a streaming turn shifts its topPx', async () => {
+  it('cardTopPx clamps on the card\'s MEASURED height, not on the max-height cap', () =>
+    createRoot((dispose) => {
+      const [dots] = createSignal<DotCluster[]>([dot(1n, 8)])
+      const [drag] = createSignal<number | null>(null)
+      const [railHeight] = createSignal(600)
+      const [thumbHeightPx] = createSignal(24)
+      const [cardHeightPx] = createSignal(40) // a one-line preview, far short of the 200px cap
+      const p = createDotPreview({ dots, drag, railHeight, thumbHeightPx, cardHeightPx })
+      p.openDot(dot(1n, 8))
+      // Clamping against half the CAP would put this card at y=100 -- 92px from the 8px dot it
+      // describes, pointing at nothing. Its own half-height is the real floor.
+      expect(p.cardTopPx()).toBe(20)
+      dispose()
+    }))
+
+  it('cardTopPx still points at its dot on a rail shorter than the card cap', () =>
+    createRoot((dispose) => {
+      const [dots] = createSignal<DotCluster[]>([dot(1n, 40), dot(2n, 120)])
+      const [drag] = createSignal<number | null>(null)
+      const [railHeight] = createSignal(160) // shorter than 2 * the 200px cap
+      const [thumbHeightPx] = createSignal(24)
+      const [cardHeightPx] = createSignal(40)
+      const p = createDotPreview({ dots, drag, railHeight, thumbHeightPx, cardHeightPx })
+      // Against the cap the clamp interval collapsed to the single point rh/2, so EVERY dot's
+      // card sat at the rail midpoint -- the short-viewport case the e2e run exercises.
+      p.openDot(dot(1n, 40))
+      expect(p.cardTopPx()).toBe(40)
+      p.openDot(dot(2n, 120))
+      expect(p.cardTopPx()).toBe(120)
+      dispose()
+    }))
+
+  it('puts an unmeasured card exactly on its dot, rather than at a guessed offset', () =>
+    createRoot((dispose) => {
+      const [dots] = createSignal<DotCluster[]>([dot(1n, 8)])
+      const [drag] = createSignal<number | null>(null)
+      const [railHeight] = createSignal(600)
+      const [thumbHeightPx] = createSignal(24)
+      const [cardHeightPx] = createSignal(0) // the frame before the card reports its size
+      const p = createDotPreview({ dots, drag, railHeight, thumbHeightPx, cardHeightPx })
+      p.openDot(dot(1n, 8))
+      expect(p.cardTopPx()).toBe(8)
+      dispose()
+    }))
+
+  it('re-anchors the hovered card to the same-seq dot when a streaming turn shifts its topPx', async () => {
     await createRoot(async (dispose) => {
       const [dots, setDots] = createSignal<DotCluster[]>([dot(5n, 100)])
       const [drag] = createSignal<number | null>(null)
       const [railHeight] = createSignal(200)
       const [thumbHeightPx] = createSignal(24)
-      const p = createDotPreview({ dots, drag, railHeight, thumbHeightPx })
-      p.setHoverDot(dot(5n, 100))
+      const [cardHeightPx] = createSignal(0)
+      const p = createDotPreview({ dots, drag, railHeight, thumbHeightPx, cardHeightPx })
+      p.openDot(dot(5n, 100))
       expect(p.activeDot()?.seq).toBe(5n)
       // maxSeq ticks during a streaming turn: the SAME seq's cluster re-rounds to a new topPx and
-      // <For> hands over a fresh (unequal) object. The popover must FOLLOW the dot, not vanish.
+      // <For> hands over a fresh (unequal) object. The card must FOLLOW the dot, not vanish.
       setDots([dot(5n, 101)])
       await tick()
       expect(p.activeDot()?.seq).toBe(5n)
@@ -91,21 +183,210 @@ describe('createdotpreview', () => {
     })
   })
 
-  it('clears the hovered popover only when its seq is truly gone from the rail', async () => {
+  it('clears the hovered card only when its seq is truly gone from the rail', async () => {
     await createRoot(async (dispose) => {
       const [dots, setDots] = createSignal<DotCluster[]>([dot(5n, 100)])
       const [drag] = createSignal<number | null>(null)
       const [railHeight] = createSignal(200)
       const [thumbHeightPx] = createSignal(24)
-      const p = createDotPreview({ dots, drag, railHeight, thumbHeightPx })
-      p.setHoverDot(dot(5n, 100))
+      const [cardHeightPx] = createSignal(0)
+      const p = createDotPreview({ dots, drag, railHeight, thumbHeightPx, cardHeightPx })
+      p.openDot(dot(5n, 100))
       expect(p.activeDot()?.seq).toBe(5n)
       // The hovered mark's message was deleted/reseq'd -- no dot carries seq 5 anymore, so the
-      // popover clears rather than pointing at a stale cluster.
+      // card clears rather than pointing at a stale cluster.
       setDots([dot(9n, 100)])
       await tick()
       expect(p.activeDot()).toBeNull()
       dispose()
+    })
+  })
+
+  it('re-anchors a FOCUSED dot too, so a keyboard reader keeps the card a streaming turn moved', async () => {
+    await createRoot(async (dispose) => {
+      const [dots, setDots] = createSignal<DotCluster[]>([dot(5n, 100)])
+      const [drag] = createSignal<number | null>(null)
+      const [railHeight] = createSignal(200)
+      const [thumbHeightPx] = createSignal(24)
+      const [cardHeightPx] = createSignal(0)
+      const p = createDotPreview({ dots, drag, railHeight, thumbHeightPx, cardHeightPx })
+      // The focus channel is a second holder of a cluster reference, so it needs the same
+      // re-anchor the pointer channel gets -- otherwise a streaming tick strands a focused dot's
+      // card on a torn-down cluster and it vanishes with no blur to explain it.
+      p.focusDot(dot(5n, 100))
+      setDots([dot(5n, 101)])
+      await tick()
+      expect(p.activeDot()?.topPx).toBe(101)
+
+      // And it still clears when the seq is genuinely gone.
+      setDots([dot(9n, 100)])
+      await tick()
+      expect(p.activeDot()).toBeNull()
+      dispose()
+    })
+  })
+
+  it('a re-anchor during a streaming turn does not extend a card the pointer already left', async () => {
+    vi.useFakeTimers()
+    await createRoot(async (dispose) => {
+      const [dots, setDots] = createSignal<DotCluster[]>([dot(5n, 100)])
+      const [drag] = createSignal<number | null>(null)
+      const [railHeight] = createSignal(200)
+      const [thumbHeightPx] = createSignal(24)
+      const [cardHeightPx] = createSignal(0)
+      const p = createDotPreview({ dots, drag, railHeight, thumbHeightPx, cardHeightPx })
+      p.openDot(dot(5n, 100))
+      p.closeSoon()
+      // A streaming turn re-rounds the same seq's topPx while the close is pending. The re-anchor
+      // must follow the dot WITHOUT touching the timer -- otherwise a streaming conversation
+      // cancels the close on every tick and pins the card open for good.
+      setDots([dot(5n, 101)])
+      await vi.advanceTimersByTimeAsync(POINTER_CLOSE_DELAY_MS - 50)
+      expect(p.activeDot()?.topPx).toBe(101) // the re-anchor really ran within the close window
+      await vi.advanceTimersByTimeAsync(50)
+      expect(p.activeDot()).toBeNull() // and it left the pending close alone
+      dispose()
+    })
+  })
+})
+
+describe('createDotPreview open/close policy', () => {
+  /** A controller over one dot at topPx 100, with no drag in progress. */
+  function oneDot() {
+    const [dots] = createSignal<DotCluster[]>([dot(5n, 100), dot(9n, 20)])
+    const [drag] = createSignal<number | null>(null)
+    const [railHeight] = createSignal(200)
+    const [thumbHeightPx] = createSignal(24)
+    const [cardHeightPx] = createSignal(0)
+    return createDotPreview({ dots, drag, railHeight, thumbHeightPx, cardHeightPx })
+  }
+
+  it('holds the card open for the close delay after the pointer leaves, then closes it', () => {
+    vi.useFakeTimers()
+    createRoot((dispose) => {
+      const p = oneDot()
+      p.openDot(dot(5n, 100))
+      p.closeSoon()
+      // The whole point of the delay: the card outlives the pointer leaving the dot, so the
+      // reader can cross the gutter and land on it.
+      vi.advanceTimersByTime(POINTER_CLOSE_DELAY_MS - 1)
+      expect(p.activeDot()?.seq).toBe(5n)
+      vi.advanceTimersByTime(1)
+      expect(p.activeDot()).toBeNull()
+      dispose()
+    })
+  })
+
+  it('cancels a pending close when the pointer comes back (onto the dot or onto the card)', () => {
+    vi.useFakeTimers()
+    createRoot((dispose) => {
+      const p = oneDot()
+      p.openDot(dot(5n, 100))
+      p.closeSoon()
+      vi.advanceTimersByTime(POINTER_CLOSE_DELAY_MS - 1)
+      p.openDot(dot(5n, 100)) // the card re-declares its own dot when the pointer reaches it
+      vi.advanceTimersByTime(POINTER_CLOSE_DELAY_MS * 10) // the superseded timer never fires
+      expect(p.activeDot()?.seq).toBe(5n)
+      dispose()
+    })
+  })
+
+  it('replaces the card at once when another dot opens during the close delay', () => {
+    vi.useFakeTimers()
+    createRoot((dispose) => {
+      const p = oneDot()
+      p.openDot(dot(5n, 100))
+      p.closeSoon()
+      p.openDot(dot(9n, 20)) // the pointer reached a second dot -- no wait, and no stale card
+      expect(p.activeDot()?.seq).toBe(9n)
+      // The first dot's pending close must not take the second dot's card down with it.
+      vi.advanceTimersByTime(POINTER_CLOSE_DELAY_MS * 10)
+      expect(p.activeDot()?.seq).toBe(9n)
+      dispose()
+    })
+  })
+
+  it('closeNow closes with no delay, and drops a pending close', () => {
+    vi.useFakeTimers()
+    createRoot((dispose) => {
+      const p = oneDot()
+      p.openDot(dot(5n, 100))
+      p.closeSoon()
+      p.closeNow()
+      expect(p.activeDot()).toBeNull()
+      expect(vi.getTimerCount()).toBe(0)
+      dispose()
+    })
+  })
+
+  it('keeps a FOCUSED dot open when the pointer channel closes, and drops it on blur', () => {
+    vi.useFakeTimers()
+    createRoot((dispose) => {
+      const p = oneDot()
+      p.focusDot(dot(5n, 100))
+      p.openDot(dot(5n, 100)) // the pointer visits the card the focus opened
+      p.closeSoon() // ...and leaves it again
+      vi.advanceTimersByTime(POINTER_CLOSE_DELAY_MS * 10)
+      expect(p.activeDot()?.seq).toBe(5n) // focus still holds it
+      p.blurDot()
+      expect(p.activeDot()).toBeNull() // and lets go at once, with no delay to wait out
+      dispose()
+    })
+  })
+
+  it('lets the pointer show a different dot than the focused one', () => {
+    createRoot((dispose) => {
+      const p = oneDot()
+      p.focusDot(dot(9n, 20))
+      p.openDot(dot(5n, 100))
+      // The pointer is the input the reader is steering, so it wins while it holds a dot.
+      expect(p.activeDot()?.seq).toBe(5n)
+      p.closeNow()
+      expect(p.activeDot()).toBeNull() // a teardown drops BOTH channels
+      dispose()
+    })
+  })
+
+  it('lets FOCUS take the card from a pointer parked on another dot', () => {
+    createRoot((dispose) => {
+      const p = oneDot()
+      // The cursor rests on dot 5 and never moves, so no pointerleave is coming to release it --
+      // the state a reader is in the moment after they use the rail.
+      p.openDot(dot(5n, 100))
+      p.focusDot(dot(9n, 20))
+      // A channel the pointer could mask would leave dot 5's card under dot 9's focus ring, and
+      // the warm effect fetching dot 5's message, for every dot the reader tabbed to.
+      expect(p.activeDot()?.seq).toBe(9n)
+      dispose()
+    })
+  })
+
+  it('lets FOCUS take the card mid-close, with no delay left to wait out', () => {
+    vi.useFakeTimers()
+    createRoot((dispose) => {
+      const p = oneDot()
+      p.openDot(dot(5n, 100))
+      p.closeSoon() // the pointer left dot 5; its close is pending
+      p.focusDot(dot(9n, 20))
+      // Not "dot 5 for the rest of the delay, then dot 9": reaching a dot by focus replaces the
+      // card at once, exactly as reaching one by hover or by a scrub does.
+      expect(p.activeDot()?.seq).toBe(9n)
+      vi.advanceTimersByTime(POINTER_CLOSE_DELAY_MS * 10)
+      expect(p.activeDot()?.seq).toBe(9n) // and the superseded close cannot take it down
+      dispose()
+    })
+  })
+
+  it('drops a pending close timer when its owner is disposed', () => {
+    vi.useFakeTimers()
+    createRoot((dispose) => {
+      const p = oneDot()
+      p.openDot(dot(5n, 100))
+      p.closeSoon()
+      expect(vi.getTimerCount()).toBe(1)
+      dispose()
+      // A timer surviving the dispose would write a signal of a torn-down rail.
+      expect(vi.getTimerCount()).toBe(0)
     })
   })
 })

--- a/frontend/src/components/chat/chatDotPreview.ts
+++ b/frontend/src/components/chat/chatDotPreview.ts
@@ -1,7 +1,8 @@
-import type { Accessor, Setter } from 'solid-js'
+import type { Accessor } from 'solid-js'
 import type { DotCluster } from './chatRailPolicy'
 import { createEffect, createMemo, createSignal, onCleanup, untrack } from 'solid-js'
 import { clamp } from '~/lib/clamp'
+import { trailingDebounce } from '~/lib/debounce'
 import { dotClusterEqual, nearestDotWithin } from './chatRailPolicy'
 import * as styles from './ChatScrollRail.css'
 import { centerAxisY } from './chatScrollRailGeometry'
@@ -9,18 +10,47 @@ import { centerAxisY } from './chatScrollRailGeometry'
 // ---------------------------------------------------------------------------
 // Scroll-rail dot preview
 //
-// The rail's "which dot the single popover describes + when to warm its preview" state machine:
-// a scrub target (the dot the dragging thumb is over) takes precedence over a hovered/focused
-// dot, the popover is placed on the dot's centre-axis Y (clamped off the rail edges), and the
-// preview is warmed instantly on hover/focus but DEBOUNCED during a scrub -- so dragging across a
-// dense rail doesn't fire a GetAgentMessage per fly-over dot. Extracted from ChatScrollRail (where
-// it was a signal, three memos, an effect, and a debounce timer tangled through the component) so
-// the subtle precedence/debounce/cleanup behaviour is one named, unit-tested unit -- the sibling
-// of createRailMetrics / createDragReleaseHold / createThumbDrag.
+// The rail's "which dot the single card describes + when to open and close it + when to warm its
+// preview" state machine: a scrub target (the dot the dragging thumb is over) takes precedence
+// over a pointer or a keyboard focus, the card is placed on the dot's centre-axis Y (clamped off
+// the rail edges), and the preview is warmed instantly on hover/focus but DEBOUNCED during a
+// scrub -- so dragging across a dense rail doesn't fire a GetAgentMessage per fly-over dot.
+// Opening is always immediate; the POINTER channel closes after a short delay (see
+// POINTER_CLOSE_DELAY_MS), because the card is a place the reader goes rather than only a label.
+// Extracted from ChatScrollRail (where it was a signal, three memos, an effect, and a debounce
+// timer tangled through the component) so the subtle precedence/delay/cleanup behaviour is one
+// named, unit-tested unit -- the sibling of createRailMetrics / createDragReleaseHold /
+// createThumbDrag.
 // ---------------------------------------------------------------------------
 
-/** Rail px within which a dragging thumb counts as "over" a dot, revealing its scrub preview. */
-const SCRUB_PREVIEW_RANGE_PX = 12
+/**
+ * Rail px within which a dragging thumb counts as "over" a dot, revealing its scrub preview.
+ *
+ * Derived from the coarse hit circle, not chosen next to it. A finger presses anywhere inside that
+ * circle and the press centres the thumb on the pressed point, so the card that press must open is
+ * resolved by distance from the dot's rail-Y. A range narrower than the circle's RADIUS would
+ * leave a rim of the dot's own hit area that jumps to the message but shows no preview of it --
+ * the one thing tests/e2e/047c-chat-scroll-rail-scrub.spec.ts exists to protect, and a silent
+ * failure the moment either number moved on its own.
+ */
+const SCRUB_PREVIEW_RANGE_PX = styles.DOT_COARSE_HIT_PX / 2
+
+/**
+ * How long the card stays open after the POINTER lets go of it: it left the dot, it left the
+ * card, or a press inside the card ended. One window, two jobs. It bridges the gutter between the
+ * dot and the card: for that moment the pointer is over neither, so without the delay the card
+ * closes before the reader who aims at it arrives, and its selectable, scrollable text is
+ * unreachable. It is also the tail that lets a reader who overshoots come back without aiming at
+ * a 6px dot again.
+ *
+ * Nothing that OPENS a card waits for it: reaching another dot -- by hover, by focus, or by a
+ * scrub -- replaces the card at once (see openDot, focusDot, and activeDot). Nor does anything
+ * that ABANDONS one: a scrub and a rail teardown both drop the card immediately.
+ *
+ * The FOCUS channel has no delay in either direction. Focus moves in discrete steps, so there is
+ * no gap for the reader to cross and nothing to wait out.
+ */
+export const POINTER_CLOSE_DELAY_MS = 300
 
 /**
  * How long the thumb must settle on a dot mid-scrub before its preview is fetched. A hover/focus
@@ -33,26 +63,60 @@ export const SCRUB_WARM_DEBOUNCE_MS = 120
 export interface DotPreviewDeps {
   /** The rail's current dot clusters (ascending by topPx). */
   dots: Accessor<DotCluster[]>
-  /** The live drag fraction (null when not dragging), so a scrub can take popover precedence. */
+  /** The live drag fraction (null when not dragging), so a scrub can take card precedence. */
   drag: Accessor<number | null>
-  /** The rail's pixel height, for the centre-axis mapping and the popover clamp. */
+  /** The rail's pixel height, for the centre-axis mapping and the card clamp. */
   railHeight: Accessor<number>
   /** The current thumb height (px), for mapping a drag fraction to the thumb-centre rail-Y. */
   thumbHeightPx: Accessor<number>
+  /**
+   * The open card's MEASURED height (px), or 0 before the first measurement.
+   *
+   * The clamp reads this rather than PREVIEW_CARD_MAX_H_PX, because that constant is the CAP and
+   * not the height. A one-line card clamped against half the cap lands up to ~90px from the dot it
+   * points at, and on a rail shorter than twice the cap the clamp interval collapses to a single
+   * point, so EVERY card sits at the rail's midpoint whatever dot it describes.
+   */
+  cardHeightPx: Accessor<number>
   /** Kick off resolving a mark's preview (dot hover/focus or scrub-settle). Deduped upstream. */
   warmPreview?: (seq: bigint) => void
 }
 
-// Named ...Controller (not DotPreview) to avoid clashing with the sibling DotPreview presentation
-// component in ChatScrollRailPreview -- this is the state machine that decides WHICH dot that
-// component renders, not the component itself.
+// Named ...Controller (not DotPreviewCard) to avoid clashing with the sibling DotPreviewCard
+// presentation component in ChatScrollRailPreview -- this is the state machine that decides WHICH
+// dot that component renders, not the component itself.
 export interface DotPreviewController {
-  /** The dot the single preview popover describes: the scrub target while dragging, else hover/focus. */
+  /** The dot the single preview card describes: the scrub target while dragging, else hover/focus. */
   activeDot: Accessor<DotCluster | null>
-  /** The popover's rail-Y, clamped so a dot near the top/bottom doesn't clip past the wrapper. */
-  popoverTopPx: Accessor<number>
-  /** Set/clear the hovered/focused dot (from a dot's pointer/focus handlers and the rail teardown). */
-  setHoverDot: Setter<DotCluster | null>
+  /** The card's rail-Y, clamped so a dot near the top/bottom doesn't clip past the wrapper. */
+  cardTopPx: Accessor<number>
+  /**
+   * The POINTER reached a dot, or reached the open card: show that dot's card NOW, and cancel a
+   * pending close. The card re-declares the dot it shows, so a card that a scrub opened stays
+   * when the scrub ends.
+   */
+  openDot: (dot: DotCluster) => void
+  /** The POINTER left a dot or the card: close after {@link POINTER_CLOSE_DELAY_MS}. */
+  closeSoon: () => void
+  /**
+   * A GESTURE took the pointer over: drop the pointer channel at once, with no delay to wait out.
+   * The rail calls this when a grab becomes a scrub, because the press started ON a dot and the
+   * captured drag fires no pointerleave to release it -- so without this the card springs back to
+   * the pressed dot the moment the drag ends, pointing at a dot the reader scrubbed away from.
+   * Leaves the FOCUS channel alone: a keyboard reader's entitlement to their card survives a
+   * gesture they did not make, and no blur is coming to restore it.
+   */
+  abandonDot: () => void
+  /**
+   * Keyboard focus reached a dot. Focus TAKES the card: it drops whatever the pointer holds,
+   * because the reader steered to this dot and must read THIS dot's message, not the one their
+   * parked cursor still rests on.
+   */
+  focusDot: (dot: DotCluster) => void
+  /** Keyboard focus left the dot. Closes the focus channel at once. */
+  blurDot: () => void
+  /** Close every channel with no delay. For a teardown (the rail hides or unmounts). */
+  closeNow: () => void
 }
 
 /**
@@ -61,9 +125,49 @@ export interface DotPreviewController {
  * level, exactly like its createRailMetrics / createDragReleaseHold siblings.
  */
 export function createDotPreview(deps: DotPreviewDeps): DotPreviewController {
-  // The dot the pointer is hovering / focusing (null when none). The rail shows ONE preview
-  // popover for the "active" dot -- a scrub target takes precedence over this (see activeDot).
-  const [hoverDot, setHoverDot] = createSignal<DotCluster | null>(null)
+  // Two channels can hold the card open, because they end at different moments. POINTER: the dot
+  // under the pointer, or the dot of the card the pointer moved onto; it closes on a delay. FOCUS:
+  // the dot with keyboard focus; it opens and closes at once. One channel would make the pointer
+  // leaving the card close a card that a focused dot is still entitled to -- a keyboard reader
+  // would lose it by touching the mouse.
+  //
+  // They are separate, not independent: focus TAKES the card from the pointer (see focusDot), so
+  // the pointer can only win a dot that focus has not claimed since. Without that, a cursor parked
+  // on one dot -- the state the reader is in the moment after they use the rail -- masks the focus
+  // channel outright, and tabbing along the dots shows one dot's card under every other dot's
+  // focus ring.
+  const [pointerDot, setPointerDot] = createSignal<DotCluster | null>(null)
+  const [focusedDot, setFocusedDot] = createSignal<DotCluster | null>(null)
+
+  // The pointer wins when both hold a dot: it is the input the reader is steering right now, and
+  // focus already cleared the pointer channel when it took a dot of its own.
+  const hoverOrFocusDot = createMemo(() => pointerDot() ?? focusedDot())
+
+  // "The pointer let go; close unless it comes back" (see POINTER_CLOSE_DELAY_MS). Built on the
+  // shared trailingDebounce primitive rather than a hand-rolled timer pair, exactly as the sibling
+  // createThumbDrag does, so the arm/cancel bookkeeping is the one tested implementation the rest
+  // of the app already uses.
+  const closePointerDot = trailingDebounce(() => setPointerDot(null), POINTER_CLOSE_DELAY_MS)
+  onCleanup(closePointerDot.cancel)
+
+  const openDot = (dot: DotCluster) => {
+    closePointerDot.cancel()
+    setPointerDot(dot)
+  }
+  const closeSoon = () => closePointerDot()
+  const abandonDot = () => {
+    closePointerDot.cancel()
+    setPointerDot(null)
+  }
+  const focusDot = (dot: DotCluster) => {
+    abandonDot()
+    setFocusedDot(dot)
+  }
+  const blurDot = () => setFocusedDot(null)
+  const closeNow = () => {
+    abandonDot()
+    setFocusedDot(null)
+  }
 
   // While dragging, the dot the thumb is currently over (nearest within range), so a scrub --
   // mouse OR touch -- reveals each marked message's preview as the thumb passes it. Null when
@@ -79,58 +183,94 @@ export function createDotPreview(deps: DotPreviewDeps): DotPreviewController {
     return nearestDotWithin(deps.dots(), y, SCRUB_PREVIEW_RANGE_PX)
   })
 
-  // The dot the single preview popover describes: the scrub target while dragging (it takes
-  // precedence, so hovering a dot mid-scrub can't open a second popover), else the hovered/
-  // focused dot. One source -> one popover, shown immediately (no hover delay).
-  const activeDot = createMemo(() => scrubDot() ?? hoverDot())
+  // The dot the single preview card describes: the scrub target while the thumb is over one (it
+  // takes precedence, so hovering a dot mid-scrub cannot open a second card), else the pointer's
+  // or the focused dot, which the close delay keeps open a moment longer (see
+  // POINTER_CLOSE_DELAY_MS). One source -> one card, shown immediately (no open delay).
+  //
+  // A live drag still OWNS the card, but the rail ABANDONS the pointer channel when the grab
+  // becomes a scrub (see abandonDot) rather than this memo masking that channel for as long as
+  // `drag()` is non-null. Masking left two holes that clearing closes. The channel came back the
+  // moment the mask lifted, so the card sprang onto the PRESSED dot after the reader had scrubbed
+  // away from it -- the very bug the mask was added to fix, moved to the end of the gesture. And
+  // `drag()` stays non-null for the whole post-release hold (createDragReleaseHold pins the thumb
+  // until an out-of-window seek lands), so a reader who hovered a dot while that fetch was in
+  // flight got no card at all.
+  //
+  // scrubDot re-runs on every drag frame (deps.drag() changes per animation frame while the thumb
+  // moves), but it returns the SAME cluster between two dots, so this memo does not re-run with it.
+  const activeDot = createMemo(() => scrubDot() ?? hoverOrFocusDot())
 
+  // Keep a held dot anchored to the CURRENT cluster for its seq.
+  //
+  // The held cluster can change identity while still standing for the same seq: a streaming turn
+  // ticks maxSeq and re-rounds its topPx by a pixel, or a fresh mark lands in its pixel and bumps
+  // the count. <For> is reference-keyed, so it tears the held button down and mounts a new one --
+  // and removing the element under the cursor fires no pointerleave, so the channel still holds
+  // the STALE cluster. Re-anchor so the card the reader is looking at FOLLOWS the dot instead of
+  // vanishing out from under them; clear only when that seq is genuinely gone (its message was
+  // deleted or reseq'd).
+  //
+  // Writes each signal directly rather than through openDot/closeNow, so a re-anchor NEVER touches
+  // the close timer: a streaming turn re-anchors repeatedly, and cancelling the timer on each one
+  // would pin open a card the pointer already left.
+  const reanchor = (
+    held: DotCluster | null,
+    currentDots: readonly DotCluster[],
+    write: (next: DotCluster | null) => void,
+  ) => {
+    if (!held)
+      return
+    // The exact held cluster is still present -- leave the card alone.
+    if (currentDots.some(d => dotClusterEqual(d, held)))
+      return
+    write(currentDots.find(d => d.seq === held.seq) ?? null)
+  }
   createEffect(() => {
-    const h = hoverDot()
-    if (!h)
-      return
     const currentDots = deps.dots()
-    // The exact hovered cluster is still present -- leave the popover alone.
-    if (currentDots.some(d => dotClusterEqual(d, h)))
-      return
-    // The hovered cluster changed identity but may still stand for the same seq: a streaming
-    // turn ticks maxSeq and re-rounds its topPx by a pixel, or a fresh mark lands in its pixel
-    // and bumps the count. <For> is reference-keyed, so it tears the hovered button down and
-    // mounts a new one -- and removing the element under the cursor fires no pointerleave, so
-    // hoverDot still holds the STALE cluster. Re-anchor to the current cluster for the same seq
-    // so the popover the reader is looking at FOLLOWS the dot instead of vanishing out from
-    // under them; clear only when that seq is genuinely gone (its message was deleted/reseq'd).
-    setHoverDot(currentDots.find(d => d.seq === h.seq) ?? null)
+    reanchor(untrack(pointerDot), currentDots, setPointerDot)
+    reanchor(untrack(focusedDot), currentDots, setFocusedDot)
   })
 
-  // The popover's rail-Y: centred on the active dot but clamped so a dot near the rail's top
+  // The card's rail-Y: centred on the active dot but clamped so a dot near the rail's top
   // or bottom doesn't push the card past the overflow-hidden wrapper and clip it.
-  const popoverTopPx = createMemo(() => {
+  //
+  // Clamped against the card's MEASURED half-height, not against half the max-height cap. The cap
+  // is what the card may grow to, and most previews are far shorter: clamping a one-line card as
+  // though it were 200px tall pushed it up to ~90px away from the dot it describes, and on a rail
+  // shorter than twice the cap it left no interval at all, so every card was pinned to the rail
+  // midpoint. Before the first measurement the height is 0, which clamps to nothing and puts the
+  // card exactly on its dot -- the right answer for one frame, and better than a fixed offset.
+  const cardTopPx = createMemo(() => {
     const d = activeDot()
     if (!d)
       return 0
     const rh = deps.railHeight()
-    const half = Math.min(styles.PREVIEW_POPOVER_MAX_H_PX / 2, rh / 2)
+    const half = Math.min(deps.cardHeightPx() / 2, rh / 2)
     return clamp(d.topPx, half, rh - half)
   })
 
-  // Warm the active dot's preview so the popover fills in. A HOVER/focus warms instantly; a SCRUB
+  // Warm the active dot's preview so the card fills in. A HOVER/focus warms instantly; a SCRUB
   // (thumb drag) debounces -- dragging across a dense rail changes activeDot dot-by-dot, and
   // warming each would fire a GetAgentMessage RPC per out-of-window mark it crosses. The effect
   // tracks ONLY activeDot (its scrub source, scrubDot, dedups per dot, so it changes when the
   // thumb reaches a NEW dot, not on every drag pixel); the scrub-vs-hover classification reads
   // drag() untracked so a fraction change doesn't itself reset the debounce.
-  let scrubWarmTimer: ReturnType<typeof setTimeout> | undefined
-  const clearScrubWarmTimer = () => {
-    if (scrubWarmTimer !== undefined) {
-      clearTimeout(scrubWarmTimer)
-      scrubWarmTimer = undefined
-    }
-  }
-  onCleanup(clearScrubWarmTimer)
+  //
+  // The seq rides in a plain local beside the debounce rather than inside the timer callback,
+  // because trailingDebounce takes no argument -- the same shape createThumbDrag uses for its own
+  // debounced settle. Every arm overwrites it, which is exactly the coalescing this wants: the
+  // pending warm always stands for the dot the thumb is on NOW.
+  let pendingWarmSeq: bigint | null = null
+  const warmScrubDot = trailingDebounce(() => {
+    if (pendingWarmSeq !== null)
+      deps.warmPreview?.(pendingWarmSeq)
+  }, SCRUB_WARM_DEBOUNCE_MS)
+  onCleanup(warmScrubDot.cancel)
   createEffect(() => {
     const d = activeDot()
     // A new active dot supersedes any pending scrub warm (the thumb moved on before it settled).
-    clearScrubWarmTimer()
+    warmScrubDot.cancel()
     if (!d)
       return
     if (untrack(() => deps.drag()) === null) {
@@ -138,11 +278,9 @@ export function createDotPreview(deps: DotPreviewDeps): DotPreviewController {
       return
     }
     // Scrub: warm only once the thumb has settled on this dot for the debounce window.
-    scrubWarmTimer = setTimeout(() => {
-      scrubWarmTimer = undefined
-      deps.warmPreview?.(d.seq)
-    }, SCRUB_WARM_DEBOUNCE_MS)
+    pendingWarmSeq = d.seq
+    warmScrubDot()
   })
 
-  return { activeDot, popoverTopPx, setHoverDot }
+  return { activeDot, cardTopPx, openDot, closeSoon, abandonDot, focusDot, blurDot, closeNow }
 }

--- a/frontend/src/components/chat/chatScrollGeometry.test.ts
+++ b/frontend/src/components/chat/chatScrollGeometry.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { cannotLeaveStickyBand, maxScrollTopOf, STICKY_BOTTOM_THRESHOLD_PX } from './chatScrollGeometry'
+import { cannotLeaveStickyBand, hasScrollRoom, maxScrollTopOf, STICKY_BOTTOM_THRESHOLD_PX } from './chatScrollGeometry'
 import { makeFakeScrollDiv } from './useChatScroll.testkit'
 
-describe('cannotleavestickyband', () => {
+describe('cannotLeaveStickyBand', () => {
   const paneOf = (scrollHeight: number, clientHeight: number) => {
     const div = makeFakeScrollDiv()
     div.setClientHeight(clientHeight)
@@ -29,5 +29,56 @@ describe('cannotleavestickyband', () => {
 
   it('is false for a comfortably scrollable pane', () => {
     expect(cannotLeaveStickyBand(paneOf(50000, 500))).toBe(false)
+  })
+})
+
+describe('hasScrollRoom', () => {
+  /** A scroller of `scrollHeight` in a `clientHeight` box, parked at `scrollTop`. */
+  const scrollerAt = (scrollHeight: number, clientHeight: number, scrollTop: number) => {
+    const div = makeFakeScrollDiv()
+    div.setClientHeight(clientHeight)
+    div.setScrollHeight(scrollHeight)
+    div.el.scrollTop = scrollTop
+    return div.el
+  }
+
+  it('reads room in the direction the wheel actually goes', () => {
+    // 600 of content in a 400 box = 200px of travel, and the reader sits halfway down it. Both
+    // directions have room, and a formula that measured only one would be wrong for the other.
+    const midway = scrollerAt(600, 400, 100)
+    expect(hasScrollRoom(midway, 50)).toBe(true) // down
+    expect(hasScrollRoom(midway, -50)).toBe(true) // up
+  })
+
+  it('has none downward at the bottom, and none upward at the top', () => {
+    const atBottom = scrollerAt(600, 400, 200)
+    expect(hasScrollRoom(atBottom, 50)).toBe(false)
+    expect(hasScrollRoom(atBottom, -50)).toBe(true) // the whole travel is still above it
+
+    const atTop = scrollerAt(600, 400, 0)
+    expect(hasScrollRoom(atTop, -50)).toBe(false)
+    expect(hasScrollRoom(atTop, 50)).toBe(true)
+  })
+
+  it('has no room in either direction when the content fits', () => {
+    const fits = scrollerAt(200, 400, 0)
+    expect(hasScrollRoom(fits, 50)).toBe(false)
+    expect(hasScrollRoom(fits, -50)).toBe(false)
+  })
+
+  it('ignores sub-pixel travel, which no reader can use', () => {
+    // Fractional DPI and browser zoom leave a sliver on a scroller that is already at its limit.
+    // Reporting it as room would trap the wheel at the end of the card instead of chaining out.
+    const sliverLeft = scrollerAt(600.4, 400, 200)
+    expect(hasScrollRoom(sliverLeft, 50)).toBe(false)
+    expect(hasScrollRoom(scrollerAt(600.4, 400, 199), 50)).toBe(true) // a whole pixel does count
+  })
+
+  it('reads the SIGN of the delta only, so a line/page-mode wheel needs no conversion first', () => {
+    // deltaMode scales the magnitude, never the sign, which is why the card's wheel handler can
+    // skip the deltaMode normalization the rail's own forwarder has to do.
+    const midway = scrollerAt(600, 400, 100)
+    expect(hasScrollRoom(midway, 1)).toBe(hasScrollRoom(midway, 10_000))
+    expect(hasScrollRoom(midway, -1)).toBe(hasScrollRoom(midway, -10_000))
   })
 })

--- a/frontend/src/components/chat/chatScrollGeometry.ts
+++ b/frontend/src/components/chat/chatScrollGeometry.ts
@@ -134,6 +134,32 @@ export function distFromBottom(el: HTMLDivElement): number {
   return el.scrollHeight - el.scrollTop - el.clientHeight
 }
 
+/**
+ * Slack (px) for "can this scroller still move that way?". Sub-pixel layout (fractional
+ * device pixel ratio, browser zoom) leaves a fraction of a pixel of travel on a scroller that
+ * already sits at its limit, so a strict `> 0` test reports room that the reader cannot use.
+ * A whole pixel is the smallest movement anybody can see, and it matches the slack the sibling
+ * edge tests above take.
+ */
+export const SCROLL_ROOM_TOLERANCE_PX = 1
+
+/**
+ * True when `el` can still scroll a whole pixel in the direction of `deltaY` (negative is up).
+ *
+ * The test an INNER scroller applies to decide whether it keeps a wheel or lets the outer one
+ * have it. The two directions read DIFFERENT room: a scroller at its bottom has none left
+ * downward and its whole travel upward, so one formula for both would either trap the wheel at
+ * an end or hand the outer scroller a wheel the inner one could still use. Only the SIGN of
+ * `deltaY` is read, so a line-mode or page-mode wheel needs no `deltaMode` conversion first.
+ *
+ * Lives here with distFromBottom and maxScrollTopOf, so the "how far can this scroll" formulas
+ * stay in one place rather than being re-derived inside an event handler.
+ */
+export function hasScrollRoom(el: HTMLElement, deltaY: number): boolean {
+  const room = deltaY < 0 ? el.scrollTop : el.scrollHeight - el.clientHeight - el.scrollTop
+  return room >= SCROLL_ROOM_TOLERANCE_PX
+}
+
 /** Fraction of the viewport height that counts as the "near the top" band. */
 const NEAR_TOP_BAND_RATIO = 0.5
 

--- a/frontend/src/components/chat/chatScrollRailDrag.test.ts
+++ b/frontend/src/components/chat/chatScrollRailDrag.test.ts
@@ -2,6 +2,7 @@ import type { ThumbDragDeps } from './chatScrollRailDrag'
 import type { PreparedGeometry } from './chatScrollRailGeometry'
 import type { VirtualItem } from './useChatVirtualizer'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { SCRUB_WARM_DEBOUNCE_MS } from './chatDotPreview'
 import { createThumbDrag, SCRUB_SEEK_DEBOUNCE_MS } from './chatScrollRailDrag'
 import { prepareGeometry } from './chatScrollRailGeometry'
 
@@ -64,6 +65,7 @@ function setup(opts: { engageSlopPx?: number } = {}) {
   const setDrag = vi.fn()
   const previewScrollTo = vi.fn()
   const scrubSeek = vi.fn()
+  const abandonSeeks = vi.fn()
   const onEngage = vi.fn()
   const onRelease = vi.fn()
   const onEnd = vi.fn()
@@ -83,12 +85,13 @@ function setup(opts: { engageSlopPx?: number } = {}) {
     setDrag,
     previewScrollTo,
     scrubSeek,
+    abandonSeeks,
     onEngage,
     onRelease,
     onEnd,
   }
   const handle = createThumbDrag(deps)
-  return { el, handle, state, setDrag, previewScrollTo, scrubSeek, onEngage, onRelease, onEnd }
+  return { el, handle, state, setDrag, previewScrollTo, scrubSeek, abandonSeeks, onEngage, onRelease, onEnd }
 }
 
 function move(el: HTMLElement, clientY: number) {
@@ -97,6 +100,18 @@ function move(el: HTMLElement, clientY: number) {
 function up(el: HTMLElement, clientY: number) {
   el.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, clientY }))
 }
+
+describe('scrub debounce ordering', () => {
+  it('settles the seek LATER than the dot preview warms', () => {
+    // The two debounces are a deliberate sequence, and SCRUB_SEEK_DEBOUNCE_MS's own doc states
+    // it: on a rest the cheap message preview resolves first, and only a longer rest moves the
+    // view. Nothing in either module enforces the ordering, and each constant reads as
+    // reasonable alone -- so an edit to either one could invert the sequence with both files
+    // still looking correct. Pin it here, as ChatView.test.tsx pins the sibling
+    // RAIL_MOMENTUM_GRACE_MS < RAIL_VISIBLE_IDLE_MS ordering.
+    expect(SCRUB_WARM_DEBOUNCE_MS).toBeLessThan(SCRUB_SEEK_DEBOUNCE_MS)
+  })
+})
 
 describe('createthumbdrag', () => {
   it('captures the pointer and applies the initial position, live-scrolling in-window', () => {
@@ -391,7 +406,7 @@ describe('createthumbdrag', () => {
       state.windowFirstSeq = 4n // seqs below 4 are out of the loaded window
       handle.start(1, 100) // grabbed on the resting thumb top: clientY maps 1:1 to the fraction
       scrubTo(el, 200) // fraction 0.5 -> seq 3, out of window
-      expect(scrubSeek).not.toHaveBeenCalled() // not until the thumb has rested
+      expect(scrubSeek).not.toHaveBeenCalled() // not until the thumb rests
       vi.advanceTimersByTime(SCRUB_SEEK_DEBOUNCE_MS)
       expect(scrubSeek).toHaveBeenCalledWith(3n)
     })
@@ -479,7 +494,7 @@ describe('createthumbdrag', () => {
 
     it('seeks when the loaded window is UNKNOWN, rather than scrubbing over a frozen transcript', () => {
       // No window bounds at all (a conversation whose rows are all optimistic locals, or a
-      // window that has not resolved yet) is the fail-closed case: "outside". The reader must
+      // window that does not resolve yet) is the fail-closed case: "outside". The reader must
       // still get the debounced seek, or the thumb moves over a transcript that never follows.
       const { el, handle, state, scrubSeek, previewScrollTo } = setup()
       state.windowFirstSeq = undefined
@@ -511,6 +526,152 @@ describe('createthumbdrag', () => {
       handle.cancel()
       vi.advanceTimersByTime(SCRUB_SEEK_DEBOUNCE_MS * 4)
       expect(scrubSeek).not.toHaveBeenCalled()
+    })
+
+    describe('abandoning a seek the scrub already fired', () => {
+      // Cancelling the TIMER only stops a fetch that has not started. Once a rest fires its seek,
+      // the page request is in flight and nothing else recalls it -- so a scrub that moves on
+      // must abandon it through the owner, or it lands whenever it finishes and yanks the
+      // transcript to a position the reader scrubbed past long before.
+
+      it('abandons a fired seek once the thumb reaches a different seq', () => {
+        const { el, handle, state, scrubSeek, abandonSeeks } = setup()
+        state.windowFirstSeq = 4n
+        handle.start(1, 100)
+        scrubTo(el, 200) // seq 3
+        vi.advanceTimersByTime(SCRUB_SEEK_DEBOUNCE_MS)
+        expect(scrubSeek).toHaveBeenCalledWith(3n)
+        abandonSeeks.mockClear()
+
+        scrubTo(el, 100) // seq 2: seq 3's page is no longer the one under the thumb
+        expect(abandonSeeks).toHaveBeenCalledTimes(1)
+      })
+
+      it('does NOT abandon while the thumb only jitters within the sought seq', () => {
+        // The dedup rule that stops a rest/jitter/rest from fetching twice must not turn into an
+        // abandon of the fetch it deduped against.
+        const { el, handle, state, abandonSeeks } = setup()
+        state.windowFirstSeq = 4n
+        handle.start(1, 100)
+        scrubTo(el, 200)
+        vi.advanceTimersByTime(SCRUB_SEEK_DEBOUNCE_MS)
+        abandonSeeks.mockClear()
+
+        scrubTo(el, 201) // still seq 3
+        expect(abandonSeeks).not.toHaveBeenCalled()
+      })
+
+      it('abandons a fired seek when the thumb scrubs back into the loaded window', () => {
+        const { el, handle, state, abandonSeeks } = setup()
+        state.windowFirstSeq = 4n
+        handle.start(1, 100)
+        scrubTo(el, 200)
+        vi.advanceTimersByTime(SCRUB_SEEK_DEBOUNCE_MS)
+        abandonSeeks.mockClear()
+
+        scrubTo(el, 300) // in-window: the live-scroll drives the view from here
+        expect(abandonSeeks).toHaveBeenCalledTimes(1)
+      })
+
+      it('seeks the same seq again after abandoning it, rather than deduping against a dead fetch', () => {
+        // `soughtSeq` means "a fetch is outstanding for this seq". Once abandoned there is no
+        // fetch, so a reader who scrubs away and comes back must get the page -- otherwise the
+        // thumb sits on a position the transcript never reaches for the rest of the drag.
+        const { el, handle, state, scrubSeek } = setup()
+        state.windowFirstSeq = 4n
+        handle.start(1, 100)
+        scrubTo(el, 200) // seq 3
+        vi.advanceTimersByTime(SCRUB_SEEK_DEBOUNCE_MS)
+        expect(scrubSeek).toHaveBeenCalledTimes(1)
+
+        scrubTo(el, 100) // seq 2 -- abandons seq 3's fetch
+        scrubTo(el, 200) // back to seq 3
+        vi.advanceTimersByTime(SCRUB_SEEK_DEBOUNCE_MS)
+        expect(scrubSeek).toHaveBeenNthCalledWith(2, 3n)
+      })
+
+      it('leaves a fired seek alone on a deliberate release, whose own seek supersedes it', () => {
+        // A release issues the seek that wins. Abandoning here would also drop a TAP's press
+        // jump, whose whole meaning is that it lands.
+        const { el, handle, state, abandonSeeks } = setup()
+        state.windowFirstSeq = 4n
+        handle.start(1, 100)
+        scrubTo(el, 200)
+        vi.advanceTimersByTime(SCRUB_SEEK_DEBOUNCE_MS)
+        abandonSeeks.mockClear()
+
+        up(el, 200)
+        expect(abandonSeeks).not.toHaveBeenCalled()
+      })
+
+      it('leaves a completed release alone when cancel() arrives after it', () => {
+        // cancel() is the unmount path, and it is documented as a no-op once the drag ended. The
+        // release it follows already issued the seek the reader waits for, so abandoning here
+        // would cancel exactly the fetch that is about to land.
+        const { el, handle, abandonSeeks } = setup()
+        handle.start(1, 100)
+        up(el, 100) // a deliberate release: its own seek is in flight
+        abandonSeeks.mockClear()
+
+        handle.cancel()
+        expect(abandonSeeks).not.toHaveBeenCalled()
+      })
+
+      it.each([
+        ['pointercancel', (el: HTMLElement) => el.dispatchEvent(new PointerEvent('pointercancel', { bubbles: true, clientY: 100 }))],
+        ['lostpointercapture', (el: HTMLElement) => el.dispatchEvent(new PointerEvent('lostpointercapture', { bubbles: true, clientY: 100 }))],
+      ])('abandons EVERY seek of an aborted gesture on %s, press jump included', (_name, abort) => {
+        // No settle seek has fired here, so the only thing outstanding is the press's own jump --
+        // which the owner issued and only it can drop. An aborted gesture lands nothing, so the
+        // abandon must fire even with no seq of its own to forget.
+        const { el, handle, abandonSeeks } = setup()
+        handle.start(1, 100)
+        abandonSeeks.mockClear()
+        abort(el)
+        expect(abandonSeeks).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
+
+  describe('lostpointercapture', () => {
+    // A pointerup does not always come back to the rail: a context menu can swallow it, and the
+    // browser revokes capture when the captured element is removed. The drag listens on the rail
+    // and relies on capture to retarget the moves, so without this the drag would never tear
+    // down -- and the owner's "a drag is live" guard would reject every later press for the life
+    // of the component.
+    it('tears the drag down and clears the preview, like a pointercancel', () => {
+      const { el, handle, setDrag, onEnd, onRelease } = setup()
+      handle.start(1, 100)
+      setDrag.mockClear()
+
+      el.dispatchEvent(new PointerEvent('lostpointercapture', { bubbles: true, clientY: 100 }))
+      expect(setDrag).toHaveBeenCalledWith(null)
+      expect(onEnd).toHaveBeenCalledTimes(1)
+      expect(onRelease).not.toHaveBeenCalled() // an abandoned gesture seeks nothing
+
+      // And it really stopped tracking: a later move must not move the preview.
+      setDrag.mockClear()
+      move(el, 300)
+      flushRaf()
+      expect(setDrag).not.toHaveBeenCalled()
+    })
+
+    it('does not fire from the drag releasing its OWN capture on a normal release', () => {
+      // teardown detaches before it calls releasePointerCapture, which itself fires
+      // lostpointercapture. A listener still attached would turn every release into an abandon
+      // and clear the preview the owner is holding for its seek.
+      const { el, handle, setDrag, onRelease } = setup()
+      el.releasePointerCapture = vi.fn(() => {
+        el.dispatchEvent(new PointerEvent('lostpointercapture', { bubbles: true, clientY: 200 }))
+      })
+      handle.start(1, 100)
+      move(el, 200)
+      flushRaf()
+      setDrag.mockClear()
+
+      up(el, 200)
+      expect(onRelease).toHaveBeenCalledWith(0.5, true)
+      expect(setDrag).not.toHaveBeenCalled() // the owner still holds the preview
     })
   })
 })

--- a/frontend/src/components/chat/chatScrollRailDrag.test.ts
+++ b/frontend/src/components/chat/chatScrollRailDrag.test.ts
@@ -2,7 +2,7 @@ import type { ThumbDragDeps } from './chatScrollRailDrag'
 import type { PreparedGeometry } from './chatScrollRailGeometry'
 import type { VirtualItem } from './useChatVirtualizer'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createThumbDrag } from './chatScrollRailDrag'
+import { createThumbDrag, SCRUB_SEEK_DEBOUNCE_MS } from './chatScrollRailDrag'
 import { prepareGeometry } from './chatScrollRailGeometry'
 
 // A hand-driven rAF so moves flush deterministically: requestAnimationFrame queues the
@@ -44,7 +44,7 @@ function makeRect(): DOMRect {
   return { top: 0, left: 0, height: 400, width: 10, right: 10, bottom: 400, x: 0, y: 0, toJSON: () => ({}) } as DOMRect
 }
 
-function setup() {
+function setup(opts: { engageSlopPx?: number } = {}) {
   const el = document.createElement('div')
   el.setPointerCapture = vi.fn()
   el.releasePointerCapture = vi.fn()
@@ -63,12 +63,17 @@ function setup() {
   const grabThumbTopPx = 100
   const setDrag = vi.fn()
   const previewScrollTo = vi.fn()
+  const scrubSeek = vi.fn()
+  const onEngage = vi.fn()
   const onRelease = vi.fn()
   const onEnd = vi.fn()
   const deps: ThumbDragDeps = {
     el,
     rect: makeRect(),
     grabThumbTopPx,
+    // Default 0 -- the thumb-grab case, where the first pixel of travel scrubs. The slop tests
+    // pass their own.
+    engageSlopPx: opts.engageSlopPx ?? 0,
     minSeq: () => state.minSeq,
     maxSeq: () => state.maxSeq,
     windowFirstSeq: () => state.windowFirstSeq,
@@ -77,11 +82,13 @@ function setup() {
     thumbHeightPx: () => state.thumbHeightPx,
     setDrag,
     previewScrollTo,
+    scrubSeek,
+    onEngage,
     onRelease,
     onEnd,
   }
   const handle = createThumbDrag(deps)
-  return { el, handle, state, setDrag, previewScrollTo, onRelease, onEnd }
+  return { el, handle, state, setDrag, previewScrollTo, scrubSeek, onEngage, onRelease, onEnd }
 }
 
 function move(el: HTMLElement, clientY: number) {
@@ -190,7 +197,9 @@ describe('createthumbdrag', () => {
     handle.start(1, 100)
     setDrag.mockClear()
     up(el, 100) // fraction 0.25
-    expect(onRelease).toHaveBeenCalledWith(0.25)
+    // Pressed and released on the same pixel: a TAP, so `engaged` is false and the owner keeps
+    // whatever meaning it gave the press rather than seeking again.
+    expect(onRelease).toHaveBeenCalledWith(0.25, false)
     // The controller does NOT clear the preview on release -- the owner holds it until settle.
     expect(setDrag).not.toHaveBeenCalled()
     // Listeners detached: a later move does nothing.
@@ -203,7 +212,96 @@ describe('createthumbdrag', () => {
     const { el, handle, onRelease } = setup()
     handle.start(1, 100) // grabbed at 0.25
     up(el, 300) // released at 300/400 = 0.75
-    expect(onRelease).toHaveBeenCalledWith(0.75)
+    expect(onRelease).toHaveBeenCalledWith(0.75, true)
+  })
+
+  it('engages off the RELEASE position when the browser coalesced the last move into pointerup', () => {
+    // A pointerup can carry a position no pointermove ever reported. Trusting only the moves
+    // would report this real drag as a tap and drop its seek.
+    const { el, handle, onEngage, onRelease } = setup({ engageSlopPx: 6 })
+    handle.start(1, 100)
+    up(el, 300) // 200px of travel, none of it in a pointermove
+    expect(onRelease).toHaveBeenCalledWith(0.75, true)
+    // onEngage is for a LIVE scrub (it drops the press's own stale seek); a release already
+    // supersedes that seek with its own, so the controller does not fire it here.
+    expect(onEngage).not.toHaveBeenCalled()
+  })
+
+  describe('engage slop', () => {
+    it('drops a move within the slop: no preview, no live-scroll, and the release is a tap', () => {
+      const { el, handle, setDrag, previewScrollTo, onEngage, onRelease } = setup({ engageSlopPx: 6 })
+      handle.start(1, 100)
+      setDrag.mockClear()
+      previewScrollTo.mockClear()
+      move(el, 106) // exactly the slop -- still a tap
+      flushRaf()
+      expect(setDrag).not.toHaveBeenCalled()
+      expect(previewScrollTo).not.toHaveBeenCalled()
+      expect(onEngage).not.toHaveBeenCalled()
+      // The tap reports the PRESS fraction (0.25), not the drifted release position, so the
+      // owner's pinned thumb stays on the point the press acted on.
+      up(el, 104)
+      expect(onRelease).toHaveBeenCalledWith(0.25, false)
+    })
+
+    it('engages once past the slop, then tracks every later move', () => {
+      const { el, handle, setDrag, onEngage, onRelease } = setup({ engageSlopPx: 6 })
+      handle.start(1, 100)
+      setDrag.mockClear()
+      move(el, 107) // one past the slop
+      flushRaf()
+      expect(onEngage).toHaveBeenCalledTimes(1)
+      expect(setDrag).toHaveBeenLastCalledWith(107 / 400)
+      move(el, 300)
+      flushRaf()
+      expect(onEngage).toHaveBeenCalledTimes(1) // engaging is one-way
+      expect(setDrag).toHaveBeenLastCalledWith(0.75)
+      up(el, 300)
+      expect(onRelease).toHaveBeenCalledWith(0.75, true)
+    })
+
+    it('engages on the first move with the default slop of 0 (the thumb grab)', () => {
+      const { el, handle, onEngage, setDrag } = setup()
+      handle.start(1, 100)
+      setDrag.mockClear()
+      move(el, 101) // a single pixel: a thumb must move with the pointer, never wait
+      flushRaf()
+      expect(onEngage).toHaveBeenCalledTimes(1)
+      expect(setDrag).toHaveBeenLastCalledWith(101 / 400)
+    })
+
+    it('drags with the optional deps omitted entirely', () => {
+      // engageSlopPx, scrubSeek and onEngage are all optional. With none of them supplied the
+      // controller must still track and release -- the slop defaults to 0 and an out-of-window
+      // rest simply seeks nothing, rather than calling through an undefined sink.
+      const el = document.createElement('div')
+      el.setPointerCapture = vi.fn()
+      el.releasePointerCapture = vi.fn()
+      const setDrag = vi.fn()
+      const onRelease = vi.fn()
+      const handle = createThumbDrag({
+        el,
+        rect: makeRect(),
+        grabThumbTopPx: 100,
+        minSeq: () => 1n,
+        maxSeq: () => 5n,
+        windowFirstSeq: () => undefined, // every target is out of window: the seek path is live
+        windowLastSeq: () => undefined,
+        prepared: () => prepOf([1n, 2n, 3n, 4n, 5n]),
+        thumbHeightPx: () => 0,
+        setDrag,
+        previewScrollTo: vi.fn(),
+        onRelease,
+      })
+      handle.start(1, 100)
+      expect(() => {
+        move(el, 200)
+        flushRaf()
+      }).not.toThrow()
+      expect(setDrag).toHaveBeenLastCalledWith(0.5) // the default slop of 0 engaged on that move
+      up(el, 200)
+      expect(onRelease).toHaveBeenCalledWith(0.5, true)
+    })
   })
 
   it('abandons the drag on pointercancel: clears the preview and does not release/seek', () => {
@@ -274,5 +372,145 @@ describe('createthumbdrag', () => {
     b.handle.start(1, 100)
     b.handle.cancel()
     expect(b.onEnd).toHaveBeenCalledTimes(1)
+  })
+
+  describe('out-of-window settle seek', () => {
+    // Only setTimeout/clearTimeout are faked: rAF stays the hand-driven stub above, which the
+    // move coalescer needs.
+    beforeEach(() => vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] }))
+    afterEach(() => vi.useRealTimers())
+
+    /** Move the thumb to an out-of-window position and flush the frame it schedules. */
+    function scrubTo(el: HTMLElement, clientY: number) {
+      move(el, clientY)
+      flushRaf()
+    }
+
+    it('seeks the settled seq once the debounce elapses', () => {
+      const { el, handle, state, scrubSeek } = setup()
+      state.windowFirstSeq = 4n // seqs below 4 are out of the loaded window
+      handle.start(1, 100) // grabbed on the resting thumb top: clientY maps 1:1 to the fraction
+      scrubTo(el, 200) // fraction 0.5 -> seq 3, out of window
+      expect(scrubSeek).not.toHaveBeenCalled() // not until the thumb has rested
+      vi.advanceTimersByTime(SCRUB_SEEK_DEBOUNCE_MS)
+      expect(scrubSeek).toHaveBeenCalledWith(3n)
+    })
+
+    it('never seeks an in-window target -- that path live-scrolls instead', () => {
+      const { el, handle, scrubSeek, previewScrollTo } = setup()
+      handle.start(1, 100)
+      scrubTo(el, 200) // seqF 3, inside the loaded window 1..5
+      vi.advanceTimersByTime(SCRUB_SEEK_DEBOUNCE_MS * 4)
+      expect(scrubSeek).not.toHaveBeenCalled()
+      expect(previewScrollTo).toHaveBeenCalledWith(200)
+    })
+
+    it('does not arm a seek from the press itself', () => {
+      // The owner decides what a press means (a track/dot press jumps on its own). If the
+      // initial apply armed one too, every out-of-window press would fetch its page twice.
+      const { handle, state, scrubSeek } = setup()
+      state.windowFirstSeq = 4n
+      handle.start(1, 100) // out of window, but no move yet
+      vi.advanceTimersByTime(SCRUB_SEEK_DEBOUNCE_MS * 4)
+      expect(scrubSeek).not.toHaveBeenCalled()
+    })
+
+    it('restarts the debounce on every move: only the settled position seeks', () => {
+      const { el, handle, state, scrubSeek } = setup()
+      state.windowFirstSeq = 4n
+      handle.start(1, 100)
+      scrubTo(el, 200) // seq 3
+      vi.advanceTimersByTime(SCRUB_SEEK_DEBOUNCE_MS - 1)
+      scrubTo(el, 100) // seq 2 -- still out of window, and it supersedes the pending seek
+      vi.advanceTimersByTime(SCRUB_SEEK_DEBOUNCE_MS)
+      expect(scrubSeek).toHaveBeenCalledTimes(1)
+      expect(scrubSeek).toHaveBeenCalledWith(2n)
+    })
+
+    it('drops a pending seek when the thumb scrubs back into the loaded window', () => {
+      const { el, handle, state, scrubSeek } = setup()
+      state.windowFirstSeq = 4n
+      handle.start(1, 100)
+      scrubTo(el, 200) // seq 3, out of window: a seek is armed
+      scrubTo(el, 300) // back in-window (seqF 4): the armed fetch is now for a stale position
+      vi.advanceTimersByTime(SCRUB_SEEK_DEBOUNCE_MS * 4)
+      expect(scrubSeek).not.toHaveBeenCalled()
+    })
+
+    it('re-tests the window when the timer fires, not only when it was armed', () => {
+      // An earlier seek (or an edge page load) can swap the window during the wait, which makes
+      // this target in-window and the fetch pointless.
+      const { el, handle, state, scrubSeek } = setup()
+      state.windowFirstSeq = 4n
+      handle.start(1, 100)
+      scrubTo(el, 200)
+      state.windowFirstSeq = 1n // the window swapped mid-wait: seq 3 is loaded now
+      vi.advanceTimersByTime(SCRUB_SEEK_DEBOUNCE_MS)
+      expect(scrubSeek).not.toHaveBeenCalled()
+    })
+
+    it('seeks the same seq only once across two rests', () => {
+      const { el, handle, state, scrubSeek } = setup()
+      state.windowFirstSeq = 4n
+      handle.start(1, 100)
+      scrubTo(el, 200)
+      vi.advanceTimersByTime(SCRUB_SEEK_DEBOUNCE_MS)
+      expect(scrubSeek).toHaveBeenCalledTimes(1)
+      // A jitter that maps back to the SAME seq (3) must not fetch its page again.
+      scrubTo(el, 201)
+      vi.advanceTimersByTime(SCRUB_SEEK_DEBOUNCE_MS)
+      expect(scrubSeek).toHaveBeenCalledTimes(1)
+    })
+
+    it.each([
+      ['pointerup', (el: HTMLElement) => up(el, 100)],
+      ['pointercancel', (el: HTMLElement) => el.dispatchEvent(new PointerEvent('pointercancel', { bubbles: true, clientY: 100 }))],
+    ])('cancels a pending seek on %s', (_name, end) => {
+      const { el, handle, state, scrubSeek } = setup()
+      state.windowFirstSeq = 4n
+      handle.start(1, 100)
+      scrubTo(el, 200)
+      end(el)
+      vi.advanceTimersByTime(SCRUB_SEEK_DEBOUNCE_MS * 4)
+      // A release seeks through the owner's own release path; a late duplicate from this timer
+      // would fetch a second page behind it.
+      expect(scrubSeek).not.toHaveBeenCalled()
+    })
+
+    it('seeks when the loaded window is UNKNOWN, rather than scrubbing over a frozen transcript', () => {
+      // No window bounds at all (a conversation whose rows are all optimistic locals, or a
+      // window that has not resolved yet) is the fail-closed case: "outside". The reader must
+      // still get the debounced seek, or the thumb moves over a transcript that never follows.
+      const { el, handle, state, scrubSeek, previewScrollTo } = setup()
+      state.windowFirstSeq = undefined
+      state.windowLastSeq = undefined
+      handle.start(1, 100)
+      scrubTo(el, 200)
+      expect(previewScrollTo).not.toHaveBeenCalled() // nothing loaded to live-scroll to
+      vi.advanceTimersByTime(SCRUB_SEEK_DEBOUNCE_MS)
+      expect(scrubSeek).toHaveBeenCalledWith(3n)
+    })
+
+    it('seeks nothing when the seq range degenerates between the arm and the fire', () => {
+      // The range is re-read when the timer fires, so a window that goes inverted mid-wait must
+      // fail closed rather than map the fraction onto a range that no longer makes sense.
+      const { el, handle, state, scrubSeek } = setup()
+      state.windowFirstSeq = 4n
+      handle.start(1, 100)
+      scrubTo(el, 200)
+      state.maxSeq = 0n // inverted: maxSeq < minSeq
+      vi.advanceTimersByTime(SCRUB_SEEK_DEBOUNCE_MS)
+      expect(scrubSeek).not.toHaveBeenCalled()
+    })
+
+    it('cancels a pending seek on cancel() (an unmount mid-scrub)', () => {
+      const { el, handle, state, scrubSeek } = setup()
+      state.windowFirstSeq = 4n
+      handle.start(1, 100)
+      scrubTo(el, 200)
+      handle.cancel()
+      vi.advanceTimersByTime(SCRUB_SEEK_DEBOUNCE_MS * 4)
+      expect(scrubSeek).not.toHaveBeenCalled()
+    })
   })
 })

--- a/frontend/src/components/chat/chatScrollRailDrag.ts
+++ b/frontend/src/components/chat/chatScrollRailDrag.ts
@@ -1,6 +1,6 @@
 import type { PreparedGeometry } from './chatScrollRailGeometry'
 import { createRafCoalescer } from '~/lib/rafCoalesce'
-import { centerAxisFraction, contentYForSeq, safeSeqNumber, seqNumberAtFraction } from './chatScrollRailGeometry'
+import { centerAxisFraction, contentYForSeq, fractionToSeq, safeSeqNumber, seqNumberAtFraction } from './chatScrollRailGeometry'
 
 // ---------------------------------------------------------------------------
 // Scroll-rail thumb-drag controller
@@ -11,7 +11,29 @@ import { centerAxisFraction, contentYForSeq, safeSeqNumber, seqNumberAtFraction 
 // geometry are read through accessors -- called FRESH on each move/release -- because a
 // live-tail advance mid-drag grows maxSeq, and the release must land against the same range
 // the last move previewed against.
+//
+// One grab drives BOTH gestures the rail offers, told apart by how far the pointer travels:
+// a press that stays within `engageSlopPx` is a TAP (the owner's press action stands alone),
+// and the first move past it ENGAGES a scrub that tracks the pointer until release.
 // ---------------------------------------------------------------------------
+
+/**
+ * Pointer travel (px) before a press becomes a scrub. A press whose action already jumped
+ * (a track or dot press) needs this slop: a finger jitters a few pixels while it lifts, and
+ * on a long history 2px of rail is hundreds of seqs -- so without it a tap would land
+ * somewhere other than where it jumped. A thumb grab passes 0: its press has no competing
+ * tap meaning, and a conventional scrollbar thumb must not wait before it moves.
+ */
+export const SCRUB_ENGAGE_SLOP_PX = 6
+
+/**
+ * How long the thumb must settle on an OUT-OF-WINDOW seq mid-scrub before the rail seeks to
+ * it. In-window targets live-scroll on every frame for free; an out-of-window one costs a
+ * page fetch plus a window swap, so only a rest pulls one. Deliberately longer than
+ * SCRUB_WARM_DEBOUNCE_MS (see ./chatDotPreview): the cheap message preview resolves first,
+ * and only a longer rest moves the view.
+ */
+export const SCRUB_SEEK_DEBOUNCE_MS = 200
 
 export interface ThumbDragDeps {
   /** The rail element the pointer was captured on (also the move/up listener target). */
@@ -25,6 +47,11 @@ export interface ThumbDragDeps {
    * scrollbar feel), which matters most when grabbing near the thumb's edge on a tall history.
    */
   grabThumbTopPx: number
+  /**
+   * Pointer travel (px) before this grab becomes a scrub; 0 (the default) engages on the first
+   * move. See {@link SCRUB_ENGAGE_SLOP_PX} for which press passes which value.
+   */
+  engageSlopPx?: number
   /** Live whole-history seq range (read each move/release). */
   minSeq: () => bigint
   maxSeq: () => bigint
@@ -40,12 +67,29 @@ export interface ThumbDragDeps {
   /** Guard-marked programmatic scroll write for in-window live-scroll. */
   previewScrollTo: (top: number) => void
   /**
-   * The pointer was released at rail fraction `fraction`. The controller does NOT clear the
-   * drag preview here -- the owner holds the thumb at this position and clears it once the
-   * seek has scrolled the view to match, so the thumb doesn't flash back to the pre-drag
-   * position while an out-of-window seek fetches + lands.
+   * Seek to a seq the thumb settled on while that seq is OUTSIDE the loaded window -- the
+   * out-of-window counterpart of previewScrollTo, debounced by
+   * {@link SCRUB_SEEK_DEBOUNCE_MS}. Without it a scrub across a long history moves the thumb
+   * and the dot preview while the transcript stands still, because there is nothing loaded to
+   * scroll to. Optional; omit it to keep the preview-only behaviour.
    */
-  onRelease: (fraction: number) => void
+  scrubSeek?: (seq: bigint) => void
+  /**
+   * The grab became a scrub: a pointermove arrived past `engageSlopPx`. Fires at most once per
+   * grab, and never for a release that engages on its own coalesced position (a release
+   * supersedes the press action by itself). Lets the owner drop the press action it took on
+   * pointerdown -- the reader has taken manual control of the thumb.
+   */
+  onEngage?: () => void
+  /**
+   * The pointer was released at rail fraction `fraction`; `engaged` reports whether the grab
+   * ever became a scrub (see `engageSlopPx`), so the owner can tell a tap -- whose press
+   * action already stands -- from a scrub that must land where it was released. The controller
+   * does NOT clear the drag preview here -- the owner holds the thumb at this position and
+   * clears it once the seek has scrolled the view to match, so the thumb doesn't flash back to
+   * the pre-drag position while an out-of-window seek fetches + lands.
+   */
+  onRelease: (fraction: number, engaged: boolean) => void
   /**
    * The pointer lifecycle ended (release, cancel, or an explicit cancel() from an unmount):
    * the controller has torn down its listeners + rAF. Fires at most once per drag, BEFORE
@@ -65,13 +109,21 @@ export interface ThumbDragHandle {
 
 /**
  * Create a thumb-drag controller for one grab. `start` captures the pointer and begins
- * tracking; the drag ends on pointerup/pointercancel (seeking the mapped seq) or when the
- * caller invokes `cancel` (mid-drag unmount). All handlers are idempotent, so `cancel`
- * after a completed drag is a harmless no-op.
+ * tracking; the drag ends on pointerup (reporting the release fraction and whether the grab
+ * ever engaged), on pointercancel (no seek at all), or when the caller invokes `cancel`
+ * (mid-drag unmount). All handlers are idempotent, so `cancel` after a completed drag is a
+ * harmless no-op.
  */
 export function createThumbDrag(deps: ThumbDragDeps): ThumbDragHandle {
   const { el, rect } = deps
+  const engageSlopPx = deps.engageSlopPx ?? 0
   let capturedPointerId: number | null = null
+
+  // The press Y, and whether the pointer has travelled far enough from it to become a scrub.
+  // Until it has, every move is dropped: the preview stays where the press put it, nothing
+  // live-scrolls, and no settle seek is armed -- so a tap keeps the meaning its press gave it.
+  let pressClientY = 0
+  let engaged = false
 
   // The thumb height + within-thumb grab offset, both frozen at grab (start) so the
   // pointer->fraction axis stays internally consistent for the whole drag: the offset is measured
@@ -105,11 +157,65 @@ export function createThumbDrag(deps: ThumbDragDeps): ThumbDragHandle {
     capturedPointerId = null
   }
 
-  // Map a rail-relative pointer Y to the drag fraction, preview the thumb, and -- while the
-  // target maps INSIDE the loaded window -- live-scroll the chat so the view tracks the thumb.
+  // Whether the (fractional) seq under the thumb lies INSIDE the loaded window. This is the test
+  // that splits the two ways a scrub moves the view: in-window the drag live-scrolls on every
+  // frame for free, out of it only a settled thumb seeks (armScrubSeek), because that costs a page
+  // fetch. Fail-closed on an absent/unsafe window bound: report "outside", so the reader gets the
+  // debounced seek rather than a thumb that moves over a transcript that never does.
+  const insideWindow = (seqF: number): boolean => {
+    const wf = deps.windowFirstSeq()
+    const wl = deps.windowLastSeq()
+    const first = wf === undefined ? null : safeSeqNumber(wf)
+    const last = wl === undefined ? null : safeSeqNumber(wl)
+    return first !== null && last !== null && seqF >= first && seqF <= last
+  }
+
+  // The debounced out-of-window seek: the thumb must rest on a target for
+  // SCRUB_SEEK_DEBOUNCE_MS before the rail pulls the page it needs. The last seq actually sought
+  // is remembered so a rest, a jitter, and a second rest on the SAME seq fetch once.
+  let scrubSeekTimer: ReturnType<typeof setTimeout> | undefined
+  let lastScrubSeekSeq: bigint | null = null
+
+  const cancelScrubSeek = () => {
+    if (scrubSeekTimer !== undefined) {
+      clearTimeout(scrubSeekTimer)
+      scrubSeekTimer = undefined
+    }
+  }
+
+  const fireScrubSeek = (fraction: number) => {
+    const min = deps.minSeq()
+    const max = deps.maxSeq()
+    const seqF = seqNumberAtFraction(fraction, min, max)
+    // Re-test against the LIVE window: an earlier rest's seek (or an edge page load) can swap the
+    // window while this timer waits, which makes the target in-window and this fetch pointless.
+    if (seqF === null || insideWindow(seqF))
+      return
+    const seq = fractionToSeq(fraction, min, max)
+    if (seq === null || seq === lastScrubSeekSeq)
+      return
+    lastScrubSeekSeq = seq
+    deps.scrubSeek?.(seq)
+  }
+
+  const armScrubSeek = (fraction: number) => {
+    if (deps.scrubSeek === undefined)
+      return
+    // Restart the wait on every move, so a thumb sweeping across a dense history seeks only where
+    // it STOPS -- the fly-over positions coalesce into one fetch, exactly as the dot-preview warm
+    // debounce coalesces its fly-over previews (see ./chatDotPreview).
+    cancelScrubSeek()
+    scrubSeekTimer = setTimeout(() => {
+      scrubSeekTimer = undefined
+      fireScrubSeek(fraction)
+    }, SCRUB_SEEK_DEBOUNCE_MS)
+  }
+
+  // Map a rail-relative pointer Y to the drag fraction, preview the thumb, and move the view to
+  // match: live-scroll while the target is in-window, else arm the debounced out-of-window seek.
   const apply = (clientY: number) => {
-    // Map the pointer to the drag fraction (offset-preserving; see fractionAt), preview the thumb
-    // there, and -- while the mapped seq is in-window -- live-scroll so the view tracks the thumb.
+    // Map the pointer to the drag fraction (offset-preserving; see fractionAt) and preview the
+    // thumb there.
     const f = fractionAt(clientY)
     deps.setDrag(f)
     // The absolute (fractional) seq under the thumb, via the SAME fail-closed mapping the resting
@@ -118,25 +224,44 @@ export function createThumbDrag(deps: ThumbDragDeps): ThumbDragHandle {
     const seqF = seqNumberAtFraction(f, deps.minSeq(), deps.maxSeq())
     if (seqF === null)
       return
-    const wf = deps.windowFirstSeq()
-    const wl = deps.windowLastSeq()
-    const first = wf === undefined ? null : safeSeqNumber(wf)
-    const last = wl === undefined ? null : safeSeqNumber(wl)
-    if (first !== null && last !== null && seqF >= first && seqF <= last) {
+    if (insideWindow(seqF)) {
+      // Back inside loaded rows: drop a pending out-of-window seek, which would now fetch a page
+      // for a position the reader already scrubbed away from.
+      cancelScrubSeek()
       const cy = contentYForSeq(deps.prepared(), seqF)
       if (cy !== null)
         deps.previewScrollTo(cy)
+      return
     }
+    // Only a SCRUB seeks. The initial apply() at start() runs before the grab engages, so the
+    // press keeps whatever meaning the owner gave it (a track/dot press jumps on its own; a thumb
+    // grab jumps nowhere) instead of this arming a second, later seek behind it.
+    if (engaged)
+      armScrubSeek(f)
   }
+
+  /** Whether the pointer travelled far enough from the press to count as a scrub, not a tap. */
+  const movedPastSlop = (clientY: number) => Math.abs(clientY - pressClientY) > engageSlopPx
 
   // rAF-coalesce pointermove through the shared helper: one apply() per frame with the latest
   // pointer Y, instead of re-hand-rolling the schedule-once + lastY bookkeeping.
   const moveCoalescer = createRafCoalescer<number>(apply)
-  const onMove = (ev: PointerEvent) => moveCoalescer.push(ev.clientY)
+  const onMove = (ev: PointerEvent) => {
+    // Below the slop the grab is armed but not engaged: drop the move whole, so the preview stays
+    // where the press put it and the release still reads as a tap.
+    if (!engaged) {
+      if (!movedPastSlop(ev.clientY))
+        return
+      engaged = true
+      deps.onEngage?.()
+    }
+    moveCoalescer.push(ev.clientY)
+  }
 
   let ended = false
   const teardown = () => {
     moveCoalescer.abort()
+    cancelScrubSeek()
     releasePointerCapture()
     el.removeEventListener('pointermove', onMove)
     el.removeEventListener('pointerup', finish)
@@ -156,8 +281,15 @@ export function createThumbDrag(deps: ThumbDragDeps): ThumbDragHandle {
   // pointerup: a deliberate release -> seek. Runs as a pointerup listener.
   function finish(ev: PointerEvent) {
     teardown()
-    const f = fractionAt(ev.clientY)
-    deps.onRelease(f) // owner keeps the preview until the seek settles -- see onRelease
+    // Test the release position against the slop as well, rather than trusting `engaged` alone: a
+    // pointerup can carry a position no pointermove ever reported (the browser coalesces the last
+    // move into it), and dropping that travel would silently turn a real drag into a tap.
+    const released = engaged || movedPastSlop(ev.clientY)
+    // A tap reports the PRESS position, not the release one: the pointer may have drifted within
+    // the slop while the finger lifted, and the owner pins the thumb at this fraction -- so
+    // reading the release Y would slide the thumb off the point the press jumped to.
+    const f = fractionAt(released ? ev.clientY : pressClientY)
+    deps.onRelease(f, released) // owner keeps the preview until the seek settles -- see onRelease
   }
 
   // pointercancel: the interaction was aborted (a system/edge gesture stole the pointer,
@@ -183,6 +315,8 @@ export function createThumbDrag(deps: ThumbDragDeps): ThumbDragHandle {
       // apply() so it holds the thumb where it rests (no jump) and then tracks the pointer delta.
       grabThumbHeightPx = deps.thumbHeightPx()
       grabOffsetPx = (initialClientY - rect.top) - deps.grabThumbTopPx
+      // The slop is measured from HERE, and the release reads it back for a tap's fraction.
+      pressClientY = initialClientY
       el.addEventListener('pointermove', onMove)
       el.addEventListener('pointerup', finish)
       el.addEventListener('pointercancel', abandon)

--- a/frontend/src/components/chat/chatScrollRailDrag.ts
+++ b/frontend/src/components/chat/chatScrollRailDrag.ts
@@ -1,4 +1,5 @@
 import type { PreparedGeometry } from './chatScrollRailGeometry'
+import { trailingDebounce } from '~/lib/debounce'
 import { createRafCoalescer } from '~/lib/rafCoalesce'
 import { centerAxisFraction, contentYForSeq, fractionToSeq, safeSeqNumber, seqNumberAtFraction } from './chatScrollRailGeometry'
 
@@ -75,18 +76,31 @@ export interface ThumbDragDeps {
    */
   scrubSeek?: (seq: bigint) => void
   /**
+   * Abandon every seek this grab issued and did not choose to land, so none of them can scroll
+   * the view after the reader moved on. The controller calls it at each moment that makes an
+   * outstanding seek stale: the thumb scrubs away from the seq a settle seek asked for, the
+   * thumb returns to the loaded window, or the whole gesture is abandoned (pointercancel or an
+   * unmount), which also drops the press's own jump. A DELIBERATE release does not call it --
+   * that release issues the seek that supersedes them. Optional.
+   *
+   * Required for correctness once `scrubSeek` is wired: `scrubSeek` starts a page fetch that
+   * nothing else recalls, so without this a fetch armed at one rest lands minutes of scrubbing
+   * later and yanks the transcript away from the thumb.
+   */
+  abandonSeeks?: () => void
+  /**
    * The grab became a scrub: a pointermove arrived past `engageSlopPx`. Fires at most once per
    * grab, and never for a release that engages on its own coalesced position (a release
    * supersedes the press action by itself). Lets the owner drop the press action it took on
-   * pointerdown -- the reader has taken manual control of the thumb.
+   * pointerdown -- the reader took manual control of the thumb.
    */
   onEngage?: () => void
   /**
-   * The pointer was released at rail fraction `fraction`; `engaged` reports whether the grab
+   * The reader released the pointer at rail fraction `fraction`; `engaged` reports whether the grab
    * ever became a scrub (see `engageSlopPx`), so the owner can tell a tap -- whose press
-   * action already stands -- from a scrub that must land where it was released. The controller
+   * action already stands -- from a scrub that must land at its release position. The controller
    * does NOT clear the drag preview here -- the owner holds the thumb at this position and
-   * clears it once the seek has scrolled the view to match, so the thumb doesn't flash back to
+   * clears it once the seek scrolled the view to match, so the thumb doesn't flash back to
    * the pre-drag position while an out-of-window seek fetches + lands.
    */
   onRelease: (fraction: number, engaged: boolean) => void
@@ -119,7 +133,7 @@ export function createThumbDrag(deps: ThumbDragDeps): ThumbDragHandle {
   const engageSlopPx = deps.engageSlopPx ?? 0
   let capturedPointerId: number | null = null
 
-  // The press Y, and whether the pointer has travelled far enough from it to become a scrub.
+  // The press Y, and whether the pointer travelled far enough from it to become a scrub.
   // Until it has, every move is dropped: the preview stays where the press put it, nothing
   // live-scrolls, and no settle seek is armed -- so a tap keeps the meaning its press gave it.
   let pressClientY = 0
@@ -171,44 +185,59 @@ export function createThumbDrag(deps: ThumbDragDeps): ThumbDragHandle {
   }
 
   // The debounced out-of-window seek: the thumb must rest on a target for
-  // SCRUB_SEEK_DEBOUNCE_MS before the rail pulls the page it needs. The last seq actually sought
-  // is remembered so a rest, a jitter, and a second rest on the SAME seq fetch once.
-  let scrubSeekTimer: ReturnType<typeof setTimeout> | undefined
-  let lastScrubSeekSeq: bigint | null = null
+  // SCRUB_SEEK_DEBOUNCE_MS before the rail pulls the page it needs. Built on the shared
+  // trailingDebounce primitive rather than a hand-rolled timer pair, so the arm/cancel
+  // bookkeeping is the one tested implementation the rest of the app already uses.
+  //
+  // Two variables carry the state that outlives one fire. `seekFraction` is the position the
+  // pending timer will fire against -- the debounce is re-armed on every move, so only the LAST
+  // one matters. `soughtSeq` is the seq a settle seek already asked for and has not abandoned,
+  // and it serves two rules at once: a rest, a jitter, and a second rest on the SAME seq fetch
+  // once, and a thumb that scrubs AWAY from that seq abandons the fetch it started, so the page
+  // cannot land under a reader who moved on (see abandonSeeks).
+  let seekFraction = 0
+  let soughtSeq: bigint | null = null
 
-  const cancelScrubSeek = () => {
-    if (scrubSeekTimer !== undefined) {
-      clearTimeout(scrubSeekTimer)
-      scrubSeekTimer = undefined
-    }
-  }
-
-  const fireScrubSeek = (fraction: number) => {
+  const fireScrubSeek = () => {
     const min = deps.minSeq()
     const max = deps.maxSeq()
-    const seqF = seqNumberAtFraction(fraction, min, max)
+    const seqF = seqNumberAtFraction(seekFraction, min, max)
     // Re-test against the LIVE window: an earlier rest's seek (or an edge page load) can swap the
     // window while this timer waits, which makes the target in-window and this fetch pointless.
     if (seqF === null || insideWindow(seqF))
       return
-    const seq = fractionToSeq(fraction, min, max)
-    if (seq === null || seq === lastScrubSeekSeq)
+    const seq = fractionToSeq(seekFraction, min, max)
+    if (seq === null || seq === soughtSeq)
       return
-    lastScrubSeekSeq = seq
+    soughtSeq = seq
     deps.scrubSeek?.(seq)
   }
+
+  // Restart the wait on every move, so a thumb sweeping across a dense history seeks only where
+  // it STOPS -- the fly-over positions coalesce into one fetch, exactly as the dot-preview warm
+  // debounce coalesces its fly-over previews (see ./chatDotPreview).
+  const scrubSeekDebounced = trailingDebounce(fireScrubSeek, SCRUB_SEEK_DEBOUNCE_MS)
 
   const armScrubSeek = (fraction: number) => {
     if (deps.scrubSeek === undefined)
       return
-    // Restart the wait on every move, so a thumb sweeping across a dense history seeks only where
-    // it STOPS -- the fly-over positions coalesce into one fetch, exactly as the dot-preview warm
-    // debounce coalesces its fly-over previews (see ./chatDotPreview).
-    cancelScrubSeek()
-    scrubSeekTimer = setTimeout(() => {
-      scrubSeekTimer = undefined
-      fireScrubSeek(fraction)
-    }, SCRUB_SEEK_DEBOUNCE_MS)
+    seekFraction = fraction
+    scrubSeekDebounced()
+  }
+
+  /**
+   * Drop everything this grab has outstanding towards a seq it no longer points at: the pending
+   * debounce, and -- through the owner -- a fetch an earlier rest already started. `force` also
+   * abandons a seek the grab issued OUTSIDE the settle path (a track or dot press's own jump),
+   * which only an abandoned gesture may do; a deliberate release must leave that jump alone,
+   * because a tap's whole meaning is that its press jump lands.
+   */
+  const dropScrubSeek = (force = false) => {
+    scrubSeekDebounced.cancel()
+    if (soughtSeq === null && !force)
+      return
+    soughtSeq = null
+    deps.abandonSeeks?.()
   }
 
   // Map a rail-relative pointer Y to the drag fraction, preview the thumb, and move the view to
@@ -218,16 +247,19 @@ export function createThumbDrag(deps: ThumbDragDeps): ThumbDragHandle {
     // thumb there.
     const f = fractionAt(clientY)
     deps.setDrag(f)
+    const min = deps.minSeq()
+    const max = deps.maxSeq()
     // The absolute (fractional) seq under the thumb, via the SAME fail-closed mapping the resting
     // thumb geometry (fractionToSeq) uses -- so the drag and the rest of the rail agree on the
     // range->seq travel math. Null on a degenerate/unsafe range: preview the thumb, no live-scroll.
-    const seqF = seqNumberAtFraction(f, deps.minSeq(), deps.maxSeq())
+    const seqF = seqNumberAtFraction(f, min, max)
     if (seqF === null)
       return
     if (insideWindow(seqF)) {
-      // Back inside loaded rows: drop a pending out-of-window seek, which would now fetch a page
-      // for a position the reader already scrubbed away from.
-      cancelScrubSeek()
+      // Back inside loaded rows: drop the pending out-of-window seek AND abandon one an earlier
+      // rest already started, because both fetch a page for a position the reader scrubbed away
+      // from. From here the live-scroll below drives the view.
+      dropScrubSeek()
       const cy = contentYForSeq(deps.prepared(), seqF)
       if (cy !== null)
         deps.previewScrollTo(cy)
@@ -236,8 +268,16 @@ export function createThumbDrag(deps: ThumbDragDeps): ThumbDragHandle {
     // Only a SCRUB seeks. The initial apply() at start() runs before the grab engages, so the
     // press keeps whatever meaning the owner gave it (a track/dot press jumps on its own; a thumb
     // grab jumps nowhere) instead of this arming a second, later seek behind it.
-    if (engaged)
-      armScrubSeek(f)
+    if (!engaged)
+      return
+    // An earlier rest's seek is still fetching, and the thumb now points at a DIFFERENT seq: its
+    // page is no longer the one under the thumb, so abandon it before arming the next rest.
+    // Without this it lands whenever the fetch finishes and yanks the transcript to a position
+    // the reader already scrubbed past. The bigint round runs ONLY while a seek is outstanding,
+    // so an ordinary scrub frame pays nothing for it.
+    if (soughtSeq !== null && fractionToSeq(f, min, max) !== soughtSeq)
+      dropScrubSeek()
+    armScrubSeek(f)
   }
 
   /** Whether the pointer travelled far enough from the press to count as a scrub, not a tap. */
@@ -261,11 +301,18 @@ export function createThumbDrag(deps: ThumbDragDeps): ThumbDragHandle {
   let ended = false
   const teardown = () => {
     moveCoalescer.abort()
-    cancelScrubSeek()
-    releasePointerCapture()
+    // Cancel the pending debounce only. A seek an earlier rest ALREADY started belongs to the
+    // release that follows: an engaged release supersedes it with its own seek, and a tap's
+    // press jump must still land. Only abandon() drops those (see dropScrubSeek).
+    scrubSeekDebounced.cancel()
+    // Detach BEFORE releasing capture: an explicit releasePointerCapture also fires
+    // lostpointercapture, and that handler abandons the drag -- so a listener still attached
+    // here would turn every ordinary release into an abandon and clear the release's preview.
     el.removeEventListener('pointermove', onMove)
     el.removeEventListener('pointerup', finish)
     el.removeEventListener('pointercancel', abandon)
+    el.removeEventListener('lostpointercapture', abandon)
+    releasePointerCapture()
     // Fire onEnd exactly once, even if teardown runs again (a normal release then a later
     // cancel() from an unmount): the owner's "drag active" guard must clear only once.
     if (!ended) {
@@ -285,18 +332,30 @@ export function createThumbDrag(deps: ThumbDragDeps): ThumbDragHandle {
     // pointerup can carry a position no pointermove ever reported (the browser coalesces the last
     // move into it), and dropping that travel would silently turn a real drag into a tap.
     const released = engaged || movedPastSlop(ev.clientY)
-    // A tap reports the PRESS position, not the release one: the pointer may have drifted within
+    // A tap reports the PRESS position, not the release one: the pointer can drift within
     // the slop while the finger lifted, and the owner pins the thumb at this fraction -- so
     // reading the release Y would slide the thumb off the point the press jumped to.
     const f = fractionAt(released ? ev.clientY : pressClientY)
     deps.onRelease(f, released) // owner keeps the preview until the seek settles -- see onRelease
   }
 
-  // pointercancel: the interaction was aborted (a system/edge gesture stole the pointer,
-  // common on touch) -- do NOT seek; just drop the preview and stop tracking, as if the drag
-  // never happened.
+  // The gesture ended without a deliberate release, so it lands NOTHING: drop the preview, stop
+  // tracking, and abandon every seek the grab issued -- including a track or dot press's own
+  // jump, whose fetch would otherwise land seconds later and move the transcript for a gesture
+  // the reader never completed. Runs for two events plus the explicit cancel():
+  //   - pointercancel: a system or edge gesture stole the pointer (common on touch).
+  //   - lostpointercapture: the browser revoked the capture (the captured element was removed, a
+  //     context menu took the pointer). The pointerup then retargets elsewhere and NEVER reaches
+  //     this rail, so without this the drag would never tear down and its "a drag is live" guard
+  //     would reject every later press for the life of the component.
   function abandon() {
+    // Only a gesture that is still LIVE abandons its seeks. cancel() after a completed release
+    // must stay the documented no-op: that release already issued the seek the reader is waiting
+    // for, and dropping it here would cancel exactly the fetch that is about to land.
+    const wasLive = !ended
     teardown()
+    if (wasLive)
+      dropScrubSeek(true)
     deps.setDrag(null)
   }
 
@@ -320,6 +379,7 @@ export function createThumbDrag(deps: ThumbDragDeps): ThumbDragHandle {
       el.addEventListener('pointermove', onMove)
       el.addEventListener('pointerup', finish)
       el.addEventListener('pointercancel', abandon)
+      el.addEventListener('lostpointercapture', abandon)
       apply(initialClientY)
     },
     cancel: abandon,

--- a/frontend/src/components/chat/chatSeek.ts
+++ b/frontend/src/components/chat/chatSeek.ts
@@ -33,11 +33,18 @@ export interface ChatSeek {
   previewScrollTo: (top: number) => void
   /**
    * Abandon any in-flight out-of-window seek so its late-resolving fetch cannot land
-   * (yank the viewport) after the user has taken manual control. The hook's handleScroll
-   * calls this on a genuine user scroll, and the rail calls it (via the hook) when a fresh
-   * thumb grab begins -- a drag scrolls only programmatically, so it never trips the
-   * user-scroll path. Clearing pendingSeek makes an in-flight seek's `.then` short-circuit
-   * (its epoch no longer matches a live pendingSeek).
+   * (yank the viewport) after the user took manual control. The hook's handleScroll calls
+   * this on a genuine user scroll, and the rail calls it (via the hook) at each moment its
+   * gesture stops wanting a seek it issued -- a drag scrolls only programmatically, so it
+   * never trips the user-scroll path.
+   *
+   * The seek stops in BOTH places it can still move the view. Clearing pendingSeek makes an
+   * in-flight seek's `.then` short-circuit, because its epoch no longer matches a live
+   * pendingSeek. Aborting its controller reaches the page fetch itself (onJumpToSeq threads
+   * the signal to the paginator), so the request ends at the transport instead of completing
+   * and swapping the window. Without the abort the landing was suppressed but the swap was
+   * not: the reader kept the viewport they scrolled to, holding a window centred somewhere
+   * they abandoned.
    */
   cancelPendingSeek: () => void
 }
@@ -70,7 +77,7 @@ export interface ChatSeekExtras {
   /** Refresh atBottom off a fresh DOM read (used when an out-of-window fetch fails). */
   checkAtBottom: () => void
   /** Replace the window with a page centered on `seq` (the out-of-window seek). */
-  onJumpToSeq: ((seq: bigint) => Promise<void> | void) | undefined
+  onJumpToSeq: ((seq: bigint, signal?: AbortSignal) => Promise<void> | void) | undefined
   /** Hand a hidden-mid-jump target to the SavedViewportScroll restore path. */
   onSaveViewportScroll: ((state: SavedViewportScroll) => void) | undefined
   /** Whether newer messages exist beyond the loaded window (windowed away from tail). */
@@ -81,10 +88,23 @@ export function createChatSeek(ctx: ScrollContext, extras: ChatSeekExtras): Chat
   // Pixels of breathing room left above the target row when landing on a seek.
   const SEEK_ALIGN_OFFSET_PX = 8
 
-  // The in-flight out-of-window seek, guarded by an epoch so a superseding jump / a genuine
-  // user scroll (which clears it via cancelPendingSeek) makes a late resolve a no-op.
-  let pendingSeek: { seq: bigint, epoch: number } | null = null
+  // The in-flight out-of-window seek. The epoch makes a late resolve a no-op; the controller
+  // makes the fetch behind it genuinely stop. Both are needed and they are not the same thing:
+  // the epoch is what THIS module checks before it lands, while the controller reaches the page
+  // fetch itself (onJumpToSeq threads it to the paginator's abort signal), so a seek nobody
+  // wants any more stops its round trip instead of completing and swapping the window.
+  let pendingSeek: { seq: bigint, epoch: number, controller: AbortController } | null = null
   let seekEpoch = 0
+
+  /**
+   * Abandon the in-flight out-of-window seek: stop its fetch and forget it, so neither the fetch
+   * nor this module's own landing can move the view. Used by the two ways a seek stops being
+   * wanted -- a superseding jump, and a caller giving up (cancelPendingSeek).
+   */
+  const abandonPendingSeek = () => {
+    pendingSeek?.controller.abort()
+    pendingSeek = null
+  }
 
   // The window's first/last SERVER seq (skipping seq-0n optimistic locals) come from the
   // shared chatMessageOrder helpers -- the same definition the rail's window bounds and the
@@ -169,7 +189,9 @@ export function createChatSeek(ctx: ScrollContext, extras: ChatSeekExtras): Chat
     // In-window: the seq sits within the loaded server span. Re-take control (clear the
     // per-window filler pause/settle/suppress flags, same as forceScrollToBottom) and land.
     if (firstS !== undefined && lastS !== undefined && seq >= firstS && seq <= lastS) {
-      pendingSeek = null
+      // This jump needs no fetch, but it still supersedes one already running: without the
+      // abort, that page would land afterwards and swap the window out from under this landing.
+      abandonPendingSeek()
       extras.retakeScrollControl()
       return Promise.resolve(landOnSeq(seq))
     }
@@ -184,9 +206,12 @@ export function createChatSeek(ctx: ScrollContext, extras: ChatSeekExtras): Chat
     if (ctx.isFollowing())
       extras.captureAnchor()
     ctx.setAtBottom(false)
+    // Supersede any seek already in flight -- abort its fetch, not just its landing.
+    abandonPendingSeek()
     const epoch = ++seekEpoch
-    pendingSeek = { seq, epoch }
-    return Promise.resolve(extras.onJumpToSeq?.(seq))
+    const controller = new AbortController()
+    pendingSeek = { seq, epoch, controller }
+    return Promise.resolve(extras.onJumpToSeq?.(seq, controller.signal))
       .then(() => {
         // Superseded by a newer jump, or cancelled by a genuine user scroll.
         if (pendingSeek?.epoch !== epoch)
@@ -227,7 +252,7 @@ export function createChatSeek(ctx: ScrollContext, extras: ChatSeekExtras): Chat
   }
 
   const cancelPendingSeek = () => {
-    pendingSeek = null
+    abandonPendingSeek()
   }
 
   return { jumpToSeq, previewScrollTo, cancelPendingSeek }

--- a/frontend/src/components/chat/composer/composer.css.ts
+++ b/frontend/src/components/chat/composer/composer.css.ts
@@ -98,8 +98,8 @@ export const axisChipLabel = style([clippedText, {
  * around items that carry their own padding.
  *
  * A popover whose content is a CARD does not belong here. It uses the shared
- * `popoverCard` class from `~/styles/popover.css`, which insets the content by
- * Oat's own card padding.
+ * `popoverCard` class from `~/styles/popover.css.ts`, which carries Oat's card
+ * surface and the compact inset every floating card shares.
  */
 const composerMenuPopover = style([popoverColumnClamp, {
   backgroundColor: 'var(--background)',
@@ -172,5 +172,5 @@ export const subPopover = style([composerMenuPopover, {
 
 // The `[+]` menu's "Agent info" submenu has no style here. Its content is a card
 // of labelled rows rather than a list of menu items, so it uses the shared
-// `popoverCard` class from `~/styles/popover.css` -- the same one the status
+// `popoverCard` class from `~/styles/popover.css.ts` -- the same one the status
 // bar's copy of that card uses, which is what keeps the two insets equal.

--- a/frontend/src/components/chat/useChatScroll.seek.test.ts
+++ b/frontend/src/components/chat/useChatScroll.seek.test.ts
@@ -118,7 +118,8 @@ describe('usechatscroll jump to seq', () => {
           hook.attachListRef(div.el)
 
           hook.jumpToSeq(5n)
-          expect(onJumpToSeq).toHaveBeenCalledWith(5n)
+          // The seq, plus the abort signal that lets a caller who gave up stop this fetch.
+          expect(onJumpToSeq).toHaveBeenCalledWith(5n, expect.any(AbortSignal))
 
           // Let the onJumpToSeq promise resolve, then the landing runs.
           await Promise.resolve()
@@ -277,6 +278,71 @@ describe('usechatscroll jump to seq', () => {
         }
       })
     }))
+
+  describe('abandoning an out-of-window seek aborts its fetch, not just its landing', () => {
+    // Suppressing the landing leaves the page fetch running, and that fetch SWAPS THE WINDOW on
+    // arrival. The reader then keeps the scroll position they took manual control of, while the
+    // loaded window is centred on a target they abandoned -- so the next scroll-up or edge fill
+    // pages around the wrong place. The signal is what actually stops it.
+
+    /** Stand up a hook whose out-of-window fetch never resolves, and capture its abort signal. */
+    function seekWithHeldFetch() {
+      const div = makeFakeScrollDiv()
+      div.setScrollHeight(5000)
+      div.setClientHeight(500)
+      div.setScrollTop(2500)
+      const [messages] = createSignal(mkMsgs([100, 101, 102, 103, 104]))
+      const [streamingText] = createSignal('')
+      const signals: (AbortSignal | undefined)[] = []
+      const onJumpToSeq = vi.fn((_seq: bigint, signal?: AbortSignal) => {
+        signals.push(signal)
+        return new Promise<void>(() => {}) // held: only an abort ends this seek
+      })
+      const hook = useChatScroll({
+        virtualizer: seekVirt(),
+        messages,
+        streamingText,
+        hasOlderMessages: () => true,
+        hasNewerMessages: () => false,
+        onJumpToSeq,
+      })
+      hook.attachListRef(div.el)
+      return { hook, signals, div }
+    }
+
+    it('aborts the fetch when cancelPendingSeek abandons the seek', () =>
+      createRoot((dispose) => {
+        const { hook, signals } = seekWithHeldFetch()
+        void hook.jumpToSeq(5n)
+        expect(signals[0]?.aborted).toBe(false)
+
+        hook.cancelPendingSeek()
+        expect(signals[0]?.aborted).toBe(true)
+        dispose()
+      }))
+
+    it('aborts the previous fetch when a newer out-of-window jump supersedes it', () =>
+      createRoot((dispose) => {
+        const { hook, signals } = seekWithHeldFetch()
+        void hook.jumpToSeq(5n)
+        void hook.jumpToSeq(9n)
+        // Two disjoint pages would otherwise race, and the loser could land last.
+        expect(signals[0]?.aborted).toBe(true)
+        expect(signals[1]?.aborted).toBe(false)
+        dispose()
+      }))
+
+    it('aborts a pending fetch when an IN-WINDOW jump supersedes it', () =>
+      createRoot((dispose) => {
+        const { hook, signals } = seekWithHeldFetch()
+        void hook.jumpToSeq(5n)
+        // 102 is inside the loaded span, so this jump lands at once and issues no fetch of its
+        // own -- but the running one must still stop, or its swap arrives after this landing.
+        void hook.jumpToSeq(102n)
+        expect(signals[0]?.aborted).toBe(true)
+        dispose()
+      }))
+  })
 
   it('previewScrollTo writes a clamped programmatic scroll for in-window drag', () =>
     createRoot((dispose) => {

--- a/frontend/src/components/chat/useChatScroll.ts
+++ b/frontend/src/components/chat/useChatScroll.ts
@@ -282,9 +282,11 @@ export interface PaginationCallbacks {
   onJumpToOldest?: () => Promise<void> | void
   /**
    * Replace the window with a page centered on `seq` (the scroll rail's out-of-window
-   * seek). Resolves once the window has been swapped, so the hook can land on the row.
+   * seek). Resolves once the window swapped, so the hook can land on the row. `signal`
+   * abandons the fetch: the seek that issued it gave up (see ChatSeek.cancelPendingSeek),
+   * so the page must not arrive and swap the window under a reader who moved on.
    */
-  onJumpToSeq?: (seq: bigint) => Promise<void> | void
+  onJumpToSeq?: (seq: bigint, signal?: AbortSignal) => Promise<void> | void
   /**
    * Cap the in-memory window on a live-tail append. `minKeepNewest` is the count of
    * newest messages the trim must retain to leave a scrolled-up reader's viewport
@@ -373,8 +375,9 @@ export interface UseChatScrollResult {
    */
   previewScrollTo: (top: number) => void
   /**
-   * Abandon any in-flight out-of-window seek (rail thumb re-grab): its late fetch must
-   * not yank the viewport after the user has taken manual control of the thumb.
+   * Abandon any in-flight out-of-window seek (a rail gesture that moved on, or a genuine
+   * user scroll): its fetch is aborted and its landing dropped, so neither the page nor
+   * the scroll can arrive after the user took manual control.
    */
   cancelPendingSeek: () => void
   /**

--- a/frontend/src/components/common/Tooltip.css.ts
+++ b/frontend/src/components/common/Tooltip.css.ts
@@ -1,10 +1,14 @@
 import { style } from '@vanilla-extract/css'
+import { floatingCardSurface } from '~/styles/popover.css'
 
-export const tooltip = style({
+// The fill, border, radius, inset, shadow and line height come from `floatingCardSurface` in
+// `~/styles/popover.css.ts` -- the same class the chat rail's preview card carries, so the app's
+// two floating surfaces cannot drift apart again. Only what is genuinely a TOOLTIP's own is left
+// here: where it sits, how wide it grows, how its text wraps, and that it never takes a pointer.
+export const tooltip = style([floatingCardSurface, {
   position: 'fixed',
   margin: 0,
   inset: 'unset',
-  padding: 'var(--space-2) var(--space-3)',
   fontSize: 'var(--text-8)',
   // Short button labels stay one line; long content (e.g. Claude
   // TaskCreate descriptions) soft-wraps at `maxWidth`. We need to
@@ -15,13 +19,7 @@ export const tooltip = style({
   // preferred size and lets `max-width` clamp it.
   width: 'max-content',
   maxWidth: 'min(28rem, calc(100vw - var(--space-4)))',
-  lineHeight: 1.4,
   whiteSpace: 'normal',
   overflowWrap: 'anywhere',
-  background: 'var(--card)',
-  color: 'var(--foreground)',
-  border: '1px solid var(--border)',
-  borderRadius: 'var(--radius-medium)',
-  boxShadow: '0 2px 8px rgba(0, 0, 0, 0.15)',
   pointerEvents: 'none',
-})
+}])

--- a/frontend/src/components/shell/TileRenderer.tsx
+++ b/frontend/src/components/shell/TileRenderer.tsx
@@ -828,7 +828,7 @@ export function createTileRenderer(opts: TileRendererOpts) {
                       onLoadNewerMessages: () => chatStore.loadNewerPage(agent()?.workerId ?? '', agentId),
                       onJumpToLatest: () => chatStore.jumpToLatestMessages(agent()?.workerId ?? '', agentId),
                       onJumpToOldest: () => chatStore.jumpToOldestMessages(agent()?.workerId ?? '', agentId),
-                      onJumpToSeq: seq => chatStore.jumpToMessagesAroundSeq(agent()?.workerId ?? '', agentId, seq),
+                      onJumpToSeq: (seq, signal) => chatStore.jumpToMessagesAroundSeq(agent()?.workerId ?? '', agentId, seq, signal),
                     }}
                     rail={railProps()}
                     savedViewportScroll={chatStore.viewportScroll.get(agentId)}

--- a/frontend/src/stores/chatHistoryPaginator.test.ts
+++ b/frontend/src/stores/chatHistoryPaginator.test.ts
@@ -217,8 +217,8 @@ describe('chathistorypaginator', () => {
       await h.paginator.jumpToMessagesAroundSeq('w', 'a', 5n)
 
       // Cursor values: BEFORE is exclusive at seq+1 (includes the target), AFTER at seq.
-      expect(listAgentMessages).toHaveBeenCalledWith('w', expect.objectContaining({ anchor: MessagePageAnchor.BEFORE, cursorSeq: 6n }))
-      expect(listAgentMessages).toHaveBeenCalledWith('w', expect.objectContaining({ anchor: MessagePageAnchor.AFTER, cursorSeq: 5n }))
+      expect(listAgentMessages).toHaveBeenCalledWith('w', expect.objectContaining({ anchor: MessagePageAnchor.BEFORE, cursorSeq: 6n }), expect.anything())
+      expect(listAgentMessages).toHaveBeenCalledWith('w', expect.objectContaining({ anchor: MessagePageAnchor.AFTER, cursorSeq: 5n }), expect.anything())
       // One window swap with the disjoint, ascending concatenation; hasMoreOlder from before.
       expect(h.applyMessages).toHaveBeenCalledWith('a', [makeMsg(4n), makeMsg(5n), makeMsg(6n), makeMsg(7n)], true)
       // after.hasMore=false and caughtUp -> no newer.
@@ -238,15 +238,15 @@ describe('chathistorypaginator', () => {
       expect(listAgentMessages).toHaveBeenCalledWith('w', expect.objectContaining({
         anchor: MessagePageAnchor.LATEST,
         limit: MESSAGE_PAGE_SIZE,
-      }))
+      }), expect.anything())
       expect(listAgentMessages).toHaveBeenCalledWith('w', expect.objectContaining({
         anchor: MessagePageAnchor.AFTER,
         cursorSeq: maxInt64Seq,
         limit: MESSAGE_PAGE_SIZE,
-      }))
+      }), expect.anything())
       expect(listAgentMessages).not.toHaveBeenCalledWith('w', expect.objectContaining({
         cursorSeq: maxInt64Seq + 1n,
-      }))
+      }), expect.anything())
       expect(h.applyMessages).toHaveBeenCalledWith('a', [makeMsg(maxInt64Seq)], true)
       expect(h.state.hasMoreNewer.a).toBe(false)
     })
@@ -270,6 +270,54 @@ describe('chathistorypaginator', () => {
 
       // hasMoreOlder from before.hasMore=false (nothing older survives).
       expect(h.applyMessages).toHaveBeenCalledWith('a', [makeMsg(8n), makeMsg(9n)], false)
+    })
+
+    it('carries the watch signal to BOTH page requests, so a caller can abort the round trip', async () => {
+      // The seek that asked for this page can give up mid-flight (the rail's scrub moves on).
+      // Suppressing its landing is not enough: the fetch would still arrive and SWAP THE
+      // WINDOW, leaving the reader's own scroll position over a window centred somewhere they
+      // abandoned. The signal has to reach the transport.
+      const h = harness({ messages: [makeMsg(1n)], caughtUp: () => true })
+      const watch = new AbortController()
+      // Hold both pages in flight, so the abort lands while the requests are still open --
+      // which is the only moment aborting them means anything.
+      let releaseBefore: (() => void) | undefined
+      listAgentMessages.mockImplementation((_w: string, req: { anchor: number }) =>
+        req.anchor === MessagePageAnchor.BEFORE
+          ? new Promise((resolve) => {
+              releaseBefore = () => resolve(page([makeMsg(5n)], false))
+            })
+          : Promise.resolve(page([makeMsg(6n)], false)))
+
+      const jump = h.paginator.jumpToMessagesAroundSeq('w', 'a', 5n, watch.signal)
+      await Promise.resolve()
+
+      const signals = listAgentMessages.mock.calls.map((call: unknown[]) => (call[2] as { signal?: AbortSignal } | undefined)?.signal)
+      expect(signals).toHaveLength(2)
+      expect(signals.every((sig?: AbortSignal) => sig !== undefined)).toBe(true)
+      expect(signals.some((sig?: AbortSignal) => sig?.aborted === true)).toBe(false)
+
+      // The caller gives up: every request it opened is aborted, not merely ignored.
+      watch.abort()
+      expect(signals.every((sig?: AbortSignal) => sig?.aborted === true)).toBe(true)
+
+      releaseBefore?.()
+      await jump
+      expect(h.applyMessages).not.toHaveBeenCalled() // and nothing swaps the window afterwards
+    })
+
+    it('leaves the window untouched when the fetch rejects because it was aborted', async () => {
+      // An abort is how this fetch is designed to end early, so it must not read as a failure
+      // and must not disturb the window the reader is looking at.
+      const h = harness({ messages: [makeMsg(1n)], caughtUp: () => true })
+      const watch = new AbortController()
+      listAgentMessages.mockImplementation(async () => {
+        watch.abort()
+        throw new DOMException('aborted', 'AbortError')
+      })
+
+      await expect(h.paginator.jumpToMessagesAroundSeq('w', 'a', 5n, watch.signal)).resolves.toBeUndefined()
+      expect(h.applyMessages).not.toHaveBeenCalled()
     })
 
     it('empties the window and resets a stale tail when the history vanished around the seq', async () => {

--- a/frontend/src/stores/chatHistoryPaginator.ts
+++ b/frontend/src/stores/chatHistoryPaginator.ts
@@ -728,7 +728,7 @@ export function createHistoryPaginator(deps: HistoryPaginatorDeps) {
    * the surviving oldest/newest rows. Both empty means the history genuinely vanished
    * (mirrors jumpToLatestMessages' authoritative-empty reset).
    */
-  async function jumpToMessagesAroundSeq(workerId: string, agentId: string, seq: bigint): Promise<void> {
+  async function jumpToMessagesAroundSeq(workerId: string, agentId: string, seq: bigint, watchSignal?: AbortSignal): Promise<void> {
     await deps.runHistoryFetch(agentId, 'fetchingNewer', async (signal) => {
       // Snapshot the recorded live tail before the swap: a message broadcast DURING the
       // fetch raises it past this, and hasMoreNewer/resetToEmptyIfStale must respect that.
@@ -736,10 +736,25 @@ export function createHistoryPaginator(deps: HistoryPaginatorDeps) {
       const beforeRequest = seq >= MAX_INT64_SEQ
         ? { agentId, anchor: MessagePageAnchor.LATEST, limit: MESSAGE_PAGE_SIZE }
         : { agentId, anchor: MessagePageAnchor.BEFORE, cursorSeq: seq + 1n, limit: MESSAGE_PAGE_SIZE }
-      const [before, after] = await Promise.all([
-        listAgentMessages(workerId, beforeRequest),
-        listAgentMessages(workerId, { agentId, anchor: MessagePageAnchor.AFTER, cursorSeq: seq, limit: MESSAGE_PAGE_SIZE }),
-      ])
+      // Both requests carry `signal`, so an abort ends them at the transport rather than only
+      // discarding what they return. That is what makes a seek genuinely abandonable: the caller
+      // that gave up (the rail, when its scrub leaves this target) stops the round trip instead
+      // of paying for a page it will throw away.
+      let before, after
+      try {
+        [before, after] = await Promise.all([
+          listAgentMessages(workerId, beforeRequest, { signal }),
+          listAgentMessages(workerId, { agentId, anchor: MessagePageAnchor.AFTER, cursorSeq: seq, limit: MESSAGE_PAGE_SIZE }, { signal }),
+        ])
+      }
+      catch (err) {
+        // An abort is how this fetch is DESIGNED to end early -- a superseding jump, or a caller
+        // abandoning its seek -- so it is not a failure to report. Leave the window untouched,
+        // exactly as the aborted-after-resolve path below does.
+        if (signal.aborted)
+          return
+        throw err
+      }
       if (signal.aborted)
         return
       const rows = [...before.messages, ...after.messages]
@@ -758,7 +773,7 @@ export function createHistoryPaginator(deps: HistoryPaginatorDeps) {
       // !caughtUpToLiveTail term (mirroring loadNewerPage) covers a live message that
       // bumped the recorded tail during the fetch, so the window can't claim the tail.
       setState('hasMoreNewer', agentId, after.hasMore || !deps.caughtUpToLiveTail(agentId))
-    })
+    }, watchSignal)
   }
 
   return {

--- a/frontend/src/styles/global.css.ts
+++ b/frontend/src/styles/global.css.ts
@@ -97,17 +97,23 @@ globalStyle('body', {
 // is dispatched below that layer. `touch-action: none` on html+body
 // refuses the pan gesture entirely at the page level.
 //
-// Inner scroll regions still pan, and need NO opt-in to: the browser
-// resolves a touch's allowed behaviour against the ancestors up to the
-// element that will handle the gesture, which for a touch inside the
-// chat list is that list, not the page. So a nested `overflow: auto`
-// region — the message list, a code block that scrolls sideways — keeps
-// its own pan. Setting `touch-action` on those regions would only take
-// panning away (`pan-y` on the message list would freeze the horizontal
-// scroll of every code block and table inside it), so none of them does.
-// The one element that DOES set it sets it to refuse: the scroll rail
-// (`touchAction: 'none'`, see ~/components/chat/ChatScrollRail.css.ts),
-// so a finger dragging its thumb scrubs instead of panning the list.
+// A nested scroll region still pans: the browser resolves a touch's
+// allowed behaviour against the ancestors up to the element that handles
+// the gesture, which for a touch inside the chat list is that list, not
+// the page. So the message list needs no opt-in, and it sets none —
+// `pan-y` there would freeze the sideways scroll of every code block and
+// table inside it, because a `touch-action` on an ANCESTOR restricts a
+// descendant scroller.
+//
+// That is the rule for the whole app: a region declares `touch-action`
+// only to constrain a gesture it owns, never to re-enable one. Three do.
+// Two refuse a gesture — the scroll rail (`touchAction: 'none'`, see
+// ~/components/chat/ChatScrollRail.css.ts), so a finger dragging its
+// thumb scrubs instead of panning the list, and the tiling separator
+// (see ~/components/shell/TilingLayout.css.ts), so a drag resizes the
+// pane instead of scrolling. One narrows a gesture to the single axis it
+// scrolls: the tab strip (`touchAction: 'pan-x'`, see
+// ~/components/shell/TabBar.css.ts).
 globalStyle('html, body', {
   overscrollBehavior: 'none',
   touchAction: 'none',

--- a/frontend/src/styles/global.css.ts
+++ b/frontend/src/styles/global.css.ts
@@ -95,8 +95,19 @@ globalStyle('body', {
 // Kill iOS Safari's rubber-band overscroll on the page itself.
 // `overscroll-behavior` alone isn't enough on iOS WebKit — the bounce
 // is dispatched below that layer. `touch-action: none` on html+body
-// refuses the pan gesture entirely at the page level; inner scroll
-// regions opt back in (e.g. messageList → `pan-y`).
+// refuses the pan gesture entirely at the page level.
+//
+// Inner scroll regions still pan, and need NO opt-in to: the browser
+// resolves a touch's allowed behaviour against the ancestors up to the
+// element that will handle the gesture, which for a touch inside the
+// chat list is that list, not the page. So a nested `overflow: auto`
+// region — the message list, a code block that scrolls sideways — keeps
+// its own pan. Setting `touch-action` on those regions would only take
+// panning away (`pan-y` on the message list would freeze the horizontal
+// scroll of every code block and table inside it), so none of them does.
+// The one element that DOES set it sets it to refuse: the scroll rail
+// (`touchAction: 'none'`, see ~/components/chat/ChatScrollRail.css.ts),
+// so a finger dragging its thumb scrubs instead of panning the list.
 globalStyle('html, body', {
   overscrollBehavior: 'none',
   touchAction: 'none',

--- a/frontend/src/styles/popover.css.test.ts
+++ b/frontend/src/styles/popover.css.test.ts
@@ -1,27 +1,74 @@
 import { describe, expect, it } from 'vitest'
-import { popoverBase, popoverCard } from '~/styles/popover.css'
+import { previewCard } from '~/components/chat/ChatScrollRail.css'
+import { tooltip } from '~/components/common/Tooltip.css'
+import { floatingCardSurface, popoverBase, popoverCard, popoverCardPadding } from '~/styles/popover.css'
+import { POPOVER_CARD_PADDING } from '~/styles/popoverTokens'
 
 describe('popoverCard', () => {
-  it('carries Oat\'s own card class, which is where the inset comes from', () => {
-    // The padding is NOT declared here: Oat's `card` rule sets it
-    // (`var(--space-6)` on each side), so every card popover follows Oat and
-    // two surfaces of the same card cannot inset their content differently.
+  it('carries Oat\'s own card class, which is where the surface comes from', () => {
+    // Background, border, radius and shadow are NOT declared here: Oat's `card`
+    // rule sets them, so every card popover follows Oat and two surfaces of the
+    // same card cannot look different.
     //
     // Nothing else catches a dropped `card`. jsdom loads no Oat stylesheet, so
-    // no component test can see padding at all, and the surviving class still
-    // positions the popover correctly -- the cards would simply lose their inset
-    // on a real page, which only the e2e run measures.
+    // no component test can see the surface at all, and the surviving classes
+    // still position the popover correctly -- the cards would simply lose their
+    // background on a real page, which only the e2e run measures.
     expect(popoverCard.split(' ')).toContain('card')
+  })
+
+  it('carries the compact inset, which Oat\'s card padding is NOT the source of', () => {
+    // Oat pads a card by var(--space-6), which is right for a card that fills the
+    // page (the auth forms) and too much for one that opens over the reader's
+    // work. This class is what overrides it, and it is shared with the chat
+    // rail's preview card so the two cannot drift.
+    expect(popoverCard.split(' ')).toContain(popoverCardPadding)
   })
 
   it('carries the positioning reset too, so a call site needs no second class', () => {
     // vanilla-extract emits every composed class, so the list is: Oat's `card`,
-    // popoverBase, and the layout class that composes it. popoverBase is what
-    // resets the UA popover defaults and stops a CLOSED popover from swallowing
-    // the next click, and a bare `card` popover had neither -- which is the
-    // second half of what applying this class whole buys.
+    // popoverBase, the layout class that composes it, and the padding class.
+    // popoverBase is what resets the UA popover defaults and stops a CLOSED
+    // popover from swallowing the next click, and a bare `card` popover had
+    // neither -- which is the second half of what applying this class whole buys.
     const classes = popoverCard.split(' ')
     expect(classes).toContain(popoverBase)
-    expect(classes).toHaveLength(3)
+    expect(classes).toHaveLength(4)
+  })
+})
+
+describe('floatingCardSurface', () => {
+  it('takes Oat\'s card fill, border and radius rather than restating them', () => {
+    // The whole point of the class: a floating card FOLLOWS Oat's card, so it cannot end up
+    // painted a different colour from every other card in the app. That is not hypothetical --
+    // the rail's preview card filled var(--background) while the tooltip filled var(--card),
+    // which is the drift this class exists to make impossible.
+    expect(floatingCardSurface.split(' ')).toContain('card')
+  })
+
+  it('takes the compact inset, not Oat\'s page-card padding', () => {
+    expect(floatingCardSurface.split(' ')).toContain(popoverCardPadding)
+  })
+
+  it('is the surface BOTH floating surfaces in the app carry', () => {
+    // A tooltip and the chat rail's preview card are the same kind of thing -- a small surface
+    // that opens over the reader's work -- and each used to write the fill, border, radius,
+    // shadow, inset and line height out for itself. jsdom loads no Oat stylesheet, so the class
+    // list is the only thing a unit test can see; the resolved pixels are e2e territory.
+    //
+    // Compared token by token: vanilla-extract FLATTENS a composed class into the consumer's own
+    // list, so the composite arrives as several class names and never as one string to match.
+    const surface = floatingCardSurface.split(' ')
+    expect(tooltip.split(' ')).toEqual(expect.arrayContaining(surface))
+    expect(previewCard.split(' ')).toEqual(expect.arrayContaining(surface))
+  })
+})
+
+describe('popoverCardPadding', () => {
+  it('is built from the plain token the e2e run also reads', () => {
+    // The value lives in a plain `.ts` file because Playwright cannot import a `.css.ts` module,
+    // and the e2e spec measures this inset. If the spec restated the declaration instead, a
+    // legitimate change to the inset would fail the spec while the app stayed correct.
+    expect(POPOVER_CARD_PADDING).toBe('var(--space-2) var(--space-3)')
   })
 })

--- a/frontend/src/styles/popover.css.ts
+++ b/frontend/src/styles/popover.css.ts
@@ -1,4 +1,5 @@
 import { style } from '@vanilla-extract/css'
+import { POPOVER_CARD_PADDING } from '~/styles/popoverTokens'
 
 /**
  * The base class a `popover="auto"` element needs when it is positioned by JS (an
@@ -65,18 +66,67 @@ export const popoverColumnClamp = style([popoverBase, {
 }])
 
 /**
+ * The inset a card gives its content when it FLOATS over the reader's work.
+ *
+ * Oat's own `card` rule pads by `var(--space-6)` on each side. That suits a card that IS the
+ * page -- the login, signup, and setup forms, which fill a centred column and are the only
+ * thing on screen. It is too much for a card that opens OVER that work. The reader takes a
+ * popover in at a glance and dismisses it, and a 24px edge on each side pushes its rows apart
+ * and its content toward the edge of the screen. So a floating card takes the compact inset
+ * instead: the one the chat rail's message-preview card already used.
+ *
+ * Declared as its own class, not folded into `popoverColumnClamp`, because that class also
+ * carries the composer's MENU popovers, whose items pad themselves.
+ *
+ * It beats Oat's padding by LAYER, not by specificity -- the two selectors are both (0,1,0), so
+ * specificity ties. Oat declares `@layer theme,base,components,animations,utilities` and puts
+ * `.card` in `components`; this class is unlayered, and unlayered author CSS outranks every
+ * author layer. `~/styles/global.css.ts` records the same mechanic for the menu-item rules.
+ *
+ * The value itself lives in `~/styles/popoverTokens.ts`, a plain `.ts` file, because the e2e run
+ * measures this inset and Playwright cannot import a `.css.ts` module. One declaration, two
+ * readers, no restatement to drift.
+ */
+export const popoverCardPadding = style({
+  padding: POPOVER_CARD_PADDING,
+})
+
+/**
+ * The whole surface of a card that FLOATS over the reader's work: Oat's card fill, border and
+ * radius, the compact inset above, and the lift that separates it from the page.
+ *
+ * One class, because the app kept re-deriving this surface by hand and the copies drifted. The
+ * chat rail's preview card and `~/components/common/Tooltip.css.ts` each wrote out the same
+ * border, radius, shadow, colour, line height and inset -- and disagreed on the one that matters
+ * most: the tooltip filled `var(--card)` while the rail's card filled `var(--background)`, so the
+ * only floating surface in the app painted the page colour was separated from the transcript
+ * behind it by a 1px border alone. That is hardest to see in dark theme, where the two tokens are
+ * a shade apart.
+ *
+ * The shadow is NOT Oat's `--shadow-small`. That token is the subtle lift of a card sitting IN the
+ * page; a card floating OVER it needs a shadow the reader reads as depth, which is the value both
+ * hand-rolled copies had already converged on.
+ *
+ * Composes Oat's `card` as a plain class name (vanilla-extract accepts one in a style list), so
+ * the fill, the border and the radius follow Oat rather than being restated here.
+ */
+export const floatingCardSurface = style(['card', popoverCardPadding, {
+  boxShadow: '0 2px 8px rgba(0, 0, 0, 0.15)',
+  lineHeight: 1.4,
+}])
+
+/**
  * The class list for a popover whose content is a CARD -- labelled rows, a list,
  * a panel -- and not a list of menu items. Apply it whole:
  * `<DropdownMenu as="div" class={popoverCard}>`.
  *
- * It is a class LIST, and both parts are load-bearing. Oat's own `card` rule
- * supplies the inset (`var(--space-6)` on each side), so every card popover uses
- * the standard card padding and follows Oat if that value changes -- two
- * surfaces of the SAME card cannot drift apart, which is what the agent-info
- * card did while each call site set its own padding. `popoverColumnClamp` adds
- * what a popover needs on top of a card: the positioning reset and the viewport
- * clamp.
+ * It is a class LIST, and every part is load-bearing. Oat's own `card` rule supplies the
+ * surface (background, border, radius, shadow). `popoverCardPadding` supplies the inset, so
+ * every card popover insets its content the same way -- two surfaces of the SAME card cannot
+ * drift apart, which is what the agent-info card did while each call site set its own padding.
+ * `popoverColumnClamp` adds what a popover needs on top of a card: the positioning reset and
+ * the viewport clamp.
  *
  * Exported as one string so that no call site can apply half of it.
  */
-export const popoverCard = `card ${popoverColumnClamp}`
+export const popoverCard = `card ${popoverColumnClamp} ${popoverCardPadding}`

--- a/frontend/src/styles/popoverTokens.ts
+++ b/frontend/src/styles/popoverTokens.ts
@@ -1,0 +1,13 @@
+// The popover-card inset, as plain data.
+//
+// Two consumers need this value and only one of them can execute CSS: `~/styles/popover.css.ts`
+// declares it as `popoverCardPadding`, and `tests/e2e/036-dropdown-popover.spec.ts` measures the
+// resolved pixels through a page-side probe. Playwright runs no Vite and no vanilla-extract, so a
+// spec that imports a `.css.ts` module fails with "Styles were unable to be assigned to a file"
+// -- hence a plain `.ts` file with no imports, which both sides can read. Same reason
+// `~/styles/palette.ts` exists.
+//
+// Without it the spec has to restate the declaration, and then a legitimate change to the inset
+// fails the spec while the app is correct and consistent -- pointing at the popovers instead of at
+// the copy that nobody updated.
+export const POPOVER_CARD_PADDING = 'var(--space-2) var(--space-3)'

--- a/frontend/tests/e2e/036-dropdown-popover.spec.ts
+++ b/frontend/tests/e2e/036-dropdown-popover.spec.ts
@@ -1,4 +1,5 @@
 import type { Locator } from '@playwright/test'
+import { POPOVER_CARD_PADDING } from '../../src/styles/popoverTokens'
 import { expect, test } from './fixtures'
 import { ARITHMETIC_ANSWER, ARITHMETIC_PROMPT, assistantBubbles, closeComposerMenus, expectAssistantAnswer, openAgentViaUI, openPlusMenu, sendMessage, waitForAgentIdle } from './helpers/ui'
 
@@ -321,25 +322,36 @@ function readPadding(el: Element): string {
 }
 
 /**
- * Oat's own inset for a card, read from a throwaway element that carries its
- * `card` class.
+ * Both insets a card can take, measured from throwaway elements: Oat's own (which a card that
+ * FILLS the page, like the auth forms, still uses) and the compact one a FLOATING card takes.
  *
- * Measured rather than written down: the card popovers are supposed to FOLLOW
- * Oat's card padding, so a literal `24px` here would keep passing on the day Oat
- * changes it and the two surfaces silently stop matching the rest of the app.
+ * Measured rather than written down as `24px` and `8px 12px`, because every half comes from Oat's
+ * spacing scale -- a literal would keep passing on the day that scale changes and the cards
+ * silently stop matching the rest of the app. The compact inset arrives as an ARGUMENT, from
+ * `~/styles/popoverTokens.ts`, which `popover.css.ts` also reads: Playwright runs no
+ * vanilla-extract, so the spec cannot import the class, but it can import the plain value the
+ * class is built from, and then there is no second copy to drift.
  *
- * Runs inside the page, so it must not close over anything in this file.
+ * ONE function for both probes, with its `read` helper defined INSIDE it: Playwright serializes
+ * this function into the page, so it must not close over anything in this file -- which also rules
+ * out passing `read` in, because a function argument is not serializable either.
  */
-function resolveOatCardPadding(): string {
-  const probe = document.createElement('div')
-  probe.className = 'card'
-  document.body.append(probe)
-  try {
-    const style = getComputedStyle(probe)
-    return [style.paddingTop, style.paddingRight, style.paddingBottom, style.paddingLeft].join(' ')
+function resolveCardPaddings(popoverPadding: string): { oat: string, popover: string } {
+  const read = (configure: (el: HTMLElement) => void): string => {
+    const probe = document.createElement('div')
+    configure(probe)
+    document.body.append(probe)
+    try {
+      const style = getComputedStyle(probe)
+      return [style.paddingTop, style.paddingRight, style.paddingBottom, style.paddingLeft].join(' ')
+    }
+    finally {
+      probe.remove()
+    }
   }
-  finally {
-    probe.remove()
+  return {
+    oat: read((el) => { el.className = 'card' }),
+    popover: read((el) => { el.style.padding = popoverPadding }),
   }
 }
 
@@ -350,7 +362,7 @@ test.describe('agent info card', () => {
    * inset those rows differently for as long as each call site sets its own
    * padding, which is what this asserts against.
    */
-  test('both surfaces inset the card by Oat\'s card padding', async ({ page, authenticatedWorkspace }) => {
+  test('both surfaces inset the card by the shared popover-card padding', async ({ page, authenticatedWorkspace }) => {
     await openAgentViaUI(page)
     await sendMessage(page, ARITHMETIC_PROMPT)
     await expectAssistantAnswer(page)
@@ -373,9 +385,29 @@ test.describe('agent info card', () => {
     await expect(plusMenuCard).toBeVisible()
     const plusMenuPadding = await plusMenuCard.evaluate(readPadding)
 
-    const oatCardPadding = await page.evaluate(resolveOatCardPadding)
-    expect(statusBarPadding, 'the status bar\'s card must use Oat\'s card padding').toBe(oatCardPadding)
-    expect(plusMenuPadding, 'the `[+]` menu\'s card must use Oat\'s card padding').toBe(oatCardPadding)
+    const padding = await page.evaluate(resolveCardPaddings, POPOVER_CARD_PADDING)
+    expect(statusBarPadding, 'the status bar\'s card must use the popover-card padding').toBe(padding.popover)
+    expect(plusMenuPadding, 'the `[+]` menu\'s card must use the popover-card padding').toBe(padding.popover)
+
+    // The override reaches the card at all. It wins by LAYER, not by specificity: both
+    // selectors are (0,1,0), so a tie would be decided by stylesheet order alone. If the
+    // unlayered class ever stopped outranking Oat's `components` layer, the cards would
+    // quietly fall back to the generous page-card inset, and the two assertions above would
+    // still pass together.
+    expect(statusBarPadding, 'a floating card must NOT keep Oat\'s page-card inset').not.toBe(padding.oat)
+
+    // ...and Oat's `card` class still reaches it, which nothing above can see anymore. The inset
+    // used to BE the proof: it came from Oat, so a card that lost the class lost the padding with
+    // it. The unlayered override now supplies that padding on its own, so a popover stripped of
+    // `card` would render as a transparent, border-less block over the transcript and every
+    // assertion above would still pass. Measure what only Oat supplies instead.
+    const cardSurface = await statusBarCard.evaluate((el) => {
+      const style = getComputedStyle(el)
+      return { background: style.backgroundColor, border: style.borderTopWidth, shadow: style.boxShadow }
+    })
+    expect(cardSurface.background, 'a card popover must paint Oat\'s card background').not.toBe('rgba(0, 0, 0, 0)')
+    expect(cardSurface.border, 'a card popover must carry Oat\'s card border').not.toBe('0px')
+    expect(cardSurface.shadow, 'a card popover must carry Oat\'s card shadow').not.toBe('none')
   })
 
   /**

--- a/frontend/tests/e2e/047-chat-scroll-rail.spec.ts
+++ b/frontend/tests/e2e/047-chat-scroll-rail.spec.ts
@@ -16,6 +16,13 @@ import { sendMessage, USER_BUBBLE_SELECTOR, userBubbles, waitForAgentIdle } from
 // overflow the short viewport below -- otherwise the rail correctly hides itself.
 const LONG_MESSAGE = `Please just reply with "ok". Ignore this filler: ${'the quick brown fox jumps over the lazy dog. '.repeat(12)}`
 
+/**
+ * How long to rest on the preview card before checking that it is still there. Comfortably
+ * longer than POINTER_CLOSE_DELAY_MS, so a card that ignored the pointer would already be gone.
+ * A fixed wait is the only way to assert that something does NOT happen within a window.
+ */
+const POPOVER_LINGER_MS = 1000
+
 /** The virtual row wrapper (carries data-seq) for the Nth user message bubble. */
 function userRow(page: Page, nth: number) {
   return page
@@ -71,7 +78,46 @@ test.describe('chat scroll rail', () => {
     // message text begins with a fixed phrase, so the preview (extracted + truncated on the
     // client) must contain it.
     await page.locator(`[data-testid="chat-scroll-rail-dot"][data-seq="${firstUserSeq}"]`).hover()
-    await expect(page.locator('[data-testid="chat-scroll-rail-preview"]')).toContainText('Please just reply with "ok"')
+    const preview = page.locator('[data-testid="chat-scroll-rail-preview"]')
+    await expect(preview).toContainText('Please just reply with "ok"')
+
+    // The card is a place the reader can GO: the pointer leaves the dot, crosses the gutter, and
+    // lands on the card, which then stays for as long as the pointer rests on it. Only a real
+    // browser covers this -- it needs the card's pointer-events (a media query jsdom never
+    // evaluates) and a hit-test that reaches it. See POINTER_CLOSE_DELAY_MS.
+    const previewBox = await preview.boundingBox()
+    expect(previewBox).not.toBeNull()
+    await page.mouse.move(previewBox!.x + previewBox!.width / 2, previewBox!.y + previewBox!.height / 2)
+    await page.waitForTimeout(POPOVER_LINGER_MS)
+    await expect(preview).toBeVisible()
+    // And its text is selectable, although the rail around it sets user-select: none so a thumb
+    // drag never selects anything.
+    await expect(preview).toHaveCSS('user-select', 'text')
+
+    // A real drag-select inside the card, ending OUTSIDE it -- what selecting to the end of a line
+    // does, because the card's right edge is only a gutter away from the rail. The card must
+    // outlive that release, and the selection must survive with it. Only a real browser has a
+    // selection engine, so nothing but this run covers it. The drag starts inside the first line
+    // of text (past the card's own inset) and ends just past the right edge, which is still on
+    // screen -- a release beyond the viewport would extend no selection at all.
+    await page.mouse.move(previewBox!.x + 12, previewBox!.y + 14)
+    await page.mouse.down()
+    await page.mouse.move(previewBox!.x + previewBox!.width + 4, previewBox!.y + 14, { steps: 10 })
+    await page.mouse.up()
+    const selected = await page.evaluate(() => document.getSelection()?.toString() ?? '')
+    expect(selected.length, 'the drag must leave a selection the reader can copy').toBeGreaterThan(0)
+    await page.waitForTimeout(POPOVER_LINGER_MS)
+    await expect(preview).toBeVisible()
+
+    // The reader's next click collapses that selection, and the card lets go with it.
+    await page.mouse.click(previewBox!.x - 200, previewBox!.y)
+    await expect(preview).toHaveCount(0)
+
+    // Moving away closes it (after the same delay), so it is a card the reader visits, not a panel.
+    await page.locator(`[data-testid="chat-scroll-rail-dot"][data-seq="${firstUserSeq}"]`).hover()
+    await expect(preview).toBeVisible()
+    await page.mouse.move(previewBox!.x - 200, previewBox!.y)
+    await expect(preview).toHaveCount(0)
 
     // The thumb is sized to the viewport's share of the conversation, not the whole rail.
     const railBox = await rail.boundingBox()

--- a/frontend/tests/e2e/047b-chat-scroll-rail-autohide.spec.ts
+++ b/frontend/tests/e2e/047b-chat-scroll-rail-autohide.spec.ts
@@ -1,5 +1,5 @@
-import { devices } from '@playwright/test'
 import { expect, test } from './fixtures'
+import { COARSE_POINTER_METRICS } from './helpers/touch'
 import { sendMessage, userBubbles, waitForAgentIdle } from './helpers/ui'
 
 /**
@@ -26,21 +26,6 @@ const LONG_MESSAGE = `Please just reply with "ok". Ignore this filler: ${'the qu
 
 const RAIL = '[data-testid="chat-scroll-rail"]'
 const SCROLLER = '[data-chat-scroll-container="true"]'
-
-/**
- * Pixel 7's device metrics WITHOUT its `defaultBrowserType`, and with a shorter viewport.
- * Playwright refuses a `defaultBrowserType` inside a describe group -- it would force a new
- * worker -- and this suite's only project is already chromium, so the field is both unusable
- * and redundant. The rest is what actually gives Blink a COARSE primary pointer. The height
- * is cut from the device's 915px to 047's 380px: the device is narrower than 720px, so its
- * lines wrap more and one seeded message still overflows comfortably.
- */
-const PIXEL_7_METRICS = {
-  viewport: { width: devices['Pixel 7'].viewport.width, height: 380 },
-  deviceScaleFactor: devices['Pixel 7'].deviceScaleFactor,
-  isMobile: devices['Pixel 7'].isMobile,
-  hasTouch: devices['Pixel 7'].hasTouch,
-} as const
 
 /**
  * Send one tall message so the conversation overflows and the rail takes over scrolling.
@@ -180,13 +165,11 @@ test.describe('chat scroll rail auto-hide', () => {
     await expect.poll(async () => await scroller.evaluate((el: HTMLElement) => el.scrollTop)).toBeGreaterThan(0)
   })
 
-  // Device-metrics emulation is the only way to get `(pointer: coarse)`: Blink derives the
-  // primary pointer type from the mobile viewport, not from `hasTouch`, so a project that
-  // only set hasTouch would look like coverage and be none. Scoped to the one test that
-  // needs it -- `test.use` at describe level takes per-test context options and needs no
-  // change to playwright.config.ts.
+  // Device-metrics emulation is the only way to get `(pointer: coarse)` -- see
+  // COARSE_POINTER_METRICS. Scoped to the one test that needs it: `test.use` at describe level
+  // takes per-test context options and needs no change to playwright.config.ts.
   test.describe('on a coarse pointer', () => {
-    test.use(PIXEL_7_METRICS)
+    test.use(COARSE_POINTER_METRICS)
 
     test('makes the idle rail inert, so its strip cannot swallow a tap', async ({ page, authenticatedWorkspace }) => {
       // With the phone gutters the 22px coarse strip overlaps ~20px of message content. An

--- a/frontend/tests/e2e/047c-chat-scroll-rail-scrub.spec.ts
+++ b/frontend/tests/e2e/047c-chat-scroll-rail-scrub.spec.ts
@@ -1,0 +1,169 @@
+import type { Page } from '@playwright/test'
+import { expect, test } from './fixtures'
+import { COARSE_POINTER_METRICS, touchDown, touchSwipe } from './helpers/touch'
+import { sendMessage, userBubbles, waitForAgentIdle } from './helpers/ui'
+
+/**
+ * Scrubbing the scroll rail: press anywhere on it, the view jumps there, and the SAME press
+ * drags on to scan the history. This is E2E-only by construction. The logic is unit tested
+ * (chatScrollRailDrag.test.ts, ChatScrollRail.test.tsx), but what makes the gesture work on a
+ * phone is the browser: a trusted touch pointer that `setPointerCapture` accepts, the rail's
+ * `touch-action: none` refusing the pan that would otherwise scroll the list under the finger,
+ * and the coarse-pointer hit areas that let a fingertip land on a 6px dot at all. jsdom has
+ * none of those, and a synthesized PointerEvent cannot stand in for one -- see ./helpers/touch.
+ *
+ * 047 covers the rail's geometry, dots and dot-click seek; 047b covers its auto-hide. Nothing
+ * here re-asserts them.
+ */
+
+/**
+ * Byte-for-byte 047's and 047b's filler. These specs drive a REAL agent, so the prompt is the
+ * test's runtime. Make the VIEWPORT shorter, never the message longer, when a test needs more
+ * overflow.
+ */
+const LONG_MESSAGE = `Please just reply with "ok". Ignore this filler: ${'the quick brown fox jumps over the lazy dog. '.repeat(12)}`
+
+const RAIL = '[data-testid="chat-scroll-rail"]'
+const THUMB = '[data-testid="chat-scroll-rail-thumb"]'
+const PREVIEW = '[data-testid="chat-scroll-rail-preview"]'
+const SCROLLER = '[data-chat-scroll-container="true"]'
+
+/** Send one tall message so the conversation overflows and the rail takes over scrolling. */
+async function seedOverflowingConversation(page: Page) {
+  const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+  await expect(editor).toBeVisible()
+  // Let the agent finish starting so the send takes the fast path (see 010).
+  await expect(page.getByText(/^Starting /)).not.toBeVisible()
+  await sendMessage(page, LONG_MESSAGE)
+  await waitForAgentIdle(page)
+  await expect(userBubbles(page)).toHaveCount(1)
+  await expect(page.locator(RAIL)).toBeVisible()
+}
+
+const scrollTop = (page: Page) => page.locator(SCROLLER).evaluate((el: HTMLElement) => el.scrollTop)
+
+/** The thumb's centre in viewport coordinates, for "does the thumb follow the finger" checks. */
+async function thumbCentreY(page: Page): Promise<number> {
+  const box = await page.locator(THUMB).boundingBox()
+  expect(box).not.toBeNull()
+  return box!.y + box!.height / 2
+}
+
+/**
+ * Put the transcript at the top and reveal the rail with a brief touch swipe -- the reader's
+ * own way in, and the only one on a coarse pointer: the idle rail is `pointer-events: none`,
+ * so a finger that lands on a faded strip falls through to the message underneath.
+ *
+ * Returns the rail's box, whose x is where every press below lands.
+ */
+async function revealRailByTouch(page: Page) {
+  const scroller = page.locator(SCROLLER)
+  await scroller.evaluate((el: HTMLElement) => {
+    el.scrollTop = 0
+  })
+  const scrollerBox = await scroller.boundingBox()
+  expect(scrollerBox).not.toBeNull()
+  // Swipe well clear of the rail strip on the right edge.
+  const swipeX = scrollerBox!.x + scrollerBox!.width / 3
+  await touchSwipe(page, { x: swipeX, fromY: scrollerBox!.y + scrollerBox!.height * 0.7, toY: scrollerBox!.y + scrollerBox!.height * 0.5 })
+  const rail = page.locator(RAIL)
+  await expect(rail).toHaveCSS('opacity', '1')
+  const railBox = await rail.boundingBox()
+  expect(railBox).not.toBeNull()
+  return railBox!
+}
+
+test.describe('chat scroll rail scrubbing', () => {
+  test.describe('by touch', () => {
+    test.use(COARSE_POINTER_METRICS)
+
+    test('jumps to the touched point, then scrubs while the finger stays down', async ({ page, authenticatedWorkspace }) => {
+      await seedOverflowingConversation(page)
+      const railBox = await revealRailByTouch(page)
+      const x = railBox.x + railBox.width / 2
+      // Both points sit inside the thumb-CENTRE travel range, which is inset by half the 24px
+      // thumb at each end: a press in that inset still seeks to the very end of the history, but
+      // the thumb cannot be drawn centred on it without overrunning the rail, so a
+      // thumb-follows-the-finger assertion has to stay off the last 12px.
+      const nearBottom = railBox.y + railBox.height - 30
+      const nearTop = railBox.y + 20
+
+      // Press near the bottom of the rail: the view jumps there at once, without waiting for
+      // the finger to lift. This is the press that used to do nothing at all under a finger.
+      const finger = await touchDown(page, x, nearBottom)
+      await expect.poll(() => scrollTop(page)).toBeGreaterThan(0)
+      // The thumb is under the finger, not wherever it rested before the press.
+      expect(Math.abs(await thumbCentreY(page) - nearBottom)).toBeLessThan(4)
+      const afterPress = await scrollTop(page)
+
+      // Scrub back up WITHOUT lifting: the thumb follows the finger and the view follows the
+      // thumb. Both are what a scrubbing gesture means; neither happened before.
+      await finger.moveTo(x, nearTop)
+      await expect.poll(() => thumbCentreY(page)).toBeLessThan(nearBottom - 40)
+      await expect.poll(() => scrollTop(page)).toBeLessThan(afterPress)
+
+      await finger.end()
+      // The release lands where the scrub ended, not back at the pressed point.
+      await expect.poll(() => scrollTop(page)).toBeLessThan(afterPress)
+
+      // A plain TAP still works as a track click: down and up with no travel in between.
+      const tap = await touchDown(page, x, nearBottom)
+      await tap.end()
+      await expect.poll(() => scrollTop(page)).toBeGreaterThanOrEqual(afterPress)
+    })
+
+    test('previews the message under the finger when a scrub starts on a dot', async ({ page, authenticatedWorkspace }) => {
+      // On a coarse pointer each dot carries a 24px hit circle, so on a marked conversation most
+      // of the rail is dot rather than track -- and a touch has no hover to open the preview
+      // with. The press itself must both open it and start the scrub.
+      await seedOverflowingConversation(page)
+      await revealRailByTouch(page)
+
+      const dot = page.locator('[data-testid="chat-scroll-rail-dot"]').first()
+      const dotBox = await dot.boundingBox()
+      expect(dotBox).not.toBeNull()
+      const dotX = dotBox!.x + dotBox!.width / 2
+      const dotY = dotBox!.y + dotBox!.height / 2
+
+      const finger = await touchDown(page, dotX, dotY)
+      // The preview opens from the press alone, and shows the message the dot marks.
+      await expect(page.locator(PREVIEW)).toContainText('Please just reply with "ok"')
+      // The same press scrubs on: dragging to the bottom moves the view off the dot's message.
+      const railBox = await page.locator(RAIL).boundingBox()
+      await finger.moveTo(dotX, railBox!.y + railBox!.height - 8)
+      await expect.poll(() => scrollTop(page)).toBeGreaterThan(0)
+      await finger.end()
+    })
+  })
+
+  test('scrubs the same way under a mouse on a desktop viewport', async ({ page, authenticatedWorkspace }) => {
+    // The press-jump-then-scrub rule is uniform across pointer types -- exactly what a native
+    // scrollbar track already does under a mouse. Pin that here so nobody re-introduces a
+    // coarse-pointer branch, and to cover the fine-pointer path CDP touch cannot reach.
+    await page.setViewportSize({ width: 1024, height: 400 })
+    await seedOverflowingConversation(page)
+
+    const scroller = page.locator(SCROLLER)
+    await scroller.evaluate((el: HTMLElement) => {
+      el.scrollTop = 0
+    })
+    const rail = page.locator(RAIL)
+    const railBox = await rail.boundingBox()
+    expect(railBox).not.toBeNull()
+    const x = railBox!.x + railBox!.width / 2
+    const nearBottom = railBox!.y + railBox!.height - 8
+    const nearTop = railBox!.y + 8
+
+    // Moving onto the strip relights the faded rail (a fine pointer keeps it hit-testable),
+    // so the press that follows is not rejected by the can't-click-what-you-can't-see guard.
+    await page.mouse.move(x, nearBottom)
+    await expect(rail).toHaveCSS('opacity', '1')
+
+    await page.mouse.down()
+    await expect.poll(() => scrollTop(page)).toBeGreaterThan(0)
+    await page.mouse.move(x, nearTop, { steps: 8 })
+    await expect.poll(() => scrollTop(page)).toBe(0)
+    await page.mouse.up()
+    await expect.poll(() => scrollTop(page)).toBe(0)
+  })
+})

--- a/frontend/tests/e2e/047c-chat-scroll-rail-scrub.spec.ts
+++ b/frontend/tests/e2e/047c-chat-scroll-rail-scrub.spec.ts
@@ -63,13 +63,19 @@ async function revealRailByTouch(page: Page) {
   })
   const scrollerBox = await scroller.boundingBox()
   expect(scrollerBox).not.toBeNull()
+  // Measure the rail BEFORE the swipe, not after. The rail's activity window is short, and every
+  // awaited round trip between the swipe and the caller's press eats into it -- on a loaded CI
+  // worker enough of them let the rail go idle, where a coarse pointer finds it
+  // `pointer-events: none` and the press falls through to the message underneath. The rail's box
+  // does not depend on the swipe (it is faded, not unmounted -- see 047b), so taking it first
+  // leaves only the opacity assertion in that gap.
+  const rail = page.locator(RAIL)
+  const railBox = await rail.boundingBox()
+  expect(railBox).not.toBeNull()
   // Swipe well clear of the rail strip on the right edge.
   const swipeX = scrollerBox!.x + scrollerBox!.width / 3
   await touchSwipe(page, { x: swipeX, fromY: scrollerBox!.y + scrollerBox!.height * 0.7, toY: scrollerBox!.y + scrollerBox!.height * 0.5 })
-  const rail = page.locator(RAIL)
   await expect(rail).toHaveCSS('opacity', '1')
-  const railBox = await rail.boundingBox()
-  expect(railBox).not.toBeNull()
   return railBox!
 }
 

--- a/frontend/tests/e2e/helpers/touch.ts
+++ b/frontend/tests/e2e/helpers/touch.ts
@@ -1,0 +1,72 @@
+import type { Page } from '@playwright/test'
+import { devices } from '@playwright/test'
+
+/**
+ * Real touch input for the E2E specs, plus the device metrics that give Blink a coarse pointer.
+ *
+ * Playwright's own touch API is `page.touchscreen.tap` and nothing else, so a DRAG needs the raw
+ * CDP command underneath it. A synthesized `PointerEvent` is not an alternative: the browser
+ * rejects `setPointerCapture` for a pointer id that no real input created, so every drag
+ * controller in the app bails on the first press and the test proves nothing.
+ */
+
+/**
+ * Pixel 7's device metrics WITHOUT its `defaultBrowserType`, and with a shorter viewport.
+ * Playwright refuses a `defaultBrowserType` inside a describe group -- it would force a new
+ * worker -- and this suite's only project is already chromium, so the field is both unusable
+ * and redundant. The rest is what actually gives Blink a COARSE primary pointer: it derives the
+ * primary pointer type from the mobile viewport, not from `hasTouch`, so metrics that set only
+ * `hasTouch` would look like coverage and be none. The height is cut from the device's 915px to
+ * 380px: the device is narrower than 720px, so its lines wrap more and one seeded message still
+ * overflows comfortably.
+ */
+export const COARSE_POINTER_METRICS = {
+  viewport: { width: devices['Pixel 7'].viewport.width, height: 380 },
+  deviceScaleFactor: devices['Pixel 7'].deviceScaleFactor,
+  isMobile: devices['Pixel 7'].isMobile,
+  hasTouch: devices['Pixel 7'].hasTouch,
+} as const
+
+/** A finger held on the screen. Move it, then end it -- both in viewport CSS pixels. */
+export interface TouchPointer {
+  /** Drag the finger to an absolute viewport position. */
+  moveTo: (x: number, y: number) => Promise<void>
+  /** Lift the finger and release the CDP session. */
+  end: () => Promise<void>
+}
+
+/**
+ * Press a finger at a viewport position and keep it down, so a test can assert what the page
+ * does WHILE the gesture is live (a rail thumb tracking the finger, a preview popover opening)
+ * rather than only after it. The context must have `hasTouch` -- see
+ * {@link COARSE_POINTER_METRICS} -- or Blink discards the events.
+ */
+export async function touchDown(page: Page, x: number, y: number): Promise<TouchPointer> {
+  const cdp = await page.context().newCDPSession(page)
+  await cdp.send('Input.dispatchTouchEvent', { type: 'touchStart', touchPoints: [{ x, y }] })
+  return {
+    async moveTo(nextX, nextY) {
+      await cdp.send('Input.dispatchTouchEvent', { type: 'touchMove', touchPoints: [{ x: nextX, y: nextY }] })
+    },
+    async end() {
+      // touchEnd carries NO touch points: the one that lifted is the one that is gone.
+      await cdp.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] })
+      await cdp.detach()
+    },
+  }
+}
+
+/**
+ * A complete finger swipe along a vertical line, in `steps` moves. Use this to drive the page's
+ * own touch scrolling; use {@link touchDown} when the test must assert something mid-gesture.
+ */
+export async function touchSwipe(
+  page: Page,
+  opts: { x: number, fromY: number, toY: number, steps?: number },
+): Promise<void> {
+  const steps = opts.steps ?? 5
+  const finger = await touchDown(page, opts.x, opts.fromY)
+  for (let step = 1; step <= steps; step++)
+    await finger.moveTo(opts.x, opts.fromY + ((opts.toY - opts.fromY) * step) / steps)
+  await finger.end()
+}

--- a/frontend/tests/e2e/helpers/touch.ts
+++ b/frontend/tests/e2e/helpers/touch.ts
@@ -66,7 +66,14 @@ export async function touchSwipe(
 ): Promise<void> {
   const steps = opts.steps ?? 5
   const finger = await touchDown(page, opts.x, opts.fromY)
-  for (let step = 1; step <= steps; step++)
-    await finger.moveTo(opts.x, opts.fromY + ((opts.toY - opts.fromY) * step) / steps)
-  await finger.end()
+  // `finally`, so a failed move still lifts the finger and detaches the session. Without it a
+  // mid-swipe protocol error would leave Blink believing a finger is still down, and every later
+  // touch in the same test would arrive as a second contact point.
+  try {
+    for (let step = 1; step <= steps; step++)
+      await finger.moveTo(opts.x, opts.fromY + ((opts.toY - opts.fromY) * step) / steps)
+  }
+  finally {
+    await finger.end()
+  }
 }


### PR DESCRIPTION
## Motivation

The chat scroll rail served three separate gestures through three separate code paths: a thumb drag, a track press, and a dot press. None of them worked as one continuous touch gesture, because touch has no hover and no second press to spend.

The rail's dot preview behaved like a tooltip. It closed as soon as the pointer left the dot, so a reader could not select or scroll its text, and a keyboard user could not reach it through focus.

A scrub that moved past a loaded page could abandon a seek at the view layer, but the underlying fetch continued. The fetch then applied a stale set of messages, and replaced the window that the reader already left.

## Modifications

**Rail gesture**

- Merge the thumb, track, and dot presses into one `createThumbDrag` grab, so a single pointer-down starts every rail gesture. A track or dot press jumps immediately and also starts a drag centered on the pressed point.
- Add `SCRUB_ENGAGE_SLOP_PX` (6 pixels) to separate a tap from a scrub. A thumb grab uses 0 pixels of slop, because a thumb press does not also mean a tap.
- Debounce an out-of-window seek by `SCRUB_SEEK_DEBOUNCE_MS` (200 milliseconds). A scrub across a long history now loads the page it needs; before this change, the thumb moved over a transcript that never followed it.
- Add a `seekTo` helper that centralizes every seek call site. A rejected or thrown seek now degrades to `false` with a warning, instead of a leaked unhandled rejection or a stuck thumb.
- Handle `lostpointercapture` to recover a capture that the browser revokes on its own. This previously left the drag-active guard stuck.
- Anchor the thumb on the pressed point instead of on the dot. A dot press no longer offsets the thumb, the preview, and the release point by up to 12 pixels from the finger.
- Re-invoke `onActivity` on the falling edge of the rail's own "held lit" state. The rail now fades out when a slow seek outlives the host's idle window, instead of an immediate change to dark.

**Preview card**

- Turn the dot preview into an interactive card. It is no longer `pointer-events: none`, so its text is selectable and scrollable. It stays inert on a coarse pointer, for the reason `railIdle` does.
- Add a two-channel state machine to `createDotPreview`, with a pointer channel and a focus channel. It exposes `openDot`, `closeSoon` (delayed by `POINTER_CLOSE_DELAY_MS`, 300 milliseconds), `abandonDot` (immediate, for when a grab becomes a scrub), `focusDot`, `blurDot`, and `closeNow`. Focus takes the card from the pointer, so a parked cursor cannot mask the dot that a keyboard reader tabs to.
- Keep the card open while the pointer rests on it, a press inside it stays down, or its text stays selected. The press is tracked on the window and keyed to the pressing `pointerId`, and only a primary press opens a hold.
- Clamp the card's vertical position against its measured height instead of against the maximum-height cap, so a short card sits next to its dot instead of up to 90 pixels away. On a rail shorter than twice the cap, every card previously collapsed onto the rail's midpoint.
- Reuse a single card element across dots, and reset its scroll position when the shown message sequence changes.
- Extract a shared `floatingCardSurface` style for the fill, border, radius, shadow, inset, and line height that the tooltip and the rail card each defined on their own. The two drifted apart: the tooltip filled `var(--card)` and the rail card filled `var(--background)`.
- Add plain-data `popoverTokens.ts` to hold `POPOVER_CARD_PADDING`, because Playwright cannot import a `.css.ts` module but the end-to-end test must measure the value.
- Point `aria-describedby` at the open card from a focused dot, so a screen reader announces the message preview instead of only "Your message".
- Move `hasScrollRoom(el, deltaY)` into `chatScrollGeometry.ts`, next to the other scroll formulas.

**Seek abandonment**

- Give `pendingSeek` an `AbortController`, and thread its signal through `chatSeek`, `useChatScroll`, `ChatView`, `TileRenderer`, and `chatHistoryPaginator`, down to both `listAgentMessages` calls. An abandoned seek now stops its network request instead of only its effect on the view.
- Treat an abort in `jumpToMessagesAroundSeq` as a designed early exit that never touches state.
- Add an optional `{ signal }` parameter to `listAgentMessages`. This parameter follows the convention that `listMessageMarks` already uses. No existing caller needs a change.

**Tests**

- Add the end-to-end helper `helpers/touch.ts`, which drives real Chrome DevTools Protocol touch input, because a synthesized `PointerEvent` fails `setPointerCapture`.
- Add the end-to-end spec `047c-chat-scroll-rail-scrub.spec.ts`, which covers press-to-jump, drag-to-scan, tap-as-click, and a dot press that opens the preview mid-scrub, under both touch and mouse.
- Extend `047-chat-scroll-rail.spec.ts` with a real drag-select inside the card that ends outside it, and `036-dropdown-popover.spec.ts` with the shared inset and the card surface that only Oat's `card` class supplies.

## Result

A touch user can press anywhere on the rail to jump, then keep the same press down to scrub through the transcript. A mouse user keeps the same gesture.

The dot preview stays open under the pointer, under a held press, or while its text stays selected, so a reader can copy a preview instead of only a glance at it. A keyboard reader reaches the same card, and a screen reader announces its text.

A scrub that moves past a loaded page never applies a stale window to a reader who already scrolled elsewhere.

This is an internal breaking change: `ThumbDragDeps.onRelease` now takes `(fraction, engaged)` instead of `(fraction)`. No public API changes.
