### PR TITLE
feat(chat): Run the chat's surfaces out to the panel edges

### DIFF
--- a/frontend/src/components/chat/ChatScrollRail.css.ts
+++ b/frontend/src/components/chat/ChatScrollRail.css.ts
@@ -1,5 +1,6 @@
 import { globalStyle, style } from '@vanilla-extract/css'
 import { floatingCardSurface } from '~/styles/popover.css'
+import { CHAT_RAIL_WIDTH_VAR, COARSE_HIT_PX } from './chatChromeVars'
 
 // Fixed px here are scrollbar-like dimensions (rail/thumb/dot widths, thumb radius),
 // NOT spacing-scale values -- see CLAUDE.md. The top/bottom insets use the spacing scale.
@@ -15,28 +16,64 @@ import { floatingCardSurface } from '~/styles/popover.css'
  */
 const PREVIEW_CARD_MAX_H_PX = 200
 
-/** Width of the rail overlay column (a touch wider than the 8px native scrollbar). */
-const RAIL_WIDTH_PX = 10
-/**
- * Wider interactive column on COARSE pointers (touch): a finger can't hit a 10px strip, so
- * the hit area grows to a touch-friendlier size while the thin visuals (track/thumb/dots)
- * stay their fine-pointer widths, just centred in the wider column. Below breakpoints.sm the
- * list's right gutter shrinks to reclaim text width, so this strip now overlaps roughly 20px
- * of message content instead of 8px. That is acceptable ONLY because the rail is
- * pointer-events:none while idle (see railIdle), which is the large majority of the time.
- * Widening it further, or dropping the idle inertness, starts swallowing message taps into
- * track-click jumps.
- */
-const RAIL_WIDTH_COARSE_PX = 22
+/** Width of the muted vertical track line. */
+const TRACK_WIDTH_PX = 2
 /** Thumb width, matching the app's 8px native scrollbar thumb. */
 const THUMB_WIDTH_PX = 8
+
+/**
+ * The rail's box comes from a token the chat root publishes
+ * (`~/components/chat/ChatView.css.ts`), because a message row's floating toolbar
+ * needs the same number to sit clear of this column. The token travels as a
+ * custom property rather than an import: `ChatView.css.ts` already imports
+ * `~/components/chat/messageStyles.css.ts`, and the toolbar rules live there, so
+ * the value has to reach two modules that cannot both import each other. The
+ * NAMES are shared, from the import-free leaf `~/components/chat/chatChromeVars.ts`.
+ *
+ * The column is the gutter. That one decision does three things at once:
+ * everything the rail draws sits centred in it, so the track, thumb and dots run
+ * down the gutter's middle; the box normally stops at the message column, so it
+ * does not cover a row's floating action buttons; and the hover target is the
+ * whole gutter rather than the ~10px strip that was hard to hit.
+ *
+ * The second point is the one that matters most. The rail overlays a row from
+ * OUTSIDE its stacking context and stays hit-testable while faded, so every
+ * pointer event inside the rail's box goes to the rail, and no z-index or
+ * pointer-events arrangement inside the row changes that. A box that stops at the
+ * gutter cannot receive an event meant for a row's action buttons.
+ *
+ * Two floors break that rule on purpose, because a 4px phone gutter and a coarse
+ * pointer both need a wider press target than the gutter gives. The column then
+ * DOES overhang the message text, and the row's floating actions are inset by
+ * exactly that overhang to stay clear of it -- see the toolbar rules in
+ * `~/components/chat/messageStyles.css.ts`, which read the same two properties.
+ */
+const RAIL_WIDTH = `var(${CHAT_RAIL_WIDTH_VAR})`
+
+/**
+ * Opacity of the rail's own surface while it is shown.
+ *
+ * Painted in `--background` -- the PANEL colour, not the message surface -- so
+ * the strip reads as a channel cut out of the content: it lightens the column in
+ * the light theme and darkens it in the dark one, from the same declaration.
+ * Partial, so the content beneath still shows through and the strip does not
+ * read as an opaque bar. The whole rail fades with `railIdle`, so this needs no
+ * shown/hidden branch of its own.
+ */
+const RAIL_SURFACE_ALPHA = 0.7
 
 export const rail = style({
   'position': 'absolute',
   'top': 'var(--space-2)',
   'bottom': 'var(--space-2)',
-  'right': '2px',
-  'width': `${RAIL_WIDTH_PX}px`,
+  'right': 0,
+  'width': RAIL_WIDTH,
+  'backgroundColor': `color-mix(in srgb, var(--background) ${RAIL_SURFACE_ALPHA * 100}%, transparent)`,
+  // Round the surface off the same way as the loading pills and the scroll-to-bottom
+  // button: the base radius token, NOT a pill. All of them float over this one viewport,
+  // so they should read as one set. (The corner this replaced was twice the TRACK's width,
+  // which is a measurement of the line inside the strip, not of the strip.)
+  'borderRadius': 'var(--radius-medium)',
   'zIndex': 10,
   // Interactive (unlike the pointer-events:none loading pills): track clicks + thumb drag.
   'cursor': 'pointer',
@@ -53,9 +90,6 @@ export const rail = style({
     '(prefers-reduced-motion: no-preference)': {
       transition: 'opacity var(--transition)',
     },
-    '(pointer: coarse)': {
-      width: `${RAIL_WIDTH_COARSE_PX}px`,
-    },
   },
 })
 
@@ -70,19 +104,26 @@ export const rail = style({
  * tree and could disturb the height its own ResizeObserver measures.
  *
  * `pointer-events: none` is COARSE-ONLY, deliberately:
- *   - on touch the idle rail must go inert, because below breakpoints.sm the list's right
- *     gutter shrinks and this strip then overlaps ~20px of message content. An invisible
- *     strip that swallowed taps into a track-click jump would be a trap.
- *   - on a FINE pointer the faded rail STAYS hit-testable so a `pointermove` over it relights
- *     it (see ChatScrollRail.onPointerMove -> onActivity), but a CLICK on the faded rail is
- *     rejected in the pointer handler -- you can't click what you can't see. So a mouse
- *     reaches the rail by scrolling or by moving onto the strip (which relights it) first.
+ *   - on touch the idle rail must go inert. The column takes a finger-sized floor there, so on
+ *     a phone, whose right gutter is 4px, this strip overlaps 20px of message content. An
+ *     invisible strip that swallowed taps into a track-click jump would be a trap.
+ *   - on a FINE pointer the faded rail STAYS hit-testable so a pointer over it relights it (see
+ *     ChatScrollRail.onPointerEnter, and onPointerMove for the strip that appears under an
+ *     already-stationary cursor), but a CLICK on the faded rail is rejected in the pointer
+ *     handler -- you can't click what you can't see. So a mouse reaches the rail by scrolling or
+ *     by moving onto the strip, which relights it, first.
+ *
+ * A universal `pointer-events: none` cannot protect what the column overhangs. The relight has
+ * to come from a pointer event on the strip itself, so an inert strip never lights again from
+ * the pointer, and a strip that stays live takes the hover from whatever it covers. Neither
+ * setting helps, which is why the overhang is removed at the source instead: the column is the
+ * gutter, and the row's actions are inset by the little that the two floors add to it.
  *
  * `opacity: 0` is universal: every screen/pointer fades the idle rail the same way. There is
- * deliberately NO `:hover { opacity: 1 }` shortcut: that would make the rail LOOK visible
- * under a parked cursor while the activity window is still closed, so the click guard would
- * reject a click on something that appeared visible. Visibility stays driven solely by the
- * activity window, which carries its own idle timeout so a parked cursor cannot pin it lit.
+ * deliberately NO `:hover { opacity: 1 }` shortcut. That would make the rail LOOK visible while
+ * the press guard still read it as faded, and the guard would reject a click on something that
+ * appeared visible. A parked cursor DOES hold the rail lit, but through the `hovered` signal
+ * that `idle()` folds in (ChatScrollRail.tsx), so the look and the guard move together.
  */
 export const railIdle = style({
   'opacity': 0,
@@ -102,15 +143,19 @@ globalStyle(`${railIdle} *`, {
   cursor: 'auto',
 })
 
-/** The muted vertical track line, centered in the rail. Non-interactive (clicks fall to rail). */
+/**
+ * The muted vertical track line, centred in the rail -- and so, because the rail
+ * fills the gutter exactly, down the gutter's middle. The thumb and the dots
+ * share that axis. Non-interactive (clicks fall to rail).
+ */
 export const track = style({
   position: 'absolute',
   top: 0,
   bottom: 0,
   left: '50%',
   transform: 'translateX(-50%)',
-  width: '2px',
-  borderRadius: '1px',
+  width: `${TRACK_WIDTH_PX}px`,
+  borderRadius: `${TRACK_WIDTH_PX / 2}px`,
   backgroundColor: 'var(--border)',
   pointerEvents: 'none',
 })
@@ -175,8 +220,11 @@ export const dot = style({
  * anywhere inside this circle, and the preview card that press opens is resolved by distance from
  * the dot's rail-Y, so a range narrower than this circle's radius leaves a rim of the hit area
  * that jumps but shows no preview. Same reason PREVIEW_CARD_MAX_H_PX is exported above.
+ *
+ * The finger size itself comes from the shared constant, which the rail's own column also floors
+ * at on a coarse pointer -- so a dot and the track around it take the same press target.
  */
-export const DOT_COARSE_HIT_PX = 24
+export const DOT_COARSE_HIT_PX = COARSE_HIT_PX
 
 // Coarse-pointer (touch) hit expander: a transparent circle centred on the 6px dot, so a finger
 // tap within range still hits the button. A pseudo-element leaves the dot's visual fill + ring at
@@ -262,7 +310,11 @@ globalStyle(`${dotPreviewMarkdown} > * > :last-child`, { marginBottom: 0 })
  */
 export const previewCard = style([floatingCardSurface, {
   'position': 'absolute',
-  'right': 'calc(100% + var(--space-2))',
+  // Flush against the rail's left edge. The rail is a wide hit column whose
+  // visuals sit centred in it, so any gap here is added to the ~10px the column
+  // already puts between its left edge and the dot the card describes -- and the
+  // card drifts away from the thing it points at.
+  'right': '100%',
   'transform': 'translateY(-50%)',
   'width': 'max-content',
   'maxWidth': '280px',

--- a/frontend/src/components/chat/ChatScrollRail.test.tsx
+++ b/frontend/src/components/chat/ChatScrollRail.test.tsx
@@ -1915,6 +1915,141 @@ describe('chatScrollRail dot preview card', () => {
       expect(onActivity).toHaveBeenCalledTimes(1)
     })
 
+    it('holds the rail lit under a PARKED cursor, which sends no further pointermove', () => {
+      // The bug this fixes: the host's activity window closes on its own timer, and a
+      // stationary cursor re-arms nothing, so the rail faded out from under a reader who was
+      // sitting on it. Hover is part of idle() now, so the strip stays lit with no further
+      // events at all -- scrollActive going false must NOT be able to fade it.
+      HTMLElement.prototype.setPointerCapture = vi.fn()
+      installImmediateRaf()
+      const [scrollActive, setScrollActive] = createSignal(true)
+      const { container } = render(() => (
+        <ChatScrollRail {...baseProps()} scrollActive={scrollActive()} />
+      ))
+      const rail = railWithRect(container)
+      expect(rail.className).not.toContain(styles.railIdle)
+
+      rail.dispatchEvent(new PointerEvent('pointerenter', { bubbles: true, pointerType: 'mouse', pointerId: 1 }))
+      // The host's window closes while the cursor rests there, sending nothing.
+      setScrollActive(false)
+      expect(rail.className).not.toContain(styles.railIdle)
+
+      // It fades only once the cursor actually leaves.
+      rail.dispatchEvent(new PointerEvent('pointerleave', { bubbles: true, pointerType: 'mouse', pointerId: 1 }))
+      expect(rail.className).toContain(styles.railIdle)
+    })
+
+    it('re-arms the host window on the way in, so leaving fades rather than snaps dark', () => {
+      HTMLElement.prototype.setPointerCapture = vi.fn()
+      installImmediateRaf()
+      const onActivity = vi.fn()
+      const { container } = render(() => (
+        <ChatScrollRail {...baseProps({ onActivity })} scrollActive={false} />
+      ))
+      const rail = railWithRect(container)
+
+      rail.dispatchEvent(new PointerEvent('pointerenter', { bubbles: true, pointerType: 'mouse', pointerId: 1 }))
+      expect(onActivity).toHaveBeenCalled()
+
+      // And again on the falling edge, so the fade tail starts when the cursor leaves --
+      // not at whatever moment the window happened to close underneath it.
+      onActivity.mockClear()
+      rail.dispatchEvent(new PointerEvent('pointerleave', { bubbles: true, pointerType: 'mouse', pointerId: 1 }))
+      expect(onActivity).toHaveBeenCalled()
+    })
+
+    it('does not let a TOUCH pin the rail lit, since it never leaves until the next tap', () => {
+      // pointerenter fires on tap and pointerleave only when the next tap lands elsewhere,
+      // so honouring touch here would hold the rail up indefinitely on a surface where it is
+      // meant to fade. A finger holds it through drag() and activeDot(), which end with the
+      // gesture.
+      HTMLElement.prototype.setPointerCapture = vi.fn()
+      installImmediateRaf()
+      const { container } = render(() => (
+        <ChatScrollRail {...baseProps()} scrollActive={false} />
+      ))
+      const rail = railWithRect(container)
+      expect(rail.className).toContain(styles.railIdle)
+
+      rail.dispatchEvent(new PointerEvent('pointerenter', { bubbles: true, pointerType: 'touch', pointerId: 1 }))
+      expect(rail.className).toContain(styles.railIdle)
+    })
+
+    it('does not let a TOUCH leave clear the hold a mouse has on the rail', () => {
+      // Only a mouse SETS the hold, so an unfiltered leave could only ever clear one that a
+      // mouse holds. On a hybrid device a tap elsewhere would then drop the rail out from
+      // under a parked cursor -- the exact fade the hold exists to stop.
+      HTMLElement.prototype.setPointerCapture = vi.fn()
+      installImmediateRaf()
+      const { container } = render(() => (
+        <ChatScrollRail {...baseProps()} scrollActive={false} />
+      ))
+      const rail = railWithRect(container)
+
+      rail.dispatchEvent(new PointerEvent('pointerenter', { bubbles: true, pointerType: 'mouse', pointerId: 1 }))
+      expect(rail.className).not.toContain(styles.railIdle)
+
+      rail.dispatchEvent(new PointerEvent('pointerleave', { bubbles: true, pointerType: 'touch', pointerId: 2 }))
+      expect(rail.className).not.toContain(styles.railIdle)
+
+      rail.dispatchEvent(new PointerEvent('pointerleave', { bubbles: true, pointerType: 'mouse', pointerId: 1 }))
+      expect(rail.className).toContain(styles.railIdle)
+    })
+
+    it('holds the rail lit from a MOUSE move, for a strip that appeared under a still cursor', () => {
+      // A rail that mounts or un-hides under a stationary cursor gets no pointerenter, because
+      // nothing entered. Its first move has to establish the hold, or the cursor stops moving
+      // and the host's window closes under it.
+      HTMLElement.prototype.setPointerCapture = vi.fn()
+      installImmediateRaf()
+      const [scrollActive, setScrollActive] = createSignal(false)
+      const onActivity = vi.fn(() => setScrollActive(true))
+      const { container } = render(() => (
+        <ChatScrollRail {...baseProps({ onActivity })} scrollActive={scrollActive()} />
+      ))
+      const rail = railWithRect(container)
+
+      rail.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, pointerType: 'mouse', clientY: 200, pointerId: 1 }))
+      expect(onActivity).toHaveBeenCalledTimes(1)
+      expect(rail.className).not.toContain(styles.railIdle)
+
+      // The host's window closes and the still cursor sends no further input. The hold, not
+      // the window, is what keeps the rail lit from here.
+      setScrollActive(false)
+      expect(rail.className).not.toContain(styles.railIdle)
+
+      // Leaving releases the hold, whose falling edge re-arms the window -- so the rail fades
+      // out on the host's timer instead of snapping dark under the departing cursor.
+      rail.dispatchEvent(new PointerEvent('pointerleave', { bubbles: true, pointerType: 'mouse', pointerId: 1 }))
+      expect(onActivity).toHaveBeenCalledTimes(2)
+      setScrollActive(false)
+      expect(rail.className).toContain(styles.railIdle)
+    })
+
+    it('clears the hold when the rail hides under the cursor, so it returns faded', async () => {
+      // A DOM removal delivers no pointerleave. Without the teardown the flag would survive the
+      // hide, and the rail would come back fully lit with the cursor nowhere near it -- and stay
+      // lit, because the falling edge that re-arms the host's window never comes either.
+      HTMLElement.prototype.setPointerCapture = vi.fn()
+      installImmediateRaf()
+      const [hidden, setHidden] = createSignal(false)
+      const { container } = render(() => (
+        <ChatScrollRail {...baseProps()} scrollActive={false} hidden={hidden()} />
+      ))
+      let rail = railWithRect(container)
+
+      rail.dispatchEvent(new PointerEvent('pointerenter', { bubbles: true, pointerType: 'mouse', pointerId: 1 }))
+      expect(rail.className).not.toContain(styles.railIdle)
+
+      setHidden(true)
+      await Promise.resolve()
+      setHidden(false)
+      await Promise.resolve()
+
+      rail = railWithRect(container)
+      expect(rail.className).toContain(styles.railIdle)
+    })
+
     it('reopens the host window from a pointermove only while the rail is faded, not on every move', () => {
       // A captured thumb drag retargets its pointermove to the rail, so the host's scroll
       // container sees nothing -- the FIRST move onto a faded strip must relight it. But once lit

--- a/frontend/src/components/chat/ChatScrollRail.tsx
+++ b/frontend/src/components/chat/ChatScrollRail.tsx
@@ -151,6 +151,12 @@ export function ChatScrollRail(props: ChatScrollRailProps) {
   const dragHold = createDragReleaseHold()
   const drag = dragHold.fraction
 
+  // A MOUSE resting on the strip. Restricted to `pointerType === 'mouse'`: a touch fires
+  // pointerenter on tap and does not leave until the next tap lands elsewhere, which would
+  // pin the rail lit on a surface where it is meant to fade back out. A finger holds the
+  // rail through drag() and activeDot() instead, both of which end with the gesture.
+  const [hovered, setHovered] = createSignal(false)
+
   // The (n+1)-length row-seq map is computed ONCE in ChatView (railRowSeqs, memoized on the item
   // list) and handed down as a prop -- the scroll-owner resolution there already needs it, so the
   // O(n) row-seq scan runs once per item-list change instead of twice. The thin `geo` wrapper still
@@ -217,6 +223,12 @@ export function ChatScrollRail(props: ChatScrollRailProps) {
     railResizeObserver = undefined
     railEl = undefined
     setRailHeight(0)
+    // Clear the hover here, with the other self-overrides. A DOM removal delivers no
+    // pointerleave, so a cursor that rests on the strip when the rail hides would otherwise
+    // leave this flag set: the rail then returns lit, with the cursor elsewhere, and only a
+    // deliberate enter-then-leave clears it. Every override that holds the rail lit drops in
+    // this one teardown, so the next one added is safe by default.
+    setHovered(false)
     // No close delay here: the rail is going away, so there is no card left to move onto. The
     // press lock needs no reset: the card clears it from its own cleanup as it unmounts, which
     // keeps the card the single owner of its press lifecycle.
@@ -258,31 +270,47 @@ export function ChatScrollRail(props: ChatScrollRailProps) {
   // the viewport with zero or two scrollbars; the rail now trusts the single upstream decision.
   const hidden = () => props.hidden
 
-  // Idle is a PAINT state, never an unmount (see the `scrollActive` prop). Two of the
-  // rail's OWN states override the host's window, so an interaction never fades under the
-  // reader's finger or cursor: a live thumb drag AND its post-release settle (drag() stays
-  // non-null until the seek lands -- see createDragReleaseHold), and an open dot popover
-  // (activeDot() folds hover, KEYBOARD FOCUS, and scrub into one signal, so no CSS
-  // :focus-within is needed).
-  const idle = createMemo(() => !props.scrollActive && drag() === null && activeDot() === null)
+  // The rail's OWN overrides of the host's activity window. Four states hold the rail lit, so
+  // an interaction never fades under the reader's finger or cursor: a live thumb drag AND its
+  // post-release settle (drag() stays non-null until the seek lands -- see
+  // createDragReleaseHold), an open dot popover (activeDot() folds hover, KEYBOARD FOCUS, and
+  // scrub into one signal, so no CSS :focus-within is needed), and a mouse that rests anywhere
+  // on the strip.
+  //
+  // ONE definition, read by both the paint state below and the re-arm effect under it. An
+  // override carries a two-sided contract -- hold the rail lit, then re-arm the host's window
+  // when it releases -- and a term written into only one side either fails to hold the paint or
+  // fails to re-arm, with no error either way.
+  //
+  // The hover term is a real state, not a `:hover { opacity: 1 }` paint override. The host's
+  // window closes on its own timer, and a parked cursor sends no further pointermove to re-arm
+  // it, so the rail faded out from under a cursor that rested on it -- and a CSS-only override
+  // would have made it LOOK usable while the press guard below still read it as faded and
+  // rejected the click. Folding hover in here keeps the look and the guard agreeing: hovered
+  // means lit means clickable.
+  const heldLit = createMemo(() => drag() !== null || activeDot() !== null || hovered())
 
-  // Re-open the host's activity window on the FALLING edge of the rail's OWN overrides -- the
-  // live drag, its post-release hold, and the open dot popover that idle() above lets outrank
-  // the host's window. Each of them holds the rail lit while nothing re-arms that window: a
-  // captured drag's pointermove retargets to the rail, so the host's scroll container never
-  // sees it, and the rail's own onPointerMove relight is inert for the whole time (idle() is
-  // false). So without this, any override outlasting the host's idle timeout ends by snapping
-  // the rail dark instead of fading it. Keying the re-arm on the overrides rather than on the
-  // pointer lifecycle is what covers all three: a release whose out-of-window seek outlives the
-  // window re-arms when the hold clears, not when the finger lifts.
-  let railHeldLit = false
+  // Idle is a PAINT state, never an unmount (see the `scrollActive` prop).
+  const idle = createMemo(() => !props.scrollActive && !heldLit())
+
+  // Re-open the host's activity window on the FALLING edge of those overrides. Each of them
+  // holds the rail lit while nothing re-arms that window: a captured drag's pointermove
+  // retargets to the rail, so the host's scroll container never sees it, and the rail's own
+  // onPointerMove relight is inert for the whole time (idle() is false). So without this, any
+  // override that outlasts the host's idle timeout ends by snapping the rail dark instead of
+  // fading it. Keying the re-arm on the overrides rather than on the pointer lifecycle is what
+  // covers all four: a release whose out-of-window seek outlives the window re-arms when the
+  // hold clears, not when the finger lifts. The hover term also re-arms on the way IN (see
+  // onPointerEnter), so that a leave fades the rail instead of snapping it dark; both halves are
+  // deliberate, and neither one is redundant.
+  let wasHeldLit = false
   createEffect(() => {
-    const heldLit = drag() !== null || activeDot() !== null
+    const lit = heldLit()
     // Not while hidden: the rail that just stopped rendering must not re-arm a window for
     // itself. Hiding tears the drag down (below), which is a falling edge of its own.
-    if (railHeldLit && !heldLit && !hidden())
+    if (wasHeldLit && !lit && !hidden())
       props.onActivity?.()
-    railHeldLit = heldLit
+    wasHeldLit = lit
   })
 
   createEffect(() => {
@@ -623,15 +651,43 @@ export function ChatScrollRail(props: ChatScrollRailProps) {
         class={`${styles.rail}${idle() ? ` ${styles.railIdle}` : ''}`}
         data-testid="chat-scroll-rail"
         onPointerDown={onRailPointerDown}
-        // Reopen the host's window ONLY when the rail is faded: a cursor crossing the invisible
-        // strip relights it (intent to use it), and a captured thumb drag's pointermove retargets
-        // here so the scroll container never sees it. Once lit, idle() is false -- the drag itself
-        // (drag() !== null) or the now-open host window holds the rail visible -- so further moves
-        // would only re-arm a timer that the next move cancels again (dozens of clearTimeout +
-        // setTimeout pairs per second of dragging). No-op once visible; the host's idle timer
-        // carries the fade tail.
-        onPointerMove={() => {
-          if (idle())
+        // A cursor on the strip HOLDS the rail lit for as long as it rests there (see idle()),
+        // and re-arms the host's window on the way in so leaving fades it out instead of
+        // snapping it dark. Enter/leave rather than pointermove, because a parked cursor sends
+        // no moves -- which is exactly how the rail used to disappear from under one.
+        onPointerEnter={(event: PointerEvent) => {
+          if (event.pointerType !== 'mouse')
+            return
+          setHovered(true)
+          props.onActivity?.()
+        }}
+        // Mouse only, to match the enter handler. A touch never SETS the hover, so an unfiltered
+        // leave could only clear one that a mouse holds: on a hybrid device a tap elsewhere would
+        // then drop the rail out from under a parked cursor.
+        onPointerLeave={(event: PointerEvent) => {
+          if (event.pointerType !== 'mouse')
+            return
+          setHovered(false)
+        }}
+        // Two jobs, with different audiences.
+        //
+        // The relight (every pointer type) reopens the host's window from a move onto a faded
+        // strip. A captured thumb drag's pointermove retargets here, so the scroll container
+        // never sees it. Only while idle: once lit, further moves would replace a timer that the
+        // next move replaces again, dozens of times a second through a drag.
+        //
+        // The hold (a MOUSE that is not dragging) is the enter handler's other half. A rail that
+        // mounts or un-hides UNDER a stationary cursor receives no pointerenter, because nothing
+        // entered, so its first move has to establish the hover -- otherwise a cursor that then
+        // stops moving loses the rail to the host's timer, which is the case the hold exists for.
+        // Skipped during a drag, because capture retargets moves from far outside the strip;
+        // without capture, a move on this element means the pointer IS on it, so no hit test is
+        // needed. Read idle() BEFORE the set, or the set hides the falling edge from the relight.
+        onPointerMove={(event: PointerEvent) => {
+          const wasIdle = idle()
+          if (drag() === null && event.pointerType === 'mouse')
+            setHovered(true)
+          if (wasIdle)
             props.onActivity?.()
         }}
         // focusin bubbles from a dot button, so tabbing through the dots keeps the rail

--- a/frontend/src/components/chat/ChatView.css.ts
+++ b/frontend/src/components/chat/ChatView.css.ts
@@ -2,6 +2,9 @@ import { globalStyle, keyframes, style } from '@vanilla-extract/css'
 import { resizeHandleSelectors } from '~/styles/resizeHandle'
 import { chipBase } from '~/styles/shared.css'
 import { breakpoints, motion } from '~/styles/tokens'
+import { CHAT_PAD_LEFT_VAR, CHAT_PAD_RIGHT_VAR, CHAT_RAIL_WIDTH_VAR, COARSE_HIT_PX } from './chatChromeVars'
+import { BAND_BORDER_PX } from './chatRowGeometry'
+import { contentColumnBleed } from './messageStyles.css'
 
 export const editorResizeHandle = style({
   height: '4px',
@@ -23,11 +26,93 @@ export const editorResizeHandleActive = style({
   },
 })
 
+/**
+ * Horizontal inset of the composer box. Deliberately NOT the list's gutter
+ * (`CHAT_PAD_LEFT_VAR`, one step wider): the composer is a bordered box on the
+ * panel, and the list is a column of rows that run to the panel edge, so the two
+ * insets answer different questions and must not be folded into one token.
+ */
+const COMPOSER_INSET = 'var(--space-3)'
+
+/**
+ * The chat list's horizontal gutter, as CSS vars so the band rows can cancel it.
+ * An assistant band paints edge to edge: it negates these two values and adds
+ * them back as padding (see `bandRow` in ~/components/chat/messageStyles.css.ts),
+ * which only works while the gutter has ONE definition. Declared on the chat
+ * ROOT rather than on the list: the scroll rail sizes its column from the right
+ * gutter and is the list's SIBLING, so a definition on the list itself would be
+ * out of its reach. `premeasureRoot` INHERITS them from here, media override
+ * included, which is what puts the hidden measurement in the same horizontal
+ * geometry as the live list.
+ */
+const chatGutterVars = {
+  [CHAT_PAD_LEFT_VAR]: 'var(--space-4)',
+  [CHAT_PAD_RIGHT_VAR]: 'var(--space-4)',
+} as const
+
+/**
+ * The scroll rail's column, published as a token on the chat root.
+ *
+ * The rail IS the gutter: it fills that strip exactly, so its track, thumb and
+ * dots -- all centred in it -- run down the gutter's middle. Its box also stops
+ * at the gutter, which matters because the rail overlays a row from outside that
+ * row's stacking context and stays hit-testable while faded: every pointer event
+ * inside the rail's box goes to the rail, and no z-index or pointer-events
+ * arrangement inside the row changes that. A box that stops at the gutter cannot
+ * receive an event meant for a row's floating action buttons.
+ *
+ * Two floors keep the column usable where the gutter alone is too thin to press:
+ * the phone gutter shrinks to 4px to reclaim text width, and a coarse pointer
+ * needs a whole finger. Both floors make the column WIDER than the gutter, so it
+ * does overhang the message column -- which is why the row's floating actions are
+ * inset by exactly that overhang (see the toolbar rules in
+ * ~/components/chat/messageStyles.css.ts). The inset is computed from these same
+ * two properties, so it is zero whenever the column is the bare gutter and it
+ * tracks either floor automatically.
+ */
+const RAIL_MIN_WIDTH = '16px'
+const chatRailVars = {
+  [CHAT_RAIL_WIDTH_VAR]: `max(var(${CHAT_PAD_RIGHT_VAR}), ${RAIL_MIN_WIDTH})`,
+} as const
+
 export const container = style({
-  display: 'flex',
-  flexDirection: 'column',
-  height: '100%',
-  overflow: 'hidden',
+  'display': 'flex',
+  'flexDirection': 'column',
+  'height': '100%',
+  'overflow': 'hidden',
+  'vars': { ...chatGutterVars, ...chatRailVars },
+  '@media': {
+    /**
+     * Phone gutters. The rail floats over the right edge, so 16px reserved there is pure
+     * lost text width; 4px still separates the text from the panel edge. The left drops to
+     * 12px rather than matching 4px for two reasons: the span-line stack overhangs the
+     * content box by COL_OVERLAP (5px, see ./widgets/SpanLines.css.ts) and `overflowX:
+     * hidden` would clip it, and 24px against 4px reads visibly uneven on a 360px viewport.
+     *
+     * Declared HERE, with the gutter itself, so the rail -- the list's sibling -- narrows
+     * with it rather than reading a stale desktop value.
+     */
+    [`(max-width: ${breakpoints.sm - 1}px)`]: {
+      vars: {
+        [CHAT_PAD_LEFT_VAR]: 'var(--space-3)',
+        [CHAT_PAD_RIGHT_VAR]: 'var(--space-1)',
+      },
+    },
+    /**
+     * A finger cannot press a 16px strip. The rail's column is the only part of the rail
+     * that a track click or a thumb drag can land on, so it takes the finger size directly
+     * -- the dots carry their own hit circle of the same diameter (DOT_COARSE_HIT_PX in
+     * ~/components/chat/ChatScrollRail.css.ts, derived from the same constant).
+     *
+     * Declared as a floor rather than a fixed width, so a wide desktop-class gutter on a
+     * touch screen still gives the rail the whole gutter and no more.
+     */
+    '(pointer: coarse)': {
+      vars: {
+        [CHAT_RAIL_WIDTH_VAR]: `max(var(${CHAT_PAD_RIGHT_VAR}), ${COARSE_HIT_PX}px)`,
+      },
+    },
+  },
 })
 
 export const messageListWrapper = style({
@@ -50,11 +135,36 @@ export const messageListSelectionRoot = style({
   overflowAnchor: 'none',
 })
 
+/**
+ * Flow gap between the virtual spacer and the in-flow tail UI below it.
+ *
+ * Named because two rules must agree on it: this gap, and the negative margin that
+ * `bandTailMerged` uses to cancel it. It also matches the virtualizer's own
+ * gapLargePx, which ChatView measures from the same token (see the
+ * `measureSpaceToken('--space-5', …)` call), so a virtual row and the tail are
+ * spaced alike.
+ */
+const MESSAGE_LIST_ROW_GAP = 'var(--space-5)'
+
 export const messageListContent = style({
   display: 'flex',
   flexDirection: 'column',
   flexShrink: 0,
-  gap: 'var(--space-5)',
+  gap: MESSAGE_LIST_ROW_GAP,
+})
+
+/**
+ * Merge the streaming tail's band into the band of the row directly above it.
+ *
+ * The virtualizer overlaps two adjacent bands by one border width in its offset
+ * map, so the pair shows one line. The tail is not in that map -- it is a flow
+ * sibling of the virtual spacer -- so the same merge has to be spelled here: cancel
+ * the flow gap, then one more border so the tail's top border lands on the row's
+ * bottom border. Without it the reader watches a gap and two separate lines while
+ * the reply streams, which close the instant the persisted row lands.
+ */
+export const bandTailMerged = style({
+  marginTop: `calc(-1 * ${MESSAGE_LIST_ROW_GAP} - ${BAND_BORDER_PX}px)`,
 })
 
 export const messageList = style({
@@ -62,7 +172,7 @@ export const messageList = style({
   'overflowX': 'hidden',
   'overflowY': 'auto',
   'overflowAnchor': 'none',
-  'padding': 'var(--space-4)',
+  'padding': `var(--space-4) var(${CHAT_PAD_RIGHT_VAR}) var(--space-4) var(${CHAT_PAD_LEFT_VAR})`,
   'display': 'flex',
   'flexDirection': 'column',
   'gap': 'var(--space-3)',
@@ -89,17 +199,6 @@ export const messageList = style({
      */
     '(pointer: coarse)': {
       scrollbarWidth: 'none',
-    },
-    /**
-     * Phone gutters. The rail floats over the right edge, so 16px reserved there is pure
-     * lost text width; 4px still keeps the text off the glass. The left drops to 12px
-     * rather than matching 4px for two reasons: the span-line stack overhangs the content
-     * box by COL_OVERLAP (5px, see ./widgets/SpanLines.css.ts) and `overflowX: hidden`
-     * would clip it, and 24px against 4px reads visibly lopsided on a 360px viewport.
-     */
-    [`(max-width: ${breakpoints.sm - 1}px)`]: {
-      paddingLeft: 'var(--space-3)',
-      paddingRight: 'var(--space-1)',
     },
   },
 })
@@ -178,7 +277,7 @@ export const inputArea = style({
   // Bottom padding is space-1 when the status bar is shown beneath, and
   // space-2 when it's hidden (the status bar's own space-2 bottom padding
   // then provides the gap to the window edge instead).
-  padding: 'var(--space-1) var(--space-3) var(--space-1)',
+  padding: `var(--space-1) ${COMPOSER_INSET} var(--space-1)`,
   flexShrink: 0,
 })
 
@@ -311,13 +410,28 @@ export const rateLimitCountdown = style({
   whiteSpace: 'nowrap',
 })
 
-export const messageRow = style({
+/**
+ * A row's RAILED wrapper: the span-line stack beside the content column. Named
+ * for the rails, NOT `messageRow`, because `~/components/chat/messageStyles.css.ts`
+ * exports a different class under that name -- the bubble row that the band and
+ * meta selectors target. Two exports with one name make a reader decide which is
+ * meant at every read, and a `:has()` selector written against the wrong one
+ * matches nothing at all.
+ */
+export const railedRow = style({
   display: 'flex',
 })
 
-export const messageRowContent = style({
+/** The content column beside those rails. */
+export const railedRowContent = style({
   flex: 1,
   minWidth: 0,
+  // Widen the CLIP box to both panel edges without moving the content box, so a
+  // bleeding descendant (a turn-end rule, a user bubble's right side) is not cut
+  // off at the content column. `flex: 1` absorbs the negative margins -- the box
+  // grows by exactly what they remove, and the equal padding gives the content
+  // back its original width -- so a row without a bleeding child is unchanged.
+  ...contentColumnBleed,
   // Isolate the bubble's layout/paint so an internal change (e.g. a tool card
   // expanding) doesn't invalidate the span columns beside it. The row itself
   // is also contained (see virtualRow); this inner boundary keeps bubble
@@ -400,12 +514,26 @@ export const premeasureRoot = style({
   overflow: 'hidden',
   zIndex: -1,
   contain: 'layout paint',
+  // Deliberately no `vars: chatGutterVars` here. This element is a descendant of
+  // `container`, so it already INHERITS the gutter -- media override and all. A
+  // restatement would carry the desktop values only, and below breakpoints.sm the
+  // measured row would then read a 16px gutter where the live row reads 4px. That
+  // costs nothing on a band, whose margins and padding cancel, but a bleeding
+  // DESCENDANT (a turn-end rule) resolves its negative margins straight from these
+  // two values: it would measure a whole gutter wider than it renders, wrap its
+  // label at the wrong width, and commit a short height into the offset map.
 })
 
+// Sized to the premeasure root's own width, which ChatView sets to the live
+// list's CONTENT width. Deliberately no `width: 100%`: with border-box sizing a
+// band row's negative gutter margins plus its equal padding would leave a
+// content box two gutters too narrow, so band text would wrap differently here
+// than in the list and commit a wrong height. A block box with auto width
+// resolves to the containing block minus its own margins, which lands on the
+// live row's content width for a band and a non-band alike.
 export const premeasureRow = style({
   display: 'flow-root',
   position: 'relative',
-  width: '100%',
 })
 
 export const editorPanelWrapper = style({

--- a/frontend/src/components/chat/ChatView.test.tsx
+++ b/frontend/src/components/chat/ChatView.test.tsx
@@ -11,9 +11,11 @@ import { KEY_BROWSER_PREFS, localStorageSet } from '~/lib/browserStorage'
 import { flushAnimationFrame, installControllableResizeObserver, triggerResizeObserverFor, triggerResizeObservers } from '~/test-support/resizeObserverStub'
 import { railIdle } from './ChatScrollRail.css'
 import { ChatView, RAIL_MOMENTUM_GRACE_MS, RAIL_VISIBLE_IDLE_MS, rowChromeHeightKey, SKELETON_SHOW_DELAY_MS, SYNTAX_HIGHLIGHT_SCROLL_IDLE_MS } from './ChatView'
-import { messageListRailActive, rowSkeletonClosing } from './ChatView.css'
+import { bandTailMerged, messageListRailActive, railedRowContent, rowSkeletonClosing } from './ChatView.css'
 import { computeOverscanPx, PRE_MEASURE_WIDTH_PX } from './chatViewportGeometry'
+import { bandMessage, bandRow, bandRowThought, bleedRow } from './messageStyles.css'
 import { sameVirtualItems } from './useChatVirtualizer'
+import { ROW_BLEED_LEFT_VAR, rowBleedLeftStyle } from './widgets/SpanLines.geometry'
 
 const A_TXT_RE = /a\.txt/
 const B_TXT_RE = /b\.txt/
@@ -797,6 +799,95 @@ describe('chatView', () => {
     expect(screen.getByText('Hi there')).toBeInTheDocument()
   })
 
+  it('marks assistant message and thought ROWS as bands, and nothing else', () => {
+    // The full-bleed strip is the ROW's own background and border, so the band
+    // marker must land on the row wrapper -- not on the bubble, which paint
+    // containment would clip at the list gutter.
+    const withContent = (id: string, inner: unknown, seq: bigint): AgentChatMessage => ({
+      ...makeMessage('assistant', '', id),
+      seq,
+      content: new TextEncoder().encode(JSON.stringify(inner)),
+    })
+    const messages = [
+      withContent('m1', { type: 'assistant', message: { content: [{ type: 'text', text: 'answer' }] } }, 1n),
+      withContent('m2', { type: 'assistant', message: { content: [{ type: 'thinking', thinking: 'pondering' }] } }, 2n),
+      withContent('m3', { type: 'assistant', message: { content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'ls' } }] } }, 3n),
+    ]
+
+    const view = render(() => (
+      <PreferencesProvider>
+        <ChatView messages={messages} streamingText="" />
+      </PreferencesProvider>
+    ))
+
+    const bands = [...view.container.querySelectorAll('[data-seq]')]
+      .map(row => (row as HTMLElement).dataset.band)
+    expect(bands).toEqual(['text', 'thought', undefined])
+  })
+
+  it('publishes the distance to the panel edge on the row content column, rails included', () => {
+    // A bleeding child reads this var instead of assuming the bare gutter. On a
+    // row WITH rails the content column starts further right, and a bleed that
+    // ignored that stopped short of the panel edge.
+    const withSpanLines = (id: string, seq: bigint, lines: unknown[]): AgentChatMessage => ({
+      ...makeMessage('assistant', 'answer', id),
+      seq,
+      spanLines: JSON.stringify(lines),
+    })
+    const messages = [
+      withSpanLines('m1', 1n, []),
+      withSpanLines('m2', 2n, [
+        { span_id: 's1', color: 1, type: 'active' },
+        { span_id: 's2', color: 2, type: 'active' },
+      ]),
+    ]
+
+    const view = render(() => (
+      <PreferencesProvider>
+        <ChatView messages={messages} streamingText="" />
+      </PreferencesProvider>
+    ))
+
+    const columnOf = (seq: string) => {
+      const row = view.container.querySelector(`[data-seq="${seq}"]`) as HTMLElement
+      return row.querySelector('[data-span-columns]')!.matches('[data-span-columns="0"]')
+        ? row.querySelector('[data-span-columns="0"]') as HTMLElement
+        : row.querySelector(`.${railedRowContent}`) as HTMLElement
+    }
+
+    expect(columnOf('1').style.getPropertyValue(ROW_BLEED_LEFT_VAR))
+      .toBe(rowBleedLeftStyle(0)[ROW_BLEED_LEFT_VAR])
+    expect(columnOf('2').style.getPropertyValue(ROW_BLEED_LEFT_VAR))
+      .toBe(rowBleedLeftStyle(2)[ROW_BLEED_LEFT_VAR])
+    // The two must differ, or the rails were not folded in at all.
+    expect(columnOf('1').style.getPropertyValue(ROW_BLEED_LEFT_VAR))
+      .not
+      .toBe(columnOf('2').style.getPropertyValue(ROW_BLEED_LEFT_VAR))
+  })
+
+  it('widens a turn-end divider row without banding it', () => {
+    // A divider bleeds like a band, but its rule is drawn by a DESCENDANT, so
+    // the row only widens -- it paints no strip and carries no band marker.
+    const messages = [{
+      ...makeMessage('assistant', '', 'm1'),
+      seq: 1n,
+      content: new TextEncoder().encode(JSON.stringify({ type: 'result', subtype: 'success', duration_ms: 1200 })),
+    }]
+
+    const view = render(() => (
+      <PreferencesProvider>
+        <ChatView messages={messages} streamingText="" />
+      </PreferencesProvider>
+    ))
+
+    const row = view.container.querySelector('[data-seq="1"]') as HTMLElement | null
+    expect(row).not.toBeNull()
+    expect(row!.classList.contains(bleedRow)).toBe(true)
+    expect(row!.classList.contains(bandRow)).toBe(false)
+    expect(row!.dataset.band).toBeUndefined()
+    expect(view.container.querySelector('[data-testid="result-divider"]')).not.toBeNull()
+  })
+
   it('hides a trailing optimistic local while windowed away from the live tail', () => {
     const messages = [
       makeMessage('assistant', 'Server reply', 'm1'),
@@ -961,6 +1052,69 @@ describe('chatView', () => {
     expect(tailRow!.style.visibility).toBe('')
     expect(tailRow!.style.opacity).toBe('1')
     expect(spacer!.style.height).toBe('532px')
+  })
+
+  it('wears the assistant band on the streaming tail, so the strip does not appear only once the row lands', async () => {
+    // The tail is NOT a virtual row -- it sits in flow beside the spacer -- so it
+    // carries the band classes itself. Without them the gray strip would pop into
+    // existence at the moment streaming text is replaced by the persisted row.
+    const view = render(() => (
+      <PreferencesProvider>
+        <ChatView messages={[]} streamingText="Streaming answer" />
+      </PreferencesProvider>
+    ))
+
+    await waitFor(() => expect(screen.getByText('Streaming answer')).toBeInTheDocument())
+
+    const tail = view.container.querySelector('[data-band="text"]') as HTMLElement | null
+    expect(tail).not.toBeNull()
+    expect(tail!.classList.contains(bandRow)).toBe(true)
+    expect(tail!.classList.contains(bandRowThought)).toBe(false)
+    expect(tail!.querySelector(`.${bandMessage}`)).not.toBeNull()
+    expect(tail!.textContent).toContain('Streaming answer')
+    // Nothing above it, so there is no band to merge into and the gap stays.
+    expect(tail!.classList.contains(bandTailMerged)).toBe(false)
+  })
+
+  it('merges the streaming tail into the band above it, so the seam does not close when the row lands', async () => {
+    // The tail is in FLOW, not in the offset map, so the virtualizer's band overlap cannot
+    // reach it. Without its own merge the reader watches a gap and two border lines for the
+    // whole of a streamed reply, which snap into one line the instant the message lands --
+    // and the transcript above the seam jumps by that gap plus a border.
+    const withContent = (id: string, inner: unknown): AgentChatMessage => ({
+      ...makeMessage('assistant', '', id),
+      seq: 1n,
+      content: new TextEncoder().encode(JSON.stringify(inner)),
+    })
+    const thought = withContent('m1', { type: 'assistant', message: { content: [{ type: 'thinking', thinking: 'pondering' }] } })
+    const toolUse = withContent('m1', { type: 'assistant', message: { content: [{ type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'ls' } }] } })
+
+    // The tail is the LAST band in flow; a virtual row comes before it.
+    const tailOf = (container: HTMLElement) => {
+      const bands = [...container.querySelectorAll('[data-band="text"]')] as HTMLElement[]
+      return bands[bands.length - 1]
+    }
+
+    // A visible thought above the tail: two bands that must read as one surface, so the
+    // tail cancels the flow gap it would otherwise keep.
+    const withThought = render(() => (
+      <PreferencesProvider>
+        <ChatView messages={[thought]} streamingText="Streaming answer" />
+      </PreferencesProvider>
+    ))
+    await waitFor(() => expect(withThought.container.querySelector('[data-band="thought"]')).not.toBeNull())
+    expect(tailOf(withThought.container).classList.contains(bandTailMerged)).toBe(true)
+    withThought.unmount()
+
+    // A tool row above it is not a band, so the tail keeps the ordinary flow gap.
+    const withTool = render(() => (
+      <PreferencesProvider>
+        <ChatView messages={[toolUse]} streamingText="Streaming answer" />
+      </PreferencesProvider>
+    ))
+    await waitFor(() => expect(tailOf(withTool.container)).toBeDefined())
+    expect(withTool.container.querySelector('[data-band="thought"]')).toBeNull()
+    expect(tailOf(withTool.container).classList.contains(bandTailMerged)).toBe(false)
   })
 
   it('keeps streaming text visible until its replacement row is measured', async () => {
@@ -2409,6 +2563,46 @@ describe('chat view virtualized with stubbed deps', () => {
       expect(interior!.style.visibility).toBe('hidden')
       expect(tail).not.toBeNull()
       expect(tail!.style.visibility).toBe('hidden')
+    })
+
+    it('gives a band row its own chrome while its skeleton stands in for it', () => {
+      // The skeleton slot is a FOURTH row-mount site. The row it covers is invisible, and a
+      // band's gray surface and its two border lines belong to the ROW -- so without the
+      // chrome here the shimmer sits on the bare panel and the band appears only at the
+      // crossfade, which is the pop-in the tail already avoids.
+      vi.useFakeTimers()
+      virtualizerState.attachedIds = []
+      virtualizerState.measuredIds = new Set(['m0'])
+      virtualizerState.currentHeightKeys = new Map()
+      virtualizerState.setDeferred?.(false)
+      hiddenPremeasureState.candidates = []
+      hiddenPremeasureState.onMeasure = undefined
+      virtualizerState.setRange?.({ start: 0, end: 1 })
+      // The full Claude envelope: `type: 'assistant'` is what makes the row a band.
+      const assistantText = (id: string, seq: bigint, text: string): AgentChatMessage => ({
+        ...makeMessage('assistant', '', id),
+        seq,
+        content: new TextEncoder().encode(JSON.stringify({
+          type: 'assistant',
+          message: { content: [{ type: 'text', text }] },
+        })),
+      })
+      const [messages, setMessages] = createSignal([assistantText('m0', 1n, 'first')])
+      const { container } = render(() => (
+        <ChatView messages={messages()} streamingText="" />
+      ))
+
+      virtualizerState.setRange?.({ start: 0, end: 2 })
+      setMessages([assistantText('m0', 1n, 'first'), assistantText('m1', 2n, 'answer')])
+      vi.advanceTimersByTime(SKELETON_SHOW_DELAY_MS)
+
+      const skeleton = container.querySelector('[data-testid="row-skeleton"]')
+      expect(skeleton).not.toBeNull()
+      const slot = skeleton!.parentElement!
+      expect(slot.classList.contains(bandRow)).toBe(true)
+      // The class ONLY. `data-band` is the e2e hook, and a second visible element carrying
+      // it would break the seam check that walks every [data-band] in DOM order.
+      expect(slot.hasAttribute('data-band')).toBe(false)
     })
 
     it('defers loading skeletons past the show-delay, then paints them (including the live tail)', () => {

--- a/frontend/src/components/chat/ChatView.tsx
+++ b/frontend/src/components/chat/ChatView.tsx
@@ -17,7 +17,7 @@ import { Icon } from '~/components/common/Icon'
 import { SelectionQuotePopover } from '~/components/common/SelectionQuotePopover'
 import { Spinner } from '~/components/common/Spinner'
 import { usePreferences } from '~/context/PreferencesContext'
-import { AgentStatus } from '~/generated/leapmux/v1/agent_pb'
+import { AgentStatus, MessageSource } from '~/generated/leapmux/v1/agent_pb'
 import { formatChatQuote } from '~/lib/quoteUtils'
 import { motion } from '~/styles/tokens'
 import { AgentStartupBanner } from './AgentStartupBanner'
@@ -27,7 +27,7 @@ import { createMessageUiState } from './chatMessageUiState'
 import { createOrderedTailReveal } from './chatOrderedReveal'
 import { createChatPremeasureBands } from './chatPremeasureBands'
 import { resolveScrollbarOwner } from './chatRailPolicy'
-import { kindScopedLayoutKey } from './chatRowGeometry'
+import { kindScopedLayoutKey, messageBandKind } from './chatRowGeometry'
 import { createRowHeightPersistence } from './chatRowHeightPersistence'
 import { createScrollActivity } from './chatScrollActivity'
 import { ChatScrollRail } from './ChatScrollRail'
@@ -38,8 +38,8 @@ import * as styles from './ChatView.css'
 import { computeOverscanPx, createViewportSizeObserver, measureSpaceToken, PRE_MEASURE_WIDTH_PX } from './chatViewportGeometry'
 import { markdownContent } from './markdownEditor/markdownContent.css'
 import { MessageBubble } from './MessageBubble'
+import { messageBubbleClass, messageRowChrome } from './messageClassification'
 import { createMessageRenderCacheStore } from './messageRenderCache'
-import { assistantMessage } from './messageStyles.css'
 import { expandedUiKeyFor, messageUiDefault } from './messageUiKeys'
 import { ToolUseLayout } from './toolRenderers'
 import { useChatScroll } from './useChatScroll'
@@ -47,7 +47,7 @@ import { sameVirtualItems, useChatVirtualizer } from './useChatVirtualizer'
 import { ChatRowSkeleton } from './widgets/ChatRowSkeleton'
 import { SpanLineGapBridges } from './widgets/SpanLineGapBridges'
 import { SpanLines } from './widgets/SpanLines'
-import { NO_SPAN_MARGIN } from './widgets/SpanLines.geometry'
+import { reservedRowContentColumnStyle, rowBleedLeftStyle } from './widgets/SpanLines.geometry'
 import { ThinkingIndicator } from './widgets/ThinkingIndicator'
 
 /**
@@ -57,11 +57,11 @@ import { ThinkingIndicator } from './widgets/ThinkingIndicator'
  */
 export const SYNTAX_HIGHLIGHT_SCROLL_IDLE_MS = 160
 /**
- * How long the floating scroll rail stays lit after the last scroll activity, on the
- * touch / narrow viewports where it auto-hides at all. Much longer than the
- * syntax-highlight pause on purpose: that one only has to outlast a repaint, while this
- * is a navigation affordance the reader must have time to see, aim at, and tap a jump
- * dot on.
+ * How long the floating scroll rail stays lit after the last scroll activity. Every
+ * viewport and pointer fades it the same way. Much longer than the syntax-highlight
+ * pause on purpose: that one only has to outlast a repaint, while this is a navigation
+ * affordance the reader must have time to see, aim at, and tap a jump dot on. A mouse
+ * that rests on the strip holds it lit past this window -- see the rail's `hovered`.
  */
 export const RAIL_VISIBLE_IDLE_MS = 1200
 /**
@@ -727,6 +727,19 @@ export const ChatView: Component<ChatViewProps> = (props) => {
     isCoveredByInFlowTail(id) || rowHiddenPendingReveal(id)
   )
 
+  // The streaming tail paints a band, and so does the last virtual row above it in
+  // the common case (a thought, then the streamed reply). The virtualizer merges
+  // two adjacent bands in its offset map, but the tail has no offset-map entry, so
+  // it must cancel its own flow gap. Requires the row above to be PAINTING: a row
+  // held invisible until it measures shows no band, and merging against it would
+  // pull the tail up over blank space.
+  const tailMergesWithRowAbove = createMemo(() => {
+    const above = tailVisibleEntry()
+    return above !== undefined
+      && messageBandKind(above.category.kind) !== undefined
+      && !rowHiddenUntilMeasured(above.msg.id)
+  })
+
   // Fling-skeleton phases for the rendered rows, collected into one reactive set so the
   // gap-bridge overlay (rendered outside the rows) can see which rows are skeletons.
   const flingSkeletons = createFlingSkeletonRegistry(virt, SKELETON_CROSSFADE_MS)
@@ -954,7 +967,19 @@ export const ChatView: Component<ChatViewProps> = (props) => {
   // place instead of two copies that could drift.
   const positionedRowSkeleton = (entry: ClassifiedEntry, closing = false) => (
     <div
-      class={closing ? `${styles.virtualRow} ${styles.rowSkeletonClosing}` : styles.virtualRow}
+      // A band row's decoration is the ROW's own background and border, and the row
+      // this slot stands in for is invisible -- so without the chrome here the
+      // shimmer bars sit on the bare panel and the band appears only at the
+      // crossfade. Carries the class and NOT `data-band`: the marker is an e2e
+      // hook, and a second visible element with it would break the seam check that
+      // walks every [data-band] in DOM order.
+      //
+      // The CLOSING copy stays bare on purpose. The real row is already visible
+      // underneath and paints its own band, so an opaque surface on the fading copy
+      // would cover the revealed text for the length of the crossfade.
+      class={closing
+        ? `${styles.virtualRow} ${styles.rowSkeletonClosing}`
+        : messageRowChrome(styles.virtualRow, entry.category.kind, entry.msg.source).class}
       style={{ transform: `translateY(${virt.offsetOfId(entry.msg.id) ?? 0}px)` }}
     >
       <ChatRowSkeleton height={virt.heightOfId(entry.msg.id)} seed={entry.msg.id} />
@@ -1033,6 +1058,7 @@ export const ChatView: Component<ChatViewProps> = (props) => {
                     precedingEntry={visibleEntries()[virt.range().start - 1]}
                     topOf={id => virt.offsetOfId(id) ?? 0}
                     hiddenOf={rowSpanColumnHidden}
+                    gapAboveOf={virt.gapAboveOf}
                   />
                   {/*
                     Loading skeletons: a premeasure-hidden row whose wait has
@@ -1075,9 +1101,19 @@ export const ChatView: Component<ChatViewProps> = (props) => {
                       // this row's bridge while the skeleton shows.
                       const upgradePhase = flingSkeletons.trackRow(msg.id)
 
+                      // An assistant message / thought paints a full-bleed band
+                      // BEHIND the row: the band is the row's own background and
+                      // border, so paint containment can't clip it and the span
+                      // rails and toolbar sit on top of the gray. Read once --
+                      // reclassifying a row replaces its entry, which remounts
+                      // this row. data-band is the e2e hook, because every style
+                      // class is a hashed name.
+                      const chrome = messageRowChrome(styles.virtualRow, entry.category.kind, msg.source)
+
                       return (
                         <div
-                          class={styles.virtualRow}
+                          class={chrome.class}
+                          data-band={chrome.band}
                           style={{
                             transform: `translateY(${top()}px)`,
                             // Absolute rows do not reserve flow height for
@@ -1116,13 +1152,28 @@ export const ChatView: Component<ChatViewProps> = (props) => {
                                     name, so an e2e spec has no other stable way
                                     to read the rail count of one row.
                                   */}
+                                  {/*
+                                    Both arms publish ROW_BLEED_LEFT_VAR: how far
+                                    the panel's left edge is from where this row's
+                                    content starts. The rails push that start
+                                    right by a width only the row knows, so a
+                                    bleeding child reads it instead of assuming
+                                    the bare gutter.
+                                  */}
                                   <Show
                                     when={parsedSpanLines.length > 0}
-                                    fallback={<div data-span-columns={parsedSpanLines.length} style={{ 'margin-left': `${NO_SPAN_MARGIN}px` }}>{bubble}</div>}
+                                    fallback={(
+                                      <div
+                                        data-span-columns={parsedSpanLines.length}
+                                        style={reservedRowContentColumnStyle(0)}
+                                      >
+                                        {bubble}
+                                      </div>
+                                    )}
                                   >
-                                    <div class={styles.messageRow} data-span-columns={parsedSpanLines.length}>
+                                    <div class={styles.railedRow} data-span-columns={parsedSpanLines.length}>
                                       <SpanLines lines={parsedSpanLines} />
-                                      <div class={styles.messageRowContent}>
+                                      <div class={styles.railedRowContent} style={rowBleedLeftStyle(parsedSpanLines.length)}>
                                         {bubble}
                                       </div>
                                     </div>
@@ -1155,12 +1206,31 @@ export const ChatView: Component<ChatViewProps> = (props) => {
                     {streamingTail => (
                       <Show
                         when={streamingTail().type === 'plan'}
-                        fallback={(
-                          <div class={assistantMessage}>
-                            {/* eslint-disable-next-line solid/no-innerhtml -- streaming text rendered via remark */}
-                            <div class={markdownContent} innerHTML={streamingTail().html} />
-                          </div>
-                        )}
+                        fallback={(() => {
+                          // The live tail wears the SAME chrome as the persisted
+                          // assistant row that replaces it, so the band does not
+                          // appear only after the message lands. Derived from the
+                          // kind it will become, never hardcoded: this is a row
+                          // mount site like the other three, and a hand-written
+                          // copy is what lets them drift.
+                          const chrome = messageRowChrome('', 'assistant_text', MessageSource.AGENT)
+                          return (
+                            <div
+                              // The tail sits in FLOW, not in the offset map, so the
+                              // virtualizer's band overlap cannot reach it. Cancel
+                              // the flow gap and one border here instead, or the
+                              // reader sees two lines and a gap that snap into one
+                              // line the instant the message lands.
+                              class={tailMergesWithRowAbove() ? `${chrome.class} ${styles.bandTailMerged}` : chrome.class}
+                              data-band={chrome.band}
+                            >
+                              <div class={messageBubbleClass('assistant_text', MessageSource.AGENT)}>
+                                {/* eslint-disable-next-line solid/no-innerhtml -- streaming text rendered via remark */}
+                                <div class={markdownContent} innerHTML={streamingTail().html} />
+                              </div>
+                            </div>
+                          )
+                        })()}
                       >
                         <ToolUseLayout
                           icon={PlaneTakeoff}
@@ -1264,11 +1334,11 @@ export const ChatView: Component<ChatViewProps> = (props) => {
             // derived from ONE railOwner resolution (single viewport-height source), so the rail is
             // shown exactly when the native bar is hidden -- never zero, never two scrollbars.
             hidden={railOwner() !== 'rail'}
-            // Paint-only auto-hide on touch / narrow viewports; never an unmount (see the
-            // rail's scrollActive prop). Driven by railActivity, which takes user input plus
-            // a momentum-gated scroll, so a streaming turn's stick-to-bottom writes cannot
-            // light it. Passed unconditionally: every declaration the resulting class carries
-            // lives inside a media query, so desktop is unaffected with no JS branch here.
+            // Paint-only auto-hide; never an unmount (see the rail's scrollActive prop).
+            // Driven by railActivity, which takes user input plus a momentum-gated scroll, so
+            // a streaming turn's stick-to-bottom writes cannot light it. Every viewport and
+            // pointer fades the idle rail the same way -- only the `pointer-events` half of
+            // railIdle is coarse-only -- so there is no JS branch here.
             scrollActive={railActivity.active()}
             // The rail's own interactions (grab, drag move, dot hover or focus) reopen the
             // window -- a captured thumb drag fires no events on the scroll container.

--- a/frontend/src/components/chat/MessageBubble.test.tsx
+++ b/frontend/src/components/chat/MessageBubble.test.tsx
@@ -2,8 +2,10 @@ import { fireEvent, render, screen, waitFor } from '@solidjs/testing-library'
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { codeCopyHostClass } from '~/components/chat/markdownEditor/markdownContent.css'
 import { MessageBubble } from '~/components/chat/MessageBubble'
+import * as bubbleStyles from '~/components/chat/MessageBubble.css'
+import { classifyAgentMessage, messageRowChromeClass } from '~/components/chat/messageClassification'
 import * as chatStyles from '~/components/chat/messageStyles.css'
-import { toolBodyContent } from '~/components/chat/toolStyles.css'
+import { toolBodyContent, toolHeaderTimestamp } from '~/components/chat/toolStyles.css'
 import { PreferencesProvider, usePreferences } from '~/context/PreferencesContext'
 import { AgentProvider, MessageSource } from '~/generated/leapmux/v1/agent_pb'
 import { KEY_BROWSER_PREFS, localStorageSet } from '~/lib/browserStorage'
@@ -262,6 +264,80 @@ describe('thinking message toolbar buttons', () => {
 
     expect(screen.queryByTestId('message-quote')).toBeInTheDocument()
     expect(screen.queryByTestId('message-copy-markdown')).toBeInTheDocument()
+  })
+
+  it('orders the toolbar timestamp, Copy Raw JSON, Copy Markdown, then Quote', () => {
+    const innerMsg = {
+      type: 'assistant',
+      message: { content: [{ type: 'thinking', thinking: 'Order matters.' }] },
+    }
+    const msg = makeMsg({
+      source: MessageSource.AGENT,
+      content: rawContent(innerMsg),
+    })
+
+    render(() => (
+      <PreferencesProvider>
+        <MessageBubble message={msg} onReply={() => {}} />
+      </PreferencesProvider>
+    ))
+
+    // One order for every left-to-right row -- a tool header and an agent
+    // message row used to disagree, which moved the same two buttons between
+    // rows depending on which row was above.
+    const toolbar = screen.getByTestId('message-toolbar')
+    const ids = [...toolbar.querySelectorAll('[data-testid]')].map(el => el.getAttribute('data-testid'))
+    expect(ids).toEqual(['message-copy-json', 'message-copy-markdown', 'message-quote'])
+    // The timestamp leads, ahead of every button.
+    const timestamp = toolbar.querySelector(`.${toolHeaderTimestamp}`)
+    expect(timestamp).not.toBeNull()
+    expect(timestamp!.compareDocumentPosition(screen.getByTestId('message-copy-json')))
+      .toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+  })
+
+  it('keeps the mirrored order on a user row: Quote first, then the timestamp', () => {
+    // A user bubble is right-aligned and its toolbar is laid out right-to-left
+    // beside it, so Quote leads in the DOM to land nearest the bubble. The agent
+    // rows' order change must NOT reach this row.
+    const msg = makeMsg({
+      source: MessageSource.USER,
+      content: rawContent({ content: 'ping' }),
+    })
+
+    render(() => (
+      <PreferencesProvider>
+        <MessageBubble message={msg} onReply={() => {}} />
+      </PreferencesProvider>
+    ))
+
+    const toolbar = screen.getByTestId('message-toolbar')
+    const ids = [...toolbar.querySelectorAll('[data-testid]')].map(el => el.getAttribute('data-testid'))
+    expect(ids).toEqual(['message-quote', 'message-copy-markdown', 'message-copy-json'])
+    const timestamp = toolbar.querySelector(`.${toolHeaderTimestamp}`)
+    expect(timestamp).not.toBeNull()
+    expect(timestamp!.compareDocumentPosition(screen.getByTestId('message-quote')))
+      .toBe(Node.DOCUMENT_POSITION_PRECEDING)
+  })
+
+  it('gives a message and a thought the same chrome-less band content class', () => {
+    const bandContent = (inner: unknown) => {
+      const { unmount } = render(() => (
+        <PreferencesProvider>
+          <MessageBubble message={makeMsg({ source: MessageSource.AGENT, content: rawContent(inner) })} />
+        </PreferencesProvider>
+      ))
+      const cls = screen.getByTestId('message-bubble').className
+      unmount()
+      return cls
+    }
+
+    // The band's own strip -- background, borders, full bleed -- belongs to the
+    // ROW, so the element inside it carries no bubble chrome at all.
+    const thought = bandContent({ type: 'assistant', message: { content: [{ type: 'thinking', thinking: 'hmm' }] } })
+    const text = bandContent({ type: 'assistant', message: { content: [{ type: 'text', text: 'hello' }] } })
+    expect(text).toContain(chatStyles.bandMessage)
+    expect(thought).toBe(text)
+    expect(text).not.toContain(chatStyles.messageBubble)
   })
 
   it('keeps inert Quote and Copy Markdown button slots during premeasure', async () => {
@@ -1163,6 +1239,81 @@ describe('pending user bubble state', () => {
     ))
 
     expect(screen.getByTestId('message-bubble')).toHaveClass(chatStyles.userMessagePending)
+  })
+
+  it('widens the row behind a pulsing local bubble, which bleeds like a settled one', () => {
+    // `userMessagePending` spreads the same `userBubble`, so it carries the negative right
+    // margin that runs the bubble to the panel edge. Paint containment on the virtual row
+    // clips a descendant to the row's padding box, so the row has to widen to match -- and
+    // this branch is picked by isPendingUserMessage, which messageBubbleClass never sees.
+    // The invariant test beside messageBubbleClass therefore cannot reach it.
+    const msg = makeMsg({
+      id: 'local-3',
+      source: MessageSource.USER,
+      content: rawContent({ content: 'hello' }),
+    })
+
+    render(() => (
+      <PreferencesProvider>
+        <MessageBubble message={msg} />
+      </PreferencesProvider>
+    ))
+
+    expect(screen.getByTestId('message-bubble')).toHaveClass(chatStyles.userMessagePending)
+    expect(messageRowChromeClass(classifyAgentMessage(msg).kind, msg.source)).toBe(chatStyles.bleedRow)
+  })
+
+  it('closes the bubble again when the message failed to deliver', () => {
+    // The "Failed to deliver / Retry / Delete" line is a sibling below the row, laid out
+    // against the row's content edge -- so a bleeding bubble above it would leave the two
+    // right edges a whole gutter apart. Bleeding that line to match would put Retry and
+    // Delete under the scroll rail's column, which takes every pointer event in its own box.
+    const msg = makeMsg({
+      id: 'local-4',
+      source: MessageSource.USER,
+      content: rawContent({ content: 'hello' }),
+    })
+
+    const { container } = render(() => (
+      <PreferencesProvider>
+        <MessageBubble message={msg} error="Failed to deliver" />
+      </PreferencesProvider>
+    ))
+
+    expect(container.querySelector(`.${bubbleStyles.messageWithError}`)).not.toBeNull()
+    expect(screen.getByTestId('message-error')).toBeInTheDocument()
+    // The bubble is still a user bubble, and it drops ONLY the flush-right marker.
+    // Nothing cancels a bleed here: without the marker no bleed is declared at all.
+    expect(screen.getByTestId('message-bubble')).toHaveClass(chatStyles.userMessage)
+    expect(screen.getByTestId('message-bubble')).not.toHaveClass(chatStyles.bubbleFlushRight)
+  })
+
+  it('marks a delivered user bubble flush-right, settled or pending alike', () => {
+    for (const [id, expected] of [['m-settled', chatStyles.userMessage], ['local-5', chatStyles.userMessagePending]] as const) {
+      const msg = makeMsg({ id, source: MessageSource.USER, content: rawContent({ content: 'hello' }) })
+      const view = render(() => (
+        <PreferencesProvider>
+          <MessageBubble message={msg} />
+        </PreferencesProvider>
+      ))
+      const bubble = view.getByTestId('message-bubble')
+      expect(bubble).toHaveClass(expected)
+      expect(bubble).toHaveClass(chatStyles.bubbleFlushRight)
+      view.unmount()
+    }
+  })
+
+  it('never marks an AGENT bubble flush-right', () => {
+    // The marker only takes effect inside a widened row, and an agent row is not
+    // widened -- but it must not carry the marker either, or the stylesheet is the
+    // only thing standing between it and a clipped bleed.
+    const msg = makeMsg({ source: MessageSource.AGENT, content: rawContent({ content: 'hi' }) })
+    render(() => (
+      <PreferencesProvider>
+        <MessageBubble message={msg} />
+      </PreferencesProvider>
+    ))
+    expect(screen.getByTestId('message-bubble')).not.toHaveClass(chatStyles.bubbleFlushRight)
   })
 })
 

--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -27,7 +27,7 @@ import { resolveStack } from '~/lib/resolveStack'
 import { buildRawJsonEnvelope } from './chatRawJson'
 import { codeCopyHostClass } from './markdownEditor/markdownContent.css'
 import * as styles from './MessageBubble.css'
-import { classifyParsedMessage, messageBubbleClass, messageRowClass } from './messageClassification'
+import { bubbleRunsToRightEdge, classifyParsedMessage, isMirroredMessageRow, messageBubbleClass, messageRowClass } from './messageClassification'
 import { renderMessageContent } from './messageRenderers'
 import * as chatStyles from './messageStyles.css'
 import { expandedUiKeyFor, MESSAGE_UI_KEY, messageUiDefault } from './messageUiKeys'
@@ -329,9 +329,17 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
   const rowClass = () => messageRowClass(category().kind, props.message.source)
   const isLocalPending = () => props.message.id.startsWith('local-')
   const isPendingUserMessage = () => isLocalPending() && props.message.source === MessageSource.USER && !props.error
-  const bubbleClass = () => isPendingUserMessage()
-    ? chatStyles.userMessagePending
-    : messageBubbleClass(category().kind, props.message.source)
+  const bubbleClass = () => {
+    // The pending variant is chosen HERE, not in messageBubbleClass, because only
+    // this component knows the message is an optimistic local. It is the same
+    // bubble otherwise, so it takes the same flush-right treatment.
+    const base = isPendingUserMessage()
+      ? chatStyles.userMessagePending
+      : messageBubbleClass(category().kind, props.message.source)
+    return bubbleRunsToRightEdge(category().kind, props.message.source, !!props.error)
+      ? `${base} ${chatStyles.bubbleFlushRight}`
+      : base
+  }
 
   // A notification category carries the messages to render -- a consolidated
   // thread holds the wrapper's messages; a standalone notification is a
@@ -343,7 +351,7 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
   }
 
   // The payload to hand a renderer: the parsed parent object, or the raw text
-  // when the envelope didn't parse to an object. Named once so renderContent and
+  // when the envelope didn't parse to an object. Defined once so renderContent and
   // the result_divider arm pass the renderers the same shape.
   const renderPayload = () => parsed().parentObject ?? parsed().rawText
 
@@ -502,6 +510,10 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
               markdownCopied: markdownCopied(),
             }}
             layout={{
+              // A right-aligned user row mirrors its toolbar beside the bubble,
+              // so it reverses the button order -- read from the same predicate
+              // that picks the row class, never re-derived here.
+              mirrored: isMirroredMessageRow(category().kind, props.message.source),
               createdAt: props.message.createdAt,
               expanded: toolResultExpanded(),
               onToggleExpand: isCollapsibleToolResult() ? toggleToolResultExpanded : undefined,

--- a/frontend/src/components/chat/ToolUseLayout.test.tsx
+++ b/frontend/src/components/chat/ToolUseLayout.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@solidjs/testing-library'
 import ListTodo from 'lucide-solid/icons/list-todo'
 import { beforeAll, describe, expect, it, vi } from 'vitest'
 import { ToolUseLayout } from '~/components/chat/toolRenderers'
-import { toolBodyBorder, toolBodyContent, toolInputText } from '~/components/chat/toolStyles.css'
+import { toolBodyBorder, toolBodyContent, toolHeaderTimestamp, toolInputText } from '~/components/chat/toolStyles.css'
 import { PreferencesProvider } from '~/context/PreferencesContext'
 import { classSelector } from '~/test-support/composedClass'
 
@@ -40,6 +40,35 @@ describe('toolUseLayout', () => {
     expect(container).toHaveTextContent('3 tasks')
     // Icon should be present as an SVG element
     expect(container.querySelector('svg')).toBeInTheDocument()
+  })
+
+  it('orders the header actions the same way an assistant row does', () => {
+    // A tool header and an agent message row used to lay their toolbars out
+    // differently, so the same two buttons moved depending on which row was
+    // above. They now share one order; this pins the tool-header half of that,
+    // and MessageBubble.test.tsx pins the message-row half.
+    render(() => (
+      <PreferencesProvider>
+        <ToolUseLayout
+          icon={ListTodo}
+          toolName="TestTool"
+          title="3 tasks"
+          context={makeContext({ createdAt: '2026-08-13T00:00:00Z' })}
+          onToggleExpand={() => {}}
+        >
+          <div>details</div>
+        </ToolUseLayout>
+      </PreferencesProvider>
+    ))
+
+    const toolbar = screen.getByTestId('message-toolbar')
+    const ids = [...toolbar.querySelectorAll('[data-testid]')].map(el => el.getAttribute('data-testid'))
+    expect(ids).toEqual(['message-copy-json'])
+    // The timestamp leads the copy button, as on every left-to-right row.
+    const timestamp = toolbar.querySelector(classSelector(toolHeaderTimestamp))
+    expect(timestamp).not.toBeNull()
+    expect(timestamp!.compareDocumentPosition(screen.getByTestId('message-copy-json')))
+      .toBe(Node.DOCUMENT_POSITION_FOLLOWING)
   })
 
   it('shows summary inside bordered area', () => {

--- a/frontend/src/components/chat/chatChromeVars.ts
+++ b/frontend/src/components/chat/chatChromeVars.ts
@@ -1,0 +1,37 @@
+/**
+ * The custom properties the chat ROOT publishes, and the one size that decides how
+ * wide a touch target must be.
+ *
+ * Four stylesheets read these names -- `~/components/chat/ChatView.css.ts` declares
+ * them, `~/components/chat/messageStyles.css.ts` cancels the gutter to bleed a row
+ * to the panel edge, `~/components/chat/ChatScrollRail.css.ts` sizes its column from
+ * the right gutter, and `./widgets/SpanLines.geometry.ts` adds the gutter to the
+ * rails' reserved width. Every reader also carries a `, 0px` fallback, so a typo in
+ * one spelling does not fail the build: the bleed collapses to zero and the band
+ * stops at the gutter with no error at all. One exported name for each property
+ * makes that mistake a type error instead.
+ *
+ * This module imports nothing on purpose. `ChatView.css.ts` already imports
+ * `messageStyles.css.ts`, so the names cannot live in either one without a cycle
+ * through the stylesheet graph, and a leaf is reachable from all four.
+ */
+
+/** Distance from the chat list's left edge to the first content column. */
+export const CHAT_PAD_LEFT_VAR = '--chat-pad-left'
+
+/** Distance from the chat list's right edge to the content column. The scroll rail fills it. */
+export const CHAT_PAD_RIGHT_VAR = '--chat-pad-right'
+
+/**
+ * Width of the scroll rail's column. At least the right gutter, so the rail owns that
+ * strip exactly; never less than a finger, so the thumb stays draggable on a phone
+ * where the gutter shrinks to reclaim text width.
+ */
+export const CHAT_RAIL_WIDTH_VAR = '--chat-rail-width'
+
+/**
+ * Diameter (px) of a touch target, used wherever a finger must land on something
+ * that a mouse hits comfortably at a smaller size: the rail's column on a coarse
+ * pointer, and the hit circle around a rail dot.
+ */
+export const COARSE_HIT_PX = 24

--- a/frontend/src/components/chat/chatHiddenPremeasure.render.test.tsx
+++ b/frontend/src/components/chat/chatHiddenPremeasure.render.test.tsx
@@ -1,20 +1,60 @@
 import type { ClassifiedEntry } from './chatEntryCache'
+import type { MessageCategory } from './messageClassification'
 import type { VirtualItem } from './useChatVirtualizer'
 import type { AgentChatMessage } from '~/generated/leapmux/v1/agent_pb'
 import { render, screen } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
+import { MessageSource } from '~/generated/leapmux/v1/agent_pb'
 import { ChatHiddenPremeasure } from './chatHiddenPremeasure'
-import { COL_SPACING, CONTAINER_PAD_RIGHT, spanLinesReservedWidth } from './widgets/SpanLines.geometry'
+import { bandRow, bandRowThought, bleedRow } from './messageStyles.css'
+import { COL_SPACING, CONTAINER_PAD_RIGHT, ROW_BLEED_LEFT_VAR, rowBleedLeftStyle, spanLinesReservedWidth } from './widgets/SpanLines.geometry'
 
-function entryWithSpanLines(lineCount: number): ClassifiedEntry {
+function entryWithSpanLines(
+  lineCount: number,
+  kind: MessageCategory['kind'] = 'user_text',
+  source: MessageSource = MessageSource.AGENT,
+): ClassifiedEntry {
   return {
-    msg: { id: 'm1', seq: 1n, spanId: 'span-1' } as AgentChatMessage,
+    msg: { id: 'm1', seq: 1n, spanId: 'span-1', source } as AgentChatMessage,
+    category: { kind } as MessageCategory,
     parsedSpanLines: Array.from({ length: lineCount }, (_, i) => ({
       span_id: `s${i}`,
       color: i + 1,
       type: 'active' as const,
     })),
   } as ClassifiedEntry
+}
+
+/** The premeasure row element: the bubble's grandparent (row > reserved wrapper > bubble). */
+function premeasureRowOf(bubble: HTMLElement): HTMLElement {
+  const row = bubble.parentElement?.parentElement
+  if (!row)
+    throw new Error('premeasure row not found')
+  return row
+}
+
+/**
+ * Render one candidate through the premeasure root and hand back the two elements
+ * every test below asserts on. The mount is identical across them -- only the kind,
+ * the source and the rail count vary -- so it lives here rather than in each `it`.
+ */
+function renderPremeasureRow(
+  kind: MessageCategory['kind'],
+  source: MessageSource = MessageSource.AGENT,
+  lineCount = 0,
+): { row: HTMLElement, column: HTMLElement, unmount: () => void } {
+  const entry = entryWithSpanLines(lineCount, kind, source)
+  const item: VirtualItem = { id: 'm1', hasSpanLines: lineCount > 0, heightKey: 'k1' }
+  const { unmount } = render(() => (
+    <ChatHiddenPremeasure
+      candidates={[{ entry, item }]}
+      contentWidthPx={400}
+      renderBubble={() => <div data-testid="bubble">bubble</div>}
+      onMeasure={vi.fn()}
+    />
+  ))
+  const bubble = screen.getByTestId('bubble')
+  return { row: premeasureRowOf(bubble), column: bubble.parentElement!, unmount }
 }
 
 describe('chat hidden premeasure rendering', () => {
@@ -25,22 +65,65 @@ describe('chat hidden premeasure rendering', () => {
   })
 
   it('reserves span-line width without mounting SpanLines columns', () => {
-    const entry = entryWithSpanLines(3)
-    const item: VirtualItem = { id: 'm1', hasSpanLines: true, heightKey: 'k1' }
+    const { column } = renderPremeasureRow('user_text', MessageSource.AGENT, 3)
+    expect(column.style.marginLeft).toBe(`${spanLinesReservedWidth(3)}px`)
+    expect(column.previousElementSibling).toBeNull()
+  })
 
-    render(() => (
-      <ChatHiddenPremeasure
-        candidates={[{ entry, item }]}
-        contentWidthPx={400}
-        renderBubble={() => <div data-testid="bubble">bubble</div>}
-        onMeasure={vi.fn()}
-      />
-    ))
+  // The band's two borders and its vertical padding are part of the row's height,
+  // so a premeasured band row must carry the same strip as the live row -- else
+  // every band commits a height short by both borders.
+  it('wears the band strip when the candidate is an assistant message', () => {
+    const { row } = renderPremeasureRow('assistant_text')
+    expect(row.classList.contains(bandRow)).toBe(true)
+    expect(row.classList.contains(bandRowThought)).toBe(false)
+    expect(row.dataset.band).toBe('text')
+  })
 
-    const bubble = screen.getByTestId('bubble')
-    const reservedWrapper = bubble.parentElement
-    expect(reservedWrapper?.style.marginLeft).toBe(`${spanLinesReservedWidth(3)}px`)
-    expect(reservedWrapper?.previousElementSibling).toBeNull()
+  it('wears the dashed band strip when the candidate is a thought', () => {
+    const { row } = renderPremeasureRow('assistant_thinking')
+    expect(row.classList.contains(bandRow)).toBe(true)
+    expect(row.classList.contains(bandRowThought)).toBe(true)
+    expect(row.dataset.band).toBe('thought')
+  })
+
+  it('leaves a non-band candidate unbanded', () => {
+    const { row } = renderPremeasureRow('tool_result')
+    expect(row.classList.contains(bandRow)).toBe(false)
+    expect(row.classList.contains(bleedRow)).toBe(false)
+    expect(row.dataset.band).toBeUndefined()
+  })
+
+  it('widens a user message candidate, whose bubble bleeds to the right edge', () => {
+    // The widening is decided by kind AND source here, exactly as in the live row.
+    // A premeasure row that missed it would clip the bubble's bleed and measure a
+    // different wrap than the list shows.
+    const { row } = renderPremeasureRow('user_text', MessageSource.USER)
+    expect(row.classList.contains(bleedRow)).toBe(true)
+    expect(row.classList.contains(bandRow)).toBe(false)
+  })
+
+  it('publishes the distance to the panel edge, rails included, like the live row', () => {
+    // The bleeding child inside reads this var to size its negative margin. If the
+    // measured row published a different distance than the live one, the two would
+    // wrap their text at different widths and the committed height would be wrong.
+    for (const lineCount of [0, 3]) {
+      const { column, unmount } = renderPremeasureRow('result_divider', MessageSource.AGENT, lineCount)
+      expect(column.style.getPropertyValue(ROW_BLEED_LEFT_VAR))
+        .toBe(rowBleedLeftStyle(lineCount)[ROW_BLEED_LEFT_VAR])
+      // And it tracks the rails: the two counts must not resolve to the same distance.
+      expect(column.style.marginLeft).toBe(`${spanLinesReservedWidth(lineCount)}px`)
+      unmount()
+    }
+  })
+
+  // A turn-end divider bleeds too, so the measured row must be as wide as the
+  // live one -- a long divider label wraps differently at the narrower width.
+  it('widens a turn-end divider candidate without banding it', () => {
+    const { row } = renderPremeasureRow('result_divider')
+    expect(row.classList.contains(bleedRow)).toBe(true)
+    expect(row.classList.contains(bandRow)).toBe(false)
+    expect(row.dataset.band).toBeUndefined()
   })
 
   it('remeasures when an image loads after the first premeasure frame', () => {

--- a/frontend/src/components/chat/chatHiddenPremeasure.tsx
+++ b/frontend/src/components/chat/chatHiddenPremeasure.tsx
@@ -1,10 +1,11 @@
 import type { JSX } from 'solid-js'
 import type { ClassifiedEntry } from './chatEntryCache'
 import type { VirtualItem } from './useChatVirtualizer'
-import { batch, createEffect, createSignal, For, on, onCleanup } from 'solid-js'
+import { batch, createEffect, createMemo, createSignal, For, on, onCleanup } from 'solid-js'
 import { monotonicNow } from '~/lib/monotonicNow'
 import * as styles from './ChatView.css'
-import { spanLinesReservedWidth } from './widgets/SpanLines.geometry'
+import { messageRowChrome } from './messageClassification'
+import { reservedRowContentColumnStyle } from './widgets/SpanLines.geometry'
 
 export interface ChatDomPremeasureCandidate {
   entry: ClassifiedEntry
@@ -180,11 +181,25 @@ function PremeasureRow(props: {
       props.frame.cancel(scheduledMeasureKey)
   })
 
-  const reservedLeftPx = () => spanLinesReservedWidth(props.candidate.entry.parsedSpanLines.length)
+  // Row chrome is part of the row's HEIGHT: a band's borders and vertical
+  // padding add to it directly, and any bleed widens the row, which is what the
+  // text inside wraps against. The measured row must therefore wear exactly what
+  // the live row wears (ChatView's virtual row), or it commits a wrong height.
+  const chrome = createMemo(() => messageRowChrome(
+    styles.premeasureRow,
+    props.candidate.entry.category.kind,
+    props.candidate.entry.msg.source,
+  ))
+
+  const lineCount = () => props.candidate.entry.parsedSpanLines.length
 
   return (
-    <div ref={rowEl} class={styles.premeasureRow}>
-      <div style={{ 'margin-left': `${reservedLeftPx()}px` }}>
+    <div ref={rowEl} class={chrome().class} data-band={chrome().band}>
+      {/* Mirrors the live row's content column, ROW_BLEED_LEFT_VAR included: a
+          bleeding child that measured at the wrong width would wrap its text
+          differently here than in the list. This row RESERVES the rails' width
+          rather than rendering them, so it takes the margin too. */}
+      <div style={reservedRowContentColumnStyle(lineCount())}>
         {props.renderBubble(props.candidate.entry)}
       </div>
     </div>

--- a/frontend/src/components/chat/chatRowGeometry.test.ts
+++ b/frontend/src/components/chat/chatRowGeometry.test.ts
@@ -1,5 +1,62 @@
+import type { MessageBandKind } from './chatRowGeometry'
+import type { MessageCategory } from './messageClassification'
 import { describe, expect, it, vi } from 'vitest'
-import { kindScopedLayoutKey } from './chatRowGeometry'
+import { kindScopedLayoutKey, messageBandKind } from './chatRowGeometry'
+
+/**
+ * The band each message kind paints. The `Record<MessageCategory['kind'], ...>`
+ * annotation IS the guard: both functions under test take a bare `string` -- the
+ * virtualizer hands them `item.kind ?? ''` -- so nothing in the source forces a
+ * NEW kind to be considered. Here it becomes a `tsc` failure, and the author has
+ * to say whether the new kind paints a band before the suite compiles.
+ *
+ * The tables live in the test rather than in `./chatRowGeometry`, on purpose.
+ * That module is imported by `./messageStyles.css.ts`, so it sits on the
+ * vanilla-extract build-evaluation path, and its doc states the import-free
+ * property as the reason it exists. A type-only import is erased today, but it
+ * would falsify that stated property and leave one slip between the stylesheet
+ * build and the provider registry. The type checker reports the same omission
+ * from here, in the same CI run, at no risk to that graph.
+ */
+const BAND_BY_KIND: Record<MessageCategory['kind'], MessageBandKind | undefined> = {
+  assistant_text: 'text',
+  assistant_thinking: 'thought',
+  // plan_execution shares the thought expander but stays a right-aligned accent
+  // bubble, so it must NOT join the band set -- it would also lose its gap
+  // against the assistant rows around it.
+  plan_execution: undefined,
+  agent_prompt: undefined,
+  compact_summary: undefined,
+  control_response: undefined,
+  hidden: undefined,
+  notification: undefined,
+  result_divider: undefined,
+  tool_result: undefined,
+  tool_use: undefined,
+  unknown: undefined,
+  unsupported_provider: undefined,
+  user_content: undefined,
+  user_text: undefined,
+}
+
+/** The scoped-layout term each kind contributes, under diffView 'split' + expanded thoughts. */
+const SCOPED_KEY_BY_KIND: Record<MessageCategory['kind'], string> = {
+  tool_use: '|d:split',
+  tool_result: '|d:split',
+  assistant_thinking: '|t:1',
+  agent_prompt: '',
+  assistant_text: '',
+  compact_summary: '',
+  control_response: '',
+  hidden: '',
+  notification: '',
+  plan_execution: '',
+  result_divider: '',
+  unknown: '',
+  unsupported_provider: '',
+  user_content: '',
+  user_text: '',
+}
 
 describe('chatrowgeometry', () => {
   describe('kindscopedlayoutkey', () => {
@@ -13,10 +70,17 @@ describe('chatrowgeometry', () => {
       expect(kindScopedLayoutKey('assistant_thinking', () => 'split', () => false)).toBe('|t:0')
     })
 
+    it('adds a scoped term for exactly the kinds a scoped pref can resize', () => {
+      for (const [kind, expected] of Object.entries(SCOPED_KEY_BY_KIND))
+        expect(kindScopedLayoutKey(kind, () => 'split', () => true)).toBe(expected)
+    })
+
     it('adds nothing for a kind no scoped pref can resize', () => {
       // A change in the omitted term must leave these keys byte-identical, so a global
       // diffView / expandThoughts toggle never re-measures them.
-      for (const kind of ['assistant_text', 'user_text', 'user_content', 'plan_execution', 'agent_prompt', 'notification', 'unknown']) {
+      for (const [kind, expected] of Object.entries(SCOPED_KEY_BY_KIND)) {
+        if (expected !== '')
+          continue
         expect(kindScopedLayoutKey(kind, () => 'split', () => true)).toBe('')
         expect(kindScopedLayoutKey(kind, () => 'unified', () => false)).toBe('')
       }
@@ -41,6 +105,28 @@ describe('chatrowgeometry', () => {
       kindScopedLayoutKey('user_text', diff, think)
       expect(diff).not.toHaveBeenCalled()
       expect(think).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('messageBandKind', () => {
+    it('maps an assistant message to the solid-line band', () => {
+      expect(messageBandKind('assistant_text')).toBe('text')
+    })
+
+    it('maps an assistant thought to the dashed-line band', () => {
+      expect(messageBandKind('assistant_thinking')).toBe('thought')
+    })
+
+    it('decides the band for every kind the classifier can produce', () => {
+      for (const [kind, band] of Object.entries(BAND_BY_KIND))
+        expect(messageBandKind(kind)).toBe(band)
+    })
+
+    it('treats an unclassified or a packed tool kind as no band', () => {
+      // The virtualizer passes `item.kind ?? ''`, and a tool row's kind reaches other
+      // callers packed as `tool_use:<name>`. Neither is a member of the union above.
+      expect(messageBandKind('')).toBeUndefined()
+      expect(messageBandKind('tool_use:Bash')).toBeUndefined()
     })
   })
 })

--- a/frontend/src/components/chat/chatRowGeometry.ts
+++ b/frontend/src/components/chat/chatRowGeometry.ts
@@ -3,8 +3,9 @@
  *
  * Pixel height estimation is intentionally absent: row heights come from
  * visible/hidden DOM measurement plus the virtualizer's generic unknown-row
- * fallback. This module only carries non-pixel identifiers that let caches know
- * when a previously measured DOM height is stale.
+ * fallback. This module carries the identifiers that let caches know when a
+ * previously measured DOM height is stale, plus the few fixed constants that
+ * the offset map and the stylesheet must agree on.
  */
 
 /**
@@ -18,6 +19,46 @@ export const TOOL_USE_KIND_PREFIX = 'tool_use:'
 export function toolNameFromKind(kind: string): string | undefined {
   return kind.startsWith(TOOL_USE_KIND_PREFIX) ? kind.slice(TOOL_USE_KIND_PREFIX.length) : undefined
 }
+
+/**
+ * Which full-bleed band a row paints. An assistant message draws a solid line
+ * on its top and bottom edge; an assistant thought draws a dashed one.
+ */
+export type MessageBandKind = 'text' | 'thought'
+
+/**
+ * The band a row kind paints, or undefined when the row is not a band.
+ *
+ * This is the ONE place that decides which kinds render as a band. The
+ * virtualizer reads it to close the gap between two adjacent bands, and
+ * messageClassification reads it to pick the row and bubble classes -- both
+ * from here, so the offset map and the borders can never disagree. It lives in
+ * this leaf module (no imports) rather than in messageClassification, whose own
+ * imports pull in every provider plugin: the virtualizer must stay clear of that
+ * graph.
+ *
+ * `plan_execution` is deliberately absent. It shares the thought expander but
+ * renders as a right-aligned accent bubble, which marks the plan hand-off as a
+ * distinct event rather than more agent narration.
+ */
+export function messageBandKind(kind: string): MessageBandKind | undefined {
+  if (kind === 'assistant_text')
+    return 'text'
+  if (kind === 'assistant_thinking')
+    return 'thought'
+  return undefined
+}
+
+/**
+ * Width of a band's top and bottom border, in CSS pixels.
+ *
+ * Two adjacent bands are placed exactly this far apart in the NEGATIVE
+ * direction (see gapAfter in ~/components/chat/useChatVirtualizer.ts), so the
+ * lower row's top border lands on the upper row's bottom border and the pair
+ * shows one line instead of two. Keep it equal to the border width that
+ * `bandRow` declares in ~/components/chat/messageStyles.css.ts.
+ */
+export const BAND_BORDER_PX = 1
 
 /**
  * Per-row inputs that make a cached DOM measurement stale even when the message

--- a/frontend/src/components/chat/chatRowHeightPersistence.test.ts
+++ b/frontend/src/components/chat/chatRowHeightPersistence.test.ts
@@ -3,10 +3,10 @@ import { createRoot, createSignal } from 'solid-js'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { localStorageGet, localStorageRemove, localStorageSet, PREFIX_CHAT_ROW_HEIGHTS } from '~/lib/browserStorage'
 import { fnv1a32Hex } from '~/lib/stringDigest'
-import { createRowHeightPersistence, PERSISTED_ROW_HEIGHTS_MAX, ROW_HEIGHT_SAVE_DEBOUNCE_MS } from './chatRowHeightPersistence'
+import { createRowHeightPersistence, PERSISTED_ROW_HEIGHTS_MAX, ROW_HEIGHT_SAVE_DEBOUNCE_MS, STORED_ROW_HEIGHTS_VERSION } from './chatRowHeightPersistence'
 
 interface StoredShape {
-  v: 1
+  v: typeof STORED_ROW_HEIGHTS_VERSION
   rows: [string, string, number][]
 }
 
@@ -71,7 +71,7 @@ describe('chatrowheightpersistence', () => {
 
   it('hydrates stored rows whose key digest matches the live heightKey', () => {
     localStorageSet(`${PREFIX_CHAT_ROW_HEIGHTS}agent-1`, {
-      v: 1,
+      v: STORED_ROW_HEIGHTS_VERSION,
       rows: [storedRow('a', 'k-a', 120), storedRow('b', 'k-b-old', 80)],
     })
     const h = makeHarness({
@@ -86,7 +86,7 @@ describe('chatrowheightpersistence', () => {
 
   it('adopts a pending row later, when its live key changes to match (width settles)', () => {
     localStorageSet(`${PREFIX_CHAT_ROW_HEIGHTS}agent-1`, {
-      v: 1,
+      v: STORED_ROW_HEIGHTS_VERSION,
       rows: [storedRow('a', 'k-a|w800', 120)],
     })
     const h = makeHarness({ storageId: 'agent-1', items: [item('a', 'k-a|w360')] })
@@ -98,7 +98,7 @@ describe('chatrowheightpersistence', () => {
 
   it('keeps a pending row when the virtualizer defers prime-height adoption', () => {
     localStorageSet(`${PREFIX_CHAT_ROW_HEIGHTS}agent-1`, {
-      v: 1,
+      v: STORED_ROW_HEIGHTS_VERSION,
       rows: [storedRow('a', 'k-a', 120)],
     })
     const pending = new Set<string>()
@@ -135,7 +135,7 @@ describe('chatrowheightpersistence', () => {
     // is still not in the cache -- so the persistence layer MUST re-attempt the
     // prime when the key matches again. It must not permanently bar the row.
     localStorageSet(`${PREFIX_CHAT_ROW_HEIGHTS}agent-1`, {
-      v: 1,
+      v: STORED_ROW_HEIGHTS_VERSION,
       rows: [storedRow('a', 'k-a', 120)],
     })
     const pending = new Set<string>()
@@ -190,7 +190,7 @@ describe('chatrowheightpersistence', () => {
     // attempt marker), the persistence layer must re-attempt when the row returns,
     // or the stale marker bars its warm-start height for the component's life.
     localStorageSet(`${PREFIX_CHAT_ROW_HEIGHTS}agent-1`, {
-      v: 1,
+      v: STORED_ROW_HEIGHTS_VERSION,
       rows: [storedRow('a', 'k-a', 120)],
     })
     const pending = new Set<string>()
@@ -235,7 +235,7 @@ describe('chatrowheightpersistence', () => {
 
   it('retires a pending row once a real measurement supersedes it', () => {
     localStorageSet(`${PREFIX_CHAT_ROW_HEIGHTS}agent-1`, {
-      v: 1,
+      v: STORED_ROW_HEIGHTS_VERSION,
       rows: [storedRow('a', 'k-a', 120)],
     })
     const measured = new Set(['a'])
@@ -248,7 +248,7 @@ describe('chatrowheightpersistence', () => {
     // 'old' is a stored row for history that has not paginated in — it must
     // survive the save instead of being clobbered by the fresh snapshot.
     localStorageSet(`${PREFIX_CHAT_ROW_HEIGHTS}agent-1`, {
-      v: 1,
+      v: STORED_ROW_HEIGHTS_VERSION,
       rows: [storedRow('old', 'k-old', 300)],
     })
     const h = makeHarness({ storageId: 'agent-1', items: [] })
@@ -279,7 +279,7 @@ describe('chatrowheightpersistence', () => {
 
   it('never replaces stored data with an empty snapshot', () => {
     localStorageSet(`${PREFIX_CHAT_ROW_HEIGHTS}agent-1`, {
-      v: 1,
+      v: STORED_ROW_HEIGHTS_VERSION,
       rows: [storedRow('a', 'k-a|w800', 120)],
     })
     // Live key never matches (different width), so nothing adopts and the
@@ -312,7 +312,7 @@ describe('chatrowheightpersistence', () => {
 
   it('loads and hydrates once the storage id arrives late', () => {
     localStorageSet(`${PREFIX_CHAT_ROW_HEIGHTS}agent-1`, {
-      v: 1,
+      v: STORED_ROW_HEIGHTS_VERSION,
       rows: [storedRow('a', 'k-a', 120)],
     })
     const h = makeHarness({ items: [item('a', 'k-a')] }) // no id yet
@@ -327,7 +327,7 @@ describe('chatrowheightpersistence', () => {
     // ceiling's worth of fresh measurements: the cap must keep every fresh
     // row and shed the pending one first.
     localStorageSet(`${PREFIX_CHAT_ROW_HEIGHTS}agent-1`, {
-      v: 1,
+      v: STORED_ROW_HEIGHTS_VERSION,
       rows: [storedRow('stale', 'k-stale|w999', 50)],
     })
     const h = makeHarness({ storageId: 'agent-1', items: [item('stale', 'k-live')] })
@@ -350,7 +350,7 @@ describe('chatrowheightpersistence', () => {
     // the snapshot -- and its fresh measurement must land at the recent end, not
     // inherit 'a's early pending slot (which the cap would shed first).
     localStorageSet(`${PREFIX_CHAT_ROW_HEIGHTS}agent-1`, {
-      v: 1,
+      v: STORED_ROW_HEIGHTS_VERSION,
       rows: [storedRow('a', 'k-a-old', 120)],
     })
     const h = makeHarness({ storageId: 'agent-1', items: [item('a', 'k-a-new')] })
@@ -370,9 +370,26 @@ describe('chatrowheightpersistence', () => {
     h.dispose()
   })
 
+  it('discards a payload written by an older layout version', () => {
+    // A heightKey never encodes the stylesheet, so an older payload's digests
+    // still match while every height in it is wrong. The version guard is the
+    // only thing that stops those heights from jumping the offset map.
+    localStorageSet(`${PREFIX_CHAT_ROW_HEIGHTS}agent-1`, {
+      v: STORED_ROW_HEIGHTS_VERSION - 1,
+      rows: [storedRow('a', 'k-a', 120)],
+    })
+    const h = makeHarness({ storageId: 'agent-1', items: [item('a', 'k-a')] })
+    expect(h.primed).toEqual([])
+    // And it is DELETED, not merely ignored. The read that returned it also refreshed its
+    // expiry, so a chat the reader opens and leaves -- one that commits no height, and so
+    // never overwrites the key -- would keep tens of KB of dead rows alive indefinitely.
+    expect(localStorageGet(`${PREFIX_CHAT_ROW_HEIGHTS}agent-1`)).toBeUndefined()
+    h.dispose()
+  })
+
   it('ignores malformed stored payloads', () => {
     localStorageSet(`${PREFIX_CHAT_ROW_HEIGHTS}agent-1`, {
-      v: 1,
+      v: STORED_ROW_HEIGHTS_VERSION,
       rows: [
         ['a', fnv1a32Hex('k-a')], // missing height
         ['b', fnv1a32Hex('k-b'), -5], // non-positive

--- a/frontend/src/components/chat/chatRowHeightPersistence.ts
+++ b/frontend/src/components/chat/chatRowHeightPersistence.ts
@@ -1,7 +1,7 @@
 import type { Accessor } from 'solid-js'
 import type { PersistableRowHeight, UseChatVirtualizerResult, VirtualItem } from './useChatVirtualizer'
 import { createEffect, onCleanup, untrack } from 'solid-js'
-import { localStorageGet, localStorageSet, PREFIX_CHAT_ROW_HEIGHTS } from '~/lib/browserStorage'
+import { localStorageGet, localStorageRemove, localStorageSet, PREFIX_CHAT_ROW_HEIGHTS } from '~/lib/browserStorage'
 import { capMapInsertionOrder } from '~/lib/mapLru'
 import { fnv1a32Hex } from '~/lib/stringDigest'
 import { MAX_LOADED_CHAT_MESSAGES_CEILING } from '~/stores/chat.store'
@@ -34,8 +34,21 @@ import { MAX_LOADED_CHAT_MESSAGES_CEILING } from '~/stores/chat.store'
 /** One stored row: [message id, heightKey digest, height (px, 2dp)]. */
 type StoredRow = [id: string, digest: string, height: number]
 
+/**
+ * Stored-payload version. A heightKey encodes the row's CONTENT, width and UI
+ * state -- never the stylesheet -- so a layout change keeps every digest valid
+ * while making every stored height wrong. Bump this whenever a change to the
+ * chat CSS moves row heights, and the next load discards the whole payload
+ * instead of hydrating heights that jump the offset map under the scroll anchor
+ * until re-measurement heals them.
+ *
+ * 2: assistant messages and thoughts became full-bleed bands (row borders and
+ *    band padding replaced the bubble's border, padding and 85% width cap).
+ */
+export const STORED_ROW_HEIGHTS_VERSION = 2
+
 interface StoredRowHeights {
-  v: 1
+  v: typeof STORED_ROW_HEIGHTS_VERSION
   rows: StoredRow[]
 }
 
@@ -65,7 +78,7 @@ export interface RowHeightPersistenceDeps {
 
 function parseStoredRows(raw: unknown): Map<string, { digest: string, height: number }> {
   const pending = new Map<string, { digest: string, height: number }>()
-  if (raw === null || typeof raw !== 'object' || (raw as StoredRowHeights).v !== 1)
+  if (raw === null || typeof raw !== 'object' || (raw as StoredRowHeights).v !== STORED_ROW_HEIGHTS_VERSION)
     return pending
   const rows = (raw as StoredRowHeights).rows
   if (!Array.isArray(rows))
@@ -192,7 +205,7 @@ export function createRowHeightPersistence(deps: RowHeightPersistenceDeps): void
     // rows (snapshotHeights is LRU-ordered, oldest first), keeping the most recent
     // measurements -- and the eviction bound can't drift from the render/token caches'.
     capMapInsertionOrder(merged, PERSISTED_ROW_HEIGHTS_MAX)
-    localStorageSet(storageKey(id), { v: 1, rows: [...merged.values()] } satisfies StoredRowHeights)
+    localStorageSet(storageKey(id), { v: STORED_ROW_HEIGHTS_VERSION, rows: [...merged.values()] } satisfies StoredRowHeights)
   }
 
   // Load once, as soon as the storage identity is available.
@@ -203,7 +216,14 @@ export function createRowHeightPersistence(deps: RowHeightPersistenceDeps): void
     loaded = true
     const stored = localStorageGet<StoredRowHeights>(storageKey(id))
     if (stored !== undefined) {
-      for (const [rowId, entry] of parseStoredRows(stored))
+      const rows = parseStoredRows(stored)
+      // A payload from an older version parses to nothing. Drop it now rather
+      // than leaving it: the read that just returned it also refreshed its
+      // expiry, so a chat that never commits a height (one the reader opens and
+      // leaves) would keep tens of KB of dead rows alive indefinitely.
+      if (rows.size === 0)
+        localStorageRemove(storageKey(id))
+      for (const [rowId, entry] of rows)
         pending.set(rowId, entry)
     }
     tryAdopt(untrack(deps.virtualItems))

--- a/frontend/src/components/chat/messageClassification.test.ts
+++ b/frontend/src/components/chat/messageClassification.test.ts
@@ -1,8 +1,40 @@
+import type { MessageCategory } from '~/components/chat/messageClassification'
 import { describe, expect, it } from 'vitest'
-import { classifyMessage, messageBubbleClass, messageRowClass } from '~/components/chat/messageClassification'
+import { bubbleRunsToRightEdge, classifyMessage, isMirroredMessageRow, messageBubbleClass, messageRowChrome, messageRowChromeClass, messageRowClass } from '~/components/chat/messageClassification'
 import * as chatStyles from '~/components/chat/messageStyles.css'
 import { input } from '~/components/chat/providers/testUtils'
 import { AgentProvider, MessageSource } from '~/generated/leapmux/v1/agent_pb'
+
+/**
+ * Every kind the classifier can produce. The `satisfies Record<...>` annotation is
+ * the guard: a new member of `MessageCategory` fails `tsc` here until it is listed,
+ * which is what forces the whole-domain sweeps below to stay whole.
+ */
+const ALL_MESSAGE_KINDS = Object.keys({
+  agent_prompt: true,
+  assistant_text: true,
+  assistant_thinking: true,
+  compact_summary: true,
+  control_response: true,
+  hidden: true,
+  notification: true,
+  plan_execution: true,
+  result_divider: true,
+  tool_result: true,
+  tool_use: true,
+  unknown: true,
+  unsupported_provider: true,
+  user_content: true,
+  user_text: true,
+} satisfies Record<MessageCategory['kind'], true>) as MessageCategory['kind'][]
+
+/** Every source a persisted row can carry. */
+const ALL_MESSAGE_SOURCES = [
+  MessageSource.UNSPECIFIED,
+  MessageSource.USER,
+  MessageSource.AGENT,
+  MessageSource.LEAPMUX,
+] as const
 
 // ---------------------------------------------------------------------------
 // Helper to build assistant message payloads
@@ -481,6 +513,41 @@ describe('messageRowClass', () => {
 })
 
 // ---------------------------------------------------------------------------
+// isMirroredMessageRow
+// ---------------------------------------------------------------------------
+
+describe('isMirroredMessageRow', () => {
+  it('is true for exactly the rows messageRowClass sends to messageRowEnd', () => {
+    // The toolbar's button order reads this predicate and the row class reads it
+    // too; a disagreement would reverse the buttons on a row that is not
+    // mirrored, which is how the agent rows' new order once leaked into user rows.
+    const cases: Array<[Parameters<typeof messageRowClass>[0], MessageSource]> = [
+      ['user_text', MessageSource.USER],
+      ['user_content', MessageSource.USER],
+      ['user_text', MessageSource.AGENT],
+      ['assistant_text', MessageSource.AGENT],
+      ['assistant_thinking', MessageSource.AGENT],
+      ['tool_use', MessageSource.USER],
+      ['tool_result', MessageSource.USER],
+      ['hidden', MessageSource.USER],
+      ['notification', MessageSource.USER],
+      ['plan_execution', MessageSource.USER],
+    ]
+    for (const [kind, source] of cases) {
+      expect(isMirroredMessageRow(kind, source))
+        .toBe(messageRowClass(kind, source) === chatStyles.messageRowEnd)
+    }
+  })
+
+  it('mirrors a user message and never an agent one', () => {
+    expect(isMirroredMessageRow('user_text', MessageSource.USER)).toBe(true)
+    expect(isMirroredMessageRow('assistant_text', MessageSource.AGENT)).toBe(false)
+    expect(isMirroredMessageRow('tool_use', MessageSource.USER)).toBe(false)
+    expect(isMirroredMessageRow('notification', MessageSource.USER)).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // messageBubbleClass
 // ---------------------------------------------------------------------------
 
@@ -489,8 +556,8 @@ describe('messageBubbleClass', () => {
     expect(messageBubbleClass('notification', MessageSource.AGENT)).toBe(chatStyles.systemMessage)
   })
 
-  it('returns thinkingMessage for assistant_thinking', () => {
-    expect(messageBubbleClass('assistant_thinking', MessageSource.AGENT)).toBe(chatStyles.thinkingMessage)
+  it('returns bandMessage for assistant_thinking', () => {
+    expect(messageBubbleClass('assistant_thinking', MessageSource.AGENT)).toBe(chatStyles.bandMessage)
   })
 
   it('returns metaMessage for meta kinds', () => {
@@ -502,8 +569,30 @@ describe('messageBubbleClass', () => {
     expect(messageBubbleClass('compact_summary', MessageSource.AGENT)).toBe(chatStyles.metaMessage)
   })
 
-  it('returns assistantMessage for assistant_text with AGENT source', () => {
-    expect(messageBubbleClass('assistant_text', MessageSource.AGENT)).toBe(chatStyles.assistantMessage)
+  it('returns bandMessage for assistant_text with AGENT source', () => {
+    expect(messageBubbleClass('assistant_text', MessageSource.AGENT)).toBe(chatStyles.bandMessage)
+  })
+
+  it('gives a message and a thought the SAME content class -- the line style lives on the row', () => {
+    expect(messageBubbleClass('assistant_text', MessageSource.AGENT))
+      .toBe(messageBubbleClass('assistant_thinking', MessageSource.AGENT))
+  })
+
+  it('returns bandMessage for a band kind regardless of source', () => {
+    // The band is decided by kind alone, exactly as messageRowChromeClass and the
+    // virtualizer's gap decide it -- a source-dependent answer here would let the
+    // strip and its content disagree.
+    expect(messageBubbleClass('assistant_text', MessageSource.USER)).toBe(chatStyles.bandMessage)
+    expect(messageBubbleClass('assistant_thinking', MessageSource.LEAPMUX)).toBe(chatStyles.bandMessage)
+  })
+
+  it('returns the fallback bubble for an unclassified AGENT shape', () => {
+    // `unknown` renders as a bare raw-text span, so it still needs a container.
+    expect(messageBubbleClass('unknown', MessageSource.AGENT)).toBe(chatStyles.agentFallbackMessage)
+  })
+
+  it('keeps plan_execution on its own bubble, not a band', () => {
+    expect(messageBubbleClass('plan_execution', MessageSource.AGENT)).toBe(chatStyles.planExecutionMessage)
   })
 
   it('returns userMessage for user_text with USER source', () => {
@@ -516,5 +605,145 @@ describe('messageBubbleClass', () => {
 
   it('returns systemMessage for unknown kind with LEAPMUX source', () => {
     expect(messageBubbleClass('unknown', MessageSource.LEAPMUX)).toBe(chatStyles.systemMessage)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// messageRowChromeClass
+// ---------------------------------------------------------------------------
+
+describe('messageRowChromeClass', () => {
+  it('returns the plain band for an assistant message', () => {
+    expect(messageRowChromeClass('assistant_text', MessageSource.AGENT)).toBe(chatStyles.bandRow)
+  })
+
+  it('adds the dashed variant for a thought', () => {
+    const classes = messageRowChromeClass('assistant_thinking', MessageSource.AGENT).split(' ')
+    expect(classes).toContain(chatStyles.bandRow)
+    expect(classes).toContain(chatStyles.bandRowThought)
+  })
+
+  it('widens a turn-end divider row so its rule can reach both edges', () => {
+    expect(messageRowChromeClass('result_divider', MessageSource.AGENT)).toBe(chatStyles.bleedRow)
+  })
+
+  it('widens a user message row so its bubble can reach the right edge', () => {
+    expect(messageRowChromeClass('user_text', MessageSource.USER)).toBe(chatStyles.bleedRow)
+    expect(messageRowChromeClass('user_content', MessageSource.USER)).toBe(chatStyles.bleedRow)
+  })
+
+  it('widens exactly the rows that mirror -- never a meta row from the user', () => {
+    // The bubble's negative margin and the row's widening must cover the same
+    // rows; a tool row sent by the user renders a metaMessage, not a bubble, so
+    // widening it would be pointless and could clip nothing into view.
+    for (const kind of ['tool_use', 'tool_result', 'hidden', 'notification'] as const) {
+      expect(messageRowChromeClass(kind, MessageSource.USER)).toBe('')
+      expect(isMirroredMessageRow(kind, MessageSource.USER)).toBe(false)
+    }
+  })
+
+  it('gives a widened row NO band chrome -- it paints no strip of its own', () => {
+    for (const [kind, source] of [['result_divider', MessageSource.AGENT], ['user_text', MessageSource.USER]] as const) {
+      const classes = messageRowChromeClass(kind, source).split(' ')
+      expect(classes).not.toContain(chatStyles.bandRow)
+      expect(classes).not.toContain(chatStyles.bandRowThought)
+    }
+  })
+
+  it('returns an empty string for every row that stays inside the gutter', () => {
+    for (const kind of ['tool_use', 'tool_result', 'agent_prompt', 'user_text', 'user_content', 'plan_execution', 'notification', 'control_response', 'compact_summary', 'hidden', 'unsupported_provider', 'unknown'] as const) {
+      expect(messageRowChromeClass(kind, MessageSource.AGENT)).toBe('')
+    }
+  })
+
+  it('agrees with messageBubbleClass on which kinds are bands', () => {
+    // The strip and the content inside it are chosen by two functions; a
+    // disagreement would paint gray behind a bubble or leave a band unpainted.
+    // result_divider and a user row bleed WITHOUT being bands, so this checks
+    // the band class specifically, not "chrome is non-empty".
+    for (const kind of ['assistant_text', 'assistant_thinking', 'result_divider', 'tool_use', 'user_text', 'plan_execution', 'notification', 'unknown'] as const) {
+      const isBand = messageRowChromeClass(kind, MessageSource.AGENT).split(' ').includes(chatStyles.bandRow)
+      expect(messageBubbleClass(kind, MessageSource.AGENT) === chatStyles.bandMessage).toBe(isBand)
+    }
+  })
+
+  it('widens a row whenever its bubble runs to the right edge', () => {
+    // The invariant the layout rests on: a bubble that bleeds needs its row widened,
+    // or paint containment clips the bleed away. Swept over the WHOLE domain, not a
+    // sample -- a new kind that reaches the edge without bleedRow would otherwise
+    // land as a silently clipped bubble that only a screenshot catches.
+    let bleedingBubbles = 0
+    for (const kind of ALL_MESSAGE_KINDS) {
+      for (const source of ALL_MESSAGE_SOURCES) {
+        if (!bubbleRunsToRightEdge(kind, source, false))
+          continue
+        bleedingBubbles++
+        expect(messageRowChromeClass(kind, source)).toBe(chatStyles.bleedRow)
+      }
+    }
+    // Guard the loop against becoming a no-op if the bubble mapping ever changes.
+    expect(bleedingBubbles).toBeGreaterThan(0)
+  })
+})
+
+describe('messageRowChrome', () => {
+  it('joins the base class with the row chrome and reports the band beside it', () => {
+    // The four row-mount sites spread this ONE result. Before it existed they each
+    // hand-built the class join and looked the band up again, and the streaming tail
+    // hardcoded both -- so a row could be measured without the chrome it renders with.
+    const chrome = messageRowChrome('base-class', 'assistant_thinking', MessageSource.AGENT)
+    expect(chrome.class.split(' ')).toEqual([
+      'base-class',
+      chatStyles.bandRow,
+      chatStyles.bandRowThought,
+    ])
+    expect(chrome.band).toBe('thought')
+  })
+
+  it('emits no stray separator for a row that paints nothing', () => {
+    // messageRowChromeClass returns '' for such a row, and a naive join would leave a
+    // trailing space -- which reads as an empty class token in the DOM.
+    const chrome = messageRowChrome('base-class', 'tool_use', MessageSource.AGENT)
+    expect(chrome.class).toBe('base-class')
+    expect(chrome.band).toBeUndefined()
+  })
+
+  it('drops the separator the other way too, for a row mounted with no base class', () => {
+    // The streaming tail passes '' -- it is in flow, so it has no positioning class of
+    // its own. A leading space would be the same empty token.
+    const chrome = messageRowChrome('', 'assistant_text', MessageSource.AGENT)
+    expect(chrome.class).toBe(chatStyles.bandRow)
+    expect(chrome.band).toBe('text')
+  })
+
+  it('agrees with messageRowChromeClass over the whole domain', () => {
+    for (const kind of ALL_MESSAGE_KINDS) {
+      for (const source of ALL_MESSAGE_SOURCES) {
+        const expected = [messageRowChromeClass(kind, source)].filter(Boolean).join(' ')
+        expect(messageRowChrome('', kind, source).class).toBe(expected)
+      }
+    }
+  })
+})
+
+describe('bubbleRunsToRightEdge', () => {
+  it('is true for exactly the rows whose bubble is a user bubble', () => {
+    // Derived from messageBubbleClass rather than from a condition written again,
+    // so the two can never disagree about which bubbles reach the edge.
+    for (const kind of ALL_MESSAGE_KINDS) {
+      for (const source of ALL_MESSAGE_SOURCES) {
+        const isUserBubble = messageBubbleClass(kind, source) === chatStyles.userMessage
+        expect(bubbleRunsToRightEdge(kind, source, false)).toBe(isUserBubble)
+      }
+    }
+  })
+
+  it('is false for every row once a delivery error stacks controls under the bubble', () => {
+    // Retry and Delete are laid out against the row's CONTENT edge, so a bleeding
+    // bubble above them would leave the two right edges a whole gutter apart.
+    for (const kind of ALL_MESSAGE_KINDS) {
+      for (const source of ALL_MESSAGE_SOURCES)
+        expect(bubbleRunsToRightEdge(kind, source, true)).toBe(false)
+    }
   })
 })

--- a/frontend/src/components/chat/messageClassification.ts
+++ b/frontend/src/components/chat/messageClassification.ts
@@ -1,9 +1,11 @@
+import type { MessageBandKind } from './chatRowGeometry'
 import type { ClassificationContext, ClassificationInput } from './providers/registry'
 import type { AgentChatMessage } from '~/generated/leapmux/v1/agent_pb'
 import type { ParsedMessageContent } from '~/lib/messageParser'
 import { MessageSource } from '~/generated/leapmux/v1/agent_pb'
 import { parseMessageContent } from '~/lib/messageParser'
 import { isWorkerAuthoredNotification } from '~/lib/notificationTypes'
+import { messageBandKind } from './chatRowGeometry'
 import * as chatStyles from './messageStyles.css'
 import { isPersistedControlResponse } from './persistedControlResponse'
 import { pluginFor } from './providers/registry'
@@ -168,7 +170,7 @@ export function invalidateMessageClassificationCache(message: AgentChatMessage):
 function sourceStyle(source: MessageSource): string {
   switch (source) {
     case MessageSource.USER: return chatStyles.userMessage
-    case MessageSource.AGENT: return chatStyles.assistantMessage
+    case MessageSource.AGENT: return chatStyles.agentFallbackMessage
     default: return chatStyles.systemMessage
   }
 }
@@ -222,24 +224,122 @@ export function shouldClearStreamingText(
   return !NON_STREAM_CLEAR_KINDS.has(category.kind)
 }
 
+/**
+ * True when the row lays its bubble out at the END of the line and MIRRORS its
+ * toolbar beside it (`messageRowEnd`: a right-aligned user message, whose
+ * actions sit to the LEFT of the bubble in a right-to-left grid).
+ *
+ * Exported because the toolbar's button order depends on it: a mirrored row puts
+ * Quote first so it lands nearest the bubble, where every other row puts the
+ * timestamp first. Both callers read this one predicate, so the class and the
+ * order can't disagree about which rows are mirrored.
+ */
+export function isMirroredMessageRow(kind: MessageCategory['kind'], source: MessageSource): boolean {
+  // `notification` needs no test of its own: META_KINDS holds it.
+  return !META_KINDS.has(kind) && source === MessageSource.USER
+}
+
 /** Row class: determines horizontal alignment. */
 export function messageRowClass(kind: MessageCategory['kind'], source: MessageSource): string {
   if (kind === 'notification')
     return chatStyles.messageRowCenter
-  if (!META_KINDS.has(kind) && source === MessageSource.USER)
+  if (isMirroredMessageRow(kind, source))
     return chatStyles.messageRowEnd
   return chatStyles.messageRow
 }
 
 /** Bubble class: determines visual style of the message container. */
 export function messageBubbleClass(kind: MessageCategory['kind'], source: MessageSource): string {
+  // A band's content class is the same for a message and a thought -- the solid
+  // vs dashed line lives on the ROW (see messageRowChromeClass), so this must not
+  // branch on the band kind again.
+  if (messageBandKind(kind))
+    return chatStyles.bandMessage
   if (kind === 'notification')
     return chatStyles.systemMessage
-  if (kind === 'assistant_thinking')
-    return chatStyles.thinkingMessage
   if (kind === 'plan_execution')
     return chatStyles.planExecutionMessage
   if (META_KINDS.has(kind))
     return chatStyles.metaMessage
   return sourceStyle(source)
+}
+
+/**
+ * Row class for the decoration a row paints across the FULL panel width, or ''
+ * for a row that stays inside the list gutter. Three rows bleed: a message or a
+ * thought paints a band behind itself, a turn-end divider runs its rule to both
+ * edges, and a user message's bubble runs its right side to the right edge.
+ *
+ * Belongs on the ROW element, so that the measured row and the visible row carry
+ * identical chrome and cannot wrap their text at different widths. Reach it
+ * through `messageRowChrome` below, which is what every row-mount site uses.
+ */
+export function messageRowChromeClass(kind: MessageCategory['kind'], source: MessageSource): string {
+  const band = messageBandKind(kind)
+  if (band)
+    return band === 'thought' ? `${chatStyles.bandRow} ${chatStyles.bandRowThought}` : chatStyles.bandRow
+  // A turn-end rule reaches both edges; a user bubble's right side reaches the
+  // right one. Neither row paints anything itself, so both just widen.
+  if (kind === 'result_divider' || isMirroredMessageRow(kind, source))
+    return chatStyles.bleedRow
+  return ''
+}
+
+/**
+ * True when the row's bubble runs its RIGHT side off the panel edge.
+ *
+ * Derived from `messageBubbleClass`, not from a condition written again here, so
+ * the two cannot disagree about which bubbles bleed. That derivation also proves
+ * the pairing the layout depends on: `sourceStyle` returns `userMessage` only for
+ * a USER source on a non-meta kind, which is exactly `isMirroredMessageRow`, so a
+ * bubble that reaches the edge always sits in a row that `messageRowChromeClass`
+ * widened. (The stylesheet enforces it a second time: the bleed is declared only
+ * inside `bleedRow` -- see `bubbleFlushRight`.)
+ *
+ * A delivery error is the one case that opts out. It stacks "Failed to deliver /
+ * Retry / Delete" under the bubble, laid out against the row's CONTENT edge, so a
+ * bleeding bubble above it would leave the two right edges a whole gutter apart.
+ * Bleeding that line to match would be worse: it would put Retry and Delete under
+ * the scroll rail's column, which takes every pointer event in its own box. An
+ * undelivered message is also not part of the settled transcript that runs off
+ * the panel edge, and a closed bubble with its controls squared under it says so.
+ */
+export function bubbleRunsToRightEdge(
+  kind: MessageCategory['kind'],
+  source: MessageSource,
+  hasDeliveryError: boolean,
+): boolean {
+  return !hasDeliveryError && messageBubbleClass(kind, source) === chatStyles.userMessage
+}
+
+/** Everything a mounted chat row's own element carries, for one `(kind, source)`. */
+export interface MessageRowChrome {
+  /** `baseClass` and the row's bleed decoration, joined and ready for `class=`. */
+  class: string
+  /** The band this row paints, or undefined. `data-band` is the e2e hook for it. */
+  band: MessageBandKind | undefined
+}
+
+/**
+ * The chrome for ONE mounted chat row. Every place that mounts a row calls this
+ * and spreads the result, which is what keeps them identical.
+ *
+ * There are four such places, and they agree on nothing else: the virtual row and
+ * the streaming tail (ChatView), the hidden premeasure row (chatHiddenPremeasure)
+ * and, for its class alone, the positioned skeleton that stands in for an
+ * unmeasured row. They differ in positioning and in role -- absolute and measured,
+ * in flow, hidden and measured, an overlay -- so they are deliberately NOT one
+ * component. Their CHROME is the one thing that must not differ: a row measured
+ * without its band commits a height two borders and two paddings short of the
+ * height it renders at, and the offset map then shifts under the reader.
+ */
+export function messageRowChrome(
+  baseClass: string,
+  kind: MessageCategory['kind'],
+  source: MessageSource,
+): MessageRowChrome {
+  return {
+    class: [baseClass, messageRowChromeClass(kind, source)].filter(Boolean).join(' '),
+    band: messageBandKind(kind),
+  }
 }

--- a/frontend/src/components/chat/messageStyles.css.ts
+++ b/frontend/src/components/chat/messageStyles.css.ts
@@ -1,7 +1,76 @@
 import { globalStyle, keyframes, style } from '@vanilla-extract/css'
 import { codeTypography, codeWrap } from '~/styles/codeBlock'
+import { CHAT_PAD_LEFT_VAR, CHAT_PAD_RIGHT_VAR, CHAT_RAIL_WIDTH_VAR } from './chatChromeVars'
+import { BAND_BORDER_PX } from './chatRowGeometry'
 import { shikiDualThemeColors } from './shikiTokenColors.css'
 import { toolHeaderActions, toolHeaderTimestamp } from './toolStyles.css'
+import { ROW_BLEED_LEFT_VAR } from './widgets/SpanLines.geometry'
+
+/**
+ * A band's vertical breathing room: the space between its border line and its
+ * first and last line of text. Defined once because two rules must agree on it --
+ * the band's own padding, and the top offset that drops the band's absolute
+ * toolbar onto the band's first text line.
+ */
+const BAND_PAD_Y = 'var(--space-3)'
+
+/** Distance from the chat list's own edges to the panel's, on each side. */
+const gutterLeft = `var(${CHAT_PAD_LEFT_VAR}, 0px)`
+const gutterRight = `var(${CHAT_PAD_RIGHT_VAR}, 0px)`
+
+/**
+ * Distance from a CONTENT COLUMN's left edge to the PANEL's left edge: the gutter
+ * plus the span rails' reserved width, which only the row knows. Every element
+ * that starts a content column publishes ROW_BLEED_LEFT_VAR, so a bleeding child
+ * reads the real distance instead of assuming the bare gutter. The fallback
+ * covers a content column with no rails beside it.
+ */
+const contentColumnLeft = `var(${ROW_BLEED_LEFT_VAR}, ${gutterLeft})`
+
+/** Cancel the distance to a panel edge, so a box reaches it on that side. */
+export const bleedLeft = `calc(-1 * ${contentColumnLeft})`
+export const bleedRight = `calc(-1 * ${gutterRight})`
+
+/**
+ * Widen a box that CLIPS its contents (paint containment) so its padding box
+ * reaches both panel edges, without moving its content box. Pairs with the
+ * negative margins above on whatever bleeds inside it.
+ */
+export const contentColumnBleed = {
+  marginLeft: bleedLeft,
+  marginRight: bleedRight,
+  paddingLeft: contentColumnLeft,
+  paddingRight: gutterRight,
+} as const
+
+/**
+ * Widen a ROW to the full panel width without moving anything inside it: the
+ * negative margins cancel the list gutter, and the equal padding puts the row's
+ * CONTENT box back exactly where it was.
+ *
+ * Both sides read `gutterLeft`, never `contentColumnLeft`. A row sits AT the
+ * gutter with no rails to its left, so the two are equal today -- but
+ * ROW_BLEED_LEFT_VAR inherits, and a row mounted inside some future content
+ * column would inherit a wider value into the margin alone. The cancellation
+ * would then stop cancelling, and the row's text would wrap at a width that
+ * hidden premeasure never reproduces. One source on both sides makes that
+ * unrepresentable rather than merely absent.
+ *
+ * Two things need this. A row that paints its OWN decoration edge to edge (a
+ * band's background and borders) needs only this, because an element's own
+ * background and border are not subject to paint containment. A row whose
+ * decoration is drawn by a DESCENDANT (a turn-end rule, a user bubble's right
+ * side) needs this AND a matching negative margin on that descendant, because
+ * paint containment on `virtualRow` and `railedRowContent`
+ * (~/components/chat/ChatView.css.ts) clips a descendant to the row's padding
+ * box -- which is precisely what this widens.
+ */
+const rowBleed = {
+  marginLeft: `calc(-1 * ${gutterLeft})`,
+  marginRight: bleedRight,
+  paddingLeft: gutterLeft,
+  paddingRight: gutterRight,
+} as const
 
 export const messageBubble = style({
   position: 'relative',
@@ -12,23 +81,31 @@ export const messageBubble = style({
   wordBreak: 'break-word',
 })
 
-export const userMessage = style([messageBubble, {
+/**
+ * A user message's bubble: an accent card at the end of the line, rounded and
+ * outlined on every side, and only as wide as the message needs up to the shared
+ * 85% cap.
+ *
+ * It carries NO bleed of its own. Running its right side off the panel edge is
+ * `bubbleFlushRight` below, which only takes effect inside a widened row.
+ */
+const userBubble = {
   backgroundColor: 'var(--accent)',
   border: '1px solid var(--border)',
   color: 'var(--foreground)',
   alignSelf: 'flex-end',
-}])
+} as const
+
+export const userMessage = style([messageBubble, userBubble])
 
 const pendingPulse = keyframes({
   '0%, 100%': { opacity: 0.5 },
   '50%': { opacity: 0.85 },
 })
 
+/** The same bubble, pulsing while an optimistic local waits for its agent. */
 export const userMessagePending = style([messageBubble, {
-  'backgroundColor': 'var(--accent)',
-  'border': '1px solid var(--border)',
-  'color': 'var(--foreground)',
-  'alignSelf': 'flex-end',
+  ...userBubble,
   'animation': `${pendingPulse} 1.5s ease-in-out infinite`,
   '@media': {
     '(prefers-reduced-motion: reduce)': {
@@ -38,19 +115,106 @@ export const userMessagePending = style([messageBubble, {
   },
 }])
 
-export const assistantMessage = style([messageBubble, {
+/**
+ * Fallback bubble for an AGENT-source row that is not a band -- in practice an
+ * `unknown` shape from a registered provider, which renders as a bare raw-text
+ * span and would otherwise float with no container at all. A band is reserved
+ * for the kinds messageBandKind lists; anything else the agent emits keeps this
+ * bubble so an unclassified row stays visibly a bubble, not chrome-less text.
+ */
+export const agentFallbackMessage = style([messageBubble, {
   backgroundColor: 'var(--card)',
   border: '1px solid var(--border)',
   color: 'var(--foreground)',
   alignSelf: 'flex-start',
 }])
 
-export const thinkingMessage = style([messageBubble, {
+/**
+ * The band an assistant message or thought paints: a full-bleed gray surface with
+ * a line on its top and bottom edge. Applied to the ROW element, not to the
+ * bubble, because paint containment would clip a bubble at the gutter, and
+ * because a band painted BEHIND the row's content is what lets the span rails and
+ * the toolbar sit on the gray.
+ *
+ * `--row-surface` tells the row's absolute toolbar which color to paint behind
+ * itself: one toolbar rule serves both this row family and the meta rows, whose
+ * surface is the panel background.
+ */
+export const bandRow = style({
+  ...rowBleed,
   backgroundColor: 'var(--card)',
-  border: '1px dashed var(--border)',
+  borderTop: `${BAND_BORDER_PX}px solid var(--border)`,
+  borderBottom: `${BAND_BORDER_PX}px solid var(--border)`,
+  vars: {
+    '--row-surface': 'var(--card)',
+  },
+})
+
+/**
+ * A row that paints nothing itself and only widens, so that a DESCENDANT can
+ * reach a panel edge. Used by a turn-end divider (its rule runs to both edges,
+ * see the globalStyle beside `resultDivider`) and by a user message row (its
+ * bubble's right side runs to the right edge, see `bubbleFlushRight`).
+ */
+export const bleedRow = style(rowBleed)
+
+/**
+ * Marks a BUBBLE that runs its right side off the panel edge.
+ *
+ * The class carries nothing by itself. The declarations that move the bubble live
+ * in the rule below, scoped to `bleedRow`, so a marked bubble in a row that was
+ * never widened produces no bleed at all -- rather than one that paint
+ * containment silently clips at the gutter. The pairing that the row chrome and
+ * the bubble class have to agree on is expressed in the selector instead of being
+ * left to two predicates that happen to overlap. Same construction as the turn-end
+ * rule below.
+ */
+export const bubbleFlushRight = style({})
+
+globalStyle(`${bleedRow} .${bubbleFlushRight}`, {
+  // Cancel the gutter, then drop the right border and the right corners: a
+  // rounded, outlined corner flush against a panel edge reads as a mistake.
+  marginRight: bleedRight,
+  borderRightWidth: 0,
+  borderTopRightRadius: 0,
+  borderBottomRightRadius: 0,
+})
+
+/**
+ * A thought's band. It carries a dashed line instead of a solid one. Dashed is
+ * the chat's established mark for a de-emphasized surface -- systemMessage,
+ * planExecutionMessage and hiddenMessageJson all use it, as the thought bubble
+ * itself did before it became a band.
+ *
+ * A modifier, applied BESIDE `bandRow` rather than composed into it, because both
+ * classes are read as single tokens: `messageRowChromeClass` joins them, and the
+ * tests assert each one with `classList.contains`.
+ */
+export const bandRowThought = style({
+  borderTopStyle: 'dashed',
+  borderBottomStyle: 'dashed',
+})
+
+/**
+ * The content inside a band. It carries NO background, border or radius -- the
+ * band behind it does (see bandRow) -- and it stretches to the row's full
+ * content width like a tool message rather than capping at a bubble's 85%.
+ *
+ * The vertical padding lives here, not on bandRow, so the span rails (a flex
+ * sibling of this element's wrapper, stretched by the row) span the whole gray
+ * instead of stopping short of it at every band boundary.
+ */
+export const bandMessage = style({
+  position: 'relative',
+  alignSelf: 'stretch',
+  flex: 1,
+  minWidth: 0,
+  paddingTop: BAND_PAD_Y,
+  paddingBottom: BAND_PAD_Y,
+  lineHeight: 1.6,
+  wordBreak: 'break-word',
   color: 'var(--foreground)',
-  alignSelf: 'flex-start',
-}])
+})
 
 export const planExecutionMessage = style([messageBubble, {
   backgroundColor: 'var(--accent)',
@@ -126,6 +290,18 @@ export const resultDivider = style({
   },
 })
 
+/**
+ * Run a turn-end divider's rule to both panel edges. Scoped to `bleedRow`, and
+ * NOT put on `resultDivider` itself, because the same class also draws the
+ * compaction-boundary rule inside a CENTERED bubble (NotificationDivider in
+ * ~/components/chat/notificationRenderers.tsx). Bleeding there would push the
+ * rule straight out of that bubble's dashed border.
+ */
+globalStyle(`${bleedRow} .${resultDivider}`, {
+  marginLeft: bleedLeft,
+  marginRight: bleedRight,
+})
+
 // Error detail text shown below the result divider for execution errors
 export const resultErrorDetail = style({
   margin: 0,
@@ -199,8 +375,11 @@ export const messageRowCenter = style({
   position: 'relative',
 })
 
-// Extra vertical spacing for user, assistant, and notification message rows
-globalStyle(`${messageRow}:has(> .${assistantMessage}), ${messageRow}:has(> .${thinkingMessage}), ${messageRowEnd}, ${messageRowCenter}`, {
+// Extra vertical spacing for user and notification message rows. A band row is
+// deliberately absent: its own vertical padding (bandMessage) provides the
+// breathing room, and a margin here would put transparent space between two
+// bands that must touch.
+globalStyle(`${messageRowEnd}, ${messageRowCenter}`, {
   marginTop: 'var(--space-1)',
   marginBottom: 'var(--space-1)',
 })
@@ -211,18 +390,45 @@ globalStyle(`${messageRow} > .${metaMessage}`, {
   alignSelf: 'auto',
 })
 
-// Inside messageRow containing a metaMessage, position actions absolutely so they don't take space
-globalStyle(`${messageRow}:has(> .${metaMessage})`, {
+// A meta row (tool, divider) and a band row both give their whole width to the
+// content, so the actions float over it instead of taking layout space.
+globalStyle(`${messageRow}:has(> .${metaMessage}), ${messageRow}:has(> .${bandMessage})`, {
   position: 'relative',
 })
 
-globalStyle(`${messageRow}:has(> .${metaMessage}) > .${toolHeaderActions}`, {
+/**
+ * How far the floating actions sit inside the content column's right edge: exactly
+ * the amount by which the scroll rail's column overhangs the gutter it fills.
+ *
+ * The rail is normally the gutter and nothing more, so this is 0 and the actions
+ * sit flush at the edge. Where the rail takes a floor -- a 4px phone gutter, or a
+ * coarse pointer that needs a whole finger -- the column reaches into the message
+ * text, and the rail wins every pointer event in its own box because it overlays
+ * the row from OUTSIDE that row's stacking context. Anything under the overhang is
+ * unreachable. Moving the actions clear of it by the same two properties the rail
+ * is sized from keeps them reachable at every width, with no breakpoint of its own
+ * to keep in step.
+ */
+const railOverhang = `calc(var(${CHAT_RAIL_WIDTH_VAR}, ${gutterRight}) - ${gutterRight})`
+
+// A meta row (tool, divider), a band row and a notification row all give their
+// whole width to the content, so the actions float over it at the same right edge
+// instead of taking layout space.
+globalStyle(`${messageRow}:has(> .${metaMessage}) > .${toolHeaderActions}, ${messageRow}:has(> .${bandMessage}) > .${toolHeaderActions}, ${messageRowCenter} > .${toolHeaderActions}`, {
   position: 'absolute',
-  right: 0,
+  right: railOverhang,
   marginLeft: 0,
-  background: 'var(--background)',
+  // The surface the actions must occlude: the panel background on a meta row or a
+  // notification row, the band's gray on a band row (bandRow sets --row-surface).
+  background: 'var(--row-surface, var(--background))',
   borderRadius: 'var(--radius-small)',
   paddingLeft: 'var(--space-1)',
+})
+
+// A band's content starts below its own top padding, so drop the actions by the
+// same amount to put them on the band's first text line.
+globalStyle(`${messageRow}:has(> .${bandMessage}) > .${toolHeaderActions}`, {
+  top: BAND_PAD_Y,
 })
 
 // Inside messageRowEnd, place actions to the left of the bubble in a 2-column grid (mirrored via RTL)
@@ -241,32 +447,9 @@ globalStyle(`${messageRowEnd} > .${toolHeaderActions} > *`, {
   direction: 'ltr',
 })
 
-// 2-column grid layout for assistant/thinking bubble actions so primary actions sit adjacent to the bubble
-globalStyle(`${messageRow}:has(> .${assistantMessage}) > .${toolHeaderActions}, ${messageRow}:has(> .${thinkingMessage}) > .${toolHeaderActions}`, {
-  paddingTop: 'var(--space-1)',
-  paddingBottom: 'var(--space-1)',
-  display: 'grid',
-  gridTemplateColumns: 'auto auto',
-})
-
-// Add left padding to timestamps in assistant grid so they align with the icon button below
-globalStyle(`${messageRow}:has(> .${assistantMessage}) > .${toolHeaderActions} .${toolHeaderTimestamp}, ${messageRow}:has(> .${thinkingMessage}) > .${toolHeaderActions} .${toolHeaderTimestamp}`, {
-  paddingLeft: 'var(--space-1)',
-})
-
 // Add right padding to timestamps in user grid (mirrored) so they align with the icon button below
 globalStyle(`${messageRowEnd} > .${toolHeaderActions} .${toolHeaderTimestamp}`, {
   paddingRight: 'var(--space-1)',
-})
-
-// Inside messageRowCenter, position actions at the right edge absolutely
-globalStyle(`${messageRowCenter} > .${toolHeaderActions}`, {
-  position: 'absolute',
-  right: 0,
-  marginLeft: 0,
-  background: 'var(--background)',
-  borderRadius: 'var(--radius-small)',
-  paddingLeft: 'var(--space-1)',
 })
 
 // When hovering a message row, reveal the actions
@@ -274,12 +457,12 @@ globalStyle(`${messageRow}:hover .${toolHeaderActions}, ${messageRowEnd}:hover .
   opacity: 1,
 })
 
-globalStyle(`${messageBubble} code`, {
+globalStyle(`${messageBubble} code, ${bandMessage} code`, {
   fontFamily: 'var(--font-mono)',
   fontVariantLigatures: 'none',
 })
 
-globalStyle(`${messageBubble} pre`, {
+globalStyle(`${messageBubble} pre, ${bandMessage} pre`, {
   fontFamily: 'var(--font-mono)',
   fontVariantLigatures: 'none',
 })

--- a/frontend/src/components/chat/resultDividerRenderers.tsx
+++ b/frontend/src/components/chat/resultDividerRenderers.tsx
@@ -14,7 +14,17 @@ import { pluginFor } from './providers/registry'
 function ResultDivider(props: { model: ResultDividerModel }): JSXElement {
   return (
     <>
-      <div class={resultDivider} style={props.model.isError ? { color: 'var(--danger)' } : undefined}>
+      {/*
+        The test id marks the TURN-END rule specifically. `resultDivider` is a
+        hashed class and is shared with the compaction-boundary rule inside a
+        centered bubble (NotificationDivider), which does NOT bleed -- so a class
+        selector could not tell the two apart.
+      */}
+      <div
+        class={resultDivider}
+        data-testid="result-divider"
+        style={props.model.isError ? { color: 'var(--danger)' } : undefined}
+      >
         {props.model.label}
       </div>
       {props.model.detail && <pre class={resultErrorDetail}>{props.model.detail}</pre>}

--- a/frontend/src/components/chat/toolRenderers.tsx
+++ b/frontend/src/components/chat/toolRenderers.tsx
@@ -131,7 +131,6 @@ export function ToolUseLayout(props: {
           <ToolHeaderActions
             caller={actions()}
             layout={{
-              inline: true,
               createdAt: props.context?.createdAt,
               expanded: expanded(),
               onToggleExpand: props.onToggleExpand,
@@ -196,11 +195,18 @@ export interface ToolHeaderActionsLayoutProps {
   hasDiff?: boolean
   diffView?: DiffViewPreference
   onToggleDiffView?: () => void
-  /** When true, use inline tool header order; when false (default), use bubble order. */
-  inline?: boolean
+  /**
+   * The row mirrors its toolbar beside a right-aligned bubble (a user message --
+   * see isMirroredMessageRow). Such a row reverses the button order so Quote
+   * still lands nearest the bubble; every other row leads with the timestamp.
+   */
+  mirrored?: boolean
 }
 
-/** Actions area in tool header: Reply + Raw JSON copy + diff toggle + expand/collapse, all with tooltips. */
+/**
+ * Actions area for a message row or a tool header: timestamp, the copies, Quote,
+ * then the diff and expand toggles -- all with tooltips.
+ */
 export function ToolHeaderActions(props: {
   caller?: ToolHeaderActionsCallerProps
   layout?: ToolHeaderActionsLayoutProps
@@ -262,23 +268,47 @@ export function ToolHeaderActions(props: {
 
   return (
     <div class={toolHeaderActions} data-testid="message-toolbar">
-      {layout()?.inline
+      {/*
+        One order, READ LEFT TO RIGHT ON SCREEN, for every row: timestamp, then
+        the copies from broadest (the whole envelope) to narrowest (the rendered
+        content), then Quote. A tool header and a message row used to disagree
+        here, which put the same two buttons in different places depending on the
+        row above.
+
+        A MIRRORED row (a right-aligned user message) moves Quote only, from last
+        to second, so it still lands nearest the bubble on its right. Everything
+        else keeps its place: timestamp, Quote, JSON, Markdown, Content.
+
+        Its source order looks scrambled because it is NOT the render order. That
+        toolbar is a two-column `direction: rtl` grid (see `messageRowEnd >
+        toolHeaderActions` in ~/components/chat/messageStyles.css.ts), so the
+        FIRST item of each pair lands in the RIGHT cell:
+
+          source [Quote, timestamp]  renders  timestamp  Quote
+          source [Markdown, JSON]    renders  JSON       Markdown
+          source [Content]           renders             Content
+
+        Reading those rows left to right gives the one order above. The two arms
+        must therefore stay pairwise-swapped against each other; writing them the
+        "same" way is what would break them apart.
+      */}
+      {layout()?.mirrored
         ? (
             <>
-              {timestampEl}
-              {copyJsonButton}
-              {copyMarkdownButton}
-              {copyContentButton}
               {replyButton}
+              {timestampEl}
+              {copyMarkdownButton}
+              {copyJsonButton}
+              {copyContentButton}
             </>
           )
         : (
             <>
-              {replyButton}
               {timestampEl}
-              {copyMarkdownButton}
               {copyJsonButton}
+              {copyMarkdownButton}
               {copyContentButton}
+              {replyButton}
             </>
           )}
       <Show when={layout()?.hasDiff && layout()?.onToggleDiffView}>

--- a/frontend/src/components/chat/useChatVirtualizer.geometry.test.ts
+++ b/frontend/src/components/chat/useChatVirtualizer.geometry.test.ts
@@ -2,6 +2,7 @@ import type { VirtualItem } from './useChatVirtualizer'
 import { createRoot, createSignal } from 'solid-js'
 import { describe, expect, it } from 'vitest'
 import { MAX_LOADED_CHAT_MESSAGES_CEILING } from '~/stores/chat.store'
+import { BAND_BORDER_PX } from './chatRowGeometry'
 import { HEIGHT_CACHE_MAX, sameVirtualItems, useChatVirtualizer } from './useChatVirtualizer'
 import { fakeRow, makeItems, plainItems, setup } from './useChatVirtualizer.testkit'
 
@@ -27,6 +28,112 @@ describe('useChatVirtualizer geometry', () => {
       expect(virt.offsetOfIndex(2)).toBe(230) // +100 + large gap (lower row plain)
       expect(virt.totalHeight()).toBe(330) // +100
       dispose()
+    })
+  })
+
+  describe('adjacent band rows', () => {
+    // A band paints a full-bleed strip with a line on its top and bottom edge. Two
+    // adjacent bands overlap by one border width so the pair shows ONE line.
+    it('overlaps two adjacent bands by the band border width', () => {
+      createRoot((dispose) => {
+        const { virt } = setup(makeItems([{ seq: 1, kind: 'assistant_text' }, { seq: 2, kind: 'assistant_thinking' }]))
+        expect(virt.offsetOfIndex(1)).toBe(100 - BAND_BORDER_PX)
+        expect(virt.totalHeight()).toBe(200 - BAND_BORDER_PX)
+        dispose()
+      })
+    })
+
+    it('overlaps once per pair across a run of bands', () => {
+      createRoot((dispose) => {
+        const { virt } = setup(makeItems([
+          { seq: 1, kind: 'assistant_thinking' },
+          { seq: 2, kind: 'assistant_text' },
+          { seq: 3, kind: 'assistant_thinking' },
+          { seq: 4, kind: 'assistant_text' },
+        ]))
+        expect(virt.offsetOfIndex(1)).toBe(100 - BAND_BORDER_PX)
+        expect(virt.offsetOfIndex(2)).toBe(200 - 2 * BAND_BORDER_PX)
+        expect(virt.offsetOfIndex(3)).toBe(300 - 3 * BAND_BORDER_PX)
+        expect(virt.totalHeight()).toBe(400 - 3 * BAND_BORDER_PX)
+        dispose()
+      })
+    })
+
+    it('keeps the normal gap when only one side of the pair is a band', () => {
+      createRoot((dispose) => {
+        // band -> tool, then tool -> band. Neither pair merges, so both keep the
+        // large gap: a band next to a non-band still draws both of its own lines.
+        const { virt } = setup(makeItems([
+          { seq: 1, kind: 'assistant_text' },
+          { seq: 2, kind: 'tool_use' },
+          { seq: 3, kind: 'assistant_thinking' },
+        ]))
+        expect(virt.offsetOfIndex(1)).toBe(120)
+        expect(virt.offsetOfIndex(2)).toBe(240)
+        expect(virt.totalHeight()).toBe(340)
+        dispose()
+      })
+    })
+
+    it('overlaps a band pair even when the lower band has span lines', () => {
+      createRoot((dispose) => {
+        // The band rule wins over the small-gap rule. The rails then meet at the
+        // band's own shared border rather than across a gap, and the bridge across
+        // that seam collapses -- it sizes itself from gapAboveOf, asserted below.
+        const { virt } = setup(makeItems([
+          { seq: 1, kind: 'assistant_text', span: true },
+          { seq: 2, kind: 'assistant_thinking', span: true },
+        ]))
+        expect(virt.offsetOfIndex(1)).toBe(100 - BAND_BORDER_PX)
+        dispose()
+      })
+    })
+
+    it('still uses the small gap when a span row below a band is not a band', () => {
+      createRoot((dispose) => {
+        const { virt } = setup(makeItems([
+          { seq: 1, kind: 'assistant_text' },
+          { seq: 2, kind: 'tool_use', span: true },
+        ]))
+        expect(virt.offsetOfIndex(1)).toBe(110)
+        dispose()
+      })
+    })
+
+    it('adds no gap after the last row, band or not', () => {
+      createRoot((dispose) => {
+        const { virt } = setup(makeItems([{ seq: 1, kind: 'assistant_text' }]))
+        expect(virt.totalHeight()).toBe(100)
+        dispose()
+      })
+    })
+
+    it('reports the gap above each row, which is what sizes the span-line bridge', () => {
+      // The bridge overlay reads this instead of restating the gap as a token of its
+      // own, so a merged band seam -- where there IS no gap -- collapses its segment
+      // rather than drawing one for a gap that does not exist.
+      createRoot((dispose) => {
+        const { virt } = setup(makeItems([
+          { seq: 1, kind: 'assistant_text' },
+          { seq: 2, kind: 'assistant_thinking' },
+          { seq: 3, kind: 'tool_use', span: true },
+          { seq: 4, kind: 'tool_result' },
+        ]))
+        expect(virt.gapAboveOf('m1')).toBe(0) // nothing above the first row
+        expect(virt.gapAboveOf('m2')).toBe(-BAND_BORDER_PX) // merged band pair
+        expect(virt.gapAboveOf('m3')).toBe(10) // small gap: the lower row has rails
+        expect(virt.gapAboveOf('m4')).toBe(20) // large gap
+        expect(virt.gapAboveOf('nope')).toBe(0) // an absent row bridges nothing
+        dispose()
+      })
+    })
+
+    it('treats a row with no kind as a non-band', () => {
+      createRoot((dispose) => {
+        const { virt } = setup(makeItems([{ seq: 1 }, { seq: 2 }]))
+        expect(virt.offsetOfIndex(1)).toBe(120)
+        dispose()
+      })
     })
   })
 

--- a/frontend/src/components/chat/useChatVirtualizer.testkit.ts
+++ b/frontend/src/components/chat/useChatVirtualizer.testkit.ts
@@ -9,10 +9,11 @@ import { useChatVirtualizer } from './useChatVirtualizer'
  * split imports.
  */
 
-export function makeItems(specs: Array<{ seq: number, span?: boolean }>): VirtualItem[] {
+export function makeItems(specs: Array<{ seq: number, span?: boolean, kind?: string }>): VirtualItem[] {
   // `seq` is only a convenient way to derive a unique row id in these specs; the
-  // virtualizer itself keys everything by `id`.
-  return specs.map(s => ({ id: `m${s.seq}`, hasSpanLines: !!s.span }))
+  // virtualizer itself keys everything by `id`. `kind` is omitted unless a spec
+  // sets it, so the rows that don't care keep the shared estimate bucket.
+  return specs.map(s => ({ id: `m${s.seq}`, hasSpanLines: !!s.span, ...(s.kind === undefined ? {} : { kind: s.kind }) }))
 }
 
 export function plainItems(count: number, startSeq = 1): VirtualItem[] {

--- a/frontend/src/components/chat/useChatVirtualizer.ts
+++ b/frontend/src/components/chat/useChatVirtualizer.ts
@@ -6,6 +6,7 @@ import { largestIndexWhere, smallestIndexWhere } from '~/lib/binarySearch'
 import { clamp } from '~/lib/clamp'
 import { capMapInsertionOrder } from '~/lib/mapLru'
 import { monotonicNow } from '~/lib/monotonicNow'
+import { BAND_BORDER_PX, messageBandKind } from './chatRowGeometry'
 import { anchorAtOffset, resolveAnchorScrollTop, resolveNearestAnchorScrollTop } from './chatScrollAnchor'
 import { warnSlowScrollPhase } from './chatScrollGeometry'
 import { createRowMeasurer } from './createRowMeasurer'
@@ -311,6 +312,16 @@ export interface UseChatVirtualizerResult {
    */
   heightOfId: (id: string) => number
   /**
+   * The gap (px) the offset map left ABOVE a row: `gapAfter` of the row before
+   * it, and 0 for the first row. Negative where two adjacent bands overlap.
+   *
+   * The gap-bridge overlay sizes its segments from this rather than from a token
+   * of its own, so the bridge and the offsets cannot disagree: at a merged band
+   * seam there is no gap, and the segment collapses instead of being drawn for
+   * one that does not exist.
+   */
+  gapAboveOf: (id: string) => number
+  /**
    * Debug accessor: a row's measured DOM height when the cache holds one. The
    * generic fallback estimate is deliberately omitted from the raw-JSON surface;
    * it is not a row-specific analytical model.
@@ -610,12 +621,24 @@ export function useChatVirtualizer(opts: UseChatVirtualizerOptions): UseChatVirt
 
   // The gap between row i and i+1 is tightened (small) whenever the LOWER row
   // (i+1) has span lines. SpanLines gives the lower row column-specific
-  // ownership of the top bridge across this gap, so ROW_GAP (--space-2) must
-  // match gapSmallPx.
+  // ownership of the top bridge across this gap, and that bridge sizes itself
+  // from `gapAboveOf` below rather than from a token of its own -- so this
+  // function is the single decider for both the offset and the rail across it.
+  //
+  // Two adjacent BANDS (assistant message / thought) instead OVERLAP by one
+  // border width. Each band paints a full-bleed strip with a line on its top and
+  // bottom edge, so a zero gap would stack two lines; the lower row paints after
+  // the upper one, so this overlap puts its top border exactly over the upper
+  // row's bottom border and the pair shows one line. Placing the merge HERE, in
+  // the offset map, keeps every row's own height independent of its neighbour --
+  // which hidden premeasure requires, because it measures each row alone.
   const gapAfter = (list: VirtualItem[], i: number): number => {
     if (i >= list.length - 1)
       return 0
-    return list[i + 1].hasSpanLines
+    const next = list[i + 1]
+    if (messageBandKind(list[i].kind ?? '') && messageBandKind(next.kind ?? ''))
+      return -BAND_BORDER_PX
+    return next.hasSpanLines
       ? resolve(opts.gapSmallPx, DEFAULT_GAP_SMALL_PX)
       : resolve(opts.gapLargePx, DEFAULT_GAP_LARGE_PX)
   }
@@ -687,6 +710,11 @@ export function useChatVirtualizer(opts: UseChatVirtualizerOptions): UseChatVirt
   }
 
   const heightOfId = (id: string): number => heightOfIndex(indexOfId(id))
+
+  const gapAboveOf = (id: string): number => {
+    const i = indexOfId(id)
+    return i > 0 ? gapAfter(geom().list, i - 1) : 0
+  }
 
   const currentHeightKey = (id: string): string | undefined => {
     const g = geom()
@@ -1080,6 +1108,7 @@ export function useChatVirtualizer(opts: UseChatVirtualizerOptions): UseChatVirt
     scrollTopNearAnchor,
     heightOfIndex,
     heightOfId,
+    gapAboveOf,
     heightDebugOfId,
     estimateHeight,
     lastMeasurement: () => lastMeasurement,

--- a/frontend/src/components/chat/widgets/SpanLineGapBridges.test.tsx
+++ b/frontend/src/components/chat/widgets/SpanLineGapBridges.test.tsx
@@ -2,7 +2,9 @@ import type { SpanBridgeEntry } from './SpanLineGapBridges'
 import { render } from '@solidjs/testing-library'
 import { createSignal } from 'solid-js'
 import { describe, expect, it } from 'vitest'
+import { BAND_BORDER_PX } from '../chatRowGeometry'
 import { SpanLineGapBridges } from './SpanLineGapBridges'
+import { SPAN_BRIDGE_GAP_VAR } from './SpanLines.geometry'
 
 describe('spanlinegapbridges', () => {
   // Two rows sharing one active span column: the SECOND row's column continues from the
@@ -22,6 +24,7 @@ describe('spanlinegapbridges', () => {
         precedingEntry={undefined}
         topOf={() => 0}
         hiddenOf={() => false}
+        gapAboveOf={() => 8}
       />
     ))
     expect(container.querySelector('[data-span-gap-bridges-for="a"]')).toBeNull()
@@ -39,6 +42,7 @@ describe('spanlinegapbridges', () => {
         precedingEntry={undefined}
         topOf={() => 0}
         hiddenOf={id => id === 'b' && hidden()}
+        gapAboveOf={() => 8}
       />
     ))
     const bridgeB = () => container.querySelector('[data-span-gap-bridges-for="b"]') as HTMLElement
@@ -47,5 +51,38 @@ describe('spanlinegapbridges', () => {
     expect(bridgeB().style.visibility).toBe('hidden')
     setHidden(false) // row 'b' upgrades to real
     expect(bridgeB().style.visibility).toBe('')
+  })
+
+  it('sizes its segments from the gap the offset map actually left above the row', () => {
+    // The bridge used to restate the gap as a token of its own, which held only while
+    // every gap was the same. Two adjacent BANDS overlap by a border width instead, so a
+    // segment sized from a token was built for a gap that does not exist. Reading the
+    // offset map's own decider collapses it, and keeps one function in charge of both a
+    // row's offset and the rail that spans the space above it.
+    const entries = [entry('a'), entry('b')]
+    const render8 = render(() => (
+      <SpanLineGapBridges
+        entries={entries}
+        precedingEntry={undefined}
+        topOf={() => 0}
+        hiddenOf={() => false}
+        gapAboveOf={() => 8}
+      />
+    ))
+    const anchor8 = render8.container.querySelector('[data-span-gap-bridges-for="b"]') as HTMLElement
+    expect(anchor8.style.getPropertyValue(SPAN_BRIDGE_GAP_VAR)).toBe('8px')
+    render8.unmount()
+
+    const merged = render(() => (
+      <SpanLineGapBridges
+        entries={entries}
+        precedingEntry={undefined}
+        topOf={() => 0}
+        hiddenOf={() => false}
+        gapAboveOf={() => -BAND_BORDER_PX}
+      />
+    ))
+    const anchorMerged = merged.container.querySelector('[data-span-gap-bridges-for="b"]') as HTMLElement
+    expect(anchorMerged.style.getPropertyValue(SPAN_BRIDGE_GAP_VAR)).toBe(`${-BAND_BORDER_PX}px`)
   })
 })

--- a/frontend/src/components/chat/widgets/SpanLineGapBridges.tsx
+++ b/frontend/src/components/chat/widgets/SpanLineGapBridges.tsx
@@ -3,7 +3,7 @@ import type { SpanLine } from './SpanLines'
 import { createMemo, For, Index, Show } from 'solid-js'
 import { bodySpanKey, shouldConnectSpanLineTop, spanColorClassFor } from './SpanLines'
 import { spanGapBridge, spanGapBridgeRow } from './SpanLines.css'
-import { LINE_THICKNESS, spanColumnCenterX } from './SpanLines.geometry'
+import { LINE_THICKNESS, SPAN_BRIDGE_GAP_VAR, spanColumnCenterX } from './SpanLines.geometry'
 
 /**
  * The slice of a classified chat entry the bridge overlay reads. Structural
@@ -30,13 +30,23 @@ export interface SpanLineGapBridgesProps {
   topOf: (id: string) => number
   /** Mirrors the row's hide-until-measured state so a bridge never paints for an invisible row. */
   hiddenOf: (id: string) => boolean
+  /**
+   * The gap the offset map left above a row (`gapAboveOf` on the virtualizer).
+   * The segments are sized from it, so this overlay and the row offsets read one
+   * decider. Required, not optional, so a new mount site cannot forget it and
+   * silently draw every bridge at zero height.
+   */
+  gapAboveOf: (id: string) => number
 }
 
 /**
  * The inter-row rail segments, drawn OUTSIDE the rows in one overlay inside
  * the virtual spacer. The rows' own span columns stop exactly at the row
- * edge; this overlay paints the ROW_GAP-tall continuation above each row
- * whose column connects to the row above. Living outside the rows is what
+ * edge; this overlay paints the continuation across the gap above each row
+ * whose column connects to the row above, sized from that row's own gap (see
+ * `gapAboveOf`), so a merged band pair -- which has no gap -- gets a segment of
+ * zero height instead of one drawn for a gap that does not exist. Living
+ * outside the rows is what
  * lets every virtualized row take `contain: layout paint` — the one thing
  * that used to overflow a row's box was this bridge segment.
  */
@@ -61,6 +71,9 @@ export const SpanLineGapBridges: Component<SpanLineGapBridgesProps> = props => (
             style={{
               transform: `translateY(${props.topOf(entry.msg.id)}px)`,
               visibility: props.hiddenOf(entry.msg.id) ? 'hidden' : undefined,
+              // Published once per ROW, not per column: every segment in this
+              // anchor spans the same gap.
+              [SPAN_BRIDGE_GAP_VAR]: `${props.gapAboveOf(entry.msg.id)}px`,
             }}
             data-span-gap-bridges-for={entry.msg.id}
           >

--- a/frontend/src/components/chat/widgets/SpanLines.css.ts
+++ b/frontend/src/components/chat/widgets/SpanLines.css.ts
@@ -12,7 +12,7 @@ import {
   CONNECTOR_Y,
   CONTAINER_PAD_RIGHT,
   LINE_THICKNESS,
-  ROW_GAP,
+  SPAN_BRIDGE_GAP_VAR,
 } from './SpanLines.geometry'
 
 // ─── Span Column Geometry ───────────────────────────────────────────
@@ -44,13 +44,22 @@ import {
 
 // ─── Styles ─────────────────────────────────────────────────────────
 
-/** Container for all span line columns. */
+/**
+ * Container for all span line columns.
+ *
+ * Raised above the row's content column, which now bleeds LEFT under the rails
+ * to reach the panel edge. Without this the content column, a later sibling,
+ * would paint its band or its turn-end rule over them. This is the same
+ * precedence the band already has: the rails stay legible on top.
+ */
 export const spanLinesContainer = style({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'stretch',
   flexShrink: 0,
   paddingRight: `${CONTAINER_PAD_RIGHT}px`,
+  position: 'relative',
+  zIndex: 1,
 })
 
 /** Base style for a single span line column. */
@@ -253,8 +262,8 @@ export const spanGapBridgeRow = style({
  */
 export const spanGapBridge = style({
   position: 'absolute',
-  top: `calc(-1 * ${ROW_GAP})`,
-  height: `calc(${ROW_GAP} + ${BRIDGE_SEAM}px)`,
+  top: `calc(-1 * var(${SPAN_BRIDGE_GAP_VAR}, 0px))`,
+  height: `calc(var(${SPAN_BRIDGE_GAP_VAR}, 0px) + ${BRIDGE_SEAM}px)`,
   width: `${LINE_THICKNESS}px`,
   backgroundColor: 'var(--span-line-color, var(--border))',
 })

--- a/frontend/src/components/chat/widgets/SpanLines.geometry.ts
+++ b/frontend/src/components/chat/widgets/SpanLines.geometry.ts
@@ -1,3 +1,5 @@
+import { CHAT_PAD_LEFT_VAR } from '../chatChromeVars'
+
 /** Thickness of all span lines (vertical, horizontal, connectors, bridges). */
 export const LINE_THICKNESS = 2
 
@@ -20,11 +22,17 @@ export const CONNECTOR_GAP = 4
 export const CONTAINER_PAD_RIGHT = 1
 
 /**
- * Extension to bridge vertical lines across the gap between message rows.
- * Span-line rows sit a tightened --space-2 apart (the virtualizer encodes this
- * gap directly in each row's offset; see useChatVirtualizer's gapSmallPx).
+ * Custom property carrying the gap the offset map left ABOVE a row.
+ *
+ * The bridge overlay publishes it per row from `gapAboveOf`
+ * (~/components/chat/useChatVirtualizer.ts) and `./SpanLines.css.ts` sizes the
+ * segment from it, so ONE function decides both a row's offset and the height of
+ * the rail that spans the space above it. The bridge used to restate that gap as
+ * its own token, which held only while every gap was the same: two adjacent
+ * BANDS overlap by a border width instead, and a segment sized from a token was
+ * built for a gap that does not exist. Reading the decider makes it collapse.
  */
-export const ROW_GAP = 'var(--space-2)'
+export const SPAN_BRIDGE_GAP_VAR = '--span-bridge-gap'
 
 /** Diameter of the bridge arc. */
 export const BRIDGE_DIAMETER = 10
@@ -52,6 +60,38 @@ export function spanLinesReservedWidth(lineCount: number): number {
   if (lineCount <= 0)
     return NO_SPAN_MARGIN
   return lineCount * COL_SPACING + CONTAINER_PAD_RIGHT
+}
+
+/**
+ * Custom property holding the distance from a row-content element's own left
+ * edge to the PANEL's left edge: the chat list's gutter plus whatever the span
+ * rails reserve to its left.
+ *
+ * A bleeding descendant (a turn-end rule, a band) cannot use the gutter alone,
+ * because the rails push it right by a width only the row knows. Every element
+ * that starts a row's content column publishes this, so one negative margin
+ * reaches the panel edge whether the row has rails or not.
+ */
+export const ROW_BLEED_LEFT_VAR = '--row-bleed-left'
+
+/** The `ROW_BLEED_LEFT_VAR` declaration for a row with `lineCount` rails. */
+export function rowBleedLeftStyle(lineCount: number): Record<string, string> {
+  return { [ROW_BLEED_LEFT_VAR]: `calc(var(${CHAT_PAD_LEFT_VAR}, 0px) + ${spanLinesReservedWidth(lineCount)}px)` }
+}
+
+/**
+ * Content-column style for a row that RESERVES the rails' width instead of
+ * rendering the rails: the hidden premeasure row, and the live row that has no
+ * rails at all. Emits the left margin and ROW_BLEED_LEFT_VAR together, from one
+ * `lineCount`, so the two cannot fall out of step -- a column whose margin and
+ * whose published distance disagree wraps its text at a width the other row never
+ * reproduces, and the wrong height reaches the offset map.
+ *
+ * A row that RENDERS its rails needs no margin: the `SpanLines` element occupies
+ * that width as a flex sibling. It publishes the var alone.
+ */
+export function reservedRowContentColumnStyle(lineCount: number): Record<string, string> {
+  return { 'margin-left': `${spanLinesReservedWidth(lineCount)}px`, ...rowBleedLeftStyle(lineCount) }
 }
 
 /**

--- a/frontend/src/components/chat/widgets/SpanLines.test.tsx
+++ b/frontend/src/components/chat/widgets/SpanLines.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@solidjs/testing-library'
 import { describe, expect, it } from 'vitest'
 import { SpanLineGapBridges } from '~/components/chat/widgets/SpanLineGapBridges'
 import { bodySpanKey, shouldConnectSpanLineTop, SpanLines } from '~/components/chat/widgets/SpanLines'
-import { LINE_THICKNESS, spanColumnCenterX } from '~/components/chat/widgets/SpanLines.geometry'
+import { COL_SPACING, LINE_THICKNESS, NO_SPAN_MARGIN, ROW_BLEED_LEFT_VAR, rowBleedLeftStyle, spanColumnCenterX, spanLinesReservedWidth } from '~/components/chat/widgets/SpanLines.geometry'
 
 describe('spanLines', () => {
   it('renders nothing when lines array is empty', () => {
@@ -82,6 +82,7 @@ describe('spanLines', () => {
         precedingEntry={undefined}
         topOf={id => (id === 'm2' ? 240 : 120)}
         hiddenOf={() => false}
+        gapAboveOf={() => 8}
       />
     ))
 
@@ -107,6 +108,7 @@ describe('spanLines', () => {
         precedingEntry={{ msg: { id: 'm5' }, category: { kind: 'assistant_text' }, parsedSpanLines: [lineA, lineB] }}
         topOf={() => 300}
         hiddenOf={() => false}
+        gapAboveOf={() => 8}
       />
     ))
     const anchor = container.querySelector('[data-span-gap-bridges-for="m6"]') as HTMLElement
@@ -127,6 +129,7 @@ describe('spanLines', () => {
         precedingEntry={{ msg: { id: 'm2' }, category: { kind: 'assistant_text' }, parsedSpanLines: [line] }}
         topOf={() => 100}
         hiddenOf={() => true}
+        gapAboveOf={() => 8}
       />
     ))
     const anchor = container.querySelector('[data-span-gap-bridges-for="m3"]') as HTMLElement
@@ -154,6 +157,7 @@ describe('spanLines', () => {
         }}
         topOf={() => 60}
         hiddenOf={() => false}
+        gapAboveOf={() => 8}
       />
     ))
     const anchor = container.querySelector('[data-span-gap-bridges-for="m4"]') as HTMLElement
@@ -187,5 +191,30 @@ describe('spanLines', () => {
       { span_id: 'span-parent', color: 1, type: 'active' },
       previousToolBodyKey,
     )).toBe(false)
+  })
+})
+
+describe('rowBleedLeftStyle', () => {
+  it('folds the rails width into the distance to the panel edge', () => {
+    // A bleeding child cannot assume the bare gutter: the rails push the row's
+    // content column right, and only the row knows by how much. Getting this
+    // wrong is exactly what stopped a bleed short of the edge on a span row.
+    for (const lineCount of [0, 1, 2, 5]) {
+      expect(rowBleedLeftStyle(lineCount)).toEqual({
+        [ROW_BLEED_LEFT_VAR]: `calc(var(--chat-pad-left, 0px) + ${spanLinesReservedWidth(lineCount)}px)`,
+      })
+    }
+  })
+
+  it('grows with each rail, by exactly one column spacing', () => {
+    const at = (n: number) => Number.parseInt(rowBleedLeftStyle(n)[ROW_BLEED_LEFT_VAR].match(/\+ (\d+)px/)![1], 10)
+    expect(at(1) - at(0)).toBe(COL_SPACING)
+    expect(at(3) - at(2)).toBe(COL_SPACING)
+  })
+
+  it('reserves the no-rail inset for a row with no span lines', () => {
+    // The railless wrapper carries margin-left: NO_SPAN_MARGIN, so the distance
+    // to the edge must include that same pixel.
+    expect(rowBleedLeftStyle(0)[ROW_BLEED_LEFT_VAR]).toContain(`+ ${NO_SPAN_MARGIN}px`)
   })
 })

--- a/frontend/tests/e2e/040-chat-message-rendering.spec.ts
+++ b/frontend/tests/e2e/040-chat-message-rendering.spec.ts
@@ -1,5 +1,17 @@
+import type { Page } from '@playwright/test'
 import { expect, test } from './fixtures'
-import { assistantBubbles, firstAssistantBubble, messageContents, userBubbles, waitForAgentIdle } from './helpers/ui'
+import { ARITHMETIC_PROMPT, assistantBubbles, bandRows, CHAT_SCROLL_CONTAINER, chatScrollContainer, firstAssistantBubble, measureAgainstChatList, messageContents, sendMessage, userBubbles, waitForAgentIdle } from './helpers/ui'
+
+/**
+ * Send one prompt and wait for the turn to settle. Every test below opens the
+ * same way, and `sendMessage` also waits for the editor to empty, which is the
+ * app's own acknowledgement that the send committed.
+ */
+async function sendAndSettle(page: Page, prompt = ARITHMETIC_PROMPT) {
+  await sendMessage(page, prompt)
+  await expect(firstAssistantBubble(page)).toBeVisible()
+  await waitForAgentIdle(page)
+}
 
 /**
  * Smoke test for end-to-end chat rendering: user input → real LLM response →
@@ -13,14 +25,7 @@ import { assistantBubbles, firstAssistantBubble, messageContents, userBubbles, w
 
 test.describe('Chat Message Rendering', () => {
   test('user message renders as human text and assistant reply renders as markdown', async ({ page, authenticatedWorkspace }) => {
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
-    await expect(editor).toBeVisible()
-    await editor.click()
-    await page.keyboard.type('What is 1234 + 5678? Reply with just the number.')
-    await page.keyboard.press('Meta+Enter')
-
-    await expect(firstAssistantBubble(page)).toBeVisible()
-    await waitForAgentIdle(page)
+    await sendAndSettle(page)
 
     // User bubble: shows the human text, NOT the raw JSON envelope.
     const userBubble = userBubbles(page).first()
@@ -36,5 +41,129 @@ test.describe('Chat Message Rendering', () => {
     const assistantContent = assistantBubble.locator('[data-testid="message-content"]')
     const paragraphs = await assistantContent.locator('p').count()
     expect(paragraphs).toBeGreaterThan(0)
+  })
+
+  /**
+   * The band reaches both panel edges. Only a real browser can verify it: the
+   * strip's width comes from CSS var arithmetic that cancels the scroll
+   * container's gutter, and it works around paint containment, neither of which
+   * jsdom computes.
+   *
+   * The seam check that follows is an OPPORTUNISTIC invariant, not the point of
+   * this test: a live turn need not produce two ADJACENT band rows, so on a turn
+   * that yields one band, or that puts a tool row between two bands, the loop
+   * asserts nothing. The overlap arithmetic itself is covered exhaustively, and
+   * deterministically, in `src/components/chat/useChatVirtualizer.geometry.test.ts`.
+   */
+  test('an assistant row paints a band that reaches both panel edges', async ({ page, authenticatedWorkspace }) => {
+    await sendAndSettle(page)
+
+    await expect(bandRows(page, 'text').first()).toBeVisible()
+
+    // EVERY visible band, not just the first, and each one reported with the rail count
+    // it was carrying. A row's rails push its content column right by a width only the
+    // row knows, so a bleed sized to the bare gutter stops short on a railed row and
+    // reaches the edge on a bare one -- the very case ROW_BLEED_LEFT_VAR exists for.
+    // Checking one band would pass on a transcript whose only band has no rails.
+    const bands = await bandRows(page).evaluateAll((els, selector) => els.map((el) => {
+      const list = el.closest(selector)!
+      return {
+        rails: el.querySelector('[data-span-columns]')?.getAttribute('data-span-columns') ?? '0',
+        width: el.getBoundingClientRect().width,
+        listWidth: list.clientWidth,
+      }
+    }), CHAT_SCROLL_CONTAINER)
+
+    expect(bands.length).toBeGreaterThan(0)
+    for (const band of bands) {
+      expect(band.listWidth).toBeGreaterThan(0)
+      expect({ rails: band.rails, offBy: Math.round(Math.abs(band.width - band.listWidth)) })
+        .toEqual({ rails: band.rails, offBy: 0 })
+    }
+
+    // No two ADJACENT bands may show a gap between them: the lower row overlaps the
+    // upper one by the band border width so the pair reads as one line. Walk the rows in
+    // DOM order and compare only true neighbours -- comparing every pair of BANDS instead
+    // would fail whenever a tool row sits between two of them, on a layout the code got
+    // right. The in-flow streaming tail is a neighbour like any other, which is what
+    // covers its own merge (bandTailMerged) here.
+    //
+    // `data-seq` marks every virtual row; the tail has no seq but does carry `data-band`.
+    // Scoped to the scroll container, which excludes the hidden premeasure copies (they
+    // mount outside it) and the rail's dots (which reuse data-seq).
+    const seams = await chatScrollContainer(page).locator('[data-seq], [data-band]').evaluateAll(els =>
+      els
+        .map((el) => {
+          const r = el.getBoundingClientRect()
+          return {
+            band: el.getAttribute('data-band'),
+            painting: globalThis.getComputedStyle(el).visibility !== 'hidden',
+            top: r.top,
+            bottom: r.bottom,
+          }
+        })
+        .flatMap((row, i, all) => {
+          const above = all[i - 1]
+          if (!above || !above.band || !row.band || !above.painting || !row.painting)
+            return []
+          return [row.top - above.bottom]
+        }),
+    )
+    for (const seam of seams) {
+      expect(seam).toBeLessThanOrEqual(0)
+      expect(seam).toBeGreaterThanOrEqual(-2)
+    }
+  })
+
+  /**
+   * The turn-end rule bleeds by a DESCENDANT's negative margin, not by the row's
+   * own background, so it exercises the other half of the paint-containment
+   * story: the row's padding box must be wide enough for the rule to reach it.
+   * jsdom computes neither, which is why this lives here.
+   */
+  test('the turn-end divider runs its rule to both panel edges', async ({ page, authenticatedWorkspace }) => {
+    await sendAndSettle(page)
+
+    const divider = page.locator('[data-testid="result-divider"]:visible').first()
+    await expect(divider).toBeVisible()
+
+    const { width, listWidth } = await measureAgainstChatList(divider)
+    expect(listWidth).toBeGreaterThan(0)
+    expect(Math.abs(width - listWidth)).toBeLessThanOrEqual(1)
+  })
+
+  /**
+   * A user bubble bleeds on ONE side only, which is the interesting case: the
+   * right edge meets the panel, while the left keeps the bubble's rounded,
+   * content-hugging shape well inside the gutter.
+   */
+  test('a user bubble meets the right panel edge and keeps its left side inset', async ({ page, authenticatedWorkspace }) => {
+    await sendMessage(page, 'hi')
+
+    const bubble = userBubbles(page).first()
+    await expect(bubble).toBeVisible()
+
+    const box = await bubble.evaluate((el, selector) => {
+      const list = el.closest(selector)!
+      const listRect = list.getBoundingClientRect()
+      const self = el.getBoundingClientRect()
+      // The PADDING box on both sides. `clientLeft` is the left border, and `clientWidth`
+      // stops before a native scrollbar -- so the right edge tracks the same box the sibling
+      // tests measure through measureAgainstChatList, whichever scrollbar the list is wearing.
+      const padLeft = listRect.left + list.clientLeft
+      return {
+        rightGap: padLeft + list.clientWidth - self.right,
+        leftGap: self.left - padLeft,
+        radius: globalThis.getComputedStyle(el).borderTopRightRadius,
+      }
+    }, CHAT_SCROLL_CONTAINER)
+
+    // Flush right: the bubble's right edge sits on the list's padding-box edge.
+    expect(Math.abs(box.rightGap)).toBeLessThanOrEqual(1)
+    // Still a bubble on the left: inset by at least the gutter, and short of the
+    // full width -- 'hi' must not stretch the bubble across the panel.
+    expect(box.leftGap).toBeGreaterThan(20)
+    // A rounded corner flush against the edge would read as a mistake.
+    expect(box.radius).toBe('0px')
   })
 })

--- a/frontend/tests/e2e/047b-chat-scroll-rail-autohide.spec.ts
+++ b/frontend/tests/e2e/047b-chat-scroll-rail-autohide.spec.ts
@@ -24,6 +24,15 @@ import { sendMessage, userBubbles, waitForAgentIdle } from './helpers/ui'
  */
 const LONG_MESSAGE = `Please just reply with "ok". Ignore this filler: ${'the quick brown fox jumps over the lazy dog. '.repeat(12)}`
 
+/**
+ * A wait that comfortably outlasts the rail's idle window (RAIL_VISIBLE_IDLE_MS in
+ * ~/components/chat/ChatView, 1200ms). Not imported: pulling a component into the e2e type
+ * program drags `import.meta.env` with it, which that tsconfig does not model. Only a LOWER
+ * bound is needed here, so a generous local value cannot make the test wrong -- if the window
+ * ever grew past this, the test would stop proving anything rather than start failing.
+ */
+const PAST_RAIL_IDLE_MS = 4000
+
 const RAIL = '[data-testid="chat-scroll-rail"]'
 const SCROLLER = '[data-chat-scroll-container="true"]'
 
@@ -63,6 +72,30 @@ test.describe('chat scroll rail auto-hide', () => {
     await expect(rail).toHaveCSS('opacity', '1')
 
     // ...and it fades again once that gesture goes quiet.
+    await expect(rail).toHaveCSS('opacity', '0')
+  })
+
+  test('keeps the rail lit while the cursor rests on it, and fades once it leaves', async ({ page, authenticatedWorkspace }) => {
+    // A parked cursor sends no pointermove, so nothing re-arms the host's activity window and
+    // the rail used to fade out from under the reader sitting on it. Only a real browser
+    // covers this: it needs the live idle timer, a real hover, and the CSS opacity it drives.
+    await page.setViewportSize({ width: 1024, height: 600 })
+    await seedOverflowingConversation(page)
+
+    const rail = page.locator(RAIL)
+    await expect(rail).toHaveCSS('opacity', '0')
+
+    // Move onto the strip and STOP. Nothing further is dispatched from here on.
+    const railBox = await rail.boundingBox()
+    await page.mouse.move(railBox!.x + railBox!.width / 2, railBox!.y + railBox!.height / 2, { steps: 5 })
+    await expect(rail).toHaveCSS('opacity', '1')
+
+    // Well past the idle window the cursor has not moved, and the rail is still there.
+    await page.waitForTimeout(PAST_RAIL_IDLE_MS)
+    await expect(rail).toHaveCSS('opacity', '1')
+
+    // Leaving hands it back to the window, which fades it.
+    await page.mouse.move(railBox!.x - 200, railBox!.y + railBox!.height / 2, { steps: 5 })
     await expect(rail).toHaveCSS('opacity', '0')
   })
 
@@ -127,6 +160,75 @@ test.describe('chat scroll rail auto-hide', () => {
     await expect(scroller).toHaveCSS('padding-right', '4px')
   })
 
+  test('fills the gutter exactly, centring its visuals and clearing the message column', async ({ page, authenticatedWorkspace }) => {
+    // The rail owns the gutter and nothing else. That places its visuals down the
+    // gutter's middle AND keeps the column off the message content -- the rail
+    // overlays a row from outside its stacking context and is hit-testable while
+    // faded, so anything it covers it takes from the text and the row action
+    // buttons underneath. Only a real browser resolves the width against the
+    // tokens; the rail needs content to overflow before it renders at all.
+    await page.setViewportSize({ width: 1024, height: 600 })
+    await seedOverflowingConversation(page)
+
+    const thumb = page.locator('[data-testid="chat-scroll-rail-thumb"]')
+    await expect(thumb).toBeVisible()
+
+    const thumbBox = await thumb.boundingBox()
+    const railBox = await page.locator(RAIL).boundingBox()
+    const gutter = await page.locator(SCROLLER).evaluate((el) => {
+      const rect = el.getBoundingClientRect()
+      const paddingRight = Number.parseFloat(globalThis.getComputedStyle(el).paddingRight)
+      // Where the message column stops, and how wide the strip beyond it is.
+      return { contentRight: rect.right - paddingRight, width: paddingRight, right: rect.right }
+    })
+
+    // The column is the gutter: it starts where the content stops and runs to the edge.
+    expect(gutter.width).toBeGreaterThan(0)
+    expect(Math.abs(railBox!.x - gutter.contentRight)).toBeLessThanOrEqual(1)
+    expect(Math.abs(railBox!.width - gutter.width)).toBeLessThanOrEqual(1)
+    expect(Math.abs((railBox!.x + railBox!.width) - gutter.right)).toBeLessThanOrEqual(1)
+
+    // And the thumb runs down its middle.
+    expect(Math.abs((thumbBox!.x + thumbBox!.width / 2) - (railBox!.x + railBox!.width / 2)))
+      .toBeLessThanOrEqual(1)
+
+    // The rail paints the PANEL colour at partial alpha, so the strip reads as a
+    // channel cut out of the content -- lighter in the light theme, darker in the
+    // dark one -- rather than an opaque bar.
+    const surface = await page.locator(RAIL).evaluate(el => globalThis.getComputedStyle(el).backgroundColor)
+    // A color-mix result serializes as `color(srgb r g b / a)`; a plain colour as
+    // `rgba(r, g, b, a)` or an opaque `rgb(r, g, b)`. Only the first two carry an
+    // alpha, and an opaque value means the translucency was dropped -- which is
+    // the regression this guards.
+    const alpha = surface.match(/\/\s*([\d.]+)\s*\)$/)?.[1]
+      ?? surface.match(/^rgba\((?:\s*[\d.]+\s*,){3}\s*([\d.]+)\s*\)$/)?.[1]
+    expect(alpha, `rail background was ${surface}`).toBeDefined()
+    expect(Number.parseFloat(alpha!)).toBeGreaterThan(0)
+    expect(Number.parseFloat(alpha!)).toBeLessThan(1)
+
+    // The hover target is worth having: the whole gutter, not the thin strip the
+    // thumb draws. This is what made the rail hard to hover before.
+    expect(railBox!.width).toBeGreaterThan(thumbBox!.width * 1.5)
+
+    // A row's FLOATING actions sit clear of that column. Here the column IS the gutter,
+    // so there is nothing to clear and they sit flush at the content edge.
+    //
+    // Scoped to a band row inside the scroller: only a row that gives its whole width to
+    // the content floats its actions absolutely, so a user row's toolbar -- which is
+    // in-flow in a mirrored grid -- reads `right: auto` and would prove nothing.
+    const toolbarRight = () => page.locator(`${SCROLLER} [data-band] [data-testid="message-toolbar"]`).first().evaluate(el => globalThis.getComputedStyle(el).right)
+    expect(await toolbarRight()).toBe('0px')
+
+    // Below the phone breakpoint the gutter shrinks to 4px but the column keeps its
+    // floor, so it overhangs the message text by 12px. The rail wins every pointer event
+    // in its own box, so anything left under that overhang is unreachable -- the actions
+    // move in by exactly the overhang. Asserted from the same page: the rail itself
+    // unmounts at this width (resolveScrollbarOwner stops naming it the owner), but the
+    // inset reads the tokens on the chat root, which do not depend on the rail rendering.
+    await page.setViewportSize({ width: 600, height: 600 })
+    await expect.poll(toolbarRight).toBe('12px')
+  })
+
   test('stays hit-testable on a fine pointer but rejects a click on the faded rail', async ({ page, authenticatedWorkspace }) => {
     // The faded rail stays hit-testable on a fine pointer (pointer-events: auto) so a
     // pointermove onto it can relight it -- but a CLICK on the faded rail is rejected at the
@@ -172,14 +274,22 @@ test.describe('chat scroll rail auto-hide', () => {
     test.use(COARSE_POINTER_METRICS)
 
     test('makes the idle rail inert, so its strip cannot swallow a tap', async ({ page, authenticatedWorkspace }) => {
-      // With the phone gutters the 22px coarse strip overlaps ~20px of message content. An
+      // A finger needs a whole target, so on a coarse pointer the rail's column floors at
+      // 24px -- against a 4px phone gutter, that overlaps 20px of message content. An
       // INVISIBLE strip that still took pointer events would turn a tap on the text into a
       // track-click jump, so going inert while idle is what makes that overlap acceptable.
+      // The row's own floating actions are inset by the same overhang, so they stay clear
+      // of it whether the rail is inert or not.
       await seedOverflowingConversation(page)
 
       const rail = page.locator(RAIL)
       await expect(rail).toHaveCSS('opacity', '0')
       await expect(rail).toHaveCSS('pointer-events', 'none')
+
+      // And the column is a whole finger wide, not the 4px gutter under it. A track
+      // click and a thumb drag can land nowhere else, so the gutter alone would leave
+      // them unhittable -- this is the one place the coarse floor is observable.
+      await expect(rail).toHaveCSS('width', '24px')
     })
   })
 })

--- a/frontend/tests/e2e/helpers/ui.ts
+++ b/frontend/tests/e2e/helpers/ui.ts
@@ -193,6 +193,47 @@ export function messageContents(page: Page) {
 }
 
 /**
+ * Return a locator for the visible band ROWS -- the full-bleed strips an
+ * assistant message (`data-band="text"`) and a thought (`data-band="thought"`)
+ * paint behind themselves. Pass a kind to restrict to one of the two.
+ *
+ * The strip is the row's own background and border, so it is the ROW that
+ * carries the marker, not the bubble inside it. Every style class is a hashed
+ * vanilla-extract name, which is why the attribute exists at all.
+ */
+export function bandRows(page: Page, kind?: 'text' | 'thought') {
+  const selector = kind === undefined ? '[data-band]' : `[data-band="${kind}"]`
+  return page.locator(selector + VISIBLE)
+}
+
+/** The chat's scrolling element, which the app publishes for exactly this purpose. */
+export const CHAT_SCROLL_CONTAINER = '[data-chat-scroll-container="true"]'
+
+/** Return a locator for the chat's scrolling element. */
+export function chatScrollContainer(page: Page) {
+  return page.locator(CHAT_SCROLL_CONTAINER)
+}
+
+/**
+ * Measure a full-bleed chat element against the width it must span: the chat
+ * scroll container's `clientWidth`, which IS its padding box (the scrollbar
+ * excluded), and which is exactly what a band or a turn-end rule reaches.
+ *
+ * The container is resolved from the element itself rather than from a
+ * hard-coded position in the DOM, and by the attribute the app publishes rather
+ * than by a computed-style walk that has to guess which ancestor scrolls. Both
+ * numbers are read in one browser round trip, so they cannot straddle a resize.
+ */
+export async function measureAgainstChatList(locator: Locator): Promise<{ width: number, listWidth: number }> {
+  return locator.evaluate((el, selector) => {
+    const list = el.closest(selector)
+    if (!list)
+      throw new Error('measureAgainstChatList: element is not inside the chat scroll container')
+    return { width: el.getBoundingClientRect().width, listWidth: list.clientWidth }
+  }, CHAT_SCROLL_CONTAINER)
+}
+
+/**
  * Restrict `locator` to the elements the user can see.
  *
  * For page-rooted chat assertions that match by text rather than test id --


### PR DESCRIPTION
## Motivation

An assistant message and an assistant thought rendered as a bubble: a card box with a border, a radius, an 85% width cap, and a gutter to each panel edge. The transcript's right side therefore read as three different edges — the bubble's, the tool cards', and the scroll rail's.

The chat gutter also lived in more than one place: padding on the list, a fixed pixel constant in the rail, and a second copy in the hidden premeasure root. That duplication carried a real defect. Below the phone breakpoint the premeasure root kept the desktop values, so a bleeding row measured a gutter wider than it renders, wrapped its text at the wrong width, and committed a short height into the offset map.

The scroll rail had two problems of its own. Its column overlapped the message content, so it took pointer events meant for a row's action buttons. And it faded out from under a cursor that rested on it, because a parked cursor sends no further pointermove to re-arm the rail's activity window.

## Modifications

- Render an assistant message and an assistant thought as a full-bleed **band** (`bandRow` / `bandMessage`): a gray surface that runs edge to edge, with a line on its top and bottom edge and the row's actions at its right end, inside the gray. A message draws a solid line; a thought draws a dashed one. Remove `assistantMessage` and `thinkingMessage`; `agentFallbackMessage` keeps a bubble for an unclassified agent shape.
- Paint the band on the ROW rather than on the bubble. Paint containment clips a descendant to the row's padding box but not the row's own background, and hidden premeasure renders each row alone, so a row's height must never depend on its neighbour. The shared line between two adjacent bands therefore comes from the offset map: `gapAfter` overlaps the pair by one border width.
- Compute a row's chrome once, in `messageRowChrome`, and apply it at all four row-mount sites — the virtual row, the streaming tail, the hidden premeasure row, and the skeleton that stands in for a row awaiting its height. The tail also cancels its own flow gap when the row above it paints a band, because it has no entry in the offset map.
- Run a user message's bubble to the right panel edge. The bleed is declared only inside `bleedRow`, through a `bubbleFlushRight` marker, so a bubble in a row that was never widened produces no bleed rather than one that paint containment silently clips. A message that failed to deliver opts out and keeps a closed bubble, because its Retry and Delete controls sit under it at the content edge.
- Publish the list gutter and the rail width as custom properties on the chat ROOT, and add `chatChromeVars.ts` — an import-free leaf that holds their names. The rail is the list's sibling, so a definition on the list was out of its reach; and each reader carries a `0px` fallback, so a typo in one spelling would collapse a bleed to zero with no build error. The premeasure root now inherits the pair instead of restating it.
- Give the scroll rail the gutter and only the gutter, floored where the gutter alone is too thin to press. Both floors make the column overhang the message text, so a row's floating actions are inset by exactly that overhang, computed from the same two properties. Hold the rail lit while a mouse rests on it, and clear that hold in the hide teardown, because a DOM removal delivers no pointerleave.
- Give every left-to-right toolbar one button order: timestamp, the copies, then Quote. A tool header and a message row disagreed here, which moved the same two buttons depending on the row above. A mirrored row moves Quote alone, from last to second, so it still lands nearest the bubble.
- Size the span-line gap bridge from the offset map's own `gapAboveOf` rather than a duplicate token, so one function decides both a row's offset and the rail that spans the space above it.
- Bump the persisted row-height version. A height key encodes content, width and UI state, never the stylesheet, so without the bump the first load hydrates pre-change heights whose digests still match. A payload from an older version is now deleted rather than left in place, because the read that discards it also refreshes its expiry.

**Breaking change (internal):** `ToolHeaderActionsLayoutProps.inline` is replaced by `mirrored`, and `SpanLineGapBridgesProps.gapAboveOf` is a new required prop. `ROW_GAP`, `assistantMessage` and `thinkingMessage` are removed, and `ChatView.css.ts`'s `messageRow` / `messageRowContent` are renamed `railedRow` / `railedRowContent` to end a name collision with a different `messageRow` in `messageStyles.css.ts`. Every call site is updated; nothing outside the chat components consumes these.

## Result

The right edge of the transcript reads as one line rather than three. An assistant message and a thought run edge to edge, two adjacent ones share a single border, and the turn-end divider and a user bubble reach the same edge. The band is present while a row's skeleton shows and while a reply streams, so it no longer appears at the moment the message lands.

The scroll rail fills the gutter exactly and no longer covers a row's action buttons at any width. It stays lit while your cursor rests on it, and fades once you move away.

On a narrow viewport the hidden measurement now matches the live list, so a row no longer commits a short height and shifts the transcript under your scroll position after it settles.
