### PR TITLE
docs(claude): Correct what a local_bash task event means

### DIFF
--- a/backend/internal/worker/agent/claude_subagent.go
+++ b/backend/internal/worker/agent/claude_subagent.go
@@ -35,10 +35,15 @@ func claudeToolSpawnsSubagent(toolName string) bool {
 }
 
 // The task_type values a Claude task_started event carries. local_bash is a
-// backgrounded shell; local_agent is a Task subagent; local_workflow is a
-// Workflow run. Only local_bash is NOT a spawn, so the code tests for that one
-// and treats every other value -- including one this list does not name -- as a
-// spawn that owns no span and gets a child transcript.
+// shell, which is NOT the same as a BACKGROUNDED shell; local_agent is a Task
+// subagent; local_workflow is a Workflow run. Only local_bash is NOT a spawn, so
+// the code tests for that one and treats every other value -- including one this
+// list does not name -- as a spawn that owns no span and gets a child
+// transcript.
+//
+// A foreground shell reports local_bash too, once the command runs for 2
+// seconds. claudeHandleTaskEvent gives the mechanism and says why the registry
+// keeps the row anyway.
 const (
 	claudeTaskTypeBash     = "local_bash"
 	claudeTaskTypeWorkflow = "local_workflow"
@@ -77,15 +82,16 @@ type claudeTaskUsage struct {
 //
 // Findings (Claude 2.1.220, --forward-subagent-text):
 //   - task_started {task_id, tool_use_id, task_type, description, workflow_name?}
-//     fires for Task subagents (local_agent), bg shells (local_bash), and
-//     Workflow runs (local_workflow).
+//     fires for Task subagents (local_agent), shells (local_bash, foreground
+//     ones included), and Workflow runs (local_workflow).
 //   - task_progress {task_id, description, last_tool_name?, usage?, workflow_progress?}
 //   - task_notification {task_id, tool_use_id, status, summary, output_file, usage?}
 //     is final and fires for foreground Tasks too.
-//   - task_updated {task_id, patch:{status,end_time}} is redundant with the
-//     notification; consumed as a no-op refresh.
-//   - background_tasks_changed is Claude's own bg-shell list push; redundant
-//     with task_* events here, so consumed silently.
+//   - task_updated {task_id, patch:{status,end_time,is_backgrounded?}} repeats
+//     the notification's status; consumed as a no-op refresh.
+//   - background_tasks_changed is Claude's own live background-task list. It is
+//     the one event that separates a backgrounded shell from a foreground one,
+//     and it is consumed silently all the same -- see the case below.
 //   - Workflow agents do NOT forward their transcripts (0 parent_tool_use_id
 //     rows); they are registry-only, grouped by workflow_name.
 func (a *ClaudeCodeAgent) claudeHandleTaskEvent(content []byte) bool {
@@ -104,8 +110,27 @@ func (a *ClaudeCodeAgent) claudeHandleTaskEvent(content []byte) bool {
 		a.handleClaudeTaskNotification(&ev)
 		return true
 	case "task_updated", "background_tasks_changed":
-		// Consumed: redundant with the task_* events above. Our registry is
-		// authoritative, so these carry no extra information.
+		// Consumed as a no-op: the task_* bookends above drive the registry, and
+		// neither event changes a row.
+		//
+		// background_tasks_changed is not redundant, and the difference decides
+		// which shells the sidebar lists. The CLI registers a FOREGROUND shell as
+		// a local_bash task once the command runs for 2 seconds, so the user can
+		// background it with ctrl-b, and that registration emits task_started
+		// (2.1.220: the Bash progress loop calls the registrar at 2000 ms with
+		// isBackgrounded false). A shell row therefore appears for any command
+		// slower than 2 seconds, although nothing backgrounded it. These two
+		// events carry the only signal that separates the two cases:
+		// background_tasks_changed lists the live tasks whose isBackgrounded is
+		// true, and task_updated reports the foreground -> background flip in
+		// patch.is_backgrounded.
+		//
+		// The registry lists every local_bash task on purpose. The CLI's own task
+		// dialog hides a foreground one, so this is a divergence from the CLI, not
+		// parity with it. Filtering on background_tasks_changed would trade the
+		// divergence for a worse failure: the CLI's task-event queue holds 1000
+		// events and drops a NON-bookend event first when it fills, so one lost
+		// level event would hide a real background shell for its whole run.
 		return true
 	case "session_state_changed":
 		// Consumed silently: carries session bookkeeping we don't surface.
@@ -196,10 +221,11 @@ func (a *ClaudeCodeAgent) handleClaudeTaskStarted(ev *claudeTaskEnvelope) {
 	}
 
 	// task_started is the authority on which Claude tool calls own a span. A
-	// backgrounded shell is a plain Bash span whose tool_result returns at once,
-	// so it keeps its rail; every other task type starts a subagent and owns no
-	// span. The same startedKind that classifies the registry row above decides
-	// it here, so a task type nobody matched by name is still handled.
+	// shell is a plain Bash span whose own tool_result closes it -- at once for a
+	// backgrounded one, at the end of the command for a foreground one -- so it
+	// keeps its rail; every other task type starts a subagent and owns no span.
+	// The same startedKind that classifies the registry row above decides it
+	// here, so a task type nobody matched by name is still handled.
 	//
 	// A spawn that claudeToolSpawnsSubagent already matched never opened a span,
 	// so this is a no-op for it. A Workflow run is why the call exists: the CLI

--- a/backend/internal/worker/agent/claude_subagent_test.go
+++ b/backend/internal/worker/agent/claude_subagent_test.go
@@ -222,6 +222,117 @@ func TestClaude_TaskNotificationWithOutputFileKeepsTheShellKind(t *testing.T) {
 	assert.Equal(t, bgtask.KindShell, tasks[0].Kind)
 }
 
+// background_tasks_changed is a LEVEL signal with replace semantics: it lists
+// the tasks the CLI counts as live BACKGROUND work, and it drops a task whose
+// isBackgrounded is false. A foreground shell -- which the CLI registers as a
+// local_bash task once its command runs for 2 seconds -- is therefore absent
+// from every payload, although its task_started already opened a row here.
+//
+// The registry keeps that row on purpose, so this event must stay a no-op.
+// Applying the payload's replace semantics to the registry would delete a row
+// the sidebar is showing, and a payload that a full event queue dropped (the
+// CLI evicts a non-bookend event first) would delete a genuine background
+// shell's row mid-run.
+func TestClaude_BackgroundTasksChangedLeavesTheRegistryAlone(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	a.HandleOutput([]byte(`{
+		"type": "system",
+		"subtype": "task_started",
+		"task_id": "task-sh",
+		"tool_use_id": "tu-shell",
+		"task_type": "local_bash",
+		"description": "task test-e2e"
+	}`))
+	require.Len(t, sink.BackgroundTasks(), 1)
+
+	// The empty list is the payload a FOREGROUND shell produces: nothing is
+	// backgrounded, so the CLI reports no live background task.
+	a.HandleOutput([]byte(`{
+		"type": "system",
+		"subtype": "background_tasks_changed",
+		"tasks": []
+	}`))
+
+	tasks := sink.BackgroundTasks()
+	require.Len(t, tasks, 1, "the level signal must not evict the row")
+	assert.Equal(t, "task-sh", tasks[0].RowKey)
+	assert.Equal(t, bgtask.StatusRunning, tasks[0].Status)
+	assert.Equal(t, "task test-e2e", tasks[0].Title)
+	assertTaskEventConsumed(t, sink)
+}
+
+// task_updated repeats what the closing task_notification carries, plus the
+// foreground -> background flip in patch.is_backgrounded. It is a no-op refresh:
+// the notification is the authority on a final status, so a patch must not close
+// a row on its own, and the flip changes nothing because the row already exists.
+func TestClaude_TaskUpdatedDoesNotChangeTheRow(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	a.HandleOutput([]byte(`{
+		"type": "system",
+		"subtype": "task_started",
+		"task_id": "task-sh",
+		"tool_use_id": "tu-shell",
+		"task_type": "local_bash",
+		"description": "sleep 30"
+	}`))
+	require.Len(t, sink.BackgroundTasks(), 1)
+
+	a.HandleOutput([]byte(`{
+		"type": "system",
+		"subtype": "task_updated",
+		"task_id": "task-sh",
+		"patch": {"status": "completed", "end_time": 1760000000000, "is_backgrounded": true}
+	}`))
+
+	tasks := sink.BackgroundTasks()
+	require.Len(t, tasks, 1)
+	assert.Equal(t, bgtask.StatusRunning, tasks[0].Status,
+		"only task_notification ends a row")
+	assert.True(t, tasks[0].EndedAt.IsZero(), "the row is still active")
+	assertTaskEventConsumed(t, sink)
+}
+
+// A task event for a row that no task_started opened creates nothing. The
+// registry is opened by the bookends alone, so a task_updated or a
+// background_tasks_changed that names an unknown task cannot invent a row.
+func TestClaude_TaskUpdatedForAnUnknownTaskCreatesNoRow(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	a.HandleOutput([]byte(`{
+		"type": "system",
+		"subtype": "task_updated",
+		"task_id": "task-never-started",
+		"patch": {"is_backgrounded": true}
+	}`))
+	a.HandleOutput([]byte(`{
+		"type": "system",
+		"subtype": "background_tasks_changed",
+		"tasks": [{"task_id": "task-never-started", "task_type": "local_bash", "description": "sleep 30"}]
+	}`))
+
+	assert.Empty(t, sink.BackgroundTasks())
+	assertTaskEventConsumed(t, sink)
+}
+
+// assertTaskEventConsumed checks that a task event reached NO persist path. A
+// `system` line that claudeHandleTaskEvent declines falls through to one of two
+// sinks -- PersistNotification when the classifier calls it consolidatable, and
+// PersistMessage otherwise -- so an assertion on either one alone would pass
+// vacuously when a regression routed the line to the other.
+func assertTaskEventConsumed(t *testing.T, sink *testSink) {
+	t.Helper()
+	assert.Empty(t, sink.Messages(), "a consumed event never reaches the transcript")
+	assert.Empty(t, sink.PersistedNotifications(), "nor the notification thread")
+}
+
 // A replayed task_started (a re-attach after a worker restart) must not stack a
 // second copy of the prompt on top of the transcript it already introduced.
 func TestClaude_ReplayedTaskStartedDoesNotDuplicateThePrompt(t *testing.T) {
@@ -454,9 +565,11 @@ func TestClaude_WorkflowTaskStartedGivesTheSpanBack(t *testing.T) {
 	assert.Empty(t, msgs[1].SpansOpenAtPersist, "the workflow rail is gone")
 }
 
-// A backgrounded shell is an ordinary Bash span whose tool_result returns at
-// once. It reports task_started too, and it must KEEP its rail.
-func TestClaude_BackgroundShellTaskStartedKeepsTheSpan(t *testing.T) {
+// A shell is an ordinary Bash span whose own tool_result closes it. It reports
+// task_started too, and it must KEEP its rail. The event is identical for a
+// backgrounded shell and for a foreground one that passed the CLI's 2-second
+// registration threshold, so this covers both.
+func TestClaude_ShellTaskStartedKeepsTheSpan(t *testing.T) {
 	t.Parallel()
 
 	sink := &testSink{}


### PR DESCRIPTION
## Motivation

A plain foreground `Bash` call — `task test-e2e …` — showed up in the Background
tasks sidebar. It was never backgrounded, so the row looked like a defect in the
registry.

The cause is in the Claude CLI, not here. Its Bash progress loop registers a
FOREGROUND shell as a `local_bash` task once the command runs for 2 seconds
(2.1.220: the registrar runs at 2000 ms with `isBackgrounded` false), so the user
can background it with ctrl-b. That registration emits `task_started`, which is
byte-identical to the one a genuinely backgrounded shell sends. Any command
slower than 2 seconds therefore opens a shell row here.

The comments in `claude_subagent.go` documented the opposite contract. They said
`local_bash` means "a backgrounded shell", and that `background_tasks_changed`
is "redundant with the task_* events" and "carries no extra information". Both
statements are wrong, and the second one hides the only signal that separates
the two cases: the CLI's live background-task list drops a task whose
`isBackgrounded` is false, and `task_updated` reports the foreground → background
flip in `patch.is_backgrounded`.

The behavior is unchanged on purpose. Filtering on `background_tasks_changed`
would trade a divergence from the CLI's own task dialog for a worse failure: the
CLI's task-event queue holds 1000 events and evicts a NON-bookend event first
when it fills, so one lost level event would hide a real background shell for
its whole run.

## Modifications

- Correct the `local_bash`, `task_updated`, and `background_tasks_changed`
  descriptions, and the span comment that called a shell's `tool_result`
  immediate (true for a backgrounded shell, not for a foreground one).
- Record at the no-op arm why it stays a no-op: what each event carries, that
  the registry lists every `local_bash` task deliberately, and what a filter
  would cost.
- Cover that arm, which had no test at all:
  - `TestClaude_BackgroundTasksChangedLeavesTheRegistryAlone` — an empty level
    payload (what a foreground shell produces) evicts no row.
  - `TestClaude_TaskUpdatedDoesNotChangeTheRow` — a patch carrying `status`,
    `end_time`, and `is_backgrounded` ends no row; only `task_notification`
    does.
  - `TestClaude_TaskUpdatedForAnUnknownTaskCreatesNoRow` — neither event
    invents a row for a task no `task_started` opened.
  - A shared `assertTaskEventConsumed` helper asserts BOTH persist paths stay
    empty, so the check cannot pass vacuously when a regression routes the line
    to the other one. Verified by mutation: flipping the arm to `return false`
    fails all three.
- Rename `TestClaude_BackgroundShellTaskStartedKeepsTheSpan` to
  `TestClaude_ShellTaskStartedKeepsTheSpan`, because the event it feeds is
  identical for a foreground shell.

No behavior change: no production statement was added, removed, or altered.

## Result

- The sidebar keeps listing every `local_bash` task, foreground ones included.
  That is now a documented decision with its reason at the site, instead of a
  side effect of a contract description that was wrong.
- The next reader who reaches for a `background_tasks_changed` filter finds the
  eviction hazard before writing it, and the three new tests fail if the no-op
  arm ever starts mutating the registry or leaking a system line into the
  transcript.
