### PR TITLE
fix(worker): Correct the removal-refusal toast and platform-bound tests

### DIFF
--- a/backend/internal/worker/service/close_tab.go
+++ b/backend/internal/worker/service/close_tab.go
@@ -332,7 +332,7 @@ func (svc *Service) removeWorktreeIfLastReference(result *leapmuxv1.CloseTabResu
 		if hasWork, reason := svc.worktreeHoldsUnsavedWork(bgCtx(), *wt); hasWork {
 			slog.Info("skipping worktree removal for an already-closed tab, worktree may hold unsaved work",
 				"worktree_id", wt.ID, "worktree_path", wt.WorktreePath, "reason", reason)
-			setWorktreeRemovalRefused(result, wt, reason)
+			setWorktreeRemovalRefused(result, wt, "Worktree kept: it may hold unsaved work", reason)
 			return
 		}
 	}
@@ -354,7 +354,7 @@ func (svc *Service) removeWorktreeIfLastReference(result *leapmuxv1.CloseTabResu
 	} else if reason != "" {
 		slog.Info("refusing a worktree removal git would reject",
 			"worktree_id", wt.ID, "worktree_path", wt.WorktreePath, "reason", reason)
-		setWorktreeRemovalRefused(result, wt, reason)
+		setWorktreeRemovalRefused(result, wt, "Worktree kept: git refuses to remove it", reason)
 		return
 	}
 	if err := svc.removeWorktreeFromDisk(*wt); err != nil {
@@ -364,17 +364,20 @@ func (svc *Service) removeWorktreeIfLastReference(result *leapmuxv1.CloseTabResu
 	result.WorktreeRemoval = leapmuxv1.WorktreeRemovalOutcome_WORKTREE_REMOVAL_OUTCOME_REMOVED
 }
 
-// setWorktreeRemovalRefused marks a removal we declined on purpose, because the
-// close could not be attributed to a live tab and the directory still holds work
-// nobody was asked about. Reported as FAILED so the UI surfaces it rather than
-// implying the directory is gone.
+// setWorktreeRemovalRefused marks a removal the worker declined on purpose --
+// as opposed to one it attempted and failed. Reported as FAILED so the UI
+// surfaces it rather than implying the directory is gone.
+//
+// message names WHY this call refused (unsaved work nobody confirmed, or a
+// removal git itself would reject); reason carries the specifics and renders
+// after the message in the close-failure toast.
 //
 // The directory survives, but nothing revisits it: this close already dropped
 // the last worktree_tabs link (that is what `remaining == 0` above means), and
 // ListOrphanCandidateWorktrees requires at least one link, so the orphan
 // reconciler never sees the worktree again. The user cleans it up by hand.
-func setWorktreeRemovalRefused(result *leapmuxv1.CloseTabResult, wt *db.Worktree, reason string) {
-	result.FailureMessage = "Worktree kept: it may hold unsaved work"
+func setWorktreeRemovalRefused(result *leapmuxv1.CloseTabResult, wt *db.Worktree, message, reason string) {
+	result.FailureMessage = message
 	result.FailureDetail = reason
 	result.WorktreePath = wt.WorktreePath
 	result.WorktreeId = wt.ID

--- a/backend/internal/worker/service/close_tab_test.go
+++ b/backend/internal/worker/service/close_tab_test.go
@@ -126,6 +126,8 @@ func TestCloseAgent_WithWorktreeActionRemove_RefusesALockedWorktree(t *testing.T
 	require.NoError(t, proto.Unmarshal(fx.w.responses[0].GetPayload(), &resp))
 
 	assert.Equal(t, leapmuxv1.WorktreeRemovalOutcome_WORKTREE_REMOVAL_OUTCOME_FAILED, resp.GetResult().GetWorktreeRemoval())
+	assert.Equal(t, "Worktree kept: git refuses to remove it", resp.GetResult().GetFailureMessage(),
+		"the refusal names git, not unsaved work -- the lock is what kept the directory")
 	// The curated sentence, not git's raw stderr. One source states the reason,
 	// so every surface says the same thing and every one of them is actionable.
 	assert.Contains(t, resp.GetResult().GetFailureDetail(), "held for review")
@@ -699,11 +701,25 @@ func TestCloseAgent_WorktreeRemoveFailure_ReturnsFailureMessage(t *testing.T) {
 	defer drainAllInFlight(svc)
 
 	// Create a worktree DB row pointing at a path that is NOT a git
-	// worktree. This makes `git worktree remove` fail; since the path
-	// still exists, removeWorktreeFromDisk must return an error.
+	// worktree — the row a `mv` of the directory leaves behind. The removal
+	// preflight answers for git up front (worktreeRemovalBlockedReason): it
+	// sees git does not list the path and refuses the close, so `git
+	// worktree remove` never runs and the refusal, not git's stderr, is the
+	// failure the close must report.
+	//
+	// The row is stored CANONICALIZED, as ensureTrackedWorktreeWith stores
+	// every production row. worktreeListingFor's DB fallback looks the row
+	// up by CanonicalizeAbsent, so a raw-spelled path (t.TempDir under
+	// macOS's /var symlink) dodges the fallback, fails the preflight open,
+	// and the removal reaches `git worktree remove` — a different outcome
+	// per platform off one setup.
 	repoDir := initRepo(t)
-	bogusPath := filepath.Join(t.TempDir(), "not-a-worktree")
-	require.NoError(t, os.MkdirAll(bogusPath, 0o755))
+	// Canonicalize only after the directory exists: Canonicalize falls back
+	// to Clean while the path is absent, which on macOS keeps the /var
+	// spelling rather than resolving to /private/var.
+	rawPath := filepath.Join(t.TempDir(), "not-a-worktree")
+	require.NoError(t, os.MkdirAll(rawPath, 0o755))
+	bogusPath := pathutil.Canonicalize(rawPath)
 	wtID := "wt-bogus"
 	_, cwErr := svc.Queries.CreateWorktree(context.Background(), db.CreateWorktreeParams{
 		ID:           wtID,
@@ -729,9 +745,11 @@ func TestCloseAgent_WorktreeRemoveFailure_ReturnsFailureMessage(t *testing.T) {
 	require.Len(t, w.responses, 1)
 	var resp leapmuxv1.CloseAgentResponse
 	require.NoError(t, proto.Unmarshal(w.responses[0].GetPayload(), &resp))
-	assert.NotEmpty(t, resp.GetResult().GetFailureMessage(), "expected failure message for unremovable worktree")
-	assert.Contains(t, resp.GetResult().GetFailureDetail(), bogusPath, "detail should include worktree path")
-	assert.Equal(t, bogusPath, resp.GetResult().GetWorktreePath())
+	assert.Equal(t, "Worktree kept: git refuses to remove it", resp.GetResult().GetFailureMessage(),
+		"the refusal names git, not unsaved work -- nothing probed the directory for work")
+	assert.Contains(t, resp.GetResult().GetFailureDetail(), "no longer lists this directory",
+		"detail should state the preflight's refusal, not git's raw stderr")
+	assert.Equal(t, bogusPath, resp.GetResult().GetWorktreePath(), "the path the user must clean up by hand rides the structured field")
 	assert.Equal(t, wtID, resp.GetResult().GetWorktreeId())
 	assert.Equal(t, leapmuxv1.WorktreeRemovalOutcome_WORKTREE_REMOVAL_OUTCOME_FAILED, resp.GetResult().GetWorktreeRemoval(), "a failed removal should report FAILED")
 
@@ -1473,6 +1491,8 @@ func TestCloseTabCommon_RemoveOnAlreadyClosedTabDoesNotDiscardUnsavedWork(t *tes
 	assert.Equal(t, leapmuxv1.WorktreeRemovalOutcome_WORKTREE_REMOVAL_OUTCOME_FAILED,
 		result.GetWorktreeRemoval(),
 		"a REMOVE that retired no live row must not silently report the directory gone")
+	assert.Equal(t, "Worktree kept: it may hold unsaved work", result.GetFailureMessage(),
+		"this refusal is about unconfirmed work, unlike the git-refusal copy")
 	assert.DirExists(t, wt.WorktreePath,
 		"the worktree holds uncommitted work and nobody confirmed its deletion, so it must survive")
 

--- a/backend/internal/worker/service/file_test.go
+++ b/backend/internal/worker/service/file_test.go
@@ -430,8 +430,11 @@ func TestReadFile_CarriesModTime(t *testing.T) {
 	t.Parallel()
 
 	// A fixed past instant, so the assertion pins the file's mtime rather than
-	// "roughly now", which any clock would satisfy.
-	want := time.Date(2026, 3, 4, 5, 6, 7, 123456789, time.UTC)
+	// "roughly now", which any clock would satisfy. The nanosecond tail ends
+	// in 00 because NTFS stores file times in 100ns ticks: a value off that
+	// grid comes back rounded on Windows, and the round trip would fail there.
+	// Seven significant digits still prove sub-microsecond fidelity.
+	want := time.Date(2026, 3, 4, 5, 6, 7, 123456700, time.UTC)
 
 	readModTime := func(t *testing.T, metaOnly bool, limit int64) string {
 		t.Helper()

--- a/backend/internal/worker/service/git_test.go
+++ b/backend/internal/worker/service/git_test.go
@@ -2572,12 +2572,18 @@ func TestListGitWorktrees_DecodesAQuotedLockReason(t *testing.T) {
 // first drops it and names a directory that does not exist -- and every later
 // path compare then misses the entry, which turns a locked worktree into a
 // removable one.
+//
+// Skip on platforms that refuse the fixture: Windows strips trailing spaces
+// from path components, so `git worktree add` cannot create the directory at
+// all there.
 func TestListGitWorktrees_KeepsATrailingSpaceInAPath(t *testing.T) {
 	t.Parallel()
 
 	repoDir := initRepo(t)
 	wtDir := filepath.Join(t.TempDir(), "trailing-space-wt ")
-	run(t, repoDir, "git", "worktree", "add", "-b", "trailing-space", wtDir)
+	if err := exec.Command("git", "-C", repoDir, "worktree", "add", "-b", "trailing-space", wtDir).Run(); err != nil {
+		t.Skipf("platform refused a trailing-space worktree path: %v", err)
+	}
 	run(t, repoDir, "git", "worktree", "lock", "--reason", "held", wtDir)
 
 	entries, err := listGitWorktrees(context.Background(), repoDir)


### PR DESCRIPTION
## Motivation

CI on main has been red since 2026-08-13: the macOS jobs pass while linux amd64, linux arm64, and windows fail, so the platform-dependent breakage slipped through local verification (failing run: https://github.com/leapmux/leapmux/actions/runs/31807441358). The failures come from two recent changes:

- 92c68b97 (#380 worktree-removal preflight): `TestCloseAgent_WorktreeRemoveFailure_ReturnsFailureMessage` still expected the pre-preflight `git worktree remove` error path, and its outcome depended on the raw path spelling (a `/var` form that dodges the DB fallback under macOS's `/var -> /private/var` symlink), and the trailing-space worktree fixture used by `TestListGitWorktrees_KeepsATrailingSpaceInAPath` cannot be created on Windows, which strips trailing spaces from path components.
- 7f64198f (#382 file tree sort): `TestReadFile_CarriesModTime` pinned an mtime off NTFS's 100ns tick grid, and Windows rounds it, failing the round-trip assertion.

Separately, both worktree-removal refusal paths in `removeWorktreeIfLastReference` shared the same toast copy, so a git refusal (locked worktree, the main working tree, a path git no longer lists) was mislabeled to the user as an unconfirmed-unsaved-work refusal.

## Modifications

- `setWorktreeRemovalRefused` (backend/internal/worker/service/close_tab.go) now takes a `message` parameter. The stale-close unsaved-work probe keeps "Worktree kept: it may hold unsaved work", while the `worktreeRemovalBlockedReason` preflight refusal now reports "Worktree kept: git refuses to remove it". The curated reason still rides `FailureDetail`, so the toast (`${failureMessage}: ${failureDetail}`) stays specific.
- Reworked `TestCloseAgent_WorktreeRemoveFailure_ReturnsFailureMessage` for the #380 preflight reality: the bogus worktree row's path is canonicalized via `pathutil.Canonicalize` once the directory exists, matching how `ensureTrackedWorktreeWith` stores production rows, so the preflight — not `git worktree remove` — produces the failure deterministically on every platform. Assertions tightened to the exact refusal message, the curated "no longer lists this directory" detail instead of git's stderr, and the canonical path/id/FAILED outcome.
- `TestReadFile_CarriesModTime` pins its fixture mtime to `...123456700` ns so it sits on NTFS's 100ns tick grid; sub-microsecond fidelity is still proven.
- `TestListGitWorktrees_KeepsATrailingSpaceInAPath` replaces the fail-hard `run` helper with a direct `exec.Command(...).Run()` plus `t.Skipf` when the trailing-space directory cannot be created, the same try-then-skip the newline-in-path sibling uses.
- `TestCloseAgent_WithWorktreeActionRemove_RefusesALockedWorktree` and `TestCloseTabCommon_RemoveOnAlreadyClosedTabDoesNotDiscardUnsavedWork` gained message assertions to lock the git-refusal vs unsaved-work copy split.

## Result

The three failing tests now behave identically on every platform: the close-path test takes the preflight-refusal path (verified on macOS and in a Linux/arm64 container, where it previously failed), the trailing-space fixture skips only where Windows cannot create it, and the mtime fixture round-trips exactly on NTFS, ext4, and APFS. When a tab close fails because git refuses to remove the worktree, the user sees "Worktree kept: git refuses to remove it: <curated reason>" instead of the misleading "it may hold unsaved work" message; genuine unsaved-work refusals keep their original copy. No breaking changes: `setWorktreeRemovalRefused` is package-private and the `CloseTabResult` wire shape is unchanged (only the `FailureMessage` string content differs on one path).
