### PR TITLE
feat(menus): Open a row's context menu by long press or right-click

### DIFF
--- a/frontend/src/components/chat/ChatView.tsx
+++ b/frontend/src/components/chat/ChatView.tsx
@@ -39,6 +39,7 @@ import { computeOverscanPx, createViewportSizeObserver, measureSpaceToken, PRE_M
 import { markdownContent } from './markdownEditor/markdownContent.css'
 import { MessageBubble } from './MessageBubble'
 import { messageBubbleClass, messageRowChrome } from './messageClassification'
+import { MessageContextMenuHostProvider } from './MessageContextMenuHost'
 import { createMessageRenderCacheStore } from './messageRenderCache'
 import { expandedUiKeyFor, messageUiDefault } from './messageUiKeys'
 import { ToolUseLayout } from './toolRenderers'
@@ -988,55 +989,59 @@ export const ChatView: Component<ChatViewProps> = (props) => {
 
   return (
     <div class={styles.container} data-testid="chat-container">
-      <div class={styles.messageListWrapper}>
-        <div
-          ref={(el) => {
-            listEl = el
-            setScrollEl(el)
-            scroll.attachListRef(el)
-            viewportSizeObserver.observe(el)
-            attachPassiveScrollListeners(el)
-          }}
-          // Hide the native scrollbar when the rail is active and either can draw a thumb
-          // from a server anchor, or there is no scrollable local-only overflow that would
-          // need the native scrollbar as a fallback.
-          class={`${styles.messageList} ${hideNativeScrollbar() ? styles.messageListRailActive : ''}`}
-          data-chat-scroll-container="true"
-          tabIndex={0}
-          {...scrollHandlers}
-        >
-          {/*
+      {/* One shared menu for every row below, including the streaming tail. The
+          host renders a trigger-less popover, so it adds no box to this column --
+          see `data-headless` in ~/components/common/DropdownMenu.tsx. */}
+      <MessageContextMenuHostProvider>
+        <div class={styles.messageListWrapper}>
+          <div
+            ref={(el) => {
+              listEl = el
+              setScrollEl(el)
+              scroll.attachListRef(el)
+              viewportSizeObserver.observe(el)
+              attachPassiveScrollListeners(el)
+            }}
+            // Hide the native scrollbar when the rail is active and either can draw a thumb
+            // from a server anchor, or there is no scrollable local-only overflow that would
+            // need the native scrollbar as a fallback.
+            class={`${styles.messageList} ${hideNativeScrollbar() ? styles.messageListRailActive : ''}`}
+            data-chat-scroll-container="true"
+            tabIndex={0}
+            {...scrollHandlers}
+          >
+            {/*
             AgentStartupBanner is rendered in two places below: once in the
             empty-state fallback and once trailing the message list. They
             are NOT redundant — the outer <Show> only renders one branch at
             a time, so at most one banner is in the DOM for any given state.
           */}
-          <Show
-            when={hasVisibleEntries() || props.streamingText || props.agentLifecycle?.agentWorking
-              || props.pagination?.hasOlderMessages || props.pagination?.hasNewerMessages
-              || props.pagination?.fetchingOlder || props.pagination?.fetchingNewer}
-            fallback={(
-              <Switch fallback={<div class={styles.emptyChat}>Send a message to start</div>}>
-                <Match when={props.agentLifecycle?.agentStatus === AgentStatus.STARTING || props.agentLifecycle?.agentStatus === AgentStatus.STARTUP_FAILED}>
-                  <AgentStartupBanner
-                    status={props.agentLifecycle?.agentStatus}
-                    providerLabel={props.agentLifecycle?.providerLabel}
-                    startupError={props.agentLifecycle?.startupError}
-                    startupMessage={props.agentLifecycle?.startupMessage}
-                    containerClass={styles.emptyChat}
-                  />
-                </Match>
-              </Switch>
-            )}
-          >
-            <div class={styles.messageListSpacer} />
-            <SelectionQuotePopover
-              class={styles.messageListSelectionRoot}
-              onQuote={text => props.onQuote?.(formatChatQuote(text))}
-              onSelectionActiveChange={setTextSelectionActive}
+            <Show
+              when={hasVisibleEntries() || props.streamingText || props.agentLifecycle?.agentWorking
+                || props.pagination?.hasOlderMessages || props.pagination?.hasNewerMessages
+                || props.pagination?.fetchingOlder || props.pagination?.fetchingNewer}
+              fallback={(
+                <Switch fallback={<div class={styles.emptyChat}>Send a message to start</div>}>
+                  <Match when={props.agentLifecycle?.agentStatus === AgentStatus.STARTING || props.agentLifecycle?.agentStatus === AgentStatus.STARTUP_FAILED}>
+                    <AgentStartupBanner
+                      status={props.agentLifecycle?.agentStatus}
+                      providerLabel={props.agentLifecycle?.providerLabel}
+                      startupError={props.agentLifecycle?.startupError}
+                      startupMessage={props.agentLifecycle?.startupMessage}
+                      containerClass={styles.emptyChat}
+                    />
+                  </Match>
+                </Switch>
+              )}
             >
-              <div class={styles.messageListContent}>
-                {/*
+              <div class={styles.messageListSpacer} />
+              <SelectionQuotePopover
+                class={styles.messageListSelectionRoot}
+                onQuote={text => props.onQuote?.(formatChatQuote(text))}
+                onSelectionActiveChange={setTextSelectionActive}
+              >
+                <div class={styles.messageListContent}>
+                  {/*
                   Virtualized list: only rows in/near the viewport are mounted,
                   absolutely positioned by translateY inside a spacer sized to
                   the whole window's height (so the native scrollbar is correct).
@@ -1047,20 +1052,20 @@ export const ChatView: Component<ChatViewProps> = (props) => {
                   fast fling cannot scroll past the loaded edge into unloaded history
                   -- it stalls there until the buffer filler loads more, never skips.
                 */}
-                <div class={styles.virtualSpacer} style={{ height: `${virt.totalHeight()}px` }}>
-                  {/* Inter-row rail segments, outside the paint-contained rows
+                  <div class={styles.virtualSpacer} style={{ height: `${virt.totalHeight()}px` }}>
+                    {/* Inter-row rail segments, outside the paint-contained rows
                       (before the <For>, so rows paint over any overlap). Keyed
                       on the same stable entry references as the row <For>, so
                       geometry changes move anchors in place instead of
                       recreating the overlay DOM. */}
-                  <SpanLineGapBridges
-                    entries={visibleSlice()}
-                    precedingEntry={visibleEntries()[virt.range().start - 1]}
-                    topOf={id => virt.offsetOfId(id) ?? 0}
-                    hiddenOf={rowSpanColumnHidden}
-                    gapAboveOf={virt.gapAboveOf}
-                  />
-                  {/*
+                    <SpanLineGapBridges
+                      entries={visibleSlice()}
+                      precedingEntry={visibleEntries()[virt.range().start - 1]}
+                      topOf={id => virt.offsetOfId(id) ?? 0}
+                      hiddenOf={rowSpanColumnHidden}
+                      gapAboveOf={virt.gapAboveOf}
+                    />
+                    {/*
                     Loading skeletons: a premeasure-hidden row whose wait has
                     exceeded SKELETON_SHOW_DELAY_MS paints its reserved slot as
                     shimmer lines instead of blank space (a fast re-measure never
@@ -1069,82 +1074,82 @@ export const ChatView: Component<ChatViewProps> = (props) => {
                     by the same offsets, so they vanish seamlessly the moment the
                     real row's measurement commits and it fades in.
                   */}
-                  <For each={skeletonSlice()}>
-                    {entry => positionedRowSkeleton(entry)}
-                  </For>
-                  {/*
+                    <For each={skeletonSlice()}>
+                      {entry => positionedRowSkeleton(entry)}
+                    </For>
+                    {/*
                     Crossfade tail: skeletons whose row just measured fade OUT
                     here while the real row's opacity fades in — the two
                     overlap for one beat, so the swap never pops.
                   */}
-                  <For each={lingeringSkeletonSlice()}>
-                    {entry => positionedRowSkeleton(entry, true)}
-                  </For>
-                  <For each={visibleSlice()}>
-                    {(entry) => {
-                      const { msg, parsedSpanLines } = entry
-                      // Offset is resolved by the row's own id, not by
-                      // range().start + localIndex(): the id is the stable,
-                      // unique key into the offset map (seq is 0n for every
-                      // optimistic local), so it can't transiently disagree with
-                      // the slice bounds during a scroll/measure flush.
-                      const top = () => virt.offsetOfId(msg.id) ?? 0
-                      // Fling skeleton: a MEASURED row entering the window
-                      // during a FAST user scroll mounts as line placeholders at
-                      // its known height instead of paying full bubble
-                      // construction on the scroll-critical path, then upgrades
-                      // in place (skeleton -> crossfade -> real) once the scroll
-                      // settles. The per-row phase machine lives in
-                      // createRowUpgradePhase (see rowSkeletonUpgradeOverlay for
-                      // the crossfade copy). trackRow also registers this row's phase
-                      // in flingSkeletons.skeletonIds so the gap-bridge overlay hides
-                      // this row's bridge while the skeleton shows.
-                      const upgradePhase = flingSkeletons.trackRow(msg.id)
+                    <For each={lingeringSkeletonSlice()}>
+                      {entry => positionedRowSkeleton(entry, true)}
+                    </For>
+                    <For each={visibleSlice()}>
+                      {(entry) => {
+                        const { msg, parsedSpanLines } = entry
+                        // Offset is resolved by the row's own id, not by
+                        // range().start + localIndex(): the id is the stable,
+                        // unique key into the offset map (seq is 0n for every
+                        // optimistic local), so it can't transiently disagree with
+                        // the slice bounds during a scroll/measure flush.
+                        const top = () => virt.offsetOfId(msg.id) ?? 0
+                        // Fling skeleton: a MEASURED row entering the window
+                        // during a FAST user scroll mounts as line placeholders at
+                        // its known height instead of paying full bubble
+                        // construction on the scroll-critical path, then upgrades
+                        // in place (skeleton -> crossfade -> real) once the scroll
+                        // settles. The per-row phase machine lives in
+                        // createRowUpgradePhase (see rowSkeletonUpgradeOverlay for
+                        // the crossfade copy). trackRow also registers this row's phase
+                        // in flingSkeletons.skeletonIds so the gap-bridge overlay hides
+                        // this row's bridge while the skeleton shows.
+                        const upgradePhase = flingSkeletons.trackRow(msg.id)
 
-                      // An assistant message / thought paints a full-bleed band
-                      // BEHIND the row: the band is the row's own background and
-                      // border, so paint containment can't clip it and the span
-                      // rails and toolbar sit on top of the gray. Read once --
-                      // reclassifying a row replaces its entry, which remounts
-                      // this row. data-band is the e2e hook, because every style
-                      // class is a hashed name.
-                      const chrome = messageRowChrome(styles.virtualRow, entry.category.kind, msg.source)
+                        // An assistant message / thought paints a full-bleed band
+                        // BEHIND the row: the band is the row's own background and
+                        // border, so paint containment can't clip it and the span
+                        // rails and toolbar sit on top of the gray. Read once --
+                        // reclassifying a row replaces its entry, which remounts
+                        // this row. data-band is the e2e hook, because every style
+                        // class is a hashed name.
+                        const chrome = messageRowChrome(styles.virtualRow, entry.category.kind, msg.source)
 
-                      return (
-                        <div
-                          class={chrome.class}
-                          data-band={chrome.band}
-                          style={{
-                            transform: `translateY(${top()}px)`,
-                            // Absolute rows do not reserve flow height for
-                            // siblings — see rowHiddenUntilMeasured for why an
-                            // unmeasured premeasuring row stays invisible.
-                            visibility: rowHiddenUntilMeasured(msg.id) ? 'hidden' : undefined,
-                            opacity: rowHiddenUntilMeasured(msg.id) ? '0' : '1',
-                          }}
-                          data-seq={msg.seq.toString()}
-                          ref={(el) => {
-                            virt.attachRow(msg.id, el)
-                            onCleanup(() => virt.detachRow(el))
-                          }}
-                        >
-                          <Show
-                            when={upgradePhase() !== 'skeleton'}
-                            fallback={(
-                              <ChatRowSkeleton
-                                height={virt.heightOfId(msg.id)}
-                                seed={msg.id}
-                              />
-                            )}
+                        return (
+                          <div
+                            class={chrome.class}
+                            data-band={chrome.band}
+                            style={{
+                              transform: `translateY(${top()}px)`,
+                              // Absolute rows do not reserve flow height for
+                              // siblings — see rowHiddenUntilMeasured for why an
+                              // unmeasured premeasuring row stays invisible.
+                              visibility: rowHiddenUntilMeasured(msg.id) ? 'hidden' : undefined,
+                              opacity: rowHiddenUntilMeasured(msg.id) ? '0' : '1',
+                            }}
+                            data-seq={msg.seq.toString()}
+                            ref={(el) => {
+                              virt.attachRow(msg.id, el)
+                              onCleanup(() => virt.detachRow(el))
+                            }}
                           >
-                            {(() => {
+                            <Show
+                              when={upgradePhase() !== 'skeleton'}
+                              fallback={(
+                                <ChatRowSkeleton
+                                  height={virt.heightOfId(msg.id)}
+                                  seed={msg.id}
+                                />
+                              )}
+                            >
+                              {(() => {
                               // Constructed lazily: while the skeleton shows,
                               // the bubble (markdown, tokens, toolbars) is
                               // never built for this row.
-                              const bubble = renderMessageBubble(entry)
-                              return (
-                                <>
-                                  {/*
+                                const bubble = renderMessageBubble(entry)
+                                return (
+                                  <>
+                                    {/*
                                     data-span-columns carries how many rails
                                     this row draws (0 when it draws none, e.g. a
                                     subagent spawn with nothing else open). Every
@@ -1152,7 +1157,7 @@ export const ChatView: Component<ChatViewProps> = (props) => {
                                     name, so an e2e spec has no other stable way
                                     to read the rail count of one row.
                                   */}
-                                  {/*
+                                    {/*
                                     Both arms publish ROW_BLEED_LEFT_VAR: how far
                                     the panel's left edge is from where this row's
                                     content starts. The rails push that start
@@ -1160,126 +1165,126 @@ export const ChatView: Component<ChatViewProps> = (props) => {
                                     bleeding child reads it instead of assuming
                                     the bare gutter.
                                   */}
-                                  <Show
-                                    when={parsedSpanLines.length > 0}
-                                    fallback={(
-                                      <div
-                                        data-span-columns={parsedSpanLines.length}
-                                        style={reservedRowContentColumnStyle(0)}
-                                      >
-                                        {bubble}
+                                    <Show
+                                      when={parsedSpanLines.length > 0}
+                                      fallback={(
+                                        <div
+                                          data-span-columns={parsedSpanLines.length}
+                                          style={reservedRowContentColumnStyle(0)}
+                                        >
+                                          {bubble}
+                                        </div>
+                                      )}
+                                    >
+                                      <div class={styles.railedRow} data-span-columns={parsedSpanLines.length}>
+                                        <SpanLines lines={parsedSpanLines} />
+                                        <div class={styles.railedRowContent} style={rowBleedLeftStyle(parsedSpanLines.length)}>
+                                          {bubble}
+                                        </div>
                                       </div>
-                                    )}
-                                  >
-                                    <div class={styles.railedRow} data-span-columns={parsedSpanLines.length}>
-                                      <SpanLines lines={parsedSpanLines} />
-                                      <div class={styles.railedRowContent} style={rowBleedLeftStyle(parsedSpanLines.length)}>
-                                        {bubble}
+                                    </Show>
+                                    <Show when={upgradePhase() === 'crossfade'}>
+                                      <div class={`${styles.rowSkeletonUpgradeOverlay} ${styles.rowSkeletonClosing}`}>
+                                        <ChatRowSkeleton
+                                          height={virt.heightOfId(msg.id)}
+                                          seed={msg.id}
+                                        />
                                       </div>
-                                    </div>
-                                  </Show>
-                                  <Show when={upgradePhase() === 'crossfade'}>
-                                    <div class={`${styles.rowSkeletonUpgradeOverlay} ${styles.rowSkeletonClosing}`}>
-                                      <ChatRowSkeleton
-                                        height={virt.heightOfId(msg.id)}
-                                        seed={msg.id}
-                                      />
-                                    </div>
-                                  </Show>
-                                </>
-                              )
-                            })()}
-                          </Show>
-                        </div>
-                      )
-                    }}
-                  </For>
-                </div>
-                {/*
+                                    </Show>
+                                  </>
+                                )
+                              })()}
+                            </Show>
+                          </div>
+                        )
+                      }}
+                    </For>
+                  </div>
+                  {/*
                   Streaming text and the thinking indicator belong at the live
                   tail. While windowed away from the tail (hasNewerMessages) the
                   bottom of the in-memory list isn't the real bottom, so hide
                   them — the scroll-to-bottom button jumps back to the tail.
                 */}
-                <Show when={!props.pagination?.hasNewerMessages}>
-                  <Show when={streamingTailRender()}>
-                    {streamingTail => (
-                      <Show
-                        when={streamingTail().type === 'plan'}
-                        fallback={(() => {
+                  <Show when={!props.pagination?.hasNewerMessages}>
+                    <Show when={streamingTailRender()}>
+                      {streamingTail => (
+                        <Show
+                          when={streamingTail().type === 'plan'}
+                          fallback={(() => {
                           // The live tail wears the SAME chrome as the persisted
                           // assistant row that replaces it, so the band does not
                           // appear only after the message lands. Derived from the
                           // kind it will become, never hardcoded: this is a row
                           // mount site like the other three, and a hand-written
                           // copy is what lets them drift.
-                          const chrome = messageRowChrome('', 'assistant_text', MessageSource.AGENT)
-                          return (
-                            <div
+                            const chrome = messageRowChrome('', 'assistant_text', MessageSource.AGENT)
+                            return (
+                              <div
                               // The tail sits in FLOW, not in the offset map, so the
                               // virtualizer's band overlap cannot reach it. Cancel
                               // the flow gap and one border here instead, or the
                               // reader sees two lines and a gap that snap into one
                               // line the instant the message lands.
-                              class={tailMergesWithRowAbove() ? `${chrome.class} ${styles.bandTailMerged}` : chrome.class}
-                              data-band={chrome.band}
-                            >
-                              <div class={messageBubbleClass('assistant_text', MessageSource.AGENT)}>
-                                {/* eslint-disable-next-line solid/no-innerhtml -- streaming text rendered via remark */}
-                                <div class={markdownContent} innerHTML={streamingTail().html} />
+                                class={tailMergesWithRowAbove() ? `${chrome.class} ${styles.bandTailMerged}` : chrome.class}
+                                data-band={chrome.band}
+                              >
+                                <div class={messageBubbleClass('assistant_text', MessageSource.AGENT)}>
+                                  {/* eslint-disable-next-line solid/no-innerhtml -- streaming text rendered via remark */}
+                                  <div class={markdownContent} innerHTML={streamingTail().html} />
+                                </div>
                               </div>
-                            </div>
-                          )
-                        })()}
-                      >
-                        <ToolUseLayout
-                          icon={PlaneTakeoff}
-                          toolName="Plan"
-                          title="Proposed Plan"
-                          alwaysVisible={true}
-                          bordered={false}
+                            )
+                          })()}
                         >
-                          <>
-                            <hr />
-                            {/* eslint-disable-next-line solid/no-innerhtml -- streaming text rendered via remark */}
-                            <div class={markdownContent} style={{ 'font-size': 'var(--text-regular)' }} innerHTML={streamingTail().html} />
-                          </>
-                        </ToolUseLayout>
-                      </Show>
-                    )}
-                  </Show>
-                  <ThinkingIndicator
-                    id={props.agentId}
-                    visible={props.agentLifecycle?.agentWorking ?? false}
-                    thinkingTokens={props.agentLifecycle?.thinkingTokens}
-                    paused={props.tabActive === false}
-                    backgroundTasks={props.agentLifecycle?.backgroundTasks}
-                    onOpenSubagent={props.agentLifecycle?.onOpenSubagent}
-                    todos={props.agentLifecycle?.todos}
-                    onExpandTick={() => {
-                      if (scroll.isAtBottomFresh())
-                        scroll.jumpToBottom()
-                    }}
-                  />
-                  {/*
+                          <ToolUseLayout
+                            icon={PlaneTakeoff}
+                            toolName="Plan"
+                            title="Proposed Plan"
+                            alwaysVisible={true}
+                            bordered={false}
+                          >
+                            <>
+                              <hr />
+                              {/* eslint-disable-next-line solid/no-innerhtml -- streaming text rendered via remark */}
+                              <div class={markdownContent} style={{ 'font-size': 'var(--text-regular)' }} innerHTML={streamingTail().html} />
+                            </>
+                          </ToolUseLayout>
+                        </Show>
+                      )}
+                    </Show>
+                    <ThinkingIndicator
+                      id={props.agentId}
+                      visible={props.agentLifecycle?.agentWorking ?? false}
+                      thinkingTokens={props.agentLifecycle?.thinkingTokens}
+                      paused={props.tabActive === false}
+                      backgroundTasks={props.agentLifecycle?.backgroundTasks}
+                      onOpenSubagent={props.agentLifecycle?.onOpenSubagent}
+                      todos={props.agentLifecycle?.todos}
+                      onExpandTick={() => {
+                        if (scroll.isAtBottomFresh())
+                          scroll.jumpToBottom()
+                      }}
+                    />
+                    {/*
                     The startup banner is tail-anchored like the streaming/thinking
                     UI above: while windowed away from the live tail (hasNewerMessages)
                     the in-memory bottom isn't the real bottom, so it stays gated --
                     otherwise a STARTING restart would paint the banner mid-history.
                   */}
-                  <AgentStartupBanner
-                    status={props.agentLifecycle?.agentStatus}
-                    providerLabel={props.agentLifecycle?.providerLabel}
-                    startupError={props.agentLifecycle?.startupError}
-                    startupMessage={props.agentLifecycle?.startupMessage}
-                    containerClass={styles.startupPanelInline}
-                  />
-                </Show>
-              </div>
-            </SelectionQuotePopover>
-          </Show>
-        </div>
-        {/*
+                    <AgentStartupBanner
+                      status={props.agentLifecycle?.agentStatus}
+                      providerLabel={props.agentLifecycle?.providerLabel}
+                      startupError={props.agentLifecycle?.startupError}
+                      startupMessage={props.agentLifecycle?.startupMessage}
+                      containerClass={styles.startupPanelInline}
+                    />
+                  </Show>
+                </div>
+              </SelectionQuotePopover>
+            </Show>
+          </div>
+          {/*
           History loading indicators: absolute OVERLAYS pinned to the top / bottom of
           the viewport, NOT in the scroll flow. In-flow they would shift the virtualized
           content by their height as fetching toggles -- a shift the anchor re-pin can't
@@ -1289,76 +1294,77 @@ export const ChatView: Component<ChatViewProps> = (props) => {
           they show ONLY when the view is clamped against the loaded edge waiting on the
           fetch -- a background pre-fetch (the common case) stays silent.
         */}
-        <Show when={scroll.stalledOlder()}>
-          <div class={styles.loadingOlderIndicator}>
-            <Spinner />
-            Loading older messages...
-          </div>
-        </Show>
-        <Show when={scroll.stalledNewer()}>
-          <div class={styles.loadingNewerIndicator}>
-            <Spinner />
-            Loading newer messages...
-          </div>
-        </Show>
-        {/*
+          <Show when={scroll.stalledOlder()}>
+            <div class={styles.loadingOlderIndicator}>
+              <Spinner />
+              Loading older messages...
+            </div>
+          </Show>
+          <Show when={scroll.stalledNewer()}>
+            <div class={styles.loadingNewerIndicator}>
+              <Spinner />
+              Loading newer messages...
+            </div>
+          </Show>
+          {/*
           Hide the scroll-to-bottom button while the newer-loading indicator is up: both
           float at bottom-center, so the indicator takes the slot for the brief stall and
           the button reappears once the page lands (or the fetch times out).
         */}
-        <Show when={!scroll.stalledNewer() && (!scroll.atBottom() || props.pagination?.hasNewerMessages)}>
-          <button
-            type="button"
-            class={`outline icon ${styles.scrollToBottomButton}`}
-            onClick={() => scroll.scrollToBottom()}
-          >
-            <Icon icon={ArrowDown} size="lg" />
-          </button>
-        </Show>
-        <Show when={props.rail?.loaded}>
-          <ChatScrollRail
-            scrollEl={scrollEl()}
-            items={virtualItems()}
-            offsetOfIndex={virt.offsetOfIndex}
-            totalHeight={virt.totalHeight()}
-            geometryVersion={virt.geometryVersion()}
-            // The row-seq map the owner resolution above already computes (railRowSeqs), reused by
-            // the rail's geometry so the O(n) scan runs once per item-list change, not twice.
-            railRowSeqs={railRowSeqs()}
-            // ChatRailProps extends ChatRailData, so pass the whole object straight through as the
-            // rail's `rail` prop rather than re-flattening its six fields (which the view would then
-            // have to keep in hand-sync). previewFor/warmPreview are the orthogonal on-demand
-            // callbacks and stay separate.
-            rail={props.rail!}
-            // Whether the rail hides itself, the exact complement of hideNativeScrollbar: both are
-            // derived from ONE railOwner resolution (single viewport-height source), so the rail is
-            // shown exactly when the native bar is hidden -- never zero, never two scrollbars.
-            hidden={railOwner() !== 'rail'}
-            // Paint-only auto-hide; never an unmount (see the rail's scrollActive prop).
-            // Driven by railActivity, which takes user input plus a momentum-gated scroll, so
-            // a streaming turn's stick-to-bottom writes cannot light it. Every viewport and
-            // pointer fades the idle rail the same way -- only the `pointer-events` half of
-            // railIdle is coarse-only -- so there is no JS branch here.
-            scrollActive={railActivity.active()}
-            // The rail's own interactions (grab, drag move, dot hover or focus) reopen the
-            // window -- a captured thumb drag fires no events on the scroll container.
-            onActivity={() => railActivity.noteInput()}
-            hasMoreOlder={!!props.pagination?.hasOlderMessages}
-            hasMoreNewer={!!props.pagination?.hasNewerMessages}
-            onJumpToSeq={seq => scroll.jumpToSeq(seq)}
-            previewScrollTo={top => scroll.previewScrollTo(top)}
-            onSeekInterrupt={() => scroll.cancelPendingSeek()}
-            previewFor={props.rail!.previewFor}
-            warmPreview={props.rail!.warmPreview}
-          />
-        </Show>
-      </div>
-      <ChatHiddenPremeasure
-        candidates={premeasureCandidates()}
-        contentWidthPx={effectiveContentWidth()}
-        renderBubble={entry => renderMessageBubble(entry, { premeasureMode: true })}
-        onMeasure={premeasure.onMeasure}
-      />
+          <Show when={!scroll.stalledNewer() && (!scroll.atBottom() || props.pagination?.hasNewerMessages)}>
+            <button
+              type="button"
+              class={`outline icon ${styles.scrollToBottomButton}`}
+              onClick={() => scroll.scrollToBottom()}
+            >
+              <Icon icon={ArrowDown} size="lg" />
+            </button>
+          </Show>
+          <Show when={props.rail?.loaded}>
+            <ChatScrollRail
+              scrollEl={scrollEl()}
+              items={virtualItems()}
+              offsetOfIndex={virt.offsetOfIndex}
+              totalHeight={virt.totalHeight()}
+              geometryVersion={virt.geometryVersion()}
+              // The row-seq map the owner resolution above already computes (railRowSeqs), reused by
+              // the rail's geometry so the O(n) scan runs once per item-list change, not twice.
+              railRowSeqs={railRowSeqs()}
+              // ChatRailProps extends ChatRailData, so pass the whole object straight through as the
+              // rail's `rail` prop rather than re-flattening its six fields (which the view would then
+              // have to keep in hand-sync). previewFor/warmPreview are the orthogonal on-demand
+              // callbacks and stay separate.
+              rail={props.rail!}
+              // Whether the rail hides itself, the exact complement of hideNativeScrollbar: both are
+              // derived from ONE railOwner resolution (single viewport-height source), so the rail is
+              // shown exactly when the native bar is hidden -- never zero, never two scrollbars.
+              hidden={railOwner() !== 'rail'}
+              // Paint-only auto-hide; never an unmount (see the rail's scrollActive prop).
+              // Driven by railActivity, which takes user input plus a momentum-gated scroll, so
+              // a streaming turn's stick-to-bottom writes cannot light it. Every viewport and
+              // pointer fades the idle rail the same way -- only the `pointer-events` half of
+              // railIdle is coarse-only -- so there is no JS branch here.
+              scrollActive={railActivity.active()}
+              // The rail's own interactions (grab, drag move, dot hover or focus) reopen the
+              // window -- a captured thumb drag fires no events on the scroll container.
+              onActivity={() => railActivity.noteInput()}
+              hasMoreOlder={!!props.pagination?.hasOlderMessages}
+              hasMoreNewer={!!props.pagination?.hasNewerMessages}
+              onJumpToSeq={seq => scroll.jumpToSeq(seq)}
+              previewScrollTo={top => scroll.previewScrollTo(top)}
+              onSeekInterrupt={() => scroll.cancelPendingSeek()}
+              previewFor={props.rail!.previewFor}
+              warmPreview={props.rail!.warmPreview}
+            />
+          </Show>
+        </div>
+        <ChatHiddenPremeasure
+          candidates={premeasureCandidates()}
+          contentWidthPx={effectiveContentWidth()}
+          renderBubble={entry => renderMessageBubble(entry, { premeasureMode: true })}
+          onMeasure={premeasure.onMeasure}
+        />
+      </MessageContextMenuHostProvider>
     </div>
   )
 }

--- a/frontend/src/components/chat/MessageBubble.test.tsx
+++ b/frontend/src/components/chat/MessageBubble.test.tsx
@@ -4,6 +4,7 @@ import { codeCopyHostClass } from '~/components/chat/markdownEditor/markdownCont
 import { MessageBubble } from '~/components/chat/MessageBubble'
 import * as bubbleStyles from '~/components/chat/MessageBubble.css'
 import { classifyAgentMessage, messageRowChromeClass } from '~/components/chat/messageClassification'
+import { MessageContextMenuHostProvider } from '~/components/chat/MessageContextMenuHost'
 import * as chatStyles from '~/components/chat/messageStyles.css'
 import { toolBodyContent, toolHeaderTimestamp } from '~/components/chat/toolStyles.css'
 import { PreferencesProvider, usePreferences } from '~/context/PreferencesContext'
@@ -1404,5 +1405,159 @@ describe('edit/write tool_use rendering', () => {
     // No diff view should be rendered for empty content without child result
     const diffView = container.querySelector('[data-diff-view]')
     expect(diffView).not.toBeInTheDocument()
+  })
+
+  describe('row context menu', () => {
+    // The jsdom popover stubs come from vitest.setup.ts, which runs before
+    // every test file.
+
+    function renderWithHost(msg: ReturnType<typeof makeMsg>, opts: { premeasureMode?: boolean } = {}) {
+      return render(() => (
+        <PreferencesProvider>
+          <MessageContextMenuHostProvider>
+            <MessageBubble message={msg} onReply={() => {}} premeasureMode={opts.premeasureMode} />
+          </MessageContextMenuHostProvider>
+        </PreferencesProvider>
+      ))
+    }
+
+    function agentMsg() {
+      return makeMsg({
+        source: MessageSource.AGENT,
+        content: rawContent({ type: 'assistant', message: { content: [{ type: 'text', text: 'hello' }] } }),
+      })
+    }
+
+    /** The row element the gesture attaches to. */
+    function rowOf(container: HTMLElement): HTMLElement {
+      return container.querySelector(`.${chatStyles.messageRow}`) as HTMLElement
+    }
+
+    it('opens the same actions the hover toolbar carries', async () => {
+      const { container } = renderWithHost(agentMsg())
+
+      const toolbarIds = [...screen.getByTestId('message-toolbar').querySelectorAll('[data-testid]')]
+        .map(el => el.getAttribute('data-testid')!)
+        .map(id => id.replace('message-', ''))
+
+      rowOf(container).dispatchEvent(
+        new MouseEvent('contextmenu', { clientX: 150, buttons: 0, bubbles: true, cancelable: true }),
+      )
+      await waitFor(() => expect(screen.queryByTestId('message-context-menu')?.querySelector('[data-testid]')).toBeTruthy())
+
+      const menu = screen.getByTestId('message-context-menu')
+      const menuIds = [...menu.querySelectorAll('[data-testid]')]
+        .map(el => el.getAttribute('data-testid')!.replace('message-menu-', ''))
+        // The info block is the menu's form of the toolbar's leading timestamp,
+        // which is a plain element there and carries no test id; asserted below.
+        .filter(id => id !== 'info')
+
+      // The menu is the same set, so a touch user reaches every action the mouse
+      // user reaches on hover. Order is each surface's own concern.
+      expect([...menuIds].sort()).toEqual([...toolbarIds].sort())
+
+      // Both surfaces carry the send time.
+      expect(screen.getByTestId('message-toolbar').querySelector(`.${toolHeaderTimestamp}`)).not.toBeNull()
+      expect(menu.querySelector('[data-testid="message-menu-info"]')).not.toBeNull()
+    })
+
+    it('suppresses the native menu on the row', () => {
+      const { container } = renderWithHost(agentMsg())
+
+      const e = new MouseEvent('contextmenu', { clientX: 150, buttons: 0, bubbles: true, cancelable: true })
+      rowOf(container).dispatchEvent(e)
+
+      expect(e.defaultPrevented).toBe(true)
+    })
+
+    it('arms no gesture on a hidden premeasure copy', () => {
+      const { container } = renderWithHost(agentMsg(), { premeasureMode: true })
+
+      const e = new MouseEvent('contextmenu', { clientX: 150, buttons: 0, bubbles: true, cancelable: true })
+      rowOf(container).dispatchEvent(e)
+
+      expect(e.defaultPrevented).toBe(false)
+    })
+
+    it('carries Retry and Delete for a failed message, but keeps them off the toolbar', async () => {
+      const onRetry = vi.fn()
+      const onDelete = vi.fn()
+      const msg = agentMsg()
+
+      const { container } = render(() => (
+        <PreferencesProvider>
+          <MessageContextMenuHostProvider>
+            <MessageBubble message={msg} onReply={() => {}} error="send failed" onRetry={onRetry} onDelete={onDelete} />
+          </MessageContextMenuHostProvider>
+        </PreferencesProvider>
+      ))
+
+      // The row's own visible buttons are unchanged, and the toolbar did not grow.
+      expect(screen.getByTestId('message-retry-button')).toBeInTheDocument()
+      expect(screen.getByTestId('message-delete-button')).toBeInTheDocument()
+      const toolbar = screen.getByTestId('message-toolbar')
+      expect(toolbar.querySelector('[data-testid="message-menu-retry"]')).toBeNull()
+      expect(toolbar.querySelector('[data-testid="message-menu-delete"]')).toBeNull()
+
+      // Activating an item closes the menu, so each is exercised from its own open.
+      const openMenu = async () => {
+        rowOf(container).dispatchEvent(
+          new MouseEvent('contextmenu', { clientX: 150, buttons: 0, bubbles: true, cancelable: true }),
+        )
+        await waitFor(() => expect(screen.queryByTestId('message-menu-delete')).toBeInTheDocument())
+      }
+
+      await openMenu()
+      fireEvent.click(screen.getByTestId('message-menu-retry'))
+      expect(onRetry).toHaveBeenCalledTimes(1)
+
+      await openMenu()
+      fireEvent.click(screen.getByTestId('message-menu-delete'))
+      expect(onDelete).toHaveBeenCalledTimes(1)
+    })
+
+    it('offers no recovery actions for a message that delivered', async () => {
+      const { container } = renderWithHost(agentMsg())
+
+      rowOf(container).dispatchEvent(
+        new MouseEvent('contextmenu', { clientX: 150, buttons: 0, bubbles: true, cancelable: true }),
+      )
+      await waitFor(() => expect(screen.queryByTestId('message-menu-copy-json')).toBeInTheDocument())
+
+      expect(screen.queryByTestId('message-menu-retry')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('message-menu-delete')).not.toBeInTheDocument()
+    })
+
+    it('opens the menu from the failed-delivery strip, which is a row sibling', async () => {
+      // The strip sits OUTSIDE the row div the gesture normally attaches to, so
+      // it carries the gesture of its own -- a press on the one place a user
+      // most expects Retry and Delete must not fall through to the browser.
+      render(() => (
+        <PreferencesProvider>
+          <MessageContextMenuHostProvider>
+            <MessageBubble message={agentMsg()} onReply={() => {}} error="send failed" onRetry={() => {}} onDelete={() => {}} />
+          </MessageContextMenuHostProvider>
+        </PreferencesProvider>
+      ))
+
+      const e = new MouseEvent('contextmenu', { clientX: 150, buttons: 0, bubbles: true, cancelable: true })
+      screen.getByTestId('message-error').dispatchEvent(e)
+      expect(e.defaultPrevented).toBe(true)
+
+      await waitFor(() => expect(screen.queryByTestId('message-menu-retry')).toBeInTheDocument())
+    })
+
+    it('renders without a host, so a bare bubble is unaffected', () => {
+      const { container } = render(() => (
+        <PreferencesProvider>
+          <MessageBubble message={agentMsg()} onReply={() => {}} />
+        </PreferencesProvider>
+      ))
+
+      const e = new MouseEvent('contextmenu', { clientX: 150, buttons: 0, bubbles: true, cancelable: true })
+      rowOf(container).dispatchEvent(e)
+
+      expect(e.defaultPrevented).toBe(false)
+    })
   })
 })

--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -1,4 +1,5 @@
 import type { Component } from 'solid-js'
+import type { ToolHeaderActionsCallerProps, ToolHeaderActionsLayoutProps } from './messageActions'
 import type { MessageCategory } from './messageClassification'
 import type { MessageRenderCache } from './messageRenderCache'
 import type { MessageUiWriteOptions, RenderContext } from './messageRenderers'
@@ -14,6 +15,7 @@ import Copy from 'lucide-solid/icons/copy'
 import { createEffect, createMemo, createResource, ErrorBoundary, onCleanup, onMount, Show, untrack } from 'solid-js'
 import { render } from 'solid-js/web'
 import { agentProviderLabel } from '~/components/common/AgentProviderIcon'
+import { attachContextMenuGesture } from '~/components/common/contextMenuGesture'
 import { IconButton } from '~/components/common/IconButton'
 import { usePreferences } from '~/context/PreferencesContext'
 import { MessageSource } from '~/generated/leapmux/v1/agent_pb'
@@ -26,15 +28,18 @@ import { formatChatQuote } from '~/lib/quoteUtils'
 import { resolveStack } from '~/lib/resolveStack'
 import { buildRawJsonEnvelope } from './chatRawJson'
 import { codeCopyHostClass } from './markdownEditor/markdownContent.css'
+import { buildMessageActions } from './messageActions'
 import * as styles from './MessageBubble.css'
 import { bubbleRunsToRightEdge, classifyParsedMessage, isMirroredMessageRow, messageBubbleClass, messageRowClass } from './messageClassification'
+import { useMessageContextMenu } from './MessageContextMenuHost'
 import { renderMessageContent } from './messageRenderers'
 import * as chatStyles from './messageStyles.css'
 import { expandedUiKeyFor, MESSAGE_UI_KEY, messageUiDefault } from './messageUiKeys'
 import { renderNotificationThread } from './notificationRenderers'
 import { providerFor } from './providers/registry'
 import { renderResultDivider } from './resultDividerRenderers'
-import { JsonHighlightHtml, ToolHeaderActions } from './toolRenderers'
+import { ToolHeaderActions } from './ToolHeaderActions'
+import { JsonHighlightHtml } from './toolRenderers'
 
 const logger = createLogger('MessageBubble')
 
@@ -475,12 +480,71 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
     })
   })
 
+  // The two action bags, read by the hover toolbar AND by the row's context menu
+  // (below). One definition, so the menu can never offer a different set from the
+  // toolbar -- see `buildMessageActions` in ~/components/chat/messageActions.ts.
+  const actionsCaller = createMemo((): ToolHeaderActionsCallerProps => ({
+    onCopyContent: hasCopyableResult() ? copyResultContent : undefined,
+    contentCopied: resultCopied(),
+    onReply: extractQuotableText() ? (props.premeasureMode ? () => {} : handleReply) : undefined,
+    onCopyMarkdown: extractQuotableText() ? copyMarkdown : undefined,
+    markdownCopied: markdownCopied(),
+  }))
+
+  const actionsLayout = createMemo((): ToolHeaderActionsLayoutProps => ({
+    // A right-aligned user row mirrors its toolbar beside the bubble, so it
+    // reverses the button order -- read from the same predicate that picks the row
+    // class, never re-derived here.
+    mirrored: isMirroredMessageRow(category().kind, props.message.source),
+    createdAt: props.message.createdAt,
+    expanded: toolResultExpanded(),
+    onToggleExpand: isCollapsibleToolResult() ? toggleToolResultExpanded : undefined,
+    onCopyJson: copyJson,
+    jsonCopied: jsonCopied(),
+    hasDiff: hasToolResultDiff(),
+    diffView: diffView(),
+    onToggleDiffView: hasToolResultDiff() ? toggleDiffView : undefined,
+  }))
+
+  // Right-click / long-press anywhere on the row opens the same actions the hover
+  // toolbar carries. Attached here rather than through `DropdownMenu`'s
+  // `contextMenuFor`, because the menu itself is a singleton for the whole list --
+  // see ~/components/chat/MessageContextMenuHost.tsx for why a per-row menu is not
+  // affordable in a virtualized list.
+  const contextMenu = useMessageContextMenu()
+
+  function attachRowMenu(el: HTMLElement) {
+    // The hidden premeasure pass renders a second copy of every unmeasured row. It
+    // is `visibility: hidden` and `pointer-events: none`, so it can never receive
+    // the gesture -- but arming one per copy would still churn listeners on every
+    // fling for nothing.
+    if (!contextMenu || props.premeasureMode)
+      return
+    const detach = attachContextMenuGesture(el, {
+      // Message bodies are prose. Keep them selectable, and let a right-click on a
+      // live selection fall through to the browser's own Copy.
+      selectableText: true,
+      onOpen: press => contextMenu.open({
+        press,
+        // The menu is the ONE surface that also carries the recovery actions: the
+        // failed row renders them as visible buttons, but a user who reached for
+        // the menu should not have to go looking for them somewhere else.
+        actions: buildMessageActions(actionsCaller(), actionsLayout(), props.error
+          ? { onRetry: props.onRetry, onDelete: props.onDelete }
+          : undefined),
+        createdAt: props.message.createdAt,
+      }),
+    })
+    onCleanup(detach)
+  }
+
   return (
     <div
       class={props.error ? styles.messageWithError : undefined}
       style={!props.error ? { display: 'contents' } : undefined}
     >
-      <div class={rowClass()}>
+      {/* eslint-disable-next-line solid/reactivity -- a ref callback, not a signal to read */}
+      <div class={rowClass()} ref={attachRowMenu}>
         <div
           class={bubbleClass()}
           data-testid="message-bubble"
@@ -501,34 +565,17 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
           </div>
         </div>
         <Show when={!hasInternalActions()}>
-          <ToolHeaderActions
-            caller={{
-              onCopyContent: hasCopyableResult() ? copyResultContent : undefined,
-              contentCopied: resultCopied(),
-              onReply: extractQuotableText() ? (props.premeasureMode ? () => {} : handleReply) : undefined,
-              onCopyMarkdown: extractQuotableText() ? copyMarkdown : undefined,
-              markdownCopied: markdownCopied(),
-            }}
-            layout={{
-              // A right-aligned user row mirrors its toolbar beside the bubble,
-              // so it reverses the button order -- read from the same predicate
-              // that picks the row class, never re-derived here.
-              mirrored: isMirroredMessageRow(category().kind, props.message.source),
-              createdAt: props.message.createdAt,
-              expanded: toolResultExpanded(),
-              onToggleExpand: isCollapsibleToolResult() ? toggleToolResultExpanded : undefined,
-              onCopyJson: copyJson,
-              jsonCopied: jsonCopied(),
-              hasDiff: hasToolResultDiff(),
-              diffView: diffView(),
-              onToggleDiffView: hasToolResultDiff() ? toggleDiffView : undefined,
-            }}
-          />
+          <ToolHeaderActions caller={actionsCaller()} layout={actionsLayout()} />
         </Show>
       </div>
 
+      {/* The strip is a SIBLING of the row div, so the row's gesture never sees a
+          press on it. It carries the recovery actions, which the menu also offers,
+          so a press there opens the same menu -- `attachRowMenu` is idempotent
+          about the premeasure/no-host guards and registers its own cleanup. */}
       <Show when={props.error}>
-        <div class={styles.messageError} data-testid="message-error">
+        {/* eslint-disable-next-line solid/reactivity -- a ref callback, not a signal to read */}
+        <div class={styles.messageError} data-testid="message-error" ref={attachRowMenu}>
           <span class={styles.messageErrorText}>Failed to deliver</span>
           <span class={styles.messageErrorDot}>&middot;</span>
           <button class={styles.messageRetryButton} onClick={() => props.onRetry?.()} data-testid="message-retry-button">Retry</button>

--- a/frontend/src/components/chat/MessageContextMenuHost.test.tsx
+++ b/frontend/src/components/chat/MessageContextMenuHost.test.tsx
@@ -1,0 +1,229 @@
+import type { MessageAction } from './messageActions'
+import type { MessageContextMenuHost } from './MessageContextMenuHost'
+import { cleanup, fireEvent, render, screen } from '@solidjs/testing-library'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { MessageContextMenuHostProvider, useMessageContextMenu } from './MessageContextMenuHost'
+
+// The jsdom popover stubs (showPopover/hidePopover/togglePopover plus the
+// `:popover-open` matches interceptor) come from vitest.setup.ts, which runs
+// before every test file.
+
+afterEach(() => cleanup())
+
+function action(id: MessageAction['id'], run = () => {}): MessageAction {
+  return { id, label: id, icon: () => null, run }
+}
+
+function dangerAction(id: MessageAction['id'], run = () => {}): MessageAction {
+  return { ...action(id, run), danger: true }
+}
+
+/** Render the provider and hand back the host a descendant row would get. */
+function renderHost() {
+  const captured: { host?: MessageContextMenuHost } = {}
+
+  function Row() {
+    captured.host = useMessageContextMenu()
+    return <div data-testid="row" />
+  }
+
+  render(() => (
+    <MessageContextMenuHostProvider>
+      <Row />
+    </MessageContextMenuHostProvider>
+  ))
+
+  return captured
+}
+
+describe('messageContextMenuHost', () => {
+  it('provides a host to its descendants', () => {
+    const captured = renderHost()
+    expect(captured.host).toBeDefined()
+  })
+
+  it('returns undefined with no provider, so a bare MessageBubble still renders', () => {
+    const captured: { host?: MessageContextMenuHost } = {}
+
+    function Row() {
+      captured.host = useMessageContextMenu()
+      return <div />
+    }
+
+    render(() => <Row />)
+    expect(captured.host).toBeUndefined()
+  })
+
+  it('mounts no items until a row asks it to open', () => {
+    renderHost()
+    expect(screen.queryByRole('menuitem')).not.toBeInTheDocument()
+  })
+
+  it('renders the actions the requesting row supplied', () => {
+    const captured = renderHost()
+
+    captured.host!.open({
+      press: { clientX: 150, clientY: 60 },
+      actions: [action('copy-json'), action('quote')],
+    })
+
+    expect(screen.getByTestId('message-menu-copy-json')).toBeInTheDocument()
+    expect(screen.getByTestId('message-menu-quote')).toBeInTheDocument()
+    expect(screen.queryByTestId('message-menu-expand')).not.toBeInTheDocument()
+  })
+
+  it('lists the actions in the reverse of the toolbar order', () => {
+    const captured = renderHost()
+
+    captured.host!.open({
+      press: { clientX: 150, clientY: 60 },
+      // The toolbar's own order: broadest copy first, view toggles last.
+      actions: [action('copy-json'), action('copy-markdown'), action('quote'), action('expand')],
+    })
+
+    const ids = [...screen.getByTestId('message-context-menu').querySelectorAll('[data-testid^="message-menu-"]')]
+      .map(el => el.getAttribute('data-testid')!.replace('message-menu-', ''))
+
+    // Read top-down from the cursor, the narrowest and most-used actions come first.
+    expect(ids).toEqual(['expand', 'quote', 'copy-markdown', 'copy-json'])
+  })
+
+  /**
+   * Reversal puts the most-used action directly under the cursor. A destructive
+   * one must never land there.
+   */
+  it('pins a destructive action to the foot, out of the reversal', () => {
+    const captured = renderHost()
+
+    captured.host!.open({
+      press: { clientX: 150, clientY: 60 },
+      actions: [action('copy-json'), action('quote'), action('retry'), dangerAction('delete')],
+    })
+
+    const ids = [...screen.getByTestId('message-context-menu').querySelectorAll('[data-testid^="message-menu-"]')]
+      .map(el => el.getAttribute('data-testid')!.replace('message-menu-', ''))
+
+    expect(ids).toEqual(['retry', 'quote', 'copy-json', 'delete'])
+    // And behind a rule, like every other danger item in the app.
+    expect(screen.getByTestId('message-context-menu').querySelector('hr')).toBeInTheDocument()
+  })
+
+  it('runs a destructive action once when activated', () => {
+    const captured = renderHost()
+    const run = vi.fn()
+
+    captured.host!.open({
+      press: { clientX: 150, clientY: 60 },
+      actions: [action('quote'), dangerAction('delete', run)],
+    })
+    fireEvent.click(screen.getByTestId('message-menu-delete'))
+
+    expect(run).toHaveBeenCalledTimes(1)
+  })
+
+  it('leads with the send time when the message has one', () => {
+    const captured = renderHost()
+
+    captured.host!.open({
+      press: { clientX: 150, clientY: 60 },
+      actions: [action('quote')],
+      createdAt: '2025-01-15T10:00:00.000Z',
+    })
+
+    const info = screen.getByTestId('message-menu-info')
+    expect(info).toHaveTextContent('Sent:')
+    // Ahead of every action, like the worker and file menus' info blocks.
+    expect(info.compareDocumentPosition(screen.getByTestId('message-menu-quote')))
+      .toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+  })
+
+  it('omits the info block when the message carries no timestamp', () => {
+    const captured = renderHost()
+
+    captured.host!.open({ press: { clientX: 150, clientY: 60 }, actions: [action('quote')] })
+
+    expect(screen.queryByTestId('message-menu-info')).not.toBeInTheDocument()
+    // And no orphan separator above the first action.
+    expect(screen.getByTestId('message-context-menu').querySelector('hr')).not.toBeInTheDocument()
+  })
+
+  it('runs an action when its item is activated', () => {
+    const captured = renderHost()
+    const run = vi.fn()
+
+    captured.host!.open({ press: { clientX: 150, clientY: 60 }, actions: [action('quote', run)] })
+    fireEvent.click(screen.getByTestId('message-menu-quote'))
+
+    expect(run).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows the popover at the press point, not at the row it came from', () => {
+    vi.stubGlobal('innerHeight', 800)
+    vi.stubGlobal('innerWidth', 1200)
+    try {
+      const captured = renderHost()
+      const popover = screen.getByTestId('message-context-menu')
+      popover.getBoundingClientRect = () => ({
+        top: 0,
+        bottom: 150,
+        left: 0,
+        right: 200,
+        width: 200,
+        height: 150,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      })
+      const show = vi.spyOn(popover, 'showPopover')
+
+      captured.host!.open({ press: { clientX: 150, clientY: 60 }, actions: [action('quote')] })
+
+      expect(show).toHaveBeenCalled()
+      // A chat row can be hundreds of pixels tall, so the menu must land on the
+      // cursor and not at the row's bottom edge.
+      expect(popover.style.left).toBe('150px')
+      expect(popover.style.top).toBe('60px')
+    }
+    finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('re-anchors in place when a second row opens while the menu is up', () => {
+    vi.stubGlobal('innerHeight', 800)
+    vi.stubGlobal('innerWidth', 1200)
+    try {
+      const captured = renderHost()
+      const popover = screen.getByTestId('message-context-menu')
+      popover.getBoundingClientRect = () => ({
+        top: 0,
+        bottom: 150,
+        left: 0,
+        right: 200,
+        width: 200,
+        height: 150,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      })
+      const hide = vi.spyOn(popover, 'hidePopover')
+
+      captured.host!.open({ press: { clientX: 150, clientY: 60 }, actions: [action('quote')] })
+      expect(popover.style.left).toBe('150px')
+
+      captured.host!.open({ press: { clientX: 300, clientY: 90 }, actions: [action('copy-json')] })
+
+      // No close/reopen pass: the menu stays up, re-anchors to the new press,
+      // and swaps content synchronously. DropdownMenu's open effect tracks the
+      // anchor, so a still-true `open` with a new anchor repositions in place.
+      expect(hide).not.toHaveBeenCalled()
+      expect(popover.style.left).toBe('300px')
+      expect(popover.style.top).toBe('90px')
+      expect(screen.getByTestId('message-menu-copy-json')).toBeInTheDocument()
+      expect(screen.queryByTestId('message-menu-quote')).not.toBeInTheDocument()
+    }
+    finally {
+      vi.unstubAllGlobals()
+    }
+  })
+})

--- a/frontend/src/components/chat/MessageContextMenuHost.tsx
+++ b/frontend/src/components/chat/MessageContextMenuHost.tsx
@@ -1,0 +1,158 @@
+import type { ParentComponent } from 'solid-js'
+import type { MessageAction } from './messageActions'
+import type { ContextMenuPress } from '~/components/common/contextMenuGesture'
+import type { MenuInfoRow } from '~/components/common/MenuInfoRows'
+import type { PopoverAnchor } from '~/lib/popoverPosition'
+import { createSignal, For, Show, useContext } from 'solid-js'
+import { pressAnchorRect } from '~/components/common/contextMenuGesture'
+import { DropdownMenu } from '~/components/common/DropdownMenu'
+import { MenuInfoButton } from '~/components/common/MenuInfoRows'
+import { createStableContext } from '~/lib/createStableContext'
+import { dangerMenuItem } from '~/styles/shared.css'
+import { RelativeTimeAgo } from './RelativeTime'
+
+/** One request from a message row asking the shared menu to open at `press`. */
+export interface MessageContextMenuRequest {
+  press: ContextMenuPress
+  actions: MessageAction[]
+  /** RFC3339 send time, for the info block. Omitted when the message carries none. */
+  createdAt?: string
+}
+
+export interface MessageContextMenuHost {
+  open: (request: MessageContextMenuRequest) => void
+}
+
+const MessageContextMenuContext = createStableContext<MessageContextMenuHost | undefined>(
+  'chat/MessageContextMenuHost',
+  undefined,
+)
+
+/**
+ * Read the host from context. Returns `undefined` when no provider ancestor
+ * exists -- a unit-test render tree that mounts a `MessageBubble` on its own. The
+ * row then simply has no context menu rather than failing to render.
+ */
+export function useMessageContextMenu(): MessageContextMenuHost | undefined {
+  return useContext(MessageContextMenuContext)
+}
+
+/**
+ * Provide ONE shared context menu for every message row beneath it.
+ *
+ * Rationale, the same one recorded on ~/components/shell/GridPopoverHost.tsx:
+ * `DropdownMenu` renders its children into the `popover="auto"` element, hidden
+ * rather than unmounted. The chat list keeps 30-70 `MessageBubble` instances
+ * mounted at once (the overscan band, plus the hidden premeasure copies) and
+ * churns them on every fling, so a menu per row would mean dozens of hidden menus
+ * built and torn down continuously. Routing every row through this singleton means
+ * the items exist exactly once.
+ *
+ * The menu anchors to a RECT, not to an element -- the press point, which
+ * `calcPopoverPosition` accepts directly. No row needs a phantom anchor element,
+ * and a tall row (which a chat message often is) does not drag the menu down to
+ * its own bottom edge.
+ */
+export const MessageContextMenuHostProvider: ParentComponent = (props) => {
+  const [request, setRequest] = createSignal<MessageContextMenuRequest | null>(null)
+
+  const host: MessageContextMenuHost = {
+    // Replacing the request while the menu is up re-anchors it in place:
+    // DropdownMenu's open effect tracks the anchor, so swapping `request()`
+    // under a still-true `open` repositions with no close/reopen pass. (A
+    // pointer-driven open is usually preceded by the browser's own light
+    // dismiss, which closes the previous menu first; the keyboard menu key is
+    // the path that opens over an open menu.)
+    open: (req) => {
+      setRequest(req)
+    },
+  }
+
+  const anchor = (): PopoverAnchor | undefined => {
+    const req = request()
+    return req ? pressAnchorRect(req.press) : undefined
+  }
+
+  const infoRows = (): MenuInfoRow[] => {
+    const createdAt = request()?.createdAt
+    return createdAt ? [{ label: 'Sent:', value: <RelativeTimeAgo timestamp={createdAt} /> }] : []
+  }
+
+  /**
+   * The toolbar's order, reversed.
+   *
+   * The toolbar runs broadest to narrowest -- the whole envelope's raw JSON first,
+   * the rendered content last -- which suits a strip the reader scans. A menu is
+   * read top-down from the pointer, so the same order would put the raw-JSON
+   * debugging copy first and Quote near the bottom. Reversing lands the narrowest,
+   * most-used actions nearest the cursor.
+   */
+  const menuActions = (): MessageAction[] =>
+    [...(request()?.actions ?? []).filter(a => !a.danger)].reverse()
+
+  /**
+   * The destructive actions, kept OUT of the reversal and pinned to the foot of
+   * the menu behind a rule.
+   *
+   * Reversing would otherwise float Delete to the very top, directly under the
+   * cursor the menu just opened at -- the one place a destructive item must never
+   * be. Every other menu in the app puts its danger item last, after an `<hr>`.
+   */
+  const dangerActions = (): MessageAction[] => (request()?.actions ?? []).filter(a => a.danger)
+
+  return (
+    <MessageContextMenuContext.Provider value={host}>
+      {props.children}
+      <DropdownMenu
+        open={() => request() !== null}
+        anchorRef={anchor}
+        data-testid="message-context-menu"
+        aria-label="Message actions"
+        onToggle={(open) => {
+          if (!open)
+            setRequest(null)
+        }}
+      >
+        {/* The same info block the worker and file menus lead with, so a message's
+            send time reads the same way as a file's modified time. It is also the
+            only place the timestamp is reachable without a hover: the toolbar's
+            copy is inside the strip that only appears on one. */}
+        <MenuInfoButton
+          rows={infoRows()}
+          copyText={() => request()?.createdAt ?? ''}
+          toastMessage="Timestamp copied to clipboard"
+          data-testid="message-menu-info"
+        />
+        <Show when={infoRows().length > 0 && menuActions().length > 0}>
+          <hr />
+        </Show>
+        <For each={menuActions()}>
+          {action => (
+            <button
+              role="menuitem"
+              data-testid={`message-menu-${action.id}`}
+              onClick={() => action.run()}
+            >
+              {action.label}
+            </button>
+          )}
+        </For>
+        <Show when={dangerActions().length > 0 && menuActions().length > 0}>
+          <hr />
+        </Show>
+        <For each={dangerActions()}>
+          {action => (
+            <button
+              role="menuitem"
+              class={dangerMenuItem}
+              data-testid={`message-menu-${action.id}`}
+              onClick={() => action.run()}
+            >
+              {action.label}
+            </button>
+          )}
+        </For>
+      </DropdownMenu>
+    </MessageContextMenuContext.Provider>
+  )
+}

--- a/frontend/src/components/chat/ToolHeaderActions.test.tsx
+++ b/frontend/src/components/chat/ToolHeaderActions.test.tsx
@@ -1,0 +1,54 @@
+import { cleanup, render, screen } from '@solidjs/testing-library'
+import { createSignal } from 'solid-js'
+import { afterEach, describe, expect, it } from 'vitest'
+import { ToolHeaderActions } from './ToolHeaderActions'
+
+describe('toolHeaderActions', () => {
+  afterEach(() => cleanup())
+
+  /**
+   * `buildMessageActions` returns fresh objects whenever any input changes, and a
+   * copy flipping to "Copied" is such a change. Rebuilding the elements from that
+   * list would replace the button the user just clicked, taking its focus with it.
+   */
+  it('keeps each button element across a copied-state flip', () => {
+    const [copied, setCopied] = createSignal(false)
+    render(() => (
+      <ToolHeaderActions
+        caller={{ onReply: () => {} }}
+        layout={{ onCopyJson: () => {}, get jsonCopied() { return copied() } }}
+      />
+    ))
+
+    const copyBefore = screen.getByTestId('message-copy-json')
+    const quoteBefore = screen.getByTestId('message-quote')
+    // `IconButton` routes `title` through `<Tooltip ariaLabel>`, so the label
+    // lands on `aria-label` rather than the OS `title` attribute.
+    expect(copyBefore).toHaveAttribute('aria-label', 'Copy Raw JSON')
+
+    setCopied(true)
+
+    // Same nodes, updated in place.
+    expect(screen.getByTestId('message-copy-json')).toBe(copyBefore)
+    expect(screen.getByTestId('message-quote')).toBe(quoteBefore)
+    expect(copyBefore).toHaveAttribute('aria-label', 'Copied')
+  })
+
+  it('adds and removes a button when the row gains or loses that action', () => {
+    const [quotable, setQuotable] = createSignal(false)
+    render(() => (
+      <ToolHeaderActions
+        caller={{ get onReply() { return quotable() ? () => {} : undefined } }}
+        layout={{ onCopyJson: () => {} }}
+      />
+    ))
+
+    expect(screen.queryByTestId('message-quote')).not.toBeInTheDocument()
+
+    setQuotable(true)
+    expect(screen.getByTestId('message-quote')).toBeInTheDocument()
+
+    setQuotable(false)
+    expect(screen.queryByTestId('message-quote')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/chat/ToolHeaderActions.tsx
+++ b/frontend/src/components/chat/ToolHeaderActions.tsx
@@ -1,0 +1,126 @@
+import type { JSX } from 'solid-js'
+import type { MessageAction, MessageActionId, ToolHeaderActionsCallerProps, ToolHeaderActionsLayoutProps } from './messageActions'
+import { createMemo, For, Show } from 'solid-js'
+import { IconButton } from '~/components/common/IconButton'
+import { buildMessageActions, leadingActions, trailingActions } from './messageActions'
+import { RelativeTime } from './RelativeTime'
+import { toolHeaderActions, toolHeaderTimestamp } from './toolStyles.css'
+
+/**
+ * Actions area for a message row or a tool header: timestamp, the copies, Quote,
+ * then the diff and expand toggles -- all with tooltips.
+ *
+ * The buttons come from `buildMessageActions` rather than being written out here,
+ * so the row's context menu (~/components/chat/MessageContextMenuHost.tsx) offers
+ * exactly the same set. Only the ORDER is this component's own.
+ *
+ * The cells render through `<For>` keyed on the action id. `buildMessageActions`
+ * returns fresh objects whenever any input changes -- a copy flipping to its
+ * "Copied" state is such a change -- and `<For>` reuses the mapped element while
+ * the id survives, so the strip updates in place: the icon and title computations
+ * re-run, the `<button>` and its focus stay, and an id that leaves the list
+ * unmounts its cell instead of lingering as a stale read.
+ */
+export function ToolHeaderActions(props: {
+  caller?: ToolHeaderActionsCallerProps
+  layout?: ToolHeaderActionsLayoutProps
+}): JSX.Element {
+  const layout = () => props.layout
+  const actions = createMemo(() => buildMessageActions(props.caller, props.layout))
+
+  /** The cells the leading group renders: the timestamp slot plus the action ids. */
+  type LeadingCell = 'timestamp' | MessageActionId
+
+  /**
+   * The action for `id` as it stands now. Called only for ids the lists below
+   * still carry: `<For>` unmounts a removed action's cell, so no computation
+   * outlives its action.
+   */
+  const liveAction = (id: MessageActionId): MessageAction =>
+    actions().find(a => a.id === id)!
+
+  const timestampEl = (
+    <Show when={layout()?.createdAt}>
+      <RelativeTime
+        timestamp={layout()!.createdAt!}
+        class={toolHeaderTimestamp}
+      />
+    </Show>
+  )
+
+  const cell = (id: LeadingCell): JSX.Element =>
+    id === 'timestamp'
+      ? timestampEl
+      : (
+          <IconButton
+            icon={liveAction(id).icon}
+            size="sm"
+            data-testid={liveAction(id).testId}
+            onClick={(e: MouseEvent) => {
+              const action = liveAction(id)
+              if (action.stopPropagation)
+                e.stopPropagation()
+              action.run()
+            }}
+            title={liveAction(id).label}
+          />
+        )
+
+  /*
+    One order, READ LEFT TO RIGHT ON SCREEN, for every row: timestamp, then the
+    copies from broadest (the whole envelope) to narrowest (the rendered content),
+    then Quote. A tool header and a message row used to disagree here, which put
+    the same two buttons in different places depending on the row above.
+
+    A MIRRORED row (a right-aligned user message) moves Quote only, from last to
+    second, so it still lands nearest the bubble on its right. Everything else
+    keeps its place: timestamp, Quote, JSON, Markdown, Content. `leadingActions`
+    owns both orders.
+
+    A mirrored row's SOURCE order is not its render order. That toolbar is a
+    two-column `direction: rtl` grid (see `messageRowEnd > toolHeaderActions` in
+    ~/components/chat/messageStyles.css.ts), so the FIRST item of each pair lands
+    in the RIGHT cell:
+
+      source [Quote, timestamp]  renders  timestamp  Quote
+      source [Markdown, JSON]    renders  JSON       Markdown
+      source [Content]           renders             Content
+
+    `swapPairs` below derives that source order from the screen order, so the two
+    arms cannot drift apart the way two hand-written lists could. `<For>` then
+    reorders the SAME elements into that order, keeping each button's node (and
+    focus) through the flip.
+  */
+  const leadingCells = createMemo((): LeadingCell[] => {
+    const mirrored = layout()?.mirrored === true
+    // `timestampEl` holds its cell whether or not it renders anything: it is one
+    // item of the mirrored grid's pairing, and dropping it for a message with no
+    // `createdAt` would re-pair every button after it.
+    const screen: LeadingCell[] = [
+      'timestamp',
+      ...leadingActions(actions(), mirrored).map(action => action.id),
+    ]
+    return mirrored ? swapPairs(screen) : screen
+  })
+
+  const trailingCells = createMemo(() => trailingActions(actions()).map(action => action.id))
+
+  return (
+    <div class={toolHeaderActions} data-testid="message-toolbar">
+      <For each={leadingCells()}>{cell}</For>
+      <For each={trailingCells()}>{cell}</For>
+    </div>
+  )
+}
+
+/**
+ * Swap each adjacent pair, leaving a trailing odd item in place. Turns a
+ * left-to-right screen order into the source order a two-column `direction: rtl`
+ * grid needs, because that grid puts the first item of each pair in the right cell.
+ */
+function swapPairs<T>(items: T[]): T[] {
+  const out = items.slice()
+  for (let i = 0; i + 1 < out.length; i += 2)
+    [out[i], out[i + 1]] = [out[i + 1], out[i]]
+  return out
+}

--- a/frontend/src/components/chat/messageActions.test.tsx
+++ b/frontend/src/components/chat/messageActions.test.tsx
@@ -1,0 +1,190 @@
+import type { ToolHeaderActionsCallerProps, ToolHeaderActionsLayoutProps } from './messageActions'
+import { describe, expect, it, vi } from 'vitest'
+import { buildMessageActions, leadingActions, trailingActions } from './messageActions'
+
+function ids(caller?: ToolHeaderActionsCallerProps, layout?: ToolHeaderActionsLayoutProps) {
+  return buildMessageActions(caller, layout).map(a => a.id)
+}
+
+describe('buildMessageActions', () => {
+  it('offers nothing for a row with no actions', () => {
+    expect(ids()).toEqual([])
+    expect(ids({}, {})).toEqual([])
+  })
+
+  it('offers only the JSON copy for a plain message', () => {
+    expect(ids({}, { onCopyJson: () => {} })).toEqual(['copy-json'])
+  })
+
+  it('adds the quotable pair when the provider extracted text', () => {
+    expect(ids(
+      { onCopyMarkdown: () => {}, onReply: () => {} },
+      { onCopyJson: () => {} },
+    )).toEqual(['copy-json', 'copy-markdown', 'quote'])
+  })
+
+  it('adds the tool-result actions the provider metadata gates', () => {
+    expect(ids(
+      { onCopyContent: () => {} },
+      { onCopyJson: () => {}, hasDiff: true, onToggleDiffView: () => {}, onToggleExpand: () => {} },
+    )).toEqual(['copy-json', 'copy-content', 'diff-view', 'expand'])
+  })
+
+  it('withholds the diff toggle when the result has no diff', () => {
+    // `hasDiff` and the handler are separate gates, and both must hold.
+    expect(ids({}, { onToggleDiffView: () => {} })).toEqual([])
+    expect(ids({}, { hasDiff: true })).toEqual([])
+  })
+
+  it('labels each copy for its own scope', () => {
+    const actions = buildMessageActions(
+      { onCopyMarkdown: () => {}, onCopyContent: () => {}, copyContentLabel: 'Copy Command' },
+      { onCopyJson: () => {} },
+    )
+    expect(actions.map(a => a.label)).toEqual(['Copy Raw JSON', 'Copy Markdown', 'Copy Command'])
+  })
+
+  it('falls back to a bare Copy when the renderer named no content label', () => {
+    const [action] = buildMessageActions({ onCopyContent: () => {} }, {})
+    expect(action.label).toBe('Copy')
+  })
+
+  it('reports the copied state in the label', () => {
+    const actions = buildMessageActions(
+      { onCopyMarkdown: () => {}, markdownCopied: true },
+      { onCopyJson: () => {}, jsonCopied: true },
+    )
+    expect(actions.map(a => a.label)).toEqual(['Copied', 'Copied'])
+  })
+
+  it('names the toggles by what they will do, not by the current state', () => {
+    const unified = buildMessageActions({}, {
+      hasDiff: true,
+      diffView: 'unified',
+      onToggleDiffView: () => {},
+      expanded: false,
+      onToggleExpand: () => {},
+    })
+    expect(unified.map(a => a.label)).toEqual(['Switch to split view', 'Expand'])
+
+    const split = buildMessageActions({}, {
+      hasDiff: true,
+      diffView: 'split',
+      onToggleDiffView: () => {},
+      expanded: true,
+      onToggleExpand: () => {},
+    })
+    expect(split.map(a => a.label)).toEqual(['Switch to unified view', 'Collapse'])
+  })
+
+  it('uses the renderer expand label when the row supplies one', () => {
+    const [action] = buildMessageActions({}, { onToggleExpand: () => {}, expandLabel: 'Show 40 more lines' })
+    expect(action.label).toBe('Show 40 more lines')
+  })
+
+  it('runs the handler the caller supplied', () => {
+    const onReply = vi.fn()
+    const [action] = buildMessageActions({ onReply }, {})
+    action.run()
+    expect(onReply).toHaveBeenCalledTimes(1)
+  })
+
+  // The expand toggle sits inside a header that is itself click-to-expand.
+  it('marks only the expand toggle as needing the event stopped', () => {
+    const actions = buildMessageActions(
+      { onReply: () => {} },
+      { onCopyJson: () => {}, onToggleExpand: () => {} },
+    )
+    expect(actions.filter(a => a.stopPropagation).map(a => a.id)).toEqual(['expand'])
+  })
+})
+
+describe('leadingActions', () => {
+  const all = () => buildMessageActions(
+    { onCopyMarkdown: () => {}, onCopyContent: () => {}, onReply: () => {} },
+    { onCopyJson: () => {}, hasDiff: true, onToggleDiffView: () => {}, onToggleExpand: () => {} },
+  )
+
+  it('reads copies-then-quote on an ordinary row', () => {
+    expect(leadingActions(all(), false).map(a => a.id))
+      .toEqual(['copy-json', 'copy-markdown', 'copy-content', 'quote'])
+  })
+
+  it('moves quote to second on a mirrored row so it lands nearest the bubble', () => {
+    expect(leadingActions(all(), true).map(a => a.id))
+      .toEqual(['quote', 'copy-json', 'copy-markdown', 'copy-content'])
+  })
+
+  it('skips an action the row does not offer, in both orders', () => {
+    const some = buildMessageActions({ onReply: () => {} }, { onCopyJson: () => {} })
+    expect(leadingActions(some, false).map(a => a.id)).toEqual(['copy-json', 'quote'])
+    expect(leadingActions(some, true).map(a => a.id)).toEqual(['quote', 'copy-json'])
+  })
+
+  it('never includes a trailing toggle', () => {
+    expect(leadingActions(all(), false).map(a => a.id)).not.toContain('expand')
+    expect(leadingActions(all(), false).map(a => a.id)).not.toContain('diff-view')
+  })
+})
+
+describe('error recovery actions', () => {
+  const errored = () => buildMessageActions(
+    { onReply: () => {} },
+    { onCopyJson: () => {} },
+    { onRetry: () => {}, onDelete: () => {} },
+  )
+
+  it('appends retry and delete last', () => {
+    expect(errored().map(a => a.id)).toEqual(['copy-json', 'quote', 'retry', 'delete'])
+  })
+
+  it('marks only delete destructive', () => {
+    expect(errored().filter(a => a.danger).map(a => a.id)).toEqual(['delete'])
+  })
+
+  it('offers neither for a message that delivered', () => {
+    expect(buildMessageActions({}, { onCopyJson: () => {} }).map(a => a.id)).toEqual(['copy-json'])
+  })
+
+  it('offers each independently', () => {
+    expect(buildMessageActions({}, {}, { onRetry: () => {} }).map(a => a.id)).toEqual(['retry'])
+    expect(buildMessageActions({}, {}, { onDelete: () => {} }).map(a => a.id)).toEqual(['delete'])
+  })
+
+  it('runs the handler the row supplied', () => {
+    const onRetry = vi.fn()
+    const [action] = buildMessageActions({}, {}, { onRetry })
+    action.run()
+    expect(onRetry).toHaveBeenCalledTimes(1)
+  })
+
+  /**
+   * The toolbar picks its buttons by explicit id list, so a recovery action can
+   * never reach it -- the failed row already renders Retry and Delete as visible
+   * buttons directly beside the toolbar, and a second copy would be noise.
+   */
+  it('stays out of both toolbar groups', () => {
+    const ids = [
+      ...leadingActions(errored(), false).map(a => a.id),
+      ...leadingActions(errored(), true).map(a => a.id),
+      ...trailingActions(errored()).map(a => a.id),
+    ]
+    expect(ids).not.toContain('retry')
+    expect(ids).not.toContain('delete')
+  })
+})
+
+describe('trailingActions', () => {
+  it('keeps the view toggles in a fixed order', () => {
+    const actions = buildMessageActions({}, {
+      hasDiff: true,
+      onToggleDiffView: () => {},
+      onToggleExpand: () => {},
+    })
+    expect(trailingActions(actions).map(a => a.id)).toEqual(['diff-view', 'expand'])
+  })
+
+  it('is empty when the row has neither toggle', () => {
+    expect(trailingActions(buildMessageActions({}, { onCopyJson: () => {} }))).toEqual([])
+  })
+})

--- a/frontend/src/components/chat/messageActions.ts
+++ b/frontend/src/components/chat/messageActions.ts
@@ -1,0 +1,237 @@
+import type { Component } from 'solid-js'
+import type { DiffViewPreference } from '~/context/PreferencesContext'
+import Braces from 'lucide-solid/icons/braces'
+import Check from 'lucide-solid/icons/check'
+import Columns2 from 'lucide-solid/icons/columns-2'
+import Copy from 'lucide-solid/icons/copy'
+import FoldVertical from 'lucide-solid/icons/fold-vertical'
+import Quote from 'lucide-solid/icons/quote'
+import RotateCcw from 'lucide-solid/icons/rotate-ccw'
+import Rows2 from 'lucide-solid/icons/rows-2'
+import Trash2 from 'lucide-solid/icons/trash-2'
+import UnfoldVertical from 'lucide-solid/icons/unfold-vertical'
+
+/**
+ * Caller-controlled buttons for a message row's actions. These are the subset
+ * whose source is the *renderer* (e.g. an Edit tool's "Copy diff", a markdown
+ * tool's "Copy markdown", a reply quote callback).
+ *
+ * `ToolUseLayout` re-exposes this bag verbatim as `headerActions=`.
+ */
+export interface ToolHeaderActionsCallerProps {
+  onCopyContent?: () => void
+  contentCopied?: boolean
+  copyContentLabel?: string
+  onReply?: () => void
+  onCopyMarkdown?: () => void
+  markdownCopied?: boolean
+}
+
+/**
+ * Layout-controlled state for a message row's actions. These come from the
+ * wrapping layout/bubble (timestamp, expand state, JSON copy, diff-view toggle),
+ * not the per-renderer caller.
+ */
+export interface ToolHeaderActionsLayoutProps {
+  createdAt?: string
+  expanded?: boolean
+  onToggleExpand?: () => void
+  expandLabel?: string
+  onCopyJson?: () => void
+  jsonCopied?: boolean
+  hasDiff?: boolean
+  diffView?: DiffViewPreference
+  onToggleDiffView?: () => void
+  /**
+   * The row mirrors its toolbar beside a right-aligned bubble (a user message --
+   * see isMirroredMessageRow). Such a row reverses the button order so Quote
+   * still lands nearest the bubble; every other row leads with the timestamp.
+   */
+  mirrored?: boolean
+}
+
+/**
+ * The recovery actions an undelivered message offers. Passed only by the row's
+ * CONTEXT MENU, never by the toolbar: the failed row already renders Retry and
+ * Delete as visible buttons of its own, and the toolbar sits right beside them.
+ */
+export interface MessageErrorActions {
+  onRetry?: () => void
+  onDelete?: () => void
+}
+
+export type MessageActionId
+  = | 'copy-json'
+    | 'copy-markdown'
+    | 'copy-content'
+    | 'quote'
+    | 'diff-view'
+    | 'expand'
+    | 'retry'
+    | 'delete'
+
+export interface MessageAction {
+  id: MessageActionId
+  /** The tooltip on the toolbar button, and the item text in the menu. */
+  label: string
+  icon: Component<{ size?: number | string, class?: string }>
+  /** data-testid for the toolbar button. The menu derives its own from `id`. */
+  testId?: string
+  /**
+   * Destructive. The menu pins these to its foot behind a rule instead of letting
+   * its reversal float them under the cursor; see `dangerActions` in
+   * ~/components/chat/MessageContextMenuHost.tsx.
+   */
+  danger?: boolean
+  /**
+   * Stop the event before running. The expand toggle sits inside a tool header
+   * that is itself click-to-expand, so its own click must not also reach it.
+   */
+  stopPropagation?: boolean
+  run: () => void
+}
+
+/**
+ * Every action a message row offers, in one canonical order.
+ *
+ * One list with two presentations: `ToolHeaderActions` renders it as the
+ * hover-revealed button strip, and `MessageContextMenu` renders it as menu items.
+ * The list is what stops them drifting -- and it is why the diff-view and expand
+ * toggles stop being mouse-only, which is the same gap this whole feature exists
+ * to close.
+ *
+ * The order is broadest copy to narrowest (whole envelope, rendered markdown, tool
+ * content), then Quote, then the view toggles. The toolbar reorders it for a
+ * mirrored row; see the grid note there.
+ *
+ * Provider-specific extraction stays where it belongs: `onCopyMarkdown`/`onReply`
+ * come from `plugin.extractQuotableText` and `onCopyContent` from
+ * `plugin.toolResultMeta().copyableContent`, both resolved by `MessageBubble`
+ * before they reach this function. Nothing here parses a provider's shapes.
+ */
+export function buildMessageActions(
+  caller: ToolHeaderActionsCallerProps | undefined,
+  layout: ToolHeaderActionsLayoutProps | undefined,
+  error?: MessageErrorActions,
+): MessageAction[] {
+  const actions: MessageAction[] = []
+
+  if (layout?.onCopyJson) {
+    actions.push({
+      id: 'copy-json',
+      label: layout.jsonCopied ? 'Copied' : 'Copy Raw JSON',
+      icon: layout.jsonCopied ? Check : Braces,
+      testId: 'message-copy-json',
+      run: layout.onCopyJson,
+    })
+  }
+
+  if (caller?.onCopyMarkdown) {
+    actions.push({
+      id: 'copy-markdown',
+      label: caller.markdownCopied ? 'Copied' : 'Copy Markdown',
+      icon: caller.markdownCopied ? Check : Copy,
+      testId: 'message-copy-markdown',
+      run: caller.onCopyMarkdown,
+    })
+  }
+
+  if (caller?.onCopyContent) {
+    actions.push({
+      id: 'copy-content',
+      label: caller.contentCopied ? 'Copied' : (caller.copyContentLabel || 'Copy'),
+      icon: caller.contentCopied ? Check : Copy,
+      run: caller.onCopyContent,
+    })
+  }
+
+  if (caller?.onReply) {
+    actions.push({
+      id: 'quote',
+      label: 'Quote',
+      icon: Quote,
+      testId: 'message-quote',
+      run: caller.onReply,
+    })
+  }
+
+  if (layout?.hasDiff && layout.onToggleDiffView) {
+    const unified = layout.diffView === 'unified'
+    actions.push({
+      id: 'diff-view',
+      label: unified ? 'Switch to split view' : 'Switch to unified view',
+      icon: unified ? Columns2 : Rows2,
+      run: layout.onToggleDiffView,
+    })
+  }
+
+  if (layout?.onToggleExpand) {
+    actions.push({
+      id: 'expand',
+      label: layout.expanded ? 'Collapse' : (layout.expandLabel || 'Expand'),
+      icon: layout.expanded ? FoldVertical : UnfoldVertical,
+      stopPropagation: true,
+      run: layout.onToggleExpand,
+    })
+  }
+
+  // Last, and outside both `leadingActions` and `trailingActions` -- so even if a
+  // caller did pass `error` to the toolbar, the toolbar would not render them.
+  if (error?.onRetry) {
+    actions.push({
+      id: 'retry',
+      label: 'Retry',
+      icon: RotateCcw,
+      run: error.onRetry,
+    })
+  }
+
+  if (error?.onDelete) {
+    actions.push({
+      id: 'delete',
+      label: 'Delete',
+      icon: Trash2,
+      danger: true,
+      run: error.onDelete,
+    })
+  }
+
+  return actions
+}
+
+/**
+ * The action ids of the toolbar's leading group, in the order they appear ON
+ * SCREEN, for the two row flavors.
+ *
+ * A mirrored row moves Quote only, from last to second, so it lands nearest the
+ * bubble on its right. Everything else keeps its place. The trailing view toggles
+ * (`diff-view`, `expand`) sit outside this group and never move.
+ */
+const SCREEN_ORDER: Record<'mirrored' | 'normal', MessageActionId[]> = {
+  normal: ['copy-json', 'copy-markdown', 'copy-content', 'quote'],
+  mirrored: ['quote', 'copy-json', 'copy-markdown', 'copy-content'],
+}
+
+/** The ids the trailing group renders, always after the leading one. */
+const TRAILING_ACTION_IDS: MessageActionId[] = ['diff-view', 'expand']
+
+/**
+ * The leading group's actions for a row, ordered as they should READ ON SCREEN --
+ * the timestamp notionally first, then these.
+ *
+ * The caller is responsible for turning this into source order, which for a
+ * mirrored row is not the same thing; see `ToolHeaderActions`.
+ */
+export function leadingActions(actions: MessageAction[], mirrored: boolean): MessageAction[] {
+  const order = SCREEN_ORDER[mirrored ? 'mirrored' : 'normal']
+  return order
+    .map(id => actions.find(a => a.id === id))
+    .filter((a): a is MessageAction => a !== undefined)
+}
+
+/** The trailing view toggles for a row, in order. */
+export function trailingActions(actions: MessageAction[]): MessageAction[] {
+  return TRAILING_ACTION_IDS
+    .map(id => actions.find(a => a.id === id))
+    .filter((a): a is MessageAction => a !== undefined)
+}

--- a/frontend/src/components/chat/toolRenderers.tsx
+++ b/frontend/src/components/chat/toolRenderers.tsx
@@ -1,41 +1,32 @@
 import type { LucideIcon } from 'lucide-solid'
 import type { JSX } from 'solid-js'
+import type { ToolHeaderActionsCallerProps } from './messageActions'
 import type { RenderContext } from './messageRenderers'
 import type { CommandResultSource } from './results/commandResult'
 import type { FileEditDiffSource } from './results/fileEditDiff'
 import type { TokenGate } from './useAsyncCodeTokens'
 import type { DiffViewPreference } from '~/context/PreferencesContext'
 import type { CachedToken } from '~/lib/tokenCache'
-import Braces from 'lucide-solid/icons/braces'
 import Check from 'lucide-solid/icons/check'
 import CircleAlert from 'lucide-solid/icons/circle-alert'
-import Columns2 from 'lucide-solid/icons/columns-2'
-import Copy from 'lucide-solid/icons/copy'
-import FoldVertical from 'lucide-solid/icons/fold-vertical'
 import ListTodo from 'lucide-solid/icons/list-todo'
-import Quote from 'lucide-solid/icons/quote'
-import Rows2 from 'lucide-solid/icons/rows-2'
-import UnfoldVertical from 'lucide-solid/icons/unfold-vertical'
 import { createMemo, For, Show } from 'solid-js'
 import { Alert } from '~/components/common/Alert'
 import { Icon } from '~/components/common/Icon'
-import { IconButton } from '~/components/common/IconButton'
 import { Tooltip } from '~/components/common/Tooltip'
 import { stripLeadingBlankLines } from '~/lib/normalizeProgressOutput'
 import { inlineFlex } from '~/styles/shared.css'
 import { getToolResultExpanded, shouldPauseSyntaxHighlighting } from './messageRenderers'
-import { RelativeTime } from './RelativeTime'
 import { canHighlightBySize, COLLAPSED_RESULT_ROWS } from './results/collapse'
 import { CollapsibleContent } from './results/CollapsibleContent'
 import { CommandResultBody } from './results/commandResult'
 import { FileEditDiffBody, fileEditHasDiff } from './results/fileEditDiff'
 import { parseReadContent, ReadResultView } from './results/ReadResultView'
 import { useCollapsedLines } from './results/useCollapsedLines'
+import { ToolHeaderActions } from './ToolHeaderActions'
 import {
   toolBodyBorder,
   toolBodyContent,
-  toolHeaderActions,
-  toolHeaderTimestamp,
   toolInputText,
   toolMessage,
   toolResultCollapsed,
@@ -159,176 +150,6 @@ export function ToolUseLayout(props: {
             {props.children}
           </Show>
         </div>
-      </Show>
-    </div>
-  )
-}
-
-/**
- * Caller-controlled buttons forwarded into `ToolHeaderActions`. These are
- * the subset of actions whose source is the *renderer* (e.g. an Edit tool's
- * "Copy diff", a markdown tool's "Copy markdown", a reply quote callback).
- *
- * `ToolUseLayout` re-exposes this bag verbatim as `headerActions=`.
- */
-export interface ToolHeaderActionsCallerProps {
-  onCopyContent?: () => void
-  contentCopied?: boolean
-  copyContentLabel?: string
-  onReply?: () => void
-  onCopyMarkdown?: () => void
-  markdownCopied?: boolean
-}
-
-/**
- * Layout-controlled state forwarded into `ToolHeaderActions`. These come
- * from the wrapping layout/bubble (timestamp, expand state, JSON copy,
- * diff-view toggle), not the per-renderer caller.
- */
-export interface ToolHeaderActionsLayoutProps {
-  createdAt?: string
-  expanded?: boolean
-  onToggleExpand?: () => void
-  expandLabel?: string
-  onCopyJson?: () => void
-  jsonCopied?: boolean
-  hasDiff?: boolean
-  diffView?: DiffViewPreference
-  onToggleDiffView?: () => void
-  /**
-   * The row mirrors its toolbar beside a right-aligned bubble (a user message --
-   * see isMirroredMessageRow). Such a row reverses the button order so Quote
-   * still lands nearest the bubble; every other row leads with the timestamp.
-   */
-  mirrored?: boolean
-}
-
-/**
- * Actions area for a message row or a tool header: timestamp, the copies, Quote,
- * then the diff and expand toggles -- all with tooltips.
- */
-export function ToolHeaderActions(props: {
-  caller?: ToolHeaderActionsCallerProps
-  layout?: ToolHeaderActionsLayoutProps
-}): JSX.Element {
-  const caller = () => props.caller
-  const layout = () => props.layout
-
-  const replyButton = (
-    <Show when={caller()?.onReply}>
-      <IconButton
-        icon={Quote}
-        size="sm"
-        data-testid="message-quote"
-        onClick={() => caller()?.onReply?.()}
-        title="Quote"
-      />
-    </Show>
-  )
-  const timestampEl = (
-    <Show when={layout()?.createdAt}>
-      <RelativeTime
-        timestamp={layout()!.createdAt!}
-        class={toolHeaderTimestamp}
-      />
-    </Show>
-  )
-  const copyJsonButton = (
-    <Show when={layout()?.onCopyJson}>
-      <IconButton
-        icon={layout()?.jsonCopied ? Check : Braces}
-        size="sm"
-        data-testid="message-copy-json"
-        onClick={() => layout()?.onCopyJson?.()}
-        title={layout()?.jsonCopied ? 'Copied' : 'Copy Raw JSON'}
-      />
-    </Show>
-  )
-  const copyMarkdownButton = (
-    <Show when={caller()?.onCopyMarkdown}>
-      <IconButton
-        icon={caller()?.markdownCopied ? Check : Copy}
-        size="sm"
-        data-testid="message-copy-markdown"
-        onClick={() => caller()?.onCopyMarkdown?.()}
-        title={caller()?.markdownCopied ? 'Copied' : 'Copy Markdown'}
-      />
-    </Show>
-  )
-  const copyContentButton = (
-    <Show when={caller()?.onCopyContent}>
-      <IconButton
-        icon={caller()?.contentCopied ? Check : Copy}
-        size="sm"
-        onClick={() => caller()?.onCopyContent?.()}
-        title={caller()?.contentCopied ? 'Copied' : (caller()?.copyContentLabel || 'Copy')}
-      />
-    </Show>
-  )
-
-  return (
-    <div class={toolHeaderActions} data-testid="message-toolbar">
-      {/*
-        One order, READ LEFT TO RIGHT ON SCREEN, for every row: timestamp, then
-        the copies from broadest (the whole envelope) to narrowest (the rendered
-        content), then Quote. A tool header and a message row used to disagree
-        here, which put the same two buttons in different places depending on the
-        row above.
-
-        A MIRRORED row (a right-aligned user message) moves Quote only, from last
-        to second, so it still lands nearest the bubble on its right. Everything
-        else keeps its place: timestamp, Quote, JSON, Markdown, Content.
-
-        Its source order looks scrambled because it is NOT the render order. That
-        toolbar is a two-column `direction: rtl` grid (see `messageRowEnd >
-        toolHeaderActions` in ~/components/chat/messageStyles.css.ts), so the
-        FIRST item of each pair lands in the RIGHT cell:
-
-          source [Quote, timestamp]  renders  timestamp  Quote
-          source [Markdown, JSON]    renders  JSON       Markdown
-          source [Content]           renders             Content
-
-        Reading those rows left to right gives the one order above. The two arms
-        must therefore stay pairwise-swapped against each other; writing them the
-        "same" way is what would break them apart.
-      */}
-      {layout()?.mirrored
-        ? (
-            <>
-              {replyButton}
-              {timestampEl}
-              {copyMarkdownButton}
-              {copyJsonButton}
-              {copyContentButton}
-            </>
-          )
-        : (
-            <>
-              {timestampEl}
-              {copyJsonButton}
-              {copyMarkdownButton}
-              {copyContentButton}
-              {replyButton}
-            </>
-          )}
-      <Show when={layout()?.hasDiff && layout()?.onToggleDiffView}>
-        <IconButton
-          icon={layout()?.diffView === 'unified' ? Columns2 : Rows2}
-          size="sm"
-          onClick={() => layout()!.onToggleDiffView!()}
-          title={layout()?.diffView === 'unified' ? 'Switch to split view' : 'Switch to unified view'}
-        />
-      </Show>
-      <Show when={layout()?.onToggleExpand}>
-        <IconButton
-          icon={layout()?.expanded ? FoldVertical : UnfoldVertical}
-          size="sm"
-          onClick={(e: MouseEvent) => {
-            e.stopPropagation()
-            layout()!.onToggleExpand!()
-          }}
-          title={layout()?.expanded ? 'Collapse' : (layout()?.expandLabel || 'Expand')}
-        />
       </Show>
     </div>
   )

--- a/frontend/src/components/common/DropdownMenu.test.tsx
+++ b/frontend/src/components/common/DropdownMenu.test.tsx
@@ -1,22 +1,12 @@
 /// <reference types="vitest/globals" />
-import { fireEvent, render, screen } from '@solidjs/testing-library'
+import { cleanup, fireEvent, render, screen } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
 import { popoverCard } from '~/styles/popover.css'
 import { DropdownMenu, DropdownMenuCheckableItem, DropdownMenuItemContent } from './DropdownMenu'
 
-// jsdom does not implement the native Popover API.
-// Stub the methods so the component can render without errors.
-beforeAll(() => {
-  if (!HTMLElement.prototype.showPopover) {
-    HTMLElement.prototype.showPopover = vi.fn()
-  }
-  if (!HTMLElement.prototype.hidePopover) {
-    HTMLElement.prototype.hidePopover = vi.fn()
-  }
-  if (!HTMLElement.prototype.togglePopover) {
-    HTMLElement.prototype.togglePopover = vi.fn()
-  }
-})
+// The jsdom popover stubs (showPopover/hidePopover/togglePopover plus the
+// `:popover-open` matches interceptor) come from vitest.setup.ts, which runs
+// before every test file.
 
 describe('dropdownMenu', () => {
   it('renders trailing shortcut text in menu item content', () => {
@@ -425,6 +415,182 @@ describe('dropdownMenu content-click dismiss', () => {
     await fireEvent.click(screen.getByTestId('content-menu-trigger'))
     await fireEvent.click(screen.getByTestId('content-menu-item'))
     expect(hide).toHaveBeenCalled()
+  })
+})
+
+describe('dropdownMenu contextMenuFor', () => {
+  /**
+   * Render a row plus a menu whose `contextMenuFor` points at it. The row gets a
+   * stubbed rect because jsdom does no layout and the press anchor is built from
+   * the row's vertical band.
+   */
+  function renderRowMenu() {
+    let rowEl!: HTMLDivElement
+
+    render(() => (
+      <>
+        <div ref={rowEl} data-testid="row" onClick={() => {}}>row</div>
+        <DropdownMenu
+          id="row-menu"
+          data-testid="row-menu-popover"
+          contextMenuFor={() => rowEl}
+          trigger={triggerProps => <button data-testid="row-kebab" {...triggerProps}>Open</button>}
+        >
+          <button role="menuitem" data-testid="row-menu-item">Rename</button>
+        </DropdownMenu>
+      </>
+    ))
+
+    const row = screen.getByTestId('row')
+    row.getBoundingClientRect = () => ({
+      top: 100,
+      bottom: 122,
+      left: 40,
+      right: 240,
+      width: 200,
+      height: 22,
+      x: 40,
+      y: 100,
+      toJSON: () => ({}),
+    })
+
+    const popover = screen.getByTestId('row-menu-popover')
+    popover.getBoundingClientRect = () => ({
+      top: 0,
+      bottom: 150,
+      left: 0,
+      right: 200,
+      width: 200,
+      height: 150,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    })
+
+    return { row, popover }
+  }
+
+  it('opens the menu on right-click', async () => {
+    vi.useFakeTimers()
+    try {
+      const { row, popover } = renderRowMenu()
+      const show = vi.spyOn(popover, 'showPopover')
+
+      row.dispatchEvent(new MouseEvent('contextmenu', { clientX: 150, bubbles: true, cancelable: true }))
+      vi.runAllTimers()
+
+      expect(show).toHaveBeenCalled()
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('anchors the menu at the cursor, not at the row', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('innerHeight', 800)
+    vi.stubGlobal('innerWidth', 1200)
+    try {
+      const { row, popover } = renderRowMenu()
+
+      row.dispatchEvent(new MouseEvent('contextmenu', { clientX: 150, clientY: 108, bubbles: true, cancelable: true }))
+      vi.runAllTimers()
+
+      expect(popover.style.left).toBe('150px') // the click x, not the row's left edge
+      expect(popover.style.top).toBe('108px') // the click y, not the row's bottom
+    }
+    finally {
+      vi.unstubAllGlobals()
+      vi.useRealTimers()
+    }
+  })
+
+  it('suppresses the native menu on the row', () => {
+    const { row } = renderRowMenu()
+
+    const e = new MouseEvent('contextmenu', { clientX: 150, bubbles: true, cancelable: true })
+    row.dispatchEvent(e)
+
+    expect(e.defaultPrevented).toBe(true)
+  })
+
+  it('hides a press-anchored menu when anything else scrolls', () => {
+    vi.useFakeTimers()
+    try {
+      const { row, popover } = renderRowMenu()
+      const hide = vi.spyOn(popover, 'hidePopover')
+
+      row.dispatchEvent(new MouseEvent('contextmenu', { clientX: 150, bubbles: true, cancelable: true }))
+      vi.runAllTimers()
+      expect(popover.matches(':popover-open')).toBe(true)
+
+      // A press anchor is a frozen point, not an element to follow: the row it
+      // pointed at has scrolled away, so the menu closes instead of floating
+      // over whatever took its place. Element-anchored menus keep repositioning.
+      document.dispatchEvent(new Event('scroll'))
+
+      expect(hide).toHaveBeenCalled()
+      expect(popover.matches(':popover-open')).toBe(false)
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('attaches nothing when the accessor has no element yet', () => {
+    // A row whose ref has not resolved must not throw or bind to anything.
+    expect(() =>
+      render(() => (
+        <DropdownMenu id="empty-menu" contextMenuFor={() => undefined}>
+          <button role="menuitem">Item</button>
+        </DropdownMenu>
+      )),
+    ).not.toThrow()
+  })
+
+  /**
+   * A trigger-less dropdown holds nothing but its `position: fixed` popover, and
+   * `ot-dropdown` defaults to `display: inline`. Inside a flex row that empty
+   * inline box is still a flex ITEM, adding one `gap` of dead space to every row
+   * that mounts such a menu -- which is every tab row. The attribute is what the
+   * `display: contents` rule in ~/styles/popover.css.ts keys on.
+   */
+  it('marks a trigger-less host headless so it takes no room in the row', () => {
+    const { container } = render(() => (
+      <DropdownMenu id="headless-menu" contextMenuFor={() => undefined}>
+        <button role="menuitem">Item</button>
+      </DropdownMenu>
+    ))
+
+    expect(container.querySelector('ot-dropdown')).toHaveAttribute('data-headless')
+  })
+
+  it('leaves a host with a trigger laid out as usual', () => {
+    const { container } = render(() => (
+      <DropdownMenu id="triggered-menu" trigger={<button>Open</button>}>
+        <button role="menuitem">Item</button>
+      </DropdownMenu>
+    ))
+
+    expect(container.querySelector('ot-dropdown')).not.toHaveAttribute('data-headless')
+  })
+
+  it('detaches on unmount', () => {
+    vi.useFakeTimers()
+    try {
+      const { row, popover } = renderRowMenu()
+      const show = vi.spyOn(popover, 'showPopover')
+
+      cleanup()
+
+      row.dispatchEvent(new MouseEvent('contextmenu', { clientX: 150, bubbles: true, cancelable: true }))
+      vi.runAllTimers()
+
+      expect(show).not.toHaveBeenCalled()
+    }
+    finally {
+      vi.useRealTimers()
+    }
   })
 })
 

--- a/frontend/src/components/common/DropdownMenu.tsx
+++ b/frontend/src/components/common/DropdownMenu.tsx
@@ -1,10 +1,12 @@
 import type { Accessor, JSX } from 'solid-js'
-import type { PopoverPositionOptions } from '~/lib/popoverPosition'
+import type { ContextMenuPress } from './contextMenuGesture'
+import type { PopoverAnchor, PopoverPositionOptions } from '~/lib/popoverPosition'
 import { createEffect, createSignal, createUniqueId, on, onCleanup, Show } from 'solid-js'
 import { Dynamic } from 'solid-js/web'
 import { calcPopoverPosition } from '~/lib/popoverPosition'
 import { popoverCard } from '~/styles/popover.css'
 import { clippedText, menuItemContent, menuItemShortcut } from '~/styles/shared.css'
+import { attachContextMenuGesture, pressAnchorRect } from './contextMenuGesture'
 
 /**
  * Marks a dropdown's trigger element. An enclosing popover's dismiss handler
@@ -24,6 +26,31 @@ export interface DropdownTriggerProps {
   'onClick': () => void
 }
 
+/**
+ * The row-menu half of `DropdownMenuProps`, for the thin wrappers that own one
+ * row's menu (`WorkspaceContextMenu`, `BranchContextMenu`, `WorkerContextMenu`,
+ * `TunnelContextMenu`, `FileActionsMenu`, `TabContextMenu`). Each extends this
+ * instead of redeclaring the prop, so the contract and its documentation stay in
+ * one place.
+ */
+export interface ContextMenuTargetProps {
+  /** See `DropdownMenuProps.contextMenuFor`. */
+  contextMenuFor?: Accessor<HTMLElement | undefined>
+}
+
+/**
+ * The row element for a `contextMenuFor` menu, as a signal so the menu's attach
+ * effect tracks it -- a plain `let` depends on the ref happening to be assigned
+ * before effects flush. Pass the accessor to `contextMenuFor`, and use the setter
+ * as the row's `ref`, or call it first inside a composed ref callback beside the
+ * row's own directives (`sortable`, `draggable`, an imperative `let` for
+ * scroll-into-view, ...).
+ */
+export function createContextMenuAnchor(): [Accessor<HTMLElement | undefined>, (el: HTMLElement) => void] {
+  const [anchor, setAnchor] = createSignal<HTMLElement>()
+  return [anchor, setAnchor]
+}
+
 export interface DropdownMenuProps {
   /**
    * The trigger element. Two forms:
@@ -40,16 +67,30 @@ export interface DropdownMenuProps {
   'trigger'?: JSX.Element | ((props: DropdownTriggerProps) => JSX.Element)
 
   /**
-   * Anchor element for positioning when no trigger is provided.
+   * Anchor for positioning when no trigger is provided.
    * Used for programmatic popovers (e.g. CodeLanguagePopover).
    */
-  'anchorRef'?: Accessor<HTMLElement | undefined>
+  'anchorRef'?: Accessor<PopoverAnchor | undefined>
 
   /**
    * Programmatic open/close control. When provided without a trigger,
    * the component calls showPopover()/hidePopover() reactively.
    */
   'open'?: Accessor<boolean>
+
+  /**
+   * The element whose RIGHT-CLICK or touch LONG-PRESS opens this menu -- normally
+   * the row the menu belongs to. The menu then opens at the press point rather
+   * than at `trigger`; see `pressAnchorRect`.
+   *
+   * The kebab `trigger` keeps working unchanged. This is a second way in, for the
+   * two inputs that have no hover: a mouse's secondary button, and a finger.
+   *
+   * Rows whose text must stay selectable attach the gesture directly with
+   * `selectableText` instead (see ~/components/common/contextMenuGesture.ts) --
+   * the chat message rows, whose menu is a singleton host and not this component.
+   */
+  'contextMenuFor'?: Accessor<HTMLElement | undefined>
 
   /** Popover content. */
   'children': JSX.Element
@@ -209,6 +250,10 @@ export function DropdownMenu(props: DropdownMenuProps) {
   // intended to close (toggle off) vs open (toggle on) the popover.
   let wasOpenOnPointerDown = false
 
+  // Where a right-click or long-press that opened this menu landed. Cleared when
+  // the popover closes, so the next kebab click re-anchors to the kebab.
+  const [pressAnchor, setPressAnchor] = createSignal<ContextMenuPress>()
+
   const setTriggerRef = (el: HTMLElement) => {
     triggerEl = el
     // Mark the trigger so an ancestor popover's dismiss handler can recognize
@@ -218,10 +263,15 @@ export function DropdownMenu(props: DropdownMenuProps) {
     el.setAttribute(TRIGGER_ATTR, '')
   }
 
-  // Resolve the positioning anchor: for the JSX-element trigger path,
-  // triggerEl is the display:contents wrapper whose bounding rect is zero.
-  // Fall back to its first visible child element.
-  const getAnchor = (): HTMLElement | undefined => {
+  // Resolve the positioning anchor. A press anchor wins while it is set, because
+  // the menu the user just opened by right-click or long-press must point at that
+  // press and not at the kebab they never touched.
+  const getAnchor = (): PopoverAnchor | undefined => {
+    const press = pressAnchor()
+    if (press)
+      return pressAnchorRect(press)
+    // For the JSX-element trigger path, triggerEl is the display:contents wrapper
+    // whose bounding rect is zero. Fall back to its first visible child element.
     if (triggerEl) {
       const rect = triggerEl.getBoundingClientRect()
       if (rect.width === 0 && rect.height === 0 && triggerEl.firstElementChild) {
@@ -230,6 +280,13 @@ export function DropdownMenu(props: DropdownMenuProps) {
       return triggerEl
     }
     return props.anchorRef?.()
+  }
+
+  // `aria-expanded` is an element concern; a press anchor is a bare rect and has no
+  // attributes to carry it.
+  const getAnchorElement = (): Element | undefined => {
+    const anchor = getAnchor()
+    return anchor instanceof Element ? anchor : undefined
   }
 
   const reposition = () => {
@@ -255,6 +312,15 @@ export function DropdownMenu(props: DropdownMenuProps) {
   // inside the popover content by dragging.
   const repositionOnExternalScroll = (e: Event) => {
     if (popoverEl && e.target instanceof Node && popoverEl.contains(e.target)) {
+      return
+    }
+    // A press anchor is a frozen point in the viewport, not an element: the row
+    // the user pressed has scrolled away, and re-running the arithmetic would
+    // glue the menu to that dead point over whatever scrolled into place. Every
+    // OS context menu closes on scroll instead, and so does this one. An
+    // element anchor follows its element, so it keeps repositioning.
+    if (!(getAnchor() instanceof Element)) {
+      popoverEl?.hidePopover()
       return
     }
     reposition()
@@ -287,20 +353,18 @@ export function DropdownMenu(props: DropdownMenuProps) {
         resizeObserver.observe(popoverEl)
       }
 
-      const anchor = getAnchor()
-      if (anchor) {
-        anchor.setAttribute('aria-expanded', 'true')
-      }
+      getAnchorElement()?.setAttribute('aria-expanded', 'true')
     }
     else {
       window.removeEventListener('scroll', repositionOnExternalScroll, true)
       resizeObserver?.disconnect()
       resizeObserver = undefined
 
-      const anchor = getAnchor()
-      if (anchor) {
-        anchor.setAttribute('aria-expanded', 'false')
-      }
+      getAnchorElement()?.setAttribute('aria-expanded', 'false')
+      // Drop the press so the next kebab click anchors to the kebab again. A menu
+      // opened by a press has no element anchor to clear `aria-expanded` on -- the
+      // trigger's own copy is reactive on `isOpen()` and falls with it.
+      setPressAnchor(undefined)
     }
 
     props.onToggle?.(opening)
@@ -318,7 +382,12 @@ export function DropdownMenu(props: DropdownMenuProps) {
   // Programmatic open/close when `open` accessor is provided
   // eslint-disable-next-line solid/reactivity -- guards presence of accessor; on() tracks it reactively
   if (props.open) {
-    createEffect(on(props.open, (shouldOpen) => { // eslint-disable-line solid/reactivity -- passing accessor to on() is correct
+    // Track the ANCHOR, not just the boolean: an already-open menu whose anchor
+    // changed (a singleton host serving a second row's press) repositions IN
+    // PLACE, so no host has to close and reopen just to re-trigger this effect.
+    // A caller whose anchor is a stable element gains no new subscription -- the
+    // anchor read was already part of every reposition.
+    createEffect(on(() => [props.open?.(), props.anchorRef?.()], ([shouldOpen]) => {
       if (!popoverEl)
         return
       // Guard against redundant show/hide: showPopover() on an already-open popover
@@ -337,11 +406,53 @@ export function DropdownMenu(props: DropdownMenuProps) {
         // ResizeObserver then refine it for any late layout.
         reposition()
       }
+      else if (shouldOpen && nativeOpen) {
+        // Open the whole time, anchor moved: re-anchor with no teardown. The
+        // ResizeObserver from the first open re-refines once swapped content
+        // settles its size, same as it does after a scroll.
+        reposition()
+      }
       else if (!shouldOpen && nativeOpen) {
         popoverEl.hidePopover()
       }
     }))
   }
+
+  // Right-click / long-press on the owning row. The gesture defers its callback
+  // past the pointer event that completed it, so by the time this runs the
+  // browser's light-dismiss pass is over and showPopover() sticks -- see
+  // `scheduleOpen` in ~/components/common/contextMenuGesture.ts.
+  createEffect(() => {
+    const el = props.contextMenuFor?.()
+    if (!el)
+      return
+    const detach = attachContextMenuGesture(el, {
+      onOpen: (press) => {
+        setPressAnchor(press)
+        if (popoverEl?.matches(':popover-open')) {
+          // Already up from the kebab, or from a right-click on another row that
+          // shares this menu: re-point it at the new press.
+          reposition()
+        }
+        else {
+          popoverEl?.showPopover()
+          // Position synchronously, before the browser paints this frame, so the
+          // popover never appears at the UA-default position and then jumps. The
+          // content is already in the DOM (rendered before this effect), so it
+          // measures at its real size here. The rAF reposition in handleToggle + the
+          // ResizeObserver then refine it for any late layout.
+          reposition()
+          // `showPopover` queues the `toggle` event as a task, and a menu that
+          // gates content on `onToggle` (FileActionsMenu's info block) has not
+          // rendered it yet, so the measurement above saw a shorter popover.
+          // Re-measure one task later, after that event and its render, before
+          // any paint can show the miss.
+          setTimeout(reposition, 0)
+        }
+      },
+    })
+    onCleanup(detach)
+  })
 
   onCleanup(() => {
     popoverEl?.removeEventListener('toggle', handleToggle)
@@ -417,8 +528,16 @@ export function DropdownMenu(props: DropdownMenuProps) {
     return null
   }
 
+  // `data-headless` marks a dropdown with no trigger -- one opened only by
+  // right-click or long press. The host then collapses to `display: contents` and
+  // adds no flex item to the row that mounts it; see ~/styles/popover.css.ts.
+  //
+  // `attr:` is required, not stylistic: `ot-dropdown` has a dash in its name, so
+  // Solid treats it as a custom element and assigns unknown props as PROPERTIES.
+  // Without the namespace this sets `el.dataHeadless` and no attribute, and the
+  // CSS rule never matches.
   return (
-    <ot-dropdown>
+    <ot-dropdown attr:data-headless={props.trigger === undefined ? 'true' : undefined}>
       {renderTrigger()}
       {/* `menu` (default) and `div` popovers differ ONLY by tag; everything else (the
           popover attr, id, ref, class, testid, and the Escape/outside-click dismiss

--- a/frontend/src/components/common/FileActionsMenu.tsx
+++ b/frontend/src/components/common/FileActionsMenu.tsx
@@ -1,4 +1,5 @@
 import type { Component } from 'solid-js'
+import type { ContextMenuTargetProps } from '~/components/common/DropdownMenu'
 import type { FileSaveActions } from '~/components/common/fileSaveActions'
 import type { MenuInfoRow } from '~/components/common/MenuInfoRows'
 import type { PathFlavor } from '~/lib/paths'
@@ -34,7 +35,7 @@ import { relativizePath } from '~/lib/paths'
  *   - `rootPath`       → "Copy relative path"
  *   - `!isDir`         → "Download" (web) or "Save as..." + "Save to Downloads" (desktop)
  */
-export interface FileActionsMenuProps {
+export interface FileActionsMenuProps extends ContextMenuTargetProps {
   workerId: string
   path: string
   flavor: PathFlavor
@@ -158,6 +159,7 @@ export const FileActionsMenu: Component<FileActionsMenuProps> = (props) => {
     <DropdownMenu
       placement={props.placement}
       onToggle={setMenuOpen}
+      contextMenuFor={props.contextMenuFor}
       trigger={moreHorizontalTrigger({
         'class': props.triggerClass,
         'data-testid': props.triggerTestId ?? 'file-actions-trigger',

--- a/frontend/src/components/common/TabContextMenu.test.tsx
+++ b/frontend/src/components/common/TabContextMenu.test.tsx
@@ -1,0 +1,112 @@
+import { fireEvent, render, screen } from '@solidjs/testing-library'
+import { describe, expect, it, vi } from 'vitest'
+import { TabContextMenu } from './TabContextMenu'
+
+/** Records what the mocked DropdownMenu last received for `contextMenuFor`. */
+const captured: { contextMenuFor?: () => HTMLElement | undefined } = {}
+
+// Mock DropdownMenu to render children directly (jsdom lacks the popover API).
+vi.mock('~/components/common/DropdownMenu', () => ({
+  DropdownMenu(props: any) {
+    // eslint-disable-next-line solid/reactivity -- capturing the accessor itself for the assertion, not reading it
+    captured.contextMenuFor = props.contextMenuFor
+    return <>{props.children}</>
+  },
+}))
+
+describe('tabContextMenu', () => {
+  it('renders nothing when the tab offers no action', () => {
+    const { container } = render(() => <TabContextMenu />)
+
+    expect(container.textContent).toBe('')
+    expect(screen.queryByRole('menuitem')).not.toBeInTheDocument()
+  })
+
+  it('offers rename and close for an ordinary tab', () => {
+    render(() => <TabContextMenu onRename={() => {}} onClose={() => {}} />)
+
+    expect(screen.getByTestId('tab-menu-rename')).toBeInTheDocument()
+    expect(screen.getByTestId('tab-menu-close')).toBeInTheDocument()
+  })
+
+  it('hides rename for a tab that cannot be renamed', () => {
+    render(() => <TabContextMenu onClose={() => {}} />)
+
+    expect(screen.queryByTestId('tab-menu-rename')).not.toBeInTheDocument()
+    expect(screen.getByTestId('tab-menu-close')).toBeInTheDocument()
+  })
+
+  it('hides close for a tab that cannot be closed', () => {
+    render(() => <TabContextMenu onRename={() => {}} />)
+
+    expect(screen.getByTestId('tab-menu-rename')).toBeInTheDocument()
+    expect(screen.queryByTestId('tab-menu-close')).not.toBeInTheDocument()
+  })
+
+  it('shows the pop affordance with the label the surface supplied', () => {
+    const onClick = vi.fn()
+    render(() => (
+      <TabContextMenu
+        onClose={() => {}}
+        pop={{ label: 'Pop out to floating window', onClick }}
+      />
+    ))
+
+    const item = screen.getByTestId('tab-menu-pop')
+    expect(item).toHaveTextContent('Pop out to floating window')
+
+    fireEvent.click(item)
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('omits the pop affordance when the surface has none', () => {
+    render(() => <TabContextMenu onRename={() => {}} onClose={() => {}} />)
+
+    expect(screen.queryByTestId('tab-menu-pop')).not.toBeInTheDocument()
+  })
+
+  it('runs rename and close exactly once each', () => {
+    const onRename = vi.fn()
+    const onClose = vi.fn()
+    render(() => <TabContextMenu onRename={onRename} onClose={onClose} />)
+
+    fireEvent.click(screen.getByTestId('tab-menu-rename'))
+    fireEvent.click(screen.getByTestId('tab-menu-close'))
+
+    expect(onRename).toHaveBeenCalledTimes(1)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps close visible but inert while a close is already in flight', () => {
+    const onClose = vi.fn()
+    render(() => <TabContextMenu onRename={() => {}} onClose={onClose} isClosing />)
+
+    const item = screen.getByTestId('tab-menu-close')
+    // Visible, so the menu does not reshape under the user mid-click.
+    expect(item).toBeInTheDocument()
+    // The native `disabled` attribute is the mechanism; the guard in the handler
+    // is what keeps it correct if this ever moves to `aria-disabled`.
+    expect(item).toBeDisabled()
+
+    fireEvent.click(item)
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('separates close from the items above it, and only when there are any', () => {
+    const { container: withRename } = render(() => (
+      <TabContextMenu onRename={() => {}} onClose={() => {}} />
+    ))
+    expect(withRename.querySelector('hr')).toBeInTheDocument()
+
+    const { container: closeOnly } = render(() => <TabContextMenu onClose={() => {}} />)
+    expect(closeOnly.querySelector('hr')).not.toBeInTheDocument()
+  })
+
+  it('forwards contextMenuFor so the row itself opens the menu', () => {
+    const row = document.createElement('div')
+
+    render(() => <TabContextMenu contextMenuFor={() => row} onClose={() => {}} />)
+
+    expect(captured.contextMenuFor?.()).toBe(row)
+  })
+})

--- a/frontend/src/components/common/TabContextMenu.tsx
+++ b/frontend/src/components/common/TabContextMenu.tsx
@@ -1,0 +1,89 @@
+import type { Component } from 'solid-js'
+import type { ContextMenuTargetProps } from '~/components/common/DropdownMenu'
+import { Show } from 'solid-js'
+import { DropdownMenu } from '~/components/common/DropdownMenu'
+import { dangerMenuItem } from '~/styles/shared.css'
+
+/**
+ * The pop-out / pop-in affordance, when the surface offers one. Declared here in
+ * the common layer so this component does not depend on the shell; the
+ * tile-level affordance is its subtype -- see `TilePopAction` in
+ * ~/components/shell/TileActionsMenu.tsx, which adds the `testId` its own
+ * trigger carries.
+ */
+export interface TabPopAction {
+  label: string
+  onClick: () => void
+}
+
+export interface TabContextMenuProps extends ContextMenuTargetProps {
+  /** Start the inline rename. Omit to hide the item. */
+  'onRename'?: () => void
+  /** Close the tab. Omit to hide the item -- a tab the surface refuses to close has no Close. */
+  'onClose'?: () => void
+  /** A close is already in flight. The item stays visible, so the row's menu does not reshape mid-click. */
+  'isClosing'?: boolean
+  'pop'?: TabPopAction
+  'data-testid'?: string
+}
+
+/**
+ * The right-click / long-press menu for a tab, shared by the sidebar's tab leaf
+ * and the tile tab bar's tab.
+ *
+ * Every item is an action the row ALREADY performs through some other input --
+ * double-click to rename, the hover X or a middle click to close -- promoted to a
+ * place a finger and a secondary button can reach. Nothing new is invented here:
+ * "close others", "close to the right", "duplicate" and "pin" have no
+ * implementation anywhere in the app, and adding them is a different piece of work
+ * from making the existing actions reachable.
+ *
+ * Neither tab row gets a kebab. Both already spend their one hover-revealed action
+ * slot on the close X, and a second button beside it would widen every row and
+ * duplicate Close.
+ *
+ * Renders nothing when no item would appear. A menu that opens empty is worse than
+ * a right-click that falls through to the browser's own.
+ */
+export const TabContextMenu: Component<TabContextMenuProps> = (props) => {
+  const hasAnyItem = () => Boolean(props.onRename || props.onClose || props.pop)
+
+  return (
+    <Show when={hasAnyItem()}>
+      <DropdownMenu contextMenuFor={props.contextMenuFor} data-testid={props['data-testid']}>
+        <Show when={props.onRename}>
+          <button role="menuitem" data-testid="tab-menu-rename" onClick={() => props.onRename!()}>
+            Rename
+          </button>
+        </Show>
+
+        <Show when={props.pop}>
+          {pop => (
+            <button role="menuitem" data-testid="tab-menu-pop" onClick={() => pop().onClick()}>
+              {pop().label}
+            </button>
+          )}
+        </Show>
+
+        <Show when={props.onClose}>
+          {/* Only when something precedes it, so a Close-only menu has no leading rule. */}
+          <Show when={props.onRename || props.pop}>
+            <hr />
+          </Show>
+          <button
+            role="menuitem"
+            class={dangerMenuItem}
+            data-testid="tab-menu-close"
+            disabled={props.isClosing}
+            onClick={() => {
+              if (!props.isClosing)
+                props.onClose!()
+            }}
+          >
+            Close
+          </button>
+        </Show>
+      </DropdownMenu>
+    </Show>
+  )
+}

--- a/frontend/src/components/common/Tooltip.test.tsx
+++ b/frontend/src/components/common/Tooltip.test.tsx
@@ -1,5 +1,7 @@
 import { fireEvent, render, screen } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
+import { attachContextMenuGesture } from '~/components/common/contextMenuGesture'
+import { motion } from '~/styles/tokens'
 import { Tooltip } from './Tooltip'
 
 describe('tooltip', () => {
@@ -297,6 +299,40 @@ describe('tooltip', () => {
       tap(screen.getByRole('button', { name: 'Trigger' }))
 
       expect(screen.queryByRole('tooltip', { hidden: true })).toBeNull()
+    })
+
+    it('does not present on the release of a long press whose menu is opening', () => {
+      // The gesture must let that release propagate (the drag sensor and the
+      // chat scroller consume it), so it flags it and the tooltip stands down:
+      // a `popover="manual"` tooltip entering the top layer a frame after the
+      // menu would stack above it.
+      const row = document.createElement('div')
+      document.body.appendChild(row)
+      const detach = attachContextMenuGesture(row, { onOpen: () => {} })
+      try {
+        row.dispatchEvent(new PointerEvent('pointerdown', { pointerType: 'touch', pointerId: 1, isPrimary: true, bubbles: true, cancelable: true }))
+        vi.advanceTimersByTime(motion.longPress)
+        row.dispatchEvent(new PointerEvent('pointerup', { pointerType: 'touch', pointerId: 1, bubbles: true, cancelable: true }))
+
+        render(() => (
+          <Tooltip text="Tooltip text">
+            <button type="button">Trigger</button>
+          </Tooltip>
+        ))
+
+        const button = screen.getByRole('button', { name: 'Trigger' })
+        fireEvent(button, new PointerEvent('pointerup', { pointerType: 'touch', bubbles: true }))
+        expect(screen.queryByRole('tooltip', { hidden: true })).toBeNull()
+
+        // The menu's open task clears the flag; a tap after it presents as usual.
+        vi.runAllTimers()
+        tap(button)
+        expect(screen.getByRole('tooltip', { hidden: true })).toBeInTheDocument()
+      }
+      finally {
+        detach()
+        row.remove()
+      }
     })
 
     it('leaves a mouse click dismissing the tooltip', () => {

--- a/frontend/src/components/common/Tooltip.tsx
+++ b/frontend/src/components/common/Tooltip.tsx
@@ -1,6 +1,7 @@
 import type { JSX } from 'solid-js'
 import { createEffect, createSignal, createUniqueId, getOwner, onCleanup, onMount, runWithOwner, Show } from 'solid-js'
 import { Portal } from 'solid-js/web'
+import { touchReleaseOpensMenu } from '~/components/common/contextMenuGesture'
 import * as styles from './Tooltip.css'
 
 /** Exported so a test advances its fake timers by the real delay. */
@@ -304,6 +305,14 @@ export function Tooltip(props: TooltipProps) {
    */
   const showOnTouch = (e: PointerEvent) => {
     if (e.pointerType !== 'touch')
+      return
+    // The release of a long press whose context menu is about to open. The
+    // gesture must let that release propagate (the drag sensor and the chat
+    // scroller consume it), so it flags it here instead of stopping it. A
+    // tooltip presented now enters the top layer a frame AFTER the menu and
+    // would stack above it. See `touchReleaseOpensMenu` in
+    // ~/components/common/contextMenuGesture.ts.
+    if (touchReleaseOpensMenu())
       return
     if (!props.text && !props.content)
       return

--- a/frontend/src/components/common/contextMenuGesture.css.ts
+++ b/frontend/src/components/common/contextMenuGesture.css.ts
@@ -1,0 +1,112 @@
+import { globalStyle } from '@vanilla-extract/css'
+import { motion } from '~/styles/tokens'
+
+/**
+ * How long before the hold completes the reduced-motion step lands. The step is
+ * feedback, not decoration, so it must arrive while the finger is still down and
+ * early enough to read as "ready", but late enough that an ordinary tap never
+ * flashes it.
+ */
+const REDUCED_MOTION_STEP_LEAD_MS = 120
+
+/**
+ * The accent tint that grows while a finger holds a row.
+ *
+ * Every rule keys on the `data-ctx-menu` attribute that
+ * `attachContextMenuGesture` sets on the row (see ./contextMenuGesture.ts), not
+ * on a class. The rows that mount the gesture assign their own `class`
+ * reactively, and that assignment replaces the whole class list, so a class
+ * added once at attach would not survive the row's next class change (a tab
+ * becoming active, a chat row reclassifying mid-stream). An attribute does.
+ *
+ * The tint is a `::before` overlay at `z-index: -1` inside an isolated row, so it
+ * paints ABOVE the row's own `background-color` and BELOW its content. That is the
+ * one layer that composites with the hover, selected and drop-target backgrounds a
+ * row already carries instead of replacing them.
+ *
+ * `box-shadow: inset 0 0 0 9999px` reaches the same layer with one property and no
+ * stacking context, and it is the wrong choice here: `box-shadow` does not compose,
+ * so a later rule that gives any of these rows a shadow would silently delete the
+ * indicator with no failing test and no visible cause.
+ *
+ * Each state owns the transition INTO itself: the base rule fades the tint out on
+ * release, and the `[data-press-hold]` rule ramps it in during the press. A single
+ * transition on the base rule cannot express this, because the press needs the
+ * whole hold duration and the release must be immediate.
+ *
+ * Reduced motion is the DEFAULT and the ramp is the opt-in, following the rule
+ * recorded in ~/components/chat/ChatScrollRail.css.ts: two blocks setting the same
+ * property at equal specificity would have to win by source order, which a key
+ * reorder silently breaks. Under reduced motion the tint arrives as a single step
+ * shortly before the hold completes -- `prefers-reduced-motion` asks for less
+ * motion, not less information, and this indicator is the only signal the gesture
+ * emits before the menu appears.
+ *
+ * (`globalStyle`'s rule type takes no nested `selectors` under `@media`, so each
+ * media-scoped block is its own call with the query in the selector string.)
+ */
+globalStyle('[data-ctx-menu]', {
+  position: 'relative',
+  // Without this, `z-index: -1` on the pseudo-element escapes to the nearest
+  // ancestor stacking context and paints behind the row's own background.
+  isolation: 'isolate',
+})
+
+globalStyle('[data-ctx-menu]::before', {
+  content: '""',
+  position: 'absolute',
+  inset: 0,
+  zIndex: -1,
+  borderRadius: 'inherit',
+  pointerEvents: 'none',
+  background: 'var(--accent)',
+  opacity: 0,
+  transition: 'opacity 1ms linear',
+})
+
+// `attachContextMenuGesture` sets the attribute on pointerdown and removes it
+// when the gesture ends, so the ramp runs forward on press and unwinds on
+// release with no second class to keep in step.
+globalStyle('[data-ctx-menu][data-press-hold]::before', {
+  opacity: 1,
+  transition: `opacity 1ms linear ${motion.longPress - REDUCED_MOTION_STEP_LEAD_MS}ms`,
+})
+
+globalStyle('@media (prefers-reduced-motion: no-preference) { [data-ctx-menu]::before }', {
+  transition: `opacity ${motion.fast}ms ease-out`,
+})
+
+globalStyle('@media (prefers-reduced-motion: no-preference) { [data-ctx-menu][data-press-hold]::before }', {
+  transition: `opacity ${motion.longPress}ms linear`,
+})
+
+/**
+ * The default variant: `attachContextMenuGesture` writes the `owned` value itself
+ * (see ./contextMenuGesture.ts), so a row opts into the gesture and its paint with
+ * one call and cannot receive half of it.
+ *
+ * This variant owns the long press outright. `-webkit-touch-callout` and
+ * `user-select` are both off, because iOS raises the selection callout on a long
+ * press over any selectable text and that callout would cover the menu. Every row
+ * that uses it is chrome, not prose.
+ */
+globalStyle('[data-ctx-menu="owned"]', {
+  WebkitTouchCallout: 'none',
+  userSelect: 'none',
+  WebkitUserSelect: 'none',
+})
+
+/**
+ * The variant for an element whose text must stay selectable -- the chat message
+ * rows, which the gesture marks `selectable`.
+ *
+ * The suppression is scoped to `(pointer: coarse)`: a phone trades partial-text
+ * selection for the menu (which carries Copy and Quote in its place), while a mouse
+ * -- including a hybrid laptop's, where `pointer` is `fine` and only `any-pointer`
+ * is coarse -- keeps selection intact and reaches the menu through right-click.
+ */
+globalStyle('@media (pointer: coarse) { [data-ctx-menu="selectable"] }', {
+  WebkitTouchCallout: 'none',
+  userSelect: 'none',
+  WebkitUserSelect: 'none',
+})

--- a/frontend/src/components/common/contextMenuGesture.test.ts
+++ b/frontend/src/components/common/contextMenuGesture.test.ts
@@ -1,0 +1,626 @@
+import type { ContextMenuPress } from './contextMenuGesture'
+import type { PointerOpts } from '~/test-support/pointer'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { motion } from '~/styles/tokens'
+import { pointerEvent } from '~/test-support/pointer'
+import { selectTextWithRect } from '~/test-support/selection'
+import { attachContextMenuGesture, PRESS_SLOP_PX, pressAnchorRect, touchReleaseOpensMenu } from './contextMenuGesture'
+
+const HOLD_MS = motion.longPress
+
+/** The gesture's own events are touch presses; the shared factory defaults to a mouse. */
+function pointer(type: string, opts: PointerOpts = {}): PointerEvent {
+  return pointerEvent(type, { pointerType: 'touch', ...opts })
+}
+
+describe('pressAnchorRect', () => {
+  it('is a zero-height band at the press point', () => {
+    // `calcPopoverPosition` puts the popover below `bottom` and left-aligned to
+    // `left`, so collapsing the band onto the point lands the menu's corner there.
+    expect(pressAnchorRect({ clientX: 150, clientY: 108 }))
+      .toEqual({ top: 108, bottom: 108, left: 150 })
+  })
+
+  it('carries no offset for touch, because the finger has already lifted', () => {
+    // A long press opens its menu on RELEASE, so there is nothing left to occlude
+    // and no clearance to add. One rule serves both inputs.
+    expect(pressAnchorRect({ clientX: 40, clientY: 0 }))
+      .toEqual({ top: 0, bottom: 0, left: 40 })
+  })
+})
+
+describe('attachContextMenuGesture', () => {
+  let row: HTMLElement
+  let detach: () => void
+  let onOpen: ReturnType<typeof vi.fn<(press: ContextMenuPress) => void>>
+  /** The rect the row reports; a test moves it to make a scroll "move the row". */
+  let rowRect: { top: number, left: number }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    row = document.createElement('div')
+    rowRect = { top: 100, left: 40 }
+    row.getBoundingClientRect = () => ({
+      top: rowRect.top,
+      bottom: rowRect.top + 22,
+      left: rowRect.left,
+      right: rowRect.left + 200,
+      width: 200,
+      height: 22,
+      x: rowRect.left,
+      y: rowRect.top,
+      toJSON: () => ({}),
+    })
+    document.body.appendChild(row)
+    onOpen = vi.fn()
+    detach = attachContextMenuGesture(row, { onOpen })
+  })
+
+  afterEach(() => {
+    detach()
+    row.remove()
+    vi.useRealTimers()
+  })
+
+  /** Drive a full touch press-and-hold that completes, then release. */
+  function holdAndRelease(x = 90, y = 110) {
+    row.dispatchEvent(pointer('pointerdown', { x, y }))
+    vi.advanceTimersByTime(HOLD_MS)
+    row.dispatchEvent(pointer('pointerup', { x, y }))
+    vi.runAllTimers()
+  }
+
+  it('opens after the hold completes, anchored at the press x', () => {
+    holdAndRelease(90, 110)
+
+    expect(onOpen).toHaveBeenCalledTimes(1)
+    expect(onOpen).toHaveBeenCalledWith(expect.objectContaining({ clientX: 90 }))
+  })
+
+  it('marks the row while the hold is in flight and clears it on release', () => {
+    row.dispatchEvent(pointer('pointerdown', { x: 90, y: 110 }))
+    expect(row.hasAttribute('data-press-hold')).toBe(true)
+
+    vi.advanceTimersByTime(HOLD_MS)
+    // Still down: the tint stays at full until the finger lifts.
+    expect(row.hasAttribute('data-press-hold')).toBe(true)
+
+    row.dispatchEvent(pointer('pointerup', { x: 90, y: 110 }))
+    expect(row.hasAttribute('data-press-hold')).toBe(false)
+  })
+
+  it('arms the indicator as an attribute that survives a class-list rewrite', () => {
+    // The rows that mount the gesture assign their `class` reactively, and that
+    // assignment replaces the whole class list -- a Solid `class={...}` template
+    // string runs `element.className = value` on every change (a tab becoming
+    // active, a chat row reclassifying mid-stream). The indicator is an
+    // attribute precisely so it survives this.
+    expect(row.getAttribute('data-ctx-menu')).toBe('owned')
+
+    row.className = 'row-active row-dragging'
+    expect(row.getAttribute('data-ctx-menu')).toBe('owned')
+  })
+
+  // The light-dismiss contract: a popover shown while the finger is still down is
+  // hidden by the very release that ends the gesture.
+  it('never calls onOpen synchronously inside a pointer handler', () => {
+    row.dispatchEvent(pointer('pointerdown', { x: 90, y: 110 }))
+    vi.advanceTimersByTime(HOLD_MS)
+    expect(onOpen).not.toHaveBeenCalled()
+
+    row.dispatchEvent(pointer('pointerup', { x: 90, y: 110 }))
+    expect(onOpen).not.toHaveBeenCalled()
+
+    vi.runAllTimers()
+    expect(onOpen).toHaveBeenCalledTimes(1)
+  })
+
+  it('opens once for a whole gesture', () => {
+    holdAndRelease()
+    expect(onOpen).toHaveBeenCalledTimes(1)
+  })
+
+  it('does nothing when the finger lifts before the threshold', () => {
+    row.dispatchEvent(pointer('pointerdown', { x: 90, y: 110 }))
+    vi.advanceTimersByTime(HOLD_MS - 1)
+    row.dispatchEvent(pointer('pointerup', { x: 90, y: 110 }))
+    vi.runAllTimers()
+
+    expect(onOpen).not.toHaveBeenCalled()
+    expect(row.hasAttribute('data-press-hold')).toBe(false)
+  })
+
+  it('lets the row click through when the hold did not complete', () => {
+    row.dispatchEvent(pointer('pointerdown', { x: 90, y: 110 }))
+    vi.advanceTimersByTime(HOLD_MS - 1)
+    row.dispatchEvent(pointer('pointerup', { x: 90, y: 110 }))
+
+    const click = new MouseEvent('click', { bubbles: true, cancelable: true })
+    row.dispatchEvent(click)
+
+    expect(click.defaultPrevented).toBe(false)
+  })
+
+  it('swallows the click that completes a fired hold', () => {
+    const documentClick = vi.fn()
+    document.addEventListener('click', documentClick)
+
+    holdAndRelease()
+    const click = new MouseEvent('click', { bubbles: true, cancelable: true })
+    row.dispatchEvent(click)
+
+    expect(click.defaultPrevented).toBe(true)
+    expect(documentClick).not.toHaveBeenCalled()
+
+    document.removeEventListener('click', documentClick)
+  })
+
+  it('swallows only the one click it claimed', () => {
+    holdAndRelease()
+    row.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+
+    const later = new MouseEvent('click', { bubbles: true, cancelable: true })
+    row.dispatchEvent(later)
+
+    expect(later.defaultPrevented).toBe(false)
+  })
+
+  it('cancels when the finger travels past the slop', () => {
+    row.dispatchEvent(pointer('pointerdown', { x: 90, y: 110 }))
+    row.dispatchEvent(pointer('pointermove', { x: 90, y: 110 + PRESS_SLOP_PX + 1 }))
+    vi.advanceTimersByTime(HOLD_MS)
+    row.dispatchEvent(pointer('pointerup', { x: 90, y: 110 + PRESS_SLOP_PX + 1 }))
+    vi.runAllTimers()
+
+    expect(onOpen).not.toHaveBeenCalled()
+    expect(row.hasAttribute('data-press-hold')).toBe(false)
+  })
+
+  it('tolerates travel within the slop', () => {
+    row.dispatchEvent(pointer('pointerdown', { x: 90, y: 110 }))
+    row.dispatchEvent(pointer('pointermove', { x: 90, y: 110 + PRESS_SLOP_PX - 1 }))
+    vi.advanceTimersByTime(HOLD_MS)
+    row.dispatchEvent(pointer('pointerup', { x: 90, y: 110 }))
+    vi.runAllTimers()
+
+    expect(onOpen).toHaveBeenCalledTimes(1)
+  })
+
+  it('cancels on pointercancel, which is the browser claiming the touch for a pan', () => {
+    row.dispatchEvent(pointer('pointerdown', { x: 90, y: 110 }))
+    row.dispatchEvent(pointer('pointercancel'))
+    vi.advanceTimersByTime(HOLD_MS)
+    vi.runAllTimers()
+
+    expect(onOpen).not.toHaveBeenCalled()
+    expect(row.hasAttribute('data-press-hold')).toBe(false)
+  })
+
+  it('cancels on pointercancel even after the hold fired', () => {
+    row.dispatchEvent(pointer('pointerdown', { x: 90, y: 110 }))
+    vi.advanceTimersByTime(HOLD_MS)
+    row.dispatchEvent(pointer('pointercancel'))
+    vi.runAllTimers()
+
+    expect(onOpen).not.toHaveBeenCalled()
+  })
+
+  it('cancels when a scroll moves the row', () => {
+    row.dispatchEvent(pointer('pointerdown', { x: 90, y: 110 }))
+    // The row's ancestor pans: the row itself moves in the viewport.
+    rowRect.top += 40
+    document.dispatchEvent(new Event('scroll'))
+    vi.advanceTimersByTime(HOLD_MS)
+    vi.runAllTimers()
+
+    expect(onOpen).not.toHaveBeenCalled()
+  })
+
+  it('keeps the hold through a scroll that does not move the row', () => {
+    // The app scrolls itself constantly -- the chat list sticks to the bottom
+    // while the agent streams -- and none of those scrolls touches this row.
+    // Cancelling on any scroll would make a long press impossible while
+    // anything streams.
+    row.dispatchEvent(pointer('pointerdown', { x: 90, y: 110 }))
+    document.dispatchEvent(new Event('scroll'))
+    document.dispatchEvent(new Event('scroll'))
+    vi.advanceTimersByTime(HOLD_MS)
+    row.dispatchEvent(pointer('pointerup', { x: 90, y: 110 }))
+    vi.runAllTimers()
+
+    expect(onOpen).toHaveBeenCalledTimes(1)
+  })
+
+  it('drops a hold that already fired when a scroll moves the row', () => {
+    // On engines that pan without `pointercancel`, the scroll fallback is the
+    // only cancel. A fired hold must fall with the unfired one, or the menu
+    // pops on lift while the user is scrolling past.
+    row.dispatchEvent(pointer('pointerdown', { x: 90, y: 110 }))
+    vi.advanceTimersByTime(HOLD_MS)
+    rowRect.top += 40
+    document.dispatchEvent(new Event('scroll'))
+    row.dispatchEvent(pointer('pointerup', { x: 90, y: 110 }))
+    vi.runAllTimers()
+
+    expect(onOpen).not.toHaveBeenCalled()
+  })
+
+  it('ignores a scroll once no hold is in flight', () => {
+    // Nothing is armed, so the listener must already be detached and this must not
+    // reach into the gesture's state.
+    document.dispatchEvent(new Event('scroll'))
+    holdAndRelease()
+
+    expect(onOpen).toHaveBeenCalledTimes(1)
+  })
+
+  it('never starts a hold for a mouse', () => {
+    row.dispatchEvent(pointer('pointerdown', { x: 90, y: 110, pointerType: 'mouse' }))
+    expect(row.hasAttribute('data-press-hold')).toBe(false)
+
+    vi.advanceTimersByTime(HOLD_MS * 2)
+    vi.runAllTimers()
+
+    expect(onOpen).not.toHaveBeenCalled()
+  })
+
+  it('ignores a secondary finger', () => {
+    row.dispatchEvent(pointer('pointerdown', { x: 90, y: 110, isPrimary: false }))
+    vi.advanceTimersByTime(HOLD_MS)
+    vi.runAllTimers()
+
+    expect(onOpen).not.toHaveBeenCalled()
+  })
+
+  it('ignores a press that starts inside a text input', () => {
+    const input = document.createElement('input')
+    row.appendChild(input)
+
+    input.dispatchEvent(pointer('pointerdown', { x: 90, y: 110 }))
+    vi.advanceTimersByTime(HOLD_MS)
+    vi.runAllTimers()
+
+    expect(onOpen).not.toHaveBeenCalled()
+    expect(row.hasAttribute('data-press-hold')).toBe(false)
+  })
+
+  it('ignores a press that starts inside a popover', () => {
+    // On the `contextMenuFor` surfaces the menu is a DOM child of the row. A
+    // press on a menu item belongs to the menu: arming here would ramp the tint
+    // on every tap, and a 500ms decision hold would swallow the item's click.
+    const popover = document.createElement('menu')
+    popover.setAttribute('popover', 'auto')
+    const item = document.createElement('button')
+    popover.appendChild(item)
+    row.appendChild(popover)
+
+    item.dispatchEvent(pointer('pointerdown', { x: 90, y: 110 }))
+    vi.advanceTimersByTime(HOLD_MS)
+    vi.runAllTimers()
+
+    expect(onOpen).not.toHaveBeenCalled()
+    expect(row.hasAttribute('data-press-hold')).toBe(false)
+
+    const e = new MouseEvent('contextmenu', { clientX: 95, bubbles: true, cancelable: true })
+    item.dispatchEvent(e)
+    expect(e.defaultPrevented).toBe(false)
+  })
+
+  it('keeps a fired hold through another pointer press', () => {
+    // A second finger, or a mouse click on a hybrid device, must not kill the
+    // hold the first finger is still holding for.
+    row.dispatchEvent(pointer('pointerdown', { x: 90, y: 110 }))
+    vi.advanceTimersByTime(HOLD_MS)
+
+    row.dispatchEvent(pointer('pointerdown', { x: 130, y: 110, pointerId: 2, isPrimary: false }))
+    row.dispatchEvent(pointer('pointerdown', { x: 130, y: 110, pointerType: 'mouse' }))
+
+    row.dispatchEvent(pointer('pointerup', { x: 90, y: 110 }))
+    vi.runAllTimers()
+
+    expect(onOpen).toHaveBeenCalledTimes(1)
+  })
+
+  it('lets the release of a fired hold reach document-level listeners', () => {
+    // The drag sensor detaches on this release and the chat scroller drops the
+    // pointer from its input set, so the event must keep propagating.
+    const documentPointerUp = vi.fn()
+    document.addEventListener('pointerup', documentPointerUp)
+
+    row.dispatchEvent(pointer('pointerdown', { x: 90, y: 110 }))
+    vi.advanceTimersByTime(HOLD_MS)
+    row.dispatchEvent(pointer('pointerup', { x: 90, y: 110 }))
+    vi.runAllTimers()
+
+    expect(documentPointerUp).toHaveBeenCalledTimes(1)
+    document.removeEventListener('pointerup', documentPointerUp)
+  })
+
+  it('flags the fired release for tooltip suppression until the menu opens', () => {
+    row.dispatchEvent(pointer('pointerdown', { x: 90, y: 110 }))
+    vi.advanceTimersByTime(HOLD_MS)
+    expect(touchReleaseOpensMenu()).toBe(false)
+
+    row.dispatchEvent(pointer('pointerup', { x: 90, y: 110 }))
+    expect(touchReleaseOpensMenu()).toBe(true)
+
+    vi.runAllTimers()
+    expect(touchReleaseOpensMenu()).toBe(false)
+  })
+
+  it('ignores a move belonging to a different pointer', () => {
+    row.dispatchEvent(pointer('pointerdown', { x: 90, y: 110, pointerId: 1 }))
+    row.dispatchEvent(pointer('pointermove', { x: 400, y: 400, pointerId: 2 }))
+    vi.advanceTimersByTime(HOLD_MS)
+    row.dispatchEvent(pointer('pointerup', { x: 90, y: 110, pointerId: 1 }))
+    vi.runAllTimers()
+
+    expect(onOpen).toHaveBeenCalledTimes(1)
+  })
+
+  describe('contextmenu', () => {
+    /** Windows dispatches `contextmenu` on button RELEASE, so no button is down. */
+    function rightClick(x = 150): MouseEvent {
+      const e = new MouseEvent('contextmenu', { clientX: x, buttons: 0, bubbles: true, cancelable: true })
+      row.dispatchEvent(e)
+      return e
+    }
+
+    /** macOS and Linux dispatch `contextmenu` on button PRESS, with button 2 still held. */
+    function rightPress(x = 150): MouseEvent {
+      const e = new MouseEvent('contextmenu', { clientX: x, buttons: 2, bubbles: true, cancelable: true })
+      row.dispatchEvent(e)
+      return e
+    }
+
+    it('opens at the cursor and suppresses the native menu', () => {
+      const e = rightClick(150)
+      vi.runAllTimers()
+
+      expect(e.defaultPrevented).toBe(true)
+      expect(onOpen).toHaveBeenCalledTimes(1)
+      expect(onOpen).toHaveBeenCalledWith(expect.objectContaining({ clientX: 150 }))
+    })
+
+    it('anchors at the cursor on the viewport\'s top edge, where clientY is 0', () => {
+      // clientY 0 is a real coordinate, not the keyboard path's "no position".
+      const e = new MouseEvent('contextmenu', { clientX: 150, clientY: 0, buttons: 0, bubbles: true, cancelable: true })
+      row.dispatchEvent(e)
+      vi.runAllTimers()
+
+      expect(onOpen).toHaveBeenCalledWith(expect.objectContaining({ clientX: 150, clientY: 0 }))
+    })
+
+    it('does not open early on another pointer\'s release while the button is held', () => {
+      rightPress(150)
+
+      // A touch tap elsewhere: its release still reports the held secondary
+      // button in `buttons`, so it must not open the menu.
+      document.dispatchEvent(new PointerEvent('pointerup', {
+        pointerId: 9,
+        pointerType: 'touch',
+        button: 0,
+        buttons: 2,
+        bubbles: true,
+      }))
+      vi.runAllTimers()
+      expect(onOpen).not.toHaveBeenCalled()
+
+      document.dispatchEvent(new PointerEvent('pointerup', {
+        pointerId: 5,
+        pointerType: 'mouse',
+        button: 2,
+        buttons: 0,
+        bubbles: true,
+      }))
+      vi.runAllTimers()
+
+      expect(onOpen).toHaveBeenCalledTimes(1)
+      expect(onOpen).toHaveBeenCalledWith(expect.objectContaining({ clientX: 150 }))
+    })
+
+    // The popover light-dismiss algorithm hides, on `pointerup`, every popover
+    // that was not open at `pointerdown`. Opening while the secondary button is
+    // still held therefore shows a menu that vanishes the instant the user lets
+    // go -- and stays up only for as long as they keep holding.
+    it('waits for the button to be released before opening', () => {
+      rightPress(150)
+      vi.runAllTimers()
+
+      expect(onOpen).not.toHaveBeenCalled()
+
+      document.dispatchEvent(new PointerEvent('pointerup', { pointerId: 5, pointerType: 'mouse', button: 2, bubbles: true }))
+      vi.runAllTimers()
+
+      expect(onOpen).toHaveBeenCalledTimes(1)
+      expect(onOpen).toHaveBeenCalledWith(expect.objectContaining({ clientX: 150 }))
+    })
+
+    it('opens once when the button is released, not once per release', () => {
+      rightPress(150)
+      document.dispatchEvent(new PointerEvent('pointerup', { pointerId: 5, pointerType: 'mouse', button: 2, bubbles: true }))
+      document.dispatchEvent(new PointerEvent('pointerup', { pointerId: 5, pointerType: 'mouse', button: 0, bubbles: true }))
+      vi.runAllTimers()
+
+      expect(onOpen).toHaveBeenCalledTimes(1)
+    })
+
+    it('abandons a held press that the browser cancels', () => {
+      rightPress(150)
+      document.dispatchEvent(new PointerEvent('pointercancel', { pointerId: 5, pointerType: 'mouse', bubbles: true }))
+      vi.runAllTimers()
+
+      expect(onOpen).not.toHaveBeenCalled()
+    })
+
+    it('falls back to the row edge for the keyboard menu key, which reports no position', () => {
+      rightClick(0)
+      vi.runAllTimers()
+
+      expect(onOpen).toHaveBeenCalledWith(expect.objectContaining({ clientX: 40 })) // the row's left edge
+    })
+
+    it('does not claim a click, so the next left-click still reaches the row', () => {
+      rightClick(150)
+      vi.runAllTimers()
+
+      const click = new MouseEvent('click', { bubbles: true, cancelable: true })
+      row.dispatchEvent(click)
+
+      expect(click.defaultPrevented).toBe(false)
+    })
+
+    // Android Chrome synthesizes a contextmenu at its own long-press threshold, on
+    // top of the one this module's timer already fired.
+    it('opens once when it arrives after a touch hold fired', () => {
+      row.dispatchEvent(pointer('pointerdown', { x: 90, y: 110 }))
+      vi.advanceTimersByTime(HOLD_MS)
+      rightClick(300)
+      row.dispatchEvent(pointer('pointerup', { x: 90, y: 110 }))
+      vi.runAllTimers()
+
+      expect(onOpen).toHaveBeenCalledTimes(1)
+      expect(onOpen).toHaveBeenCalledWith(expect.objectContaining({ clientX: 90 })) // the press x, not the synthetic event's
+    })
+
+    // Where the platform fires it BEFORE this module's timer, the platform wins.
+    it('fires an in-flight hold early and still opens once', () => {
+      row.dispatchEvent(pointer('pointerdown', { x: 90, y: 110 }))
+      vi.advanceTimersByTime(HOLD_MS / 2)
+      rightClick(300)
+      row.dispatchEvent(pointer('pointerup', { x: 90, y: 110 }))
+      vi.runAllTimers()
+
+      expect(onOpen).toHaveBeenCalledTimes(1)
+      expect(onOpen).toHaveBeenCalledWith(expect.objectContaining({ clientX: 90 }))
+    })
+  })
+
+  describe('selectableText', () => {
+    let selectable: HTMLElement
+    let detachSelectable: () => void
+    let onOpenSelectable: ReturnType<typeof vi.fn<(press: ContextMenuPress) => void>>
+
+    beforeEach(() => {
+      selectable = document.createElement('div')
+      selectable.textContent = 'a message body'
+      document.body.appendChild(selectable)
+      onOpenSelectable = vi.fn()
+      detachSelectable = attachContextMenuGesture(selectable, {
+        onOpen: onOpenSelectable,
+        selectableText: true,
+      })
+    })
+
+    afterEach(() => {
+      detachSelectable()
+      selectable.remove()
+      window.getSelection()?.removeAllRanges()
+    })
+
+    it('yields to the native menu when the click lands on selected text', () => {
+      selectTextWithRect(selectable, { left: 100, right: 300, top: 50, bottom: 70 })
+
+      const e = new MouseEvent('contextmenu', { clientX: 150, clientY: 60, bubbles: true, cancelable: true })
+      selectable.dispatchEvent(e)
+      vi.runAllTimers()
+
+      expect(e.defaultPrevented).toBe(false)
+      expect(onOpenSelectable).not.toHaveBeenCalled()
+    })
+
+    it('opens the app menu when the click lands beside the selection', () => {
+      selectTextWithRect(selectable, { left: 100, right: 300, top: 50, bottom: 70 })
+
+      const e = new MouseEvent('contextmenu', { clientX: 400, clientY: 60, bubbles: true, cancelable: true })
+      selectable.dispatchEvent(e)
+      vi.runAllTimers()
+
+      expect(e.defaultPrevented).toBe(true)
+      expect(onOpenSelectable).toHaveBeenCalledTimes(1)
+    })
+
+    it('opens the app menu when nothing is selected', () => {
+      const e = new MouseEvent('contextmenu', { clientX: 150, clientY: 60, bubbles: true, cancelable: true })
+      selectable.dispatchEvent(e)
+      vi.runAllTimers()
+
+      expect(e.defaultPrevented).toBe(true)
+      expect(onOpenSelectable).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('options', () => {
+    it('honours a caller-supplied hold duration', () => {
+      detach()
+      const onCustom = vi.fn()
+      detach = attachContextMenuGesture(row, { onOpen: onCustom, holdMs: 1000 })
+
+      row.dispatchEvent(pointer('pointerdown', { x: 90, y: 110 }))
+      vi.advanceTimersByTime(HOLD_MS)
+      row.dispatchEvent(pointer('pointerup', { x: 90, y: 110 }))
+      vi.runAllTimers()
+      // The default threshold is not this gesture's threshold.
+      expect(onCustom).not.toHaveBeenCalled()
+
+      row.dispatchEvent(pointer('pointerdown', { x: 90, y: 110 }))
+      vi.advanceTimersByTime(1000)
+      row.dispatchEvent(pointer('pointerup', { x: 90, y: 110 }))
+      vi.runAllTimers()
+      expect(onCustom).toHaveBeenCalledTimes(1)
+    })
+
+    it('honours a caller-supplied slop', () => {
+      detach()
+      const onCustom = vi.fn()
+      detach = attachContextMenuGesture(row, { onOpen: onCustom, slopPx: 40 })
+
+      row.dispatchEvent(pointer('pointerdown', { x: 90, y: 110 }))
+      // Past the default slop, inside this gesture's own.
+      row.dispatchEvent(pointer('pointermove', { x: 90, y: 110 + PRESS_SLOP_PX + 5 }))
+      vi.advanceTimersByTime(HOLD_MS)
+      row.dispatchEvent(pointer('pointerup', { x: 90, y: 110 }))
+      vi.runAllTimers()
+
+      expect(onCustom).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('detach', () => {
+    it('makes every listener inert', () => {
+      detach()
+
+      row.dispatchEvent(pointer('pointerdown', { x: 90, y: 110 }))
+      vi.advanceTimersByTime(HOLD_MS)
+      row.dispatchEvent(pointer('pointerup', { x: 90, y: 110 }))
+      const menu = new MouseEvent('contextmenu', { clientX: 150, bubbles: true, cancelable: true })
+      row.dispatchEvent(menu)
+      vi.runAllTimers()
+
+      expect(onOpen).not.toHaveBeenCalled()
+      expect(menu.defaultPrevented).toBe(false)
+      expect(row.hasAttribute('data-press-hold')).toBe(false)
+
+      // afterEach detaches again; that must stay safe.
+      detach = () => {}
+    })
+
+    it('drops the indicator attribute', () => {
+      expect(row.hasAttribute('data-ctx-menu')).toBe(true)
+      detach()
+      expect(row.hasAttribute('data-ctx-menu')).toBe(false)
+      detach = () => {}
+    })
+
+    it('cancels a scheduled open', () => {
+      row.dispatchEvent(pointer('pointerdown', { x: 90, y: 110 }))
+      vi.advanceTimersByTime(HOLD_MS)
+      row.dispatchEvent(pointer('pointerup', { x: 90, y: 110 }))
+      detach()
+      vi.runAllTimers()
+
+      expect(onOpen).not.toHaveBeenCalled()
+      detach = () => {}
+    })
+  })
+})

--- a/frontend/src/components/common/contextMenuGesture.ts
+++ b/frontend/src/components/common/contextMenuGesture.ts
@@ -1,0 +1,471 @@
+import type { PopoverAnchorRect } from '~/lib/popoverPosition'
+import { motion } from '~/styles/tokens'
+import './contextMenuGesture.css'
+
+/** Where a right-click or a long press landed, in viewport coordinates. */
+export interface ContextMenuPress {
+  clientX: number
+  clientY: number
+}
+
+/**
+ * The rect a context menu opens against: a zero-height band at the press point,
+ * so the menu's top-left corner sits exactly there.
+ *
+ * One rule for both inputs, with no finger-clearance offset for touch, because a
+ * long press opens its menu on RELEASE (see `scheduleOpen`) -- the finger has left
+ * the glass by the time there is anything to cover. Anchoring to the pressed row
+ * instead would put the menu at that row's bottom edge, which is nowhere near the
+ * pointer on a tall row such as a chat message.
+ *
+ * `calcPopoverPosition` still flips the menu above the point when it would be
+ * clipped at the foot of the viewport, which is what a context menu should do.
+ */
+export function pressAnchorRect(press: ContextMenuPress): PopoverAnchorRect {
+  return { top: press.clientY, bottom: press.clientY, left: press.clientX }
+}
+
+/**
+ * Pointer travel that abandons a hold, in CSS pixels.
+ *
+ * Deliberately BELOW solid-dnd's activation distance of 10 (see
+ * ~/components/shell/dragPointerSensor.ts), so a finger that starts to drag always
+ * abandons the menu before the drag lifts the row. Also inside iOS's 10-point
+ * `allowableMovement` and Android's 8dp touch slop, so an unsteady finger that the
+ * platform would still call a long press is one here too.
+ */
+export const PRESS_SLOP_PX = 8
+
+/** Row movement, in CSS pixels, past which a scroll counts as moving the row. */
+const SCROLL_MOVE_PX = 1
+
+/**
+ * Marks an armed row. An ATTRIBUTE, never a class: the rows that mount this
+ * gesture assign their own `class` reactively, and that assignment replaces the
+ * whole class list -- a class added here once at attach would be silently
+ * deleted the next time the row's class string re-ran (a tab becoming active, a
+ * chat row reclassifying mid-stream). Nothing rewrites another attribute.
+ * ~/components/common/contextMenuGesture.css.ts keys every indicator rule on it.
+ */
+const GESTURE_ATTR = 'data-ctx-menu'
+
+/** Marks a row whose hold is in flight. The CSS ramps the tint off it. */
+const PRESS_HOLD_ATTR = 'data-press-hold'
+
+/**
+ * True for the single task between a fired hold's release and its menu opening.
+ *
+ * The release must stay visible to document-level listeners -- the drag sensor
+ * detaches on it, and the chat scroller drops the pointer from its input set --
+ * so it is NOT stopped. `Tooltip`'s touch handler reads this flag and declines
+ * to present, which is the one reaction a stop used to prevent: the tooltip is
+ * a `popover="manual"` that enters the top layer a frame AFTER the menu, so an
+ * unsuppressed one would stack above the menu. See `showOnTouch` in
+ * ~/components/common/Tooltip.tsx.
+ */
+let releaseOpensMenu = false
+
+/** Whether `pointerup` is the release of a long press whose menu is about to open. */
+export function touchReleaseOpensMenu(): boolean {
+  return releaseOpensMenu
+}
+
+/**
+ * Presses this module must leave alone: the inline rename inputs inside these
+ * rows (a long press there must keep the native selection handles and paste
+ * callout), and any popover -- on the `contextMenuFor` surfaces the menu itself
+ * is a DOM child of the row, so a press on a menu item belongs to the menu.
+ * Arming on one would swallow the item's click after a decision hold, and a
+ * drag would start from under the open menu.
+ */
+function pressBelongsToEmbeddedUi(e: PointerEvent | MouseEvent): boolean {
+  const target = e.target as Element | null
+  return Boolean(target?.closest?.('input, textarea, [contenteditable="true"], [popover]'))
+}
+
+export interface ContextMenuGestureOptions {
+  /**
+   * Open the menu at `press`. Called at most once per gesture, and always from a
+   * task of its own -- never synchronously inside the pointer event that completed
+   * the gesture. See `scheduleOpen` for why that matters.
+   */
+  onOpen: (press: ContextMenuPress) => void
+  /**
+   * Keep the element's text selectable. Only the iOS callout is suppressed, and
+   * then only on a coarse pointer; a right-click inside an existing selection
+   * yields to the native menu so its Copy still works. The chat message rows set
+   * this; every other row owns its long press outright.
+   */
+  selectableText?: boolean
+  /** Hold duration in ms. Defaults to `motion.longPress`. */
+  holdMs?: number
+  /** Movement cancel threshold in CSS pixels. Defaults to `PRESS_SLOP_PX`. */
+  slopPx?: number
+}
+
+/**
+ * Give `el` the two context-menu inputs that a hover-revealed kebab does not have:
+ * a touch long press and a secondary-button click. Returns the detach function.
+ *
+ * The module attaches real listeners to an element rather than returning a bag of
+ * JSX props for two reasons. It needs the CAPTURE phase for the `click` it
+ * swallows -- the row must not also select, and Solid delegates `onClick` to
+ * `document`, which a bubble-phase stop never beats. And it keeps the open state
+ * inside `DropdownMenu`, which already owns `showPopover()` and the anchor,
+ * instead of threading four wires through every row.
+ */
+export function attachContextMenuGesture(
+  el: HTMLElement,
+  opts: ContextMenuGestureOptions,
+): () => void {
+  const holdMs = opts.holdMs ?? motion.longPress
+  const slopPx = opts.slopPx ?? PRESS_SLOP_PX
+
+  /** The touch being timed. `null` means no hold is in flight. */
+  let pointerId: number | null = null
+  let startX = 0
+  let startY = 0
+  /** The row's position at pointerdown, to tell a scroll that moves it from one that does not. */
+  let startTop = 0
+  let startLeft = 0
+  let holdTimer: ReturnType<typeof setTimeout> | undefined
+  let openTimer: ReturnType<typeof setTimeout> | undefined
+  /** Where this gesture will anchor, captured when it decided to open. */
+  let firedAt: ContextMenuPress = { clientX: 0, clientY: 0 }
+  /** This gesture decided to open a menu. */
+  let fired = false
+  /** The next `click` belongs to the gesture, not to the row. */
+  let swallowClick = false
+  /** Removes the release listeners armed by `openAfterRelease`. A no-op when none are. */
+  let disarmRelease: () => void = () => {}
+
+  el.setAttribute(GESTURE_ATTR, opts.selectableText ? 'selectable' : 'owned')
+
+  /**
+   * Cancel a hold when a scroll moves the pressed row.
+   *
+   * Blink fires `pointercancel` the moment it claims a touch for a pan, which is
+   * the primary path; this is the fallback for engines that pan without one.
+   * Armed only while a hold is in flight, so the module never holds a standing
+   * document listener.
+   *
+   * The rect comparison is the whole test. The app scrolls itself constantly
+   * (the chat list sticks to the bottom while the agent streams), and a scroll
+   * ANYWHERE fires an event here; cancelling on it would make a long press
+   * impossible while anything streams. Only a scroll that actually moved this
+   * row -- an ancestor pan, a programmatic scrollIntoView -- ends the gesture.
+   */
+  function onDocumentScroll() {
+    const rect = el.getBoundingClientRect()
+    if (Math.abs(rect.top - startTop) <= SCROLL_MOVE_PX && Math.abs(rect.left - startLeft) <= SCROLL_MOVE_PX)
+      return
+    // The row moved under the finger, fired or not. The user is scrolling past
+    // it; no `click` will follow to be swallowed. Mirrors `onPointerCancel`.
+    fired = false
+    swallowClick = false
+    endGesture()
+  }
+
+  const armScrollCancel = () => {
+    document.addEventListener('scroll', onDocumentScroll, { capture: true, passive: true })
+  }
+
+  const disarmScrollCancel = () => {
+    document.removeEventListener('scroll', onDocumentScroll, { capture: true })
+  }
+
+  /**
+   * End the gesture's pointer phase. Leaves `swallowClick` and `openTimer` alone -- both outlive it.
+   *
+   * A function declaration, not an arrow constant: `onDocumentScroll` above and
+   * the pointer handlers below both end the gesture, and only hoisting lets a
+   * definition sit after one caller and before the other without a forward
+   * reference.
+   */
+  function endGesture() {
+    if (pointerId === null && holdTimer === undefined)
+      return
+    pointerId = null
+    clearTimeout(holdTimer)
+    holdTimer = undefined
+    el.removeAttribute(PRESS_HOLD_ATTR)
+    disarmScrollCancel()
+  }
+
+  /** Abandon a hold that has not fired. A fired hold is finished by `endGesture` on release. */
+  function cancelHold() {
+    if (fired)
+      return
+    endGesture()
+  }
+
+  /**
+   * Decide to open. Records the anchor x, but does NOT open -- `scheduleOpen` does
+   * that after the pointer phase ends.
+   *
+   * Only a touch hold claims the click that follows it. A secondary-button press
+   * produces no `click` at all (the spec dispatches `auxclick` instead), and the
+   * keyboard path has no pointer events, so claiming there would leave a standing
+   * flag that swallows the row's next legitimate left-click instead.
+   */
+  const fire = (press: ContextMenuPress, claimsClick: boolean) => {
+    if (fired)
+      return
+    fired = true
+    swallowClick = claimsClick
+    firedAt = press
+    clearTimeout(holdTimer)
+    holdTimer = undefined
+  }
+
+  /**
+   * Open in a task of its own.
+   *
+   * The HTML light-dismiss algorithm records the popover ancestor of the
+   * `pointerdown` target and, on `pointerup`, hides every popover that is not in
+   * that chain. A `popover="auto"` shown while the finger is still down on a row --
+   * which has no popover ancestor -- is therefore hidden by the very release that
+   * ends the gesture. Right-click has the same shape, because `contextmenu` fires
+   * on button-down on macOS and Linux.
+   *
+   * So every caller reaches this only once the pointer is already up: the touch
+   * path from `pointerup`, the still-held mouse path from `openAfterRelease`, and
+   * the Windows / keyboard path straight from `contextmenu`, where nothing is
+   * held. The `setTimeout` then puts the open one task beyond the release, after
+   * the browser's light-dismiss pass for it has run.
+   *
+   * Two things fall out of that: the release can never land on a menu item,
+   * because the menu does not exist yet, and the press indicator still completes
+   * at `holdMs`, so a touch user gets the "ready" signal on time and the menu
+   * follows on lift.
+   */
+  const scheduleOpen = () => {
+    clearTimeout(openTimer)
+    openTimer = setTimeout(() => {
+      openTimer = undefined
+      releaseOpensMenu = false
+      const press = firedAt
+      fired = false
+      opts.onOpen(press)
+    }, 0)
+  }
+
+  /**
+   * Open once the currently-held secondary button comes back up.
+   *
+   * macOS and Linux dispatch `contextmenu` on button PRESS, so at that moment the
+   * gesture is only half over and the release is still to come -- and that release
+   * is exactly what light-dismiss acts on. Opening from the `contextmenu` event
+   * itself produced a menu that appeared and then vanished the instant the user
+   * let go, staying up only while they kept holding the button.
+   *
+   * Windows dispatches `contextmenu` on RELEASE instead, and the keyboard menu key
+   * dispatches it with no buttons at all; both report `buttons === 0` and take the
+   * immediate path, so this listener is never armed for them.
+   *
+   * Only the held button's own release completes the gesture. Another pointer's
+   * release -- a touch tap elsewhere while the button is down -- still reports
+   * `buttons` with the secondary bit set, and must not open the menu early: the
+   * button's own release would light-dismiss it a moment later. A touch
+   * `pointercancel` is another finger's pan and is ignored the same way.
+   */
+  const openAfterRelease = () => {
+    disarmRelease()
+
+    const onRelease = (e: Event) => {
+      const pointer = e as PointerEvent
+      if (e.type === 'pointerup') {
+        if (pointer.button === 2 || pointer.buttons === 0) {
+          disarmRelease()
+          scheduleOpen()
+        }
+        return
+      }
+      // `pointercancel`: the held pointer's stream was cancelled outright (rare
+      // for a mouse; pens lose it to palm rejection). No release follows, so
+      // there is no menu to open.
+      if (pointer.pointerType !== 'touch') {
+        disarmRelease()
+        fired = false
+      }
+    }
+
+    document.addEventListener('pointerup', onRelease, true)
+    document.addEventListener('pointercancel', onRelease, true)
+    disarmRelease = () => {
+      document.removeEventListener('pointerup', onRelease, true)
+      document.removeEventListener('pointercancel', onRelease, true)
+      disarmRelease = () => {}
+    }
+  }
+
+  const onPointerDown = (e: PointerEvent) => {
+    // Any new press ends the previous gesture's claim on the click that follows
+    // it. That click has had its chance.
+    swallowClick = false
+
+    // A mouse never starts a hold. It has `contextmenu`, and a mouse hold must not
+    // steal click-drag, text selection, or the row's own press states.
+    if (e.pointerType !== 'touch' || !e.isPrimary || e.button !== 0)
+      return
+    if (pressBelongsToEmbeddedUi(e))
+      return
+    // A fresh tracked press supersedes a hold that already fired and is waiting
+    // for its release: that release no longer matches `pointerId`.
+    fired = false
+
+    pointerId = e.pointerId
+    startX = e.clientX
+    startY = e.clientY
+    const rect = el.getBoundingClientRect()
+    startTop = rect.top
+    startLeft = rect.left
+    el.setAttribute(PRESS_HOLD_ATTR, '')
+    armScrollCancel()
+    holdTimer = setTimeout(() => {
+      holdTimer = undefined
+      // The press point, not wherever the finger drifted to inside the slop.
+      fire({ clientX: startX, clientY: startY }, true)
+    }, holdMs)
+  }
+
+  const onPointerMove = (e: PointerEvent) => {
+    if (pointerId === null || e.pointerId !== pointerId)
+      return
+    if (Math.hypot(e.clientX - startX, e.clientY - startY) > slopPx)
+      cancelHold()
+  }
+
+  const onPointerCancel = (e: PointerEvent) => {
+    if (pointerId === null || e.pointerId !== pointerId)
+      return
+    // The browser took the touch for a pan. Drop the hold even if it fired -- the
+    // user is scrolling, and no `click` will follow to be swallowed.
+    fired = false
+    swallowClick = false
+    endGesture()
+  }
+
+  const onPointerUp = (e: PointerEvent) => {
+    if (pointerId === null || e.pointerId !== pointerId)
+      return
+    if (fired) {
+      // The release keeps propagating: the drag sensor detaches on it, and the
+      // chat scroller drops the pointer from its input set. The one consumer
+      // that must NOT react -- `Tooltip`, which would present over the menu --
+      // checks `touchReleaseOpensMenu` instead.
+      releaseOpensMenu = true
+      scheduleOpen()
+    }
+    endGesture()
+  }
+
+  const onClickCapture = (e: MouseEvent) => {
+    if (!swallowClick)
+      return
+    swallowClick = false
+    // Solid delegates `onClick` to `document`, so stopping here is what keeps the
+    // row from also selecting, expanding, or opening a tab.
+    e.stopPropagation()
+    e.preventDefault()
+  }
+
+  const onContextMenu = (e: MouseEvent) => {
+    if (pressBelongsToEmbeddedUi(e))
+      return
+    if (opts.selectableText && clickIsInsideSelection(e)) {
+      // Leave the native menu alone so its Copy still works over selected text.
+      return
+    }
+    e.preventDefault()
+
+    if (fired) {
+      // Android Chrome synthesizes a `contextmenu` at its own long-press threshold.
+      // The hold timer already claimed this gesture, so drop the duplicate.
+      return
+    }
+    if (pointerId !== null) {
+      // A `contextmenu` during a touch hold IS the long press. Where the platform
+      // has an opinion about timing, it wins. The trailing click is this touch's,
+      // so claim it; `pointerup` schedules the open.
+      fire({ clientX: startX, clientY: startY }, true)
+      return
+    }
+    // A mouse right-click, or the keyboard Menu key / Shift+F10 on a focused row.
+    // The keyboard path reports no position at all, which reads as both
+    // coordinates zero; a real pointer at the viewport's exact top-left pixel
+    // matches that too, but nothing else does. Fall back to the row's own edges:
+    // the menu opens below the row, left-aligned with it.
+    const rect = el.getBoundingClientRect()
+    const hasPosition = e.clientX !== 0 || e.clientY !== 0
+    fire({
+      clientX: hasPosition ? e.clientX : rect.left,
+      clientY: hasPosition ? e.clientY : rect.bottom,
+    }, false)
+    if (e.buttons === 0)
+      scheduleOpen()
+    else
+      openAfterRelease()
+  }
+
+  el.addEventListener('pointerdown', onPointerDown)
+  el.addEventListener('pointermove', onPointerMove, { passive: true })
+  el.addEventListener('pointercancel', onPointerCancel)
+  el.addEventListener('pointerup', onPointerUp)
+  el.addEventListener('click', onClickCapture, { capture: true })
+  el.addEventListener('contextmenu', onContextMenu)
+
+  return () => {
+    el.removeEventListener('pointerdown', onPointerDown)
+    el.removeEventListener('pointermove', onPointerMove)
+    el.removeEventListener('pointercancel', onPointerCancel)
+    el.removeEventListener('pointerup', onPointerUp)
+    el.removeEventListener('click', onClickCapture, { capture: true })
+    el.removeEventListener('contextmenu', onContextMenu)
+    clearTimeout(holdTimer)
+    clearTimeout(openTimer)
+    holdTimer = undefined
+    openTimer = undefined
+    pointerId = null
+    fired = false
+    swallowClick = false
+    releaseOpensMenu = false
+    disarmRelease()
+    disarmScrollCancel()
+    el.removeAttribute(PRESS_HOLD_ATTR)
+    el.removeAttribute(GESTURE_ATTR)
+  }
+}
+
+/**
+ * Whether a right-click landed on live selected text.
+ *
+ * The test is the click POINT against the selection's rects, not the click target
+ * against the selected nodes. `Selection.containsNode` answers the wrong question
+ * here: a row that holds the selection is not itself contained by it, so a
+ * right-click over a highlighted word inside that row would read as "outside" and
+ * lose the native Copy. Rects also give the correct answer for the reverse case --
+ * a click on the row's padding, next to the highlight, opens the app menu.
+ */
+function clickIsInsideSelection(e: MouseEvent): boolean {
+  const selection = window.getSelection()
+  if (!selection || selection.isCollapsed || selection.rangeCount === 0)
+    return false
+  for (let i = 0; i < selection.rangeCount; i++) {
+    // jsdom does no layout and does not implement `Range.getClientRects` at all, so
+    // this stays optional. There, and anywhere else without geometry, the predicate
+    // reports "not on the selection" and the app menu opens -- the same answer a
+    // real browser gives for an empty rect list.
+    const rects = selection.getRangeAt(i).getClientRects?.()
+    if (!rects)
+      continue
+    for (let r = 0; r < rects.length; r++) {
+      const rect = rects[r]
+      if (e.clientX >= rect.left && e.clientX <= rect.right
+        && e.clientY >= rect.top && e.clientY <= rect.bottom) {
+        return true
+      }
+    }
+  }
+  return false
+}

--- a/frontend/src/components/shell/SectionDragContext.tsx
+++ b/frontend/src/components/shell/SectionDragContext.tsx
@@ -1,10 +1,11 @@
 import type { JSX } from 'solid-js'
 import type { Section } from '~/generated/leapmux/v1/section_pb'
-import { closestCenter, DragDropProvider, DragDropSensors, DragOverlay } from '@thisbeyond/solid-dnd'
+import { closestCenter, DragDropProvider, DragOverlay } from '@thisbeyond/solid-dnd'
 import { createSignal, useContext } from 'solid-js'
 import { Sidebar } from '~/generated/leapmux/v1/section_pb'
 import { createStableContext } from '~/lib/createStableContext'
 import { mid } from '~/lib/lexorank'
+import { DragPointerSensor } from './dragPointerSensor'
 import { dragOverlayAboveFloating } from './FloatingWindowContainer.css'
 import {
   computeInsertPosition,
@@ -415,7 +416,7 @@ export function SectionDragProvider(props: SectionDragProviderProps) {
         onDragEnd={handleDragEnd}
         collisionDetector={collisionDetector as any}
       >
-        <DragDropSensors />
+        <DragPointerSensor />
         {props.children}
         <DragOverlay class={dragOverlayAboveFloating}>
           {(draggable: any) => {

--- a/frontend/src/components/shell/TabBar.test.tsx
+++ b/frontend/src/components/shell/TabBar.test.tsx
@@ -27,45 +27,52 @@ vi.mock('~/components/shell/TabDragContext', () => ({
 }))
 
 // Mock DropdownMenu to render children directly (jsdom lacks popover API)
-vi.mock('~/components/common/DropdownMenu', () => ({
-  DropdownMenu(props: any) {
-    const trigger = () => typeof props.trigger === 'function'
-      ? props.trigger({
-          'aria-expanded': false,
-          'ref': () => {},
-          'onPointerDown': () => {},
-          'onClick': () => {},
-        })
-      : props.trigger
-    return (
-      <>
-        {trigger()}
-        {props.children}
-      </>
-    )
-  },
-  DropdownMenuItemContent(props: any) {
-    return (
-      <span>
-        <span>{props.label}</span>
-        {props.shortcut ? <span>{props.shortcut}</span> : null}
-      </span>
-    )
-  },
-  DropdownMenuCheckableItem(props: any) {
-    return (
-      <button
-        role={props.kind === 'checkbox' ? 'menuitemcheckbox' : 'menuitemradio'}
-        aria-checked={props.checked}
-        disabled={props.disabled}
-        onClick={() => props.onSelect()}
-      >
-        <input type={props.kind} checked={props.checked} disabled />
-        <span>{props.label}</span>
-      </button>
-    )
-  },
-}))
+vi.mock('~/components/common/DropdownMenu', async () => {
+  const { createSignal } = await import('solid-js')
+  return {
+    createContextMenuAnchor: () => {
+      const [anchor, setAnchor] = createSignal<HTMLElement>()
+      return [anchor, setAnchor]
+    },
+    DropdownMenu(props: any) {
+      const trigger = () => typeof props.trigger === 'function'
+        ? props.trigger({
+            'aria-expanded': false,
+            'ref': () => {},
+            'onPointerDown': () => {},
+            'onClick': () => {},
+          })
+        : props.trigger
+      return (
+        <>
+          {trigger()}
+          {props.children}
+        </>
+      )
+    },
+    DropdownMenuItemContent(props: any) {
+      return (
+        <span>
+          <span>{props.label}</span>
+          {props.shortcut ? <span>{props.shortcut}</span> : null}
+        </span>
+      )
+    },
+    DropdownMenuCheckableItem(props: any) {
+      return (
+        <button
+          role={props.kind === 'checkbox' ? 'menuitemcheckbox' : 'menuitemradio'}
+          aria-checked={props.checked}
+          disabled={props.disabled}
+          onClick={() => props.onSelect()}
+        >
+          <input type={props.kind} checked={props.checked} disabled />
+          <span>{props.label}</span>
+        </button>
+      )
+    },
+  }
+})
 
 // Mock TabBar.css to provide minimal class names
 vi.mock('~/components/shell/TabBar.css', () => ({

--- a/frontend/src/components/shell/TabBar.tsx
+++ b/frontend/src/components/shell/TabBar.tsx
@@ -1,5 +1,6 @@
 import type { Component, JSX } from 'solid-js'
 import type { TileActions } from './TileActionsMenu'
+import type { TabPopAction } from '~/components/common/TabContextMenu'
 import type { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import type { TerminalStatus } from '~/generated/leapmux/v1/terminal_pb'
 import type { Tab } from '~/stores/tab.types'
@@ -13,8 +14,9 @@ import Terminal from 'lucide-solid/icons/terminal'
 import X from 'lucide-solid/icons/x'
 import { createSignal, ErrorBoundary, For, onCleanup, onMount, Show } from 'solid-js'
 import { AgentProviderIcon, agentProviderLabel } from '~/components/common/AgentProviderIcon'
-import { DropdownMenu, DropdownMenuCheckableItem, DropdownMenuItemContent } from '~/components/common/DropdownMenu'
+import { createContextMenuAnchor, DropdownMenu, DropdownMenuCheckableItem, DropdownMenuItemContent } from '~/components/common/DropdownMenu'
 import { IconButton, IconButtonState } from '~/components/common/IconButton'
+import { TabContextMenu } from '~/components/common/TabContextMenu'
 import { TabTypeIcon } from '~/components/common/TabTypeIcon'
 import { Tooltip } from '~/components/common/Tooltip'
 import { usePreferences } from '~/context/PreferencesContext'
@@ -114,6 +116,11 @@ interface TabBarProps {
   mobile?: TabBarMobileProps
   /** Tile-level actions in the overflow menu. */
   tileActions?: TileActions
+  /**
+   * The pop-out / pop-in affordance for one tab, for that tab's context menu.
+   * Built by `TileRenderer` from the same function that builds the tile-level one.
+   */
+  tabPop?: (tab: Tab) => TabPopAction | undefined
 }
 
 export const TabBar: Component<TabBarProps> = (props) => {
@@ -218,10 +225,17 @@ export const TabBar: Component<TabBarProps> = (props) => {
   // it to stay live. Reading it once here would freeze the row at whatever the
   // tab looked like when it mounted.
   const renderTab = (tab: () => Tab, sortable?: ReturnType<typeof createSortable>) => {
+    // The tab element, for its right-click / long-press menu.
+    const [tabEl, setTabEl] = createContextMenuAnchor()
+    const isClosing = () => props.closingTabKeys?.has(tabKey(tab())) ?? false
+    const canRename = () => tab().type !== TabType.FILE && !props.readOnly
     return (
       <div
         role="tab"
-        ref={sortable}
+        ref={(el) => {
+          setTabEl(el)
+          sortable?.(el)
+        }}
         tabIndex={0}
         aria-selected={props.activeTabKey === tabKey(tab())}
         class={styles.tab}
@@ -245,9 +259,6 @@ export const TabBar: Component<TabBarProps> = (props) => {
               return
             props.onClose(tab())
           }
-        }}
-        onContextMenu={(e: MouseEvent) => {
-          e.preventDefault()
         }}
         onDblClick={(e: MouseEvent) => {
           e.preventDefault()
@@ -314,6 +325,17 @@ export const TabBar: Component<TabBarProps> = (props) => {
             }}
           />
         </Show>
+        {/* Outside the close block: a tab that cannot be closed can still be
+            renamed or popped out. The menu host collapses to `display: contents`,
+            so it costs the tab strip no layout either way. */}
+        <TabContextMenu
+          contextMenuFor={tabEl}
+          data-testid="tab-bar-tab-menu"
+          onRename={canRename() ? () => startEditing(tab()) : undefined}
+          onClose={canCloseTab(props.readOnly, tab()) ? () => props.onClose(tab()) : undefined}
+          isClosing={isClosing()}
+          pop={props.tabPop?.(tab())}
+        />
       </div>
     )
   }

--- a/frontend/src/components/shell/TileActionsMenu.tsx
+++ b/frontend/src/components/shell/TileActionsMenu.tsx
@@ -1,4 +1,5 @@
 import type { Component } from 'solid-js'
+import type { TabPopAction } from '~/components/common/TabContextMenu'
 import type { SplitOrientation, TileCloseMode } from '~/stores/layout.store'
 import Columns2 from 'lucide-solid/icons/columns-2'
 import LayoutGrid from 'lucide-solid/icons/layout-grid'
@@ -60,11 +61,15 @@ export const SPLIT_ACTIONS: readonly SplitActionDef[] = [
  * (`createTileRenderer`) picks `label`/`testId` to match the direction;
  * absent when the tile cannot pop in either direction (workspace
  * archived, no active tab, etc.).
+ *
+ * Extends `TabPopAction` -- the shape each tab's own context menu reads -- so
+ * the two surfaces share one declared affordance instead of passing by
+ * structural coincidence. The shell layer may depend on common; common must not
+ * depend on the shell.
  */
-export interface TilePopAction {
-  label: string
+export interface TilePopAction extends TabPopAction {
+  /** The tile-level menu's trigger carries a test id; a tab's own menu derives its own. */
   testId: string
-  onClick: () => void
 }
 
 interface TileActionsMenuProps {

--- a/frontend/src/components/shell/TileRenderer.tsx
+++ b/frontend/src/components/shell/TileRenderer.tsx
@@ -554,6 +554,26 @@ export function createTileRenderer(opts: TileRendererOpts) {
   const todosFor = (agentId: string) => chatStore.todos.get(bgRootFor(agentId))
   const onOpenBackgroundTask = opts.onOpenBackgroundTask
 
+  /**
+   * The pop-out / pop-in affordance for ONE tab of a tile.
+   *
+   * Whether a tile is floating is a property of the TILE, not of a tab
+   * (`getWindowIdForTile`), so every tab in it shares the predicate and the label;
+   * only the handler's argument differs. Both the tile-level menu (through the
+   * tile's active tab) and each tab's own context menu read this one function.
+   */
+  const tabPopFor = (tileId: string, tab: Tab): TilePopAction | undefined => {
+    const inMain = getWindowIdForTile(tileId) === null
+    const handler = inMain ? onDetachTab : onAttachTab
+    if (!handler)
+      return undefined
+    return {
+      label: inMain ? 'Pop out to floating window' : 'Pop in to main window',
+      testId: inMain ? 'pop-out-button' : 'pop-in-button',
+      onClick: () => handler(tab),
+    }
+  }
+
   const createTabBarForTile = (tileId: string, actions?: () => TileActions) => {
     // Reactive accessor either way: callers from `renderTile` pass their
     // own memo (so predicate updates propagate to surviving leaves); the
@@ -616,6 +636,7 @@ export function createTileRenderer(opts: TileRendererOpts) {
             }
           : undefined}
         tileActions={liveActions()}
+        tabPop={tab => tabPopFor(tileId, tab)}
       />
     )
   }
@@ -1167,21 +1188,14 @@ export function createTileRenderer(opts: TileRendererOpts) {
     // and the TabBar overflow menu read the bag through reactive prop
     // getters, so passing `actions()` here keeps both surfaces in sync.
     const actions = createMemo(() => buildTileActions(tileId))
-    // Memoise the per-tile lookups used in pop affordance bindings so each
-    // prop re-evaluation reuses one cached projection per tile.
-    const windowId = createMemo(() => getWindowIdForTile(tileId))
+    // Memoise the per-tile lookup so each prop re-evaluation reuses one cached
+    // projection per tile.
     const activeTab = createMemo(() => getActiveTabForTile(tileId))
+    // The tile-level affordance IS the per-tab one applied to the active tab, so
+    // the two surfaces cannot drift.
     const pop = createMemo<TilePopAction | undefined>(() => {
       const tab = activeTab()
-      if (!tab)
-        return undefined
-      const inMain = windowId() === null
-      const handler = inMain ? onDetachTab : onAttachTab
-      if (!handler)
-        return undefined
-      const label = inMain ? 'Pop out to floating window' : 'Pop in to main window'
-      const testId = inMain ? 'pop-out-button' : 'pop-in-button'
-      return { label, testId, onClick: () => handler(tab) }
+      return tab ? tabPopFor(tileId, tab) : undefined
     })
     return (
       <Tile

--- a/frontend/src/components/shell/dragPointerSensor.test.tsx
+++ b/frontend/src/components/shell/dragPointerSensor.test.tsx
@@ -1,0 +1,264 @@
+import { cleanup, render } from '@solidjs/testing-library'
+import { createDraggable, DragDropProvider } from '@thisbeyond/solid-dnd'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { PRESS_SLOP_PX } from '~/components/common/contextMenuGesture'
+import { motion } from '~/styles/tokens'
+import { pointerEvent } from '~/test-support/pointer'
+import { ACTIVATION_DELAY_MS, ACTIVATION_DISTANCE_PX, DragPointerSensor } from './dragPointerSensor'
+
+/** The sensor's own events are mouse presses; the shared factory defaults to one. */
+function pointer(type: string, opts: { x?: number, y?: number, pointerType?: string, pointerId?: number, isPrimary?: boolean, button?: number } = {}): PointerEvent {
+  return pointerEvent(type, opts)
+}
+
+describe('dragPointerSensor', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+  })
+
+  it('keeps the two touch-press protocols ordered: menu slop below drag distance, drag claim below menu hold', () => {
+    // The sensor and the context-menu gesture share one press. A finger that
+    // starts to drag must abandon the menu hold BEFORE crossing the drag
+    // activation distance, and the drag's claim must come before the menu's
+    // hold -- or the row lifts under a press that is still meant to open a menu.
+    // The constants live in two modules, so nothing else holds them to this.
+    expect(PRESS_SLOP_PX).toBeLessThan(ACTIVATION_DISTANCE_PX)
+    expect(ACTIVATION_DELAY_MS).toBeLessThan(motion.longPress)
+  })
+
+  /**
+   * A `DragDropProvider` holding one draggable row and the sensor under test.
+   * `onDragStart` records what the library actually activated, which keeps the
+   * assertions off solid-dnd's internal store.
+   */
+  function renderProbe() {
+    let activeId: string | null = null
+    let rowEl!: HTMLDivElement
+
+    function Row() {
+      const draggable = createDraggable('row-1')
+      return (
+        <div
+          ref={(el) => {
+            rowEl = el
+            draggable(el)
+          }}
+        >
+          row
+        </div>
+      )
+    }
+
+    render(() => (
+      <DragDropProvider onDragStart={({ draggable }) => { activeId = String(draggable.id) }}>
+        <DragPointerSensor />
+        <Row />
+      </DragDropProvider>
+    ))
+
+    return { rowEl, activeDraggableId: () => activeId }
+  }
+
+  it('does not start a drag from a stationary touch hold', () => {
+    const { rowEl, activeDraggableId } = renderProbe()
+
+    rowEl.dispatchEvent(pointer('pointerdown', { x: 50, y: 50, pointerType: 'touch' }))
+    vi.advanceTimersByTime(motion.longPress * 2)
+
+    // The hold belongs to the context menu; the claim never lifts the row on its own.
+    expect(activeDraggableId()).toBeNull()
+  })
+
+  it('starts a touch drag when the finger moves after the claim', () => {
+    const { rowEl, activeDraggableId } = renderProbe()
+
+    rowEl.dispatchEvent(pointer('pointerdown', { x: 50, y: 50, pointerType: 'touch' }))
+    vi.advanceTimersByTime(ACTIVATION_DELAY_MS)
+    document.dispatchEvent(pointer('pointermove', { x: 50, y: 70, pointerType: 'touch' }))
+
+    expect(activeDraggableId()).toBe('row-1')
+  })
+
+  it('treats a touch that moves before the claim as a scroll, however far it travels', () => {
+    const { rowEl, activeDraggableId } = renderProbe()
+
+    rowEl.dispatchEvent(pointer('pointerdown', { x: 50, y: 50, pointerType: 'touch' }))
+    document.dispatchEvent(pointer('pointermove', { x: 50, y: 400, pointerType: 'touch' }))
+
+    expect(activeDraggableId()).toBeNull()
+  })
+
+  it('blocks the browser pan while the claim stands, so the drag wins the race', () => {
+    const { rowEl } = renderProbe()
+
+    rowEl.dispatchEvent(pointer('pointerdown', { x: 50, y: 50, pointerType: 'touch' }))
+
+    // Before the claim: the move belongs to the scroller, untouched.
+    const early = pointer('pointermove', { x: 50, y: 55, pointerType: 'touch' })
+    document.dispatchEvent(early)
+    expect(early.defaultPrevented).toBe(false)
+
+    vi.advanceTimersByTime(ACTIVATION_DELAY_MS)
+
+    const claimedMove = pointer('pointermove', { x: 50, y: 53, pointerType: 'touch' })
+    document.dispatchEvent(claimedMove)
+    expect(claimedMove.defaultPrevented).toBe(true)
+  })
+
+  it('hands the press back at the context menu threshold', () => {
+    const { rowEl, activeDraggableId } = renderProbe()
+
+    rowEl.dispatchEvent(pointer('pointerdown', { x: 50, y: 50, pointerType: 'touch' }))
+    vi.advanceTimersByTime(motion.longPress)
+
+    // The claim is gone, so a late drag cannot start on top of the open menu.
+    const late = pointer('pointermove', { x: 50, y: 200, pointerType: 'touch' })
+    document.dispatchEvent(late)
+
+    expect(late.defaultPrevented).toBe(false)
+    expect(activeDraggableId()).toBeNull()
+  })
+
+  // The test that stops the fork drifting into "we broke desktop drag".
+  it('still starts a drag from a stationary mouse hold', () => {
+    const { rowEl, activeDraggableId } = renderProbe()
+
+    rowEl.dispatchEvent(pointer('pointerdown', { x: 50, y: 50, pointerType: 'mouse' }))
+    vi.advanceTimersByTime(ACTIVATION_DELAY_MS)
+
+    expect(activeDraggableId()).toBe('row-1')
+  })
+
+  it('ignores a non-primary button', () => {
+    const { rowEl, activeDraggableId } = renderProbe()
+
+    rowEl.dispatchEvent(new PointerEvent('pointerdown', {
+      clientX: 50,
+      clientY: 50,
+      pointerId: 1,
+      pointerType: 'mouse',
+      button: 2,
+      isPrimary: true,
+      bubbles: true,
+      cancelable: true,
+    }))
+    vi.advanceTimersByTime(ACTIVATION_DELAY_MS * 2)
+
+    expect(activeDraggableId()).toBeNull()
+  })
+
+  it('unwinds on pointercancel instead of leaking document listeners', () => {
+    const { rowEl } = renderProbe()
+    const removeSpy = vi.spyOn(document, 'removeEventListener')
+
+    rowEl.dispatchEvent(pointer('pointerdown', { x: 50, y: 50, pointerType: 'touch' }))
+    document.dispatchEvent(pointer('pointercancel', { pointerType: 'touch' }))
+
+    const removed = removeSpy.mock.calls.map(call => call[0])
+    expect(removed).toContain('pointermove')
+    expect(removed).toContain('pointerup')
+    expect(removed).toContain('pointercancel')
+
+    removeSpy.mockRestore()
+  })
+
+  it('does not activate after a cancelled touch press', () => {
+    const { rowEl, activeDraggableId } = renderProbe()
+
+    rowEl.dispatchEvent(pointer('pointerdown', { x: 50, y: 50, pointerType: 'touch' }))
+    vi.advanceTimersByTime(ACTIVATION_DELAY_MS)
+    document.dispatchEvent(pointer('pointercancel', { pointerType: 'touch' }))
+    document.dispatchEvent(pointer('pointermove', { x: 50, y: 200, pointerType: 'touch' }))
+
+    expect(activeDraggableId()).toBeNull()
+  })
+
+  it('starts a fresh press without the previous one\'s claim', () => {
+    const { rowEl, activeDraggableId } = renderProbe()
+
+    // Claim, then let the press end.
+    rowEl.dispatchEvent(pointer('pointerdown', { x: 50, y: 50, pointerType: 'touch' }))
+    vi.advanceTimersByTime(ACTIVATION_DELAY_MS)
+    document.dispatchEvent(pointer('pointerup', { x: 50, y: 50, pointerType: 'touch' }))
+
+    // A new press that moves at once is a scroll again, not a drag.
+    rowEl.dispatchEvent(pointer('pointerdown', { x: 50, y: 50, pointerType: 'touch' }))
+    document.dispatchEvent(pointer('pointermove', { x: 50, y: 400, pointerType: 'touch' }))
+
+    expect(activeDraggableId()).toBeNull()
+  })
+
+  it('does not activate after a cancelled mouse press', () => {
+    const { rowEl, activeDraggableId } = renderProbe()
+
+    rowEl.dispatchEvent(pointer('pointerdown', { x: 50, y: 50, pointerType: 'mouse' }))
+    document.dispatchEvent(pointer('pointercancel', { pointerType: 'mouse' }))
+    vi.advanceTimersByTime(ACTIVATION_DELAY_MS * 2)
+
+    expect(activeDraggableId()).toBeNull()
+  })
+
+  it('ignores a touch press that starts inside an inline input', () => {
+    // The rename inputs on these rows keep their native selection gestures --
+    // the same exemption the sibling context-menu gesture applies.
+    const { rowEl, activeDraggableId } = renderProbe()
+    const input = document.createElement('input')
+    rowEl.appendChild(input)
+
+    input.dispatchEvent(pointer('pointerdown', { x: 50, y: 50, pointerType: 'touch' }))
+    vi.advanceTimersByTime(ACTIVATION_DELAY_MS)
+    document.dispatchEvent(pointer('pointermove', { x: 50, y: 90, pointerType: 'touch' }))
+
+    expect(activeDraggableId()).toBeNull()
+  })
+
+  it('ignores a touch press that starts inside a row menu popover', () => {
+    // A row's context menu is a DOM child of the row. A press on a menu item
+    // belongs to the menu, and a drag must not start from under it.
+    const { rowEl, activeDraggableId } = renderProbe()
+    const popover = document.createElement('menu')
+    popover.setAttribute('popover', 'auto')
+    rowEl.appendChild(popover)
+
+    popover.dispatchEvent(pointer('pointerdown', { x: 50, y: 50, pointerType: 'touch' }))
+    vi.advanceTimersByTime(ACTIVATION_DELAY_MS)
+    document.dispatchEvent(pointer('pointermove', { x: 50, y: 90, pointerType: 'touch' }))
+
+    expect(activeDraggableId()).toBeNull()
+  })
+
+  it('clears a superseded press\'s claim timer, so it cannot arm the next press', () => {
+    const { rowEl, activeDraggableId } = renderProbe()
+
+    // Press A at t=0, superseded by press B at t=100. A's claim timer would
+    // fire at t=250; without the clear it would mark B's press claimed, and a
+    // move at t=300 -- 200ms into B, before B's own claim -- would drag.
+    rowEl.dispatchEvent(pointer('pointerdown', { x: 50, y: 50, pointerType: 'touch' }))
+    vi.advanceTimersByTime(100)
+    rowEl.dispatchEvent(pointer('pointerdown', { x: 50, y: 50, pointerType: 'touch', pointerId: 3 }))
+    vi.advanceTimersByTime(200)
+    document.dispatchEvent(pointer('pointermove', { x: 50, y: 90, pointerId: 3, pointerType: 'touch' }))
+
+    expect(activeDraggableId()).toBeNull()
+  })
+
+  it('a secondary finger\'s release does not end the primary press', () => {
+    const { rowEl, activeDraggableId } = renderProbe()
+
+    // The primary finger presses and earns the claim.
+    rowEl.dispatchEvent(pointer('pointerdown', { x: 50, y: 50, pointerType: 'touch', pointerId: 1 }))
+    vi.advanceTimersByTime(ACTIVATION_DELAY_MS)
+
+    // A second finger taps elsewhere and lifts: its pointerup must not detach
+    // the tracked press, or the drag below would die mid-gesture.
+    document.dispatchEvent(pointer('pointerup', { x: 300, y: 300, pointerType: 'touch', pointerId: 2 }))
+    document.dispatchEvent(pointer('pointermove', { x: 50, y: 70, pointerType: 'touch', pointerId: 1 }))
+
+    expect(activeDraggableId()).toBe('row-1')
+  })
+})

--- a/frontend/src/components/shell/dragPointerSensor.ts
+++ b/frontend/src/components/shell/dragPointerSensor.ts
@@ -1,0 +1,235 @@
+import type { Id } from '@thisbeyond/solid-dnd'
+import { useDragDropContext } from '@thisbeyond/solid-dnd'
+import { onCleanup, onMount } from 'solid-js'
+import { motion } from '~/styles/tokens'
+
+/**
+ * solid-dnd's own default, kept verbatim. `PRESS_SLOP_PX` in
+ * ~/components/common/contextMenuGesture.ts sits below it deliberately; the
+ * ordering test in ./dragPointerSensor.test.tsx holds the two modules to that.
+ */
+export const ACTIVATION_DISTANCE_PX = 10
+
+/**
+ * solid-dnd's own default. Mouse only here -- see the component doc. Exported
+ * for the same ordering test.
+ */
+export const ACTIVATION_DELAY_MS = 250
+
+const SENSOR_ID = 'pointer-sensor'
+
+/**
+ * solid-dnd's pointer sensor with one policy change and one bug fix.
+ *
+ * **Policy: on touch, the 250ms hold CLAIMS the pointer instead of starting a
+ * drag.** A touch press then resolves three ways, and each is unambiguous:
+ *
+ * ```
+ *   move now (< 250ms)          -> the browser pans. A scroll.
+ *   hold 250ms, then move       -> a drag. The claim blocked the pan, so this
+ *                                  wins the race it used to lose.
+ *   hold 500ms without moving   -> the claim releases and the row's context menu
+ *                                  opens (~/components/common/contextMenuGesture.ts).
+ * ```
+ *
+ * Upstream instead started the drag outright at 250ms, filtering only on
+ * `event.button !== 0` -- which a touch pointerdown passes. That made a stationary
+ * hold lift the row, so the hold could not also mean "open the menu", and a finger
+ * resting on a row for a quarter second could no longer scroll.
+ *
+ * The claim is deliberately INVISIBLE: it calls `preventDefault` on the moves it
+ * sees and nothing else. Starting the real drag at 250ms and cancelling it at
+ * 500ms would reach the same three outcomes, but every long press would first lift
+ * the row into a drag overlay and then snap it back -- a false start the user sees
+ * on every single menu.
+ *
+ * A touch drag now REQUIRES the claim: a swipe that begins immediately is a scroll,
+ * never a drag, however far it travels. Press-then-drag is the reorder gesture on
+ * every mobile platform, and it is the only one that does not race the scroller.
+ *
+ * Mouse behaviour is identical to upstream -- 250ms delay or 10px of travel, either
+ * one starts the drag -- so nothing on the desktop changes.
+ *
+ * **Fix: detach on `pointercancel`.** Upstream listens for `pointermove` and
+ * `pointerup` only, so when the browser claims a touch for a pan -- which ends the
+ * pointer stream with `pointercancel` and no `pointerup` -- its two document
+ * listeners stay attached for the life of the page, and the pending activation
+ * timer still fires.
+ *
+ * Rendered once, in ./SectionDragContext.tsx, in place of `<DragDropSensors />`.
+ */
+export function DragPointerSensor() {
+  const context = useDragDropContext()
+  // `DragDropProvider` is always an ancestor at the one mount site, but the hook is
+  // typed as nullable and a test tree could render this bare.
+  if (!context)
+    return null
+
+  const [state, { addSensor, removeSensor, sensorStart, sensorMove, sensorEnd, dragStart, dragEnd }] = context
+
+  const isActiveSensor = () => state.active.sensorId === SENSOR_ID
+
+  const initialCoordinates = { x: 0, y: 0 }
+  let activationDelayTimeoutId: ReturnType<typeof setTimeout> | null = null
+  let claimReleaseTimeoutId: ReturnType<typeof setTimeout> | null = null
+  let activationDraggableId: Id | null = null
+  /** The pointer this sensor tracks. `null` when no press is live. */
+  let trackedPointerId: number | null = null
+  /** This press is a touch, so it takes the claim path rather than upstream's delay. */
+  let isTouchPress = false
+  /**
+   * The hold has claimed the pointer: every move from here is prevented, so the
+   * browser cannot pan, and travel past the activation distance starts a drag.
+   * False again once the claim window closes and the press becomes a menu.
+   */
+  let claimed = false
+
+  // Declarations, not arrow constants: these handlers reference one another in a
+  // cycle (attach -> onPointerMove -> onActivate -> detach -> onPointerMove), which
+  // only hoisting can express without an arbitrary forward reference.
+  function attach(event: PointerEvent, draggableId: Id) {
+    // A secondary finger never owns the press; the primary one may still be
+    // mid-hold elsewhere, and its release must not end this press.
+    if (event.button !== 0 || !event.isPrimary)
+      return
+    // The inline rename inputs inside these rows keep their native selection
+    // gestures (the sibling context-menu gesture exempts them too -- see
+    // ~/components/common/contextMenuGesture.ts), and a row's open menu is a DOM
+    // child of the row: a press on a menu item belongs to the menu, and a drag
+    // must not start from under it.
+    const target = event.target as Element | null
+    if (target?.closest?.('input, textarea, [contenteditable="true"], [popover]'))
+      return
+
+    // A press while another is still tracked supersedes it. Clear the old press's
+    // timers and listeners first, or its claim timer would fire under this one
+    // and set `claimed` for a press that never earned it, and its release timer
+    // would null this press's handle so a later `detach()` could not cancel it.
+    detach()
+
+    document.addEventListener('pointermove', onPointerMove)
+    document.addEventListener('pointerup', onPointerUp)
+    document.addEventListener('pointercancel', onPointerCancel)
+
+    activationDraggableId = draggableId
+    trackedPointerId = event.pointerId
+    initialCoordinates.x = event.clientX
+    initialCoordinates.y = event.clientY
+    isTouchPress = event.pointerType === 'touch'
+    claimed = false
+
+    if (!isTouchPress) {
+      activationDelayTimeoutId = setTimeout(onActivate, ACTIVATION_DELAY_MS)
+      return
+    }
+
+    // Touch: claim at the same 250ms upstream used, then hand the press back at
+    // the context menu's own threshold if it never moved. The two timers are what
+    // make one press mean three different things.
+    activationDelayTimeoutId = setTimeout(() => {
+      activationDelayTimeoutId = null
+      claimed = true
+    }, ACTIVATION_DELAY_MS)
+    claimReleaseTimeoutId = setTimeout(() => {
+      claimReleaseTimeoutId = null
+      claimed = false
+    }, motion.longPress)
+  }
+
+  function detach() {
+    if (activationDelayTimeoutId) {
+      clearTimeout(activationDelayTimeoutId)
+      activationDelayTimeoutId = null
+    }
+    if (claimReleaseTimeoutId) {
+      clearTimeout(claimReleaseTimeoutId)
+      claimReleaseTimeoutId = null
+    }
+    claimed = false
+    trackedPointerId = null
+    document.removeEventListener('pointermove', onPointerMove)
+    document.removeEventListener('pointerup', onPointerUp)
+    document.removeEventListener('pointercancel', onPointerCancel)
+    document.removeEventListener('selectionchange', clearSelection)
+  }
+
+  function onActivate() {
+    if (!state.active.sensor) {
+      sensorStart(SENSOR_ID, initialCoordinates)
+      dragStart(activationDraggableId!)
+      clearSelection()
+      document.addEventListener('selectionchange', clearSelection)
+    }
+    else if (!isActiveSensor()) {
+      detach()
+    }
+  }
+
+  function onPointerMove(event: PointerEvent) {
+    if (trackedPointerId === null || event.pointerId !== trackedPointerId)
+      return
+    const coordinates = { x: event.clientX, y: event.clientY }
+
+    if (!state.active.sensor) {
+      // A touch that moves before the claim is a scroll, whatever distance it
+      // covers. Only a claimed press can become a drag.
+      if (isTouchPress && !claimed)
+        return
+      // Hold the browser off while the claim stands, so the pan cannot start under
+      // a press that is about to become a drag. `cancelable` is false once the
+      // browser has already begun scrolling; calling it then only logs a warning.
+      if (claimed && event.cancelable)
+        event.preventDefault()
+
+      const transform = {
+        x: coordinates.x - initialCoordinates.x,
+        y: coordinates.y - initialCoordinates.y,
+      }
+      if (Math.sqrt(transform.x ** 2 + transform.y ** 2) > ACTIVATION_DISTANCE_PX)
+        onActivate()
+    }
+
+    if (isActiveSensor()) {
+      event.preventDefault()
+      sensorMove(coordinates)
+    }
+  }
+
+  function onPointerUp(event: PointerEvent) {
+    if (trackedPointerId === null || event.pointerId !== trackedPointerId)
+      return
+    detach()
+    if (isActiveSensor()) {
+      event.preventDefault()
+      dragEnd()
+      sensorEnd()
+    }
+  }
+
+  function onPointerCancel(event: PointerEvent) {
+    if (trackedPointerId === null || event.pointerId !== trackedPointerId)
+      return
+    // The browser took the pointer -- a pan, or the gesture leaving the window. No
+    // `pointerup` will follow, so this is the only chance to unwind.
+    detach()
+    if (isActiveSensor()) {
+      dragEnd()
+      sensorEnd()
+    }
+  }
+
+  function clearSelection() {
+    window.getSelection()?.removeAllRanges()
+  }
+
+  onMount(() => {
+    addSensor({ id: SENSOR_ID, activators: { pointerdown: attach } })
+  })
+
+  onCleanup(() => {
+    detach()
+    removeSensor(SENSOR_ID)
+  })
+
+  return null
+}

--- a/frontend/src/components/tree/DirectoryTree.test.tsx
+++ b/frontend/src/components/tree/DirectoryTree.test.tsx
@@ -95,6 +95,28 @@ describe('directoryTree', () => {
     expect(rowFor('a.txt')).toBe(before)
     expect(before.isConnected).toBe(true)
   })
+
+  it('marks the selected row with data-active, the one marker the coarse-pointer kebab reveal keys on', async () => {
+    const root = '/repo-active'
+    listDirectory.mockResolvedValue({
+      entries: [entry(root, 'a.txt'), entry(root, 'b.txt')],
+      truncated: false,
+    })
+
+    render(() => (
+      <DirectoryTree
+        workerId="w1"
+        showFiles
+        rootPath={root}
+        selectedPath={`${root}/a.txt`}
+        onSelect={() => {}}
+      />
+    ))
+    await waitFor(() => expect(rowFor('a.txt')).toBeTruthy())
+
+    expect(rowFor('a.txt')).toHaveAttribute('data-active', 'true')
+    expect(rowFor('b.txt')).toHaveAttribute('data-active', 'false')
+  })
 })
 
 describe('directoryTree sorting', () => {

--- a/frontend/src/components/tree/DirectoryTree.tsx
+++ b/frontend/src/components/tree/DirectoryTree.tsx
@@ -1,4 +1,4 @@
-import type { Component } from 'solid-js'
+import type { Accessor, Component } from 'solid-js'
 import type { FileSortFields, FileSortKey, FileSortOrder } from '~/lib/fileSort'
 import type { PathFlavor } from '~/lib/paths'
 import type { createGitFileStatusStore, DiffStats } from '~/stores/gitFileStatus.store'
@@ -9,6 +9,7 @@ import FolderOpen from 'lucide-solid/icons/folder-open'
 import { batch, createEffect, createMemo, createSignal, For, Match, on, onCleanup, onMount, Show, Switch, useContext } from 'solid-js'
 import { createStore, produce, reconcile } from 'solid-js/store'
 import * as workerRpc from '~/api/workerRpc'
+import { createContextMenuAnchor } from '~/components/common/DropdownMenu'
 import { FileActionsMenu } from '~/components/common/FileActionsMenu'
 import { Icon } from '~/components/common/Icon'
 import { StartupSpinner } from '~/components/common/StartupPanel'
@@ -322,10 +323,12 @@ const TreeContextMenu: Component<{
   isDir: boolean
   size?: number
   modTime?: string
+  contextMenuFor?: Accessor<HTMLElement | undefined>
 }> = (props) => {
   const tree = useTree()
   return (
     <FileActionsMenu
+      contextMenuFor={props.contextMenuFor}
       workerId={tree.workerId}
       path={props.path}
       flavor={tree.flavor()}
@@ -354,7 +357,10 @@ const TreeNode: Component<{
   const tree = useTree()
   const [loading, setLoading] = createSignal(false)
   let wrapperRef!: HTMLDivElement
+  // `nodeRef` stays for the imperative scroll-into-view callers.
   let nodeRef!: HTMLDivElement
+  // The same element as `nodeRef`, for the row menu's attach effect.
+  const [nodeEl, setNodeEl] = createContextMenuAnchor()
   let childrenRef: HTMLDivElement | undefined
 
   const expanded = () => tree.isNodeExpanded(props.node.path)
@@ -550,9 +556,16 @@ const TreeNode: Component<{
   return (
     <div ref={wrapperRef}>
       <div
-        ref={nodeRef}
+        ref={(el) => {
+          nodeRef = el
+          setNodeEl(el)
+        }}
         class={styles.node}
         classList={{ [styles.nodeSelected]: isSelected() }}
+        // The row's own statement of selection, so the coarse-pointer kebab
+        // reveal (~/components/tree/sidebarActions.css.ts) keys on ONE marker
+        // for every row type, not on each type's style class.
+        data-active={isSelected() ? 'true' : 'false'}
         style={{ 'padding-left': indent() }}
         data-testid="tree-row"
         onClick={toggle}
@@ -585,6 +598,7 @@ const TreeNode: Component<{
         />
         <div class={sidebarActions}>
           <TreeContextMenu
+            contextMenuFor={nodeEl}
             path={props.node.path}
             isDir={props.node.isDir}
             size={props.node.size}
@@ -631,6 +645,8 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
   const [error, setError] = createSignal<string | null>(null)
   let loadVersion = 0
   let treeRef!: HTMLDivElement
+  // The root row element, for its right-click / long-press menu.
+  const [rootNodeEl, setRootNodeEl] = createContextMenuAnchor()
 
   // When the tree container shrinks (e.g. WorktreeOptions appearing below),
   // re-scroll the selected node into view if it was pushed out.
@@ -932,8 +948,10 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
             <div class={styles.treeInner}>
               {/* Root directory row */}
               <div
+                ref={setRootNodeEl}
                 class={styles.node}
                 classList={{ [styles.nodeSelected]: props.selectedPath === rootPath() }}
+                data-active={props.selectedPath === rootPath() ? 'true' : 'false'}
                 style={{ 'padding-left': '8px' }}
                 data-testid="tree-root-node"
                 onClick={() => props.onSelect(rootPath())}
@@ -946,6 +964,7 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
                 />
                 <div class={sidebarActions}>
                   <TreeContextMenu
+                    contextMenuFor={rootNodeEl}
                     path={rootPath()}
                     isDir
                     modTime={rootModTime()}

--- a/frontend/src/components/tree/sidebarActions.css.ts
+++ b/frontend/src/components/tree/sidebarActions.css.ts
@@ -83,3 +83,39 @@ globalStyle(`:hover > ${sidebarActions}`, {
 globalStyle(`:hover > ${sidebarActions} ${menuTrigger}`, {
   opacity: 1,
 })
+
+/**
+ * The kebab on a COARSE pointer, where the hover rule above can never fire.
+ *
+ * Without this, a touch user's only way into a row menu is the long press, and
+ * nothing on screen says so. Revealing every row's kebab would say it, at the cost
+ * of one button per row -- clutter in a phone-width sidebar, and a 20px target
+ * besides.
+ *
+ * So the SELECTED row only. Exactly one kebab is visible at a time, on the row the
+ * user just tapped and the one they are most likely to act on. It teaches the
+ * gesture by example without ever crowding the list.
+ *
+ * Every row that HAS a selection states it with the one `data-active` marker:
+ * the workspace row, the tab leaf, the file-tree node and the file-tree root. A
+ * worker, tunnel or branch-group row has no such state -- selecting one means
+ * nothing -- so those keep the gesture alone.
+ */
+globalStyle(`[data-active="true"] > ${sidebarActions} ${menuTrigger}`, {
+  '@media': {
+    '(pointer: coarse)': {
+      opacity: 1,
+    },
+  },
+})
+
+// The resting indicator and the trigger are exact inverses wherever they share a
+// cell, so the coarse-pointer reveal has to hide the indicator too -- otherwise
+// the indicator would paint underneath the revealed kebab.
+globalStyle(`[data-active="true"] > ${sidebarActions} ${actionSlotResting}`, {
+  '@media': {
+    '(pointer: coarse)': {
+      opacity: 0,
+    },
+  },
+})

--- a/frontend/src/components/workers/TunnelContextMenu.tsx
+++ b/frontend/src/components/workers/TunnelContextMenu.tsx
@@ -1,15 +1,16 @@
 import type { Component } from 'solid-js'
+import type { ContextMenuTargetProps } from '~/components/common/DropdownMenu'
 import { DropdownMenu } from '~/components/common/DropdownMenu'
 import { rowContextMenuTrigger } from '~/components/common/moreHorizontalTrigger'
 import { dangerMenuItem } from '~/styles/shared.css'
 
-interface TunnelContextMenuProps {
+interface TunnelContextMenuProps extends ContextMenuTargetProps {
   onDelete: () => void
 }
 
 export const TunnelContextMenu: Component<TunnelContextMenuProps> = (props) => {
   return (
-    <DropdownMenu trigger={rowContextMenuTrigger()}>
+    <DropdownMenu trigger={rowContextMenuTrigger()} contextMenuFor={props.contextMenuFor}>
       <button role="menuitem" class={dangerMenuItem} onClick={() => props.onDelete()}>
         Delete...
       </button>

--- a/frontend/src/components/workers/WorkerContextMenu.tsx
+++ b/frontend/src/components/workers/WorkerContextMenu.tsx
@@ -1,4 +1,5 @@
 import type { Component } from 'solid-js'
+import type { ContextMenuTargetProps } from '~/components/common/DropdownMenu'
 import type { MenuInfoRow } from '~/components/common/MenuInfoRows'
 import type { WorkerInfo } from '~/lib/workerInfoCache'
 import { createMemo, Show } from 'solid-js'
@@ -10,7 +11,7 @@ import { rowContextMenuTrigger } from '~/components/common/moreHorizontalTrigger
 import { prettifyJson } from '~/lib/jsonFormat'
 import { dangerMenuItem } from '~/styles/shared.css'
 
-interface WorkerContextMenuProps {
+interface WorkerContextMenuProps extends ContextMenuTargetProps {
   workerInfo: WorkerInfo | null
   // True for the in-process worker the solo launcher auto-registers.
   // The deregister handler refuses these (it would just re-register on
@@ -61,7 +62,7 @@ export const WorkerContextMenu: Component<WorkerContextMenuProps> = (props) => {
   }
 
   return (
-    <DropdownMenu trigger={rowContextMenuTrigger()}>
+    <DropdownMenu trigger={rowContextMenuTrigger()} contextMenuFor={props.contextMenuFor}>
       <MenuInfoButton
         rows={infoRows()}
         copyText={infoJson}

--- a/frontend/src/components/workers/WorkerSectionContent.tsx
+++ b/frontend/src/components/workers/WorkerSectionContent.tsx
@@ -9,6 +9,7 @@ import ChevronsLeftRightEllipsis from 'lucide-solid/icons/chevrons-left-right-el
 import { createMemo, createSignal, For, Show } from 'solid-js'
 import { ClippedText } from '~/components/common/ClippedText'
 import { ConfirmDialog } from '~/components/common/ConfirmDialog'
+import { createContextMenuAnchor } from '~/components/common/DropdownMenu'
 import { StatusDot } from '~/components/common/StatusDot'
 import * as shared from '~/components/tree/sharedTree.css'
 import { actionSlot, actionSlotResting, sidebarActions } from '~/components/tree/sidebarActions.css'
@@ -75,9 +76,12 @@ export const WorkerSectionContent: Component<WorkerSectionContentProps> = (props
             const workerTunnels = () => tunnel?.tunnelsForWorker(worker.id) ?? []
             const workerName = createMemo(() => props.workerInfo(worker.id)?.name ?? '\u2014')
             const status = () => props.channelStatus(worker.id)
+            // The row element, for its right-click / long-press menu.
+            const [rowEl, setRowEl] = createContextMenuAnchor()
             return (
               <>
                 <div
+                  ref={setRowEl}
                   class={listStyles.item}
                   data-testid="worker-row"
                   onClick={() => toggleExpanded(worker.id)}
@@ -105,6 +109,7 @@ export const WorkerSectionContent: Component<WorkerSectionContentProps> = (props
                         status={status()}
                       />
                       <WorkerContextMenu
+                        contextMenuFor={rowEl}
                         workerInfo={props.workerInfo(worker.id)}
                         autoRegistered={worker.autoRegistered}
                         hasTunnels={workerTunnels().length > 0}
@@ -121,14 +126,18 @@ export const WorkerSectionContent: Component<WorkerSectionContentProps> = (props
                       <For each={workerTunnels()}>
                         {(t) => {
                           const label = tunnelLabel(t)
+                          const [tunnelRowEl, setTunnelRowEl] = createContextMenuAnchor()
                           return (
-                            <div class={`${shared.node} ${styles.tunnelItem}`}>
+                            <div ref={setTunnelRowEl} class={`${shared.node} ${styles.tunnelItem}`}>
                               {t.type === 'socks5'
                                 ? <ChevronsLeftRightEllipsis size={14} class={styles.tunnelIcon} />
                                 : <ArrowBigRightDash size={14} class={styles.tunnelIcon} />}
                               <ClippedText text={label} class={listStyles.itemTitle} />
                               <div class={sidebarActions}>
-                                <TunnelContextMenu onDelete={() => setDeleteTunnelTarget(t)} />
+                                <TunnelContextMenu
+                                  contextMenuFor={tunnelRowEl}
+                                  onDelete={() => setDeleteTunnelTarget(t)}
+                                />
                               </div>
                             </div>
                           )

--- a/frontend/src/components/workspace/BranchContextMenu.tsx
+++ b/frontend/src/components/workspace/BranchContextMenu.tsx
@@ -1,10 +1,10 @@
 import type { Component, JSX } from 'solid-js'
-import type { DropdownTriggerProps } from '~/components/common/DropdownMenu'
+import type { ContextMenuTargetProps, DropdownTriggerProps } from '~/components/common/DropdownMenu'
 import { DropdownMenu } from '~/components/common/DropdownMenu'
 import { rowContextMenuTrigger } from '~/components/common/moreHorizontalTrigger'
 import { dangerMenuItem } from '~/styles/shared.css'
 
-interface BranchContextMenuProps {
+interface BranchContextMenuProps extends ContextMenuTargetProps {
   'onChangeBranch': () => void
   'onDeleteBranch': () => void
   /**
@@ -42,7 +42,11 @@ interface BranchContextMenuProps {
 // close over their row's branch data via the calling component's
 // closure, so there's no shared overlay state to thread.
 export const BranchContextMenu: Component<BranchContextMenuProps> = props => (
-  <DropdownMenu trigger={props.trigger ?? rowContextMenuTrigger()} data-testid={props['data-testid']}>
+  <DropdownMenu
+    trigger={props.trigger ?? rowContextMenuTrigger()}
+    contextMenuFor={props.contextMenuFor}
+    data-testid={props['data-testid']}
+  >
     <button
       role="menuitem"
       disabled={Boolean(props.disabledReason)}

--- a/frontend/src/components/workspace/WorkspaceContextMenu.test.tsx
+++ b/frontend/src/components/workspace/WorkspaceContextMenu.test.tsx
@@ -4,9 +4,18 @@ import { describe, expect, it, vi } from 'vitest'
 import { WorkspaceContextMenu } from '~/components/workspace/WorkspaceContextMenu'
 import { SectionSchema, SectionType, Sidebar } from '~/generated/leapmux/v1/section_pb'
 
+/**
+ * Records what the mocked DropdownMenu last received for `contextMenuFor`. A
+ * holder object rather than a bare `let`: TS cannot see the assignment inside the
+ * `vi.mock` factory, so it would narrow a `let` to `undefined` at every read.
+ */
+const captured: { contextMenuFor?: () => HTMLElement | undefined } = {}
+
 // Mock DropdownMenu to render children directly (jsdom lacks popover API).
 vi.mock('~/components/common/DropdownMenu', () => ({
   DropdownMenu(props: any) {
+    // eslint-disable-next-line solid/reactivity -- capturing the accessor itself for the assertion, not reading it
+    captured.contextMenuFor = props.contextMenuFor
     // Render trigger (if function, call with dummy props) and children
     const trigger = () => typeof props.trigger === 'function'
       ? props.trigger({
@@ -162,5 +171,24 @@ describe('workspaceContextMenu', () => {
     expect(screen.getByText('Rename')).toBeInTheDocument()
     expect(screen.getByText('Delete')).toBeInTheDocument()
     expect(screen.getByText('Archive')).toBeInTheDocument()
+  })
+
+  // One representative for the six row menus. The other five wrappers forward the
+  // same prop through the same two lines, and `DropdownMenu` owns everything that
+  // happens after -- covered in ~/components/common/DropdownMenu.test.tsx.
+  it('forwards contextMenuFor so the row itself opens the menu', () => {
+    // No reset first: the assertion is identity against a FRESH element, so a
+    // stale capture from an earlier render fails rather than passing by accident.
+    const row = document.createElement('div')
+
+    render(() => (
+      <WorkspaceContextMenu
+        {...defaultProps}
+        contextMenuFor={() => row}
+        sections={[makeSection('sec-ip', 'In Progress', SectionType.WORKSPACES_IN_PROGRESS)]}
+      />
+    ))
+
+    expect(captured.contextMenuFor?.()).toBe(row)
   })
 })

--- a/frontend/src/components/workspace/WorkspaceContextMenu.tsx
+++ b/frontend/src/components/workspace/WorkspaceContextMenu.tsx
@@ -1,4 +1,5 @@
 import type { Component } from 'solid-js'
+import type { ContextMenuTargetProps } from '~/components/common/DropdownMenu'
 import type { Section } from '~/generated/leapmux/v1/section_pb'
 import ChevronRight from 'lucide-solid/icons/chevron-right'
 import { For, Show } from 'solid-js'
@@ -8,7 +9,7 @@ import { rowContextMenuTrigger } from '~/components/common/moreHorizontalTrigger
 import { isMoveTargetSection } from '~/components/shell/sectionUtils'
 import { dangerMenuItem } from '~/styles/shared.css'
 
-interface WorkspaceContextMenuProps {
+interface WorkspaceContextMenuProps extends ContextMenuTargetProps {
   isArchived: boolean
   sections: Section[]
   currentSectionId: string | undefined
@@ -21,7 +22,7 @@ interface WorkspaceContextMenuProps {
 
 export const WorkspaceContextMenu: Component<WorkspaceContextMenuProps> = (props) => {
   return (
-    <DropdownMenu trigger={rowContextMenuTrigger()}>
+    <DropdownMenu trigger={rowContextMenuTrigger()} contextMenuFor={props.contextMenuFor}>
       <button role="menuitem" onClick={() => props.onRename()}>
         Rename
       </button>

--- a/frontend/src/components/workspace/WorkspaceSectionContent.tsx
+++ b/frontend/src/components/workspace/WorkspaceSectionContent.tsx
@@ -8,6 +8,7 @@ import type { Tab, TabItemOps } from '~/stores/tab.types'
 import { createDroppable, createSortable, SortableProvider, transformStyle } from '@thisbeyond/solid-dnd'
 import ChevronRight from 'lucide-solid/icons/chevron-right'
 import { createEffect, createMemo, createSignal, For, Show } from 'solid-js'
+import { createContextMenuAnchor } from '~/components/common/DropdownMenu'
 import { Spinner } from '~/components/common/Spinner'
 import { Tooltip } from '~/components/common/Tooltip'
 import { WORKSPACE_DROP_PREFIX } from '~/components/shell/TabDragContext'
@@ -188,10 +189,14 @@ export const WorkspaceSectionContent: Component<WorkspaceSectionContentProps> = 
                   wasDragging = true
               })
 
+              // The row element, for the right-click / long-press menu below.
+              const [rowEl, setRowEl] = createContextMenuAnchor()
+
               return (
                 <>
                   <div
                     ref={(el: HTMLElement) => {
+                      setRowEl(el)
                       applyDirective(sortable, el)
                       applyDirective(wsDroppable, el)
                     }}
@@ -270,6 +275,7 @@ export const WorkspaceSectionContent: Component<WorkspaceSectionContentProps> = 
                       >
                         <Show when={!isRenaming()}>
                           <WorkspaceContextMenu
+                            contextMenuFor={rowEl}
                             isArchived={props.isArchived(id)}
                             sections={props.sections}
                             currentSectionId={props.sectionId}

--- a/frontend/src/components/workspace/WorkspaceTabTree.interactions.test.tsx
+++ b/frontend/src/components/workspace/WorkspaceTabTree.interactions.test.tsx
@@ -577,6 +577,22 @@ describe('workspaceTabTree interactions', () => {
     } as Tab
   }
 
+  /**
+   * The branch rows' own menus. Scoped to the branch-group element rather than
+   * counted document-wide: every tab leaf now mounts its own `TabContextMenu`
+   * popover too, so a document-wide count no longer answers "did the BRANCH row
+   * get a menu". The leaf menus live in the sibling children wrapper, outside this
+   * element.
+   */
+  function branchRowMenus(): NodeListOf<Element> {
+    return document.querySelectorAll('[data-testid="tab-tree-branch-group"] menu[popover]')
+  }
+
+  /** Every tab leaf's own context menu. */
+  function leafRowMenus(): NodeListOf<Element> {
+    return document.querySelectorAll('[data-testid="tab-tree-leaf"] menu[popover]')
+  }
+
   it('mounts one BranchContextMenu per branch row', () => {
     // Each branch row owns its own DropdownMenu, so N rows = N menu
     // instances. The trade-off vs. the prior hoisted-singleton design:
@@ -602,7 +618,7 @@ describe('workspaceTabTree interactions', () => {
     expect(screen.getAllByTestId('tab-tree-branch-group')).toHaveLength(4)
     expect(screen.getAllByText('Change branch...')).toHaveLength(4)
     expect(screen.getAllByText('Delete branch...')).toHaveLength(4)
-    expect(document.querySelectorAll('menu[popover]')).toHaveLength(4)
+    expect(branchRowMenus()).toHaveLength(4)
   })
 
   it('does not mount a row menu when neither callback is supplied', () => {
@@ -617,7 +633,7 @@ describe('workspaceTabTree interactions', () => {
         workspaceId="ws-1"
       />
     ))
-    expect(document.querySelectorAll('menu[popover]')).toHaveLength(0)
+    expect(branchRowMenus()).toHaveLength(0)
     expect(screen.queryByText('Change branch...')).toBeNull()
   })
 
@@ -651,7 +667,7 @@ describe('workspaceTabTree interactions', () => {
       />
     ))
     expect(screen.getAllByTestId('tab-tree-branch-group')).toHaveLength(1)
-    expect(document.querySelectorAll('menu[popover]')).toHaveLength(0)
+    expect(branchRowMenus()).toHaveLength(0)
     expect(screen.queryByText('Change branch...')).toBeNull()
     expect(screen.queryByText('Delete branch...')).toBeNull()
   })
@@ -668,7 +684,59 @@ describe('workspaceTabTree interactions', () => {
         onDeleteBranch={vi.fn()}
       />
     ))
-    expect(document.querySelectorAll('menu[popover]')).toHaveLength(0)
+    expect(branchRowMenus()).toHaveLength(0)
+    // Nor a leaf menu: a read-only tree can neither rename nor close a tab, and
+    // `TabContextMenu` renders nothing rather than an empty popover.
+    expect(leafRowMenus()).toHaveLength(0)
+  })
+
+  it('offers no Rename on a FILE leaf, whose title IS its path', () => {
+    // The same guard `startEditing` applies, surfaced so the menu hides an item
+    // that would do nothing rather than showing a dead one.
+    render(() => (
+      <WorkspaceTabTree
+        tabs={[makeTab(TabType.FILE, 'f1', 'readme.md')]}
+        activeTabKey={null}
+        onTabClick={() => {}}
+        workspaceId="ws-1"
+        tabItemOps={{ onClose: vi.fn(), onRename: vi.fn() }}
+      />
+    ))
+
+    expect(screen.queryByTestId('tab-menu-rename')).not.toBeInTheDocument()
+    // Close still stands: a file tab closes like any other.
+    expect(screen.getByTestId('tab-menu-close')).toBeInTheDocument()
+  })
+
+  it('offers no Rename when the tree has no rename handler', () => {
+    render(() => (
+      <WorkspaceTabTree
+        tabs={[makeTab(TabType.AGENT, 'a1', 'Agent')]}
+        activeTabKey={null}
+        onTabClick={() => {}}
+        workspaceId="ws-1"
+        tabItemOps={{ onClose: vi.fn() }}
+      />
+    ))
+
+    expect(screen.queryByTestId('tab-menu-rename')).not.toBeInTheDocument()
+    expect(screen.getByTestId('tab-menu-close')).toBeInTheDocument()
+  })
+
+  it('mounts a context menu on each tab leaf', () => {
+    render(() => (
+      <WorkspaceTabTree
+        tabs={[gitTabOnBranch('a1', 'feature-1'), gitTabOnBranch('a2', 'feature-1')]}
+        activeTabKey={null}
+        onTabClick={() => {}}
+        workspaceId="ws-1"
+        tabItemOps={{ onClose: vi.fn(), onRename: vi.fn() }}
+      />
+    ))
+    expect(screen.getAllByTestId('tab-tree-leaf')).toHaveLength(2)
+    expect(leafRowMenus()).toHaveLength(2)
+    expect(screen.getAllByTestId('tab-menu-rename')).toHaveLength(2)
+    expect(screen.getAllByTestId('tab-menu-close')).toHaveLength(2)
   })
 
   it('dispatches with each row’s own identity (closure capture, not shared state)', async () => {

--- a/frontend/src/components/workspace/WorkspaceTabTree.tsx
+++ b/frontend/src/components/workspace/WorkspaceTabTree.tsx
@@ -7,7 +7,9 @@ import FolderGit from 'lucide-solid/icons/folder-git'
 import GitBranch from 'lucide-solid/icons/git-branch'
 import X from 'lucide-solid/icons/x'
 import { createMemo, createSignal, on, Show, useContext } from 'solid-js'
+import { createContextMenuAnchor } from '~/components/common/DropdownMenu'
 import { IconButton, IconButtonState } from '~/components/common/IconButton'
+import { TabContextMenu } from '~/components/common/TabContextMenu'
 import { TabTypeIcon } from '~/components/common/TabTypeIcon'
 import { Tooltip } from '~/components/common/Tooltip'
 import { SIDEBAR_TAB_PREFIX } from '~/components/shell/TabDragContext'
@@ -197,6 +199,8 @@ const TabLeaf: Component<{
   editingValue: string
   onClick: () => void
   onDblClick: () => void
+  /** Start the inline rename from the row's context menu. Undefined hides the item. */
+  onRename?: () => void
   onClose?: () => void
   isClosing?: boolean
   canClose: boolean
@@ -204,6 +208,8 @@ const TabLeaf: Component<{
   onEditCommit: () => void
   onEditCancel: () => void
 }> = (props) => {
+  // The row element, for its right-click / long-press menu.
+  const [rowEl, setRowEl] = createContextMenuAnchor()
   /* eslint-disable solid/reactivity -- stable identifier for createDraggable */
   const draggable = createDraggable(
     `${SIDEBAR_TAB_PREFIX}${props.workspaceId}:${props.tab.type}:${props.tab.id}`,
@@ -228,7 +234,10 @@ const TabLeaf: Component<{
 
   return (
     <div
-      ref={draggable}
+      ref={(el) => {
+        setRowEl(el)
+        draggable(el)
+      }}
       class={`${shared.node} ${css.leafNode} ${props.isActive ? css.leafActive : ''} ${draggable.isActiveDraggable ? css.leafDragging : ''}`}
       style={{ 'padding-left': `${4 + props.depth * 16}px` }}
       onClick={() => {
@@ -320,6 +329,16 @@ const TabLeaf: Component<{
           />
         </div>
       </Show>
+      {/* Outside the `canClose` block: a row that cannot be closed can still be
+          renamed, and the menu host collapses to `display: contents`, so it costs
+          the row no layout either way. */}
+      <TabContextMenu
+        contextMenuFor={rowEl}
+        data-testid="tab-tree-leaf-menu"
+        onRename={props.onRename}
+        onClose={props.canClose ? props.onClose : undefined}
+        isClosing={props.isClosing}
+      />
     </div>
   )
 }
@@ -359,6 +378,12 @@ interface RowEditingContextValue {
   editingTabKey: Accessor<string | null>
   editingValue: Accessor<string>
   setEditingValue: (v: string) => void
+  /**
+   * Whether `startEditing` would do anything for this tab. `startEditing` returns
+   * early on the same condition, so a caller that only needs to ACT can ignore
+   * this; the row menu needs it to hide a Rename item that would do nothing.
+   */
+  canRename: (tab: Tab) => boolean
   startEditing: (tab: Tab) => void
   commitEdit: (tab: Tab) => void
   cancelEdit: () => void
@@ -412,6 +437,7 @@ const TabLeafSlot: Component<{ tab: Tab, depth: number }> = (props) => {
       editingValue={edit.editingValue()}
       onClick={() => sel.onTabClick(props.tab.type, props.tab.id)}
       onDblClick={() => edit.startEditing(props.tab)}
+      onRename={edit.canRename(props.tab) ? () => edit.startEditing(props.tab) : undefined}
       onClose={() => sel.tabItemOps()?.onClose?.(props.tab)}
       isClosing={sel.tabItemOps()?.closingKeys?.has(tabKey(props.tab))}
       canClose={sel.canClose(props.tab)}
@@ -520,9 +546,12 @@ const BranchGroupRow: Component<{
       return undefined
     return WORKER_OFFLINE_BRANCH_REASON
   })
+  // The row element, for its right-click / long-press menu.
+  const [rowEl, setRowEl] = createContextMenuAnchor()
   return (
     <>
       <div
+        ref={setRowEl}
         class={shared.node}
         style={{ 'padding-left': '36px' }}
         onClick={() => sel.toggleCollapsed(collapseKey())}
@@ -553,6 +582,7 @@ const BranchGroupRow: Component<{
         <Show when={!sel.readOnly() && props.branch().branchName !== null && props.branch().gitToplevel !== '' && actions.onChangeBranch && actions.onDeleteBranch}>
           <div class={sidebarActions}>
             <BranchContextMenu
+              contextMenuFor={rowEl}
               disabledReason={menuDisabledReason()}
               onChangeBranch={() => actions.onChangeBranch!(buildBranchRef(sel.workspaceId(), props.branch(), sel.liveTab))}
               onDeleteBranch={() => actions.onDeleteBranch!(buildBranchRef(sel.workspaceId(), props.branch(), sel.liveTab))}
@@ -765,8 +795,12 @@ export const WorkspaceTabTree: Component<WorkspaceTabTreeProps> = (props) => {
   let editCancelled = false
   const canClose = (tab: Tab) => canCloseTab(props.readOnly, tab)
 
+  // A FILE tab's title IS its path, and a read-only tree owns nothing to rename.
+  const canRename = (tab: Tab) =>
+    !props.readOnly && tab.type !== TabType.FILE && Boolean(props.tabItemOps?.onRename)
+
   const startEditing = (tab: Tab) => {
-    if (props.readOnly || tab.type === TabType.FILE || !props.tabItemOps?.onRename)
+    if (!canRename(tab))
       return
     setEditingTabKey(tabKey(tab))
     setEditingValue(tabDisplayLabel(tab))
@@ -823,6 +857,7 @@ export const WorkspaceTabTree: Component<WorkspaceTabTreeProps> = (props) => {
     editingTabKey,
     editingValue,
     setEditingValue,
+    canRename,
     startEditing,
     commitEdit,
     cancelEdit,

--- a/frontend/src/lib/popoverPosition.test.ts
+++ b/frontend/src/lib/popoverPosition.test.ts
@@ -178,4 +178,61 @@ describe('calcPopoverPosition', () => {
 
     expect(result.left).toBe(200) // unchanged
   })
+
+  // A rect anchor is what a right-click or a touch long press supplies: the
+  // pressed row's vertical band, with the pointer's x as the left edge.
+  describe('rect anchor', () => {
+    it('positions below the rect, left-aligned to its left edge', () => {
+      vi.stubGlobal('innerHeight', 800)
+      vi.stubGlobal('innerWidth', 1200)
+
+      const popover = mockPopover({ width: 200, height: 150 })
+
+      const result = calcPopoverPosition({ top: 100, bottom: 122, left: 340 }, popover)
+
+      expect(result.top).toBe(122) // the row's bottom, not the pointer's y
+      expect(result.left).toBe(340) // the pointer's x
+      expect(result.flipped).toBe(false)
+    })
+
+    it('flips above the rect when clipped at the bottom', () => {
+      vi.stubGlobal('innerHeight', 400)
+      vi.stubGlobal('innerWidth', 1200)
+
+      const popover = mockPopover({ width: 200, height: 150 })
+
+      const result = calcPopoverPosition({ top: 300, bottom: 322, left: 50 }, popover)
+
+      expect(result.top).toBe(150) // 300 - 150
+      expect(result.flipped).toBe(true)
+    })
+
+    it('clamps a rect anchor near the right edge', () => {
+      vi.stubGlobal('innerHeight', 800)
+      vi.stubGlobal('innerWidth', 500)
+
+      const popover = mockPopover({ width: 200, height: 150 })
+
+      const result = calcPopoverPosition({ top: 100, bottom: 122, left: 460 }, popover)
+
+      // 460 + 200 = 660 > 500, overflow = 160 -> left = 300
+      expect(result.left).toBe(300)
+    })
+
+    it('honours offset and placement for a rect anchor', () => {
+      vi.stubGlobal('innerHeight', 800)
+      vi.stubGlobal('innerWidth', 1200)
+
+      const popover = mockPopover({ width: 200, height: 100 })
+
+      const result = calcPopoverPosition(
+        { top: 300, bottom: 322, left: 100 },
+        popover,
+        { placement: 'above', offset: 8 },
+      )
+
+      expect(result.top).toBe(192) // 300 - 100 - 8
+      expect(result.flipped).toBe(true)
+    })
+  })
 })

--- a/frontend/src/lib/popoverPosition.ts
+++ b/frontend/src/lib/popoverPosition.ts
@@ -10,16 +10,34 @@ export interface PopoverPositionOptions {
 }
 
 /**
+ * A viewport rect that a popover points at, for an anchor that is not an
+ * element -- a right-click or a touch long press, which anchors to the pressed
+ * row's vertical band at the pointer's x.
+ *
+ * `DOMRect` satisfies this shape structurally, so an element anchor and a
+ * pointer anchor run the same flip and clamp arithmetic below. Only these three
+ * edges are read: the popover goes below `bottom` (flipping above `top` when
+ * clipped), left-aligned to `left`.
+ */
+export interface PopoverAnchorRect {
+  top: number
+  bottom: number
+  left: number
+}
+
+export type PopoverAnchor = Element | PopoverAnchorRect
+
+/**
  * Calculate the top/left for a fixed-position popover so it doesn't
  * overflow the bottom of the viewport.
  */
 export function calcPopoverPosition(
-  trigger: Element,
+  anchor: PopoverAnchor,
   popover: HTMLElement,
   options: PopoverPositionOptions = {},
 ): { top: number, left: number, flipped: boolean } {
   const { placement = 'auto', offset = 0, xOffset = 0, yOffset = 0 } = options
-  const triggerRect = trigger.getBoundingClientRect()
+  const triggerRect = 'getBoundingClientRect' in anchor ? anchor.getBoundingClientRect() : anchor
   const popoverRect = popover.getBoundingClientRect()
   const viewportHeight = window.innerHeight
 
@@ -88,20 +106,4 @@ export function calcPopoverPosition(
   }
 
   return { top, left, flipped }
-}
-
-/**
- * Position a popover directly above a trigger element.
- * Convenience wrapper for imperative use (e.g. the link popover).
- */
-export function positionPopoverAbove(
-  trigger: Element,
-  popover: HTMLElement,
-  offset = 4,
-): void {
-  const triggerRect = trigger.getBoundingClientRect()
-  const popoverRect = popover.getBoundingClientRect()
-  popover.style.top = `${triggerRect.top - popoverRect.height - offset}px`
-  popover.style.left = `${triggerRect.left}px`
-  popover.setAttribute('data-flipped', '')
 }

--- a/frontend/src/styles/popover.css.ts
+++ b/frontend/src/styles/popover.css.ts
@@ -1,5 +1,20 @@
-import { style } from '@vanilla-extract/css'
+import { globalStyle, style } from '@vanilla-extract/css'
 import { POPOVER_CARD_PADDING } from '~/styles/popoverTokens'
+
+/**
+ * A dropdown host with no trigger produces no box.
+ *
+ * `ot-dropdown` is an unknown element to the UA, so it defaults to
+ * `display: inline`. A trigger-less `DropdownMenu` -- one opened only by
+ * right-click or long press -- holds nothing but its `position: fixed` popover, so
+ * that inline box is empty. Inside a flex row it is still a flex ITEM, and it adds
+ * one `gap` of dead space to every row that mounts such a menu.
+ *
+ * `DropdownMenu` sets the attribute; see `data-headless` there.
+ */
+globalStyle('ot-dropdown[data-headless]', {
+  display: 'contents',
+})
 
 /**
  * The base class a `popover="auto"` element needs when it is positioned by JS (an

--- a/frontend/src/styles/tokens.ts
+++ b/frontend/src/styles/tokens.ts
@@ -19,11 +19,19 @@ export const headerHeight = `${headerHeightPx}px`
 // tests) and `${motion.X}ms` in vanilla-extract CSS template strings,
 // so the JS timeout and the CSS animation can never drift apart.
 //
-//   fast    — popover / dialog fade, small chrome animations.
-//   medium  — drawer slide, overlay fade, panel resize.
+//   fast      — popover / dialog fade, small chrome animations.
+//   medium    — drawer slide, overlay fade, panel resize.
+//   longPress — the touch hold that opens a row's context menu. The
+//               press indicator's ramp IS this duration, so the tint
+//               reaching full and the menu becoming ready are the same
+//               number by construction. 500ms is what iOS
+//               (`UILongPressGestureRecognizer.minimumPressDuration`),
+//               Android (`ViewConfiguration.getLongPressTimeout()`),
+//               Blink and WebKit all use for a touch long press.
 export const motion = {
   fast: 150,
   medium: 200,
+  longPress: 500,
 }
 
 // Min-width thresholds in CSS pixels, matching Tailwind's defaults.

--- a/frontend/src/test-support/pointer.ts
+++ b/frontend/src/test-support/pointer.ts
@@ -22,10 +22,36 @@ export function stubBoundingRect(el: HTMLElement, width: number, height: number)
   })
 }
 
-interface PointerOpts {
+export interface PointerOpts {
   x?: number
   y?: number
   pointerId?: number
+  /** Defaults to `mouse`. The gesture and sensor tests pass `touch` explicitly. */
+  pointerType?: string
+  /** Defaults to true; a secondary finger reports false. */
+  isPrimary?: boolean
+  /** The button that changed: 0 contact/left, 2 secondary. */
+  button?: number
+  /** Buttons held AFTER the event, as `PointerEvent.buttons` reports them. */
+  buttons?: number
+}
+
+/**
+ * Build a real PointerEvent. The one definition every pointer-driven test uses;
+ * a local factory in a test file drifts from the defaults the hooks rely on.
+ */
+export function pointerEvent(type: string, opts: PointerOpts = {}): PointerEvent {
+  return new PointerEvent(type, {
+    clientX: opts.x ?? 0,
+    clientY: opts.y ?? 0,
+    pointerId: opts.pointerId ?? 1,
+    pointerType: opts.pointerType ?? 'mouse',
+    isPrimary: opts.isPrimary ?? true,
+    button: opts.button ?? 0,
+    buttons: opts.buttons,
+    bubbles: true,
+    cancelable: true,
+  })
 }
 
 function makePointerEvent(type: string, opts: PointerOpts = {}, init: PointerEventInit = {}): PointerEvent {

--- a/frontend/src/test-support/selection.ts
+++ b/frontend/src/test-support/selection.ts
@@ -1,0 +1,19 @@
+/**
+ * Select an element's text and give the range one client rect.
+ *
+ * jsdom does no layout, so `Range.getClientRects` returns an empty list unless
+ * it is supplied -- and every hit-test against a selection (a right-click that
+ * must yield to the browser's Copy) reads that empty list as "nothing
+ * selected". This helper installs one synthetic rect so those predicates have
+ * geometry to answer with.
+ */
+export function selectTextWithRect(el: HTMLElement, rect: { left: number, right: number, top: number, bottom: number }) {
+  const range = document.createRange()
+  range.selectNodeContents(el)
+  const selection = window.getSelection()!
+  selection.removeAllRanges()
+  selection.addRange(range)
+  const live = selection.getRangeAt(0) as Range & { getClientRects: () => DOMRectList }
+  live.getClientRects = () =>
+    [{ ...rect, width: rect.right - rect.left, height: rect.bottom - rect.top }] as unknown as DOMRectList
+}

--- a/frontend/tests/e2e/013-workspace-context-menu.spec.ts
+++ b/frontend/tests/e2e/013-workspace-context-menu.spec.ts
@@ -1,4 +1,7 @@
+import type { Locator } from '@playwright/test'
 import { expect, test } from './fixtures'
+import { createWorkspaceViaAPI, deleteWorkspaceViaAPI } from './helpers/api'
+import { COARSE_POINTER_METRICS, touchDown } from './helpers/touch'
 import { workspaceRow } from './helpers/ui'
 
 /**
@@ -43,5 +46,120 @@ test.describe('Workspace Context Menu', () => {
     await dialog.getByRole('button', { name: 'Confirm?' }).click()
 
     await expect(workspaceItem).not.toBeVisible()
+  })
+
+  /**
+   * The two inputs that reach the menu without a hover. The item set itself is
+   * covered above and in the unit tests; what needs a real browser here is the
+   * platform behaviour the gesture works around -- popover light dismiss on the
+   * pointer release, and the row's own click.
+   */
+  test('right-click opens the menu at the cursor without selecting the row', async ({ page, authenticatedWorkspace }) => {
+    const workspaceItem = workspaceRow(page, authenticatedWorkspace.workspaceId)
+    await expect(workspaceItem).toBeVisible()
+
+    const before = await workspaceItem.getAttribute('data-active')
+    const box = (await workspaceItem.boundingBox())!
+    const x = box.x + box.width / 2
+    const y = box.y + box.height / 2
+
+    await page.mouse.move(x, y)
+    await page.mouse.down({ button: 'right' })
+    await page.mouse.up({ button: 'right' })
+
+    const renameItem = page.getByRole('menuitem', { name: 'Rename' })
+    await expect(renameItem).toBeVisible()
+
+    // Still visible a moment later: the menu opens after the release, so the
+    // release's own light-dismiss pass cannot take it back down again.
+    await expect(renameItem).toBeVisible()
+
+    // The menu lands ON the cursor, not at the row's edge.
+    const menuBox = (await page.locator('menu:popover-open').boundingBox())!
+    expect(Math.abs(menuBox.x - x)).toBeLessThan(4)
+
+    // A secondary click reads the row; it must not select it.
+    expect(await workspaceItem.getAttribute('data-active')).toBe(before)
+  })
+
+  test.describe('touch long press', () => {
+    // A desktop viewport keeps the sidebar docked, which keeps `workspaceRow`
+    // simple. `hasTouch` alone is enough here because the gesture branches on
+    // `pointerType` in JS, not on a `(pointer: coarse)` media query.
+    test.use({ hasTouch: true })
+
+    test('a long press opens the menu; a press that scrolls away does not', async ({ page, authenticatedWorkspace }) => {
+      const workspaceItem = workspaceRow(page, authenticatedWorkspace.workspaceId)
+      await expect(workspaceItem).toBeVisible()
+
+      const before = await workspaceItem.getAttribute('data-active')
+      const box = (await workspaceItem.boundingBox())!
+      const x = box.x + box.width / 2
+      const y = box.y + box.height / 2
+
+      // ── A press that travels is a scroll, not a menu ────────────────────────
+      const scrolling = await touchDown(page, x, y)
+      await scrolling.moveTo(x, y + 60)
+      await scrolling.end()
+      await expect(page.getByRole('menuitem', { name: 'Rename' })).toBeHidden()
+      await expect(workspaceItem).not.toHaveAttribute('data-press-hold')
+
+      // ── A press that stays put opens the menu ───────────────────────────────
+      const holding = await touchDown(page, x, y)
+      // The indicator is armed while the finger is still down, which is the only
+      // thing telling the user a menu is coming.
+      await expect(workspaceItem).toHaveAttribute('data-press-hold', '')
+
+      // Hold until the accent tint reaches full. That is the hold completing --
+      // the CSS ramp and the JS timer are the same `motion.longPress` -- so this
+      // waits on the real threshold instead of sleeping a guessed interval, and
+      // proves the indicator the user watches actually runs.
+      await expect.poll(async () => Number.parseFloat(
+        await workspaceItem.evaluate(el => getComputedStyle(el, '::before').opacity),
+      )).toBeGreaterThan(0.99)
+
+      await holding.end()
+
+      await expect(page.getByRole('menuitem', { name: 'Rename' })).toBeVisible()
+      await expect(workspaceItem).not.toHaveAttribute('data-press-hold')
+      // The press must not also fire the row's own click.
+      expect(await workspaceItem.getAttribute('data-active')).toBe(before)
+    })
+  })
+
+  test.describe('coarse pointer', () => {
+    // The kebab reveal is a `(pointer: coarse)` media rule, and Blink derives the
+    // primary pointer type from the MOBILE VIEWPORT, not from `hasTouch` -- so the
+    // full device metrics are what make this test test anything.
+    test.use(COARSE_POINTER_METRICS)
+
+    test('only the selected row shows its kebab', async ({ page, authenticatedWorkspace, leapmuxServer }) => {
+      // A SECOND workspace, so the "not selected" half of the rule has something
+      // to be true about. With one row the comparison would be vacuous.
+      const otherId = await createWorkspaceViaAPI(leapmuxServer.hubUrl, leapmuxServer.adminToken, 'Unselected')
+      try {
+        // The mobile layout keeps the sidebar in a drawer.
+        await page.getByRole('button', { name: 'Toggle workspaces' }).click()
+
+        const selected = workspaceRow(page, authenticatedWorkspace.workspaceId)
+        const unselected = workspaceRow(page, otherId)
+        await expect(selected).toBeVisible()
+        await expect(unselected).toBeVisible()
+        await expect(selected).toHaveAttribute('data-active', 'true')
+        await expect(unselected).toHaveAttribute('data-active', 'false')
+
+        const kebabOpacity = (row: Locator) =>
+          row.locator('[aria-expanded]').first().evaluate(el => Number.parseFloat(getComputedStyle(el).opacity))
+
+        // Painted, not merely present: the trigger has always been hit-testable at
+        // `opacity: 0`, so only the computed value proves the rule fired.
+        await expect.poll(() => kebabOpacity(selected)).toBe(1)
+        // And the other row stays clean, which is the whole point of selecting one.
+        expect(await kebabOpacity(unselected)).toBe(0)
+      }
+      finally {
+        await deleteWorkspaceViaAPI(leapmuxServer.hubUrl, leapmuxServer.adminToken, otherId).catch(() => {})
+      }
+    })
   })
 })

--- a/frontend/tests/e2e/035-tabbar-improvements.spec.ts
+++ b/frontend/tests/e2e/035-tabbar-improvements.spec.ts
@@ -41,4 +41,35 @@ test.describe('TabBar Improvements', () => {
     const text = await sessionIdValue.textContent()
     expect(text?.length ?? 0).toBeGreaterThan(0)
   })
+
+  /**
+   * The tab used to swallow `contextmenu` and offer nothing in its place, which is
+   * strictly worse than leaving the browser's own menu alone. It now carries the
+   * actions the tab already had by other means.
+   */
+  test('right-click on a tab opens its menu, and Rename starts the inline edit', async ({ page, authenticatedWorkspace }) => {
+    await openAgentViaUI(page)
+
+    const tab = page.locator('[data-testid="tab"]:visible').first()
+    await expect(tab).toBeVisible()
+
+    await tab.click({ button: 'right' })
+
+    // Scoped to the OPEN popover: every tab mounts its own menu, and a popover
+    // keeps its children in the DOM while closed.
+    const menu = page.locator('[data-testid="tab-bar-tab-menu"]:popover-open')
+    await expect(menu).toBeVisible()
+    await expect(menu.locator('[data-testid="tab-menu-rename"]')).toBeVisible()
+    await expect(menu.locator('[data-testid="tab-menu-close"]')).toBeVisible()
+    // Proves the whole `tabPop` chain -- TileRenderer builds it per tab from the
+    // same function the tile-level affordance uses, TabBar forwards it, the menu
+    // renders it. The tile is in the main window here, so it reads "Pop out".
+    await expect(menu.locator('[data-testid="tab-menu-pop"]')).toHaveText('Pop out to floating window')
+    // Tile-scoped actions stay on the tile's own surfaces, not on a tab's menu.
+    await expect(menu.locator('[data-testid="split-vertical"]')).toHaveCount(0)
+    await expect(menu.locator('[data-testid="make-grid-menu-item"]')).toHaveCount(0)
+
+    await menu.locator('[data-testid="tab-menu-rename"]').click()
+    await expect(page.locator('[data-testid="tab-rename-input"]:visible')).toBeFocused()
+  })
 })

--- a/frontend/tests/e2e/040-chat-message-rendering.spec.ts
+++ b/frontend/tests/e2e/040-chat-message-rendering.spec.ts
@@ -166,4 +166,53 @@ test.describe('Chat Message Rendering', () => {
     // A rounded corner flush against the edge would read as a mistake.
     expect(box.radius).toBe('0px')
   })
+
+  /**
+   * The chat list is the one surface where the row menu has to share the press
+   * with text selection, and the one whose rows are tall enough that anchoring to
+   * the row instead of the cursor would be obviously wrong.
+   */
+  test('right-click on a message opens its menu at the cursor, and leaves a selection to the browser', async ({ page, authenticatedWorkspace }) => {
+    await sendAndSettle(page)
+
+    const bubble = firstAssistantBubble(page)
+    await expect(bubble).toBeVisible()
+
+    const box = (await bubble.boundingBox())!
+    const x = box.x + box.width / 2
+    const y = box.y + Math.min(20, box.height / 2)
+
+    await page.mouse.click(x, y, { button: 'right' })
+
+    const menu = page.locator('[data-testid="message-context-menu"]:popover-open')
+    await expect(menu).toBeVisible()
+    // The same actions the hover toolbar carries, plus the send time.
+    await expect(menu.locator('[data-testid="message-menu-copy-json"]')).toBeVisible()
+    await expect(menu.locator('[data-testid="message-menu-info"]')).toBeVisible()
+
+    // At the cursor. A message row is tall, so anchoring to the row would put the
+    // menu far from the pointer.
+    const menuBox = (await menu.boundingBox())!
+    expect(Math.abs(menuBox.x - x)).toBeLessThan(4)
+    expect(Math.abs(menuBox.y - y)).toBeLessThan(4)
+
+    await page.keyboard.press('Escape')
+    await expect(menu).toBeHidden()
+
+    // With text selected under the cursor, the browser's own menu wins so Copy
+    // still works. The app suppresses neither the selection nor the native menu.
+    await bubble.evaluate((el) => {
+      const range = document.createRange()
+      range.selectNodeContents(el)
+      const selection = window.getSelection()!
+      selection.removeAllRanges()
+      selection.addRange(range)
+    })
+    const selectionBox = await bubble.evaluate(() => {
+      const rect = window.getSelection()!.getRangeAt(0).getClientRects()[0]
+      return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 }
+    })
+    await page.mouse.click(selectionBox.x, selectionBox.y, { button: 'right' })
+    await expect(menu).toBeHidden()
+  })
 })

--- a/frontend/tests/e2e/065-directory-tree.spec.ts
+++ b/frontend/tests/e2e/065-directory-tree.spec.ts
@@ -412,4 +412,33 @@ test.describe('DirectoryTree', () => {
       await deleteWorkspaceViaAPI(hubUrl, adminToken, workspaceId).catch(() => {})
     }
   })
+
+  /**
+   * The tree is the clean control for the right-click path: its rows carry no
+   * drag, so nothing else competes for the press.
+   */
+  test('right-click opens a row menu without selecting the row', async ({ page, leapmuxServer }) => {
+    const { hubUrl, adminToken, workerId } = leapmuxServer
+    const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, 'Tree Right Click Test')
+    await openAgentViaAPI(hubUrl, adminToken, workerId, workspaceId, frontendDir)
+    try {
+      await loginViaToken(page, adminToken)
+      await openWorkspace(page, workspaceId)
+
+      const row = treeRow(page, 'package.json')
+      await expect(row).toBeVisible()
+
+      await row.click({ button: 'right' })
+      await expect(page.locator('[data-testid="tree-copy-path-button"]:visible')).toBeVisible()
+
+      // The root row owns its own menu, so a right-click there is not the same
+      // element's menu re-anchored.
+      await page.keyboard.press('Escape')
+      await page.locator('[data-testid="tree-root-node"]:visible').click({ button: 'right' })
+      await expect(page.locator('[data-testid="tree-copy-path-button"]:visible')).toBeVisible()
+    }
+    finally {
+      await deleteWorkspaceViaAPI(hubUrl, adminToken, workspaceId).catch(() => {})
+    }
+  })
 })


### PR DESCRIPTION
## Motivation

Row-level actions lived in hover toolbars and kebab menus, so they were invisible or unreachable without a hovering mouse. Chat message actions (Copy Markdown, Quote, diff/expand toggles) were hover-only; the tab bar suppressed `contextmenu` while offering nothing; on touch devices there was no way to open any row menu at all. Touch input also made drag-vs-scroll ambiguous — solid-dnd's pointer sensor would start a drag on any press that moved, and it leaked document listeners whenever the browser claimed a touch via `pointercancel`.

## Modifications

- **Gesture infrastructure**: new `attachContextMenuGesture()` (`frontend/src/components/common/contextMenuGesture.ts`) gives any row long-press (500 ms, shared with the CSS indicator via a new `motion.longPress` token) and secondary-button `contextmenu` inputs — 8 px press slop (deliberately under the 10 px drag threshold), scroll-cancel only when the pressed row itself moves, presses inside inputs/popovers ignored, and the menu open deferred past pointer release so popover light-dismiss can't immediately hide it.
- **DropdownMenu**: new `contextMenuFor` prop attaches the gesture to a row and anchors the popover at the press point — `PopoverAnchor` now accepts `Element | {top, bottom, left}` so `calcPopoverPosition` handles cursor anchoring with the same flip/clamp logic. `createContextMenuAnchor()` replaces the per-surface wiring that every menu wrapper repeated; trigger-less hosts collapse to `display: contents` via `data-headless`.
- **Chat**: `buildMessageActions()` is the single source of message actions, consumed by both the hover toolbar and the new `MessageContextMenuHost` — one shared menu for the whole virtualized list (per-row popovers are unaffordable at 30–70 mounted bubbles), anchored at the press point, leading with a copyable "Sent:" timestamp and pinning destructive items at the foot. `ToolHeaderActions` moved from `toolRenderers.tsx` to its own module (all import sites updated; the app is greenfield, so no external consumers exist), and its buttons now keep DOM identity/focus across Copy → Copied state flips.
- **Touch drag policy**: new `DragPointerSensor` (a fork of solid-dnd's pointer sensor) resolves one touch press three unambiguous ways — move immediately = browser scroll, hold 250 ms then move past 10 px = drag, hold 500 ms without moving = context menu. It detaches on `pointercancel` (fixing the upstream listener leak) and ignores presses on inline inputs and open row menus. `SectionDragContext` uses it for all section/tile/tab reordering. **Breaking (touch behavior, deliberate)**: an immediate swipe is now always a scroll; dragging requires press-and-hold first. Desktop mouse behavior is unchanged.
- **Surfaces**: per-tab `TabContextMenu` (Rename / Pop / Close) on the tab strip and workspace tab-tree leaves; row-anchored menus on file-tree nodes, workspace rows, branch-group rows, worker rows, and tunnel rows, all via the shared `ContextMenuTargetProps`. On coarse pointers the kebab is revealed only on the selected row, keyed on a uniform `data-active` marker.
- **Tooltip** no longer presents on the release of a long-press that is about to open a menu, so it cannot stack above the menu in the top layer.
- Removed dead `positionPopoverAbove` (zero callers).

## Result

Every major row surface — chat messages, tabs, tiles, file tree, workspace/branch/worker/tunnel rows — now opens its menu on right-click at the cursor and on touch long-press with a visible hold indicator:

```tsx
// any row gains right-click + long-press for free
const [rowEl, setRowEl] = createContextMenuAnchor()
// <div ref={setRowEl}>…row content…</div>
<TabContextMenu contextMenuFor={rowEl} onRename={startRename} onClose={close} />
```

Chat message menus mirror the hover toolbar exactly (both derive from `buildMessageActions`, so they cannot drift), add a copyable timestamp, and offer Retry/Delete for failed deliveries; right-clicking a live text selection still yields to the browser's native Copy. On touch, the three gestures no longer fight: swipe scrolls, hold-then-drag reorders, and a 500 ms hold opens the menu — with the kebab visible on the selected row so the menus are discoverable without hover.
