### PR TITLE
fix(terminal): Correct CJK/IME input and exactly-once output rendering

### DIFF
--- a/backend/internal/worker/service/closed_tab_test.go
+++ b/backend/internal/worker/service/closed_tab_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"bytes"
 	"context"
+	"errors"
 	"runtime"
 	"strings"
 	"sync"
@@ -41,6 +42,15 @@ type testResponseWriter struct {
 	errors     []testError
 	streams    []*leapmuxv1.InnerStreamMessage
 	streamCtrl channel.StreamController
+	failStream bool
+}
+
+// killStreamSends makes every later SendStream fail, simulating a dead
+// transport for the replay paths that classify send errors.
+func (w *testResponseWriter) killStreamSends() {
+	w.mu.Lock()
+	w.failStream = true
+	w.mu.Unlock()
 }
 
 type testError struct {
@@ -65,6 +75,9 @@ func (w *testResponseWriter) SendError(code int32, msg string) error {
 func (w *testResponseWriter) SendStream(m *leapmuxv1.InnerStreamMessage) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	if w.failStream {
+		return errors.New("test: transport gone")
+	}
 	w.streams = append(w.streams, m)
 	return nil
 }

--- a/backend/internal/worker/service/service.go
+++ b/backend/internal/worker/service/service.go
@@ -29,6 +29,7 @@ import (
 	"github.com/leapmux/leapmux/internal/worker/channel"
 	"github.com/leapmux/leapmux/internal/worker/config"
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
+	"github.com/leapmux/leapmux/internal/worker/gitutil"
 	"github.com/leapmux/leapmux/internal/worker/terminal"
 	"github.com/leapmux/leapmux/internal/worker/wakelock"
 	"github.com/leapmux/leapmux/util/validate"
@@ -82,6 +83,10 @@ type Service struct {
 	startTerminalFn     func(context.Context, terminal.Options, terminal.OutputHandler, terminal.ExitHandler) error
 	createAgentRecordFn func(context.Context, db.CreateAgentParams) error
 	getAgentByIDFn      func(context.Context, string) (db.Agent, error)
+	// batchGitStatusFn runs the concurrent git-status batch for a watch
+	// catch-up. A seam (same contract as its siblings above) so tests can
+	// observe the overlap's cancellation without spawning real git processes.
+	batchGitStatusFn func(ctx context.Context, dirs []string) []*leapmuxv1.AgentGitStatus
 
 	// ---- Mutable runtime state: everything that changes over the worker's
 	// life, touched concurrently by the handler goroutines DispatchAsync
@@ -462,6 +467,7 @@ func New(cfg Config) *Service {
 	svc.startTerminalFn = svc.Terminals.StartTerminal
 	svc.createAgentRecordFn = svc.Queries.CreateAgent
 	svc.getAgentByIDFn = svc.Queries.GetAgentByID
+	svc.batchGitStatusFn = gitutil.BatchGetGitStatus
 
 	// Wire auto-continue so OutputHandler can send synthetic user messages.
 	// An auto-continue injection is not a human-typed input, so it stays

--- a/backend/internal/worker/service/watch_events_test.go
+++ b/backend/internal/worker/service/watch_events_test.go
@@ -496,6 +496,132 @@ func TestWatchEvents_DualPromote_TerminalCatchUpBeforeAgent(t *testing.T) {
 	assert.Less(t, termIdx, agentStartIdx, "terminal catch-up must precede agent catch-up on dual promote")
 }
 
+// TestWatchEvents_DualPromote_GitBatchOverlapsTerminalCatchUp pins the
+// overlap's throughput half: the git-status batch and the terminal catch-up
+// are independent stages, so the terminal frames must stream WHILE the git
+// batch is still running, not after it. The seam parks the batch open until
+// the test releases it; if the stages were sequential again, the terminal
+// frame could not appear before the release.
+func TestWatchEvents_DualPromote_GitBatchOverlapsTerminalCatchUp(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc, d, w := setupTestService(t)
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "agent-overlap", WorkingDir: "/tmp", HomeDir: "/tmp",
+	}))
+	startTestTerminal(t, svc, ctx, "term-overlap")
+	require.True(t, svc.Terminals.AppendOutput("term-overlap", []byte("screen")))
+
+	gitStarted := make(chan struct{})
+	release := make(chan struct{})
+	svc.batchGitStatusFn = func(_ context.Context, dirs []string) []*leapmuxv1.AgentGitStatus {
+		close(gitStarted)
+		<-release
+		return make([]*leapmuxv1.AgentGitStatus, len(dirs))
+	}
+
+	dispatch(d, "WatchEvents", &leapmuxv1.WatchEventsRequest{
+		Agents:    []*leapmuxv1.WatchAgentEntry{{AgentId: "agent-overlap", Mode: leapmuxv1.WatchMode_WATCH_MODE_NOTIFY}},
+		Terminals: []*leapmuxv1.WatchTerminalEntry{{TerminalId: "term-overlap", Mode: leapmuxv1.WatchMode_WATCH_MODE_NOTIFY}},
+	}, w)
+	waitAgentWatchCount(t, svc, "agent-overlap", 1)
+	waitTerminalWatchCount(t, svc, "term-overlap", 1)
+
+	promote, err := proto.Marshal(&leapmuxv1.WatchEventsRequest{
+		UpdateId: 1,
+		Agents:   []*leapmuxv1.WatchAgentEntry{{AgentId: "agent-overlap", Mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}},
+		Terminals: []*leapmuxv1.WatchTerminalEntry{{
+			TerminalId: "term-overlap", AfterOffset: 0, Mode: leapmuxv1.WatchMode_WATCH_MODE_FULL,
+		}},
+	})
+	require.NoError(t, err)
+	w.deliverStreamRequest(promote, false)
+
+	select {
+	case <-gitStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("git batch never started")
+	}
+
+	// The git batch is parked open, yet the terminal catch-up data must
+	// already be on the wire — the two stages overlap.
+	require.Eventually(t, func() bool {
+		for _, m := range w.streamsSnapshot() {
+			var resp leapmuxv1.WatchEventsResponse
+			if err := proto.Unmarshal(m.GetPayload(), &resp); err != nil {
+				continue
+			}
+			if te := resp.GetTerminalEvent(); te != nil && te.GetTerminalId() == "term-overlap" && te.GetData() != nil {
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 10*time.Millisecond, "terminal catch-up must stream while the git batch is in flight")
+
+	close(release)
+	require.Eventually(t, func() bool {
+		return countCatchUpCompletes(w) >= 1
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
+// TestWatchEvents_DualPromote_CancelsGitBatchWhenTransportDies pins the
+// overlap's cancellation half: a transport that dies during the terminal
+// replay gets no agent replay, so its still-running git batch is pure waste
+// and must be cancelled — and the cancelled join must not hang the session.
+func TestWatchEvents_DualPromote_CancelsGitBatchWhenTransportDies(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc, d, w := setupTestService(t)
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "agent-git-cancel", WorkingDir: "/tmp", HomeDir: "/tmp",
+	}))
+	startTestTerminal(t, svc, ctx, "term-git-cancel")
+	require.True(t, svc.Terminals.AppendOutput("term-git-cancel", []byte("screen")))
+
+	gitStarted := make(chan struct{})
+	gitCancelled := make(chan struct{})
+	svc.batchGitStatusFn = func(gitCtx context.Context, dirs []string) []*leapmuxv1.AgentGitStatus {
+		close(gitStarted)
+		<-gitCtx.Done()
+		close(gitCancelled)
+		return make([]*leapmuxv1.AgentGitStatus, len(dirs))
+	}
+
+	dispatch(d, "WatchEvents", &leapmuxv1.WatchEventsRequest{
+		Agents:    []*leapmuxv1.WatchAgentEntry{{AgentId: "agent-git-cancel", Mode: leapmuxv1.WatchMode_WATCH_MODE_NOTIFY}},
+		Terminals: []*leapmuxv1.WatchTerminalEntry{{TerminalId: "term-git-cancel", Mode: leapmuxv1.WatchMode_WATCH_MODE_NOTIFY}},
+	}, w)
+	waitAgentWatchCount(t, svc, "agent-git-cancel", 1)
+	waitTerminalWatchCount(t, svc, "term-git-cancel", 1)
+
+	// Every stream send dies from here on: the terminal replay's first frame
+	// kills the sink, so the agent replay never runs.
+	w.killStreamSends()
+
+	promote, err := proto.Marshal(&leapmuxv1.WatchEventsRequest{
+		UpdateId: 1,
+		Agents:   []*leapmuxv1.WatchAgentEntry{{AgentId: "agent-git-cancel", Mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}},
+		Terminals: []*leapmuxv1.WatchTerminalEntry{{
+			TerminalId: "term-git-cancel", AfterOffset: 0, Mode: leapmuxv1.WatchMode_WATCH_MODE_FULL,
+		}},
+	})
+	require.NoError(t, err)
+	w.deliverStreamRequest(promote, false)
+
+	select {
+	case <-gitStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("git batch never started")
+	}
+	select {
+	case <-gitCancelled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("git batch was not cancelled after the transport died")
+	}
+}
+
 func TestWatchEvents_LookupFailedRetryPerformsOwedReplay(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/worker/service/watch_session.go
+++ b/backend/internal/worker/service/watch_session.go
@@ -8,7 +8,6 @@ import (
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/worker/channel"
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
-	"github.com/leapmux/leapmux/internal/worker/gitutil"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -199,24 +198,51 @@ func (s *watchSession) apply(r *leapmuxv1.WatchEventsRequest) {
 	}
 
 	sink := newReplaySink(s.sender)
+
+	// The git-status batch feeds only the agent replay below, so start it
+	// BEFORE the terminal catch-up and let the two overlap: the terminal
+	// sends stream while git works, and the agent replay waits for neither
+	// stage to re-run. The shell-outs stay cancellable — a transport that
+	// died mid-terminal-replay gets no agent replay, so its git batch is
+	// pure waste and is cancelled below.
+	gitCtx, cancelGit := context.WithCancel(bgCtx())
+	defer cancelGit()
 	var replayGitStatuses []*leapmuxv1.AgentGitStatus
-	if sink.alive() && len(promotedAgentRows) > 0 {
+	var gitDone chan struct{}
+	if len(promotedAgentRows) > 0 {
 		dirs := make([]string, len(promotedAgentRows))
 		for i, row := range promotedAgentRows {
 			dirs[i] = row.WorkingDir
 		}
-		replayGitStatuses = gitutil.BatchGetGitStatus(bgCtx(), dirs)
+		gitDone = make(chan struct{})
+		go func() {
+			defer close(gitDone)
+			replayGitStatuses = s.svc.batchGitStatusFn(gitCtx, dirs)
+		}()
 	} else {
 		replayGitStatuses = make([]*leapmuxv1.AgentGitStatus, len(promotedAgentRows))
 	}
 
-	// Terminal catch-up first so screen restore is not HOL-blocked behind
-	// a multi-page agent message replay on the same revision.
+	// Terminal catch-up FIRST on the wire. This session registered for live
+	// terminal events above, and the catch-up snapshot re-includes every byte
+	// the live path already delivered in between — the client trims that
+	// overlap by offset, but the window (and the duplicated bytes on the
+	// wire) still grows with everything that runs here. Streaming this loop
+	// immediately minimizes it, and keeps screen restore from waiting behind
+	// the concurrent git batch or a multi-page agent replay on the same
+	// revision.
 	for i, termID := range promotedTermIDs {
 		if !sink.alive() {
 			break
 		}
 		s.svc.replayTerminalCatchUp(sink, termID, promotedOffsets[termID], promotedTermRows[i])
+	}
+
+	if gitDone != nil {
+		if !sink.alive() {
+			cancelGit()
+		}
+		<-gitDone
 	}
 	for i, agentEntry := range promotedAgents {
 		if !sink.alive() {

--- a/backend/internal/worker/terminal/screenbuffer_test.go
+++ b/backend/internal/worker/terminal/screenbuffer_test.go
@@ -24,14 +24,14 @@ func TestScreenBuffer_SnapshotSince_CaughtUp(t *testing.T) {
 	assert.False(t, isSnap)
 }
 
-// TestScreenBuffer_SnapshotSince_ColdSubscribeWithinWindow: after_offset=0
-// on a buffer whose ring has NOT wrapped returns the full retained bytes
-// as an incremental delta, NOT a snapshot. The snapshot flag exists to
-// tell a frontend to reset pre-existing state; a cold subscriber has no
-// state to reset, and a frontend that happens to hold the first N bytes
-// legitimately is resuming in-window. The distinction only matters once
-// the ring has wrapped (see BehindRing test).
-func TestScreenBuffer_SnapshotSince_ColdSubscribeWithinWindow(t *testing.T) {
+// TestScreenBuffer_SnapshotSince_ForcedResyncAtZero: after_offset=0 is the
+// forced-resync subscribe. A client that lost bytes (its pending-frame queue
+// evicted frames) asks for a full rebuild, and the answer must be the whole
+// retained buffer with the snapshot flag EVEN while the ring still holds
+// byte 0 — an incremental-from-zero delta would come back instead, and the
+// client's stale cursor would trim the rebuilt bytes as "already rendered",
+// which is exactly the garbled state the resync exists to repair.
+func TestScreenBuffer_SnapshotSince_ForcedResyncAtZero(t *testing.T) {
 	t.Parallel()
 
 	sb := NewScreenBuffer()
@@ -39,10 +39,11 @@ func TestScreenBuffer_SnapshotSince_ColdSubscribeWithinWindow(t *testing.T) {
 	sb.Write([]byte(" world"))
 
 	data, offset, isSnap := sb.SnapshotSince(0)
-	assert.Equal(t, []byte("hello world"), data)
+	assert.True(t, isSnap,
+		"offset 0 is a forced resync and must rebuild the client's state")
 	assert.Equal(t, int64(11), offset)
-	assert.False(t, isSnap,
-		"offset 0 while the ring still holds byte 0 is valid in-window resume")
+	assert.Contains(t, string(data), "hello world",
+		"the resync snapshot carries the full retained bytes")
 }
 
 // TestScreenBuffer_SnapshotSince_IncrementalDelta: after_offset inside the
@@ -201,8 +202,9 @@ func TestScreenBuffer_SnapshotSince_NegativeOffset(t *testing.T) {
 
 // TestScreenBuffer_SnapshotSince_WrapsAtExactBoundary: when a write
 // exactly fills the ring (pos==len(buf), full transitions false→true),
-// SnapshotSince(0) must still return all bytes as an in-window resume —
-// not a snapshot, because byte 0 is still the retention window's start.
+// SnapshotSince(0) still answers the forced-resync subscribe with the
+// full buffer and the snapshot flag — byte 0 being the retention window's
+// start does not change what a zero-offset subscriber asked for.
 func TestScreenBuffer_SnapshotSince_WrapsAtExactBoundary(t *testing.T) {
 	t.Parallel()
 
@@ -217,8 +219,8 @@ func TestScreenBuffer_SnapshotSince_WrapsAtExactBoundary(t *testing.T) {
 	data, end, isSnap := sb.SnapshotSince(0)
 	assert.Len(t, data, screenBufferSize)
 	assert.Equal(t, int64(screenBufferSize), end)
-	assert.False(t, isSnap,
-		"ring exactly full: byte 0 is at windowStart, still in-window")
+	assert.True(t, isSnap,
+		"offset 0 is a forced resync regardless of where the window starts")
 }
 
 // TestScreenBuffer_SnapshotSince_MultiWrap: after the ring has wrapped

--- a/backend/internal/worker/terminal/terminal.go
+++ b/backend/internal/worker/terminal/terminal.go
@@ -199,10 +199,11 @@ func (sb *ScreenBuffer) tailBytesLocked(n int) []byte {
 //   - afterOffset == total: caller is caught up. Returns (nil, total, false).
 //   - afterOffset within the retained window: returns the incremental
 //     delta since afterOffset. isSnapshot is false.
-//   - afterOffset has fallen out of the retained window, is negative, or
-//     is larger than total (PTY recreated beneath a stale client):
-//     returns the full retained buffer with isSnapshot=true so the caller
-//     drops any stale state.
+//   - afterOffset <= 0 (a forced-resync subscribe: the caller knows it
+//     lost bytes and an incremental delta cannot fill the hole), afterOffset
+//     has fallen out of the retained window, or is larger than total (PTY
+//     recreated beneath a stale client): returns the full retained buffer
+//     with isSnapshot=true so the caller drops any stale state.
 func (sb *ScreenBuffer) SnapshotSince(afterOffset int64) (data []byte, endOffset int64, isSnapshot bool) {
 	sb.mu.Lock()
 	defer sb.mu.Unlock()
@@ -215,14 +216,17 @@ func (sb *ScreenBuffer) SnapshotSince(afterOffset int64) (data []byte, endOffset
 	windowStart := total - int64(sb.retainedLocked())
 
 	// Incremental catch-up: afterOffset is inside the retained window,
-	// so copy only the missing suffix directly from the ring.
-	if afterOffset >= windowStart && afterOffset < total {
+	// so copy only the missing suffix directly from the ring. afterOffset 0
+	// is excluded on purpose: it is the forced-resync subscribe, and when the
+	// whole history is still retained an incremental-from-zero delta would
+	// come back instead of the snapshot the caller asked for.
+	if afterOffset > 0 && afterOffset >= windowStart && afterOffset < total {
 		return sb.tailBytesLocked(int(total - afterOffset)), total, false
 	}
 
-	// Cold subscribe, negative offset, stale offset > total, or caller
-	// has fallen behind the retained window: send everything we have
-	// with the snapshot flag, prefixed with the tracker's mode-restore
+	// Cold subscribe, forced resync (afterOffset <= 0), stale offset > total,
+	// or caller has fallen behind the retained window: send everything we
+	// have with the snapshot flag, prefixed with the tracker's mode-restore
 	// bytes so a TUI in alt screen still renders correctly after the
 	// xterm reset+replay.
 	body := sb.tailBytesLocked(sb.retainedLocked())

--- a/frontend/src/api/workerRpc.ts
+++ b/frontend/src/api/workerRpc.ts
@@ -405,8 +405,8 @@ export function restartTerminal(workerId: string, req: MessageInitShape<typeof R
   return callWorker(workerId, 'RestartTerminal', RestartTerminalRequestSchema, RestartTerminalResponseSchema, req)
 }
 
-export function sendInput(workerId: string, req: MessageInitShape<typeof SendInputRequestSchema>): Promise<SendInputResponse> {
-  return callWorker(workerId, 'SendInput', SendInputRequestSchema, SendInputResponseSchema, req)
+export function sendInput(workerId: string, req: MessageInitShape<typeof SendInputRequestSchema>, opts?: { timeoutMs?: number, signal?: AbortSignal }): Promise<SendInputResponse> {
+  return callWorker(workerId, 'SendInput', SendInputRequestSchema, SendInputResponseSchema, req, opts)
 }
 
 export function resizeTerminal(workerId: string, req: MessageInitShape<typeof ResizeTerminalRequestSchema>): Promise<ResizeTerminalResponse> {

--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -378,7 +378,14 @@ export const AppShell: Component = () => {
   // the row again would strand a full serialized scrollback that nothing can
   // ever retire, because the sweep retires an id once and it can never be live
   // again.
-  setTerminalScreenSink((tabId, screen) => tabMetadata.patchExisting(tabId, { screen }))
+  // The sink also rewinds lastOffset to the parsed offset the serialized
+  // screen actually covers: the live cursor can sit ahead of the parser (a
+  // write is queued before it parses), and a remount would otherwise trim the
+  // never-painted span of the next catch-up delta as "already rendered".
+  setTerminalScreenSink((tabId, screen, parsedOffset) => tabMetadata.patchExisting(tabId, {
+    screen,
+    ...(parsedOffset !== undefined ? { lastOffset: parsedOffset } : {}),
+  }))
   onCleanup(() => setTerminalScreenSink(null))
 
   // Workspace & section loading

--- a/frontend/src/components/shell/useTerminalOperations.test.ts
+++ b/frontend/src/components/shell/useTerminalOperations.test.ts
@@ -12,7 +12,7 @@ import { TerminalStatus } from '~/generated/leapmux/v1/terminal_pb'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
 import { handleTerminalBell } from '~/hooks/terminalEvents'
 import { emitAddTab } from '~/stores/tabOps'
-import { flush } from '~/test-support/async'
+import { deferred, flush } from '~/test-support/async'
 import { installTestBridge } from '~/test-support/crdtBridge'
 import { createTestTabStores } from '~/test-support/tabStores'
 
@@ -49,6 +49,20 @@ const openTerminalMock = workerRpc.openTerminal as unknown as ReturnType<typeof 
 const closeTerminalMock = workerRpc.closeTerminal as unknown as ReturnType<typeof vi.fn>
 const listAvailableShellsMock = workerRpc.listAvailableShells as unknown as ReturnType<typeof vi.fn>
 const showWarnToastMock = showWarnToast as unknown as ReturnType<typeof vi.fn>
+
+/**
+ * Park the next SendInput until `release` fires, so a test can type into the
+ * queue while the RPC is still in flight.
+ */
+function parkSendInputOnce(opts: { failAfterRelease?: boolean } = {}): { release: () => void } {
+  const gate = deferred<void>()
+  sendInputMock.mockImplementationOnce(() => gate.promise.then(() => {
+    if (opts.failAfterRelease)
+      throw new Error('worker offline')
+    return {}
+  }))
+  return { release: gate.resolve }
+}
 
 interface TabOverrides {
   id?: string
@@ -373,13 +387,7 @@ describe('useterminaloperations.handleterminalinput', () => {
     // in flight together can reach the PTY transposed. Two syllables swapped is
     // exactly the corruption CJK typing shows.
     const { ops } = setup(TerminalStatus.READY)
-    let release: (() => void) | undefined
-    sendInputMock.mockImplementationOnce(async () => {
-      await new Promise<void>((resolve) => {
-        release = resolve
-      })
-      return {}
-    })
+    const parked = parkSendInputOnce()
 
     const first = ops.handleTerminalInput('tid-1', new TextEncoder().encode('\uC548'))
     await Promise.resolve()
@@ -391,7 +399,7 @@ describe('useterminaloperations.handleterminalinput', () => {
     await Promise.resolve()
     expect(sendInputMock).toHaveBeenCalledTimes(1)
 
-    release!()
+    parked.release()
     await first
 
     // The queued bytes left together, in the order they were typed.
@@ -413,46 +421,89 @@ describe('useterminaloperations.handleterminalinput', () => {
     expect(new TextDecoder().decode(sendInputMock.mock.calls[1][1].data)).toBe('b')
   })
 
-  it('keeps draining after a failed send', async () => {
+  it('retries a failed batch once so a transient RPC failure loses nothing', async () => {
     const { ops } = setup(TerminalStatus.READY)
-    let release: (() => void) | undefined
-    sendInputMock.mockImplementationOnce(async () => {
-      await new Promise<void>((resolve) => {
-        release = resolve
-      })
-      throw new Error('worker offline')
-    })
+    const parked = parkSendInputOnce({ failAfterRelease: true })
 
     const first = ops.handleTerminalInput('tid-1', new TextEncoder().encode('a'))
     await Promise.resolve()
     void ops.handleTerminalInput('tid-1', new TextEncoder().encode('b'))
-    release!()
-    // One failed write must not discard the rest of what the user typed, and
-    // must not propagate: xterm's onData callback has no error sink.
+    parked.release()
+    // One failed write must not discard what the user typed, and must not
+    // propagate: xterm's onData callback has no error sink. A clean rejection
+    // never reached the PTY, so the batch rides again — merged with the bytes
+    // typed while it was failing.
     await expect(first).resolves.toBeUndefined()
     expect(sendInputMock).toHaveBeenCalledTimes(2)
-    expect(new TextDecoder().decode(sendInputMock.mock.calls[1][1].data)).toBe('b')
+    expect(new TextDecoder().decode(sendInputMock.mock.calls[1][1].data)).toBe('ab')
   })
 
   it('stops draining when the terminal exits mid-burst', async () => {
     const { ops, metadata } = setup(TerminalStatus.READY)
-    let release: (() => void) | undefined
-    sendInputMock.mockImplementationOnce(async () => {
-      await new Promise<void>((resolve) => {
-        release = resolve
-      })
-      return {}
-    })
+    const parked = parkSendInputOnce()
 
     const first = ops.handleTerminalInput('tid-1', new TextEncoder().encode('a'))
     await Promise.resolve()
     void ops.handleTerminalInput('tid-1', new TextEncoder().encode('b'))
     // The shell exits while the first write is still out.
     metadata.patch('tid-1', { terminalStatus: TerminalStatus.EXITED })
-    release!()
+    parked.release()
     await first
 
     expect(sendInputMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps draining through a transient disconnect', async () => {
+    const { ops, metadata } = setup(TerminalStatus.READY)
+    const parked = parkSendInputOnce()
+
+    const first = ops.handleTerminalInput('tid-1', new TextEncoder().encode('a'))
+    await Promise.resolve()
+    void ops.handleTerminalInput('tid-1', new TextEncoder().encode('b'))
+    // DISCONNECTED is a client-derived status that a false-positive sweep
+    // can set while the data path still delivers. The queued keystroke must
+    // not be discarded on it — the send attempt itself decides.
+    metadata.patch('tid-1', { terminalStatus: TerminalStatus.DISCONNECTED })
+    parked.release()
+    await first
+
+    expect(sendInputMock).toHaveBeenCalledTimes(2)
+    expect(new TextDecoder().decode(sendInputMock.mock.calls[1][1].data)).toBe('b')
+  })
+
+  it('sends each batch without a per-RPC timeout override', async () => {
+    // The queue races the WHOLE send against apiLoadingTimeoutMs (the same
+    // deadline sizing every channel RPC uses). A per-RPC timeoutMs here would
+    // arm only after the channel opens, so a reconnecting worker would park
+    // the queue on the channel-open chain with no deadline at all.
+    const { ops } = setup(TerminalStatus.READY)
+    await ops.handleTerminalInput('tid-1', new TextEncoder().encode('a'))
+
+    expect(sendInputMock).toHaveBeenCalledTimes(1)
+    expect(sendInputMock.mock.calls[0][2]).toBeUndefined()
+  })
+
+  it('keeps one queue per terminal across hook instances', async () => {
+    // The shell can remount (an error-boundary reset) while a drain is still
+    // parked on its in-flight RPC. The queue map is module-level, so the
+    // fresh hook instance joins the existing drain instead of racing a
+    // second SendInput for the same terminal.
+    const firstInstance = setup(TerminalStatus.READY)
+    const parked = parkSendInputOnce()
+
+    const first = firstInstance.ops.handleTerminalInput('tid-1', new TextEncoder().encode('a'))
+    await Promise.resolve()
+
+    const secondInstance = setup(TerminalStatus.READY)
+    void secondInstance.ops.handleTerminalInput('tid-1', new TextEncoder().encode('b'))
+    await Promise.resolve()
+    // The second instance must not start a SendInput of its own.
+    expect(sendInputMock).toHaveBeenCalledTimes(1)
+
+    parked.release()
+    await first
+    expect(sendInputMock).toHaveBeenCalledTimes(2)
+    expect(new TextDecoder().decode(sendInputMock.mock.calls[1][1].data)).toBe('b')
   })
 
   it('calls restartTerminal when Enter (CR) is pressed on an EXITED terminal', async () => {
@@ -516,10 +567,8 @@ describe('useterminaloperations.handleterminalinput', () => {
     // armed. A held Enter (autorepeat) would otherwise fire one RPC
     // per keystroke and toast-spam the user with FailedPrecondition
     // rejects from the backend.
-    let releaseRestart: (() => void) | undefined
-    restartTerminalMock.mockImplementationOnce(() => new Promise((resolve) => {
-      releaseRestart = () => resolve({})
-    }))
+    const gate = deferred<Record<string, never>>()
+    restartTerminalMock.mockImplementationOnce(() => gate.promise)
     const { ops } = setup(TerminalStatus.EXITED)
     const firstPress = ops.handleTerminalInput('tid-1', new Uint8Array([0x0D]))
     // Second/third presses must be no-ops while the first call is pending.
@@ -527,7 +576,7 @@ describe('useterminaloperations.handleterminalinput', () => {
     await ops.handleTerminalInput('tid-1', new Uint8Array([0x0D]))
     expect(restartTerminalMock).toHaveBeenCalledTimes(1)
     expect(showWarnToastMock).not.toHaveBeenCalled()
-    releaseRestart?.()
+    gate.resolve({})
     await firstPress
   })
 

--- a/frontend/src/components/shell/useTerminalOperations.test.ts
+++ b/frontend/src/components/shell/useTerminalOperations.test.ts
@@ -368,6 +368,93 @@ describe('useterminaloperations.handleterminalinput', () => {
     expect(arg.terminalId).toBe('tid-1')
   })
 
+  it('keeps one SendInput in flight per terminal so the PTY sees arrival order', async () => {
+    // The worker dispatches every inner RPC on its own goroutine, so two calls
+    // in flight together can reach the PTY transposed. Two syllables swapped is
+    // exactly the corruption CJK typing shows.
+    const { ops } = setup(TerminalStatus.READY)
+    let release: (() => void) | undefined
+    sendInputMock.mockImplementationOnce(async () => {
+      await new Promise<void>((resolve) => {
+        release = resolve
+      })
+      return {}
+    })
+
+    const first = ops.handleTerminalInput('tid-1', new TextEncoder().encode('\uC548'))
+    await Promise.resolve()
+    expect(sendInputMock).toHaveBeenCalledTimes(1)
+
+    // Typed while the first call is still out. Neither may start a second call.
+    void ops.handleTerminalInput('tid-1', new TextEncoder().encode('\uB155'))
+    void ops.handleTerminalInput('tid-1', new TextEncoder().encode('!'))
+    await Promise.resolve()
+    expect(sendInputMock).toHaveBeenCalledTimes(1)
+
+    release!()
+    await first
+
+    // The queued bytes left together, in the order they were typed.
+    expect(sendInputMock).toHaveBeenCalledTimes(2)
+    expect(new TextDecoder().decode(sendInputMock.mock.calls[0][1].data)).toBe('\uC548')
+    expect(new TextDecoder().decode(sendInputMock.mock.calls[1][1].data)).toBe('\uB155!')
+  })
+
+  it('starts a fresh queue once a burst has drained', async () => {
+    // The queue is dropped when it empties, so a later keystroke must not land
+    // in a stale one -- nor be batched onto bytes that already went out.
+    const { ops } = setup(TerminalStatus.READY)
+
+    await ops.handleTerminalInput('tid-1', new TextEncoder().encode('a'))
+    await ops.handleTerminalInput('tid-1', new TextEncoder().encode('b'))
+
+    expect(sendInputMock).toHaveBeenCalledTimes(2)
+    expect(new TextDecoder().decode(sendInputMock.mock.calls[0][1].data)).toBe('a')
+    expect(new TextDecoder().decode(sendInputMock.mock.calls[1][1].data)).toBe('b')
+  })
+
+  it('keeps draining after a failed send', async () => {
+    const { ops } = setup(TerminalStatus.READY)
+    let release: (() => void) | undefined
+    sendInputMock.mockImplementationOnce(async () => {
+      await new Promise<void>((resolve) => {
+        release = resolve
+      })
+      throw new Error('worker offline')
+    })
+
+    const first = ops.handleTerminalInput('tid-1', new TextEncoder().encode('a'))
+    await Promise.resolve()
+    void ops.handleTerminalInput('tid-1', new TextEncoder().encode('b'))
+    release!()
+    // One failed write must not discard the rest of what the user typed, and
+    // must not propagate: xterm's onData callback has no error sink.
+    await expect(first).resolves.toBeUndefined()
+    expect(sendInputMock).toHaveBeenCalledTimes(2)
+    expect(new TextDecoder().decode(sendInputMock.mock.calls[1][1].data)).toBe('b')
+  })
+
+  it('stops draining when the terminal exits mid-burst', async () => {
+    const { ops, metadata } = setup(TerminalStatus.READY)
+    let release: (() => void) | undefined
+    sendInputMock.mockImplementationOnce(async () => {
+      await new Promise<void>((resolve) => {
+        release = resolve
+      })
+      return {}
+    })
+
+    const first = ops.handleTerminalInput('tid-1', new TextEncoder().encode('a'))
+    await Promise.resolve()
+    void ops.handleTerminalInput('tid-1', new TextEncoder().encode('b'))
+    // The shell exits while the first write is still out.
+    metadata.patch('tid-1', { terminalStatus: TerminalStatus.EXITED })
+    release!()
+    await first
+
+    expect(sendInputMock).toHaveBeenCalledTimes(1)
+  })
+
   it('calls restartTerminal when Enter (CR) is pressed on an EXITED terminal', async () => {
     const { ops } = setup(TerminalStatus.EXITED)
     await ops.handleTerminalInput('tid-1', new Uint8Array([0x0D]))

--- a/frontend/src/components/shell/useTerminalOperations.ts
+++ b/frontend/src/components/shell/useTerminalOperations.ts
@@ -3,11 +3,13 @@ import type { TabContext } from './tabContext'
 import type { CloseTabResult } from '~/generated/leapmux/v1/common_pb'
 import type { Workspace } from '~/generated/leapmux/v1/workspace_pb'
 import type { ToggleDialogState } from '~/hooks/createDialogState'
+import type { InputQueueDrain } from '~/lib/inputQueue'
 import type { createLayoutStore } from '~/stores/layout.store'
 import type { TabMetadataStore } from '~/stores/tabMetadata.store'
 import type { TabSelectionStore } from '~/stores/tabSelection.store'
 
 import type { TabView } from '~/stores/tabView'
+import { apiLoadingTimeoutMs } from '~/api/transport'
 import * as workerRpc from '~/api/workerRpc'
 import { showWarnToast } from '~/components/common/Toast'
 import { awaitCloseResult, warnWorktreeUnreachable } from '~/components/shell/closeResultToast'
@@ -16,17 +18,33 @@ import { WorktreeAction } from '~/generated/leapmux/v1/common_pb'
 import { TerminalStatus } from '~/generated/leapmux/v1/terminal_pb'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
 import { useAvailableShells } from '~/hooks/useAvailableShells'
-import { concatBytes } from '~/lib/bytes'
 import { createInflightCache } from '~/lib/inflightCache'
-import { DEFAULT_TERMINAL_COLS, DEFAULT_TERMINAL_ROWS } from '~/lib/terminal'
+import { createSharedInputQueues } from '~/lib/inputQueue'
+import { DEFAULT_TERMINAL_COLS, DEFAULT_TERMINAL_ROWS, ENTER_KEY_CR } from '~/lib/terminal'
 import { openedTerminalMetadata, resolveOptimisticGitInfo } from '~/stores/tab.helpers'
 import { emitRemoveTab } from '~/stores/tabOps'
 import { openTabInFocusedTile } from './openTabInFocusedTile'
 
-// xterm emits Enter as a single CR byte (0x0D) on a non-modifier press.
+// xterm emits Enter as a single CR byte on a non-modifier press.
 // We gate the EXITED-tab restart flow on exactly that one byte so a stray
 // keystroke (or the autorepeat from a held key) doesn't fire a restart.
-const ENTER_KEY_CR = 0x0D
+// The byte itself lives in ~/lib/terminal with the other PTY wire constants.
+
+// The pending input queue for each terminal, drained one SendInput at a time
+// by the hook below. Created at MODULE scope, like the terminal instances it
+// feeds (TerminalView keeps the same module-level map for the same reason):
+// the one-in-flight invariant must hold across every hook instance, not per
+// instance. An error-boundary remount of the shell creates a fresh hook while
+// an old drain still parks on its in-flight RPC; a per-instance queue would
+// let the next keystroke start a SECOND concurrent SendInput for the same
+// terminal, which is the transposed-write race this queue exists to prevent.
+// The mechanism and its unit tests live in ~/lib/inputQueue.
+const terminalInputQueues = createSharedInputQueues<string, TerminalInputContext>()
+
+/** What the input drain needs to route one SendInput. */
+interface TerminalInputContext {
+  workerId?: string
+}
 
 export interface UseTerminalOperationsProps {
   view: TabView
@@ -58,6 +76,40 @@ export function useTerminalOperations(props: UseTerminalOperationsProps) {
   // returns on overlapping presses so they never reach the shared
   // promise's eventual rejection (which would multi-toast).
   const restartInflight = createInflightCache<string, void>()
+
+  // One input drain per hook instance, built once. It captures ONLY `view`
+  // (not the whole props graph), so the module-level queue below retains a
+  // single store reference for as long as one of its bursts is open. The
+  // queue takes the drain from the newest enqueue, so a remounted hook takes
+  // its own terminals back on the next keystroke.
+  const view = props.view
+  const terminalInputDrain: InputQueueDrain<string, TerminalInputContext> = {
+    // Re-resolve the tab before each batch. Only a tab that is gone, or a
+    // terminal that EXITED, stops the drain: a transient status such as
+    // DISCONNECTED (a client-derived status that a false-positive sweep
+    // can set while the data path still delivers) must not silently
+    // discard what the user already typed — the send attempt itself
+    // decides, and a failed attempt keeps draining for a reconnect.
+    resolve: (id) => {
+      const t = view.getTerminalTab(id)
+      if (!t || t.status === TerminalStatus.EXITED)
+        return undefined
+      return { workerId: t.workerId }
+    },
+    send: async (id, t, batch) => {
+      await workerRpc.sendInput(t.workerId ?? '', { terminalId: id, data: batch })
+    },
+    // The deadline the queue races each send against is the canonical RPC
+    // deadline (1.5 × the worker's context deadline, ~/api/transport), for
+    // two reasons. It satisfies the sizing rule every channel RPC follows —
+    // the client must out-wait the worker's own deadline, or the drain's
+    // next batch would run while the previous send can still deliver, which
+    // re-opens the transposed-write race the queue exists to close. And it
+    // covers legs a per-RPC timeout cannot reach: the RPC timer arms only
+    // after the channel is open, so a reconnecting worker would otherwise
+    // park the queue on the channel-open chain for far longer.
+    sendDeadlineMs: apiLoadingTimeoutMs,
+  }
 
   // Shared open path for both the default-shell quick-action and the
   // shell-picker dropdown. The only call-site differences captured by
@@ -135,70 +187,13 @@ export function useTerminalOperations(props: UseTerminalOperationsProps) {
   const handleOpenTerminalWithShell = (shell: string) =>
     openTerminalCore({ shell, setLoading: props.setNewShellLoading })
 
-  /**
-   * Drain the queued bytes for one terminal, one SendInput at a time.
-   *
-   * The worker dispatches every inner RPC on its own goroutine, so two
-   * SendInput calls in flight together reach the PTY in whichever order their
-   * goroutines win — the per-terminal mutex gives mutual exclusion, not FIFO.
-   * Keeping a single call in flight per terminal removes the race at the only
-   * point that can see the true order, which is here.
-   *
-   * It costs nothing in the common case: with nothing in flight the first
-   * keystroke goes out immediately. Only a burst that outruns the round trip
-   * queues, and that burst then leaves as ONE larger write rather than several
-   * racing ones, which is also what the PTY prefers. Serializing on the
-   * response instead — awaiting each keystroke before reading the next — would
-   * have gated typing on the round-trip time.
-   */
-  const inputQueues = new Map<string, Uint8Array[]>()
-
-  const drainTerminalInput = async (terminalId: string) => {
-    const pending = inputQueues.get(terminalId)
-    if (!pending)
-      return
-    try {
-      while (pending.length > 0) {
-        const batch = concatBytes(...pending)
-        pending.length = 0
-        // Re-read the tab each time round: a terminal that exited mid-drain
-        // must not keep receiving the rest of the burst.
-        const tab = props.view.getTerminalTab(terminalId)
-        if (!tab || tab.status !== TerminalStatus.READY)
-          return
-        try {
-          await workerRpc.sendInput(tab.workerId ?? '', { terminalId, data: batch })
-        }
-        catch {
-          // Ignore input errors, and keep draining: dropping the rest of what
-          // the user typed because one write failed is the worse outcome.
-        }
-      }
-    }
-    finally {
-      // Safe to drop: the loop only exits with the queue empty or the terminal
-      // gone, and nothing can push in between (no await separates the check
-      // from here). A later keystroke simply creates a fresh queue.
-      inputQueues.delete(terminalId)
-    }
-  }
-
   const handleTerminalInput = async (terminalId: string, data: Uint8Array) => {
     const tab = props.view.getTerminalTab(terminalId)
     if (!tab)
       return
 
     if (tab.status === TerminalStatus.READY) {
-      const pending = inputQueues.get(terminalId)
-      if (pending) {
-        // A drain is already running and owns this queue; it will pick these
-        // bytes up on its next turn, after the in-flight call resolves.
-        pending.push(data)
-        return
-      }
-      inputQueues.set(terminalId, [data])
-      await drainTerminalInput(terminalId)
-      return
+      return terminalInputQueues.enqueue(terminalId, data, terminalInputDrain)
     }
 
     // On an exited terminal, the only key that does something is Enter,

--- a/frontend/src/components/shell/useTerminalOperations.ts
+++ b/frontend/src/components/shell/useTerminalOperations.ts
@@ -16,6 +16,7 @@ import { WorktreeAction } from '~/generated/leapmux/v1/common_pb'
 import { TerminalStatus } from '~/generated/leapmux/v1/terminal_pb'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
 import { useAvailableShells } from '~/hooks/useAvailableShells'
+import { concatBytes } from '~/lib/bytes'
 import { createInflightCache } from '~/lib/inflightCache'
 import { DEFAULT_TERMINAL_COLS, DEFAULT_TERMINAL_ROWS } from '~/lib/terminal'
 import { openedTerminalMetadata, resolveOptimisticGitInfo } from '~/stores/tab.helpers'
@@ -134,18 +135,69 @@ export function useTerminalOperations(props: UseTerminalOperationsProps) {
   const handleOpenTerminalWithShell = (shell: string) =>
     openTerminalCore({ shell, setLoading: props.setNewShellLoading })
 
+  /**
+   * Drain the queued bytes for one terminal, one SendInput at a time.
+   *
+   * The worker dispatches every inner RPC on its own goroutine, so two
+   * SendInput calls in flight together reach the PTY in whichever order their
+   * goroutines win — the per-terminal mutex gives mutual exclusion, not FIFO.
+   * Keeping a single call in flight per terminal removes the race at the only
+   * point that can see the true order, which is here.
+   *
+   * It costs nothing in the common case: with nothing in flight the first
+   * keystroke goes out immediately. Only a burst that outruns the round trip
+   * queues, and that burst then leaves as ONE larger write rather than several
+   * racing ones, which is also what the PTY prefers. Serializing on the
+   * response instead — awaiting each keystroke before reading the next — would
+   * have gated typing on the round-trip time.
+   */
+  const inputQueues = new Map<string, Uint8Array[]>()
+
+  const drainTerminalInput = async (terminalId: string) => {
+    const pending = inputQueues.get(terminalId)
+    if (!pending)
+      return
+    try {
+      while (pending.length > 0) {
+        const batch = concatBytes(...pending)
+        pending.length = 0
+        // Re-read the tab each time round: a terminal that exited mid-drain
+        // must not keep receiving the rest of the burst.
+        const tab = props.view.getTerminalTab(terminalId)
+        if (!tab || tab.status !== TerminalStatus.READY)
+          return
+        try {
+          await workerRpc.sendInput(tab.workerId ?? '', { terminalId, data: batch })
+        }
+        catch {
+          // Ignore input errors, and keep draining: dropping the rest of what
+          // the user typed because one write failed is the worse outcome.
+        }
+      }
+    }
+    finally {
+      // Safe to drop: the loop only exits with the queue empty or the terminal
+      // gone, and nothing can push in between (no await separates the check
+      // from here). A later keystroke simply creates a fresh queue.
+      inputQueues.delete(terminalId)
+    }
+  }
+
   const handleTerminalInput = async (terminalId: string, data: Uint8Array) => {
     const tab = props.view.getTerminalTab(terminalId)
     if (!tab)
       return
 
     if (tab.status === TerminalStatus.READY) {
-      try {
-        await workerRpc.sendInput(tab.workerId ?? '', { terminalId, data })
+      const pending = inputQueues.get(terminalId)
+      if (pending) {
+        // A drain is already running and owns this queue; it will pick these
+        // bytes up on its next turn, after the in-flight call resolves.
+        pending.push(data)
+        return
       }
-      catch {
-        // ignore input errors
-      }
+      inputQueues.set(terminalId, [data])
+      await drainTerminalInput(terminalId)
       return
     }
 

--- a/frontend/src/components/terminal/TerminalView.test.tsx
+++ b/frontend/src/components/terminal/TerminalView.test.tsx
@@ -9,6 +9,8 @@ import { TerminalStatus } from '~/generated/leapmux/v1/terminal_pb'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
 import { darkTerminalTheme, lightTerminalTheme } from '~/lib/terminal'
 import { webglPool } from '~/lib/webglTerminalPool'
+import { compositionPreview } from '~/test-support/compositionPreview'
+import { stubMatchMedia } from '~/test-support/matchMediaStub'
 
 const mockCreateTerminalInstance = vi.fn()
 // Overridable only where a test needs to drive the disposal-capture guard; the
@@ -36,11 +38,7 @@ beforeAll(() => {
     unobserve() {}
     disconnect() {}
   } as unknown as typeof ResizeObserver
-  window.matchMedia = vi.fn().mockReturnValue({
-    matches: false,
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-  }) as any
+  stubMatchMedia()
 })
 
 /**
@@ -74,7 +72,8 @@ function makeMockTerminalInstance(): TerminalInstance {
     element: undefined as HTMLElement | undefined,
     textarea,
     attachCustomKeyEventHandler: vi.fn(),
-    onData: vi.fn(),
+    // Real xterm's onData returns an IDisposable; the IME layer disposes it.
+    onData: vi.fn(() => ({ dispose: () => {} })),
     onTitleChange: vi.fn(),
     onBell: vi.fn((cb: () => void) => {
       bellHandler = cb
@@ -425,15 +424,8 @@ describe('terminalView', () => {
     // registers. With the default match-ui terminal theme + system UI theme the
     // resolved theme follows the OS, so this exercises the (guarded) theme
     // effect end to end. matchMedia starts in light.
-    const originalMatchMedia = window.matchMedia
-    let colorSchemeHandler: ((e: { matches: boolean }) => void) | undefined
-    window.matchMedia = vi.fn().mockReturnValue({
-      matches: false,
-      addEventListener: (_type: string, cb: (e: { matches: boolean }) => void) => {
-        colorSchemeHandler = cb
-      },
-      removeEventListener: vi.fn(),
-    }) as any
+    const matchMedia = stubMatchMedia()
+    const colorScheme = () => matchMedia.handlersFor('(prefers-color-scheme: dark)')[0]
 
     try {
       const baseTab = { type: TabType.TERMINAL as const, workspaceId: 'ws-1', screen: new Uint8Array() }
@@ -451,11 +443,11 @@ describe('terminalView', () => {
         </PreferencesProvider>
       ))
 
-      await waitFor(() => expect(colorSchemeHandler).toBeDefined())
+      await waitFor(() => expect(colorScheme()).toBeDefined())
 
       // Flip the OS to dark: the effect's change guard must let a genuine
       // change through and re-apply the dark theme to the live instance.
-      colorSchemeHandler!({ matches: true })
+      colorScheme()!({ matches: true })
       await waitFor(() => {
         expect(instance.terminal.options.theme).toBe(darkTerminalTheme)
       })
@@ -463,13 +455,13 @@ describe('terminalView', () => {
       // Flip back to light: a second genuine change must also propagate,
       // proving the guard updates its last-applied theme rather than latching
       // on the first one it saw.
-      colorSchemeHandler!({ matches: false })
+      colorScheme()!({ matches: false })
       await waitFor(() => {
         expect(instance.terminal.options.theme).toBe(lightTerminalTheme)
       })
     }
     finally {
-      window.matchMedia = originalMatchMedia
+      matchMedia.restore()
     }
   })
 
@@ -509,15 +501,8 @@ describe('terminalView', () => {
       .mockReturnValueOnce(instanceB)
 
     // Collect every view's prefers-color-scheme handler so we can flip both.
-    const originalMatchMedia = window.matchMedia
-    const colorSchemeHandlers: Array<(e: { matches: boolean }) => void> = []
-    window.matchMedia = vi.fn().mockReturnValue({
-      matches: false,
-      addEventListener: (_type: string, cb: (e: { matches: boolean }) => void) => {
-        colorSchemeHandlers.push(cb)
-      },
-      removeEventListener: vi.fn(),
-    }) as any
+    const matchMedia = stubMatchMedia()
+    const colorSchemeHandlers = () => matchMedia.handlersFor('(prefers-color-scheme: dark)')
 
     try {
       const baseTab = { type: TabType.TERMINAL as const, workspaceId: 'ws-1', screen: new Uint8Array() }
@@ -546,7 +531,7 @@ describe('terminalView', () => {
 
       // Both views mount, both register a handler, both instances exist.
       await waitFor(() => {
-        expect(colorSchemeHandlers.length).toBe(2)
+        expect(colorSchemeHandlers().length).toBe(2)
         expect(getTerminalInstance('themed-A')).toBe(instanceA)
         expect(getTerminalInstance('themed-B')).toBe(instanceB)
       })
@@ -557,7 +542,7 @@ describe('terminalView', () => {
       const baselineB = writesB()
 
       // Flip the OS to dark and drive every view's handler.
-      for (const handler of colorSchemeHandlers)
+      for (const handler of colorSchemeHandlers())
         handler({ matches: true })
 
       await waitFor(() => {
@@ -572,7 +557,7 @@ describe('terminalView', () => {
       expect(writesB() - baselineB).toBe(1)
     }
     finally {
-      window.matchMedia = originalMatchMedia
+      matchMedia.restore()
     }
   })
 
@@ -716,21 +701,22 @@ describe('terminalView', () => {
  * through `disposeTerminalInstance`, and nothing re-fetches the bytes
  * afterwards (`hydrated` is already true), so a miss here is permanent.
  */
+/**
+ * Reset every module mock and pool this file's suites share, so the reset
+ * list stays in sync when a new mock or pool joins the file.
+ */
+function resetTerminalViewMocks(): void {
+  mockCreateTerminalInstance.mockReset()
+  mockBufferHasVisibleContent.mockReset().mockReturnValue(undefined)
+  mockSerializeXtermBuffer.mockReset().mockReturnValue(undefined)
+  webglPool.disposeAll()
+  // Re-install the full stub in case an earlier suite left a partial one
+  // behind; beforeAll has already run, so it does not re-arm on its own.
+  stubMatchMedia()
+}
+
 describe('disposeTerminalInstance scrollback capture', () => {
-  beforeEach(() => {
-    mockCreateTerminalInstance.mockReset()
-    mockBufferHasVisibleContent.mockReset().mockReturnValue(undefined)
-    mockSerializeXtermBuffer.mockReset().mockReturnValue(undefined)
-    webglPool.disposeAll()
-    // An earlier suite may leave matchMedia as a bare `{ matches }` stub with
-    // no addEventListener, and beforeAll has already run — restore the full
-    // shape the rendered component needs.
-    window.matchMedia = vi.fn().mockReturnValue({
-      matches: false,
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-    }) as any
-  })
+  beforeEach(resetTerminalViewMocks)
 
   afterEach(() => {
     setTerminalScreenSink(null)
@@ -757,14 +743,15 @@ describe('disposeTerminalInstance scrollback capture', () => {
     return instance
   }
 
-  it('hands the live buffer to the sink before tearing the instance down', async () => {
-    await mount('term-dispose')
+  it('hands the live buffer and its parsed offset to the sink before tearing the instance down', async () => {
+    const instance = await mount('term-dispose')
+    instance.lastParsedOffset = 4321
     mockBufferHasVisibleContent.mockReturnValue(true)
     mockSerializeXtermBuffer.mockReturnValue(new TextEncoder().encode('scrollback-worth-keeping'))
 
-    const captured: Array<{ id: string, text: string }> = []
-    setTerminalScreenSink((id, screen) => {
-      captured.push({ id, text: new TextDecoder().decode(screen) })
+    const captured: Array<{ id: string, text: string, parsedOffset?: number }> = []
+    setTerminalScreenSink((id, screen, parsedOffset) => {
+      captured.push({ id, text: new TextDecoder().decode(screen), parsedOffset })
     })
 
     disposeTerminalInstance('term-dispose')
@@ -772,8 +759,31 @@ describe('disposeTerminalInstance scrollback capture', () => {
     expect(captured).toHaveLength(1)
     expect(captured[0].id).toBe('term-dispose')
     expect(captured[0].text).toBe('scrollback-worth-keeping')
+    // The offset the serialized screen actually covers rides along, so the
+    // store can rewind lastOffset onto it.
+    expect(captured[0].parsedOffset).toBe(4321)
     // And the instance really is gone — capturing must not keep it alive.
     expect(getTerminalInstance('term-dispose')).toBeUndefined()
+  })
+
+  it('skips the capture while a write is still unparsed', async () => {
+    // A dispose mid-parse serializes fewer bytes than the live cursor
+    // claims. Storing that screen next to the inflated cursor would make the
+    // remount trim the never-painted span of the next catch-up delta as
+    // "already rendered" — so the capture waits for a parsed write instead
+    // and the previous stored screen stays.
+    const instance = await mount('term-midparse')
+    instance.lastParsedOffset = undefined
+    mockBufferHasVisibleContent.mockReturnValue(true)
+    mockSerializeXtermBuffer.mockReturnValue(new TextEncoder().encode('half-parsed'))
+
+    const captured: string[] = []
+    setTerminalScreenSink(id => captured.push(id))
+
+    disposeTerminalInstance('term-midparse')
+
+    expect(captured).toEqual([])
+    expect(getTerminalInstance('term-midparse')).toBeUndefined()
   })
 
   it('writes nothing for a buffer that has not painted yet', async () => {
@@ -793,6 +803,7 @@ describe('disposeTerminalInstance scrollback capture', () => {
 
   it('still tears down when the sink throws', async () => {
     const instance = await mount('term-throws')
+    instance.lastParsedOffset = 10
     mockBufferHasVisibleContent.mockReturnValue(true)
     mockSerializeXtermBuffer.mockReturnValue(new Uint8Array([1]))
 
@@ -807,20 +818,9 @@ describe('disposeTerminalInstance scrollback capture', () => {
 })
 
 describe('terminalView IME wiring', () => {
-  beforeEach(() => {
-    mockCreateTerminalInstance.mockReset()
-    mockBufferHasVisibleContent.mockReset().mockReturnValue(undefined)
-    mockSerializeXtermBuffer.mockReset().mockReturnValue(undefined)
-    webglPool.disposeAll()
-    window.matchMedia = vi.fn().mockReturnValue({
-      matches: false,
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-    }) as any
-  })
+  beforeEach(resetTerminalViewMocks)
 
-  async function mount(id: string, onInput = vi.fn()) {
-    const instance = makeMockTerminalInstance()
+  async function mount(id: string, onInput = vi.fn(), instance = makeMockTerminalInstance()) {
     mockCreateTerminalInstance.mockReturnValue(instance)
     render(() => (
       <PreferencesProvider>
@@ -854,6 +854,69 @@ describe('terminalView IME wiring', () => {
     expect(instance.ime).toBeDefined()
 
     disposeTerminalInstance('term-ime-attach')
+  })
+
+  it('logs the input the gate forwarded, and only that', async () => {
+    // The e2e IME specs assert against this log; it must record every path
+    // the gate lets through (keystrokes, IME commits, programmatic writes)
+    // and nothing the gate suppressed, or the doubling/loss assertions would
+    // measure the wrong thing.
+    const onInput = vi.fn()
+    const { instance } = await mount('term-ime-log', onInput)
+
+    const commit = (text: string) => instance.terminal.textarea!.dispatchEvent(
+      new CompositionEvent('compositionend', { data: text, bubbles: true, composed: true }),
+    )
+
+    commit('\uC548')
+    instance.sendInput!(new TextEncoder().encode('!!'))
+    expect((window as any).__getActiveTerminalInputLog()).toBe('\uC548!!')
+
+    // A write mid-replay is swallowed by the gate and must stay out of the
+    // log — the log is the send-side truth, not the attempt-side.
+    instance.suppressInput = true
+    commit('\uB155')
+    expect((window as any).__getActiveTerminalInputLog()).toBe('\uC548!!')
+
+    disposeTerminalInstance('term-ime-log')
+  })
+
+  it('releases the IME layer before the terminal on dispose', async () => {
+    const { instance } = await mount('term-ime-order')
+    const order: string[] = []
+    const imeDispose = instance.ime!.dispose.bind(instance.ime)
+    instance.ime!.dispose = () => {
+      order.push('ime')
+      imeDispose()
+    }
+    const instanceDispose = instance.dispose.bind(instance)
+    instance.dispose = () => {
+      order.push('terminal')
+      instanceDispose()
+    }
+
+    disposeTerminalInstance('term-ime-order')
+
+    // The layer's listeners and its preview node hang off terminal.element,
+    // which xterm removes as it tears down, so the layer must go first.
+    expect(order).toEqual(['ime', 'terminal'])
+    expect(instance.ime).toBeUndefined()
+  })
+
+  it('keeps the shell alive when the IME layer cannot attach', async () => {
+    // An xterm upgrade that changes the helper DOM shape makes
+    // attachTerminalIme throw by design. The throw must cost the composition
+    // path only — escaping onMount would reach the route-level boundary and
+    // blank every tile.
+    const broken = makeMockTerminalInstance()
+    broken.terminal.textarea!.remove()
+    const { instance } = await mount('term-ime-broken', vi.fn(), broken)
+
+    expect(instance.ime).toBeUndefined()
+    // The plain key path is still wired.
+    expect(instance.terminal.attachCustomKeyEventHandler).toHaveBeenCalledTimes(1)
+
+    disposeTerminalInstance('term-ime-broken')
   })
 
   it('takes composed keystrokes away from xterm', async () => {
@@ -902,9 +965,27 @@ describe('terminalView IME wiring', () => {
     disposeTerminalInstance('term-ime-gate')
   })
 
+  it('suppresses programmatic sendInput on snapshot replay like a keystroke', async () => {
+    const onInput = vi.fn()
+    const { instance } = await mount('term-ime-sendgate', onInput)
+
+    // Programmatic writes (keyboard shortcuts, the e2e input hook) go through
+    // the same gate as keystrokes: a write that leaks through mid-replay
+    // interleaves with the snapshot being replayed.
+    instance.sendInput!(new TextEncoder().encode('\x01'))
+    expect(onInput).toHaveBeenCalledTimes(1)
+    expect(onInput.mock.calls[0][0]).toBe('term-ime-sendgate')
+
+    instance.suppressInput = true
+    instance.sendInput!(new TextEncoder().encode('\x05'))
+    expect(onInput).toHaveBeenCalledTimes(1)
+
+    disposeTerminalInstance('term-ime-sendgate')
+  })
+
   it('releases the IME layer when the instance is disposed', async () => {
     const { instance } = await mount('term-ime-dispose')
-    const preview = () => instance.terminal.element!.querySelector('[data-testid="terminal-composition-preview"]')
+    const preview = () => compositionPreview(instance.terminal.element)
     expect(preview()).not.toBeNull()
 
     // The real dispose() tears the IME layer down; the mock instance's dispose

--- a/frontend/src/components/terminal/TerminalView.test.tsx
+++ b/frontend/src/components/terminal/TerminalView.test.tsx
@@ -43,16 +43,46 @@ beforeAll(() => {
   }) as any
 })
 
+/**
+ * The DOM shape xterm builds inside `open()`, which the IME layer hooks:
+ * `.xterm > .xterm-screen > .xterm-helpers > .xterm-helper-textarea`. The mock
+ * terminal below has to provide it, because `attachTerminalIme` binds on
+ * `terminal.element` and positions its preview against `terminal.textarea`.
+ */
+function makeMockTerminalDom(): { element: HTMLElement, textarea: HTMLTextAreaElement } {
+  const element = document.createElement('div')
+  element.className = 'xterm'
+  const screen = document.createElement('div')
+  screen.className = 'xterm-screen'
+  const helpers = document.createElement('div')
+  helpers.className = 'xterm-helpers'
+  const textarea = document.createElement('textarea')
+  textarea.className = 'xterm-helper-textarea'
+  helpers.appendChild(textarea)
+  screen.appendChild(helpers)
+  element.appendChild(screen)
+  return { element, textarea }
+}
+
 function makeMockTerminalInstance(): TerminalInstance {
   let bellHandler: (() => void) | undefined
+  const { element, textarea } = makeMockTerminalDom()
 
   const terminal = {
+    // Undefined until open(), exactly as real xterm behaves — TerminalView
+    // branches on it to tell a first mount from a re-parent.
+    element: undefined as HTMLElement | undefined,
+    textarea,
+    attachCustomKeyEventHandler: vi.fn(),
     onData: vi.fn(),
     onTitleChange: vi.fn(),
     onBell: vi.fn((cb: () => void) => {
       bellHandler = cb
     }),
-    open: vi.fn(),
+    open: vi.fn((parent: HTMLElement) => {
+      terminal.element = element
+      parent.appendChild(element)
+    }),
     reset: vi.fn(),
     write: vi.fn((data: string | Uint8Array, cb?: () => void) => {
       const text = typeof data === 'string' ? data : new TextDecoder().decode(data)
@@ -773,5 +803,115 @@ describe('disposeTerminalInstance scrollback capture', () => {
     expect(() => disposeTerminalInstance('term-throws')).not.toThrow()
     expect(getTerminalInstance('term-throws'), 'the instance must not leak').toBeUndefined()
     expect(instance.dispose).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('terminalView IME wiring', () => {
+  beforeEach(() => {
+    mockCreateTerminalInstance.mockReset()
+    mockBufferHasVisibleContent.mockReset().mockReturnValue(undefined)
+    mockSerializeXtermBuffer.mockReset().mockReturnValue(undefined)
+    webglPool.disposeAll()
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }) as any
+  })
+
+  async function mount(id: string, onInput = vi.fn()) {
+    const instance = makeMockTerminalInstance()
+    mockCreateTerminalInstance.mockReturnValue(instance)
+    render(() => (
+      <PreferencesProvider>
+        <TerminalView
+          terminals={[{ id, type: TabType.TERMINAL, workspaceId: 'ws-1', screen: new Uint8Array() } as TerminalTab]}
+          activeTerminalId={id}
+          visible
+          tileFocused={false}
+          onInput={onInput}
+          onResize={vi.fn()}
+          onContentReady={vi.fn()}
+        />
+      </PreferencesProvider>
+    ))
+    await waitFor(() => expect(getTerminalInstance(id)).toBe(instance))
+    return { instance, onInput }
+  }
+
+  /** The handler TerminalView passed to xterm's attachCustomKeyEventHandler. */
+  function keyHandler(instance: TerminalInstance): (e: KeyboardEvent) => boolean {
+    const attach = instance.terminal.attachCustomKeyEventHandler as unknown as ReturnType<typeof vi.fn>
+    expect(attach).toHaveBeenCalledTimes(1)
+    return attach.mock.calls[0][0]
+  }
+
+  it('attaches the key handler and the IME layer on every platform', async () => {
+    // jsdom is not macOS. Before the IME work this handler was attached only on
+    // macOS, so CJK input had no interception path at all on Linux or Windows.
+    const { instance } = await mount('term-ime-attach')
+    expect(instance.terminal.attachCustomKeyEventHandler).toHaveBeenCalledTimes(1)
+    expect(instance.ime).toBeDefined()
+
+    disposeTerminalInstance('term-ime-attach')
+  })
+
+  it('takes composed keystrokes away from xterm', async () => {
+    const { instance } = await mount('term-ime-keys')
+    const handle = keyHandler(instance)
+
+    // false means "xterm must not process this".
+    expect(handle(new KeyboardEvent('keydown', { key: 'Process', keyCode: 229 } as KeyboardEventInit))).toBe(false)
+    expect(handle(new KeyboardEvent('keydown', { key: 'd', isComposing: true } as KeyboardEventInit))).toBe(false)
+    expect(handle(new KeyboardEvent('keydown', { key: 'd', keyCode: 68 }))).toBe(true)
+
+    disposeTerminalInstance('term-ime-keys')
+  })
+
+  it('leaves the arrow keys to xterm off macOS', async () => {
+    // The CMD/ALT+Arrow rule stays macOS-only even though the handler is now
+    // attached everywhere; the shortcut system only sends those sequences there.
+    const { instance } = await mount('term-ime-arrows')
+    const handle = keyHandler(instance)
+
+    expect(handle(new KeyboardEvent('keydown', { key: 'ArrowLeft', metaKey: true }))).toBe(true)
+    expect(handle(new KeyboardEvent('keydown', { key: 'ArrowRight', altKey: true }))).toBe(true)
+
+    disposeTerminalInstance('term-ime-arrows')
+  })
+
+  it('sends composed text through the same suppressInput gate as onData', async () => {
+    const onInput = vi.fn()
+    const { instance } = await mount('term-ime-gate', onInput)
+
+    const commit = () => instance.terminal.textarea!.dispatchEvent(
+      new CompositionEvent('compositionend', { data: '안', bubbles: true, composed: true }),
+    )
+
+    commit()
+    expect(onInput).toHaveBeenCalledTimes(1)
+    expect(new TextDecoder().decode(onInput.mock.calls[0][1])).toBe('안')
+
+    // Snapshot replay must swallow composed input exactly as it swallows
+    // ordinary keystrokes, or a reconnect replays the user's typing at the PTY.
+    onInput.mockClear()
+    instance.suppressInput = true
+    commit()
+    expect(onInput).not.toHaveBeenCalled()
+
+    disposeTerminalInstance('term-ime-gate')
+  })
+
+  it('releases the IME layer when the instance is disposed', async () => {
+    const { instance } = await mount('term-ime-dispose')
+    const preview = () => instance.terminal.element!.querySelector('[data-testid="terminal-composition-preview"]')
+    expect(preview()).not.toBeNull()
+
+    // The real dispose() tears the IME layer down; the mock instance's dispose
+    // is a spy, so drive the layer directly to assert the teardown contract.
+    instance.ime!.dispose()
+    expect(preview()).toBeNull()
+
+    disposeTerminalInstance('term-ime-dispose')
   })
 })

--- a/frontend/src/components/terminal/TerminalView.tsx
+++ b/frontend/src/components/terminal/TerminalView.tsx
@@ -7,6 +7,7 @@ import { StartupErrorBody, StartupSpinner } from '~/components/common/StartupPan
 import { usePreferences } from '~/context/PreferencesContext'
 import { TerminalStatus } from '~/generated/leapmux/v1/terminal_pb'
 import { createKeyedRows } from '~/lib/keyedRows'
+import { createLogger } from '~/lib/logger'
 import { createRafResizeObserver } from '~/lib/resizeObserver'
 import { isMac } from '~/lib/shortcuts/platform'
 import { applyTerminalData, bufferHasVisibleContent, createTerminalInstance, DEFAULT_FONT_SIZE, refreshTerminalFont, resolveTerminalTheme, resolveTerminalThemeMode, serializeXtermBuffer } from '~/lib/terminal'
@@ -39,6 +40,20 @@ interface TerminalViewProps {
 }
 
 const instances = new Map<string, TerminalInstance>()
+const log = createLogger('terminalView')
+// TextEncoder construction is not free, and every keystroke passes through
+// one (the shared input gate below and the programmatic write path). The
+// encoder is stateless, so one instance serves every call site in this
+// module. (Same pattern as ~/lib/crdt/hlc.)
+const utf8Encoder = new TextEncoder()
+const utf8Decoder = new TextDecoder()
+// What each terminal's input gate forwarded, most recent input last — the
+// send-side truth the e2e IME specs assert against, because the terminal
+// buffer cannot tell a doubled send from the shell's own echo of the same
+// text. Bounded so a terminal that types all day keeps only its recent
+// input; cleared with the instance.
+const INPUT_LOG_LIMIT = 4096
+const inputLogs = new Map<string, string>()
 // Tracks which terminals have already had their initial screen snapshot
 // applied. This must outlive TerminalContainer mount/unmount because the
 // container re-mounts whenever its surrounding tile is restructured —
@@ -57,9 +72,9 @@ let lastActiveTerminalId: string | null = null
  * on the store graph. Left unset in tests that render a `TerminalView` without
  * a metadata store, where dropping the buffer is the correct behaviour.
  */
-let screenSink: ((tabId: string, screen: Uint8Array) => void) | null = null
+let screenSink: ((tabId: string, screen: Uint8Array, parsedOffset?: number) => void) | null = null
 
-export function setTerminalScreenSink(sink: ((tabId: string, screen: Uint8Array) => void) | null): void {
+export function setTerminalScreenSink(sink: ((tabId: string, screen: Uint8Array, parsedOffset?: number) => void) | null): void {
   screenSink = sink
 }
 
@@ -91,9 +106,16 @@ export function disposeTerminalInstance(id: string, opts?: { captureScreen?: boo
   // `bufferHasVisibleContent` guards a real hazard: a freshly-mounted xterm
   // still parsing its snapshot through the write queue serializes BLANK, and
   // writing that back would erase the bytes `ListTerminals` returned.
-  if (captureScreen && screenSink && bufferHasVisibleContent(instance.terminal)) {
+  if (captureScreen && screenSink && instance.lastParsedOffset !== undefined && bufferHasVisibleContent(instance.terminal)) {
     try {
-      screenSink(id, serializeXtermBuffer(instance))
+      // Pair the serialized (parsed) screen with the offset it actually
+      // covers. A capture taken mid-parse would otherwise store a screen
+      // that covers fewer bytes than the tab's lastOffset claims; on remount
+      // the overlap trim then discards the never-painted span as "already
+      // rendered" and a chunk of output goes missing until a snapshot
+      // rebuilds. Rewinding lastOffset to the parsed offset (in the sink)
+      // makes the next catch-up re-deliver exactly that span.
+      screenSink(id, serializeXtermBuffer(instance), instance.lastParsedOffset)
     }
     catch {
       // A serialization failure must never block teardown — the WebGL context
@@ -104,9 +126,17 @@ export function disposeTerminalInstance(id: string, opts?: { captureScreen?: boo
   // another terminal. This is the single teardown chokepoint reached by every
   // path — explicit close, HMR dispose, and the unmount microtask below.
   webglPool.release(id)
+  // Before instance.dispose(): the IME layer's listeners and its preview
+  // node hang off `terminal.element`, which xterm removes from the document
+  // as it tears down. The view owns both ends of the ime field's lifecycle —
+  // it attaches the layer after open(), and this is the only teardown
+  // chokepoint.
+  instance.ime?.dispose()
+  instance.ime = undefined
   instance.dispose()
   instances.delete(id)
   screenApplied.delete(id)
+  inputLogs.delete(id)
 }
 
 export function getTerminalInstance(id: string): TerminalInstance | undefined {
@@ -164,6 +194,11 @@ if (typeof window !== 'undefined') {
   }
   ;(window as any).__getActiveTerminalRows = () => getActiveInstance()?.terminal.rows ?? 0
   ;(window as any).__getActiveTerminalBufferType = () => getActiveInstance()?.terminal.buffer.active.type ?? 'normal'
+  // E2E hook: the input the active terminal's gate FORWARDED, in order —
+  // the send-side counterpart of __getActiveTerminalText. Doubled or lost
+  // sends are exact here, whatever the shell redraws onto the screen.
+  ;(window as any).__getActiveTerminalInputLog = () =>
+    (lastActiveTerminalId ? inputLogs.get(lastActiveTerminalId) : undefined) ?? ''
   // E2E hook: drive input through the same sendInput callback xterm's
   // onData handler uses, so the test exercises the full handleTerminalInput
   // routing (READY → SendInput RPC, EXITED → RestartTerminal RPC) without
@@ -172,7 +207,7 @@ if (typeof window !== 'undefined') {
     const instance = getActiveInstance()
     if (!instance?.sendInput)
       return false
-    instance.sendInput(new TextEncoder().encode(text))
+    instance.sendInput(utf8Encoder.encode(text))
     return true
   }
   // E2E hooks for the WebGL context pool: assert that the number of live
@@ -223,17 +258,10 @@ const TerminalContainer: Component<{
       return
 
     const id = props.terminalId
-    const onInput = props.onInput
-
-    // The one gate every keystroke passes through, so xterm's onData and the
-    // IME layer cannot drift apart on whether snapshot replay is in flight.
-    const emit = (data: string) => {
-      if (!instances.get(id)?.suppressInput)
-        onInput(id, new TextEncoder().encode(data))
-    }
-
+    let fresh = false
     let instance = instances.get(id)
     if (!instance) {
+      fresh = true
       instance = createTerminalInstance({
         fontFamily: props.fontFamily,
         fontSize: props.fontSize,
@@ -243,24 +271,6 @@ const TerminalContainer: Component<{
       })
       instances.set(id, instance)
       notifyTerminalInstanceReady(id)
-
-      instance.sendInput = data => onInput(id, data)
-
-      // Attached on every platform: the IME rules below are not macOS-specific,
-      // and this handler is the only hook that runs before xterm's composition
-      // machinery (CoreBrowserTerminal._keyDown consults it first).
-      instance.terminal.attachCustomKeyEventHandler((e: KeyboardEvent) => {
-        // Composed keystrokes belong to the IME layer; see ~/lib/terminalIme.
-        if (instances.get(id)?.ime?.shouldBypassKeyEvent(e))
-          return false
-        // On macOS, suppress CMD+Arrow and ALT+Arrow so xterm.js doesn't
-        // process them — the shortcut system sends the correct escape sequences.
-        if (isMac() && (e.key === 'ArrowLeft' || e.key === 'ArrowRight') && (e.metaKey || e.altKey))
-          return false
-        return true
-      })
-
-      instance.terminal.onData(emit)
     }
 
     // xterm's `Terminal.open()` is idempotent in a way that breaks
@@ -276,13 +286,63 @@ const TerminalContainer: Component<{
     else
       instance.terminal.open(ref)
 
-    // Take over composed input, which xterm mishandles badly enough that CJK is
-    // unusable on WebKit (see ~/lib/terminalIme). Attached after open() because
-    // it hooks `terminal.element`, and only once per instance: those listeners
-    // live on that element, so they travel with it when a layout edit re-parents
-    // the terminal into a new container above.
-    if (!instance.ime)
-      instance.ime = attachTerminalIme(instance.terminal, emit)
+    if (fresh) {
+      // Every input path is wired ONCE, on the mount that created the
+      // instance, and each closure captures the instance directly — the
+      // instance owns its gate state (suppressInput, ime), so the module
+      // map is never a routing hop for events that belong to one instance,
+      // and a re-mount cannot mint a dead parallel gate.
+      const inst = instance
+      const onInput = props.onInput
+      // The one gate every input path passes through — xterm's onData, the IME
+      // layer, and the programmatic `sendInput` field below — so none of them
+      // can drift apart on whether snapshot replay is in flight. A shortcut or
+      // e2e hook that writes mid-replay must be suppressed exactly like a
+      // keystroke, or its bytes interleave with the replayed snapshot.
+      const send = (data: Uint8Array) => {
+        if (inst.suppressInput)
+          return
+        const prev = inputLogs.get(id) ?? ''
+        inputLogs.set(id, (prev + utf8Decoder.decode(data)).slice(-INPUT_LOG_LIMIT))
+        onInput(id, data)
+      }
+      const emit = (data: string) => send(utf8Encoder.encode(data))
+
+      // Programmatic writes (keyboard shortcuts via writeToFocusedTerminal,
+      // the e2e input hook) route through the same gate as keystrokes.
+      inst.sendInput = send
+
+      // Attached on every platform: the IME rules below are not macOS-specific,
+      // and this handler is the only hook that runs before xterm's composition
+      // machinery (CoreBrowserTerminal._keyDown consults it first).
+      inst.terminal.attachCustomKeyEventHandler((e: KeyboardEvent) => {
+        // Composed keystrokes belong to the IME layer; see ~/lib/terminalIme.
+        if (inst.ime?.shouldBypassKeyEvent(e))
+          return false
+        // On macOS, suppress CMD+Arrow and ALT+Arrow so xterm.js doesn't
+        // process them — the shortcut system sends the correct escape sequences.
+        if (isMac() && (e.key === 'ArrowLeft' || e.key === 'ArrowRight') && (e.metaKey || e.altKey))
+          return false
+        return true
+      })
+
+      inst.terminal.onData(emit)
+
+      // Take over composed input, which xterm mishandles badly enough that CJK
+      // is unusable on WebKit (see ~/lib/terminalIme). Attached after open()
+      // because it hooks `terminal.element`, and only on the mount that created
+      // the instance: those listeners live on that element, so they travel with
+      // it when a layout edit re-parents the terminal into a new container
+      // above. attachTerminalIme fails loudly on an unexpected DOM shape; a
+      // throw here would escape onMount to the route-level error boundary and
+      // blank every tile, so keep the failure to the composition path and log.
+      try {
+        inst.ime = attachTerminalIme(inst.terminal, emit)
+      }
+      catch (err) {
+        log.error('IME layer failed to attach; composed input is disabled', { id, err })
+      }
+    }
 
     // Write screen snapshot if available (restore on refresh). Seed the
     // resume cursor from lastOffset (from the backend, carried through
@@ -305,17 +365,15 @@ const TerminalContainer: Component<{
       screenApplied.add(props.terminalId)
       const termId = props.terminalId
       const reportReady = props.onContentReady
-      applyTerminalData(
-        instance,
-        screen,
-        true,
-        props.lastOffset ?? screen.length,
-        0,
-        () => {
+      applyTerminalData(instance, {
+        kind: 'snapshot',
+        data: screen,
+        endOffset: props.lastOffset ?? screen.length,
+        onParsed: () => {
           if (bufferHasVisibleContent(instance.terminal))
             reportReady(termId)
         },
-      )
+      })
     })
 
     // ResizeObserver on this terminal's container element.
@@ -420,7 +478,7 @@ export const TerminalView: Component<TerminalViewProps> = (props) => {
       return
     const instance = instances.get(props.activeTerminalId)
     if (instance?.sendInput)
-      instance.sendInput(new TextEncoder().encode(data))
+      instance.sendInput(utf8Encoder.encode(data))
   }
 
   // React to font preference changes and update existing terminal instances.

--- a/frontend/src/components/terminal/TerminalView.tsx
+++ b/frontend/src/components/terminal/TerminalView.tsx
@@ -10,6 +10,7 @@ import { createKeyedRows } from '~/lib/keyedRows'
 import { createRafResizeObserver } from '~/lib/resizeObserver'
 import { isMac } from '~/lib/shortcuts/platform'
 import { applyTerminalData, bufferHasVisibleContent, createTerminalInstance, DEFAULT_FONT_SIZE, refreshTerminalFont, resolveTerminalTheme, resolveTerminalThemeMode, serializeXtermBuffer } from '~/lib/terminal'
+import { attachTerminalIme } from '~/lib/terminalIme'
 import { webglPool } from '~/lib/webglTerminalPool'
 import * as styles from './TerminalView.css'
 import '@xterm/xterm/css/xterm.css'
@@ -221,7 +222,17 @@ const TerminalContainer: Component<{
     if (!ref)
       return
 
-    let instance = instances.get(props.terminalId)
+    const id = props.terminalId
+    const onInput = props.onInput
+
+    // The one gate every keystroke passes through, so xterm's onData and the
+    // IME layer cannot drift apart on whether snapshot replay is in flight.
+    const emit = (data: string) => {
+      if (!instances.get(id)?.suppressInput)
+        onInput(id, new TextEncoder().encode(data))
+    }
+
+    let instance = instances.get(id)
     if (!instance) {
       instance = createTerminalInstance({
         fontFamily: props.fontFamily,
@@ -230,28 +241,26 @@ const TerminalContainer: Component<{
         rows: props.rows,
         theme: props.theme,
       })
-      instances.set(props.terminalId, instance)
-      notifyTerminalInstanceReady(props.terminalId)
+      instances.set(id, instance)
+      notifyTerminalInstanceReady(id)
 
-      const id = props.terminalId
-      const onInput = props.onInput
       instance.sendInput = data => onInput(id, data)
 
-      // On macOS, suppress CMD+Arrow and ALT+Arrow so xterm.js doesn't
-      // process them — the shortcut system sends the correct escape sequences.
-      if (isMac()) {
-        instance.terminal.attachCustomKeyEventHandler((e: KeyboardEvent) => {
-          if ((e.key === 'ArrowLeft' || e.key === 'ArrowRight') && (e.metaKey || e.altKey))
-            return false
-          return true
-        })
-      }
-
-      instance.terminal.onData((data) => {
-        if (!instances.get(id)?.suppressInput) {
-          onInput(id, new TextEncoder().encode(data))
-        }
+      // Attached on every platform: the IME rules below are not macOS-specific,
+      // and this handler is the only hook that runs before xterm's composition
+      // machinery (CoreBrowserTerminal._keyDown consults it first).
+      instance.terminal.attachCustomKeyEventHandler((e: KeyboardEvent) => {
+        // Composed keystrokes belong to the IME layer; see ~/lib/terminalIme.
+        if (instances.get(id)?.ime?.shouldBypassKeyEvent(e))
+          return false
+        // On macOS, suppress CMD+Arrow and ALT+Arrow so xterm.js doesn't
+        // process them — the shortcut system sends the correct escape sequences.
+        if (isMac() && (e.key === 'ArrowLeft' || e.key === 'ArrowRight') && (e.metaKey || e.altKey))
+          return false
+        return true
       })
+
+      instance.terminal.onData(emit)
     }
 
     // xterm's `Terminal.open()` is idempotent in a way that breaks
@@ -266,6 +275,14 @@ const TerminalContainer: Component<{
       ref.appendChild(instance.terminal.element)
     else
       instance.terminal.open(ref)
+
+    // Take over composed input, which xterm mishandles badly enough that CJK is
+    // unusable on WebKit (see ~/lib/terminalIme). Attached after open() because
+    // it hooks `terminal.element`, and only once per instance: those listeners
+    // live on that element, so they travel with it when a layout edit re-parents
+    // the terminal into a new container above.
+    if (!instance.ime)
+      instance.ime = attachTerminalIme(instance.terminal, emit)
 
     // Write screen snapshot if available (restore on refresh). Seed the
     // resume cursor from lastOffset (from the backend, carried through

--- a/frontend/src/hooks/useWatchEventsStreams.test.ts
+++ b/frontend/src/hooks/useWatchEventsStreams.test.ts
@@ -84,7 +84,7 @@ describe('useWatchEventsStreams', () => {
     await Promise.resolve()
   }
 
-  function mount(plansFn: () => Map<string, { agents: never[], terminals: never[] }>, opts: Partial<{
+  function mount(plansFn: () => Map<string, { agents: never[], terminals: never[], terminalResync: Set<string> }>, opts: Partial<{
     onEvent: (workerId: string, resp: unknown) => void
     onWorkerOnline: (workerId: string, online: boolean) => void
     onPromoted: (workerId: string, agentIds: string[]) => void
@@ -107,8 +107,8 @@ describe('useWatchEventsStreams', () => {
 
   it('opens one stream per worker', async () => {
     const { harness } = mount(() => new Map([
-      ['w1', { agents: [{ agentId: 'a1', mode: WatchMode.FULL } as never], terminals: [] }],
-      ['w2', { agents: [{ agentId: 'a2', mode: WatchMode.FULL } as never], terminals: [] }],
+      ['w1', { agents: [{ agentId: 'a1', mode: WatchMode.FULL } as never], terminals: [], terminalResync: new Set<string>() }],
+      ['w2', { agents: [{ agentId: 'a2', mode: WatchMode.FULL } as never], terminals: [], terminalResync: new Set<string>() }],
     ]))
     emitAddTab({ type: TabType.AGENT, id: 'a1', tileId: harness.rootTileId, position: '1', workerId: 'w1' })
     emitAddTab({ type: TabType.AGENT, id: 'a2', tileId: harness.rootTileId, position: '2', workerId: 'w2' })
@@ -124,7 +124,7 @@ describe('useWatchEventsStreams', () => {
     createRoot((dispose) => {
       disposeRoot = dispose
       const plans = createMemo(() => new Map([
-        ['w1', { agents: [{ agentId: 'a1', mode: mode() } as never], terminals: [] }],
+        ['w1', { agents: [{ agentId: 'a1', mode: mode() } as never], terminals: [], terminalResync: new Set<string>() }],
       ]))
       useWatchEventsStreams({
         view: stores.view,
@@ -145,7 +145,7 @@ describe('useWatchEventsStreams', () => {
   it('transport error marks worker offline and reconnects', async () => {
     const online: boolean[] = []
     const { harness } = mount(
-      () => new Map([['w1', { agents: [{ agentId: 'a1', mode: WatchMode.FULL } as never], terminals: [] }]]),
+      () => new Map([['w1', { agents: [{ agentId: 'a1', mode: WatchMode.FULL } as never], terminals: [], terminalResync: new Set<string>() }]]),
       { onWorkerOnline: (_w, o) => online.push(o) },
     )
     emitAddTab({ type: TabType.AGENT, id: 'a1', tileId: harness.rootTileId, position: '1', workerId: 'w1' })
@@ -167,7 +167,7 @@ describe('useWatchEventsStreams', () => {
   it('a fatal relay close marks the worker offline without a reconnecting toast', async () => {
     const online: boolean[] = []
     const { harness } = mount(
-      () => new Map([['w1', { agents: [{ agentId: 'a1', mode: WatchMode.FULL } as never], terminals: [] }]]),
+      () => new Map([['w1', { agents: [{ agentId: 'a1', mode: WatchMode.FULL } as never], terminals: [], terminalResync: new Set<string>() }]]),
       { onWorkerOnline: (_w, o) => online.push(o) },
     )
     emitAddTab({ type: TabType.AGENT, id: 'a1', tileId: harness.rootTileId, position: '1', workerId: 'w1' })
@@ -183,7 +183,7 @@ describe('useWatchEventsStreams', () => {
   // scoped to the fatal case, not to transport errors at large.
   it('a recoverable transport error still toasts', async () => {
     const { harness } = mount(
-      () => new Map([['w1', { agents: [{ agentId: 'a1', mode: WatchMode.FULL } as never], terminals: [] }]]),
+      () => new Map([['w1', { agents: [{ agentId: 'a1', mode: WatchMode.FULL } as never], terminals: [], terminalResync: new Set<string>() }]]),
     )
     emitAddTab({ type: TabType.AGENT, id: 'a1', tileId: harness.rootTileId, position: '1', workerId: 'w1' })
     await flush()
@@ -197,7 +197,7 @@ describe('useWatchEventsStreams', () => {
   // 30s for the life of the page that can never succeed.
   it('a fatal stream error arms no reconnect timer', async () => {
     const { harness } = mount(
-      () => new Map([['w1', { agents: [{ agentId: 'a1', mode: WatchMode.FULL } as never], terminals: [] }]]),
+      () => new Map([['w1', { agents: [{ agentId: 'a1', mode: WatchMode.FULL } as never], terminals: [], terminalResync: new Set<string>() }]]),
     )
     emitAddTab({ type: TabType.AGENT, id: 'a1', tileId: harness.rootTileId, position: '1', workerId: 'w1' })
     await flush()
@@ -216,7 +216,7 @@ describe('useWatchEventsStreams', () => {
       throw new ChannelError('transport', 'too many places', 0, true)
     })
     const { harness } = mount(
-      () => new Map([['w1', { agents: [{ agentId: 'a1', mode: WatchMode.FULL } as never], terminals: [] }]]),
+      () => new Map([['w1', { agents: [{ agentId: 'a1', mode: WatchMode.FULL } as never], terminals: [], terminalResync: new Set<string>() }]]),
     )
     emitAddTab({ type: TabType.AGENT, id: 'a1', tileId: harness.rootTileId, position: '1', workerId: 'w1' })
     await flush()
@@ -238,7 +238,7 @@ describe('useWatchEventsStreams', () => {
     createRoot((dispose) => {
       disposeRoot = dispose
       const plans = createMemo(() => new Map([
-        ['w1', { agents: [{ agentId: 'a1', mode: mode() } as never], terminals: [] }],
+        ['w1', { agents: [{ agentId: 'a1', mode: mode() } as never], terminals: [], terminalResync: new Set<string>() }],
       ]))
       useWatchEventsStreams({
         view: stores.view,
@@ -268,7 +268,7 @@ describe('useWatchEventsStreams', () => {
     createRoot((dispose) => {
       disposeRoot = dispose
       const plans = createMemo(() => new Map([
-        ['w1', { agents: [{ agentId: 'a1', mode: mode() } as never], terminals: [] }],
+        ['w1', { agents: [{ agentId: 'a1', mode: mode() } as never], terminals: [], terminalResync: new Set<string>() }],
       ]))
       useWatchEventsStreams({
         view: stores.view,
@@ -296,8 +296,8 @@ describe('useWatchEventsStreams', () => {
     emitAddTab({ type: TabType.AGENT, id: 'a1', tileId: harness.rootTileId, position: '1', workerId: 'w1' })
     emitAddTab({ type: TabType.AGENT, id: 'a2', tileId: harness.rootTileId, position: '2', workerId: 'w2' })
     const [plans, setPlans] = createSignal(new Map([
-      ['w1', { agents: [{ agentId: 'a1', mode: WatchMode.FULL } as never], terminals: [] }],
-      ['w2', { agents: [{ agentId: 'a2', mode: WatchMode.FULL } as never], terminals: [] }],
+      ['w1', { agents: [{ agentId: 'a1', mode: WatchMode.FULL } as never], terminals: [], terminalResync: new Set<string>() }],
+      ['w2', { agents: [{ agentId: 'a2', mode: WatchMode.FULL } as never], terminals: [], terminalResync: new Set<string>() }],
     ]))
     createRoot((dispose) => {
       disposeRoot = dispose
@@ -312,7 +312,7 @@ describe('useWatchEventsStreams', () => {
     await flush()
     expect(handles).toHaveLength(2)
     setPlans(new Map([
-      ['w2', { agents: [{ agentId: 'a2', mode: WatchMode.FULL } as never], terminals: [] }],
+      ['w2', { agents: [{ agentId: 'a2', mode: WatchMode.FULL } as never], terminals: [], terminalResync: new Set<string>() }],
     ]))
     await flush()
     expect(handles[0]!.close).toHaveBeenCalled()
@@ -321,7 +321,7 @@ describe('useWatchEventsStreams', () => {
 
   it('retries LOOKUP_FAILED when the tab still exists', async () => {
     const { harness } = mount(
-      () => new Map([['w1', { agents: [{ agentId: 'a1', mode: WatchMode.FULL } as never], terminals: [] }]]),
+      () => new Map([['w1', { agents: [{ agentId: 'a1', mode: WatchMode.FULL } as never], terminals: [], terminalResync: new Set<string>() }]]),
     )
     emitAddTab({ type: TabType.AGENT, id: 'a1', tileId: harness.rootTileId, position: '1', workerId: 'w1' })
     await flush()
@@ -342,7 +342,7 @@ describe('useWatchEventsStreams', () => {
 
   it('does not retry NOT_FOUND even when the tab exists', async () => {
     const { harness } = mount(
-      () => new Map([['w1', { agents: [{ agentId: 'a1', mode: WatchMode.FULL } as never], terminals: [] }]]),
+      () => new Map([['w1', { agents: [{ agentId: 'a1', mode: WatchMode.FULL } as never], terminals: [], terminalResync: new Set<string>() }]]),
     )
     emitAddTab({ type: TabType.AGENT, id: 'a1', tileId: harness.rootTileId, position: '1', workerId: 'w1' })
     await flush()
@@ -363,7 +363,7 @@ describe('useWatchEventsStreams', () => {
 
   it('does not retry LOOKUP_FAILED when the tab is gone', async () => {
     mount(
-      () => new Map([['w1', { agents: [{ agentId: 'a1', mode: WatchMode.FULL } as never], terminals: [] }]]),
+      () => new Map([['w1', { agents: [{ agentId: 'a1', mode: WatchMode.FULL } as never], terminals: [], terminalResync: new Set<string>() }]]),
     )
     await flush()
     // No emitAddTab — the plan mentions a1 but no local tab exists.
@@ -384,7 +384,7 @@ describe('useWatchEventsStreams', () => {
 
   it('stops retrying LOOKUP_FAILED after the retry budget is exhausted', async () => {
     const { harness } = mount(
-      () => new Map([['w1', { agents: [{ agentId: 'a1', mode: WatchMode.FULL } as never], terminals: [] }]]),
+      () => new Map([['w1', { agents: [{ agentId: 'a1', mode: WatchMode.FULL } as never], terminals: [], terminalResync: new Set<string>() }]]),
     )
     emitAddTab({ type: TabType.AGENT, id: 'a1', tileId: harness.rootTileId, position: '1', workerId: 'w1' })
     await flush()
@@ -417,7 +417,7 @@ describe('useWatchEventsStreams', () => {
     createRoot((dispose) => {
       disposeRoot = dispose
       const plans = createMemo(() => new Map([
-        ['w1', { agents: [{ agentId: 'a1', mode: mode() } as never], terminals: [] }],
+        ['w1', { agents: [{ agentId: 'a1', mode: mode() } as never], terminals: [], terminalResync: new Set<string>() }],
       ]))
       useWatchEventsStreams({
         view: stores.view,
@@ -449,7 +449,7 @@ describe('useWatchEventsStreams', () => {
   it('reconnects after a clean stream end without marking offline', async () => {
     const online: boolean[] = []
     const { harness } = mount(
-      () => new Map([['w1', { agents: [{ agentId: 'a1', mode: WatchMode.FULL } as never], terminals: [] }]]),
+      () => new Map([['w1', { agents: [{ agentId: 'a1', mode: WatchMode.FULL } as never], terminals: [], terminalResync: new Set<string>() }]]),
       { onWorkerOnline: (_w, o) => online.push(o) },
     )
     emitAddTab({ type: TabType.AGENT, id: 'a1', tileId: harness.rootTileId, position: '1', workerId: 'w1' })
@@ -467,7 +467,7 @@ describe('useWatchEventsStreams', () => {
   // the refusal that was already latched when it was armed.
   it('does not arm a reconnect when the relay has latched, even with no error to pass', async () => {
     const { harness } = mount(
-      () => new Map([['w1', { agents: [{ agentId: 'a1', mode: WatchMode.FULL } as never], terminals: [] }]]),
+      () => new Map([['w1', { agents: [{ agentId: 'a1', mode: WatchMode.FULL } as never], terminals: [], terminalResync: new Set<string>() }]]),
     )
     emitAddTab({ type: TabType.AGENT, id: 'a1', tileId: harness.rootTileId, position: '1', workerId: 'w1' })
     await flush()
@@ -486,7 +486,7 @@ describe('useWatchEventsStreams', () => {
 
   it('resets LOOKUP_FAILED retry budget after a settled updateAck', async () => {
     const { harness } = mount(
-      () => new Map([['w1', { agents: [{ agentId: 'a1', mode: WatchMode.FULL } as never], terminals: [] }]]),
+      () => new Map([['w1', { agents: [{ agentId: 'a1', mode: WatchMode.FULL } as never], terminals: [], terminalResync: new Set<string>() }]]),
     )
     emitAddTab({ type: TabType.AGENT, id: 'a1', tileId: harness.rootTileId, position: '1', workerId: 'w1' })
     await flush()
@@ -539,8 +539,8 @@ describe('useWatchEventsStreams', () => {
     emitAddTab({ type: TabType.AGENT, id: 'a1', tileId: harness.rootTileId, position: '1', workerId: 'w1' })
     emitAddTab({ type: TabType.AGENT, id: 'a2', tileId: harness.rootTileId, position: '2', workerId: 'w2' })
     const [plans, setPlans] = createSignal(new Map([
-      ['w1', { agents: [{ agentId: 'a1', mode: WatchMode.FULL } as never], terminals: [] }],
-      ['w2', { agents: [{ agentId: 'a2', mode: WatchMode.FULL } as never], terminals: [] }],
+      ['w1', { agents: [{ agentId: 'a1', mode: WatchMode.FULL } as never], terminals: [], terminalResync: new Set<string>() }],
+      ['w2', { agents: [{ agentId: 'a2', mode: WatchMode.FULL } as never], terminals: [], terminalResync: new Set<string>() }],
     ]))
     createRoot((dispose) => {
       disposeRoot = dispose
@@ -560,7 +560,7 @@ describe('useWatchEventsStreams', () => {
     // Cancelling w2 must not wipe w1's pending reconnect timer.
     handles[0]!._end()
     setPlans(new Map([
-      ['w1', { agents: [{ agentId: 'a1', mode: WatchMode.FULL } as never], terminals: [] }],
+      ['w1', { agents: [{ agentId: 'a1', mode: WatchMode.FULL } as never], terminals: [], terminalResync: new Set<string>() }],
     ]))
     await flush()
     expect(handles[1]!.close).toHaveBeenCalled()
@@ -579,8 +579,8 @@ describe('useWatchEventsStreams', () => {
     createRoot((dispose) => {
       disposeRoot = dispose
       const plans = createMemo(() => new Map([
-        ['w1', { agents: [{ agentId: 'a1', mode: WatchMode.FULL } as never], terminals: [] }],
-        ['w2', { agents: [{ agentId: 'a2', mode: WatchMode.FULL } as never], terminals: [] }],
+        ['w1', { agents: [{ agentId: 'a1', mode: WatchMode.FULL } as never], terminals: [], terminalResync: new Set<string>() }],
+        ['w2', { agents: [{ agentId: 'a2', mode: WatchMode.FULL } as never], terminals: [], terminalResync: new Set<string>() }],
       ]))
       useWatchEventsStreams({
         view: stores.view,

--- a/frontend/src/hooks/useWorkspaceConnection.test.ts
+++ b/frontend/src/hooks/useWorkspaceConnection.test.ts
@@ -112,8 +112,8 @@ describe('watch plan helpers', () => {
   })
 
   it('watchPlanKey moves when a mode changes', () => {
-    const notify = { agents: [{ agentId: 'a1', mode: WatchMode.NOTIFY } as never], terminals: [] as never[] }
-    const full = { agents: [{ agentId: 'a1', mode: WatchMode.FULL } as never], terminals: [] as never[] }
+    const notify = { agents: [{ agentId: 'a1', mode: WatchMode.NOTIFY } as never], terminals: [] as never[], terminalResync: new Set<string>() }
+    const full = { agents: [{ agentId: 'a1', mode: WatchMode.FULL } as never], terminals: [] as never[], terminalResync: new Set<string>() }
     expect(watchPlanKey(notify)).not.toBe(watchPlanKey(full))
   })
 })
@@ -2082,11 +2082,22 @@ describe('extracted handleAgentEvent arm handlers', () => {
     it('caps the queue so a never-mounting terminal cannot grow it without bound', () => {
       const pending = new Map<string, Array<{ data: Uint8Array, isSnapshot: boolean, endOffset: bigint }>>()
       // Enqueue well over the cap; only the newest MAX_PENDING_TERMINAL_FRAMES survive.
+      let evicted = false
       for (let i = 0; i < MAX_PENDING_TERMINAL_FRAMES + 50; i++)
-        enqueuePendingTerminalData(pending, 't1', { data: new Uint8Array([i]), isSnapshot: false, endOffset: BigInt(i) })
+        evicted = enqueuePendingTerminalData(pending, 't1', { data: new Uint8Array([i]), isSnapshot: false, endOffset: BigInt(i) }) || evicted
       expect(pending.get('t1')).toHaveLength(MAX_PENDING_TERMINAL_FRAMES)
       // The oldest frames were dropped; the last surviving frame is the most recent.
       expect(pending.get('t1')!.at(-1)!.endOffset).toBe(BigInt(MAX_PENDING_TERMINAL_FRAMES + 49))
+      // The eviction is reported: the caller must flag the terminal for a
+      // full-snapshot resubscribe, because the dropped bytes leave a hole no
+      // incremental delta can fill.
+      expect(evicted).toBe(true)
+    })
+
+    it('reports no eviction while the queue stays under the cap', () => {
+      const pending = new Map<string, Array<{ data: Uint8Array, isSnapshot: boolean, endOffset: bigint }>>()
+      for (let i = 0; i < 3; i++)
+        expect(enqueuePendingTerminalData(pending, 't1', { data: new Uint8Array([i]), isSnapshot: false, endOffset: BigInt(i) })).toBe(false)
     })
   })
 

--- a/frontend/src/hooks/useWorkspaceConnection.ts
+++ b/frontend/src/hooks/useWorkspaceConnection.ts
@@ -59,21 +59,32 @@ export interface PendingTerminalDataFrame {
  */
 export const MAX_PENDING_TERMINAL_FRAMES = 256
 
-/** Queue TerminalData until an xterm instance mounts. Snapshots clear prior deltas. */
+/**
+ * Queue TerminalData until an xterm instance mounts. Snapshots clear prior
+ * deltas.
+ *
+ * Returns true when the cap evicted oldest frames — those bytes are lost to
+ * this client, so the caller must flag the terminal for a full-snapshot
+ * resubscribe (see `TerminalMeta.needsResync`).
+ */
 export function enqueuePendingTerminalData(
   pending: Map<string, PendingTerminalDataFrame[]>,
   terminalId: string,
   frame: PendingTerminalDataFrame,
-): void {
+): boolean {
   const queue = pending.get(terminalId) ?? []
   if (frame.isSnapshot)
     queue.length = 0
   queue.push(frame)
   // Bound memory for a terminal that never mounts: drop the oldest frames. A
   // snapshot clears the queue, so this only trims a long run of pure deltas.
-  if (queue.length > MAX_PENDING_TERMINAL_FRAMES)
+  let evicted = false
+  if (queue.length > MAX_PENDING_TERMINAL_FRAMES) {
     queue.splice(0, queue.length - MAX_PENDING_TERMINAL_FRAMES)
+    evicted = true
+  }
   pending.set(terminalId, queue)
+  return evicted
 }
 
 /** Drop queued frames for a terminal that is gone (tab closed / re-placed). */
@@ -170,14 +181,11 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
         if (checkContent && bufferHasVisibleContent(instance.terminal))
           metadata.patch(terminalId, { contentReady: true })
       }
-      lastOffset = applyTerminalData(
-        instance,
-        frame.data,
-        frame.isSnapshot,
-        Number(frame.endOffset),
-        lastOffset,
-        onParsed,
-      )
+      lastOffset = applyTerminalData(instance, frame.isSnapshot
+        ? { kind: 'snapshot', data: frame.data, endOffset: Number(frame.endOffset), onParsed }
+        : { kind: 'delta', data: frame.data, endOffset: Number(frame.endOffset), currentOffset: lastOffset, onParsed })
+      if (frame.isSnapshot)
+        metadata.patch(terminalId, { needsResync: false })
     }
     metadata.patch(terminalId, { lastOffset })
   }
@@ -215,6 +223,11 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
       tileId => selection.activeKeyForTile(tileId),
       agentId => untrack(() => chatStore.getResumeAfterSeq(agentId)),
       terminalId => untrack(() => metadata.get(terminalId)?.lastOffset ?? 0),
+      // Tracked on purpose: the plan must go out the moment a terminal is
+      // flagged, and back out when the snapshot lands. Only this field is
+      // tracked — lastOffset above moves at PTY-read frequency, and keying
+      // the plan on it would re-send a watch update per output chunk.
+      terminalId => metadata.get(terminalId)?.needsResync === true,
       (agentId: string) => view.getAgentTab(agentId),
     ),
   )
@@ -357,7 +370,11 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
         if (!instance) {
           // Do not advance lastOffset until bytes land on a live instance —
           // otherwise a late mount would skip catch-up and leave a blank PTY.
-          enqueuePendingTerminalData(pendingTerminalData, terminalId, { data, isSnapshot, endOffset })
+          // An eviction marks the terminal for a full-snapshot resubscribe:
+          // the dropped frames leave a hole no incremental delta can fill.
+          const evicted = enqueuePendingTerminalData(pendingTerminalData, terminalId, { data, isSnapshot, endOffset })
+          if (evicted)
+            metadata.patch(terminalId, { needsResync: true })
           break
         }
         const tab = view.getTerminalTab(terminalId)
@@ -366,15 +383,12 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
           if (checkContent && bufferHasVisibleContent(instance.terminal))
             metadata.patch(terminalId, { contentReady: true })
         }
-        const newOffset = applyTerminalData(
-          instance,
-          data,
-          isSnapshot,
-          Number(endOffset),
-          metadata.get(terminalId)?.lastOffset ?? 0,
-          onParsed,
-        )
-        metadata.patch(terminalId, { lastOffset: newOffset })
+        const newOffset = applyTerminalData(instance, isSnapshot
+          ? { kind: 'snapshot', data, endOffset: Number(endOffset), onParsed }
+          : { kind: 'delta', data, endOffset: Number(endOffset), currentOffset: metadata.get(terminalId)?.lastOffset ?? 0, onParsed })
+        // An applied snapshot is itself the resync: the buffer was rebuilt
+        // from the worker's ring, so no forced resubscribe is pending.
+        metadata.patch(terminalId, { lastOffset: newOffset, ...(isSnapshot ? { needsResync: false } : {}) })
         break
       }
       case 'closed':

--- a/frontend/src/hooks/watchPlan.test.ts
+++ b/frontend/src/hooks/watchPlan.test.ts
@@ -137,7 +137,7 @@ describe('buildWatchPlans', () => {
     }
     const getAgentTab = (id: string): AgentTab | undefined =>
       tabs.find(t => t.id === id) as AgentTab | undefined
-    const plans = buildWatchPlans(tabs, 'ws-1', activeKey, () => 0n, () => 0, getAgentTab)
+    const plans = buildWatchPlans(tabs, 'ws-1', activeKey, () => 0n, () => 0, () => false, getAgentTab)
     const agentIds = plans.get('w1')!.agents.map(a => ({ id: a.agentId, mode: a.mode }))
     // root-1 appears twice (its own FULL + the child-driven NOTIFY). The dedup
     // keeps it to one entry — the root's own tab already placed it.
@@ -157,7 +157,7 @@ describe('buildWatchPlans', () => {
         return { ...child, id: 'root-1', parentAgentId: undefined } as AgentTab
       return undefined
     }
-    const plans = buildWatchPlans([child], 'ws-1', () => '1:child-1', () => 0n, () => 0, getAgentTab)
+    const plans = buildWatchPlans([child], 'ws-1', () => '1:child-1', () => 0n, () => 0, () => false, getAgentTab)
     const agentIds = plans.get('w1')!.agents.map(a => ({ id: a.agentId, mode: a.mode }))
     // The child's own entry + a NOTIFY root entry.
     expect(agentIds).toContainEqual({ id: 'child-1', mode: WatchMode.FULL })
@@ -181,7 +181,7 @@ describe('buildWatchPlans', () => {
         return { type: TabType.AGENT, id: 'root-1' } as AgentTab
       return tabs.find(t => t.id === id) as AgentTab | undefined
     }
-    const plans = buildWatchPlans(tabs, 'ws-1', activeKey, () => 0n, () => 0, getAgentTab)
+    const plans = buildWatchPlans(tabs, 'ws-1', activeKey, () => 0n, () => 0, () => false, getAgentTab)
     const rootEntries = plans.get('w1')!.agents.filter(a => a.agentId === 'root-1')
     expect(rootEntries).toHaveLength(1)
     expect(rootEntries[0].mode).toBe(WatchMode.NOTIFY)
@@ -193,17 +193,60 @@ describe('watchPlanKey', () => {
     const a = {
       agents: [{ agentId: 'a1', mode: WatchMode.FULL, cursorSeq: BigInt(1) } as never],
       terminals: [] as never[],
+      terminalResync: new Set<string>(),
     }
     const b = {
       agents: [{ agentId: 'a1', mode: WatchMode.FULL, cursorSeq: BigInt(99) } as never],
       terminals: [] as never[],
+      terminalResync: new Set<string>(),
     }
     const c = {
       agents: [{ agentId: 'a1', mode: WatchMode.NOTIFY, cursorSeq: BigInt(99) } as never],
       terminals: [] as never[],
+      terminalResync: new Set<string>(),
     }
     expect(watchPlanKey(a)).toBe(watchPlanKey(b))
     expect(watchPlanKey(a)).not.toBe(watchPlanKey(c))
+  })
+
+  it('moves when a terminal is flagged for resync, so the cold plan goes out', () => {
+    const clean = {
+      agents: [] as never[],
+      terminals: [{ terminalId: 't1', afterOffset: BigInt(400), mode: WatchMode.FULL } as never],
+      terminalResync: new Set<string>(),
+    }
+    const flagged = {
+      agents: [] as never[],
+      terminals: [{ terminalId: 't1', afterOffset: BigInt(0), mode: WatchMode.FULL } as never],
+      terminalResync: new Set(['t1']),
+    }
+    // Without the resync arm in the key, both plans would key identically
+    // (`t1:FULL`) and the stream would never re-send the cold afterOffset.
+    expect(watchPlanKey(clean)).not.toBe(watchPlanKey(flagged))
+  })
+})
+
+describe('terminal resync plans', () => {
+  it('subscribes a flagged terminal cold and records it in the plan', () => {
+    const tab = {
+      type: TabType.TERMINAL,
+      id: 't1',
+      workerId: 'w1',
+      tileId: 'tile-1',
+      position: 'p1',
+    } as never
+    const plans = buildWatchPlans(
+      [tab],
+      'ws-1',
+      () => '1:t1',
+      () => 0n,
+      () => 400,
+      () => true,
+    )
+    const plan = plans.get('w1')!
+    expect(plan.terminals).toHaveLength(1)
+    expect(plan.terminals[0].afterOffset).toBe(BigInt(0))
+    expect(plan.terminalResync.has('t1')).toBe(true)
   })
 })
 

--- a/frontend/src/hooks/watchPlan.ts
+++ b/frontend/src/hooks/watchPlan.ts
@@ -23,6 +23,14 @@ import { rootAgentIdFor } from '~/stores/tab.helpers'
 export interface WatchPlan {
   agents: WatchAgentEntry[]
   terminals: WatchTerminalEntry[]
+  /**
+   * Terminals whose next subscribe must force a full snapshot (the client
+   * lost bytes and an incremental catch-up cannot fill the hole). Kept beside
+   * the entries — never sent on the wire — so `watchPlanKey` can re-key the
+   * plan when the resync state flips; it is NOT part of the entries because
+   * those are serialized straight into the WatchEvents request.
+   */
+  terminalResync: Set<string>
 }
 
 /**
@@ -99,6 +107,7 @@ export function buildWatchPlans(
   activeKeyForTile: (tileId: string) => string | null,
   agentResumeSeq: (agentId: string) => bigint = () => 0n,
   terminalAfterOffset: (terminalId: string) => bigint | number = () => 0,
+  terminalNeedsResync: (terminalId: string) => boolean = () => false,
   getAgentTab: ((agentId: string) => AgentTab | undefined) | undefined = undefined,
 ): Map<string, WatchPlan> {
   const plans = new Map<string, WatchPlan>()
@@ -123,7 +132,7 @@ export function buildWatchPlans(
     const workerId = tab.workerId
     let plan = plans.get(workerId)
     if (!plan) {
-      plan = { agents: [], terminals: [] }
+      plan = { agents: [], terminals: [], terminalResync: new Set() }
       plans.set(workerId, plan)
     }
     if (tab.type === TabType.AGENT) {
@@ -144,7 +153,13 @@ export function buildWatchPlans(
       }
     }
     else if (tab.type === TabType.TERMINAL) {
-      const after = terminalAfterOffset(tab.id)
+      // A flagged terminal subscribes cold (afterOffset 0), which the worker
+      // answers with a full snapshot — the only thing that can rebuild a
+      // screen with a hole in it.
+      const resync = terminalNeedsResync(tab.id)
+      const after = resync ? 0 : terminalAfterOffset(tab.id)
+      if (resync)
+        plan.terminalResync.add(tab.id)
       plan.terminals.push({
         terminalId: tab.id,
         afterOffset: typeof after === 'bigint' ? after : BigInt(after),
@@ -156,9 +171,11 @@ export function buildWatchPlans(
 }
 
 /**
- * Change key for one plan: ids AND modes, deliberately NOT cursors. Cursors
- * move on every message, and keying on them would re-send an update per chat
- * frame.
+ * Change key for one plan: ids, modes, and forced-resync state — deliberately
+ * NOT cursors. Cursors move on every message, and keying on them would re-send
+ * an update per chat frame. The resync arm re-keys only when a terminal is
+ * flagged or unflagged, so the plan carrying afterOffset 0 actually goes out
+ * (and the plan that returns to the normal cursor goes out after it).
  */
 export function watchPlanKey(plan: WatchPlan): string {
   const agents = plan.agents
@@ -166,7 +183,7 @@ export function watchPlanKey(plan: WatchPlan): string {
     .toSorted()
     .join(',')
   const terminals = plan.terminals
-    .map(t => `${t.terminalId}:${t.mode}`)
+    .map(t => `${t.terminalId}:${t.mode}${plan.terminalResync.has(t.terminalId) ? ':r' : ''}`)
     .toSorted()
     .join(',')
   return `a:${agents}|t:${terminals}`

--- a/frontend/src/lib/applyTerminalData.test.ts
+++ b/frontend/src/lib/applyTerminalData.test.ts
@@ -29,9 +29,9 @@ function makeStubInstance(): TerminalInstance & { _log: string[] } {
 }
 
 describe('applyTerminalData', () => {
-  it('is_snapshot=true: resets xterm before writing the payload', () => {
+  it('kind=snapshot: resets xterm before writing the payload', () => {
     const inst = makeStubInstance()
-    applyTerminalData(inst, new TextEncoder().encode('snap'), true, 4, 0)
+    applyTerminalData(inst, { kind: 'snapshot', data: new TextEncoder().encode('snap'), endOffset: 4 })
 
     // The reset MUST come before the write. An implementation that
     // writes first and then resets would still pass "both were called"
@@ -39,9 +39,9 @@ describe('applyTerminalData', () => {
     expect(inst._log).toEqual(['reset', 'write:snap'])
   })
 
-  it('is_snapshot=false: writes without resetting (incremental catch-up)', () => {
+  it('kind=delta: writes without resetting (incremental catch-up)', () => {
     const inst = makeStubInstance()
-    applyTerminalData(inst, new TextEncoder().encode('delta'), false, 5, 0)
+    applyTerminalData(inst, { kind: 'delta', data: new TextEncoder().encode('delta'), endOffset: 5, currentOffset: 0 })
 
     expect(inst._log).toEqual(['write:delta'])
     expect(inst.terminal.reset).not.toHaveBeenCalled()
@@ -53,21 +53,21 @@ describe('applyTerminalData', () => {
     // must fire before the write — otherwise the xterm ends up holding
     // "abc" + "xyz" instead of just "xyz".
     const inst = makeStubInstance()
-    applyTerminalData(inst, new TextEncoder().encode('abc'), false, 3, 0)
-    applyTerminalData(inst, new TextEncoder().encode('xyz'), true, 3, 3)
+    applyTerminalData(inst, { kind: 'delta', data: new TextEncoder().encode('abc'), endOffset: 3, currentOffset: 0 })
+    applyTerminalData(inst, { kind: 'snapshot', data: new TextEncoder().encode('xyz'), endOffset: 3 })
 
     expect(inst._log).toEqual(['write:abc', 'reset', 'write:xyz'])
   })
 
   it('returns endOffset on incremental writes when greater than current', () => {
     const inst = makeStubInstance()
-    expect(applyTerminalData(inst, new TextEncoder().encode('a'), false, 1, 0)).toBe(1)
-    expect(applyTerminalData(inst, new TextEncoder().encode('bc'), false, 3, 1)).toBe(3)
+    expect(applyTerminalData(inst, { kind: 'delta', data: new TextEncoder().encode('a'), endOffset: 1, currentOffset: 0 })).toBe(1)
+    expect(applyTerminalData(inst, { kind: 'delta', data: new TextEncoder().encode('bc'), endOffset: 3, currentOffset: 1 })).toBe(3)
   })
 
   it('returns endOffset on snapshot writes', () => {
     const inst = makeStubInstance()
-    expect(applyTerminalData(inst, new TextEncoder().encode('reset'), true, 100, 42)).toBe(100)
+    expect(applyTerminalData(inst, { kind: 'snapshot', data: new TextEncoder().encode('reset'), endOffset: 100 })).toBe(100)
   })
 
   it('does not decrease the cursor on an incremental event with a smaller end_offset', () => {
@@ -76,7 +76,7 @@ describe('applyTerminalData', () => {
     // the resume cursor and trigger spurious snapshot replays on the
     // next resubscribe.
     const inst = makeStubInstance()
-    expect(applyTerminalData(inst, new TextEncoder().encode('late'), false, 50, 100)).toBe(100)
+    expect(applyTerminalData(inst, { kind: 'delta', data: new TextEncoder().encode('late'), endOffset: 50, currentOffset: 100 })).toBe(100)
   })
 
   it('snapshot returns endOffset even when smaller than current', () => {
@@ -84,7 +84,7 @@ describe('applyTerminalData', () => {
     // larger stale cursor would tell the backend on resubscribe that we
     // have bytes we don't, silently skipping bytes on the next catch-up.
     const inst = makeStubInstance()
-    expect(applyTerminalData(inst, new TextEncoder().encode('snap'), true, 50, 100)).toBe(50)
+    expect(applyTerminalData(inst, { kind: 'snapshot', data: new TextEncoder().encode('snap'), endOffset: 50 })).toBe(50)
   })
 
   it('sets and clears suppressInput around snapshot writes', () => {
@@ -99,7 +99,7 @@ describe('applyTerminalData', () => {
       cb?.()
     })
 
-    applyTerminalData(inst, new TextEncoder().encode('snap'), true, 4, 0)
+    applyTerminalData(inst, { kind: 'snapshot', data: new TextEncoder().encode('snap'), endOffset: 4 })
 
     expect(suppressedDuringWrite).toBe(true)
     expect(inst.suppressInput).toBe(false)
@@ -110,7 +110,7 @@ describe('applyTerminalData', () => {
     // sequences in it ARE legitimate user-visible behavior and must
     // reach the PTY (e.g. cursor position reports).
     const inst = makeStubInstance()
-    applyTerminalData(inst, new TextEncoder().encode('delta'), false, 5, 0)
+    applyTerminalData(inst, { kind: 'delta', data: new TextEncoder().encode('delta'), endOffset: 5, currentOffset: 0 })
 
     expect(inst.suppressInput).toBe(false)
   })
@@ -119,7 +119,7 @@ describe('applyTerminalData', () => {
     const inst = makeStubInstance()
     const onParsed = vi.fn()
 
-    applyTerminalData(inst, new TextEncoder().encode('snap'), true, 4, 0, onParsed)
+    applyTerminalData(inst, { kind: 'snapshot', data: new TextEncoder().encode('snap'), endOffset: 4, onParsed })
     expect(onParsed).toHaveBeenCalledTimes(1)
   })
 
@@ -127,7 +127,7 @@ describe('applyTerminalData', () => {
     const inst = makeStubInstance()
     const onParsed = vi.fn()
 
-    applyTerminalData(inst, new TextEncoder().encode('delta'), false, 5, 0, onParsed)
+    applyTerminalData(inst, { kind: 'delta', data: new TextEncoder().encode('delta'), endOffset: 5, currentOffset: 0, onParsed })
     expect(onParsed).toHaveBeenCalledTimes(1)
   })
 })

--- a/frontend/src/lib/browserStorage.ts
+++ b/frontend/src/lib/browserStorage.ts
@@ -337,6 +337,19 @@ export function localStorageRemove(key: string): void {
   catch { /* ignore errors */ }
 }
 
+/**
+ * Clear localStorage. For tests only: production code removes keys by name
+ * (`localStorageRemove`); a wholesale clear is a test-fixture reset, which
+ * still routes through this module so no call site touches localStorage
+ * directly.
+ */
+export function localStorageClearForTests(): void {
+  try {
+    localStorage.clear()
+  }
+  catch { /* ignore errors */ }
+}
+
 /** Load the consolidated browser preferences from localStorage. */
 export function loadBrowserPrefs(): BrowserPreferences {
   return localStorageGet<BrowserPreferences>(KEY_BROWSER_PREFS) ?? {}

--- a/frontend/src/lib/bytes.test.ts
+++ b/frontend/src/lib/bytes.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { concatBytes } from './bytes'
+
+describe('concatBytes', () => {
+  it('joins arrays in order', () => {
+    expect([...concatBytes(new Uint8Array([1, 2]), new Uint8Array([3]))]).toEqual([1, 2, 3])
+  })
+
+  it('returns an empty array when given none', () => {
+    expect(concatBytes()).toEqual(new Uint8Array(0))
+  })
+
+  it('skips empty inputs without disturbing the order', () => {
+    const joined = concatBytes(
+      new Uint8Array(0),
+      new Uint8Array([1]),
+      new Uint8Array(0),
+      new Uint8Array([2, 3]),
+    )
+    expect([...joined]).toEqual([1, 2, 3])
+  })
+
+  it('copies, so the result survives a mutated input', () => {
+    const source = new Uint8Array([1, 2])
+    const joined = concatBytes(source)
+    source[0] = 9
+    expect([...joined]).toEqual([1, 2])
+  })
+
+  it('preserves multi-byte UTF-8 split across arrays', () => {
+    // The terminal's input queue concatenates encoded keystrokes, so a syllable
+    // must survive whatever boundary the batching happens to fall on.
+    const encoded = new TextEncoder().encode('안녕')
+    const joined = concatBytes(encoded.slice(0, 2), encoded.slice(2))
+    expect(new TextDecoder().decode(joined)).toBe('안녕')
+  })
+})

--- a/frontend/src/lib/bytes.ts
+++ b/frontend/src/lib/bytes.ts
@@ -1,0 +1,27 @@
+/**
+ * Byte-array helpers.
+ *
+ * These carry no protocol knowledge. They live here rather than in
+ * `./noise` — where `concatBytes` grew up — because the consumers now span the
+ * Noise handshake, the key-pin store, and the terminal's input queue, and a
+ * module named after a crypto protocol is the wrong place for any of them to
+ * reach.
+ */
+
+/**
+ * Join byte arrays into one, in order. Returns an empty array when given none.
+ *
+ * The result always owns a fresh buffer, so a caller may keep it after the
+ * inputs are reused or cleared.
+ */
+export function concatBytes(...arrays: Uint8Array[]): Uint8Array {
+  let totalLen = 0
+  for (const a of arrays) totalLen += a.length
+  const result = new Uint8Array(totalLen)
+  let offset = 0
+  for (const a of arrays) {
+    result.set(a, offset)
+    offset += a.length
+  }
+  return result
+}

--- a/frontend/src/lib/bytes.ts
+++ b/frontend/src/lib/bytes.ts
@@ -2,10 +2,10 @@
  * Byte-array helpers.
  *
  * These carry no protocol knowledge. They live here rather than in
- * `./noise` — where `concatBytes` grew up — because the consumers now span the
- * Noise handshake, the key-pin store, and the terminal's input queue, and a
- * module named after a crypto protocol is the wrong place for any of them to
- * reach.
+ * `./noise` — where `concatBytes` was first defined — because the consumers
+ * now span the Noise handshake, the key-pin store, and the terminal's input
+ * queue, and a module named after a crypto protocol is the wrong place for
+ * any of them to reach.
  */
 
 /**

--- a/frontend/src/lib/inputQueue.test.ts
+++ b/frontend/src/lib/inputQueue.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it, vi } from 'vitest'
+import { deferred } from '~/test-support/async'
+import { createSharedInputQueues } from './inputQueue'
+
+const enc = (s: string) => new TextEncoder().encode(s)
+const dec = (b: Uint8Array) => new TextDecoder().decode(b)
+
+// A deadline no test below reaches unless it says so.
+const noDeadline = () => 60_000
+
+describe('createSharedInputQueues', () => {
+  it('joins data queued while a send is in flight into one ordered batch', async () => {
+    const queues = createSharedInputQueues<string, null>()
+    const batches: string[] = []
+    const gate = deferred<void>()
+    const send = vi.fn(async (_key: string, _ctx: null, batch: Uint8Array) => {
+      batches.push(dec(batch))
+      if (batches.length === 1)
+        await gate.promise
+    })
+    const drain = { resolve: () => null, send, sendDeadlineMs: noDeadline }
+
+    const first = queues.enqueue('t-1', enc('a'), drain)
+    await Promise.resolve()
+    expect(send).toHaveBeenCalledTimes(1)
+
+    void queues.enqueue('t-1', enc('b'), drain)
+    void queues.enqueue('t-1', enc('c'), drain)
+    await Promise.resolve()
+    expect(send, 'no second send may start while one is in flight').toHaveBeenCalledTimes(1)
+
+    gate.resolve()
+    await first
+    expect(send).toHaveBeenCalledTimes(2)
+    expect(batches).toEqual(['a', 'bc'])
+  })
+
+  it('resolves a joining enqueue only when the owning drain finishes', async () => {
+    const queues = createSharedInputQueues<string, null>()
+    const gate = deferred<void>()
+    const send = vi.fn(async () => {
+      if (send.mock.calls.length === 1)
+        await gate.promise
+    })
+    const drain = { resolve: () => null, send, sendDeadlineMs: noDeadline }
+
+    const first = queues.enqueue('t-1', enc('a'), drain)
+    let joinerDone = false
+    const joiner = queues.enqueue('t-1', enc('b'), drain)
+    joiner.then(() => {
+      joinerDone = true
+    })
+    await Promise.resolve()
+
+    // The joiner's bytes are still queued behind the in-flight send, so its
+    // promise must not claim completion yet.
+    expect(joinerDone).toBe(false)
+
+    gate.resolve()
+    await first
+    await joiner
+    expect(joinerDone).toBe(true)
+  })
+
+  it('drops the queue when resolve returns undefined, then a later enqueue starts fresh', async () => {
+    const queues = createSharedInputQueues<string, null>()
+    const batches: string[] = []
+    const send = async (_key: string, _ctx: null, batch: Uint8Array) => {
+      batches.push(dec(batch))
+    }
+    let alive = true
+    const drain = { resolve: () => (alive ? null : undefined), send, sendDeadlineMs: noDeadline }
+
+    const first = queues.enqueue('t-1', enc('a'), drain)
+    alive = false // target exits mid-burst
+    void queues.enqueue('t-1', enc('b'), drain)
+    await first
+    expect(batches).toEqual(['a']) // queued bytes dropped, queue deleted
+
+    alive = true
+    await queues.enqueue('t-1', enc('c'), drain)
+    expect(batches).toEqual(['a', 'c'])
+  })
+
+  it('drops the queue when resolve throws, without rejecting into the input path', async () => {
+    const queues = createSharedInputQueues<string, null>()
+    const send = vi.fn(async () => {})
+    const drain = {
+      resolve: () => {
+        throw new Error('disposed store')
+      },
+      send,
+      sendDeadlineMs: noDeadline,
+    }
+
+    // The drain-starting promise is fire-and-forget at the call site, so a
+    // throwing resolve must resolve (and drop) rather than reject.
+    await expect(queues.enqueue('t-1', enc('a'), drain)).resolves.toBeUndefined()
+    expect(send).not.toHaveBeenCalled()
+
+    // The queue is gone: a later enqueue starts fresh.
+    const ok = { resolve: () => null, send, sendDeadlineMs: noDeadline }
+    await queues.enqueue('t-1', enc('b'), ok)
+    expect(send).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries a rejected batch once, merged with bytes typed meanwhile', async () => {
+    const queues = createSharedInputQueues<string, null>()
+    const gate = deferred<void>()
+    const batches: string[] = []
+    const send = vi.fn(async (_key: string, _ctx: null, batch: Uint8Array) => {
+      batches.push(dec(batch))
+      if (batches.length === 1) {
+        await gate.promise.then(() => {
+          throw new Error('worker offline')
+        })
+      }
+    })
+    const drain = { resolve: () => null, send, sendDeadlineMs: noDeadline }
+
+    const first = queues.enqueue('t-1', enc('a'), drain)
+    await Promise.resolve()
+    void queues.enqueue('t-1', enc('b'), drain)
+    gate.resolve()
+
+    // The rejected batch is safe to re-send (it never ran) and goes first,
+    // joined with the bytes that arrived while it was failing.
+    await first
+    expect(batches).toEqual(['a', 'ab'])
+  })
+
+  it('drops a batch after a second rejection and keeps draining the rest', async () => {
+    const queues = createSharedInputQueues<string, null>()
+    const batches: string[] = []
+    const gate = deferred<void>()
+    let calls = 0
+    const send = async (_key: string, _ctx: null, batch: Uint8Array) => {
+      calls++
+      batches.push(dec(batch))
+      if (calls === 1) {
+        await gate.promise.then(() => {
+          throw new Error('worker offline')
+        })
+      }
+      if (calls === 2)
+        throw new Error('worker offline')
+    }
+    const drain = { resolve: () => null, send, sendDeadlineMs: noDeadline }
+
+    const first = queues.enqueue('t-1', enc('a'), drain)
+    await Promise.resolve()
+    void queues.enqueue('t-1', enc('b'), drain)
+    gate.resolve()
+    await first
+
+    // The retry merged 'a' with 'b' and failed too; the batch is gone and
+    // the queue is empty, so the drain ends without another send.
+    expect(calls).toBe(2)
+    expect(batches).toEqual(['a', 'ab'])
+  })
+
+  it('moves on at the deadline and never re-sends the abandoned batch', async () => {
+    const queues = createSharedInputQueues<string, null>()
+    const batches: string[] = []
+    const gate = deferred<void>()
+    const send = vi.fn(async (_key: string, _ctx: null, batch: Uint8Array) => {
+      batches.push(dec(batch))
+      if (batches.length === 1)
+        await gate.promise // black-holed: never settles
+    })
+    const drain = { resolve: () => null, send, sendDeadlineMs: () => 0 }
+
+    const first = queues.enqueue('t-1', enc('a'), drain)
+    void queues.enqueue('t-1', enc('b'), drain)
+    await new Promise(resolve => setTimeout(resolve, 10))
+
+    // The deadline freed the drain without the first send settling; the
+    // abandoned batch may still deliver, so it must not ride again.
+    expect(batches).toEqual(['a', 'b'])
+    gate.resolve()
+    await first
+    expect(batches).toEqual(['a', 'b'])
+  })
+
+  it('hands the next batch to the most recent drain', async () => {
+    const queues = createSharedInputQueues<string, 'A' | 'B'>()
+    const gate = deferred<void>()
+    const sendA = vi.fn(async () => {
+      if (sendA.mock.calls.length === 1)
+        await gate.promise
+    })
+    const sendB = vi.fn(async (_key: string, _ctx: 'A' | 'B', _batch: Uint8Array) => {})
+    const drainA = { resolve: () => 'A' as const, send: sendA, sendDeadlineMs: noDeadline }
+    const drainB = { resolve: () => 'B' as const, send: sendB, sendDeadlineMs: noDeadline }
+
+    const first = queues.enqueue('t-1', enc('a'), drainA)
+    await Promise.resolve()
+    // A remounted owner joins the running burst with its own drain.
+    void queues.enqueue('t-1', enc('b'), drainB)
+    gate.resolve()
+    await first
+
+    expect(sendA).toHaveBeenCalledTimes(1)
+    expect(sendB).toHaveBeenCalledTimes(1)
+    expect(dec(sendB.mock.calls[0][2])).toBe('b')
+  })
+})

--- a/frontend/src/lib/inputQueue.ts
+++ b/frontend/src/lib/inputQueue.ts
@@ -1,0 +1,165 @@
+import { concatBytes } from './bytes'
+import { createLogger } from './logger'
+
+const log = createLogger('inputQueue')
+
+/**
+ * Shared per-key batch queues, drained one send at a time.
+ *
+ * The worker dispatches every inner RPC on its own goroutine, so two sends in
+ * flight together can arrive transposed. Keeping a single send in flight per
+ * key removes the race at the only point that can see the true order, which
+ * is the sender. The entry's presence in the map IS the drain lock: an
+ * enqueue that finds an entry joins the running drain; only an enqueue on a
+ * missing entry may start one. Create the queues ONCE (module scope of the
+ * consumer) — a second instance would race a second send for the same key.
+ *
+ * A joining enqueue REPLACES the entry's drain, so the most recent owner
+ * decides every next batch. Owners that remount mid-burst therefore take
+ * their own terminals back instead of staying served by the previous owner's
+ * closures.
+ */
+export interface InputQueueDrain<K, C> {
+  /** Resolve the target before each batch. Return undefined to drop the queue. */
+  resolve: (key: K) => C | undefined
+  /** Send one batch. A rejection retries the batch once, then drops it. */
+  send: (key: K, ctx: C, batch: Uint8Array) => Promise<void>
+  /**
+   * How long one send may stay in flight before the drain moves on without
+   * it. The deadline covers the WHOLE send — every leg it awaits — unlike a
+   * per-RPC timeout that arms only once the transport is open. Size it past
+   * the receiver's own response deadline: a drain that moves on while its
+   * send may still deliver re-opens the transposition race the one-in-flight
+   * rule exists to close.
+   */
+  sendDeadlineMs: () => number
+}
+
+export interface SharedInputQueues<K, C> {
+  /**
+   * Queue `data` for `key`. Resolves when the drain that took `data`
+   * finishes — for every enqueue of the burst, the one that started the
+   * drain included. Resolution does not promise delivery: a batch the drain
+   * dropped (target gone) or lost (send failed twice, deadline passed) is
+   * gone by then.
+   */
+  enqueue: (key: K, data: Uint8Array, drain: InputQueueDrain<K, C>) => Promise<void>
+}
+
+interface QueueEntry<K, C> {
+  batches: Uint8Array[]
+  drain: InputQueueDrain<K, C>
+  /** Settled when the entry's drain ends, for every enqueue it took. */
+  waiters: Array<() => void>
+}
+
+type SendOutcome = 'sent' | 'rejected' | 'deadline'
+
+/**
+ * Run one send under the drain's deadline. The send's own rejection is
+ * reported as `rejected` — distinct from `deadline`, because only a
+ * rejection is known not to have run: a send abandoned at its deadline may
+ * still deliver later, and its batch must not be re-sent.
+ */
+async function attemptSend<K, C>(
+  drain: InputQueueDrain<K, C>,
+  key: K,
+  ctx: C,
+  batch: Uint8Array,
+): Promise<SendOutcome> {
+  let settled = false
+  return new Promise<SendOutcome>((resolve) => {
+    let send: Promise<void>
+    try {
+      send = drain.send(key, ctx, batch)
+    }
+    catch {
+      // A send that throws before returning a promise ran no I/O; treat it
+      // like a rejection so the batch gets its one retry.
+      resolve('rejected')
+      return
+    }
+    const timer = setTimeout(() => {
+      settled = true
+      resolve('deadline')
+    }, drain.sendDeadlineMs())
+    send.then(
+      () => {
+        if (!settled)
+          resolve('sent')
+        clearTimeout(timer)
+      },
+      () => {
+        if (!settled)
+          resolve('rejected')
+        clearTimeout(timer)
+      },
+    )
+  })
+}
+
+export function createSharedInputQueues<K, C>(): SharedInputQueues<K, C> {
+  const queues = new Map<K, QueueEntry<K, C>>()
+
+  const drainKey = async (key: K, entry: QueueEntry<K, C>) => {
+    const { batches } = entry
+    try {
+      let canRetry = true
+      while (batches.length > 0) {
+        const batch = concatBytes(...batches)
+        batches.length = 0
+        let ctx: C | undefined
+        try {
+          ctx = entry.drain.resolve(key)
+        }
+        catch (err) {
+          // A resolve that throws is the owner's bug. Treat it as "target
+          // gone" and drop the queue — a rejection here would escape into
+          // the fire-and-forget input path, which has no error sink.
+          log.error('resolve threw; dropping queue', { key, err })
+          return
+        }
+        if (ctx === undefined)
+          return
+        const outcome = await attemptSend(entry.drain, key, ctx, batch)
+        if (outcome === 'sent') {
+          canRetry = true
+          continue
+        }
+        if (outcome === 'rejected' && canRetry) {
+          // One clean retry per batch: a rejection means the send never ran
+          // (channel refused, worker answered with an error), so the same
+          // bytes are safe to send again, ahead of anything typed since. A
+          // deadline, by contrast, leaves delivery unknown — that batch is
+          // dropped, never re-sent.
+          canRetry = false
+          batches.unshift(batch)
+          continue
+        }
+        // Lost batch. Keep draining: dropping the rest of the queue because
+        // one write failed is the worse outcome.
+      }
+    }
+    finally {
+      // Safe to drop: the loop only exits with the queue empty or the target
+      // gone, and no await separates the check from here.
+      queues.delete(key)
+      for (const w of entry.waiters)
+        w()
+    }
+  }
+
+  return {
+    enqueue(key, data, drain) {
+      const existing = queues.get(key)
+      if (existing) {
+        existing.batches.push(data)
+        existing.drain = drain
+        return new Promise<void>(resolve => existing.waiters.push(resolve))
+      }
+      const entry: QueueEntry<K, C> = { batches: [data], drain, waiters: [] }
+      queues.set(key, entry)
+      return drainKey(key, entry)
+    },
+  }
+}

--- a/frontend/src/lib/keyPinStore.ts
+++ b/frontend/src/lib/keyPinStore.ts
@@ -12,7 +12,7 @@
 import type { WorkerKeyBundle } from './workerKeyBundle'
 import { bytesToHex } from '@noble/hashes/utils.js'
 import { KEY_KEY_PINS, localStorageGet, localStorageRemove, localStorageSet } from './browserStorage'
-import { concatBytes } from './noise'
+import { concatBytes } from './bytes'
 
 export type KeyPinDecision = 'accept' | 'reject'
 

--- a/frontend/src/lib/noise-hybrid.test.ts
+++ b/frontend/src/lib/noise-hybrid.test.ts
@@ -11,7 +11,8 @@ import { ml_kem1024 } from '@noble/post-quantum/ml-kem.js'
 import { slh_dsa_shake_256f } from '@noble/post-quantum/slh-dsa.js'
 
 import { describe, expect, it } from 'vitest'
-import { concatBytes, hkdf } from './noise'
+import { concatBytes } from './bytes'
+import { hkdf } from './noise'
 import { clearHandshakeState, initiatorHandshake1, initiatorHandshake2 } from './noise-hybrid'
 
 const PROTOCOL_NAME = 'Noise_NK_25519_ChaChaPoly_BLAKE2b'

--- a/frontend/src/lib/noise-hybrid.ts
+++ b/frontend/src/lib/noise-hybrid.ts
@@ -14,7 +14,8 @@ import { blake2b } from '@noble/hashes/blake2.js'
 import { ml_kem1024 } from '@noble/post-quantum/ml-kem.js'
 
 import { slh_dsa_shake_256f } from '@noble/post-quantum/slh-dsa.js'
-import { concatBytes, SymmetricState } from './noise'
+import { concatBytes } from './bytes'
+import { SymmetricState } from './noise'
 
 const PROTOCOL_NAME = 'Noise_NK_25519_ChaChaPoly_BLAKE2b'
 const DH_LEN = 32

--- a/frontend/src/lib/noise.test.ts
+++ b/frontend/src/lib/noise.test.ts
@@ -8,24 +8,10 @@ import { blake2b } from '@noble/hashes/blake2.js'
 import { hmac } from '@noble/hashes/hmac.js'
 
 import { describe, expect, it } from 'vitest'
+import { concatBytes } from './bytes'
 import { CipherState, initiatorHandshake1, initiatorHandshake2 } from './noise'
 
 const PROTOCOL_NAME = 'Noise_NK_25519_ChaChaPoly_BLAKE2b'
-
-// Deliberately local, not the export from ~/lib/bytes. This file is an
-// independent reimplementation of the responder side, and it is only a useful
-// oracle for the initiator while it shares no code with it.
-function concatBytes(...arrays: Uint8Array[]): Uint8Array {
-  let totalLen = 0
-  for (const a of arrays) totalLen += a.length
-  const result = new Uint8Array(totalLen)
-  let offset = 0
-  for (const a of arrays) {
-    result.set(a, offset)
-    offset += a.length
-  }
-  return result
-}
 
 function hkdf2(ck: Uint8Array, ikm: Uint8Array): [Uint8Array, Uint8Array] {
   const tempKey = hmac(blake2b, ck, ikm)

--- a/frontend/src/lib/noise.test.ts
+++ b/frontend/src/lib/noise.test.ts
@@ -12,6 +12,9 @@ import { CipherState, initiatorHandshake1, initiatorHandshake2 } from './noise'
 
 const PROTOCOL_NAME = 'Noise_NK_25519_ChaChaPoly_BLAKE2b'
 
+// Deliberately local, not the export from ~/lib/bytes. This file is an
+// independent reimplementation of the responder side, and it is only a useful
+// oracle for the initiator while it shares no code with it.
 function concatBytes(...arrays: Uint8Array[]): Uint8Array {
   let totalLen = 0
   for (const a of arrays) totalLen += a.length

--- a/frontend/src/lib/noise.ts
+++ b/frontend/src/lib/noise.ts
@@ -14,6 +14,7 @@ import { chacha20poly1305 } from '@noble/ciphers/chacha.js'
 import { x25519 } from '@noble/curves/ed25519.js'
 import { blake2b } from '@noble/hashes/blake2.js'
 import { hmac } from '@noble/hashes/hmac.js'
+import { concatBytes } from './bytes'
 import { monotonicNow } from './monotonicNow'
 
 const PROTOCOL_NAME = 'Noise_NK_25519_ChaChaPoly_BLAKE2b'
@@ -61,18 +62,6 @@ function decrypt(key: Uint8Array, nonce: number, ad: Uint8Array, ciphertext: Uin
   new DataView(nonceBytes.buffer).setUint32(4, nonce, true)
   const cipher = chacha20poly1305(key, nonceBytes, ad)
   return cipher.decrypt(ciphertext)
-}
-
-export function concatBytes(...arrays: Uint8Array[]): Uint8Array {
-  let totalLen = 0
-  for (const a of arrays) totalLen += a.length
-  const result = new Uint8Array(totalLen)
-  let offset = 0
-  for (const a of arrays) {
-    result.set(a, offset)
-    offset += a.length
-  }
-  return result
 }
 
 // ---- Noise Protocol State Machines ----

--- a/frontend/src/lib/terminal.test.ts
+++ b/frontend/src/lib/terminal.test.ts
@@ -19,6 +19,28 @@ describe('createTerminalInstance', () => {
     instance.dispose()
   })
 
+  it('tears the IME layer down before the terminal', () => {
+    const instance = createTerminalInstance()
+    const order: string[] = []
+    instance.ime = {
+      composing: false,
+      shouldBypassKeyEvent: () => false,
+      dispose: () => order.push('ime'),
+    }
+    const terminalDispose = instance.terminal.dispose.bind(instance.terminal)
+    instance.terminal.dispose = () => {
+      order.push('terminal')
+      terminalDispose()
+    }
+
+    instance.dispose()
+
+    // The layer's listeners and its preview node hang off `terminal.element`,
+    // which xterm removes as it tears down, so the order matters.
+    expect(order).toEqual(['ime', 'terminal'])
+    expect(instance.ime).toBeUndefined()
+  })
+
   it('suppresses onData forwarding during snapshot replay', async () => {
     const instance = createTerminalInstance()
     const forwarded: string[] = []

--- a/frontend/src/lib/terminal.test.ts
+++ b/frontend/src/lib/terminal.test.ts
@@ -1,44 +1,30 @@
 import type { Terminal } from '@xterm/xterm'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { KEY_BROWSER_PREFS, localStorageSet } from './browserStorage'
-import { attachWebgl, createTerminalInstance, detachWebgl, getTerminalRendererPreference, loadTerminalFonts, refreshTerminalFont, resolveTerminalRendererPreference, resolveTerminalThemeMode, serializeXtermBuffer } from './terminal'
+import { stubMatchMedia } from '~/test-support/matchMediaStub'
+import { KEY_BROWSER_PREFS, localStorageClearForTests, localStorageSet } from './browserStorage'
+import { applyTerminalData, attachWebgl, createTerminalInstance, detachWebgl, getTerminalRendererPreference, loadTerminalFonts, refreshTerminalFont, resolveTerminalRendererPreference, resolveTerminalThemeMode, serializeXtermBuffer } from './terminal'
 
 // xterm.js requires a DOM element for open(), but we can still test
 // the suppressInput mechanism without rendering.
 
-describe('createTerminalInstance', () => {
-  beforeEach(() => {
-    localStorage.clear()
-    // jsdom doesn't implement matchMedia
-    window.matchMedia = vi.fn().mockReturnValue({ matches: false }) as any
-  })
+let matchMedia: ReturnType<typeof stubMatchMedia>
 
+// Every suite in this file needs a clean storage state and a matchMedia stub
+// (jsdom implements neither), so the pair is installed once at file level.
+beforeEach(() => {
+  localStorageClearForTests()
+  matchMedia = stubMatchMedia()
+})
+
+afterEach(() => {
+  matchMedia?.restore()
+})
+
+describe('createTerminalInstance', () => {
   it('initializes suppressInput to false', () => {
     const instance = createTerminalInstance()
     expect(instance.suppressInput).toBe(false)
     instance.dispose()
-  })
-
-  it('tears the IME layer down before the terminal', () => {
-    const instance = createTerminalInstance()
-    const order: string[] = []
-    instance.ime = {
-      composing: false,
-      shouldBypassKeyEvent: () => false,
-      dispose: () => order.push('ime'),
-    }
-    const terminalDispose = instance.terminal.dispose.bind(instance.terminal)
-    instance.terminal.dispose = () => {
-      order.push('terminal')
-      terminalDispose()
-    }
-
-    instance.dispose()
-
-    // The layer's listeners and its preview node hang off `terminal.element`,
-    // which xterm removes as it tears down, so the order matters.
-    expect(order).toEqual(['ime', 'terminal'])
-    expect(instance.ime).toBeUndefined()
   })
 
   it('suppresses onData forwarding during snapshot replay', async () => {
@@ -98,12 +84,96 @@ describe('createTerminalInstance', () => {
   })
 })
 
-describe('serializeXtermBuffer', () => {
-  beforeEach(() => {
-    localStorage.clear()
-    window.matchMedia = vi.fn().mockReturnValue({ matches: false }) as any
+describe('applyTerminalData delta overlap', () => {
+  /** A real instance whose terminal.write records every payload. */
+  function recordingInstance() {
+    const instance = createTerminalInstance()
+    const writes: Uint8Array[] = []
+    const originalWrite = instance.terminal.write.bind(instance.terminal)
+    instance.terminal.write = ((data: string | Uint8Array, cb?: () => void) => {
+      writes.push(typeof data === 'string' ? new TextEncoder().encode(data) : data)
+      return originalWrite(data, cb)
+    }) as typeof instance.terminal.write
+    return { instance, writes }
+  }
+
+  it('writes a delta that starts at the current offset', () => {
+    const { instance, writes } = recordingInstance()
+    const out = applyTerminalData(instance, { kind: 'delta', data: new TextEncoder().encode('abc'), endOffset: 13, currentOffset: 10 })
+    expect(new TextDecoder().decode(writes[0])).toBe('abc')
+    expect(out).toBe(13)
+    instance.dispose()
   })
 
+  it('trims the prefix of a delta that overlaps rendered bytes', () => {
+    // The worker registers a watcher for live events first and takes its
+    // catch-up snapshot after, so a delta can re-include bytes the live
+    // path already delivered. Rendering the delta again duplicates them.
+    const { instance, writes } = recordingInstance()
+    // Current offset 12; the delta covers [10, 15): bytes 10..11 already
+    // rendered, so only "cde" (offsets 12..14) may write.
+    const out = applyTerminalData(instance, { kind: 'delta', data: new TextEncoder().encode('abcde'), endOffset: 15, currentOffset: 12 })
+    expect(new TextDecoder().decode(writes[0])).toBe('cde')
+    expect(out).toBe(15)
+    instance.dispose()
+  })
+
+  it('writes nothing when the delta lies entirely in the past', () => {
+    const { instance, writes } = recordingInstance()
+    let parsed = 0
+    // Offset 20; the delta covers [10, 14) — fully applied already.
+    const out = applyTerminalData(instance, { kind: 'delta', data: new TextEncoder().encode('abcd'), endOffset: 14, currentOffset: 20, onParsed: () => {
+      parsed++
+    } })
+    expect(writes).toEqual([])
+    // The parse callback still fires: callers gate content-ready on it.
+    expect(parsed).toBe(1)
+    // A stale duplicate must not rewind the cursor.
+    expect(out).toBe(20)
+    instance.dispose()
+  })
+
+  it('marks the parsed offset only once xterm parses the write', async () => {
+    const { instance } = recordingInstance()
+
+    // The write is queued, not parsed: the marker must stay unset so a
+    // dispose right here skips the capture instead of storing a screen whose
+    // coverage the tab's cursor overstates.
+    const out = applyTerminalData(instance, { kind: 'delta', data: new TextEncoder().encode('abc'), endOffset: 13, currentOffset: 10 })
+    expect(out).toBe(13)
+    expect(instance.lastParsedOffset).toBeUndefined()
+
+    // Flush xterm's async parser; the write's callback marks the cursor.
+    await new Promise<void>(resolve => instance.terminal.write('', resolve))
+    expect(instance.lastParsedOffset).toBe(13)
+
+    // A snapshot resets the buffer, so the marker is unsettled again until
+    // the snapshot's own write parses.
+    applyTerminalData(instance, { kind: 'snapshot', data: new TextEncoder().encode('rebuilt'), endOffset: 7 })
+    expect(instance.lastParsedOffset).toBeUndefined()
+    await new Promise<void>(resolve => instance.terminal.write('', resolve))
+    expect(instance.lastParsedOffset).toBe(7)
+
+    instance.dispose()
+  })
+
+  it('treats a snapshot as authoritative regardless of the current offset', async () => {
+    // After overlapping live deltas, a snapshot (the worker rebuilt the
+    // screen because the cursor fell outside the retained ring) resets the
+    // buffer and adopts the snapshot's cursor, even when the snapshot ends
+    // BEHIND the stale local offset.
+    const { instance } = recordingInstance()
+    instance.terminal.write('live')
+    await new Promise<void>(resolve => instance.terminal.write('', resolve))
+    const out = applyTerminalData(instance, { kind: 'snapshot', data: new TextEncoder().encode('rebuilt'), endOffset: 5 })
+    await new Promise<void>(resolve => instance.terminal.write('', resolve))
+    expect(instance.terminal.buffer.active.getLine(0)?.translateToString(true)).toContain('rebuilt')
+    expect(out).toBe(5)
+    instance.dispose()
+  })
+})
+
+describe('serializeXtermBuffer', () => {
   // Helper: synchronously write then await xterm's async parser via the
   // write callback. xterm processes its write queue asynchronously, so
   // calling serialize immediately after write() races the parser.
@@ -194,7 +264,6 @@ describe('resolveTerminalThemeMode', () => {
 
 describe('getTerminalRendererPreference', () => {
   beforeEach(() => {
-    localStorage.clear()
     Object.defineProperty(window, '__TAURI_INTERNALS__', {
       configurable: true,
       value: undefined,
@@ -254,8 +323,6 @@ describe('getTerminalRendererPreference', () => {
 
 describe('lazy WebGL renderer', () => {
   beforeEach(() => {
-    localStorage.clear()
-    window.matchMedia = vi.fn().mockReturnValue({ matches: false }) as any
     // Reset globals a prior describe may have left set (Object.defineProperty
     // leaks across blocks in jsdom), so the renderer preference resolves as a
     // plain non-Tauri browser rather than Linux desktop Tauri (→ canvas).

--- a/frontend/src/lib/terminal.ts
+++ b/frontend/src/lib/terminal.ts
@@ -13,6 +13,9 @@ import { sleep } from './sleep'
 
 const DEFAULT_MONO_FONT_FAMILY = '"Hack NF", Hack, "SF Mono", Consolas, monospace'
 const log = createLogger('terminal')
+// TextEncoder construction is not free, so one stateless instance serves
+// every call site in this module. (Same pattern as ~/lib/crdt/hlc.)
+const utf8Encoder = new TextEncoder()
 
 // Default PTY dimensions used by OpenTerminal / RestartTerminal callers
 // when no measured size is available yet (new-terminal dialog before
@@ -21,6 +24,15 @@ const log = createLogger('terminal')
 // and the restart fallback share a single source of truth.
 export const DEFAULT_TERMINAL_COLS = 80
 export const DEFAULT_TERMINAL_ROWS = 25
+
+// The bytes a terminal puts on the wire for Enter and for erase-one-
+// character, matching what xterm itself sends for those keys. Kept beside
+// the dimension constants for the same reason: every module that speaks
+// the PTY's input dialect — the restart-on-Enter gate in
+// useTerminalOperations, the IME replacement path in terminalIme —
+// shares one source of truth instead of redefining the byte it needs.
+export const ENTER_KEY_CR = 0x0D
+export const ERASE_CHARACTER = '\x7F'
 
 export type TerminalThemePreference = 'light' | 'dark' | 'match-ui'
 type ResolvedTerminalRenderer = 'webgl' | 'canvas'
@@ -70,11 +82,23 @@ export interface TerminalInstance {
   /** Send raw input data to the PTY backing this terminal. */
   sendInput?: (data: Uint8Array) => void
   /**
-   * The IME layer, attached once the terminal has been opened (it needs
+   * The IME layer, attached once the terminal is open (it needs
    * `terminal.element`). Owns every composed keystroke; see `./terminalIme`
-   * for why xterm's own composition handling cannot be left in charge.
+   * for why xterm's own composition handling cannot be left in charge. The
+   * VIEW owns both ends of this field's lifecycle: `TerminalView` attaches it
+   * after open() and releases it in `disposeTerminalInstance` — this module
+   * never touches it, so `dispose()` below does not release it.
    */
   ime?: TerminalImeHandle
+  /**
+   * The highest byte offset whose write xterm has PARSED (its write callback
+   * fired). Undefined while nothing has parsed, and from a snapshot's reset
+   * until the snapshot's write completes. The dispose path pairs this with
+   * the serialized screen so the stored screen and the tab's `lastOffset`
+   * describe the same bytes; the live cursor in tab metadata may run ahead of
+   * this, because a write is queued before it parses.
+   */
+  lastParsedOffset?: number
   dispose: () => void
 }
 
@@ -87,7 +111,7 @@ export interface TerminalInstance {
  * stored straight into the tab's `screen` metadata and replayed from there.
  */
 export function serializeXtermBuffer(instance: TerminalInstance): Uint8Array {
-  const encoded = new TextEncoder().encode(instance.serializeAddon.serialize())
+  const encoded = utf8Encoder.encode(instance.serializeAddon.serialize())
   // Node's TextEncoder (used by jsdom/vitest) returns a Buffer — a
   // Uint8Array subclass — whose prototype chain doesn't pass
   // `instanceof Uint8Array` across realms. Wrap as a plain view over the
@@ -217,40 +241,67 @@ export function resolveTerminalTheme(
 }
 
 /**
+ * One terminal-data frame to apply, in the shape the caller knows it by:
+ * a snapshot replaces the visible state, a delta extends it. The union
+ * states the delta-range contract in the type — a delta's range is
+ * [endOffset - data.length, endOffset) — where a boolean flag and two
+ * adjacent same-typed offsets left it to a doc comment.
+ */
+export type TerminalDataPayload
+  = | { kind: 'snapshot', data: Uint8Array, endOffset: number, onParsed?: () => void }
+    | { kind: 'delta', data: Uint8Array, endOffset: number, currentOffset: number, onParsed?: () => void }
+
+/**
  * Apply a TerminalData event (or an initial snapshot from ListTerminals)
  * to an xterm instance. Returns the new resume cursor — callers store
  * this as the tab's `lastOffset` and echo it on the next resubscribe.
  *
- * - isSnapshot=true: backend is replacing the terminal's visible state
+ * - kind=snapshot: backend is replacing the terminal's visible state
  *   (client's after_offset was stale or outside the retained ring). The
  *   xterm buffer is reset before the payload is written so the new bytes
  *   don't append to stale content. The returned cursor is `endOffset`
- *   unconditionally — even if smaller than `currentOffset`, since the
- *   buffer now exactly reflects those `endOffset` bytes.
- * - isSnapshot=false: payload is a strict incremental delta since
- *   `currentOffset`; written without resetting. The returned cursor is
- *   `max(currentOffset, endOffset)` so out-of-order duplicates can't
- *   rewind it.
+ *   unconditionally — even if smaller than the caller's current offset,
+ *   since the buffer now exactly reflects those `endOffset` bytes.
+ * - kind=delta: payload is a delta whose range is
+ *   [endOffset - data.length, endOffset). A delta may OVERLAP what this
+ *   terminal already rendered: the worker registers a new watcher for live
+ *   events first and takes its catch-up snapshot after, so any byte the
+ *   live path already delivered also rides in the catch-up range. The
+ *   offsets are authoritative on both ends, so the already-rendered prefix
+ *   is trimmed here — rendering stays exactly-once no matter how the two
+ *   deliveries interleave. A gap (delta starts BEYOND the current offset)
+ *   means bytes were missed; nothing here can recover them, so the delta
+ *   writes as-is and the next snapshot rebuilds the screen. The returned
+ *   cursor is `max(currentOffset, endOffset)` so out-of-order duplicates
+ *   can't rewind it.
  */
-export function applyTerminalData(
-  instance: TerminalInstance,
-  data: Uint8Array,
-  isSnapshot: boolean,
-  endOffset: number,
-  currentOffset: number,
-  onParsed?: () => void,
-): number {
-  if (isSnapshot) {
+export function applyTerminalData(instance: TerminalInstance, payload: TerminalDataPayload): number {
+  if (payload.kind === 'snapshot') {
     instance.terminal.reset()
     instance.suppressInput = true
-    instance.terminal.write(data, () => {
+    // reset() emptied the buffer, so nothing is parsed until the write below
+    // completes — see `lastParsedOffset`.
+    instance.lastParsedOffset = undefined
+    instance.terminal.write(payload.data, () => {
+      instance.lastParsedOffset = payload.endOffset
       instance.suppressInput = false
-      onParsed?.()
+      payload.onParsed?.()
     })
-    return endOffset
+    return payload.endOffset
   }
-  instance.terminal.write(data, onParsed)
-  return endOffset > currentOffset ? endOffset : currentOffset
+  const { data, endOffset, currentOffset, onParsed } = payload
+  const deltaStart = endOffset - data.byteLength
+  const unrendered = currentOffset > deltaStart ? data.subarray(currentOffset - deltaStart) : data
+  if (unrendered.byteLength === 0) {
+    onParsed?.()
+    return Math.max(currentOffset, endOffset)
+  }
+  const cursor = Math.max(currentOffset, endOffset)
+  instance.terminal.write(unrendered, () => {
+    instance.lastParsedOffset = cursor
+    onParsed?.()
+  })
+  return cursor
 }
 
 /**
@@ -343,11 +394,6 @@ export function createTerminalInstance(opts?: TerminalFontOptions & { theme?: IT
     fontsReady,
     webglAddon: undefined,
     dispose() {
-      // Before terminal.dispose(): the IME layer's listeners and its preview
-      // node hang off `terminal.element`, which xterm removes from the document
-      // as it tears down.
-      instance.ime?.dispose()
-      instance.ime = undefined
       terminal.dispose()
     },
   }

--- a/frontend/src/lib/terminal.ts
+++ b/frontend/src/lib/terminal.ts
@@ -1,5 +1,6 @@
 import type { ITheme } from '@xterm/xterm'
 import type { BrowserPreferences, TerminalRendererPreference } from './browserStorage'
+import type { TerminalImeHandle } from './terminalIme'
 import type { ThemePreference } from '~/app'
 import { FitAddon } from '@xterm/addon-fit'
 import { SerializeAddon } from '@xterm/addon-serialize'
@@ -68,6 +69,12 @@ export interface TerminalInstance {
   webglAddon?: WebglAddon
   /** Send raw input data to the PTY backing this terminal. */
   sendInput?: (data: Uint8Array) => void
+  /**
+   * The IME layer, attached once the terminal has been opened (it needs
+   * `terminal.element`). Owns every composed keystroke; see `./terminalIme`
+   * for why xterm's own composition handling cannot be left in charge.
+   */
+  ime?: TerminalImeHandle
   dispose: () => void
 }
 
@@ -327,7 +334,7 @@ export function createTerminalInstance(opts?: TerminalFontOptions & { theme?: IT
     void copyTextToClipboard(terminal.getSelection())
   })
 
-  return {
+  const instance: TerminalInstance = {
     terminal,
     fitAddon,
     serializeAddon,
@@ -336,9 +343,15 @@ export function createTerminalInstance(opts?: TerminalFontOptions & { theme?: IT
     fontsReady,
     webglAddon: undefined,
     dispose() {
+      // Before terminal.dispose(): the IME layer's listeners and its preview
+      // node hang off `terminal.element`, which xterm removes from the document
+      // as it tears down.
+      instance.ime?.dispose()
+      instance.ime = undefined
       terminal.dispose()
     },
   }
+  return instance
 }
 
 /**

--- a/frontend/src/lib/terminalIme.css.ts
+++ b/frontend/src/lib/terminalIme.css.ts
@@ -1,0 +1,34 @@
+import { style } from '@vanilla-extract/css'
+
+/**
+ * The in-progress IME composition, painted over the cell the cursor sits on.
+ *
+ * Only layout lives here. The font and the colors are written as inline styles
+ * when the preview is shown, because they must follow the live xterm options
+ * (`terminal.options.fontFamily`, `fontSize`, and `theme`), which the user can
+ * change at any time from the settings panel.
+ *
+ * xterm ships its own `.composition-view` for this, but it is unusable here on
+ * two counts: LeapMux intercepts the composition events before xterm sees them,
+ * so xterm never activates it, and it hardcodes `background: #000; color: #FFF`,
+ * which is unreadable against a light terminal theme.
+ */
+export const compositionPreview = style({
+  position: 'absolute',
+  display: 'none',
+  whiteSpace: 'nowrap',
+  // Above the renderer's canvases, matching the z-index xterm gives its own
+  // composition view so the preview is never painted over by a cell.
+  zIndex: 1,
+  // The composed text is almost always wider than the single cell the textarea
+  // is sized to, so it must be free to overflow that box to the right.
+  pointerEvents: 'none',
+  // Underline it the way a native input marks composing text, so it reads as
+  // pending rather than as terminal output.
+  textDecoration: 'underline',
+})
+
+/** Applied while a composition is active. */
+export const compositionPreviewActive = style({
+  display: 'block',
+})

--- a/frontend/src/lib/terminalIme.test.ts
+++ b/frontend/src/lib/terminalIme.test.ts
@@ -1,6 +1,8 @@
 import type { TerminalImeHandle } from './terminalIme'
 import { Terminal } from '@xterm/xterm'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { compositionPreview } from '~/test-support/compositionPreview'
+import { stubMatchMedia } from '~/test-support/matchMediaStub'
 import { attachTerminalIme } from './terminalIme'
 
 /**
@@ -79,46 +81,48 @@ function wkKeystroke(h: Harness, inputType: string, data: string, replacedRange:
     const end = h.textarea.value.length
     h.textarea.setSelectionRange(end, end)
   }
-  h.textarea.dispatchEvent(new InputEvent('beforeinput', {
-    data,
-    inputType,
-    isComposing: false,
-    bubbles: true,
-    cancelable: true,
-    composed: true,
-  }))
+  dispatchInputEvent(h.textarea, 'beforeinput', { data, inputType })
   h.textarea.value = nextValue
   h.textarea.setSelectionRange(nextValue.length, nextValue.length)
-  h.textarea.dispatchEvent(new InputEvent('input', {
-    data,
-    inputType,
-    isComposing: false,
-    bubbles: true,
-    cancelable: true,
-    composed: true,
-  }))
+  dispatchInputEvent(h.textarea, 'input', { data, inputType })
   keydown(h.textarea, { key: data.slice(-1), keyCode: 229 })
   h.textarea.dispatchEvent(new KeyboardEvent('keyup', { key: data.slice(-1), keyCode: 68, bubbles: true }))
 }
 
+/**
+ * Dispatch one input-type event with the init bag a trusted event carries.
+ * Trusted input events are composed, and xterm's `_inputEvent` reads that
+ * flag to decide whether the key path already sent the character. Leaving
+ * it off makes xterm double-send and the test measures the wrong thing.
+ */
+function dispatchInputEvent(
+  target: HTMLElement,
+  type: 'beforeinput' | 'input',
+  init: { data?: string | null, inputType?: string, isComposing?: boolean },
+): void {
+  target.dispatchEvent(new InputEvent(type, {
+    data: init.data,
+    inputType: init.inputType,
+    isComposing: init.isComposing ?? false,
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+  }))
+}
+
+/** One beforeinput + input pair for the same edit, as an engine fires them. */
 function input(target: HTMLElement, inputType: string, data: string | null, isComposing = false): void {
-  for (const type of ['beforeinput', 'input']) {
-    target.dispatchEvent(new InputEvent(type, {
-      data,
-      inputType,
-      isComposing,
-      bubbles: true,
-      cancelable: true,
-      // Trusted input events are composed, and xterm's `_inputEvent` reads that
-      // flag to decide whether the key path already sent the character. Leaving
-      // it off makes xterm double-send and the test measures the wrong thing.
-      composed: true,
-    }))
-  }
+  for (const type of ['beforeinput', 'input'] as const)
+    dispatchInputEvent(target, type, { data, inputType, isComposing })
 }
 
 function keydown(target: HTMLElement, init: KeyboardEventInit & { keyCode?: number }): void {
   target.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init }))
+}
+
+/** One trusted-shape keypress carrying a charCode — the echo of a deferred A–Z. */
+function keypress(target: HTMLElement, charCode: number): void {
+  target.dispatchEvent(new KeyboardEvent('keypress', { charCode, bubbles: true, cancelable: true } as KeyboardEventInit))
 }
 
 /**
@@ -138,20 +142,12 @@ function chromiumCompose(h: Harness, steps: string[], opts: { start: boolean }):
 }
 
 describe('attachTerminalIme', () => {
-  let originalMatchMedia: typeof window.matchMedia
+  let matchMedia: ReturnType<typeof stubMatchMedia>
 
   beforeEach(() => {
-    originalMatchMedia = window.matchMedia
-    // jsdom has no matchMedia, and xterm's CoreBrowserService watches the
-    // device-pixel-ratio query through the LEGACY addListener/removeListener
-    // pair, so a stub with only addEventListener throws inside open().
-    window.matchMedia = vi.fn().mockReturnValue({
-      matches: false,
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-    }) as any
+    // jsdom has no matchMedia; the shared stub carries the legacy listener
+    // pair xterm's open() needs.
+    matchMedia = stubMatchMedia()
   })
 
   afterEach(() => {
@@ -161,10 +157,8 @@ describe('attachTerminalIme', () => {
       h.container.remove()
     }
     harnesses = []
-    // Restore rather than leave the stub behind: a bare stub leaking out of
-    // this suite is what the note in TerminalView.test.tsx exists to work
-    // around, and there is no reason to add another source of it.
-    window.matchMedia = originalMatchMedia
+    // Restore rather than leave the stub behind.
+    matchMedia.restore()
   })
 
   it('sends each committed syllable once for the recorded Chromium trace', () => {
@@ -264,27 +258,131 @@ describe('attachTerminalIme', () => {
     // characters the user never asked to lose.
     h.textarea.value = 'abc'
     h.textarea.setSelectionRange(0, 3)
-    h.textarea.dispatchEvent(new InputEvent('beforeinput', {
+    dispatchInputEvent(h.textarea, 'beforeinput', { data: 'x', inputType: 'insertText' })
+    // The measurement is only good for the paired input event.
+    await Promise.resolve()
+
+    h.textarea.value = 'abc'
+    h.textarea.setSelectionRange(3, 3)
+    dispatchInputEvent(h.textarea, 'input', { data: '안', inputType: 'insertText' })
+
+    expect(h.sent).toEqual(['안'])
+  })
+
+  it('applies the erase across the microtask checkpoint a real browser runs', async () => {
+    const h = createHarness()
+
+    // The production shape: a real browser dispatches beforeinput and input
+    // as two separate event dispatches, and the JS stack is empty between
+    // them, so a microtask checkpoint runs exactly here. A timing-based
+    // reset of the measurement dies at that checkpoint, and the erase half
+    // of every WKWebView replacement silently never fires. jsdom hides this
+    // because a synchronous dispatchEvent keeps the stack non-empty.
+    h.textarea.value = 'ㅇ'
+    h.textarea.setSelectionRange(0, 1)
+    dispatchInputEvent(h.textarea, 'beforeinput', { data: '아', inputType: 'insertReplacementText' })
+    await Promise.resolve()
+    h.textarea.value = '아'
+    h.textarea.setSelectionRange(1, 1)
+    dispatchInputEvent(h.textarea, 'input', { data: '아', inputType: 'insertReplacementText' })
+
+    expect(h.sent).toEqual(['\x7F아'])
+  })
+
+  it('prefers the engine target ranges over the live selection', () => {
+    const h = createHarness()
+
+    // The selection has already collapsed by the time an engine that
+    // populates getTargetRanges dispatches beforeinput; the ranges are the
+    // engine's own statement of what the edit replaces.
+    h.textarea.value = 'abcd'
+    h.textarea.setSelectionRange(4, 4)
+    const beforeinput = new InputEvent('beforeinput', {
       data: 'x',
       inputType: 'insertText',
       bubbles: true,
       cancelable: true,
       composed: true,
-    }))
-    // The measurement is only good for the input event of the same task.
-    await Promise.resolve()
+    })
+    Object.defineProperty(beforeinput, 'getTargetRanges', {
+      value: () => [{
+        startContainer: h.textarea,
+        endContainer: h.textarea,
+        startOffset: 1,
+        endOffset: 3,
+      }],
+    })
+    h.textarea.dispatchEvent(beforeinput)
+    h.textarea.value = 'axd'
+    h.textarea.setSelectionRange(2, 2)
+    dispatchInputEvent(h.textarea, 'input', { data: 'x', inputType: 'insertText' })
 
-    h.textarea.value = 'abc'
-    h.textarea.setSelectionRange(3, 3)
-    h.textarea.dispatchEvent(new InputEvent('input', {
-      data: '안',
+    expect(h.sent).toEqual(['\x7F\x7Fx'])
+  })
+
+  it('falls back to the selection when the target ranges point at another node', () => {
+    const h = createHarness()
+
+    // A range shape this module cannot interpret (containers that are not
+    // the textarea) must not silence the measurement: the live selection
+    // still covers the replaced range in every recorded trace.
+    h.textarea.value = 'ab'
+    h.textarea.setSelectionRange(0, 1)
+    const beforeinput = new InputEvent('beforeinput', {
+      data: 'x',
       inputType: 'insertText',
       bubbles: true,
       cancelable: true,
       composed: true,
-    }))
+    })
+    Object.defineProperty(beforeinput, 'getTargetRanges', {
+      value: () => [{
+        startContainer: document.body,
+        endContainer: document.body,
+        startOffset: 0,
+        endOffset: 9,
+      }],
+    })
+    h.textarea.dispatchEvent(beforeinput)
+    h.textarea.value = 'xb'
+    h.textarea.setSelectionRange(1, 1)
+    dispatchInputEvent(h.textarea, 'input', { data: 'x', inputType: 'insertText' })
 
-    expect(h.sent).toEqual(['안'])
+    expect(h.sent).toEqual(['\x7Fx'])
+  })
+
+  it('claims an IME insert that lands while a plain capital is still in flight', () => {
+    const h = createHarness()
+
+    // Rollover: the capital's keyup has not arrived when the IME's first
+    // jamo does. xterm already sent the capital from keypress, and its
+    // `_keyDownSeen` guard drops the jamo — reading the stale keydown as
+    // "xterm owns the insertText" loses the jamo, and the follow-up
+    // replacement then erases the capital the user actually typed.
+    keydown(h.textarea, { key: 'C', keyCode: 67 })
+    keypress(h.textarea, 67)
+    h.textarea.value = 'C'
+    input(h.textarea, 'insertText', 'ㅇ')
+    h.textarea.value = 'Cㅇ'
+    wkKeystroke(h, 'insertReplacementText', '아', [1, 2], 'C아')
+
+    expect(applyToLine([...h.fromXterm, ...h.sent])).toBe('C아')
+  })
+
+  it('claims a dead key precomposed character that xterm never sends', () => {
+    const h = createHarness()
+
+    // Dead key: xterm records the dead key, and the follow-up keydown takes
+    // xterm's `_unprocessedDeadKey` branch — no bytes, no preventDefault —
+    // so the composed character arrives only as an insertText whose text
+    // differs from the key in flight.
+    keydown(h.textarea, { key: 'Dead' })
+    keydown(h.textarea, { key: 'e', keyCode: 69 })
+    h.textarea.value = 'é'
+    input(h.textarea, 'insertText', 'é')
+
+    expect(h.sent).toEqual(['é'])
+    expect(h.fromXterm).toEqual([])
   })
 
   it('counts a replaced surrogate pair as one character', () => {
@@ -373,6 +471,71 @@ describe('attachTerminalIme', () => {
     expect(h.ime.shouldBypassKeyEvent(second)).toBe(false)
   })
 
+  it('suppresses every echo of a multi-character commit', () => {
+    const h = createHarness()
+
+    // Japanese and Chinese commit a whole reading in one compositionend. If
+    // the engine echoes it as one synthetic keypress per character, every
+    // echo must be suppressed — a one-shot suppression lets xterm's
+    // `_keyPress` send the remaining characters a second time.
+    composition(h.textarea, 'compositionstart', '')
+    composition(h.textarea, 'compositionupdate', 'ab')
+    composition(h.textarea, 'compositionend', 'ab')
+
+    for (const ch of ['a', 'b']) {
+      expect(h.ime.shouldBypassKeyEvent(
+        new KeyboardEvent('keypress', { charCode: ch.charCodeAt(0) } as KeyboardEventInit),
+      )).toBe(true)
+    }
+    // The window is spent: a further keypress of a committed character is
+    // genuine and must survive.
+    expect(h.ime.shouldBypassKeyEvent(
+      new KeyboardEvent('keypress', { charCode: 97 } as KeyboardEventInit),
+    )).toBe(false)
+    expect(h.sent).toEqual(['ab'])
+    expect(h.fromXterm).toEqual([])
+  })
+
+  it('never lets a lone-surrogate echo keypress reach xterm', () => {
+    const h = createHarness()
+
+    // An astral commit (an emoji) is two UTF-16 units, and an engine that
+    // echoes per unit emits one synthetic keypress per surrogate half. When
+    // its echo count diverges from the per-unit bookkeeping (a repeated
+    // half), the surplus keypress carries a lone surrogate. xterm's
+    // `_keyPress` would send String.fromCharCode(charCode) verbatim, and a
+    // lone surrogate reaches the PTY as U+FFFD — so it must be bypassed
+    // unconditionally.
+    composition(h.textarea, 'compositionstart', '')
+    composition(h.textarea, 'compositionend', '😀')
+
+    const high = 0xD83D
+    expect(h.ime.shouldBypassKeyEvent(new KeyboardEvent('keypress', { charCode: high } as KeyboardEventInit))).toBe(true)
+    // The divergent surplus echo of the same half is garbage, not input.
+    expect(h.ime.shouldBypassKeyEvent(new KeyboardEvent('keypress', { charCode: high } as KeyboardEventInit))).toBe(true)
+    // The low half still goes through the ordinary consumption.
+    expect(h.ime.shouldBypassKeyEvent(new KeyboardEvent('keypress', { charCode: 0xDE00 } as KeyboardEventInit))).toBe(true)
+
+    expect(h.sent).toEqual(['😀'])
+    expect(h.fromXterm).toEqual([])
+  })
+
+  it('still suppresses the echo when the IME keydown lands after the commit', () => {
+    const h = createHarness()
+
+    // WKWebView delivers the IME-consumed keydown AFTER the input event it
+    // produced; the same order around a commit must not close the echo
+    // window before the synthetic keypress arrives.
+    composition(h.textarea, 'compositionstart', '')
+    composition(h.textarea, 'compositionend', '안')
+    keydown(h.textarea, { key: 'ㅇ', keyCode: 229 })
+
+    expect(h.ime.shouldBypassKeyEvent(
+      new KeyboardEvent('keypress', { charCode: '안'.charCodeAt(0) } as KeyboardEventInit),
+    )).toBe(true)
+    expect(h.sent).toEqual(['안'])
+  })
+
   it('keeps the keystroke that follows a commit, which xterm drops', () => {
     const h = createHarness()
 
@@ -387,7 +550,7 @@ describe('attachTerminalIme', () => {
     expect(h.sent).toEqual(['~', '/'])
   })
 
-  it('leaves ordinary typing on xterm own key path', () => {
+  it('leaves ordinary typing on xterm\'s own key path', () => {
     const h = createHarness()
 
     // xterm handles a plain printable key in keydown and calls preventDefault,
@@ -410,18 +573,93 @@ describe('attachTerminalIme', () => {
     // event for a capital, and claiming it doubles every one the user types --
     // `CANCELLED` arriving as `CCAANNCCEELLLLEEDD`.
     keydown(h.textarea, { key: 'C', keyCode: 67 })
-    h.textarea.dispatchEvent(new KeyboardEvent('keypress', {
-      charCode: 67,
-      bubbles: true,
-      cancelable: true,
-    } as KeyboardEventInit))
+    keypress(h.textarea, 67)
     input(h.textarea, 'insertText', 'C')
 
     expect(h.fromXterm).toEqual(['C'])
     expect(h.sent).toEqual([])
   })
 
-  it('leaves paste to xterm own paste handler', () => {
+  it('leaves caps-lock-folded text to xterm, which sends the folded case', () => {
+    const h = createHarness()
+
+    // Caps lock on: the keydown reports 'C', the keypress (and xterm's send)
+    // carries 'c'. Ownership reads the OBSERVED emission, so the input event
+    // for 'c' is xterm's echo — claiming it would double the letter.
+    keydown(h.textarea, { key: 'C', keyCode: 67 })
+    keypress(h.textarea, 99)
+    h.textarea.value = 'c'
+    input(h.textarea, 'insertText', 'c')
+
+    expect(h.fromXterm).toEqual(['c'])
+    expect(h.sent).toEqual([])
+  })
+
+  it('claims text whose keystroke produced no xterm emission', () => {
+    const h = createHarness()
+
+    // A deferred key whose keypress never ran — an engine that skips it, or
+    // delivers the input event first. xterm emits nothing, so the text is
+    // ours; reading the key's shape instead would hand it to an xterm path
+    // that never fires, and the character would be lost.
+    keydown(h.textarea, { key: 'C', keyCode: 67 })
+    h.textarea.value = 'C'
+    input(h.textarea, 'insertText', 'C')
+
+    expect(h.sent).toEqual(['C'])
+    expect(h.fromXterm).toEqual([])
+  })
+
+  it('claims an IME insert whose text merely occurs inside an in-flight emission', () => {
+    const h = createHarness()
+
+    // An arrow key emits '\x1b[C' through xterm's key path. If its keyup has
+    // not landed (WKWebView delivers events out of band; fast typists), a
+    // substring match reads an IME-committed 'C' as that emission's echo and
+    // silently drops it. An emission must answer only its exact echo.
+    keydown(h.textarea, { key: 'ArrowRight', keyCode: 39 })
+    input(h.textarea, 'insertText', 'C')
+
+    // The arrow's emission really is in flight — that is what makes 'C'
+    // look like a substring of it.
+    expect(h.fromXterm).toEqual(['\x1B[C'])
+    expect(h.sent).toEqual(['C'])
+  })
+
+  it('answers each deferred capital\'s echo with its own emission', () => {
+    const h = createHarness()
+
+    // Rollover: both capitals' keypresses ran before either input event
+    // arrived. Each input event must consume its own emission — an arrow's
+    // '\x1b[C' above shows why the entries cannot be merged into one string —
+    // or the second echo would ride the first's match and be double-sent.
+    keydown(h.textarea, { key: 'C', keyCode: 67 })
+    keypress(h.textarea, 67)
+    keydown(h.textarea, { key: 'A', keyCode: 65 })
+    keypress(h.textarea, 65)
+    input(h.textarea, 'insertText', 'C')
+    input(h.textarea, 'insertText', 'A')
+
+    expect(h.fromXterm).toEqual(['C', 'A'])
+    expect(h.sent).toEqual([])
+  })
+
+  it('expires the emission when the keystroke ends', () => {
+    const h = createHarness()
+
+    // A fully-typed capital leaves no emission behind, so a later
+    // mouse-committed candidate of the same character is ours, not an echo.
+    keydown(h.textarea, { key: 'C', keyCode: 67 })
+    keypress(h.textarea, 67)
+    h.textarea.dispatchEvent(new KeyboardEvent('keyup', { key: 'C', keyCode: 67, bubbles: true }))
+    h.textarea.value = ''
+    input(h.textarea, 'insertText', 'C')
+
+    expect(h.sent).toEqual(['C'])
+    expect(h.fromXterm).toEqual(['C'])
+  })
+
+  it('leaves paste to xterm\'s own paste handler', () => {
     const h = createHarness()
 
     // xterm binds `paste` on the textarea and writes the clipboard itself.
@@ -435,9 +673,9 @@ describe('attachTerminalIme', () => {
   it('leaves editing input types alone', () => {
     const h = createHarness()
 
-    // Backspace and friends reach the PTY through xterm's key path as control
-    // bytes. Forwarding the matching input event would send them a second time
-    // as text.
+    // Backspace and similar editing keys reach the PTY through xterm's key
+    // path as control bytes. Forwarding the matching input event would send
+    // them a second time as text.
     input(h.textarea, 'deleteContentBackward', null)
     input(h.textarea, 'insertLineBreak', null)
 
@@ -501,7 +739,7 @@ describe('attachTerminalIme', () => {
 
   it('shows the composing text and hides it on commit', () => {
     const h = createHarness()
-    const preview = () => h.container.querySelector<HTMLElement>('[data-testid="terminal-composition-preview"]')!
+    const preview = () => compositionPreview(h.container)!
 
     expect(preview().textContent).toBe('')
 
@@ -517,14 +755,14 @@ describe('attachTerminalIme', () => {
 
   it('places the preview on the cursor and in the terminal colors', () => {
     const h = createHarness()
-    const preview = () => h.container.querySelector<HTMLElement>('[data-testid="terminal-composition-preview"]')!
+    const preview = () => compositionPreview(h.container)!
 
     // xterm parks its helper textarea on the cursor, and the preview borrows
     // that box rather than measuring cells itself.
     h.textarea.style.left = '48px'
     h.textarea.style.top = '17px'
     h.textarea.style.height = '19px'
-    // One token, so the assertion below is not really testing how the CSSOM
+    // One token, so the assertion below does not really test how the CSSOM
     // quotes a family name that contains a space.
     h.terminal.options.fontFamily = 'TestMono'
     h.terminal.options.fontSize = 15
@@ -543,16 +781,6 @@ describe('attachTerminalIme', () => {
     expect(preview().style.color).toBe('rgb(16, 16, 16)')
   })
 
-  it('tracks composing across the composition', () => {
-    const h = createHarness()
-
-    expect(h.ime.composing).toBe(false)
-    composition(h.textarea, 'compositionstart', '')
-    expect(h.ime.composing).toBe(true)
-    composition(h.textarea, 'compositionend', '안')
-    expect(h.ime.composing).toBe(false)
-  })
-
   it('drops a keypress that arrives mid-composition', () => {
     const h = createHarness()
 
@@ -564,11 +792,10 @@ describe('attachTerminalIme', () => {
 
   it('releases its listeners and its preview on dispose', () => {
     const h = createHarness()
-    const selector = '[data-testid="terminal-composition-preview"]'
-    expect(h.container.querySelector(selector)).not.toBeNull()
+    expect(compositionPreview(h.container)).not.toBeNull()
 
     h.ime.dispose()
-    expect(h.container.querySelector(selector)).toBeNull()
+    expect(compositionPreview(h.container)).toBeNull()
 
     // With the layer gone the events belong to xterm again, so nothing more
     // reaches our sink.
@@ -586,5 +813,18 @@ describe('attachTerminalIme', () => {
     const terminal = new Terminal()
     expect(() => attachTerminalIme(terminal, () => {})).toThrow(/terminal\.open/)
     terminal.dispose()
+  })
+
+  it('refuses to attach when the textarea was detached from the DOM', () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const terminal = new Terminal({ cols: 80, rows: 24 })
+    terminal.open(container)
+    // A DOM shape change that detaches the helper must fail loudly: a preview
+    // silently re-parented to another containing block would position wrong.
+    terminal.textarea!.remove()
+    expect(() => attachTerminalIme(terminal, () => {})).toThrow(/attached/)
+    terminal.dispose()
+    container.remove()
   })
 })

--- a/frontend/src/lib/terminalIme.test.ts
+++ b/frontend/src/lib/terminalIme.test.ts
@@ -1,0 +1,590 @@
+import type { TerminalImeHandle } from './terminalIme'
+import { Terminal } from '@xterm/xterm'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { attachTerminalIme } from './terminalIme'
+
+/**
+ * The two traces below are not invented. The Chromium one was recorded from a
+ * real composition driven through Chrome DevTools Protocol
+ * (`Input.imeSetComposition`), and the WebKit one is the trace posted on
+ * xtermjs/xterm.js#5894. They are the reason this module exists, so the tests
+ * replay them rather than a tidied-up approximation.
+ */
+
+interface Harness {
+  terminal: Terminal
+  ime: TerminalImeHandle
+  textarea: HTMLTextAreaElement
+  /** Text this module handed to the PTY. */
+  sent: string[]
+  /** Text xterm produced on its own. Composed input must never appear here. */
+  fromXterm: string[]
+  container: HTMLDivElement
+}
+
+let harnesses: Harness[] = []
+
+function createHarness(): Harness {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+
+  const terminal = new Terminal({ cols: 80, rows: 24 })
+  terminal.open(container)
+
+  const sent: string[] = []
+  const fromXterm: string[] = []
+  terminal.onData(data => fromXterm.push(data))
+
+  const ime = attachTerminalIme(terminal, data => sent.push(data))
+  // Mirror how TerminalView wires the handler, so these tests exercise the real
+  // interaction with xterm's key path rather than the module in isolation.
+  terminal.attachCustomKeyEventHandler(event => !ime.shouldBypassKeyEvent(event))
+
+  const harness: Harness = { terminal, ime, textarea: terminal.textarea!, sent, fromXterm, container }
+  harnesses.push(harness)
+  return harness
+}
+
+function composition(target: HTMLElement, type: string, data: string): void {
+  target.dispatchEvent(new CompositionEvent(type, { data, bubbles: true, cancelable: true, composed: true }))
+}
+
+/**
+ * Apply what the module sent to a one-line model of the shell's input line, so
+ * the assertions read as "the user ended up with 안녕" rather than as a pinned
+ * byte sequence. DEL (0x7F) is what xterm sends for Backspace and what readline
+ * treats as backward-delete-char.
+ */
+function applyToLine(writes: string[]): string {
+  const line: string[] = []
+  for (const ch of [...writes.join('')]) {
+    if (ch === '\x7F')
+      line.pop()
+    else
+      line.push(ch)
+  }
+  return line.join('')
+}
+
+/**
+ * One WKWebView keystroke: the text event arrives FIRST, and the keydown the
+ * input method consumed follows it. That order is the reverse of Chromium's and
+ * it is what the recorded desktop trace shows.
+ */
+function wkKeystroke(h: Harness, inputType: string, data: string, replacedRange: [number, number] | null, nextValue: string): void {
+  if (replacedRange) {
+    h.textarea.setSelectionRange(replacedRange[0], replacedRange[1])
+  }
+  else {
+    const end = h.textarea.value.length
+    h.textarea.setSelectionRange(end, end)
+  }
+  h.textarea.dispatchEvent(new InputEvent('beforeinput', {
+    data,
+    inputType,
+    isComposing: false,
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+  }))
+  h.textarea.value = nextValue
+  h.textarea.setSelectionRange(nextValue.length, nextValue.length)
+  h.textarea.dispatchEvent(new InputEvent('input', {
+    data,
+    inputType,
+    isComposing: false,
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+  }))
+  keydown(h.textarea, { key: data.slice(-1), keyCode: 229 })
+  h.textarea.dispatchEvent(new KeyboardEvent('keyup', { key: data.slice(-1), keyCode: 68, bubbles: true }))
+}
+
+function input(target: HTMLElement, inputType: string, data: string | null, isComposing = false): void {
+  for (const type of ['beforeinput', 'input']) {
+    target.dispatchEvent(new InputEvent(type, {
+      data,
+      inputType,
+      isComposing,
+      bubbles: true,
+      cancelable: true,
+      // Trusted input events are composed, and xterm's `_inputEvent` reads that
+      // flag to decide whether the key path already sent the character. Leaving
+      // it off makes xterm double-send and the test measures the wrong thing.
+      composed: true,
+    }))
+  }
+}
+
+function keydown(target: HTMLElement, init: KeyboardEventInit & { keyCode?: number }): void {
+  target.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init }))
+}
+
+/**
+ * One syllable of the Chromium trace: an IME-consumed keydown per keystroke,
+ * then the composition update and the input event that writes the textarea.
+ */
+function chromiumCompose(h: Harness, steps: string[], opts: { start: boolean }): void {
+  steps.forEach((text, index) => {
+    keydown(h.textarea, { key: 'Process', keyCode: 229 })
+    if (index === 0 && opts.start)
+      composition(h.textarea, 'compositionstart', '')
+    composition(h.textarea, 'compositionupdate', text)
+    input(h.textarea, 'insertCompositionText', text, true)
+    // Chromium writes the composing text into the textarea as it goes.
+    h.textarea.value = h.textarea.value.slice(0, h.textarea.value.length - (index === 0 ? 0 : 1)) + text
+  })
+}
+
+describe('attachTerminalIme', () => {
+  let originalMatchMedia: typeof window.matchMedia
+
+  beforeEach(() => {
+    originalMatchMedia = window.matchMedia
+    // jsdom has no matchMedia, and xterm's CoreBrowserService watches the
+    // device-pixel-ratio query through the LEGACY addListener/removeListener
+    // pair, so a stub with only addEventListener throws inside open().
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }) as any
+  })
+
+  afterEach(() => {
+    for (const h of harnesses) {
+      h.ime.dispose()
+      h.terminal.dispose()
+      h.container.remove()
+    }
+    harnesses = []
+    // Restore rather than leave the stub behind: a bare stub leaking out of
+    // this suite is what the note in TerminalView.test.tsx exists to work
+    // around, and there is no reason to add another source of it.
+    window.matchMedia = originalMatchMedia
+  })
+
+  it('sends each committed syllable once for the recorded Chromium trace', () => {
+    const h = createHarness()
+
+    // 안: ㅇ -> 아 -> 안, then the commit that starts 녕.
+    chromiumCompose(h, ['ㅇ', '아', '안'], { start: true })
+    keydown(h.textarea, { key: 'Process', keyCode: 229 })
+    composition(h.textarea, 'compositionend', '안')
+    // Chromium starts the next composition in the same burst, with the
+    // committed syllable already in the textarea value.
+    composition(h.textarea, 'compositionstart', '')
+    chromiumCompose(h, ['ㄴ', '녀', '녕'], { start: false })
+    composition(h.textarea, 'compositionend', '녕')
+
+    expect(h.sent).toEqual(['안', '녕'])
+  })
+
+  it('composes Korean on WKWebView, which sends no composition events', () => {
+    const h = createHarness()
+
+    // Replayed from a desktop (Tauri/WKWebView) recording of someone typing
+    // 안녕. There is no compositionstart, no compositionupdate and no
+    // compositionend anywhere in it, and `isComposing` is false throughout:
+    // WKWebView refines each syllable by REPLACING the text it already
+    // inserted. Reading only `insertText` leaves the terminal with ㅇ and ㄴ.
+    wkKeystroke(h, 'insertText', 'ㅇ', null, 'ㅇ')
+    wkKeystroke(h, 'insertReplacementText', '아', [0, 1], '아')
+    wkKeystroke(h, 'insertReplacementText', '안', [0, 1], '안')
+    wkKeystroke(h, 'insertReplacementText', '안', [0, 1], '안')
+    wkKeystroke(h, 'insertText', 'ㄴ', null, '안ㄴ')
+    wkKeystroke(h, 'insertReplacementText', '녀', [1, 2], '안녀')
+    wkKeystroke(h, 'insertReplacementText', '녕', [1, 2], '안녕')
+
+    expect(applyToLine(h.sent)).toBe('안녕')
+    // xterm's own key path must not have added anything of its own.
+    expect(h.fromXterm).toEqual([])
+  })
+
+  it('erases exactly what a replacement supersedes', () => {
+    const h = createHarness()
+
+    wkKeystroke(h, 'insertText', 'ㅇ', null, 'ㅇ')
+    expect(h.sent).toEqual(['ㅇ'])
+
+    // One character replaced means one erase, then the new text, and both in a
+    // single write so no other keystroke can land between them.
+    wkKeystroke(h, 'insertReplacementText', '아', [0, 1], '아')
+    expect(h.sent[1]).toBe('\x7F아')
+  })
+
+  it('claims the text even when the previous keyup has not landed yet', () => {
+    const h = createHarness()
+
+    // WKWebView delivers the keydown AFTER the input event it produced, so a
+    // fast typist leaves the PREVIOUS keystroke still recorded when the next
+    // one's text arrives. Reading that stale keydown as "xterm owns this"
+    // silently drops the character.
+    keydown(h.textarea, { key: 'ㅇ', keyCode: 229 })
+    // No keyup. The next syllable's text arrives regardless.
+    input(h.textarea, 'insertText', 'ㄴ')
+
+    expect(h.sent).toEqual(['ㄴ'])
+  })
+
+  it('never defers a replacement to xterm, which has no branch for one', () => {
+    const h = createHarness()
+
+    // A plain keydown that xterm did not claim would make `insertText`
+    // ambiguous, but a replacement is unambiguous: xterm only ever inspects
+    // `insertText`, so leaving one to xterm loses it.
+    h.textarea.value = 'a'
+    keydown(h.textarea, { key: 'a', keyCode: 65 })
+    wkKeystroke(h, 'insertReplacementText', '안', [0, 1], '안')
+
+    expect(applyToLine(h.sent)).toBe('안')
+  })
+
+  it('erases every character a multi-character replacement supersedes', () => {
+    const h = createHarness()
+
+    // Japanese and Chinese refine a whole reading rather than one syllable, so
+    // a replacement can supersede several characters at once.
+    h.textarea.value = 'こんにち'
+    wkKeystroke(h, 'insertReplacementText', 'こんにちは', [0, 4], 'こんにちは')
+
+    expect(h.sent).toEqual(['\x7F\x7F\x7F\x7Fこんにちは'])
+    expect(applyToLine(['こんにち', ...h.sent])).toBe('こんにちは')
+  })
+
+  it('does not carry a measurement over to a later event', async () => {
+    const h = createHarness()
+
+    // A beforeinput whose input event never arrives — something cancelled it,
+    // or the engine skipped it — must not leave its measurement behind. An
+    // input event that then arrives on its own would otherwise erase three
+    // characters the user never asked to lose.
+    h.textarea.value = 'abc'
+    h.textarea.setSelectionRange(0, 3)
+    h.textarea.dispatchEvent(new InputEvent('beforeinput', {
+      data: 'x',
+      inputType: 'insertText',
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+    }))
+    // The measurement is only good for the input event of the same task.
+    await Promise.resolve()
+
+    h.textarea.value = 'abc'
+    h.textarea.setSelectionRange(3, 3)
+    h.textarea.dispatchEvent(new InputEvent('input', {
+      data: '안',
+      inputType: 'insertText',
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+    }))
+
+    expect(h.sent).toEqual(['안'])
+  })
+
+  it('counts a replaced surrogate pair as one character', () => {
+    const h = createHarness()
+
+    // An emoji is two UTF-16 units but one character, and the terminal erases
+    // by character.
+    h.textarea.value = '😀'
+    wkKeystroke(h, 'insertReplacementText', 'x', [0, 2], 'x')
+
+    expect(h.sent).toEqual(['\x7Fx'])
+  })
+
+  it('keeps composed input away from xterm entirely', () => {
+    const h = createHarness()
+
+    chromiumCompose(h, ['ㅇ', '아', '안'], { start: true })
+    composition(h.textarea, 'compositionend', '안')
+
+    // xterm's own CompositionHelper is the thing being replaced. If any of its
+    // handlers still ran, the syllable would be emitted a second time here.
+    expect(h.fromXterm).toEqual([])
+    expect(h.sent).toEqual(['안'])
+  })
+
+  it('sends nothing when the composition is cancelled', () => {
+    const h = createHarness()
+
+    composition(h.textarea, 'compositionstart', '')
+    composition(h.textarea, 'compositionupdate', 'ㅇ')
+    input(h.textarea, 'insertCompositionText', 'ㅇ', true)
+    input(h.textarea, 'deleteCompositionText', null, true)
+    composition(h.textarea, 'compositionend', '')
+
+    expect(h.sent).toEqual([])
+    expect(h.fromXterm).toEqual([])
+  })
+
+  it('suppresses the keypress WebKit echoes after a commit', () => {
+    const h = createHarness()
+
+    // The trace from xtermjs/xterm.js#5894: WebKit retracts the composing text,
+    // re-inserts it as a commit, ends the composition, and then fires a
+    // synthetic keypress whose charCode is the character it just committed.
+    composition(h.textarea, 'compositionstart', '')
+    composition(h.textarea, 'compositionupdate', '안')
+    input(h.textarea, 'insertCompositionText', '안', true)
+    input(h.textarea, 'deleteCompositionText', null, true)
+    input(h.textarea, 'insertFromComposition', '안', true)
+    composition(h.textarea, 'compositionend', '안')
+
+    const echo = new KeyboardEvent('keypress', { charCode: '안'.charCodeAt(0) } as KeyboardEventInit)
+    expect(h.ime.shouldBypassKeyEvent(echo)).toBe(true)
+
+    // Only the commit reached the PTY -- not the echo, and nothing from xterm.
+    expect(h.sent).toEqual(['안'])
+    expect(h.fromXterm).toEqual([])
+  })
+
+  it('does not swallow a real keystroke typed after the commit', () => {
+    const h = createHarness()
+
+    // WebKit's echo arrives with no keydown between it and the commit. A
+    // capital the user actually types later does have one, and must survive
+    // even when the composition happened to contain the same character.
+    composition(h.textarea, 'compositionstart', '')
+    composition(h.textarea, 'compositionend', 'C')
+    keydown(h.textarea, { key: 'C', keyCode: 67 })
+
+    expect(h.ime.shouldBypassKeyEvent(
+      new KeyboardEvent('keypress', { charCode: 67 } as KeyboardEventInit),
+    )).toBe(false)
+  })
+
+  it('suppresses the echoed keypress only once', () => {
+    const h = createHarness()
+
+    composition(h.textarea, 'compositionstart', '')
+    composition(h.textarea, 'compositionupdate', 'a')
+    composition(h.textarea, 'compositionend', 'a')
+
+    const first = new KeyboardEvent('keypress', { charCode: 97 } as KeyboardEventInit)
+    expect(h.ime.shouldBypassKeyEvent(first)).toBe(true)
+    // A genuine keystroke of the same character right afterwards must survive.
+    const second = new KeyboardEvent('keypress', { charCode: 97 } as KeyboardEventInit)
+    expect(h.ime.shouldBypassKeyEvent(second)).toBe(false)
+  })
+
+  it('keeps the keystroke that follows a commit, which xterm drops', () => {
+    const h = createHarness()
+
+    composition(h.textarea, 'compositionstart', '')
+    composition(h.textarea, 'compositionupdate', '~')
+    composition(h.textarea, 'compositionend', '~')
+    // WebKit reports this keydown with a two-character `key`, so xterm's
+    // printable check rejects it and its `_inputEvent` guard drops the insert.
+    keydown(h.textarea, { key: '~/' })
+    input(h.textarea, 'insertText', '/')
+
+    expect(h.sent).toEqual(['~', '/'])
+  })
+
+  it('leaves ordinary typing on xterm own key path', () => {
+    const h = createHarness()
+
+    // xterm handles a plain printable key in keydown and calls preventDefault,
+    // which is how this module knows the bytes already went out.
+    keydown(h.textarea, { key: 'a', keyCode: 65 })
+    // A browser would not fire this after a prevented keydown; dispatching it
+    // anyway proves the module does not double-send if one arrives.
+    input(h.textarea, 'insertText', 'a')
+
+    expect(h.fromXterm).toEqual(['a'])
+    expect(h.sent).toEqual([])
+  })
+
+  it('leaves capital letters to xterm, which defers them to keypress', () => {
+    const h = createHarness()
+
+    // xterm deliberately does NOT preventDefault a keydown for A-Z: it defers
+    // those to `keypress` so lower-case letters still work under an input
+    // method with caps lock on. The browser therefore delivers a real `input`
+    // event for a capital, and claiming it doubles every one the user types --
+    // `CANCELLED` arriving as `CCAANNCCEELLLLEEDD`.
+    keydown(h.textarea, { key: 'C', keyCode: 67 })
+    h.textarea.dispatchEvent(new KeyboardEvent('keypress', {
+      charCode: 67,
+      bubbles: true,
+      cancelable: true,
+    } as KeyboardEventInit))
+    input(h.textarea, 'insertText', 'C')
+
+    expect(h.fromXterm).toEqual(['C'])
+    expect(h.sent).toEqual([])
+  })
+
+  it('leaves paste to xterm own paste handler', () => {
+    const h = createHarness()
+
+    // xterm binds `paste` on the textarea and writes the clipboard itself.
+    // Claiming the input event that follows would send every paste twice, and
+    // there is no keystroke in flight to tell the two apart.
+    input(h.textarea, 'insertFromPaste', 'pasted text')
+
+    expect(h.sent).toEqual([])
+  })
+
+  it('leaves editing input types alone', () => {
+    const h = createHarness()
+
+    // Backspace and friends reach the PTY through xterm's key path as control
+    // bytes. Forwarding the matching input event would send them a second time
+    // as text.
+    input(h.textarea, 'deleteContentBackward', null)
+    input(h.textarea, 'insertLineBreak', null)
+
+    expect(h.sent).toEqual([])
+  })
+
+  it('claims insertText that arrives with no keystroke in flight', () => {
+    const h = createHarness()
+
+    // A candidate committed by clicking the input method's popup: there is no
+    // key event at all, and xterm's `_inputEvent` drops it.
+    input(h.textarea, 'insertText', '안')
+
+    expect(h.sent).toEqual(['안'])
+  })
+
+  it('forgets a keystroke that ends without a keyup', () => {
+    const h = createHarness()
+
+    keydown(h.textarea, { key: 'C', keyCode: 67 })
+    // Focus leaves mid-keystroke, so no keyup ever arrives. A keydown left
+    // standing would make the next mouse-committed candidate look like xterm's.
+    h.textarea.dispatchEvent(new FocusEvent('blur'))
+    input(h.textarea, 'insertText', '안')
+
+    expect(h.sent).toEqual(['안'])
+  })
+
+  it('bypasses xterm key path for IME keydowns on both engines', () => {
+    const h = createHarness()
+
+    // Chromium marks the keystroke with the legacy 229 code.
+    expect(h.ime.shouldBypassKeyEvent(
+      new KeyboardEvent('keydown', { key: 'Process', keyCode: 229 } as KeyboardEventInit),
+    )).toBe(true)
+    // WebKit can report the real key while a composition is running.
+    expect(h.ime.shouldBypassKeyEvent(
+      new KeyboardEvent('keydown', { key: 'd', isComposing: true } as KeyboardEventInit),
+    )).toBe(true)
+    // Everything else stays xterm's.
+    expect(h.ime.shouldBypassKeyEvent(
+      new KeyboardEvent('keydown', { key: 'd', keyCode: 68 }),
+    )).toBe(false)
+    expect(h.ime.shouldBypassKeyEvent(
+      new KeyboardEvent('keyup', { key: 'd', keyCode: 68 }),
+    )).toBe(false)
+  })
+
+  it('stops xterm sending the raw key of a composed keystroke', () => {
+    const h = createHarness()
+
+    // The case the bypass exists for: WebKit reports a real keyCode during
+    // composition, so without it xterm would send the Latin letter the input
+    // method consumed.
+    composition(h.textarea, 'compositionstart', '')
+    keydown(h.textarea, { key: 'd', keyCode: 68, isComposing: true })
+
+    expect(h.fromXterm).toEqual([])
+    expect(h.sent).toEqual([])
+  })
+
+  it('shows the composing text and hides it on commit', () => {
+    const h = createHarness()
+    const preview = () => h.container.querySelector<HTMLElement>('[data-testid="terminal-composition-preview"]')!
+
+    expect(preview().textContent).toBe('')
+
+    composition(h.textarea, 'compositionstart', '')
+    composition(h.textarea, 'compositionupdate', '안')
+    expect(preview().textContent).toBe('안')
+    expect(preview().className).toContain('Active')
+
+    composition(h.textarea, 'compositionend', '안')
+    expect(preview().textContent).toBe('')
+    expect(preview().className).not.toContain('Active')
+  })
+
+  it('places the preview on the cursor and in the terminal colors', () => {
+    const h = createHarness()
+    const preview = () => h.container.querySelector<HTMLElement>('[data-testid="terminal-composition-preview"]')!
+
+    // xterm parks its helper textarea on the cursor, and the preview borrows
+    // that box rather than measuring cells itself.
+    h.textarea.style.left = '48px'
+    h.textarea.style.top = '17px'
+    h.textarea.style.height = '19px'
+    // One token, so the assertion below is not really testing how the CSSOM
+    // quotes a family name that contains a space.
+    h.terminal.options.fontFamily = 'TestMono'
+    h.terminal.options.fontSize = 15
+    h.terminal.options.theme = { background: '#101010', foreground: '#f0f0f0' }
+
+    composition(h.textarea, 'compositionstart', '')
+    composition(h.textarea, 'compositionupdate', '안')
+
+    expect(preview().style.left).toBe('48px')
+    expect(preview().style.top).toBe('17px')
+    expect(preview().style.height).toBe('19px')
+    expect(preview().style.fontFamily).toBe('TestMono')
+    expect(preview().style.fontSize).toBe('15px')
+    // Inverted, so the pending text reads as marked rather than as shell output.
+    expect(preview().style.backgroundColor).toBe('rgb(240, 240, 240)')
+    expect(preview().style.color).toBe('rgb(16, 16, 16)')
+  })
+
+  it('tracks composing across the composition', () => {
+    const h = createHarness()
+
+    expect(h.ime.composing).toBe(false)
+    composition(h.textarea, 'compositionstart', '')
+    expect(h.ime.composing).toBe(true)
+    composition(h.textarea, 'compositionend', '안')
+    expect(h.ime.composing).toBe(false)
+  })
+
+  it('drops a keypress that arrives mid-composition', () => {
+    const h = createHarness()
+
+    composition(h.textarea, 'compositionstart', '')
+    expect(h.ime.shouldBypassKeyEvent(
+      new KeyboardEvent('keypress', { charCode: 100 } as KeyboardEventInit),
+    )).toBe(true)
+  })
+
+  it('releases its listeners and its preview on dispose', () => {
+    const h = createHarness()
+    const selector = '[data-testid="terminal-composition-preview"]'
+    expect(h.container.querySelector(selector)).not.toBeNull()
+
+    h.ime.dispose()
+    expect(h.container.querySelector(selector)).toBeNull()
+
+    // With the layer gone the events belong to xterm again, so nothing more
+    // reaches our sink.
+    const before = h.sent.length
+    composition(h.textarea, 'compositionstart', '')
+    composition(h.textarea, 'compositionend', '안')
+    expect(h.sent.length).toBe(before)
+
+    // dispose() must be safe to call twice -- the instance teardown in
+    // ~/lib/terminal calls it, and so does the afterEach here.
+    expect(() => h.ime.dispose()).not.toThrow()
+  })
+
+  it('refuses to attach to a terminal that was never opened', () => {
+    const terminal = new Terminal()
+    expect(() => attachTerminalIme(terminal, () => {})).toThrow(/terminal\.open/)
+    terminal.dispose()
+  })
+})

--- a/frontend/src/lib/terminalIme.ts
+++ b/frontend/src/lib/terminalIme.ts
@@ -1,4 +1,5 @@
 import type { Terminal } from '@xterm/xterm'
+import { ERASE_CHARACTER } from './terminal'
 import * as styles from './terminalIme.css'
 
 /**
@@ -8,10 +9,10 @@ import * as styles from './terminalIme.css'
  * diffing substrings of its hidden helper textarea across `setTimeout(0)`
  * boundaries (`CompositionHelper._finalizeComposition`), which assumes an event
  * order and a textarea value that only Chromium actually provides. Measured:
- * Chromium composes `안녕` correctly, WebKit does not. On WebKit a commit is
- * followed by a synthetic `keypress` carrying the COMMITTED character, so xterm
- * emits it a second time from `_keyPress`, and the keystroke after the commit is
- * then dropped by the `_keyDownSeen` guard in `_inputEvent`
+ * Chromium composes `안녕` correctly, WebKit does not. WebKit follows each
+ * commit with a synthetic `keypress` that carries the COMMITTED character, so
+ * xterm emits it a second time from `_keyPress`, and the keystroke after the
+ * commit is then dropped by the `_keyDownSeen` guard in `_inputEvent`
  * (xtermjs/xterm.js#5894). Korean commits once per syllable, so the damage
  * repeats for every syllable and only stray jamo survive.
  *
@@ -35,8 +36,6 @@ import * as styles from './terminalIme.css'
  * IME candidate window therefore lands in the right place with no work here.
  */
 export interface TerminalImeHandle {
-  /** True while a composition is active. */
-  readonly composing: boolean
   /**
    * Whether xterm must not process this key event. Pass every event that
    * `attachCustomKeyEventHandler` receives; return `false` from that handler
@@ -47,7 +46,7 @@ export interface TerminalImeHandle {
 }
 
 /**
- * `inputType` values a browser reports while it is editing composed text. Every
+ * `inputType` values a browser reports while it edits composed text. Every
  * one of them is the composition's business, so xterm must not see any of them.
  * `insertFromComposition` and `deleteByComposition` are WebKit's; Chromium uses
  * `insertCompositionText` throughout and `deleteCompositionText` to retract.
@@ -83,112 +82,38 @@ const TEXT_INSERTING_INPUT_TYPES = new Set([
   'insertReplacementText',
 ])
 
-/**
- * What the terminal sends to erase one character, matching the byte xterm
- * itself sends for Backspace. A replacement has to retract the text it
- * supersedes before the new text goes out.
- */
-const ERASE_CHARACTER = '\x7F'
-
 /** The legacy `keyCode` a browser reports for a keystroke an IME consumed. */
 const KEY_CODE_IME_PROCESS = 229
 
-export function attachTerminalIme(
+/**
+ * The in-progress composition preview: the text the user is currently
+ * composing, painted over the cell the cursor sits on.
+ *
+ * Only layout lives in the stylesheet. The font and the colors are written as
+ * inline styles on every `show`, because they must follow the live xterm
+ * options and the helper textarea's box, both of which can change while a
+ * composition is open (the cursor moves as output arrives; the user can
+ * change the theme from the settings panel).
+ */
+function createCompositionPreview(
+  helpers: HTMLElement,
+  textarea: HTMLTextAreaElement,
   terminal: Terminal,
-  send: (text: string) => void,
-): TerminalImeHandle {
-  const root = terminal.element
-  const textarea = terminal.textarea
-  if (!root || !textarea) {
-    // Failing loudly beats attaching nothing: a silent no-op would leave CJK
-    // input broken with no sign that the layer never came up.
-    throw new Error('attachTerminalIme requires an opened terminal (call terminal.open first)')
-  }
-  // xterm builds `.xterm-helpers` as `position: absolute`, so it is the
-  // containing block for both the helper textarea and the preview below. That
-  // is what lets the preview borrow the textarea's own offsets verbatim.
-  const helpers = textarea.parentElement ?? root
-
-  let composing = false
-  /**
-   * The text the last `compositionend` committed, held only long enough to
-   * recognize WebKit's synthetic echo of it. See `shouldBypassKeyEvent`.
-   */
-  let lastCommit = ''
-  /**
-   * The keystroke currently in flight, or null between keyup and the next
-   * keydown. `onInput` uses it to decide whether an `insertText` belongs to
-   * xterm or to us; see `xtermOwnsKeystroke`.
-   */
-  let activeKeydown: { keyLength: number, prevented: boolean, imeConsumed: boolean } | null = null
-
-  /**
-   * How many characters the next `input` event replaces, counted at
-   * `beforeinput` time. It has to be read then: the selection still covers the
-   * range about to be replaced, and by the `input` event it has collapsed.
-   */
-  let replacedByNextInput = 0
-
-  /** Characters, not UTF-16 units, so a surrogate pair counts once. */
-  const selectedCharacterCount = (): number => {
-    const start = textarea.selectionStart ?? 0
-    const end = textarea.selectionEnd ?? start
-    if (end <= start)
-      return 0
-    return [...textarea.value.slice(start, end)].length
-  }
-
-  /**
-   * Whether xterm's own key path produces the bytes for the keystroke in
-   * flight, which means the `input` event that follows must be left alone.
-   *
-   * There are three shapes, and the middle one is easy to get wrong:
-   *
-   * - xterm handled the key in keydown. It calls `preventDefault()` whenever it
-   *   turns a key into terminal input, and the browser then fires no `input`
-   *   event at all.
-   * - xterm DEFERRED the key to `keypress`. It does this for A-Z, deliberately
-   *   and without preventing the keydown, to keep lower-case letters working
-   *   under an input method while caps lock is on. The browser therefore does
-   *   fire an `input` event, and treating that as unclaimed doubles every
-   *   capital letter the user types.
-   * - xterm produced nothing. Its printable check requires a single-character
-   *   `key`, so a keydown reporting something longer that it did not prevent is
-   *   one it cannot turn into input. WebKit reports exactly that for the key
-   *   after a cancelled dead key (`key === "~/"`), and the character is lost
-   *   today because xterm's own `_inputEvent` guard drops it too.
-   *
-   * With no keystroke in flight the text came from somewhere else entirely — a
-   * candidate committed by mouse click — and is ours.
-   *
-   * A keystroke the input method consumed is never xterm's, whatever it looks
-   * like: this module already held it back from xterm's key path. That case
-   * needs its own arm because WKWebView delivers the keydown AFTER the input
-   * event it produced, so a fast typist can leave the PREVIOUS keystroke still
-   * recorded here when the next one's text arrives.
-   */
-  const xtermOwnsKeystroke = (): boolean => {
-    if (activeKeydown === null || activeKeydown.imeConsumed)
-      return false
-    return activeKeydown.prevented || activeKeydown.keyLength === 1
-  }
-
+): { show: (text: string) => void, hide: () => void, dispose: () => void } {
   const preview = document.createElement('div')
   preview.className = styles.compositionPreview
-  // The composed text is already announced by the input method itself, and the
+  // The input method itself already announces the composed text, and the
   // preview duplicates the textarea's own value, so hide it from assistive
   // technology rather than reading it out twice.
   preview.setAttribute('aria-hidden', 'true')
   preview.dataset.testid = 'terminal-composition-preview'
   helpers.appendChild(preview)
 
-  // Arrow functions, not declarations: a hoisted `function` loses the narrowing
-  // that the guard above established on `textarea`.
-  const showPreview = (text: string): void => {
+  const show = (text: string): void => {
     preview.textContent = text
     // Borrow the textarea's box. xterm's `_syncTextArea()` parks it on the
-    // cursor on every cursor move, and it keeps doing so because our
-    // interception leaves xterm's `isComposing` false.
+    // cursor on every cursor move, and it keeps doing so because the
+    // interception in this module leaves xterm's `isComposing` false.
     preview.style.left = textarea.style.left
     preview.style.top = textarea.style.top
     preview.style.height = textarea.style.height
@@ -203,10 +128,216 @@ export function attachTerminalIme(
     preview.classList.add(styles.compositionPreviewActive)
   }
 
-  const hidePreview = (): void => {
+  const hide = (): void => {
     preview.classList.remove(styles.compositionPreviewActive)
     preview.textContent = ''
   }
+
+  return {
+    show,
+    hide,
+    dispose: () => preview.remove(),
+  }
+}
+
+/**
+ * The keystroke-ownership tracker: what xterm's own key path emitted for the
+ * keystroke in flight, and whether a given inserted text is that emission's
+ * echo. Extracted from `attachTerminalIme` (as `createCompositionPreview`
+ * was) so the emission machine — record, consume, expire — has one boundary
+ * a test can target.
+ *
+ * `onPlainKeydown` fires for every keystroke the input method did NOT
+ * consume. The caller owns the echo-suppression window and closes it there:
+ * a genuine capital typed some time after a composition that contained the
+ * same character must survive.
+ */
+function createKeystrokeOwnership(
+  terminal: Terminal,
+  onPlainKeydown: () => void,
+): {
+  /** Bind on the textarea, capture phase, registered after xterm's own keydown listener. */
+  onKeyDownAfterXterm: (event: Event) => void
+  /** Bind on the textarea, capture phase, on keyup and blur. */
+  onKeystrokeEnd: () => void
+  /**
+   * Whether xterm's own key path already produced the bytes for this text —
+   * and if it did, consume the emission that proves it, so one emission can
+   * never answer for two input events.
+   *
+   * The decision reads the OBSERVED emissions — what xterm's `onData` sent
+   * for the keystroke in flight, one entry per emission — and matches
+   * EXACTLY: a genuine echo inserts exactly the text one emission carried, so
+   * 'C' is an echo only when an emission was 'C', never because an arrow's
+   * '\x1b[C' merely contains it. Caps-lock case folding needs no arm of its
+   * own, because the emission carries the character xterm actually sent;
+   * deferred A–Z rollover (two capitals' keypresses before either input
+   * event) works because each keypress contributes its own entry.
+   *
+   * - xterm handled the key, in keydown or in the `keypress` it defers A-Z
+   *   to, and sent the bytes: the matching emission is xterm's echo, and the
+   *   input event that follows must be left alone.
+   * - No emission matches: a dead key's precomposed character, a jamo the
+   *   input method inserted while a previous keystroke is still in flight, a
+   *   candidate committed from a popup, a Latin character inside a control
+   *   sequence an arrow key emitted, or a deferred key whose keypress never
+   *   ran. The text is ours, and xterm's own `_inputEvent` guard would have
+   *   dropped it.
+   *
+   * A keystroke the input method consumed is never xterm's by construction —
+   * the caller bypassed xterm's key path for it — and WKWebView's reversed
+   * order (keydown AFTER the input event) needs no arm either: the stale
+   * keystroke's emission simply does not match the new text.
+   *
+   * One shape stays ambiguous for any observer: an input method that commits
+   * EXACTLY the text xterm emitted for a keystroke still in flight. No
+   * recorded engine trace shows it, and distinguishing it from the genuine
+   * echo of that keystroke is impossible from the DOM alone.
+   */
+  consumeXtermEcho: (text: string) => boolean
+  dispose: () => void
+} {
+  /**
+   * The keystroke currently in flight, or null between keyup and the next
+   * keydown. `consumeXtermEcho` reads it: an input method that consumed the
+   * keystroke never left xterm's key path an emission to answer for.
+   */
+  let activeKeydown: { imeConsumed: boolean } | null = null
+
+  /**
+   * What xterm's own key path actually sent (`onData`) since the keystroke in
+   * flight began, one entry per emission. Cleared when the keystroke ends
+   * (keyup, blur), so an emission can never be attributed to a later text
+   * insertion, and consumed by the echo it answers.
+   */
+  const emissionsInFlight: string[] = []
+
+  const consumeXtermEcho = (text: string): boolean => {
+    if (activeKeydown === null || activeKeydown.imeConsumed)
+      return false
+    const match = emissionsInFlight.indexOf(text)
+    if (match === -1)
+      return false
+    emissionsInFlight.splice(match, 1)
+    return true
+  }
+
+  // Record what xterm actually emits for the keystroke in flight. `onData`
+  // fires synchronously inside xterm's keydown/keypress handlers, before the
+  // browser dispatches the input event of the same keystroke — which is what
+  // makes the observed emission a sound basis for the decision above.
+  const dataSubscription = terminal.onData((data) => {
+    emissionsInFlight.push(data)
+  })
+
+  const onKeyDownAfterXterm = (event: Event): void => {
+    const keyEvent = event as KeyboardEvent
+    activeKeydown = {
+      imeConsumed: keyEvent.isComposing || keyEvent.keyCode === KEY_CODE_IME_PROCESS,
+    }
+    // A keystroke the input method consumed keeps the echo window open,
+    // because WKWebView delivers that keydown AFTER the compositionend it
+    // belongs to, and the echo that follows must still be recognized.
+    if (!activeKeydown.imeConsumed)
+      onPlainKeydown()
+  }
+
+  const onKeystrokeEnd = (): void => {
+    activeKeydown = null
+    // The emissions belong to the keystroke that produced them; once the
+    // keystroke ends, no later text insertion may claim to be its echo.
+    emissionsInFlight.length = 0
+  }
+
+  return {
+    onKeyDownAfterXterm,
+    onKeystrokeEnd,
+    consumeXtermEcho,
+    dispose: () => dataSubscription.dispose(),
+  }
+}
+
+export function attachTerminalIme(terminal: Terminal, send: (text: string) => void): TerminalImeHandle {
+  const root = terminal.element
+  const textarea = terminal.textarea
+  if (!root || !textarea) {
+    // Failing loudly beats attaching nothing: a silent no-op would leave CJK
+    // input broken with no sign that the layer never came up.
+    throw new Error('attachTerminalIme requires an opened terminal (call terminal.open first)')
+  }
+  // xterm builds `.xterm-helpers` as `position: absolute`, so it is the
+  // containing block for both the helper textarea and the preview below. That
+  // is what lets the preview borrow the textarea's own offsets verbatim. No
+  // fallback: a detached parent means the DOM shape changed, and a silently
+  // re-parented preview would position against the wrong containing block —
+  // fail loudly, like the guard above.
+  const helpers = textarea.parentElement
+  if (!helpers) {
+    throw new Error('attachTerminalIme requires the terminal textarea to be attached (xterm builds .xterm-helpers in open())')
+  }
+
+  let composing = false
+  /**
+   * The text the last `compositionend` committed, held only long enough to
+   * recognize WebKit's synthetic echo of it. See `shouldBypassKeyEvent`.
+   */
+  let lastCommit = ''
+
+  /**
+   * The edit that the next `input` event applies, measured at `beforeinput`
+   * time and PAIRED to the event it was measured for: how many characters the
+   * event replaces, under the `inputType` and `data` of the `beforeinput` it
+   * belongs to. `onInput` consumes it only when the event that arrives matches
+   * the pair, so a measurement can never apply itself to a later, unrelated
+   * event. The range has to be measured at `beforeinput` time because the
+   * selection still covers it then; by the `input` event it collapses.
+   */
+  let pendingEdit: { replaced: number, inputType: string, data: string | null } | null = null
+
+  /** Characters, not UTF-16 units, so a surrogate pair counts once. */
+  const codePointCount = (text: string): number => [...text].length
+
+  const selectedCharacterCount = (): number => {
+    const start = textarea.selectionStart ?? 0
+    const end = textarea.selectionEnd ?? start
+    if (end <= start)
+      return 0
+    return codePointCount(textarea.value.slice(start, end))
+  }
+
+  /**
+   * How many characters the edit behind this `beforeinput` replaces.
+   *
+   * `event.getTargetRanges()` is the engine's own statement of the replaced
+   * ranges, and it stays correct when the live selection has already collapsed
+   * or never covered the range. For a textarea the ranges' containers are the
+   * element itself and the offsets index its value. An engine that supplies no
+   * ranges, or a shape this module cannot interpret, falls back to the live
+   * selection, which still covers the replaced range in every recorded trace.
+   */
+  const replacedCharacterCount = (event: InputEvent): number => {
+    const ranges = typeof event.getTargetRanges === 'function' ? event.getTargetRanges() : []
+    if (ranges.length === 0)
+      return selectedCharacterCount()
+    let total = 0
+    for (const range of ranges) {
+      if (range.startContainer !== textarea || range.endContainer !== textarea)
+        return selectedCharacterCount()
+      total += codePointCount(textarea.value.slice(range.startOffset, range.endOffset))
+    }
+    return total
+  }
+
+  const preview = createCompositionPreview(helpers, textarea, terminal)
+
+  // The keystroke-ownership machine (what xterm emitted for the keystroke in
+  // flight, and which inserted text is that emission's echo). The plain-keydown
+  // callback closes the echo-suppression window below: a keystroke the input
+  // method did not consume ends the window in which WebKit's synthetic echo of
+  // a previous commit can still appear.
+  const ownership = createKeystrokeOwnership(terminal, () => {
+    lastCommit = ''
+  })
 
   const isCompositionInput = (event: InputEvent): boolean =>
     composing
@@ -217,18 +348,18 @@ export function attachTerminalIme(
     event.stopPropagation()
     composing = true
     lastCommit = ''
-    showPreview('')
+    preview.show('')
   }
 
   const onCompositionUpdate = (event: Event): void => {
     event.stopPropagation()
-    showPreview((event as CompositionEvent).data ?? '')
+    preview.show((event as CompositionEvent).data ?? '')
   }
 
   const onCompositionEnd = (event: Event): void => {
     event.stopPropagation()
     composing = false
-    hidePreview()
+    preview.hide()
     const data = (event as CompositionEvent).data ?? ''
     // An empty commit is a cancelled composition (Escape, or a candidate window
     // dismissed). Sending it would put a stray empty write on the wire.
@@ -236,30 +367,36 @@ export function attachTerminalIme(
       lastCommit = data
       send(data)
     }
-    // The textarea's value is deliberately left alone. Nothing here reads it,
-    // and xterm already clears it on Enter, on Ctrl+C, and on blur, which bounds
-    // its growth exactly as it does today. Clearing it inside this handler would
-    // reach into the editor while the browser is still finalizing the commit.
+    // This module deliberately leaves the textarea's value alone. Nothing here
+    // reads it for the commit path, and xterm already clears it on Enter, on
+    // Ctrl+C, and on blur, which limits its growth exactly as it does today.
+    // Clearing it inside this handler would reach into the editor while the
+    // browser still finalizes the commit.
   }
 
   const onBeforeInput = (event: Event): void => {
     const inputEvent = event as InputEvent
     const composed = isCompositionInput(inputEvent)
     // Measure the range this event is about to replace while the selection
-    // still covers it; by the `input` event it has collapsed. Written on EVERY
-    // beforeinput, composition included, so a measurement can never outlive the
-    // event it was taken for and apply itself to a later one.
-    replacedByNextInput = composed ? 0 : selectedCharacterCount()
-    // A browser dispatches beforeinput and the input event it precedes in one
-    // task, so a measurement that survives into the next one belongs to an edit
-    // that never happened — a cancelled beforeinput, or an engine that skipped
-    // it. Dropping it there stops those erase bytes from landing on an
-    // unrelated input event and eating text the user meant to keep.
-    queueMicrotask(() => {
-      replacedByNextInput = 0
-    })
-    if (composed)
+    // still covers it; by the `input` event it collapses. The measurement is
+    // PAIRED to the event it was measured for, and `onInput` consumes it only
+    // when the event that arrives matches the pair. A timing-based reset
+    // cannot replace the pairing: a real browser runs a microtask checkpoint
+    // after the `beforeinput` listener returns — the JS stack is empty between
+    // the two dispatches — so a microtask reset would clear the measurement
+    // before its own `input` event reads it, and the erase half of every
+    // replacement would silently never fire outside jsdom.
+    if (composed) {
+      pendingEdit = null
       event.stopPropagation()
+    }
+    else {
+      pendingEdit = {
+        replaced: replacedCharacterCount(inputEvent),
+        inputType: inputEvent.inputType ?? '',
+        data: inputEvent.data,
+      }
+    }
   }
 
   const onInput = (event: Event): void => {
@@ -268,8 +405,17 @@ export function attachTerminalIme(
       event.stopPropagation()
       return
     }
-    const replaced = replacedByNextInput
-    replacedByNextInput = 0
+    // Consume the measurement only when this event is the one it was measured
+    // for. A `beforeinput` whose `input` event never arrived — something
+    // cancelled it, or an engine skipped it — leaves its pair behind, and the
+    // next `beforeinput` overwrites it; either way, a stray erase count cannot
+    // land on an unrelated event and eat text the user meant to keep.
+    const replaced = pendingEdit !== null
+      && pendingEdit.inputType === inputEvent.inputType
+      && pendingEdit.data === inputEvent.data
+      ? pendingEdit.replaced
+      : 0
+    pendingEdit = null
 
     // Text that arrived without xterm's key path producing it. xterm drops all
     // of it — its `_inputEvent` bails whenever a keydown is in flight — so it
@@ -277,38 +423,27 @@ export function attachTerminalIme(
     //
     // The ownership question only arises for `insertText`, the one type xterm
     // looks at. A replacement is always ours: xterm has no branch for it, so
-    // deferring one to xterm drops it on the floor.
+    // deferring one to xterm discards it.
     const claimable = inputEvent.inputType != null
       && TEXT_INSERTING_INPUT_TYPES.has(inputEvent.inputType)
-      && (inputEvent.inputType !== 'insertText' || !xtermOwnsKeystroke())
+      && (inputEvent.inputType !== 'insertText' || !ownership.consumeXtermEcho(inputEvent.data ?? ''))
     if (claimable && inputEvent.data) {
       // Retract what this event supersedes before the new text goes out, so a
       // WKWebView replacement lands on the PTY as the edit it actually is.
       // Both halves go out in ONE send: the terminal's input queue must never
       // interleave another keystroke between the erase and its replacement.
+      //
+      // The count comes from the engine's textarea, which mirrors what the
+      // engine itself inserted. Line edits that go through xterm's key path
+      // (Ctrl+W, Ctrl+U) change the shell's line without changing the
+      // textarea, so a replacement after such an edit can erase more than the
+      // shell has at the cursor. No frontend layer can track the shell's true
+      // line state — completion and history redraw it from the PTY side — so
+      // the engine's own replaced range is the best available source.
       const payload = ERASE_CHARACTER.repeat(replaced) + inputEvent.data
       event.stopPropagation()
       send(payload)
     }
-  }
-
-  const onKeyDownAfterXterm = (event: Event): void => {
-    const keyEvent = event as KeyboardEvent
-    activeKeydown = {
-      keyLength: keyEvent.key?.length ?? 0,
-      prevented: keyEvent.defaultPrevented,
-      imeConsumed: keyEvent.isComposing || keyEvent.keyCode === KEY_CODE_IME_PROCESS,
-    }
-    // A fresh keystroke ends the window in which an echoed keypress can appear.
-    // In the WebKit trace the keydown comes BEFORE the compositionend, so this
-    // never clears the commit it has to recognize; what it does rule out is
-    // swallowing a genuine capital typed some time after a composition that
-    // happened to contain the same character.
-    lastCommit = ''
-  }
-
-  const onKeystrokeEnd = (): void => {
-    activeKeydown = null
   }
 
   root.addEventListener('compositionstart', onCompositionStart, true)
@@ -320,23 +455,48 @@ export function attachTerminalIme(
   // listener so it runs immediately after it and reads the `preventDefault()`
   // that xterm just left behind. Both details are load-bearing. xterm handles a
   // key by calling `cancel()`, which is `preventDefault()` plus
-  // `stopPropagation()`: a listener on an ancestor never runs at all, and a
-  // non-capture listener even on this same textarea is skipped too, because the
-  // target's bubble-phase dispatch is a separate pass that the stop-propagation
-  // flag suppresses. Same phase, same target, later registration is the one
+  // `stopPropagation()`. A listener on an ancestor therefore never runs at all.
+  // A non-capture listener on this same textarea is skipped too: the target's
+  // bubble-phase dispatch is a separate pass, and the stop-propagation flag
+  // suppresses it. Same phase, same target, later registration is the one
   // position that always runs.
-  textarea.addEventListener('keydown', onKeyDownAfterXterm, true)
-  // Close the keystroke out. Blur matters as well as keyup: focus can leave
-  // between the two, and a keydown left standing would make the next
-  // mouse-committed candidate look like it belonged to xterm.
-  textarea.addEventListener('keyup', onKeystrokeEnd, true)
-  textarea.addEventListener('blur', onKeystrokeEnd, true)
+  textarea.addEventListener('keydown', ownership.onKeyDownAfterXterm, true)
+  // Close the keystroke out — its keydown and its emission expire together.
+  // Blur matters as well as keyup: focus can leave between the two, and a
+  // keystroke left standing would make the next mouse-committed candidate
+  // look like it belonged to xterm.
+  textarea.addEventListener('keyup', ownership.onKeystrokeEnd, true)
+  textarea.addEventListener('blur', ownership.onKeystrokeEnd, true)
+
+  /**
+   * WebKit follows a commit with a synthetic keypress whose charCode is a
+   * character just committed (xtermjs/xterm.js#5894); `compositionend`
+   * already sent it. Consume one occurrence of the character per echo, so a
+   * multi-character commit that the engine echoes as one keypress per
+   * character suppresses every echo. A genuine keystroke of the same
+   * character is never swallowed: it is always preceded by its own keydown,
+   * and that clears the window (see `onKeyDownAfterXterm`).
+   */
+  const consumeEchoKeypress = (charCode: number): boolean => {
+    const ch = String.fromCharCode(charCode)
+    if (!lastCommit.includes(ch))
+      return false
+    lastCommit = lastCommit.replace(ch, '')
+    return true
+  }
+
+  /**
+   * A keypress whose charCode is half of a surrogate pair. No well-formed
+   * keystroke carries one — an astral character needs BOTH halves — and a
+   * lone surrogate cannot be encoded as UTF-8: the PTY would see U+FFFD. An
+   * engine whose astral echo count diverges from the per-unit bookkeeping
+   * above (a repeated or masked half) delivers exactly that, so suppress it
+   * unconditionally.
+   */
+  const isLoneSurrogate = (charCode: number): boolean =>
+    charCode >= 0xD800 && charCode <= 0xDFFF
 
   return {
-    get composing() {
-      return composing
-    },
-
     shouldBypassKeyEvent(event: KeyboardEvent): boolean {
       if (event.type === 'keydown') {
         // Hand every IME-consumed keystroke to the composition handlers above.
@@ -349,15 +509,10 @@ export function attachTerminalIme(
         // `_keyPress` would happily send the raw Latin key the IME consumed.
         if (composing)
           return true
-        // WebKit follows a commit with a synthetic keypress whose charCode is
-        // the character just committed (xtermjs/xterm.js#5894). `compositionend`
-        // already sent it. Suppress the echo once, then stop looking, so a
-        // genuine keystroke of the same character is never swallowed.
-        if (lastCommit.length > 0 && event.charCode > 0
-          && lastCommit.includes(String.fromCharCode(event.charCode))) {
-          lastCommit = ''
+        // Consumption first keeps `lastCommit` exact where the engine is
+        // exact; the surrogate guard is the net under divergence.
+        if (event.charCode > 0 && (consumeEchoKeypress(event.charCode) || isLoneSurrogate(event.charCode)))
           return true
-        }
       }
       return false
     },
@@ -368,10 +523,11 @@ export function attachTerminalIme(
       root.removeEventListener('compositionend', onCompositionEnd, true)
       root.removeEventListener('beforeinput', onBeforeInput, true)
       root.removeEventListener('input', onInput, true)
-      textarea.removeEventListener('keydown', onKeyDownAfterXterm, true)
-      textarea.removeEventListener('keyup', onKeystrokeEnd, true)
-      textarea.removeEventListener('blur', onKeystrokeEnd, true)
-      preview.remove()
+      textarea.removeEventListener('keydown', ownership.onKeyDownAfterXterm, true)
+      textarea.removeEventListener('keyup', ownership.onKeystrokeEnd, true)
+      textarea.removeEventListener('blur', ownership.onKeystrokeEnd, true)
+      ownership.dispose()
+      preview.dispose()
     },
   }
 }

--- a/frontend/src/lib/terminalIme.ts
+++ b/frontend/src/lib/terminalIme.ts
@@ -1,0 +1,377 @@
+import type { Terminal } from '@xterm/xterm'
+import * as styles from './terminalIme.css'
+
+/**
+ * LeapMux owns the terminal's text-input path for input methods (IME).
+ *
+ * xterm never reads `compositionend.data`. It rebuilds the committed text by
+ * diffing substrings of its hidden helper textarea across `setTimeout(0)`
+ * boundaries (`CompositionHelper._finalizeComposition`), which assumes an event
+ * order and a textarea value that only Chromium actually provides. Measured:
+ * Chromium composes `안녕` correctly, WebKit does not. On WebKit a commit is
+ * followed by a synthetic `keypress` carrying the COMMITTED character, so xterm
+ * emits it a second time from `_keyPress`, and the keystroke after the commit is
+ * then dropped by the `_keyDownSeen` guard in `_inputEvent`
+ * (xtermjs/xterm.js#5894). Korean commits once per syllable, so the damage
+ * repeats for every syllable and only stray jamo survive.
+ *
+ * This module takes the whole path instead of patching the arithmetic. It reads
+ * `compositionend.data`, which the UI Events specification defines as the final
+ * composed string, so it does not depend on the event order of any engine.
+ *
+ * It needs two things to be true, both verified against xterm 6.0.0:
+ *
+ * - `terminal.element` is an ANCESTOR of `terminal.textarea`
+ *   (`.xterm > .xterm-screen > .xterm-helpers > .xterm-helper-textarea`), and
+ *   xterm binds its composition handlers on the textarea itself. A capture-phase
+ *   listener on the ancestor therefore runs first and can stop the event before
+ *   xterm's `CompositionHelper` ever sees it.
+ * - `attachCustomKeyEventHandler` runs BEFORE `_compositionHelper.keydown()` in
+ *   `CoreBrowserTerminal._keyDown`, so returning `false` from it bypasses xterm's
+ *   composition machinery for a keystroke completely.
+ *
+ * With the composition events intercepted, xterm's `isComposing` stays `false`,
+ * so its `_syncTextArea()` keeps parking the helper textarea on the cursor. The
+ * IME candidate window therefore lands in the right place with no work here.
+ */
+export interface TerminalImeHandle {
+  /** True while a composition is active. */
+  readonly composing: boolean
+  /**
+   * Whether xterm must not process this key event. Pass every event that
+   * `attachCustomKeyEventHandler` receives; return `false` from that handler
+   * when this returns true.
+   */
+  shouldBypassKeyEvent: (event: KeyboardEvent) => boolean
+  dispose: () => void
+}
+
+/**
+ * `inputType` values a browser reports while it is editing composed text. Every
+ * one of them is the composition's business, so xterm must not see any of them.
+ * `insertFromComposition` and `deleteByComposition` are WebKit's; Chromium uses
+ * `insertCompositionText` throughout and `deleteCompositionText` to retract.
+ */
+const COMPOSITION_INPUT_TYPES = new Set([
+  'insertCompositionText',
+  'deleteCompositionText',
+  'insertFromComposition',
+  'deleteByComposition',
+])
+
+/**
+ * `inputType` values that put text into the textarea.
+ *
+ * `insertReplacementText` is how WKWebView drives an input method, and it is
+ * the whole reason CJK failed in the desktop app. Recorded there while typing
+ * `안녕`, with no composition event of any kind and `isComposing` false
+ * throughout:
+ *
+ *   insertText            "ㅇ"     value ""    -> "ㅇ"
+ *   insertReplacementText "아"     value "ㅇ"  -> "아"
+ *   insertReplacementText "안"     value "아"  -> "안"
+ *   insertText            "ㄴ"     value "안"  -> "안ㄴ"
+ *   insertReplacementText "녀"     value "안ㄴ" -> "안녀"
+ *   insertReplacementText "녕"     value "안녀" -> "안녕"
+ *
+ * WKWebView refines a syllable by REPLACING the text it already inserted. Treat
+ * a replacement as an insert and the terminal keeps only the two `insertText`
+ * jamo, `ㅇ` and `ㄴ` — exactly the reported symptom.
+ */
+const TEXT_INSERTING_INPUT_TYPES = new Set([
+  'insertText',
+  'insertReplacementText',
+])
+
+/**
+ * What the terminal sends to erase one character, matching the byte xterm
+ * itself sends for Backspace. A replacement has to retract the text it
+ * supersedes before the new text goes out.
+ */
+const ERASE_CHARACTER = '\x7F'
+
+/** The legacy `keyCode` a browser reports for a keystroke an IME consumed. */
+const KEY_CODE_IME_PROCESS = 229
+
+export function attachTerminalIme(
+  terminal: Terminal,
+  send: (text: string) => void,
+): TerminalImeHandle {
+  const root = terminal.element
+  const textarea = terminal.textarea
+  if (!root || !textarea) {
+    // Failing loudly beats attaching nothing: a silent no-op would leave CJK
+    // input broken with no sign that the layer never came up.
+    throw new Error('attachTerminalIme requires an opened terminal (call terminal.open first)')
+  }
+  // xterm builds `.xterm-helpers` as `position: absolute`, so it is the
+  // containing block for both the helper textarea and the preview below. That
+  // is what lets the preview borrow the textarea's own offsets verbatim.
+  const helpers = textarea.parentElement ?? root
+
+  let composing = false
+  /**
+   * The text the last `compositionend` committed, held only long enough to
+   * recognize WebKit's synthetic echo of it. See `shouldBypassKeyEvent`.
+   */
+  let lastCommit = ''
+  /**
+   * The keystroke currently in flight, or null between keyup and the next
+   * keydown. `onInput` uses it to decide whether an `insertText` belongs to
+   * xterm or to us; see `xtermOwnsKeystroke`.
+   */
+  let activeKeydown: { keyLength: number, prevented: boolean, imeConsumed: boolean } | null = null
+
+  /**
+   * How many characters the next `input` event replaces, counted at
+   * `beforeinput` time. It has to be read then: the selection still covers the
+   * range about to be replaced, and by the `input` event it has collapsed.
+   */
+  let replacedByNextInput = 0
+
+  /** Characters, not UTF-16 units, so a surrogate pair counts once. */
+  const selectedCharacterCount = (): number => {
+    const start = textarea.selectionStart ?? 0
+    const end = textarea.selectionEnd ?? start
+    if (end <= start)
+      return 0
+    return [...textarea.value.slice(start, end)].length
+  }
+
+  /**
+   * Whether xterm's own key path produces the bytes for the keystroke in
+   * flight, which means the `input` event that follows must be left alone.
+   *
+   * There are three shapes, and the middle one is easy to get wrong:
+   *
+   * - xterm handled the key in keydown. It calls `preventDefault()` whenever it
+   *   turns a key into terminal input, and the browser then fires no `input`
+   *   event at all.
+   * - xterm DEFERRED the key to `keypress`. It does this for A-Z, deliberately
+   *   and without preventing the keydown, to keep lower-case letters working
+   *   under an input method while caps lock is on. The browser therefore does
+   *   fire an `input` event, and treating that as unclaimed doubles every
+   *   capital letter the user types.
+   * - xterm produced nothing. Its printable check requires a single-character
+   *   `key`, so a keydown reporting something longer that it did not prevent is
+   *   one it cannot turn into input. WebKit reports exactly that for the key
+   *   after a cancelled dead key (`key === "~/"`), and the character is lost
+   *   today because xterm's own `_inputEvent` guard drops it too.
+   *
+   * With no keystroke in flight the text came from somewhere else entirely — a
+   * candidate committed by mouse click — and is ours.
+   *
+   * A keystroke the input method consumed is never xterm's, whatever it looks
+   * like: this module already held it back from xterm's key path. That case
+   * needs its own arm because WKWebView delivers the keydown AFTER the input
+   * event it produced, so a fast typist can leave the PREVIOUS keystroke still
+   * recorded here when the next one's text arrives.
+   */
+  const xtermOwnsKeystroke = (): boolean => {
+    if (activeKeydown === null || activeKeydown.imeConsumed)
+      return false
+    return activeKeydown.prevented || activeKeydown.keyLength === 1
+  }
+
+  const preview = document.createElement('div')
+  preview.className = styles.compositionPreview
+  // The composed text is already announced by the input method itself, and the
+  // preview duplicates the textarea's own value, so hide it from assistive
+  // technology rather than reading it out twice.
+  preview.setAttribute('aria-hidden', 'true')
+  preview.dataset.testid = 'terminal-composition-preview'
+  helpers.appendChild(preview)
+
+  // Arrow functions, not declarations: a hoisted `function` loses the narrowing
+  // that the guard above established on `textarea`.
+  const showPreview = (text: string): void => {
+    preview.textContent = text
+    // Borrow the textarea's box. xterm's `_syncTextArea()` parks it on the
+    // cursor on every cursor move, and it keeps doing so because our
+    // interception leaves xterm's `isComposing` false.
+    preview.style.left = textarea.style.left
+    preview.style.top = textarea.style.top
+    preview.style.height = textarea.style.height
+    preview.style.lineHeight = textarea.style.height
+    const options = terminal.options
+    preview.style.fontFamily = options.fontFamily ?? ''
+    preview.style.fontSize = options.fontSize != null ? `${options.fontSize}px` : ''
+    // Invert the terminal's own colors so the pending text reads as a marked
+    // region rather than as text the shell already echoed.
+    preview.style.backgroundColor = options.theme?.foreground ?? ''
+    preview.style.color = options.theme?.background ?? ''
+    preview.classList.add(styles.compositionPreviewActive)
+  }
+
+  const hidePreview = (): void => {
+    preview.classList.remove(styles.compositionPreviewActive)
+    preview.textContent = ''
+  }
+
+  const isCompositionInput = (event: InputEvent): boolean =>
+    composing
+    || event.isComposing
+    || (event.inputType != null && COMPOSITION_INPUT_TYPES.has(event.inputType))
+
+  const onCompositionStart = (event: Event): void => {
+    event.stopPropagation()
+    composing = true
+    lastCommit = ''
+    showPreview('')
+  }
+
+  const onCompositionUpdate = (event: Event): void => {
+    event.stopPropagation()
+    showPreview((event as CompositionEvent).data ?? '')
+  }
+
+  const onCompositionEnd = (event: Event): void => {
+    event.stopPropagation()
+    composing = false
+    hidePreview()
+    const data = (event as CompositionEvent).data ?? ''
+    // An empty commit is a cancelled composition (Escape, or a candidate window
+    // dismissed). Sending it would put a stray empty write on the wire.
+    if (data.length > 0) {
+      lastCommit = data
+      send(data)
+    }
+    // The textarea's value is deliberately left alone. Nothing here reads it,
+    // and xterm already clears it on Enter, on Ctrl+C, and on blur, which bounds
+    // its growth exactly as it does today. Clearing it inside this handler would
+    // reach into the editor while the browser is still finalizing the commit.
+  }
+
+  const onBeforeInput = (event: Event): void => {
+    const inputEvent = event as InputEvent
+    const composed = isCompositionInput(inputEvent)
+    // Measure the range this event is about to replace while the selection
+    // still covers it; by the `input` event it has collapsed. Written on EVERY
+    // beforeinput, composition included, so a measurement can never outlive the
+    // event it was taken for and apply itself to a later one.
+    replacedByNextInput = composed ? 0 : selectedCharacterCount()
+    // A browser dispatches beforeinput and the input event it precedes in one
+    // task, so a measurement that survives into the next one belongs to an edit
+    // that never happened — a cancelled beforeinput, or an engine that skipped
+    // it. Dropping it there stops those erase bytes from landing on an
+    // unrelated input event and eating text the user meant to keep.
+    queueMicrotask(() => {
+      replacedByNextInput = 0
+    })
+    if (composed)
+      event.stopPropagation()
+  }
+
+  const onInput = (event: Event): void => {
+    const inputEvent = event as InputEvent
+    if (isCompositionInput(inputEvent)) {
+      event.stopPropagation()
+      return
+    }
+    const replaced = replacedByNextInput
+    replacedByNextInput = 0
+
+    // Text that arrived without xterm's key path producing it. xterm drops all
+    // of it — its `_inputEvent` bails whenever a keydown is in flight — so it
+    // is ours to send.
+    //
+    // The ownership question only arises for `insertText`, the one type xterm
+    // looks at. A replacement is always ours: xterm has no branch for it, so
+    // deferring one to xterm drops it on the floor.
+    const claimable = inputEvent.inputType != null
+      && TEXT_INSERTING_INPUT_TYPES.has(inputEvent.inputType)
+      && (inputEvent.inputType !== 'insertText' || !xtermOwnsKeystroke())
+    if (claimable && inputEvent.data) {
+      // Retract what this event supersedes before the new text goes out, so a
+      // WKWebView replacement lands on the PTY as the edit it actually is.
+      // Both halves go out in ONE send: the terminal's input queue must never
+      // interleave another keystroke between the erase and its replacement.
+      const payload = ERASE_CHARACTER.repeat(replaced) + inputEvent.data
+      event.stopPropagation()
+      send(payload)
+    }
+  }
+
+  const onKeyDownAfterXterm = (event: Event): void => {
+    const keyEvent = event as KeyboardEvent
+    activeKeydown = {
+      keyLength: keyEvent.key?.length ?? 0,
+      prevented: keyEvent.defaultPrevented,
+      imeConsumed: keyEvent.isComposing || keyEvent.keyCode === KEY_CODE_IME_PROCESS,
+    }
+    // A fresh keystroke ends the window in which an echoed keypress can appear.
+    // In the WebKit trace the keydown comes BEFORE the compositionend, so this
+    // never clears the commit it has to recognize; what it does rule out is
+    // swallowing a genuine capital typed some time after a composition that
+    // happened to contain the same character.
+    lastCommit = ''
+  }
+
+  const onKeystrokeEnd = (): void => {
+    activeKeydown = null
+  }
+
+  root.addEventListener('compositionstart', onCompositionStart, true)
+  root.addEventListener('compositionupdate', onCompositionUpdate, true)
+  root.addEventListener('compositionend', onCompositionEnd, true)
+  root.addEventListener('beforeinput', onBeforeInput, true)
+  root.addEventListener('input', onInput, true)
+  // On the textarea, in the CAPTURE phase, registered after xterm's own keydown
+  // listener so it runs immediately after it and reads the `preventDefault()`
+  // that xterm just left behind. Both details are load-bearing. xterm handles a
+  // key by calling `cancel()`, which is `preventDefault()` plus
+  // `stopPropagation()`: a listener on an ancestor never runs at all, and a
+  // non-capture listener even on this same textarea is skipped too, because the
+  // target's bubble-phase dispatch is a separate pass that the stop-propagation
+  // flag suppresses. Same phase, same target, later registration is the one
+  // position that always runs.
+  textarea.addEventListener('keydown', onKeyDownAfterXterm, true)
+  // Close the keystroke out. Blur matters as well as keyup: focus can leave
+  // between the two, and a keydown left standing would make the next
+  // mouse-committed candidate look like it belonged to xterm.
+  textarea.addEventListener('keyup', onKeystrokeEnd, true)
+  textarea.addEventListener('blur', onKeystrokeEnd, true)
+
+  return {
+    get composing() {
+      return composing
+    },
+
+    shouldBypassKeyEvent(event: KeyboardEvent): boolean {
+      if (event.type === 'keydown') {
+        // Hand every IME-consumed keystroke to the composition handlers above.
+        // This also keeps xterm's `_handleAnyTextareaChanges` from firing, which
+        // is what leaks a half-formed jamo onto the wire.
+        return event.isComposing || event.keyCode === KEY_CODE_IME_PROCESS
+      }
+      if (event.type === 'keypress') {
+        // A bypassed keydown leaves xterm's `_keyDownHandled` false, so
+        // `_keyPress` would happily send the raw Latin key the IME consumed.
+        if (composing)
+          return true
+        // WebKit follows a commit with a synthetic keypress whose charCode is
+        // the character just committed (xtermjs/xterm.js#5894). `compositionend`
+        // already sent it. Suppress the echo once, then stop looking, so a
+        // genuine keystroke of the same character is never swallowed.
+        if (lastCommit.length > 0 && event.charCode > 0
+          && lastCommit.includes(String.fromCharCode(event.charCode))) {
+          lastCommit = ''
+          return true
+        }
+      }
+      return false
+    },
+
+    dispose() {
+      root.removeEventListener('compositionstart', onCompositionStart, true)
+      root.removeEventListener('compositionupdate', onCompositionUpdate, true)
+      root.removeEventListener('compositionend', onCompositionEnd, true)
+      root.removeEventListener('beforeinput', onBeforeInput, true)
+      root.removeEventListener('input', onInput, true)
+      textarea.removeEventListener('keydown', onKeyDownAfterXterm, true)
+      textarea.removeEventListener('keyup', onKeystrokeEnd, true)
+      textarea.removeEventListener('blur', onKeystrokeEnd, true)
+      preview.remove()
+    },
+  }
+}

--- a/frontend/src/stores/tabMetadata.store.ts
+++ b/frontend/src/stores/tabMetadata.store.ts
@@ -139,6 +139,14 @@ export interface TerminalMeta {
    * the resubscribe cursor: it cannot lag behind a join that has not recomputed.
    */
   lastOffset?: number
+  /**
+   * Set when this client knows it lost terminal bytes (the pending-frame
+   * queue evicted oldest frames for a terminal that never mounted). The next
+   * watch plan subscribes with afterOffset 0, which the worker answers with a
+   * full snapshot; the flag clears when that snapshot applies. Local
+   * recovery state, like lastOffset — never synced.
+   */
+  needsResync?: boolean
   /** PTY-driven title from OSC 0/2; does not replace a user rename (`title`). */
   ptyTitle?: string
   /** Task progress from OSC 9;4 (ConEmu / Windows Terminal protocol). */

--- a/frontend/src/test-support/compositionPreview.ts
+++ b/frontend/src/test-support/compositionPreview.ts
@@ -1,0 +1,10 @@
+/**
+ * The composition-preview node the IME layer paints over the cursor
+ * (`createCompositionPreview` sets this testid in ~/lib/terminalIme). Shared
+ * by the IME suite and the TerminalView suite so the selector cannot drift
+ * from the node the production code builds. Returns null when absent, so
+ * null-assertion sites and presence assertions share one shape.
+ */
+export function compositionPreview(root: ParentNode | null | undefined): HTMLElement | null {
+  return root?.querySelector<HTMLElement>('[data-testid="terminal-composition-preview"]') ?? null
+}

--- a/frontend/src/test-support/matchMediaStub.ts
+++ b/frontend/src/test-support/matchMediaStub.ts
@@ -1,0 +1,37 @@
+// Shared window.matchMedia stub for unit tests. jsdom does not implement
+// matchMedia, and xterm's CoreBrowserService watches the device-pixel-ratio
+// query through the LEGACY addListener/removeListener pair, so a stub with
+// only addEventListener throws inside open(). This stub reports no query as
+// matching (always light), records every change handler per query for tests
+// that flip a media query, and restores the original matchMedia on cleanup.
+
+type ChangeHandler = (e: { matches: boolean }) => void
+
+export function stubMatchMedia() {
+  const original = window.matchMedia
+  const handlers = new Map<string, Set<ChangeHandler>>()
+
+  window.matchMedia = ((query: string) => {
+    let set = handlers.get(query)
+    if (!set) {
+      set = new Set()
+      handlers.set(query, set)
+    }
+    const listenerSet = set
+    return {
+      matches: false,
+      addListener: (cb: ChangeHandler) => listenerSet.add(cb),
+      removeListener: (cb: ChangeHandler) => listenerSet.delete(cb),
+      addEventListener: (_type: string, cb: ChangeHandler) => listenerSet.add(cb),
+      removeEventListener: (_type: string, cb: ChangeHandler) => listenerSet.delete(cb),
+    }
+  }) as unknown as typeof window.matchMedia
+
+  return {
+    /** The change handlers registered for one query, in registration order. */
+    handlersFor: (query: string): ChangeHandler[] => [...(handlers.get(query) ?? [])],
+    restore: () => {
+      window.matchMedia = original
+    },
+  }
+}

--- a/frontend/tests/e2e/023-full-restart.spec.ts
+++ b/frontend/tests/e2e/023-full-restart.spec.ts
@@ -1,4 +1,5 @@
 import { createWorkspaceViaAPI, deleteWorkspaceViaAPI, openAgentViaAPI } from './helpers/api'
+import { focusActiveTerminal } from './helpers/terminal'
 import { ARITHMETIC_PROMPT, assistantBubbles, expectAnyVisible, expectAssistantAnswer, expectUserMessage, loginViaToken, openTerminalViaUI, openWorkspace, renameTabViaUI, reopenWorkspace, SECOND_ARITHMETIC_ANSWER, SECOND_ARITHMETIC_PROMPT, waitForLayoutSave } from './helpers/ui'
 import { listTerminalsViaAPI } from './helpers/worktree'
 import { ensureWorkerOnline, expect, restartHub, restartWorker, stopHub, stopWorker, processTest as test } from './process-control-fixtures'
@@ -153,18 +154,7 @@ test.describe('Full Hub+Worker Restart', () => {
       return terminals.map(t => t.title)
     }, 'the renamed title must reach the worker before the restart').toContain('Recovered Title')
 
-    await page.evaluate(() => {
-      const containers = document.querySelectorAll<HTMLElement>('[data-terminal-id]')
-      for (const container of containers) {
-        if (container.dataset.active === 'true') {
-          const textarea = container.querySelector<HTMLTextAreaElement>('.xterm-helper-textarea')
-          if (textarea) {
-            textarea.focus()
-            return
-          }
-        }
-      }
-    })
+    await focusActiveTerminal(page)
     await page.keyboard.type('echo EXITEDRESTORE\n', { delay: 30 })
     await page.waitForFunction(() => {
       return typeof (window as any).__getActiveTerminalText === 'function'

--- a/frontend/tests/e2e/060-terminal.spec.ts
+++ b/frontend/tests/e2e/060-terminal.spec.ts
@@ -1,26 +1,6 @@
-import type { Page } from '@playwright/test'
 import { expect, test } from './fixtures'
-import { getTerminalText, waitForTerminalText } from './helpers/terminal'
+import { focusActiveTerminal, getTerminalText, typeInTerminal, waitForTerminalText } from './helpers/terminal'
 import { openTerminalViaUI, waitForLayoutSave } from './helpers/ui'
-
-/** Type a command into the active terminal and press Enter. */
-async function typeInTerminal(page: Page, command: string) {
-  // Focus the textarea inside the visible (active) terminal container
-  await page.evaluate(() => {
-    const containers = document.querySelectorAll<HTMLElement>('[data-terminal-id]')
-    for (const container of containers) {
-      if (container.dataset.active === 'true') {
-        const textarea = container.querySelector<HTMLTextAreaElement>('.xterm-helper-textarea')
-        if (textarea) {
-          textarea.focus()
-          return
-        }
-      }
-    }
-  })
-  await page.keyboard.type(command, { delay: 30 })
-  await page.keyboard.press('Enter')
-}
 
 test.describe('Terminal', () => {
   test('should open a terminal and render xterm', async ({ page, authenticatedWorkspace }) => {
@@ -173,18 +153,7 @@ test.describe('Terminal', () => {
 
     // Verify the terminal no longer accepts input: type something and
     // confirm it does NOT appear in the terminal output
-    await page.evaluate(() => {
-      const containers = document.querySelectorAll<HTMLElement>('[data-terminal-id]')
-      for (const container of containers) {
-        if (container.dataset.active === 'true') {
-          const textarea = container.querySelector<HTMLTextAreaElement>('.xterm-helper-textarea')
-          if (textarea) {
-            textarea.focus()
-            return
-          }
-        }
-      }
-    })
+    await focusActiveTerminal(page)
     await page.keyboard.type('echo SHOULD_NOT_APPEAR', { delay: 100 })
     await page.keyboard.press('Enter')
     await page.waitForTimeout(1000)

--- a/frontend/tests/e2e/068-terminal-signals-background.spec.ts
+++ b/frontend/tests/e2e/068-terminal-signals-background.spec.ts
@@ -1,25 +1,7 @@
 import type { Page } from '@playwright/test'
 import { expect, test } from './fixtures'
-import { waitForTerminalText } from './helpers/terminal'
+import { typeInTerminal, waitForTerminalText } from './helpers/terminal'
 import { openTerminalViaUI, waitForWorkspaceReady } from './helpers/ui'
-
-/** Type a command into the active terminal and press Enter. */
-async function typeInTerminal(page: Page, command: string) {
-  await page.evaluate(() => {
-    const containers = document.querySelectorAll<HTMLElement>('[data-terminal-id]')
-    for (const container of containers) {
-      if (container.dataset.active === 'true') {
-        const textarea = container.querySelector<HTMLTextAreaElement>('.xterm-helper-textarea')
-        if (textarea) {
-          textarea.focus()
-          return
-        }
-      }
-    }
-  })
-  await page.keyboard.type(command, { delay: 20 })
-  await page.keyboard.press('Enter')
-}
 
 /** Terminal tab label text with chrome nodes stripped. */
 async function terminalTabLabel(page: Page, index: number): Promise<string> {
@@ -54,8 +36,14 @@ test.describe('Terminal signals while backgrounded', () => {
     await termTab.click()
     await expect(termTab).toHaveAttribute('aria-selected', 'true')
 
-    // Queue signals that fire after a short delay, then hide the tab before they land.
-    await typeInTerminal(page, 'sleep 0.4; printf \'\\a\'; sleep 0.2; printf \'\\033]0;newtitle\\a\'; sleep 0.2; printf \'\\033]9;hi\\a\'; echo SIGNALS_DONE')
+    // Queue signals that fire after a short delay, then hide the tab before they
+    // land. The trailing sleep is load-bearing for the title assertion below:
+    // the default shell re-emits its OWN OSC title (user@host: cwd) on every
+    // new prompt, so once this command finishes, the prompt would overwrite
+    // 'newtitle' before the hover happens. Sleeping keeps the shell from
+    // printing a new prompt — and re-setting the title — until the assertions
+    // are done.
+    await typeInTerminal(page, 'sleep 0.4; printf \'\\a\'; sleep 0.2; printf \'\\033]0;newtitle\\a\'; sleep 0.2; printf \'\\033]9;hi\\a\'; echo SIGNALS_DONE; sleep 15')
     await agentTab.click()
     await expect(agentTab).toHaveAttribute('aria-selected', 'true')
 

--- a/frontend/tests/e2e/069-terminal-ime.spec.ts
+++ b/frontend/tests/e2e/069-terminal-ime.spec.ts
@@ -1,6 +1,6 @@
 import type { CDPSession, Page } from '@playwright/test'
 import { expect, test } from './fixtures'
-import { waitForTerminalText } from './helpers/terminal'
+import { focusActiveTerminal, waitForTerminalText } from './helpers/terminal'
 import { openTerminalViaUI } from './helpers/ui'
 
 /**
@@ -13,21 +13,28 @@ import { openTerminalViaUI } from './helpers/ui'
  * engine that drops and duplicates composed text is WebKit, which no headless
  * runner here can drive with a real input method. The reproduction lives in
  * src/lib/terminalIme.test.ts, which replays the WebKit trace from
- * xtermjs/xterm.js#5894. What these specs prove is the other half: that taking
- * the composition path away from xterm did not break the engine that worked.
+ * xtermjs/xterm.js#5894 and asserts EXACT send sequences (`h.sent` equality).
+ * What these specs prove is the other half: that taking the composition path
+ * away from xterm did not break the engine that worked, end to end.
  */
 
-/** Focus the helper textarea of the visible terminal, as 060 does. */
-async function focusTerminal(page: Page): Promise<void> {
-  await page.evaluate(() => {
-    const containers = document.querySelectorAll<HTMLElement>('[data-terminal-id]')
-    for (const container of containers) {
-      if (container.dataset.active === 'true') {
-        container.querySelector<HTMLTextAreaElement>('.xterm-helper-textarea')?.focus()
-        return
-      }
-    }
-  })
+/**
+ * The exact bytes the active terminal's input gate forwarded, in order.
+ *
+ * The terminal buffer cannot carry a doubling assertion: the buffer-text hook
+ * joins rows with no separator, so the shell's own echo of `echo 안녕` next to
+ * the command's output puts `안녕안녕` in the string with exactly one send.
+ * The gate's log is the send-side truth — every input path (xterm keys, IME
+ * commits, programmatic writes) passes through it, so a doubled, lost, or
+ * stray send is exact here whatever the shell redraws onto the screen.
+ */
+async function getInputLog(page: Page): Promise<string> {
+  return page.evaluate(() => (window as any).__getActiveTerminalInputLog?.() ?? '')
+}
+
+async function expectInputLog(page: Page, expected: string): Promise<void> {
+  const log = await getInputLog(page)
+  expect(log, 'terminal input log').toBe(expected)
 }
 
 /**
@@ -71,12 +78,21 @@ async function composeInTerminal(cdp: CDPSession, compositions: Composition[]): 
   }
 }
 
+/**
+ * The preamble every test in this file starts with: open a terminal, wait for
+ * it to render, and focus it so keystrokes — and the CDP-driven input method
+ * — land in xterm.
+ */
+async function openFocusedTerminal(page: Page): Promise<void> {
+  await openTerminalViaUI(page)
+  await expect(page.locator('.xterm')).toBeVisible()
+  await focusActiveTerminal(page)
+}
+
 test.describe('Terminal IME input', () => {
   test('composes Korean, where every syllable commits the previous one', async ({ page, authenticatedWorkspace }) => {
     void authenticatedWorkspace
-    await openTerminalViaUI(page)
-    await expect(page.locator('.xterm')).toBeVisible()
-    await focusTerminal(page)
+    await openFocusedTerminal(page)
 
     const cdp = await page.context().newCDPSession(page)
     // `echo` first so the assertion reads a command line the shell echoed back
@@ -91,13 +107,13 @@ test.describe('Terminal IME input', () => {
     await page.keyboard.press('Enter')
 
     await waitForTerminalText(page, '안녕')
+    // One send of each syllable, once: the committed text and nothing else.
+    await expectInputLog(page, 'echo 안녕\r')
   })
 
   test('composes Japanese with a single explicit commit', async ({ page, authenticatedWorkspace }) => {
     void authenticatedWorkspace
-    await openTerminalViaUI(page)
-    await expect(page.locator('.xterm')).toBeVisible()
-    await focusTerminal(page)
+    await openFocusedTerminal(page)
 
     const cdp = await page.context().newCDPSession(page)
     await page.keyboard.type('echo ', { delay: 30 })
@@ -109,13 +125,12 @@ test.describe('Terminal IME input', () => {
     await page.keyboard.press('Enter')
 
     await waitForTerminalText(page, 'こんにちは')
+    await expectInputLog(page, 'echo こんにちは\r')
   })
 
   test('sends nothing when the composition is cancelled', async ({ page, authenticatedWorkspace }) => {
     void authenticatedWorkspace
-    await openTerminalViaUI(page)
-    await expect(page.locator('.xterm')).toBeVisible()
-    await focusTerminal(page)
+    await openFocusedTerminal(page)
 
     const cdp = await page.context().newCDPSession(page)
     await page.keyboard.type('echo CANCELLED', { delay: 30 })
@@ -124,17 +139,14 @@ test.describe('Terminal IME input', () => {
     await page.keyboard.press('Enter')
 
     await waitForTerminalText(page, 'CANCELLED')
-    // The abandoned syllable must not have reached the PTY in any form.
-    const text = await page.evaluate(() => (window as any).__getActiveTerminalText?.() ?? '')
-    expect(text).not.toContain('안')
-    expect(text).not.toContain('ㅇ')
+    // The abandoned syllable never left the client in any form: not the
+    // intermediate jamo, not the composed syllable, not an erase for either.
+    await expectInputLog(page, 'echo CANCELLED\r')
   })
 
-  test('still types plain ASCII through xterm own key path', async ({ page, authenticatedWorkspace }) => {
+  test('still types plain ASCII through xterm\'s own key path', async ({ page, authenticatedWorkspace }) => {
     void authenticatedWorkspace
-    await openTerminalViaUI(page)
-    await expect(page.locator('.xterm')).toBeVisible()
-    await focusTerminal(page)
+    await openFocusedTerminal(page)
 
     // The IME layer sits in front of every keystroke, so the ordinary path is
     // the regression that matters most.
@@ -142,5 +154,6 @@ test.describe('Terminal IME input', () => {
     await page.keyboard.press('Enter')
 
     await waitForTerminalText(page, 'ASCII_STILL_WORKS')
+    await expectInputLog(page, 'echo ASCII_STILL_WORKS\r')
   })
 })

--- a/frontend/tests/e2e/069-terminal-ime.spec.ts
+++ b/frontend/tests/e2e/069-terminal-ime.spec.ts
@@ -1,0 +1,146 @@
+import type { CDPSession, Page } from '@playwright/test'
+import { expect, test } from './fixtures'
+import { waitForTerminalText } from './helpers/terminal'
+import { openTerminalViaUI } from './helpers/ui'
+
+/**
+ * Input-method (IME) input in the terminal, driven through Chrome DevTools
+ * Protocol so the browser generates GENUINE composition events rather than
+ * synthesized ones. Playwright's keyboard cannot compose.
+ *
+ * Read this as a regression guard, not as the reproduction of the original
+ * defect. Chromium composes correctly even without ~/lib/terminalIme; the
+ * engine that drops and duplicates composed text is WebKit, which no headless
+ * runner here can drive with a real input method. The reproduction lives in
+ * src/lib/terminalIme.test.ts, which replays the WebKit trace from
+ * xtermjs/xterm.js#5894. What these specs prove is the other half: that taking
+ * the composition path away from xterm did not break the engine that worked.
+ */
+
+/** Focus the helper textarea of the visible terminal, as 060 does. */
+async function focusTerminal(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const containers = document.querySelectorAll<HTMLElement>('[data-terminal-id]')
+    for (const container of containers) {
+      if (container.dataset.active === 'true') {
+        container.querySelector<HTMLTextAreaElement>('.xterm-helper-textarea')?.focus()
+        return
+      }
+    }
+  })
+}
+
+/**
+ * One composition: the intermediate states, then the text it commits. A null
+ * commit abandons the composition instead, which is what Escape does.
+ */
+interface Composition {
+  steps: string[]
+  commit: string | null
+}
+
+/**
+ * Type through a real input method. Every keystroke an input method consumes
+ * carries the legacy keyCode 229, which is what the terminal's IME layer keys
+ * on to hold the keystroke back from xterm, so the specs send those too.
+ */
+async function composeInTerminal(cdp: CDPSession, compositions: Composition[]): Promise<void> {
+  for (const { steps, commit } of compositions) {
+    for (const text of steps) {
+      await cdp.send('Input.dispatchKeyEvent', {
+        type: 'rawKeyDown',
+        windowsVirtualKeyCode: 229,
+        nativeVirtualKeyCode: 229,
+        key: 'Process',
+      })
+      await cdp.send('Input.imeSetComposition', {
+        text,
+        selectionStart: text.length,
+        selectionEnd: text.length,
+      })
+      await cdp.send('Input.dispatchKeyEvent', { type: 'keyUp', key: 'Process' })
+    }
+    if (commit === null) {
+      // Setting the composition to the empty string retracts it, which is how
+      // Chromium reports a composition the user abandoned. `Input.insertText`
+      // with an empty string is NOT the same thing and never resolves.
+      await cdp.send('Input.imeSetComposition', { text: '', selectionStart: 0, selectionEnd: 0 })
+      continue
+    }
+    await cdp.send('Input.insertText', { text: commit })
+  }
+}
+
+test.describe('Terminal IME input', () => {
+  test('composes Korean, where every syllable commits the previous one', async ({ page, authenticatedWorkspace }) => {
+    void authenticatedWorkspace
+    await openTerminalViaUI(page)
+    await expect(page.locator('.xterm')).toBeVisible()
+    await focusTerminal(page)
+
+    const cdp = await page.context().newCDPSession(page)
+    // `echo` first so the assertion reads a command line the shell echoed back
+    // -- xterm paints nothing on its own, so text on screen came from the PTY.
+    await page.keyboard.type('echo ', { delay: 30 })
+    // 안녕. 안 is committed by the keystroke that begins 녕, which is the case
+    // that breaks: the commit and the next compositionstart arrive together.
+    await composeInTerminal(cdp, [
+      { steps: ['ㅇ', '아', '안'], commit: '안' },
+      { steps: ['ㄴ', '녀', '녕'], commit: '녕' },
+    ])
+    await page.keyboard.press('Enter')
+
+    await waitForTerminalText(page, '안녕')
+  })
+
+  test('composes Japanese with a single explicit commit', async ({ page, authenticatedWorkspace }) => {
+    void authenticatedWorkspace
+    await openTerminalViaUI(page)
+    await expect(page.locator('.xterm')).toBeVisible()
+    await focusTerminal(page)
+
+    const cdp = await page.context().newCDPSession(page)
+    await page.keyboard.type('echo ', { delay: 30 })
+    // One composition held open across several candidates, then committed --
+    // the shape Japanese and Chinese input methods use, unlike Korean.
+    await composeInTerminal(cdp, [
+      { steps: ['こ', 'こん', 'こんに', 'こんにち', 'こんにちは'], commit: 'こんにちは' },
+    ])
+    await page.keyboard.press('Enter')
+
+    await waitForTerminalText(page, 'こんにちは')
+  })
+
+  test('sends nothing when the composition is cancelled', async ({ page, authenticatedWorkspace }) => {
+    void authenticatedWorkspace
+    await openTerminalViaUI(page)
+    await expect(page.locator('.xterm')).toBeVisible()
+    await focusTerminal(page)
+
+    const cdp = await page.context().newCDPSession(page)
+    await page.keyboard.type('echo CANCELLED', { delay: 30 })
+    // Build a composition, then retract it the way Escape does.
+    await composeInTerminal(cdp, [{ steps: ['ㅇ', '아', '안'], commit: null }])
+    await page.keyboard.press('Enter')
+
+    await waitForTerminalText(page, 'CANCELLED')
+    // The abandoned syllable must not have reached the PTY in any form.
+    const text = await page.evaluate(() => (window as any).__getActiveTerminalText?.() ?? '')
+    expect(text).not.toContain('안')
+    expect(text).not.toContain('ㅇ')
+  })
+
+  test('still types plain ASCII through xterm own key path', async ({ page, authenticatedWorkspace }) => {
+    void authenticatedWorkspace
+    await openTerminalViaUI(page)
+    await expect(page.locator('.xterm')).toBeVisible()
+    await focusTerminal(page)
+
+    // The IME layer sits in front of every keystroke, so the ordinary path is
+    // the regression that matters most.
+    await page.keyboard.type('echo ASCII_STILL_WORKS', { delay: 30 })
+    await page.keyboard.press('Enter')
+
+    await waitForTerminalText(page, 'ASCII_STILL_WORKS')
+  })
+})

--- a/frontend/tests/e2e/161-watch-stream-continuity.spec.ts
+++ b/frontend/tests/e2e/161-watch-stream-continuity.spec.ts
@@ -1,7 +1,7 @@
 import type { Page } from '@playwright/test'
 import { expect, test } from './fixtures'
 import { createWorkspaceViaAPI, deleteWorkspaceViaAPI, openAgentViaAPI } from './helpers/api'
-import { waitForTerminalText } from './helpers/terminal'
+import { typeInTerminal, waitForTerminalText } from './helpers/terminal'
 import { armTurnEndSound, expectDoorbellCount } from './helpers/turnEndSound'
 import {
   loginViaToken,
@@ -26,23 +26,6 @@ async function installWatchOpenCounter(page: Page) {
       w.__watchOpens = (w.__watchOpens ?? 0) + 1
     })
   })
-}
-
-async function typeInTerminal(page: Page, command: string) {
-  await page.evaluate(() => {
-    const containers = document.querySelectorAll<HTMLElement>('[data-terminal-id]')
-    for (const container of containers) {
-      if (container.dataset.active === 'true') {
-        const textarea = container.querySelector<HTMLTextAreaElement>('.xterm-helper-textarea')
-        if (textarea) {
-          textarea.focus()
-          return
-        }
-      }
-    }
-  })
-  await page.keyboard.type(command, { delay: 20 })
-  await page.keyboard.press('Enter')
 }
 
 const TOOL_USING_PROMPT = 'Run the command `pwd` and tell me the result.'

--- a/frontend/tests/e2e/helpers/terminal.ts
+++ b/frontend/tests/e2e/helpers/terminal.ts
@@ -33,6 +33,31 @@ export async function waitForTerminalText(page: Page, text: string, timeout?: nu
 }
 
 /**
+ * Focus the helper textarea of the active terminal, so keyboard input (and a
+ * real input method driven over CDP) lands in xterm.
+ */
+export async function focusActiveTerminal(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const containers = document.querySelectorAll<HTMLElement>('[data-terminal-id]')
+    for (const container of containers) {
+      if (container.dataset.active === 'true') {
+        container.querySelector<HTMLTextAreaElement>('.xterm-helper-textarea')?.focus()
+        return
+      }
+    }
+  })
+}
+
+/**
+ * Type a command into the active terminal and press Enter.
+ */
+export async function typeInTerminal(page: Page, command: string, delay = 30): Promise<void> {
+  await focusActiveTerminal(page)
+  await page.keyboard.type(command, { delay })
+  await page.keyboard.press('Enter')
+}
+
+/**
  * Send input to the active terminal via the same callback xterm's
  * onData fires. Returns false when no terminal is registered with the
  * window hook (e.g. xterm not mounted yet).


### PR DESCRIPTION
## Motivation

Typing non-ASCII text into the terminal was broken in several ways, and the output path had correctness holes of its own:

- **CJK/IME input.** xterm's built-in text-input path depends on engine-specific behavior that fails on WebKit (it re-emits committed characters via a synthetic keypress and drops the following keystroke — xtermjs/xterm.js#5894) and on WKWebView, the desktop app's engine, which sends no composition events at all and refines syllables via `insertReplacementText`. IME typing in those engines produced doubled, dropped, or garbled characters.
- **Transposed input.** The worker dispatches inner RPCs on goroutines, so two concurrent `SendInput` calls can reach the PTY transposed — visible to users as corrupted typing.
- **Duplicated output.** When a catch-up delta overlapped bytes already rendered live, the overlap was rendered a second time. Relatedly, the dispose-time screen capture could store a screen whose cursor overstated queued-but-unparsed writes, and evicted pending frames had no way to force a full terminal resync.
- **Slow catch-up.** During dual-promote catch-up, the git-status batch shell-outs ran before the terminal replay loop, stalling terminal frames behind git.

## Modifications

- **New IME layer (`frontend/src/lib/terminalIme.ts`).** `attachTerminalIme(terminal, send)` takes over xterm's entire text-input path: it intercepts composition/`beforeinput`/`input` in the capture phase and sends commits read from `compositionend.data`. A keystroke-ownership machine records xterm's `onData` emissions in flight and marks an `insertText` as xterm's echo only on an exact, consumed match (deferred capitals, caps-lock folding, arrow escapes, pastes, and rollover are neither double-sent nor dropped). WebKit echo suppression bypasses IME-consumed keydowns and consumes one synthetic keypress per committed character. A custom composition preview (vanilla-extract styles) is painted over the cursor cell in the live terminal font/theme, since xterm's own hardcoded black-on-white view never activates once events are intercepted.
- **One-in-flight input queue (`frontend/src/lib/inputQueue.ts`).** A generic per-key batch queue drained one send at a time; it retries a cleanly-rejected batch once (never after a deadline, when delivery is unknown) and races the whole send against a caller-supplied deadline. `useTerminalOperations` routes READY-terminal input through it (queue map at module scope so the invariant survives error-boundary remounts), keeps draining through transient DISCONNECTED, and uses `apiLoadingTimeoutMs` as the deadline.
- **Exactly-once output (`frontend/src/lib/terminal.ts`).** `applyTerminalData` is redesigned around a discriminated-union payload `{ kind: 'snapshot' | 'delta', ... }` with contractual delta ranges; the delta path trims the already-rendered prefix by offset, a fully-stale delta writes nothing but still fires `onParsed`, and a gap writes as-is until a snapshot rebuilds. `lastParsedOffset` is set only inside xterm's async write callback and cleared on snapshot reset, so dispose-time screen capture pairs the serialized screen with a cursor describing exactly the parsed bytes.
- **Full-snapshot resync on eviction.** `enqueuePendingTerminalData` reports eviction; the flag `TerminalMeta.needsResync` makes `buildWatchPlans` subscribe cold (afterOffset 0) and is recorded in `WatchPlan.terminalResync`; `watchPlanKey` gained a `:r` arm so the cold plan actually goes out. Applying a snapshot clears the flag. `AppShell` rewinds the tab's `lastOffset` onto the capture's `parsedOffset` across remounts.
- **Backend catch-up (worker).** The git-status batch now launches on a background goroutine with a cancellable context *before* the terminal replay loop, so frames stream while git runs; if the transport dies mid-replay the batch is cancelled and joined. `ScreenBuffer.SnapshotSince` treats `afterOffset <= 0` as a forced resync that always returns the full retained buffer.
- **TerminalView.** All input paths (xterm `onData`, IME layer, programmatic `sendInput`) pass through one send gate honoring `suppressInput`, wired once on the creating mount; the key handler attaches on every platform (CMD/ALT+Arrow suppression stays macOS-only); IME attach failures are caught and logged. Added a bounded per-terminal input log plus the `__getActiveTerminalInputLog` e2e hook.
- **Shared plumbing.** `concatBytes` extracted from `noise.ts` into `frontend/src/lib/bytes.ts` (shared by the Noise handshake, key-pin store, and input queue); shared `ENTER_KEY_CR`/`ERASE_CHARACTER` constants; `workerRpc.sendInput` accepts `{ timeoutMs?, signal? }`.
- **Tests/e2e.** 41 unit tests replaying real recorded composition traces (Chromium via CDP, the WebKit trace from xtermjs#5894, a recorded WKWebView 안녕 session) plus dead keys, surrogate pairs, cancelled compositions, paste, disposal, and fail-loud attach guards; new spec `069-terminal-ime.spec.ts` drives genuine IME via CDP and asserts the exact bytes the input gate forwarded; shared `focusActiveTerminal`/`typeInTerminal` helpers removed ~85 lines of duplication across specs 023/060/068/161; two new backend dual-promote tests (overlap with the git batch parked; cancellation on transport death).

**Breaking changes (internal):**
- `applyTerminalData` signature changed from positional args to a payload object (all in-repo callers updated).
- `concatBytes` moved from `./noise` to `./bytes`.
- `SnapshotSince(0)` now returns a full snapshot with the reset flag instead of an in-window incremental delta (wire-behavior change).
- Screen-sink callback gained a `parsedOffset` param; `enqueuePendingTerminalData` returns a boolean; `buildWatchPlans` gained a `terminalNeedsResync` param; `WatchPlan.terminalResync` is now a required field.

## Result

- IME typing (Korean, Japanese, Chinese, dead keys) now works correctly in the browser on both Chromium and WebKit and in the desktop WKWebView app — no doubled or dropped characters, with a composition preview that matches the terminal's own font and theme.
- Rapid typing no longer corrupts input: sends are serialized one-in-flight per terminal, so keystrokes reach the PTY in order.
- Terminal output is rendered exactly once — catch-up replay no longer duplicates lines that were already visible live.
- If pending frames are evicted, the terminal automatically resubscribes cold and rebuilds from a full snapshot instead of showing a gap.
- Reconnecting after a workspace promotion feels faster: terminal frames stream immediately while git status loads in parallel.
