### PR TITLE
fix(desktop): Install Linux icons where a launcher finds them

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -199,6 +199,8 @@ tasks:
       - frontend/bun.lock
       - frontend/scripts/**/*
       - scripts/build-ico.mjs
+      - scripts/render-icon.mjs
+      - scripts/icon-corners.mjs
       - frontend/src/generated/**/*
     generates:
       - frontend/node_modules/**/*
@@ -213,7 +215,6 @@ tasks:
       - task: generate-proto
       - task: generate-spinners
       - cd frontend && bun install
-      - mkdir -p frontend/public/icons
       - NODE_PATH=frontend/node_modules bun frontend/scripts/generate-icons.mjs icons/leapmux-icon.svg icons/leapmux-icon-square.svg frontend/public
       - "[ -a NOTICE.html ] && cp NOTICE.html frontend/public/NOTICE.html || true"
 
@@ -253,19 +254,24 @@ tasks:
       - icons/leapmux-icon.svg
       - desktop/rust/scripts/**/*
       - scripts/build-ico.mjs
+      - scripts/render-icon.mjs
+      - scripts/icon-corners.mjs
       - frontend/.output/**/*
       - backend/internal/hub/generated/frontend/public/**/*
     generates:
-      - desktop/rust/icons/icon@2x.png
+      # The set that desktop/rust/scripts/icon-set.mjs defines.
+      - desktop/rust/icons/*.png
       - desktop/rust/icons/icon.ico
     cmds:
       - task: generate-proto
       - task: build-frontend
       - task: prepare-backend
-      - mkdir -p desktop/rust/icons
-      - cmd: NODE_PATH=frontend/node_modules bun desktop/rust/scripts/generate-icons.mjs icons/leapmux-icon-square.svg icons/leapmux-icon.svg desktop/rust/icons/icon@2x.png desktop/rust/icons/icon.ico opaque
+      # macOS renders the square source, because the system applies its own mask
+      # and a rounded icon would show the corner twice. Linux and Windows draw
+      # the icon as authored, so they render the rounded source.
+      - cmd: NODE_PATH=frontend/node_modules bun desktop/rust/scripts/generate-icons.mjs icons/leapmux-icon-square.svg icons/leapmux-icon.svg desktop/rust/icons opaque
         if: '[ "{{OS}}" = "darwin" ]'
-      - cmd: NODE_PATH=frontend/node_modules bun desktop/rust/scripts/generate-icons.mjs icons/leapmux-icon.svg icons/leapmux-icon.svg desktop/rust/icons/icon@2x.png desktop/rust/icons/icon.ico transparent
+      - cmd: NODE_PATH=frontend/node_modules bun desktop/rust/scripts/generate-icons.mjs icons/leapmux-icon.svg icons/leapmux-icon.svg desktop/rust/icons transparent
         if: '[ "{{OS}}" = "linux" ] || [ "{{OS}}" = "windows" ]'
 
   # --- Build ---
@@ -359,7 +365,7 @@ tasks:
       - desktop/rust/capabilities/**/*
       - desktop/rust/tauri.conf.json
       - desktop/rust/entitlements.plist
-      - desktop/rust/icons/icon@2x.png
+      - desktop/rust/icons/*
       - desktop/rust/scripts/**/*
       - frontend/.output/**/*
       - backend/internal/hub/generated/frontend/public/**/*
@@ -502,7 +508,7 @@ tasks:
       - desktop/rust/tauri.conf.json
       - desktop/rust/tauri.linux.conf.json
       - desktop/rust/desktop-template.desktop
-      - desktop/rust/icons/icon@2x.png
+      - desktop/rust/icons/*
       - desktop/rust/scripts/**/*
       - frontend/.output/**/*
       - backend/internal/hub/generated/frontend/public/**/*
@@ -601,6 +607,11 @@ tasks:
           dpkg-deb -b "$work" "$deb"
           rm -rf "$work"
         done
+      # Read the icons back out of the repacked .deb. tauri-bundler derives each
+      # destination from the PNG header and the `@2x` suffix, so a size that no
+      # icon theme declares installs without an error and leaves the app with no
+      # icon anywhere -- the failure that shipped as issue #387.
+      - bun desktop/rust/scripts/verify-deb-icons.mjs leapmux-desktop_*.deb
 
   build-desktop-windows:
     desc: Build desktop for Windows
@@ -619,7 +630,7 @@ tasks:
       - desktop/rust/tauri.conf.json
       - desktop/rust/tauri.windows.conf.json
       - desktop/rust/windows/**/*
-      - desktop/rust/icons/icon.ico
+      - desktop/rust/icons/*
       - desktop/rust/scripts/**/*
       - frontend/.output/**/*
       - backend/internal/hub/generated/frontend/public/**/*
@@ -714,16 +725,18 @@ tasks:
 
   test-scripts:
     desc: Test repository scripts
-    # `bun test` rather than vitest: these are repo-root Bun scripts, outside
-    # frontend/ and its vitest project (whose root is frontend/ and whose
-    # co-location rule covers frontend/src only).
+    # `bun test` rather than vitest: these are build scripts outside frontend/
+    # and its vitest project (whose root is frontend/ and whose co-location rule
+    # covers frontend/src only). desktop/rust/scripts/ holds the desktop build's
+    # own Bun scripts and joins them here for the same reason.
     #
-    # Deliberately NOT fingerprinted. The suites read beyond scripts/*.mjs --
-    # versions.env, and scripts/license-overrides/spdx/ through the real
-    # vendored path -- so a `sources:` list narrow enough to be worth having
-    # would go stale and skip the run that mattered. It takes ~40 ms.
+    # Deliberately NOT fingerprinted. The suites read beyond their own *.mjs --
+    # versions.env, scripts/license-overrides/spdx/ through the real vendored
+    # path, and the Tauri configs next to desktop/rust/scripts/ -- so a
+    # `sources:` list narrow enough to be worth having would go stale and skip
+    # the run that mattered. It takes ~40 ms.
     cmds:
-      - bun test scripts/
+      - bun test scripts/ desktop/rust/scripts/
 
   test-frontend:
     desc: Run frontend tests
@@ -812,10 +825,11 @@ tasks:
     deps: [prepare-frontend]
     sources:
       - scripts/*.mjs
+      - desktop/rust/scripts/*.mjs
       - eslint.config.mjs
       - frontend/eslint.config.ts
     cmds:
-      - ./frontend/node_modules/.bin/eslint scripts/
+      - ./frontend/node_modules/.bin/eslint scripts/ desktop/rust/scripts/
 
   lint-versions:
     desc: Check documented tool versions against versions.env

--- a/desktop/rust/scripts/create-dmg.sh
+++ b/desktop/rust/scripts/create-dmg.sh
@@ -25,7 +25,6 @@ WIN_HEIGHT=360
 WIN_X=100
 WIN_Y=100
 ICON_SIZE=128
-TEXT_SIZE=14
 APP_X=130
 APP_Y=150
 APPS_X=410
@@ -72,11 +71,9 @@ ln -s /Applications "${MOUNT_POINT}/Applications"
 
 # -- 3. Generate .DS_Store with Node.js. --
 node "${SCRIPT_DIR}/generate-dsstore.mjs" \
-  "${MOUNT_POINT}" \
   "${MOUNT_POINT}/.DS_Store" \
   --bg-color "${BG_R},${BG_G},${BG_B}" \
   --icon-size "${ICON_SIZE}" \
-  --text-size "${TEXT_SIZE}" \
   --window-pos "${WIN_X},${WIN_Y}" \
   --window-size "${WIN_WIDTH},${WIN_HEIGHT}" \
   --icon "${APP_NAME},${APP_X},${APP_Y}" \

--- a/desktop/rust/scripts/generate-dsstore.mjs
+++ b/desktop/rust/scripts/generate-dsstore.mjs
@@ -2,103 +2,106 @@
 //
 // Generates a .DS_Store file for DMG styling.
 //
-// Usage: generate-dsstore.mjs <volume-path> <output-path>
+// Usage: generate-dsstore.mjs <output-path>
 //        [--bg-image <path>] [--bg-color <r,g,b>]
-//        [--icon-size <px>] [--text-size <px>]
+//        [--icon-size <px>]
 //        [--window-pos <x,y>] [--window-size <w,h>]
 //        [--icon <name,x,y>]...
 //
 // Example:
-//   generate-dsstore.mjs "/Volumes/MyApp 1.0" out/.DS_Store \
+//   generate-dsstore.mjs out/.DS_Store \
 //     --bg-image "/Volumes/MyApp 1.0/.background/bg@2x.png" \
-//     --icon-size 128 --text-size 14 \
+//     --icon-size 128 \
 //     --window-pos 100,100 --window-size 540,360 \
 //     --icon "MyApp.app,130,150" \
 //     --icon "Applications,410,150"
+//
+// There is no text-size option, although a DMG window does have a label size:
+// the ds-store package writes the settings through its Helper API, which offers
+// setIconSize, setIconPos, setWindowPos, setWindowSize, and the two background
+// setters, and no setter for the label size.
 
-import { createRequire } from 'node:module';
-import { resolve, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module'
+import { dirname, resolve } from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const frontendDir = resolve(__dirname, '../../../frontend');
-const require = createRequire(resolve(frontendDir, 'package.json'));
-const DSStore = require('ds-store');
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const frontendDir = resolve(__dirname, '../../../frontend')
+const require = createRequire(resolve(frontendDir, 'package.json'))
+const DSStore = require('ds-store')
 
-const args = process.argv.slice(2);
-if (args.length < 2) {
-  console.error('Usage: generate-dsstore.mjs <volume-path> <output-path> [options]');
-  process.exit(1);
+const args = process.argv.slice(2)
+if (args.length < 1) {
+  console.error('Usage: generate-dsstore.mjs <output-path> [options]')
+  process.exit(1)
 }
 
-const volumePath = args[0];
-const outputPath = args[1];
+const outputPath = args[0]
 
 // Defaults
-let bgImage = null;
-let bgColor = null;
-let iconSize = 128;
-let textSize = 14;
-let windowPos = [100, 100];
-let windowSize = [540, 360];
-const icons = [];
+let bgImage = null
+let bgColor = null
+let iconSize = 128
+let windowPos = [100, 100]
+let windowSize = [540, 360]
+const icons = []
 
 // Parse options
-for (let i = 2; i < args.length; i++) {
+for (let i = 1; i < args.length; i++) {
   switch (args[i]) {
     case '--bg-image':
-      bgImage = args[++i];
-      break;
+      bgImage = args[++i]
+      break
     case '--bg-color':
-      bgColor = args[++i].split(',').map(Number);
-      break;
+      bgColor = args[++i].split(',').map(Number)
+      break
     case '--icon-size':
-      iconSize = Number(args[++i]);
-      break;
-    case '--text-size':
-      textSize = Number(args[++i]);
-      break;
+      iconSize = Number(args[++i])
+      break
     case '--window-pos':
-      windowPos = args[++i].split(',').map(Number);
-      break;
+      windowPos = args[++i].split(',').map(Number)
+      break
     case '--window-size':
-      windowSize = args[++i].split(',').map(Number);
-      break;
+      windowSize = args[++i].split(',').map(Number)
+      break
     case '--icon': {
-      const parts = args[++i].split(',');
-      icons.push({ name: parts[0], x: Number(parts[1]), y: Number(parts[2]) });
-      break;
+      const parts = args[++i].split(',')
+      icons.push({ name: parts[0], x: Number(parts[1]), y: Number(parts[2]) })
+      break
     }
     default:
-      console.error(`Unknown option: ${args[i]}`);
-      process.exit(1);
+      console.error(`Unknown option: ${args[i]}`)
+      process.exit(1)
   }
 }
 
-const store = new DSStore();
+const store = new DSStore()
 
-store.setIconSize(iconSize);
-store.setWindowPos(windowPos[0], windowPos[1]);
-store.setWindowSize(windowSize[0], windowSize[1]);
-store.vSrn(1);
+store.setIconSize(iconSize)
+store.setWindowPos(windowPos[0], windowPos[1])
+store.setWindowSize(windowSize[0], windowSize[1])
+store.vSrn(1)
 
 if (bgImage) {
-  store.setBackgroundPath(bgImage);
-} else if (bgColor) {
-  store.setBackgroundColor(bgColor[0], bgColor[1], bgColor[2]);
-} else {
+  store.setBackgroundPath(bgImage)
+}
+else if (bgColor) {
+  store.setBackgroundColor(bgColor[0], bgColor[1], bgColor[2])
+}
+else {
   // Default: warm sand color
-  store.setBackgroundColor(0.961, 0.945, 0.922);
+  store.setBackgroundColor(0.961, 0.945, 0.922)
 }
 
 for (const icon of icons) {
-  store.setIconPos(icon.name, icon.x, icon.y);
+  store.setIconPos(icon.name, icon.x, icon.y)
 }
 
 store.write(outputPath, (err) => {
   if (err) {
-    console.error('Error writing .DS_Store:', err.message);
-    process.exit(1);
+    console.error('Error writing .DS_Store:', err.message)
+    process.exit(1)
   }
-  console.log(`Generated: ${outputPath}`);
-});
+  console.log(`Generated: ${outputPath}`)
+})

--- a/desktop/rust/scripts/generate-icons.mjs
+++ b/desktop/rust/scripts/generate-icons.mjs
@@ -1,41 +1,56 @@
 #!/usr/bin/env node
 
-// Converts separate LeapMux SVG sources to PNG (appicon) and ICO (Windows).
-// Usage: node generate-icons.mjs <png-svg-path> <ico-svg-path> <png-out> <ico-out> [opaque|transparent]
+// Renders the desktop icon set (see ./icon-set.mjs) from the LeapMux SVG
+// sources: one PNG for each entry, plus the ICO that Windows installs.
 //
-// Requires @resvg/resvg-js (installed automatically when run via bunx).
+// Usage: node generate-icons.mjs <png-svg> <ico-svg> <out-dir> <opaque|transparent>
+//
+// The two SVG sources differ by their corners, and the caller picks which one
+// renders the PNGs: macOS masks the app icon itself and needs the square source
+// with opaque corners, while Linux and Windows need the rounded source. The
+// fourth argument states which corners the chosen source must produce, so a
+// swapped pair fails the build instead of shipping the wrong shape.
+//
+// Requires @resvg/resvg-js (installed with the frontend dependencies).
 
-import { readFileSync, writeFileSync } from 'node:fs'
-import { Resvg } from '@resvg/resvg-js'
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import process from 'node:process'
+
 import { buildIco } from '../../../scripts/build-ico.mjs'
+import { renderPng } from '../../../scripts/render-icon.mjs'
+import { ALL_ICON_FILES, ICO_FILE, ICO_SIZE, pixelSize } from './icon-set.mjs'
 
-const [pngSvgPath, icoSvgPath, pngOut, icoOut, appiconCorners] = process.argv.slice(2)
-if (!pngSvgPath || !icoSvgPath || !pngOut || !icoOut) {
-  console.error('Usage: generate-icons.mjs <png-svg> <ico-svg> <png-out> <ico-out> [opaque|transparent]')
+const [pngSvgPath, icoSvgPath, outDir, corners] = process.argv.slice(2)
+if (!pngSvgPath || !icoSvgPath || !outDir || !corners) {
+  console.error('Usage: generate-icons.mjs <png-svg> <ico-svg> <out-dir> <opaque|transparent>')
+  process.exit(1)
+}
+if (corners !== 'opaque' && corners !== 'transparent') {
+  console.error(`Corners must be "opaque" or "transparent", not "${corners}"`)
   process.exit(1)
 }
 
 const pngSvg = readFileSync(pngSvgPath)
 const icoSvg = readFileSync(icoSvgPath)
+const opaqueCorners = corners === 'opaque'
 
-// Render 1024x1024 PNG for appicon.
-const appIcon = new Resvg(pngSvg, { fitTo: { mode: 'width', value: 1024 } })
-const appIconRendered = appIcon.render()
-if (appiconCorners) {
-  const shouldBeOpaque = appiconCorners === 'opaque'
-  for (const [x, y] of [[0, 0], [appIconRendered.width - 1, 0], [0, appIconRendered.height - 1], [appIconRendered.width - 1, appIconRendered.height - 1]]) {
-    const alpha = appIconRendered.pixels[(y * appIconRendered.width + x) * 4 + 3]
-    const ok = shouldBeOpaque ? alpha === 255 : alpha === 0
-    if (!ok) {
-      const expected = shouldBeOpaque ? 'opaque' : 'transparent'
-      throw new Error(`${pngOut} has alpha=${alpha} at (${x},${y}); expected ${expected} corners`)
-    }
+mkdirSync(outDir, { recursive: true })
+
+// Render each distinct size once. `128x128@2x.png` and `256x256.png` are both
+// 256 pixels; they differ only by the density that the bundler reads from the
+// name, so they share the bytes.
+const rendered = new Map()
+for (const name of ALL_ICON_FILES) {
+  const size = pixelSize(name)
+  if (!rendered.has(size)) {
+    rendered.set(size, renderPng(pngSvg, size, { opaqueCorners }))
   }
+  writeFileSync(join(outDir, name), rendered.get(size))
 }
-writeFileSync(pngOut, appIconRendered.asPng())
 
-// Render 256x256 PNG, then wrap in ICO for Windows.
-const icoIcon = new Resvg(icoSvg, { fitTo: { mode: 'width', value: 256 } })
-writeFileSync(icoOut, buildIco(icoIcon.render().asPng(), 256))
+// The ICO always comes from the rounded source: Windows draws the icon as
+// authored, with no mask of its own.
+writeFileSync(join(outDir, ICO_FILE), buildIco(renderPng(icoSvg, ICO_SIZE), ICO_SIZE))
 
-console.log(`Generated ${pngOut} (1024x1024) and ${icoOut} (256x256 ICO)`)
+console.log(`Generated ${ALL_ICON_FILES.length} PNGs (${ALL_ICON_FILES.join(', ')}) and ${ICO_FILE} (${ICO_SIZE}x${ICO_SIZE}) in ${outDir}`)

--- a/desktop/rust/scripts/icon-set.mjs
+++ b/desktop/rust/scripts/icon-set.mjs
@@ -1,0 +1,103 @@
+// The desktop icon set: one entry for each icon file that tauri-bundler packages.
+//
+// A file name states the icon's logical size and its density. `128x128.png` is
+// 128 physical pixels; `128x128@2x.png` is 256. tauri-bundler reads both facts,
+// from two different places: the pixel size comes from the PNG header, and the
+// density comes from the `@2x` suffix on the file stem (`utils::is_retina`).
+//
+// The two lists differ because the two bundlers accept different sizes, and
+// neither one reports a size that it cannot use.
+//
+// `bundle.icon` in tauri.conf.json and tauri.linux.conf.json MUST match these
+// lists. icon-set.test.mjs fails when they drift.
+
+// Icons that the Linux .deb and .AppImage ship. tauri-bundler installs each one
+// at `usr/share/icons/hicolor/<pixels>x<pixels>[@2]/apps/<binary>.png`.
+//
+// Every size here is a size that the hicolor theme declares in its index.theme.
+// This constraint is the whole reason the list exists: an icon that lands in an
+// undeclared directory installs without an error and stays invisible to every
+// launcher, because an icon lookup reads index.theme and never sees that
+// directory. A 1024x1024 icon named `icon@2x.png` produced exactly that failure
+// -- it installed to `hicolor/1024x1024@2/apps/`, which no theme declares, and
+// the app showed no icon at all (issue #387).
+//
+// The order carries one decision, and only the first entry matters: tauri-codegen
+// embeds the FIRST PNG of `bundle.icon` as the default window icon, decoded to
+// raw RGBA, and GTK publishes that one image as _NET_WM_ICON. 128x128 leads the
+// list because a panel scales it down cleanly to the 24 to 64 pixel button it
+// draws, and it costs 64 KiB of binary. 32x32 would cost 4 KiB and blur when a
+// 48 pixel panel scales it up; the 1024x1024 master would cost 4 MiB. The
+// bundler reads every other entry, so their order is free.
+export const LINUX_ICON_FILES = [
+  '128x128.png',
+  '32x32.png',
+  '48x48.png',
+  '64x64.png',
+  '128x128@2x.png',
+  '256x256.png',
+  '256x256@2x.png',
+  '512x512.png',
+]
+
+// Icons that macOS and Windows ship.
+//
+// The macOS bundler packs each PNG into the .icns through
+// `icns::IconType::from_pixel_size_and_density`, which maps 16, 32, 48, 64, 128,
+// 256, 512, and 1024 pixels only. It resizes anything else down to the next
+// power of two, so a 96 would add a duplicate rather than an icon. The 1024
+// pixel master (`512x512@2x.png`) is the entry the Dock needs at scale 2, and it
+// is also the reason this list stays separate from the Linux one: hicolor
+// declares no directory for 1024 pixels.
+//
+// The master leads the list because `cargo tauri dev` on macOS has no .app
+// bundle to take a Dock icon from, so tauri-codegen embeds the first PNG as the
+// dev Dock icon. It is the default window icon too, which macOS never draws.
+//
+// Windows takes its icon from `icon.ico` -- the WiX installer, the executable
+// resource, and tauri-codegen's window icon each search `bundle.icon` for the
+// first `.ico` -- so the PNGs are inert there and the ICO can stay last.
+export const SHARED_ICON_FILES = [
+  '512x512@2x.png',
+  '32x32.png',
+  '128x128.png',
+  '128x128@2x.png',
+  '256x256.png',
+  '256x256@2x.png',
+  '512x512.png',
+]
+
+// The Windows icon, and the size of the single image inside it.
+export const ICO_FILE = 'icon.ico'
+export const ICO_SIZE = 256
+
+const ICON_NAME_PATTERN = /^(\d+)x(\d+)(@2x)?\.png$/
+
+// Returns the physical pixel size that `name` states. `128x128@2x.png` is 256
+// pixels, because `@2x` means two device pixels for each logical pixel.
+export function pixelSize(name) {
+  const match = ICON_NAME_PATTERN.exec(name)
+  if (!match) {
+    throw new Error(`Icon name ${name} does not have the form <width>x<height>[@2x].png`)
+  }
+  const [, width, height, retina] = match
+  if (width !== height) {
+    throw new Error(`Icon ${name} is not square`)
+  }
+  return Number(width) * (retina ? 2 : 1)
+}
+
+// Returns the path, relative to the package root, where tauri-bundler installs
+// `name` for the binary `binaryName`. Mirrors `list_icon_files` in
+// tauri-bundler's linux/freedesktop module: the directory carries the PNG's
+// pixel dimensions, and `@2` marks the high density variant.
+export function hicolorIconPath(name, binaryName) {
+  const pixels = pixelSize(name)
+  const density = name.includes('@2x') ? '@2' : ''
+  return `usr/share/icons/hicolor/${pixels}x${pixels}${density}/apps/${binaryName}.png`
+}
+
+// Every PNG that the generator renders, so one build serves each platform's
+// list. Declared last because it calls pixelSize while the module evaluates.
+export const ALL_ICON_FILES = [...new Set([...LINUX_ICON_FILES, ...SHARED_ICON_FILES])]
+  .sort((a, b) => pixelSize(a) - pixelSize(b) || a.localeCompare(b))

--- a/desktop/rust/scripts/icon-set.test.mjs
+++ b/desktop/rust/scripts/icon-set.test.mjs
@@ -1,0 +1,152 @@
+// Tests for icon-set.mjs, run by `bun test` via `task test-scripts`.
+//
+// The risk these cover is drift, not arithmetic. The icon set, the two Tauri
+// configs, and the desktop entry template each hold one part of the same fact,
+// and nothing at build time complains when they disagree: tauri-bundler
+// installs whatever size it is given, into a directory it derives from the PNG
+// header, and a launcher that cannot find the icon says nothing either.
+
+import { readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { describe, expect, it } from 'bun:test'
+
+import {
+  ALL_ICON_FILES,
+  hicolorIconPath,
+  ICO_FILE,
+  LINUX_ICON_FILES,
+  pixelSize,
+  SHARED_ICON_FILES,
+} from './icon-set.mjs'
+
+const RUST_DIR = resolve(import.meta.dirname, '..')
+
+// The icon sizes that the hicolor theme declares in its index.theme, taken from
+// the `Directories=` key of the freedesktop default-icon-theme source. Each one
+// exists twice there, as `<size>x<size>/apps` and as `<size>x<size>@2/apps`.
+// Nothing outside this list is reachable: an icon lookup reads index.theme, so a
+// directory that index.theme omits is invisible even though the file is on disk.
+const HICOLOR_SIZES = [16, 22, 24, 32, 36, 48, 64, 72, 96, 128, 192, 256, 512]
+
+function readJson(name) {
+  return JSON.parse(readFileSync(join(RUST_DIR, name), 'utf8'))
+}
+
+const baseConfig = readJson('tauri.conf.json')
+const linuxConfig = readJson('tauri.linux.conf.json')
+
+describe('pixelSize', () => {
+  it('reads the size from a plain name', () => {
+    expect(pixelSize('32x32.png')).toBe(32)
+    expect(pixelSize('512x512.png')).toBe(512)
+  })
+
+  it('doubles the size for a @2x name', () => {
+    expect(pixelSize('128x128@2x.png')).toBe(256)
+    expect(pixelSize('512x512@2x.png')).toBe(1024)
+  })
+
+  it('rejects a name that states no size', () => {
+    expect(() => pixelSize('icon.png')).toThrow('does not have the form')
+    expect(() => pixelSize('128x128@3x.png')).toThrow('does not have the form')
+    expect(() => pixelSize('128x128.ico')).toThrow('does not have the form')
+  })
+
+  it('rejects a name that is not square', () => {
+    expect(() => pixelSize('128x64.png')).toThrow('is not square')
+  })
+})
+
+describe('hicolorIconPath', () => {
+  it('uses the plain directory for a standard density icon', () => {
+    expect(hicolorIconPath('256x256.png', 'leapmux-desktop'))
+      .toBe('usr/share/icons/hicolor/256x256/apps/leapmux-desktop.png')
+  })
+
+  // The bundler takes the directory's size from the PNG header and the `@2`
+  // suffix from the file name, so a 256 pixel @2x file lands under 256x256@2 --
+  // NOT under the 128x128@2 that its name suggests.
+  it('uses the pixel size and the @2 suffix for a high density icon', () => {
+    expect(hicolorIconPath('128x128@2x.png', 'leapmux-desktop'))
+      .toBe('usr/share/icons/hicolor/256x256@2/apps/leapmux-desktop.png')
+  })
+})
+
+describe('LINUX_ICON_FILES', () => {
+  // The regression test for issue #387. The package shipped one 1024x1024 icon
+  // named icon@2x.png, so it installed to hicolor/1024x1024@2/apps/ and no
+  // launcher ever found it.
+  it('holds only sizes that the hicolor theme declares', () => {
+    for (const name of LINUX_ICON_FILES) {
+      const pixels = pixelSize(name)
+      expect(HICOLOR_SIZES).toContain(pixels)
+    }
+  })
+
+  // tauri-codegen embeds the first PNG as the window icon, which GTK publishes
+  // as _NET_WM_ICON. A panel scales 128 down cleanly; 32 would blur when a 48
+  // pixel panel scales it up, and the 1024 master would cost 4 MiB of binary.
+  it('starts with the icon that a panel scales best', () => {
+    expect(LINUX_ICON_FILES[0]).toBe('128x128.png')
+  })
+
+  it('covers the sizes a launcher asks for most', () => {
+    expect(LINUX_ICON_FILES.map(pixelSize)).toEqual(expect.arrayContaining([32, 48, 64, 128, 256, 512]))
+  })
+
+  it('matches bundle.icon in tauri.linux.conf.json', () => {
+    expect(linuxConfig.bundle.icon).toEqual(LINUX_ICON_FILES.map(name => `icons/${name}`))
+  })
+})
+
+describe('SHARED_ICON_FILES', () => {
+  // icns::IconType::from_pixel_size_and_density maps powers of two only. The
+  // macOS bundler resizes anything else down to the next power of two, which
+  // adds a duplicate of a size the set already has.
+  it('holds power of two sizes only', () => {
+    for (const name of SHARED_ICON_FILES) {
+      const pixels = pixelSize(name)
+      expect(Number.isInteger(Math.log2(pixels))).toBe(true)
+    }
+  })
+
+  // `cargo tauri dev` on macOS has no .app bundle to take a Dock icon from, so
+  // tauri-codegen embeds the first PNG for it. The master keeps that icon sharp.
+  it('starts with the 1024 pixel master that the macOS Dock needs at scale 2', () => {
+    expect(SHARED_ICON_FILES[0]).toBe('512x512@2x.png')
+    expect(pixelSize(SHARED_ICON_FILES[0])).toBe(1024)
+  })
+
+  it('matches bundle.icon in tauri.conf.json, with the ICO last', () => {
+    expect(baseConfig.bundle.icon).toEqual([
+      ...SHARED_ICON_FILES.map(name => `icons/${name}`),
+      `icons/${ICO_FILE}`,
+    ])
+  })
+})
+
+describe('ALL_ICON_FILES', () => {
+  it('holds each file of both platform lists exactly once', () => {
+    expect([...new Set(ALL_ICON_FILES)]).toEqual(ALL_ICON_FILES)
+    for (const name of [...LINUX_ICON_FILES, ...SHARED_ICON_FILES]) {
+      expect(ALL_ICON_FILES).toContain(name)
+    }
+  })
+
+  it('adds no file that neither platform ships', () => {
+    const shipped = new Set([...LINUX_ICON_FILES, ...SHARED_ICON_FILES])
+    for (const name of ALL_ICON_FILES) {
+      expect(shipped.has(name)).toBe(true)
+    }
+  })
+})
+
+describe('desktop entry', () => {
+  // The bundler names each icon file after mainBinaryName. A launcher resolves
+  // the Icon key against those file names, so the two must agree.
+  it('looks the icon up by the name the bundler writes', () => {
+    const template = readFileSync(join(RUST_DIR, 'desktop-template.desktop'), 'utf8')
+    const iconKey = /^Icon=(.*)$/m.exec(template)?.[1]
+    expect(iconKey).toBe(linuxConfig.mainBinaryName)
+  })
+})

--- a/desktop/rust/scripts/verify-deb-icons.mjs
+++ b/desktop/rust/scripts/verify-deb-icons.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env bun
+
+// Checks that a built .deb installs its icons where a launcher finds them.
+//
+// Usage: bun verify-deb-icons.mjs <deb> [<deb> ...]
+//
+// icon-set.test.mjs proves that the checked-in config asks for the right sizes.
+// This check proves what the package actually carries, which is the half that a
+// tauri-bundler change can break on its own: the bundler derives each
+// destination from the PNG header plus the `@2x` suffix, so a size that no icon
+// theme declares installs silently and leaves the app with no icon (issue #387).
+//
+// Runs as the last step of `task build-desktop-linux`, after the .deb is
+// repacked, so it reads the file that ships. dpkg-deb is already a hard
+// requirement of that task.
+
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import process from 'node:process'
+
+import { hicolorIconPath, LINUX_ICON_FILES } from './icon-set.mjs'
+
+const RUST_DIR = resolve(import.meta.dirname, '..')
+const HICOLOR_PREFIX = 'usr/share/icons/hicolor/'
+
+// Reads the paths out of a `dpkg-deb -c` listing.
+//
+// Each row is `ls -l` shaped: permissions, owner/group, size, date, time, then
+// the path, which dpkg prefixes with `./`. The path is the rest of the row, not
+// the last field -- it can hold a space, and a symlink row appends ` -> target`.
+// The path group starts with `\S` so that the separator before it stays
+// unambiguous, which also keeps the match linear.
+const LISTING_ROW = /^(\S+) +\S+ +\d+ +\S+ +\S+ +(\S.*)$/
+
+export function parseDebPaths(listing) {
+  const paths = new Set()
+  for (const line of listing.split('\n')) {
+    const row = LISTING_ROW.exec(line)
+    if (!row) {
+      continue
+    }
+    const [, mode, field] = row
+    const path = mode.startsWith('l') ? field.replace(/ -> .*$/, '') : field
+    const relative = path.replace(/^\.\//, '')
+    if (relative !== '') {
+      paths.add(relative)
+    }
+  }
+  return paths
+}
+
+// Returns one message for each icon problem in `paths`, and an empty array when
+// the package is correct.
+export function iconProblems(paths, { icons, desktopEntry }) {
+  const problems = []
+  for (const icon of icons) {
+    if (!paths.has(icon)) {
+      problems.push(`missing ${icon}`)
+    }
+  }
+  if (!paths.has(desktopEntry)) {
+    problems.push(`missing ${desktopEntry}`)
+  }
+
+  // An extra icon is a defect too, not clutter: it means the bundler resolved a
+  // size differently than icon-set.mjs states, and the same drift can move the
+  // icons that a launcher needs.
+  for (const path of paths) {
+    if (path.startsWith(HICOLOR_PREFIX) && path.endsWith('.png') && !icons.includes(path)) {
+      problems.push(`unexpected icon ${path}`)
+    }
+  }
+  return problems
+}
+
+// Reads the names that the .deb is built from. The bundler names each icon file
+// after mainBinaryName and the desktop entry after productName, and the desktop
+// entry's Icon key is what a launcher looks up -- so the Icon key must be the
+// icon file's base name, or the lookup misses every icon the package installs.
+export function expectedContents(rustDir) {
+  const linuxConfig = JSON.parse(readFileSync(join(rustDir, 'tauri.linux.conf.json'), 'utf8'))
+  const template = readFileSync(join(rustDir, 'desktop-template.desktop'), 'utf8')
+  const iconKey = /^Icon=(.*)$/m.exec(template)?.[1]
+  if (iconKey !== linuxConfig.mainBinaryName) {
+    throw new Error(
+      `desktop-template.desktop has Icon=${iconKey}, but the bundler installs icons as ${linuxConfig.mainBinaryName}.png`,
+    )
+  }
+  return {
+    icons: LINUX_ICON_FILES.map(name => hicolorIconPath(name, linuxConfig.mainBinaryName)),
+    desktopEntry: `usr/share/applications/${linuxConfig.productName}.desktop`,
+  }
+}
+
+function main(debPaths) {
+  if (debPaths.length === 0) {
+    console.error('Usage: verify-deb-icons.mjs <deb> [<deb> ...]')
+    process.exit(1)
+  }
+
+  let expected
+  try {
+    expected = expectedContents(RUST_DIR)
+  }
+  catch (error) {
+    console.error(`Icon check failed: ${error.message}`)
+    process.exit(1)
+  }
+
+  const failures = []
+  for (const debPath of debPaths) {
+    // A .deb carries the whole app, so the listing runs to thousands of rows.
+    const listing = execFileSync('dpkg-deb', ['-c', debPath], {
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024,
+    })
+    for (const problem of iconProblems(parseDebPaths(listing), expected)) {
+      failures.push(`${debPath}: ${problem}`)
+    }
+  }
+
+  if (failures.length > 0) {
+    console.error('Icon check failed:')
+    for (const failure of failures) {
+      console.error(`  - ${failure}`)
+    }
+    process.exit(1)
+  }
+
+  console.log(`Verified ${expected.icons.length} icons and the desktop entry in ${debPaths.join(', ')}`)
+}
+
+if (import.meta.main) {
+  main(process.argv.slice(2))
+}

--- a/desktop/rust/scripts/verify-deb-icons.test.mjs
+++ b/desktop/rust/scripts/verify-deb-icons.test.mjs
@@ -1,0 +1,121 @@
+// Tests for verify-deb-icons.mjs, run by `bun test` via `task test-scripts`.
+//
+// The check itself needs a built .deb and dpkg-deb, so only Linux runs it for
+// real. These cover the parts that decide the verdict -- the listing parser and
+// the comparison -- so a check that reports "verified" while reading the rows
+// wrongly cannot pass unnoticed on any platform.
+
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { describe, expect, it } from 'bun:test'
+
+import { hicolorIconPath, LINUX_ICON_FILES } from './icon-set.mjs'
+import { expectedContents, iconProblems, parseDebPaths } from './verify-deb-icons.mjs'
+
+const RUST_DIR = resolve(import.meta.dirname, '..')
+
+// Rows copied from `dpkg-deb -c` over a real leapmux-desktop .deb, with a
+// symlink row and a spaced path added for the shapes dpkg also emits.
+const LISTING = `drwxr-xr-x runner/runner         0 2026-08-15 18:56 ./
+drwxr-xr-x runner/runner         0 2026-08-15 18:56 ./usr/share/icons/hicolor/
+-rw-r--r-- runner/runner     27604 2026-08-15 18:56 ./usr/share/icons/hicolor/256x256@2/apps/leapmux-desktop.png
+-rw-r--r-- runner/runner       199 2026-08-15 18:59 ./usr/share/applications/leapmux-desktop.desktop
+lrwxrwxrwx runner/runner         0 2026-08-15 18:59 ./usr/lib/leapmux-desktop/libfoo.so -> libfoo.so.1
+-rw-r--r-- runner/runner       512 2026-08-15 18:59 ./usr/share/doc/leapmux-desktop/read me.txt
+`
+
+// The layout that shipped as issue #387: one icon, at a size no theme declares.
+function brokenPaths() {
+  return new Set([
+    'usr/share/applications/leapmux-desktop.desktop',
+    'usr/share/icons/hicolor/1024x1024@2/apps/leapmux-desktop.png',
+  ])
+}
+
+function correctPaths() {
+  return new Set([
+    'usr/share/applications/leapmux-desktop.desktop',
+    ...LINUX_ICON_FILES.map(name => hicolorIconPath(name, 'leapmux-desktop')),
+  ])
+}
+
+const EXPECTED = {
+  icons: LINUX_ICON_FILES.map(name => hicolorIconPath(name, 'leapmux-desktop')),
+  desktopEntry: 'usr/share/applications/leapmux-desktop.desktop',
+}
+
+describe('parseDebPaths', () => {
+  const paths = parseDebPaths(LISTING)
+
+  it('strips the ./ prefix that dpkg puts on every row', () => {
+    expect(paths).toContain('usr/share/icons/hicolor/256x256@2/apps/leapmux-desktop.png')
+    expect(paths).toContain('usr/share/applications/leapmux-desktop.desktop')
+  })
+
+  it('takes the link path from a symlink row, not the target', () => {
+    expect(paths).toContain('usr/lib/leapmux-desktop/libfoo.so')
+    expect(paths).not.toContain('libfoo.so.1')
+  })
+
+  it('keeps a path that holds a space whole', () => {
+    expect(paths).toContain('usr/share/doc/leapmux-desktop/read me.txt')
+  })
+
+  it('drops the package root and the trailing blank line', () => {
+    expect(paths).not.toContain('')
+    expect(paths.size).toBe(5)
+  })
+})
+
+describe('iconProblems', () => {
+  it('reports nothing when the package carries the whole set', () => {
+    expect(iconProblems(correctPaths(), EXPECTED)).toEqual([])
+  })
+
+  // The regression check for issue #387, stated as the verifier sees it.
+  it('reports every missing icon and the icon in the undeclared directory', () => {
+    const problems = iconProblems(brokenPaths(), EXPECTED)
+    expect(problems).toContain('missing usr/share/icons/hicolor/32x32/apps/leapmux-desktop.png')
+    expect(problems).toContain('missing usr/share/icons/hicolor/512x512/apps/leapmux-desktop.png')
+    expect(problems).toContain('unexpected icon usr/share/icons/hicolor/1024x1024@2/apps/leapmux-desktop.png')
+    expect(problems).toHaveLength(LINUX_ICON_FILES.length + 1)
+  })
+
+  it('reports a missing desktop entry', () => {
+    const paths = correctPaths()
+    paths.delete('usr/share/applications/leapmux-desktop.desktop')
+    expect(iconProblems(paths, EXPECTED)).toEqual(['missing usr/share/applications/leapmux-desktop.desktop'])
+  })
+
+  it('reports an icon whose name does not match the desktop entry Icon key', () => {
+    const paths = correctPaths()
+    paths.add('usr/share/icons/hicolor/32x32/apps/leapmux.png')
+    expect(iconProblems(paths, EXPECTED)).toEqual(['unexpected icon usr/share/icons/hicolor/32x32/apps/leapmux.png'])
+  })
+
+  it('ignores a non-icon file that sits outside the hicolor tree', () => {
+    const paths = correctPaths()
+    paths.add('usr/share/doc/leapmux-desktop/changelog.gz')
+    expect(iconProblems(paths, EXPECTED)).toEqual([])
+  })
+})
+
+describe('expectedContents', () => {
+  it('derives the icon paths from the checked-in Linux config', () => {
+    const expected = expectedContents(RUST_DIR)
+    expect(expected.icons).toHaveLength(LINUX_ICON_FILES.length)
+    expect(expected.icons).toContain('usr/share/icons/hicolor/32x32/apps/leapmux-desktop.png')
+    expect(expected.desktopEntry).toBe('usr/share/applications/leapmux-desktop.desktop')
+  })
+
+  it('fails when the desktop entry looks up a name the bundler never writes', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'leapmux-icons-'))
+    writeFileSync(join(dir, 'tauri.linux.conf.json'), JSON.stringify({
+      mainBinaryName: 'leapmux-desktop',
+      productName: 'leapmux-desktop',
+    }))
+    writeFileSync(join(dir, 'desktop-template.desktop'), '[Desktop Entry]\nIcon=leapmux\nName=LeapMux Desktop\n')
+    expect(() => expectedContents(dir)).toThrow('Icon=leapmux')
+  })
+})

--- a/desktop/rust/tauri.conf.json
+++ b/desktop/rust/tauri.conf.json
@@ -38,8 +38,14 @@
       "../go/bin/*"
     ],
     "icon": [
-      "icons/icon@2x.png",
-      "./icons/icon.ico"
+      "icons/512x512@2x.png",
+      "icons/32x32.png",
+      "icons/128x128.png",
+      "icons/128x128@2x.png",
+      "icons/256x256.png",
+      "icons/256x256@2x.png",
+      "icons/512x512.png",
+      "icons/icon.ico"
     ]
   }
 }

--- a/desktop/rust/tauri.linux.conf.json
+++ b/desktop/rust/tauri.linux.conf.json
@@ -4,6 +4,16 @@
   "mainBinaryName": "leapmux-desktop",
   "bundle": {
     "targets": ["deb", "appimage"],
+    "icon": [
+      "icons/128x128.png",
+      "icons/32x32.png",
+      "icons/48x48.png",
+      "icons/64x64.png",
+      "icons/128x128@2x.png",
+      "icons/256x256.png",
+      "icons/256x256@2x.png",
+      "icons/512x512.png"
+    ],
     "resources": {
       "../go/bin/leapmux-desktop-service-*-unknown-linux-gnu": ""
     },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,8 +1,9 @@
-// ESLint for the repo-root build scripts.
+// ESLint for the build scripts outside frontend/.
 //
-// These four files are not small: they rewrite tracked source (sync-versions),
-// generate the shipped legal artifact (generate-notice), and drive codegen
-// (sync-generated, build-ico). Nothing linted them until now -- the only config
+// These files are not small: they rewrite tracked source (sync-versions),
+// generate the shipped legal artifact (generate-notice), drive codegen
+// (sync-generated, build-ico), and render and verify the desktop icons
+// (desktop/rust/scripts). Nothing linted them until now -- the only config
 // lived in frontend/, and `eslint .` runs with cwd=frontend, so `../scripts` came
 // back as "File ignored because outside of base path". That is how an unused
 // import sat in the version-rewriting script.
@@ -21,11 +22,14 @@ export default antfu({
     indent: 2,
     quotes: 'single',
   },
-  // Only the repo-root scripts. frontend/ has its own config with the Solid and
-  // Playwright rules these files have no use for.
-  ignores: ['**/*', '!scripts/**'],
+  // Only the scripts outside frontend/. frontend/ has its own config with the
+  // Solid and Playwright rules these files have no use for, and it already
+  // covers frontend/scripts/. The intermediate directories need a negation each,
+  // because `**/*` ignores `desktop/` itself and ESLint cannot re-include a path
+  // below an ignored directory.
+  ignores: ['**/*', '!scripts/**', '!desktop', '!desktop/rust', '!desktop/rust/scripts/**'],
 }, {
-  files: ['scripts/**/*.mjs'],
+  files: ['scripts/**/*.mjs', 'desktop/rust/scripts/**/*.mjs'],
   rules: {
     // These run under `bun scripts/...`, so stdout/stderr IS the interface.
     'no-console': 'off',

--- a/frontend/scripts/generate-icons.mjs
+++ b/frontend/scripts/generate-icons.mjs
@@ -15,8 +15,8 @@
 import { copyFileSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import process from 'node:process'
-import { Resvg } from '@resvg/resvg-js'
 import { buildIco } from '../../scripts/build-ico.mjs'
+import { renderPng } from '../../scripts/render-icon.mjs'
 
 const [roundedSvgPath, squareSvgPath, publicDir] = process.argv.slice(2)
 if (!roundedSvgPath || !squareSvgPath || !publicDir) {
@@ -27,25 +27,8 @@ if (!roundedSvgPath || !squareSvgPath || !publicDir) {
 const roundedSvg = readFileSync(roundedSvgPath)
 const squareSvg = readFileSync(squareSvgPath)
 
-function renderPng(svgData, size, { opaqueCorners } = {}) {
-  const resvg = new Resvg(svgData, { fitTo: { mode: 'width', value: size } })
-  const rendered = resvg.render()
-  if (opaqueCorners !== undefined) {
-    assertCornerAlpha(rendered.pixels, rendered.width, rendered.height, opaqueCorners)
-  }
-  return rendered.asPng()
-}
-
-function assertCornerAlpha(pixels, width, height, shouldBeOpaque) {
-  for (const [x, y] of [[0, 0], [width - 1, 0], [0, height - 1], [width - 1, height - 1]]) {
-    const alpha = pixels[(y * width + x) * 4 + 3]
-    const ok = shouldBeOpaque ? alpha === 255 : alpha === 0
-    if (!ok) {
-      const expected = shouldBeOpaque ? 'opaque' : 'transparent'
-      throw new Error(`Icon ${width}x${height} has alpha=${alpha} at (${x},${y}); expected ${expected} corners`)
-    }
-  }
-}
+// Ensure the icons output directory exists before the first write.
+mkdirSync(join(publicDir, 'icons'), { recursive: true })
 
 // Copy the rounded SVG to public dir for modern browsers.
 copyFileSync(roundedSvgPath, join(publicDir, 'icons', 'leapmux-icon.svg'))
@@ -53,9 +36,6 @@ copyFileSync(roundedSvgPath, join(publicDir, 'icons', 'leapmux-icon.svg'))
 // Generate a favicon ICO from the rounded SVG.
 const ico48Png = renderPng(roundedSvg, 48)
 writeFileSync(join(publicDir, 'icons', 'leapmux-icon.ico'), buildIco(ico48Png, 48))
-
-// Ensure the icons output directory exists.
-mkdirSync(join(publicDir, 'icons'), { recursive: true })
 
 // Generate rounded web icons and square Apple touch icon.
 writeFileSync(join(publicDir, 'icons', 'leapmux-icon-192.png'), renderPng(roundedSvg, 192, { opaqueCorners: false }))

--- a/scripts/icon-corners.mjs
+++ b/scripts/icon-corners.mjs
@@ -1,0 +1,24 @@
+// The corner check that both icon generators apply to a rendered icon.
+//
+// It lives apart from ./render-icon.mjs, which imports @resvg/resvg-js from
+// frontend/node_modules: `bun test` resolves neither NODE_PATH nor that
+// directory, so a test that reaches the renderer cannot run. This half is pure,
+// and it is the half that carries the logic.
+
+// Fails when a corner pixel does not have the alpha that the caller expects.
+// `pixels` is RGBA, four bytes for each pixel, in row order.
+//
+// The two LeapMux sources differ at four pixels only: the rounded icon leaves
+// its corners transparent, and the square icon fills them. A generator that
+// renders the wrong source produces an icon that looks correct everywhere else,
+// so each generator states which source it expects and this check enforces it.
+export function assertCornerAlpha(pixels, width, height, shouldBeOpaque) {
+  for (const [x, y] of [[0, 0], [width - 1, 0], [0, height - 1], [width - 1, height - 1]]) {
+    const alpha = pixels[(y * width + x) * 4 + 3]
+    const ok = shouldBeOpaque ? alpha === 255 : alpha === 0
+    if (!ok) {
+      const expected = shouldBeOpaque ? 'opaque' : 'transparent'
+      throw new Error(`Icon ${width}x${height} has alpha=${alpha} at (${x},${y}); expected ${expected} corners`)
+    }
+  }
+}

--- a/scripts/icon-corners.test.mjs
+++ b/scripts/icon-corners.test.mjs
@@ -1,0 +1,75 @@
+// Tests for icon-corners.mjs, run by `bun test` via `task test-scripts`.
+//
+// This check is the one thing that stops a generator from rendering the wrong
+// SVG source. The two sources differ at four pixels; everything else about the
+// icon -- the colors, the glyph, the size -- looks correct either way, in the
+// build log and in a quick look at the file.
+
+import { describe, expect, it } from 'bun:test'
+
+import { assertCornerAlpha } from './icon-corners.mjs'
+
+// Builds an RGBA buffer of opaque pixels, then sets the four corner alphas in
+// the order [top left, top right, bottom left, bottom right].
+function pixelsWithCornerAlpha(width, height, [topLeft, topRight, bottomLeft, bottomRight]) {
+  const pixels = new Uint8Array(width * height * 4).fill(255)
+  pixels[3] = topLeft
+  pixels[(width - 1) * 4 + 3] = topRight
+  pixels[(height - 1) * width * 4 + 3] = bottomLeft
+  pixels[((height - 1) * width + width - 1) * 4 + 3] = bottomRight
+  return pixels
+}
+
+describe('assertCornerAlpha', () => {
+  it('accepts four opaque corners when it expects opaque', () => {
+    expect(() => assertCornerAlpha(pixelsWithCornerAlpha(4, 4, [255, 255, 255, 255]), 4, 4, true)).not.toThrow()
+  })
+
+  it('accepts four transparent corners when it expects transparent', () => {
+    const pixels = pixelsWithCornerAlpha(4, 4, [0, 0, 0, 0])
+    expect(() => assertCornerAlpha(pixels, 4, 4, false)).not.toThrow()
+  })
+
+  it('rejects opaque corners when it expects transparent', () => {
+    const pixels = pixelsWithCornerAlpha(4, 4, [255, 255, 255, 255])
+    expect(() => assertCornerAlpha(pixels, 4, 4, false)).toThrow('expected transparent corners')
+  })
+
+  it('rejects transparent corners when it expects opaque', () => {
+    const pixels = pixelsWithCornerAlpha(4, 4, [0, 0, 0, 0])
+    expect(() => assertCornerAlpha(pixels, 4, 4, true)).toThrow('expected opaque corners')
+  })
+
+  // Each corner has its own offset, so a check that got one offset wrong would
+  // still pass on an image that is opaque or transparent everywhere.
+  it('reads each of the four corners', () => {
+    const corners = [
+      { alpha: [0, 255, 255, 255], at: '(0,0)' },
+      { alpha: [255, 0, 255, 255], at: '(3,0)' },
+      { alpha: [255, 255, 0, 255], at: '(0,3)' },
+      { alpha: [255, 255, 255, 0], at: '(3,3)' },
+    ]
+    for (const { alpha, at } of corners) {
+      expect(() => assertCornerAlpha(pixelsWithCornerAlpha(4, 4, alpha), 4, 4, true))
+        .toThrow(`Icon 4x4 has alpha=0 at ${at}; expected opaque corners`)
+    }
+  })
+
+  // Anti-aliasing leaves a partly covered corner, which is neither state.
+  it('rejects a corner that is neither fully opaque nor fully transparent', () => {
+    expect(() => assertCornerAlpha(pixelsWithCornerAlpha(4, 4, [128, 255, 255, 255]), 4, 4, true))
+      .toThrow('alpha=128')
+    expect(() => assertCornerAlpha(pixelsWithCornerAlpha(4, 4, [1, 0, 0, 0]), 4, 4, false))
+      .toThrow('alpha=1')
+  })
+
+  it('reads a non-square image at its own width and height', () => {
+    const pixels = pixelsWithCornerAlpha(8, 2, [255, 255, 255, 0])
+    expect(() => assertCornerAlpha(pixels, 8, 2, true)).toThrow('Icon 8x2 has alpha=0 at (7,1)')
+  })
+
+  it('reads the corners of a one pixel image without leaving the buffer', () => {
+    expect(() => assertCornerAlpha(new Uint8Array([0, 0, 0, 255]), 1, 1, true)).not.toThrow()
+    expect(() => assertCornerAlpha(new Uint8Array([0, 0, 0, 0]), 1, 1, true)).toThrow('alpha=0 at (0,0)')
+  })
+})

--- a/scripts/render-icon.mjs
+++ b/scripts/render-icon.mjs
@@ -1,0 +1,27 @@
+// Renders an SVG source to a square PNG, shared by the web icon generator
+// (frontend/scripts/generate-icons.mjs) and the desktop icon generator
+// (desktop/rust/scripts/generate-icons.mjs).
+//
+// Requires @resvg/resvg-js, which the repo installs into frontend/node_modules.
+// Both callers run under `NODE_PATH=frontend/node_modules bun ...`, so importing
+// this module outside that environment fails at load time. The corner check
+// lives in ./icon-corners.mjs for that reason -- it stays reachable from a test.
+
+import { Resvg } from '@resvg/resvg-js'
+
+import { assertCornerAlpha } from './icon-corners.mjs'
+
+// Renders `svgData` at `size` physical pixels and returns the PNG bytes.
+//
+// Pass `opaqueCorners` to assert the corner pixels: `true` for an icon that must
+// fill its square (the macOS app icon, which the system masks itself), `false`
+// for an icon whose rounded corners must stay transparent. Omit it to skip the
+// check.
+export function renderPng(svgData, size, { opaqueCorners } = {}) {
+  const resvg = new Resvg(svgData, { fitTo: { mode: 'width', value: size } })
+  const rendered = resvg.render()
+  if (opaqueCorners !== undefined) {
+    assertCornerAlpha(rendered.pixels, rendered.width, rendered.height, opaqueCorners)
+  }
+  return rendered.asPng()
+}


### PR DESCRIPTION
## Motivation

Fixes #387.

The `.deb` installed exactly one icon, at
`usr/share/icons/hicolor/1024x1024@2/apps/leapmux-desktop.png`, and no launcher
ever found it. The app appeared with no icon at all.

tauri-bundler builds that directory from two facts that it reads separately:
the pixel size comes from the PNG header, and the density comes from the `@2x`
suffix on the file stem (`utils::is_retina`). The build supplied one 1024x1024
PNG named `icon@2x.png`, so both halves of the directory came out wrong. The
hicolor theme declares sizes up to 512 only, and an icon lookup reads
`index.theme`, so a directory that `index.theme` omits stays invisible although
the file is on disk.

Two more consequences followed from the same single icon. tauri-codegen embeds
the first PNG of `bundle.icon` as the default window icon, decoded to raw RGBA,
so the Linux binary carried 4 MiB for an icon that a panel draws at 48 pixels.
The macOS `.icns` held one entry, because a 1024 pixel `@2x` PNG maps to one
icns type.

## Modifications

- **`desktop/rust/scripts/icon-set.mjs` (new)** — the single source of truth for
  the icon set. It states which file names each platform ships, derives the
  pixel size from the name, and derives the hicolor destination the way
  tauri-bundler does.
- **Two platform lists.** Linux ships sizes that hicolor declares (32 through
  512, with the `@2x` variants). macOS and Windows keep the 1024 pixel master,
  because the `.icns` encoder maps powers of two and the Dock wants the master
  at scale 2. Neither list can hold the other's sizes, so `tauri.linux.conf.json`
  overrides `bundle.icon`.
- **Order carries one decision each.** The first PNG is what tauri-codegen
  embeds: `128x128.png` on Linux, which GTK publishes as `_NET_WM_ICON` and a
  panel scales down cleanly, and the master on macOS, which `tauri dev` shows in
  the Dock.
- **`desktop/rust/scripts/verify-deb-icons.mjs` (new)** — reads the icons back
  out of the built `.deb` and fails the Linux build on a missing icon, an icon
  in a directory the set does not name, or a desktop entry whose `Icon` key does
  not match the file names the bundler writes.
- **`scripts/render-icon.mjs` and `scripts/icon-corners.mjs` (new)** — the SVG
  renderer and its corner check, which the web and the desktop generator each
  held a copy of. The corner check lives apart because `bun test` cannot resolve
  `@resvg/resvg-js` from `frontend/node_modules`, and the check is the half that
  carries the logic.
- **`frontend/scripts/generate-icons.mjs`** — creates its output directory
  before the first write instead of after it. The Taskfile's `mkdir -p` was the
  only reason the original order worked.
- **Lint coverage for `desktop/rust/scripts/`**, which no ESLint config reached.
  The two errors it surfaced were dead parameters in the `.DS_Store` generator:
  an unused volume-path argument, and a `--text-size` option that `ds-store` has
  no setter for. Both are gone, together with the arguments `create-dmg.sh`
  passed for them.

### Tests

- `desktop/rust/scripts/icon-set.test.mjs` — the name-to-size and
  name-to-hicolor-path derivations, that every Linux size is one hicolor
  declares (the regression test for this issue), that macOS takes powers of two
  only, and that both Tauri configs match the set.
- `desktop/rust/scripts/verify-deb-icons.test.mjs` — the `dpkg-deb -c` parser
  (symlink rows, spaced paths, the `./` prefix) and the comparison, including
  the exact layout that shipped as #387.
- `scripts/icon-corners.test.mjs` — each of the four corners, both expectations,
  a partly transparent corner, and a one pixel image.
- `task test-scripts` now also runs `desktop/rust/scripts/`.

## Result

A Linux install puts eight icons under the hicolor directories that a launcher
reads, and the desktop entry's `Icon=leapmux-desktop` resolves. The embedded
Linux window icon drops from 4 MiB of raw RGBA to 64 KiB. The macOS `.icns`
carries seven sizes instead of one (verified on a real `task build-desktop-darwin`
run). Two checks keep it that way: the script tests compare the Tauri configs
against the icon set, and the Linux build reads the icons back out of the `.deb`
it just packed.

Verified against the artifact from issue #387: the new check reports the missing
icons and the icon in `1024x1024@2` on that `.deb`, and passes on a package with
the new layout.
