### PR TITLE
fix(shell): Refuse tab placement until the workspace tree is projected

### DIFF
--- a/backend/internal/hub/crdt/validate_test.go
+++ b/backend/internal/hub/crdt/validate_test.go
@@ -524,3 +524,35 @@ func TestValidate_AuthCheck_AllowsOwnerWrite(t *testing.T) {
 	res, _ := crdt.ValidateBatch(context.Background(), pre, []*leapmuxv1.CrdtOp{op, worker, pos}, false, "p1", onlyOwner{allowed: map[string]bool{"w1": true}})
 	assert.Equal(t, leapmuxv1.BatchRejectionReason_BATCH_REJECTION_UNSPECIFIED, res.Reason, "owner write should pass")
 }
+
+// The other arm of the placement invariant: the tile EXISTS and is a live
+// leaf, but no workspace register claims its chain, so the tab would belong to
+// no workspace. Placement itself must reject that — the auth pass's
+// UNKNOWN_WORKSPACE is the second check, and a tab-create batch never reaches
+// it. This is the guard that makes "a tab that belongs to no workspace"
+// uncommitable, whatever client emitted the op; allowAll proves the rejection
+// is structural, not an auth deny.
+func TestValidate_TabPlacement_TabOnTileOutsideAnyWorkspace(t *testing.T) {
+	pre := crdt.NewState("user-1")
+	// A live leaf node that no Workspaces entry lists as its root.
+	crdt.Apply(pre, stamped(&leapmuxv1.SetNodeRegisterOp{
+		NodeId: "orphan-root",
+		Field:  &leapmuxv1.SetNodeRegisterOp_Kind{Kind: leapmuxv1.NodeKind_NODE_KIND_LEAF},
+	}, hlcAt(1, 0, "seed")))
+
+	tab := stamped(&leapmuxv1.SetTabRegisterOp{
+		TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: "t1",
+		Field: &leapmuxv1.SetTabRegisterOp_TileId{TileId: "orphan-root"},
+	}, hlcAt(10, 0, "a"))
+	worker := stamped(&leapmuxv1.SetTabRegisterOp{
+		TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: "t1",
+		Field: &leapmuxv1.SetTabRegisterOp_WorkerId{WorkerId: "w1"},
+	}, hlcAt(10, 1, "a"))
+	pos := stamped(&leapmuxv1.SetTabRegisterOp{
+		TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: "t1",
+		Field: &leapmuxv1.SetTabRegisterOp_Position{Position: "a"},
+	}, hlcAt(10, 2, "a"))
+
+	res, _ := crdt.ValidateBatch(context.Background(), pre, []*leapmuxv1.CrdtOp{tab, worker, pos}, false /* not internal */, "p1", allowAll{})
+	assert.Equal(t, leapmuxv1.BatchRejectionReason_BATCH_REJECTION_TAB_PLACEMENT_INVALID, res.Reason)
+}

--- a/backend/internal/hub/service/crdt_service_test.go
+++ b/backend/internal/hub/service/crdt_service_test.go
@@ -353,6 +353,57 @@ func TestCRDTService_SubmitOps_OriginClientIdSpoofingRejected(t *testing.T) {
 	assert.Equal(t, "wkr1", tab.GetWorkerId().GetValue())
 }
 
+// TestCRDTService_SubmitOps_TabOutsideAnyWorkspaceRejected is the
+// end-to-end form of the tab-placement guard: a batch that creates a tab
+// on a tile no workspace claims is REJECTED, not committed. Browsers and
+// the CLI both refuse to emit such an op client-side (the worker resource
+// is created before the placement op, so a rejection after it strands an
+// orphan); this pins the hub-side check that makes the class impossible
+// for a buggy or hostile client regardless.
+func TestCRDTService_SubmitOps_TabOutsideAnyWorkspaceRejected(t *testing.T) {
+	t.Parallel()
+
+	env := setupCRDTService(t)
+
+	// A live leaf that no workspace register claims — reachable only by
+	// seeding it internally, since a client batch creating it would fail
+	// the same resolution for the node op.
+	_, err := env.mgr.SubmitInternal(context.Background(), crdt.SubmitInput{
+		Batches: []*leapmuxv1.OpBatch{{BatchId: "seed-orphan-leaf", Ops: []*leapmuxv1.CrdtOp{{
+			OpId: "seed-orphan-kind",
+			Body: &leapmuxv1.CrdtOp_SetNodeRegister{SetNodeRegister: &leapmuxv1.SetNodeRegisterOp{
+				NodeId: "orphan-root",
+				Field:  &leapmuxv1.SetNodeRegisterOp_Kind{Kind: leapmuxv1.NodeKind_NODE_KIND_LEAF},
+			}},
+		}}}},
+	})
+	require.NoError(t, err)
+
+	ctx := auth.WithUser(context.Background(), &auth.UserInfo{ID: userid.MustNew(env.userID)})
+	req := connect.NewRequest(&leapmuxv1.SubmitOpsRequest{
+		Epoch:   env.mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch(),
+		Batches: []*leapmuxv1.OpBatch{{BatchId: "b-orphan", Ops: addTabOps("opX", "tOrphan", "orphan-root", "wkr1", "p1")}},
+	})
+
+	resp, err := env.svc.SubmitOps(ctx, req)
+	require.NoError(t, err, "the rejection is in-band, not an RPC error")
+	rejected := resp.Msg.GetResults()[0].GetRejected()
+	require.NotNil(t, rejected, "the batch must be rejected")
+	assert.Equal(t, leapmuxv1.BatchRejectionReason_BATCH_REJECTION_TAB_PLACEMENT_INVALID, rejected.GetReason())
+
+	// Nothing was committed: the tab never entered the materialized state.
+	assert.NotContains(t, env.mgr.State().GetTabs(), "tOrphan")
+	// And the seeded workspace's own root still takes tabs — the guard
+	// rejects the placement, not the submitter.
+	req2 := connect.NewRequest(&leapmuxv1.SubmitOpsRequest{
+		Epoch:   env.mgr.Materialized(crdt.SubscriberFilter{}).GetCurrentEpoch(),
+		Batches: []*leapmuxv1.OpBatch{{BatchId: "b-ok", Ops: addTabOps("opY", "tFine", "root1", "wkr1", "p1")}},
+	})
+	resp2, err := env.svc.SubmitOps(ctx, req2)
+	require.NoError(t, err)
+	require.NotNil(t, resp2.Msg.GetResults()[0].GetCommitted(), "a tab on a registered root still commits")
+}
+
 // TestCRDTService_UpdatePresence_RequiresAuth ensures presence calls
 // without an authenticated user are rejected with Unauthenticated.
 func TestCRDTService_UpdatePresence_RequiresAuth(t *testing.T) {

--- a/frontend/src/components/shell/AppShell.css.ts
+++ b/frontend/src/components/shell/AppShell.css.ts
@@ -1,6 +1,7 @@
 import { style } from '@vanilla-extract/css'
 import { resizeHandleSelectors } from '~/styles/resizeHandle'
 import { motion } from '~/styles/tokens'
+import { tileContent } from './Tile.css'
 
 export const shell = style({
   height: '100%',
@@ -230,14 +231,15 @@ export const sheetOverlayOpen = style({
 // returned by `renderTileContent`. Without this wrapper the tilePanes fall
 // out of flow (`position: absolute; inset: 0`) and only the tab bar +
 // composer end up in mobileCenter's flex flow — collapsing the composer
-// up against the tab bar at the top of the viewport. Mirrors the desktop
-// `tileContent` style at `./Tile.css.ts`.
-export const mobileTilePaneSlot = style({
-  flex: 1,
-  minHeight: 0,
-  position: 'relative',
-  overflow: 'hidden',
-})
+// up against the tab bar at the top of the viewport. Composes the desktop
+// `tileContent` class at `./Tile.css.ts` so the shared flex facts have one
+// definition; `minHeight: 0` is the one mobile delta — the slot is a
+// shrinking child of mobileCenter's column, while the desktop slot sits in
+// `tile` which already carries it. The in-flow empty states
+// (`emptyTileActions`, `placeholder`) center their content by growing with
+// `flex: 1`, which only fills this pane when the slot itself is a flex
+// container — without it they pinned to the top.
+export const mobileTilePaneSlot = style([tileContent, { minHeight: 0 }])
 
 // --- End mobile layout styles ---
 

--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -88,6 +88,7 @@ import { useTurnEnd } from './useTurnEnd'
 import { useWorkerPrivateStreams } from './useWorkerPrivateStreams'
 import { useWorkerSection } from './useWorkerSection'
 import { useWorkspaceLoader } from './useWorkspaceLoader'
+import { WorkspaceCenterFallback } from './WorkspaceCenterFallback'
 import { createWorkspaceSwitcher } from './workspaceSwitcher'
 
 const log = createLogger('shell')
@@ -703,21 +704,42 @@ export const AppShell: Component = () => {
   })
 
   /**
-   * Has the bootstrap delivered the workspace on screen? The ONE question the
-   * tiling area paints on.
+   * Has the bootstrap delivered the workspace on screen? The ONE question
+   * the tiling area paints on — and, through `placementTileId`, the one
+   * tab placement asks, so the render gate and the create guards agree by
+   * construction instead of by coincidence.
    *
-   * Asked of the projection rather than tracked in a flag, so nothing can force
-   * it true. That distinction is the whole point: `state.root` falls back to a
-   * locally-minted placeholder leaf when the projection has no tree, and
-   * painting that as real gives its action handlers a node the hub has never
-   * heard of. The "open a new agent / terminal" affordances create the worker
-   * resource BEFORE emitting the op, so the rejected batch leaves an orphaned
-   * agent behind with no tab to reach it by.
+   * Asked of the projection rather than tracked in a flag, so nothing can
+   * force it true. That distinction is the whole point: a workspace
+   * RECORD can arrive without its tree (a split registration batch), and
+   * `state.root` then falls back to a locally-minted placeholder leaf.
+   * Painting that as real gives its action handlers a node the hub has
+   * never heard of. The "open a new agent / terminal" affordances create
+   * the worker resource BEFORE emitting the op, so the rejected batch
+   * leaves an orphaned agent behind with no tab to reach it by.
    */
   const workspaceReady = createMemo(() => {
     const wsId = workspace.activeWorkspaceId()
-    return !!wsId && hasWorkspace(wsId)
+    return !!wsId && hasWorkspace(wsId) && layoutStore.hasProjectedTree()
   })
+
+  /**
+   * The center's render gate, derived once for both layouts: boolean by
+   * construction so a workspace-list refresh that swaps the ACTIVE
+   * workspace's object identity (a rename, a lifecycle event) cannot
+   * re-run the mobile tile-content insert and remount every pane — the
+   * memo's output simply stays `true`.
+   */
+  const centerReady = createMemo(() => !!activeWorkspace() && workspaceReady())
+
+  /** The shared "nothing to tile" input: no selection AND no saved id. */
+  const centerNoWorkspace = createMemo(() => !activeWorkspace() && !workspace.activeWorkspaceId())
+
+  const openNewWorkspaceDialog = () => {
+    newWorkspaceDialog.open({
+      targetSectionId: sectionStore.getInProgressSection()?.id ?? null,
+    })
+  }
 
   // Watchdog: never leave the shell silent forever on a bootstrap that never
   // arrives.
@@ -1103,7 +1125,27 @@ export const AppShell: Component = () => {
       leftSidebarElement={createLeftSidebarElement(sidebarOpts())}
       rightSidebarElement={createRightSidebarElement(sidebarOpts())}
       tabBarElement={tileRenderer.tabBarElement()}
-      tileContent={tileRenderer.renderTileContent(layoutStore.focusedTileId())}
+      tileContent={
+        // The same gate the desktop center paints on, for the same reason:
+        // `state.root` falls back to a locally-minted placeholder leaf while
+        // the projection has no tree, and rendering tile content against it
+        // hands its action handlers a node the hub has never heard of. A
+        // ternary (not <Show>) so the expression keeps re-deriving on a
+        // focusedTileId change — MobileLayout's insert runs this getter in a
+        // tracking scope. `centerReady()` is a BOOLEAN memo on purpose: the
+        // insert would otherwise track `activeWorkspace()` by object
+        // identity, and a list refresh that swaps the active workspace's
+        // row would remount every pane mid-use.
+        centerReady()
+          ? tileRenderer.renderTileContent(layoutStore.focusedTileId())
+          : (
+              <WorkspaceCenterFallback
+                noWorkspace={centerNoWorkspace()}
+                bootstrapTimedOut={bootstrapTimedOut()}
+                onNewWorkspace={openNewWorkspaceDialog}
+              />
+            )
+      }
       editorPanel={
         tileRenderer.focusedAgentId() && !isActiveWorkspaceArchived()
         && <tileRenderer.FocusedAgentEditorPanel containerHeight={0} />
@@ -1128,15 +1170,11 @@ export const AppShell: Component = () => {
           setRightSidebarVisible={setRightSidebarVisible}
           layoutStore={layoutStore}
           activeWorkspaceId={workspace.activeWorkspaceId()}
-          activeWorkspace={activeWorkspace}
-          workspaceReady={workspaceReady()}
+          centerReady={centerReady()}
+          centerNoWorkspace={centerNoWorkspace()}
           bootstrapTimedOut={bootstrapTimedOut()}
           getInProgressSectionId={() => sectionStore.getInProgressSection()?.id ?? null}
-          onNewWorkspace={() => {
-            newWorkspaceDialog.open({
-              targetSectionId: sectionStore.getInProgressSection()?.id ?? null,
-            })
-          }}
+          onNewWorkspace={openNewWorkspaceDialog}
           setCenterPanelHeight={setCenterPanelHeight}
           renderTile={tileRenderer.renderTile}
           onRatioChange={(splitId, ratios) => layoutStore.updateRatios(splitId, ratios)}
@@ -1231,6 +1269,7 @@ export const AppShell: Component = () => {
           newBranch,
         )}
         activeWorkspace={activeWorkspace}
+        isActiveWorkspaceMutatable={isActiveWorkspaceMutatable}
         getCurrentTabContext={getCurrentTabContext}
         agentOps={agentOps}
         termOps={termOps}

--- a/frontend/src/components/shell/AppShellDialogs.test.tsx
+++ b/frontend/src/components/shell/AppShellDialogs.test.tsx
@@ -32,6 +32,22 @@ vi.mock('~/components/common/Toast', () => ({
   showErrorToast: vi.fn(),
 }))
 
+// The two creation dialogs are stubbed for the same reason ChangeBranchDialog
+// is (see below): this suite tests the PARENT's plumbing, not the dialogs' own
+// fields. The stubs surface the guard reason the parent computes so a test can
+// assert what the real dialog would disable submit on.
+vi.mock('~/components/shell/NewAgentDialog', () => ({
+  NewAgentDialog: (props: { blockedReason?: () => string | undefined, onClose: () => void }) => (
+    <div data-testid="new-agent-stub">{props.blockedReason?.() ?? ''}</div>
+  ),
+}))
+
+vi.mock('~/components/shell/NewTerminalDialog', () => ({
+  NewTerminalDialog: (props: { blockedReason?: () => string | undefined, onClose: () => void }) => (
+    <div data-testid="new-terminal-stub">{props.blockedReason?.() ?? ''}</div>
+  ),
+}))
+
 // This stub replaces the ChangeBranch slot, so a test can fire its callbacks
 // in the HOSTILE order (close, then notify). The stub does not drive that
 // dialog's git-mode UI. The point under test is the parent closure, not the
@@ -40,11 +56,13 @@ vi.mock('~/components/common/Toast', () => ({
 // create.
 vi.mock('~/components/workspace/ChangeBranchDialog', () => ({
   ChangeBranchDialog: (props: {
+    blockedReason?: () => string | undefined
     onBranchChanged?: (branch: string) => void
     onTerminalCreated?: (terminalId: string, workerId: string, workingDir: string, title: string) => void
     onClose: () => void
   }) => (
     <>
+      <div data-testid="change-branch-blocked">{props.blockedReason?.() ?? ''}</div>
       <button
         type="button"
         data-testid="change-branch-stub"
@@ -93,7 +111,10 @@ function makeDialogs(): AppShellDialogStates {
   }
 }
 
-function renderDialogs(activeWorkspace: () => { id: string } | null = () => null) {
+function renderDialogs(
+  activeWorkspace: () => { id: string } | null = () => null,
+  opts: { placementTileId?: string, mutatable?: boolean } = {},
+) {
   const dialogs = makeDialogs()
   const onBranchChanged = vi.fn()
   const closeWorktreeTabs = vi.fn().mockResolvedValue({
@@ -102,7 +123,10 @@ function renderDialogs(activeWorkspace: () => { id: string } | null = () => null
     stillReferenced: false,
     unknown: false,
   })
-  const focusedTileId = vi.fn(() => '')
+  // `placementTileId` answers where a new tab would land — `''` means no
+  // projected tree. `hasPlaceableTab` asks exactly this, so one knob drives
+  // every guard-reason arm.
+  const placementTileId = vi.fn(() => opts.placementTileId ?? '')
   // `satisfies` type-checks the fields this fixture DOES fill, so a rename
   // of `closeWorktreeTabs` or a change to the TabContext shape fails to
   // compile. The one widening cast stays at the render call, because each
@@ -116,7 +140,8 @@ function renderDialogs(activeWorkspace: () => { id: string } | null = () => null
     onBranchChanged,
     tabOps: tabOps as unknown as ReturnType<typeof useTabOperations>,
     activeWorkspace,
-    layoutStore: { focusedTileId } as unknown as ComponentProps<typeof AppShellDialogs>['layoutStore'],
+    isActiveWorkspaceMutatable: () => opts.mutatable ?? true,
+    layoutStore: { placementTileId } as unknown as ComponentProps<typeof AppShellDialogs>['layoutStore'],
     getCurrentTabContext: () => ({
       workerId: 'w1',
       workingDir: '/repo',
@@ -125,7 +150,7 @@ function renderDialogs(activeWorkspace: () => { id: string } | null = () => null
     }),
   } satisfies Partial<ComponentProps<typeof AppShellDialogs>>
   render(() => <AppShellDialogs {...(props as unknown as ComponentProps<typeof AppShellDialogs>)} />)
-  return { dialogs, onBranchChanged, closeWorktreeTabs, focusedTileId }
+  return { dialogs, onBranchChanged, closeWorktreeTabs, placementTileId }
 }
 
 async function chooseSwitchToAndConfirm(branch: string) {
@@ -343,7 +368,7 @@ describe('appShellDialogs branch dialogs', () => {
   // may only join the focused tile when the dialog's own workspace IS the
   // active one; otherwise it lands in the wrong workspace's tree.
   it('change branch: inserts a created tab only when the dialog targets the active workspace', async () => {
-    const { dialogs, focusedTileId } = renderDialogs(() => ({ id: 'ws1' }))
+    const { dialogs, placementTileId } = renderDialogs(() => ({ id: 'ws1' }))
     dialogs.changeBranch.open({
       workerId: 'w2',
       gitToplevel: '/other',
@@ -354,11 +379,11 @@ describe('appShellDialogs branch dialogs', () => {
 
     fireEvent.click(await screen.findByTestId('change-branch-terminal-stub'))
 
-    expect(focusedTileId).toHaveBeenCalled()
+    expect(placementTileId).toHaveBeenCalled()
   })
 
   it('change branch: skips the tab insertion when the dialog targets another workspace', async () => {
-    const { dialogs, focusedTileId } = renderDialogs(() => ({ id: 'another-ws' }))
+    const { dialogs, placementTileId } = renderDialogs(() => ({ id: 'another-ws' }))
     dialogs.changeBranch.open({
       workerId: 'w2',
       gitToplevel: '/other',
@@ -369,6 +394,77 @@ describe('appShellDialogs branch dialogs', () => {
 
     fireEvent.click(await screen.findByTestId('change-branch-terminal-stub'))
 
-    expect(focusedTileId).not.toHaveBeenCalled()
+    expect(placementTileId).not.toHaveBeenCalled()
+  })
+
+  // The change-branch guard reason describes the ACTIVE workspace's
+  // placement — the same condition the tab-insertion callbacks gate on. A
+  // dialog opened against another workspace's branch row places no local
+  // tab, so it must not inherit a reason it cannot act on.
+  it('change branch: hands the guard reason only when the dialog targets the active workspace', async () => {
+    const { dialogs } = renderDialogs(() => ({ id: 'ws1' }), { placementTileId: '' })
+    dialogs.changeBranch.open({
+      workerId: 'w2',
+      gitToplevel: '/other',
+      workspaceId: 'ws1',
+      branchName: 'feature',
+      isWorktree: false,
+    })
+
+    expect(await screen.findByTestId('change-branch-blocked')).toHaveTextContent(/not ready yet/i)
+  })
+
+  it('change branch: passes no reason when the dialog targets another workspace', async () => {
+    const { dialogs } = renderDialogs(() => ({ id: 'another-ws' }), { placementTileId: '' })
+    dialogs.changeBranch.open({
+      workerId: 'w2',
+      gitToplevel: '/other',
+      workspaceId: 'ws1',
+      branchName: 'feature',
+      isWorktree: false,
+    })
+
+    expect(await screen.findByTestId('change-branch-blocked')).toHaveTextContent(/^$/)
+  })
+
+  // A tab is placed onto the active workspace's projected tree, so the
+  // creation dialogs must not create the worker-side agent/pty when there is
+  // nowhere to place it — the placement refusal arrives only after the RPC,
+  // and the resource it strands has no tab to reach it by. The parent hands
+  // the dialogs the reason; these pin its outcomes, one per arm.
+  describe('new-tab guard reason', () => {
+    it('tells the dialogs to block creation when there is no workspace at all', async () => {
+      const { dialogs } = renderDialogs(() => null)
+      dialogs.newAgent.open()
+
+      expect(await screen.findByTestId('new-agent-stub')).toHaveTextContent(/create a workspace first/i)
+    })
+
+    it('blocks while the active workspace has no projected tree yet', async () => {
+      // placementTileId '' — the tree never arrived, so nothing can take a tab.
+      const { dialogs } = renderDialogs(() => ({ id: 'ws1' }), { placementTileId: '' })
+      dialogs.newTerminal.open()
+
+      expect(await screen.findByTestId('new-terminal-stub')).toHaveTextContent(/not ready yet/i)
+    })
+
+    it('blocks when the active workspace is archived', async () => {
+      // An archived workspace keeps its tree, so only the mutatability arm
+      // fires — the same refusal every quick-action path applies.
+      const { dialogs } = renderDialogs(() => ({ id: 'ws1' }), { placementTileId: 'tile-1', mutatable: false })
+      dialogs.newAgent.open()
+
+      expect(await screen.findByTestId('new-agent-stub')).toHaveTextContent(/archived/i)
+    })
+
+    it('passes no reason once the workspace can take a tab', async () => {
+      const { dialogs } = renderDialogs(
+        () => ({ id: 'ws1' }),
+        { placementTileId: 'tile-1' },
+      )
+      dialogs.newAgent.open()
+
+      expect(await screen.findByTestId('new-agent-stub')).toHaveTextContent(/^$/)
+    })
   })
 })

--- a/frontend/src/components/shell/AppShellDialogs.tsx
+++ b/frontend/src/components/shell/AppShellDialogs.tsx
@@ -25,7 +25,7 @@ import { openedTerminalMetadata, protoToAgentTabFields } from '~/stores/tab.help
 import { LastTabCloseDialog } from './LastTabCloseDialog'
 import { NewAgentDialog } from './NewAgentDialog'
 import { NewTerminalDialog } from './NewTerminalDialog'
-import { openTabInFocusedTile } from './openTabInFocusedTile'
+import { hasPlaceableTab, openTabInFocusedTile } from './openTabInFocusedTile'
 import { placeWorkspaceInSection } from './placeWorkspaceInSection'
 
 export interface KeyPinConfirmState {
@@ -115,6 +115,8 @@ interface AppShellDialogsProps {
    */
   onBranchChanged?: (repo: RepoRef, newBranch: string) => void
   activeWorkspace: () => { id: string } | null
+  /** False while the active workspace is archived — read-only, so no new tabs. */
+  isActiveWorkspaceMutatable: () => boolean
   getCurrentTabContext: () => TabContext
   agentOps: ReturnType<typeof useAgentOperations>
   termOps: ReturnType<typeof useTerminalOperations>
@@ -153,6 +155,23 @@ export const AppShellDialogs: Component<AppShellDialogsProps> = (props) => {
     )
   }
 
+  /**
+   * Why a new tab cannot be created right now, or undefined when it can.
+   * A tab is placed onto the active workspace's projected tree, so the
+   * workspace, its mutatability, and its tree are preconditions — the
+   * dialogs disable submit on this reason instead of creating the
+   * worker-side agent/pty first and orphaning it when placement refuses.
+   */
+  const newTabBlockedReason = (): string | undefined => {
+    if (!props.activeWorkspace())
+      return 'Create a workspace first — a tab lives inside a workspace.'
+    if (!props.isActiveWorkspaceMutatable())
+      return 'This workspace is archived. Unarchive it to create tabs.'
+    if (!hasPlaceableTab(props.layoutStore))
+      return 'The workspace view is not ready yet. Try again in a moment.'
+    return undefined
+  }
+
   return (
     <>
       <Show when={props.dialogs.newAgent.isOpen()}>
@@ -161,6 +180,7 @@ export const AppShellDialogs: Component<AppShellDialogsProps> = (props) => {
           defaultWorkingDir={props.getCurrentTabContext().workingDir}
           availableProviders={props.availableProviders}
           onRefreshProviders={props.onRefreshProviders}
+          blockedReason={newTabBlockedReason}
           onCreated={(agent) => {
             props.dialogs.newAgent.close()
             addAgentTabToFocusedTile(agent)
@@ -174,6 +194,7 @@ export const AppShellDialogs: Component<AppShellDialogsProps> = (props) => {
         <NewTerminalDialog
           defaultWorkerId={props.getCurrentTabContext().workerId}
           defaultWorkingDir={props.getCurrentTabContext().workingDir}
+          blockedReason={newTabBlockedReason}
           onCreated={(terminalId, workerId, workingDir, title) => {
             props.dialogs.newTerminal.close()
             if (!props.activeWorkspace())
@@ -298,6 +319,14 @@ export const AppShellDialogs: Component<AppShellDialogsProps> = (props) => {
             availableProviders={props.availableProviders}
             onRefreshProviders={props.onRefreshProviders}
             onBranchChanged={newBranch => props.onBranchChanged?.(state, newBranch)}
+            // The guard reason describes the ACTIVE workspace's placement
+            // (the same condition the onAgentCreated/onTerminalCreated
+            // callbacks below gate on) — a dialog opened against another
+            // workspace's branch row places no local tab, so no reason
+            // applies to it.
+            blockedReason={() => state.workspaceId === props.activeWorkspace()?.id
+              ? newTabBlockedReason()
+              : undefined}
             // Local-UI tab insertion only applies when the dialog's
             // target workspace IS the active one — addAgentTabToFocusedTile
             // and addTerminalTabToFocusedTile place the tab on the ACTIVE

--- a/frontend/src/components/shell/BlockedReasonNotice.test.tsx
+++ b/frontend/src/components/shell/BlockedReasonNotice.test.tsx
@@ -1,0 +1,35 @@
+/// <reference types="vitest/globals" />
+import { render, screen } from '@solidjs/testing-library'
+import { createSignal } from 'solid-js'
+import { describe, expect, it } from 'vitest'
+import { BlockedReasonNotice } from './BlockedReasonNotice'
+
+describe('blockedReasonNotice', () => {
+  it('renders the reason under the shared testid', () => {
+    render(() => <BlockedReasonNotice reason="Create a workspace first." />)
+    expect(screen.getByTestId('new-tab-blocked-reason')).toHaveTextContent('Create a workspace first.')
+  })
+
+  it('renders nothing when there is no reason', () => {
+    const { container } = render(() => <BlockedReasonNotice reason={undefined} />)
+    expect(container.textContent).toBe('')
+  })
+
+  it('follows the reason reactively — an empty string hides the notice', () => {
+    const [reason, setReason] = createSignal<string | undefined>('Not ready.')
+    const { container } = render(() => <BlockedReasonNotice reason={reason()} />)
+    expect(screen.getByTestId('new-tab-blocked-reason')).toBeInTheDocument()
+
+    setReason(undefined)
+    expect(container.textContent).toBe('')
+  })
+
+  it('re-appears when a reason arrives after mount', () => {
+    const [reason, setReason] = createSignal<string | undefined>(undefined)
+    render(() => <BlockedReasonNotice reason={reason()} />)
+    expect(screen.queryByTestId('new-tab-blocked-reason')).toBeNull()
+
+    setReason('The workspace view is not ready yet.')
+    expect(screen.getByTestId('new-tab-blocked-reason')).toHaveTextContent('The workspace view is not ready yet.')
+  })
+})

--- a/frontend/src/components/shell/BlockedReasonNotice.tsx
+++ b/frontend/src/components/shell/BlockedReasonNotice.tsx
@@ -1,0 +1,27 @@
+import type { Component } from 'solid-js'
+import { Show } from 'solid-js'
+import { DialogTopSection } from '~/components/common/Dialog'
+import { errorText } from '~/styles/shared.css'
+
+interface BlockedReasonNoticeProps {
+  /**
+   * Why submit is disabled — a precondition outside the dialog (no
+   * placeable tile, an archived workspace). Nothing renders when empty.
+   */
+  reason: string | undefined
+}
+
+/**
+ * The blocked-precondition notice shared by the tab-creating dialogs:
+ * one shape, one testid, so New Agent, New Terminal, and the
+ * Change-branch worktree flow cannot drift on how the reason renders.
+ */
+export const BlockedReasonNotice: Component<BlockedReasonNoticeProps> = props => (
+  <Show when={props.reason}>
+    {reason => (
+      <DialogTopSection>
+        <div class={errorText} data-testid="new-tab-blocked-reason">{reason()}</div>
+      </DialogTopSection>
+    )}
+  </Show>
+)

--- a/frontend/src/components/shell/DesktopLayout.tsx
+++ b/frontend/src/components/shell/DesktopLayout.tsx
@@ -1,18 +1,15 @@
 import type { Accessor, Component, JSX } from 'solid-js'
 import type { createLayoutStore, GridAxis } from '~/stores/layout.store'
-import Plus from 'lucide-solid/icons/plus'
 import { createEffect, createSignal, onCleanup, onMount, Show } from 'solid-js'
 import { ChatDropZone } from '~/components/chat/ChatDropZone'
-import { Icon } from '~/components/common/Icon'
-import { StartupErrorBody } from '~/components/common/StartupPanel'
 import { useShortcutContext } from '~/hooks/useShortcutContext'
 import { PREFIX_SIDEBAR, sessionStorageGet, sessionStorageSet } from '~/lib/browserStorage'
 import { trailingDebounce } from '~/lib/debounce'
 import { createRafResizeObserver } from '~/lib/resizeObserver'
-import { getShortcutHintsText } from '~/lib/shortcuts/display'
 import * as styles from './AppShell.css'
 import { TilingLayout } from './TilingLayout'
 import { useWindowPointerDrag } from './windowPointerDrag'
+import { WorkspaceCenterFallback } from './WorkspaceCenterFallback'
 
 const DEFAULT_SIDEBAR_PX = 250
 const MIN_SIDEBAR_PX = 250
@@ -123,10 +120,10 @@ interface SidebarState {
 interface DesktopLayoutProps {
   layoutStore: ReturnType<typeof createLayoutStore>
   activeWorkspaceId: string | null | undefined
-  activeWorkspace: () => { id: string } | null
   /**
-   * Has the CRDT bootstrap delivered the active workspace? The tiling area
-   * paints only when this is true.
+   * The center's render gate, derived once in AppShell and shared with the
+   * mobile center: true only when the active workspace exists AND its tree
+   * arrived in the projection.
    *
    * Deliberately NOT `!workspaceLoading`: a watchdog clears that flag on a timer
    * so a wedged bootstrap still renders something, and painting on it meant
@@ -135,7 +132,9 @@ interface DesktopLayoutProps {
    * "open a new agent/terminal" affordances create the worker resource BEFORE
    * that op, so the rejected batch leaves an orphan behind.
    */
-  workspaceReady: boolean
+  centerReady: boolean
+  /** No workspace selected at all — paints the create-workspace empty state. */
+  centerNoWorkspace: boolean
   /** The watchdog fired and the bootstrap still has not delivered a workspace. */
   bootstrapTimedOut: boolean
   getInProgressSectionId: () => string | null
@@ -434,44 +433,13 @@ export const DesktopLayout: Component<DesktopLayoutProps> = (props) => {
           }}
         >
           <Show
-            when={props.activeWorkspace() && props.workspaceReady}
+            when={props.centerReady}
             fallback={(
-              <Show
-                when={!props.activeWorkspace() && !props.activeWorkspaceId}
-                fallback={(
-                  // A workspace IS selected but its state has not arrived. Silence
-                  // is only right while it might still be coming: once the watchdog
-                  // has given up, an outage would otherwise render identically to a
-                  // workspace with no tabs, for the rest of the page.
-                  <Show when={props.bootstrapTimedOut}>
-                    <div class={styles.emptyTileActions} data-testid="workspace-bootstrap-failed">
-                      <StartupErrorBody
-                        title="Couldn't load this workspace"
-                        error="The workspace's state never arrived. Check your connection to the hub, then reload."
-                      />
-                      <button class="outline" onClick={() => window.location.reload()}>
-                        <span class={styles.emptyTileActionContent}><span>Reload</span></span>
-                      </button>
-                    </div>
-                  </Show>
-                )}
-              >
-                <div class={styles.emptyTileActions} data-testid="no-workspace-empty-state">
-                  <button
-                    class="outline"
-                    data-testid="create-workspace-button"
-                    onClick={props.onNewWorkspace}
-                  >
-                    <Icon icon={Plus} size="sm" />
-                    <span class={styles.emptyTileActionContent}>
-                      <span>Create a new workspace...</span>
-                      <Show when={getShortcutHintsText('app.newWorkspaceDialog')}>
-                        {shortcut => <span class={styles.emptyTileActionShortcut}>{shortcut()}</span>}
-                      </Show>
-                    </span>
-                  </button>
-                </div>
-              </Show>
+              <WorkspaceCenterFallback
+                noWorkspace={props.centerNoWorkspace}
+                bootstrapTimedOut={props.bootstrapTimedOut}
+                onNewWorkspace={props.onNewWorkspace}
+              />
             )}
           >
             <ChatDropZone onDrop={props.onFileDrop} disabled={props.fileDropDisabled}>

--- a/frontend/src/components/shell/NewAgentDialog.test.tsx
+++ b/frontend/src/components/shell/NewAgentDialog.test.tsx
@@ -1,0 +1,90 @@
+/// <reference types="vitest/globals" />
+import { create } from '@bufbuild/protobuf'
+import { fireEvent, render, screen, waitFor } from '@solidjs/testing-library'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as workerRpc from '~/api/workerRpc'
+import { NewAgentDialog } from '~/components/shell/NewAgentDialog'
+import { WorkerSchema } from '~/generated/leapmux/v1/worker_pb'
+
+// The agent dialog's own guard wiring, mirroring the terminal twin: the
+// parent computes the reason (AppShellDialogs suite), but THIS component
+// stops the worker RPC — the notice renders, submit disables, and a form
+// submit fires no openAgent. The wiring is token-identical to
+// NewTerminalDialog's today; without this file it had no component-level
+// pin, so dropping the `blockedReason` field or the notice passed every
+// suite (the AppShellDialogs stub replaces the component entirely).
+vi.mock('~/api/clients', () => ({
+  workerClient: {
+    // The dialog context filters the fleet to ONLINE workers before it
+    // applies the preselection, so the one mock worker must be online.
+    listWorkers: vi.fn(async () => ({
+      workers: [create(WorkerSchema, { id: 'w-1', online: true })],
+    })),
+  },
+}))
+
+// Bare-success shapes are enough: the dialog only reads resp fields it
+// needs, and the point of these mocks is to let the tree mount — a MISSING
+// export throws inside the render chain and takes the shells effect down
+// with it, which is exactly what these mocks exist to prevent.
+vi.mock('~/api/workerRpc', () => ({
+  getGitInfo: vi.fn(async () => ({})),
+  getWorkerSystemInfo: vi.fn(async () => ({})),
+  statFile: vi.fn(async () => ({})),
+  listDirectory: vi.fn(async () => ({ entries: [] })),
+  openAgent: vi.fn(async () => ({})),
+}))
+
+const openAgentMock = workerRpc.openAgent as unknown as ReturnType<typeof vi.fn>
+
+function renderDialog(blockedReason?: () => string | undefined) {
+  return render(() => (
+    <NewAgentDialog
+      defaultWorkerId="w-1"
+      defaultWorkingDir="/tmp"
+      blockedReason={blockedReason}
+      onCreated={() => {}}
+      onClose={() => {}}
+    />
+  ))
+}
+
+async function findCreateButton(): Promise<HTMLButtonElement> {
+  await screen.findByRole('button', { name: 'Create' })
+  return screen.getByRole('button', { name: 'Create' }) as HTMLButtonElement
+}
+
+describe('newAgentDialog tab-placement guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows the blocked reason, disables submit, and fires no openAgent', async () => {
+    renderDialog(() => 'Create a workspace first — a tab lives inside a workspace.')
+
+    expect(await screen.findByTestId('new-tab-blocked-reason'))
+      .toHaveTextContent(/create a workspace first/i)
+    expect(await findCreateButton()).toBeDisabled()
+
+    // The footer's button is `type=submit`, but programmatic submits (Enter
+    // in an input) reach the same form handler — which re-checks the gate
+    // and bails before the RPC.
+    const form = document.querySelector('form')
+    expect(form, 'the shell wraps body + footer in a form').toBeTruthy()
+    fireEvent.submit(form!)
+
+    expect(openAgentMock, 'the blocked guard holds before the worker RPC').not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled()
+  })
+
+  it('keeps submit enabled once the placement precondition passes', async () => {
+    // The companion that proves the BLOCKED reason is the disabler above:
+    // with no reason and the same worker/dir state, submit arms.
+    renderDialog()
+
+    await waitFor(async () => {
+      expect(await findCreateButton()).not.toBeDisabled()
+    })
+    expect(screen.queryByTestId('new-tab-blocked-reason')).toBeNull()
+  })
+})

--- a/frontend/src/components/shell/NewAgentDialog.tsx
+++ b/frontend/src/components/shell/NewAgentDialog.tsx
@@ -1,10 +1,11 @@
 import type { Component } from 'solid-js'
 import type { AgentInfo, AgentProvider } from '~/generated/leapmux/v1/agent_pb'
-import { Show } from 'solid-js'
+import { createMemo, Show } from 'solid-js'
 import * as workerRpc from '~/api/workerRpc'
 import { openAgentRequestOptions } from '~/components/chat/providers/registry'
 import { DialogColumns, DialogTopRow, DialogTopSection } from '~/components/common/Dialog'
 import { AgentProviderSelector } from '~/components/shell/AgentProviderSelector'
+import { BlockedReasonNotice } from '~/components/shell/BlockedReasonNotice'
 import { isAgentCreateDisabled } from '~/components/shell/dialogValidation'
 import { DirectorySelector } from '~/components/shell/DirectorySelector'
 import { GitOptions } from '~/components/shell/GitOptions'
@@ -23,6 +24,13 @@ interface NewAgentDialogProps {
   defaultAgentProvider?: AgentProvider
   availableProviders?: AgentProvider[]
   onRefreshProviders?: () => void
+  /**
+   * When this returns a string, no tab can be placed right now (no
+   * workspace, or its tree has not arrived): submit is disabled and the
+   * string is shown as the reason. Guards the worker RPC — creating the
+   * agent first and refusing placement second would orphan the agent.
+   */
+  blockedReason?: () => string | undefined
   onCreated: (agent: AgentInfo) => void
   onClose: () => void
 }
@@ -44,8 +52,14 @@ export const NewAgentDialog: Component<NewAgentDialogProps> = (props) => {
 
   const sessionId = createSessionIdState()
 
+  // One memo, two readers (submit gate + notice): `blockedReason` walks
+  // the layout tree, and the submit computation re-runs on every field
+  // keystroke — the memo keeps those walks to one per actual change.
+  const blockedReason = createMemo(() => props.blockedReason?.())
+
   const submitDisabled = () => isAgentCreateDisabled({
     submitting: submitting.loading(),
+    blockedReason: blockedReason(),
     workerId: worker.workerId(),
     workingDir: worker.workingDir(),
     noProviders: noProviders(),
@@ -103,6 +117,7 @@ export const NewAgentDialog: Component<NewAgentDialogProps> = (props) => {
           />
         </DialogTopRow>
       </DialogTopSection>
+      <BlockedReasonNotice reason={blockedReason()} />
       <DialogColumns
         left={<DirectorySelector state={worker} tree={tree} />}
         right={(

--- a/frontend/src/components/shell/NewTerminalDialog.test.tsx
+++ b/frontend/src/components/shell/NewTerminalDialog.test.tsx
@@ -1,0 +1,91 @@
+/// <reference types="vitest/globals" />
+import { create } from '@bufbuild/protobuf'
+import { fireEvent, render, screen, waitFor } from '@solidjs/testing-library'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as workerRpc from '~/api/workerRpc'
+import { NewTerminalDialog } from '~/components/shell/NewTerminalDialog'
+import { WorkerSchema } from '~/generated/leapmux/v1/worker_pb'
+
+// The dialog's own guard wiring — the parent computes the reason, but THIS
+// component is what stops the worker RPC: the notice renders, submit
+// disables, and a form submit fires no openTerminal. The AppShellDialogs
+// suite covers the reason's computation with stubbed dialogs; this file
+// renders the real one, so its worker/shell/git fetches are mocked at the
+// API boundary.
+vi.mock('~/api/clients', () => ({
+  workerClient: {
+    // The dialog context filters the fleet to ONLINE workers before it
+    // applies the preselection, so the one mock worker must be online.
+    listWorkers: vi.fn(async () => ({
+      workers: [create(WorkerSchema, { id: 'w-1', online: true })],
+    })),
+  },
+}))
+
+// Bare-success shapes are enough: the dialog only reads resp fields it
+// needs, and the point of these mocks is to let the tree mount — a MISSING
+// export throws inside the render chain and takes the shells effect down
+// with it, which is exactly what these mocks exist to prevent.
+vi.mock('~/api/workerRpc', () => ({
+  getGitInfo: vi.fn(async () => ({})),
+  getWorkerSystemInfo: vi.fn(async () => ({})),
+  listAvailableShells: vi.fn(async () => ({ shells: ['bash', 'zsh'], defaultShell: 'bash' })),
+  statFile: vi.fn(async () => ({})),
+  listDirectory: vi.fn(async () => ({ entries: [] })),
+  openTerminal: vi.fn(async () => ({ terminalId: 'tid-1', title: 'Terminal 1' })),
+}))
+
+const openTerminalMock = workerRpc.openTerminal as unknown as ReturnType<typeof vi.fn>
+
+function renderDialog(blockedReason?: () => string | undefined) {
+  return render(() => (
+    <NewTerminalDialog
+      defaultWorkerId="w-1"
+      defaultWorkingDir="/tmp"
+      blockedReason={blockedReason}
+      onCreated={() => {}}
+      onClose={() => {}}
+    />
+  ))
+}
+
+async function findCreateButton(): Promise<HTMLButtonElement> {
+  await screen.findByRole('button', { name: 'Create' })
+  return screen.getByRole('button', { name: 'Create' }) as HTMLButtonElement
+}
+
+describe('newTerminalDialog tab-placement guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows the blocked reason, disables submit, and fires no openTerminal', async () => {
+    renderDialog(() => 'Create a workspace first — a tab lives inside a workspace.')
+
+    expect(await screen.findByTestId('new-tab-blocked-reason'))
+      .toHaveTextContent(/create a workspace first/i)
+    expect(await findCreateButton()).toBeDisabled()
+
+    // The footer's button is `type=submit`, but programmatic submits (Enter
+    // in an input) reach the same form handler — which re-checks the gate
+    // and bails before the RPC (and before the loading state, which is why
+    // the label stays "Create").
+    const form = document.querySelector('form')
+    expect(form, 'the shell wraps body + footer in a form').toBeTruthy()
+    fireEvent.submit(form!)
+
+    expect(openTerminalMock, 'the blocked guard holds before the worker RPC').not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled()
+  })
+
+  it('keeps submit enabled once the placement precondition passes', async () => {
+    // The companion that proves the BLOCKED reason is the disabler above:
+    // with no reason and the same worker/dir/shell state, submit arms.
+    renderDialog()
+
+    await waitFor(async () => {
+      expect(await findCreateButton()).not.toBeDisabled()
+    })
+    expect(screen.queryByTestId('new-tab-blocked-reason')).toBeNull()
+  })
+})

--- a/frontend/src/components/shell/NewTerminalDialog.tsx
+++ b/frontend/src/components/shell/NewTerminalDialog.tsx
@@ -1,7 +1,8 @@
 import type { Component } from 'solid-js'
-import { Show } from 'solid-js'
+import { createMemo, Show } from 'solid-js'
 import * as workerRpc from '~/api/workerRpc'
 import { DialogColumns, DialogTopRow, DialogTopSection } from '~/components/common/Dialog'
+import { BlockedReasonNotice } from '~/components/shell/BlockedReasonNotice'
 import { isTerminalCreateDisabled } from '~/components/shell/dialogValidation'
 import { DirectorySelector } from '~/components/shell/DirectorySelector'
 import { GitOptions } from '~/components/shell/GitOptions'
@@ -18,6 +19,13 @@ import { DEFAULT_TERMINAL_COLS, DEFAULT_TERMINAL_ROWS } from '~/lib/terminal'
 interface NewTerminalDialogProps {
   defaultWorkerId?: string
   defaultWorkingDir?: string
+  /**
+   * When this returns a string, no tab can be placed right now (no
+   * workspace, or its tree has not arrived): submit is disabled and the
+   * string is shown as the reason. Guards the worker RPC — creating the
+   * pty first and refusing placement second would orphan it.
+   */
+  blockedReason?: () => string | undefined
   onCreated: (terminalId: string, workerId: string, workingDir: string, title: string) => void
   onClose: () => void
 }
@@ -55,8 +63,14 @@ export const NewTerminalDialog: Component<NewTerminalDialogProps> = (props) => {
     </label>
   )
 
+  // One memo, two readers (submit gate + notice): `blockedReason` walks
+  // the layout tree, and the submit computation re-runs on every field
+  // keystroke — the memo keeps those walks to one per actual change.
+  const blockedReason = createMemo(() => props.blockedReason?.())
+
   const submitDisabled = () => isTerminalCreateDisabled({
     submitting: submitting.loading(),
+    blockedReason: blockedReason(),
     workerId: worker.workerId(),
     workingDir: worker.workingDir(),
     shell: shell(),
@@ -98,6 +112,7 @@ export const NewTerminalDialog: Component<NewTerminalDialogProps> = (props) => {
           {shellSelector()}
         </DialogTopRow>
       </DialogTopSection>
+      <BlockedReasonNotice reason={blockedReason()} />
       <DialogColumns
         twoColumn={Boolean(worker.workerId()) && (pathInfo.loading() || pathInfo.showGitOptions())}
         left={<DirectorySelector state={worker} tree={tree} />}

--- a/frontend/src/components/shell/TabBar.css.ts
+++ b/frontend/src/components/shell/TabBar.css.ts
@@ -347,6 +347,14 @@ export const tabChip = style({
   },
 })
 
+// Holds the chip's flex role while the chip itself is hidden (a tile with no
+// tabs): the chip's `flex: 1` is what fills the bar's middle and lands the
+// files toggle at the right end, so without a stand-in the trailing chrome
+// collapses against the head of the bar instead.
+export const mobileBarSpacer = style({
+  flex: 1,
+})
+
 /**
  * Clipped single-line label for the mobile surfaces (the chip's tab name,
  * the sheet row's label). Composed with an EMPTY rule on purpose — same

--- a/frontend/src/components/shell/TabBar.test.tsx
+++ b/frontend/src/components/shell/TabBar.test.tsx
@@ -126,6 +126,7 @@ vi.mock('~/components/shell/TabBar.css', () => ({
   collapsedOverflow: 'collapsedOverflow',
   shellDefault: 'shellDefault',
   tabChip: 'tabChip',
+  mobileBarSpacer: 'mobileBarSpacer',
   mobileClippedLabel: 'mobileClippedLabel',
   tabChipCount: 'tabChipCount',
   tabChipChevron: 'tabChipChevron',
@@ -640,14 +641,14 @@ describe('tabBar mobile variant', () => {
        Renders the mobile bar with a real signal behind the sheet-open prop, the
       same contract AppShell's overlay state feeds it.
    */
-  function renderMobileTabBar(tabs: Tab[], activeTabKey: string | null, opts: MobileOpts = {}) {
+  function renderMobileTabBar(tabs: Tab[] | (() => Tab[]), activeTabKey: string | null, opts: MobileOpts = {}) {
     const [sheetOpen, setSheetOpen] = createSignal(false)
     const onToggleSheetSpy = vi.fn(() => setSheetOpen(prev => !prev))
     const view = render(() => (
       <PreferencesProvider>
         <TabBar
           {...defaultProps}
-          tabs={tabs}
+          tabs={typeof tabs === 'function' ? tabs() : tabs}
           activeTabKey={activeTabKey}
           onSelect={opts.onSelect ?? noop}
           onClose={opts.onClose ?? noop}
@@ -791,6 +792,48 @@ describe('tabBar mobile variant', () => {
     expect(onToggleDrawer).toHaveBeenCalledTimes(2)
   })
 
+  it('the files toggle sits at the right end of the bar, chip or no chip', () => {
+    // The chip's `flex: 1` fills the bar's middle, which is what lands the
+    // files toggle at the right end. With the chip hidden (no tabs) a spacer
+    // holds that flex role — without it the trailing chrome collapses against
+    // the head of the bar.
+    const barChromeLabels = () =>
+      [...screen.getByTestId('tab-bar').querySelectorAll('button')]
+        .map(b => b.getAttribute('aria-label') ?? b.dataset.testid ?? '')
+        // The "+" dropdown's menu items render inline with no label — they are
+        // not bar chrome; only the labelled controls carry the layout.
+        .filter(label => label !== '')
+
+    const rendered = renderMobileTabBar(twoTabs(), `${TabType.AGENT}:a1`)
+    expect(barChromeLabels()).toEqual(['Toggle workspaces', 'tab-chip', 'collapsed-new-tab-button', 'Toggle files'])
+    expect(screen.queryByTestId('tab-bar-spacer')).toBeNull()
+    rendered.view.unmount()
+
+    renderMobileTabBar([], null)
+    expect(barChromeLabels()).toEqual(['Toggle workspaces', 'collapsed-new-tab-button', 'Toggle files'])
+    expect(screen.getByTestId('tab-bar-spacer')).toBeInTheDocument()
+  })
+
+  it('closing the last tab closes the sheet, whose only bar toggle (the chip) is gone', () => {
+    const [tabs, setTabs] = createSignal<Tab[]>([makeTab(TabType.AGENT, 'a1', 'Agent Olivia')])
+    // The close handler drops the row the way the real store does, so the
+    // prop shrinks from inside the event. Passing the ACCESSOR (not a read)
+    // lets the harness prop re-derive per tick; the rule cannot see that.
+    // eslint-disable-next-line solid/reactivity -- accessor passed, never read here
+    renderMobileTabBar(tabs, `${TabType.AGENT}:a1`, { onClose: () => setTabs([]) })
+
+    fireEvent.click(screen.getByTestId('tab-chip'))
+    expect(screen.getByTestId('tab-sheet')).toHaveClass('sheetPanelOpen')
+
+    // Close the last tab from inside the sheet. The chip unmounts with the
+    // last tab, so the sheet must close itself rather than stay open with
+    // no bar control left to dismiss it by.
+    fireEvent.click(screen.getAllByTestId('tab-close')[0])
+
+    expect(screen.queryByTestId('tab-chip')).toBeNull()
+    expect(screen.getByTestId('tab-sheet')).not.toHaveClass('sheetPanelOpen')
+  })
+
   it('pressing Escape closes the sheet (the scrim is the layout\'s, covered in MobileLayout)', () => {
     renderMobileTabBar(twoTabs(), `${TabType.AGENT}:a1`)
 
@@ -802,13 +845,16 @@ describe('tabBar mobile variant', () => {
     expect(panel).not.toHaveClass('sheetPanelOpen')
   })
 
-  it('a chip with no tabs opens the new-agent dialog instead of the sheet', () => {
+  it('a chip with no tabs is not rendered at all — no "0" chip, no new-tab trigger', () => {
     const onNewAgentAdvanced = vi.fn()
     renderMobileTabBar([], null, { onNewAgentAdvanced })
 
-    fireEvent.click(screen.getByTestId('tab-chip'))
-
-    expect(onNewAgentAdvanced).toHaveBeenCalledOnce()
+    // The chip toggles a tab sheet; with nothing to list it would only show
+    // a count of 0. The main area's empty-state buttons are the affordance
+    // for the first tab instead.
+    expect(screen.queryByTestId('tab-chip')).toBeNull()
+    expect(screen.queryByTestId('tab-chip-count')).toBeNull()
+    expect(onNewAgentAdvanced).not.toHaveBeenCalled()
     expect(screen.getByTestId('tab-sheet')).not.toHaveClass('sheetPanelOpen')
   })
 

--- a/frontend/src/components/shell/TabBar.tsx
+++ b/frontend/src/components/shell/TabBar.tsx
@@ -545,18 +545,6 @@ export const TabBar: Component<TabBarProps> = (props) => {
 
   return (
     <div class={styles.tabBar} data-testid="tab-bar">
-      <Show when={props.mobile}>
-        {mobile => (
-          <IconButton
-            icon={Menu}
-            iconSize="lg"
-            size="xl"
-            aria-label="Toggle workspaces"
-            onClick={() => mobile().onToggleDrawer('left')}
-          />
-        )}
-      </Show>
-
       <Show
         when={props.mobile}
         fallback={(
@@ -711,67 +699,82 @@ export const TabBar: Component<TabBarProps> = (props) => {
           </>
         )}
       >
-        {mobile => (
-          <>
-            {/* Mobile: the strip collapses to a chip that opens the tab sheet. */}
-            <button
-              type="button"
-              class={styles.tabChip}
-              data-testid="tab-chip"
-              aria-haspopup="dialog"
-              aria-expanded={mobile().sheetOpen()}
-              onClick={() => {
-                const tab = chipTab()
-                if (!tab) {
-                  // Mirrors the strip's empty-area double-click: no tabs to list,
-                  // so the chip becomes a new-tab trigger.
-                  props.newTab.onNewAgentAdvanced?.()
-                  return
-                }
-                mobile().onToggleSheet()
-              }}
-            >
+        {(mobile) => {
+          // Closing the last tab from inside the sheet removes the chip —
+          // the sheet's only toggle — so the sheet closes with it instead
+          // of staying open over the empty tile state with no bar control
+          // left to dismiss it by (the scrim still works, but it should
+          // not have to).
+          createEffect(() => {
+            if (props.tabs.length === 0 && mobile().sheetOpen())
+              mobile().onCloseSheet()
+          })
+          return (
+            <>
+              {/* Mobile: the strip collapses to a chip that opens the tab sheet.
+                  The chip is hidden while the tile has no tabs — a "0" chip that
+                  toggles an empty sheet explains nothing, and the main area's
+                  empty-state buttons are the affordance for creating the first
+                  tab. Its flex role (filling the middle so the files toggle
+                  lands at the right end) is held by a spacer in its absence. */}
+              <IconButton
+                icon={Menu}
+                iconSize="lg"
+                size="xl"
+                aria-label="Toggle workspaces"
+                onClick={() => mobile().onToggleDrawer('left')}
+              />
               <Show
-                when={chipTab()}
-                fallback={<span class={styles.tabIcon} />}
+                when={props.tabs.length > 0}
+                fallback={<div class={styles.mobileBarSpacer} data-testid="tab-bar-spacer" aria-hidden="true" />}
               >
-                {tab => (
-                  <>
-                    <span class={styles.tabIcon}>
-                      <TabTypeIcon tab={tab()} />
-                    </span>
-                    <span class={styles.mobileClippedLabel}>{tabDisplayLabel(tab())}</span>
-                    <Show when={tab().hasNotification}>
-                      <span class={styles.tabNotification} data-testid="tab-notification" />
-                    </Show>
-                  </>
-                )}
+                <button
+                  type="button"
+                  class={styles.tabChip}
+                  data-testid="tab-chip"
+                  aria-haspopup="dialog"
+                  aria-expanded={mobile().sheetOpen()}
+                  onClick={() => mobile().onToggleSheet()}
+                >
+                  {/* Always truthy here — the chip renders only with tabs — but
+                      `<Show>` is still the narrowest way to hand the row a live
+                      tab accessor. */}
+                  <Show when={chipTab()}>
+                    {tab => (
+                      <>
+                        <span class={styles.tabIcon}>
+                          <TabTypeIcon tab={tab()} />
+                        </span>
+                        <span class={styles.mobileClippedLabel}>{tabDisplayLabel(tab())}</span>
+                        <Show when={tab().hasNotification}>
+                          <span class={styles.tabNotification} data-testid="tab-notification" />
+                        </Show>
+                      </>
+                    )}
+                  </Show>
+                  <span class={styles.tabChipCount} data-testid="tab-chip-count">{props.tabs.length}</span>
+                  <ChevronDown size={14} class={styles.tabChipChevron} />
+                </button>
               </Show>
-              <span class={styles.tabChipCount} data-testid="tab-chip-count">{props.tabs.length}</span>
-              <ChevronDown size={14} class={styles.tabChipChevron} />
-            </button>
 
-            {/* Mobile keeps the single "+" new-tab dropdown. The mobile bar
-                has no [data-tile-size] ancestor (it renders outside any Tile),
-                so the tile-size rules that reveal `collapsedNewTab` never
-                apply — this variant is visible on its own. */}
-            <Show when={props.newTab.showAddButton}>
-              <CollapsedNewTabMenu wrapperClass={styles.mobileNewTab} />
-            </Show>
-          </>
-        )}
-      </Show>
+              {/* Mobile keeps the single "+" new-tab dropdown. The mobile bar
+                  has no [data-tile-size] ancestor (it renders outside any Tile),
+                  so the tile-size rules that reveal `collapsedNewTab` never
+                  apply — this variant is visible on its own. */}
+              <Show when={props.newTab.showAddButton}>
+                <CollapsedNewTabMenu wrapperClass={styles.mobileNewTab} />
+              </Show>
 
-      <Show when={props.mobile}>
-        {mobile => (
-          <IconButton
-            icon={PanelRight}
-            iconSize="lg"
-            size="xl"
-            aria-label="Toggle files"
-            onClick={() => mobile().onToggleDrawer('right')}
-          />
-        )}
+              <IconButton
+                icon={PanelRight}
+                iconSize="lg"
+                size="xl"
+                aria-label="Toggle files"
+                onClick={() => mobile().onToggleDrawer('right')}
+              />
+            </>
+          )
+        }}
       </Show>
 
       {/* The mobile tab sheet, fixed-positioned within the tab bar's stacking

--- a/frontend/src/components/shell/WorkspaceCenterFallback.test.tsx
+++ b/frontend/src/components/shell/WorkspaceCenterFallback.test.tsx
@@ -1,0 +1,34 @@
+import { fireEvent, render, screen } from '@solidjs/testing-library'
+import { describe, expect, it, vi } from 'vitest'
+import { WorkspaceCenterFallback } from './WorkspaceCenterFallback'
+
+describe('workspaceCenterFallback', () => {
+  it('shows the create-workspace affordance when there is no workspace', () => {
+    const onNewWorkspace = vi.fn()
+    render(() => (
+      <WorkspaceCenterFallback noWorkspace bootstrapTimedOut={false} onNewWorkspace={onNewWorkspace} />
+    ))
+
+    fireEvent.click(screen.getByTestId('create-workspace-button'))
+    expect(onNewWorkspace).toHaveBeenCalledTimes(1)
+    expect(screen.queryByTestId('workspace-bootstrap-failed')).toBeNull()
+  })
+
+  it('reports a bootstrap the watchdog gave up on instead of leaving a blank panel', () => {
+    render(() => (
+      <WorkspaceCenterFallback noWorkspace={false} bootstrapTimedOut onNewWorkspace={() => {}} />
+    ))
+
+    expect(screen.getByTestId('workspace-bootstrap-failed')).toBeInTheDocument()
+    expect(screen.getByText(/state never arrived/i)).toBeInTheDocument()
+    expect(screen.queryByTestId('create-workspace-button')).toBeNull()
+  })
+
+  it('renders nothing while a selected workspace might still be arriving', () => {
+    const { container } = render(() => (
+      <WorkspaceCenterFallback noWorkspace={false} bootstrapTimedOut={false} onNewWorkspace={() => {}} />
+    ))
+
+    expect(container.innerHTML).toBe('')
+  })
+})

--- a/frontend/src/components/shell/WorkspaceCenterFallback.tsx
+++ b/frontend/src/components/shell/WorkspaceCenterFallback.tsx
@@ -1,0 +1,67 @@
+import type { Component } from 'solid-js'
+import Plus from 'lucide-solid/icons/plus'
+import { Show } from 'solid-js'
+import { Icon } from '~/components/common/Icon'
+import { StartupErrorBody } from '~/components/common/StartupPanel'
+import { getShortcutHintsText } from '~/lib/shortcuts/display'
+import * as styles from './AppShell.css'
+
+interface WorkspaceCenterFallbackProps {
+  /**
+   * True when no workspace is selected at all. The caller decides what
+   * "none" means from its own signals (an empty id AND an empty list
+   * lookup) so this component stays layout-agnostic — desktop and mobile
+   * render the same ladder from the same inputs.
+   */
+  noWorkspace: boolean
+  /** The watchdog fired and the bootstrap still has not delivered a workspace. */
+  bootstrapTimedOut: boolean
+  onNewWorkspace: () => void
+}
+
+/**
+ * What the center panel shows when there is no workspace to tile: the
+ * no-workspace empty state (a create-workspace affordance), or — for a
+ * workspace whose state never arrived — the bootstrap watchdog's report.
+ * With neither flag set nothing renders: silence is only right while the
+ * workspace can still arrive.
+ *
+ * Extracted from DesktopLayout's fallback arm so the mobile shell can
+ * render the identical states instead of a blank panel.
+ */
+export const WorkspaceCenterFallback: Component<WorkspaceCenterFallbackProps> = (props) => {
+  return (
+    <Show
+      when={props.noWorkspace}
+      fallback={(
+        <Show when={props.bootstrapTimedOut}>
+          <div class={styles.emptyTileActions} data-testid="workspace-bootstrap-failed">
+            <StartupErrorBody
+              title="Couldn't load this workspace"
+              error="The workspace's state never arrived. Check your connection to the hub, then reload."
+            />
+            <button class="outline" onClick={() => window.location.reload()}>
+              <span class={styles.emptyTileActionContent}><span>Reload</span></span>
+            </button>
+          </div>
+        </Show>
+      )}
+    >
+      <div class={styles.emptyTileActions} data-testid="no-workspace-empty-state">
+        <button
+          class="outline"
+          data-testid="create-workspace-button"
+          onClick={() => props.onNewWorkspace()}
+        >
+          <Icon icon={Plus} size="sm" />
+          <span class={styles.emptyTileActionContent}>
+            <span>Create a new workspace...</span>
+            <Show when={getShortcutHintsText('app.newWorkspaceDialog')}>
+              {shortcut => <span class={styles.emptyTileActionShortcut}>{shortcut()}</span>}
+            </Show>
+          </span>
+        </button>
+      </div>
+    </Show>
+  )
+}

--- a/frontend/src/components/shell/dialogValidation.test.ts
+++ b/frontend/src/components/shell/dialogValidation.test.ts
@@ -111,6 +111,14 @@ describe('isAgentCreateDisabled', () => {
     expect(isAgentCreateDisabled(valid)).toBe(false)
   })
 
+  it('returns true when a blocked reason is present (no workspace to place the tab in)', () => {
+    expect(isAgentCreateDisabled({ ...valid, blockedReason: 'Create a workspace first.' })).toBe(true)
+  })
+
+  it('treats an empty blocked reason as absent — it blocks nothing and renders no notice', () => {
+    expect(isAgentCreateDisabled({ ...valid, blockedReason: '' })).toBe(false)
+  })
+
   it('returns true when no providers are available', () => {
     expect(isAgentCreateDisabled({ ...valid, noProviders: true })).toBe(true)
   })
@@ -278,6 +286,10 @@ describe('isTerminalCreateDisabled', () => {
     expect(isTerminalCreateDisabled(valid)).toBe(false)
   })
 
+  it('returns true when a blocked reason is present (no workspace to place the tab in)', () => {
+    expect(isTerminalCreateDisabled({ ...valid, blockedReason: 'Create a workspace first.' })).toBe(true)
+  })
+
   it('returns true when submitting', () => {
     expect(isTerminalCreateDisabled({ ...valid, submitting: true })).toBe(true)
   })
@@ -325,6 +337,17 @@ describe('isChangeBranchSubmitDisabled', () => {
 
   it('returns false when switch-branch mode is valid', () => {
     expect(isChangeBranchSubmitDisabled(switchBranchValid)).toBe(false)
+  })
+
+  // The worktree mode's submit opens a worker-side agent/pty that placement
+  // could orphan, so a blocked reason (no placeable tile, archived
+  // workspace) must disable it like any other tab-creating dialog.
+  it('returns true when a blocked reason is present (worktree mode cannot place its tab)', () => {
+    expect(isChangeBranchSubmitDisabled({
+      ...switchBranchValid,
+      git: { mode: GitMode.CreateWorktree, worktreeBranch: 'feat', worktreeBranchError: null, worktreeBaseBranch: 'main' },
+      blockedReason: 'The workspace view is not ready yet.',
+    })).toBe(true)
   })
 
   it('returns true when submitting', () => {

--- a/frontend/src/components/shell/dialogValidation.ts
+++ b/frontend/src/components/shell/dialogValidation.ts
@@ -9,6 +9,16 @@ interface BaseDialogState {
   workerId: string
   workingDir: string
   /**
+   * Why a precondition OUTSIDE the dialog blocks creation — e.g. no
+   * workspace to place the new tab in. A non-empty string disables submit
+   * and is shown as the reason. Distinct from the field checks: the
+   * submit it prevents would create the worker-side resource first and
+   * orphan it when placement refuses. Carrying the reason (not a bare
+   * boolean) keeps the gate and the notice from disagreeing about the
+   * same moment.
+   */
+  blockedReason?: string
+  /**
    * The currently-active git-mode intent. Optional so dialogs without
    * git options can skip it entirely — adding a new git mode then only
    * touches `useGitModeState` and the switch in `isGitModeInvalid`.
@@ -71,6 +81,7 @@ export function isGitModeInvalid(intent: GitModeIntent | undefined): boolean {
 // dialog-specific checks layered on top.
 function isBaseDialogInvalid(state: BaseDialogState): boolean {
   return state.submitting
+    || !!state.blockedReason
     || !state.workerId
     || !state.workingDir.trim()
     || isGitModeInvalid(state.git)
@@ -97,6 +108,13 @@ export function isTerminalCreateDisabled(state: TerminalDialogState): boolean {
 interface ChangeBranchDialogState {
   submitting: boolean
   git: GitModeIntent
+  /**
+   * Why tab creation is blocked outside the dialog — set only while the
+   * active mode is `CreateWorktree`, the one mode whose submit opens a
+   * worker-side resource that placement could orphan. The other modes
+   * change no tabs, so no reason applies to them.
+   */
+  blockedReason?: string
   /**
    * When the active mode is `CreateWorktree`, the dialog asks the user
    * what kind of tab to open in the new worktree (AGENT or TERMINAL),
@@ -125,6 +143,8 @@ interface ChangeBranchDialogState {
  */
 export function isChangeBranchSubmitDisabled(state: ChangeBranchDialogState): boolean {
   if (state.submitting)
+    return true
+  if (state.blockedReason)
     return true
   if (!isChangeBranchMode(state.git.mode))
     return true

--- a/frontend/src/components/shell/openTabInFocusedTile.test.ts
+++ b/frontend/src/components/shell/openTabInFocusedTile.test.ts
@@ -7,7 +7,7 @@ import { tabKey } from '~/stores/tab.helpers'
 import { emitAddTab } from '~/stores/tabOps'
 import { installTestBridge } from '~/test-support/crdtBridge'
 import { createTestTabStores } from '~/test-support/tabStores'
-import { openTabInFocusedTile } from './openTabInFocusedTile'
+import { hasPlaceableTab, openTabInFocusedTile } from './openTabInFocusedTile'
 
 afterEach(() => setCRDTBridge(null))
 
@@ -96,13 +96,12 @@ describe('openTabInFocusedTile', () => {
   })
 
   /**
-   * `focusedTileId()` never answers "nothing" -- it falls back to the first leaf
-   * of `projectedRoot()`, which is a LOCALLY-MINTED placeholder whenever the
-   * projection has no tree for the workspace. A bootstrap that never lands
-   * leaves the shell in exactly that state, and the caller has already created
-   * the agent or terminal on the worker by the time it gets here: emitting
-   * against the placeholder gets the batch rejected and leaves an orphan with no
-   * tab to reach it by.
+   * `placementTileId()` answers `''` while the projection has no tree for
+   * the workspace — the locally-minted placeholder leaf is not a placeable
+   * tile. A bootstrap that never lands leaves the shell in exactly that
+   * state, and the caller has already created the agent or terminal on the
+   * worker by the time it gets here: emitting against the placeholder gets
+   * the batch rejected and leaves an orphan with no tab to reach it by.
    */
   it('refuses to place a tab when the workspace has no projected tree', () => {
     createRoot((dispose) => {
@@ -112,6 +111,43 @@ describe('openTabInFocusedTile', () => {
 
       expect(tileId, 'no real tile to place it on').toBe('')
       expect(s.view.all(), 'and nothing was emitted against the placeholder').toEqual([])
+      dispose()
+    })
+  })
+
+  /**
+   * Focus may legally sit on a floating-window tile, which the main tree
+   * does not contain — an op naming it is rejected by the hub. Placement
+   * falls back to the first main leaf, the same fallback `focusedTileId`
+   * applies when nothing is focused, so a popped-out window never blocks
+   * tab creation.
+   */
+  it('falls back to the first main leaf when focus sits on a floating tile', () => {
+    createRoot((dispose) => {
+      const s = setup()
+      s.layoutStore.setFocusedTile('floating-tile-1')
+
+      const tileId = openTabInFocusedTile(s, { type: TabType.AGENT, id: 'a1' }, {})
+
+      expect(tileId).toBe(s.harness.rootTileId)
+      expect(s.view.getById(TabType.AGENT, 'a1')?.tileId).toBe(s.harness.rootTileId)
+      dispose()
+    })
+  })
+
+  /** The pre-RPC form of the refusals above, consulted by every tab-creation path. */
+  it('hasPlaceableTab answers whether placement is possible right now', () => {
+    createRoot((dispose) => {
+      const ready = setup()
+      ready.layoutStore.setFocusedTile(ready.harness.rootTileId)
+      expect(hasPlaceableTab(ready.layoutStore)).toBe(true)
+
+      const floatingFocused = setup()
+      floatingFocused.layoutStore.setFocusedTile('floating-tile-1')
+      expect(hasPlaceableTab(floatingFocused.layoutStore), 'a floating focus still places on the main tree').toBe(true)
+
+      const unbootstrapped = setupUnbootstrapped()
+      expect(hasPlaceableTab(unbootstrapped.layoutStore), 'placeholder leaf is not a placeable tile').toBe(false)
       dispose()
     })
   })

--- a/frontend/src/components/shell/openTabInFocusedTile.ts
+++ b/frontend/src/components/shell/openTabInFocusedTile.ts
@@ -11,7 +11,8 @@ import { emitAddTab, positionAfterKey } from '~/stores/tabOps'
  * Every "open a tab" path does the same five steps in the same order, and the
  * ORDER is the part worth having in one place:
  *
- *   1. resolve the focused tile,
+ *   1. resolve the placement tile (the focused tile, or the first main
+ *      leaf when focus sits on a floating-window tile),
  *   2. read that tile's current selection, so the new tab lands next to it
  *      rather than at the end of the strip,
  *   3. write metadata FIRST — `emitAddTab` applies to `speculativeState`
@@ -38,25 +39,44 @@ export interface OpenTabPlacement {
 }
 
 /**
- * Returns the tile the tab was placed on, or `''` when there is no real tile to
- * place it on.
+ * Whether `openTabInFocusedTile` would place a tab right now: the
+ * workspace's tree really arrived in the projection. Focus does not enter
+ * the question — placement resolves to the first main leaf when the
+ * focused tile is a floating-window tile (`placementTileId`).
  *
- * The empty answer is a refusal, not a failure mode to ignore: `focusedTileId`
- * falls back to the first leaf of `projectedRoot()`, which is a LOCALLY-MINTED
- * placeholder while the projection has no tree for this workspace. Emitting
- * `AddTab` against that names a node the hub has never heard of, and it rejects
- * the batch -- after the caller has already created the agent or terminal on the
- * worker, so the result is an orphaned resource with no tab. Callers already
- * check `workspaceReady` before offering the affordance; this makes the class
- * impossible rather than merely unreached.
+ * Every path that creates a worker-side resource — the quick actions, the
+ * New Agent / New Terminal dialogs, the Change-branch worktree flow, and
+ * file opens — consults this BEFORE the worker RPC, because the RPC is
+ * the step that cannot be taken back: a placement refusal after it leaves
+ * an orphaned agent or pty behind with no tab to reach it by.
+ * `openTabInFocusedTile` keeps its own refusal as well (the predicate
+ * becoming false between the check and the call is always possible),
+ * making the orphan class impossible rather than merely unreached.
+ */
+export function hasPlaceableTab(
+  layoutStore: ReturnType<typeof createLayoutStore>,
+): boolean {
+  return layoutStore.placementTileId() !== ''
+}
+
+/**
+ * Returns the tile the tab was placed on, or `''` when there is no real
+ * tile to place it on.
+ *
+ * The empty answer is a refusal, not a failure mode to ignore: while the
+ * projection has no tree for this workspace, placement resolves to the
+ * locally-minted placeholder leaf. Emitting `AddTab` against that names a
+ * node the hub has never heard of, and it rejects the batch — after the
+ * caller has already created the agent or terminal on the worker, so the
+ * result is an orphaned resource with no tab.
  */
 export function openTabInFocusedTile(
   deps: OpenTabDeps,
   tab: OpenTabPlacement,
   metadataFields: TabMetadata,
 ): string {
-  const tileId = deps.layoutStore.focusedTileId()
-  if (!tileId || !deps.layoutStore.hasProjectedTile(tileId))
+  const tileId = deps.layoutStore.placementTileId()
+  if (!tileId)
     return ''
   const afterKey = deps.selection.activeKeyForTile(tileId)
   deps.metadata.patch(tab.id, metadataFields)

--- a/frontend/src/components/shell/placeableTabGuard.ts
+++ b/frontend/src/components/shell/placeableTabGuard.ts
@@ -1,0 +1,23 @@
+import type { createLayoutStore } from '~/stores/layout.store'
+import { showWarnToast } from '~/components/common/Toast'
+import { hasPlaceableTab } from './openTabInFocusedTile'
+
+/**
+ * The shared pre-RPC refusal for every path that creates a worker-side
+ * resource and then places a tab: warn and answer false when no tile can
+ * take the tab, so the caller never creates an orphan. `what` names the
+ * resource in the toast title ("an agent", "a terminal", "the file").
+ *
+ * Hooks surface the refusal as this toast; the creation dialogs surface
+ * it as a disabled submit with the reason visible (`newTabBlockedReason`
+ * in AppShellDialogs), because their submit never reaches the RPC.
+ */
+export function warnUnlessPlaceableTab(
+  layoutStore: ReturnType<typeof createLayoutStore>,
+  what: string,
+): boolean {
+  if (hasPlaceableTab(layoutStore))
+    return true
+  showWarnToast(`Cannot open ${what}`, new Error('The workspace is not ready for a new tab yet.'))
+  return false
+}

--- a/frontend/src/components/shell/useAgentOperations.test.ts
+++ b/frontend/src/components/shell/useAgentOperations.test.ts
@@ -9,7 +9,7 @@ import { useAgentOperations } from '~/components/shell/useAgentOperations'
 import { AgentInfoSchema, AgentProvider, ContentCompression, MessageSource } from '~/generated/leapmux/v1/agent_pb'
 import { WorktreeAction } from '~/generated/leapmux/v1/common_pb'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
-import { KEY_MRU_AGENT_PROVIDERS, localStorageSet } from '~/lib/browserStorage'
+import { KEY_MRU_AGENT_PROVIDERS, localStorageGet, localStorageSet } from '~/lib/browserStorage'
 import { createAgentSessionStore } from '~/stores/agentSession.store'
 import { createControlStore } from '~/stores/control.store'
 import { protoToAgentTabFields } from '~/stores/tab.helpers'
@@ -80,11 +80,16 @@ function addAgent(
   stores.selection.setActiveById(TabType.AGENT, id)
 }
 
-function setup() {
+/**
+ * `storeWorkspaceId` keys the stores the shell answers for. The bridge
+ * always delivers ws-1's tree, so a DIFFERENT id produces the
+ * never-bootstrapped wedge (no projected tree for the active workspace).
+ */
+function setup(storeWorkspaceId: string = 'ws-1') {
   const agentSessionStore = createAgentSessionStore()
   const controlStore = createControlStore()
   const harness = installTestBridge({ workspaceId: 'ws-1' })
-  const stores = createTestTabStores('ws-1')
+  const stores = createTestTabStores(storeWorkspaceId)
 
   const chatStore = {
     getMessages: vi.fn().mockReturnValue([]),
@@ -101,11 +106,11 @@ function setup() {
     view: stores.view,
     metadata: stores.metadata,
     selection: stores.selection,
-    getActiveWorkspaceId: () => 'ws-1',
+    getActiveWorkspaceId: () => storeWorkspaceId,
     layoutStore: stores.layoutStore,
     settingsLoading: { start: vi.fn(), stop: vi.fn() },
     isActiveWorkspaceMutatable: () => true,
-    activeWorkspace: () => ({ id: 'ws-1' } as Workspace),
+    activeWorkspace: () => ({ id: storeWorkspaceId } as Workspace),
     getCurrentTabContext: () => ({ workerId: 'w-1', workingDir: '/tmp' }),
     newAgentDialog: { open: vi.fn(), close: vi.fn(), isOpen: () => false },
     setNewAgentLoadingProvider: vi.fn(),
@@ -249,6 +254,52 @@ describe('useAgentOperations', () => {
 
           expect(newAgentDialog.open).toHaveBeenCalled()
           expect(mockOpenAgent).not.toHaveBeenCalled()
+        }
+        finally {
+          dispose()
+        }
+      })
+    })
+
+    // The worker RPC is the step that cannot be taken back: a placement
+    // refusal AFTER it strands an orphaned agent on the worker with no tab
+    // to reach it by. When the workspace's tree never arrived, the open
+    // must refuse BEFORE the RPC.
+    it('refuses before the worker RPC when the workspace has no projected tree', async () => {
+      await createRoot(async (dispose) => {
+        try {
+          mockListAvailableProviders.mockResolvedValue({ providers: [AgentProvider.CLAUDE_CODE] })
+          // The bridge delivers ws-1's tree; the shell answers for a
+          // workspace the bootstrap never delivered, so placement has no
+          // projected tile to resolve to.
+          const { ops } = setup('ws-never-bootstrapped')
+
+          await flush()
+          await ops.handleOpenAgent()
+
+          expect(mockOpenAgent).not.toHaveBeenCalled()
+          expect(mockShowWarnToast).toHaveBeenCalled()
+        }
+        finally {
+          dispose()
+        }
+      })
+    })
+
+    // A refused open is not a use: recording it would promote a provider
+    // the user never successfully opened, and the next quick-create pick
+    // (MRU order) would follow a phantom.
+    it('does not record an MRU provider use when the open is refused', async () => {
+      await createRoot(async (dispose) => {
+        try {
+          mockListAvailableProviders.mockResolvedValue({ providers: [AgentProvider.CLAUDE_CODE, AgentProvider.CODEX] })
+          const { ops } = setup('ws-never-bootstrapped')
+
+          await flush()
+          await ops.handleOpenAgent(AgentProvider.CODEX)
+
+          expect(mockOpenAgent).not.toHaveBeenCalled()
+          expect(localStorageGet(KEY_MRU_AGENT_PROVIDERS), 'a refused open is not a use').toBeUndefined()
         }
         finally {
           dispose()

--- a/frontend/src/components/shell/useAgentOperations.ts
+++ b/frontend/src/components/shell/useAgentOperations.ts
@@ -28,6 +28,7 @@ import { getMruProviders, touchMruProvider } from '~/lib/mruAgentProviders'
 import { protoToAgentTabFields, resolveOptimisticGitInfo, setOptionValue } from '~/stores/tab.helpers'
 import { emitRemoveTab, emitRemoveTabs, hasLiveTabRecord } from '~/stores/tabOps'
 import { openTabInFocusedTile } from './openTabInFocusedTile'
+import { warnUnlessPlaceableTab } from './placeableTabGuard'
 import '~/components/chat/providers'
 
 export interface UseAgentOperationsProps {
@@ -102,8 +103,16 @@ export function useAgentOperations(props: UseAgentOperationsProps) {
     return available[0] ?? null
   }
 
-  // Open a new agent in the given workspace
-  const openAgentInWorkspace = async (workspaceId: string, workerId: string, workingDir: string, sessionId?: string, agentProvider: AgentProvider = AgentProvider.CLAUDE_CODE) => {
+  // Open a new agent in the given workspace. Answers whether an agent was
+  // actually opened, so callers can record the "use" only on success — a
+  // refused open (see the guard below) is not a use.
+  const openAgentInWorkspace = async (workspaceId: string, workerId: string, workingDir: string, sessionId?: string, agentProvider: AgentProvider = AgentProvider.CLAUDE_CODE): Promise<boolean> => {
+    // BEFORE the worker RPC: it is the step that can't be taken back. A
+    // placement refusal after it (no projected tree to place on — e.g. the
+    // workspace's tree hasn't arrived) leaves an orphaned agent behind with
+    // no tab to reach it by.
+    if (!warnUnlessPlaceableTab(props.layoutStore, 'an agent'))
+      return false
     try {
       // Title left empty: the worker picks "Agent <Name>" server-side
       // so CLI and UI paths share one pool (see worker/service/
@@ -139,10 +148,13 @@ export function useAgentOperations(props: UseAgentOperationsProps) {
         )
         // Focus the editor after the reactive updates propagate to the DOM.
         requestAnimationFrame(() => props.focusEditor?.())
+        return true
       }
+      return false
     }
     catch (err) {
       showWarnToast('Failed to open agent', err)
+      return false
     }
   }
 
@@ -168,8 +180,10 @@ export function useAgentOperations(props: UseAgentOperationsProps) {
     }
     props.setNewAgentLoadingProvider(provider)
     try {
-      await openAgentInWorkspace(ws.id, ctx.workerId, ctx.workingDir, undefined, provider)
-      touchMruProvider(provider)
+      // Only a successful open counts as a use: a refused or failed open
+      // records nothing, so the MRU list keeps reflecting real usage.
+      if (await openAgentInWorkspace(ws.id, ctx.workerId, ctx.workingDir, undefined, provider))
+        touchMruProvider(provider)
     }
     finally {
       props.setNewAgentLoadingProvider(null)

--- a/frontend/src/components/shell/useTabOperations.test.ts
+++ b/frontend/src/components/shell/useTabOperations.test.ts
@@ -91,11 +91,14 @@ function setup(
   // Default ONLINE, because that is the normal state and it is the state in
   // which a transport failure must NOT be read as "the worker is gone".
   workerOnlineState: (workerId: string) => boolean | undefined = () => true,
+  // `unbootstrapped` keys the stores at a workspace the bridge never
+  // delivered, so placement has no projected tree to resolve to.
+  opts: { unbootstrapped?: boolean } = {},
 ) {
   // Override the global test bridge with a known tile id so the
   // projection's root leaf is the tile these tests address.
   installTestBridge({ rootTileId: 'tile-1' })
-  const stores = createTestTabStores('ws-test')
+  const stores = createTestTabStores(opts.unbootstrapped ? 'ws-never-bootstrapped' : 'ws-test')
   const { view, metadata, selection, layoutStore } = stores
   const chatStore = createChatStore()
 
@@ -225,6 +228,30 @@ describe('useTabOperations', () => {
             gitIsWorktree: false,
             workingDir: '/tmp',
           })
+        }
+        finally {
+          dispose()
+        }
+      })
+    })
+
+    // A refused placement added no tab, so the worker must not persist a
+    // file-tab path for the id either: the row (and its broadcast to peers)
+    // would name a tab no tree holds, and only the hourly reconciler sweep
+    // would remove it.
+    it('handleFileOpen registers no path and warns when placement refuses', async () => {
+      await createRoot(async (dispose) => {
+        try {
+          const { ops, view } = setup(DEFAULT_SCROLL_STATE, () => true, { unbootstrapped: true })
+
+          ops.handleFileOpen('/tmp/orphan.go')
+          await Promise.resolve()
+
+          // The seeded agent tabs are outside this workspace's tree; the
+          // claim is that no FILE tab joined them.
+          expect(view.all().some(t => t.type === TabType.FILE), 'nothing was placed').toBe(false)
+          expect(mockRegisterFileTabPath, 'no phantom row for an unplaced tab id').not.toHaveBeenCalled()
+          expect(mockShowWarnToast).toHaveBeenCalled()
         }
         finally {
           dispose()

--- a/frontend/src/components/shell/useTabOperations.ts
+++ b/frontend/src/components/shell/useTabOperations.ts
@@ -630,7 +630,7 @@ export function useTabOperations(opts: UseTabOperationsOpts) {
     // renders ungrouped until the next git-status refresh reaches it, even
     // though the answer was on screen at the moment of the open.
     const gitSeed = resolveOptimisticGitInfo(activeTab(), { workingDir: ctx.workingDir })
-    openTabInFocusedTile(
+    const placedTileId = openTabInFocusedTile(
       { view, layoutStore, selection, metadata },
       { type: TabType.FILE, id: tabId, workerId: ctx.workerId },
       {
@@ -649,6 +649,13 @@ export function useTabOperations(opts: UseTabOperationsOpts) {
         hydrated: true,
       },
     )
+    // A refused placement added no tab. Registering the path anyway would
+    // persist a worker-side row (and broadcast it to peers) for a tab id
+    // no tree holds — a phantom the reconciler only sweeps an hour later.
+    if (!placedTileId) {
+      showWarnToast('Cannot open the file', new Error('The workspace is not ready for a new tab yet.'))
+      return
+    }
 
     // E2EE worker-side path registration. The hub never sees the path; the
     // worker persists `(user_id, tab_id, file_path, working_dir)` and emits

--- a/frontend/src/components/shell/useTerminalOperations.test.ts
+++ b/frontend/src/components/shell/useTerminalOperations.test.ts
@@ -178,6 +178,12 @@ interface OpenSetupOpts {
   setNewTerminalLoading?: (v: boolean) => void
   setNewShellLoading?: (v: boolean) => void
   dialogOpen?: () => void
+  /**
+   * Key the stores at a workspace the bridge never delivered, so
+   * `focusedTileId` is the locally-minted placeholder leaf — the state a
+   * wedged CRDT bootstrap leaves the shell in.
+   */
+  unbootstrapped?: boolean
 }
 
 // Open-terminal-specific setup: lets each test inject a ctx (to
@@ -192,7 +198,7 @@ function setupForOpen(opts: OpenSetupOpts = {}) {
   )
   let ops!: ReturnType<typeof useTerminalOperations>
   const dispose = createRoot((d) => {
-    stores = createTestTabStores('ws-1')
+    stores = createTestTabStores(opts.unbootstrapped ? 'ws-never-bootstrapped' : 'ws-1')
     ops = useTerminalOperations({
       view: stores.view,
       metadata: stores.metadata,
@@ -331,6 +337,20 @@ describe('useterminaloperations.handleopenterminal', () => {
     expect(openTerminalMock).not.toHaveBeenCalled()
     expect(dialogOpen).not.toHaveBeenCalled()
     expect(setLoading).not.toHaveBeenCalled()
+    expect(view.all()).toHaveLength(0)
+  })
+
+  // The pty RPC is the step that cannot be taken back: a placement refusal
+  // AFTER it strands an orphaned pty on the worker with no tab to reach it
+  // by. When the workspace's tree never arrived, the open must refuse
+  // BEFORE the RPC — with a visible reason, not silence.
+  it('refuses before the worker RPC when the workspace has no projected tree', async () => {
+    const { ops, view } = setupForOpen({ unbootstrapped: true })
+
+    await ops.handleOpenTerminal()
+
+    expect(openTerminalMock).not.toHaveBeenCalled()
+    expect(showWarnToastMock).toHaveBeenCalledTimes(1)
     expect(view.all()).toHaveLength(0)
   })
 

--- a/frontend/src/components/shell/useTerminalOperations.ts
+++ b/frontend/src/components/shell/useTerminalOperations.ts
@@ -24,6 +24,7 @@ import { DEFAULT_TERMINAL_COLS, DEFAULT_TERMINAL_ROWS, ENTER_KEY_CR } from '~/li
 import { openedTerminalMetadata, resolveOptimisticGitInfo } from '~/stores/tab.helpers'
 import { emitRemoveTab } from '~/stores/tabOps'
 import { openTabInFocusedTile } from './openTabInFocusedTile'
+import { warnUnlessPlaceableTab } from './placeableTabGuard'
 
 // xterm emits Enter as a single CR byte on a non-modifier press.
 // We gate the EXITED-tab restart flow on exactly that one byte so a stray
@@ -136,6 +137,12 @@ export function useTerminalOperations(props: UseTerminalOperationsProps) {
       props.newTerminalDialog.open()
       return
     }
+    // BEFORE the worker RPC: it is the step that can't be taken back. A
+    // placement refusal after it (no projected tree to place on — e.g. the
+    // workspace's tree hasn't arrived) leaves an orphaned pty behind with
+    // no tab to reach it by.
+    if (!warnUnlessPlaceableTab(props.layoutStore, 'a terminal'))
+      return
     args.setLoading(true)
     try {
       const resp = await workerRpc.openTerminal(ctx.workerId, {

--- a/frontend/src/components/workspace/ChangeBranchDialog.test.tsx
+++ b/frontend/src/components/workspace/ChangeBranchDialog.test.tsx
@@ -344,6 +344,43 @@ describe('changeBranchDialog', () => {
     await waitFor(() => expect(props.onAgentCreated).toHaveBeenCalled())
   })
 
+  // The worktree mode's submit opens a worker-side agent/pty that placement
+  // could orphan, so a blocked reason must disable it like the other
+  // tab-creating dialogs — and the click must never reach the RPC.
+  it('worktree mode: a blocked reason disables Apply, shows the notice, and fires no RPC', async () => {
+    const props = renderDialog({ blockedReason: () => 'The workspace view is not ready yet.' })
+    await awaitFormReady()
+    fireEvent.click(screen.getByText('Create new worktree'))
+
+    expect(await screen.findByTestId('new-tab-blocked-reason'))
+      .toHaveTextContent(/not ready yet/i)
+    const apply = screen.getByRole('button', { name: 'Apply' }) as HTMLButtonElement
+    expect(apply.disabled).toBe(true)
+
+    fireEvent.click(apply)
+    await Promise.resolve()
+    expect(workerRpc.openAgent, 'the guard holds before the worker RPC').not.toHaveBeenCalled()
+    expect(workerRpc.openTerminal).not.toHaveBeenCalled()
+    expect(props.onClose, 'and the dialog did not close as a success').not.toHaveBeenCalled()
+  })
+
+  // The companion: the reason is mode-conditioned, not global. A branch
+  // checkout creates no tab, so the same accessor must not disable it.
+  it('the blocked reason never applies outside worktree mode — a branch checkout opens no tab', async () => {
+    const props = renderDialog({ blockedReason: () => 'The workspace view is not ready yet.' })
+    await awaitFormReady()
+
+    expect(screen.queryByTestId('new-tab-blocked-reason')).toBeNull()
+    const select = screen.getAllByRole('combobox')[0] as HTMLSelectElement
+    fireEvent.change(select, { target: { value: 'main' } })
+    const apply = screen.getByRole('button', { name: 'Apply' }) as HTMLButtonElement
+    expect(apply.disabled, 'switch-branch arms despite the reason').toBe(false)
+
+    fireEvent.click(apply)
+    await waitFor(() => expect(workerRpc.checkoutBranch).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(props.onClose).toHaveBeenCalled())
+  })
+
   it('worktree mode (terminal): calls openTerminal with the chosen shell', async () => {
     vi.mocked(workerRpc.openTerminal).mockResolvedValue({
       $typeName: 'leapmux.v1.OpenTerminalResponse',

--- a/frontend/src/components/workspace/ChangeBranchDialog.tsx
+++ b/frontend/src/components/workspace/ChangeBranchDialog.tsx
@@ -5,6 +5,7 @@ import * as workerRpc from '~/api/workerRpc'
 import { openAgentRequestOptions } from '~/components/chat/providers/registry'
 import { labelRow } from '~/components/common/Dialog.css'
 import { AgentProviderSelector } from '~/components/shell/AgentProviderSelector'
+import { BlockedReasonNotice } from '~/components/shell/BlockedReasonNotice'
 import { isChangeBranchSubmitDisabled } from '~/components/shell/dialogValidation'
 import { GitOptions } from '~/components/shell/GitOptions'
 import { GitOptionsLoader } from '~/components/shell/GitOptionsLoader'
@@ -64,6 +65,15 @@ interface ChangeBranchDialogProps {
    * needed rather than waiting for the next git-status poll).
    */
   onBranchChanged?: (newBranch: string) => void
+  /**
+   * When this returns a string in CreateWorktree mode, no tab can be
+   * placed for the new worktree's agent/terminal (no workspace tree, or
+   * an archived workspace): submit is disabled and the string is shown
+   * as the reason. Guards the worker RPC — creating the resource first
+   * and refusing placement second would orphan it. The branch-only modes
+   * open no tab, so the reason never applies to them.
+   */
+  blockedReason?: () => string | undefined
   onAgentCreated?: (agent: AgentInfo) => void
   onTerminalCreated?: (terminalId: string, workerId: string, workingDir: string, title: string) => void
   onClose: () => void
@@ -115,8 +125,16 @@ export const ChangeBranchDialog: Component<ChangeBranchDialogProps> = (props) =>
     err => log.warn('Failed to list shells', err),
   )
 
+  // The guard reason applies only to the one mode whose submit opens a
+  // worker-side resource that placement could orphan; branch-only modes
+  // change no tabs. One accessor so the submit gate and the notice read
+  // the same value.
+  const worktreeBlockedReason = () =>
+    gitMode.currentIntent().mode === GitMode.CreateWorktree ? props.blockedReason?.() : undefined
+
   const submitDisabled = () => isChangeBranchSubmitDisabled({
     submitting: submitting.loading(),
+    blockedReason: worktreeBlockedReason(),
     // SwitchBranch intent now carries `checkoutBranchError` set by
     // GitOptions when the destination resolves to the current branch
     // (the path-info probe's currentBranch is the source of truth, and
@@ -257,6 +275,7 @@ export const ChangeBranchDialog: Component<ChangeBranchDialogProps> = (props) =>
         />
       )}
     >
+      <BlockedReasonNotice reason={worktreeBlockedReason()} />
       <GitOptionsLoader gitInfo={pathInfo}>
         {() => (
           <>

--- a/frontend/src/stores/layout.store.ts
+++ b/frontend/src/stores/layout.store.ts
@@ -704,6 +704,37 @@ export function createLayoutStore(opts: CreateLayoutStoreOpts) {
       return focusedTileIdRaw() ?? firstLeafId(projectedRoot()) ?? ''
     },
 
+    /**
+     * The tile a new tab places on: the focused tile when it belongs to
+     * the projected main tree, otherwise the tree's first leaf.
+     *
+     * Focus may legally sit on a floating-window tile (see the invariant
+     * note above), which the main tree does not contain — an op naming it
+     * is rejected by the hub, so placement falls back to the first main
+     * leaf the same way `focusedTileId()` falls back when nothing is
+     * focused. `''` when the workspace's tree has not arrived; the tree,
+     * not the focus, is what makes placement possible.
+     */
+    placementTileId(): string {
+      const local = localTreeFor(opts.getWorkspaceId() ?? '')
+      if (!local)
+        return ''
+      const focused = focusedTileIdRaw()
+      return focused && containsTileId(local, focused) ? focused : firstLeafId(local) ?? ''
+    },
+
+    /**
+     * Has the active workspace's layout tree arrived in the projection?
+     *
+     * The one question the center render gate and tab placement both ask,
+     * so they agree by construction: `localTrees` only holds trees the
+     * projection delivered, and `placementTileId()` answers `''` exactly
+     * when this answers false.
+     */
+    hasProjectedTree(): boolean {
+      return localTreeFor(opts.getWorkspaceId() ?? '') !== undefined
+    },
+
     splitTile,
 
     makeGrid,


### PR DESCRIPTION
## Motivation

A workspace record and its projected layout tree can arrive in separate registration batches. In that window the layout store falls back to a locally-minted placeholder leaf whose action handlers reference a node the hub never heard of. Every create-first/place-second flow that fires then — new agent, new terminal, worktree creation, file open — runs its irreversible worker RPC before placing the tab, the hub rejects the placement (`BATCH_REJECTION_TAB_PLACEMENT_INVALID`), and the worker-side resource is stranded: an orphaned agent session or pty, or a phantom `(tab_id, file_path)` row that only the hourly reconciler sweep can remove. A refused or failed quick-create also promoted a never-used provider to the top of the MRU list driving the next pick. The mobile shell compounded the window with a blank center panel and a "0" tab chip that opened the new-agent dialog on a tile with zero tabs.

## Modifications

- **Placement core** (`layout.store.ts`, `openTabInFocusedTile.ts`, new `placeableTabGuard.ts`): new store primitives `placementTileId()` and `hasProjectedTree()`. `placementTileId()` resolves the tile a new tab lands on — the focused tile when it belongs to the projected main tree, otherwise the tree's first leaf (covers focus sitting on a floating-window tile, which the hub would reject), `''` when no tree arrived. Prop change (internal, AppShell updated in the same PR): `DesktopLayout` drops the `activeWorkspace` accessor and replaces `workspaceReady` with `centerReady` (workspace exists AND its tree arrived) plus `centerNoWorkspace`, derived once in AppShell so desktop and mobile share one gate; `centerReady` is deliberately a boolean so a workspace-list refresh that swaps object identity cannot remount panes mid-use. `openTabInFocusedTile` now places via `placementTileId()` and refuses *before* the worker RPC; it exports `hasPlaceableTab()`, and `warnUnlessPlaceableTab()` is the shared toast wrapper for hook call sites.
- **Dialog guards**: `newTabBlockedReason()` in AppShellDialogs (no active workspace / archived workspace / no projected tree) flows as a `blockedReason` accessor prop into NewAgentDialog, NewTerminalDialog, and ChangeBranchDialog, rendered by the new shared `BlockedReasonNotice` (one testid across all three) and wired into `dialogValidation` — `BaseDialogState` gains optional `blockedReason`, where a non-empty string disables submit. In ChangeBranchDialog the block applies only to CreateWorktree mode (the one mode opening a worker-side resource) and is passed only when the dialog targets the active workspace; the accessor is wrapped in `createMemo` so layout-tree walks run once per actual change.
- **Ops hooks**: the agent, terminal, and file-open paths call `warnUnlessPlaceableTab` before their RPC. Return change: `openAgentInWorkspace` now answers `Promise<boolean>` (true only when a tab was created), and quick-create records `touchMruProvider` only on success. `handleFileOpen` returns before `registerFileTabPath` when placement is refused, so no phantom file row is persisted or broadcast.
- **Mobile shell**: `WorkspaceCenterFallback` extracted from DesktopLayout and shared — create-workspace empty state, watchdog "Couldn't load this workspace" report, and the waiting state now render on mobile instead of a blank panel. TabBar no longer renders a chip at zero tabs (the new `mobileBarSpacer` keeps the files toggle right-aligned) and auto-closes the tab sheet when the last tab closes; `mobileTilePaneSlot` composes the desktop `tileContent` class instead of duplicating it, so in-flow empty states center.
- **Backend** (tests only; the hub guard pre-exists in validate.go): `TestValidate_TabPlacement_TabOnTileOutsideAnyWorkspace` proves the structural rejection under `allowAll`, and `TestCRDTService_SubmitOps_TabOutsideAnyWorkspaceRejected` proves the in-band rejection commits nothing while a follow-up placement on a registered root still commits. Test setups gained an unbootstrapped-workspace mode.

## Result

Every creation surface now answers "can this tab be placed?" before doing anything irreversible:

```ts
warnUnlessPlaceableTab(layoutStore, 'an agent')
// false → "Cannot open an agent — The workspace is not ready for a new tab yet."
```

Dialogs disable submit with the reason visible above the form (e.g. "Create a workspace first — a tab lives inside a workspace.", "This workspace is archived. Unarchive it to create tabs.", "The workspace view is not ready yet. Try again in a moment."), so form submits never fire an RPC that placement would strand. Quick actions refuse with a warning toast instead of orphaning an agent session, pty, or phantom file row, and a refused quick-create no longer reshuffles the provider MRU. On mobile, the center shows the proper empty/timeout states, the zero-tab chip is gone, and closing the last tab closes the tab sheet instead of leaving a dangling sheet behind.
