### PR TITLE
feat(subagent): Revive a finished subagent when its parent messages it

### DIFF
--- a/backend/internal/worker/agent/agent.go
+++ b/backend/internal/worker/agent/agent.go
@@ -347,6 +347,20 @@ type OutputSink interface {
 	// below the transcript it is supposed to introduce.
 	PersistChildPrompt(childAgentID, prompt string) error
 
+	// PersistChildUserMessage APPENDS text to a child transcript as a USER
+	// message, in the same {"content": text} envelope PersistChildPrompt uses.
+	// For a message the parent delivered to a subagent mid-transcript, where
+	// PersistChildPrompt cannot help: that one opens the transcript and is a
+	// no-op once the subagent has spoken.
+	//
+	// Carries MARK_TYPE_USER_MESSAGE, which the opening prompt does not: this
+	// message lands in the MIDDLE of a transcript, and a mid-transcript user
+	// message is exactly what the scroll rail exists to find.
+	//
+	// A no-op for a blank text or an empty child id. The envelope shape stays
+	// here, with the other transcript primitives, so no provider encodes it.
+	PersistChildUserMessage(childAgentID, text string) error
+
 	// CleanupChildAgent releases the per-child service state (span tracker,
 	// todos cache, cached child sink) for a child that has reached a final
 	// state. A provider calls this once a subagent closes for good so a
@@ -375,6 +389,38 @@ type OutputSink interface {
 	// the row opens under the toolCallId and the session id surfaces late). A
 	// no-op when oldKey is absent or newKey is empty.
 	RenameBackgroundTask(oldKey, newKey string) error
+
+	// LookupBackgroundTask resolves a provider row key to the child transcript it
+	// owns and the row's current status. ok is false when the root's registry
+	// holds no such row, and the returned status is meaningless then -- the zero
+	// Status is StatusPending, a real value, not an "unknown" sentinel.
+	//
+	// err is non-nil when the registry could not be READ at all, which is a third
+	// answer and not a miss. A caller must not treat it as "no such row": the two
+	// are indistinguishable in the return values, and the decisions that turn on
+	// a miss (this is a first start; there is nothing to revive) are all wrong
+	// when the truth is "unknown".
+	//
+	// This is how a provider turns an id the MODEL supplied into one of its own
+	// subagents. The registry is the right index for it: it is keyed by row key,
+	// it carries the child linkage, and it survives both a provider's own
+	// bookkeeping being dropped at task end and a worker restart. A key that
+	// identifies nothing (a display name, another session, a foreign address)
+	// simply misses.
+	LookupBackgroundTask(rowKey string) (childAgentID string, status bgtask.Status, ok bool, err error)
+
+	// ReviveBackgroundTask returns a FINISHED row to Running, clears its
+	// ended_at, and lets the reopened transcript be closed again by the next
+	// completion. A no-op for an absent row and for one that is already active,
+	// so a duplicate revive is harmless.
+	//
+	// Call this ONLY with positive evidence that the provider restarted the task.
+	// Every other registry write treats a final status as absorbing, because a
+	// replayed running update cannot prove a restart and honoring it would leave
+	// a row Running that nothing closes -- which pins the parent's thinking
+	// indicator for good. This method is the one deliberate exception, and the
+	// burden of proof sits with its caller.
+	ReviveBackgroundTask(rowKey string) error
 }
 
 // Agent is the interface that all coding agent providers must implement.

--- a/backend/internal/worker/agent/agent.go
+++ b/backend/internal/worker/agent/agent.go
@@ -403,10 +403,12 @@ type OutputSink interface {
 	//
 	// This is how a provider turns an id the MODEL supplied into one of its own
 	// subagents. The registry is the right index for it: it is keyed by row key,
-	// it carries the child linkage, and it survives both a provider's own
-	// bookkeeping being dropped at task end and a worker restart. A key that
-	// identifies nothing (a display name, another session, a foreign address)
-	// simply misses.
+	// it carries the child linkage, and it survives a provider's own bookkeeping
+	// being dropped at task end, a worker restart, AND the display cap -- a row
+	// that carries a child transcript outlives the capped list the sidebar
+	// shows, so the thousandth subagent of a session resolves exactly like the
+	// first. A key that identifies nothing (a display name, another session, a
+	// foreign address) simply misses.
 	LookupBackgroundTask(rowKey string) (childAgentID string, status bgtask.Status, ok bool, err error)
 
 	// ReviveBackgroundTask returns a FINISHED row to Running, clears its

--- a/backend/internal/worker/agent/agent.go
+++ b/backend/internal/worker/agent/agent.go
@@ -319,8 +319,8 @@ type OutputSink interface {
 	// the same rule every other writer of a title column applies, and the one
 	// place that documents its steps. A provider passes what it has, and does
 	// not cap or strip it first. Pass "" when the provider has no title: the
-	// sink keeps the registry row's current title and gives the agent row its
-	// own name.
+	// sink keeps the registry row's current title and gives the agent row a
+	// pooled fallback name.
 	EnsureChildAgent(spawnSpanID, providerChildKey, title string) (childAgentID string, err error)
 
 	// ChildSink returns an OutputSink bound to the child agent's transcript.
@@ -351,7 +351,7 @@ type OutputSink interface {
 	// message, in the same {"content": text} envelope PersistChildPrompt uses.
 	// For a message the parent delivered to a subagent mid-transcript, where
 	// PersistChildPrompt cannot help: that one opens the transcript and is a
-	// no-op once the subagent has spoken.
+	// no-op once the subagent spoke.
 	//
 	// Carries MARK_TYPE_USER_MESSAGE, which the opening prompt does not: this
 	// message lands in the MIDDLE of a transcript, and a mid-transcript user

--- a/backend/internal/worker/agent/claude.go
+++ b/backend/internal/worker/agent/claude.go
@@ -145,25 +145,15 @@ type ClaudeCodeAgent struct {
 	// task_notification.
 	taskToolUse map[string]string // task_id -> tool_use_id
 	toolUseTask map[string]string // tool_use_id -> task_id
-	// taskChild/childTask index the same link from the CHILD transcript side, so
-	// a forwarded envelope resolves its registry row when the tool_use index
+	// childTask indexes the same link from the CHILD transcript side, so a
+	// forwarded envelope resolves its registry row when the tool_use index
 	// cannot. A revive re-registers the task under the SendMessage tool_use id,
 	// and the first completion already dropped the spawn span, so a run-2 result
 	// forwarded under the ORIGINAL spawn resolves no task and leaves the row the
 	// revive reopened Running for the agent's life. Guarded by a.mu, and NOT
-	// dropped at a completion: the pair describes the transcript, which outlives
+	// dropped at a completion: the entry describes the transcript, which outlives
 	// every run of it.
-	taskChild map[string]string // task_id -> child_agent_id
 	childTask map[string]string // child_agent_id -> task_id
-	// pendingChildMessage holds a delivered message whose child transcript could
-	// not be resolved when it arrived, keyed by task id. A revive whose registry
-	// row was cap-evicted carries no linkage, and the event's tool_use id is the
-	// SendMessage call rather than a spawn span -- opening a transcript from it
-	// would key an agents row by a non-spawn id and re-point the row at that
-	// orphan. The text waits here until a forwarded envelope resolves the real
-	// transcript. Guarded by a.mu; dropped with the rest of the index in
-	// forgetTaskIndex.
-	pendingChildMessage map[string]string // task_id -> the delivered text
 	// finishedTasks holds every task id this process gave a final status. A wake
 	// block names the backgrounded shell whose completion restarted a subagent,
 	// and confirming that id here is what separates a real wake from a resumed

--- a/backend/internal/worker/agent/claude.go
+++ b/backend/internal/worker/agent/claude.go
@@ -141,10 +141,36 @@ type ClaudeCodeAgent struct {
 	// tool_use id (parent_tool_use_id on forwarded envelopes). Used to route
 	// forwarded subagent output into the right child transcript and to drive
 	// the background-task registry. Guarded by a.mu. NOT cleared at turn end
-	// (background tasks outlive turns); entries dropped on the terminal
+	// (background tasks outlive turns); entries dropped on the final
 	// task_notification.
 	taskToolUse map[string]string // task_id -> tool_use_id
 	toolUseTask map[string]string // tool_use_id -> task_id
+	// taskChild/childTask index the same link from the CHILD transcript side, so
+	// a forwarded envelope resolves its registry row when the tool_use index
+	// cannot. A revive re-registers the task under the SendMessage tool_use id,
+	// and the first completion already dropped the spawn span, so a run-2 result
+	// forwarded under the ORIGINAL spawn resolves no task and leaves the row the
+	// revive reopened Running for the agent's life. Guarded by a.mu, and NOT
+	// dropped at a completion: the pair describes the transcript, which outlives
+	// every run of it.
+	taskChild map[string]string // task_id -> child_agent_id
+	childTask map[string]string // child_agent_id -> task_id
+	// pendingChildMessage holds a delivered message whose child transcript could
+	// not be resolved when it arrived, keyed by task id. A revive whose registry
+	// row was cap-evicted carries no linkage, and the event's tool_use id is the
+	// SendMessage call rather than a spawn span -- opening a transcript from it
+	// would key an agents row by a non-spawn id and re-point the row at that
+	// orphan. The text waits here until a forwarded envelope resolves the real
+	// transcript. Guarded by a.mu; dropped with the rest of the index in
+	// forgetTaskIndex.
+	pendingChildMessage map[string]string // task_id -> the delivered text
+	// finishedTasks holds every task id this process gave a final status. A wake
+	// block names the backgrounded shell whose completion restarted a subagent,
+	// and confirming that id here is what separates a real wake from a resumed
+	// session's hydration burst, which replays prompts naming tasks of a PREVIOUS
+	// process. Guarded by a.mu; never cleared, and bounded by the tasks one
+	// process ran.
+	finishedTasks map[string]struct{} // task_id this process finalized
 	// taskKind remembers what task_started said a task IS, because only
 	// task_started carries task_type. A later task_notification has to upsert
 	// the row again (to record a shell's output_file) and would otherwise have
@@ -154,10 +180,22 @@ type ClaudeCodeAgent struct {
 	// notification.
 	taskKind map[string]bgtask.Kind // task_id -> kind
 	// pendingTaskEnd holds a final status for a Task subagent whose result
-	// message arrived BEFORE its task_started (a forward of the child's terminal
+	// message arrived BEFORE its task_started (a forward of the child's final
 	// result can race past a reordered task_started). Keyed by spawn tool_use id
 	// so the late task_started can close the row it just opened. Guarded by a.mu.
-	pendingTaskEnd map[string]bgtask.Status // spawn tool_use_id -> terminal status
+	pendingTaskEnd map[string]bgtask.Status // spawn tool_use_id -> final status
+	// pendingRevive holds the task ids the in-flight SendMessage calls addressed.
+	// A task_started for a task already in a final status is a REVIVE only when
+	// the id is armed here; see claudeArmRevivesFromBlocks for why the tool call
+	// is the evidence and the event alone is not. Guarded by a.mu.
+	//
+	// The VALUE is the transcript that armed it: "" for the root, the spawn span
+	// id for a subagent. Each transcript's own turn end drops only its own arms,
+	// because a subagent outlives the root turn it was spawned in -- clearing on
+	// the root's result alone dropped a live subagent's arm before its
+	// task_started could fire it, and left that arm standing for the agent's life
+	// while the root sat idle.
+	pendingRevive map[string]string // task_id -> the spawn span that armed it ("" == root)
 }
 
 // claudeResumeArgs returns the `--resume` argv pair for a stored session ID,

--- a/backend/internal/worker/agent/claude.go
+++ b/backend/internal/worker/agent/claude.go
@@ -19,7 +19,6 @@ import (
 	"github.com/leapmux/leapmux/internal/util/envutil"
 	"github.com/leapmux/leapmux/internal/util/optionids"
 	"github.com/leapmux/leapmux/internal/util/optionmap"
-	"github.com/leapmux/leapmux/internal/worker/bgtask"
 	"github.com/leapmux/leapmux/util/validate"
 )
 
@@ -137,55 +136,13 @@ type ClaudeCodeAgent struct {
 	// catalog.
 	availableModels []*ModelInfo
 
-	// Subagent (Task/Workflow) index. Maps a Claude task_id <-> the spawning
-	// tool_use id (parent_tool_use_id on forwarded envelopes). Used to route
-	// forwarded subagent output into the right child transcript and to drive
-	// the background-task registry. Guarded by a.mu. NOT cleared at turn end
-	// (background tasks outlive turns); entries dropped on the final
-	// task_notification.
-	taskToolUse map[string]string // task_id -> tool_use_id
-	toolUseTask map[string]string // tool_use_id -> task_id
-	// childTask indexes the same link from the CHILD transcript side, so a
-	// forwarded envelope resolves its registry row when the tool_use index
-	// cannot. A revive re-registers the task under the SendMessage tool_use id,
-	// and the first completion already dropped the spawn span, so a run-2 result
-	// forwarded under the ORIGINAL spawn resolves no task and leaves the row the
-	// revive reopened Running for the agent's life. Guarded by a.mu, and NOT
-	// dropped at a completion: the entry describes the transcript, which outlives
-	// every run of it.
-	childTask map[string]string // child_agent_id -> task_id
-	// finishedTasks holds every task id this process gave a final status. A wake
-	// block names the backgrounded shell whose completion restarted a subagent,
-	// and confirming that id here is what separates a real wake from a resumed
-	// session's hydration burst, which replays prompts naming tasks of a PREVIOUS
-	// process. Guarded by a.mu; never cleared, and bounded by the tasks one
-	// process ran.
-	finishedTasks map[string]struct{} // task_id this process finalized
-	// taskKind remembers what task_started said a task IS, because only
-	// task_started carries task_type. A later task_notification has to upsert
-	// the row again (to record a shell's output_file) and would otherwise have
-	// to guess the kind -- guessing "shell" there rewrote every Task subagent's
-	// row into a shell one, since notifications fire for subagents too.
-	// Guarded by a.mu; dropped with the rest of the index on the closing
-	// notification.
-	taskKind map[string]bgtask.Kind // task_id -> kind
-	// pendingTaskEnd holds a final status for a Task subagent whose result
-	// message arrived BEFORE its task_started (a forward of the child's final
-	// result can race past a reordered task_started). Keyed by spawn tool_use id
-	// so the late task_started can close the row it just opened. Guarded by a.mu.
-	pendingTaskEnd map[string]bgtask.Status // spawn tool_use_id -> final status
-	// pendingRevive holds the task ids the in-flight SendMessage calls addressed.
-	// A task_started for a task already in a final status is a REVIVE only when
-	// the id is armed here; see claudeArmRevivesFromBlocks for why the tool call
-	// is the evidence and the event alone is not. Guarded by a.mu.
-	//
-	// The VALUE is the transcript that armed it: "" for the root, the spawn span
-	// id for a subagent. Each transcript's own turn end drops only its own arms,
-	// because a subagent outlives the root turn it was spawned in -- clearing on
-	// the root's result alone dropped a live subagent's arm before its
-	// task_started could fire it, and left that arm standing for the agent's life
-	// while the root sat idle.
-	pendingRevive map[string]string // task_id -> the spawn span that armed it ("" == root)
+	// tasks indexes everything this agent knows about a Claude task. It carries
+	// its own mutex, so the eight maps no longer contend on processBase.mu --
+	// the process-lifecycle lock every provider embeds, which guards `stopped`,
+	// the model, and the effort. A value, not a pointer: ClaudeCodeAgent is
+	// built at many sites that do not go through StartClaudeCode, and a nil
+	// receiver would be reachable from every one of them.
+	tasks claudeTaskIndex
 }
 
 // claudeResumeArgs returns the `--resume` argv pair for a stored session ID,
@@ -324,9 +281,6 @@ func StartClaudeCode(ctx context.Context, opts Options, sink OutputSink) (*Claud
 		thirdPartyFromSettings: thirdPartyFromSettings,
 		pendingControl:         make(map[string]chan<- claudeCodeControlResult),
 		alwaysThinking:         AlwaysThinkingOn,
-		taskToolUse:            make(map[string]string),
-		toolUseTask:            make(map[string]string),
-		taskKind:               make(map[string]bgtask.Kind),
 	}
 
 	TraceStartupPhase(opts.AgentID, "before_exec_start")

--- a/backend/internal/worker/agent/claude_output.go
+++ b/backend/internal/worker/agent/claude_output.go
@@ -292,6 +292,12 @@ func (a *ClaudeCodeAgent) processAssistantBlocks(env *messageEnvelope) {
 	// Determine the parent span for any Agent tool_use blocks.
 	parentSpanID := env.ParentToolUseID
 
+	// A SendMessage here may be about to restart a finished subagent. Record the
+	// recipient before the tool runs, because the task_started it produces cannot
+	// be told from a session resume's hydration burst on its own. This is the
+	// ROOT transcript, so the arms are scoped to it ("").
+	a.claudeArmRevivesFromBlocks(env, "")
+
 	toolUseCount := 0
 	planFileProcessed := false
 	for _, block := range env.ContentBlocks() {
@@ -450,7 +456,7 @@ func claudeCloseToolResultSpans(sink OutputSink, env *messageEnvelope) {
 // Source for persistence is derived from msgType: USER for the `user`
 // envelope (which on the Claude wire includes both human input and
 // tool_result echoes under role:"user"); AGENT for assistant text,
-// system notifications, and the terminal `result` envelope. `result`
+// system notifications, and the final `result` envelope. `result`
 // routes through PersistTurnEnd so its source value is unused.
 func (a *ClaudeCodeAgent) handlePersistableMessage(content []byte, msgType string) {
 	source := leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT
@@ -579,6 +585,16 @@ func (a *ClaudeCodeAgent) handlePersistableMessage(content []byte, msgType strin
 
 		// Reset all span tracking so the next turn starts clean.
 		a.sink.ResetSpans()
+		// Drop the ROOT's SendMessage revive arms with it. A revive's task_started
+		// lands inside the turn that sent the message (the tool awaits the
+		// restart), so an arm still standing here addressed a live subagent, a
+		// recipient outside this session, or a send the CLI refused -- and none of
+		// those will ever fire it.
+		//
+		// Only the root's. A subagent runs past this boundary and clears its own
+		// arms at its own turn end, so wiping every arm here would drop a live
+		// subagent's before its task_started arrived.
+		a.clearClaudeRevives("")
 	}
 }
 

--- a/backend/internal/worker/agent/claude_output.go
+++ b/backend/internal/worker/agent/claude_output.go
@@ -594,7 +594,7 @@ func (a *ClaudeCodeAgent) handlePersistableMessage(content []byte, msgType strin
 		// Only the root's. A subagent runs past this boundary and clears its own
 		// arms at its own turn end, so wiping every arm here would drop a live
 		// subagent's before its task_started arrived.
-		a.clearClaudeRevives("")
+		a.tasks.clearClaudeRevives("")
 	}
 }
 

--- a/backend/internal/worker/agent/claude_subagent.go
+++ b/backend/internal/worker/agent/claude_subagent.go
@@ -302,11 +302,21 @@ func (a *ClaudeCodeAgent) handleClaudeTaskStarted(ev *claudeTaskEnvelope) {
 		// makes the two resolutions one, so they cannot disagree.
 		childID, err := known.childID, error(nil)
 		//
-		// Never from a SendMessage id. EnsureChildAgent takes a SPAWN SPAN, and on
-		// a re-registration whose row was cap-evicted the row-key path misses and
-		// the spawn-span lookup misses too -- so it would CREATE a second child
-		// keyed by a non-spawn id and re-point the durable row at that orphan,
-		// leaving the subagent's real transcript unreachable.
+		// Never from a SendMessage id. EnsureChildAgent takes a SPAWN SPAN, and a
+		// re-registration's tool_use_id is the call that RESTARTED the task -- so
+		// handing it over walks past the row-key fast path, fails
+		// GetChildAgentBySpawnSpan, and CREATES a child keyed by a non-spawn id,
+		// which a later forwarded envelope under the real spawn span then
+		// duplicates.
+		//
+		// A linked row never reaches this test, because the registry row that
+		// carries the child outlives the display cap. What reaches it is a row
+		// that holds no linkage at all: an EnsureChildAgent that a DB failure
+		// defeated at spawn time, or a registry this process could not read. The
+		// recorded span type is the only positive evidence available in either
+		// state, and refusing an unproven id costs a transcript the subagent
+		// never had -- creating one under the wrong key costs the transcript it
+		// does have.
 		if childID == "" && ev.ToolUseID != "" && a.sink.GetSpanType(ev.ToolUseID) != ToolNameClaudeSendMessage {
 			childID, err = a.sink.EnsureChildAgent(ev.ToolUseID, ev.TaskID, title)
 		}
@@ -317,14 +327,14 @@ func (a *ClaudeCodeAgent) handleClaudeTaskStarted(ev *claudeTaskEnvelope) {
 		case err != nil:
 			slog.Warn("claude task_started ensure child failed", "task_id", ev.TaskID, "error", err)
 		case childID == "":
-			// No transcript to write into yet. When the parent addressed this task,
-			// hold the delivered text: the subagent's first forwarded envelope
-			// resolves its real transcript through the spawn span, and the flush
-			// there puts the message above the reply it asked for. Dropping it
-			// instead would lose the one thing the user cannot reconstruct.
-			if a.takeClaudeRevive(ev.TaskID) && !a.claudeWakeRestartedTask(ev) {
-				a.parkClaudeChildMessage(ev.TaskID, ev.Prompt)
-			}
+			// No transcript, and none this event can open. The revive arm is left
+			// STANDING rather than consumed: the row is still finished, so a later
+			// task_started for this task in the same turn is still a revive and
+			// deserves the retry -- the same reason a failed registry write puts
+			// its arm back.
+			slog.Warn("claude task_started resolved no child transcript",
+				"task_id", ev.TaskID, "tool_use_id", ev.ToolUseID,
+				"row_exists", known.exists, "registry_unreadable", known.unreadable)
 		default:
 			handled, err := a.reviveClaudeSubagent(ev, childID, known)
 			switch {
@@ -597,14 +607,6 @@ func (a *ClaudeCodeAgent) routeSubagentMessage(content []byte, msgType string, e
 		taskID = a.taskIDForChild(childID)
 	}
 	a.rememberTaskChild(taskID, childID)
-	// A delivered message that had no transcript when it arrived. This is the
-	// first point where the subagent's real one is known, and it runs BEFORE the
-	// envelope persists so the message sits above the reply it asked for.
-	if text := a.takeClaudeChildMessage(taskID); text != "" {
-		if err := a.sink.PersistChildUserMessage(childID, text); err != nil {
-			slog.Warn("claude flush held child message failed", "child", childID, "error", err)
-		}
-	}
 
 	// Resolve the span metadata and reserve the tool_use's color with the SAME
 	// helper the parent transcript uses, but against the CHILD sink's tracker
@@ -782,37 +784,7 @@ func (a *ClaudeCodeAgent) claudeWakeRestartedTask(ev *claudeTaskEnvelope) bool {
 	return seen
 }
 
-// parkClaudeChildMessage holds a delivered message until a transcript resolves.
-// A no-op for a blank text, so a revive that carried none parks nothing.
-func (a *ClaudeCodeAgent) parkClaudeChildMessage(taskID, text string) {
-	if taskID == "" || strings.TrimSpace(text) == "" {
-		return
-	}
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	if a.pendingChildMessage == nil {
-		a.pendingChildMessage = make(map[string]string)
-	}
-	a.pendingChildMessage[taskID] = text
-}
-
-// takeClaudeChildMessage removes and returns a held message, so one delivery is
-// written once. Returns "" when nothing is held for this task.
-func (a *ClaudeCodeAgent) takeClaudeChildMessage(taskID string) string {
-	if taskID == "" {
-		return ""
-	}
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	text, ok := a.pendingChildMessage[taskID]
-	if !ok {
-		return ""
-	}
-	delete(a.pendingChildMessage, taskID)
-	return text
-}
-
-// rememberTaskChild records the task_id <-> child transcript pair, so a
+// rememberTaskChild records the child transcript -> task_id link, so a
 // forwarded envelope can identify its registry row from the child alone.
 func (a *ClaudeCodeAgent) rememberTaskChild(taskID, childID string) {
 	if taskID == "" || childID == "" {
@@ -820,13 +792,9 @@ func (a *ClaudeCodeAgent) rememberTaskChild(taskID, childID string) {
 	}
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	if a.taskChild == nil {
-		a.taskChild = make(map[string]string)
-	}
 	if a.childTask == nil {
 		a.childTask = make(map[string]string)
 	}
-	a.taskChild[taskID] = childID
 	a.childTask[childID] = taskID
 }
 
@@ -855,15 +823,11 @@ func (a *ClaudeCodeAgent) forgetTaskIndex(taskID string) {
 		delete(a.taskToolUse, taskID)
 		delete(a.toolUseTask, tuid)
 	}
-	// taskChild/childTask deliberately SURVIVE. They describe the transcript, not
-	// the run, and a transcript is permanent: a revived run's forwarded envelopes
-	// still have to name this row, and the spawn span the tool_use index carried
-	// is gone by then. Bounded by the number of subagents this agent spawned,
-	// which is the same bound as the child sinks the sink already holds.
-	//
-	// A held message does NOT survive: by a completion it either flushed on the
-	// run's first forwarded envelope or has no transcript to reach.
-	delete(a.pendingChildMessage, taskID)
+	// childTask deliberately SURVIVES. It describes the transcript, not the run,
+	// and a transcript is permanent: a revived run's forwarded envelopes still
+	// have to name this row, and the spawn span the tool_use index carried is
+	// gone by then. Bounded by the number of subagents this agent spawned, which
+	// is the same bound as the child sinks the sink already holds.
 	delete(a.taskKind, taskID)
 }
 

--- a/backend/internal/worker/agent/claude_subagent.go
+++ b/backend/internal/worker/agent/claude_subagent.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"maps"
 	"strings"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
@@ -20,6 +21,15 @@ const (
 	ToolNameClaudeAgent = "Agent"
 	ToolNameClaudeTask  = "Task"
 )
+
+// ToolNameClaudeSendMessage is the tool the main agent uses to message another
+// agent. When it addresses a subagent of this session that already FINISHED, the
+// CLI restarts that subagent, and this is the only signal that says so before
+// the restart happens.
+//
+// It is deliberately absent from claudeToolSpawnsSubagent: the call starts no
+// new transcript, so it owns an ordinary span that its own tool_result closes.
+const ToolNameClaudeSendMessage = "SendMessage"
 
 // claudeToolSpawnsSubagent reports whether a Claude tool_use block starts a
 // subagent. A spawn owns no span: the subagent's own output lands in its child
@@ -148,6 +158,16 @@ func (a *ClaudeCodeAgent) handleClaudeTaskStarted(ev *claudeTaskEnvelope) {
 	if ev.TaskID == "" {
 		return
 	}
+	// Resolve the registry BEFORE anything is written, because "does a row for
+	// this task already exist" is what separates a first start from a
+	// re-registration, and two decisions below turn on it.
+	//
+	// The CLI emits task_started again for the same task_id in two cases: it
+	// revived a finished subagent, or a resumed session is re-announcing the
+	// tasks it once ran. Both re-register, and in both the event's tool_use_id
+	// identifies the tool call that runs NOW, not the original spawn.
+	known := lookupClaudeKnownTask(a.sink, ev.TaskID)
+
 	// Record the index (task_id <-> tool_use_id). Guarded by a.mu; never
 	// cleared at turn end (background tasks outlive turns).
 	a.mu.Lock()
@@ -200,8 +220,16 @@ func (a *ClaudeCodeAgent) handleClaudeTaskStarted(ev *claudeTaskEnvelope) {
 	// nothing on the wire says which. Prose set in the monospace face reads
 	// worse than a command set in the normal one, so the ambiguous case takes
 	// the normal one.
+	//
+	// The prompt fallback is for a FIRST start only. On a re-registration the
+	// prompt is the message the parent just sent, and a non-blank title
+	// overwrites the row's own (PreservingBlanksFrom keeps only a BLANK one), so
+	// the Background-tasks entry would rename itself to a chat message while the
+	// child agents row -- which EnsureChildAgent never rewrites -- kept the real
+	// title. A blank title here is the correct value for a row that already has
+	// one.
 	title := ev.Description
-	if title == "" {
+	if title == "" && !known.exists && !known.unreadable {
 		title = bgtask.FirstLine(ev.Prompt)
 	}
 
@@ -232,7 +260,28 @@ func (a *ClaudeCodeAgent) handleClaudeTaskStarted(ev *claudeTaskEnvelope) {
 	// keeps that tool behind the WORKFLOW_SCRIPTS feature flag, so its wire name
 	// is not a stable thing to match, and this event is the first authoritative
 	// word that the call is a workflow.
-	if startedKind != bgtask.KindShell && ev.ToolUseID != "" {
+	//
+	// Not for a re-registration. Its tool_use_id is the tool call that RESTARTED
+	// the task -- the parent's SendMessage -- and that call is still running in
+	// the parent transcript. Closing its span here would free the rail mid-flight,
+	// so its own tool_result would draw a connector_end with no vertical line
+	// above it to meet.
+	//
+	// The recorded span TYPE decides it, not "does the registry hold this task".
+	// The registry is durable and the span tracker is not, so a row that outlived
+	// a worker restart, or one a reordered task_notification opened first, would
+	// suppress the close for a genuine spawn and strand its rail open for the rest
+	// of the transcript. processAssistantBlocks records a type for every tool_use,
+	// CloseSpan preserves it (only the turn-end Reset clears it), and a revive's
+	// task_started lands inside the sending turn -- so this reads SendMessage
+	// exactly when the event re-registers a task and the spawn's own name
+	// otherwise.
+	// An unreadable registry suppresses the close too: it cannot prove this is a
+	// spawn, and freeing a rail that is still in use is the worse of the two
+	// errors -- a rail given back too late costs one column, one given back too
+	// early leaves a tool_result drawing a connector end with nothing above it.
+	if !known.unreadable && a.sink.GetSpanType(ev.ToolUseID) != ToolNameClaudeSendMessage &&
+		startedKind != bgtask.KindShell && ev.ToolUseID != "" {
 		// CloseSpan, although the subagent keeps running: the call frees the
 		// column and nothing downstream distinguishes "ended" from "given back".
 		// The recorded span type survives it, so the tool_result still persists
@@ -240,19 +289,63 @@ func (a *ClaudeCodeAgent) handleClaudeTaskStarted(ev *claudeTaskEnvelope) {
 		a.sink.CloseSpan(ev.ToolUseID)
 	}
 
-	// Pre-create the child transcript for a Task subagent (local_agent), keyed
-	// by its spawning tool_use id. local_bash (shell) and local_workflow have no
-	// transcript; their envelopes are never forwarded.
-	if ev.TaskType != claudeTaskTypeBash && ev.TaskType != claudeTaskTypeWorkflow && ev.ToolUseID != "" {
-		childID, err := a.sink.EnsureChildAgent(ev.ToolUseID, ev.TaskID, title)
-		if err != nil {
+	// Pre-create the child transcript for a Task subagent (local_agent).
+	// local_bash (shell) and local_workflow have no transcript; their envelopes
+	// are never forwarded.
+	if ev.TaskType != claudeTaskTypeBash && ev.TaskType != claudeTaskTypeWorkflow {
+		// The registry's own linkage FIRST, and EnsureChildAgent only when the row
+		// carries none. On a re-registration ev.ToolUseID is the SendMessage call,
+		// not the spawn span, so handing it to EnsureChildAgent walks past the
+		// row-key fast path (which misses whenever the row lost its linkage),
+		// fails GetChildAgentBySpawnSpan, and CREATES a second transcript keyed by
+		// that id -- then re-links the row to the orphan. Reading known.childID
+		// makes the two resolutions one, so they cannot disagree.
+		childID, err := known.childID, error(nil)
+		//
+		// Never from a SendMessage id. EnsureChildAgent takes a SPAWN SPAN, and on
+		// a re-registration whose row was cap-evicted the row-key path misses and
+		// the spawn-span lookup misses too -- so it would CREATE a second child
+		// keyed by a non-spawn id and re-point the durable row at that orphan,
+		// leaving the subagent's real transcript unreachable.
+		if childID == "" && ev.ToolUseID != "" && a.sink.GetSpanType(ev.ToolUseID) != ToolNameClaudeSendMessage {
+			childID, err = a.sink.EnsureChildAgent(ev.ToolUseID, ev.TaskID, title)
+		}
+		if childID != "" {
+			a.rememberTaskChild(ev.TaskID, childID)
+		}
+		switch {
+		case err != nil:
 			slog.Warn("claude task_started ensure child failed", "task_id", ev.TaskID, "error", err)
-		} else if err := a.sink.PersistChildPrompt(childID, ev.Prompt); err != nil {
-			// task_started is the only Claude event that carries the spawn
-			// prompt, and it lands before any forwarded envelope, so the child
-			// transcript opens on the instruction rather than on the reply.
-			// Losing it costs the first message, not the transcript.
-			slog.Warn("claude task_started persist prompt failed", "task_id", ev.TaskID, "error", err)
+		case childID == "":
+			// No transcript to write into yet. When the parent addressed this task,
+			// hold the delivered text: the subagent's first forwarded envelope
+			// resolves its real transcript through the spawn span, and the flush
+			// there puts the message above the reply it asked for. Dropping it
+			// instead would lose the one thing the user cannot reconstruct.
+			if a.takeClaudeRevive(ev.TaskID) && !a.claudeWakeRestartedTask(ev) {
+				a.parkClaudeChildMessage(ev.TaskID, ev.Prompt)
+			}
+		default:
+			handled, err := a.reviveClaudeSubagent(ev, childID, known)
+			switch {
+			case err != nil:
+				// It WAS a revive; only the registry write failed. The delivered
+				// message is already in the transcript and the arm is back, so the
+				// first-start path below must not run -- PersistChildPrompt says
+				// nothing on a transcript that already has messages anyway.
+				slog.Warn("claude revive background task failed", "task_id", ev.TaskID, "error", err)
+			case handled:
+				// The prompt was the message the parent just sent, appended to the
+				// running transcript rather than prepended as the opening instruction.
+			default:
+				if err := a.sink.PersistChildPrompt(childID, ev.Prompt); err != nil {
+					// task_started is the only Claude event that carries the spawn
+					// prompt, and it lands before any forwarded envelope, so the child
+					// transcript opens on the instruction rather than on the reply.
+					// Losing it costs the first message, not the transcript.
+					slog.Warn("claude task_started persist prompt failed", "task_id", ev.TaskID, "error", err)
+				}
+			}
 		}
 	}
 
@@ -264,6 +357,107 @@ func (a *ClaudeCodeAgent) handleClaudeTaskStarted(ev *claudeTaskEnvelope) {
 		_ = a.sink.CloseBackgroundTask(ev.TaskID, pendingEnd)
 		a.forgetTaskIndex(ev.TaskID)
 	}
+}
+
+// claudeKnownTask is what the registry already knows about a task id, read once
+// at the top of handleClaudeTaskStarted.
+//
+// `exists` is the load-bearing field: a task_started for a task the registry
+// ALREADY holds is a re-registration, not a first start, and in a
+// re-registration the event's tool_use_id identifies the tool call that runs now
+// rather than the original spawn. Grouped into one value because childID and
+// status are only ever meaningful together with it, and because two adjacent
+// string parameters (this childID and the resolved one) are easy to hand over
+// the wrong way round.
+type claudeKnownTask struct {
+	childID string
+	status  bgtask.Status
+	exists  bool
+	// unreadable is set when the registry could not be READ, which is neither
+	// "holds this task" nor "does not". Every decision below that treats a miss
+	// as "this is a first start" is wrong when the truth is unknown, so they test
+	// this first.
+	unreadable bool
+}
+
+func lookupClaudeKnownTask(sink OutputSink, taskID string) claudeKnownTask {
+	childID, status, exists, err := sink.LookupBackgroundTask(taskID)
+	if err != nil {
+		slog.Warn("claude task_started: registry lookup failed", "task_id", taskID, "error", err)
+		return claudeKnownTask{unreadable: true}
+	}
+	return claudeKnownTask{childID: childID, status: status, exists: exists}
+}
+
+// reviveClaudeSubagent handles a task_started that restarted a FINISHED subagent
+// because the parent sent it a message. It reopens the registry row and appends
+// the delivered message to the child transcript. Reports whether it took the
+// event, so the caller skips the first-start prompt path.
+//
+// Three conditions must all hold, and each excludes a different impostor:
+//
+//   - the registry already holds this task -- a first start is not a revive;
+//   - the row is in a FINISHED status -- a duplicate task_started for a running
+//     task changes nothing;
+//   - a SendMessage this turn addressed this task id -- which is what a resumed
+//     session's hydration burst never carries, and it re-announces every task it
+//     once ran with all of them finished.
+//
+// A SendMessage is not the CLI's only restart. Captured against 2.1.233: it also
+// re-registers a FINISHED subagent when one of that subagent's own backgrounded
+// shells completes, emitting a task_started with NO tool_use_id whose prompt is
+// a <task-notification> block, and the subagent then runs again. No arm exists
+// for it, so its row stays finished while it works. Recognizing it needs a
+// discriminator that a resumed session's burst cannot forge, and matching on the
+// prompt text is not one -- see the report attached to this change.
+//
+// The message text comes from the event's prompt rather than from the
+// SendMessage input. That is what the subagent actually received, wrapping and
+// all, and it arrives on the one event that also proves the restart happened, so
+// a send the CLI refused records nothing.
+//
+// Reports `handled` -- whether this event WAS a revive -- separately from the
+// error, because the two answer different questions. The caller skips the
+// first-start prompt path on handled, and a failed registry write does not make
+// the event any less a revive: falling back there would hand the delivered
+// message to PersistChildPrompt, which says nothing once the transcript has
+// messages, and the arm is spent by then.
+func (a *ClaudeCodeAgent) reviveClaudeSubagent(ev *claudeTaskEnvelope, childID string, known claudeKnownTask) (handled bool, err error) {
+	if childID == "" || !known.exists || !known.status.IsFinished() {
+		return false, nil
+	}
+	// Two restarts, two proofs. A SendMessage the parent made this turn, or the
+	// CLI waking this subagent because one of its own backgrounded shells
+	// finished. Only the first delivers text: a wake's prompt is a
+	// <task-notification> block addressed to the model, which is harness
+	// plumbing rather than anything the user asked for, so it reopens the row and
+	// writes nothing.
+	delivered := a.takeClaudeRevive(ev.TaskID)
+	if !delivered && !a.claudeWakeRestartedTask(ev) {
+		return false, nil
+	}
+	// The message BEFORE the registry write, because the two are independent and
+	// the text is the half the user cannot recover. A row that stays finished is
+	// visibly wrong and the next notification corrects it; a message that was
+	// never written is gone, and nothing retries it.
+	if delivered {
+		if err := a.sink.PersistChildUserMessage(childID, ev.Prompt); err != nil {
+			slog.Warn("claude revive persist message failed", "child", childID, "error", err)
+		}
+	}
+	if err := a.sink.ReviveBackgroundTask(ev.TaskID); err != nil {
+		// Put a consumed DELIVERY arm back. The row is still finished, so a later
+		// task_started for this task in the same turn is still a revive and
+		// deserves the retry that a consumed arm would deny it. Re-armed at ROOT
+		// scope ("") because this runs on the root stream and the root's turn end
+		// is the later of the two boundaries -- the retry window is never cut
+		// short. A wake consumed nothing, so it has nothing to give back.
+		if delivered {
+			a.armClaudeRevive(ev.TaskID, "")
+		}
+		return true, err
+	}
+	return true, nil
 }
 
 func (a *ClaudeCodeAgent) handleClaudeTaskProgress(ev *claudeTaskEnvelope) {
@@ -299,6 +493,9 @@ func (a *ClaudeCodeAgent) handleClaudeTaskNotification(ev *claudeTaskEnvelope) {
 	if !known {
 		return
 	}
+	// Remember it BEFORE the writes: a wake for this task's owner can follow
+	// immediately, and it proves itself by naming an id this process finalized.
+	a.rememberFinishedTask(ev.TaskID)
 	summary := strings.TrimSpace(ev.Summary)
 	if err := a.sink.UpdateBackgroundTaskStatus(ev.TaskID, status, summary); err != nil {
 		slog.Warn("claude task_notification status update failed", "task_id", ev.TaskID, "error", err)
@@ -369,11 +566,21 @@ func (a *ClaudeCodeAgent) routeSubagentMessage(content []byte, msgType string, e
 	// the async path and emits nothing of the kind, which is why only a
 	// foreground subagent opened its transcript on two identical prompts.
 	//
-	// Nothing else can arrive this way. Inside the run loop the CLI forwards a
-	// message only when it holds a tool_use or a tool_result block, so every
-	// other forwarded user envelope is a tool_result; and a Claude subagent
-	// cannot be steered (only Codex implements ChildSteerer), so no typed user
-	// message reaches a child transcript either.
+	// Inside the run loop the CLI forwards a message only when it holds a tool_use
+	// or a tool_result block, so every other forwarded user envelope is a
+	// tool_result; and a Claude subagent cannot be steered (only Codex implements
+	// ChildSteerer), so no TYPED user message reaches a child transcript either.
+	//
+	// A SendMessage the parent addresses to a subagent does not reach a child
+	// transcript this way either, and a live recipient is not an exception.
+	// Captured against 2.1.233: the CLI CONCLUDES the recipient's current run
+	// before it delivers. A subagent that was mid-Bash when the parent addressed
+	// it emitted task_notification=completed FIRST, then the parent's SendMessage
+	// tool_use, then a task_started carrying the message as its prompt. The
+	// delivered text rides on exactly two envelopes -- the parent's own tool_use
+	// input, and task_started.prompt -- and never on a forwarded one. So a
+	// recipient is always FINISHED by delivery time, the revive path is the whole
+	// mechanism, and there is no live-delivery case for this guard to drop.
 	if msgType == claudeMsgTypeUser && !hasToolResultBlock(env) {
 		return
 	}
@@ -385,6 +592,18 @@ func (a *ClaudeCodeAgent) routeSubagentMessage(content []byte, msgType string, e
 	if err != nil {
 		slog.Warn("claude route subagent: ensure child failed", "spawn_span", spawnSpanID, "error", err)
 		return
+	}
+	if taskID == "" {
+		taskID = a.taskIDForChild(childID)
+	}
+	a.rememberTaskChild(taskID, childID)
+	// A delivered message that had no transcript when it arrived. This is the
+	// first point where the subagent's real one is known, and it runs BEFORE the
+	// envelope persists so the message sits above the reply it asked for.
+	if text := a.takeClaudeChildMessage(taskID); text != "" {
+		if err := a.sink.PersistChildUserMessage(childID, text); err != nil {
+			slog.Warn("claude flush held child message failed", "child", childID, "error", err)
+		}
 	}
 
 	// Resolve the span metadata and reserve the tool_use's color with the SAME
@@ -405,6 +624,15 @@ func (a *ClaudeCodeAgent) routeSubagentMessage(content []byte, msgType string, e
 		// fallback when no task_notification arrived.
 		if err := childSink.PersistTurnEnd(content, spanInfo); err != nil {
 			slog.Warn("claude route subagent turn-end failed", "child", childID, "error", err)
+		}
+		if taskID == "" {
+			// The tool_use index answers "" for a REVIVED run whose result the CLI
+			// forwarded under the ORIGINAL spawn span: the first completion dropped
+			// that span, and the revive re-registered the task under the SendMessage
+			// call. The child transcript is the same across both runs, so it still
+			// identifies the row. Without this the reopened row stays Running for
+			// good whenever no task_notification follows.
+			taskID = a.taskIDForChild(childID)
 		}
 		if taskID != "" {
 			status := bgtask.StatusCompleted
@@ -427,6 +655,10 @@ func (a *ClaudeCodeAgent) routeSubagentMessage(content []byte, msgType string, e
 			}
 			a.recordPendingTaskEnd(spawnSpanID, status)
 		}
+		// This subagent's turn ended, so drop the arms IT set. Its own result is
+		// the boundary for them; the root's is not, because this transcript
+		// outlives the root turn that spawned it.
+		a.clearClaudeRevives(spawnSpanID)
 		return
 	}
 
@@ -451,6 +683,12 @@ func (a *ClaudeCodeAgent) routeSubagentMessage(content []byte, msgType string, e
 	// its own -- which owns no span here for the same reason it owns none in the
 	// parent transcript: its output goes to a transcript of its own.
 	if msgType == claudeMsgTypeAssistant {
+		// A subagent can message another agent, so its SendMessage calls arm a
+		// revive exactly as the parent's do. The arms live on the agent, not on a
+		// sink, because the task_started that fires them arrives on the root
+		// stream whichever transcript sent the message. They carry this
+		// transcript's spawn span, so the root's turn end cannot drop them.
+		a.claudeArmRevivesFromBlocks(env, spawnSpanID)
 		for _, block := range env.ContentBlocks() {
 			if block.Type == "tool_use" && block.ID != "" {
 				childSink.SetSpanType(block.ID, block.Name)
@@ -479,6 +717,130 @@ func (a *ClaudeCodeAgent) taskIDForToolUse(toolUseID string) string {
 	return a.toolUseTask[toolUseID]
 }
 
+// The wake block the CLI hands a subagent when one of that subagent's own
+// backgrounded shells finishes. It arrives as a task_started prompt.
+const (
+	claudeWakeOpenTag  = "<task-notification>"
+	claudeWakeCloseTag = "</task-notification>"
+)
+
+// claudeWakeTaskID reports the task id a <task-notification> wake block names.
+//
+// Two conditions, and neither is decoration. The block must OPEN the first line
+// or CLOSE the last one, so a spawn prompt that merely discusses the tag is not
+// mistaken for one. And the caller must confirm the id against the tasks THIS
+// process finished: a resumed session's hydration burst replays prompts from a
+// previous process, so the shell it names is one this process never saw. The
+// pair is the same class of proof the SendMessage arm supplies -- positive,
+// per-process evidence that the restart really happened -- rather than a guess
+// from the event alone.
+func claudeWakeTaskID(prompt string) (string, bool) {
+	lines := strings.Split(strings.TrimSpace(prompt), "\n")
+	if len(lines) < 2 {
+		return "", false
+	}
+	if strings.TrimSpace(lines[0]) != claudeWakeOpenTag &&
+		strings.TrimSpace(lines[len(lines)-1]) != claudeWakeCloseTag {
+		return "", false
+	}
+	for _, line := range lines {
+		rest, ok := strings.CutPrefix(strings.TrimSpace(line), "<task-id>")
+		if !ok {
+			continue
+		}
+		if id, ok := strings.CutSuffix(rest, "</task-id>"); ok && id != "" {
+			return id, true
+		}
+	}
+	return "", false
+}
+
+// rememberFinishedTask records a task this process gave a final status, so a
+// later wake block that names it is provably about THIS session.
+func (a *ClaudeCodeAgent) rememberFinishedTask(taskID string) {
+	if taskID == "" {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.finishedTasks == nil {
+		a.finishedTasks = make(map[string]struct{})
+	}
+	a.finishedTasks[taskID] = struct{}{}
+}
+
+// claudeWakeRestartedTask reports whether this task_started is the CLI waking a
+// finished subagent because one of its own backgrounded shells completed.
+func (a *ClaudeCodeAgent) claudeWakeRestartedTask(ev *claudeTaskEnvelope) bool {
+	shellTaskID, ok := claudeWakeTaskID(ev.Prompt)
+	if !ok {
+		return false
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	_, seen := a.finishedTasks[shellTaskID]
+	return seen
+}
+
+// parkClaudeChildMessage holds a delivered message until a transcript resolves.
+// A no-op for a blank text, so a revive that carried none parks nothing.
+func (a *ClaudeCodeAgent) parkClaudeChildMessage(taskID, text string) {
+	if taskID == "" || strings.TrimSpace(text) == "" {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.pendingChildMessage == nil {
+		a.pendingChildMessage = make(map[string]string)
+	}
+	a.pendingChildMessage[taskID] = text
+}
+
+// takeClaudeChildMessage removes and returns a held message, so one delivery is
+// written once. Returns "" when nothing is held for this task.
+func (a *ClaudeCodeAgent) takeClaudeChildMessage(taskID string) string {
+	if taskID == "" {
+		return ""
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	text, ok := a.pendingChildMessage[taskID]
+	if !ok {
+		return ""
+	}
+	delete(a.pendingChildMessage, taskID)
+	return text
+}
+
+// rememberTaskChild records the task_id <-> child transcript pair, so a
+// forwarded envelope can identify its registry row from the child alone.
+func (a *ClaudeCodeAgent) rememberTaskChild(taskID, childID string) {
+	if taskID == "" || childID == "" {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.taskChild == nil {
+		a.taskChild = make(map[string]string)
+	}
+	if a.childTask == nil {
+		a.childTask = make(map[string]string)
+	}
+	a.taskChild[taskID] = childID
+	a.childTask[childID] = taskID
+}
+
+// taskIDForChild resolves the registry row_key for a child transcript id.
+// Returns "" when no task_started linked one.
+func (a *ClaudeCodeAgent) taskIDForChild(childID string) string {
+	if childID == "" {
+		return ""
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.childTask[childID]
+}
+
 // forgetTaskIndex drops the task_id <-> tool_use_id pair from both directions
 // of the index. Called when a task reaches a final state via either a
 // task_notification or the result-message fallback, so a task that ends
@@ -493,6 +855,15 @@ func (a *ClaudeCodeAgent) forgetTaskIndex(taskID string) {
 		delete(a.taskToolUse, taskID)
 		delete(a.toolUseTask, tuid)
 	}
+	// taskChild/childTask deliberately SURVIVE. They describe the transcript, not
+	// the run, and a transcript is permanent: a revived run's forwarded envelopes
+	// still have to name this row, and the spawn span the tool_use index carried
+	// is gone by then. Bounded by the number of subagents this agent spawned,
+	// which is the same bound as the child sinks the sink already holds.
+	//
+	// A held message does NOT survive: by a completion it either flushed on the
+	// run's first forwarded envelope or has no transcript to reach.
+	delete(a.pendingChildMessage, taskID)
 	delete(a.taskKind, taskID)
 }
 
@@ -505,6 +876,96 @@ func (a *ClaudeCodeAgent) kindForTask(taskID string) bgtask.Kind {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	return a.taskKind[taskID]
+}
+
+// claudeSendMessageInput is the part of a SendMessage tool_use input this code
+// reads. `to` is the recipient, and for a subagent of this session it is the
+// Claude task_id -- the CLI keys its task registry by agent id, which is the
+// same string LeapMux stores as the registry row_key. Every other recipient form
+// (a display name, another session, a uds:/bridge:/did: address) identifies no row
+// of ours and resolves to nothing, which is the correct outcome for it.
+type claudeSendMessageInput struct {
+	To string `json:"to"`
+}
+
+// claudeArmRevivesFromBlocks records the task ids an assistant envelope's
+// SendMessage calls addressed, so a following task_started for one of them is
+// recognized as a revive.
+//
+// The tool call is the evidence, and the event alone cannot be. A resumed
+// session re-emits task_started for EVERY subagent it once ran, to rebuild the
+// CLI's own task registry, and those tasks are all in a final status here. So
+// "task_started for a finished row" describes the hydration burst exactly as
+// well as it describes a revive, and acting on it would resurrect every old
+// subagent with no close ever arriving. A SendMessage that gives that task id is
+// what separates the two, because the hydration burst carries none.
+//
+// Arming is deliberately unconditional on whether `to` resolves. The registry
+// lookup happens when the arm FIRES, so a recipient that identifies no row simply
+// never matches a task_started, and the arm expires at the turn end.
+//
+// Shared by the parent transcript and the child one: a subagent can message
+// another agent, and its tool_use blocks arrive through routeSubagentMessage.
+// `armedBy` separates the two -- "" for the root, the spawn span id for a
+// subagent -- so each transcript's turn end drops only the arms it set.
+func (a *ClaudeCodeAgent) claudeArmRevivesFromBlocks(env *messageEnvelope, armedBy string) {
+	for _, block := range env.ContentBlocks() {
+		if block.Type != "tool_use" || block.Name != ToolNameClaudeSendMessage {
+			continue
+		}
+		var input claudeSendMessageInput
+		if err := json.Unmarshal(block.Input, &input); err != nil {
+			slog.Warn("claude SendMessage input unmarshal failed", "agent_id", a.agentID, "error", err)
+			continue
+		}
+		a.armClaudeRevive(input.To, armedBy)
+	}
+}
+
+// armClaudeRevive records one recipient id as revivable until the turn end of
+// the transcript that sent the message. armedBy is "" for the root and the
+// spawn span id for a subagent.
+func (a *ClaudeCodeAgent) armClaudeRevive(to, armedBy string) {
+	if to == "" {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.pendingRevive == nil {
+		a.pendingRevive = make(map[string]string)
+	}
+	a.pendingRevive[to] = armedBy
+}
+
+// takeClaudeRevive reports whether an in-flight SendMessage addressed taskID,
+// and consumes the arm so one send cannot revive the same row twice.
+func (a *ClaudeCodeAgent) takeClaudeRevive(taskID string) bool {
+	if taskID == "" {
+		return false
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if _, ok := a.pendingRevive[taskID]; !ok {
+		return false
+	}
+	delete(a.pendingRevive, taskID)
+	return true
+}
+
+// clearClaudeRevives drops the arms that ONE transcript set, at that
+// transcript's turn end. A SendMessage to a LIVE subagent, to a recipient
+// outside this session, or one the CLI refused emits no task_started, so
+// without this the arms would accumulate for the agent's life.
+//
+// Scoped, not global: a subagent outlives the root turn that spawned it, so the
+// root's result is not its turn boundary. Clearing everything there dropped a
+// live subagent's arm before its task_started could fire it, which left the
+// recipient's row finished and its transcript looking dead -- the exact bug the
+// revive exists to fix.
+func (a *ClaudeCodeAgent) clearClaudeRevives(armedBy string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	maps.DeleteFunc(a.pendingRevive, func(_, scope string) bool { return scope == armedBy })
 }
 
 // recordPendingTaskEnd remembers a final status for a Task subagent whose

--- a/backend/internal/worker/agent/claude_subagent.go
+++ b/backend/internal/worker/agent/claude_subagent.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"maps"
 	"strings"
+	"sync"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/worker/bgtask"
@@ -168,39 +169,16 @@ func (a *ClaudeCodeAgent) handleClaudeTaskStarted(ev *claudeTaskEnvelope) {
 	// identifies the tool call that runs NOW, not the original spawn.
 	known := lookupClaudeKnownTask(a.sink, ev.TaskID)
 
-	// Record the index (task_id <-> tool_use_id). Guarded by a.mu; never
-	// cleared at turn end (background tasks outlive turns).
-	a.mu.Lock()
-	if a.taskToolUse == nil {
-		a.taskToolUse = make(map[string]string)
-	}
-	if a.toolUseTask == nil {
-		a.toolUseTask = make(map[string]string)
-	}
-	if ev.ToolUseID != "" {
-		a.taskToolUse[ev.TaskID] = ev.ToolUseID
-		a.toolUseTask[ev.ToolUseID] = ev.TaskID
-	}
-	if a.taskKind == nil {
-		a.taskKind = make(map[string]bgtask.Kind)
-	}
+	// The per-process proof that this event RE-REGISTERS a task rather than
+	// starting one. Read once at the top, because four decisions below turn on it
+	// and none may disagree with another.
+	restart := a.restartEvidenceFor(ev)
+
 	startedKind := bgtask.KindSubagent
 	if ev.TaskType == claudeTaskTypeBash {
 		startedKind = bgtask.KindShell
 	}
-	a.taskKind[ev.TaskID] = startedKind
-	// A final result that arrived before this (reordered) task_started left
-	// a pending close keyed by the spawn span. Take it now and close the row
-	// this upsert is about to open, so the row cannot leak Running.
-	var pendingEnd bgtask.Status
-	var hasPending bool
-	if ev.ToolUseID != "" && a.pendingTaskEnd != nil {
-		if s, ok := a.pendingTaskEnd[ev.ToolUseID]; ok {
-			pendingEnd, hasPending = s, true
-			delete(a.pendingTaskEnd, ev.ToolUseID)
-		}
-	}
-	a.mu.Unlock()
+	pendingEnd, hasPending := a.tasks.startTask(ev.TaskID, ev.ToolUseID, startedKind)
 
 	kind := startedKind
 	groupKey, groupLabel := a.workflowGroup(ev)
@@ -228,8 +206,21 @@ func (a *ClaudeCodeAgent) handleClaudeTaskStarted(ev *claudeTaskEnvelope) {
 	// child agents row -- which EnsureChildAgent never rewrites -- kept the real
 	// title. A blank title here is the correct value for a row that already has
 	// one.
+	//
+	// Positive restart evidence suppresses the fallback, and an UNREADABLE
+	// registry is not evidence. Keying on the read failure had the asymmetry
+	// backwards: a read fails most often on the first registry touch of a
+	// process, where a first start is the overwhelmingly common event, and the
+	// row then took a blank title that nothing rewrites -- and EnsureChildAgent,
+	// given the same blank, took the tab name from the pool instead of from the
+	// prompt.
+	//
+	// The WAKE half of the evidence matters here even though `known.exists`
+	// usually answers for it: a wake against a registry this process cannot read
+	// leaves exists false, and the fallback then renamed the row to the wake
+	// block itself -- a literal <task-notification> in the sidebar.
 	title := ev.Description
-	if title == "" && !known.exists && !known.unreadable {
+	if title == "" && !known.exists && !restart.restarted() {
 		title = bgtask.FirstLine(ev.Prompt)
 	}
 
@@ -262,25 +253,31 @@ func (a *ClaudeCodeAgent) handleClaudeTaskStarted(ev *claudeTaskEnvelope) {
 	// word that the call is a workflow.
 	//
 	// Not for a re-registration. Its tool_use_id is the tool call that RESTARTED
-	// the task -- the parent's SendMessage -- and that call is still running in
+	// the task -- the parent's SendMessage -- and that call still runs in
 	// the parent transcript. Closing its span here would free the rail mid-flight,
 	// so its own tool_result would draw a connector_end with no vertical line
 	// above it to meet.
 	//
-	// The recorded span TYPE decides it, not "does the registry hold this task".
-	// The registry is durable and the span tracker is not, so a row that outlived
-	// a worker restart, or one a reordered task_notification opened first, would
-	// suppress the close for a genuine spawn and strand its rail open for the rest
-	// of the transcript. processAssistantBlocks records a type for every tool_use,
-	// CloseSpan preserves it (only the turn-end Reset clears it), and a revive's
-	// task_started lands inside the sending turn -- so this reads SendMessage
-	// exactly when the event re-registers a task and the spawn's own name
-	// otherwise.
+	// The in-flight SendMessage CALLS decide it, not "does the registry hold this
+	// task". The registry is durable and the call index is not, so a row that
+	// outlived a worker restart, or one a reordered task_notification opened
+	// first, would suppress the close for a genuine spawn and strand its rail
+	// open for the rest of the transcript. claudeArmRevivesFromBlocks records
+	// every SendMessage tool_use id as the block is parsed, and each transcript
+	// drops its own at its own turn end -- so this reads "restart call" exactly
+	// when the event re-registers a task, and nothing otherwise.
+	//
+	// The span tracker cannot answer this. A subagent's own SendMessage records
+	// its span type on that CHILD's tracker (routeSubagentMessage), while this
+	// runs on the ROOT sink, which answers "" for an id it never saw -- and ""
+	// is indistinguishable from a spawn here. So a sibling-to-sibling send, the
+	// case the revive exists to support, read as a spawn at both guards.
+	//
 	// An unreadable registry suppresses the close too: it cannot prove this is a
 	// spawn, and freeing a rail that is still in use is the worse of the two
 	// errors -- a rail given back too late costs one column, one given back too
 	// early leaves a tool_result drawing a connector end with nothing above it.
-	if !known.unreadable && a.sink.GetSpanType(ev.ToolUseID) != ToolNameClaudeSendMessage &&
+	if !known.unreadable && !restart.restarted() &&
 		startedKind != bgtask.KindShell && ev.ToolUseID != "" {
 		// CloseSpan, although the subagent keeps running: the call frees the
 		// column and nothing downstream distinguishes "ended" from "given back".
@@ -313,15 +310,19 @@ func (a *ClaudeCodeAgent) handleClaudeTaskStarted(ev *claudeTaskEnvelope) {
 		// carries the child outlives the display cap. What reaches it is a row
 		// that holds no linkage at all: an EnsureChildAgent that a DB failure
 		// defeated at spawn time, or a registry this process could not read. The
-		// recorded span type is the only positive evidence available in either
-		// state, and refusing an unproven id costs a transcript the subagent
-		// never had -- creating one under the wrong key costs the transcript it
-		// does have.
-		if childID == "" && ev.ToolUseID != "" && a.sink.GetSpanType(ev.ToolUseID) != ToolNameClaudeSendMessage {
+		// in-flight SendMessage calls are the only positive evidence available in
+		// either state, and refusing an unproven id costs a transcript the
+		// subagent never had -- creating one under the wrong key costs the
+		// transcript it does have.
+		//
+		// The restart evidence and not a span-type read: the span tracker answers for one
+		// transcript, and a subagent's own SendMessage lands on that child's
+		// tracker rather than the root's. See the guard above.
+		if childID == "" && ev.ToolUseID != "" && !restart.restarted() {
 			childID, err = a.sink.EnsureChildAgent(ev.ToolUseID, ev.TaskID, title)
 		}
 		if childID != "" {
-			a.rememberTaskChild(ev.TaskID, childID)
+			a.tasks.rememberTaskChild(ev.TaskID, childID)
 		}
 		switch {
 		case err != nil:
@@ -336,7 +337,7 @@ func (a *ClaudeCodeAgent) handleClaudeTaskStarted(ev *claudeTaskEnvelope) {
 				"task_id", ev.TaskID, "tool_use_id", ev.ToolUseID,
 				"row_exists", known.exists, "registry_unreadable", known.unreadable)
 		default:
-			handled, err := a.reviveClaudeSubagent(ev, childID, known)
+			handled, err := a.reviveClaudeSubagent(ev, childID, known, restart)
 			switch {
 			case err != nil:
 				// It WAS a revive; only the registry write failed. The delivered
@@ -365,7 +366,7 @@ func (a *ClaudeCodeAgent) handleClaudeTaskStarted(ev *claudeTaskEnvelope) {
 	if hasPending {
 		_ = a.sink.UpdateBackgroundTaskStatus(ev.TaskID, pendingEnd, "")
 		_ = a.sink.CloseBackgroundTask(ev.TaskID, pendingEnd)
-		a.forgetTaskIndex(ev.TaskID)
+		a.tasks.forgetTaskIndex(ev.TaskID)
 	}
 }
 
@@ -432,7 +433,7 @@ func lookupClaudeKnownTask(sink OutputSink, taskID string) claudeKnownTask {
 // the event any less a revive: falling back there would hand the delivered
 // message to PersistChildPrompt, which says nothing once the transcript has
 // messages, and the arm is spent by then.
-func (a *ClaudeCodeAgent) reviveClaudeSubagent(ev *claudeTaskEnvelope, childID string, known claudeKnownTask) (handled bool, err error) {
+func (a *ClaudeCodeAgent) reviveClaudeSubagent(ev *claudeTaskEnvelope, childID string, known claudeKnownTask, restart claudeRestartEvidence) (handled bool, err error) {
 	if childID == "" || !known.exists || !known.status.IsFinished() {
 		return false, nil
 	}
@@ -442,8 +443,14 @@ func (a *ClaudeCodeAgent) reviveClaudeSubagent(ev *claudeTaskEnvelope, childID s
 	// <task-notification> block addressed to the model, which is harness
 	// plumbing rather than anything the user asked for, so it reopens the row and
 	// writes nothing.
-	delivered := a.takeClaudeRevive(ev.TaskID)
-	if !delivered && !a.claudeWakeRestartedTask(ev) {
+	//
+	// The evidence arrives as a parameter, because the caller reads it before it
+	// derives the row title from the same event. Two reads of one fact would let
+	// the title and the revive disagree about what this event is. This is also
+	// the ONE decision that reads a single form rather than restarted(): only a
+	// SendMessage delivers text, so a wake reopens the row and writes nothing.
+	delivered := a.tasks.takeClaudeRevive(ev.TaskID)
+	if !delivered && !restart.wake {
 		return false, nil
 	}
 	// The message BEFORE the registry write, because the two are independent and
@@ -463,7 +470,7 @@ func (a *ClaudeCodeAgent) reviveClaudeSubagent(ev *claudeTaskEnvelope, childID s
 		// is the later of the two boundaries -- the retry window is never cut
 		// short. A wake consumed nothing, so it has nothing to give back.
 		if delivered {
-			a.armClaudeRevive(ev.TaskID, "")
+			a.tasks.armClaudeRevive(ev.TaskID, "")
 		}
 		return true, err
 	}
@@ -503,9 +510,11 @@ func (a *ClaudeCodeAgent) handleClaudeTaskNotification(ev *claudeTaskEnvelope) {
 	if !known {
 		return
 	}
-	// Remember it BEFORE the writes: a wake for this task's owner can follow
-	// immediately, and it proves itself by naming an id this process finalized.
-	a.rememberFinishedTask(ev.TaskID)
+	// Remember it BEFORE the writes: a wake for this shell's owner can follow
+	// immediately, and it proves itself with an id this process finalized. The
+	// call filters to shells; forgetTaskIndex below drops the kind, so the read
+	// has to happen here.
+	a.tasks.rememberFinishedShellTask(ev.TaskID)
 	summary := strings.TrimSpace(ev.Summary)
 	if err := a.sink.UpdateBackgroundTaskStatus(ev.TaskID, status, summary); err != nil {
 		slog.Warn("claude task_notification status update failed", "task_id", ev.TaskID, "error", err)
@@ -521,7 +530,7 @@ func (a *ClaudeCodeAgent) handleClaudeTaskNotification(ev *claudeTaskEnvelope) {
 	if ev.OutputFile != "" {
 		_ = a.sink.UpsertBackgroundTask(bgtask.Upsert{
 			RowKey:      ev.TaskID,
-			Kind:        a.kindForTask(ev.TaskID),
+			Kind:        a.tasks.kindForTask(ev.TaskID),
 			Description: ev.OutputFile,
 			Status:      status,
 		})
@@ -530,7 +539,7 @@ func (a *ClaudeCodeAgent) handleClaudeTaskNotification(ev *claudeTaskEnvelope) {
 		slog.Warn("claude task_notification close failed", "task_id", ev.TaskID, "error", err)
 	}
 	// Drop the index entry.
-	a.forgetTaskIndex(ev.TaskID)
+	a.tasks.forgetTaskIndex(ev.TaskID)
 }
 
 // workflowGroup derives the (group_key, group_label) for a workflow task from
@@ -596,17 +605,19 @@ func (a *ClaudeCodeAgent) routeSubagentMessage(content []byte, msgType string, e
 	}
 
 	spawnSpanID := env.ParentToolUseID
-	taskID := a.taskIDForToolUse(spawnSpanID)
+	taskID := a.tasks.taskIDForToolUse(spawnSpanID)
 
 	childID, err := a.sink.EnsureChildAgent(spawnSpanID, taskID, "")
 	if err != nil {
 		slog.Warn("claude route subagent: ensure child failed", "spawn_span", spawnSpanID, "error", err)
 		return
 	}
-	if taskID == "" {
-		taskID = a.taskIDForChild(childID)
-	}
-	a.rememberTaskChild(taskID, childID)
+	// Only an index-derived id is recorded here. Resolving the task FROM the
+	// child and then writing the pair back would be a no-op write, and it would
+	// leave two copies of the child-keyed fallback -- the result branch below
+	// holds the one that earns its place, where a revived run's result is the
+	// only reader that needs it.
+	a.tasks.rememberTaskChild(taskID, childID)
 
 	// Resolve the span metadata and reserve the tool_use's color with the SAME
 	// helper the parent transcript uses, but against the CHILD sink's tracker
@@ -634,7 +645,7 @@ func (a *ClaudeCodeAgent) routeSubagentMessage(content []byte, msgType string, e
 			// call. The child transcript is the same across both runs, so it still
 			// identifies the row. Without this the reopened row stays Running for
 			// good whenever no task_notification follows.
-			taskID = a.taskIDForChild(childID)
+			taskID = a.tasks.taskIDForChild(childID)
 		}
 		if taskID != "" {
 			status := bgtask.StatusCompleted
@@ -645,7 +656,7 @@ func (a *ClaudeCodeAgent) routeSubagentMessage(content []byte, msgType string, e
 			_ = a.sink.CloseBackgroundTask(taskID, status)
 			// Drop the index entry on the fallback path too (a task that ends
 			// via the result without a task_notification would otherwise leak).
-			a.forgetTaskIndex(taskID)
+			a.tasks.forgetTaskIndex(taskID)
 		} else {
 			// task_started has not arrived yet (a reorder): remember the final
 			// status keyed by the spawn span so the late task_started can close
@@ -655,12 +666,12 @@ func (a *ClaudeCodeAgent) routeSubagentMessage(content []byte, msgType string, e
 			if env.IsError {
 				status = bgtask.StatusFailed
 			}
-			a.recordPendingTaskEnd(spawnSpanID, status)
+			a.tasks.recordPendingTaskEnd(spawnSpanID, status)
 		}
 		// This subagent's turn ended, so drop the arms IT set. Its own result is
 		// the boundary for them; the root's is not, because this transcript
 		// outlives the root turn that spawned it.
-		a.clearClaudeRevives(spawnSpanID)
+		a.tasks.clearClaudeRevives(spawnSpanID)
 		return
 	}
 
@@ -707,128 +718,277 @@ func (a *ClaudeCodeAgent) routeSubagentMessage(content []byte, msgType string, e
 	}
 }
 
+// claudeTaskIndex is everything this agent knows about a Claude task, in one
+// value with one mutex.
+//
+// Eight maps index the same concept, and they were eight fields on the agent
+// under processBase.mu -- the process-lifecycle lock, shared with `stopped`, the
+// model, and the effort. Grouping them states the shared lifetime rule in one
+// place (forgetTaskIndex drops the run-scoped entries; childTask and
+// finishedTasks describe things that outlive a run) rather than in five field
+// comments that a reader has to collect.
+//
+// A zero value is usable: every write lazily builds its map, so the many sites
+// that build a ClaudeCodeAgent without StartClaudeCode need no constructor.
+type claudeTaskIndex struct {
+	mu sync.Mutex
+	// Subagent (Task/Workflow) index. Maps a Claude task_id <-> the spawning
+	// tool_use id (parent_tool_use_id on forwarded envelopes). Used to route
+	// forwarded subagent output into the right child transcript and to drive
+	// the background-task registry. Guarded by i.mu. NOT cleared at turn end
+	// (background tasks outlive turns); entries dropped on the final
+	// task_notification.
+	taskToolUse map[string]string // task_id -> tool_use_id
+	toolUseTask map[string]string // tool_use_id -> task_id
+	// childTask indexes the same link from the CHILD transcript side, so a
+	// forwarded envelope resolves its registry row when the tool_use index
+	// cannot. A revive re-registers the task under the SendMessage tool_use id,
+	// and the first completion already dropped the spawn span, so a run-2 result
+	// forwarded under the ORIGINAL spawn resolves no task and leaves the row the
+	// revive reopened Running for the agent's life. Guarded by i.mu, and NOT
+	// dropped at a completion: the entry describes the transcript, which outlives
+	// every run of it.
+	childTask map[string]string // child_agent_id -> task_id
+	// finishedTasks holds the id of every backgrounded SHELL this process gave a
+	// final status. A wake block identifies the shell whose completion restarted
+	// a subagent, and confirming that id here is what separates a real wake from
+	// a resumed session's hydration burst, which replays prompts that identify
+	// tasks of a PREVIOUS process.
+	//
+	// Shells only. Recording every finished task let a SUBAGENT's own id satisfy
+	// the proof, and a hydration burst replays that subagent's own wake prompt --
+	// so the one impostor the discriminator exists to exclude walked through it.
+	// Guarded by i.mu; never cleared, and limited to the shells one process ran.
+	finishedTasks map[string]struct{} // shell task_id this process finalized
+	// taskKind remembers what task_started said a task IS, because only
+	// task_started carries task_type. A later task_notification has to upsert
+	// the row again (to record a shell's output_file) and would otherwise have
+	// to guess the kind -- guessing "shell" there rewrote every Task subagent's
+	// row into a shell one, since notifications fire for subagents too.
+	// Guarded by i.mu; dropped with the rest of the index on the closing
+	// notification.
+	taskKind map[string]bgtask.Kind // task_id -> kind
+	// pendingTaskEnd holds a final status for a Task subagent whose result
+	// message arrived BEFORE its task_started (a forward of the child's final
+	// result can race past a reordered task_started). Keyed by spawn tool_use id
+	// so the late task_started can close the row it just opened. Guarded by i.mu.
+	pendingTaskEnd map[string]bgtask.Status // spawn tool_use_id -> final status
+	// pendingRevive holds the task ids the in-flight SendMessage calls addressed.
+	// A task_started for a task already in a final status is a REVIVE only when
+	// the id is armed here; see claudeArmRevivesFromBlocks for why the tool call
+	// is the evidence and the event alone is not. Guarded by i.mu.
+	//
+	// The VALUE is the SET of transcripts that armed it: "" for the root, the
+	// spawn span id for a subagent. Each transcript's own turn end drops only its
+	// own arms, because a subagent outlives the root turn it was spawned in --
+	// clearing on the root's result alone dropped a live subagent's arm before
+	// its task_started could fire it, and left that arm standing for the agent's
+	// life while the root sat idle.
+	//
+	// A set and not one scope, because two transcripts can address one recipient
+	// inside a single root turn. With one scope the second sender overwrote the
+	// first, and whichever turn ended first dropped an arm the other still
+	// needed.
+	pendingRevive map[string]map[string]struct{} // task_id -> the spawn spans that armed it ("" == root)
+	// sendMessageCalls holds the tool_use id of every in-flight SendMessage call,
+	// with the transcript that made it. handleClaudeTaskStarted asks it whether
+	// an event's tool_use_id is a restart call rather than the spawn span that
+	// created the task, and two decisions turn on the answer: the span close, and
+	// whether the id may reach EnsureChildAgent.
+	//
+	// The SPAN tracker cannot answer it. A subagent's own SendMessage records its
+	// span type on that child's tracker, while handleClaudeTaskStarted reads the
+	// ROOT sink -- which answers "" for an id it never saw, and "" is what a
+	// spawn also answers there. Recording the call where the block is parsed
+	// covers both transcripts with one index. Guarded by i.mu, and cleared with
+	// pendingRevive at the turn end of the transcript that set it.
+	sendMessageCalls map[string]string // tool_use_id -> the spawn span that made it ("" == root)
+}
+
 // taskIDForToolUse resolves the registry row_key (Claude task_id) for a
 // spawning tool_use id, recorded at task_started. Returns "" when unknown
+
+// startTask records what a task_started says a task IS, and takes any pending
+// close that a reordered final result left for it.
+//
+// One critical section for all three maps, because they describe one event: the
+// task_id <-> tool_use_id pair, the kind, and the reordered close. Neither pair
+// is cleared at a turn end -- a background task outlives the turn that spawned
+// it -- and forgetTaskIndex drops all three on the closing notification.
+//
+// The pending close is keyed by the spawn span: a final result can arrive
+// BEFORE the task_started it belongs to, and taking it here lets the caller
+// close the row this event is about to open, so the row cannot leak Running.
+func (i *claudeTaskIndex) startTask(taskID, toolUseID string, kind bgtask.Kind) (bgtask.Status, bool) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if toolUseID != "" {
+		if i.taskToolUse == nil {
+			i.taskToolUse = make(map[string]string)
+		}
+		if i.toolUseTask == nil {
+			i.toolUseTask = make(map[string]string)
+		}
+		i.taskToolUse[taskID] = toolUseID
+		i.toolUseTask[toolUseID] = taskID
+	}
+	if i.taskKind == nil {
+		i.taskKind = make(map[string]bgtask.Kind)
+	}
+	i.taskKind[taskID] = kind
+	if toolUseID == "" {
+		return bgtask.StatusPending, false
+	}
+	status, ok := i.pendingTaskEnd[toolUseID]
+	if ok {
+		delete(i.pendingTaskEnd, toolUseID)
+	}
+	return status, ok
+}
+
 // (a reorder or a pre-task_started forwarded envelope).
-func (a *ClaudeCodeAgent) taskIDForToolUse(toolUseID string) string {
+func (i *claudeTaskIndex) taskIDForToolUse(toolUseID string) string {
 	if toolUseID == "" {
 		return ""
 	}
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	return a.toolUseTask[toolUseID]
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return i.toolUseTask[toolUseID]
 }
 
 // The wake block the CLI hands a subagent when one of that subagent's own
 // backgrounded shells finishes. It arrives as a task_started prompt.
 const (
-	claudeWakeOpenTag  = "<task-notification>"
-	claudeWakeCloseTag = "</task-notification>"
+	claudeWakeOpenTag        = "<task-notification>"
+	claudeWakeCloseTag       = "</task-notification>"
+	claudeWakeTaskIDOpenTag  = "<task-id>"
+	claudeWakeTaskIDCloseTag = "</task-id>"
 )
 
-// claudeWakeTaskID reports the task id a <task-notification> wake block names.
+// claudeWakeTaskID reports the task id a <task-notification> wake block
+// identifies.
 //
-// Two conditions, and neither is decoration. The block must OPEN the first line
-// or CLOSE the last one, so a spawn prompt that merely discusses the tag is not
-// mistaken for one. And the caller must confirm the id against the tasks THIS
-// process finished: a resumed session's hydration burst replays prompts from a
-// previous process, so the shell it names is one this process never saw. The
-// pair is the same class of proof the SendMessage arm supplies -- positive,
-// per-process evidence that the restart really happened -- rather than a guess
-// from the event alone.
+// The block must carry BOTH the open tag and the close tag, and the id must sit
+// inside a <task-id> element. Neither condition is where the safety lives: the
+// caller confirms the id against the tasks THIS process finished, and
+// reviveClaudeSubagent acts only on a row the registry already holds in a
+// finished status. That pair is the same class of proof the SendMessage arm
+// supplies -- positive, per-process evidence that the restart really happened --
+// and a resumed session's hydration burst cannot forge it, because it replays
+// prompts from a PREVIOUS process whose shell ids this one never saw.
+//
+// The parse is therefore deliberately shape-tolerant. It matches the tags
+// anywhere in the prompt and takes the first <task-id> element wherever it
+// sits, rather than requiring the tags at the first and last line and the id
+// alone on its own. This text is model-facing prose that no LeapMux code
+// controls, and the two failures are not symmetric: a false NEGATIVE silently
+// restores the whole bug this change exists to fix -- the row reads "finished"
+// for a run that is still going, and the run ends with no closing divider --
+// while a false POSITIVE cannot get past the two proofs above.
 func claudeWakeTaskID(prompt string) (string, bool) {
-	lines := strings.Split(strings.TrimSpace(prompt), "\n")
-	if len(lines) < 2 {
+	if !strings.Contains(prompt, claudeWakeOpenTag) || !strings.Contains(prompt, claudeWakeCloseTag) {
 		return "", false
 	}
-	if strings.TrimSpace(lines[0]) != claudeWakeOpenTag &&
-		strings.TrimSpace(lines[len(lines)-1]) != claudeWakeCloseTag {
+	_, rest, ok := strings.Cut(prompt, claudeWakeTaskIDOpenTag)
+	if !ok {
 		return "", false
 	}
-	for _, line := range lines {
-		rest, ok := strings.CutPrefix(strings.TrimSpace(line), "<task-id>")
-		if !ok {
-			continue
-		}
-		if id, ok := strings.CutSuffix(rest, "</task-id>"); ok && id != "" {
-			return id, true
-		}
+	id, _, ok := strings.Cut(rest, claudeWakeTaskIDCloseTag)
+	if !ok {
+		return "", false
 	}
-	return "", false
+	id = strings.TrimSpace(id)
+	return id, id != ""
 }
 
-// rememberFinishedTask records a task this process gave a final status, so a
-// later wake block that names it is provably about THIS session.
-func (a *ClaudeCodeAgent) rememberFinishedTask(taskID string) {
+// rememberFinishedShellTask records a backgrounded SHELL this process gave a
+// final status, so a later wake block that identifies it is provably about THIS
+// session.
+//
+// Shells only, because that is what a wake is about: the CLI wakes a subagent
+// when one of that subagent's own backgrounded shells completes. Recording
+// every finished task let a SUBAGENT's own id satisfy the proof, and a resumed
+// session replays that subagent's wake prompt verbatim -- so the hydration
+// burst, the one impostor the whole discriminator exists to exclude, walked
+// straight through it and reopened a row with nothing to close it.
+//
+// The kind read shares this lock rather than calling kindForTask, which takes
+// the same one. A task whose task_started this process never saw has no kind and
+// is not recorded, which is the conservative answer: an unknown task is not a
+// shell this process ran.
+func (i *claudeTaskIndex) rememberFinishedShellTask(taskID string) {
 	if taskID == "" {
 		return
 	}
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	if a.finishedTasks == nil {
-		a.finishedTasks = make(map[string]struct{})
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.taskKind[taskID] != bgtask.KindShell {
+		return
 	}
-	a.finishedTasks[taskID] = struct{}{}
+	if i.finishedTasks == nil {
+		i.finishedTasks = make(map[string]struct{})
+	}
+	i.finishedTasks[taskID] = struct{}{}
 }
 
 // claudeWakeRestartedTask reports whether this task_started is the CLI waking a
 // finished subagent because one of its own backgrounded shells completed.
-func (a *ClaudeCodeAgent) claudeWakeRestartedTask(ev *claudeTaskEnvelope) bool {
+func (i *claudeTaskIndex) claudeWakeRestartedTask(ev *claudeTaskEnvelope) bool {
 	shellTaskID, ok := claudeWakeTaskID(ev.Prompt)
 	if !ok {
 		return false
 	}
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	_, seen := a.finishedTasks[shellTaskID]
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	_, seen := i.finishedTasks[shellTaskID]
 	return seen
 }
 
 // rememberTaskChild records the child transcript -> task_id link, so a
 // forwarded envelope can identify its registry row from the child alone.
-func (a *ClaudeCodeAgent) rememberTaskChild(taskID, childID string) {
+func (i *claudeTaskIndex) rememberTaskChild(taskID, childID string) {
 	if taskID == "" || childID == "" {
 		return
 	}
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	if a.childTask == nil {
-		a.childTask = make(map[string]string)
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.childTask == nil {
+		i.childTask = make(map[string]string)
 	}
-	a.childTask[childID] = taskID
+	i.childTask[childID] = taskID
 }
 
 // taskIDForChild resolves the registry row_key for a child transcript id.
 // Returns "" when no task_started linked one.
-func (a *ClaudeCodeAgent) taskIDForChild(childID string) string {
+func (i *claudeTaskIndex) taskIDForChild(childID string) string {
 	if childID == "" {
 		return ""
 	}
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	return a.childTask[childID]
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return i.childTask[childID]
 }
 
 // forgetTaskIndex drops the task_id <-> tool_use_id pair from both directions
 // of the index. Called when a task reaches a final state via either a
 // task_notification or the result-message fallback, so a task that ends
 // without a notification does not leak its index entries for the agent's life.
-func (a *ClaudeCodeAgent) forgetTaskIndex(taskID string) {
+func (i *claudeTaskIndex) forgetTaskIndex(taskID string) {
 	if taskID == "" {
 		return
 	}
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	if tuid, ok := a.taskToolUse[taskID]; ok {
-		delete(a.taskToolUse, taskID)
-		delete(a.toolUseTask, tuid)
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if tuid, ok := i.taskToolUse[taskID]; ok {
+		delete(i.taskToolUse, taskID)
+		delete(i.toolUseTask, tuid)
 	}
 	// childTask deliberately SURVIVES. It describes the transcript, not the run,
 	// and a transcript is permanent: a revived run's forwarded envelopes still
 	// have to name this row, and the spawn span the tool_use index carried is
-	// gone by then. Bounded by the number of subagents this agent spawned, which
+	// gone by then. Limited to the number of subagents this agent spawned, which
 	// is the same bound as the child sinks the sink already holds.
-	delete(a.taskKind, taskID)
+	delete(i.taskKind, taskID)
 }
 
 // kindForTask returns what task_started said this task is, or KindUnspecified
@@ -836,10 +996,10 @@ func (a *ClaudeCodeAgent) forgetTaskIndex(taskID string) {
 // resume) or one already forgotten. The registry's blank-means-keep rule then
 // preserves whatever kind the row already carries, which is the right answer
 // for an existing row and the only honest one for a task nothing described.
-func (a *ClaudeCodeAgent) kindForTask(taskID string) bgtask.Kind {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	return a.taskKind[taskID]
+func (i *claudeTaskIndex) kindForTask(taskID string) bgtask.Kind {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return i.taskKind[taskID]
 }
 
 // claudeSendMessageInput is the part of a SendMessage tool_use input this code
@@ -877,42 +1037,128 @@ func (a *ClaudeCodeAgent) claudeArmRevivesFromBlocks(env *messageEnvelope, armed
 		if block.Type != "tool_use" || block.Name != ToolNameClaudeSendMessage {
 			continue
 		}
+		// The CALL is recorded whatever its input says, and before the input is
+		// read. Two guards in handleClaudeTaskStarted ask "is this tool_use id a
+		// restart call rather than a spawn span", and that answer does not depend
+		// on the recipient resolving -- an input this code cannot parse is still
+		// not a spawn.
+		a.tasks.rememberSendMessageCall(block.ID, armedBy)
 		var input claudeSendMessageInput
 		if err := json.Unmarshal(block.Input, &input); err != nil {
 			slog.Warn("claude SendMessage input unmarshal failed", "agent_id", a.agentID, "error", err)
 			continue
 		}
-		a.armClaudeRevive(input.To, armedBy)
+		a.tasks.armClaudeRevive(input.To, armedBy)
+	}
+}
+
+// rememberSendMessageCall records one in-flight SendMessage tool_use id with the
+// transcript that made it, until that transcript's turn end.
+func (i *claudeTaskIndex) rememberSendMessageCall(toolUseID, armedBy string) {
+	if toolUseID == "" {
+		return
+	}
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.sendMessageCalls == nil {
+		i.sendMessageCalls = make(map[string]string)
+	}
+	i.sendMessageCalls[toolUseID] = armedBy
+}
+
+// claudeRestartCall reports whether toolUseID is an in-flight SendMessage call,
+// which is what separates a task_started that RE-REGISTERS a task from the spawn
+// that created one.
+//
+// It is not consumed. Both guards in handleClaudeTaskStarted read it, and a
+// second task_started for the same call inside the turn must get the same
+// answer; the turn end of the transcript that made the call drops it.
+func (i *claudeTaskIndex) claudeRestartCall(toolUseID string) bool {
+	if toolUseID == "" {
+		return false
+	}
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	_, ok := i.sendMessageCalls[toolUseID]
+	return ok
+}
+
+// claudeRestartEvidence is the positive, per-process proof that a task_started
+// RE-REGISTERS a task rather than starting one. Each restart form the CLI has
+// contributes one field, and every decision that asks "is this a
+// re-registration" reads restarted() -- so a new form costs one field here and
+// no decision site is left behind. The two forms drifted apart before this
+// type existed: three decisions read the SendMessage half alone, and a wake
+// against an unreadable registry took the prompt-derived title branch and
+// renamed the row to the wake block.
+//
+// Positive evidence, never the absence of an impostor. "task_started against a
+// finished row" describes a resumed session's hydration burst, a duplicate
+// task_started, and a reordered one just as well as it describes a restart, and
+// honoring any of them reopens a row that nothing will close.
+type claudeRestartEvidence struct {
+	// sendMessage: the event's tool_use_id is an in-flight SendMessage call, so
+	// it is that call and not the spawn span that created the task.
+	sendMessage bool
+	// wake: the prompt is a wake block that identifies a backgrounded shell this
+	// process finished, which is the CLI restarting that shell's owner. Only this
+	// form is read on its own, by reviveClaudeSubagent -- a wake delivers no text,
+	// and a SendMessage does.
+	wake bool
+}
+
+// restarted reports whether ANY form proved a re-registration.
+func (e claudeRestartEvidence) restarted() bool { return e.sendMessage || e.wake }
+
+func (a *ClaudeCodeAgent) restartEvidenceFor(ev *claudeTaskEnvelope) claudeRestartEvidence {
+	return claudeRestartEvidence{
+		sendMessage: a.tasks.claudeRestartCall(ev.ToolUseID),
+		wake:        a.tasks.claudeWakeRestartedTask(ev),
 	}
 }
 
 // armClaudeRevive records one recipient id as revivable until the turn end of
 // the transcript that sent the message. armedBy is "" for the root and the
 // spawn span id for a subagent.
-func (a *ClaudeCodeAgent) armClaudeRevive(to, armedBy string) {
+//
+// A recipient carries the SET of transcripts that addressed it, not the last
+// one. Two senders can address one subagent inside a single root turn -- the
+// root and a live sibling -- and a single-valued arm let the second overwrite
+// the first's scope. The sibling's own result then ended its turn, dropped the
+// arm under ITS scope, and the root's send found nothing to fire: the row stayed
+// finished for the whole restarted run and the delivered text never reached the
+// transcript, which is the failure the arm exists to prevent.
+func (i *claudeTaskIndex) armClaudeRevive(to, armedBy string) {
 	if to == "" {
 		return
 	}
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	if a.pendingRevive == nil {
-		a.pendingRevive = make(map[string]string)
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.pendingRevive == nil {
+		i.pendingRevive = make(map[string]map[string]struct{})
 	}
-	a.pendingRevive[to] = armedBy
+	if i.pendingRevive[to] == nil {
+		i.pendingRevive[to] = make(map[string]struct{})
+	}
+	i.pendingRevive[to][armedBy] = struct{}{}
 }
 
 // takeClaudeRevive reports whether an in-flight SendMessage addressed taskID,
-// and consumes the arm so one send cannot revive the same row twice.
-func (a *ClaudeCodeAgent) takeClaudeRevive(taskID string) bool {
+// and consumes every arm on it so one restart cannot revive the same row twice.
+//
+// The whole set goes, not one scope: the arms are proof that a restart is
+// expected, and the CLI restarts the recipient ONCE however many senders queued
+// a message for it.
+func (i *claudeTaskIndex) takeClaudeRevive(taskID string) bool {
 	if taskID == "" {
 		return false
 	}
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	if _, ok := a.pendingRevive[taskID]; !ok {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if _, ok := i.pendingRevive[taskID]; !ok {
 		return false
 	}
-	delete(a.pendingRevive, taskID)
+	delete(i.pendingRevive, taskID)
 	return true
 }
 
@@ -926,10 +1172,25 @@ func (a *ClaudeCodeAgent) takeClaudeRevive(taskID string) bool {
 // live subagent's arm before its task_started could fire it, which left the
 // recipient's row finished and its transcript looking dead -- the exact bug the
 // revive exists to fix.
-func (a *ClaudeCodeAgent) clearClaudeRevives(armedBy string) {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	maps.DeleteFunc(a.pendingRevive, func(_, scope string) bool { return scope == armedBy })
+func (i *claudeTaskIndex) clearClaudeRevives(armedBy string) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	// One scope leaves each recipient's set, and the recipient goes only when its
+	// last sender does. A recipient two transcripts addressed stays armed until
+	// both of their turns end, so the earlier one cannot cancel the later one's
+	// restart.
+	for to, scopes := range i.pendingRevive {
+		delete(scopes, armedBy)
+		if len(scopes) == 0 {
+			delete(i.pendingRevive, to)
+		}
+	}
+	// The calls go with the arms. Both describe the same in-flight SendMessage
+	// tool calls and carry the same scope, so one boundary ends both -- and a
+	// call left standing would keep answering "restart" for an id whose turn
+	// ended, which suppresses the span close for a later genuine spawn. The
+	// tool_use id is unique per call, so this side needs no set.
+	maps.DeleteFunc(i.sendMessageCalls, func(_, scope string) bool { return scope == armedBy })
 }
 
 // recordPendingTaskEnd remembers a final status for a Task subagent whose
@@ -937,14 +1198,14 @@ func (a *ClaudeCodeAgent) clearClaudeRevives(armedBy string) {
 // task_started takes the entry and closes the row it opens, so the row cannot
 // leak Running. Keyed by the spawn tool_use id (the parent_tool_use_id every
 // forwarded envelope shares).
-func (a *ClaudeCodeAgent) recordPendingTaskEnd(spawnToolUseID string, status bgtask.Status) {
+func (i *claudeTaskIndex) recordPendingTaskEnd(spawnToolUseID string, status bgtask.Status) {
 	if spawnToolUseID == "" {
 		return
 	}
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	if a.pendingTaskEnd == nil {
-		a.pendingTaskEnd = make(map[string]bgtask.Status)
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.pendingTaskEnd == nil {
+		i.pendingTaskEnd = make(map[string]bgtask.Status)
 	}
-	a.pendingTaskEnd[spawnToolUseID] = status
+	i.pendingTaskEnd[spawnToolUseID] = status
 }

--- a/backend/internal/worker/agent/claude_subagent_test.go
+++ b/backend/internal/worker/agent/claude_subagent_test.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"errors"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,8 +13,8 @@ import (
 )
 
 // TestClaude_PendingTaskEndRecordsAndConsumes verifies the pending-end map
-// that closes a Task subagent row whose terminal RESULT arrived before its
-// task_started (a forward reorder). recordPendingTaskEnd stores the terminal
+// that closes a Task subagent row whose FINAL result arrived before its
+// task_started (a forward reorder). recordPendingTaskEnd stores the final
 // status keyed by the spawn tool_use id; handleClaudeTaskStarted consumes it
 // inline under a.mu. This test exercises the store+take mechanics directly so
 // the reorder close cannot silently regress to a leaked Running row.
@@ -20,7 +22,7 @@ func TestClaude_PendingTaskEndRecordsAndConsumes(t *testing.T) {
 	t.Parallel()
 	a := &ClaudeCodeAgent{}
 
-	// A terminal result for spawn span "tu-1" arrives before task_started.
+	// A final result for spawn span "tu-1" arrives before task_started.
 	a.recordPendingTaskEnd("tu-1", bgtask.StatusCompleted)
 	assert.Len(t, a.pendingTaskEnd, 1)
 	assert.Equal(t, bgtask.StatusCompleted, a.pendingTaskEnd["tu-1"])
@@ -300,7 +302,7 @@ func TestClaude_TaskUpdatedDoesNotChangeTheRow(t *testing.T) {
 
 // A task event for a row that no task_started opened creates nothing. The
 // registry is opened by the bookends alone, so a task_updated or a
-// background_tasks_changed that names an unknown task cannot invent a row.
+// background_tasks_changed that identifies an unknown task cannot invent a row.
 func TestClaude_TaskUpdatedForAnUnknownTaskCreatesNoRow(t *testing.T) {
 	t.Parallel()
 
@@ -781,4 +783,733 @@ func TestClaude_NestedSpawnOpensNoSpanInTheChildTranscript(t *testing.T) {
 		"the row's color comes from the first block, which is the nested spawn")
 	assert.Equal(t, ToolNameClaudeAgent, child.GetSpanType("tu-nested"),
 		"the nested spawn's type is still recorded for its tool_result")
+}
+
+// --- SendMessage revive ---
+//
+// Claude restarts a FINISHED subagent when the parent messages it, and says so by
+// emitting task_started again for the same task_id. The event alone cannot drive
+// the revive: a resumed session re-announces every task it once ran the same way,
+// with all of them finished. So the SendMessage tool_use arms a recipient and the
+// task_started fires it. These tests pin both halves and each impostor the pair
+// excludes.
+
+// spawnAndFinishSubagent replays a full first run -- spawn, one reply, final
+// notification -- and returns the child sink the subagent wrote into. Starting
+// from the real lifecycle rather than a seeded row is what makes the revive
+// assertions meaningful: the transcript already holds its closing divider's
+// registry state, and the row already carries the child linkage.
+func spawnAndFinishSubagent(t *testing.T, a *ClaudeCodeAgent, sink *testSink) *testSink {
+	t.Helper()
+	a.HandleOutput([]byte(`{
+		"type": "system",
+		"subtype": "task_started",
+		"task_id": "task-1",
+		"tool_use_id": "tu-spawn",
+		"task_type": "local_agent",
+		"description": "Explore the parser",
+		"prompt": "Find every caller."
+	}`))
+	a.HandleOutput([]byte(`{
+		"type": "assistant",
+		"parent_tool_use_id": "tu-spawn",
+		"message": {"content": [{"type": "text", "text": "Found three."}]}
+	}`))
+	a.HandleOutput([]byte(`{
+		"type": "system",
+		"subtype": "task_notification",
+		"task_id": "task-1",
+		"tool_use_id": "tu-spawn",
+		"status": "completed",
+		"summary": "done"
+	}`))
+	child, ok := sink.ChildSink("child-of-tu-spawn").(*testSink)
+	require.True(t, ok)
+	_, status, found, _ := sink.LookupBackgroundTask("task-1")
+	require.True(t, found, "the first run left a registry row")
+	require.True(t, status.IsFinished(), "the first run finished")
+	return child
+}
+
+// spanIDs flattens the recorded opens to their span ids.
+func spanIDs(opens []testSinkSpanOpen) []string {
+	ids := make([]string, 0, len(opens))
+	for _, o := range opens {
+		ids = append(ids, o.SpanID)
+	}
+	return ids
+}
+
+// sendMessageTo is the parent's SendMessage tool_use, which arms the revive.
+func sendMessageTo(a *ClaudeCodeAgent, toolUseID, recipient string) {
+	a.HandleOutput([]byte(`{
+		"type": "assistant",
+		"message": {"content": [{
+			"type": "tool_use",
+			"id": "` + toolUseID + `",
+			"name": "SendMessage",
+			"input": {"to": "` + recipient + `", "message": "keep going"}
+		}]}
+	}`))
+}
+
+// reviveTaskStarted is the event the CLI emits once the restart happened. Its
+// tool_use_id is the SENDMESSAGE call, not the original spawn -- the CLI
+// re-registers the task under the tool call that restarted it -- and its prompt
+// is the text the subagent actually received.
+func reviveTaskStarted(a *ClaudeCodeAgent, toolUseID, prompt string) {
+	a.HandleOutput([]byte(`{
+		"type": "system",
+		"subtype": "task_started",
+		"task_id": "task-1",
+		"tool_use_id": "` + toolUseID + `",
+		"task_type": "local_agent",
+		"description": "Explore the parser",
+		"prompt": "` + prompt + `"
+	}`))
+}
+
+func TestClaude_SendMessageRevivesAFinishedSubagent(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	child := spawnAndFinishSubagent(t, a, sink)
+	before := len(child.Messages())
+
+	sendMessageTo(a, "tu-send", "task-1")
+	reviveTaskStarted(a, "tu-send", "Also check the tests.")
+
+	assert.Equal(t, []string{"task-1"}, sink.RevivedTasks(),
+		"the armed task_started reopens the registry row")
+	_, status, ok, _ := sink.LookupBackgroundTask("task-1")
+	require.True(t, ok)
+	assert.Equal(t, bgtask.StatusRunning, status, "the row is active again")
+
+	msgs := child.Messages()
+	require.Len(t, msgs, before+1, "the delivered message is appended to the SAME transcript")
+	last := msgs[len(msgs)-1]
+	assert.Equal(t, leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, last.Source)
+	assert.JSONEq(t, `{"content":"Also check the tests."}`, string(last.Content),
+		"the text recorded is what task_started says the subagent received")
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_USER_MESSAGE, last.MarkType,
+		"a mid-transcript message carries a scroll-rail mark; the opening prompt does not")
+}
+
+// The revive's task_started identifies the SendMessage call, which still runs in
+// the parent transcript. Closing its span would free the rail mid-flight and
+// leave its own tool_result drawing a connector_end with nothing above it.
+func TestClaude_ReviveDoesNotCloseTheSendMessageSpan(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	spawnAndFinishSubagent(t, a, sink)
+
+	sendMessageTo(a, "tu-send", "task-1")
+	require.Contains(t, spanIDs(sink.OpenSpans()), "tu-send", "SendMessage owns an ordinary span")
+	reviveTaskStarted(a, "tu-send", "more work")
+
+	assert.NotContains(t, sink.ClosedSpans(), "tu-send",
+		"a re-registration's tool_use_id is not a spawn span")
+}
+
+// The narrowed CloseSpan must still fire for a genuine first spawn, which is the
+// case it was written for: the spawn owns no rail because its output goes to a
+// transcript of its own.
+func TestClaude_FirstTaskStartedStillClosesTheSpawnSpan(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	a.HandleOutput([]byte(`{
+		"type": "system",
+		"subtype": "task_started",
+		"task_id": "task-1",
+		"tool_use_id": "tu-spawn",
+		"task_type": "local_workflow",
+		"description": "a workflow run"
+	}`))
+
+	assert.Contains(t, sink.ClosedSpans(), "tu-spawn")
+}
+
+// The resumed-session hydration burst: task_started for a finished row, with no
+// SendMessage anywhere. Reviving here would resurrect every subagent the session
+// ever ran, each with no close ever arriving.
+func TestClaude_TaskStartedWithoutASendMessageDoesNotRevive(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	child := spawnAndFinishSubagent(t, a, sink)
+	before := len(child.Messages())
+
+	reviveTaskStarted(a, "tu-spawn", "(resumed agent)")
+
+	assert.Empty(t, sink.RevivedTasks(), "an unarmed re-registration is not a revive")
+	_, status, ok, _ := sink.LookupBackgroundTask("task-1")
+	require.True(t, ok)
+	assert.Equal(t, bgtask.StatusCompleted, status, "the row keeps its final status")
+	assert.Len(t, child.Messages(), before, "nothing is appended to the transcript")
+}
+
+// An arm lives for one turn. A revive's task_started lands inside the turn that
+// sent the message, so an arm still standing at the turn end addressed a live
+// subagent, a foreign recipient, or a send the CLI refused.
+func TestClaude_SendMessageArmExpiresAtTheTurnEnd(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	spawnAndFinishSubagent(t, a, sink)
+
+	sendMessageTo(a, "tu-send", "task-1")
+	a.HandleOutput([]byte(`{"type": "result", "subtype": "success", "result": "ok"}`))
+	reviveTaskStarted(a, "tu-send", "too late")
+
+	assert.Empty(t, sink.RevivedTasks(), "the arm did not survive the turn")
+	_, status, ok, _ := sink.LookupBackgroundTask("task-1")
+	require.True(t, ok)
+	assert.Equal(t, bgtask.StatusCompleted, status)
+}
+
+// `to` may be a display name, another session, or a uds:/bridge:/did: address.
+// None of those identifies a row of ours, so the arm never matches anything.
+func TestClaude_SendMessageToAnUnknownRecipientIsInert(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	child := spawnAndFinishSubagent(t, a, sink)
+	before := len(child.Messages())
+
+	sendMessageTo(a, "tu-send", "bridge:some-other-machine")
+	reviveTaskStarted(a, "tu-send", "not for us")
+
+	assert.Empty(t, sink.RevivedTasks())
+	assert.Len(t, child.Messages(), before)
+}
+
+// A SendMessage that addresses a task whose row is still RUNNING changes nothing:
+// the CLI queues the message for the live subagent and emits no task_started.
+func TestClaude_SendMessageToARunningSubagentDoesNotRevive(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	a.HandleOutput([]byte(`{
+		"type": "system",
+		"subtype": "task_started",
+		"task_id": "task-1",
+		"tool_use_id": "tu-spawn",
+		"task_type": "local_agent",
+		"prompt": "Find every caller."
+	}`))
+
+	sendMessageTo(a, "tu-send", "task-1")
+	reviveTaskStarted(a, "tu-send", "more work")
+
+	assert.Empty(t, sink.RevivedTasks(), "an active row has nothing to revive")
+	_, status, ok, _ := sink.LookupBackgroundTask("task-1")
+	require.True(t, ok)
+	assert.Equal(t, bgtask.StatusRunning, status)
+}
+
+// A subagent can message another agent. Its tool_use blocks arrive through the
+// child-transcript router, so the arm has to be recorded there too.
+func TestClaude_SendMessageFromAChildTranscriptArms(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	spawnAndFinishSubagent(t, a, sink)
+
+	// A DIFFERENT subagent sends the message, so the envelope is forwarded.
+	a.HandleOutput([]byte(`{
+		"type": "assistant",
+		"parent_tool_use_id": "tu-other-spawn",
+		"message": {"content": [{
+			"type": "tool_use",
+			"id": "tu-send",
+			"name": "SendMessage",
+			"input": {"to": "task-1", "message": "keep going"}
+		}]}
+	}`))
+	reviveTaskStarted(a, "tu-send", "from a sibling")
+
+	assert.Equal(t, []string{"task-1"}, sink.RevivedTasks(),
+		"a subagent's SendMessage arms the same revive the parent's does")
+}
+
+// sendMessageFromChild is a subagent's SendMessage, forwarded under its spawn
+// span. The arm it sets belongs to THAT transcript's turn, not to the root's.
+func sendMessageFromChild(a *ClaudeCodeAgent, spawnSpanID, toolUseID, recipient string) {
+	a.HandleOutput([]byte(`{
+		"type": "assistant",
+		"parent_tool_use_id": "` + spawnSpanID + `",
+		"message": {"content": [{
+			"type": "tool_use",
+			"id": "` + toolUseID + `",
+			"name": "SendMessage",
+			"input": {"to": "` + recipient + `", "message": "keep going"}
+		}]}
+	}`))
+}
+
+// A subagent outlives the root turn that spawned it. A backgrounded one that
+// messages a finished sibling AFTER the root's turn ended must keep its arm:
+// clearing every arm on the root's result dropped it before the task_started
+// could fire, which left the recipient finished and its transcript looking dead.
+func TestClaude_AChildArmSurvivesTheRootTurnEnd(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	spawnAndFinishSubagent(t, a, sink)
+
+	sendMessageFromChild(a, "tu-other-spawn", "tu-send", "task-1")
+	a.HandleOutput([]byte(`{"type": "result", "subtype": "success", "result": "ok"}`))
+	reviveTaskStarted(a, "tu-send", "from a sibling")
+
+	assert.Equal(t, []string{"task-1"}, sink.RevivedTasks(),
+		"the root's turn end drops only the root's own arms")
+}
+
+// The child's own forwarded result IS the boundary for the arms it set, so one
+// that never fired expires there rather than standing for the agent's life.
+func TestClaude_AChildArmExpiresAtTheChildTurnEnd(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	spawnAndFinishSubagent(t, a, sink)
+
+	sendMessageFromChild(a, "tu-other-spawn", "tu-send", "task-1")
+	a.HandleOutput([]byte(`{
+		"type": "result",
+		"parent_tool_use_id": "tu-other-spawn",
+		"subtype": "success",
+		"result": "ok"
+	}`))
+	reviveTaskStarted(a, "tu-send", "too late")
+
+	assert.Empty(t, sink.RevivedTasks(), "the arm did not survive the sending transcript's turn")
+}
+
+// A child's turn end must not take the ROOT's arms with it. The two scopes are
+// distinct keys, and a subagent finishing mid-turn is the common case.
+func TestClaude_AChildTurnEndKeepsTheRootArms(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	spawnAndFinishSubagent(t, a, sink)
+
+	sendMessageTo(a, "tu-send", "task-1")
+	a.HandleOutput([]byte(`{
+		"type": "result",
+		"parent_tool_use_id": "tu-other-spawn",
+		"subtype": "success",
+		"result": "ok"
+	}`))
+	reviveTaskStarted(a, "tu-send", "still armed")
+
+	assert.Equal(t, []string{"task-1"}, sink.RevivedTasks(),
+		"a subagent's turn end leaves the root's arms alone")
+}
+
+// Output forwarded AFTER the revive must land in the transcript the subagent
+// already owns. The registry row key resolves it, so it does not matter whether
+// the CLI tags the forwarded envelope with the original spawn span or with the
+// tool_use id it re-registered under.
+func TestClaude_RevivedSubagentOutputStaysInOneTranscript(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name            string
+		parentToolUseID string
+	}{
+		{"original spawn span", "tu-spawn"},
+		{"the re-registered tool_use id", "tu-send"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			sink := &testSink{}
+			a := newTestAgent(sink)
+			child := spawnAndFinishSubagent(t, a, sink)
+			before := len(child.Messages())
+
+			sendMessageTo(a, "tu-send", "task-1")
+			reviveTaskStarted(a, "tu-send", "Also check the tests.")
+			a.HandleOutput([]byte(`{
+				"type": "assistant",
+				"parent_tool_use_id": "` + tc.parentToolUseID + `",
+				"message": {"content": [{"type": "text", "text": "Checked them."}]}
+			}`))
+
+			msgs := child.Messages()
+			require.Len(t, msgs, before+2, "the revive message and the new reply both land here")
+			assert.Contains(t, string(msgs[len(msgs)-1].Content), "Checked them.")
+		})
+	}
+}
+
+// A revive with no prompt still reopens the row. The subagent runs again, so its
+// thinking indicator is owed even when there is no text to show.
+func TestClaude_ReviveWithoutAPromptStillReopensTheRow(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	child := spawnAndFinishSubagent(t, a, sink)
+	before := len(child.Messages())
+
+	sendMessageTo(a, "tu-send", "task-1")
+	reviveTaskStarted(a, "tu-send", "   ")
+
+	assert.Equal(t, []string{"task-1"}, sink.RevivedTasks())
+	assert.Len(t, child.Messages(), before, "a blank prompt persists no bubble")
+}
+
+// One SendMessage arms one revive. A second task_started for the same task must
+// not reopen a row that closed again in between.
+func TestClaude_OneSendMessageArmsOneRevive(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	spawnAndFinishSubagent(t, a, sink)
+
+	sendMessageTo(a, "tu-send", "task-1")
+	reviveTaskStarted(a, "tu-send", "first")
+	a.HandleOutput([]byte(`{
+		"type": "system",
+		"subtype": "task_notification",
+		"task_id": "task-1",
+		"tool_use_id": "tu-send",
+		"status": "completed"
+	}`))
+	reviveTaskStarted(a, "tu-send", "second")
+
+	assert.Equal(t, []string{"task-1"}, sink.RevivedTasks(), "the arm was consumed by the first")
+}
+
+// One assistant message can carry parallel tool calls, so a turn that messages
+// two finished subagents at once must arm both.
+func TestClaude_SendMessageArmsEveryRecipientInOneMessage(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	for _, spawn := range []string{"tu-spawn-a", "tu-spawn-b"} {
+		a.HandleOutput([]byte(`{
+			"type": "system", "subtype": "task_started",
+			"task_id": "task-` + spawn + `", "tool_use_id": "` + spawn + `",
+			"task_type": "local_agent", "prompt": "go"
+		}`))
+		a.HandleOutput([]byte(`{
+			"type": "system", "subtype": "task_notification",
+			"task_id": "task-` + spawn + `", "status": "completed"
+		}`))
+	}
+
+	a.HandleOutput([]byte(`{
+		"type": "assistant",
+		"message": {"content": [
+			{"type": "tool_use", "id": "tu-send-a", "name": "SendMessage",
+			 "input": {"to": "task-tu-spawn-a", "message": "one"}},
+			{"type": "tool_use", "id": "tu-send-b", "name": "SendMessage",
+			 "input": {"to": "task-tu-spawn-b", "message": "two"}}
+		]}
+	}`))
+	for _, spawn := range []string{"tu-spawn-a", "tu-spawn-b"} {
+		a.HandleOutput([]byte(`{
+			"type": "system", "subtype": "task_started",
+			"task_id": "task-` + spawn + `", "tool_use_id": "tu-send-` + spawn + `",
+			"task_type": "local_agent", "prompt": "more"
+		}`))
+	}
+
+	assert.ElementsMatch(t, []string{"task-tu-spawn-a", "task-tu-spawn-b"}, sink.RevivedTasks(),
+		"a parallel pair of sends arms a revive for each recipient")
+}
+
+// A SendMessage whose input this code cannot read must not stop the turn or arm
+// anything. `to` is absent for a malformed call and non-string for a structured
+// one the schema allows to vary.
+func TestClaude_SendMessageWithUnreadableInputArmsNothing(t *testing.T) {
+	t.Parallel()
+
+	for _, input := range []string{
+		`{"message": "no recipient"}`,
+		`{"to": {"nested": "object"}, "message": "wrong type"}`,
+		`"not an object at all"`,
+		`{"to": "", "message": "blank recipient"}`,
+	} {
+		sink := &testSink{}
+		a := newTestAgent(sink)
+		spawnAndFinishSubagent(t, a, sink)
+
+		a.HandleOutput([]byte(`{
+			"type": "assistant",
+			"message": {"content": [{
+				"type": "tool_use", "id": "tu-send", "name": "SendMessage",
+				"input": ` + input + `
+			}]}
+		}`))
+		reviveTaskStarted(a, "tu-send", "should not land")
+
+		assert.Empty(t, sink.RevivedTasks(), "input %s must arm nothing", input)
+	}
+}
+
+// An unreadable registry is a THIRD answer, not a miss. Folding it into
+// "no such row" made the first registry read of a process -- exactly what a
+// worker restart leaves for a revive's task_started -- close the still-running
+// SendMessage span and treat a finished subagent as brand new.
+func TestClaude_AnUnreadableRegistryDoesNotFreeTheSendMessageSpan(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{lookupErr: errors.New("database is locked")}
+	a := newTestAgent(sink)
+
+	sendMessageTo(a, "tu-send", "task-1")
+	require.Contains(t, spanIDs(sink.OpenSpans()), "tu-send")
+	reviveTaskStarted(a, "tu-send", "more work")
+
+	assert.NotContains(t, sink.ClosedSpans(), "tu-send",
+		"a registry it could not read cannot prove this is a spawn")
+}
+
+// A revive whose registry row was cap-evicted has no linkage, and the event's
+// tool_use id is the SendMessage call. Handing that to EnsureChildAgent created
+// a SECOND child agent keyed by a non-spawn span and re-pointed the durable row
+// at the orphan, leaving the subagent's real transcript unreachable.
+func TestClaude_ReviveWithNoRegistryRowOpensNoSecondTranscript(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	child := spawnAndFinishSubagent(t, a, sink)
+	before := len(child.Messages())
+	// The row is gone, as cap-eviction or a cold seed window leaves it.
+	sink.ForgetBackgroundTask("task-1")
+
+	sendMessageTo(a, "tu-send", "task-1")
+	reviveTaskStarted(a, "tu-send", "Also check the tests.")
+
+	assert.NotContains(t, sink.ChildAgentIDs(), "child-of-tu-send",
+		"a SendMessage id must never open a transcript")
+	assert.Len(t, child.Messages(), before, "nothing is written before a transcript resolves")
+
+	// The subagent's own output resolves its real transcript, and the held
+	// message lands above the reply it asked for.
+	a.HandleOutput([]byte(`{
+		"type": "assistant",
+		"parent_tool_use_id": "tu-spawn",
+		"message": {"content": [{"type": "text", "text": "Checked them."}]}
+	}`))
+
+	msgs := child.Messages()
+	require.Len(t, msgs, before+2, "the held message and the reply both land here")
+	assert.JSONEq(t, `{"content":"Also check the tests."}`, string(msgs[before].Content))
+	assert.Contains(t, string(msgs[before+1].Content), "Checked them.")
+}
+
+// One send, one delivery: a held message is written once and not replayed into
+// every later envelope.
+func TestClaude_AHeldChildMessageIsWrittenOnce(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	child := spawnAndFinishSubagent(t, a, sink)
+	before := len(child.Messages())
+	sink.ForgetBackgroundTask("task-1")
+
+	sendMessageTo(a, "tu-send", "task-1")
+	reviveTaskStarted(a, "tu-send", "Also check the tests.")
+	for range 2 {
+		a.HandleOutput([]byte(`{
+			"type": "assistant",
+			"parent_tool_use_id": "tu-spawn",
+			"message": {"content": [{"type": "text", "text": "Working."}]}
+		}`))
+	}
+
+	held := 0
+	for _, m := range child.Messages()[before:] {
+		if string(m.Content) == `{"content":"Also check the tests."}` {
+			held++
+		}
+	}
+	assert.Equal(t, 1, held, "the held message is consumed by the first envelope that resolves a child")
+}
+
+// The CLI may stamp a revived run's forwarded result with the ORIGINAL spawn
+// span. The first completion dropped that span from the tool_use index, and the
+// revive re-registered the task under the SendMessage call -- so without a
+// child-keyed fallback the result names no row and the row the revive just
+// reopened stays Running for the agent's life.
+func TestClaude_ARevivedResultUnderTheSpawnSpanClosesTheRow(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	spawnAndFinishSubagent(t, a, sink)
+
+	sendMessageTo(a, "tu-send", "task-1")
+	reviveTaskStarted(a, "tu-send", "Also check the tests.")
+	_, status, ok, _ := sink.LookupBackgroundTask("task-1")
+	require.True(t, ok)
+	require.Equal(t, bgtask.StatusRunning, status, "the revive reopened the row")
+
+	a.HandleOutput([]byte(`{
+		"type": "result",
+		"parent_tool_use_id": "tu-spawn",
+		"subtype": "success"
+	}`))
+
+	_, status, ok, _ = sink.LookupBackgroundTask("task-1")
+	require.True(t, ok)
+	assert.Equal(t, bgtask.StatusCompleted, status,
+		"the revived run's result closes the row it reopened")
+}
+
+// --- Wake revive ---
+//
+// A SendMessage is not the CLI's only restart. Captured against 2.1.233: when a
+// subagent's own backgrounded shell finishes, the CLI re-registers that finished
+// subagent with a <task-notification> block as the prompt and NO tool_use_id,
+// and the subagent runs again. The row must reopen, and the block must NOT
+// appear in the transcript -- it is harness plumbing addressed to the model.
+
+// wakePrompt is the block the CLI hands a subagent when its shell completes.
+func wakePrompt(shellTaskID string) string {
+	return "<task-notification>\n<task-id>" + shellTaskID + "</task-id>\n" +
+		"<tool-use-id>tu-bash</tool-use-id>\n<status>completed</status>\n</task-notification>"
+}
+
+// finishShellTask replays a backgrounded shell of the subagent, start to finish,
+// so this process has seen the id the wake block names.
+func finishShellTask(a *ClaudeCodeAgent, shellTaskID string) {
+	a.HandleOutput([]byte(`{
+		"type": "system", "subtype": "task_started",
+		"task_id": "` + shellTaskID + `", "tool_use_id": "tu-bash", "task_type": "local_bash"
+	}`))
+	a.HandleOutput([]byte(`{
+		"type": "system", "subtype": "task_notification",
+		"task_id": "` + shellTaskID + `", "tool_use_id": "tu-bash", "status": "completed"
+	}`))
+}
+
+func TestClaude_AShellWakeRevivesTheSubagentWithoutAMessage(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	child := spawnAndFinishSubagent(t, a, sink)
+	before := len(child.Messages())
+	finishShellTask(a, "shell-1")
+
+	// The wake carries no tool_use_id at all, which is the shape the CLI emits.
+	a.HandleOutput([]byte(`{
+		"type": "system", "subtype": "task_started",
+		"task_id": "task-1", "task_type": "local_agent",
+		"prompt": ` + strconv.Quote(wakePrompt("shell-1")) + `
+	}`))
+
+	assert.Equal(t, []string{"task-1"}, sink.RevivedTasks(), "the woken subagent's row reopens")
+	assert.Len(t, child.Messages(), before,
+		"a wake block is harness plumbing, not a message the user asked for")
+}
+
+// The case the discriminator exists to exclude. A resumed session re-announces
+// every task it once ran, replaying prompts from a PREVIOUS process -- so the
+// shell a replayed wake names is one this process never finished.
+func TestClaude_AWakeNamingAnUnseenShellDoesNotRevive(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	spawnAndFinishSubagent(t, a, sink)
+
+	a.HandleOutput([]byte(`{
+		"type": "system", "subtype": "task_started",
+		"task_id": "task-1", "task_type": "local_agent",
+		"prompt": ` + strconv.Quote(wakePrompt("shell-from-a-previous-process")) + `
+	}`))
+
+	assert.Empty(t, sink.RevivedTasks(), "a wake this process cannot corroborate is not proof")
+	_, status, ok, _ := sink.LookupBackgroundTask("task-1")
+	require.True(t, ok)
+	assert.Equal(t, bgtask.StatusCompleted, status)
+}
+
+// The tag must OPEN the first line or CLOSE the last one, so an ordinary spawn
+// prompt that merely discusses it is not mistaken for a wake.
+func TestClaude_WakeTaskIDRequiresTheTagAtAnEdge(t *testing.T) {
+	t.Parallel()
+
+	id, ok := claudeWakeTaskID(wakePrompt("shell-9"))
+	assert.True(t, ok)
+	assert.Equal(t, "shell-9", id)
+
+	// Closing tag on the last line, with prose above it.
+	_, ok = claudeWakeTaskID("Some preamble\n<task-id>shell-9</task-id>\n</task-notification>")
+	assert.True(t, ok, "a closing tag on the last line is the other edge")
+
+	for _, prompt := range []string{
+		"Explain how <task-notification> blocks work.\nThe <task-id>shell-9</task-id> names the shell.\nThanks.",
+		"",
+		"<task-notification>",
+		"<task-notification>\n<status>completed</status>\n</task-notification>",
+	} {
+		_, ok := claudeWakeTaskID(prompt)
+		assert.False(t, ok, "prompt %q must not read as a wake", prompt)
+	}
+}
+
+// A revive resolves the transcript from the REGISTRY ROW, never from the event's
+// tool_use id. On a re-registration that id is the SendMessage call, so handing
+// it to EnsureChildAgent walks past the row-key fast path, fails the
+// spawn-span lookup, and creates a SECOND transcript keyed by the wrong span --
+// then re-links the row to that orphan.
+func TestClaude_ReviveResolvesTheChildFromTheRegistryRow(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	child := spawnAndFinishSubagent(t, a, sink)
+	before := len(child.Messages())
+
+	sendMessageTo(a, "tu-send", "task-1")
+	reviveTaskStarted(a, "tu-send", "Also check the tests.")
+
+	assert.NotContains(t, sink.ChildAgentIDs(), "child-of-tu-send",
+		"the SendMessage id must not open a transcript of its own")
+	require.Len(t, child.Messages(), before+1, "the message lands in the transcript the ROW points at")
+}
+
+// The registry write is the half that can fail after the arm is spent. The
+// delivered message must still reach the transcript, and the arm must come back
+// -- the fallback path cannot record it, because PersistChildPrompt says nothing
+// once a transcript has messages.
+func TestClaude_AFailedReviveKeepsTheMessageAndRearms(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{reviveErr: errors.New("database is locked")}
+	a := newTestAgent(sink)
+	child := spawnAndFinishSubagent(t, a, sink)
+	before := len(child.Messages())
+
+	sendMessageTo(a, "tu-send", "task-1")
+	reviveTaskStarted(a, "tu-send", "Also check the tests.")
+
+	msgs := child.Messages()
+	require.Len(t, msgs, before+1, "the delivered message is recorded although the row write failed")
+	assert.JSONEq(t, `{"content":"Also check the tests."}`, string(msgs[len(msgs)-1].Content))
+	assert.True(t, a.takeClaudeRevive("task-1"), "the arm is back, so a later task_started can retry")
 }

--- a/backend/internal/worker/agent/claude_subagent_test.go
+++ b/backend/internal/worker/agent/claude_subagent_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"errors"
+	"slices"
 	"strconv"
 	"testing"
 
@@ -23,22 +24,22 @@ func TestClaude_PendingTaskEndRecordsAndConsumes(t *testing.T) {
 	a := &ClaudeCodeAgent{}
 
 	// A final result for spawn span "tu-1" arrives before task_started.
-	a.recordPendingTaskEnd("tu-1", bgtask.StatusCompleted)
-	assert.Len(t, a.pendingTaskEnd, 1)
-	assert.Equal(t, bgtask.StatusCompleted, a.pendingTaskEnd["tu-1"])
+	a.tasks.recordPendingTaskEnd("tu-1", bgtask.StatusCompleted)
+	assert.Len(t, a.tasks.pendingTaskEnd, 1)
+	assert.Equal(t, bgtask.StatusCompleted, a.tasks.pendingTaskEnd["tu-1"])
 
 	// handleClaudeTaskStarted takes the entry inline. Simulate the take.
 	a.mu.Lock()
 	var got bgtask.Status
 	var ok bool
-	if s, present := a.pendingTaskEnd["tu-1"]; present {
+	if s, present := a.tasks.pendingTaskEnd["tu-1"]; present {
 		got, ok = s, true
-		delete(a.pendingTaskEnd, "tu-1")
+		delete(a.tasks.pendingTaskEnd, "tu-1")
 	}
 	a.mu.Unlock()
 	assert.True(t, ok, "pending end taken on the late task_started")
 	assert.Equal(t, bgtask.StatusCompleted, got)
-	assert.Empty(t, a.pendingTaskEnd, "entry consumed so it cannot fire twice")
+	assert.Empty(t, a.tasks.pendingTaskEnd, "entry consumed so it cannot fire twice")
 }
 
 // TestClaude_PendingTaskEndIgnoresEmptySpan verifies a result with no
@@ -47,8 +48,8 @@ func TestClaude_PendingTaskEndRecordsAndConsumes(t *testing.T) {
 func TestClaude_PendingTaskEndIgnoresEmptySpan(t *testing.T) {
 	t.Parallel()
 	a := &ClaudeCodeAgent{}
-	a.recordPendingTaskEnd("", bgtask.StatusCompleted)
-	assert.Nil(t, a.pendingTaskEnd, "no entry recorded for an empty spawn span")
+	a.tasks.recordPendingTaskEnd("", bgtask.StatusCompleted)
+	assert.Nil(t, a.tasks.pendingTaskEnd, "no entry recorded for an empty spawn span")
 }
 
 // A subagent tab must open on the instruction the subagent was given, not on
@@ -1285,7 +1286,7 @@ func TestClaude_AnUnreadableRegistryDoesNotFreeTheSendMessageSpan(t *testing.T) 
 		"nor can it prove the id is a spawn span worth opening a transcript from")
 }
 
-// A row that names no transcript is the one state left in which a revive cannot
+// A row that identifies no transcript is the one state left in which a revive cannot
 // resolve its child, and only a failed registry write produces it: cap eviction
 // does not, because a linked row survives the display cap in the store. The
 // event's tool_use id is the SendMessage call, so handing it to EnsureChildAgent
@@ -1337,13 +1338,13 @@ func TestClaude_ATaskStartedThatResolvesNoChildKeepsTheArm(t *testing.T) {
 	reviveTaskStarted(a, "tu-send", "Also check the tests.")
 
 	assert.Empty(t, sink.RevivedTasks(), "no transcript resolved, so no revive happened")
-	assert.True(t, a.takeClaudeRevive("task-1"), "the arm is still standing for a retry")
+	assert.True(t, a.tasks.takeClaudeRevive("task-1"), "the arm is still standing for a retry")
 }
 
 // The CLI may stamp a revived run's forwarded result with the ORIGINAL spawn
 // span. The first completion dropped that span from the tool_use index, and the
 // revive re-registered the task under the SendMessage call -- so without a
-// child-keyed fallback the result names no row and the row the revive just
+// child-keyed fallback the result identifies no row and the row the revive just
 // reopened stays Running for the agent's life.
 func TestClaude_ARevivedResultUnderTheSpawnSpanClosesTheRow(t *testing.T) {
 	t.Parallel()
@@ -1385,7 +1386,7 @@ func wakePrompt(shellTaskID string) string {
 }
 
 // finishShellTask replays a backgrounded shell of the subagent, start to finish,
-// so this process has seen the id the wake block names.
+// so this process saw the id the wake block identifies.
 func finishShellTask(a *ClaudeCodeAgent, shellTaskID string) {
 	a.HandleOutput([]byte(`{
 		"type": "system", "subtype": "task_started",
@@ -1420,7 +1421,7 @@ func TestClaude_AShellWakeRevivesTheSubagentWithoutAMessage(t *testing.T) {
 
 // The case the discriminator exists to exclude. A resumed session re-announces
 // every task it once ran, replaying prompts from a PREVIOUS process -- so the
-// shell a replayed wake names is one this process never finished.
+// shell a replayed wake identifies is one this process never finished.
 func TestClaude_AWakeNamingAnUnseenShellDoesNotRevive(t *testing.T) {
 	t.Parallel()
 
@@ -1440,28 +1441,62 @@ func TestClaude_AWakeNamingAnUnseenShellDoesNotRevive(t *testing.T) {
 	assert.Equal(t, bgtask.StatusCompleted, status)
 }
 
-// The tag must OPEN the first line or CLOSE the last one, so an ordinary spawn
-// prompt that merely discusses it is not mistaken for a wake.
-func TestClaude_WakeTaskIDRequiresTheTagAtAnEdge(t *testing.T) {
+// The parse takes the id wherever the block puts it, and asks only for both
+// tags. The safety is NOT here -- claudeWakeRestartedTask corroborates the id
+// against the shells THIS process finished, and reviveClaudeSubagent acts only
+// on a row already in a finished status. So the parse errs toward reading a
+// wake, because missing one restores the whole bug the revive exists to fix.
+func TestClaude_WakeTaskIDReadsTheBlockWhateverItsShape(t *testing.T) {
 	t.Parallel()
 
-	id, ok := claudeWakeTaskID(wakePrompt("shell-9"))
-	assert.True(t, ok)
-	assert.Equal(t, "shell-9", id)
+	for name, prompt := range map[string]string{
+		"multi-line":         wakePrompt("shell-9"),
+		"one line":           "<task-notification><task-id>shell-9</task-id><status>completed</status></task-notification>",
+		"id beside siblings": "<task-notification>\n<tool-use-id>tu</tool-use-id><task-id>shell-9</task-id>\n</task-notification>",
+		"trailing prose":     "<task-notification>\n<task-id>shell-9</task-id>\n</task-notification>\nReport when done.",
+		"padded id":          "<task-notification>\n<task-id> shell-9 </task-id>\n</task-notification>",
+	} {
+		id, ok := claudeWakeTaskID(prompt)
+		assert.True(t, ok, "%s must read as a wake", name)
+		assert.Equal(t, "shell-9", id, "%s", name)
+	}
 
-	// Closing tag on the last line, with prose above it.
-	_, ok = claudeWakeTaskID("Some preamble\n<task-id>shell-9</task-id>\n</task-notification>")
-	assert.True(t, ok, "a closing tag on the last line is the other edge")
-
-	for _, prompt := range []string{
-		"Explain how <task-notification> blocks work.\nThe <task-id>shell-9</task-id> names the shell.\nThanks.",
-		"",
-		"<task-notification>",
-		"<task-notification>\n<status>completed</status>\n</task-notification>",
+	for name, prompt := range map[string]string{
+		"empty":              "",
+		"open tag only":      "Explain how <task-notification> blocks work.\nThe <task-id>shell-9</task-id> is the shell.",
+		"close tag only":     "Some preamble\n<task-id>shell-9</task-id>\n</task-notification>",
+		"unopened id":        "<task-notification>\n<status>completed</status>\n</task-notification>",
+		"empty id":           "<task-notification>\n<task-id></task-id>\n</task-notification>",
+		"whitespace-only id": "<task-notification>\n<task-id>   </task-id>\n</task-notification>",
 	} {
 		_, ok := claudeWakeTaskID(prompt)
-		assert.False(t, ok, "prompt %q must not read as a wake", prompt)
+		assert.False(t, ok, "%s must not read as a wake", name)
 	}
+}
+
+// The shape the edge-anchored parse dropped: the CLI emits the whole block on
+// ONE line. Nothing about that makes it less of a restart, and refusing it left
+// the row reading "finished" for the entire second run, with no closing divider
+// -- exactly the state the revive exists to repair.
+func TestClaude_AOneLineWakeBlockRevivesTheRow(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	spawnAndFinishSubagent(t, a, sink)
+	finishShellTask(a, "shell-7")
+
+	a.HandleOutput([]byte(`{
+		"type": "system", "subtype": "task_started",
+		"task_id": "task-1", "task_type": "local_agent",
+		"prompt": ` + strconv.Quote("<task-notification><task-id>shell-7</task-id><status>completed</status></task-notification>") + `
+	}`))
+
+	assert.Equal(t, []string{"task-1"}, sink.RevivedTasks(),
+		"a wake block on one line restarts the subagent like any other")
+	_, status, ok, _ := sink.LookupBackgroundTask("task-1")
+	require.True(t, ok)
+	assert.Equal(t, bgtask.StatusRunning, status)
 }
 
 // A revive resolves the transcript from the REGISTRY ROW, never from the event's
@@ -1503,5 +1538,186 @@ func TestClaude_AFailedReviveKeepsTheMessageAndRearms(t *testing.T) {
 	msgs := child.Messages()
 	require.Len(t, msgs, before+1, "the delivered message is recorded although the row write failed")
 	assert.JSONEq(t, `{"content":"Also check the tests."}`, string(msgs[len(msgs)-1].Content))
-	assert.True(t, a.takeClaudeRevive("task-1"), "the arm is back, so a later task_started can retry")
+	assert.True(t, a.tasks.takeClaudeRevive("task-1"), "the arm is back, so a later task_started can retry")
+}
+
+// A subagent can message a finished SIBLING, and that send must be recognized as
+// a restart at both guards in handleClaudeTaskStarted. It records its span type
+// on the CHILD sink's tracker, so the ROOT's tracker -- the one this handler
+// reads -- answered "" for it, which is exactly what a spawn answers there. The
+// unlinked row is what makes the mistake visible: the SendMessage id reaches
+// EnsureChildAgent and opens a SECOND transcript, and the durable row is
+// re-pointed at the orphan while the subagent's real messages keep arriving
+// under the original spawn span.
+func TestClaude_ASiblingSendOpensNoSecondTranscript(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	spawnAndFinishSubagent(t, a, sink)
+	// The sender: a second, still-running subagent of the same root.
+	a.HandleOutput([]byte(`{
+		"type": "system", "subtype": "task_started",
+		"task_id": "task-2", "tool_use_id": "tu-spawn-2", "task_type": "local_agent",
+		"description": "Sibling", "prompt": "Coordinate."
+	}`))
+	sink.UnlinkBackgroundTask("task-1")
+
+	sendMessageFromChild(a, "tu-spawn-2", "tu-send", "task-1")
+	reviveTaskStarted(a, "tu-send", "keep going")
+
+	assert.NotContains(t, sink.ChildAgentIDs(), "child-of-tu-send",
+		"a sibling's SendMessage id must never reach EnsureChildAgent")
+}
+
+// The other half of the same blindness: the span close. A sibling's SendMessage
+// call is still running in that sibling's transcript, so freeing its rail on the
+// task_started it produced would leave its own tool_result drawing a connector
+// end with no line above it to meet.
+func TestClaude_ASiblingSendKeepsItsSpanOpen(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	spawnAndFinishSubagent(t, a, sink)
+	a.HandleOutput([]byte(`{
+		"type": "system", "subtype": "task_started",
+		"task_id": "task-2", "tool_use_id": "tu-spawn-2", "task_type": "local_agent",
+		"description": "Sibling", "prompt": "Coordinate."
+	}`))
+
+	sendMessageFromChild(a, "tu-spawn-2", "tu-send", "task-1")
+	reviveTaskStarted(a, "tu-send", "keep going")
+
+	assert.NotContains(t, sink.ClosedSpans(), "tu-send",
+		"the restart call still runs in the sibling's transcript")
+}
+
+// Two transcripts can address ONE recipient inside a single root turn. A
+// single-valued arm let the second sender overwrite the first's scope, so
+// whichever turn ended first dropped an arm the other still needed -- and the
+// row stayed finished for the whole restarted run with the delivered text never
+// written.
+func TestClaude_ASecondSenderDoesNotCancelTheFirstsArm(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	spawnAndFinishSubagent(t, a, sink)
+	a.HandleOutput([]byte(`{
+		"type": "system", "subtype": "task_started",
+		"task_id": "task-2", "tool_use_id": "tu-spawn-2", "task_type": "local_agent",
+		"description": "Sibling", "prompt": "Coordinate."
+	}`))
+
+	// The root arms first, then a live sibling arms the SAME recipient.
+	sendMessageTo(a, "tu-send-root", "task-1")
+	sendMessageFromChild(a, "tu-spawn-2", "tu-send-child", "task-1")
+	// The sibling's turn ends, which drops only the arms IT set.
+	a.HandleOutput([]byte(`{
+		"type": "result", "parent_tool_use_id": "tu-spawn-2", "subtype": "success"
+	}`))
+
+	reviveTaskStarted(a, "tu-send-root", "keep going")
+
+	assert.Equal(t, []string{"task-1"}, sink.RevivedTasks(),
+		"the root's arm survives the sibling's turn end")
+}
+
+// The wake proof is about a backgrounded SHELL. Recording every finished task
+// let a SUBAGENT's own id satisfy it -- and a resumed session replays that
+// subagent's own wake prompt verbatim, so the hydration burst, the one impostor
+// the discriminator exists to exclude, walked straight through it and reopened a
+// row with nothing left to close it.
+func TestClaude_AWakeNamingASubagentIsNotProof(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	spawnAndFinishSubagent(t, a, sink)
+
+	// task-1 is a finished SUBAGENT, not a shell. A replayed prompt that carries
+	// its id must not read as a wake.
+	a.HandleOutput([]byte(`{
+		"type": "system", "subtype": "task_started",
+		"task_id": "task-1", "task_type": "local_agent",
+		"prompt": ` + strconv.Quote(wakePrompt("task-1")) + `
+	}`))
+
+	assert.Empty(t, sink.RevivedTasks(), "only a finished shell corroborates a wake")
+	_, status, ok, _ := sink.LookupBackgroundTask("task-1")
+	require.True(t, ok)
+	assert.Equal(t, bgtask.StatusCompleted, status)
+}
+
+// A registry the process could not READ is not evidence of a re-registration.
+// Suppressing the prompt-derived title whenever the read failed had the
+// asymmetry backwards: a read fails most often on the first registry touch of a
+// process, where a FIRST start is the overwhelmingly common event -- and the row
+// then took a blank title that nothing rewrites, while EnsureChildAgent, given
+// the same blank, took the tab name from the pool instead of from the prompt.
+func TestClaude_AnUnreadableRegistryKeepsThePromptTitleForAFirstStart(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{lookupErr: errors.New("database is locked")}
+	a := newTestAgent(sink)
+
+	a.HandleOutput([]byte(`{
+		"type": "system", "subtype": "task_started",
+		"task_id": "task-1", "tool_use_id": "tu-spawn", "task_type": "local_agent",
+		"prompt": "Find every caller of parseHeader."
+	}`))
+
+	_, _, _, lookupErr := sink.LookupBackgroundTask("task-1")
+	require.Error(t, lookupErr, "the fake reports the registry as unreadable")
+	rows := sink.BackgroundTasks()
+	idx := slices.IndexFunc(rows, func(i bgtask.Item) bool { return i.RowKey == "task-1" })
+	require.GreaterOrEqual(t, idx, 0, "the row is still created")
+	assert.Equal(t, "Find every caller of parseHeader.", rows[idx].Title,
+		"a first start still takes its title from the prompt")
+}
+
+// A wake block is harness plumbing addressed to the model, never a row title.
+// An unreadable registry cannot answer "does this row exist", so `known.exists`
+// is false there -- and while only the SendMessage half of the restart evidence
+// reached this guard, the prompt-derived fallback renamed the row to the wake
+// block itself, leaving a literal <task-notification> in the sidebar.
+func TestClaude_AWakeBlockNeverBecomesTheRowTitle(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{lookupErr: errors.New("database is locked")}
+	a := newTestAgent(sink)
+	finishShellTask(a, "shell-7")
+
+	a.HandleOutput([]byte(`{
+		"type": "system", "subtype": "task_started",
+		"task_id": "task-1", "task_type": "local_agent",
+		"prompt": ` + strconv.Quote(wakePrompt("shell-7")) + `
+	}`))
+
+	rows := sink.BackgroundTasks()
+	idx := slices.IndexFunc(rows, func(i bgtask.Item) bool { return i.RowKey == "task-1" })
+	require.GreaterOrEqual(t, idx, 0, "the event still upserts a row")
+	assert.Empty(t, rows[idx].Title, "a wake block must not become the row title")
+}
+
+// A task_started with NO tool_use_id still records what the task IS. The wake
+// form of a restart carries none, and the kind is what a later
+// task_notification reads to avoid rewriting a subagent's row into a shell one.
+// The tool_use pair is skipped rather than written under an empty key.
+func TestClaude_StartTaskWithoutAToolUseIDStillRecordsTheKind(t *testing.T) {
+	t.Parallel()
+
+	var idx claudeTaskIndex
+
+	pending, hasPending := idx.startTask("task-1", "", bgtask.KindSubagent)
+	assert.False(t, hasPending, "no spawn span means no pending close to take")
+	assert.Equal(t, bgtask.StatusPending, pending)
+	assert.Equal(t, bgtask.KindSubagent, idx.kindForTask("task-1"))
+	assert.Empty(t, idx.taskIDForToolUse(""), "no pair is written under an empty key")
+
+	// And with a spawn span the pair IS written, both ways.
+	idx.startTask("task-2", "tu-2", bgtask.KindShell)
+	assert.Equal(t, "task-2", idx.taskIDForToolUse("tu-2"))
+	assert.Equal(t, bgtask.KindShell, idx.kindForTask("task-2"))
 }

--- a/backend/internal/worker/agent/claude_subagent_test.go
+++ b/backend/internal/worker/agent/claude_subagent_test.go
@@ -1281,31 +1281,35 @@ func TestClaude_AnUnreadableRegistryDoesNotFreeTheSendMessageSpan(t *testing.T) 
 
 	assert.NotContains(t, sink.ClosedSpans(), "tu-send",
 		"a registry it could not read cannot prove this is a spawn")
+	assert.NotContains(t, sink.ChildAgentIDs(), "child-of-tu-send",
+		"nor can it prove the id is a spawn span worth opening a transcript from")
 }
 
-// A revive whose registry row was cap-evicted has no linkage, and the event's
-// tool_use id is the SendMessage call. Handing that to EnsureChildAgent created
-// a SECOND child agent keyed by a non-spawn span and re-pointed the durable row
-// at the orphan, leaving the subagent's real transcript unreachable.
-func TestClaude_ReviveWithNoRegistryRowOpensNoSecondTranscript(t *testing.T) {
+// A row that names no transcript is the one state left in which a revive cannot
+// resolve its child, and only a failed registry write produces it: cap eviction
+// does not, because a linked row survives the display cap in the store. The
+// event's tool_use id is the SendMessage call, so handing it to EnsureChildAgent
+// would create a child keyed by a non-spawn span -- which the subagent's own
+// forwarded envelopes, all stamped with the real spawn span, then duplicate.
+func TestClaude_ReviveWithAnUnlinkedRowOpensNoSecondTranscript(t *testing.T) {
 	t.Parallel()
 
 	sink := &testSink{}
 	a := newTestAgent(sink)
 	child := spawnAndFinishSubagent(t, a, sink)
 	before := len(child.Messages())
-	// The row is gone, as cap-eviction or a cold seed window leaves it.
-	sink.ForgetBackgroundTask("task-1")
+	// The child transcript exists; only the row's linkage to it is missing.
+	sink.UnlinkBackgroundTask("task-1")
 
 	sendMessageTo(a, "tu-send", "task-1")
 	reviveTaskStarted(a, "tu-send", "Also check the tests.")
 
 	assert.NotContains(t, sink.ChildAgentIDs(), "child-of-tu-send",
 		"a SendMessage id must never open a transcript")
-	assert.Len(t, child.Messages(), before, "nothing is written before a transcript resolves")
+	assert.Len(t, child.Messages(), before, "nothing is written to a transcript the row does not name")
 
-	// The subagent's own output resolves its real transcript, and the held
-	// message lands above the reply it asked for.
+	// Refusing the SendMessage id costs no transcript: the subagent's own output
+	// still resolves the real one through the spawn span.
 	a.HandleOutput([]byte(`{
 		"type": "assistant",
 		"parent_tool_use_id": "tu-spawn",
@@ -1313,39 +1317,27 @@ func TestClaude_ReviveWithNoRegistryRowOpensNoSecondTranscript(t *testing.T) {
 	}`))
 
 	msgs := child.Messages()
-	require.Len(t, msgs, before+2, "the held message and the reply both land here")
-	assert.JSONEq(t, `{"content":"Also check the tests."}`, string(msgs[before].Content))
-	assert.Contains(t, string(msgs[before+1].Content), "Checked them.")
+	require.Len(t, msgs, before+1, "the reply lands in the subagent's own transcript")
+	assert.Contains(t, string(msgs[before].Content), "Checked them.")
 }
 
-// One send, one delivery: a held message is written once and not replayed into
-// every later envelope.
-func TestClaude_AHeldChildMessageIsWrittenOnce(t *testing.T) {
+// The revive arm is spent only by a revive that resolved a transcript. A
+// task_started that resolved none leaves it standing, so the retry a later
+// task_started deserves is still armed -- the same rule a failed registry write
+// follows.
+func TestClaude_ATaskStartedThatResolvesNoChildKeepsTheArm(t *testing.T) {
 	t.Parallel()
 
 	sink := &testSink{}
 	a := newTestAgent(sink)
-	child := spawnAndFinishSubagent(t, a, sink)
-	before := len(child.Messages())
-	sink.ForgetBackgroundTask("task-1")
+	spawnAndFinishSubagent(t, a, sink)
+	sink.UnlinkBackgroundTask("task-1")
 
 	sendMessageTo(a, "tu-send", "task-1")
 	reviveTaskStarted(a, "tu-send", "Also check the tests.")
-	for range 2 {
-		a.HandleOutput([]byte(`{
-			"type": "assistant",
-			"parent_tool_use_id": "tu-spawn",
-			"message": {"content": [{"type": "text", "text": "Working."}]}
-		}`))
-	}
 
-	held := 0
-	for _, m := range child.Messages()[before:] {
-		if string(m.Content) == `{"content":"Also check the tests."}` {
-			held++
-		}
-	}
-	assert.Equal(t, 1, held, "the held message is consumed by the first envelope that resolves a child")
+	assert.Empty(t, sink.RevivedTasks(), "no transcript resolved, so no revive happened")
+	assert.True(t, a.takeClaudeRevive("task-1"), "the arm is still standing for a retry")
 }
 
 // The CLI may stamp a revived run's forwarded result with the ORIGINAL spawn

--- a/backend/internal/worker/agent/codex_output.go
+++ b/backend/internal/worker/agent/codex_output.go
@@ -127,19 +127,11 @@ func (a *CodexAgent) handleTurnStarted(params json.RawMessage) {
 			// running registry row so the child tab reflects activity.
 			a.setChildTurnID(notif.ThreadID, notif.Turn.ID)
 			if a.knownCollabChild(notif.ThreadID) {
-				// A child that runs again after its row went final. The upsert
-				// below absorbs a non-final status against a final row --
-				// deliberately, because a replayed running update cannot prove a
-				// restart -- so without this the sidebar row and the tab chip read
-				// "finished" for the whole second run while the transcript fills.
-				//
-				// knownCollabChild is the proof. removeCollabChildIndex drops the
-				// entry at the close, so a thread that is known HERE was
-				// re-registered by a later collab call, which a replay never does.
-				// The reopened row keeps a closer: that collab call's own
-				// item/completed runs the states walk, which closes it.
-				a.reviveFinishedCollabChild(notif.ThreadID)
-				_ = a.sink.UpsertBackgroundTask(bgtask.Upsert{
+				// upsertCollabChildRow reopens the row first when this child runs
+				// again after going final. The reopened row keeps a closer: that
+				// collab call's own item/completed runs the states walk, which
+				// closes it.
+				_ = a.upsertCollabChildRow(bgtask.Upsert{
 					RowKey:     notif.ThreadID,
 					Kind:       bgtask.KindSubagent,
 					Title:      a.collabChildTitle(notif.ThreadID),

--- a/backend/internal/worker/agent/codex_output.go
+++ b/backend/internal/worker/agent/codex_output.go
@@ -127,6 +127,18 @@ func (a *CodexAgent) handleTurnStarted(params json.RawMessage) {
 			// running registry row so the child tab reflects activity.
 			a.setChildTurnID(notif.ThreadID, notif.Turn.ID)
 			if a.knownCollabChild(notif.ThreadID) {
+				// A child that runs again after its row went final. The upsert
+				// below absorbs a non-final status against a final row --
+				// deliberately, because a replayed running update cannot prove a
+				// restart -- so without this the sidebar row and the tab chip read
+				// "finished" for the whole second run while the transcript fills.
+				//
+				// knownCollabChild is the proof. removeCollabChildIndex drops the
+				// entry at the close, so a thread that is known HERE was
+				// re-registered by a later collab call, which a replay never does.
+				// The reopened row keeps a closer: that collab call's own
+				// item/completed runs the states walk, which closes it.
+				a.reviveFinishedCollabChild(notif.ThreadID)
 				_ = a.sink.UpsertBackgroundTask(bgtask.Upsert{
 					RowKey:     notif.ThreadID,
 					Kind:       bgtask.KindSubagent,

--- a/backend/internal/worker/agent/codex_output_test.go
+++ b/backend/internal/worker/agent/codex_output_test.go
@@ -632,6 +632,69 @@ func TestHandleCodexOutput_SpawnAgentCompletedLeavesNoSpan(t *testing.T) {
 	assert.Empty(t, messages[1].SpansOpenAtPersist, "and it draws no rail")
 }
 
+// A collab child that runs again after its row went final. The upsert absorbs a
+// non-final status against a final row -- deliberately, because a replayed
+// snapshot cannot prove a restart -- so without the revive the sidebar row and
+// the tab chip read "finished" for the whole second run.
+func TestHandleCodexOutput_ARerunCollabChildReopensItsRow(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink)
+
+	started := `{"method":"item/started","params":{"threadId":"main-thread","turnId":"turn1","item":{"type":"collabAgentToolCall","id":"call-1","tool":"spawnAgent","status":"inProgress","senderThreadId":"main-thread","receiverThreadIds":["child-1"],"prompt":"do work","model":"gpt-5.4","reasoningEffort":"medium","agentsStates":{}}}}`
+	completed := `{"method":"item/completed","params":{"threadId":"main-thread","turnId":"turn1","item":{"type":"collabAgentToolCall","id":"call-1","tool":"spawnAgent","status":"completed","senderThreadId":"main-thread","receiverThreadIds":["child-1"],"prompt":"do work","model":"gpt-5.4","reasoningEffort":"medium","agentsStates":{"child-1":{"status":"completed","message":"done"}}}}}`
+	// The root resumes the finished child: item/started re-registers the receiver,
+	// which is the proof a replayed snapshot never carries. The child's own
+	// turn/started then reports it working again.
+	resumed := `{"method":"item/started","params":{"threadId":"main-thread","turnId":"turn2","item":{"type":"collabAgentToolCall","id":"call-2","tool":"resumeAgent","status":"inProgress","senderThreadId":"main-thread","receiverThreadIds":["child-1"],"prompt":"more work","model":"gpt-5.4","reasoningEffort":"medium","agentsStates":{}}}}`
+	childTurn := `{"method":"turn/started","params":{"threadId":"child-1","turn":{"id":"turn-c2"}}}`
+
+	handleCodexOutput(agent, parseLine([]byte(started)))
+	handleCodexOutput(agent, parseLine([]byte(completed)))
+	_, status, ok, _ := sink.LookupBackgroundTask("child-1")
+	require.True(t, ok)
+	require.True(t, status.IsFinished(), "the first run closed the row")
+
+	handleCodexOutput(agent, parseLine([]byte(resumed)))
+	handleCodexOutput(agent, parseLine([]byte(childTurn)))
+
+	assert.Equal(t, []string{"child-1"}, sink.RevivedTasks(), "the re-registered child reopens its row")
+	_, status, ok, _ = sink.LookupBackgroundTask("child-1")
+	require.True(t, ok)
+	assert.Equal(t, bgtask.StatusRunning, status)
+}
+
+// A replayed snapshot that still calls an old child running must NOT resurrect
+// it. The close dropped the child index, and nothing re-registered it, so the
+// row stays final and keeps its closer.
+func TestHandleCodexOutput_AReplayedRunningStateDoesNotReopenARow(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink)
+
+	started := `{"method":"item/started","params":{"threadId":"main-thread","turnId":"turn1","item":{"type":"collabAgentToolCall","id":"call-1","tool":"spawnAgent","status":"inProgress","senderThreadId":"main-thread","receiverThreadIds":["child-1"],"prompt":"do work","model":"gpt-5.4","reasoningEffort":"medium","agentsStates":{}}}}`
+	completed := `{"method":"item/completed","params":{"threadId":"main-thread","turnId":"turn1","item":{"type":"collabAgentToolCall","id":"call-1","tool":"spawnAgent","status":"completed","senderThreadId":"main-thread","receiverThreadIds":["child-1"],"prompt":"do work","model":"gpt-5.4","reasoningEffort":"medium","agentsStates":{"child-1":{"status":"completed","message":"done"}}}}}`
+	// A LATER collab call for a DIFFERENT child, whose snapshot still carries the
+	// old child as running.
+	stale := `{"method":"item/completed","params":{"threadId":"main-thread","turnId":"turn2","item":{"type":"collabAgentToolCall","id":"call-2","tool":"spawnAgent","status":"completed","senderThreadId":"main-thread","receiverThreadIds":["child-2"],"prompt":"other","model":"gpt-5.4","reasoningEffort":"medium","agentsStates":{"child-1":{"status":"running"},"child-2":{"status":"completed"}}}}}`
+
+	// A child turn/started for the closed child, with no re-registration before
+	// it: knownCollabChild is false, so nothing reopens the row.
+	orphanTurn := `{"method":"turn/started","params":{"threadId":"child-1","turn":{"id":"turn-c9"}}}`
+
+	handleCodexOutput(agent, parseLine([]byte(started)))
+	handleCodexOutput(agent, parseLine([]byte(completed)))
+	handleCodexOutput(agent, parseLine([]byte(stale)))
+	handleCodexOutput(agent, parseLine([]byte(orphanTurn)))
+
+	assert.Empty(t, sink.RevivedTasks(), "a snapshot alone cannot prove a restart")
+	_, status, ok, _ := sink.LookupBackgroundTask("child-1")
+	require.True(t, ok)
+	assert.Equal(t, bgtask.StatusCompleted, status, "the row keeps its final status")
+}
+
 // A subagent spawn that starts while an unrelated command is running draws that
 // command's rail and nothing more -- one column, not two.
 func TestHandleCodexOutput_SpawnInsideOpenCommandDrawsOneColumn(t *testing.T) {

--- a/backend/internal/worker/agent/codex_output_test.go
+++ b/backend/internal/worker/agent/codex_output_test.go
@@ -1782,3 +1782,56 @@ func TestCodexSubAgentActivity_InterruptedStaysRunning(t *testing.T) {
 	assert.Equal(t, bgtask.StatusRunning, rows[0].Status)
 	assert.Equal(t, "", rows[0].ActiveForm, "started cleared the paused activity line")
 }
+
+// subAgentActivity is the THIRD writer that reports a collab child active again,
+// and it had no coverage for the reopen at all. The upsert absorbs a non-final
+// status against a final row, so without the reopen an `interacted` lands its
+// "received input" activity on a row that still reads "completed" -- the sidebar
+// then shows a finished subagent that just took a message.
+func TestHandleCodexOutput_ASubAgentActivityReopensAFinishedChild(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink)
+
+	started := `{"method":"item/started","params":{"threadId":"main-thread","turnId":"turn1","item":{"type":"collabAgentToolCall","id":"call-1","tool":"spawnAgent","status":"inProgress","senderThreadId":"main-thread","receiverThreadIds":["child-1"],"prompt":"do work","model":"gpt-5.4","reasoningEffort":"medium","agentsStates":{}}}}`
+	completed := `{"method":"item/completed","params":{"threadId":"main-thread","turnId":"turn1","item":{"type":"collabAgentToolCall","id":"call-1","tool":"spawnAgent","status":"completed","senderThreadId":"main-thread","receiverThreadIds":["child-1"],"prompt":"do work","model":"gpt-5.4","reasoningEffort":"medium","agentsStates":{"child-1":{"status":"completed","message":"done"}}}}}`
+	resumed := `{"method":"item/started","params":{"threadId":"main-thread","turnId":"turn2","item":{"type":"collabAgentToolCall","id":"call-2","tool":"resumeAgent","status":"inProgress","senderThreadId":"main-thread","receiverThreadIds":["child-1"],"prompt":"more work","model":"gpt-5.4","reasoningEffort":"medium","agentsStates":{}}}}`
+	interacted := `{"method":"item/completed","params":{"threadId":"main-thread","turnId":"turn2","item":{"type":"subAgentActivity","agentThreadId":"child-1","kind":"interacted"}}}`
+
+	handleCodexOutput(agent, parseLine([]byte(started)))
+	handleCodexOutput(agent, parseLine([]byte(completed)))
+	_, status, ok, _ := sink.LookupBackgroundTask("child-1")
+	require.True(t, ok)
+	require.True(t, status.IsFinished(), "the first run closed the row")
+
+	handleCodexOutput(agent, parseLine([]byte(resumed)))
+	handleCodexOutput(agent, parseLine([]byte(interacted)))
+
+	assert.Equal(t, []string{"child-1"}, sink.RevivedTasks(), "the activity reopens the re-registered child")
+	_, status, ok, _ = sink.LookupBackgroundTask("child-1")
+	require.True(t, ok)
+	assert.Equal(t, bgtask.StatusRunning, status)
+}
+
+// The negative half: an activity for a child nothing re-registered must NOT
+// reopen the row. The close dropped the child index, so the proof is absent.
+func TestHandleCodexOutput_ASubAgentActivityAloneDoesNotReopenARow(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink)
+
+	started := `{"method":"item/started","params":{"threadId":"main-thread","turnId":"turn1","item":{"type":"collabAgentToolCall","id":"call-1","tool":"spawnAgent","status":"inProgress","senderThreadId":"main-thread","receiverThreadIds":["child-1"],"prompt":"do work","model":"gpt-5.4","reasoningEffort":"medium","agentsStates":{}}}}`
+	completed := `{"method":"item/completed","params":{"threadId":"main-thread","turnId":"turn1","item":{"type":"collabAgentToolCall","id":"call-1","tool":"spawnAgent","status":"completed","senderThreadId":"main-thread","receiverThreadIds":["child-1"],"prompt":"do work","model":"gpt-5.4","reasoningEffort":"medium","agentsStates":{"child-1":{"status":"completed","message":"done"}}}}}`
+	interacted := `{"method":"item/completed","params":{"threadId":"main-thread","turnId":"turn2","item":{"type":"subAgentActivity","agentThreadId":"child-1","kind":"interacted"}}}`
+
+	handleCodexOutput(agent, parseLine([]byte(started)))
+	handleCodexOutput(agent, parseLine([]byte(completed)))
+	handleCodexOutput(agent, parseLine([]byte(interacted)))
+
+	assert.Empty(t, sink.RevivedTasks(), "an activity with no re-registration is not proof of a restart")
+	_, status, ok, _ := sink.LookupBackgroundTask("child-1")
+	require.True(t, ok)
+	assert.True(t, status.IsFinished(), "the row keeps its final status")
+}

--- a/backend/internal/worker/agent/codex_subagent.go
+++ b/backend/internal/worker/agent/codex_subagent.go
@@ -66,7 +66,8 @@ func (a *CodexAgent) collabAgentsStatesToRegistry(collab *codexCollabAgentToolCa
 		// Link the registry row to a child transcript when the index knows the
 		// thread (EnsureChildAgent is idempotent).
 		childAgentID := ""
-		if spawnSpan := a.collabSpanForThread(threadID); spawnSpan != "" {
+		spawnSpan := a.collabSpanForThread(threadID)
+		if spawnSpan != "" {
 			var err error
 			childAgentID, err = a.sink.EnsureChildAgent(spawnSpan, threadID, title)
 			if err != nil {
@@ -77,6 +78,19 @@ func (a *CodexAgent) collabAgentsStatesToRegistry(collab *codexCollabAgentToolCa
 					slog.Warn("codex collab persist prompt failed", "thread", threadID, "error", err)
 				}
 			}
+		}
+		// The SECOND signal that a child runs again after its row went final. The
+		// child's own turn/started is the first and the prompt one; this covers a
+		// collab call that reports a still-running child without one. Same helper,
+		// same proof, and idempotent -- a no-op for a row that is already active.
+		//
+		// The child INDEX is the proof. removeCollabChildIndex drops the span at
+		// the close, so a non-empty spawnSpan here means registerCollabReceiver
+		// re-registered this thread AFTER that close, which a replayed
+		// agentsStates snapshot never does. The reopened row keeps a closer: this
+		// same walk closes it when the state goes final again.
+		if !finished && spawnSpan != "" {
+			a.reviveFinishedCollabChild(threadID)
 		}
 		if err := a.sink.UpsertBackgroundTask(bgtask.Upsert{
 			RowKey:        threadID,
@@ -102,6 +116,23 @@ func (a *CodexAgent) collabAgentsStatesToRegistry(collab *codexCollabAgentToolCa
 				a.sink.CleanupChildAgent(childAgentID)
 			}
 		}
+	}
+}
+
+// reviveFinishedCollabChild returns a collab child's row to Running when the
+// registry still holds it in a final status. A no-op for an absent row and for
+// one that is already active, so the common case costs one cache read.
+func (a *CodexAgent) reviveFinishedCollabChild(threadID string) {
+	_, status, ok, err := a.sink.LookupBackgroundTask(threadID)
+	if err != nil {
+		slog.Warn("codex collab registry lookup failed", "thread", threadID, "error", err)
+		return
+	}
+	if !ok || !status.IsFinished() {
+		return
+	}
+	if err := a.sink.ReviveBackgroundTask(threadID); err != nil {
+		slog.Warn("codex collab revive failed", "thread", threadID, "error", err)
 	}
 }
 

--- a/backend/internal/worker/agent/codex_subagent.go
+++ b/backend/internal/worker/agent/codex_subagent.go
@@ -79,20 +79,10 @@ func (a *CodexAgent) collabAgentsStatesToRegistry(collab *codexCollabAgentToolCa
 				}
 			}
 		}
-		// The SECOND signal that a child runs again after its row went final. The
-		// child's own turn/started is the first and the prompt one; this covers a
-		// collab call that reports a still-running child without one. Same helper,
-		// same proof, and idempotent -- a no-op for a row that is already active.
-		//
-		// The child INDEX is the proof. removeCollabChildIndex drops the span at
-		// the close, so a non-empty spawnSpan here means registerCollabReceiver
-		// re-registered this thread AFTER that close, which a replayed
-		// agentsStates snapshot never does. The reopened row keeps a closer: this
-		// same walk closes it when the state goes final again.
-		if !finished && spawnSpan != "" {
-			a.reviveFinishedCollabChild(threadID)
-		}
-		if err := a.sink.UpsertBackgroundTask(bgtask.Upsert{
+		// upsertCollabChildRow reopens the row first when this walk reports the
+		// child still running after its row went final. The reopened row keeps a
+		// closer: this same walk closes it when the state goes final again.
+		if err := a.upsertCollabChildRow(bgtask.Upsert{
 			RowKey:        threadID,
 			Kind:          bgtask.KindSubagent,
 			ChildAgentID:  childAgentID,
@@ -139,6 +129,26 @@ func (a *CodexAgent) reviveFinishedCollabChild(threadID string) {
 	}
 }
 
+// upsertCollabChildRow writes a collab child's registry row, reopening the row
+// first when this write reports the child ACTIVE again and the registry still
+// holds it finished.
+//
+// The proof and the write are ONE call, so a fourth writer cannot forget the
+// reopen -- which is the whole hazard, because the upsert deliberately absorbs
+// a non-final status against a final row. Three sites report a child active (a
+// child turn/started, a collab agentsStates walk, a subAgentActivity), and each
+// carried its own hand-placed copy of the same pair.
+//
+// The child INDEX is the proof: removeCollabChildIndex drops the entry at the
+// close, so a thread that is still known was re-registered by a later collab
+// call, which a replayed snapshot never does.
+func (a *CodexAgent) upsertCollabChildRow(up bgtask.Upsert) error {
+	if !up.Status.IsFinished() && a.knownCollabChild(up.RowKey) {
+		a.reviveFinishedCollabChild(up.RowKey)
+	}
+	return a.sink.UpsertBackgroundTask(up)
+}
+
 // handleCodexSubAgentActivity handles a v2 subAgentActivity item (registry
 // only; never persisted): {kind: started|interacted|interrupted, agentThreadId}.
 // started→Running, interacted→activity "received input", interrupted→Running
@@ -170,7 +180,10 @@ func (a *CodexAgent) handleCodexSubAgentActivity(item json.RawMessage) bool {
 	default:
 		status = bgtask.StatusRunning
 	}
-	if err := a.sink.UpsertBackgroundTask(bgtask.Upsert{
+	// upsertCollabChildRow reopens the row first. Without it an activity that
+	// follows a close lands its ActiveForm ("received input") on a row that still
+	// reads "completed" -- a finished subagent that just took a message.
+	if err := a.upsertCollabChildRow(bgtask.Upsert{
 		RowKey:     act.AgentThreadID,
 		Kind:       bgtask.KindSubagent,
 		Title:      a.collabChildTitle(act.AgentThreadID),

--- a/backend/internal/worker/agent/codex_subagent.go
+++ b/backend/internal/worker/agent/codex_subagent.go
@@ -121,7 +121,10 @@ func (a *CodexAgent) collabAgentsStatesToRegistry(collab *codexCollabAgentToolCa
 
 // reviveFinishedCollabChild returns a collab child's row to Running when the
 // registry still holds it in a final status. A no-op for an absent row and for
-// one that is already active, so the common case costs one cache read.
+// one that is already active, so the common case costs one cache read. A row
+// past the display cap costs one indexed point lookup instead, and still
+// revives -- which is the point: a session's older collab children must reopen
+// the same way its newest one does.
 func (a *CodexAgent) reviveFinishedCollabChild(threadID string) {
 	_, status, ok, err := a.sink.LookupBackgroundTask(threadID)
 	if err != nil {

--- a/backend/internal/worker/agent/notification_types.go
+++ b/backend/internal/worker/agent/notification_types.go
@@ -50,13 +50,19 @@ const (
 	NotificationTypeRateLimit      = "rate_limit"
 	NotificationTypeRateLimitEvent = "rate_limit_event"
 
-	// NotificationTypeSubagentEnded closes a subagent transcript. The worker
-	// writes exactly one into a child transcript when that subagent's
-	// background-task row reaches a final status, so the subagent tab shows
-	// WHERE it stopped and WHY instead of a thinking indicator that never
-	// resolves. Carries a `status` field holding the registry's final wire
-	// status (completed / failed / stopped / interrupted). Provider-neutral:
-	// the registry close is the one moment every provider agrees a subagent is
-	// over, including the ones whose child transcript simply stops.
+	// NotificationTypeSubagentEnded closes a subagent RUN. The worker writes one
+	// into a child transcript each time that subagent's background-task row
+	// reaches a final status, so the subagent tab shows WHERE it stopped and WHY
+	// instead of a thinking indicator that never resolves. Carries a `status`
+	// field holding the registry's final wire status (completed / failed /
+	// stopped / interrupted). Provider-neutral: the registry close is the one
+	// moment every provider agrees a subagent is over, including the ones whose
+	// child transcript simply stops.
+	//
+	// One per run, NOT one per transcript, and nothing follows it only until
+	// something does. Claude restarts a finished subagent when the parent
+	// messages it, and the restarted run ends the same way -- so a transcript
+	// holds as many of these as the subagent had runs, each with more messages
+	// below it.
 	NotificationTypeSubagentEnded = "subagent_ended"
 )

--- a/backend/internal/worker/agent/sink_test.go
+++ b/backend/internal/worker/agent/sink_test.go
@@ -4,7 +4,11 @@ import (
 	"encoding/json"
 	"strings"
 	"sync"
+	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/util/optionmap"
@@ -600,27 +604,40 @@ func (s *testSink) ReviveBackgroundTask(rowKey string) error {
 	return nil
 }
 
-// RevivedTasks returns the row keys ReviveBackgroundTask actually reopened.
-// ForgetBackgroundTask drops a row the way cap-eviction and a cold seed window
-// do: the registry entry goes, and the child agent row survives it.
-func (s *testSink) ForgetBackgroundTask(rowKey string) {
+// UnlinkBackgroundTask clears a row's child linkage, leaving the row and the
+// child transcript in place. This is the one state a provider can still meet in
+// which a finished subagent's row names no transcript: EnsureChildAgent created
+// the child agent row and the registry upsert that links it then failed. Cap
+// eviction does NOT produce it -- a linked row survives the display cap in the
+// store (see registryOps.retainInStore) -- so a test must not use eviction to
+// reach it.
+func (s *testSink) UnlinkBackgroundTask(rowKey string) {
 	s.bgTasksMu.Lock()
 	defer s.bgTasksMu.Unlock()
-	delete(s.bgTasks, rowKey)
+	item, ok := s.bgTasks[rowKey]
+	if !ok {
+		return
+	}
+	item.ChildAgentID = ""
+	s.bgTasks[rowKey] = item
 }
 
 // ChildAgentIDs lists every child transcript this sink handed out, so a test can
-// assert that a resolution did NOT open a second one.
+// assert that a resolution did NOT open a second one. It returns the child agent
+// IDS, not the spawn spans that key the map: an assertion reads
+// "child-of-<span>", which no spawn span can ever equal, so returning the keys
+// made every NotContains on it pass whatever the code did.
 func (s *testSink) ChildAgentIDs() []string {
 	s.childSinkMu.Lock()
 	defer s.childSinkMu.Unlock()
 	ids := make([]string, 0, len(s.children))
-	for id := range s.children {
-		ids = append(ids, id)
+	for _, c := range s.children {
+		ids = append(ids, c.childAgentID())
 	}
 	return ids
 }
 
+// RevivedTasks returns the row keys ReviveBackgroundTask actually reopened.
 func (s *testSink) RevivedTasks() []string {
 	s.bgTasksMu.Lock()
 	defer s.bgTasksMu.Unlock()
@@ -894,3 +911,19 @@ func (noopSink) LookupBackgroundTask(string) (string, bgtask.Status, bool, error
 func (noopSink) ReviveBackgroundTask(string) error            { return nil }
 func (noopSink) PersistChildUserMessage(string, string) error { return nil }
 func (noopSink) CleanupChildAgent(string)                     {}
+
+// The one test in this helpers file, and it belongs here: every caller of
+// ChildAgentIDs asserts NotContains against a child id, so a version that
+// returned the map's spawn-span keys satisfied all of them and proved nothing.
+// Pinning the return shape beside the fake keeps that from coming back.
+func TestTestSink_ChildAgentIDsReturnsChildIDsNotSpawnSpans(t *testing.T) {
+	t.Parallel()
+
+	s := &testSink{}
+	childID, err := s.EnsureChildAgent("tu-spawn", "task-1", "explore")
+	require.NoError(t, err)
+	require.Equal(t, "child-of-tu-spawn", childID)
+
+	assert.Equal(t, []string{childID}, s.ChildAgentIDs())
+	assert.NotContains(t, s.ChildAgentIDs(), "tu-spawn", "the spawn span is the key, not the id")
+}

--- a/backend/internal/worker/agent/sink_test.go
+++ b/backend/internal/worker/agent/sink_test.go
@@ -597,7 +597,13 @@ func (s *testSink) ReviveBackgroundTask(rowKey string) error {
 		return nil
 	}
 	item.Status = bgtask.StatusRunning
+	// ActiveForm AND Description, the pair the real ReviveAgentBackgroundTask
+	// clears. Both describe the run that ENDED -- the last activity text, and the
+	// output file its task_notification identified -- so a fake that cleared only
+	// one would pass a test that asserts the finished run's output path survives
+	// a restart, which the registry makes certain it does not.
 	item.ActiveForm = ""
+	item.Description = ""
 	item.EndedAt = time.Time{}
 	s.bgTasks[rowKey] = item
 	s.revivedTasks = append(s.revivedTasks, rowKey)
@@ -606,10 +612,10 @@ func (s *testSink) ReviveBackgroundTask(rowKey string) error {
 
 // UnlinkBackgroundTask clears a row's child linkage, leaving the row and the
 // child transcript in place. This is the one state a provider can still meet in
-// which a finished subagent's row names no transcript: EnsureChildAgent created
-// the child agent row and the registry upsert that links it then failed. Cap
-// eviction does NOT produce it -- a linked row survives the display cap in the
-// store (see registryOps.retainInStore) -- so a test must not use eviction to
+// which a finished subagent's row identifies no transcript: EnsureChildAgent
+// created the child agent row and the registry upsert that links it then failed.
+// Cap eviction does NOT produce it -- a linked row survives the display cap in
+// the store (see registryOps.retention) -- so a test must not use eviction to
 // reach it.
 func (s *testSink) UnlinkBackgroundTask(rowKey string) {
 	s.bgTasksMu.Lock()

--- a/backend/internal/worker/agent/sink_test.go
+++ b/backend/internal/worker/agent/sink_test.go
@@ -59,7 +59,20 @@ type testSink struct {
 	childIDMu   sync.Mutex
 	childIDVal  string
 	// bgTasks records the latest registry state per row key (owner == this sink).
-	bgTasks   map[string]bgtask.Item
+	bgTasks map[string]bgtask.Item
+	// revivedTasks records every row key ReviveBackgroundTask actually reopened,
+	// in order. The effect alone cannot prove the call: a revive leaves the row
+	// running, which is also how it looked before it ever finished.
+	revivedTasks []string
+	// reviveErr, when set, is what ReviveBackgroundTask returns INSTEAD of
+	// reopening the row. The only way to exercise the caller's failure path: a
+	// revive that cannot fail leaves the "arm is spent, message is lost" branch
+	// unreachable from a test. Read without the lock -- set at construction.
+	reviveErr error
+	// lookupErr, when set, is what LookupBackgroundTask returns instead of an
+	// answer -- the "registry unreadable" third case, which a miss cannot stand
+	// in for. Read without the lock: set at construction.
+	lookupErr error
 	bgTasksMu sync.Mutex
 	// notifSuppressBroadcast makes PersistNotification report broadcast=false,
 	// simulating the service layer collapsing a flapping notification
@@ -330,6 +343,20 @@ func (s *testSink) CancelAutoContinue(reason AutoContinueReason) {
 // provider tests can assert child resolution without a DB. The same span always
 // resolves to the same id (idempotent replay).
 func (s *testSink) EnsureChildAgent(spawnSpanID, providerChildKey, title string) (string, error) {
+	// Resolve by ROW KEY before spawn span, as the real sink does. That order is
+	// load-bearing, not an optimization: Claude re-registers a revived subagent
+	// under the tool_use id of the call that restarted it, so a spawn-span-only
+	// lookup would miss and hand back a SECOND transcript for the same subagent.
+	// A double that resolved differently would report a split the real sink does
+	// not have, and hide one it does.
+	if providerChildKey != "" {
+		s.bgTasksMu.Lock()
+		existing := s.bgTasks[providerChildKey].ChildAgentID
+		s.bgTasksMu.Unlock()
+		if existing != "" {
+			return existing, nil
+		}
+	}
 	s.childSinkMu.Lock()
 	defer s.childSinkMu.Unlock()
 	if s.children == nil {
@@ -435,10 +462,39 @@ func (s *testSink) PersistChildPrompt(childAgentID, prompt string) error {
 	return cs.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, content, SpanInfo{})
 }
 
+// PersistChildUserMessage mirrors the real sink: it APPENDS, with no emptiness
+// guard, and carries the scroll-rail mark the opening prompt does not. The
+// missing guard is the whole difference from PersistChildPrompt above -- a
+// delivered message belongs wherever the transcript currently ends.
+func (s *testSink) PersistChildUserMessage(childAgentID, text string) error {
+	if childAgentID == "" || strings.TrimSpace(text) == "" {
+		return nil
+	}
+	cs, _ := s.ChildSink(childAgentID).(*testSink)
+	if cs == nil {
+		return nil
+	}
+	content, err := json.Marshal(map[string]string{"content": text})
+	if err != nil {
+		return err
+	}
+	return cs.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, content, SpanInfo{
+		MarkType: leapmuxv1.MarkType_MARK_TYPE_USER_MESSAGE,
+	})
+}
+
 // testFakeEndedAt is the instant the fake stamps on an active -> final
 // transition. A fixed value, because the fake models WHETHER ended_at is set,
 // not when: an assertion that the stamp is absent for a non-final status was
 // vacuously true while nothing ever set it.
+//
+// updated_at is deliberately NOT modeled, although every production applier
+// stamps it. Nothing in this package can read it: LookupBackgroundTask hands
+// back a status and a child id rather than an Item, so the field reaches no
+// provider decision. Stamping a fixed instant would make "the second write
+// advanced updated_at" fail against correct code, and stamping the real clock
+// would make the fake non-deterministic. A test that needs the stamp belongs in
+// the service package, against the real registry.
 var testFakeEndedAt = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 
 func (s *testSink) UpsertBackgroundTask(task bgtask.Upsert) error {
@@ -506,6 +562,69 @@ func (s *testSink) CloseBackgroundTask(rowKey string, status bgtask.Status) erro
 		s.bgTasks[rowKey] = item
 	}
 	return nil
+}
+
+func (s *testSink) LookupBackgroundTask(rowKey string) (string, bgtask.Status, bool, error) {
+	var noStatus bgtask.Status
+	if s.lookupErr != nil {
+		return "", noStatus, false, s.lookupErr
+	}
+	s.bgTasksMu.Lock()
+	defer s.bgTasksMu.Unlock()
+	item, ok := s.bgTasks[rowKey]
+	if !ok {
+		return "", noStatus, false, nil
+	}
+	return item.ChildAgentID, item.Status, true, nil
+}
+
+// ReviveBackgroundTask mirrors the registry's revive: a finished row returns to
+// running with its ended_at cleared, and an absent or already-active row is a
+// no-op. The row keys it actually revived are recorded so a test can assert the
+// call happened rather than only its effect.
+func (s *testSink) ReviveBackgroundTask(rowKey string) error {
+	if s.reviveErr != nil {
+		return s.reviveErr
+	}
+	s.bgTasksMu.Lock()
+	defer s.bgTasksMu.Unlock()
+	item, ok := s.bgTasks[rowKey]
+	if !ok || !item.Status.IsFinished() {
+		return nil
+	}
+	item.Status = bgtask.StatusRunning
+	item.ActiveForm = ""
+	item.EndedAt = time.Time{}
+	s.bgTasks[rowKey] = item
+	s.revivedTasks = append(s.revivedTasks, rowKey)
+	return nil
+}
+
+// RevivedTasks returns the row keys ReviveBackgroundTask actually reopened.
+// ForgetBackgroundTask drops a row the way cap-eviction and a cold seed window
+// do: the registry entry goes, and the child agent row survives it.
+func (s *testSink) ForgetBackgroundTask(rowKey string) {
+	s.bgTasksMu.Lock()
+	defer s.bgTasksMu.Unlock()
+	delete(s.bgTasks, rowKey)
+}
+
+// ChildAgentIDs lists every child transcript this sink handed out, so a test can
+// assert that a resolution did NOT open a second one.
+func (s *testSink) ChildAgentIDs() []string {
+	s.childSinkMu.Lock()
+	defer s.childSinkMu.Unlock()
+	ids := make([]string, 0, len(s.children))
+	for id := range s.children {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+func (s *testSink) RevivedTasks() []string {
+	s.bgTasksMu.Lock()
+	defer s.bgTasksMu.Unlock()
+	return append([]string(nil), s.revivedTasks...)
 }
 
 func (s *testSink) RenameBackgroundTask(oldKey, newKey string) error {
@@ -768,4 +887,10 @@ func (noopSink) UpdateBackgroundTaskStatus(string, bgtask.Status, string) error 
 }
 func (noopSink) CloseBackgroundTask(string, bgtask.Status) error { return nil }
 func (noopSink) RenameBackgroundTask(string, string) error       { return nil }
-func (noopSink) CleanupChildAgent(string)                        {}
+func (noopSink) LookupBackgroundTask(string) (string, bgtask.Status, bool, error) {
+	var noStatus bgtask.Status
+	return "", noStatus, false, nil
+}
+func (noopSink) ReviveBackgroundTask(string) error            { return nil }
+func (noopSink) PersistChildUserMessage(string, string) error { return nil }
+func (noopSink) CleanupChildAgent(string)                     {}

--- a/backend/internal/worker/db/queries/agent_background_tasks.sql
+++ b/backend/internal/worker/db/queries/agent_background_tasks.sql
@@ -21,14 +21,24 @@ ORDER BY seq DESC LIMIT ?;
 -- DeleteFinishedAgentBackgroundTasksBelowSeq reclaims the rows a pool's seed
 -- window left behind.
 --
--- The cap is SOFT: an upsert exceeds it rather than orphan a steerable child, so
--- a pool can hold more rows than its window admits. Eviction only ever deletes a
--- row the CACHE holds, so without this pass the surplus is never loaded and
--- never deleted -- invisible in the sidebar and growing without limit in the DB.
--- Only FINISHED rows are reclaimed: an active row still names a live child.
+-- The cap bounds the DISPLAY list, not the table: a row that carries a child
+-- transcript survives eviction, so a pool holds more rows than its window
+-- admits. Eviction only ever touches a row the CACHE holds, so without this pass
+-- an unlinked surplus row is never loaded and never deleted -- invisible in the
+-- sidebar and growing without limit in the DB.
+--
+-- Two filters keep this pass off the rows that are still worth something. Only
+-- FINISHED rows are reclaimed: an active row still names a live child. And only
+-- UNLINKED rows: the row of a subagent is the one index from that child agent id
+-- back to (owner, row_key), the child agents row outlives the registry delete,
+-- and deleting the row leaves that subagent permanently unmessageable and
+-- uninterruptible. A linked row is retained for the life of its root agent,
+-- which is what ON DELETE CASCADE from agents(id) already gives the transcript
+-- it points at.
 -- name: DeleteFinishedAgentBackgroundTasksBelowSeq :execrows
 DELETE FROM agent_background_tasks
 WHERE owner_agent_id = ? AND kind = ? AND seq < ?
+  AND child_agent_id = ''
   AND status IN ('completed','failed','stopped','interrupted');
 
 -- UpsertAgentBackgroundTask inserts a new row or updates an existing one keyed
@@ -147,20 +157,35 @@ UPDATE agent_background_tasks SET row_key = ? WHERE owner_agent_id = ? AND row_k
 -- name: CountAgentBackgroundTasksByRowKey :one
 SELECT COUNT(*) FROM agent_background_tasks WHERE owner_agent_id = ? AND row_key = ?;
 
+-- GetAgentBackgroundTaskByRowKey reads one row by its PRIMARY KEY, so a lookup
+-- that misses the capped display cache still resolves. The cap bounds what the
+-- sidebar shows; a row that carries a child transcript outlives it, and this
+-- point lookup is how the linkage stays reachable after the row leaves the
+-- cache.
+-- name: GetAgentBackgroundTaskByRowKey :one
+SELECT * FROM agent_background_tasks WHERE owner_agent_id = ? AND row_key = ?;
+
 -- GetAgentBackgroundTaskByChildAgentID is the reverse lookup behind
 -- send-to-subagent and interrupt routing: child agent id -> (owner, row_key).
 -- name: GetAgentBackgroundTaskByChildAgentID :one
 SELECT * FROM agent_background_tasks WHERE child_agent_id = ?;
 
 -- MarkAgentBackgroundTasksEnded gives every still-active row owned by an agent a
--- final status (used on clean process exit). Returns the affected-row count so
--- the caller can skip the broadcast when nothing moved.
--- name: MarkAgentBackgroundTasksEnded :execrows
+-- final status (used on clean process exit).
+--
+-- It RETURNS the child transcript of each row it ended, for the same reason the
+-- boot sweep below does: the write is the single source for both facts. The
+-- caller cannot read the set back afterwards (the rows are no longer active),
+-- and its in-memory cache holds the DISPLAY list only -- so a row past the cap
+-- or below the seed window would get a final status here and no closing
+-- divider, permanently.
+-- name: MarkAgentBackgroundTasksEnded :many
 UPDATE agent_background_tasks SET
     status     = ?,
     ended_at   = ?,
     updated_at = ?
-WHERE owner_agent_id = ? AND status IN ('pending','running');
+WHERE owner_agent_id = ? AND status IN ('pending','running')
+RETURNING child_agent_id;
 
 -- MarkAllActiveAgentBackgroundTasksInterrupted runs at worker boot before any
 -- caches exist: every active row left over from the previous process is

--- a/backend/internal/worker/db/queries/agent_background_tasks.sql
+++ b/backend/internal/worker/db/queries/agent_background_tasks.sql
@@ -97,6 +97,37 @@ UPDATE agent_background_tasks SET
     updated_at = ?
 WHERE owner_agent_id = ? AND row_key = ? AND status IN ('pending','running');
 
+-- ReviveAgentBackgroundTask returns a FINISHED row to running and clears its
+-- ended_at, for a subagent that its parent restarted by sending it a message.
+--
+-- This is the one write that undoes a final status, and it is deliberately its
+-- own statement rather than a relaxation of the guards on the upsert and the
+-- status update. Those guards drop a NON-final status against a final row, and
+-- they must keep doing so: a replayed running upsert (a duplicate task_started,
+-- a worker restart, a resumed session that re-announces every task it once ran)
+-- would otherwise leave a row running that nothing ever closes, which pins the
+-- parent's thinking indicator for good. A caller reaches this query only with
+-- positive evidence that the provider restarted the task.
+--
+-- active_form and description are cleared with the status. Both describe the run
+-- that ENDED -- the last activity text, and the output file its task_notification
+-- named -- and the restarted run has reported neither yet. The row's activity
+-- slot shows whichever is present, so leaving them pins the previous run's
+-- output path under a subagent that is running again.
+--
+-- The status-IN filter makes the call idempotent -- an absent or still-active
+-- row matches nothing -- and :execrows lets the caller tell a real revive from
+-- a no-op, because only a real one owes the transcript-close release.
+-- name: ReviveAgentBackgroundTask :execrows
+UPDATE agent_background_tasks SET
+    status      = 'running',
+    active_form = '',
+    description = '',
+    ended_at    = NULL,
+    updated_at  = ?
+WHERE owner_agent_id = ? AND row_key = ?
+  AND status IN ('completed','failed','stopped','interrupted');
+
 -- name: DeleteAgentBackgroundTaskByRowKey :execresult
 DELETE FROM agent_background_tasks WHERE owner_agent_id = ? AND row_key = ?;
 

--- a/backend/internal/worker/db/queries/agent_background_tasks.sql
+++ b/backend/internal/worker/db/queries/agent_background_tasks.sql
@@ -21,14 +21,14 @@ ORDER BY seq DESC LIMIT ?;
 -- DeleteFinishedAgentBackgroundTasksBelowSeq reclaims the rows a pool's seed
 -- window left behind.
 --
--- The cap bounds the DISPLAY list, not the table: a row that carries a child
+-- The cap limits the DISPLAY list, not the table: a row that carries a child
 -- transcript survives eviction, so a pool holds more rows than its window
 -- admits. Eviction only ever touches a row the CACHE holds, so without this pass
 -- an unlinked surplus row is never loaded and never deleted -- invisible in the
 -- sidebar and growing without limit in the DB.
 --
 -- Two filters keep this pass off the rows that are still worth something. Only
--- FINISHED rows are reclaimed: an active row still names a live child. And only
+-- FINISHED rows are reclaimed: an active row still identifies a live child. And only
 -- UNLINKED rows: the row of a subagent is the one index from that child agent id
 -- back to (owner, row_key), the child agents row outlives the registry delete,
 -- and deleting the row leaves that subagent permanently unmessageable and
@@ -121,9 +121,9 @@ WHERE owner_agent_id = ? AND row_key = ? AND status IN ('pending','running');
 --
 -- active_form and description are cleared with the status. Both describe the run
 -- that ENDED -- the last activity text, and the output file its task_notification
--- named -- and the restarted run has reported neither yet. The row's activity
+-- identified -- and the restarted run reported neither yet. The row's activity
 -- slot shows whichever is present, so leaving them pins the previous run's
--- output path under a subagent that is running again.
+-- output path under a subagent that runs again.
 --
 -- The status-IN filter makes the call idempotent -- an absent or still-active
 -- row matches nothing -- and :execrows lets the caller tell a real revive from
@@ -140,6 +140,21 @@ WHERE owner_agent_id = ? AND row_key = ?
 
 -- name: DeleteAgentBackgroundTaskByRowKey :execresult
 DELETE FROM agent_background_tasks WHERE owner_agent_id = ? AND row_key = ?;
+
+-- ResequenceAgentBackgroundTask gives a row a new seq, for one the display cache
+-- re-admitted after the cap evicted it.
+--
+-- The seq is the display list's one ordering key: the cache holds its rows in
+-- ascending seq, and the cold-start seed reads the newest rows by seq. A
+-- re-admission that changed the in-memory order alone left the two disagreeing
+-- -- so a subagent a revive had just reopened sat at the end of the sidebar for
+-- the life of the process, then fell outside the seed window and vanished on the
+-- next worker restart, while 64 older finished rows stayed on screen.
+--
+-- UNIQUE (owner_agent_id, seq) makes the caller's monotonic nextSeq the only
+-- safe value, which is the same value an INSERT would bind.
+-- name: ResequenceAgentBackgroundTask :exec
+UPDATE agent_background_tasks SET seq = ? WHERE owner_agent_id = ? AND row_key = ?;
 
 -- RenameAgentBackgroundTask re-keys a row (owner_agent_id, old_row_key) to
 -- new_row_key. The row_key is the provider linkage key; a provider that learns
@@ -158,7 +173,7 @@ UPDATE agent_background_tasks SET row_key = ? WHERE owner_agent_id = ? AND row_k
 SELECT COUNT(*) FROM agent_background_tasks WHERE owner_agent_id = ? AND row_key = ?;
 
 -- GetAgentBackgroundTaskByRowKey reads one row by its PRIMARY KEY, so a lookup
--- that misses the capped display cache still resolves. The cap bounds what the
+-- that misses the capped display cache still resolves. The cap limits what the
 -- sidebar shows; a row that carries a child transcript outlives it, and this
 -- point lookup is how the linkage stays reachable after the row leaves the
 -- cache.

--- a/backend/internal/worker/db/queries/subagent_transcript_closes.sql
+++ b/backend/internal/worker/db/queries/subagent_transcript_closes.sql
@@ -9,3 +9,15 @@
 -- than the duplicate a fail-open can produce.
 INSERT INTO subagent_transcript_closes (child_agent_id) VALUES (?)
 ON CONFLICT (child_agent_id) DO NOTHING;
+
+-- name: ReleaseSubagentTranscriptClose :exec
+-- Give the claim back, so the NEXT completion of this subagent writes the next
+-- closing divider.
+--
+-- A subagent transcript holds one divider for each completion, not one for its
+-- whole life: Claude revives a finished subagent when the parent messages it,
+-- and the revived run ends the same way the first one did. The claim is what
+-- keeps the two writers of a single close (the registry and the child's own
+-- turn end) from doubling it, so the revive releases it rather than working
+-- around it.
+DELETE FROM subagent_transcript_closes WHERE child_agent_id = ?;

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -357,7 +357,12 @@ func registerAgentHandlers(d registrar, svc *Service) {
 			// which the frontend classifies as user_content and renders as markdown.
 			// When attachments are present, include their metadata (filename + mime_type)
 			// but not the raw binary data (too large for DB storage).
-			var payload interface{}
+			// A marshal failure must NOT fall through: innerJSON would stay nil and we'd
+			// compress + persist + broadcast an empty-content row (while still handing the
+			// agent the real content), silently corrupting the visible history. Fail the
+			// RPC instead so the caller can retry, mirroring the persist-failure path below.
+			var innerJSON []byte
+			var encErr error
 			if len(attachments) > 0 {
 				type attachmentMeta struct {
 					Filename string `json:"filename"`
@@ -367,17 +372,14 @@ func registerAgentHandlers(d registrar, svc *Service) {
 				for i, a := range attachments {
 					meta[i] = attachmentMeta{Filename: a.GetFilename(), MimeType: a.GetMimeType()}
 				}
-				payload = map[string]interface{}{"content": content, "attachments": meta}
+				// A different envelope, so it stays inline: userMessageContent encodes
+				// the {content} shape alone.
+				innerJSON, encErr = json.Marshal(map[string]interface{}{"content": content, "attachments": meta})
 			} else {
-				payload = map[string]string{"content": content}
+				innerJSON, encErr = userMessageContent(content)
 			}
-			// A marshal failure must NOT fall through: innerJSON would stay nil and we'd
-			// compress + persist + broadcast an empty-content row (while still handing the
-			// agent the real content), silently corrupting the visible history. Fail the
-			// RPC instead so the caller can retry, mirroring the persist-failure path below.
-			innerJSON, err := json.Marshal(payload)
-			if err != nil {
-				slog.Error("failed to encode user message", "agent_id", agentID, "error", err)
+			if encErr != nil {
+				slog.Error("failed to encode user message", "agent_id", agentID, "error", encErr)
 				sendInternalError(sender, "failed to encode message")
 				return
 			}
@@ -1318,7 +1320,7 @@ func (svc *Service) sendChildMessage(
 	persistChildUserRowWithDeliveryError := func(deliveryErr string) {
 		childMsgID := id.Generate()
 		nowChild := nowMillis()
-		innerJSON, mErr := json.Marshal(map[string]string{"content": r.GetContent()})
+		innerJSON, mErr := userMessageContent(r.GetContent())
 		if mErr != nil {
 			sendInternalError(sender, "failed to encode message")
 			return
@@ -2884,7 +2886,7 @@ func (svc *Service) persistSyntheticUserMessage(agentID string, provider leapmux
 		return
 	}
 
-	innerJSON, err := json.Marshal(map[string]string{"content": content})
+	innerJSON, err := userMessageContent(content)
 	if err != nil {
 		slog.Warn("synthetic user message: marshal failed", "agent_id", agentID, "error", err)
 		return
@@ -3032,7 +3034,7 @@ func (svc *Service) sendSyntheticUserMessage(agentID, content string, markType l
 
 	messageID := id.Generate()
 	now := nowMillis()
-	innerJSON, err := json.Marshal(map[string]string{"content": content})
+	innerJSON, err := userMessageContent(content)
 	if err != nil {
 		slog.Warn("synthetic user message: marshal failed", "agent_id", agentID, "error", err)
 		return

--- a/backend/internal/worker/service/output_bgtask.go
+++ b/backend/internal/worker/service/output_bgtask.go
@@ -95,10 +95,14 @@ func (h *OutputHandler) bgTaskOps() registryOps[bgtask.Item] {
 		// id back to (owner, row_key) -- the reverse lookup behind
 		// send-to-subagent and interrupt -- and the child agents row outlives the
 		// registry delete, so deleting the row leaves a subagent nobody can reach
-		// while its transcript is still readable. LookupBackgroundTask reads a
-		// retained row back through GetAgentBackgroundTaskByRowKey.
-		retainInStore: func(r bgtask.Item) bool { return r.ChildAgentID != "" },
-		cap:           bgtask.MaxTasks,
+		// while its transcript is still readable.
+		retention: &registryRetention[bgtask.Item]{
+			keep: func(r bgtask.Item) bool { return r.ChildAgentID != "" },
+			load: func(ctx context.Context, ownerID, key string) (bgtask.Item, bool, error) {
+				return h.loadStoredBgTask(ctx, ownerID, key)
+			},
+		},
+		cap: bgtask.MaxTasks,
 		// One cap pool per KIND. A run that opens hundreds of shells would
 		// otherwise evict every finished subagent, and the subagent rows are the
 		// ones carrying a transcript worth reopening.
@@ -106,6 +110,29 @@ func (h *OutputHandler) bgTaskOps() registryOps[bgtask.Item] {
 		buckets:  bgtask.KindWires(),
 		label:    "background tasks",
 	}
+}
+
+// loadStoredBgTask reads one persisted registry row by its PRIMARY KEY and
+// projects it into the in-memory shape. found=false for a row that does not
+// exist, so a caller tells "absent" from "unreadable" without inspecting the
+// error.
+//
+// This is the single reader for a row the display cache does not hold. Both
+// callers need it for the same reason -- the cap bounds the list, not the table
+// -- and one of them (registryOps.retention.load) is how every mutation reaches
+// a retained row.
+func (h *OutputHandler) loadStoredBgTask(ctx context.Context, ownerID, rowKey string) (bgtask.Item, bool, error) {
+	row, err := h.queries.GetAgentBackgroundTaskByRowKey(ctx, db.GetAgentBackgroundTaskByRowKeyParams{
+		OwnerAgentID: ownerID,
+		RowKey:       rowKey,
+	})
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return bgtask.Item{}, false, nil
+	case err != nil:
+		return bgtask.Item{}, false, fmt.Errorf("read background task %s/%s: %w", ownerID, rowKey, err)
+	}
+	return bgItemFromRow(row), true, nil
 }
 
 // bgTaskCache returns the per-root-agent cache, creating an empty (unseeded)
@@ -216,7 +243,10 @@ func (h *OutputHandler) applyBackgroundTaskStatus(rootAgentID, rowKey string, st
 	if err := cache.ensureSeededLocked(ctx, rootAgentID); err != nil {
 		return registryChange{}, err
 	}
-	idx := cache.indexOf(rowKey)
+	idx, err := cache.rowIndexLocked(ctx, rootAgentID, rowKey)
+	if err != nil {
+		return registryChange{}, err
+	}
 	if idx < 0 {
 		return registryChange{rows: cache.snapshot()}, nil
 	}
@@ -300,7 +330,10 @@ func (h *OutputHandler) applyBackgroundTaskClose(rootAgentID, rowKey string, sta
 	if err := cache.ensureSeededLocked(ctx, rootAgentID); err != nil {
 		return registryChange{}, err
 	}
-	idx := cache.indexOf(rowKey)
+	idx, err := cache.rowIndexLocked(ctx, rootAgentID, rowKey)
+	if err != nil {
+		return registryChange{}, err
+	}
 	if idx < 0 {
 		return registryChange{rows: cache.snapshot()}, nil
 	}
@@ -351,7 +384,10 @@ func (h *OutputHandler) applyBackgroundTaskRevive(rootAgentID, rowKey string) (r
 	if err := cache.ensureSeededLocked(ctx, rootAgentID); err != nil {
 		return registryChange{}, err
 	}
-	idx := cache.indexOf(rowKey)
+	idx, err := cache.rowIndexLocked(ctx, rootAgentID, rowKey)
+	if err != nil {
+		return registryChange{}, err
+	}
 	if idx < 0 {
 		return registryChange{rows: cache.snapshot()}, nil
 	}
@@ -1049,20 +1085,21 @@ func (s *agentOutputSink) LookupBackgroundTask(rowKey string) (string, bgtask.St
 	// subagents, EVERY revive of an older one would read "no such row", open a
 	// second transcript, and leave the real one unreachable. Fall through to the
 	// PRIMARY KEY, which is one indexed point lookup.
-	row, err := s.h.queries.GetAgentBackgroundTaskByRowKey(s.h.bgTaskCtx(), db.GetAgentBackgroundTaskByRowKeyParams{
-		OwnerAgentID: s.rootAgentID,
-		RowKey:       rowKey,
-	})
+	//
+	// This READS the retained row without re-admitting it to the display list,
+	// unlike the appliers: a lookup answers a question, and a question is not the
+	// activity that earns a place in the sidebar.
+	row, found, err := s.h.loadStoredBgTask(s.h.bgTaskCtx(), s.rootAgentID, rowKey)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return "", noStatus, false, nil
-		}
 		// A DB failure stays the THIRD answer, distinct from a miss, for the same
 		// reason the seed failure above does: a caller that reads "no such row"
 		// from a database it could not read treats a live subagent as brand new.
-		return "", noStatus, false, fmt.Errorf("read background task %s/%s: %w", s.rootAgentID, rowKey, err)
+		return "", noStatus, false, err
 	}
-	return row.ChildAgentID, bgtask.StatusFromWire(row.Status), true, nil
+	if !found {
+		return "", noStatus, false, nil
+	}
+	return row.ChildAgentID, row.Status, true, nil
 }
 
 // ReviveBackgroundTask returns a finished row to Running and lets the reopened
@@ -1218,7 +1255,16 @@ func (h *OutputHandler) applyBackgroundTaskUpsertLocked(cache *bgTaskCache, root
 	if err := cache.ensureSeededLocked(ctx, rootAgentID); err != nil {
 		return registryChange{}, err
 	}
-	idx := cache.indexOf(task.RowKey)
+	// rowIndexLocked, not indexOf: a RETAINED row that left the display list is
+	// an existing row, and taking it for a new one would skip the merge below --
+	// so a resumed session's replayed Running upsert would resurrect a finished
+	// subagent, and its title and created_at would be rewritten from the replay.
+	// The re-admit also makes room for itself, which is why the cap branch below
+	// only ever runs for a genuinely new row.
+	idx, err := cache.rowIndexLocked(ctx, rootAgentID, task.RowKey)
+	if err != nil {
+		return registryChange{}, err
+	}
 	// Set on the active -> final transition below, so an upsert that carries the
 	// final status writes the closing divider the same way a close does.
 	var endedChildID string
@@ -1258,35 +1304,28 @@ func (h *OutputHandler) applyBackgroundTaskUpsertLocked(cache *bgTaskCache, root
 		if existing.WithUpdatedAt(merged.UpdatedAt) == merged {
 			return registryChange{rows: cache.snapshot()}, nil
 		}
-	} else if bucket := bgtask.KindWire(merged.Kind); cache.atCapForBucket(bucket) {
-		// Scoped to the incoming row's kind, so making room for a shell never
-		// deletes a subagent (and the reverse).
-		_, evicted, err := cache.evictOldestFinishedInBucketLocked(ctx, rootAgentID, bucket)
+	} else {
+		// Room for the new row, scoped to its own KIND so making space for a
+		// shell never drops a subagent (and the reverse). Dropping the new row
+		// instead is not an option: it would orphan an already-created child
+		// agent row (EnsureChildAgent inserts the child before this upsert links
+		// it), leaving an unopenable transcript.
+		//
+		// A pool with no finished row gives up its oldest ACTIVE one. That needs
+		// no special case for the linkage, because retention keeps a linked row
+		// in the table -- the cap bounds what the sidebar shows, not what the
+		// registry indexes. An unlinked active row (a running shell) does lose
+		// its persisted row, which is the honest cost of a pool that is full of
+		// running work, and is what the warning records.
+		bucket := bgtask.KindWire(merged.Kind)
+		evictedRow, dropped, err := cache.makeRoomLocked(ctx, rootAgentID, bucket)
 		if err != nil {
 			return registryChange{}, err
 		}
-		if !evicted {
-			// At the cap with every row in the pool still active. Dropping the
-			// NEW row is not an option: it would orphan an already-created child
-			// agent row (EnsureChildAgent inserts the child before this upsert
-			// links it), leaving an unopenable transcript. So the oldest active
-			// row leaves the display list instead, whatever it carries.
-			//
-			// Its linkage is safe without a special case here, because
-			// retainInStore keeps a linked row in the table -- the cap is a bound
-			// on what the sidebar shows, not on what the registry indexes. An
-			// UNLINKED active row (a running shell) does lose its persisted row,
-			// which is the honest cost of a pool that is full of running work,
-			// and is what the warning records.
-			evictedRow, dropped, err := cache.evictOldestInBucketLocked(ctx, rootAgentID, bucket)
-			if err != nil {
-				return registryChange{}, err
-			}
-			if dropped {
-				slog.Warn("background task registry at cap with no finished row; dropping the oldest active row from the display list",
-					"owner", rootAgentID, "row_key", task.RowKey, "kind", bucket, "cap", bgtask.MaxTasks,
-					"evicted_row_key", evictedRow.RowKey, "retained_in_store", evictedRow.ChildAgentID != "")
-			}
+		if dropped && !evictedRow.Status.IsFinished() {
+			slog.Warn("background task registry at cap with no finished row; dropping the oldest active row from the display list",
+				"owner", rootAgentID, "row_key", task.RowKey, "kind", bucket, "cap", bgtask.MaxTasks,
+				"evicted_row_key", evictedRow.RowKey, "retained_in_store", evictedRow.ChildAgentID != "")
 		}
 	}
 	if idx < 0 {

--- a/backend/internal/worker/service/output_bgtask.go
+++ b/backend/internal/worker/service/output_bgtask.go
@@ -171,6 +171,13 @@ type registryChange struct {
 	// the divider reports what the applier actually wrote rather than what the
 	// caller asked for (an upsert can keep an existing final status instead).
 	endedStatus bgtask.Status
+	// revivedChildID is the child transcript this mutation REOPENED, or "" when
+	// the row stayed final, was already active, carries no child, or nothing
+	// changed. The mirror of endedChildID: a revive owes the transcript-close
+	// release exactly as an ending owes the divider, so both travel with the
+	// change and applyAndBroadcast performs both. A revive path cannot reach the
+	// registry and forget the release.
+	revivedChildID string
 }
 
 // applyBackgroundTaskUpsert is the persist-mutate-broadcast for an upsert. It
@@ -304,6 +311,75 @@ func (h *OutputHandler) applyBackgroundTaskClose(rootAgentID, rowKey string, sta
 		changed:      true,
 		endedChildID: cache.Rows[idx].ChildAgentID,
 		endedStatus:  status,
+	}, nil
+}
+
+// applyBackgroundTaskRevive returns a FINISHED row to Running and clears its
+// ended_at and its descriptive state, for a subagent that its provider
+// restarted. The change carries the child transcript the revive reopened, so
+// applyAndBroadcast releases that transcript's close claim.
+//
+// This is the ONLY applier that undoes a final status, and it stays separate
+// from the upsert and the status update on purpose. Those two absorb a non-final
+// status against a final row, and that guard must hold: a replayed running
+// upsert has no way to prove the task restarted, so honoring it would leave a
+// row Running that nothing closes and pin the parent's thinking indicator. A
+// caller reaches THIS applier only with positive evidence of a restart, so the
+// two cases never have to be told apart after the fact.
+//
+// Idempotent: an absent row and an already-active row both return an unchanged
+// no-op, which is what makes a duplicate revive harmless.
+func (h *OutputHandler) applyBackgroundTaskRevive(rootAgentID, rowKey string) (registryChange, error) {
+	ctx := h.bgTaskCtx()
+	cache := h.bgTaskCache(rootAgentID)
+	cache.Mu.Lock()
+	defer cache.Mu.Unlock()
+	if err := cache.ensureSeededLocked(ctx, rootAgentID); err != nil {
+		return registryChange{}, err
+	}
+	idx := cache.indexOf(rowKey)
+	if idx < 0 {
+		return registryChange{rows: cache.snapshot()}, nil
+	}
+	if !cache.Rows[idx].Status.IsFinished() {
+		return registryChange{rows: cache.snapshot()}, nil
+	}
+	// One ms-floored instant for the DB write and the cache, so a warm-cache read
+	// matches a cold-start read (no Go-time.Now-vs-SQLite drift).
+	now := nowMillis()
+	rows, err := h.queries.ReviveAgentBackgroundTask(ctx, db.ReviveAgentBackgroundTaskParams{
+		UpdatedAt:    sqltime.NewSQLiteTime(now),
+		OwnerAgentID: rootAgentID,
+		RowKey:       rowKey,
+	})
+	if err != nil {
+		return registryChange{}, err
+	}
+	if rows == 0 {
+		// The DB disagrees with the cache about this row being finished, and the DB
+		// decides. Report NO revive, so the transcript-close claim stays held for a
+		// transcript that never reopened -- but adopt the durable answer, because
+		// the UPDATE matched nothing only if the row is already active. Leaving the
+		// cache saying "finished" would keep every later broadcast and cold read
+		// disagreeing with the row until the worker restarts.
+		cache.Rows[idx].Status = bgtask.StatusRunning
+		cache.Rows[idx].EndedAt = time.Time{}
+		return registryChange{rows: cache.snapshot(), changed: true}, nil
+	}
+	cache.Rows[idx].Status = bgtask.StatusRunning
+	// ActiveForm and Description both describe the run that ENDED -- the last
+	// activity text, and the output file its task_notification named. The
+	// restarted run has reported neither yet, and the row's activity slot shows
+	// whichever is present, so leaving them pins the previous run's output path
+	// under a subagent that is running again.
+	cache.Rows[idx].ActiveForm = ""
+	cache.Rows[idx].Description = ""
+	cache.Rows[idx].EndedAt = time.Time{}
+	cache.Rows[idx].UpdatedAt = now
+	return registryChange{
+		rows:           cache.snapshot(),
+		changed:        true,
+		revivedChildID: cache.Rows[idx].ChildAgentID,
 	}, nil
 }
 
@@ -665,7 +741,7 @@ func (s *agentOutputSink) PersistChildPrompt(childAgentID, prompt string) error 
 	}
 	// The same envelope a typed user message uses, so the renderer needs no new
 	// shape: markdown body, USER source, no span.
-	content, err := json.Marshal(map[string]string{"content": prompt})
+	content, err := childUserMessageContent(prompt)
 	if err != nil {
 		return fmt.Errorf("marshal child prompt: %w", err)
 	}
@@ -673,13 +749,54 @@ func (s *agentOutputSink) PersistChildPrompt(childAgentID, prompt string) error 
 		leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, content, agent.SpanInfo{})
 }
 
+// childUserMessageContent encodes text as the transcript's user-message
+// envelope. One encoder for the opening prompt and for a delivered message, so
+// the wire shape has a single home in the service layer and no provider spells
+// it out.
+func childUserMessageContent(text string) ([]byte, error) {
+	return json.Marshal(map[string]string{"content": text})
+}
+
+// PersistChildUserMessage appends a delivered message to a child transcript.
+// See the OutputSink doc for the contract. Unlike PersistChildPrompt there is
+// NO emptiness guard: this message belongs wherever the transcript currently
+// ends, which is the point of it.
+func (s *agentOutputSink) PersistChildUserMessage(childAgentID, text string) error {
+	if childAgentID == "" || strings.TrimSpace(text) == "" {
+		return nil
+	}
+	content, err := childUserMessageContent(text)
+	if err != nil {
+		return fmt.Errorf("marshal child user message: %w", err)
+	}
+	return s.ChildSink(childAgentID).PersistMessage(
+		leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, content,
+		agent.SpanInfo{MarkType: leapmuxv1.MarkType_MARK_TYPE_USER_MESSAGE})
+}
+
 // claimSubagentTranscriptClose reports whether THIS caller owns the closing
 // divider for a subagent transcript.
 //
-// Exactly one divider closes a transcript, and TWO independent writers can end
-// one: the registry (whichever applier moved the row into a final status) and
-// the child's own turn end (a provider that forwards its subagent's closing
+// Exactly one divider closes each COMPLETION, and TWO independent writers can
+// end one: the registry (whichever applier moved the row into a final status)
+// and the child's own turn end (a provider that forwards its subagent's closing
 // envelope, like Claude's result). Either can arrive first.
+//
+// One completion, not one transcript: a subagent that its parent revives runs
+// again and ends again, so ReviveBackgroundTask releases the claim and the next
+// completion takes a fresh one. A transcript therefore holds as many dividers as
+// the subagent had runs.
+//
+// The key is the child id alone, and a run number cannot improve it. The second
+// writer is the child's own turn end (PersistTurnEnd), which holds s.agentID and
+// the envelope bytes and nothing else -- no run number rides on the wire. So a
+// generation-keyed claim would have to READ the current generation from the
+// registry, and a run-1 result that arrived after the revive would read run 2's
+// generation, take run 2's slot, and produce exactly what the plain key
+// produces: a divider in the middle of run 2 and none at its end. The ordered
+// stream is what keeps the two apart. One goroutine reads the CLI's stdout in
+// line order (processBase.readOutput) and both writers run inside that call, so
+// run 1's result is processed before the task_started that revives the subagent.
 //
 // A durable INSERT decides it, rather than each side reading the transcript's
 // last message and inferring what the other did. Two reasons the probes could
@@ -709,10 +826,11 @@ func (h *OutputHandler) claimSubagentTranscriptClose(ctx context.Context, childA
 // update, or a close, whichever the provider uses -- plus the process-exit
 // sweep and the boot sweep, which end rows no provider will ever close.
 //
-// Called exactly once per row: an applier reports endedChildID only on that
-// transition, and the DB's own status guard makes it hold across a worker
-// restart. A no-op for an empty id (a shell row, a re-close, or a subagent
-// whose provider never linked a transcript).
+// Called exactly once per active -> final transition: an applier reports
+// endedChildID only on that transition, and the DB's own status guard makes it
+// hold across a worker restart. A revived row transitions again, and writes
+// another divider then. A no-op for an empty id (a shell row, a re-close, or a
+// subagent whose provider never linked a transcript).
 //
 // The provider comes from the child's own agent row rather than from a caller:
 // createMessageRow refuses an UNSPECIFIED provider, and the sweeps have no sink
@@ -835,6 +953,17 @@ func (s *agentOutputSink) applyAndBroadcast(rowKey string, apply func(rootAgentI
 	// DB's own status guard makes that hold across a worker restart, so this
 	// runs exactly once per row and needs no emptiness check of its own.
 	s.h.persistSubagentEndDivider(change.endedChildID, change.endedStatus)
+	// The mirror write: a revive gives the transcript-close claim back, so the
+	// restarted run can take a fresh one and end with a divider of its own.
+	// Failing it is logged, never returned. The row is already committed and
+	// already broadcast by this point, so reporting an error here would tell the
+	// caller a revive that DID happen did not -- and Claude's caller answers that
+	// by dropping the message the parent just delivered.
+	if change.revivedChildID != "" {
+		if err := s.h.queries.ReleaseSubagentTranscriptClose(s.h.bgTaskCtx(), change.revivedChildID); err != nil {
+			slog.Warn("release subagent transcript close", "child", change.revivedChildID, "error", err)
+		}
+	}
 	return nil
 }
 
@@ -865,6 +994,49 @@ func (s *agentOutputSink) CloseBackgroundTask(rowKey string, status bgtask.Statu
 	return s.applyAndBroadcast(rowKey, func(root, key string) (registryChange, error) {
 		return s.h.applyBackgroundTaskClose(root, key, status)
 	})
+}
+
+func (s *agentOutputSink) LookupBackgroundTask(rowKey string) (string, bgtask.Status, bool, error) {
+	// The zero Status is StatusPending, a real value rather than an "unknown"
+	// sentinel, so a miss returns it alongside ok=false and callers must read ok.
+	var noStatus bgtask.Status
+	rowKey = bgtask.SanitizeRowKey(rowKey)
+	if rowKey == "" {
+		return "", noStatus, false, nil
+	}
+	cache := s.h.bgTaskCache(s.rootAgentID)
+	cache.Mu.Lock()
+	defer cache.Mu.Unlock()
+	// The seed failure is RETURNED, not folded into ok=false. It runs on the
+	// first registry touch of a process, which is exactly the state a worker
+	// restart leaves behind -- so the one call most likely to hit it is a revive
+	// for a subagent that finished in the previous process, and answering "no
+	// such row" there closes a live span and leaves the row finished.
+	if err := cache.ensureSeededLocked(s.h.bgTaskCtx(), s.rootAgentID); err != nil {
+		return "", noStatus, false, fmt.Errorf("seed background tasks for %s: %w", s.rootAgentID, err)
+	}
+	idx := cache.indexOf(rowKey)
+	if idx < 0 {
+		return "", noStatus, false, nil
+	}
+	return cache.Rows[idx].ChildAgentID, cache.Rows[idx].Status, true, nil
+}
+
+// ReviveBackgroundTask returns a finished row to Running and lets the reopened
+// transcript be closed again.
+//
+// The claim release is the second half of the revive and cannot be skipped: the
+// first completion durably claimed this transcript's closing divider, so without
+// the release the revived run would end with no divider at all. The applier
+// reports the reopened child on the change, and applyAndBroadcast performs the
+// release beside the ending divider -- so the two halves cannot come apart, and
+// a revive that changed nothing releases nothing.
+//
+// The error this returns therefore covers the REGISTRY write alone. That is what
+// the caller needs to know: it holds a one-shot arm, and only a failure to
+// reopen the row means the restart went unrecorded.
+func (s *agentOutputSink) ReviveBackgroundTask(rowKey string) error {
+	return s.applyAndBroadcast(rowKey, s.h.applyBackgroundTaskRevive)
 }
 
 // RenameBackgroundTask atomically re-keys a row from oldKey to newKey under the

--- a/backend/internal/worker/service/output_bgtask.go
+++ b/backend/internal/worker/service/output_bgtask.go
@@ -90,7 +90,15 @@ func (h *OutputHandler) bgTaskOps() registryOps[bgtask.Item] {
 			})
 			return err
 		},
-		cap: bgtask.MaxTasks,
+		// A row that carries a child transcript leaves the DISPLAY list at the
+		// cap but stays in the table. It is the only index from that child agent
+		// id back to (owner, row_key) -- the reverse lookup behind
+		// send-to-subagent and interrupt -- and the child agents row outlives the
+		// registry delete, so deleting the row leaves a subagent nobody can reach
+		// while its transcript is still readable. LookupBackgroundTask reads a
+		// retained row back through GetAgentBackgroundTaskByRowKey.
+		retainInStore: func(r bgtask.Item) bool { return r.ChildAgentID != "" },
+		cap:           bgtask.MaxTasks,
 		// One cap pool per KIND. A run that opens hundreds of shells would
 		// otherwise evict every finished subagent, and the subagent rows are the
 		// ones carrying a transcript worth reopening.
@@ -133,10 +141,16 @@ func (h *OutputHandler) broadcastBackgroundTasks(rootAgentID string, rows []bgta
 	})
 }
 
-// LoadBackgroundTasks returns the root's registry, seeding the in-memory cache
-// from agent_background_tasks on first access. Cold-start RPCs route through
-// here so a warm cache returns without a DB read. For a CHILD agent this
+// LoadBackgroundTasks returns the root's DISPLAY list, seeding the in-memory
+// cache from agent_background_tasks on first access. Cold-start RPCs route
+// through here so a warm cache returns without a DB read. For a CHILD agent this
 // returns empty (children own no registry).
+//
+// The list is capped at bgtask.MaxTasks per kind and is NOT exhaustive: a row
+// that carries a child transcript stays in the table after it leaves this list
+// (see registryOps.retainInStore), so it is invisible in the sidebar and still
+// resolvable by key. A caller that needs the linkage must query the table --
+// LookupBackgroundTask and GetAgentBackgroundTaskByChildAgentID both do.
 func (h *OutputHandler) LoadBackgroundTasks(ctx context.Context, rootAgentID string) ([]bgtask.Item, error) {
 	cache := h.bgTaskCache(rootAgentID)
 	cache.Mu.Lock()
@@ -405,32 +419,34 @@ func (h *OutputHandler) MarkAgentBackgroundTasksExited(rootAgentID string, stopp
 		status = bgtask.StatusStopped
 	}
 	now := nowMillis()
-	if _, err := h.queries.MarkAgentBackgroundTasksEnded(ctx, db.MarkAgentBackgroundTasksEndedParams{
+	// The children this sweep just ended come from the WRITE, not from a scan of
+	// the cache. The cache holds the capped display list, so a row past the cap
+	// or below the seed window is ended in the DB and absent here -- and a
+	// cache-derived list would leave that subagent's transcript with no closing
+	// divider, permanently. Without a divider a subagent whose owner process died
+	// keeps a transcript that simply stops.
+	endedChildIDs, err := h.queries.MarkAgentBackgroundTasksEnded(ctx, db.MarkAgentBackgroundTasksEndedParams{
 		Status:       bgtask.StatusWire(status),
 		EndedAt:      sqltime.SQLiteNullTimeOf(now),
 		UpdatedAt:    sqltime.NewSQLiteTime(now),
 		OwnerAgentID: rootAgentID,
-	}); err != nil {
+	})
+	if err != nil {
 		cache.Mu.Unlock()
 		slog.Warn("mark background tasks ended failed", "agent_id", rootAgentID, "error", err)
 		return
 	}
+	// The cache catches up to the write it just made, so the broadcast below
+	// reports the display list the DB now holds. `changed` is the CACHE's answer
+	// on purpose: a row the display list never held moved nothing the client can
+	// see.
 	changed := false
-	// The children this sweep just ended. Collected here, under the lock, on the
-	// same "was still active" test that decides the write -- so each transcript
-	// gets its closing divider exactly once, for the same reason a registry
-	// mutation does. Without this a subagent whose owner process died would keep
-	// a transcript that simply stops.
-	var endedChildIDs []string
 	for i := range cache.Rows {
 		if !cache.Rows[i].Status.IsFinished() {
 			cache.Rows[i].Status = status
 			cache.Rows[i].EndedAt = now
 			cache.Rows[i].UpdatedAt = now
 			changed = true
-			if cache.Rows[i].ChildAgentID != "" {
-				endedChildIDs = append(endedChildIDs, cache.Rows[i].ChildAgentID)
-			}
 		}
 	}
 	// Snapshot under the lock; broadcast AFTER release so a slow/stalled gRPC
@@ -1006,20 +1022,47 @@ func (s *agentOutputSink) LookupBackgroundTask(rowKey string) (string, bgtask.St
 	}
 	cache := s.h.bgTaskCache(s.rootAgentID)
 	cache.Mu.Lock()
-	defer cache.Mu.Unlock()
 	// The seed failure is RETURNED, not folded into ok=false. It runs on the
 	// first registry touch of a process, which is exactly the state a worker
 	// restart leaves behind -- so the one call most likely to hit it is a revive
 	// for a subagent that finished in the previous process, and answering "no
 	// such row" there closes a live span and leaves the row finished.
 	if err := cache.ensureSeededLocked(s.h.bgTaskCtx(), s.rootAgentID); err != nil {
+		cache.Mu.Unlock()
 		return "", noStatus, false, fmt.Errorf("seed background tasks for %s: %w", s.rootAgentID, err)
 	}
-	idx := cache.indexOf(rowKey)
-	if idx < 0 {
-		return "", noStatus, false, nil
+	if idx := cache.indexOf(rowKey); idx >= 0 {
+		childID, status := cache.Rows[idx].ChildAgentID, cache.Rows[idx].Status
+		cache.Mu.Unlock()
+		return childID, status, true, nil
 	}
-	return cache.Rows[idx].ChildAgentID, cache.Rows[idx].Status, true, nil
+	// The lock is released BEFORE the DB read, the way ensureChildAgentLocked
+	// releases it around its own: this miss path runs on every FIRST task_started
+	// too (no row exists yet), so holding the mutex across the round trip would
+	// serialize a burst of spawns behind one another. Nothing is mutated here,
+	// and the write order elsewhere is DB-then-cache, so an insert that lands in
+	// the gap is visible to this read rather than lost by it.
+	cache.Mu.Unlock()
+	// The cache holds only what the sidebar shows -- the newest MaxTasks rows of
+	// each kind -- and a row that carries a child transcript outlives that cap in
+	// the table. So a cache miss is not an answer yet: past MaxTasks finished
+	// subagents, EVERY revive of an older one would read "no such row", open a
+	// second transcript, and leave the real one unreachable. Fall through to the
+	// PRIMARY KEY, which is one indexed point lookup.
+	row, err := s.h.queries.GetAgentBackgroundTaskByRowKey(s.h.bgTaskCtx(), db.GetAgentBackgroundTaskByRowKeyParams{
+		OwnerAgentID: s.rootAgentID,
+		RowKey:       rowKey,
+	})
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", noStatus, false, nil
+		}
+		// A DB failure stays the THIRD answer, distinct from a miss, for the same
+		// reason the seed failure above does: a caller that reads "no such row"
+		// from a database it could not read treats a live subagent as brand new.
+		return "", noStatus, false, fmt.Errorf("read background task %s/%s: %w", s.rootAgentID, rowKey, err)
+	}
+	return row.ChildAgentID, bgtask.StatusFromWire(row.Status), true, nil
 }
 
 // ReviveBackgroundTask returns a finished row to Running and lets the reopened
@@ -1082,7 +1125,7 @@ func (s *agentOutputSink) RenameBackgroundTask(oldKey, newKey string) error {
 	// re-created row Running for the life of the process, which pinned the
 	// parent's thinking indicator. The row already at newKey is the complete one --
 	// it carries the lifecycle that reached the rename -- so the DUPLICATE at
-	// oldKey loses and is deleted.
+	// oldKey loses and leaves the display list.
 	occupied, err := s.h.queries.CountAgentBackgroundTasksByRowKey(ctx, db.CountAgentBackgroundTasksByRowKeyParams{
 		OwnerAgentID: s.rootAgentID,
 		RowKey:       newKey,
@@ -1096,12 +1139,32 @@ func (s *agentOutputSink) RenameBackgroundTask(oldKey, newKey string) error {
 			cache.Mu.Unlock()
 			return nil
 		}
-		if _, err := s.h.queries.DeleteAgentBackgroundTaskByRowKey(ctx, db.DeleteAgentBackgroundTaskByRowKeyParams{
+		// Whether the loser's PERSISTED row goes with it is the question
+		// eviction asks, and the answer is the same: a row that carries a child
+		// transcript is the only index from that child agent id back to
+		// (owner, row_key), so it is retained and only hidden. No caller reaches
+		// this with a linked row today -- the ACP providers that rename
+		// (OpenCode, Kilo) drop child sessions over ACP and never report a
+		// ChildAgentKey -- but the invariant belongs to every row, not to the
+		// ones a caller happens to produce.
+		loser, err := s.h.queries.GetAgentBackgroundTaskByRowKey(ctx, db.GetAgentBackgroundTaskByRowKeyParams{
 			OwnerAgentID: s.rootAgentID,
 			RowKey:       oldKey,
-		}); err != nil {
+		})
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+			// Already gone; the cache drop below is all that is left to do.
+		case err != nil:
 			cache.Mu.Unlock()
 			return err
+		case loser.ChildAgentID == "":
+			if _, err := s.h.queries.DeleteAgentBackgroundTaskByRowKey(ctx, db.DeleteAgentBackgroundTaskByRowKeyParams{
+				OwnerAgentID: s.rootAgentID,
+				RowKey:       oldKey,
+			}); err != nil {
+				cache.Mu.Unlock()
+				return err
+			}
 		}
 		if cache.dropRowLocked(oldKey) {
 			pendingBroadcast = cache.snapshot()
@@ -1203,33 +1266,26 @@ func (h *OutputHandler) applyBackgroundTaskUpsertLocked(cache *bgTaskCache, root
 			return registryChange{}, err
 		}
 		if !evicted {
-			// At the cap with no finished row to evict. Dropping the new row
-			// would orphan an already-created child agent row (EnsureChildAgent
-			// inserts the child before this upsert links it), leaving an
-			// unopenable transcript. Evict an older row instead. Prefer the
-			// oldest row that carries NO child linkage: evicting a linked row
-			// would make that child permanently unsteerable (the registry row
-			// is the only index from child id -> owner+rowKey, and the child
-			// agents row survives the registry delete). When every active row
-			// is linked to a child transcript, exceed the cap rather than
-			// orphan a steerable child -- the cap is a soft bound to protect
-			// the child-linkage invariant.
-			slog.Warn("background task registry at cap with no finished row; evicting oldest unlinked active row",
-				"owner", rootAgentID, "row_key", task.RowKey, "kind", bucket, "cap", bgtask.MaxTasks)
-			evictIdx := -1
-			for i, r := range cache.Rows {
-				if bgtask.KindWire(r.Kind) == bucket && r.ChildAgentID == "" {
-					evictIdx = i
-					break
-				}
+			// At the cap with every row in the pool still active. Dropping the
+			// NEW row is not an option: it would orphan an already-created child
+			// agent row (EnsureChildAgent inserts the child before this upsert
+			// links it), leaving an unopenable transcript. So the oldest active
+			// row leaves the display list instead, whatever it carries.
+			//
+			// Its linkage is safe without a special case here, because
+			// retainInStore keeps a linked row in the table -- the cap is a bound
+			// on what the sidebar shows, not on what the registry indexes. An
+			// UNLINKED active row (a running shell) does lose its persisted row,
+			// which is the honest cost of a pool that is full of running work,
+			// and is what the warning records.
+			evictedRow, dropped, err := cache.evictOldestInBucketLocked(ctx, rootAgentID, bucket)
+			if err != nil {
+				return registryChange{}, err
 			}
-			if evictIdx >= 0 {
-				if _, _, err := cache.evictAtLocked(ctx, rootAgentID, evictIdx); err != nil {
-					return registryChange{}, err
-				}
-			} else {
-				slog.Warn("background task registry at cap with all active rows linked to children; exceeding cap to avoid orphaning a steerable child",
-					"owner", rootAgentID, "row_key", task.RowKey, "kind", bucket, "cap", bgtask.MaxTasks)
+			if dropped {
+				slog.Warn("background task registry at cap with no finished row; dropping the oldest active row from the display list",
+					"owner", rootAgentID, "row_key", task.RowKey, "kind", bucket, "cap", bgtask.MaxTasks,
+					"evicted_row_key", evictedRow.RowKey, "retained_in_store", evictedRow.ChildAgentID != "")
 			}
 		}
 	}

--- a/backend/internal/worker/service/output_bgtask.go
+++ b/backend/internal/worker/service/output_bgtask.go
@@ -101,6 +101,13 @@ func (h *OutputHandler) bgTaskOps() registryOps[bgtask.Item] {
 			load: func(ctx context.Context, ownerID, key string) (bgtask.Item, bool, error) {
 				return h.loadStoredBgTask(ctx, ownerID, key)
 			},
+			reseq: func(ctx context.Context, ownerID, key string, seq int64) error {
+				return h.queries.ResequenceAgentBackgroundTask(ctx, db.ResequenceAgentBackgroundTaskParams{
+					Seq:          seq,
+					OwnerAgentID: ownerID,
+					RowKey:       key,
+				})
+			},
 		},
 		cap: bgtask.MaxTasks,
 		// One cap pool per KIND. A run that opens hundreds of shells would
@@ -118,7 +125,7 @@ func (h *OutputHandler) bgTaskOps() registryOps[bgtask.Item] {
 // error.
 //
 // This is the single reader for a row the display cache does not hold. Both
-// callers need it for the same reason -- the cap bounds the list, not the table
+// callers need it for the same reason -- the cap limits the list, not the table
 // -- and one of them (registryOps.retention.load) is how every mutation reaches
 // a retained row.
 func (h *OutputHandler) loadStoredBgTask(ctx context.Context, ownerID, rowKey string) (bgtask.Item, bool, error) {
@@ -175,7 +182,7 @@ func (h *OutputHandler) broadcastBackgroundTasks(rootAgentID string, rows []bgta
 //
 // The list is capped at bgtask.MaxTasks per kind and is NOT exhaustive: a row
 // that carries a child transcript stays in the table after it leaves this list
-// (see registryOps.retainInStore), so it is invisible in the sidebar and still
+// (see registryOps.retention), so it is invisible in the sidebar and still
 // resolvable by key. A caller that needs the linkage must query the table --
 // LookupBackgroundTask and GetAgentBackgroundTaskByChildAgentID both do.
 func (h *OutputHandler) LoadBackgroundTasks(ctx context.Context, rootAgentID string) ([]bgtask.Item, error) {
@@ -232,10 +239,26 @@ func (h *OutputHandler) applyBackgroundTaskUpsert(rootAgentID string, task bgtas
 	return h.applyBackgroundTaskUpsertLocked(cache, rootAgentID, task)
 }
 
-// applyBackgroundTaskStatus updates a row's status + active_form without
-// closing it (used for running-progress updates). A no-op when the row is
-// absent or the patch is a no-op.
-func (h *OutputHandler) applyBackgroundTaskStatus(rootAgentID, rowKey string, status bgtask.Status, activeForm string) (registryChange, error) {
+// withBgTaskRow runs `mutate` against the registry row at rowKey, under the
+// root's cache mutex and with the cache seeded. A no-op for a row that exists
+// nowhere.
+//
+// One prologue for every applier that patches an EXISTING row, so the seeding
+// rule, the lookup rule, and the "no such row" answer have a single home. The
+// upsert applier is deliberately not a caller: it runs under a lock the caller
+// already holds, and its miss branch inserts instead of answering no-op.
+//
+// `mutate` receives the resolved row and an `admit` function, and it must call
+// `admit` at the point where it commits to a write. That order is the contract:
+// a retained row that left the display list is not put back for a mutation that
+// turns out to be a no-op, because re-admitting evicts a displayed row -- and
+// deletes an unlinked one from the table -- and the applier then reports
+// changed=false, so no broadcast tells the client its list moved. `admit` is
+// also the only route to a cache index, so an applier cannot write without it.
+func (h *OutputHandler) withBgTaskRow(
+	rootAgentID, rowKey string,
+	mutate func(ctx context.Context, cache *bgTaskCache, row bgtask.Item, displayed bool, admit func() (int, error)) (registryChange, error),
+) (registryChange, error) {
 	ctx := h.bgTaskCtx()
 	cache := h.bgTaskCache(rootAgentID)
 	cache.Mu.Lock()
@@ -243,122 +266,134 @@ func (h *OutputHandler) applyBackgroundTaskStatus(rootAgentID, rowKey string, st
 	if err := cache.ensureSeededLocked(ctx, rootAgentID); err != nil {
 		return registryChange{}, err
 	}
-	idx, err := cache.rowIndexLocked(ctx, rootAgentID, rowKey)
+	row, idx, found, err := cache.findRowLocked(ctx, rootAgentID, rowKey)
 	if err != nil {
 		return registryChange{}, err
 	}
-	if idx < 0 {
+	if !found {
 		return registryChange{rows: cache.snapshot()}, nil
 	}
-	existing := cache.Rows[idx]
-	// A final status is monotonic and absorbing: a late or replayed
-	// non-final status update (a duplicate task_progress, a replayed
-	// running upsert) must not resurrect a row that already reached a
-	// final state. Without this guard the row flips back to running and
-	// pins the parent's thinking indicator forever (no later close arrives).
-	if existing.Status.IsFinished() && !status.IsFinished() {
-		return registryChange{rows: cache.snapshot()}, nil
+	admit := func() (int, error) {
+		if idx >= 0 {
+			return idx, nil
+		}
+		var err error
+		idx, err = cache.admitRowLocked(ctx, rootAgentID, row)
+		return idx, err
 	}
-	if existing.Status == status && existing.ActiveForm == activeForm {
-		return registryChange{rows: cache.snapshot()}, nil
-	}
-	// One ms-floored instant for both the DB write and the in-memory cache, so a
-	// warm-cache read after this transition returns the same stamp a cold-start
-	// read does (no Go-time.Now-vs-SQLite-strftime drift).
-	now := nowMillis()
-	if err := h.queries.UpdateAgentBackgroundTaskStatus(ctx, db.UpdateAgentBackgroundTaskStatusParams{
-		Status:       bgtask.StatusWire(status),
-		ActiveForm:   activeForm,
-		UpdatedAt:    sqltime.NewSQLiteTime(now),
-		OwnerAgentID: rootAgentID,
-		RowKey:       rowKey,
-	}); err != nil {
-		return registryChange{}, err
-	}
-	// A transition into a final status stamps ended_at. The status-update query does not
-	// (sqlc cannot infer the type of a positional parameter inside a CASE WHEN,
-	// so the atomic single-statement form is not generatable), so a dedicated
-	// idempotent query does it. The stamp's WHERE filters `ended_at IS NULL AND
-	// status IN (the final statuses)`, so it only writes on a genuine transition. On a
-	// transient DB error the cache leaves EndedAt zero (mirroring the DB's NULL)
-	// and the error propagates so the caller sees the incomplete transition;
-	// the idempotent stamp can be retried by any later final update.
-	if status.IsFinished() {
-		if err := h.queries.StampAgentBackgroundTaskEndedAt(ctx, db.StampAgentBackgroundTaskEndedAtParams{
-			EndedAt:      sqltime.SQLiteNullTimeOf(now),
+	return mutate(ctx, cache, row, idx >= 0, admit)
+}
+
+// applyBackgroundTaskStatus updates a row's status + active_form without
+// closing it (used for running-progress updates). A no-op when the row is
+// absent or the patch is a no-op.
+func (h *OutputHandler) applyBackgroundTaskStatus(rootAgentID, rowKey string, status bgtask.Status, activeForm string) (registryChange, error) {
+	return h.withBgTaskRow(rootAgentID, rowKey, func(ctx context.Context, cache *bgTaskCache, existing bgtask.Item, displayed bool, admit func() (int, error)) (registryChange, error) {
+		// A final status is monotonic and absorbing: a late or replayed
+		// non-final status update (a duplicate task_progress, a replayed
+		// running upsert) must not resurrect a row that already reached a
+		// final state. Without this guard the row flips back to running and
+		// pins the parent's thinking indicator forever (no later close arrives).
+		if existing.Status.IsFinished() && !status.IsFinished() {
+			return registryChange{rows: cache.snapshot()}, nil
+		}
+		if existing.Status == status && existing.ActiveForm == activeForm {
+			return registryChange{rows: cache.snapshot()}, nil
+		}
+		idx, err := admit()
+		if err != nil {
+			return registryChange{}, err
+		}
+		// One ms-floored instant for both the DB write and the in-memory cache, so a
+		// warm-cache read after this transition returns the same stamp a cold-start
+		// read does (no Go-time.Now-vs-SQLite-strftime drift).
+		now := nowMillis()
+		if err := h.queries.UpdateAgentBackgroundTaskStatus(ctx, db.UpdateAgentBackgroundTaskStatusParams{
+			Status:       bgtask.StatusWire(status),
+			ActiveForm:   activeForm,
+			UpdatedAt:    sqltime.NewSQLiteTime(now),
 			OwnerAgentID: rootAgentID,
 			RowKey:       rowKey,
 		}); err != nil {
 			return registryChange{}, err
 		}
-		if cache.Rows[idx].EndedAt.IsZero() {
-			cache.Rows[idx].EndedAt = now
+		// A transition into a final status stamps ended_at. The status-update query does not
+		// (sqlc cannot infer the type of a positional parameter inside a CASE WHEN,
+		// so the atomic single-statement form is not generatable), so a dedicated
+		// idempotent query does it. The stamp's WHERE filters `ended_at IS NULL AND
+		// status IN (the final statuses)`, so it only writes on a genuine transition. On a
+		// transient DB error the cache leaves EndedAt zero (mirroring the DB's NULL)
+		// and the error propagates so the caller sees the incomplete transition;
+		// the idempotent stamp can be retried by any later final update.
+		if status.IsFinished() {
+			if err := h.queries.StampAgentBackgroundTaskEndedAt(ctx, db.StampAgentBackgroundTaskEndedAtParams{
+				EndedAt:      sqltime.SQLiteNullTimeOf(now),
+				OwnerAgentID: rootAgentID,
+				RowKey:       rowKey,
+			}); err != nil {
+				return registryChange{}, err
+			}
+			if cache.Rows[idx].EndedAt.IsZero() {
+				cache.Rows[idx].EndedAt = now
+			}
 		}
-	}
-	// Read the row's PRIOR status before the write overwrites it: the divider is
-	// owed to the active -> final transition alone.
-	wasFinished := cache.Rows[idx].Status.IsFinished()
-	cache.Rows[idx].Status = status
-	cache.Rows[idx].ActiveForm = activeForm
-	cache.Rows[idx].UpdatedAt = now
-	// The guards above exclude an already-final row only when the incoming status
-	// is non-final, or when BOTH the status and the activeForm repeat. A second
-	// final update carrying the same status and a different activeForm reaches
-	// here -- Claude sends exactly that, a summary-bearing update followed by a
-	// bare one -- so the transition is tested against the prior status rather
-	// than assumed. Reporting the child twice writes the closing divider twice.
-	var endedChildID string
-	if !wasFinished && status.IsFinished() {
-		endedChildID = cache.Rows[idx].ChildAgentID
-	}
-	return registryChange{
-		rows:         cache.snapshot(),
-		changed:      true,
-		endedChildID: endedChildID,
-		endedStatus:  status,
-	}, nil
+		// Read the row's PRIOR status before the write overwrites it: the divider is
+		// owed to the active -> final transition alone.
+		wasFinished := cache.Rows[idx].Status.IsFinished()
+		cache.Rows[idx].Status = status
+		cache.Rows[idx].ActiveForm = activeForm
+		cache.Rows[idx].UpdatedAt = now
+		// The guards above exclude an already-final row only when the incoming status
+		// is non-final, or when BOTH the status and the activeForm repeat. A second
+		// final update carrying the same status and a different activeForm reaches
+		// here -- Claude sends exactly that, a summary-bearing update followed by a
+		// bare one -- so the transition is tested against the prior status rather
+		// than assumed. Reporting the child twice writes the closing divider twice.
+		var endedChildID string
+		if !wasFinished && status.IsFinished() {
+			endedChildID = cache.Rows[idx].ChildAgentID
+		}
+		return registryChange{
+			rows:         cache.snapshot(),
+			changed:      true,
+			endedChildID: endedChildID,
+			endedStatus:  status,
+		}, nil
+	})
 }
 
 // applyBackgroundTaskClose moves a row into a final status (stamps ended_at).
 // The query's status-IN('pending','running') guard means a final row can never
 // be resurrected or re-closed. A no-op when the row is already final.
 func (h *OutputHandler) applyBackgroundTaskClose(rootAgentID, rowKey string, status bgtask.Status) (registryChange, error) {
-	ctx := h.bgTaskCtx()
-	cache := h.bgTaskCache(rootAgentID)
-	cache.Mu.Lock()
-	defer cache.Mu.Unlock()
-	if err := cache.ensureSeededLocked(ctx, rootAgentID); err != nil {
-		return registryChange{}, err
-	}
-	idx, err := cache.rowIndexLocked(ctx, rootAgentID, rowKey)
-	if err != nil {
-		return registryChange{}, err
-	}
-	if idx < 0 {
-		return registryChange{rows: cache.snapshot()}, nil
-	}
-	if cache.Rows[idx].Status.IsFinished() {
-		return registryChange{rows: cache.snapshot()}, nil
-	}
-	now := nowMillis()
-	if err := h.queries.CloseAgentBackgroundTask(ctx, db.CloseAgentBackgroundTaskParams{
-		Status:       bgtask.StatusWire(status),
-		EndedAt:      sqltime.SQLiteNullTimeOf(now),
-		UpdatedAt:    sqltime.NewSQLiteTime(now),
-		OwnerAgentID: rootAgentID,
-		RowKey:       rowKey,
-	}); err != nil {
-		return registryChange{}, err
-	}
-	cache.Rows[idx].Status = status
-	cache.Rows[idx].EndedAt = now
-	cache.Rows[idx].UpdatedAt = now
-	return registryChange{
-		rows:         cache.snapshot(),
-		changed:      true,
-		endedChildID: cache.Rows[idx].ChildAgentID,
-		endedStatus:  status,
-	}, nil
+	return h.withBgTaskRow(rootAgentID, rowKey, func(ctx context.Context, cache *bgTaskCache, existing bgtask.Item, displayed bool, admit func() (int, error)) (registryChange, error) {
+		if existing.Status.IsFinished() {
+			return registryChange{rows: cache.snapshot()}, nil
+		}
+		idx, err := admit()
+		if err != nil {
+			return registryChange{}, err
+		}
+		now := nowMillis()
+		if err := h.queries.CloseAgentBackgroundTask(ctx, db.CloseAgentBackgroundTaskParams{
+			Status:       bgtask.StatusWire(status),
+			EndedAt:      sqltime.SQLiteNullTimeOf(now),
+			UpdatedAt:    sqltime.NewSQLiteTime(now),
+			OwnerAgentID: rootAgentID,
+			RowKey:       rowKey,
+		}); err != nil {
+			return registryChange{}, err
+		}
+		cache.Rows[idx].Status = status
+		cache.Rows[idx].EndedAt = now
+		cache.Rows[idx].UpdatedAt = now
+		return registryChange{
+			rows:         cache.snapshot(),
+			changed:      true,
+			endedChildID: cache.Rows[idx].ChildAgentID,
+			endedStatus:  status,
+		}, nil
+	})
 }
 
 // applyBackgroundTaskRevive returns a FINISHED row to Running and clears its
@@ -377,59 +412,110 @@ func (h *OutputHandler) applyBackgroundTaskClose(rootAgentID, rowKey string, sta
 // Idempotent: an absent row and an already-active row both return an unchanged
 // no-op, which is what makes a duplicate revive harmless.
 func (h *OutputHandler) applyBackgroundTaskRevive(rootAgentID, rowKey string) (registryChange, error) {
-	ctx := h.bgTaskCtx()
-	cache := h.bgTaskCache(rootAgentID)
-	cache.Mu.Lock()
-	defer cache.Mu.Unlock()
-	if err := cache.ensureSeededLocked(ctx, rootAgentID); err != nil {
-		return registryChange{}, err
-	}
-	idx, err := cache.rowIndexLocked(ctx, rootAgentID, rowKey)
-	if err != nil {
-		return registryChange{}, err
-	}
-	if idx < 0 {
-		return registryChange{rows: cache.snapshot()}, nil
-	}
-	if !cache.Rows[idx].Status.IsFinished() {
-		return registryChange{rows: cache.snapshot()}, nil
-	}
-	// One ms-floored instant for the DB write and the cache, so a warm-cache read
-	// matches a cold-start read (no Go-time.Now-vs-SQLite drift).
-	now := nowMillis()
-	rows, err := h.queries.ReviveAgentBackgroundTask(ctx, db.ReviveAgentBackgroundTaskParams{
-		UpdatedAt:    sqltime.NewSQLiteTime(now),
-		OwnerAgentID: rootAgentID,
-		RowKey:       rowKey,
-	})
-	if err != nil {
-		return registryChange{}, err
-	}
-	if rows == 0 {
-		// The DB disagrees with the cache about this row being finished, and the DB
-		// decides. Report NO revive, so the transcript-close claim stays held for a
-		// transcript that never reopened -- but adopt the durable answer, because
-		// the UPDATE matched nothing only if the row is already active. Leaving the
-		// cache saying "finished" would keep every later broadcast and cold read
-		// disagreeing with the row until the worker restarts.
+	return h.withBgTaskRow(rootAgentID, rowKey, func(ctx context.Context, cache *bgTaskCache, existing bgtask.Item, displayed bool, admit func() (int, error)) (registryChange, error) {
+		if !existing.Status.IsFinished() {
+			return registryChange{rows: cache.snapshot()}, nil
+		}
+		// One ms-floored instant for the DB write and the cache, so a warm-cache read
+		// matches a cold-start read (no Go-time.Now-vs-SQLite drift).
+		now := nowMillis()
+		rows, err := h.queries.ReviveAgentBackgroundTask(ctx, db.ReviveAgentBackgroundTaskParams{
+			UpdatedAt:    sqltime.NewSQLiteTime(now),
+			OwnerAgentID: rootAgentID,
+			RowKey:       rowKey,
+		})
+		if err != nil {
+			return registryChange{}, err
+		}
+		if rows == 0 {
+			return h.adoptStoredBgTaskRowLocked(ctx, cache, rootAgentID, rowKey, displayed, admit)
+		}
+		idx, err := admit()
+		if err != nil {
+			return registryChange{}, err
+		}
 		cache.Rows[idx].Status = bgtask.StatusRunning
+		// ActiveForm and Description both describe the run that ENDED -- the last
+		// activity text, and the output file its task_notification specified. The
+		// restarted run reported neither yet, and the row's activity slot shows
+		// whichever is present, so leaving them pins the previous run's output path
+		// under a subagent that runs again.
+		cache.Rows[idx].ActiveForm = ""
+		cache.Rows[idx].Description = ""
 		cache.Rows[idx].EndedAt = time.Time{}
-		return registryChange{rows: cache.snapshot(), changed: true}, nil
+		cache.Rows[idx].UpdatedAt = now
+		return registryChange{
+			rows:           cache.snapshot(),
+			changed:        true,
+			revivedChildID: cache.Rows[idx].ChildAgentID,
+		}, nil
+	})
+}
+
+// adoptStoredBgTaskRowLocked replaces a cached row with what the store holds,
+// for a revive whose UPDATE matched nothing. Caller must hold cache.Mu.
+//
+// The revive's WHERE filters on a final status, so a zero row count means the
+// cache and the row disagree, and the row decides. It does NOT mean "the row is
+// already active": the same count answers "no such row", and the two need
+// different repairs. Re-reading settles it without a second guess, and it also
+// adopts every field rather than the two a hand-written repair remembered --
+// active_form and description describe the run that ENDED, and the SQL clears
+// them for exactly that reason.
+//
+// The re-read also decides the transcript-close claim, which the caller cannot.
+// A stored row that is ACTIVE and carries a child IS a reopened transcript, so
+// the restarted run owes a closing divider and the claim the first completion
+// took has to go back. Guessing the other way is the worse error, and this file
+// already says so where it fails the claim OPEN on a DB error: "a missing
+// divider leaves a transcript that never visibly ends, with a thinking indicator
+// that never resolves, which is worse than a duplicated rule."
+//
+// A stored row that is still FINISHED reopened nothing and releases nothing.
+// That combination needs a race to reach -- the UPDATE matched no final row, so
+// something closed it between the two statements -- but the test is on the row
+// rather than on the count, because the count alone cannot tell the two apart.
+//
+// The repair is for the DISPLAY list only. A retained row that left the list has
+// no cached copy to disagree with the store, so there is nothing to adopt and
+// nothing to broadcast -- and admitting it would evict a displayed row, and
+// delete an unlinked one, for a write that never happens.
+func (h *OutputHandler) adoptStoredBgTaskRowLocked(
+	ctx context.Context, cache *bgTaskCache, rootAgentID, rowKey string, displayed bool, admit func() (int, error),
+) (registryChange, error) {
+	if !displayed {
+		return registryChange{rows: cache.snapshot()}, nil
 	}
-	cache.Rows[idx].Status = bgtask.StatusRunning
-	// ActiveForm and Description both describe the run that ENDED -- the last
-	// activity text, and the output file its task_notification named. The
-	// restarted run has reported neither yet, and the row's activity slot shows
-	// whichever is present, so leaving them pins the previous run's output path
-	// under a subagent that is running again.
-	cache.Rows[idx].ActiveForm = ""
-	cache.Rows[idx].Description = ""
-	cache.Rows[idx].EndedAt = time.Time{}
-	cache.Rows[idx].UpdatedAt = now
+	stored, found, err := h.loadStoredBgTask(ctx, rootAgentID, rowKey)
+	if err != nil {
+		return registryChange{}, err
+	}
+	if !found {
+		// The row is gone (a cascade from its root agent, or a delete that raced
+		// this call). Drop the stale cache entry rather than leave the display list
+		// showing a row no cold read returns. dropRowLocked touches no DB row,
+		// which is correct: there is none left to delete.
+		//
+		// The drop runs BEFORE the snapshot. Go evaluates a composite literal's
+		// fields in order, so building both in one expression would capture the
+		// list with the dead row still in it and broadcast that.
+		dropped := cache.dropRowLocked(rowKey)
+		return registryChange{rows: cache.snapshot(), changed: dropped}, nil
+	}
+	idx, err := admit()
+	if err != nil {
+		return registryChange{}, err
+	}
+	changed := cache.Rows[idx] != stored
+	cache.Rows[idx] = stored
+	revivedChildID := ""
+	if !stored.Status.IsFinished() {
+		revivedChildID = stored.ChildAgentID
+	}
 	return registryChange{
 		rows:           cache.snapshot(),
-		changed:        true,
-		revivedChildID: cache.Rows[idx].ChildAgentID,
+		changed:        changed,
+		revivedChildID: revivedChildID,
 	}, nil
 }
 
@@ -604,6 +690,27 @@ func (s *agentOutputSink) ensureChildAgentLocked(ctx context.Context, spawnSpanI
 	cache.Mu.Unlock()
 
 	// 2. DB work OUTSIDE the lock.
+	// The retained row is the SECOND answer to the fast path's question, and it
+	// belongs here rather than above it: the store read is DB work, and this
+	// function exists to keep DB work off the per-root mutex.
+	//
+	// The display list alone answered "no transcript" for every linked row past
+	// the cap, and the spawn-span lookup below then missed too, so the call
+	// CREATED a second transcript and re-pointed the durable row at it. Codex
+	// reaches that state routinely: a collab call that re-registers a closed
+	// thread hands EnsureChildAgent a NEW spawn span, so the spawn span cannot
+	// find the child the first run made. This reads the row without re-admitting
+	// it, which is right -- a question is not the activity that earns a place in
+	// the sidebar.
+	if providerChildKey != "" {
+		row, found, err := s.h.loadStoredBgTask(ctx, s.rootAgentID, providerChildKey)
+		if err != nil {
+			return "", err
+		}
+		if found && row.ChildAgentID != "" {
+			return row.ChildAgentID, nil
+		}
+	}
 	// Fallback: GetChildAgentBySpawnSpan covers a worker restart between the
 	// agent-row insert and the registry upsert. parent_agent_id for the new row
 	// is THIS sink's agentID (works for grandchild spawns too: the spawn span
@@ -691,11 +798,36 @@ func (s *agentOutputSink) linkRegistryRow(cache *bgTaskCache, providerChildKey, 
 	if providerChildKey == "" {
 		return
 	}
+	// The store half of the re-check runs BEFORE the lock, for the reason
+	// ensureChildAgentLocked states: DB work stays off the per-root mutex. "First
+	// linker wins" is an invariant of the ROW, so a linked row past the display
+	// cap has to answer it too -- reading the display list alone made the guard
+	// fall through for exactly those rows and let this call re-point the durable
+	// child_agent_id at the losing child.
+	//
+	// A read failure keeps the guard: it cannot prove the row is unlinked, and
+	// overwriting a linkage that exists costs the transcript the subagent has,
+	// while skipping a link the row lacks costs one a later event repeats.
+	//
+	// The residual window is narrow and is the price of the lock discipline: a
+	// concurrent linker that commits between this read and the lock, for a row
+	// the display list does not hold, is invisible to both halves of the guard.
+	// The cache re-check below closes that window for every displayed row, which
+	// is every row of all but the largest sessions.
+	stored, storedFound, err := s.h.loadStoredBgTask(s.h.bgTaskCtx(), s.rootAgentID, providerChildKey)
+	if err != nil {
+		slog.Warn("link registry row: read failed", "row_key", providerChildKey, "error", err)
+		return
+	}
 	cache.Mu.Lock()
 	defer cache.Mu.Unlock()
 	// Re-check: a concurrent EnsureChildAgent for the same key may have committed
 	// while this caller's DB work ran unlocked. If so, do not overwrite.
-	if idx := cache.indexOf(providerChildKey); idx >= 0 && cache.Rows[idx].ChildAgentID != "" {
+	if idx := cache.indexOf(providerChildKey); idx >= 0 {
+		if cache.Rows[idx].ChildAgentID != "" {
+			return
+		}
+	} else if storedFound && stored.ChildAgentID != "" {
 		return
 	}
 	*pendingBroadcast = s.ensureRegistryRowLocked(cache, providerChildKey, childID, title)
@@ -793,7 +925,7 @@ func (s *agentOutputSink) PersistChildPrompt(childAgentID, prompt string) error 
 	}
 	// The same envelope a typed user message uses, so the renderer needs no new
 	// shape: markdown body, USER source, no span.
-	content, err := childUserMessageContent(prompt)
+	content, err := userMessageContent(prompt)
 	if err != nil {
 		return fmt.Errorf("marshal child prompt: %w", err)
 	}
@@ -801,11 +933,18 @@ func (s *agentOutputSink) PersistChildPrompt(childAgentID, prompt string) error 
 		leapmuxv1.MessageSource_MESSAGE_SOURCE_USER, content, agent.SpanInfo{})
 }
 
-// childUserMessageContent encodes text as the transcript's user-message
-// envelope. One encoder for the opening prompt and for a delivered message, so
-// the wire shape has a single home in the service layer and no provider spells
-// it out.
-func childUserMessageContent(text string) ([]byte, error) {
+// userMessageContent encodes text as a transcript's user-message envelope: the
+// shape the frontend classifies as user_content and renders as markdown.
+//
+// The one encoder for every user row the service writes -- a child's opening
+// prompt, a message the parent delivered to a subagent, a typed message, a
+// resend, and each backend-synthesized row. The shape is a wire contract with
+// the renderer, so five hand-written copies of it could be changed in four
+// places and drift in the fifth.
+//
+// Not for a message that carries attachments: that row is a different envelope
+// ({content, attachments}) and its one caller builds it inline.
+func userMessageContent(text string) ([]byte, error) {
 	return json.Marshal(map[string]string{"content": text})
 }
 
@@ -817,7 +956,7 @@ func (s *agentOutputSink) PersistChildUserMessage(childAgentID, text string) err
 	if childAgentID == "" || strings.TrimSpace(text) == "" {
 		return nil
 	}
-	content, err := childUserMessageContent(text)
+	content, err := userMessageContent(text)
 	if err != nil {
 		return fmt.Errorf("marshal child user message: %w", err)
 	}
@@ -898,7 +1037,7 @@ func (h *OutputHandler) persistSubagentEndDivider(childAgentID string, status bg
 		slog.Warn("subagent end divider: child agent not found", "child", childAgentID, "error", err)
 		return
 	}
-	// Exactly ONE divider closes a subagent transcript. A provider that forwards
+	// Exactly ONE divider closes each RUN of a subagent. A provider that forwards
 	// its subagent's own closing envelope (Claude's result) draws a richer one --
 	// it carries the duration, and on failure the error label and detail -- so it
 	// claims first when it gets there first, and this neutral divider stands
@@ -1052,8 +1191,16 @@ func (s *agentOutputSink) LookupBackgroundTask(rowKey string) (string, bgtask.St
 	// The zero Status is StatusPending, a real value rather than an "unknown"
 	// sentinel, so a miss returns it alongside ok=false and callers must read ok.
 	var noStatus bgtask.Status
-	rowKey = bgtask.SanitizeRowKey(rowKey)
-	if rowKey == "" {
+	// Checked and passed through unchanged, never rewritten, exactly as the
+	// mutation path checks it: a rewrite is not injective, so two provider keys
+	// could map onto one string and this lookup would answer for the wrong row.
+	//
+	// A key that fails the check is a MISS, not an error. The error return of
+	// this method means "the registry could not be read", and a caller that gets
+	// it holds a live subagent it must not treat as new. A malformed key is the
+	// opposite: the registry is fine and no row can carry that key, which is
+	// what ok=false already says.
+	if err := bgtask.ValidateRowKey(rowKey); err != nil || rowKey == "" {
 		return "", noStatus, false, nil
 	}
 	cache := s.h.bgTaskCache(s.rootAgentID)
@@ -1176,34 +1323,22 @@ func (s *agentOutputSink) RenameBackgroundTask(oldKey, newKey string) error {
 			cache.Mu.Unlock()
 			return nil
 		}
-		// Whether the loser's PERSISTED row goes with it is the question
-		// eviction asks, and the answer is the same: a row that carries a child
-		// transcript is the only index from that child agent id back to
-		// (owner, row_key), so it is retained and only hidden. No caller reaches
-		// this with a linked row today -- the ACP providers that rename
-		// (OpenCode, Kilo) drop child sessions over ACP and never report a
-		// ChildAgentKey -- but the invariant belongs to every row, not to the
-		// ones a caller happens to produce.
-		loser, err := s.h.queries.GetAgentBackgroundTaskByRowKey(ctx, db.GetAgentBackgroundTaskByRowKeyParams{
-			OwnerAgentID: s.rootAgentID,
-			RowKey:       oldKey,
-		})
-		switch {
-		case errors.Is(err, sql.ErrNoRows):
-			// Already gone; the cache drop below is all that is left to do.
-		case err != nil:
+		// deleteRowLocked, not a delete of this caller's own: whether the loser's
+		// PERSISTED row goes with it is the question eviction asks, and the answer
+		// is the same, so both ask registryRetention.keep through one function. A
+		// row that carries a child transcript is the only index from that child
+		// agent id back to (owner, row_key), so it is retained and only hidden. No
+		// caller reaches this with a linked row today -- the ACP providers that
+		// rename (OpenCode, Kilo) drop child sessions over ACP and never report a
+		// ChildAgentKey -- but the invariant belongs to every row, not to the ones
+		// a caller happens to produce, and the next delete path added must not
+		// have to remember it.
+		dropped, err := cache.deleteRowLocked(ctx, s.rootAgentID, oldKey)
+		if err != nil {
 			cache.Mu.Unlock()
 			return err
-		case loser.ChildAgentID == "":
-			if _, err := s.h.queries.DeleteAgentBackgroundTaskByRowKey(ctx, db.DeleteAgentBackgroundTaskByRowKeyParams{
-				OwnerAgentID: s.rootAgentID,
-				RowKey:       oldKey,
-			}); err != nil {
-				cache.Mu.Unlock()
-				return err
-			}
 		}
-		if cache.dropRowLocked(oldKey) {
+		if dropped {
 			pendingBroadcast = cache.snapshot()
 		}
 		cache.Mu.Unlock()
@@ -1255,13 +1390,13 @@ func (h *OutputHandler) applyBackgroundTaskUpsertLocked(cache *bgTaskCache, root
 	if err := cache.ensureSeededLocked(ctx, rootAgentID); err != nil {
 		return registryChange{}, err
 	}
-	// rowIndexLocked, not indexOf: a RETAINED row that left the display list is
+	// findRowLocked, not indexOf: a RETAINED row that left the display list is
 	// an existing row, and taking it for a new one would skip the merge below --
 	// so a resumed session's replayed Running upsert would resurrect a finished
 	// subagent, and its title and created_at would be rewritten from the replay.
-	// The re-admit also makes room for itself, which is why the cap branch below
+	// `found` and not `idx >= 0` decides that, which is why the cap branch below
 	// only ever runs for a genuinely new row.
-	idx, err := cache.rowIndexLocked(ctx, rootAgentID, task.RowKey)
+	existing, idx, found, err := cache.findRowLocked(ctx, rootAgentID, task.RowKey)
 	if err != nil {
 		return registryChange{}, err
 	}
@@ -1273,8 +1408,7 @@ func (h *OutputHandler) applyBackgroundTaskUpsertLocked(cache *bgTaskCache, root
 	now := nowMillis()
 	merged := task.ToItem()
 	merged.UpdatedAt = now
-	if idx >= 0 {
-		existing := cache.Rows[idx]
+	if found {
 		merged.CreatedAt = existing.CreatedAt
 		merged.EndedAt = existing.EndedAt
 		// Preserve descriptive fields the incoming upsert left blank so a partial
@@ -1304,6 +1438,16 @@ func (h *OutputHandler) applyBackgroundTaskUpsertLocked(cache *bgTaskCache, root
 		if existing.WithUpdatedAt(merged.UpdatedAt) == merged {
 			return registryChange{rows: cache.snapshot()}, nil
 		}
+		// The write is committed, so a retained row earns its place back in the
+		// display list. AFTER the no-op guard, never before: re-admitting evicts a
+		// displayed row, and a byte-identical replay would then churn the sidebar
+		// on the server while reporting changed=false, so no broadcast tells the
+		// client its list moved.
+		if idx < 0 {
+			if idx, err = cache.admitRowLocked(ctx, rootAgentID, existing); err != nil {
+				return registryChange{}, err
+			}
+		}
 	} else {
 		// Room for the new row, scoped to its own KIND so making space for a
 		// shell never drops a subagent (and the reverse). Dropping the new row
@@ -1313,7 +1457,7 @@ func (h *OutputHandler) applyBackgroundTaskUpsertLocked(cache *bgTaskCache, root
 		//
 		// A pool with no finished row gives up its oldest ACTIVE one. That needs
 		// no special case for the linkage, because retention keeps a linked row
-		// in the table -- the cap bounds what the sidebar shows, not what the
+		// in the table -- the cap limits what the sidebar shows, not what the
 		// registry indexes. An unlinked active row (a running shell) does lose
 		// its persisted row, which is the honest cost of a pool that is full of
 		// running work, and is what the warning records.
@@ -1328,7 +1472,7 @@ func (h *OutputHandler) applyBackgroundTaskUpsertLocked(cache *bgTaskCache, root
 				"evicted_row_key", evictedRow.RowKey, "retained_in_store", evictedRow.ChildAgentID != "")
 		}
 	}
-	if idx < 0 {
+	if !found {
 		merged.CreatedAt = now
 		// A row that is born final never had an active phase, so it ends its
 		// child transcript here -- the only transition it will ever have.
@@ -1361,7 +1505,7 @@ func (h *OutputHandler) applyBackgroundTaskUpsertLocked(cache *bgTaskCache, root
 	}); err != nil {
 		return registryChange{}, err
 	}
-	if idx < 0 {
+	if !found {
 		cache.Rows = append(cache.Rows, merged)
 		cache.nextSeq++
 	} else {

--- a/backend/internal/worker/service/output_bgtasks_test.go
+++ b/backend/internal/worker/service/output_bgtasks_test.go
@@ -564,6 +564,37 @@ func TestBgTask_RenameOntoOccupiedKeyDropsTheDuplicate(t *testing.T) {
 	assert.Equal(t, "completed", rows[0].Status, "the surviving row keeps its final status")
 }
 
+// The losing duplicate leaves the display list, but its PERSISTED row goes only
+// when it carries no child. A row that names a transcript is that child's one
+// index back to (owner, row_key), and the rename is no more entitled to destroy
+// it than eviction is. No provider reaches this today -- OpenCode and Kilo are
+// the only renamers, and both drop child sessions over ACP -- so the invariant
+// is pinned here rather than left to the callers that happen to exist.
+func TestBgTask_RenameOntoOccupiedKeyRetainsALinkedDuplicate(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc, sink, ownerID, listRows := setupBgTaskTestWithService(t)
+	require.NoError(t, sink.UpsertBackgroundTask(bgtask.Upsert{
+		RowKey: "sess-stable", Kind: bgtask.KindSubagent, Title: "spawn", Status: bgtask.StatusRunning,
+	}))
+	require.NoError(t, sink.CloseBackgroundTask("sess-stable", bgtask.StatusCompleted))
+	require.NoError(t, sink.UpsertBackgroundTask(bgtask.Upsert{
+		RowKey: "spawn-key", Kind: bgtask.KindSubagent, Title: "spawn",
+		ChildAgentID: "child-1", Status: bgtask.StatusRunning,
+	}))
+
+	require.NoError(t, sink.RenameBackgroundTask("spawn-key", "sess-stable"))
+
+	assert.NotContains(t, displayedRowKeys(t, svc, ownerID), "spawn-key",
+		"the duplicate leaves the display list either way")
+	assert.Contains(t, rowKeySet(listRows()), "spawn-key",
+		"its row is retained, because it names a transcript")
+	row, err := svc.Queries.GetAgentBackgroundTaskByChildAgentID(ctx, "child-1")
+	require.NoError(t, err, "the child keeps its index")
+	assert.Equal(t, "spawn-key", row.RowKey)
+}
+
 // TestBgTask_RenameOnColdCacheRekeysDBRow verifies the rename seeds the cache
 // BEFORE re-keying it: a rename arriving as the first registry touch for a root
 // (after a worker restart emptied the in-memory cache) must still re-key the
@@ -1230,4 +1261,158 @@ func TestBgTask_SeedKeepsTheNewestRowsPastTheCap(t *testing.T) {
 		RowKey: "agent-after-reseed", Kind: bgtask.KindSubagent,
 		Title: "post-restart", Status: bgtask.StatusRunning,
 	}))
+}
+
+// --- Writes against a row that outlived the display cap ---
+//
+// The cap made the cache a PARTIAL view of the table, so every applier that
+// reads `indexOf` and treats a miss as "no such row" now has a second answer to
+// give: the row is retained, it is just not displayed. These three lock that
+// down, one per applier.
+
+// storedRow reads one persisted row by key, failing the test when it is absent.
+// The DISPLAY list cannot answer for a retained row, which is the point of every
+// test that uses this.
+func storedRow(t *testing.T, svc *Service, ownerID, rowKey string) db.AgentBackgroundTask {
+	t.Helper()
+	row, err := svc.Queries.GetAgentBackgroundTaskByRowKey(context.Background(),
+		db.GetAgentBackgroundTaskByRowKeyParams{OwnerAgentID: ownerID, RowKey: rowKey})
+	require.NoError(t, err, "no persisted row %q", rowKey)
+	return row
+}
+
+// A final status is absorbing wherever the row lives. A resumed session
+// re-announces every task it once ran with a Running upsert, and the guard that
+// drops it sits on the cached branch -- so a retained row took the replay as an
+// INSERT, and the subagent's finished row came back Running with nothing left to
+// close it.
+func TestBgTask_ReplayedRunningUpsertCannotResurrectARetainedRow(t *testing.T) {
+	t.Parallel()
+
+	svc, sink, ownerID, _ := setupBgTaskTestWithService(t)
+	require.NoError(t, sink.UpsertBackgroundTask(bgtask.Upsert{
+		RowKey: "task-1", Kind: bgtask.KindSubagent, Title: "SCAN",
+		ChildAgentID: "child-1", Status: bgtask.StatusRunning,
+	}))
+	require.NoError(t, sink.CloseBackgroundTask("task-1", bgtask.StatusCompleted))
+	fillSubagentDisplayCap(t, sink, bgtask.MaxTasks)
+	require.NotContains(t, displayedRowKeys(t, svc, ownerID), "task-1",
+		"the row must have left the display list")
+	endedAt := storedRow(t, svc, ownerID, "task-1").EndedAt
+
+	require.NoError(t, sink.UpsertBackgroundTask(bgtask.Upsert{
+		RowKey: "task-1", Kind: bgtask.KindSubagent, Title: "SCAN",
+		ChildAgentID: "child-1", Status: bgtask.StatusRunning,
+	}))
+
+	row := storedRow(t, svc, ownerID, "task-1")
+	assert.Equal(t, "completed", row.Status, "the replay must not resurrect the row")
+	assert.Equal(t, endedAt, row.EndedAt, "ended_at survives the replay")
+}
+
+// A progress update for a retained row has to land on it. Dropping it left the
+// row Running in the table for the life of the process, and a reseed then put a
+// stale Running subagent back in the sidebar.
+func TestBgTask_StatusUpdateReachesARetainedRow(t *testing.T) {
+	t.Parallel()
+
+	svc, sink, ownerID, _ := setupBgTaskTestWithService(t)
+	_, err := sink.EnsureChildAgent("span-1", "task-1", "SCAN")
+	require.NoError(t, err)
+	fillSubagentDisplayCap(t, sink, bgtask.MaxTasks)
+	require.NotContains(t, displayedRowKeys(t, svc, ownerID), "task-1",
+		"the row must have left the display list")
+
+	require.NoError(t, sink.UpdateBackgroundTaskStatus("task-1", bgtask.StatusRunning, "running Bash"))
+
+	assert.Equal(t, "running Bash", storedRow(t, svc, ownerID, "task-1").ActiveForm)
+}
+
+// The close is the half that ends the subagent, and it owes the child
+// transcript its divider. A dropped close left the row Running AND the
+// transcript with no ending -- until the next boot swept it, which is not the
+// same run and not the same status.
+func TestBgTask_CloseReachesARetainedRowAndEndsItsTranscript(t *testing.T) {
+	t.Parallel()
+
+	svc, sink, ownerID, _ := setupBgTaskTestWithService(t)
+	childID, err := sink.EnsureChildAgent("span-1", "task-1", "SCAN")
+	require.NoError(t, err)
+	fillSubagentDisplayCap(t, sink, bgtask.MaxTasks)
+	require.NotContains(t, displayedRowKeys(t, svc, ownerID), "task-1",
+		"the row must have left the display list")
+
+	require.NoError(t, sink.CloseBackgroundTask("task-1", bgtask.StatusCompleted))
+
+	row := storedRow(t, svc, ownerID, "task-1")
+	assert.Equal(t, "completed", row.Status)
+	assert.True(t, row.EndedAt.Valid, "the close stamps ended_at")
+
+	msgs := transcriptMessages(t, svc, childID)
+	require.Len(t, msgs, 1, "the child transcript gets its closing divider")
+	assert.Equal(t, agent.NotificationTypeSubagentEnded, msgs[0]["type"])
+	assert.Equal(t, "completed", msgs[0]["status"])
+}
+
+// The revive is the applier the whole change exists for: a Claude SendMessage
+// restarts a subagent whose row left the display list long ago. Dropping it left
+// the row finished while the subagent ran again, so the sidebar and the tab chip
+// read "completed" for the whole second run.
+func TestBgTask_ReviveReachesARetainedRow(t *testing.T) {
+	t.Parallel()
+
+	svc, sink, ownerID, _ := setupBgTaskTestWithService(t)
+	_, err := sink.EnsureChildAgent("span-1", "task-1", "SCAN")
+	require.NoError(t, err)
+	require.NoError(t, sink.CloseBackgroundTask("task-1", bgtask.StatusCompleted))
+	fillSubagentDisplayCap(t, sink, bgtask.MaxTasks)
+	require.NotContains(t, displayedRowKeys(t, svc, ownerID), "task-1",
+		"the row must have left the display list")
+
+	require.NoError(t, sink.ReviveBackgroundTask("task-1"))
+
+	row := storedRow(t, svc, ownerID, "task-1")
+	assert.Equal(t, "running", row.Status, "the subagent is running again")
+	assert.False(t, row.EndedAt.Valid, "the revive clears ended_at")
+}
+
+// Re-admission is what makes a mutation reach a retained row, and it must not
+// buy that by growing the list. The row comes back at the END, because a row a
+// mutation just touched is the newest activity the registry has.
+func TestBgTask_ReAdmittingARetainedRowHoldsTheDisplayCap(t *testing.T) {
+	t.Parallel()
+
+	svc, sink, ownerID, _ := setupBgTaskTestWithService(t)
+	_, err := sink.EnsureChildAgent("span-1", "task-1", "SCAN")
+	require.NoError(t, err)
+	fillSubagentDisplayCap(t, sink, bgtask.MaxTasks)
+	require.NotContains(t, displayedRowKeys(t, svc, ownerID), "task-1")
+
+	require.NoError(t, sink.UpdateBackgroundTaskStatus("task-1", bgtask.StatusRunning, "running Bash"))
+
+	displayed := displayedRowKeys(t, svc, ownerID)
+	assert.Len(t, displayed, bgtask.MaxTasks, "the cap holds across a re-admission")
+	require.NotEmpty(t, displayed)
+	assert.Equal(t, "task-1", displayed[len(displayed)-1],
+		"the touched row is the newest entry in the list")
+	assert.NotContains(t, displayed, "filler-0", "the oldest entry left to make room")
+}
+
+// A registry with no retention (agent_todos) must not gain a store fallback:
+// its cap IS a storage bound, and a key it does not hold identifies nothing.
+// The bgtask registry proves the other half, so this pins the nil branch of
+// rowIndexLocked that every todo mutation takes.
+func TestTodos_AnAbsentRowStaysAMissWithNoRetention(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc, _, _ := setupTestService(t)
+	cache := svc.Output.todoCache("agent-1")
+	cache.Mu.Lock()
+	defer cache.Mu.Unlock()
+	require.Nil(t, cache.ops.retention, "agent_todos retains nothing past its cap")
+
+	idx, err := cache.rowIndexLocked(ctx, "agent-1", "todo-nope")
+	require.NoError(t, err)
+	assert.Equal(t, -1, idx, "no store fallback runs for a registry without retention")
 }

--- a/backend/internal/worker/service/output_bgtasks_test.go
+++ b/backend/internal/worker/service/output_bgtasks_test.go
@@ -23,6 +23,17 @@ import (
 // Mirrors setupTodoTest.
 func setupBgTaskTest(t *testing.T) (agent.OutputSink, string, func() []db.AgentBackgroundTask) {
 	t.Helper()
+	_, sink, ownerID, listRows := setupBgTaskTestWithService(t)
+	return sink, ownerID, listRows
+}
+
+// setupBgTaskTestWithService is setupBgTaskTest for a test that also reads the
+// DISPLAY list, which only the service can answer. The two lists are no longer
+// the same: the cap bounds what LoadBackgroundTasks returns, and a row that
+// carries a child transcript stays in the table after it leaves that list, so
+// listRows (the table) and displayedRowKeys (the list) disagree by design.
+func setupBgTaskTestWithService(t *testing.T) (*Service, agent.OutputSink, string, func() []db.AgentBackgroundTask) {
+	t.Helper()
 	ctx := context.Background()
 	svc, _, _ := setupTestService(t)
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
@@ -40,7 +51,30 @@ func setupBgTaskTest(t *testing.T) (agent.OutputSink, string, func() []db.AgentB
 		require.NoError(t, err)
 		return rows
 	}
-	return sink, "agent-1", listRows
+	return svc, sink, "agent-1", listRows
+}
+
+// displayedRowKeys returns the row keys of the capped display list -- what the
+// sidebar shows and what a client receives -- in cache order.
+func displayedRowKeys(t *testing.T, svc *Service, ownerID string) []string {
+	t.Helper()
+	items, err := svc.Output.LoadBackgroundTasks(context.Background(), ownerID)
+	require.NoError(t, err)
+	keys := make([]string, len(items))
+	for i, item := range items {
+		keys[i] = item.RowKey
+	}
+	return keys
+}
+
+// rowKeySet collapses persisted rows to a set of their keys for a Contains /
+// NotContains assertion.
+func rowKeySet(rows []db.AgentBackgroundTask) map[string]struct{} {
+	keys := make(map[string]struct{}, len(rows))
+	for _, r := range rows {
+		keys[r.RowKey] = struct{}{}
+	}
+	return keys
 }
 
 func TestBgTask_UpsertCreatesRowAndBroadcasts(t *testing.T) {
@@ -315,23 +349,15 @@ func TestBgTask_CapNoFinishedRowEvictsOldestActive(t *testing.T) {
 	assert.Contains(t, keys, "task-new", "new row linked")
 }
 
-// TestBgTask_CapAllActiveLinkedPreservesChildLinkage verifies the cap-eviction
-// path never deletes a row that carries a child_agent_id: doing so would make
-// that child permanently unsteerable (the registry row is the only index from
-// child id -> owner+rowKey, and the agents row survives the delete). When every
-// active row is linked, the cap is exceeded instead of orphaning a child.
-func TestBgTask_CapAllActiveLinkedPreservesChildLinkage(t *testing.T) {
+// TestBgTask_CapAllActiveLinkedHoldsTheDisplayCap verifies that a pool full of
+// linked ACTIVE rows still respects the cap on the display list. The cap used to
+// be exceeded here to keep a linked row's index alive; that trade is gone,
+// because the row now survives eviction in the table on its own.
+func TestBgTask_CapAllActiveLinkedHoldsTheDisplayCap(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	svc, _, _ := setupTestService(t)
-	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
-		ID:            "agent-linked",
-		WorkingDir:    t.TempDir(),
-		HomeDir:       t.TempDir(),
-		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
-	}))
-	sink := svc.Output.NewSink("agent-linked", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)
+	svc, sink, ownerID, listRows := setupBgTaskTestWithService(t)
 	// Seed MaxTasks running rows, each linked to a distinct child transcript.
 	for i := 1; i <= bgtask.MaxTasks; i++ {
 		require.NoError(t, sink.UpsertBackgroundTask(bgtask.Upsert{
@@ -343,8 +369,6 @@ func TestBgTask_CapAllActiveLinkedPreservesChildLinkage(t *testing.T) {
 		}))
 	}
 
-	// Insert one more at the cap with no finished row: every active row is
-	// linked, so the cap is exceeded rather than orphaning a steerable child.
 	require.NoError(t, sink.UpsertBackgroundTask(bgtask.Upsert{
 		RowKey:       "task-new",
 		Kind:         bgtask.KindSubagent,
@@ -353,54 +377,127 @@ func TestBgTask_CapAllActiveLinkedPreservesChildLinkage(t *testing.T) {
 		Status:       bgtask.StatusRunning,
 	}))
 
-	rows, err := svc.Queries.ListAgentBackgroundTasksNewestFirst(ctx, db.ListAgentBackgroundTasksNewestFirstParams{
-		OwnerAgentID: "agent-linked", Limit: 1000,
-	})
-	require.NoError(t, err)
-	assert.Len(t, rows, bgtask.MaxTasks+1, "cap exceeded rather than orphaning a linked child")
+	displayed := displayedRowKeys(t, svc, ownerID)
+	assert.Len(t, displayed, bgtask.MaxTasks, "the display list holds its cap")
+	assert.NotContains(t, displayed, "task-1", "the oldest row left the display list")
+	assert.Contains(t, displayed, "task-new")
 
-	// Every child linkage survives -- none were evicted.
+	// The table keeps every row, so no child lost its index.
+	assert.Len(t, listRows(), bgtask.MaxTasks+1, "the evicted row is retained in the table")
 	for i := 1; i <= bgtask.MaxTasks; i++ {
 		_, err := svc.Queries.GetAgentBackgroundTaskByChildAgentID(ctx, fmt.Sprintf("child-%d", i))
-		assert.NoError(t, err, "child-%d linkage preserved (not evicted)", i)
+		assert.NoError(t, err, "child-%d linkage preserved", i)
 	}
 }
 
-// TestBgTask_CapAllActiveEvictsOldestUnlinked verifies that when the cap is hit
-// with no finished row and SOME active rows are unlinked, eviction takes the
-// oldest UNLINKED row (not the oldest linked one), preserving child steerability.
-func TestBgTask_CapAllActiveEvictsOldestUnlinked(t *testing.T) {
+// TestBgTask_CapAllActiveEvictsTheOldestWhateverItCarries verifies the rule that
+// replaced "prefer an unlinked row": at the cap with no finished row, the OLDEST
+// active row leaves the display list, and its linkage alone decides whether the
+// persisted row goes with it.
+func TestBgTask_CapAllActiveEvictsTheOldestWhateverItCarries(t *testing.T) {
 	t.Parallel()
 
-	sink, _, listRows := setupBgTaskTest(t)
-	// task-1: unlinked (evict candidate). task-2: linked (must survive).
+	svc, sink, ownerID, listRows := setupBgTaskTestWithService(t)
+	// task-1: linked and oldest. task-2: unlinked, and under the old rule it
+	// would have been evicted in task-1's place.
 	require.NoError(t, sink.UpsertBackgroundTask(bgtask.Upsert{
-		RowKey: "task-1", Kind: bgtask.KindSubagent, Title: "unlinked", Status: bgtask.StatusRunning,
+		RowKey: "task-1", Kind: bgtask.KindSubagent, Title: "linked", ChildAgentID: "child-1", Status: bgtask.StatusRunning,
 	}))
 	require.NoError(t, sink.UpsertBackgroundTask(bgtask.Upsert{
-		RowKey: "task-2", Kind: bgtask.KindSubagent, Title: "linked", ChildAgentID: "child-2", Status: bgtask.StatusRunning,
+		RowKey: "task-2", Kind: bgtask.KindSubagent, Title: "unlinked", Status: bgtask.StatusRunning,
 	}))
-	// Fill the rest of the cap with linked rows.
 	for i := 3; i <= bgtask.MaxTasks; i++ {
 		require.NoError(t, sink.UpsertBackgroundTask(bgtask.Upsert{
 			RowKey: fmt.Sprintf("task-%d", i), Kind: bgtask.KindSubagent, Title: fmt.Sprintf("t%d", i),
 			ChildAgentID: fmt.Sprintf("child-%d", i), Status: bgtask.StatusRunning,
 		}))
 	}
-	require.Len(t, listRows(), bgtask.MaxTasks)
+	require.Len(t, displayedRowKeys(t, svc, ownerID), bgtask.MaxTasks)
 
-	// One more: the oldest UNLINKED row (task-1) is evicted; task-2 (linked) survives.
 	require.NoError(t, sink.UpsertBackgroundTask(bgtask.Upsert{
 		RowKey: "task-new", Kind: bgtask.KindSubagent, Title: "fresh", Status: bgtask.StatusRunning,
 	}))
-	rows := listRows()
-	require.Len(t, rows, bgtask.MaxTasks, "cap maintained by evicting the unlinked row")
-	keys := make(map[string]struct{}, len(rows))
-	for _, r := range rows {
-		keys[r.RowKey] = struct{}{}
+
+	displayed := displayedRowKeys(t, svc, ownerID)
+	require.Len(t, displayed, bgtask.MaxTasks, "the display list holds its cap")
+	assert.NotContains(t, displayed, "task-1", "the OLDEST active row leaves the list, linked or not")
+	assert.Contains(t, displayed, "task-2", "an unlinked younger row is not preferred as the victim")
+
+	// task-1 left the list but keeps its row, because it carries a transcript.
+	assert.Contains(t, rowKeySet(listRows()), "task-1", "a linked row is retained in the table")
+	childID, status, ok, err := sink.LookupBackgroundTask("task-1")
+	require.NoError(t, err)
+	require.True(t, ok, "the retained row still resolves by key")
+	assert.Equal(t, "child-1", childID)
+	assert.Equal(t, bgtask.StatusRunning, status)
+}
+
+// A row that carries NO transcript indexes nothing, so eviction must still
+// reclaim it: retention is for the linkage, not a licence to grow the table.
+func TestBgTask_CapDeletesAnEvictedUnlinkedRow(t *testing.T) {
+	t.Parallel()
+
+	svc, sink, ownerID, listRows := setupBgTaskTestWithService(t)
+	require.NoError(t, sink.UpsertBackgroundTask(bgtask.Upsert{
+		RowKey: "shell-1", Kind: bgtask.KindShell, Title: "npm test", Status: bgtask.StatusCompleted,
+	}))
+	for i := 2; i <= bgtask.MaxTasks; i++ {
+		require.NoError(t, sink.UpsertBackgroundTask(bgtask.Upsert{
+			RowKey: fmt.Sprintf("shell-%d", i), Kind: bgtask.KindShell,
+			Title: fmt.Sprintf("cmd %d", i), Status: bgtask.StatusRunning,
+		}))
 	}
-	assert.NotContains(t, keys, "task-1", "oldest UNLINKED row evicted")
-	assert.Contains(t, keys, "task-2", "linked row preserved")
+	require.Len(t, listRows(), bgtask.MaxTasks)
+
+	require.NoError(t, sink.UpsertBackgroundTask(bgtask.Upsert{
+		RowKey: "shell-new", Kind: bgtask.KindShell, Title: "fresh", Status: bgtask.StatusRunning,
+	}))
+
+	assert.NotContains(t, displayedRowKeys(t, svc, ownerID), "shell-1")
+	assert.NotContains(t, rowKeySet(listRows()), "shell-1", "an unlinked row is deleted, not retained")
+	assert.Len(t, listRows(), bgtask.MaxTasks, "the table holds the cap when nothing is retained")
+
+	_, _, ok, err := sink.LookupBackgroundTask("shell-1")
+	require.NoError(t, err)
+	assert.False(t, ok, "a deleted row resolves nowhere")
+}
+
+// The linkage is what eviction must not destroy: past the cap a finished
+// subagent still has to resolve its transcript, both by row key (a Claude
+// SendMessage revive) and by child agent id (send-to-subagent and interrupt).
+func TestBgTask_CapRetainsAnEvictedLinkedRow(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc, sink, ownerID, listRows := setupBgTaskTestWithService(t)
+	for i := 1; i <= bgtask.MaxTasks; i++ {
+		require.NoError(t, sink.UpsertBackgroundTask(bgtask.Upsert{
+			RowKey: fmt.Sprintf("task-%d", i), Kind: bgtask.KindSubagent, Title: fmt.Sprintf("t%d", i),
+			ChildAgentID: fmt.Sprintf("child-%d", i), Status: bgtask.StatusCompleted,
+		}))
+	}
+	require.NoError(t, sink.UpsertBackgroundTask(bgtask.Upsert{
+		RowKey: "task-new", Kind: bgtask.KindSubagent, Title: "fresh",
+		ChildAgentID: "child-new", Status: bgtask.StatusRunning,
+	}))
+
+	require.NotContains(t, displayedRowKeys(t, svc, ownerID), "task-1",
+		"the oldest finished row left the display list")
+
+	// Route 1: row key -> child. This is what a revive reads.
+	childID, status, ok, err := sink.LookupBackgroundTask("task-1")
+	require.NoError(t, err)
+	require.True(t, ok, "the evicted row still resolves by key")
+	assert.Equal(t, "child-1", childID)
+	assert.Equal(t, bgtask.StatusCompleted, status, "the retained row keeps its final status")
+
+	// Route 2: child -> (owner, row key). This is what send and interrupt read.
+	row, err := svc.Queries.GetAgentBackgroundTaskByChildAgentID(ctx, "child-1")
+	require.NoError(t, err, "the reverse lookup behind send/interrupt still resolves")
+	assert.Equal(t, ownerID, row.OwnerAgentID)
+	assert.Equal(t, "task-1", row.RowKey)
+
+	assert.Len(t, listRows(), bgtask.MaxTasks+1, "the table keeps the retained row")
 }
 
 func TestBgTask_RenameRekeysRowAndPreservesStatus(t *testing.T) {
@@ -1034,9 +1131,57 @@ func TestBgTask_SeedReclaimsFinishedSurplus(t *testing.T) {
 	assert.Len(t, after, bgtask.MaxTasks, "the seed reclaimed the finished surplus")
 }
 
-// The cap is a SOFT bound: applyBackgroundTaskUpsertLocked exceeds it rather
-// than orphan a steerable child, so an owner can hold more rows than
-// MaxTasksTotal. The seed must then keep the NEWEST rows.
+// The reclaim pass and the cap agree on what a linked row is worth. A finished
+// subagent row below the seed window is the only index from its child agent id
+// back to (owner, row_key), so the pass must step over it -- otherwise a restart
+// deletes at boot exactly what eviction was changed to keep.
+func TestBgTask_SeedReclaimSparesLinkedRows(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc, _, ownerID, listRows := setupBgTaskTestWithService(t)
+	// Straight to the DB, so nothing is evicted before the seed runs. Below the
+	// window: one finished row that carries a child, one that does not.
+	const overflow = 4
+	now := nowMillis()
+	for i := 1; i <= bgtask.MaxTasks+overflow; i++ {
+		childID := ""
+		if i%2 == 0 {
+			childID = fmt.Sprintf("child-%03d", i)
+		}
+		require.NoError(t, svc.Queries.UpsertAgentBackgroundTask(ctx, db.UpsertAgentBackgroundTaskParams{
+			OwnerAgentID: ownerID,
+			RowKey:       fmt.Sprintf("task-%03d", i),
+			Seq:          int64(i),
+			Kind:         "subagent",
+			ChildAgentID: childID,
+			Title:        "t",
+			Status:       "completed",
+			CreatedAt:    sqltime.NewSQLiteTime(now),
+			UpdatedAt:    sqltime.NewSQLiteTime(now),
+		}))
+	}
+	require.Len(t, listRows(), bgtask.MaxTasks+overflow)
+
+	_, err := svc.Output.LoadBackgroundTasks(ctx, ownerID)
+	require.NoError(t, err)
+
+	keys := rowKeySet(listRows())
+	// task-001 .. task-004 sit below the window: the even ones are linked.
+	assert.Contains(t, keys, "task-002", "a linked row below the window is spared")
+	assert.Contains(t, keys, "task-004", "a linked row below the window is spared")
+	assert.NotContains(t, keys, "task-001", "an unlinked row below the window is reclaimed")
+	assert.NotContains(t, keys, "task-003", "an unlinked row below the window is reclaimed")
+	assert.Len(t, keys, bgtask.MaxTasks+overflow/2)
+
+	// The spared rows still answer the reverse lookup that send and interrupt use.
+	row, err := svc.Queries.GetAgentBackgroundTaskByChildAgentID(ctx, "child-002")
+	require.NoError(t, err)
+	assert.Equal(t, "task-002", row.RowKey)
+}
+
+// The TABLE outgrows the cap, because a row that carries a child transcript
+// survives eviction there. The seed must then keep the NEWEST rows.
 //
 // An oldest-first LIMIT keeps the finished rows and drops the live subagents,
 // so a restart shows a registry of stale completed rows with the running work
@@ -1047,18 +1192,11 @@ func TestBgTask_SeedKeepsTheNewestRowsPastTheCap(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	svc, _, _ := setupTestService(t)
-	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
-		ID:            "agent-1",
-		WorkingDir:    t.TempDir(),
-		HomeDir:       t.TempDir(),
-		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
-	}))
-	sink := svc.Output.NewSink("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)
+	svc, sink, ownerID, listRows := setupBgTaskTestWithService(t)
 
-	// Fill the subagent pool with ACTIVE rows that each carry a child, which is
-	// the state that makes the cap soft: eviction refuses to orphan them. Go past
-	// the pool's cap so the seed's LIMIT genuinely has to choose.
+	// Fill the subagent pool with rows that each carry a child, which is the
+	// state that outgrows the cap: eviction hides them, it does not delete them.
+	// Go past the pool's cap so the seed's LIMIT genuinely has to choose.
 	const overflow = 8
 	newest := fmt.Sprintf("agent-%03d", bgtask.MaxTasks+overflow)
 	for i := 1; i <= bgtask.MaxTasks+overflow; i++ {
@@ -1066,10 +1204,10 @@ func TestBgTask_SeedKeepsTheNewestRowsPastTheCap(t *testing.T) {
 		_, err := sink.EnsureChildAgent(fmt.Sprintf("span-%03d", i), rowKey, "SCAN")
 		require.NoError(t, err)
 	}
-	total, err := svc.Output.LoadBackgroundTasks(ctx, "agent-1")
-	require.NoError(t, err)
-	require.Greater(t, len(total), bgtask.MaxTasks,
-		"the soft cap must actually be exceeded, or this test proves nothing")
+	require.Len(t, listRows(), bgtask.MaxTasks+overflow,
+		"the table must actually outgrow the cap, or this test proves nothing")
+	require.Len(t, displayedRowKeys(t, svc, ownerID), bgtask.MaxTasks,
+		"the display list holds the cap all the same")
 
 	// Drop the warm cache so the next read seeds from the DB.
 	svc.Output.CleanupAgent("agent-1")

--- a/backend/internal/worker/service/output_bgtasks_test.go
+++ b/backend/internal/worker/service/output_bgtasks_test.go
@@ -29,7 +29,7 @@ func setupBgTaskTest(t *testing.T) (agent.OutputSink, string, func() []db.AgentB
 
 // setupBgTaskTestWithService is setupBgTaskTest for a test that also reads the
 // DISPLAY list, which only the service can answer. The two lists are no longer
-// the same: the cap bounds what LoadBackgroundTasks returns, and a row that
+// the same: the cap limits what LoadBackgroundTasks returns, and a row that
 // carries a child transcript stays in the table after it leaves that list, so
 // listRows (the table) and displayedRowKeys (the list) disagree by design.
 func setupBgTaskTestWithService(t *testing.T) (*Service, agent.OutputSink, string, func() []db.AgentBackgroundTask) {
@@ -399,7 +399,7 @@ func TestBgTask_CapAllActiveEvictsTheOldestWhateverItCarries(t *testing.T) {
 
 	svc, sink, ownerID, listRows := setupBgTaskTestWithService(t)
 	// task-1: linked and oldest. task-2: unlinked, and under the old rule it
-	// would have been evicted in task-1's place.
+	// the old rule evicted it in task-1's place.
 	require.NoError(t, sink.UpsertBackgroundTask(bgtask.Upsert{
 		RowKey: "task-1", Kind: bgtask.KindSubagent, Title: "linked", ChildAgentID: "child-1", Status: bgtask.StatusRunning,
 	}))
@@ -565,7 +565,7 @@ func TestBgTask_RenameOntoOccupiedKeyDropsTheDuplicate(t *testing.T) {
 }
 
 // The losing duplicate leaves the display list, but its PERSISTED row goes only
-// when it carries no child. A row that names a transcript is that child's one
+// when it carries no child. A row that identifies a transcript is that child's one
 // index back to (owner, row_key), and the rename is no more entitled to destroy
 // it than eviction is. No provider reaches this today -- OpenCode and Kilo are
 // the only renamers, and both drop child sessions over ACP -- so the invariant
@@ -589,7 +589,7 @@ func TestBgTask_RenameOntoOccupiedKeyRetainsALinkedDuplicate(t *testing.T) {
 	assert.NotContains(t, displayedRowKeys(t, svc, ownerID), "spawn-key",
 		"the duplicate leaves the display list either way")
 	assert.Contains(t, rowKeySet(listRows()), "spawn-key",
-		"its row is retained, because it names a transcript")
+		"its row is retained, because it identifies a transcript")
 	row, err := svc.Queries.GetAgentBackgroundTaskByChildAgentID(ctx, "child-1")
 	require.NoError(t, err, "the child keeps its index")
 	assert.Equal(t, "spawn-key", row.RowKey)
@@ -1281,7 +1281,7 @@ func storedRow(t *testing.T, svc *Service, ownerID, rowKey string) db.AgentBackg
 	return row
 }
 
-// A final status is absorbing wherever the row lives. A resumed session
+// A final status absorbs a non-final one wherever the row lives. A resumed session
 // re-announces every task it once ran with a Running upsert, and the guard that
 // drops it sits on the cached branch -- so a retained row took the replay as an
 // INSERT, and the subagent's finished row came back Running with nothing left to
@@ -1297,7 +1297,7 @@ func TestBgTask_ReplayedRunningUpsertCannotResurrectARetainedRow(t *testing.T) {
 	require.NoError(t, sink.CloseBackgroundTask("task-1", bgtask.StatusCompleted))
 	fillSubagentDisplayCap(t, sink, bgtask.MaxTasks)
 	require.NotContains(t, displayedRowKeys(t, svc, ownerID), "task-1",
-		"the row must have left the display list")
+		"the row leaves the display list")
 	endedAt := storedRow(t, svc, ownerID, "task-1").EndedAt
 
 	require.NoError(t, sink.UpsertBackgroundTask(bgtask.Upsert{
@@ -1321,7 +1321,7 @@ func TestBgTask_StatusUpdateReachesARetainedRow(t *testing.T) {
 	require.NoError(t, err)
 	fillSubagentDisplayCap(t, sink, bgtask.MaxTasks)
 	require.NotContains(t, displayedRowKeys(t, svc, ownerID), "task-1",
-		"the row must have left the display list")
+		"the row leaves the display list")
 
 	require.NoError(t, sink.UpdateBackgroundTaskStatus("task-1", bgtask.StatusRunning, "running Bash"))
 
@@ -1340,7 +1340,7 @@ func TestBgTask_CloseReachesARetainedRowAndEndsItsTranscript(t *testing.T) {
 	require.NoError(t, err)
 	fillSubagentDisplayCap(t, sink, bgtask.MaxTasks)
 	require.NotContains(t, displayedRowKeys(t, svc, ownerID), "task-1",
-		"the row must have left the display list")
+		"the row leaves the display list")
 
 	require.NoError(t, sink.CloseBackgroundTask("task-1", bgtask.StatusCompleted))
 
@@ -1367,12 +1367,12 @@ func TestBgTask_ReviveReachesARetainedRow(t *testing.T) {
 	require.NoError(t, sink.CloseBackgroundTask("task-1", bgtask.StatusCompleted))
 	fillSubagentDisplayCap(t, sink, bgtask.MaxTasks)
 	require.NotContains(t, displayedRowKeys(t, svc, ownerID), "task-1",
-		"the row must have left the display list")
+		"the row leaves the display list")
 
 	require.NoError(t, sink.ReviveBackgroundTask("task-1"))
 
 	row := storedRow(t, svc, ownerID, "task-1")
-	assert.Equal(t, "running", row.Status, "the subagent is running again")
+	assert.Equal(t, "running", row.Status, "the subagent runs again")
 	assert.False(t, row.EndedAt.Valid, "the revive clears ended_at")
 }
 
@@ -1401,7 +1401,7 @@ func TestBgTask_ReAdmittingARetainedRowHoldsTheDisplayCap(t *testing.T) {
 // A registry with no retention (agent_todos) must not gain a store fallback:
 // its cap IS a storage bound, and a key it does not hold identifies nothing.
 // The bgtask registry proves the other half, so this pins the nil branch of
-// rowIndexLocked that every todo mutation takes.
+// findRowLocked that every todo mutation takes.
 func TestTodos_AnAbsentRowStaysAMissWithNoRetention(t *testing.T) {
 	t.Parallel()
 
@@ -1412,7 +1412,204 @@ func TestTodos_AnAbsentRowStaysAMissWithNoRetention(t *testing.T) {
 	defer cache.Mu.Unlock()
 	require.Nil(t, cache.ops.retention, "agent_todos retains nothing past its cap")
 
-	idx, err := cache.rowIndexLocked(ctx, "agent-1", "todo-nope")
+	_, idx, found, err := cache.findRowLocked(ctx, "agent-1", "todo-nope")
 	require.NoError(t, err)
-	assert.Equal(t, -1, idx, "no store fallback runs for a registry without retention")
+	assert.False(t, found, "no store fallback runs for a registry without retention")
+	assert.Equal(t, -1, idx, "an absent row has no display index")
+}
+
+// A mutation that turns out to be a NO-OP must leave the display list exactly
+// as it found it. Re-admitting a retained row first, and only then discovering
+// the write changes nothing, evicted a displayed row to make space for a write
+// that never happened -- and reported changed=false, so no broadcast told the
+// client its list had moved. A resumed session replays one of these per past
+// subagent, so the whole sidebar rotated behind the client's back.
+func TestBgTask_ANoOpMutationOnARetainedRowLeavesTheDisplayListAlone(t *testing.T) {
+	t.Parallel()
+
+	svc, sink, ownerID, _ := setupBgTaskTestWithService(t)
+	_, err := sink.EnsureChildAgent("span-1", "task-1", "SCAN")
+	require.NoError(t, err)
+	require.NoError(t, sink.CloseBackgroundTask("task-1", bgtask.StatusCompleted))
+	fillSubagentDisplayCap(t, sink, bgtask.MaxTasks)
+	before := displayedRowKeys(t, svc, ownerID)
+	require.NotContains(t, before, "task-1", "the row leaves the display list")
+
+	// Absorbed by the final-status guard: the row is completed, so a running
+	// update writes nothing.
+	require.NoError(t, sink.UpdateBackgroundTaskStatus("task-1", bgtask.StatusRunning, "running Bash"))
+	// Absorbed by the already-final guard.
+	require.NoError(t, sink.CloseBackgroundTask("task-1", bgtask.StatusCompleted))
+
+	assert.Equal(t, before, displayedRowKeys(t, svc, ownerID),
+		"a write that never happens evicts nothing and re-admits nothing")
+}
+
+// The eviction a no-op mutation used to trigger did not merely hide a row: an
+// UNLINKED row that retention does not keep was DELETED from the table, so a
+// duplicate progress event on one retained row destroyed an unrelated shell row.
+func TestBgTask_ANoOpMutationOnARetainedRowDeletesNothing(t *testing.T) {
+	t.Parallel()
+
+	svc, sink, ownerID, listRows := setupBgTaskTestWithService(t)
+	// task-1 is the OLDEST finished row, so the fill evicts it first and it ends
+	// up retained-but-not-displayed. unlinked-1 is the NEXT finished row and
+	// carries no child, so retention does not keep it -- it is what an eviction
+	// on the re-admit path would delete from the table.
+	_, err := sink.EnsureChildAgent("span-1", "task-1", "SCAN")
+	require.NoError(t, err)
+	require.NoError(t, sink.CloseBackgroundTask("task-1", bgtask.StatusCompleted))
+	require.NoError(t, sink.UpsertBackgroundTask(bgtask.Upsert{
+		RowKey: "unlinked-1", Kind: bgtask.KindSubagent, Title: "no transcript",
+		Status: bgtask.StatusCompleted,
+	}))
+	// One row over the cap, so exactly one eviction runs and it takes task-1.
+	fillSubagentDisplayCap(t, sink, bgtask.MaxTasks-1)
+	require.NotContains(t, displayedRowKeys(t, svc, ownerID), "task-1")
+	require.Contains(t, displayedRowKeys(t, svc, ownerID), "unlinked-1",
+		"the victim is still displayed, so eviction can reach it")
+	before := len(listRows())
+
+	require.NoError(t, sink.UpdateBackgroundTaskStatus("task-1", bgtask.StatusRunning, "running Bash"))
+
+	assert.Len(t, listRows(), before, "no persisted row is deleted for a no-op")
+	assert.Equal(t, "completed", storedRow(t, svc, ownerID, "unlinked-1").Status,
+		"the unlinked row an eviction would have destroyed is still there")
+	assert.Equal(t, "completed", storedRow(t, svc, ownerID, "task-1").Status,
+		"the absorbing guard still holds")
+}
+
+// A revive whose UPDATE matches nothing re-reads the row rather than guessing.
+// The zero count answers "already active" AND "no such row", and the branch that
+// assumed the first left a cache row with no table row behind it -- a subagent
+// chip spinning for good. It also adopts every field, not the two a hand-written
+// repair remembered: active_form and description describe the run that ENDED.
+func TestBgTask_AReviveThatMatchesNothingAdoptsTheStoredRow(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc, sink, ownerID, _ := setupBgTaskTestWithService(t)
+	require.NoError(t, sink.UpsertBackgroundTask(bgtask.Upsert{
+		RowKey: "task-1", Kind: bgtask.KindSubagent, Title: "SCAN",
+		Status: bgtask.StatusCompleted, Description: "/tmp/out.md", ActiveForm: "writing the report",
+	}))
+	// The cache says finished; the ROW is active. Only the DB moves, so the
+	// revive's UPDATE (which filters on a final status) matches nothing.
+	_, err := svc.Queries.ReviveAgentBackgroundTask(ctx, db.ReviveAgentBackgroundTaskParams{
+		UpdatedAt:    sqltime.NewSQLiteTime(nowMillis()),
+		OwnerAgentID: ownerID,
+		RowKey:       "task-1",
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, sink.ReviveBackgroundTask("task-1"))
+
+	items, err := svc.Output.LoadBackgroundTasks(ctx, ownerID)
+	require.NoError(t, err)
+	idx := slices.IndexFunc(items, func(i bgtask.Item) bool { return i.RowKey == "task-1" })
+	require.GreaterOrEqual(t, idx, 0)
+	assert.Equal(t, bgtask.StatusRunning, items[idx].Status, "the cache adopts the row's status")
+	assert.Empty(t, items[idx].Description, "and the row's cleared description, not the finished run's")
+	assert.Empty(t, items[idx].ActiveForm, "and the row's cleared activity text")
+}
+
+// The same branch for a row that is GONE. Reporting the drop and the snapshot in
+// one composite literal built the payload before the drop ran, so the broadcast
+// still carried the dead row and no later mutation corrected it.
+func TestBgTask_AReviveOfADeletedRowBroadcastsWithoutIt(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc, sink, ownerID, _ := setupBgTaskTestWithService(t)
+	require.NoError(t, sink.UpsertBackgroundTask(bgtask.Upsert{
+		RowKey: "task-1", Kind: bgtask.KindSubagent, Title: "SCAN", Status: bgtask.StatusCompleted,
+	}))
+	require.Contains(t, displayedRowKeys(t, svc, ownerID), "task-1")
+	// Delete the row under the cache, the way a cascade or a racing delete does.
+	_, err := svc.Queries.DeleteAgentBackgroundTaskByRowKey(ctx, db.DeleteAgentBackgroundTaskByRowKeyParams{
+		OwnerAgentID: ownerID, RowKey: "task-1",
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, sink.ReviveBackgroundTask("task-1"))
+
+	assert.NotContains(t, displayedRowKeys(t, svc, ownerID), "task-1",
+		"a row the table no longer holds leaves the display list too")
+}
+
+// A retained row that is not DISPLAYED has no cached copy to disagree with the
+// store, so the zero-count repair has nothing to adopt -- and admitting it would
+// evict a displayed row, and delete an unlinked one, for a write that never
+// happens.
+func TestBgTask_AReviveThatMatchesNothingSparesTheDisplayListForARetainedRow(t *testing.T) {
+	t.Parallel()
+
+	svc, sink, ownerID, listRows := setupBgTaskTestWithService(t)
+	_, err := sink.EnsureChildAgent("span-1", "task-1", "SCAN")
+	require.NoError(t, err)
+	// The row is ACTIVE in the table, so the revive's UPDATE matches nothing.
+	fillSubagentDisplayCap(t, sink, bgtask.MaxTasks)
+	before := displayedRowKeys(t, svc, ownerID)
+	require.NotContains(t, before, "task-1", "the row leaves the display list")
+	beforeRows := len(listRows())
+
+	require.NoError(t, sink.ReviveBackgroundTask("task-1"))
+
+	assert.Equal(t, before, displayedRowKeys(t, svc, ownerID), "the display list is untouched")
+	assert.Len(t, listRows(), beforeRows, "and no persisted row is deleted")
+}
+
+// EnsureChildAgent asks "does a row for this key already carry a transcript",
+// and a row that carries one outlives the display cap. Reading the display list
+// alone answered "no" for every linked row past it, so the call fell through to
+// the spawn-span lookup, missed there too, and CREATED a second transcript --
+// then re-pointed the durable row at the orphan, leaving the first run's whole
+// transcript unreachable. Codex reaches this on every re-registration, because a
+// collab call that re-opens a closed thread supplies a NEW spawn span.
+func TestBgTask_EnsureChildAgentFindsTheTranscriptOfARetainedRow(t *testing.T) {
+	t.Parallel()
+
+	svc, sink, ownerID, _ := setupBgTaskTestWithService(t)
+	firstChild, err := sink.EnsureChildAgent("span-1", "thread-1", "collab child")
+	require.NoError(t, err)
+	require.NoError(t, sink.CloseBackgroundTask("thread-1", bgtask.StatusCompleted))
+	fillSubagentDisplayCap(t, sink, bgtask.MaxTasks)
+	require.NotContains(t, displayedRowKeys(t, svc, ownerID), "thread-1",
+		"the row leaves the display list")
+
+	// The re-registration: a DIFFERENT spawn span for the same provider key.
+	againChild, err := sink.EnsureChildAgent("span-2", "thread-1", "collab child")
+	require.NoError(t, err)
+
+	assert.Equal(t, firstChild, againChild, "the row's transcript is the one that answers")
+	assert.Equal(t, firstChild, storedRow(t, svc, ownerID, "thread-1").ChildAgentID,
+		"and the durable row still points at it")
+}
+
+// A re-admitted row takes a fresh seq, because the display list's slice order
+// and the stored seq are ONE ordering key. Moving only the slice left the two
+// disagreeing: a subagent a revive had just reopened sat at the end of the
+// sidebar for the life of the process, then fell outside the next cold seed's
+// window (the newest rows by seq) and vanished on the worker restart -- while
+// 64 older finished rows stayed on screen.
+func TestBgTask_AReAdmittedRowSurvivesTheNextColdSeed(t *testing.T) {
+	t.Parallel()
+
+	svc, sink, ownerID, _ := setupBgTaskTestWithService(t)
+	_, err := sink.EnsureChildAgent("span-1", "task-1", "SCAN")
+	require.NoError(t, err)
+	require.NoError(t, sink.CloseBackgroundTask("task-1", bgtask.StatusCompleted))
+	fillSubagentDisplayCap(t, sink, bgtask.MaxTasks)
+	require.NotContains(t, displayedRowKeys(t, svc, ownerID), "task-1",
+		"the row leaves the display list")
+
+	require.NoError(t, sink.ReviveBackgroundTask("task-1"))
+	require.Contains(t, displayedRowKeys(t, svc, ownerID), "task-1",
+		"the revive re-admits the row to this process's list")
+
+	// Drop the cache, the way a worker restart does, and seed again from the DB.
+	svc.Output.bgtasks.Delete(ownerID)
+
+	assert.Contains(t, displayedRowKeys(t, svc, ownerID), "task-1",
+		"the re-admitted row is inside the seed window the next process reads")
 }

--- a/backend/internal/worker/service/output_child_agent_test.go
+++ b/backend/internal/worker/service/output_child_agent_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"sync"
 	"testing"
 
@@ -800,6 +801,32 @@ func TestMarkBackgroundTasksExited_WritesTheSubagentEndDivider(t *testing.T) {
 	assert.Equal(t, "interrupted", msgs[0]["status"])
 }
 
+// The sweep ends every active row in the TABLE, and its divider list has to
+// match. A row past the display cap is not in the cache, so a cache-derived list
+// left that subagent's transcript with no closing divider -- permanently, since
+// the sweep cannot repeat itself (the rows are no longer active).
+func TestMarkBackgroundTasksExited_ClosesASubagentPastTheDisplayCap(t *testing.T) {
+	t.Parallel()
+
+	svc, sink := setupRootSink(t, "root-1")
+	childID, err := sink.EnsureChildAgent("span-1", "task-1", "SCAN")
+	require.NoError(t, err)
+	fillSubagentDisplayCap(t, sink, bgtask.MaxTasks)
+
+	displayed, err := svc.Output.LoadBackgroundTasks(context.Background(), "root-1")
+	require.NoError(t, err)
+	for _, item := range displayed {
+		require.NotEqual(t, "task-1", item.RowKey, "the row must have left the display list")
+	}
+
+	svc.Output.MarkAgentBackgroundTasksExited("root-1", false)
+
+	msgs := transcriptMessages(t, svc, childID)
+	require.Len(t, msgs, 1, "the retained row's transcript is closed too")
+	assert.Equal(t, agent.NotificationTypeSubagentEnded, msgs[0]["type"])
+	assert.Equal(t, "interrupted", msgs[0]["status"])
+}
+
 func TestMarkBackgroundTasksExited_LabelsAnExplicitStopAsStopped(t *testing.T) {
 	t.Parallel()
 
@@ -1091,6 +1118,67 @@ func TestLookupBackgroundTask_ResolvesTheChildAndStatus(t *testing.T) {
 	_, status, ok, _ = sink.LookupBackgroundTask("task-1")
 	require.True(t, ok)
 	assert.Equal(t, bgtask.StatusCompleted, status)
+}
+
+// fillSubagentDisplayCap pushes `extra` fresh subagent rows through the root's
+// registry, so every row that was there before leaves the capped display list.
+// Each row carries a child transcript, which is the case the cap must not
+// destroy.
+func fillSubagentDisplayCap(t *testing.T, sink agent.OutputSink, extra int) {
+	t.Helper()
+	for i := range extra {
+		_, err := sink.EnsureChildAgent(fmt.Sprintf("filler-span-%d", i), fmt.Sprintf("filler-%d", i), "filler")
+		require.NoError(t, err)
+	}
+}
+
+// The display cap is not a storage bound. Past MaxTasks subagents, a revive of
+// an older one still has to find its transcript: a miss here made Claude open a
+// SECOND transcript keyed by the SendMessage id and leave the real one
+// unreachable.
+func TestLookupBackgroundTask_ResolvesARowThatLeftTheDisplayCache(t *testing.T) {
+	t.Parallel()
+
+	svc, sink := setupRootSink(t, "root-1")
+	childID, err := sink.EnsureChildAgent("span-1", "task-1", "SCAN")
+	require.NoError(t, err)
+	require.NoError(t, sink.CloseBackgroundTask("task-1", bgtask.StatusCompleted))
+
+	fillSubagentDisplayCap(t, sink, bgtask.MaxTasks)
+
+	displayed, err := svc.Output.LoadBackgroundTasks(context.Background(), "root-1")
+	require.NoError(t, err)
+	require.Len(t, displayed, bgtask.MaxTasks)
+	for _, item := range displayed {
+		require.NotEqual(t, "task-1", item.RowKey, "the row must have left the display list")
+	}
+
+	gotChild, status, ok, err := sink.LookupBackgroundTask("task-1")
+	require.NoError(t, err)
+	require.True(t, ok, "the retained row resolves through the point lookup")
+	assert.Equal(t, childID, gotChild)
+	assert.Equal(t, bgtask.StatusCompleted, status)
+}
+
+// resolveChildRegistryRow's query is the reverse route, and it is what
+// send-to-subagent and interrupt use. Losing the row past the cap answered
+// ErrNoRows, which the caller reports as "subagent registry not yet loaded;
+// retry" -- forever, for a subagent whose transcript is right there.
+func TestGetAgentBackgroundTaskByChildAgentID_ResolvesPastTheDisplayCap(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc, sink := setupRootSink(t, "root-1")
+	childID, err := sink.EnsureChildAgent("span-1", "task-1", "SCAN")
+	require.NoError(t, err)
+	require.NoError(t, sink.CloseBackgroundTask("task-1", bgtask.StatusCompleted))
+
+	fillSubagentDisplayCap(t, sink, bgtask.MaxTasks)
+
+	row, err := svc.Queries.GetAgentBackgroundTaskByChildAgentID(ctx, childID)
+	require.NoError(t, err, "the child stays messageable and interruptible")
+	assert.Equal(t, "root-1", row.OwnerAgentID)
+	assert.Equal(t, "task-1", row.RowKey)
 }
 
 // A row key that identifies nothing misses, which is what every recipient outside

--- a/backend/internal/worker/service/output_child_agent_test.go
+++ b/backend/internal/worker/service/output_child_agent_test.go
@@ -11,6 +11,7 @@ import (
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/util/msgcodec"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
 	"github.com/leapmux/leapmux/internal/worker/agent"
 	"github.com/leapmux/leapmux/internal/worker/bgtask"
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
@@ -310,7 +311,7 @@ func TestCleanupChildAgent_OrphanedTrackerPointerIsBenign(t *testing.T) {
 }
 
 // TestCleanupChildAgent_PrunesChildSinkFromDirectParent verifies that a
-// terminal child close prunes the cached child sink from the DIRECT PARENT in
+// final child close prunes the cached child sink from the DIRECT PARENT in
 // O(1) (the parent sink is the receiver), without scanning every root sink.
 // Closes one of two children and asserts the sibling stays cached. A regression
 // that reverted to the O(roots) rootSinks scan would still pass today (one
@@ -930,4 +931,229 @@ func TestMarkBackgroundTasksExited_SkipsATranscriptThatAlreadyEnded(t *testing.T
 	msgs := transcriptMessages(t, svc, childID)
 	require.Len(t, msgs, 1)
 	assert.Equal(t, "result", msgs[0]["type"])
+}
+
+// --- Revive ---
+//
+// Claude restarts a finished subagent when the parent messages it. The registry
+// row has to reopen, and the transcript has to become closeable again -- the
+// first completion durably claimed its closing divider, so without a release the
+// second run would end with no divider at all.
+
+// registrySnapshotRow reads one row back through the snapshot clients receive,
+// which is the cache. Distinct from registryRow in title_cleaning_test.go, which
+// reads the DB directly -- the revive writes BOTH, so the two together are what
+// catch a cache that drifted from the durable row.
+func registrySnapshotRow(t *testing.T, svc *Service, rootID, rowKey string) bgtask.Item {
+	t.Helper()
+	items, err := svc.Output.LoadBackgroundTasks(context.Background(), rootID)
+	require.NoError(t, err)
+	for _, it := range items {
+		if it.RowKey == rowKey {
+			return it
+		}
+	}
+	t.Fatalf("no registry row %q", rowKey)
+	return bgtask.Item{}
+}
+
+func TestReviveBackgroundTask_ReturnsAFinishedRowToRunning(t *testing.T) {
+	t.Parallel()
+
+	svc, sink := setupRootSink(t, "root-1")
+	_, err := sink.EnsureChildAgent("span-1", "task-1", "SCAN")
+	require.NoError(t, err)
+	// A finished Claude subagent carries its output file in Description, written
+	// by the same task_notification that ended it.
+	require.NoError(t, sink.UpsertBackgroundTask(bgtask.Upsert{
+		RowKey:      "task-1",
+		Kind:        bgtask.KindSubagent,
+		Description: "/tmp/task-1.output",
+		Status:      bgtask.StatusRunning,
+	}))
+	require.NoError(t, sink.UpdateBackgroundTaskStatus("task-1", bgtask.StatusCompleted, "wrote the report"))
+	require.NoError(t, sink.CloseBackgroundTask("task-1", bgtask.StatusCompleted))
+	require.True(t, registrySnapshotRow(t, svc, "root-1", "task-1").Status.IsFinished())
+
+	require.NoError(t, sink.ReviveBackgroundTask("task-1"))
+
+	row := registrySnapshotRow(t, svc, "root-1", "task-1")
+	assert.Equal(t, bgtask.StatusRunning, row.Status)
+	assert.True(t, row.EndedAt.IsZero(), "a running row carries no end time")
+	assert.Empty(t, row.ActiveForm,
+		"active_form described the finished run; the new one has reported nothing yet")
+	assert.Empty(t, row.Description,
+		"description held the finished run's output file; the new run has not named one")
+
+	// The durable row too, not only the cache. The revive writes both, and a
+	// cache that says running over a DB row that still says completed would
+	// survive until the next worker restart and then silently un-revive.
+	stored := registryRow(t, svc)
+	assert.Equal(t, "running", stored.Status)
+	assert.False(t, stored.EndedAt.Valid, "ended_at is cleared to NULL, not left stamped")
+	assert.Empty(t, stored.ActiveForm)
+	assert.Empty(t, stored.Description)
+}
+
+// Idempotent in both directions, so a duplicate revive and a revive for a task
+// this root never ran are both harmless.
+func TestReviveBackgroundTask_IsANoOpForAnActiveOrAbsentRow(t *testing.T) {
+	t.Parallel()
+
+	svc, sink := setupRootSink(t, "root-1")
+	_, err := sink.EnsureChildAgent("span-1", "task-1", "SCAN")
+	require.NoError(t, err)
+
+	// Still running: nothing to reopen, and the row must not be disturbed.
+	require.NoError(t, sink.UpdateBackgroundTaskStatus("task-1", bgtask.StatusRunning, "reading files"))
+	require.NoError(t, sink.ReviveBackgroundTask("task-1"))
+	row := registrySnapshotRow(t, svc, "root-1", "task-1")
+	assert.Equal(t, bgtask.StatusRunning, row.Status)
+	assert.Equal(t, "reading files", row.ActiveForm, "an active row keeps its live activity text")
+
+	// Absent: no row, no error.
+	assert.NoError(t, sink.ReviveBackgroundTask("task-nope"))
+}
+
+// The claim release is the half that is easy to forget, and forgetting it costs
+// the second run its closing divider entirely.
+func TestReviveBackgroundTask_ReleasesTheTranscriptCloseClaim(t *testing.T) {
+	t.Parallel()
+
+	svc, sink := setupRootSink(t, "root-1")
+	childID, err := sink.EnsureChildAgent("span-1", "task-1", "SCAN")
+	require.NoError(t, err)
+	require.NoError(t, sink.CloseBackgroundTask("task-1", bgtask.StatusCompleted))
+	require.False(t, svc.Output.claimSubagentTranscriptClose(context.Background(), childID),
+		"the first completion holds the claim")
+
+	require.NoError(t, sink.ReviveBackgroundTask("task-1"))
+
+	assert.True(t, svc.Output.claimSubagentTranscriptClose(context.Background(), childID),
+		"the revive gives the claim back so the next completion can take it")
+}
+
+// End to end: a transcript holds one divider per completion, not one for its
+// whole life.
+func TestSubagentEndDivider_WrittenAgainAfterARevive(t *testing.T) {
+	t.Parallel()
+
+	svc, sink := setupRootSink(t, "root-1")
+	childID, err := sink.EnsureChildAgent("span-1", "task-1", "SCAN")
+	require.NoError(t, err)
+	require.NoError(t, sink.CloseBackgroundTask("task-1", bgtask.StatusCompleted))
+	require.NoError(t, sink.ReviveBackgroundTask("task-1"))
+	require.NoError(t, sink.CloseBackgroundTask("task-1", bgtask.StatusFailed))
+
+	msgs := transcriptMessages(t, svc, childID)
+	require.Len(t, msgs, 2, "one divider for each run")
+	assert.Equal(t, agent.NotificationTypeSubagentEnded, msgs[0]["type"])
+	assert.Equal(t, "completed", msgs[0]["status"])
+	assert.Equal(t, agent.NotificationTypeSubagentEnded, msgs[1]["type"])
+	assert.Equal(t, "failed", msgs[1]["status"], "the second divider reports the SECOND run's outcome")
+}
+
+// Regression lock. Nothing seals a child transcript: a divider is a message, not
+// a terminator, and a revived subagent's output has to keep landing below it. A
+// future "stop persisting once it ended" shortcut would break the revive
+// silently, so the behavior is pinned here rather than left implicit.
+func TestChildTranscript_AppendsBelowTheEndDivider(t *testing.T) {
+	t.Parallel()
+
+	svc, sink := setupRootSink(t, "root-1")
+	childID, err := sink.EnsureChildAgent("span-1", "task-1", "SCAN")
+	require.NoError(t, err)
+	require.NoError(t, sink.CloseBackgroundTask("task-1", bgtask.StatusCompleted))
+
+	require.NoError(t, sink.PersistChildMessage(childID,
+		leapmuxv1.MessageSource_MESSAGE_SOURCE_USER,
+		[]byte(`{"content":"keep going"}`), agent.SpanInfo{}))
+
+	msgs := transcriptMessages(t, svc, childID)
+	require.Len(t, msgs, 2)
+	assert.Equal(t, agent.NotificationTypeSubagentEnded, msgs[0]["type"])
+	assert.Equal(t, "keep going", msgs[1]["content"], "the later message sits below the divider")
+}
+
+func TestLookupBackgroundTask_ResolvesTheChildAndStatus(t *testing.T) {
+	t.Parallel()
+
+	_, sink := setupRootSink(t, "root-1")
+	childID, err := sink.EnsureChildAgent("span-1", "task-1", "SCAN")
+	require.NoError(t, err)
+
+	gotChild, status, ok, _ := sink.LookupBackgroundTask("task-1")
+	require.True(t, ok)
+	assert.Equal(t, childID, gotChild)
+	assert.Equal(t, bgtask.StatusRunning, status)
+
+	require.NoError(t, sink.CloseBackgroundTask("task-1", bgtask.StatusCompleted))
+	_, status, ok, _ = sink.LookupBackgroundTask("task-1")
+	require.True(t, ok)
+	assert.Equal(t, bgtask.StatusCompleted, status)
+}
+
+// A row key that identifies nothing misses, which is what every recipient outside
+// this session's subagents does -- a display name, another session, an address.
+func TestLookupBackgroundTask_ReportsAMissForAnUnknownKey(t *testing.T) {
+	t.Parallel()
+
+	_, sink := setupRootSink(t, "root-1")
+	_, err := sink.EnsureChildAgent("span-1", "task-1", "SCAN")
+	require.NoError(t, err)
+
+	for _, key := range []string{"", "task-nope", "bridge:another-machine"} {
+		childID, _, ok, _ := sink.LookupBackgroundTask(key)
+		assert.False(t, ok, "key %q identifies no row", key)
+		assert.Empty(t, childID)
+	}
+}
+
+// A shell row owns no transcript, so there is no close claim to give back. The
+// revive still reopens the row, and the release must not run against an empty
+// child id.
+func TestReviveBackgroundTask_RowWithNoTranscript(t *testing.T) {
+	t.Parallel()
+
+	svc, sink := setupRootSink(t, "root-1")
+	require.NoError(t, sink.UpsertBackgroundTask(bgtask.Upsert{
+		RowKey: "shell-1",
+		Kind:   bgtask.KindShell,
+		Title:  "npm test",
+		Status: bgtask.StatusRunning,
+	}))
+	require.NoError(t, sink.CloseBackgroundTask("shell-1", bgtask.StatusCompleted))
+
+	require.NoError(t, sink.ReviveBackgroundTask("shell-1"))
+	assert.Equal(t, bgtask.StatusRunning, registrySnapshotRow(t, svc, "root-1", "shell-1").Status)
+}
+
+// The cache and the durable row are two sources, and the query is the one that
+// decides. When the DB says the row is already active the UPDATE matches nothing,
+// and reporting a revive anyway would release a transcript-close claim for a
+// transcript that never reopened -- letting a SECOND divider be written for the
+// FIRST completion.
+func TestReviveBackgroundTask_TrustsTheDatabaseOverAStaleCache(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc, sink := setupRootSink(t, "root-1")
+	childID, err := sink.EnsureChildAgent("span-1", "task-1", "SCAN")
+	require.NoError(t, err)
+	require.NoError(t, sink.CloseBackgroundTask("task-1", bgtask.StatusCompleted))
+	require.False(t, svc.Output.claimSubagentTranscriptClose(ctx, childID))
+
+	// Put the DB back to running behind the cache's back, so the two disagree
+	// exactly as a concurrent revive would leave them.
+	require.NoError(t, svc.Queries.UpdateAgentBackgroundTaskStatus(ctx, db.UpdateAgentBackgroundTaskStatusParams{
+		Status:       bgtask.StatusWire(bgtask.StatusRunning),
+		UpdatedAt:    sqltime.NewSQLiteTime(nowMillis()),
+		OwnerAgentID: "root-1",
+		RowKey:       "task-1",
+	}))
+
+	require.NoError(t, sink.ReviveBackgroundTask("task-1"))
+
+	assert.False(t, svc.Output.claimSubagentTranscriptClose(ctx, childID),
+		"the claim is still held: no revive was reported, so none was released")
 }

--- a/backend/internal/worker/service/output_child_agent_test.go
+++ b/backend/internal/worker/service/output_child_agent_test.go
@@ -816,7 +816,7 @@ func TestMarkBackgroundTasksExited_ClosesASubagentPastTheDisplayCap(t *testing.T
 	displayed, err := svc.Output.LoadBackgroundTasks(context.Background(), "root-1")
 	require.NoError(t, err)
 	for _, item := range displayed {
-		require.NotEqual(t, "task-1", item.RowKey, "the row must have left the display list")
+		require.NotEqual(t, "task-1", item.RowKey, "the row leaves the display list")
 	}
 
 	svc.Output.MarkAgentBackgroundTasksExited("root-1", false)
@@ -1008,9 +1008,9 @@ func TestReviveBackgroundTask_ReturnsAFinishedRowToRunning(t *testing.T) {
 	assert.Equal(t, bgtask.StatusRunning, row.Status)
 	assert.True(t, row.EndedAt.IsZero(), "a running row carries no end time")
 	assert.Empty(t, row.ActiveForm,
-		"active_form described the finished run; the new one has reported nothing yet")
+		"active_form described the finished run; the new one reported nothing yet")
 	assert.Empty(t, row.Description,
-		"description held the finished run's output file; the new run has not named one")
+		"description held the finished run's output file; the new run identified none")
 
 	// The durable row too, not only the cache. The revive writes both, and a
 	// cache that says running over a DB row that still says completed would
@@ -1150,7 +1150,7 @@ func TestLookupBackgroundTask_ResolvesARowThatLeftTheDisplayCache(t *testing.T) 
 	require.NoError(t, err)
 	require.Len(t, displayed, bgtask.MaxTasks)
 	for _, item := range displayed {
-		require.NotEqual(t, "task-1", item.RowKey, "the row must have left the display list")
+		require.NotEqual(t, "task-1", item.RowKey, "the row leaves the display list")
 	}
 
 	gotChild, status, ok, err := sink.LookupBackgroundTask("task-1")
@@ -1216,11 +1216,16 @@ func TestReviveBackgroundTask_RowWithNoTranscript(t *testing.T) {
 	assert.Equal(t, bgtask.StatusRunning, registrySnapshotRow(t, svc, "root-1", "shell-1").Status)
 }
 
-// The cache and the durable row are two sources, and the query is the one that
-// decides. When the DB says the row is already active the UPDATE matches nothing,
-// and reporting a revive anyway would release a transcript-close claim for a
-// transcript that never reopened -- letting a SECOND divider be written for the
-// FIRST completion.
+// The cache and the durable row are two sources, and the row is the one that
+// decides. When the row is already ACTIVE the UPDATE matches nothing, and the
+// applier re-reads rather than guessing -- so the cache adopts the row, and the
+// transcript-close claim goes back, because a row that is active and carries a
+// child IS a reopened transcript that owes a closing divider.
+//
+// The claim, not the UPDATE, is what makes this the right way round. Holding it
+// leaves the restarted run with no divider at all and a thinking indicator that
+// never resolves, which this file calls the worse error where it fails the claim
+// open on a DB error.
 func TestReviveBackgroundTask_TrustsTheDatabaseOverAStaleCache(t *testing.T) {
 	t.Parallel()
 
@@ -1242,6 +1247,53 @@ func TestReviveBackgroundTask_TrustsTheDatabaseOverAStaleCache(t *testing.T) {
 
 	require.NoError(t, sink.ReviveBackgroundTask("task-1"))
 
-	assert.False(t, svc.Output.claimSubagentTranscriptClose(ctx, childID),
-		"the claim is still held: no revive was reported, so none was released")
+	assert.True(t, svc.Output.claimSubagentTranscriptClose(ctx, childID),
+		"the row is active and linked, so the reopened transcript gets its claim back")
+}
+
+// PersistChildUserMessage is the write a revive makes, and its three properties
+// are what the delivered message depends on. Nothing tested the REAL sink: the
+// provider test asserts against a fake that was written to return the right
+// mark, so removing the mark from the sink -- or routing the call through the
+// emptiness-guarded opening-prompt path -- would break the scroll rail with a
+// green suite.
+func TestPersistChildUserMessage_AppendsWithTheScrollRailMark(t *testing.T) {
+	t.Parallel()
+
+	svc, sink := setupRootSink(t, "root-1")
+	childID, err := sink.EnsureChildAgent("span-1", "task-1", "SCAN")
+	require.NoError(t, err)
+	require.NoError(t, sink.PersistChildPrompt(childID, "Find every caller."))
+
+	require.NoError(t, sink.PersistChildUserMessage(childID, "Also check the tests."))
+
+	msgs := transcriptMessages(t, svc, childID)
+	require.Len(t, msgs, 2, "the delivered message APPENDS; it does not replace the opening prompt")
+	assert.Equal(t, "Also check the tests.", msgs[1]["content"])
+	assert.Equal(t, float64(leapmuxv1.MessageSource_MESSAGE_SOURCE_USER), msgs[1]["__source"])
+
+	rows, err := svc.Queries.ListAllMessagesByAgentID(context.Background(),
+		db.ListAllMessagesByAgentIDParams{AgentID: childID})
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_USER_MESSAGE, rows[1].MarkType,
+		"a mid-transcript user message is exactly what the scroll rail exists to find")
+	assert.Equal(t, leapmuxv1.MarkType_MARK_TYPE_UNSPECIFIED, rows[0].MarkType,
+		"and the opening prompt carries none, so the rail does not point at it")
+}
+
+// The two no-ops the doc promises. A blank text and an empty child id both write
+// nothing, so a send the CLI refused, or one for a subagent with no transcript,
+// cannot leave an empty bubble in the transcript.
+func TestPersistChildUserMessage_IsANoOpForBlankInput(t *testing.T) {
+	t.Parallel()
+
+	svc, sink := setupRootSink(t, "root-1")
+	childID, err := sink.EnsureChildAgent("span-1", "task-1", "SCAN")
+	require.NoError(t, err)
+
+	require.NoError(t, sink.PersistChildUserMessage(childID, "   \n\t "))
+	require.NoError(t, sink.PersistChildUserMessage("", "a real message"))
+
+	assert.Empty(t, transcriptMessages(t, svc, childID), "neither call writes a message")
 }

--- a/backend/internal/worker/service/registry_cache.go
+++ b/backend/internal/worker/service/registry_cache.go
@@ -59,6 +59,11 @@ type registryRetention[T any] struct {
 	// load reads a persisted row back by key, so an operation on a row the cache
 	// no longer holds still finds it. found=false for a row that does not exist.
 	load func(ctx context.Context, ownerID, key string) (row T, found bool, err error)
+	// reseq gives a re-admitted row a new seq, so the display list and the
+	// cold-start seed keep ONE ordering key. Without it a re-admitted row sat at
+	// the end of the list in memory while its stored seq still placed it outside
+	// the next seed's window.
+	reseq func(ctx context.Context, ownerID, key string, seq int64) error
 }
 
 // registryOps supplies the type-specific behaviour a registryCache needs. It is
@@ -193,42 +198,106 @@ func (c *registryCache[T]) indexOf(key string) int {
 	return slices.IndexFunc(c.Rows, func(r T) bool { return c.ops.keyOf(r) == key })
 }
 
-// rowIndexLocked returns the cache index of the row at key, re-admitting a
-// RETAINED row from the store when the display cache no longer holds it.
-// Returns -1 when no row exists anywhere. Caller must hold c.Mu.
+// findRowLocked resolves the row at key WITHOUT changing the display list. It
+// reports the row, its display index, and whether a row exists at all:
 //
-// Every mutation goes through here, and that is what keeps retention honest.
-// The cap made the cache a partial view of the table, so a mutation that read
-// indexOf alone had a second reason to see -1 -- the row is retained, just not
-// displayed -- and it could not tell that apart from "no such row". Each applier
-// then dropped its write: a close left the row Running with its transcript
-// unended, a status update went nowhere, a revive never reopened the row, and a
-// replayed running upsert took the retained row for a new one and resurrected
-// it. One lookup for all of them, so no applier can forget the case.
+//   - found=false, idx=-1: no row exists anywhere.
+//   - found=true, idx>=0: the display cache holds it, and idx addresses it.
+//   - found=true, idx=-1: the row is RETAINED in the store but left the display
+//     list. A caller that means to WRITE calls admitRowLocked to put it back.
 //
-// A re-admitted row goes to the END of the display list, and the pool evicts to
-// stay at its cap first. Both follow from what the list is for: a row that a
-// mutation just touched is the most recent activity in the registry, so it is
-// the last thing that should leave the list again.
-func (c *registryCache[T]) rowIndexLocked(ctx context.Context, ownerID, key string) (int, error) {
+// Caller must hold c.Mu.
+//
+// Every mutation resolves through here, and that is what keeps retention
+// honest. The cap made the cache a partial view of the table, so a mutation
+// that read indexOf alone had a second reason to see -1 -- the row is retained,
+// just not displayed -- and it could not tell that apart from "no such row".
+// Each applier then dropped its write: a close left the row Running with its
+// transcript unended, a status update went nowhere, a revive never reopened the
+// row, and a replayed running upsert took the retained row for a new one and
+// resurrected it. One lookup for all of them, so no applier can forget the case.
+//
+// The read and the re-admission are SEPARATE because a mutation decides between
+// them. Most appliers guard first and write second, and a guard that stops the
+// write must leave the display list alone: admitting there evicts a displayed
+// row -- and deletes an unlinked one from the table -- to make space for a write
+// that never happens, and the applier then reports changed=false, so no
+// broadcast tells the client its list moved.
+func (c *registryCache[T]) findRowLocked(ctx context.Context, ownerID, key string) (T, int, bool, error) {
 	if idx := c.indexOf(key); idx >= 0 {
-		return idx, nil
+		return c.Rows[idx], idx, true, nil
 	}
+	var zero T
 	if c.ops.retention == nil {
-		return -1, nil
+		return zero, -1, false, nil
 	}
 	row, found, err := c.ops.retention.load(ctx, ownerID, key)
 	if err != nil {
-		return -1, fmt.Errorf("load retained %s row %s/%s: %w", c.ops.label, ownerID, key, err)
+		return zero, -1, false, fmt.Errorf("load retained %s row %s/%s: %w", c.ops.label, ownerID, key, err)
 	}
 	if !found {
-		return -1, nil
+		return zero, -1, false, nil
 	}
+	return row, -1, true, nil
+}
+
+// admitRowLocked returns a retained row to the display list and reports its new
+// index. Call it only at the point where a mutation commits to a write, because
+// it evicts to keep the pool at its cap. Caller must hold c.Mu.
+//
+// The row goes to the END of the display list, and the pool evicts to stay at
+// its cap first. Both follow from what the list is for: a row that a mutation
+// just touched is the most recent activity in the registry, so it is the last
+// thing that should leave the list again.
+//
+// The stored seq moves with it (ops.retention.reseq), because the position in
+// this slice and the seq are ONE ordering key, not two. ensureSeededLocked
+// states the rule -- ascending seq is what the snapshot, the eviction by slice
+// order, and the sidebar all assume -- and a re-admission that reordered only
+// the slice broke it in both directions: eviction stopped picking the oldest
+// row, and the next cold seed (newest rows by seq) dropped the re-admitted row
+// again, so a subagent a revive had just reopened vanished from the sidebar on
+// the next worker restart.
+func (c *registryCache[T]) admitRowLocked(ctx context.Context, ownerID string, row T) (int, error) {
 	if _, _, err := c.makeRoomLocked(ctx, ownerID, c.bucket(row)); err != nil {
 		return -1, err
 	}
+	if c.ops.retention != nil && c.ops.retention.reseq != nil {
+		if err := c.ops.retention.reseq(ctx, ownerID, c.ops.keyOf(row), c.nextSeq); err != nil {
+			return -1, fmt.Errorf("resequence %s row %s: %w", c.ops.label, c.ops.keyOf(row), err)
+		}
+		c.nextSeq++
+	}
 	c.Rows = append(c.Rows, row)
 	return len(c.Rows) - 1, nil
+}
+
+// deleteRowLocked removes the row at key from the display list, and from the
+// store unless ops.retention keeps it. Reports whether a displayed row left the
+// list. Caller must hold c.Mu.
+//
+// This is the ONE delete a Go caller reaches, so "a retained row survives a
+// delete" cannot be forgotten at a new call site: eviction and an explicit
+// delete now ask ops.retention.keep through the same code. The seed-time
+// reclaim is the one delete that cannot route here -- it is a set-based
+// statement over rows the cache never loaded -- so it mirrors the rule in its
+// own WHERE clause instead.
+func (c *registryCache[T]) deleteRowLocked(ctx context.Context, ownerID, key string) (bool, error) {
+	row, idx, found, err := c.findRowLocked(ctx, ownerID, key)
+	if err != nil {
+		return false, err
+	}
+	if !found {
+		return false, nil
+	}
+	if err := c.dropStoredRowLocked(ctx, ownerID, row); err != nil {
+		return false, fmt.Errorf("delete %s: %w", c.ops.label, err)
+	}
+	if idx < 0 {
+		return false, nil
+	}
+	c.Rows = slices.Delete(c.Rows, idx, idx+1)
+	return true, nil
 }
 
 // makeRoomLocked frees one slot in a full cap pool so an insert keeps the
@@ -295,15 +364,22 @@ func (c *registryCache[T]) evictFirstMatchLocked(ctx context.Context, ownerID st
 // reachable through rowIndexLocked. Caller must hold c.Mu.
 func (c *registryCache[T]) evictAtLocked(ctx context.Context, ownerID string, evictIdx int) (T, bool, error) {
 	evicted := c.Rows[evictIdx]
-	if c.ops.retention == nil || !c.ops.retention.keep(evicted) {
-		key := c.ops.keyOf(evicted)
-		if err := c.ops.deleteByKey(ctx, ownerID, key); err != nil {
-			var zero T
-			return zero, false, fmt.Errorf("evict %s: %w", c.ops.label, err)
-		}
+	if err := c.dropStoredRowLocked(ctx, ownerID, evicted); err != nil {
+		var zero T
+		return zero, false, fmt.Errorf("evict %s: %w", c.ops.label, err)
 	}
 	c.Rows = slices.Delete(c.Rows, evictIdx, evictIdx+1)
 	return evicted, true, nil
+}
+
+// dropStoredRowLocked deletes the persisted row unless ops.retention keeps it,
+// and is the ONE place that asks the question. A registry without retention
+// deletes every row. Caller must hold c.Mu.
+func (c *registryCache[T]) dropStoredRowLocked(ctx context.Context, ownerID string, row T) error {
+	if c.ops.retention != nil && c.ops.retention.keep(row) {
+		return nil
+	}
+	return c.ops.deleteByKey(ctx, ownerID, c.ops.keyOf(row))
 }
 
 // dropRowLocked removes the cached row at key WITHOUT touching the DB, for a

--- a/backend/internal/worker/service/registry_cache.go
+++ b/backend/internal/worker/service/registry_cache.go
@@ -36,6 +36,31 @@ type seedEntry[T any] struct {
 	seq  int64
 }
 
+// registryRetention lets a registry keep a row in the store after the display
+// cap evicts it from the cache. The cap is then a bound on what the sidebar
+// SHOWS, not on what the registry indexes.
+//
+// The background-task registry needs this: a row that carries a child
+// transcript is the only index from that child agent id back to
+// (owner, row_key), and the child `agents` row outlives the registry delete --
+// so deleting the row leaves a live subagent permanently unmessageable and
+// uninterruptible. Retention costs one small row per transcript, and the row
+// cascades away with the root agent exactly when the transcript does.
+//
+// The two halves are ONE field because neither works alone. Keeping a row that
+// nothing can read back makes it unreachable, which is the bug retention exists
+// to fix; and loading a row that eviction deleted finds nothing. Setting both
+// or neither is therefore the only correct choice, and a single pointer is what
+// makes it the only available one.
+type registryRetention[T any] struct {
+	// keep reports whether a row must SURVIVE eviction in the store. Eviction
+	// then drops it from the capped display cache only.
+	keep func(T) bool
+	// load reads a persisted row back by key, so an operation on a row the cache
+	// no longer holds still finds it. found=false for a row that does not exist.
+	load func(ctx context.Context, ownerID, key string) (row T, found bool, err error)
+}
+
 // registryOps supplies the type-specific behaviour a registryCache needs. It is
 // built once per OutputHandler (the closures capture h.queries) and shared by
 // every cache instance of that registry type. Both the background-task registry
@@ -56,18 +81,9 @@ type registryOps[T any] struct {
 	isFinished func(T) bool
 	// deleteByKey deletes the persisted row for `key` under `ownerID`.
 	deleteByKey func(ctx context.Context, ownerID string, key string) error
-	// retainInStore reports whether a row must SURVIVE eviction in the store.
-	// Eviction then drops it from the capped display cache only. Optional: nil
-	// means every evicted row is deleted.
-	//
-	// The cap is a DISPLAY bound, not a storage bound. A background-task row
-	// that carries a child transcript is also the only index from that child id
-	// back to (owner, row_key), and the child `agents` row outlives the registry
-	// delete -- so deleting the row makes a live subagent permanently
-	// unmessageable and uninterruptible. Retention costs one small row per
-	// transcript, and the row cascades away with the root agent exactly when the
-	// transcript does.
-	retainInStore func(T) bool
+	// retention makes some rows outlive the display cap in the store. Optional:
+	// nil means the cap is a storage bound too, and every evicted row is deleted.
+	retention *registryRetention[T]
 	// cap is the maximum number of rows the registry holds IN ONE POOL. With
 	// bucketOf nil there is a single pool, so this is the whole registry.
 	cap int32
@@ -105,7 +121,7 @@ func (c *registryCache[T]) inBucket(row T, bucket string) bool {
 // only ever touches a row the cache HOLDS, so without this pass a surplus row
 // below the window is neither loaded nor deleted -- invisible in the sidebar and
 // growing without limit in the DB. A registry that retains rows past the cap
-// (see ops.retainInStore) must spare those same rows here, in the reclaim query
+// (see ops.retention) must spare those same rows here, in the reclaim query
 // itself, because that surplus is the point: a retained row is an index the
 // display list no longer shows. A reclaim failure is logged, not
 // returned: the cache is correctly seeded either way, and refusing to seed over
@@ -168,8 +184,70 @@ func (c *registryCache[T]) snapshot() []T {
 }
 
 // indexOf returns the row index whose key matches, or -1. Caller must hold c.Mu.
+//
+// This answers "is the row DISPLAYED", which is not the same question as "does
+// the row exist" for a registry with retention. A mutation must ask
+// rowIndexLocked instead; indexOf is for a caller that genuinely means the
+// display list.
 func (c *registryCache[T]) indexOf(key string) int {
 	return slices.IndexFunc(c.Rows, func(r T) bool { return c.ops.keyOf(r) == key })
+}
+
+// rowIndexLocked returns the cache index of the row at key, re-admitting a
+// RETAINED row from the store when the display cache no longer holds it.
+// Returns -1 when no row exists anywhere. Caller must hold c.Mu.
+//
+// Every mutation goes through here, and that is what keeps retention honest.
+// The cap made the cache a partial view of the table, so a mutation that read
+// indexOf alone had a second reason to see -1 -- the row is retained, just not
+// displayed -- and it could not tell that apart from "no such row". Each applier
+// then dropped its write: a close left the row Running with its transcript
+// unended, a status update went nowhere, a revive never reopened the row, and a
+// replayed running upsert took the retained row for a new one and resurrected
+// it. One lookup for all of them, so no applier can forget the case.
+//
+// A re-admitted row goes to the END of the display list, and the pool evicts to
+// stay at its cap first. Both follow from what the list is for: a row that a
+// mutation just touched is the most recent activity in the registry, so it is
+// the last thing that should leave the list again.
+func (c *registryCache[T]) rowIndexLocked(ctx context.Context, ownerID, key string) (int, error) {
+	if idx := c.indexOf(key); idx >= 0 {
+		return idx, nil
+	}
+	if c.ops.retention == nil {
+		return -1, nil
+	}
+	row, found, err := c.ops.retention.load(ctx, ownerID, key)
+	if err != nil {
+		return -1, fmt.Errorf("load retained %s row %s/%s: %w", c.ops.label, ownerID, key, err)
+	}
+	if !found {
+		return -1, nil
+	}
+	if _, _, err := c.makeRoomLocked(ctx, ownerID, c.bucket(row)); err != nil {
+		return -1, err
+	}
+	c.Rows = append(c.Rows, row)
+	return len(c.Rows) - 1, nil
+}
+
+// makeRoomLocked frees one slot in a full cap pool so an insert keeps the
+// display list at its bound, and does nothing when the pool has room. It owns
+// the whole eviction preference: the oldest FINISHED row first, and the oldest
+// row of any status when the pool holds none. RETURNS the evicted row (ok=false
+// when nothing was evicted), so a caller can report which case it got by testing
+// isFinished on it rather than by re-deriving the preference. Caller must hold
+// c.Mu.
+func (c *registryCache[T]) makeRoomLocked(ctx context.Context, ownerID, bucket string) (T, bool, error) {
+	if !c.atCapForBucket(bucket) {
+		var zero T
+		return zero, false, nil
+	}
+	evicted, ok, err := c.evictOldestFinishedInBucketLocked(ctx, ownerID, bucket)
+	if err != nil || ok {
+		return evicted, ok, err
+	}
+	return c.evictOldestInBucketLocked(ctx, ownerID, bucket)
 }
 
 // evictOldestFinishedInBucketLocked removes the first finished row (by slice
@@ -193,8 +271,8 @@ func (c *registryCache[T]) evictOldestFinishedInBucketLocked(ctx context.Context
 // evictOldestInBucketLocked removes the first row (by slice order) of ONE cap
 // pool whatever its status, for an insert into a pool that holds no finished row
 // at all. The cap is a bound on the DISPLAY list, so the oldest entry leaves it
-// even while it runs; ops.retainInStore decides whether the persisted row goes
-// with it. Same bucket and return contract as
+// even while it runs; ops.retention decides whether the persisted row goes with
+// it. Same bucket and return contract as
 // evictOldestFinishedInBucketLocked. Caller must hold c.Mu.
 func (c *registryCache[T]) evictOldestInBucketLocked(ctx context.Context, ownerID, bucket string) (T, bool, error) {
 	return c.evictFirstMatchLocked(ctx, ownerID, func(r T) bool { return c.inBucket(r, bucket) })
@@ -213,11 +291,11 @@ func (c *registryCache[T]) evictFirstMatchLocked(ctx context.Context, ownerID st
 
 // evictAtLocked removes the row at evictIdx from the capped display cache,
 // returning the row it removed. The persisted row goes with it UNLESS
-// ops.retainInStore keeps it: eviction is a display bound, and a retained row
-// stays addressable by a point lookup on its key. Caller must hold c.Mu.
+// ops.retention keeps it: eviction is a display bound, and a retained row stays
+// reachable through rowIndexLocked. Caller must hold c.Mu.
 func (c *registryCache[T]) evictAtLocked(ctx context.Context, ownerID string, evictIdx int) (T, bool, error) {
 	evicted := c.Rows[evictIdx]
-	if c.ops.retainInStore == nil || !c.ops.retainInStore(evicted) {
+	if c.ops.retention == nil || !c.ops.retention.keep(evicted) {
 		key := c.ops.keyOf(evicted)
 		if err := c.ops.deleteByKey(ctx, ownerID, key); err != nil {
 			var zero T

--- a/backend/internal/worker/service/registry_cache.go
+++ b/backend/internal/worker/service/registry_cache.go
@@ -56,6 +56,18 @@ type registryOps[T any] struct {
 	isFinished func(T) bool
 	// deleteByKey deletes the persisted row for `key` under `ownerID`.
 	deleteByKey func(ctx context.Context, ownerID string, key string) error
+	// retainInStore reports whether a row must SURVIVE eviction in the store.
+	// Eviction then drops it from the capped display cache only. Optional: nil
+	// means every evicted row is deleted.
+	//
+	// The cap is a DISPLAY bound, not a storage bound. A background-task row
+	// that carries a child transcript is also the only index from that child id
+	// back to (owner, row_key), and the child `agents` row outlives the registry
+	// delete -- so deleting the row makes a live subagent permanently
+	// unmessageable and uninterruptible. Retention costs one small row per
+	// transcript, and the row cascades away with the root agent exactly when the
+	// transcript does.
+	retainInStore func(T) bool
 	// cap is the maximum number of rows the registry holds IN ONE POOL. With
 	// bucketOf nil there is a single pool, so this is the whole registry.
 	cap int32
@@ -89,13 +101,15 @@ func (c *registryCache[T]) inBucket(row T, bucket string) bool {
 // independently. One global window has the wrong shape: an owner whose newest
 // `cap` rows all belong to one pool seeds every other pool EMPTY.
 //
-// Each pool then reclaims the finished rows its window left behind. The cap is
-// soft (an upsert exceeds it rather than orphan a steerable child), and eviction
-// only ever deletes a row the cache HOLDS -- so without the reclaim the surplus
-// is neither loaded nor deleted, invisible in the sidebar and growing without
-// limit in the DB. A reclaim failure is logged, not returned: the cache is
-// correctly seeded either way, and refusing to seed over it would cost the
-// registry its rows.
+// Each pool then reclaims the finished rows its window left behind. Eviction
+// only ever touches a row the cache HOLDS, so without this pass a surplus row
+// below the window is neither loaded nor deleted -- invisible in the sidebar and
+// growing without limit in the DB. A registry that retains rows past the cap
+// (see ops.retainInStore) must spare those same rows here, in the reclaim query
+// itself, because that surplus is the point: a retained row is an index the
+// display list no longer shows. A reclaim failure is logged, not
+// returned: the cache is correctly seeded either way, and refusing to seed over
+// it would cost the registry its rows.
 func (c *registryCache[T]) ensureSeededLocked(ctx context.Context, ownerID string) error {
 	if c.seeded {
 		return nil
@@ -159,21 +173,37 @@ func (c *registryCache[T]) indexOf(key string) int {
 }
 
 // evictOldestFinishedInBucketLocked removes the first finished row (by slice
-// order) of ONE cap pool from the cache and DB, so making room for a shell row
-// never deletes a subagent's. Pass "" for a single-pool registry (bucketOf nil),
-// where every row shares one pool. RETURNS the evicted row, so a caller that
-// logs it reads the row this method actually deleted rather than re-running an
-// equivalent scan of its own -- two expressions of one predicate that agree only
-// while nobody edits either. Returns ok=false (no error) when the pool holds no
-// finished row. Caller must hold c.Mu.
+// order) of ONE cap pool, so making room for a shell row never drops a
+// subagent's. Pass "" for a single-pool registry (bucketOf nil), where every row
+// shares one pool. RETURNS the evicted row, so a caller that logs it reads the
+// row this method actually removed rather than re-running an equivalent scan of
+// its own -- two expressions of one predicate that agree only while nobody edits
+// either. Returns ok=false (no error) when the pool holds no finished row.
+// Caller must hold c.Mu.
 //
 // There is deliberately NO unscoped wrapper: with a bucketed registry, bucket ""
 // matches nothing, so a wrapper that hardcoded it would evict nothing and report
 // "no finished row" without an error or a log. Naming the pool is the caller's.
 func (c *registryCache[T]) evictOldestFinishedInBucketLocked(ctx context.Context, ownerID, bucket string) (T, bool, error) {
-	evictIdx := slices.IndexFunc(c.Rows, func(r T) bool {
+	return c.evictFirstMatchLocked(ctx, ownerID, func(r T) bool {
 		return c.inBucket(r, bucket) && c.ops.isFinished(r)
 	})
+}
+
+// evictOldestInBucketLocked removes the first row (by slice order) of ONE cap
+// pool whatever its status, for an insert into a pool that holds no finished row
+// at all. The cap is a bound on the DISPLAY list, so the oldest entry leaves it
+// even while it runs; ops.retainInStore decides whether the persisted row goes
+// with it. Same bucket and return contract as
+// evictOldestFinishedInBucketLocked. Caller must hold c.Mu.
+func (c *registryCache[T]) evictOldestInBucketLocked(ctx context.Context, ownerID, bucket string) (T, bool, error) {
+	return c.evictFirstMatchLocked(ctx, ownerID, func(r T) bool { return c.inBucket(r, bucket) })
+}
+
+// evictFirstMatchLocked evicts the first row the predicate accepts, or reports
+// ok=false when none matches. Caller must hold c.Mu.
+func (c *registryCache[T]) evictFirstMatchLocked(ctx context.Context, ownerID string, match func(T) bool) (T, bool, error) {
+	evictIdx := slices.IndexFunc(c.Rows, match)
 	if evictIdx < 0 {
 		var zero T
 		return zero, false, nil
@@ -181,14 +211,18 @@ func (c *registryCache[T]) evictOldestFinishedInBucketLocked(ctx context.Context
 	return c.evictAtLocked(ctx, ownerID, evictIdx)
 }
 
-// evictAtLocked deletes the row at evictIdx from the cache and DB, returning the
-// row it removed. Caller must hold c.Mu.
+// evictAtLocked removes the row at evictIdx from the capped display cache,
+// returning the row it removed. The persisted row goes with it UNLESS
+// ops.retainInStore keeps it: eviction is a display bound, and a retained row
+// stays addressable by a point lookup on its key. Caller must hold c.Mu.
 func (c *registryCache[T]) evictAtLocked(ctx context.Context, ownerID string, evictIdx int) (T, bool, error) {
 	evicted := c.Rows[evictIdx]
-	key := c.ops.keyOf(evicted)
-	if err := c.ops.deleteByKey(ctx, ownerID, key); err != nil {
-		var zero T
-		return zero, false, fmt.Errorf("evict %s: %w", c.ops.label, err)
+	if c.ops.retainInStore == nil || !c.ops.retainInStore(evicted) {
+		key := c.ops.keyOf(evicted)
+		if err := c.ops.deleteByKey(ctx, ownerID, key); err != nil {
+			var zero T
+			return zero, false, fmt.Errorf("evict %s: %w", c.ops.label, err)
+		}
 	}
 	c.Rows = slices.Delete(c.Rows, evictIdx, evictIdx+1)
 	return evicted, true, nil

--- a/frontend/src/components/backgroundtasks/BackgroundTaskList.tsx
+++ b/frontend/src/components/backgroundtasks/BackgroundTaskList.tsx
@@ -15,6 +15,7 @@ import {
   filterBackgroundTasksByKind,
   groupBackgroundTasks,
   isActiveBackgroundTaskStatus,
+  opensSubagentTranscript,
   sortBackgroundTasks,
 } from '~/stores/chatBackgroundTasks'
 import * as styles from './BackgroundTaskList.css'
@@ -250,7 +251,7 @@ export const BackgroundTaskList: Component<BackgroundTaskListProps> = (props) =>
   })
 
   const renderRow = (item: BackgroundTaskItem): JSX.Element => {
-    const clickable = item.kind === 'subagent' && !!item.childAgentId && !!props.onOpenSubagent
+    const clickable = opensSubagentTranscript(item) && !!props.onOpenSubagent
     return (
       <Show
         when={clickable}

--- a/frontend/src/components/chat/AgentEditorPanel.tsx
+++ b/frontend/src/components/chat/AgentEditorPanel.tsx
@@ -173,7 +173,18 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
   /** Register the editor ref if the editor is ready and both refs are available. */
   const tryRegisterEditorRef = (agentId: string) => {
     if (editorReady && editorContentRef && editorFocusFn) {
-      registerEditorRef(agentId, { get: editorContentRef.get, set: editorContentRef.set, focus: editorFocusFn, insert: text => editorInsertFn?.(text) })
+      // `writable` reads the SAME predicate that drives the disabled placeholder,
+      // the send button, and the Enter-to-send plugin, so every surface agrees
+      // about whether this composer takes input. It is passed as a thunk because
+      // `disabledReason` is reactive: a subagent tab resolves it again once the
+      // worker's authoritative acceptsMessages arrives.
+      registerEditorRef(agentId, {
+        get: editorContentRef.get,
+        set: editorContentRef.set,
+        focus: editorFocusFn,
+        insert: text => editorInsertFn?.(text),
+        writable: () => !disabled(),
+      })
       registeredAgentId = agentId
     }
   }

--- a/frontend/src/components/chat/ChatView.tsx
+++ b/frontend/src/components/chat/ChatView.tsx
@@ -341,33 +341,32 @@ export const ChatView: Component<ChatViewProps> = (props) => {
   // re-bundled per row, so buildMessageHost below only assembles the genuinely
   // per-message bindings on top -- making the agent-scoped vs message-scoped split
   // explicit instead of a flat 8-field literal where the distinction is invisible.
-  // Solid compiles `agentLifecycle` -- an object literal at the call site -- to
-  // ONE getter, so reading any field of it inside a tracking scope subscribes to
-  // EVERY field, `thinkingTokens` included, and that streams many deltas per
-  // turn. These two memos absorb that: each re-runs per delta but returns the
-  // same identity (`registryRows` is itself a memo upstream, `onOpenSubagent` a
-  // stable const), so the default === equality stops the propagation here rather
-  // than letting it reach `hostLookups` and rebuild every row's host.
-  const registryRows = createMemo(() => props.agentLifecycle?.registryRows)
-  const openSubagent = createMemo(() => props.agentLifecycle?.onOpenSubagent)
+  // The ROOT registry, indexed by row key so a tool card can turn an agent id
+  // into a link. Indexed once per registry change rather than scanned per card:
+  // a transcript can hold many SendMessage rows, each resolving on every render,
+  // and the registry arrives authoritative-and-replaced-wholesale so there is
+  // exactly one moment to rebuild.
+  const bgRowIndex = createMemo(() => new Map(
+    (props.agentLifecycle?.registryRows ?? []).map(t => [t.rowKey, t] as const),
+  ))
+  // Declared OUTSIDE hostLookups, and by reference. The index has to live in its
+  // own memo: the registry is replaced wholesale on every task_progress tick of
+  // any shell or subagent under this root, so building it inside hostLookups
+  // gave that memo a new identity per tick -- and hostLookups is spread into
+  // every row's host, so one background shell's progress line rebuilt the host
+  // of every message on screen, in every agent tab of the tile. Reading
+  // bgRowIndex() here instead subscribes the CARD that calls this, and nothing
+  // else.
+  const resolveBackgroundTaskRow = (rowKey: string): BackgroundTaskItem | undefined =>
+    bgRowIndex().get(rowKey)
 
-  const hostLookups = createMemo(() => {
-    // The ROOT registry, indexed by row key so a tool card can turn an agent id
-    // into a link. Indexed once per registry change rather than scanned per
-    // card: a transcript can hold many SendMessage rows, each resolving on every
-    // render, and the registry arrives authoritative-and-replaced-wholesale so
-    // there is exactly one moment to rebuild.
-    const byRowKey = new Map(
-      (registryRows() ?? []).map(t => [t.rowKey, t] as const),
-    )
-    return {
-      getTodoById: props.lookups?.getTodoById,
-      getToolUseParsedBySpanId: props.lookups?.getToolUseParsedBySpanId,
-      getToolResultParsedBySpanId: props.lookups?.getToolResultParsedBySpanId,
-      resolveBackgroundTaskRow: (rowKey: string) => byRowKey.get(rowKey),
-      onOpenSubagent: openSubagent(),
-    }
-  })
+  const hostLookups = createMemo(() => ({
+    getTodoById: props.lookups?.getTodoById,
+    getToolUseParsedBySpanId: props.lookups?.getToolUseParsedBySpanId,
+    getToolResultParsedBySpanId: props.lookups?.getToolResultParsedBySpanId,
+    resolveBackgroundTaskRow,
+    onOpenSubagent: props.agentLifecycle?.onOpenSubagent,
+  }))
 
   // The scroll container (also handed to scroll.attachListRef below). Read
   // non-reactively by isRowNearViewport at worker-dispatch time.

--- a/frontend/src/components/chat/ChatView.tsx
+++ b/frontend/src/components/chat/ChatView.tsx
@@ -205,6 +205,14 @@ export interface AgentLifecycleProps {
   providerLabel?: string
   /** Full registry (active + past) for the chip and the popover it opens. */
   backgroundTasks?: BackgroundTaskItem[]
+  /**
+   * The ROOT registry, unfiltered -- what a tool card resolves a recipient id
+   * against. Deliberately NOT `backgroundTasks`: that list is CHIP-scoped, so on
+   * a child tab it holds only the rows that tab itself spawned, and a
+   * SendMessage addressing a sibling or the parent would resolve to nothing --
+   * exactly the sibling-to-sibling case the worker arms a revive for.
+   */
+  registryRows?: BackgroundTaskItem[]
   onOpenSubagent?: (item: BackgroundTaskItem) => void
   /** The agent's to-do list for the todos chip + popover. */
   todos?: TodoItem[]
@@ -333,11 +341,33 @@ export const ChatView: Component<ChatViewProps> = (props) => {
   // re-bundled per row, so buildMessageHost below only assembles the genuinely
   // per-message bindings on top -- making the agent-scoped vs message-scoped split
   // explicit instead of a flat 8-field literal where the distinction is invisible.
-  const hostLookups = createMemo(() => ({
-    getTodoById: props.lookups?.getTodoById,
-    getToolUseParsedBySpanId: props.lookups?.getToolUseParsedBySpanId,
-    getToolResultParsedBySpanId: props.lookups?.getToolResultParsedBySpanId,
-  }))
+  // Solid compiles `agentLifecycle` -- an object literal at the call site -- to
+  // ONE getter, so reading any field of it inside a tracking scope subscribes to
+  // EVERY field, `thinkingTokens` included, and that streams many deltas per
+  // turn. These two memos absorb that: each re-runs per delta but returns the
+  // same identity (`registryRows` is itself a memo upstream, `onOpenSubagent` a
+  // stable const), so the default === equality stops the propagation here rather
+  // than letting it reach `hostLookups` and rebuild every row's host.
+  const registryRows = createMemo(() => props.agentLifecycle?.registryRows)
+  const openSubagent = createMemo(() => props.agentLifecycle?.onOpenSubagent)
+
+  const hostLookups = createMemo(() => {
+    // The ROOT registry, indexed by row key so a tool card can turn an agent id
+    // into a link. Indexed once per registry change rather than scanned per
+    // card: a transcript can hold many SendMessage rows, each resolving on every
+    // render, and the registry arrives authoritative-and-replaced-wholesale so
+    // there is exactly one moment to rebuild.
+    const byRowKey = new Map(
+      (registryRows() ?? []).map(t => [t.rowKey, t] as const),
+    )
+    return {
+      getTodoById: props.lookups?.getTodoById,
+      getToolUseParsedBySpanId: props.lookups?.getToolUseParsedBySpanId,
+      getToolResultParsedBySpanId: props.lookups?.getToolResultParsedBySpanId,
+      resolveBackgroundTaskRow: (rowKey: string) => byRowKey.get(rowKey),
+      onOpenSubagent: openSubagent(),
+    }
+  })
 
   // The scroll container (also handed to scroll.attachListRef below). Read
   // non-reactively by isRowNearViewport at worker-dispatch time.

--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -7,6 +7,7 @@ import type { MessageUiKey } from './messageUiKeys'
 import type { ToolResultMeta } from './providers/registry'
 import type { AgentChatMessage } from '~/generated/leapmux/v1/agent_pb'
 import type { ParsedMessageContent } from '~/lib/messageParser'
+import type { BackgroundTaskItem } from '~/stores/chatBackgroundTasks'
 import type { TodoItem } from '~/stores/chatTodos'
 import type { CommandStreamSegment } from '~/stores/chatTypes'
 
@@ -134,6 +135,14 @@ export interface MessageBubbleHost {
   /** Look up the parsed tool_result message by spanId (for tool_use → tool_result linking). */
   getToolResultParsedBySpanId?: (spanId: string) => ParsedMessageContent | undefined
   /**
+   * Resolve a background-task row key to its row, so a tool card that identifies
+   * an agent by id (Claude's SendMessage `to`) can link to that subagent's
+   * transcript.
+   */
+  resolveBackgroundTaskRow?: (rowKey: string) => BackgroundTaskItem | undefined
+  /** Open (or activate, or revive) a subagent's tab from its registry row. */
+  onOpenSubagent?: (item: BackgroundTaskItem) => void
+  /**
    * Live command stream for this message's span, as a thunk so the host
    * literal stays cheap to construct: callers do the lookup only when a
    * renderer reads it.
@@ -245,7 +254,7 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
   // Toolbar metadata for the current message — collapsibility, diff presence,
   // and a lazy copyable-content getter. Each provider's plugin decides which
   // messages produce metadata (Claude returns it for tool_result; Codex for
-  // terminal-state tool_use spans).
+  // final-state tool_use spans).
   const toolMeta = createMemo<ToolResultMeta | null>(() => {
     const plugin = providerFor(props.message.agentProvider)
     if (!plugin?.toolResultMeta)
@@ -291,6 +300,8 @@ export const MessageBubble: Component<MessageBubbleProps> = (props) => {
     get homeDir() { return props.homeDir },
     diffView,
     get onReply() { return wrappedOnReply() },
+    get resolveBackgroundTaskRow() { return props.host?.resolveBackgroundTaskRow },
+    get onOpenSubagent() { return props.host?.onOpenSubagent },
     get onCopyJson() { return copyJson },
     get jsonCopied() { return props.premeasureMode ? () => false : jsonCopied },
     get createdAt() { return props.message.createdAt },

--- a/frontend/src/components/chat/messageRenderers.tsx
+++ b/frontend/src/components/chat/messageRenderers.tsx
@@ -7,6 +7,7 @@ import type { ControlResponseDeriver } from './persistedControlResponse'
 import type { DiffViewPreference } from '~/context/PreferencesContext'
 import type { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import type { ParsedMessageContent } from '~/lib/messageParser'
+import type { BackgroundTaskItem } from '~/stores/chatBackgroundTasks'
 import type { TodoItem } from '~/stores/chatTodos'
 import type { CommandStreamSegment } from '~/stores/chatTypes'
 import Brain from 'lucide-solid/icons/brain'
@@ -128,6 +129,18 @@ export interface RenderContext {
    * scrolled in (see createWorkerPriorityGate).
    */
   rowOffscreen?: () => boolean
+  /**
+   * Resolve a provider registry row key to its background-task row, so a tool
+   * card that identifies an agent by id can link to that subagent's transcript.
+   *
+   * The key is `BackgroundTaskItem.rowKey` (the proto item calls it `id`) — the
+   * same string Claude's SendMessage carries in `to`. Returns undefined when the
+   * key identifies no row of this root, which is the answer for every recipient
+   * outside this session's subagents.
+   */
+  resolveBackgroundTaskRow?: (rowKey: string) => BackgroundTaskItem | undefined
+  /** Open (or activate, or revive) a subagent's tab from its registry row. */
+  onOpenSubagent?: (item: BackgroundTaskItem) => void
 }
 
 export interface MessageContentRenderer {

--- a/frontend/src/components/chat/providers/agentResultRendering.test.tsx
+++ b/frontend/src/components/chat/providers/agentResultRendering.test.tsx
@@ -1,0 +1,273 @@
+import type { MessageCategory } from '../messageClassification'
+import { render } from '@solidjs/testing-library'
+import { describe, expect, it } from 'vitest'
+import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
+import { claudeToolResultMeta } from './claude/toolResult'
+import './testMocks'
+
+const { renderMessageContent } = await import('../messageRenderers')
+
+const PROMPT = 'You are the lead reviewer subagent. Read the code that it names.'
+const OUTPUT_FILE = '/private/tmp/claude-501/-Users-trustin/tasks/a7bcba10b2b861663.output'
+
+/**
+ * The instructions the CLI attaches to a launch. Addressed to the calling MODEL
+ * -- "never quote or paste any part of it", the id it must not mention, the
+ * warning against reading the output file -- and about nothing the user needs.
+ */
+const HARNESS_TEXT = [
+  'Async agent launched successfully. (This tool result is internal metadata — never quote or paste any part of it.)',
+  'agentId: a7bcba10b2b861663 (internal ID - do not mention to user.)',
+  'Do NOT Read or tail this file via the shell tool.',
+].join('\n')
+
+function asyncLaunch(over: Record<string, unknown> = {}) {
+  return {
+    isAsync: true,
+    status: 'async_launched',
+    agentId: 'a7bcba10b2b861663',
+    description: 'Verify V1 theme pair freeze',
+    resolvedModel: 'claude-opus-5[1m]',
+    prompt: PROMPT,
+    outputFile: OUTPUT_FILE,
+    canReadOutputFile: true,
+    ...over,
+  }
+}
+
+function agentToolResult(resultContent: string, toolUseResult?: Record<string, unknown>) {
+  return {
+    type: 'user',
+    message: {
+      role: 'user',
+      content: [{ tool_use_id: 'test-agent', type: 'tool_result', content: resultContent }],
+    },
+    ...(toolUseResult ? { tool_use_result: toolUseResult } : {}),
+  }
+}
+
+function renderAgentResult(resultContent: string, toolUseResult?: Record<string, unknown>): HTMLElement {
+  const category: MessageCategory = { kind: 'tool_result' }
+  const result = renderMessageContent(
+    agentToolResult(resultContent, toolUseResult),
+    { spanType: 'Agent' },
+    category,
+    AgentProvider.CLAUDE_CODE,
+  )
+  return render(() => result).container
+}
+
+describe('claude Agent tool_result rendering: an async launch', () => {
+  // The task title is the only human-written string in the payload, and the one
+  // the user recognizes. The agent id is a generated token that says nothing
+  // about the work, so it belongs in the field list rather than the headline.
+  it('shows the task in the header rather than the agent id', () => {
+    const text = renderAgentResult(HARNESS_TEXT, asyncLaunch()).textContent ?? ''
+    expect(text).toContain('Agent \'Verify V1 theme pair freeze\' launched asynchronously')
+  })
+
+  it('lists the agent id, the model and the output file', () => {
+    const text = renderAgentResult(HARNESS_TEXT, asyncLaunch()).textContent ?? ''
+    expect(text).toContain('Agent ID:')
+    expect(text).toContain('a7bcba10b2b861663')
+    expect(text).toContain('Model:')
+    expect(text).toContain('claude-opus-5[1m]')
+    expect(text).toContain('Output:')
+    expect(text).toContain(OUTPUT_FILE)
+  })
+
+  it('shows the prompt as the body, under a label', () => {
+    const text = renderAgentResult(HARNESS_TEXT, asyncLaunch()).textContent ?? ''
+    expect(text).toContain('Prompt')
+    expect(text).toContain('Read the code that it names')
+  })
+
+  // The whole point of the change: a launch has no report, so the old card fell
+  // back to the harness instructions and buried the task under them.
+  it('drops the harness instructions entirely', () => {
+    const text = renderAgentResult(HARNESS_TEXT, asyncLaunch()).textContent ?? ''
+    expect(text).not.toContain('internal metadata')
+    expect(text).not.toContain('Do NOT Read or tail')
+  })
+
+  // resolvedModel alone reports only where the run ended up, which reads as
+  // though it ran there throughout.
+  it('reports a mid-run model swap in full', () => {
+    const text = renderAgentResult(HARNESS_TEXT, asyncLaunch({
+      modelsUsed: ['claude-sonnet-5', 'claude-opus-5[1m]'],
+    })).textContent ?? ''
+    expect(text).toContain('Models:')
+    expect(text).toContain('claude-sonnet-5 → claude-opus-5[1m]')
+  })
+
+  // The header is one CLIPPED line that ENDS with the outcome, so an unbounded
+  // description pushes `launched asynchronously` off the right edge -- and the
+  // icon separates only `completed` from everything else, so a failed run and a
+  // launched one become indistinguishable.
+  it('caps an overlong task description so the outcome stays in the header', () => {
+    const description = 'Audit every renderer that clips a one-line header '.repeat(4)
+    const text = renderAgentResult(HARNESS_TEXT, asyncLaunch({ description })).textContent ?? ''
+    expect(text).toContain('\u2026\' launched asynchronously')
+    expect(text).not.toContain(description)
+  })
+
+  it('keeps a multi-line description to its first line', () => {
+    const text = renderAgentResult(HARNESS_TEXT, asyncLaunch({
+      description: 'Freeze the theme pairs\nand then audit them',
+    })).textContent ?? ''
+    expect(text).toContain('Agent \'Freeze the theme pairs\' launched asynchronously')
+    expect(text).not.toContain('and then audit them')
+  })
+
+  // A whitespace-only description took the truthy branch and rendered
+  // `Agent '   ' launched asynchronously`; the trim makes it fall back to the id,
+  // which is what agentTitle's own doc says happens.
+  it('falls back to the agent id for a blank description', () => {
+    const text = renderAgentResult(HARNESS_TEXT, asyncLaunch({ description: '   ' })).textContent ?? ''
+    expect(text).toContain('Agent a7bcba10b2b861663 launched asynchronously')
+  })
+
+  // A finished sync run carries no description at all, so the id is all there is.
+  it('falls back to the agent id when the payload carries no description', () => {
+    const text = renderAgentResult(HARNESS_TEXT, asyncLaunch({ description: '' })).textContent ?? ''
+    expect(text).toContain('Agent a7bcba10b2b861663 launched asynchronously')
+  })
+})
+
+describe('claude Agent tool_result rendering: a remote launch', () => {
+  it('shows the task and lists the task id and session url', () => {
+    const text = renderAgentResult('', {
+      status: 'remote_launched',
+      taskId: 'task-remote-1',
+      sessionUrl: 'https://claude.ai/session/abc',
+      description: 'Audit the migration',
+      prompt: PROMPT,
+      outputFile: OUTPUT_FILE,
+    }).textContent ?? ''
+    expect(text).toContain('Agent \'Audit the migration\' launched remotely')
+    expect(text).toContain('Task ID:')
+    expect(text).toContain('task-remote-1')
+    expect(text).toContain('Session:')
+    expect(text).toContain('https://claude.ai/session/abc')
+  })
+})
+
+describe('claude Agent tool_result rendering: a finished run', () => {
+  const completed = {
+    status: 'completed',
+    agentId: 'a7bcba10b2b861663',
+    content: [{ type: 'text', text: 'The tide comes in twice a day.' }],
+    prompt: PROMPT,
+    resolvedModel: 'claude-opus-5[1m]',
+  }
+
+  // The report is the deliverable here, so it stays the body and the prompt does
+  // not push it down the card.
+  it('shows the report rather than the prompt', () => {
+    const text = renderAgentResult('', completed).textContent ?? ''
+    expect(text).toContain('The tide comes in twice a day.')
+    expect(text).not.toContain('Read the code that it names')
+    expect(text).not.toContain('Prompt')
+  })
+
+  it('keeps the agent id in the header when there is no description', () => {
+    const text = renderAgentResult('', completed).textContent ?? ''
+    expect(text).toContain('Agent a7bcba10b2b861663 completed')
+  })
+
+  // A sync result recorded before the structured content existed has only the
+  // block text, and that IS the report -- unlike a launch, where it is harness
+  // instructions.
+  it('falls back to the block content for a run that carries no content array', () => {
+    const text = renderAgentResult('A plain report.', {
+      status: 'completed',
+      agentId: 'a1',
+    }).textContent ?? ''
+    expect(text).toContain('A plain report.')
+  })
+
+  it('falls through to the catch-all when there is no structured payload at all', () => {
+    const text = renderAgentResult('just text').textContent ?? ''
+    expect(text).not.toContain('Agent ID:')
+  })
+})
+
+describe('claudeToolResultMeta for Agent', () => {
+  const meta = (toolUseResult: Record<string, unknown>, resultContent = HARNESS_TEXT) =>
+    claudeToolResultMeta(
+      { kind: 'tool_result' },
+      agentToolResult(resultContent, toolUseResult),
+      'Agent',
+      undefined,
+    )
+
+  // The toolbar must act on the text the card shows. Copying the harness
+  // instructions gave the user the one thing on the row that is not about their
+  // subagent.
+  it('copies the prompt for a launch, not the harness instructions', () => {
+    expect(meta(asyncLaunch())?.copyableContent()).toBe(PROMPT)
+  })
+
+  it('copies the report for a finished run', () => {
+    const copied = meta({
+      status: 'completed',
+      agentId: 'a1',
+      content: [{ type: 'text', text: 'The report.' }],
+      prompt: PROMPT,
+    }, '')?.copyableContent()
+    expect(copied).toBe('The report.')
+  })
+
+  it('judges collapsibility from the body the card renders', () => {
+    const longPrompt = Array.from({ length: 40 }, (_, i) => `line ${i}`).join('\n')
+    expect(meta(asyncLaunch({ prompt: longPrompt }))?.collapsible).toBe(true)
+    expect(meta(asyncLaunch({ prompt: 'one line' }))?.collapsible).toBe(false)
+  })
+})
+
+describe('claude Agent tool_result rendering: field-list edge cases', () => {
+  // One entry is not a swap, so the singular label is the honest one.
+  it('reports a single-entry modelsUsed as the plain model', () => {
+    const text = renderAgentResult(HARNESS_TEXT, asyncLaunch({
+      modelsUsed: ['claude-opus-5[1m]'],
+    })).textContent ?? ''
+    expect(text).toContain('Model:')
+    expect(text).not.toContain('Models:')
+  })
+
+  it('lists the worktree of an isolated run', () => {
+    const text = renderAgentResult('', {
+      status: 'completed',
+      agentId: 'a1',
+      content: [{ type: 'text', text: 'done' }],
+      worktreePath: '/tmp/wt/feature',
+      worktreeBranch: 'feature-x',
+    }).textContent ?? ''
+    expect(text).toContain('Branch:')
+    expect(text).toContain('feature-x')
+    expect(text).toContain('Worktree:')
+    expect(text).toContain('/tmp/wt/feature')
+  })
+
+  // Neither a report nor a prompt: the card is its header and fields, with no
+  // empty body block below them.
+  it('renders no body when the payload carries neither report nor prompt', () => {
+    const container = renderAgentResult('', {
+      status: 'async_launched',
+      agentId: 'a1',
+      description: 'Something',
+    })
+    expect(container.textContent).toContain('Agent \'Something\' launched asynchronously')
+    expect(container.textContent).not.toContain('Prompt')
+  })
+
+  // A launch whose payload lost its agent id still says what it is, rather than
+  // rendering a header with a gap where the identity should be.
+  it('keeps a readable header when the launch carries no identity at all', () => {
+    const text = renderAgentResult('', {
+      status: 'async_launched',
+      prompt: 'do the thing',
+    }).textContent ?? ''
+    expect(text).toContain('Agent launched asynchronously')
+  })
+})

--- a/frontend/src/components/chat/providers/claude/extractors/agent.test.ts
+++ b/frontend/src/components/chat/providers/claude/extractors/agent.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+import { claudeAgentFromToolResult, claudeAgentResultBody, claudeAgentResultIsLaunch } from './agent'
+
+const HARNESS_TEXT = 'Async agent launched successfully. (internal metadata — never quote it.)'
+
+describe('claudeAgentFromToolResult', () => {
+  it('returns null for a payload that is not an object', () => {
+    expect(claudeAgentFromToolResult(undefined, 'text')).toBeNull()
+  })
+
+  it('defaults an absent status to completed', () => {
+    expect(claudeAgentFromToolResult({ agentId: 'a1' }, '')?.status).toBe('completed')
+  })
+
+  // The block text is the report for a finished run, and the CLI's instructions
+  // to the model for a launch -- so it backs the body in one case only.
+  it('adopts the block text as the report for a finished run', () => {
+    const source = claudeAgentFromToolResult({ status: 'completed', agentId: 'a1' }, 'A plain report.')
+    expect(source?.content).toBe('A plain report.')
+  })
+
+  it('leaves a launch body empty rather than adopting the harness text', () => {
+    const source = claudeAgentFromToolResult({ status: 'async_launched', agentId: 'a1' }, HARNESS_TEXT)
+    expect(source?.content).toBe('')
+  })
+})
+
+describe('agent report text', () => {
+  it('joins the text blocks of a finished run', () => {
+    const source = claudeAgentFromToolResult({
+      status: 'completed',
+      content: [{ type: 'text', text: 'First.' }, { type: 'text', text: 'Second.' }],
+    }, '')
+    expect(source?.content).toBe('First.\n\nSecond.')
+  })
+
+  // A subagent that takes a screenshot returns image blocks, and the card
+  // renders markdown. Filtering to text alone dropped the picture entirely.
+  it('keeps an image block as markdown', () => {
+    const source = claudeAgentFromToolResult({
+      status: 'completed',
+      content: [
+        { type: 'text', text: 'Here it is.' },
+        { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'AAA' } },
+      ],
+    }, '')
+    expect(source?.content).toContain('Here it is.')
+    expect(source?.content).toContain('![image](data:image/png;base64,AAA)')
+  })
+
+  it('keeps an external image as a link rather than an inline embed', () => {
+    const source = claudeAgentFromToolResult({
+      status: 'completed',
+      content: [{ type: 'image', source: { type: 'url', url: 'https://example.test/a.png' } }],
+    }, '')
+    expect(source?.content).toBe('[image](https://example.test/a.png)')
+  })
+
+  // A non-array `content` yields no report, so a finished run falls back to the
+  // block text exactly as it does when the field is absent.
+  it('ignores a content field that is not an array', () => {
+    const source = claudeAgentFromToolResult({ status: 'completed', content: 'oops' }, 'The block text.')
+    expect(source?.content).toBe('The block text.')
+  })
+})
+
+describe('claudeAgentResultIsLaunch', () => {
+  it.each(['async_launched', 'remote_launched'])('reports %s as a launch', (status) => {
+    expect(claudeAgentResultIsLaunch(claudeAgentFromToolResult({ status }, '')!)).toBe(true)
+  })
+
+  it('reports a finished run as not a launch', () => {
+    const source = claudeAgentFromToolResult({ status: 'completed', content: [{ type: 'text', text: 'done' }] }, '')
+    expect(claudeAgentResultIsLaunch(source!)).toBe(false)
+  })
+
+  // A finished synchronous run carries no output file, so "no report but an
+  // output file" is a launch whatever the CLI calls the status. Without this a
+  // launch status added later falls through to the finished path, where the
+  // body becomes the harness instructions.
+  it('reports an unknown status with an output file as a launch', () => {
+    const source = claudeAgentFromToolResult({ status: 'queued', outputFile: '/tmp/a.output' }, HARNESS_TEXT)
+    expect(claudeAgentResultIsLaunch(source!)).toBe(true)
+    expect(source?.content).toBe('')
+  })
+
+  it('does not call a run with a report a launch merely because it gives an output file', () => {
+    const source = claudeAgentFromToolResult({
+      status: 'completed',
+      outputFile: '/tmp/a.output',
+      content: [{ type: 'text', text: 'The report.' }],
+    }, '')
+    expect(claudeAgentResultIsLaunch(source!)).toBe(false)
+  })
+})
+
+describe('claudeAgentResultBody', () => {
+  it('prefers the report over the prompt', () => {
+    const source = claudeAgentFromToolResult({
+      status: 'completed',
+      prompt: 'Do the thing.',
+      content: [{ type: 'text', text: 'Did it.' }],
+    }, '')
+    expect(claudeAgentResultBody(source!)).toBe('Did it.')
+  })
+
+  it('falls back to the prompt for a launch, which has no report yet', () => {
+    const source = claudeAgentFromToolResult({ status: 'async_launched', prompt: 'Do the thing.' }, HARNESS_TEXT)
+    expect(claudeAgentResultBody(source!)).toBe('Do the thing.')
+  })
+
+  it('is empty when the payload carries neither', () => {
+    const source = claudeAgentFromToolResult({ status: 'async_launched', agentId: 'a1' }, '')
+    expect(claudeAgentResultBody(source!)).toBe('')
+  })
+})

--- a/frontend/src/components/chat/providers/claude/extractors/agent.ts
+++ b/frontend/src/components/chat/providers/claude/extractors/agent.ts
@@ -1,0 +1,115 @@
+import { asContentArray, joinContentParagraphs } from '~/lib/contentBlocks'
+import { isObject, pickString, stringArray } from '~/lib/jsonPick'
+
+/**
+ * The three shapes an `Agent` tool_result carries, flattened into one.
+ *
+ * The CLI returns a union (2.1.233), and the variants differ in what they can
+ * possibly hold, which is why the view branches on `status` rather than on
+ * whether a field happens to be filled:
+ *
+ *   - `completed` — a SYNCHRONOUS run. Carries the agent's own report in
+ *     `content[]`, plus usage and tool stats. Carries NO `description` and no
+ *     `outputFile`.
+ *   - `async_launched` — a backgrounded run. Carries `description` (the task
+ *     title the model wrote), `outputFile`, and the `prompt` it was given, but
+ *     no report: it has not produced one yet.
+ *   - `remote_launched` — a cloud run. Like the async one, but identified by
+ *     `taskId` + `sessionUrl` instead of `agentId`.
+ */
+export interface ClaudeAgentResult {
+  status: string
+  /** The model-supplied task title. A launch has one; a finished sync run does not. */
+  description: string
+  agentId: string
+  taskId: string
+  sessionUrl: string
+  resolvedModel: string
+  /** Every distinct model used before backgrounding. Longer than 1 means a mid-run swap. */
+  modelsUsed: string[]
+  outputFile: string
+  prompt: string
+  worktreePath: string
+  worktreeBranch: string
+  /** The agent's own report. Only a finished sync run has one. */
+  content: string
+}
+
+/**
+ * Whether this result announces a launch rather than reporting a finished run.
+ *
+ * The status allowlist is the primary signal, and `outputFile` widens it: a
+ * finished synchronous run carries none (see the variants above), so a result
+ * with no report but an output file is a launch whatever the CLI calls it. The
+ * status list alone would let a launch status added tomorrow fall through to the
+ * finished path, where the body becomes the harness instructions -- the bug this
+ * card exists to avoid.
+ */
+export function claudeAgentResultIsLaunch(source: ClaudeAgentResult): boolean {
+  return source.status === 'async_launched'
+    || source.status === 'remote_launched'
+    || (!source.content && source.outputFile !== '')
+}
+
+/**
+ * Flatten an `Agent` tool_result into {@link ClaudeAgentResult}.
+ *
+ * `resultContent` backs the report ONLY for a non-launch. For a launch it is the
+ * CLI's instructions to the calling model -- "never quote or paste any part of
+ * it", the id it must not mention, the warning against reading the output file.
+ * None of that is about the subagent that the user reads, so treating it as
+ * the card's body buried the one thing that is: what the agent was asked to do.
+ *
+ * Returns null when the payload is not an object, so the dispatch entry can fall
+ * through to the catch-all.
+ */
+export function claudeAgentFromToolResult(
+  toolUseResult: Record<string, unknown> | undefined,
+  resultContent: string,
+): ClaudeAgentResult | null {
+  if (!isObject(toolUseResult))
+    return null
+  const status = pickString(toolUseResult, 'status', 'completed')
+  const source: ClaudeAgentResult = {
+    status,
+    description: pickString(toolUseResult, 'description'),
+    agentId: pickString(toolUseResult, 'agentId'),
+    taskId: pickString(toolUseResult, 'taskId'),
+    sessionUrl: pickString(toolUseResult, 'sessionUrl'),
+    resolvedModel: pickString(toolUseResult, 'resolvedModel'),
+    modelsUsed: stringArray(toolUseResult.modelsUsed),
+    outputFile: pickString(toolUseResult, 'outputFile'),
+    prompt: pickString(toolUseResult, 'prompt'),
+    worktreePath: pickString(toolUseResult, 'worktreePath'),
+    worktreeBranch: pickString(toolUseResult, 'worktreeBranch'),
+    content: agentReportText(toolUseResult),
+  }
+  // The block text backs the report only for a NON-launch. For a launch it is
+  // the CLI's instructions to the calling model, which is the one thing on the
+  // row that is not about the user's subagent.
+  if (!source.content && !claudeAgentResultIsLaunch(source))
+    source.content = resultContent
+  return source
+}
+
+/**
+ * Join the blocks of a finished run's `content[]` into the report.
+ *
+ * `joinContentParagraphs` rather than a text-only filter, because its default
+ * `formatOther` is `markdownImageFormatter`: a subagent that returns a
+ * screenshot or a diagram carries image blocks, and the card renders markdown,
+ * so they survive as `![image](...)`. Dropping every non-text block lost that
+ * picture with nothing to replace it.
+ */
+function agentReportText(toolUseResult: Record<string, unknown>): string {
+  return joinContentParagraphs(asContentArray(toolUseResult.content), { text: 'text' }).trim()
+}
+
+/**
+ * What the card's collapsible body shows: the agent's report when it has one,
+ * and otherwise the prompt it was launched with. A launch has no report, so the
+ * prompt is the only thing it can say about the work now in flight.
+ */
+export function claudeAgentResultBody(source: ClaudeAgentResult): string {
+  return source.content || source.prompt
+}

--- a/frontend/src/components/chat/providers/claude/extractors/agent.ts
+++ b/frontend/src/components/chat/providers/claude/extractors/agent.ts
@@ -13,7 +13,7 @@ import { isObject, pickString, stringArray } from '~/lib/jsonPick'
  *     `outputFile`.
  *   - `async_launched` — a backgrounded run. Carries `description` (the task
  *     title the model wrote), `outputFile`, and the `prompt` it was given, but
- *     no report: it has not produced one yet.
+ *     no report: it produced none yet.
  *   - `remote_launched` — a cloud run. Like the async one, but identified by
  *     `taskId` + `sessionUrl` instead of `agentId`.
  */

--- a/frontend/src/components/chat/providers/claude/extractors/listAgents.ts
+++ b/frontend/src/components/chat/providers/claude/extractors/listAgents.ts
@@ -1,0 +1,22 @@
+import { pickString } from '~/lib/jsonPick'
+
+/**
+ * The `ListAgents` listing: the CLI's own `listing` field, falling back to the
+ * block text.
+ *
+ * Structured first, text second -- the documented idiom. `listing` is what the
+ * CLI's `mapToolResultToToolResultBlockParam` puts into the tool_result content,
+ * so the two are the same string today and the fallback covers a transcript
+ * recorded before the structured payload existed.
+ *
+ * One home for the rule, because three callers ask about the same text and must
+ * agree: the card renders it, the toolbar decides collapsibility from it, and
+ * Copy yields it. A second copy is how "the toolbar acts on what the user sees"
+ * stops being true.
+ */
+export function claudeListAgentsListing(
+  toolUseResult: Record<string, unknown> | undefined,
+  resultContent: string,
+): string {
+  return pickString(toolUseResult, 'listing', '') || resultContent
+}

--- a/frontend/src/components/chat/providers/claude/extractors/listAgents.ts
+++ b/frontend/src/components/chat/providers/claude/extractors/listAgents.ts
@@ -18,5 +18,10 @@ export function claudeListAgentsListing(
   toolUseResult: Record<string, unknown> | undefined,
   resultContent: string,
 ): string {
-  return pickString(toolUseResult, 'listing', '') || resultContent
+  // Trimmed HERE, so every caller sees the same string. The renderer treated a
+  // whitespace-only listing as absent and handed the row to the catch-all, while
+  // the toolbar read the untrimmed value as non-empty and offered a Copy button
+  // that yielded spaces -- the exact disagreement the one-home rule above exists
+  // to prevent.
+  return (pickString(toolUseResult, 'listing', '') || resultContent).trim()
 }

--- a/frontend/src/components/chat/providers/claude/toolResult.ts
+++ b/frontend/src/components/chat/providers/claude/toolResult.ts
@@ -8,8 +8,10 @@ import { formatUnifiedDiffText } from '../../diff'
 import { COLLAPSED_RESULT_ROWS, hasMoreLinesThan } from '../../results/collapse'
 import { commandOutputIsCollapsible } from '../../results/commandResult'
 import { fileEditDiffHunks, fileEditHasDiff } from '../../results/fileEditDiff'
+import { claudeAgentFromToolResult, claudeAgentResultBody } from './extractors/agent'
 import { extractToolResultText } from './extractors/assistantContent'
 import { claudeFileEditFromToolUseResult } from './extractors/fileEdit'
+import { claudeListAgentsListing } from './extractors/listAgents'
 import { claudeRemoteTriggerFromToolResult } from './extractors/remoteTrigger'
 
 /** Resolve toolName + tool_use_result for a Claude tool_result message. */
@@ -24,6 +26,35 @@ function extractToolResultInfo(
   if (!toolName && !toolUseResult)
     return null
   return { toolName, toolUseResult }
+}
+
+/**
+ * The body a structured card RENDERS, for the tools that have one.
+ *
+ * These are the only tools whose three questions below -- is it collapsible, is
+ * there anything to copy, what gets copied -- have ONE answer, so reading the
+ * body once here is what stops them drifting. Every other tool measures the
+ * three differently (Grep counts filenames, Read reads file.numLines, Bash
+ * normalizes \r-overwrites first), which is why they keep their own branches and
+ * this returns null for them.
+ *
+ * null means "this tool has no structured body, answer from resultText". '' means
+ * "it has one and it is empty" -- a launch with no prompt, which must NOT fall
+ * back to resultText, because there resultText is the CLI's instructions to the
+ * model and the card never shows them.
+ */
+function structuredResultBody(
+  toolName: string,
+  toolUseResult: Record<string, unknown> | undefined,
+  resultText: string | null,
+): string | null {
+  if (toolName === CLAUDE_TOOL.LIST_AGENTS)
+    return claudeListAgentsListing(toolUseResult, resultText ?? '')
+  if (toolName === CLAUDE_TOOL.AGENT) {
+    const source = claudeAgentFromToolResult(toolUseResult, resultText ?? '')
+    return source ? claudeAgentResultBody(source) : null
+  }
+  return null
 }
 
 /**
@@ -53,13 +84,12 @@ function isCollapsible(
       return (file.numLines as number) > COLLAPSED_RESULT_ROWS
   }
 
-  if (toolName === CLAUDE_TOOL.AGENT) {
-    if (Array.isArray(toolUseResult?.content)
-      && (toolUseResult.content as Array<Record<string, unknown>>).some(c => isObject(c) && c.type === 'text')) {
-      return true
-    }
-    return resultText != null && hasMoreLinesThan(resultText, COLLAPSED_RESULT_ROWS)
-  }
+  // Judge the text the CARD shows, which for a launch is the prompt rather than
+  // the harness instructions in resultText. Reading resultText there put the
+  // expand button on a body the card no longer renders.
+  const structuredCollapsible = structuredResultBody(toolName, toolUseResult, resultText)
+  if (structuredCollapsible !== null)
+    return hasMoreLinesThan(structuredCollapsible, COLLAPSED_RESULT_ROWS)
 
   if (toolName === CLAUDE_TOOL.WEB_FETCH && typeof toolUseResult?.code === 'number')
     return true
@@ -98,6 +128,13 @@ function hasCopyable(
   }
   if (toolName === CLAUDE_TOOL.WRITE)
     return typeof toolUseResult?.newString === 'string'
+  // Mirrors computeCopyableContent's structured branch. Without it the default
+  // answers from resultText, which extractToolResultText reports as null for an
+  // empty block content -- so a card showing a structured listing, or a launch
+  // showing its prompt, offered no Copy button at all.
+  const structured = structuredResultBody(toolName, toolUseResult, resultText)
+  if (structured !== null)
+    return structured !== ''
   return resultText !== null
 }
 
@@ -128,6 +165,13 @@ function computeCopyableContent(
     if (source)
       return `HTTP ${source.status}\n${prettifyJson(source.parsed ?? source.json)}`
   }
+
+  // No `|| resultText` fallback. For a launch with no prompt the body is empty
+  // and resultText is the CLI's instructions to the model -- text the card
+  // deliberately never shows, so Copy must not hand it over either.
+  const structuredCopy = structuredResultBody(toolName, toolUseResult, resultText)
+  if (structuredCopy !== null)
+    return structuredCopy || null
 
   return resultText
 }

--- a/frontend/src/components/chat/providers/claude/toolResult.ts
+++ b/frontend/src/components/chat/providers/claude/toolResult.ts
@@ -58,14 +58,15 @@ function structuredResultBody(
 }
 
 /**
- * Per-tool collapsibility check. `resultText` is the (possibly null) cached
- * tool_result text for the current message; pass it in so `claudeToolResultMeta`
- * only walks the content array once.
+ * Per-tool collapsibility check. `resultText` and `structuredBody` are the
+ * cached tool_result text and structured body for the current message; pass
+ * them in so `claudeToolResultMeta` only walks the content array once.
  */
 function isCollapsible(
   toolName: string,
   toolUseResult: Record<string, unknown> | undefined,
   resultText: string | null,
+  structuredBody: string | null,
 ): boolean {
   if (toolName === CLAUDE_TOOL.GREP || toolName === CLAUDE_TOOL.GLOB) {
     const filenames = Array.isArray(toolUseResult?.filenames) ? toolUseResult.filenames as string[] : []
@@ -87,9 +88,8 @@ function isCollapsible(
   // Judge the text the CARD shows, which for a launch is the prompt rather than
   // the harness instructions in resultText. Reading resultText there put the
   // expand button on a body the card no longer renders.
-  const structuredCollapsible = structuredResultBody(toolName, toolUseResult, resultText)
-  if (structuredCollapsible !== null)
-    return hasMoreLinesThan(structuredCollapsible, COLLAPSED_RESULT_ROWS)
+  if (structuredBody !== null)
+    return hasMoreLinesThan(structuredBody, COLLAPSED_RESULT_ROWS)
 
   if (toolName === CLAUDE_TOOL.WEB_FETCH && typeof toolUseResult?.code === 'number')
     return true
@@ -119,6 +119,7 @@ function hasCopyable(
   toolUseResult: Record<string, unknown> | undefined,
   hasEditDiff: boolean,
   resultText: string | null,
+  structuredBody: string | null,
 ): boolean {
   if (toolName === CLAUDE_TOOL.EDIT)
     return hasEditDiff
@@ -132,9 +133,8 @@ function hasCopyable(
   // answers from resultText, which extractToolResultText reports as null for an
   // empty block content -- so a card showing a structured listing, or a launch
   // showing its prompt, offered no Copy button at all.
-  const structured = structuredResultBody(toolName, toolUseResult, resultText)
-  if (structured !== null)
-    return structured !== ''
+  if (structuredBody !== null)
+    return structuredBody !== ''
   return resultText !== null
 }
 
@@ -143,6 +143,7 @@ function computeCopyableContent(
   toolName: string,
   toolUseResult: Record<string, unknown> | undefined,
   resultText: string | null,
+  structuredBody: string | null,
 ): string | null {
   if (toolName === CLAUDE_TOOL.EDIT) {
     const src = claudeFileEditFromToolUseResult(toolUseResult)
@@ -169,9 +170,8 @@ function computeCopyableContent(
   // No `|| resultText` fallback. For a launch with no prompt the body is empty
   // and resultText is the CLI's instructions to the model -- text the card
   // deliberately never shows, so Copy must not hand it over either.
-  const structuredCopy = structuredResultBody(toolName, toolUseResult, resultText)
-  if (structuredCopy !== null)
-    return structuredCopy || null
+  if (structuredBody !== null)
+    return structuredBody || null
 
   return resultText
 }
@@ -204,11 +204,16 @@ export function claudeToolResultMeta(
   // Walk message.content once; downstream collapsibility/copy paths reuse it.
   const resultText = extractToolResultText(obj)
   const hasEditDiff = fileEditHasDiff(claudeFileEditFromToolUseResult(toolUseResult))
+  // The structured body ONCE, beside resultText and for the same reason. Each of
+  // the three readers below used to build it again, so an Agent report was
+  // re-flattened twice per meta -- and a subagent that returned a screenshot had
+  // its base64 payload re-embedded into a data URL each time.
+  const structuredBody = structuredResultBody(toolName, toolUseResult, resultText)
 
   return {
-    collapsible: isCollapsible(toolName, toolUseResult, resultText),
+    collapsible: isCollapsible(toolName, toolUseResult, resultText, structuredBody),
     hasDiff: hasEditDiff,
-    hasCopyable: hasCopyable(toolName, toolUseResult, hasEditDiff, resultText),
-    copyableContent: () => computeCopyableContent(toolName, toolUseResult, resultText),
+    hasCopyable: hasCopyable(toolName, toolUseResult, hasEditDiff, resultText, structuredBody),
+    copyableContent: () => computeCopyableContent(toolName, toolUseResult, resultText, structuredBody),
   }
 }

--- a/frontend/src/components/chat/providers/claude/toolResults/agent.tsx
+++ b/frontend/src/components/chat/providers/claude/toolResults/agent.tsx
@@ -4,6 +4,7 @@ import type { ClaudeAgentResult } from '../extractors/agent'
 import Bot from 'lucide-solid/icons/bot'
 import Check from 'lucide-solid/icons/check'
 import { createMemo, For, Show } from 'solid-js'
+import { clipFirstLine } from '~/lib/clipFirstLine'
 import { getToolResultExpanded } from '../../../messageRenderers'
 import { CollapsibleContent } from '../../../results/CollapsibleContent'
 import { ToolStatusHeader } from '../../../results/ToolStatusHeader'
@@ -37,8 +38,7 @@ const DESCRIPTION_LIMIT = 80
  * launched one.
  */
 function clipDescription(description: string): string {
-  const line = description.trim().split('\n', 1)[0]
-  return line.length > DESCRIPTION_LIMIT ? `${line.slice(0, DESCRIPTION_LIMIT)}\u2026` : line
+  return clipFirstLine(description, DESCRIPTION_LIMIT)
 }
 
 /**

--- a/frontend/src/components/chat/providers/claude/toolResults/agent.tsx
+++ b/frontend/src/components/chat/providers/claude/toolResults/agent.tsx
@@ -1,34 +1,143 @@
 import type { JSX } from 'solid-js'
 import type { RenderContext } from '../../../messageRenderers'
+import type { ClaudeAgentResult } from '../extractors/agent'
 import Bot from 'lucide-solid/icons/bot'
 import Check from 'lucide-solid/icons/check'
+import { createMemo, For, Show } from 'solid-js'
 import { getToolResultExpanded } from '../../../messageRenderers'
 import { CollapsibleContent } from '../../../results/CollapsibleContent'
 import { ToolStatusHeader } from '../../../results/ToolStatusHeader'
 import { useCollapsedFlag } from '../../../results/useCollapsedLines'
+import { toolMetaLabel, toolMetaList, toolMetaRow, toolMetaValue, toolResultPrompt } from '../../../toolStyles.css'
+import { claudeAgentResultBody, claudeAgentResultIsLaunch } from '../extractors/agent'
 
 function formatAgentStatus(status: string): string {
-  if (status === 'async_launched')
-    return 'launched asynchronously'
-  return status
+  switch (status) {
+    case 'async_launched': return 'launched asynchronously'
+    case 'remote_launched': return 'launched remotely'
+    default: return status
+  }
 }
 
-/** Collapsed Agent result view: icon + "Agent {agentId} {status}" header + collapsed markdown body. */
+/**
+ * The longest task description the header shows. The same cap the tool_use
+ * titles apply to model prose (toolUse/title.tsx, toolUse/summary.tsx).
+ */
+const DESCRIPTION_LIMIT = 80
+
+/**
+ * The first line of the task description, capped.
+ *
+ * `description` is free model prose with no length limit and no line limit --
+ * unlike every model-supplied title the backend stores, which passes
+ * bgtask.FirstLine + bgtask.TruncateRunes. The header is ONE clipped line that
+ * ENDS with the outcome, so an overlong description pushed `completed` /
+ * `failed` / `launched asynchronously` off the right edge, and the icon
+ * separates only `completed` from everything else -- so a failed run read as a
+ * launched one.
+ */
+function clipDescription(description: string): string {
+  const line = description.trim().split('\n', 1)[0]
+  return line.length > DESCRIPTION_LIMIT ? `${line.slice(0, DESCRIPTION_LIMIT)}\u2026` : line
+}
+
+/**
+ * The header line. A launch gives the TASK, because that is the thing the user
+ * recognizes and the only human-written string in the payload; the agent id is a
+ * generated token that says nothing about the work. A finished sync run carries
+ * no description at all, so it falls back to the id.
+ */
+function agentTitle(source: ClaudeAgentResult): string {
+  const status = formatAgentStatus(source.status)
+  const description = clipDescription(source.description)
+  if (description)
+    return `Agent '${description}' ${status}`
+  const id = source.agentId || source.taskId
+  return id ? `Agent ${id} ${status}` : `Agent ${status}`
+}
+
+/**
+ * The identity and location rows.
+ *
+ * A launch is the one result the user may need to act on later -- to message the
+ * agent, or to look at where it writes its output -- and every field
+ * needed for that arrives here and nowhere else. The CLI tells the model not to
+ * surface the agent id; that instruction protects the model's own reply, not
+ * this UI, which is the user's own view of their own session.
+ */
+function metaRows(source: ClaudeAgentResult): Array<{ label: string, value: string }> {
+  const rows: Array<{ label: string, value: string }> = []
+  if (source.agentId)
+    rows.push({ label: 'Agent ID', value: source.agentId })
+  if (source.taskId)
+    rows.push({ label: 'Task ID', value: source.taskId })
+  if (source.sessionUrl)
+    rows.push({ label: 'Session', value: source.sessionUrl })
+  // A mid-run model swap is worth showing in full: `resolvedModel` alone reports
+  // only where the run ended up, which reads as though it ran on that model
+  // throughout.
+  if (source.modelsUsed.length > 1)
+    rows.push({ label: 'Models', value: source.modelsUsed.join(' → ') })
+  else if (source.resolvedModel)
+    rows.push({ label: 'Model', value: source.resolvedModel })
+  if (source.worktreeBranch)
+    rows.push({ label: 'Branch', value: source.worktreeBranch })
+  if (source.worktreePath)
+    rows.push({ label: 'Worktree', value: source.worktreePath })
+  if (source.outputFile)
+    rows.push({ label: 'Output', value: source.outputFile })
+  return rows
+}
+
+/**
+ * The Agent result card: a title that gives the task, the structured fields as a
+ * label/value list, and one collapsible body -- the agent's report when it
+ * finished, the prompt it was given when it has only just launched.
+ */
 export function AgentResultView(props: {
-  agentId: string
-  status: string
-  content: string
+  source: ClaudeAgentResult
   context?: RenderContext
 }): JSX.Element {
+  const body = () => claudeAgentResultBody(props.source)
+  // One evaluation, one array identity. metaRows builds fresh row objects, and
+  // it is read twice below -- by the Show gate and by the For -- so without the
+  // memo the field list is rebuilt on each read and <For> gets items it can
+  // never reconcile by identity.
+  const rows = createMemo(() => metaRows(props.source))
   const isCollapsed = useCollapsedFlag({
-    text: () => props.content,
+    text: body,
     expanded: () => getToolResultExpanded(props.context),
   })
-  const icon = () => props.status === 'completed' ? Check : Bot
+  const icon = () => props.source.status === 'completed' ? Check : Bot
+  // A launch's body is the instruction it was given, which needs saying: without
+  // the label it reads as though the agent already answered at length.
+  const bodyLabel = () => claudeAgentResultIsLaunch(props.source) ? 'Prompt' : ''
 
   return (
-    <ToolStatusHeader icon={icon()} title={`Agent ${props.agentId} ${formatAgentStatus(props.status)}`}>
-      <CollapsibleContent kind="markdown-tool-result" text={props.content} isCollapsed={isCollapsed()} context={props.context} />
+    <ToolStatusHeader icon={icon()} title={agentTitle(props.source)}>
+      <Show when={rows().length > 0}>
+        <div class={toolMetaList}>
+          <For each={rows()}>
+            {row => (
+              <div class={toolMetaRow}>
+                <span class={toolMetaLabel}>{`${row.label}:`}</span>
+                <span class={toolMetaValue}>{row.value}</span>
+              </div>
+            )}
+          </For>
+        </div>
+      </Show>
+      <Show when={body()}>
+        <Show when={bodyLabel()}>
+          <div class={toolResultPrompt}>{bodyLabel()}</div>
+        </Show>
+        <CollapsibleContent
+          kind="markdown-tool-result"
+          text={body()}
+          isCollapsed={isCollapsed()}
+          context={props.context}
+        />
+      </Show>
     </ToolStatusHeader>
   )
 }

--- a/frontend/src/components/chat/providers/claude/toolResults/index.tsx
+++ b/frontend/src/components/chat/providers/claude/toolResults/index.tsx
@@ -3,7 +3,7 @@ import type { JSX } from 'solid-js'
 import type { RenderContext } from '../../../messageRenderers'
 import type { ReadFileResultSource } from '../../../results/readFileResult'
 import { joinContentParagraphs } from '~/lib/contentBlocks'
-import { isObject, pickObject, pickString } from '~/lib/jsonPick'
+import { isObject, pickObject } from '~/lib/jsonPick'
 import { CLAUDE_TOOL } from '~/types/toolMessages'
 import { cachedRenderValue } from '../../../messageRenderCache'
 import { pickFileEditDiff } from '../../../results/fileEditDiff'
@@ -13,10 +13,12 @@ import { SearchResultBody } from '../../../results/searchResult'
 import { WebFetchResultBody } from '../../../results/webFetchResult'
 import { WebSearchResultsBody } from '../../../results/webSearchResults'
 import { ToolResultMessage } from '../../../toolRenderers'
+import { claudeAgentFromToolResult } from '../extractors/agent'
 import { extractToolUseInfo, getMessageContentArray } from '../extractors/assistantContent'
 import { claudeBashFromToolResult } from '../extractors/bash'
 import { claudeCreateResultDiff, claudeFileEditFromToolUseInput, claudeFileEditFromToolUseResult, isClaudeFileEditTool } from '../extractors/fileEdit'
 import { claudeGlobFromToolResult, claudeGrepFromToolResult } from '../extractors/grepGlob'
+import { claudeListAgentsListing } from '../extractors/listAgents'
 import { claudeMcpFromToolResult, isClaudeMcpTool } from '../extractors/mcp'
 import { claudeReadFromToolResult } from '../extractors/read'
 import { claudeRemoteTriggerFromToolResult } from '../extractors/remoteTrigger'
@@ -25,6 +27,7 @@ import { claudeWebSearchFromToolResult } from '../extractors/webSearch'
 import { AgentResultView } from './agent'
 import { AskUserQuestionResultView } from './askUserQuestion'
 import { ExitPlanModeResultView } from './exitPlanMode'
+import { ListAgentsResultView } from './listAgents'
 import { RemoteTriggerResultView } from './remoteTrigger'
 import { TaskOutputResultView } from './taskOutput'
 import { ToolSearchResultView } from './toolSearch'
@@ -98,14 +101,10 @@ const TOOL_RESULT_ENTRIES: Record<string, ToolResultEntry> = {
   },
 
   [CLAUDE_TOOL.AGENT]: (info, ctx) => {
-    if (!info.toolUseResult)
+    const source = claudeAgentFromToolResult(info.toolUseResult, info.resultContent)
+    if (!source)
       return null
-    const agentId = pickString(info.toolUseResult, 'agentId')
-    const status = pickString(info.toolUseResult, 'status', 'completed')
-    const agentContent = Array.isArray(info.toolUseResult.content)
-      ? joinContentParagraphs(info.toolUseResult.content as Array<Record<string, unknown>>, { text: 'text' })
-      : info.resultContent
-    return <AgentResultView agentId={agentId} status={status} content={agentContent} context={ctx} />
+    return <AgentResultView source={source} context={ctx} />
   },
 
   [CLAUDE_TOOL.TASK_OUTPUT]: (info, ctx) => {
@@ -148,6 +147,13 @@ const TOOL_RESULT_ENTRIES: Record<string, ToolResultEntry> = {
       context={ctx}
     />
   ),
+
+  [CLAUDE_TOOL.LIST_AGENTS]: (info, ctx) => {
+    const listing = claudeListAgentsListing(info.toolUseResult, info.resultContent)
+    if (!listing.trim())
+      return null
+    return <ListAgentsResultView listing={listing} context={ctx} />
+  },
 
   [CLAUDE_TOOL.REMOTE_TRIGGER]: (info, ctx) => {
     const source = claudeRemoteTriggerFromToolResult(info.toolUseResult, info.resultContent)

--- a/frontend/src/components/chat/providers/claude/toolResults/listAgents.tsx
+++ b/frontend/src/components/chat/providers/claude/toolResults/listAgents.tsx
@@ -1,0 +1,37 @@
+import type { JSX } from 'solid-js'
+import type { RenderContext } from '../../../messageRenderers'
+import Users from 'lucide-solid/icons/users'
+import { getToolResultExpanded } from '../../../messageRenderers'
+import { CollapsibleContent } from '../../../results/CollapsibleContent'
+import { ToolStatusHeader } from '../../../results/ToolStatusHeader'
+import { useCollapsedFlag } from '../../../results/useCollapsedLines'
+
+/**
+ * The ListAgents listing, rendered as markdown.
+ *
+ * The CLI hands the whole listing over as ONE pre-formatted string rather than
+ * as rows: its `mapToolResultToToolResultBlockParam` puts `data.listing`
+ * straight into the tool_result content. Rendering that as markdown shows the
+ * table it is today and keeps working if the CLI reformats it, which building
+ * bespoke row markup around a shape we do not control would not.
+ */
+export function ListAgentsResultView(props: {
+  listing: string
+  context?: RenderContext
+}): JSX.Element {
+  const isCollapsed = useCollapsedFlag({
+    text: () => props.listing,
+    expanded: () => getToolResultExpanded(props.context),
+  })
+
+  return (
+    <ToolStatusHeader icon={Users} title="Reachable agents">
+      <CollapsibleContent
+        kind="markdown-tool-result"
+        text={props.listing}
+        isCollapsed={isCollapsed()}
+        context={props.context}
+      />
+    </ToolStatusHeader>
+  )
+}

--- a/frontend/src/components/chat/providers/claude/toolUse/icons.ts
+++ b/frontend/src/components/chat/providers/claude/toolUse/icons.ts
@@ -13,9 +13,11 @@ import OctagonX from 'lucide-solid/icons/octagon-x'
 import PlaneTakeoff from 'lucide-solid/icons/plane-takeoff'
 import PocketKnife from 'lucide-solid/icons/pocket-knife'
 import Search from 'lucide-solid/icons/search'
+import Send from 'lucide-solid/icons/send'
 import Terminal from 'lucide-solid/icons/terminal'
 import TextSearch from 'lucide-solid/icons/text-search'
 import TicketsPlane from 'lucide-solid/icons/tickets-plane'
+import Users from 'lucide-solid/icons/users'
 import Vote from 'lucide-solid/icons/vote'
 import Webhook from 'lucide-solid/icons/webhook'
 import Wrench from 'lucide-solid/icons/wrench'
@@ -46,6 +48,8 @@ export function toolIconFor(name: string): LucideIcon {
     case CLAUDE_TOOL.TOOL_SEARCH: return Search
     case CLAUDE_TOOL.TASK_STOP: return OctagonX
     case CLAUDE_TOOL.REMOTE_TRIGGER: return Webhook
+    case CLAUDE_TOOL.SEND_MESSAGE: return Send
+    case CLAUDE_TOOL.LIST_AGENTS: return Users
     default: return isClaudeMcpTool(name) ? Wrench : ChevronsRight
   }
 }

--- a/frontend/src/components/chat/providers/claude/toolUse/sendMessage.tsx
+++ b/frontend/src/components/chat/providers/claude/toolUse/sendMessage.tsx
@@ -1,0 +1,64 @@
+import type { JSX } from 'solid-js'
+import type { RenderContext } from '../../../messageRenderers'
+import type { SendMessageInput } from '~/types/toolMessages'
+import { Show } from 'solid-js'
+import { opensSubagentTranscript } from '~/stores/chatBackgroundTasks'
+import { toolInputText, toolRecipientLink } from '../../../toolStyles.css'
+
+/**
+ * The recipient of a SendMessage call, as a link when it identifies a subagent of
+ * this session and as plain text otherwise.
+ *
+ * The recipient is the one thing this card must lead with, and the generic tool
+ * card cannot show it: `to` is not among the input keys the fallback title
+ * inspects, so every SendMessage rendered as its message body with the
+ * addressee invisible.
+ *
+ * `to` is the registry row key for a subagent of this session (Claude keys its
+ * task registry by agent id). Every other recipient form -- a display name,
+ * another session, a uds:/bridge:/did: address -- identifies no row here, so it stays
+ * plain text rather than pretending to be somewhere the user can go.
+ */
+export function SendMessageRecipient(props: {
+  to: string
+  context?: RenderContext
+}): JSX.Element {
+  const row = () => props.context?.resolveBackgroundTaskRow?.(props.to)
+  // Linkable only when the row owns a transcript. A shell row, or a subagent
+  // whose provider never linked one, has no tab to open.
+  const openable = () => {
+    const item = row()
+    if (!item || !opensSubagentTranscript(item))
+      return undefined
+    return props.context?.onOpenSubagent ? item : undefined
+  }
+  // The row's title is what the Background tasks list calls this subagent, so
+  // the two show it the same way. The raw id is the honest fallback.
+  const label = () => row()?.title || props.to
+
+  return (
+    <Show when={openable()} fallback={<span class={toolInputText}>{label()}</span>}>
+      {item => (
+        <button
+          type="button"
+          class={toolRecipientLink}
+          data-testid="send-message-recipient"
+          onClick={() => props.context?.onOpenSubagent?.(item())}
+        >
+          {label()}
+        </button>
+      )}
+    </Show>
+  )
+}
+
+/** Title for a SendMessage tool_use card: the recipient, linked where possible. */
+export function renderSendMessageTitle(
+  input: SendMessageInput,
+  context?: RenderContext,
+): JSX.Element | null {
+  const to = typeof input.to === 'string' ? input.to.trim() : ''
+  if (!to)
+    return null
+  return <SendMessageRecipient to={to} context={context} />
+}

--- a/frontend/src/components/chat/providers/claude/toolUse/summary.tsx
+++ b/frontend/src/components/chat/providers/claude/toolUse/summary.tsx
@@ -1,9 +1,12 @@
 import type { JSX } from 'solid-js'
 import type { RenderContext } from '../../../messageRenderers'
-import type { GrepInput } from '~/types/toolMessages'
+import type { GrepInput, SendMessageInput } from '~/types/toolMessages'
 import { relativizePath } from '~/lib/paths'
 import { CLAUDE_TOOL } from '~/types/toolMessages'
 import { toolInputSummary } from '../../../toolStyles.css'
+
+/** The longest message preview the summary line shows before it clips. */
+const SEND_MESSAGE_PREVIEW_LIMIT = 120
 
 /** Derive a summary element for a generic tool_use (search paths, etc.). */
 export function deriveToolSummary(toolName: string, input: Record<string, unknown>, context?: RenderContext): JSX.Element | undefined {
@@ -13,6 +16,27 @@ export function deriveToolSummary(toolName: string, input: Record<string, unknow
       if (!path)
         return undefined
       return <div class={toolInputSummary}>{relativizePath(path, context?.workingDir, context?.homeDir)}</div>
+    }
+    // The card's title carries the RECIPIENT, so the message itself belongs
+    // here. Without it the parent steering a subagent is invisible: the user
+    // sees who was addressed and never what was said.
+    //
+    // `message` is a plain string for an ordinary send and an object for the
+    // structured kinds (shutdown_request, plan_approval_response), which have no
+    // one-line form worth showing. toolInputSummary has no height cap, unlike
+    // Bash's collapsed command, so a long steering message is clipped here
+    // rather than allowed to inflate the row.
+    case CLAUDE_TOOL.SEND_MESSAGE: {
+      const { message } = input as SendMessageInput
+      if (typeof message !== 'string')
+        return undefined
+      const line = message.trim().split('\n', 1)[0]
+      if (!line)
+        return undefined
+      const preview = line.length > SEND_MESSAGE_PREVIEW_LIMIT
+        ? `${line.slice(0, SEND_MESSAGE_PREVIEW_LIMIT)}\u2026`
+        : line
+      return <div class={toolInputSummary}>{preview}</div>
     }
     default:
       return undefined

--- a/frontend/src/components/chat/providers/claude/toolUse/summary.tsx
+++ b/frontend/src/components/chat/providers/claude/toolUse/summary.tsx
@@ -1,6 +1,7 @@
 import type { JSX } from 'solid-js'
 import type { RenderContext } from '../../../messageRenderers'
 import type { GrepInput, SendMessageInput } from '~/types/toolMessages'
+import { clipFirstLine } from '~/lib/clipFirstLine'
 import { relativizePath } from '~/lib/paths'
 import { CLAUDE_TOOL } from '~/types/toolMessages'
 import { toolInputSummary } from '../../../toolStyles.css'
@@ -27,15 +28,20 @@ export function deriveToolSummary(toolName: string, input: Record<string, unknow
     // Bash's collapsed command, so a long steering message is clipped here
     // rather than allowed to inflate the row.
     case CLAUDE_TOOL.SEND_MESSAGE: {
-      const { message } = input as SendMessageInput
-      if (typeof message !== 'string')
+      const { message, summary } = input as SendMessageInput
+      // `summary` first. The tool's own schema describes it as "a 5-10 word
+      // summary shown as a one-line preview in the UI", and the model writes it
+      // for exactly this surface -- so preferring the raw first line of the
+      // message threw away the label written for the slot. It is also the only
+      // one-line form the STRUCTURED kinds have: for an object-valued `message`
+      // the first-line clip yields nothing, and the card showed the recipient
+      // with no preview at all.
+      const preview = clipFirstLine(
+        summary ?? (typeof message === 'string' ? message : ''),
+        SEND_MESSAGE_PREVIEW_LIMIT,
+      )
+      if (!preview)
         return undefined
-      const line = message.trim().split('\n', 1)[0]
-      if (!line)
-        return undefined
-      const preview = line.length > SEND_MESSAGE_PREVIEW_LIMIT
-        ? `${line.slice(0, SEND_MESSAGE_PREVIEW_LIMIT)}\u2026`
-        : line
       return <div class={toolInputSummary}>{preview}</div>
     }
     default:

--- a/frontend/src/components/chat/providers/claude/toolUse/title.tsx
+++ b/frontend/src/components/chat/providers/claude/toolUse/title.tsx
@@ -1,6 +1,7 @@
 import type { JSX } from 'solid-js'
 import type { RenderContext } from '../../../messageRenderers'
-import type { BashInput, EditInput, GlobInput, GrepInput, ReadInput, RemoteTriggerInput, TaskStopInput, ToolSearchInput, WebFetchInput, WebSearchInput, WriteInput } from '~/types/toolMessages'
+import type { BashInput, EditInput, GlobInput, GrepInput, ReadInput, RemoteTriggerInput, SendMessageInput, TaskStopInput, ToolSearchInput, WebFetchInput, WebSearchInput, WriteInput } from '~/types/toolMessages'
+import { pickString } from '~/lib/jsonPick'
 import { CLAUDE_TOOL } from '~/types/toolMessages'
 import { joinMetaParts } from '../../../rendererUtils'
 import { toolInputCode, toolInputText } from '../../../toolStyles.css'
@@ -16,6 +17,7 @@ import {
   renderWriteTitle,
 } from '../../../toolTitleRenderers'
 import { formatClaudeMcpDisplayName, parseClaudeMcpToolName } from '../extractors/mcp'
+import { renderSendMessageTitle } from './sendMessage'
 
 /** Prefer common parameter names for the hint, then fall back to first short string. */
 const HINT_KEYS = ['query', 'input', 'prompt', 'text', 'command', 'description', 'url']
@@ -53,6 +55,22 @@ export function renderClaudeToolTitle(toolName: string, input: Record<string, un
     case CLAUDE_TOOL.TASK: return renderAgentTitle(String(input.description || toolName), input.subagent_type ? String(input.subagent_type) : undefined)
 
     // Claude-only tool titles
+    case CLAUDE_TOOL.SEND_MESSAGE:
+      return renderSendMessageTitle(input as SendMessageInput, context)
+    case CLAUDE_TOOL.LIST_AGENTS: {
+      // Both filters are optional and usually absent, so the bare label is the
+      // normal case rather than a fallback. pickString rather than a cast: the
+      // model writes this input, and a non-string that survives a bare cast is
+      // still truthy, so it template-interpolates into `channel: [object
+      // Object]` where an absent field correctly yields the plain label.
+      const channel = pickString(input, 'channel').trim()
+      const q = pickString(input, 'q').trim()
+      const filters = joinMetaParts([
+        channel && `channel: ${channel}`,
+        q && `matching: ${q}`,
+      ])
+      return <span class={toolInputText}>{filters ? `List agents (${filters})` : 'List agents'}</span>
+    }
     case CLAUDE_TOOL.TASK_OUTPUT: {
       const { task_id, block, timeout } = input as { task_id?: string, block?: boolean, timeout?: number }
       const inner = joinMetaParts([

--- a/frontend/src/components/chat/providers/listAgentsRendering.test.tsx
+++ b/frontend/src/components/chat/providers/listAgentsRendering.test.tsx
@@ -1,0 +1,130 @@
+import type { MessageCategory } from '../messageClassification'
+import type { RenderContext } from '../messageRenderers'
+import { render } from '@solidjs/testing-library'
+import { describe, expect, it } from 'vitest'
+import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
+import { claudeToolResultMeta } from './claude/toolResult'
+import './testMocks'
+
+const { renderMessageContent } = await import('../messageRenderers')
+
+const LISTING = [
+  '| Name | Kind | Status |',
+  '|------|------|--------|',
+  '| Explore the parser | in-process subagent | completed |',
+  '| laptop | Remote Control session | idle |',
+].join('\n')
+
+function renderToolUseText(input: Record<string, unknown>): string {
+  const msg = {
+    type: 'assistant',
+    message: {
+      content: [{ type: 'tool_use', id: 'test-listagents', name: 'ListAgents', input }],
+    },
+  }
+  const content = msg.message.content as Array<Record<string, unknown>>
+  const category: MessageCategory = {
+    kind: 'tool_use',
+    toolName: 'ListAgents',
+    toolUse: content[0],
+    content,
+  }
+  const result = renderMessageContent(msg, undefined, category, AgentProvider.CLAUDE_CODE)
+  return render(() => result).container.textContent?.trim() ?? ''
+}
+
+function listAgentsToolResult(resultContent: string, toolUseResult?: Record<string, unknown>) {
+  return {
+    type: 'user',
+    message: {
+      role: 'user',
+      content: [{ tool_use_id: 'test-listagents', type: 'tool_result', content: resultContent }],
+    },
+    ...(toolUseResult ? { tool_use_result: toolUseResult } : {}),
+  }
+}
+
+function renderToolResult(
+  resultContent: string,
+  toolUseResult?: Record<string, unknown>,
+  context?: RenderContext,
+): HTMLElement {
+  const msg = listAgentsToolResult(resultContent, toolUseResult)
+  const category: MessageCategory = { kind: 'tool_result' }
+  const result = renderMessageContent(
+    msg,
+    { spanType: 'ListAgents', ...context },
+    category,
+    AgentProvider.CLAUDE_CODE,
+  )
+  return render(() => result).container
+}
+
+describe('claude ListAgents tool_use rendering', () => {
+  // Both filters are optional and absent in this CLI build, so the bare label is
+  // the normal case rather than a degraded one.
+  it('labels an unfiltered call', () => {
+    expect(renderToolUseText({})).toBe('List agents')
+  })
+
+  it('lists the filters when the call carries them', () => {
+    expect(renderToolUseText({ channel: 'team' })).toContain('channel: team')
+    expect(renderToolUseText({ q: 'explore' })).toContain('matching: explore')
+    const both = renderToolUseText({ channel: 'team', q: 'explore' })
+    expect(both).toContain('channel: team')
+    expect(both).toContain('matching: explore')
+  })
+})
+
+describe('claude ListAgents tool_result rendering', () => {
+  // The CLI hands the whole listing over as ONE pre-formatted string under
+  // `listing`, and maps that same string into the block content.
+  it('renders the structured listing', () => {
+    const container = renderToolResult('', { listing: LISTING })
+    expect(container.textContent).toContain('Explore the parser')
+    expect(container.textContent).toContain('Remote Control session')
+  })
+
+  it('falls back to the block content when no structured payload is present', () => {
+    const container = renderToolResult(LISTING)
+    expect(container.textContent).toContain('Explore the parser')
+  })
+
+  it('prefers the structured listing over the block content', () => {
+    const container = renderToolResult('stale text', { listing: LISTING })
+    expect(container.textContent).toContain('Explore the parser')
+    expect(container.textContent).not.toContain('stale text')
+  })
+
+  // Returning null from the dispatch entry hands the row to the catch-all, which
+  // is how every renderer here degrades rather than rendering an empty card.
+  it('falls through to the catch-all when the payload carries no listing', () => {
+    const container = renderToolResult('', { unexpected: 1 })
+    expect(container.textContent ?? '').not.toContain('Reachable agents')
+  })
+})
+
+describe('claudeToolResultMeta for ListAgents', () => {
+  // The toolbar's expand button and Copy must act on the text the body shows,
+  // which is the structured listing whenever there is one.
+  it('reports a long listing as collapsible and copies it', () => {
+    const meta = claudeToolResultMeta(
+      { kind: 'tool_result' },
+      listAgentsToolResult('', { listing: LISTING }),
+      'ListAgents',
+      undefined,
+    )
+    expect(meta?.collapsible).toBe(true)
+    expect(meta?.copyableContent()).toBe(LISTING)
+  })
+
+  it('reports a one-line listing as not collapsible', () => {
+    const meta = claudeToolResultMeta(
+      { kind: 'tool_result' },
+      listAgentsToolResult('', { listing: 'No agents are reachable.' }),
+      'ListAgents',
+      undefined,
+    )
+    expect(meta?.collapsible).toBe(false)
+  })
+})

--- a/frontend/src/components/chat/providers/listAgentsRendering.test.tsx
+++ b/frontend/src/components/chat/providers/listAgentsRendering.test.tsx
@@ -127,4 +127,19 @@ describe('claudeToolResultMeta for ListAgents', () => {
     )
     expect(meta?.collapsible).toBe(false)
   })
+
+  // The renderer treats a whitespace-only listing as absent and hands the row to
+  // the catch-all. The toolbar has to agree: reading the untrimmed value made it
+  // offer a Copy button on a card whose body came from somewhere else, and yield
+  // spaces.
+  it('offers no Copy for a whitespace-only listing', () => {
+    const meta = claudeToolResultMeta(
+      { kind: 'tool_result' },
+      listAgentsToolResult('', { listing: '   \n\t  ' }),
+      'ListAgents',
+      undefined,
+    )
+    expect(meta?.hasCopyable).toBe(false)
+    expect(meta?.copyableContent()).toBeNull()
+  })
 })

--- a/frontend/src/components/chat/providers/sendMessageRendering.test.tsx
+++ b/frontend/src/components/chat/providers/sendMessageRendering.test.tsx
@@ -1,0 +1,130 @@
+import type { MessageCategory } from '../messageClassification'
+import type { RenderContext } from '../messageRenderers'
+import type { BackgroundTaskItem } from '~/stores/chatBackgroundTasks'
+import { render } from '@solidjs/testing-library'
+import { describe, expect, it, vi } from 'vitest'
+import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
+import './testMocks'
+
+const { renderMessageContent } = await import('../messageRenderers')
+
+function subagentRow(over: Partial<BackgroundTaskItem> = {}): BackgroundTaskItem {
+  return {
+    rowKey: 'a1b2c3d4e5f60718',
+    kind: 'subagent',
+    childAgentId: 'child-1',
+    title: 'Explore the parser',
+    activity: '',
+    status: 'completed',
+    ...over,
+  }
+}
+
+function renderToolUse(input: Record<string, unknown>, context?: RenderContext): HTMLElement {
+  const msg = {
+    type: 'assistant',
+    message: {
+      content: [{ type: 'tool_use', id: 'test-sendmessage', name: 'SendMessage', input }],
+    },
+  }
+  const content = msg.message.content as Array<Record<string, unknown>>
+  const category: MessageCategory = {
+    kind: 'tool_use',
+    toolName: 'SendMessage',
+    toolUse: content[0],
+    content,
+  }
+  const result = renderMessageContent(msg, context, category, AgentProvider.CLAUDE_CODE)
+  return render(() => result).container
+}
+
+describe('claude SendMessage tool_use rendering', () => {
+  // The recipient is what the card exists to show. The generic fallback title
+  // cannot: `to` is not among the input keys it inspects, so it rendered the
+  // message body and left the addressee invisible.
+  it('leads with the recipient and shows the message under it', () => {
+    const container = renderToolUse({ to: 'a1b2c3d4e5f60718', message: 'keep going' })
+    const text = container.textContent ?? ''
+    expect(text).toContain('a1b2c3d4e5f60718')
+    expect(text).toContain('keep going')
+    expect(text.indexOf('a1b2c3d4e5f60718')).toBeLessThan(text.indexOf('keep going'))
+  })
+
+  // The summary line has no height cap, so a long steering message would
+  // otherwise inflate the chat row it sits in.
+  it('clips a long message to one line', () => {
+    const long = `${'x'.repeat(200)}\nsecond line`
+    const text = renderToolUse({ to: 'a1b2c3d4e5f60718', message: long }).textContent ?? ''
+    expect(text).toContain('\u2026')
+    expect(text).not.toContain('second line')
+    expect(text).not.toContain('x'.repeat(200))
+  })
+
+  // The structured message kinds (shutdown_request, plan_approval_response) are
+  // objects with no one-line form; the card shows the recipient alone.
+  it('shows no summary for a structured message', () => {
+    const text = renderToolUse({ to: 'a1b2c3d4e5f60718', message: { kind: 'shutdown_request' } }).textContent ?? ''
+    expect(text).toContain('a1b2c3d4e5f60718')
+    expect(text).not.toContain('shutdown_request')
+  })
+
+  it('shows the recipient the way the Background tasks list shows it', () => {
+    const container = renderToolUse(
+      { to: 'a1b2c3d4e5f60718', message: 'keep going' },
+      { resolveBackgroundTaskRow: () => subagentRow(), onOpenSubagent: vi.fn() },
+    )
+    expect(container.textContent).toContain('Explore the parser')
+  })
+
+  it('opens the subagent tab when the recipient identifies a row that owns one', () => {
+    const onOpenSubagent = vi.fn()
+    const row = subagentRow()
+    const container = renderToolUse(
+      { to: 'a1b2c3d4e5f60718', message: 'keep going' },
+      { resolveBackgroundTaskRow: () => row, onOpenSubagent },
+    )
+    const button = container.querySelector<HTMLButtonElement>('[data-testid="send-message-recipient"]')
+    expect(button).not.toBeNull()
+    button!.click()
+    expect(onOpenSubagent).toHaveBeenCalledWith(row)
+  })
+
+  // A display name, another session, a uds:/bridge:/did: address: none of these
+  // identify a row here, so the card must not pretend to be somewhere to go.
+  it('renders an unresolvable recipient as plain text', () => {
+    const container = renderToolUse(
+      { to: 'bridge:another-machine', message: 'keep going' },
+      { resolveBackgroundTaskRow: () => undefined, onOpenSubagent: vi.fn() },
+    )
+    expect(container.querySelector('[data-testid="send-message-recipient"]')).toBeNull()
+    expect(container.textContent).toContain('bridge:another-machine')
+  })
+
+  // A shell row has no transcript, and a subagent row whose provider never
+  // linked one has nothing to open either.
+  it('is not clickable for a row that owns no transcript', () => {
+    for (const row of [subagentRow({ childAgentId: undefined }), subagentRow({ kind: 'shell' })]) {
+      const container = renderToolUse(
+        { to: 'a1b2c3d4e5f60718', message: 'keep going' },
+        { resolveBackgroundTaskRow: () => row, onOpenSubagent: vi.fn() },
+      )
+      expect(container.querySelector('[data-testid="send-message-recipient"]')).toBeNull()
+    }
+  })
+
+  // Without a handler there is nowhere to send the click, so the label must not
+  // pose as a control.
+  it('is not clickable when the host supplied no open handler', () => {
+    const container = renderToolUse(
+      { to: 'a1b2c3d4e5f60718', message: 'keep going' },
+      { resolveBackgroundTaskRow: () => subagentRow() },
+    )
+    expect(container.querySelector('[data-testid="send-message-recipient"]')).toBeNull()
+    expect(container.textContent).toContain('Explore the parser')
+  })
+
+  it('falls back to the generic card when the call gives no recipient', () => {
+    const container = renderToolUse({ message: 'keep going' })
+    expect(container.textContent).toContain('SendMessage')
+  })
+})

--- a/frontend/src/components/chat/providers/sendMessageRendering.test.tsx
+++ b/frontend/src/components/chat/providers/sendMessageRendering.test.tsx
@@ -8,6 +8,9 @@ import './testMocks'
 
 const { renderMessageContent } = await import('../messageRenderers')
 
+/** Half of an astral character, left behind by a cut between the pair. */
+const LONE_SURROGATE = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/
+
 function subagentRow(over: Partial<BackgroundTaskItem> = {}): BackgroundTaskItem {
   return {
     rowKey: 'a1b2c3d4e5f60718',
@@ -48,6 +51,40 @@ describe('claude SendMessage tool_use rendering', () => {
     expect(text).toContain('a1b2c3d4e5f60718')
     expect(text).toContain('keep going')
     expect(text.indexOf('a1b2c3d4e5f60718')).toBeLessThan(text.indexOf('keep going'))
+  })
+
+  // `summary` is the label the MODEL wrote for this exact slot -- the tool's own
+  // schema calls it "a 5-10 word summary shown as a one-line preview in the UI".
+  // Deriving the preview from the raw message threw that away.
+  it('prefers the model-written summary over the message body', () => {
+    const text = renderToolUse({
+      to: 'a1b2c3d4e5f60718',
+      message: 'A very long steering message with several clauses in it.',
+      summary: 'Retry with the parser fix',
+    }).textContent ?? ''
+    expect(text).toContain('Retry with the parser fix')
+    expect(text).not.toContain('several clauses')
+  })
+
+  // The STRUCTURED kinds carry an object `message`, which has no first line to
+  // clip -- so the card showed the recipient with no preview at all, although
+  // `summary` is exactly the one-line form those kinds do have.
+  it('still previews a structured message from its summary', () => {
+    const text = renderToolUse({
+      to: 'a1b2c3d4e5f60718',
+      message: { type: 'plan_approval_response', approved: true },
+      summary: 'Approved the plan',
+    }).textContent ?? ''
+    expect(text).toContain('Approved the plan')
+  })
+
+  // An astral character straddling the limit used to be cut in half, leaving a
+  // lone surrogate that renders as a replacement glyph.
+  it('clips a message without splitting an astral character', () => {
+    const long = `${'x'.repeat(119)}😀${'y'.repeat(100)}`
+    const text = renderToolUse({ to: 'a1b2c3d4e5f60718', message: long }).textContent ?? ''
+    expect(LONE_SURROGATE.test(text)).toBe(false)
+    expect(text).toContain('😀')
   })
 
   // The summary line has no height cap, so a long steering message would

--- a/frontend/src/components/chat/results/webSearchResults.test.tsx
+++ b/frontend/src/components/chat/results/webSearchResults.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { clippedText } from '~/styles/shared.css'
 import { hoverForTooltip, stubClipped, stubFitting } from '~/test-support/clipStub'
 import { classSelector } from '~/test-support/composedClass'
+import { toolMetaRow } from '../toolStyles.css'
 import { WebSearchResultsBody } from './webSearchResults'
 
 const LONG_TITLE = 'How to configure a reverse proxy for a self-hosted service without breaking websockets'
@@ -19,6 +20,14 @@ function renderResults(title = LONG_TITLE) {
 }
 
 describe('webSearchResultsBody', () => {
+  // The link row and the Agent card's meta row are one primitive, and this file
+  // held a byte-identical copy of it. Pinning the shared class here is what stops
+  // the next renderer from forking a third.
+  it('puts each link on the shared tool meta row', () => {
+    const { container } = renderResults()
+    expect(container.querySelector(classSelector(toolMetaRow))).toBeTruthy()
+  })
+
   it('renders the link title and its domain', () => {
     const { container } = renderResults()
     expect(container.textContent).toContain(LONG_TITLE)

--- a/frontend/src/components/chat/results/webSearchResults.tsx
+++ b/frontend/src/components/chat/results/webSearchResults.tsx
@@ -10,10 +10,10 @@ import { clippedText } from '~/styles/shared.css'
 import { getToolResultExpanded, renderMarkdownForContext } from '../messageRenderers'
 import {
   toolMessage,
+  toolMetaRow,
   toolResultCollapsed,
   toolResultContent,
   toolResultPrompt,
-  webSearchLink,
   webSearchLinkDomain,
   webSearchLinkList,
 } from '../toolStyles.css'
@@ -45,7 +45,7 @@ export function WebSearchResultsBody(props: {
         <div class={`${webSearchLinkList}${isCollapsed() ? ` ${toolResultCollapsed}` : ''}`}>
           <For each={displayLinks()}>
             {link => (
-              <div class={webSearchLink}>
+              <div class={toolMetaRow}>
                 {/* The raw style plus a hand-built `Tooltip`, not `ClippedText`:
                     the label has to hold the <a>, and `ClippedText` renders a
                     plain string. The clip must stay on the SPAN, because an

--- a/frontend/src/components/chat/toolStyles.css.ts
+++ b/frontend/src/components/chat/toolStyles.css.ts
@@ -253,15 +253,6 @@ export const webSearchLinkList = style({
   gap: '2px',
 })
 
-export const webSearchLink = style({
-  display: 'flex',
-  alignItems: 'baseline',
-  gap: 'var(--space-2)',
-  fontSize: 'var(--text-8)',
-  lineHeight: 1.5,
-  overflow: 'hidden',
-})
-
 export const webSearchLinkDomain = style({
   color: 'var(--muted-foreground)',
   fontSize: 'var(--text-9)',
@@ -328,6 +319,14 @@ export const toolMetaList = style({
   marginBottom: 'var(--space-1)',
 })
 
+/**
+ * One "label: value" line. Shared by the Agent result card's meta list and by
+ * the WebSearch link rows, which are the same primitive: a baseline-aligned flex
+ * row that clips. The role difference between the two lives entirely on the
+ * CHILDREN -- WebSearch puts the muted non-shrinking part on the right (the
+ * domain), the Agent card on the left (the label) -- so the row itself carries
+ * no property either renderer owns.
+ */
 export const toolMetaRow = style({
   display: 'flex',
   alignItems: 'baseline',

--- a/frontend/src/components/chat/toolStyles.css.ts
+++ b/frontend/src/components/chat/toolStyles.css.ts
@@ -296,3 +296,57 @@ export const mcpImageRow = style({
   marginTop: 'var(--space-1)',
   marginBottom: 'var(--space-1)',
 })
+
+// The SendMessage card's recipient, when it resolves to a subagent tab.
+//
+// `all: unset` first, because Oat's base layer paints every `button` as a solid
+// primary pill -- inline-flex, 8px/16px padding, a border and a radius -- and a
+// class that sets only colour leaves all of it standing. Without the reset the
+// recipient rendered as a filled button inside the one-line tool header, and the
+// row changed height the moment the registry hydrated and turned the plain span
+// into that button.
+export const toolRecipientLink = style([{ all: 'unset' }, clippedText, {
+  // `all: unset` is its own composed layer, FIRST, so the clipping and the
+  // colours below survive it rather than being reset by it.
+  cursor: 'pointer',
+  color: 'var(--primary)',
+  textDecoration: 'underline',
+  textUnderlineOffset: '2px',
+  selectors: {
+    '&:hover': { color: 'rgb(from var(--primary) r g b / 0.8)' },
+  },
+}])
+
+// A label/value list for a tool result's structured fields (the Agent card's
+// agent id, model, output file). The label is muted and does not shrink, so the
+// values line up while a long path is the part that wraps.
+export const toolMetaList = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 'var(--space-1)',
+  marginTop: 'var(--space-1)',
+  marginBottom: 'var(--space-1)',
+})
+
+export const toolMetaRow = style({
+  display: 'flex',
+  alignItems: 'baseline',
+  gap: 'var(--space-2)',
+  fontSize: 'var(--text-8)',
+  lineHeight: 1.5,
+  overflow: 'hidden',
+})
+
+export const toolMetaLabel = style({
+  color: 'var(--muted-foreground)',
+  flexShrink: 0,
+  whiteSpace: 'nowrap',
+})
+
+// The value half. `minWidth: 0` is what lets a long path actually wrap inside
+// the flex row instead of forcing the row wider than the card.
+export const toolMetaValue = style({
+  ...codeTypography,
+  ...codeWrap,
+  minWidth: 0,
+})

--- a/frontend/src/components/shell/TileRenderer.tsx
+++ b/frontend/src/components/shell/TileRenderer.tsx
@@ -48,7 +48,7 @@ import { parentDirectory, relativizePath } from '~/lib/paths'
 import { pluralize } from '~/lib/plural'
 import { formatFileMention, formatFileQuote } from '~/lib/quoteUtils'
 import { chipTasksFor, rootWorkState, subagentWorkState } from '~/stores/chatBackgroundTasks'
-import { appendText, insertIntoMruAgentEditor } from '~/stores/editorRef.store'
+import { appendText, insertIntoMruAgentEditor, queueInsertForAgent } from '~/stores/editorRef.store'
 import { buildTilePredicateMap, CLOSE_MODE_NONE } from '~/stores/layout.store'
 import { agentTabToInfo, isSteerableAgentTab, rootAgentIdFor } from '~/stores/tab.helpers'
 import { emitMergeTabsIntoTile, emitReassignTabsToTile } from '~/stores/tabOps'
@@ -178,6 +178,28 @@ export function createTileRenderer(opts: TileRendererOpts) {
   } = opts.stores
   const { agentOps, termOps } = opts.ops
   const mruEditorDeps = opts.mruEditorDeps
+
+  // A child (subagent) tab whose provider cannot steer a subagent conversation
+  // is a READ-ONLY transcript: the worker routes both a child message
+  // (SendChildInput) and a child interrupt (InterruptChild) through the same
+  // ChildSteerer, so a provider that implements neither can do neither. Roots
+  // and steerable children stay fully interactive. isSteerableAgentTab resolves
+  // acceptsMessages (backend-authoritative) with a supportsSubagentSend fallback
+  // for optimistic state.
+  //
+  // One predicate feeds the composer gate, its hint, the Interrupt button, and
+  // where a quote goes, so those cannot disagree about what a tab can do. It
+  // takes an agent id rather than reading the focused one, because the quote
+  // handlers run per TAB inside the tile loop while the composer is built for
+  // the focused tab alone.
+  const isSubagentReadOnly = (agentId: string): boolean => {
+    const t = view.getAgentTab(agentId)
+    // Absent tab -> not read-only: nothing is mounted to refuse, and the write
+    // path (appendText, the composer gate) answers for itself. isSteerableAgentTab
+    // already returns true for a root, so this needs no parentAgentId test of its
+    // own -- a second copy of that rule is how the two answers drift apart.
+    return t !== undefined && !isSteerableAgentTab(t)
+  }
   const {
     isActiveWorkspaceMutatable,
     isActiveWorkspaceArchived,
@@ -792,12 +814,50 @@ export function createTileRenderer(opts: TileRendererOpts) {
             // re-filtered the whole registry, and each fresh array identity
             // defeated BackgroundTaskList's own sort-and-group memo.
             const chipTasks = createMemo(() => chipTasksForTab(agentId))
+            // The ROOT registry, unfiltered. `chipTasks` above is chip-scoped --
+            // a child tab sees only the rows IT spawned -- so a SendMessage card
+            // in a subagent transcript could not resolve a sibling or the parent.
+            // Memoized because bgRootFor walks the parent chain on every call.
+            const rootTasks = createMemo(() => bgTasksFor(agentId))
 
             const railProps = createMemo<ChatRailProps>(() => ({
               ...chatStore.getRailData(agentId),
               previewFor: railPreviewFor,
               warmPreview: railWarmPreview,
             }))
+            // Quoting a message from THIS transcript. Both the toolbar's Quote
+            // action and the selection popover land here, so they cannot diverge.
+            //
+            // A read-only subagent transcript has no composer to quote into, so
+            // the text goes where the file viewer's quote and @mention already
+            // send theirs: the most-recent agent tab that accepts messages --
+            // normally the parent this tab was opened from. That call activates
+            // and focuses the destination, so the quote is never inserted out of
+            // sight, and it filters this tab out by construction.
+            //
+            // A writable tab keeps the same-tab insert. Routing every quote
+            // through the MRU resolution would collapse the branch and is wrong:
+            // mruOrder is workspace-wide, so with split tiles its head can be an
+            // agent in a different tile than the one being read.
+            const quoteIntoComposer = (text: string) => {
+              if (isSubagentReadOnly(agentId)) {
+                insertIntoMruAgentEditor(mruEditorDeps, text)
+                return
+              }
+              if (appendText(agentId, text)) {
+                focusEditorRef()?.()
+                return
+              }
+              // No ref registered for this agent. The composer is mounted for the
+              // FOCUSED tab alone, so this quote came from another tile: queue it
+              // and bring that tab forward, the way an unmounted editor is already
+              // handled for a mention. Focusing here instead would focus a
+              // DIFFERENT agent's composer -- the one that received no text.
+              const tab = view.getAgentTab(agentId)
+              if (tab)
+                mruEditorDeps.activate(tab)
+              queueInsertForAgent(agentId, text)
+            }
             onCleanup(() => {
               agentScrollStates.delete(agentId)
               agentScrollToBottoms.delete(agentId)
@@ -856,18 +916,8 @@ export function createTileRenderer(opts: TileRendererOpts) {
                       }
                     }}
                     lookups={lookups}
-                    onQuote={isActiveWorkspaceArchived()
-                      ? undefined
-                      : (text) => {
-                          appendText(agentId, text)
-                          focusEditorRef()?.()
-                        }}
-                    onReply={isActiveWorkspaceArchived()
-                      ? undefined
-                      : (text) => {
-                          appendText(agentId, text)
-                          focusEditorRef()?.()
-                        }}
+                    onQuote={isActiveWorkspaceArchived() ? undefined : quoteIntoComposer}
+                    onReply={isActiveWorkspaceArchived() ? undefined : quoteIntoComposer}
                     agentLifecycle={{
                       agentWorking: agentThinking(agentId),
                       thinkingTokens: agentSessionStore.getInfo(agentId).thinkingTokens,
@@ -876,6 +926,7 @@ export function createTileRenderer(opts: TileRendererOpts) {
                       startupMessage: agent()?.startupMessage,
                       providerLabel: agentProviderLabel(agent()?.agentProvider),
                       backgroundTasks: chipTasks(),
+                      registryRows: rootTasks(),
                       onOpenSubagent: onOpenBackgroundTask,
                       todos: todosFor(agentId),
                     }}
@@ -1023,22 +1074,7 @@ export function createTileRenderer(opts: TileRendererOpts) {
 
   const FocusedAgentEditorPanel: Component<{ containerHeight: number }> = (props) => {
     const agentId = () => focusedAgentId()!
-    // A child (subagent) tab whose provider cannot steer a subagent conversation
-    // is a READ-ONLY transcript: the worker routes both a child message
-    // (SendChildInput) and a child interrupt (InterruptChild) through the same
-    // ChildSteerer, so a provider that implements neither can do neither. Roots
-    // and steerable children stay fully interactive. isSteerableAgentTab
-    // resolves acceptsMessages (backend-authoritative) with a
-    // supportsSubagentSend fallback for optimistic state.
-    //
-    // One predicate feeds the composer gate, its hint, and the Interrupt button,
-    // so the three cannot disagree about what this tab can do.
-    const subagentReadOnly = () => {
-      const t = view.getAgentTab(agentId())
-      if (!t?.parentAgentId)
-        return false
-      return !isSteerableAgentTab(t)
-    }
+    const subagentReadOnly = () => isSubagentReadOnly(agentId())
     // The composer's GitBranch chip: one call answers both "can these actions
     // run?" and "what ref do the dialogs get?", so an enabled menu item can
     // never resolve to nothing. `buildRef` is lazy — the guard is read on

--- a/frontend/src/components/shell/TileRenderer.tsx
+++ b/frontend/src/components/shell/TileRenderer.tsx
@@ -7,7 +7,7 @@ import type { TileActions, TilePopAction } from './TileActionsMenu'
 import type { useAgentOperations } from './useAgentOperations'
 import type { useTerminalOperations } from './useTerminalOperations'
 import type { FileAttachment } from '~/components/chat/attachments'
-import type { ChatMessageLookups, ChatRailProps } from '~/components/chat/ChatView'
+import type { AgentLifecycleProps, ChatMessageLookups, ChatRailProps } from '~/components/chat/ChatView'
 import type { BranchRef } from '~/components/workspace/WorkspaceTabTree'
 import type { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import type { ToggleDialogState } from '~/hooks/createDialogState'
@@ -48,7 +48,7 @@ import { parentDirectory, relativizePath } from '~/lib/paths'
 import { pluralize } from '~/lib/plural'
 import { formatFileMention, formatFileQuote } from '~/lib/quoteUtils'
 import { chipTasksFor, rootWorkState, subagentWorkState } from '~/stores/chatBackgroundTasks'
-import { appendText, insertIntoMruAgentEditor, queueInsertForAgent } from '~/stores/editorRef.store'
+import { insertIntoAgentEditor, insertIntoMruAgentEditor } from '~/stores/editorRef.store'
 import { buildTilePredicateMap, CLOSE_MODE_NONE } from '~/stores/layout.store'
 import { agentTabToInfo, isSteerableAgentTab, rootAgentIdFor } from '~/stores/tab.helpers'
 import { emitMergeTabsIntoTile, emitReassignTabsToTile } from '~/stores/tabOps'
@@ -195,7 +195,7 @@ export function createTileRenderer(opts: TileRendererOpts) {
   const isSubagentReadOnly = (agentId: string): boolean => {
     const t = view.getAgentTab(agentId)
     // Absent tab -> not read-only: nothing is mounted to refuse, and the write
-    // path (appendText, the composer gate) answers for itself. isSteerableAgentTab
+    // path (insertIntoAgentEditor, the composer gate) answers for itself. isSteerableAgentTab
     // already returns true for a root, so this needs no parentAgentId test of its
     // own -- a second copy of that rule is how the two answers drift apart.
     return t !== undefined && !isSteerableAgentTab(t)
@@ -820,6 +820,27 @@ export function createTileRenderer(opts: TileRendererOpts) {
             // Memoized because bgRootFor walks the parent chain on every call.
             const rootTasks = createMemo(() => bgTasksFor(agentId))
 
+            // A named const with GETTERS, not an inline object literal in the
+            // JSX. Solid compiles a literal passed as a prop into ONE getter for
+            // the whole object, so any reader that touches one field inside a
+            // tracking scope subscribes to EVERY field -- `thinkingTokens` and
+            // `agentWorking` included, and those change many times per turn. A
+            // bare identifier compiles to a STATIC prop instead, so each getter
+            // below is its own reactive read. `renderContext` in MessageBubble is
+            // the same pattern for the same reason.
+            const agentLifecycle: AgentLifecycleProps = {
+              get agentWorking() { return agentThinking(agentId) },
+              get thinkingTokens() { return agentSessionStore.getInfo(agentId).thinkingTokens },
+              get agentStatus() { return agent()?.agentStatus },
+              get startupError() { return agent()?.startupError },
+              get startupMessage() { return agent()?.startupMessage },
+              get providerLabel() { return agentProviderLabel(agent()?.agentProvider) },
+              get backgroundTasks() { return chipTasks() },
+              get registryRows() { return rootTasks() },
+              onOpenSubagent: onOpenBackgroundTask,
+              get todos() { return todosFor(agentId) },
+            }
+
             const railProps = createMemo<ChatRailProps>(() => ({
               ...chatStore.getRailData(agentId),
               previewFor: railPreviewFor,
@@ -838,25 +859,25 @@ export function createTileRenderer(opts: TileRendererOpts) {
             // A writable tab keeps the same-tab insert. Routing every quote
             // through the MRU resolution would collapse the branch and is wrong:
             // mruOrder is workspace-wide, so with split tiles its head can be an
-            // agent in a different tile than the one being read.
+            // agent in a different tile than the tile the user reads.
             const quoteIntoComposer = (text: string) => {
               if (isSubagentReadOnly(agentId)) {
                 insertIntoMruAgentEditor(mruEditorDeps, text)
                 return
               }
-              if (appendText(agentId, text)) {
-                focusEditorRef()?.()
+              // One router decides the three cases, so this call site cannot
+              // read "the editor refused it" as "no editor is mounted" and queue
+              // into a composer nothing will ever flush.
+              if (insertIntoAgentEditor(agentId, text) === 'inserted')
                 return
-              }
-              // No ref registered for this agent. The composer is mounted for the
-              // FOCUSED tab alone, so this quote came from another tile: queue it
-              // and bring that tab forward, the way an unmounted editor is already
-              // handled for a mention. Focusing here instead would focus a
-              // DIFFERENT agent's composer -- the one that received no text.
+              // The composer is mounted for the FOCUSED tab alone, so a quote
+              // taken in another tile is already parked. Bring that tab forward,
+              // the way an unmounted editor is already handled for a mention.
+              // Activating BEFORE the insert would mount the destination editor
+              // first, and it would register to an empty queue.
               const tab = view.getAgentTab(agentId)
               if (tab)
                 mruEditorDeps.activate(tab)
-              queueInsertForAgent(agentId, text)
             }
             onCleanup(() => {
               agentScrollStates.delete(agentId)
@@ -918,18 +939,7 @@ export function createTileRenderer(opts: TileRendererOpts) {
                     lookups={lookups}
                     onQuote={isActiveWorkspaceArchived() ? undefined : quoteIntoComposer}
                     onReply={isActiveWorkspaceArchived() ? undefined : quoteIntoComposer}
-                    agentLifecycle={{
-                      agentWorking: agentThinking(agentId),
-                      thinkingTokens: agentSessionStore.getInfo(agentId).thinkingTokens,
-                      agentStatus: agent()?.agentStatus,
-                      startupError: agent()?.startupError,
-                      startupMessage: agent()?.startupMessage,
-                      providerLabel: agentProviderLabel(agent()?.agentProvider),
-                      backgroundTasks: chipTasks(),
-                      registryRows: rootTasks(),
-                      onOpenSubagent: onOpenBackgroundTask,
-                      todos: todosFor(agentId),
-                    }}
+                    agentLifecycle={agentLifecycle}
                   />
                 </Show>
               </div>

--- a/frontend/src/components/shell/mruAgentEditorDeps.ts
+++ b/frontend/src/components/shell/mruAgentEditorDeps.ts
@@ -1,8 +1,9 @@
+import type { MruAgentEditorDeps } from '~/stores/editorRef.store'
 import type { createFloatingWindowStore } from '~/stores/floatingWindow.store'
 import type { createLayoutStore } from '~/stores/layout.store'
-import type { Tab } from '~/stores/tab.types'
 import type { TabSelectionStore } from '~/stores/tabSelection.store'
 import type { TabView } from '~/stores/tabView'
+import { showInfoToast } from '~/components/common/Toast'
 import { focusTile } from './tileLifecycle'
 
 /**
@@ -28,7 +29,7 @@ export function mruAgentEditorDeps(deps: {
   layoutStore: ReturnType<typeof createLayoutStore>
   floatingWindowStore: ReturnType<typeof createFloatingWindowStore> | undefined
   getWorkspaceId: () => string | undefined
-}): { mruTabs: () => Tab[], activate: (tab: Tab) => void } {
+}): MruAgentEditorDeps {
   return {
     // EVERY tab type in MRU order, not just agents. `insertIntoMruAgentEditor`
     // owns the AGENT narrowing; calling this `mruAgentTabs` made that filter
@@ -39,5 +40,10 @@ export function mruAgentEditorDeps(deps: {
       if (tab.tileId)
         focusTile(deps.layoutStore, deps.floatingWindowStore, tab.tileId, tab.workspaceId)
     },
+    // The store reports; the shell decides it is a toast. Both moments move the
+    // user's text somewhere other than where the click implied, and both are
+    // silent without this -- a re-routed insert lands in a different composer
+    // while the tab moves, and a refused one lands nowhere at all.
+    notify: showInfoToast,
   }
 }

--- a/frontend/src/components/shell/openSubagentTab.ts
+++ b/frontend/src/components/shell/openSubagentTab.ts
@@ -174,10 +174,18 @@ function buildMetadata(
   item: { parentAgentId?: string, title?: string },
 ): TabMetadata {
   const parent = item.parentAgentId ? deps.view.getAgentTab(item.parentAgentId) : undefined
-  // workerId and parentAgentId are NOT metadata fields: workerId lives on the
-  // projection (the emit*Tab op carries it), and parentAgentId is hydrated by
-  // listAgents. Seed only title/workingDir/agentProvider + the optimistic git
-  // fields the sidebar groups by until hydration lands.
+  // workerId is NOT a metadata field: it lives on the projection, and the
+  // emit*Tab op carries it. `parentAgentId` IS one (see AgentMeta in
+  // tabMetadata.store), and it is left out deliberately rather than because it
+  // has nowhere to go: listAgents hydrates it, along with `acceptsMessages`.
+  //
+  // The cost of leaving it out is real and worth knowing. Until hydration lands
+  // the tab has no parent, so isSteerableAgentTab calls it steerable, and a
+  // mention or quote taken in that window is routed to this tab and then
+  // dropped when the composer mounts read-only.
+  //
+  // Seed only title/workingDir/agentProvider + the optimistic git fields the
+  // sidebar groups by until hydration lands.
   const git = parent ? resolveOptimisticGitInfo(parent, { workingDir: parent.workingDir }) : undefined
   return {
     title: item.title || undefined,

--- a/frontend/src/hooks/useChatAutoFocus.test.ts
+++ b/frontend/src/hooks/useChatAutoFocus.test.ts
@@ -6,8 +6,14 @@ import { useChatAutoFocus } from './useChatAutoFocus'
 
 const AGENT_ID = 'agent-1'
 
-/** An editor ref that records what the hook inserts into it. */
-function fakeEditor(): { ref: EditorRef, inserted: string[] } {
+/**
+ * An editor ref that records what the hook inserts into it.
+ *
+ * `writable` decides whether the registry lets the insert through at all: this
+ * hook types straight into `getEditorRef(...).insert`, so a read-only composer
+ * is refused by the guarded handle rather than by the hook.
+ */
+function fakeEditor(writable = true): { ref: EditorRef, inserted: string[] } {
   const inserted: string[] = []
   return {
     inserted,
@@ -18,6 +24,7 @@ function fakeEditor(): { ref: EditorRef, inserted: string[] } {
       insert: (text: string) => {
         inserted.push(text)
       },
+      writable: () => writable,
     },
   }
 }
@@ -29,8 +36,8 @@ function fakeEditor(): { ref: EditorRef, inserted: string[] } {
  * the focused editor received rather than on the hook's return value — the
  * hook returns nothing.
  */
-function mount(agentId: string | null = AGENT_ID) {
-  const editor = fakeEditor()
+function mount(agentId: string | null = AGENT_ID, writable = true) {
+  const editor = fakeEditor(writable)
   registerEditorRef(AGENT_ID, editor.ref)
   const { cleanup } = renderHook(() => useChatAutoFocus(() => agentId))
   return { inserted: editor.inserted, cleanup }
@@ -174,5 +181,27 @@ describe('useChatAutoFocus', () => {
     cleanup()
     expect(press('a')).toBe(false)
     expect(inserted).toEqual([])
+  })
+})
+
+// Type-to-focus reaches the editor through `getEditorRef(...).insert`, which
+// never passes through a function in editorRef.store. That is exactly why the
+// registry hands out a guarded handle: a subagent tab that refuses messages has
+// a mounted, registered, disabled composer, and a keystroke must not land in it.
+describe('useChatAutoFocus on a read-only composer', () => {
+  afterEach(() => {
+    unregisterEditorRef(AGENT_ID)
+    document.body.replaceChildren()
+  })
+
+  it('inserts nothing and reports the key unhandled when the focused agent refuses input', () => {
+    const { inserted, cleanup } = mount(AGENT_ID, false)
+    try {
+      expect(press('a')).toBe(false)
+      expect(inserted).toEqual([])
+    }
+    finally {
+      cleanup()
+    }
   })
 })

--- a/frontend/src/hooks/useChatAutoFocus.ts
+++ b/frontend/src/hooks/useChatAutoFocus.ts
@@ -18,8 +18,12 @@ export function useChatAutoFocus(getFocusedAgentId: () => string | null): void {
     if (!agentId)
       return
 
+    // `writable()` decides it, not the mere presence of a ref: a read-only
+    // subagent's composer is mounted and registered, merely disabled. Returning
+    // here rather than calling the guarded no-op keeps preventDefault honest --
+    // the handler must not report a key as handled when it dropped it.
     const ref = getEditorRef(agentId)
-    if (!ref)
+    if (!ref?.writable())
       return
 
     ref.insert(e.key)

--- a/frontend/src/lib/clipFirstLine.test.ts
+++ b/frontend/src/lib/clipFirstLine.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { clipFirstLine } from './clipFirstLine'
+
+/**
+ * A lone surrogate: half of an astral character, left behind by a cut that
+ * landed between the pair. `String.prototype.isWellFormed` says the same thing
+ * but needs an ES2024 lib target.
+ */
+const LONE_SURROGATE = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/
+
+describe('clipFirstLine', () => {
+  it('returns a short line unchanged and adds no ellipsis', () => {
+    expect(clipFirstLine('Explore the parser', 80)).toBe('Explore the parser')
+  })
+
+  it('keeps the first line only', () => {
+    expect(clipFirstLine('first line\nsecond line', 80)).toBe('first line')
+  })
+
+  // A CRLF payload left the carriage return on the end of the line, where it
+  // renders as nothing and still counts toward the length.
+  it('drops a trailing carriage return from a CRLF line', () => {
+    expect(clipFirstLine('first line\r\nsecond line', 80)).toBe('first line')
+  })
+
+  it('clips at the limit and marks the cut', () => {
+    expect(clipFirstLine('x'.repeat(200), 10)).toBe(`${'x'.repeat(10)}…`)
+  })
+
+  // The defect this helper exists to remove. A raw slice at a fixed offset lands
+  // between the two halves of a surrogate pair, and the lone surrogate left
+  // behind renders as a replacement glyph.
+  it('never cuts an astral character in half', () => {
+    const text = `${'x'.repeat(9)}😀 and more text after it`
+    const clipped = clipFirstLine(text, 10)
+    expect(LONE_SURROGATE.test(clipped)).toBe(false)
+    expect(clipped).toBe(`${'x'.repeat(9)}😀…`)
+  })
+
+  it('reports blank input as an empty string', () => {
+    expect(clipFirstLine('   \n\t ', 80)).toBe('')
+    expect(clipFirstLine('', 80)).toBe('')
+  })
+})

--- a/frontend/src/lib/clipFirstLine.ts
+++ b/frontend/src/lib/clipFirstLine.ts
@@ -1,0 +1,26 @@
+import { cutAtCodeUnit, PREVIEW_ELLIPSIS } from './markdownSafeCut'
+
+/**
+ * The first line of `text`, capped at `limit` code units and given an ellipsis
+ * when it was cut.
+ *
+ * For a one-line label built from model prose: a tool-card header, a tool-use
+ * summary. Not for a preview of markdown -- `truncatePreview` is that, and it
+ * keeps paragraph structure and cuts on a grapheme boundary, which is the wrong
+ * shape here because the caller wants exactly one line.
+ *
+ * `cutAtCodeUnit`, not `slice`. A raw slice at a fixed offset can land between
+ * the two halves of a surrogate pair, and an emoji or a CJK-extension character
+ * in the model's prose then leaves a lone surrogate that the browser renders as
+ * a replacement glyph. The backend's own equivalent (bgtask.TruncateRunes)
+ * counts runes for the same reason.
+ *
+ * Returns "" when the text is blank, so a caller tests one value rather than
+ * testing for blankness itself.
+ */
+export function clipFirstLine(text: string, limit: number): string {
+  // \r included: a CRLF payload would otherwise leave the carriage return on the
+  // end of the line, where it renders as nothing and defeats a length check.
+  const line = text.trim().split(/\r?\n/, 1)[0].trim()
+  return line.length > limit ? `${cutAtCodeUnit(line, limit)}${PREVIEW_ELLIPSIS}` : line
+}

--- a/frontend/src/lib/markdownSafeCut.ts
+++ b/frontend/src/lib/markdownSafeCut.ts
@@ -42,7 +42,7 @@ interface RefEntry {
  * landing between a high and low surrogate extends by one unit to keep the
  * astral character whole, so the result is always well-formed UTF-16.
  */
-function cutAtCodeUnit(s: string, at: number): string {
+export function cutAtCodeUnit(s: string, at: number): string {
   const i = Math.min(Math.max(at, 0), s.length)
   if (i === 0 || i >= s.length)
     return s.slice(0, i)

--- a/frontend/src/stores/chatBackgroundTasks.test.ts
+++ b/frontend/src/stores/chatBackgroundTasks.test.ts
@@ -11,6 +11,7 @@ import {
   filterBackgroundTasksByKind,
   groupBackgroundTasks,
   isActiveBackgroundTaskStatus,
+  opensSubagentTranscript,
   protoBackgroundTaskToStore,
   rootWorkState,
   shouldShowBackgroundTasksSection,
@@ -329,5 +330,28 @@ describe('shouldShowBackgroundTasksSection', () => {
   // the flag only decides visibility, never what replaces the content.
   it('shows the section when the load failed and rows survive', () => {
     expect(shouldShowBackgroundTasksSection([item({ rowKey: 'a' })], true)).toBe(true)
+  })
+})
+
+// One predicate for "is this row a link", read by the Background tasks list and
+// by the SendMessage card. Each site covers only half of it today, so the cases
+// live here.
+describe('opensSubagentTranscript', () => {
+  it('reports a subagent row that owns a transcript', () => {
+    expect(opensSubagentTranscript(item({ rowKey: 'r1', kind: 'subagent', childAgentId: 'c1' }))).toBe(true)
+  })
+
+  it('reports a subagent whose provider never linked one', () => {
+    expect(opensSubagentTranscript(item({ rowKey: 'r1', kind: 'subagent', childAgentId: undefined }))).toBe(false)
+  })
+
+  // The falsy-empty-string case, which is why the predicate tests truthiness
+  // rather than `!== undefined`.
+  it('reports a blank child id as no transcript', () => {
+    expect(opensSubagentTranscript(item({ rowKey: 'r1', kind: 'subagent', childAgentId: '' }))).toBe(false)
+  })
+
+  it('reports a shell row as no transcript, whatever it carries', () => {
+    expect(opensSubagentTranscript(item({ rowKey: 'r1', kind: 'shell', childAgentId: 'c1' }))).toBe(false)
   })
 })

--- a/frontend/src/stores/chatBackgroundTasks.ts
+++ b/frontend/src/stores/chatBackgroundTasks.ts
@@ -207,6 +207,14 @@ export function subagentWorkState(childAgentId: string, rootTasks: BackgroundTas
  * own row by construction: that row belongs to its parent. Without the scoping
  * a subagent tab read its PARENT's count, siblings and itself included.
  */
+export function chipTasksFor(
+  agentId: string,
+  rootTasks: BackgroundTaskItem[],
+  isChild: boolean,
+): BackgroundTaskItem[] {
+  return isChild ? rootTasks.filter(t => t.parentAgentId === agentId) : rootTasks
+}
+
 /**
  * Whether this row owns a subagent transcript that a click can open. A shell row
  * owns none, and a subagent whose provider never linked one owns none either.
@@ -219,14 +227,6 @@ export function subagentWorkState(childAgentId: string, rootTasks: BackgroundTas
  */
 export function opensSubagentTranscript(item: BackgroundTaskItem): boolean {
   return item.kind === 'subagent' && !!item.childAgentId
-}
-
-export function chipTasksFor(
-  agentId: string,
-  rootTasks: BackgroundTaskItem[],
-  isChild: boolean,
-): BackgroundTaskItem[] {
-  return isChild ? rootTasks.filter(t => t.parentAgentId === agentId) : rootTasks
 }
 
 /**

--- a/frontend/src/stores/chatBackgroundTasks.ts
+++ b/frontend/src/stores/chatBackgroundTasks.ts
@@ -207,6 +207,20 @@ export function subagentWorkState(childAgentId: string, rootTasks: BackgroundTas
  * own row by construction: that row belongs to its parent. Without the scoping
  * a subagent tab read its PARENT's count, siblings and itself included.
  */
+/**
+ * Whether this row owns a subagent transcript that a click can open. A shell row
+ * owns none, and a subagent whose provider never linked one owns none either.
+ * Shared, so the Background tasks list and the SendMessage card cannot disagree
+ * about which rows are a link.
+ *
+ * The row property only. Whether the HOST supplied an open handler is the call
+ * site's own question, and folding it in here would make a pure registry
+ * predicate depend on a component's props.
+ */
+export function opensSubagentTranscript(item: BackgroundTaskItem): boolean {
+  return item.kind === 'subagent' && !!item.childAgentId
+}
+
 export function chipTasksFor(
   agentId: string,
   rootTasks: BackgroundTaskItem[],

--- a/frontend/src/stores/editorRef.store.test.ts
+++ b/frontend/src/stores/editorRef.store.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { registerProvider } from '~/components/chat/providers/registry'
 import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
-import { appendText, computeSeparator, getEditorRef, insertIntoMruAgentEditor, registerEditorRef, unregisterEditorRef } from './editorRef.store'
+import { computeSeparator, getEditorRef, insertIntoAgentEditor, insertIntoMruAgentEditor, registerEditorRef, unregisterEditorRef } from './editorRef.store'
 
 /** An EditorRef with the parts a test does not care about filled in. */
 function makeRef(over: Partial<EditorRef> = {}): EditorRef {
@@ -196,11 +196,11 @@ describe('insertIntoMruAgentEditor', () => {
  * module (type-to-focus uses the ref directly) and the ones not written yet.
  */
 describe('a read-only editor refuses writes', () => {
-  it('appendText writes nothing and reports that it did not', () => {
+  it('insertIntoAgentEditor writes nothing and reports refused', () => {
     const set = vi.fn()
     registerEditorRef('ro', readOnlyRef({ get: () => 'draft', set }))
     try {
-      expect(appendText('ro', 'quoted')).toBe(false)
+      expect(insertIntoAgentEditor('ro', 'quoted')).toBe('refused')
       expect(set).not.toHaveBeenCalled()
     }
     finally {
@@ -208,11 +208,11 @@ describe('a read-only editor refuses writes', () => {
     }
   })
 
-  it('appendText reports success for a writable editor', () => {
+  it('insertIntoAgentEditor reports inserted for a writable editor', () => {
     const set = vi.fn()
     registerEditorRef('rw', writableRef({ get: () => 'draft', set }))
     try {
-      expect(appendText('rw', 'quoted')).toBe(true)
+      expect(insertIntoAgentEditor('rw', 'quoted')).toBe('inserted')
       expect(set).toHaveBeenCalledWith('draft\n\nquoted')
     }
     finally {
@@ -220,8 +220,22 @@ describe('a read-only editor refuses writes', () => {
     }
   })
 
-  it('appendText reports failure when no editor is registered', () => {
-    expect(appendText('missing', 'quoted')).toBe(false)
+  // `queued` and `refused` are separate answers on purpose. Merging them into
+  // one boolean is what let the quote handler read a refusing editor as an
+  // absent one and park text nothing would ever flush.
+  it('insertIntoAgentEditor reports queued when no editor is registered', () => {
+    vi.useFakeTimers()
+    const set = vi.fn()
+    try {
+      expect(insertIntoAgentEditor('missing', 'quoted')).toBe('queued')
+      registerEditorRef('missing', writableRef({ set }))
+      vi.advanceTimersByTime(100)
+      expect(set).toHaveBeenCalledWith('quoted')
+    }
+    finally {
+      unregisterEditorRef('missing')
+      vi.useRealTimers()
+    }
   })
 
   it('getEditorRef hands out a handle whose set and insert are inert', () => {
@@ -281,6 +295,66 @@ describe('a read-only editor refuses writes', () => {
     }
   })
 
+  // Dropping is right; dropping SILENTLY is not. The destination is chosen from
+  // optimistic tab state -- a subagent tab opened from the sidebar has no
+  // parentAgentId until listAgents hydrates it, so it looks steerable and wins
+  // the MRU until its composer mounts and says otherwise. The text goes to the
+  // nearest agent that accepts messages, which is the same answer this function
+  // gives when the target is read-only up front.
+  it('re-routes a dropped queue to the nearest writable agent', async () => {
+    const setRoot = vi.fn()
+    const notify = vi.fn()
+    const optimisticChild = { type: TabType.AGENT, id: 'c1', workspaceId: 'ws' } as Tab
+    const hydratedChild = {
+      type: TabType.AGENT,
+      id: 'c1',
+      workspaceId: 'ws',
+      parentAgentId: 'root-1',
+      acceptsMessages: false,
+    } as Tab
+    const root = { type: TabType.AGENT, id: 'root-1', workspaceId: 'ws' } as Tab
+    let hydrated = false
+    const deps = {
+      mruTabs: () => (hydrated ? [hydratedChild, root] : [optimisticChild, root]),
+      activate: vi.fn(),
+      notify,
+    }
+    registerEditorRef('root-1', writableRef({ set: setRoot }))
+    try {
+      insertIntoMruAgentEditor(deps, 'quoted')
+      // listAgents lands and the child's composer mounts read-only.
+      hydrated = true
+      registerEditorRef('c1', readOnlyRef())
+      await new Promise(resolve => setTimeout(resolve, 120))
+
+      expect(setRoot).toHaveBeenCalledWith('quoted')
+      expect(notify).toHaveBeenCalledOnce()
+    }
+    finally {
+      unregisterEditorRef('c1')
+      unregisterEditorRef('root-1')
+    }
+  })
+
+  // The other silent drop on this path: the MRU target is MOUNTED and refuses
+  // input, so the text is not queued either -- nothing would ever flush a queue
+  // for an editor that already registered. The user has to be told, or the
+  // quote disappears with the tab moving forward as if it had landed.
+  it('reports a refused insert instead of dropping it silently', () => {
+    const notify = vi.fn()
+    const activate = vi.fn()
+    const target = { type: TabType.AGENT, id: 'ro-target', workspaceId: 'ws' } as Tab
+    registerEditorRef('ro-target', readOnlyRef())
+    try {
+      insertIntoMruAgentEditor({ mruTabs: () => [target], activate, notify }, 'quoted')
+      expect(notify).toHaveBeenCalledOnce()
+      expect(activate).toHaveBeenCalledWith(target)
+    }
+    finally {
+      unregisterEditorRef('ro-target')
+    }
+  })
+
   it('still flushes a queued insert when the editor registers writable', async () => {
     const set = vi.fn()
     const activate = vi.fn()
@@ -300,8 +374,8 @@ describe('a read-only editor refuses writes', () => {
 })
 
 /**
- * Queueing is only correct when the editor is ABSENT. A mounted editor has
- * already registered, so nothing will ever flush a queue for it -- text parked
+ * Queueing is only correct when the editor is ABSENT. A mounted editor already
+ * registered, so nothing will ever flush a queue for it -- text parked
  * there would land late on some later re-registration.
  */
 describe('insertIntoMruAgentEditor with a mounted read-only editor', () => {
@@ -342,9 +416,9 @@ describe('writable is re-read on every write', () => {
     let writable = false
     registerEditorRef('flip', makeRef({ get: () => '', set, writable: () => writable }))
     try {
-      expect(appendText('flip', 'first')).toBe(false)
+      expect(insertIntoAgentEditor('flip', 'first')).toBe('refused')
       writable = true
-      expect(appendText('flip', 'second')).toBe(true)
+      expect(insertIntoAgentEditor('flip', 'second')).toBe('inserted')
       expect(set).toHaveBeenCalledTimes(1)
       expect(set).toHaveBeenCalledWith('second')
     }
@@ -356,7 +430,7 @@ describe('writable is re-read on every write', () => {
   // The flush retries for ~500 ms after registration, and the worker's
   // authoritative acceptsMessages can arrive inside that window. Checking
   // writability once, at registration, let the later attempts write into a
-  // composer that had already turned read-only -- where the draft layer persists
+  // composer that already turned read-only -- where the draft layer persists
   // the text under that subagent's key and it survives a reload.
   it('stops a queued flush when the editor turns read-only mid-retry', async () => {
     const set = vi.fn()

--- a/frontend/src/stores/editorRef.store.test.ts
+++ b/frontend/src/stores/editorRef.store.test.ts
@@ -1,9 +1,42 @@
+import type { EditorRef } from './editorRef.store'
 import type { Tab } from '~/stores/tab.types'
 import { describe, expect, it, vi } from 'vitest'
 import { registerProvider } from '~/components/chat/providers/registry'
 import { AgentProvider } from '~/generated/leapmux/v1/agent_pb'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
-import { computeSeparator, insertIntoMruAgentEditor, registerEditorRef, unregisterEditorRef } from './editorRef.store'
+import { appendText, computeSeparator, getEditorRef, insertIntoMruAgentEditor, registerEditorRef, unregisterEditorRef } from './editorRef.store'
+
+/** An EditorRef with the parts a test does not care about filled in. */
+function makeRef(over: Partial<EditorRef> = {}): EditorRef {
+  // `get` reads back what `set` wrote, rather than a constant ''. The flush in
+  // registerEditorRef retries every 50 ms while `get()` reads empty, so a fake
+  // that never reflects the write keeps firing timers for ~500 ms after the test
+  // that armed it finished -- into whichever test runs next in this module.
+  let content = ''
+  const ref: EditorRef = {
+    get: () => content,
+    set: (value) => { content = value },
+    focus: vi.fn(),
+    insert: vi.fn(),
+    writable: () => true,
+  }
+  // A `set` override still records; keep the content mirror behind it so `get`
+  // stays consistent for the retry check.
+  if (over.set) {
+    const overridden = over.set
+    over = {
+      ...over,
+      set: (value) => {
+        content = value
+        overridden(value)
+      },
+    }
+  }
+  return { ...ref, ...over }
+}
+
+const writableRef = (over: Partial<EditorRef> = {}): EditorRef => makeRef(over)
+const readOnlyRef = (over: Partial<EditorRef> = {}): EditorRef => makeRef({ ...over, writable: () => false })
 
 describe('computeSeparator', () => {
   it('returns empty string when current is empty (block)', () => {
@@ -45,7 +78,7 @@ describe('insertIntoMruAgentEditor', () => {
   it('skips a non-agent tab at the MRU head and reaches the agent behind it', () => {
     const set = vi.fn()
     const activate = vi.fn()
-    registerEditorRef('a1', { get: () => '', set, focus: vi.fn(), insert: vi.fn() })
+    registerEditorRef('a1', writableRef({ get: () => '', set }))
     try {
       insertIntoMruAgentEditor(
         // A terminal is the most recently touched tab; the agent is behind it.
@@ -84,7 +117,7 @@ describe('insertIntoMruAgentEditor', () => {
     }
     // The root is always steerable (no parentAgentId).
     const root: Tab = { type: TabType.AGENT, id: 'root-1', workspaceId: 'ws' }
-    registerEditorRef('root-1', { get: () => '', set: setRoot, focus: vi.fn(), insert: vi.fn() })
+    registerEditorRef('root-1', writableRef({ get: () => '', set: setRoot }))
     try {
       insertIntoMruAgentEditor(
         // Non-steerable child is MRU; the root is behind it.
@@ -113,7 +146,7 @@ describe('insertIntoMruAgentEditor', () => {
       acceptsMessages: true,
       agentProvider: AgentProvider.CODEX,
     }
-    registerEditorRef('c1', { get: () => '', set: setChild, focus: vi.fn(), insert: vi.fn() })
+    registerEditorRef('c1', writableRef({ get: () => '', set: setChild }))
     try {
       insertIntoMruAgentEditor(
         { mruTabs: () => [steerableChild], activate },
@@ -141,7 +174,7 @@ describe('insertIntoMruAgentEditor', () => {
       parentAgentId: 'root-1',
       agentProvider: AgentProvider.CODEX,
     }
-    registerEditorRef('c1', { get: () => '', set: setChild, focus: vi.fn(), insert: vi.fn() })
+    registerEditorRef('c1', writableRef({ get: () => '', set: setChild }))
     try {
       insertIntoMruAgentEditor(
         { mruTabs: () => [codexChildUnhydrated], activate },
@@ -151,6 +184,234 @@ describe('insertIntoMruAgentEditor', () => {
     }
     finally {
       unregisterEditorRef('c1')
+    }
+  })
+})
+
+/**
+ * A read-only composer is MOUNTED and registered like any other -- a
+ * non-steerable subagent's editor is disabled, not absent -- so the registry is
+ * the only place that can refuse a write to it. Refusing here rather than at
+ * each call site is what covers the writers that never call a function in this
+ * module (type-to-focus uses the ref directly) and the ones not written yet.
+ */
+describe('a read-only editor refuses writes', () => {
+  it('appendText writes nothing and reports that it did not', () => {
+    const set = vi.fn()
+    registerEditorRef('ro', readOnlyRef({ get: () => 'draft', set }))
+    try {
+      expect(appendText('ro', 'quoted')).toBe(false)
+      expect(set).not.toHaveBeenCalled()
+    }
+    finally {
+      unregisterEditorRef('ro')
+    }
+  })
+
+  it('appendText reports success for a writable editor', () => {
+    const set = vi.fn()
+    registerEditorRef('rw', writableRef({ get: () => 'draft', set }))
+    try {
+      expect(appendText('rw', 'quoted')).toBe(true)
+      expect(set).toHaveBeenCalledWith('draft\n\nquoted')
+    }
+    finally {
+      unregisterEditorRef('rw')
+    }
+  })
+
+  it('appendText reports failure when no editor is registered', () => {
+    expect(appendText('missing', 'quoted')).toBe(false)
+  })
+
+  it('getEditorRef hands out a handle whose set and insert are inert', () => {
+    const set = vi.fn()
+    const insert = vi.fn()
+    registerEditorRef('ro', readOnlyRef({ get: () => 'draft', set, insert }))
+    try {
+      const ref = getEditorRef('ro')
+      ref?.set('replaced')
+      ref?.insert('x')
+      expect(set).not.toHaveBeenCalled()
+      expect(insert).not.toHaveBeenCalled()
+      // Reading and focusing stay available: the transcript is still readable,
+      // and focus moves without changing anything.
+      expect(ref?.get()).toBe('draft')
+    }
+    finally {
+      unregisterEditorRef('ro')
+    }
+  })
+
+  it('getEditorRef still forwards set and insert for a writable editor', () => {
+    const set = vi.fn()
+    const insert = vi.fn()
+    registerEditorRef('rw', writableRef({ set, insert }))
+    try {
+      const ref = getEditorRef('rw')
+      ref?.set('replaced')
+      ref?.insert('x')
+      expect(set).toHaveBeenCalledWith('replaced')
+      expect(insert).toHaveBeenCalledWith('x')
+    }
+    finally {
+      unregisterEditorRef('rw')
+    }
+  })
+
+  // Writability is unknown when a queue is built, because the editor is not
+  // mounted yet. Flushing it into an editor that turns out to be read-only would
+  // land the text late -- and the draft layer would then persist it under that
+  // subagent's own key, where it survives a reload.
+  it('drops a queued insert when the editor registers read-only', async () => {
+    const set = vi.fn()
+    const activate = vi.fn()
+    insertIntoMruAgentEditor(
+      { mruTabs: () => [{ type: TabType.AGENT, id: 'later', workspaceId: 'ws' } as Tab], activate },
+      'queued',
+    )
+    registerEditorRef('later', readOnlyRef({ set }))
+    try {
+      // The flush is scheduled on a timer, so give it more than its own delay.
+      await new Promise(resolve => setTimeout(resolve, 120))
+      expect(set).not.toHaveBeenCalled()
+    }
+    finally {
+      unregisterEditorRef('later')
+    }
+  })
+
+  it('still flushes a queued insert when the editor registers writable', async () => {
+    const set = vi.fn()
+    const activate = vi.fn()
+    insertIntoMruAgentEditor(
+      { mruTabs: () => [{ type: TabType.AGENT, id: 'later2', workspaceId: 'ws' } as Tab], activate },
+      'queued',
+    )
+    registerEditorRef('later2', writableRef({ set }))
+    try {
+      await new Promise(resolve => setTimeout(resolve, 120))
+      expect(set).toHaveBeenCalledWith('queued')
+    }
+    finally {
+      unregisterEditorRef('later2')
+    }
+  })
+})
+
+/**
+ * Queueing is only correct when the editor is ABSENT. A mounted editor has
+ * already registered, so nothing will ever flush a queue for it -- text parked
+ * there would land late on some later re-registration.
+ */
+describe('insertIntoMruAgentEditor with a mounted read-only editor', () => {
+  it('drops the text rather than queueing it', async () => {
+    const set = vi.fn()
+    const activate = vi.fn()
+    // A root tab (always steerable by tab state) whose live editor refuses
+    // input: the two sources disagree, and the editor is the one that knows.
+    registerEditorRef('root-1', readOnlyRef({ set }))
+    try {
+      insertIntoMruAgentEditor(
+        { mruTabs: () => [{ type: TabType.AGENT, id: 'root-1', workspaceId: 'ws' } as Tab], activate },
+        'hello',
+      )
+      expect(set).not.toHaveBeenCalled()
+      // Nothing was parked: re-registering as writable must not replay it.
+      unregisterEditorRef('root-1')
+      const laterSet = vi.fn()
+      registerEditorRef('root-1', writableRef({ set: laterSet }))
+      await new Promise(resolve => setTimeout(resolve, 120))
+      expect(laterSet, 'a dropped insert must not resurface later').not.toHaveBeenCalled()
+    }
+    finally {
+      unregisterEditorRef('root-1')
+    }
+  })
+})
+
+/**
+ * `writable` is a thunk, not a boolean, because a subagent tab answers from its
+ * provider plugin until the worker's authoritative `acceptsMessages` arrives --
+ * so the answer flips under a ref that was registered once. Reading it per call
+ * is what makes the guard follow that change.
+ */
+describe('writable is re-read on every write', () => {
+  it('follows a ref that becomes writable after registration', () => {
+    const set = vi.fn()
+    let writable = false
+    registerEditorRef('flip', makeRef({ get: () => '', set, writable: () => writable }))
+    try {
+      expect(appendText('flip', 'first')).toBe(false)
+      writable = true
+      expect(appendText('flip', 'second')).toBe(true)
+      expect(set).toHaveBeenCalledTimes(1)
+      expect(set).toHaveBeenCalledWith('second')
+    }
+    finally {
+      unregisterEditorRef('flip')
+    }
+  })
+
+  // The flush retries for ~500 ms after registration, and the worker's
+  // authoritative acceptsMessages can arrive inside that window. Checking
+  // writability once, at registration, let the later attempts write into a
+  // composer that had already turned read-only -- where the draft layer persists
+  // the text under that subagent's key and it survives a reload.
+  it('stops a queued flush when the editor turns read-only mid-retry', async () => {
+    const set = vi.fn()
+    const activate = vi.fn()
+    let writable = true
+    insertIntoMruAgentEditor(
+      { mruTabs: () => [{ type: TabType.AGENT, id: 'flip-flush', workspaceId: 'ws' } as Tab], activate },
+      'queued',
+    )
+    registerEditorRef('flip-flush', makeRef({ get: () => '', set, writable: () => writable }))
+    try {
+      writable = false
+      await new Promise(resolve => setTimeout(resolve, 200))
+      expect(set).not.toHaveBeenCalled()
+    }
+    finally {
+      unregisterEditorRef('flip-flush')
+    }
+  })
+
+  // A tab can close inside the same retry window. Without re-reading the
+  // registry the loop kept calling set() and finally focus() on an unmounted
+  // composer, stealing focus from whatever replaced it.
+  it('stops a queued flush when the editor unregisters mid-retry', async () => {
+    const set = vi.fn()
+    const focus = vi.fn()
+    const activate = vi.fn()
+    insertIntoMruAgentEditor(
+      { mruTabs: () => [{ type: TabType.AGENT, id: 'gone-flush', workspaceId: 'ws' } as Tab], activate },
+      'queued',
+    )
+    // `get` stays empty so the flush would retry to its 10-attempt limit.
+    registerEditorRef('gone-flush', makeRef({ get: () => '', set, focus }))
+    unregisterEditorRef('gone-flush')
+    await new Promise(resolve => setTimeout(resolve, 200))
+    expect(set).not.toHaveBeenCalled()
+    expect(focus).not.toHaveBeenCalled()
+  })
+
+  it('follows a ref that becomes read-only after registration', () => {
+    const insert = vi.fn()
+    let writable = true
+    registerEditorRef('flip', makeRef({ insert, writable: () => writable }))
+    try {
+      getEditorRef('flip')?.insert('a')
+      writable = false
+      // The SAME handle, taken while the editor still accepted input, must stop
+      // writing once it does not -- a caller can hold one across the change.
+      const held = getEditorRef('flip')
+      held?.insert('b')
+      expect(insert).toHaveBeenCalledTimes(1)
+      expect(insert).toHaveBeenCalledWith('a')
+    }
+    finally {
+      unregisterEditorRef('flip')
     }
   })
 })

--- a/frontend/src/stores/editorRef.store.ts
+++ b/frontend/src/stores/editorRef.store.ts
@@ -6,11 +6,51 @@ export interface EditorRef {
   set: (value: string) => void
   focus: () => void
   insert: (text: string) => void
+  /**
+   * Whether this composer accepts input at all. A thunk, not a boolean: a
+   * subagent tab starts out on its provider plugin's guess and flips once the
+   * worker's authoritative `acceptsMessages` hydrates.
+   *
+   * The EDITOR declares this, rather than each writer looking the tab up,
+   * because the registry is the only route to a composer -- so refusing here is
+   * what makes a write to a read-only one impossible rather than merely
+   * unusual. A read-only subagent's composer is mounted and registered like any
+   * other (it is disabled, not absent), so without this every writer would land
+   * text in it, and the draft layer would persist that text under the
+   * subagent's own key where it survives a reload.
+   */
+  writable: () => boolean
 }
 
 const registry = new Map<string, EditorRef>()
 /** Pending inserts to flush when an editor ref is registered. */
 const pendingInserts = new Map<string, Array<{ text: string, mode: 'block' | 'inline' }>>()
+
+/**
+ * A ref whose writes are dropped while the editor refuses input, but whose reads
+ * and focus still work.
+ *
+ * The registry STORES this, so every route to a composer is guarded by
+ * construction: `getEditorRef`, `appendText`, the MRU insert, and the deferred
+ * flush all read the same guarded handle. Guarding only the accessor left the
+ * module's own writers on the raw ref, and the flush retry -- which writes for
+ * up to half a second after registration -- never re-checked at all.
+ */
+function guarded(ref: EditorRef): EditorRef {
+  return {
+    get: ref.get,
+    focus: ref.focus,
+    writable: ref.writable,
+    set: (value) => {
+      if (ref.writable())
+        ref.set(value)
+    },
+    insert: (text) => {
+      if (ref.writable())
+        ref.insert(text)
+    },
+  }
+}
 
 /** Compute the separator to join `text` after `current` content. */
 export function computeSeparator(current: string, mode: 'block' | 'inline'): string {
@@ -22,28 +62,45 @@ export function computeSeparator(current: string, mode: 'block' | 'inline'): str
 }
 
 export function registerEditorRef(agentId: string, ref: EditorRef): void {
-  registry.set(agentId, ref)
+  const editor = guarded(ref)
+  registry.set(agentId, editor)
   // Flush any pending inserts that were queued before the component mounted.
   // Milkdown's ProseMirror view may silently reject replaceAll if it isn't
   // fully initialized, so we retry a few times with increasing delays.
   const pending = pendingInserts.get(agentId)
   if (pending != null) {
     pendingInserts.delete(agentId)
+    // Writability is unknown when a queue is built (the editor is not mounted
+    // yet), so it is checked HERE, once the editor says what it is. Dropping the
+    // queue is the whole point: a queued quote must not land in a composer that
+    // turned out to be read-only.
+    if (!editor.writable())
+      return
     const tryFlush = (attempt: number) => {
+      // Re-read on EVERY attempt, and off the registry rather than the captured
+      // ref. This loop writes for up to half a second after the check above, and
+      // two things can change inside that window: the worker's authoritative
+      // acceptsMessages can arrive and turn the composer read-only, and the tab
+      // can close, which unregisters it. Either one must stop the flush -- the
+      // guarded handle refuses the write, and an absent entry ends the retry
+      // instead of setting and focusing an unmounted editor.
+      const live = registry.get(agentId)
+      if (live === undefined || !live.writable())
+        return
       // Read existing content at flush time (not registration time) so draft
       // content loaded by Milkdown is preserved.
-      let combined = ref.get()
+      let combined = live.get()
       for (const { text, mode } of pending) {
         const sep = computeSeparator(combined, mode)
         combined = combined ? `${combined}${sep}${text}` : text
       }
-      ref.set(combined)
+      live.set(combined)
       // Verify the text was actually inserted (ref.set may silently fail).
-      if (ref.get().length === 0 && attempt < 10) {
+      if (live.get().length === 0 && attempt < 10) {
         setTimeout(tryFlush, 50, attempt + 1)
       }
       else {
-        ref.focus()
+        live.focus()
       }
     }
     // Start with a small delay to let the editor settle after mount.
@@ -59,14 +116,35 @@ export function getEditorRef(agentId: string): EditorRef | undefined {
   return registry.get(agentId)
 }
 
-/** Append text to an editor's existing content as a new paragraph. */
-export function appendText(agentId: string, text: string): void {
+/**
+ * Append text to an editor's existing content as a new paragraph. Reports
+ * whether it landed, so a caller can skip following up with `focus()` on a
+ * composer that refused the text and would only sit there inert.
+ */
+export function appendText(agentId: string, text: string): boolean {
   const ref = registry.get(agentId)
-  if (!ref)
-    return
+  if (ref === undefined || !ref.writable())
+    return false
   const current = ref.get()
   const combined = current ? `${current}\n\n${text}` : text
   ref.set(combined)
+  return true
+}
+
+/**
+ * Park text for an editor that is not mounted yet, to be flushed when it
+ * registers.
+ *
+ * Queueing is only correct while the editor is ABSENT. A mounted one has already
+ * registered, so nothing would ever flush a queue for it and the text would sit
+ * until some later re-registration wrote it in late. The flush re-checks
+ * writability, so a queue for an editor that turns out to be read-only is
+ * dropped rather than delivered.
+ */
+export function queueInsertForAgent(agentId: string, text: string, mode: 'block' | 'inline' = 'block'): void {
+  const existing = pendingInserts.get(agentId) ?? []
+  existing.push({ text, mode })
+  pendingInserts.set(agentId, existing)
 }
 
 /**
@@ -87,26 +165,35 @@ export function insertIntoMruAgentEditor(
 ): void {
   // Find the most-recent agent tab that is STEERABLE — a non-steerable child
   // (a read-only subagent transcript) must never receive an inserted mention or
-  // quote.
+  // quote. The chat quote reaches this too, for a message read in such a
+  // transcript: the tab it was read in is filtered out here, so the text goes to
+  // the nearest writable agent instead, and `activate` brings that tab forward
+  // so it is never inserted out of sight.
   const target = mruSteerableAgentTab(deps.mruTabs())
   if (!target)
     return
   const agentId = target.id
 
-  // Try to insert directly if the ref is available (same-tab scenario).
+  // Three cases, and the middle one is why they are spelled out rather than
+  // folded into one `isWritable` test: queueing is only right when the editor is
+  // ABSENT. A mounted editor that refuses input has already registered, so
+  // nothing will flush a queue for it -- the text would sit there until some
+  // later re-registration wrote it in late.
   const ref = registry.get(agentId)
-  if (ref) {
+  if (ref === undefined) {
+    // Editor is not mounted yet — queue text for when it registers. The flush
+    // re-checks writability then, once the editor can answer.
+    queueInsertForAgent(agentId, text, mode)
+  }
+  else if (ref.writable()) {
     const current = ref.get()
     const sep = computeSeparator(current, mode)
     ref.set(current ? `${current}${sep}${text}` : text)
     ref.focus()
   }
-  else {
-    // Editor is not mounted yet — queue text for when it registers.
-    const existing = pendingInserts.get(agentId) ?? []
-    existing.push({ text, mode })
-    pendingInserts.set(agentId, existing)
-  }
+  // Mounted and read-only: drop it. The tab passed mruSteerableAgentTab, so this
+  // is the two sources disagreeing (tab state vs the live editor) and the editor
+  // is the one that knows. Activating below still brings the tab forward.
 
   // Activate the agent tab (workspace + per-tile).
   deps.activate(target)

--- a/frontend/src/stores/editorRef.store.ts
+++ b/frontend/src/stores/editorRef.store.ts
@@ -24,14 +24,26 @@ export interface EditorRef {
 
 const registry = new Map<string, EditorRef>()
 /** Pending inserts to flush when an editor ref is registered. */
-const pendingInserts = new Map<string, Array<{ text: string, mode: 'block' | 'inline' }>>()
+const pendingInserts = new Map<string, PendingInsert[]>()
+
+interface PendingInsert {
+  text: string
+  mode: 'block' | 'inline'
+  /**
+   * Called when the flush DROPS this entry, because the editor turned out to
+   * refuse input. Queueing happens before the destination can answer, so the
+   * drop is the only moment the caller learns its target was wrong -- and
+   * without a hook the user's text vanished with no message and no fallback.
+   */
+  onDropped?: () => void
+}
 
 /**
  * A ref whose writes are dropped while the editor refuses input, but whose reads
  * and focus still work.
  *
  * The registry STORES this, so every route to a composer is guarded by
- * construction: `getEditorRef`, `appendText`, the MRU insert, and the deferred
+ * construction: `getEditorRef`, `insertIntoAgentEditor`, and the deferred
  * flush all read the same guarded handle. Guarding only the accessor left the
  * module's own writers on the raw ref, and the flush retry -- which writes for
  * up to half a second after registration -- never re-checked at all.
@@ -74,8 +86,17 @@ export function registerEditorRef(agentId: string, ref: EditorRef): void {
     // yet), so it is checked HERE, once the editor says what it is. Dropping the
     // queue is the whole point: a queued quote must not land in a composer that
     // turned out to be read-only.
-    if (!editor.writable())
+    //
+    // Each entry is TOLD it was dropped, so the caller can put the text
+    // somewhere the user can still send it. The queue is deleted first, so a
+    // handler that queues again for this same agent cannot append to a list this
+    // loop is walking -- and it will not, because the registry already holds the
+    // editor by now, so a re-entrant insert gets 'refused' rather than 'queued'.
+    if (!editor.writable()) {
+      for (const entry of pending)
+        entry.onDropped?.()
       return
+    }
     const tryFlush = (attempt: number) => {
       // Re-read on EVERY attempt, and off the registry rather than the captured
       // ref. This loop writes for up to half a second after the check above, and
@@ -117,33 +138,70 @@ export function getEditorRef(agentId: string): EditorRef | undefined {
 }
 
 /**
- * Append text to an editor's existing content as a new paragraph. Reports
- * whether it landed, so a caller can skip following up with `focus()` on a
- * composer that refused the text and would only sit there inert.
+ * What `insertIntoAgentEditor` did with the text.
+ *
+ * - `inserted`: the editor took it, and the editor is focused.
+ * - `queued`: no editor is mounted, so the text waits for one to register.
+ * - `refused`: an editor IS mounted and does not accept input. The text is
+ *   dropped, because nothing will ever flush a queue for an editor that already
+ *   registered.
  */
-export function appendText(agentId: string, text: string): boolean {
+export type InsertOutcome = 'inserted' | 'queued' | 'refused'
+
+/**
+ * Put text into one agent's composer, and report which of the three cases the
+ * caller got.
+ *
+ * This is the ONE router. Every caller used to spell the three cases out again,
+ * and the two spellings already disagreed: the boolean the quote handler read
+ * reported absent and refusing alike, so it took every failure for "not
+ * mounted" and queued -- into an editor that already registered, where nothing
+ * would ever flush it. Reporting the case removes the guess.
+ *
+ * The caller activates the tab AFTER this returns, never before. A tab
+ * activation mounts the destination editor synchronously, and an editor that
+ * registers before the text is parked finds an empty queue and leaves the quote
+ * to be replayed into some later re-registration.
+ */
+export function insertIntoAgentEditor(
+  agentId: string,
+  text: string,
+  mode: 'block' | 'inline' = 'block',
+  onDropped?: () => void,
+): InsertOutcome {
   const ref = registry.get(agentId)
-  if (ref === undefined || !ref.writable())
-    return false
+  if (ref === undefined) {
+    queueInsertForAgent(agentId, text, mode, onDropped)
+    return 'queued'
+  }
+  if (!ref.writable())
+    return 'refused'
   const current = ref.get()
-  const combined = current ? `${current}\n\n${text}` : text
-  ref.set(combined)
-  return true
+  const sep = computeSeparator(current, mode)
+  ref.set(current ? `${current}${sep}${text}` : text)
+  ref.focus()
+  return 'inserted'
 }
 
 /**
  * Park text for an editor that is not mounted yet, to be flushed when it
  * registers.
  *
- * Queueing is only correct while the editor is ABSENT. A mounted one has already
+ * Queueing is only correct while the editor is ABSENT. A mounted one already
  * registered, so nothing would ever flush a queue for it and the text would sit
- * until some later re-registration wrote it in late. The flush re-checks
- * writability, so a queue for an editor that turns out to be read-only is
- * dropped rather than delivered.
+ * until some later re-registration wrote it in late. `insertIntoAgentEditor`
+ * makes that distinction for every caller; reach for this directly only when the
+ * editor is known to be absent. The flush re-checks writability, so a queue for
+ * an editor that turns out to be read-only is dropped rather than delivered.
  */
-export function queueInsertForAgent(agentId: string, text: string, mode: 'block' | 'inline' = 'block'): void {
+export function queueInsertForAgent(
+  agentId: string,
+  text: string,
+  mode: 'block' | 'inline' = 'block',
+  onDropped?: () => void,
+): void {
   const existing = pendingInserts.get(agentId) ?? []
-  existing.push({ text, mode })
+  existing.push({ text, mode, onDropped })
   pendingInserts.set(agentId, existing)
 }
 
@@ -151,15 +209,28 @@ export function queueInsertForAgent(agentId: string, text: string, mode: 'block'
  * Find the MRU agent tab and insert text into its editor.
  * Activates the agent tab and focuses the editor.
  */
+export interface MruAgentEditorDeps {
+  /**
+   * EVERY tab in the workspace on screen, most-recently-used first — not
+   * pre-filtered to agents. The narrowing below is the only one.
+   */
+  mruTabs: () => Tab[]
+  activate: (tab: Tab) => void
+  /**
+   * Tell the user the text did not go where the click implied. A thunk supplied
+   * by the shell, so this module keeps no UI import: it reports, and the shell
+   * decides whether that is a toast.
+   *
+   * Two moments need it, and both are invisible otherwise. A queued insert whose
+   * destination turns out to be read-only is RE-ROUTED here, up to half a second
+   * after the click and with the tab moving under the user. And a destination
+   * that is mounted and refuses input drops the text outright.
+   */
+  notify?: (message: string) => void
+}
+
 export function insertIntoMruAgentEditor(
-  deps: {
-    /**
-     * EVERY tab in the workspace on screen, most-recently-used first — not
-     * pre-filtered to agents. The narrowing below is the only one.
-     */
-    mruTabs: () => Tab[]
-    activate: (tab: Tab) => void
-  },
+  deps: MruAgentEditorDeps,
   text: string,
   mode: 'block' | 'inline' = 'block',
 ): void {
@@ -174,27 +245,29 @@ export function insertIntoMruAgentEditor(
     return
   const agentId = target.id
 
-  // Three cases, and the middle one is why they are spelled out rather than
-  // folded into one `isWritable` test: queueing is only right when the editor is
-  // ABSENT. A mounted editor that refuses input has already registered, so
-  // nothing will flush a queue for it -- the text would sit there until some
-  // later re-registration wrote it in late.
-  const ref = registry.get(agentId)
-  if (ref === undefined) {
-    // Editor is not mounted yet — queue text for when it registers. The flush
-    // re-checks writability then, once the editor can answer.
-    queueInsertForAgent(agentId, text, mode)
-  }
-  else if (ref.writable()) {
-    const current = ref.get()
-    const sep = computeSeparator(current, mode)
-    ref.set(current ? `${current}${sep}${text}` : text)
-    ref.focus()
-  }
-  // Mounted and read-only: drop it. The tab passed mruSteerableAgentTab, so this
-  // is the two sources disagreeing (tab state vs the live editor) and the editor
-  // is the one that knows. Activating below still brings the tab forward.
+  // `onDropped` re-runs this whole resolution. The destination was chosen from
+  // TAB state, which is optimistic: a subagent tab opened from the sidebar has
+  // no parentAgentId until listAgents hydrates it, so it looks steerable and
+  // wins the MRU until its composer mounts and says otherwise. Re-resolving is
+  // completing the original request, not inventing a new one -- and the same
+  // answer this function already gives when the target is read-only up front.
+  //
+  // The recursion is bounded: registerEditorRef puts the editor in the registry
+  // BEFORE it walks the queue, so a re-entrant call for the same agent finds a
+  // registered editor and returns 'refused' rather than queueing again.
+  const outcome = insertIntoAgentEditor(agentId, text, mode, () => {
+    insertIntoMruAgentEditor(deps, text, mode)
+    deps.notify?.('That subagent\'s composer is read-only. The text went to the nearest agent that accepts messages.')
+  })
+  // Mounted and refusing: the two sources disagree (tab state said steerable,
+  // the live editor says otherwise) and the editor is the one that knows. The
+  // text is dropped rather than queued, because nothing would ever flush a queue
+  // for an editor that already registered -- so the user has to be told.
+  if (outcome === 'refused')
+    deps.notify?.('That agent\'s composer does not accept input. The text was not inserted.')
 
-  // Activate the agent tab (workspace + per-tile).
+  // Activate the agent tab (workspace + per-tile). AFTER the insert, never
+  // before: activation mounts the destination editor, and an editor that
+  // registers ahead of the queue finds it empty.
   deps.activate(target)
 }

--- a/frontend/src/stores/tab.helpers.ts
+++ b/frontend/src/stores/tab.helpers.ts
@@ -284,7 +284,13 @@ export function descendantAgentTabs(tabs: readonly Tab[], agentId: string): Agen
  * always accept. Children accept only when their feeding provider can steer a
  * subagent conversation (acceptsMessages === true); a non-steerable child is a
  * read-only transcript. Used to exclude non-steerable children from MRU-agent
- * resolution (file mentions/quotes never target a disabled composer).
+ * resolution (file mentions/quotes never target a disabled composer), and to
+ * decide that a quote taken IN such a transcript goes to the nearest writable
+ * agent instead of into the composer beside it.
+ *
+ * This is the tab-state answer, not the last word: `EditorRef.writable` is what
+ * actually refuses a write, because the mounted editor is the one that knows and
+ * every route to a composer goes through that registry.
  */
 export function isSteerableAgentTab(tab: { type: TabType, parentAgentId?: string, acceptsMessages?: boolean, agentProvider?: AgentProvider }): boolean {
   if (tab.type !== TabType.AGENT)

--- a/frontend/src/types/toolMessages.ts
+++ b/frontend/src/types/toolMessages.ts
@@ -40,18 +40,6 @@ export interface GlobInput {
   path?: string
 }
 
-export interface TaskInput {
-  description?: string
-  prompt?: string
-  subagent_type?: string
-}
-
-export interface AgentInput {
-  description?: string
-  prompt?: string
-  subagent_type?: string
-}
-
 export interface WebFetchInput {
   url?: string
   prompt?: string
@@ -59,20 +47,6 @@ export interface WebFetchInput {
 
 export interface WebSearchInput {
   query?: string
-}
-
-export interface TodoWriteInput {
-  todos?: Array<{
-    content?: string
-    status?: string
-    activeForm?: string
-  }>
-}
-
-export interface TaskOutputInput {
-  task_id?: string
-  block?: boolean
-  timeout?: number
 }
 
 export interface ToolSearchInput {
@@ -85,56 +59,18 @@ export interface TaskStopInput {
 }
 
 /**
- * Claude Code 2.1.142+ to-do list tools. TaskCreate / TaskUpdate /
- * TaskGet / TaskList replace TodoWrite's single snapshot model with
- * incremental mutations addressed by `taskId`.
+ * SendMessage addresses another agent. `to` is the recipient: for a subagent of
+ * this session it is the background-task row key (Claude keys its task registry
+ * by agent id), and otherwise a display name, another session, or a
+ * uds:/bridge:/did: address.
+ *
+ * `message` is a plain string for an ordinary message and an object for the
+ * structured kinds (shutdown_request, plan_approval_response, ...).
  */
-export interface TaskCreateInput {
-  subject?: string
-  description?: string
-  activeForm?: string
-  metadata?: Record<string, unknown>
-}
-
-/**
- * Wire sentinel passed in `TaskUpdateInput.status` (or echoed as
- * `tool_use_result.statusChange.to`) to permanently remove a task.
- * Not a real status — handle it as a delete request, not a status
- * value to display.
- */
-export const TASK_DELETE_SENTINEL = 'deleted'
-
-export interface TaskUpdateInput {
-  taskId?: string
-  subject?: string
-  description?: string
-  activeForm?: string
-  status?: 'pending' | 'in_progress' | 'completed' | typeof TASK_DELETE_SENTINEL
-  addBlocks?: string[]
-  addBlockedBy?: string[]
-  owner?: string
-  metadata?: Record<string, unknown>
-}
-
-export interface TaskGetInput {
-  taskId?: string
-}
-
-export interface TaskListInput {
-  // intentionally empty — TaskList takes no arguments.
-  [key: string]: never
-}
-
-export interface AskUserQuestionInput {
-  questions?: Array<{
-    question?: string
-    header?: string
-    options?: Array<{
-      label?: string
-      description?: string
-    }>
-    multiSelect?: boolean
-  }>
+export interface SendMessageInput {
+  to?: string
+  message?: string | Record<string, unknown>
+  summary?: string
 }
 
 export interface RemoteTriggerInput {
@@ -172,63 +108,11 @@ export const CLAUDE_TOOL = {
   EXIT_PLAN_MODE: 'ExitPlanMode',
   SKILL: 'Skill',
   REMOTE_TRIGGER: 'RemoteTrigger',
+  SEND_MESSAGE: 'SendMessage',
+  LIST_AGENTS: 'ListAgents',
 } as const
 
 export type ClaudeToolName = typeof CLAUDE_TOOL[keyof typeof CLAUDE_TOOL]
-
-/** Discriminated union of all known tool input types keyed by tool name. */
-export type KnownToolInput
-  = | { toolName: typeof CLAUDE_TOOL.BASH, input: BashInput }
-    | { toolName: typeof CLAUDE_TOOL.READ, input: ReadInput }
-    | { toolName: typeof CLAUDE_TOOL.WRITE, input: WriteInput }
-    | { toolName: typeof CLAUDE_TOOL.EDIT, input: EditInput }
-    | { toolName: typeof CLAUDE_TOOL.GREP, input: GrepInput }
-    | { toolName: typeof CLAUDE_TOOL.GLOB, input: GlobInput }
-    | { toolName: typeof CLAUDE_TOOL.TASK, input: TaskInput }
-    | { toolName: typeof CLAUDE_TOOL.AGENT, input: AgentInput }
-    | { toolName: typeof CLAUDE_TOOL.WEB_FETCH, input: WebFetchInput }
-    | { toolName: typeof CLAUDE_TOOL.WEB_SEARCH, input: WebSearchInput }
-    | { toolName: typeof CLAUDE_TOOL.TODO_WRITE, input: TodoWriteInput }
-    | { toolName: typeof CLAUDE_TOOL.TASK_CREATE, input: TaskCreateInput }
-    | { toolName: typeof CLAUDE_TOOL.TASK_UPDATE, input: TaskUpdateInput }
-    | { toolName: typeof CLAUDE_TOOL.TASK_GET, input: TaskGetInput }
-    | { toolName: typeof CLAUDE_TOOL.TASK_LIST, input: TaskListInput }
-    | { toolName: typeof CLAUDE_TOOL.TASK_OUTPUT, input: TaskOutputInput }
-    | { toolName: typeof CLAUDE_TOOL.TOOL_SEARCH, input: ToolSearchInput }
-    | { toolName: typeof CLAUDE_TOOL.TASK_STOP, input: TaskStopInput }
-    | { toolName: typeof CLAUDE_TOOL.ASK_USER_QUESTION, input: AskUserQuestionInput }
-    | { toolName: typeof CLAUDE_TOOL.REMOTE_TRIGGER, input: RemoteTriggerInput }
-
-/** All known tool names (subset of ClaudeToolName that have typed inputs). */
-export type KnownToolName = KnownToolInput['toolName']
-
-const KNOWN_TOOLS = new Set<string>([
-  CLAUDE_TOOL.BASH,
-  CLAUDE_TOOL.READ,
-  CLAUDE_TOOL.WRITE,
-  CLAUDE_TOOL.EDIT,
-  CLAUDE_TOOL.GREP,
-  CLAUDE_TOOL.GLOB,
-  CLAUDE_TOOL.TASK,
-  CLAUDE_TOOL.AGENT,
-  CLAUDE_TOOL.WEB_FETCH,
-  CLAUDE_TOOL.WEB_SEARCH,
-  CLAUDE_TOOL.TASK_OUTPUT,
-  CLAUDE_TOOL.TODO_WRITE,
-  CLAUDE_TOOL.TASK_CREATE,
-  CLAUDE_TOOL.TASK_UPDATE,
-  CLAUDE_TOOL.TASK_GET,
-  CLAUDE_TOOL.TASK_LIST,
-  CLAUDE_TOOL.TOOL_SEARCH,
-  CLAUDE_TOOL.TASK_STOP,
-  CLAUDE_TOOL.ASK_USER_QUESTION,
-  CLAUDE_TOOL.REMOTE_TRIGGER,
-])
-
-/** Type guard: returns true if the tool name is a known tool. */
-export function isKnownTool(name: string): name is KnownToolName {
-  return KNOWN_TOOLS.has(name)
-}
 
 /**
  * Canonical ACP `sessionUpdate` literals (the discriminator used by the Agent

--- a/frontend/src/utils/agentState.test.ts
+++ b/frontend/src/utils/agentState.test.ts
@@ -418,10 +418,14 @@ describe('shouldShowThinkingIndicator', () => {
   })
 })
 
-// A subagent transcript is closed by the worker's subagent-end divider (written
-// when that subagent's registry row reaches a final status). It is a notification, so
+// A subagent RUN is closed by the worker's subagent-end divider (written when
+// that subagent's registry row reaches a final status). It is a notification, so
 // without an explicit stop the backwards scan would step over it, reach the
 // subagent's last real message, and report a finished subagent as still working.
+//
+// One divider per run, not per transcript: Claude restarts a finished subagent
+// when the parent messages it, so a transcript can hold several with work
+// between them.
 describe('isAgentWorking: the subagent-end divider', () => {
   const ended = (status: string) =>
     makeMsg(MessageSource.LEAPMUX, rawContent({ type: 'subagent_ended', status }))
@@ -444,12 +448,27 @@ describe('isAgentWorking: the subagent-end divider', () => {
   })
 
   it('still reports working when the subagent spoke after the divider', () => {
-    // Not a shape the worker produces, but the scan must answer from the LAST
-    // message rather than from "a divider exists somewhere".
+    // This IS a shape the worker produces: a revived subagent appends below the
+    // divider that closed its previous run. The scan answers from the LAST
+    // message rather than from "a divider exists somewhere", which is what makes
+    // the revive need no change here.
     expect(isAgentWorking([
       ended('completed'),
       makeMsg(MessageSource.AGENT, rawContent({ type: 'text', text: 'more' })),
     ])).toBe(true)
+  })
+
+  // The full revive shape end to end: first run, its divider, the message the
+  // parent sent, and the restarted run's output.
+  it('reports working again through a revive, and finished after the second divider', () => {
+    const revived = [
+      makeMsg(MessageSource.AGENT, rawContent({ type: 'text', text: 'first run' })),
+      ended('completed'),
+      makeMsg(MessageSource.USER, rawContent({ content: 'keep going' })),
+      makeMsg(MessageSource.AGENT, rawContent({ type: 'text', text: 'second run' })),
+    ]
+    expect(isAgentWorking(revived)).toBe(true)
+    expect(isAgentWorking([...revived, ended('completed')])).toBe(false)
   })
 
   it('reports working while the subagent is mid-flight', () => {

--- a/frontend/src/utils/agentState.ts
+++ b/frontend/src/utils/agentState.ts
@@ -145,11 +145,17 @@ export function isAgentWorking(msgs: AgentChatMessage[]): boolean {
     // forever, so it likewise stops the scan as "not working".
     if (category.kind === 'result_divider' || category.kind === 'unsupported_provider')
       return false
-    // The subagent-end divider is a subagent transcript's closing boundary:
-    // the worker writes exactly one, when that subagent's registry row reaches a
-    // final status, and nothing follows it. `subagent_ended` is not a
-    // non-progress type, so without this guard the scan stops AT this message
-    // and reports a finished subagent as still working.
+    // The subagent-end divider closes one subagent RUN: the worker writes one
+    // each time that subagent's registry row reaches a final status.
+    // `subagent_ended` is not a non-progress type, so without this guard the
+    // scan stops AT this message and reports a finished subagent as still
+    // working.
+    //
+    // A transcript can hold several, because Claude restarts a finished subagent
+    // when the parent messages it. This scan runs BACKWARDS, so it meets a
+    // restarted run's messages before the divider that closed the previous run
+    // and reports the subagent working again -- which is why the revive needs no
+    // change here.
     if (getInnerMessageType(parsed) === NOTIFICATION_TYPE.SubagentEnded)
       return false
     // context_cleared in a notification-thread row means the agent
@@ -213,9 +219,15 @@ export function shouldShowThinkingIndicator(
   // A finished registry row outranks the MESSAGE HISTORY, but not live evidence
   // of a turn in flight. A steerable subagent -- Codex re-registers a collab
   // child on any later tool call -- can be sent a new message after its row went
-  // final, and the row never reopens. Placing this ahead of `streamingText` and
-  // the provider's own turn check meant that turn ran with no thinking indicator
-  // and, because the same predicate gates Interrupt, no way to cancel it.
+  // final, and Codex's row never reopens. Placing this ahead of `streamingText`
+  // and the provider's own turn check meant that turn ran with no thinking
+  // indicator and, because the same predicate controls Interrupt, no way to cancel
+  // it.
+  //
+  // Claude's row DOES reopen: the worker revives it when the parent messages a
+  // finished subagent, so `work` is 'active' again by the time that run starts
+  // and the check above already returned true. This branch is the answer for a
+  // subagent that is genuinely over.
   if (work === 'finished')
     return false
   return isAgentWorking(msgs)

--- a/frontend/src/utils/agentState.ts
+++ b/frontend/src/utils/agentState.ts
@@ -217,17 +217,20 @@ export function shouldShowThinkingIndicator(
   if (override !== null && override !== undefined)
     return override
   // A finished registry row outranks the MESSAGE HISTORY, but not live evidence
-  // of a turn in flight. A steerable subagent -- Codex re-registers a collab
-  // child on any later tool call -- can be sent a new message after its row went
-  // final, and Codex's row never reopens. Placing this ahead of `streamingText`
-  // and the provider's own turn check meant that turn ran with no thinking
-  // indicator and, because the same predicate controls Interrupt, no way to cancel
-  // it.
+  // of a turn in flight, which is why this sits BELOW `streamingText` and the
+  // provider's own turn check rather than above them.
   //
-  // Claude's row DOES reopen: the worker revives it when the parent messages a
-  // finished subagent, so `work` is 'active' again by the time that run starts
-  // and the check above already returned true. This branch is the answer for a
-  // subagent that is genuinely over.
+  // The worker reopens the row for both providers now -- Claude when a parent
+  // messages a finished subagent, Codex when a later collab call re-registers a
+  // child that runs again -- so `work` returns to 'active' and the check at the
+  // top of this function answers first. But not INSTANTLY: the revive is a
+  // worker-side write that reaches the client asynchronously, so a restarted run
+  // can be streaming while `work` still reads 'finished'. The live checks above
+  // cover that window; putting this branch ahead of them left that run with no
+  // thinking indicator and, because the same predicate controls Interrupt, no
+  // way to cancel it.
+  //
+  // So this branch is the answer for a subagent that is genuinely over.
   if (work === 'finished')
     return false
   return isAgentWorking(msgs)

--- a/frontend/tests/e2e/174-goose-subagent-registry.spec.ts
+++ b/frontend/tests/e2e/174-goose-subagent-registry.spec.ts
@@ -70,6 +70,14 @@ gooseTest.describe('Goose subagent registry', () => {
       // box, so a read-only subagent tab said the same sentence twice, a few
       // pixels apart.
       await expect(page.getByText(noMessages, { exact: true })).toHaveCount(0)
+
+      // Quote routing out of a read-only transcript is NOT asserted here. Goose's
+      // child transcript carries only `subagent_tool_request` rows, and the ACP
+      // plugin returns no quotable text for that category, so no row in it ever
+      // renders a Quote action -- every locator for one matches zero elements.
+      // The guarded version of this check reported green while asserting
+      // nothing. The routing is covered where it has a real seam, in
+      // `editorRef.store.test.ts` and `tab.helpers.test.ts`.
     }
 
     await expectRowBecomesFinal(page, r)

--- a/frontend/tests/e2e/178-subagent-spawn-has-no-span.spec.ts
+++ b/frontend/tests/e2e/178-subagent-spawn-has-no-span.spec.ts
@@ -25,8 +25,24 @@ import { expect, test } from './fixtures'
 import { requireRegistryRow } from './helpers/subagentRegistry'
 import { ASSISTANT_BUBBLE_SELECTOR, sendMessage, waitForAgentIdle } from './helpers/ui'
 
-/** The Claude Agent tool's result header: "Agent <id> completed". */
-const AGENT_RESULT_HEADER = /Agent \S+ (completed|failed|launched asynchronously)/
+/**
+ * The Claude Agent tool's result header.
+ *
+ * The middle part is the TASK title when the payload carries one -- a launch
+ * does, quoted and with spaces in it -- and the agent id when it does not, which
+ * is the case for a finished synchronous run. The alternation covers both while
+ * keeping each side anchored.
+ *
+ * NOT `.+?`, which this pattern used and which fails in both directions: `.`
+ * matches a space, so it crosses out of the header into ordinary assistant prose
+ * ("I'll launch the Agent tool and report once it has completed"), and that row
+ * sits EARLIER in the DOM, so `.first()` picks a plain text row whose
+ * data-span-columns is trivially 0 -- the assertion below then passes however
+ * the spawn card renders. `.` also does not match a newline, so a model-written
+ * title with a line break made the locator find nothing. `[^']*` inside the
+ * quotes spans a newline; `\S+` keeps the bare-id form from crossing a space.
+ */
+const AGENT_RESULT_HEADER = /Agent (?:'[^']*'|\S+) (?:completed|failed|launched asynchronously|launched remotely)/
 /** The Agent tool's own card title, which carries the subagent type. */
 const AGENT_TYPE = 'general-purpose'
 

--- a/frontend/tests/e2e/178-subagent-spawn-has-no-span.spec.ts
+++ b/frontend/tests/e2e/178-subagent-spawn-has-no-span.spec.ts
@@ -35,14 +35,22 @@ import { ASSISTANT_BUBBLE_SELECTOR, sendMessage, waitForAgentIdle } from './help
  *
  * NOT `.+?`, which this pattern used and which fails in both directions: `.`
  * matches a space, so it crosses out of the header into ordinary assistant prose
- * ("I'll launch the Agent tool and report once it has completed"), and that row
+ * ("I'll launch the Agent tool and report once it completed"), and that row
  * sits EARLIER in the DOM, so `.first()` picks a plain text row whose
  * data-span-columns is trivially 0 -- the assertion below then passes however
  * the spawn card renders. `.` also does not match a newline, so a model-written
- * title with a line break made the locator find nothing. `[^']*` inside the
- * quotes spans a newline; `\S+` keeps the bare-id form from crossing a space.
+ * title with a line break made the locator find nothing.
+ *
+ * Inside the quotes: `[\s\S]*?`, LAZY, and not `[^']*`. The title is model prose,
+ * so an apostrophe in it is ordinary ("the parser's callers") -- and `[^']*`
+ * stops dead at that apostrophe, then demands a status where the next letter
+ * sits, so the whole locator matched nothing and the assertion failed red
+ * against a card that rendered correctly. `[\s\S]` spans a newline, and the lazy
+ * quantifier stops at the FIRST quote that a status follows rather than running
+ * to the last quote on the page. `\S+` keeps the bare-id form from crossing a
+ * space.
  */
-const AGENT_RESULT_HEADER = /Agent (?:'[^']*'|\S+) (?:completed|failed|launched asynchronously|launched remotely)/
+const AGENT_RESULT_HEADER = /Agent (?:'[\s\S]*?'|\S+) (?:completed|failed|launched asynchronously|launched remotely)/
 /** The Agent tool's own card title, which carries the subagent type. */
 const AGENT_TYPE = 'general-purpose'
 


### PR DESCRIPTION
## Motivation

The Claude Code CLI restarts a FINISHED subagent when the main agent messages
it again with the `SendMessage` tool. It also restarts one silently when a
backgrounded shell that subagent launched finishes. LeapMux's background-task
registry treated a FINISHED row as final: no path reopened it, so a restarted
subagent's output had nowhere to attach, the sidebar row and the tab chip read
"finished" for the whole second run, and that run ended with no closing
divider. The transcript looked dead while work continued below it.

The registry cache also holds only the newest 64 rows per kind. A row that fell
off that list still had to receive status updates, closes, and revives, because
its `child_agent_id` is the only index from a subagent back to `(owner,
row_key)`.
A mutation on an evicted row was a silent no-op, which left rows
stuck Running with an unended transcript -- and let Codex create a SECOND
transcript for a child that re-registered, then re-point the durable row at the
orphan.

On the frontend, a subagent whose provider cannot steer a subagent conversation
has a read-only composer. A quote, a reply, or a mention could target it and
vanish with no error and no fallback.

## Modifications

- **Revive path (Claude).** Two independent proofs that the CLI restarted a
  subagent -- a matched in-flight `SendMessage` tool-use id, or a wake block that
  identifies a shell this process finished -- are carried in one
  `claudeRestartEvidence` value, so every decision that asks "is this a
  re-registration" reads one answer. Neither is inferred from `task_started`
  against a finished row alone: a resumed session's hydration burst re-announces
  every past task as finished and must not trigger a revive. A confirmed revive
  reopens the row, clears `ended_at`/`active_form`/`description`, and appends the
  delivered text to the existing child transcript through a new
  `PersistChildUserMessage` sink method.
- **Revive path (Codex).** `upsertCollabChildRow` pairs the proof with the write
  at all three sites that report a collab child active, so a fourth cannot forget
  it. The in-memory child index is the proof, so a replayed snapshot cannot
  resurrect a row on its own.
- **Retention past the display cap.** `registryRetention[T]` keeps a row that
  carries a child transcript in the store after the 64-row cap evicts it from the
  cache. Every mutation resolves through `findRowLocked` (found anywhere) rather
  than `indexOf` (displayed only), and `admitRowLocked` puts a retained row back
  -- with a fresh `seq`, so the display order and the cold-start seed agree --
  only once the mutation commits to a write.
- **New sqlc queries**: `ReviveAgentBackgroundTask`,
  `ResequenceAgentBackgroundTask`, `GetAgentBackgroundTaskByRowKey`, and
  `ReleaseSubagentTranscriptClose`. The last gives back the closing-divider claim
  the first completion took, so the restarted run ends with a divider of its own
  instead of none. A transcript now holds one divider per RUN, not one for its
  whole life.
- **`OutputSink` gained three required methods** (internal to the worker):
  `LookupBackgroundTask`, `ReviveBackgroundTask`, `PersistChildUserMessage`.
  Every implementer must add them.
- **Read-only composers refuse writes by construction.** `EditorRef` gained a
  `writable()` thunk and the registry stores a `guarded()` handle, so refusing is
  what the registry does rather than what each caller remembers. One
  `insertIntoAgentEditor` router reports `inserted | queued | refused`, replacing
  a boolean that conflated "not mounted" with "refuses input" -- the conflation
  parked text in an editor nothing would ever flush. A queued insert whose
  destination turns out to be read-only is re-routed to the nearest agent that
  accepts messages, and reported.
- **New tool cards.** `SendMessage` leads with the recipient, linked to that
  subagent's tab and resolved against the ROOT registry so a sibling or the
  parent resolves. `ListAgents` renders the CLI's listing as markdown. The
  `Agent` result card is reworked around one extractor that normalizes the CLI's
  sync, async-launch, and remote-launch shapes. `AgentResultView`'s props changed
  from `{agentId, status, content}` to `{source}` (internal).
- **Deleted**: `KnownToolInput`, `KNOWN_TOOLS`, `isKnownTool`, and ten wire-shape
  interfaces that nothing read.

About 2,600 of the added lines are tests, including the first coverage of the
real `PersistChildUserMessage` and of the Codex `subAgentActivity` reopen.

## Result

- A subagent the CLI restarts shows as Running again, keeps writing to its
  existing transcript, and gets its own closing divider when it finishes the
  second time -- instead of reading "finished" while it works.
- A row stays reachable for status updates, close, and revive after 64 newer rows
  push it off the visible list. That closes the stuck-Running rows, the
  transcripts that simply stop, and the duplicate transcript Codex could create
  on re-registration.
- A quote or mention aimed at a read-only subagent composer no longer disappears.
  It goes to the nearest agent that accepts messages, with a notification.
- `Agent`, `SendMessage`, and `ListAgents` calls render as dedicated cards, with
  expand and copy acting on the text the card actually shows.
