### PR TITLE
fix(shortcuts): Let Escape dismiss one layer, innermost first

### DIFF
--- a/frontend/src/components/common/Dialog.test.tsx
+++ b/frontend/src/components/common/Dialog.test.tsx
@@ -2,6 +2,7 @@
 import { render, waitFor } from '@solidjs/testing-library'
 import { createSignal, Show } from 'solid-js'
 import { describe, expect, it, vi } from 'vitest'
+import { motion } from '~/styles/tokens'
 import { Dialog, DialogColumns } from './Dialog'
 import * as styles from './Dialog.css'
 
@@ -70,7 +71,7 @@ describe('dialog', () => {
     expect(onClose).not.toHaveBeenCalled()
   })
 
-  it('closes on Escape when not busy', async () => {
+  it('closes on the close request Escape makes, when not busy', async () => {
     const onClose = vi.fn()
     const { container } = render(() => (
       <Dialog title="Test" onClose={onClose}>
@@ -79,10 +80,35 @@ describe('dialog', () => {
     ))
 
     const dialog = container.querySelector('dialog')!
-    dialog.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    const cancel = new Event('cancel', { bubbles: false, cancelable: true })
+    dialog.dispatchEvent(cancel)
+    // The native close skips the exit animation and ignores `busy`, so the
+    // component takes the request over instead of letting it run.
+    expect(cancel.defaultPrevented).toBe(true)
     // User-initiated close paths run an exit animation before calling
     // `onClose` (see `Dialog.tsx`'s `beginClose`); poll until it fires.
     await waitFor(() => expect(onClose).toHaveBeenCalled())
+  })
+
+  it('acts on no Escape of its own, so an inner layer can consume it', async () => {
+    const onClose = vi.fn()
+    const { container } = render(() => (
+      <Dialog title="Test" onClose={onClose}>
+        <p>Content</p>
+      </Dialog>
+    ))
+
+    const dialog = container.querySelector('dialog')!
+    const escape = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true })
+    dialog.dispatchEvent(escape)
+
+    // The browser turns an unconsumed Escape into a close request aimed at the
+    // TOPMOST layer, which is the open menu and not this dialog. A keydown
+    // handler here would close the dialog under that menu, so there is none.
+    expect(escape.defaultPrevented).toBe(false)
+    await new Promise(resolve => setTimeout(resolve, motion.fast * 3))
+    expect(onClose).not.toHaveBeenCalled()
+    expect(dialog.hasAttribute('open')).toBe(true)
   })
 
   it('closes on backdrop click when not busy', async () => {
@@ -248,7 +274,7 @@ describe('dialog', () => {
     expect(onSubmit).not.toHaveBeenCalled()
   })
 
-  it('does not close on Escape when busy', () => {
+  it('does not close on a close request when busy', () => {
     const onClose = vi.fn()
     const { container } = render(() => (
       <Dialog title="Test" busy onClose={onClose}>
@@ -257,7 +283,11 @@ describe('dialog', () => {
     ))
 
     const dialog = container.querySelector('dialog')!
-    dialog.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    const cancel = new Event('cancel', { bubbles: false, cancelable: true })
+    dialog.dispatchEvent(cancel)
+    // Prevented even while busy: an unprevented request closes the element
+    // itself, which would leave a mounted dialog the user cannot see.
+    expect(cancel.defaultPrevented).toBe(true)
     expect(dialog.hasAttribute('open')).toBe(true)
     expect(onClose).not.toHaveBeenCalled()
   })

--- a/frontend/src/components/common/Dialog.tsx
+++ b/frontend/src/components/common/Dialog.tsx
@@ -65,12 +65,28 @@ export const Dialog: Component<DialogProps> = (props) => {
     }, motion.fast)
   }
 
+  // The platform's close request -- Escape, and the Android back gesture --
+  // arrives as `cancel`, and it arrives ONLY when this dialog is the innermost
+  // open layer. The browser sends a close request to the topmost element of
+  // the top layer, so an open popover (a `DropdownMenu` inside this dialog)
+  // takes it first, and a handler that already consumed the key (see
+  // `PreferencesSearch`, which clears the query instead) cancels the request
+  // before the browser makes it.
+  //
+  // That layering is why nothing here binds Escape itself. An app-level Escape
+  // handler runs on the propagation path, which knows the DOM tree but not the
+  // top layer, so it closes this dialog while a menu above it is still open.
+  //
+  // Prevent the native close and take our own path instead. The native one
+  // skips the exit animation, and it closes the element behind this
+  // component's back: a `busy` dialog would go invisible while the parent
+  // `<Show>` still held it mounted. `beginClose` refuses both.
+  const handleCancel = (e: Event) => {
+    e.preventDefault()
+    beginClose()
+  }
+
   const handleKeyDown = (e: KeyboardEvent) => {
-    if (e.key === 'Escape') {
-      e.preventDefault()
-      beginClose()
-      return
-    }
     if (
       e.key === 'Enter'
       && !e.defaultPrevented
@@ -97,12 +113,14 @@ export const Dialog: Component<DialogProps> = (props) => {
     // focus ring / auto-scrolling to reveal a form field below the fold.
     bodyRef.focus()
     dialogRef.addEventListener('keydown', handleKeyDown)
+    dialogRef.addEventListener('cancel', handleCancel)
   })
   onCleanup(() => {
     unmounting = true
     if (closeTimer)
       clearTimeout(closeTimer)
     dialogRef.removeEventListener('keydown', handleKeyDown)
+    dialogRef.removeEventListener('cancel', handleCancel)
     if (dialogRef.open) {
       dialogRef.close()
     }

--- a/frontend/src/components/settings/controls/StringListControl.test.tsx
+++ b/frontend/src/components/settings/controls/StringListControl.test.tsx
@@ -119,7 +119,7 @@ describe('stringListControl', () => {
     expect(screen.getByText(`Too many entries (max ${MAX_STRING_LIST_ITEMS})`)).toBeTruthy()
   })
 
-  it('escape during rename does not commit', () => {
+  it('escape during rename does not commit, and does not reach the dialog', () => {
     const onChange = vi.fn()
     render(() => (
       <StringListControl value={['Inter']} addLabel="Add font" ariaLabel="Fonts" onChange={onChange} />
@@ -127,9 +127,13 @@ describe('stringListControl', () => {
     fireEvent.dblClick(screen.getByText('Inter'))
     const editor = screen.getByLabelText('Rename Fonts') as HTMLInputElement
     fireEvent.input(editor, { target: { value: 'Hack' } })
-    fireEvent.keyDown(editor, { key: 'Escape' })
+    const escape = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true })
+    editor.dispatchEvent(escape)
     expect(onChange).not.toHaveBeenCalled()
     expect(screen.getByText('Inter')).toBeTruthy()
+    // An Escape left unconsumed becomes a close request, and the request
+    // closes the Preferences dialog around the edit the user meant to cancel.
+    expect(escape.defaultPrevented).toBe(true)
   })
 })
 

--- a/frontend/src/components/settings/controls/StringListControl.tsx
+++ b/frontend/src/components/settings/controls/StringListControl.tsx
@@ -266,6 +266,11 @@ export const StringListControl: Component<StringListControlProps> = (props) => {
                           commitEdit(i())
                         }
                         else if (e.key === 'Escape') {
+                          // Consume it, the way `PreferencesSearch` does. An
+                          // Escape left unhandled becomes a close request, and
+                          // that request closes the Preferences dialog around
+                          // the edit the user meant to cancel.
+                          e.preventDefault()
                           cancelEdit()
                         }
                       }}

--- a/frontend/src/hooks/useShortcuts.test.tsx
+++ b/frontend/src/hooks/useShortcuts.test.tsx
@@ -1,6 +1,5 @@
 import { cleanup, render } from '@solidjs/testing-library'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { Dialog } from '~/components/common/Dialog'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
 import { executeCommand, getCommand, resetCommands } from '~/lib/shortcuts/commands'
 import { evaluateWhen } from '~/lib/shortcuts/context'
@@ -45,27 +44,6 @@ vi.mock('~/lib/fileTreeOps', () => ({
   toggleHiddenFiles: () => toggleHiddenFiles(),
 }))
 
-let originalShowModal: typeof HTMLDialogElement.prototype.showModal | undefined
-let originalClose: typeof HTMLDialogElement.prototype.close
-
-beforeAll(() => {
-  if (!HTMLDialogElement.prototype.showModal) {
-    originalShowModal = undefined
-    HTMLDialogElement.prototype.showModal = vi.fn(function (this: HTMLDialogElement) {
-      this.setAttribute('open', '')
-    })
-  }
-  else {
-    originalShowModal = HTMLDialogElement.prototype.showModal
-  }
-
-  originalClose = HTMLDialogElement.prototype.close
-  HTMLDialogElement.prototype.close = function () {
-    this.removeAttribute('open')
-    this.dispatchEvent(new Event('close'))
-  }
-})
-
 afterEach(() => {
   cleanup()
   resetCommands()
@@ -74,13 +52,6 @@ afterEach(() => {
   openInEditorMock.mockReset()
   runtimeStateMock.mockReset()
   loadDetectedEditorsMock.mockReset()
-})
-
-afterAll(() => {
-  if (originalShowModal) {
-    HTMLDialogElement.prototype.showModal = originalShowModal
-  }
-  HTMLDialogElement.prototype.close = originalClose
 })
 
 function makeProps() {
@@ -193,42 +164,6 @@ describe('useShortcuts', () => {
     executeCommand('app.closeActiveTab')
 
     expect(props.tabOps.handleTabClose).toHaveBeenCalledWith(tab)
-  })
-
-  it('closes the topmost open dialog without redispatching Escape', () => {
-    const props = makeProps()
-    const onClose = vi.fn()
-
-    render(() => {
-      useShortcuts(props as any)
-      return <Dialog title="Test" onClose={onClose}><p>Content</p></Dialog>
-    })
-
-    const dialog = document.querySelector('dialog') as HTMLDialogElement
-    const dispatchSpy = vi.spyOn(dialog, 'dispatchEvent')
-
-    executeCommand('dialog.close')
-
-    expect(dialog.hasAttribute('open')).toBe(false)
-    expect(onClose).toHaveBeenCalledOnce()
-    expect(dispatchSpy).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'keydown' }))
-  })
-
-  it('does not close a busy dialog from the global dialog.close command', () => {
-    const props = makeProps()
-    const onClose = vi.fn()
-
-    render(() => {
-      useShortcuts(props as any)
-      return <Dialog title="Test" busy onClose={onClose}><p>Content</p></Dialog>
-    })
-
-    const dialog = document.querySelector('dialog') as HTMLDialogElement
-
-    executeCommand('dialog.close')
-
-    expect(dialog.hasAttribute('open')).toBe(true)
-    expect(onClose).not.toHaveBeenCalled()
   })
 
   describe('without an active workspace', () => {

--- a/frontend/src/hooks/useShortcuts.ts
+++ b/frontend/src/hooks/useShortcuts.ts
@@ -163,12 +163,6 @@ export function useShortcuts(props: UseShortcutsProps): void {
   cmd('app.openPreferences', 'Open Preferences', () => {
     openPreferences('appearance')
   }, 'App')
-  cmd('dialog.close', 'Close Dialog', () => {
-    const dialogs = [...document.querySelectorAll('dialog[open]')]
-    const last = dialogs.at(-1) as HTMLDialogElement | undefined
-    if (last && !last.hasAttribute('data-busy'))
-      last.close()
-  }, 'App')
 
   cmd('app.openInExternalEditor', 'Open in External Editor', async () => {
     const dir = getCurrentTabContext().workingDir

--- a/frontend/src/lib/shortcuts/defaults.test.ts
+++ b/frontend/src/lib/shortcuts/defaults.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { CORE_KEYBINDINGS, WORKSPACE_KEYBINDINGS } from './defaults'
+
+const ALL_DEFAULTS = [...CORE_KEYBINDINGS, ...WORKSPACE_KEYBINDINGS]
+
+describe('default keybindings', () => {
+  it('leaves Escape unbound, so the innermost layer keeps it', () => {
+    // The user's half of this rule is enforced, not tested: `RESERVED_KEYS` in
+    // ~/lib/shortcuts/keybindings.ts drops an override that claims Escape.
+    // These defaults pass through no such filter, so the rule needs a case.
+    //
+    // `activateBindings` dispatches from a capture-phase listener on `window`,
+    // which runs before every handler on the propagation path. An Escape
+    // binding therefore preempts each layer that dismisses itself on Escape --
+    // an open `DropdownMenu`, the Preferences search box, an inline rename --
+    // and one press dismissed the layer AND the dialog under it. The platform
+    // aims a close request at the topmost layer instead; `Dialog` acts on the
+    // request it receives.
+    const escapeBindings = ALL_DEFAULTS.filter(b => b.key === 'Escape')
+    expect(escapeBindings).toEqual([])
+  })
+
+  it('binds no key twice in the same when-context', () => {
+    const seen = new Map<string, string>()
+    for (const b of ALL_DEFAULTS) {
+      const slot = JSON.stringify([b.key, b.when ?? ''])
+      const holder = seen.get(slot)
+      expect(holder, `${b.key} is bound to both ${holder} and ${b.command}`).toBeUndefined()
+      seen.set(slot, b.command)
+    }
+  })
+})

--- a/frontend/src/lib/shortcuts/defaults.ts
+++ b/frontend/src/lib/shortcuts/defaults.ts
@@ -67,8 +67,14 @@ export const WORKSPACE_KEYBINDINGS: readonly Keybinding[] = [
   // Preferences
   { key: '$mod+Comma', command: 'app.openPreferences' },
 
-  // Dialog close
-  { key: 'Escape', command: 'dialog.close', when: 'dialogOpen' },
+  // Escape is reserved and no binding may claim it -- see `RESERVED_KEYS` in
+  // ~/lib/shortcuts/keybindings.ts, which drops a user override for it too.
+  // Every binding here dispatches from a capture-phase listener on `window`,
+  // which is the first handler on the path, so an Escape binding preempts each
+  // inner layer that closes on Escape by itself: an open `DropdownMenu`, the
+  // Preferences search box, an inline rename. One press then dismissed two
+  // layers at once. The platform routes a close request to the innermost open
+  // layer instead, and `Dialog` acts on the request it receives.
 
   // Terminal cursor navigation (macOS)
   { key: '$mod+ArrowLeft', command: 'terminal.lineStart', when: 'terminalFocused && platform == "mac"' },

--- a/frontend/src/lib/shortcuts/keybindings.test.ts
+++ b/frontend/src/lib/shortcuts/keybindings.test.ts
@@ -13,7 +13,7 @@ const DEFAULTS: Keybinding[] = [
   { key: '$mod+n', command: 'app.newAgent', when: '!dialogOpen' },
   { key: '$mod+t', command: 'app.newTerminal', when: '!dialogOpen' },
   { key: '$mod+w', command: 'app.closeActiveTab' },
-  { key: 'Escape', command: 'dialog.close', when: 'dialogOpen' },
+  { key: '$mod+Shift+e', command: 'app.openInExternalEditor', when: 'isDesktop' },
   { key: '$mod+Shift+BracketLeft', command: 'app.toggleLeftSidebar' },
 ]
 
@@ -131,6 +131,43 @@ describe('mergeKeybindings', () => {
     mergeKeybindings(DEFAULTS, [{ key: '$mod+Shift+a', command: 'app.newAgent' }])
     expect(DEFAULTS).toEqual(original)
   })
+
+  it('drops an override that binds the reserved Escape key', () => {
+    const overrides: UserKeybindingOverride[] = [
+      { key: 'Escape', command: 'app.newAgent' },
+    ]
+    const result = mergeKeybindings(DEFAULTS, overrides)
+    expect(result.some(b => b.key === 'Escape')).toBe(false)
+    // The command keeps its default rather than losing its binding, so one
+    // bad line in the hand-edited JSON costs the user that line alone.
+    expect(result.find(b => b.command === 'app.newAgent')?.key).toBe('$mod+n')
+  })
+
+  it('keeps the other overrides for a command whose Escape entry is dropped', () => {
+    const overrides: UserKeybindingOverride[] = [
+      { key: 'Escape', command: 'app.newAgent' },
+      { key: '$mod+Shift+a', command: 'app.newAgent' },
+    ]
+    const result = mergeKeybindings(DEFAULTS, overrides)
+    const newAgent = result.filter(b => b.command === 'app.newAgent')
+    expect(newAgent.map(b => b.key)).toEqual(['$mod+Shift+a'])
+  })
+
+  it('reserves the bare key only, so a chord that contains Escape survives', () => {
+    // Shift+Escape makes no close request, so it displaces no layer.
+    const overrides: UserKeybindingOverride[] = [
+      { key: 'Shift+Escape', command: 'app.newAgent' },
+    ]
+    const result = mergeKeybindings(DEFAULTS, overrides)
+    expect(result.find(b => b.command === 'app.newAgent')?.key).toBe('Shift+Escape')
+  })
+
+  it('still unbinds a command through an empty-key override', () => {
+    // The empty key is not reserved: the reserved-key skip must not swallow
+    // the one override shape that means "remove this binding".
+    const result = mergeKeybindings(DEFAULTS, [{ key: '', command: 'app.newAgent' }])
+    expect(result.some(b => b.command === 'app.newAgent')).toBe(false)
+  })
 })
 
 describe('groupBindings', () => {
@@ -152,28 +189,28 @@ describe('groupBindings', () => {
 describe('resolve', () => {
   it('returns first matching command', () => {
     const bindings: Keybinding[] = [
-      { key: 'Escape', command: 'dialog.close', when: 'dialogOpen' },
-      { key: 'Escape', command: 'app.blur' },
+      { key: '$mod+w', command: 'app.closeActiveTab', when: 'dialogOpen' },
+      { key: '$mod+w', command: 'app.blur' },
     ]
     setContext('dialogOpen', true)
-    expect(resolve(bindings, 'Escape')).toBe('dialog.close')
+    expect(resolve(bindings, '$mod+w')).toBe('app.closeActiveTab')
   })
 
   it('skips bindings with failing when clause', () => {
     const bindings: Keybinding[] = [
-      { key: 'Escape', command: 'dialog.close', when: 'dialogOpen' },
-      { key: 'Escape', command: 'app.blur' },
+      { key: '$mod+w', command: 'app.closeActiveTab', when: 'dialogOpen' },
+      { key: '$mod+w', command: 'app.blur' },
     ]
     setContext('dialogOpen', false)
-    expect(resolve(bindings, 'Escape')).toBe('app.blur')
+    expect(resolve(bindings, '$mod+w')).toBe('app.blur')
   })
 
   it('returns null when no binding matches', () => {
     const bindings: Keybinding[] = [
-      { key: 'Escape', command: 'dialog.close', when: 'dialogOpen' },
+      { key: '$mod+w', command: 'app.closeActiveTab', when: 'dialogOpen' },
     ]
     setContext('dialogOpen', false)
-    expect(resolve(bindings, 'Escape')).toBeNull()
+    expect(resolve(bindings, '$mod+w')).toBeNull()
   })
 
   it('returns command when no when clause is set', () => {
@@ -201,10 +238,14 @@ describe('resolve', () => {
 
   it('still suppresses other plain special keys when input is focused', () => {
     const bindings: Keybinding[] = [
-      { key: 'Escape', command: 'app.example' },
+      { key: 'Home', command: 'app.example' },
     ]
     setContext('inputFocused', true)
-    expect(resolve(bindings, 'Escape')).toBeNull()
+    expect(resolve(bindings, 'Home')).toBeNull()
+    // The same binding fires once the caret leaves the input, so the null
+    // above is the suppression and not an absent binding.
+    setContext('inputFocused', false)
+    expect(resolve(bindings, 'Home')).toBe('app.example')
   })
 })
 

--- a/frontend/src/lib/shortcuts/keybindings.ts
+++ b/frontend/src/lib/shortcuts/keybindings.ts
@@ -8,6 +8,26 @@ import { evaluateWhen, getContext, whenReferencesKey } from './context'
 const log = createLogger('shortcuts')
 
 /**
+ * Keys that no binding may claim, whatever a user writes by hand in
+ * `custom_keybindings_json`.
+ *
+ * `activateBindings` dispatches from a capture-phase listener on `window`,
+ * which is the first handler on the whole propagation path. A binding for
+ * Escape therefore preempts every layer that dismisses itself on Escape -- an
+ * open `DropdownMenu`, the Preferences search box, an inline rename -- so one
+ * press dismisses two layers at once. The browser already aims a close request
+ * at the innermost open layer, and `Dialog` acts on the request it receives.
+ *
+ * A chord that merely CONTAINS Escape (`Shift+Escape`) is not reserved: the
+ * browser makes no close request for it, so it displaces no layer.
+ *
+ * The settings editor cannot produce one of these either -- `captureKeydown`
+ * in `KeybindingsControl` reads Escape as "stop capturing". This guard covers
+ * the hand-edited JSON, which reaches the merge without passing that editor.
+ */
+const RESERVED_KEYS: ReadonlySet<string> = new Set(['Escape'])
+
+/**
  * Merge default keybindings with user overrides.
  *
  * Multiple overrides for the same command are supported — each non-empty-key
@@ -20,6 +40,10 @@ const log = createLogger('shortcuts')
  * - If all overrides have empty keys, the command is fully unbound
  *
  * Overrides for commands not in defaults are appended as new bindings.
+ *
+ * An override for a reserved key is dropped, and the command keeps whatever
+ * the defaults give it. Dropping the one entry beats unbinding the command:
+ * a single bad line in the JSON costs the user that line, not the shortcut.
  */
 export function mergeKeybindings(
   defaults: readonly Keybinding[],
@@ -27,6 +51,10 @@ export function mergeKeybindings(
 ): Keybinding[] {
   const overrideMap = new Map<string, UserKeybindingOverride[]>()
   for (const o of overrides) {
+    if (RESERVED_KEYS.has(o.key)) {
+      log.warn('Ignoring an override that binds a reserved key', { key: o.key, command: o.command })
+      continue
+    }
     let list = overrideMap.get(o.command)
     if (!list) {
       list = []

--- a/frontend/tests/e2e/081-preferences-navigation.spec.ts
+++ b/frontend/tests/e2e/081-preferences-navigation.spec.ts
@@ -1,3 +1,4 @@
+import { motion } from '../../src/styles/tokens'
 import { expect, test } from './fixtures'
 import { loginViaToken, openPreferencesDialog } from './helpers/ui'
 
@@ -78,5 +79,32 @@ test.describe('Preferences navigation', () => {
     await dialog.getByText('Notifications \u203A Turn-end volume').click()
     await expect(dialog.getByTestId('preferences-nav-notifications')).toBeVisible()
     await expect(dialog.getByText('Turn-end volume')).toBeVisible()
+  })
+
+  // Escape dismisses ONE layer, innermost first. The search box is the inner
+  // one while it holds a query, and `PreferencesSearch` says so in code -- it
+  // consumes the key and lets only an EMPTY query through to the dialog. A
+  // global Escape binding used to run first and close the dialog either way,
+  // so the search box never got the press it claimed.
+  test('clears the search on Escape, and closes the dialog only once the query is empty', async ({ page, leapmuxServer }) => {
+    await loginViaToken(page, leapmuxServer.adminToken)
+    await page.goto('/')
+    await openPreferencesDialog(page, 'appearance')
+    const dialog = page.getByRole('dialog', { name: 'Preferences' })
+
+    const search = dialog.getByTestId('preferences-search')
+    await search.fill('volume')
+    await expect(dialog.getByTestId('preferences-search-results')).toBeVisible()
+
+    await search.press('Escape')
+    await expect(search).toHaveValue('')
+    // Outlast `Dialog`'s exit animation before reading the dialog: it defers
+    // the unmount, so a check here also passes on a dialog that IS closing.
+    await page.waitForTimeout(motion.fast * 3)
+    await expect(dialog, 'Escape closed the dialog instead of clearing the search').toBeVisible()
+
+    // An empty query holds nothing back, so the same key now reaches the dialog.
+    await search.press('Escape')
+    await expect(dialog).toBeHidden()
   })
 })

--- a/frontend/tests/e2e/084-theme-picker.spec.ts
+++ b/frontend/tests/e2e/084-theme-picker.spec.ts
@@ -1,5 +1,6 @@
 import type { Page } from '@playwright/test'
 import { CODE_BLOCK_TINT_PERCENT } from '../../src/styles/codePalette'
+import { motion } from '../../src/styles/tokens'
 import { colorAlpha } from '../../src/test-support/color'
 import { expect, test } from './fixtures'
 import { getBrowserPrefValue, loginViaToken, openPreferencesDialog, pickTheme, resolvedColor } from './helpers/ui'
@@ -441,6 +442,37 @@ test.describe('Theme picker', () => {
     })
     expect(item?.role, 'ArrowDown did not land on a menu item').toMatch(/^menuitem/)
     expect(item?.outline, 'the focused menu item draws no ring').not.toBe('none')
+  })
+
+  // One Escape dismisses ONE layer, innermost first -- the WAI-ARIA menu
+  // pattern. The menu is the layer above the dialog, so the first press takes
+  // the menu and leaves the dialog; only the second press takes the dialog.
+  //
+  // Chromium is required. happy-dom has no `showModal`, no top layer and no
+  // native popover light-dismiss, so a unit test passes on the broken app.
+  test('dismisses the menu on the first Escape and the dialog on the second', async ({ page, leapmuxServer }) => {
+    const { trigger, menu } = await openThemeMenu(page, leapmuxServer.adminToken)
+    const dialog = page.getByRole('dialog', { name: 'Preferences' })
+    await trigger.click()
+    await expect(menu).toBeVisible()
+
+    await page.keyboard.press('Escape')
+    await expect(menu).toBeHidden()
+
+    // `Dialog` defers its unmount by `motion.fast` ms so the fade-out can play,
+    // so a bare visibility check here also passes on a dialog that IS closing.
+    // Outlast that window before reading the dialog.
+    await page.waitForTimeout(motion.fast * 3)
+    await expect(dialog, 'the first Escape took the dialog as well as the menu').toBeVisible()
+
+    // The dialog is still live, not merely still painted.
+    await trigger.click()
+    await expect(menu).toBeVisible()
+    await page.keyboard.press('Escape')
+    await expect(menu).toBeHidden()
+
+    await page.keyboard.press('Escape')
+    await expect(dialog, 'the second Escape left the dialog open').toBeHidden()
   })
 
   test('turns the code block opaque when the syntax theme opposes the app', async ({ page, leapmuxServer }) => {

--- a/site/content/docs/using/keyboard-shortcuts.md
+++ b/site/content/docs/using/keyboard-shortcuts.md
@@ -26,7 +26,7 @@ Key strings use the `tinykeys` vocabulary. The most important token is `$mod`:
 
 So a single binding such as `$mod+n` is shown as `⌘N` on a Mac and `Ctrl+N` everywhere else. The tables below give both forms.
 
-Other modifiers are `Shift`, `Alt` (also written `Option`), `Control`/`Ctrl`, and `Meta`. Named keys used in the defaults include `Escape`, `F5`, `F12`, the arrow keys, `PageUp`/`PageDown`, the bracket and backslash keys, and the digits `0`–`9`.
+Other modifiers are `Shift`, `Alt` (also written `Option`), `Control`/`Ctrl`, and `Meta`. Named keys used in the defaults include `F5`, `F12`, the arrow keys, `PageUp`/`PageDown`, the bracket and backslash keys, and the digits `0`–`9`.
 
 ### Chords
 
@@ -136,11 +136,11 @@ Under the hood these send terminal control sequences (Ctrl-A, Ctrl-E, Esc-b, Esc
 
 ### Dialogs
 
-| Command | macOS | Windows / Linux | Active when |
-|---|---|---|---|
-| Close Dialog | `Esc` | `Esc` | a dialog is open |
-
 `Esc` closes the most recently opened dialog — unless that dialog is busy (for example, mid-operation), in which case it resists closing until the operation finishes.
+
+`Esc` is not a keybinding, and no command performs this action. The browser delivers the key to the innermost open layer, so one press dismisses one layer: with a drop-down menu open inside a dialog, the first `Esc` closes the menu and the second closes the dialog. A control that answers `Esc` itself comes first in the same way — the Preferences search box clears the query, and an inline rename cancels the edit.
+
+`Esc` is **reserved**: an override that binds it is ignored, and the log records the entry that was dropped. Every keybinding fires from a single listener that runs ahead of the layers, so a binding for `Esc` would close a dialog underneath an open menu — which is the behaviour the reservation exists to prevent.
 
 ### New Workspace
 
@@ -234,6 +234,7 @@ For each overridden command, LeapMux merges the overrides with the defaults usin
 - A command may have **multiple overrides** — it gets bound to every non-empty key listed.
 - An override with `"key": ""` (empty) **unbinds** the command. If every override for a command has an empty key, the command is fully unbound.
 - An override for a command **not** in the defaults is appended as a brand-new binding (with no inherited `when`-clause).
+- An override whose key is `Escape` is **dropped**, and the command keeps whatever the defaults give it. `Esc` is reserved for the innermost open layer — see [Dialogs](#dialogs). A chord that merely contains it, such as `Shift+Escape`, binds normally.
 
 Changes take effect immediately: when the overrides change, LeapMux re-merges and re-binds the workspace shortcuts without a reload.
 
@@ -257,7 +258,6 @@ Each override targets a command by its id. Each id corresponds to one of the act
 | `app.toggleLeftSidebar` / `app.toggleRightSidebar` | Toggle Left / Right Sidebar |
 | `app.openPreferences` | Open Preferences |
 | `app.openInExternalEditor` | Open in External Editor |
-| `dialog.close` | Close Dialog |
 | `chat.sendMessage` | Send Message |
 | `terminal.lineStart` / `terminal.lineEnd` | Go to Line Start / End |
 | `terminal.wordLeft` / `terminal.wordRight` | Go to Previous / Next Word |


### PR DESCRIPTION
## Motivation

Opening the UI theme drop-down inside the Preferences dialog and pressing Escape closed the menu **and** the dialog on that single press. One Escape should dismiss one layer, innermost first — the WAI-ARIA menu pattern.

Every shortcut dispatches from a capture-phase listener on `window` (`tinykeys(window, keyMap, { capture: true })`), which is the first handler on the whole propagation path. `Escape` was bound there to `dialog.close`, which called `close()` on the last `dialog[open]`. That binding ran ahead of every inner layer, so nothing above the dialog ever saw the key, and the close was programmatic — no `cancel`, no exit animation.

The codebase already assumed the layered behaviour it never got. `PreferencesSearch` consumes Escape to clear the query and says so at the site: *"only an EMPTY query lets Escape through to the dialog's close handler."* Its `stopPropagation()` could never help, because the window-capture handler had already run and had already stopped propagation itself.

The browser implements this layering: it aims a close request at the topmost element of the top layer, and only when the keydown finished unprevented. Hand Escape back to it.

## Modifications

- **Reserve Escape.** No default binds it; `RESERVED_KEYS` in `keybindings.ts` drops a hand-written `custom_keybindings_json` override that claims it and logs the dropped entry; a new `defaults.test.ts` case fails the suite if a default returns. A chord that merely *contains* Escape (`Shift+Escape`) makes no close request, so it still binds normally.
- **(Breaking) Removes the `dialog.close` command**, and with it the "Close Dialog" row in the keybindings editor. An existing `custom_keybindings_json` override for that command no longer resolves. Escape is the gesture and the platform owns it; a command that reaches around the layer stack can only get the ordering wrong.
- **`Dialog` acts on `cancel`** rather than on Escape. The event arrives only when the dialog *is* the innermost open layer. Preventing the native close keeps the exit animation and honours `busy` — which also stops the platform closing a busy dialog behind the component's back and leaving it mounted but invisible.
- **`StringListControl`'s inline rename consumes Escape**, the way `PreferencesSearch` already documents.
- Adds E2E coverage in Chromium for both halves, because happy-dom has no `showModal`, no top layer and no native popover dismissal — a unit test passes there while the app is broken.
- Corrects a keybindings case that built an `Escape` binding and then resolved `$mod+w`: it passed on the absent binding, not on the input-focus suppression it claims to cover.

## Result

- In Preferences, the first Escape closes the open theme menu and leaves the dialog; the second closes the dialog.
- The settings search box clears its query on Escape and keeps the dialog open, as its own comment always promised. A second press then closes the dialog.
- Escape during an inline rename cancels the edit instead of discarding it and closing Preferences along with it.
- Escape plays the dialog's fade-out. The old path skipped it, so Escape was the one dismissal that snapped shut.
- A busy dialog can no longer be driven into a closed-but-mounted state that renders nothing.
- **Removed:** the `dialog.close` command. Press Escape, or bind a key to a different command.
