### PR TITLE
fix(solo): Tighten shutdown drain timing assertion

### DIFF
--- a/backend/solo/solo_test.go
+++ b/backend/solo/solo_test.go
@@ -1228,7 +1228,10 @@ func TestSoloStart_AWorkerBringUpFailureIsStillTheWorkers(t *testing.T) {
 // slow one as a worker that failed to drain.
 func TestInstanceShutdown_StopsTheHubOnTheDrainNotTheWorkersFullExit(t *testing.T) {
 	orig := workerDrainTimeout
-	workerDrainTimeout = 20 * time.Millisecond
+	// Generous against scheduler jitter; still far below a mistaken wait for the
+	// full backstop. 20ms was too tight once CaptureStderr and logging.Setup
+	// sat inside the same wall-clock budget on Windows CI.
+	workerDrainTimeout = 100 * time.Millisecond
 	t.Cleanup(func() { workerDrainTimeout = orig })
 
 	hubDone := make(chan struct{})
@@ -1257,16 +1260,20 @@ func TestInstanceShutdown_StopsTheHubOnTheDrainNotTheWorkersFullExit(t *testing.
 		<-releaseTeardown
 	}()
 
-	start := time.Now()
+	var elapsed time.Duration
 	// logging.Setup inside the capture, or the handler still points at the real
 	// stderr and the NotContains below holds no matter what shutdown logs.
+	// Time only shutdown: CaptureStderr's pipe setup and logging.Setup are not
+	// part of the drain-vs-backstop claim and blew a 20ms budget on Windows CI.
 	logs := testutil.CaptureStderr(t, func() {
 		logging.Setup()
+		start := time.Now()
 		inst.shutdown()
+		elapsed = time.Since(start)
 	})
 
 	assert.True(t, hubCancelled.Load())
-	assert.Less(t, time.Since(start), workerDrainTimeout,
+	assert.Less(t, elapsed, workerDrainTimeout,
 		"the hub must stop on the drain signal, not wait out the backstop for a teardown it has no stake in")
 	assert.NotContains(t, logs, "did not finish before the hub shutdown deadline",
 		"a worker that drained promptly must not be reported as failing to")

--- a/backend/solo/solo_test.go
+++ b/backend/solo/solo_test.go
@@ -1226,12 +1226,17 @@ func TestSoloStart_AWorkerBringUpFailureIsStillTheWorkers(t *testing.T) {
 // away, NOT when the Worker has finished its local teardown. Waiting on the
 // latter held the Hub up for a database close it has no stake in, and reported a
 // slow one as a worker that failed to drain.
+//
+// No wall-clock budget: shutdown returning while teardown is still held proves
+// it did not wait for the Worker's full exit, and the absent backstop warn
+// proves WaitBounded took the done path rather than timer.C. A Less(elapsed,
+// timeout) assertion duplicated that second claim and flaked on Windows CI
+// when CaptureStderr and logging.Setup shared the same stopwatch.
 func TestInstanceShutdown_StopsTheHubOnTheDrainNotTheWorkersFullExit(t *testing.T) {
 	orig := workerDrainTimeout
-	// Generous against scheduler jitter; still far below a mistaken wait for the
-	// full backstop. 20ms was too tight once CaptureStderr and logging.Setup
-	// sat inside the same wall-clock budget on Windows CI.
-	workerDrainTimeout = 100 * time.Millisecond
+	// Short only so a regression that waits out the backstop stays cheap; the
+	// assertions below do not measure against it.
+	workerDrainTimeout = 20 * time.Millisecond
 	t.Cleanup(func() { workerDrainTimeout = orig })
 
 	hubDone := make(chan struct{})
@@ -1260,21 +1265,17 @@ func TestInstanceShutdown_StopsTheHubOnTheDrainNotTheWorkersFullExit(t *testing.
 		<-releaseTeardown
 	}()
 
-	var elapsed time.Duration
 	// logging.Setup inside the capture, or the handler still points at the real
 	// stderr and the NotContains below holds no matter what shutdown logs.
-	// Time only shutdown: CaptureStderr's pipe setup and logging.Setup are not
-	// part of the drain-vs-backstop claim and blew a 20ms budget on Windows CI.
 	logs := testutil.CaptureStderr(t, func() {
 		logging.Setup()
-		start := time.Now()
 		inst.shutdown()
-		elapsed = time.Since(start)
 	})
 
-	assert.True(t, hubCancelled.Load())
-	assert.Less(t, elapsed, workerDrainTimeout,
-		"the hub must stop on the drain signal, not wait out the backstop for a teardown it has no stake in")
+	assert.True(t, hubCancelled.Load(),
+		"the hub must stop once the worker has drained")
 	assert.NotContains(t, logs, "did not finish before the hub shutdown deadline",
-		"a worker that drained promptly must not be reported as failing to")
+		"a worker that drained promptly must not be reported as failing to; "+
+			"WaitBounded only logs that line on timer.C, so its absence is the "+
+			"proof the hub stopped on the drain signal rather than the backstop")
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the Windows CI failure on `main` (`43922faa`, run [32546498972](https://github.com/leapmux/leapmux/actions/runs/32546498972)): `TestInstanceShutdown_StopsTheHubOnTheDrainNotTheWorkersFullExit` asserted `"22.9607ms" is not less than "20ms"`.

## Cause

The wall-clock `Less(elapsed, workerDrainTimeout)` assertion duplicated a claim the test already proved without time, and flaked when `CaptureStderr` / `logging.Setup` shared the stopwatch on Windows.

## Change

Drop the wall-clock assertion. Keep the semantic proofs:

- Shutdown returns while worker teardown is still held → Hub did not wait for the Worker's full exit
- Absent backstop warn line → `WaitBounded` took the `done` path, not `timer.C`

Raising the threshold still races. A fake clock needs a production seam in `drain.WaitBounded`; this claim does not justify that.

## Verification

`task test-backend -- ./solo -run 'TestInstanceShutdown_…' -count=50` — 150 passes, plus backend lint/vet for windows/linux/darwin.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0277e-757d-7242-be60-9a4869c7ae60?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0277e-757d-7242-be60-9a4869c7ae60&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

