### PR TITLE
fix(chat): Correct a mis-rendered send and a flaky chat measurement

### DIFF
--- a/frontend/src/components/chat/chatHiddenPremeasure.render.test.tsx
+++ b/frontend/src/components/chat/chatHiddenPremeasure.render.test.tsx
@@ -58,6 +58,22 @@ function renderPremeasureRow(
 }
 
 describe('chat hidden premeasure rendering', () => {
+  // The root publishes what a reader -- a screen reader, or an e2e measurement --
+  // needs to tell a hidden COPY of a row from the row itself. Both markers are
+  // load-bearing and neither is visible from inside a row, so nothing else fails
+  // if one is dropped: the copy simply starts passing for the real thing.
+  it('marks its root as a hidden copy, reachable from any bubble inside it', () => {
+    const { row } = renderPremeasureRow('user_text', MessageSource.USER)
+    const root = row.parentElement!
+    expect(root.getAttribute('aria-hidden')).toBe('true')
+    expect(root.getAttribute('data-chat-premeasure-root')).toBe('true')
+    // The query a chat measurement actually runs: from the bubble UP. It is how
+    // measureBubbleEdges names a premeasure copy instead of reporting the same
+    // "not inside the chat scroll container" a remounted row produces
+    // (tests/e2e/helpers/ui.ts, and https://github.com/leapmux/leapmux/issues/402).
+    expect(screen.getByTestId('bubble').closest('[data-chat-premeasure-root="true"]')).toBe(root)
+  })
+
   it('reserves the same width as visible span-line columns', () => {
     expect(spanLinesReservedWidth(0)).toBe(CONTAINER_PAD_RIGHT)
     expect(spanLinesReservedWidth(1)).toBe(COL_SPACING + CONTAINER_PAD_RIGHT)

--- a/frontend/src/components/chat/chatHiddenPremeasure.tsx
+++ b/frontend/src/components/chat/chatHiddenPremeasure.tsx
@@ -216,6 +216,15 @@ export function ChatHiddenPremeasure(props: ChatDomPremeasureProps): JSX.Element
       class={styles.premeasureRoot}
       style={{ width: `${Math.max(1, props.contentWidthPx)}px` }}
       aria-hidden="true"
+      // An e2e hook, like `data-chat-scroll-container` and `data-band`: the class
+      // is a hashed vanilla-extract name, so a spec has no other stable way to
+      // ask "is this element the hidden COPY of a row rather than the row?".
+      // A chat measurement that lands on a copy is a real defect (the copy sits
+      // outside the scroll container and carries no live geometry), and without
+      // this marker the failure is indistinguishable from a row that simply
+      // remounted -- which is what made
+      // https://github.com/leapmux/leapmux/issues/402 a three-way guess.
+      data-chat-premeasure-root="true"
     >
       <For each={props.candidates}>
         {candidate => (

--- a/frontend/src/components/chat/messageClassification.test.ts
+++ b/frontend/src/components/chat/messageClassification.test.ts
@@ -169,6 +169,85 @@ describe('classifyMessage', () => {
     expect(result.kind).toBe('unsupported_provider')
   })
 
+  // -- LeapMux's own user row, whatever the provider ------------------------
+
+  describe('a user row with no registered plugin', () => {
+    // The optimistic bubble a send builds carries whatever provider its agent TAB
+    // holds, and a tab projected from the CRDT holds none until useTabHydrators
+    // fetches the worker-side metadata. Classifying that as unsupported_provider
+    // rendered the user's own message as "Unsupported agent provider: Unknown (0)"
+    // until the server echo replaced it -- in a META row, which also cost the
+    // full-bleed geometry every user row is laid out with.
+    it('classifies LeapMux\'s flat user payload as user_content', () => {
+      const result = classifyMessage(input({ content: 'hi' }, null, AgentProvider.UNSPECIFIED, MessageSource.USER))
+      expect(result.kind).toBe('user_content')
+    })
+
+    it('keeps that row out of META_KINDS, so it stays widened and mirrored', () => {
+      // The geometry half: a META kind is neither mirrored nor widened, which is
+      // what made the pending bubble 32px narrower than its own echo.
+      const { kind } = classifyMessage(input({ content: 'hi' }, null, AgentProvider.UNSPECIFIED, MessageSource.USER))
+      expect(isMirroredMessageRow(kind, MessageSource.USER)).toBe(true)
+      expect(rowIsWidened(kind, MessageSource.USER)).toBe(true)
+      expect(bubbleRunsToRightEdge(kind, MessageSource.USER, false)).toBe(true)
+    })
+
+    it('carries attachments through, since they are part of the same payload', () => {
+      const result = classifyMessage(input(
+        { content: 'see this', attachments: [{ filename: 'a.png' }] },
+        null,
+        AgentProvider.UNSPECIFIED,
+        MessageSource.USER,
+      ))
+      expect(result.kind).toBe('user_content')
+    })
+
+    it('still reports an AGENT row as unsupported_provider', () => {
+      // The carve-out is for rows LeapMux WROTE. Agent bytes that happen to hold a
+      // `content` string are still a provider envelope nobody can read.
+      const result = classifyMessage(input({ content: 'hi' }, null, AgentProvider.UNSPECIFIED, MessageSource.AGENT))
+      expect(result.kind).toBe('unsupported_provider')
+    })
+
+    it('still reports a TAGGED user envelope as unsupported_provider', () => {
+      // A `type` key marks a provider's own wire shape, which LeapMux's flat user
+      // payload never carries -- and which the neutral renderer cannot draw.
+      const result = classifyMessage(input({ type: 'user', content: 'hi' }, null, AgentProvider.UNSPECIFIED, MessageSource.USER))
+      expect(result.kind).toBe('unsupported_provider')
+    })
+
+    it('still reports a user row with no content string as unsupported_provider', () => {
+      const result = classifyMessage(input({ attachments: [] }, null, AgentProvider.UNSPECIFIED, MessageSource.USER))
+      expect(result.kind).toBe('unsupported_provider')
+    })
+
+    it('leaves a notification thread to the notification path', () => {
+      // A wrapper classifies as a notification wherever it comes from; the
+      // carve-out must not intercept one that happens to be user-sourced.
+      const result = classifyMessage(input(
+        { content: 'hi' },
+        wrapper({ type: 'settings_changed' }),
+        AgentProvider.UNSPECIFIED,
+        MessageSource.USER,
+      ))
+      expect(result.kind).not.toBe('user_content')
+    })
+
+    it('agrees with the plugin that would have read the same payload', () => {
+      // The point of the carve-out is that the optimistic bubble and the server
+      // echo it reconciles to are the SAME row. They differ only in the provider
+      // the tab could supply at the time, so they must classify alike -- otherwise
+      // the echo re-classifies, ChatView replaces the row, and the send visibly
+      // reshapes. Claude reaches user_content through its own plugin; assert the
+      // two answers are equal rather than restating the literal, so a plugin that
+      // moves this payload elsewhere fails here instead of drifting silently.
+      const payload = { content: 'hi' }
+      const withoutPlugin = classifyMessage(input(payload, null, AgentProvider.UNSPECIFIED, MessageSource.USER))
+      const withPlugin = classifyMessage(input(payload, null, AgentProvider.CLAUDE_CODE, MessageSource.USER))
+      expect(withoutPlugin.kind).toBe(withPlugin.kind)
+    })
+  })
+
   // -- hidden ---------------------------------------------------------------
 
   describe('hidden', () => {

--- a/frontend/src/components/chat/messageClassification.test.ts
+++ b/frontend/src/components/chat/messageClassification.test.ts
@@ -202,13 +202,6 @@ describe('classifyMessage', () => {
       expect(result.kind).toBe('user_content')
     })
 
-    it('still reports an AGENT row as unsupported_provider', () => {
-      // The carve-out is for rows LeapMux WROTE. Agent bytes that happen to hold a
-      // `content` string are still a provider envelope nobody can read.
-      const result = classifyMessage(input({ content: 'hi' }, null, AgentProvider.UNSPECIFIED, MessageSource.AGENT))
-      expect(result.kind).toBe('unsupported_provider')
-    })
-
     it('still reports a TAGGED user envelope as unsupported_provider', () => {
       // A `type` key marks a provider's own wire shape, which LeapMux's flat user
       // payload never carries -- and which the neutral renderer cannot draw.
@@ -218,6 +211,40 @@ describe('classifyMessage', () => {
 
     it('still reports a user row with no content string as unsupported_provider', () => {
       const result = classifyMessage(input({ attachments: [] }, null, AgentProvider.UNSPECIFIED, MessageSource.USER))
+      expect(result.kind).toBe('unsupported_provider')
+    })
+
+    it('still reports a row with no parsed object as unsupported_provider', () => {
+      // An envelope that failed to parse leaves parentObject undefined. There is
+      // nothing to read, so the loud error is the right answer even for a user row.
+      const result = classifyMessage(input(undefined, null, AgentProvider.UNSPECIFIED, MessageSource.USER))
+      expect(result.kind).toBe('unsupported_provider')
+    })
+
+    it('takes an attachment-only send, whose content is the empty string', () => {
+      // Sending a file with no typed text persists `content: ''`. The empty string
+      // is still a string, so this is a real user row -- and the one whose payload
+      // most looks like an absent field.
+      const result = classifyMessage(input(
+        { content: '', attachments: [{ filename: 'diagram.png' }] },
+        null,
+        AgentProvider.UNSPECIFIED,
+        MessageSource.USER,
+      ))
+      expect(result.kind).toBe('user_content')
+    })
+
+    it.each([
+      ['UNSPECIFIED', MessageSource.UNSPECIFIED],
+      ['LEAPMUX', MessageSource.LEAPMUX],
+      ['AGENT', MessageSource.AGENT],
+    ])('reports the same payload from a %s source as unsupported_provider', (_label, source) => {
+      // The carve-out is for rows LeapMux WROTE, so it turns on the SOURCE and not
+      // on the shape: agent bytes that happen to hold a `content` string are still
+      // a provider envelope nobody can read. Swept rather than asserted once,
+      // because widening the predicate to "any row that looks flat" is the mistake
+      // that would put those bytes in a user card.
+      const result = classifyMessage(input({ content: 'hi' }, null, AgentProvider.UNSPECIFIED, source))
       expect(result.kind).toBe('unsupported_provider')
     })
 

--- a/frontend/src/components/chat/messageClassification.ts
+++ b/frontend/src/components/chat/messageClassification.ts
@@ -56,6 +56,7 @@ export function toClassificationInput(
     parentObject: parsed.parentObject,
     wrapper: parsed.wrapper,
     agentProvider: message.agentProvider,
+    source: message.source,
     spanId: message.spanId,
     spanType: message.spanType,
     parentSpanId: message.parentSpanId,
@@ -65,21 +66,58 @@ export function toClassificationInput(
 }
 
 /**
+ * True for LeapMux's OWN user-row payload: the flat `{content, attachments?}`
+ * object every user message is persisted as.
+ *
+ * Tests exactly what the shared `UserContentMessage` renderer reads, and the same
+ * `type`-free shape Claude's `userContentRenderer` requires, so a row this accepts
+ * is one the neutral renderer can draw. The absence of `type` is what separates it
+ * from a provider envelope, every one of which is tagged.
+ *
+ * Restricted to a USER source and to an unwrapped row: a notification thread
+ * carries its own wrapper and classifies as a notification, and an AGENT row is
+ * provider bytes whatever it happens to look like.
+ */
+function isLeapMuxUserPayload(input: ClassificationInput): boolean {
+  return input.source === MessageSource.USER
+    && input.wrapper === null
+    && input.parentObject !== undefined
+    && typeof input.parentObject.content === 'string'
+    && !('type' in input.parentObject)
+}
+
+/**
  * Classify a parsed message into exactly one category.
  *
  * Dispatches strictly through the message's own provider plugin. An UNSPECIFIED
  * or unregistered provider has no plugin: we refuse to guess one (e.g. default
  * to Claude), because misreading another provider's envelope is worse than a
  * visible failure -- the result is `unsupported_provider`, which MessageBubble
- * surfaces as a loud error.
+ * surfaces as a loud error. A row LeapMux wrote ITSELF is the exception; see
+ * {@link isLeapMuxUserPayload}.
  */
 export function classifyMessage(
   input: ClassificationInput,
   context?: ClassificationContext,
 ): MessageCategory {
   const plugin = pluginFor(input.agentProvider)
-  if (!plugin)
+  if (!plugin) {
+    // A USER row is the one message no plugin is needed to read: LeapMux writes
+    // every one of them itself, in its own flat `{content, attachments?}` shape
+    // (see the SendAgentMessage handler and chatReconcile's payload extractor).
+    // There are no provider bytes here to misread, so the loud error below is
+    // the wrong answer for it -- and it is not hypothetical. An agent tab
+    // arrives from the CRDT projection with NO worker-side metadata, because the
+    // hub strips the agent payload (it is E2EE on the worker) and useTabHydrators
+    // fetches it separately. Until that answers, the tab carries no
+    // agentProvider, so the optimistic bubble a send builds from it claims
+    // UNSPECIFIED -- and the user's own message rendered as "Unsupported agent
+    // provider: Unknown (0)" for as long as the echo took to arrive, in a META
+    // row that also lost the full-bleed geometry a user row is laid out with.
+    if (isLeapMuxUserPayload(input))
+      return { kind: 'user_content' }
     return { kind: 'unsupported_provider' }
+  }
 
   // A persisted control-response row ({isSynthetic, controlResponse}) is a LeapMux-NEUTRAL synthetic
   // shape, not a provider wire format, so its classification lives here once instead of being

--- a/frontend/src/components/chat/messageRenderers.test.tsx
+++ b/frontend/src/components/chat/messageRenderers.test.tsx
@@ -283,6 +283,17 @@ describe('a user row whose provider has no plugin', () => {
     expect(container.textContent).toContain('see this')
   })
 
+  it('draws an attachment-only send, whose content is the empty string', () => {
+    // A file dragged in with no typed text. The empty string is the boundary the
+    // neutral branch has to pass through to UserContentMessage: a renderer that
+    // treated it as "nothing to draw" would show an empty card for a real message.
+    const parsed = { content: '', attachments: [{ filename: 'notes.pdf', mime_type: 'application/pdf' }] }
+    const { container } = render(() =>
+      renderMessageContent(parsed, undefined, { kind: 'user_content' } as MessageCategory, AgentProvider.UNSPECIFIED))
+    expect(container.textContent).toContain('notes.pdf')
+    expect(container.textContent).not.toContain('mime_type')
+  })
+
   it('still drops an AGENT-shaped row to the raw-JSON span', () => {
     // The neutral branch is keyed on the category, and only a USER row reaches
     // `user_content` without a plugin (see classifyMessage). A provider's own

--- a/frontend/src/components/chat/messageRenderers.test.tsx
+++ b/frontend/src/components/chat/messageRenderers.test.tsx
@@ -250,3 +250,46 @@ describe('thinking renderer honors context.expandUiKey', () => {
     expect(getMessageUiState).not.toHaveBeenCalledWith(MESSAGE_UI_KEY.THINKING)
   })
 })
+
+describe('a user row whose provider has no plugin', () => {
+  // LeapMux writes every user row itself, in its own flat `{content, attachments?}`
+  // shape, so it needs no plugin to draw -- and the optimistic bubble a send builds
+  // routinely has none, because an agent tab projected from the CRDT carries no
+  // agentProvider until useTabHydrators fetches the worker-side metadata. Without
+  // the neutral branch this fell through to the raw-JSON span.
+  it('draws the same card a registered provider would, not raw JSON', () => {
+    const parsed = { content: 'hello there' }
+    const category = { kind: 'user_content' } as MessageCategory
+
+    const neutral = render(() => renderMessageContent(parsed, undefined, category, AgentProvider.UNSPECIFIED))
+    expect(neutral.container.textContent).toContain('hello there')
+    expect(neutral.container.textContent).not.toContain('"content"')
+
+    // Byte-for-byte the same markup as the plugin path, which is what keeps the
+    // optimistic bubble and its server echo the same size: a difference here is a
+    // re-measure the reader sees as the row blinking.
+    const viaPlugin = render(() => renderMessageContent(parsed, undefined, category, AgentProvider.CLAUDE_CODE))
+    expect(neutral.container.innerHTML).toBe(viaPlugin.container.innerHTML)
+  })
+
+  it('lists the attachments carried on the same payload', () => {
+    const parsed = { content: 'see this', attachments: [{ filename: 'diagram.png', mime_type: 'image/png' }] }
+    const { container } = render(() =>
+      renderMessageContent(parsed, undefined, { kind: 'user_content' } as MessageCategory, AgentProvider.UNSPECIFIED))
+    expect(container.textContent).toContain('diagram.png')
+    // Not merely present in a serialized blob: the raw-JSON span this replaced
+    // also "contained" the filename, so assert the payload's own keys are gone.
+    expect(container.textContent).not.toContain('mime_type')
+    expect(container.textContent).toContain('see this')
+  })
+
+  it('still drops an AGENT-shaped row to the raw-JSON span', () => {
+    // The neutral branch is keyed on the category, and only a USER row reaches
+    // `user_content` without a plugin (see classifyMessage). A provider's own
+    // unreadable bytes must still surface as raw JSON rather than as a user card.
+    const parsed = { type: 'result', subtype: 'success', duration_ms: 1095 }
+    const { container } = render(() =>
+      renderMessageContent(parsed, undefined, { kind: 'unsupported_provider' } as MessageCategory, AgentProvider.UNSPECIFIED))
+    expect(container.textContent).toContain('"duration_ms"')
+  })
+})

--- a/frontend/src/components/chat/messageRenderers.tsx
+++ b/frontend/src/components/chat/messageRenderers.tsx
@@ -445,6 +445,16 @@ export function renderMessageContent(
       if (row !== null)
         return row
     }
+
+    // A user row is provider-neutral in the renderer layer for the same reason it
+    // is in `classifyMessage`: LeapMux writes it, in its own flat
+    // `{content, attachments?}` shape. Every plugin that names this kind already
+    // draws it with UserContentMessage, so a message whose provider has no plugin
+    // -- an optimistic bubble built from a tab whose worker metadata has not
+    // hydrated yet -- gets the SAME card here, rather than the raw-JSON span
+    // below. Reached only when no plugin claimed the row above.
+    if (category?.kind === 'user_content')
+      return <UserContentMessage parsed={parsed} context={context} />
   }
   catch (err) { logger.warn('Failed to render message content:', err) }
   return <span>{typeof parsedOrRawJson === 'string' ? parsedOrRawJson : JSON.stringify(parsedOrRawJson)}</span>

--- a/frontend/src/components/chat/providers/registry.ts
+++ b/frontend/src/components/chat/providers/registry.ts
@@ -13,7 +13,7 @@ import type { ActionsProps, AskQuestionState, ContentProps, Question } from '../
 import type { MessageCategory } from '../messageClassification'
 import type { RenderContext } from '../messageRenderers'
 import type { ControlResponseDeriver } from '../persistedControlResponse'
-import type { AgentInfo, AgentProvider } from '~/generated/leapmux/v1/agent_pb'
+import type { AgentInfo, AgentProvider, MessageSource } from '~/generated/leapmux/v1/agent_pb'
 import type { ParsedMessageContent } from '~/lib/messageParser'
 import type { AgentSessionInfo, ContextUsageInfo, RateLimitInfo } from '~/stores/agentSession.store'
 import type { CommandStreamSegment } from '~/stores/chatTypes'
@@ -52,6 +52,13 @@ export interface AttachmentCapabilities {
 
 export interface ClassificationInput extends ParsedMessageContent {
   agentProvider?: AgentProvider
+  /**
+   * Who wrote the row. Read ONLY by the provider-neutral carve-outs in
+   * `classifyMessage`, never by a plugin: a plugin recognizes its own wire
+   * format by shape, and branching on the source instead would let it claim a
+   * row LeapMux wrote.
+   */
+  source?: MessageSource
   spanId?: string
   spanType?: string
   parentSpanId?: string

--- a/frontend/src/components/chat/providers/testUtils.ts
+++ b/frontend/src/components/chat/providers/testUtils.ts
@@ -1,5 +1,5 @@
 import type { ClassificationInput } from './registry'
-import type { AvailableOption } from '~/generated/leapmux/v1/agent_pb'
+import type { AvailableOption, MessageSource } from '~/generated/leapmux/v1/agent_pb'
 import { create } from '@bufbuild/protobuf'
 import {
   AgentProvider,
@@ -13,11 +13,16 @@ import {
  * dispatches to the Claude plugin (now that classifyMessage no longer falls back
  * to Claude for an unset provider); pass an explicit provider to exercise another
  * plugin's dispatch or the `unsupported_provider` path.
+ *
+ * `source` is left unset by default because only the provider-neutral carve-outs
+ * in classifyMessage read it; pass MessageSource.USER to exercise the LeapMux
+ * user-row path.
  */
 export function input(
   parent?: Record<string, unknown>,
   wrapper?: { old_seqs: number[], messages: unknown[] } | null,
   agentProvider: AgentProvider = AgentProvider.CLAUDE_CODE,
+  source?: MessageSource,
 ): ClassificationInput {
   return {
     rawText: '',
@@ -25,6 +30,7 @@ export function input(
     parentObject: parent,
     wrapper: wrapper ?? null,
     agentProvider,
+    source,
   }
 }
 

--- a/frontend/src/test-support/chatRowReads.test.ts
+++ b/frontend/src/test-support/chatRowReads.test.ts
@@ -1,0 +1,139 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { dirname, join, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+// E2E guard: read a chat row through `readAttached`, never through a bare
+// `locator.evaluate` / `locator.evaluateAll`.
+//
+// Resolving a locator and reading from what it resolved are two browser round
+// trips, and a chat row does not survive the gap. ChatView re-creates a row
+// whenever its entry is replaced, which every send does about 350ms later, when
+// the optimistic local reconciles to a server echo carrying a different id and a
+// different seq. A resolve that lands just before the swap leaves the read
+// holding a DETACHED node.
+//
+// `evaluateAll` is no safer than `evaluate`, which is worth stating because it
+// reads as though it should be: Playwright runs it as `querySelectorAll` into an
+// array HANDLE and then a second call that applies the callback to that handle,
+// so the elements are pinned a round trip before the callback sees them. A probe
+// that replaced its element on every event-loop turn fed both forms a detached
+// node on most attempts.
+//
+// What makes this worth a guard rather than a comment is how quietly it fails. A
+// detached node reports an empty rect, a null `closest()` and NO computed style,
+// so a geometry assertion fails at random (issue 402) while a colour assertion of
+// the "these two must differ" shape PASSES against an empty string -- green, and
+// proving nothing. 033 held one of those.
+//
+// `readAttached` in tests/e2e/helpers/ui.ts takes the read that the guard
+// requires: it hands the callback every match, the callback keeps only what is
+// still in the document, and returning null retries.
+//
+// Only CHAT locators are in scope. The scroll container, the composer, a popover
+// and the sidebar are not rebuilt under a reader, so `locator.evaluate` stays
+// correct for them.
+
+/** What marks an expression as resolving to a chat row, or to something inside one. */
+const CHAT_LOCATOR_MARKERS = [
+  'userBubbles(',
+  'assistantBubbles(',
+  'messageBubbles(',
+  'messageContents(',
+  'bandRows(',
+  'firstAssistantBubble(',
+  'lastAssistantBubble(',
+  'message-bubble',
+  'message-content',
+  'data-seq',
+  'data-band',
+]
+
+/** The two-round-trip reads, as they appear after a receiver. */
+const RACY_READ = String.raw`\.\s*evaluate(?:All)?\s*\(`
+
+const frontendRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const e2eRoot = join(frontendRoot, 'tests', 'e2e')
+
+/** `const name = <expression>`, the only binding form the specs use for a locator. */
+const BINDING = /(?:const|let)\s+(\w+)\s*=\s*([^\n]*)/g
+
+function collectSpecFiles(dir: string): string[] {
+  const found: string[] = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory())
+      found.push(...collectSpecFiles(full))
+    else if (entry.name.endsWith('.ts'))
+      found.push(full)
+  }
+  return found
+}
+
+/**
+ * The names in `source` that hold a chat locator.
+ *
+ * Runs to a fixed point so a locator scoped off another one is caught too:
+ * `const sent = bubble.locator('pre')` is as exposed to its row's remount as
+ * `bubble` is.
+ */
+function chatLocatorNames(source: string): Set<string> {
+  const names = new Set<string>()
+  for (let grew = true; grew;) {
+    grew = false
+    for (const [, name, expression] of source.matchAll(BINDING)) {
+      if (names.has(name))
+        continue
+      const derived = [...names].some(known => new RegExp(`\\b${known}\\b`).test(expression))
+      if (!CHAT_LOCATOR_MARKERS.some(marker => expression.includes(marker)) && !derived)
+        continue
+      names.add(name)
+      grew = true
+    }
+  }
+  return names
+}
+
+/** Every two-round-trip read of a chat row in one file, as `line  snippet`. */
+function racyChatReads(source: string): Array<{ index: number, text: string }> {
+  const found: Array<{ index: number, text: string }> = []
+  // A read through a named locator: the name, any chain of calls off it
+  // (`.first()`, `.nth(i)`, `.locator(…)`), then the read.
+  for (const name of chatLocatorNames(source)) {
+    const pattern = new RegExp(String.raw`\b${name}\b(?:\s*\.\w+\([^()]*\))*\s*${RACY_READ}`, 'g')
+    for (const match of source.matchAll(pattern))
+      found.push({ index: match.index, text: match[0] })
+  }
+  // A read straight off the helper that builds the locator, with no name in
+  // between -- `bandRows(page).evaluateAll(…)`. Matched per line, because the
+  // callback that follows spans many of them.
+  let offset = 0
+  for (const line of source.split('\n')) {
+    const read = new RegExp(RACY_READ).exec(line)
+    if (read && CHAT_LOCATOR_MARKERS.some(marker => line.includes(marker)))
+      found.push({ index: offset + read.index, text: line.trim() })
+    offset += line.length + 1
+  }
+  return found
+}
+
+describe('e2e chat row reads', () => {
+  it('never reads a chat row through a two-round-trip evaluate', () => {
+    const offenders = new Set<string>()
+    for (const file of collectSpecFiles(e2eRoot)) {
+      const source = readFileSync(file, 'utf-8')
+      for (const { index, text } of racyChatReads(source)) {
+        const line = source.slice(0, index).split('\n').length
+        offenders.add(`${relative(frontendRoot, file)}:${line}  ${text}`)
+      }
+    }
+    const hint = [
+      'A chat row is re-created whenever its entry is replaced, so a handle resolved one round trip',
+      'earlier can already be detached -- which reports an empty rect and NO computed style.',
+      '`evaluateAll` pins its elements a round trip early too. Read through readAttached',
+      '(tests/e2e/helpers/ui.ts), skipping any match whose `isConnected` is false, or measure the row',
+      'with measureBubbleEdges / measureAgainstChatList:',
+    ].join(' ')
+    expect([...offenders].sort(), `${hint}\n  ${[...offenders].sort().join('\n  ')}`).toEqual([])
+  })
+})

--- a/frontend/tests/e2e/033-markdown-editor-code.spec.ts
+++ b/frontend/tests/e2e/033-markdown-editor-code.spec.ts
@@ -2,7 +2,7 @@ import { CODE_BLOCK_TINT_PERCENT } from '../../src/styles/codePalette'
 import { colorAlpha } from '../../src/test-support/color'
 import { expect, test } from './fixtures'
 import { enterAndExitPlanMode } from './helpers/plan-mode'
-import { resolvedColor, userBubbles } from './helpers/ui'
+import { readAttached, resolvedColor, userBubbles } from './helpers/ui'
 
 const MONOSPACE_FONT_RE = /HackNerdFont|Menlo|Monaco|Courier New|monospace/
 
@@ -63,7 +63,13 @@ test.describe('Code block field', () => {
    * case a tint cannot answer.
    */
   async function blockBackground(block: import('@playwright/test').Locator): Promise<string> {
-    return block.evaluate(el => getComputedStyle(el).backgroundColor)
+    // Skip a detached match, because half these blocks live in a chat row: a row
+    // that remounts between a resolve and a read leaves a DETACHED node, whose
+    // computed style is empty rather than wrong. See readAttached.
+    return readAttached(block, 'blockBackground', (matches) => {
+      const el = matches.find(candidate => candidate.isConnected)
+      return el ? getComputedStyle(el).backgroundColor : null
+    })
   }
 
   test('paints the composer code block a field that composites on its host, in both polarities', async ({ page, authenticatedWorkspace }) => {
@@ -128,7 +134,10 @@ test.describe('Code block field', () => {
     // ...and that is not a trivial match: the bubble it lands in paints a
     // DIFFERENT surface than the panel behind the composer. One declaration on
     // two hosts is the whole point of a field that composites.
-    const bubbleSurface = await bubble.evaluate(el => getComputedStyle(el).backgroundColor)
+    const bubbleSurface = await readAttached(bubble, 'the bubble surface', (matches) => {
+      const el = matches.find(candidate => candidate.isConnected)
+      return el ? getComputedStyle(el).backgroundColor : null
+    })
     const panelSurface = await resolvedColor(page, 'var(--background)')
     expect(bubbleSurface, 'a user bubble is a different surface from the panel').not.toBe(panelSurface)
 
@@ -136,7 +145,10 @@ test.describe('Code block field', () => {
     // transient, so the field is measured on a bare `<pre>` placed in the same
     // markdown body rather than by racing the render: a selector narrowed back
     // to `pre.shiki` leaves this one on the app's own tint instead.
-    const unhighlighted = await sent.evaluate((el) => {
+    const unhighlighted = await readAttached(sent, 'an un-highlighted <pre>', (matches) => {
+      const el = matches.find(candidate => candidate.isConnected)
+      if (!el)
+        return null
       const bare = document.createElement('pre')
       el.parentElement!.append(bare)
       const painted = getComputedStyle(bare).backgroundColor

--- a/frontend/tests/e2e/040-chat-message-rendering.spec.ts
+++ b/frontend/tests/e2e/040-chat-message-rendering.spec.ts
@@ -142,6 +142,69 @@ test.describe('Chat Message Rendering', () => {
   })
 
   /**
+   * A send renders the user's own words from the first frame, in the card a user
+   * row is laid out in -- and does not change its mind when the server echo lands.
+   *
+   * The optimistic bubble is built from the agent TAB, and a tab projected from
+   * the CRDT carries no `agentProvider` until useTabHydrators fetches the
+   * worker-side metadata the hub strips (it is E2EE on the worker). Classifying a
+   * providerless row as `unsupported_provider` therefore rendered the user's own
+   * message as "Unsupported agent provider: Unknown (0)" until the echo replaced
+   * it -- in a META row, 32px narrower, whose different height then made the echo
+   * re-measure and blank the row for ~160ms on top.
+   *
+   * Sampled from INSIDE the page, from before the send, because every state this
+   * covers is gone within about 400ms: an assertion that resolves afterwards
+   * passes against the echo and proves nothing. The recorder keeps one entry per
+   * distinct state, so the check reads every frame the reader could have seen.
+   */
+  test('a send renders the message itself, in one shape, from the first frame', async ({ page, authenticatedWorkspace }) => {
+    await page.evaluate(() => {
+      const seen: Array<{ seq: string, text: string, bleed: boolean }> = []
+      ;(globalThis as unknown as { __sentStates: typeof seen }).__sentStates = seen
+      let last = ''
+      const sample = () => {
+        const list = document.querySelector('[data-chat-scroll-container="true"]')
+        const bubble = list?.querySelector('[data-testid="message-bubble"][data-role="user"]')
+        const row = bubble?.closest('[data-seq]')
+        if (bubble && row) {
+          const state = {
+            seq: row.getAttribute('data-seq') ?? '',
+            text: (bubble.textContent ?? '').replace(/\s+/g, ' ').trim(),
+            // The full-bleed row class is a hashed vanilla-extract name, so match
+            // the readable part rather than importing the stylesheet into the page.
+            bleed: row.className.includes('bleedRow'),
+          }
+          const key = JSON.stringify(state)
+          if (key !== last) {
+            seen.push(state)
+            last = key
+          }
+        }
+        requestAnimationFrame(sample)
+      }
+      requestAnimationFrame(sample)
+    })
+
+    await sendMessage(page, 'hi')
+
+    // Wait for the ECHO specifically -- a non-zero seq. Waiting on the bubble
+    // instead would let the assertions run while only the optimistic row exists,
+    // and the reclassification this covers happens at the swap.
+    const states = () => page.evaluate(() =>
+      (globalThis as unknown as { __sentStates: Array<{ seq: string, text: string, bleed: boolean }> }).__sentStates)
+    await expect.poll(async () => (await states()).some(s => s.seq !== '0')).toBe(true)
+
+    const seen = await states()
+    // Both sides of the swap were sampled, or the check below is vacuous.
+    expect(seen.some(s => s.seq === '0')).toBe(true)
+    expect(seen.some(s => s.seq !== '0')).toBe(true)
+    // ...and every one of them showed the user's text, in a widened row.
+    expect(seen.map(s => ({ text: s.text, bleed: s.bleed })))
+      .toEqual(seen.map(() => ({ text: 'hi', bleed: true })))
+  })
+
+  /**
    * A user bubble bleeds on ONE side only, which is the interesting case: the
    * right edge meets the panel, while the left keeps the bubble's rounded,
    * content-hugging shape well inside the gutter.

--- a/frontend/tests/e2e/040-chat-message-rendering.spec.ts
+++ b/frontend/tests/e2e/040-chat-message-rendering.spec.ts
@@ -1,7 +1,7 @@
 import type { Page } from '@playwright/test'
 import { expect, test } from './fixtures'
 import { COARSE_POINTER_METRICS, touchDown } from './helpers/touch'
-import { ARITHMETIC_PROMPT, assistantBubbles, bandRows, CHAT_SCROLL_CONTAINER, chatScrollContainer, firstAssistantBubble, measureAgainstChatList, measureBubbleEdges, messageContents, sendMessage, userBubbles, waitForAgentIdle } from './helpers/ui'
+import { ARITHMETIC_PROMPT, assistantBubbles, bandRows, chatScrollContainer, firstAssistantBubble, measureAgainstChatList, measureBubbleEdges, messageContents, readAttached, sendMessage, userBubbles, waitForAgentIdle } from './helpers/ui'
 
 /**
  * Send one prompt and wait for the turn to settle. Every test below opens the
@@ -66,14 +66,19 @@ test.describe('Chat Message Rendering', () => {
     // row knows, so a bleed sized to the bare gutter stops short on a railed row and
     // reaches the edge on a bare one -- the very case ROW_BLEED_LEFT_VAR exists for.
     // Checking one band would pass on a transcript whose only band has no rails.
-    const bands = await bandRows(page).evaluateAll((els, selector) => els.map((el) => {
-      const list = el.closest(selector)!
-      return {
-        rails: el.querySelector('[data-span-columns]')?.getAttribute('data-span-columns') ?? '0',
-        width: el.getBoundingClientRect().width,
-        listWidth: list.clientWidth,
-      }
-    }), CHAT_SCROLL_CONTAINER)
+    const bands = await readAttached(bandRows(page), 'the band rows', (matches, selector) => {
+      const attached = matches.filter(candidate => candidate.isConnected)
+      if (attached.length === 0)
+        return null
+      return attached.map((el) => {
+        const list = el.closest(selector)!
+        return {
+          rails: el.querySelector('[data-span-columns]')?.getAttribute('data-span-columns') ?? '0',
+          width: el.getBoundingClientRect().width,
+          listWidth: list.clientWidth,
+        }
+      })
+    })
 
     expect(bands.length).toBeGreaterThan(0)
     for (const band of bands) {
@@ -92,8 +97,11 @@ test.describe('Chat Message Rendering', () => {
     // `data-seq` marks every virtual row; the tail has no seq but does carry `data-band`.
     // Scoped to the scroll container, which excludes the hidden premeasure copies (they
     // mount outside it) and the rail's dots (which reuse data-seq).
-    const seams = await chatScrollContainer(page).locator('[data-seq], [data-band]').evaluateAll(els =>
-      els
+    const seams = await readAttached(
+      chatScrollContainer(page).locator('[data-seq], [data-band]'),
+      'the band seams',
+      matches => matches
+        .filter(candidate => candidate.isConnected)
         .map((el) => {
           const r = el.getBoundingClientRect()
           return {
@@ -141,13 +149,13 @@ test.describe('Chat Message Rendering', () => {
    * The plan-execution card takes the same rule, and 050-plan-mode.spec.ts
    * measures it through the same helper.
    *
-   * This test flakes in COMBINED runs and passes alone, with
-   * `measureBubbleEdges: element is not inside the chat scroll container`:
-   * https://github.com/leapmux/leapmux/issues/402. The cause is not the
-   * premeasure-copy trap -- `userBubbles` is already `:visible`-scoped, which
-   * a `visibility: hidden` copy cannot pass. Do not wrap the measurement in a
-   * retry until the cause is known, because two of the three candidates are
-   * real defects that a retry would hide.
+   * This measures a bubble the send has only just created, which is the window
+   * the row is REPLACED in: the optimistic local reconciles to its server echo
+   * about 350ms later, under a new id and a new seq, so ChatView tears the row
+   * down and builds a fresh one. `measureBubbleEdges` skips a match that has
+   * left the document for that reason, rather than measuring the empty rect one
+   * reports -- see readAttached in helpers/ui.ts and
+   * https://github.com/leapmux/leapmux/issues/402.
    */
   test('a user bubble meets the right panel edge and keeps its left side inset', async ({ page, authenticatedWorkspace }) => {
     await sendMessage(page, 'hi')
@@ -156,18 +164,91 @@ test.describe('Chat Message Rendering', () => {
     await expect(bubble).toBeVisible()
 
     const box = await measureBubbleEdges(bubble)
+    // Every assertion below reports the WHOLE box, because one number out of
+    // five names the symptom and not the shape that produced it -- a bubble
+    // measured against the wrong list reads very differently from one the rule
+    // simply failed to bleed.
+    const measured = `measured ${JSON.stringify(box)}`
 
     // Flush right: the bubble's right edge sits on the list's padding-box edge.
-    expect(Math.abs(box.rightGap)).toBeLessThanOrEqual(1)
+    expect(Math.abs(box.rightGap), measured).toBeLessThanOrEqual(1)
     // Still a bubble on the left: inset by at least the gutter, and short of the
     // full width -- 'hi' must not stretch the bubble across the panel.
-    expect(box.leftGap).toBeGreaterThan(20)
+    expect(box.leftGap, measured).toBeGreaterThan(20)
     // A rounded corner flush against the edge would read as a mistake.
-    expect(box.radius).toBe('0px')
+    expect(box.radius, measured).toBe('0px')
     // Top edge on the row's. The row places the bubble on BOTH axes; a bubble-level
     // `alignSelf` is what would move this, and it would take the bubble's first line
     // off the line the toolbar beside it sits on.
+    expect(Math.abs(box.topGapInRow), measured).toBeLessThanOrEqual(1)
+  })
+
+  /**
+   * The contract the test above depends on: a chat measurement reads a row that
+   * is being replaced under it, or it reports why it could not -- it never
+   * measures a node that left the document.
+   *
+   * It lives beside the measurement it protects, and it drives a STAND-IN list
+   * rather than the real one. Agitating ChatView's own rows would detach nodes
+   * Solid still holds as insertion anchors, so the appended assistant row could
+   * fail to insert -- the probe would then be testing the agitation, and a page
+   * error would land on whichever assertion followed. A hand-built list exercises
+   * the helper's whole path (find the container, read both edges, read the row)
+   * with nothing else able to move.
+   */
+  test('a chat measurement survives a row that remounts under it', async ({ page, authenticatedWorkspace }) => {
+    void authenticatedWorkspace
+
+    await page.evaluate(() => {
+      const list = document.createElement('div')
+      list.setAttribute('data-chat-scroll-container', 'true')
+      list.style.cssText = 'position:fixed;top:0;left:0;width:600px;height:200px;box-sizing:border-box;border:2px solid;padding:0;overflow:auto'
+      const row = document.createElement('div')
+      row.style.cssText = 'position:relative;height:100px'
+      const probe = document.createElement('div')
+      probe.setAttribute('data-testid', 'remount-probe')
+      probe.style.cssText = 'position:absolute;right:0;top:0;width:100px;height:50px;border-top-right-radius:4px'
+      row.append(probe)
+      list.append(row)
+      document.body.append(list)
+
+      // Replace the probe with an equivalent copy as fast as the event loop
+      // allows. The old node is detached FOR GOOD, which is what a remount does
+      // and what a handle resolved a round trip earlier is left holding.
+      let live = true
+      const swap = () => {
+        if (!live)
+          return
+        const current = document.querySelector('[data-testid="remount-probe"]')
+        current?.replaceWith(current.cloneNode(true))
+        setTimeout(swap, 0)
+      }
+      ;(globalThis as unknown as { __stopRemountProbe: () => void }).__stopRemountProbe = () => {
+        live = false
+        list.remove()
+      }
+      swap()
+    })
+
+    const box = await measureBubbleEdges(page.locator('[data-testid="remount-probe"]:visible'))
+
+    // Read off a node that had left the document, every one of these would be a
+    // zero from an empty rect -- and `radius` an empty string, since a detached
+    // element resolves no computed style at all.
+    expect(Math.abs(box.rightGap)).toBeLessThanOrEqual(1)
     expect(Math.abs(box.topGapInRow)).toBeLessThanOrEqual(1)
+    expect(box.leftGap).toBeGreaterThan(400)
+    expect(box.radius).toBe('4px')
+
+    // An element that is outside every chat list is a STANDING condition, not a
+    // remount, so it must report itself on the first look instead of spending the
+    // retry budget and expiring as a bare timeout. The bound is ~1000x a single
+    // page-side read and a third of that budget, so only a real retry loop trips it.
+    const startedAt = Date.now()
+    await expect(measureBubbleEdges(page.locator('body'))).rejects.toThrow(/not inside the chat scroll container/)
+    expect(Date.now() - startedAt).toBeLessThan(5000)
+
+    await page.evaluate(() => (globalThis as unknown as { __stopRemountProbe: () => void }).__stopRemountProbe())
   })
 
   /**
@@ -222,15 +303,25 @@ test.describe('Chat Message Rendering', () => {
 
     // With text selected under the cursor, the browser's own menu wins so Copy
     // still works. The app suppresses neither the selection nor the native menu.
-    await bubble.evaluate((el) => {
+    //
+    // Select and measure in the SAME page-side turn, off a node that is still in
+    // the document. Split over two, a row that remounts in between leaves the
+    // range anchored to a node that has left it, and the rects it reports are
+    // empty.
+    const selectionBox = await readAttached(bubble, 'the bubble text selection', (matches) => {
+      const el = matches.find(candidate => candidate.isConnected)
+      if (!el)
+        return null
       const range = document.createRange()
       range.selectNodeContents(el)
       const selection = window.getSelection()!
       selection.removeAllRanges()
       selection.addRange(range)
-    })
-    const selectionBox = await bubble.evaluate(() => {
-      const rect = window.getSelection()!.getRangeAt(0).getClientRects()[0]
+      // Read back through the SELECTION rather than the range that was just
+      // built, so this also proves the browser took it.
+      const rect = selection.getRangeAt(0).getClientRects()[0]
+      if (!rect)
+        throw new Error('the bubble text selection: the selected text paints no rect')
       return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 }
     })
     await page.mouse.click(selectionBox.x, selectionBox.y, { button: 'right' })

--- a/frontend/tests/e2e/041-chat-pagination.spec.ts
+++ b/frontend/tests/e2e/041-chat-pagination.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from './fixtures'
-import { firstAssistantBubble, sendMessage } from './helpers/ui'
+import { firstAssistantBubble, readAttached, sendMessage } from './helpers/ui'
 
 /**
  * Smoke test for chat scroll + pagination integration. The store-level
@@ -41,12 +41,20 @@ test.describe('Chat Pagination & Scroll', () => {
     // LATER row instead — a non-zero translateY computes to a matrix(...), which
     // actually proves the virtualizer laid rows out rather than trivially
     // accepting the first row's 'none'.
+    //
+    // Skip a detached match: a row is re-created whenever its entry is replaced,
+    // and a detached one reports no transform at all rather than the wrong one.
+    // See readAttached.
+    const rowTransform = (row: typeof seqElements) =>
+      readAttached(row, 'the row transform', (matches) => {
+        const el = matches.find(candidate => candidate.isConnected)
+        return el ? getComputedStyle(el).transform : null
+      })
     if (count > 1) {
-      const lastTransform = await seqElements.last().evaluate(el => getComputedStyle(el).transform)
-      expect(lastTransform).toMatch(/^matrix/)
+      expect(await rowTransform(seqElements.last())).toMatch(/^matrix/)
     }
     else {
-      const transform = await seqElements.first().evaluate(el => getComputedStyle(el).transform)
+      const transform = await rowTransform(seqElements.first())
       expect(transform === 'none' || transform.startsWith('matrix')).toBe(true)
     }
 

--- a/frontend/tests/e2e/047b-chat-scroll-rail-autohide.spec.ts
+++ b/frontend/tests/e2e/047b-chat-scroll-rail-autohide.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from './fixtures'
 import { COARSE_POINTER_METRICS } from './helpers/touch'
-import { sendMessage, userBubbles, waitForAgentIdle } from './helpers/ui'
+import { readAttached, sendMessage, userBubbles, waitForAgentIdle } from './helpers/ui'
 
 /**
  * The scroll rail's floating auto-hide, which is E2E-only by construction. Everything that
@@ -223,7 +223,17 @@ test.describe('chat scroll rail auto-hide', () => {
     // Scoped to a band row inside the scroller: only a row that gives its whole width to
     // the content floats its actions absolutely, so a user row's toolbar -- which is
     // in-flow in a mirrored grid -- reads `right: auto` and would prove nothing.
-    const toolbarRight = () => page.locator(`${SCROLLER} [data-band] [data-testid="message-toolbar"]`).first().evaluate(el => globalThis.getComputedStyle(el).right)
+    //
+    // Read through readAttached: this toolbar is inside a chat row, and a row that
+    // remounts between the resolve and the read reports no computed style at all.
+    const toolbarRight = () => readAttached(
+      page.locator(`${SCROLLER} [data-band] [data-testid="message-toolbar"]`).first(),
+      'the row toolbar inset',
+      (matches) => {
+        const el = matches.find(candidate => candidate.isConnected)
+        return el ? globalThis.getComputedStyle(el).right : null
+      },
+    )
     expect(await toolbarRight()).toBe('0px')
 
     // Below the phone breakpoint the gutter shrinks to 4px but the column keeps its

--- a/frontend/tests/e2e/helpers/ui.ts
+++ b/frontend/tests/e2e/helpers/ui.ts
@@ -215,26 +215,175 @@ export function chatScrollContainer(page: Page) {
 }
 
 /**
+ * How long {@link readAttached} waits for a match that is still in the document.
+ *
+ * The only thing it waits out is a REMOUNT, which is a handful of frames, so the
+ * budget is deliberately far below `expect.timeout`: an element that is genuinely
+ * outside every chat list must report THAT, rather than expire as a bare test
+ * timeout with no named assertion.
+ */
+const ATTACHED_READ_TIMEOUT_MS = 15_000
+
+/**
+ * Read from the first match of `locator` that is still in the document.
+ *
+ * Use this, not `locator.evaluate`, for anything the app can re-create -- every
+ * chat row, and everything inside one.
+ *
+ * Reading a chat row is racy in a way no Playwright API removes. Resolving a
+ * locator and reading from what it resolved are two browser round trips, and a
+ * chat row does not survive the gap: ChatView re-creates a row whenever its entry
+ * is replaced, and every send does exactly that about 350ms later, when the
+ * optimistic local (`local-…`, seq 0) reconciles to a server echo carrying a
+ * different id AND a different seq. A resolve that lands just before the swap
+ * leaves the read holding a DETACHED node, whose `closest()` is null, whose rect
+ * is all zeroes and whose computed style is EMPTY -- which fails an assertion on
+ * geometry at random (https://github.com/leapmux/leapmux/issues/402) and silently
+ * PASSES one that only asks for two colours to differ.
+ *
+ * `evaluateAll` does not close that gap, and assuming it did was the first attempt
+ * at this fix. Playwright runs it as `querySelectorAll` into an array HANDLE, then
+ * a second call that applies `read` to that handle -- so the elements are pinned
+ * one round trip before `read` sees them, exactly like `evaluate`. Driving a
+ * probe that replaced its element on every event-loop turn, both forms handed
+ * `read` a detached node on most attempts. The one-round-trip alternative,
+ * `page.evaluate` with the query inside it, gives up Playwright's `:visible`
+ * engine -- which is what keeps the hidden premeasure copy out of every chat
+ * locator -- so it trades this defect for that one.
+ *
+ * What IS guaranteed is that the element and everything `read` derives from it
+ * belong to the same synchronous page turn. So `read` filters out what has left
+ * the document and returns null, and this retries. A measurement it does return
+ * came off a node that was attached when it was taken.
+ *
+ * `read` takes the match ARRAY, and must skip the detached candidates itself,
+ * because a wrapper cannot do it for them: Playwright serializes `read` and runs
+ * it inside the page, so a wrapper that called it would have to close over a
+ * Node-side function that does not survive the crossing. For the same reason
+ * `read` cannot reach {@link CHAT_SCROLL_CONTAINER}, so every read is handed it as
+ * a second argument; one that does not need the list just declares one parameter.
+ */
+export async function readAttached<R>(
+  locator: Locator,
+  what: string,
+  read: (possiblyDetachedMatches: (SVGElement | HTMLElement)[], chatScrollContainerSelector: string) => R | null,
+): Promise<R> {
+  // Held on an object rather than in a `let`: the assignment happens inside the
+  // retry closure, which control-flow narrowing cannot see through.
+  const held: { value: R | null } = { value: null }
+  await expect(async () => {
+    held.value = await locator.evaluateAll(read, CHAT_SCROLL_CONTAINER)
+    expect(held.value, `${what}: matched no element that was still in the document`).not.toBeNull()
+  }).toPass({ timeout: ATTACHED_READ_TIMEOUT_MS })
+  return held.value!
+}
+
+/**
+ * Every number the two chat measurements below need, read together.
+ *
+ * One page-side reader serves both so they cannot drift apart on how they read
+ * the box -- the guarantee their own doc comments claim, made structural instead
+ * of aspirational. Each caller projects the fields it asked for.
+ */
+interface ChatBoxGeometry {
+  /** The element's own border-box width. */
+  width: number
+  /** The list's padding-box width, the native scrollbar excluded. */
+  listWidth: number
+  /** Distance from the element's right side to the list's padding-box right edge. */
+  rightGap: number
+  /** Distance from the list's padding-box left edge to the element's left side. */
+  leftGap: number
+  /** Distance from the element's top edge down from its ROW's top edge, null when it has no parent. */
+  topGapInRow: number | null
+  /** The element's computed `border-top-right-radius`, as CSS reports it. */
+  radius: string
+}
+
+/** A match that cannot be measured, and what it turned out to be instead. */
+interface ChatBoxOutsideList {
+  outside: string
+}
+
+/**
+ * Measure the first still-attached match against its chat scroll container and
+ * its own row.
+ *
+ * The container is resolved from the element itself rather than from a hard-coded
+ * position in the DOM, and by the attribute the app publishes rather than by a
+ * computed-style walk that has to guess which ancestor scrolls. `clientLeft` is
+ * the list's left border and `clientWidth` stops before a native scrollbar, so
+ * both edges track the same padding box whichever scrollbar the list is wearing.
+ * Every number comes off one layout, so none of them can straddle a resize.
+ */
+function readChatBoxGeometry(
+  possiblyDetachedMatches: (SVGElement | HTMLElement)[],
+  chatScrollContainerSelector: string,
+): ChatBoxGeometry | ChatBoxOutsideList | null {
+  // A row that remounted between the resolve and this read is gone for good, and
+  // reports a zero rect and an empty computed style rather than an error.
+  const el = possiblyDetachedMatches.find(candidate => candidate.isConnected)
+  if (!el)
+    return null
+  const list = el.closest(chatScrollContainerSelector)
+  if (!list) {
+    // Name the copy outright. The premeasure root sits OUTSIDE the scroll
+    // container, so a measurement that lands on it looks exactly like a row that
+    // remounted -- telling the two apart by hand is what made issue 402 a guess.
+    if (el.closest('[data-chat-premeasure-root="true"]'))
+      return { outside: 'it is ChatView\'s hidden premeasure copy, not the live row' }
+    const chain: string[] = []
+    for (let node: Element | null = el; node && chain.length < 8; node = node.parentElement) {
+      const testId = node.getAttribute('data-testid')
+      chain.push(node.tagName.toLowerCase() + (testId ? `[${testId}]` : ''))
+    }
+    return { outside: `ancestors: ${chain.join(' < ')}` }
+  }
+  const listRect = list.getBoundingClientRect()
+  const self = el.getBoundingClientRect()
+  const row = el.parentElement
+  const padLeft = listRect.left + list.clientLeft
+  return {
+    width: self.width,
+    listWidth: list.clientWidth,
+    rightGap: padLeft + list.clientWidth - self.right,
+    leftGap: self.left - padLeft,
+    topGapInRow: row ? self.top - row.getBoundingClientRect().top : null,
+    radius: globalThis.getComputedStyle(el).borderTopRightRadius,
+  }
+}
+
+/** Run {@link readChatBoxGeometry} through {@link readAttached} and reject a match it cannot measure. */
+async function measureChatBox(locator: Locator, what: string): Promise<ChatBoxGeometry> {
+  const read = await readAttached(locator, what, readChatBoxGeometry)
+  // Not retried: an element outside every chat list stays outside, so looping on
+  // it would replace this message with a test timeout 15 seconds later.
+  if ('outside' in read)
+    throw new Error(`${what}: element is not inside the chat scroll container -- ${read.outside}`)
+  return read
+}
+
+/**
  * Measure a full-bleed chat element against the width it must span: the chat
  * scroll container's `clientWidth`, which IS its padding box (the scrollbar
  * excluded), and which is exactly what a band or a turn-end rule reaches.
- *
- * The container is resolved from the element itself rather than from a
- * hard-coded position in the DOM, and by the attribute the app publishes rather
- * than by a computed-style walk that has to guess which ancestor scrolls. Both
- * numbers are read in one browser round trip, so they cannot straddle a resize.
  */
 export async function measureAgainstChatList(locator: Locator): Promise<{ width: number, listWidth: number }> {
-  return locator.evaluate((el, selector) => {
-    const list = el.closest(selector)
-    if (!list)
-      throw new Error('measureAgainstChatList: element is not inside the chat scroll container')
-    return { width: el.getBoundingClientRect().width, listWidth: list.clientWidth }
-  }, CHAT_SCROLL_CONTAINER)
+  const { width, listWidth } = await measureChatBox(locator, 'measureAgainstChatList')
+  return { width, listWidth }
 }
 
 /** Where an end-of-line card's sides sit, and the corner it turns at the edge. */
 export interface BubbleEdges {
+  /**
+   * The list's padding-box width, which the two gaps are measured against.
+   *
+   * Carried so a failure reports the SHAPE and not just the symptom: with it, a
+   * card measured against the wrong list is one glance away from a card the
+   * bleed rule simply missed. The card's own width is `listWidth - leftGap -
+   * rightGap`, so it is not repeated here.
+   */
+  listWidth: number
   /** Distance from the card's right side to the list's padding-box right edge. */
   rightGap: number
   /** Distance from the list's padding-box left edge to the card's left side. */
@@ -250,9 +399,7 @@ export interface BubbleEdges {
  *
  * One rule runs a user message and a plan execution to the right edge, so both
  * specs measure through this function and cannot drift apart on how they read
- * the box. `clientLeft` is the list's left border and `clientWidth` stops before
- * a native scrollbar, so the right edge tracks the same padding box that
- * {@link measureAgainstChatList} reads, whichever scrollbar the list is wearing.
+ * the box.
  *
  * `topGapInRow` is the vertical half: the ROW places its bubble on both axes, so
  * a card's top edge must sit on its row's. It is what a bubble-level `alignSelf`
@@ -260,23 +407,10 @@ export interface BubbleEdges {
  * that line.
  */
 export async function measureBubbleEdges(locator: Locator): Promise<BubbleEdges> {
-  return locator.evaluate((el, selector) => {
-    const list = el.closest(selector)
-    if (!list)
-      throw new Error('measureBubbleEdges: element is not inside the chat scroll container')
-    const row = el.parentElement
-    if (!row)
-      throw new Error('measureBubbleEdges: element has no row to measure against')
-    const listRect = list.getBoundingClientRect()
-    const self = el.getBoundingClientRect()
-    const padLeft = listRect.left + list.clientLeft
-    return {
-      rightGap: padLeft + list.clientWidth - self.right,
-      leftGap: self.left - padLeft,
-      topGapInRow: self.top - row.getBoundingClientRect().top,
-      radius: globalThis.getComputedStyle(el).borderTopRightRadius,
-    }
-  }, CHAT_SCROLL_CONTAINER)
+  const { listWidth, rightGap, leftGap, topGapInRow, radius } = await measureChatBox(locator, 'measureBubbleEdges')
+  if (topGapInRow === null)
+    throw new Error('measureBubbleEdges: element has no row to measure against')
+  return { listWidth, rightGap, leftGap, topGapInRow, radius }
 }
 
 /**


### PR DESCRIPTION
Closes #402

## Motivation

Test `040` measures the edges of a user bubble. It failed in combined runs and
passed alone, with the error `measureBubbleEdges: element is not inside the chat
scroll container` (#402). Three possible causes were listed. Nobody confirmed
one.

A probe measured the cause. It sent one message, then it read the bubble 400
times. Each read resolved the locator first, then evaluated against the result.
One read returned a node whose `isConnected` was false. That node left the
document.

A locator resolve and the read that follows it are two browser round trips. A
chat row does not survive the gap. Each send replaces the row about 350ms later,
when the optimistic local reconciles to its server echo. The echo carries a
different id and a different seq, so ChatView builds a new row.

A detached node reports an empty rect, a null `closest()`, and no computed style
at all. A geometry assertion therefore fails at random. An assertion that only
compares two colours PASSES instead, because it compares a real colour against
the empty string. Test `033` held such an assertion.

The same investigation found a second defect, which the user sees. For about
250ms after each send, the user's own message showed the text "Unsupported agent
provider: Unknown (0)". The row pulsed, and it was 32px narrower than the row
that replaced it. This occurred in 3 runs of 4.

The optimistic bubble takes its provider from the agent tab. A tab from the CRDT
projection carries no `agentProvider`. The hub removes the worker-side payload,
because the worker holds it under end-to-end encryption (E2EE), and
`useTabHydrators` fetches it separately. Before that fetch answers, the bubble
declares UNSPECIFIED. No plugin matches it, so `classifyMessage` returned
`unsupported_provider`.

That answer also changed the geometry. `unsupported_provider` is a META kind, so
the row lost the full-bleed layout of a user row. Its height then differed from
the height of the echo. The echo measured again and hid the row for a further
160ms.

## Modifications

**The chat measurement**

- Add `readAttached` (`tests/e2e/helpers/ui.ts`). It is the one entry point that
  reads a chat row. It gives the callback every match. The callback keeps only
  the elements that remain in the document. A null result retries, under a short
  budget.
- Record that `evaluateAll` does not close the gap. It appears to close it, and
  the first attempt at this fix assumed so. Playwright runs `evaluateAll` as
  `querySelectorAll` into an array handle, then as a second call against that
  handle. The alternative that takes one round trip gives up Playwright's
  `:visible` engine, which keeps the premeasure copy out of every chat locator.
- Read `measureAgainstChatList` and `measureBubbleEdges` through one shared
  page-side reader. The two cannot disagree about how they read the box. Each
  failure reports the whole box, not one number.
- Publish `data-chat-premeasure-root`. A measurement that lands on a premeasure
  copy now identifies that copy. Before, it reported the error of a row that
  remounted.
- Convert the chat-row reads in `033`, `040`, `041`, and `047b`. One of them was
  the assertion that passed against an empty computed style.
- Add the guard `src/test-support/chatRowReads.test.ts`. The flake is rare, so it
  survives several runs that pass.

**The user row**

- Classify LeapMux's own flat `{content, attachments?}` user payload without a
  provider. Two comparable rules exist already: one for a persisted control
  response, and one for a worker-authored notification. The new rule returns the
  same `user_content` that a registered plugin returns, so the echo does not
  classify differently.
- Draw that kind with the shared `UserContentMessage` when no plugin claims the
  row. Before, the renderer drew the raw-JSON span.
- Carry the message source into `ClassificationInput`, so the rule can test the
  source. A plugin must not read the source. A plugin identifies its own wire
  format by shape.
- Keep `unsupported_provider` for every other case. An AGENT, UNSPECIFIED, or
  LEAPMUX source, a `type`-tagged envelope, a notification thread, and a row
  without a content string all still return it.

## Result

A probe replaced its element on each event-loop turn. Under that probe, the old
form failed 22 of 25 reads, and 24 of 25 on a second run. The new form failed
none of 75.

A send now shows the user's words in the first frame, in the correct card. The
hidden gap after the echo swap fell from about 160ms to one frame.

11,021 unit tests in 604 files pass. `task lint` reports 0 issues. Each new test
survived a mutation check: a revert of the behaviour that it covers makes the
test fail.

A full E2E run followed, because #402 appears only in a local full-suite run:
the suite is too heavy for CI. Every test that this PR touches passed in that
run. `040` passed all 8 of its tests, and `033`, `041`, `047b`, and `050` pass.
None of the three error signatures appeared:

- `measureBubbleEdges: element is not inside the chat scroll container` — 0
  occurrences
- `Unsupported agent provider` — 0 occurrences
- the `rightGap` diagnostic — 0 occurrences. One unexplained value,
  `rightGap = 193`, appeared once during development. It did not appear again
  under the load that produced it.
