### PR TITLE
fix(agent): Stop racing ACP terminal Running status

### DIFF
--- a/backend/internal/worker/agent/acp_terminal_test.go
+++ b/backend/internal/worker/agent/acp_terminal_test.go
@@ -133,6 +133,8 @@ func TestACPTerminal_CreateWaitOutputRelease(t *testing.T) {
 	// upserted first (see terminalCreate), which a live snapshot cannot.
 	require.NotEmpty(t, statusLog)
 	assert.Equal(t, bgtask.StatusRunning, statusLog[0])
+	assert.Contains(t, []bgtask.Status{bgtask.StatusRunning, bgtask.StatusCompleted}, row.Status,
+		"create must leave the row Running or already Completed, not Failed/Stopped")
 	assert.Equal(t, "printf 'hello-acp'", row.Title)
 	// terminal/create carries the command and nothing else, so this title IS the
 	// command and the client may set it as code -- unlike Claude's shell rows,
@@ -167,8 +169,10 @@ func TestACPTerminal_CreateWaitOutputRelease(t *testing.T) {
 
 	sink.bgTasksMu.Lock()
 	row = sink.bgTasks[termID]
+	statusLog = append([]bgtask.Status(nil), sink.bgTaskStatuses[termID]...)
 	sink.bgTasksMu.Unlock()
 	assert.Equal(t, bgtask.StatusCompleted, row.Status)
+	assert.Equal(t, []bgtask.Status{bgtask.StatusRunning, bgtask.StatusCompleted}, statusLog)
 
 	b.terminalsMu.Lock()
 	_, still := b.terminals[termID]
@@ -647,8 +651,9 @@ func TestACPTerminal_OutputBeforeExitOmitsExitStatus(t *testing.T) {
 	termID := resps[0]["result"].(map[string]interface{})["terminalId"].(string)
 
 	sink.bgTasksMu.Lock()
-	row := sink.bgTasks[termID]
+	row, ok := sink.bgTasks[termID]
 	sink.bgTasksMu.Unlock()
+	require.True(t, ok, "create must upsert a background-task row")
 	assert.Equal(t, bgtask.StatusRunning, row.Status, "a still-running sleep must stay Running")
 
 	dispatchTerminal(b, acpMethodTerminalOutput, 2, map[string]interface{}{

--- a/backend/internal/worker/agent/acp_terminal_test.go
+++ b/backend/internal/worker/agent/acp_terminal_test.go
@@ -125,10 +125,14 @@ func TestACPTerminal_CreateWaitOutputRelease(t *testing.T) {
 
 	sink.bgTasksMu.Lock()
 	row, ok := sink.bgTasks[termID]
+	statusLog := append([]bgtask.Status(nil), sink.bgTaskStatuses[termID]...)
 	sink.bgTasksMu.Unlock()
 	require.True(t, ok)
 	assert.Equal(t, bgtask.KindShell, row.Kind)
-	assert.Equal(t, bgtask.StatusRunning, row.Status)
+	// printf often exits before this read; the status trail proves Running was
+	// upserted first (see terminalCreate), which a live snapshot cannot.
+	require.NotEmpty(t, statusLog)
+	assert.Equal(t, bgtask.StatusRunning, statusLog[0])
 	assert.Equal(t, "printf 'hello-acp'", row.Title)
 	// terminal/create carries the command and nothing else, so this title IS the
 	// command and the client may set it as code -- unlike Claude's shell rows,
@@ -641,6 +645,11 @@ func TestACPTerminal_OutputBeforeExitOmitsExitStatus(t *testing.T) {
 	})
 	resps := rec.wait(t, 1, 3*time.Second)
 	termID := resps[0]["result"].(map[string]interface{})["terminalId"].(string)
+
+	sink.bgTasksMu.Lock()
+	row := sink.bgTasks[termID]
+	sink.bgTasksMu.Unlock()
+	assert.Equal(t, bgtask.StatusRunning, row.Status, "a still-running sleep must stay Running")
 
 	dispatchTerminal(b, acpMethodTerminalOutput, 2, map[string]interface{}{
 		"sessionId":  "sess-1",

--- a/backend/internal/worker/agent/sink_fake_parity_test.go
+++ b/backend/internal/worker/agent/sink_fake_parity_test.go
@@ -46,3 +46,42 @@ func TestTestSinkKeysRowsTheWayProductionDoes(t *testing.T) {
 	assert.Equal(t, bgtask.StatusCompleted, rows[0].Status)
 	assert.Equal(t, "working", rows[0].ActiveForm)
 }
+
+// Distinct status writes form a trail so a fast Close cannot hide that Running
+// landed first. No-op and absorbed writes must not pad the trail.
+func TestTestSinkRecordsDistinctBackgroundTaskStatuses(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	require.NoError(t, sink.UpsertBackgroundTask(bgtask.Upsert{
+		RowKey: "term_1", Kind: bgtask.KindShell, Title: "printf hi", Status: bgtask.StatusRunning,
+	}))
+	// Same status again: active-form-only update must not pad the trail.
+	require.NoError(t, sink.UpdateBackgroundTaskStatus("term_1", bgtask.StatusRunning, "still going"))
+	require.NoError(t, sink.UpsertBackgroundTask(bgtask.Upsert{
+		RowKey: "term_1", Kind: bgtask.KindShell, Title: "printf hi", Status: bgtask.StatusRunning,
+	}))
+	require.NoError(t, sink.CloseBackgroundTask("term_1", bgtask.StatusCompleted))
+	// First close wins: a second close must not append.
+	require.NoError(t, sink.CloseBackgroundTask("term_1", bgtask.StatusFailed))
+	// Absorbed non-final upsert must not append either.
+	require.NoError(t, sink.UpsertBackgroundTask(bgtask.Upsert{
+		RowKey: "term_1", Kind: bgtask.KindShell, Title: "printf hi", Status: bgtask.StatusRunning,
+	}))
+
+	sink.bgTasksMu.Lock()
+	log := append([]bgtask.Status(nil), sink.bgTaskStatuses["term_1"]...)
+	row := sink.bgTasks["term_1"]
+	sink.bgTasksMu.Unlock()
+
+	assert.Equal(t, []bgtask.Status{bgtask.StatusRunning, bgtask.StatusCompleted}, log)
+	assert.Equal(t, bgtask.StatusCompleted, row.Status)
+
+	require.NoError(t, sink.ReviveBackgroundTask("term_1"))
+	sink.bgTasksMu.Lock()
+	log = append([]bgtask.Status(nil), sink.bgTaskStatuses["term_1"]...)
+	sink.bgTasksMu.Unlock()
+	assert.Equal(t, []bgtask.Status{
+		bgtask.StatusRunning, bgtask.StatusCompleted, bgtask.StatusRunning,
+	}, log)
+}

--- a/backend/internal/worker/agent/sink_test.go
+++ b/backend/internal/worker/agent/sink_test.go
@@ -64,9 +64,11 @@ type testSink struct {
 	childIDVal  string
 	// bgTasks records the latest registry state per row key (owner == this sink).
 	bgTasks map[string]bgtask.Item
-	// bgTaskStatuses records every status write per row key, in order. A
-	// fast-exiting shell can Close before a test reads bgTasks, so the trail
-	// is the only way to prove Running landed first.
+	// bgTaskStatuses records distinct status values per row key, in order.
+	// A fast-exiting shell can Close before a test reads bgTasks, so the
+	// trail is the only way to prove Running landed first. Duplicate writes
+	// (no-op upsert, absorbed reject) are skipped so length asserts stay
+	// meaningful.
 	bgTaskStatuses map[string][]bgtask.Status
 	// revivedTasks records every row key ReviveBackgroundTask actually reopened,
 	// in order. The effect alone cannot prove the call: a revive leaves the row
@@ -554,7 +556,11 @@ func (s *testSink) recordBgTaskStatusLocked(rowKey string, status bgtask.Status)
 	if s.bgTaskStatuses == nil {
 		s.bgTaskStatuses = make(map[string][]bgtask.Status)
 	}
-	s.bgTaskStatuses[rowKey] = append(s.bgTaskStatuses[rowKey], status)
+	log := s.bgTaskStatuses[rowKey]
+	if len(log) > 0 && log[len(log)-1] == status {
+		return
+	}
+	s.bgTaskStatuses[rowKey] = append(log, status)
 }
 
 func (s *testSink) UpdateBackgroundTaskStatus(rowKey string, status bgtask.Status, activeForm string) error {

--- a/backend/internal/worker/agent/sink_test.go
+++ b/backend/internal/worker/agent/sink_test.go
@@ -64,6 +64,10 @@ type testSink struct {
 	childIDVal  string
 	// bgTasks records the latest registry state per row key (owner == this sink).
 	bgTasks map[string]bgtask.Item
+	// bgTaskStatuses records every status write per row key, in order. A
+	// fast-exiting shell can Close before a test reads bgTasks, so the trail
+	// is the only way to prove Running landed first.
+	bgTaskStatuses map[string][]bgtask.Status
 	// revivedTasks records every row key ReviveBackgroundTask actually reopened,
 	// in order. The effect alone cannot prove the call: a revive leaves the row
 	// running, which is also how it looked before it ever finished.
@@ -542,7 +546,15 @@ func (s *testSink) UpsertBackgroundTask(task bgtask.Upsert) error {
 		item.EndedAt = testFakeEndedAt
 	}
 	s.bgTasks[task.RowKey] = item
+	s.recordBgTaskStatusLocked(task.RowKey, item.Status)
 	return nil
+}
+
+func (s *testSink) recordBgTaskStatusLocked(rowKey string, status bgtask.Status) {
+	if s.bgTaskStatuses == nil {
+		s.bgTaskStatuses = make(map[string][]bgtask.Status)
+	}
+	s.bgTaskStatuses[rowKey] = append(s.bgTaskStatuses[rowKey], status)
 }
 
 func (s *testSink) UpdateBackgroundTaskStatus(rowKey string, status bgtask.Status, activeForm string) error {
@@ -561,6 +573,7 @@ func (s *testSink) UpdateBackgroundTaskStatus(rowKey string, status bgtask.Statu
 		item.Status = status
 		item.ActiveForm = activeForm
 		s.bgTasks[rowKey] = item
+		s.recordBgTaskStatusLocked(rowKey, status)
 	}
 	return nil
 }
@@ -578,6 +591,7 @@ func (s *testSink) CloseBackgroundTask(rowKey string, status bgtask.Status) erro
 		item.Status = status
 		item.EndedAt = testFakeEndedAt
 		s.bgTasks[rowKey] = item
+		s.recordBgTaskStatusLocked(rowKey, status)
 	}
 	return nil
 }
@@ -620,6 +634,7 @@ func (s *testSink) ReviveBackgroundTask(rowKey string) error {
 	item.Description = ""
 	item.EndedAt = time.Time{}
 	s.bgTasks[rowKey] = item
+	s.recordBgTaskStatusLocked(rowKey, item.Status)
 	s.revivedTasks = append(s.revivedTasks, rowKey)
 	return nil
 }


### PR DESCRIPTION
## Problem

[CI job](https://github.com/leapmux/leapmux/actions/runs/32624015275/job/97156453795) failed on `linux (arm64)` with:

`TestACPTerminal_CreateWaitOutputRelease` expected `StatusRunning` (1), got `StatusCompleted` (2).

`terminal/create` upserts Running, then starts waiters and replies. For `printf 'hello-acp'`, the child can exit and `CloseBackgroundTask` can land Completed before the test reads the live sink row. Production order is correct; the live-snapshot assertion was racy.

## Fix

- Record distinct background-task status transitions on `testSink`
- Assert the first recorded status was Running (proves upsert-before-close)
- Constrain the live post-create status to Running or Completed
- Assert live Running while a `sleep 30` terminal is still in flight (with row-exists check)
- Assert the full Running→Completed trail after release
- Unit-test trail dedupe, absorb, and revive