### PR TITLE
fix(sendq): Close Flush race after a failed write

### DIFF
--- a/backend/internal/hub/workermgr/conn.go
+++ b/backend/internal/hub/workermgr/conn.go
@@ -247,12 +247,15 @@ func (c *Conn) SendControl(msg *leapmuxv1.ConnectResponse) error {
 // tore down before delivery -- not success.
 //
 // A write-error give-up Fences this conn (OnGiveUp), which cancels the writer
-// context Flush may be selecting on. That cancel is mapped to
-// ErrConnectionClosed when GaveUp is set, so callers do not see a bare
-// context.Canceled for a Hub-side reclaim.
+// context Flush may be selecting on. sendq usually returns ErrClosed once
+// torn down; if Flush still surfaces that cancel/deadline, map it to
+// ErrConnectionClosed only when GaveUp is set -- not every error.
 func (c *Conn) Flush(ctx context.Context) error {
 	if err := c.q.Flush(ctx); err != nil {
-		if errors.Is(err, sendq.ErrClosed) || c.GaveUp() {
+		if errors.Is(err, sendq.ErrClosed) {
+			return ErrConnectionClosed
+		}
+		if c.GaveUp() && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
 			return ErrConnectionClosed
 		}
 		return err

--- a/backend/internal/hub/workermgr/conn.go
+++ b/backend/internal/hub/workermgr/conn.go
@@ -245,9 +245,14 @@ func (c *Conn) SendControl(msg *leapmuxv1.ConnectResponse) error {
 // Its only escape besides a drain is the caller's deadline or a fence; every
 // caller MUST pass a bounded context. ErrConnectionClosed means the queue
 // tore down before delivery -- not success.
+//
+// A write-error give-up Fences this conn (OnGiveUp), which cancels the writer
+// context Flush may be selecting on. That cancel is mapped to
+// ErrConnectionClosed when GaveUp is set, so callers do not see a bare
+// context.Canceled for a Hub-side reclaim.
 func (c *Conn) Flush(ctx context.Context) error {
 	if err := c.q.Flush(ctx); err != nil {
-		if errors.Is(err, sendq.ErrClosed) {
+		if errors.Is(err, sendq.ErrClosed) || c.GaveUp() {
 			return ErrConnectionClosed
 		}
 		return err

--- a/backend/internal/hub/workermgr/conn.go
+++ b/backend/internal/hub/workermgr/conn.go
@@ -295,6 +295,13 @@ func (c *Conn) GaveUp() bool {
 	return c.q.GaveUp()
 }
 
+// WritePanicked reports whether a transport Write panic latched this
+// connection's queue closed without giveUp. classifyNotifyErr reads it so a
+// panicking stream is filed as Hub-side failure, not "worker already gone".
+func (c *Conn) WritePanicked() bool {
+	return c.q.WritePanicked()
+}
+
 // EncryptionMode returns the encryption mode cached from the worker's
 // heartbeat. Safe for concurrent use with SetEncryptionMode.
 func (c *Conn) EncryptionMode() leapmuxv1.EncryptionMode {

--- a/backend/internal/hub/workermgr/conn_test.go
+++ b/backend/internal/hub/workermgr/conn_test.go
@@ -431,6 +431,48 @@ func TestConnFlushReturnsErrConnectionClosedOnWriteError(t *testing.T) {
 	assert.True(t, conn.GaveUp())
 }
 
+// Caller Flush deadline on a still-open queue must stay a deadline error.
+// Mapping every cancel to ErrConnectionClosed would hide a live slow peer.
+func TestConnFlushPreservesCallerDeadlineWhenQueueStillOpen(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	release := make(chan struct{})
+	defer close(release)
+	var writeStarted sync.WaitGroup
+	writeStarted.Add(1)
+	conn, pump := NewConn(ctx, cancel, "w1", "u1", sendq.NewMaxBytesPoolForTest(), func(*leapmuxv1.ConnectResponse) error {
+		writeStarted.Done()
+		<-release
+		return nil
+	}, nil)
+	t.Cleanup(conn.Fence)
+
+	go func() {
+		for {
+			select {
+			case <-pump.Ready():
+				_ = pump.Drain()
+			case <-conn.Done():
+				return
+			}
+		}
+	}()
+
+	require.NoError(t, conn.SendControl(&leapmuxv1.ConnectResponse{
+		Payload: &leapmuxv1.ConnectResponse_Heartbeat{Heartbeat: &leapmuxv1.Heartbeat{}},
+	}))
+	writeStarted.Wait()
+
+	flushCtx, flushCancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer flushCancel()
+	err := conn.Flush(flushCtx)
+	require.ErrorIs(t, err, context.DeadlineExceeded,
+		"Flush must not map a caller deadline to ErrConnectionClosed while the queue is open")
+	assert.False(t, conn.GaveUp())
+	assert.NotErrorIs(t, err, ErrConnectionClosed)
+}
+
 func TestSendPumpDrainTurnBoundsBatchAndResignals(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/backend/internal/hub/workermgr/conn_test.go
+++ b/backend/internal/hub/workermgr/conn_test.go
@@ -3,6 +3,7 @@ package workermgr
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -384,6 +385,50 @@ func TestConnFlushReturnsErrConnectionClosedAfterDiscard(t *testing.T) {
 	defer flushCancel()
 	assert.ErrorIs(t, conn.Flush(flushCtx), ErrConnectionClosed,
 		"Flush must map a discarded queue to ErrConnectionClosed, not success")
+}
+
+func TestConnFlushReturnsErrConnectionClosedOnWriteError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	release := make(chan struct{})
+	var writeStarted sync.WaitGroup
+	writeStarted.Add(1)
+	conn, pump := NewConn(ctx, cancel, "w1", "u1", sendq.NewMaxBytesPoolForTest(), func(*leapmuxv1.ConnectResponse) error {
+		writeStarted.Done()
+		<-release
+		return fmt.Errorf("connection reset")
+	}, nil)
+	t.Cleanup(conn.Fence)
+
+	go func() {
+		for {
+			select {
+			case <-pump.Ready():
+				_ = pump.Drain()
+			case <-conn.Done():
+				return
+			}
+		}
+	}()
+
+	require.NoError(t, conn.SendControl(&leapmuxv1.ConnectResponse{
+		Payload: &leapmuxv1.ConnectResponse_Heartbeat{Heartbeat: &leapmuxv1.Heartbeat{}},
+	}))
+	writeStarted.Wait()
+
+	flushed := make(chan error, 1)
+	flushCtx, flushCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer flushCancel()
+	go func() { flushed <- conn.Flush(flushCtx) }()
+	close(release)
+
+	select {
+	case err := <-flushed:
+		require.ErrorIs(t, err, ErrConnectionClosed,
+			"Flush must map a refused write to ErrConnectionClosed, not success")
+	case <-time.After(3 * time.Second):
+		t.Fatal("Flush never returned after the write failed")
+	}
+	assert.True(t, conn.GaveUp())
 }
 
 func TestSendPumpDrainTurnBoundsBatchAndResignals(t *testing.T) {

--- a/backend/internal/hub/workermgr/manager.go
+++ b/backend/internal/hub/workermgr/manager.go
@@ -493,6 +493,9 @@ const (
 //   - Conn.GaveUp: the queue's give-up callback fenced on a write timeout, a
 //     blown budget, or pool pressure. Without this the Hub reclaiming a slow
 //     worker reads as that worker having left.
+//   - Conn.WritePanicked: a transport Write panic latched the queue closed
+//     without giveUp (handler recover Fences). Same ErrConnectionClosed from
+//     Flush as a departed worker, but the Hub tore the stream down.
 //   - ctx.Err(): the caller's own budget expired, and NotifyShutdownAndFence
 //     fences everything on its way out -- so past this point Done() is a channel
 //     the Hub closed itself and says nothing about the worker.
@@ -505,7 +508,7 @@ func classifyNotifyErr(ctx context.Context, conn *Conn, err error) notifyOutcome
 	switch {
 	case err == nil:
 		return notifyDelivered
-	case errors.Is(err, ErrControlSaturated), conn.GaveUp(), ctx.Err() != nil:
+	case errors.Is(err, ErrControlSaturated), conn.GaveUp(), conn.WritePanicked(), ctx.Err() != nil:
 		return notifyFailed
 	case errors.Is(err, ErrConnectionClosed):
 		return notifyAlreadyGone

--- a/backend/internal/hub/workermgr/manager_shutdown_test.go
+++ b/backend/internal/hub/workermgr/manager_shutdown_test.go
@@ -579,6 +579,40 @@ func TestClassifyNotifyErr(t *testing.T) {
 		require.True(t, conn.GaveUp(), "fixture must model a queue the Hub gave up on")
 		return conn
 	}
+	// A Write panic latches closed without giveUp (handler Fence owns teardown).
+	// Flush still returns ErrConnectionClosed; without WritePanicked this files
+	// as "worker already gone" and hides a Hub-side stream failure.
+	writePanickedConn := func(t *testing.T) *Conn {
+		t.Helper()
+		release := make(chan struct{})
+		var writeStarted sync.WaitGroup
+		writeStarted.Add(1)
+		conn, pump := newTestConn(t, "write-panic", func(*leapmuxv1.ConnectResponse) error {
+			writeStarted.Done()
+			<-release
+			panic("transport exploded")
+		}, nil)
+		pumpStart(t, pump, conn)
+		require.NoError(t, conn.SendControl(&leapmuxv1.ConnectResponse{}))
+		writeStarted.Wait()
+
+		flushed := make(chan error, 1)
+		ctx, cancel := boundedNotifyCtx(t)
+		defer cancel()
+		go func() { flushed <- conn.Flush(ctx) }()
+		close(release)
+
+		select {
+		case err := <-flushed:
+			require.ErrorIs(t, err, ErrConnectionClosed,
+				"Flush must surface the panicking write; nil is a Delivered mis-count")
+		case <-time.After(3 * time.Second):
+			t.Fatal("Flush never returned after the write panicked")
+		}
+		require.True(t, conn.WritePanicked(), "fixture must model a panicking Write latch")
+		require.False(t, conn.GaveUp(), "panic must not set GaveUp inside writeTurn")
+		return conn
+	}
 	expired := func(t *testing.T) context.Context {
 		t.Helper()
 		ctx, cancel := context.WithCancel(context.Background())
@@ -603,6 +637,14 @@ func TestClassifyNotifyErr(t *testing.T) {
 			// operator can act on.
 			name: "hub gave up on the queue",
 			conn: gaveUpConn,
+			err:  ErrConnectionClosed,
+			want: notifyFailed,
+		},
+		{
+			// Write panic: same ErrConnectionClosed from Flush, gaveUp still
+			// false (Fence recovers), but WritePanicked marks Hub-side failure.
+			name: "transport write panicked",
+			conn: writePanickedConn,
 			err:  ErrConnectionClosed,
 			want: notifyFailed,
 		},

--- a/backend/internal/hub/workermgr/manager_shutdown_test.go
+++ b/backend/internal/hub/workermgr/manager_shutdown_test.go
@@ -574,7 +574,8 @@ func TestClassifyNotifyErr(t *testing.T) {
 		require.NoError(t, conn.SendControl(&leapmuxv1.ConnectResponse{}))
 		ctx, cancel := boundedNotifyCtx(t)
 		defer cancel()
-		_ = conn.Flush(ctx)
+		require.ErrorIs(t, conn.Flush(ctx), ErrConnectionClosed,
+			"Flush must surface the write failure; nil here is the sendq race that mis-counts Delivered")
 		require.True(t, conn.GaveUp(), "fixture must model a queue the Hub gave up on")
 		return conn
 	}

--- a/backend/internal/hub/workermgr/manager_shutdown_test.go
+++ b/backend/internal/hub/workermgr/manager_shutdown_test.go
@@ -199,6 +199,10 @@ func TestNotifyShutdownAndFence_ContinuesOnSendError(t *testing.T) {
 	// error is the way to reach them. Asserted here because a broken transport
 	// fences the conn on its way out, so without the give-up latch this reports
 	// as the worker having left and the warning silently becomes a Debug line.
+	//
+	// That latch lives in sendq.writeTurn: giveUp runs before finishWrite, or
+	// Flush can return nil on a refused write and this tally becomes
+	// Delivered:2 Failed:0 (see TestWriterFlushReturnsErrClosedWhenWriteFails).
 	assert.Equal(t, ShutdownNotifyResult{Delivered: 1, Failed: 1, Total: 2}, got)
 	assert.Contains(t, logs.String(), "failed to send shutdown notification to worker")
 	assert.Contains(t, logs.String(), "level=WARN")

--- a/backend/internal/sendq/sendq.go
+++ b/backend/internal/sendq/sendq.go
@@ -778,10 +778,15 @@ func (w *Writer[T]) signalDrained() {
 //
 // Returns nil only when the queue is idle (empty and not writing) while the
 // writer is still open. Returns ErrClosed if the writer closed or gave up --
-// including when Close discarded queued frames -- so a caller that needs
-// "reached the wire" (shutdown notify) cannot mistakingly treat a discard as
-// success. Returns ctx.Err / the writer's context error when the wait was cut
-// short while frames were still drainable.
+// including when Close discarded queued frames, and when a refused or
+// panicking Write latched the writer torn down -- so a caller that needs
+// "reached the wire" (shutdown notify) cannot mistakingly treat a failed
+// delivery as success.
+//
+// Returns ctx.Err / the writer's context error only when the wait was cut
+// short while the writer was still open and able to deliver. If a cancel
+// races a give-up or close, Flush prefers ErrClosed: the frame did not
+// reach the wire, regardless of which deadline fired first.
 //
 // A refused or panicking Write latches the writer closed before finishWrite
 // clears the in-flight flag, so Flush cannot observe idle+open after the
@@ -813,36 +818,24 @@ func (w *Writer[T]) Flush(ctx context.Context) error {
 		select {
 		case <-drained:
 		case <-ctx.Done():
-			// Give-up may have raced the caller's budget; prefer ErrClosed when
-			// the writer is already idle and torn down.
 			w.mu.Lock()
-			idle = len(w.queue) == 0 && !w.writing
 			tornDown = w.closed || w.gaveUp
 			w.mu.Unlock()
-			if idle && tornDown {
+			if tornDown {
 				return ErrClosed
 			}
 			return ctx.Err()
 		case <-w.ctx.Done():
-			// OnGiveUp often Fences (cancels w.ctx) before finishWrite clears
-			// writing. Do not return that cancel while a give-up is still
-			// finishing the refused frame -- wait for idle, then ErrClosed.
+			// OnGiveUp often Fences (cancels w.ctx) during give-up. Prefer
+			// ErrClosed whenever the writer is already torn down, whether or
+			// not finishWrite has cleared writing yet.
 			w.mu.Lock()
-			idle = len(w.queue) == 0 && !w.writing
 			tornDown = w.closed || w.gaveUp
-			drained = w.drained
 			w.mu.Unlock()
-			if !tornDown {
-				return w.ctx.Err()
-			}
-			if idle {
+			if tornDown {
 				return ErrClosed
 			}
-			select {
-			case <-drained:
-			case <-ctx.Done():
-				return ctx.Err()
-			}
+			return w.ctx.Err()
 		}
 	}
 }

--- a/backend/internal/sendq/sendq.go
+++ b/backend/internal/sendq/sendq.go
@@ -783,6 +783,13 @@ func (w *Writer[T]) signalDrained() {
 // success. Returns ctx.Err / the writer's context error when the wait was cut
 // short while frames were still drainable.
 //
+// A transport write error gives up before finishWrite clears the in-flight
+// flag, so Flush cannot observe idle+open after a refused write. A panicking
+// Write is different: finishWrite still runs before the outer recover /
+// Fence, so a Flush racing that unwind can still see a brief idle+open window.
+// Panic recovery must not give up inside writeTurn (handler-drained Fence
+// leaves gaveUp false for the watchdog test), so that window stays.
+//
 // This is what makes a graceful shutdown's last words actually leave the
 // machine. Enqueue and EnqueueWait return once a frame is QUEUED, so a caller
 // that broadcasts and then tears the connection down is racing the drain
@@ -974,9 +981,8 @@ func (w *Writer[T]) DrainLimited(lim DrainLimits) error {
 		// relief to write latency for no functional reason.
 		w.signalBudgetFreed()
 		if err := w.writeTurn(frame.item); err != nil {
-			// writeTurn already gave up on a transport error (or found the
-			// writer closed). Do not clear writing here -- writeTurn pairs
-			// giveUp with finishWrite so Flush cannot observe idle+open.
+			// writeTurn owns give-up and finishWrite for this frame. Returning
+			// here avoids a second giveUp after writing has already cleared.
 			return err
 		}
 	}
@@ -992,7 +998,8 @@ func (w *Writer[T]) DrainLimited(lim DrainLimits) error {
 // delivered frame the peer had already refused. Panic must NOT give up here:
 // the handler-drained path recovers with Fence/Close and leaves gaveUp false
 // so the write watchdog stays the thing that proves a late timer was disarmed
-// (see TestWriterPanickingWriteDisarmsTheWatchdog).
+// (see TestWriterPanickingWriteDisarmsTheWatchdog). That choice leaves a brief
+// idle+open window for Flush across a panicking Write; see Flush's docs.
 //
 // Both drain modes catch that unwind, one layer up: a handler-drained writer
 // unwinds into workermgr.SendPump.drain, a goroutine-drained one (sendq.New --

--- a/backend/internal/sendq/sendq.go
+++ b/backend/internal/sendq/sendq.go
@@ -783,12 +783,11 @@ func (w *Writer[T]) signalDrained() {
 // success. Returns ctx.Err / the writer's context error when the wait was cut
 // short while frames were still drainable.
 //
-// A transport write error gives up before finishWrite clears the in-flight
-// flag, so Flush cannot observe idle+open after a refused write. A panicking
-// Write is different: finishWrite still runs before the outer recover /
-// Fence, so a Flush racing that unwind can still see a brief idle+open window.
-// Panic recovery must not give up inside writeTurn (handler-drained Fence
-// leaves gaveUp false for the watchdog test), so that window stays.
+// A refused or panicking Write latches the writer closed before finishWrite
+// clears the in-flight flag, so Flush cannot observe idle+open after the
+// transport failed. A panic still does not set gaveUp inside writeTurn -- the
+// handler-drained path recovers with Fence/Close and needs gaveUp false for
+// the watchdog test -- but it does set closed, which is enough for Flush.
 //
 // This is what makes a graceful shutdown's last words actually leave the
 // machine. Enqueue and EnqueueWait return once a frame is QUEUED, so a caller
@@ -814,9 +813,36 @@ func (w *Writer[T]) Flush(ctx context.Context) error {
 		select {
 		case <-drained:
 		case <-ctx.Done():
+			// Give-up may have raced the caller's budget; prefer ErrClosed when
+			// the writer is already idle and torn down.
+			w.mu.Lock()
+			idle = len(w.queue) == 0 && !w.writing
+			tornDown = w.closed || w.gaveUp
+			w.mu.Unlock()
+			if idle && tornDown {
+				return ErrClosed
+			}
 			return ctx.Err()
 		case <-w.ctx.Done():
-			return w.ctx.Err()
+			// OnGiveUp often Fences (cancels w.ctx) before finishWrite clears
+			// writing. Do not return that cancel while a give-up is still
+			// finishing the refused frame -- wait for idle, then ErrClosed.
+			w.mu.Lock()
+			idle = len(w.queue) == 0 && !w.writing
+			tornDown = w.closed || w.gaveUp
+			drained = w.drained
+			w.mu.Unlock()
+			if !tornDown {
+				return w.ctx.Err()
+			}
+			if idle {
+				return ErrClosed
+			}
+			select {
+			case <-drained:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
 		}
 	}
 }
@@ -992,23 +1018,28 @@ func (w *Writer[T]) DrainLimited(lim DrainLimits) error {
 // when Write PANICS. The flag left set would park every later Flush on this
 // writer until its deadline, and the deferred clear is what survives an unwind.
 //
-// On a transport error, giveUp runs before the deferred finishWrite. The other
-// order left a window where the queue was empty, writing was false, and
-// gaveUp was still unset -- Flush returned nil and shutdown notify counted a
-// delivered frame the peer had already refused. Panic must NOT give up here:
-// the handler-drained path recovers with Fence/Close and leaves gaveUp false
-// so the write watchdog stays the thing that proves a late timer was disarmed
-// (see TestWriterPanickingWriteDisarmsTheWatchdog). That choice leaves a brief
-// idle+open window for Flush across a panicking Write; see Flush's docs.
+// On a transport error, giveUp runs before finishWrite. The other order left a
+// window where the queue was empty, writing was false, and gaveUp was still
+// unset -- Flush returned nil and shutdown notify counted a delivered frame
+// the peer had already refused. On panic, closed is latched (without gaveUp /
+// OnGiveUp) before finishWrite for the same Flush reason; gaveUp stays false
+// so the handler-drained Fence path can still prove the write watchdog was
+// disarmed (see TestWriterPanickingWriteDisarmsTheWatchdog).
 //
 // Both drain modes catch that unwind, one layer up: a handler-drained writer
 // unwinds into workermgr.SendPump.drain, a goroutine-drained one (sendq.New --
 // the frontend relay and the worker's Hub client) into run's own recover. Either
 // way the connection is given up and the process survives. The frame's pool
 // charge is refunded at pop, so it is not leaked on that path either.
-func (w *Writer[T]) writeTurn(item T) error {
-	defer w.finishWrite()
-	err := w.writeItem(item)
+func (w *Writer[T]) writeTurn(item T) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			w.latchClosedAfterTransportFailure()
+			w.finishWrite()
+			panic(r)
+		}
+	}()
+	err = w.writeItem(item)
 	if err != nil && !w.isClosed() {
 		reason := GiveUpWriteError
 		if errors.Is(err, errStalled) {
@@ -1016,7 +1047,30 @@ func (w *Writer[T]) writeTurn(item T) error {
 		}
 		w.giveUp(reason, err)
 	}
+	w.finishWrite()
 	return err
+}
+
+// latchClosedAfterTransportFailure marks the writer closed without giving up,
+// so Flush racing a panicking Write cannot observe idle+open while the
+// handler-drained recover still sees gaveUp false. Does not Detach or call
+// OnGiveUp -- Fence / Close / giveUp own those.
+func (w *Writer[T]) latchClosedAfterTransportFailure() {
+	w.mu.Lock()
+	if w.closed {
+		w.mu.Unlock()
+		return
+	}
+	bytes, frames := w.discardQueueLocked()
+	w.closed = true
+	onDiscard := w.cfg.OnDiscard
+	w.mu.Unlock()
+	w.signalWake()
+	w.signalBudgetFreed()
+	w.signalDrained()
+	if onDiscard != nil && frames > 0 {
+		onDiscard(frames, bytes)
+	}
 }
 
 func (w *Writer[T]) signalWakeIfQueued() {

--- a/backend/internal/sendq/sendq.go
+++ b/backend/internal/sendq/sendq.go
@@ -974,14 +974,9 @@ func (w *Writer[T]) DrainLimited(lim DrainLimits) error {
 		// relief to write latency for no functional reason.
 		w.signalBudgetFreed()
 		if err := w.writeTurn(frame.item); err != nil {
-			if w.isClosed() {
-				return err
-			}
-			reason := GiveUpWriteError
-			if errors.Is(err, errStalled) {
-				reason = GiveUpStall
-			}
-			w.giveUp(reason, err)
+			// writeTurn already gave up on a transport error (or found the
+			// writer closed). Do not clear writing here -- writeTurn pairs
+			// giveUp with finishWrite so Flush cannot observe idle+open.
 			return err
 		}
 	}
@@ -991,6 +986,14 @@ func (w *Writer[T]) DrainLimited(lim DrainLimits) error {
 // when Write PANICS. The flag left set would park every later Flush on this
 // writer until its deadline, and the deferred clear is what survives an unwind.
 //
+// On a transport error, giveUp runs before the deferred finishWrite. The other
+// order left a window where the queue was empty, writing was false, and
+// gaveUp was still unset -- Flush returned nil and shutdown notify counted a
+// delivered frame the peer had already refused. Panic must NOT give up here:
+// the handler-drained path recovers with Fence/Close and leaves gaveUp false
+// so the write watchdog stays the thing that proves a late timer was disarmed
+// (see TestWriterPanickingWriteDisarmsTheWatchdog).
+//
 // Both drain modes catch that unwind, one layer up: a handler-drained writer
 // unwinds into workermgr.SendPump.drain, a goroutine-drained one (sendq.New --
 // the frontend relay and the worker's Hub client) into run's own recover. Either
@@ -998,7 +1001,15 @@ func (w *Writer[T]) DrainLimited(lim DrainLimits) error {
 // charge is refunded at pop, so it is not leaked on that path either.
 func (w *Writer[T]) writeTurn(item T) error {
 	defer w.finishWrite()
-	return w.writeItem(item)
+	err := w.writeItem(item)
+	if err != nil && !w.isClosed() {
+		reason := GiveUpWriteError
+		if errors.Is(err, errStalled) {
+			reason = GiveUpStall
+		}
+		w.giveUp(reason, err)
+	}
+	return err
 }
 
 func (w *Writer[T]) signalWakeIfQueued() {

--- a/backend/internal/sendq/sendq.go
+++ b/backend/internal/sendq/sendq.go
@@ -258,6 +258,11 @@ type Writer[T any] struct {
 	controlBytes int64
 	closed       bool
 	gaveUp       bool
+	// writePanicked is set when a Write panic latched the writer closed without
+	// giveUp. Distinct from gaveUp so the handler-drained Fence path can still
+	// prove the watchdog disarmed without a give-up guard, while shutdown
+	// notify can still file the failure as Hub-side rather than "worker left".
+	writePanicked bool
 	// writing is true from the moment the drain pops a frame until
 	// its Write returns. Flush needs it because pop() removes the frame before
 	// the write happens, so an empty queue alone does not mean the last frame
@@ -780,7 +785,7 @@ func (w *Writer[T]) signalDrained() {
 // writer is still open. Returns ErrClosed if the writer closed or gave up --
 // including when Close discarded queued frames, and when a refused or
 // panicking Write latched the writer torn down -- so a caller that needs
-// "reached the wire" (shutdown notify) cannot mistakingly treat a failed
+// "reached the wire" (shutdown notify) cannot mistakenly treat a failed
 // delivery as success.
 //
 // Returns ctx.Err / the writer's context error only when the wait was cut
@@ -792,7 +797,8 @@ func (w *Writer[T]) signalDrained() {
 // clears the in-flight flag, so Flush cannot observe idle+open after the
 // transport failed. A panic still does not set gaveUp inside writeTurn -- the
 // handler-drained path recovers with Fence/Close and needs gaveUp false for
-// the watchdog test -- but it does set closed, which is enough for Flush.
+// the write-watchdog contract -- but it sets closed and writePanicked, which
+// are enough for Flush and for shutdown notify to file Hub-side failure.
 //
 // This is what makes a graceful shutdown's last words actually leave the
 // machine. Enqueue and EnqueueWait return once a frame is QUEUED, so a caller
@@ -937,6 +943,16 @@ func (w *Writer[T]) GaveUp() bool {
 	return w.gaveUp
 }
 
+// WritePanicked reports whether a transport Write panic latched this writer
+// closed. Distinct from GaveUp: the handler-drained path recovers with Fence
+// and must keep gaveUp false for the write-watchdog contract, but shutdown
+// notify still needs a Hub-side cause when Flush returns ErrClosed.
+func (w *Writer[T]) WritePanicked() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.writePanicked
+}
+
 // Wake returns the depth-1 wake channel that fires when a frame is enqueued
 // (or the writer closes). Exactly one goroutine may select on it: a second
 // consumer would steal the coalesced signal that signalNonBlocking depends on.
@@ -1009,7 +1025,8 @@ func (w *Writer[T]) DrainLimited(lim DrainLimits) error {
 
 // writeTurn writes one frame and always clears the in-flight flag, including
 // when Write PANICS. The flag left set would park every later Flush on this
-// writer until its deadline, and the deferred clear is what survives an unwind.
+// writer until its deadline, and the deferred clear is what survives an unwind
+// -- including a re-panic after the latch, or a panic from OnDiscard during it.
 //
 // On a transport error, giveUp runs before finishWrite. The other order left a
 // window where the queue was empty, writing was false, and gaveUp was still
@@ -1017,7 +1034,8 @@ func (w *Writer[T]) DrainLimited(lim DrainLimits) error {
 // the peer had already refused. On panic, closed is latched (without gaveUp /
 // OnGiveUp) before finishWrite for the same Flush reason; gaveUp stays false
 // so the handler-drained Fence path can still prove the write watchdog was
-// disarmed (see TestWriterPanickingWriteDisarmsTheWatchdog).
+// disarmed (see TestWriterPanickingWriteDisarmsTheWatchdog). writePanicked is
+// set instead so shutdown notify can still file the failure as Hub-side.
 //
 // Both drain modes catch that unwind, one layer up: a handler-drained writer
 // unwinds into workermgr.SendPump.drain, a goroutine-drained one (sendq.New --
@@ -1025,10 +1043,12 @@ func (w *Writer[T]) DrainLimited(lim DrainLimits) error {
 // way the connection is given up and the process survives. The frame's pool
 // charge is refunded at pop, so it is not leaked on that path either.
 func (w *Writer[T]) writeTurn(item T) (err error) {
+	// finishWrite is registered first so it still runs after a re-panic from the
+	// recover defer (and after a panic raised inside the latch itself).
+	defer w.finishWrite()
 	defer func() {
 		if r := recover(); r != nil {
 			w.latchClosedAfterTransportFailure()
-			w.finishWrite()
 			panic(r)
 		}
 	}()
@@ -1040,22 +1060,25 @@ func (w *Writer[T]) writeTurn(item T) (err error) {
 		}
 		w.giveUp(reason, err)
 	}
-	w.finishWrite()
 	return err
 }
 
 // latchClosedAfterTransportFailure marks the writer closed without giving up,
 // so Flush racing a panicking Write cannot observe idle+open while the
-// handler-drained recover still sees gaveUp false. Does not Detach or call
-// OnGiveUp -- Fence / Close / giveUp own those.
+// handler-drained recover still sees gaveUp false. Sets writePanicked so a
+// caller that maps ErrClosed can still tell Hub-side transport failure from a
+// worker that left. Does not Detach or call OnGiveUp -- Fence / Close / giveUp
+// own those.
 func (w *Writer[T]) latchClosedAfterTransportFailure() {
 	w.mu.Lock()
 	if w.closed {
+		w.writePanicked = true
 		w.mu.Unlock()
 		return
 	}
 	bytes, frames := w.discardQueueLocked()
 	w.closed = true
+	w.writePanicked = true
 	onDiscard := w.cfg.OnDiscard
 	w.mu.Unlock()
 	w.signalWake()

--- a/backend/internal/sendq/sendq_test.go
+++ b/backend/internal/sendq/sendq_test.go
@@ -1007,21 +1007,73 @@ func TestWriterFlushReturnsErrClosedWhenWriteFails(t *testing.T) {
 	defer fcancel()
 	go func() { flushed <- w.Flush(fctx) }()
 
-	// Park Flush on the in-flight write, then let Write fail.
-	time.Sleep(20 * time.Millisecond)
+	// Write is in flight (writing=true). Releasing it fails the transport;
+	// giveUp must latch closed before finishWrite or Flush can return nil.
 	close(release)
 
 	select {
 	case err := <-flushed:
-		// A nil return here is the race: finishWrite cleared `writing` before
-		// giveUp latched the writer closed, so Flush saw idle+open and reported
-		// success while the transport had already refused the frame.
 		require.ErrorIs(t, err, ErrClosed,
 			"Flush must not report success when the in-flight write failed")
 	case <-time.After(3 * time.Second):
 		t.Fatal("Flush never returned after the write failed")
 	}
 	assert.True(t, w.GaveUp(), "a write error must give up the writer")
+}
+
+// A panicking Write must still make Flush report ErrClosed, without setting
+// gaveUp inside writeTurn (the handler-drained Fence path needs that false).
+func TestWriterFlushReturnsErrClosedWhenWritePanics(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	release := make(chan struct{})
+	var writeStarted sync.WaitGroup
+	writeStarted.Add(1)
+	w := NewUnstarted(ctx, Config[string]{
+		Write: func(context.Context, string) error {
+			writeStarted.Done()
+			<-release
+			panic("transport exploded")
+		},
+		Size:     func(s string) int { return len(s) },
+		MaxBytes: 1024,
+	})
+	t.Cleanup(w.Close)
+
+	go func() {
+		for {
+			select {
+			case <-w.Wake():
+				func() {
+					defer func() { _ = recover() }()
+					_ = w.Drain()
+				}()
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	require.True(t, w.TryEnqueueControl("frame"))
+	writeStarted.Wait()
+
+	flushed := make(chan error, 1)
+	fctx, fcancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer fcancel()
+	go func() { flushed <- w.Flush(fctx) }()
+	close(release)
+
+	select {
+	case err := <-flushed:
+		require.ErrorIs(t, err, ErrClosed,
+			"Flush must not report success when the in-flight write panicked")
+	case <-time.After(3 * time.Second):
+		t.Fatal("Flush never returned after the write panicked")
+	}
+	assert.False(t, w.GaveUp(), "panic must not give up inside writeTurn")
+	assert.True(t, w.IsClosed(), "panic must latch closed so Flush sees torn-down")
 }
 
 func TestWriterFlushReturnsErrClosedWhenQueueWasDiscarded(t *testing.T) {

--- a/backend/internal/sendq/sendq_test.go
+++ b/backend/internal/sendq/sendq_test.go
@@ -977,7 +977,9 @@ func TestWriterFlushReturnsErrClosedWhenWriteFails(t *testing.T) {
 	release := make(chan struct{})
 	var writeStarted sync.WaitGroup
 	writeStarted.Add(1)
-	w := NewUnstarted(ctx, Config[string]{
+	var gaveUpSawWriting atomic.Bool
+	var w *Writer[string]
+	w = NewUnstarted(ctx, Config[string]{
 		Write: func(context.Context, string) error {
 			writeStarted.Done()
 			<-release
@@ -985,6 +987,14 @@ func TestWriterFlushReturnsErrClosedWhenWriteFails(t *testing.T) {
 		},
 		Size:     func(s string) int { return len(s) },
 		MaxBytes: 1024,
+		OnGiveUp: func(GiveUpReason, error) {
+			// Pin the race: giveUp must observe writing still set. If
+			// finishWrite ran first, Flush can return nil on a refused frame.
+			w.mu.Lock()
+			saw := w.writing
+			w.mu.Unlock()
+			gaveUpSawWriting.Store(saw)
+		},
 	})
 	t.Cleanup(w.Close)
 
@@ -1019,6 +1029,8 @@ func TestWriterFlushReturnsErrClosedWhenWriteFails(t *testing.T) {
 		t.Fatal("Flush never returned after the write failed")
 	}
 	assert.True(t, w.GaveUp(), "a write error must give up the writer")
+	assert.True(t, gaveUpSawWriting.Load(),
+		"giveUp must run before finishWrite clears writing (the Flush race)")
 }
 
 // A panicking Write must still make Flush report ErrClosed, without setting
@@ -1074,6 +1086,8 @@ func TestWriterFlushReturnsErrClosedWhenWritePanics(t *testing.T) {
 	}
 	assert.False(t, w.GaveUp(), "panic must not give up inside writeTurn")
 	assert.True(t, w.IsClosed(), "panic must latch closed so Flush sees torn-down")
+	assert.True(t, w.WritePanicked(),
+		"panic must set WritePanicked so shutdown notify can file Hub-side failure")
 }
 
 // OnGiveUp often cancels the writer context (Conn.Fence). Flush must still

--- a/backend/internal/sendq/sendq_test.go
+++ b/backend/internal/sendq/sendq_test.go
@@ -1024,6 +1024,21 @@ func TestWriterFlushReturnsErrClosedWhenWriteFails(t *testing.T) {
 	assert.True(t, w.GaveUp(), "a write error must give up the writer")
 }
 
+func TestWriterFlushReturnsErrClosedWhenQueueWasDiscarded(t *testing.T) {
+	t.Parallel()
+	w := NewUnstarted(context.Background(), Config[string]{
+		Write:    func(context.Context, string) error { return nil },
+		Size:     func(s string) int { return len(s) },
+		MaxBytes: 1024,
+	})
+	require.NoError(t, w.Enqueue("frame"))
+	w.Close() // discards without writing
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	assert.ErrorIs(t, w.Flush(ctx), ErrClosed,
+		"Flush must not report success when Close discarded queued frames")
+}
+
 func TestWriterDrainLimitedYieldsAndResignals(t *testing.T) {
 	t.Parallel()
 	wrote := make([]string, 0, 4)

--- a/backend/internal/sendq/sendq_test.go
+++ b/backend/internal/sendq/sendq_test.go
@@ -969,19 +969,59 @@ func TestWriterDrainAfterCloseWritesNothing(t *testing.T) {
 	assert.Zero(t, wrote)
 }
 
-func TestWriterFlushReturnsErrClosedWhenQueueWasDiscarded(t *testing.T) {
+func TestWriterFlushReturnsErrClosedWhenWriteFails(t *testing.T) {
 	t.Parallel()
-	w := NewUnstarted(context.Background(), Config[string]{
-		Write:    func(context.Context, string) error { return nil },
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	release := make(chan struct{})
+	var writeStarted sync.WaitGroup
+	writeStarted.Add(1)
+	w := NewUnstarted(ctx, Config[string]{
+		Write: func(context.Context, string) error {
+			writeStarted.Done()
+			<-release
+			return errors.New("connection reset")
+		},
 		Size:     func(s string) int { return len(s) },
 		MaxBytes: 1024,
 	})
-	require.NoError(t, w.Enqueue("frame"))
-	w.Close() // discards without writing
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	assert.ErrorIs(t, w.Flush(ctx), ErrClosed,
-		"Flush must not report success when Close discarded queued frames")
+	t.Cleanup(w.Close)
+
+	go func() {
+		for {
+			select {
+			case <-w.Wake():
+				_ = w.Drain()
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	require.True(t, w.TryEnqueueControl("frame"))
+	writeStarted.Wait()
+
+	flushed := make(chan error, 1)
+	fctx, fcancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer fcancel()
+	go func() { flushed <- w.Flush(fctx) }()
+
+	// Park Flush on the in-flight write, then let Write fail.
+	time.Sleep(20 * time.Millisecond)
+	close(release)
+
+	select {
+	case err := <-flushed:
+		// A nil return here is the race: finishWrite cleared `writing` before
+		// giveUp latched the writer closed, so Flush saw idle+open and reported
+		// success while the transport had already refused the frame.
+		require.ErrorIs(t, err, ErrClosed,
+			"Flush must not report success when the in-flight write failed")
+	case <-time.After(3 * time.Second):
+		t.Fatal("Flush never returned after the write failed")
+	}
+	assert.True(t, w.GaveUp(), "a write error must give up the writer")
 }
 
 func TestWriterDrainLimitedYieldsAndResignals(t *testing.T) {

--- a/backend/internal/sendq/sendq_test.go
+++ b/backend/internal/sendq/sendq_test.go
@@ -1076,6 +1076,61 @@ func TestWriterFlushReturnsErrClosedWhenWritePanics(t *testing.T) {
 	assert.True(t, w.IsClosed(), "panic must latch closed so Flush sees torn-down")
 }
 
+// OnGiveUp often cancels the writer context (Conn.Fence). Flush must still
+// report ErrClosed for the refused write, not the cancel that teardown used.
+func TestWriterFlushReturnsErrClosedWhenGiveUpCancelsWriterCtx(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	release := make(chan struct{})
+	var writeStarted sync.WaitGroup
+	writeStarted.Add(1)
+	w := NewUnstarted(ctx, Config[string]{
+		Write: func(context.Context, string) error {
+			writeStarted.Done()
+			<-release
+			return errors.New("connection reset")
+		},
+		Size:     func(s string) int { return len(s) },
+		MaxBytes: 1024,
+		OnGiveUp: func(GiveUpReason, error) {
+			cancel()
+		},
+	})
+	t.Cleanup(w.Close)
+
+	go func() {
+		for {
+			select {
+			case <-w.Wake():
+				_ = w.Drain()
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	require.True(t, w.TryEnqueueControl("frame"))
+	writeStarted.Wait()
+
+	flushed := make(chan error, 1)
+	fctx, fcancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer fcancel()
+	go func() { flushed <- w.Flush(fctx) }()
+	close(release)
+
+	select {
+	case err := <-flushed:
+		require.ErrorIs(t, err, ErrClosed,
+			"Flush must prefer ErrClosed over the OnGiveUp writer-ctx cancel")
+		assert.NotErrorIs(t, err, context.Canceled)
+	case <-time.After(3 * time.Second):
+		t.Fatal("Flush never returned after the write failed")
+	}
+	assert.True(t, w.GaveUp())
+}
+
 func TestWriterFlushReturnsErrClosedWhenQueueWasDiscarded(t *testing.T) {
 	t.Parallel()
 	w := NewUnstarted(context.Background(), Config[string]{

--- a/backend/internal/sendq/sendq_test.go
+++ b/backend/internal/sendq/sendq_test.go
@@ -1090,6 +1090,81 @@ func TestWriterFlushReturnsErrClosedWhenWritePanics(t *testing.T) {
 		"panic must set WritePanicked so shutdown notify can file Hub-side failure")
 }
 
+// If OnDiscard panics while latching a panicking Write, finishWrite must still
+// clear writing -- otherwise Flush parks until its deadline on a dead writer.
+func TestWriterFlushClearsWritingWhenOnDiscardPanicsAfterWritePanic(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	release := make(chan struct{})
+	var writeStarted sync.WaitGroup
+	writeStarted.Add(1)
+	w := NewUnstarted(ctx, Config[string]{
+		Write: func(context.Context, string) error {
+			writeStarted.Done()
+			<-release
+			panic("transport exploded")
+		},
+		Size:     func(s string) int { return len(s) },
+		MaxBytes: 1024,
+		OnDiscard: func(int, int64) {
+			panic("OnDiscard exploded")
+		},
+	})
+	t.Cleanup(w.Close)
+
+	drained := make(chan struct{})
+	go func() {
+		defer close(drained)
+		for {
+			select {
+			case <-w.Wake():
+				func() {
+					defer func() { _ = recover() }()
+					_ = w.Drain()
+				}()
+				return
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	// Second frame stays queued so latchClosed's discard path runs OnDiscard.
+	require.True(t, w.TryEnqueueControl("in-flight"))
+	require.True(t, w.TryEnqueueControl("discard-me"))
+	writeStarted.Wait()
+
+	flushed := make(chan error, 1)
+	fctx, fcancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer fcancel()
+	go func() { flushed <- w.Flush(fctx) }()
+	close(release)
+
+	select {
+	case <-drained:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Drain never returned after Write+OnDiscard panicked")
+	}
+
+	w.mu.Lock()
+	writing := w.writing
+	w.mu.Unlock()
+	assert.False(t, writing,
+		"finishWrite must run after an OnDiscard panic during the write-panic latch")
+
+	select {
+	case err := <-flushed:
+		require.ErrorIs(t, err, ErrClosed,
+			"Flush must not hang or succeed after Write+OnDiscard panic")
+	case <-time.After(3 * time.Second):
+		t.Fatal("Flush never returned after Write+OnDiscard panicked")
+	}
+	assert.True(t, w.WritePanicked())
+	assert.False(t, w.GaveUp())
+}
+
 // OnGiveUp often cancels the writer context (Conn.Fence). Flush must still
 // report ErrClosed for the refused write, not the cancel that teardown used.
 func TestWriterFlushReturnsErrClosedWhenGiveUpCancelsWriterCtx(t *testing.T) {


### PR DESCRIPTION
## Root cause

[CI job](https://github.com/leapmux/leapmux/actions/runs/32631810724/job/97175639117) failed on `linux (amd64)` with `TestNotifyShutdownAndFence_ContinuesOnSendError`: expected `Delivered:1, Failed:1`, got `Delivered:2, Failed:0`. The log showed the shutdown tally first, then `worker connect stream writer gave up; fencing` with `write_error`.

`Flush` waits until the queue is idle. On a transport write error, `finishWrite` cleared the in-flight flag before `giveUp` latched the writer closed. `Flush` could observe idle+open and return nil, so `NotifyShutdownAndFence` classified the worker as Delivered even though the peer refused the frame.

## Fix

- On transport write errors, call `giveUp` before `finishWrite` in `writeTurn`
- On panic, latch `closed` + `writePanicked` (without `gaveUp`) before `finishWrite`
- Prefer `ErrClosed` whenever Flush wakes on cancel against a torn-down writer (caller or writer ctx)
- Map `Conn.Flush` cancel/deadline to `ErrConnectionClosed` only when `GaveUp` is set
- `classifyNotifyErr` treats `WritePanicked` as Hub-side failure (not AlreadyGone)
- Defer `finishWrite` so it still runs after a re-panic or OnDiscard panic during latch