### PR TITLE
feat(auth): Add passkey sign-in and SMTP-based email verification

### DIFF
--- a/NOTICE.html
+++ b/NOTICE.html
@@ -125,6 +125,7 @@ body {
 <li><a href="#githubcomcpuguy83dockercfg-v032">github.com/cpuguy83/dockercfg v0.3.2</a></li>
 <li><a href="#githubcomcreackpty-v1124">github.com/creack/pty v1.1.24</a></li>
 <li><a href="#githubcomdavecghgo-spew-v111">github.com/davecgh/go-spew v1.1.1</a></li>
+<li><a href="#githubcomdescopevirtualwebauthn-v105">github.com/descope/virtualwebauthn v1.0.5</a></li>
 <li><a href="#githubcomdistributionreference-v060">github.com/distribution/reference v0.6.0</a></li>
 <li><a href="#githubcomdockergo-connections-v070">github.com/docker/go-connections v0.7.0</a></li>
 <li><a href="#githubcomdockergo-units-v050">github.com/docker/go-units v0.5.0</a></li>
@@ -132,12 +133,17 @@ body {
 <li><a href="#githubcomebitenginepurego-v0100">github.com/ebitengine/purego v0.10.0</a></li>
 <li><a href="#githubcomfelixgehttpsnoop-v110">github.com/felixge/httpsnoop v1.1.0</a></li>
 <li><a href="#githubcomfsnotifyfsnotify-v1101">github.com/fsnotify/fsnotify v1.10.1</a></li>
+<li><a href="#githubcomfxamackercborv2-v292">github.com/fxamacker/cbor/v2 v2.9.2</a></li>
 <li><a href="#githubcomgo-josego-josev4-v414">github.com/go-jose/go-jose/v4 v4.1.4</a></li>
 <li><a href="#githubcomgo-logrlogr-v144">github.com/go-logr/logr v1.4.4</a></li>
 <li><a href="#githubcomgo-logrstdr-v122">github.com/go-logr/stdr v1.2.2</a></li>
 <li><a href="#githubcomgo-olego-ole-v130">github.com/go-ole/go-ole v1.3.0</a></li>
 <li><a href="#githubcomgo-sql-drivermysql-v1100">github.com/go-sql-driver/mysql v1.10.0</a></li>
 <li><a href="#githubcomgo-vipermapstructurev2-v250">github.com/go-viper/mapstructure/v2 v2.5.0</a></li>
+<li><a href="#githubcomgo-webauthnwebauthn-v0174">github.com/go-webauthn/webauthn v0.17.4</a></li>
+<li><a href="#githubcomgo-webauthnx-v026">github.com/go-webauthn/x v0.2.6</a></li>
+<li><a href="#githubcomgolang-jwtjwtv5-v531">github.com/golang-jwt/jwt/v5 v5.3.1</a></li>
+<li><a href="#githubcomgooglego-tpm-v098">github.com/google/go-tpm v0.9.8</a></li>
 <li><a href="#githubcomgoogleuuid-v160">github.com/google/uuid v1.6.0</a></li>
 <li><a href="#githubcomgorillacss-v101">github.com/gorilla/css v1.0.1</a></li>
 <li><a href="#githubcomjackcpgerrcode-v000-20250907135507-afb5586c32a6">github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6</a></li>
@@ -175,6 +181,7 @@ body {
 <li><a href="#githubcomncrucesgo-strftime-v100">github.com/ncruces/go-strftime v1.0.0</a></li>
 <li><a href="#githubcomopencontainersgo-digest-v100">github.com/opencontainers/go-digest v1.0.0</a></li>
 <li><a href="#githubcomopencontainersimage-spec-v111">github.com/opencontainers/image-spec v1.1.1</a></li>
+<li><a href="#githubcomphilhoferfwd-v120">github.com/philhofer/fwd v1.2.0</a></li>
 <li><a href="#githubcompmezardgo-difflib-v100">github.com/pmezard/go-difflib v1.0.0</a></li>
 <li><a href="#githubcompresslygoosev3-v3273">github.com/pressly/goose/v3 v3.27.3</a></li>
 <li><a href="#githubcomprometheusclient_golang-v1241">github.com/prometheus/client_golang v1.24.1</a></li>
@@ -188,9 +195,11 @@ body {
 <li><a href="#githubcomstretchrtestify-v1111">github.com/stretchr/testify v1.11.1</a></li>
 <li><a href="#githubcomtestcontainerstestcontainers-go-v0430">github.com/testcontainers/testcontainers-go v0.43.0</a></li>
 <li><a href="#githubcomthings-gogo-socks5-v011">github.com/things-go/go-socks5 v0.1.1</a></li>
+<li><a href="#githubcomtinylibmsgp-v164">github.com/tinylib/msgp v1.6.4</a></li>
 <li><a href="#githubcomtklausergo-sysconf-v0316">github.com/tklauser/go-sysconf v0.3.16</a></li>
 <li><a href="#githubcomtklausernumcpus-v0110">github.com/tklauser/numcpus v0.11.0</a></li>
 <li><a href="#githubcomu-rootu-root-v0160">github.com/u-root/u-root v0.16.0</a></li>
+<li><a href="#githubcomx448float16-v084">github.com/x448/float16 v0.8.4</a></li>
 <li><a href="#githubcomyusufpapurcuwmi-v124">github.com/yusufpapurcu/wmi v1.2.4</a></li>
 <li><a href="#goopentelemetryioautosdk-v121">go.opentelemetry.io/auto/sdk v1.2.1</a></li>
 <li><a href="#goopentelemetryiocontribinstrumentationnethttpotelhttp-v0690">go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0</a></li>
@@ -773,6 +782,7 @@ body {
 <li><a href="#noblehashes-220-mit">@noble/hashes 2.2.0 (MIT)</a></li>
 <li><a href="#noblepost-quantum-061-mit">@noble/post-quantum 0.6.1 (MIT)</a></li>
 <li><a href="#shikijsrehype-441-mit">@shikijs/rehype 4.4.1 (MIT)</a></li>
+<li><a href="#simplewebauthnbrowser-1330-mit">@simplewebauthn/browser 13.3.0 (MIT)</a></li>
 <li><a href="#solidjsrouter-100-mit">@solidjs/router 1.0.0 (MIT)</a></li>
 <li><a href="#solidjsstart-132-mit">@solidjs/start 1.3.2 (MIT)</a></li>
 <li><a href="#tauri-appsapi-2111-apache-20-or-mit">@tauri-apps/api 2.11.1 (Apache-2.0 OR MIT)</a></li>
@@ -2381,6 +2391,29 @@ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 </code></pre>
+<h3 id="githubcomdescopevirtualwebauthn-v105">github.com/descope/virtualwebauthn v1.0.5</h3>
+<pre><code>MIT License
+
+Copyright (c) 2022 Descope
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</code></pre>
 <h3 id="githubcomdistributionreference-v060">github.com/distribution/reference v0.6.0</h3>
 <pre><code>Apache License
                            Version 2.0, January 2004
@@ -3241,6 +3274,29 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
 ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</code></pre>
+<h3 id="githubcomfxamackercborv2-v292">github.com/fxamacker/cbor/v2 v2.9.2</h3>
+<pre><code>MIT License
+
+Copyright (c) 2019-present Faye Amacker
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 </code></pre>
 <h3 id="githubcomgo-josego-josev4-v414">github.com/go-jose/go-jose/v4 v4.1.4</h3>
 <pre><code>                                 Apache License
@@ -4271,6 +4327,270 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+</code></pre>
+<h3 id="githubcomgo-webauthnwebauthn-v0174">github.com/go-webauthn/webauthn v0.17.4</h3>
+<pre><code>Copyright (c) 2025 github.com/go-webauthn/webauthn authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</code></pre>
+<h3 id="githubcomgo-webauthnx-v026">github.com/go-webauthn/x v0.2.6</h3>
+<pre><code>Copyright (c) 2021-2023 github.com/go-webauthn authors.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+   disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+   disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</code></pre>
+<h3 id="githubcomgolang-jwtjwtv5-v531">github.com/golang-jwt/jwt/v5 v5.3.1</h3>
+<pre><code>Copyright (c) 2012 Dave Grijalva
+Copyright (c) 2021 golang-jwt maintainers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+</code></pre>
+<h3 id="githubcomgooglego-tpm-v098">github.com/google/go-tpm v0.9.8</h3>
+<pre><code>                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
 </code></pre>
 <h3 id="githubcomgoogleuuid-v160">github.com/google/uuid v1.6.0</h3>
 <pre><code>Copyright (c) 2009,2014 Google Inc. All rights reserved.
@@ -7575,6 +7895,15 @@ SOFTWARE.
    See the License for the specific language governing permissions and
    limitations under the License.
 </code></pre>
+<h3 id="githubcomphilhoferfwd-v120">github.com/philhofer/fwd v1.2.0</h3>
+<pre><code>Copyright (c) 2014-2015, Philip Hofer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+</code></pre>
 <h3 id="githubcompmezardgo-difflib-v100">github.com/pmezard/go-difflib v1.0.0</h3>
 <pre><code>Copyright (c) 2013, Patrick Mezard
 All rights reserved.
@@ -8826,6 +9155,16 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 </code></pre>
+<h3 id="githubcomtinylibmsgp-v164">github.com/tinylib/msgp v1.6.4</h3>
+<pre><code>Copyright (c) 2014 Philip Hofer
+Portions Copyright (c) 2009 The Go Authors (license at http://golang.org) where indicated
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+</code></pre>
 <h3 id="githubcomtklausergo-sysconf-v0316">github.com/tklauser/go-sysconf v0.3.16</h3>
 <pre><code>BSD 3-Clause License
 
@@ -9090,6 +9429,29 @@ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</code></pre>
+<h3 id="githubcomx448float16-v084">github.com/x448/float16 v0.8.4</h3>
+<pre><code>MIT License
+
+Copyright (c) 2019 Montgomery Edwards⁴⁴⁸ and Faye Amacker
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 </code></pre>
 <h3 id="githubcomyusufpapurcuwmi-v124">github.com/yusufpapurcu/wmi v1.2.4</h3>
 <pre><code>The MIT License (MIT)
@@ -101403,6 +101765,26 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+</code></pre>
+<h3 id="simplewebauthnbrowser-1330-mit">@simplewebauthn/browser 13.3.0 (MIT)</h3>
+<pre><code>MIT License
+
+Copyright (c) 2020 Matthew Miller
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 </code></pre>
 <h3 id="solidjsrouter-100-mit">@solidjs/router 1.0.0 (MIT)</h3>
 <pre><code>MIT License

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -29,6 +29,7 @@ For the latest version, see [NOTICE.md on GitHub](https://github.com/leapmux/lea
 - [github.com/cpuguy83/dockercfg v0.3.2](#githubcomcpuguy83dockercfg-v032)
 - [github.com/creack/pty v1.1.24](#githubcomcreackpty-v1124)
 - [github.com/davecgh/go-spew v1.1.1](#githubcomdavecghgo-spew-v111)
+- [github.com/descope/virtualwebauthn v1.0.5](#githubcomdescopevirtualwebauthn-v105)
 - [github.com/distribution/reference v0.6.0](#githubcomdistributionreference-v060)
 - [github.com/docker/go-connections v0.7.0](#githubcomdockergo-connections-v070)
 - [github.com/docker/go-units v0.5.0](#githubcomdockergo-units-v050)
@@ -36,12 +37,17 @@ For the latest version, see [NOTICE.md on GitHub](https://github.com/leapmux/lea
 - [github.com/ebitengine/purego v0.10.0](#githubcomebitenginepurego-v0100)
 - [github.com/felixge/httpsnoop v1.1.0](#githubcomfelixgehttpsnoop-v110)
 - [github.com/fsnotify/fsnotify v1.10.1](#githubcomfsnotifyfsnotify-v1101)
+- [github.com/fxamacker/cbor/v2 v2.9.2](#githubcomfxamackercborv2-v292)
 - [github.com/go-jose/go-jose/v4 v4.1.4](#githubcomgo-josego-josev4-v414)
 - [github.com/go-logr/logr v1.4.4](#githubcomgo-logrlogr-v144)
 - [github.com/go-logr/stdr v1.2.2](#githubcomgo-logrstdr-v122)
 - [github.com/go-ole/go-ole v1.3.0](#githubcomgo-olego-ole-v130)
 - [github.com/go-sql-driver/mysql v1.10.0](#githubcomgo-sql-drivermysql-v1100)
 - [github.com/go-viper/mapstructure/v2 v2.5.0](#githubcomgo-vipermapstructurev2-v250)
+- [github.com/go-webauthn/webauthn v0.17.4](#githubcomgo-webauthnwebauthn-v0174)
+- [github.com/go-webauthn/x v0.2.6](#githubcomgo-webauthnx-v026)
+- [github.com/golang-jwt/jwt/v5 v5.3.1](#githubcomgolang-jwtjwtv5-v531)
+- [github.com/google/go-tpm v0.9.8](#githubcomgooglego-tpm-v098)
 - [github.com/google/uuid v1.6.0](#githubcomgoogleuuid-v160)
 - [github.com/gorilla/css v1.0.1](#githubcomgorillacss-v101)
 - [github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6](#githubcomjackcpgerrcode-v000-20250907135507-afb5586c32a6)
@@ -79,6 +85,7 @@ For the latest version, see [NOTICE.md on GitHub](https://github.com/leapmux/lea
 - [github.com/ncruces/go-strftime v1.0.0](#githubcomncrucesgo-strftime-v100)
 - [github.com/opencontainers/go-digest v1.0.0](#githubcomopencontainersgo-digest-v100)
 - [github.com/opencontainers/image-spec v1.1.1](#githubcomopencontainersimage-spec-v111)
+- [github.com/philhofer/fwd v1.2.0](#githubcomphilhoferfwd-v120)
 - [github.com/pmezard/go-difflib v1.0.0](#githubcompmezardgo-difflib-v100)
 - [github.com/pressly/goose/v3 v3.27.3](#githubcompresslygoosev3-v3273)
 - [github.com/prometheus/client_golang v1.24.1](#githubcomprometheusclient_golang-v1241)
@@ -92,9 +99,11 @@ For the latest version, see [NOTICE.md on GitHub](https://github.com/leapmux/lea
 - [github.com/stretchr/testify v1.11.1](#githubcomstretchrtestify-v1111)
 - [github.com/testcontainers/testcontainers-go v0.43.0](#githubcomtestcontainerstestcontainers-go-v0430)
 - [github.com/things-go/go-socks5 v0.1.1](#githubcomthings-gogo-socks5-v011)
+- [github.com/tinylib/msgp v1.6.4](#githubcomtinylibmsgp-v164)
 - [github.com/tklauser/go-sysconf v0.3.16](#githubcomtklausergo-sysconf-v0316)
 - [github.com/tklauser/numcpus v0.11.0](#githubcomtklausernumcpus-v0110)
 - [github.com/u-root/u-root v0.16.0](#githubcomu-rootu-root-v0160)
+- [github.com/x448/float16 v0.8.4](#githubcomx448float16-v084)
 - [github.com/yusufpapurcu/wmi v1.2.4](#githubcomyusufpapurcuwmi-v124)
 - [go.opentelemetry.io/auto/sdk v1.2.1](#goopentelemetryioautosdk-v121)
 - [go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0](#goopentelemetryiocontribinstrumentationnethttpotelhttp-v0690)
@@ -677,6 +686,7 @@ For the latest version, see [NOTICE.md on GitHub](https://github.com/leapmux/lea
 - [@noble/hashes 2.2.0 (MIT)](#noblehashes-220-mit)
 - [@noble/post-quantum 0.6.1 (MIT)](#noblepost-quantum-061-mit)
 - [@shikijs/rehype 4.4.1 (MIT)](#shikijsrehype-441-mit)
+- [@simplewebauthn/browser 13.3.0 (MIT)](#simplewebauthnbrowser-1330-mit)
 - [@solidjs/router 1.0.0 (MIT)](#solidjsrouter-100-mit)
 - [@solidjs/start 1.3.2 (MIT)](#solidjsstart-132-mit)
 - [@tauri-apps/api 2.11.1 (Apache-2.0 OR MIT)](#tauri-appsapi-2111-apache-20-or-mit)
@@ -2350,6 +2360,32 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 ```
 
+### github.com/descope/virtualwebauthn v1.0.5
+
+```
+MIT License
+
+Copyright (c) 2022 Descope
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
 ### github.com/distribution/reference v0.6.0
 
 ```
@@ -3230,6 +3266,32 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
 ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+### github.com/fxamacker/cbor/v2 v2.9.2
+
+```
+MIT License
+
+Copyright (c) 2019-present Faye Amacker
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 ```
 
 ### github.com/go-jose/go-jose/v4 v4.1.4
@@ -4278,6 +4340,282 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+```
+
+### github.com/go-webauthn/webauthn v0.17.4
+
+```
+Copyright (c) 2025 github.com/go-webauthn/webauthn authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+### github.com/go-webauthn/x v0.2.6
+
+```
+Copyright (c) 2021-2023 github.com/go-webauthn authors.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+   disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+   disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+### github.com/golang-jwt/jwt/v5 v5.3.1
+
+```
+Copyright (c) 2012 Dave Grijalva
+Copyright (c) 2021 golang-jwt maintainers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+```
+
+### github.com/google/go-tpm v0.9.8
+
+```
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
 ```
 
 ### github.com/google/uuid v1.6.0
@@ -7694,6 +8032,18 @@ SOFTWARE.
    limitations under the License.
 ```
 
+### github.com/philhofer/fwd v1.2.0
+
+```
+Copyright (c) 2014-2015, Philip Hofer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+```
+
 ### github.com/pmezard/go-difflib v1.0.0
 
 ```
@@ -8984,6 +9334,19 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
+### github.com/tinylib/msgp v1.6.4
+
+```
+Copyright (c) 2014 Philip Hofer
+Portions Copyright (c) 2009 The Go Authors (license at http://golang.org) where indicated
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+```
+
 ### github.com/tklauser/go-sysconf v0.3.16
 
 ```
@@ -9256,6 +9619,32 @@ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+### github.com/x448/float16 v0.8.4
+
+```
+MIT License
+
+Copyright (c) 2019 Montgomery Edwards⁴⁴⁸ and Faye Amacker
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 ```
 
 ### github.com/yusufpapurcu/wmi v1.2.4
@@ -103301,6 +103690,29 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+```
+
+### @simplewebauthn/browser 13.3.0 (MIT)
+
+```
+MIT License
+
+Copyright (c) 2020 Matthew Miller
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
 ### @solidjs/router 1.0.0 (MIT)

--- a/backend/cmd/leapmux/recover_encryption.go
+++ b/backend/cmd/leapmux/recover_encryption.go
@@ -76,10 +76,10 @@ func runRemoveEncryptionKey(cmd cmdCtx, args []string) error {
 // countEncryptedRefs returns human-readable descriptions of data still
 // encrypted under the given key version. An empty result means the version is
 // safe to remove. It scans the persistent encrypted secrets — OAuth provider
-// client secrets, user OAuth tokens, and captcha provider secrets. Transient
-// pending_oauth_signups are not scanned: they auto-expire, are never migrated
-// by reencrypt, and a bricked one only fails an in-flight signup the user can
-// simply retry.
+// client secrets, user OAuth tokens, captcha provider secrets, and passkey
+// public keys. Transient pending_oauth_signups and webauthn_sessions are not
+// scanned: they auto-expire, are never migrated by reencrypt, and a bricked
+// row only fails an in-flight signup or ceremony the user can simply retry.
 func countEncryptedRefs(ctx context.Context, st store.Store, version uint32) ([]string, error) {
 	var refs []string
 
@@ -120,6 +120,14 @@ func countEncryptedRefs(ctx context.Context, st store.Store, version uint32) ([]
 	}
 	if settingsCount > 0 {
 		refs = append(refs, fmt.Sprintf("%d settings secret(s)", settingsCount))
+	}
+
+	passkeys, err := st.PasskeyCredentials().CountByKeyVersion(ctx, int64(version))
+	if err != nil {
+		return nil, fmt.Errorf("count passkey credentials for key version %d: %w", version, err)
+	}
+	if passkeys > 0 {
+		refs = append(refs, fmt.Sprintf("%d passkey credential(s)", passkeys))
 	}
 
 	return refs, nil
@@ -265,6 +273,34 @@ func runReencryptSecrets(cmd cmdCtx, args []string) error {
 				return fmt.Errorf("update settings secret for %s: %w", row.Key, err)
 			}
 			count++
+		}
+
+		// Re-encrypt passkey_credentials.public_key rows.
+		for _, ver := range ks.Versions() {
+			if ver == activeVer {
+				continue
+			}
+			passkeys, listErr := st.PasskeyCredentials().ListByKeyVersion(ctx, int64(ver))
+			if listErr != nil {
+				return fmt.Errorf("list passkey credentials for key version %d: %w", ver, listErr)
+			}
+			for _, pk := range passkeys {
+				aad := keystore.PasskeyPublicKeyAAD(pk.ID)
+				newCt, err := reencryptBlob(ks, pk.PublicKey, aad,
+					fmt.Sprintf("passkey public key %s", pk.ID))
+				if err != nil {
+					return err
+				}
+				if err := st.PasskeyCredentials().UpdatePublicKey(ctx, store.UpdatePasskeyPublicKeyParams{
+					ID:         pk.ID,
+					UserID:     pk.UserID,
+					PublicKey:  newCt,
+					KeyVersion: int64(activeVer),
+				}); err != nil {
+					return fmt.Errorf("update passkey credential %s: %w", pk.ID, err)
+				}
+				count++
+			}
 		}
 
 		fmt.Printf("Re-encrypted %d secrets to key version %d.\n", count, activeVer)

--- a/backend/cmd/leapmux/recover_test.go
+++ b/backend/cmd/leapmux/recover_test.go
@@ -942,3 +942,95 @@ func TestRecoverRefusalWordingIsTheOneAnOperatorSees(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown recover db command: zzz")
 }
+
+func TestCLI_PasswordReset_DeletesPasskeys(t *testing.T) {
+	dir := setupTestDataDir(t)
+	user := createTestUser(t, dir, "pkuser")
+	ctx := context.Background()
+
+	st, err := storeopen.Open(ctx, recoverConfig(dir))
+	require.NoError(t, err)
+	pkID := id.Generate()
+	require.NoError(t, st.PasskeyCredentials().Create(ctx, store.CreatePasskeyCredentialParams{
+		ID: pkID, UserID: user.ID, CredentialID: []byte("cred-" + pkID),
+		PublicKey: []byte("pubkey"), SignCount: 0, Transports: "[]",
+		FriendlyName: "Phone", KeyVersion: 1, CreatedAt: time.Now().UTC(),
+	}))
+	require.NoError(t, st.Close())
+
+	require.NoError(t, runPasswordReset(testCmdCtx, []string{
+		"--id", user.ID,
+		"--password", "NewPassword2!",
+		"--data-dir", dir,
+	}))
+
+	st, err = storeopen.Open(ctx, recoverConfig(dir))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+	rows, err := st.PasskeyCredentials().ListByUser(ctx, user.ID)
+	require.NoError(t, err)
+	assert.Empty(t, rows)
+}
+
+func TestCLI_Reencrypt_MigratesPasskeyPublicKey(t *testing.T) {
+	dir := setupTestDataDir(t)
+	ctx := context.Background()
+	keyPath := filepath.Join(dir, "encryption.key")
+
+	ks, err := keystore.LoadFromFile(keyPath)
+	require.NoError(t, err)
+	st, err := storeopen.Open(ctx, recoverConfig(dir))
+	require.NoError(t, err)
+	user := storetest.SeedUser(t, st, "pkreenc")
+	pkID := id.Generate()
+	plain := []byte("cose-public-key-bytes")
+	enc, err := ks.Encrypt(plain, keystore.PasskeyPublicKeyAAD(pkID))
+	require.NoError(t, err)
+	require.NoError(t, st.PasskeyCredentials().Create(ctx, store.CreatePasskeyCredentialParams{
+		ID: pkID, UserID: user.ID, CredentialID: []byte("cred-" + pkID),
+		PublicKey: enc, SignCount: 0, Transports: "[]",
+		FriendlyName: "Key", KeyVersion: int64(ks.ActiveVersion()), CreatedAt: time.Now().UTC(),
+	}))
+	require.NoError(t, st.Close())
+
+	require.NoError(t, runRotateEncryptionKey(testCmdCtx, []string{"--data-dir", dir}))
+	require.NoError(t, runReencryptSecrets(testCmdCtx, []string{"--data-dir", dir}))
+
+	ks2, err := keystore.LoadFromFile(keyPath)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(2), ks2.ActiveVersion())
+	st, err = storeopen.Open(ctx, recoverConfig(dir))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+	rows, err := st.PasskeyCredentials().ListByKeyVersion(ctx, 2)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	dec, err := ks2.Decrypt(rows[0].PublicKey, keystore.PasskeyPublicKeyAAD(pkID))
+	require.NoError(t, err)
+	assert.Equal(t, plain, dec)
+	old, err := st.PasskeyCredentials().ListByKeyVersion(ctx, 1)
+	require.NoError(t, err)
+	assert.Empty(t, old)
+}
+
+func TestCLI_RemoveEncryptionKey_RefusesWhenPasskeyReferenced(t *testing.T) {
+	dir := setupTestDataDir(t)
+	ctx := context.Background()
+
+	st, err := storeopen.Open(ctx, recoverConfig(dir))
+	require.NoError(t, err)
+	user := storetest.SeedUser(t, st, "pkref")
+	pkID := id.Generate()
+	require.NoError(t, st.PasskeyCredentials().Create(ctx, store.CreatePasskeyCredentialParams{
+		ID: pkID, UserID: user.ID, CredentialID: []byte("cred-" + pkID),
+		PublicKey: []byte("cipher"), SignCount: 0, Transports: "[]",
+		FriendlyName: "Key", KeyVersion: 1, CreatedAt: time.Now().UTC(),
+	}))
+	require.NoError(t, st.Close())
+
+	require.NoError(t, runRotateEncryptionKey(testCmdCtx, []string{"--data-dir", dir}))
+	err = runRemoveEncryptionKey(testCmdCtx, []string{"--version", "1", "--data-dir", dir})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "still encrypts")
+	assert.Contains(t, err.Error(), "passkey")
+}

--- a/backend/cmd/leapmux/recover_user.go
+++ b/backend/cmd/leapmux/recover_user.go
@@ -142,6 +142,13 @@ func runPasswordReset(cmd cmdCtx, args []string) error {
 				return fmt.Errorf("update password: %w", err)
 			}
 
+			// Offline break-glass matches online admin reset and self-service
+			// CompletePasswordReset: passkeys, ceremonies, and any pending
+			// reset email die with the password rotation.
+			if err := service.RevokePasskeyAuthState(ctx, tx, user.ID); err != nil {
+				return err
+			}
+
 			if err := tx.Sessions().DeleteByUser(ctx, revokeUID); err != nil {
 				return fmt.Errorf("delete sessions: %w", err)
 			}
@@ -163,7 +170,7 @@ func runPasswordReset(cmd cmdCtx, args []string) error {
 			return err
 		}
 
-		fmt.Printf("Password reset for user %q (id: %s). All sessions revoked.\n", user.Username, user.ID)
+		fmt.Printf("Password reset for user %q (id: %s). All sessions and passkeys revoked.\n", user.Username, user.ID)
 		return nil
 	})
 }

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -11,9 +11,11 @@ require (
 	github.com/cloudflare/circl v1.6.5
 	github.com/coder/websocket v1.8.15
 	github.com/coreos/go-oidc/v3 v3.20.0
+	github.com/descope/virtualwebauthn v1.0.5
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-sql-driver/mysql v1.10.0
 	github.com/go-viper/mapstructure/v2 v2.5.0
+	github.com/go-webauthn/webauthn v0.17.4
 	github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/klauspost/compress v1.19.2
@@ -131,6 +133,7 @@ require (
 	github.com/felixge/httpsnoop v1.1.0 // indirect
 	github.com/firefart/nonamedreturns v1.0.6 // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
+	github.com/fxamacker/cbor/v2 v2.9.2 // indirect
 	github.com/fzipp/gocyclo v0.6.0 // indirect
 	github.com/ghostiam/protogetter v0.3.20 // indirect
 	github.com/go-critic/go-critic v0.14.3 // indirect
@@ -144,10 +147,12 @@ require (
 	github.com/go-toolsmith/astp v1.1.0 // indirect
 	github.com/go-toolsmith/strparse v1.1.0 // indirect
 	github.com/go-toolsmith/typep v1.1.0 // indirect
+	github.com/go-webauthn/x v0.2.6 // indirect
 	github.com/go-xmlfmt/xmlfmt v1.1.3 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/godoc-lint/godoc-lint v0.11.2 // indirect
 	github.com/gofrs/flock v0.13.0 // indirect
+	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/golangci/asciicheck v0.5.0 // indirect
 	github.com/golangci/dupl v0.0.0-20260401084720-c99c5cf5c202 // indirect
 	github.com/golangci/go-printf-func-name v0.1.1 // indirect
@@ -162,6 +167,7 @@ require (
 	github.com/golangci/unconvert v0.0.0-20250410112200-a129a6e6413e // indirect
 	github.com/google/cel-go v0.28.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/google/go-tpm v0.9.8 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gordonklaus/ineffassign v0.2.0 // indirect
@@ -238,6 +244,7 @@ require (
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.3.1 // indirect
 	github.com/pganalyze/pg_query_go/v6 v6.2.2 // indirect
+	github.com/philhofer/fwd v1.2.0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20250523034308-74f78ae071ee // indirect
 	github.com/pingcap/failpoint v0.0.0-20240528011301-b51a646c7c86 // indirect
 	github.com/pingcap/log v1.1.0 // indirect
@@ -286,6 +293,7 @@ require (
 	github.com/tetratelabs/wazero v1.11.0 // indirect
 	github.com/timakin/bodyclose v0.0.0-20260129054331-73d1f95b84b4 // indirect
 	github.com/timonwong/loggercheck v0.11.0 // indirect
+	github.com/tinylib/msgp v1.6.4 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
 	github.com/tomarrell/wrapcheck/v2 v2.12.0 // indirect
@@ -297,6 +305,7 @@ require (
 	github.com/uudashr/iface v1.4.2 // indirect
 	github.com/wasilibs/go-pgquery v0.0.0-20250409022910-10ac41983c07 // indirect
 	github.com/wasilibs/wazero-helpers v0.0.0-20240620070341-3dff1577cd52 // indirect
+	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xen0n/gosmopolitan v1.3.0 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yagipy/maintidx v1.0.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -170,6 +170,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/denis-tingaikin/go-header v0.5.0 h1:SRdnP5ZKvcO9KKRP1KJrhFR3RrlGuD+42t4429eC9k8=
 github.com/denis-tingaikin/go-header v0.5.0/go.mod h1:mMenU5bWrok6Wl2UsZjy+1okegmwQ3UgWl4V1D8gjlY=
+github.com/descope/virtualwebauthn v1.0.5 h1:fMXji5UMepJC51Ge6d4v5IAjiJQRKmXE9hlo/B9SczQ=
+github.com/descope/virtualwebauthn v1.0.5/go.mod h1:lLCfN+DpCM3iisM4bCILZlFEWkC1Zo7ZgsxC45CUapI=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/dlclark/regexp2 v1.12.0 h1:0j4c5qQmnC6XOWNjP3PIXURXN2gWx76rd3KvgdPkCz8=
@@ -198,6 +200,8 @@ github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3
 github.com/frankban/quicktest v1.14.3/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUorkibMOrVTHZps=
 github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
 github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
+github.com/fxamacker/cbor/v2 v2.9.2 h1:X4Ksno9+x3cz0TZv69ec1hxP/+tymuR8PXQJyDwfh78=
+github.com/fxamacker/cbor/v2 v2.9.2/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/fzipp/gocyclo v0.6.0 h1:lsblElZG7d3ALtGMx9fmxeTKZaLLpU8mET09yN4BBLo=
 github.com/fzipp/gocyclo v0.6.0/go.mod h1:rXPyn8fnlpa0R2csP/31uerbiVBugk5whMdlyaLkLoA=
 github.com/ghostiam/protogetter v0.3.20 h1:oW7OPFit2FxZOpmMRPP9FffU4uUpfeE/rEdE1f+MzD0=
@@ -240,6 +244,10 @@ github.com/go-toolsmith/typep v1.1.0 h1:fIRYDyF+JywLfqzyhdiHzRop/GQDxxNhLGQ6gFUN
 github.com/go-toolsmith/typep v1.1.0/go.mod h1:fVIw+7zjdsMxDA3ITWnH1yOiw1rnTQKCsF/sk2H/qig=
 github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPEgAXnvj1Ro=
 github.com/go-viper/mapstructure/v2 v2.5.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/go-webauthn/webauthn v0.17.4 h1:KFTSz3R2RYDiUn/0cDi3XTJgFenSG74eKTTHlqWhlxk=
+github.com/go-webauthn/webauthn v0.17.4/go.mod h1:pZk63EE/BdztlmyS4Yc+9H5g4a8blNlbtGmdHQHbZX8=
+github.com/go-webauthn/x v0.2.6 h1:TEyDuQAIiEgYpx60nKiBJIX/5nSUC8LxNbH+uf5U9uk=
+github.com/go-webauthn/x v0.2.6/go.mod h1:45bA7YEqyQhRcQJ/TiBb46Ww8yqHBGvgEhQ3WWF0aDo=
 github.com/go-xmlfmt/xmlfmt v1.1.3 h1:t8Ey3Uy7jDSEisW2K3somuMKIpzktkWptA0iFCnRUWY=
 github.com/go-xmlfmt/xmlfmt v1.1.3/go.mod h1:aUCEOzzezBEjDBbFBoSiya/gduyIiWYRP6CnSFIV8AM=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
@@ -248,6 +256,8 @@ github.com/godoc-lint/godoc-lint v0.11.2 h1:Bp0FkJWoSdNsBikdNgIcgtaoo+xz6I/Y9s5W
 github.com/godoc-lint/godoc-lint v0.11.2/go.mod h1:iVpGdL1JCikNH2gGeAn3Hh+AgN5Gx/I/cxV+91L41jo=
 github.com/gofrs/flock v0.13.0 h1:95JolYOvGMqeH31+FC7D2+uULf6mG61mEZ/A8dRYMzw=
 github.com/gofrs/flock v0.13.0/go.mod h1:jxeyy9R1auM5S6JYDBhDt+E2TCo7DkratH4Pgi8P+Z0=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/golangci/asciicheck v0.5.0 h1:jczN/BorERZwK8oiFBOGvlGPknhvq0bjnysTj4nUfo0=
@@ -282,6 +292,10 @@ github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/go-tpm v0.9.8 h1:slArAR9Ft+1ybZu0lBwpSmpwhRXaa85hWtMinMyRAWo=
+github.com/google/go-tpm v0.9.8/go.mod h1:h9jEsEECg7gtLis0upRBQU+GhYVH6jMjrFxI8u6bVUY=
+github.com/google/go-tpm-tools v0.3.13-0.20230620182252-4639ecce2aba h1:qJEJcuLzH5KDR0gKc0zcktin6KSAwL7+jWKBYceddTc=
+github.com/google/go-tpm-tools v0.3.13-0.20230620182252-4639ecce2aba/go.mod h1:EFYHy8/1y2KfgTAsx7Luu7NGhoxtuVHnNo8jE7FikKc=
 github.com/google/pprof v0.0.0-20260802141513-ef3492d7dac3 h1:LMLX+LgTNWpfvCBdFebv6EsYotImrt/Ppc5cXIriCSo=
 github.com/google/pprof v0.0.0-20260802141513-ef3492d7dac3/go.mod h1:jl5iWTm0/hd5PjEYEOuwAJ57L/CibdZfrqZ5XA5GrCk=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
@@ -493,6 +507,8 @@ github.com/pelletier/go-toml/v2 v2.3.1 h1:MYEvvGnQjeNkRF1qUuGolNtNExTDwct51yp7ol
 github.com/pelletier/go-toml/v2 v2.3.1/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pganalyze/pg_query_go/v6 v6.2.2 h1:O0L6zMC226R82RF3X5n0Ki6HjytDsoAzuzp4ATVAHNo=
 github.com/pganalyze/pg_query_go/v6 v6.2.2/go.mod h1:Cn6+j4870kJz3iYNsb0VsNG04vpSWgEvBwc590J4qD0=
+github.com/philhofer/fwd v1.2.0 h1:e6DnBTl7vGY+Gz322/ASL4Gyp1FspeMvx1RNDoToZuM=
+github.com/philhofer/fwd v1.2.0/go.mod h1:RqIHx9QI14HlwKwm98g9Re5prTQ6LdeRQn+gXJFxsJM=
 github.com/pingcap/errors v0.11.0/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pingcap/errors v0.11.5-0.20250523034308-74f78ae071ee h1:/IDPbpzkzA97t1/Z1+C3KlxbevjMeaI6BQYxvivu4u8=
 github.com/pingcap/errors v0.11.5-0.20250523034308-74f78ae071ee/go.mod h1:X2r9ueLEUZgtx2cIogM0v4Zj5uvvzhuuiu7Pn8HzMPg=
@@ -615,6 +631,8 @@ github.com/timakin/bodyclose v0.0.0-20260129054331-73d1f95b84b4 h1:SiHe5XLTn9sFW
 github.com/timakin/bodyclose v0.0.0-20260129054331-73d1f95b84b4/go.mod h1:sDHLK7rb/59v/ZxZ7KtymgcoxuUMxjXq8gtu9VMOK8M=
 github.com/timonwong/loggercheck v0.11.0 h1:jdaMpYBl+Uq9mWPXv1r8jc5fC3gyXx4/WGwTnnNKn4M=
 github.com/timonwong/loggercheck v0.11.0/go.mod h1:HEAWU8djynujaAVX7QI65Myb8qgfcZ1uKbdpg3ZzKl8=
+github.com/tinylib/msgp v1.6.4 h1:mOwYbyYDLPj35mkA2BjjYejgJk9BuHxDdvRnb6v2ZcQ=
+github.com/tinylib/msgp v1.6.4/go.mod h1:RSp0LW9oSxFut3KzESt5Voq4GVWyS+PSulT77roAqEA=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=
 github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7gh/BmM179nYI=
 github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=
@@ -639,6 +657,8 @@ github.com/wasilibs/go-pgquery v0.0.0-20250409022910-10ac41983c07 h1:mJdDDPblDfP
 github.com/wasilibs/go-pgquery v0.0.0-20250409022910-10ac41983c07/go.mod h1:Ak17IJ037caFp4jpCw/iQQ7/W74Sqpb1YuKJU6HTKfM=
 github.com/wasilibs/wazero-helpers v0.0.0-20240620070341-3dff1577cd52 h1:OvLBa8SqJnZ6P+mjlzc2K7PM22rRUPE1x32G9DTPrC4=
 github.com/wasilibs/wazero-helpers v0.0.0-20240620070341-3dff1577cd52/go.mod h1:jMeV4Vpbi8osrE/pKUxRZkVaA0EX7NZN0A9/oRzgpgY=
+github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
+github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xen0n/gosmopolitan v1.3.0 h1:zAZI1zefvo7gcpbCOrPSHJZJYA9ZgLfJqtKzZ5pHqQM=
 github.com/xen0n/gosmopolitan v1.3.0/go.mod h1:rckfr5T6o4lBtM1ga7mLGKZmLxswUoH1zxHgNXOsEt4=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
@@ -690,6 +710,8 @@ go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+go.uber.org/mock v0.6.0 h1:hyF9dfmbgIX5EfOdasqLsWD6xqpNZlXblLB/Dbnwv3Y=
+go.uber.org/mock v0.6.0/go.mod h1:KiVJ4BqZJaMj4svdfmHM0AUx4NJYO8ZNpPnZn1Z+BBU=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/multierr v1.7.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/backend/hub/server.go
+++ b/backend/hub/server.go
@@ -444,9 +444,8 @@ func NewServer(cfg *config.Config, opts ...ServerOption) (*Server, error) {
 	// snapshot on every Send, so `admin settings set smtp ...` applies to
 	// the next email without a restart. With SMTP unconfigured it returns
 	// the loud, matchable ErrEmailDisabled rather than silently dropping
-	// mail. The write path's cross-validation keeps
-	// email_verification_required=true from pairing with an absent SMTP
-	// host; the read path degrades that combination to verification-off.
+	// mail. Email verification follows SMTP: EmailVerificationEffective is
+	// true only when SMTP is enabled (no separate toggle).
 	mailSender := mail.NewSettingsSender(setMgr)
 	// The renderer derives its base URL per render so a public_url change
 	// reaches the next email's links and footers without a restart.
@@ -581,7 +580,7 @@ func NewServer(cfg *config.Config, opts ...ServerOption) (*Server, error) {
 	// UserService drives credential-rotation paths (ChangePassword) through the
 	// shared lifecycle, whose RevokeUserPreservingSession hard-closes every
 	// channel a user owns alongside the delegation-token revocation.
-	userSvc := service.NewUserService(st, cfg, setMgr, lifecycle, mailSender, mailRenderer)
+	userSvc := service.NewUserService(st, cfg, setMgr, lifecycle, mailSender, mailRenderer, ks)
 	userPath, userHandler := leapmuxv1connect.NewUserServiceHandler(userSvc, connectOpts)
 	mux.Handle(userPath, userHandler)
 
@@ -604,9 +603,6 @@ func NewServer(cfg *config.Config, opts ...ServerOption) (*Server, error) {
 	setMgr.Configure(
 		settings.WithEffective(settings.KeySignupEnabled.Name(), func(s *settings.Snapshot) (any, bool) {
 			return settings.SignupEnabledEffective(s, cfg.DevMode), true
-		}),
-		settings.WithEffective(settings.KeyEmailVerificationRequired.Name(), func(s *settings.Snapshot) (any, bool) {
-			return settings.EmailVerificationEffective(s), true
 		}),
 		settings.WithEffective(captcha.CaptchaSelectedKey.Name(), func(s *settings.Snapshot) (any, bool) {
 			// A selected provider that is not fully configured degrades at
@@ -639,7 +635,7 @@ func NewServer(cfg *config.Config, opts ...ServerOption) (*Server, error) {
 	adminSettingsPath, adminSettingsHandler := leapmuxv1connect.NewAdminSettingsServiceHandler(adminSettingsSvc, connectOpts)
 	mux.Handle(adminSettingsPath, adminSettingsHandler)
 
-	adminUserSvc := service.NewAdminUserService(st, tokenValidator, lifecycle, workerEffects)
+	adminUserSvc := service.NewAdminUserService(st, tokenValidator, lifecycle, workerEffects, setMgr)
 	adminUserPath, adminUserHandler := leapmuxv1connect.NewAdminUserServiceHandler(adminUserSvc, connectOpts)
 	mux.Handle(adminUserPath, adminUserHandler)
 

--- a/backend/hub/server_settings_rules_test.go
+++ b/backend/hub/server_settings_rules_test.go
@@ -96,20 +96,6 @@ func TestSettingsReadTimeRulesAreRegistered(t *testing.T) {
 	// cross-key rules refuse them, which is exactly why a READ-time rule has
 	// to degrade them. Direct SQL plus a reload is how an operator reaches
 	// them, and how this test does.
-	t.Run("email_verification_required degrades without SMTP", func(t *testing.T) {
-		require.NoError(t, srv.Store().Settings().Upsert(ctx, store.UpsertSettingParams{
-			Key:   settings.KeyEmailVerificationRequired.Name(),
-			Value: ptrconv.Ptr("true"),
-		}))
-		require.NoError(t, set.Load(ctx))
-
-		snap := set.Snapshot(ctx)
-		require.Equal(t, true, snap.ValueOf(settings.KeyEmailVerificationRequired),
-			"the stored row says verification is required")
-		assert.Equal(t, false, set.Effective(snap, settings.KeyEmailVerificationRequired),
-			"with no SMTP host the hub cannot send, so verification degrades off")
-	})
-
 	t.Run("captcha.selected reports the provider that serves challenges", func(t *testing.T) {
 		selected := captcha.ProviderAlias(captcha.ProviderTurnstile)
 		require.NoError(t, srv.Store().Settings().Upsert(ctx, store.UpsertSettingParams{

--- a/backend/internal/hub/auth/auth.go
+++ b/backend/internal/hub/auth/auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"connectrpc.com/connect"
@@ -191,6 +192,12 @@ func MustGetUser(ctx context.Context) (*UserInfo, error) {
 // lock anyone out.
 var ErrInvalidCurrentPassword = errors.New("current password is incorrect")
 
+// ErrInvalidReauthProof wraps passkey-management rejections caused by a
+// missing, expired, or invalid reauth proof (and failed FinishPasskeyReauth
+// assertions). The rate limiter keys on it the same way it keys on
+// ErrInvalidCurrentPassword.
+var ErrInvalidReauthProof = errors.New("invalid or expired reauth proof")
+
 // RevokeAllUserCredentials revokes every active api_tokens and
 // delegation_tokens row for userID and, via RevokeUserTokens, bumps
 // users.tokens_revoked_at AND users.auth_generation, emitting the durable
@@ -277,6 +284,13 @@ func Login(ctx context.Context, st store.Store, username, password string, lifet
 		return "", nil, zero, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("invalid credentials"))
 	}
 
+	// Passkey-only / OAuth-only accounts store PlaceholderHash. Verify would
+	// return a parse error mapped to CodeInternal and leak that the username
+	// exists without a password. Treat "no password" like a wrong password.
+	if !user.PasswordSet {
+		return "", nil, zero, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("invalid credentials"))
+	}
+
 	// Verify the password OUTSIDE the auth transaction. On the default
 	// SQLite backend RunInUserAuthTransaction promotes to a write
 	// transaction (LockUserAuthState), which serializes every other hub
@@ -302,6 +316,9 @@ func Login(ctx context.Context, st store.Store, username, password string, lifet
 		if lockedUser.Username != store.NormalizeUsername(username) {
 			return connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("invalid credentials"))
 		}
+		if !lockedUser.PasswordSet {
+			return connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("invalid credentials"))
+		}
 		match, verifyErr := matchPrelock, verifyErrPrelock
 		if lockedUser.PasswordHash != prelockHash {
 			// The hash changed under the lock (concurrent rotation), so the
@@ -309,7 +326,14 @@ func Login(ctx context.Context, st store.Store, username, password string, lifet
 			match, verifyErr = pwdhash.Verify(lockedUser.PasswordHash, password)
 		}
 		if verifyErr != nil {
-			return connect.NewError(connect.CodeInternal, fmt.Errorf("verify password: %w", verifyErr))
+			// Malformed hashes (including PlaceholderHash) must not become
+			// CodeInternal — that distinguishes "exists without password".
+			// Log the parse cause server-side: a corrupted stored hash is
+			// otherwise indistinguishable from a wrong password, with no
+			// operator signal at all.
+			slog.WarnContext(ctx, "stored password hash failed to parse",
+				"user_id", user.ID, "err", verifyErr)
+			return connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("invalid credentials"))
 		}
 		if !match {
 			return connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("invalid credentials"))
@@ -385,7 +409,7 @@ func CreateSession(ctx context.Context, st store.Store, userID userid.UserID, li
 // the token is invalid or expired. Uses a single joined query to avoid two
 // sequential DB round-trips.
 func ValidateToken(ctx context.Context, st store.Store, token string) (*UserInfo, error) {
-	row, err := st.Sessions().ValidateWithUser(ctx, token)
+	row, err := st.Sessions().ValidateWithUser(ctx, token, time.Now().UTC())
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("invalid or expired token"))

--- a/backend/internal/hub/auth/auth_test.go
+++ b/backend/internal/hub/auth/auth_test.go
@@ -68,7 +68,7 @@ func TestLogin_StampsTheGivenLifetime(t *testing.T) {
 	require.NoError(t, err)
 	hubtestutil.AssertSessionLifetime(t, before, lifetime, expiresAt)
 
-	sess, err := st.Sessions().GetByID(ctx, token)
+	sess, err := st.Sessions().GetByID(ctx, token, time.Now().UTC())
 	require.NoError(t, err)
 	assert.WithinDuration(t, expiresAt, sess.ExpiresAt, time.Second,
 		"the returned expiry and the stored row must be the same deadline")
@@ -286,6 +286,26 @@ func TestLogin_UnknownUser(t *testing.T) {
 
 	_, _, _, err := auth.Login(ctx, st, "nonexistent", "password", auth.DefaultSessionDuration)
 	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+}
+
+func TestLogin_PasswordNotSet_SameAsUnknownUser(t *testing.T) {
+	st := setupStore(t)
+	ctx := context.Background()
+	userID := id.Generate()
+	require.NoError(t, st.Users().Create(ctx, store.CreateUserParams{
+		ID:           userID,
+		Username:     "pkonly",
+		PasswordHash: password.PlaceholderHash,
+		DisplayName:  "PK Only",
+		PasswordSet:  false,
+		IsAdmin:      false,
+	}))
+
+	_, _, _, err := auth.Login(ctx, st, "pkonly", "any-password", auth.DefaultSessionDuration)
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+	assert.Contains(t, err.Error(), "invalid credentials")
 }
 
 func TestLogin_HashUnchangedAfterLogin(t *testing.T) {
@@ -483,7 +503,7 @@ func TestValidateToken_Success(t *testing.T) {
 	assert.Equal(t, "testuser", info.Username)
 	assert.True(t, info.IsAdmin)
 
-	session, err := st.Sessions().GetByID(ctx, token)
+	session, err := st.Sessions().GetByID(ctx, token, time.Now().UTC())
 	require.NoError(t, err)
 	assert.True(t, info.AuthenticatedAt.Equal(session.CreatedAt.UTC()),
 		"session auth basis should use the DB session creation timestamp")
@@ -667,7 +687,7 @@ type blankIDSessions struct {
 	row *store.SessionWithUser
 }
 
-func (s blankIDSessions) ValidateWithUser(context.Context, string) (*store.SessionWithUser, error) {
+func (s blankIDSessions) ValidateWithUser(context.Context, string, time.Time) (*store.SessionWithUser, error) {
 	return s.row, nil
 }
 

--- a/backend/internal/hub/auth/bearer_cache_gen_test.go
+++ b/backend/internal/hub/auth/bearer_cache_gen_test.go
@@ -52,6 +52,9 @@ type touchRecordingSessionStore struct {
 	store.SessionStore
 	row     *store.SessionWithUser
 	touched store.TouchSessionParams
+	// touchedNow records the hub clock the interceptor passed, so a test can
+	// assert the liveness predicate is bound and not left at the zero time.
+	touchedNow time.Time
 	// touchMissed simulates the conditional UPDATE matching zero rows (the
 	// session was touched within the threshold). Default false = one row
 	// matched.
@@ -67,8 +70,9 @@ func (s *touchRecordingSessionStore) ValidateWithUser(context.Context, string, t
 	return s.row, nil
 }
 
-func (s *touchRecordingSessionStore) Touch(_ context.Context, p store.TouchSessionParams) (int64, error) {
+func (s *touchRecordingSessionStore) Touch(_ context.Context, p store.TouchSessionParams, now time.Time) (int64, error) {
 	s.touched = p
+	s.touchedNow = now
 	s.touchCalls++
 	if s.touchErr != nil {
 		return 0, s.touchErr

--- a/backend/internal/hub/auth/bearer_cache_gen_test.go
+++ b/backend/internal/hub/auth/bearer_cache_gen_test.go
@@ -37,7 +37,7 @@ type sessionValidationStore struct {
 	validate func(context.Context, string) (*store.SessionWithUser, error)
 }
 
-func (s sessionValidationStore) ValidateWithUser(ctx context.Context, sessionID string) (*store.SessionWithUser, error) {
+func (s sessionValidationStore) ValidateWithUser(ctx context.Context, sessionID string, now time.Time) (*store.SessionWithUser, error) {
 	return s.validate(ctx, sessionID)
 }
 
@@ -63,7 +63,7 @@ type touchRecordingSessionStore struct {
 	touchCalls int
 }
 
-func (s *touchRecordingSessionStore) ValidateWithUser(context.Context, string) (*store.SessionWithUser, error) {
+func (s *touchRecordingSessionStore) ValidateWithUser(context.Context, string, time.Time) (*store.SessionWithUser, error) {
 	return s.row, nil
 }
 
@@ -159,7 +159,7 @@ type staticUserStore struct {
 
 func (s staticUserStore) GetByID(context.Context, string) (*store.User, error) { return s.row, nil }
 
-func (s validationErrorSessionStore) ValidateWithUser(context.Context, string) (*store.SessionWithUser, error) {
+func (s validationErrorSessionStore) ValidateWithUser(context.Context, string, time.Time) (*store.SessionWithUser, error) {
 	return nil, s.err
 }
 

--- a/backend/internal/hub/auth/interceptor.go
+++ b/backend/internal/hub/auth/interceptor.go
@@ -61,7 +61,13 @@ var publicProcedures = map[string]bool{
 	// fetchable before login. The captcha interceptor guards the
 	// procedures that consume solutions, not the one that issues
 	// challenges.
-	leapmuxv1connect.AuthServiceGetAltchaChallengeProcedure: true,
+	leapmuxv1connect.AuthServiceGetAltchaChallengeProcedure:    true,
+	leapmuxv1connect.AuthServiceBeginPasskeyLoginProcedure:     true,
+	leapmuxv1connect.AuthServiceFinishPasskeyLoginProcedure:    true,
+	leapmuxv1connect.AuthServiceBeginPasskeySignUpProcedure:    true,
+	leapmuxv1connect.AuthServiceFinishPasskeySignUpProcedure:   true,
+	leapmuxv1connect.AuthServiceRequestPasswordResetProcedure:  true,
+	leapmuxv1connect.AuthServiceCompletePasswordResetProcedure: true,
 }
 
 // PublicProcedures lists every procedure the auth interceptor waives, so
@@ -349,7 +355,7 @@ func NewInterceptor(opts InterceptorOptions) (connect.Interceptor, *AuthContextR
 		// session's cache row. ValidateWithUser returns ErrNotFound for a gone or
 		// expired session, which the caller degrades to the connect-time value.
 		sc.sessionExpiry = func(ctx context.Context, sessionID string) (time.Time, bool, error) {
-			sess, err := st.Sessions().ValidateWithUser(ctx, sessionID)
+			sess, err := st.Sessions().ValidateWithUser(ctx, sessionID, time.Now().UTC())
 			if errors.Is(err, store.ErrNotFound) {
 				return time.Time{}, false, nil
 			}
@@ -1247,6 +1253,9 @@ func (a *authInterceptor) touchSession(ctx context.Context, sessionID string, us
 		ID:           sessionID,
 		ExpiresAt:    newExpiry,
 		LastActiveAt: now.Add(-threshold).UTC(),
+		// The hub clock judges the previous expiry; a zero Now would let an
+		// expired session match and revive.
+		Now: now.UTC(),
 	})
 	if err != nil {
 		// Nothing above this call reports the failure, and the caller cannot

--- a/backend/internal/hub/auth/interceptor.go
+++ b/backend/internal/hub/auth/interceptor.go
@@ -1249,14 +1249,13 @@ func (a *authInterceptor) touchSession(ctx context.Context, sessionID string, us
 	a.state.lastTouch.Store(sessionID, now)
 
 	newExpiry := now.Add(a.slideDuration(p)).UTC()
+	// The trailing instant is the hub clock that judges the previous
+	// expiry, so an expired session cannot match and revive.
 	rows, err := a.store.Sessions().Touch(ctx, store.TouchSessionParams{
 		ID:           sessionID,
 		ExpiresAt:    newExpiry,
 		LastActiveAt: now.Add(-threshold).UTC(),
-		// The hub clock judges the previous expiry; a zero Now would let an
-		// expired session match and revive.
-		Now: now.UTC(),
-	})
+	}, now.UTC())
 	if err != nil {
 		// Nothing above this call reports the failure, and the caller cannot
 		// tell it apart from a throttled request. Log it, or a store that

--- a/backend/internal/hub/auth/interceptor_test.go
+++ b/backend/internal/hub/auth/interceptor_test.go
@@ -607,7 +607,7 @@ func TestTouchSession_ThrottledWithinThreshold(t *testing.T) {
 	_, err := client.GetCurrentUser(context.Background(), req1)
 	require.NoError(t, err)
 
-	sess1, err := st.Sessions().GetByID(context.Background(), token)
+	sess1, err := st.Sessions().GetByID(context.Background(), token, time.Now().UTC())
 	require.NoError(t, err)
 	t1 := sess1.LastActiveAt
 
@@ -617,7 +617,7 @@ func TestTouchSession_ThrottledWithinThreshold(t *testing.T) {
 	_, err = client.GetCurrentUser(context.Background(), req2)
 	require.NoError(t, err)
 
-	sess2, err := st.Sessions().GetByID(context.Background(), token)
+	sess2, err := st.Sessions().GetByID(context.Background(), token, time.Now().UTC())
 	require.NoError(t, err)
 	t2 := sess2.LastActiveAt
 
@@ -666,7 +666,7 @@ func TestTouchSession_SlideRefreshesCookie(t *testing.T) {
 	assert.WithinDuration(t, before.Add(configured), parsed.Expires, 15*time.Minute,
 		"the slide must follow the configured duration, not the default")
 
-	sess, err := st.Sessions().GetByID(context.Background(), token)
+	sess, err := st.Sessions().GetByID(context.Background(), token, time.Now().UTC())
 	require.NoError(t, err)
 	assert.WithinDuration(t, sess.ExpiresAt, parsed.Expires, time.Second,
 		"the cookie and the row must expire together, or one outlives the other silently")
@@ -682,7 +682,7 @@ func TestLogin_UsesConfiguredSessionDuration(t *testing.T) {
 	before := time.Now()
 	token := loginAdmin(t, client)
 
-	sess, err := st.Sessions().GetByID(context.Background(), token)
+	sess, err := st.Sessions().GetByID(context.Background(), token, time.Now().UTC())
 	require.NoError(t, err)
 	hubtestutil.AssertSessionLifetime(t, before, configured, sess.ExpiresAt)
 }
@@ -695,7 +695,7 @@ func TestLogin_UnconfiguredUsesDefaultSessionDuration(t *testing.T) {
 	before := time.Now()
 	token := loginAdmin(t, client)
 
-	sess, err := st.Sessions().GetByID(context.Background(), token)
+	sess, err := st.Sessions().GetByID(context.Background(), token, time.Now().UTC())
 	require.NoError(t, err)
 	hubtestutil.AssertSessionLifetime(t, before, auth.DefaultSessionDuration, sess.ExpiresAt)
 }

--- a/backend/internal/hub/auth/public_procedures_test.go
+++ b/backend/internal/hub/auth/public_procedures_test.go
@@ -44,6 +44,12 @@ var publicProcedureRationale = map[string]string{
 	leapmuxv1connect.AuthServiceGetPendingOAuthSignupProcedure: "keyed by the single-use pending-signup id issued by the OAuth callback",
 	leapmuxv1connect.AuthServiceCompleteOAuthSignupProcedure:   "keyed by the single-use pending-signup id issued by the OAuth callback",
 	leapmuxv1connect.AuthServiceGetAltchaChallengeProcedure:    "discloses only a self-authenticating PoW challenge (no secret); needed pre-login so the captcha widget can arm Login/SignUp",
+	leapmuxv1connect.AuthServiceBeginPasskeyLoginProcedure:     "credential-acquiring: starts a passkey assertion ceremony",
+	leapmuxv1connect.AuthServiceFinishPasskeyLoginProcedure:    "credential-acquiring: verifies a passkey assertion and mints a session",
+	leapmuxv1connect.AuthServiceBeginPasskeySignUpProcedure:    "credential-acquiring: starts passkey registration during sign-up",
+	leapmuxv1connect.AuthServiceFinishPasskeySignUpProcedure:   "credential-acquiring: verifies passkey registration and creates the account",
+	leapmuxv1connect.AuthServiceRequestPasswordResetProcedure:  "self-service break-glass: issues a reset email when SMTP is configured",
+	leapmuxv1connect.AuthServiceCompletePasswordResetProcedure: "self-service break-glass: consumes a single-use reset token and sets a new password",
 
 	// Self-authenticating against a worker credential the interceptor cannot
 	// parse. Each handler resolves the caller itself and refuses without it.

--- a/backend/internal/hub/captcha/interceptor.go
+++ b/backend/internal/hub/captcha/interceptor.go
@@ -23,6 +23,10 @@ var (
 	_ captchaRequest = (*leapmuxv1.LoginRequest)(nil)
 	_ captchaRequest = (*leapmuxv1.SignUpRequest)(nil)
 	_ captchaRequest = (*leapmuxv1.CompleteOAuthSignupRequest)(nil)
+	_ captchaRequest = (*leapmuxv1.BeginPasskeyLoginRequest)(nil)
+	_ captchaRequest = (*leapmuxv1.BeginPasskeySignUpRequest)(nil)
+	_ captchaRequest = (*leapmuxv1.RequestPasswordResetRequest)(nil)
+	_ captchaRequest = (*leapmuxv1.CompletePasswordResetRequest)(nil)
 )
 
 // protectedProcedure is one protected procedure's captcha contract.
@@ -42,9 +46,13 @@ type protectedProcedure struct {
 // action in the same entry makes a protected procedure without an action
 // structurally impossible.
 var protectedProcedures = map[string]protectedProcedure{
-	leapmuxv1connect.AuthServiceLoginProcedure:               {action: "login"},
-	leapmuxv1connect.AuthServiceSignUpProcedure:              {action: "signup"},
-	leapmuxv1connect.AuthServiceCompleteOAuthSignupProcedure: {action: "complete_signup"},
+	leapmuxv1connect.AuthServiceLoginProcedure:                 {action: "login"},
+	leapmuxv1connect.AuthServiceSignUpProcedure:                {action: "signup"},
+	leapmuxv1connect.AuthServiceCompleteOAuthSignupProcedure:   {action: "complete_signup"},
+	leapmuxv1connect.AuthServiceBeginPasskeyLoginProcedure:     {action: "passkey_login"},
+	leapmuxv1connect.AuthServiceBeginPasskeySignUpProcedure:    {action: "passkey_signup"},
+	leapmuxv1connect.AuthServiceRequestPasswordResetProcedure:  {action: "password_reset"},
+	leapmuxv1connect.AuthServiceCompletePasswordResetProcedure: {action: "complete_password_reset"},
 }
 
 // NewInterceptor returns a unary interceptor enforcing captcha + honeypot

--- a/backend/internal/hub/captcha/protected_procedures_test.go
+++ b/backend/internal/hub/captcha/protected_procedures_test.go
@@ -16,9 +16,13 @@ import (
 // that make an unauthenticated caller run Argon2 or create users, so an
 // entry without a written reason is unaudited.
 var protectedProcedureRationale = map[string]string{
-	leapmuxv1connect.AuthServiceLoginProcedure:               "runs Argon2 verification for an anonymous caller",
-	leapmuxv1connect.AuthServiceSignUpProcedure:              "creates a user (Argon2 hash, optional SMTP) for an anonymous caller",
-	leapmuxv1connect.AuthServiceCompleteOAuthSignupProcedure: "consumes a single-use pending id and creates a user for an anonymous caller",
+	leapmuxv1connect.AuthServiceLoginProcedure:                 "runs Argon2 verification for an anonymous caller",
+	leapmuxv1connect.AuthServiceSignUpProcedure:                "creates a user (Argon2 hash, optional SMTP) for an anonymous caller",
+	leapmuxv1connect.AuthServiceCompleteOAuthSignupProcedure:   "consumes a single-use pending id and creates a user for an anonymous caller",
+	leapmuxv1connect.AuthServiceBeginPasskeyLoginProcedure:     "starts a passkey assertion ceremony for an anonymous caller",
+	leapmuxv1connect.AuthServiceBeginPasskeySignUpProcedure:    "starts a passkey registration ceremony for an anonymous caller",
+	leapmuxv1connect.AuthServiceRequestPasswordResetProcedure:  "issues a password-reset email for an anonymous caller",
+	leapmuxv1connect.AuthServiceCompletePasswordResetProcedure: "runs Argon2 and rotates credentials for an anonymous caller with a reset token",
 }
 
 // captchaExemptRationale records, for every OTHER public procedure, why it
@@ -32,6 +36,8 @@ var captchaExemptRationale = map[string]string{
 	leapmuxv1connect.AuthServiceGetOAuthProvidersProcedure:                  "cheap pre-login read",
 	leapmuxv1connect.AuthServiceGetPendingOAuthSignupProcedure:              "read keyed by a single-use pending id; no expensive action",
 	leapmuxv1connect.AuthServiceGetAltchaChallengeProcedure:                 "issues the ALTCHA challenges themselves; protecting it would be circular",
+	leapmuxv1connect.AuthServiceFinishPasskeyLoginProcedure:                 "consumes a short-lived ceremony session; expensive work is in Begin",
+	leapmuxv1connect.AuthServiceFinishPasskeySignUpProcedure:                "consumes a short-lived ceremony session; expensive work is in Begin",
 	leapmuxv1connect.WorkerConnectorServiceRegisterProcedure:                "caller is a worker process with a registration key, not a human form",
 	leapmuxv1connect.WorkerConnectorServiceConnectProcedure:                 "caller is a worker process with an auth_token, not a human form",
 	leapmuxv1connect.WorkerReconcilerServiceListOwnedTabsForWorkerProcedure: "caller is a worker process with an auth_token, not a human form",

--- a/backend/internal/hub/cleanup/cleanup.go
+++ b/backend/internal/hub/cleanup/cleanup.go
@@ -38,14 +38,15 @@ func run(ctx context.Context, st store.Store) {
 
 	// Order respects FK dependencies: child rows before parent rows.
 	// workspaces/workers reference users.
-	cleanupStep("expired sessions", func() (int64, error) { return cs.HardDeleteExpiredSessions(ctx) })
+	cleanupStep("expired sessions", func() (int64, error) { return cs.HardDeleteExpiredSessions(ctx, now) })
 	cleanupStep("workspaces", func() (int64, error) { return cs.HardDeleteWorkspacesBefore(ctx, cutoff) })
 	cleanupStep("workers", func() (int64, error) { return cs.HardDeleteWorkersBefore(ctx, cutoff) })
 	cleanupStep("expired registration keys", func() (int64, error) { return cs.HardDeleteExpiredRegistrationKeysBefore(ctx, cutoff) })
 	cleanupStep("stale pending emails", func() (int64, error) { return cs.ClearStalePendingEmails(ctx, cutoff) })
 	cleanupStep("users", func() (int64, error) { return cs.HardDeleteUsersBefore(ctx, cutoff) })
-	cleanupStep("expired oauth states", func() (int64, error) { return cs.DeleteExpiredOAuthStates(ctx) })
-	cleanupStep("expired pending signups", func() (int64, error) { return cs.DeleteExpiredPendingOAuthSignups(ctx) })
+	cleanupStep("expired oauth states", func() (int64, error) { return cs.DeleteExpiredOAuthStates(ctx, now) })
+	cleanupStep("expired pending signups", func() (int64, error) { return cs.DeleteExpiredPendingOAuthSignups(ctx, now) })
+	cleanupStep("expired webauthn sessions", func() (int64, error) { return cs.DeleteExpiredWebAuthnSessions(ctx, now) })
 	cleanupStep("expired device authorizations", func() (int64, error) { return cs.DeleteExpiredDeviceAuthorizations(ctx, now) })
 	cleanupStep("expired CLI authorization codes", func() (int64, error) {
 		return cs.DeleteExpiredCLIAuthorizationCodes(ctx, now)

--- a/backend/internal/hub/cleanup/cleanup_test.go
+++ b/backend/internal/hub/cleanup/cleanup_test.go
@@ -233,3 +233,35 @@ func TestDrainUntilEmpty(t *testing.T) {
 		assert.Zero(t, calls)
 	})
 }
+
+func TestRun_DeletesExpiredWebAuthnSessions(t *testing.T) {
+	st := setupTestStore(t)
+	ctx := context.Background()
+
+	userID := id.Generate()
+	hash, err := password.Hash("TestPassword1!")
+	require.NoError(t, err)
+	require.NoError(t, st.Users().Create(ctx, store.CreateUserParams{
+		ID: userID, Username: "wauser",
+		PasswordHash: hash, DisplayName: "WA", PasswordSet: true,
+	}))
+
+	expiredID := id.Generate()
+	liveID := id.Generate()
+	now := time.Now().UTC()
+	require.NoError(t, st.WebAuthnSessions().Create(ctx, store.CreateWebAuthnSessionParams{
+		ID: expiredID, Kind: "login", UserID: userID, PayloadJSON: "{}",
+		SessionData: []byte("x"), ExpiresAt: now.Add(-time.Hour), CreatedAt: now.Add(-2 * time.Hour),
+	}))
+	require.NoError(t, st.WebAuthnSessions().Create(ctx, store.CreateWebAuthnSessionParams{
+		ID: liveID, Kind: "login", UserID: userID, PayloadJSON: "{}",
+		SessionData: []byte("y"), ExpiresAt: now.Add(time.Hour), CreatedAt: now,
+	}))
+
+	run(ctx, st)
+
+	_, err = st.WebAuthnSessions().Get(ctx, expiredID)
+	require.ErrorIs(t, err, store.ErrNotFound)
+	_, err = st.WebAuthnSessions().Get(ctx, liveID)
+	require.NoError(t, err)
+}

--- a/backend/internal/hub/keystore/keystore.go
+++ b/backend/internal/hub/keystore/keystore.go
@@ -57,6 +57,26 @@ func SettingsSecretAAD(key string) []byte {
 	return []byte("hub_settings:" + key)
 }
 
+// PasskeyPublicKeyAAD returns the AAD for a passkey credential's encrypted
+// COSE public key. The credential row id is bound so ciphertext cannot be
+// moved across rows.
+func PasskeyPublicKeyAAD(credentialRowID string) []byte {
+	return []byte("passkey_public_key:" + credentialRowID)
+}
+
+// WebAuthnSessionDataAAD returns the AAD for encrypted WebAuthn ceremony
+// state stored in webauthn_sessions.session_data.
+func WebAuthnSessionDataAAD(sessionID string) []byte {
+	return []byte("webauthn_session:" + sessionID)
+}
+
+// WebAuthnPayloadAAD returns the AAD for an encrypted signup draft stored
+// in webauthn_sessions.payload_json. The session id is bound so ciphertext
+// cannot be swapped between ceremony rows.
+func WebAuthnPayloadAAD(sessionID string) []byte {
+	return []byte("webauthn_payload:" + sessionID)
+}
+
 // Keystore manages a versioned key ring for XChaCha20-Poly1305 envelope
 // encryption plus a dedicated, stable pepper for bearer-token hashing.
 type Keystore struct {

--- a/backend/internal/hub/keystore/keystore_test.go
+++ b/backend/internal/hub/keystore/keystore_test.go
@@ -360,3 +360,26 @@ func newTestKeystore(t *testing.T) *Keystore {
 	require.NoError(t, err)
 	return ks
 }
+
+func TestPasskeyPublicKeyAAD(t *testing.T) {
+	aad := PasskeyPublicKeyAAD("cred-row-1")
+	assert.Equal(t, []byte("passkey_public_key:cred-row-1"), aad)
+}
+
+func TestWebAuthnPayloadAAD(t *testing.T) {
+	aad := WebAuthnPayloadAAD("session-1")
+	assert.Equal(t, []byte("webauthn_payload:session-1"), aad)
+}
+
+func TestWebAuthnSessionDataAAD(t *testing.T) {
+	aad := WebAuthnSessionDataAAD("session-1")
+	assert.Equal(t, []byte("webauthn_session:session-1"), aad)
+}
+
+func TestPasskeyAADBindingRejectsSwap(t *testing.T) {
+	ks := newTestKeystore(t)
+	ct, err := ks.Encrypt([]byte("cose-key"), PasskeyPublicKeyAAD("row-a"))
+	require.NoError(t, err)
+	_, err = ks.Decrypt(ct, PasskeyPublicKeyAAD("row-b"))
+	assert.Error(t, err)
+}

--- a/backend/internal/hub/mail/smtp.go
+++ b/backend/internal/hub/mail/smtp.go
@@ -93,7 +93,32 @@ func NewSMTPSender(cfg SMTPConfig) *SMTPSender {
 //  7. Build RFC 5322 headers + body and write via Data(). The textproto
 //     DotWriter handles dot-stuffing AND \n→\r\n translation, so the
 //     body is written with plain LF line endings.
+//
+// sendTimeout caps one complete SMTP exchange when the caller supplies no
+// deadline. It has to cover dial, TLS handshake, EHLO, AUTH, and DATA
+// against a slow relay, while staying well inside the interactive request
+// a user is waiting on.
+const sendTimeout = 20 * time.Second
+
 func (s *SMTPSender) Send(ctx context.Context, msg Message) error {
+	// Bound the WHOLE exchange, not just the dial. Callers send inline on
+	// interactive RPC paths (login, sign-up, password reset), and a Connect
+	// request context carries no server-side deadline of its own, so a relay
+	// that completes the TCP handshake and then stalls in EHLO, AUTH, or
+	// DATA held the request goroutine open indefinitely: the sign-in button
+	// spun until the client's own timeout, and a login whose session was
+	// already minted and committed surfaced as a failure.
+	//
+	// The deadline goes here rather than at each call site because the steps
+	// below already honor it -- the watchdog closes the connection on
+	// cancellation and SetDeadline covers the non-ctx-aware stdlib calls. A
+	// caller that sets a shorter deadline keeps it.
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, sendTimeout)
+		defer cancel()
+	}
+
 	cfg := s.cfg
 	if err := validateNoCRLF("To", msg.To); err != nil {
 		return err

--- a/backend/internal/hub/mail/smtp.go
+++ b/backend/internal/hub/mail/smtp.go
@@ -130,7 +130,10 @@ func (s *SMTPSender) Send(ctx context.Context, msg Message) error {
 
 	dial := cfg.Dialer
 	if dial == nil {
-		dial = (&net.Dialer{}).DialContext
+		// Bound the connect phase: callers send mail inline on interactive
+		// RPC paths (login, signup), and the OS default TCP timeout is far
+		// longer than any user waits.
+		dial = (&net.Dialer{Timeout: 10 * time.Second}).DialContext
 	}
 	addr := net.JoinHostPort(cfg.Host, strconv.Itoa(cfg.Port))
 

--- a/backend/internal/hub/mail/smtp_test.go
+++ b/backend/internal/hub/mail/smtp_test.go
@@ -565,6 +565,53 @@ func TestSMTPSender_ContextCancelledBeforeDial(t *testing.T) {
 	}
 }
 
+// A caller that supplies no deadline still gets one: Send is called inline
+// on interactive RPC paths, and a Connect request context carries no
+// server-side deadline, so a relay that completes the TCP handshake and
+// then stalls would hold the request goroutine open indefinitely.
+func TestSMTPSender_BoundsAnUndeadlinedSend(t *testing.T) {
+	// A dialer that returns a connection nobody ever answers on: the
+	// exchange stalls after the dial, which is exactly the phase the
+	// pre-existing net.Dialer timeout does not cover.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			// Accept and say nothing. The client waits for the greeting.
+			t.Cleanup(func() { _ = conn.Close() })
+		}
+	}()
+
+	sender := mail.NewSMTPSender(mail.SMTPConfig{
+		Host: "127.0.0.1", Port: 25, From: "hub@example.test", TLSMode: "none",
+		Dialer: func(ctx context.Context, network, _ string) (net.Conn, error) {
+			var d net.Dialer
+			return d.DialContext(ctx, network, listener.Addr().String())
+		},
+	})
+
+	// The caller's own deadline wins, and it proves the bound is honored
+	// across the post-dial phases without making the test wait for the
+	// production default.
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	err = sender.Send(ctx, mail.Message{To: "alice@example.test", Subject: "x", Body: "y\n"})
+	if err == nil {
+		t.Fatal("expected the stalled exchange to fail, got nil")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("Send took %v; the exchange is not bounded", elapsed)
+	}
+}
+
 // poolFromServerCfg lifts the leaf cert from a server-side *tls.Config
 // (where it lives as a tls.Certificate) into a *x509.CertPool the
 // client can trust. Avoids re-minting cert material per test.

--- a/backend/internal/hub/mail/templates.go
+++ b/backend/internal/hub/mail/templates.go
@@ -55,6 +55,22 @@ func (r Renderer) footer() string {
 		"Please do not reply.\n"
 }
 
+// expiresIn renders a token lifetime as the prose the email bodies use.
+// The two production lifetimes keep their pinned English; any other
+// duration falls back to whole minutes so a future lifetime cannot render
+// empty. Callers pass the same constant that governs the real expiry, so
+// the sentence and the token cannot promise different lifetimes.
+func expiresIn(ttl time.Duration) string {
+	switch ttl {
+	case time.Hour:
+		return "one hour"
+	case 30 * time.Minute:
+		return "30 minutes"
+	default:
+		return fmt.Sprintf("%d minutes", int(ttl.Minutes()))
+	}
+}
+
 // VerificationEmail builds the email that delivers a verification code
 // to confirm a new or changed email address.
 //
@@ -79,7 +95,7 @@ func (r Renderer) footer() string {
 //
 //	    {link}
 //
-//	The code expires in 30 minutes.
+//	The code expires in {ttl}.
 //
 //	-- ␠
 //	This is an automated message from your LeapMux hub at {hubURL}.
@@ -87,22 +103,6 @@ func (r Renderer) footer() string {
 //
 // (The "␠" marker stands in for a literal trailing space on the "-- "
 // signature delimiter; see RFC 3676 §4.3.)
-// expiresIn renders a token lifetime as the prose the email bodies use.
-// The two production lifetimes keep their pinned English; any other
-// duration falls back to whole minutes so a future lifetime cannot render
-// empty. Callers pass the same constant that governs the real expiry, so
-// the sentence and the token cannot promise different lifetimes.
-func expiresIn(ttl time.Duration) string {
-	switch ttl {
-	case time.Hour:
-		return "one hour"
-	case 30 * time.Minute:
-		return "30 minutes"
-	default:
-		return fmt.Sprintf("%d minutes", int(ttl.Minutes()))
-	}
-}
-
 func (r Renderer) VerificationEmail(to, storedCode string, ttl time.Duration) Message {
 	display := verifycode.Format(storedCode)
 	link := r.hubURL() + verifyEmailPath + display
@@ -165,11 +165,16 @@ func (r Renderer) RegistrationInstructions(to, command string) Message {
 // PasswordResetEmail builds the self-service password reset email.
 func (r Renderer) PasswordResetEmail(to, token string, ttl time.Duration) Message {
 	link := r.hubURL() + resetPasswordPath + token
+	// expiresIn is an ARGUMENT, never spliced into the format string: a
+	// concatenated value carries its own text into the verb list, so one
+	// stray %% in a future duration string would shift every verb after it
+	// and render "%!o(string=F)f an hour" into the delivered mail.
 	body := fmt.Sprintf(
 		"You requested a password reset for your LeapMux account.\n\n"+
 			"Click the link below to choose a new password:\n\n    %s\n\n"+
-			"The link expires in "+expiresIn(ttl)+". If you did not request this, you can ignore this email.\n\n%s",
+			"The link expires in %s. If you did not request this, you can ignore this email.\n\n%s",
 		link,
+		expiresIn(ttl),
 		r.footer(),
 	)
 	return Message{

--- a/backend/internal/hub/mail/templates.go
+++ b/backend/internal/hub/mail/templates.go
@@ -3,6 +3,7 @@ package mail
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/leapmux/leapmux/internal/util/verifycode"
 )
@@ -19,6 +20,9 @@ const footerSeparator = "-- \n"
 // verification link is built" — callers only know the code, not the URL
 // shape.
 const verifyEmailPath = "/verify-email?code="
+
+// resetPasswordPath is the frontend route for self-service password reset.
+const resetPasswordPath = "/reset-password?token="
 
 // Renderer builds the email Messages this package sends. It carries a
 // base-URL closure so render call sites only pass per-message data
@@ -55,7 +59,7 @@ func (r Renderer) footer() string {
 // to confirm a new or changed email address.
 //
 // Sent when:
-//   - Password sign-up with email when EmailVerificationRequired=true.
+//   - Password sign-up with email when SMTP verification is effective.
 //   - OAuth sign-up when the provider's email is untrusted.
 //   - User requests an email change.
 //   - User requests a resend of a previously-issued code.
@@ -83,7 +87,23 @@ func (r Renderer) footer() string {
 //
 // (The "␠" marker stands in for a literal trailing space on the "-- "
 // signature delimiter; see RFC 3676 §4.3.)
-func (r Renderer) VerificationEmail(to, storedCode string) Message {
+// expiresIn renders a token lifetime as the prose the email bodies use.
+// The two production lifetimes keep their pinned English; any other
+// duration falls back to whole minutes so a future lifetime cannot render
+// empty. Callers pass the same constant that governs the real expiry, so
+// the sentence and the token cannot promise different lifetimes.
+func expiresIn(ttl time.Duration) string {
+	switch ttl {
+	case time.Hour:
+		return "one hour"
+	case 30 * time.Minute:
+		return "30 minutes"
+	default:
+		return fmt.Sprintf("%d minutes", int(ttl.Minutes()))
+	}
+}
+
+func (r Renderer) VerificationEmail(to, storedCode string, ttl time.Duration) Message {
 	display := verifycode.Format(storedCode)
 	link := r.hubURL() + verifyEmailPath + display
 	var body strings.Builder
@@ -91,7 +111,7 @@ func (r Renderer) VerificationEmail(to, storedCode string) Message {
 	body.WriteString(display)
 	body.WriteString("\n\nOr click the link below:\n\n    ")
 	body.WriteString(link)
-	body.WriteString("\n\nThe code expires in 30 minutes.\n\n")
+	body.WriteString("\n\nThe code expires in " + expiresIn(ttl) + ".\n\n")
 	body.WriteString(r.footer())
 	return Message{
 		To:      to,
@@ -138,6 +158,23 @@ func (r Renderer) RegistrationInstructions(to, command string) Message {
 	return Message{
 		To:      to,
 		Subject: "[LeapMux] Your worker registration command",
+		Body:    body,
+	}
+}
+
+// PasswordResetEmail builds the self-service password reset email.
+func (r Renderer) PasswordResetEmail(to, token string, ttl time.Duration) Message {
+	link := r.hubURL() + resetPasswordPath + token
+	body := fmt.Sprintf(
+		"You requested a password reset for your LeapMux account.\n\n"+
+			"Click the link below to choose a new password:\n\n    %s\n\n"+
+			"The link expires in "+expiresIn(ttl)+". If you did not request this, you can ignore this email.\n\n%s",
+		link,
+		r.footer(),
+	)
+	return Message{
+		To:      to,
+		Subject: "[LeapMux] Reset your password",
 		Body:    body,
 	}
 }

--- a/backend/internal/hub/mail/templates_test.go
+++ b/backend/internal/hub/mail/templates_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/leapmux/leapmux/internal/hub/mail"
 )
@@ -44,6 +45,18 @@ func expectedRegistrationBody(command, hubURL string) string {
 	return b.String()
 }
 
+func expectedPasswordResetBody(link, hubURL string) string {
+	var b strings.Builder
+	b.WriteString("You requested a password reset for your LeapMux account.\n\n")
+	b.WriteString("Click the link below to choose a new password:\n\n    ")
+	b.WriteString(link)
+	b.WriteString("\n\nThe link expires in one hour. If you did not request this, you can ignore this email.\n\n")
+	b.WriteString(verificationFooterTrailingSpace + "\n")
+	b.WriteString("This is an automated message from your LeapMux hub at " + hubURL + ".\n")
+	b.WriteString("Please do not reply.\n")
+	return b.String()
+}
+
 // TestRenderer_VerificationEmail_Bytes is the exactness oracle for the
 // verification email's body. It pins every byte including the trailing
 // space on "-- ", the blank line before the link, and the {hubURL}
@@ -55,7 +68,7 @@ func TestRenderer_VerificationEmail_Bytes(t *testing.T) {
 	link := hubURL + "/verify-email?code=" + formatted
 
 	r := mail.Renderer{BaseURL: func() string { return hubURL }}
-	msg := r.VerificationEmail("alice@example.test", storedCode)
+	msg := r.VerificationEmail("alice@example.test", storedCode, 30*time.Minute)
 
 	if msg.To != "alice@example.test" {
 		t.Errorf("To = %q, want %q", msg.To, "alice@example.test")
@@ -70,6 +83,28 @@ func TestRenderer_VerificationEmail_Bytes(t *testing.T) {
 	}
 	if !strings.Contains(msg.Body, "\n-- \n") {
 		t.Error("body must contain the literal RFC 3676 §4.3 signature delimiter \"\\n-- \\n\" (dash-dash-space-newline)")
+	}
+}
+
+// TestRenderer_PasswordResetEmail_Bytes pins the password reset email body.
+func TestRenderer_PasswordResetEmail_Bytes(t *testing.T) {
+	const token = "abc123"
+	const hubURL = "https://hub.example.com"
+	link := hubURL + "/reset-password?token=" + token
+
+	r := mail.Renderer{BaseURL: func() string { return hubURL }}
+	msg := r.PasswordResetEmail("alice@example.test", token, time.Hour)
+
+	if msg.To != "alice@example.test" {
+		t.Errorf("To = %q, want %q", msg.To, "alice@example.test")
+	}
+	if msg.Subject != "[LeapMux] Reset your password" {
+		t.Errorf("Subject = %q, want %q", msg.Subject, "[LeapMux] Reset your password")
+	}
+
+	want := expectedPasswordResetBody(link, hubURL)
+	if msg.Body != want {
+		t.Errorf("Body bytes mismatch.\n got: %q\nwant: %q", msg.Body, want)
 	}
 }
 
@@ -110,7 +145,7 @@ func printForExample(msg mail.Message) string {
 
 func ExampleRenderer_VerificationEmail() {
 	r := mail.Renderer{BaseURL: func() string { return "https://hub.example.com" }}
-	msg := r.VerificationEmail("alice@example.test", "ABC234")
+	msg := r.VerificationEmail("alice@example.test", "ABC234", 30*time.Minute)
 	fmt.Print(printForExample(msg))
 	// Output:
 	// [LeapMux] Verify your email address
@@ -151,4 +186,17 @@ func ExampleRenderer_RegistrationInstructions() {
 	// -- ␠
 	// This is an automated message from your LeapMux hub at https://hub.example.com.
 	// Please do not reply.
+}
+
+// A renderer must reflect the TTL argument it was given: the sentence and
+// the token lifetime come from one constant, so they cannot drift.
+func TestRenderersReflectTTLArgument(t *testing.T) {
+	v := mail.Renderer{}.VerificationEmail("alice@example.test", "ABC234", 2*time.Hour)
+	if !strings.Contains(v.Body, "The code expires in 120 minutes.") {
+		t.Errorf("verification body does not reflect the TTL: %q", v.Body)
+	}
+	p := mail.Renderer{}.PasswordResetEmail("alice@example.test", "tok", 2*time.Hour)
+	if !strings.Contains(p.Body, "The link expires in 120 minutes.") {
+		t.Errorf("reset body does not reflect the TTL: %q", p.Body)
+	}
 }

--- a/backend/internal/hub/ratelimit/ratelimit.go
+++ b/backend/internal/hub/ratelimit/ratelimit.go
@@ -34,6 +34,11 @@ type Operation string
 const (
 	// OpChangePassword rate-limits UserService.ChangePassword per user.
 	OpChangePassword Operation = "change-password"
+	// OpPasskeyManagement rate-limits passkey management RPCs per user
+	// (Begin/Finish registration and reauth, rename, delete, deactivate).
+	// Same budget shape as ChangePassword: Argon2 verify on each failed
+	// current-password attempt; Begin/Finish also share the in-flight cap.
+	OpPasskeyManagement Operation = "passkey-management"
 )
 
 // Limits is one operation's effective budget.
@@ -82,7 +87,16 @@ var defaults = map[Operation]opSpec{
 	OpChangePassword: {
 		limits: Limits{MaxAttempts: 5, WindowSeconds: 900},
 		isCredentialFailure: func(err error) bool {
-			return errors.Is(err, auth.ErrInvalidCurrentPassword)
+			// ChangePassword also authenticates passkey-only accounts via a
+			// reauth proof; both wrong-secret classes count against the
+			// same budget.
+			return errors.Is(err, auth.ErrInvalidCurrentPassword) || errors.Is(err, auth.ErrInvalidReauthProof)
+		},
+	},
+	OpPasskeyManagement: {
+		limits: Limits{MaxAttempts: 5, WindowSeconds: 900},
+		isCredentialFailure: func(err error) bool {
+			return errors.Is(err, auth.ErrInvalidCurrentPassword) || errors.Is(err, auth.ErrInvalidReauthProof)
 		},
 	},
 }
@@ -156,7 +170,14 @@ func KnownOperations() []Operation {
 // The interceptor must be registered AFTER the auth interceptor so the
 // authenticated user is already in the context.
 var procedureOperations = map[string]Operation{
-	leapmuxv1connect.UserServiceChangePasswordProcedure: OpChangePassword,
+	leapmuxv1connect.UserServiceChangePasswordProcedure:            OpChangePassword,
+	leapmuxv1connect.UserServiceBeginPasskeyRegistrationProcedure:  OpPasskeyManagement,
+	leapmuxv1connect.UserServiceFinishPasskeyRegistrationProcedure: OpPasskeyManagement,
+	leapmuxv1connect.UserServiceBeginPasskeyReauthProcedure:        OpPasskeyManagement,
+	leapmuxv1connect.UserServiceFinishPasskeyReauthProcedure:       OpPasskeyManagement,
+	leapmuxv1connect.UserServiceRenamePasskeyProcedure:             OpPasskeyManagement,
+	leapmuxv1connect.UserServiceDeletePasskeyProcedure:             OpPasskeyManagement,
+	leapmuxv1connect.UserServiceDeactivatePasskeyAuthProcedure:     OpPasskeyManagement,
 }
 
 // effectiveLimit is the resolved per-operation policy.

--- a/backend/internal/hub/ratelimit/ratelimit_test.go
+++ b/backend/internal/hub/ratelimit/ratelimit_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"google.golang.org/protobuf/reflect/protoregistry"
+
 	"connectrpc.com/connect"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -81,6 +83,45 @@ func changePasswordClient(t *testing.T, m *Manager, handlerErr error, authentica
 	server := httptest.NewServer(mux)
 	t.Cleanup(server.Close)
 	return leapmuxv1connect.NewUserServiceClient(server.Client(), server.URL), &handlerCalls
+}
+
+func wrongReauthProofError() error {
+	return connect.NewError(connect.CodeUnauthenticated, auth.ErrInvalidReauthProof)
+}
+
+func renamePasskeyClient(t *testing.T, m *Manager, handlerErr error, authenticated bool) (leapmuxv1connect.UserServiceClient, *int) {
+	t.Helper()
+	handlerCalls := 0
+	handler := connect.NewUnaryHandler(
+		leapmuxv1connect.UserServiceRenamePasskeyProcedure,
+		func(ctx context.Context, req *connect.Request[leapmuxv1.RenamePasskeyRequest]) (*connect.Response[leapmuxv1.RenamePasskeyResponse], error) {
+			handlerCalls++
+			if handlerErr != nil {
+				return nil, handlerErr
+			}
+			return connect.NewResponse(&leapmuxv1.RenamePasskeyResponse{}), nil
+		},
+		connect.WithInterceptors(NewInterceptor(m)),
+	)
+	mux := http.NewServeMux()
+	mux.Handle(leapmuxv1connect.UserServiceRenamePasskeyProcedure, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if authenticated {
+			r = r.WithContext(auth.WithUser(r.Context(), &auth.UserInfo{ID: userid.MustNew("usr_test123")}))
+		}
+		handler.ServeHTTP(w, r)
+	}))
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	return leapmuxv1connect.NewUserServiceClient(server.Client(), server.URL), &handlerCalls
+}
+
+func tryRenamePasskey(t *testing.T, client leapmuxv1connect.UserServiceClient) error {
+	t.Helper()
+	_, err := client.RenamePasskey(context.Background(), connect.NewRequest(&leapmuxv1.RenamePasskeyRequest{
+		Id:           "pk-1",
+		FriendlyName: "Phone",
+	}))
+	return err
 }
 
 func tryChangePassword(t *testing.T, client leapmuxv1connect.UserServiceClient) error {
@@ -363,7 +404,7 @@ func TestPanickingHandlerReleasesReservation(t *testing.T) {
 }
 
 func TestKnownOperationsSortedAndEffectiveLimitsOverlay(t *testing.T) {
-	assert.Equal(t, []Operation{OpChangePassword}, KnownOperations())
+	assert.Equal(t, []Operation{OpChangePassword, OpPasskeyManagement}, KnownOperations())
 
 	// No row: defaults, enabled.
 	m := newTestManager(t, false)
@@ -456,10 +497,75 @@ func TestProcedureRoutingAndCatalogueAgree(t *testing.T) {
 	}
 }
 
+// TestChangePasswordCountsInvalidReauthProof pins that ChangePassword's
+// budget covers BOTH wrong-secret classes it can return: an invalid current
+// password and an invalid reauth proof (passkey-only accounts step up with a
+// proof). The proof class shipped unrouted once — unlimited retries while
+// the sibling passkey operations were capped.
+func TestChangePasswordCountsInvalidReauthProof(t *testing.T) {
+	m := newTestManager(t, false)
+	upsertLimit(t, m, OpChangePassword, true, 2, 900)
+
+	client, calls := changePasswordClient(t, m, wrongReauthProofError(), true)
+	for i := 0; i < 2; i++ {
+		assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(tryChangePassword(t, client)))
+	}
+	assert.Equal(t, 2, *calls)
+	assert.Equal(t, connect.CodeResourceExhausted, connect.CodeOf(tryChangePassword(t, client)))
+	assert.Equal(t, 2, *calls, "denied attempt must not reach the handler")
+}
+
+// TestCredentialConsumingProceduresAreRouted walks the live user.proto
+// descriptor: every UserService method whose request carries a step-up
+// secret (current_password or reauth_proof) must have a procedureOperations
+// entry. The routing map is hand-maintained; a new credential-consuming RPC
+// that ships unrouted keeps unlimited retries while its siblings are
+// capped, and only a descriptor walk catches the forgotten direction.
+func TestCredentialConsumingProceduresAreRouted(t *testing.T) {
+	fd, err := protoregistry.GlobalFiles.FindFileByPath("leapmux/v1/user.proto")
+	require.NoError(t, err, "user.proto descriptor must be registered; import the generated pb package")
+	services := fd.Services()
+	require.Equal(t, 1, services.Len(), "expected exactly the UserService in user.proto")
+	methods := services.Get(0).Methods()
+	for i := 0; i < methods.Len(); i++ {
+		method := methods.Get(i)
+		consumesSecret := false
+		fields := method.Input().Fields()
+		for j := 0; j < fields.Len(); j++ {
+			name := string(fields.Get(j).Name())
+			if name == "current_password" || name == "reauth_proof" {
+				consumesSecret = true
+				break
+			}
+		}
+		if !consumesSecret {
+			continue
+		}
+		procedure := "/" + string(services.Get(0).FullName()) + "/" + string(method.Name())
+		_, routed := procedureOperations[procedure]
+		assert.Truef(t, routed,
+			"UserService.%s carries a step-up secret but has no procedureOperations entry; it ships with unlimited retries (procedure %q)",
+			method.Name(), procedure)
+	}
+}
+
 func TestValidateLimits(t *testing.T) {
 	assert.NoError(t, ValidateLimits(Limits{MaxAttempts: 5, WindowSeconds: 900}))
 	assert.Error(t, ValidateLimits(Limits{MaxAttempts: 0, WindowSeconds: 900}))
 	assert.Error(t, ValidateLimits(Limits{MaxAttempts: 5000, WindowSeconds: 900}))
 	assert.Error(t, ValidateLimits(Limits{MaxAttempts: 5, WindowSeconds: 30}))
 	assert.Error(t, ValidateLimits(Limits{MaxAttempts: 5, WindowSeconds: 100000}))
+}
+
+func TestPasskeyManagementCountsInvalidReauthProof(t *testing.T) {
+	m := newTestManager(t, false)
+	upsertLimit(t, m, OpPasskeyManagement, true, 2, 900)
+
+	client, calls := renamePasskeyClient(t, m, wrongReauthProofError(), true)
+	for i := 0; i < 2; i++ {
+		assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(tryRenamePasskey(t, client)))
+	}
+	assert.Equal(t, 2, *calls)
+	assert.Equal(t, connect.CodeResourceExhausted, connect.CodeOf(tryRenamePasskey(t, client)))
+	assert.Equal(t, 2, *calls, "denied attempt must not reach the handler")
 }

--- a/backend/internal/hub/service/admin_settings_service_test.go
+++ b/backend/internal/hub/service/admin_settings_service_test.go
@@ -186,14 +186,6 @@ func TestAdminSettingsService_ValuesDefaultAndCustomized(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
 
-	// Cross-key refusal: requiring email verification without SMTP.
-	_, err = env.client.UpdateSetting(ctx, authedReq(&leapmuxv1.UpdateSettingRequest{
-		Key:         "email_verification_required",
-		PartialJson: "true",
-	}, env.token))
-	require.Error(t, err)
-	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
-
 	// Reset returns the default.
 	reset, err := env.client.ResetSetting(ctx, authedReq(&leapmuxv1.ResetSettingRequest{
 		Key: "session_duration_seconds",
@@ -369,9 +361,8 @@ func TestAdminSettingsService_SoloOmitsHiddenInSolo(t *testing.T) {
 		// No captcha to solve, and no second user to rate-limit.
 		"captcha.altcha", "captcha.enabled", "captcha.recaptcha_v3",
 		"captcha.selected", "captcha.turnstile",
-		// Sign-up is refused outright, so neither key does anything.
-		"email_verification_required",
 		"rate_limit.change-password",
+		"rate_limit.passkey-management",
 		// No cookie and no session exist on the synthetic-user path.
 		"secure_cookies", "session_duration_seconds",
 		"signup_enabled",

--- a/backend/internal/hub/service/admin_user_service.go
+++ b/backend/internal/hub/service/admin_user_service.go
@@ -623,6 +623,40 @@ func (s *AdminUserService) SetUserAdmin(ctx context.Context, req *connect.Reques
 			}); err != nil {
 				return storeConnectError(err, "mark admin email verified")
 			}
+			return nil
+		}
+		// Demotion must repair the flag the admin invariant forced, or the
+		// promotion leaks a verified state the account never earned: the
+		// demoted row then passes the login verification gate, passes
+		// UpdateUser's clear-email guard, and satisfies the "no durable
+		// identity" refusal that protects a first passkey.
+		//
+		// An EMPTY email is the case this can decide. email_verified
+		// describes an address, so with no address there is nothing that
+		// could have been confirmed and the flag can only have come from the
+		// promotion above (or from createUserInTx forcing it for the /setup
+		// admin). A demoted account that HAS an address is left alone: the
+		// row records no pre-promotion value, so lowering it there would
+		// un-verify an address the user really did confirm.
+		if !req.Msg.GetIsAdmin() {
+			// Re-read INSIDE the transaction. `user` is the unlocked
+			// pre-transaction snapshot, and the decision turns on the very
+			// columns a concurrent VerifyEmail rewrites: promoting a pending
+			// address sets email and email_verified together, so deciding
+			// from the snapshot would clear a verification the user really
+			// completed between the read and this write.
+			locked, err := tx.Users().GetByID(ctx, user.ID)
+			if err != nil {
+				return storeConnectError(err, "re-read user for demotion")
+			}
+			if locked.EmailVerified && locked.Email == "" {
+				if err := tx.Users().UpdateEmailVerified(ctx, store.UpdateUserEmailVerifiedParams{
+					EmailVerified: false,
+					ID:            user.ID,
+				}); err != nil {
+					return storeConnectError(err, "clear unearned email verification")
+				}
+			}
 		}
 		return nil
 	}); err != nil {
@@ -722,7 +756,7 @@ func (s *AdminUserService) ListUserSessions(ctx context.Context, req *connect.Re
 	page, err := s.store.Sessions().ListByUserID(ctx, store.ListUserSessionsParams{
 		UserID:     uid,
 		PageParams: AdminPageParams(req.Msg.GetCursor(), req.Msg.GetLimit()),
-	})
+	}, time.Now().UTC())
 	if err != nil {
 		return nil, storeConnectError(err, "list user sessions")
 	}
@@ -745,7 +779,7 @@ func (s *AdminUserService) ListUserSessions(ctx context.Context, req *connect.Re
 func (s *AdminUserService) ListSessions(ctx context.Context, req *connect.Request[leapmuxv1.ListSessionsRequest]) (*connect.Response[leapmuxv1.ListSessionsResponse], error) {
 	page, err := s.store.Sessions().ListAllActive(ctx, store.ListAllActiveSessionsParams{
 		PageParams: AdminPageParams(req.Msg.GetCursor(), req.Msg.GetLimit()),
-	})
+	}, time.Now().UTC())
 	if err != nil {
 		return nil, storeConnectError(err, "list sessions")
 	}

--- a/backend/internal/hub/service/admin_user_service.go
+++ b/backend/internal/hub/service/admin_user_service.go
@@ -12,6 +12,7 @@ import (
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/hub/auth"
 	"github.com/leapmux/leapmux/internal/hub/password"
+	"github.com/leapmux/leapmux/internal/hub/settings"
 	"github.com/leapmux/leapmux/internal/hub/store"
 	"github.com/leapmux/leapmux/internal/hub/usernames"
 	"github.com/leapmux/leapmux/internal/util/id"
@@ -27,6 +28,7 @@ import (
 // hub stopped) stay in `leapmux recover`.
 type AdminUserService struct {
 	store     store.Store
+	set       *settings.Manager
 	validator *auth.TokenValidator
 	// lifecycle tears down the in-process holders of a credential this
 	// service revokes. The durable revocation events reach every hub, but
@@ -39,8 +41,8 @@ type AdminUserService struct {
 	workerEffects *WorkerDeregisterEffects
 }
 
-func NewAdminUserService(st store.Store, validator *auth.TokenValidator, lifecycle *auth.CredentialLifecycleEffects, workerEffects *WorkerDeregisterEffects) *AdminUserService {
-	return &AdminUserService{store: st, validator: validator, lifecycle: lifecycle, workerEffects: workerEffects}
+func NewAdminUserService(st store.Store, validator *auth.TokenValidator, lifecycle *auth.CredentialLifecycleEffects, workerEffects *WorkerDeregisterEffects, set *settings.Manager) *AdminUserService {
+	return &AdminUserService{set: set, store: st, validator: validator, lifecycle: lifecycle, workerEffects: workerEffects}
 }
 
 // adminUserToProto maps a user row. Password material never crosses.
@@ -346,6 +348,15 @@ func (s *AdminUserService) CreateUser(ctx context.Context, req *connect.Request[
 			return nil, connect.NewError(connect.CodeInvalidArgument, err)
 		}
 	}
+	// When the hub requires verification, an email-less unverified
+	// non-admin account lands on /verify-email with no code that can ever
+	// arrive: the login flow flags it verification-required but there is
+	// nothing to verify. Admins and explicit email_verified=true requests
+	// pass; CreateUser forces the admin flag in the database regardless.
+	if email == "" && !msg.GetIsAdmin() && !msg.GetEmailVerified() &&
+		s.set != nil && settings.EmailVerificationEffective(s.set.Snapshot(ctx)) {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("email is required when the hub requires email verification"))
+	}
 
 	// Pre-check availability so a collision is reported as a collision;
 	// the unique index remains the real guard against the race.
@@ -360,6 +371,8 @@ func (s *AdminUserService) CreateUser(ctx context.Context, req *connect.Request[
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("hash password: %w", err))
 	}
+	// CreateUser forces EmailVerified for admins, so the single invariant
+	// site owns the rule.
 	user, err := CreateUser(ctx, s.store, CreateUserParams{
 		Username:      username,
 		PasswordHash:  hashed,
@@ -404,6 +417,23 @@ func (s *AdminUserService) UpdateUser(ctx context.Context, req *connect.Request[
 		if err := validate.ValidateEmail(msg.GetEmail()); err != nil {
 			return nil, connect.NewError(connect.CodeInvalidArgument, err)
 		}
+	}
+	// Clearing the email must not mint the state CreateUser refuses: an
+	// email-less unverified account on a hub that requires verification
+	// lands on /verify-email with no code that can ever arrive.
+	if updateEmail && msg.GetEmail() == "" && !user.IsAdmin && !user.EmailVerified &&
+		s.set != nil && settings.EmailVerificationEffective(s.set.Snapshot(ctx)) {
+		return nil, connect.NewError(connect.CodeInvalidArgument,
+			errors.New("cannot clear the email of an unverified account while the hub requires email verification"))
+	}
+	// Admins are always email_verified=true in the database: CreateUser and
+	// SetUserAdmin force the flag, and the stored state is what keeps the
+	// runtime IsAdmin exemption (the auth interceptor's verification bypass)
+	// honest. The lowering verb therefore refuses for admin accounts;
+	// demotion (SetUserAdmin) is the path that reopens it.
+	if updateEmailVerified && !msg.GetEmailVerified() && user.IsAdmin {
+		return nil, connect.NewError(connect.CodeInvalidArgument,
+			errors.New("an administrator's email is always verified; demote the account first"))
 	}
 
 	err = s.store.RunInTransaction(ctx, func(tx store.Store) error {
@@ -499,6 +529,11 @@ func (s *AdminUserService) DeleteUser(ctx context.Context, req *connect.Request[
 		if _, _, committedGeneration, err = revokeEveryUserCredential(ctx, tx, delUID); err != nil {
 			return err
 		}
+		// Soft-delete does not CASCADE; clear passkey state now so
+		// credential_id uniqueness and encrypted material do not linger.
+		if err := RevokePasskeyAuthState(ctx, tx, user.ID); err != nil {
+			return err
+		}
 		if err := tx.Users().Delete(ctx, user.ID); err != nil {
 			return fmt.Errorf("delete user: %w", err)
 		}
@@ -568,11 +603,34 @@ func (s *AdminUserService) SetUserAdmin(ctx context.Context, req *connect.Reques
 				errors.New("this removes your own administrator access; pass force to confirm"))
 		}
 	}
-	if err := s.store.Users().UpdateAdmin(ctx, store.UpdateUserAdminParams{
-		IsAdmin: req.Msg.GetIsAdmin(),
-		ID:      user.ID,
+	// Both writes share one transaction: a failure between them must not
+	// leave an admin whose stored email_verified=false -- the exact row
+	// state UpdateUser refuses and CreateUser forbids.
+	if err := s.store.RunInTransaction(ctx, func(tx store.Store) error {
+		if err := tx.Users().UpdateAdmin(ctx, store.UpdateUserAdminParams{
+			IsAdmin: req.Msg.GetIsAdmin(),
+			ID:      user.ID,
+		}); err != nil {
+			return storeConnectError(err, "update admin flag")
+		}
+		// Admins are always email_verified=true in the database, regardless of
+		// SMTP. Promotion must set the flag so the stored state matches the
+		// runtime exemption (IsAdmin bypasses the gate either way).
+		if req.Msg.GetIsAdmin() && !user.EmailVerified {
+			if err := tx.Users().UpdateEmailVerified(ctx, store.UpdateUserEmailVerifiedParams{
+				EmailVerified: true,
+				ID:            user.ID,
+			}); err != nil {
+				return storeConnectError(err, "mark admin email verified")
+			}
+		}
+		return nil
 	}); err != nil {
-		return nil, storeConnectError(err, "update admin flag")
+		var connectErr *connect.Error
+		if errors.As(err, &connectErr) {
+			return nil, connectErr
+		}
+		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	updated, err := s.store.Users().GetByID(ctx, user.ID)
 	if err != nil {
@@ -623,6 +681,13 @@ func (s *AdminUserService) ResetPassword(ctx context.Context, req *connect.Reque
 			ID:           user.ID,
 		}); err != nil {
 			return fmt.Errorf("update password: %w", err)
+		}
+		// Admin password reset is break-glass: clear passkeys the same way
+		// self-service CompletePasswordReset does, so a lost-device recovery
+		// cannot leave orphan credentials, and a reset email requested
+		// before this emergency reset must not stay completable.
+		if err := RevokePasskeyAuthState(ctx, tx, user.ID); err != nil {
+			return err
 		}
 		// An administrator's reset rotates the user's auth basis globally.
 		// Every credential that predates the rotation must die, because
@@ -728,7 +793,7 @@ func (s *AdminUserService) RevokeUserSessions(ctx context.Context, req *connect.
 }
 
 func (s *AdminUserService) PurgeExpiredSessions(ctx context.Context, _ *connect.Request[leapmuxv1.PurgeExpiredSessionsRequest]) (*connect.Response[leapmuxv1.PurgeExpiredSessionsResponse], error) {
-	n, err := s.store.Cleanup().HardDeleteExpiredSessions(ctx)
+	n, err := s.store.Cleanup().HardDeleteExpiredSessions(ctx, time.Now().UTC())
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("purge expired sessions: %w", err))
 	}

--- a/backend/internal/hub/service/admin_user_service_test.go
+++ b/backend/internal/hub/service/admin_user_service_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/stretchr/testify/assert"
@@ -18,6 +19,7 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/auth"
 	"github.com/leapmux/leapmux/internal/hub/password"
 	"github.com/leapmux/leapmux/internal/hub/service"
+	"github.com/leapmux/leapmux/internal/hub/servicetest"
 	"github.com/leapmux/leapmux/internal/hub/store"
 	"github.com/leapmux/leapmux/internal/hub/store/sqlite"
 	"github.com/leapmux/leapmux/internal/hub/store/storetest"
@@ -164,7 +166,7 @@ func setupAdminUserTest(t *testing.T) *adminUserEnv {
 	// delivered one).
 	revocations := &recordingCredentialCloser{}
 	lifecycle := auth.NewCredentialLifecycleEffects(contexts, revocations, nil)
-	path, handler := leapmuxv1connect.NewAdminUserServiceHandler(service.NewAdminUserService(st, tv, lifecycle, nil), opts)
+	path, handler := leapmuxv1connect.NewAdminUserServiceHandler(service.NewAdminUserService(st, tv, lifecycle, nil, nil), opts)
 	mux.Handle(path, handler)
 
 	server := httptest.NewUnstartedServer(mux)
@@ -435,6 +437,106 @@ func TestAdminUserService_UpdateUser_EmailRules(t *testing.T) {
 	}, env.token))
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+
+// TestAdminUserService_CreateUserRequiresEmailWhenVerificationRequired pins
+// the funnel guard: on a hub that requires email verification, an email-less
+// non-admin account lands on /verify-email with no code that can ever
+// arrive (the login flow flags it verification-required, but there is
+// nothing to verify). Admins and explicitly-verified accounts are exempt.
+func TestAdminUserService_CreateUserRequiresEmailWhenVerificationRequired(t *testing.T) {
+	st, err := sqlite.Open(":memory:", sqlitedb.Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+	require.NoError(t, st.Migrator().Migrate(context.Background()))
+
+	hash, err := password.Hash("adminpass123")
+	require.NoError(t, err)
+	_, err = service.CreateUser(context.Background(), st, service.CreateUserParams{
+		Username: "admin", PasswordHash: hash, DisplayName: "Admin", PasswordSet: true, IsAdmin: true,
+	})
+	require.NoError(t, err)
+	session, _, _, err := auth.Login(context.Background(), st, "admin", "adminpass123", auth.DefaultSessionDuration)
+	require.NoError(t, err)
+	tv, err := auth.NewTokenValidator(st, []byte("0123456789abcdef0123456789abcdef"))
+	require.NoError(t, err)
+
+	// The settings manager the service reads: SMTP on makes
+	// EmailVerificationEffective true.
+	set := servicetest.NewSettingsManager(t, st, nil)
+	seedSMTP(t, set)
+
+	mux := http.NewServeMux()
+	interceptor, contexts := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st, TokenValidator: tv})
+	t.Cleanup(contexts.Stop)
+	adminSvc := service.NewAdminUserService(st, tv, auth.NewCredentialLifecycleEffects(contexts, nil, nil), nil, set)
+	path, handler := leapmuxv1connect.NewAdminUserServiceHandler(adminSvc, connect.WithInterceptors(interceptor))
+	mux.Handle(path, handler)
+	server := httptest.NewUnstartedServer(mux)
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	t.Cleanup(server.Close)
+	client := leapmuxv1connect.NewAdminUserServiceClient(server.Client(), server.URL, connect.WithGRPC())
+
+	// No email, not verified: refused.
+	_, err = client.CreateUser(context.Background(), authedReq(&leapmuxv1.CreateUserRequest{
+		Username: "nou-email", Password: "password123",
+	}, session))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	assert.Contains(t, err.Error(), "email is required")
+
+	// Explicitly verified without an email: allowed.
+	resp, err := client.CreateUser(context.Background(), authedReq(&leapmuxv1.CreateUserRequest{
+		Username: "trusted", Password: "password123", EmailVerified: true,
+	}, session))
+	require.NoError(t, err)
+	assert.True(t, resp.Msg.GetUser().GetEmailVerified())
+
+	// Email present: allowed and lands unverified, as the caller stated.
+	resp, err = client.CreateUser(context.Background(), authedReq(&leapmuxv1.CreateUserRequest{
+		Username: "withmail", Password: "password123", Email: "withmail@example.com",
+	}, session))
+	require.NoError(t, err)
+	assert.False(t, resp.Msg.GetUser().GetEmailVerified())
+}
+
+// TestAdminUserService_LoweringEmailVerifiedRefusesForAdmins pins the admin
+// arm of the lowering verb. Every path that grants is_admin forces
+// email_verified=true with it (CreateUser, SetUserAdmin, offline
+// bootstrap), so the stored flag matches the auth interceptor's runtime
+// IsAdmin exemption. UpdateUser's lowering verb is the one write that
+// could split them apart; it must refuse for admin targets, in both the
+// bare form and the paired {email, email_verified:false} form, and leave
+// the row untouched. Demotion (SetUserAdmin) is the documented path that
+// reopens the verb.
+func TestAdminUserService_LoweringEmailVerifiedRefusesForAdmins(t *testing.T) {
+	env := setupAdminUserTest(t)
+	ctx := context.Background()
+
+	// The acting administrator targets itself, bare form.
+	_, err := env.client.UpdateUser(ctx, authedReq(&leapmuxv1.UpdateUserRequest{
+		Username:      "admin",
+		EmailVerified: proto.Bool(false),
+	}, env.token))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	assert.Contains(t, err.Error(), "demote the account first")
+
+	// The paired form an earlier bug shipped ({email, email_verified:false}
+	// taking the unfenced arm) refuses the same way.
+	_, err = env.client.UpdateUser(ctx, authedReq(&leapmuxv1.UpdateUserRequest{
+		Username:      "admin",
+		Email:         proto.String("admin@example.com"),
+		EmailVerified: proto.Bool(false),
+	}, env.token))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+
+	row, err := env.st.Users().GetByID(ctx, env.adminID)
+	require.NoError(t, err)
+	assert.True(t, row.IsAdmin, "the refusal must not demote")
+	assert.True(t, row.EmailVerified, "an administrator's email_verified must stay true")
 }
 
 // TestAdminUserService_SetUserAdmin_FencesADemotedUser pins the credential
@@ -1113,4 +1215,61 @@ func TestAdminUserService_ResetPassword_SelfResetKillsTheActingAPIToken(t *testi
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err),
 		"the bearer that made the call stops authenticating at once")
+}
+
+func TestAdminUserService_SetUserAdmin_MarksEmailVerified(t *testing.T) {
+	env := setupAdminUserTest(t)
+	ctx := context.Background()
+
+	created, err := env.client.CreateUser(ctx, authedReq(&leapmuxv1.CreateUserRequest{
+		Username: "promotee", Password: "password123", DisplayName: "Promotee",
+		Email: "promotee@example.com", EmailVerified: false,
+	}, env.token))
+	require.NoError(t, err)
+	assert.False(t, created.Msg.GetUser().GetEmailVerified())
+
+	resp, err := env.client.SetUserAdmin(ctx, authedReq(&leapmuxv1.SetUserAdminRequest{
+		Id: created.Msg.GetUser().GetId(), IsAdmin: true,
+	}, env.token))
+	require.NoError(t, err)
+	assert.True(t, resp.Msg.GetUser().GetIsAdmin())
+	assert.True(t, resp.Msg.GetUser().GetEmailVerified())
+
+	row, err := env.st.Users().GetByID(ctx, created.Msg.GetUser().GetId())
+	require.NoError(t, err)
+	assert.True(t, row.EmailVerified)
+}
+
+func TestAdminUserService_CreateUser_AdminForcesEmailVerified(t *testing.T) {
+	env := setupAdminUserTest(t)
+	ctx := context.Background()
+
+	resp, err := env.client.CreateUser(ctx, authedReq(&leapmuxv1.CreateUserRequest{
+		Username: "newadmin", Password: "password123", DisplayName: "New Admin",
+		Email: "newadmin@example.com", EmailVerified: false, IsAdmin: true,
+	}, env.token))
+	require.NoError(t, err)
+	assert.True(t, resp.Msg.GetUser().GetIsAdmin())
+	assert.True(t, resp.Msg.GetUser().GetEmailVerified())
+}
+
+func TestAdminUserService_ResetPassword_DeletesPasskeys(t *testing.T) {
+	env := setupResetPasswordTest(t)
+	ctx := context.Background()
+
+	pkID := id.Generate()
+	require.NoError(t, env.st.PasskeyCredentials().Create(ctx, store.CreatePasskeyCredentialParams{
+		ID: pkID, UserID: env.userID, CredentialID: []byte("cred-" + pkID),
+		PublicKey: []byte("pubkey"), SignCount: 0, Transports: "[]",
+		FriendlyName: "Phone", KeyVersion: 1, CreatedAt: time.Now().UTC(),
+	}))
+
+	_, err := env.client.ResetPassword(ctx, authedReq(&leapmuxv1.ResetPasswordRequest{
+		Id: env.userID, Password: "brand-new-password",
+	}, env.token))
+	require.NoError(t, err)
+
+	rows, err := env.st.PasskeyCredentials().ListByUser(ctx, env.userID)
+	require.NoError(t, err)
+	assert.Empty(t, rows)
 }

--- a/backend/internal/hub/service/admin_user_service_test.go
+++ b/backend/internal/hub/service/admin_user_service_test.go
@@ -298,7 +298,7 @@ func TestAdminUserService_DeleteUser_ForceAndCredentialRevocation(t *testing.T) 
 	sessions, err := env.st.Sessions().ListByUserID(ctx, store.ListUserSessionsParams{
 		UserID:     userid.MustNew(carolID),
 		PageParams: store.PageParams{Limit: 10},
-	})
+	}, time.Now().UTC())
 	require.NoError(t, err)
 	assert.Empty(t, sessions.Rows)
 
@@ -581,6 +581,71 @@ func TestAdminUserService_SetUserAdmin_FencesADemotedUser(t *testing.T) {
 	assert.False(t, revoked.Msg.GetUser().GetIsAdmin())
 	assert.Greater(t, generation(), before,
 		"a demotion must bump auth_generation so admin-era sessions and tokens die")
+}
+
+// Promotion forces email_verified=true so the stored flag matches the
+// runtime IsAdmin exemption. Demotion has to repair that, or the account
+// keeps a verified state it never earned: the demoted row would then pass
+// the login verification gate, pass UpdateUser's clear-email guard, and
+// satisfy the "no durable identity" refusal that protects a first passkey.
+func TestAdminUserService_SetUserAdmin_DemotionClearsUnearnedVerification(t *testing.T) {
+	env := setupAdminUserTest(t)
+	ctx := context.Background()
+
+	created, err := env.client.CreateUser(ctx, authedReq(&leapmuxv1.CreateUserRequest{
+		Username: "noaddress", Password: "password123",
+	}, env.token))
+	require.NoError(t, err)
+	target := created.Msg.GetUser().GetId()
+
+	row, err := env.st.Users().GetByID(ctx, target)
+	require.NoError(t, err)
+	require.Empty(t, row.Email, "precondition: the account has no address to verify")
+	require.False(t, row.EmailVerified)
+
+	_, err = env.client.SetUserAdmin(ctx, authedReq(&leapmuxv1.SetUserAdminRequest{
+		Username: "noaddress", IsAdmin: true,
+	}, env.token))
+	require.NoError(t, err)
+	row, err = env.st.Users().GetByID(ctx, target)
+	require.NoError(t, err)
+	require.True(t, row.EmailVerified, "the admin invariant forces the flag")
+
+	_, err = env.client.SetUserAdmin(ctx, authedReq(&leapmuxv1.SetUserAdminRequest{
+		Username: "noaddress", IsAdmin: false,
+	}, env.token))
+	require.NoError(t, err)
+	row, err = env.st.Users().GetByID(ctx, target)
+	require.NoError(t, err)
+	assert.False(t, row.EmailVerified,
+		"with no address there is nothing that could have been confirmed")
+}
+
+// The other half of the rule: a demotion must NOT un-verify an address the
+// user really did confirm, because the row records no pre-promotion value.
+func TestAdminUserService_SetUserAdmin_DemotionKeepsAConfirmedAddress(t *testing.T) {
+	env := setupAdminUserTest(t)
+	ctx := context.Background()
+
+	created, err := env.client.CreateUser(ctx, authedReq(&leapmuxv1.CreateUserRequest{
+		Username: "hasaddress", Password: "password123", Email: "real@example.com",
+	}, env.token))
+	require.NoError(t, err)
+	target := created.Msg.GetUser().GetId()
+	require.NoError(t, env.st.Users().UpdateEmail(ctx, store.UpdateUserEmailParams{
+		ID: target, Email: "real@example.com", EmailVerified: true,
+	}))
+
+	for _, isAdmin := range []bool{true, false} {
+		_, err = env.client.SetUserAdmin(ctx, authedReq(&leapmuxv1.SetUserAdminRequest{
+			Username: "hasaddress", IsAdmin: isAdmin,
+		}, env.token))
+		require.NoError(t, err)
+	}
+
+	row, err := env.st.Users().GetByID(ctx, target)
+	require.NoError(t, err)
+	assert.True(t, row.EmailVerified, "a confirmed address survives a promote/demote round trip")
 }
 
 func ptr(s string) *string { return &s }
@@ -1050,7 +1115,7 @@ func TestAdminUserService_ResetPassword_TearsDownEveryCredential(t *testing.T) {
 	sessions, err := env.st.Sessions().ListByUserID(ctx, store.ListUserSessionsParams{
 		UserID:     userid.MustNew(env.userID),
 		PageParams: store.PageParams{Limit: 10},
-	})
+	}, time.Now().UTC())
 	require.NoError(t, err)
 	assert.Empty(t, sessions.Rows, "every session of the user must be deleted")
 	_, err = auth.ValidateToken(ctx, env.st, env.session)
@@ -1159,7 +1224,7 @@ func TestAdminUserService_ResetPassword_SelfResetEndsTheActingSession(t *testing
 	sessions, err := env.st.Sessions().ListByUserID(ctx, store.ListUserSessionsParams{
 		UserID:     userid.MustNew(env.adminID),
 		PageParams: store.PageParams{Limit: 10},
-	})
+	}, time.Now().UTC())
 	require.NoError(t, err)
 	assert.Empty(t, sessions.Rows, "the caller's own session row is deleted too")
 

--- a/backend/internal/hub/service/api_auth_device_code.go
+++ b/backend/internal/hub/service/api_auth_device_code.go
@@ -79,10 +79,13 @@ func (h *APIAuthHandler) handleActivate(w http.ResponseWriter, r *http.Request) 
 			http.Error(w, "invalid user_code", http.StatusBadRequest)
 			return
 		}
+		// h.now(), not time.Now(): the handler's seam is the one clock every
+		// instant it mints or compares comes from, so a test that advances
+		// the fake clock past the grant TTL sees the expiry it set up.
 		rows, err := h.store.DeviceAuthorizations().ApproveByUserCode(r.Context(), store.ApproveDeviceAuthorizationByUserCodeParams{
 			UserCode: normalized,
 			UserID:   user.ID,
-		})
+		}, h.now().UTC())
 		if err != nil {
 			writeInternalError(w, "device authorization approval failed", err)
 			return

--- a/backend/internal/hub/service/api_auth_handler_test.go
+++ b/backend/internal/hub/service/api_auth_handler_test.go
@@ -1303,7 +1303,7 @@ func TestAPIAuth_DeviceCode_UserLookupFailureLeavesGrantRetryable(t *testing.T) 
 	}))
 	rows, err := env.store.DeviceAuthorizations().Approve(context.Background(), store.ApproveDeviceAuthorizationParams{
 		DeviceCode: deviceCode, UserID: userid.MustNew(env.userID),
-	})
+	}, env.clock.now().UTC())
 	require.NoError(t, err)
 	require.Equal(t, int64(1), rows)
 
@@ -1390,7 +1390,7 @@ func TestAPIAuth_DeviceCode_ConsumeRequiresOneRow(t *testing.T) {
 	}))
 	rows, err := env.store.DeviceAuthorizations().Approve(context.Background(), store.ApproveDeviceAuthorizationParams{
 		DeviceCode: deviceCode, UserID: userid.MustNew(env.userID),
-	})
+	}, env.clock.now().UTC())
 	require.NoError(t, err)
 	require.Equal(t, int64(1), rows)
 	device := deviceAuthorizationOverride{DeviceAuthorizationStore: env.store.DeviceAuthorizations(), consume: func(context.Context, string) (int64, error) {
@@ -1428,7 +1428,7 @@ func TestAPIAuth_DeviceCode_ApprovedPollAdvancesThrottleDespiteIssuanceFailure(t
 	}))
 	rows, err := env.store.DeviceAuthorizations().Approve(context.Background(), store.ApproveDeviceAuthorizationParams{
 		DeviceCode: deviceCode, UserID: userid.MustNew(env.userID),
-	})
+	}, env.clock.now().UTC())
 	require.NoError(t, err)
 	require.Equal(t, int64(1), rows)
 

--- a/backend/internal/hub/service/api_auth_handler_test.go
+++ b/backend/internal/hub/service/api_auth_handler_test.go
@@ -1204,11 +1204,11 @@ func (s deviceAuthorizationOverride) TouchPoll(ctx context.Context, code string)
 	return s.DeviceAuthorizationStore.TouchPoll(ctx, code)
 }
 
-func (s deviceAuthorizationOverride) Consume(ctx context.Context, code string) (int64, error) {
+func (s deviceAuthorizationOverride) Consume(ctx context.Context, code string, now time.Time) (int64, error) {
 	if s.consume != nil {
 		return s.consume(ctx, code)
 	}
-	return s.DeviceAuthorizationStore.Consume(ctx, code)
+	return s.DeviceAuthorizationStore.Consume(ctx, code, now)
 }
 
 func (s userLookupFailStore) Users() store.UserStore { return s.users }
@@ -1890,7 +1890,7 @@ type blankGrantCodes struct {
 	row *store.CLIAuthorizationCode
 }
 
-func (s blankGrantCodes) GetActive(context.Context, string) (*store.CLIAuthorizationCode, error) {
+func (s blankGrantCodes) GetActive(context.Context, string, time.Time) (*store.CLIAuthorizationCode, error) {
 	return s.row, nil
 }
 

--- a/backend/internal/hub/service/api_auth_token.go
+++ b/backend/internal/hub/service/api_auth_token.go
@@ -67,7 +67,7 @@ func (h *APIAuthHandler) handleTokenAuthorizationCode(w http.ResponseWriter, r *
 		writeOAuthError(w, http.StatusBadRequest, "invalid_request", "code and code_verifier are required")
 		return
 	}
-	row, err := h.store.CLIAuthorizationCodes().GetActive(r.Context(), code, time.Now().UTC())
+	row, err := h.store.CLIAuthorizationCodes().GetActive(r.Context(), code, h.now().UTC())
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "code expired or already consumed")
@@ -98,7 +98,7 @@ func (h *APIAuthHandler) handleTokenAuthorizationCode(w http.ResponseWriter, r *
 		"code expired or already consumed",
 		"authorization code token issuance failed",
 		func(tx store.Store) error {
-			if _, err := tx.CLIAuthorizationCodes().Consume(r.Context(), code, time.Now().UTC()); err != nil {
+			if _, err := tx.CLIAuthorizationCodes().Consume(r.Context(), code, h.now().UTC()); err != nil {
 				if errors.Is(err, store.ErrNotFound) {
 					return errAuthorizationGrantUnavailable
 				}
@@ -194,7 +194,7 @@ func (h *APIAuthHandler) handleTokenDeviceCode(w http.ResponseWriter, r *http.Re
 			// Consume is the single-use consumption that must stay atomic
 			// with token creation, so it -- and only it -- remains in the
 			// transaction.
-			affected, err := tx.DeviceAuthorizations().Consume(r.Context(), deviceCode, time.Now().UTC())
+			affected, err := tx.DeviceAuthorizations().Consume(r.Context(), deviceCode, h.now().UTC())
 			if err != nil {
 				return fmt.Errorf("consume device authorization: %w", err)
 			}

--- a/backend/internal/hub/service/api_auth_token.go
+++ b/backend/internal/hub/service/api_auth_token.go
@@ -67,7 +67,7 @@ func (h *APIAuthHandler) handleTokenAuthorizationCode(w http.ResponseWriter, r *
 		writeOAuthError(w, http.StatusBadRequest, "invalid_request", "code and code_verifier are required")
 		return
 	}
-	row, err := h.store.CLIAuthorizationCodes().GetActive(r.Context(), code)
+	row, err := h.store.CLIAuthorizationCodes().GetActive(r.Context(), code, time.Now().UTC())
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "code expired or already consumed")
@@ -98,7 +98,7 @@ func (h *APIAuthHandler) handleTokenAuthorizationCode(w http.ResponseWriter, r *
 		"code expired or already consumed",
 		"authorization code token issuance failed",
 		func(tx store.Store) error {
-			if _, err := tx.CLIAuthorizationCodes().Consume(r.Context(), code); err != nil {
+			if _, err := tx.CLIAuthorizationCodes().Consume(r.Context(), code, time.Now().UTC()); err != nil {
 				if errors.Is(err, store.ErrNotFound) {
 					return errAuthorizationGrantUnavailable
 				}
@@ -194,7 +194,7 @@ func (h *APIAuthHandler) handleTokenDeviceCode(w http.ResponseWriter, r *http.Re
 			// Consume is the single-use consumption that must stay atomic
 			// with token creation, so it -- and only it -- remains in the
 			// transaction.
-			affected, err := tx.DeviceAuthorizations().Consume(r.Context(), deviceCode)
+			affected, err := tx.DeviceAuthorizations().Consume(r.Context(), deviceCode, time.Now().UTC())
 			if err != nil {
 				return fmt.Errorf("consume device authorization: %w", err)
 			}

--- a/backend/internal/hub/service/auth_passkey.go
+++ b/backend/internal/hub/service/auth_passkey.go
@@ -1,0 +1,560 @@
+package service
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"connectrpc.com/connect"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/hub/auth"
+	pwdhash "github.com/leapmux/leapmux/internal/hub/password"
+	"github.com/leapmux/leapmux/internal/hub/store"
+	hubwebauthn "github.com/leapmux/leapmux/internal/hub/webauthn"
+	"github.com/leapmux/leapmux/internal/util/id"
+	"github.com/leapmux/leapmux/internal/util/userid"
+	"github.com/leapmux/leapmux/util/validate"
+)
+
+const (
+	passwordResetExpiry = time.Hour
+	// passwordResetResendCooldown limits how often one account can mint a
+	// fresh reset token, mirroring the verification-email resend cooldown.
+	passwordResetResendCooldown = 60 * time.Second
+)
+
+// loginVerificationOutcome carries the verification flags for login responses.
+type loginVerificationOutcome struct {
+	Required              bool
+	EmailSent             bool
+	NextResendAvailableAt *time.Time
+}
+
+// emailVerificationToProto maps a login verification outcome onto the
+// shared response message.
+func emailVerificationToProto(out loginVerificationOutcome) *leapmuxv1.EmailVerificationStatus {
+	return &leapmuxv1.EmailVerificationStatus{
+		VerificationRequired:  out.Required,
+		VerificationEmailSent: out.EmailSent,
+		NextResendAvailableAt: protoTimestamp(out.NextResendAvailableAt),
+	}
+}
+
+func (s *AuthService) loginVerificationOutcome(ctx context.Context, user *store.User) loginVerificationOutcome {
+	if !s.emailVerificationRequired(ctx) || user.IsAdmin || user.EmailVerified {
+		return loginVerificationOutcome{}
+	}
+	out := loginVerificationOutcome{Required: true}
+	targetEmail := user.PendingEmail
+	if targetEmail == "" {
+		targetEmail = user.Email
+	}
+	if targetEmail == "" {
+		return out
+	}
+	if user.PendingEmail == "" {
+		sent, next, err := s.ensurePendingVerification(ctx, user.ID, targetEmail)
+		if err != nil {
+			slogWarnVerification(ctx, "ensure pending verification on login", user.ID, err)
+			return out
+		}
+		out.EmailSent = sent
+		out.NextResendAvailableAt = next
+		return out
+	}
+	if user.PendingEmailExpiresAt != nil {
+		next := nextResendAt(issuedAtFromExpiry(*user.PendingEmailExpiresAt, pendingEmailExpiry))
+		if time.Now().UTC().Before(next) {
+			out.NextResendAvailableAt = &next
+			return out
+		}
+	}
+	sent, err := issuePendingEmailVerification(ctx, s.store, s.mail, s.renderer, user.ID, user.PendingEmail)
+	if err != nil {
+		slogWarnVerification(ctx, "resend verification on login", user.ID, err)
+		return out
+	}
+	out.EmailSent = sent
+	if sent {
+		next := nextResendAt(time.Now().UTC())
+		out.NextResendAvailableAt = &next
+	}
+	return out
+}
+
+func (s *AuthService) ensurePendingVerification(ctx context.Context, userID, email string) (sent bool, nextResend *time.Time, err error) {
+	if err := CheckEmailAvailable(ctx, s.store, email, userID); err != nil {
+		return false, nil, err
+	}
+	sent, err = issuePendingEmailVerification(ctx, s.store, s.mail, s.renderer, userID, email)
+	if err != nil {
+		return false, nil, err
+	}
+	if sent {
+		next := nextResendAt(time.Now().UTC())
+		nextResend = &next
+	}
+	return sent, nextResend, nil
+}
+
+func slogWarnVerification(ctx context.Context, msg, userID string, err error) {
+	slog.WarnContext(ctx, msg, "user_id", userID, "err", err)
+}
+
+func protoTimestamp(t *time.Time) *timestamppb.Timestamp {
+	if t == nil {
+		return nil
+	}
+	return timestamppb.New(*t)
+}
+
+func (s *AuthService) BeginPasskeyLogin(ctx context.Context, req *connect.Request[leapmuxv1.BeginPasskeyLoginRequest]) (*connect.Response[leapmuxv1.BeginPasskeyLoginResponse], error) {
+	wa, err := s.webauthnService(ctx)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, err)
+	}
+	username, err := validate.SanitizeSlug("username", req.Msg.GetUsername())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+	user, err := s.store.Users().GetByUsername(ctx, username)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			// Same code/message as "no passkeys" so callers cannot enumerate.
+			return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("passkey login is not available for this account"))
+		}
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	sessionID, optionsJSON, rpID, err := wa.BeginLogin(ctx, user.ID, originFromRequest(req))
+	if err != nil {
+		switch {
+		case errors.Is(err, hubwebauthn.ErrNoPasskeys):
+			// Same code and message as the missing-user path so callers
+			// cannot enumerate accounts by the error.
+			return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("passkey login is not available for this account"))
+		case errors.Is(err, hubwebauthn.ErrOriginNotAllowed):
+			return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("passkey login is not available on this origin; open the hub through its configured URL"))
+		default:
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+	}
+	return connect.NewResponse(&leapmuxv1.BeginPasskeyLoginResponse{
+		SessionId:   sessionID,
+		OptionsJson: optionsJSON,
+		RpId:        rpID,
+	}), nil
+}
+
+func (s *AuthService) FinishPasskeyLogin(ctx context.Context, req *connect.Request[leapmuxv1.FinishPasskeyLoginRequest]) (*connect.Response[leapmuxv1.FinishPasskeyLoginResponse], error) {
+	wa, err := s.webauthnService(ctx)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, err)
+	}
+	user, passkeyCount, err := wa.FinishLogin(ctx, req.Msg.GetSessionId(), req.Msg.GetCredentialJson())
+	if err != nil {
+		switch {
+		case errors.Is(err, hubwebauthn.ErrCloneDetected):
+			// A clone warning is a security event, not a login failure: log
+			// it server-side and report it as itself, so it never counts
+			// against the login rate-limit budget.
+			slog.WarnContext(ctx, "passkey clone warning during login")
+			return nil, connect.NewError(connect.CodeUnauthenticated, err)
+		case errors.Is(err, hubwebauthn.ErrCeremonyInvalid), errors.Is(err, hubwebauthn.ErrAssertionRejected):
+			return nil, connect.NewError(connect.CodeUnauthenticated, err)
+		default:
+			// Store and infrastructure failures (keystore decrypt, session
+			// consume, sign-count update) are not credential failures.
+			// Reporting them as CodeInternal keeps them out of the login
+			// rate-limit budget and out of the anonymous client's Unauthenticated
+			// body.
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+	}
+	loginUID, mintErr := mintRowUserID(user.ID)
+	if mintErr != nil {
+		return nil, mintErr
+	}
+	sessionID, expiresAt, err := auth.CreateSession(ctx, s.store, loginUID, s.sessionDuration(ctx))
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("create session: %w", err))
+	}
+	resp := connect.NewResponse(&leapmuxv1.FinishPasskeyLoginResponse{
+		User:              userToProto(user, passkeyCount),
+		EmailVerification: emailVerificationToProto(s.loginVerificationOutcome(ctx, user)),
+	})
+	s.setSessionCookie(ctx, resp.Header(), sessionID, expiresAt)
+	return resp, nil
+}
+
+func (s *AuthService) BeginPasskeySignUp(ctx context.Context, req *connect.Request[leapmuxv1.BeginPasskeySignUpRequest]) (*connect.Response[leapmuxv1.BeginPasskeySignUpResponse], error) {
+	if s.cfg.SoloMode {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("sign-up is not available in solo mode"))
+	}
+	hasUser, err := s.checkHasAnyUser(ctx)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	isSetupMode := !hasUser
+	if isSetupMode {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("passkey sign-up is not available during initial setup; use password sign-up"))
+	}
+	if !s.signupEnabled(ctx) {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("sign-up is disabled"))
+	}
+
+	username, err := validate.SanitizeSlug("username", req.Msg.GetUsername())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+	displayName, err := validate.SanitizeDisplayName(req.Msg.GetDisplayName(), username)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("display name: %w", err))
+	}
+	if err := s.validatePublicSignupUsername(ctx, username); err != nil {
+		return nil, err
+	}
+	if err := s.validateSignupEmail(ctx, req.Msg.GetEmail()); err != nil {
+		return nil, err
+	}
+	email := req.Msg.GetEmail()
+
+	wa, err := s.webauthnService(ctx)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, err)
+	}
+	sessionID, optionsJSON, rpID, err := wa.BeginSignUp(ctx, hubwebauthn.SignupDraft{
+		Username:    username,
+		Email:       email,
+		DisplayName: displayName,
+	}, originFromRequest(req))
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	return connect.NewResponse(&leapmuxv1.BeginPasskeySignUpResponse{
+		SessionId:   sessionID,
+		OptionsJson: optionsJSON,
+		RpId:        rpID,
+	}), nil
+}
+
+func (s *AuthService) FinishPasskeySignUp(ctx context.Context, req *connect.Request[leapmuxv1.FinishPasskeySignUpRequest]) (*connect.Response[leapmuxv1.FinishPasskeySignUpResponse], error) {
+	if s.cfg.SoloMode {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("passkey sign-up is not available"))
+	}
+	wa, err := s.webauthnService(ctx)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, err)
+	}
+	draft, cred, err := wa.FinishSignUp(ctx, req.Msg.GetSessionId(), req.Msg.GetCredentialJson())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+
+	// Re-check the controls at finish so an admin disable or a race on
+	// username/email between Begin and Finish cannot create an account past
+	// policy. Setup mode is re-checked too: Begin refuses it, but if every
+	// user vanished inside the ceremony window, this commit creates the
+	// hub's first account and it must be an admin, exactly like password
+	// sign-up -- otherwise /setup is withdrawn and the hub has no
+	// administrator.
+	hasUser, err := s.checkHasAnyUser(ctx)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("check users: %w", err))
+	}
+	isFirstUser := !hasUser
+	if !isFirstUser && !s.signupEnabled(ctx) {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("sign-up is disabled"))
+	}
+	if err := s.validatePublicSignupUsername(ctx, draft.Username); err != nil {
+		return nil, err
+	}
+	if err := s.validateSignupEmail(ctx, draft.Email); err != nil {
+		return nil, err
+	}
+
+	email := draft.Email
+	pendingEmail := ""
+	if s.emailVerificationRequired(ctx) {
+		email = ""
+		pendingEmail = draft.Email
+	}
+	verificationRequired := pendingEmail != ""
+
+	createdUser, storedCode, err := createUserInTx(ctx, s.store, createUserTxParams{
+		userID:       draft.UserID,
+		username:     draft.Username,
+		displayName:  draft.DisplayName,
+		email:        email,
+		pendingEmail: pendingEmail,
+		passwordHash: pwdhash.PlaceholderHash,
+		isAdmin:      isFirstUser,
+		extra: func(tx store.Store) error {
+			_, err := wa.StoreCredential(ctx, tx, id.Generate(), draft.UserID, cred, "Passkey")
+			return err
+		},
+	})
+	if err != nil {
+		return nil, mapSignupCommitError(err)
+	}
+
+	emailSent := false
+	var nextResend *time.Time
+	if verificationRequired && pendingEmail != "" {
+		if err := s.deliverSignupVerification(ctx, createdUser.ID, pendingEmail, storedCode); err != nil {
+			return nil, err
+		}
+		emailSent = true
+		next := nextResendAt(time.Now().UTC())
+		nextResend = &next
+	}
+
+	s.hasAnyUser.Store(true)
+	loginUID, mintErr := mintRowUserID(createdUser.ID)
+	if mintErr != nil {
+		return nil, mintErr
+	}
+	sessionID, sessionExpires, err := auth.CreateSession(ctx, s.store, loginUID, s.sessionDuration(ctx))
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("create session: %w", err))
+	}
+	resp := connect.NewResponse(&leapmuxv1.FinishPasskeySignUpResponse{
+		// The ceremony just stored this account's single passkey.
+		User: userToProto(createdUser, 1),
+		EmailVerification: &leapmuxv1.EmailVerificationStatus{
+			VerificationRequired:  verificationRequired,
+			VerificationEmailSent: emailSent,
+			NextResendAvailableAt: protoTimestamp(nextResend),
+		},
+	})
+	s.setSessionCookie(ctx, resp.Header(), sessionID, sessionExpires)
+	return resp, nil
+}
+
+func hashPasswordResetToken(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}
+
+// generatePasswordResetToken mints the emailed reset secret from the
+// shared id mint (crypto-rand backed, 48 chars over a 62-alphabet, ~285
+// bits), mirroring auth.MintAccessSecret and the session ids.
+func generatePasswordResetToken() string {
+	return id.Generate()
+}
+
+func (s *AuthService) RequestPasswordReset(ctx context.Context, req *connect.Request[leapmuxv1.RequestPasswordResetRequest]) (*connect.Response[leapmuxv1.RequestPasswordResetResponse], error) {
+	if s.cfg.SoloMode {
+		return connect.NewResponse(&leapmuxv1.RequestPasswordResetResponse{}), nil
+	}
+	identifier := req.Msg.GetIdentifier()
+	var user *store.User
+	var err error
+	if strings.Contains(identifier, "@") {
+		user, err = s.store.Users().GetByEmail(ctx, strings.TrimSpace(identifier))
+	} else {
+		username, slugErr := validate.SanitizeSlug("username", identifier)
+		if slugErr != nil {
+			return connect.NewResponse(&leapmuxv1.RequestPasswordResetResponse{}), nil
+		}
+		user, err = s.store.Users().GetByUsername(ctx, username)
+	}
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return connect.NewResponse(&leapmuxv1.RequestPasswordResetResponse{}), nil
+		}
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	// Every miss path returns the same empty body as a hit. Timing is NOT
+	// equalized: the hit path performs a synchronous SMTP send whose dial
+	// dominates any padding, so a burn would be security theater. The real
+	// anti-enumeration controls are the captcha on this procedure, the
+	// uniform response body, and the per-account resend cooldown below.
+	targetEmail := user.Email
+	if targetEmail == "" {
+		return connect.NewResponse(&leapmuxv1.RequestPasswordResetResponse{}), nil
+	}
+	// No IsAdmin exemption here, unlike the auth interceptor's verification
+	// control: this predicate asks whether THIS address is trusted with a
+	// credential-bearing reset link, and the hub has never verified it. An
+	// unverified admin self-recovers via RequestEmailChange + VerifyEmail
+	// (both allowlisted for unverified users).
+	if !user.EmailVerified && s.emailVerificationRequired(ctx) {
+		return connect.NewResponse(&leapmuxv1.RequestPasswordResetResponse{}), nil
+	}
+	// Cooldown: a recent request keeps its link. Minting a fresh token on
+	// every request would flood the inbox and invalidate the link the
+	// previous email still carries. The mint below is conditional -- the
+	// write lands only when no previous token exists or the previous one
+	// was issued at least the cooldown ago -- so a double-submit race
+	// cannot mint and send twice and the first email's link stays valid.
+	// The cutoff derivation: issued_at = previous expiry minus the constant
+	// token TTL, so "issued at least cooldown ago" is "previous expiry at
+	// or before now + (TTL - cooldown)". Both timestamps are on the app
+	// clock, the clock that wrote the expiry.
+	cooldownCutoff := time.Now().UTC().Add(passwordResetExpiry - passwordResetResendCooldown)
+	rawToken := generatePasswordResetToken()
+	expiresAt := time.Now().Add(passwordResetExpiry).UTC()
+	minted, err := s.store.Users().SetPendingPasswordReset(ctx, store.SetPendingPasswordResetParams{
+		ID:                            user.ID,
+		PendingPasswordResetToken:     hashPasswordResetToken(rawToken),
+		PendingPasswordResetExpiresAt: expiresAt,
+		CooldownCutoff:                cooldownCutoff,
+	})
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	if !minted {
+		// A concurrent or recent request holds a live token: keep it (its
+		// email is on the way or already delivered) and answer the same
+		// empty body as every other path.
+		return connect.NewResponse(&leapmuxv1.RequestPasswordResetResponse{}), nil
+	}
+	if err := s.mail.Send(ctx, s.renderer.PasswordResetEmail(targetEmail, rawToken, passwordResetExpiry)); err != nil {
+		_ = s.store.Users().ClearPendingPasswordReset(ctx, user.ID)
+		slog.WarnContext(ctx, "password reset email send failed; cleared pending token",
+			"user_id", user.ID, "err", err)
+		// Still return empty success so the response cannot enumerate accounts,
+		// but do not leave a live token after a failed send.
+		return connect.NewResponse(&leapmuxv1.RequestPasswordResetResponse{}), nil
+	}
+	return connect.NewResponse(&leapmuxv1.RequestPasswordResetResponse{}), nil
+}
+
+func (s *AuthService) CompletePasswordReset(ctx context.Context, req *connect.Request[leapmuxv1.CompletePasswordResetRequest]) (*connect.Response[leapmuxv1.CompletePasswordResetResponse], error) {
+	if s.cfg.SoloMode {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("password reset is not available in solo mode"))
+	}
+	token := req.Msg.GetToken()
+	if token == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("token is required"))
+	}
+	if err := validate.ValidatePassword(req.Msg.GetNewPassword()); err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+	hashedToken := hashPasswordResetToken(token)
+
+	// Charge one attempt against the row that holds this exact token. The
+	// find, the charge, and the token re-check are one statement, so a token
+	// cleared by a concurrent reset cannot slip through as a 500.
+	charged, err := s.store.Users().ConsumePasswordResetAttemptByToken(ctx, hashedToken, time.Now().UTC(), maxPasswordResetAttempts)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("invalid or expired reset token"))
+		}
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	// Attempt 6+ expires the token in SQL (sets expires_at = now). Refuse
+	// before Argon2 so the attempt budget is a hard cap, not soft.
+	if charged.PendingPasswordResetAttempts > 5 {
+		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("invalid or expired reset token"))
+	}
+	if charged.PendingPasswordResetExpiresAt != nil && time.Now().UTC().After(*charged.PendingPasswordResetExpiresAt) {
+		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("reset token expired"))
+	}
+
+	hashed, err := pwdhash.Hash(req.Msg.GetNewPassword())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+
+	user := charged
+	uid, mintErr := mintRowUserID(user.ID)
+	if mintErr != nil {
+		return nil, mintErr
+	}
+	var revoked *store.PasswordResetRevocation
+	if err := s.store.RunInUserAuthTransaction(ctx, uid, func(tx store.Store) error {
+		var completeErr error
+		revoked, completeErr = tx.Users().CompletePasswordReset(ctx, store.CompletePasswordResetParams{
+			ID:                        user.ID,
+			PasswordHash:              hashed,
+			PendingPasswordResetToken: hashedToken,
+		})
+		if completeErr != nil {
+			if errors.Is(completeErr, store.ErrNotFound) {
+				return connect.NewError(connect.CodeNotFound, fmt.Errorf("invalid or expired reset token"))
+			}
+			return completeErr
+		}
+		if err := RevokePasskeyAuthState(ctx, tx, user.ID); err != nil {
+			return err
+		}
+		if err := tx.Sessions().DeleteByUser(ctx, uid); err != nil {
+			return fmt.Errorf("delete sessions: %w", err)
+		}
+		if _, err := tx.APITokens().RevokeByUser(ctx, uid); err != nil {
+			return fmt.Errorf("revoke api tokens: %w", err)
+		}
+		if _, err := tx.DelegationTokens().RevokeByUser(ctx, uid); err != nil {
+			return fmt.Errorf("revoke delegation tokens: %w", err)
+		}
+		return nil
+	}); err != nil {
+		var connectErr *connect.Error
+		if errors.As(err, &connectErr) {
+			return nil, connectErr
+		}
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	if revoked != nil {
+		s.lifecycle.UserRevoked(user.ID, revoked.AuthGeneration)
+	}
+	return connect.NewResponse(&leapmuxv1.CompletePasswordResetResponse{}), nil
+}
+
+// RevokePasskeyAuthState removes every passkey artifact a user owns: the
+// credential rows, their ceremony and proof sessions, and any pending
+// password reset. The credential-rotation teardown paths (self-service
+// CompletePasswordReset, admin ResetPassword, admin DeleteUser, the
+// offline recover CLI, and signup rollback) share it, so the next
+// credential type is registered here once instead of remembered at each
+// rotation site.
+func RevokePasskeyAuthState(ctx context.Context, tx store.Store, userID string) error {
+	if err := tx.PasskeyCredentials().DeleteAllByUser(ctx, userID); err != nil {
+		return fmt.Errorf("delete passkeys: %w", err)
+	}
+	if err := tx.WebAuthnSessions().DeleteAllByUser(ctx, userID); err != nil {
+		return fmt.Errorf("delete webauthn sessions: %w", err)
+	}
+	if err := tx.Users().ClearPendingPasswordReset(ctx, userID); err != nil {
+		return fmt.Errorf("clear pending password reset: %w", err)
+	}
+	return nil
+}
+
+// rollbackUnusableSignup removes a just-created account after a fail-closed
+// verification email failure that happened outside the create transaction.
+// All steps share one transaction so a partial wipe cannot leave a
+// passkey-less account that still holds the username.
+func rollbackUnusableSignup(ctx context.Context, st store.Store, userID string) error {
+	return st.RunInTransaction(ctx, func(tx store.Store) error {
+		if err := RevokePasskeyAuthState(ctx, tx, userID); err != nil {
+			return err
+		}
+		if uid, ok := userid.New(userID); ok {
+			links, err := tx.OAuthUserLinks().ListByUser(ctx, uid)
+			if err != nil {
+				return fmt.Errorf("list oauth links: %w", err)
+			}
+			for _, link := range links {
+				if err := tx.OAuthUserLinks().Delete(ctx, store.DeleteOAuthUserLinkParams{
+					UserID:     uid,
+					ProviderID: link.ProviderID,
+				}); err != nil {
+					return fmt.Errorf("delete oauth link: %w", err)
+				}
+			}
+		}
+		if err := tx.Users().Delete(ctx, userID); err != nil {
+			return fmt.Errorf("delete user: %w", err)
+		}
+		return nil
+	})
+}

--- a/backend/internal/hub/service/auth_passkey.go
+++ b/backend/internal/hub/service/auth_passkey.go
@@ -30,16 +30,19 @@ const (
 	passwordResetResendCooldown = 60 * time.Second
 )
 
-// loginVerificationOutcome carries the verification flags for login responses.
-type loginVerificationOutcome struct {
+// verificationOutcome carries the verification flags every login and
+// sign-up response reports. Not login-only: the four sign-up flavors and
+// the GetCurrentUser bootstrap build one too, and each used to hand-write
+// the proto literal instead.
+type verificationOutcome struct {
 	Required              bool
 	EmailSent             bool
 	NextResendAvailableAt *time.Time
 }
 
-// emailVerificationToProto maps a login verification outcome onto the
-// shared response message.
-func emailVerificationToProto(out loginVerificationOutcome) *leapmuxv1.EmailVerificationStatus {
+// emailVerificationToProto maps a verification outcome onto the shared
+// response message. Every response that carries the status builds it here.
+func emailVerificationToProto(out verificationOutcome) *leapmuxv1.EmailVerificationStatus {
 	return &leapmuxv1.EmailVerificationStatus{
 		VerificationRequired:  out.Required,
 		VerificationEmailSent: out.EmailSent,
@@ -47,11 +50,33 @@ func emailVerificationToProto(out loginVerificationOutcome) *leapmuxv1.EmailVeri
 	}
 }
 
-func (s *AuthService) loginVerificationOutcome(ctx context.Context, user *store.User) loginVerificationOutcome {
+// verificationStatusFor REPORTS the account's verification state without
+// sending anything. loginVerificationOutcome is the sending twin, and the
+// difference matters: this one serves GetCurrentUser, which every page load
+// calls, so issuing mail from it would send a message per reload.
+//
+// The cooldown it reports comes from the live pending row, so a hard reload
+// of /verify-email resumes the same countdown a login handed out instead of
+// starting at zero and letting the button hammer a refusal.
+func (s *AuthService) verificationStatusFor(ctx context.Context, user *store.User) verificationOutcome {
 	if !s.emailVerificationRequired(ctx) || user.IsAdmin || user.EmailVerified {
-		return loginVerificationOutcome{}
+		return verificationOutcome{}
 	}
-	out := loginVerificationOutcome{Required: true}
+	out := verificationOutcome{Required: true}
+	if user.PendingEmail != "" && user.PendingEmailExpiresAt != nil {
+		next := nextResendAt(issuedAtFromExpiry(*user.PendingEmailExpiresAt, pendingEmailExpiry))
+		if time.Now().UTC().Before(next) {
+			out.NextResendAvailableAt = &next
+		}
+	}
+	return out
+}
+
+func (s *AuthService) loginVerificationOutcome(ctx context.Context, user *store.User) verificationOutcome {
+	if !s.emailVerificationRequired(ctx) || user.IsAdmin || user.EmailVerified {
+		return verificationOutcome{}
+	}
+	out := verificationOutcome{Required: true}
 	targetEmail := user.PendingEmail
 	if targetEmail == "" {
 		targetEmail = user.Email
@@ -134,16 +159,16 @@ func (s *AuthService) BeginPasskeyLogin(ctx context.Context, req *connect.Reques
 	}
 	sessionID, optionsJSON, rpID, err := wa.BeginLogin(ctx, user.ID, originFromRequest(req))
 	if err != nil {
-		switch {
-		case errors.Is(err, hubwebauthn.ErrNoPasskeys):
-			// Same code and message as the missing-user path so callers
-			// cannot enumerate accounts by the error.
+		if classifyWebAuthnError(err) == webAuthnErrorUnavailable {
+			// An unserved origin names the remediation. Everything else in
+			// this class answers with the same code and message as the
+			// missing-user path, so the error is not an enumeration oracle.
+			if errors.Is(err, hubwebauthn.ErrOriginNotAllowed) {
+				return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("passkey login is not available on this origin; open the hub through its configured URL"))
+			}
 			return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("passkey login is not available for this account"))
-		case errors.Is(err, hubwebauthn.ErrOriginNotAllowed):
-			return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("passkey login is not available on this origin; open the hub through its configured URL"))
-		default:
-			return nil, connect.NewError(connect.CodeInternal, err)
 		}
+		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	return connect.NewResponse(&leapmuxv1.BeginPasskeyLoginResponse{
 		SessionId:   sessionID,
@@ -159,23 +184,31 @@ func (s *AuthService) FinishPasskeyLogin(ctx context.Context, req *connect.Reque
 	}
 	user, passkeyCount, err := wa.FinishLogin(ctx, req.Msg.GetSessionId(), req.Msg.GetCredentialJson())
 	if err != nil {
-		switch {
-		case errors.Is(err, hubwebauthn.ErrCloneDetected):
+		switch classifyWebAuthnError(err) {
+		case webAuthnErrorClone:
 			// A clone warning is a security event, not a login failure: log
 			// it server-side and report it as itself, so it never counts
 			// against the login rate-limit budget.
 			slog.WarnContext(ctx, "passkey clone warning during login")
 			return nil, connect.NewError(connect.CodeUnauthenticated, err)
-		case errors.Is(err, hubwebauthn.ErrCeremonyInvalid), errors.Is(err, hubwebauthn.ErrAssertionRejected):
+		case webAuthnErrorCredential:
 			return nil, connect.NewError(connect.CodeUnauthenticated, err)
-		default:
+		case webAuthnErrorUnavailable:
+			// Same code Begin answers for the same state. These sentinels
+			// describe the hub and the origin, not the account, so the
+			// enumeration argument that collapses a credential failure into
+			// Unauthenticated does not reach them -- and reporting a hub
+			// misconfiguration as "authentication failed" tells the user to
+			// try another credential for something no credential can fix.
+			return nil, connect.NewError(connect.CodeFailedPrecondition, err)
+		case webAuthnErrorInfrastructure:
 			// Store and infrastructure failures (keystore decrypt, session
-			// consume, sign-count update) are not credential failures.
-			// Reporting them as CodeInternal keeps them out of the login
-			// rate-limit budget and out of the anonymous client's Unauthenticated
+			// consume, sign-count update) are not credential failures, so
+			// they must not read as one in the anonymous client's response
 			// body.
 			return nil, connect.NewError(connect.CodeInternal, err)
 		}
+		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	loginUID, mintErr := mintRowUserID(user.ID)
 	if mintErr != nil {
@@ -285,8 +318,6 @@ func (s *AuthService) FinishPasskeySignUp(ctx context.Context, req *connect.Requ
 		email = ""
 		pendingEmail = draft.Email
 	}
-	verificationRequired := pendingEmail != ""
-
 	createdUser, storedCode, err := createUserInTx(ctx, s.store, createUserTxParams{
 		userID:       draft.UserID,
 		username:     draft.Username,
@@ -304,10 +335,18 @@ func (s *AuthService) FinishPasskeySignUp(ctx context.Context, req *connect.Requ
 		return nil, mapSignupCommitError(err)
 	}
 
+	// The returned code is the authority on whether a pending verification
+	// was actually written, NOT the caller's pre-call intent: createUserInTx
+	// promotes an admin's pending address into the email column and writes
+	// no pending row, so the first-user branch reaches here with
+	// pendingEmail still set and nothing to verify. Sending on the local
+	// intent mailed a blank code, and a failed send then rolled back the
+	// hub's only administrator.
+	verificationRequired := storedCode != ""
 	emailSent := false
 	var nextResend *time.Time
-	if verificationRequired && pendingEmail != "" {
-		if err := s.deliverSignupVerification(ctx, createdUser.ID, pendingEmail, storedCode); err != nil {
+	if verificationRequired {
+		if err := s.deliverSignupVerification(ctx, createdUser.ID, createdUser.PendingEmail, storedCode); err != nil {
 			return nil, err
 		}
 		emailSent = true
@@ -327,11 +366,11 @@ func (s *AuthService) FinishPasskeySignUp(ctx context.Context, req *connect.Requ
 	resp := connect.NewResponse(&leapmuxv1.FinishPasskeySignUpResponse{
 		// The ceremony just stored this account's single passkey.
 		User: userToProto(createdUser, 1),
-		EmailVerification: &leapmuxv1.EmailVerificationStatus{
-			VerificationRequired:  verificationRequired,
-			VerificationEmailSent: emailSent,
-			NextResendAvailableAt: protoTimestamp(nextResend),
-		},
+		EmailVerification: emailVerificationToProto(verificationOutcome{
+			Required:              verificationRequired,
+			EmailSent:             emailSent,
+			NextResendAvailableAt: nextResend,
+		}),
 	})
 	s.setSessionCookie(ctx, resp.Header(), sessionID, sessionExpires)
 	return resp, nil
@@ -417,7 +456,14 @@ func (s *AuthService) RequestPasswordReset(ctx context.Context, req *connect.Req
 		return connect.NewResponse(&leapmuxv1.RequestPasswordResetResponse{}), nil
 	}
 	if err := s.mail.Send(ctx, s.renderer.PasswordResetEmail(targetEmail, rawToken, passwordResetExpiry)); err != nil {
-		_ = s.store.Users().ClearPendingPasswordReset(ctx, user.ID)
+		// Report the clear separately from the send. A log line that claims
+		// "cleared pending token" while the clear itself failed sends the
+		// operator looking for the wrong cause of a token that is still
+		// live for the full reset TTL.
+		if clearErr := s.store.Users().ClearPendingPasswordReset(ctx, user.ID); clearErr != nil {
+			slog.WarnContext(ctx, "clear pending password reset after failed send",
+				"user_id", user.ID, "err", clearErr)
+		}
 		slog.WarnContext(ctx, "password reset email send failed; cleared pending token",
 			"user_id", user.ID, "err", err)
 		// Still return empty success so the response cannot enumerate accounts,
@@ -452,7 +498,7 @@ func (s *AuthService) CompletePasswordReset(ctx context.Context, req *connect.Re
 	}
 	// Attempt 6+ expires the token in SQL (sets expires_at = now). Refuse
 	// before Argon2 so the attempt budget is a hard cap, not soft.
-	if charged.PendingPasswordResetAttempts > 5 {
+	if charged.PendingPasswordResetAttempts > maxPasswordResetAttempts {
 		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("invalid or expired reset token"))
 	}
 	if charged.PendingPasswordResetExpiresAt != nil && time.Now().UTC().After(*charged.PendingPasswordResetExpiresAt) {

--- a/backend/internal/hub/service/auth_password_reset_test.go
+++ b/backend/internal/hub/service/auth_password_reset_test.go
@@ -1,0 +1,522 @@
+package service_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	leapmuxv1connect "github.com/leapmux/leapmux/generated/proto/leapmux/v1/leapmuxv1connect"
+	"github.com/leapmux/leapmux/internal/hub/auth"
+	"github.com/leapmux/leapmux/internal/hub/mail"
+	"github.com/leapmux/leapmux/internal/hub/password"
+	"github.com/leapmux/leapmux/internal/hub/service"
+	"github.com/leapmux/leapmux/internal/hub/servicetest"
+	"github.com/leapmux/leapmux/internal/hub/settings"
+	"github.com/leapmux/leapmux/internal/hub/store"
+	hubtestutil "github.com/leapmux/leapmux/internal/hub/testutil"
+	"github.com/leapmux/leapmux/internal/util/id"
+	"github.com/leapmux/leapmux/internal/util/userid"
+)
+
+type recordingMailSender struct {
+	msgs []mail.Message
+	err  error
+}
+
+func (r *recordingMailSender) Send(_ context.Context, msg mail.Message) error {
+	if r.err != nil {
+		return r.err
+	}
+	r.msgs = append(r.msgs, msg)
+	return nil
+}
+
+func setupPasswordResetAuthService(t *testing.T, sender mail.Sender) (leapmuxv1connect.AuthServiceClient, store.Store) {
+	t.Helper()
+
+	st := hubtestutil.OpenTestStore(t)
+	set := servicetest.NewSettingsManager(t, st, nil)
+	enableSignup(t, set)
+
+	mux := http.NewServeMux()
+	interceptor, sc := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st})
+	t.Cleanup(sc.Stop)
+	opts := connect.WithInterceptors(interceptor)
+	authSvc := service.NewAuthService(service.AuthServiceDeps{
+		Store:     st,
+		Config:    testConfig(),
+		Settings:  set,
+		Lifecycle: auth.NewCredentialLifecycleEffects(sc, nil, nil),
+		Mail:      sender,
+		Renderer:  mail.Renderer{BaseURL: func() string { return "https://hub.example.com" }},
+	})
+	path, handler := leapmuxv1connect.NewAuthServiceHandler(authSvc, opts)
+	mux.Handle(path, handler)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := leapmuxv1connect.NewAuthServiceClient(server.Client(), server.URL)
+	return client, st
+}
+
+func extractPasswordResetToken(body string) string {
+	const marker = "/reset-password?token="
+	i := strings.Index(body, marker)
+	if i < 0 {
+		return ""
+	}
+	rest := body[i+len(marker):]
+	if j := strings.IndexAny(rest, " \n\r\t"); j >= 0 {
+		return rest[:j]
+	}
+	return rest
+}
+
+func TestRequestPasswordReset_UnknownUser_EmptySuccess(t *testing.T) {
+	t.Parallel()
+
+	sender := &recordingMailSender{}
+	client, _ := setupPasswordResetAuthService(t, sender)
+
+	_, err := client.RequestPasswordReset(context.Background(), connect.NewRequest(&leapmuxv1.RequestPasswordResetRequest{
+		Identifier: "nobody@example.com",
+	}))
+	require.NoError(t, err)
+	assert.Empty(t, sender.msgs)
+}
+
+func TestRequestPasswordReset_KnownUser_SendsMail(t *testing.T) {
+	t.Parallel()
+
+	sender := &recordingMailSender{}
+	client, st := setupPasswordResetAuthService(t, sender)
+
+	userID := id.Generate()
+	hash, err := password.Hash("oldpass123")
+	require.NoError(t, err)
+	require.NoError(t, st.Users().Create(context.Background(), store.CreateUserParams{
+		ID:            userID,
+		Username:      "resetme",
+		PasswordHash:  hash,
+		DisplayName:   "Reset Me",
+		Email:         "resetme@example.com",
+		EmailVerified: true,
+		PasswordSet:   true,
+	}))
+
+	_, err = client.RequestPasswordReset(context.Background(), connect.NewRequest(&leapmuxv1.RequestPasswordResetRequest{
+		Identifier: "resetme@example.com",
+	}))
+	require.NoError(t, err)
+	require.Len(t, sender.msgs, 1)
+	assert.Equal(t, "resetme@example.com", sender.msgs[0].To)
+
+	token := extractPasswordResetToken(sender.msgs[0].Body)
+	require.NotEmpty(t, token)
+	// The reset secret comes from the shared id mint, like session ids and
+	// API access secrets.
+	assert.Regexp(t, "^[A-Za-z0-9]{48}$", token)
+
+	user, err := st.Users().GetByID(context.Background(), userID)
+	require.NoError(t, err)
+	assert.NotEmpty(t, user.PendingPasswordResetToken)
+	assert.NotNil(t, user.PendingPasswordResetExpiresAt)
+
+	_, err = client.CompletePasswordReset(context.Background(), connect.NewRequest(&leapmuxv1.CompletePasswordResetRequest{
+		Token:       token,
+		NewPassword: "newpass123",
+	}))
+	require.NoError(t, err)
+
+	user, err = st.Users().GetByID(context.Background(), userID)
+	require.NoError(t, err)
+	assert.True(t, user.PasswordSet)
+	match, err := password.Verify(user.PasswordHash, "newpass123")
+	require.NoError(t, err)
+	assert.True(t, match)
+}
+
+func TestRequestPasswordReset_MailFailure_ClearsToken(t *testing.T) {
+	t.Parallel()
+
+	sender := &recordingMailSender{err: errors.New("smtp down")}
+	client, st := setupPasswordResetAuthService(t, sender)
+
+	userID := id.Generate()
+	hash, err := password.Hash("oldpass123")
+	require.NoError(t, err)
+	require.NoError(t, st.Users().Create(context.Background(), store.CreateUserParams{
+		ID:            userID,
+		Username:      "mailfail",
+		PasswordHash:  hash,
+		DisplayName:   "Mail Fail",
+		Email:         "mailfail@example.com",
+		EmailVerified: true,
+		PasswordSet:   true,
+	}))
+
+	_, err = client.RequestPasswordReset(context.Background(), connect.NewRequest(&leapmuxv1.RequestPasswordResetRequest{
+		Identifier: "mailfail@example.com",
+	}))
+	require.NoError(t, err)
+
+	user, err := st.Users().GetByID(context.Background(), userID)
+	require.NoError(t, err)
+	assert.Empty(t, user.PendingPasswordResetToken)
+}
+
+func TestCompletePasswordReset_InvalidToken_NotFound(t *testing.T) {
+	t.Parallel()
+
+	client, st := setupPasswordResetAuthService(t, mail.NewStubSender())
+
+	userID := id.Generate()
+	hash, err := password.Hash("oldpass123")
+	require.NoError(t, err)
+	require.NoError(t, st.Users().Create(context.Background(), store.CreateUserParams{
+		ID:           userID,
+		Username:     "badtoken",
+		PasswordHash: hash,
+		PasswordSet:  true,
+	}))
+
+	_, err = client.CompletePasswordReset(context.Background(), connect.NewRequest(&leapmuxv1.CompletePasswordResetRequest{
+		Token:       "not-a-real-token",
+		NewPassword: "newpass123",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+
+	user, err := st.Users().GetByID(context.Background(), userID)
+	require.NoError(t, err)
+	match, err := password.Verify(user.PasswordHash, "oldpass123")
+	require.NoError(t, err)
+	assert.True(t, match)
+}
+
+func TestCompletePasswordReset_Success_WipesPasskeysAndSessions(t *testing.T) {
+	t.Parallel()
+
+	sender := &recordingMailSender{}
+	client, st := setupPasswordResetAuthService(t, sender)
+
+	userID := id.Generate()
+	hash, err := password.Hash("oldpass123")
+	require.NoError(t, err)
+	require.NoError(t, st.Users().Create(context.Background(), store.CreateUserParams{
+		ID:            userID,
+		Username:      "wipeme",
+		PasswordHash:  hash,
+		DisplayName:   "Wipe Me",
+		Email:         "wipeme@example.com",
+		EmailVerified: true,
+		PasswordSet:   true,
+	}))
+	seedPasskeyCredential(t, st, userID, "Laptop")
+	uid := userid.MustNew(userID)
+	oldSession, _, err := auth.CreateSession(context.Background(), st, uid, auth.DefaultSessionDuration)
+	require.NoError(t, err)
+	ceremonyID := id.Generate()
+	now := time.Now().UTC()
+	require.NoError(t, st.WebAuthnSessions().Create(context.Background(), store.CreateWebAuthnSessionParams{
+		ID:          ceremonyID,
+		Kind:        "login",
+		UserID:      userID,
+		PayloadJSON: "{}",
+		SessionData: []byte("dummy-ceremony"),
+		ExpiresAt:   now.Add(5 * time.Minute),
+		CreatedAt:   now,
+	}))
+
+	_, err = client.RequestPasswordReset(context.Background(), connect.NewRequest(&leapmuxv1.RequestPasswordResetRequest{
+		Identifier: "wipeme",
+	}))
+	require.NoError(t, err)
+	require.Len(t, sender.msgs, 1)
+	token := extractPasswordResetToken(sender.msgs[0].Body)
+	require.NotEmpty(t, token)
+	// The reset secret comes from the shared id mint, like session ids and
+	// API access secrets.
+	assert.Regexp(t, "^[A-Za-z0-9]{48}$", token)
+
+	_, err = client.CompletePasswordReset(context.Background(), connect.NewRequest(&leapmuxv1.CompletePasswordResetRequest{
+		Token:       token,
+		NewPassword: "newpass123",
+	}))
+	require.NoError(t, err)
+
+	count, err := st.PasskeyCredentials().CountByUser(context.Background(), userID)
+	require.NoError(t, err)
+	assert.EqualValues(t, 0, count)
+
+	_, err = st.Sessions().GetByID(context.Background(), oldSession, time.Now().UTC())
+	assert.ErrorIs(t, err, store.ErrNotFound)
+
+	_, err = st.WebAuthnSessions().Get(context.Background(), ceremonyID)
+	assert.ErrorIs(t, err, store.ErrNotFound)
+
+	_, _, _, err = auth.Login(context.Background(), st, "wipeme", "newpass123", auth.DefaultSessionDuration)
+	require.NoError(t, err)
+}
+
+func TestCompletePasswordReset_ExpiredToken_NotFound(t *testing.T) {
+	t.Parallel()
+
+	sender := &recordingMailSender{}
+	client, st := setupPasswordResetAuthService(t, sender)
+
+	userID := id.Generate()
+	hash, err := password.Hash("oldpass123")
+	require.NoError(t, err)
+	require.NoError(t, st.Users().Create(context.Background(), store.CreateUserParams{
+		ID:            userID,
+		Username:      "expired",
+		PasswordHash:  hash,
+		Email:         "expired@example.com",
+		EmailVerified: true,
+		PasswordSet:   true,
+	}))
+
+	_, err = client.RequestPasswordReset(context.Background(), connect.NewRequest(&leapmuxv1.RequestPasswordResetRequest{
+		Identifier: "expired@example.com",
+	}))
+	require.NoError(t, err)
+	require.Len(t, sender.msgs, 1)
+	token := extractPasswordResetToken(sender.msgs[0].Body)
+	require.NotEmpty(t, token)
+	// The reset secret comes from the shared id mint, like session ids and
+	// API access secrets.
+	assert.Regexp(t, "^[A-Za-z0-9]{48}$", token)
+
+	user, err := st.Users().GetByID(context.Background(), userID)
+	require.NoError(t, err)
+	_, err = st.Users().SetPendingPasswordReset(context.Background(), store.SetPendingPasswordResetParams{
+		ID:                            userID,
+		PendingPasswordResetToken:     user.PendingPasswordResetToken,
+		PendingPasswordResetExpiresAt: time.Now().UTC().Add(-time.Hour),
+		CooldownCutoff:                time.Now().UTC().Add(time.Hour),
+	})
+	require.NoError(t, err)
+
+	_, err = client.CompletePasswordReset(context.Background(), connect.NewRequest(&leapmuxv1.CompletePasswordResetRequest{
+		Token:       token,
+		NewPassword: "newpass123",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+}
+
+func TestCompletePasswordReset_AttemptLimitBlocksBeforeArgon2(t *testing.T) {
+	t.Parallel()
+
+	sender := &recordingMailSender{}
+	client, st := setupPasswordResetAuthService(t, sender)
+
+	userID := id.Generate()
+	hash, err := password.Hash("oldpass123")
+	require.NoError(t, err)
+	require.NoError(t, st.Users().Create(context.Background(), store.CreateUserParams{
+		ID:            userID,
+		Username:      "attemptcap",
+		PasswordHash:  hash,
+		Email:         "attemptcap@example.com",
+		EmailVerified: true,
+		PasswordSet:   true,
+	}))
+
+	_, err = client.RequestPasswordReset(context.Background(), connect.NewRequest(&leapmuxv1.RequestPasswordResetRequest{
+		Identifier: "attemptcap@example.com",
+	}))
+	require.NoError(t, err)
+	require.Len(t, sender.msgs, 1)
+	token := extractPasswordResetToken(sender.msgs[0].Body)
+	require.NotEmpty(t, token)
+	// The reset secret comes from the shared id mint, like session ids and
+	// API access secrets.
+	assert.Regexp(t, "^[A-Za-z0-9]{48}$", token)
+
+	// Burn the 5 soft attempts with a wrong password that still matches the
+	// token row (Consume increments). Use the real token so lookup succeeds;
+	// CompletePasswordReset validates password strength before hashing, so a
+	// valid new password is required. We force attempts via the store API.
+	for i := 0; i < 5; i++ {
+		_, err = st.Users().ConsumePasswordResetAttemptByToken(context.Background(), tokenHashForTest(token), time.Now().UTC(), 5)
+		require.NoError(t, err)
+	}
+
+	// Sixth Complete must refuse after Consume sets attempts>5, before a
+	// successful password change (password stays oldpass123).
+	_, err = client.CompletePasswordReset(context.Background(), connect.NewRequest(&leapmuxv1.CompletePasswordResetRequest{
+		Token:       token,
+		NewPassword: "newpass123",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+
+	user, err := st.Users().GetByID(context.Background(), userID)
+	require.NoError(t, err)
+	match, err := password.Verify(user.PasswordHash, "oldpass123")
+	require.NoError(t, err)
+	assert.True(t, match, "attempt limit must block before password hash is replaced")
+	assert.Greater(t, user.PendingPasswordResetAttempts, int64(5))
+}
+
+func TestRequestPasswordReset_InvalidUsername_EmptySuccess(t *testing.T) {
+	t.Parallel()
+
+	sender := &recordingMailSender{}
+	client, _ := setupPasswordResetAuthService(t, sender)
+
+	_, err := client.RequestPasswordReset(context.Background(), connect.NewRequest(&leapmuxv1.RequestPasswordResetRequest{
+		Identifier: "!!!not-a-slug!!!",
+	}))
+	require.NoError(t, err)
+	assert.Empty(t, sender.msgs)
+}
+
+func TestRequestPasswordReset_UsernameIsSanitized(t *testing.T) {
+	t.Parallel()
+
+	sender := &recordingMailSender{}
+	client, st := setupPasswordResetAuthService(t, sender)
+
+	userID := id.Generate()
+	hash, err := password.Hash("oldpass123")
+	require.NoError(t, err)
+	require.NoError(t, st.Users().Create(context.Background(), store.CreateUserParams{
+		ID:            userID,
+		Username:      "resetme",
+		PasswordHash:  hash,
+		DisplayName:   "Reset Me",
+		Email:         "resetme@example.com",
+		EmailVerified: true,
+		PasswordSet:   true,
+	}))
+
+	_, err = client.RequestPasswordReset(context.Background(), connect.NewRequest(&leapmuxv1.RequestPasswordResetRequest{
+		Identifier: "ResetMe",
+	}))
+	require.NoError(t, err)
+	require.Len(t, sender.msgs, 1)
+}
+
+func tokenHashForTest(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}
+
+// TestRequestPasswordReset_CooldownKeepsPreviousLink pins the per-account
+// resend cooldown: a second request inside the window must not mint a fresh
+// token (which would invalidate the link the first email still carries and
+// flood the inbox), and the first token must still complete.
+func TestRequestPasswordReset_CooldownKeepsPreviousLink(t *testing.T) {
+	sender := &recordingMailSender{}
+	client, _, st := setupPasswordResetAuthServiceConfigured(t, sender, seedSMTP)
+
+	userID := id.Generate()
+	require.NoError(t, st.Users().Create(context.Background(), store.CreateUserParams{
+		ID:            userID,
+		Username:      "cooldown-user",
+		PasswordHash:  password.PlaceholderHash,
+		DisplayName:   "Cooldown User",
+		Email:         "cooldown@example.com",
+		EmailVerified: true,
+		PasswordSet:   true,
+	}))
+
+	for i := 0; i < 2; i++ {
+		_, err := client.RequestPasswordReset(context.Background(), connect.NewRequest(&leapmuxv1.RequestPasswordResetRequest{
+			Identifier: "cooldown@example.com",
+		}))
+		require.NoError(t, err)
+	}
+	require.Len(t, sender.msgs, 1, "cooldown must suppress the second send")
+
+	token := extractPasswordResetToken(sender.msgs[0].Body)
+	require.NotEmpty(t, token)
+	// The reset secret comes from the shared id mint, like session ids and
+	// API access secrets.
+	assert.Regexp(t, "^[A-Za-z0-9]{48}$", token)
+	_, err := client.CompletePasswordReset(context.Background(), connect.NewRequest(&leapmuxv1.CompletePasswordResetRequest{
+		Token:       token,
+		NewPassword: "freshpass123",
+	}))
+	require.NoError(t, err, "the first link must stay completable inside the cooldown window")
+}
+
+// TestSignUp_MailFailureDoesNotLeakTransportDetails pins that a fail-closed
+// signup reports a generic error to the anonymous caller: the SMTP
+// transport chain specifies the relay host and port, and that detail stays in
+// the server log, never in the client response.
+func TestSignUp_MailFailureDoesNotLeakTransportDetails(t *testing.T) {
+	sender := &recordingMailSender{err: errors.New("dial tcp smtp.secret-relay.example:587: connection refused")}
+	client, _, st := setupPasswordResetAuthServiceConfigured(t, sender, seedSMTP)
+
+	// A user must exist so the sign-up takes the public path, not the
+	// first-admin setup path (which verifies nothing and sends no mail).
+	require.NoError(t, st.Users().Create(context.Background(), store.CreateUserParams{
+		ID:            id.Generate(),
+		Username:      "existing-admin",
+		PasswordHash:  password.PlaceholderHash,
+		DisplayName:   "Existing Admin",
+		Email:         "admin@example.com",
+		EmailVerified: true,
+		PasswordSet:   true,
+		IsAdmin:       true,
+	}))
+
+	_, err := client.SignUp(context.Background(), connect.NewRequest(&leapmuxv1.SignUpRequest{
+		Username:    "leakcheck-user",
+		Password:    "hunter2abc",
+		DisplayName: "Leak Check",
+		Email:       "leakcheck@example.com",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnavailable, connect.CodeOf(err))
+	assert.NotContains(t, err.Error(), "smtp.secret-relay.example")
+	assert.NotContains(t, err.Error(), ":587")
+	assert.NotContains(t, err.Error(), "connection refused")
+}
+
+// setupPasswordResetAuthServiceConfigured builds the reset harness with a
+// settings callback that runs against the SAME manager the service reads,
+// so a seeded SMTP row is visible to the service under test.
+func setupPasswordResetAuthServiceConfigured(t *testing.T, sender mail.Sender, configure func(t *testing.T, set *settings.Manager)) (leapmuxv1connect.AuthServiceClient, *settings.Manager, store.Store) {
+	t.Helper()
+
+	st := hubtestutil.OpenTestStore(t)
+	set := servicetest.NewSettingsManager(t, st, nil)
+	enableSignup(t, set)
+	configure(t, set)
+
+	mux := http.NewServeMux()
+	interceptor, sc := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st})
+	t.Cleanup(sc.Stop)
+	opts := connect.WithInterceptors(interceptor)
+	authSvc := service.NewAuthService(service.AuthServiceDeps{
+		Store:     st,
+		Config:    testConfig(),
+		Settings:  set,
+		Lifecycle: auth.NewCredentialLifecycleEffects(sc, nil, nil),
+		Mail:      sender,
+		Renderer:  mail.Renderer{BaseURL: func() string { return "https://hub.example.com" }},
+	})
+	path, handler := leapmuxv1connect.NewAuthServiceHandler(authSvc, opts)
+	mux.Handle(path, handler)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := leapmuxv1connect.NewAuthServiceClient(server.Client(), server.URL)
+	return client, set, st
+}

--- a/backend/internal/hub/service/auth_service.go
+++ b/backend/internal/hub/service/auth_service.go
@@ -222,6 +222,8 @@ func (s *AuthService) GetCurrentUser(ctx context.Context, req *connect.Request[l
 	userProto.OauthProviders = linkedProviders
 	return connect.NewResponse(&leapmuxv1.GetCurrentUserResponse{
 		User: userProto,
+		// Reported, never sent: this runs on every page load.
+		EmailVerification: emailVerificationToProto(s.verificationStatusFor(ctx, user)),
 	}), nil
 }
 
@@ -307,11 +309,11 @@ func (s *AuthService) SignUp(ctx context.Context, req *connect.Request[leapmuxv1
 		resp := connect.NewResponse(&leapmuxv1.SignUpResponse{
 			// A password sign-up carries no passkeys yet.
 			User: userToProto(createdUser, 0),
-			EmailVerification: &leapmuxv1.EmailVerificationStatus{
-				VerificationRequired:  true,
-				VerificationEmailSent: true,
-				NextResendAvailableAt: protoTimestamp(&nextResend),
-			},
+			EmailVerification: emailVerificationToProto(verificationOutcome{
+				Required:              true,
+				EmailSent:             true,
+				NextResendAvailableAt: &nextResend,
+			}),
 		})
 		s.setSessionCookie(ctx, resp.Header(), sessionID, sessionExpires)
 		s.hasAnyUser.Store(true)
@@ -571,7 +573,9 @@ func (s *AuthService) CompleteOAuthSignup(ctx context.Context, req *connect.Requ
 	}
 
 	// Use the email from the pending signup (provider-reported, already validated
-	// at callback time). The request's email field is ignored.
+	// at callback time). The request's email field is a FALLBACK only, read
+	// below when an untrusted provider supplied nothing; a provider-supplied
+	// address always wins, so the caller cannot substitute one.
 	email := pending.Email
 	rawDisplayName := req.Msg.GetDisplayName()
 	if rawDisplayName == "" {
@@ -606,6 +610,17 @@ func (s *AuthService) CompleteOAuthSignup(ctx context.Context, req *connect.Requ
 		// Untrusted provider: the hub applies its own signup email policy
 		// (required + verified-available when SMTP is on, optional
 		// otherwise), exactly like local signup.
+		//
+		// A provider that omits the email claim leaves the caller to supply
+		// one. Without this the sign-up is a dead end whenever SMTP is on:
+		// validateSignupEmail refuses an empty address, and no other step in
+		// the flow can produce one, so the pending token expires and the
+		// account can never be created. The request field is only honored
+		// when the provider gave nothing -- a provider-supplied address
+		// still wins, so the caller cannot substitute one.
+		if email == "" {
+			email = req.Msg.GetEmail()
+		}
 		if err := s.validateSignupEmail(ctx, email); err != nil {
 			return nil, err
 		}
@@ -681,11 +696,11 @@ func (s *AuthService) CompleteOAuthSignup(ctx context.Context, req *connect.Requ
 	resp := connect.NewResponse(&leapmuxv1.CompleteOAuthSignupResponse{
 		// An OAuth sign-up carries no passkeys yet.
 		User: userToProto(finalUser, 0),
-		EmailVerification: &leapmuxv1.EmailVerificationStatus{
-			VerificationRequired:  pendingEmail != "",
-			VerificationEmailSent: emailSent,
-			NextResendAvailableAt: protoTimestamp(nextResend),
-		},
+		EmailVerification: emailVerificationToProto(verificationOutcome{
+			Required:              pendingEmail != "",
+			EmailSent:             emailSent,
+			NextResendAvailableAt: nextResend,
+		}),
 	})
 	s.setSessionCookie(ctx, resp.Header(), sessionID, expiresAt)
 	return resp, nil
@@ -807,7 +822,7 @@ func (s *AuthService) validateSignupEmail(ctx context.Context, email string) err
 // signed-up account whose code was never delivered. That account
 // self-recovers — its credential committed with it, Login and the passkey
 // finish are public, and ResendVerificationEmail is allowlisted for
-// unverified sessions — so the strand is bounded to a double fault and
+// unverified sessions — so the strand is limited to a double fault and
 // needs no outbox. A rollback that itself fails is logged, never surfaced.
 func (s *AuthService) deliverSignupVerification(ctx context.Context, userID, email, code string) error {
 	if err := s.mail.Send(ctx, s.renderer.VerificationEmail(email, code, pendingEmailExpiry)); err != nil {

--- a/backend/internal/hub/service/auth_service.go
+++ b/backend/internal/hub/service/auth_service.go
@@ -21,6 +21,7 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/settings"
 	"github.com/leapmux/leapmux/internal/hub/store"
 	"github.com/leapmux/leapmux/internal/hub/usernames"
+	"github.com/leapmux/leapmux/internal/util/id"
 	"github.com/leapmux/leapmux/util/validate"
 	"github.com/leapmux/leapmux/util/version"
 )
@@ -111,9 +112,10 @@ func (s *AuthService) signupEnabled(ctx context.Context) bool {
 	return settings.SignupEnabledEffective(s.snap(ctx), s.cfg.DevMode)
 }
 
-// emailVerificationRequired reads the verification gate with its
-// degradation rule: requiring verification without SMTP cannot hold, so
-// it reads as off rather than locking every signup.
+// emailVerificationRequired reports whether the hub requires a verified
+// email before an account may act. Verification follows SMTP
+// (settings.EmailVerificationEffective): without a mail transport there is
+// no channel to verify through.
 func (s *AuthService) emailVerificationRequired(ctx context.Context) bool {
 	return settings.EmailVerificationEffective(s.snap(ctx))
 }
@@ -160,9 +162,9 @@ func (s *AuthService) Login(ctx context.Context, req *connect.Request[leapmuxv1.
 		return nil, err
 	}
 
-	resp := connect.NewResponse(&leapmuxv1.LoginResponse{
-		User: userToProto(user),
-	})
+	resp := connect.NewResponse(&leapmuxv1.LoginResponse{})
+	resp.Msg.User = userToProtoWithPasskeys(ctx, s.store, user)
+	resp.Msg.EmailVerification = emailVerificationToProto(s.loginVerificationOutcome(ctx, user))
 	s.setSessionCookie(ctx, resp.Header(), token, expiresAt)
 	return resp, nil
 }
@@ -216,8 +218,10 @@ func (s *AuthService) GetCurrentUser(ctx context.Context, req *connect.Request[l
 		}
 	}
 
+	userProto := userToProtoWithPasskeys(ctx, s.store, user)
+	userProto.OauthProviders = linkedProviders
 	return connect.NewResponse(&leapmuxv1.GetCurrentUserResponse{
-		User: userToProtoWithOAuth(user, linkedProviders),
+		User: userProto,
 	}), nil
 }
 
@@ -263,11 +267,10 @@ func (s *AuthService) SignUp(ctx context.Context, req *connect.Request[leapmuxv1
 	if err := CheckUsernameAvailable(ctx, s.store, username); err != nil {
 		return nil, AvailabilityConnectError(err)
 	}
-
-	email := req.Msg.GetEmail()
-	if err := validate.ValidateEmail(email); err != nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	if err := s.validateSignupEmail(ctx, req.Msg.GetEmail()); err != nil {
+		return nil, err
 	}
+	email := req.Msg.GetEmail()
 	hash, err := pwdhash.Hash(pw)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("hash password: %w", err))
@@ -277,47 +280,23 @@ func (s *AuthService) SignUp(ctx context.Context, req *connect.Request[leapmuxv1
 		return s.signUpSetupMode(ctx, username, displayName, email, hash)
 	}
 
-	if s.emailVerificationRequired(ctx) && email != "" {
-		// Email goes to pending_email; email column stays empty until verified.
-		if err := CheckEmailAvailable(ctx, s.store, email, ""); err != nil {
-			return nil, AvailabilityConnectError(err)
-		}
-
-		user, err := CreateUser(ctx, s.store, CreateUserParams{
-			Username:     username,
-			PasswordHash: hash,
-			DisplayName:  displayName,
-			Email:        "", // email goes to pending_email
-			PasswordSet:  true,
-			IsAdmin:      false,
+	if s.emailVerificationRequired(ctx) {
+		createdUser, storedCode, err := createUserInTx(ctx, s.store, createUserTxParams{
+			username:     username,
+			displayName:  displayName,
+			pendingEmail: email,
+			passwordHash: hash,
+			passwordSet:  true,
 		})
 		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, err)
+			return nil, mapSignupCommitError(err)
 		}
+		if err := s.deliverSignupVerification(ctx, createdUser.ID, email, storedCode); err != nil {
+			return nil, err
+		}
+		nextResend := nextResendAt(time.Now().UTC())
 
-		// Issue the verification email. Failure does NOT roll back the
-		// user: signup succeeds and the frontend surfaces a Resend prompt
-		// driven by verification_email_sent=false. The pending row stays
-		// in place so a future Resend can reuse the same address slot.
-		emailSent, err := issuePendingEmailVerification(ctx, s.store, s.mail, s.renderer, user.ID, email)
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, err)
-		}
-		if !emailSent {
-			slog.Warn("verification email send failed during signup",
-				"user_id", user.ID,
-			)
-		}
-
-		// Re-fetch so the User proto reflects the just-set pending fields.
-		updatedUser, err := s.store.Users().GetByID(ctx, user.ID)
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, err)
-		}
-
-		// Always create the session — without it, the user can't call the
-		// authenticated VerifyEmail RPC.
-		uid, mintErr := mintRowUserID(user.ID)
+		uid, mintErr := mintRowUserID(createdUser.ID)
 		if mintErr != nil {
 			return nil, mintErr
 		}
@@ -326,21 +305,20 @@ func (s *AuthService) SignUp(ctx context.Context, req *connect.Request[leapmuxv1
 			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("create session: %w", err))
 		}
 		resp := connect.NewResponse(&leapmuxv1.SignUpResponse{
-			User:                  userToProto(updatedUser),
-			VerificationRequired:  true,
-			VerificationEmailSent: emailSent,
+			// A password sign-up carries no passkeys yet.
+			User: userToProto(createdUser, 0),
+			EmailVerification: &leapmuxv1.EmailVerificationStatus{
+				VerificationRequired:  true,
+				VerificationEmailSent: true,
+				NextResendAvailableAt: protoTimestamp(&nextResend),
+			},
 		})
 		s.setSessionCookie(ctx, resp.Header(), sessionID, sessionExpires)
+		s.hasAnyUser.Store(true)
 		return resp, nil
 	}
 
 	// No verification required — email goes directly to email column.
-	if email != "" {
-		if err := CheckEmailAvailable(ctx, s.store, email, ""); err != nil {
-			return nil, AvailabilityConnectError(err)
-		}
-	}
-
 	user, err := CreateUser(ctx, s.store, CreateUserParams{
 		Username:     username,
 		PasswordHash: hash,
@@ -376,13 +354,12 @@ func (s *AuthService) signUpSetupMode(ctx context.Context, username, displayName
 	}
 
 	user, err := CreateUser(ctx, s.store, CreateUserParams{
-		Username:      username,
-		PasswordHash:  passwordHash,
-		DisplayName:   displayName,
-		Email:         email,
-		EmailVerified: email != "",
-		PasswordSet:   true,
-		IsAdmin:       true,
+		Username:     username,
+		PasswordHash: passwordHash,
+		DisplayName:  displayName,
+		Email:        email,
+		PasswordSet:  true,
+		IsAdmin:      true,
 	})
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
@@ -404,7 +381,8 @@ func (s *AuthService) signUpResponse(ctx context.Context, user *store.User) (*co
 	}
 
 	resp := connect.NewResponse(&leapmuxv1.SignUpResponse{
-		User: userToProto(user),
+		// Both callers are password sign-ups: no passkeys yet.
+		User: userToProto(user, 0),
 	})
 	s.setSessionCookie(ctx, resp.Header(), sessionID, expiresAt)
 	return resp, nil
@@ -468,6 +446,7 @@ func (s *AuthService) GetSystemInfo(ctx context.Context, req *connect.Request[le
 		OauthEnabled:    len(providers) > 0,
 		WorkerHubUrl:    workerHubURL,
 		EmailEnabled:    settings.KeySMTP.Of(snap).Enabled(),
+		PasskeyEnabled:  s.passkeysAvailable(ctx),
 		CaptchaEnabled:  captchaEnabled,
 		AltchaAlgorithm: altchaAlgorithm,
 		CaptchaProvider: captchaProvider,
@@ -574,12 +553,8 @@ func (s *AuthService) CompleteOAuthSignup(ctx context.Context, req *connect.Requ
 	}
 	// OAuth completion is always treated as public signup — the first-admin
 	// flow lives at /setup, so both reserved rules apply.
-	if usernames.IsReservedForPublicSignup(username) {
-		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("%q is a reserved username", username))
-	}
-
-	if err := CheckUsernameAvailable(ctx, s.store, username); err != nil {
-		return nil, AvailabilityConnectError(err)
+	if err := s.validatePublicSignupUsername(ctx, username); err != nil {
+		return nil, err
 	}
 
 	// Check that the OAuth link doesn't already exist (race protection).
@@ -618,66 +593,70 @@ func (s *AuthService) CompleteOAuthSignup(ctx context.Context, req *connect.Requ
 	var emailVerified bool
 	var pendingEmail string
 
-	if email != "" {
+	if trustEmail {
+		if email == "" {
+			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("trusted OAuth provider returned no email"))
+		}
 		if err := CheckEmailAvailable(ctx, s.store, email, ""); err != nil {
 			return nil, AvailabilityConnectError(err)
 		}
-
-		if trustEmail {
-			// Trusted OAuth email — goes directly to email column as verified.
-			userEmail = email
-			emailVerified = true
-		} else if s.emailVerificationRequired(ctx) {
-			// Untrusted + verification required — goes to pending_email.
+		userEmail = email
+		emailVerified = true
+	} else {
+		// Untrusted provider: the hub applies its own signup email policy
+		// (required + verified-available when SMTP is on, optional
+		// otherwise), exactly like local signup.
+		if err := s.validateSignupEmail(ctx, email); err != nil {
+			return nil, err
+		}
+		if s.emailVerificationRequired(ctx) {
 			pendingEmail = email
 		} else {
-			// Untrusted + verification not required — goes to email column unverified.
 			userEmail = email
 		}
 	}
 
-	user, err := CreateUser(ctx, s.store, CreateUserParams{
-		Username:      username,
-		PasswordHash:  pwdhash.PlaceholderHash,
-		DisplayName:   displayName,
-		Email:         userEmail,
-		EmailVerified: emailVerified,
-		PasswordSet:   false, // OAuth users don't have a real password
-		IsAdmin:       false,
+	linkUserID := id.Generate()
+	link := func(tx store.Store) error {
+		linkUID, mintErr := mintRowUserID(linkUserID)
+		if mintErr != nil {
+			return mintErr
+		}
+		if err := tx.OAuthUserLinks().Create(ctx, store.CreateOAuthUserLinkParams{
+			UserID:          linkUID,
+			ProviderID:      pending.ProviderID,
+			ProviderSubject: pending.ProviderSubject,
+		}); err != nil {
+			return fmt.Errorf("create user link: %w", err)
+		}
+		return nil
+	}
+
+	var user *store.User
+	emailSent := false
+	var storedCode string
+
+	var nextResend *time.Time
+	user, storedCode, err = createUserInTx(ctx, s.store, createUserTxParams{
+		userID:        linkUserID,
+		username:      username,
+		displayName:   displayName,
+		email:         userEmail,
+		emailVerified: emailVerified,
+		pendingEmail:  pendingEmail,
+		passwordHash:  pwdhash.PlaceholderHash,
+		extra:         link,
 	})
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, mapSignupCommitError(err)
 	}
-
-	// Handle pending email if needed. Send failures during OAuth signup
-	// don't roll back: the OAuth-linked account exists, and the user can
-	// re-trigger verification via Resend later. emailSent flows back to
-	// the response so the frontend can surface a Resend prompt when the
-	// SMTP send failed but the row was written.
-	emailSent := false
 	if pendingEmail != "" {
-		sent, err := issuePendingEmailVerification(ctx, s.store, s.mail, s.renderer, user.ID, pendingEmail)
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, err)
+		if err := s.deliverSignupVerification(ctx, user.ID, pendingEmail, storedCode); err != nil {
+			return nil, err
 		}
-		emailSent = sent
-		if !sent {
-			slog.Warn("verification email send failed during oauth signup",
-				"user_id", user.ID,
-			)
-		}
-	}
-
-	linkUID, err := mintRowUserID(user.ID)
-	if err != nil {
-		return nil, err
-	}
-	if err := s.store.OAuthUserLinks().Create(ctx, store.CreateOAuthUserLinkParams{
-		UserID:          linkUID,
-		ProviderID:      pending.ProviderID,
-		ProviderSubject: pending.ProviderSubject,
-	}); err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("create user link: %w", err))
+		emailSent = true
+		next := nextResendAt(time.Now().UTC())
+		nextResend = &next
 	}
 
 	// Decrypt and re-store OAuth tokens with the real user ID as AAD.
@@ -689,16 +668,7 @@ func (s *AuthService) CompleteOAuthSignup(ctx context.Context, req *connect.Requ
 
 	_ = s.store.PendingOAuthSignups().Delete(ctx, signupToken)
 
-	// Re-fetch user only when pending email modified the user row.
 	finalUser := user
-	if pendingEmail != "" {
-		refetched, refetchErr := s.store.Users().GetByID(ctx, user.ID)
-		if refetchErr != nil {
-			return nil, connect.NewError(connect.CodeInternal, refetchErr)
-		}
-		finalUser = refetched
-	}
-
 	finalUID, mintErr := mintRowUserID(finalUser.ID)
 	if mintErr != nil {
 		return nil, mintErr
@@ -709,9 +679,13 @@ func (s *AuthService) CompleteOAuthSignup(ctx context.Context, req *connect.Requ
 	}
 
 	resp := connect.NewResponse(&leapmuxv1.CompleteOAuthSignupResponse{
-		User:                  userToProto(finalUser),
-		VerificationRequired:  pendingEmail != "",
-		VerificationEmailSent: emailSent,
+		// An OAuth sign-up carries no passkeys yet.
+		User: userToProto(finalUser, 0),
+		EmailVerification: &leapmuxv1.EmailVerificationStatus{
+			VerificationRequired:  pendingEmail != "",
+			VerificationEmailSent: emailSent,
+			NextResendAvailableAt: protoTimestamp(nextResend),
+		},
 	})
 	s.setSessionCookie(ctx, resp.Header(), sessionID, expiresAt)
 	return resp, nil
@@ -749,7 +723,7 @@ func reencryptPendingTokens(ctx context.Context, ks *keystore.Keystore, st store
 	})
 }
 
-func userToProto(u *store.User) *leapmuxv1.User {
+func userToProto(u *store.User, passkeyCount int64) *leapmuxv1.User {
 	return &leapmuxv1.User{
 		Id:            u.ID,
 		Username:      u.Username,
@@ -759,11 +733,90 @@ func userToProto(u *store.User) *leapmuxv1.User {
 		EmailVerified: u.EmailVerified,
 		PendingEmail:  u.PendingEmail,
 		PasswordSet:   u.PasswordSet,
+		PasskeyCount:  int32(passkeyCount),
 	}
 }
 
-func userToProtoWithOAuth(u *store.User, oauthProviders []*leapmuxv1.LinkedOAuthProvider) *leapmuxv1.User {
-	p := userToProto(u)
-	p.OauthProviders = oauthProviders
-	return p
+// userToProtoWithPasskeys fills the passkey count best-effort. The count is
+// display data; a transient failure of this one query must not fail an RPC
+// whose main work already committed (a minted session, a rotated password).
+// The failure is logged and the count reports zero.
+func userToProtoWithPasskeys(ctx context.Context, st store.Store, u *store.User) *leapmuxv1.User {
+	count, err := st.PasskeyCredentials().CountByUser(ctx, u.ID)
+	if err != nil {
+		slog.WarnContext(ctx, "count passkeys for user proto", "user_id", u.ID, "err", err)
+		count = 0
+	}
+	return userToProto(u, count)
+}
+
+// mapSignupCommitError maps an account-creation failure onto a connect
+// code. A uniqueness conflict is AlreadyExists with a stable message: the
+// unique index, not the pre-checks, is the real guard against a race, and
+// a permanent conflict reported as a retryable fault with raw driver text
+// misleads both the client and the operator. Everything else is Internal.
+func mapSignupCommitError(err error) error {
+	if errors.Is(err, store.ErrConflict) {
+		return connect.NewError(connect.CodeAlreadyExists, fmt.Errorf("username or email already taken"))
+	}
+	return connect.NewError(connect.CodeInternal, err)
+}
+
+// validatePublicSignupUsername enforces the public-signup username rules
+// (reserved names + availability) shared by the OAuth completion and both
+// passkey sign-up halves. The first-admin flow at /setup is not public
+// signup and keeps its own setup-mode rules.
+func (s *AuthService) validatePublicSignupUsername(ctx context.Context, username string) error {
+	if usernames.IsReservedForPublicSignup(username) {
+		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("%q is a reserved username", username))
+	}
+	if err := CheckUsernameAvailable(ctx, s.store, username); err != nil {
+		return AvailabilityConnectError(err)
+	}
+	return nil
+}
+
+// validateSignupEmail enforces the email policy shared by every sign-up
+// flavor: the address is required and verified-available when the hub
+// requires email verification, validated and availability-checked whenever
+// present otherwise. One spelling of the policy, so the password, OAuth,
+// and passkey flavors cannot drift.
+func (s *AuthService) validateSignupEmail(ctx context.Context, email string) error {
+	if email == "" {
+		if s.emailVerificationRequired(ctx) {
+			return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("email is required"))
+		}
+		return nil
+	}
+	if err := validate.ValidateEmail(email); err != nil {
+		return connect.NewError(connect.CodeInvalidArgument, err)
+	}
+	if err := CheckEmailAvailable(ctx, s.store, email, ""); err != nil {
+		return AvailabilityConnectError(err)
+	}
+	return nil
+}
+
+// deliverSignupVerification sends the verification email. A send failure
+// fails closed: the account cannot verify its email, so the just-created
+// account is rolled back and the caller sees a generic error. The transport
+// error stays in the server log — never in the anonymous client response.
+//
+// The rollback is a best-effort compensation in a SECOND transaction: a
+// process death between the create commit and this rollback leaves a
+// signed-up account whose code was never delivered. That account
+// self-recovers — its credential committed with it, Login and the passkey
+// finish are public, and ResendVerificationEmail is allowlisted for
+// unverified sessions — so the strand is bounded to a double fault and
+// needs no outbox. A rollback that itself fails is logged, never surfaced.
+func (s *AuthService) deliverSignupVerification(ctx context.Context, userID, email, code string) error {
+	if err := s.mail.Send(ctx, s.renderer.VerificationEmail(email, code, pendingEmailExpiry)); err != nil {
+		slog.WarnContext(ctx, "verification email send failed; rolling back sign-up",
+			"user_id", userID, "err", err)
+		if rbErr := rollbackUnusableSignup(ctx, s.store, userID); rbErr != nil {
+			slog.ErrorContext(ctx, "sign-up rollback failed", "user_id", userID, "err", rbErr)
+		}
+		return connect.NewError(connect.CodeUnavailable, fmt.Errorf("sign-up failed: verification email could not be sent"))
+	}
+	return nil
 }

--- a/backend/internal/hub/service/auth_service_test.go
+++ b/backend/internal/hub/service/auth_service_test.go
@@ -159,6 +159,56 @@ func TestAuthService_GetCurrentUser(t *testing.T) {
 	assert.Equal(t, "admin", resp.Msg.GetUser().GetUsername())
 }
 
+// GetCurrentUser is the only response the /verify-email page's own
+// bootstrap reads, so it has to carry the resend cooldown: without it a
+// hard reload restarted the countdown at zero, the button re-enabled, and
+// the click got a ResourceExhausted with no timestamp to restart from.
+//
+// It must also REPORT and never SEND, because every page load calls it.
+func TestAuthService_GetCurrentUser_CarriesTheVerificationCooldown(t *testing.T) {
+	t.Parallel()
+
+	// An admin already exists, so this is a PUBLIC sign-up rather than the
+	// setup-mode first user (which is always an admin, and admins are
+	// exempt from verification).
+	client, st, _ := setupAuthTestServer(t, testConfig(), func(t *testing.T, set *settings.Manager) {
+		t.Helper()
+		seedSMTP(t, set)
+		enableSignup(t, set)
+	})
+
+	signUp, err := client.SignUp(context.Background(), connect.NewRequest(&leapmuxv1.SignUpRequest{
+		Username: "pending", Password: "strongpass1", DisplayName: "Pending",
+		Email: "pending@example.test",
+	}))
+	require.NoError(t, err)
+	require.True(t, signUp.Msg.GetEmailVerification().GetVerificationRequired())
+	seeded := signUp.Msg.GetEmailVerification().GetNextResendAvailableAt()
+	require.NotNil(t, seeded, "sign-up hands out the first cooldown")
+
+	req := connect.NewRequest(&leapmuxv1.GetCurrentUserRequest{})
+	req.Header().Set("Cookie", auth.CookieName+"="+sessionFromCookie(t, signUp.Header().Get("Set-Cookie")))
+	resp, err := client.GetCurrentUser(context.Background(), req)
+	require.NoError(t, err)
+
+	status := resp.Msg.GetEmailVerification()
+	require.NotNil(t, status, "the bootstrap response must carry the status")
+	assert.True(t, status.GetVerificationRequired())
+	require.NotNil(t, status.GetNextResendAvailableAt(),
+		"a reload must resume the countdown the sign-up handed out")
+	assert.WithinDuration(t, seeded.AsTime(), status.GetNextResendAvailableAt().AsTime(), time.Second)
+
+	// Reporting, not sending: the pending code is untouched by the call.
+	before, err := st.Users().GetByUsername(context.Background(), "pending")
+	require.NoError(t, err)
+	_, err = client.GetCurrentUser(context.Background(), req)
+	require.NoError(t, err)
+	after, err := st.Users().GetByUsername(context.Background(), "pending")
+	require.NoError(t, err)
+	assert.Equal(t, before.PendingEmailToken, after.PendingEmailToken,
+		"a page load must not mint or re-send a verification code")
+}
+
 func TestAuthService_GetCurrentUser_NoToken(t *testing.T) {
 	t.Parallel()
 
@@ -408,11 +458,12 @@ func TestPromotePendingEmail_ClearsCompetingPendingEmails(t *testing.T) {
 			IsAdmin:      false,
 		})
 		require.NoError(t, err)
-		err = st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
+		_, err = st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
 			PendingEmail:          "shared@example.com",
 			PendingEmailToken:     verifycode.Generate(),
 			PendingEmailExpiresAt: ptrTime(time.Now().Add(24 * time.Hour).UTC()),
 			ID:                    userID,
+			CooldownCutoff:        store.UnconditionalMintCutoff(),
 		})
 		require.NoError(t, err)
 	}
@@ -468,11 +519,12 @@ func TestSignUp_DirectEmail_ClearsCompetingPendingEmails(t *testing.T) {
 		IsAdmin:      false,
 	})
 	require.NoError(t, err)
-	err = st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
+	_, err = st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
 		PendingEmail:          "race@example.com",
 		PendingEmailToken:     verifycode.Generate(),
 		PendingEmailExpiresAt: ptrTime(time.Now().Add(24 * time.Hour).UTC()),
 		ID:                    userAID,
+		CooldownCutoff:        store.UnconditionalMintCutoff(),
 	})
 	require.NoError(t, err)
 

--- a/backend/internal/hub/service/auth_service_test.go
+++ b/backend/internal/hub/service/auth_service_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/leapmux/leapmux/generated/proto/leapmux/v1/leapmuxv1connect"
 	"github.com/leapmux/leapmux/internal/hub/auth"
 	"github.com/leapmux/leapmux/internal/hub/config"
+	"github.com/leapmux/leapmux/internal/hub/keystore"
 	"github.com/leapmux/leapmux/internal/hub/mail"
 
 	"github.com/leapmux/leapmux/internal/hub/password"
@@ -71,7 +72,7 @@ func TestLifecycleAwareServicesRequireEffects(t *testing.T) {
 		service.NewAuthService(service.AuthServiceDeps{Renderer: mail.Renderer{}})
 	})
 	assert.Panics(t, func() {
-		service.NewUserService(nil, nil, nil, nil, nil, mail.Renderer{})
+		service.NewUserService(nil, nil, nil, nil, nil, mail.Renderer{}, nil)
 	})
 	assert.Panics(t, func() {
 		service.NewWorkerDelegationHandler(nil, nil, nil)
@@ -245,7 +246,7 @@ func TestAuthService_SessionMintPathsUseConfiguredDuration(t *testing.T) {
 
 	assertExpiry := func(t *testing.T, st store.Store, sessionID string, before time.Time) {
 		t.Helper()
-		sess, err := st.Sessions().GetByID(context.Background(), sessionID)
+		sess, err := st.Sessions().GetByID(context.Background(), sessionID, time.Now().UTC())
 		require.NoError(t, err)
 		hubtestutil.AssertSessionLifetime(t, before, configured, sess.ExpiresAt)
 	}
@@ -254,7 +255,7 @@ func TestAuthService_SessionMintPathsUseConfiguredDuration(t *testing.T) {
 		t.Parallel()
 		before := time.Now()
 		resp, st, sessionID := signUp(t, enableSignup, "newuser")
-		require.False(t, resp.Msg.GetVerificationRequired(), "control: this is the plain branch")
+		require.False(t, resp.Msg.GetEmailVerification().GetVerificationRequired(), "control: this is the plain branch")
 		assertExpiry(t, st, sessionID, before)
 	})
 
@@ -267,7 +268,7 @@ func TestAuthService_SessionMintPathsUseConfiguredDuration(t *testing.T) {
 		}, "unverified")
 		// Without this the subtest would silently repeat the branch above, and
 		// the second CreateSession call site would go unexercised.
-		require.True(t, resp.Msg.GetVerificationRequired(), "this must take the verification branch")
+		require.True(t, resp.Msg.GetEmailVerification().GetVerificationRequired(), "this must take the verification branch")
 		assertExpiry(t, st, sessionID, before)
 	})
 
@@ -338,7 +339,7 @@ func TestAuthService_ChangePassword_WrongOldPassword(t *testing.T) {
 	mux := http.NewServeMux()
 	interceptor, _ := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st})
 	opts := connect.WithInterceptors(interceptor)
-	userSvc := service.NewUserService(st, testConfig(), set, auth.NewCredentialLifecycleEffects(nil, nil, nil), mail.NewStubSender(), mail.Renderer{})
+	userSvc := service.NewUserService(st, testConfig(), set, auth.NewCredentialLifecycleEffects(nil, nil, nil), mail.NewStubSender(), mail.Renderer{}, nil)
 	path, handler := leapmuxv1connect.NewUserServiceHandler(userSvc, opts)
 	mux.Handle(path, handler)
 	server := httptest.NewServer(mux)
@@ -545,7 +546,7 @@ func setupVerificationGatingTestServer(t *testing.T, emailVerificationRequired b
 	interceptor, _ := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st, Policy: servicetest.AuthPolicy(set)})
 	opts := connect.WithInterceptors(interceptor)
 
-	userSvc := service.NewUserService(st, testConfig(), set, auth.NewCredentialLifecycleEffects(nil, nil, nil), mail.NewStubSender(), mail.Renderer{})
+	userSvc := service.NewUserService(st, testConfig(), set, auth.NewCredentialLifecycleEffects(nil, nil, nil), mail.NewStubSender(), mail.Renderer{}, nil)
 	userPath, userHandler := leapmuxv1connect.NewUserServiceHandler(userSvc, opts)
 	mux.Handle(userPath, userHandler)
 
@@ -640,7 +641,7 @@ func TestVerificationGating_ConfigOff_NotBlocked(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// --- SignUp with EmailVerificationRequired ---
+// --- SignUp with email verification (requires SMTP) ---
 
 func TestSignUp_VerificationRequired_EmailInPendingColumn(t *testing.T) {
 	t.Parallel()
@@ -660,8 +661,8 @@ func TestSignUp_VerificationRequired_EmailInPendingColumn(t *testing.T) {
 
 	// The response should indicate verification was required and that
 	// the (stub) email send succeeded.
-	assert.True(t, resp.Msg.GetVerificationRequired())
-	assert.True(t, resp.Msg.GetVerificationEmailSent())
+	assert.True(t, resp.Msg.GetEmailVerification().GetVerificationRequired())
+	assert.True(t, resp.Msg.GetEmailVerification().GetVerificationEmailSent())
 	assert.Equal(t, "verifyuser", resp.Msg.GetUser().GetUsername())
 
 	// Email stays in the pending column until the user submits the code.
@@ -679,14 +680,49 @@ func TestSignUp_VerificationRequired_EmailInPendingColumn(t *testing.T) {
 	assert.Contains(t, resp.Header().Get("Set-Cookie"), auth.CookieName+"=")
 }
 
-// --- VerifyEmail tests ---
+type failingMailSender struct{ err error }
 
-// VerifyEmail moved from AuthService to UserService and is now
-// authenticated. The exhaustive coverage lives in user_service_test.go;
-// keeping this file slim avoids accidental drift between two suites
-// testing the same handler.
+func (f failingMailSender) Send(context.Context, mail.Message) error { return f.err }
 
-// --- Verification gating: allowed methods ---
+func TestSignUp_FailClosedWhenVerificationEmailFails(t *testing.T) {
+	t.Parallel()
+
+	st := hubtestutil.OpenTestStore(t)
+	set := servicetest.NewSettingsManager(t, st, nil)
+	enableSignup(t, set)
+	enableEmailVerification(t, set)
+
+	mux := http.NewServeMux()
+	interceptor, sc := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st})
+	t.Cleanup(sc.Stop)
+	opts := connect.WithInterceptors(interceptor)
+	authSvc := service.NewAuthService(service.AuthServiceDeps{
+		Store:     st,
+		Config:    testConfig(),
+		Settings:  set,
+		Lifecycle: auth.NewCredentialLifecycleEffects(sc, nil, nil),
+		Mail:      failingMailSender{err: errors.New("smtp down")},
+		Renderer:  mail.Renderer{},
+	})
+	path, handler := leapmuxv1connect.NewAuthServiceHandler(authSvc, opts)
+	mux.Handle(path, handler)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	client := leapmuxv1connect.NewAuthServiceClient(server.Client(), server.URL)
+	hubtestutil.CreateTestAdmin(t, st)
+
+	_, err := client.SignUp(context.Background(), connect.NewRequest(&leapmuxv1.SignUpRequest{
+		Username:    "failclosed",
+		Password:    "password123",
+		DisplayName: "Fail Closed",
+		Email:       "failclosed@example.com",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnavailable, connect.CodeOf(err))
+
+	_, err = st.Users().GetByUsername(context.Background(), "failclosed")
+	assert.ErrorIs(t, err, store.ErrNotFound)
+}
 
 func TestVerificationGating_LogoutAllowed(t *testing.T) {
 	t.Parallel()
@@ -902,13 +938,14 @@ func TestSetupSignUp_EmptyEmail(t *testing.T) {
 	user := resp.Msg.GetUser()
 	assert.True(t, user.GetIsAdmin())
 	assert.Empty(t, user.GetEmail())
-	assert.False(t, user.GetEmailVerified())
+	// Setup-mode admin is always treated as verified, even with no email.
+	assert.True(t, user.GetEmailVerified())
 
 	// Verify in DB.
 	dbUser, err := st.Users().GetByUsername(context.Background(), "myadmin")
 	require.NoError(t, err)
 	assert.True(t, dbUser.IsAdmin)
-	assert.False(t, dbUser.EmailVerified)
+	assert.True(t, dbUser.EmailVerified)
 }
 
 func TestSetupSignUp_GetSystemInfoReturnsSetupRequired(t *testing.T) {
@@ -1240,4 +1277,233 @@ func TestSignUp_RejectsAdminInPublicSignup(t *testing.T) {
 	}))
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+
+func TestSignUp_RequiresEmailWhenSMTPConfigured(t *testing.T) {
+	t.Parallel()
+
+	client, _, set := setupAuthTestServer(t, testConfig(), enableSignup)
+	enableEmailVerification(t, set)
+
+	_, err := client.SignUp(context.Background(), connect.NewRequest(&leapmuxv1.SignUpRequest{
+		Username:    "noemail",
+		Password:    "password123",
+		DisplayName: "No Email",
+		Email:       "",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	assert.Contains(t, err.Error(), "email is required")
+}
+
+func TestSignUp_SMTPOff_StoresUnverifiedEmail(t *testing.T) {
+	t.Parallel()
+
+	client, st, _ := setupAuthTestServer(t, testConfig(), enableSignup)
+
+	resp, err := client.SignUp(context.Background(), connect.NewRequest(&leapmuxv1.SignUpRequest{
+		Username:    "smtpoff",
+		Password:    "password123",
+		DisplayName: "SMTP Off",
+		Email:       "smtpoff@example.com",
+	}))
+	require.NoError(t, err)
+	assert.False(t, resp.Msg.GetEmailVerification().GetVerificationRequired())
+	assert.NotEmpty(t, resp.Header().Get("Set-Cookie"))
+
+	user, err := st.Users().GetByUsername(context.Background(), "smtpoff")
+	require.NoError(t, err)
+	assert.Equal(t, "smtpoff@example.com", user.Email)
+	assert.False(t, user.EmailVerified)
+	assert.Empty(t, user.PendingEmail)
+}
+
+func TestLogin_ReturnsVerificationFlagsWhenVerificationRequired(t *testing.T) {
+	t.Parallel()
+
+	client, st, set := setupAuthTestServer(t, testConfig(), enableSignup)
+	enableEmailVerification(t, set)
+
+	_, err := client.SignUp(context.Background(), connect.NewRequest(&leapmuxv1.SignUpRequest{
+		Username:    "gateduser",
+		Password:    "password123",
+		DisplayName: "Gated",
+		Email:       "gated@example.com",
+	}))
+	require.NoError(t, err)
+
+	user, err := st.Users().GetByUsername(context.Background(), "gateduser")
+	require.NoError(t, err)
+	assert.False(t, user.EmailVerified)
+
+	loginResp, err := client.Login(context.Background(), connect.NewRequest(&leapmuxv1.LoginRequest{
+		Username: "gateduser",
+		Password: "password123",
+	}))
+	require.NoError(t, err)
+	assert.True(t, loginResp.Msg.GetEmailVerification().GetVerificationRequired())
+	// Signup already issued pending_email; login surfaces cooldown without resending.
+	assert.False(t, loginResp.Msg.GetEmailVerification().GetVerificationEmailSent())
+	require.NotNil(t, loginResp.Msg.GetEmailVerification().GetNextResendAvailableAt())
+}
+
+func TestFinishPasskeySignUp_FailClosedWhenVerificationEmailFails(t *testing.T) {
+	t.Parallel()
+
+	env := setupPasskeyAuthTestServer(t, func(t *testing.T, set *settings.Manager) {
+		enableSignup(t, set)
+		enableEmailVerification(t, set)
+	}, failingMailSender{err: errors.New("smtp down")})
+
+	begin := beginPasskeySignUp(t, env.client, "pkfailclosed", "pkfailclosed@example.com")
+	ceremony := newPasskeyCeremony()
+	credentialJSON, err := ceremony.registrationResponse(begin.GetOptionsJson())
+	require.NoError(t, err)
+
+	failReq := connect.NewRequest(&leapmuxv1.FinishPasskeySignUpRequest{
+		SessionId:      begin.GetSessionId(),
+		CredentialJson: credentialJSON,
+	})
+	failReq.Header().Set("Origin", passkeyTestOrigin)
+	_, err = env.client.FinishPasskeySignUp(context.Background(), failReq)
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnavailable, connect.CodeOf(err))
+
+	_, err = env.store.Users().GetByUsername(context.Background(), "pkfailclosed")
+	assert.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestFinishPasskeyLogin_ReturnsVerificationFlagsWhenVerificationRequired(t *testing.T) {
+	t.Parallel()
+
+	env := setupPasskeyAuthTestServer(t, func(t *testing.T, set *settings.Manager) {
+		enableSignup(t, set)
+		enableEmailVerification(t, set)
+	}, nil)
+
+	begin := beginPasskeySignUp(t, env.client, "pkgated", "pkgated@example.com")
+	ceremony := newPasskeyCeremony()
+	credentialJSON, err := ceremony.registrationResponse(begin.GetOptionsJson())
+	require.NoError(t, err)
+	finishReq := connect.NewRequest(&leapmuxv1.FinishPasskeySignUpRequest{
+		SessionId:      begin.GetSessionId(),
+		CredentialJson: credentialJSON,
+	})
+	finishReq.Header().Set("Origin", passkeyTestOrigin)
+	signUpResp, err := env.client.FinishPasskeySignUp(context.Background(), finishReq)
+	require.NoError(t, err)
+	assert.True(t, signUpResp.Msg.GetEmailVerification().GetVerificationRequired())
+
+	user, err := env.store.Users().GetByUsername(context.Background(), "pkgated")
+	require.NoError(t, err)
+	assert.False(t, user.EmailVerified)
+
+	loginBegin := beginPasskeyLogin(t, env.client, "pkgated")
+	assertionJSON, err := ceremony.assertionResponse(loginBegin.GetOptionsJson())
+	require.NoError(t, err)
+	loginResp, err := finishPasskeyLogin(t, env.client, loginBegin.GetSessionId(), assertionJSON)
+	require.NoError(t, err)
+	assert.True(t, loginResp.Msg.GetEmailVerification().GetVerificationRequired())
+	assert.False(t, loginResp.Msg.GetEmailVerification().GetVerificationEmailSent())
+	require.NotNil(t, loginResp.Msg.GetEmailVerification().GetNextResendAvailableAt())
+}
+
+func TestBeginPasskeySignUp_RequiresEmailWhenSMTPConfigured(t *testing.T) {
+	t.Parallel()
+
+	st := hubtestutil.OpenTestStore(t)
+	set := servicetest.NewSettingsManager(t, st, nil)
+	enableSignup(t, set)
+	enableEmailVerification(t, set)
+	hubtestutil.CreateTestAdmin(t, st)
+
+	key, err := keystore.GenerateKey()
+	require.NoError(t, err)
+	ks, err := keystore.New(map[uint32][32]byte{1: key})
+	require.NoError(t, err)
+
+	mux := http.NewServeMux()
+	interceptor, sc := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st})
+	t.Cleanup(sc.Stop)
+	authSvc := service.NewAuthService(service.AuthServiceDeps{
+		Store:     st,
+		Config:    testConfig(),
+		Settings:  set,
+		Lifecycle: auth.NewCredentialLifecycleEffects(sc, nil, nil),
+		Mail:      mail.NewStubSender(),
+		Renderer:  mail.Renderer{},
+		Keystore:  ks,
+	})
+	path, handler := leapmuxv1connect.NewAuthServiceHandler(authSvc, connect.WithInterceptors(interceptor))
+	mux.Handle(path, handler)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	client := leapmuxv1connect.NewAuthServiceClient(server.Client(), server.URL)
+
+	req := connect.NewRequest(&leapmuxv1.BeginPasskeySignUpRequest{
+		Username:    "nopkemail",
+		DisplayName: "No Email",
+		Email:       "",
+	})
+	req.Header().Set("Origin", "https://localhost")
+	_, err = client.BeginPasskeySignUp(context.Background(), req)
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	assert.Contains(t, err.Error(), "email is required")
+}
+
+func TestBeginPasskeyLogin_UnknownAndNoPasskeysShareError(t *testing.T) {
+	t.Parallel()
+
+	env := setupPasskeyAuthTestServer(t, enableSignup, nil)
+
+	unknownReq := connect.NewRequest(&leapmuxv1.BeginPasskeyLoginRequest{Username: "nobody"})
+	unknownReq.Header().Set("Origin", passkeyTestOrigin)
+	_, errUnknown := env.client.BeginPasskeyLogin(context.Background(), unknownReq)
+	require.Error(t, errUnknown)
+	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(errUnknown))
+
+	_, err := env.client.SignUp(context.Background(), connect.NewRequest(&leapmuxv1.SignUpRequest{
+		Username:    "nopasskeys",
+		Password:    "password123",
+		DisplayName: "No Keys",
+		Email:       "nopasskeys@example.com",
+	}))
+	require.NoError(t, err)
+
+	noneReq := connect.NewRequest(&leapmuxv1.BeginPasskeyLoginRequest{Username: "nopasskeys"})
+	noneReq.Header().Set("Origin", passkeyTestOrigin)
+	_, errNone := env.client.BeginPasskeyLogin(context.Background(), noneReq)
+	require.Error(t, errNone)
+	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(errNone))
+	assert.Equal(t, errUnknown.Error(), errNone.Error())
+}
+
+func TestFinishPasskeyLogin_FailedAssertionBurnsCeremony(t *testing.T) {
+	t.Parallel()
+
+	env := setupPasskeyAuthTestServer(t, enableSignup, nil)
+
+	begin := beginPasskeySignUp(t, env.client, "pkburn", "pkburn@example.com")
+	ceremony := newPasskeyCeremony()
+	credentialJSON, err := ceremony.registrationResponse(begin.GetOptionsJson())
+	require.NoError(t, err)
+	finishReq := connect.NewRequest(&leapmuxv1.FinishPasskeySignUpRequest{
+		SessionId:      begin.GetSessionId(),
+		CredentialJson: credentialJSON,
+	})
+	finishReq.Header().Set("Origin", passkeyTestOrigin)
+	_, err = env.client.FinishPasskeySignUp(context.Background(), finishReq)
+	require.NoError(t, err)
+
+	loginBegin := beginPasskeyLogin(t, env.client, "pkburn")
+	_, err = finishPasskeyLogin(t, env.client, loginBegin.GetSessionId(), "not-a-credential")
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+
+	assertionJSON, err := ceremony.assertionResponse(loginBegin.GetOptionsJson())
+	require.NoError(t, err)
+	_, err = finishPasskeyLogin(t, env.client, loginBegin.GetSessionId(), assertionJSON)
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err), "failed Finish must consume the ceremony")
 }

--- a/backend/internal/hub/service/create_user.go
+++ b/backend/internal/hub/service/create_user.go
@@ -5,6 +5,7 @@ import (
 	"crypto/subtle"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"connectrpc.com/connect"
@@ -25,8 +26,16 @@ const pendingEmailExpiry = 30 * time.Minute
 
 // maxVerificationAttempts is the per-code attempt budget. The 6th wrong
 // guess force-expires the code. With a 31-character alphabet this caps
-// the success probability of a remote brute-force at 5/31^6 ≈ 5e-9.
+// the success probability of a remote brute-force at 5/31^6 ≈ 5e-9. The
+// SQL force-expire binds this same constant (sqlc.arg(max_attempts)), so
+// the Go gate and the store can never disagree at the boundary attempt.
 const maxVerificationAttempts = 5
+
+// maxPasswordResetAttempts is the per-token attempt budget for the
+// self-service password reset. The token is a 285-bit secret, so the
+// budget is defense-in-depth against a throttled oracle, not a
+// brute-force bound; the SQL force-expire binds the same constant.
+const maxPasswordResetAttempts = 5
 
 // CreateUserParams holds the parameters for creating a new user.
 type CreateUserParams struct {
@@ -39,60 +48,121 @@ type CreateUserParams struct {
 	IsAdmin       bool
 }
 
-// CreateUser creates a user and seeds their default sidebar sections. It
-// returns the created user row.
-//
-// Both writes share ONE transaction, so a user can never exist without the
-// sections. That is what lets ListSections stay a pure read: seeding them
-// there instead was a read-modify-write that nothing serialized, so two
-// concurrent reads for one user each saw an empty list and each wrote a full
-// set, and the sidebar rendered two of every section.
-func CreateUser(ctx context.Context, st store.Store, p CreateUserParams) (*store.User, error) {
-	userID := id.Generate()
+// createUserTxParams describes one account creation. Extra runs inside the
+// same transaction after the user row exists, so a flavor-specific artifact
+// (a passkey credential, an OAuth link) commits with the account.
+type createUserTxParams struct {
+	userID        string // empty: generated here
+	username      string
+	displayName   string
+	email         string // direct email column value
+	emailVerified bool
+	pendingEmail  string // non-empty: stored as the pending verification row
+	passwordHash  string
+	passwordSet   bool
+	isAdmin       bool
+	extra         func(tx store.Store) error
+}
 
-	// The sections are keyed by a typed UserID. Refuse an empty id instead of
-	// panicking through MustNew: nothing is written yet, so failing here costs
-	// only the request, and a panic in a signup handler costs the process.
-	sectionOwner, ok := userid.New(userID)
-	if !ok {
-		return nil, fmt.Errorf("create user: generated an empty user id")
-	}
-
-	if err := st.RunInTransaction(ctx, func(tx store.Store) error {
+// createUserInTx creates the account, seeds the default sidebar sections,
+// runs the flavor hook, and stores the pending verification row, all in one
+// transaction. It returns the created user row and, when a pending email
+// was stored, the verification code. This one routine serves the admin
+// CreateUser verb and the password, OAuth, and passkey sign-up flavors, so
+// the create-user write shape and the user-always-has-sections invariant
+// cannot drift between them.
+func createUserInTx(ctx context.Context, st store.Store, opt createUserTxParams) (*store.User, string, error) {
+	var user *store.User
+	var code string
+	err := st.RunInTransaction(ctx, func(tx store.Store) error {
+		userID := opt.userID
+		if userID == "" {
+			userID = id.Generate()
+		}
+		sectionOwner, ok := userid.New(userID)
+		if !ok {
+			return fmt.Errorf("generated empty user id")
+		}
 		if err := tx.Users().Create(ctx, store.CreateUserParams{
 			ID:            userID,
-			Username:      p.Username,
-			PasswordHash:  p.PasswordHash,
-			DisplayName:   p.DisplayName,
-			Email:         p.Email,
-			EmailVerified: p.EmailVerified,
-			PasswordSet:   p.PasswordSet,
-			IsAdmin:       p.IsAdmin,
+			Username:      opt.username,
+			PasswordHash:  opt.passwordHash,
+			DisplayName:   opt.displayName,
+			Email:         opt.email,
+			EmailVerified: opt.emailVerified,
+			PasswordSet:   opt.passwordSet,
+			IsAdmin:       opt.isAdmin,
 		}); err != nil {
 			return fmt.Errorf("create user: %w", err)
 		}
 		if err := sections.InitDefaults(ctx, tx, sectionOwner); err != nil {
 			return fmt.Errorf("init sections: %w", err)
 		}
+		if opt.extra != nil {
+			if err := opt.extra(tx); err != nil {
+				return err
+			}
+		}
+		if opt.pendingEmail != "" {
+			code = verifycode.Generate()
+			expiresAt := time.Now().Add(pendingEmailExpiry).UTC()
+			if err := tx.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
+				ID:                    userID,
+				PendingEmail:          opt.pendingEmail,
+				PendingEmailToken:     code,
+				PendingEmailExpiresAt: &expiresAt,
+			}); err != nil {
+				return fmt.Errorf("set pending email: %w", err)
+			}
+		}
+		u, err := tx.Users().GetByID(ctx, userID)
+		if err != nil {
+			return err
+		}
+		user = u
 		return nil
-	}); err != nil {
+	})
+	if err != nil {
+		return nil, "", err
+	}
+	return user, code, nil
+}
+
+// CreateUser creates a user and seeds their default sidebar sections. It
+// returns the created user row.
+//
+// The write itself lives in createUserInTx, the one transaction shared by
+// every account-creation flavor: a user can never exist without the
+// sections. That is what lets ListSections stay a pure read: seeding them
+// there instead was a read-modify-write that nothing serialized, so two
+// concurrent reads for one user each saw an empty list and each wrote a full
+// set, and the sidebar rendered two of every section.
+func CreateUser(ctx context.Context, st store.Store, p CreateUserParams) (*store.User, error) {
+	// Admins are always email_verified=true in the database, whatever the
+	// caller passed: the stored flag is what keeps the auth interceptor's
+	// runtime IsAdmin exemption honest, and UpdateUser's lowering verb
+	// refuses for admin accounts on the same invariant.
+	if p.IsAdmin {
+		p.EmailVerified = true
+	}
+
+	user, _, err := createUserInTx(ctx, st, createUserTxParams{
+		username:      p.Username,
+		displayName:   p.DisplayName,
+		email:         p.Email,
+		emailVerified: p.EmailVerified,
+		passwordHash:  p.PasswordHash,
+		passwordSet:   p.PasswordSet,
+		isAdmin:       p.IsAdmin,
+	})
+	if err != nil {
 		return nil, err
 	}
 
-	createdUser := &store.User{
-		ID:            userID,
-		Username:      p.Username,
-		DisplayName:   p.DisplayName,
-		Email:         p.Email,
-		EmailVerified: p.EmailVerified,
-		PasswordSet:   p.PasswordSet,
-		IsAdmin:       p.IsAdmin,
-	}
-
 	// If this user claimed a verified email, clear competing pending_email entries.
-	ClearCompetingPendingEmails(ctx, st, p.Email, createdUser.ID)
+	ClearCompetingPendingEmails(ctx, st, p.Email, user.ID)
 
-	return createdUser, nil
+	return user, nil
 }
 
 // SetEmailAndClearCompeting updates a user's email and clears competing
@@ -212,7 +282,7 @@ func verifyPendingEmailToken(ctx context.Context, st store.Store, userID, submit
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid verification code"))
 	}
 
-	user, err := st.Users().ConsumeVerificationAttempt(ctx, userID)
+	user, err := st.Users().ConsumeVerificationAttempt(ctx, userID, time.Now().UTC(), maxVerificationAttempts)
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("no pending email change"))
@@ -285,9 +355,11 @@ func ClearCompetingPendingEmails(ctx context.Context, st store.Store, email, own
 // verification.
 //
 // Returns (sent, err): err signals a check or storage failure; sent=false
-// means the row was written but the mail send failed. The row stays in
-// place so signup / OAuth-signup / Resend callers can let the user try
-// again via Resend. Email-change callers should use
+// means the mail send failed. On a failed send the freshly stamped row is
+// cleared and the failure is logged server-side: a row whose code was
+// never delivered would block the immediate retry behind the resend
+// cooldown and leave the operator without a signal. Email-change callers
+// that surface the failure inline can use
 // issuePendingEmailVerificationOrRollback instead.
 func issuePendingEmailVerification(ctx context.Context, st store.Store, sender mail.Sender, renderer mail.Renderer, userID, email string) (bool, error) {
 	if err := CheckEmailAvailable(ctx, st, email, userID); err != nil {
@@ -304,24 +376,27 @@ func issuePendingEmailVerification(ctx context.Context, st store.Store, sender m
 		return false, fmt.Errorf("set pending email: %w", err)
 	}
 
-	if err := sender.Send(ctx, renderer.VerificationEmail(email, storedCode)); err != nil {
+	if err := sender.Send(ctx, renderer.VerificationEmail(email, storedCode, pendingEmailExpiry)); err != nil {
+		if clearErr := st.Users().ClearPendingEmail(ctx, userID); clearErr != nil {
+			slog.WarnContext(ctx, "clear pending email after failed verification send",
+				"user_id", userID, "err", clearErr)
+		}
+		slog.WarnContext(ctx, "verification email send failed; cleared pending row for retry",
+			"user_id", userID, "email", email, "err", err)
 		return false, nil
 	}
 	return true, nil
 }
 
 // issuePendingEmailVerificationOrRollback is like
-// issuePendingEmailVerification but, on send failure, clears the
-// pending_email row before returning the error so the user can retry
-// from a clean slate. Used by the email-change flow where the failure
-// is surfaced to the user inline.
+// issuePendingEmailVerification but returns an error on a failed send so
+// the email-change flow can surface the failure to the user inline.
 func issuePendingEmailVerificationOrRollback(ctx context.Context, st store.Store, sender mail.Sender, renderer mail.Renderer, userID, email string) error {
 	sent, err := issuePendingEmailVerification(ctx, st, sender, renderer, userID, email)
 	if err != nil {
 		return err
 	}
 	if !sent {
-		_ = st.Users().ClearPendingEmail(ctx, userID)
 		return fmt.Errorf("send verification email failed")
 	}
 	return nil

--- a/backend/internal/hub/service/create_user.go
+++ b/backend/internal/hub/service/create_user.go
@@ -71,7 +71,32 @@ type createUserTxParams struct {
 // CreateUser verb and the password, OAuth, and passkey sign-up flavors, so
 // the create-user write shape and the user-always-has-sections invariant
 // cannot drift between them.
+//
+// Every account-creation invariant belongs HERE, not in one caller. A rule
+// that a caller applies is a rule the next flavor omits: the admin
+// email_verified force and the competing-pending-email clear both lived in
+// CreateUser, and the OAuth and passkey sign-ups that call this routine
+// directly went past both.
 func createUserInTx(ctx context.Context, st store.Store, opt createUserTxParams) (*store.User, string, error) {
+	// Admins are always email_verified=true in the database, whatever the
+	// caller passed: the stored flag is what keeps the auth interceptor's
+	// runtime IsAdmin exemption honest, and UpdateUser's lowering verb
+	// refuses for admin accounts on the same invariant.
+	//
+	// An admin also never waits behind a pending verification row. The
+	// address moves to the email column instead, which is what /setup
+	// already does through signUpSetupMode. Committing an admin with
+	// email='' and email_verified=1 would leave the hub's only
+	// administrator with no address to reset a password to, and
+	// loginVerificationOutcome short-circuits on IsAdmin, so nothing would
+	// ever prompt them to supply one.
+	if opt.isAdmin {
+		opt.emailVerified = true
+		if opt.email == "" && opt.pendingEmail != "" {
+			opt.email, opt.pendingEmail = opt.pendingEmail, ""
+		}
+	}
+
 	var user *store.User
 	var code string
 	err := st.RunInTransaction(ctx, func(tx store.Store) error {
@@ -106,15 +131,23 @@ func createUserInTx(ctx context.Context, st store.Store, opt createUserTxParams)
 		if opt.pendingEmail != "" {
 			code = verifycode.Generate()
 			expiresAt := time.Now().Add(pendingEmailExpiry).UTC()
-			if err := tx.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
+			// A brand-new account holds no previous code, so the
+			// conditional mint always lands; UnconditionalMintCutoff says that
+			// explicitly rather than leaving a zero cutoff to mean it.
+			if _, err := tx.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
 				ID:                    userID,
 				PendingEmail:          opt.pendingEmail,
 				PendingEmailToken:     code,
 				PendingEmailExpiresAt: &expiresAt,
+				CooldownCutoff:        store.UnconditionalMintCutoff(),
 			}); err != nil {
 				return fmt.Errorf("set pending email: %w", err)
 			}
 		}
+		// The account claimed this address, so no other user may keep it as
+		// a pending verification target. Inside the transaction, so the
+		// claim and the clear commit together.
+		ClearCompetingPendingEmails(ctx, tx, opt.email, userID)
 		u, err := tx.Users().GetByID(ctx, userID)
 		if err != nil {
 			return err
@@ -138,14 +171,8 @@ func createUserInTx(ctx context.Context, st store.Store, opt createUserTxParams)
 // concurrent reads for one user each saw an empty list and each wrote a full
 // set, and the sidebar rendered two of every section.
 func CreateUser(ctx context.Context, st store.Store, p CreateUserParams) (*store.User, error) {
-	// Admins are always email_verified=true in the database, whatever the
-	// caller passed: the stored flag is what keeps the auth interceptor's
-	// runtime IsAdmin exemption honest, and UpdateUser's lowering verb
-	// refuses for admin accounts on the same invariant.
-	if p.IsAdmin {
-		p.EmailVerified = true
-	}
-
+	// The admin email_verified force and the competing-pending-email clear
+	// both live in createUserInTx, so every sign-up flavor gets them.
 	user, _, err := createUserInTx(ctx, st, createUserTxParams{
 		username:      p.Username,
 		displayName:   p.DisplayName,
@@ -158,10 +185,6 @@ func CreateUser(ctx context.Context, st store.Store, p CreateUserParams) (*store
 	if err != nil {
 		return nil, err
 	}
-
-	// If this user claimed a verified email, clear competing pending_email entries.
-	ClearCompetingPendingEmails(ctx, st, p.Email, user.ID)
-
 	return user, nil
 }
 
@@ -254,6 +277,11 @@ func AvailabilityConnectError(err error) error {
 	var taken *FieldTakenError
 	if errors.As(err, &taken) {
 		return connect.NewError(connect.CodeAlreadyExists, taken)
+	}
+	// A refused conditional mint is the resend cooldown, not a fault: the
+	// caller asked again too soon and the live code is still valid.
+	if errors.Is(err, ErrVerificationCooldown) {
+		return connect.NewError(connect.CodeResourceExhausted, err)
 	}
 	return connect.NewError(connect.CodeInternal, err)
 }
@@ -355,43 +383,89 @@ func ClearCompetingPendingEmails(ctx context.Context, st store.Store, email, own
 // verification.
 //
 // Returns (sent, err): err signals a check or storage failure; sent=false
-// means the mail send failed. On a failed send the freshly stamped row is
-// cleared and the failure is logged server-side: a row whose code was
+// means the mail send failed. On a failed send the undelivered CODE is
+// dropped and the failure is logged server-side: a row whose code was
 // never delivered would block the immediate retry behind the resend
-// cooldown and leave the operator without a signal. Email-change callers
-// that surface the failure inline can use
-// issuePendingEmailVerificationOrRollback instead.
+// cooldown and leave the operator without a signal. The pending ADDRESS
+// survives, because it is the only record of what the account is trying to
+// verify -- a sign-up that requires verification leaves users.email empty,
+// so wiping the whole row leaves ResendVerificationEmail with nothing to
+// re-send to and the account permanently unverifiable. Email-change
+// callers that surface the failure to the user inline can use
+// issuePendingEmailVerificationOrFail instead.
 func issuePendingEmailVerification(ctx context.Context, st store.Store, sender mail.Sender, renderer mail.Renderer, userID, email string) (bool, error) {
 	if err := CheckEmailAvailable(ctx, st, email, userID); err != nil {
 		return false, err
 	}
 	storedCode := verifycode.Generate()
 	expiresAt := time.Now().Add(pendingEmailExpiry).UTC()
-	if err := st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
+	minted, err := st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
 		ID:                    userID,
 		PendingEmail:          email,
 		PendingEmailToken:     storedCode,
 		PendingEmailExpiresAt: &expiresAt,
-	}); err != nil {
+		CooldownCutoff:        verificationMintCutoff(),
+	})
+	if err != nil {
 		return false, fmt.Errorf("set pending email: %w", err)
+	}
+	if !minted {
+		return false, ErrVerificationCooldown
 	}
 
 	if err := sender.Send(ctx, renderer.VerificationEmail(email, storedCode, pendingEmailExpiry)); err != nil {
-		if clearErr := st.Users().ClearPendingEmail(ctx, userID); clearErr != nil {
-			slog.WarnContext(ctx, "clear pending email after failed verification send",
+		if clearErr := clearUndeliveredVerificationCode(ctx, st, userID); clearErr != nil {
+			slog.WarnContext(ctx, "clear undelivered verification code after failed send",
 				"user_id", userID, "err", clearErr)
 		}
-		slog.WarnContext(ctx, "verification email send failed; cleared pending row for retry",
+		slog.WarnContext(ctx, "verification email send failed; dropped the code and kept the pending address for retry",
 			"user_id", userID, "email", email, "err", err)
 		return false, nil
 	}
 	return true, nil
 }
 
-// issuePendingEmailVerificationOrRollback is like
+// ErrVerificationCooldown reports a conditional mint that the resend
+// cooldown refused. It is a sentinel, not a message match: the RPC layer
+// maps it to ResourceExhausted, and infrastructure failures stay Internal.
+var ErrVerificationCooldown = errors.New("a verification code was sent recently; wait before requesting another")
+
+// verificationMintCutoff is the instant a previous code must have expired
+// at or before for a fresh mint to land.
+//
+// The derivation: issued_at is the previous expiry minus the constant code
+// TTL, so "issued at least the cooldown ago" is "previous expiry at or
+// before now + (TTL - cooldown)". Both instants are on the app clock, the
+// clock that wrote the expiry. Its twin is the password-reset cutoff in
+// RequestPasswordReset.
+func verificationMintCutoff() time.Time {
+	return time.Now().UTC().Add(pendingEmailExpiry - resendVerificationCooldown)
+}
+
+// clearUndeliveredVerificationCode drops a code that the relay refused, and
+// KEEPS the address it was for.
+//
+// An empty token is the "no live code, address still pending" state: the
+// verify path refuses it (ConsumeVerificationAttempt filters
+// pending_email_token != ”), and the resend cooldown -- which reads the
+// expiry -- does not apply, so the retry the failure message invites is
+// never blocked. Clearing the address instead would strand a
+// verification-required sign-up, whose users.email column is empty, with
+// nothing to re-send to.
+//
+// The address is still subject to retention: ClearStalePendingEmails has a
+// second arm that reaps a codeless row on updated_at, because the expiry
+// compare cannot see one.
+func clearUndeliveredVerificationCode(ctx context.Context, st store.Store, userID string) error {
+	return st.Users().ClearPendingEmailCode(ctx, userID)
+}
+
+// issuePendingEmailVerificationOrFail is like
 // issuePendingEmailVerification but returns an error on a failed send so
-// the email-change flow can surface the failure to the user inline.
-func issuePendingEmailVerificationOrRollback(ctx context.Context, st store.Store, sender mail.Sender, renderer mail.Renderer, userID, email string) error {
+// the email-change flow can surface the failure to the user inline. The
+// pending address survives either way, so Resend retries the change that
+// the relay refused instead of losing the requested target.
+func issuePendingEmailVerificationOrFail(ctx context.Context, st store.Store, sender mail.Sender, renderer mail.Renderer, userID, email string) error {
 	sent, err := issuePendingEmailVerification(ctx, st, sender, renderer, userID, email)
 	if err != nil {
 		return err

--- a/backend/internal/hub/service/create_user_test.go
+++ b/backend/internal/hub/service/create_user_test.go
@@ -227,7 +227,7 @@ func TestSetPendingEmailWithToken_RejectsAlreadyVerifiedEmail(t *testing.T) {
 	userB := createSimpleUser(t, st, "user-b", "")
 
 	// User B tries to set pending_email to the already-verified address.
-	err := issuePendingEmailVerificationOrRollback(ctx, st, sender, mail.Renderer{BaseURL: func() string { return "https://hub.example.test" }}, userB.ID, "taken@example.com")
+	err := issuePendingEmailVerificationOrFail(ctx, st, sender, mail.Renderer{BaseURL: func() string { return "https://hub.example.test" }}, userB.ID, "taken@example.com")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already in use")
 
@@ -246,7 +246,7 @@ func TestSetPendingEmailWithToken_StoresPendingForUnclaimedEmail(t *testing.T) {
 
 	user := createSimpleUser(t, st, "user-a", "")
 
-	err := issuePendingEmailVerificationOrRollback(ctx, st, sender, mail.Renderer{BaseURL: func() string { return "https://hub.example.test" }}, user.ID, "free@example.com")
+	err := issuePendingEmailVerificationOrFail(ctx, st, sender, mail.Renderer{BaseURL: func() string { return "https://hub.example.test" }}, user.ID, "free@example.com")
 	require.NoError(t, err)
 
 	// The row stays pending until the user submits a code via UserService.VerifyEmail.
@@ -267,11 +267,12 @@ func TestCreateUser_ClearsCompetingPendingEmails(t *testing.T) {
 	// User A sets pending_email.
 	userA := createSimpleUser(t, st, "user-a", "")
 	expiresAt := mustTime(t)
-	err := st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
+	_, err := st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
 		ID:                    userA.ID,
 		PendingEmail:          "race@example.com",
 		PendingEmailToken:     verifycode.Generate(),
 		PendingEmailExpiresAt: &expiresAt,
+		CooldownCutoff:        store.UnconditionalMintCutoff(),
 	})
 	require.NoError(t, err)
 
@@ -301,11 +302,12 @@ func TestSetEmailAndClearCompeting(t *testing.T) {
 	// User A has pending_email.
 	userA := createSimpleUser(t, st, "user-a", "")
 	expiresAt := mustTime(t)
-	err := st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
+	_, err := st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
 		ID:                    userA.ID,
 		PendingEmail:          "target@example.com",
 		PendingEmailToken:     verifycode.Generate(),
 		PendingEmailExpiresAt: &expiresAt,
+		CooldownCutoff:        store.UnconditionalMintCutoff(),
 	})
 	require.NoError(t, err)
 
@@ -346,4 +348,93 @@ func TestSetEmailAndClearCompeting_Unverified(t *testing.T) {
 func mustTime(t *testing.T) time.Time {
 	t.Helper()
 	return time.Now().Add(24 * time.Hour).UTC()
+}
+
+// Every account-creation invariant lives in createUserInTx, so every
+// sign-up flavor gets it. These pin the two that used to sit in CreateUser
+// alone, which the OAuth and passkey flavors called past.
+func TestCreateUserInTx_EnforcesTheAdminInvariants(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// An admin is always email_verified in the database, whatever the
+	// caller passed: the stored flag is what keeps the auth interceptor's
+	// runtime IsAdmin exemption honest.
+	t.Run("an admin is always email_verified", func(t *testing.T) {
+		t.Parallel()
+		st := setupCreateUserTestDB(t)
+		user, code, err := createUserInTx(ctx, st, createUserTxParams{
+			username: "forced-admin", displayName: "Forced", isAdmin: true,
+			emailVerified: false, passwordHash: "hash", passwordSet: true,
+		})
+		require.NoError(t, err)
+		assert.True(t, user.EmailVerified, "the caller's false must not survive")
+		assert.Empty(t, code, "no pending row, so no code")
+	})
+
+	// An admin never waits behind a pending verification row: the address
+	// moves to the email column instead. Committing an admin with email=''
+	// and email_verified=1 leaves the hub's only administrator with no
+	// address to reset a password to, and nothing prompts them for one.
+	t.Run("an admin's pending address is promoted into the email column", func(t *testing.T) {
+		t.Parallel()
+		st := setupCreateUserTestDB(t)
+		user, code, err := createUserInTx(ctx, st, createUserTxParams{
+			username: "promoted-admin", displayName: "Promoted", isAdmin: true,
+			email: "", pendingEmail: "admin@example.com",
+			passwordHash: "hash", passwordSet: true,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "admin@example.com", user.Email)
+		assert.True(t, user.EmailVerified)
+		assert.Empty(t, user.PendingEmail, "there is nothing left to verify")
+		// The returned code is what the caller keys its send on. An empty
+		// one means "no pending row was written", and the passkey first-user
+		// branch mailed a BLANK code -- and rolled the hub's only admin back
+		// when that pointless send failed -- until it read this instead of
+		// its own pre-call intent.
+		assert.Empty(t, code, "no pending row was written, so there is nothing to mail")
+	})
+
+	// A non-admin keeps the pending row, and the code comes back for the
+	// caller to deliver.
+	t.Run("a non-admin keeps its pending row and returns the code", func(t *testing.T) {
+		t.Parallel()
+		st := setupCreateUserTestDB(t)
+		user, code, err := createUserInTx(ctx, st, createUserTxParams{
+			username: "pending-user", displayName: "Pending",
+			pendingEmail: "user@example.com", passwordHash: "hash", passwordSet: true,
+		})
+		require.NoError(t, err)
+		assert.Empty(t, user.Email)
+		assert.False(t, user.EmailVerified)
+		assert.Equal(t, "user@example.com", user.PendingEmail)
+		assert.Len(t, code, verifycode.Length, "the caller mails this code")
+	})
+
+	// The claim clears every other account's pending target for the same
+	// address, inside the same transaction. Without it the loser is pinned
+	// on /verify-email with a dead row for an address it can never take.
+	t.Run("claiming an address clears a competing pending row", func(t *testing.T) {
+		t.Parallel()
+		st := setupCreateUserTestDB(t)
+		loser, _, err := createUserInTx(ctx, st, createUserTxParams{
+			username: "loser", displayName: "Loser",
+			pendingEmail: "contested@example.com", passwordHash: "hash", passwordSet: true,
+		})
+		require.NoError(t, err)
+		require.Equal(t, "contested@example.com", loser.PendingEmail)
+
+		_, _, err = createUserInTx(ctx, st, createUserTxParams{
+			username: "winner", displayName: "Winner",
+			email: "contested@example.com", emailVerified: true,
+			passwordHash: "hash", passwordSet: true,
+		})
+		require.NoError(t, err)
+
+		after, err := st.Users().GetByID(ctx, loser.ID)
+		require.NoError(t, err)
+		assert.Empty(t, after.PendingEmail,
+			"a claimed address must not stay pending for anyone else")
+	})
 }

--- a/backend/internal/hub/service/oauth_handler.go
+++ b/backend/internal/hub/service/oauth_handler.go
@@ -317,13 +317,35 @@ func (h *OAuthHandler) loginOAuthUser(w http.ResponseWriter, r *http.Request, us
 
 // sanitizeRedirectURI ensures the redirect URI is a safe relative path.
 // Returns empty string for anything that could be an open redirect.
+//
+// This is the sink guard: the value it returns reaches a Location header
+// through http.Redirect, so it must refuse every spelling a BROWSER reads
+// as an authority, not just the ones Go's URL parser does. Two spellings
+// beyond the obvious "//host" get through an RFC 3986 parser:
+//
+//   - "/\host". A WHATWG parser treats a backslash as a slash for a
+//     special scheme, so it reads "host" as the authority. Go's net/url
+//     does not, so parsing the value and comparing origins ACCEPTS this
+//     one -- which is why the guard is an allowlist on the raw bytes.
+//   - "/<TAB>/host". url.Parse rejects the control byte, so http.Redirect
+//     skips its cleaning branch and writes the value verbatim; the
+//     browser then strips the tab and reads "//host". CR and LF do not
+//     work (net/http rewrites them to a space), but refusing every
+//     control byte costs nothing and removes the dependency on that
+//     detail.
+//
+// frontend/src/lib/safeRedirect.ts applies the same three rules.
 func sanitizeRedirectURI(uri string) string {
-	if uri == "" {
+	if uri == "" || uri[0] != '/' {
 		return ""
 	}
-	// Must start with "/" and must not start with "//" (protocol-relative URL).
-	if uri[0] != '/' || (len(uri) > 1 && uri[1] == '/') {
+	if len(uri) > 1 && (uri[1] == '/' || uri[1] == '\\') {
 		return ""
+	}
+	for i := 0; i < len(uri); i++ {
+		if uri[i] < 0x20 || uri[i] == 0x7f {
+			return ""
+		}
 	}
 	return uri
 }

--- a/backend/internal/hub/service/oauth_handler_internal_test.go
+++ b/backend/internal/hub/service/oauth_handler_internal_test.go
@@ -39,6 +39,25 @@ func TestSanitizeRedirectURI(t *testing.T) {
 		{"javascript scheme rejected", "javascript:alert(1)", ""},
 		{"data scheme rejected", "data:text/html,<h1>hi</h1>", ""},
 		{"backslash rejected", "\\evil.com", ""},
+		// A WHATWG parser reads a backslash as a slash for a special
+		// scheme, so "/\host" leaves the origin although Go's own URL
+		// parser calls it a path. This is why the guard reads raw bytes
+		// instead of parsing and comparing origins.
+		{"backslash twin rejected", "/\\evil.com", ""},
+		{"backslash twin with path rejected", "/\\evil.com/callback", ""},
+		// url.Parse refuses a control byte, so http.Redirect skips its
+		// cleaning branch and writes the value verbatim; the browser then
+		// strips the tab and reads "//evil.com".
+		{"tab-injected authority rejected", "/\t/evil.com", ""},
+		{"tab before a backslash twin rejected", "/\t\\evil.com", ""},
+		{"carriage return rejected", "/\r/evil.com", ""},
+		{"line feed rejected", "/\n/evil.com", ""},
+		{"delete byte rejected", "/\x7f/evil.com", ""},
+		{"null byte rejected", "/\x00/evil.com", ""},
+		// Percent-encodings are NOT decoded before the browser picks the
+		// authority, so these stay ordinary same-origin paths.
+		{"percent-encoded tab kept", "/%09/evil.com", "/%09/evil.com"},
+		{"percent-encoded backslash kept", "/%5Cevil.com", "/%5Cevil.com"},
 	}
 
 	for _, tt := range tests {

--- a/backend/internal/hub/service/oauth_handler_internal_test.go
+++ b/backend/internal/hub/service/oauth_handler_internal_test.go
@@ -91,7 +91,7 @@ func TestLoginOAuthUser_UsesConfiguredSessionDuration(t *testing.T) {
 	require.NoError(t, err, "the callback must set a session cookie")
 	hubtestutil.AssertSessionLifetime(t, before, configured, parsed.Expires)
 
-	sess, err := st.Sessions().GetByID(context.Background(), parsed.Value)
+	sess, err := st.Sessions().GetByID(context.Background(), parsed.Value, time.Now().UTC())
 	require.NoError(t, err)
 	assert.WithinDuration(t, sess.ExpiresAt, parsed.Expires, time.Second,
 		"the cookie and the row must carry the same deadline")

--- a/backend/internal/hub/service/oauth_handler_test.go
+++ b/backend/internal/hub/service/oauth_handler_test.go
@@ -517,6 +517,57 @@ func TestCompleteOAuthSignup_UsesProviderEmail_IgnoresRequestEmail(t *testing.T)
 	assert.Equal(t, "provider@example.com", user.Email, "email must come from provider, not request")
 }
 
+// An UNTRUSTED provider that omits the email claim leaves the caller to
+// supply the address. Without the fallback the sign-up was a dead end
+// whenever verification was on: validateSignupEmail refuses an empty
+// address, no step in the flow could produce one, and the pending token
+// expired with the account never created.
+func TestCompleteOAuthSignup_UntrustedProviderWithNoEmail_UsesRequestEmail(t *testing.T) {
+	t.Parallel()
+
+	_, client, st, ks, _ := setupOAuthTestServerWithAuthService(t)
+	providerID := createTestProviderWithTrustEmail(t, st, ks, false)
+	signupToken := id.Generate()
+	insertPendingSignup(t, st, ks, providerID, signupToken, "", "No Email", "sub-noemail", time.Now().Add(5*time.Minute).UTC())
+
+	resp, err := client.CompleteOAuthSignup(context.Background(), connect.NewRequest(&leapmuxv1.CompleteOAuthSignupRequest{
+		SignupToken: signupToken,
+		Username:    "noemailuser",
+		Email:       "typed@example.com",
+	}))
+	require.NoError(t, err)
+
+	user, err := st.Users().GetByID(context.Background(), resp.Msg.GetUser().GetId())
+	require.NoError(t, err)
+	assert.Equal(t, "typed@example.com", user.Email,
+		"the caller supplies the address the provider withheld")
+	assert.False(t, user.EmailVerified, "an untrusted provider's address is never trusted-verified")
+}
+
+// The fallback must not become a substitution channel: a provider that DID
+// supply an address still wins, whatever the request says. This is the
+// untrusted twin of TestCompleteOAuthSignup_UsesProviderEmail_IgnoresRequestEmail.
+func TestCompleteOAuthSignup_UntrustedProviderEmailBeatsRequestEmail(t *testing.T) {
+	t.Parallel()
+
+	_, client, st, ks, _ := setupOAuthTestServerWithAuthService(t)
+	providerID := createTestProviderWithTrustEmail(t, st, ks, false)
+	signupToken := id.Generate()
+	insertPendingSignup(t, st, ks, providerID, signupToken, "provider@example.com", "Provider", "sub-untrusted", time.Now().Add(5*time.Minute).UTC())
+
+	resp, err := client.CompleteOAuthSignup(context.Background(), connect.NewRequest(&leapmuxv1.CompleteOAuthSignupRequest{
+		SignupToken: signupToken,
+		Username:    "untrusteduser",
+		Email:       "attacker@evil.com",
+	}))
+	require.NoError(t, err)
+
+	user, err := st.Users().GetByID(context.Background(), resp.Msg.GetUser().GetId())
+	require.NoError(t, err)
+	assert.Equal(t, "provider@example.com", user.Email,
+		"a provider-supplied address is not substitutable")
+}
+
 func TestCompleteOAuthSignup_DuplicateUsername(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/hub/service/oauth_handler_test.go
+++ b/backend/internal/hub/service/oauth_handler_test.go
@@ -2,6 +2,7 @@ package service_test
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -487,7 +488,7 @@ func TestCompleteOAuthSignup_UsesConfiguredSessionDuration(t *testing.T) {
 	require.NoError(t, err)
 
 	sessionID := sessionFromCookie(t, resp.Header().Get("Set-Cookie"))
-	sess, err := st.Sessions().GetByID(context.Background(), sessionID)
+	sess, err := st.Sessions().GetByID(context.Background(), sessionID, time.Now().UTC())
 	require.NoError(t, err)
 	hubtestutil.AssertSessionLifetime(t, before, configured, sess.ExpiresAt)
 }
@@ -574,7 +575,7 @@ func TestCompleteOAuthSignup_DuplicateEmail(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Provider has trust_email=0 and cfg.EmailVerificationRequired is false,
+	// Provider has trust_email=0 and SMTP verification is off,
 	// so email goes directly to the email column unverified. Duplicate check should fire.
 	_, err = client.CompleteOAuthSignup(context.Background(), connect.NewRequest(&leapmuxv1.CompleteOAuthSignupRequest{
 		SignupToken: signupToken,
@@ -583,6 +584,105 @@ func TestCompleteOAuthSignup_DuplicateEmail(t *testing.T) {
 	}))
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeAlreadyExists, connect.CodeOf(err))
+}
+
+func TestCompleteOAuthSignup_TrustedProviderSetsEmailVerified(t *testing.T) {
+	t.Parallel()
+
+	_, client, st, ks, _ := setupOAuthTestServerWithAuthService(t)
+	providerID := createTestProvider(t, st, ks)
+	signupToken := id.Generate()
+
+	insertPendingSignup(t, st, ks, providerID, signupToken, "trusted@example.com", "Trusted", "sub-trusted", time.Now().Add(5*time.Minute).UTC())
+
+	resp, err := client.CompleteOAuthSignup(context.Background(), connect.NewRequest(&leapmuxv1.CompleteOAuthSignupRequest{
+		SignupToken: signupToken,
+		Username:    "trusteduser",
+	}))
+	require.NoError(t, err)
+
+	user, err := st.Users().GetByID(context.Background(), resp.Msg.GetUser().GetId())
+	require.NoError(t, err)
+	assert.Equal(t, "trusted@example.com", user.Email)
+	assert.True(t, user.EmailVerified)
+	assert.Empty(t, user.PendingEmail)
+}
+
+func TestCompleteOAuthSignup_UntrustedFailClosedWhenVerificationEmailFails(t *testing.T) {
+	t.Parallel()
+
+	st, err := sqlite.Open(":memory:", sqlitedb.Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+	require.NoError(t, st.Migrator().Migrate(context.Background()))
+	hubtestutil.CreateTestAdmin(t, st)
+
+	key, err := keystore.GenerateKey()
+	require.NoError(t, err)
+	ks, err := keystore.New(map[uint32][32]byte{1: key})
+	require.NoError(t, err)
+
+	cfg := &config.Config{Listen: ":4327"}
+	set := servicetest.NewSettingsManager(t, st, ks)
+	enableSignup(t, set)
+	enableEmailVerification(t, set)
+
+	mux := http.NewServeMux()
+	oauthHandler := service.NewOAuthHandler(st, cfg, set, ks)
+	oauthHandler.RegisterRoutes(mux)
+
+	interceptor, _ := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st})
+	opts := connect.WithInterceptors(interceptor)
+	authDeps := servicetest.AuthServiceDeps(st, cfg, set, auth.NewCredentialLifecycleEffects(nil, nil, nil))
+	authDeps.Keystore = ks
+	authDeps.Mail = failingMailSender{err: errors.New("smtp down")}
+	authSvc := service.NewAuthService(authDeps)
+	path, handler := leapmuxv1connect.NewAuthServiceHandler(authSvc, opts)
+	mux.Handle(path, handler)
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	client := leapmuxv1connect.NewAuthServiceClient(server.Client(), server.URL)
+
+	providerID := createTestProviderWithTrustEmail(t, st, ks, false)
+	signupToken := id.Generate()
+	insertPendingSignup(t, st, ks, providerID, signupToken, "untrusted@example.com", "Untrusted", "sub-untrusted", time.Now().Add(5*time.Minute).UTC())
+
+	_, err = client.CompleteOAuthSignup(context.Background(), connect.NewRequest(&leapmuxv1.CompleteOAuthSignupRequest{
+		SignupToken: signupToken,
+		Username:    "untrusteduser",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnavailable, connect.CodeOf(err))
+
+	_, err = st.Users().GetByUsername(context.Background(), "untrusteduser")
+	assert.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestCompleteOAuthSignup_UntrustedWithSMTPOnUsesPendingEmail(t *testing.T) {
+	t.Parallel()
+
+	_, client, st, ks, set := setupOAuthTestServerWithAuthService(t)
+	enableEmailVerification(t, set)
+	providerID := createTestProviderWithTrustEmail(t, st, ks, false)
+	signupToken := id.Generate()
+
+	insertPendingSignup(t, st, ks, providerID, signupToken, "pending@example.com", "Pending", "sub-pending", time.Now().Add(5*time.Minute).UTC())
+
+	resp, err := client.CompleteOAuthSignup(context.Background(), connect.NewRequest(&leapmuxv1.CompleteOAuthSignupRequest{
+		SignupToken: signupToken,
+		Username:    "pendingoauth",
+	}))
+	require.NoError(t, err)
+	assert.True(t, resp.Msg.GetEmailVerification().GetVerificationRequired())
+	assert.True(t, resp.Msg.GetEmailVerification().GetVerificationEmailSent())
+
+	user, err := st.Users().GetByID(context.Background(), resp.Msg.GetUser().GetId())
+	require.NoError(t, err)
+	assert.Empty(t, user.Email)
+	assert.False(t, user.EmailVerified)
+	assert.Equal(t, "pending@example.com", user.PendingEmail)
+	assert.NotEmpty(t, user.PendingEmailToken)
 }
 
 func TestCompleteOAuthSignup_InvalidToken(t *testing.T) {

--- a/backend/internal/hub/service/oauth_refresh.go
+++ b/backend/internal/hub/service/oauth_refresh.go
@@ -23,8 +23,14 @@ func (h *OAuthHandler) StartTokenRefresh(ctx context.Context) {
 	})
 }
 
+// oauthTokenRefreshLead is how far before its stored expiry a provider
+// OAuth token becomes refresh-eligible. The SQL compared the expiry
+// against the database clock plus this window; the clock and the window
+// both come from the hub now.
+const oauthTokenRefreshLead = 5 * time.Minute
+
 func (h *OAuthHandler) refreshExpiringTokens(ctx context.Context) {
-	tokens, err := h.store.OAuthTokens().ListExpiring(ctx)
+	tokens, err := h.store.OAuthTokens().ListExpiring(ctx, time.Now().UTC().Add(oauthTokenRefreshLead))
 	if err != nil {
 		slog.Error("oauth refresh: list expiring tokens", "error", err)
 		return

--- a/backend/internal/hub/service/passkey_service.go
+++ b/backend/internal/hub/service/passkey_service.go
@@ -19,9 +19,23 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/password"
 	"github.com/leapmux/leapmux/internal/hub/store"
 	hubwebauthn "github.com/leapmux/leapmux/internal/hub/webauthn"
+	"github.com/leapmux/leapmux/internal/util/id"
 	"github.com/leapmux/leapmux/internal/util/userid"
 	"github.com/leapmux/leapmux/util/validate"
 )
+
+// lastPasskeyNeedsPasswordError is the one refusal that protects a user
+// from locking themselves out of a passwordless account.
+//
+// Two sites raise it: DeletePasskey's pre-lock decision and the locked
+// re-derivation in commitPasskeyDeactivation. They must stay byte-identical
+// -- the pre-lock message is what the user sees on the common path, and the
+// locked one is what they see when the state moved under them, so a drift
+// between the two reads as two different rules.
+func lastPasskeyNeedsPasswordError() error {
+	return connect.NewError(connect.CodeFailedPrecondition,
+		fmt.Errorf("cannot delete your only passkey; provide new_password or use DeactivatePasskeyAuth"))
+}
 
 func rejectSoloPasskeyManagement(solo bool) error {
 	if !solo {
@@ -51,53 +65,72 @@ func verifyPasswordForPasskeyManagement(user *store.User, currentPassword string
 	return nil
 }
 
+// stepUpAdmission records HOW passkeyManagementAuth admitted a mutation, so
+// the locked re-check can re-derive the same decision from the locked row
+// instead of trusting the pre-lock peek.
+//
+// A bare "needsReauth" bool collapsed two different admissions into one
+// value -- "the password verified" and "there was no credential to present"
+// -- and only the second is racy.
+type stepUpAdmission struct {
+	// needsReauth is true when the caller presented a reauth proof that the
+	// mutation transaction must consume after the mutation succeeds.
+	needsReauth bool
+	// firstCredential is true when the account had NO password and NO
+	// passkey, so no step-up credential existed to present at all.
+	//
+	// This is the one admission input a concurrent write can invalidate: a
+	// registration that commits between the peek and the lock gives the
+	// account a passkey, and the caller should then have presented a reauth
+	// proof for it. recheckStepUpUnderLock re-reads the count for exactly
+	// this case, and only for it.
+	firstCredential bool
+}
+
 // passkeyManagementAuth verifies the step-up credential OUTSIDE the
 // user-auth transaction: password verification runs Argon2 (tens of
 // milliseconds) and that transaction holds the database writer lock on
-// SQLite (see auth.Login's comment on the same trade). It returns whether
-// the caller must consume a reauth proof after its mutation succeeds; the
-// proof is only consumed inside the mutation transaction, and only then.
-func (s *UserService) passkeyManagementAuth(ctx context.Context, user *store.User, currentPassword, reauthProof string) (bool, error) {
+// SQLite (see auth.Login's comment on the same trade). It returns how the
+// mutation was admitted; a reauth proof, when one was required, is consumed
+// only inside the mutation transaction.
+func (s *UserService) passkeyManagementAuth(ctx context.Context, user *store.User, currentPassword, reauthProof string) (stepUpAdmission, error) {
 	if user.PasswordSet {
-		return false, verifyPasswordForPasskeyManagement(user, currentPassword)
+		return stepUpAdmission{}, verifyPasswordForPasskeyManagement(user, currentPassword)
 	}
 	count, err := s.store.PasskeyCredentials().CountByUser(ctx, user.ID)
 	if err != nil {
-		return false, connect.NewError(connect.CodeInternal, err)
+		return stepUpAdmission{}, connect.NewError(connect.CodeInternal, err)
 	}
 	if count == 0 {
-		return false, assertFirstCredentialWithoutPasswordAllowed(ctx, s.store, user)
+		return stepUpAdmission{firstCredential: true}, assertFirstCredentialWithoutPasswordAllowed(ctx, s.store, user)
 	}
 	if reauthProof == "" {
-		return true, invalidReauthProofError()
+		return stepUpAdmission{needsReauth: true}, invalidReauthProofError()
 	}
 	// Peek with the same validity predicate the consume uses, so an
 	// admission check and the consume cannot disagree on what a valid
 	// proof is.
 	if _, err := s.store.WebAuthnSessions().GetValidProof(ctx, reauthProof, user.ID, hubwebauthn.KindReauthProof, time.Now().UTC()); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
-			return true, invalidReauthProofError()
+			return stepUpAdmission{needsReauth: true}, invalidReauthProofError()
 		}
-		return true, connect.NewError(connect.CodeInternal, err)
+		return stepUpAdmission{needsReauth: true}, connect.NewError(connect.CodeInternal, err)
 	}
-	return true, nil
+	return stepUpAdmission{needsReauth: true}, nil
 }
 
 // assertFirstCredentialWithoutPasswordAllowed refuses a session-only first
 // lasting credential (a passkey, or the first password) when the account has
 // no durable identity (verified email or OAuth link). A stolen session on an
 // unverified shell must not attach a credential it can keep.
+//
+// The caller decides WHEN the rule applies -- it holds both facts already
+// (no password, no passkey) -- and this decides WHETHER the account has a
+// durable identity. It carried its own copies of the caller's two checks
+// plus a second CountByUser for the same answer; both branches were
+// unreachable, and the query doubled a round trip on every passwordless
+// admission.
 func assertFirstCredentialWithoutPasswordAllowed(ctx context.Context, tx store.Store, user *store.User) error {
-	if user.PasswordSet {
-		return nil
-	}
-	count, err := tx.PasskeyCredentials().CountByUser(ctx, user.ID)
-	if err != nil {
-		return connect.NewError(connect.CodeInternal, err)
-	}
-	if count > 0 {
-		return nil
-	}
 	if user.EmailVerified {
 		return nil
 	}
@@ -156,7 +189,7 @@ func (s *UserService) runPasskeyManagementTx(
 	if err != nil {
 		return connect.NewError(connect.CodeInternal, fmt.Errorf("query user: %w", err))
 	}
-	needsReauth, err := s.passkeyManagementAuth(ctx, peek, currentPassword, reauthProof)
+	admission, err := s.passkeyManagementAuth(ctx, peek, currentPassword, reauthProof)
 	if err != nil {
 		return err
 	}
@@ -170,34 +203,70 @@ func (s *UserService) runPasskeyManagementTx(
 		if err != nil {
 			return fmt.Errorf("query user: %w", err)
 		}
-		if err := recheckStepUpUnderLock(user, peek, currentPassword); err != nil {
+		if err := recheckStepUpUnderLock(ctx, tx, user, peek, currentPassword, admission); err != nil {
 			return err
 		}
 		if err := mutate(tx, user); err != nil {
 			return err
 		}
-		if needsReauth {
+		if admission.needsReauth {
 			return consumePasskeyManagementReauth(ctx, tx, user, reauthProof)
 		}
 		return nil
 	})
 }
 
-// recheckStepUpUnderLock re-verifies the step-up credential when the
-// account's password state moved between the pre-transaction peek and the
-// locked re-read. The common case (nothing moved) is one string comparison,
-// so Argon2 stays out of the lock unless the hash actually changed. A
-// structural flip (password added or removed concurrently) cannot be
-// re-verified from what the caller presented, so it fails with a clean
-// retry error instead.
-func recheckStepUpUnderLock(locked, peek *store.User, currentPassword string) error {
+// recheckStepUpUnderLock re-derives the admission from the LOCKED row when
+// a concurrent write could have invalidated the pre-transaction peek.
+//
+// The common case (nothing moved) is one string comparison, so Argon2 stays
+// out of the lock unless the hash actually changed. A structural flip
+// (password added or removed concurrently) cannot be re-verified from what
+// the caller presented, so it fails with a clean retry error instead.
+//
+// The count re-read runs ONLY on the first-credential admission, which is
+// the one input a concurrent write can invalidate. It is one indexed COUNT,
+// and only for a passwordless account that had no passkey -- the password
+// and reauth-proof paths never reach it, so the writer lock is not paying
+// for a query on the common paths.
+func recheckStepUpUnderLock(
+	ctx context.Context,
+	tx store.Store,
+	locked, peek *store.User,
+	currentPassword string,
+	admission stepUpAdmission,
+) error {
 	if locked.PasswordSet != peek.PasswordSet {
-		return connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("account credentials changed; please retry"))
+		return stepUpStateMovedError()
 	}
 	if locked.PasswordSet && locked.PasswordHash != peek.PasswordHash {
 		return verifyPasswordForPasskeyManagement(locked, currentPassword)
 	}
+	if !admission.firstCredential {
+		return nil
+	}
+	// The account was admitted BECAUSE it held no credential to present.
+	// A registration that committed in the window gave it one, so the
+	// caller should have presented a reauth proof for that passkey; without
+	// this re-read, two concurrent first-credential mutations both commit
+	// and the second sets a password with no step-up at all.
+	count, err := tx.PasskeyCredentials().CountByUser(ctx, locked.ID)
+	if err != nil {
+		return connect.NewError(connect.CodeInternal, err)
+	}
+	if count > 0 {
+		return stepUpStateMovedError()
+	}
 	return nil
+}
+
+// stepUpStateMovedError reports credential state that moved between the
+// admission and the lock. The caller must retry, because the credential
+// they presented no longer matches the state the mutation would commit
+// against.
+func stepUpStateMovedError() error {
+	return connect.NewError(connect.CodeFailedPrecondition,
+		fmt.Errorf("account credentials changed; please retry"))
 }
 
 func (s *UserService) BeginPasskeyRegistration(ctx context.Context, req *connect.Request[leapmuxv1.BeginPasskeyRegistrationRequest]) (*connect.Response[leapmuxv1.BeginPasskeyRegistrationResponse], error) {
@@ -214,16 +283,16 @@ func (s *UserService) BeginPasskeyRegistration(ctx context.Context, req *connect
 	}
 	// Peek only: FinishPasskeyRegistration consumes the reauth proof.
 	if _, err := s.passkeyManagementAuth(ctx, user, req.Msg.GetCurrentPassword(), req.Msg.GetReauthProof()); err != nil {
-		return nil, mapPasskeyConnectError(err)
+		return nil, mapPasskeyConnectError(ctx, err)
 	}
 
 	wa, err := s.webauthnService(ctx)
 	if err != nil {
-		return nil, mapPasskeyConnectError(err)
+		return nil, mapPasskeyConnectError(ctx, err)
 	}
 	sessionID, optionsJSON, rpID, err := wa.BeginRegistration(ctx, user.ID, originFromRequest(req))
 	if err != nil {
-		return nil, mapPasskeyConnectError(err)
+		return nil, mapPasskeyConnectError(ctx, err)
 	}
 	return connect.NewResponse(&leapmuxv1.BeginPasskeyRegistrationResponse{
 		SessionId:   sessionID,
@@ -252,21 +321,39 @@ func (s *UserService) FinishPasskeyRegistration(ctx context.Context, req *connec
 	}
 
 	var passkey *store.PasskeyCredential
-	// Peek before the attestation so a failed attestation does not burn the
-	// proof; the proof is consumed inside the transaction after the write.
-	if err := s.runPasskeyManagementTx(ctx, userInfo, req.Msg.GetCurrentPassword(), req.Msg.GetReauthProof(), nil, func(tx store.Store, user *store.User) error {
-		wa, err := s.webauthnServiceWithStore(ctx, tx)
-		if err != nil {
+	var verified hubwebauthn.FinishedSignUpCredential
+	// The attestation is verified in prepare -- after admission, still
+	// OUTSIDE the write transaction. It is a keystore decrypt per existing
+	// credential plus a JSON/base64/CBOR parse of a body capped only at the
+	// request limit, and on SQLite the transaction holds the single writer
+	// lock, so every other write on the hub would queue behind it. Only the
+	// credential INSERT needs the lock.
+	//
+	// Admission still precedes the attestation, so a failed attestation does
+	// not burn the reauth proof; the proof is consumed inside the
+	// transaction after the write, as before.
+	if err := s.runPasskeyManagementTx(ctx, userInfo, req.Msg.GetCurrentPassword(), req.Msg.GetReauthProof(),
+		func(peek *store.User) error {
+			wa, err := s.webauthnService(ctx)
+			if err != nil {
+				return err
+			}
+			verified, err = wa.VerifyRegistration(ctx, peek.ID, req.Msg.GetSessionId(), req.Msg.GetCredentialJson())
 			return err
-		}
-		passkey, err = wa.FinishRegistration(ctx, user.ID, req.Msg.GetSessionId(), req.Msg.GetCredentialJson(), friendlyName)
-		return err
-	}); err != nil {
-		return nil, mapPasskeyConnectError(err)
+		},
+		func(tx store.Store, user *store.User) error {
+			wa, err := s.webauthnServiceWithStore(ctx, tx)
+			if err != nil {
+				return err
+			}
+			passkey, err = wa.StoreCredential(ctx, tx, id.Generate(), user.ID, verified, friendlyName)
+			return err
+		}); err != nil {
+		return nil, mapPasskeyConnectError(ctx, err)
 	}
 
 	return connect.NewResponse(&leapmuxv1.FinishPasskeyRegistrationResponse{
-		Passkey: passkeyInfoToProto(passkey),
+		Passkey: passkeyInfoToProto(ctx, passkey),
 	}), nil
 }
 
@@ -285,11 +372,11 @@ func (s *UserService) BeginPasskeyReauth(ctx context.Context, req *connect.Reque
 	}
 	wa, err := s.webauthnService(ctx)
 	if err != nil {
-		return nil, mapPasskeyConnectError(err)
+		return nil, mapPasskeyConnectError(ctx, err)
 	}
 	sessionID, optionsJSON, rpID, err := wa.BeginReauth(ctx, user.ID, originFromRequest(req))
 	if err != nil {
-		return nil, mapPasskeyConnectError(err)
+		return nil, mapPasskeyConnectError(ctx, err)
 	}
 	return connect.NewResponse(&leapmuxv1.BeginPasskeyReauthResponse{
 		SessionId:   sessionID,
@@ -319,25 +406,30 @@ func (s *UserService) FinishPasskeyReauth(ctx context.Context, req *connect.Requ
 	}
 	wa, err := s.webauthnService(ctx)
 	if err != nil {
-		return nil, mapPasskeyConnectError(err)
+		return nil, mapPasskeyConnectError(ctx, err)
 	}
 	proof, err := wa.FinishReauth(ctx, user.ID, req.Msg.GetSessionId(), req.Msg.GetCredentialJson())
 	if err != nil {
-		switch {
-		case errors.Is(err, hubwebauthn.ErrCloneDetected):
+		switch classifyWebAuthnError(err) {
+		case webAuthnErrorClone:
 			// A clone warning is a security event, not a proof failure: log
 			// it server-side and report it as itself, so it never counts
 			// against the reauth-proof rate-limit budget.
 			slog.WarnContext(ctx, "passkey clone warning during reauth", "user_id", user.ID)
 			return nil, connect.NewError(connect.CodeUnauthenticated, err)
-		case errors.Is(err, hubwebauthn.ErrCeremonyInvalid), errors.Is(err, hubwebauthn.ErrAssertionRejected):
+		case webAuthnErrorCredential:
+			// The rate-limit interceptor keys on ErrInvalidReauthProof, so a
+			// credential failure re-labels as this surface's own sentinel.
 			return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("%w: %s", auth.ErrInvalidReauthProof, err.Error()))
-		default:
+		case webAuthnErrorUnavailable:
+			return nil, connect.NewError(connect.CodeFailedPrecondition, err)
+		case webAuthnErrorInfrastructure:
 			// Store and infrastructure failures are not proof failures.
 			// Reporting them as CodeInternal keeps them out of the shared
 			// passkey-management rate-limit budget.
 			return nil, connect.NewError(connect.CodeInternal, err)
 		}
+		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	return connect.NewResponse(&leapmuxv1.FinishPasskeyReauthResponse{ReauthProof: proof}), nil
 }
@@ -359,11 +451,11 @@ func (s *UserService) ListPasskeys(ctx context.Context, _ *connect.Request[leapm
 	// here", and the settings page would render a broken section.
 	wa, err := s.webauthnService(ctx)
 	if err != nil {
-		return nil, mapPasskeyConnectError(err)
+		return nil, mapPasskeyConnectError(ctx, err)
 	}
 	passkeys := make([]*leapmuxv1.PasskeyInfo, 0, len(rows))
 	for i := range rows {
-		passkeys = append(passkeys, passkeyInfoToProto(&rows[i]))
+		passkeys = append(passkeys, passkeyInfoToProto(ctx, &rows[i]))
 	}
 	return connect.NewResponse(&leapmuxv1.ListPasskeysResponse{Passkeys: passkeys, RpId: wa.RPID()}), nil
 }
@@ -400,10 +492,10 @@ func (s *UserService) RenamePasskey(ctx context.Context, req *connect.Request[le
 		row = got
 		return nil
 	}); err != nil {
-		return nil, mapPasskeyConnectError(err)
+		return nil, mapPasskeyConnectError(ctx, err)
 	}
 	return connect.NewResponse(&leapmuxv1.RenamePasskeyResponse{
-		Passkey: passkeyInfoToProto(row),
+		Passkey: passkeyInfoToProto(ctx, row),
 	}), nil
 }
 
@@ -439,7 +531,7 @@ func (s *UserService) DeletePasskey(ctx context.Context, req *connect.Request[le
 			return nil
 		}
 		if req.Msg.GetNewPassword() == "" {
-			return connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("cannot delete your only passkey; provide new_password or use DeactivatePasskeyAuth"))
+			return lastPasskeyNeedsPasswordError()
 		}
 		hashed, err := hashReplacementPassword(req.Msg.GetNewPassword())
 		if err != nil {
@@ -473,7 +565,7 @@ func (s *UserService) DeletePasskey(ctx context.Context, req *connect.Request[le
 		}
 		return tx.PasskeyCredentials().Delete(ctx, row.ID, user.ID)
 	}); err != nil {
-		return nil, mapPasskeyConnectError(err)
+		return nil, mapPasskeyConnectError(ctx, err)
 	}
 	if shouldRevoke {
 		s.lifecycle.RevokeUserPreservingSession(userInfo.ID.String(), actingSessionID, committedAuthGeneration)
@@ -517,7 +609,7 @@ func (s *UserService) DeactivatePasskeyAuth(ctx context.Context, req *connect.Re
 		shouldRevoke = revoked
 		return nil
 	}); err != nil {
-		return nil, mapPasskeyConnectError(err)
+		return nil, mapPasskeyConnectError(ctx, err)
 	}
 	if shouldRevoke {
 		s.lifecycle.RevokeUserPreservingSession(userInfo.ID.String(), actingSessionID, committedAuthGeneration)
@@ -549,7 +641,7 @@ func (s *UserService) commitPasskeyDeactivation(ctx context.Context, tx store.St
 	wasPasskeyOnly := !user.PasswordSet
 	if wasPasskeyOnly {
 		if hashedNewPassword == "" {
-			return 0, false, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("cannot delete your only passkey; provide new_password or use DeactivatePasskeyAuth"))
+			return 0, false, lastPasskeyNeedsPasswordError()
 		}
 		if err := tx.Users().UpdatePassword(ctx, store.UpdateUserPasswordParams{
 			PasswordHash: hashedNewPassword,
@@ -630,7 +722,7 @@ func validatePasskeyFriendlyName(name string) (string, error) {
 	return name, nil
 }
 
-func passkeyInfoToProto(row *store.PasskeyCredential) *leapmuxv1.PasskeyInfo {
+func passkeyInfoToProto(ctx context.Context, row *store.PasskeyCredential) *leapmuxv1.PasskeyInfo {
 	if row == nil {
 		return nil
 	}
@@ -644,7 +736,15 @@ func passkeyInfoToProto(row *store.PasskeyCredential) *leapmuxv1.PasskeyInfo {
 	if row.LastUsedAt != nil {
 		info.LastUsedAt = timestamppb.New(*row.LastUsedAt)
 	}
-	transports, _ := parsePasskeyTransports(row.Transports)
+	// A malformed transports column degrades the browser hint rather than
+	// failing the RPC, but it must not pass silently: the only production
+	// writer emits json.Marshal output, so a value that will not parse
+	// means the row was written from outside that path.
+	transports, err := parsePasskeyTransports(row.Transports)
+	if err != nil {
+		slog.WarnContext(ctx, "passkey transports column did not parse",
+			"passkey_id", row.ID, "err", err)
+	}
 	info.Transports = transports
 	return info
 }
@@ -660,16 +760,30 @@ func parsePasskeyTransports(raw string) ([]string, error) {
 	return transports, nil
 }
 
-func mapPasskeyConnectError(err error) error {
+// mapPasskeyConnectError classifies every error the passkey-management and
+// registration surface can return. A connect error that a handler already
+// built passes through; a store miss is NotFound; everything else routes
+// through classifyWebAuthnError, so a cancelled prompt and an unserved
+// origin answer the same way here as they do on the login surface.
+func mapPasskeyConnectError(ctx context.Context, err error) error {
 	var connectErr *connect.Error
 	if errors.As(err, &connectErr) {
 		return connectErr
 	}
-	if errors.Is(err, ErrPasskeysUnavailable) {
-		return connect.NewError(connect.CodeFailedPrecondition, err)
-	}
 	if errors.Is(err, store.ErrNotFound) {
 		return connect.NewError(connect.CodeNotFound, err)
+	}
+	switch classifyWebAuthnError(err) {
+	case webAuthnErrorClone:
+		// A clone warning is a security event, not a registration failure.
+		slog.WarnContext(ctx, "passkey clone warning during passkey management")
+		return connect.NewError(connect.CodeUnauthenticated, err)
+	case webAuthnErrorCredential:
+		return connect.NewError(connect.CodeUnauthenticated, err)
+	case webAuthnErrorUnavailable:
+		return connect.NewError(connect.CodeFailedPrecondition, err)
+	case webAuthnErrorInfrastructure:
+		return connect.NewError(connect.CodeInternal, err)
 	}
 	return connect.NewError(connect.CodeInternal, err)
 }

--- a/backend/internal/hub/service/passkey_service.go
+++ b/backend/internal/hub/service/passkey_service.go
@@ -1,0 +1,675 @@
+package service
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"connectrpc.com/connect"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/hub/auth"
+	"github.com/leapmux/leapmux/internal/hub/password"
+	"github.com/leapmux/leapmux/internal/hub/store"
+	hubwebauthn "github.com/leapmux/leapmux/internal/hub/webauthn"
+	"github.com/leapmux/leapmux/internal/util/userid"
+	"github.com/leapmux/leapmux/util/validate"
+)
+
+func rejectSoloPasskeyManagement(solo bool) error {
+	if !solo {
+		return nil
+	}
+	return connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("passkey management is not available in solo mode"))
+}
+
+func invalidReauthProofError() error {
+	return connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("%w", auth.ErrInvalidReauthProof))
+}
+
+// verifyPasswordForPasskeyManagement checks the current password when the
+// account has one. Wrong password returns ErrInvalidCurrentPassword so the
+// rate-limit interceptor can count the failure.
+func verifyPasswordForPasskeyManagement(user *store.User, currentPassword string) error {
+	if currentPassword == "" {
+		return connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("%w", auth.ErrInvalidCurrentPassword))
+	}
+	match, err := password.Verify(user.PasswordHash, currentPassword)
+	if err != nil {
+		return connect.NewError(connect.CodeInternal, fmt.Errorf("verify password: %w", err))
+	}
+	if !match {
+		return connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("%w", auth.ErrInvalidCurrentPassword))
+	}
+	return nil
+}
+
+// passkeyManagementAuth verifies the step-up credential OUTSIDE the
+// user-auth transaction: password verification runs Argon2 (tens of
+// milliseconds) and that transaction holds the database writer lock on
+// SQLite (see auth.Login's comment on the same trade). It returns whether
+// the caller must consume a reauth proof after its mutation succeeds; the
+// proof is only consumed inside the mutation transaction, and only then.
+func (s *UserService) passkeyManagementAuth(ctx context.Context, user *store.User, currentPassword, reauthProof string) (bool, error) {
+	if user.PasswordSet {
+		return false, verifyPasswordForPasskeyManagement(user, currentPassword)
+	}
+	count, err := s.store.PasskeyCredentials().CountByUser(ctx, user.ID)
+	if err != nil {
+		return false, connect.NewError(connect.CodeInternal, err)
+	}
+	if count == 0 {
+		return false, assertFirstCredentialWithoutPasswordAllowed(ctx, s.store, user)
+	}
+	if reauthProof == "" {
+		return true, invalidReauthProofError()
+	}
+	// Peek with the same validity predicate the consume uses, so an
+	// admission check and the consume cannot disagree on what a valid
+	// proof is.
+	if _, err := s.store.WebAuthnSessions().GetValidProof(ctx, reauthProof, user.ID, hubwebauthn.KindReauthProof, time.Now().UTC()); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return true, invalidReauthProofError()
+		}
+		return true, connect.NewError(connect.CodeInternal, err)
+	}
+	return true, nil
+}
+
+// assertFirstCredentialWithoutPasswordAllowed refuses a session-only first
+// lasting credential (a passkey, or the first password) when the account has
+// no durable identity (verified email or OAuth link). A stolen session on an
+// unverified shell must not attach a credential it can keep.
+func assertFirstCredentialWithoutPasswordAllowed(ctx context.Context, tx store.Store, user *store.User) error {
+	if user.PasswordSet {
+		return nil
+	}
+	count, err := tx.PasskeyCredentials().CountByUser(ctx, user.ID)
+	if err != nil {
+		return connect.NewError(connect.CodeInternal, err)
+	}
+	if count > 0 {
+		return nil
+	}
+	if user.EmailVerified {
+		return nil
+	}
+	uid, ok := userid.New(user.ID)
+	if !ok {
+		return connect.NewError(connect.CodeInternal, fmt.Errorf("invalid user id"))
+	}
+	links, err := tx.OAuthUserLinks().ListByUser(ctx, uid)
+	if err != nil {
+		return connect.NewError(connect.CodeInternal, err)
+	}
+	if len(links) > 0 {
+		return nil
+	}
+	return connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("verify your email or link an OAuth provider before adding a passkey"))
+}
+
+// consumePasskeyManagementReauth deletes a single-use reauth proof after a
+// successful mutation. Call only when passkeyManagementAuth returned
+// needsReauth=true. Password accounts never reach this path.
+func consumePasskeyManagementReauth(ctx context.Context, tx store.Store, user *store.User, reauthProof string) error {
+	if reauthProof == "" {
+		return invalidReauthProofError()
+	}
+	n, err := tx.WebAuthnSessions().ConsumeProof(ctx, reauthProof, user.ID, hubwebauthn.KindReauthProof, time.Now().UTC())
+	if err != nil {
+		return connect.NewError(connect.CodeInternal, err)
+	}
+	if n == 0 {
+		return invalidReauthProofError()
+	}
+	return nil
+}
+
+// runPasskeyManagementTx admits and runs a passkey-management mutation
+// (Finish/Rename/Delete/Deactivate, and ChangePassword's step-up side). The
+// step-up credential is verified OUTSIDE the user-auth transaction: password
+// verification runs Argon2 (tens of milliseconds) and that transaction holds
+// the database writer lock on SQLite (see auth.Login's comment on the same
+// trade). prepare runs after admission and still outside the lock -- callers
+// hash a new password there. Inside the transaction the user row is re-read
+// and the step-up is re-checked when the credential state moved between the
+// peek and the lock, mirroring auth.Login's prelock-verify/locked-recheck
+// pattern: a password rotated concurrently must not authorize this mutation
+// with the credential the rotation replaced. The reauth proof, when one was
+// required, is consumed inside the transaction after mutate succeeds -- the
+// only place a single-use proof may die.
+func (s *UserService) runPasskeyManagementTx(
+	ctx context.Context,
+	userInfo *auth.UserInfo,
+	currentPassword, reauthProof string,
+	prepare func(peek *store.User) error,
+	mutate func(tx store.Store, user *store.User) error,
+) error {
+	peek, err := s.store.Users().GetByID(ctx, userInfo.ID.String())
+	if err != nil {
+		return connect.NewError(connect.CodeInternal, fmt.Errorf("query user: %w", err))
+	}
+	needsReauth, err := s.passkeyManagementAuth(ctx, peek, currentPassword, reauthProof)
+	if err != nil {
+		return err
+	}
+	if prepare != nil {
+		if err := prepare(peek); err != nil {
+			return err
+		}
+	}
+	return s.store.RunInUserAuthTransaction(ctx, userInfo.ID, func(tx store.Store) error {
+		user, err := tx.Users().GetByID(ctx, userInfo.ID.String())
+		if err != nil {
+			return fmt.Errorf("query user: %w", err)
+		}
+		if err := recheckStepUpUnderLock(user, peek, currentPassword); err != nil {
+			return err
+		}
+		if err := mutate(tx, user); err != nil {
+			return err
+		}
+		if needsReauth {
+			return consumePasskeyManagementReauth(ctx, tx, user, reauthProof)
+		}
+		return nil
+	})
+}
+
+// recheckStepUpUnderLock re-verifies the step-up credential when the
+// account's password state moved between the pre-transaction peek and the
+// locked re-read. The common case (nothing moved) is one string comparison,
+// so Argon2 stays out of the lock unless the hash actually changed. A
+// structural flip (password added or removed concurrently) cannot be
+// re-verified from what the caller presented, so it fails with a clean
+// retry error instead.
+func recheckStepUpUnderLock(locked, peek *store.User, currentPassword string) error {
+	if locked.PasswordSet != peek.PasswordSet {
+		return connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("account credentials changed; please retry"))
+	}
+	if locked.PasswordSet && locked.PasswordHash != peek.PasswordHash {
+		return verifyPasswordForPasskeyManagement(locked, currentPassword)
+	}
+	return nil
+}
+
+func (s *UserService) BeginPasskeyRegistration(ctx context.Context, req *connect.Request[leapmuxv1.BeginPasskeyRegistrationRequest]) (*connect.Response[leapmuxv1.BeginPasskeyRegistrationResponse], error) {
+	if err := rejectSoloPasskeyManagement(s.cfg.SoloMode); err != nil {
+		return nil, err
+	}
+	userInfo, err := auth.MustGetUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+	user, err := s.store.Users().GetByID(ctx, userInfo.ID.String())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	// Peek only: FinishPasskeyRegistration consumes the reauth proof.
+	if _, err := s.passkeyManagementAuth(ctx, user, req.Msg.GetCurrentPassword(), req.Msg.GetReauthProof()); err != nil {
+		return nil, mapPasskeyConnectError(err)
+	}
+
+	wa, err := s.webauthnService(ctx)
+	if err != nil {
+		return nil, mapPasskeyConnectError(err)
+	}
+	sessionID, optionsJSON, rpID, err := wa.BeginRegistration(ctx, user.ID, originFromRequest(req))
+	if err != nil {
+		return nil, mapPasskeyConnectError(err)
+	}
+	return connect.NewResponse(&leapmuxv1.BeginPasskeyRegistrationResponse{
+		SessionId:   sessionID,
+		OptionsJson: optionsJSON,
+		RpId:        rpID,
+	}), nil
+}
+
+func (s *UserService) FinishPasskeyRegistration(ctx context.Context, req *connect.Request[leapmuxv1.FinishPasskeyRegistrationRequest]) (*connect.Response[leapmuxv1.FinishPasskeyRegistrationResponse], error) {
+	if err := rejectSoloPasskeyManagement(s.cfg.SoloMode); err != nil {
+		return nil, err
+	}
+	userInfo, err := auth.MustGetUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if req.Msg.GetSessionId() == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("session_id is required"))
+	}
+	if req.Msg.GetCredentialJson() == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("credential_json is required"))
+	}
+	friendlyName, err := validatePasskeyFriendlyName(req.Msg.GetFriendlyName())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+
+	var passkey *store.PasskeyCredential
+	// Peek before the attestation so a failed attestation does not burn the
+	// proof; the proof is consumed inside the transaction after the write.
+	if err := s.runPasskeyManagementTx(ctx, userInfo, req.Msg.GetCurrentPassword(), req.Msg.GetReauthProof(), nil, func(tx store.Store, user *store.User) error {
+		wa, err := s.webauthnServiceWithStore(ctx, tx)
+		if err != nil {
+			return err
+		}
+		passkey, err = wa.FinishRegistration(ctx, user.ID, req.Msg.GetSessionId(), req.Msg.GetCredentialJson(), friendlyName)
+		return err
+	}); err != nil {
+		return nil, mapPasskeyConnectError(err)
+	}
+
+	return connect.NewResponse(&leapmuxv1.FinishPasskeyRegistrationResponse{
+		Passkey: passkeyInfoToProto(passkey),
+	}), nil
+}
+
+func (s *UserService) BeginPasskeyReauth(ctx context.Context, req *connect.Request[leapmuxv1.BeginPasskeyReauthRequest]) (*connect.Response[leapmuxv1.BeginPasskeyReauthResponse], error) {
+	if err := rejectSoloPasskeyManagement(s.cfg.SoloMode); err != nil {
+		return nil, err
+	}
+	userInfo, err := auth.MustGetUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	user, err := s.store.Users().GetByID(ctx, userInfo.ID.String())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	wa, err := s.webauthnService(ctx)
+	if err != nil {
+		return nil, mapPasskeyConnectError(err)
+	}
+	sessionID, optionsJSON, rpID, err := wa.BeginReauth(ctx, user.ID, originFromRequest(req))
+	if err != nil {
+		return nil, mapPasskeyConnectError(err)
+	}
+	return connect.NewResponse(&leapmuxv1.BeginPasskeyReauthResponse{
+		SessionId:   sessionID,
+		OptionsJson: optionsJSON,
+		RpId:        rpID,
+	}), nil
+}
+
+func (s *UserService) FinishPasskeyReauth(ctx context.Context, req *connect.Request[leapmuxv1.FinishPasskeyReauthRequest]) (*connect.Response[leapmuxv1.FinishPasskeyReauthResponse], error) {
+	if err := rejectSoloPasskeyManagement(s.cfg.SoloMode); err != nil {
+		return nil, err
+	}
+	userInfo, err := auth.MustGetUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if req.Msg.GetSessionId() == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("session_id is required"))
+	}
+	if req.Msg.GetCredentialJson() == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("credential_json is required"))
+	}
+
+	user, err := s.store.Users().GetByID(ctx, userInfo.ID.String())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	wa, err := s.webauthnService(ctx)
+	if err != nil {
+		return nil, mapPasskeyConnectError(err)
+	}
+	proof, err := wa.FinishReauth(ctx, user.ID, req.Msg.GetSessionId(), req.Msg.GetCredentialJson())
+	if err != nil {
+		switch {
+		case errors.Is(err, hubwebauthn.ErrCloneDetected):
+			// A clone warning is a security event, not a proof failure: log
+			// it server-side and report it as itself, so it never counts
+			// against the reauth-proof rate-limit budget.
+			slog.WarnContext(ctx, "passkey clone warning during reauth", "user_id", user.ID)
+			return nil, connect.NewError(connect.CodeUnauthenticated, err)
+		case errors.Is(err, hubwebauthn.ErrCeremonyInvalid), errors.Is(err, hubwebauthn.ErrAssertionRejected):
+			return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("%w: %s", auth.ErrInvalidReauthProof, err.Error()))
+		default:
+			// Store and infrastructure failures are not proof failures.
+			// Reporting them as CodeInternal keeps them out of the shared
+			// passkey-management rate-limit budget.
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+	}
+	return connect.NewResponse(&leapmuxv1.FinishPasskeyReauthResponse{ReauthProof: proof}), nil
+}
+
+func (s *UserService) ListPasskeys(ctx context.Context, _ *connect.Request[leapmuxv1.ListPasskeysRequest]) (*connect.Response[leapmuxv1.ListPasskeysResponse], error) {
+	if err := rejectSoloPasskeyManagement(s.cfg.SoloMode); err != nil {
+		return nil, err
+	}
+	userInfo, err := auth.MustGetUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := s.store.PasskeyCredentials().ListByUser(ctx, userInfo.ID.String())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	// Surface an unconfigured hub instead of hiding it behind an empty
+	// list: the client cannot tell "no passkeys" from "passkeys cannot run
+	// here", and the settings page would render a broken section.
+	wa, err := s.webauthnService(ctx)
+	if err != nil {
+		return nil, mapPasskeyConnectError(err)
+	}
+	passkeys := make([]*leapmuxv1.PasskeyInfo, 0, len(rows))
+	for i := range rows {
+		passkeys = append(passkeys, passkeyInfoToProto(&rows[i]))
+	}
+	return connect.NewResponse(&leapmuxv1.ListPasskeysResponse{Passkeys: passkeys, RpId: wa.RPID()}), nil
+}
+
+func (s *UserService) RenamePasskey(ctx context.Context, req *connect.Request[leapmuxv1.RenamePasskeyRequest]) (*connect.Response[leapmuxv1.RenamePasskeyResponse], error) {
+	if err := rejectSoloPasskeyManagement(s.cfg.SoloMode); err != nil {
+		return nil, err
+	}
+	userInfo, err := auth.MustGetUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if req.Msg.GetId() == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("id is required"))
+	}
+	friendlyName, err := validatePasskeyFriendlyName(req.Msg.GetFriendlyName())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+
+	var row *store.PasskeyCredential
+	if err := s.runPasskeyManagementTx(ctx, userInfo, req.Msg.GetCurrentPassword(), req.Msg.GetReauthProof(), nil, func(tx store.Store, user *store.User) error {
+		got, err := tx.PasskeyCredentials().GetByID(ctx, req.Msg.GetId())
+		if err != nil {
+			return err
+		}
+		if got.UserID != user.ID {
+			return store.ErrNotFound
+		}
+		if err := tx.PasskeyCredentials().UpdateFriendlyName(ctx, got.ID, got.UserID, friendlyName); err != nil {
+			return err
+		}
+		got.FriendlyName = friendlyName
+		row = got
+		return nil
+	}); err != nil {
+		return nil, mapPasskeyConnectError(err)
+	}
+	return connect.NewResponse(&leapmuxv1.RenamePasskeyResponse{
+		Passkey: passkeyInfoToProto(row),
+	}), nil
+}
+
+func (s *UserService) DeletePasskey(ctx context.Context, req *connect.Request[leapmuxv1.DeletePasskeyRequest]) (*connect.Response[leapmuxv1.DeletePasskeyResponse], error) {
+	if err := rejectSoloPasskeyManagement(s.cfg.SoloMode); err != nil {
+		return nil, err
+	}
+	userInfo, err := auth.MustGetUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if req.Msg.GetId() == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("id is required"))
+	}
+
+	actingSessionID := userInfo.Credential.SessionID()
+	var committedAuthGeneration int64
+	var shouldRevoke bool
+	// Hash the replacement password outside the transaction (Argon2 must
+	// not hold the SQLite writer lock). Only the last-passkey branch on a
+	// passwordless account needs one; the transaction re-derives that
+	// decision from the locked row and refuses an empty hash.
+	var hashedNewPassword string
+	prepare := func(peek *store.User) error {
+		if peek.PasswordSet {
+			return nil
+		}
+		count, err := s.store.PasskeyCredentials().CountByUser(ctx, peek.ID)
+		if err != nil {
+			return connect.NewError(connect.CodeInternal, err)
+		}
+		if count > 1 {
+			return nil
+		}
+		if req.Msg.GetNewPassword() == "" {
+			return connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("cannot delete your only passkey; provide new_password or use DeactivatePasskeyAuth"))
+		}
+		hashed, err := hashReplacementPassword(req.Msg.GetNewPassword())
+		if err != nil {
+			return err
+		}
+		hashedNewPassword = hashed
+		return nil
+	}
+	if err := s.runPasskeyManagementTx(ctx, userInfo, req.Msg.GetCurrentPassword(), req.Msg.GetReauthProof(), prepare, func(tx store.Store, user *store.User) error {
+		row, err := tx.PasskeyCredentials().GetByID(ctx, req.Msg.GetId())
+		if err != nil {
+			return err
+		}
+		if row.UserID != user.ID {
+			return store.ErrNotFound
+		}
+		count, err := tx.PasskeyCredentials().CountByUser(ctx, user.ID)
+		if err != nil {
+			return err
+		}
+		// Last passkey on a passkey-only account: delegate to the
+		// deactivation commit (plan CommitPasskeyDelete).
+		if !user.PasswordSet && count <= 1 {
+			gen, revoked, err := s.commitPasskeyDeactivation(ctx, tx, user, hashedNewPassword, actingSessionID)
+			if err != nil {
+				return err
+			}
+			committedAuthGeneration = gen
+			shouldRevoke = revoked
+			return nil
+		}
+		return tx.PasskeyCredentials().Delete(ctx, row.ID, user.ID)
+	}); err != nil {
+		return nil, mapPasskeyConnectError(err)
+	}
+	if shouldRevoke {
+		s.lifecycle.RevokeUserPreservingSession(userInfo.ID.String(), actingSessionID, committedAuthGeneration)
+	}
+	return connect.NewResponse(&leapmuxv1.DeletePasskeyResponse{}), nil
+}
+
+func (s *UserService) DeactivatePasskeyAuth(ctx context.Context, req *connect.Request[leapmuxv1.DeactivatePasskeyAuthRequest]) (*connect.Response[leapmuxv1.DeactivatePasskeyAuthResponse], error) {
+	if err := rejectSoloPasskeyManagement(s.cfg.SoloMode); err != nil {
+		return nil, err
+	}
+	userInfo, err := auth.MustGetUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	actingSessionID := userInfo.Credential.SessionID()
+	var committedAuthGeneration int64
+	var shouldRevoke bool
+	// Hash the replacement password outside the transaction (Argon2 must
+	// not hold the SQLite writer lock). Only a passwordless account needs
+	// one; the transaction re-derives that from the locked row.
+	var hashedNewPassword string
+	prepare := func(peek *store.User) error {
+		if peek.PasswordSet {
+			return nil
+		}
+		hashed, err := hashReplacementPassword(req.Msg.GetNewPassword())
+		if err != nil {
+			return err
+		}
+		hashedNewPassword = hashed
+		return nil
+	}
+	if err := s.runPasskeyManagementTx(ctx, userInfo, req.Msg.GetCurrentPassword(), req.Msg.GetReauthProof(), prepare, func(tx store.Store, user *store.User) error {
+		gen, revoked, err := s.commitPasskeyDeactivation(ctx, tx, user, hashedNewPassword, actingSessionID)
+		if err != nil {
+			return err
+		}
+		committedAuthGeneration = gen
+		shouldRevoke = revoked
+		return nil
+	}); err != nil {
+		return nil, mapPasskeyConnectError(err)
+	}
+	if shouldRevoke {
+		s.lifecycle.RevokeUserPreservingSession(userInfo.ID.String(), actingSessionID, committedAuthGeneration)
+	}
+	return connect.NewResponse(&leapmuxv1.DeactivatePasskeyAuthResponse{}), nil
+}
+
+// hashReplacementPassword validates and hashes a replacement password for
+// the passkey-deactivation paths. Call outside the user-auth transaction:
+// Argon2 must not hold the SQLite writer lock.
+func hashReplacementPassword(newPassword string) (string, error) {
+	if err := validate.ValidatePassword(newPassword); err != nil {
+		return "", connect.NewError(connect.CodeInvalidArgument, err)
+	}
+	hashed, err := password.Hash(newPassword)
+	if err != nil {
+		return "", connect.NewError(connect.CodeInternal, fmt.Errorf("hash password: %w", err))
+	}
+	return hashed, nil
+}
+
+// commitPasskeyDeactivation deletes every passkey for the user. On a
+// passkey-only account it also sets the pre-hashed replacement password
+// (hashedNewPassword; empty means the caller did not supply one) and
+// revokes other sessions and tokens while preserving the acting session
+// (mirror ChangePassword). Caller must hold the user-auth lock and must
+// verify auth before this call.
+func (s *UserService) commitPasskeyDeactivation(ctx context.Context, tx store.Store, user *store.User, hashedNewPassword, actingSessionID string) (committedAuthGeneration int64, revoked bool, err error) {
+	wasPasskeyOnly := !user.PasswordSet
+	if wasPasskeyOnly {
+		if hashedNewPassword == "" {
+			return 0, false, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("cannot delete your only passkey; provide new_password or use DeactivatePasskeyAuth"))
+		}
+		if err := tx.Users().UpdatePassword(ctx, store.UpdateUserPasswordParams{
+			PasswordHash: hashedNewPassword,
+			ID:           user.ID,
+		}); err != nil {
+			return 0, false, fmt.Errorf("update password: %w", err)
+		}
+	}
+	if err := tx.PasskeyCredentials().DeleteAllByUser(ctx, user.ID); err != nil {
+		return 0, false, err
+	}
+	if !wasPasskeyOnly {
+		return 0, false, nil
+	}
+	gen, err := s.revokeOtherCredentialsPreservingSession(ctx, tx, user.ID, actingSessionID)
+	if err != nil {
+		return 0, false, err
+	}
+	return gen, true, nil
+}
+
+// revokeOtherCredentialsPreservingSession deletes other sessions, revokes API
+// and delegation tokens, bumps auth_generation, and restamps the acting
+// session. Caller must hold the user-auth transaction. Shared by
+// ChangePassword, DeletePasskey, and DeactivatePasskeyAuth.
+//
+// RefreshAuthGeneration returning n==0 means the acting session was
+// concurrently deleted (a same-user logout does not contend on this
+// user-auth lock) after the transaction began. The password change itself
+// stays valid and there is no surviving session row left to restamp, so the
+// caller does not roll the change back; the post-transaction revocation is
+// a harmless no-op for a same-process logout and self-heals across hubs
+// once the durable session-revoked event replays. n>1 is impossible
+// (session id is unique) and indicates corruption, so it stays fatal.
+func (s *UserService) revokeOtherCredentialsPreservingSession(ctx context.Context, tx store.Store, userID, actingSessionID string) (int64, error) {
+	rowUID, err := mintRowUserID(userID)
+	if err != nil {
+		return 0, err
+	}
+	if err := tx.Sessions().DeleteOthers(ctx, store.DeleteOtherSessionsParams{
+		UserID: rowUID,
+		KeepID: actingSessionID,
+	}); err != nil {
+		return 0, fmt.Errorf("delete other sessions: %w", err)
+	}
+	if _, _, err := auth.RevokeAllUserCredentials(ctx, tx, rowUID); err != nil {
+		return 0, err
+	}
+	if actingSessionID != "" {
+		n, err := tx.Sessions().RefreshAuthGeneration(ctx, store.RefreshSessionAuthGenerationParams{
+			SessionID: actingSessionID,
+			UserID:    rowUID,
+		})
+		if err != nil {
+			return 0, fmt.Errorf("refresh current session auth generation: %w", err)
+		}
+		if n > 1 {
+			return 0, fmt.Errorf("refresh current session auth generation: updated %d rows", n)
+		}
+	}
+	updatedUser, err := tx.Users().GetByID(ctx, userID)
+	if err != nil {
+		return 0, fmt.Errorf("query updated user auth generation: %w", err)
+	}
+	return updatedUser.AuthGeneration, nil
+}
+
+func validatePasskeyFriendlyName(name string) (string, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "Passkey", nil
+	}
+	// Count characters, not bytes: a CJK or emoji name under 64 characters
+	// is valid input and must not be rejected by a message about characters.
+	if utf8.RuneCountInString(name) > 64 {
+		return "", fmt.Errorf("friendly name must be at most 64 characters")
+	}
+	return name, nil
+}
+
+func passkeyInfoToProto(row *store.PasskeyCredential) *leapmuxv1.PasskeyInfo {
+	if row == nil {
+		return nil
+	}
+	info := &leapmuxv1.PasskeyInfo{
+		Id:           row.ID,
+		FriendlyName: row.FriendlyName,
+		CreatedAt:    timestamppb.New(row.CreatedAt),
+		// Base64url credential id for the browser Signal API after delete.
+		CredentialId: base64.RawURLEncoding.EncodeToString(row.CredentialID),
+	}
+	if row.LastUsedAt != nil {
+		info.LastUsedAt = timestamppb.New(*row.LastUsedAt)
+	}
+	transports, _ := parsePasskeyTransports(row.Transports)
+	info.Transports = transports
+	return info
+}
+
+func parsePasskeyTransports(raw string) ([]string, error) {
+	if raw == "" || raw == "[]" {
+		return nil, nil
+	}
+	var transports []string
+	if err := json.Unmarshal([]byte(raw), &transports); err != nil {
+		return nil, fmt.Errorf("parse passkey transports: %w", err)
+	}
+	return transports, nil
+}
+
+func mapPasskeyConnectError(err error) error {
+	var connectErr *connect.Error
+	if errors.As(err, &connectErr) {
+		return connectErr
+	}
+	if errors.Is(err, ErrPasskeysUnavailable) {
+		return connect.NewError(connect.CodeFailedPrecondition, err)
+	}
+	if errors.Is(err, store.ErrNotFound) {
+		return connect.NewError(connect.CodeNotFound, err)
+	}
+	return connect.NewError(connect.CodeInternal, err)
+}

--- a/backend/internal/hub/service/passkey_stepup_internal_test.go
+++ b/backend/internal/hub/service/passkey_stepup_internal_test.go
@@ -46,18 +46,22 @@ func stepUpUser(t *testing.T, st store.Store, passwordSet bool) *store.User {
 func TestRecheckStepUpUnderLock(t *testing.T) {
 	t.Parallel()
 
+	// The password and reauth-proof admissions never re-read the count, so
+	// a nil store proves the writer lock pays for no query on those paths.
+	passwordAdmission := stepUpAdmission{}
+
 	t.Run("unchanged row passes without re-verification", func(t *testing.T) {
 		t.Parallel()
 		peek := &store.User{PasswordSet: true, PasswordHash: "h1"}
 		locked := &store.User{PasswordSet: true, PasswordHash: "h1"}
-		assert.NoError(t, recheckStepUpUnderLock(locked, peek, "pw"))
+		assert.NoError(t, recheckStepUpUnderLock(context.Background(), nil, locked, peek, "pw", passwordAdmission))
 	})
 
 	t.Run("structural flip refuses with a retry error", func(t *testing.T) {
 		t.Parallel()
 		peek := &store.User{PasswordSet: false}
 		locked := &store.User{PasswordSet: true, PasswordHash: "h2"}
-		err := recheckStepUpUnderLock(locked, peek, "pw")
+		err := recheckStepUpUnderLock(context.Background(), nil, locked, peek, "pw", passwordAdmission)
 		require.Error(t, err)
 		connectErr := new(connect.Error)
 		require.ErrorAs(t, err, &connectErr)
@@ -74,13 +78,56 @@ func TestRecheckStepUpUnderLock(t *testing.T) {
 		require.NoError(t, err)
 		peek := &store.User{PasswordSet: true, PasswordHash: "stale-hash"}
 		locked := &store.User{PasswordSet: true, PasswordHash: realHash}
-		assert.NoError(t, recheckStepUpUnderLock(locked, peek, "stepup-password"))
+		assert.NoError(t, recheckStepUpUnderLock(context.Background(), nil, locked, peek, "stepup-password", passwordAdmission))
 
-		wrong := recheckStepUpUnderLock(locked, peek, "not-the-password")
+		wrong := recheckStepUpUnderLock(context.Background(), nil, locked, peek, "not-the-password", passwordAdmission)
 		require.Error(t, wrong)
 		connectErr := new(connect.Error)
 		require.ErrorAs(t, wrong, &connectErr)
 		assert.Equal(t, connect.CodeUnauthenticated, connectErr.Code())
+	})
+
+	// The first-credential admission is the one input a concurrent write
+	// can invalidate: the account was admitted BECAUSE it held no
+	// credential to present, so a registration that commits in the window
+	// means the caller should have presented a reauth proof for it.
+	//
+	// Without this re-read, two concurrent first-credential mutations both
+	// commit and the second sets a password with no step-up at all.
+	t.Run("first-credential admission re-reads the count under the lock", func(t *testing.T) {
+		t.Parallel()
+		st := newStepUpTestStore(t)
+		user := stepUpUser(t, st, false)
+		firstCredential := stepUpAdmission{firstCredential: true}
+
+		// Nothing committed in the window: the admission still holds.
+		assert.NoError(t, recheckStepUpUnderLock(context.Background(), st, user, user, "", firstCredential))
+
+		// A passkey committed in the window: the account now HAS a
+		// credential, so the admission no longer holds.
+		require.NoError(t, st.PasskeyCredentials().Create(context.Background(), store.CreatePasskeyCredentialParams{
+			ID:           id.Generate(),
+			UserID:       user.ID,
+			CredentialID: []byte("raced-credential"),
+			PublicKey:    []byte("key"),
+			FriendlyName: "Raced",
+		}))
+
+		err := recheckStepUpUnderLock(context.Background(), st, user, user, "", firstCredential)
+		require.Error(t, err)
+		connectErr := new(connect.Error)
+		require.ErrorAs(t, err, &connectErr)
+		assert.Equal(t, connect.CodeFailedPrecondition, connectErr.Code())
+	})
+
+	// The count re-read is scoped to the admission that needs it: a
+	// proof-bearing caller already presented a credential, so the writer
+	// lock must not pay for a query on that path.
+	t.Run("a proof-bearing admission does not re-read the count", func(t *testing.T) {
+		t.Parallel()
+		user := &store.User{ID: "u", PasswordSet: false}
+		// A nil store panics on any query, so passing gives the assertion.
+		assert.NoError(t, recheckStepUpUnderLock(context.Background(), nil, user, user, "", stepUpAdmission{needsReauth: true}))
 	})
 }
 
@@ -102,11 +149,14 @@ func (failingSender) Send(_ context.Context, _ mail.Message) error {
 	return errors.New("smtp unavailable")
 }
 
-// A failed verification send must clear the freshly stamped pending row:
-// a code that was never delivered must not block the immediate retry
-// behind the resend cooldown, and the failure must not surface as err
-// (the callers report it through the sent flag instead).
-func TestIssuePendingEmailVerificationFailedSendClearsRow(t *testing.T) {
+// A failed verification send must drop the undelivered CODE and keep the
+// pending ADDRESS. The code must not linger and arm the resend cooldown,
+// and the failure must not surface as err (the callers report it through
+// the sent flag instead). The address must survive, because a
+// verification-required sign-up leaves users.email empty, so it is the only
+// record of what the account is trying to verify -- clearing it leaves
+// ResendVerificationEmail with nothing to re-send to.
+func TestIssuePendingEmailVerificationFailedSendKeepsAddressDropsCode(t *testing.T) {
 	t.Parallel()
 	st := newStepUpTestStore(t)
 	user := stepUpUser(t, st, true)
@@ -117,10 +167,38 @@ func TestIssuePendingEmailVerificationFailedSendClearsRow(t *testing.T) {
 
 	after, err := st.Users().GetByID(context.Background(), user.ID)
 	require.NoError(t, err)
-	assert.Empty(t, after.PendingEmail, "an undelivered code must not linger and arm the cooldown")
+	assert.Equal(t, "retry@example.com", after.PendingEmail,
+		"the address must survive a failed send: it is the only record of what to re-send to")
+	assert.Empty(t, after.PendingEmailToken, "an undelivered code must not stay live")
+	assert.Nil(t, after.PendingEmailExpiresAt,
+		"no expiry means no armed cooldown, so the retry the failure invites is not blocked")
 
-	// The cleared row means an immediate retry is not cooldown-blocked.
+	// The dropped code means an immediate retry is not cooldown-blocked.
 	sent2, err2 := issuePendingEmailVerification(context.Background(), st, failingSender{}, mail.Renderer{}, user.ID, "retry@example.com")
 	require.NoError(t, err2)
 	assert.False(t, sent2)
+}
+
+// The regression this pair exists for: a sign-up that requires
+// verification stores the address ONLY in pending_email, so a failed
+// resend that wiped the row left the account with no address anywhere and
+// ResendVerificationEmail refusing forever with "no pending email change".
+func TestResendAfterFailedSendStillFindsTheAddress(t *testing.T) {
+	t.Parallel()
+	st := newStepUpTestStore(t)
+	user := stepUpUser(t, st, true)
+	// A verification-required sign-up: the address lives in pending_email
+	// and users.email is empty.
+	require.NoError(t, st.Users().UpdateEmail(context.Background(), store.UpdateUserEmailParams{
+		ID: user.ID, Email: "", EmailVerified: false,
+	}))
+
+	_, err := issuePendingEmailVerification(context.Background(), st, failingSender{}, mail.Renderer{}, user.ID, "signup@example.com")
+	require.NoError(t, err)
+
+	after, err := st.Users().GetByID(context.Background(), user.ID)
+	require.NoError(t, err)
+	require.Empty(t, after.Email, "precondition: the address is only in pending_email")
+	assert.Equal(t, "signup@example.com", after.PendingEmail,
+		"ResendVerificationEmail reads PendingEmail; an empty one is a permanent dead end")
 }

--- a/backend/internal/hub/service/passkey_stepup_internal_test.go
+++ b/backend/internal/hub/service/passkey_stepup_internal_test.go
@@ -1,0 +1,126 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/leapmux/leapmux/internal/hub/mail"
+	pwdhash "github.com/leapmux/leapmux/internal/hub/password"
+	"github.com/leapmux/leapmux/internal/hub/store"
+	"github.com/leapmux/leapmux/internal/hub/store/sqlite"
+	"github.com/leapmux/leapmux/internal/util/id"
+	"github.com/leapmux/leapmux/internal/util/sqlitedb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newStepUpTestStore(t *testing.T) store.Store {
+	t.Helper()
+	st, err := sqlite.Open(":memory:", sqlitedb.Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+	require.NoError(t, st.Migrator().Migrate(context.Background()))
+	return st
+}
+
+func stepUpUser(t *testing.T, st store.Store, passwordSet bool) *store.User {
+	t.Helper()
+	userID := id.Generate()
+	require.NoError(t, st.Users().Create(context.Background(), store.CreateUserParams{
+		ID:           userID,
+		Username:     "stepup" + userID[:8],
+		PasswordHash: "hash",
+		DisplayName:  "Step Up",
+		PasswordSet:  passwordSet,
+	}))
+	u, err := st.Users().GetByID(context.Background(), userID)
+	require.NoError(t, err)
+	return u
+}
+
+// The locked re-check is the guard a concurrent rotation must not skip:
+// the step-up ran against the peeked row, the write runs against the
+// locked row, and the two must agree.
+func TestRecheckStepUpUnderLock(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unchanged row passes without re-verification", func(t *testing.T) {
+		t.Parallel()
+		peek := &store.User{PasswordSet: true, PasswordHash: "h1"}
+		locked := &store.User{PasswordSet: true, PasswordHash: "h1"}
+		assert.NoError(t, recheckStepUpUnderLock(locked, peek, "pw"))
+	})
+
+	t.Run("structural flip refuses with a retry error", func(t *testing.T) {
+		t.Parallel()
+		peek := &store.User{PasswordSet: false}
+		locked := &store.User{PasswordSet: true, PasswordHash: "h2"}
+		err := recheckStepUpUnderLock(locked, peek, "pw")
+		require.Error(t, err)
+		connectErr := new(connect.Error)
+		require.ErrorAs(t, err, &connectErr)
+		assert.Equal(t, connect.CodeFailedPrecondition, connectErr.Code())
+	})
+
+	t.Run("rotated hash re-verifies against the locked row", func(t *testing.T) {
+		t.Parallel()
+		// The peek and the locked row disagree: the password the caller
+		// presented must be checked against the LOCKED hash, which
+		// verifyPasswordForPasskeyManagement does through Argon2. Use a
+		// real hash so the verify runs the real path.
+		realHash, err := pwdhash.Hash("stepup-password")
+		require.NoError(t, err)
+		peek := &store.User{PasswordSet: true, PasswordHash: "stale-hash"}
+		locked := &store.User{PasswordSet: true, PasswordHash: realHash}
+		assert.NoError(t, recheckStepUpUnderLock(locked, peek, "stepup-password"))
+
+		wrong := recheckStepUpUnderLock(locked, peek, "not-the-password")
+		require.Error(t, wrong)
+		connectErr := new(connect.Error)
+		require.ErrorAs(t, wrong, &connectErr)
+		assert.Equal(t, connect.CodeUnauthenticated, connectErr.Code())
+	})
+}
+
+// The friendly-name limit counts characters: a CJK or emoji name under the
+// limit is valid input and must not be rejected over its byte length.
+func TestValidatePasskeyFriendlyNameCountsCharacters(t *testing.T) {
+	t.Parallel()
+	name, err := validatePasskeyFriendlyName("비밀번호가-긴-이름인-경우에도-문자로-세면-통과합니다") // 30 characters, 90 UTF-8 bytes
+	require.NoError(t, err)
+	assert.Equal(t, "비밀번호가-긴-이름인-경우에도-문자로-세면-통과합니다", name)
+
+	_, err = validatePasskeyFriendlyName(string(make([]rune, 65)))
+	require.Error(t, err)
+}
+
+type failingSender struct{}
+
+func (failingSender) Send(_ context.Context, _ mail.Message) error {
+	return errors.New("smtp unavailable")
+}
+
+// A failed verification send must clear the freshly stamped pending row:
+// a code that was never delivered must not block the immediate retry
+// behind the resend cooldown, and the failure must not surface as err
+// (the callers report it through the sent flag instead).
+func TestIssuePendingEmailVerificationFailedSendClearsRow(t *testing.T) {
+	t.Parallel()
+	st := newStepUpTestStore(t)
+	user := stepUpUser(t, st, true)
+
+	sent, err := issuePendingEmailVerification(context.Background(), st, failingSender{}, mail.Renderer{}, user.ID, "retry@example.com")
+	require.NoError(t, err)
+	assert.False(t, sent)
+
+	after, err := st.Users().GetByID(context.Background(), user.ID)
+	require.NoError(t, err)
+	assert.Empty(t, after.PendingEmail, "an undelivered code must not linger and arm the cooldown")
+
+	// The cleared row means an immediate retry is not cooldown-blocked.
+	sent2, err2 := issuePendingEmailVerification(context.Background(), st, failingSender{}, mail.Renderer{}, user.ID, "retry@example.com")
+	require.NoError(t, err2)
+	assert.False(t, sent2)
+}

--- a/backend/internal/hub/service/passkey_webauthn.go
+++ b/backend/internal/hub/service/passkey_webauthn.go
@@ -62,3 +62,62 @@ func (s *AuthService) passkeysAvailable(ctx context.Context) bool {
 func originFromRequest[T any](req *connect.Request[T]) string {
 	return req.Header().Get("Origin")
 }
+
+// webAuthnErrorClass says how a passkey surface must answer a ceremony
+// error. It is the ONE place that knows the hubwebauthn sentinels.
+//
+// Every passkey surface asked the same question and answered it
+// separately: login and reauth each carried their own switch, and the
+// passkey-management surface had no classifier at all, so a cancelled
+// platform prompt (ErrAssertionRejected) and an unserved origin
+// (ErrOriginNotAllowed) both left FinishPasskeyRegistration as CodeInternal
+// -- a 500 for ordinary user input. A sentinel added to the webauthn
+// package is now classified on every surface at once.
+//
+// The class decides the CODE only. The rate-limit interceptor accounts on
+// the error SENTINEL (auth.ErrInvalidCurrentPassword and
+// auth.ErrInvalidReauthProof), never on the connect code, so nothing here
+// changes which attempts count against a budget.
+//
+// Each surface keeps its own message, log payload, and error wrap, because
+// those genuinely differ:
+// login answers a missing account and a passkey-less account identically
+// so the error is not an enumeration oracle, and reauth re-labels a
+// credential failure as auth.ErrInvalidReauthProof so the interceptor can
+// key on it.
+type webAuthnErrorClass int
+
+const (
+	// webAuthnErrorInfrastructure is the default. A store, keystore, or
+	// ceremony-session failure is not a credential failure, so it reports
+	// CodeInternal rather than telling the caller their credential was
+	// refused.
+	webAuthnErrorInfrastructure webAuthnErrorClass = iota
+	// webAuthnErrorCredential is a ceremony that ran and failed: a missing,
+	// expired, or rejected credential. CodeUnauthenticated.
+	webAuthnErrorCredential
+	// webAuthnErrorClone is a sign-count clone warning. It is a security
+	// event, not a login failure: the surface logs it and reports it as
+	// itself rather than as a rejected credential.
+	webAuthnErrorClone
+	// webAuthnErrorUnavailable is a precondition the user can correct: the
+	// hub runs no ceremonies, the account has no passkeys, or the browser
+	// origin is one the hub does not serve. CodeFailedPrecondition.
+	webAuthnErrorUnavailable
+)
+
+// classifyWebAuthnError maps a ceremony error to the class its surface must
+// answer with. An error it does not recognize is infrastructure.
+func classifyWebAuthnError(err error) webAuthnErrorClass {
+	switch {
+	case errors.Is(err, hubwebauthn.ErrCloneDetected):
+		return webAuthnErrorClone
+	case errors.Is(err, hubwebauthn.ErrCeremonyInvalid), errors.Is(err, hubwebauthn.ErrAssertionRejected):
+		return webAuthnErrorCredential
+	case errors.Is(err, hubwebauthn.ErrNoPasskeys), errors.Is(err, hubwebauthn.ErrOriginNotAllowed),
+		errors.Is(err, ErrPasskeysUnavailable):
+		return webAuthnErrorUnavailable
+	default:
+		return webAuthnErrorInfrastructure
+	}
+}

--- a/backend/internal/hub/service/passkey_webauthn.go
+++ b/backend/internal/hub/service/passkey_webauthn.go
@@ -1,0 +1,64 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"connectrpc.com/connect"
+
+	"github.com/leapmux/leapmux/internal/hub/config"
+	"github.com/leapmux/leapmux/internal/hub/keystore"
+	"github.com/leapmux/leapmux/internal/hub/settings"
+	"github.com/leapmux/leapmux/internal/hub/store"
+	hubwebauthn "github.com/leapmux/leapmux/internal/hub/webauthn"
+)
+
+// ErrPasskeysUnavailable reports a hub configuration state in which passkey
+// ceremonies cannot run: no keystore, or no usable browser origin (desktop
+// local-only mode). Handlers map it to CodeFailedPrecondition once, so every
+// passkey surface answers the same state the same way instead of mixing
+// Internal, FailedPrecondition, and silently empty lists.
+var ErrPasskeysUnavailable = errors.New("passkeys are not configured on this hub")
+
+// newWebAuthnService builds the per-request WebAuthn service shared by the
+// auth and user services. The RP config derives from the current settings
+// snapshot, so a public_url change applies without a restart. Both
+// configuration failures (no keystore, no hub URL) return
+// ErrPasskeysUnavailable wrapped with the remediation.
+func newWebAuthnService(ctx context.Context, set *settings.Manager, cfg *config.Config, ks *keystore.Keystore, st store.Store) (*hubwebauthn.Service, error) {
+	if ks == nil {
+		return nil, fmt.Errorf("%w: passkey support is not configured", ErrPasskeysUnavailable)
+	}
+	rp, err := hubwebauthn.RPConfigFromSettings(set.Snapshot(ctx), cfg.Listen)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrPasskeysUnavailable, err.Error())
+	}
+	return hubwebauthn.NewService(rp, st, ks)
+}
+
+func (s *UserService) webauthnService(ctx context.Context) (*hubwebauthn.Service, error) {
+	return newWebAuthnService(ctx, s.set, s.cfg, s.keystore, s.store)
+}
+
+func (s *UserService) webauthnServiceWithStore(ctx context.Context, st store.Store) (*hubwebauthn.Service, error) {
+	return newWebAuthnService(ctx, s.set, s.cfg, s.keystore, st)
+}
+
+func (s *AuthService) webauthnService(ctx context.Context) (*hubwebauthn.Service, error) {
+	return newWebAuthnService(ctx, s.set, s.cfg, s.keystore, s.store)
+}
+
+// passkeysAvailable reports whether passkey ceremonies can run on this hub,
+// for the availability signal in GetSystemInfo.
+func (s *AuthService) passkeysAvailable(ctx context.Context) bool {
+	_, err := s.webauthnService(ctx)
+	return err == nil
+}
+
+// originFromRequest returns the browser origin of a Connect request. The
+// WebAuthn layer accepts only origins the hub itself configured; an absent
+// header (non-browser client) falls back to the default RP ID.
+func originFromRequest[T any](req *connect.Request[T]) string {
+	return req.Header().Get("Origin")
+}

--- a/backend/internal/hub/service/passkey_webauthn_internal_test.go
+++ b/backend/internal/hub/service/passkey_webauthn_internal_test.go
@@ -1,0 +1,96 @@
+package service
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	hubwebauthn "github.com/leapmux/leapmux/internal/hub/webauthn"
+)
+
+// classifyWebAuthnError is the ONE place that knows the hubwebauthn
+// sentinels, and four surfaces answer from it. A sentinel that falls to the
+// default is a 500 for ordinary user input -- which is exactly what the
+// passkey-management surface returned for a cancelled platform prompt
+// before this classifier existed.
+//
+// The wrapped cases matter as much as the bare ones: every sentinel reaches
+// a handler through at least one fmt.Errorf, and the store layer's
+// transaction wrapper adds another.
+func TestClassifyWebAuthnError(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		err  error
+		want webAuthnErrorClass
+	}{
+		{"clone warning", hubwebauthn.ErrCloneDetected, webAuthnErrorClone},
+		{"invalid ceremony", hubwebauthn.ErrCeremonyInvalid, webAuthnErrorCredential},
+		{"rejected assertion", hubwebauthn.ErrAssertionRejected, webAuthnErrorCredential},
+		{"no passkeys", hubwebauthn.ErrNoPasskeys, webAuthnErrorUnavailable},
+		{"origin not allowed", hubwebauthn.ErrOriginNotAllowed, webAuthnErrorUnavailable},
+		{"passkeys unavailable", ErrPasskeysUnavailable, webAuthnErrorUnavailable},
+		{"nil", nil, webAuthnErrorInfrastructure},
+		{"unknown", fmt.Errorf("database is unwell"), webAuthnErrorInfrastructure},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, classifyWebAuthnError(tc.err))
+			if tc.err == nil {
+				return
+			}
+			// Wrapped once, as a handler sees it.
+			assert.Equal(t, tc.want, classifyWebAuthnError(fmt.Errorf("finish registration: %w", tc.err)),
+				"a wrapped sentinel must classify the same")
+			// Wrapped twice, as the transaction wrapper leaves it.
+			assert.Equal(t, tc.want, classifyWebAuthnError(fmt.Errorf("tx: %w", fmt.Errorf("finish: %w", tc.err))),
+				"nesting must not change the class")
+		})
+	}
+}
+
+// Every sentinel the webauthn package exports must be classified. A new one
+// that nobody adds to classifyWebAuthnError falls to Internal on all four
+// surfaces, which is the silent 500 the classifier exists to prevent -- and
+// no compiler check catches it, because a sentinel is just a package-level
+// var.
+//
+// The list below is hand-maintained, so the test reads the SOURCE to prove
+// the list is complete. Otherwise it would assert only what someone
+// remembered to add, which is the failure it exists to catch.
+func TestClassifyWebAuthnError_CoversEveryExportedSentinel(t *testing.T) {
+	t.Parallel()
+
+	classified := map[string]error{
+		"ErrCloneDetected":     hubwebauthn.ErrCloneDetected,
+		"ErrCeremonyInvalid":   hubwebauthn.ErrCeremonyInvalid,
+		"ErrAssertionRejected": hubwebauthn.ErrAssertionRejected,
+		"ErrNoPasskeys":        hubwebauthn.ErrNoPasskeys,
+		"ErrOriginNotAllowed":  hubwebauthn.ErrOriginNotAllowed,
+	}
+
+	for name, err := range classified {
+		assert.NotEqualf(t, webAuthnErrorInfrastructure, classifyWebAuthnError(err),
+			"%s falls to the infrastructure default, so every surface answers it with a 500", name)
+	}
+
+	// The declarations the package actually exports.
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	src, err := os.ReadFile(filepath.Join(filepath.Dir(thisFile), "..", "webauthn", "service.go"))
+	require.NoError(t, err, "the sentinel declarations must stay findable")
+
+	declared := regexp.MustCompile(`(?m)^var (Err\w+) = errors\.New\(`).FindAllStringSubmatch(string(src), -1)
+	require.NotEmpty(t, declared, "the scan found no sentinels, so it proves nothing")
+	for _, m := range declared {
+		assert.Containsf(t, classified, m[1],
+			"webauthn.%s is exported but not classified: it would answer CodeInternal on every passkey surface", m[1])
+	}
+}

--- a/backend/internal/hub/service/revoke_lifecycle_test.go
+++ b/backend/internal/hub/service/revoke_lifecycle_test.go
@@ -69,7 +69,7 @@ func TestAdminUserService_RevokeSessionClosesThatSessionsChannels(t *testing.T) 
 	sessions, err := env.st.Sessions().ListByUserID(ctx, store.ListUserSessionsParams{
 		UserID:     userid.MustNew(userID),
 		PageParams: store.PageParams{Limit: 10},
-	})
+	}, time.Now().UTC())
 	require.NoError(t, err)
 	assert.Empty(t, sessions.Rows)
 }

--- a/backend/internal/hub/service/test_helpers_test.go
+++ b/backend/internal/hub/service/test_helpers_test.go
@@ -54,13 +54,11 @@ func seedSMTP(t *testing.T, set *settings.Manager) {
 		`{"host":"smtp.example.test","port":587,"from_address":"hub@example.test","tls_mode":"starttls"}`)))
 }
 
-// enableEmailVerification turns the verification gate on. The gate reads
-// the setting as EFFECTIVE (verification requires a working SMTP relay),
-// so the seed configures both.
+// enableEmailVerification turns the verification gate on by configuring SMTP.
+// EmailVerificationEffective follows SMTP.Enabled() only.
 func enableEmailVerification(t *testing.T, set *settings.Manager) {
 	t.Helper()
 	seedSMTP(t, set)
-	require.NoError(t, settings.KeyEmailVerificationRequired.Set(context.Background(), set, true))
 }
 
 // setSessionDuration stamps every session a service mints with the given

--- a/backend/internal/hub/service/user_service.go
+++ b/backend/internal/hub/service/user_service.go
@@ -166,9 +166,17 @@ func (s *UserService) RequestEmailChange(ctx context.Context, req *connect.Reque
 	}
 
 	// Non-admin, verification required: set pending email and dispatch
-	// the verification mail. On send failure the helper rolls back the
-	// row so the user can retry from a clean slate.
-	if err := issuePendingEmailVerificationOrRollback(ctx, s.store, s.mail, s.renderer, user.ID, newEmail); err != nil {
+	// the verification mail. On send failure the helper drops the
+	// undelivered code and keeps the pending address, so Resend retries
+	// the same change.
+	if err := issuePendingEmailVerificationOrFail(ctx, s.store, s.mail, s.renderer, user.ID, newEmail); err != nil {
+		// The conditional mint refuses inside the cooldown, which is the
+		// one thing that stops this RPC from being an open relay: the
+		// address is caller-supplied, so an unconditional mint sends a
+		// message per request to any address the caller names.
+		if errors.Is(err, ErrVerificationCooldown) {
+			return nil, connect.NewError(connect.CodeResourceExhausted, err)
+		}
 		return nil, connect.NewError(connect.CodeUnavailable, err)
 	}
 
@@ -225,13 +233,9 @@ func (s *UserService) ResendVerificationEmail(ctx context.Context, _ *connect.Re
 		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("no pending email change"))
 	}
 
-	// Refuse if the previous code was issued less than the cooldown ago.
-	if full.PendingEmail != "" && full.PendingEmailExpiresAt != nil {
-		issuedAt := full.PendingEmailExpiresAt.Add(-pendingEmailExpiry)
-		if time.Since(issuedAt) < resendVerificationCooldown {
-			return nil, connect.NewError(connect.CodeResourceExhausted, fmt.Errorf("please wait before requesting another verification email"))
-		}
-	}
+	// The cooldown lives in the conditional mint inside
+	// issuePendingEmailVerification, not in a read-then-check here: two
+	// concurrent resends both passed a Go check and both sent.
 
 	sent, err := issuePendingEmailVerification(ctx, s.store, s.mail, s.renderer, full.ID, targetEmail)
 	if err != nil {
@@ -323,7 +327,7 @@ func (s *UserService) ChangePassword(ctx context.Context, req *connect.Request[l
 		committedAuthGeneration = gen
 		return nil
 	}); err != nil {
-		return nil, mapPasskeyConnectError(err)
+		return nil, mapPasskeyConnectError(ctx, err)
 	}
 
 	// The acting session survives at the new generation

--- a/backend/internal/hub/service/user_service.go
+++ b/backend/internal/hub/service/user_service.go
@@ -11,12 +11,14 @@ import (
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/hub/auth"
 	"github.com/leapmux/leapmux/internal/hub/config"
+	"github.com/leapmux/leapmux/internal/hub/keystore"
 	"github.com/leapmux/leapmux/internal/hub/mail"
 	"github.com/leapmux/leapmux/internal/hub/password"
 	"github.com/leapmux/leapmux/internal/hub/settings"
 	"github.com/leapmux/leapmux/internal/hub/store"
 	"github.com/leapmux/leapmux/internal/hub/usersettings"
 	"github.com/leapmux/leapmux/util/validate"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // UserService implements the leapmux.v1.UserService ConnectRPC handler.
@@ -27,16 +29,18 @@ type UserService struct {
 	lifecycle *auth.CredentialLifecycleEffects
 	mail      mail.Sender
 	renderer  mail.Renderer
+	keystore  *keystore.Keystore
 }
 
 // NewUserService creates a new UserService. renderer carries the hub's
 // public URL used to build absolute deep-links in the verification
-// emails sent on email-change and resend.
-func NewUserService(st store.Store, cfg *config.Config, set *settings.Manager, lifecycle *auth.CredentialLifecycleEffects, sender mail.Sender, renderer mail.Renderer) *UserService {
+// emails sent on email-change and resend. ks encrypts passkey material;
+// pass nil only in tests that do not exercise passkey RPCs.
+func NewUserService(st store.Store, cfg *config.Config, set *settings.Manager, lifecycle *auth.CredentialLifecycleEffects, sender mail.Sender, renderer mail.Renderer, ks *keystore.Keystore) *UserService {
 	if lifecycle == nil {
 		panic("user service requires credential lifecycle effects")
 	}
-	return &UserService{store: st, cfg: cfg, set: set, lifecycle: lifecycle, mail: sender, renderer: renderer}
+	return &UserService{store: st, cfg: cfg, set: set, lifecycle: lifecycle, mail: sender, renderer: renderer, keystore: ks}
 }
 
 func (s *UserService) UpdateProfile(ctx context.Context, req *connect.Request[leapmuxv1.UpdateProfileRequest]) (*connect.Response[leapmuxv1.UpdateProfileResponse], error) {
@@ -181,6 +185,20 @@ func (s *UserService) RequestEmailChange(ctx context.Context, req *connect.Reque
 // is just expires_at - pendingEmailExpiry.
 const resendVerificationCooldown = 60 * time.Second
 
+// issuedAtFromExpiry reconstructs when a pending token was issued from the
+// expiry it set and the constant TTL used to mint it. SetPendingEmail and
+// SetPendingPasswordReset store no issued-at, so every cooldown derivation
+// goes through here: one spelling of the expiry-minus-TTL trick, paired
+// with the cooldown constant below.
+func issuedAtFromExpiry(expiresAt time.Time, ttl time.Duration) time.Time {
+	return expiresAt.Add(-ttl)
+}
+
+// nextResendAt seeds the next-resend timestamp a successful send returns.
+func nextResendAt(issuedAt time.Time) time.Time {
+	return issuedAt.Add(resendVerificationCooldown)
+}
+
 // ResendVerificationEmail re-issues the verification mail for the
 // session user's pending email. It's authenticated and restricted to users
 // who actually have a pending row — there's nothing to re-send
@@ -196,28 +214,40 @@ func (s *UserService) ResendVerificationEmail(ctx context.Context, _ *connect.Re
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
-	if full.PendingEmail == "" {
+
+	targetEmail := full.PendingEmail
+	if targetEmail == "" && full.Email != "" && !full.EmailVerified && settings.EmailVerificationEffective(s.set.Snapshot(ctx)) {
+		// SMTP was enabled after signup without verification: the user has a
+		// primary email but never received a pending row. Seed one now.
+		targetEmail = full.Email
+	}
+	if targetEmail == "" {
 		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("no pending email change"))
 	}
 
 	// Refuse if the previous code was issued less than the cooldown ago.
-	// The TTL is constant, so the "issued at" time can be reconstructed
-	// from expires_at. A nil expires_at means no live row to throttle
-	// against — fall through.
-	if full.PendingEmailExpiresAt != nil {
+	if full.PendingEmail != "" && full.PendingEmailExpiresAt != nil {
 		issuedAt := full.PendingEmailExpiresAt.Add(-pendingEmailExpiry)
 		if time.Since(issuedAt) < resendVerificationCooldown {
 			return nil, connect.NewError(connect.CodeResourceExhausted, fmt.Errorf("please wait before requesting another verification email"))
 		}
 	}
 
-	sent, err := issuePendingEmailVerification(ctx, s.store, s.mail, s.renderer, full.ID, full.PendingEmail)
+	sent, err := issuePendingEmailVerification(ctx, s.store, s.mail, s.renderer, full.ID, targetEmail)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		// A claimed address surfaces as AlreadyExists, not Internal: the
+		// user can act on "email already in use", and the transport error
+		// chain stays out of the response.
+		return nil, AvailabilityConnectError(err)
 	}
-	return connect.NewResponse(&leapmuxv1.ResendVerificationEmailResponse{
-		EmailSent: sent,
-	}), nil
+	// Advertise a cooldown only after a successful send: a failed send
+	// leaves no live code, so blocking the retry the failure message
+	// invites would contradict the response.
+	resp := &leapmuxv1.ResendVerificationEmailResponse{EmailSent: sent}
+	if sent {
+		resp.NextResendAvailableAt = timestamppb.New(nextResendAt(time.Now().UTC()))
+	}
+	return connect.NewResponse(resp), nil
 }
 
 // VerifyEmail handles both signup verification and email-change verification.
@@ -241,8 +271,10 @@ func (s *UserService) VerifyEmail(ctx context.Context, req *connect.Request[leap
 	// that hit /verify-email.
 	s.lifecycle.UserInfoInvalidated(userInfo.ID.String())
 
+	userProto := userToProtoWithPasskeys(ctx, s.store, updatedUser)
+
 	return connect.NewResponse(&leapmuxv1.VerifyEmailResponse{
-		User: userToProto(updatedUser),
+		User: userProto,
 	}), nil
 }
 
@@ -259,95 +291,48 @@ func (s *UserService) ChangePassword(ctx context.Context, req *connect.Request[l
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 
-	hashed, err := password.Hash(req.Msg.GetNewPassword())
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("hash password: %w", err))
-	}
-
-	var user *store.User
-	var committedAuthGeneration int64
-	if err := s.store.RunInUserAuthTransaction(ctx, userInfo.ID, func(tx store.Store) error {
-		var err error
-		user, err = tx.Users().GetByID(ctx, userInfo.ID.String())
+	// The step-up credential is verified, the new password hashed, and the
+	// write committed through runPasskeyManagementTx: admission runs outside
+	// the user-auth transaction (Argon2 must not hold the database writer
+	// lock), the locked row is re-checked before it writes, and the reauth
+	// proof is consumed inside the transaction after the write. An
+	// identity-less shell (no password, no passkeys, no verified email, no
+	// OAuth link) may not attach a first password with the session alone --
+	// the same rule the first-passkey path enforces.
+	var hashed string
+	prepare := func(*store.User) error {
+		h, err := password.Hash(req.Msg.GetNewPassword())
 		if err != nil {
-			return fmt.Errorf("query user: %w", err)
+			return connect.NewError(connect.CodeInternal, fmt.Errorf("hash password: %w", err))
 		}
-		// OAuth-only users can set a password without a current one. For
-		// password users, verify while holding the same auth-state lock used
-		// by login so the checked hash cannot change before commit.
-		if user.PasswordSet {
-			match, err := password.Verify(user.PasswordHash, req.Msg.GetCurrentPassword())
-			if err != nil {
-				return connect.NewError(connect.CodeInternal, fmt.Errorf("verify password: %w", err))
-			}
-			if !match {
-				return connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("%w", auth.ErrInvalidCurrentPassword))
-			}
-		}
+		hashed = h
+		return nil
+	}
+	var committedAuthGeneration int64
+	if err := s.runPasskeyManagementTx(ctx, userInfo, req.Msg.GetCurrentPassword(), req.Msg.GetReauthProof(), prepare, func(tx store.Store, user *store.User) error {
 		if err := tx.Users().UpdatePassword(ctx, store.UpdateUserPasswordParams{
 			PasswordHash: hashed,
 			ID:           user.ID,
 		}); err != nil {
 			return fmt.Errorf("update password: %w", err)
 		}
-		sessionID := userInfo.Credential.SessionID()
-		rowUID, mintErr := mintRowUserID(user.ID)
-		if mintErr != nil {
-			return mintErr
-		}
-		if err := tx.Sessions().DeleteOthers(ctx, store.DeleteOtherSessionsParams{
-			UserID: rowUID,
-			KeepID: sessionID,
-		}); err != nil {
-			return fmt.Errorf("delete other sessions: %w", err)
-		}
-		if _, _, err := auth.RevokeAllUserCredentials(ctx, tx, rowUID); err != nil {
+		gen, err := s.revokeOtherCredentialsPreservingSession(ctx, tx, user.ID, userInfo.Credential.SessionID())
+		if err != nil {
 			return err
 		}
-		if sessionID != "" {
-			n, err := tx.Sessions().RefreshAuthGeneration(ctx, store.RefreshSessionAuthGenerationParams{
-				SessionID: sessionID,
-				UserID:    rowUID,
-			})
-			if err != nil {
-				return fmt.Errorf("refresh current session auth generation: %w", err)
-			}
-			// n==0 means the acting session was concurrently deleted (a
-			// same-user logout / admin force-logout does not contend on this
-			// user-auth lock) after the tx began. The password change itself is
-			// valid and there is no surviving session row left to restamp, so do
-			// not roll the whole change back. The post-tx restamp is a true no-op
-			// for a same-process logout (which already tore down this Hub's
-			// in-memory leases/channels for the session); if the logout happened
-			// on another Hub, this Hub may still hold the deleted session's
-			// in-memory holders until the durable session-revoked event replays,
-			// and the restamp briefly re-stamps those before the following
-			// UserRevoked and the replayed SessionRevoked tear them down -- benign
-			// and self-healing. n>1 is impossible (session id is unique) and
-			// indicates corruption, so it stays fatal.
-			if n > 1 {
-				return fmt.Errorf("refresh current session auth generation: updated %d rows", n)
-			}
-		}
-		updatedUser, err := tx.Users().GetByID(ctx, user.ID)
-		if err != nil {
-			return fmt.Errorf("query updated user auth generation: %w", err)
-		}
-		committedAuthGeneration = updatedUser.AuthGeneration
+		committedAuthGeneration = gen
 		return nil
 	}); err != nil {
-		var connectErr *connect.Error
-		if errors.As(err, &connectErr) {
-			return nil, connectErr
-		}
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, mapPasskeyConnectError(err)
 	}
 
-	// The acting session survives at the new generation (RefreshAuthGeneration
-	// above), so re-stamp both its leases and its channels to that generation
-	// before the user-wide revocation below -- which cancels older-generation
-	// leases and closes older-generation channels -- would otherwise tear down
-	// the surviving session's own live WebSocket connections and channels.
+	// The acting session survives at the new generation
+	// (revokeOtherCredentialsPreservingSession restamped it inside the
+	// transaction), so re-stamp both its leases and its channels to that
+	// generation before the user-wide revocation below -- which cancels
+	// older-generation leases and closes older-generation channels -- would
+	// otherwise tear down the surviving session's own live WebSocket
+	// connections and channels.
 	//
 	// This restamp-before-revoke ordering is enforced only on the in-process
 	// path. The same-process revocation watcher independently replays the durable
@@ -358,12 +343,7 @@ func (s *UserService) ChangePassword(ctx context.Context, req *connect.Request[l
 	// generation, so the client reconnects with its still-valid cookie and
 	// rebuilds its context: a spurious transient disconnect, never a lost
 	// revocation or a forced logout.
-	// Restamp the acting session (empty SessionID for a non-cookie caller, which
-	// then only revokes) before evicting every credential older than the committed
-	// generation; RevokeUserPreservingSession enforces that preserve-before-revoke
-	// ordering in one call. A concurrent login committed afterward already belongs
-	// to this generation and survives.
-	s.lifecycle.RevokeUserPreservingSession(user.ID, userInfo.Credential.SessionID(), committedAuthGeneration)
+	s.lifecycle.RevokeUserPreservingSession(userInfo.ID.String(), userInfo.Credential.SessionID(), committedAuthGeneration)
 
 	return connect.NewResponse(&leapmuxv1.ChangePasswordResponse{}), nil
 }
@@ -404,9 +384,17 @@ func (s *UserService) UnlinkOAuthProvider(ctx context.Context, req *connect.Requ
 		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("no linked account for provider %q", providerID))
 	}
 
-	// Guard: cannot unlink the last provider if the user has no password set.
+	// Guard: cannot unlink the last provider when the user has no other
+	// login method. A passkey is a login method like a password, so it
+	// keeps the unlink allowed.
 	if len(links) <= 1 && !user.PasswordSet {
-		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("cannot unlink your only login method; set a password first"))
+		passkeys, err := s.store.PasskeyCredentials().CountByUser(ctx, user.ID)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+		if passkeys == 0 {
+			return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("cannot unlink your only login method; set a password first"))
+		}
 	}
 
 	unlinkUID, mintErr := mintRowUserID(user.ID)

--- a/backend/internal/hub/service/user_service_test.go
+++ b/backend/internal/hub/service/user_service_test.go
@@ -3,6 +3,7 @@ package service_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -21,10 +22,13 @@ import (
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/generated/proto/leapmux/v1/leapmuxv1connect"
 	"github.com/leapmux/leapmux/internal/hub/auth"
+	"github.com/leapmux/leapmux/internal/hub/keystore"
 	"github.com/leapmux/leapmux/internal/hub/mail"
+	hubwebauthn "github.com/leapmux/leapmux/internal/hub/webauthn"
 
 	"github.com/leapmux/leapmux/internal/hub/service"
 	"github.com/leapmux/leapmux/internal/hub/servicetest"
+	"github.com/leapmux/leapmux/internal/hub/settings"
 	"github.com/leapmux/leapmux/internal/hub/store"
 	"github.com/leapmux/leapmux/internal/hub/store/sqlite"
 	hubtestutil "github.com/leapmux/leapmux/internal/hub/testutil"
@@ -54,7 +58,15 @@ func setupUserTest(t *testing.T) *userTestEnv {
 	mux := http.NewServeMux()
 	interceptor, contexts := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st})
 	t.Cleanup(contexts.Stop)
-	userSvc := service.NewUserService(st, testConfig(), servicetest.NewSettingsManager(t, st, nil), auth.NewCredentialLifecycleEffects(contexts, nil, nil), mail.NewStubSender(), mail.Renderer{})
+	ksKey, kErr := keystore.GenerateKey()
+	require.NoError(t, kErr)
+	ks, kErr := keystore.New(map[uint32][32]byte{1: ksKey})
+	require.NoError(t, kErr)
+	set := servicetest.NewSettingsManager(t, st, nil)
+	// Passkeys need a hub URL; ListPasskeys reports availability through
+	// the same derivation the handlers use.
+	require.NoError(t, settings.KeyPublicURL.Set(context.Background(), set, "http://localhost:4327"))
+	userSvc := service.NewUserService(st, testConfig(), set, auth.NewCredentialLifecycleEffects(contexts, nil, nil), mail.NewStubSender(), mail.Renderer{}, ks)
 	opts := connect.WithInterceptors(interceptor)
 	path, handler := leapmuxv1connect.NewUserServiceHandler(userSvc, opts)
 	mux.Handle(path, handler)
@@ -104,7 +116,7 @@ func setupOAuthUserTest(t *testing.T) *userTestEnv {
 	err = st.Migrator().Migrate(context.Background())
 	require.NoError(t, err)
 
-	userSvc := service.NewUserService(st, testConfig(), servicetest.NewSettingsManager(t, st, nil), auth.NewCredentialLifecycleEffects(nil, nil, nil), mail.NewStubSender(), mail.Renderer{})
+	userSvc := service.NewUserService(st, testConfig(), servicetest.NewSettingsManager(t, st, nil), auth.NewCredentialLifecycleEffects(nil, nil, nil), mail.NewStubSender(), mail.Renderer{}, nil)
 
 	mux := http.NewServeMux()
 	interceptor, contexts := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st})
@@ -125,18 +137,20 @@ func setupOAuthUserTest(t *testing.T) *userTestEnv {
 	)
 
 	userID := id.Generate()
-	hash, _ := password.Hash("testpass")
 
 	_ = st.Users().Create(context.Background(), store.CreateUserParams{
-		ID:           userID,
-		Username:     "testuser",
-		PasswordHash: hash,
-		DisplayName:  "Test User",
-		PasswordSet:  false,
-		IsAdmin:      true,
+		ID:            userID,
+		Username:      "testuser",
+		PasswordHash:  password.PlaceholderHash,
+		DisplayName:   "Test User",
+		Email:         "testuser@example.com",
+		EmailVerified: true,
+		PasswordSet:   false,
+		IsAdmin:       true,
 	})
 
-	token, _, _, err := auth.Login(context.Background(), st, "testuser", "testpass", auth.DefaultSessionDuration)
+	// PasswordSet is false, so password Login refuses. Mint a session directly.
+	token, _, err := auth.CreateSession(context.Background(), st, userid.MustNew(userID), auth.DefaultSessionDuration)
 	require.NoError(t, err)
 
 	return &userTestEnv{
@@ -634,8 +648,8 @@ func TestRequestEmailChange_DuplicateEmail_Rejected(t *testing.T) {
 // --- RequestEmailChange: config on, pending email ---
 
 // setupVerificationUserTestServer creates a test server with the given
-// EmailVerificationRequired setting and both UserService and AuthService
-// registered. The interceptor and the services read the gate from the
+// Email verification is controlled by SMTP (EmailVerificationEffective). Both UserService and AuthService
+// registered. The interceptor and the services read the rule from the
 // same settings. It returns a UserService client, st, and the admin token.
 func setupVerificationUserTestServer(t *testing.T, emailVerificationRequired bool) (leapmuxv1connect.UserServiceClient, store.Store, string) {
 	t.Helper()
@@ -659,7 +673,7 @@ func setupVerificationUserTestServer(t *testing.T, emailVerificationRequired boo
 	t.Cleanup(contexts.Stop)
 	opts := connect.WithInterceptors(interceptor)
 
-	userSvc := service.NewUserService(st, testConfig(), set, auth.NewCredentialLifecycleEffects(nil, nil, nil), mail.NewStubSender(), mail.Renderer{})
+	userSvc := service.NewUserService(st, testConfig(), set, auth.NewCredentialLifecycleEffects(nil, nil, nil), mail.NewStubSender(), mail.Renderer{}, nil)
 	userPath, userHandler := leapmuxv1connect.NewUserServiceHandler(userSvc, opts)
 	mux.Handle(userPath, userHandler)
 
@@ -918,7 +932,7 @@ func setupResendUserTest(t *testing.T) (*userTestEnv, *recordingSender) {
 	require.NoError(t, st.Migrator().Migrate(context.Background()))
 
 	rec := &recordingSender{}
-	userSvc := service.NewUserService(st, testConfig(), servicetest.NewSettingsManager(t, st, nil), auth.NewCredentialLifecycleEffects(nil, nil, nil), rec, mail.Renderer{})
+	userSvc := service.NewUserService(st, testConfig(), servicetest.NewSettingsManager(t, st, nil), auth.NewCredentialLifecycleEffects(nil, nil, nil), rec, mail.Renderer{}, nil)
 
 	mux := http.NewServeMux()
 	interceptor, contexts := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st})
@@ -1198,7 +1212,7 @@ func TestChangePassword_ToleratesConcurrentActingSessionDeletion(t *testing.T) {
 	mux := http.NewServeMux()
 	interceptor, contexts := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st})
 	t.Cleanup(contexts.Stop)
-	userSvc := service.NewUserService(hooked, testConfig(), servicetest.NewSettingsManager(t, hooked, nil), auth.NewCredentialLifecycleEffects(contexts, nil, nil), mail.NewStubSender(), mail.Renderer{})
+	userSvc := service.NewUserService(hooked, testConfig(), servicetest.NewSettingsManager(t, hooked, nil), auth.NewCredentialLifecycleEffects(contexts, nil, nil), mail.NewStubSender(), mail.Renderer{}, nil)
 	path, handler := leapmuxv1connect.NewUserServiceHandler(userSvc, connect.WithInterceptors(interceptor))
 	mux.Handle(path, handler)
 	server := httptest.NewUnstartedServer(mux)
@@ -1267,6 +1281,33 @@ func TestChangePassword_PasswordUser_RequiresCurrentPassword(t *testing.T) {
 	}, env.token))
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+}
+
+func TestChangePassword_PasskeyOnly_RequiresReauthProof(t *testing.T) {
+	t.Parallel()
+
+	env := setupOAuthUserTest(t)
+	seedPasskeyCredential(t, env.store, env.userID, "Phone")
+
+	_, err := env.client.ChangePassword(context.Background(), authedReq(&leapmuxv1.ChangePasswordRequest{
+		NewPassword: "newpass123",
+	}, env.token))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+
+	proof := seedReauthProof(t, env.store, env.userID)
+	_, err = env.client.ChangePassword(context.Background(), authedReq(&leapmuxv1.ChangePasswordRequest{
+		NewPassword: "newpass123",
+		ReauthProof: proof,
+	}, env.token))
+	require.NoError(t, err)
+
+	user, err := env.store.Users().GetByID(context.Background(), env.userID)
+	require.NoError(t, err)
+	assert.True(t, user.PasswordSet)
+
+	_, _, _, err = auth.Login(context.Background(), env.store, "testuser", "newpass123", auth.DefaultSessionDuration)
+	require.NoError(t, err)
 }
 
 // --- UnlinkOAuthProvider tests ---
@@ -1377,4 +1418,666 @@ func TestUnlinkOAuthProvider_NotFound(t *testing.T) {
 	}, env.token))
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+}
+
+// --- Passkey management ---
+
+func seedPasskeyCredential(t *testing.T, st store.Store, userID, friendlyName string) string {
+	t.Helper()
+	pkID := id.Generate()
+	now := time.Now().UTC()
+	require.NoError(t, st.PasskeyCredentials().Create(context.Background(), store.CreatePasskeyCredentialParams{
+		ID:           pkID,
+		UserID:       userID,
+		CredentialID: []byte("cred-" + pkID),
+		PublicKey:    []byte("pubkey"),
+		SignCount:    0,
+		Transports:   "[]",
+		FriendlyName: friendlyName,
+		KeyVersion:   1,
+		CreatedAt:    now,
+	}))
+	return pkID
+}
+
+func seedReauthProof(t *testing.T, st store.Store, userID string) string {
+	t.Helper()
+	proofID := id.Generate()
+	now := time.Now().UTC()
+	require.NoError(t, st.WebAuthnSessions().Create(context.Background(), store.CreateWebAuthnSessionParams{
+		ID:          proofID,
+		Kind:        "reauth_proof",
+		UserID:      userID,
+		PayloadJSON: "{}",
+		SessionData: []byte("dummy"),
+		ExpiresAt:   now.Add(5 * time.Minute),
+		CreatedAt:   now,
+	}))
+	return proofID
+}
+
+func TestUserService_ListPasskeys(t *testing.T) {
+	t.Parallel()
+
+	env := setupUserTest(t)
+	seedPasskeyCredential(t, env.store, env.userID, "Laptop")
+	seedPasskeyCredential(t, env.store, env.userID, "Phone")
+
+	resp, err := env.client.ListPasskeys(context.Background(), authedReq(&leapmuxv1.ListPasskeysRequest{}, env.token))
+	require.NoError(t, err)
+	require.Len(t, resp.Msg.GetPasskeys(), 2)
+	names := map[string]struct{}{}
+	for _, pk := range resp.Msg.GetPasskeys() {
+		names[pk.GetFriendlyName()] = struct{}{}
+	}
+	assert.Contains(t, names, "Laptop")
+	assert.Contains(t, names, "Phone")
+}
+
+func TestUserService_RenamePasskey(t *testing.T) {
+	t.Parallel()
+
+	env := setupUserTest(t)
+	pkID := seedPasskeyCredential(t, env.store, env.userID, "Old Name")
+
+	resp, err := env.client.RenamePasskey(context.Background(), authedReq(&leapmuxv1.RenamePasskeyRequest{
+		Id:              pkID,
+		FriendlyName:    "New Name",
+		CurrentPassword: "testpass",
+	}, env.token))
+	require.NoError(t, err)
+	assert.Equal(t, "New Name", resp.Msg.GetPasskey().GetFriendlyName())
+
+	row, err := env.store.PasskeyCredentials().GetByID(context.Background(), pkID)
+	require.NoError(t, err)
+	assert.Equal(t, "New Name", row.FriendlyName)
+}
+
+func TestUserService_RenamePasskey_RequiresPassword(t *testing.T) {
+	t.Parallel()
+
+	env := setupUserTest(t)
+	pkID := seedPasskeyCredential(t, env.store, env.userID, "Old Name")
+
+	_, err := env.client.RenamePasskey(context.Background(), authedReq(&leapmuxv1.RenamePasskeyRequest{
+		Id:           pkID,
+		FriendlyName: "New Name",
+	}, env.token))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+}
+
+func TestUserService_RenamePasskey_WithReauthProof(t *testing.T) {
+	t.Parallel()
+
+	env := setupOAuthUserTest(t)
+	pkID := seedPasskeyCredential(t, env.store, env.userID, "Old Name")
+	proof := seedReauthProof(t, env.store, env.userID)
+
+	resp, err := env.client.RenamePasskey(context.Background(), authedReq(&leapmuxv1.RenamePasskeyRequest{
+		Id:           pkID,
+		FriendlyName: "New Name",
+		ReauthProof:  proof,
+	}, env.token))
+	require.NoError(t, err)
+	assert.Equal(t, "New Name", resp.Msg.GetPasskey().GetFriendlyName())
+
+	_, err = env.store.WebAuthnSessions().Get(context.Background(), proof)
+	assert.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestUserService_DeletePasskey_WithPassword(t *testing.T) {
+	t.Parallel()
+
+	env := setupUserTest(t)
+	pkID := seedPasskeyCredential(t, env.store, env.userID, "To Delete")
+
+	_, err := env.client.DeletePasskey(context.Background(), authedReq(&leapmuxv1.DeletePasskeyRequest{
+		Id:              pkID,
+		CurrentPassword: "testpass",
+	}, env.token))
+	require.NoError(t, err)
+
+	_, err = env.store.PasskeyCredentials().GetByID(context.Background(), pkID)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, store.ErrNotFound))
+}
+
+func TestUserService_DeletePasskey_WithReauthProof(t *testing.T) {
+	t.Parallel()
+
+	env := setupOAuthUserTest(t)
+	pk1 := seedPasskeyCredential(t, env.store, env.userID, "Keep")
+	pk2 := seedPasskeyCredential(t, env.store, env.userID, "Remove")
+	proof := seedReauthProof(t, env.store, env.userID)
+
+	_, err := env.client.DeletePasskey(context.Background(), authedReq(&leapmuxv1.DeletePasskeyRequest{
+		Id:          pk2,
+		ReauthProof: proof,
+	}, env.token))
+	require.NoError(t, err)
+
+	_, err = env.store.PasskeyCredentials().GetByID(context.Background(), pk2)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, store.ErrNotFound))
+
+	_, err = env.store.PasskeyCredentials().GetByID(context.Background(), pk1)
+	require.NoError(t, err)
+}
+
+func TestUserService_DeletePasskey_LastPasskeyRejected(t *testing.T) {
+	t.Parallel()
+
+	env := setupOAuthUserTest(t)
+	pkID := seedPasskeyCredential(t, env.store, env.userID, "Only One")
+	proof := seedReauthProof(t, env.store, env.userID)
+
+	_, err := env.client.DeletePasskey(context.Background(), authedReq(&leapmuxv1.DeletePasskeyRequest{
+		Id:          pkID,
+		ReauthProof: proof,
+	}, env.token))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+	assert.Contains(t, err.Error(), "new_password")
+
+	_, err = env.store.PasskeyCredentials().GetByID(context.Background(), pkID)
+	require.NoError(t, err)
+
+	// Rejection must not consume the reauth proof.
+	_, err = env.store.WebAuthnSessions().Get(context.Background(), proof)
+	require.NoError(t, err)
+}
+
+func TestUserService_DeletePasskey_LastPasskeyWithNewPassword_Deactivates(t *testing.T) {
+	t.Parallel()
+
+	env := setupOAuthUserTest(t)
+	pkID := seedPasskeyCredential(t, env.store, env.userID, "Only One")
+	proof := seedReauthProof(t, env.store, env.userID)
+
+	otherSession, _, err := auth.CreateSession(context.Background(), env.store, userid.MustNew(env.userID), auth.DefaultSessionDuration)
+	require.NoError(t, err)
+
+	_, err = env.client.DeletePasskey(context.Background(), authedReq(&leapmuxv1.DeletePasskeyRequest{
+		Id:          pkID,
+		ReauthProof: proof,
+		NewPassword: "newpass123",
+	}, env.token))
+	require.NoError(t, err)
+
+	user, err := env.store.Users().GetByID(context.Background(), env.userID)
+	require.NoError(t, err)
+	assert.True(t, user.PasswordSet)
+
+	rows, err := env.store.PasskeyCredentials().ListByUser(context.Background(), env.userID)
+	require.NoError(t, err)
+	assert.Empty(t, rows)
+
+	_, _, _, err = auth.Login(context.Background(), env.store, "testuser", "newpass123", auth.DefaultSessionDuration)
+	require.NoError(t, err)
+
+	_, err = auth.ValidateToken(context.Background(), env.store, env.token)
+	assert.NoError(t, err, "acting session must survive")
+	_, err = auth.ValidateToken(context.Background(), env.store, otherSession)
+	assert.Error(t, err, "other sessions must be revoked after passkey-only deactivation")
+}
+
+func TestUserService_DeactivatePasskeyAuth_WithPassword(t *testing.T) {
+	t.Parallel()
+
+	env := setupUserTest(t)
+	seedPasskeyCredential(t, env.store, env.userID, "One")
+	seedPasskeyCredential(t, env.store, env.userID, "Two")
+
+	_, err := env.client.DeactivatePasskeyAuth(context.Background(), authedReq(&leapmuxv1.DeactivatePasskeyAuthRequest{
+		CurrentPassword: "testpass",
+	}, env.token))
+	require.NoError(t, err)
+
+	rows, err := env.store.PasskeyCredentials().ListByUser(context.Background(), env.userID)
+	require.NoError(t, err)
+	assert.Empty(t, rows)
+}
+
+func TestUserService_DeactivatePasskeyAuth_WithReauthAndNewPassword(t *testing.T) {
+	t.Parallel()
+
+	env := setupOAuthUserTest(t)
+	seedPasskeyCredential(t, env.store, env.userID, "Only")
+	proof := seedReauthProof(t, env.store, env.userID)
+
+	_, err := env.client.DeactivatePasskeyAuth(context.Background(), authedReq(&leapmuxv1.DeactivatePasskeyAuthRequest{
+		ReauthProof: proof,
+		NewPassword: "newpass123",
+	}, env.token))
+	require.NoError(t, err)
+
+	user, err := env.store.Users().GetByID(context.Background(), env.userID)
+	require.NoError(t, err)
+	assert.True(t, user.PasswordSet)
+
+	rows, err := env.store.PasskeyCredentials().ListByUser(context.Background(), env.userID)
+	require.NoError(t, err)
+	assert.Empty(t, rows)
+
+	_, _, _, err = auth.Login(context.Background(), env.store, "testuser", "newpass123", auth.DefaultSessionDuration)
+	require.NoError(t, err)
+}
+
+func TestUserService_DeactivatePasskeyAuth_InvalidatesOtherSessions(t *testing.T) {
+	t.Parallel()
+
+	env := setupOAuthUserTest(t)
+	seedPasskeyCredential(t, env.store, env.userID, "Only")
+	proof := seedReauthProof(t, env.store, env.userID)
+
+	otherSession, _, err := auth.CreateSession(context.Background(), env.store, userid.MustNew(env.userID), auth.DefaultSessionDuration)
+	require.NoError(t, err)
+
+	_, err = env.client.DeactivatePasskeyAuth(context.Background(), authedReq(&leapmuxv1.DeactivatePasskeyAuthRequest{
+		ReauthProof: proof,
+		NewPassword: "newpass123",
+	}, env.token))
+	require.NoError(t, err)
+
+	_, err = auth.ValidateToken(context.Background(), env.store, env.token)
+	assert.NoError(t, err, "acting session must survive")
+	_, err = auth.ValidateToken(context.Background(), env.store, otherSession)
+	assert.Error(t, err, "other sessions must be revoked")
+}
+
+func TestVerifyEmail_IncludesPasskeyCount(t *testing.T) {
+	t.Parallel()
+
+	env := setupUserTest(t)
+	seedPasskeyCredential(t, env.store, env.userID, "One")
+	seedPasskeyCredential(t, env.store, env.userID, "Two")
+
+	verifyToken := verifycode.Generate()
+	require.NoError(t, env.store.Users().SetPendingEmail(context.Background(), store.SetPendingEmailParams{
+		PendingEmail:          "counted@example.com",
+		PendingEmailToken:     verifyToken,
+		PendingEmailExpiresAt: ptrTime(time.Now().Add(1 * time.Hour).UTC()),
+		ID:                    env.userID,
+	}))
+
+	resp, err := env.client.VerifyEmail(context.Background(), authedReq(&leapmuxv1.VerifyEmailRequest{
+		VerificationToken: verifycode.Format(verifyToken),
+	}, env.token))
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), resp.Msg.GetUser().GetPasskeyCount())
+}
+
+func TestResendVerificationEmail_SMTPEnableTransition(t *testing.T) {
+	t.Parallel()
+
+	st, err := sqlite.Open(":memory:", sqlitedb.Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+	require.NoError(t, st.Migrator().Migrate(context.Background()))
+
+	set := servicetest.NewSettingsManager(t, st, nil)
+	seedSMTP(t, set)
+
+	rec := &recordingSender{}
+	userSvc := service.NewUserService(st, testConfig(), set, auth.NewCredentialLifecycleEffects(nil, nil, nil), rec, mail.Renderer{}, nil)
+
+	mux := http.NewServeMux()
+	interceptor, contexts := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st})
+	t.Cleanup(contexts.Stop)
+	path, handler := leapmuxv1connect.NewUserServiceHandler(userSvc, connect.WithInterceptors(interceptor))
+	mux.Handle(path, handler)
+
+	server := httptest.NewUnstartedServer(mux)
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	t.Cleanup(server.Close)
+
+	client := leapmuxv1connect.NewUserServiceClient(server.Client(), server.URL, connect.WithGRPC())
+
+	userID := id.Generate()
+	hash, _ := password.Hash("testpass")
+	require.NoError(t, st.Users().Create(context.Background(), store.CreateUserParams{
+		ID: userID, Username: "smtpuser", PasswordHash: hash,
+		DisplayName: "SMTP User", PasswordSet: true,
+	}))
+	require.NoError(t, st.Users().UpdateEmail(context.Background(), store.UpdateUserEmailParams{
+		Email: "unverified@example.com", EmailVerified: false, ID: userID,
+	}))
+
+	token, _, _, err := auth.Login(context.Background(), st, "smtpuser", "testpass", auth.DefaultSessionDuration)
+	require.NoError(t, err)
+
+	resp, err := client.ResendVerificationEmail(context.Background(), authedReq(&leapmuxv1.ResendVerificationEmailRequest{}, token))
+	require.NoError(t, err)
+	assert.True(t, resp.Msg.GetEmailSent())
+	require.NotNil(t, resp.Msg.GetNextResendAvailableAt())
+
+	user, err := st.Users().GetByID(context.Background(), userID)
+	require.NoError(t, err)
+	assert.Equal(t, "unverified@example.com", user.PendingEmail)
+	assert.NotEmpty(t, user.PendingEmailToken)
+
+	last := rec.last()
+	require.NotNil(t, last)
+	assert.Equal(t, "unverified@example.com", last.To)
+}
+
+func TestResendVerificationEmail_NextResendAvailableAt(t *testing.T) {
+	t.Parallel()
+
+	env, _ := setupResendUserTest(t)
+
+	require.NoError(t, env.store.Users().SetPendingEmail(context.Background(), store.SetPendingEmailParams{
+		ID:                    env.userID,
+		PendingEmail:          "u@example.com",
+		PendingEmailToken:     verifycode.Generate(),
+		PendingEmailExpiresAt: ptrTime(time.Now().Add(25 * time.Minute).UTC()),
+	}))
+
+	before := time.Now().UTC()
+	resp, err := env.client.ResendVerificationEmail(context.Background(), authedReq(&leapmuxv1.ResendVerificationEmailRequest{}, env.token))
+	require.NoError(t, err)
+
+	nextAt := resp.Msg.GetNextResendAvailableAt().AsTime()
+	assert.True(t, nextAt.After(before.Add(59*time.Second)))
+	assert.True(t, nextAt.Before(before.Add(61*time.Second)))
+}
+
+func TestBeginPasskeyRegistration_OAuthOnly_NoReauthRequired(t *testing.T) {
+	t.Parallel()
+
+	env := setupOAuthUserTest(t)
+
+	req := authedReq(&leapmuxv1.BeginPasskeyRegistrationRequest{}, env.token)
+	_, err := env.client.BeginPasskeyRegistration(context.Background(), req)
+	// Ceremony may fail for missing keystore/RP config; auth must not require reauth proof.
+	if err != nil {
+		assert.NotEqual(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+		assert.NotContains(t, err.Error(), "reauth proof required")
+		assert.NotContains(t, err.Error(), "verify your email")
+	}
+}
+
+func TestBeginPasskeyRegistration_UnverifiedShell_Rejected(t *testing.T) {
+	t.Parallel()
+
+	st, err := sqlite.Open(":memory:", sqlitedb.Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+	require.NoError(t, st.Migrator().Migrate(context.Background()))
+
+	key, err := keystore.GenerateKey()
+	require.NoError(t, err)
+	ks, err := keystore.New(map[uint32][32]byte{1: key})
+	require.NoError(t, err)
+
+	userSvc := service.NewUserService(st, testConfig(), servicetest.NewSettingsManager(t, st, nil), auth.NewCredentialLifecycleEffects(nil, nil, nil), mail.NewStubSender(), mail.Renderer{}, ks)
+	mux := http.NewServeMux()
+	interceptor, contexts := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st})
+	t.Cleanup(contexts.Stop)
+	path, handler := leapmuxv1connect.NewUserServiceHandler(userSvc, connect.WithInterceptors(interceptor))
+	mux.Handle(path, handler)
+	server := httptest.NewUnstartedServer(mux)
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	t.Cleanup(server.Close)
+	client := leapmuxv1connect.NewUserServiceClient(server.Client(), server.URL, connect.WithGRPC())
+
+	userID := id.Generate()
+	require.NoError(t, st.Users().Create(context.Background(), store.CreateUserParams{
+		ID: userID, Username: "shell", PasswordHash: password.PlaceholderHash,
+		DisplayName: "Shell", EmailVerified: false, PasswordSet: false, IsAdmin: true,
+	}))
+	token, _, err := auth.CreateSession(context.Background(), st, userid.MustNew(userID), auth.DefaultSessionDuration)
+	require.NoError(t, err)
+
+	_, err = client.BeginPasskeyRegistration(context.Background(), authedReq(&leapmuxv1.BeginPasskeyRegistrationRequest{}, token))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+	assert.Contains(t, err.Error(), "verify your email")
+}
+
+func TestFinishPasskeyRegistration_FailedCeremonyPreservesReauthProof(t *testing.T) {
+	t.Parallel()
+
+	st, err := sqlite.Open(":memory:", sqlitedb.Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+	require.NoError(t, st.Migrator().Migrate(context.Background()))
+
+	key, err := keystore.GenerateKey()
+	require.NoError(t, err)
+	ks, err := keystore.New(map[uint32][32]byte{1: key})
+	require.NoError(t, err)
+
+	userSvc := service.NewUserService(st, testConfig(), servicetest.NewSettingsManager(t, st, nil), auth.NewCredentialLifecycleEffects(nil, nil, nil), mail.NewStubSender(), mail.Renderer{}, ks)
+	mux := http.NewServeMux()
+	interceptor, contexts := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st})
+	t.Cleanup(contexts.Stop)
+	path, handler := leapmuxv1connect.NewUserServiceHandler(userSvc, connect.WithInterceptors(interceptor))
+	mux.Handle(path, handler)
+	server := httptest.NewUnstartedServer(mux)
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	t.Cleanup(server.Close)
+	client := leapmuxv1connect.NewUserServiceClient(server.Client(), server.URL, connect.WithGRPC())
+
+	userID := id.Generate()
+	require.NoError(t, st.Users().Create(context.Background(), store.CreateUserParams{
+		ID: userID, Username: "pkonly", PasswordHash: password.PlaceholderHash,
+		DisplayName: "PK Only", PasswordSet: false, IsAdmin: true,
+	}))
+	seedPasskeyCredential(t, st, userID, "Phone")
+	proof := seedReauthProof(t, st, userID)
+	token, _, err := auth.CreateSession(context.Background(), st, userid.MustNew(userID), auth.DefaultSessionDuration)
+	require.NoError(t, err)
+
+	_, err = client.FinishPasskeyRegistration(context.Background(), authedReq(&leapmuxv1.FinishPasskeyRegistrationRequest{
+		SessionId:      "missing-session",
+		CredentialJson: "{}",
+		FriendlyName:   "New",
+		ReauthProof:    proof,
+	}, token))
+	require.Error(t, err)
+
+	_, getErr := st.WebAuthnSessions().Get(context.Background(), proof)
+	require.NoError(t, getErr, "failed Finish must not consume the reauth proof")
+}
+
+// TestFinishPasskeyReauth_MalformedCredentialIsUnauthenticated pins the
+// error CLASS of a rejected reauth ceremony. A malformed credential_json on
+// a live ceremony is the caller's fault, so it must surface as
+// CodeUnauthenticated (the rate limiter's proof-failure class) -- before the
+// shared validateAssertion pipeline existed, FinishReauth returned the raw
+// parse error and the service wrapper mapped it to CodeInternal.
+func TestFinishPasskeyReauth_MalformedCredentialIsUnauthenticated(t *testing.T) {
+	t.Parallel()
+
+	st, err := sqlite.Open(":memory:", sqlitedb.Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+	require.NoError(t, st.Migrator().Migrate(context.Background()))
+
+	key, err := keystore.GenerateKey()
+	require.NoError(t, err)
+	ks, err := keystore.New(map[uint32][32]byte{1: key})
+	require.NoError(t, err)
+	wa, err := hubwebauthn.NewService(hubwebauthn.RPConfig{
+		RPID: "localhost", RPDisplayName: "LeapMux", RPOrigins: []string{"http://localhost:4327"},
+	}, st, ks)
+	require.NoError(t, err)
+
+	// The service derives its RP config from public_url (testConfig has no
+	// listen address), mirroring the ceremony-test harness.
+	set := servicetest.NewSettingsManager(t, st, nil)
+	require.NoError(t, settings.KeyPublicURL.Set(context.Background(), set, "http://localhost:4327"))
+	userSvc := service.NewUserService(st, testConfig(), set, auth.NewCredentialLifecycleEffects(nil, nil, nil), mail.NewStubSender(), mail.Renderer{}, ks)
+	mux := http.NewServeMux()
+	interceptor, contexts := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st})
+	t.Cleanup(contexts.Stop)
+	path, handler := leapmuxv1connect.NewUserServiceHandler(userSvc, connect.WithInterceptors(interceptor))
+	mux.Handle(path, handler)
+	server := httptest.NewUnstartedServer(mux)
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	t.Cleanup(server.Close)
+	client := leapmuxv1connect.NewUserServiceClient(server.Client(), server.URL, connect.WithGRPC())
+
+	userID := id.Generate()
+	require.NoError(t, st.Users().Create(context.Background(), store.CreateUserParams{
+		ID: userID, Username: "reauth-badjson", PasswordHash: password.PlaceholderHash,
+		DisplayName: "Reauth", PasswordSet: false, IsAdmin: true,
+	}))
+	credRow := id.Generate()
+	encPub, keyVersion, encErr := wa.EncryptPublicKey(credRow, []byte("pubkey"))
+	require.NoError(t, encErr)
+	require.NoError(t, st.PasskeyCredentials().Create(context.Background(), store.CreatePasskeyCredentialParams{
+		ID: credRow, UserID: userID, CredentialID: []byte("cred-reauth"), PublicKey: encPub,
+		Transports: "[]", FriendlyName: "Phone", KeyVersion: keyVersion, CreatedAt: time.Now().UTC(),
+	}))
+
+	// A LIVE reauth ceremony (BeginReauth writes the properly encrypted
+	// session row), so the failure lands on the parse arm, not the consume.
+	sessionID, _, _, err := wa.BeginReauth(context.Background(), userID, "")
+	require.NoError(t, err)
+	token, _, err := auth.CreateSession(context.Background(), st, userid.MustNew(userID), auth.DefaultSessionDuration)
+	require.NoError(t, err)
+
+	_, err = client.FinishPasskeyReauth(context.Background(), authedReq(&leapmuxv1.FinishPasskeyReauthRequest{
+		SessionId:      sessionID,
+		CredentialJson: "not-a-credential",
+	}, token))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err),
+		"a rejected ceremony is the caller's proof failure, not a server error")
+}
+
+func TestBeginPasskeyRegistration_DoesNotConsumeReauthProof(t *testing.T) {
+	t.Parallel()
+
+	st, err := sqlite.Open(":memory:", sqlitedb.Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+	require.NoError(t, st.Migrator().Migrate(context.Background()))
+
+	key, err := keystore.GenerateKey()
+	require.NoError(t, err)
+	ks, err := keystore.New(map[uint32][32]byte{1: key})
+	require.NoError(t, err)
+
+	userSvc := service.NewUserService(st, testConfig(), servicetest.NewSettingsManager(t, st, nil), auth.NewCredentialLifecycleEffects(nil, nil, nil), mail.NewStubSender(), mail.Renderer{}, ks)
+	mux := http.NewServeMux()
+	interceptor, contexts := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st})
+	t.Cleanup(contexts.Stop)
+	path, handler := leapmuxv1connect.NewUserServiceHandler(userSvc, connect.WithInterceptors(interceptor))
+	mux.Handle(path, handler)
+	server := httptest.NewUnstartedServer(mux)
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	t.Cleanup(server.Close)
+	client := leapmuxv1connect.NewUserServiceClient(server.Client(), server.URL, connect.WithGRPC())
+
+	userID := id.Generate()
+	require.NoError(t, st.Users().Create(context.Background(), store.CreateUserParams{
+		ID: userID, Username: "pkonly", PasswordHash: password.PlaceholderHash,
+		DisplayName: "PK Only", PasswordSet: false, IsAdmin: true,
+	}))
+	seedPasskeyCredential(t, st, userID, "Phone")
+	proof := seedReauthProof(t, st, userID)
+
+	token, _, err := auth.CreateSession(context.Background(), st, userid.MustNew(userID), auth.DefaultSessionDuration)
+	require.NoError(t, err)
+
+	req := authedReq(&leapmuxv1.BeginPasskeyRegistrationRequest{ReauthProof: proof}, token)
+	req.Header().Set("Origin", "https://localhost")
+	_, err = client.BeginPasskeyRegistration(context.Background(), req)
+	// Ceremony may fail for RP config, but auth must succeed without consuming the proof.
+	_, getErr := st.WebAuthnSessions().Get(context.Background(), proof)
+	require.NoError(t, getErr, "Begin must not consume the reauth proof (Finish does)")
+	_ = err
+}
+
+func TestDeletePasskey_ReauthProofReplayRejected(t *testing.T) {
+	t.Parallel()
+
+	env := setupOAuthUserTest(t)
+	_ = seedPasskeyCredential(t, env.store, env.userID, "KeepA")
+	pk1 := seedPasskeyCredential(t, env.store, env.userID, "KeepB")
+	pk2 := seedPasskeyCredential(t, env.store, env.userID, "Remove")
+	proof := seedReauthProof(t, env.store, env.userID)
+
+	_, err := env.client.DeletePasskey(context.Background(), authedReq(&leapmuxv1.DeletePasskeyRequest{
+		Id: pk2, ReauthProof: proof,
+	}, env.token))
+	require.NoError(t, err)
+
+	// Still more than one passkey left, so this hits auth (not last-passkey
+	// deactivation) and must reject the consumed proof.
+	_, err = env.client.DeletePasskey(context.Background(), authedReq(&leapmuxv1.DeletePasskeyRequest{
+		Id: pk1, ReauthProof: proof,
+	}, env.token))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+
+	_, err = env.store.PasskeyCredentials().GetByID(context.Background(), pk1)
+	require.NoError(t, err, "replay must not delete the remaining passkey")
+}
+
+func TestListPasskeys_IncludesCredentialId(t *testing.T) {
+	t.Parallel()
+
+	env := setupUserTest(t)
+	pkID := seedPasskeyCredential(t, env.store, env.userID, "Laptop")
+
+	resp, err := env.client.ListPasskeys(context.Background(), authedReq(&leapmuxv1.ListPasskeysRequest{}, env.token))
+	require.NoError(t, err)
+	require.Len(t, resp.Msg.GetPasskeys(), 1)
+	assert.Equal(t, pkID, resp.Msg.GetPasskeys()[0].GetId())
+	assert.NotEmpty(t, resp.Msg.GetPasskeys()[0].GetCredentialId())
+}
+
+func TestUserService_ListAndRenamePasskeys_SoloRejected(t *testing.T) {
+	t.Parallel()
+
+	st, err := sqlite.Open(":memory:", sqlitedb.Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+	require.NoError(t, st.Migrator().Migrate(context.Background()))
+
+	cfg := testConfig()
+	cfg.SoloMode = true
+	userSvc := service.NewUserService(st, cfg, servicetest.NewSettingsManager(t, st, nil), auth.NewCredentialLifecycleEffects(nil, nil, nil), mail.NewStubSender(), mail.Renderer{}, nil)
+	mux := http.NewServeMux()
+	interceptor, contexts := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st})
+	t.Cleanup(contexts.Stop)
+	path, handler := leapmuxv1connect.NewUserServiceHandler(userSvc, connect.WithInterceptors(interceptor))
+	mux.Handle(path, handler)
+	server := httptest.NewUnstartedServer(mux)
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	t.Cleanup(server.Close)
+	client := leapmuxv1connect.NewUserServiceClient(server.Client(), server.URL, connect.WithGRPC())
+
+	userID := id.Generate()
+	hash, err := password.Hash("testpass")
+	require.NoError(t, err)
+	require.NoError(t, st.Users().Create(context.Background(), store.CreateUserParams{
+		ID: userID, Username: "solouser", PasswordHash: hash, DisplayName: "Solo", PasswordSet: true, IsAdmin: true,
+	}))
+	token, _, err := auth.CreateSession(context.Background(), st, userid.MustNew(userID), auth.DefaultSessionDuration)
+	require.NoError(t, err)
+	pkID := seedPasskeyCredential(t, st, userID, "Laptop")
+
+	_, err = client.ListPasskeys(context.Background(), authedReq(&leapmuxv1.ListPasskeysRequest{}, token))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+	assert.Contains(t, err.Error(), "solo mode")
+
+	_, err = client.RenamePasskey(context.Background(), authedReq(&leapmuxv1.RenamePasskeyRequest{
+		Id: pkID, FriendlyName: "Phone", CurrentPassword: "testpass",
+	}, token))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+	assert.Contains(t, err.Error(), "solo mode")
 }

--- a/backend/internal/hub/service/user_service_test.go
+++ b/backend/internal/hub/service/user_service_test.go
@@ -614,6 +614,53 @@ func TestRequestEmailChange_NonAdmin_VerificationNotRequired_LandsUnverified(t *
 
 // --- RequestEmailChange: duplicate email rejected ---
 
+// RequestEmailChange had no cooldown at all: the address is
+// caller-supplied and nothing rate-limits the procedure, so a logged-in
+// user could send one verification message per request to any address
+// they named. The conditional mint is what closes that -- it refuses
+// while a previous code is live, whatever address the second request
+// asks for.
+func TestRequestEmailChange_CooldownRefusesASecondAddress(t *testing.T) {
+	t.Parallel()
+
+	client, st, _ := setupVerificationUserTestServer(t, true)
+
+	userID := id.Generate()
+	hash, _ := password.Hash("userpass")
+	require.NoError(t, st.Users().Create(context.Background(), store.CreateUserParams{
+		ID:           userID,
+		Username:     "flooduser",
+		PasswordHash: hash,
+		DisplayName:  "Flood User",
+		PasswordSet:  true,
+	}))
+	require.NoError(t, st.Users().UpdateEmail(context.Background(), store.UpdateUserEmailParams{
+		Email: "old@example.com", EmailVerified: true, ID: userID,
+	}))
+	userToken, _, _, err := auth.Login(context.Background(), st, "flooduser", "userpass", auth.DefaultSessionDuration)
+	require.NoError(t, err)
+
+	_, err = client.RequestEmailChange(context.Background(), authedReq(&leapmuxv1.RequestEmailChangeRequest{
+		NewEmail: "first@example.com",
+	}, userToken))
+	require.NoError(t, err)
+
+	// A DIFFERENT address on the second request: the old read-then-check
+	// would have minted and sent again, because it compared nothing.
+	_, err = client.RequestEmailChange(context.Background(), authedReq(&leapmuxv1.RequestEmailChangeRequest{
+		NewEmail: "victim@example.com",
+	}, userToken))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeResourceExhausted, connect.CodeOf(err),
+		"a second address inside the cooldown must be refused, not sent")
+
+	// The first request's pending row is intact: the refusal changed nothing.
+	user, err := st.Users().GetByID(context.Background(), userID)
+	require.NoError(t, err)
+	assert.Equal(t, "first@example.com", user.PendingEmail,
+		"the refused mint must not overwrite the live code's address")
+}
+
 func TestRequestEmailChange_DuplicateEmail_Rejected(t *testing.T) {
 	t.Parallel()
 
@@ -751,11 +798,12 @@ func TestVerifyEmail_Success(t *testing.T) {
 
 	// Seed pending_email + a 6-char verifycode-shaped token.
 	verifyToken := verifycode.Generate()
-	err := env.store.Users().SetPendingEmail(context.Background(), store.SetPendingEmailParams{
+	_, err := env.store.Users().SetPendingEmail(context.Background(), store.SetPendingEmailParams{
 		PendingEmail:          "verified@example.com",
 		PendingEmailToken:     verifyToken,
 		PendingEmailExpiresAt: ptrTime(time.Now().Add(1 * time.Hour).UTC()),
 		ID:                    env.userID,
+		CooldownCutoff:        store.UnconditionalMintCutoff(),
 	})
 	require.NoError(t, err)
 
@@ -786,11 +834,12 @@ func TestVerifyEmail_AcceptsLowercaseInput(t *testing.T) {
 	env := setupUserTest(t)
 
 	verifyToken := verifycode.Generate()
-	err := env.store.Users().SetPendingEmail(context.Background(), store.SetPendingEmailParams{
+	_, err := env.store.Users().SetPendingEmail(context.Background(), store.SetPendingEmailParams{
 		PendingEmail:          "lowercase@example.com",
 		PendingEmailToken:     verifyToken,
 		PendingEmailExpiresAt: ptrTime(time.Now().Add(1 * time.Hour).UTC()),
 		ID:                    env.userID,
+		CooldownCutoff:        store.UnconditionalMintCutoff(),
 	})
 	require.NoError(t, err)
 
@@ -825,11 +874,12 @@ func TestVerifyEmail_ExpiredOrMismatchSurfacesIdentically(t *testing.T) {
 	env := setupUserTest(t)
 
 	expiredToken := verifycode.Generate()
-	err := env.store.Users().SetPendingEmail(context.Background(), store.SetPendingEmailParams{
+	_, err := env.store.Users().SetPendingEmail(context.Background(), store.SetPendingEmailParams{
 		PendingEmail:          "expired@example.com",
 		PendingEmailToken:     expiredToken,
 		PendingEmailExpiresAt: ptrTime(time.Now().Add(-1 * time.Hour).UTC()),
 		ID:                    env.userID,
+		CooldownCutoff:        store.UnconditionalMintCutoff(),
 	})
 	require.NoError(t, err)
 
@@ -845,12 +895,15 @@ func TestVerifyEmail_ExpiredOrMismatchSurfacesIdentically(t *testing.T) {
 	for wrongToken == liveToken {
 		wrongToken = verifycode.Generate()
 	}
-	require.NoError(t, env.store.Users().SetPendingEmail(context.Background(), store.SetPendingEmailParams{
+	minted, err := env.store.Users().SetPendingEmail(context.Background(), store.SetPendingEmailParams{
 		PendingEmail:          "live@example.com",
 		PendingEmailToken:     liveToken,
 		PendingEmailExpiresAt: ptrTime(time.Now().Add(1 * time.Hour).UTC()),
 		ID:                    env.userID,
-	}))
+		CooldownCutoff:        store.UnconditionalMintCutoff(),
+	})
+	require.NoError(t, err)
+	require.True(t, minted)
 	_, mismatchErr := env.client.VerifyEmail(context.Background(), authedReq(&leapmuxv1.VerifyEmailRequest{
 		VerificationToken: verifycode.Format(wrongToken),
 	}, env.token))
@@ -868,11 +921,12 @@ func TestVerifyEmail_PendingEmailEmpty(t *testing.T) {
 	// Set a token but with empty pending_email — represents a "nothing
 	// to verify" precondition error, distinct from invalid/expired codes.
 	verifyToken := verifycode.Generate()
-	err := env.store.Users().SetPendingEmail(context.Background(), store.SetPendingEmailParams{
+	_, err := env.store.Users().SetPendingEmail(context.Background(), store.SetPendingEmailParams{
 		PendingEmail:          "",
 		PendingEmailToken:     verifyToken,
 		PendingEmailExpiresAt: ptrTime(time.Now().Add(1 * time.Hour).UTC()),
 		ID:                    env.userID,
+		CooldownCutoff:        store.UnconditionalMintCutoff(),
 	})
 	require.NoError(t, err)
 
@@ -889,12 +943,15 @@ func TestVerifyEmail_RateLimitForceExpires(t *testing.T) {
 	env := setupUserTest(t)
 
 	live := verifycode.Generate()
-	require.NoError(t, env.store.Users().SetPendingEmail(context.Background(), store.SetPendingEmailParams{
+	minted, err := env.store.Users().SetPendingEmail(context.Background(), store.SetPendingEmailParams{
 		PendingEmail:          "burned@example.com",
 		PendingEmailToken:     live,
 		PendingEmailExpiresAt: ptrTime(time.Now().Add(1 * time.Hour).UTC()),
 		ID:                    env.userID,
-	}))
+		CooldownCutoff:        store.UnconditionalMintCutoff(),
+	})
+	require.NoError(t, err)
+	require.True(t, minted)
 
 	// Five wrong attempts: each one should fail with NotFound but the
 	// row stays alive.
@@ -912,7 +969,7 @@ func TestVerifyEmail_RateLimitForceExpires(t *testing.T) {
 
 	// 6th attempt — even with the *correct* code — must fail with
 	// ResourceExhausted because the previous attempt force-expired the row.
-	_, err := env.client.VerifyEmail(context.Background(), authedReq(&leapmuxv1.VerifyEmailRequest{
+	_, err = env.client.VerifyEmail(context.Background(), authedReq(&leapmuxv1.VerifyEmailRequest{
 		VerificationToken: verifycode.Format(live),
 	}, env.token))
 	require.Error(t, err)
@@ -988,12 +1045,15 @@ func TestResendVerificationEmail_RotatesCodeAndSends(t *testing.T) {
 	// the cooldown window has elapsed (TTL is 30min, cooldown 60s — set
 	// expires_at = now+25min so issued_at = now-5min).
 	originalCode := verifycode.Generate()
-	require.NoError(t, env.store.Users().SetPendingEmail(context.Background(), store.SetPendingEmailParams{
+	minted, err := env.store.Users().SetPendingEmail(context.Background(), store.SetPendingEmailParams{
 		ID:                    env.userID,
 		PendingEmail:          "u@example.com",
 		PendingEmailToken:     originalCode,
 		PendingEmailExpiresAt: ptrTime(time.Now().Add(25 * time.Minute).UTC()),
-	}))
+		CooldownCutoff:        store.UnconditionalMintCutoff(),
+	})
+	require.NoError(t, err)
+	require.True(t, minted)
 
 	resp, err := env.client.ResendVerificationEmail(context.Background(), authedReq(&leapmuxv1.ResendVerificationEmailRequest{}, env.token))
 	require.NoError(t, err)
@@ -1024,14 +1084,17 @@ func TestResendVerificationEmail_CooldownEnforced(t *testing.T) {
 	// (or hostile caller) can't flood the user's inbox.
 	env, _ := setupResendUserTest(t)
 
-	require.NoError(t, env.store.Users().SetPendingEmail(context.Background(), store.SetPendingEmailParams{
+	minted, err := env.store.Users().SetPendingEmail(context.Background(), store.SetPendingEmailParams{
 		ID:                    env.userID,
 		PendingEmail:          "u@example.com",
 		PendingEmailToken:     verifycode.Generate(),
 		PendingEmailExpiresAt: ptrTime(time.Now().Add(30 * time.Minute).UTC()),
-	}))
+		CooldownCutoff:        store.UnconditionalMintCutoff(),
+	})
+	require.NoError(t, err)
+	require.True(t, minted)
 
-	_, err := env.client.ResendVerificationEmail(context.Background(), authedReq(&leapmuxv1.ResendVerificationEmailRequest{}, env.token))
+	_, err = env.client.ResendVerificationEmail(context.Background(), authedReq(&leapmuxv1.ResendVerificationEmailRequest{}, env.token))
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeResourceExhausted, connect.CodeOf(err))
 }
@@ -1042,11 +1105,12 @@ func TestVerifyEmail_EmailTakenSinceRequest(t *testing.T) {
 	env := setupUserTest(t)
 
 	verifyToken := verifycode.Generate()
-	err := env.store.Users().SetPendingEmail(context.Background(), store.SetPendingEmailParams{
+	_, err := env.store.Users().SetPendingEmail(context.Background(), store.SetPendingEmailParams{
 		PendingEmail:          "contested@example.com",
 		PendingEmailToken:     verifyToken,
 		PendingEmailExpiresAt: ptrTime(time.Now().Add(1 * time.Hour).UTC()),
 		ID:                    env.userID,
+		CooldownCutoff:        store.UnconditionalMintCutoff(),
 	})
 	require.NoError(t, err)
 
@@ -1085,11 +1149,12 @@ func TestVerifyEmail_CrossUser_NoOracle(t *testing.T) {
 	env := setupUserTest(t)
 
 	victimToken := verifycode.Generate()
-	err := env.store.Users().SetPendingEmail(context.Background(), store.SetPendingEmailParams{
+	_, err := env.store.Users().SetPendingEmail(context.Background(), store.SetPendingEmailParams{
 		PendingEmail:          "stolen@example.com",
 		PendingEmailToken:     victimToken,
 		PendingEmailExpiresAt: ptrTime(time.Now().Add(1 * time.Hour).UTC()),
 		ID:                    env.userID,
+		CooldownCutoff:        store.UnconditionalMintCutoff(),
 	})
 	require.NoError(t, err)
 
@@ -1108,12 +1173,15 @@ func TestVerifyEmail_CrossUser_NoOracle(t *testing.T) {
 		IsAdmin:      false,
 	})
 	attackerOwnToken := verifycode.Generate()
-	require.NoError(t, env.store.Users().SetPendingEmail(context.Background(), store.SetPendingEmailParams{
+	minted, err := env.store.Users().SetPendingEmail(context.Background(), store.SetPendingEmailParams{
 		PendingEmail:          "attacker@example.com",
 		PendingEmailToken:     attackerOwnToken,
 		PendingEmailExpiresAt: ptrTime(time.Now().Add(1 * time.Hour).UTC()),
 		ID:                    attackerID,
-	}))
+		CooldownCutoff:        store.UnconditionalMintCutoff(),
+	})
+	require.NoError(t, err)
+	require.True(t, minted)
 	attackerToken, _, _, err := auth.Login(context.Background(), env.store, "attacker", "testpass2", auth.DefaultSessionDuration)
 	require.NoError(t, err)
 
@@ -1694,12 +1762,15 @@ func TestVerifyEmail_IncludesPasskeyCount(t *testing.T) {
 	seedPasskeyCredential(t, env.store, env.userID, "Two")
 
 	verifyToken := verifycode.Generate()
-	require.NoError(t, env.store.Users().SetPendingEmail(context.Background(), store.SetPendingEmailParams{
+	minted, err := env.store.Users().SetPendingEmail(context.Background(), store.SetPendingEmailParams{
 		PendingEmail:          "counted@example.com",
 		PendingEmailToken:     verifyToken,
 		PendingEmailExpiresAt: ptrTime(time.Now().Add(1 * time.Hour).UTC()),
 		ID:                    env.userID,
-	}))
+		CooldownCutoff:        store.UnconditionalMintCutoff(),
+	})
+	require.NoError(t, err)
+	require.True(t, minted)
 
 	resp, err := env.client.VerifyEmail(context.Background(), authedReq(&leapmuxv1.VerifyEmailRequest{
 		VerificationToken: verifycode.Format(verifyToken),
@@ -1768,12 +1839,15 @@ func TestResendVerificationEmail_NextResendAvailableAt(t *testing.T) {
 
 	env, _ := setupResendUserTest(t)
 
-	require.NoError(t, env.store.Users().SetPendingEmail(context.Background(), store.SetPendingEmailParams{
+	minted, err := env.store.Users().SetPendingEmail(context.Background(), store.SetPendingEmailParams{
 		ID:                    env.userID,
 		PendingEmail:          "u@example.com",
 		PendingEmailToken:     verifycode.Generate(),
 		PendingEmailExpiresAt: ptrTime(time.Now().Add(25 * time.Minute).UTC()),
-	}))
+		CooldownCutoff:        store.UnconditionalMintCutoff(),
+	})
+	require.NoError(t, err)
+	require.True(t, minted)
 
 	before := time.Now().UTC()
 	resp, err := env.client.ResendVerificationEmail(context.Background(), authedReq(&leapmuxv1.ResendVerificationEmailRequest{}, env.token))

--- a/backend/internal/hub/service/webauthn_ceremony_test.go
+++ b/backend/internal/hub/service/webauthn_ceremony_test.go
@@ -1,0 +1,143 @@
+package service_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/descope/virtualwebauthn"
+	"github.com/stretchr/testify/require"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/generated/proto/leapmux/v1/leapmuxv1connect"
+	"github.com/leapmux/leapmux/internal/hub/auth"
+	"github.com/leapmux/leapmux/internal/hub/keystore"
+	"github.com/leapmux/leapmux/internal/hub/mail"
+	"github.com/leapmux/leapmux/internal/hub/service"
+	"github.com/leapmux/leapmux/internal/hub/servicetest"
+	"github.com/leapmux/leapmux/internal/hub/settings"
+	"github.com/leapmux/leapmux/internal/hub/store"
+	hubtestutil "github.com/leapmux/leapmux/internal/hub/testutil"
+)
+
+const passkeyTestOrigin = "https://localhost"
+
+type passkeyCeremony struct {
+	rp            virtualwebauthn.RelyingParty
+	authenticator virtualwebauthn.Authenticator
+	credential    virtualwebauthn.Credential
+}
+
+func newPasskeyCeremony() *passkeyCeremony {
+	return &passkeyCeremony{
+		rp: virtualwebauthn.RelyingParty{
+			Name:   "LeapMux",
+			ID:     "localhost",
+			Origin: passkeyTestOrigin,
+		},
+		authenticator: virtualwebauthn.NewAuthenticator(),
+		credential:    virtualwebauthn.NewCredential(virtualwebauthn.KeyTypeEC2),
+	}
+}
+
+func (c *passkeyCeremony) registrationResponse(optionsJSON string) (string, error) {
+	parsed, err := virtualwebauthn.ParseAttestationOptions(optionsJSON)
+	if err != nil {
+		return "", err
+	}
+	resp := virtualwebauthn.CreateAttestationResponse(c.rp, c.authenticator, c.credential, *parsed)
+	c.authenticator.AddCredential(c.credential)
+	return resp, nil
+}
+
+func (c *passkeyCeremony) assertionResponse(optionsJSON string) (string, error) {
+	parsed, err := virtualwebauthn.ParseAssertionOptions(optionsJSON)
+	if err != nil {
+		return "", err
+	}
+	return virtualwebauthn.CreateAssertionResponse(c.rp, c.authenticator, c.credential, *parsed), nil
+}
+
+type passkeyAuthTestEnv struct {
+	client leapmuxv1connect.AuthServiceClient
+	store  store.Store
+}
+
+func setupPasskeyAuthTestServer(t *testing.T, seed authTestSeed, mailSender mail.Sender) passkeyAuthTestEnv {
+	t.Helper()
+
+	st := hubtestutil.OpenTestStore(t)
+	key, err := keystore.GenerateKey()
+	require.NoError(t, err)
+	ks, err := keystore.New(map[uint32][32]byte{1: key})
+	require.NoError(t, err)
+
+	set := servicetest.NewSettingsManager(t, st, ks)
+	require.NoError(t, settings.KeyPublicURL.Set(context.Background(), set, passkeyTestOrigin))
+	if seed != nil {
+		seed(t, set)
+	}
+	hubtestutil.CreateTestAdmin(t, st)
+
+	mux := http.NewServeMux()
+	interceptor, sc := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st})
+	t.Cleanup(sc.Stop)
+	opts := connect.WithInterceptors(interceptor)
+
+	if mailSender == nil {
+		mailSender = mail.NewStubSender()
+	}
+	authSvc := service.NewAuthService(service.AuthServiceDeps{
+		Store:     st,
+		Config:    testConfig(),
+		Settings:  set,
+		Lifecycle: auth.NewCredentialLifecycleEffects(sc, nil, nil),
+		Mail:      mailSender,
+		Renderer:  mail.Renderer{},
+		Keystore:  ks,
+	})
+	path, handler := leapmuxv1connect.NewAuthServiceHandler(authSvc, opts)
+	mux.Handle(path, handler)
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	return passkeyAuthTestEnv{
+		client: leapmuxv1connect.NewAuthServiceClient(server.Client(), server.URL),
+		store:  st,
+	}
+}
+
+func beginPasskeySignUp(t *testing.T, client leapmuxv1connect.AuthServiceClient, username, email string) *leapmuxv1.BeginPasskeySignUpResponse {
+	t.Helper()
+	req := connect.NewRequest(&leapmuxv1.BeginPasskeySignUpRequest{
+		Username:    username,
+		DisplayName: username,
+		Email:       email,
+	})
+	req.Header().Set("Origin", passkeyTestOrigin)
+	resp, err := client.BeginPasskeySignUp(context.Background(), req)
+	require.NoError(t, err)
+	return resp.Msg
+}
+
+func beginPasskeyLogin(t *testing.T, client leapmuxv1connect.AuthServiceClient, username string) *leapmuxv1.BeginPasskeyLoginResponse {
+	t.Helper()
+	req := connect.NewRequest(&leapmuxv1.BeginPasskeyLoginRequest{Username: username})
+	req.Header().Set("Origin", passkeyTestOrigin)
+	resp, err := client.BeginPasskeyLogin(context.Background(), req)
+	require.NoError(t, err)
+	return resp.Msg
+}
+
+func finishPasskeyLogin(t *testing.T, client leapmuxv1connect.AuthServiceClient, sessionID, credentialJSON string) (*connect.Response[leapmuxv1.FinishPasskeyLoginResponse], error) {
+	t.Helper()
+	req := connect.NewRequest(&leapmuxv1.FinishPasskeyLoginRequest{
+		SessionId:      sessionID,
+		CredentialJson: credentialJSON,
+	})
+	req.Header().Set("Origin", passkeyTestOrigin)
+	return client.FinishPasskeyLogin(context.Background(), req)
+}

--- a/backend/internal/hub/service/worker_deregister_internal_test.go
+++ b/backend/internal/hub/service/worker_deregister_internal_test.go
@@ -190,7 +190,7 @@ func TestDeleteUserTellsEveryWorkerToStop(t *testing.T) {
 	broadcaster := NewHubEventBroadcaster(channelmgr.New(0))
 	scopeCache := auth.NewDelegationScopeCache(st)
 	svc := NewAdminUserService(st, nil, nil,
-		NewWorkerDeregisterEffects(scopeCache, newTestNotifier(t, st), broadcaster))
+		NewWorkerDeregisterEffects(scopeCache, newTestNotifier(t, st), broadcaster), nil)
 
 	// One memoized delegation scope per worker, so the eviction arm is
 	// observable per worker too.
@@ -253,7 +253,7 @@ func TestDeleteUserCarriesOnWhenOneWorkerCannotBeTold(t *testing.T) {
 	// instant are ordered by their random ids -- so failing a worker chosen
 	// by name would leave the "carries on" property untested whenever that
 	// worker happened to come last.
-	order, err := NewAdminUserService(st, nil, nil, nil).liveWorkerIDs(ctx, userid.MustNew(owner.ID))
+	order, err := NewAdminUserService(st, nil, nil, nil, nil).liveWorkerIDs(ctx, userid.MustNew(owner.ID))
 	require.NoError(t, err)
 	require.Len(t, order, 3)
 
@@ -261,7 +261,7 @@ func TestDeleteUserCarriesOnWhenOneWorkerCannotBeTold(t *testing.T) {
 	// one, so the deletion itself commits normally.
 	failing := failingNotificationStore{Store: st, failWorkerID: order[0]}
 	svc := NewAdminUserService(st, nil, nil,
-		NewWorkerDeregisterEffects(nil, newTestNotifier(t, failing), nil))
+		NewWorkerDeregisterEffects(nil, newTestNotifier(t, failing), nil), nil)
 
 	logs := testutil.CaptureDefaultLogger(t)
 	_, err = svc.DeleteUser(ctx, connectRequestForTest(&leapmuxv1.DeleteUserRequest{Id: owner.ID}))
@@ -307,7 +307,7 @@ func TestDeleteUserTellsEveryWorkerPastTheFirstPage(t *testing.T) {
 	}
 
 	svc := NewAdminUserService(st, nil, nil,
-		NewWorkerDeregisterEffects(nil, newTestNotifier(t, st), nil))
+		NewWorkerDeregisterEffects(nil, newTestNotifier(t, st), nil), nil)
 	_, err := svc.DeleteUser(ctx, connectRequestForTest(&leapmuxv1.DeleteUserRequest{Id: owner.ID}))
 	require.NoError(t, err)
 

--- a/backend/internal/hub/service/ws_channel_relay_test.go
+++ b/backend/internal/hub/service/ws_channel_relay_test.go
@@ -174,7 +174,7 @@ func (httpAuthFailureStore) Sessions() store.SessionStore {
 
 type httpAuthFailureSessions struct{ store.SessionStore }
 
-func (httpAuthFailureSessions) ValidateWithUser(context.Context, string) (*store.SessionWithUser, error) {
+func (httpAuthFailureSessions) ValidateWithUser(context.Context, string, time.Time) (*store.SessionWithUser, error) {
 	return nil, errors.New("sensitive database failure")
 }
 

--- a/backend/internal/hub/settings/keys.go
+++ b/backend/internal/hub/settings/keys.go
@@ -369,15 +369,6 @@ var (
 			Fields:       []Field{{Name: "", Label: "Open sign-up", Kind: FieldBool}},
 		})
 
-	KeyEmailVerificationRequired = NewKey[bool]("email_verification_required").
-					WithUI(UIMeta{
-			Category:     "signup",
-			Title:        "Require verified email",
-			Summary:      "require verified email before sign-in (needs smtp configured)",
-			HiddenInSolo: true,
-			Fields:       []Field{{Name: "", Label: "Require verified email", Kind: FieldBool}},
-		})
-
 	// Solo mints no session: the auth interceptor authenticates every
 	// procedure as the synthetic solo user and refreshes nothing, and the
 	// bootstrapped solo user has no password hash, so Login cannot
@@ -541,7 +532,6 @@ var (
 func CoreDescriptors() []Descriptor {
 	return []Descriptor{
 		KeySignupEnabled,
-		KeyEmailVerificationRequired,
 		KeyPublicURL,
 		KeySecureCookies,
 		KeySessionDurationSeconds,
@@ -553,25 +543,10 @@ func CoreDescriptors() []Descriptor {
 	}
 }
 
-// SMTPConfigured is the cross-key rule the old config enforced at
-// startup: requiring email verification without an SMTP relay would lock
-// every signup behind an email that can never be sent.
-func SMTPConfigured(s *Snapshot) error {
-	if !KeyEmailVerificationRequired.Of(s) {
-		return nil
-	}
-	if !KeySMTP.Of(s).Enabled() {
-		return fmt.Errorf("email_verification_required=true needs the smtp host and from address to be configured first")
-	}
-	return nil
-}
-
-// EmailVerificationEffective applies the SMTPConfigured rule at read
-// time: a state that somehow bypassed the write-path validation (direct
-// SQL) degrades to "verification off" rather than locking every signup
-// behind an email that can never be sent.
+// EmailVerificationEffective is true when SMTP is configured. The database
+// stores the true verification state; this gate controls runtime access.
 func EmailVerificationEffective(s *Snapshot) bool {
-	return KeyEmailVerificationRequired.Of(s) && KeySMTP.Of(s).Enabled()
+	return KeySMTP.Of(s).Enabled()
 }
 
 // SignupEnabledEffective applies the dev-mode default at read time: dev

--- a/backend/internal/hub/settings/keys_test.go
+++ b/backend/internal/hub/settings/keys_test.go
@@ -120,20 +120,18 @@ func TestValidateSMTPStagingRules(t *testing.T) {
 	assert.True(t, both.Enabled())
 }
 
-// TestSMTPConfiguredCrossRuleNeedsBothFields pins that the cross-key rule
-// got STRICTER, not weaker: email verification against a relay with no
-// from address can never send, so the combination stays refused.
-func TestSMTPConfiguredCrossRuleNeedsBothFields(t *testing.T) {
+// TestEmailVerificationEffectiveFollowsSMTP pins that verification gating
+// tracks SMTP.Enabled() only.
+func TestEmailVerificationEffectiveFollowsSMTP(t *testing.T) {
 	m, _, _ := newTestManagerWithStore(t)
 	ctx := context.Background()
 
+	assert.False(t, EmailVerificationEffective(m.Snapshot(ctx)))
+
 	require.NoError(t, m.Update(ctx, KeySMTP, json.RawMessage(`{"host":"smtp.example.com"}`)))
-	err := m.Update(ctx, KeyEmailVerificationRequired, json.RawMessage(`true`))
-	require.ErrorContains(t, err, "needs the smtp host and from address",
-		"a host without a from address cannot carry verification email")
+	assert.False(t, EmailVerificationEffective(m.Snapshot(ctx)), "host alone is not enough")
 
 	require.NoError(t, m.Update(ctx, KeySMTP, json.RawMessage(`{"from_address":"hub@example.com"}`)))
-	require.NoError(t, m.Update(ctx, KeyEmailVerificationRequired, json.RawMessage(`true`)))
 	assert.True(t, EmailVerificationEffective(m.Snapshot(ctx)))
 }
 

--- a/backend/internal/hub/settings/manager.go
+++ b/backend/internal/hub/settings/manager.go
@@ -712,9 +712,9 @@ func (m *Manager) requireRegistered(desc Descriptor) error {
 
 // Reset removes the key's row, returning it to its code default. The
 // cross-key rules run against the post-reset view first — the same
-// contract every write path holds — so a reset cannot store the exact
-// combination an update refuses (e.g. dropping the smtp row while
-// email_verification_required stays true).
+// contract every write path holds — so a reset cannot store a combination
+// an update refuses (for example, clearing a captcha provider secret while
+// that provider stays selected).
 func (m *Manager) Reset(ctx context.Context, desc Descriptor) error {
 	if err := m.ResetMany(ctx, []Descriptor{desc}); err != nil {
 		return fmt.Errorf("reset setting %q: %w", desc.Name(), err)

--- a/backend/internal/hub/settings/manager_test.go
+++ b/backend/internal/hub/settings/manager_test.go
@@ -45,6 +45,17 @@ type errTest string
 
 func (e errTest) Error() string { return string(e) }
 
+// newSettingsTestStore is the bare in-memory store the cross-key cases
+// build their own manager over, when the shared newTestManager registry is
+// not the one under test.
+func newSettingsTestStore(t *testing.T) store.Store {
+	t.Helper()
+	st, err := sqlite.Open(":memory:", sqlitedb.Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+	return st
+}
+
 func newTestManager(t *testing.T) (*Manager, *Key[testValue]) {
 	t.Helper()
 	m, k, _ := newTestManagerWithStore(t)
@@ -1890,12 +1901,100 @@ func TestEveryWriteVerbRefusesAnUnregisteredKey(t *testing.T) {
 
 // TestSetIfAbsentSharesPrepareRowsWithOtherWrites pins that SetIfAbsent
 // goes through the same prepareRows path as Update (validation, registry
-// check). Email verification no longer has a cross-key rule — it follows SMTP.
+// check). Email verification no longer has a cross-key rule -- it follows SMTP.
 func TestSetIfAbsentSharesPrepareRowsWithOtherWrites(t *testing.T) {
 	m, k := newTestManager(t)
 	ctx := context.Background()
 	require.NoError(t, k.SetIfAbsent(ctx, m, testValue{Port: 2525}))
 	assert.Equal(t, 2525, k.Of(m.Snapshot(ctx)).Port)
+}
+
+// TestEveryWriteVerbRunsTheCrossKeyRules pins that a cross-key refusal
+// reaches EVERY write verb, and keeps its error class through each one's
+// wrap.
+//
+// The email-verification cross rule was deleted with its key, and the tests
+// that pinned this went with it -- leaving the machinery live
+// (prepareRows -> crossValidate for Update/UpdateMany/SetValue/SetIfAbsent,
+// ResetMany for Reset/ResetMany) with the only remaining coverage asserting
+// the rules run ZERO times. A regression that dropped crossValidate from a
+// single-key verb, or that lost *InvalidError through Reset's
+// fmt.Errorf wrap, then passed the whole suite. This is not about email
+// verification; it is about the verb surface the rule has to cover.
+func TestEveryWriteVerbRunsTheCrossKeyRules(t *testing.T) {
+	ctx := context.Background()
+	a := NewKey[int64]("cross.a")
+	b := NewKey[int64]("cross.b")
+
+	// The rule refuses any state in which both keys are customized.
+	refuse := func(s *Snapshot) error {
+		if s.Customized(a) && s.Customized(b) {
+			return fmt.Errorf("cross.a and cross.b cannot both be set")
+		}
+		return nil
+	}
+
+	for _, tc := range []struct {
+		name  string
+		write func(m *Manager) error
+	}{
+		{"Update", func(m *Manager) error { return m.Update(ctx, b, json.RawMessage(`2`)) }},
+		{"UpdateMany", func(m *Manager) error {
+			return m.UpdateMany(ctx, []KeyWrite{{Desc: b, Public: json.RawMessage(`2`)}})
+		}},
+		{"SetValue", func(m *Manager) error { return m.SetValue(ctx, b, int64(2)) }},
+		{"SetIfAbsent", func(m *Manager) error { return m.SetIfAbsent(ctx, b, int64(2)) }},
+	} {
+		t.Run(tc.name+" refuses", func(t *testing.T) {
+			st := newSettingsTestStore(t)
+			m := NewManager(st, nil, []Descriptor{a, b}, WithCrossValidation(refuse))
+			require.NoError(t, m.Load(ctx))
+			require.NoError(t, m.SetValue(ctx, a, int64(1)), "the first key alone is a legal state")
+			before := m.currentEpoch()
+
+			err := tc.write(m)
+			require.Error(t, err, "the verb must run the cross-key rules")
+			require.ErrorContains(t, err, "cannot both be set")
+			var invalid *InvalidError
+			assert.ErrorAs(t, err, &invalid, "a refused combination is the caller's mistake, not a fault")
+			assert.Equal(t, before, m.currentEpoch(), "a refused write must not publish")
+			assert.False(t, m.Snapshot(ctx).Customized(b), "and must not land in the store")
+		})
+	}
+
+	// Reset and ResetMany reach crossValidate through ResetMany, and Reset
+	// wraps the error -- the class has to survive that wrap.
+	for _, tc := range []struct {
+		name  string
+		write func(m *Manager) error
+	}{
+		{"Reset", func(m *Manager) error { return m.Reset(ctx, a) }},
+		{"ResetMany", func(m *Manager) error { return m.ResetMany(ctx, []Descriptor{a}) }},
+	} {
+		t.Run(tc.name+" refuses", func(t *testing.T) {
+			st := newSettingsTestStore(t)
+			// This rule refuses the state a reset PRODUCES, so the reset
+			// itself is what the rule has to see.
+			requireA := func(s *Snapshot) error {
+				if !s.Customized(a) {
+					return fmt.Errorf("cross.a must stay set")
+				}
+				return nil
+			}
+			m := NewManager(st, nil, []Descriptor{a, b}, WithCrossValidation(requireA))
+			require.NoError(t, m.Load(ctx))
+			require.NoError(t, m.SetValue(ctx, a, int64(1)))
+			before := m.currentEpoch()
+
+			err := tc.write(m)
+			require.Error(t, err, "the verb must run the cross-key rules")
+			require.ErrorContains(t, err, "must stay set")
+			var invalid *InvalidError
+			assert.ErrorAs(t, err, &invalid, "the error class must survive Reset's wrap")
+			assert.Equal(t, before, m.currentEpoch(), "a refused reset must not publish")
+			assert.True(t, m.Snapshot(ctx).Customized(a), "and must leave the row in place")
+		})
+	}
 }
 
 // TestUpdateSecretRefusalOrder pins the ORDER the secret verb's three

--- a/backend/internal/hub/settings/manager_test.go
+++ b/backend/internal/hub/settings/manager_test.go
@@ -66,8 +66,7 @@ func newTestManagerWithStore(t *testing.T) (*Manager, *Key[testValue], store.Sto
 	require.NoError(t, err)
 
 	k := testKey()
-	m := NewManager(st, ks, []Descriptor{k, KeySMTP, KeyEmailVerificationRequired},
-		WithCrossValidation(SMTPConfigured))
+	m := NewManager(st, ks, []Descriptor{k, KeySMTP})
 	require.NoError(t, m.Load(context.Background()))
 	return m, k, st
 }
@@ -121,17 +120,6 @@ func TestUpdateRejectsInvalidValues(t *testing.T) {
 	err := m.Update(ctx, k, json.RawMessage(`{"port":99999}`))
 	require.Error(t, err)
 	assert.Equal(t, 587, k.Of(m.Snapshot(ctx)).Port, "a rejected write changes nothing")
-}
-
-func TestCrossValidationRejectsImpossibleCombination(t *testing.T) {
-	m, _ := newTestManager(t)
-	ctx := context.Background()
-	err := m.Update(ctx, KeyEmailVerificationRequired, json.RawMessage(`true`))
-	require.Error(t, err, "verification without SMTP must be refused at write time")
-
-	// With SMTP staged first, the same write succeeds.
-	require.NoError(t, m.Update(ctx, KeySMTP, json.RawMessage(`{"host":"smtp.example.com","from_address":"hub@example.com","port":587,"tls_mode":"starttls"}`)))
-	require.NoError(t, m.Update(ctx, KeyEmailVerificationRequired, json.RawMessage(`true`)))
 }
 
 func TestSecretRoundTripAndRedaction(t *testing.T) {
@@ -345,37 +333,23 @@ func TestEmailVerificationEffectiveDegradesWithoutSMTP(t *testing.T) {
 	st, err := sqlite.Open(":memory:", sqlitedb.Config{})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = st.Close() })
+
 	key, err := keystore.GenerateKey()
 	require.NoError(t, err)
 	ks, err := keystore.New(map[uint32][32]byte{1: key})
 	require.NoError(t, err)
 
-	now := time.Now()
-	m := NewManager(st, ks, []Descriptor{KeySMTP, KeyEmailVerificationRequired},
-		WithCrossValidation(SMTPConfigured), WithNow(func() time.Time { return now }))
+	m := NewManager(st, ks, []Descriptor{KeySMTP})
 	require.NoError(t, m.Load(context.Background()))
 	ctx := context.Background()
 
-	// Out of the box: verification off, SMTP off.
 	assert.False(t, EmailVerificationEffective(m.Snapshot(ctx)))
 
-	// Verification on with SMTP configured: the cross rule allowed the
-	// write, and the read agrees.
 	require.NoError(t, m.Update(ctx, KeySMTP, json.RawMessage(`{"host":"smtp.example.com","from_address":"hub@example.com","port":587,"tls_mode":"starttls"}`)))
-	require.NoError(t, m.Update(ctx, KeyEmailVerificationRequired, json.RawMessage(`true`)))
 	assert.True(t, EmailVerificationEffective(m.Snapshot(ctx)))
 
-	// SMTP removed behind the write path's back (direct SQL): the read
-	// degrades verification to off rather than locking every signup
-	// behind an email that can never be sent. The raw key still says
-	// true; only the effective view degrades.
-	require.NoError(t, st.Settings().Delete(ctx, KeySMTP.Name()))
-	now = now.Add(2 * cacheTTL) // let the cached snapshot expire
-	snap := m.Snapshot(ctx)
-	assert.True(t, KeyEmailVerificationRequired.Of(snap),
-		"the raw key still says true (only the write path was bypassed)")
-	assert.False(t, EmailVerificationEffective(snap),
-		"effective verification degrades once the SMTP removal is visible")
+	require.NoError(t, m.Reset(ctx, KeySMTP))
+	assert.False(t, EmailVerificationEffective(m.Snapshot(ctx)))
 }
 
 // upsertParams writes a row directly through the store, bypassing the
@@ -431,21 +405,12 @@ func TestUpdateRejectsUnknownFields(t *testing.T) {
 	assert.Equal(t, "smtp.example.com", k.Of(m.Snapshot(ctx)).Host, "a rejected write changes nothing")
 }
 
-// TestResetRunsCrossValidation pins that Reset cannot store the exact
-// combination the update path refuses: dropping the smtp row while
-// email_verification_required stays true must fail the same way
-// `settings set smtp '{"host":""}'` does.
-func TestResetRunsCrossValidation(t *testing.T) {
+// TestResetClearsSMTPRow pins that Reset removes a customized SMTP row and
+// returns the setting to its code default (verification gate off).
+func TestResetClearsSMTPRow(t *testing.T) {
 	m, _ := newTestManager(t)
 	ctx := context.Background()
 	require.NoError(t, m.Update(ctx, KeySMTP, json.RawMessage(`{"host":"smtp.example.com","from_address":"hub@example.com","port":587,"tls_mode":"starttls"}`)))
-	require.NoError(t, m.Update(ctx, KeyEmailVerificationRequired, json.RawMessage(`true`)))
-
-	err := m.Reset(ctx, KeySMTP)
-	require.ErrorContains(t, err, "email_verification_required=true needs the smtp host and from address")
-
-	// Lowering the requirement first makes the same reset succeed.
-	require.NoError(t, m.Update(ctx, KeyEmailVerificationRequired, json.RawMessage(`false`)))
 	require.NoError(t, m.Reset(ctx, KeySMTP))
 	assert.False(t, m.Snapshot(ctx).Customized(KeySMTP))
 }
@@ -725,16 +690,6 @@ func TestManagerWriteErrorsAreTyped(t *testing.T) {
 		var invalid *InvalidError
 		assert.ErrorAs(t, m.UpdateSecret(ctx, plain, json.RawMessage(`{"x":"y"}`)), &invalid)
 	})
-
-	// A cross-key rule refusal is equally the caller's to fix.
-	t.Run("a cross-key rule refusal", func(t *testing.T) {
-		var invalid *InvalidError
-		err := m.Update(ctx, KeyEmailVerificationRequired, json.RawMessage(`true`))
-		if err != nil {
-			assert.ErrorAs(t, err, &invalid,
-				"SMTPConfigured refuses verification without SMTP; that is caller input")
-		}
-	})
 }
 
 // TestUpdateManyLandsEveryKeyWithItsOwnDocument is the atomic verb's
@@ -834,23 +789,33 @@ func TestUpdateManyValidatesEveryKeyBeforeWritingAny(t *testing.T) {
 // whether the key HAS an encrypted half. The refusal belongs in the
 // manager, not in a handler, so every caller of the verb is covered.
 func TestUpdateManyRefusesASecretHalfForAKeyWithNoSecretFields(t *testing.T) {
-	m, _ := newTestManager(t)
+	st, err := sqlite.Open(":memory:", sqlitedb.Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	key, err := keystore.GenerateKey()
+	require.NoError(t, err)
+	ks, err := keystore.New(map[uint32][32]byte{1: key})
+	require.NoError(t, err)
+
+	m := NewManager(st, ks, []Descriptor{KeySignupEnabled, testKey()})
+	require.NoError(t, m.Load(context.Background()))
 	ctx := context.Background()
 	partial := json.RawMessage(`{"pass":"hunter2"}`)
 
-	err := m.UpdateMany(ctx, []KeyWrite{
-		{Desc: KeyEmailVerificationRequired, Secret: partial},
+	err = m.UpdateMany(ctx, []KeyWrite{
+		{Desc: KeySignupEnabled, Secret: partial},
 	})
 	require.Error(t, err)
 	var invalid *InvalidError
 	require.ErrorAs(t, err, &invalid, "a caller-supplied shape is InvalidArgument, not a store fault")
 
-	single := m.UpdateSecret(ctx, KeyEmailVerificationRequired, partial)
+	single := m.UpdateSecret(ctx, KeySignupEnabled, partial)
 	require.Error(t, single)
 	assert.Equal(t, single.Error(), err.Error(),
 		"the two verbs must refuse the same input with the same words")
 
-	assert.False(t, m.Snapshot(ctx).Customized(KeyEmailVerificationRequired),
+	assert.False(t, m.Snapshot(ctx).Customized(KeySignupEnabled),
 		"the refused write must store nothing")
 
 	// A key that DOES declare secret fields still takes the same document.
@@ -1729,9 +1694,7 @@ func TestARefusedWriteNeitherPublishesNorFiresSubscribers(t *testing.T) {
 	// it, and a cross-key rule over the whole candidate.
 	require.Error(t, m.UpdateMany(ctx, nil), "no writes given")
 	require.Error(t, m.Update(ctx, k, json.RawMessage(`{"port":99999}`)), "the key's validator refuses the value")
-	require.Error(t, m.Update(ctx, KeyEmailVerificationRequired, json.RawMessage(`true`)), "the cross-key rule refuses the combination")
 	require.Error(t, m.ResetMany(ctx, []Descriptor{NewKey[bool]("never.registered")}))
-	require.Error(t, m.SetValue(ctx, KeyEmailVerificationRequired, true), "the same cross-key refusal through the complete-value verb")
 
 	assert.Equal(t, before, m.currentEpoch(),
 		"a refused write must not reload and publish; it stored nothing")
@@ -1925,25 +1888,14 @@ func TestEveryWriteVerbRefusesAnUnregisteredKey(t *testing.T) {
 	assert.Equal(t, int64(9), b.Of(m.Snapshot(ctx)))
 }
 
-// TestSetIfAbsentRunsTheCrossKeyRules pins that the first-use provisioning
-// verb is not a way around the rules that span keys. It shares prepareRows
-// with every other write path; only its store call differs.
-func TestSetIfAbsentRunsTheCrossKeyRules(t *testing.T) {
-	m, _, st := newTestManagerWithStore(t)
+// TestSetIfAbsentSharesPrepareRowsWithOtherWrites pins that SetIfAbsent
+// goes through the same prepareRows path as Update (validation, registry
+// check). Email verification no longer has a cross-key rule — it follows SMTP.
+func TestSetIfAbsentSharesPrepareRowsWithOtherWrites(t *testing.T) {
+	m, k := newTestManager(t)
 	ctx := context.Background()
-
-	err := KeyEmailVerificationRequired.SetIfAbsent(ctx, m, true)
-	require.ErrorContains(t, err, "email_verification_required=true needs the smtp host and from address")
-	var invalid *InvalidError
-	require.ErrorAs(t, err, &invalid, "a refused combination is the caller's to fix")
-	_, getErr := st.Settings().Get(ctx, KeyEmailVerificationRequired.Name())
-	assert.ErrorIs(t, getErr, store.ErrNotFound, "the refused insert stores nothing")
-
-	// With the relay staged first, the same first-use insert lands.
-	require.NoError(t, m.Update(ctx, KeySMTP, json.RawMessage(
-		`{"host":"smtp.example.com","from_address":"hub@example.com","port":587,"tls_mode":"starttls"}`)))
-	require.NoError(t, KeyEmailVerificationRequired.SetIfAbsent(ctx, m, true))
-	assert.True(t, KeyEmailVerificationRequired.Of(m.Snapshot(ctx)))
+	require.NoError(t, k.SetIfAbsent(ctx, m, testValue{Port: 2525}))
+	assert.Equal(t, 2525, k.Of(m.Snapshot(ctx)).Port)
 }
 
 // TestUpdateSecretRefusalOrder pins the ORDER the secret verb's three
@@ -1959,7 +1911,7 @@ func TestUpdateSecretRefusalOrder(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("a key with no secret half, and no document", func(t *testing.T) {
-		err := m.UpdateSecret(ctx, KeyEmailVerificationRequired, nil)
+		err := m.UpdateSecret(ctx, KeySignupEnabled, nil)
 		require.ErrorContains(t, err, "has no secret fields")
 		assert.NotContains(t, err.Error(), "the partial document is required",
 			"the key's shape is answered before the document is examined")
@@ -1987,19 +1939,6 @@ func TestUpdateSecretRefusalOrder(t *testing.T) {
 func TestResetKeepsTheErrorClassThroughItsWrap(t *testing.T) {
 	m, _ := newTestManager(t)
 	ctx := context.Background()
-
-	t.Run("a cross-key refusal", func(t *testing.T) {
-		require.NoError(t, m.Update(ctx, KeySMTP, json.RawMessage(
-			`{"host":"smtp.example.com","from_address":"hub@example.com","port":587,"tls_mode":"starttls"}`)))
-		require.NoError(t, m.Update(ctx, KeyEmailVerificationRequired, json.RawMessage(`true`)))
-
-		err := m.Reset(ctx, KeySMTP)
-		var invalid *InvalidError
-		require.ErrorAs(t, err, &invalid, "the class survives the wrap")
-		assert.Contains(t, err.Error(), `reset setting "smtp"`, "and the wrap says which key")
-		assert.Contains(t, err.Error(), "email_verification_required=true needs the smtp host and from address",
-			"and the cross-key rule's own cause stays readable")
-	})
 
 	t.Run("an unregistered key", func(t *testing.T) {
 		err := m.Reset(ctx, NewKey[bool]("never.registered"))

--- a/backend/internal/hub/settingsregistry/settingsregistry.go
+++ b/backend/internal/hub/settingsregistry/settingsregistry.go
@@ -16,16 +16,16 @@ import (
 )
 
 // NewManager builds the settings manager over st with every domain's
-// descriptors registered and both cross-key rules attached (SMTP
-// availability for email verification; provider completeness for the
-// captcha selection). Extra options — test TTLs and clock overrides —
-// apply after the registry defaults, so callers never restate the
-// registry itself.
+// descriptors registered and the captcha cross-key rule attached (provider
+// completeness for the captcha selection). Email verification follows SMTP
+// via EmailVerificationEffective — there is no separate verification toggle.
+// Extra options — test TTLs and clock overrides — apply after the registry
+// defaults, so callers never restate the registry itself.
 func NewManager(st store.Store, ks *keystore.Keystore, opts ...settings.Option) *settings.Manager {
 	descs := append(settings.CoreDescriptors(), captcha.SettingsDescriptors()...)
 	descs = append(descs, ratelimit.SettingsDescriptors()...)
 	opts = append([]settings.Option{
-		settings.WithCrossValidation(settings.SMTPConfigured, captcha.SelectedConfigured),
+		settings.WithCrossValidation(captcha.SelectedConfigured),
 	}, opts...)
 	return settings.NewManager(st, ks, descs, opts...)
 }

--- a/backend/internal/hub/store/mysql/cleanup.go
+++ b/backend/internal/hub/store/mysql/cleanup.go
@@ -14,8 +14,8 @@ type cleanupStore struct {
 
 var _ store.CleanupStore = (*cleanupStore)(nil)
 
-func (s *cleanupStore) HardDeleteExpiredSessions(ctx context.Context) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteExpiredUserSessions(ctx))
+func (s *cleanupStore) HardDeleteExpiredSessions(ctx context.Context, now time.Time) (int64, error) {
+	return rowsAffected(s.conn.q.DeleteExpiredUserSessions(ctx, sqltime.NewMySQLTime(now)))
 }
 
 func (s *cleanupStore) HardDeleteWorkspacesBefore(ctx context.Context, cutoff time.Time) (int64, error) {
@@ -38,12 +38,16 @@ func (s *cleanupStore) HardDeleteUsersBefore(ctx context.Context, cutoff time.Ti
 	return rowsAffected(s.conn.q.HardDeleteUsersBefore(ctx, sqltime.MySQLNullTimeOf(cutoff)))
 }
 
-func (s *cleanupStore) DeleteExpiredOAuthStates(ctx context.Context) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteExpiredOAuthStates(ctx))
+func (s *cleanupStore) DeleteExpiredOAuthStates(ctx context.Context, now time.Time) (int64, error) {
+	return rowsAffected(s.conn.q.DeleteExpiredOAuthStates(ctx, sqltime.NewMySQLTime(now)))
 }
 
-func (s *cleanupStore) DeleteExpiredPendingOAuthSignups(ctx context.Context) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteExpiredPendingOAuthSignups(ctx))
+func (s *cleanupStore) DeleteExpiredPendingOAuthSignups(ctx context.Context, now time.Time) (int64, error) {
+	return rowsAffected(s.conn.q.DeleteExpiredPendingOAuthSignups(ctx, sqltime.NewMySQLTime(now)))
+}
+
+func (s *cleanupStore) DeleteExpiredWebAuthnSessions(ctx context.Context, now time.Time) (int64, error) {
+	return rowsAffected(s.conn.q.DeleteExpiredWebAuthnSessions(ctx, sqltime.NewMySQLTime(now)))
 }
 
 func (s *cleanupStore) DeleteExpiredDeviceAuthorizations(ctx context.Context, cutoff time.Time) (int64, error) {

--- a/backend/internal/hub/store/mysql/cleanup.go
+++ b/backend/internal/hub/store/mysql/cleanup.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/leapmux/leapmux/internal/hub/store"
+	gendb "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
 	"github.com/leapmux/leapmux/internal/util/sqltime"
 )
 
@@ -31,7 +32,10 @@ func (s *cleanupStore) HardDeleteExpiredRegistrationKeysBefore(ctx context.Conte
 }
 
 func (s *cleanupStore) ClearStalePendingEmails(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.ClearStalePendingEmails(ctx, sqltime.MySQLNullTimeOf(cutoff)))
+	return rowsAffected(s.conn.q.ClearStalePendingEmails(ctx, gendb.ClearStalePendingEmailsParams{
+		Cutoff:         sqltime.MySQLNullTimeOf(cutoff),
+		CodelessCutoff: sqltime.NewMySQLTime(cutoff),
+	}))
 }
 
 func (s *cleanupStore) HardDeleteUsersBefore(ctx context.Context, cutoff time.Time) (int64, error) {
@@ -50,12 +54,12 @@ func (s *cleanupStore) DeleteExpiredWebAuthnSessions(ctx context.Context, now ti
 	return rowsAffected(s.conn.q.DeleteExpiredWebAuthnSessions(ctx, sqltime.NewMySQLTime(now)))
 }
 
-func (s *cleanupStore) DeleteExpiredDeviceAuthorizations(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteExpiredDeviceAuthorizations(ctx, sqltime.NewMySQLTime(cutoff)))
+func (s *cleanupStore) DeleteExpiredDeviceAuthorizations(ctx context.Context, now time.Time) (int64, error) {
+	return rowsAffected(s.conn.q.DeleteExpiredDeviceAuthorizations(ctx, sqltime.NewMySQLTime(now)))
 }
 
-func (s *cleanupStore) DeleteExpiredCLIAuthorizationCodes(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteExpiredCLIAuthorizationCodes(ctx, sqltime.NewMySQLTime(cutoff)))
+func (s *cleanupStore) DeleteExpiredCLIAuthorizationCodes(ctx context.Context, now time.Time) (int64, error) {
+	return rowsAffected(s.conn.q.DeleteExpiredCLIAuthorizationCodes(ctx, sqltime.NewMySQLTime(now)))
 }
 
 func (s *cleanupStore) DeleteRevokedAPITokensBefore(ctx context.Context, cutoff time.Time) (int64, error) {
@@ -66,8 +70,8 @@ func (s *cleanupStore) DeleteRevokedDelegationTokensBefore(ctx context.Context, 
 	return rowsAffected(s.conn.q.DeleteRevokedDelegationTokensBefore(ctx, sqltime.MySQLNullTimeOf(cutoff)))
 }
 
-func (s *cleanupStore) DeleteExpiredDelegationTokensBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteExpiredDelegationTokensBefore(ctx, sqltime.NewMySQLTime(cutoff)))
+func (s *cleanupStore) DeleteExpiredDelegationTokensBefore(ctx context.Context, now time.Time) (int64, error) {
+	return rowsAffected(s.conn.q.DeleteExpiredDelegationTokensBefore(ctx, sqltime.NewMySQLTime(now)))
 }
 
 func (s *cleanupStore) DeleteExpiredAltchaSalts(ctx context.Context) (int64, error) {

--- a/backend/internal/hub/store/mysql/cli_authorization_codes.go
+++ b/backend/internal/hub/store/mysql/cli_authorization_codes.go
@@ -2,6 +2,7 @@ package mysql
 
 import (
 	"context"
+	"time"
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
@@ -34,8 +35,11 @@ func (s *cliAuthorizationCodeStore) Create(ctx context.Context, p store.CreateCL
 	}))
 }
 
-func (s *cliAuthorizationCodeStore) GetActive(ctx context.Context, code string) (*store.CLIAuthorizationCode, error) {
-	row, err := s.conn.q.GetActiveCLIAuthorizationCode(ctx, code)
+func (s *cliAuthorizationCodeStore) GetActive(ctx context.Context, code string, now time.Time) (*store.CLIAuthorizationCode, error) {
+	row, err := s.conn.q.GetActiveCLIAuthorizationCode(ctx, gendb.GetActiveCLIAuthorizationCodeParams{
+		Code: code,
+		Now:  sqltime.NewMySQLTime(now),
+	})
 	if err != nil {
 		return nil, mapErr(err)
 	}
@@ -47,8 +51,11 @@ func (s *cliAuthorizationCodeStore) GetActive(ctx context.Context, code string) 
 // the row as consumed (returning rows-affected); if anything was affected,
 // re-read the row to return its contents. RETURNING is unavailable on
 // MySQL.
-func (s *cliAuthorizationCodeStore) Consume(ctx context.Context, code string) (*store.CLIAuthorizationCode, error) {
-	rows, err := rowsAffected(s.conn.q.ConsumeCLIAuthorizationCode(ctx, code))
+func (s *cliAuthorizationCodeStore) Consume(ctx context.Context, code string, now time.Time) (*store.CLIAuthorizationCode, error) {
+	rows, err := rowsAffected(s.conn.q.ConsumeCLIAuthorizationCode(ctx, gendb.ConsumeCLIAuthorizationCodeParams{
+		Code: code,
+		Now:  sqltime.NewMySQLTime(now),
+	}))
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/hub/store/mysql/convert.go
+++ b/backend/internal/hub/store/mysql/convert.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"time"
 
 	mysqldriver "github.com/go-sql-driver/mysql"
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
@@ -155,15 +156,17 @@ func listWorkersAdminByUserAndStatusParams(status leapmuxv1.WorkerStatus, userID
 	})
 }
 
-func listAllActiveSessionsParams(cursor string, limit int64) (gendb.ListAllActiveSessionsParams, error) {
+func listAllActiveSessionsParams(cursor string, limit int64, now time.Time) (gendb.ListAllActiveSessionsParams, error) {
+	nt := sqltime.NewMySQLTime(now)
 	return withCursor(cursor, limit, func(ct sqltime.MySQLNullTime, cid sql.NullString, fl int32) gendb.ListAllActiveSessionsParams {
-		return gendb.ListAllActiveSessionsParams{CursorTime: ct, CursorID: cid, Limit: fl}
+		return gendb.ListAllActiveSessionsParams{Now: nt, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 
-func listUserSessionsParams(userID, cursor string, limit int64) (gendb.ListUserSessionsByUserIDParams, error) {
+func listUserSessionsParams(userID, cursor string, limit int64, now time.Time) (gendb.ListUserSessionsByUserIDParams, error) {
+	nt := sqltime.NewMySQLTime(now)
 	return withCursor(cursor, limit, func(ct sqltime.MySQLNullTime, cid sql.NullString, fl int32) gendb.ListUserSessionsByUserIDParams {
-		return gendb.ListUserSessionsByUserIDParams{UserID: userID, CursorTime: ct, CursorID: cid, Limit: fl}
+		return gendb.ListUserSessionsByUserIDParams{UserID: userID, Now: nt, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 

--- a/backend/internal/hub/store/mysql/db/migrations/00001_initial.sql
+++ b/backend/internal/hub/store/mysql/db/migrations/00001_initial.sql
@@ -56,6 +56,10 @@ CREATE TABLE users (
     -- Counts attempts against the active pending_email_token. Reset to 0
     -- whenever a new token is issued; force-expires the token at >5.
     pending_email_attempts   INT NOT NULL DEFAULT 0,
+    -- Password-reset break-glass: token stored hashed (SHA-256 hex).
+    pending_password_reset_token      VARCHAR(64) NOT NULL DEFAULT '',
+    pending_password_reset_expires_at DATETIME(3),
+    pending_password_reset_attempts   INT NOT NULL DEFAULT 0,
     password_set             BOOLEAN NOT NULL DEFAULT TRUE,
     is_admin                 BOOLEAN NOT NULL DEFAULT FALSE,
     prefs          MEDIUMTEXT NOT NULL,
@@ -83,6 +87,9 @@ CREATE INDEX idx_users_created_at ON users(created_at DESC, id DESC);
 -- Verification codes are looked up per-user (the session identifies who),
 -- so no global token index is needed. Index expiry instead, for cleanup.
 CREATE INDEX idx_users_pending_email_expires_at ON users(pending_email_expires_at);
+-- Password-reset tokens are looked up by hash on complete. MySQL has no
+-- partial indexes, so this covers every row (empty token is the common case).
+CREATE INDEX idx_users_pending_password_reset_token ON users(pending_password_reset_token);
 -- GetFirstAdmin scans for the earliest non-deleted admin (bootstrap path).
 -- MySQL has no partial indexes; the composite indexes deleted_at as a key
 -- part (IS NULL is a ref-able key part in MySQL), so the ORDER BY created_at
@@ -559,6 +566,45 @@ CREATE TABLE pending_oauth_signups (
     FOREIGN KEY (provider_id) REFERENCES oauth_providers(id)
 ) COLLATE=utf8mb4_bin;
 
+-- Passkey (WebAuthn) credentials for email-local accounts
+CREATE TABLE passkey_credentials (
+    id              VARCHAR(255) PRIMARY KEY,
+    user_id         VARCHAR(255) NOT NULL,
+    credential_id   VARBINARY(1023) NOT NULL,   -- plaintext: login lookup + unique index (WebAuthn max 1023 bytes; not BLOB — MySQL/TiDB reject unique indexes on TEXT/BLOB)
+    public_key      BLOB NOT NULL,   -- keystore-encrypted COSE public key, AAD: 'passkey_public_key:' || id
+    sign_count      BIGINT NOT NULL DEFAULT 0,
+    aaguid          BLOB,
+    backup_eligible BOOLEAN NOT NULL DEFAULT FALSE,
+    backup_state    BOOLEAN NOT NULL DEFAULT FALSE,
+    transports      TEXT NOT NULL,
+    friendly_name   TEXT NOT NULL,
+    key_version     BIGINT NOT NULL DEFAULT 1,  -- active keystore version at write; for reencrypt scans
+    created_at      DATETIME(3) NOT NULL,
+    last_used_at    DATETIME(3),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) COLLATE=utf8mb4_bin;
+CREATE UNIQUE INDEX idx_passkey_credentials_credential_id ON passkey_credentials(credential_id);
+CREATE INDEX idx_passkey_credentials_user_id ON passkey_credentials(user_id);
+CREATE INDEX idx_passkey_credentials_key_version ON passkey_credentials(key_version);
+
+-- Ephemeral WebAuthn ceremony state (signup, login, register, reauth)
+CREATE TABLE webauthn_sessions (
+    id           VARCHAR(255) PRIMARY KEY,
+    kind         VARCHAR(32) NOT NULL,
+    user_id      VARCHAR(255),
+    payload_json TEXT NOT NULL,              -- '{}' or keystore-encrypted signup draft (base64), AAD: 'webauthn_payload:' || id
+    session_data BLOB NOT NULL,              -- keystore-encrypted ceremony state, AAD: 'webauthn_session:' || id
+    expires_at   DATETIME(3) NOT NULL,
+    created_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    CHECK (kind IN ('signup', 'login', 'register', 'reauth', 'reauth_proof'))
+) COLLATE=utf8mb4_bin;
+CREATE INDEX idx_webauthn_sessions_expires_at ON webauthn_sessions(expires_at);
+
+-- Ceremony begins delete prior rows per user and kind on every Begin*;
+-- without this index each begin full-scans the not-yet-swept rows.
+CREATE INDEX idx_webauthn_sessions_user_kind ON webauthn_sessions(user_id, kind);
+
 -- Instance-level hub settings: one row per setting key. `value` is a JSON
 -- document whose shape is defined by the owning package's typed key handle
 -- (internal/hub/settings); secret-bearing keys keep the secret half in the
@@ -596,6 +642,8 @@ DROP TABLE IF EXISTS revocation_events;
 DROP TABLE IF EXISTS revocation_event_sequence;
 DROP TABLE IF EXISTS pending_oauth_signups;
 DROP TABLE IF EXISTS altcha_used_salts;
+DROP TABLE IF EXISTS webauthn_sessions;
+DROP TABLE IF EXISTS passkey_credentials;
 DROP TABLE IF EXISTS hub_settings;
 DROP TABLE IF EXISTS oauth_states;
 DROP TABLE IF EXISTS oauth_tokens;

--- a/backend/internal/hub/store/mysql/db/migrations/00001_initial.sql
+++ b/backend/internal/hub/store/mysql/db/migrations/00001_initial.sql
@@ -570,7 +570,7 @@ CREATE TABLE pending_oauth_signups (
 CREATE TABLE passkey_credentials (
     id              VARCHAR(255) PRIMARY KEY,
     user_id         VARCHAR(255) NOT NULL,
-    credential_id   VARBINARY(1023) NOT NULL,   -- plaintext: login lookup + unique index (WebAuthn max 1023 bytes; not BLOB — MySQL/TiDB reject unique indexes on TEXT/BLOB)
+    credential_id   VARBINARY(1023) NOT NULL,   -- plaintext: login lookup + unique index (WebAuthn max 1023 bytes; not BLOB -- MySQL/TiDB reject unique indexes on TEXT/BLOB)
     public_key      BLOB NOT NULL,   -- keystore-encrypted COSE public key, AAD: 'passkey_public_key:' || id
     sign_count      BIGINT NOT NULL DEFAULT 0,
     aaguid          BLOB,
@@ -610,7 +610,7 @@ CREATE INDEX idx_webauthn_sessions_user_kind ON webauthn_sessions(user_id, kind)
 -- (internal/hub/settings); secret-bearing keys keep the secret half in the
 -- keystore-encrypted column (AAD bound to the key name). An absent row means
 -- the code default, so adding, removing, or reshaping a setting is a Go
--- change only — never a migration. This table is the single home for all
+-- change only -- never a migration. This table is the single home for all
 -- runtime-changeable configuration (auth policy, SMTP, timeouts, limits,
 -- captcha providers, rate-limit overrides).
 CREATE TABLE hub_settings (

--- a/backend/internal/hub/store/mysql/db/queries/cli_authorization_codes.sql
+++ b/backend/internal/hub/store/mysql/db/queries/cli_authorization_codes.sql
@@ -1,3 +1,8 @@
+-- Clock rule: expires_at columns are written by the hub process, so every
+-- comparison of them binds the hub's clock (sqlc.arg(now)), never the
+-- database clock. Timestamps that record when something happened keep the
+-- database clock.
+
 -- name: CreateCLIAuthorizationCode :exec
 INSERT INTO cli_authorization_codes (
     code, user_id, code_challenge, device_name, expires_at
@@ -5,12 +10,12 @@ INSERT INTO cli_authorization_codes (
 
 -- name: GetActiveCLIAuthorizationCode :one
 SELECT * FROM cli_authorization_codes
-WHERE code = ? AND consumed_at IS NULL AND expires_at > NOW(3);
+WHERE code = ? AND consumed_at IS NULL AND expires_at > sqlc.arg(now);
 
 -- name: ConsumeCLIAuthorizationCode :execresult
 UPDATE cli_authorization_codes
 SET consumed_at = NOW(3)
-WHERE code = ? AND consumed_at IS NULL AND expires_at > NOW(3);
+WHERE code = ? AND consumed_at IS NULL AND expires_at > sqlc.arg(now);
 
 -- name: GetCLIAuthorizationCode :one
 SELECT * FROM cli_authorization_codes WHERE code = ?;

--- a/backend/internal/hub/store/mysql/db/queries/delegation_tokens.sql
+++ b/backend/internal/hub/store/mysql/db/queries/delegation_tokens.sql
@@ -1,3 +1,8 @@
+-- Clock rule: expires_at columns are written by the hub process, so every
+-- comparison of them binds the hub's clock (sqlc.arg(now)), never the
+-- database clock. Timestamps that record when something happened keep the
+-- database clock.
+
 -- name: CreateDelegationToken :exec
 INSERT INTO delegation_tokens (
     id, user_id, worker_id, agent_id, terminal_id,
@@ -71,7 +76,7 @@ LIMIT ?;
 SELECT * FROM delegation_tokens
 WHERE user_id = ?
   AND revoked_at IS NULL
-  AND expires_at > NOW(3)
+  AND expires_at > sqlc.arg(now)
 ORDER BY created_at DESC;
 
 -- name: RevokeDelegationTokensByUserFast :execresult

--- a/backend/internal/hub/store/mysql/db/queries/device_authorizations.sql
+++ b/backend/internal/hub/store/mysql/db/queries/device_authorizations.sql
@@ -1,3 +1,8 @@
+-- Clock rule: expires_at columns are written by the hub process, so every
+-- comparison of them binds the hub's clock (sqlc.arg(now)), never the
+-- database clock. Timestamps that record when something happened keep the
+-- database clock.
+
 -- name: CreateDeviceAuthorization :exec
 INSERT INTO device_authorizations (
     device_code, user_code, device_name, interval_seconds, expires_at
@@ -12,12 +17,12 @@ SELECT * FROM device_authorizations WHERE user_code = ?;
 -- name: ApproveDeviceAuthorization :execresult
 UPDATE device_authorizations
 SET approved = 1, user_id = ?
-WHERE device_code = ? AND consumed_at IS NULL AND expires_at > NOW(3);
+WHERE device_code = ? AND consumed_at IS NULL AND expires_at > sqlc.arg(now);
 
 -- name: ApproveDeviceAuthorizationByUserCode :execresult
 UPDATE device_authorizations
 SET approved = 1, user_id = ?
-WHERE user_code = ? AND consumed_at IS NULL AND expires_at > NOW(3);
+WHERE user_code = ? AND consumed_at IS NULL AND expires_at > sqlc.arg(now);
 
 -- name: DenyDeviceAuthorization :execresult
 UPDATE device_authorizations
@@ -28,7 +33,7 @@ WHERE device_code = ? AND consumed_at IS NULL;
 UPDATE device_authorizations
 SET consumed_at = NOW(3)
 WHERE device_code = ? AND approved = 1 AND consumed_at IS NULL
-  AND expires_at > NOW(3);
+  AND expires_at > sqlc.arg(now);
 
 -- name: TouchDeviceAuthorizationPoll :exec
 UPDATE device_authorizations

--- a/backend/internal/hub/store/mysql/db/queries/oauth_states.sql
+++ b/backend/internal/hub/store/mysql/db/queries/oauth_states.sql
@@ -1,3 +1,8 @@
+-- Clock rule: expires_at columns are written by the hub process, so every
+-- comparison of them binds the hub's clock (sqlc.arg(now)), never the
+-- database clock. Timestamps that record when something happened keep the
+-- database clock.
+
 -- name: CreateOAuthState :exec
 INSERT INTO oauth_states (state, provider_id, pkce_verifier, redirect_uri, expires_at)
 VALUES (?, ?, ?, ?, ?);
@@ -9,4 +14,4 @@ SELECT * FROM oauth_states WHERE state = ?;
 DELETE FROM oauth_states WHERE state = ?;
 
 -- name: DeleteExpiredOAuthStates :execresult
-DELETE FROM oauth_states WHERE expires_at < NOW(3);
+DELETE FROM oauth_states WHERE expires_at < sqlc.arg(now);

--- a/backend/internal/hub/store/mysql/db/queries/oauth_tokens.sql
+++ b/backend/internal/hub/store/mysql/db/queries/oauth_tokens.sql
@@ -1,3 +1,7 @@
+-- Clock rule: token expiry is stored by the hub process, so the
+-- refresh-due comparison binds the hub's clock (sqlc.arg(refresh_due_at)),
+-- never the database clock.
+
 -- name: UpsertOAuthTokens :exec
 INSERT INTO oauth_tokens (user_id, provider_id, access_token, refresh_token, token_type, expires_at, key_version)
 VALUES (?, ?, ?, ?, ?, ?, ?)
@@ -15,7 +19,7 @@ WHERE user_id = ? AND provider_id = ?;
 
 -- name: ListExpiringOAuthTokens :many
 SELECT * FROM oauth_tokens
-WHERE expires_at <= DATE_ADD(NOW(3), INTERVAL 5 MINUTE);
+WHERE expires_at <= sqlc.arg(refresh_due_at);
 
 -- name: DeleteOAuthTokensByProvider :exec
 DELETE FROM oauth_tokens WHERE provider_id = ?;

--- a/backend/internal/hub/store/mysql/db/queries/passkey_credentials.sql
+++ b/backend/internal/hub/store/mysql/db/queries/passkey_credentials.sql
@@ -1,0 +1,59 @@
+-- name: CreatePasskeyCredential :exec
+INSERT INTO passkey_credentials (
+    id, user_id, credential_id, public_key, sign_count, aaguid,
+    backup_eligible, backup_state, transports, friendly_name, key_version, created_at, last_used_at
+) VALUES (
+    sqlc.arg(id),
+    sqlc.arg(user_id),
+    sqlc.arg(credential_id),
+    sqlc.arg(public_key),
+    sqlc.arg(sign_count),
+    sqlc.narg(aaguid),
+    sqlc.arg(backup_eligible),
+    sqlc.arg(backup_state),
+    sqlc.arg(transports),
+    sqlc.arg(friendly_name),
+    sqlc.arg(key_version),
+    sqlc.arg(created_at),
+    sqlc.narg(last_used_at)
+);
+
+-- name: GetPasskeyCredentialByID :one
+SELECT * FROM passkey_credentials WHERE id = ?;
+
+-- name: GetPasskeyCredentialByCredentialID :one
+SELECT * FROM passkey_credentials WHERE credential_id = ?;
+
+-- name: ListPasskeyCredentialsByUser :many
+SELECT * FROM passkey_credentials WHERE user_id = ? ORDER BY created_at;
+
+-- name: CountPasskeyCredentialsByUser :one
+SELECT COUNT(*) FROM passkey_credentials WHERE user_id = ?;
+
+-- name: UpdatePasskeySignCount :execresult
+UPDATE passkey_credentials
+SET sign_count = sqlc.arg(sign_count), last_used_at = sqlc.arg(last_used_at)
+WHERE credential_id = sqlc.arg(credential_id) AND user_id = sqlc.arg(user_id)
+  AND (sign_count < sqlc.arg(sign_count) OR sqlc.arg(sign_count) = 0);
+
+-- name: UpdatePasskeyFriendlyName :exec
+UPDATE passkey_credentials
+SET friendly_name = sqlc.arg(friendly_name)
+WHERE id = sqlc.arg(id) AND user_id = sqlc.arg(user_id);
+
+-- name: UpdatePasskeyPublicKey :exec
+UPDATE passkey_credentials
+SET public_key = sqlc.arg(public_key), key_version = sqlc.arg(key_version)
+WHERE id = sqlc.arg(id) AND user_id = sqlc.arg(user_id);
+
+-- name: DeletePasskeyCredential :exec
+DELETE FROM passkey_credentials WHERE id = ? AND user_id = ?;
+
+-- name: DeleteAllPasskeyCredentialsByUser :exec
+DELETE FROM passkey_credentials WHERE user_id = ?;
+
+-- name: ListPasskeyCredentialsByKeyVersion :many
+SELECT * FROM passkey_credentials WHERE key_version = ?;
+
+-- name: CountPasskeyCredentialsByKeyVersion :one
+SELECT COUNT(*) FROM passkey_credentials WHERE key_version = ?;

--- a/backend/internal/hub/store/mysql/db/queries/pending_oauth_signups.sql
+++ b/backend/internal/hub/store/mysql/db/queries/pending_oauth_signups.sql
@@ -1,3 +1,8 @@
+-- Clock rule: expires_at columns are written by the hub process, so every
+-- comparison of them binds the hub's clock (sqlc.arg(now)), never the
+-- database clock. Timestamps that record when something happened keep the
+-- database clock.
+
 -- name: CreatePendingOAuthSignup :exec
 INSERT INTO pending_oauth_signups (token, provider_id, provider_subject, email, display_name, access_token, refresh_token, token_type, token_expires_at, key_version, redirect_uri, expires_at)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
@@ -9,4 +14,4 @@ SELECT * FROM pending_oauth_signups WHERE token = ?;
 DELETE FROM pending_oauth_signups WHERE token = ?;
 
 -- name: DeleteExpiredPendingOAuthSignups :execresult
-DELETE FROM pending_oauth_signups WHERE expires_at < NOW(3);
+DELETE FROM pending_oauth_signups WHERE expires_at < sqlc.arg(now);

--- a/backend/internal/hub/store/mysql/db/queries/user_sessions.sql
+++ b/backend/internal/hub/store/mysql/db/queries/user_sessions.sql
@@ -1,3 +1,8 @@
+-- Clock rule: expires_at columns are written by the hub process, so every
+-- comparison of them binds the hub's clock (sqlc.arg(now)), never the
+-- database clock. Timestamps that record when something happened
+-- (created_at, updated_at, last_active_at) keep the database clock.
+
 -- name: CreateUserSession :exec
 INSERT INTO user_sessions (
     id, user_id, expires_at, user_agent, ip_address, auth_generation
@@ -11,7 +16,7 @@ INSERT INTO user_sessions (
 );
 
 -- name: GetUserSessionByID :one
-SELECT * FROM user_sessions WHERE id = ? AND expires_at > NOW(3);
+SELECT * FROM user_sessions WHERE id = ? AND expires_at > sqlc.arg(now);
 
 -- name: TouchUserSession :execrows
 -- The expires_at predicate is what keeps an expired session dead. The Hub
@@ -21,7 +26,7 @@ SELECT * FROM user_sessions WHERE id = ? AND expires_at > NOW(3);
 UPDATE user_sessions
 SET last_active_at = NOW(3),
     expires_at = ?
-WHERE id = ? AND last_active_at < ? AND expires_at > NOW(3);
+WHERE id = ? AND last_active_at < ? AND expires_at > sqlc.arg(now);
 
 -- name: GetUserSessionForUpdate :one
 SELECT id, user_id FROM user_sessions
@@ -36,7 +41,7 @@ SELECT u.id, u.username, u.is_admin, u.email_verified, u.email, s.created_at, s.
 FROM user_sessions s
 JOIN users u ON s.user_id = u.id
 WHERE s.id = ?
-  AND s.expires_at > NOW(3)
+  AND s.expires_at > sqlc.arg(now)
   AND u.deleted_at IS NULL
   AND s.auth_generation >= u.auth_generation;
 
@@ -47,7 +52,7 @@ SET s.auth_generation = u.auth_generation
 WHERE s.id = sqlc.arg(session_id) AND s.user_id = sqlc.arg(user_id);
 
 -- name: DeleteExpiredUserSessions :execresult
-DELETE FROM user_sessions WHERE expires_at < NOW(3);
+DELETE FROM user_sessions WHERE expires_at < sqlc.arg(now);
 
 -- name: DeleteUserSessionsByUser :exec
 DELETE FROM user_sessions WHERE user_id = ?;
@@ -57,7 +62,7 @@ DELETE FROM user_sessions WHERE user_id = ? AND id != ?;
 
 -- name: ListUserSessionsByUserID :many
 SELECT * FROM user_sessions
-WHERE user_id = sqlc.arg(user_id) AND expires_at > NOW(3)
+WHERE user_id = sqlc.arg(user_id) AND expires_at > sqlc.arg(now)
   AND (sqlc.narg(cursor_time) IS NULL OR last_active_at < sqlc.narg(cursor_time) OR (last_active_at = sqlc.narg(cursor_time) AND id < sqlc.narg(cursor_id)))
 ORDER BY last_active_at DESC, id DESC
 LIMIT ?;
@@ -66,7 +71,7 @@ LIMIT ?;
 SELECT s.id, s.user_id, COALESCE(u.username, '') AS username, (u.id IS NULL) AS user_deleted, s.created_at, s.last_active_at, s.expires_at, s.ip_address, s.user_agent
 FROM user_sessions s
 LEFT JOIN users u ON s.user_id = u.id AND u.deleted_at IS NULL
-WHERE s.expires_at > NOW(3)
+WHERE s.expires_at > sqlc.arg(now)
   AND (sqlc.narg(cursor_time) IS NULL OR s.last_active_at < sqlc.narg(cursor_time) OR (s.last_active_at = sqlc.narg(cursor_time) AND s.id < sqlc.narg(cursor_id)))
 ORDER BY s.last_active_at DESC, s.id DESC
 LIMIT ?;

--- a/backend/internal/hub/store/mysql/db/queries/users.sql
+++ b/backend/internal/hub/store/mysql/db/queries/users.sql
@@ -150,8 +150,28 @@ SELECT count(*) FROM users WHERE deleted_at IS NULL;
 -- name: HasAnyUser :one
 SELECT EXISTS(SELECT 1 FROM users WHERE deleted_at IS NULL LIMIT 1) AS has_any;
 
--- name: SetPendingEmail :exec
-UPDATE users SET pending_email = ?, pending_email_token = ?, pending_email_expires_at = ?, pending_email_attempts = 0, updated_at = NOW(3)
+-- name: SetPendingEmail :execresult
+-- Conditional mint: the write lands only when no previous code exists or
+-- the previous code's expiry is at or before cooldown_cutoff, so two
+-- concurrent resends for one account cannot both mint and both send (the
+-- loser matches no row), and RequestEmailChange cannot mint on every
+-- request. Its twin SetPendingPasswordReset carries the same predicate.
+-- The Go caller derives cooldown_cutoff from the resend cooldown; the
+-- comparison stays on the app clock, the clock that wrote the expiry.
+UPDATE users SET pending_email = sqlc.arg(pending_email), pending_email_token = sqlc.arg(pending_email_token), pending_email_expires_at = sqlc.narg(pending_email_expires_at), pending_email_attempts = 0, updated_at = NOW(3)
+WHERE id = sqlc.arg(id)
+  AND (pending_email_expires_at IS NULL
+       OR pending_email_expires_at <= sqlc.arg(cooldown_cutoff));
+
+-- name: ClearPendingEmailCode :exec
+-- ClearPendingEmailCode drops an undelivered code and KEEPS the pending
+-- address. An empty token is the "no live code, address still pending"
+-- state: ConsumeVerificationAttempt and ClearStalePendingEmails both
+-- filter pending_email_token != '', so neither acts on it, and the
+-- cooldown -- which reads the expiry -- does not apply, so the retry a
+-- failed send invites is never blocked. Unconditional on purpose: it
+-- undoes a mint that the relay refused.
+UPDATE users SET pending_email_token = '', pending_email_expires_at = NULL, pending_email_attempts = 0, updated_at = NOW(3)
 WHERE id = ?;
 
 -- name: ClearPendingEmail :exec
@@ -166,12 +186,15 @@ WHERE id = sqlc.arg(id) AND pending_email != '';
 -- the user's pending verification, force-expiring on the 6th try.
 -- MySQL has no RETURNING -- the Go store layer follows up with a
 -- GetUserByID under the row lock taken by this UPDATE.
+-- The expiry CASE is assigned BEFORE the attempt increment: MySQL
+-- evaluates SET clauses left-to-right and a later clause would read the
+-- already-incremented counter, firing the force-expiry one charge early.
 -- name: ConsumeVerificationAttempt :execresult
 UPDATE users
-SET pending_email_attempts = pending_email_attempts + 1,
-    pending_email_expires_at = CASE
+SET pending_email_expires_at = CASE
         WHEN pending_email_attempts + 1 > sqlc.arg(max_attempts) THEN sqlc.arg(now)
         ELSE pending_email_expires_at END,
+    pending_email_attempts = pending_email_attempts + 1,
     updated_at = NOW(3)
 WHERE id = ? AND pending_email_token != '';
 
@@ -180,8 +203,15 @@ UPDATE users SET pending_email = '', pending_email_token = '', pending_email_exp
 WHERE pending_email = ? AND id != ?;
 
 -- name: ClearStalePendingEmails :execresult
+-- The second arm reaps a codeless row: a send the relay refused leaves the
+-- ADDRESS with no token and no expiry (ClearPendingEmailCode), so the
+-- expiry compare can never see it and an abandoned address would otherwise
+-- outlive the database. updated_at is the only instant such a row carries,
+-- and ClearPendingEmailCode stamps it.
 UPDATE users SET pending_email = '', pending_email_token = '', pending_email_expires_at = NULL, pending_email_attempts = 0, updated_at = NOW(3)
-WHERE pending_email_token != '' AND pending_email_expires_at IS NOT NULL AND pending_email_expires_at < ?;
+WHERE pending_email != ''
+  AND ((pending_email_token != '' AND pending_email_expires_at IS NOT NULL AND pending_email_expires_at < sqlc.arg(cutoff))
+    OR (pending_email_token = '' AND updated_at < sqlc.arg(codeless_cutoff)));
 
 -- The token-revocation lock/update pair has no deleted_at guard, so it
 -- would act on a soft-deleted row -- but the only caller

--- a/backend/internal/hub/store/mysql/db/queries/users.sql
+++ b/backend/internal/hub/store/mysql/db/queries/users.sql
@@ -170,7 +170,7 @@ WHERE id = sqlc.arg(id) AND pending_email != '';
 UPDATE users
 SET pending_email_attempts = pending_email_attempts + 1,
     pending_email_expires_at = CASE
-        WHEN pending_email_attempts + 1 > 5 THEN NOW(3)
+        WHEN pending_email_attempts + 1 > sqlc.arg(max_attempts) THEN sqlc.arg(now)
         ELSE pending_email_expires_at END,
     updated_at = NOW(3)
 WHERE id = ? AND pending_email_token != '';
@@ -201,3 +201,66 @@ SET tokens_revoked_at = sqlc.arg(tokens_revoked_at),
     auth_generation = sqlc.arg(auth_generation),
     updated_at = sqlc.arg(updated_at)
 WHERE id = sqlc.arg(id);
+
+-- name: SetPendingPasswordReset :execresult
+-- Conditional mint: the write lands only when no previous token exists or
+-- the previous token's expiry is at or before cooldown_cutoff, so two
+-- concurrent requests for one account cannot both mint and both send (the
+-- loser matches no row). The Go caller derives cooldown_cutoff from the
+-- resend cooldown; the comparison stays on the app clock, the same clock
+-- that wrote the expiry.
+UPDATE users
+SET pending_password_reset_token = sqlc.arg(pending_password_reset_token),
+    pending_password_reset_expires_at = sqlc.arg(pending_password_reset_expires_at),
+    pending_password_reset_attempts = 0,
+    updated_at = NOW(3)
+WHERE id = sqlc.arg(id)
+  AND (pending_password_reset_expires_at IS NULL
+       OR pending_password_reset_expires_at <= sqlc.arg(cooldown_cutoff));
+
+
+-- name: ClearPendingPasswordReset :exec
+UPDATE users
+SET pending_password_reset_token = '',
+    pending_password_reset_expires_at = NULL,
+    pending_password_reset_attempts = 0,
+    updated_at = NOW(3)
+WHERE id = ?;
+
+-- name: ConsumePasswordResetAttemptByToken :execresult
+-- Charges one attempt against the row that holds this exact token. Keying
+-- the charge by the token (not the user id) makes the find, the charge, and
+-- the ownership re-check one statement: a token cleared between a caller's
+-- read and this update simply matches no row. MySQL has no RETURNING, so a
+-- matched update is followed by one select of the same token.
+-- The expiry CASE is assigned BEFORE the attempt increment: MySQL
+-- evaluates SET clauses left-to-right and a later clause would read the
+-- already-incremented counter, firing the force-expiry one charge early.
+UPDATE users
+SET pending_password_reset_expires_at = CASE
+        WHEN pending_password_reset_attempts + 1 > sqlc.arg(max_attempts) THEN sqlc.arg(now)
+        ELSE pending_password_reset_expires_at END,
+    pending_password_reset_attempts = pending_password_reset_attempts + 1,
+    updated_at = NOW(3)
+WHERE pending_password_reset_token = ? AND pending_password_reset_token != ''
+  AND pending_password_reset_expires_at > sqlc.arg(now)
+  AND deleted_at IS NULL;
+
+-- name: GetUserAfterPasswordResetAttemptByToken :one
+-- No liveness predicate here: the paired UPDATE already enforced it, and a
+-- force-expired row (expires_at = NOW(3) in the same statement) must still
+-- be readable in the same transaction.
+SELECT * FROM users
+WHERE pending_password_reset_token = ? AND deleted_at IS NULL;
+
+-- name: CompletePasswordReset :execresult
+UPDATE users
+SET password_hash = sqlc.arg(password_hash),
+    password_set = TRUE,
+    pending_password_reset_token = '',
+    pending_password_reset_expires_at = NULL,
+    pending_password_reset_attempts = 0,
+    tokens_revoked_at = sqlc.arg(tokens_revoked_at),
+    auth_generation = sqlc.arg(auth_generation),
+    updated_at = sqlc.arg(updated_at)
+WHERE id = sqlc.arg(id) AND pending_password_reset_token = sqlc.arg(pending_password_reset_token);

--- a/backend/internal/hub/store/mysql/db/queries/webauthn_sessions.sql
+++ b/backend/internal/hub/store/mysql/db/queries/webauthn_sessions.sql
@@ -1,0 +1,47 @@
+-- Clock rule: expires_at columns are written by the hub process, so every
+-- comparison of them binds the hub's clock (sqlc.arg(now)), never the
+-- database clock. Timestamps that record when something happened
+-- (created_at, updated_at) keep the database clock.
+
+-- name: CreateWebAuthnSession :exec
+INSERT INTO webauthn_sessions (id, kind, user_id, payload_json, session_data, expires_at, created_at)
+VALUES (
+    sqlc.arg(id),
+    sqlc.arg(kind),
+    sqlc.narg(user_id),
+    sqlc.arg(payload_json),
+    sqlc.arg(session_data),
+    sqlc.arg(expires_at),
+    sqlc.arg(created_at)
+);
+
+-- name: GetWebAuthnSession :one
+SELECT * FROM webauthn_sessions WHERE id = ?;
+
+-- name: DeleteWebAuthnSession :exec
+DELETE FROM webauthn_sessions WHERE id = ?;
+
+-- name: ConsumeWebAuthnProof :execresult
+-- kind is a parameter so the Go constant (webauthn.KindReauthProof) stays
+-- the single spelling of what a proof row is named.
+DELETE FROM webauthn_sessions
+WHERE id = sqlc.arg(id) AND kind = sqlc.arg(kind) AND user_id = sqlc.arg(user_id) AND expires_at > sqlc.arg(now);
+
+-- name: GetValidWebAuthnProof :one
+-- Peek twin of ConsumeWebAuthnProof: the same validity predicate without
+-- the delete, so an admission check and a consume cannot drift apart.
+SELECT * FROM webauthn_sessions
+WHERE id = sqlc.arg(id) AND kind = sqlc.arg(kind) AND user_id = sqlc.arg(user_id) AND expires_at > sqlc.arg(now);
+
+-- name: ConsumeWebAuthnCeremonySession :execresult
+DELETE FROM webauthn_sessions
+WHERE id = sqlc.arg(id) AND kind = sqlc.arg(kind) AND expires_at > sqlc.arg(now);
+
+-- name: DeleteWebAuthnSessionsByUser :exec
+DELETE FROM webauthn_sessions WHERE user_id = ?;
+
+-- name: DeleteWebAuthnSessionsByUserAndKind :exec
+DELETE FROM webauthn_sessions WHERE user_id = ? AND kind = ?;
+
+-- name: DeleteExpiredWebAuthnSessions :execresult
+DELETE FROM webauthn_sessions WHERE expires_at < sqlc.arg(now);

--- a/backend/internal/hub/store/mysql/db/queries/webauthn_sessions.sql
+++ b/backend/internal/hub/store/mysql/db/queries/webauthn_sessions.sql
@@ -23,7 +23,7 @@ DELETE FROM webauthn_sessions WHERE id = ?;
 
 -- name: ConsumeWebAuthnProof :execresult
 -- kind is a parameter so the Go constant (webauthn.KindReauthProof) stays
--- the single spelling of what a proof row is named.
+-- the single spelling of what identifies a proof row.
 DELETE FROM webauthn_sessions
 WHERE id = sqlc.arg(id) AND kind = sqlc.arg(kind) AND user_id = sqlc.arg(user_id) AND expires_at > sqlc.arg(now);
 

--- a/backend/internal/hub/store/mysql/delegation_tokens.go
+++ b/backend/internal/hub/store/mysql/delegation_tokens.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
@@ -120,14 +121,17 @@ func (s *delegationTokenStore) ListAll(ctx context.Context, p store.ListAllDeleg
 	}
 }
 
-func (s *delegationTokenStore) ListActiveByUser(ctx context.Context, userID userid.UserID) ([]store.DelegationToken, error) {
+func (s *delegationTokenStore) ListActiveByUser(ctx context.Context, userID userid.UserID, now time.Time) ([]store.DelegationToken, error) {
 	owner, ok := userid.OwnerFilter(userID)
 	if !ok {
 		// An unminted caller owns nothing; binding "" would MATCH every
 		// blank-owner row rather than none. See userid.OwnerFilter.
 		return nil, nil
 	}
-	rows, err := s.conn.q.ListActiveDelegationTokensByUser(ctx, owner)
+	rows, err := s.conn.q.ListActiveDelegationTokensByUser(ctx, gendb.ListActiveDelegationTokensByUserParams{
+		UserID: owner,
+		Now:    sqltime.NewMySQLTime(now),
+	})
 	if err != nil {
 		return nil, mapErr(err)
 	}

--- a/backend/internal/hub/store/mysql/device_authorizations.go
+++ b/backend/internal/hub/store/mysql/device_authorizations.go
@@ -2,6 +2,7 @@ package mysql
 
 import (
 	"context"
+	"time"
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
@@ -69,6 +70,7 @@ func (s *deviceAuthorizationStore) Approve(ctx context.Context, p store.ApproveD
 	return rowsAffected(s.conn.q.ApproveDeviceAuthorization(ctx, gendb.ApproveDeviceAuthorizationParams{
 		UserID:     sqlutil.NullUserID(p.UserID),
 		DeviceCode: p.DeviceCode,
+		Now:        sqltime.NewMySQLTime(p.Now),
 	}))
 }
 
@@ -85,6 +87,7 @@ func (s *deviceAuthorizationStore) ApproveByUserCode(ctx context.Context, p stor
 	return rowsAffected(s.conn.q.ApproveDeviceAuthorizationByUserCode(ctx, gendb.ApproveDeviceAuthorizationByUserCodeParams{
 		UserID:   sqlutil.NullUserID(p.UserID),
 		UserCode: p.UserCode,
+		Now:      sqltime.NewMySQLTime(p.Now),
 	}))
 }
 
@@ -92,8 +95,11 @@ func (s *deviceAuthorizationStore) Deny(ctx context.Context, deviceCode string) 
 	return rowsAffected(s.conn.q.DenyDeviceAuthorization(ctx, deviceCode))
 }
 
-func (s *deviceAuthorizationStore) Consume(ctx context.Context, deviceCode string) (int64, error) {
-	return rowsAffected(s.conn.q.ConsumeDeviceAuthorization(ctx, deviceCode))
+func (s *deviceAuthorizationStore) Consume(ctx context.Context, deviceCode string, now time.Time) (int64, error) {
+	return rowsAffected(s.conn.q.ConsumeDeviceAuthorization(ctx, gendb.ConsumeDeviceAuthorizationParams{
+		DeviceCode: deviceCode,
+		Now:        sqltime.NewMySQLTime(now),
+	}))
 }
 
 func (s *deviceAuthorizationStore) TouchPoll(ctx context.Context, deviceCode string) error {

--- a/backend/internal/hub/store/mysql/device_authorizations.go
+++ b/backend/internal/hub/store/mysql/device_authorizations.go
@@ -57,7 +57,7 @@ func (s *deviceAuthorizationStore) GetByUserCode(ctx context.Context, userCode s
 	return &out, nil
 }
 
-func (s *deviceAuthorizationStore) Approve(ctx context.Context, p store.ApproveDeviceAuthorizationParams) (int64, error) {
+func (s *deviceAuthorizationStore) Approve(ctx context.Context, p store.ApproveDeviceAuthorizationParams, now time.Time) (int64, error) {
 	// An approval names WHO approved. A zero id would be written as SQL NULL
 	// while the UPDATE still matched the row, so the store would report one
 	// row affected, the browser would say "device authorized", and the CLI
@@ -70,11 +70,11 @@ func (s *deviceAuthorizationStore) Approve(ctx context.Context, p store.ApproveD
 	return rowsAffected(s.conn.q.ApproveDeviceAuthorization(ctx, gendb.ApproveDeviceAuthorizationParams{
 		UserID:     sqlutil.NullUserID(p.UserID),
 		DeviceCode: p.DeviceCode,
-		Now:        sqltime.NewMySQLTime(p.Now),
+		Now:        sqltime.NewMySQLTime(now),
 	}))
 }
 
-func (s *deviceAuthorizationStore) ApproveByUserCode(ctx context.Context, p store.ApproveDeviceAuthorizationByUserCodeParams) (int64, error) {
+func (s *deviceAuthorizationStore) ApproveByUserCode(ctx context.Context, p store.ApproveDeviceAuthorizationByUserCodeParams, now time.Time) (int64, error) {
 	// An approval names WHO approved. A zero id would be written as SQL NULL
 	// while the UPDATE still matched the row, so the store would report one
 	// row affected, the browser would say "device authorized", and the CLI
@@ -87,7 +87,7 @@ func (s *deviceAuthorizationStore) ApproveByUserCode(ctx context.Context, p stor
 	return rowsAffected(s.conn.q.ApproveDeviceAuthorizationByUserCode(ctx, gendb.ApproveDeviceAuthorizationByUserCodeParams{
 		UserID:   sqlutil.NullUserID(p.UserID),
 		UserCode: p.UserCode,
-		Now:      sqltime.NewMySQLTime(p.Now),
+		Now:      sqltime.NewMySQLTime(now),
 	}))
 }
 

--- a/backend/internal/hub/store/mysql/mysql.go
+++ b/backend/internal/hub/store/mysql/mysql.go
@@ -165,6 +165,12 @@ func (s *mysqlStore) OAuthUserLinks() store.OAuthUserLinkStore {
 func (s *mysqlStore) PendingOAuthSignups() store.PendingOAuthSignupStore {
 	return &pendingOAuthSignupStore{conn: s.conn}
 }
+func (s *mysqlStore) PasskeyCredentials() store.PasskeyCredentialStore {
+	return &passkeyCredentialStore{conn: s.conn}
+}
+func (s *mysqlStore) WebAuthnSessions() store.WebAuthnSessionStore {
+	return &webAuthnSessionStore{conn: s.conn}
+}
 func (s *mysqlStore) Settings() store.SettingsStore {
 	return &settingsStore{conn: s.conn}
 }

--- a/backend/internal/hub/store/mysql/oauth_tokens.go
+++ b/backend/internal/hub/store/mysql/oauth_tokens.go
@@ -2,6 +2,7 @@ package mysql
 
 import (
 	"context"
+	"time"
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
@@ -62,8 +63,8 @@ func (s *oauthTokenStore) Get(ctx context.Context, p store.GetOAuthTokensParams)
 	return &out, nil
 }
 
-func (s *oauthTokenStore) ListExpiring(ctx context.Context) ([]store.OAuthToken, error) {
-	rows, err := s.conn.q.ListExpiringOAuthTokens(ctx)
+func (s *oauthTokenStore) ListExpiring(ctx context.Context, refreshDueAt time.Time) ([]store.OAuthToken, error) {
+	rows, err := s.conn.q.ListExpiringOAuthTokens(ctx, sqltime.NewMySQLTime(refreshDueAt))
 	if err != nil {
 		return nil, mapErr(err)
 	}

--- a/backend/internal/hub/store/mysql/passkey_credentials.go
+++ b/backend/internal/hub/store/mysql/passkey_credentials.go
@@ -1,0 +1,182 @@
+package mysql
+
+import (
+	"context"
+
+	"github.com/leapmux/leapmux/internal/hub/store"
+	gendb "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
+	"github.com/leapmux/leapmux/internal/util/userid"
+)
+
+type passkeyCredentialStore struct {
+	conn *mysqlConn
+}
+
+var _ store.PasskeyCredentialStore = (*passkeyCredentialStore)(nil)
+
+func fromDBPasskeyCredential(c gendb.PasskeyCredential) store.PasskeyCredential {
+	return store.PasskeyCredential{
+		ID:             c.ID,
+		UserID:         c.UserID,
+		CredentialID:   c.CredentialID,
+		PublicKey:      c.PublicKey,
+		SignCount:      c.SignCount,
+		AAGUID:         c.Aaguid,
+		BackupEligible: c.BackupEligible,
+		BackupState:    c.BackupState,
+		Transports:     c.Transports,
+		FriendlyName:   c.FriendlyName,
+		KeyVersion:     c.KeyVersion,
+		CreatedAt:      c.CreatedAt.Time,
+		LastUsedAt:     c.LastUsedAt.Ptr(),
+	}
+}
+
+func fromDBPasskeyCredentials(rows []gendb.PasskeyCredential) []store.PasskeyCredential {
+	return store.MapSlice(rows, fromDBPasskeyCredential)
+}
+
+func (s *passkeyCredentialStore) Create(ctx context.Context, p store.CreatePasskeyCredentialParams) error {
+	owner, ok := userid.New(p.UserID)
+	if !ok {
+		return store.ErrInvalidArgument
+	}
+	return mapErr(s.conn.q.CreatePasskeyCredential(ctx, gendb.CreatePasskeyCredentialParams{
+		ID:             p.ID,
+		UserID:         owner.String(),
+		CredentialID:   p.CredentialID,
+		PublicKey:      p.PublicKey,
+		SignCount:      p.SignCount,
+		Aaguid:         p.AAGUID,
+		BackupEligible: p.BackupEligible,
+		BackupState:    p.BackupState,
+		Transports:     p.Transports,
+		FriendlyName:   p.FriendlyName,
+		KeyVersion:     p.KeyVersion,
+		CreatedAt:      sqltime.NewMySQLTime(p.CreatedAt),
+		LastUsedAt:     sqltime.NewMySQLNullTime(p.LastUsedAt),
+	}))
+}
+
+func (s *passkeyCredentialStore) GetByID(ctx context.Context, id string) (*store.PasskeyCredential, error) {
+	row, err := s.conn.q.GetPasskeyCredentialByID(ctx, id)
+	if err != nil {
+		return nil, mapErr(err)
+	}
+	out := fromDBPasskeyCredential(row)
+	return &out, nil
+}
+
+func (s *passkeyCredentialStore) GetByCredentialID(ctx context.Context, credentialID []byte) (*store.PasskeyCredential, error) {
+	row, err := s.conn.q.GetPasskeyCredentialByCredentialID(ctx, credentialID)
+	if err != nil {
+		return nil, mapErr(err)
+	}
+	out := fromDBPasskeyCredential(row)
+	return &out, nil
+}
+
+func (s *passkeyCredentialStore) ListByUser(ctx context.Context, userID string) ([]store.PasskeyCredential, error) {
+	owner, ok := userid.New(userID)
+	if !ok {
+		return nil, store.ErrInvalidArgument
+	}
+	rows, err := s.conn.q.ListPasskeyCredentialsByUser(ctx, owner.String())
+	if err != nil {
+		return nil, mapErr(err)
+	}
+	return fromDBPasskeyCredentials(rows), nil
+}
+
+func (s *passkeyCredentialStore) CountByUser(ctx context.Context, userID string) (int64, error) {
+	owner, ok := userid.New(userID)
+	if !ok {
+		return 0, store.ErrInvalidArgument
+	}
+	count, err := s.conn.q.CountPasskeyCredentialsByUser(ctx, owner.String())
+	if err != nil {
+		return 0, mapErr(err)
+	}
+	return count, nil
+}
+
+func (s *passkeyCredentialStore) UpdateSignCount(ctx context.Context, p store.UpdatePasskeySignCountParams) error {
+	owner, ok := userid.New(p.UserID)
+	if !ok {
+		return store.ErrInvalidArgument
+	}
+	n, err := rowsAffected(s.conn.q.UpdatePasskeySignCount(ctx, gendb.UpdatePasskeySignCountParams{
+		SignCount:    p.SignCount,
+		LastUsedAt:   sqltime.MySQLNullTimeOf(p.LastUsedAt),
+		CredentialID: p.CredentialID,
+		UserID:       owner.String(),
+	}))
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return store.ErrNotFound
+	}
+	return nil
+}
+
+func (s *passkeyCredentialStore) UpdateFriendlyName(ctx context.Context, id, userID, friendlyName string) error {
+	owner, ok := userid.New(userID)
+	if !ok {
+		return store.ErrInvalidArgument
+	}
+	return mapErr(s.conn.q.UpdatePasskeyFriendlyName(ctx, gendb.UpdatePasskeyFriendlyNameParams{
+		FriendlyName: friendlyName,
+		ID:           id,
+		UserID:       owner.String(),
+	}))
+}
+
+func (s *passkeyCredentialStore) UpdatePublicKey(ctx context.Context, p store.UpdatePasskeyPublicKeyParams) error {
+	owner, ok := userid.New(p.UserID)
+	if !ok {
+		return store.ErrInvalidArgument
+	}
+	return mapErr(s.conn.q.UpdatePasskeyPublicKey(ctx, gendb.UpdatePasskeyPublicKeyParams{
+		PublicKey:  p.PublicKey,
+		KeyVersion: p.KeyVersion,
+		ID:         p.ID,
+		UserID:     owner.String(),
+	}))
+}
+
+func (s *passkeyCredentialStore) Delete(ctx context.Context, id, userID string) error {
+	owner, ok := userid.New(userID)
+	if !ok {
+		return store.ErrInvalidArgument
+	}
+	return mapErr(s.conn.q.DeletePasskeyCredential(ctx, gendb.DeletePasskeyCredentialParams{
+		ID:     id,
+		UserID: owner.String(),
+	}))
+}
+
+func (s *passkeyCredentialStore) DeleteAllByUser(ctx context.Context, userID string) error {
+	owner, ok := userid.New(userID)
+	if !ok {
+		return store.ErrInvalidArgument
+	}
+	return mapErr(s.conn.q.DeleteAllPasskeyCredentialsByUser(ctx, owner.String()))
+}
+
+func (s *passkeyCredentialStore) ListByKeyVersion(ctx context.Context, keyVersion int64) ([]store.PasskeyCredential, error) {
+	rows, err := s.conn.q.ListPasskeyCredentialsByKeyVersion(ctx, keyVersion)
+	if err != nil {
+		return nil, mapErr(err)
+	}
+	return fromDBPasskeyCredentials(rows), nil
+}
+
+func (s *passkeyCredentialStore) CountByKeyVersion(ctx context.Context, keyVersion int64) (int64, error) {
+	count, err := s.conn.q.CountPasskeyCredentialsByKeyVersion(ctx, keyVersion)
+	if err != nil {
+		return 0, mapErr(err)
+	}
+	return count, nil
+}

--- a/backend/internal/hub/store/mysql/sessions.go
+++ b/backend/internal/hub/store/mysql/sessions.go
@@ -68,10 +68,10 @@ func (s *sessionStore) GetByID(ctx context.Context, id string, now time.Time) (*
 	return &out, nil
 }
 
-func (s *sessionStore) Touch(ctx context.Context, p store.TouchSessionParams) (int64, error) {
+func (s *sessionStore) Touch(ctx context.Context, p store.TouchSessionParams, now time.Time) (int64, error) {
 	n, err := s.conn.q.TouchUserSession(ctx, gendb.TouchUserSessionParams{
 		ExpiresAt:    sqltime.NewMySQLTime(p.ExpiresAt),
-		Now:          sqltime.NewMySQLTime(p.Now),
+		Now:          sqltime.NewMySQLTime(now),
 		ID:           p.ID,
 		LastActiveAt: sqltime.NewMySQLTime(p.LastActiveAt),
 	})
@@ -146,7 +146,7 @@ func (s *sessionStore) RefreshAuthGeneration(ctx context.Context, p store.Refres
 	}))
 }
 
-func (s *sessionStore) ListByUserID(ctx context.Context, p store.ListUserSessionsParams) (store.Page[store.UserSession], error) {
+func (s *sessionStore) ListByUserID(ctx context.Context, p store.ListUserSessionsParams, now time.Time) (store.Page[store.UserSession], error) {
 	owner, ok := userid.OwnerFilter(p.UserID)
 	if !ok {
 		// An unminted caller owns nothing; binding "" would MATCH every
@@ -155,15 +155,15 @@ func (s *sessionStore) ListByUserID(ctx context.Context, p store.ListUserSession
 	}
 	return queryPage(ctx, p.Limit,
 		func() (gendb.ListUserSessionsByUserIDParams, error) {
-			return listUserSessionsParams(owner, p.Cursor, p.Limit, p.Now)
+			return listUserSessionsParams(owner, p.Cursor, p.Limit, now)
 		},
 		s.conn.q.ListUserSessionsByUserID, fromDBSession)
 }
 
-func (s *sessionStore) ListAllActive(ctx context.Context, p store.ListAllActiveSessionsParams) (store.Page[store.ActiveSession], error) {
+func (s *sessionStore) ListAllActive(ctx context.Context, p store.ListAllActiveSessionsParams, now time.Time) (store.Page[store.ActiveSession], error) {
 	return queryPage(ctx, p.Limit,
 		func() (gendb.ListAllActiveSessionsParams, error) {
-			return listAllActiveSessionsParams(p.Cursor, p.Limit, p.Now)
+			return listAllActiveSessionsParams(p.Cursor, p.Limit, now)
 		},
 		s.conn.q.ListAllActiveSessions, fromDBActiveSessionRow)
 }

--- a/backend/internal/hub/store/mysql/sessions.go
+++ b/backend/internal/hub/store/mysql/sessions.go
@@ -56,8 +56,11 @@ func (s *sessionStore) Create(ctx context.Context, p store.CreateSessionParams) 
 	})
 }
 
-func (s *sessionStore) GetByID(ctx context.Context, id string) (*store.UserSession, error) {
-	sess, err := s.conn.q.GetUserSessionByID(ctx, id)
+func (s *sessionStore) GetByID(ctx context.Context, id string, now time.Time) (*store.UserSession, error) {
+	sess, err := s.conn.q.GetUserSessionByID(ctx, gendb.GetUserSessionByIDParams{
+		ID:  id,
+		Now: sqltime.NewMySQLTime(now),
+	})
 	if err != nil {
 		return nil, mapErr(err)
 	}
@@ -68,6 +71,7 @@ func (s *sessionStore) GetByID(ctx context.Context, id string) (*store.UserSessi
 func (s *sessionStore) Touch(ctx context.Context, p store.TouchSessionParams) (int64, error) {
 	n, err := s.conn.q.TouchUserSession(ctx, gendb.TouchUserSessionParams{
 		ExpiresAt:    sqltime.NewMySQLTime(p.ExpiresAt),
+		Now:          sqltime.NewMySQLTime(p.Now),
 		ID:           p.ID,
 		LastActiveAt: sqltime.NewMySQLTime(p.LastActiveAt),
 	})
@@ -151,7 +155,7 @@ func (s *sessionStore) ListByUserID(ctx context.Context, p store.ListUserSession
 	}
 	return queryPage(ctx, p.Limit,
 		func() (gendb.ListUserSessionsByUserIDParams, error) {
-			return listUserSessionsParams(owner, p.Cursor, p.Limit)
+			return listUserSessionsParams(owner, p.Cursor, p.Limit, p.Now)
 		},
 		s.conn.q.ListUserSessionsByUserID, fromDBSession)
 }
@@ -159,13 +163,16 @@ func (s *sessionStore) ListByUserID(ctx context.Context, p store.ListUserSession
 func (s *sessionStore) ListAllActive(ctx context.Context, p store.ListAllActiveSessionsParams) (store.Page[store.ActiveSession], error) {
 	return queryPage(ctx, p.Limit,
 		func() (gendb.ListAllActiveSessionsParams, error) {
-			return listAllActiveSessionsParams(p.Cursor, p.Limit)
+			return listAllActiveSessionsParams(p.Cursor, p.Limit, p.Now)
 		},
 		s.conn.q.ListAllActiveSessions, fromDBActiveSessionRow)
 }
 
-func (s *sessionStore) ValidateWithUser(ctx context.Context, id string) (*store.SessionWithUser, error) {
-	row, err := s.conn.q.ValidateSessionWithUser(ctx, id)
+func (s *sessionStore) ValidateWithUser(ctx context.Context, id string, now time.Time) (*store.SessionWithUser, error) {
+	row, err := s.conn.q.ValidateSessionWithUser(ctx, gendb.ValidateSessionWithUserParams{
+		ID:  id,
+		Now: sqltime.NewMySQLTime(now),
+	})
 	if err != nil {
 		return nil, mapErr(err)
 	}

--- a/backend/internal/hub/store/mysql/sqlc.yaml
+++ b/backend/internal/hub/store/mysql/sqlc.yaml
@@ -83,3 +83,14 @@ sql:
             go_type:
               type: "byte"
               slice: true
+          # Passkey AAGUID: keep as []byte (sqlc would map MySQL BINARY/VARBINARY
+          # to NullString otherwise).
+          - column: "passkey_credentials.aaguid"
+            go_type:
+              type: "byte"
+              slice: true
+          - column: "passkey_credentials.aaguid"
+            nullable: true
+            go_type:
+              type: "byte"
+              slice: true

--- a/backend/internal/hub/store/mysql/users.go
+++ b/backend/internal/hub/store/mysql/users.go
@@ -21,24 +21,27 @@ var _ store.UserStore = (*userStore)(nil)
 
 func fromDBUser(u gendb.User) store.User {
 	return store.User{
-		ID:                    u.ID,
-		Username:              u.Username,
-		PasswordHash:          u.PasswordHash,
-		DisplayName:           u.DisplayName,
-		Email:                 u.Email,
-		EmailVerified:         u.EmailVerified,
-		PendingEmail:          u.PendingEmail,
-		PendingEmailToken:     u.PendingEmailToken,
-		PendingEmailExpiresAt: u.PendingEmailExpiresAt.Ptr(),
-		PendingEmailAttempts:  int64(u.PendingEmailAttempts),
-		PasswordSet:           u.PasswordSet,
-		IsAdmin:               u.IsAdmin,
-		Prefs:                 u.Prefs,
-		CreatedAt:             u.CreatedAt.Time,
-		UpdatedAt:             u.UpdatedAt.Time,
-		TokensRevokedAt:       u.TokensRevokedAt.Ptr(),
-		AuthGeneration:        u.AuthGeneration,
-		DeletedAt:             u.DeletedAt.Ptr(),
+		ID:                            u.ID,
+		Username:                      u.Username,
+		PasswordHash:                  u.PasswordHash,
+		DisplayName:                   u.DisplayName,
+		Email:                         u.Email,
+		EmailVerified:                 u.EmailVerified,
+		PendingEmail:                  u.PendingEmail,
+		PendingEmailToken:             u.PendingEmailToken,
+		PendingEmailExpiresAt:         u.PendingEmailExpiresAt.Ptr(),
+		PendingEmailAttempts:          int64(u.PendingEmailAttempts),
+		PendingPasswordResetToken:     u.PendingPasswordResetToken,
+		PendingPasswordResetExpiresAt: u.PendingPasswordResetExpiresAt.Ptr(),
+		PendingPasswordResetAttempts:  int64(u.PendingPasswordResetAttempts),
+		PasswordSet:                   u.PasswordSet,
+		IsAdmin:                       u.IsAdmin,
+		Prefs:                         u.Prefs,
+		CreatedAt:                     u.CreatedAt.Time,
+		UpdatedAt:                     u.UpdatedAt.Time,
+		TokensRevokedAt:               u.TokensRevokedAt.Ptr(),
+		AuthGeneration:                u.AuthGeneration,
+		DeletedAt:                     u.DeletedAt.Ptr(),
 	}
 }
 
@@ -126,10 +129,14 @@ func (s *userStore) ExistsByEmail(ctx context.Context, email, excludeUserID stri
 // ConsumeVerificationAttempt keeps MySQL's UPDATE and follow-up SELECT in one
 // transaction so the row lock protects the exact post-increment state returned
 // to this caller. PostgreSQL and SQLite use UPDATE ... RETURNING instead.
-func (s *userStore) ConsumeVerificationAttempt(ctx context.Context, id string) (*store.User, error) {
+func (s *userStore) ConsumeVerificationAttempt(ctx context.Context, id string, now time.Time, maxAttempts int64) (*store.User, error) {
 	var out *store.User
 	err := s.conn.withTransaction(ctx, func(conn *mysqlConn) error {
-		res, err := conn.q.ConsumeVerificationAttempt(ctx, id)
+		res, err := conn.q.ConsumeVerificationAttempt(ctx, gendb.ConsumeVerificationAttemptParams{
+			ID:          id,
+			Now:         sqltime.MySQLNullTimeOf(now),
+			MaxAttempts: int32(maxAttempts),
+		})
 		if err != nil {
 			return mapErr(err)
 		}
@@ -440,6 +447,93 @@ func (s *userStore) ClearCompetingPendingEmails(ctx context.Context, p store.Cle
 
 func (s *userStore) Delete(ctx context.Context, id string) error {
 	return mapErr(s.conn.q.DeleteUser(ctx, id))
+}
+
+func (s *userStore) SetPendingPasswordReset(ctx context.Context, p store.SetPendingPasswordResetParams) (bool, error) {
+	n, err := rowsAffected(s.conn.q.SetPendingPasswordReset(ctx, gendb.SetPendingPasswordResetParams{
+		PendingPasswordResetToken:     p.PendingPasswordResetToken,
+		PendingPasswordResetExpiresAt: sqltime.MySQLNullTimeOf(p.PendingPasswordResetExpiresAt),
+		CooldownCutoff:                sqltime.MySQLNullTimeOf(p.CooldownCutoff),
+		ID:                            p.ID,
+	}))
+	if err != nil {
+		return false, err
+	}
+	return n > 0, nil
+}
+
+func (s *userStore) ClearPendingPasswordReset(ctx context.Context, id string) error {
+	return mapErr(s.conn.q.ClearPendingPasswordReset(ctx, id))
+}
+
+// ConsumePasswordResetAttemptByToken keeps MySQL's UPDATE and follow-up SELECT
+// in one transaction so the row lock protects the exact post-increment state
+// returned to this caller. PostgreSQL and SQLite use UPDATE ... RETURNING
+// instead.
+func (s *userStore) ConsumePasswordResetAttemptByToken(ctx context.Context, tokenHash string, now time.Time, maxAttempts int64) (*store.User, error) {
+	var out *store.User
+	err := s.conn.withTransaction(ctx, func(conn *mysqlConn) error {
+		res, err := conn.q.ConsumePasswordResetAttemptByToken(ctx, gendb.ConsumePasswordResetAttemptByTokenParams{
+			PendingPasswordResetToken: tokenHash,
+			Now:                       sqltime.MySQLNullTimeOf(now),
+			MaxAttempts:               int32(maxAttempts),
+		})
+		if err != nil {
+			return mapErr(err)
+		}
+		rows, err := res.RowsAffected()
+		if err != nil {
+			return mapErr(err)
+		}
+		if rows == 0 {
+			return store.ErrNotFound
+		}
+		u, err := conn.q.GetUserAfterPasswordResetAttemptByToken(ctx, tokenHash)
+		if err != nil {
+			return mapErr(err)
+		}
+		converted := fromDBUser(u)
+		out = &converted
+		return nil
+	})
+	return out, err
+}
+
+func (s *userStore) CompletePasswordReset(ctx context.Context, p store.CompletePasswordResetParams) (*store.PasswordResetRevocation, error) {
+	var out *store.PasswordResetRevocation
+	err := s.conn.withTransaction(ctx, func(conn *mysqlConn) error {
+		row, err := conn.q.GetUserTokensRevocationForUpdate(ctx, p.ID)
+		if errors.Is(err, sql.ErrNoRows) {
+			return store.ErrNotFound
+		}
+		if err != nil {
+			return mapErr(err)
+		}
+		updatedAt := row.NowAt.UTC()
+		revokedAt := updatedAt
+		nextGeneration := row.AuthGeneration + 1
+		n, err := rowsAffected(conn.q.CompletePasswordReset(ctx, gendb.CompletePasswordResetParams{
+			PasswordHash:              p.PasswordHash,
+			TokensRevokedAt:           sqltime.MySQLNullTimeOf(revokedAt),
+			AuthGeneration:            nextGeneration,
+			UpdatedAt:                 sqltime.NewMySQLTime(updatedAt),
+			ID:                        p.ID,
+			PendingPasswordResetToken: p.PendingPasswordResetToken,
+		}))
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return store.ErrNotFound
+		}
+		out = &store.PasswordResetRevocation{
+			UserID:          row.ID,
+			TokensRevokedAt: revokedAt,
+			AuthGeneration:  nextGeneration,
+		}
+		return nil
+	})
+	return out, err
 }
 
 func (s *userStore) RevokeUserTokens(ctx context.Context, userID userid.UserID) (int64, error) {

--- a/backend/internal/hub/store/mysql/users.go
+++ b/backend/internal/hub/store/mysql/users.go
@@ -400,13 +400,24 @@ func (s *userStore) UpdatePrefs(ctx context.Context, p store.UpdateUserPrefsPara
 	}))
 }
 
-func (s *userStore) SetPendingEmail(ctx context.Context, p store.SetPendingEmailParams) error {
-	return mapErr(s.conn.q.SetPendingEmail(ctx, gendb.SetPendingEmailParams{
+func (s *userStore) SetPendingEmail(ctx context.Context, p store.SetPendingEmailParams) (bool, error) {
+	n, err := rowsAffected(s.conn.q.SetPendingEmail(ctx, gendb.SetPendingEmailParams{
 		PendingEmail:          store.NormalizeEmail(p.PendingEmail),
 		PendingEmailToken:     p.PendingEmailToken,
 		PendingEmailExpiresAt: sqltime.NewMySQLNullTime(p.PendingEmailExpiresAt),
 		ID:                    p.ID,
+		CooldownCutoff:        sqltime.MySQLNullTimeOf(p.CooldownCutoff),
 	}))
+	if err != nil {
+		return false, err
+	}
+	return n > 0, nil
+}
+
+// ClearPendingEmailCode drops an undelivered code and keeps the pending
+// address; see the query comment for why the address must survive.
+func (s *userStore) ClearPendingEmailCode(ctx context.Context, id string) error {
+	return mapErr(s.conn.q.ClearPendingEmailCode(ctx, id))
 }
 
 // PromotePendingEmail moves pending_email into email (email_verified=1). A row

--- a/backend/internal/hub/store/mysql/webauthn_sessions.go
+++ b/backend/internal/hub/store/mysql/webauthn_sessions.go
@@ -1,0 +1,127 @@
+package mysql
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/leapmux/leapmux/internal/hub/store"
+	gendb "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
+	"github.com/leapmux/leapmux/internal/util/userid"
+)
+
+type webAuthnSessionStore struct {
+	conn *mysqlConn
+}
+
+var _ store.WebAuthnSessionStore = (*webAuthnSessionStore)(nil)
+
+func fromDBWebAuthnSession(s gendb.WebauthnSession) store.WebAuthnSession {
+	out := store.WebAuthnSession{
+		ID:          s.ID,
+		Kind:        s.Kind,
+		PayloadJSON: s.PayloadJson,
+		SessionData: s.SessionData,
+		ExpiresAt:   s.ExpiresAt.Time,
+		CreatedAt:   s.CreatedAt.Time,
+	}
+	if s.UserID.Valid {
+		out.UserID = s.UserID.String
+	}
+	return out
+}
+
+func (s *webAuthnSessionStore) Create(ctx context.Context, p store.CreateWebAuthnSessionParams) error {
+	var userID sql.NullString
+	if p.UserID != "" {
+		owner, ok := userid.New(p.UserID)
+		if !ok {
+			return store.ErrInvalidArgument
+		}
+		userID = sql.NullString{String: owner.String(), Valid: true}
+	}
+	return mapErr(s.conn.q.CreateWebAuthnSession(ctx, gendb.CreateWebAuthnSessionParams{
+		ID:          p.ID,
+		Kind:        p.Kind,
+		UserID:      userID,
+		PayloadJson: p.PayloadJSON,
+		SessionData: p.SessionData,
+		ExpiresAt:   sqltime.NewMySQLTime(p.ExpiresAt),
+		CreatedAt:   sqltime.NewMySQLTime(p.CreatedAt),
+	}))
+}
+
+func (s *webAuthnSessionStore) Get(ctx context.Context, id string) (*store.WebAuthnSession, error) {
+	row, err := s.conn.q.GetWebAuthnSession(ctx, id)
+	if err != nil {
+		return nil, mapErr(err)
+	}
+	out := fromDBWebAuthnSession(row)
+	return &out, nil
+}
+
+func (s *webAuthnSessionStore) Delete(ctx context.Context, id string) error {
+	return mapErr(s.conn.q.DeleteWebAuthnSession(ctx, id))
+}
+
+func (s *webAuthnSessionStore) ConsumeCeremony(ctx context.Context, id, kind string, now time.Time) (int64, error) {
+	return rowsAffected(s.conn.q.ConsumeWebAuthnCeremonySession(ctx, gendb.ConsumeWebAuthnCeremonySessionParams{
+		ID:   id,
+		Kind: kind,
+		Now:  sqltime.NewMySQLTime(now),
+	}))
+}
+
+func (s *webAuthnSessionStore) ConsumeProof(ctx context.Context, id, userID, kind string, now time.Time) (int64, error) {
+	owner, ok := userid.New(userID)
+	if !ok {
+		return 0, store.ErrInvalidArgument
+	}
+	return rowsAffected(s.conn.q.ConsumeWebAuthnProof(ctx, gendb.ConsumeWebAuthnProofParams{
+		ID:     id,
+		Kind:   kind,
+		UserID: sql.NullString{String: owner.String(), Valid: true},
+		Now:    sqltime.NewMySQLTime(now),
+	}))
+}
+
+func (s *webAuthnSessionStore) GetValidProof(ctx context.Context, id, userID, kind string, now time.Time) (*store.WebAuthnSession, error) {
+	owner, ok := userid.New(userID)
+	if !ok {
+		return nil, store.ErrInvalidArgument
+	}
+	row, err := s.conn.q.GetValidWebAuthnProof(ctx, gendb.GetValidWebAuthnProofParams{
+		ID:     id,
+		Kind:   kind,
+		UserID: sql.NullString{String: owner.String(), Valid: true},
+		Now:    sqltime.NewMySQLTime(now),
+	})
+	if err != nil {
+		return nil, mapErr(err)
+	}
+	out := fromDBWebAuthnSession(row)
+	return &out, nil
+}
+
+func (s *webAuthnSessionStore) DeleteAllByUser(ctx context.Context, userID string) error {
+	owner, ok := userid.New(userID)
+	if !ok {
+		return store.ErrInvalidArgument
+	}
+	return mapErr(s.conn.q.DeleteWebAuthnSessionsByUser(ctx, sql.NullString{
+		String: owner.String(),
+		Valid:  true,
+	}))
+}
+
+func (s *webAuthnSessionStore) DeleteByUserAndKind(ctx context.Context, userID, kind string) error {
+	owner, ok := userid.New(userID)
+	if !ok {
+		return store.ErrInvalidArgument
+	}
+	return mapErr(s.conn.q.DeleteWebAuthnSessionsByUserAndKind(ctx, gendb.DeleteWebAuthnSessionsByUserAndKindParams{
+		UserID: sql.NullString{String: owner.String(), Valid: true},
+		Kind:   kind,
+	}))
+}

--- a/backend/internal/hub/store/postgres/cleanup.go
+++ b/backend/internal/hub/store/postgres/cleanup.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/leapmux/leapmux/internal/hub/store"
+	gendb "github.com/leapmux/leapmux/internal/hub/store/postgres/generated/db"
 	"github.com/leapmux/leapmux/internal/util/sqltime/pgtime"
 )
 
@@ -31,7 +32,10 @@ func (s *cleanupStore) HardDeleteExpiredRegistrationKeysBefore(ctx context.Conte
 }
 
 func (s *cleanupStore) ClearStalePendingEmails(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.ClearStalePendingEmails(ctx, pgtime.NullOf(cutoff)))
+	return rowsAffected(s.conn.q.ClearStalePendingEmails(ctx, gendb.ClearStalePendingEmailsParams{
+		Cutoff:         pgtime.NullOf(cutoff),
+		CodelessCutoff: pgtime.New(cutoff),
+	}))
 }
 
 func (s *cleanupStore) HardDeleteUsersBefore(ctx context.Context, cutoff time.Time) (int64, error) {
@@ -50,12 +54,12 @@ func (s *cleanupStore) DeleteExpiredWebAuthnSessions(ctx context.Context, now ti
 	return rowsAffected(s.conn.q.DeleteExpiredWebAuthnSessions(ctx, pgtime.New(now)))
 }
 
-func (s *cleanupStore) DeleteExpiredDeviceAuthorizations(ctx context.Context, cutoff time.Time) (int64, error) {
-	return s.conn.q.DeleteExpiredDeviceAuthorizations(ctx, pgtime.New(cutoff))
+func (s *cleanupStore) DeleteExpiredDeviceAuthorizations(ctx context.Context, now time.Time) (int64, error) {
+	return s.conn.q.DeleteExpiredDeviceAuthorizations(ctx, pgtime.New(now))
 }
 
-func (s *cleanupStore) DeleteExpiredCLIAuthorizationCodes(ctx context.Context, cutoff time.Time) (int64, error) {
-	return s.conn.q.DeleteExpiredCLIAuthorizationCodes(ctx, pgtime.New(cutoff))
+func (s *cleanupStore) DeleteExpiredCLIAuthorizationCodes(ctx context.Context, now time.Time) (int64, error) {
+	return s.conn.q.DeleteExpiredCLIAuthorizationCodes(ctx, pgtime.New(now))
 }
 
 func (s *cleanupStore) DeleteRevokedAPITokensBefore(ctx context.Context, cutoff time.Time) (int64, error) {
@@ -66,8 +70,8 @@ func (s *cleanupStore) DeleteRevokedDelegationTokensBefore(ctx context.Context, 
 	return s.conn.q.DeleteRevokedDelegationTokensBefore(ctx, pgtime.NullOf(cutoff))
 }
 
-func (s *cleanupStore) DeleteExpiredDelegationTokensBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return s.conn.q.DeleteExpiredDelegationTokensBefore(ctx, pgtime.New(cutoff))
+func (s *cleanupStore) DeleteExpiredDelegationTokensBefore(ctx context.Context, now time.Time) (int64, error) {
+	return s.conn.q.DeleteExpiredDelegationTokensBefore(ctx, pgtime.New(now))
 }
 
 func (s *cleanupStore) DeleteExpiredAltchaSalts(ctx context.Context) (int64, error) {

--- a/backend/internal/hub/store/postgres/cleanup.go
+++ b/backend/internal/hub/store/postgres/cleanup.go
@@ -14,8 +14,8 @@ type cleanupStore struct {
 
 var _ store.CleanupStore = (*cleanupStore)(nil)
 
-func (s *cleanupStore) HardDeleteExpiredSessions(ctx context.Context) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteExpiredUserSessions(ctx))
+func (s *cleanupStore) HardDeleteExpiredSessions(ctx context.Context, now time.Time) (int64, error) {
+	return rowsAffected(s.conn.q.DeleteExpiredUserSessions(ctx, pgtime.New(now)))
 }
 
 func (s *cleanupStore) HardDeleteWorkspacesBefore(ctx context.Context, cutoff time.Time) (int64, error) {
@@ -38,12 +38,16 @@ func (s *cleanupStore) HardDeleteUsersBefore(ctx context.Context, cutoff time.Ti
 	return rowsAffected(s.conn.q.HardDeleteUsersBefore(ctx, pgtime.NullOf(cutoff)))
 }
 
-func (s *cleanupStore) DeleteExpiredOAuthStates(ctx context.Context) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteExpiredOAuthStates(ctx))
+func (s *cleanupStore) DeleteExpiredOAuthStates(ctx context.Context, now time.Time) (int64, error) {
+	return rowsAffected(s.conn.q.DeleteExpiredOAuthStates(ctx, pgtime.New(now)))
 }
 
-func (s *cleanupStore) DeleteExpiredPendingOAuthSignups(ctx context.Context) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteExpiredPendingOAuthSignups(ctx))
+func (s *cleanupStore) DeleteExpiredPendingOAuthSignups(ctx context.Context, now time.Time) (int64, error) {
+	return rowsAffected(s.conn.q.DeleteExpiredPendingOAuthSignups(ctx, pgtime.New(now)))
+}
+
+func (s *cleanupStore) DeleteExpiredWebAuthnSessions(ctx context.Context, now time.Time) (int64, error) {
+	return rowsAffected(s.conn.q.DeleteExpiredWebAuthnSessions(ctx, pgtime.New(now)))
 }
 
 func (s *cleanupStore) DeleteExpiredDeviceAuthorizations(ctx context.Context, cutoff time.Time) (int64, error) {

--- a/backend/internal/hub/store/postgres/cli_authorization_codes.go
+++ b/backend/internal/hub/store/postgres/cli_authorization_codes.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"time"
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/postgres/generated/db"
@@ -34,8 +35,11 @@ func (s *cliAuthorizationCodeStore) Create(ctx context.Context, p store.CreateCL
 	}))
 }
 
-func (s *cliAuthorizationCodeStore) GetActive(ctx context.Context, code string) (*store.CLIAuthorizationCode, error) {
-	row, err := s.conn.q.GetActiveCLIAuthorizationCode(ctx, code)
+func (s *cliAuthorizationCodeStore) GetActive(ctx context.Context, code string, now time.Time) (*store.CLIAuthorizationCode, error) {
+	row, err := s.conn.q.GetActiveCLIAuthorizationCode(ctx, gendb.GetActiveCLIAuthorizationCodeParams{
+		Code: code,
+		Now:  pgtime.New(now),
+	})
 	if err != nil {
 		return nil, mapErr(err)
 	}
@@ -43,8 +47,11 @@ func (s *cliAuthorizationCodeStore) GetActive(ctx context.Context, code string) 
 	return &out, nil
 }
 
-func (s *cliAuthorizationCodeStore) Consume(ctx context.Context, code string) (*store.CLIAuthorizationCode, error) {
-	row, err := s.conn.q.ConsumeCLIAuthorizationCode(ctx, code)
+func (s *cliAuthorizationCodeStore) Consume(ctx context.Context, code string, now time.Time) (*store.CLIAuthorizationCode, error) {
+	row, err := s.conn.q.ConsumeCLIAuthorizationCode(ctx, gendb.ConsumeCLIAuthorizationCodeParams{
+		Code: code,
+		Now:  pgtime.New(now),
+	})
 	if err != nil {
 		return nil, mapErr(err)
 	}

--- a/backend/internal/hub/store/postgres/convert.go
+++ b/backend/internal/hub/store/postgres/convert.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5"
@@ -141,15 +142,17 @@ func listWorkersAdminByUserAndStatusParams(status leapmuxv1.WorkerStatus, userID
 	})
 }
 
-func listAllActiveSessionsParams(cursor string, limit int64) (gendb.ListAllActiveSessionsParams, error) {
+func listAllActiveSessionsParams(cursor string, limit int64, now time.Time) (gendb.ListAllActiveSessionsParams, error) {
+	nt := pgtime.New(now)
 	return withCursor(cursor, limit, func(ct pgtime.NullTime, cid pgtype.Text, fl int32) gendb.ListAllActiveSessionsParams {
-		return gendb.ListAllActiveSessionsParams{CursorTime: ct, CursorID: cid, Limit: fl}
+		return gendb.ListAllActiveSessionsParams{Now: nt, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 
-func listUserSessionsParams(userID, cursor string, limit int64) (gendb.ListUserSessionsByUserIDParams, error) {
+func listUserSessionsParams(userID, cursor string, limit int64, now time.Time) (gendb.ListUserSessionsByUserIDParams, error) {
+	nt := pgtime.New(now)
 	return withCursor(cursor, limit, func(ct pgtime.NullTime, cid pgtype.Text, fl int32) gendb.ListUserSessionsByUserIDParams {
-		return gendb.ListUserSessionsByUserIDParams{UserID: userID, CursorTime: ct, CursorID: cid, Limit: fl}
+		return gendb.ListUserSessionsByUserIDParams{UserID: userID, Now: nt, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 

--- a/backend/internal/hub/store/postgres/db/migrations/00001_initial.sql
+++ b/backend/internal/hub/store/postgres/db/migrations/00001_initial.sql
@@ -547,7 +547,7 @@ CREATE INDEX idx_webauthn_sessions_user_kind ON webauthn_sessions(user_id, kind)
 -- (internal/hub/settings); secret-bearing keys keep the secret half in the
 -- keystore-encrypted column (AAD bound to the key name). An absent row means
 -- the code default, so adding, removing, or reshaping a setting is a Go
--- change only — never a migration. This table is the single home for all
+-- change only -- never a migration. This table is the single home for all
 -- runtime-changeable configuration (auth policy, SMTP, timeouts, limits,
 -- captcha providers, rate-limit overrides).
 CREATE TABLE hub_settings (

--- a/backend/internal/hub/store/postgres/db/migrations/00001_initial.sql
+++ b/backend/internal/hub/store/postgres/db/migrations/00001_initial.sql
@@ -32,6 +32,10 @@ CREATE TABLE users (
     -- Counts attempts against the active pending_email_token. Reset to 0
     -- whenever a new token is issued; force-expires the token at >5.
     pending_email_attempts   INTEGER NOT NULL DEFAULT 0,
+    -- Password-reset break-glass: token stored hashed (SHA-256 hex).
+    pending_password_reset_token      VARCHAR(64) NOT NULL DEFAULT '',
+    pending_password_reset_expires_at TIMESTAMPTZ,
+    pending_password_reset_attempts   INTEGER NOT NULL DEFAULT 0,
     password_set             BOOLEAN NOT NULL DEFAULT TRUE,
     is_admin                 BOOLEAN NOT NULL DEFAULT FALSE,
     prefs          TEXT NOT NULL DEFAULT '{}',
@@ -56,8 +60,11 @@ CREATE INDEX idx_users_created_at ON users(created_at DESC, id DESC) WHERE delet
 -- Verification codes are looked up per-user (the session identifies who),
 -- so no global token index is needed. Index expiry instead, for cleanup.
 CREATE INDEX idx_users_pending_email_expires_at ON users(pending_email_expires_at) WHERE pending_email_expires_at IS NOT NULL;
+-- Password-reset tokens are looked up by hash on complete; index non-empty
+-- values so Completes do not scan the users table.
+CREATE INDEX IF NOT EXISTS idx_users_pending_password_reset_token ON users(pending_password_reset_token) WHERE pending_password_reset_token <> '';
 -- GetFirstAdmin scans for the earliest non-deleted admin (bootstrap path).
--- Partial on (is_admin, deleted_at) keeps the index tiny; indexing on
+-- Partial on (is_admin, deleted_at) keeps the index tiny;
 -- created_at lets the ORDER BY + LIMIT 1 hit the first leaf directly.
 CREATE INDEX idx_users_is_admin ON users(created_at) WHERE is_admin AND deleted_at IS NULL;
 
@@ -497,6 +504,44 @@ CREATE TABLE pending_oauth_signups (
     created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
+-- Passkey (WebAuthn) credentials for email-local accounts
+CREATE TABLE passkey_credentials (
+    id              TEXT COLLATE "C" PRIMARY KEY,
+    user_id         TEXT COLLATE "C" NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    credential_id   BYTEA NOT NULL,   -- plaintext: login lookup + unique index
+    public_key      BYTEA NOT NULL,   -- keystore-encrypted COSE public key, AAD: 'passkey_public_key:' || id
+    sign_count      BIGINT NOT NULL DEFAULT 0,
+    aaguid          BYTEA,
+    backup_eligible BOOLEAN NOT NULL DEFAULT FALSE,
+    backup_state    BOOLEAN NOT NULL DEFAULT FALSE,
+    transports      TEXT NOT NULL DEFAULT '[]',
+    friendly_name   TEXT NOT NULL DEFAULT '',
+    key_version     BIGINT NOT NULL DEFAULT 1,  -- active keystore version at write; for reencrypt scans
+    created_at      TIMESTAMPTZ NOT NULL,
+    last_used_at    TIMESTAMPTZ
+);
+CREATE UNIQUE INDEX idx_passkey_credentials_credential_id ON passkey_credentials(credential_id);
+CREATE INDEX idx_passkey_credentials_user_id ON passkey_credentials(user_id);
+CREATE INDEX idx_passkey_credentials_key_version ON passkey_credentials(key_version);
+
+-- Ephemeral WebAuthn ceremony state (signup, login, register, reauth)
+CREATE TABLE webauthn_sessions (
+    id           TEXT COLLATE "C" PRIMARY KEY,
+    kind         TEXT NOT NULL CHECK (kind IN (
+        'signup', 'login', 'register', 'reauth', 'reauth_proof'
+    )),
+    user_id      TEXT COLLATE "C" REFERENCES users(id) ON DELETE CASCADE,
+    payload_json TEXT NOT NULL DEFAULT '{}',  -- '{}' or keystore-encrypted signup draft (base64), AAD: 'webauthn_payload:' || id
+    session_data BYTEA NOT NULL,             -- keystore-encrypted ceremony state, AAD: 'webauthn_session:' || id
+    expires_at   TIMESTAMPTZ NOT NULL,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_webauthn_sessions_expires_at ON webauthn_sessions(expires_at);
+
+-- Ceremony begins delete prior rows per user and kind on every Begin*;
+-- without this index each begin full-scans the not-yet-swept rows.
+CREATE INDEX idx_webauthn_sessions_user_kind ON webauthn_sessions(user_id, kind);
+
 -- Instance-level hub settings: one row per setting key. `value` is a JSON
 -- document whose shape is defined by the owning package's typed key handle
 -- (internal/hub/settings); secret-bearing keys keep the secret half in the
@@ -534,6 +579,8 @@ DROP TABLE IF EXISTS revocation_events;
 DROP TABLE IF EXISTS revocation_event_sequence;
 DROP TABLE IF EXISTS pending_oauth_signups;
 DROP TABLE IF EXISTS altcha_used_salts;
+DROP TABLE IF EXISTS webauthn_sessions;
+DROP TABLE IF EXISTS passkey_credentials;
 DROP TABLE IF EXISTS hub_settings;
 DROP TABLE IF EXISTS oauth_states;
 DROP TABLE IF EXISTS oauth_tokens;

--- a/backend/internal/hub/store/postgres/db/queries/cli_authorization_codes.sql
+++ b/backend/internal/hub/store/postgres/db/queries/cli_authorization_codes.sql
@@ -1,3 +1,8 @@
+-- Clock rule: expires_at columns are written by the hub process, so every
+-- comparison of them binds the hub's clock (sqlc.arg(now)), never the
+-- database clock. Timestamps that record when something happened keep the
+-- database clock.
+
 -- name: CreateCLIAuthorizationCode :exec
 INSERT INTO cli_authorization_codes (
     code, user_id, code_challenge, device_name, expires_at
@@ -5,12 +10,12 @@ INSERT INTO cli_authorization_codes (
 
 -- name: GetActiveCLIAuthorizationCode :one
 SELECT * FROM cli_authorization_codes
-WHERE code = $1 AND consumed_at IS NULL AND expires_at > NOW();
+WHERE code = $1 AND consumed_at IS NULL AND expires_at > sqlc.arg(now);
 
 -- name: ConsumeCLIAuthorizationCode :one
 UPDATE cli_authorization_codes
 SET consumed_at = NOW()
-WHERE code = $1 AND consumed_at IS NULL AND expires_at > NOW()
+WHERE code = $1 AND consumed_at IS NULL AND expires_at > sqlc.arg(now)
 RETURNING *;
 
 -- name: DeleteExpiredCLIAuthorizationCodes :execrows

--- a/backend/internal/hub/store/postgres/db/queries/delegation_tokens.sql
+++ b/backend/internal/hub/store/postgres/db/queries/delegation_tokens.sql
@@ -1,3 +1,8 @@
+-- Clock rule: expires_at columns are written by the hub process, so every
+-- comparison of them binds the hub's clock (sqlc.arg(now)), never the
+-- database clock. Timestamps that record when something happened keep the
+-- database clock.
+
 -- name: CreateDelegationToken :exec
 INSERT INTO delegation_tokens (
     id, user_id, worker_id, agent_id, terminal_id,
@@ -79,7 +84,7 @@ LIMIT sqlc.arg('limit');
 SELECT * FROM delegation_tokens
 WHERE user_id = $1
   AND revoked_at IS NULL
-  AND expires_at > NOW()
+  AND expires_at > sqlc.arg(now)
 ORDER BY created_at DESC;
 
 -- name: RevokeDelegationTokensByUserFast :execrows

--- a/backend/internal/hub/store/postgres/db/queries/device_authorizations.sql
+++ b/backend/internal/hub/store/postgres/db/queries/device_authorizations.sql
@@ -1,3 +1,8 @@
+-- Clock rule: expires_at columns are written by the hub process, so every
+-- comparison of them binds the hub's clock (sqlc.arg(now)), never the
+-- database clock. Timestamps that record when something happened keep the
+-- database clock.
+
 -- name: CreateDeviceAuthorization :exec
 INSERT INTO device_authorizations (
     device_code, user_code, device_name, interval_seconds, expires_at
@@ -12,12 +17,12 @@ SELECT * FROM device_authorizations WHERE user_code = $1;
 -- name: ApproveDeviceAuthorization :execrows
 UPDATE device_authorizations
 SET approved = 1, user_id = $1
-WHERE device_code = $2 AND consumed_at IS NULL AND expires_at > NOW();
+WHERE device_code = $2 AND consumed_at IS NULL AND expires_at > sqlc.arg(now);
 
 -- name: ApproveDeviceAuthorizationByUserCode :execrows
 UPDATE device_authorizations
 SET approved = 1, user_id = $1
-WHERE user_code = $2 AND consumed_at IS NULL AND expires_at > NOW();
+WHERE user_code = $2 AND consumed_at IS NULL AND expires_at > sqlc.arg(now);
 
 -- name: DenyDeviceAuthorization :execrows
 UPDATE device_authorizations
@@ -28,7 +33,7 @@ WHERE device_code = $1 AND consumed_at IS NULL;
 UPDATE device_authorizations
 SET consumed_at = NOW()
 WHERE device_code = $1 AND approved = 1 AND consumed_at IS NULL
-  AND expires_at > NOW();
+  AND expires_at > sqlc.arg(now);
 
 -- name: TouchDeviceAuthorizationPoll :exec
 UPDATE device_authorizations

--- a/backend/internal/hub/store/postgres/db/queries/oauth_states.sql
+++ b/backend/internal/hub/store/postgres/db/queries/oauth_states.sql
@@ -1,3 +1,8 @@
+-- Clock rule: expires_at columns are written by the hub process, so every
+-- comparison of them binds the hub's clock (sqlc.arg(now)), never the
+-- database clock. Timestamps that record when something happened keep the
+-- database clock.
+
 -- name: CreateOAuthState :exec
 INSERT INTO oauth_states (state, provider_id, pkce_verifier, redirect_uri, expires_at)
 VALUES ($1, $2, $3, $4, $5);
@@ -9,4 +14,4 @@ SELECT * FROM oauth_states WHERE state = $1;
 DELETE FROM oauth_states WHERE state = $1;
 
 -- name: DeleteExpiredOAuthStates :execresult
-DELETE FROM oauth_states WHERE expires_at < NOW();
+DELETE FROM oauth_states WHERE expires_at < sqlc.arg(now);

--- a/backend/internal/hub/store/postgres/db/queries/oauth_tokens.sql
+++ b/backend/internal/hub/store/postgres/db/queries/oauth_tokens.sql
@@ -1,3 +1,7 @@
+-- Clock rule: token expiry is stored by the hub process, so the
+-- refresh-due comparison binds the hub's clock (sqlc.arg(refresh_due_at)),
+-- never the database clock.
+
 -- name: UpsertOAuthTokens :exec
 INSERT INTO oauth_tokens (user_id, provider_id, access_token, refresh_token, token_type, expires_at, key_version)
 VALUES ($1, $2, $3, $4, $5, $6, $7)
@@ -15,7 +19,7 @@ WHERE user_id = $1 AND provider_id = $2;
 
 -- name: ListExpiringOAuthTokens :many
 SELECT * FROM oauth_tokens
-WHERE expires_at <= NOW() + INTERVAL '5 minutes';
+WHERE expires_at <= sqlc.arg(refresh_due_at);
 
 -- name: DeleteOAuthTokensByProvider :exec
 DELETE FROM oauth_tokens WHERE provider_id = $1;

--- a/backend/internal/hub/store/postgres/db/queries/passkey_credentials.sql
+++ b/backend/internal/hub/store/postgres/db/queries/passkey_credentials.sql
@@ -1,0 +1,59 @@
+-- name: CreatePasskeyCredential :exec
+INSERT INTO passkey_credentials (
+    id, user_id, credential_id, public_key, sign_count, aaguid,
+    backup_eligible, backup_state, transports, friendly_name, key_version, created_at, last_used_at
+) VALUES (
+    sqlc.arg(id),
+    sqlc.arg(user_id),
+    sqlc.arg(credential_id),
+    sqlc.arg(public_key),
+    sqlc.arg(sign_count),
+    sqlc.narg(aaguid),
+    sqlc.arg(backup_eligible),
+    sqlc.arg(backup_state),
+    sqlc.arg(transports),
+    sqlc.arg(friendly_name),
+    sqlc.arg(key_version),
+    sqlc.arg(created_at),
+    sqlc.narg(last_used_at)
+);
+
+-- name: GetPasskeyCredentialByID :one
+SELECT * FROM passkey_credentials WHERE id = $1;
+
+-- name: GetPasskeyCredentialByCredentialID :one
+SELECT * FROM passkey_credentials WHERE credential_id = $1;
+
+-- name: ListPasskeyCredentialsByUser :many
+SELECT * FROM passkey_credentials WHERE user_id = $1 ORDER BY created_at;
+
+-- name: CountPasskeyCredentialsByUser :one
+SELECT COUNT(*) FROM passkey_credentials WHERE user_id = $1;
+
+-- name: UpdatePasskeySignCount :execresult
+UPDATE passkey_credentials
+SET sign_count = sqlc.arg(sign_count), last_used_at = sqlc.arg(last_used_at)
+WHERE credential_id = sqlc.arg(credential_id) AND user_id = sqlc.arg(user_id)
+  AND (sign_count < sqlc.arg(sign_count) OR sqlc.arg(sign_count) = 0);
+
+-- name: UpdatePasskeyFriendlyName :exec
+UPDATE passkey_credentials
+SET friendly_name = sqlc.arg(friendly_name)
+WHERE id = sqlc.arg(id) AND user_id = sqlc.arg(user_id);
+
+-- name: UpdatePasskeyPublicKey :exec
+UPDATE passkey_credentials
+SET public_key = sqlc.arg(public_key), key_version = sqlc.arg(key_version)
+WHERE id = sqlc.arg(id) AND user_id = sqlc.arg(user_id);
+
+-- name: DeletePasskeyCredential :exec
+DELETE FROM passkey_credentials WHERE id = $1 AND user_id = $2;
+
+-- name: DeleteAllPasskeyCredentialsByUser :exec
+DELETE FROM passkey_credentials WHERE user_id = $1;
+
+-- name: ListPasskeyCredentialsByKeyVersion :many
+SELECT * FROM passkey_credentials WHERE key_version = $1;
+
+-- name: CountPasskeyCredentialsByKeyVersion :one
+SELECT COUNT(*) FROM passkey_credentials WHERE key_version = $1;

--- a/backend/internal/hub/store/postgres/db/queries/pending_oauth_signups.sql
+++ b/backend/internal/hub/store/postgres/db/queries/pending_oauth_signups.sql
@@ -1,3 +1,8 @@
+-- Clock rule: expires_at columns are written by the hub process, so every
+-- comparison of them binds the hub's clock (sqlc.arg(now)), never the
+-- database clock. Timestamps that record when something happened keep the
+-- database clock.
+
 -- name: CreatePendingOAuthSignup :exec
 INSERT INTO pending_oauth_signups (token, provider_id, provider_subject, email, display_name, access_token, refresh_token, token_type, token_expires_at, key_version, redirect_uri, expires_at)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12);
@@ -9,4 +14,4 @@ SELECT * FROM pending_oauth_signups WHERE token = $1;
 DELETE FROM pending_oauth_signups WHERE token = $1;
 
 -- name: DeleteExpiredPendingOAuthSignups :execresult
-DELETE FROM pending_oauth_signups WHERE expires_at < NOW();
+DELETE FROM pending_oauth_signups WHERE expires_at < sqlc.arg(now);

--- a/backend/internal/hub/store/postgres/db/queries/user_sessions.sql
+++ b/backend/internal/hub/store/postgres/db/queries/user_sessions.sql
@@ -1,3 +1,8 @@
+-- Clock rule: expires_at columns are written by the hub process, so every
+-- comparison of them binds the hub's clock (sqlc.arg(now)), never the
+-- database clock. Timestamps that record when something happened
+-- (created_at, updated_at, last_active_at) keep the database clock.
+
 -- name: CreateUserSession :exec
 INSERT INTO user_sessions (
     id, user_id, expires_at, user_agent, ip_address, auth_generation
@@ -11,7 +16,7 @@ INSERT INTO user_sessions (
 );
 
 -- name: GetUserSessionByID :one
-SELECT * FROM user_sessions WHERE id = $1 AND expires_at > NOW();
+SELECT * FROM user_sessions WHERE id = $1 AND expires_at > sqlc.arg(now);
 
 -- name: TouchUserSession :execrows
 -- The expires_at predicate is what keeps an expired session dead. The Hub
@@ -21,7 +26,7 @@ SELECT * FROM user_sessions WHERE id = $1 AND expires_at > NOW();
 UPDATE user_sessions
 SET last_active_at = NOW(),
     expires_at = $1
-WHERE id = $2 AND last_active_at < $3 AND expires_at > NOW();
+WHERE id = $2 AND last_active_at < $3 AND expires_at > sqlc.arg(now);
 
 -- name: DeleteUserSession :one
 DELETE FROM user_sessions WHERE id = $1 RETURNING id, user_id;
@@ -31,7 +36,7 @@ SELECT u.id, u.username, u.is_admin, u.email_verified, u.email, s.created_at, s.
 FROM user_sessions s
 JOIN users u ON s.user_id = u.id
 WHERE s.id = $1
-  AND s.expires_at > NOW()
+  AND s.expires_at > sqlc.arg(now)
   AND u.deleted_at IS NULL
   AND s.auth_generation >= u.auth_generation;
 
@@ -45,7 +50,7 @@ WHERE s.id = sqlc.arg(session_id)
   AND u.deleted_at IS NULL;
 
 -- name: DeleteExpiredUserSessions :execresult
-DELETE FROM user_sessions WHERE expires_at < NOW();
+DELETE FROM user_sessions WHERE expires_at < sqlc.arg(now);
 
 -- name: DeleteUserSessionsByUser :exec
 DELETE FROM user_sessions WHERE user_id = $1;
@@ -55,7 +60,7 @@ DELETE FROM user_sessions WHERE user_id = $1 AND id != $2;
 
 -- name: ListUserSessionsByUserID :many
 SELECT * FROM user_sessions
-WHERE user_id = sqlc.arg(user_id) AND expires_at > NOW()
+WHERE user_id = sqlc.arg(user_id) AND expires_at > sqlc.arg(now)
   AND (sqlc.narg(cursor_time)::timestamptz IS NULL
        OR last_active_at < sqlc.narg(cursor_time)::timestamptz
        OR (last_active_at = sqlc.narg(cursor_time)::timestamptz AND id < sqlc.narg(cursor_id)))
@@ -66,7 +71,7 @@ LIMIT sqlc.arg('limit');
 SELECT s.id, s.user_id, COALESCE(u.username, '') AS username, (u.id IS NULL)::boolean AS user_deleted, s.created_at, s.last_active_at, s.expires_at, s.ip_address, s.user_agent
 FROM user_sessions s
 LEFT JOIN users u ON s.user_id = u.id AND u.deleted_at IS NULL
-WHERE s.expires_at > NOW()
+WHERE s.expires_at > sqlc.arg(now)
   AND (sqlc.narg(cursor_time)::timestamptz IS NULL
        OR s.last_active_at < sqlc.narg(cursor_time)::timestamptz
        OR (s.last_active_at = sqlc.narg(cursor_time)::timestamptz AND s.id < sqlc.narg(cursor_id)))

--- a/backend/internal/hub/store/postgres/db/queries/users.sql
+++ b/backend/internal/hub/store/postgres/db/queries/users.sql
@@ -168,7 +168,7 @@ RETURNING id, updated_at;
 UPDATE users
 SET pending_email_attempts = pending_email_attempts + 1,
     pending_email_expires_at = CASE
-        WHEN pending_email_attempts + 1 > 5 THEN NOW()
+        WHEN pending_email_attempts + 1 > sqlc.arg(max_attempts) THEN sqlc.arg(now)
         ELSE pending_email_expires_at END,
     updated_at = NOW()
 WHERE id = $1 AND pending_email_token != ''
@@ -198,4 +198,58 @@ SET tokens_revoked_at = revocation_clock.now_at,
     updated_at = revocation_clock.now_at
 FROM (SELECT clock_timestamp() AS now_at) AS revocation_clock
 WHERE id = $1
+RETURNING id, tokens_revoked_at, auth_generation;
+
+-- name: SetPendingPasswordReset :execresult
+-- Conditional mint: the write lands only when no previous token exists or
+-- the previous token's expiry is at or before cooldown_cutoff, so two
+-- concurrent requests for one account cannot both mint and both send (the
+-- loser matches no row). The Go caller derives cooldown_cutoff from the
+-- resend cooldown; the comparison stays on the app clock, the same clock
+-- that wrote the expiry.
+UPDATE users
+SET pending_password_reset_token = sqlc.arg(pending_password_reset_token),
+    pending_password_reset_expires_at = sqlc.arg(pending_password_reset_expires_at),
+    pending_password_reset_attempts = 0,
+    updated_at = NOW()
+WHERE id = sqlc.arg(id)
+  AND (pending_password_reset_expires_at IS NULL
+       OR pending_password_reset_expires_at <= sqlc.arg(cooldown_cutoff));
+
+
+-- name: ClearPendingPasswordReset :exec
+UPDATE users
+SET pending_password_reset_token = '',
+    pending_password_reset_expires_at = NULL,
+    pending_password_reset_attempts = 0,
+    updated_at = NOW()
+WHERE id = $1;
+
+-- name: ConsumePasswordResetAttemptByToken :one
+-- Charges one attempt against the row that holds this exact token. Keying
+-- the charge by the token (not the user id) makes the find, the charge, and
+-- the ownership re-check one statement: a token cleared between a caller's
+-- read and this update simply matches no row.
+UPDATE users
+SET pending_password_reset_expires_at = CASE
+        WHEN pending_password_reset_attempts + 1 > sqlc.arg(max_attempts) THEN sqlc.arg(now)
+        ELSE pending_password_reset_expires_at END,
+    pending_password_reset_attempts = pending_password_reset_attempts + 1,
+    updated_at = NOW()
+WHERE pending_password_reset_token = sqlc.arg(token) AND pending_password_reset_token != ''
+  AND pending_password_reset_expires_at > sqlc.arg(now)
+  AND deleted_at IS NULL
+RETURNING *;
+
+-- name: CompletePasswordReset :one
+UPDATE users
+SET password_hash = sqlc.arg(password_hash),
+    password_set = TRUE,
+    pending_password_reset_token = '',
+    pending_password_reset_expires_at = NULL,
+    pending_password_reset_attempts = 0,
+    tokens_revoked_at = clock_timestamp(),
+    auth_generation = auth_generation + 1,
+    updated_at = NOW()
+WHERE id = sqlc.arg(id) AND pending_password_reset_token = sqlc.arg(pending_password_reset_token)
 RETURNING id, tokens_revoked_at, auth_generation;

--- a/backend/internal/hub/store/postgres/db/queries/users.sql
+++ b/backend/internal/hub/store/postgres/db/queries/users.sql
@@ -147,9 +147,29 @@ SELECT count(*) FROM users WHERE deleted_at IS NULL;
 -- name: HasAnyUser :one
 SELECT EXISTS(SELECT 1 FROM users WHERE deleted_at IS NULL LIMIT 1);
 
--- name: SetPendingEmail :exec
-UPDATE users SET pending_email = $1, pending_email_token = $2, pending_email_expires_at = $3, pending_email_attempts = 0, updated_at = NOW()
-WHERE id = $4;
+-- name: SetPendingEmail :execresult
+-- Conditional mint: the write lands only when no previous code exists or
+-- the previous code's expiry is at or before cooldown_cutoff, so two
+-- concurrent resends for one account cannot both mint and both send (the
+-- loser matches no row), and RequestEmailChange cannot mint on every
+-- request. Its twin SetPendingPasswordReset carries the same predicate.
+-- The Go caller derives cooldown_cutoff from the resend cooldown; the
+-- comparison stays on the app clock, the clock that wrote the expiry.
+UPDATE users SET pending_email = sqlc.arg(pending_email), pending_email_token = sqlc.arg(pending_email_token), pending_email_expires_at = sqlc.narg(pending_email_expires_at), pending_email_attempts = 0, updated_at = NOW()
+WHERE id = sqlc.arg(id)
+  AND (pending_email_expires_at IS NULL
+       OR pending_email_expires_at <= sqlc.arg(cooldown_cutoff));
+
+-- name: ClearPendingEmailCode :exec
+-- ClearPendingEmailCode drops an undelivered code and KEEPS the pending
+-- address. An empty token is the "no live code, address still pending"
+-- state: ConsumeVerificationAttempt and ClearStalePendingEmails both
+-- filter pending_email_token != '', so neither acts on it, and the
+-- cooldown -- which reads the expiry -- does not apply, so the retry a
+-- failed send invites is never blocked. Unconditional on purpose: it
+-- undoes a mint that the relay refused.
+UPDATE users SET pending_email_token = '', pending_email_expires_at = NULL, pending_email_attempts = 0, updated_at = NOW()
+WHERE id = $1;
 
 -- name: ClearPendingEmail :exec
 UPDATE users SET pending_email = '', pending_email_token = '', pending_email_expires_at = NULL, pending_email_attempts = 0, updated_at = NOW()
@@ -179,8 +199,15 @@ UPDATE users SET pending_email = '', pending_email_token = '', pending_email_exp
 WHERE pending_email = $1 AND id != $2;
 
 -- name: ClearStalePendingEmails :execresult
+-- The second arm reaps a codeless row: a send the relay refused leaves the
+-- ADDRESS with no token and no expiry (ClearPendingEmailCode), so the
+-- expiry compare can never see it and an abandoned address would otherwise
+-- outlive the database. updated_at is the only instant such a row carries,
+-- and ClearPendingEmailCode stamps it.
 UPDATE users SET pending_email = '', pending_email_token = '', pending_email_expires_at = NULL, pending_email_attempts = 0, updated_at = NOW()
-WHERE pending_email_token != '' AND pending_email_expires_at IS NOT NULL AND pending_email_expires_at < $1;
+WHERE pending_email != ''
+  AND ((pending_email_token != '' AND pending_email_expires_at IS NOT NULL AND pending_email_expires_at < sqlc.arg(cutoff))
+    OR (pending_email_token = '' AND updated_at < sqlc.arg(codeless_cutoff)));
 
 -- name: BumpUserTokensRevokedAt :one
 -- The query itself has no deleted_at guard, so it would act on a

--- a/backend/internal/hub/store/postgres/db/queries/webauthn_sessions.sql
+++ b/backend/internal/hub/store/postgres/db/queries/webauthn_sessions.sql
@@ -1,0 +1,47 @@
+-- Clock rule: expires_at columns are written by the hub process, so every
+-- comparison of them binds the hub's clock (sqlc.arg(now)), never the
+-- database clock. Timestamps that record when something happened
+-- (created_at, updated_at) keep the database clock.
+
+-- name: CreateWebAuthnSession :exec
+INSERT INTO webauthn_sessions (id, kind, user_id, payload_json, session_data, expires_at, created_at)
+VALUES (
+    sqlc.arg(id),
+    sqlc.arg(kind),
+    sqlc.narg(user_id),
+    sqlc.arg(payload_json),
+    sqlc.arg(session_data),
+    sqlc.arg(expires_at),
+    sqlc.arg(created_at)
+);
+
+-- name: GetWebAuthnSession :one
+SELECT * FROM webauthn_sessions WHERE id = $1;
+
+-- name: DeleteWebAuthnSession :exec
+DELETE FROM webauthn_sessions WHERE id = $1;
+
+-- name: ConsumeWebAuthnProof :execresult
+-- kind is a parameter so the Go constant (webauthn.KindReauthProof) stays
+-- the single spelling of what a proof row is named.
+DELETE FROM webauthn_sessions
+WHERE id = sqlc.arg(id) AND kind = sqlc.arg(kind) AND user_id = sqlc.arg(user_id) AND expires_at > sqlc.arg(now);
+
+-- name: GetValidWebAuthnProof :one
+-- Peek twin of ConsumeWebAuthnProof: the same validity predicate without
+-- the delete, so an admission check and a consume cannot drift apart.
+SELECT * FROM webauthn_sessions
+WHERE id = sqlc.arg(id) AND kind = sqlc.arg(kind) AND user_id = sqlc.arg(user_id) AND expires_at > sqlc.arg(now);
+
+-- name: ConsumeWebAuthnCeremonySession :execresult
+DELETE FROM webauthn_sessions
+WHERE id = sqlc.arg(id) AND kind = sqlc.arg(kind) AND expires_at > sqlc.arg(now);
+
+-- name: DeleteWebAuthnSessionsByUser :exec
+DELETE FROM webauthn_sessions WHERE user_id = $1;
+
+-- name: DeleteWebAuthnSessionsByUserAndKind :exec
+DELETE FROM webauthn_sessions WHERE user_id = $1 AND kind = $2;
+
+-- name: DeleteExpiredWebAuthnSessions :execresult
+DELETE FROM webauthn_sessions WHERE expires_at < sqlc.arg(now);

--- a/backend/internal/hub/store/postgres/db/queries/webauthn_sessions.sql
+++ b/backend/internal/hub/store/postgres/db/queries/webauthn_sessions.sql
@@ -23,7 +23,7 @@ DELETE FROM webauthn_sessions WHERE id = $1;
 
 -- name: ConsumeWebAuthnProof :execresult
 -- kind is a parameter so the Go constant (webauthn.KindReauthProof) stays
--- the single spelling of what a proof row is named.
+-- the single spelling of what identifies a proof row.
 DELETE FROM webauthn_sessions
 WHERE id = sqlc.arg(id) AND kind = sqlc.arg(kind) AND user_id = sqlc.arg(user_id) AND expires_at > sqlc.arg(now);
 

--- a/backend/internal/hub/store/postgres/delegation_tokens.go
+++ b/backend/internal/hub/store/postgres/delegation_tokens.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"time"
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/postgres/generated/db"
@@ -117,14 +118,17 @@ func (s *delegationTokenStore) ListAll(ctx context.Context, p store.ListAllDeleg
 	}
 }
 
-func (s *delegationTokenStore) ListActiveByUser(ctx context.Context, userID userid.UserID) ([]store.DelegationToken, error) {
+func (s *delegationTokenStore) ListActiveByUser(ctx context.Context, userID userid.UserID, now time.Time) ([]store.DelegationToken, error) {
 	owner, ok := userid.OwnerFilter(userID)
 	if !ok {
 		// An unminted caller owns nothing; binding "" would MATCH every
 		// blank-owner row rather than none. See userid.OwnerFilter.
 		return nil, nil
 	}
-	rows, err := s.conn.q.ListActiveDelegationTokensByUser(ctx, owner)
+	rows, err := s.conn.q.ListActiveDelegationTokensByUser(ctx, gendb.ListActiveDelegationTokensByUserParams{
+		UserID: owner,
+		Now:    pgtime.New(now),
+	})
 	if err != nil {
 		return nil, mapErr(err)
 	}

--- a/backend/internal/hub/store/postgres/device_authorizations.go
+++ b/backend/internal/hub/store/postgres/device_authorizations.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/leapmux/leapmux/internal/hub/store"
@@ -85,6 +86,7 @@ func (s *deviceAuthorizationStore) Approve(ctx context.Context, p store.ApproveD
 	return s.conn.q.ApproveDeviceAuthorization(ctx, gendb.ApproveDeviceAuthorizationParams{
 		UserID:     userIDText(p.UserID),
 		DeviceCode: p.DeviceCode,
+		Now:        pgtime.New(p.Now),
 	})
 }
 
@@ -101,6 +103,7 @@ func (s *deviceAuthorizationStore) ApproveByUserCode(ctx context.Context, p stor
 	return s.conn.q.ApproveDeviceAuthorizationByUserCode(ctx, gendb.ApproveDeviceAuthorizationByUserCodeParams{
 		UserID:   userIDText(p.UserID),
 		UserCode: p.UserCode,
+		Now:      pgtime.New(p.Now),
 	})
 }
 
@@ -108,8 +111,11 @@ func (s *deviceAuthorizationStore) Deny(ctx context.Context, deviceCode string) 
 	return s.conn.q.DenyDeviceAuthorization(ctx, deviceCode)
 }
 
-func (s *deviceAuthorizationStore) Consume(ctx context.Context, deviceCode string) (int64, error) {
-	return s.conn.q.ConsumeDeviceAuthorization(ctx, deviceCode)
+func (s *deviceAuthorizationStore) Consume(ctx context.Context, deviceCode string, now time.Time) (int64, error) {
+	return s.conn.q.ConsumeDeviceAuthorization(ctx, gendb.ConsumeDeviceAuthorizationParams{
+		DeviceCode: deviceCode,
+		Now:        pgtime.New(now),
+	})
 }
 
 func (s *deviceAuthorizationStore) TouchPoll(ctx context.Context, deviceCode string) error {

--- a/backend/internal/hub/store/postgres/device_authorizations.go
+++ b/backend/internal/hub/store/postgres/device_authorizations.go
@@ -73,7 +73,7 @@ func (s *deviceAuthorizationStore) GetByUserCode(ctx context.Context, userCode s
 	return &out, nil
 }
 
-func (s *deviceAuthorizationStore) Approve(ctx context.Context, p store.ApproveDeviceAuthorizationParams) (int64, error) {
+func (s *deviceAuthorizationStore) Approve(ctx context.Context, p store.ApproveDeviceAuthorizationParams, now time.Time) (int64, error) {
 	// An approval names WHO approved. A zero id would be written as SQL NULL
 	// while the UPDATE still matched the row, so the store would report one
 	// row affected, the browser would say "device authorized", and the CLI
@@ -86,11 +86,11 @@ func (s *deviceAuthorizationStore) Approve(ctx context.Context, p store.ApproveD
 	return s.conn.q.ApproveDeviceAuthorization(ctx, gendb.ApproveDeviceAuthorizationParams{
 		UserID:     userIDText(p.UserID),
 		DeviceCode: p.DeviceCode,
-		Now:        pgtime.New(p.Now),
+		Now:        pgtime.New(now),
 	})
 }
 
-func (s *deviceAuthorizationStore) ApproveByUserCode(ctx context.Context, p store.ApproveDeviceAuthorizationByUserCodeParams) (int64, error) {
+func (s *deviceAuthorizationStore) ApproveByUserCode(ctx context.Context, p store.ApproveDeviceAuthorizationByUserCodeParams, now time.Time) (int64, error) {
 	// An approval names WHO approved. A zero id would be written as SQL NULL
 	// while the UPDATE still matched the row, so the store would report one
 	// row affected, the browser would say "device authorized", and the CLI
@@ -103,7 +103,7 @@ func (s *deviceAuthorizationStore) ApproveByUserCode(ctx context.Context, p stor
 	return s.conn.q.ApproveDeviceAuthorizationByUserCode(ctx, gendb.ApproveDeviceAuthorizationByUserCodeParams{
 		UserID:   userIDText(p.UserID),
 		UserCode: p.UserCode,
-		Now:      pgtime.New(p.Now),
+		Now:      pgtime.New(now),
 	})
 }
 

--- a/backend/internal/hub/store/postgres/oauth_tokens.go
+++ b/backend/internal/hub/store/postgres/oauth_tokens.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"time"
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/postgres/generated/db"
@@ -62,8 +63,8 @@ func (s *oauthTokenStore) Get(ctx context.Context, p store.GetOAuthTokensParams)
 	return &out, nil
 }
 
-func (s *oauthTokenStore) ListExpiring(ctx context.Context) ([]store.OAuthToken, error) {
-	rows, err := s.conn.q.ListExpiringOAuthTokens(ctx)
+func (s *oauthTokenStore) ListExpiring(ctx context.Context, refreshDueAt time.Time) ([]store.OAuthToken, error) {
+	rows, err := s.conn.q.ListExpiringOAuthTokens(ctx, pgtime.New(refreshDueAt))
 	if err != nil {
 		return nil, mapErr(err)
 	}

--- a/backend/internal/hub/store/postgres/passkey_credentials.go
+++ b/backend/internal/hub/store/postgres/passkey_credentials.go
@@ -1,0 +1,182 @@
+package postgres
+
+import (
+	"context"
+
+	"github.com/leapmux/leapmux/internal/hub/store"
+	gendb "github.com/leapmux/leapmux/internal/hub/store/postgres/generated/db"
+	"github.com/leapmux/leapmux/internal/util/sqltime/pgtime"
+	"github.com/leapmux/leapmux/internal/util/userid"
+)
+
+type passkeyCredentialStore struct {
+	conn *pgConn
+}
+
+var _ store.PasskeyCredentialStore = (*passkeyCredentialStore)(nil)
+
+func fromDBPasskeyCredential(c gendb.PasskeyCredential) store.PasskeyCredential {
+	return store.PasskeyCredential{
+		ID:             c.ID,
+		UserID:         c.UserID,
+		CredentialID:   c.CredentialID,
+		PublicKey:      c.PublicKey,
+		SignCount:      c.SignCount,
+		AAGUID:         c.Aaguid,
+		BackupEligible: c.BackupEligible,
+		BackupState:    c.BackupState,
+		Transports:     c.Transports,
+		FriendlyName:   c.FriendlyName,
+		KeyVersion:     c.KeyVersion,
+		CreatedAt:      c.CreatedAt.Time,
+		LastUsedAt:     c.LastUsedAt.Ptr(),
+	}
+}
+
+func fromDBPasskeyCredentials(rows []gendb.PasskeyCredential) []store.PasskeyCredential {
+	return store.MapSlice(rows, fromDBPasskeyCredential)
+}
+
+func (s *passkeyCredentialStore) Create(ctx context.Context, p store.CreatePasskeyCredentialParams) error {
+	owner, ok := userid.New(p.UserID)
+	if !ok {
+		return store.ErrInvalidArgument
+	}
+	return mapErr(s.conn.q.CreatePasskeyCredential(ctx, gendb.CreatePasskeyCredentialParams{
+		ID:             p.ID,
+		UserID:         owner.String(),
+		CredentialID:   p.CredentialID,
+		PublicKey:      p.PublicKey,
+		SignCount:      p.SignCount,
+		Aaguid:         p.AAGUID,
+		BackupEligible: p.BackupEligible,
+		BackupState:    p.BackupState,
+		Transports:     p.Transports,
+		FriendlyName:   p.FriendlyName,
+		KeyVersion:     p.KeyVersion,
+		CreatedAt:      pgtime.New(p.CreatedAt),
+		LastUsedAt:     pgtime.NewNull(p.LastUsedAt),
+	}))
+}
+
+func (s *passkeyCredentialStore) GetByID(ctx context.Context, id string) (*store.PasskeyCredential, error) {
+	row, err := s.conn.q.GetPasskeyCredentialByID(ctx, id)
+	if err != nil {
+		return nil, mapErr(err)
+	}
+	out := fromDBPasskeyCredential(row)
+	return &out, nil
+}
+
+func (s *passkeyCredentialStore) GetByCredentialID(ctx context.Context, credentialID []byte) (*store.PasskeyCredential, error) {
+	row, err := s.conn.q.GetPasskeyCredentialByCredentialID(ctx, credentialID)
+	if err != nil {
+		return nil, mapErr(err)
+	}
+	out := fromDBPasskeyCredential(row)
+	return &out, nil
+}
+
+func (s *passkeyCredentialStore) ListByUser(ctx context.Context, userID string) ([]store.PasskeyCredential, error) {
+	owner, ok := userid.New(userID)
+	if !ok {
+		return nil, store.ErrInvalidArgument
+	}
+	rows, err := s.conn.q.ListPasskeyCredentialsByUser(ctx, owner.String())
+	if err != nil {
+		return nil, mapErr(err)
+	}
+	return fromDBPasskeyCredentials(rows), nil
+}
+
+func (s *passkeyCredentialStore) CountByUser(ctx context.Context, userID string) (int64, error) {
+	owner, ok := userid.New(userID)
+	if !ok {
+		return 0, store.ErrInvalidArgument
+	}
+	count, err := s.conn.q.CountPasskeyCredentialsByUser(ctx, owner.String())
+	if err != nil {
+		return 0, mapErr(err)
+	}
+	return count, nil
+}
+
+func (s *passkeyCredentialStore) UpdateSignCount(ctx context.Context, p store.UpdatePasskeySignCountParams) error {
+	owner, ok := userid.New(p.UserID)
+	if !ok {
+		return store.ErrInvalidArgument
+	}
+	n, err := rowsAffected(s.conn.q.UpdatePasskeySignCount(ctx, gendb.UpdatePasskeySignCountParams{
+		SignCount:    p.SignCount,
+		LastUsedAt:   pgtime.NullOf(p.LastUsedAt),
+		CredentialID: p.CredentialID,
+		UserID:       owner.String(),
+	}))
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return store.ErrNotFound
+	}
+	return nil
+}
+
+func (s *passkeyCredentialStore) UpdateFriendlyName(ctx context.Context, id, userID, friendlyName string) error {
+	owner, ok := userid.New(userID)
+	if !ok {
+		return store.ErrInvalidArgument
+	}
+	return mapErr(s.conn.q.UpdatePasskeyFriendlyName(ctx, gendb.UpdatePasskeyFriendlyNameParams{
+		FriendlyName: friendlyName,
+		ID:           id,
+		UserID:       owner.String(),
+	}))
+}
+
+func (s *passkeyCredentialStore) UpdatePublicKey(ctx context.Context, p store.UpdatePasskeyPublicKeyParams) error {
+	owner, ok := userid.New(p.UserID)
+	if !ok {
+		return store.ErrInvalidArgument
+	}
+	return mapErr(s.conn.q.UpdatePasskeyPublicKey(ctx, gendb.UpdatePasskeyPublicKeyParams{
+		PublicKey:  p.PublicKey,
+		KeyVersion: p.KeyVersion,
+		ID:         p.ID,
+		UserID:     owner.String(),
+	}))
+}
+
+func (s *passkeyCredentialStore) Delete(ctx context.Context, id, userID string) error {
+	owner, ok := userid.New(userID)
+	if !ok {
+		return store.ErrInvalidArgument
+	}
+	return mapErr(s.conn.q.DeletePasskeyCredential(ctx, gendb.DeletePasskeyCredentialParams{
+		ID:     id,
+		UserID: owner.String(),
+	}))
+}
+
+func (s *passkeyCredentialStore) DeleteAllByUser(ctx context.Context, userID string) error {
+	owner, ok := userid.New(userID)
+	if !ok {
+		return store.ErrInvalidArgument
+	}
+	return mapErr(s.conn.q.DeleteAllPasskeyCredentialsByUser(ctx, owner.String()))
+}
+
+func (s *passkeyCredentialStore) ListByKeyVersion(ctx context.Context, keyVersion int64) ([]store.PasskeyCredential, error) {
+	rows, err := s.conn.q.ListPasskeyCredentialsByKeyVersion(ctx, keyVersion)
+	if err != nil {
+		return nil, mapErr(err)
+	}
+	return fromDBPasskeyCredentials(rows), nil
+}
+
+func (s *passkeyCredentialStore) CountByKeyVersion(ctx context.Context, keyVersion int64) (int64, error) {
+	count, err := s.conn.q.CountPasskeyCredentialsByKeyVersion(ctx, keyVersion)
+	if err != nil {
+		return 0, mapErr(err)
+	}
+	return count, nil
+}

--- a/backend/internal/hub/store/postgres/postgres.go
+++ b/backend/internal/hub/store/postgres/postgres.go
@@ -147,6 +147,12 @@ func (s *pgStore) OAuthUserLinks() store.OAuthUserLinkStore {
 func (s *pgStore) PendingOAuthSignups() store.PendingOAuthSignupStore {
 	return &pendingOAuthSignupStore{conn: s.conn}
 }
+func (s *pgStore) PasskeyCredentials() store.PasskeyCredentialStore {
+	return &passkeyCredentialStore{conn: s.conn}
+}
+func (s *pgStore) WebAuthnSessions() store.WebAuthnSessionStore {
+	return &webAuthnSessionStore{conn: s.conn}
+}
 func (s *pgStore) Settings() store.SettingsStore {
 	return &settingsStore{conn: s.conn}
 }

--- a/backend/internal/hub/store/postgres/sessions.go
+++ b/backend/internal/hub/store/postgres/sessions.go
@@ -54,8 +54,11 @@ func (s *sessionStore) Create(ctx context.Context, p store.CreateSessionParams) 
 	})
 }
 
-func (s *sessionStore) GetByID(ctx context.Context, id string) (*store.UserSession, error) {
-	sess, err := s.conn.q.GetUserSessionByID(ctx, id)
+func (s *sessionStore) GetByID(ctx context.Context, id string, now time.Time) (*store.UserSession, error) {
+	sess, err := s.conn.q.GetUserSessionByID(ctx, gendb.GetUserSessionByIDParams{
+		ID:  id,
+		Now: pgtime.New(now),
+	})
 	if err != nil {
 		return nil, mapErr(err)
 	}
@@ -68,6 +71,7 @@ func (s *sessionStore) Touch(ctx context.Context, p store.TouchSessionParams) (i
 		ExpiresAt:    pgtime.New(p.ExpiresAt),
 		ID:           p.ID,
 		LastActiveAt: pgtime.New(p.LastActiveAt),
+		Now:          pgtime.New(p.Now),
 	})
 	return n, mapErr(err)
 }
@@ -139,7 +143,7 @@ func (s *sessionStore) ListByUserID(ctx context.Context, p store.ListUserSession
 	}
 	return queryPage(ctx, p.Limit,
 		func() (gendb.ListUserSessionsByUserIDParams, error) {
-			return listUserSessionsParams(owner, p.Cursor, p.Limit)
+			return listUserSessionsParams(owner, p.Cursor, p.Limit, p.Now)
 		},
 		s.conn.q.ListUserSessionsByUserID, fromDBSession)
 }
@@ -147,13 +151,16 @@ func (s *sessionStore) ListByUserID(ctx context.Context, p store.ListUserSession
 func (s *sessionStore) ListAllActive(ctx context.Context, p store.ListAllActiveSessionsParams) (store.Page[store.ActiveSession], error) {
 	return queryPage(ctx, p.Limit,
 		func() (gendb.ListAllActiveSessionsParams, error) {
-			return listAllActiveSessionsParams(p.Cursor, p.Limit)
+			return listAllActiveSessionsParams(p.Cursor, p.Limit, p.Now)
 		},
 		s.conn.q.ListAllActiveSessions, fromDBActiveSessionRow)
 }
 
-func (s *sessionStore) ValidateWithUser(ctx context.Context, id string) (*store.SessionWithUser, error) {
-	row, err := s.conn.q.ValidateSessionWithUser(ctx, id)
+func (s *sessionStore) ValidateWithUser(ctx context.Context, id string, now time.Time) (*store.SessionWithUser, error) {
+	row, err := s.conn.q.ValidateSessionWithUser(ctx, gendb.ValidateSessionWithUserParams{
+		ID:  id,
+		Now: pgtime.New(now),
+	})
 	if err != nil {
 		return nil, mapErr(err)
 	}

--- a/backend/internal/hub/store/postgres/sessions.go
+++ b/backend/internal/hub/store/postgres/sessions.go
@@ -66,12 +66,12 @@ func (s *sessionStore) GetByID(ctx context.Context, id string, now time.Time) (*
 	return &out, nil
 }
 
-func (s *sessionStore) Touch(ctx context.Context, p store.TouchSessionParams) (int64, error) {
+func (s *sessionStore) Touch(ctx context.Context, p store.TouchSessionParams, now time.Time) (int64, error) {
 	n, err := s.conn.q.TouchUserSession(ctx, gendb.TouchUserSessionParams{
 		ExpiresAt:    pgtime.New(p.ExpiresAt),
 		ID:           p.ID,
 		LastActiveAt: pgtime.New(p.LastActiveAt),
-		Now:          pgtime.New(p.Now),
+		Now:          pgtime.New(now),
 	})
 	return n, mapErr(err)
 }
@@ -134,7 +134,7 @@ func (s *sessionStore) RefreshAuthGeneration(ctx context.Context, p store.Refres
 	return n, mapErr(err)
 }
 
-func (s *sessionStore) ListByUserID(ctx context.Context, p store.ListUserSessionsParams) (store.Page[store.UserSession], error) {
+func (s *sessionStore) ListByUserID(ctx context.Context, p store.ListUserSessionsParams, now time.Time) (store.Page[store.UserSession], error) {
 	owner, ok := userid.OwnerFilter(p.UserID)
 	if !ok {
 		// An unminted caller owns nothing; binding "" would MATCH every
@@ -143,15 +143,15 @@ func (s *sessionStore) ListByUserID(ctx context.Context, p store.ListUserSession
 	}
 	return queryPage(ctx, p.Limit,
 		func() (gendb.ListUserSessionsByUserIDParams, error) {
-			return listUserSessionsParams(owner, p.Cursor, p.Limit, p.Now)
+			return listUserSessionsParams(owner, p.Cursor, p.Limit, now)
 		},
 		s.conn.q.ListUserSessionsByUserID, fromDBSession)
 }
 
-func (s *sessionStore) ListAllActive(ctx context.Context, p store.ListAllActiveSessionsParams) (store.Page[store.ActiveSession], error) {
+func (s *sessionStore) ListAllActive(ctx context.Context, p store.ListAllActiveSessionsParams, now time.Time) (store.Page[store.ActiveSession], error) {
 	return queryPage(ctx, p.Limit,
 		func() (gendb.ListAllActiveSessionsParams, error) {
-			return listAllActiveSessionsParams(p.Cursor, p.Limit, p.Now)
+			return listAllActiveSessionsParams(p.Cursor, p.Limit, now)
 		},
 		s.conn.q.ListAllActiveSessions, fromDBActiveSessionRow)
 }

--- a/backend/internal/hub/store/postgres/users.go
+++ b/backend/internal/hub/store/postgres/users.go
@@ -353,13 +353,24 @@ func (s *userStore) UpdatePrefs(ctx context.Context, p store.UpdateUserPrefsPara
 	}))
 }
 
-func (s *userStore) SetPendingEmail(ctx context.Context, p store.SetPendingEmailParams) error {
-	return mapErr(s.conn.q.SetPendingEmail(ctx, gendb.SetPendingEmailParams{
+func (s *userStore) SetPendingEmail(ctx context.Context, p store.SetPendingEmailParams) (bool, error) {
+	n, err := rowsAffected(s.conn.q.SetPendingEmail(ctx, gendb.SetPendingEmailParams{
 		PendingEmail:          store.NormalizeEmail(p.PendingEmail),
 		PendingEmailToken:     p.PendingEmailToken,
 		PendingEmailExpiresAt: pgtime.NewNull(p.PendingEmailExpiresAt),
 		ID:                    p.ID,
+		CooldownCutoff:        pgtime.NullOf(p.CooldownCutoff),
 	}))
+	if err != nil {
+		return false, err
+	}
+	return n > 0, nil
+}
+
+// ClearPendingEmailCode drops an undelivered code and keeps the pending
+// address; see the query comment for why the address must survive.
+func (s *userStore) ClearPendingEmailCode(ctx context.Context, id string) error {
+	return mapErr(s.conn.q.ClearPendingEmailCode(ctx, id))
 }
 
 // PromotePendingEmail moves pending_email into email (email_verified=TRUE). A

--- a/backend/internal/hub/store/postgres/users.go
+++ b/backend/internal/hub/store/postgres/users.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/postgres/generated/db"
 	"github.com/leapmux/leapmux/internal/hub/store/sqlutil"
@@ -20,24 +21,27 @@ var _ store.UserStore = (*userStore)(nil)
 
 func fromDBUser(u gendb.User) store.User {
 	return store.User{
-		ID:                    u.ID,
-		Username:              u.Username,
-		PasswordHash:          u.PasswordHash,
-		DisplayName:           u.DisplayName,
-		Email:                 u.Email,
-		EmailVerified:         u.EmailVerified,
-		PendingEmail:          u.PendingEmail,
-		PendingEmailToken:     u.PendingEmailToken,
-		PendingEmailExpiresAt: u.PendingEmailExpiresAt.Ptr(),
-		PendingEmailAttempts:  int64(u.PendingEmailAttempts),
-		PasswordSet:           u.PasswordSet,
-		IsAdmin:               u.IsAdmin,
-		Prefs:                 u.Prefs,
-		CreatedAt:             u.CreatedAt.Time,
-		UpdatedAt:             u.UpdatedAt.Time,
-		TokensRevokedAt:       u.TokensRevokedAt.Ptr(),
-		AuthGeneration:        u.AuthGeneration,
-		DeletedAt:             u.DeletedAt.Ptr(),
+		ID:                            u.ID,
+		Username:                      u.Username,
+		PasswordHash:                  u.PasswordHash,
+		DisplayName:                   u.DisplayName,
+		Email:                         u.Email,
+		EmailVerified:                 u.EmailVerified,
+		PendingEmail:                  u.PendingEmail,
+		PendingEmailToken:             u.PendingEmailToken,
+		PendingEmailExpiresAt:         u.PendingEmailExpiresAt.Ptr(),
+		PendingEmailAttempts:          int64(u.PendingEmailAttempts),
+		PendingPasswordResetToken:     u.PendingPasswordResetToken,
+		PendingPasswordResetExpiresAt: u.PendingPasswordResetExpiresAt.Ptr(),
+		PendingPasswordResetAttempts:  int64(u.PendingPasswordResetAttempts),
+		PasswordSet:                   u.PasswordSet,
+		IsAdmin:                       u.IsAdmin,
+		Prefs:                         u.Prefs,
+		CreatedAt:                     u.CreatedAt.Time,
+		UpdatedAt:                     u.UpdatedAt.Time,
+		TokensRevokedAt:               u.TokensRevokedAt.Ptr(),
+		AuthGeneration:                u.AuthGeneration,
+		DeletedAt:                     u.DeletedAt.Ptr(),
 	}
 }
 
@@ -122,8 +126,12 @@ func (s *userStore) ExistsByEmail(ctx context.Context, email, excludeUserID stri
 	return exists, nil
 }
 
-func (s *userStore) ConsumeVerificationAttempt(ctx context.Context, id string) (*store.User, error) {
-	u, err := s.conn.q.ConsumeVerificationAttempt(ctx, id)
+func (s *userStore) ConsumeVerificationAttempt(ctx context.Context, id string, now time.Time, maxAttempts int64) (*store.User, error) {
+	u, err := s.conn.q.ConsumeVerificationAttempt(ctx, gendb.ConsumeVerificationAttemptParams{
+		ID:          id,
+		Now:         pgtime.NullOf(now),
+		MaxAttempts: int32(maxAttempts),
+	})
 	if err != nil {
 		return nil, mapErr(err)
 	}
@@ -380,6 +388,59 @@ func (s *userStore) ClearCompetingPendingEmails(ctx context.Context, p store.Cle
 
 func (s *userStore) Delete(ctx context.Context, id string) error {
 	return mapErr(s.conn.q.DeleteUser(ctx, id))
+}
+
+func (s *userStore) SetPendingPasswordReset(ctx context.Context, p store.SetPendingPasswordResetParams) (bool, error) {
+	n, err := rowsAffected(s.conn.q.SetPendingPasswordReset(ctx, gendb.SetPendingPasswordResetParams{
+		PendingPasswordResetToken:     p.PendingPasswordResetToken,
+		PendingPasswordResetExpiresAt: pgtime.NullOf(p.PendingPasswordResetExpiresAt),
+		CooldownCutoff:                pgtime.NullOf(p.CooldownCutoff),
+		ID:                            p.ID,
+	}))
+	if err != nil {
+		return false, err
+	}
+	return n > 0, nil
+}
+
+func (s *userStore) ClearPendingPasswordReset(ctx context.Context, id string) error {
+	return mapErr(s.conn.q.ClearPendingPasswordReset(ctx, id))
+}
+
+func (s *userStore) ConsumePasswordResetAttemptByToken(ctx context.Context, tokenHash string, now time.Time, maxAttempts int64) (*store.User, error) {
+	u, err := s.conn.q.ConsumePasswordResetAttemptByToken(ctx, gendb.ConsumePasswordResetAttemptByTokenParams{
+		Token:       tokenHash,
+		Now:         pgtime.NullOf(now),
+		MaxAttempts: int32(maxAttempts),
+	})
+	if err != nil {
+		return nil, mapErr(err)
+	}
+	out := fromDBUser(u)
+	return &out, nil
+}
+
+func (s *userStore) CompletePasswordReset(ctx context.Context, p store.CompletePasswordResetParams) (*store.PasswordResetRevocation, error) {
+	row, err := s.conn.q.CompletePasswordReset(ctx, gendb.CompletePasswordResetParams{
+		PasswordHash:              p.PasswordHash,
+		ID:                        p.ID,
+		PendingPasswordResetToken: p.PendingPasswordResetToken,
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, store.ErrNotFound
+	}
+	if err != nil {
+		return nil, mapErr(err)
+	}
+	revokedAt, err := sqlutil.RequireTime(row.TokensRevokedAt.Time, row.TokensRevokedAt.Valid, "tokens_revoked_at")
+	if err != nil {
+		return nil, err
+	}
+	return &store.PasswordResetRevocation{
+		UserID:          row.ID,
+		TokensRevokedAt: revokedAt,
+		AuthGeneration:  row.AuthGeneration,
+	}, nil
 }
 
 func (s *userStore) RevokeUserTokens(ctx context.Context, userID userid.UserID) (int64, error) {

--- a/backend/internal/hub/store/postgres/webauthn_sessions.go
+++ b/backend/internal/hub/store/postgres/webauthn_sessions.go
@@ -1,0 +1,127 @@
+package postgres
+
+import (
+	"context"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/leapmux/leapmux/internal/hub/store"
+	gendb "github.com/leapmux/leapmux/internal/hub/store/postgres/generated/db"
+	"github.com/leapmux/leapmux/internal/util/sqltime/pgtime"
+	"github.com/leapmux/leapmux/internal/util/userid"
+)
+
+type webAuthnSessionStore struct {
+	conn *pgConn
+}
+
+var _ store.WebAuthnSessionStore = (*webAuthnSessionStore)(nil)
+
+func fromDBWebAuthnSession(s gendb.WebauthnSession) store.WebAuthnSession {
+	out := store.WebAuthnSession{
+		ID:          s.ID,
+		Kind:        s.Kind,
+		PayloadJSON: s.PayloadJson,
+		SessionData: s.SessionData,
+		ExpiresAt:   s.ExpiresAt.Time,
+		CreatedAt:   s.CreatedAt.Time,
+	}
+	if s.UserID.Valid {
+		out.UserID = s.UserID.String
+	}
+	return out
+}
+
+func (s *webAuthnSessionStore) Create(ctx context.Context, p store.CreateWebAuthnSessionParams) error {
+	var userID pgtype.Text
+	if p.UserID != "" {
+		owner, ok := userid.New(p.UserID)
+		if !ok {
+			return store.ErrInvalidArgument
+		}
+		userID = pgtype.Text{String: owner.String(), Valid: true}
+	}
+	return mapErr(s.conn.q.CreateWebAuthnSession(ctx, gendb.CreateWebAuthnSessionParams{
+		ID:          p.ID,
+		Kind:        p.Kind,
+		UserID:      userID,
+		PayloadJson: p.PayloadJSON,
+		SessionData: p.SessionData,
+		ExpiresAt:   pgtime.New(p.ExpiresAt),
+		CreatedAt:   pgtime.New(p.CreatedAt),
+	}))
+}
+
+func (s *webAuthnSessionStore) Get(ctx context.Context, id string) (*store.WebAuthnSession, error) {
+	row, err := s.conn.q.GetWebAuthnSession(ctx, id)
+	if err != nil {
+		return nil, mapErr(err)
+	}
+	out := fromDBWebAuthnSession(row)
+	return &out, nil
+}
+
+func (s *webAuthnSessionStore) Delete(ctx context.Context, id string) error {
+	return mapErr(s.conn.q.DeleteWebAuthnSession(ctx, id))
+}
+
+func (s *webAuthnSessionStore) ConsumeCeremony(ctx context.Context, id, kind string, now time.Time) (int64, error) {
+	return rowsAffected(s.conn.q.ConsumeWebAuthnCeremonySession(ctx, gendb.ConsumeWebAuthnCeremonySessionParams{
+		ID:   id,
+		Kind: kind,
+		Now:  pgtime.New(now),
+	}))
+}
+
+func (s *webAuthnSessionStore) ConsumeProof(ctx context.Context, id, userID, kind string, now time.Time) (int64, error) {
+	owner, ok := userid.New(userID)
+	if !ok {
+		return 0, store.ErrInvalidArgument
+	}
+	return rowsAffected(s.conn.q.ConsumeWebAuthnProof(ctx, gendb.ConsumeWebAuthnProofParams{
+		ID:     id,
+		Kind:   kind,
+		UserID: pgtype.Text{String: owner.String(), Valid: true},
+		Now:    pgtime.New(now),
+	}))
+}
+
+func (s *webAuthnSessionStore) GetValidProof(ctx context.Context, id, userID, kind string, now time.Time) (*store.WebAuthnSession, error) {
+	owner, ok := userid.New(userID)
+	if !ok {
+		return nil, store.ErrInvalidArgument
+	}
+	row, err := s.conn.q.GetValidWebAuthnProof(ctx, gendb.GetValidWebAuthnProofParams{
+		ID:     id,
+		Kind:   kind,
+		UserID: pgtype.Text{String: owner.String(), Valid: true},
+		Now:    pgtime.New(now),
+	})
+	if err != nil {
+		return nil, mapErr(err)
+	}
+	out := fromDBWebAuthnSession(row)
+	return &out, nil
+}
+
+func (s *webAuthnSessionStore) DeleteAllByUser(ctx context.Context, userID string) error {
+	owner, ok := userid.New(userID)
+	if !ok {
+		return store.ErrInvalidArgument
+	}
+	return mapErr(s.conn.q.DeleteWebAuthnSessionsByUser(ctx, pgtype.Text{
+		String: owner.String(),
+		Valid:  true,
+	}))
+}
+
+func (s *webAuthnSessionStore) DeleteByUserAndKind(ctx context.Context, userID, kind string) error {
+	owner, ok := userid.New(userID)
+	if !ok {
+		return store.ErrInvalidArgument
+	}
+	return mapErr(s.conn.q.DeleteWebAuthnSessionsByUserAndKind(ctx, gendb.DeleteWebAuthnSessionsByUserAndKindParams{
+		UserID: pgtype.Text{String: owner.String(), Valid: true},
+		Kind:   kind,
+	}))
+}

--- a/backend/internal/hub/store/sqlc_ascii_test.go
+++ b/backend/internal/hub/store/sqlc_ascii_test.go
@@ -1,0 +1,58 @@
+package store_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Every file sqlc parses must be pure ASCII.
+//
+// The repo's CLAUDE.md states the rule, and the rule exists because the
+// failure is misleading: the sqlc parser falls over on a non-ASCII byte --
+// typically an em-dash or a smart quote inside a comment -- with a
+// `mismatched input 'SELECr'`-style error that points at the wrong line, in
+// a file the author did not edit. Four em-dashes had already reached the
+// migrations, because CLAUDE.md was the only enforcement.
+//
+// BOTH inputs are covered, not just `queries/`: each dialect's sqlc.yaml
+// declares `schema: "db/migrations"`, so the parser reads a migration for
+// every generate.
+func TestSQLCInputsAreASCII(t *testing.T) {
+	t.Parallel()
+
+	roots := []string{
+		filepath.Join("sqlite", "db"),
+		filepath.Join("postgres", "db"),
+		filepath.Join("mysql", "db"),
+	}
+
+	scanned := 0
+	for _, root := range roots {
+		require.DirExistsf(t, root, "%s moved; this guard would pass vacuously", root)
+		require.NoError(t, filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+			if err != nil || d.IsDir() || !strings.HasSuffix(path, ".sql") {
+				return err
+			}
+			scanned++
+			body, readErr := os.ReadFile(path)
+			require.NoError(t, readErr)
+			for i, b := range body {
+				if b > 0x7f {
+					line := 1 + strings.Count(string(body[:i]), "\n")
+					assert.Failf(t, "non-ASCII byte in a sqlc input",
+						"%s:%d has byte 0x%02x. Use plain ASCII: -- instead of an em-dash, "+
+							"and \" instead of a smart quote. sqlc reports this as a parse error "+
+							"on an unrelated line.", path, line, b)
+					return nil
+				}
+			}
+			return nil
+		}))
+	}
+	assert.Greaterf(t, scanned, 30, "only %d files scanned; the walk is not reaching the query trees", scanned)
+}

--- a/backend/internal/hub/store/sqlite/canonical_storage_internal_test.go
+++ b/backend/internal/hub/store/sqlite/canonical_storage_internal_test.go
@@ -144,7 +144,7 @@ func TestAllDatetimeColumnsStoreCanonicalLayout(t *testing.T) {
 		CodeChallenge: "challenge",
 		ExpiresAt:     future,
 	}))
-	_, err = st.CLIAuthorizationCodes().Consume(ctx, "canon-code")
+	_, err = st.CLIAuthorizationCodes().Consume(ctx, "canon-code", time.Now().UTC())
 	require.NoError(t, err)
 
 	// device_authorizations: expires_at on Create, last_polled_at on
@@ -162,7 +162,7 @@ func TestAllDatetimeColumnsStoreCanonicalLayout(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.EqualValues(t, 1, approved)
-	consumed, err := st.DeviceAuthorizations().Consume(ctx, "canon-device-code")
+	consumed, err := st.DeviceAuthorizations().Consume(ctx, "canon-device-code", time.Now().UTC())
 	require.NoError(t, err)
 	require.EqualValues(t, 1, consumed)
 
@@ -286,6 +286,46 @@ func TestAllDatetimeColumnsStoreCanonicalLayout(t *testing.T) {
 		PendingEmail:          "canon-pending@example.com",
 		PendingEmailToken:     "canon-token",
 		PendingEmailExpiresAt: ptr(future),
+	}))
+
+	minted, err := st.Users().SetPendingPasswordReset(ctx, store.SetPendingPasswordResetParams{
+		ID:                            user.ID,
+		PendingPasswordResetToken:     "canon-reset-token",
+		PendingPasswordResetExpiresAt: future,
+		CooldownCutoff:                future,
+	})
+	require.NoError(t, err)
+	require.True(t, minted)
+
+	passkeyID := id.Generate()
+	credID := []byte("canon-cred")
+	require.NoError(t, st.PasskeyCredentials().Create(ctx, store.CreatePasskeyCredentialParams{
+		ID:           passkeyID,
+		UserID:       user.ID,
+		CredentialID: credID,
+		PublicKey:    []byte("canon-pub"),
+		SignCount:    0,
+		Transports:   "[]",
+		FriendlyName: "Canon Passkey",
+		KeyVersion:   1,
+		CreatedAt:    now.UTC(),
+	}))
+	require.NoError(t, st.PasskeyCredentials().UpdateSignCount(ctx, store.UpdatePasskeySignCountParams{
+		CredentialID: credID,
+		UserID:       user.ID,
+		SignCount:    1,
+		LastUsedAt:   now.UTC(),
+	}))
+
+	webauthnSessionID := id.Generate()
+	require.NoError(t, st.WebAuthnSessions().Create(ctx, store.CreateWebAuthnSessionParams{
+		ID:          webauthnSessionID,
+		Kind:        "reauth",
+		UserID:      user.ID,
+		PayloadJSON: "{}",
+		SessionData: []byte("canon-session"),
+		ExpiresAt:   future.UTC(),
+		CreatedAt:   now.UTC(),
 	}))
 
 	// workers.last_seen_at via UpdateLastSeen's strftime.

--- a/backend/internal/hub/store/sqlite/canonical_storage_internal_test.go
+++ b/backend/internal/hub/store/sqlite/canonical_storage_internal_test.go
@@ -159,7 +159,7 @@ func TestAllDatetimeColumnsStoreCanonicalLayout(t *testing.T) {
 	approved, err := st.DeviceAuthorizations().Approve(ctx, store.ApproveDeviceAuthorizationParams{
 		DeviceCode: "canon-device-code",
 		UserID:     userid.MustNew(user.ID),
-	})
+	}, time.Now().UTC())
 	require.NoError(t, err)
 	require.EqualValues(t, 1, approved)
 	consumed, err := st.DeviceAuthorizations().Consume(ctx, "canon-device-code", time.Now().UTC())
@@ -281,14 +281,17 @@ func TestAllDatetimeColumnsStoreCanonicalLayout(t *testing.T) {
 	require.EqualValues(t, 1, consumedSalt)
 
 	// users.pending_email_expires_at is Go-bound by SetPendingEmail.
-	require.NoError(t, st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
+	minted, err := st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
 		ID:                    user.ID,
 		PendingEmail:          "canon-pending@example.com",
 		PendingEmailToken:     "canon-token",
 		PendingEmailExpiresAt: ptr(future),
-	}))
+		CooldownCutoff:        store.UnconditionalMintCutoff(),
+	})
+	require.NoError(t, err)
+	require.True(t, minted)
 
-	minted, err := st.Users().SetPendingPasswordReset(ctx, store.SetPendingPasswordResetParams{
+	minted, err = st.Users().SetPendingPasswordReset(ctx, store.SetPendingPasswordResetParams{
 		ID:                            user.ID,
 		PendingPasswordResetToken:     "canon-reset-token",
 		PendingPasswordResetExpiresAt: future,

--- a/backend/internal/hub/store/sqlite/cleanup.go
+++ b/backend/internal/hub/store/sqlite/cleanup.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/leapmux/leapmux/internal/hub/store"
+	gendb "github.com/leapmux/leapmux/internal/hub/store/sqlite/generated/db"
 	"github.com/leapmux/leapmux/internal/util/sqltime"
 )
 
@@ -31,7 +32,10 @@ func (s *cleanupStore) HardDeleteExpiredRegistrationKeysBefore(ctx context.Conte
 }
 
 func (s *cleanupStore) ClearStalePendingEmails(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.ClearStalePendingEmails(ctx, sqltime.SQLiteNullTimeOf(cutoff)))
+	return rowsAffected(s.conn.q.ClearStalePendingEmails(ctx, gendb.ClearStalePendingEmailsParams{
+		Cutoff:         sqltime.SQLiteNullTimeOf(cutoff),
+		CodelessCutoff: sqltime.NewSQLiteTime(cutoff),
+	}))
 }
 
 func (s *cleanupStore) HardDeleteUsersBefore(ctx context.Context, cutoff time.Time) (int64, error) {
@@ -50,12 +54,12 @@ func (s *cleanupStore) DeleteExpiredWebAuthnSessions(ctx context.Context, now ti
 	return rowsAffected(s.conn.q.DeleteExpiredWebAuthnSessions(ctx, sqltime.NewSQLiteTime(now)))
 }
 
-func (s *cleanupStore) DeleteExpiredDeviceAuthorizations(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteExpiredDeviceAuthorizations(ctx, sqltime.NewSQLiteTime(cutoff)))
+func (s *cleanupStore) DeleteExpiredDeviceAuthorizations(ctx context.Context, now time.Time) (int64, error) {
+	return rowsAffected(s.conn.q.DeleteExpiredDeviceAuthorizations(ctx, sqltime.NewSQLiteTime(now)))
 }
 
-func (s *cleanupStore) DeleteExpiredCLIAuthorizationCodes(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteExpiredCLIAuthorizationCodes(ctx, sqltime.NewSQLiteTime(cutoff)))
+func (s *cleanupStore) DeleteExpiredCLIAuthorizationCodes(ctx context.Context, now time.Time) (int64, error) {
+	return rowsAffected(s.conn.q.DeleteExpiredCLIAuthorizationCodes(ctx, sqltime.NewSQLiteTime(now)))
 }
 
 func (s *cleanupStore) DeleteRevokedAPITokensBefore(ctx context.Context, cutoff time.Time) (int64, error) {
@@ -66,8 +70,8 @@ func (s *cleanupStore) DeleteRevokedDelegationTokensBefore(ctx context.Context, 
 	return rowsAffected(s.conn.q.DeleteRevokedDelegationTokensBefore(ctx, sqltime.SQLiteNullTimeOf(cutoff)))
 }
 
-func (s *cleanupStore) DeleteExpiredDelegationTokensBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteExpiredDelegationTokensBefore(ctx, sqltime.NewSQLiteTime(cutoff)))
+func (s *cleanupStore) DeleteExpiredDelegationTokensBefore(ctx context.Context, now time.Time) (int64, error) {
+	return rowsAffected(s.conn.q.DeleteExpiredDelegationTokensBefore(ctx, sqltime.NewSQLiteTime(now)))
 }
 
 func (s *cleanupStore) DeleteExpiredAltchaSalts(ctx context.Context) (int64, error) {

--- a/backend/internal/hub/store/sqlite/cleanup.go
+++ b/backend/internal/hub/store/sqlite/cleanup.go
@@ -14,8 +14,8 @@ type cleanupStore struct {
 
 var _ store.CleanupStore = (*cleanupStore)(nil)
 
-func (s *cleanupStore) HardDeleteExpiredSessions(ctx context.Context) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteExpiredUserSessions(ctx))
+func (s *cleanupStore) HardDeleteExpiredSessions(ctx context.Context, now time.Time) (int64, error) {
+	return rowsAffected(s.conn.q.DeleteExpiredUserSessions(ctx, sqltime.NewSQLiteTime(now)))
 }
 
 func (s *cleanupStore) HardDeleteWorkspacesBefore(ctx context.Context, cutoff time.Time) (int64, error) {
@@ -38,12 +38,16 @@ func (s *cleanupStore) HardDeleteUsersBefore(ctx context.Context, cutoff time.Ti
 	return rowsAffected(s.conn.q.HardDeleteUsersBefore(ctx, sqltime.SQLiteNullTimeOf(cutoff)))
 }
 
-func (s *cleanupStore) DeleteExpiredOAuthStates(ctx context.Context) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteExpiredOAuthStates(ctx))
+func (s *cleanupStore) DeleteExpiredOAuthStates(ctx context.Context, now time.Time) (int64, error) {
+	return rowsAffected(s.conn.q.DeleteExpiredOAuthStates(ctx, sqltime.NewSQLiteTime(now)))
 }
 
-func (s *cleanupStore) DeleteExpiredPendingOAuthSignups(ctx context.Context) (int64, error) {
-	return rowsAffected(s.conn.q.DeleteExpiredPendingOAuthSignups(ctx))
+func (s *cleanupStore) DeleteExpiredPendingOAuthSignups(ctx context.Context, now time.Time) (int64, error) {
+	return rowsAffected(s.conn.q.DeleteExpiredPendingOAuthSignups(ctx, sqltime.NewSQLiteTime(now)))
+}
+
+func (s *cleanupStore) DeleteExpiredWebAuthnSessions(ctx context.Context, now time.Time) (int64, error) {
+	return rowsAffected(s.conn.q.DeleteExpiredWebAuthnSessions(ctx, sqltime.NewSQLiteTime(now)))
 }
 
 func (s *cleanupStore) DeleteExpiredDeviceAuthorizations(ctx context.Context, cutoff time.Time) (int64, error) {

--- a/backend/internal/hub/store/sqlite/cli_authorization_codes.go
+++ b/backend/internal/hub/store/sqlite/cli_authorization_codes.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"context"
+	"time"
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/sqlite/generated/db"
@@ -34,8 +35,11 @@ func (s *cliAuthorizationCodeStore) Create(ctx context.Context, p store.CreateCL
 	}))
 }
 
-func (s *cliAuthorizationCodeStore) GetActive(ctx context.Context, code string) (*store.CLIAuthorizationCode, error) {
-	row, err := s.conn.q.GetActiveCLIAuthorizationCode(ctx, code)
+func (s *cliAuthorizationCodeStore) GetActive(ctx context.Context, code string, now time.Time) (*store.CLIAuthorizationCode, error) {
+	row, err := s.conn.q.GetActiveCLIAuthorizationCode(ctx, gendb.GetActiveCLIAuthorizationCodeParams{
+		Code: code,
+		Now:  sqltime.NewSQLiteTime(now),
+	})
 	if err != nil {
 		return nil, mapErr(err)
 	}
@@ -43,8 +47,11 @@ func (s *cliAuthorizationCodeStore) GetActive(ctx context.Context, code string) 
 	return &out, nil
 }
 
-func (s *cliAuthorizationCodeStore) Consume(ctx context.Context, code string) (*store.CLIAuthorizationCode, error) {
-	row, err := s.conn.q.ConsumeCLIAuthorizationCode(ctx, code)
+func (s *cliAuthorizationCodeStore) Consume(ctx context.Context, code string, now time.Time) (*store.CLIAuthorizationCode, error) {
+	row, err := s.conn.q.ConsumeCLIAuthorizationCode(ctx, gendb.ConsumeCLIAuthorizationCodeParams{
+		Code: code,
+		Now:  sqltime.NewSQLiteTime(now),
+	})
 	if err != nil {
 		return nil, mapErr(err)
 	}

--- a/backend/internal/hub/store/sqlite/convert.go
+++ b/backend/internal/hub/store/sqlite/convert.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"time"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/hub/store"
@@ -155,15 +156,17 @@ func listWorkersAdminByUserAndStatusParams(status leapmuxv1.WorkerStatus, userID
 	})
 }
 
-func listAllActiveSessionsParams(cursor string, limit int64) (gendb.ListAllActiveSessionsParams, error) {
+func listAllActiveSessionsParams(cursor string, limit int64, now time.Time) (gendb.ListAllActiveSessionsParams, error) {
+	nt := sqltime.NewSQLiteTime(now)
 	return withCursor(cursor, limit, func(ct sqltime.SQLiteNullTime, cid sql.NullString, fl int64) gendb.ListAllActiveSessionsParams {
-		return gendb.ListAllActiveSessionsParams{CursorTime: ct, CursorID: cid, Limit: fl}
+		return gendb.ListAllActiveSessionsParams{Now: nt, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 
-func listUserSessionsParams(userID, cursor string, limit int64) (gendb.ListUserSessionsByUserIDParams, error) {
+func listUserSessionsParams(userID, cursor string, limit int64, now time.Time) (gendb.ListUserSessionsByUserIDParams, error) {
+	nt := sqltime.NewSQLiteTime(now)
 	return withCursor(cursor, limit, func(ct sqltime.SQLiteNullTime, cid sql.NullString, fl int64) gendb.ListUserSessionsByUserIDParams {
-		return gendb.ListUserSessionsByUserIDParams{UserID: userID, CursorTime: ct, CursorID: cid, Limit: fl}
+		return gendb.ListUserSessionsByUserIDParams{UserID: userID, Now: nt, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }
 

--- a/backend/internal/hub/store/sqlite/db/migrations/00001_initial.sql
+++ b/backend/internal/hub/store/sqlite/db/migrations/00001_initial.sql
@@ -617,7 +617,7 @@ CREATE INDEX idx_webauthn_sessions_user_kind ON webauthn_sessions(user_id, kind)
 -- (internal/hub/settings); secret-bearing keys keep the secret half in the
 -- keystore-encrypted column (AAD bound to the key name). An absent row means
 -- the code default, so adding, removing, or reshaping a setting is a Go
--- change only — never a migration. This table is the single home for all
+-- change only -- never a migration. This table is the single home for all
 -- runtime-changeable configuration (auth policy, SMTP, timeouts, limits,
 -- captcha providers, rate-limit overrides).
 CREATE TABLE hub_settings (

--- a/backend/internal/hub/store/sqlite/db/migrations/00001_initial.sql
+++ b/backend/internal/hub/store/sqlite/db/migrations/00001_initial.sql
@@ -35,6 +35,10 @@ CREATE TABLE users (
     -- Counts attempts against the active pending_email_token. Reset to 0
     -- whenever a new token is issued; force-expires the token at >5.
     pending_email_attempts   INTEGER NOT NULL DEFAULT 0,
+    -- Password-reset break-glass: token stored hashed (SHA-256 hex).
+    pending_password_reset_token      VARCHAR(64) NOT NULL DEFAULT '',
+    pending_password_reset_expires_at DATETIME,
+    pending_password_reset_attempts   INTEGER NOT NULL DEFAULT 0,
     password_set             INTEGER NOT NULL DEFAULT 1,
     is_admin                 INTEGER NOT NULL DEFAULT 0,
     prefs          TEXT NOT NULL DEFAULT '{}',
@@ -60,8 +64,11 @@ CREATE INDEX idx_users_created_at ON users(created_at DESC, id DESC) WHERE delet
 -- Verification codes are looked up per-user (the session identifies who),
 -- so no global token index is needed. Index expiry instead, for cleanup.
 CREATE INDEX idx_users_pending_email_expires_at ON users(pending_email_expires_at) WHERE pending_email_expires_at IS NOT NULL;
+-- Password-reset tokens are looked up by hash on complete; index non-empty
+-- values so Completes do not scan the users table.
+CREATE INDEX IF NOT EXISTS idx_users_pending_password_reset_token ON users(pending_password_reset_token) WHERE pending_password_reset_token != '';
 -- GetFirstAdmin scans for the earliest non-deleted admin (bootstrap path).
--- Partial on (is_admin, deleted_at) keeps the index tiny; indexing on
+-- Partial on (is_admin, deleted_at) keeps the index tiny;
 -- created_at lets the ORDER BY + LIMIT 1 hit the first leaf directly.
 -- The predicate MUST be spelled `is_admin = 1` -- SQLite's partial-index
 -- matcher is syntactic, so a bare `is_admin` predicate never matches
@@ -567,6 +574,44 @@ CREATE TABLE pending_oauth_signups (
     created_at       DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
 );
 
+-- Passkey (WebAuthn) credentials for email-local accounts
+CREATE TABLE passkey_credentials (
+    id              TEXT PRIMARY KEY,
+    user_id         TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    credential_id   BLOB NOT NULL,   -- plaintext: login lookup + unique index
+    public_key      BLOB NOT NULL,   -- keystore-encrypted COSE public key, AAD: 'passkey_public_key:' || id
+    sign_count      BIGINT NOT NULL DEFAULT 0,
+    aaguid          BLOB,
+    backup_eligible INTEGER NOT NULL DEFAULT 0,
+    backup_state    INTEGER NOT NULL DEFAULT 0,
+    transports      TEXT NOT NULL DEFAULT '[]',
+    friendly_name   TEXT NOT NULL DEFAULT '',
+    key_version     INTEGER NOT NULL DEFAULT 1,
+    created_at      DATETIME NOT NULL,
+    last_used_at    DATETIME
+);
+CREATE UNIQUE INDEX idx_passkey_credentials_credential_id ON passkey_credentials(credential_id);
+CREATE INDEX idx_passkey_credentials_user_id ON passkey_credentials(user_id);
+CREATE INDEX idx_passkey_credentials_key_version ON passkey_credentials(key_version);
+
+-- Ephemeral WebAuthn ceremony state (signup, login, register, reauth)
+CREATE TABLE webauthn_sessions (
+    id           TEXT PRIMARY KEY,
+    kind         TEXT NOT NULL CHECK (kind IN (
+        'signup', 'login', 'register', 'reauth', 'reauth_proof'
+    )),
+    user_id      TEXT REFERENCES users(id) ON DELETE CASCADE,
+    payload_json TEXT NOT NULL DEFAULT '{}', -- '{}' or encrypted signup draft (base64), AAD: 'webauthn_payload:' || id
+    session_data BLOB NOT NULL,   -- keystore-encrypted, AAD: 'webauthn_session:' || id
+    expires_at   DATETIME NOT NULL,
+    created_at   DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+CREATE INDEX idx_webauthn_sessions_expires_at ON webauthn_sessions(expires_at);
+
+-- Ceremony begins delete prior rows per user and kind on every Begin*;
+-- without this index each begin full-scans the not-yet-swept rows.
+CREATE INDEX idx_webauthn_sessions_user_kind ON webauthn_sessions(user_id, kind);
+
 -- Instance-level hub settings: one row per setting key. `value` is a JSON
 -- document whose shape is defined by the owning package's typed key handle
 -- (internal/hub/settings); secret-bearing keys keep the secret half in the
@@ -604,6 +649,8 @@ DROP TABLE IF EXISTS revocation_events;
 DROP TABLE IF EXISTS revocation_event_sequence;
 DROP TABLE IF EXISTS pending_oauth_signups;
 DROP TABLE IF EXISTS altcha_used_salts;
+DROP TABLE IF EXISTS webauthn_sessions;
+DROP TABLE IF EXISTS passkey_credentials;
 DROP TABLE IF EXISTS hub_settings;
 DROP TABLE IF EXISTS oauth_states;
 DROP TABLE IF EXISTS oauth_tokens;

--- a/backend/internal/hub/store/sqlite/db/queries/cli_authorization_codes.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/cli_authorization_codes.sql
@@ -28,7 +28,7 @@ WHERE code = ? AND consumed_at IS NULL AND expires_at > sqlc.arg(now)
 RETURNING *;
 
 -- name: DeleteExpiredCLIAuthorizationCodes :execresult
--- Raw compare against a SQLiteTime cutoff (same canonical layout); see
+-- Raw compare against a SQLiteTime instant (same canonical layout); see
 -- DeleteExpiredDelegationTokensBefore for the pattern.
 DELETE FROM cli_authorization_codes
-WHERE expires_at < sqlc.arg(cutoff);
+WHERE expires_at < sqlc.arg(now);

--- a/backend/internal/hub/store/sqlite/db/queries/cli_authorization_codes.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/cli_authorization_codes.sql
@@ -1,3 +1,8 @@
+-- Clock rule: expires_at columns are written by the hub process, so every
+-- comparison of them binds the hub's clock (sqlc.arg(now)), never the
+-- database clock. Timestamps that record when something happened keep the
+-- database clock.
+
 -- name: CreateCLIAuthorizationCode :exec
 INSERT INTO cli_authorization_codes (
     code, user_id, code_challenge, device_name, expires_at
@@ -14,12 +19,12 @@ INSERT INTO cli_authorization_codes (
 -- binds a SQLiteTime), so the liveness guard is millisecond-exact against the
 -- same canonical RHS layout.
 SELECT * FROM cli_authorization_codes
-WHERE code = ? AND consumed_at IS NULL AND expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now');
+WHERE code = ? AND consumed_at IS NULL AND expires_at > sqlc.arg(now);
 
 -- name: ConsumeCLIAuthorizationCode :one
 UPDATE cli_authorization_codes
 SET consumed_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
-WHERE code = ? AND consumed_at IS NULL AND expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE code = ? AND consumed_at IS NULL AND expires_at > sqlc.arg(now)
 RETURNING *;
 
 -- name: DeleteExpiredCLIAuthorizationCodes :execresult

--- a/backend/internal/hub/store/sqlite/db/queries/delegation_tokens.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/delegation_tokens.sql
@@ -128,4 +128,4 @@ WHERE revoked_at IS NOT NULL AND revoked_at < sqlc.arg(cutoff);
 -- idx_delegation_tokens_expires_at -- the hourly sweep of this high-churn table
 -- seeks just the expired live rows.
 DELETE FROM delegation_tokens
-WHERE expires_at < sqlc.arg(cutoff) AND revoked_at IS NULL;
+WHERE expires_at < sqlc.arg(now) AND revoked_at IS NULL;

--- a/backend/internal/hub/store/sqlite/db/queries/delegation_tokens.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/delegation_tokens.sql
@@ -1,3 +1,8 @@
+-- Clock rule: expires_at columns are written by the hub process, so every
+-- comparison of them binds the hub's clock (sqlc.arg(now)), never the
+-- database clock. Timestamps that record when something happened keep the
+-- database clock.
+
 -- name: CreateDelegationToken :exec
 INSERT INTO delegation_tokens (
     id, user_id, worker_id, agent_id, terminal_id,
@@ -86,7 +91,7 @@ LIMIT sqlc.arg(limit);
 SELECT * FROM delegation_tokens
 WHERE user_id = ?
   AND revoked_at IS NULL
-  AND expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+  AND expires_at > sqlc.arg(now)
 ORDER BY created_at DESC;
 
 -- name: RevokeDelegationTokensByUserFast :execresult

--- a/backend/internal/hub/store/sqlite/db/queries/device_authorizations.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/device_authorizations.sql
@@ -50,7 +50,7 @@ SET last_polled_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
 WHERE device_code = ?;
 
 -- name: DeleteExpiredDeviceAuthorizations :execresult
--- Raw compare against a SQLiteTime cutoff (same canonical layout); see
+-- Raw compare against a SQLiteTime instant (same canonical layout); see
 -- DeleteExpiredDelegationTokensBefore for the pattern.
 DELETE FROM device_authorizations
-WHERE expires_at < sqlc.arg(cutoff);
+WHERE expires_at < sqlc.arg(now);

--- a/backend/internal/hub/store/sqlite/db/queries/device_authorizations.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/device_authorizations.sql
@@ -1,3 +1,8 @@
+-- Clock rule: expires_at columns are written by the hub process, so every
+-- comparison of them binds the hub's clock (sqlc.arg(now)), never the
+-- database clock. Timestamps that record when something happened keep the
+-- database clock.
+
 -- name: CreateDeviceAuthorization :exec
 INSERT INTO device_authorizations (
     device_code, user_code, device_name, interval_seconds, expires_at
@@ -21,12 +26,12 @@ SELECT * FROM device_authorizations WHERE user_code = ?;
 -- same canonical RHS layout.
 UPDATE device_authorizations
 SET approved = 1, user_id = ?
-WHERE device_code = ? AND consumed_at IS NULL AND expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now');
+WHERE device_code = ? AND consumed_at IS NULL AND expires_at > sqlc.arg(now);
 
 -- name: ApproveDeviceAuthorizationByUserCode :execresult
 UPDATE device_authorizations
 SET approved = 1, user_id = ?
-WHERE user_code = ? AND consumed_at IS NULL AND expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now');
+WHERE user_code = ? AND consumed_at IS NULL AND expires_at > sqlc.arg(now);
 
 -- name: DenyDeviceAuthorization :execresult
 UPDATE device_authorizations
@@ -37,7 +42,7 @@ WHERE device_code = ? AND consumed_at IS NULL;
 UPDATE device_authorizations
 SET consumed_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
 WHERE device_code = ? AND approved = 1 AND consumed_at IS NULL
-  AND expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now');
+  AND expires_at > sqlc.arg(now);
 
 -- name: TouchDeviceAuthorizationPoll :exec
 UPDATE device_authorizations

--- a/backend/internal/hub/store/sqlite/db/queries/oauth_states.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/oauth_states.sql
@@ -1,3 +1,8 @@
+-- Clock rule: expires_at columns are written by the hub process, so every
+-- comparison of them binds the hub's clock (sqlc.arg(now)), never the
+-- database clock. Timestamps that record when something happened keep the
+-- database clock.
+
 -- name: CreateOAuthState :exec
 INSERT INTO oauth_states (state, provider_id, pkce_verifier, redirect_uri, expires_at)
 VALUES (
@@ -18,4 +23,4 @@ DELETE FROM oauth_states WHERE state = ?;
 -- Raw compare: expires_at is stored canonical (CreateOAuthState binds a
 -- SQLiteTime), so the sweep is millisecond-exact against the same canonical RHS
 -- layout.
-DELETE FROM oauth_states WHERE expires_at < strftime('%Y-%m-%dT%H:%M:%fZ', 'now');
+DELETE FROM oauth_states WHERE expires_at < sqlc.arg(now);

--- a/backend/internal/hub/store/sqlite/db/queries/oauth_tokens.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/oauth_tokens.sql
@@ -1,3 +1,7 @@
+-- Clock rule: token expiry is stored by the hub process, so the
+-- refresh-due comparison binds the hub's clock (sqlc.arg(refresh_due_at)),
+-- never the database clock.
+
 -- name: UpsertOAuthTokens :exec
 -- expires_at is stored in the canonical layout (SQLiteTime binds it) so
 -- ListExpiringOAuthTokens can compare it raw -- sargable for
@@ -32,7 +36,7 @@ WHERE user_id = ? AND provider_id = ?;
 -- byte-exact and sargable -- idx_oauth_tokens_expires_at serves an
 -- upper-bounded SEARCH instead of a full scan under a datetime() wrap.
 SELECT * FROM oauth_tokens
-WHERE expires_at <= strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '+5 minutes');
+WHERE expires_at <= sqlc.arg(refresh_due_at);
 
 -- name: DeleteOAuthTokensByProvider :exec
 DELETE FROM oauth_tokens WHERE provider_id = ?;

--- a/backend/internal/hub/store/sqlite/db/queries/passkey_credentials.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/passkey_credentials.sql
@@ -1,0 +1,59 @@
+-- name: CreatePasskeyCredential :exec
+INSERT INTO passkey_credentials (
+    id, user_id, credential_id, public_key, sign_count, aaguid,
+    backup_eligible, backup_state, transports, friendly_name, key_version, created_at, last_used_at
+) VALUES (
+    sqlc.arg(id),
+    sqlc.arg(user_id),
+    sqlc.arg(credential_id),
+    sqlc.arg(public_key),
+    sqlc.arg(sign_count),
+    sqlc.narg(aaguid),
+    sqlc.arg(backup_eligible),
+    sqlc.arg(backup_state),
+    sqlc.arg(transports),
+    sqlc.arg(friendly_name),
+    sqlc.arg(key_version),
+    sqlc.arg(created_at),
+    sqlc.narg(last_used_at)
+);
+
+-- name: GetPasskeyCredentialByID :one
+SELECT * FROM passkey_credentials WHERE id = ?;
+
+-- name: GetPasskeyCredentialByCredentialID :one
+SELECT * FROM passkey_credentials WHERE credential_id = ?;
+
+-- name: ListPasskeyCredentialsByUser :many
+SELECT * FROM passkey_credentials WHERE user_id = ? ORDER BY created_at;
+
+-- name: CountPasskeyCredentialsByUser :one
+SELECT COUNT(*) FROM passkey_credentials WHERE user_id = ?;
+
+-- name: UpdatePasskeySignCount :execresult
+UPDATE passkey_credentials
+SET sign_count = sqlc.arg(sign_count), last_used_at = sqlc.arg(last_used_at)
+WHERE credential_id = sqlc.arg(credential_id) AND user_id = sqlc.arg(user_id)
+  AND (sign_count < sqlc.arg(sign_count) OR sqlc.arg(sign_count) = 0);
+
+-- name: UpdatePasskeyFriendlyName :exec
+UPDATE passkey_credentials
+SET friendly_name = sqlc.arg(friendly_name)
+WHERE id = sqlc.arg(id) AND user_id = sqlc.arg(user_id);
+
+-- name: UpdatePasskeyPublicKey :exec
+UPDATE passkey_credentials
+SET public_key = sqlc.arg(public_key), key_version = sqlc.arg(key_version)
+WHERE id = sqlc.arg(id) AND user_id = sqlc.arg(user_id);
+
+-- name: DeletePasskeyCredential :exec
+DELETE FROM passkey_credentials WHERE id = ? AND user_id = ?;
+
+-- name: DeleteAllPasskeyCredentialsByUser :exec
+DELETE FROM passkey_credentials WHERE user_id = ?;
+
+-- name: ListPasskeyCredentialsByKeyVersion :many
+SELECT * FROM passkey_credentials WHERE key_version = ?;
+
+-- name: CountPasskeyCredentialsByKeyVersion :one
+SELECT COUNT(*) FROM passkey_credentials WHERE key_version = ?;

--- a/backend/internal/hub/store/sqlite/db/queries/pending_oauth_signups.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/pending_oauth_signups.sql
@@ -1,3 +1,8 @@
+-- Clock rule: expires_at columns are written by the hub process, so every
+-- comparison of them binds the hub's clock (sqlc.arg(now)), never the
+-- database clock. Timestamps that record when something happened keep the
+-- database clock.
+
 -- name: CreatePendingOAuthSignup :exec
 INSERT INTO pending_oauth_signups (token, provider_id, provider_subject, email, display_name, access_token, refresh_token, token_type, token_expires_at, key_version, redirect_uri, expires_at)
 VALUES (
@@ -25,4 +30,4 @@ DELETE FROM pending_oauth_signups WHERE token = ?;
 -- Raw compare: expires_at is stored canonical (CreatePendingOAuthSignup binds
 -- a SQLiteTime), so the sweep is millisecond-exact against the same canonical
 -- RHS layout.
-DELETE FROM pending_oauth_signups WHERE expires_at < strftime('%Y-%m-%dT%H:%M:%fZ', 'now');
+DELETE FROM pending_oauth_signups WHERE expires_at < sqlc.arg(now);

--- a/backend/internal/hub/store/sqlite/db/queries/user_sessions.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/user_sessions.sql
@@ -1,3 +1,8 @@
+-- Clock rule: expires_at columns are written by the hub process, so every
+-- comparison of them binds the hub's clock (sqlc.arg(now)), never the
+-- database clock. Timestamps that record when something happened
+-- (created_at, updated_at, last_active_at) keep the database clock.
+
 -- name: CreateUserSession :exec
 INSERT INTO user_sessions (
     id, user_id, expires_at, user_agent, ip_address, auth_generation
@@ -13,8 +18,9 @@ INSERT INTO user_sessions (
 -- name: GetUserSessionByID :one
 -- expires_at is stored in the canonical strftime('%Y-%m-%dT%H:%M:%fZ') layout
 -- (CreateUserSession binds a SQLiteTime), so the liveness filter compares it raw
--- against the same layout -- millisecond-exact at the expiry boundary.
-SELECT * FROM user_sessions WHERE id = ? AND expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now');
+-- against a bound SQLiteTime (the same layout) -- millisecond-exact at the
+-- expiry boundary, and judged on the hub clock that wrote the expiry.
+SELECT * FROM user_sessions WHERE id = ? AND expires_at > sqlc.arg(now);
 
 -- name: DeleteUserSession :one
 DELETE FROM user_sessions WHERE id = ? RETURNING id, user_id;
@@ -24,7 +30,7 @@ SELECT u.id, u.username, u.is_admin, u.email_verified, u.email, s.created_at, s.
 FROM user_sessions s
 JOIN users u ON s.user_id = u.id
 WHERE s.id = ?
-  AND s.expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+  AND s.expires_at > sqlc.arg(now)
   AND u.deleted_at IS NULL
   AND s.auth_generation >= u.auth_generation;
 
@@ -46,8 +52,8 @@ WHERE user_sessions.id = sqlc.arg(session_id)
 -- SQLiteTime), so comparing it raw against the same canonical RHS is
 -- sargable for idx_user_sessions_expires_at_last_active (SEARCH expires_at<?,
 -- not a SCAN-with-residual under julianday()) -- the index was orphaned under
--- the julianday wrap. RHS is strftime('now'), evaluated once, no binding.
-DELETE FROM user_sessions WHERE expires_at < strftime('%Y-%m-%dT%H:%M:%fZ', 'now');
+-- the julianday wrap. RHS is a bound SQLiteTime in the same canonical layout.
+DELETE FROM user_sessions WHERE expires_at < sqlc.arg(now);
 
 -- name: DeleteUserSessionsByUser :exec
 DELETE FROM user_sessions WHERE user_id = ?;
@@ -57,7 +63,7 @@ DELETE FROM user_sessions WHERE user_id = ? AND id != ?;
 
 -- name: ListUserSessionsByUserID :many
 SELECT * FROM user_sessions
-WHERE user_id = sqlc.arg(user_id) AND expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE user_id = sqlc.arg(user_id) AND expires_at > sqlc.arg(now)
   AND (sqlc.narg(cursor_time) IS NULL
        OR last_active_at < sqlc.narg(cursor_time)
        OR (last_active_at = sqlc.narg(cursor_time) AND id < sqlc.narg(cursor_id)))
@@ -81,7 +87,7 @@ LIMIT sqlc.arg(limit);
 SELECT s.id, s.user_id, COALESCE(u.username, '') AS username, CAST(u.id IS NULL AS BOOLEAN) AS user_deleted, s.created_at, s.last_active_at, s.expires_at, s.ip_address, s.user_agent
 FROM user_sessions s
 LEFT JOIN users u ON s.user_id = u.id AND u.deleted_at IS NULL
-WHERE s.expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE s.expires_at > sqlc.arg(now)
   AND (sqlc.narg(cursor_time) IS NULL
        OR s.last_active_at < sqlc.narg(cursor_time)
        OR (s.last_active_at = sqlc.narg(cursor_time) AND s.id < sqlc.narg(cursor_id)))

--- a/backend/internal/hub/store/sqlite/db/queries/users.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/users.sql
@@ -160,7 +160,15 @@ SELECT count(*) FROM users WHERE deleted_at IS NULL;
 -- name: HasAnyUser :one
 SELECT EXISTS(SELECT 1 FROM users WHERE deleted_at IS NULL LIMIT 1);
 
--- name: SetPendingEmail :exec
+-- name: SetPendingEmail :execresult
+-- Conditional mint: the write lands only when no previous code exists or
+-- the previous code's expiry is at or before cooldown_cutoff, so two
+-- concurrent resends for one account cannot both mint and both send (the
+-- loser matches no row), and RequestEmailChange cannot mint on every
+-- request. Its twin SetPendingPasswordReset carries the same predicate.
+-- The Go caller derives cooldown_cutoff from the resend cooldown; the
+-- comparison stays on the app clock, the clock that wrote the expiry.
+--
 -- pending_email_expires_at MUST land in the canonical strftime layout, so the
 -- bound instant is a SQLiteNullTime rather than the modernc driver layout a raw
 -- time.Time bind would produce: ConsumeVerificationAttempt's lockout branch
@@ -169,7 +177,20 @@ SELECT EXISTS(SELECT 1 FROM users WHERE deleted_at IS NULL LIMIT 1);
 -- lexicographic compare at the ' ' vs 'T' separator byte (byte 10). An invalid
 -- SQLiteNullTime binds NULL.
 UPDATE users SET pending_email = sqlc.arg(pending_email), pending_email_token = sqlc.arg(pending_email_token), pending_email_expires_at = sqlc.narg(pending_email_expires_at), pending_email_attempts = 0, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
-WHERE id = sqlc.arg(id);
+WHERE id = sqlc.arg(id)
+  AND (pending_email_expires_at IS NULL
+       OR pending_email_expires_at <= sqlc.arg(cooldown_cutoff));
+
+-- name: ClearPendingEmailCode :exec
+-- ClearPendingEmailCode drops an undelivered code and KEEPS the pending
+-- address. An empty token is the "no live code, address still pending"
+-- state: ConsumeVerificationAttempt and ClearStalePendingEmails both
+-- filter pending_email_token != '', so neither acts on it, and the
+-- cooldown -- which reads the expiry -- does not apply, so the retry a
+-- failed send invites is never blocked. Unconditional on purpose: it
+-- undoes a mint that the relay refused.
+UPDATE users SET pending_email_token = '', pending_email_expires_at = NULL, pending_email_attempts = 0, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE id = ?;
 
 -- name: ClearPendingEmail :exec
 UPDATE users SET pending_email = '', pending_email_token = '', pending_email_expires_at = NULL, pending_email_attempts = 0, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
@@ -195,12 +216,19 @@ UPDATE users SET pending_email = '', pending_email_token = '', pending_email_exp
 WHERE pending_email = ? AND id != ?;
 
 -- name: ClearStalePendingEmails :execresult
+-- The second arm reaps a codeless row: a send the relay refused leaves the
+-- ADDRESS with no token and no expiry (ClearPendingEmailCode), so the
+-- expiry compare can never see it and an abandoned address would otherwise
+-- outlive the database. updated_at is the only instant such a row carries,
+-- and ClearPendingEmailCode stamps it.
 -- Raw compare: pending_email_expires_at is stored canonical on every write path
 -- (SetPendingEmail binds a SQLiteNullTime; ConsumeVerificationAttempt's lockout
 -- branch writes strftime('now')), so comparing it raw against the SQLiteTime
 -- cutoff (same canonical layout) is byte-exact; see HardDeleteUsersBefore.
 UPDATE users SET pending_email = '', pending_email_token = '', pending_email_expires_at = NULL, pending_email_attempts = 0, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
-WHERE pending_email_token != '' AND pending_email_expires_at IS NOT NULL AND pending_email_expires_at < sqlc.arg(cutoff);
+WHERE pending_email != ''
+  AND ((pending_email_token != '' AND pending_email_expires_at IS NOT NULL AND pending_email_expires_at < sqlc.arg(cutoff))
+    OR (pending_email_token = '' AND updated_at < sqlc.arg(codeless_cutoff)));
 
 -- name: BumpUserTokensRevokedAt :one
 -- Bumps the user-wide revocation timestamp and credential epoch, then

--- a/backend/internal/hub/store/sqlite/db/queries/users.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/users.sql
@@ -184,10 +184,10 @@ RETURNING id, updated_at;
 UPDATE users
 SET pending_email_attempts = pending_email_attempts + 1,
     pending_email_expires_at = CASE
-        WHEN pending_email_attempts + 1 > 5 THEN strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+        WHEN pending_email_attempts + 1 > sqlc.arg(max_attempts) THEN sqlc.arg(now)
         ELSE pending_email_expires_at END,
     updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
-WHERE id = ? AND pending_email_token != ''
+WHERE id = sqlc.arg(id) AND pending_email_token != ''
 RETURNING *;
 
 -- name: ClearCompetingPendingEmails :exec
@@ -220,4 +220,58 @@ SET tokens_revoked_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
     auth_generation   = auth_generation + 1,
     updated_at        = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
 WHERE id = ?
+RETURNING id, tokens_revoked_at, auth_generation;
+
+-- name: SetPendingPasswordReset :execresult
+-- Conditional mint: the write lands only when no previous token exists or
+-- the previous token's expiry is at or before cooldown_cutoff, so two
+-- concurrent requests for one account cannot both mint and both send (the
+-- loser matches no row). The Go caller derives cooldown_cutoff from the
+-- resend cooldown; the comparison stays on the app clock, the same clock
+-- that wrote the expiry.
+UPDATE users
+SET pending_password_reset_token = sqlc.arg(pending_password_reset_token),
+    pending_password_reset_expires_at = sqlc.arg(pending_password_reset_expires_at),
+    pending_password_reset_attempts = 0,
+    updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE id = sqlc.arg(id)
+  AND (pending_password_reset_expires_at IS NULL
+       OR pending_password_reset_expires_at <= sqlc.arg(cooldown_cutoff));
+
+
+-- name: ClearPendingPasswordReset :exec
+UPDATE users
+SET pending_password_reset_token = '',
+    pending_password_reset_expires_at = NULL,
+    pending_password_reset_attempts = 0,
+    updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE id = ?;
+
+-- name: ConsumePasswordResetAttemptByToken :one
+-- Charges one attempt against the row that holds this exact token. Keying
+-- the charge by the token (not the user id) makes the find, the charge, and
+-- the ownership re-check one statement: a token cleared between a caller's
+-- read and this update simply matches no row.
+UPDATE users
+SET pending_password_reset_expires_at = CASE
+        WHEN pending_password_reset_attempts + 1 > sqlc.arg(max_attempts) THEN sqlc.arg(now)
+        ELSE pending_password_reset_expires_at END,
+    pending_password_reset_attempts = pending_password_reset_attempts + 1,
+    updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE pending_password_reset_token = sqlc.arg(token) AND pending_password_reset_token != ''
+  AND pending_password_reset_expires_at > sqlc.arg(now)
+  AND deleted_at IS NULL
+RETURNING *;
+
+-- name: CompletePasswordReset :one
+UPDATE users
+SET password_hash = sqlc.arg(password_hash),
+    password_set = 1,
+    pending_password_reset_token = '',
+    pending_password_reset_expires_at = NULL,
+    pending_password_reset_attempts = 0,
+    tokens_revoked_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+    auth_generation = auth_generation + 1,
+    updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE id = sqlc.arg(id) AND pending_password_reset_token = sqlc.arg(pending_password_reset_token)
 RETURNING id, tokens_revoked_at, auth_generation;

--- a/backend/internal/hub/store/sqlite/db/queries/webauthn_sessions.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/webauthn_sessions.sql
@@ -1,0 +1,47 @@
+-- Clock rule: expires_at columns are written by the hub process, so every
+-- comparison of them binds the hub's clock (sqlc.arg(now)), never the
+-- database clock. Timestamps that record when something happened
+-- (created_at, updated_at) keep the database clock.
+
+-- name: CreateWebAuthnSession :exec
+INSERT INTO webauthn_sessions (id, kind, user_id, payload_json, session_data, expires_at, created_at)
+VALUES (
+    sqlc.arg(id),
+    sqlc.arg(kind),
+    sqlc.narg(user_id),
+    sqlc.arg(payload_json),
+    sqlc.arg(session_data),
+    sqlc.arg(expires_at),
+    sqlc.arg(created_at)
+);
+
+-- name: GetWebAuthnSession :one
+SELECT * FROM webauthn_sessions WHERE id = ?;
+
+-- name: DeleteWebAuthnSession :exec
+DELETE FROM webauthn_sessions WHERE id = ?;
+
+-- name: ConsumeWebAuthnProof :execresult
+-- kind is a parameter so the Go constant (webauthn.KindReauthProof) stays
+-- the single spelling of what a proof row is named.
+DELETE FROM webauthn_sessions
+WHERE id = sqlc.arg(id) AND kind = sqlc.arg(kind) AND user_id = sqlc.arg(user_id) AND expires_at > sqlc.arg(now);
+
+-- name: GetValidWebAuthnProof :one
+-- Peek twin of ConsumeWebAuthnProof: the same validity predicate without
+-- the delete, so an admission check and a consume cannot drift apart.
+SELECT * FROM webauthn_sessions
+WHERE id = sqlc.arg(id) AND kind = sqlc.arg(kind) AND user_id = sqlc.arg(user_id) AND expires_at > sqlc.arg(now);
+
+-- name: ConsumeWebAuthnCeremonySession :execresult
+DELETE FROM webauthn_sessions
+WHERE id = sqlc.arg(id) AND kind = sqlc.arg(kind) AND expires_at > sqlc.arg(now);
+
+-- name: DeleteWebAuthnSessionsByUser :exec
+DELETE FROM webauthn_sessions WHERE user_id = ?;
+
+-- name: DeleteWebAuthnSessionsByUserAndKind :exec
+DELETE FROM webauthn_sessions WHERE user_id = ? AND kind = ?;
+
+-- name: DeleteExpiredWebAuthnSessions :execresult
+DELETE FROM webauthn_sessions WHERE expires_at < sqlc.arg(now);

--- a/backend/internal/hub/store/sqlite/db/queries/webauthn_sessions.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/webauthn_sessions.sql
@@ -23,7 +23,7 @@ DELETE FROM webauthn_sessions WHERE id = ?;
 
 -- name: ConsumeWebAuthnProof :execresult
 -- kind is a parameter so the Go constant (webauthn.KindReauthProof) stays
--- the single spelling of what a proof row is named.
+-- the single spelling of what identifies a proof row.
 DELETE FROM webauthn_sessions
 WHERE id = sqlc.arg(id) AND kind = sqlc.arg(kind) AND user_id = sqlc.arg(user_id) AND expires_at > sqlc.arg(now);
 

--- a/backend/internal/hub/store/sqlite/delegation_tokens.go
+++ b/backend/internal/hub/store/sqlite/delegation_tokens.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"context"
+	"time"
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/sqlite/generated/db"
@@ -117,14 +118,17 @@ func (s *delegationTokenStore) ListAll(ctx context.Context, p store.ListAllDeleg
 	}
 }
 
-func (s *delegationTokenStore) ListActiveByUser(ctx context.Context, userID userid.UserID) ([]store.DelegationToken, error) {
+func (s *delegationTokenStore) ListActiveByUser(ctx context.Context, userID userid.UserID, now time.Time) ([]store.DelegationToken, error) {
 	owner, ok := userid.OwnerFilter(userID)
 	if !ok {
 		// An unminted caller owns nothing; binding "" would MATCH every
 		// blank-owner row rather than none. See userid.OwnerFilter.
 		return nil, nil
 	}
-	rows, err := s.conn.q.ListActiveDelegationTokensByUser(ctx, owner)
+	rows, err := s.conn.q.ListActiveDelegationTokensByUser(ctx, gendb.ListActiveDelegationTokensByUserParams{
+		UserID: owner,
+		Now:    sqltime.NewSQLiteTime(now),
+	})
 	if err != nil {
 		return nil, mapErr(err)
 	}

--- a/backend/internal/hub/store/sqlite/device_authorizations.go
+++ b/backend/internal/hub/store/sqlite/device_authorizations.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"context"
+	"time"
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/sqlite/generated/db"
@@ -69,6 +70,7 @@ func (s *deviceAuthorizationStore) Approve(ctx context.Context, p store.ApproveD
 	return rowsAffected(s.conn.q.ApproveDeviceAuthorization(ctx, gendb.ApproveDeviceAuthorizationParams{
 		UserID:     sqlutil.NullUserID(p.UserID),
 		DeviceCode: p.DeviceCode,
+		Now:        sqltime.NewSQLiteTime(p.Now),
 	}))
 }
 
@@ -85,6 +87,7 @@ func (s *deviceAuthorizationStore) ApproveByUserCode(ctx context.Context, p stor
 	return rowsAffected(s.conn.q.ApproveDeviceAuthorizationByUserCode(ctx, gendb.ApproveDeviceAuthorizationByUserCodeParams{
 		UserID:   sqlutil.NullUserID(p.UserID),
 		UserCode: p.UserCode,
+		Now:      sqltime.NewSQLiteTime(p.Now),
 	}))
 }
 
@@ -92,8 +95,11 @@ func (s *deviceAuthorizationStore) Deny(ctx context.Context, deviceCode string) 
 	return rowsAffected(s.conn.q.DenyDeviceAuthorization(ctx, deviceCode))
 }
 
-func (s *deviceAuthorizationStore) Consume(ctx context.Context, deviceCode string) (int64, error) {
-	return rowsAffected(s.conn.q.ConsumeDeviceAuthorization(ctx, deviceCode))
+func (s *deviceAuthorizationStore) Consume(ctx context.Context, deviceCode string, now time.Time) (int64, error) {
+	return rowsAffected(s.conn.q.ConsumeDeviceAuthorization(ctx, gendb.ConsumeDeviceAuthorizationParams{
+		DeviceCode: deviceCode,
+		Now:        sqltime.NewSQLiteTime(now),
+	}))
 }
 
 func (s *deviceAuthorizationStore) TouchPoll(ctx context.Context, deviceCode string) error {

--- a/backend/internal/hub/store/sqlite/device_authorizations.go
+++ b/backend/internal/hub/store/sqlite/device_authorizations.go
@@ -57,7 +57,7 @@ func (s *deviceAuthorizationStore) GetByUserCode(ctx context.Context, userCode s
 	return &out, nil
 }
 
-func (s *deviceAuthorizationStore) Approve(ctx context.Context, p store.ApproveDeviceAuthorizationParams) (int64, error) {
+func (s *deviceAuthorizationStore) Approve(ctx context.Context, p store.ApproveDeviceAuthorizationParams, now time.Time) (int64, error) {
 	// An approval names WHO approved. A zero id would be written as SQL NULL
 	// while the UPDATE still matched the row, so the store would report one
 	// row affected, the browser would say "device authorized", and the CLI
@@ -70,11 +70,11 @@ func (s *deviceAuthorizationStore) Approve(ctx context.Context, p store.ApproveD
 	return rowsAffected(s.conn.q.ApproveDeviceAuthorization(ctx, gendb.ApproveDeviceAuthorizationParams{
 		UserID:     sqlutil.NullUserID(p.UserID),
 		DeviceCode: p.DeviceCode,
-		Now:        sqltime.NewSQLiteTime(p.Now),
+		Now:        sqltime.NewSQLiteTime(now),
 	}))
 }
 
-func (s *deviceAuthorizationStore) ApproveByUserCode(ctx context.Context, p store.ApproveDeviceAuthorizationByUserCodeParams) (int64, error) {
+func (s *deviceAuthorizationStore) ApproveByUserCode(ctx context.Context, p store.ApproveDeviceAuthorizationByUserCodeParams, now time.Time) (int64, error) {
 	// An approval names WHO approved. A zero id would be written as SQL NULL
 	// while the UPDATE still matched the row, so the store would report one
 	// row affected, the browser would say "device authorized", and the CLI
@@ -87,7 +87,7 @@ func (s *deviceAuthorizationStore) ApproveByUserCode(ctx context.Context, p stor
 	return rowsAffected(s.conn.q.ApproveDeviceAuthorizationByUserCode(ctx, gendb.ApproveDeviceAuthorizationByUserCodeParams{
 		UserID:   sqlutil.NullUserID(p.UserID),
 		UserCode: p.UserCode,
-		Now:      sqltime.NewSQLiteTime(p.Now),
+		Now:      sqltime.NewSQLiteTime(now),
 	}))
 }
 

--- a/backend/internal/hub/store/sqlite/oauth_tokens.go
+++ b/backend/internal/hub/store/sqlite/oauth_tokens.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"context"
+	"time"
 
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/sqlite/generated/db"
@@ -62,8 +63,8 @@ func (s *oauthTokenStore) Get(ctx context.Context, p store.GetOAuthTokensParams)
 	return &out, nil
 }
 
-func (s *oauthTokenStore) ListExpiring(ctx context.Context) ([]store.OAuthToken, error) {
-	rows, err := s.conn.q.ListExpiringOAuthTokens(ctx)
+func (s *oauthTokenStore) ListExpiring(ctx context.Context, refreshDueAt time.Time) ([]store.OAuthToken, error) {
+	rows, err := s.conn.q.ListExpiringOAuthTokens(ctx, sqltime.NewSQLiteTime(refreshDueAt))
 	if err != nil {
 		return nil, mapErr(err)
 	}

--- a/backend/internal/hub/store/sqlite/passkey_credentials.go
+++ b/backend/internal/hub/store/sqlite/passkey_credentials.go
@@ -1,0 +1,183 @@
+package sqlite
+
+import (
+	"context"
+
+	"github.com/leapmux/leapmux/internal/hub/store"
+	gendb "github.com/leapmux/leapmux/internal/hub/store/sqlite/generated/db"
+	"github.com/leapmux/leapmux/internal/util/ptrconv"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
+	"github.com/leapmux/leapmux/internal/util/userid"
+)
+
+type passkeyCredentialStore struct {
+	conn *sqliteConn
+}
+
+var _ store.PasskeyCredentialStore = (*passkeyCredentialStore)(nil)
+
+func fromDBPasskeyCredential(c gendb.PasskeyCredential) store.PasskeyCredential {
+	return store.PasskeyCredential{
+		ID:             c.ID,
+		UserID:         c.UserID,
+		CredentialID:   c.CredentialID,
+		PublicKey:      c.PublicKey,
+		SignCount:      c.SignCount,
+		AAGUID:         c.Aaguid,
+		BackupEligible: ptrconv.Int64ToBool(c.BackupEligible),
+		BackupState:    ptrconv.Int64ToBool(c.BackupState),
+		Transports:     c.Transports,
+		FriendlyName:   c.FriendlyName,
+		KeyVersion:     c.KeyVersion,
+		CreatedAt:      c.CreatedAt.Time,
+		LastUsedAt:     c.LastUsedAt.Ptr(),
+	}
+}
+
+func fromDBPasskeyCredentials(rows []gendb.PasskeyCredential) []store.PasskeyCredential {
+	return store.MapSlice(rows, fromDBPasskeyCredential)
+}
+
+func (s *passkeyCredentialStore) Create(ctx context.Context, p store.CreatePasskeyCredentialParams) error {
+	owner, ok := userid.New(p.UserID)
+	if !ok {
+		return store.ErrInvalidArgument
+	}
+	return mapErr(s.conn.q.CreatePasskeyCredential(ctx, gendb.CreatePasskeyCredentialParams{
+		ID:             p.ID,
+		UserID:         owner.String(),
+		CredentialID:   p.CredentialID,
+		PublicKey:      p.PublicKey,
+		SignCount:      p.SignCount,
+		Aaguid:         p.AAGUID,
+		BackupEligible: ptrconv.BoolToInt64(p.BackupEligible),
+		BackupState:    ptrconv.BoolToInt64(p.BackupState),
+		Transports:     p.Transports,
+		FriendlyName:   p.FriendlyName,
+		KeyVersion:     p.KeyVersion,
+		CreatedAt:      sqltime.NewSQLiteTime(p.CreatedAt),
+		LastUsedAt:     sqltime.NewSQLiteNullTime(p.LastUsedAt),
+	}))
+}
+
+func (s *passkeyCredentialStore) GetByID(ctx context.Context, id string) (*store.PasskeyCredential, error) {
+	row, err := s.conn.q.GetPasskeyCredentialByID(ctx, id)
+	if err != nil {
+		return nil, mapErr(err)
+	}
+	out := fromDBPasskeyCredential(row)
+	return &out, nil
+}
+
+func (s *passkeyCredentialStore) GetByCredentialID(ctx context.Context, credentialID []byte) (*store.PasskeyCredential, error) {
+	row, err := s.conn.q.GetPasskeyCredentialByCredentialID(ctx, credentialID)
+	if err != nil {
+		return nil, mapErr(err)
+	}
+	out := fromDBPasskeyCredential(row)
+	return &out, nil
+}
+
+func (s *passkeyCredentialStore) ListByUser(ctx context.Context, userID string) ([]store.PasskeyCredential, error) {
+	owner, ok := userid.New(userID)
+	if !ok {
+		return nil, store.ErrInvalidArgument
+	}
+	rows, err := s.conn.q.ListPasskeyCredentialsByUser(ctx, owner.String())
+	if err != nil {
+		return nil, mapErr(err)
+	}
+	return fromDBPasskeyCredentials(rows), nil
+}
+
+func (s *passkeyCredentialStore) CountByUser(ctx context.Context, userID string) (int64, error) {
+	owner, ok := userid.New(userID)
+	if !ok {
+		return 0, store.ErrInvalidArgument
+	}
+	count, err := s.conn.q.CountPasskeyCredentialsByUser(ctx, owner.String())
+	if err != nil {
+		return 0, mapErr(err)
+	}
+	return count, nil
+}
+
+func (s *passkeyCredentialStore) UpdateSignCount(ctx context.Context, p store.UpdatePasskeySignCountParams) error {
+	owner, ok := userid.New(p.UserID)
+	if !ok {
+		return store.ErrInvalidArgument
+	}
+	n, err := rowsAffected(s.conn.q.UpdatePasskeySignCount(ctx, gendb.UpdatePasskeySignCountParams{
+		SignCount:    p.SignCount,
+		LastUsedAt:   sqltime.SQLiteNullTimeOf(p.LastUsedAt),
+		CredentialID: p.CredentialID,
+		UserID:       owner.String(),
+	}))
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return store.ErrNotFound
+	}
+	return nil
+}
+
+func (s *passkeyCredentialStore) UpdateFriendlyName(ctx context.Context, id, userID, friendlyName string) error {
+	owner, ok := userid.New(userID)
+	if !ok {
+		return store.ErrInvalidArgument
+	}
+	return mapErr(s.conn.q.UpdatePasskeyFriendlyName(ctx, gendb.UpdatePasskeyFriendlyNameParams{
+		FriendlyName: friendlyName,
+		ID:           id,
+		UserID:       owner.String(),
+	}))
+}
+
+func (s *passkeyCredentialStore) UpdatePublicKey(ctx context.Context, p store.UpdatePasskeyPublicKeyParams) error {
+	owner, ok := userid.New(p.UserID)
+	if !ok {
+		return store.ErrInvalidArgument
+	}
+	return mapErr(s.conn.q.UpdatePasskeyPublicKey(ctx, gendb.UpdatePasskeyPublicKeyParams{
+		PublicKey:  p.PublicKey,
+		KeyVersion: p.KeyVersion,
+		ID:         p.ID,
+		UserID:     owner.String(),
+	}))
+}
+
+func (s *passkeyCredentialStore) Delete(ctx context.Context, id, userID string) error {
+	owner, ok := userid.New(userID)
+	if !ok {
+		return store.ErrInvalidArgument
+	}
+	return mapErr(s.conn.q.DeletePasskeyCredential(ctx, gendb.DeletePasskeyCredentialParams{
+		ID:     id,
+		UserID: owner.String(),
+	}))
+}
+
+func (s *passkeyCredentialStore) DeleteAllByUser(ctx context.Context, userID string) error {
+	owner, ok := userid.New(userID)
+	if !ok {
+		return store.ErrInvalidArgument
+	}
+	return mapErr(s.conn.q.DeleteAllPasskeyCredentialsByUser(ctx, owner.String()))
+}
+
+func (s *passkeyCredentialStore) ListByKeyVersion(ctx context.Context, keyVersion int64) ([]store.PasskeyCredential, error) {
+	rows, err := s.conn.q.ListPasskeyCredentialsByKeyVersion(ctx, keyVersion)
+	if err != nil {
+		return nil, mapErr(err)
+	}
+	return fromDBPasskeyCredentials(rows), nil
+}
+
+func (s *passkeyCredentialStore) CountByKeyVersion(ctx context.Context, keyVersion int64) (int64, error) {
+	count, err := s.conn.q.CountPasskeyCredentialsByKeyVersion(ctx, keyVersion)
+	if err != nil {
+		return 0, mapErr(err)
+	}
+	return count, nil
+}

--- a/backend/internal/hub/store/sqlite/sessions.go
+++ b/backend/internal/hub/store/sqlite/sessions.go
@@ -56,8 +56,11 @@ func (s *sessionStore) Create(ctx context.Context, p store.CreateSessionParams) 
 	})
 }
 
-func (s *sessionStore) GetByID(ctx context.Context, id string) (*store.UserSession, error) {
-	sess, err := s.conn.q.GetUserSessionByID(ctx, id)
+func (s *sessionStore) GetByID(ctx context.Context, id string, now time.Time) (*store.UserSession, error) {
+	sess, err := s.conn.q.GetUserSessionByID(ctx, gendb.GetUserSessionByIDParams{
+		ID:  id,
+		Now: sqltime.NewSQLiteTime(now),
+	})
 	if err != nil {
 		return nil, mapErr(err)
 	}
@@ -80,8 +83,8 @@ func (s *sessionStore) Touch(ctx context.Context, p store.TouchSessionParams) (i
 		 SET last_active_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
 		     expires_at = ?
 		 WHERE id = ? AND last_active_at < ?
-		   AND expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`,
-		sqltime.NewSQLiteTime(p.ExpiresAt), p.ID, sqltime.NewSQLiteTime(p.LastActiveAt),
+		   AND expires_at > ?`,
+		sqltime.NewSQLiteTime(p.ExpiresAt), p.ID, sqltime.NewSQLiteTime(p.LastActiveAt), sqltime.NewSQLiteTime(p.Now),
 	)
 	if err != nil {
 		return 0, mapErr(err)
@@ -152,7 +155,7 @@ func (s *sessionStore) ListByUserID(ctx context.Context, p store.ListUserSession
 	}
 	return queryPage(ctx, p.Limit,
 		func() (gendb.ListUserSessionsByUserIDParams, error) {
-			return listUserSessionsParams(owner, p.Cursor, p.Limit)
+			return listUserSessionsParams(owner, p.Cursor, p.Limit, p.Now)
 		},
 		s.conn.q.ListUserSessionsByUserID, fromDBSession)
 }
@@ -160,13 +163,16 @@ func (s *sessionStore) ListByUserID(ctx context.Context, p store.ListUserSession
 func (s *sessionStore) ListAllActive(ctx context.Context, p store.ListAllActiveSessionsParams) (store.Page[store.ActiveSession], error) {
 	return queryPage(ctx, p.Limit,
 		func() (gendb.ListAllActiveSessionsParams, error) {
-			return listAllActiveSessionsParams(p.Cursor, p.Limit)
+			return listAllActiveSessionsParams(p.Cursor, p.Limit, p.Now)
 		},
 		s.conn.q.ListAllActiveSessions, fromDBActiveSessionRow)
 }
 
-func (s *sessionStore) ValidateWithUser(ctx context.Context, id string) (*store.SessionWithUser, error) {
-	row, err := s.conn.q.ValidateSessionWithUser(ctx, id)
+func (s *sessionStore) ValidateWithUser(ctx context.Context, id string, now time.Time) (*store.SessionWithUser, error) {
+	row, err := s.conn.q.ValidateSessionWithUser(ctx, gendb.ValidateSessionWithUserParams{
+		ID:  id,
+		Now: sqltime.NewSQLiteTime(now),
+	})
 	if err != nil {
 		return nil, mapErr(err)
 	}

--- a/backend/internal/hub/store/sqlite/sessions.go
+++ b/backend/internal/hub/store/sqlite/sessions.go
@@ -68,7 +68,7 @@ func (s *sessionStore) GetByID(ctx context.Context, id string, now time.Time) (*
 	return &out, nil
 }
 
-func (s *sessionStore) Touch(ctx context.Context, p store.TouchSessionParams) (int64, error) {
+func (s *sessionStore) Touch(ctx context.Context, p store.TouchSessionParams, now time.Time) (int64, error) {
 	// sqlite Touch is an inline query rather than a generated one (unlike
 	// postgres/mysql). last_active_at is written SQL-side by strftime('now'); the
 	// expires_at write and the last_active_at WHERE comparand are bound as
@@ -84,7 +84,7 @@ func (s *sessionStore) Touch(ctx context.Context, p store.TouchSessionParams) (i
 		     expires_at = ?
 		 WHERE id = ? AND last_active_at < ?
 		   AND expires_at > ?`,
-		sqltime.NewSQLiteTime(p.ExpiresAt), p.ID, sqltime.NewSQLiteTime(p.LastActiveAt), sqltime.NewSQLiteTime(p.Now),
+		sqltime.NewSQLiteTime(p.ExpiresAt), p.ID, sqltime.NewSQLiteTime(p.LastActiveAt), sqltime.NewSQLiteTime(now),
 	)
 	if err != nil {
 		return 0, mapErr(err)
@@ -146,7 +146,7 @@ func (s *sessionStore) RefreshAuthGeneration(ctx context.Context, p store.Refres
 	}))
 }
 
-func (s *sessionStore) ListByUserID(ctx context.Context, p store.ListUserSessionsParams) (store.Page[store.UserSession], error) {
+func (s *sessionStore) ListByUserID(ctx context.Context, p store.ListUserSessionsParams, now time.Time) (store.Page[store.UserSession], error) {
 	owner, ok := userid.OwnerFilter(p.UserID)
 	if !ok {
 		// An unminted caller owns nothing; binding "" would MATCH every
@@ -155,15 +155,15 @@ func (s *sessionStore) ListByUserID(ctx context.Context, p store.ListUserSession
 	}
 	return queryPage(ctx, p.Limit,
 		func() (gendb.ListUserSessionsByUserIDParams, error) {
-			return listUserSessionsParams(owner, p.Cursor, p.Limit, p.Now)
+			return listUserSessionsParams(owner, p.Cursor, p.Limit, now)
 		},
 		s.conn.q.ListUserSessionsByUserID, fromDBSession)
 }
 
-func (s *sessionStore) ListAllActive(ctx context.Context, p store.ListAllActiveSessionsParams) (store.Page[store.ActiveSession], error) {
+func (s *sessionStore) ListAllActive(ctx context.Context, p store.ListAllActiveSessionsParams, now time.Time) (store.Page[store.ActiveSession], error) {
 	return queryPage(ctx, p.Limit,
 		func() (gendb.ListAllActiveSessionsParams, error) {
-			return listAllActiveSessionsParams(p.Cursor, p.Limit, p.Now)
+			return listAllActiveSessionsParams(p.Cursor, p.Limit, now)
 		},
 		s.conn.q.ListAllActiveSessions, fromDBActiveSessionRow)
 }

--- a/backend/internal/hub/store/sqlite/sessions_internal_test.go
+++ b/backend/internal/hub/store/sqlite/sessions_internal_test.go
@@ -62,9 +62,9 @@ func TestSessionExpiryPredicatesPreserveFractionalPrecision(t *testing.T) {
 		_, err := db.Exec(`UPDATE user_sessions SET expires_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '+0.500 seconds') WHERE id = ?`, sessionID)
 		require.NoError(t, err)
 
-		_, err = st.Sessions().GetByID(context.Background(), sessionID)
+		_, err = st.Sessions().GetByID(context.Background(), sessionID, time.Now().UTC())
 		require.NoError(t, err)
-		_, err = st.Sessions().ValidateWithUser(context.Background(), sessionID)
+		_, err = st.Sessions().ValidateWithUser(context.Background(), sessionID, time.Now().UTC())
 		require.NoError(t, err)
 		byUserPage, err := st.Sessions().ListByUserID(context.Background(), store.ListUserSessionsParams{UserID: userid.MustNew(userID), PageParams: store.PageParams{Limit: 1000}})
 		require.NoError(t, err)
@@ -82,7 +82,7 @@ func TestSessionExpiryPredicatesPreserveFractionalPrecision(t *testing.T) {
 		_, err := db.Exec(`UPDATE user_sessions SET expires_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-0.500 seconds') WHERE id = ?`, sessionID)
 		require.NoError(t, err)
 
-		deleted, err := st.Cleanup().HardDeleteExpiredSessions(context.Background())
+		deleted, err := st.Cleanup().HardDeleteExpiredSessions(context.Background(), time.Now().UTC())
 		require.NoError(t, err)
 		assert.Equal(t, int64(1), deleted)
 	})
@@ -260,7 +260,7 @@ func TestTouchStoresExpiresAtCanonical(t *testing.T) {
 	// The user-visible consequence: GetByID uses that same raw-string filter,
 	// so a non-canonical stored value returns ErrNotFound on the request after
 	// each Touch.
-	_, err = st.Sessions().GetByID(context.Background(), sessionID)
+	_, err = st.Sessions().GetByID(context.Background(), sessionID, time.Now().UTC())
 	require.NoError(t, err, "touched session must remain visible to GetByID")
 }
 

--- a/backend/internal/hub/store/sqlite/sessions_internal_test.go
+++ b/backend/internal/hub/store/sqlite/sessions_internal_test.go
@@ -66,11 +66,11 @@ func TestSessionExpiryPredicatesPreserveFractionalPrecision(t *testing.T) {
 		require.NoError(t, err)
 		_, err = st.Sessions().ValidateWithUser(context.Background(), sessionID, time.Now().UTC())
 		require.NoError(t, err)
-		byUserPage, err := st.Sessions().ListByUserID(context.Background(), store.ListUserSessionsParams{UserID: userid.MustNew(userID), PageParams: store.PageParams{Limit: 1000}})
+		byUserPage, err := st.Sessions().ListByUserID(context.Background(), store.ListUserSessionsParams{UserID: userid.MustNew(userID), PageParams: store.PageParams{Limit: 1000}}, time.Now().UTC())
 		require.NoError(t, err)
 		byUser := byUserPage.Rows
 		assert.Len(t, byUser, 1)
-		page, err := st.Sessions().ListAllActive(context.Background(), store.ListAllActiveSessionsParams{PageParams: store.PageParams{Limit: 10}})
+		page, err := st.Sessions().ListAllActive(context.Background(), store.ListAllActiveSessionsParams{PageParams: store.PageParams{Limit: 10}}, time.Now().UTC())
 		require.NoError(t, err)
 		assert.Len(t, page.Rows, 1)
 	})
@@ -126,7 +126,7 @@ func TestListAllActiveSessionsPreservesFractionalCursorPrecision(t *testing.T) {
 
 	page, err := st.Sessions().ListAllActive(context.Background(), store.ListAllActiveSessionsParams{
 		PageParams: store.PageParams{Cursor: store.EncodeCursor(cursorTime, tieCursorID), Limit: 10},
-	})
+	}, time.Now().UTC())
 	require.NoError(t, err)
 	// The cursor row itself is excluded (id not < itself); the tied row with
 	// the smaller id survives via the equality branch; the 400ms row survives
@@ -226,7 +226,7 @@ func TestTouchStoresExpiresAtCanonical(t *testing.T) {
 		ID:           sessionID,
 		ExpiresAt:    newExpiry,
 		LastActiveAt: time.Now().UTC(),
-	})
+	}, time.Now().UTC())
 	require.NoError(t, err)
 	require.Equal(t, int64(1), n, "Touch must fire against the backdated row")
 
@@ -320,7 +320,7 @@ func TestKeysetCursorTrailingZeroMillisecondTie(t *testing.T) {
 	page, err := st.Sessions().ListByUserID(context.Background(), store.ListUserSessionsParams{
 		UserID:     userid.MustNew(user.ID),
 		PageParams: store.PageParams{Cursor: store.EncodeCursor(tieInstant, boundary), Limit: 10},
-	})
+	}, time.Now().UTC())
 	require.NoError(t, err)
 	require.Len(t, page.Rows, 2, "the tied smaller-id row and the earlier row must both survive the boundary")
 	assert.Equal(t, expectTied, page.Rows[0].ID)

--- a/backend/internal/hub/store/sqlite/sqlite.go
+++ b/backend/internal/hub/store/sqlite/sqlite.go
@@ -108,6 +108,12 @@ func (s *sqliteStore) OAuthUserLinks() store.OAuthUserLinkStore {
 func (s *sqliteStore) PendingOAuthSignups() store.PendingOAuthSignupStore {
 	return &pendingOAuthSignupStore{conn: s.conn}
 }
+func (s *sqliteStore) PasskeyCredentials() store.PasskeyCredentialStore {
+	return &passkeyCredentialStore{conn: s.conn}
+}
+func (s *sqliteStore) WebAuthnSessions() store.WebAuthnSessionStore {
+	return &webAuthnSessionStore{conn: s.conn}
+}
 func (s *sqliteStore) Settings() store.SettingsStore {
 	return &settingsStore{conn: s.conn}
 }

--- a/backend/internal/hub/store/sqlite/users.go
+++ b/backend/internal/hub/store/sqlite/users.go
@@ -351,13 +351,24 @@ func (s *userStore) UpdatePrefs(ctx context.Context, p store.UpdateUserPrefsPara
 	}))
 }
 
-func (s *userStore) SetPendingEmail(ctx context.Context, p store.SetPendingEmailParams) error {
-	return mapErr(s.conn.q.SetPendingEmail(ctx, gendb.SetPendingEmailParams{
+func (s *userStore) SetPendingEmail(ctx context.Context, p store.SetPendingEmailParams) (bool, error) {
+	n, err := rowsAffected(s.conn.q.SetPendingEmail(ctx, gendb.SetPendingEmailParams{
 		PendingEmail:          store.NormalizeEmail(p.PendingEmail),
 		PendingEmailToken:     p.PendingEmailToken,
 		PendingEmailExpiresAt: sqltime.NewSQLiteNullTime(p.PendingEmailExpiresAt),
 		ID:                    p.ID,
+		CooldownCutoff:        sqltime.SQLiteNullTimeOf(p.CooldownCutoff),
 	}))
+	if err != nil {
+		return false, err
+	}
+	return n > 0, nil
+}
+
+// ClearPendingEmailCode drops an undelivered code and keeps the pending
+// address; see the query comment for why the address must survive.
+func (s *userStore) ClearPendingEmailCode(ctx context.Context, id string) error {
+	return mapErr(s.conn.q.ClearPendingEmailCode(ctx, id))
 }
 
 // PromotePendingEmail moves pending_email into email (email_verified=1). A row

--- a/backend/internal/hub/store/sqlite/users.go
+++ b/backend/internal/hub/store/sqlite/users.go
@@ -22,24 +22,27 @@ var _ store.UserStore = (*userStore)(nil)
 
 func fromDBUser(u gendb.User) store.User {
 	return store.User{
-		ID:                    u.ID,
-		Username:              u.Username,
-		PasswordHash:          u.PasswordHash,
-		DisplayName:           u.DisplayName,
-		Email:                 u.Email,
-		EmailVerified:         ptrconv.Int64ToBool(u.EmailVerified),
-		PendingEmail:          u.PendingEmail,
-		PendingEmailToken:     u.PendingEmailToken,
-		PendingEmailExpiresAt: u.PendingEmailExpiresAt.Ptr(),
-		PendingEmailAttempts:  u.PendingEmailAttempts,
-		PasswordSet:           ptrconv.Int64ToBool(u.PasswordSet),
-		IsAdmin:               ptrconv.Int64ToBool(u.IsAdmin),
-		Prefs:                 u.Prefs,
-		CreatedAt:             u.CreatedAt.Time,
-		UpdatedAt:             u.UpdatedAt.Time,
-		TokensRevokedAt:       u.TokensRevokedAt.Ptr(),
-		AuthGeneration:        u.AuthGeneration,
-		DeletedAt:             u.DeletedAt.Ptr(),
+		ID:                            u.ID,
+		Username:                      u.Username,
+		PasswordHash:                  u.PasswordHash,
+		DisplayName:                   u.DisplayName,
+		Email:                         u.Email,
+		EmailVerified:                 ptrconv.Int64ToBool(u.EmailVerified),
+		PendingEmail:                  u.PendingEmail,
+		PendingEmailToken:             u.PendingEmailToken,
+		PendingEmailExpiresAt:         u.PendingEmailExpiresAt.Ptr(),
+		PendingEmailAttempts:          u.PendingEmailAttempts,
+		PendingPasswordResetToken:     u.PendingPasswordResetToken,
+		PendingPasswordResetExpiresAt: u.PendingPasswordResetExpiresAt.Ptr(),
+		PendingPasswordResetAttempts:  u.PendingPasswordResetAttempts,
+		PasswordSet:                   ptrconv.Int64ToBool(u.PasswordSet),
+		IsAdmin:                       ptrconv.Int64ToBool(u.IsAdmin),
+		Prefs:                         u.Prefs,
+		CreatedAt:                     u.CreatedAt.Time,
+		UpdatedAt:                     u.UpdatedAt.Time,
+		TokensRevokedAt:               u.TokensRevokedAt.Ptr(),
+		AuthGeneration:                u.AuthGeneration,
+		DeletedAt:                     u.DeletedAt.Ptr(),
 	}
 }
 
@@ -124,8 +127,12 @@ func (s *userStore) ExistsByEmail(ctx context.Context, email, excludeUserID stri
 	return v, nil
 }
 
-func (s *userStore) ConsumeVerificationAttempt(ctx context.Context, id string) (*store.User, error) {
-	u, err := s.conn.q.ConsumeVerificationAttempt(ctx, id)
+func (s *userStore) ConsumeVerificationAttempt(ctx context.Context, id string, now time.Time, maxAttempts int64) (*store.User, error) {
+	u, err := s.conn.q.ConsumeVerificationAttempt(ctx, gendb.ConsumeVerificationAttemptParams{
+		ID:          id,
+		Now:         sqltime.SQLiteNullTimeOf(now),
+		MaxAttempts: maxAttempts,
+	})
 	if err != nil {
 		return nil, mapErr(err)
 	}
@@ -379,6 +386,59 @@ func (s *userStore) ClearCompetingPendingEmails(ctx context.Context, p store.Cle
 
 func (s *userStore) Delete(ctx context.Context, id string) error {
 	return mapErr(s.conn.q.DeleteUser(ctx, id))
+}
+
+func (s *userStore) SetPendingPasswordReset(ctx context.Context, p store.SetPendingPasswordResetParams) (bool, error) {
+	n, err := rowsAffected(s.conn.q.SetPendingPasswordReset(ctx, gendb.SetPendingPasswordResetParams{
+		PendingPasswordResetToken:     p.PendingPasswordResetToken,
+		PendingPasswordResetExpiresAt: sqltime.SQLiteNullTimeOf(p.PendingPasswordResetExpiresAt),
+		CooldownCutoff:                sqltime.SQLiteNullTimeOf(p.CooldownCutoff),
+		ID:                            p.ID,
+	}))
+	if err != nil {
+		return false, err
+	}
+	return n > 0, nil
+}
+
+func (s *userStore) ClearPendingPasswordReset(ctx context.Context, id string) error {
+	return mapErr(s.conn.q.ClearPendingPasswordReset(ctx, id))
+}
+
+func (s *userStore) ConsumePasswordResetAttemptByToken(ctx context.Context, tokenHash string, now time.Time, maxAttempts int64) (*store.User, error) {
+	u, err := s.conn.q.ConsumePasswordResetAttemptByToken(ctx, gendb.ConsumePasswordResetAttemptByTokenParams{
+		Token:       tokenHash,
+		Now:         sqltime.SQLiteNullTimeOf(now),
+		MaxAttempts: maxAttempts,
+	})
+	if err != nil {
+		return nil, mapErr(err)
+	}
+	out := fromDBUser(u)
+	return &out, nil
+}
+
+func (s *userStore) CompletePasswordReset(ctx context.Context, p store.CompletePasswordResetParams) (*store.PasswordResetRevocation, error) {
+	row, err := s.conn.q.CompletePasswordReset(ctx, gendb.CompletePasswordResetParams{
+		PasswordHash:              p.PasswordHash,
+		ID:                        p.ID,
+		PendingPasswordResetToken: p.PendingPasswordResetToken,
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, store.ErrNotFound
+	}
+	if err != nil {
+		return nil, mapErr(err)
+	}
+	revokedAt, err := sqlutil.RequireTime(row.TokensRevokedAt.Time, row.TokensRevokedAt.Valid, "tokens_revoked_at")
+	if err != nil {
+		return nil, err
+	}
+	return &store.PasswordResetRevocation{
+		UserID:          row.ID,
+		TokensRevokedAt: revokedAt,
+		AuthGeneration:  row.AuthGeneration,
+	}, nil
 }
 
 func (s *userStore) RevokeUserTokens(ctx context.Context, userID userid.UserID) (int64, error) {

--- a/backend/internal/hub/store/sqlite/users_internal_test.go
+++ b/backend/internal/hub/store/sqlite/users_internal_test.go
@@ -78,7 +78,7 @@ func TestClearStalePendingEmailsSweepsLockoutRowSameDay(t *testing.T) {
 	// Exceed the attempt budget so the lockout branch rewrites
 	// pending_email_expires_at to strftime('now').
 	for range 6 {
-		_, err := st.Users().ConsumeVerificationAttempt(ctx, user.ID)
+		_, err := st.Users().ConsumeVerificationAttempt(ctx, user.ID, time.Now().UTC(), 5)
 		require.NoError(t, err)
 	}
 

--- a/backend/internal/hub/store/sqlite/users_internal_test.go
+++ b/backend/internal/hub/store/sqlite/users_internal_test.go
@@ -33,12 +33,15 @@ func TestSetPendingEmailStoresCanonicalFormat(t *testing.T) {
 	// sqltime.SQLiteTime/timefmt.Format truncate, so a ms-aligned instant
 	// isolates the layout assertion from that sub-ms rounding difference.
 	expiry := time.Now().UTC().Add(30 * time.Minute).Truncate(time.Millisecond)
-	require.NoError(t, st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
+	minted, err := st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
 		ID:                    user.ID,
 		PendingEmail:          "new@example.com",
 		PendingEmailToken:     "tok-1",
 		PendingEmailExpiresAt: &expiry,
-	}))
+		CooldownCutoff:        store.UnconditionalMintCutoff(),
+	})
+	require.NoError(t, err)
+	require.True(t, minted)
 
 	// Direct layout pin: the on-disk value must equal timefmt.Format(expiry)
 	// byte-for-byte. Comparing SQL-side (raw = CAST) avoids modernc's
@@ -68,12 +71,15 @@ func TestClearStalePendingEmailsSweepsLockoutRowSameDay(t *testing.T) {
 	user := storetest.SeedUser(t, st, "lockout-sweep-user")
 
 	expiry := time.Now().UTC().Add(24 * time.Hour)
-	require.NoError(t, st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
+	minted, err := st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
 		ID:                    user.ID,
 		PendingEmail:          "locked@example.com",
 		PendingEmailToken:     "tok-lock",
 		PendingEmailExpiresAt: &expiry,
-	}))
+		CooldownCutoff:        store.UnconditionalMintCutoff(),
+	})
+	require.NoError(t, err)
+	require.True(t, minted)
 
 	// Exceed the attempt budget so the lockout branch rewrites
 	// pending_email_expires_at to strftime('now').

--- a/backend/internal/hub/store/sqlite/webauthn_sessions.go
+++ b/backend/internal/hub/store/sqlite/webauthn_sessions.go
@@ -1,0 +1,127 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/leapmux/leapmux/internal/hub/store"
+	gendb "github.com/leapmux/leapmux/internal/hub/store/sqlite/generated/db"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
+	"github.com/leapmux/leapmux/internal/util/userid"
+)
+
+type webAuthnSessionStore struct {
+	conn *sqliteConn
+}
+
+var _ store.WebAuthnSessionStore = (*webAuthnSessionStore)(nil)
+
+func fromDBWebAuthnSession(s gendb.WebauthnSession) store.WebAuthnSession {
+	out := store.WebAuthnSession{
+		ID:          s.ID,
+		Kind:        s.Kind,
+		PayloadJSON: s.PayloadJson,
+		SessionData: s.SessionData,
+		ExpiresAt:   s.ExpiresAt.Time,
+		CreatedAt:   s.CreatedAt.Time,
+	}
+	if s.UserID.Valid {
+		out.UserID = s.UserID.String
+	}
+	return out
+}
+
+func (s *webAuthnSessionStore) Create(ctx context.Context, p store.CreateWebAuthnSessionParams) error {
+	var userID sql.NullString
+	if p.UserID != "" {
+		owner, ok := userid.New(p.UserID)
+		if !ok {
+			return store.ErrInvalidArgument
+		}
+		userID = sql.NullString{String: owner.String(), Valid: true}
+	}
+	return mapErr(s.conn.q.CreateWebAuthnSession(ctx, gendb.CreateWebAuthnSessionParams{
+		ID:          p.ID,
+		Kind:        p.Kind,
+		UserID:      userID,
+		PayloadJson: p.PayloadJSON,
+		SessionData: p.SessionData,
+		ExpiresAt:   sqltime.NewSQLiteTime(p.ExpiresAt),
+		CreatedAt:   sqltime.NewSQLiteTime(p.CreatedAt),
+	}))
+}
+
+func (s *webAuthnSessionStore) Get(ctx context.Context, id string) (*store.WebAuthnSession, error) {
+	row, err := s.conn.q.GetWebAuthnSession(ctx, id)
+	if err != nil {
+		return nil, mapErr(err)
+	}
+	out := fromDBWebAuthnSession(row)
+	return &out, nil
+}
+
+func (s *webAuthnSessionStore) Delete(ctx context.Context, id string) error {
+	return mapErr(s.conn.q.DeleteWebAuthnSession(ctx, id))
+}
+
+func (s *webAuthnSessionStore) ConsumeCeremony(ctx context.Context, id, kind string, now time.Time) (int64, error) {
+	return rowsAffected(s.conn.q.ConsumeWebAuthnCeremonySession(ctx, gendb.ConsumeWebAuthnCeremonySessionParams{
+		ID:   id,
+		Kind: kind,
+		Now:  sqltime.NewSQLiteTime(now),
+	}))
+}
+
+func (s *webAuthnSessionStore) ConsumeProof(ctx context.Context, id, userID, kind string, now time.Time) (int64, error) {
+	owner, ok := userid.New(userID)
+	if !ok {
+		return 0, store.ErrInvalidArgument
+	}
+	return rowsAffected(s.conn.q.ConsumeWebAuthnProof(ctx, gendb.ConsumeWebAuthnProofParams{
+		ID:     id,
+		Kind:   kind,
+		UserID: sql.NullString{String: owner.String(), Valid: true},
+		Now:    sqltime.NewSQLiteTime(now),
+	}))
+}
+
+func (s *webAuthnSessionStore) GetValidProof(ctx context.Context, id, userID, kind string, now time.Time) (*store.WebAuthnSession, error) {
+	owner, ok := userid.New(userID)
+	if !ok {
+		return nil, store.ErrInvalidArgument
+	}
+	row, err := s.conn.q.GetValidWebAuthnProof(ctx, gendb.GetValidWebAuthnProofParams{
+		ID:     id,
+		Kind:   kind,
+		UserID: sql.NullString{String: owner.String(), Valid: true},
+		Now:    sqltime.NewSQLiteTime(now),
+	})
+	if err != nil {
+		return nil, mapErr(err)
+	}
+	out := fromDBWebAuthnSession(row)
+	return &out, nil
+}
+
+func (s *webAuthnSessionStore) DeleteAllByUser(ctx context.Context, userID string) error {
+	owner, ok := userid.New(userID)
+	if !ok {
+		return store.ErrInvalidArgument
+	}
+	return mapErr(s.conn.q.DeleteWebAuthnSessionsByUser(ctx, sql.NullString{
+		String: owner.String(),
+		Valid:  true,
+	}))
+}
+
+func (s *webAuthnSessionStore) DeleteByUserAndKind(ctx context.Context, userID, kind string) error {
+	owner, ok := userid.New(userID)
+	if !ok {
+		return store.ErrInvalidArgument
+	}
+	return mapErr(s.conn.q.DeleteWebAuthnSessionsByUserAndKind(ctx, gendb.DeleteWebAuthnSessionsByUserAndKindParams{
+		UserID: sql.NullString{String: owner.String(), Valid: true},
+		Kind:   kind,
+	}))
+}

--- a/backend/internal/hub/store/sqlutil/tables.go
+++ b/backend/internal/hub/store/sqlutil/tables.go
@@ -13,5 +13,6 @@ var SQLTruncateTableOrder = []string{
 	"workspace_section_items", "workspace_sections",
 	"delegation_tokens", "api_tokens",
 	"workspaces", "worker_notifications", "worker_registration_keys", "workers",
+	"passkey_credentials", "webauthn_sessions",
 	"user_sessions", "users",
 }

--- a/backend/internal/hub/store/store.go
+++ b/backend/internal/hub/store/store.go
@@ -33,6 +33,8 @@ type Store interface {
 	OAuthTokens() OAuthTokenStore
 	OAuthUserLinks() OAuthUserLinkStore
 	PendingOAuthSignups() PendingOAuthSignupStore
+	PasskeyCredentials() PasskeyCredentialStore
+	WebAuthnSessions() WebAuthnSessionStore
 	Settings() SettingsStore
 	AltchaSalts() AltchaSaltsStore
 	APITokens() APITokenStore
@@ -90,7 +92,7 @@ type UserStore interface {
 	// is no pending verification to charge — callers should map that
 	// to FailedPrecondition. The returned row is the source of truth
 	// for the constant-time code comparison that follows.
-	ConsumeVerificationAttempt(ctx context.Context, id string) (*User, error)
+	ConsumeVerificationAttempt(ctx context.Context, id string, now time.Time, maxAttempts int64) (*User, error)
 	GetPrefs(ctx context.Context, id string) (string, error)
 	// GetPrefsForUpdate reads the prefs blob locked against concurrent
 	// writers (SELECT ... FOR UPDATE, or the SQLite self-assign write that
@@ -113,6 +115,10 @@ type UserStore interface {
 	PromotePendingEmail(ctx context.Context, id string) error
 	ClearPendingEmail(ctx context.Context, id string) error
 	ClearCompetingPendingEmails(ctx context.Context, p ClearCompetingPendingEmailsParams) error
+	SetPendingPasswordReset(ctx context.Context, p SetPendingPasswordResetParams) (bool, error)
+	ClearPendingPasswordReset(ctx context.Context, id string) error
+	ConsumePasswordResetAttemptByToken(ctx context.Context, tokenHash string, now time.Time, maxAttempts int64) (*User, error)
+	CompletePasswordReset(ctx context.Context, p CompletePasswordResetParams) (*PasswordResetRevocation, error)
 	// Delete soft-deletes the user.
 	Delete(ctx context.Context, id string) error
 	// RevokeUserTokens advances the user's tokens_revoked_at marker
@@ -134,7 +140,7 @@ type UserStore interface {
 
 type SessionStore interface {
 	Create(ctx context.Context, p CreateSessionParams) error
-	GetByID(ctx context.Context, id string) (*UserSession, error)
+	GetByID(ctx context.Context, id string, now time.Time) (*UserSession, error)
 	// Touch conditionally slides a session's expiry forward and returns the
 	// number of rows updated. The UPDATE is guarded by last_active_at so a
 	// recently-touched session matches zero rows; callers must gate any
@@ -150,7 +156,7 @@ type SessionStore interface {
 	RefreshAuthGeneration(ctx context.Context, p RefreshSessionAuthGenerationParams) (int64, error)
 	ListByUserID(ctx context.Context, p ListUserSessionsParams) (Page[UserSession], error)
 	ListAllActive(ctx context.Context, p ListAllActiveSessionsParams) (Page[ActiveSession], error)
-	ValidateWithUser(ctx context.Context, id string) (*SessionWithUser, error)
+	ValidateWithUser(ctx context.Context, id string, now time.Time) (*SessionWithUser, error)
 }
 
 type WorkerStore interface {
@@ -416,7 +422,7 @@ type DelegationTokenStore interface {
 	// (LEFT JOIN users), replacing the admin CLI's per-user fanout. Keyset on
 	// created_at.
 	ListAll(ctx context.Context, p ListAllDelegationTokensParams) (Page[DelegationTokenWithOwner], error)
-	ListActiveByUser(ctx context.Context, userID userid.UserID) ([]DelegationToken, error)
+	ListActiveByUser(ctx context.Context, userID userid.UserID, now time.Time) ([]DelegationToken, error)
 	Touch(ctx context.Context, id string) error
 	Revoke(ctx context.Context, id string) (int64, error)
 	// RevokeByUser bulk-revokes every non-revoked delegation token for
@@ -530,15 +536,15 @@ type DeviceAuthorizationStore interface {
 	Approve(ctx context.Context, p ApproveDeviceAuthorizationParams) (int64, error)
 	ApproveByUserCode(ctx context.Context, p ApproveDeviceAuthorizationByUserCodeParams) (int64, error)
 	Deny(ctx context.Context, deviceCode string) (int64, error)
-	Consume(ctx context.Context, deviceCode string) (int64, error)
+	Consume(ctx context.Context, deviceCode string, now time.Time) (int64, error)
 	TouchPoll(ctx context.Context, deviceCode string) error
 }
 
 // CLIAuthorizationCodeStore manages local-redirect one-shot codes.
 type CLIAuthorizationCodeStore interface {
 	Create(ctx context.Context, p CreateCLIAuthorizationCodeParams) error
-	GetActive(ctx context.Context, code string) (*CLIAuthorizationCode, error)
-	Consume(ctx context.Context, code string) (*CLIAuthorizationCode, error)
+	GetActive(ctx context.Context, code string, now time.Time) (*CLIAuthorizationCode, error)
+	Consume(ctx context.Context, code string, now time.Time) (*CLIAuthorizationCode, error)
 }
 
 type WorkspaceSectionStore interface {
@@ -582,7 +588,7 @@ type OAuthStateStore interface {
 type OAuthTokenStore interface {
 	Upsert(ctx context.Context, p UpsertOAuthTokensParams) error
 	Get(ctx context.Context, p GetOAuthTokensParams) (*OAuthToken, error)
-	ListExpiring(ctx context.Context) ([]OAuthToken, error)
+	ListExpiring(ctx context.Context, refreshDueAt time.Time) ([]OAuthToken, error)
 	ListByKeyVersion(ctx context.Context, keyVersion int64) ([]OAuthToken, error)
 	CountByKeyVersion(ctx context.Context, keyVersion int64) (int64, error)
 	DeleteByProvider(ctx context.Context, providerID string) error
@@ -607,6 +613,36 @@ type PendingOAuthSignupStore interface {
 	Create(ctx context.Context, p CreatePendingOAuthSignupParams) error
 	Get(ctx context.Context, token string) (*PendingOAuthSignup, error)
 	Delete(ctx context.Context, token string) error
+}
+
+type PasskeyCredentialStore interface {
+	Create(ctx context.Context, p CreatePasskeyCredentialParams) error
+	GetByID(ctx context.Context, id string) (*PasskeyCredential, error)
+	GetByCredentialID(ctx context.Context, credentialID []byte) (*PasskeyCredential, error)
+	ListByUser(ctx context.Context, userID string) ([]PasskeyCredential, error)
+	CountByUser(ctx context.Context, userID string) (int64, error)
+	UpdateSignCount(ctx context.Context, p UpdatePasskeySignCountParams) error
+	UpdateFriendlyName(ctx context.Context, id, userID, friendlyName string) error
+	UpdatePublicKey(ctx context.Context, p UpdatePasskeyPublicKeyParams) error
+	Delete(ctx context.Context, id, userID string) error
+	DeleteAllByUser(ctx context.Context, userID string) error
+	ListByKeyVersion(ctx context.Context, keyVersion int64) ([]PasskeyCredential, error)
+	CountByKeyVersion(ctx context.Context, keyVersion int64) (int64, error)
+}
+
+type WebAuthnSessionStore interface {
+	Create(ctx context.Context, p CreateWebAuthnSessionParams) error
+	Get(ctx context.Context, id string) (*WebAuthnSession, error)
+	Delete(ctx context.Context, id string) error
+	// ConsumeCeremony deletes one unexpired ceremony row of the given kind.
+	// Returns rows affected (0 when missing, wrong kind, expired, or already consumed).
+	ConsumeCeremony(ctx context.Context, id, kind string, now time.Time) (int64, error)
+	ConsumeProof(ctx context.Context, id, userID, kind string, now time.Time) (int64, error)
+	GetValidProof(ctx context.Context, id, userID, kind string, now time.Time) (*WebAuthnSession, error)
+	DeleteAllByUser(ctx context.Context, userID string) error
+	// DeleteByUserAndKind removes open ceremony rows for one user and kind
+	// (for example, replacing a prior reauth Begin).
+	DeleteByUserAndKind(ctx context.Context, userID, kind string) error
 }
 
 // SettingsStore manages the hub_settings table: one row per setting key,
@@ -670,7 +706,7 @@ type AltchaSaltsStore interface {
 // mechanisms but must implement all methods for consistent cross-backend
 // behavior.
 type CleanupStore interface {
-	HardDeleteExpiredSessions(ctx context.Context) (int64, error)
+	HardDeleteExpiredSessions(ctx context.Context, now time.Time) (int64, error)
 	HardDeleteWorkspacesBefore(ctx context.Context, cutoff time.Time) (int64, error)
 	HardDeleteWorkersBefore(ctx context.Context, cutoff time.Time) (int64, error)
 	HardDeleteExpiredRegistrationKeysBefore(ctx context.Context, cutoff time.Time) (int64, error)
@@ -693,8 +729,9 @@ type CleanupStore interface {
 	// pending_email_expires_at is older than cutoff. Frees up index slots
 	// and ensures stale codes don't leak into future lookups.
 	ClearStalePendingEmails(ctx context.Context, cutoff time.Time) (int64, error)
-	DeleteExpiredOAuthStates(ctx context.Context) (int64, error)
-	DeleteExpiredPendingOAuthSignups(ctx context.Context) (int64, error)
+	DeleteExpiredOAuthStates(ctx context.Context, now time.Time) (int64, error)
+	DeleteExpiredPendingOAuthSignups(ctx context.Context, now time.Time) (int64, error)
+	DeleteExpiredWebAuthnSessions(ctx context.Context, now time.Time) (int64, error)
 	DeleteExpiredDeviceAuthorizations(ctx context.Context, cutoff time.Time) (int64, error)
 	DeleteExpiredCLIAuthorizationCodes(ctx context.Context, cutoff time.Time) (int64, error)
 	DeleteRevokedAPITokensBefore(ctx context.Context, cutoff time.Time) (int64, error)

--- a/backend/internal/hub/store/store.go
+++ b/backend/internal/hub/store/store.go
@@ -111,9 +111,16 @@ type UserStore interface {
 	UpdateEmailVerified(ctx context.Context, p UpdateUserEmailVerifiedParams) error
 	UpdateAdmin(ctx context.Context, p UpdateUserAdminParams) error
 	UpdatePrefs(ctx context.Context, p UpdateUserPrefsParams) error
-	SetPendingEmail(ctx context.Context, p SetPendingEmailParams) error
+	// SetPendingEmail conditionally mints a verification code. It reports
+	// false when a previous code is still inside its resend cooldown, so
+	// the caller neither sends nor overwrites the live code.
+	SetPendingEmail(ctx context.Context, p SetPendingEmailParams) (bool, error)
 	PromotePendingEmail(ctx context.Context, id string) error
 	ClearPendingEmail(ctx context.Context, id string) error
+	// ClearPendingEmailCode drops an undelivered code and keeps the
+	// pending address, so a failed send does not lose the only record of
+	// what the account is verifying.
+	ClearPendingEmailCode(ctx context.Context, id string) error
 	ClearCompetingPendingEmails(ctx context.Context, p ClearCompetingPendingEmailsParams) error
 	SetPendingPasswordReset(ctx context.Context, p SetPendingPasswordResetParams) (bool, error)
 	ClearPendingPasswordReset(ctx context.Context, id string) error
@@ -146,7 +153,7 @@ type SessionStore interface {
 	// recently-touched session matches zero rows; callers must gate any
 	// in-memory lifecycle extension on rowsAffected > 0 so cached deadlines
 	// never advance past the un-updated DB expiry.
-	Touch(ctx context.Context, p TouchSessionParams) (int64, error)
+	Touch(ctx context.Context, p TouchSessionParams, now time.Time) (int64, error)
 	Delete(ctx context.Context, id string) (int64, error)
 	DeleteByUser(ctx context.Context, userID userid.UserID) error
 	DeleteOthers(ctx context.Context, p DeleteOtherSessionsParams) error
@@ -154,8 +161,8 @@ type SessionStore interface {
 	// user's latest auth_generation after a password change. Other
 	// sessions remain deleted or stale.
 	RefreshAuthGeneration(ctx context.Context, p RefreshSessionAuthGenerationParams) (int64, error)
-	ListByUserID(ctx context.Context, p ListUserSessionsParams) (Page[UserSession], error)
-	ListAllActive(ctx context.Context, p ListAllActiveSessionsParams) (Page[ActiveSession], error)
+	ListByUserID(ctx context.Context, p ListUserSessionsParams, now time.Time) (Page[UserSession], error)
+	ListAllActive(ctx context.Context, p ListAllActiveSessionsParams, now time.Time) (Page[ActiveSession], error)
 	ValidateWithUser(ctx context.Context, id string, now time.Time) (*SessionWithUser, error)
 }
 
@@ -533,8 +540,8 @@ type DeviceAuthorizationStore interface {
 	Create(ctx context.Context, p CreateDeviceAuthorizationParams) error
 	Get(ctx context.Context, deviceCode string) (*DeviceAuthorization, error)
 	GetByUserCode(ctx context.Context, userCode string) (*DeviceAuthorization, error)
-	Approve(ctx context.Context, p ApproveDeviceAuthorizationParams) (int64, error)
-	ApproveByUserCode(ctx context.Context, p ApproveDeviceAuthorizationByUserCodeParams) (int64, error)
+	Approve(ctx context.Context, p ApproveDeviceAuthorizationParams, now time.Time) (int64, error)
+	ApproveByUserCode(ctx context.Context, p ApproveDeviceAuthorizationByUserCodeParams, now time.Time) (int64, error)
 	Deny(ctx context.Context, deviceCode string) (int64, error)
 	Consume(ctx context.Context, deviceCode string, now time.Time) (int64, error)
 	TouchPoll(ctx context.Context, deviceCode string) error
@@ -732,11 +739,11 @@ type CleanupStore interface {
 	DeleteExpiredOAuthStates(ctx context.Context, now time.Time) (int64, error)
 	DeleteExpiredPendingOAuthSignups(ctx context.Context, now time.Time) (int64, error)
 	DeleteExpiredWebAuthnSessions(ctx context.Context, now time.Time) (int64, error)
-	DeleteExpiredDeviceAuthorizations(ctx context.Context, cutoff time.Time) (int64, error)
-	DeleteExpiredCLIAuthorizationCodes(ctx context.Context, cutoff time.Time) (int64, error)
+	DeleteExpiredDeviceAuthorizations(ctx context.Context, now time.Time) (int64, error)
+	DeleteExpiredCLIAuthorizationCodes(ctx context.Context, now time.Time) (int64, error)
 	DeleteRevokedAPITokensBefore(ctx context.Context, cutoff time.Time) (int64, error)
 	DeleteRevokedDelegationTokensBefore(ctx context.Context, cutoff time.Time) (int64, error)
-	DeleteExpiredDelegationTokensBefore(ctx context.Context, cutoff time.Time) (int64, error)
+	DeleteExpiredDelegationTokensBefore(ctx context.Context, now time.Time) (int64, error)
 	// DeleteExpiredAltchaSalts purges consumed ALTCHA salts whose
 	// challenge window passed; the salt can no longer verify after
 	// expiry, so the row only caps table growth until this sweep drops

--- a/backend/internal/hub/store/storetest/helpers.go
+++ b/backend/internal/hub/store/storetest/helpers.go
@@ -31,7 +31,7 @@ var ctx = context.Background()
 // membership rather than paging behavior.
 func ListAllSessions(t *testing.T, st store.Store, userID string) []store.UserSession {
 	t.Helper()
-	page, err := st.Sessions().ListByUserID(ctx, store.ListUserSessionsParams{UserID: userid.MustNew(userID), PageParams: store.PageParams{Limit: 1000}})
+	page, err := st.Sessions().ListByUserID(ctx, store.ListUserSessionsParams{UserID: userid.MustNew(userID), PageParams: store.PageParams{Limit: 1000}, Now: time.Now().UTC()})
 	require.NoError(t, err)
 	return page.Rows
 }
@@ -203,7 +203,7 @@ func SeedSession(t *testing.T, st store.Store, userID string) *store.UserSession
 	})
 	require.NoError(t, err)
 
-	sess, err := st.Sessions().GetByID(ctx, sessID)
+	sess, err := st.Sessions().GetByID(ctx, sessID, time.Now().UTC())
 	require.NoError(t, err)
 	return sess
 }

--- a/backend/internal/hub/store/storetest/helpers.go
+++ b/backend/internal/hub/store/storetest/helpers.go
@@ -31,7 +31,7 @@ var ctx = context.Background()
 // membership rather than paging behavior.
 func ListAllSessions(t *testing.T, st store.Store, userID string) []store.UserSession {
 	t.Helper()
-	page, err := st.Sessions().ListByUserID(ctx, store.ListUserSessionsParams{UserID: userid.MustNew(userID), PageParams: store.PageParams{Limit: 1000}, Now: time.Now().UTC()})
+	page, err := st.Sessions().ListByUserID(ctx, store.ListUserSessionsParams{UserID: userid.MustNew(userID), PageParams: store.PageParams{Limit: 1000}}, time.Now().UTC())
 	require.NoError(t, err)
 	return page.Rows
 }
@@ -206,4 +206,13 @@ func SeedSession(t *testing.T, st store.Store, userID string) *store.UserSession
 	sess, err := st.Sessions().GetByID(ctx, sessID, time.Now().UTC())
 	require.NoError(t, err)
 	return sess
+}
+
+// mustSetPendingEmail asserts the conditional mint landed. Most suite cases
+// seed a fresh code and want the write, not the cooldown branch; a silent
+// false there would leave the row unset and fail the case somewhere else.
+func mustSetPendingEmail(t *testing.T, minted bool, err error) {
+	t.Helper()
+	require.NoError(t, err)
+	require.True(t, minted, "the conditional mint must land for a fresh pending code")
 }

--- a/backend/internal/hub/store/storetest/suite.go
+++ b/backend/internal/hub/store/storetest/suite.go
@@ -38,6 +38,8 @@ func (s *Suite) Run(t *testing.T) {
 	t.Run("oauth_tokens", s.testOAuthTokens)
 	t.Run("oauth_user_links", s.testOAuthUserLinks)
 	t.Run("pending_oauth_signups", s.testPendingOAuthSignups)
+	t.Run("passkeys", s.testPasskeys)
+	t.Run("password reset store", s.testPasswordResetStore)
 	t.Run("hub_settings", s.testHubSettings)
 	t.Run("cli_authorizations", s.testCLIAuthorizations)
 	t.Run("transactions", s.testTransactions)

--- a/backend/internal/hub/store/storetest/test_cleanup.go
+++ b/backend/internal/hub/store/storetest/test_cleanup.go
@@ -29,7 +29,7 @@ func (s *Suite) testCleanup(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		n, err := st.Cleanup().HardDeleteExpiredSessions(ctx)
+		n, err := st.Cleanup().HardDeleteExpiredSessions(ctx, time.Now().UTC())
 		require.NoError(t, err)
 		assert.Equal(t, int64(1), n)
 	})
@@ -272,7 +272,7 @@ func (s *Suite) testCleanup(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		_, err = st.Cleanup().DeleteExpiredOAuthStates(ctx)
+		_, err = st.Cleanup().DeleteExpiredOAuthStates(ctx, time.Now().UTC())
 		require.NoError(t, err)
 
 		_, err = st.OAuthStates().Get(ctx, state)
@@ -300,7 +300,7 @@ func (s *Suite) testCleanup(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		_, err = st.Cleanup().DeleteExpiredPendingOAuthSignups(ctx)
+		_, err = st.Cleanup().DeleteExpiredPendingOAuthSignups(ctx, time.Now().UTC())
 		require.NoError(t, err)
 
 		_, err = st.PendingOAuthSignups().Get(ctx, token)
@@ -311,7 +311,7 @@ func (s *Suite) testCleanup(t *testing.T) {
 		st := s.NewStore(t)
 		cutoff := time.Now()
 
-		n, err := st.Cleanup().HardDeleteExpiredSessions(ctx)
+		n, err := st.Cleanup().HardDeleteExpiredSessions(ctx, time.Now().UTC())
 		require.NoError(t, err)
 		assert.Equal(t, int64(0), n)
 
@@ -352,12 +352,12 @@ func (s *Suite) testCleanup(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		n, err := st.Cleanup().HardDeleteExpiredSessions(ctx)
+		n, err := st.Cleanup().HardDeleteExpiredSessions(ctx, time.Now().UTC())
 		require.NoError(t, err)
 		assert.Equal(t, int64(1), n)
 
 		// Active session should still exist.
-		_, err = st.Sessions().GetByID(ctx, activeSess.ID)
+		_, err = st.Sessions().GetByID(ctx, activeSess.ID, time.Now().UTC())
 		require.NoError(t, err)
 	})
 

--- a/backend/internal/hub/store/storetest/test_cleanup.go
+++ b/backend/internal/hub/store/storetest/test_cleanup.go
@@ -137,11 +137,12 @@ func (s *Suite) testCleanup(t *testing.T) {
 		// expires_at is older than retention, so this exercises the
 		// "expired-and-aged-out" path.
 		past := time.Now().Add(-48 * time.Hour).UTC()
-		err := st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
+		_, err := st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
 			ID:                    user.ID,
 			PendingEmail:          "stale@example.com",
 			PendingEmailToken:     "ABC123",
 			PendingEmailExpiresAt: &past,
+			CooldownCutoff:        store.UnconditionalMintCutoff(),
 		})
 		require.NoError(t, err)
 
@@ -159,6 +160,43 @@ func (s *Suite) testCleanup(t *testing.T) {
 		assert.Zero(t, got.PendingEmailAttempts)
 	})
 
+	// A send the relay refused leaves the ADDRESS with no token and no
+	// expiry, so the expiry compare can never see it. Without the second
+	// arm that row outlived the database: the sweep it is subject to
+	// matched neither predicate, and an abandoned address stayed forever.
+	t.Run("clear stale pending emails reaps a codeless address", func(t *testing.T) {
+		st := s.NewStore(t)
+		user := SeedUser(t, st, "cleanup-codeless-pending-user")
+
+		expires := time.Now().Add(30 * time.Minute).UTC()
+		minted, err := st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
+			ID:                    user.ID,
+			PendingEmail:          "undelivered@example.com",
+			PendingEmailToken:     "DEAD12",
+			PendingEmailExpiresAt: &expires,
+			CooldownCutoff:        store.UnconditionalMintCutoff(),
+		})
+		require.NoError(t, err)
+		require.True(t, minted)
+		// The failed-send state: the code is gone, the address remains.
+		require.NoError(t, st.Users().ClearPendingEmailCode(ctx, user.ID))
+
+		// A cutoff before the row's updated_at leaves it alone: the address
+		// is recent, and the user can still ask for a fresh code.
+		n, err := st.Cleanup().ClearStalePendingEmails(ctx, time.Now().Add(-24*time.Hour))
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), n, "a recent codeless address is not stale yet")
+
+		// A cutoff past it reaps the address.
+		n, err = st.Cleanup().ClearStalePendingEmails(ctx, time.Now().Add(24*time.Hour))
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), n)
+
+		got, err := st.Users().GetByID(ctx, user.ID)
+		require.NoError(t, err)
+		assert.Empty(t, got.PendingEmail, "an abandoned address must not outlive the retention window")
+	})
+
 	t.Run("clear stale pending emails skips live ones", func(t *testing.T) {
 		st := s.NewStore(t)
 		user := SeedUser(t, st, "cleanup-live-pending-user")
@@ -167,11 +205,12 @@ func (s *Suite) testCleanup(t *testing.T) {
 		// — the code is still usable and wiping it would silently lock
 		// the user out of completing verification.
 		future := time.Now().Add(15 * time.Minute).UTC()
-		err := st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
+		_, err := st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
 			ID:                    user.ID,
 			PendingEmail:          "still-valid@example.com",
 			PendingEmailToken:     "LIVE12",
 			PendingEmailExpiresAt: &future,
+			CooldownCutoff:        store.UnconditionalMintCutoff(),
 		})
 		require.NoError(t, err)
 

--- a/backend/internal/hub/store/storetest/test_cleanup_boundaries.go
+++ b/backend/internal/hub/store/storetest/test_cleanup_boundaries.go
@@ -289,12 +289,14 @@ func (s *Suite) testCleanupBoundaries(t *testing.T) {
 		} {
 			user := SeedUser(t, st, "boundary-email-user-"+string(rune('a'+i)))
 			expiry := expiresAt
-			require.NoError(t, st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
+			minted, err := st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
 				ID:                    user.ID,
 				PendingEmail:          user.Username + "@example.com",
 				PendingEmailToken:     "TOKEN1",
 				PendingEmailExpiresAt: &expiry,
-			}))
+				CooldownCutoff:        store.UnconditionalMintCutoff(),
+			})
+			mustSetPendingEmail(t, minted, err)
 		}
 
 		assertBoundarySweep(t, cutoff, func(c time.Time) (int64, error) {

--- a/backend/internal/hub/store/storetest/test_cli_authorizations.go
+++ b/backend/internal/hub/store/storetest/test_cli_authorizations.go
@@ -46,7 +46,7 @@ func (s *Suite) testCLIAuthorizations(t *testing.T) {
 		require.Equal(t, int64(1), rows)
 		time.Sleep(time.Until(expiresAt) + 100*time.Millisecond)
 
-		rows, err = st.DeviceAuthorizations().Consume(ctx, deviceCode)
+		rows, err = st.DeviceAuthorizations().Consume(ctx, deviceCode, time.Now().UTC())
 		require.NoError(t, err)
 		assert.Zero(t, rows)
 	})

--- a/backend/internal/hub/store/storetest/test_cli_authorizations.go
+++ b/backend/internal/hub/store/storetest/test_cli_authorizations.go
@@ -26,9 +26,43 @@ func (s *Suite) testCLIAuthorizations(t *testing.T) {
 		require.NoError(t, st.DeviceAuthorizations().Create(ctx, store.CreateDeviceAuthorizationParams{
 			DeviceCode: deviceCode, UserCode: verifycode.Generate(), ExpiresAt: expiresAt,
 		}))
-		rows, err := st.DeviceAuthorizations().Approve(ctx, store.ApproveDeviceAuthorizationParams{DeviceCode: deviceCode, UserID: userid.MustNew(user.ID)})
+		rows, err := st.DeviceAuthorizations().Approve(ctx, store.ApproveDeviceAuthorizationParams{DeviceCode: deviceCode, UserID: userid.MustNew(user.ID)}, time.Now().UTC())
 		require.NoError(t, err)
 		assert.Equal(t, int64(1), rows)
+	})
+
+	// Both approve verbs judge grant liveness on the caller's clock. The
+	// omission that left this unbound was a silent always-true predicate on
+	// sqlite/postgres/mysql and a hard `Incorrect datetime value` on TiDB,
+	// so every CLI device authorization on a TiDB hub answered 500.
+	t.Run("device grant approval judges liveness on the caller clock", func(t *testing.T) {
+		st := s.NewStore(t)
+		user := SeedUser(t, st, "device-auth-clock-user")
+		deviceCode := id.Generate()
+		userCode := verifycode.Generate()
+		require.NoError(t, st.DeviceAuthorizations().Create(ctx, store.CreateDeviceAuthorizationParams{
+			DeviceCode: deviceCode, UserCode: userCode, ExpiresAt: time.Now().Add(time.Hour),
+		}))
+		afterExpiry := time.Now().UTC().Add(48 * time.Hour)
+
+		rows, err := st.DeviceAuthorizations().Approve(ctx, store.ApproveDeviceAuthorizationParams{
+			DeviceCode: deviceCode, UserID: userid.MustNew(user.ID),
+		}, afterExpiry)
+		require.NoError(t, err)
+		assert.Zero(t, rows, "Approve must refuse a grant that is dead at the caller's clock")
+
+		rows, err = st.DeviceAuthorizations().ApproveByUserCode(ctx, store.ApproveDeviceAuthorizationByUserCodeParams{
+			UserCode: userCode, UserID: userid.MustNew(user.ID),
+		}, afterExpiry)
+		require.NoError(t, err)
+		assert.Zero(t, rows, "ApproveByUserCode must refuse a grant that is dead at the caller's clock")
+
+		// Control: the same row, at the caller's own clock.
+		rows, err = st.DeviceAuthorizations().ApproveByUserCode(ctx, store.ApproveDeviceAuthorizationByUserCodeParams{
+			UserCode: userCode, UserID: userid.MustNew(user.ID),
+		}, time.Now().UTC())
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), rows, "control: the same grant approves at a live clock")
 	})
 
 	t.Run("expired approved device grant cannot be consumed", func(t *testing.T) {
@@ -41,7 +75,7 @@ func (s *Suite) testCLIAuthorizations(t *testing.T) {
 		}))
 		rows, err := st.DeviceAuthorizations().Approve(ctx, store.ApproveDeviceAuthorizationParams{
 			DeviceCode: deviceCode, UserID: userid.MustNew(user.ID),
-		})
+		}, time.Now().UTC())
 		require.NoError(t, err)
 		require.Equal(t, int64(1), rows)
 		time.Sleep(time.Until(expiresAt) + 100*time.Millisecond)
@@ -71,11 +105,11 @@ func (s *Suite) testCLIAuthorizations(t *testing.T) {
 
 		_, err := st.DeviceAuthorizations().Approve(ctx, store.ApproveDeviceAuthorizationParams{
 			DeviceCode: deviceCode, UserID: userid.UserID{},
-		})
+		}, time.Now().UTC())
 		require.ErrorIs(t, err, store.ErrInvalidArgument)
 		_, err = st.DeviceAuthorizations().ApproveByUserCode(ctx, store.ApproveDeviceAuthorizationByUserCodeParams{
 			UserCode: userCode, UserID: userid.UserID{},
-		})
+		}, time.Now().UTC())
 		require.ErrorIs(t, err, store.ErrInvalidArgument)
 
 		// The row must be untouched -- still pending, still approvable.
@@ -86,7 +120,7 @@ func (s *Suite) testCLIAuthorizations(t *testing.T) {
 		// Control: the same row, approved by a real user.
 		rows, err := st.DeviceAuthorizations().ApproveByUserCode(ctx, store.ApproveDeviceAuthorizationByUserCodeParams{
 			UserCode: userCode, UserID: userid.MustNew(user.ID),
-		})
+		}, time.Now().UTC())
 		require.NoError(t, err)
 		assert.Equal(t, int64(1), rows, "control: a real user approves the same row")
 	})

--- a/backend/internal/hub/store/storetest/test_oauth_states.go
+++ b/backend/internal/hub/store/storetest/test_oauth_states.go
@@ -84,7 +84,7 @@ func (s *Suite) testOAuthStates(t *testing.T) {
 		require.NoError(t, err)
 
 		// Run cleanup via the Cleanup store.
-		_, err = st.Cleanup().DeleteExpiredOAuthStates(ctx)
+		_, err = st.Cleanup().DeleteExpiredOAuthStates(ctx, time.Now().UTC())
 		require.NoError(t, err)
 
 		// The expired state should be gone.

--- a/backend/internal/hub/store/storetest/test_oauth_tokens.go
+++ b/backend/internal/hub/store/storetest/test_oauth_tokens.go
@@ -95,7 +95,7 @@ func (s *Suite) testOAuthTokens(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		tokens, err := st.OAuthTokens().ListExpiring(ctx)
+		tokens, err := st.OAuthTokens().ListExpiring(ctx, time.Now().UTC().Add(5*time.Minute))
 		require.NoError(t, err)
 		assert.NotEmpty(t, tokens)
 	})
@@ -261,7 +261,7 @@ func (s *Suite) testOAuthTokens(t *testing.T) {
 	t.Run("list expiring empty", func(t *testing.T) {
 		st := s.NewStore(t)
 
-		tokens, err := st.OAuthTokens().ListExpiring(ctx)
+		tokens, err := st.OAuthTokens().ListExpiring(ctx, time.Now().UTC().Add(5*time.Minute))
 		require.NoError(t, err)
 		require.NotNil(t, tokens)
 		assert.Empty(t, tokens)

--- a/backend/internal/hub/store/storetest/test_passkeys.go
+++ b/backend/internal/hub/store/storetest/test_passkeys.go
@@ -1,0 +1,269 @@
+package storetest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/leapmux/leapmux/internal/hub/store"
+	"github.com/leapmux/leapmux/internal/hub/webauthn"
+	"github.com/leapmux/leapmux/internal/util/id"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func (s *Suite) testPasskeys(t *testing.T) {
+	t.Run("create get list count update delete", func(t *testing.T) {
+		st := s.NewStore(t)
+		user := SeedUser(t, st, "passkey-owner")
+		now := time.Now().UTC().Truncate(time.Millisecond)
+		pkID := id.Generate()
+		credID := []byte("cred-" + pkID)
+
+		require.NoError(t, st.PasskeyCredentials().Create(ctx, store.CreatePasskeyCredentialParams{
+			ID:           pkID,
+			UserID:       user.ID,
+			CredentialID: credID,
+			PublicKey:    []byte("encrypted-public-key"),
+			SignCount:    1,
+			Transports:   `["usb"]`,
+			FriendlyName: "YubiKey",
+			KeyVersion:   1,
+			CreatedAt:    now,
+		}))
+
+		got, err := st.PasskeyCredentials().GetByID(ctx, pkID)
+		require.NoError(t, err)
+		assert.Equal(t, user.ID, got.UserID)
+		assert.Equal(t, credID, got.CredentialID)
+		assert.Equal(t, []byte("encrypted-public-key"), got.PublicKey)
+		assert.EqualValues(t, 1, got.SignCount)
+		assert.Equal(t, "YubiKey", got.FriendlyName)
+
+		byCred, err := st.PasskeyCredentials().GetByCredentialID(ctx, credID)
+		require.NoError(t, err)
+		assert.Equal(t, pkID, byCred.ID)
+
+		list, err := st.PasskeyCredentials().ListByUser(ctx, user.ID)
+		require.NoError(t, err)
+		require.Len(t, list, 1)
+
+		count, err := st.PasskeyCredentials().CountByUser(ctx, user.ID)
+		require.NoError(t, err)
+		assert.EqualValues(t, 1, count)
+
+		usedAt := now.Add(time.Minute)
+		require.NoError(t, st.PasskeyCredentials().UpdateSignCount(ctx, store.UpdatePasskeySignCountParams{
+			CredentialID: credID,
+			UserID:       user.ID,
+			SignCount:    5,
+			LastUsedAt:   usedAt,
+		}))
+		got, err = st.PasskeyCredentials().GetByID(ctx, pkID)
+		require.NoError(t, err)
+		assert.EqualValues(t, 5, got.SignCount)
+		require.NotNil(t, got.LastUsedAt)
+
+		// A non-advancing target must miss (monotonic predicate).
+		err = st.PasskeyCredentials().UpdateSignCount(ctx, store.UpdatePasskeySignCountParams{
+			CredentialID: credID,
+			UserID:       user.ID,
+			SignCount:    5,
+			LastUsedAt:   usedAt,
+		})
+		assert.ErrorIs(t, err, store.ErrNotFound)
+
+		require.NoError(t, st.PasskeyCredentials().UpdateSignCount(ctx, store.UpdatePasskeySignCountParams{
+			CredentialID: credID,
+			UserID:       user.ID,
+			SignCount:    6,
+			LastUsedAt:   usedAt,
+		}))
+		got, err = st.PasskeyCredentials().GetByID(ctx, pkID)
+		require.NoError(t, err)
+		assert.EqualValues(t, 6, got.SignCount)
+
+		require.NoError(t, st.PasskeyCredentials().UpdateFriendlyName(ctx, pkID, user.ID, "Renamed"))
+		got, err = st.PasskeyCredentials().GetByID(ctx, pkID)
+		require.NoError(t, err)
+		assert.Equal(t, "Renamed", got.FriendlyName)
+
+		require.NoError(t, st.PasskeyCredentials().UpdatePublicKey(ctx, store.UpdatePasskeyPublicKeyParams{
+			ID:         pkID,
+			UserID:     user.ID,
+			PublicKey:  []byte("reencrypted"),
+			KeyVersion: 2,
+		}))
+		byVersion, err := st.PasskeyCredentials().ListByKeyVersion(ctx, 2)
+		require.NoError(t, err)
+		require.Len(t, byVersion, 1)
+		versionCount, err := st.PasskeyCredentials().CountByKeyVersion(ctx, 2)
+		require.NoError(t, err)
+		assert.EqualValues(t, 1, versionCount)
+
+		require.NoError(t, st.PasskeyCredentials().Delete(ctx, pkID, user.ID))
+		_, err = st.PasskeyCredentials().GetByID(ctx, pkID)
+		assert.ErrorIs(t, err, store.ErrNotFound)
+	})
+
+	t.Run("delete all by user", func(t *testing.T) {
+		st := s.NewStore(t)
+		user := SeedUser(t, st, "passkey-multi")
+		now := time.Now().UTC()
+		for i := 0; i < 2; i++ {
+			pkID := id.Generate()
+			require.NoError(t, st.PasskeyCredentials().Create(ctx, store.CreatePasskeyCredentialParams{
+				ID:           pkID,
+				UserID:       user.ID,
+				CredentialID: []byte("multi-" + pkID),
+				PublicKey:    []byte("pk"),
+				Transports:   "[]",
+				FriendlyName: "pk",
+				KeyVersion:   1,
+				CreatedAt:    now,
+			}))
+		}
+		require.NoError(t, st.PasskeyCredentials().DeleteAllByUser(ctx, user.ID))
+		count, err := st.PasskeyCredentials().CountByUser(ctx, user.ID)
+		require.NoError(t, err)
+		assert.EqualValues(t, 0, count)
+	})
+
+	t.Run("webauthn session create get delete", func(t *testing.T) {
+		st := s.NewStore(t)
+		user := SeedUser(t, st, "wa-session")
+		sessionID := id.Generate()
+		now := time.Now().UTC()
+		require.NoError(t, st.WebAuthnSessions().Create(ctx, store.CreateWebAuthnSessionParams{
+			ID:          sessionID,
+			Kind:        "login",
+			UserID:      user.ID,
+			PayloadJSON: "{}",
+			SessionData: []byte("encrypted-session"),
+			ExpiresAt:   now.Add(5 * time.Minute),
+			CreatedAt:   now,
+		}))
+
+		got, err := st.WebAuthnSessions().Get(ctx, sessionID)
+		require.NoError(t, err)
+		assert.Equal(t, "login", got.Kind)
+		assert.Equal(t, []byte("encrypted-session"), got.SessionData)
+
+		require.NoError(t, st.WebAuthnSessions().Delete(ctx, sessionID))
+		_, err = st.WebAuthnSessions().Get(ctx, sessionID)
+		assert.ErrorIs(t, err, store.ErrNotFound)
+	})
+
+	t.Run("consume reauth proof is single use", func(t *testing.T) {
+		st := s.NewStore(t)
+		user := SeedUser(t, st, "wa-proof")
+		proofID := id.Generate()
+		now := time.Now().UTC()
+		require.NoError(t, st.WebAuthnSessions().Create(ctx, store.CreateWebAuthnSessionParams{
+			ID:          proofID,
+			Kind:        "reauth_proof",
+			UserID:      user.ID,
+			PayloadJSON: "{}",
+			SessionData: []byte("proof"),
+			ExpiresAt:   now.Add(2 * time.Minute),
+			CreatedAt:   now,
+		}))
+
+		n, err := st.WebAuthnSessions().ConsumeProof(ctx, proofID, user.ID, webauthn.KindReauthProof, time.Now().UTC())
+		require.NoError(t, err)
+		assert.EqualValues(t, 1, n)
+
+		n, err = st.WebAuthnSessions().ConsumeProof(ctx, proofID, user.ID, webauthn.KindReauthProof, time.Now().UTC())
+		require.NoError(t, err)
+		assert.EqualValues(t, 0, n, "replay must delete zero rows")
+	})
+
+	t.Run("consume reauth proof rejects wrong user or expired", func(t *testing.T) {
+		st := s.NewStore(t)
+		owner := SeedUser(t, st, "wa-proof-owner")
+		other := SeedUser(t, st, "wa-proof-other")
+		now := time.Now().UTC()
+
+		liveID := id.Generate()
+		require.NoError(t, st.WebAuthnSessions().Create(ctx, store.CreateWebAuthnSessionParams{
+			ID:          liveID,
+			Kind:        "reauth_proof",
+			UserID:      owner.ID,
+			PayloadJSON: "{}",
+			SessionData: []byte("proof"),
+			ExpiresAt:   now.Add(2 * time.Minute),
+			CreatedAt:   now,
+		}))
+		n, err := st.WebAuthnSessions().ConsumeProof(ctx, liveID, other.ID, webauthn.KindReauthProof, time.Now().UTC())
+		require.NoError(t, err)
+		assert.EqualValues(t, 0, n)
+
+		expiredID := id.Generate()
+		require.NoError(t, st.WebAuthnSessions().Create(ctx, store.CreateWebAuthnSessionParams{
+			ID:          expiredID,
+			Kind:        "reauth_proof",
+			UserID:      owner.ID,
+			PayloadJSON: "{}",
+			SessionData: []byte("proof"),
+			ExpiresAt:   now.Add(-time.Minute),
+			CreatedAt:   now.Add(-2 * time.Minute),
+		}))
+		n, err = st.WebAuthnSessions().ConsumeProof(ctx, expiredID, owner.ID, webauthn.KindReauthProof, time.Now().UTC())
+		require.NoError(t, err)
+		assert.EqualValues(t, 0, n)
+	})
+
+	t.Run("consume ceremony session is single use", func(t *testing.T) {
+		st := s.NewStore(t)
+		user := SeedUser(t, st, "wa-ceremony")
+		sessionID := id.Generate()
+		now := time.Now().UTC()
+		require.NoError(t, st.WebAuthnSessions().Create(ctx, store.CreateWebAuthnSessionParams{
+			ID:          sessionID,
+			Kind:        "login",
+			UserID:      user.ID,
+			PayloadJSON: "{}",
+			SessionData: []byte("ceremony"),
+			ExpiresAt:   now.Add(5 * time.Minute),
+			CreatedAt:   now,
+		}))
+
+		n, err := st.WebAuthnSessions().ConsumeCeremony(ctx, sessionID, "login", time.Now().UTC())
+		require.NoError(t, err)
+		assert.EqualValues(t, 1, n)
+
+		n, err = st.WebAuthnSessions().ConsumeCeremony(ctx, sessionID, "login", time.Now().UTC())
+		require.NoError(t, err)
+		assert.EqualValues(t, 0, n)
+
+		n, err = st.WebAuthnSessions().ConsumeCeremony(ctx, sessionID, "register", time.Now().UTC())
+		require.NoError(t, err)
+		assert.EqualValues(t, 0, n)
+	})
+
+	t.Run("delete by user and kind leaves other kinds", func(t *testing.T) {
+		st := s.NewStore(t)
+		user := SeedUser(t, st, "wa-kind")
+		now := time.Now().UTC()
+		reauthID := id.Generate()
+		proofID := id.Generate()
+		require.NoError(t, st.WebAuthnSessions().Create(ctx, store.CreateWebAuthnSessionParams{
+			ID: reauthID, Kind: "reauth", UserID: user.ID, PayloadJSON: "{}",
+			SessionData: []byte("reauth"), ExpiresAt: now.Add(time.Minute), CreatedAt: now,
+		}))
+		require.NoError(t, st.WebAuthnSessions().Create(ctx, store.CreateWebAuthnSessionParams{
+			ID: proofID, Kind: "reauth_proof", UserID: user.ID, PayloadJSON: "{}",
+			SessionData: []byte("proof"), ExpiresAt: now.Add(time.Minute), CreatedAt: now,
+		}))
+		require.NoError(t, st.WebAuthnSessions().DeleteByUserAndKind(ctx, user.ID, "reauth"))
+		_, err := st.WebAuthnSessions().Get(ctx, reauthID)
+		assert.ErrorIs(t, err, store.ErrNotFound)
+		_, err = st.WebAuthnSessions().Get(ctx, proofID)
+		require.NoError(t, err)
+	})
+
+	t.Run("blank user id refused on passkey list", func(t *testing.T) {
+		st := s.NewStore(t)
+		_, err := st.PasskeyCredentials().ListByUser(ctx, "")
+		assert.ErrorIs(t, err, store.ErrInvalidArgument)
+	})
+}

--- a/backend/internal/hub/store/storetest/test_password_reset.go
+++ b/backend/internal/hub/store/storetest/test_password_reset.go
@@ -1,0 +1,188 @@
+package storetest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/leapmux/leapmux/internal/hub/store"
+)
+
+func hashFor(s string) string { return "hash-" + s }
+
+// farFutureCutoff lets a seeded mint always land: the conditional write
+// compares the previous expiry against this cutoff.
+func farFutureCutoff() time.Time { return time.Now().Add(48 * time.Hour).UTC() }
+
+// testPasswordResetStore pins the password-reset user-store queries across
+// every dialect: the token-keyed consume (attempts increment, force-expiry
+// past the budget, ErrNotFound for a cleared or unknown token), the
+// conditional mint's cooldown gate, the completion clear, and the manual
+// clear.
+func (s *Suite) testPasswordResetStore(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("consume by token charges attempts and force-expires", func(t *testing.T) {
+		st := s.NewStore(t)
+		user := SeedUser(t, st, "reset-consume-user")
+		token := "tok-" + user.ID
+
+		// Seed the expiry far in the future: the consume's liveness
+		// predicate compares against the DATABASE clock, and a seed near
+		// "now" can lose to container clock skew.
+		minted, err := st.Users().SetPendingPasswordReset(ctx, store.SetPendingPasswordResetParams{
+			ID:                            user.ID,
+			PendingPasswordResetToken:     token,
+			PendingPasswordResetExpiresAt: time.Now().Add(24 * time.Hour).UTC(),
+			CooldownCutoff:                farFutureCutoff(),
+		})
+		require.NoError(t, err)
+		require.True(t, minted)
+
+		for i := 1; i <= 6; i++ {
+			charged, err := st.Users().ConsumePasswordResetAttemptByToken(ctx, token, time.Now().UTC(), 5)
+			require.NoErrorf(t, err, "consume iteration %d failed", i)
+			assert.Equal(t, user.ID, charged.ID)
+			assert.Equal(t, int64(i), charged.PendingPasswordResetAttempts)
+		}
+
+		// The 6th charge force-expired the row in SQL (attempts + 1 > 5
+		// sets expires_at = now), so the next consume finds no live row.
+		_, err = st.Users().ConsumePasswordResetAttemptByToken(ctx, token, time.Now().UTC(), 5)
+		require.ErrorIs(t, err, store.ErrNotFound)
+	})
+
+	t.Run("consume by token rejects cleared and unknown tokens", func(t *testing.T) {
+		st := s.NewStore(t)
+		user := SeedUser(t, st, "reset-miss-user")
+
+		_, err := st.Users().ConsumePasswordResetAttemptByToken(ctx, "tok-unknown", time.Now().UTC(), 5)
+		require.ErrorIs(t, err, store.ErrNotFound)
+
+		minted, err := st.Users().SetPendingPasswordReset(ctx, store.SetPendingPasswordResetParams{
+			ID:                            user.ID,
+			PendingPasswordResetToken:     "tok-live",
+			PendingPasswordResetExpiresAt: time.Now().Add(time.Hour).UTC(),
+			CooldownCutoff:                farFutureCutoff(),
+		})
+		require.NoError(t, err)
+		require.True(t, minted)
+		require.NoError(t, st.Users().ClearPendingPasswordReset(ctx, user.ID))
+		_, err = st.Users().ConsumePasswordResetAttemptByToken(ctx, "tok-live", time.Now().UTC(), 5)
+		require.ErrorIs(t, err, store.ErrNotFound)
+	})
+
+	t.Run("attempt budget comes from the caller, not the SQL text", func(t *testing.T) {
+		st := s.NewStore(t)
+		user := SeedUser(t, st, "reset-budget-user")
+
+		minted, err := st.Users().SetPendingPasswordReset(ctx, store.SetPendingPasswordResetParams{
+			ID:                            user.ID,
+			PendingPasswordResetToken:     "tok-budget",
+			PendingPasswordResetExpiresAt: time.Now().Add(24 * time.Hour).UTC(),
+			CooldownCutoff:                farFutureCutoff(),
+		})
+		require.NoError(t, err)
+		require.True(t, minted)
+
+		// A budget of 2 force-expires at the third charge (2 + 1 > 2 in
+		// the SQL CASE, whose threshold rides the bound max_attempts
+		// argument instead of a literal), and the row's liveness WHERE
+		// sees the forced expiry on the NEXT charge: under the default
+		// budget of 5 neither would happen for another two charges.
+		for i := 1; i <= 3; i++ {
+			charged, err := st.Users().ConsumePasswordResetAttemptByToken(ctx, "tok-budget", time.Now().UTC(), 2)
+			require.NoErrorf(t, err, "charge %d failed", i)
+			assert.Equal(t, int64(i), charged.PendingPasswordResetAttempts)
+		}
+		_, err = st.Users().ConsumePasswordResetAttemptByToken(ctx, "tok-budget", time.Now().UTC(), 2)
+		require.ErrorIs(t, err, store.ErrNotFound)
+	})
+
+	t.Run("conditional mint refuses a token inside the cooldown window", func(t *testing.T) {
+		st := s.NewStore(t)
+		user := SeedUser(t, st, "reset-mint-user")
+
+		// First mint: no previous token exists, so any cutoff passes.
+		minted, err := st.Users().SetPendingPasswordReset(ctx, store.SetPendingPasswordResetParams{
+			ID:                            user.ID,
+			PendingPasswordResetToken:     "tok-first",
+			PendingPasswordResetExpiresAt: time.Now().Add(time.Hour).UTC(),
+			CooldownCutoff:                time.Now().UTC(),
+		})
+		require.NoError(t, err)
+		require.True(t, minted)
+
+		// The previous token expires in one hour; a cutoff before that
+		// expiry means the cooldown has not elapsed, so the mint must
+		// refuse and the FIRST token must survive.
+		minted, err = st.Users().SetPendingPasswordReset(ctx, store.SetPendingPasswordResetParams{
+			ID:                            user.ID,
+			PendingPasswordResetToken:     "tok-second",
+			PendingPasswordResetExpiresAt: time.Now().Add(2 * time.Hour).UTC(),
+			CooldownCutoff:                time.Now().UTC(),
+		})
+		require.NoError(t, err)
+		require.False(t, minted)
+
+		after, err := st.Users().GetByID(ctx, user.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "tok-first", after.PendingPasswordResetToken)
+
+		// Once the previous expiry is at or before the cutoff (the cooldown
+		// elapsed), the mint lands and replaces the token.
+		minted, err = st.Users().SetPendingPasswordReset(ctx, store.SetPendingPasswordResetParams{
+			ID:                            user.ID,
+			PendingPasswordResetToken:     "tok-third",
+			PendingPasswordResetExpiresAt: time.Now().Add(2 * time.Hour).UTC(),
+			CooldownCutoff:                time.Now().Add(time.Hour).UTC(),
+		})
+		require.NoError(t, err)
+		require.True(t, minted)
+
+		after, err = st.Users().GetByID(ctx, user.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "tok-third", after.PendingPasswordResetToken)
+	})
+
+	t.Run("complete rotates password and clears the pending row", func(t *testing.T) {
+		st := s.NewStore(t)
+		user := SeedUser(t, st, "reset-complete-user")
+		token := "tok-complete"
+		minted, err := st.Users().SetPendingPasswordReset(ctx, store.SetPendingPasswordResetParams{
+			ID:                            user.ID,
+			PendingPasswordResetToken:     token,
+			PendingPasswordResetExpiresAt: time.Now().Add(time.Hour).UTC(),
+			CooldownCutoff:                farFutureCutoff(),
+		})
+		require.NoError(t, err)
+		require.True(t, minted)
+
+		revoked, err := st.Users().CompletePasswordReset(ctx, store.CompletePasswordResetParams{
+			ID:                        user.ID,
+			PasswordHash:              hashFor("newpass"),
+			PendingPasswordResetToken: token,
+		})
+		require.NoError(t, err)
+		assert.NotZero(t, revoked.AuthGeneration)
+
+		after, err := st.Users().GetByID(ctx, user.ID)
+		require.NoError(t, err)
+		assert.Equal(t, hashFor("newpass"), after.PasswordHash)
+		assert.True(t, after.PasswordSet)
+		assert.Empty(t, after.PendingPasswordResetToken)
+		assert.Nil(t, after.PendingPasswordResetExpiresAt)
+		assert.Zero(t, after.PendingPasswordResetAttempts)
+
+		// A replayed completion matches no row.
+		_, err = st.Users().CompletePasswordReset(ctx, store.CompletePasswordResetParams{
+			ID:                        user.ID,
+			PasswordHash:              hashFor("replay"),
+			PendingPasswordResetToken: token,
+		})
+		require.ErrorIs(t, err, store.ErrNotFound)
+	})
+}

--- a/backend/internal/hub/store/storetest/test_password_reset.go
+++ b/backend/internal/hub/store/storetest/test_password_reset.go
@@ -13,10 +13,6 @@ import (
 
 func hashFor(s string) string { return "hash-" + s }
 
-// farFutureCutoff lets a seeded mint always land: the conditional write
-// compares the previous expiry against this cutoff.
-func farFutureCutoff() time.Time { return time.Now().Add(48 * time.Hour).UTC() }
-
 // testPasswordResetStore pins the password-reset user-store queries across
 // every dialect: the token-keyed consume (attempts increment, force-expiry
 // past the budget, ErrNotFound for a cleared or unknown token), the
@@ -37,7 +33,7 @@ func (s *Suite) testPasswordResetStore(t *testing.T) {
 			ID:                            user.ID,
 			PendingPasswordResetToken:     token,
 			PendingPasswordResetExpiresAt: time.Now().Add(24 * time.Hour).UTC(),
-			CooldownCutoff:                farFutureCutoff(),
+			CooldownCutoff:                store.UnconditionalMintCutoff(),
 		})
 		require.NoError(t, err)
 		require.True(t, minted)
@@ -66,7 +62,7 @@ func (s *Suite) testPasswordResetStore(t *testing.T) {
 			ID:                            user.ID,
 			PendingPasswordResetToken:     "tok-live",
 			PendingPasswordResetExpiresAt: time.Now().Add(time.Hour).UTC(),
-			CooldownCutoff:                farFutureCutoff(),
+			CooldownCutoff:                store.UnconditionalMintCutoff(),
 		})
 		require.NoError(t, err)
 		require.True(t, minted)
@@ -83,7 +79,7 @@ func (s *Suite) testPasswordResetStore(t *testing.T) {
 			ID:                            user.ID,
 			PendingPasswordResetToken:     "tok-budget",
 			PendingPasswordResetExpiresAt: time.Now().Add(24 * time.Hour).UTC(),
-			CooldownCutoff:                farFutureCutoff(),
+			CooldownCutoff:                store.UnconditionalMintCutoff(),
 		})
 		require.NoError(t, err)
 		require.True(t, minted)
@@ -156,7 +152,7 @@ func (s *Suite) testPasswordResetStore(t *testing.T) {
 			ID:                            user.ID,
 			PendingPasswordResetToken:     token,
 			PendingPasswordResetExpiresAt: time.Now().Add(time.Hour).UTC(),
-			CooldownCutoff:                farFutureCutoff(),
+			CooldownCutoff:                store.UnconditionalMintCutoff(),
 		})
 		require.NoError(t, err)
 		require.True(t, minted)

--- a/backend/internal/hub/store/storetest/test_pending_oauth_signups.go
+++ b/backend/internal/hub/store/storetest/test_pending_oauth_signups.go
@@ -112,7 +112,7 @@ func (s *Suite) testPendingOAuthSignups(t *testing.T) {
 		require.NoError(t, err)
 
 		// Run cleanup.
-		_, err = st.Cleanup().DeleteExpiredPendingOAuthSignups(ctx)
+		_, err = st.Cleanup().DeleteExpiredPendingOAuthSignups(ctx, time.Now().UTC())
 		require.NoError(t, err)
 
 		// The expired signup should be gone.

--- a/backend/internal/hub/store/storetest/test_sessions.go
+++ b/backend/internal/hub/store/storetest/test_sessions.go
@@ -52,6 +52,45 @@ func (s *Suite) testSessions(t *testing.T) {
 		assert.ErrorIs(t, err, store.ErrNotFound, "a session past the caller's clock must not resolve")
 	})
 
+	// The three session reads and the touch all bind the caller's clock the
+	// same way GetByID does. Each one is asserted at a caller clock past the
+	// row's expiry, because the omission that made these predicates
+	// unconditional was invisible on sqlite/postgres/mysql (silently
+	// always-true) and a hard error only on TiDB.
+	t.Run("session listings and touch judge liveness on the caller clock", func(t *testing.T) {
+		st := s.NewStore(t)
+		user := SeedUser(t, st, "sess-clock-listing-user")
+		sess := SeedSession(t, st, user.ID)
+		afterExpiry := time.Now().UTC().Add(48 * time.Hour)
+
+		live, err := st.Sessions().ListAllActive(ctx, store.ListAllActiveSessionsParams{
+			PageParams: store.PageParams{Limit: 10},
+		}, time.Now().UTC())
+		require.NoError(t, err)
+		require.Len(t, live.Rows, 1, "control: the row is live at the caller's own clock")
+
+		dead, err := st.Sessions().ListAllActive(ctx, store.ListAllActiveSessionsParams{
+			PageParams: store.PageParams{Limit: 10},
+		}, afterExpiry)
+		require.NoError(t, err)
+		assert.Empty(t, dead.Rows, "ListAllActive must exclude a session past the caller's clock")
+
+		byUser, err := st.Sessions().ListByUserID(ctx, store.ListUserSessionsParams{
+			UserID:     userid.MustNew(user.ID),
+			PageParams: store.PageParams{Limit: 10},
+		}, afterExpiry)
+		require.NoError(t, err)
+		assert.Empty(t, byUser.Rows, "ListByUserID must exclude a session past the caller's clock")
+
+		n, err := st.Sessions().Touch(ctx, store.TouchSessionParams{
+			ID:           sess.ID,
+			ExpiresAt:    afterExpiry.Add(time.Hour),
+			LastActiveAt: afterExpiry,
+		}, afterExpiry)
+		require.NoError(t, err)
+		assert.Zero(t, n, "Touch must not revive a session that is dead at the caller's clock")
+	})
+
 	t.Run("touch", func(t *testing.T) {
 		st := s.NewStore(t)
 		user := SeedUser(t, st, "touch-user")
@@ -65,8 +104,7 @@ func (s *Suite) testSessions(t *testing.T) {
 			ID:           sess.ID,
 			ExpiresAt:    newExpiry,
 			LastActiveAt: newActive,
-			Now:          time.Now().UTC(),
-		})
+		}, time.Now().UTC())
 		require.NoError(t, err)
 		assert.Equal(t, int64(1), n, "a matched touch reports one updated row")
 
@@ -244,8 +282,7 @@ func (s *Suite) testSessions(t *testing.T) {
 
 		page, err := st.Sessions().ListAllActive(ctx, store.ListAllActiveSessionsParams{
 			PageParams: store.PageParams{Limit: 100},
-			Now:        time.Now().UTC(),
-		})
+		}, time.Now().UTC())
 		require.NoError(t, err)
 		sessions := page.Rows
 		assert.GreaterOrEqual(t, len(sessions), 2)
@@ -289,8 +326,7 @@ func (s *Suite) testSessions(t *testing.T) {
 			ID:           sess.ID,
 			ExpiresAt:    newExpiry,
 			LastActiveAt: futureActive,
-			Now:          time.Now().UTC(),
-		})
+		}, time.Now().UTC())
 		require.NoError(t, err)
 		assert.Equal(t, int64(1), n, "the first (matching) touch updates one row")
 
@@ -308,8 +344,7 @@ func (s *Suite) testSessions(t *testing.T) {
 			ID:           sess.ID,
 			ExpiresAt:    staleExpiry,
 			LastActiveAt: staleActive,
-			Now:          time.Now().UTC(),
-		})
+		}, time.Now().UTC())
 		require.NoError(t, err)
 		assert.Equal(t, int64(0), n, "a stale (below-threshold) touch matches no row")
 
@@ -341,8 +376,7 @@ func (s *Suite) testSessions(t *testing.T) {
 			ID:           sessID,
 			ExpiresAt:    time.Now().Add(48 * time.Hour),
 			LastActiveAt: time.Now().Add(time.Minute),
-			Now:          time.Now().UTC(),
-		})
+		}, time.Now().UTC())
 		require.NoError(t, err)
 		assert.Equal(t, int64(0), n, "an expired session must match no row")
 
@@ -359,8 +393,7 @@ func (s *Suite) testSessions(t *testing.T) {
 			ID:           "nonexistent-sess",
 			ExpiresAt:    time.Now().Add(24 * time.Hour),
 			LastActiveAt: time.Now(),
-			Now:          time.Now().UTC(),
-		})
+		}, time.Now().UTC())
 		require.NoError(t, err)
 		assert.Equal(t, int64(0), n, "touching a missing session matches no row")
 	})
@@ -377,8 +410,7 @@ func (s *Suite) testSessions(t *testing.T) {
 				ID:           sess.ID,
 				ExpiresAt:    newExpiry,
 				LastActiveAt: time.Now().Add(1 * time.Minute),
-				Now:          time.Now().UTC(),
-			})
+			}, time.Now().UTC())
 			require.NoError(t, err)
 			assert.Equal(t, int64(1), n, "the in-transaction touch updates one row before rollback")
 			return rollbackErr
@@ -412,8 +444,7 @@ func (s *Suite) testSessions(t *testing.T) {
 
 		page, err := st.Sessions().ListAllActive(ctx, store.ListAllActiveSessionsParams{
 			PageParams: store.PageParams{Limit: 100},
-			Now:        time.Now().UTC(),
-		})
+		}, time.Now().UTC())
 		require.NoError(t, err)
 		require.NotNil(t, page.Rows)
 		assert.Empty(t, page.Rows)
@@ -439,8 +470,7 @@ func (s *Suite) testSessions(t *testing.T) {
 
 		page, err := st.Sessions().ListAllActive(ctx, store.ListAllActiveSessionsParams{
 			PageParams: store.PageParams{Limit: 100},
-			Now:        time.Now().UTC(),
-		})
+		}, time.Now().UTC())
 		require.NoError(t, err)
 		// Only the valid session should appear.
 		require.Len(t, page.Rows, 1)
@@ -456,7 +486,7 @@ func (s *Suite) testSessions(t *testing.T) {
 
 		page, err := st.Sessions().ListAllActive(ctx, store.ListAllActiveSessionsParams{
 			PageParams: store.PageParams{Limit: 2},
-		})
+		}, time.Now().UTC())
 		require.NoError(t, err)
 		assert.Len(t, page.Rows, 2)
 	})
@@ -487,8 +517,7 @@ func (s *Suite) testSessions(t *testing.T) {
 
 		page, err := st.Sessions().ListAllActive(ctx, store.ListAllActiveSessionsParams{
 			PageParams: store.PageParams{Limit: 100},
-			Now:        time.Now().UTC(),
-		})
+		}, time.Now().UTC())
 		require.NoError(t, err)
 		// The soft-deleted user's still-live session must surface for operator audit
 		// (LEFT JOIN with u.deleted_at IS NULL in the join condition, NOT an INNER
@@ -547,14 +576,14 @@ func (s *Suite) testSessions(t *testing.T) {
 		// ListByUserID pages on (last_active_at DESC, id DESC) -- NOT
 		// created_at; a wrong PageCursor column or ORDER BY would misorder or
 		// drop rows across this boundary.
-		page, err := st.Sessions().ListByUserID(ctx, store.ListUserSessionsParams{UserID: userid.MustNew(user.ID), PageParams: store.PageParams{Limit: 2}, Now: time.Now().UTC()})
+		page, err := st.Sessions().ListByUserID(ctx, store.ListUserSessionsParams{UserID: userid.MustNew(user.ID), PageParams: store.PageParams{Limit: 2}}, time.Now().UTC())
 		require.NoError(t, err)
 		require.Len(t, page.Rows, 2)
 		assert.Equal(t, s3.ID, page.Rows[0].ID)
 		assert.Equal(t, s2.ID, page.Rows[1].ID)
 		require.True(t, page.HasMore())
 
-		page, err = st.Sessions().ListByUserID(ctx, store.ListUserSessionsParams{UserID: userid.MustNew(user.ID), PageParams: store.PageParams{Cursor: page.NextCursor, Limit: 2}, Now: time.Now().UTC()})
+		page, err = st.Sessions().ListByUserID(ctx, store.ListUserSessionsParams{UserID: userid.MustNew(user.ID), PageParams: store.PageParams{Cursor: page.NextCursor, Limit: 2}}, time.Now().UTC())
 		require.NoError(t, err)
 		require.Len(t, page.Rows, 1)
 		assert.Equal(t, s1.ID, page.Rows[0].ID)
@@ -585,7 +614,7 @@ func (s *Suite) testSessions(t *testing.T) {
 		// First page: newest first, so the last two seeds in reverse order.
 		res1, err := st.Sessions().ListAllActive(ctx, store.ListAllActiveSessionsParams{
 			PageParams: store.PageParams{Limit: 2},
-		})
+		}, time.Now().UTC())
 		require.NoError(t, err)
 		assert.True(t, res1.HasMore())
 		page1 := res1.Rows
@@ -597,7 +626,7 @@ func (s *Suite) testSessions(t *testing.T) {
 		cursor := store.EncodeCursor(page1[len(page1)-1].LastActiveAt, page1[len(page1)-1].ID)
 		res2, err := st.Sessions().ListAllActive(ctx, store.ListAllActiveSessionsParams{
 			PageParams: store.PageParams{Cursor: cursor, Limit: 2},
-		})
+		}, time.Now().UTC())
 		require.NoError(t, err)
 		page2 := res2.Rows
 		require.Len(t, page2, 1)
@@ -622,7 +651,7 @@ func (s *Suite) testSessions(t *testing.T) {
 		seen := pageThroughByOne(t, func(cursor string) (store.Page[store.ActiveSession], error) {
 			return st.Sessions().ListAllActive(ctx, store.ListAllActiveSessionsParams{
 				PageParams: store.PageParams{Cursor: cursor, Limit: 1},
-			})
+			}, time.Now().UTC())
 		})
 		assert.ElementsMatch(t, []string{older.ID, tiedA.ID, tiedB.ID}, seen,
 			"same-millisecond sessions must not be skipped across page boundaries")
@@ -661,7 +690,7 @@ func (s *Suite) testSessions(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				_, err := st.Sessions().ListAllActive(ctx, store.ListAllActiveSessionsParams{
 					PageParams: store.PageParams{Cursor: bad, Limit: 10},
-				})
+				}, time.Now().UTC())
 				assert.ErrorIs(t, err, store.ErrInvalidCursor,
 					"cursor %q must surface as ErrInvalidCursor, not a generic store fault", bad)
 			})

--- a/backend/internal/hub/store/storetest/test_sessions.go
+++ b/backend/internal/hub/store/storetest/test_sessions.go
@@ -20,7 +20,7 @@ func (s *Suite) testSessions(t *testing.T) {
 		user := SeedUser(t, st, "sess-user")
 		sess := SeedSession(t, st, user.ID)
 
-		found, err := st.Sessions().GetByID(ctx, sess.ID)
+		found, err := st.Sessions().GetByID(ctx, sess.ID, time.Now().UTC())
 		require.NoError(t, err)
 		assert.Equal(t, sess.ID, found.ID)
 		assert.Equal(t, user.ID, found.UserID)
@@ -32,8 +32,24 @@ func (s *Suite) testSessions(t *testing.T) {
 
 	t.Run("get by id not found", func(t *testing.T) {
 		st := s.NewStore(t)
-		_, err := st.Sessions().GetByID(ctx, "nonexistent")
+		_, err := st.Sessions().GetByID(ctx, "nonexistent", time.Now().UTC())
 		assert.ErrorIs(t, err, store.ErrNotFound)
+	})
+
+	t.Run("liveness follows the caller's clock, not the database clock", func(t *testing.T) {
+		st := s.NewStore(t)
+		user := SeedUser(t, st, "sess-clock-user")
+		sess := SeedSession(t, st, user.ID)
+
+		// The same row is live at now and dead two days later: the bound
+		// clock parameter decides, which is what keeps hub/database clock
+		// skew from shifting session TTLs.
+		found, err := st.Sessions().GetByID(ctx, sess.ID, time.Now().UTC())
+		require.NoError(t, err)
+		assert.Equal(t, sess.ID, found.ID)
+
+		_, err = st.Sessions().GetByID(ctx, sess.ID, time.Now().UTC().Add(48*time.Hour))
+		assert.ErrorIs(t, err, store.ErrNotFound, "a session past the caller's clock must not resolve")
 	})
 
 	t.Run("touch", func(t *testing.T) {
@@ -49,11 +65,12 @@ func (s *Suite) testSessions(t *testing.T) {
 			ID:           sess.ID,
 			ExpiresAt:    newExpiry,
 			LastActiveAt: newActive,
+			Now:          time.Now().UTC(),
 		})
 		require.NoError(t, err)
 		assert.Equal(t, int64(1), n, "a matched touch reports one updated row")
 
-		updated, err := st.Sessions().GetByID(ctx, sess.ID)
+		updated, err := st.Sessions().GetByID(ctx, sess.ID, time.Now().UTC())
 		require.NoError(t, err)
 		assert.WithinDuration(t, newExpiry, updated.ExpiresAt, time.Second)
 		// The SQL sets last_active_at to strftime('now'), not the passed value.
@@ -69,7 +86,7 @@ func (s *Suite) testSessions(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, int64(1), n)
 
-		_, err = st.Sessions().GetByID(ctx, sess.ID)
+		_, err = st.Sessions().GetByID(ctx, sess.ID, time.Now().UTC())
 		assert.ErrorIs(t, err, store.ErrNotFound)
 	})
 
@@ -160,7 +177,7 @@ func (s *Suite) testSessions(t *testing.T) {
 
 		sess := SeedSession(t, st, userID)
 
-		sw, err := st.Sessions().ValidateWithUser(ctx, sess.ID)
+		sw, err := st.Sessions().ValidateWithUser(ctx, sess.ID, time.Now().UTC())
 		require.NoError(t, err)
 		assert.Equal(t, userID, sw.UserID)
 		assert.Equal(t, "validate-user", sw.Username)
@@ -173,13 +190,13 @@ func (s *Suite) testSessions(t *testing.T) {
 		user := SeedUser(t, st, "generation-user")
 		sess := SeedSession(t, st, user.ID)
 
-		sw, err := st.Sessions().ValidateWithUser(ctx, sess.ID)
+		sw, err := st.Sessions().ValidateWithUser(ctx, sess.ID, time.Now().UTC())
 		require.NoError(t, err)
 		assert.Equal(t, int64(0), sw.AuthGeneration)
 
 		_, err = st.Users().RevokeUserTokens(ctx, userid.MustNew(user.ID))
 		require.NoError(t, err)
-		_, err = st.Sessions().ValidateWithUser(ctx, sess.ID)
+		_, err = st.Sessions().ValidateWithUser(ctx, sess.ID, time.Now().UTC())
 		assert.ErrorIs(t, err, store.ErrNotFound)
 
 		n, err := st.Sessions().RefreshAuthGeneration(ctx, store.RefreshSessionAuthGenerationParams{
@@ -189,14 +206,14 @@ func (s *Suite) testSessions(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, int64(1), n)
 
-		sw, err = st.Sessions().ValidateWithUser(ctx, sess.ID)
+		sw, err = st.Sessions().ValidateWithUser(ctx, sess.ID, time.Now().UTC())
 		require.NoError(t, err)
 		assert.Equal(t, int64(1), sw.AuthGeneration)
 	})
 
 	t.Run("validate with user not found", func(t *testing.T) {
 		st := s.NewStore(t)
-		_, err := st.Sessions().ValidateWithUser(ctx, "nonexistent")
+		_, err := st.Sessions().ValidateWithUser(ctx, "nonexistent", time.Now().UTC())
 		assert.ErrorIs(t, err, store.ErrNotFound)
 	})
 
@@ -214,7 +231,7 @@ func (s *Suite) testSessions(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		_, err = st.Sessions().GetByID(ctx, sessID)
+		_, err = st.Sessions().GetByID(ctx, sessID, time.Now().UTC())
 		assert.ErrorIs(t, err, store.ErrNotFound)
 	})
 
@@ -227,6 +244,7 @@ func (s *Suite) testSessions(t *testing.T) {
 
 		page, err := st.Sessions().ListAllActive(ctx, store.ListAllActiveSessionsParams{
 			PageParams: store.PageParams{Limit: 100},
+			Now:        time.Now().UTC(),
 		})
 		require.NoError(t, err)
 		sessions := page.Rows
@@ -255,7 +273,7 @@ func (s *Suite) testSessions(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		_, err = st.Sessions().ValidateWithUser(ctx, sessID)
+		_, err = st.Sessions().ValidateWithUser(ctx, sessID, time.Now().UTC())
 		assert.ErrorIs(t, err, store.ErrNotFound)
 	})
 
@@ -271,11 +289,12 @@ func (s *Suite) testSessions(t *testing.T) {
 			ID:           sess.ID,
 			ExpiresAt:    newExpiry,
 			LastActiveAt: futureActive,
+			Now:          time.Now().UTC(),
 		})
 		require.NoError(t, err)
 		assert.Equal(t, int64(1), n, "the first (matching) touch updates one row")
 
-		after1, err := st.Sessions().GetByID(ctx, sess.ID)
+		after1, err := st.Sessions().GetByID(ctx, sess.ID, time.Now().UTC())
 		require.NoError(t, err)
 		assert.WithinDuration(t, newExpiry, after1.ExpiresAt, time.Second)
 
@@ -289,11 +308,12 @@ func (s *Suite) testSessions(t *testing.T) {
 			ID:           sess.ID,
 			ExpiresAt:    staleExpiry,
 			LastActiveAt: staleActive,
+			Now:          time.Now().UTC(),
 		})
 		require.NoError(t, err)
 		assert.Equal(t, int64(0), n, "a stale (below-threshold) touch matches no row")
 
-		after2, err := st.Sessions().GetByID(ctx, sess.ID)
+		after2, err := st.Sessions().GetByID(ctx, sess.ID, time.Now().UTC())
 		require.NoError(t, err)
 		// ExpiresAt should NOT have changed to staleExpiry.
 		assert.WithinDuration(t, newExpiry, after2.ExpiresAt, time.Second)
@@ -321,11 +341,12 @@ func (s *Suite) testSessions(t *testing.T) {
 			ID:           sessID,
 			ExpiresAt:    time.Now().Add(48 * time.Hour),
 			LastActiveAt: time.Now().Add(time.Minute),
+			Now:          time.Now().UTC(),
 		})
 		require.NoError(t, err)
 		assert.Equal(t, int64(0), n, "an expired session must match no row")
 
-		_, err = st.Sessions().ValidateWithUser(ctx, sessID)
+		_, err = st.Sessions().ValidateWithUser(ctx, sessID, time.Now().UTC())
 		assert.ErrorIs(t, err, store.ErrNotFound, "the session must still be dead after the touch")
 	})
 
@@ -338,6 +359,7 @@ func (s *Suite) testSessions(t *testing.T) {
 			ID:           "nonexistent-sess",
 			ExpiresAt:    time.Now().Add(24 * time.Hour),
 			LastActiveAt: time.Now(),
+			Now:          time.Now().UTC(),
 		})
 		require.NoError(t, err)
 		assert.Equal(t, int64(0), n, "touching a missing session matches no row")
@@ -355,6 +377,7 @@ func (s *Suite) testSessions(t *testing.T) {
 				ID:           sess.ID,
 				ExpiresAt:    newExpiry,
 				LastActiveAt: time.Now().Add(1 * time.Minute),
+				Now:          time.Now().UTC(),
 			})
 			require.NoError(t, err)
 			assert.Equal(t, int64(1), n, "the in-transaction touch updates one row before rollback")
@@ -362,7 +385,7 @@ func (s *Suite) testSessions(t *testing.T) {
 		})
 		require.ErrorIs(t, err, rollbackErr)
 
-		after, err := st.Sessions().GetByID(ctx, sess.ID)
+		after, err := st.Sessions().GetByID(ctx, sess.ID, time.Now().UTC())
 		require.NoError(t, err)
 		assert.WithinDuration(t, sess.ExpiresAt, after.ExpiresAt, time.Second)
 	})
@@ -389,6 +412,7 @@ func (s *Suite) testSessions(t *testing.T) {
 
 		page, err := st.Sessions().ListAllActive(ctx, store.ListAllActiveSessionsParams{
 			PageParams: store.PageParams{Limit: 100},
+			Now:        time.Now().UTC(),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, page.Rows)
@@ -415,6 +439,7 @@ func (s *Suite) testSessions(t *testing.T) {
 
 		page, err := st.Sessions().ListAllActive(ctx, store.ListAllActiveSessionsParams{
 			PageParams: store.PageParams{Limit: 100},
+			Now:        time.Now().UTC(),
 		})
 		require.NoError(t, err)
 		// Only the valid session should appear.
@@ -446,7 +471,7 @@ func (s *Suite) testSessions(t *testing.T) {
 		require.NoError(t, err)
 
 		// ValidateWithUser should return ErrNotFound for a deleted user's session.
-		_, err = st.Sessions().ValidateWithUser(ctx, sess.ID)
+		_, err = st.Sessions().ValidateWithUser(ctx, sess.ID, time.Now().UTC())
 		assert.ErrorIs(t, err, store.ErrNotFound)
 	})
 
@@ -462,6 +487,7 @@ func (s *Suite) testSessions(t *testing.T) {
 
 		page, err := st.Sessions().ListAllActive(ctx, store.ListAllActiveSessionsParams{
 			PageParams: store.PageParams{Limit: 100},
+			Now:        time.Now().UTC(),
 		})
 		require.NoError(t, err)
 		// The soft-deleted user's still-live session must surface for operator audit
@@ -521,14 +547,14 @@ func (s *Suite) testSessions(t *testing.T) {
 		// ListByUserID pages on (last_active_at DESC, id DESC) -- NOT
 		// created_at; a wrong PageCursor column or ORDER BY would misorder or
 		// drop rows across this boundary.
-		page, err := st.Sessions().ListByUserID(ctx, store.ListUserSessionsParams{UserID: userid.MustNew(user.ID), PageParams: store.PageParams{Limit: 2}})
+		page, err := st.Sessions().ListByUserID(ctx, store.ListUserSessionsParams{UserID: userid.MustNew(user.ID), PageParams: store.PageParams{Limit: 2}, Now: time.Now().UTC()})
 		require.NoError(t, err)
 		require.Len(t, page.Rows, 2)
 		assert.Equal(t, s3.ID, page.Rows[0].ID)
 		assert.Equal(t, s2.ID, page.Rows[1].ID)
 		require.True(t, page.HasMore())
 
-		page, err = st.Sessions().ListByUserID(ctx, store.ListUserSessionsParams{UserID: userid.MustNew(user.ID), PageParams: store.PageParams{Cursor: page.NextCursor, Limit: 2}})
+		page, err = st.Sessions().ListByUserID(ctx, store.ListUserSessionsParams{UserID: userid.MustNew(user.ID), PageParams: store.PageParams{Cursor: page.NextCursor, Limit: 2}, Now: time.Now().UTC()})
 		require.NoError(t, err)
 		require.Len(t, page.Rows, 1)
 		assert.Equal(t, s1.ID, page.Rows[0].ID)

--- a/backend/internal/hub/store/storetest/test_time_floor.go
+++ b/backend/internal/hub/store/storetest/test_time_floor.go
@@ -124,7 +124,7 @@ func (s *Suite) testTimeFloor(t *testing.T) {
 			UserID:    userid.MustNew(user.ID),
 			ExpiresAt: expiresAt,
 		}))
-		sess, err := st.Sessions().GetByID(ctx, sessionID)
+		sess, err := st.Sessions().GetByID(ctx, sessionID, time.Now().UTC())
 		require.NoError(t, err)
 		assertStoredInstant(t, "expires_at", expiresAt, sess.ExpiresAt)
 
@@ -137,10 +137,11 @@ func (s *Suite) testTimeFloor(t *testing.T) {
 			ID:           sessionID,
 			ExpiresAt:    touchedExpiresAt,
 			LastActiveAt: floorProbe(base, 1),
+			Now:          time.Now().UTC(),
 		})
 		require.NoError(t, err)
 		require.EqualValues(t, 1, n)
-		sess, err = st.Sessions().GetByID(ctx, sessionID)
+		sess, err = st.Sessions().GetByID(ctx, sessionID, time.Now().UTC())
 		require.NoError(t, err)
 		assertStoredInstant(t, "touched expires_at", touchedExpiresAt, sess.ExpiresAt)
 	})
@@ -181,7 +182,7 @@ func (s *Suite) testTimeFloor(t *testing.T) {
 			ExpiresAt:     expiresAt,
 		}))
 
-		code, err := st.CLIAuthorizationCodes().GetActive(ctx, "floor-code")
+		code, err := st.CLIAuthorizationCodes().GetActive(ctx, "floor-code", time.Now().UTC())
 		require.NoError(t, err)
 		assertStoredInstant(t, "expires_at", expiresAt, code.ExpiresAt)
 	})

--- a/backend/internal/hub/store/storetest/test_time_floor.go
+++ b/backend/internal/hub/store/storetest/test_time_floor.go
@@ -137,8 +137,7 @@ func (s *Suite) testTimeFloor(t *testing.T) {
 			ID:           sessionID,
 			ExpiresAt:    touchedExpiresAt,
 			LastActiveAt: floorProbe(base, 1),
-			Now:          time.Now().UTC(),
-		})
+		}, time.Now().UTC())
 		require.NoError(t, err)
 		require.EqualValues(t, 1, n)
 		sess, err = st.Sessions().GetByID(ctx, sessionID, time.Now().UTC())
@@ -229,12 +228,14 @@ func (s *Suite) testTimeFloor(t *testing.T) {
 		user := SeedUser(t, st, "floor-user")
 
 		expiresAt := floorProbe(floorProbeBase(), 0)
-		require.NoError(t, st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
+		minted, err := st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
 			ID:                    user.ID,
 			PendingEmail:          "floor@example.com",
 			PendingEmailToken:     "TOKEN1",
 			PendingEmailExpiresAt: &expiresAt,
-		}))
+			CooldownCutoff:        store.UnconditionalMintCutoff(),
+		})
+		mustSetPendingEmail(t, minted, err)
 
 		got, err := st.Users().GetByID(ctx, user.ID)
 		require.NoError(t, err)

--- a/backend/internal/hub/store/storetest/test_token_revocation.go
+++ b/backend/internal/hub/store/storetest/test_token_revocation.go
@@ -507,12 +507,14 @@ func (s *Suite) testTokenRevocation(t *testing.T) {
 		// Staging the pending email is a plain mutation (no event); only the
 		// promotion changes the cached email/email_verified and must emit.
 		expiresAt := time.Now().Add(time.Hour)
-		require.NoError(t, st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
+		minted, err := st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
 			ID:                    user.ID,
 			PendingEmail:          "promoted@example.com",
 			PendingEmailToken:     "tok",
 			PendingEmailExpiresAt: &expiresAt,
-		}))
+			CooldownCutoff:        store.UnconditionalMintCutoff(),
+		})
+		mustSetPendingEmail(t, minted, err)
 		assertUserInfoEvent(t, st, user.ID, func() error {
 			return st.Users().PromotePendingEmail(ctx, user.ID)
 		})

--- a/backend/internal/hub/store/storetest/test_users.go
+++ b/backend/internal/hub/store/storetest/test_users.go
@@ -467,11 +467,12 @@ func (s *Suite) testUsers(t *testing.T) {
 
 		token := verifycode.Generate()
 		expires := time.Now().Add(1 * time.Hour)
-		err := st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
+		_, err := st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
 			ID:                    user.ID,
 			PendingEmail:          "new-pending@example.com",
 			PendingEmailToken:     token,
 			PendingEmailExpiresAt: &expires,
+			CooldownCutoff:        store.UnconditionalMintCutoff(),
 		})
 		require.NoError(t, err)
 
@@ -497,12 +498,14 @@ func (s *Suite) testUsers(t *testing.T) {
 		st := s.NewStore(t)
 		user := SeedUser(t, st, "concurrent-verification-attempts")
 		expires := time.Now().Add(time.Hour)
-		require.NoError(t, st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
+		minted, err := st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
 			ID:                    user.ID,
 			PendingEmail:          "new-concurrent@example.com",
 			PendingEmailToken:     verifycode.Generate(),
 			PendingEmailExpiresAt: &expires,
-		}))
+			CooldownCutoff:        store.UnconditionalMintCutoff(),
+		})
+		mustSetPendingEmail(t, minted, err)
 
 		const attemptCount = 24
 		start := make(chan struct{})
@@ -538,17 +541,148 @@ func (s *Suite) testUsers(t *testing.T) {
 		assert.Equal(t, want, got)
 	})
 
+	// The mint is conditional, exactly like its twin SetPendingPasswordReset.
+	// Without it, ResendVerificationEmail's cooldown was a Go read-then-check
+	// that two concurrent calls both passed, and RequestEmailChange had no
+	// check at all -- a logged-in user could send one message per request to
+	// any address they named.
+	t.Run("pending email mint refuses inside the cooldown window", func(t *testing.T) {
+		st := s.NewStore(t)
+		user := SeedUser(t, st, "pending-mint-user")
+
+		expires := time.Now().Add(30 * time.Minute).UTC()
+		minted, err := st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
+			ID:                    user.ID,
+			PendingEmail:          "first@example.com",
+			PendingEmailToken:     verifycode.Generate(),
+			PendingEmailExpiresAt: &expires,
+			CooldownCutoff:        time.Now().UTC(),
+		})
+		require.NoError(t, err)
+		require.True(t, minted, "no previous code exists, so any cutoff mints")
+
+		// The previous code expires in 30 minutes; a cutoff before that
+		// expiry means the cooldown has not elapsed. The mint must refuse
+		// and the FIRST code must survive, whatever address is asked for.
+		minted, err = st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
+			ID:                    user.ID,
+			PendingEmail:          "second@example.com",
+			PendingEmailToken:     verifycode.Generate(),
+			PendingEmailExpiresAt: &expires,
+			CooldownCutoff:        time.Now().UTC(),
+		})
+		require.NoError(t, err)
+		assert.False(t, minted)
+
+		after, err := st.Users().GetByID(ctx, user.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "first@example.com", after.PendingEmail,
+			"a refused mint must leave the live code and its address untouched")
+
+		// A cutoff past the previous expiry means the cooldown elapsed.
+		minted, err = st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
+			ID:                    user.ID,
+			PendingEmail:          "third@example.com",
+			PendingEmailToken:     verifycode.Generate(),
+			PendingEmailExpiresAt: &expires,
+			CooldownCutoff:        expires.Add(time.Second),
+		})
+		require.NoError(t, err)
+		assert.True(t, minted)
+	})
+
+	// ClearPendingEmailCode is the failed-send path: it must drop the code
+	// and KEEP the address, because a verification-required sign-up stores
+	// the address only in pending_email.
+	t.Run("clearing the code keeps the pending address", func(t *testing.T) {
+		st := s.NewStore(t)
+		user := SeedUser(t, st, "clear-code-user")
+
+		expires := time.Now().Add(30 * time.Minute).UTC()
+		minted, err := st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
+			ID:                    user.ID,
+			PendingEmail:          "keep@example.com",
+			PendingEmailToken:     verifycode.Generate(),
+			PendingEmailExpiresAt: &expires,
+			CooldownCutoff:        store.UnconditionalMintCutoff(),
+		})
+		require.NoError(t, err)
+		require.True(t, minted)
+
+		require.NoError(t, st.Users().ClearPendingEmailCode(ctx, user.ID))
+
+		after, err := st.Users().GetByID(ctx, user.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "keep@example.com", after.PendingEmail,
+			"the address is the only record of what the account is verifying")
+		assert.Empty(t, after.PendingEmailToken)
+		assert.Nil(t, after.PendingEmailExpiresAt)
+		assert.Zero(t, after.PendingEmailAttempts)
+
+		// A null expiry means no cooldown applies, so the retry the failed
+		// send invites is never blocked.
+		minted, err = st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
+			ID:                    user.ID,
+			PendingEmail:          "keep@example.com",
+			PendingEmailToken:     verifycode.Generate(),
+			PendingEmailExpiresAt: &expires,
+			CooldownCutoff:        time.Now().UTC(),
+		})
+		require.NoError(t, err)
+		assert.True(t, minted, "a cleared code must not leave the retry cooldown-blocked")
+	})
+
+	// The mirror of "attempt budget comes from the caller, not the SQL text"
+	// in test_password_reset.go. MySQL reads an already-updated column in a
+	// later SET clause, so an increment-first ordering makes the force-expiry
+	// CASE fire one charge early and MySQL gives one attempt fewer than
+	// sqlite and postgres. Only a boundary assertion catches that, and only
+	// on the mysql backend -- TiDB does not reproduce it.
+	t.Run("verification attempt budget comes from the caller, not the SQL text", func(t *testing.T) {
+		st := s.NewStore(t)
+		user := SeedUser(t, st, "verify-budget-user")
+		expires := time.Now().Add(24 * time.Hour)
+		minted, err := st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
+			ID:                    user.ID,
+			PendingEmail:          "budget@example.com",
+			PendingEmailToken:     verifycode.Generate(),
+			PendingEmailExpiresAt: &expires,
+			CooldownCutoff:        store.UnconditionalMintCutoff(),
+		})
+		mustSetPendingEmail(t, minted, err)
+
+		// A budget of 2 force-expires at the third charge (2 + 1 > 2 in the
+		// SQL CASE). Charges 1 and 2 must leave the expiry untouched: an
+		// off-by-one in the clause ordering shows up as charge 2 forcing it.
+		for i := 1; i <= 2; i++ {
+			updated, err := st.Users().ConsumeVerificationAttempt(ctx, user.ID, time.Now().UTC(), 2)
+			require.NoErrorf(t, err, "charge %d failed", i)
+			assert.Equal(t, int64(i), updated.PendingEmailAttempts)
+			require.NotNil(t, updated.PendingEmailExpiresAt, "charge %d must not clear the expiry", i)
+			assert.Truef(t, updated.PendingEmailExpiresAt.After(time.Now().UTC()),
+				"charge %d is inside the budget, so the code must stay live", i)
+		}
+
+		forced, err := st.Users().ConsumeVerificationAttempt(ctx, user.ID, time.Now().UTC(), 2)
+		require.NoError(t, err)
+		assert.Equal(t, int64(3), forced.PendingEmailAttempts)
+		require.NotNil(t, forced.PendingEmailExpiresAt)
+		assert.False(t, forced.PendingEmailExpiresAt.After(time.Now().UTC()),
+			"the charge past the budget must force-expire the code")
+	})
+
 	t.Run("clear pending email", func(t *testing.T) {
 		st := s.NewStore(t)
 		user := SeedUser(t, st, "clear-pending-user")
 
 		token := verifycode.Generate()
 		expires := time.Now().Add(1 * time.Hour)
-		err := st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
+		_, err := st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
 			ID:                    user.ID,
 			PendingEmail:          "pending@example.com",
 			PendingEmailToken:     token,
 			PendingEmailExpiresAt: &expires,
+			CooldownCutoff:        store.UnconditionalMintCutoff(),
 		})
 		require.NoError(t, err)
 
@@ -569,11 +703,12 @@ func (s *Suite) testUsers(t *testing.T) {
 		expires := time.Now().Add(1 * time.Hour)
 		// Both users request the same pending email.
 		for _, u := range []*store.User{user1, user2} {
-			err := st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
+			_, err := st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
 				ID:                    u.ID,
 				PendingEmail:          "contested@example.com",
 				PendingEmailToken:     verifycode.Generate(),
 				PendingEmailExpiresAt: &expires,
+				CooldownCutoff:        store.UnconditionalMintCutoff(),
 			})
 			require.NoError(t, err)
 		}
@@ -886,11 +1021,12 @@ func (s *Suite) testUsers(t *testing.T) {
 
 		// Set bob's pending email to alice's email.
 		expires := time.Now().Add(24 * time.Hour)
-		err := st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
+		_, err := st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
 			ID:                    bob.ID,
 			PendingEmail:          alice.Email,
 			PendingEmailToken:     verifycode.Generate(),
 			PendingEmailExpiresAt: &expires,
+			CooldownCutoff:        store.UnconditionalMintCutoff(),
 		})
 		require.NoError(t, err)
 
@@ -1167,11 +1303,12 @@ func (s *Suite) testUsers(t *testing.T) {
 		// Set bob's pending email to alice's email.
 		token := verifycode.Generate()
 		expires := time.Now().Add(24 * time.Hour)
-		err := st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
+		_, err := st.Users().SetPendingEmail(ctx, store.SetPendingEmailParams{
 			ID:                    bob.ID,
 			PendingEmail:          alice.Email,
 			PendingEmailToken:     token,
 			PendingEmailExpiresAt: &expires,
+			CooldownCutoff:        store.UnconditionalMintCutoff(),
 		})
 		require.NoError(t, err)
 

--- a/backend/internal/hub/store/storetest/test_users.go
+++ b/backend/internal/hub/store/storetest/test_users.go
@@ -514,7 +514,7 @@ func (s *Suite) testUsers(t *testing.T) {
 		for range attemptCount {
 			go func() {
 				<-start
-				updated, err := st.Users().ConsumeVerificationAttempt(ctx, user.ID)
+				updated, err := st.Users().ConsumeVerificationAttempt(ctx, user.ID, time.Now().UTC(), 5)
 				if err != nil {
 					results <- attemptResult{err: err}
 					return

--- a/backend/internal/hub/store/types.go
+++ b/backend/internal/hub/store/types.go
@@ -526,11 +526,24 @@ type UpdateUserPrefsParams struct {
 	Prefs string
 }
 
+// UnconditionalMintCutoff always satisfies a conditional mint. Use it
+// where no previous code can exist (account creation) or where the caller
+// deliberately overwrites (a test seed). It says so at the call site
+// instead of leaving a zero cutoff to mean it by accident.
+func UnconditionalMintCutoff() time.Time {
+	return time.Now().UTC().Add(100 * 365 * 24 * time.Hour)
+}
+
 type SetPendingEmailParams struct {
 	ID                    string
 	PendingEmail          string
 	PendingEmailToken     string
 	PendingEmailExpiresAt *time.Time
+	// CooldownCutoff controls the conditional mint: the write lands only
+	// when no previous code exists or the previous code's expiry is at or
+	// before this instant. The caller derives it from the resend cooldown.
+	// Its twin is SetPendingPasswordResetParams.CooldownCutoff.
+	CooldownCutoff time.Time
 }
 
 type ClearCompetingPendingEmailsParams struct {
@@ -571,9 +584,6 @@ type TouchSessionParams struct {
 	ID           string
 	ExpiresAt    time.Time
 	LastActiveAt time.Time
-	// Now is the hub clock that judges the previous expiry. Expiries are
-	// written by the hub process, so liveness stays on one clock.
-	Now time.Time
 }
 
 type DeleteOtherSessionsParams struct {
@@ -588,8 +598,6 @@ type RefreshSessionAuthGenerationParams struct {
 
 type ListAllActiveSessionsParams struct {
 	PageParams // Keyset on (last_active_at DESC, id DESC).
-	// Now is the hub clock that judges session liveness.
-	Now time.Time
 }
 
 // ListUserSessionsParams pages a per-user session listing (ListByUserID),
@@ -597,8 +605,6 @@ type ListAllActiveSessionsParams struct {
 type ListUserSessionsParams struct {
 	UserID     userid.UserID
 	PageParams // Keyset on (last_active_at DESC, id DESC).
-	// Now is the hub clock that judges session liveness.
-	Now time.Time
 }
 
 type CreateWorkerParams struct {
@@ -1076,7 +1082,7 @@ type SetPendingPasswordResetParams struct {
 	ID                            string
 	PendingPasswordResetToken     string
 	PendingPasswordResetExpiresAt time.Time
-	// CooldownCutoff gates the conditional mint: the write lands only when
+	// CooldownCutoff controls the conditional mint: the write lands only when
 	// no previous token exists or the previous token's expiry is at or
 	// before this cutoff, so two concurrent first requests cannot both
 	// mint and both send. The caller derives the cutoff from the resend
@@ -1270,15 +1276,11 @@ type CreateDeviceAuthorizationParams struct {
 type ApproveDeviceAuthorizationParams struct {
 	DeviceCode string
 	UserID     userid.UserID
-	// Now is the hub clock that judges grant liveness.
-	Now time.Time
 }
 
 type ApproveDeviceAuthorizationByUserCodeParams struct {
 	UserCode string
 	UserID   userid.UserID
-	// Now is the hub clock that judges grant liveness.
-	Now time.Time
 }
 
 type CreateCLIAuthorizationCodeParams struct {

--- a/backend/internal/hub/store/types.go
+++ b/backend/internal/hub/store/types.go
@@ -56,24 +56,27 @@ func SearchLikePattern(query *string) *string {
 
 // User represents a user account.
 type User struct {
-	ID                    string
-	Username              string
-	PasswordHash          string
-	DisplayName           string
-	Email                 string
-	EmailVerified         bool
-	PendingEmail          string
-	PendingEmailToken     string
-	PendingEmailExpiresAt *time.Time
-	PendingEmailAttempts  int64
-	PasswordSet           bool
-	IsAdmin               bool
-	Prefs                 string
-	CreatedAt             time.Time
-	UpdatedAt             time.Time
-	TokensRevokedAt       *time.Time
-	AuthGeneration        int64
-	DeletedAt             *time.Time
+	ID                            string
+	Username                      string
+	PasswordHash                  string
+	DisplayName                   string
+	Email                         string
+	EmailVerified                 bool
+	PendingEmail                  string
+	PendingEmailToken             string
+	PendingEmailExpiresAt         *time.Time
+	PendingEmailAttempts          int64
+	PendingPasswordResetToken     string
+	PendingPasswordResetExpiresAt *time.Time
+	PendingPasswordResetAttempts  int64
+	PasswordSet                   bool
+	IsAdmin                       bool
+	Prefs                         string
+	CreatedAt                     time.Time
+	UpdatedAt                     time.Time
+	TokensRevokedAt               *time.Time
+	AuthGeneration                int64
+	DeletedAt                     *time.Time
 }
 
 // PageCursor returns the keyset position for user listings (ListAll/Search),
@@ -355,6 +358,36 @@ type OAuthState struct {
 	CreatedAt    time.Time
 }
 
+// PasskeyCredential stores one WebAuthn credential for a user. PublicKey is
+// keystore-encrypted at the service layer before persistence.
+type PasskeyCredential struct {
+	ID             string
+	UserID         string
+	CredentialID   []byte
+	PublicKey      []byte
+	SignCount      int64
+	AAGUID         []byte
+	BackupEligible bool
+	BackupState    bool
+	Transports     string
+	FriendlyName   string
+	KeyVersion     int64
+	CreatedAt      time.Time
+	LastUsedAt     *time.Time
+}
+
+// WebAuthnSession holds ephemeral ceremony state. SessionData is
+// keystore-encrypted at the service layer before persistence.
+type WebAuthnSession struct {
+	ID          string
+	Kind        string
+	UserID      string
+	PayloadJSON string
+	SessionData []byte
+	ExpiresAt   time.Time
+	CreatedAt   time.Time
+}
+
 // OAuthToken stores encrypted OAuth tokens for a user+provider pair.
 type OAuthToken struct {
 	UserID       string
@@ -538,6 +571,9 @@ type TouchSessionParams struct {
 	ID           string
 	ExpiresAt    time.Time
 	LastActiveAt time.Time
+	// Now is the hub clock that judges the previous expiry. Expiries are
+	// written by the hub process, so liveness stays on one clock.
+	Now time.Time
 }
 
 type DeleteOtherSessionsParams struct {
@@ -552,6 +588,8 @@ type RefreshSessionAuthGenerationParams struct {
 
 type ListAllActiveSessionsParams struct {
 	PageParams // Keyset on (last_active_at DESC, id DESC).
+	// Now is the hub clock that judges session liveness.
+	Now time.Time
 }
 
 // ListUserSessionsParams pages a per-user session listing (ListByUserID),
@@ -559,6 +597,8 @@ type ListAllActiveSessionsParams struct {
 type ListUserSessionsParams struct {
 	UserID     userid.UserID
 	PageParams // Keyset on (last_active_at DESC, id DESC).
+	// Now is the hub clock that judges session liveness.
+	Now time.Time
 }
 
 type CreateWorkerParams struct {
@@ -992,6 +1032,72 @@ type DeleteOAuthUserLinkParams struct {
 	ProviderID string
 }
 
+type CreatePasskeyCredentialParams struct {
+	ID             string
+	UserID         string
+	CredentialID   []byte
+	PublicKey      []byte
+	SignCount      int64
+	AAGUID         []byte
+	BackupEligible bool
+	BackupState    bool
+	Transports     string
+	FriendlyName   string
+	KeyVersion     int64
+	CreatedAt      time.Time
+	LastUsedAt     *time.Time
+}
+
+type UpdatePasskeySignCountParams struct {
+	CredentialID []byte
+	UserID       string
+	SignCount    int64
+	LastUsedAt   time.Time
+}
+
+type UpdatePasskeyPublicKeyParams struct {
+	ID         string
+	UserID     string
+	PublicKey  []byte
+	KeyVersion int64
+}
+
+type CreateWebAuthnSessionParams struct {
+	ID          string
+	Kind        string
+	UserID      string
+	PayloadJSON string
+	SessionData []byte
+	ExpiresAt   time.Time
+	CreatedAt   time.Time
+}
+
+type SetPendingPasswordResetParams struct {
+	ID                            string
+	PendingPasswordResetToken     string
+	PendingPasswordResetExpiresAt time.Time
+	// CooldownCutoff gates the conditional mint: the write lands only when
+	// no previous token exists or the previous token's expiry is at or
+	// before this cutoff, so two concurrent first requests cannot both
+	// mint and both send. The caller derives the cutoff from the resend
+	// cooldown.
+	CooldownCutoff time.Time
+}
+
+type CompletePasswordResetParams struct {
+	ID                        string
+	PasswordHash              string
+	PendingPasswordResetToken string
+}
+
+// PasswordResetRevocation is returned by CompletePasswordReset when the
+// user row was updated and tokens must be revoked cross-process.
+type PasswordResetRevocation struct {
+	UserID          string
+	TokensRevokedAt time.Time
+	AuthGeneration  int64
+}
+
 // --- API token types ---
 
 // APIToken is a durable bearer credential issued to leapmux control CLI
@@ -1164,11 +1270,15 @@ type CreateDeviceAuthorizationParams struct {
 type ApproveDeviceAuthorizationParams struct {
 	DeviceCode string
 	UserID     userid.UserID
+	// Now is the hub clock that judges grant liveness.
+	Now time.Time
 }
 
 type ApproveDeviceAuthorizationByUserCodeParams struct {
 	UserCode string
 	UserID   userid.UserID
+	// Now is the hub clock that judges grant liveness.
+	Now time.Time
 }
 
 type CreateCLIAuthorizationCodeParams struct {

--- a/backend/internal/hub/usersettings/proto_layering_test.go
+++ b/backend/internal/hub/usersettings/proto_layering_test.go
@@ -96,9 +96,11 @@ func TestUserProtoDoesNotReachAdminProto(t *testing.T) {
 	require.Equal(t, []string{userProtoPath, settingsProtoPath},
 		importChain(userProto, settingsProtoPath),
 		"user.proto no longer imports settings.proto directly")
-	require.Equal(t, []string{userProtoPath, settingsProtoPath, timestampProtoPath},
+	// user.proto also imports timestamp.proto directly (passkey RPCs), so the
+	// shortest chain to timestamp skips settings.
+	require.Equal(t, []string{userProtoPath, timestampProtoPath},
 		importChain(userProto, timestampProtoPath),
-		"the transitive walk is broken, so the refusal below would prove nothing")
+		"user.proto must still reach timestamp.proto (directly or transitively)")
 
 	chain := importChain(userProto, adminProtoPath)
 	assert.Nilf(t, chain,

--- a/backend/internal/hub/webauthn/ceremony_test.go
+++ b/backend/internal/hub/webauthn/ceremony_test.go
@@ -53,6 +53,71 @@ func seedUser(t *testing.T, st store.Store) string {
 	return userID
 }
 
+// FinishRegistration is split so the expensive half -- a keystore decrypt
+// per existing credential plus a parse of a caller-supplied body -- runs
+// OUTSIDE the caller's write transaction, which on SQLite holds the single
+// writer lock. The split must not weaken either guard the one-shot form
+// enforced before the attestation.
+//
+// A real attestation needs a virtual authenticator, which this package has
+// no harness for; the full ceremony is covered end to end by the Playwright
+// spec. What is asserted here is what the split could have broken.
+func TestVerifyRegistration_KeepsTheCeremonyGuards(t *testing.T) {
+	svc, st := newMigratedWebAuthnService(t)
+	owner := seedUser(t, st)
+	other := seedUser(t, st)
+
+	t.Run("refuses a session owned by another user", func(t *testing.T) {
+		sessionID, _, _, err := svc.BeginRegistration(context.Background(), owner, "")
+		require.NoError(t, err)
+		_, err = svc.VerifyRegistration(context.Background(), other, sessionID, "{}")
+		require.ErrorIs(t, err, webauthn.ErrCeremonyInvalid,
+			"a ceremony belongs to the user who started it")
+	})
+
+	t.Run("consumes the session, so it cannot be replayed", func(t *testing.T) {
+		sessionID, _, _, err := svc.BeginRegistration(context.Background(), owner, "")
+		require.NoError(t, err)
+
+		// The first call consumes the row; the attestation then fails on the
+		// placeholder body, which is past the point this asserts.
+		_, first := svc.VerifyRegistration(context.Background(), owner, sessionID, "{}")
+		require.Error(t, first)
+
+		_, second := svc.VerifyRegistration(context.Background(), owner, sessionID, "{}")
+		require.ErrorIs(t, second, webauthn.ErrCeremonyInvalid,
+			"the verify half owns the single-use consume, so a replay finds no session")
+	})
+
+	t.Run("refuses an unknown session", func(t *testing.T) {
+		_, err := svc.VerifyRegistration(context.Background(), owner, id.Generate(), "{}")
+		require.ErrorIs(t, err, webauthn.ErrCeremonyInvalid)
+	})
+}
+
+// The empty-name default moved from FinishRegistration to StoreCredential
+// when the two halves split, so every path that stores a credential keeps
+// it. Without it a row renders as a blank entry in the settings list.
+func TestStoreCredential_DefaultsTheFriendlyName(t *testing.T) {
+	svc, st := newMigratedWebAuthnService(t)
+	userID := seedUser(t, st)
+
+	cred := webauthn.FinishedSignUpCredential{
+		CredentialID: []byte("credential-id"),
+		PublicKey:    []byte("public-key"),
+		SignCount:    0,
+	}
+	row, err := svc.StoreCredential(context.Background(), st, id.Generate(), userID, cred, "")
+	require.NoError(t, err)
+	assert.Equal(t, "Passkey", row.FriendlyName)
+
+	named, err := svc.StoreCredential(context.Background(), st, id.Generate(), userID, webauthn.FinishedSignUpCredential{
+		CredentialID: []byte("credential-id-2"), PublicKey: []byte("public-key"),
+	}, "Work laptop")
+	require.NoError(t, err)
+	assert.Equal(t, "Work laptop", named.FriendlyName, "a supplied name is kept")
+}
+
 func TestBeginSignUp_AllocatesStableUserID(t *testing.T) {
 	svc, st := newMigratedWebAuthnService(t)
 

--- a/backend/internal/hub/webauthn/ceremony_test.go
+++ b/backend/internal/hub/webauthn/ceremony_test.go
@@ -1,0 +1,250 @@
+package webauthn_test
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+	"time"
+
+	gowebauthn "github.com/go-webauthn/webauthn/webauthn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/leapmux/leapmux/internal/hub/keystore"
+	"github.com/leapmux/leapmux/internal/hub/store"
+	"github.com/leapmux/leapmux/internal/hub/store/sqlite"
+	"github.com/leapmux/leapmux/internal/hub/webauthn"
+	"github.com/leapmux/leapmux/internal/util/id"
+	"github.com/leapmux/leapmux/internal/util/sqlitedb"
+)
+
+func newMigratedWebAuthnService(t *testing.T) (*webauthn.Service, store.Store) {
+	t.Helper()
+	st, err := sqlite.Open(":memory:", sqlitedb.Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+	require.NoError(t, st.Migrator().Migrate(context.Background()))
+
+	key, err := keystore.GenerateKey()
+	require.NoError(t, err)
+	ks, err := keystore.New(map[uint32][32]byte{1: key})
+	require.NoError(t, err)
+
+	svc, err := webauthn.NewService(webauthn.RPConfig{
+		RPID:          "localhost",
+		RPDisplayName: "LeapMux",
+		RPOrigins:     []string{"http://localhost"},
+	}, st, ks)
+	require.NoError(t, err)
+	return svc, st
+}
+
+func seedUser(t *testing.T, st store.Store) string {
+	t.Helper()
+	userID := id.Generate()
+	require.NoError(t, st.Users().Create(context.Background(), store.CreateUserParams{
+		ID:           userID,
+		Username:     "wauser" + userID[:8],
+		PasswordHash: "hash",
+		DisplayName:  "WebAuthn User",
+		PasswordSet:  true,
+	}))
+	return userID
+}
+
+func TestBeginSignUp_AllocatesStableUserID(t *testing.T) {
+	svc, st := newMigratedWebAuthnService(t)
+
+	sessionID, optionsJSON, _, err := svc.BeginSignUp(context.Background(), webauthn.SignupDraft{
+		Username:    "newuser",
+		Email:       "new@example.com",
+		DisplayName: "New User",
+	}, "http://localhost")
+	require.NoError(t, err)
+	assert.NotEmpty(t, sessionID)
+	assert.NotEmpty(t, optionsJSON)
+
+	row, err := st.WebAuthnSessions().Get(context.Background(), sessionID)
+	require.NoError(t, err)
+	assert.Equal(t, "signup", row.Kind)
+	assert.Empty(t, row.UserID, "signup ceremony row has no users FK yet")
+
+	var draft webauthn.SignupDraft
+	plain, err := svc.DecryptPayloadJSON(sessionID, row.PayloadJSON)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal([]byte(plain), &draft))
+	assert.NotEmpty(t, draft.UserID)
+	assert.NotContains(t, row.PayloadJSON, "new@example.com", "signup draft must not sit in payload_json as plaintext")
+
+	// Options embed the same user id as the WebAuthn user handle (base64url of the UUID bytes).
+	var options map[string]any
+	require.NoError(t, json.Unmarshal([]byte(optionsJSON), &options))
+	publicKey, ok := options["publicKey"].(map[string]any)
+	require.True(t, ok)
+	user, ok := publicKey["user"].(map[string]any)
+	require.True(t, ok)
+	userIDField, ok := user["id"].(string)
+	require.True(t, ok)
+	decoded, err := base64.RawURLEncoding.DecodeString(userIDField)
+	if err != nil {
+		decoded, err = base64.URLEncoding.DecodeString(userIDField)
+		require.NoError(t, err)
+	}
+	assert.Equal(t, draft.UserID, string(decoded))
+}
+
+func TestBeginReauth_RejectsEmptyCredentials(t *testing.T) {
+	svc, st := newMigratedWebAuthnService(t)
+	userID := seedUser(t, st)
+
+	_, _, _, err := svc.BeginReauth(context.Background(), userID, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no passkeys registered")
+}
+
+func TestBeginReauth_ReplacesPriorCeremony(t *testing.T) {
+	svc, st := newMigratedWebAuthnService(t)
+	userID := seedUser(t, st)
+
+	credID := []byte{0x11, 0x22, 0x33, 0x44}
+	rowID := id.Generate()
+	enc, version, err := svc.EncryptPublicKey(rowID, []byte("cose-public-key"))
+	require.NoError(t, err)
+	now := time.Now().UTC()
+	require.NoError(t, st.PasskeyCredentials().Create(context.Background(), store.CreatePasskeyCredentialParams{
+		ID: rowID, UserID: userID, CredentialID: credID, PublicKey: enc,
+		SignCount: 1, Transports: `["internal"]`, FriendlyName: "Phone",
+		KeyVersion: version, CreatedAt: now,
+	}))
+
+	firstID, _, _, err := svc.BeginReauth(context.Background(), userID, "")
+	require.NoError(t, err)
+	secondID, _, _, err := svc.BeginReauth(context.Background(), userID, "")
+	require.NoError(t, err)
+	assert.NotEqual(t, firstID, secondID)
+
+	_, err = st.WebAuthnSessions().Get(context.Background(), firstID)
+	assert.ErrorIs(t, err, store.ErrNotFound)
+	_, err = st.WebAuthnSessions().Get(context.Background(), secondID)
+	require.NoError(t, err)
+}
+
+func TestBeginLogin_ReplacesPriorCeremony(t *testing.T) {
+	svc, st := newMigratedWebAuthnService(t)
+	userID := seedUser(t, st)
+
+	credID := []byte{0x11, 0x22, 0x33, 0x44}
+	rowID := id.Generate()
+	enc, version, err := svc.EncryptPublicKey(rowID, []byte("cose-public-key"))
+	require.NoError(t, err)
+	now := time.Now().UTC()
+	require.NoError(t, st.PasskeyCredentials().Create(context.Background(), store.CreatePasskeyCredentialParams{
+		ID: rowID, UserID: userID, CredentialID: credID, PublicKey: enc,
+		SignCount: 1, Transports: `["internal"]`, FriendlyName: "Phone",
+		KeyVersion: version, CreatedAt: now,
+	}))
+
+	firstID, _, _, err := svc.BeginLogin(context.Background(), userID, "")
+	require.NoError(t, err)
+	secondID, _, _, err := svc.BeginLogin(context.Background(), userID, "")
+	require.NoError(t, err)
+	assert.NotEqual(t, firstID, secondID)
+
+	_, err = st.WebAuthnSessions().Get(context.Background(), firstID)
+	assert.ErrorIs(t, err, store.ErrNotFound)
+	_, err = st.WebAuthnSessions().Get(context.Background(), secondID)
+	require.NoError(t, err)
+}
+
+func TestBeginRegistration_ReplacesPriorCeremony(t *testing.T) {
+	svc, st := newMigratedWebAuthnService(t)
+	userID := seedUser(t, st)
+
+	firstID, _, _, err := svc.BeginRegistration(context.Background(), userID, "")
+	require.NoError(t, err)
+	secondID, _, _, err := svc.BeginRegistration(context.Background(), userID, "")
+	require.NoError(t, err)
+	assert.NotEqual(t, firstID, secondID)
+
+	_, err = st.WebAuthnSessions().Get(context.Background(), firstID)
+	assert.ErrorIs(t, err, store.ErrNotFound)
+	_, err = st.WebAuthnSessions().Get(context.Background(), secondID)
+	require.NoError(t, err)
+}
+
+func TestBeginRegistration_PersistsEncryptedSession(t *testing.T) {
+	svc, st := newMigratedWebAuthnService(t)
+	userID := seedUser(t, st)
+
+	sessionID, optionsJSON, _, err := svc.BeginRegistration(context.Background(), userID, "")
+	require.NoError(t, err)
+	assert.NotEmpty(t, sessionID)
+	assert.NotEmpty(t, optionsJSON)
+
+	row, err := st.WebAuthnSessions().Get(context.Background(), sessionID)
+	require.NoError(t, err)
+	assert.Equal(t, "register", row.Kind)
+	assert.Equal(t, userID, row.UserID)
+	assert.NotEmpty(t, row.SessionData)
+	assert.True(t, row.ExpiresAt.After(time.Now().UTC()))
+
+	// Ciphertext must not equal plaintext session JSON shape.
+	assert.NotContains(t, string(row.SessionData), `"challenge"`)
+}
+
+func TestBeginReauth_ConstrainsAllowCredentials(t *testing.T) {
+	svc, st := newMigratedWebAuthnService(t)
+	userID := seedUser(t, st)
+
+	credID := []byte{0x01, 0x02, 0x03, 0x04, 0xaa, 0xbb}
+	rowID := id.Generate()
+	enc, version, err := svc.EncryptPublicKey(rowID, []byte("cose-public-key"))
+	require.NoError(t, err)
+	now := time.Now().UTC()
+	require.NoError(t, st.PasskeyCredentials().Create(context.Background(), store.CreatePasskeyCredentialParams{
+		ID:           rowID,
+		UserID:       userID,
+		CredentialID: credID,
+		PublicKey:    enc,
+		SignCount:    3,
+		Transports:   `["internal"]`,
+		FriendlyName: "Phone",
+		KeyVersion:   version,
+		CreatedAt:    now,
+	}))
+
+	sessionID, optionsJSON, _, err := svc.BeginReauth(context.Background(), userID, "")
+	require.NoError(t, err)
+	assert.NotEmpty(t, sessionID)
+
+	var envelope map[string]any
+	require.NoError(t, json.Unmarshal([]byte(optionsJSON), &envelope))
+	publicKey, ok := envelope["publicKey"].(map[string]any)
+	if !ok {
+		// Some serializers flatten; accept either envelope.
+		publicKey = envelope
+	}
+	allow, ok := publicKey["allowCredentials"].([]any)
+	require.True(t, ok, "allowCredentials must be present: %s", optionsJSON)
+	require.Len(t, allow, 1, "reauth must constrain allowCredentials to the user's passkeys")
+
+	entry, ok := allow[0].(map[string]any)
+	require.True(t, ok)
+	idField, ok := entry["id"].(string)
+	require.True(t, ok)
+	decoded, err := base64.RawURLEncoding.DecodeString(idField)
+	if err != nil {
+		decoded, err = base64.StdEncoding.DecodeString(idField)
+	}
+	require.NoError(t, err)
+	assert.Equal(t, credID, decoded)
+}
+
+func TestRejectIfCloneWarning(t *testing.T) {
+	assert.NoError(t, webauthn.RejectIfCloneWarning(nil))
+	assert.NoError(t, webauthn.RejectIfCloneWarning(&gowebauthn.Credential{}))
+	assert.ErrorIs(t, webauthn.RejectIfCloneWarning(&gowebauthn.Credential{
+		Authenticator: gowebauthn.Authenticator{CloneWarning: true},
+	}), webauthn.ErrCloneDetected)
+}

--- a/backend/internal/hub/webauthn/config.go
+++ b/backend/internal/hub/webauthn/config.go
@@ -1,0 +1,116 @@
+package webauthn
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/leapmux/leapmux/internal/hub/settings"
+)
+
+// RPConfig carries the relying-party parameters derived from hub settings.
+type RPConfig struct {
+	// RPID is the default RP ID: the host of the hub's base origin.
+	RPID          string
+	RPDisplayName string
+	// RPOrigins lists every browser origin the hub accepts. Origins come
+	// only from configured settings and the listen address — never from a
+	// client Origin/Referer header.
+	RPOrigins []string
+}
+
+// RPConfigFromSettings builds RP parameters from the public_url setting and
+// the process listen address. It returns an error when the hub has no usable
+// browser origin (desktop local-only mode, where listen is empty): passkeys
+// are then cleanly unavailable instead of silently broken.
+func RPConfigFromSettings(s *settings.Snapshot, listen string) (RPConfig, error) {
+	baseURL := settings.BaseURL(s, listen)
+	u, err := url.Parse(baseURL)
+	if err != nil || u.Scheme == "" || u.Hostname() == "" {
+		return RPConfig{}, fmt.Errorf("passkeys need a hub URL; set public_url or enable the TCP listener")
+	}
+	return RPConfig{
+		RPID:          rpIDForHost(u.Hostname()),
+		RPDisplayName: "LeapMux",
+		RPOrigins:     allowedOrigins(u),
+	}, nil
+}
+
+// RPIDForOrigin returns the RP ID for a browser origin the hub allows, and
+// whether the origin is allowed at all. The match is on the full origin
+// (scheme, host, port): a host-only match would admit a different port or
+// scheme, the browser would accept the ceremony (the RP ID is still a
+// suffix of the page host), and the finish-time origin check would then
+// reject the assertion — a guaranteed-dead ceremony after interactive
+// biometric work. An unallowed or unparseable origin reports allowed=false
+// so Begin can refuse it with a clear error. An empty origin (a non-browser
+// client without an Origin header) keeps the default RPID: there is no
+// browser ceremony to mislead.
+func (c RPConfig) RPIDForOrigin(origin string) (rpID string, allowed bool) {
+	if origin == "" {
+		return c.RPID, true
+	}
+	u, err := url.Parse(origin)
+	if err != nil || u.Scheme == "" || u.Hostname() == "" {
+		return "", false
+	}
+	candidate := u.Scheme + "://" + u.Host
+	for _, a := range c.RPOrigins {
+		if strings.EqualFold(a, candidate) {
+			return rpIDForHost(u.Hostname()), true
+		}
+	}
+	return "", false
+}
+
+// allowedOrigins returns the base origin plus the loopback spellings when a
+// hub bound on this host also answers on loopback. Browsers reach the same
+// local hub through several host spellings, and the browser — not the
+// server — decides which one the ceremony runs on.
+func allowedOrigins(u *url.URL) []string {
+	origin := u.Scheme + "://" + u.Host
+	origins := []string{origin}
+	if !servesLoopback(u.Hostname()) {
+		return origins
+	}
+	port := u.Port()
+	for _, alt := range []string{"localhost", "127.0.0.1", "[::1]"} {
+		altURL := u.Scheme + "://" + alt
+		if port != "" {
+			altURL += ":" + port
+		}
+		if !originListed(origins, altURL) {
+			origins = append(origins, altURL)
+		}
+	}
+	return origins
+}
+
+// servesLoopback reports whether a hub bound on this host also answers on
+// the loopback spellings: a loopback bind, a wildcard bind, or an empty host.
+func servesLoopback(host string) bool {
+	h := normalizeHost(host)
+	return isLoopbackHost(h) || h == "0.0.0.0" || h == "::"
+}
+
+func isLoopbackHost(host string) bool {
+	h := normalizeHost(host)
+	return h == "localhost" || h == "127.0.0.1" || h == "::1"
+}
+
+func rpIDForHost(host string) string {
+	return normalizeHost(host)
+}
+
+func normalizeHost(host string) string {
+	return strings.Trim(strings.ToLower(host), "[]")
+}
+
+func originListed(origins []string, candidate string) bool {
+	for _, o := range origins {
+		if strings.EqualFold(o, candidate) {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/hub/webauthn/config_test.go
+++ b/backend/internal/hub/webauthn/config_test.go
@@ -1,0 +1,100 @@
+package webauthn_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/leapmux/leapmux/internal/hub/servicetest"
+	"github.com/leapmux/leapmux/internal/hub/settings"
+	"github.com/leapmux/leapmux/internal/hub/testutil"
+	"github.com/leapmux/leapmux/internal/hub/webauthn"
+)
+
+func TestRPConfigFromSettings_UsesPublicURL(t *testing.T) {
+	st := testutil.OpenTestStore(t)
+	set := servicetest.NewSettingsManager(t, st, nil)
+	ctx := context.Background()
+	require.NoError(t, settings.KeyPublicURL.Set(ctx, set, "https://hub.example.com"))
+
+	cfg, err := webauthn.RPConfigFromSettings(set.Snapshot(ctx), "127.0.0.1:8080")
+	require.NoError(t, err)
+	assert.Equal(t, "hub.example.com", cfg.RPID)
+	assert.Equal(t, []string{"https://hub.example.com"}, cfg.RPOrigins)
+}
+
+func TestRPConfigFromSettings_RejectsOriginlessListen(t *testing.T) {
+	st := testutil.OpenTestStore(t)
+	set := servicetest.NewSettingsManager(t, st, nil)
+	ctx := context.Background()
+
+	// Desktop local-only mode: no TCP listener, no public URL. Passkeys are
+	// cleanly unavailable instead of silently broken against a bogus origin.
+	_, err := webauthn.RPConfigFromSettings(set.Snapshot(ctx), "")
+	require.Error(t, err)
+}
+
+func TestRPConfigFromSettings_LoopbackAliasesMatchOriginHost(t *testing.T) {
+	st := testutil.OpenTestStore(t)
+	set := servicetest.NewSettingsManager(t, st, nil)
+	ctx := context.Background()
+
+	cfg, err := webauthn.RPConfigFromSettings(set.Snapshot(ctx), "127.0.0.1:8080")
+	require.NoError(t, err)
+	assert.Contains(t, cfg.RPOrigins, "http://127.0.0.1:8080")
+	assert.Contains(t, cfg.RPOrigins, "http://localhost:8080")
+	assert.Contains(t, cfg.RPOrigins, "http://[::1]:8080")
+	// The default RP ID is the base origin's host; each allowlisted origin
+	// maps to its own host because browsers reject an RP ID that is not a
+	// suffix of the page origin (localhost is not a suffix of 127.0.0.1).
+	assert.Equal(t, "127.0.0.1", cfg.RPID)
+	rpID, allowed := cfg.RPIDForOrigin("http://localhost:8080")
+	require.True(t, allowed)
+	assert.Equal(t, "localhost", rpID)
+	rpID, allowed = cfg.RPIDForOrigin("http://127.0.0.1:8080")
+	require.True(t, allowed)
+	assert.Equal(t, "127.0.0.1", rpID)
+}
+
+func TestRPConfigFromSettings_WildcardListenServesLoopback(t *testing.T) {
+	st := testutil.OpenTestStore(t)
+	set := servicetest.NewSettingsManager(t, st, nil)
+	ctx := context.Background()
+
+	cfg, err := webauthn.RPConfigFromSettings(set.Snapshot(ctx), "0.0.0.0:9999")
+	require.NoError(t, err)
+	assert.Contains(t, cfg.RPOrigins, "http://localhost:9999")
+	assert.Contains(t, cfg.RPOrigins, "http://127.0.0.1:9999")
+}
+
+func TestRPConfigFromSettings_RPIDForOriginOnlyAllowsConfiguredOrigins(t *testing.T) {
+	st := testutil.OpenTestStore(t)
+	set := servicetest.NewSettingsManager(t, st, nil)
+	ctx := context.Background()
+	require.NoError(t, settings.KeyPublicURL.Set(ctx, set, "http://localhost:4327"))
+
+	cfg, err := webauthn.RPConfigFromSettings(set.Snapshot(ctx), "0.0.0.0:9999")
+	require.NoError(t, err)
+	rpID, allowed := cfg.RPIDForOrigin("http://127.0.0.1:4327")
+	require.True(t, allowed)
+	assert.Equal(t, "127.0.0.1", rpID)
+	// An origin the hub does not serve is refused outright instead of
+	// falling back to the default RP ID: the browser would accept the
+	// ceremony (the RP ID stays a suffix of the page host) and the
+	// finish-time origin check would reject it -- interactive biometric
+	// work for a guaranteed-dead ceremony. A client-claimed origin can
+	// never widen the credential scope either, because it matches nothing.
+	_, allowed = cfg.RPIDForOrigin("https://evil.example.com")
+	assert.False(t, allowed)
+	// A port-mismatched spelling of the allowed host is refused for the
+	// same reason: the host matches, the origin does not.
+	_, allowed = cfg.RPIDForOrigin("http://localhost:9999")
+	assert.False(t, allowed)
+	// An empty origin (a non-browser client without an Origin header) keeps
+	// the default RPID: there is no browser ceremony to mislead.
+	rpID, allowed = cfg.RPIDForOrigin("")
+	require.True(t, allowed)
+	assert.Equal(t, cfg.RPID, rpID)
+}

--- a/backend/internal/hub/webauthn/crypto.go
+++ b/backend/internal/hub/webauthn/crypto.go
@@ -1,0 +1,81 @@
+package webauthn
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	gowebauthn "github.com/go-webauthn/webauthn/webauthn"
+
+	"github.com/leapmux/leapmux/internal/hub/keystore"
+)
+
+func (s *Service) encryptSessionData(sessionID string, data *gowebauthn.SessionData) ([]byte, error) {
+	if s.ks == nil {
+		return nil, fmt.Errorf("keystore required for webauthn sessions")
+	}
+	plain, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("marshal session data: %w", err)
+	}
+	return s.ks.Encrypt(plain, keystore.WebAuthnSessionDataAAD(sessionID))
+}
+
+func (s *Service) decryptSessionData(sessionID string, ciphertext []byte) (*gowebauthn.SessionData, error) {
+	if s.ks == nil {
+		return nil, fmt.Errorf("keystore required for webauthn sessions")
+	}
+	plain, err := s.ks.Decrypt(ciphertext, keystore.WebAuthnSessionDataAAD(sessionID))
+	if err != nil {
+		return nil, fmt.Errorf("decrypt session data: %w", err)
+	}
+	var data gowebauthn.SessionData
+	if err := json.Unmarshal(plain, &data); err != nil {
+		return nil, fmt.Errorf("unmarshal session data: %w", err)
+	}
+	return &data, nil
+}
+
+func (s *Service) encryptPublicKey(credentialRowID string, publicKey []byte) ([]byte, int64, error) {
+	if s.ks == nil {
+		return nil, 0, fmt.Errorf("keystore required for passkey credentials")
+	}
+	enc, err := s.ks.Encrypt(publicKey, keystore.PasskeyPublicKeyAAD(credentialRowID))
+	if err != nil {
+		return nil, 0, err
+	}
+	return enc, int64(s.ks.ActiveVersion()), nil
+}
+
+func (s *Service) decryptPublicKey(credentialRowID string, ciphertext []byte) ([]byte, error) {
+	if s.ks == nil {
+		return nil, fmt.Errorf("keystore required for passkey credentials")
+	}
+	return s.ks.Decrypt(ciphertext, keystore.PasskeyPublicKeyAAD(credentialRowID))
+}
+
+func (s *Service) encryptPayloadJSON(sessionID, plain string) (string, error) {
+	if s.ks == nil {
+		return "", fmt.Errorf("keystore required for webauthn payload")
+	}
+	enc, err := s.ks.Encrypt([]byte(plain), keystore.WebAuthnPayloadAAD(sessionID))
+	if err != nil {
+		return "", fmt.Errorf("encrypt signup draft: %w", err)
+	}
+	return base64.StdEncoding.EncodeToString(enc), nil
+}
+
+func (s *Service) decryptPayloadJSON(sessionID, stored string) (string, error) {
+	if s.ks == nil {
+		return "", fmt.Errorf("keystore required for webauthn payload")
+	}
+	raw, err := base64.StdEncoding.DecodeString(stored)
+	if err != nil {
+		return "", fmt.Errorf("decode signup draft: %w", err)
+	}
+	plain, err := s.ks.Decrypt(raw, keystore.WebAuthnPayloadAAD(sessionID))
+	if err != nil {
+		return "", fmt.Errorf("decrypt signup draft: %w", err)
+	}
+	return string(plain), nil
+}

--- a/backend/internal/hub/webauthn/crypto_test.go
+++ b/backend/internal/hub/webauthn/crypto_test.go
@@ -1,0 +1,124 @@
+package webauthn_test
+
+import (
+	"testing"
+
+	gowebauthn "github.com/go-webauthn/webauthn/webauthn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/leapmux/leapmux/internal/hub/keystore"
+	"github.com/leapmux/leapmux/internal/hub/store/sqlite"
+	"github.com/leapmux/leapmux/internal/hub/webauthn"
+	"github.com/leapmux/leapmux/internal/util/sqlitedb"
+)
+
+func newWebAuthnTestService(t *testing.T) *webauthn.Service {
+	t.Helper()
+	st, err := sqlite.Open(":memory:", sqlitedb.Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	key, err := keystore.GenerateKey()
+	require.NoError(t, err)
+	ks, err := keystore.New(map[uint32][32]byte{1: key})
+	require.NoError(t, err)
+
+	svc, err := webauthn.NewService(webauthn.RPConfig{
+		RPID:          "localhost",
+		RPDisplayName: "LeapMux",
+		RPOrigins:     []string{"http://localhost"},
+	}, st, ks)
+	require.NoError(t, err)
+	return svc
+}
+
+func newTestKeystore(t *testing.T) *keystore.Keystore {
+	t.Helper()
+	key, err := keystore.GenerateKey()
+	require.NoError(t, err)
+	ks, err := keystore.New(map[uint32][32]byte{1: key})
+	require.NoError(t, err)
+	return ks
+}
+
+func TestEncryptDecryptPublicKeyRoundtrip(t *testing.T) {
+	svc := newWebAuthnTestService(t)
+	const rowID = "cred_test"
+	plain := []byte("cose-public-key-bytes")
+
+	enc, version, err := svc.EncryptPublicKey(rowID, plain)
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, version)
+
+	got, err := svc.DecryptPublicKey(rowID, enc)
+	require.NoError(t, err)
+	assert.Equal(t, plain, got)
+}
+
+func TestEncryptDecryptPublicKeyWrongRowIDFails(t *testing.T) {
+	svc := newWebAuthnTestService(t)
+	enc, _, err := svc.EncryptPublicKey("cred_a", []byte("key"))
+	require.NoError(t, err)
+
+	_, err = svc.DecryptPublicKey("cred_b", enc)
+	assert.Error(t, err)
+}
+
+func TestPasskeyPublicKeyAADIsRowBound(t *testing.T) {
+	ks := newTestKeystore(t)
+	plain := []byte("secret")
+	aad := keystore.PasskeyPublicKeyAAD("row-1")
+
+	enc, err := ks.Encrypt(plain, aad)
+	require.NoError(t, err)
+
+	_, err = ks.Decrypt(enc, keystore.PasskeyPublicKeyAAD("row-2"))
+	assert.Error(t, err)
+
+	got, err := ks.Decrypt(enc, aad)
+	require.NoError(t, err)
+	assert.Equal(t, plain, got)
+}
+
+func TestWebAuthnPayloadAADIsSessionBound(t *testing.T) {
+	ks := newTestKeystore(t)
+	plain := []byte(`{"email":"a@example.com"}`)
+	aad := keystore.WebAuthnPayloadAAD("sess-1")
+
+	enc, err := ks.Encrypt(plain, aad)
+	require.NoError(t, err)
+
+	_, err = ks.Decrypt(enc, keystore.WebAuthnPayloadAAD("sess-2"))
+	assert.Error(t, err)
+
+	got, err := ks.Decrypt(enc, aad)
+	require.NoError(t, err)
+	assert.Equal(t, plain, got)
+}
+
+func TestWebAuthnSessionDataAADIsSessionBound(t *testing.T) {
+	ks := newTestKeystore(t)
+	plain := []byte(`{"challenge":"abc"}`)
+	aad := keystore.WebAuthnSessionDataAAD("sess-1")
+
+	enc, err := ks.Encrypt(plain, aad)
+	require.NoError(t, err)
+
+	_, err = ks.Decrypt(enc, keystore.WebAuthnSessionDataAAD("sess-2"))
+	assert.Error(t, err)
+
+	got, err := ks.Decrypt(enc, aad)
+	require.NoError(t, err)
+	assert.Equal(t, plain, got)
+}
+
+func TestRoundTripSessionData(t *testing.T) {
+	svc := newWebAuthnTestService(t)
+	data := &gowebauthn.SessionData{Challenge: "test-challenge", UserID: []byte("user-1")}
+
+	got, err := svc.RoundTripSessionData("sess-1", data)
+	require.NoError(t, err)
+	assert.Equal(t, data.Challenge, got.Challenge)
+	assert.Equal(t, data.UserID, got.UserID)
+}

--- a/backend/internal/hub/webauthn/kinds.go
+++ b/backend/internal/hub/webauthn/kinds.go
@@ -1,0 +1,10 @@
+package webauthn
+
+// Ceremony session kinds stored in webauthn_sessions.kind.
+const (
+	KindSignup      = "signup"
+	KindLogin       = "login"
+	KindRegister    = "register"
+	KindReauth      = "reauth"
+	KindReauthProof = "reauth_proof"
+)

--- a/backend/internal/hub/webauthn/service.go
+++ b/backend/internal/hub/webauthn/service.go
@@ -1,0 +1,674 @@
+package webauthn
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-webauthn/webauthn/protocol"
+	gowebauthn "github.com/go-webauthn/webauthn/webauthn"
+
+	"github.com/leapmux/leapmux/internal/hub/keystore"
+	"github.com/leapmux/leapmux/internal/hub/store"
+	"github.com/leapmux/leapmux/internal/util/id"
+)
+
+const (
+	sessionTTL = 5 * time.Minute
+	// reauthProofTTL must span the whole step-up window, not one ceremony:
+	// the proof is minted at FinishPasskeyReauth (browser prompt one) and is
+	// only consumed at the Finish of the management ceremony that follows
+	// (browser prompt two). Two interactive OS prompts plus both RPC legs
+	// routinely exceed two minutes.
+	reauthProofTTL = 10 * time.Minute
+)
+
+// SignupDraft is stored in webauthn_sessions.payload_json during passkey signup.
+// UserID is allocated at BeginSignUp and reused as the WebAuthn user handle and
+// the users row primary key, so assertion userHandle matches on later logins.
+type SignupDraft struct {
+	UserID      string `json:"userId"`
+	Username    string `json:"username"`
+	Email       string `json:"email"`
+	DisplayName string `json:"displayName"`
+	// RPID records the RP ID the ceremony started with so Finish rebuilds
+	// the same relying-party parameters.
+	RPID string `json:"rpId,omitempty"`
+}
+
+// ceremonyMeta is stored in webauthn_sessions.payload_json for the
+// login, register, and reauth kinds so Finish rebuilds the RP ID the
+// ceremony started with.
+type ceremonyMeta struct {
+	RPID string `json:"rpId"`
+}
+
+// Service orchestrates WebAuthn ceremonies with encrypted session and credential storage.
+type Service struct {
+	w     *gowebauthn.WebAuthn
+	rp    RPConfig
+	store store.Store
+	ks    *keystore.Keystore
+}
+
+// NewService constructs a WebAuthn service from RP config and collaborators.
+func NewService(rp RPConfig, st store.Store, ks *keystore.Keystore) (*Service, error) {
+	if ks == nil {
+		return nil, fmt.Errorf("webauthn service requires keystore")
+	}
+	cfg := &gowebauthn.Config{
+		RPID:          rp.RPID,
+		RPDisplayName: rp.RPDisplayName,
+		RPOrigins:     rp.RPOrigins,
+		AuthenticatorSelection: protocol.AuthenticatorSelection{
+			UserVerification: protocol.VerificationRequired,
+		},
+	}
+	w, err := gowebauthn.New(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("create webauthn: %w", err)
+	}
+	return &Service{w: w, rp: rp, store: st, ks: ks}, nil
+}
+
+// ceremonyWebAuthn returns the go-webauthn instance for a ceremony RP ID.
+// A ceremony bound to a different allowed origin (for example 127.0.0.1
+// instead of localhost) needs the RP ID of that origin in both its options
+// and its finish-time validation, because the browser hashes the RP ID into
+// the assertion.
+func (s *Service) ceremonyWebAuthn(rpID string) (*gowebauthn.WebAuthn, error) {
+	if rpID == "" || rpID == s.rp.RPID {
+		return s.w, nil
+	}
+	cfg := *s.w.Config
+	cfg.RPID = rpID
+	w, err := gowebauthn.New(&cfg)
+	if err != nil {
+		return nil, fmt.Errorf("create webauthn for rp id %q: %w", rpID, err)
+	}
+	return w, nil
+}
+
+// BeginSignUp starts a passkey-only signup ceremony. origin is the browser
+// origin of the request; it must be one the hub allows.
+func (s *Service) BeginSignUp(ctx context.Context, draft SignupDraft, origin string) (sessionID string, optionsJSON string, rpID string, err error) {
+	if draft.UserID == "" {
+		draft.UserID = id.Generate()
+	}
+	draft.RPID, err = s.ceremonyRPIDForOrigin(origin)
+	if err != nil {
+		return "", "", "", err
+	}
+	payload, err := json.Marshal(draft)
+	if err != nil {
+		return "", "", "", fmt.Errorf("marshal signup draft: %w", err)
+	}
+	waUser := &user{
+		id:          userIDBytes(draft.UserID),
+		name:        draft.Username,
+		displayName: draft.DisplayName,
+	}
+	w, err := s.ceremonyWebAuthn(draft.RPID)
+	if err != nil {
+		return "", "", "", err
+	}
+	creation, session, err := w.BeginRegistration(waUser)
+	if err != nil {
+		return "", "", "", fmt.Errorf("begin registration: %w", err)
+	}
+	sessionID, optionsJSON, err = s.persistSession(ctx, KindSignup, "", string(payload), session, creation)
+	return sessionID, optionsJSON, draft.RPID, err
+}
+
+// BeginLogin starts a passkey login for an existing user.
+func (s *Service) BeginLogin(ctx context.Context, userID, origin string) (sessionID string, optionsJSON string, rpID string, err error) {
+	return s.beginAssertion(ctx, KindLogin, userID, origin)
+}
+
+// FinishLogin validates a passkey assertion and returns the authenticated
+// user (derived from the ceremony session) and the passkey count of the
+// loaded credential set.
+func (s *Service) FinishLogin(ctx context.Context, sessionID, credentialJSON string) (*store.User, int64, error) {
+	return s.validateAssertion(ctx, sessionID, KindLogin, "", credentialJSON)
+}
+
+// beginAssertion runs the shared begin flow for login and reauth: resolve
+// the ceremony RP ID from the request origin, refuse an account with no
+// passkeys, mint assertion options, and persist the per-user ceremony
+// session (persistSession replaces any prior open row of the same kind, so
+// repeated Begin calls cannot accumulate ceremony rows until TTL cleanup).
+func (s *Service) beginAssertion(ctx context.Context, kind, userID, origin string) (sessionID string, optionsJSON string, rpID string, err error) {
+	rpID, err = s.ceremonyRPIDForOrigin(origin)
+	if err != nil {
+		return "", "", "", err
+	}
+	w, waUser, count, err := s.loadUserWithRPID(ctx, userID, rpID)
+	if err != nil {
+		return "", "", "", err
+	}
+	if count == 0 {
+		return "", "", "", ErrNoPasskeys
+	}
+	assertion, session, err := w.BeginLogin(waUser)
+	if err != nil {
+		return "", "", "", fmt.Errorf("begin assertion: %w", err)
+	}
+	sessionID, optionsJSON, err = s.persistSession(ctx, kind, userID, ceremonyPayload(rpID), session, assertion)
+	return sessionID, optionsJSON, rpID, err
+}
+
+// ceremonyRPIDForOrigin resolves the request origin to a ceremony RP ID,
+// refusing an origin the hub does not serve before any interactive
+// ceremony starts.
+func (s *Service) ceremonyRPIDForOrigin(origin string) (string, error) {
+	rpID, allowed := s.rp.RPIDForOrigin(origin)
+	if !allowed {
+		return "", fmt.Errorf("%w: %q", ErrOriginNotAllowed, origin)
+	}
+	return rpID, nil
+}
+
+// validateAssertion runs the assertion pipeline shared by login and reauth:
+// consume the ceremony session, bind the session's user (an empty
+// expectedUserID derives it from the session row; otherwise the session must
+// belong to that user), load the credential set with the ceremony's RP ID,
+// parse and validate the assertion, reject clone warnings, and persist the
+// sign count. Kind-specific concerns (signup drafts, proof minting) stay
+// with the callers.
+func (s *Service) validateAssertion(ctx context.Context, sessionID, wantKind, expectedUserID, credentialJSON string) (*store.User, int64, error) {
+	row, sessionData, err := s.consumeCeremonySession(ctx, sessionID, wantKind)
+	if err != nil {
+		return nil, 0, err
+	}
+	userID := expectedUserID
+	if userID == "" {
+		if row.UserID == "" {
+			return nil, 0, fmt.Errorf("%w: missing user", ErrCeremonyInvalid)
+		}
+		userID = row.UserID
+	} else if row.UserID != expectedUserID {
+		return nil, 0, fmt.Errorf("%w: session owner mismatch", ErrCeremonyInvalid)
+	}
+	if !bytes.Equal(sessionData.UserID, userIDBytes(userID)) {
+		return nil, 0, fmt.Errorf("%w: user mismatch", ErrCeremonyInvalid)
+	}
+	w, stored, count, err := s.loadUserWithRPID(ctx, userID, ceremonyRPID(row.PayloadJSON))
+	if err != nil {
+		return nil, 0, err
+	}
+	parsed, err := protocol.ParseCredentialRequestResponseBody(strings.NewReader(credentialJSON))
+	if err != nil {
+		return nil, 0, fmt.Errorf("%w: parse: %w", ErrAssertionRejected, err)
+	}
+	cred, err := w.ValidateLogin(stored, *sessionData, parsed)
+	if err != nil {
+		return nil, 0, fmt.Errorf("%w: %w", ErrAssertionRejected, err)
+	}
+	if err := RejectIfCloneWarning(cred); err != nil {
+		return nil, 0, err
+	}
+	if err := s.applySignCountUpdate(ctx, cred.ID, userID, int64(cred.Authenticator.SignCount), time.Now().UTC()); err != nil {
+		return nil, 0, err
+	}
+	return stored.source, count, nil
+}
+
+// FinishedSignUpCredential is the credential material a finish call returns
+// for the caller to commit inside its own transaction.
+type FinishedSignUpCredential struct {
+	CredentialID   []byte
+	PublicKey      []byte
+	SignCount      int64
+	AAGUID         []byte
+	BackupEligible bool
+	BackupState    bool
+	Transports     string
+}
+
+// FinishSignUp validates attestation and returns the signup draft plus credential data.
+func (s *Service) FinishSignUp(ctx context.Context, sessionID, credentialJSON string) (SignupDraft, FinishedSignUpCredential, error) {
+	var zero FinishedSignUpCredential
+	row, sessionData, err := s.consumeCeremonySession(ctx, sessionID, KindSignup)
+	if err != nil {
+		return SignupDraft{}, zero, err
+	}
+	plain, err := s.decryptPayloadJSON(sessionID, row.PayloadJSON)
+	if err != nil {
+		return SignupDraft{}, zero, err
+	}
+	draft, err := ParseSignupDraft(plain)
+	if err != nil {
+		return SignupDraft{}, zero, fmt.Errorf("parse signup draft: %w", err)
+	}
+	if draft.UserID == "" {
+		return SignupDraft{}, zero, fmt.Errorf("signup draft missing user id")
+	}
+	waUser := &user{
+		id:          sessionData.UserID,
+		name:        draft.Username,
+		displayName: draft.DisplayName,
+	}
+	if !bytes.Equal(waUser.id, userIDBytes(draft.UserID)) {
+		return SignupDraft{}, zero, fmt.Errorf("signup draft user id mismatch")
+	}
+	w, err := s.ceremonyWebAuthn(draft.RPID)
+	if err != nil {
+		return SignupDraft{}, zero, err
+	}
+	finished, err := verifyAttestation(w, waUser, *sessionData, credentialJSON)
+	if err != nil {
+		return SignupDraft{}, zero, err
+	}
+	return draft, finished, nil
+}
+
+// BeginRegistration starts adding a passkey to an authenticated account.
+func (s *Service) BeginRegistration(ctx context.Context, userID, origin string) (sessionID string, optionsJSON string, rpID string, err error) {
+	rpID, err = s.ceremonyRPIDForOrigin(origin)
+	if err != nil {
+		return "", "", "", err
+	}
+	w, waUser, _, err := s.loadUserWithRPID(ctx, userID, rpID)
+	if err != nil {
+		return "", "", "", err
+	}
+	creation, session, err := w.BeginRegistration(waUser,
+		gowebauthn.WithExclusions(gowebauthn.Credentials(waUser.credentials).CredentialDescriptors()),
+	)
+	if err != nil {
+		return "", "", "", fmt.Errorf("begin registration: %w", err)
+	}
+	sessionID, optionsJSON, err = s.persistSession(ctx, KindRegister, userID, ceremonyPayload(rpID), session, creation)
+	return sessionID, optionsJSON, rpID, err
+}
+
+// FinishRegistration validates attestation and stores a new passkey for userID.
+func (s *Service) FinishRegistration(ctx context.Context, userID, sessionID, credentialJSON, friendlyName string) (*store.PasskeyCredential, error) {
+	row, sessionData, err := s.consumeCeremonySession(ctx, sessionID, KindRegister)
+	if err != nil {
+		return nil, err
+	}
+	if row.UserID != userID {
+		return nil, fmt.Errorf("%w: owner mismatch", ErrCeremonyInvalid)
+	}
+	w, waUser, _, err := s.loadUserWithRPID(ctx, userID, ceremonyRPID(row.PayloadJSON))
+	if err != nil {
+		return nil, err
+	}
+	finished, err := verifyAttestation(w, waUser, *sessionData, credentialJSON)
+	if err != nil {
+		return nil, err
+	}
+	if friendlyName == "" {
+		friendlyName = "Passkey"
+	}
+	return s.StoreCredential(ctx, s.store, id.Generate(), userID, finished, friendlyName)
+}
+
+// BeginReauth starts a passkey assertion for step-up authentication.
+func (s *Service) BeginReauth(ctx context.Context, userID, origin string) (sessionID string, optionsJSON string, rpID string, err error) {
+	return s.beginAssertion(ctx, KindReauth, userID, origin)
+}
+
+// FinishReauth validates a passkey assertion and mints a single-use reauth proof.
+func (s *Service) FinishReauth(ctx context.Context, userID, sessionID, credentialJSON string) (string, error) {
+	if _, _, err := s.validateAssertion(ctx, sessionID, KindReauth, userID, credentialJSON); err != nil {
+		return "", err
+	}
+	now := time.Now().UTC()
+
+	proofID := id.Generate()
+	proofSession := &gowebauthn.SessionData{UserID: userIDBytes(userID)}
+	enc, err := s.encryptSessionData(proofID, proofSession)
+	if err != nil {
+		return "", err
+	}
+	if err := s.store.WebAuthnSessions().Create(ctx, store.CreateWebAuthnSessionParams{
+		ID:          proofID,
+		Kind:        KindReauthProof,
+		UserID:      userID,
+		PayloadJSON: "{}",
+		SessionData: enc,
+		ExpiresAt:   now.Add(reauthProofTTL),
+		CreatedAt:   now,
+	}); err != nil {
+		return "", err
+	}
+	return proofID, nil
+}
+
+// StoreCredential encrypts and persists a passkey credential row through the
+// given store, so a caller that commits inside a transaction writes the row
+// in that same transaction. It returns the persisted row, built from the
+// same values it wrote, so the credential-to-row mapping has one home.
+func (s *Service) StoreCredential(ctx context.Context, st store.Store, rowID, userID string, cred FinishedSignUpCredential, friendlyName string) (*store.PasskeyCredential, error) {
+	encKey, keyVersion, err := s.encryptPublicKey(rowID, cred.PublicKey)
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now().UTC()
+	if err := st.PasskeyCredentials().Create(ctx, store.CreatePasskeyCredentialParams{
+		ID:             rowID,
+		UserID:         userID,
+		CredentialID:   cred.CredentialID,
+		PublicKey:      encKey,
+		SignCount:      cred.SignCount,
+		AAGUID:         cred.AAGUID,
+		BackupEligible: cred.BackupEligible,
+		BackupState:    cred.BackupState,
+		Transports:     cred.Transports,
+		FriendlyName:   friendlyName,
+		KeyVersion:     keyVersion,
+		CreatedAt:      now,
+	}); err != nil {
+		return nil, err
+	}
+	return &store.PasskeyCredential{
+		ID:             rowID,
+		UserID:         userID,
+		CredentialID:   cred.CredentialID,
+		SignCount:      cred.SignCount,
+		AAGUID:         cred.AAGUID,
+		BackupEligible: cred.BackupEligible,
+		BackupState:    cred.BackupState,
+		Transports:     cred.Transports,
+		FriendlyName:   friendlyName,
+		KeyVersion:     keyVersion,
+		CreatedAt:      now,
+	}, nil
+}
+
+// verifyAttestation parses an attestation response, validates it against the
+// ceremony session, and assembles the finished credential material shared by
+// signup and registration finishes.
+func verifyAttestation(w *gowebauthn.WebAuthn, waUser *user, sessionData gowebauthn.SessionData, credentialJSON string) (FinishedSignUpCredential, error) {
+	parsed, err := protocol.ParseCredentialCreationResponseBody(strings.NewReader(credentialJSON))
+	if err != nil {
+		return FinishedSignUpCredential{}, fmt.Errorf("%w: parse: %w", ErrAssertionRejected, err)
+	}
+	cred, err := w.CreateCredential(waUser, sessionData, parsed)
+	if err != nil {
+		return FinishedSignUpCredential{}, fmt.Errorf("%w: %w", ErrAssertionRejected, err)
+	}
+	transports, err := json.Marshal(cred.Transport)
+	if err != nil {
+		return FinishedSignUpCredential{}, fmt.Errorf("marshal transports: %w", err)
+	}
+	return FinishedSignUpCredential{
+		CredentialID:   cred.ID,
+		PublicKey:      cred.PublicKey,
+		SignCount:      int64(cred.Authenticator.SignCount),
+		AAGUID:         cred.Authenticator.AAGUID,
+		BackupEligible: cred.Flags.BackupEligible,
+		BackupState:    cred.Flags.BackupState,
+		Transports:     string(transports),
+	}, nil
+}
+
+func (s *Service) persistSession(ctx context.Context, kind, userID, payload string, session *gowebauthn.SessionData, options any) (sessionID, optionsJSON string, err error) {
+	// Login, register, and reauth ceremonies are per-user. Replace any
+	// prior open row of the same kind so repeated Begin calls cannot
+	// accumulate encrypted sessions until TTL cleanup. Signup has no
+	// users FK yet (the account does not exist), so it cannot replace
+	// by user; captcha on BeginSignUp limits anonymous accumulation.
+	if userID != "" {
+		switch kind {
+		case KindLogin, KindRegister, KindReauth:
+			if err := s.store.WebAuthnSessions().DeleteByUserAndKind(ctx, userID, kind); err != nil {
+				return "", "", fmt.Errorf("clear prior %s ceremony: %w", kind, err)
+			}
+		}
+	}
+	sessionID = id.Generate()
+	enc, err := s.encryptSessionData(sessionID, session)
+	if err != nil {
+		return "", "", err
+	}
+	payloadJSON := payload
+	if kind == KindSignup {
+		encPayload, encErr := s.encryptPayloadJSON(sessionID, payload)
+		if encErr != nil {
+			return "", "", encErr
+		}
+		payloadJSON = encPayload
+	}
+	now := time.Now().UTC()
+	if err := s.store.WebAuthnSessions().Create(ctx, store.CreateWebAuthnSessionParams{
+		ID:          sessionID,
+		Kind:        kind,
+		UserID:      userID,
+		PayloadJSON: payloadJSON,
+		SessionData: enc,
+		ExpiresAt:   now.Add(sessionTTL),
+		CreatedAt:   now,
+	}); err != nil {
+		return "", "", fmt.Errorf("store session: %w", err)
+	}
+	optionsJSON, err = marshalOptions(options)
+	if err != nil {
+		return "", "", err
+	}
+	return sessionID, optionsJSON, nil
+}
+
+func marshalOptions(v any) (string, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "", fmt.Errorf("marshal options: %w", err)
+	}
+	return string(b), nil
+}
+
+// ceremonyRPID extracts the persisted RP ID from a ceremony payload. An
+// empty value means the ceremony used the default RP ID.
+func ceremonyRPID(payload string) string {
+	var meta ceremonyMeta
+	if err := json.Unmarshal([]byte(payload), &meta); err != nil {
+		return ""
+	}
+	return meta.RPID
+}
+
+func ceremonyPayload(rpID string) string {
+	b, err := json.Marshal(ceremonyMeta{RPID: rpID})
+	if err != nil {
+		return "{}"
+	}
+	return string(b)
+}
+
+// consumeCeremonySession loads a ceremony row then atomically deletes it so a
+// second Finish call cannot reuse the same assertion/attestation. The kind
+// and expiry rules live in the consume SQL; Go does not re-check them.
+func (s *Service) consumeCeremonySession(ctx context.Context, sessionID, wantKind string) (*store.WebAuthnSession, *gowebauthn.SessionData, error) {
+	row, err := s.store.WebAuthnSessions().Get(ctx, sessionID)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, nil, fmt.Errorf("%w", ErrCeremonyInvalid)
+		}
+		return nil, nil, fmt.Errorf("load session: %w", err)
+	}
+	if row.Kind != wantKind {
+		return nil, nil, fmt.Errorf("%w: wrong kind", ErrCeremonyInvalid)
+	}
+	data, err := s.decryptSessionData(sessionID, row.SessionData)
+	if err != nil {
+		return nil, nil, err
+	}
+	n, err := s.store.WebAuthnSessions().ConsumeCeremony(ctx, sessionID, wantKind, time.Now().UTC())
+	if err != nil {
+		return nil, nil, fmt.Errorf("consume ceremony session: %w", err)
+	}
+	if n == 0 {
+		return nil, nil, fmt.Errorf("%w", ErrCeremonyInvalid)
+	}
+	return row, data, nil
+}
+
+// RPID returns the default relying-party ID for this hub.
+func (s *Service) RPID() string {
+	return s.rp.RPID
+}
+
+// loadUserWithRPID loads the user row and its passkey credentials and returns
+// the go-webauthn instance for the given ceremony RP ID.
+func (s *Service) loadUserWithRPID(ctx context.Context, userID, rpID string) (*gowebauthn.WebAuthn, *user, int64, error) {
+	u, err := s.store.Users().GetByID(ctx, userID)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, nil, 0, fmt.Errorf("user not found")
+		}
+		return nil, nil, 0, fmt.Errorf("load user: %w", err)
+	}
+	creds, err := s.store.PasskeyCredentials().ListByUser(ctx, userID)
+	if err != nil {
+		return nil, nil, 0, fmt.Errorf("list passkeys: %w", err)
+	}
+	waCreds := make([]gowebauthn.Credential, 0, len(creds))
+	for _, c := range creds {
+		pub, err := s.decryptPublicKey(c.ID, c.PublicKey)
+		if err != nil {
+			return nil, nil, 0, fmt.Errorf("decrypt passkey %s: %w", c.ID, err)
+		}
+		var transports []protocol.AuthenticatorTransport
+		if c.Transports != "" && c.Transports != "[]" {
+			_ = json.Unmarshal([]byte(c.Transports), &transports)
+		}
+		waCreds = append(waCreds, gowebauthn.Credential{
+			ID:        c.CredentialID,
+			PublicKey: pub,
+			Transport: transports,
+			Flags: gowebauthn.CredentialFlags{
+				BackupEligible: c.BackupEligible,
+				BackupState:    c.BackupState,
+			},
+			Authenticator: gowebauthn.Authenticator{
+				AAGUID:    c.AAGUID,
+				SignCount: uint32(c.SignCount),
+			},
+		})
+	}
+	waUser := &user{
+		id:          userIDBytes(userID),
+		name:        u.Username,
+		displayName: u.DisplayName,
+		credentials: waCreds,
+		source:      u,
+	}
+	w, err := s.ceremonyWebAuthn(rpID)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	return w, waUser, int64(len(creds)), nil
+}
+
+// DecryptPublicKey exposes keystore decrypt for tests and reencrypt tooling.
+func (s *Service) DecryptPublicKey(credentialRowID string, ciphertext []byte) ([]byte, error) {
+	return s.decryptPublicKey(credentialRowID, ciphertext)
+}
+
+// EncryptPublicKey exposes keystore encrypt for tests.
+func (s *Service) EncryptPublicKey(credentialRowID string, publicKey []byte) ([]byte, int64, error) {
+	return s.encryptPublicKey(credentialRowID, publicKey)
+}
+
+// DecryptPayloadJSON exposes signup-draft decrypt for tests.
+func (s *Service) DecryptPayloadJSON(sessionID, stored string) (string, error) {
+	return s.decryptPayloadJSON(sessionID, stored)
+}
+
+// ErrCloneDetected is returned when the authenticator sign count indicates a
+// possible cloned credential (WebAuthn CloneWarning).
+var ErrCloneDetected = errors.New("authenticator sign count indicates a possible clone")
+
+// ErrCeremonyInvalid reports a ceremony session that is missing, expired,
+// of the wrong kind, or bound to another user.
+var ErrCeremonyInvalid = errors.New("invalid or expired ceremony session")
+
+// ErrAssertionRejected reports a ceremony that ran but whose attestation or
+// assertion failed validation.
+var ErrAssertionRejected = errors.New("passkey assertion rejected")
+
+// ErrNoPasskeys reports an account with no registered passkeys at Begin
+// time, so callers classify it with errors.Is instead of matching text.
+var ErrNoPasskeys = errors.New("no passkeys registered")
+
+// ErrOriginNotAllowed reports a browser origin the hub does not serve. The
+// ceremony is refused at Begin instead of failing at Finish, after the user
+// already completed an interactive prompt.
+var ErrOriginNotAllowed = errors.New("origin is not allowed for passkey ceremonies")
+
+// RejectIfCloneWarning refuses an assertion when go-webauthn flagged a
+// non-monotonic sign count. The library still returns success and only sets
+// CloneWarning; the relying party must fail the ceremony.
+func RejectIfCloneWarning(cred *gowebauthn.Credential) error {
+	if cred != nil && cred.Authenticator.CloneWarning {
+		return ErrCloneDetected
+	}
+	return nil
+}
+
+// applySignCountUpdate writes the authenticator sign count with one
+// monotonic conditional update keyed by the credential id the assertion
+// carried: the store advances the row only when the assertion count is
+// strictly greater (a zero assertion pairs with a stored zero — an
+// authenticator that never maintained a counter). Ceremony sessions are
+// already consumed before this runs, so a valid strictly-greater assertion
+// must never fail on a concurrent advance; the monotonic predicate cannot
+// lose that race, and no retry loop is needed.
+//
+// WebAuthn clone detection: when both the stored count and the assertion
+// count are greater than zero, the assertion must be strictly greater.
+// An equality or a regression matches no row (0 rows -> ErrNotFound), and
+// the re-read below reports it as a clone. A drop to zero from a positive
+// stored count is already rejected before this runs
+// (RejectIfCloneWarning), per the WebAuthn clone-detection rule.
+func (s *Service) applySignCountUpdate(ctx context.Context, credentialID []byte, userID string, newSignCount int64, lastUsedAt time.Time) error {
+	err := s.store.PasskeyCredentials().UpdateSignCount(ctx, store.UpdatePasskeySignCountParams{
+		CredentialID: credentialID,
+		UserID:       userID,
+		SignCount:    newSignCount,
+		LastUsedAt:   lastUsedAt,
+	})
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, store.ErrNotFound) {
+		return fmt.Errorf("update sign count: %w", err)
+	}
+	// No row advanced: the stored count already reached or passed the
+	// assertion count. Classify against the committed row.
+	fresh, freshErr := s.store.PasskeyCredentials().GetByCredentialID(ctx, credentialID)
+	if freshErr != nil {
+		return fmt.Errorf("re-read credential after sign count update: %w", freshErr)
+	}
+	if fresh.UserID != userID {
+		return fmt.Errorf("credential owner mismatch")
+	}
+	if newSignCount > 0 && fresh.SignCount > 0 && newSignCount <= fresh.SignCount {
+		return ErrCloneDetected
+	}
+	return fmt.Errorf("update sign count: row did not advance (stored %d, assertion %d)", fresh.SignCount, newSignCount)
+}
+
+// RoundTripSessionData is a test helper for session encrypt/decrypt.
+func (s *Service) RoundTripSessionData(sessionID string, data *gowebauthn.SessionData) (*gowebauthn.SessionData, error) {
+	enc, err := s.encryptSessionData(sessionID, data)
+	if err != nil {
+		return nil, err
+	}
+	return s.decryptSessionData(sessionID, enc)
+}
+
+// ParseSignupDraft decodes a signup payload_json blob.
+func ParseSignupDraft(payload string) (SignupDraft, error) {
+	var draft SignupDraft
+	if err := json.Unmarshal([]byte(payload), &draft); err != nil {
+		return SignupDraft{}, err
+	}
+	return draft, nil
+}

--- a/backend/internal/hub/webauthn/service.go
+++ b/backend/internal/hub/webauthn/service.go
@@ -286,27 +286,34 @@ func (s *Service) BeginRegistration(ctx context.Context, userID, origin string) 
 	return sessionID, optionsJSON, rpID, err
 }
 
-// FinishRegistration validates attestation and stores a new passkey for userID.
-func (s *Service) FinishRegistration(ctx context.Context, userID, sessionID, credentialJSON, friendlyName string) (*store.PasskeyCredential, error) {
+// VerifyRegistration consumes the ceremony session and validates the
+// attestation, WITHOUT writing the credential. It is the half that needs no
+// transaction, so a caller that must write inside one can keep this work
+// outside it.
+//
+// That split is not cosmetic on SQLite, which has a single writer lock:
+// this runs a keystore decrypt per existing credential plus a JSON, base64,
+// and CBOR parse of a caller-supplied body capped only at the 4 MiB request
+// limit. Holding the writer lock for all of that queues every other write
+// on the hub behind one registration. The ceremony consume is its own
+// atomic conditional UPDATE, so it does not need to share the caller's
+// transaction either -- only the credential INSERT does.
+//
+// FinishSignUp and CompletePasswordReset already order their expensive work
+// this way; this is the same shape for the registration path.
+func (s *Service) VerifyRegistration(ctx context.Context, userID, sessionID, credentialJSON string) (FinishedSignUpCredential, error) {
 	row, sessionData, err := s.consumeCeremonySession(ctx, sessionID, KindRegister)
 	if err != nil {
-		return nil, err
+		return FinishedSignUpCredential{}, err
 	}
 	if row.UserID != userID {
-		return nil, fmt.Errorf("%w: owner mismatch", ErrCeremonyInvalid)
+		return FinishedSignUpCredential{}, fmt.Errorf("%w: owner mismatch", ErrCeremonyInvalid)
 	}
 	w, waUser, _, err := s.loadUserWithRPID(ctx, userID, ceremonyRPID(row.PayloadJSON))
 	if err != nil {
-		return nil, err
+		return FinishedSignUpCredential{}, err
 	}
-	finished, err := verifyAttestation(w, waUser, *sessionData, credentialJSON)
-	if err != nil {
-		return nil, err
-	}
-	if friendlyName == "" {
-		friendlyName = "Passkey"
-	}
-	return s.StoreCredential(ctx, s.store, id.Generate(), userID, finished, friendlyName)
+	return verifyAttestation(w, waUser, *sessionData, credentialJSON)
 }
 
 // BeginReauth starts a passkey assertion for step-up authentication.
@@ -346,6 +353,12 @@ func (s *Service) FinishReauth(ctx context.Context, userID, sessionID, credentia
 // in that same transaction. It returns the persisted row, built from the
 // same values it wrote, so the credential-to-row mapping has one home.
 func (s *Service) StoreCredential(ctx context.Context, st store.Store, rowID, userID string, cred FinishedSignUpCredential, friendlyName string) (*store.PasskeyCredential, error) {
+	// The default lives at the WRITE, not at one caller: every path that
+	// stores a credential gets it, and a row with an empty name renders as
+	// a blank entry in the settings list.
+	if friendlyName == "" {
+		friendlyName = "Passkey"
+	}
 	encKey, keyVersion, err := s.encryptPublicKey(rowID, cred.PublicKey)
 	if err != nil {
 		return nil, err

--- a/backend/internal/hub/webauthn/signcount_test.go
+++ b/backend/internal/hub/webauthn/signcount_test.go
@@ -1,0 +1,151 @@
+package webauthn
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/leapmux/leapmux/internal/hub/keystore"
+	"github.com/leapmux/leapmux/internal/hub/store"
+	"github.com/leapmux/leapmux/internal/hub/store/sqlite"
+	"github.com/leapmux/leapmux/internal/util/id"
+	"github.com/leapmux/leapmux/internal/util/sqlitedb"
+)
+
+func newSignCountTestService(t *testing.T) (*Service, store.Store, string, string, []byte) {
+	t.Helper()
+	st, err := sqlite.Open(":memory:", sqlitedb.Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+	require.NoError(t, st.Migrator().Migrate(context.Background()))
+
+	key, err := keystore.GenerateKey()
+	require.NoError(t, err)
+	ks, err := keystore.New(map[uint32][32]byte{1: key})
+	require.NoError(t, err)
+
+	svc, err := NewService(RPConfig{
+		RPID:          "localhost",
+		RPDisplayName: "LeapMux",
+		RPOrigins:     []string{"http://localhost"},
+	}, st, ks)
+	require.NoError(t, err)
+
+	userID := id.Generate()
+	require.NoError(t, st.Users().Create(context.Background(), store.CreateUserParams{
+		ID:           userID,
+		Username:     "scuser" + userID[:8],
+		PasswordHash: "hash",
+		DisplayName:  "SC User",
+		PasswordSet:  true,
+	}))
+	rowID := id.Generate()
+	credID := []byte("cred-" + rowID)
+	now := time.Now().UTC()
+	require.NoError(t, st.PasskeyCredentials().Create(context.Background(), store.CreatePasskeyCredentialParams{
+		ID:           rowID,
+		UserID:       userID,
+		CredentialID: credID,
+		PublicKey:    []byte("pk"),
+		SignCount:    10,
+		Transports:   "[]",
+		FriendlyName: "Key",
+		KeyVersion:   1,
+		CreatedAt:    now,
+	}))
+	return svc, st, userID, rowID, credID
+}
+
+func TestApplySignCountUpdate_Succeeds(t *testing.T) {
+	svc, st, userID, rowID, credID := newSignCountTestService(t)
+	require.NoError(t, svc.applySignCountUpdate(context.Background(), credID, userID, 11, time.Now().UTC()))
+
+	row, err := st.PasskeyCredentials().GetByID(context.Background(), rowID)
+	require.NoError(t, err)
+	assert.EqualValues(t, 11, row.SignCount)
+}
+
+func TestApplySignCountUpdate_EqualNonZeroIsClone(t *testing.T) {
+	svc, st, userID, _, credID := newSignCountTestService(t)
+	now := time.Now().UTC()
+	require.NoError(t, st.PasskeyCredentials().UpdateSignCount(context.Background(), store.UpdatePasskeySignCountParams{
+		CredentialID: credID, UserID: userID, SignCount: 11, LastUsedAt: now,
+	}))
+
+	err := svc.applySignCountUpdate(context.Background(), credID, userID, 11, now)
+	assert.ErrorIs(t, err, ErrCloneDetected, "a second assertion at an already-applied non-zero count is a clone")
+}
+
+func TestApplySignCountUpdate_ZeroCounterDoesNotClone(t *testing.T) {
+	svc, st, userID, rowID, credID := newSignCountTestService(t)
+	now := time.Now().UTC()
+	require.NoError(t, st.PasskeyCredentials().UpdateSignCount(context.Background(), store.UpdatePasskeySignCountParams{
+		CredentialID: credID, UserID: userID, SignCount: 0, LastUsedAt: now,
+	}))
+
+	require.NoError(t, svc.applySignCountUpdate(context.Background(), credID, userID, 0, now))
+	row, err := st.PasskeyCredentials().GetByID(context.Background(), rowID)
+	require.NoError(t, err)
+	assert.EqualValues(t, 0, row.SignCount)
+}
+
+func TestApplySignCountUpdate_RetriesPastConcurrentAdvance(t *testing.T) {
+	svc, st, userID, rowID, credID := newSignCountTestService(t)
+	now := time.Now().UTC()
+	// Simulate another finish that advanced 10 -> 11 while we still aim for 12.
+	require.NoError(t, st.PasskeyCredentials().UpdateSignCount(context.Background(), store.UpdatePasskeySignCountParams{
+		CredentialID: credID, UserID: userID, SignCount: 11, LastUsedAt: now,
+	}))
+
+	err := svc.applySignCountUpdate(context.Background(), credID, userID, 12, now)
+	require.NoError(t, err)
+
+	row, err := st.PasskeyCredentials().GetByID(context.Background(), rowID)
+	require.NoError(t, err)
+	assert.EqualValues(t, 12, row.SignCount)
+}
+
+func TestApplySignCountUpdate_RejectsBehindCounter(t *testing.T) {
+	svc, _, userID, _, credID := newSignCountTestService(t)
+	err := svc.applySignCountUpdate(context.Background(), credID, userID, 9, time.Now().UTC())
+	assert.ErrorIs(t, err, ErrCloneDetected)
+}
+
+func TestApplySignCountUpdate_ConcurrentSameTarget(t *testing.T) {
+	svc, st, userID, rowID, credID := newSignCountTestService(t)
+	now := time.Now().UTC()
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 8)
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := svc.applySignCountUpdate(context.Background(), credID, userID, 11, now)
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(errs)
+
+	successes := 0
+	clones := 0
+	for err := range errs {
+		if errors.Is(err, ErrCloneDetected) {
+			clones++
+			continue
+		}
+		require.NoError(t, err)
+		successes++
+	}
+	assert.Equal(t, 1, successes, "exactly one concurrent writer may commit the increment")
+	assert.Equal(t, 7, clones, "the other writers must fail clone detection")
+	row, err := st.PasskeyCredentials().GetByID(context.Background(), rowID)
+	require.NoError(t, err)
+	assert.EqualValues(t, 11, row.SignCount)
+}

--- a/backend/internal/hub/webauthn/user.go
+++ b/backend/internal/hub/webauthn/user.go
@@ -1,0 +1,27 @@
+package webauthn
+
+import (
+	gowebauthn "github.com/go-webauthn/webauthn/webauthn"
+
+	"github.com/leapmux/leapmux/internal/hub/store"
+)
+
+// user adapts a LeapMux account to go-webauthn's User interface. source
+// carries the loaded store row so callers can reuse it without a second
+// query after a ceremony.
+type user struct {
+	id          []byte
+	name        string
+	displayName string
+	credentials []gowebauthn.Credential
+	source      *store.User
+}
+
+func (u *user) WebAuthnID() []byte                           { return u.id }
+func (u *user) WebAuthnName() string                         { return u.name }
+func (u *user) WebAuthnDisplayName() string                  { return u.displayName }
+func (u *user) WebAuthnCredentials() []gowebauthn.Credential { return u.credentials }
+
+func userIDBytes(userID string) []byte {
+	return []byte(userID)
+}

--- a/desktop/go/socket_test.go
+++ b/desktop/go/socket_test.go
@@ -208,9 +208,10 @@ func TestRunSocketServerRetriesTransientAcceptError(t *testing.T) {
 // closed, then returns net.ErrClosed -- a retry storm that ends only when
 // the listener dies.
 type emfileListener struct {
-	mu     sync.Mutex
-	calls  int
-	closed chan struct{}
+	mu        sync.Mutex
+	calls     int
+	closed    chan struct{}
+	closeOnce sync.Once
 }
 
 func (l *emfileListener) Accept() (net.Conn, error) {
@@ -225,12 +226,12 @@ func (l *emfileListener) Accept() (net.Conn, error) {
 	}
 }
 
+// Close is idempotent and safe to call concurrently. A select/default
+// check-then-act races when closeListenerOnShutdown and the deferred
+// listener.Close() in runSocketServer both run -- both find the channel
+// open and both close it, panicking with "close of closed channel".
 func (l *emfileListener) Close() error {
-	select {
-	case <-l.closed:
-	default:
-		close(l.closed)
-	}
+	l.closeOnce.Do(func() { close(l.closed) })
 	return nil
 }
 
@@ -240,6 +241,23 @@ func (l *emfileListener) acceptCalls() int {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	return l.calls
+}
+
+func TestEmfileListenerCloseIsConcurrencySafe(t *testing.T) {
+	t.Parallel()
+	for range 200 {
+		l := &emfileListener{closed: make(chan struct{})}
+		var wg sync.WaitGroup
+		for range 8 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				assert.NoError(t, l.Close())
+			}()
+		}
+		wg.Wait()
+		assert.ErrorIs(t, func() error { _, err := l.Accept(); return err }(), net.ErrClosed)
+	}
 }
 
 // An external shutdown must end the sidecar promptly even mid-retry-storm: the

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -23,6 +23,7 @@
         "@noble/hashes": "^2.2.0",
         "@noble/post-quantum": "^0.6.1",
         "@shikijs/rehype": "^4.4.1",
+        "@simplewebauthn/browser": "^13.3.0",
         "@solidjs/router": "^1.0.0",
         "@solidjs/start": "^1.3.2",
         "@tauri-apps/api": "^2.11.1",
@@ -515,6 +516,8 @@
     "@shikijs/types": ["@shikijs/types@4.4.1", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.5" } }, "sha512-GOwCLQDHM5EjGUWNPrhzJbr6JP8V/Dx/CDVkWvbZ1Avw5JFnNUckrgbLmE07qtg4WlW7Q7QFndhjIkeU9XMPvw=="],
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
+    "@simplewebauthn/browser": ["@simplewebauthn/browser@13.3.0", "", {}, "sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ=="],
 
     "@sindresorhus/base62": ["@sindresorhus/base62@1.0.0", "", {}, "sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,6 +38,7 @@
     "@noble/hashes": "^2.2.0",
     "@noble/post-quantum": "^0.6.1",
     "@shikijs/rehype": "^4.4.1",
+    "@simplewebauthn/browser": "^13.3.0",
     "@solidjs/router": "^1.0.0",
     "@solidjs/start": "^1.3.2",
     "@tauri-apps/api": "^2.11.1",

--- a/frontend/src/components/common/AltchaField.test.tsx
+++ b/frontend/src/components/common/AltchaField.test.tsx
@@ -180,6 +180,24 @@ describe('altchaField', () => {
       expect(mockFetchAltchaChallenge).toHaveBeenCalledTimes(2)
     })
   })
+
+  it('re-arms from the handle when widget.reset throws', async () => {
+    let handle: CaptchaFieldHandle | undefined
+    const { container } = render(() => (
+      <div><AltchaField onPayload={vi.fn()} onUnavailable={vi.fn()} ref={h => (handle = h)} /></div>
+    ))
+    await vi.waitFor(() => {
+      expect(widgetEls(container)[0].configure).toHaveBeenCalled()
+    })
+    widgetEls(container)[0].reset.mockImplementation(() => {
+      throw new Error('n?.reset is not a function')
+    })
+
+    expect(() => handle!.reset()).not.toThrow()
+    await vi.waitFor(() => {
+      expect(mockFetchAltchaChallenge).toHaveBeenCalledTimes(2)
+    })
+  })
 })
 
 describe('captchaHoneypot', () => {

--- a/frontend/src/components/common/AltchaField.tsx
+++ b/frontend/src/components/common/AltchaField.tsx
@@ -71,10 +71,17 @@ export const AltchaField: Component<AltchaFieldProps> = (props) => {
   }
 
   function resetWidget() {
-    // reset() is not always a function: the element can still be mounting,
-    // or a keyed remount (Password/Passkey action switch) can tear it
-    // down while this handle still runs. A throw here used to skip arm()
-    // and leave the checkbox dead.
+    // reset() is not always a function: <altcha-widget> is a custom
+    // element, and the method is genuinely absent until the browser
+    // upgrades it. A throw here used to skip arm() and leave the checkbox
+    // dead.
+    //
+    // NOT a keyed remount: CaptchaField wraps only the Turnstile and
+    // reCAPTCHA arms in a keyed Show, and ALTCHA is the unwrapped
+    // fallback, so this field never tears down on a Password/Passkey
+    // switch. Skipping the reset is safe either way -- the caller has
+    // already cleared the payload and readiness, and arm() re-configures
+    // the widget with a fresh challenge.
     try {
       if (typeof widget?.reset === 'function')
         widget.reset()

--- a/frontend/src/components/common/AltchaField.tsx
+++ b/frontend/src/components/common/AltchaField.tsx
@@ -70,6 +70,20 @@ export const AltchaField: Component<AltchaFieldProps> = (props) => {
     }
   }
 
+  function resetWidget() {
+    // reset() is not always a function: the element can still be mounting,
+    // or a keyed remount (Password/Passkey action switch) can tear it
+    // down while this handle still runs. A throw here used to skip arm()
+    // and leave the checkbox dead.
+    try {
+      if (typeof widget?.reset === 'function')
+        widget.reset()
+    }
+    catch {
+      // Ignore teardown and pre-configure failures.
+    }
+  }
+
   function handleStateChange(ev: Event) {
     const detail = (ev as CustomEvent<{ state: string, payload?: string }>).detail
     if (detail.state === 'verified' && detail.payload) {
@@ -80,7 +94,7 @@ export const AltchaField: Component<AltchaFieldProps> = (props) => {
       // An expired challenge (idle on the form too long) or a solve error
       // needs a fresh challenge before the user can try again.
       if (detail.state === 'expired' || detail.state === 'error') {
-        widget?.reset()
+        resetWidget()
         void arm()
       }
     }
@@ -94,8 +108,9 @@ export const AltchaField: Component<AltchaFieldProps> = (props) => {
         armEpoch++
         props.onPayload(null)
         base.setReady(false)
-        widget?.reset()
-        void arm()
+        resetWidget()
+        if (!base.disposed())
+          void arm()
       },
     })
   })

--- a/frontend/src/components/common/CaptchaField.test.tsx
+++ b/frontend/src/components/common/CaptchaField.test.tsx
@@ -1,6 +1,7 @@
+import type { CaptchaFieldProps } from './CaptchaField'
+
 /// <reference types="vitest/globals" />
 import { render } from '@solidjs/testing-library'
-
 import { createSignal } from 'solid-js'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { CaptchaProvider } from '~/generated/leapmux/v1/auth_pb'
@@ -70,5 +71,19 @@ describe('captchaField dispatcher', () => {
     setProvider(99 as CaptchaProvider)
     renderDispatcher()
     expect(altchaMounted).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-mounts the provider field when the form action changes', () => {
+    setProvider(CaptchaProvider.TURNSTILE)
+    const [action, setAction] = createSignal<CaptchaFieldProps['action']>('login')
+    render(() => (
+      <CaptchaField action={action()} onPayload={vi.fn()} onUnavailable={vi.fn()} ref={vi.fn()} />
+    ))
+    expect(turnstileMounted).toHaveBeenCalledTimes(1)
+    expect(turnstileMounted.mock.calls[0]?.[0]?.action).toBe('login')
+
+    setAction('passkey_login')
+    expect(turnstileMounted).toHaveBeenCalledTimes(2)
+    expect(turnstileMounted.mock.calls[1]?.[0]?.action).toBe('passkey_login')
   })
 })

--- a/frontend/src/components/common/CaptchaField.tsx
+++ b/frontend/src/components/common/CaptchaField.tsx
@@ -42,9 +42,16 @@ export interface CaptchaFieldProps {
 // selected row — the safe default on both ends.
 //
 // Only the external providers key on the action: they bind the action into
-// the token, and their own effect re-arms when it changes. ALTCHA ignores
-// the action entirely (the hub drops it), so it stays mounted across
-// Password/Passkey toggles and keeps the user's solved challenge.
+// the token, so a Password/Passkey toggle must mint a fresh one or the hub
+// denies it. The keyed Show is the whole mechanism -- it disposes the field,
+// and createCaptchaFieldBase's onCleanup then tears the widget down and
+// clears the payload together, which an in-field effect would have to
+// re-derive by hand. Neither approach avoids the re-solve, because the
+// action is bound at render/execute time either way.
+//
+// ALTCHA ignores the action entirely (the hub drops it), so it stays
+// mounted across Password/Passkey toggles and keeps the user's solved
+// challenge.
 export const CaptchaField: Component<CaptchaFieldProps> = (props) => {
   return (
     <Switch fallback={<AltchaField onPayload={props.onPayload} onUnavailable={props.onUnavailable} ref={props.ref} />}>

--- a/frontend/src/components/common/CaptchaField.tsx
+++ b/frontend/src/components/common/CaptchaField.tsx
@@ -1,5 +1,5 @@
 import type { Component } from 'solid-js'
-import { Match, Switch } from 'solid-js'
+import { Match, Show, Switch } from 'solid-js'
 
 import { CaptchaProvider } from '~/generated/leapmux/v1/auth_pb'
 import { getCaptchaProvider } from '~/lib/systemInfo'
@@ -21,7 +21,7 @@ export interface CaptchaFieldProps {
    * 'complete_signup'. External providers bind it into the token and the
    * hub refuses mismatches; ALTCHA ignores it.
    */
-  action: 'login' | 'signup' | 'complete_signup'
+  action: 'login' | 'signup' | 'complete_signup' | 'passkey_login' | 'passkey_signup' | 'password_reset' | 'complete_password_reset'
   /** Receives the provider token once solved, null otherwise. */
   onPayload: (payload: string | null) => void
   /**
@@ -40,14 +40,23 @@ export interface CaptchaFieldProps {
 // without a page refresh. Anything but the two external enum values falls
 // back to ALTCHA, which the hub serves whenever it cannot resolve the
 // selected row — the safe default on both ends.
+//
+// Only the external providers key on the action: they bind the action into
+// the token, and their own effect re-arms when it changes. ALTCHA ignores
+// the action entirely (the hub drops it), so it stays mounted across
+// Password/Passkey toggles and keeps the user's solved challenge.
 export const CaptchaField: Component<CaptchaFieldProps> = (props) => {
   return (
     <Switch fallback={<AltchaField onPayload={props.onPayload} onUnavailable={props.onUnavailable} ref={props.ref} />}>
       <Match when={getCaptchaProvider() === CaptchaProvider.TURNSTILE}>
-        <TurnstileField action={props.action} onPayload={props.onPayload} ref={props.ref} />
+        <Show when={props.action} keyed>
+          {action => <TurnstileField action={action} onPayload={props.onPayload} ref={props.ref} />}
+        </Show>
       </Match>
       <Match when={getCaptchaProvider() === CaptchaProvider.RECAPTCHA_V3}>
-        <RecaptchaV3Field action={props.action} onPayload={props.onPayload} ref={props.ref} />
+        <Show when={props.action} keyed>
+          {action => <RecaptchaV3Field action={action} onPayload={props.onPayload} ref={props.ref} />}
+        </Show>
       </Match>
     </Switch>
   )

--- a/frontend/src/components/common/ForgotPasswordPage.test.tsx
+++ b/frontend/src/components/common/ForgotPasswordPage.test.tsx
@@ -1,0 +1,106 @@
+import { Code, ConnectError } from '@connectrpc/connect'
+import { createMemoryHistory, MemoryRouter, Route } from '@solidjs/router'
+/// <reference types="vitest/globals" />
+import { fireEvent, render, screen } from '@solidjs/testing-library'
+import { createSignal } from 'solid-js'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { CaptchaProvider } from '~/generated/leapmux/v1/auth_pb'
+import { mockLoadSystemInfo, resetSystemInfoMock, setSystemInfoMock } from '~/test-support/systemInfoMock'
+
+import { ForgotPasswordPage } from './ForgotPasswordPage'
+
+const mockRequestPasswordReset = vi.fn()
+
+vi.mock('~/api/clients', () => ({
+  authClient: {
+    requestPasswordReset: (...args: unknown[]) => mockRequestPasswordReset(...args),
+  },
+}))
+
+vi.mock('~/lib/systemInfo', async () => {
+  const m = await import('~/test-support/systemInfoMock')
+  return m.systemInfoMock
+})
+
+const [mockCaptchaPayload, setMockCaptchaPayload] = createSignal<string | null>(null)
+vi.mock('~/components/common/CaptchaField', async () => {
+  const { createEffect } = await import('solid-js')
+  return {
+    CaptchaField: (props: { action: string, onPayload: (p: string | null) => void, onUnavailable: () => void }) => {
+      createEffect(() => props.onPayload(mockCaptchaPayload()))
+      return <div data-testid="captcha-field" data-action={props.action} />
+    },
+  }
+})
+vi.mock('~/components/common/CaptchaHoneypot', () => ({
+  CaptchaHoneypot: (props: { value: string, onInput: (v: string) => void }) => (
+    <input
+      data-testid="captcha-honeypot"
+      type="text"
+      name="website"
+      value={props.value}
+      onInput={e => props.onInput(e.currentTarget.value)}
+    />
+  ),
+}))
+
+function renderForgotPasswordPage() {
+  const history = createMemoryHistory()
+  history.set({ value: '/forgot-password', replace: true, scroll: false })
+  return render(() => (
+    <MemoryRouter history={history}>
+      <Route path="/forgot-password" component={ForgotPasswordPage} />
+      <Route path="/login" component={() => <div data-testid="login-page" />} />
+    </MemoryRouter>
+  ))
+}
+
+describe('forgot password page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetSystemInfoMock()
+    setMockCaptchaPayload(null)
+    mockRequestPasswordReset.mockResolvedValue({})
+  })
+
+  it('keeps Send reset link disabled until an identifier is entered', async () => {
+    renderForgotPasswordPage()
+    expect(await screen.findByRole('button', { name: 'Send reset link' })).toBeDisabled()
+    fireEvent.input(screen.getByLabelText('Email or username'), { target: { value: 'alice' } })
+    expect(screen.getByRole('button', { name: 'Send reset link' })).toBeEnabled()
+  })
+
+  it('shows the generic success copy and does not re-enable submit after a successful request', async () => {
+    renderForgotPasswordPage()
+    fireEvent.input(await screen.findByLabelText('Email or username'), { target: { value: 'alice' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Send reset link' }))
+    await vi.waitFor(() => {
+      expect(mockRequestPasswordReset).toHaveBeenCalledWith(expect.objectContaining({
+        identifier: 'alice',
+      }))
+    })
+    expect(await screen.findByText(/If an account with that email or username exists/)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Send reset link' })).not.toBeInTheDocument()
+  })
+
+  it('passes the password_reset action to the captcha field', async () => {
+    setSystemInfoMock({ captchaEnabled: true, captchaProvider: CaptchaProvider.TURNSTILE, captchaSiteKey: '1x00000000000000000000AA' })
+    renderForgotPasswordPage()
+    await vi.waitFor(() => {
+      expect(screen.getByTestId('captcha-field')).toHaveAttribute('data-action', 'password_reset')
+    })
+  })
+
+  it('re-enables Send reset link after a failed attempt and refreshes captcha info on PermissionDenied', async () => {
+    mockRequestPasswordReset.mockRejectedValue(new ConnectError('denied', Code.PermissionDenied))
+    renderForgotPasswordPage()
+    fireEvent.input(await screen.findByLabelText('Email or username'), { target: { value: 'alice' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Send reset link' }))
+    await vi.waitFor(() => {
+      expect(mockRequestPasswordReset).toHaveBeenCalledOnce()
+    })
+    expect(await screen.findByRole('button', { name: 'Send reset link' })).toBeEnabled()
+    expect(mockLoadSystemInfo).toHaveBeenCalledWith(true)
+  })
+})

--- a/frontend/src/components/common/ForgotPasswordPage.tsx
+++ b/frontend/src/components/common/ForgotPasswordPage.tsx
@@ -1,0 +1,82 @@
+import type { Component } from 'solid-js'
+import { A } from '@solidjs/router'
+import { createSignal, Show } from 'solid-js'
+import { authClient } from '~/api/clients'
+import { CaptchaSection } from '~/components/common/CaptchaSection'
+import { Spinner } from '~/components/common/Spinner'
+import { createCaptchaForm } from '~/lib/captchaForm'
+import { formatErrorMessage } from '~/lib/errors'
+import { errorText, pageCard, successText } from '~/styles/shared.css'
+import * as styles from './LoginPage.css'
+
+export const ForgotPasswordPage: Component = () => {
+  const [identifier, setIdentifier] = createSignal('')
+  const [submitting, setSubmitting] = createSignal(false)
+  const [error, setError] = createSignal<string | null>(null)
+  const [submitted, setSubmitted] = createSignal(false)
+  const captcha = createCaptchaForm()
+
+  const handleSubmit = async (e: Event) => {
+    e.preventDefault()
+    if (!identifier().trim())
+      return
+    setSubmitting(true)
+    setError(null)
+    try {
+      await authClient.requestPasswordReset({
+        identifier: identifier().trim(),
+        ...captcha.fields(),
+      })
+      setSubmitted(true)
+    }
+    catch (err) {
+      setError(formatErrorMessage(err, 'Request failed'))
+      captcha.reset(err)
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div class={styles.container}>
+      <div class={pageCard}>
+        <h1>Reset password</h1>
+        <Show
+          when={!submitted()}
+          fallback={(
+            <div class="vstack gap-4">
+              <p class={successText}>
+                If an account with that email or username exists, we sent a reset link.
+              </p>
+              <A href="/login">Back to login</A>
+            </div>
+          )}
+        >
+          <p>Enter your email or username and we will send a reset link if an account exists.</p>
+          <form class="vstack gap-4" onSubmit={handleSubmit}>
+            <label>
+              Email or username
+              <input
+                type="text"
+                value={identifier()}
+                onInput={e => setIdentifier(e.currentTarget.value)}
+                autocomplete="username"
+                required
+              />
+            </label>
+            <CaptchaSection action="password_reset" captcha={captcha} />
+            <Show when={error()}>
+              <div class={errorText}>{error()}</div>
+            </Show>
+            <button type="submit" disabled={submitting() || !identifier().trim() || captcha.blocksSubmit()}>
+              <Show when={submitting()}><Spinner /></Show>
+              {submitting() ? 'Sending…' : 'Send reset link'}
+            </button>
+          </form>
+          <div class={styles.authFooter}>
+            <A href="/login">Back to login</A>
+          </div>
+        </Show>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/common/LoginPage.test.tsx
+++ b/frontend/src/components/common/LoginPage.test.tsx
@@ -1,11 +1,12 @@
+import { Code, ConnectError } from '@connectrpc/connect'
 import { createMemoryHistory, MemoryRouter, Route } from '@solidjs/router'
 /// <reference types="vitest/globals" />
 import { fireEvent, render, screen } from '@solidjs/testing-library'
 import { createSignal } from 'solid-js'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { CaptchaProvider } from '~/generated/leapmux/v1/auth_pb'
-import { mockLoadOAuthProviders, resetSystemInfoMock, setSystemInfoMock } from '~/test-support/systemInfoMock'
+import { mockLoadOAuthProviders, mockLoadSystemInfo, resetSystemInfoMock, setSystemInfoMock } from '~/test-support/systemInfoMock'
 
 import { LoginPage } from './LoginPage'
 
@@ -60,6 +61,8 @@ vi.mock('~/components/common/CaptchaHoneypot', () => ({
 }))
 
 const mockLogin = vi.fn()
+const mockLoginWithPasskey = vi.fn()
+const mockSetVerificationResendAvailableAt = vi.fn()
 const mockUser = vi.fn<() => { id: string, username: string } | null>(() => null)
 // `loading` is a real signal so a test can hold the page in the pre-bootstrap
 // state and then release it, which is the whole shape of the race below.
@@ -70,8 +73,11 @@ vi.mock('~/context/AuthContext', () => ({
     loading: () => authLoading(),
     error: () => null,
     login: mockLogin,
+    loginWithPasskey: mockLoginWithPasskey,
     logout: vi.fn(),
     setAuth: vi.fn(),
+    setVerificationResendAvailableAt: mockSetVerificationResendAvailableAt,
+    verificationResendAvailableAt: () => undefined,
     isAuthenticated: () => false,
   }),
   AuthProvider: (props: { children: unknown }) => <>{props.children}</>,
@@ -84,6 +90,7 @@ function renderLoginPage(initialPath = '/login') {
     <MemoryRouter history={history}>
       <Route path="/login" component={LoginPage} />
       <Route path="/" component={() => <div data-testid="app-home" />} />
+      <Route path="/verify-email" component={() => <div data-testid="verify-email-page" />} />
       <Route path="/setup" component={() => <div data-testid="setup-page" />} />
     </MemoryRouter>
   ))
@@ -96,6 +103,8 @@ describe('loginPage', () => {
     setMockCaptchaPayload(null)
     mockCaptchaUnavailable = undefined
     setAuthLoading(false)
+    mockLogin.mockResolvedValue({ verificationRequired: false, verificationEmailSent: false })
+    mockLoginWithPasskey.mockResolvedValue({ verificationRequired: false, verificationEmailSent: false })
   })
 
   // These three pin the bootstrap race. The system-info getters are plain
@@ -389,7 +398,7 @@ describe('loginPage', () => {
   it('keeps button disabled after successful login', async () => {
     mockLogin.mockImplementation(() => {
       mockUser.mockReturnValue({ id: 'u1', username: 'alice' })
-      return Promise.resolve()
+      return Promise.resolve({ verificationRequired: false, verificationEmailSent: false })
     })
 
     renderLoginPage()
@@ -416,10 +425,41 @@ describe('loginPage', () => {
     expect(screen.queryByRole('button', { name: 'Sign in' })).not.toBeInTheDocument()
   })
 
+  it('re-enables the form when a login resolves without a user', async () => {
+    // A conforming server always populates user on success; a server
+    // regression or a response-shape change must not strand the form on a
+    // spinner with no error. The finally block re-enables submission.
+    mockLogin.mockImplementation(() => {
+      mockUser.mockReturnValue(null)
+      return Promise.resolve({ verificationRequired: false, verificationEmailSent: false })
+    })
+
+    renderLoginPage()
+
+    await vi.waitFor(() => {
+      expect(screen.getByLabelText('Username')).toBeInTheDocument()
+    })
+
+    fireEvent.input(screen.getByLabelText('Username'), { target: { value: 'alice' } })
+    fireEvent.input(screen.getByLabelText('Password'), { target: { value: 'secret' } })
+
+    const button = screen.getByRole('button', { name: 'Sign in' })
+    fireEvent.click(button)
+
+    await vi.waitFor(() => {
+      expect(mockLogin).toHaveBeenCalledOnce()
+    })
+    await new Promise(r => setTimeout(r, 0))
+
+    // The form recovers: the button is enabled and says 'Sign in' again.
+    const recovered = screen.getByRole('button', { name: 'Sign in' })
+    expect(recovered).toBeEnabled()
+  })
+
   it('redirects to / after successful login when no redirect param', async () => {
     mockLogin.mockImplementation(() => {
       mockUser.mockReturnValue({ id: 'u1', username: 'alice' })
-      return Promise.resolve()
+      return Promise.resolve({ verificationRequired: false, verificationEmailSent: false })
     })
 
     renderLoginPage()
@@ -434,5 +474,90 @@ describe('loginPage', () => {
 
     // Flat user-owned home is `/` (no org slug).
     expect(await screen.findByTestId('app-home')).toBeInTheDocument()
+  })
+
+  it('redirects to /verify-email when login reports verification required', async () => {
+    mockLogin.mockImplementation(() => {
+      mockUser.mockReturnValue({ id: 'u1', username: 'alice' })
+      return Promise.resolve({ verificationRequired: true, verificationEmailSent: true })
+    })
+
+    renderLoginPage()
+
+    await vi.waitFor(() => {
+      expect(screen.getByLabelText('Username')).toBeInTheDocument()
+    })
+
+    fireEvent.input(screen.getByLabelText('Username'), { target: { value: 'alice' } })
+    fireEvent.input(screen.getByLabelText('Password'), { target: { value: 'secret' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }))
+
+    expect(await screen.findByTestId('verify-email-page')).toBeInTheDocument()
+  })
+
+  it('always shows the password and passkey method chooser', async () => {
+    renderLoginPage()
+    await vi.waitFor(() => {
+      expect(screen.getByLabelText('Username')).toBeInTheDocument()
+    })
+    expect(screen.getByRole('radiogroup', { name: 'Sign-in method' })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: 'Password' })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: 'Passkey' })).toBeInTheDocument()
+  })
+
+  it('shows forgot password when email is enabled and password sign-in is selected', async () => {
+    setSystemInfoMock({ emailEnabled: true })
+    renderLoginPage()
+    await vi.waitFor(() => {
+      expect(screen.getByText('Forgot password?')).toBeInTheDocument()
+    })
+  })
+
+  it('switches captcha action when the passkey method is selected', async () => {
+    setSystemInfoMock({ captchaEnabled: true, captchaProvider: CaptchaProvider.TURNSTILE, captchaSiteKey: '1x00000000000000000000AA' })
+    renderLoginPage()
+    await vi.waitFor(() => {
+      expect(screen.getByTestId('captcha-field')).toHaveAttribute('data-action', 'login')
+    })
+    fireEvent.click(screen.getByRole('radio', { name: 'Passkey' }))
+    await vi.waitFor(() => {
+      expect(screen.getByTestId('captcha-field')).toHaveAttribute('data-action', 'passkey_login')
+    })
+  })
+
+  it('keeps Sign in disabled while a login is in flight', async () => {
+    let resolveLogin!: (value: { verificationRequired: boolean, verificationEmailSent: boolean }) => void
+    mockLogin.mockReturnValue(new Promise((resolve) => {
+      resolveLogin = resolve
+    }))
+    renderLoginPage()
+    await vi.waitFor(() => {
+      expect(screen.getByLabelText('Username')).toBeInTheDocument()
+    })
+    fireEvent.input(screen.getByLabelText('Username'), { target: { value: 'alice' } })
+    fireEvent.input(screen.getByLabelText('Password'), { target: { value: 'secret' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }))
+    expect(await screen.findByRole('button', { name: 'Signing in...' })).toBeDisabled()
+    fireEvent.click(screen.getByRole('button', { name: 'Signing in...' }))
+    expect(mockLogin).toHaveBeenCalledOnce()
+    mockUser.mockReturnValue({ id: '1', username: 'alice' })
+    resolveLogin({ verificationRequired: false, verificationEmailSent: false })
+    expect(await screen.findByTestId('app-home')).toBeInTheDocument()
+  })
+
+  it('re-enables Sign in after a failed attempt and refreshes captcha info on PermissionDenied', async () => {
+    mockLogin.mockRejectedValue(new ConnectError('denied', Code.PermissionDenied))
+    renderLoginPage()
+    await vi.waitFor(() => {
+      expect(screen.getByLabelText('Username')).toBeInTheDocument()
+    })
+    fireEvent.input(screen.getByLabelText('Username'), { target: { value: 'alice' } })
+    fireEvent.input(screen.getByLabelText('Password'), { target: { value: 'secret' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }))
+    await vi.waitFor(() => {
+      expect(mockLogin).toHaveBeenCalledOnce()
+    })
+    expect(await screen.findByRole('button', { name: 'Sign in' })).toBeEnabled()
+    expect(mockLoadSystemInfo).toHaveBeenCalledWith(true)
   })
 })

--- a/frontend/src/components/common/LoginPage.tsx
+++ b/frontend/src/components/common/LoginPage.tsx
@@ -1,3 +1,4 @@
+import type { Timestamp } from '@bufbuild/protobuf/wkt'
 import type { Component } from 'solid-js'
 
 import type { OAuthProviderInfo } from '~/generated/leapmux/v1/auth_pb'
@@ -5,12 +6,16 @@ import { A, useNavigate, useSearchParams } from '@solidjs/router'
 import { createEffect, createSignal, Show } from 'solid-js'
 import { CaptchaSection } from '~/components/common/CaptchaSection'
 import { OAuthProviderList } from '~/components/common/OAuthProviderList'
+import { PillGroup } from '~/components/common/PillGroup'
 import { Spinner } from '~/components/common/Spinner'
 import { useAuth } from '~/context/AuthContext'
 import { createCaptchaForm } from '~/lib/captchaForm'
-import { isSetupRequired, isSignupEnabled, isSoloMode, loadOAuthProviders } from '~/lib/systemInfo'
+import { safeRedirect } from '~/lib/safeRedirect'
+import { isEmailEnabled, isPasskeyEnabled, isSetupRequired, isSignupEnabled, isSoloMode, loadOAuthProviders } from '~/lib/systemInfo'
 import { errorText, pageCard } from '~/styles/shared.css'
 import * as styles from './LoginPage.css'
+
+type LoginMethod = 'password' | 'passkey'
 
 export const LoginPage: Component = () => {
   const auth = useAuth()
@@ -18,6 +23,7 @@ export const LoginPage: Component = () => {
   const [searchParams] = useSearchParams()
   const [username, setUsername] = createSignal('')
   const [password, setPassword] = createSignal('')
+  const [loginMethod, setLoginMethod] = createSignal<LoginMethod>('password')
   const [submitting, setSubmitting] = createSignal(false)
   const [oauthProviders, setOAuthProviders] = createSignal<OAuthProviderInfo[]>([])
   const captcha = createCaptchaForm()
@@ -79,26 +85,42 @@ export const LoginPage: Component = () => {
     void loadOAuthProviders().then(setOAuthProviders)
   })
 
+  const navigateAfterAuth = (verificationRequired: boolean, nextResendAvailableAt?: Timestamp) => {
+    if (verificationRequired) {
+      auth.setVerificationResendAvailableAt(nextResendAvailableAt)
+      navigate('/verify-email', { replace: true })
+      return
+    }
+    const redirect = safeRedirect(typeof searchParams.redirect === 'string' ? searchParams.redirect : undefined)
+    navigate(redirect ?? '/', { replace: true })
+  }
+
+  // The passkey pill renders only when the hub can run ceremonies; a stale
+  // passkey selection falls back to the password arm.
+  const effectiveMethod = (): LoginMethod => {
+    return loginMethod() === 'passkey' && isPasskeyEnabled() ? 'passkey' : 'password'
+  }
+
   const handleSubmit = async (e: Event) => {
     e.preventDefault()
     setSubmitting(true)
     try {
-      await auth.login(username(), password(), captcha.fields())
-      const user = auth.user()
-      if (user) {
-        const redirect = typeof searchParams.redirect === 'string' ? searchParams.redirect : undefined
-        if (redirect && redirect.startsWith('/') && !redirect.startsWith('//')) {
-          navigate(redirect, { replace: true })
-        }
-        else {
-          navigate('/', { replace: true })
-        }
-      }
+      const result = effectiveMethod() === 'passkey'
+        ? await auth.loginWithPasskey(username(), captcha.fields())
+        : await auth.login(username(), password(), captcha.fields())
+      if (auth.user())
+        navigateAfterAuth(result.verificationRequired, result.nextResendAvailableAt)
+      // A success without a user leaves nowhere to navigate; the finally
+      // below re-enables the form instead of leaving a spinner with no
+      // error and no way to resubmit.
     }
     catch (err) {
       // Error is captured by auth context. A rejected captcha (expired
-      // solve, replay) must not linger: force a fresh challenge.
+      // solve, replay) must not linger: force a fresh challenge. Pass
+      // the error so PermissionDenied refreshes captcha system-info.
       captcha.reset(err)
+    }
+    finally {
       setSubmitting(false)
     }
   }
@@ -110,6 +132,16 @@ export const LoginPage: Component = () => {
       return `${url}?redirect=${encodeURIComponent(redirect)}`
     }
     return url
+  }
+
+  const captchaAction = () => effectiveMethod() === 'passkey' ? 'passkey_login' as const : 'login' as const
+
+  const canSubmit = () => {
+    if (!username() || captcha.blocksSubmit())
+      return false
+    if (effectiveMethod() === 'passkey')
+      return true
+    return !!password()
   }
 
   return (
@@ -135,27 +167,45 @@ export const LoginPage: Component = () => {
               autocomplete="username"
             />
           </label>
-          <label>
-            Password
-            <input
-              ref={passwordRef}
-              type="password"
-              value={password()}
-              onInput={e => setPassword(e.currentTarget.value)}
-              autocomplete="current-password"
-            />
-          </label>
-          <CaptchaSection action="login" captcha={captcha} />
+          <PillGroup
+            label="Sign-in method"
+            options={[
+              { value: 'password' as const, label: 'Password' },
+              ...(isPasskeyEnabled() ? [{ value: 'passkey' as const, label: 'Passkey' }] : []),
+            ]}
+            selected={v => effectiveMethod() === v}
+            onSelect={setLoginMethod}
+          />
+          <Show when={effectiveMethod() === 'password'}>
+            <label>
+              Password
+              <input
+                ref={passwordRef}
+                type="password"
+                value={password()}
+                onInput={e => setPassword(e.currentTarget.value)}
+                autocomplete="current-password"
+              />
+            </label>
+          </Show>
+          <CaptchaSection action={captchaAction()} captcha={captcha} />
           <Show when={auth.error()}>
             <div class={errorText}>{auth.error()}</div>
           </Show>
           <button
             type="submit"
-            disabled={submitting() || !username() || !password() || captcha.blocksSubmit()}
+            disabled={submitting() || !canSubmit()}
           >
             <Show when={submitting()}><Spinner /></Show>
-            {submitting() ? 'Signing in...' : 'Sign in'}
+            {submitting()
+              ? 'Signing in...'
+              : effectiveMethod() === 'passkey' ? 'Sign in with passkey' : 'Sign in'}
           </button>
+          <Show when={isEmailEnabled() && loginMethod() === 'password'}>
+            <div>
+              <A href="/forgot-password">Forgot password?</A>
+            </div>
+          </Show>
         </form>
         <Show when={isSignupEnabled()}>
           <div class={styles.authFooter}>

--- a/frontend/src/components/common/LoginPage.tsx
+++ b/frontend/src/components/common/LoginPage.tsx
@@ -9,13 +9,12 @@ import { OAuthProviderList } from '~/components/common/OAuthProviderList'
 import { PillGroup } from '~/components/common/PillGroup'
 import { Spinner } from '~/components/common/Spinner'
 import { useAuth } from '~/context/AuthContext'
+import { createAuthMethodSelection } from '~/lib/authMethodSelection'
 import { createCaptchaForm } from '~/lib/captchaForm'
 import { safeRedirect } from '~/lib/safeRedirect'
 import { isEmailEnabled, isPasskeyEnabled, isSetupRequired, isSignupEnabled, isSoloMode, loadOAuthProviders } from '~/lib/systemInfo'
 import { errorText, pageCard } from '~/styles/shared.css'
 import * as styles from './LoginPage.css'
-
-type LoginMethod = 'password' | 'passkey'
 
 export const LoginPage: Component = () => {
   const auth = useAuth()
@@ -23,7 +22,8 @@ export const LoginPage: Component = () => {
   const [searchParams] = useSearchParams()
   const [username, setUsername] = createSignal('')
   const [password, setPassword] = createSignal('')
-  const [loginMethod, setLoginMethod] = createSignal<LoginMethod>('password')
+  const methodSelection = createAuthMethodSelection('login')
+  const effectiveMethod = methodSelection.effectiveMethod
   const [submitting, setSubmitting] = createSignal(false)
   const [oauthProviders, setOAuthProviders] = createSignal<OAuthProviderInfo[]>([])
   const captcha = createCaptchaForm()
@@ -95,12 +95,6 @@ export const LoginPage: Component = () => {
     navigate(redirect ?? '/', { replace: true })
   }
 
-  // The passkey pill renders only when the hub can run ceremonies; a stale
-  // passkey selection falls back to the password arm.
-  const effectiveMethod = (): LoginMethod => {
-    return loginMethod() === 'passkey' && isPasskeyEnabled() ? 'passkey' : 'password'
-  }
-
   const handleSubmit = async (e: Event) => {
     e.preventDefault()
     setSubmitting(true)
@@ -134,7 +128,7 @@ export const LoginPage: Component = () => {
     return url
   }
 
-  const captchaAction = () => effectiveMethod() === 'passkey' ? 'passkey_login' as const : 'login' as const
+  const captchaAction = methodSelection.captchaAction
 
   const canSubmit = () => {
     if (!username() || captcha.blocksSubmit())
@@ -174,7 +168,7 @@ export const LoginPage: Component = () => {
               ...(isPasskeyEnabled() ? [{ value: 'passkey' as const, label: 'Passkey' }] : []),
             ]}
             selected={v => effectiveMethod() === v}
-            onSelect={setLoginMethod}
+            onSelect={methodSelection.select}
           />
           <Show when={effectiveMethod() === 'password'}>
             <label>
@@ -201,7 +195,7 @@ export const LoginPage: Component = () => {
               ? 'Signing in...'
               : effectiveMethod() === 'passkey' ? 'Sign in with passkey' : 'Sign in'}
           </button>
-          <Show when={isEmailEnabled() && loginMethod() === 'password'}>
+          <Show when={isEmailEnabled() && effectiveMethod() === 'password'}>
             <div>
               <A href="/forgot-password">Forgot password?</A>
             </div>

--- a/frontend/src/components/common/RecaptchaV3Field.test.tsx
+++ b/frontend/src/components/common/RecaptchaV3Field.test.tsx
@@ -1,6 +1,7 @@
 import type { CaptchaFieldHandle } from './CaptchaField'
 /// <reference types="vitest/globals" />
 import { render } from '@solidjs/testing-library'
+import { createSignal } from 'solid-js'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mockLoadSystemInfo, resetSystemInfoMock, setSystemInfoMock } from '~/test-support/systemInfoMock'
@@ -199,5 +200,21 @@ describe('recaptchaV3Field', () => {
     const callsAfterUnmount = execute.mock.calls.length
     vi.advanceTimersByTime(110_000)
     expect(execute.mock.calls.length).toBe(callsAfterUnmount)
+  })
+
+  it('re-executes when the form action changes', async () => {
+    const execute = installFakeGrecaptcha()
+    const [action, setAction] = createSignal('login')
+    render(() => (
+      <div><RecaptchaV3Field action={action()} onPayload={vi.fn()} /></div>
+    ))
+    await vi.waitFor(() => {
+      expect(execute).toHaveBeenCalledWith('site-key', { action: 'login' })
+    })
+
+    setAction('passkey_login')
+    await vi.waitFor(() => {
+      expect(execute).toHaveBeenCalledWith('site-key', { action: 'passkey_login' })
+    })
   })
 })

--- a/frontend/src/components/common/RecaptchaV3Field.test.tsx
+++ b/frontend/src/components/common/RecaptchaV3Field.test.tsx
@@ -202,7 +202,12 @@ describe('recaptchaV3Field', () => {
     expect(execute.mock.calls.length).toBe(callsAfterUnmount)
   })
 
-  it('re-executes when the form action changes', async () => {
+  // The action is a MOUNT-TIME constant here; CaptchaField's keyed Show is
+  // what re-arms on a change. An in-field effect would have to clear the
+  // previous token itself, and the one this file used to carry did not --
+  // it re-executed while the old token stayed armed. This test fails if it
+  // comes back.
+  it('binds the action at mount and does not track later changes', async () => {
     const execute = installFakeGrecaptcha()
     const [action, setAction] = createSignal('login')
     render(() => (
@@ -211,8 +216,29 @@ describe('recaptchaV3Field', () => {
     await vi.waitFor(() => {
       expect(execute).toHaveBeenCalledWith('site-key', { action: 'login' })
     })
+    const callsAfterMount = execute.mock.calls.length
 
     setAction('passkey_login')
+    await Promise.resolve()
+    expect(execute.mock.calls.length).toBe(callsAfterMount)
+    expect(execute).not.toHaveBeenCalledWith('site-key', { action: 'passkey_login' })
+  })
+
+  // The other half of the contract: the fresh instance a keyed remount
+  // creates executes under the new action.
+  it('executes a fresh mount under its own action', async () => {
+    const execute = installFakeGrecaptcha()
+    const first = render(() => (
+      <div><RecaptchaV3Field action="login" onPayload={vi.fn()} /></div>
+    ))
+    await vi.waitFor(() => {
+      expect(execute).toHaveBeenCalledWith('site-key', { action: 'login' })
+    })
+    first.unmount()
+
+    render(() => (
+      <div><RecaptchaV3Field action="passkey_login" onPayload={vi.fn()} /></div>
+    ))
     await vi.waitFor(() => {
       expect(execute).toHaveBeenCalledWith('site-key', { action: 'passkey_login' })
     })

--- a/frontend/src/components/common/RecaptchaV3Field.tsx
+++ b/frontend/src/components/common/RecaptchaV3Field.tsx
@@ -1,7 +1,7 @@
 import type { Component } from 'solid-js'
 import type { CaptchaFieldHandle } from './CaptchaField'
 
-import { onMount } from 'solid-js'
+import { createEffect, onMount } from 'solid-js'
 import { loadExternalScript } from '~/lib/scriptLoader'
 import { getCaptchaSiteKey } from '~/lib/systemInfo'
 import { createCaptchaFieldBase, noteFieldArmFailure } from './captchaFieldBase'
@@ -98,6 +98,13 @@ export const RecaptchaV3Field: Component<RecaptchaV3FieldProps> = (props) => {
   // execute() are tracked.
   // eslint-disable-next-line solid/reactivity
   base.onSiteKeyChange(() => void execute())
+
+  createEffect((prev?: string) => {
+    const action = props.action
+    if (prev !== undefined && prev !== action)
+      void execute()
+    return action
+  })
 
   onMount(() => {
     void execute()

--- a/frontend/src/components/common/RecaptchaV3Field.tsx
+++ b/frontend/src/components/common/RecaptchaV3Field.tsx
@@ -1,7 +1,7 @@
 import type { Component } from 'solid-js'
 import type { CaptchaFieldHandle } from './CaptchaField'
 
-import { createEffect, onMount } from 'solid-js'
+import { onMount } from 'solid-js'
 import { loadExternalScript } from '~/lib/scriptLoader'
 import { getCaptchaSiteKey } from '~/lib/systemInfo'
 import { createCaptchaFieldBase, noteFieldArmFailure } from './captchaFieldBase'
@@ -98,13 +98,6 @@ export const RecaptchaV3Field: Component<RecaptchaV3FieldProps> = (props) => {
   // execute() are tracked.
   // eslint-disable-next-line solid/reactivity
   base.onSiteKeyChange(() => void execute())
-
-  createEffect((prev?: string) => {
-    const action = props.action
-    if (prev !== undefined && prev !== action)
-      void execute()
-    return action
-  })
 
   onMount(() => {
     void execute()

--- a/frontend/src/components/common/ResetPasswordPage.test.tsx
+++ b/frontend/src/components/common/ResetPasswordPage.test.tsx
@@ -1,0 +1,120 @@
+import { Code, ConnectError } from '@connectrpc/connect'
+import { createMemoryHistory, MemoryRouter, Route } from '@solidjs/router'
+/// <reference types="vitest/globals" />
+import { fireEvent, render, screen } from '@solidjs/testing-library'
+import { createSignal } from 'solid-js'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { CaptchaProvider } from '~/generated/leapmux/v1/auth_pb'
+import { mockLoadSystemInfo, resetSystemInfoMock, setSystemInfoMock } from '~/test-support/systemInfoMock'
+
+import { ResetPasswordPage } from './ResetPasswordPage'
+
+const mockCompletePasswordReset = vi.fn()
+
+vi.mock('~/api/clients', () => ({
+  authClient: {
+    completePasswordReset: (...args: unknown[]) => mockCompletePasswordReset(...args),
+  },
+}))
+
+vi.mock('~/lib/systemInfo', async () => {
+  const m = await import('~/test-support/systemInfoMock')
+  return m.systemInfoMock
+})
+
+const [mockCaptchaPayload, setMockCaptchaPayload] = createSignal<string | null>(null)
+vi.mock('~/components/common/CaptchaField', async () => {
+  const { createEffect } = await import('solid-js')
+  return {
+    CaptchaField: (props: { action: string, onPayload: (p: string | null) => void, onUnavailable: () => void }) => {
+      createEffect(() => props.onPayload(mockCaptchaPayload()))
+      return <div data-testid="captcha-field" data-action={props.action} />
+    },
+  }
+})
+vi.mock('~/components/common/CaptchaHoneypot', () => ({
+  CaptchaHoneypot: (props: { value: string, onInput: (v: string) => void }) => (
+    <input
+      data-testid="captcha-honeypot"
+      type="text"
+      name="website"
+      value={props.value}
+      onInput={e => props.onInput(e.currentTarget.value)}
+    />
+  ),
+}))
+
+function renderResetPasswordPage(initialPath: string) {
+  const history = createMemoryHistory()
+  history.set({ value: initialPath, replace: true, scroll: false })
+  return render(() => (
+    <MemoryRouter history={history}>
+      <Route path="/reset-password" component={ResetPasswordPage} />
+      <Route path="/login" component={() => <div data-testid="login-page" />} />
+      <Route path="/forgot-password" component={() => <div data-testid="forgot-page" />} />
+    </MemoryRouter>
+  ))
+}
+
+describe('reset password page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetSystemInfoMock()
+    setMockCaptchaPayload(null)
+    mockCompletePasswordReset.mockResolvedValue({})
+  })
+
+  it('shows a missing-token error when the reset link has no token', async () => {
+    renderResetPasswordPage('/reset-password')
+    expect(await screen.findByText('Missing reset token. Open the link from your email.')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Request a new link' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Reset password' })).not.toBeInTheDocument()
+  })
+
+  it('keeps Reset password disabled until the new password fields match', async () => {
+    renderResetPasswordPage('/reset-password?token=reset-token')
+    expect(await screen.findByRole('button', { name: 'Reset password' })).toBeDisabled()
+    fireEvent.input(screen.getByLabelText('New Password'), { target: { value: 'newpass123' } })
+    expect(screen.getByRole('button', { name: 'Reset password' })).toBeDisabled()
+    fireEvent.input(screen.getByLabelText('Confirm Password'), { target: { value: 'newpass123' } })
+    expect(screen.getByRole('button', { name: 'Reset password' })).toBeEnabled()
+  })
+
+  it('navigates to login after a successful reset and does not re-enable submit', async () => {
+    let resolveReset!: (value: unknown) => void
+    mockCompletePasswordReset.mockReturnValue(new Promise((resolve) => {
+      resolveReset = resolve
+    }))
+    renderResetPasswordPage('/reset-password?token=reset-token')
+    fireEvent.input(await screen.findByLabelText('New Password'), { target: { value: 'newpass123' } })
+    fireEvent.input(screen.getByLabelText('Confirm Password'), { target: { value: 'newpass123' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Reset password' }))
+    expect(await screen.findByRole('button', { name: 'Resetting…' })).toBeDisabled()
+    fireEvent.click(screen.getByRole('button', { name: 'Resetting…' }))
+    expect(mockCompletePasswordReset).toHaveBeenCalledOnce()
+    resolveReset({})
+    expect(await screen.findByTestId('login-page')).toBeInTheDocument()
+  })
+
+  it('passes the complete_password_reset action to the captcha field', async () => {
+    setSystemInfoMock({ captchaEnabled: true, captchaProvider: CaptchaProvider.TURNSTILE, captchaSiteKey: '1x00000000000000000000AA' })
+    renderResetPasswordPage('/reset-password?token=reset-token')
+    await vi.waitFor(() => {
+      expect(screen.getByTestId('captcha-field')).toHaveAttribute('data-action', 'complete_password_reset')
+    })
+  })
+
+  it('re-enables Reset password after a failed attempt and refreshes captcha info on PermissionDenied', async () => {
+    mockCompletePasswordReset.mockRejectedValue(new ConnectError('denied', Code.PermissionDenied))
+    renderResetPasswordPage('/reset-password?token=reset-token')
+    fireEvent.input(await screen.findByLabelText('New Password'), { target: { value: 'newpass123' } })
+    fireEvent.input(screen.getByLabelText('Confirm Password'), { target: { value: 'newpass123' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Reset password' }))
+    await vi.waitFor(() => {
+      expect(mockCompletePasswordReset).toHaveBeenCalledOnce()
+    })
+    expect(await screen.findByRole('button', { name: 'Reset password' })).toBeEnabled()
+    expect(mockLoadSystemInfo).toHaveBeenCalledWith(true)
+  })
+})

--- a/frontend/src/components/common/ResetPasswordPage.tsx
+++ b/frontend/src/components/common/ResetPasswordPage.tsx
@@ -1,0 +1,88 @@
+import type { Component } from 'solid-js'
+import { A, useNavigate, useSearchParams } from '@solidjs/router'
+import { createSignal, Show } from 'solid-js'
+import { authClient } from '~/api/clients'
+import { CaptchaSection } from '~/components/common/CaptchaSection'
+import { Spinner } from '~/components/common/Spinner'
+import { createCaptchaForm } from '~/lib/captchaForm'
+import { formatErrorMessage } from '~/lib/errors'
+import { errorText, pageCard } from '~/styles/shared.css'
+import * as styles from './LoginPage.css'
+import { passwordCanSubmit, PasswordFields } from './PasswordFields'
+
+export const ResetPasswordPage: Component = () => {
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const [password, setPassword] = createSignal('')
+  const [confirmPassword, setConfirmPassword] = createSignal('')
+  const [submitting, setSubmitting] = createSignal(false)
+  const [error, setError] = createSignal<string | null>(null)
+  const captcha = createCaptchaForm()
+
+  const token = () => typeof searchParams.token === 'string' ? searchParams.token : ''
+
+  const pwProps = { password, confirmPassword }
+
+  const handleSubmit = async (e: Event) => {
+    e.preventDefault()
+    if (!passwordCanSubmit(pwProps))
+      return
+    const resetToken = token()
+    if (!resetToken) {
+      setError('Missing reset token. Open the link from your email.')
+      return
+    }
+    setSubmitting(true)
+    setError(null)
+    try {
+      await authClient.completePasswordReset({
+        token: resetToken,
+        newPassword: password(),
+        ...captcha.fields(),
+      })
+      navigate('/login', { replace: true })
+    }
+    catch (err) {
+      setError(formatErrorMessage(err, 'Password reset failed'))
+      captcha.reset(err)
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div class={styles.container}>
+      <div class={pageCard}>
+        <h1>Choose a new password</h1>
+        <Show
+          when={token()}
+          fallback={(
+            <div class="vstack gap-4">
+              <div class={errorText}>Missing reset token. Open the link from your email.</div>
+              <A href="/forgot-password">Request a new link</A>
+            </div>
+          )}
+        >
+          <form class="vstack gap-4" onSubmit={handleSubmit}>
+            <PasswordFields
+              password={password}
+              setPassword={setPassword}
+              confirmPassword={confirmPassword}
+              setConfirmPassword={setConfirmPassword}
+            />
+            <CaptchaSection action="complete_password_reset" captcha={captcha} />
+            <Show when={error()}>
+              <div class={errorText}>{error()}</div>
+            </Show>
+            <button type="submit" disabled={submitting() || !passwordCanSubmit(pwProps) || captcha.blocksSubmit()}>
+              <Show when={submitting()}><Spinner /></Show>
+              {submitting() ? 'Resetting…' : 'Reset password'}
+            </button>
+          </form>
+        </Show>
+        <div class={styles.authFooter}>
+          <A href="/login">Back to login</A>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/common/SetupPage.test.tsx
+++ b/frontend/src/components/common/SetupPage.test.tsx
@@ -22,6 +22,7 @@ vi.mock('~/api/clients', () => ({
 
 const mockIsSetupRequired = vi.fn<() => boolean>(() => true)
 vi.mock('~/lib/systemInfo', () => ({
+  isEmailEnabled: () => false,
   isSoloMode: () => false,
   isSetupRequired: () => mockIsSetupRequired(),
   loadSystemInfo: () => Promise.resolve(),

--- a/frontend/src/components/common/SetupPage.tsx
+++ b/frontend/src/components/common/SetupPage.tsx
@@ -38,6 +38,7 @@ export const SetupPage: Component = () => {
             submittingLabel="Creating account..."
             errorPrefix="Setup failed"
             allowAdminUsername
+            passwordOnly
             header={<p>Create the first administrator account to get started.</p>}
             onSuccess={(resp) => {
               // Fire-and-forget refresh of `setupRequired`: the account now
@@ -45,7 +46,7 @@ export const SetupPage: Component = () => {
               // redirects once it re-reads. Nothing on this path may block or
               // fail on it, hence the swallowed rejection.
               void loadSystemInfo(true).catch(() => {})
-              auth.setAuth(resp.user!)
+              auth.setAuth(resp.user)
               navigate('/', { replace: true })
             }}
           />

--- a/frontend/src/components/common/SignupForm.test.tsx
+++ b/frontend/src/components/common/SignupForm.test.tsx
@@ -1,34 +1,49 @@
+import { Code, ConnectError } from '@connectrpc/connect'
 import { fireEvent, render, screen } from '@solidjs/testing-library'
-import { describe, expect, it, vi } from 'vitest'
+import { createSignal } from 'solid-js'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { CaptchaProvider } from '~/generated/leapmux/v1/auth_pb'
+import { mockLoadSystemInfo, resetSystemInfoMock, setSystemInfoMock } from '~/test-support/systemInfoMock'
 
 import { SignupForm } from './SignupForm'
 
 const mockSignUp = vi.fn<(...args: unknown[]) => Promise<unknown>>()
+const mockBeginPasskeySignUp = vi.fn<(...args: unknown[]) => Promise<unknown>>()
+const mockFinishPasskeySignUp = vi.fn<(...args: unknown[]) => Promise<unknown>>()
 
 vi.mock('~/api/clients', () => ({
   authClient: {
     signUp: (...args: unknown[]) => mockSignUp(...args),
+    beginPasskeySignUp: (...args: unknown[]) => mockBeginPasskeySignUp(...args),
+    finishPasskeySignUp: (...args: unknown[]) => mockFinishPasskeySignUp(...args),
     login: vi.fn(),
     logout: vi.fn(),
     getCurrentUser: vi.fn(),
   },
 }))
 
-// The real captchaForm state reads these; answering "loaded, no captcha"
-// keeps blocksSubmit() false so the form renders fully interactive without
-// a widget. The CaptchaSection that would render the widget is stubbed
-// below precisely because there is no widget to mount.
-vi.mock('~/lib/systemInfo', () => ({
-  isSoloMode: () => false,
-  loadSystemInfo: () => Promise.resolve(),
-  isSignupEnabled: () => true,
-  isSystemInfoLoaded: () => true,
-  isCaptchaEnabled: () => false,
-  refreshSnapshot: () => {},
+vi.mock('~/lib/webauthn', () => ({
+  startRegistration: vi.fn().mockResolvedValue('{"id":"cred"}'),
 }))
 
-vi.mock('~/components/common/CaptchaSection', () => ({
-  CaptchaSection: () => <div data-testid="captcha-section" />,
+vi.mock('~/lib/systemInfo', async () => {
+  const m = await import('~/test-support/systemInfoMock')
+  return m.systemInfoMock
+})
+
+const [mockCaptchaPayload, setMockCaptchaPayload] = createSignal<string | null>(null)
+vi.mock('~/components/common/CaptchaField', async () => {
+  const { createEffect } = await import('solid-js')
+  return {
+    CaptchaField: (props: { action: string, onPayload: (p: string | null) => void, onUnavailable: () => void }) => {
+      createEffect(() => props.onPayload(mockCaptchaPayload()))
+      return <div data-testid="captcha-field" data-action={props.action} />
+    },
+  }
+})
+vi.mock('~/components/common/CaptchaHoneypot', () => ({
+  CaptchaHoneypot: () => <input data-testid="captcha-honeypot" type="text" name="website" />,
 }))
 
 function usernameInput() {
@@ -50,6 +65,13 @@ function renderForm() {
 }
 
 describe('signup form display-name mirror', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetSystemInfoMock()
+    setMockCaptchaPayload(null)
+    mockSignUp.mockResolvedValue({})
+  })
+
   it('mirrors the username into the display name as it is typed', () => {
     renderForm()
 
@@ -84,5 +106,58 @@ describe('signup form display-name mirror', () => {
 
     fireEvent.input(usernameInput(), { target: { value: 'bobby' } })
     expect(displayNameInput().value).toBe('')
+  })
+})
+
+describe('signup form passkey path', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetSystemInfoMock()
+    setMockCaptchaPayload(null)
+  })
+
+  it('requires email before submit', () => {
+    // The hub requires an email only when SMTP (the verification channel)
+    // is configured.
+    setSystemInfoMock({ emailEnabled: true })
+    renderForm()
+    fireEvent.input(usernameInput(), { target: { value: 'alice' } })
+    fireEvent.click(screen.getByRole('radio', { name: 'Passkey' }))
+    expect(screen.getByRole('button', { name: 'Sign up with passkey' })).toBeDisabled()
+    expect(mockBeginPasskeySignUp).not.toHaveBeenCalled()
+  })
+
+  it('hides password fields when passkey is selected', () => {
+    renderForm()
+    fireEvent.click(screen.getByRole('radio', { name: 'Passkey' }))
+    expect(screen.queryByLabelText('Password')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Confirm Password')).not.toBeInTheDocument()
+  })
+
+  it('switches captcha action when the passkey method is selected', async () => {
+    setSystemInfoMock({ captchaEnabled: true, captchaProvider: CaptchaProvider.TURNSTILE, captchaSiteKey: '1x00000000000000000000AA' })
+    renderForm()
+    await vi.waitFor(() => {
+      expect(screen.getByTestId('captcha-field')).toHaveAttribute('data-action', 'signup')
+    })
+    fireEvent.click(screen.getByRole('radio', { name: 'Passkey' }))
+    await vi.waitFor(() => {
+      expect(screen.getByTestId('captcha-field')).toHaveAttribute('data-action', 'passkey_signup')
+    })
+  })
+
+  it('re-enables Create account after a failed attempt and refreshes captcha info on PermissionDenied', async () => {
+    mockSignUp.mockRejectedValue(new ConnectError('denied', Code.PermissionDenied))
+    renderForm()
+    fireEvent.input(usernameInput(), { target: { value: 'alice' } })
+    fireEvent.input(screen.getByLabelText('Email'), { target: { value: 'alice@example.com' } })
+    fireEvent.input(screen.getByLabelText('New Password'), { target: { value: 'newpass123' } })
+    fireEvent.input(screen.getByLabelText('Confirm Password'), { target: { value: 'newpass123' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Create account' }))
+    await vi.waitFor(() => {
+      expect(mockSignUp).toHaveBeenCalledOnce()
+    })
+    expect(await screen.findByRole('button', { name: 'Create account' })).toBeEnabled()
+    expect(mockLoadSystemInfo).toHaveBeenCalledWith(true)
   })
 })

--- a/frontend/src/components/common/SignupForm.test.tsx
+++ b/frontend/src/components/common/SignupForm.test.tsx
@@ -23,7 +23,11 @@ vi.mock('~/api/clients', () => ({
   },
 }))
 
-vi.mock('~/lib/webauthn', () => ({
+// Partial mock: only the ceremony is faked. passkeyErrorMessage is the real
+// classifier, so these tests exercise the same cancel-vs-failure rule the
+// component ships with.
+vi.mock('~/lib/webauthn', async importOriginal => ({
+  ...await importOriginal<typeof import('~/lib/webauthn')>(),
   startRegistration: vi.fn().mockResolvedValue('{"id":"cred"}'),
 }))
 

--- a/frontend/src/components/common/SignupForm.tsx
+++ b/frontend/src/components/common/SignupForm.tsx
@@ -1,22 +1,20 @@
 import type { Timestamp } from '@bufbuild/protobuf/wkt'
 import type { Component, JSX } from 'solid-js'
 
-import type { User } from '~/generated/leapmux/v1/auth_pb'
+import type { EmailVerificationStatus, User } from '~/generated/leapmux/v1/auth_pb'
 import { createSignal, Show } from 'solid-js'
 import { authClient } from '~/api/clients'
 import { CaptchaSection } from '~/components/common/CaptchaSection'
 import { PillGroup } from '~/components/common/PillGroup'
+import { createAuthMethodSelection } from '~/lib/authMethodSelection'
 import { createCaptchaForm } from '~/lib/captchaForm'
-import { formatErrorMessage } from '~/lib/errors'
 import { isEmailEnabled, isPasskeyEnabled } from '~/lib/systemInfo'
 import { sanitizeDisplayName, sanitizeSlug, validateEmail, validateReservedUsername } from '~/lib/validate'
-import { startRegistration } from '~/lib/webauthn'
+import { passkeyErrorMessage, startRegistration } from '~/lib/webauthn'
 import { errorText } from '~/styles/shared.css'
 import { passwordCanSubmit, PasswordFields } from './PasswordFields'
 import { Spinner } from './Spinner'
 import { UsernameField } from './UsernameField'
-
-type SignupMethod = 'password' | 'passkey'
 
 /**
  * What a successful sign-up hands its caller. `user` is always set on a
@@ -54,7 +52,8 @@ export const SignupForm: Component<SignupFormProps> = (props) => {
   const [displayName, setDisplayName] = createSignal('')
   const [displayNameEdited, setDisplayNameEdited] = createSignal(false)
   const [email, setEmail] = createSignal('')
-  const [signupMethod, setSignupMethod] = createSignal<SignupMethod>('password')
+  const methodSelection = createAuthMethodSelection('signup')
+  const effectiveMethod = methodSelection.effectiveMethod
   const [submitting, setSubmitting] = createSignal(false)
   const [error, setError] = createSignal<string | null>(null)
   const captcha = createCaptchaForm()
@@ -105,22 +104,17 @@ export const SignupForm: Component<SignupFormProps> = (props) => {
     return { slug, sanitizedDisplayName, email: trimmedEmail }
   }
 
-  // The passkey pill renders only when the hub can run ceremonies; a stale
-  // passkey selection falls back to the password arm.
-  const effectiveMethod = (): SignupMethod => {
-    return signupMethod() === 'passkey' && isPasskeyEnabled() ? 'passkey' : 'password'
-  }
-
   const handleSubmit = async (e: Event) => {
     e.preventDefault()
     const fields = validateCommonFields()
     if (!fields)
       return
-    if (signupMethod() === 'password' && !passwordCanSubmit(pwProps))
+    if (effectiveMethod() === 'password' && !passwordCanSubmit(pwProps))
       return
     setSubmitting(true)
     setError(null)
     try {
+      let resp: { user?: User, emailVerification?: EmailVerificationStatus }
       if (effectiveMethod() === 'passkey') {
         const begin = await authClient.beginPasskeySignUp({
           username: fields.slug,
@@ -129,43 +123,41 @@ export const SignupForm: Component<SignupFormProps> = (props) => {
           ...captcha.fields(),
         })
         const credentialJson = await startRegistration(begin.optionsJson)
-        const resp = await authClient.finishPasskeySignUp({
+        const passkeyResp = await authClient.finishPasskeySignUp({
           sessionId: begin.sessionId,
           credentialJson,
         })
-        if (!resp.user)
-          throw new Error('sign-up response missing user')
-        props.onSuccess({
-          user: resp.user,
-          verificationRequired: resp.emailVerification?.verificationRequired ?? false,
-          nextResendAvailableAt: resp.emailVerification?.nextResendAvailableAt,
-        })
+        resp = passkeyResp
       }
       else {
-        const resp = await authClient.signUp({
+        resp = await authClient.signUp({
           username: fields.slug,
           password: password(),
           displayName: fields.sanitizedDisplayName,
           email: fields.email,
           ...captcha.fields(),
         })
-        if (!resp.user)
-          throw new Error('sign-up response missing user')
-        props.onSuccess({
-          user: resp.user,
-          verificationRequired: resp.emailVerification?.verificationRequired ?? false,
-          nextResendAvailableAt: resp.emailVerification?.nextResendAvailableAt,
-        })
       }
+      // One success path for both arms: the two responses carry the same
+      // two fields, and the `?? false` defaults were spelled twice.
+      if (!resp.user)
+        throw new Error('sign-up response missing user')
+      props.onSuccess({
+        user: resp.user,
+        verificationRequired: resp.emailVerification?.verificationRequired ?? false,
+        nextResendAvailableAt: resp.emailVerification?.nextResendAvailableAt,
+      })
     }
     catch (err) {
-      setError(formatErrorMessage(err, props.errorPrefix ?? 'Sign up failed'))
+      // A dismissed passkey prompt is not a sign-up failure: leave the
+      // banner empty and let the user try again.
+      setError(passkeyErrorMessage(err, props.errorPrefix ?? 'Sign up failed') ?? '')
       captcha.reset(err)
       setSubmitting(false)
     }
   }
 
-  const captchaAction = () => effectiveMethod() === 'passkey' ? 'passkey_signup' as const : 'signup' as const
+  const captchaAction = methodSelection.captchaAction
 
   const emailRequired = () => isEmailEnabled()
 
@@ -211,10 +203,10 @@ export const SignupForm: Component<SignupFormProps> = (props) => {
               ...(isPasskeyEnabled() ? [{ value: 'passkey' as const, label: 'Passkey' }] : []),
             ]}
             selected={v => effectiveMethod() === v}
-            onSelect={setSignupMethod}
+            onSelect={methodSelection.select}
           />
         </Show>
-        <Show when={signupMethod() === 'password' || props.passwordOnly}>
+        <Show when={effectiveMethod() === 'password'}>
           <PasswordFields
             password={password}
             setPassword={setPassword}

--- a/frontend/src/components/common/SignupForm.tsx
+++ b/frontend/src/components/common/SignupForm.tsx
@@ -1,16 +1,33 @@
+import type { Timestamp } from '@bufbuild/protobuf/wkt'
 import type { Component, JSX } from 'solid-js'
 
-import type { SignUpResponse } from '~/generated/leapmux/v1/auth_pb'
+import type { User } from '~/generated/leapmux/v1/auth_pb'
 import { createSignal, Show } from 'solid-js'
 import { authClient } from '~/api/clients'
 import { CaptchaSection } from '~/components/common/CaptchaSection'
+import { PillGroup } from '~/components/common/PillGroup'
 import { createCaptchaForm } from '~/lib/captchaForm'
 import { formatErrorMessage } from '~/lib/errors'
+import { isEmailEnabled, isPasskeyEnabled } from '~/lib/systemInfo'
 import { sanitizeDisplayName, sanitizeSlug, validateEmail, validateReservedUsername } from '~/lib/validate'
+import { startRegistration } from '~/lib/webauthn'
 import { errorText } from '~/styles/shared.css'
 import { passwordCanSubmit, PasswordFields } from './PasswordFields'
 import { Spinner } from './Spinner'
 import { UsernameField } from './UsernameField'
+
+type SignupMethod = 'password' | 'passkey'
+
+/**
+ * What a successful sign-up hands its caller. `user` is always set on a
+ * successful RPC; `verificationEmailSent` is display noise the callers never
+ * read, so it stays out of the contract.
+ */
+export interface SignupResult {
+  user: User
+  verificationRequired: boolean
+  nextResendAvailableAt?: Timestamp
+}
 
 interface SignupFormProps {
   submitLabel: string
@@ -22,7 +39,12 @@ interface SignupFormProps {
    * setup flow. Defaults to false for public signup paths.
    */
   allowAdminUsername?: boolean
-  onSuccess: (resp: SignUpResponse) => void
+  /**
+   * When true, only password signup is offered (first-admin /setup). Passkey
+   * signup is refused by the server during initial setup.
+   */
+  passwordOnly?: boolean
+  onSuccess: (resp: SignupResult) => void
 }
 
 export const SignupForm: Component<SignupFormProps> = (props) => {
@@ -32,6 +54,7 @@ export const SignupForm: Component<SignupFormProps> = (props) => {
   const [displayName, setDisplayName] = createSignal('')
   const [displayNameEdited, setDisplayNameEdited] = createSignal(false)
   const [email, setEmail] = createSignal('')
+  const [signupMethod, setSignupMethod] = createSignal<SignupMethod>('password')
   const [submitting, setSubmitting] = createSignal(false)
   const [error, setError] = createSignal<string | null>(null)
   const captcha = createCaptchaForm()
@@ -48,47 +71,110 @@ export const SignupForm: Component<SignupFormProps> = (props) => {
     }
   }
 
-  const handleSubmit = async (e: Event) => {
-    e.preventDefault()
-    if (!passwordCanSubmit(pwProps))
-      return
+  const validateCommonFields = () => {
     const [slug, slugErr] = sanitizeSlug('Username', username())
     if (slugErr) {
       setError(slugErr)
-      return
+      return null
     }
     const reservedErr = validateReservedUsername(slug, props.allowAdminUsername ?? false)
     if (reservedErr) {
       setError(reservedErr)
-      return
+      return null
     }
     const { value: sanitizedDisplayName, error: dnErr } = sanitizeDisplayName(displayName(), slug)
     if (dnErr) {
       setError(dnErr)
-      return
+      return null
     }
-    const emailErr = validateEmail(email())
-    if (emailErr) {
-      setError(emailErr)
-      return
+    const trimmedEmail = email().trim()
+    // The hub requires an email only when SMTP is configured (it is the
+    // verification channel); without SMTP the server accepts an empty
+    // email, and the form must not be narrower than the contract.
+    if (!trimmedEmail && isEmailEnabled()) {
+      setError('Email is required.')
+      return null
     }
+    if (trimmedEmail) {
+      const emailErr = validateEmail(trimmedEmail)
+      if (emailErr) {
+        setError(emailErr)
+        return null
+      }
+    }
+    return { slug, sanitizedDisplayName, email: trimmedEmail }
+  }
+
+  // The passkey pill renders only when the hub can run ceremonies; a stale
+  // passkey selection falls back to the password arm.
+  const effectiveMethod = (): SignupMethod => {
+    return signupMethod() === 'passkey' && isPasskeyEnabled() ? 'passkey' : 'password'
+  }
+
+  const handleSubmit = async (e: Event) => {
+    e.preventDefault()
+    const fields = validateCommonFields()
+    if (!fields)
+      return
+    if (signupMethod() === 'password' && !passwordCanSubmit(pwProps))
+      return
     setSubmitting(true)
     setError(null)
     try {
-      const resp = await authClient.signUp({
-        username: slug,
-        password: password(),
-        displayName: sanitizedDisplayName,
-        email: email(),
-        ...captcha.fields(),
-      })
-      props.onSuccess(resp)
+      if (effectiveMethod() === 'passkey') {
+        const begin = await authClient.beginPasskeySignUp({
+          username: fields.slug,
+          displayName: fields.sanitizedDisplayName,
+          email: fields.email,
+          ...captcha.fields(),
+        })
+        const credentialJson = await startRegistration(begin.optionsJson)
+        const resp = await authClient.finishPasskeySignUp({
+          sessionId: begin.sessionId,
+          credentialJson,
+        })
+        if (!resp.user)
+          throw new Error('sign-up response missing user')
+        props.onSuccess({
+          user: resp.user,
+          verificationRequired: resp.emailVerification?.verificationRequired ?? false,
+          nextResendAvailableAt: resp.emailVerification?.nextResendAvailableAt,
+        })
+      }
+      else {
+        const resp = await authClient.signUp({
+          username: fields.slug,
+          password: password(),
+          displayName: fields.sanitizedDisplayName,
+          email: fields.email,
+          ...captcha.fields(),
+        })
+        if (!resp.user)
+          throw new Error('sign-up response missing user')
+        props.onSuccess({
+          user: resp.user,
+          verificationRequired: resp.emailVerification?.verificationRequired ?? false,
+          nextResendAvailableAt: resp.emailVerification?.nextResendAvailableAt,
+        })
+      }
     }
-    catch (e) {
-      setError(formatErrorMessage(e, props.errorPrefix ?? 'Sign up failed'))
-      captcha.reset(e)
+    catch (err) {
+      setError(formatErrorMessage(err, props.errorPrefix ?? 'Sign up failed'))
+      captcha.reset(err)
       setSubmitting(false)
     }
+  }
+
+  const captchaAction = () => effectiveMethod() === 'passkey' ? 'passkey_signup' as const : 'signup' as const
+
+  const emailRequired = () => isEmailEnabled()
+
+  const canSubmit = () => {
+    if (!username() || (emailRequired() && !email().trim()) || captcha.blocksSubmit())
+      return false
+    if (effectiveMethod() === 'passkey')
+      return true
+    return passwordCanSubmit(pwProps)
   }
 
   return (
@@ -109,21 +195,42 @@ export const SignupForm: Component<SignupFormProps> = (props) => {
         </label>
         <label>
           Email
-          <input type="email" value={email()} onInput={e => setEmail(e.currentTarget.value)} />
+          <input
+            type="email"
+            value={email()}
+            onInput={e => setEmail(e.currentTarget.value)}
+            required={emailRequired()}
+            placeholder={emailRequired() ? undefined : 'Optional: enables password reset'}
+          />
         </label>
-        <PasswordFields
-          password={password}
-          setPassword={setPassword}
-          confirmPassword={confirmPassword}
-          setConfirmPassword={setConfirmPassword}
-        />
-        <CaptchaSection action="signup" captcha={captcha} />
+        <Show when={!props.passwordOnly}>
+          <PillGroup
+            label="Sign-up method"
+            options={[
+              { value: 'password' as const, label: 'Password' },
+              ...(isPasskeyEnabled() ? [{ value: 'passkey' as const, label: 'Passkey' }] : []),
+            ]}
+            selected={v => effectiveMethod() === v}
+            onSelect={setSignupMethod}
+          />
+        </Show>
+        <Show when={signupMethod() === 'password' || props.passwordOnly}>
+          <PasswordFields
+            password={password}
+            setPassword={setPassword}
+            confirmPassword={confirmPassword}
+            setConfirmPassword={setConfirmPassword}
+          />
+        </Show>
+        <CaptchaSection action={captchaAction()} captcha={captcha} />
         <Show when={error()}>
           <div class={errorText}>{error()}</div>
         </Show>
-        <button type="submit" disabled={submitting() || !username() || !passwordCanSubmit(pwProps) || captcha.blocksSubmit()}>
+        <button type="submit" disabled={submitting() || !canSubmit()}>
           <Show when={submitting()}><Spinner /></Show>
-          {submitting() ? props.submittingLabel : props.submitLabel}
+          {submitting()
+            ? props.submittingLabel
+            : effectiveMethod() === 'passkey' ? 'Sign up with passkey' : props.submitLabel}
         </button>
       </form>
     </>

--- a/frontend/src/components/common/SignupPage.test.tsx
+++ b/frontend/src/components/common/SignupPage.test.tsx
@@ -20,6 +20,8 @@ const mockIsCaptchaEnabled = vi.fn<() => boolean>(() => false)
 const mockGetCaptchaProvider = vi.fn<() => number>(() => 1) // CaptchaProvider.ALTCHA
 vi.mock('~/lib/systemInfo', () => ({
   isSoloMode: () => false,
+  isEmailEnabled: () => false,
+  isPasskeyEnabled: () => false,
   loadSystemInfo: () => Promise.resolve(),
   isSignupEnabled: () => mockIsSignupEnabled(),
   loadOAuthProviders: () => mockLoadOAuthProviders(),
@@ -45,6 +47,7 @@ vi.mock('~/context/AuthContext', () => ({
     login: vi.fn(),
     logout: vi.fn(),
     setAuth: vi.fn(),
+    setVerificationResendAvailableAt: vi.fn(),
     isAuthenticated: () => false,
   }),
   AuthProvider: (props: { children: unknown }) => <>{props.children}</>,

--- a/frontend/src/components/common/SignupPage.tsx
+++ b/frontend/src/components/common/SignupPage.tsx
@@ -1,10 +1,11 @@
 import type { Component } from 'solid-js'
 import type { OAuthProviderInfo } from '~/generated/leapmux/v1/auth_pb'
 
-import { A, useNavigate } from '@solidjs/router'
+import { A, useNavigate, useSearchParams } from '@solidjs/router'
 import { createSignal, onMount, Show } from 'solid-js'
 import { OAuthProviderList } from '~/components/common/OAuthProviderList'
 import { useAuth } from '~/context/AuthContext'
+import { safeRedirect } from '~/lib/safeRedirect'
 import { isSignupEnabled, loadOAuthProviders } from '~/lib/systemInfo'
 import { pageCard } from '~/styles/shared.css'
 import * as styles from './LoginPage.css'
@@ -13,6 +14,7 @@ import { SignupForm } from './SignupForm'
 
 export const SignupPage: Component = () => {
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
   const auth = useAuth()
   const [ready, setReady] = createSignal(false)
   const [verificationSent, setVerificationSent] = createSignal(false)
@@ -60,20 +62,21 @@ export const SignupPage: Component = () => {
                   </Show>
                 )}
                 onSuccess={(resp) => {
+                  // The signup RPC creates a session even when verification
+                  // is required, so the user can hit the authenticated
+                  // VerifyEmail RPC directly. Send them to the verify page to
+                  // click the email link or paste the code.
+                  auth.setAuth(resp.user)
                   if (resp.verificationRequired) {
-                    // The signup RPC now creates a session even when
-                    // verification is required, so the user can hit the
-                    // authenticated VerifyEmail RPC directly. Navigate
-                    // them to the verify page so they can either click
-                    // the link from the email or paste the code.
-                    auth.setAuth(resp.user!)
+                    auth.setVerificationResendAvailableAt(resp.nextResendAvailableAt)
                     setVerificationSent(true)
                     navigate('/verify-email', { replace: true })
+                    return
                   }
-                  else {
-                    auth.setAuth(resp.user!)
-                    navigate('/', { replace: true })
-                  }
+                  // Same redirect contract as login (see safeRedirect):
+                  // a safe in-app path wins, anything else goes home.
+                  const redirect = safeRedirect(typeof searchParams.redirect === 'string' ? searchParams.redirect : undefined)
+                  navigate(redirect ?? '/', { replace: true })
                 }}
               />
               <div class={styles.authFooter}>

--- a/frontend/src/components/common/TurnstileField.test.tsx
+++ b/frontend/src/components/common/TurnstileField.test.tsx
@@ -1,6 +1,7 @@
 import type { CaptchaFieldHandle } from './CaptchaField'
 /// <reference types="vitest/globals" />
 import { render } from '@solidjs/testing-library'
+import { createSignal } from 'solid-js'
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { mockLoadSystemInfo, resetSystemInfoMock, setSystemInfoMock } from '~/test-support/systemInfoMock'
@@ -186,6 +187,27 @@ describe('turnstileField', () => {
     })
     expect(turnstile.removes).toEqual(['widget-1'])
     expect(turnstile.calls[1]?.options.sitekey).toBe('2x00000000000000000000BB')
+    expect(onPayload).toHaveBeenLastCalledWith(null)
+  })
+
+  it('re-renders the widget when the form action changes', async () => {
+    const turnstile = installFakeTurnstile()
+    const onPayload = vi.fn()
+    const [action, setAction] = createSignal('login')
+    render(() => (
+      <div><TurnstileField action={action()} onPayload={onPayload} /></div>
+    ))
+    await vi.waitFor(() => {
+      expect(turnstile.calls).toHaveLength(1)
+    })
+    expect(turnstile.calls[0]?.options.action).toBe('login')
+
+    setAction('passkey_login')
+    await vi.waitFor(() => {
+      expect(turnstile.calls).toHaveLength(2)
+    })
+    expect(turnstile.calls[1]?.options.action).toBe('passkey_login')
+    expect(turnstile.removes).toEqual(['widget-1'])
     expect(onPayload).toHaveBeenLastCalledWith(null)
   })
 })

--- a/frontend/src/components/common/TurnstileField.test.tsx
+++ b/frontend/src/components/common/TurnstileField.test.tsx
@@ -190,7 +190,12 @@ describe('turnstileField', () => {
     expect(onPayload).toHaveBeenLastCalledWith(null)
   })
 
-  it('re-renders the widget when the form action changes', async () => {
+  // The action is a MOUNT-TIME constant here. CaptchaField wraps this field
+  // in a keyed Show, so an action change disposes the instance and mounts a
+  // fresh one; the field itself must not also track the prop, or the two
+  // mechanisms fight and only one of them clears the stale payload. This
+  // test fails if an in-field re-arm effect comes back.
+  it('binds the action at mount and does not track later changes', async () => {
     const turnstile = installFakeTurnstile()
     const onPayload = vi.fn()
     const [action, setAction] = createSignal('login')
@@ -203,11 +208,30 @@ describe('turnstileField', () => {
     expect(turnstile.calls[0]?.options.action).toBe('login')
 
     setAction('passkey_login')
+    await Promise.resolve()
+    expect(turnstile.calls).toHaveLength(1)
+    expect(turnstile.removes).toEqual([])
+  })
+
+  // The other half of the contract: the fresh instance a keyed remount
+  // creates arms the real widget under the new action.
+  it('arms a fresh mount under its own action', async () => {
+    const turnstile = installFakeTurnstile()
+    const first = render(() => (
+      <div><TurnstileField action="login" onPayload={vi.fn()} /></div>
+    ))
+    await vi.waitFor(() => {
+      expect(turnstile.calls).toHaveLength(1)
+    })
+    expect(turnstile.calls[0]?.options.action).toBe('login')
+    first.unmount()
+
+    render(() => (
+      <div><TurnstileField action="passkey_login" onPayload={vi.fn()} /></div>
+    ))
     await vi.waitFor(() => {
       expect(turnstile.calls).toHaveLength(2)
     })
     expect(turnstile.calls[1]?.options.action).toBe('passkey_login')
-    expect(turnstile.removes).toEqual(['widget-1'])
-    expect(onPayload).toHaveBeenLastCalledWith(null)
   })
 })

--- a/frontend/src/components/common/TurnstileField.tsx
+++ b/frontend/src/components/common/TurnstileField.tsx
@@ -1,7 +1,7 @@
 import type { Component } from 'solid-js'
 import type { CaptchaFieldHandle } from './CaptchaField'
 
-import { onMount } from 'solid-js'
+import { createEffect, onMount } from 'solid-js'
 import { loadExternalScript } from '~/lib/scriptLoader'
 import { getCaptchaSiteKey } from '~/lib/systemInfo'
 import { createCaptchaFieldBase, noteFieldArmFailure } from './captchaFieldBase'
@@ -98,6 +98,21 @@ export const TurnstileField: Component<TurnstileFieldProps> = (props) => {
   base.onSiteKeyChange(() => {
     clearWidget()
     void arm()
+  })
+
+  // Re-render when the form action changes. reset() keeps the action
+  // baked into the first render(); a Password/Passkey switch must mint
+  // a token under the new action or the hub denies it. The first run
+  // only records the action; onMount arms the widget.
+  createEffect((prev?: string) => {
+    const action = props.action
+    if (prev !== undefined && prev !== action) {
+      props.onPayload(null)
+      base.setReady(false)
+      clearWidget()
+      void arm()
+    }
+    return action
   })
 
   onMount(() => {

--- a/frontend/src/components/common/TurnstileField.tsx
+++ b/frontend/src/components/common/TurnstileField.tsx
@@ -1,7 +1,7 @@
 import type { Component } from 'solid-js'
 import type { CaptchaFieldHandle } from './CaptchaField'
 
-import { createEffect, onMount } from 'solid-js'
+import { onMount } from 'solid-js'
 import { loadExternalScript } from '~/lib/scriptLoader'
 import { getCaptchaSiteKey } from '~/lib/systemInfo'
 import { createCaptchaFieldBase, noteFieldArmFailure } from './captchaFieldBase'
@@ -98,21 +98,6 @@ export const TurnstileField: Component<TurnstileFieldProps> = (props) => {
   base.onSiteKeyChange(() => {
     clearWidget()
     void arm()
-  })
-
-  // Re-render when the form action changes. reset() keeps the action
-  // baked into the first render(); a Password/Passkey switch must mint
-  // a token under the new action or the hub denies it. The first run
-  // only records the action; onMount arms the widget.
-  createEffect((prev?: string) => {
-    const action = props.action
-    if (prev !== undefined && prev !== action) {
-      props.onPayload(null)
-      base.setReady(false)
-      clearWidget()
-      void arm()
-    }
-    return action
   })
 
   onMount(() => {

--- a/frontend/src/components/common/VerifyEmailPage.test.tsx
+++ b/frontend/src/components/common/VerifyEmailPage.test.tsx
@@ -30,6 +30,7 @@ vi.mock('~/api/clients', () => ({
 
 const mockSetAuth = vi.fn()
 const mockUser = vi.fn<() => { username: string, emailVerified: boolean } | null>()
+const mockVerificationResendAvailableAt = vi.fn<() => { seconds: bigint, nanos: number } | undefined>()
 vi.mock('~/context/AuthContext', () => ({
   useAuth: () => ({
     user: () => mockUser(),
@@ -38,6 +39,8 @@ vi.mock('~/context/AuthContext', () => ({
     login: vi.fn(),
     logout: vi.fn(),
     setAuth: mockSetAuth,
+    verificationResendAvailableAt: () => mockVerificationResendAvailableAt(),
+    setVerificationResendAvailableAt: vi.fn(),
     isAuthenticated: () => mockUser() != null,
   }),
   AuthProvider: (props: { children: unknown }) => <>{props.children}</>,
@@ -172,6 +175,21 @@ describe('verifyEmailPage', () => {
       // it's shown rather than swallowed).
       expect(screen.getByText(/invalid or expired/i)).toBeInTheDocument()
     })
+  })
+
+  it('seeds resend cooldown from login verification timestamp', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+    mockVerificationResendAvailableAt.mockReturnValue({
+      seconds: BigInt(Math.floor(Date.now() / 1000) + 42),
+      nanos: 0,
+    })
+
+    renderPage('/verify-email')
+
+    const resendButton = await screen.findByTestId('verify-email-resend')
+    expect(resendButton).toBeDisabled()
+    expect(resendButton).toHaveTextContent(/Resend code \(0:42\)/)
   })
 
   it('clicking Resend issues the RPC and shows a status line on success', async () => {

--- a/frontend/src/components/common/VerifyEmailPage.tsx
+++ b/frontend/src/components/common/VerifyEmailPage.tsx
@@ -125,7 +125,14 @@ export const VerifyEmailPage: Component = () => {
         <button
           type="button"
           data-testid="verify-email-resend"
-          onClick={() => void resend.resend()}
+          onClick={() => {
+            // Clear the code error first. resend() clears only its own
+            // signals, so a stale "invalid or expired verification code"
+            // would otherwise render beside "A fresh code has been sent",
+            // which reads as though the new code was rejected too.
+            setError(null)
+            void resend.resend()
+          }}
           disabled={resend.disabled()}
         >
           {resend.buttonLabel()}

--- a/frontend/src/components/common/VerifyEmailPage.tsx
+++ b/frontend/src/components/common/VerifyEmailPage.tsx
@@ -1,8 +1,10 @@
 import type { Component } from 'solid-js'
 import { useNavigate, useSearchParams } from '@solidjs/router'
-import { createSignal, onMount, Show } from 'solid-js'
+import { createEffect, createSignal, Show } from 'solid-js'
 import { userClient } from '~/api/clients'
 import { useAuth } from '~/context/AuthContext'
+import { formatErrorMessage } from '~/lib/errors'
+import { useVerificationResend } from '~/lib/useVerificationResend'
 import { errorText, pageCard } from '~/styles/shared.css'
 import * as styles from './LoginPage.css'
 
@@ -22,10 +24,19 @@ export const VerifyEmailPage: Component = () => {
   const [code, setCode] = createSignal('')
   const [submitting, setSubmitting] = createSignal(false)
   const [error, setError] = createSignal<string | null>(null)
-  const [resending, setResending] = createSignal(false)
-  const [resendStatus, setResendStatus] = createSignal<string | null>(null)
+  const resend = useVerificationResend({
+    nextResendAvailableAt: () => auth.verificationResendAvailableAt(),
+  })
 
-  onMount(async () => {
+  const [decided, setDecided] = createSignal(false)
+  createEffect(() => {
+    // Wait out the auth bootstrap before deciding "not signed in": on a
+    // fresh load the session cookie is often still restoring, and reading
+    // auth.user() too early bounces a valid session to the login form
+    // (LoginPage guards the same race with auth.loading()).
+    if (auth.loading() || decided())
+      return
+    setDecided(true)
     // Pull the URL code (used for both prefill and auto-submit). It may
     // arrive in display form ("XXX-XXX") or raw ("XXXXXX").
     const urlCode = typeof searchParams.code === 'string' ? searchParams.code : ''
@@ -42,7 +53,7 @@ export const VerifyEmailPage: Component = () => {
 
     if (urlCode) {
       setCode(urlCode)
-      await submitCode(urlCode)
+      void submitCode(urlCode)
     }
   })
 
@@ -62,7 +73,7 @@ export const VerifyEmailPage: Component = () => {
       navigate('/', { replace: true })
     }
     catch (e) {
-      setError(`${e}`)
+      setError(formatErrorMessage(e, 'Verification failed'))
     }
     finally {
       setSubmitting(false)
@@ -72,25 +83,6 @@ export const VerifyEmailPage: Component = () => {
   function handleSubmit(e: Event) {
     e.preventDefault()
     void submitCode(code())
-  }
-
-  async function handleResend() {
-    setResending(true)
-    setResendStatus(null)
-    setError(null)
-    try {
-      const resp = await userClient.resendVerificationEmail({})
-      // The backend may have updated the row but skipped the SMTP send
-      // (e.g. mail provider 5xx). Surface the difference so the user
-      // doesn't sit waiting for an email that's not coming.
-      setResendStatus(resp.emailSent ? 'A fresh code has been sent to your inbox.' : 'We couldn\'t send the email — please try again shortly.')
-    }
-    catch (e) {
-      setError(`${e}`)
-    }
-    finally {
-      setResending(false)
-    }
   }
 
   return (
@@ -124,16 +116,19 @@ export const VerifyEmailPage: Component = () => {
         <Show when={error()}>
           {msg => <div class={errorText}>{msg()}</div>}
         </Show>
-        <Show when={resendStatus()}>
+        <Show when={resend.error()}>
+          {msg => <div class={errorText}>{msg()}</div>}
+        </Show>
+        <Show when={resend.status()}>
           {msg => <div data-testid="verify-email-resend-status">{msg()}</div>}
         </Show>
         <button
           type="button"
           data-testid="verify-email-resend"
-          onClick={() => void handleResend()}
-          disabled={resending()}
+          onClick={() => void resend.resend()}
+          disabled={resend.disabled()}
         >
-          {resending() ? 'Sending…' : 'Resend code'}
+          {resend.buttonLabel()}
         </button>
       </div>
     </div>

--- a/frontend/src/components/settings/PasskeyStepUp.tsx
+++ b/frontend/src/components/settings/PasskeyStepUp.tsx
@@ -1,0 +1,26 @@
+import type { Component } from 'solid-js'
+import { Show } from 'solid-js'
+import { successText } from '~/styles/shared.css'
+
+/**
+ * The step-up control shared by every passkey-management surface: offer a
+ * passkey verification ("Verify with passkey") and render the verified
+ * state once a proof exists. `onVerify` runs the reauth ceremony and stores
+ * the proof; `proof` decides which half renders.
+ */
+export const PasskeyStepUp: Component<{
+  proof: string
+  busy: boolean
+  onVerify: () => void
+}> = (props) => {
+  return (
+    <Show
+      when={!props.proof}
+      fallback={<span class={successText}>Passkey verified.</span>}
+    >
+      <button type="button" onClick={() => props.onVerify()} disabled={props.busy}>
+        Verify with passkey
+      </button>
+    </Show>
+  )
+}

--- a/frontend/src/components/settings/PasskeysSettings.tsx
+++ b/frontend/src/components/settings/PasskeysSettings.tsx
@@ -1,0 +1,536 @@
+import type { Component } from 'solid-js'
+import type { PasskeyInfo } from '~/generated/leapmux/v1/user_pb'
+import { timestampDate } from '@bufbuild/protobuf/wkt'
+import { createSignal, For, onMount, Show } from 'solid-js'
+import { userClient } from '~/api/clients'
+import { Dialog } from '~/components/common/Dialog'
+import { Spinner } from '~/components/common/Spinner'
+import { PasskeyStepUp } from '~/components/settings/PasskeyStepUp'
+import { useAuth } from '~/context/AuthContext'
+import { formatErrorMessage } from '~/lib/errors'
+import {
+  credentialIdFromRegistrationJson,
+  isReauthProofRejected,
+  loadPasskeys,
+  obtainPasskeyReauthProof,
+} from '~/lib/passkeyManagement'
+import { signalAcceptedPasskeys, signalPasskeyRemoved, startRegistration } from '~/lib/webauthn'
+import { errorText, successText, warningText } from '~/styles/shared.css'
+import * as styles from './ProfileSettings.css'
+
+type ModalMode = 'add' | 'delete' | 'deactivate' | null
+
+export const PasskeysSettings: Component<{
+  onPasskeysChange?: (count: number) => void
+}> = (props) => {
+  const auth = useAuth()
+  const [passkeys, setPasskeys] = createSignal<PasskeyInfo[]>([])
+  // The hub's relying party ID for Signal API calls; arrives with the
+  // passkey list so this component never derives it locally.
+  const [rpId, setRpId] = createSignal('')
+  const [loading, setLoading] = createSignal(true)
+  const [busy, setBusy] = createSignal(false)
+  const [message, setMessage] = createSignal<{ type: 'success' | 'error', text: string } | null>(null)
+  const [modalMessage, setModalMessage] = createSignal<{ type: 'success' | 'error', text: string } | null>(null)
+  const [modal, setModal] = createSignal<ModalMode>(null)
+  const [targetPasskey, setTargetPasskey] = createSignal<PasskeyInfo | null>(null)
+  const [currentPassword, setCurrentPassword] = createSignal('')
+  const [newPassword, setNewPassword] = createSignal('')
+  const [confirmPassword, setConfirmPassword] = createSignal('')
+  const [reauthProof, setReauthProof] = createSignal('')
+  const [friendlyName, setFriendlyName] = createSignal('')
+  const [renamingId, setRenamingId] = createSignal<string | null>(null)
+  const [renameValue, setRenameValue] = createSignal('')
+
+  const passwordSet = () => auth.user()?.passwordSet === true
+  const passkeyCount = () => passkeys().length
+
+  const notifyCount = (list: PasskeyInfo[]) => {
+    props.onPasskeysChange?.(list.length)
+  }
+
+  const refresh = async (opts?: { preserveSuccess?: boolean, refreshUser?: boolean }) => {
+    const preserveSuccess = opts?.preserveSuccess === true && message()?.type === 'success'
+    setLoading(true)
+    try {
+      const list = await loadPasskeys()
+      setRpId(list.rpId)
+      setPasskeys(list.passkeys)
+      notifyCount(list.passkeys)
+      if (opts?.refreshUser === true)
+        await auth.refreshUser()
+    }
+    catch (e) {
+      if (!preserveSuccess)
+        setMessage({ type: 'error', text: formatErrorMessage(e, 'Failed to load passkeys') })
+    }
+    finally {
+      setLoading(false)
+    }
+  }
+
+  onMount(() => {
+    void refresh()
+  })
+
+  // A stale or invalid reauth proof must not stick around: every retry
+  // would resend the same dead proof and fail identically. Clear it so the
+  // next attempt asks the user to verify again. The classification rides
+  // the connect code, not the message text.
+  const dropProofIfInvalid = (e: unknown) => {
+    if (isReauthProofRejected(e))
+      setReauthProof('')
+  }
+
+  const resetModalFields = () => {
+    setCurrentPassword('')
+    setNewPassword('')
+    setConfirmPassword('')
+    setReauthProof('')
+    setFriendlyName('')
+    setTargetPasskey(null)
+  }
+
+  const closeModal = () => {
+    if (busy())
+      return
+    setModal(null)
+    setModalMessage(null)
+    resetModalFields()
+  }
+
+  const openAdd = () => {
+    resetModalFields()
+    setModalMessage(null)
+    setFriendlyName('Passkey')
+    setModal('add')
+  }
+
+  const openDelete = (passkey: PasskeyInfo) => {
+    resetModalFields()
+    setTargetPasskey(passkey)
+    setModal('delete')
+  }
+
+  const openDeactivate = () => {
+    resetModalFields()
+    setModal('deactivate')
+  }
+
+  const needsReauthForAdd = () => !passwordSet() && passkeyCount() > 0
+  const needsReauthForDelete = () => !passwordSet() && passkeyCount() > 1
+  const deleteIsDeactivation = () => !passwordSet() && passkeyCount() === 1
+  const newPasswordReady = () => newPassword() !== '' && newPassword() === confirmPassword()
+  const addConfirmDisabled = () => busy() || (passwordSet() ? !currentPassword() : (needsReauthForAdd() && !reauthProof()))
+  const deleteConfirmDisabled = () => {
+    if (busy())
+      return true
+    if (passwordSet())
+      return !currentPassword()
+    if (deleteIsDeactivation())
+      return !reauthProof() || !newPasswordReady()
+    return needsReauthForDelete() && !reauthProof()
+  }
+  const deactivateConfirmDisabled = () => {
+    if (busy())
+      return true
+    if (passwordSet())
+      return !currentPassword()
+    return !reauthProof() || !newPasswordReady()
+  }
+
+  const applyLocalList = (list: PasskeyInfo[]) => {
+    setPasskeys(list)
+    notifyCount(list)
+  }
+
+  const handleReauth = async () => {
+    setBusy(true)
+    setModalMessage(null)
+    try {
+      setReauthProof(await obtainPasskeyReauthProof())
+    }
+    catch (e) {
+      const text = formatErrorMessage(e, 'Passkey verification failed')
+      if (modal())
+        setModalMessage({ type: 'error', text })
+      else
+        setMessage({ type: 'error', text })
+    }
+    finally {
+      setBusy(false)
+    }
+  }
+
+  const forceCloseModal = () => {
+    setModal(null)
+    setModalMessage(null)
+    resetModalFields()
+  }
+
+  const handleAddPasskey = async () => {
+    setBusy(true)
+    setModalMessage(null)
+    try {
+      let proof = reauthProof()
+      if (needsReauthForAdd() && !proof)
+        proof = await obtainPasskeyReauthProof()
+      const begin = await userClient.beginPasskeyRegistration({
+        currentPassword: currentPassword(),
+        reauthProof: proof,
+      })
+      const credentialJson = await startRegistration(begin.optionsJson)
+      const finish = await userClient.finishPasskeyRegistration({
+        sessionId: begin.sessionId,
+        credentialJson,
+        friendlyName: friendlyName().trim() || 'Passkey',
+        currentPassword: currentPassword(),
+        reauthProof: proof,
+      })
+      forceCloseModal()
+      setMessage({ type: 'success', text: 'Passkey added.' })
+      if (finish.passkey) {
+        const added = finish.passkey
+        applyLocalList([...passkeys().filter(pk => pk.id !== added.id), added])
+      }
+      const userId = auth.user()?.id
+      if (userId && rpId()) {
+        const ids = new Set(passkeys().map(pk => pk.credentialId).filter(Boolean))
+        const fromFinish = finish.passkey?.credentialId
+        if (fromFinish)
+          ids.add(fromFinish)
+        const fromJson = credentialIdFromRegistrationJson(credentialJson)
+        if (fromJson)
+          ids.add(fromJson)
+        signalAcceptedPasskeys(rpId(), userId, [...ids])
+      }
+    }
+    catch (e) {
+      dropProofIfInvalid(e)
+      setModalMessage({ type: 'error', text: formatErrorMessage(e, 'Failed to add passkey') })
+    }
+    finally {
+      setBusy(false)
+    }
+  }
+
+  const handleDeletePasskey = async () => {
+    const passkey = targetPasskey()
+    if (!passkey)
+      return
+    if (deleteIsDeactivation()) {
+      if (!reauthProof() || newPassword() !== confirmPassword() || !newPassword()) {
+        setModalMessage({ type: 'error', text: 'Verify with a passkey and set a new password to remove your last passkey.' })
+        return
+      }
+    }
+    setBusy(true)
+    setModalMessage(null)
+    try {
+      let proof = reauthProof()
+      if ((needsReauthForDelete() || deleteIsDeactivation()) && !proof)
+        proof = await obtainPasskeyReauthProof()
+      await userClient.deletePasskey({
+        id: passkey.id,
+        currentPassword: currentPassword(),
+        reauthProof: proof,
+        newPassword: deleteIsDeactivation() ? newPassword() : '',
+      })
+      if (rpId())
+        signalPasskeyRemoved(rpId(), passkey.credentialId)
+      forceCloseModal()
+      setMessage({ type: 'success', text: 'Passkey removed.' })
+      applyLocalList(passkeys().filter(pk => pk.id !== passkey.id))
+      // Only the last-passkey deactivation flips passwordSet; a plain
+      // delete changed nothing the local list does not already carry.
+      if (deleteIsDeactivation())
+        await refresh({ preserveSuccess: true, refreshUser: true })
+    }
+    catch (e) {
+      dropProofIfInvalid(e)
+      setModalMessage({ type: 'error', text: formatErrorMessage(e, 'Failed to remove passkey') })
+    }
+    finally {
+      setBusy(false)
+    }
+  }
+
+  const handleDeactivate = async () => {
+    if (!passwordSet()) {
+      if (newPassword() !== confirmPassword() || !newPassword()) {
+        setModalMessage({ type: 'error', text: 'Verify with a passkey and set a new password to disable passkey sign-in.' })
+        return
+      }
+    }
+    setBusy(true)
+    setModalMessage(null)
+    try {
+      let proof = reauthProof()
+      if (!passwordSet() && !proof)
+        proof = await obtainPasskeyReauthProof()
+      await userClient.deactivatePasskeyAuth({
+        currentPassword: currentPassword(),
+        reauthProof: proof,
+        newPassword: passwordSet() ? '' : newPassword(),
+      })
+      if (rpId()) {
+        for (const pk of passkeys())
+          signalPasskeyRemoved(rpId(), pk.credentialId)
+      }
+      forceCloseModal()
+      setMessage({ type: 'success', text: 'Passkey sign-in disabled.' })
+      applyLocalList([])
+      // Deactivation always flips passwordSet on a passkey-only account.
+      await refresh({ preserveSuccess: true, refreshUser: true })
+    }
+    catch (e) {
+      dropProofIfInvalid(e)
+      setModalMessage({ type: 'error', text: formatErrorMessage(e, 'Failed to deactivate passkeys') })
+    }
+    finally {
+      setBusy(false)
+    }
+  }
+
+  const startRename = (passkey: PasskeyInfo) => {
+    setCurrentPassword('')
+    setReauthProof('')
+    setRenamingId(passkey.id)
+    setRenameValue(passkey.friendlyName || 'Passkey')
+  }
+
+  const cancelRename = () => {
+    setRenamingId(null)
+    setRenameValue('')
+    setCurrentPassword('')
+    setReauthProof('')
+  }
+
+  const saveRename = async (id: string) => {
+    setBusy(true)
+    setMessage(null)
+    try {
+      let proof = reauthProof()
+      if (!passwordSet() && !proof)
+        proof = await obtainPasskeyReauthProof()
+      const resp = await userClient.renamePasskey({
+        id,
+        friendlyName: renameValue().trim() || 'Passkey',
+        currentPassword: currentPassword(),
+        reauthProof: proof,
+      })
+      cancelRename()
+      setMessage({ type: 'success', text: 'Passkey renamed.' })
+      // The response carries the renamed row; a rename changes nothing else.
+      if (resp.passkey)
+        applyLocalList(passkeys().map(pk => (pk.id === resp.passkey!.id ? resp.passkey! : pk)))
+    }
+    catch (e) {
+      dropProofIfInvalid(e)
+      setMessage({ type: 'error', text: formatErrorMessage(e, 'Failed to rename passkey') })
+    }
+    finally {
+      setBusy(false)
+    }
+  }
+
+  const formatPasskeyDate = (passkey: PasskeyInfo) => {
+    const ts = passkey.lastUsedAt ?? passkey.createdAt
+    if (!ts)
+      return ''
+    return timestampDate(ts).toLocaleString()
+  }
+
+  return (
+    <>
+      <h3 class={styles.sectionHeading}>Passkeys</h3>
+      <div class="vstack gap-4">
+        <Show when={loading()}>
+          <div class={styles.passkeyLoading}><Spinner /></div>
+        </Show>
+        <Show when={!loading() && passkeys().length === 0}>
+          <p class={styles.passkeyEmpty}>No passkeys registered yet.</p>
+        </Show>
+        <For each={passkeys()}>
+          {passkey => (
+            <div class={styles.passkeyRow}>
+              <div class={styles.passkeyInfo}>
+                <Show
+                  when={renamingId() !== passkey.id}
+                  fallback={(
+                    <input
+                      type="text"
+                      value={renameValue()}
+                      onInput={e => setRenameValue(e.currentTarget.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter')
+                          void saveRename(passkey.id)
+                        if (e.key === 'Escape')
+                          cancelRename()
+                      }}
+                    />
+                  )}
+                >
+                  <span class={styles.passkeyName}>{passkey.friendlyName || 'Passkey'}</span>
+                </Show>
+                <span class={styles.passkeyMeta}>
+                  {passkey.lastUsedAt ? `Last used ${formatPasskeyDate(passkey)}` : `Added ${formatPasskeyDate(passkey)}`}
+                </span>
+              </div>
+              <div class={styles.passkeyActions}>
+                <Show when={renamingId() === passkey.id}>
+                  <Show when={passwordSet()}>
+                    <input
+                      type="password"
+                      placeholder="Current password"
+                      value={currentPassword()}
+                      onInput={e => setCurrentPassword(e.currentTarget.value)}
+                      autocomplete="current-password"
+                    />
+                  </Show>
+                  <Show when={!passwordSet()}>
+                    <PasskeyStepUp proof={reauthProof()} busy={busy()} onVerify={() => void handleReauth()} />
+                  </Show>
+                  <button
+                    type="button"
+                    onClick={() => void saveRename(passkey.id)}
+                    disabled={busy() || (passwordSet() ? !currentPassword() : !reauthProof())}
+                  >
+                    Save
+                  </button>
+                  <button type="button" onClick={cancelRename} disabled={busy()}>Cancel</button>
+                </Show>
+                <Show when={renamingId() !== passkey.id}>
+                  <button type="button" onClick={() => startRename(passkey)} disabled={busy()}>Rename</button>
+                  <button type="button" class={styles.passkeyDelete} onClick={() => openDelete(passkey)} disabled={busy()}>
+                    Remove
+                  </button>
+                </Show>
+              </div>
+            </div>
+          )}
+        </For>
+        <Show when={message()}>
+          {msg => <div class={msg().type === 'success' ? successText : errorText}>{msg().text}</div>}
+        </Show>
+        <div class={styles.passkeyButtons}>
+          <button type="button" onClick={openAdd} disabled={busy() || loading()}>
+            Add passkey
+          </button>
+          <Show when={passkeyCount() > 0}>
+            <button type="button" onClick={openDeactivate} disabled={busy() || loading()}>
+              Disable passkey sign-in
+            </button>
+          </Show>
+        </div>
+      </div>
+
+      <Show when={modal() === 'add'}>
+        <Dialog title="Add passkey" onClose={closeModal} busy={busy()}>
+          <div class="vstack gap-4">
+            <label class={styles.fieldLabel}>
+              Name
+              <input type="text" value={friendlyName()} onInput={e => setFriendlyName(e.currentTarget.value)} />
+            </label>
+            <Show when={passwordSet()}>
+              <label class={styles.fieldLabel}>
+                Current password
+                <input
+                  type="password"
+                  value={currentPassword()}
+                  onInput={e => setCurrentPassword(e.currentTarget.value)}
+                  autocomplete="current-password"
+                />
+              </label>
+            </Show>
+            <Show when={needsReauthForAdd()}>
+              <PasskeyStepUp proof={reauthProof()} busy={busy()} onVerify={() => void handleReauth()} />
+            </Show>
+            <Show when={modalMessage()}>
+              {msg => <div class={msg().type === 'success' ? successText : errorText}>{msg().text}</div>}
+            </Show>
+            <button type="button" onClick={() => void handleAddPasskey()} disabled={addConfirmDisabled()}>
+              {busy() ? 'Adding…' : 'Continue'}
+            </button>
+          </div>
+        </Dialog>
+      </Show>
+
+      <Show when={modal() === 'delete'}>
+        <Dialog title="Remove passkey" onClose={closeModal} busy={busy()}>
+          <div class="vstack gap-4">
+            <Show when={deleteIsDeactivation()}>
+              <div class={warningText}>
+                This is your only sign-in method. Removing it requires setting a password.
+              </div>
+              <label class={styles.fieldLabel}>
+                New password
+                <input type="password" value={newPassword()} onInput={e => setNewPassword(e.currentTarget.value)} />
+              </label>
+              <label class={styles.fieldLabel}>
+                Confirm password
+                <input type="password" value={confirmPassword()} onInput={e => setConfirmPassword(e.currentTarget.value)} />
+              </label>
+            </Show>
+            <Show when={passwordSet()}>
+              <label class={styles.fieldLabel}>
+                Current password
+                <input
+                  type="password"
+                  value={currentPassword()}
+                  onInput={e => setCurrentPassword(e.currentTarget.value)}
+                  autocomplete="current-password"
+                />
+              </label>
+            </Show>
+            <Show when={needsReauthForDelete() || deleteIsDeactivation()}>
+              <PasskeyStepUp proof={reauthProof()} busy={busy()} onVerify={() => void handleReauth()} />
+            </Show>
+            <Show when={modalMessage()}>
+              {msg => <div class={msg().type === 'success' ? successText : errorText}>{msg().text}</div>}
+            </Show>
+            <button type="button" class={styles.passkeyDelete} onClick={() => void handleDeletePasskey()} disabled={deleteConfirmDisabled()}>
+              {busy() ? 'Removing…' : 'Remove passkey'}
+            </button>
+          </div>
+        </Dialog>
+      </Show>
+
+      <Show when={modal() === 'deactivate'}>
+        <Dialog title="Disable passkey sign-in" onClose={closeModal} busy={busy()}>
+          <div class="vstack gap-4">
+            <p>Removes all passkeys from your account.</p>
+            <Show when={passwordSet()}>
+              <label class={styles.fieldLabel}>
+                Current password
+                <input
+                  type="password"
+                  value={currentPassword()}
+                  onInput={e => setCurrentPassword(e.currentTarget.value)}
+                  autocomplete="current-password"
+                />
+              </label>
+            </Show>
+            <Show when={!passwordSet()}>
+              <label class={styles.fieldLabel}>
+                New password
+                <input type="password" value={newPassword()} onInput={e => setNewPassword(e.currentTarget.value)} />
+              </label>
+              <label class={styles.fieldLabel}>
+                Confirm password
+                <input type="password" value={confirmPassword()} onInput={e => setConfirmPassword(e.currentTarget.value)} />
+              </label>
+              <PasskeyStepUp proof={reauthProof()} busy={busy()} onVerify={() => void handleReauth()} />
+            </Show>
+            <Show when={modalMessage()}>
+              {msg => <div class={msg().type === 'success' ? successText : errorText}>{msg().text}</div>}
+            </Show>
+            <button type="button" onClick={() => void handleDeactivate()} disabled={deactivateConfirmDisabled()}>
+              {busy() ? 'Disabling…' : 'Disable passkey sign-in'}
+            </button>
+          </div>
+        </Dialog>
+      </Show>
+    </>
+  )
+}

--- a/frontend/src/components/settings/PasskeysSettings.tsx
+++ b/frontend/src/components/settings/PasskeysSettings.tsx
@@ -14,7 +14,7 @@ import {
   loadPasskeys,
   obtainPasskeyReauthProof,
 } from '~/lib/passkeyManagement'
-import { signalAcceptedPasskeys, signalPasskeyRemoved, startRegistration } from '~/lib/webauthn'
+import { passkeyErrorMessage, signalAcceptedPasskeys, signalPasskeyRemoved, startRegistration } from '~/lib/webauthn'
 import { errorText, successText, warningText } from '~/styles/shared.css'
 import * as styles from './ProfileSettings.css'
 
@@ -49,14 +49,35 @@ export const PasskeysSettings: Component<{
     props.onPasskeysChange?.(list.length)
   }
 
+  const resetModalFields = () => {
+    setCurrentPassword('')
+    setNewPassword('')
+    setConfirmPassword('')
+    setReauthProof('')
+    setFriendlyName('')
+    setTargetPasskey(null)
+  }
+
+  const applyLocalList = (list: PasskeyInfo[]) => {
+    setPasskeys(list)
+    notifyCount(list)
+  }
+
+  const forceCloseModal = () => {
+    setModal(null)
+    setModalMessage(null)
+    resetModalFields()
+  }
+
   const refresh = async (opts?: { preserveSuccess?: boolean, refreshUser?: boolean }) => {
     const preserveSuccess = opts?.preserveSuccess === true && message()?.type === 'success'
     setLoading(true)
     try {
       const list = await loadPasskeys()
       setRpId(list.rpId)
-      setPasskeys(list.passkeys)
-      notifyCount(list.passkeys)
+      // Through applyLocalList, so "every list write notifies the parent"
+      // is structural rather than remembered at each write.
+      applyLocalList(list.passkeys)
       if (opts?.refreshUser === true)
         await auth.refreshUser()
     }
@@ -82,21 +103,11 @@ export const PasskeysSettings: Component<{
       setReauthProof('')
   }
 
-  const resetModalFields = () => {
-    setCurrentPassword('')
-    setNewPassword('')
-    setConfirmPassword('')
-    setReauthProof('')
-    setFriendlyName('')
-    setTargetPasskey(null)
-  }
-
+  // A busy dialog is not dismissible; everything else is forceCloseModal.
   const closeModal = () => {
     if (busy())
       return
-    setModal(null)
-    setModalMessage(null)
-    resetModalFields()
+    forceCloseModal()
   }
 
   const openAdd = () => {
@@ -139,9 +150,19 @@ export const PasskeysSettings: Component<{
     return !reauthProof() || !newPasswordReady()
   }
 
-  const applyLocalList = (list: PasskeyInfo[]) => {
-    setPasskeys(list)
-    notifyCount(list)
+  /**
+   * The step-up proof for an action, acquiring one only when the action
+   * needs it and the dialog does not already hold one.
+   *
+   * Four handlers repeated this three-line dance, and each one spelled its
+   * own `needed` condition beside it; a fifth action meant remembering the
+   * shape rather than passing a boolean.
+   */
+  const ensureProof = async (needed: boolean): Promise<string> => {
+    const held = reauthProof()
+    if (held || !needed)
+      return held
+    return await obtainPasskeyReauthProof()
   }
 
   const handleReauth = async () => {
@@ -151,30 +172,21 @@ export const PasskeysSettings: Component<{
       setReauthProof(await obtainPasskeyReauthProof())
     }
     catch (e) {
-      const text = formatErrorMessage(e, 'Passkey verification failed')
-      if (modal())
-        setModalMessage({ type: 'error', text })
-      else
-        setMessage({ type: 'error', text })
+      // A dismissed prompt is not a failure to report.
+      const text = passkeyErrorMessage(e, 'Passkey verification failed')
+      if (text)
+        (modal() ? setModalMessage : setMessage)({ type: 'error', text })
     }
     finally {
       setBusy(false)
     }
   }
 
-  const forceCloseModal = () => {
-    setModal(null)
-    setModalMessage(null)
-    resetModalFields()
-  }
-
   const handleAddPasskey = async () => {
     setBusy(true)
     setModalMessage(null)
     try {
-      let proof = reauthProof()
-      if (needsReauthForAdd() && !proof)
-        proof = await obtainPasskeyReauthProof()
+      const proof = await ensureProof(needsReauthForAdd())
       const begin = await userClient.beginPasskeyRegistration({
         currentPassword: currentPassword(),
         reauthProof: proof,
@@ -207,7 +219,9 @@ export const PasskeysSettings: Component<{
     }
     catch (e) {
       dropProofIfInvalid(e)
-      setModalMessage({ type: 'error', text: formatErrorMessage(e, 'Failed to add passkey') })
+      const text = passkeyErrorMessage(e, 'Failed to add passkey')
+      if (text)
+        setModalMessage({ type: 'error', text })
     }
     finally {
       setBusy(false)
@@ -227,9 +241,7 @@ export const PasskeysSettings: Component<{
     setBusy(true)
     setModalMessage(null)
     try {
-      let proof = reauthProof()
-      if ((needsReauthForDelete() || deleteIsDeactivation()) && !proof)
-        proof = await obtainPasskeyReauthProof()
+      const proof = await ensureProof(needsReauthForDelete() || deleteIsDeactivation())
       await userClient.deletePasskey({
         id: passkey.id,
         currentPassword: currentPassword(),
@@ -248,7 +260,9 @@ export const PasskeysSettings: Component<{
     }
     catch (e) {
       dropProofIfInvalid(e)
-      setModalMessage({ type: 'error', text: formatErrorMessage(e, 'Failed to remove passkey') })
+      const text = passkeyErrorMessage(e, 'Failed to remove passkey')
+      if (text)
+        setModalMessage({ type: 'error', text })
     }
     finally {
       setBusy(false)
@@ -265,9 +279,7 @@ export const PasskeysSettings: Component<{
     setBusy(true)
     setModalMessage(null)
     try {
-      let proof = reauthProof()
-      if (!passwordSet() && !proof)
-        proof = await obtainPasskeyReauthProof()
+      const proof = await ensureProof(!passwordSet())
       await userClient.deactivatePasskeyAuth({
         currentPassword: currentPassword(),
         reauthProof: proof,
@@ -285,7 +297,9 @@ export const PasskeysSettings: Component<{
     }
     catch (e) {
       dropProofIfInvalid(e)
-      setModalMessage({ type: 'error', text: formatErrorMessage(e, 'Failed to deactivate passkeys') })
+      const text = passkeyErrorMessage(e, 'Failed to deactivate passkeys')
+      if (text)
+        setModalMessage({ type: 'error', text })
     }
     finally {
       setBusy(false)
@@ -310,9 +324,7 @@ export const PasskeysSettings: Component<{
     setBusy(true)
     setMessage(null)
     try {
-      let proof = reauthProof()
-      if (!passwordSet() && !proof)
-        proof = await obtainPasskeyReauthProof()
+      const proof = await ensureProof(!passwordSet())
       const resp = await userClient.renamePasskey({
         id,
         friendlyName: renameValue().trim() || 'Passkey',

--- a/frontend/src/components/settings/ProfileSettings.css.ts
+++ b/frontend/src/components/settings/ProfileSettings.css.ts
@@ -71,3 +71,61 @@ export const linkedAccountUnlink = style({
     color: 'var(--danger)',
   },
 })
+
+export const passkeyLoading = style({
+  display: 'flex',
+  justifyContent: 'center',
+  padding: 'var(--space-2) 0',
+})
+
+export const passkeyEmpty = style({
+  fontSize: 'var(--text-7)',
+  color: 'var(--muted-foreground)',
+  margin: 0,
+})
+
+export const passkeyRow = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: 'var(--space-3)',
+  padding: 'var(--space-2) var(--space-3)',
+  fontSize: 'var(--text-7)',
+  color: 'var(--foreground)',
+  backgroundColor: 'var(--card)',
+  border: '1px solid var(--border)',
+  borderRadius: 'var(--radius-2)',
+})
+
+export const passkeyInfo = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 'var(--space-1)',
+  flex: 1,
+  minWidth: 0,
+})
+
+export const passkeyName = style({
+  fontWeight: 'var(--font-medium)',
+})
+
+export const passkeyMeta = style({
+  fontSize: 'var(--text-8)',
+  color: 'var(--muted-foreground)',
+})
+
+export const passkeyActions = style({
+  display: 'flex',
+  gap: 'var(--space-2)',
+  flexShrink: 0,
+})
+
+export const passkeyDelete = style({
+  color: 'var(--danger)',
+})
+
+export const passkeyButtons = style({
+  display: 'flex',
+  gap: 'var(--space-3)',
+  flexWrap: 'wrap',
+})

--- a/frontend/src/components/settings/ProfileSettings.test.tsx
+++ b/frontend/src/components/settings/ProfileSettings.test.tsx
@@ -96,7 +96,7 @@ describe('profileSettings passkeys', () => {
     })
   })
 
-  it('lists passkeys and offers password-gated add flow', async () => {
+  it('lists passkeys and offers password-protected add flow', async () => {
     render(() => <ProfileSettings />)
     expect(await screen.findByText('Laptop')).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: 'Add passkey' }))
@@ -136,7 +136,7 @@ describe('profileSettings passkeys', () => {
     expect(mockSignalPasskeyRemoved).toHaveBeenCalledWith('localhost', 'cred-abc')
   })
 
-  it('offers reauth-gated add flow when password is not set', async () => {
+  it('offers reauth-protected add flow when password is not set', async () => {
     mockUser.mockReturnValue({
       username: 'alice',
       displayName: 'Alice',

--- a/frontend/src/components/settings/ProfileSettings.test.tsx
+++ b/frontend/src/components/settings/ProfileSettings.test.tsx
@@ -1,0 +1,513 @@
+import { fireEvent, render, screen, within } from '@solidjs/testing-library'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ProfileSettings } from './ProfileSettings'
+
+const mockListPasskeys = vi.fn()
+const mockDeletePasskey = vi.fn()
+const mockDeactivatePasskeyAuth = vi.fn()
+const mockRenamePasskey = vi.fn()
+const mockChangePassword = vi.fn()
+const mockSignalPasskeyRemoved = vi.fn()
+const mockSignalAcceptedPasskeys = vi.fn()
+const mockObtainPasskeyReauthProof = vi.fn()
+const mockBeginPasskeyRegistration = vi.fn()
+const mockFinishPasskeyRegistration = vi.fn()
+const mockStartRegistration = vi.fn()
+const mockUser = vi.fn()
+const mockRefreshUser = vi.fn()
+
+vi.mock('~/api/clients', () => ({
+  userClient: {
+    listPasskeys: (...args: unknown[]) => mockListPasskeys(...args),
+    updateProfile: vi.fn(),
+    requestEmailChange: vi.fn(),
+    changePassword: (...args: unknown[]) => mockChangePassword(...args),
+    unlinkOAuthProvider: vi.fn(),
+    renamePasskey: (...args: unknown[]) => mockRenamePasskey(...args),
+    deletePasskey: (...args: unknown[]) => mockDeletePasskey(...args),
+    deactivatePasskeyAuth: (...args: unknown[]) => mockDeactivatePasskeyAuth(...args),
+    beginPasskeyRegistration: (...args: unknown[]) => mockBeginPasskeyRegistration(...args),
+    finishPasskeyRegistration: (...args: unknown[]) => mockFinishPasskeyRegistration(...args),
+    beginPasskeyReauth: vi.fn(),
+    finishPasskeyReauth: vi.fn(),
+  },
+}))
+
+vi.mock('~/context/AuthContext', () => ({
+  useAuth: () => ({
+    user: () => mockUser(),
+    refreshUser: mockRefreshUser,
+  }),
+}))
+
+vi.mock('~/lib/webauthn', () => ({
+  startRegistration: (...args: unknown[]) => mockStartRegistration(...args),
+  startAuthentication: vi.fn(),
+  signalPasskeyRemoved: (...args: unknown[]) => mockSignalPasskeyRemoved(...args),
+  signalAcceptedPasskeys: (...args: unknown[]) => mockSignalAcceptedPasskeys(...args),
+}))
+
+vi.mock('~/lib/passkeyManagement', async () => {
+  const actual = await vi.importActual<typeof import('~/lib/passkeyManagement')>('~/lib/passkeyManagement')
+  return {
+    ...actual,
+    loadPasskeys: async () => {
+      const resp = await mockListPasskeys({})
+      return { passkeys: resp.passkeys ?? [], rpId: resp.rpId ?? 'localhost' }
+    },
+    obtainPasskeyReauthProof: (...args: unknown[]) => mockObtainPasskeyReauthProof(...args),
+  }
+})
+
+describe('profileSettings passkeys', () => {
+  beforeEach(() => {
+    HTMLDialogElement.prototype.showModal = vi.fn(function (this: HTMLDialogElement) {
+      this.open = true
+    })
+    HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+      this.open = false
+    })
+    vi.clearAllMocks()
+    mockRefreshUser.mockResolvedValue(undefined)
+    mockUser.mockReturnValue({
+      id: 'user-1',
+      username: 'alice',
+      displayName: 'Alice',
+      email: 'alice@example.com',
+      emailVerified: true,
+      passwordSet: true,
+      passkeyCount: 1,
+      oauthProviders: [],
+    })
+    mockListPasskeys.mockResolvedValue({
+      passkeys: [{ id: 'pk-1', friendlyName: 'Laptop', transports: [], credentialId: 'cred-abc' }],
+      rpId: 'localhost',
+    })
+    mockDeletePasskey.mockResolvedValue({})
+    mockDeactivatePasskeyAuth.mockResolvedValue({})
+    mockRenamePasskey.mockResolvedValue({})
+    mockChangePassword.mockResolvedValue({})
+    mockObtainPasskeyReauthProof.mockResolvedValue('proof-123')
+    mockBeginPasskeyRegistration.mockResolvedValue({ sessionId: 'sess-1', optionsJson: '{}' })
+    mockStartRegistration.mockResolvedValue('{"id":"cred-new"}')
+    mockFinishPasskeyRegistration.mockResolvedValue({
+      passkey: { id: 'pk-2', friendlyName: 'Phone', transports: [], credentialId: 'cred-new' },
+    })
+  })
+
+  it('lists passkeys and offers password-gated add flow', async () => {
+    render(() => <ProfileSettings />)
+    expect(await screen.findByText('Laptop')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Add passkey' }))
+    expect(await screen.findByLabelText('Current password')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled()
+    fireEvent.input(screen.getByLabelText('Current password'), { target: { value: 'secret' } })
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeEnabled()
+  })
+
+  it('deletes a passkey with the current password and notifies Signal API', async () => {
+    render(() => <ProfileSettings />)
+    expect(await screen.findByText('Laptop')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }))
+    fireEvent.input(await screen.findByLabelText('Current password'), { target: { value: 'secret' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Remove passkey' }))
+    await vi.waitFor(() => {
+      expect(mockDeletePasskey).toHaveBeenCalledWith(expect.objectContaining({
+        id: 'pk-1',
+        currentPassword: 'secret',
+      }))
+    })
+    expect(mockSignalPasskeyRemoved).toHaveBeenCalledWith('localhost', 'cred-abc')
+  })
+
+  it('deactivates passkey sign-in with the current password and notifies Signal API', async () => {
+    render(() => <ProfileSettings />)
+    expect(await screen.findByText('Laptop')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Disable passkey sign-in' }))
+    fireEvent.input(await screen.findByLabelText('Current password'), { target: { value: 'secret' } })
+    const confirmButtons = screen.getAllByRole('button', { name: 'Disable passkey sign-in' })
+    fireEvent.click(confirmButtons[confirmButtons.length - 1]!)
+    await vi.waitFor(() => {
+      expect(mockDeactivatePasskeyAuth).toHaveBeenCalledWith(expect.objectContaining({
+        currentPassword: 'secret',
+      }))
+    })
+    expect(mockSignalPasskeyRemoved).toHaveBeenCalledWith('localhost', 'cred-abc')
+  })
+
+  it('offers reauth-gated add flow when password is not set', async () => {
+    mockUser.mockReturnValue({
+      username: 'alice',
+      displayName: 'Alice',
+      email: 'alice@example.com',
+      emailVerified: true,
+      passwordSet: false,
+      passkeyCount: 1,
+      oauthProviders: [],
+    })
+
+    render(() => <ProfileSettings />)
+    expect(await screen.findByText('Laptop')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Add passkey' }))
+    expect(screen.queryByLabelText('Current password')).not.toBeInTheDocument()
+    const verifyButtons = await screen.findAllByRole('button', { name: 'Verify with passkey' })
+    // Password section + add-passkey modal both offer Verify when !passwordSet.
+    expect(verifyButtons.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('deletes a non-last passkey with reauth when password is not set', async () => {
+    mockUser.mockReturnValue({
+      username: 'alice',
+      displayName: 'Alice',
+      email: 'alice@example.com',
+      emailVerified: true,
+      passwordSet: false,
+      passkeyCount: 2,
+      oauthProviders: [],
+    })
+    mockListPasskeys.mockResolvedValue({
+      passkeys: [
+        { id: 'pk-1', friendlyName: 'Laptop', transports: [], credentialId: 'cred-abc' },
+        { id: 'pk-2', friendlyName: 'Phone', transports: [], credentialId: 'cred-def' },
+      ],
+    })
+
+    render(() => <ProfileSettings />)
+    expect(await screen.findByText('Phone')).toBeInTheDocument()
+    const removeButtons = screen.getAllByRole('button', { name: 'Remove' })
+    fireEvent.click(removeButtons[1]!)
+    const verifyButtons = await screen.findAllByRole('button', { name: 'Verify with passkey' })
+    fireEvent.click(verifyButtons[verifyButtons.length - 1]!)
+    await vi.waitFor(() => {
+      expect(mockObtainPasskeyReauthProof).toHaveBeenCalled()
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Remove passkey' }))
+    await vi.waitFor(() => {
+      expect(mockDeletePasskey).toHaveBeenCalledWith(expect.objectContaining({
+        id: 'pk-2',
+        reauthProof: 'proof-123',
+      }))
+    })
+  })
+
+  it('shows verify UI when removing the last passkey without a password', async () => {
+    mockUser.mockReturnValue({
+      username: 'alice',
+      displayName: 'Alice',
+      email: 'alice@example.com',
+      emailVerified: true,
+      passwordSet: false,
+      passkeyCount: 1,
+      oauthProviders: [],
+    })
+
+    render(() => <ProfileSettings />)
+    expect(await screen.findByText('Laptop')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }))
+    expect(await screen.findByText(/only sign-in method/i)).toBeInTheDocument()
+    expect(await screen.findByLabelText('New password')).toBeInTheDocument()
+    const verifyButtons = await screen.findAllByRole('button', { name: 'Verify with passkey' })
+    // Password section + last-passkey delete modal.
+    expect(verifyButtons.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('offers verify with passkey when setting a first password and passkeys exist', async () => {
+    mockUser.mockReturnValue({
+      username: 'alice',
+      displayName: 'Alice',
+      email: 'alice@example.com',
+      emailVerified: true,
+      passwordSet: false,
+      passkeyCount: 1,
+      oauthProviders: [],
+    })
+
+    render(() => <ProfileSettings />)
+    expect(await screen.findByText('Laptop')).toBeInTheDocument()
+    const verifyButtons = await screen.findAllByRole('button', { name: 'Verify with passkey' })
+    // Password section shows Verify when !passwordSet and passkeys exist.
+    expect(verifyButtons.length).toBe(1)
+  })
+
+  it('hides password-section verify for OAuth-only users with zero passkeys', async () => {
+    mockUser.mockReturnValue({
+      username: 'alice',
+      displayName: 'Alice',
+      email: 'alice@example.com',
+      emailVerified: true,
+      passwordSet: false,
+      passkeyCount: 0,
+      oauthProviders: [{ id: 'github', name: 'GitHub' }],
+    })
+    mockListPasskeys.mockResolvedValue({ passkeys: [] })
+
+    render(() => <ProfileSettings />)
+    await vi.waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Set Password' })).toBeInTheDocument()
+    })
+    expect(screen.queryByRole('button', { name: 'Verify with passkey' })).not.toBeInTheDocument()
+  })
+
+  it('hides verify in add-passkey modal for OAuth-only users with zero passkeys', async () => {
+    mockUser.mockReturnValue({
+      username: 'alice',
+      displayName: 'Alice',
+      email: 'alice@example.com',
+      emailVerified: true,
+      passwordSet: false,
+      passkeyCount: 0,
+      oauthProviders: [{ id: 'github', name: 'GitHub' }],
+    })
+    mockListPasskeys.mockResolvedValue({ passkeys: [] })
+
+    render(() => <ProfileSettings />)
+    expect(await screen.findByText('No passkeys registered yet.')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Add passkey' }))
+    expect(await screen.findByLabelText('Name')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Verify with passkey' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeInTheDocument()
+  })
+
+  it('renames a passkey with the current password', async () => {
+    render(() => <ProfileSettings />)
+    expect(await screen.findByText('Laptop')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Rename' }))
+    fireEvent.input(screen.getByPlaceholderText('Current password'), { target: { value: 'secret' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await vi.waitFor(() => {
+      expect(mockRenamePasskey).toHaveBeenCalledWith(expect.objectContaining({
+        id: 'pk-1',
+        currentPassword: 'secret',
+      }))
+    })
+  })
+
+  it('updates password-section verify from live passkey list count', async () => {
+    mockUser.mockReturnValue({
+      username: 'alice',
+      displayName: 'Alice',
+      email: 'alice@example.com',
+      emailVerified: true,
+      passwordSet: false,
+      passkeyCount: 0,
+      oauthProviders: [{ id: 'github', name: 'GitHub' }],
+    })
+    mockListPasskeys.mockResolvedValue({
+      passkeys: [{ id: 'pk-1', friendlyName: 'Laptop', transports: [], credentialId: 'cred-abc' }],
+    })
+
+    render(() => <ProfileSettings />)
+    expect(await screen.findByText('Laptop')).toBeInTheDocument()
+    // auth.user().passkeyCount is still 0; live list drives the verify button.
+    const verifyButtons = await screen.findAllByRole('button', { name: 'Verify with passkey' })
+    expect(verifyButtons.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('deactivates passkey-only auth with reauth and a new password', async () => {
+    mockUser.mockReturnValue({
+      username: 'alice',
+      displayName: 'Alice',
+      email: 'alice@example.com',
+      emailVerified: true,
+      passwordSet: false,
+      passkeyCount: 1,
+      oauthProviders: [],
+    })
+
+    render(() => <ProfileSettings />)
+    expect(await screen.findByText('Laptop')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Disable passkey sign-in' }))
+    fireEvent.input(await screen.findByLabelText('New password'), { target: { value: 'newpass123' } })
+    fireEvent.input(await screen.findByLabelText('Confirm password'), { target: { value: 'newpass123' } })
+    const verifyButtons = await screen.findAllByRole('button', { name: 'Verify with passkey' })
+    fireEvent.click(verifyButtons[verifyButtons.length - 1]!)
+    await vi.waitFor(() => {
+      expect(mockObtainPasskeyReauthProof).toHaveBeenCalled()
+    })
+    const confirmButtons = screen.getAllByRole('button', { name: 'Disable passkey sign-in' })
+    fireEvent.click(confirmButtons[confirmButtons.length - 1]!)
+    await vi.waitFor(() => {
+      expect(mockDeactivatePasskeyAuth).toHaveBeenCalledWith(expect.objectContaining({
+        reauthProof: 'proof-123',
+        newPassword: 'newpass123',
+      }))
+    })
+    expect(mockSignalPasskeyRemoved).toHaveBeenCalledWith('localhost', 'cred-abc')
+  })
+
+  it('keeps Set Password disabled until passkey verification succeeds', async () => {
+    mockUser.mockReturnValue({
+      username: 'alice',
+      displayName: 'Alice',
+      email: 'alice@example.com',
+      emailVerified: true,
+      passwordSet: false,
+      passkeyCount: 1,
+      oauthProviders: [],
+    })
+
+    render(() => <ProfileSettings />)
+    expect(await screen.findByText('Laptop')).toBeInTheDocument()
+    fireEvent.input(screen.getByLabelText('New Password'), { target: { value: 'newpass123' } })
+    fireEvent.input(screen.getByLabelText('Confirm Password'), { target: { value: 'newpass123' } })
+    expect(screen.getByRole('button', { name: 'Set Password' })).toBeDisabled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Verify with passkey' }))
+    await vi.waitFor(() => {
+      expect(mockObtainPasskeyReauthProof).toHaveBeenCalled()
+    })
+    expect(await screen.findByRole('button', { name: 'Set Password' })).toBeEnabled()
+  })
+
+  it('shows current-password add flow after set-password refresh', async () => {
+    mockUser.mockReturnValue({
+      username: 'alice',
+      displayName: 'Alice',
+      email: 'alice@example.com',
+      emailVerified: true,
+      passwordSet: false,
+      passkeyCount: 1,
+      oauthProviders: [],
+    })
+    mockChangePassword.mockImplementation(async () => {
+      mockUser.mockReturnValue({
+        username: 'alice',
+        displayName: 'Alice',
+        email: 'alice@example.com',
+        emailVerified: true,
+        passwordSet: true,
+        passkeyCount: 1,
+        oauthProviders: [],
+      })
+    })
+
+    render(() => <ProfileSettings />)
+    expect(await screen.findByText('Laptop')).toBeInTheDocument()
+    fireEvent.input(screen.getByLabelText('New Password'), { target: { value: 'newpass123' } })
+    fireEvent.input(screen.getByLabelText('Confirm Password'), { target: { value: 'newpass123' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Verify with passkey' }))
+    await vi.waitFor(() => {
+      expect(mockObtainPasskeyReauthProof).toHaveBeenCalled()
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Set Password' }))
+    await vi.waitFor(() => {
+      expect(mockChangePassword).toHaveBeenCalled()
+    })
+    await vi.waitFor(() => {
+      expect(mockRefreshUser).toHaveBeenCalled()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add passkey' }))
+    expect(await screen.findByLabelText('Current password')).toBeInTheDocument()
+    const addDialog = screen.getByRole('dialog', { name: 'Add passkey' })
+    expect(within(addDialog).queryByRole('button', { name: 'Verify with passkey' })).not.toBeInTheDocument()
+  })
+
+  it('renames a passkey with reauth when password is not set', async () => {
+    mockUser.mockReturnValue({
+      username: 'alice',
+      displayName: 'Alice',
+      email: 'alice@example.com',
+      emailVerified: true,
+      passwordSet: false,
+      passkeyCount: 1,
+      oauthProviders: [],
+    })
+
+    render(() => <ProfileSettings />)
+    expect(await screen.findByText('Laptop')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Rename' }))
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+    const verifyButtons = screen.getAllByRole('button', { name: 'Verify with passkey' })
+    fireEvent.click(verifyButtons[verifyButtons.length - 1]!)
+    await vi.waitFor(() => {
+      expect(mockObtainPasskeyReauthProof).toHaveBeenCalled()
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await vi.waitFor(() => {
+      expect(mockRenamePasskey).toHaveBeenCalledWith(expect.objectContaining({
+        id: 'pk-1',
+        reauthProof: 'proof-123',
+      }))
+    })
+  })
+
+  it('keeps last-passkey remove disabled until the new password matches', async () => {
+    mockUser.mockReturnValue({
+      username: 'alice',
+      displayName: 'Alice',
+      email: 'alice@example.com',
+      emailVerified: true,
+      passwordSet: false,
+      passkeyCount: 1,
+      oauthProviders: [],
+    })
+
+    render(() => <ProfileSettings />)
+    expect(await screen.findByText('Laptop')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }))
+    expect(await screen.findByRole('button', { name: 'Remove passkey' })).toBeDisabled()
+    fireEvent.input(screen.getByLabelText('New password'), { target: { value: 'newpass123' } })
+    fireEvent.input(screen.getByLabelText('Confirm password'), { target: { value: 'newpass123' } })
+    expect(screen.getByRole('button', { name: 'Remove passkey' })).toBeDisabled()
+    const verifyButtons = screen.getAllByRole('button', { name: 'Verify with passkey' })
+    fireEvent.click(verifyButtons[verifyButtons.length - 1]!)
+    await vi.waitFor(() => {
+      expect(mockObtainPasskeyReauthProof).toHaveBeenCalled()
+    })
+    expect(screen.getByRole('button', { name: 'Remove passkey' })).toBeEnabled()
+  })
+
+  it('keeps the added passkey in the list when the follow-up refresh fails', async () => {
+    mockUser.mockReturnValue({
+      id: 'user-1',
+      username: 'alice',
+      displayName: 'Alice',
+      email: 'alice@example.com',
+      emailVerified: true,
+      passwordSet: true,
+      passkeyCount: 1,
+      oauthProviders: [],
+    })
+    mockListPasskeys
+      .mockResolvedValueOnce({
+        passkeys: [{ id: 'pk-1', friendlyName: 'Laptop', transports: [], credentialId: 'cred-abc' }],
+      })
+      .mockRejectedValue(new Error('list failed'))
+
+    render(() => <ProfileSettings />)
+    expect(await screen.findByText('Laptop')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Add passkey' }))
+    fireEvent.input(await screen.findByLabelText('Current password'), { target: { value: 'secret' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+    expect(await screen.findByText('Phone')).toBeInTheDocument()
+    expect(screen.getByText('Laptop')).toBeInTheDocument()
+    expect(screen.getByText('Passkey added.')).toBeInTheDocument()
+    await vi.waitFor(() => {
+      expect(mockSignalAcceptedPasskeys).toHaveBeenCalledWith(
+        'localhost',
+        'user-1',
+        expect.arrayContaining(['cred-abc', 'cred-new']),
+      )
+    })
+  })
+
+  it('keeps the passkey removed from the list when the follow-up refresh fails', async () => {
+    mockListPasskeys
+      .mockResolvedValueOnce({
+        passkeys: [{ id: 'pk-1', friendlyName: 'Laptop', transports: [], credentialId: 'cred-abc' }],
+      })
+      .mockRejectedValue(new Error('list failed'))
+
+    render(() => <ProfileSettings />)
+    expect(await screen.findByText('Laptop')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }))
+    fireEvent.input(await screen.findByLabelText('Current password'), { target: { value: 'secret' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Remove passkey' }))
+    await vi.waitFor(() => {
+      expect(screen.queryByText('Laptop')).not.toBeInTheDocument()
+    })
+    expect(screen.getByText('Passkey removed.')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/settings/ProfileSettings.tsx
+++ b/frontend/src/components/settings/ProfileSettings.tsx
@@ -3,8 +3,11 @@ import { createMemo, createSignal, For, onMount, Show } from 'solid-js'
 import { userClient } from '~/api/clients'
 import { passwordCanSubmit, PasswordFields } from '~/components/common/PasswordFields'
 import { UsernameField } from '~/components/common/UsernameField'
+import { PasskeysSettings } from '~/components/settings/PasskeysSettings'
+import { PasskeyStepUp } from '~/components/settings/PasskeyStepUp'
 import { useAuth } from '~/context/AuthContext'
 import { formatErrorMessage } from '~/lib/errors'
+import { isReauthProofRejected, obtainPasskeyReauthProof } from '~/lib/passkeyManagement'
 import { sanitizeDisplayName, sanitizeName, sanitizeSlug, validateEmail } from '~/lib/validate'
 import { errorText, successText, warningText } from '~/styles/shared.css'
 import * as styles from './ProfileSettings.css'
@@ -26,6 +29,9 @@ export const ProfileSettings: Component = () => {
   const [confirmPassword, setConfirmPassword] = createSignal('')
   const [passwordSaving, setPasswordSaving] = createSignal(false)
   const [passwordMessage, setPasswordMessage] = createSignal<{ type: 'success' | 'error', text: string } | null>(null)
+  const [reauthProof, setReauthProof] = createSignal('')
+  const [reauthBusy, setReauthBusy] = createSignal(false)
+  const [livePasskeyCount, setLivePasskeyCount] = createSignal(auth.user()?.passkeyCount ?? 0)
 
   const [unlinkingProvider, setUnlinkingProvider] = createSignal<string | null>(null)
   const [unlinkMessage, setUnlinkMessage] = createSignal<{ type: 'success' | 'error', text: string } | null>(null)
@@ -127,6 +133,20 @@ export const ProfileSettings: Component = () => {
     }
   }
 
+  const handlePasswordReauth = async () => {
+    setReauthBusy(true)
+    setPasswordMessage(null)
+    try {
+      setReauthProof(await obtainPasskeyReauthProof())
+    }
+    catch (e) {
+      setPasswordMessage({ type: 'error', text: formatErrorMessage(e, 'Passkey verification failed') })
+    }
+    finally {
+      setReauthBusy(false)
+    }
+  }
+
   const handleChangePassword = async () => {
     if (!passwordCanSubmit(pwProps))
       return
@@ -136,14 +156,21 @@ export const ProfileSettings: Component = () => {
       await userClient.changePassword({
         currentPassword: currentPassword(),
         newPassword: newPassword(),
+        reauthProof: reauthProof(),
       })
       setPasswordMessage({ type: 'success', text: auth.user()?.passwordSet ? 'Password changed.' : 'Password set.' })
       setCurrentPassword('')
       setNewPassword('')
       setConfirmPassword('')
-      auth.refreshUser()
+      setReauthProof('')
+      await auth.refreshUser()
     }
     catch (e) {
+      // A consumed or expired proof must not stick around: every retry
+      // would resend the same dead proof. Drop it so the "Verify with
+      // passkey" control returns.
+      if (isReauthProofRejected(e))
+        setReauthProof('')
       setPasswordMessage({ type: 'error', text: formatErrorMessage(e, 'Failed to change password') })
     }
     finally {
@@ -240,15 +267,20 @@ export const ProfileSettings: Component = () => {
           setCurrentPassword={setCurrentPassword}
           labelClass={styles.fieldLabel}
         />
+        <Show when={!auth.user()?.passwordSet && livePasskeyCount() > 0}>
+          <PasskeyStepUp proof={reauthProof()} busy={passwordSaving() || reauthBusy()} onVerify={() => void handlePasswordReauth()} />
+        </Show>
         <Show when={passwordMessage()}>
           {msg => <div class={msg().type === 'success' ? successText : errorText}>{msg().text}</div>}
         </Show>
-        <button type="button" onClick={handleChangePassword} disabled={passwordSaving() || !passwordCanSubmit(pwProps)}>
+        <button type="button" onClick={handleChangePassword} disabled={passwordSaving() || !passwordCanSubmit(pwProps) || (!auth.user()?.passwordSet && livePasskeyCount() > 0 && !reauthProof())}>
           {passwordSaving()
             ? (auth.user()?.passwordSet ? 'Changing...' : 'Setting...')
             : (auth.user()?.passwordSet ? 'Change Password' : 'Set Password')}
         </button>
       </div>
+
+      <PasskeysSettings onPasskeysChange={setLivePasskeyCount} />
 
       <Show when={auth.user()?.oauthProviders && auth.user()!.oauthProviders.length > 0}>
         <h3 class={styles.sectionHeading}>Linked Accounts</h3>

--- a/frontend/src/components/settings/ProfileSettings.tsx
+++ b/frontend/src/components/settings/ProfileSettings.tsx
@@ -9,6 +9,7 @@ import { useAuth } from '~/context/AuthContext'
 import { formatErrorMessage } from '~/lib/errors'
 import { isReauthProofRejected, obtainPasskeyReauthProof } from '~/lib/passkeyManagement'
 import { sanitizeDisplayName, sanitizeName, sanitizeSlug, validateEmail } from '~/lib/validate'
+import { passkeyErrorMessage } from '~/lib/webauthn'
 import { errorText, successText, warningText } from '~/styles/shared.css'
 import * as styles from './ProfileSettings.css'
 
@@ -140,7 +141,10 @@ export const ProfileSettings: Component = () => {
       setReauthProof(await obtainPasskeyReauthProof())
     }
     catch (e) {
-      setPasswordMessage({ type: 'error', text: formatErrorMessage(e, 'Passkey verification failed') })
+      // A dismissed prompt is not a failure to report.
+      const text = passkeyErrorMessage(e, 'Passkey verification failed')
+      if (text)
+        setPasswordMessage({ type: 'error', text })
     }
     finally {
       setReauthBusy(false)

--- a/frontend/src/components/settings/protoRegistry.test.ts
+++ b/frontend/src/components/settings/protoRegistry.test.ts
@@ -252,7 +252,7 @@ describe('buildProtoRows', () => {
   it('depends_on can address another setting key', () => {
     const values = new Map([
       ['signup_enabled', value('signup_enabled', 'true')],
-      ['email_verification_required', value('email_verification_required', 'false')],
+      ['some_other_setting', value('some_other_setting', 'false')],
     ])
     expect(conditionHolds({ key: 'signup_enabled', field: '', in: ['true'] } as SettingFieldCondition, 'other', values)).toBe(true)
     expect(conditionHolds({ key: 'signup_enabled', field: '', in: ['false'] } as SettingFieldCondition, 'other', values)).toBe(false)

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,5 +1,6 @@
+import type { Timestamp } from '@bufbuild/protobuf/wkt'
 import type { ParentComponent } from 'solid-js'
-import type { User } from '~/generated/leapmux/v1/auth_pb'
+import type { EmailVerificationStatus, User } from '~/generated/leapmux/v1/auth_pb'
 import type { CaptchaRequestFields } from '~/lib/captchaForm'
 import { create } from '@bufbuild/protobuf'
 import { Code, ConnectError } from '@connectrpc/connect'
@@ -13,13 +14,22 @@ import { createStableContext } from '~/lib/createStableContext'
 import { formatErrorMessage } from '~/lib/errors'
 import { createLogger } from '~/lib/logger'
 import { isSoloMode, loadSystemInfo } from '~/lib/systemInfo'
+import { startAuthentication } from '~/lib/webauthn'
 
 const log = createLogger('auth')
+
+export interface AuthLoginResult {
+  verificationRequired: boolean
+  verificationEmailSent: boolean
+  nextResendAvailableAt?: Timestamp
+}
 
 export interface AuthState {
   user: () => User | null
   loading: () => boolean
   error: () => string | null
+  /** Cooldown timestamp seeded from login when verification is required. */
+  verificationResendAvailableAt: () => Timestamp | undefined
   /**
    * Set when bootstrap failed for a reason OTHER than "no session" -- i.e.
    * either `loadSystemInfo` could not reach the hub, or the session restore
@@ -38,7 +48,9 @@ export interface AuthState {
   bootstrapError: () => string | null
   /** Retry the bootstrap session-restore after a `bootstrapError`. */
   retryBootstrap: () => Promise<void>
-  login: (username: string, password: string, captcha?: CaptchaRequestFields) => Promise<void>
+  login: (username: string, password: string, captcha?: CaptchaRequestFields) => Promise<AuthLoginResult>
+  loginWithPasskey: (username: string, captcha?: CaptchaRequestFields) => Promise<AuthLoginResult>
+  setVerificationResendAvailableAt: (at?: Timestamp) => void
   logout: () => Promise<void>
   setAuth: (user: User) => void
   refreshUser: () => Promise<void>
@@ -52,6 +64,7 @@ export const AuthProvider: ParentComponent = (props) => {
   const [loading, setLoading] = createSignal(true)
   const [error, setError] = createSignal<string | null>(null)
   const [bootstrapError, setBootstrapError] = createSignal<string | null>(null)
+  const [verificationResendAvailableAt, setVerificationResendAvailableAt] = createSignal<Timestamp | undefined>()
 
   /**
    * Drop every pooled E2EE channel on an identity change.
@@ -93,10 +106,15 @@ export const AuthProvider: ParentComponent = (props) => {
       closePooledChannels()
   }, { defer: true }))
 
+  const clearAuthUser = () => {
+    setUser(null)
+    setVerificationResendAvailableAt(undefined)
+  }
+
   // Register auth error callback for auto-logout on 401.
   setOnAuthError(() => {
     if (!isSoloMode())
-      setUser(null)
+      clearAuthUser()
   })
 
   /**
@@ -117,7 +135,7 @@ export const AuthProvider: ParentComponent = (props) => {
     }
     catch (err) {
       if (err instanceof ConnectError && err.code === Code.Unauthenticated) {
-        setUser(null)
+        clearAuthUser()
       }
       else {
         const msg = formatErrorMessage(err)
@@ -164,7 +182,13 @@ export const AuthProvider: ParentComponent = (props) => {
     setLoading(false)
   }
 
-  const login = async (username: string, password: string, captcha?: CaptchaRequestFields) => {
+  const loginResultFromResponse = (status: EmailVerificationStatus | undefined): AuthLoginResult => ({
+    verificationRequired: status?.verificationRequired ?? false,
+    verificationEmailSent: status?.verificationEmailSent ?? false,
+    nextResendAvailableAt: status?.nextResendAvailableAt,
+  })
+
+  const login = async (username: string, password: string, captcha?: CaptchaRequestFields): Promise<AuthLoginResult> => {
     setError(null)
     setLoading(true)
     try {
@@ -185,6 +209,7 @@ export const AuthProvider: ParentComponent = (props) => {
       // one channel per request while the shared WebSocket stays held for the old user).
       setUser(resp.user ?? null)
       loadTimeouts().catch(() => {})
+      return loginResultFromResponse(resp.emailVerification)
     }
     catch (e) {
       const msg = formatErrorMessage(e, 'Login failed')
@@ -192,6 +217,34 @@ export const AuthProvider: ParentComponent = (props) => {
       // The login form's captcha.reset() (see createCaptchaForm) triggers
       // the system-info reload that converges a stale captcha snapshot
       // after a runtime enable/disable or provider switch.
+      throw e
+    }
+    finally {
+      setLoading(false)
+    }
+  }
+
+  const loginWithPasskey = async (username: string, captcha?: CaptchaRequestFields): Promise<AuthLoginResult> => {
+    setError(null)
+    setLoading(true)
+    try {
+      const begin = await authClient.beginPasskeyLogin({
+        username,
+        captchaPayload: captcha?.captchaPayload ?? '',
+        honeypot: captcha?.honeypot ?? '',
+      })
+      const credentialJson = await startAuthentication(begin.optionsJson)
+      const resp = await authClient.finishPasskeyLogin({
+        sessionId: begin.sessionId,
+        credentialJson,
+      })
+      setUser(resp.user ?? null)
+      loadTimeouts().catch(() => {})
+      return loginResultFromResponse(resp.emailVerification)
+    }
+    catch (e) {
+      const msg = formatErrorMessage(e, 'Passkey login failed')
+      setError(msg)
       throw e
     }
     finally {
@@ -209,7 +262,7 @@ export const AuthProvider: ParentComponent = (props) => {
       // Ignore logout errors.
     }
     finally {
-      setUser(null)
+      clearAuthUser()
     }
   }
 
@@ -232,7 +285,10 @@ export const AuthProvider: ParentComponent = (props) => {
     user,
     loading,
     error,
+    verificationResendAvailableAt,
     login,
+    loginWithPasskey,
+    setVerificationResendAvailableAt,
     logout,
     setAuth,
     refreshUser,

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -14,7 +14,7 @@ import { createStableContext } from '~/lib/createStableContext'
 import { formatErrorMessage } from '~/lib/errors'
 import { createLogger } from '~/lib/logger'
 import { isSoloMode, loadSystemInfo } from '~/lib/systemInfo'
-import { startAuthentication } from '~/lib/webauthn'
+import { passkeyErrorMessage, startAuthentication } from '~/lib/webauthn'
 
 const log = createLogger('auth')
 
@@ -131,6 +131,11 @@ export const AuthProvider: ParentComponent = (props) => {
     try {
       const resp = await authClient.getCurrentUser({})
       setUser(resp.user ?? null)
+      // GetCurrentUser is the only response the /verify-email page's own
+      // bootstrap reads. Seeding the cooldown from it is what lets a hard
+      // reload of that page resume the countdown instead of restarting at
+      // zero and letting the button hammer a ResourceExhausted refusal.
+      setVerificationResendAvailableAt(resp.emailVerification?.nextResendAvailableAt)
       loadTimeouts().catch(() => {})
     }
     catch (err) {
@@ -188,20 +193,25 @@ export const AuthProvider: ParentComponent = (props) => {
     nextResendAvailableAt: status?.nextResendAvailableAt,
   })
 
-  const login = async (username: string, password: string, captcha?: CaptchaRequestFields): Promise<AuthLoginResult> => {
+  /**
+   * The state machine both sign-in paths share: clear the banner, hold
+   * `loading` for the whole attempt, adopt the returned user, and report
+   * the verification status.
+   *
+   * `login` and `loginWithPasskey` were byte-identical apart from the RPC
+   * in the middle and the fallback message, so a fix to the identity
+   * transition below had to be made twice. `fallback` is passed through
+   * `passkeyErrorMessage`, which returns null for a dismissed passkey
+   * prompt -- that is not a failure to report, so the banner stays empty.
+   */
+  const runSignIn = async (
+    fallback: string,
+    attempt: () => Promise<{ user?: User, emailVerification?: EmailVerificationStatus }>,
+  ): Promise<AuthLoginResult> => {
     setError(null)
     setLoading(true)
     try {
-      const req = create(LoginRequestSchema, {
-        username,
-        password,
-        // The honeypot rides on every attempt; the payload is empty until
-        // the widget verifies (the hub ignores it while captcha is
-        // disabled — see createCaptchaForm's requirement gate).
-        captchaPayload: captcha?.captchaPayload ?? '',
-        honeypot: captcha?.honeypot ?? '',
-      })
-      const resp = await authClient.login(req)
+      const resp = await attempt()
       // Logging in over a still-authenticated session (a bookmarked /login, a stale
       // tab) is an identity transition just like logout: setUser drives the eager
       // release of the previous user's pooled channels through the createEffect above,
@@ -212,8 +222,7 @@ export const AuthProvider: ParentComponent = (props) => {
       return loginResultFromResponse(resp.emailVerification)
     }
     catch (e) {
-      const msg = formatErrorMessage(e, 'Login failed')
-      setError(msg)
+      setError(passkeyErrorMessage(e, fallback) ?? '')
       // The login form's captcha.reset() (see createCaptchaForm) triggers
       // the system-info reload that converges a stale captcha snapshot
       // after a runtime enable/disable or provider switch.
@@ -224,33 +233,29 @@ export const AuthProvider: ParentComponent = (props) => {
     }
   }
 
-  const loginWithPasskey = async (username: string, captcha?: CaptchaRequestFields): Promise<AuthLoginResult> => {
-    setError(null)
-    setLoading(true)
-    try {
+  const login = (username: string, password: string, captcha?: CaptchaRequestFields): Promise<AuthLoginResult> =>
+    runSignIn('Login failed', () => authClient.login(create(LoginRequestSchema, {
+      username,
+      password,
+      // The honeypot rides on every attempt; the payload is empty until
+      // the widget verifies (the hub ignores it while captcha is
+      // disabled — see createCaptchaForm's requirement gate).
+      captchaPayload: captcha?.captchaPayload ?? '',
+      honeypot: captcha?.honeypot ?? '',
+    })))
+
+  const loginWithPasskey = (username: string, captcha?: CaptchaRequestFields): Promise<AuthLoginResult> =>
+    runSignIn('Passkey login failed', async () => {
       const begin = await authClient.beginPasskeyLogin({
         username,
         captchaPayload: captcha?.captchaPayload ?? '',
         honeypot: captcha?.honeypot ?? '',
       })
-      const credentialJson = await startAuthentication(begin.optionsJson)
-      const resp = await authClient.finishPasskeyLogin({
+      return await authClient.finishPasskeyLogin({
         sessionId: begin.sessionId,
-        credentialJson,
+        credentialJson: await startAuthentication(begin.optionsJson),
       })
-      setUser(resp.user ?? null)
-      loadTimeouts().catch(() => {})
-      return loginResultFromResponse(resp.emailVerification)
-    }
-    catch (e) {
-      const msg = formatErrorMessage(e, 'Passkey login failed')
-      setError(msg)
-      throw e
-    }
-    finally {
-      setLoading(false)
-    }
-  }
+    })
 
   const logout = async () => {
     if (isSoloMode())

--- a/frontend/src/lib/authMethodSelection.test.ts
+++ b/frontend/src/lib/authMethodSelection.test.ts
@@ -1,0 +1,88 @@
+import { createRoot } from 'solid-js'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createAuthMethodSelection } from './authMethodSelection'
+
+vi.mock('~/lib/systemInfo', async () => {
+  const m = await import('~/test-support/systemInfoMock')
+  return m.systemInfoMock
+})
+
+const { resetSystemInfoMock, setSystemInfoMock } = await import('~/test-support/systemInfoMock')
+
+describe('createAuthMethodSelection', () => {
+  beforeEach(() => {
+    resetSystemInfoMock()
+  })
+
+  it('starts on password', () => {
+    createRoot((dispose) => {
+      const s = createAuthMethodSelection('login')
+      expect(s.effectiveMethod()).toBe('password')
+      dispose()
+    })
+  })
+
+  it('selects passkey when the hub can run ceremonies', () => {
+    setSystemInfoMock({ passkeyEnabled: true })
+    createRoot((dispose) => {
+      const s = createAuthMethodSelection('login')
+      s.select('passkey')
+      expect(s.effectiveMethod()).toBe('passkey')
+      dispose()
+    })
+  })
+
+  // The regression this helper exists for. A captcha refusal re-fetches
+  // system info, and an admin can clear the hub's public URL, so
+  // passkeyEnabled can flip false with a passkey already selected. Every
+  // reader must then see 'password' -- LoginPage and SignupForm each read
+  // the RAW signal at one or two sites, which hid the password field, hid
+  // the "Forgot password?" link, and skipped the password validation while
+  // the submit path had already fallen back.
+  it('falls back to password when passkey support disappears mid-form', () => {
+    setSystemInfoMock({ passkeyEnabled: true })
+    createRoot((dispose) => {
+      const s = createAuthMethodSelection('login')
+      s.select('passkey')
+      expect(s.effectiveMethod()).toBe('passkey')
+
+      setSystemInfoMock({ passkeyEnabled: false })
+      expect(s.effectiveMethod()).toBe('password')
+      dispose()
+    })
+  })
+
+  it('derives the captcha action from the effective method, not the raw one', () => {
+    setSystemInfoMock({ passkeyEnabled: true })
+    createRoot((dispose) => {
+      const login = createAuthMethodSelection('login')
+      const signup = createAuthMethodSelection('signup')
+      expect(login.captchaAction()).toBe('login')
+      expect(signup.captchaAction()).toBe('signup')
+
+      login.select('passkey')
+      signup.select('passkey')
+      expect(login.captchaAction()).toBe('passkey_login')
+      expect(signup.captchaAction()).toBe('passkey_signup')
+
+      // The hub refuses a token minted under a different action, so the
+      // fallback must move the action too.
+      setSystemInfoMock({ passkeyEnabled: false })
+      expect(login.captchaAction()).toBe('login')
+      expect(signup.captchaAction()).toBe('signup')
+      dispose()
+    })
+  })
+
+  it('keeps two selections independent', () => {
+    setSystemInfoMock({ passkeyEnabled: true })
+    createRoot((dispose) => {
+      const a = createAuthMethodSelection('login')
+      const b = createAuthMethodSelection('signup')
+      a.select('passkey')
+      expect(a.effectiveMethod()).toBe('passkey')
+      expect(b.effectiveMethod()).toBe('password')
+      dispose()
+    })
+  })
+})

--- a/frontend/src/lib/authMethodSelection.ts
+++ b/frontend/src/lib/authMethodSelection.ts
@@ -1,0 +1,58 @@
+import type { Accessor } from 'solid-js'
+
+import { createSignal } from 'solid-js'
+import { isPasskeyEnabled } from '~/lib/systemInfo'
+
+/** The two credential kinds the login and sign-up forms offer. */
+export type AuthMethod = 'password' | 'passkey'
+
+/** Which form the selection belongs to. Only the captcha action differs. */
+export type AuthMethodKind = 'login' | 'signup'
+
+/**
+ * The captcha action bound into an external provider's token. The hub
+ * refuses a token minted under a different action, so this must follow the
+ * EFFECTIVE method, never the raw selection.
+ */
+export type AuthCaptchaAction = 'login' | 'signup' | 'passkey_login' | 'passkey_signup'
+
+export interface AuthMethodSelection {
+  /**
+   * The method the form must actually act on. `isPasskeyEnabled()` can flip
+   * false at runtime — a captcha refusal re-fetches system info, and an
+   * admin can clear the hub's public URL — so a passkey selection made
+   * before that falls back to the password arm.
+   */
+  effectiveMethod: Accessor<AuthMethod>
+  /** Handler for the method pills. */
+  select: (method: AuthMethod) => void
+  /** The captcha action for the effective method. */
+  captchaAction: Accessor<AuthCaptchaAction>
+}
+
+/**
+ * Owns the credential-kind choice for an auth form.
+ *
+ * The raw signal stays PRIVATE on purpose. LoginPage and SignupForm each
+ * kept their own copy of this two-line state machine, and each then read
+ * the raw signal at one or two sites while every other site read the
+ * effective one — so a hub that lost passkey support mid-form hid the
+ * password field, hid the "Forgot password?" link and skipped the password
+ * validation, while the submit path had already fallen back to the password
+ * arm. A caller that cannot reach the raw signal cannot reintroduce that
+ * split.
+ */
+export function createAuthMethodSelection(kind: AuthMethodKind): AuthMethodSelection {
+  const [method, setMethod] = createSignal<AuthMethod>('password')
+
+  const effectiveMethod = (): AuthMethod =>
+    method() === 'passkey' && isPasskeyEnabled() ? 'passkey' : 'password'
+
+  const captchaAction = (): AuthCaptchaAction => {
+    if (effectiveMethod() === 'passkey')
+      return kind === 'login' ? 'passkey_login' : 'passkey_signup'
+    return kind
+  }
+
+  return { effectiveMethod, select: setMethod, captchaAction }
+}

--- a/frontend/src/lib/captchaForm.test.ts
+++ b/frontend/src/lib/captchaForm.test.ts
@@ -86,6 +86,19 @@ describe('createCaptchaForm', () => {
     await Promise.resolve()
   })
 
+  it('clears payload even when the field handle reset throws', () => {
+    setSystemInfoMock({ captchaEnabled: true })
+    const captcha = createCaptchaForm()
+    captcha.bindField({
+      reset: () => {
+        throw new Error('n?.reset is not a function')
+      },
+    })
+    captcha.setPayload('consumed')
+    expect(() => captcha.reset()).not.toThrow()
+    expect(captcha.payload()).toBeNull()
+  })
+
   it('reset skips the system-info refetch for failures that cannot change the captcha policy', async () => {
     setSystemInfoMock({ captchaEnabled: true })
     const captcha = createCaptchaForm()

--- a/frontend/src/lib/captchaForm.ts
+++ b/frontend/src/lib/captchaForm.ts
@@ -81,7 +81,14 @@ export function createCaptchaForm(): CaptchaFormState {
       setStoodDown(false)
       setPayload(null)
       setHoneypot('')
-      field?.reset()
+      try {
+        field?.reset()
+      }
+      catch {
+        // A keyed remount (Password/Passkey) can leave the previous
+        // handle pointing at a widget that is already gone. Payload
+        // and honeypot are already cleared; the new field arms itself.
+      }
       // A captcha denial is also the signal that the captcha snapshot in
       // systemInfo is stale: the admin may have enabled or disabled
       // captcha, or switched providers, since the page loaded. The

--- a/frontend/src/lib/passkeyManagement.test.ts
+++ b/frontend/src/lib/passkeyManagement.test.ts
@@ -1,0 +1,64 @@
+import { Code, ConnectError } from '@connectrpc/connect'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  credentialIdFromRegistrationJson,
+  isReauthProofRejected,
+  loadPasskeys,
+  obtainPasskeyReauthProof,
+} from './passkeyManagement'
+
+const mockBeginPasskeyReauth = vi.fn()
+const mockFinishPasskeyReauth = vi.fn()
+const mockListPasskeys = vi.fn()
+const mockStartAuthentication = vi.fn()
+
+vi.mock('~/api/clients', () => ({
+  userClient: {
+    beginPasskeyReauth: (...args: unknown[]) => mockBeginPasskeyReauth(...args),
+    finishPasskeyReauth: (...args: unknown[]) => mockFinishPasskeyReauth(...args),
+    listPasskeys: (...args: unknown[]) => mockListPasskeys(...args),
+  },
+}))
+
+vi.mock('~/lib/webauthn', () => ({
+  startAuthentication: (...args: unknown[]) => mockStartAuthentication(...args),
+}))
+
+describe('passkeyManagement helpers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('credentialIdFromRegistrationJson reads the credential id', () => {
+    expect(credentialIdFromRegistrationJson('{"id":"abc"}')).toBe('abc')
+    expect(credentialIdFromRegistrationJson('not-json')).toBeUndefined()
+  })
+
+  it('isReauthProofRejected matches only Unauthenticated connect errors', () => {
+    expect(isReauthProofRejected(new ConnectError('reauth proof rejected', Code.Unauthenticated))).toBe(true)
+    expect(isReauthProofRejected(new ConnectError('gone', Code.NotFound))).toBe(false)
+    expect(isReauthProofRejected(new Error('not a connect error'))).toBe(false)
+    expect(isReauthProofRejected(undefined)).toBe(false)
+  })
+
+  it('obtainPasskeyReauthProof chains begin, authenticate, and finish', async () => {
+    mockBeginPasskeyReauth.mockResolvedValue({ sessionId: 'sess-1', optionsJson: '{"challenge":"c"}' })
+    mockStartAuthentication.mockResolvedValue('{"id":"cred-1"}')
+    mockFinishPasskeyReauth.mockResolvedValue({ reauthProof: 'proof-1' })
+
+    await expect(obtainPasskeyReauthProof()).resolves.toBe('proof-1')
+    expect(mockStartAuthentication).toHaveBeenCalledWith('{"challenge":"c"}')
+    expect(mockFinishPasskeyReauth).toHaveBeenCalledWith({
+      sessionId: 'sess-1',
+      credentialJson: '{"id":"cred-1"}',
+    })
+  })
+
+  it('loadPasskeys returns the list with the server-derived RP ID', async () => {
+    const passkeys = [{ id: 'pk-1', friendlyName: 'Laptop', credentialId: 'cred-abc' }]
+    mockListPasskeys.mockResolvedValue({ passkeys, rpId: 'example.com' })
+
+    await expect(loadPasskeys()).resolves.toEqual({ passkeys, rpId: 'example.com' })
+  })
+})

--- a/frontend/src/lib/passkeyManagement.ts
+++ b/frontend/src/lib/passkeyManagement.ts
@@ -1,0 +1,52 @@
+import type { PasskeyInfo } from '~/generated/leapmux/v1/user_pb'
+import { Code, ConnectError } from '@connectrpc/connect'
+import { userClient } from '~/api/clients'
+import { startAuthentication } from '~/lib/webauthn'
+
+export async function obtainPasskeyReauthProof(): Promise<string> {
+  const begin = await userClient.beginPasskeyReauth({})
+  const credentialJson = await startAuthentication(begin.optionsJson)
+  const finish = await userClient.finishPasskeyReauth({
+    sessionId: begin.sessionId,
+    credentialJson,
+  })
+  return finish.reauthProof
+}
+
+/**
+ * A step-up rejection answers Unauthenticated. Reauth proofs are
+ * single-use: the failed mutation consumed it (or it expired), so the
+ * caller must drop the cached proof or every retry resends the same dead
+ * one and fails identically. Classifying on the connect code survives any
+ * message rewording; a wrong-password Unauthenticated on a password
+ * account carries no proof to drop, so the same classification is safe
+ * there.
+ */
+export function isReauthProofRejected(err: unknown): boolean {
+  return err instanceof ConnectError && err.code === Code.Unauthenticated
+}
+
+export function credentialIdFromRegistrationJson(credentialJson: string): string | undefined {
+  try {
+    const parsed = JSON.parse(credentialJson) as { id?: string }
+    return typeof parsed.id === 'string' ? parsed.id : undefined
+  }
+  catch {
+    return undefined
+  }
+}
+
+/**
+ * The passkey list plus the hub's relying party ID. The RP ID comes from the
+ * server (it derives it from the hub's configured origins), so the Signal
+ * API calls never mirror that derivation in TypeScript.
+ */
+export interface PasskeyList {
+  passkeys: PasskeyInfo[]
+  rpId: string
+}
+
+export async function loadPasskeys(): Promise<PasskeyList> {
+  const resp = await userClient.listPasskeys({})
+  return { passkeys: resp.passkeys, rpId: resp.rpId }
+}

--- a/frontend/src/lib/safeRedirect.test.ts
+++ b/frontend/src/lib/safeRedirect.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { safeRedirect } from './safeRedirect'
+
+describe('safeRedirect', () => {
+  it('accepts an absolute app path', () => {
+    expect(safeRedirect('/settings/profile')).toBe('/settings/profile')
+  })
+
+  it('accepts the root path', () => {
+    expect(safeRedirect('/')).toBe('/')
+  })
+
+  it('refuses a protocol-relative URL', () => {
+    expect(safeRedirect('//evil.example.com')).toBeUndefined()
+  })
+
+  it('refuses an external URL', () => {
+    expect(safeRedirect('https://evil.example.com')).toBeUndefined()
+  })
+
+  it('refuses a scheme-relative scheme prefix without a host', () => {
+    expect(safeRedirect('/\\evil.example.com')).toBeUndefined()
+  })
+
+  it('refuses a relative path', () => {
+    expect(safeRedirect('settings/profile')).toBeUndefined()
+  })
+
+  it('refuses empty and missing values', () => {
+    expect(safeRedirect('')).toBeUndefined()
+    expect(safeRedirect(undefined)).toBeUndefined()
+  })
+})

--- a/frontend/src/lib/safeRedirect.test.ts
+++ b/frontend/src/lib/safeRedirect.test.ts
@@ -20,6 +20,27 @@ describe('safeRedirect', () => {
 
   it('refuses a scheme-relative scheme prefix without a host', () => {
     expect(safeRedirect('/\\evil.example.com')).toBeUndefined()
+    expect(safeRedirect('/\\evil.example.com/callback')).toBeUndefined()
+  })
+
+  // A browser strips these during URL parsing, so "/\t/host" becomes
+  // "//host" and leaves the origin. The backend guard refuses the same
+  // class; the two must agree, because the hub forwards this value into
+  // the OAuth start URL.
+  it('refuses a control byte anywhere in the path', () => {
+    expect(safeRedirect('/\t/evil.example.com')).toBeUndefined()
+    expect(safeRedirect('/\t\\evil.example.com')).toBeUndefined()
+    expect(safeRedirect('/\r/evil.example.com')).toBeUndefined()
+    expect(safeRedirect('/\n/evil.example.com')).toBeUndefined()
+    expect(safeRedirect('/\x00/evil.example.com')).toBeUndefined()
+    expect(safeRedirect('/\x7F/evil.example.com')).toBeUndefined()
+  })
+
+  // Percent-encodings are not decoded before the browser picks the
+  // authority, so they stay ordinary same-origin paths.
+  it('accepts a percent-encoded byte that a browser does not decode', () => {
+    expect(safeRedirect('/%09/settings')).toBe('/%09/settings')
+    expect(safeRedirect('/%5Csettings')).toBe('/%5Csettings')
   })
 
   it('refuses a relative path', () => {

--- a/frontend/src/lib/safeRedirect.ts
+++ b/frontend/src/lib/safeRedirect.ts
@@ -5,14 +5,24 @@
  * refused, so a post-auth navigate can never bounce the user to another
  * origin. The login and sign-up pages share this one implementation of
  * the open-redirect guard.
+ *
+ * The three rules match `sanitizeRedirectURI` in
+ * `backend/internal/hub/service/oauth_handler.go`, which guards the same
+ * value at the stronger sink (a Location header). Keep them together: the
+ * hub forwards this parameter into the OAuth start URL, so a spelling one
+ * side refuses and the other accepts is an open redirect.
  */
 export function safeRedirect(redirect: string | undefined): string | undefined {
-  if (!redirect)
+  if (!redirect || !redirect.startsWith('/'))
     return undefined
   // A protocol-relative target ("//host") or a backslash twin ("/\host",
-  // which some browsers normalize to a scheme-relative URL) both leave the
-  // origin; refuse anything but a plain same-origin app path.
-  if (!redirect.startsWith('/') || redirect[1] === '/' || redirect[1] === '\\')
+  // which a WHATWG parser reads as scheme-relative) both leave the origin.
+  if (redirect[1] === '/' || redirect[1] === '\\')
+    return undefined
+  // A control byte survives a header write and the browser strips it, so
+  // "/\t/host" becomes "//host" at parse time. Refuse the whole class.
+  // eslint-disable-next-line no-control-regex
+  if (/[\u0000-\u001F\u007F]/.test(redirect))
     return undefined
   return redirect
 }

--- a/frontend/src/lib/safeRedirect.ts
+++ b/frontend/src/lib/safeRedirect.ts
@@ -1,0 +1,18 @@
+/**
+ * Returns the redirect target only when it is a same-origin app path: an
+ * absolute "/" path that is not protocol-relative ("//host"). Anything
+ * else — an external URL, a protocol-relative URL, a malformed value — is
+ * refused, so a post-auth navigate can never bounce the user to another
+ * origin. The login and sign-up pages share this one implementation of
+ * the open-redirect guard.
+ */
+export function safeRedirect(redirect: string | undefined): string | undefined {
+  if (!redirect)
+    return undefined
+  // A protocol-relative target ("//host") or a backslash twin ("/\host",
+  // which some browsers normalize to a scheme-relative URL) both leave the
+  // origin; refuse anything but a plain same-origin app path.
+  if (!redirect.startsWith('/') || redirect[1] === '/' || redirect[1] === '\\')
+    return undefined
+  return redirect
+}

--- a/frontend/src/lib/systemInfo.ts
+++ b/frontend/src/lib/systemInfo.ts
@@ -23,6 +23,7 @@ interface SystemInfoSnapshot {
   setupRequired: boolean
   workerHubUrl: string
   emailEnabled: boolean
+  passkeyEnabled: boolean
   captchaEnabled: boolean
   captchaProvider: GenCaptchaProvider
   captchaSiteKey: string
@@ -39,6 +40,7 @@ const DEFAULTS: SystemInfoSnapshot = {
   setupRequired: false,
   workerHubUrl: '',
   emailEnabled: false,
+  passkeyEnabled: false,
   captchaEnabled: false,
   captchaProvider: GenCaptchaProvider.ALTCHA,
   captchaSiteKey: '',
@@ -85,6 +87,7 @@ export async function loadSystemInfo(force = false): Promise<void> {
     setupRequired: resp.setupRequired,
     workerHubUrl: resp.workerHubUrl,
     emailEnabled: resp.emailEnabled,
+    passkeyEnabled: resp.passkeyEnabled,
     captchaEnabled: resp.captchaEnabled,
     captchaProvider: parseCaptchaProvider(resp.captchaProvider ?? GenCaptchaProvider.UNSPECIFIED),
     captchaSiteKey: resp.captchaSiteKey,
@@ -144,6 +147,15 @@ export function isSetupRequired(): boolean {
 // can't possibly work would mislead users.
 export function isEmailEnabled(): boolean {
   return current().emailEnabled
+}
+
+// isPasskeyEnabled returns whether passkey ceremonies can run on this hub
+// (a keystore is configured and the hub has a usable browser origin).
+// Sign-in and sign-up gate the passkey option on this flag: every Begin
+// would answer FailedPrecondition without it, so showing the option would
+// mislead users the same way an email affordance without SMTP does.
+export function isPasskeyEnabled(): boolean {
+  return current().passkeyEnabled
 }
 
 // isSystemInfoLoaded reports whether a system-info answer has arrived.

--- a/frontend/src/lib/useVerificationResend.test.ts
+++ b/frontend/src/lib/useVerificationResend.test.ts
@@ -1,0 +1,95 @@
+import type { Timestamp } from '@bufbuild/protobuf/wkt'
+import { timestampFromDate } from '@bufbuild/protobuf/wkt'
+import { createRoot } from 'solid-js'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useVerificationResend } from './useVerificationResend'
+
+const mockResend = vi.fn()
+
+vi.mock('~/api/clients', () => ({
+  userClient: {
+    resendVerificationEmail: (...args: unknown[]) => mockResend(...args),
+  },
+}))
+
+describe('useVerificationResend', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('starts a cooldown after a successful send', async () => {
+    mockResend.mockResolvedValue({
+      emailSent: true,
+      nextResendAvailableAt: timestampFromDate(new Date(Date.now() + 42_000)),
+    })
+
+    await createRoot(async (dispose) => {
+      const hook = useVerificationResend()
+      await hook.resend()
+      expect(hook.status()).toContain('fresh code')
+      expect(hook.buttonLabel()).toBe('Resend code (0:42)')
+      expect(hook.disabled()).toBe(true)
+      dispose()
+    })
+  })
+
+  it('applies cooldown even when the email was not sent', async () => {
+    mockResend.mockResolvedValue({
+      emailSent: false,
+      nextResendAvailableAt: timestampFromDate(new Date(Date.now() + 60_000)),
+    })
+
+    await createRoot(async (dispose) => {
+      const hook = useVerificationResend()
+      await hook.resend()
+      expect(hook.status()).toContain('couldn\'t send')
+      expect(hook.buttonLabel()).toBe('Resend code (1:00)')
+      expect(hook.disabled()).toBe(true)
+      dispose()
+    })
+  })
+
+  it('seeds the cooldown from an accessor that lands after mount', async () => {
+    // The FOOTGUNS-2 regression: a hard reload of /verify-email starts with
+    // the auth signal unset and receives it once the session restores. A
+    // one-time value read would miss it; the accessor must re-seed.
+    let seed: Timestamp | undefined
+    await createRoot(async (dispose) => {
+      const hook = useVerificationResend({ nextResendAvailableAt: () => seed })
+      expect(hook.buttonLabel()).toBe('Resend code')
+      expect(hook.disabled()).toBe(false)
+
+      seed = timestampFromDate(new Date(Date.now() + 42_000))
+      await Promise.resolve()
+      expect(hook.buttonLabel()).toBe('Resend code (0:42)')
+      expect(hook.disabled()).toBe(true)
+      dispose()
+    })
+  })
+
+  it('counts down toward zero', async () => {
+    mockResend.mockResolvedValue({
+      emailSent: true,
+      nextResendAvailableAt: timestampFromDate(new Date(Date.now() + 3_000)),
+    })
+
+    await createRoot(async (dispose) => {
+      const hook = useVerificationResend()
+      await hook.resend()
+      expect(hook.buttonLabel()).toBe('Resend code (0:03)')
+      vi.advanceTimersByTime(2000)
+      expect(hook.buttonLabel()).toBe('Resend code (0:01)')
+      vi.advanceTimersByTime(2000)
+      expect(hook.buttonLabel()).toBe('Resend code')
+      expect(hook.disabled()).toBe(false)
+      dispose()
+    })
+  })
+})

--- a/frontend/src/lib/useVerificationResend.ts
+++ b/frontend/src/lib/useVerificationResend.ts
@@ -10,10 +10,16 @@ function cooldownSeconds(untilMs: number, nowMs: number): number {
 
 export interface UseVerificationResendOptions {
   /**
-   * Accessor for the cooldown seed from a login/signup response. An
-   * accessor (not a value) so a session that restores after this hook
-   * mounts still seeds the countdown — a hard reload of /verify-email
-   * starts with the signal unset and receives it once auth bootstraps.
+   * Accessor for the cooldown seed. An accessor (not a value) so a session
+   * that restores after this hook mounts still seeds the countdown: a hard
+   * reload of /verify-email starts with the signal unset and receives it
+   * once auth bootstraps.
+   *
+   * That re-seed needs `GetCurrentUserResponse.email_verification`, which
+   * the bootstrap reads in `AuthContext.restoreSession`. Without it the
+   * signal stayed undefined after a reload, the countdown restarted at
+   * zero, and the click got a ResourceExhausted with no timestamp to
+   * restart from.
    */
   nextResendAvailableAt?: () => Timestamp | undefined
 }

--- a/frontend/src/lib/useVerificationResend.ts
+++ b/frontend/src/lib/useVerificationResend.ts
@@ -1,0 +1,122 @@
+import type { Timestamp } from '@bufbuild/protobuf/wkt'
+import { timestampDate } from '@bufbuild/protobuf/wkt'
+import { createEffect, createMemo, createSignal, onCleanup } from 'solid-js'
+import { userClient } from '~/api/clients'
+import { formatErrorMessage } from '~/lib/errors'
+
+function cooldownSeconds(untilMs: number, nowMs: number): number {
+  return Math.max(0, Math.ceil((untilMs - nowMs) / 1000))
+}
+
+export interface UseVerificationResendOptions {
+  /**
+   * Accessor for the cooldown seed from a login/signup response. An
+   * accessor (not a value) so a session that restores after this hook
+   * mounts still seeds the countdown — a hard reload of /verify-email
+   * starts with the signal unset and receives it once auth bootstraps.
+   */
+  nextResendAvailableAt?: () => Timestamp | undefined
+}
+
+export function useVerificationResend(options?: UseVerificationResendOptions) {
+  const seededUntil = (): number | null => {
+    const t = options?.nextResendAvailableAt?.()
+    if (!t)
+      return null
+    const ms = timestampDate(t).getTime()
+    return ms > Date.now() ? ms : null
+  }
+
+  const [resending, setResending] = createSignal(false)
+  const [status, setStatus] = createSignal<string | null>(null)
+  const [error, setError] = createSignal<string | null>(null)
+  const [cooldownUntil, setCooldownUntil] = createSignal<number | null>(seededUntil())
+  const [now, setNow] = createSignal(Date.now())
+
+  // The 1 Hz tick runs only while a countdown is actually pending; an idle
+  // verify-email tab keeps no timer and no signal writes.
+  let tick: ReturnType<typeof setInterval> | undefined
+  const stopTick = () => {
+    if (tick !== undefined) {
+      clearInterval(tick)
+      tick = undefined
+    }
+  }
+  createEffect(() => {
+    const until = cooldownUntil()
+    if (until !== null && until > now()) {
+      if (tick === undefined)
+        tick = setInterval(() => setNow(Date.now()), 1000)
+    }
+    else {
+      stopTick()
+    }
+  })
+  onCleanup(stopTick)
+
+  // Follow the auth signal: a session restored after mount can still set
+  // the cooldown (only when it is later than any local cooldown).
+  createEffect(() => {
+    const seeded = seededUntil()
+    if (seeded !== null && seeded > (cooldownUntil() ?? 0))
+      setCooldownUntil(seeded)
+  })
+
+  const countdown = createMemo(() => {
+    const until = cooldownUntil()
+    if (until === null)
+      return 0
+    return cooldownSeconds(until, now())
+  })
+
+  const buttonLabel = createMemo(() => {
+    if (resending())
+      return 'Sending…'
+    const secs = countdown()
+    if (secs > 0) {
+      const mm = Math.floor(secs / 60)
+      const ss = secs % 60
+      return `Resend code (${mm}:${String(ss).padStart(2, '0')})`
+    }
+    return 'Resend code'
+  })
+
+  const disabled = () => resending() || countdown() > 0
+
+  const resend = async () => {
+    if (disabled())
+      return
+    setResending(true)
+    setStatus(null)
+    setError(null)
+    try {
+      const resp = await userClient.resendVerificationEmail({})
+      setStatus(
+        resp.emailSent
+          ? 'A fresh code has been sent to your inbox.'
+          : 'We couldn\'t send the email — please try again shortly.',
+      )
+      if (resp.nextResendAvailableAt) {
+        setCooldownUntil(timestampDate(resp.nextResendAvailableAt).getTime())
+      }
+    }
+    catch (e) {
+      setError(formatErrorMessage(e, 'Failed to resend verification email'))
+    }
+    finally {
+      setResending(false)
+    }
+  }
+
+  return {
+    resend,
+    resending,
+    status,
+    error,
+    setError,
+    setStatus,
+    buttonLabel,
+    disabled,
+    countdown,
+  }
+}

--- a/frontend/src/lib/webauthn.test.ts
+++ b/frontend/src/lib/webauthn.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  encodeWebAuthnUserId,
+  signalAcceptedPasskeys,
+  signalPasskeyRemoved,
+  startAuthentication,
+  startRegistration,
+} from './webauthn'
+
+const mockStartRegistration = vi.fn()
+const mockStartAuthentication = vi.fn()
+
+vi.mock('@simplewebauthn/browser', () => ({
+  startRegistration: (...args: unknown[]) => mockStartRegistration(...args),
+  startAuthentication: (...args: unknown[]) => mockStartAuthentication(...args),
+}))
+
+describe('startRegistration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockStartRegistration.mockResolvedValue({ id: 'cred-1', response: {} })
+  })
+
+  it('parses server JSON and returns a credential JSON string', async () => {
+    const options = { challenge: 'abc', rp: { name: 'LeapMux' } }
+    const result = await startRegistration(JSON.stringify(options))
+    expect(mockStartRegistration).toHaveBeenCalledWith({ optionsJSON: options })
+    expect(JSON.parse(result)).toEqual({ id: 'cred-1', response: {} })
+  })
+
+  it('unwraps go-webauthn publicKey envelopes before calling the browser', async () => {
+    const inner = { challenge: 'abc', rp: { name: 'LeapMux' } }
+    await startRegistration(JSON.stringify({ publicKey: inner }))
+    expect(mockStartRegistration).toHaveBeenCalledWith({ optionsJSON: inner })
+  })
+})
+
+describe('startAuthentication', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockStartAuthentication.mockResolvedValue({ id: 'cred-2', response: {} })
+  })
+
+  it('parses server JSON and returns a credential JSON string', async () => {
+    const options = { challenge: 'xyz', rpId: 'localhost' }
+    const result = await startAuthentication(JSON.stringify(options))
+    expect(mockStartAuthentication).toHaveBeenCalledWith({ optionsJSON: options })
+    expect(JSON.parse(result)).toEqual({ id: 'cred-2', response: {} })
+  })
+
+  it('unwraps go-webauthn publicKey envelopes before calling the browser', async () => {
+    const inner = { challenge: 'xyz', rpId: 'localhost' }
+    await startAuthentication(JSON.stringify({ publicKey: inner }))
+    expect(mockStartAuthentication).toHaveBeenCalledWith({ optionsJSON: inner })
+  })
+})
+
+describe('signal helpers', () => {
+  const original = globalThis.PublicKeyCredential
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'PublicKeyCredential', {
+      configurable: true,
+      value: original,
+    })
+  })
+
+  it('encodeWebAuthnUserId base64url-encodes UTF-8 bytes of the UUID string', () => {
+    // btoa("user-1") with URL-safe alphabet and no padding
+    expect(encodeWebAuthnUserId('user-1')).toBe('dXNlci0x')
+  })
+
+  it('signalPasskeyRemoved calls the browser API when present', () => {
+    const signalUnknownCredential = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(globalThis, 'PublicKeyCredential', {
+      configurable: true,
+      value: { signalUnknownCredential },
+    })
+    signalPasskeyRemoved('example.com', 'cred-id')
+    expect(signalUnknownCredential).toHaveBeenCalledWith({ rpId: 'example.com', credentialId: 'cred-id' })
+  })
+
+  it('signalAcceptedPasskeys calls signalAllAcceptedCredentials when present', () => {
+    const signalAllAcceptedCredentials = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(globalThis, 'PublicKeyCredential', {
+      configurable: true,
+      value: { signalAllAcceptedCredentials },
+    })
+    signalAcceptedPasskeys('example.com', 'user-1', ['cred-a'])
+    expect(signalAllAcceptedCredentials).toHaveBeenCalledWith({
+      rpId: 'example.com',
+      userId: encodeWebAuthnUserId('user-1'),
+      allAcceptedCredentialIds: ['cred-a'],
+    })
+  })
+
+  it('signalAcceptedPasskeys skips empty credential lists', () => {
+    const signalAllAcceptedCredentials = vi.fn()
+    Object.defineProperty(globalThis, 'PublicKeyCredential', {
+      configurable: true,
+      value: { signalAllAcceptedCredentials },
+    })
+    signalAcceptedPasskeys('example.com', 'user-1', [])
+    expect(signalAllAcceptedCredentials).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/lib/webauthn.test.ts
+++ b/frontend/src/lib/webauthn.test.ts
@@ -2,6 +2,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   encodeWebAuthnUserId,
+  isPasskeyCeremonyCancelled,
+  PasskeyCeremonyCancelledError,
+  passkeyErrorMessage,
   signalAcceptedPasskeys,
   signalPasskeyRemoved,
   startAuthentication,
@@ -103,5 +106,31 @@ describe('signal helpers', () => {
     })
     signalAcceptedPasskeys('example.com', 'user-1', [])
     expect(signalAllAcceptedCredentials).not.toHaveBeenCalled()
+  })
+})
+
+describe('passkey ceremony error classification', () => {
+  // SimpleWebAuthn passes the browser's raw DOMException text through, so
+  // an unclassified cancel put "The operation either timed out or was not
+  // allowed. See: https://www.w3.org/TR/webauthn-2/..." in a red banner.
+  it('classifies a dismissed prompt as cancelled, not an error', () => {
+    const cancelled = new PasskeyCeremonyCancelledError(new Error('raw'))
+    expect(isPasskeyCeremonyCancelled(cancelled)).toBe(true)
+    expect(passkeyErrorMessage(cancelled, 'Failed to add passkey')).toBeNull()
+  })
+
+  it('keeps the raw error as the cause so the log still has it', () => {
+    const raw = new Error('NotAllowedError')
+    expect(new PasskeyCeremonyCancelledError(raw).cause).toBe(raw)
+  })
+
+  it('reports a real failure with the caller fallback', () => {
+    const real = new Error('authenticator is unreachable')
+    expect(isPasskeyCeremonyCancelled(real)).toBe(false)
+    expect(passkeyErrorMessage(real, 'Failed to add passkey')).toBe('authenticator is unreachable')
+  })
+
+  it('falls back when the failure carries no message', () => {
+    expect(passkeyErrorMessage({}, 'Failed to add passkey')).toBe('Failed to add passkey')
   })
 })

--- a/frontend/src/lib/webauthn.ts
+++ b/frontend/src/lib/webauthn.ts
@@ -1,0 +1,93 @@
+import {
+  startAuthentication as browserStartAuthentication,
+  startRegistration as browserStartRegistration,
+} from '@simplewebauthn/browser'
+import { createLogger } from '~/lib/logger'
+
+const log = createLogger('webauthn')
+
+type RegistrationOptionsJSON = Parameters<typeof browserStartRegistration>[0]['optionsJSON']
+type AuthenticationOptionsJSON = Parameters<typeof browserStartAuthentication>[0]['optionsJSON']
+
+/**
+ * go-webauthn serializes `CredentialCreation` / `CredentialAssertion` as
+ * `{ publicKey: … }`. @simplewebauthn/browser expects the inner options
+ * object directly.
+ */
+export function parseWebAuthnOptionsJSON<T>(optionsJson: string): T {
+  const parsed = JSON.parse(optionsJson) as T | { publicKey?: T }
+  if (parsed && typeof parsed === 'object' && 'publicKey' in parsed && parsed.publicKey)
+    return parsed.publicKey
+  return parsed as T
+}
+
+/** Begin a WebAuthn registration ceremony from server JSON options. */
+export async function startRegistration(optionsJson: string): Promise<string> {
+  const optionsJSON = parseWebAuthnOptionsJSON<RegistrationOptionsJSON>(optionsJson)
+  const credential = await browserStartRegistration({ optionsJSON })
+  return JSON.stringify(credential)
+}
+
+/** Begin a WebAuthn authentication ceremony from server JSON options. */
+export async function startAuthentication(optionsJson: string): Promise<string> {
+  const optionsJSON = parseWebAuthnOptionsJSON<AuthenticationOptionsJSON>(optionsJson)
+  const credential = await browserStartAuthentication({ optionsJSON })
+  return JSON.stringify(credential)
+}
+
+interface SignalUnknownCredential {
+  rpId: string
+  credentialId: string
+}
+
+interface SignalAllAcceptedCredentials {
+  rpId: string
+  userId: string
+  allAcceptedCredentialIds: string[]
+}
+
+type PublicKeyCredentialSignal = typeof PublicKeyCredential & {
+  signalUnknownCredential?: (options: SignalUnknownCredential) => Promise<void>
+  signalAllAcceptedCredentials?: (options: SignalAllAcceptedCredentials) => Promise<void>
+}
+
+function publicKeyCredentialSignal(): PublicKeyCredentialSignal | undefined {
+  return globalThis.PublicKeyCredential as PublicKeyCredentialSignal | undefined
+}
+
+/**
+ * Encode a LeapMux user UUID as the WebAuthn Signal API userId.
+ * Server user handles are `[]byte(uuid)` — base64url of those UTF-8 bytes.
+ */
+export function encodeWebAuthnUserId(userId: string): string {
+  const bytes = new TextEncoder().encode(userId)
+  let binary = ''
+  for (let i = 0; i < bytes.length; i++)
+    binary += String.fromCharCode(bytes[i]!)
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+/** Tell the browser a passkey was removed (best-effort; no-op when unsupported). */
+export function signalPasskeyRemoved(rpId: string, credentialId: string): void {
+  if (!credentialId)
+    return
+  // The Signal API can reject (unknown RP, malformed credential id); it is
+  // a best-effort hint, so a rejection is logged and swallowed -- an
+  // unhandled rejection would fire right after the success toast.
+  publicKeyCredentialSignal()?.signalUnknownCredential?.({ rpId, credentialId }).catch((err) => {
+    log.warn('signalUnknownCredential rejected', { error: String(err) })
+  })
+}
+
+/** Tell the browser which passkeys remain valid for a user (best-effort). */
+export function signalAcceptedPasskeys(rpId: string, userId: string, allAcceptedCredentialIds: string[]): void {
+  if (allAcceptedCredentialIds.length === 0)
+    return
+  publicKeyCredentialSignal()?.signalAllAcceptedCredentials?.({
+    rpId,
+    userId: encodeWebAuthnUserId(userId),
+    allAcceptedCredentialIds,
+  }).catch((err) => {
+    log.warn('signalAllAcceptedCredentials rejected', { error: String(err) })
+  })
+}

--- a/frontend/src/lib/webauthn.ts
+++ b/frontend/src/lib/webauthn.ts
@@ -2,6 +2,8 @@ import {
   startAuthentication as browserStartAuthentication,
   startRegistration as browserStartRegistration,
 } from '@simplewebauthn/browser'
+import { arrayBufferToBase64 } from '~/lib/base64'
+import { formatErrorMessage } from '~/lib/errors'
 import { createLogger } from '~/lib/logger'
 
 const log = createLogger('webauthn')
@@ -21,17 +23,73 @@ export function parseWebAuthnOptionsJSON<T>(optionsJson: string): T {
   return parsed as T
 }
 
+/**
+ * A ceremony the user dismissed, or that the browser ended without an
+ * error the user caused. Callers treat it as a no-op instead of an error
+ * banner: dismissing the OS passkey sheet is not a failure to report.
+ *
+ * `isPasskeyCeremonyCancelled` is the test; the raw SimpleWebAuthn error
+ * stays as the `cause` for the log.
+ */
+export class PasskeyCeremonyCancelledError extends Error {
+  constructor(cause: unknown) {
+    super('Passkey prompt dismissed', { cause })
+    this.name = 'PasskeyCeremonyCancelledError'
+  }
+}
+
+/** True when a rejected ceremony was a dismissal, not a real failure. */
+export function isPasskeyCeremonyCancelled(err: unknown): boolean {
+  return err instanceof PasskeyCeremonyCancelledError
+}
+
+/**
+ * The banner text for a rejected passkey action, or null when the user
+ * dismissed the prompt and there is nothing to report. Every surface that
+ * runs a ceremony routes its catch through here, so "cancel is not an
+ * error" is one rule rather than seven.
+ */
+export function passkeyErrorMessage(err: unknown, fallback: string): string | null {
+  if (isPasskeyCeremonyCancelled(err))
+    return null
+  return formatErrorMessage(err, fallback)
+}
+
+/**
+ * Classify a rejected ceremony at the ONE boundary that knows the
+ * SimpleWebAuthn error shape.
+ *
+ * Every call site used to fall through to `formatErrorMessage`, which
+ * returns `err.message` for any `Error` -- and SimpleWebAuthn passes the
+ * browser's raw DOMException text through verbatim. A user who simply
+ * dismissed the OS sheet read "The operation either timed out or was not
+ * allowed. See: https://www.w3.org/TR/webauthn-2/..." in a red banner.
+ *
+ * The library's own `code` carries the distinction, so the mapping lives
+ * here once instead of as seven ad-hoc fallback strings.
+ */
+function classifyCeremonyError(err: unknown): never {
+  const code = (err as { code?: string } | null)?.code
+  const causeName = (err as { cause?: { name?: string } } | null)?.cause?.name
+  if (code === 'ERROR_CEREMONY_ABORTED'
+    || causeName === 'AbortError'
+    || causeName === 'NotAllowedError') {
+    throw new PasskeyCeremonyCancelledError(err)
+  }
+  throw err
+}
+
 /** Begin a WebAuthn registration ceremony from server JSON options. */
 export async function startRegistration(optionsJson: string): Promise<string> {
   const optionsJSON = parseWebAuthnOptionsJSON<RegistrationOptionsJSON>(optionsJson)
-  const credential = await browserStartRegistration({ optionsJSON })
+  const credential = await browserStartRegistration({ optionsJSON }).catch(classifyCeremonyError)
   return JSON.stringify(credential)
 }
 
 /** Begin a WebAuthn authentication ceremony from server JSON options. */
 export async function startAuthentication(optionsJson: string): Promise<string> {
   const optionsJSON = parseWebAuthnOptionsJSON<AuthenticationOptionsJSON>(optionsJson)
-  const credential = await browserStartAuthentication({ optionsJSON })
+  const credential = await browserStartAuthentication({ optionsJSON }).catch(classifyCeremonyError)
   return JSON.stringify(credential)
 }
 
@@ -60,11 +118,7 @@ function publicKeyCredentialSignal(): PublicKeyCredentialSignal | undefined {
  * Server user handles are `[]byte(uuid)` — base64url of those UTF-8 bytes.
  */
 export function encodeWebAuthnUserId(userId: string): string {
-  const bytes = new TextEncoder().encode(userId)
-  let binary = ''
-  for (let i = 0; i < bytes.length; i++)
-    binary += String.fromCharCode(bytes[i]!)
-  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+  return arrayBufferToBase64(userId).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
 }
 
 /** Tell the browser a passkey was removed (best-effort; no-op when unsupported). */

--- a/frontend/src/routes/forgot-password.tsx
+++ b/frontend/src/routes/forgot-password.tsx
@@ -1,0 +1,10 @@
+import { onMount } from 'solid-js'
+import { ForgotPasswordPage } from '~/components/common/ForgotPasswordPage'
+import { setPageTitle } from '~/lib/pageTitle'
+
+export default function ForgotPasswordRoute() {
+  onMount(() => {
+    setPageTitle('Forgot password')
+  })
+  return <ForgotPasswordPage />
+}

--- a/frontend/src/routes/oauth/complete-signup.test.tsx
+++ b/frontend/src/routes/oauth/complete-signup.test.tsx
@@ -42,6 +42,7 @@ vi.mock('~/components/common/CaptchaField', () => ({
 }))
 
 const mockSetAuth = vi.fn()
+const mockSetVerificationResendAvailableAt = vi.fn()
 vi.mock('~/context/AuthContext', () => ({
   useAuth: () => ({
     user: () => null,
@@ -50,6 +51,7 @@ vi.mock('~/context/AuthContext', () => ({
     login: vi.fn(),
     logout: vi.fn(),
     setAuth: mockSetAuth,
+    setVerificationResendAvailableAt: mockSetVerificationResendAvailableAt,
     isAuthenticated: () => false,
   }),
   AuthProvider: (props: { children: unknown }) => <>{props.children}</>,

--- a/frontend/src/routes/oauth/complete-signup.test.tsx
+++ b/frontend/src/routes/oauth/complete-signup.test.tsx
@@ -22,12 +22,17 @@ vi.mock('~/api/clients', () => ({
 
 const mockIsCaptchaEnabled = vi.fn<() => boolean>(() => false)
 const mockGetCaptchaProvider = vi.fn<() => number>(() => 1) // CaptchaProvider.ALTCHA
+// The hub requires an address exactly when it can verify one, so the
+// field's required-ness follows this.
+const mockIsEmailEnabled = vi.fn(() => false)
+
 vi.mock('~/lib/systemInfo', () => ({
   isSoloMode: () => false,
   loadSystemInfo: () => Promise.resolve(),
   isSignupEnabled: () => false,
   loadOAuthProviders: () => Promise.resolve([]),
   isSystemInfoLoaded: () => true,
+  isEmailEnabled: () => mockIsEmailEnabled(),
   isCaptchaEnabled: () => mockIsCaptchaEnabled(),
   getAltchaAlgorithm: () => '',
   getCaptchaProvider: () => mockGetCaptchaProvider(),
@@ -138,6 +143,9 @@ describe('signup completion page (OAuthCompleteSignupPage)', () => {
         signupToken: 'test-token',
         username: 'testuser',
         displayName: 'Test User',
+        // The hub reads this only when the provider supplied nothing; a
+        // provider-supplied address always wins, so echoing it back is safe.
+        email: 'test@example.com',
         captchaPayload: '',
         honeypot: '',
       })
@@ -162,6 +170,40 @@ describe('signup completion page (OAuthCompleteSignupPage)', () => {
     const emailInput = screen.getByLabelText('Email') as HTMLInputElement
     expect(emailInput.value).toBe('provider@example.com')
     expect(emailInput.readOnly).toBe(true)
+  })
+
+  // An untrusted provider that omits the email claim used to leave the
+  // sign-up unrecoverable whenever SMTP was on: the hub refuses an empty
+  // address and no step in the flow could produce one, so the pending
+  // token expired and the account could never be created.
+  it('lets the user supply an email when the provider gave none', async () => {
+    mockIsEmailEnabled.mockReturnValue(true)
+    mockGetPendingOAuthSignup.mockResolvedValue({
+      email: '',
+      displayName: 'Test User',
+      providerName: 'GitHub',
+    })
+    mockCompleteOAuthSignup.mockResolvedValue({ user: { id: 'u1', username: 'testuser' } })
+
+    renderPage()
+
+    await vi.waitFor(() => {
+      expect(screen.getByLabelText('Email')).toBeInTheDocument()
+    })
+    const emailInput = screen.getByLabelText('Email') as HTMLInputElement
+    expect(emailInput.readOnly).toBe(false)
+    expect(emailInput.required).toBe(true)
+
+    fireEvent.input(screen.getByLabelText('Username'), { target: { value: 'testuser' } })
+    fireEvent.input(emailInput, { target: { value: '  typed@example.com  ' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Create account' }))
+
+    await vi.waitFor(() => {
+      expect(mockCompleteOAuthSignup).toHaveBeenCalledWith(
+        expect.objectContaining({ email: 'typed@example.com' }),
+      )
+    })
+    mockIsEmailEnabled.mockReturnValue(false)
   })
 
   it('shows error for username taken', async () => {

--- a/frontend/src/routes/oauth/complete-signup.tsx
+++ b/frontend/src/routes/oauth/complete-signup.tsx
@@ -85,7 +85,9 @@ const OAuthCompleteSignupPage: Component = () => {
       // to /verify-email so they can paste the code (or click through).
       // The session was created server-side, so the authenticated
       // VerifyEmail RPC is reachable from there.
-      if (resp.verificationRequired) {
+      if (resp.emailVerification?.verificationRequired) {
+        if (resp.emailVerification.nextResendAvailableAt)
+          auth.setVerificationResendAvailableAt(resp.emailVerification.nextResendAvailableAt)
         navigate('/verify-email', { replace: true })
       }
       else {

--- a/frontend/src/routes/oauth/complete-signup.tsx
+++ b/frontend/src/routes/oauth/complete-signup.tsx
@@ -11,6 +11,7 @@ import { useAuth } from '~/context/AuthContext'
 import { createCaptchaForm } from '~/lib/captchaForm'
 import { formatErrorMessage } from '~/lib/errors'
 import { setPageTitle } from '~/lib/pageTitle'
+import { isEmailEnabled } from '~/lib/systemInfo'
 import { sanitizeDisplayName, sanitizeSlug, validateReservedUsername } from '~/lib/validate'
 import { errorText, pageCard } from '~/styles/shared.css'
 
@@ -24,11 +25,17 @@ const OAuthCompleteSignupPage: Component = () => {
   const [displayName, setDisplayName] = createSignal('')
   const [email, setEmail] = createSignal('')
   const [providerName, setProviderName] = createSignal('')
+  // The provider's own claim, captured once at bootstrap. A supplied
+  // address is fixed; an absent one leaves the field to the user.
+  const [providerSuppliedEmail, setProviderSuppliedEmail] = createSignal(false)
   const [submitting, setSubmitting] = createSignal(false)
   const [error, setError] = createSignal<string | null>(null)
   const [loading, setLoading] = createSignal(true)
   const [tokenError, setTokenError] = createSignal<string | null>(null)
   const captcha = createCaptchaForm()
+  // The hub refuses an empty address whenever it can verify one, so the
+  // field is required in the same condition rather than failing at submit.
+  const emailRequired = () => isEmailEnabled()
 
   onMount(async () => {
     setPageTitle('Complete Sign Up')
@@ -41,6 +48,7 @@ const OAuthCompleteSignupPage: Component = () => {
       const resp = await authClient.getPendingOAuthSignup({ signupToken: signupToken() })
       setDisplayName(resp.displayName)
       setEmail(resp.email)
+      setProviderSuppliedEmail(resp.email !== '')
       setProviderName(resp.providerName)
     }
     catch {
@@ -77,6 +85,7 @@ const OAuthCompleteSignupPage: Component = () => {
         signupToken: signupToken(),
         username: slug,
         displayName: sanitizedDisplayName,
+        email: email().trim(),
         ...captcha.fields(),
       })
       auth.setAuth(resp.user!)
@@ -135,16 +144,23 @@ const OAuthCompleteSignupPage: Component = () => {
                 onInput={e => setDisplayName(e.currentTarget.value)}
               />
             </label>
-            <Show when={email()}>
-              <label>
-                Email
-                <input
-                  type="email"
-                  value={email()}
-                  readOnly
-                />
-              </label>
-            </Show>
+            {/*
+              A provider-supplied address is fixed -- the hub validated it at
+              the callback and will not accept a substitute. When the provider
+              gave nothing, the field is the only way to supply one, and on a
+              hub that requires verification the sign-up cannot complete
+              without it.
+            */}
+            <label>
+              Email
+              <input
+                type="email"
+                value={email()}
+                onInput={e => setEmail(e.currentTarget.value)}
+                readOnly={providerSuppliedEmail()}
+                required={emailRequired()}
+              />
+            </label>
             <CaptchaSection action="complete_signup" captcha={captcha} />
             <Show when={error()}>
               <div class={errorText}>{error()}</div>

--- a/frontend/src/routes/reset-password.tsx
+++ b/frontend/src/routes/reset-password.tsx
@@ -1,0 +1,10 @@
+import { onMount } from 'solid-js'
+import { ResetPasswordPage } from '~/components/common/ResetPasswordPage'
+import { setPageTitle } from '~/lib/pageTitle'
+
+export default function ResetPasswordRoute() {
+  onMount(() => {
+    setPageTitle('Reset password')
+  })
+  return <ResetPasswordPage />
+}

--- a/frontend/src/test-support/noMirroredUnitTests.test.ts
+++ b/frontend/src/test-support/noMirroredUnitTests.test.ts
@@ -25,7 +25,10 @@ function collectStrayUnitTests(): string[] {
   return collectFiles(testsRoot, {
     matches: name => UNIT_TEST_FILE.test(name),
     // `tests/e2e/` is the one sanctioned home for tests outside `src/`.
-    alsoSkip: new Set(['e2e']),
+    // An EXACT path, not a basename: a basename skip would also exempt
+    // `tests/unit/e2e/`, so the retired mirror this guard exists to keep
+    // out could return under one directory name.
+    skipPaths: new Set(['e2e']),
   }).map(file => relative(frontendRoot, file))
 }
 

--- a/frontend/src/test-support/noNetworkIdleWait.test.ts
+++ b/frontend/src/test-support/noNetworkIdleWait.test.ts
@@ -44,7 +44,7 @@ describe('e2e load-state waits', () => {
   it('never waits for networkidle', () => {
     const offenders: string[] = []
     for (const file of collectE2EFiles()) {
-      // The ban has to be EXPLAINED somewhere, and the explanation names the
+      // The ban has to be EXPLAINED somewhere, and the explanation identifies the
       // call, so the comment lines go before the scan reads them.
       const lines = stripCommentLines(readFileSync(file, 'utf-8')).split('\n')
       lines.forEach((text, index) => {

--- a/frontend/src/test-support/sourceTree.test.ts
+++ b/frontend/src/test-support/sourceTree.test.ts
@@ -49,7 +49,7 @@ describe('collectFiles', () => {
     expect(found.filter(file => directoriesOf(file).includes('node_modules'))).toEqual([])
   })
 
-  it('skips a named directory anywhere in the walk', () => {
+  it('skips a directory by basename anywhere in the walk', () => {
     const srcRoot = join(frontendRoot, 'src')
     const matches = (name: string): boolean => name.endsWith('.ts')
     const all = collectFiles(srcRoot, { matches })
@@ -57,6 +57,26 @@ describe('collectFiles', () => {
 
     expect(withoutTestSupport.length).toBeLessThan(all.length)
     expect(withoutTestSupport.filter(file => directoriesOf(file).includes('test-support'))).toEqual([])
+  })
+
+  // The distinction REMOVALS-9 turns on: a basename skip exempts every
+  // directory with that name at every depth, an exact path skip exempts
+  // exactly one location.
+  it('skips a path exactly, so a same-named directory elsewhere is still walked', () => {
+    const srcRoot = join(frontendRoot, 'src')
+    const matches = (name: string): boolean => name.endsWith('.ts')
+
+    // 'components' exists directly under src/, so an exact skip removes it.
+    const exact = collectFiles(srcRoot, { matches, skipPaths: new Set(['components']) })
+    expect(exact.filter(file => file.startsWith(join(srcRoot, 'components')))).toEqual([])
+
+    // A nested directory that shares a basename with an exact skip entry
+    // survives, where alsoSkip would have removed it too.
+    const nestedName = 'test-support'
+    const byPath = collectFiles(frontendRoot, { matches, skipPaths: new Set([nestedName]) })
+    expect(byPath.some(file => directoriesOf(file).includes(nestedName))).toBe(true)
+    const byName = collectFiles(frontendRoot, { matches, alsoSkip: new Set([nestedName]) })
+    expect(byName.some(file => directoriesOf(file).includes(nestedName))).toBe(false)
   })
 
   it('returns nothing when the filter accepts no file', () => {

--- a/frontend/src/test-support/sourceTree.ts
+++ b/frontend/src/test-support/sourceTree.ts
@@ -33,11 +33,24 @@ export const SKIP_DIRS: ReadonlySet<string> = new Set([
   'test-results',
 ])
 
+/** The empty default for `skipPaths`: no location is exempt. */
+const NO_PATHS: ReadonlySet<string> = new Set()
+
 export interface CollectFilesOptions {
   /** Reports whether a file belongs in the result, from its basename. */
   matches: (basename: string) => boolean
-  /** Directory basenames to skip in ADDITION to `SKIP_DIRS`. */
+  /** Directory basenames to skip in ADDITION to `SKIP_DIRS`, at ANY depth. */
   alsoSkip?: ReadonlySet<string>
+  /**
+   * Directory paths to skip, each relative to `dir` and matched EXACTLY.
+   *
+   * Use this, not `alsoSkip`, for an exemption that names one sanctioned
+   * location. A basename skip exempts every directory with that name at
+   * every depth: `alsoSkip: new Set(['e2e'])` exempted `tests/e2e/` as
+   * intended and also `tests/unit/e2e/`, so the guard that keeps the
+   * retired unit mirror out could be defeated by one directory name.
+   */
+  skipPaths?: ReadonlySet<string>
 }
 
 /**
@@ -55,18 +68,33 @@ export function collectFiles(dir: string, options: CollectFilesOptions): string[
   const skip = options.alsoSkip === undefined
     ? SKIP_DIRS
     : new Set([...SKIP_DIRS, ...options.alsoSkip])
-  return walk(dir, options.matches, skip)
+  return walk(dir, options.matches, skip, options.skipPaths ?? NO_PATHS, '')
 }
 
-/** The recursive half, with the skip set merged one time by the caller. */
-function walk(dir: string, matches: (basename: string) => boolean, skip: ReadonlySet<string>): string[] {
+/**
+ * The recursive half, with the skip set merged one time by the caller.
+ *
+ * `rel` is the current directory's path relative to the walk root, so a
+ * `skipPaths` entry names one location instead of every directory that
+ * shares its basename.
+ */
+function walk(
+  dir: string,
+  matches: (basename: string) => boolean,
+  skip: ReadonlySet<string>,
+  skipPaths: ReadonlySet<string>,
+  rel: string,
+): string[] {
   const found: string[] = []
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     if (skip.has(entry.name))
       continue
+    const entryRel = rel === '' ? entry.name : `${rel}/${entry.name}`
+    if (skipPaths.has(entryRel))
+      continue
     const full = join(dir, entry.name)
     if (entry.isDirectory())
-      found.push(...walk(full, matches, skip))
+      found.push(...walk(full, matches, skip, skipPaths, entryRel))
     else if (matches(entry.name))
       found.push(full)
   }

--- a/frontend/src/test-support/systemInfoMock.ts
+++ b/frontend/src/test-support/systemInfoMock.ts
@@ -31,6 +31,7 @@ export interface SystemInfoMockState {
   signupEnabled: boolean
   setupRequired: boolean
   emailEnabled: boolean
+  passkeyEnabled: boolean
   captchaEnabled: boolean
   captchaProvider: CaptchaProvider
   captchaSiteKey: string
@@ -44,6 +45,7 @@ const defaultState: SystemInfoMockState = {
   signupEnabled: false,
   setupRequired: false,
   emailEnabled: false,
+  passkeyEnabled: true,
   captchaEnabled: false,
   captchaProvider: CaptchaProvider.ALTCHA,
   captchaSiteKey: '',
@@ -63,6 +65,7 @@ export const systemInfoMock = {
   isSignupEnabled: () => state().signupEnabled,
   isSetupRequired: () => state().setupRequired,
   isEmailEnabled: () => state().emailEnabled,
+  isPasskeyEnabled: () => state().passkeyEnabled,
   isSystemInfoLoaded: () => state().loaded,
   isCaptchaEnabled: () => state().captchaEnabled,
   getCaptchaProvider: () => state().captchaProvider,

--- a/frontend/tests/e2e/006-passkey.spec.ts
+++ b/frontend/tests/e2e/006-passkey.spec.ts
@@ -18,17 +18,6 @@ import {
 
 const APP_HOME_URL_RE = /\/$/
 
-async function setSessionCookie(page: import('@playwright/test').Page, cookie: string) {
-  const value = cookie.split('=').slice(1).join('=')
-  await page.context().addCookies([{
-    name: 'leapmux-session',
-    value,
-    domain: 'localhost',
-    path: '/',
-    httpOnly: true,
-  }])
-}
-
 test.describe('Passkey authentication', () => {
   test('signs up with a passkey via the signup form and logs in again', async ({ page, leapmuxServer }) => {
     await enableVirtualAuthenticator(page)
@@ -49,13 +38,13 @@ test.describe('Passkey authentication', () => {
     const username = `passkey-api-${Date.now()}`
     const email = `${username}@test.local`
     const cookie = await signUpWithPasskeyViaAPIInBrowser(page, leapmuxServer.hubUrl, username, email, 'Passkey API')
-    await setSessionCookie(page, cookie)
+    await loginViaToken(page, cookie)
     await page.goto('/')
     await expect(page).toHaveURL(APP_HOME_URL_RE)
 
     await logoutViaUI(page)
     const loginCookie = await loginWithPasskeyViaAPIInBrowser(page, leapmuxServer.hubUrl, username)
-    await setSessionCookie(page, loginCookie)
+    await loginViaToken(page, loginCookie)
     await page.goto('/')
     await expect(page).toHaveURL(APP_HOME_URL_RE)
   })
@@ -73,7 +62,7 @@ test.describe('Passkey authentication', () => {
       `${username}@test.local`,
     )
 
-    await setSessionCookie(page, cookie)
+    await loginViaToken(page, cookie)
     await page.goto('/')
     await expect(page).toHaveURL(APP_HOME_URL_RE)
 
@@ -98,7 +87,7 @@ test.describe('Passkey authentication', () => {
       `${username}@test.local`,
     )
 
-    await setSessionCookie(page, cookie)
+    await loginViaToken(page, cookie)
     await page.goto('/')
     await addPasskeyViaAPIInBrowser(page, leapmuxServer.hubUrl, cookie, password)
 
@@ -119,7 +108,7 @@ test.describe('Passkey authentication', () => {
       'Remove Passkey',
       `${username}@test.local`,
     )
-    await setSessionCookie(page, cookie)
+    await loginViaToken(page, cookie)
     await page.goto('/')
     await addPasskeyViaAPIInBrowser(page, leapmuxServer.hubUrl, cookie, password)
 

--- a/frontend/tests/e2e/006-passkey.spec.ts
+++ b/frontend/tests/e2e/006-passkey.spec.ts
@@ -1,0 +1,165 @@
+import { expect, test } from './fixtures'
+import { deletePasskeyViaAPI, listPasskeysViaAPI, signUpViaAPI, TEST_ADMIN_PASSWORD } from './helpers/api'
+import {
+  loginViaToken,
+  loginViaUI,
+  loginWithPasskeyViaUI,
+  logoutViaUI,
+  openAccountSettings,
+  signUpWithPasskeyViaUI,
+} from './helpers/ui'
+import {
+  addPasskeyViaAPIInBrowser,
+  deactivatePasskeyAuthViaAPIInBrowser,
+  enableVirtualAuthenticator,
+  loginWithPasskeyViaAPIInBrowser,
+  signUpWithPasskeyViaAPIInBrowser,
+} from './helpers/webauthn'
+
+const APP_HOME_URL_RE = /\/$/
+
+async function setSessionCookie(page: import('@playwright/test').Page, cookie: string) {
+  const value = cookie.split('=').slice(1).join('=')
+  await page.context().addCookies([{
+    name: 'leapmux-session',
+    value,
+    domain: 'localhost',
+    path: '/',
+    httpOnly: true,
+  }])
+}
+
+test.describe('Passkey authentication', () => {
+  test('signs up with a passkey via the signup form and logs in again', async ({ page, leapmuxServer }) => {
+    await enableVirtualAuthenticator(page)
+
+    const username = `passkey-${Date.now()}`
+    const email = `${username}@test.local`
+    await signUpWithPasskeyViaUI(page, username, email, 'Passkey User')
+    await expect(page).toHaveURL(APP_HOME_URL_RE)
+
+    await logoutViaUI(page)
+    await loginWithPasskeyViaUI(page, username)
+    await expect(page).toHaveURL(APP_HOME_URL_RE)
+  })
+
+  test('signs up with a passkey through the API and logs in with passkey', async ({ page, leapmuxServer }) => {
+    await enableVirtualAuthenticator(page)
+
+    const username = `passkey-api-${Date.now()}`
+    const email = `${username}@test.local`
+    const cookie = await signUpWithPasskeyViaAPIInBrowser(page, leapmuxServer.hubUrl, username, email, 'Passkey API')
+    await setSessionCookie(page, cookie)
+    await page.goto('/')
+    await expect(page).toHaveURL(APP_HOME_URL_RE)
+
+    await logoutViaUI(page)
+    const loginCookie = await loginWithPasskeyViaAPIInBrowser(page, leapmuxServer.hubUrl, username)
+    await setSessionCookie(page, loginCookie)
+    await page.goto('/')
+    await expect(page).toHaveURL(APP_HOME_URL_RE)
+  })
+
+  test('adds a passkey to a password account and signs in with it', async ({ page, leapmuxServer }) => {
+    await enableVirtualAuthenticator(page)
+
+    const username = `pw-passkey-${Date.now()}`
+    const password = 'password123'
+    const cookie = await signUpViaAPI(
+      leapmuxServer.hubUrl,
+      username,
+      password,
+      'Password User',
+      `${username}@test.local`,
+    )
+
+    await setSessionCookie(page, cookie)
+    await page.goto('/')
+    await expect(page).toHaveURL(APP_HOME_URL_RE)
+
+    await addPasskeyViaAPIInBrowser(page, leapmuxServer.hubUrl, cookie, password)
+    expect((await listPasskeysViaAPI(leapmuxServer.hubUrl, cookie)).length).toBeGreaterThan(0)
+
+    await logoutViaUI(page)
+    await loginWithPasskeyViaUI(page, username)
+    await expect(page).toHaveURL(APP_HOME_URL_RE)
+  })
+
+  test('password login still works when both methods are registered', async ({ page, leapmuxServer }) => {
+    await enableVirtualAuthenticator(page)
+
+    const username = `dual-${Date.now()}`
+    const password = 'password123'
+    const cookie = await signUpViaAPI(
+      leapmuxServer.hubUrl,
+      username,
+      password,
+      'Dual Login',
+      `${username}@test.local`,
+    )
+
+    await setSessionCookie(page, cookie)
+    await page.goto('/')
+    await addPasskeyViaAPIInBrowser(page, leapmuxServer.hubUrl, cookie, password)
+
+    await logoutViaUI(page)
+    await loginViaUI(page, username, password)
+    await expect(page).toHaveURL(APP_HOME_URL_RE)
+  })
+
+  test('removes a passkey from a password account with the current password', async ({ page, leapmuxServer }) => {
+    await enableVirtualAuthenticator(page)
+
+    const username = `rm-passkey-${Date.now()}`
+    const password = 'password123'
+    const cookie = await signUpViaAPI(
+      leapmuxServer.hubUrl,
+      username,
+      password,
+      'Remove Passkey',
+      `${username}@test.local`,
+    )
+    await setSessionCookie(page, cookie)
+    await page.goto('/')
+    await addPasskeyViaAPIInBrowser(page, leapmuxServer.hubUrl, cookie, password)
+
+    const before = await listPasskeysViaAPI(leapmuxServer.hubUrl, cookie)
+    expect(before.length).toBeGreaterThan(0)
+
+    await deletePasskeyViaAPI(leapmuxServer.hubUrl, cookie, before[0]!.id, password)
+    expect(await listPasskeysViaAPI(leapmuxServer.hubUrl, cookie)).toHaveLength(0)
+  })
+
+  test('deactivates passkey-only auth with reauth and a new password', async ({ page, leapmuxServer }) => {
+    await enableVirtualAuthenticator(page)
+
+    const username = `deact-passkey-${Date.now()}`
+    const email = `${username}@test.local`
+    const newPassword = 'password123'
+    const cookie = await signUpWithPasskeyViaAPIInBrowser(page, leapmuxServer.hubUrl, username, email, 'Deact User')
+    expect((await listPasskeysViaAPI(leapmuxServer.hubUrl, cookie)).length).toBeGreaterThan(0)
+
+    await deactivatePasskeyAuthViaAPIInBrowser(page, leapmuxServer.hubUrl, cookie, newPassword)
+    expect(await listPasskeysViaAPI(leapmuxServer.hubUrl, cookie)).toHaveLength(0)
+
+    await logoutViaUI(page)
+    await loginViaUI(page, username, newPassword)
+    await expect(page).toHaveURL(APP_HOME_URL_RE)
+  })
+
+  test('keeps add-passkey continue disabled until the current password is filled', async ({ page, leapmuxServer }) => {
+    await loginViaToken(page, leapmuxServer.adminToken)
+    await page.goto('/')
+    await expect(page).toHaveURL(APP_HOME_URL_RE)
+
+    const prefs = await openAccountSettings(page)
+    await expect(prefs.getByRole('button', { name: 'Add passkey' })).toBeEnabled()
+    await prefs.getByRole('button', { name: 'Add passkey' }).click()
+
+    const addDialog = page.getByRole('dialog', { name: 'Add passkey' })
+    await expect(addDialog).toBeVisible()
+    await expect(addDialog.getByRole('button', { name: 'Continue' })).toBeDisabled()
+    await addDialog.getByLabel('Current password').fill(TEST_ADMIN_PASSWORD)
+    await expect(addDialog.getByRole('button', { name: 'Continue' })).toBeEnabled()
+  })
+})

--- a/frontend/tests/e2e/007-password-reset.spec.ts
+++ b/frontend/tests/e2e/007-password-reset.spec.ts
@@ -8,7 +8,7 @@ import {
   verifyEmailViaAPI,
 } from './helpers/api'
 import { extractPasswordResetToken, withCaptureSmtp } from './helpers/mail'
-import { loginViaUI, logoutViaUI, solveCaptchaViaUI } from './helpers/ui'
+import { loginViaToken, loginViaUI, logoutViaUI, solveCaptchaViaUI } from './helpers/ui'
 import { enableVirtualAuthenticator, loginWithPasskeyViaAPIInBrowser, signUpWithPasskeyViaAPIInBrowser } from './helpers/webauthn'
 
 function hubDataDir(dataDir: string): string {
@@ -26,13 +26,7 @@ test.describe('Password reset', () => {
       const verifyToken = await readPendingEmailToken(hubDataDir(leapmuxServer.dataDir), username)
       await verifyEmailViaAPI(leapmuxServer.hubUrl, passkeyCookie, verifyToken)
       const verifiedCookie = await loginWithPasskeyViaAPIInBrowser(page, leapmuxServer.hubUrl, username)
-      await page.context().addCookies([{
-        name: 'leapmux-session',
-        value: verifiedCookie.split('=').slice(1).join('='),
-        domain: 'localhost',
-        path: '/',
-        httpOnly: true,
-      }])
+      await loginViaToken(page, verifiedCookie)
       await page.goto('/')
       await expect(page).toHaveURL(/\/$/)
       expect((await listPasskeysViaAPI(leapmuxServer.hubUrl, verifiedCookie)).length).toBeGreaterThan(0)

--- a/frontend/tests/e2e/007-password-reset.spec.ts
+++ b/frontend/tests/e2e/007-password-reset.spec.ts
@@ -1,0 +1,100 @@
+import { join } from 'node:path'
+import { expect, test } from './fixtures'
+import {
+  authedHeaders,
+  listPasskeysViaAPI,
+  loginViaAPI,
+  readPendingEmailToken,
+  verifyEmailViaAPI,
+} from './helpers/api'
+import { extractPasswordResetToken, withCaptureSmtp } from './helpers/mail'
+import { loginViaUI, logoutViaUI, solveCaptchaViaUI } from './helpers/ui'
+import { enableVirtualAuthenticator, loginWithPasskeyViaAPIInBrowser, signUpWithPasskeyViaAPIInBrowser } from './helpers/webauthn'
+
+function hubDataDir(dataDir: string): string {
+  return join(dataDir, 'hub')
+}
+
+test.describe('Password reset', () => {
+  test('forgot-password flow clears passkeys on completion', async ({ page, leapmuxServer }) => {
+    await withCaptureSmtp(leapmuxServer, async (smtp) => {
+      await enableVirtualAuthenticator(page)
+
+      const username = `reset-${Date.now()}`
+      const email = `${username}@test.local`
+      const passkeyCookie = await signUpWithPasskeyViaAPIInBrowser(page, leapmuxServer.hubUrl, username, email)
+      const verifyToken = await readPendingEmailToken(hubDataDir(leapmuxServer.dataDir), username)
+      await verifyEmailViaAPI(leapmuxServer.hubUrl, passkeyCookie, verifyToken)
+      const verifiedCookie = await loginWithPasskeyViaAPIInBrowser(page, leapmuxServer.hubUrl, username)
+      await page.context().addCookies([{
+        name: 'leapmux-session',
+        value: verifiedCookie.split('=').slice(1).join('='),
+        domain: 'localhost',
+        path: '/',
+        httpOnly: true,
+      }])
+      await page.goto('/')
+      await expect(page).toHaveURL(/\/$/)
+      expect((await listPasskeysViaAPI(leapmuxServer.hubUrl, verifiedCookie)).length).toBeGreaterThan(0)
+
+      await logoutViaUI(page)
+
+      await page.goto('/forgot-password')
+      await page.getByLabel('Email or username').fill(username)
+      await solveCaptchaViaUI(page)
+      // Arm the wait BEFORE the click: waitForMessage resolves with the next
+      // message that arrives, never an already-buffered one (the signup
+      // verification email is still in the buffer).
+      const resetEmail = smtp.waitForMessage()
+      await page.getByRole('button', { name: 'Send reset link' }).click()
+      await expect(page.getByText(/If an account with that email or username exists/i)).toBeVisible()
+
+      const emailBody = await resetEmail
+      const token = extractPasswordResetToken(emailBody)
+
+      await page.goto(`/reset-password?token=${encodeURIComponent(token)}`)
+      const newPassword = 'newpass123'
+      await page.getByLabel('New Password').fill(newPassword)
+      await page.getByLabel('Confirm Password').fill(newPassword)
+      await solveCaptchaViaUI(page)
+      await page.getByRole('button', { name: 'Reset password' }).click()
+      await expect(page.getByRole('button', { name: 'Sign in' })).toBeVisible()
+
+      const newCookie = await loginViaAPI(leapmuxServer.hubUrl, username, newPassword)
+      expect(await listPasskeysViaAPI(leapmuxServer.hubUrl, newCookie)).toHaveLength(0)
+
+      await fetch(`${leapmuxServer.hubUrl}/leapmux.v1.AuthService/Logout`, {
+        method: 'POST',
+        headers: authedHeaders(newCookie),
+        body: '{}',
+      })
+
+      const captcha = await (async () => {
+        const { solveCaptchaViaAPI } = await import('./helpers/altcha')
+        return solveCaptchaViaAPI(leapmuxServer.hubUrl)
+      })()
+      const passkeyBegin = await fetch(`${leapmuxServer.hubUrl}/leapmux.v1.AuthService/BeginPasskeyLogin`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          username,
+          captchaPayload: captcha.captchaPayload,
+          honeypot: captcha.honeypot,
+        }),
+      })
+      expect(passkeyBegin.ok).toBe(false)
+      expect(await passkeyBegin.text()).toMatch(/no passkeys|failed_precondition|not found/i)
+
+      await loginViaUI(page, username, newPassword)
+    })
+  })
+
+  test('shows the forgot-password link when email is enabled', async ({ page, leapmuxServer }) => {
+    await withCaptureSmtp(leapmuxServer, async () => {
+      await page.goto('/login')
+      await page.getByLabel('Username').fill('admin')
+      await page.getByLabel('Username').blur()
+      await expect(page.getByRole('link', { name: 'Forgot password?' })).toBeVisible()
+    })
+  })
+})

--- a/frontend/tests/e2e/008-email-verification.spec.ts
+++ b/frontend/tests/e2e/008-email-verification.spec.ts
@@ -11,7 +11,7 @@ import {
   waitForEmailEnabled,
 } from './helpers/api'
 import { withCaptureSmtp } from './helpers/mail'
-import { signUpViaUI, solveCaptchaViaUI } from './helpers/ui'
+import { readSessionCookie, signUpViaUI, solveCaptchaViaUI } from './helpers/ui'
 
 function hubDataDir(dataDir: string): string {
   return join(dataDir, 'hub')
@@ -66,12 +66,7 @@ test.describe('Email verification', () => {
       await signUpViaUI(page, username, 'password123', 'Unverified', `${username}@test.local`)
       await expect(page).toHaveURL(/\/verify-email/)
 
-      const cookie = await (async () => {
-        const session = (await page.context().cookies()).find(c => c.name === 'leapmux-session')
-        if (!session)
-          throw new Error('expected session cookie on verify-email page')
-        return `leapmux-session=${session.value}`
-      })()
+      const cookie = await readSessionCookie(page, 'sign-up')
       await fetch(`${leapmuxServer.hubUrl}/leapmux.v1.AuthService/Logout`, {
         method: 'POST',
         headers: authedHeaders(cookie),
@@ -120,7 +115,7 @@ test.describe('Email verification', () => {
     expect(String(loginBody.code ?? '')).toMatch(/unauthenticated/i)
   })
 
-  test('enabling SMTP later gates previously unverified users', async ({ page, leapmuxServer }) => {
+  test('enabling SMTP later restricts previously unverified users', async ({ page, leapmuxServer }) => {
     await clearSmtpViaAPI(leapmuxServer.hubUrl, leapmuxServer.adminToken)
 
     const username = `transition-${Date.now()}`

--- a/frontend/tests/e2e/008-email-verification.spec.ts
+++ b/frontend/tests/e2e/008-email-verification.spec.ts
@@ -1,0 +1,144 @@
+import { join } from 'node:path'
+import { expect, test } from './fixtures'
+import { solveCaptchaViaAPI } from './helpers/altcha'
+import {
+  authedHeaders,
+  backdatePendingEmailIssuedAt,
+  clearSmtpViaAPI,
+  configureBrokenSmtpViaAPI,
+  readPendingEmailToken,
+  signUpViaAPI,
+  waitForEmailEnabled,
+} from './helpers/api'
+import { withCaptureSmtp } from './helpers/mail'
+import { signUpViaUI, solveCaptchaViaUI } from './helpers/ui'
+
+function hubDataDir(dataDir: string): string {
+  return join(dataDir, 'hub')
+}
+
+test.describe('Email verification', () => {
+  test('signup with SMTP configured routes to verify-email and accepts the code', async ({ page, leapmuxServer }) => {
+    await withCaptureSmtp(leapmuxServer, async () => {
+      const username = `verify-${Date.now()}`
+      await signUpViaUI(page, username, 'password123', 'Verify User', `${username}@test.local`)
+      await expect(page).toHaveURL(/\/verify-email/)
+
+      let token = ''
+      await expect.poll(async () => {
+        token = await readPendingEmailToken(hubDataDir(leapmuxServer.dataDir), username)
+        return token
+      }).not.toBe('')
+      await page.getByTestId('verify-email-code-input').fill(token)
+      await page.getByTestId('verify-email-submit').click()
+      await expect(page).toHaveURL(/\/$/)
+    })
+  })
+
+  test('resend code shows a cooldown on the verify-email page', async ({ page, leapmuxServer }) => {
+    await withCaptureSmtp(leapmuxServer, async () => {
+      const username = `resend-${Date.now()}`
+      await signUpViaUI(page, username, 'password123', 'Resend User', `${username}@test.local`)
+      await expect(page).toHaveURL(/\/verify-email/)
+
+      // Signup already sent a code; the page seeds the 60s cooldown from
+      // the signup response, so the button starts disabled with a countdown
+      // instead of round-tripping into a server refusal.
+      await expect(page.getByTestId('verify-email-resend')).toBeDisabled()
+      await expect(page.getByTestId('verify-email-resend')).toContainText(/Resend code \(\d+:\d{2}\)/)
+
+      // The cooldown seed lives in memory (set by the signup response), so a
+      // reload drops it; the backdated row then lets the server accept the
+      // resend immediately.
+      await backdatePendingEmailIssuedAt(hubDataDir(leapmuxServer.dataDir), username)
+      await page.reload()
+      await expect(page.getByTestId('verify-email-resend')).toBeEnabled()
+      await page.getByTestId('verify-email-resend').click()
+      await expect(page.getByTestId('verify-email-resend-status')).toContainText(/fresh code has been sent/i)
+      await expect(page.getByTestId('verify-email-resend')).toBeDisabled()
+      await expect(page.getByTestId('verify-email-resend')).toContainText(/Resend code \(\d+:\d{2}\)/)
+    })
+  })
+
+  test('unverified users can still log out while verification is pending', async ({ page, leapmuxServer }) => {
+    await withCaptureSmtp(leapmuxServer, async () => {
+      const username = `unverified-${Date.now()}`
+      await signUpViaUI(page, username, 'password123', 'Unverified', `${username}@test.local`)
+      await expect(page).toHaveURL(/\/verify-email/)
+
+      const cookie = await (async () => {
+        const session = (await page.context().cookies()).find(c => c.name === 'leapmux-session')
+        if (!session)
+          throw new Error('expected session cookie on verify-email page')
+        return `leapmux-session=${session.value}`
+      })()
+      await fetch(`${leapmuxServer.hubUrl}/leapmux.v1.AuthService/Logout`, {
+        method: 'POST',
+        headers: authedHeaders(cookie),
+        body: '{}',
+      })
+      await page.goto('/login')
+      await expect(page.getByRole('button', { name: 'Sign in' })).toBeVisible()
+
+      await page.getByLabel('Username').fill(username)
+      await page.getByLabel('Password').fill('password123')
+      await solveCaptchaViaUI(page)
+      await page.getByRole('button', { name: 'Sign in' }).click()
+      await expect(page).toHaveURL(/\/verify-email/)
+    })
+  })
+
+  test('signup fails closed when verification email cannot be sent', async ({ page, leapmuxServer }) => {
+    await configureBrokenSmtpViaAPI(leapmuxServer.hubUrl, leapmuxServer.adminToken)
+    await waitForEmailEnabled(leapmuxServer.hubUrl)
+
+    const username = `failclosed-${Date.now()}`
+    await page.goto('/signup')
+    await page.getByLabel('Username').fill(username)
+    await page.getByLabel('Display Name').fill('Fail Closed')
+    await page.getByLabel('Email').fill(`${username}@test.local`)
+    await page.getByLabel('New Password').fill('password123')
+    await page.getByLabel('Confirm Password').fill('password123')
+    await solveCaptchaViaUI(page)
+    await page.getByRole('button', { name: 'Sign up' }).click()
+    await expect(page.getByText(/sign-up failed|unavailable|failed/i)).toBeVisible()
+    await expect(page).toHaveURL(/\/signup/)
+
+    const captcha = await solveCaptchaViaAPI(leapmuxServer.hubUrl)
+    const loginResp = await fetch(`${leapmuxServer.hubUrl}/leapmux.v1.AuthService/Login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        username,
+        password: 'password123',
+        captchaPayload: captcha.captchaPayload,
+        honeypot: captcha.honeypot,
+      }),
+    })
+    expect(loginResp.ok).toBe(false)
+    const loginBody = await loginResp.json() as { code?: string }
+    expect(String(loginBody.code ?? '')).toMatch(/unauthenticated/i)
+  })
+
+  test('enabling SMTP later gates previously unverified users', async ({ page, leapmuxServer }) => {
+    await clearSmtpViaAPI(leapmuxServer.hubUrl, leapmuxServer.adminToken)
+
+    const username = `transition-${Date.now()}`
+    await signUpViaAPI(
+      leapmuxServer.hubUrl,
+      username,
+      'password123',
+      'Transition User',
+      `${username}@test.local`,
+    )
+
+    await withCaptureSmtp(leapmuxServer, async () => {
+      await page.goto('/login')
+      await page.getByLabel('Username').fill(username)
+      await page.getByLabel('Password').fill('password123')
+      await solveCaptchaViaUI(page)
+      await page.getByRole('button', { name: 'Sign in' }).click()
+      await expect(page).toHaveURL(/\/verify-email/)
+    })
+  })
+})

--- a/frontend/tests/e2e/helpers/api.ts
+++ b/frontend/tests/e2e/helpers/api.ts
@@ -234,6 +234,170 @@ export async function enableSignupViaAPI(hubUrl: string, cookie: string): Promis
   }
 }
 
+export interface SmtpCaptureTarget {
+  host: string
+  port: number
+}
+
+/**
+ * Point the hub at a loopback capture SMTP relay. Verification gating follows
+ * SMTP once host and from_address are both present.
+ */
+export async function configureCaptureSmtpViaAPI(
+  hubUrl: string,
+  adminCookie: string,
+  relay: SmtpCaptureTarget,
+  fromAddress = 'hub@test.local',
+): Promise<void> {
+  const res = await fetch(`${hubUrl}/leapmux.v1.AdminSettingsService/UpdateSetting`, {
+    method: 'POST',
+    headers: authedHeaders(adminCookie),
+    body: JSON.stringify({
+      key: 'smtp',
+      partialJson: JSON.stringify({
+        host: relay.host,
+        port: relay.port,
+        from_address: fromAddress,
+        tls_mode: 'none',
+      }),
+    }),
+  })
+  if (!res.ok) {
+    throw new Error(`configureCaptureSmtpViaAPI failed: ${res.status} ${await res.text()}`)
+  }
+}
+
+/** Poll GetSystemInfo until emailEnabled reflects the staged SMTP block. */
+export async function waitForEmailEnabled(hubUrl: string, timeoutMs = 30_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const res = await fetch(`${hubUrl}/leapmux.v1.AuthService/GetSystemInfo`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+    if (res.ok) {
+      const data = await res.json() as { emailEnabled?: boolean }
+      if (data.emailEnabled)
+        return
+    }
+    await new Promise(r => setTimeout(r, API_POLL_INTERVAL_MS))
+  }
+  throw new Error('waitForEmailEnabled: hub never reported emailEnabled=true')
+}
+
+export interface PasskeySummary {
+  id: string
+  friendlyName: string
+}
+
+/** List passkeys registered for the authenticated user. */
+export async function listPasskeysViaAPI(hubUrl: string, cookie: string): Promise<PasskeySummary[]> {
+  const res = await fetch(`${hubUrl}/leapmux.v1.UserService/ListPasskeys`, {
+    method: 'POST',
+    headers: authedHeaders(cookie),
+    body: JSON.stringify({}),
+  })
+  if (!res.ok) {
+    throw new Error(`listPasskeysViaAPI failed: ${res.status} ${await res.text()}`)
+  }
+  const data = await res.json() as { passkeys?: Array<{ id?: string, friendlyName?: string }> }
+  return (data.passkeys ?? []).map(pk => ({ id: pk.id ?? '', friendlyName: pk.friendlyName ?? '' }))
+}
+
+/** Delete one passkey with the account password. */
+export async function deletePasskeyViaAPI(
+  hubUrl: string,
+  cookie: string,
+  passkeyId: string,
+  currentPassword: string,
+): Promise<void> {
+  const res = await fetch(`${hubUrl}/leapmux.v1.UserService/DeletePasskey`, {
+    method: 'POST',
+    headers: authedHeaders(cookie),
+    body: JSON.stringify({ id: passkeyId, currentPassword }),
+  })
+  if (!res.ok) {
+    throw new Error(`deletePasskeyViaAPI failed: ${res.status} ${await res.text()}`)
+  }
+}
+
+/**
+ * Backdate a user's pending-email row so ResendVerificationEmail cooldown
+ * has elapsed (signup issues a code immediately; resend is blocked for 60s).
+ */
+export async function backdatePendingEmailIssuedAt(hubDataDir: string, username: string): Promise<void> {
+  const { execFile } = await import('node:child_process')
+  const { promisify } = await import('node:util')
+  const { join } = await import('node:path')
+  const execFileAsync = promisify(execFile)
+  const dbPath = join(hubDataDir, 'hub.db')
+  const escaped = username.replace(/'/g, `''`)
+  // pending_email_expires_at = issued_at + 30m; set issued ~2m ago.
+  // Retry on SQLITE_BUSY: the hub may hold a write lock briefly.
+  const sql = `UPDATE users SET pending_email_expires_at = datetime('now', '+28 minutes') WHERE username = '${escaped}' AND deleted_at IS NULL;`
+  let lastErr: unknown
+  for (let attempt = 0; attempt < 8; attempt++) {
+    try {
+      await execFileAsync('sqlite3', [dbPath, sql])
+      return
+    }
+    catch (err) {
+      lastErr = err
+      const msg = err instanceof Error ? err.message : String(err)
+      if (!/database is locked|SQLITE_BUSY/i.test(msg))
+        throw err
+      await new Promise(r => setTimeout(r, 50 * (attempt + 1)))
+    }
+  }
+  throw lastErr
+}
+
+export async function readPendingEmailToken(hubDataDir: string, username: string): Promise<string> {
+  const { execFile } = await import('node:child_process')
+  const { promisify } = await import('node:util')
+  const { join } = await import('node:path')
+  const execFileAsync = promisify(execFile)
+  const dbPath = join(hubDataDir, 'hub.db')
+  const escaped = username.replace(/'/g, `''`)
+  const { stdout } = await execFileAsync('sqlite3', [
+    dbPath,
+    `SELECT pending_email_token FROM users WHERE username = '${escaped}' AND deleted_at IS NULL;`,
+  ])
+  const token = stdout.trim()
+  if (!token)
+    throw new Error(`no pending_email_token for username ${username}`)
+  return token
+}
+
+/** Verify the session user's pending email with a code from the DB or inbox. */
+export async function verifyEmailViaAPI(hubUrl: string, cookie: string, verificationToken: string): Promise<void> {
+  const res = await fetch(`${hubUrl}/leapmux.v1.UserService/VerifyEmail`, {
+    method: 'POST',
+    headers: authedHeaders(cookie),
+    body: JSON.stringify({ verificationToken }),
+  })
+  if (!res.ok) {
+    throw new Error(`verifyEmailViaAPI failed: ${res.status} ${await res.text()}`)
+  }
+}
+
+/** Request a password-reset email via the public AuthService RPC. */
+export async function requestPasswordResetViaAPI(
+  hubUrl: string,
+  identifier: string,
+): Promise<void> {
+  const captcha = await solveCaptchaViaAPI(hubUrl)
+  const res = await fetch(`${hubUrl}/leapmux.v1.AuthService/RequestPasswordReset`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ identifier, captchaPayload: captcha.captchaPayload, honeypot: captcha.honeypot }),
+  })
+  if (!res.ok) {
+    throw new Error(`requestPasswordResetViaAPI failed: ${res.status} ${await res.text()}`)
+  }
+}
+
 /**
  * Mint a registration key as an authenticated user. Mirrors the
  * production UI flow: an admin (or any authorized user) calls
@@ -569,5 +733,40 @@ export async function deleteAllWorkspacesViaAPI(
   const workspaces = await listWorkspacesViaAPI(hubUrl, cookie)
   for (const ws of workspaces) {
     await deleteWorkspaceViaAPI(hubUrl, cookie, ws.id).catch(() => {})
+  }
+}
+
+/** Clear SMTP so EmailVerificationEffective turns off. */
+export async function clearSmtpViaAPI(hubUrl: string, adminCookie: string): Promise<void> {
+  const res = await fetch(`${hubUrl}/leapmux.v1.AdminSettingsService/ResetSetting`, {
+    method: 'POST',
+    headers: authedHeaders(adminCookie),
+    body: JSON.stringify({ key: 'smtp' }),
+  })
+  if (!res.ok) {
+    throw new Error(`clearSmtpViaAPI failed: ${res.status} ${await res.text()}`)
+  }
+}
+
+/** Point SMTP at an unreachable host so verification sends fail closed. */
+export async function configureBrokenSmtpViaAPI(
+  hubUrl: string,
+  adminCookie: string,
+): Promise<void> {
+  const res = await fetch(`${hubUrl}/leapmux.v1.AdminSettingsService/UpdateSetting`, {
+    method: 'POST',
+    headers: authedHeaders(adminCookie),
+    body: JSON.stringify({
+      key: 'smtp',
+      partialJson: JSON.stringify({
+        host: '127.0.0.1',
+        port: 1,
+        from_address: 'hub@test.local',
+        tls_mode: 'none',
+      }),
+    }),
+  })
+  if (!res.ok) {
+    throw new Error(`configureBrokenSmtpViaAPI failed: ${res.status} ${await res.text()}`)
   }
 }

--- a/frontend/tests/e2e/helpers/mail.ts
+++ b/frontend/tests/e2e/helpers/mail.ts
@@ -1,0 +1,153 @@
+import type { Server, Socket } from 'node:net'
+import { createServer } from 'node:net'
+import { configureCaptureSmtpViaAPI, waitForEmailEnabled } from './api'
+
+export interface CaptureSmtpServer {
+  host: string
+  port: number
+  messages: string[]
+  stop: () => Promise<void>
+  waitForMessage: (timeoutMs?: number) => Promise<string>
+}
+
+function reply(socket: Socket, code: number, message: string) {
+  socket.write(`${code} ${message}\r\n`)
+}
+
+/**
+ * Start a minimal loopback SMTP server that accepts one message at a time.
+ *
+ * The hub is pointed at this relay with `tls_mode: "none"` so E2E tests can
+ * capture verification and password-reset emails without external infra.
+ */
+export async function startCaptureSmtpServer(): Promise<CaptureSmtpServer> {
+  const messages: string[] = []
+  // FIFO of waiters: a second concurrent waitForMessage queues behind the
+  // first instead of silently discarding its resolver (which would hang the
+  // first waiter until its timeout with the message already delivered).
+  const waiters: Array<(body: string) => void> = []
+  const timers: Array<ReturnType<typeof setTimeout>> = []
+
+  const server: Server = createServer((socket) => {
+    let buffer = ''
+    let inData = false
+    let dataLines: string[] = []
+
+    reply(socket, 220, 'localhost ESMTP test')
+
+    socket.on('data', (chunk) => {
+      buffer += chunk.toString()
+      while (true) {
+        const nl = buffer.indexOf('\r\n')
+        if (nl === -1)
+          break
+        const line = buffer.slice(0, nl)
+        buffer = buffer.slice(nl + 2)
+
+        if (inData) {
+          if (line === '.') {
+            const body = dataLines.join('\r\n')
+            messages.push(body)
+            waiters.shift()?.(body)
+            dataLines = []
+            inData = false
+            reply(socket, 250, 'OK')
+            continue
+          }
+          dataLines.push(line.replace(/^\.\./, '.'))
+          continue
+        }
+
+        const cmd = line.toUpperCase()
+        if (cmd.startsWith('EHLO') || cmd.startsWith('HELO')) {
+          reply(socket, 250, 'localhost')
+        }
+        else if (cmd.startsWith('MAIL FROM') || cmd.startsWith('RCPT TO') || cmd.startsWith('RSET')) {
+          reply(socket, 250, 'OK')
+        }
+        else if (cmd.startsWith('DATA')) {
+          inData = true
+          dataLines = []
+          reply(socket, 354, 'End data with <CR><LF>.<CR><LF>')
+        }
+        else if (cmd.startsWith('QUIT')) {
+          reply(socket, 221, 'Bye')
+          socket.end()
+        }
+        else if (cmd.startsWith('NOOP')) {
+          reply(socket, 250, 'OK')
+        }
+        else if (line.length > 0) {
+          reply(socket, 250, 'OK')
+        }
+      }
+    })
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => resolve())
+  })
+
+  const addr = server.address()
+  if (!addr || typeof addr === 'string')
+    throw new Error('failed to bind SMTP capture server')
+
+  return {
+    host: '127.0.0.1',
+    port: addr.port,
+    messages,
+    stop: () => new Promise((resolve) => {
+      for (const t of timers)
+        clearTimeout(t)
+      server.close(() => resolve())
+    }),
+    // waitForMessage resolves with the NEXT message that arrives after the
+    // call — never an already-buffered one. A helper that returns
+    // `messages.at(-1)` hands back the wrong email the moment a spec sends
+    // two (signup verification, then a reset) or delivery turns async.
+    // Concurrent waits queue FIFO: each resolves with its own message.
+    waitForMessage: (timeoutMs = 30_000) => new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        const idx = waiters.indexOf(resolve)
+        if (idx !== -1)
+          waiters.splice(idx, 1)
+        reject(new Error(`timed out waiting for SMTP message after ${timeoutMs}ms`))
+      }, timeoutMs)
+      timers.push(timer)
+      waiters.push((body) => {
+        clearTimeout(timer)
+        resolve(body)
+      })
+    }),
+  }
+}
+
+/**
+ * Stage the hub with a capture SMTP server for one test body: start the
+ * server, point the hub at it, wait for email to report enabled, run the
+ * body, and stop the server. One helper, so a new required staging step
+ * applies to every SMTP spec at once.
+ */
+export async function withCaptureSmtp(
+  server: { hubUrl: string, adminToken: string },
+  body: (smtp: CaptureSmtpServer) => Promise<void>,
+): Promise<void> {
+  const smtp = await startCaptureSmtpServer()
+  try {
+    await configureCaptureSmtpViaAPI(server.hubUrl, server.adminToken, smtp)
+    await waitForEmailEnabled(server.hubUrl)
+    await body(smtp)
+  }
+  finally {
+    await smtp.stop()
+  }
+}
+
+/** Pull the self-service password-reset token out of a captured reset email body. */
+export function extractPasswordResetToken(emailBody: string): string {
+  const match = emailBody.match(/\/reset-password\?token=([0-9a-f]+)/i)
+  if (!match?.[1])
+    throw new Error('password reset token not found in captured email')
+  return match[1]
+}

--- a/frontend/tests/e2e/helpers/ui.ts
+++ b/frontend/tests/e2e/helpers/ui.ts
@@ -837,6 +837,45 @@ export async function signUpViaUI(page: Page, username: string, password: string
   await page.getByRole('button', { name: 'Sign up' }).click()
 }
 
+/** Sign up with a passkey via the signup form (virtual authenticator must be enabled). */
+export async function signUpWithPasskeyViaUI(
+  page: Page,
+  username: string,
+  email: string,
+  displayName = '',
+) {
+  await page.goto('/signup')
+  await page.getByLabel('Username').fill(username)
+  if (displayName) {
+    await page.getByLabel('Display Name').fill(displayName)
+  }
+  await page.getByLabel('Email').fill(email)
+  await page.getByRole('radio', { name: 'Passkey' }).click()
+  await solveCaptchaViaUI(page)
+  await page.getByRole('button', { name: 'Sign up with passkey' }).click()
+  await expect(page).not.toHaveURL(/\/signup(?:\?.*)?$/)
+}
+
+/** Log in with a passkey via the login form (virtual authenticator must be enabled). */
+export async function loginWithPasskeyViaUI(page: Page, username: string) {
+  await page.goto('/login')
+  await page.getByLabel('Username').fill(username)
+  await page.getByLabel('Username').blur()
+  const passkeyRadio = page.getByRole('radio', { name: 'Passkey' })
+  if (await passkeyRadio.isVisible().catch(() => false))
+    await passkeyRadio.click()
+  await solveCaptchaViaUI(page)
+  await page.getByRole('button', { name: /Sign in with passkey/i }).click()
+  await expect(page).toHaveURL(/\/$/)
+  await appMenuTrigger(page).waitFor({ state: 'visible' })
+}
+
+/** Open Preferences on the account / profile section. */
+export async function openAccountSettings(page: Page) {
+  await openPreferencesDialog(page, 'account')
+  return page.getByRole('dialog', { name: 'Preferences' })
+}
+
 /**
  * Logout via the app menu (titlebar on desktop, tab-bar "+" menu on mobile).
  */

--- a/frontend/tests/e2e/helpers/ui.ts
+++ b/frontend/tests/e2e/helpers/ui.ts
@@ -981,10 +981,30 @@ export async function setInitialBrowserPref(page: Page, field: string, value: st
   }, [KEY_BROWSER_PREFS, field, value, BROWSER_PREFS_TTL_MS] as const)
 }
 
+/** The hub's session cookie name, as `readSessionCookie` looks it up. */
+const SESSION_COOKIE_NAME = 'leapmux-session'
+
+/**
+ * The session cookie the browser context currently holds, as the
+ * "leapmux-session=<value>" token `loginViaToken` takes. Its inverse.
+ *
+ * Three specs hand-rolled this lookup. One home means a rename of the
+ * cookie name moves every reader with it.
+ */
+export async function readSessionCookie(page: Page, step: string): Promise<string> {
+  const session = (await page.context().cookies()).find(c => c.name === SESSION_COOKIE_NAME)
+  if (!session?.value)
+    throw new Error(`${step} did not set a session cookie on the browser context`)
+  return `${SESSION_COOKIE_NAME}=${session.value}`
+}
+
 /**
  * Set the session cookie in the browser context so subsequent navigations
  * are authenticated. The token is a cookie string like "leapmux-session=<value>".
  * Must be called **before** any page.goto() calls.
+ *
+ * The NAME comes from the token, not from SESSION_COOKIE_NAME: the caller
+ * passes back what a login handed it, whatever it was called.
  */
 export async function loginViaToken(page: Page, token: string) {
   const [name, ...rest] = token.split('=')

--- a/frontend/tests/e2e/helpers/webauthn.ts
+++ b/frontend/tests/e2e/helpers/webauthn.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import process from 'node:process'
 
 import { solveCaptchaViaAPI } from './altcha'
+import { loginViaToken, readSessionCookie } from './ui'
 
 const SIMPLEWEBAUTHN_BUNDLE = readFileSync(
   join(process.cwd(), 'node_modules/@simplewebauthn/browser/dist/bundle/index.umd.min.js'),
@@ -152,24 +153,6 @@ async function postConnectInPage(
   }, { hubUrl, procedure, body })
 }
 
-async function readSessionCookie(page: Page, step: string): Promise<string> {
-  const session = (await page.context().cookies()).find(c => c.name === 'leapmux-session')
-  if (!session?.value)
-    throw new Error(`${step} did not set a session cookie on the browser context`)
-  return `leapmux-session=${session.value}`
-}
-
-async function setSessionCookie(page: Page, cookie: string): Promise<void> {
-  const value = cookie.split('=').slice(1).join('=')
-  await page.context().addCookies([{
-    name: 'leapmux-session',
-    value,
-    domain: 'localhost',
-    path: '/',
-    httpOnly: true,
-  }])
-}
-
 /**
  * Complete a passkey sign-up through the Connect API while running the
  * WebAuthn ceremony inside `page` (virtual authenticator required).
@@ -216,7 +199,7 @@ export async function addPasskeyViaAPIInBrowser(
   cookie: string,
   currentPassword = '',
 ): Promise<void> {
-  await setSessionCookie(page, cookie)
+  await loginViaToken(page, cookie)
   await page.goto(`${hubUrl}/`)
   await runCeremonyInPage(page, hubUrl, {
     beginProcedure: 'UserService/BeginPasskeyRegistration',
@@ -237,7 +220,7 @@ export async function deactivatePasskeyAuthViaAPIInBrowser(
   cookie: string,
   newPassword: string,
 ): Promise<void> {
-  await setSessionCookie(page, cookie)
+  await loginViaToken(page, cookie)
   await page.goto(`${hubUrl}/`)
   const finish = await runCeremonyInPage(page, hubUrl, {
     beginProcedure: 'UserService/BeginPasskeyReauth',

--- a/frontend/tests/e2e/helpers/webauthn.ts
+++ b/frontend/tests/e2e/helpers/webauthn.ts
@@ -1,0 +1,260 @@
+import type { CDPSession, Page } from '@playwright/test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import process from 'node:process'
+
+import { solveCaptchaViaAPI } from './altcha'
+
+const SIMPLEWEBAUTHN_BUNDLE = readFileSync(
+  join(process.cwd(), 'node_modules/@simplewebauthn/browser/dist/bundle/index.umd.min.js'),
+  'utf8',
+)
+
+const installedPages = new WeakSet<Page>()
+
+export interface VirtualAuthenticator {
+  cdp: CDPSession
+  authenticatorId: string
+}
+
+/** go-webauthn wraps options in `{ publicKey: … }`; SimpleWebAuthn expects the inner object. */
+function unwrapWebAuthnOptionsScript(): string {
+  return `
+    globalThis.__unwrapWebAuthnOptions = (optionsJson) => {
+      const parsed = JSON.parse(optionsJson);
+      if (parsed && typeof parsed === 'object' && parsed.publicKey)
+        return parsed.publicKey;
+      return parsed;
+    };
+  `
+}
+
+async function installBrowserWebAuthn(page: Page): Promise<void> {
+  if (installedPages.has(page))
+    return
+  await page.addInitScript({ content: SIMPLEWEBAUTHN_BUNDLE + unwrapWebAuthnOptionsScript() })
+  installedPages.add(page)
+}
+
+/**
+ * Enable Playwright's CDP WebAuthn virtual authenticator on `page`.
+ *
+ * Must run before any navigation that triggers a WebAuthn ceremony.
+ */
+export async function enableVirtualAuthenticator(page: Page): Promise<VirtualAuthenticator> {
+  await installBrowserWebAuthn(page)
+  const cdp = await page.context().newCDPSession(page)
+  // enableUI must stay false so the virtual authenticator auto-completes
+  // ceremonies without a native picker that headless Chromium never dismisses.
+  await cdp.send('WebAuthn.enable', { enableUI: false })
+  const { authenticatorId } = await cdp.send('WebAuthn.addVirtualAuthenticator', {
+    options: {
+      protocol: 'ctap2',
+      ctap2Version: 'ctap2_1',
+      transport: 'usb',
+      hasResidentKey: true,
+      hasUserVerification: true,
+      isUserVerified: true,
+      automaticPresenceSimulation: true,
+    },
+  })
+  return { cdp, authenticatorId }
+}
+
+type CeremonyMethod = 'startRegistration' | 'startAuthentication'
+
+/**
+ * Run one Begin → browser ceremony → Finish chain inside `page` against the
+ * raw Connect API. `procedure` values carry the service prefix (for example
+ * `AuthService/BeginPasskeyLogin`). The Finish body merges
+ * `{ sessionId, credentialJson }` with `finishExtra`. Returns the parsed
+ * Finish response JSON.
+ */
+async function runCeremonyInPage(
+  page: Page,
+  hubUrl: string,
+  spec: {
+    beginProcedure: string
+    beginBody: Record<string, unknown>
+    ceremonyMethod: CeremonyMethod
+    finishProcedure: string
+    finishExtra?: Record<string, unknown>
+  },
+): Promise<Record<string, unknown>> {
+  return await page.evaluate(async ({ hubUrl, spec }: {
+    hubUrl: string
+    spec: {
+      beginProcedure: string
+      beginBody: Record<string, unknown>
+      ceremonyMethod: 'startRegistration' | 'startAuthentication'
+      finishProcedure: string
+      finishExtra?: Record<string, unknown>
+    }
+  }) => {
+    const SWB = (globalThis as typeof globalThis & {
+      SimpleWebAuthnBrowser?: Record<'startRegistration' | 'startAuthentication', (args: { optionsJSON: unknown }) => Promise<unknown>>
+    }).SimpleWebAuthnBrowser
+    const unwrap = (globalThis as typeof globalThis & { __unwrapWebAuthnOptions?: (json: string) => unknown }).__unwrapWebAuthnOptions
+    const ceremony = SWB?.[spec.ceremonyMethod]
+    if (!ceremony || !unwrap)
+      throw new Error('SimpleWebAuthnBrowser is not installed on this page')
+
+    const beginRes = await fetch(`${hubUrl}/leapmux.v1.${spec.beginProcedure}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(spec.beginBody),
+    })
+    if (!beginRes.ok)
+      throw new Error(`${spec.beginProcedure} failed: ${beginRes.status} ${await beginRes.text()}`)
+    const begin = await beginRes.json() as { sessionId?: string, optionsJson?: string }
+    if (!begin.sessionId || !begin.optionsJson)
+      throw new Error(`${spec.beginProcedure} returned incomplete payload`)
+
+    const credential = await ceremony({ optionsJSON: unwrap(begin.optionsJson) })
+    const finishRes = await fetch(`${hubUrl}/leapmux.v1.${spec.finishProcedure}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({
+        sessionId: begin.sessionId,
+        credentialJson: JSON.stringify(credential),
+        ...spec.finishExtra,
+      }),
+    })
+    if (!finishRes.ok)
+      throw new Error(`${spec.finishProcedure} failed: ${finishRes.status} ${await finishRes.text()}`)
+    return await finishRes.json() as Record<string, unknown>
+  }, { hubUrl, spec })
+}
+
+/** POST one Connect procedure inside `page` and return the parsed response. */
+async function postConnectInPage(
+  page: Page,
+  hubUrl: string,
+  procedure: string,
+  body: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  return await page.evaluate(async ({ hubUrl, procedure, body }: {
+    hubUrl: string
+    procedure: string
+    body: Record<string, unknown>
+  }) => {
+    const res = await fetch(`${hubUrl}/leapmux.v1.${procedure}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(body),
+    })
+    if (!res.ok)
+      throw new Error(`${procedure} failed: ${res.status} ${await res.text()}`)
+    return await res.json() as Record<string, unknown>
+  }, { hubUrl, procedure, body })
+}
+
+async function readSessionCookie(page: Page, step: string): Promise<string> {
+  const session = (await page.context().cookies()).find(c => c.name === 'leapmux-session')
+  if (!session?.value)
+    throw new Error(`${step} did not set a session cookie on the browser context`)
+  return `leapmux-session=${session.value}`
+}
+
+async function setSessionCookie(page: Page, cookie: string): Promise<void> {
+  const value = cookie.split('=').slice(1).join('=')
+  await page.context().addCookies([{
+    name: 'leapmux-session',
+    value,
+    domain: 'localhost',
+    path: '/',
+    httpOnly: true,
+  }])
+}
+
+/**
+ * Complete a passkey sign-up through the Connect API while running the
+ * WebAuthn ceremony inside `page` (virtual authenticator required).
+ */
+export async function signUpWithPasskeyViaAPIInBrowser(
+  page: Page,
+  hubUrl: string,
+  username: string,
+  email: string,
+  displayName = '',
+): Promise<string> {
+  const captcha = await solveCaptchaViaAPI(hubUrl)
+  await page.goto(`${hubUrl}/login`)
+  await runCeremonyInPage(page, hubUrl, {
+    beginProcedure: 'AuthService/BeginPasskeySignUp',
+    beginBody: { username, displayName, email, captchaPayload: captcha.captchaPayload, honeypot: captcha.honeypot },
+    ceremonyMethod: 'startRegistration',
+    finishProcedure: 'AuthService/FinishPasskeySignUp',
+  })
+  return readSessionCookie(page, 'FinishPasskeySignUp')
+}
+
+/** Log in with a passkey via API while running WebAuthn inside `page`. */
+export async function loginWithPasskeyViaAPIInBrowser(
+  page: Page,
+  hubUrl: string,
+  username: string,
+): Promise<string> {
+  const captcha = await solveCaptchaViaAPI(hubUrl)
+  await page.goto(`${hubUrl}/login`)
+  await runCeremonyInPage(page, hubUrl, {
+    beginProcedure: 'AuthService/BeginPasskeyLogin',
+    beginBody: { username, captchaPayload: captcha.captchaPayload, honeypot: captcha.honeypot },
+    ceremonyMethod: 'startAuthentication',
+    finishProcedure: 'AuthService/FinishPasskeyLogin',
+  })
+  return readSessionCookie(page, 'FinishPasskeyLogin')
+}
+
+/** Register an additional passkey for the authenticated session inside `page`. */
+export async function addPasskeyViaAPIInBrowser(
+  page: Page,
+  hubUrl: string,
+  cookie: string,
+  currentPassword = '',
+): Promise<void> {
+  await setSessionCookie(page, cookie)
+  await page.goto(`${hubUrl}/`)
+  await runCeremonyInPage(page, hubUrl, {
+    beginProcedure: 'UserService/BeginPasskeyRegistration',
+    beginBody: { currentPassword, reauthProof: '' },
+    ceremonyMethod: 'startRegistration',
+    finishProcedure: 'UserService/FinishPasskeyRegistration',
+    finishExtra: { friendlyName: 'E2E Passkey', currentPassword, reauthProof: '' },
+  })
+}
+
+/**
+ * Deactivate all passkeys on a passkey-only account: reauth ceremony + new password.
+ * Virtual authenticator must already be enabled on `page`.
+ */
+export async function deactivatePasskeyAuthViaAPIInBrowser(
+  page: Page,
+  hubUrl: string,
+  cookie: string,
+  newPassword: string,
+): Promise<void> {
+  await setSessionCookie(page, cookie)
+  await page.goto(`${hubUrl}/`)
+  const finish = await runCeremonyInPage(page, hubUrl, {
+    beginProcedure: 'UserService/BeginPasskeyReauth',
+    beginBody: {},
+    ceremonyMethod: 'startAuthentication',
+    finishProcedure: 'UserService/FinishPasskeyReauth',
+  })
+  const reauthProof = finish.reauthProof
+  if (typeof reauthProof !== 'string' || !reauthProof)
+    throw new Error('FinishPasskeyReauth returned no reauthProof')
+  await postConnectInPage(page, hubUrl, 'UserService/DeactivatePasskeyAuth', {
+    reauthProof,
+    newPassword,
+  })
+}
+
+/** Remove a virtual authenticator installed by {@link enableVirtualAuthenticator}. */
+export async function removeVirtualAuthenticator(auth: VirtualAuthenticator): Promise<void> {
+  await auth.cdp.send('WebAuthn.removeVirtualAuthenticator', { authenticatorId: auth.authenticatorId })
+}

--- a/proto/leapmux/v1/auth.proto
+++ b/proto/leapmux/v1/auth.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 package leapmux.v1;
 
+import "google/protobuf/timestamp.proto";
+
 // AuthService handles user authentication.
 // Called by Frontend on Hub via ConnectRPC.
 service AuthService {
@@ -28,6 +30,15 @@ service AuthService {
   // altcha provider. Empty when the selected provider is external
   // (recaptcha_v3 / turnstile) or captcha is disabled.
   rpc GetAltchaChallenge(GetAltchaChallengeRequest) returns (GetAltchaChallengeResponse);
+  // Begin/finish passkey login.
+  rpc BeginPasskeyLogin(BeginPasskeyLoginRequest) returns (BeginPasskeyLoginResponse);
+  rpc FinishPasskeyLogin(FinishPasskeyLoginRequest) returns (FinishPasskeyLoginResponse);
+  // Begin/finish passkey signup (passkey-only, no password).
+  rpc BeginPasskeySignUp(BeginPasskeySignUpRequest) returns (BeginPasskeySignUpResponse);
+  rpc FinishPasskeySignUp(FinishPasskeySignUpRequest) returns (FinishPasskeySignUpResponse);
+  // Self-service password reset (break-glass; clears passkeys).
+  rpc RequestPasswordReset(RequestPasswordResetRequest) returns (RequestPasswordResetResponse);
+  rpc CompletePasswordReset(CompletePasswordResetRequest) returns (CompletePasswordResetResponse);
 }
 
 message LoginRequest {
@@ -42,9 +53,29 @@ message LoginRequest {
   string honeypot = 4;
 }
 
+// Email-verification outcome shared by every login and sign-up response.
+// One message, one contract: a fourth field or a sixth flow touches this
+// message alone instead of five response shapes.
+message EmailVerificationStatus {
+  // True when the hub requires this account to verify an email address
+  // before it is fully active.
+  bool verification_required = 1;
+  // True when the verification email was dispatched. Sign-up is
+  // fail-closed: when verification is required and mail cannot be sent,
+  // the RPC fails and no account remains. On resend paths, false means
+  // the send failed and the frontend should surface a "couldn't send,
+  // try again" message; the pending row was cleared, so an immediate
+  // retry is allowed.
+  bool verification_email_sent = 2;
+  // Earliest time the client may request another verification email. Set
+  // only after a successful send.
+  google.protobuf.Timestamp next_resend_available_at = 3;
+}
+
 message LoginResponse {
   reserved 1; // was: token (now delivered via Set-Cookie)
   User user = 2;
+  EmailVerificationStatus email_verification = 3;
 }
 
 message LogoutRequest {}
@@ -71,12 +102,7 @@ message SignUpRequest {
 message SignUpResponse {
   reserved 1; // was: token (now delivered via Set-Cookie)
   User user = 2;
-  bool verification_required = 3;
-  // True iff the verification email was successfully dispatched. False
-  // means the user account exists but no email was sent (transient mail
-  // outage); the frontend should surface a "Resend" prompt. This flag is
-  // only meaningful when verification_required is true.
-  bool verification_email_sent = 4;
+  EmailVerificationStatus email_verification = 3;
 }
 
 message User {
@@ -89,6 +115,7 @@ message User {
   string pending_email = 7;
   repeated LinkedOAuthProvider oauth_providers = 8;
   bool password_set = 9;
+  int32 passkey_count = 10;
 }
 
 message LinkedOAuthProvider {
@@ -151,6 +178,12 @@ message GetSystemInfoResponse {
   // empty for altcha. The frontend pairs it with captcha_provider to load
   // the right widget.
   string captcha_site_key = 15;
+  // True when passkey ceremonies can run on this hub: a keystore is
+  // configured and the hub has a usable browser origin (public_url or a
+  // TCP listener). Frontend gating: when false, the passkey sign-in and
+  // sign-up options are hidden — every Begin would answer
+  // FailedPrecondition, so showing them would mislead users.
+  bool passkey_enabled = 16;
 }
 
 message GetOAuthProvidersRequest {}
@@ -201,14 +234,75 @@ message GetAltchaChallengeResponse {
 
 message CompleteOAuthSignupResponse {
   User user = 1;
-  // True when an OAuth provider returned an unverified email and the
-  // account requires email verification. The frontend shows the
-  // verify-email screen only when this flag is set, exactly as it does
-  // for SignUp.
-  bool verification_required = 2;
-  // True iff the verification email was successfully dispatched. False
-  // means the user account exists but no email was sent (transient mail
-  // outage); the frontend should surface a "Resend" prompt. This flag
-  // is only meaningful when verification_required is true.
-  bool verification_email_sent = 3;
+  EmailVerificationStatus email_verification = 2;
 }
+
+message BeginPasskeyLoginRequest {
+  string username = 1;
+  string captcha_payload = 2;
+  string honeypot = 3;
+}
+
+message BeginPasskeyLoginResponse {
+  string session_id = 1;
+  string options_json = 2;
+  // Relying party ID for this ceremony's origin; echo it in Signal API calls.
+  string rp_id = 3;
+}
+
+message FinishPasskeyLoginRequest {
+  string session_id = 1;
+  string credential_json = 2;
+}
+
+message FinishPasskeyLoginResponse {
+  User user = 1;
+  EmailVerificationStatus email_verification = 2;
+}
+
+message BeginPasskeySignUpRequest {
+  string username = 1;
+  string display_name = 2;
+  string email = 3;
+  string captcha_payload = 4;
+  string honeypot = 5;
+}
+
+message BeginPasskeySignUpResponse {
+  string session_id = 1;
+  string options_json = 2;
+  // Relying party ID for this ceremony's origin; echo it in Signal API calls.
+  string rp_id = 3;
+}
+
+message FinishPasskeySignUpRequest {
+  string session_id = 1;
+  string credential_json = 2;
+}
+
+message FinishPasskeySignUpResponse {
+  User user = 1;
+  EmailVerificationStatus email_verification = 2;
+}
+
+message RequestPasswordResetRequest {
+  string identifier = 1; // email or username
+  string captcha_payload = 2;
+  string honeypot = 3;
+}
+
+message RequestPasswordResetResponse {}
+
+message CompletePasswordResetRequest {
+  string token = 1;
+  string new_password = 2;
+  // Provider token; see LoginRequest.captcha_payload.
+  string captcha_payload = 3;
+  // Hidden anti-bot field value; see LoginRequest.honeypot.
+  string honeypot = 4;
+}
+
+// Empty on purpose: the caller is an anonymous bearer of the reset token,
+// and the flow ends at the login screen. Returning no account data keeps the
+// response free of information the token does not already carry.
+message CompletePasswordResetResponse {}

--- a/proto/leapmux/v1/auth.proto
+++ b/proto/leapmux/v1/auth.proto
@@ -86,6 +86,15 @@ message GetCurrentUserRequest {}
 
 message GetCurrentUserResponse {
   User user = 1;
+  // The same status the login and sign-up responses carry.
+  //
+  // This is the ONLY response the /verify-email page's own bootstrap
+  // reads, so without it a hard reload of that page starts with the
+  // resend cooldown unset: the countdown restarts at zero, the button
+  // re-enables, and the click gets ResourceExhausted with no timestamp
+  // to restart from. Carrying it here makes the cooldown derivable at
+  // every render instead of surviving exactly one navigation.
+  EmailVerificationStatus email_verification = 2;
 }
 
 message SignUpRequest {

--- a/proto/leapmux/v1/user.proto
+++ b/proto/leapmux/v1/user.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 package leapmux.v1;
 
+import "google/protobuf/timestamp.proto";
 import "leapmux/v1/settings.proto";
 import "leapmux/v1/auth.proto";
 
@@ -21,11 +22,11 @@ service UserService {
   // address. Authenticated; requires a pending verification to exist
   // (FailedPrecondition otherwise). The previous code is invalidated —
   // a fresh 6-character code with a new 30-minute TTL replaces it. Use
-  // this when the original mail was lost / never arrived, or when
-  // SignUpResponse.verification_email_sent came back false.
+  // this when the original mail was lost or never arrived.
   rpc ResendVerificationEmail(ResendVerificationEmailRequest) returns (ResendVerificationEmailResponse);
-  // Change the current user's password. When password_set is false (OAuth-only
-  // users), current_password may be empty.
+  // Change the current user's password. When password_set is false
+  // (OAuth-only with no passkeys), current_password may be empty. When
+  // password_set is false but passkeys exist, reauth_proof is required.
   rpc ChangePassword(ChangePasswordRequest) returns (ChangePasswordResponse);
   // Unlink an OAuth provider from the current user's account.
   rpc UnlinkOAuthProvider(UnlinkOAuthProviderRequest) returns (UnlinkOAuthProviderResponse);
@@ -42,6 +43,15 @@ service UserService {
   rpc ResetUserSetting(ResetUserSettingRequest) returns (ResetUserSettingResponse);
   // Get the current timeout configuration.
   rpc GetTimeouts(GetTimeoutsRequest) returns (GetTimeoutsResponse);
+  // Passkey management
+  rpc BeginPasskeyRegistration(BeginPasskeyRegistrationRequest) returns (BeginPasskeyRegistrationResponse);
+  rpc FinishPasskeyRegistration(FinishPasskeyRegistrationRequest) returns (FinishPasskeyRegistrationResponse);
+  rpc BeginPasskeyReauth(BeginPasskeyReauthRequest) returns (BeginPasskeyReauthResponse);
+  rpc FinishPasskeyReauth(FinishPasskeyReauthRequest) returns (FinishPasskeyReauthResponse);
+  rpc ListPasskeys(ListPasskeysRequest) returns (ListPasskeysResponse);
+  rpc RenamePasskey(RenamePasskeyRequest) returns (RenamePasskeyResponse);
+  rpc DeletePasskey(DeletePasskeyRequest) returns (DeletePasskeyResponse);
+  rpc DeactivatePasskeyAuth(DeactivatePasskeyAuthRequest) returns (DeactivatePasskeyAuthResponse);
 }
 
 message UpdateProfileRequest {
@@ -80,11 +90,15 @@ message ResendVerificationEmailResponse {
   // means the row was refreshed but the mail backend failed; the
   // frontend should surface a "couldn't send, try again" message.
   bool email_sent = 1;
+  google.protobuf.Timestamp next_resend_available_at = 2;
 }
 
 message ChangePasswordRequest {
   string current_password = 1;
   string new_password = 2;
+  // Required when the account has no password yet but has passkeys
+  // (passkey-only). Consumed like other passkey management proofs.
+  string reauth_proof = 3;
 }
 
 message ChangePasswordResponse {}
@@ -126,3 +140,95 @@ message GetTimeoutsResponse {
   int32 agent_startup_timeout_seconds = 2;
   int32 worktree_create_timeout_seconds = 3;
 }
+
+message BeginPasskeyRegistrationRequest {
+  string current_password = 1;
+  string reauth_proof = 2;
+}
+
+message BeginPasskeyRegistrationResponse {
+  string session_id = 1;
+  string options_json = 2;
+  // Relying party ID for this ceremony's origin; echo it in Signal API calls.
+  string rp_id = 3;
+}
+
+message FinishPasskeyRegistrationRequest {
+  string session_id = 1;
+  string credential_json = 2;
+  string friendly_name = 3;
+  string current_password = 4;
+  string reauth_proof = 5;
+}
+
+message FinishPasskeyRegistrationResponse {
+  PasskeyInfo passkey = 1;
+}
+
+message BeginPasskeyReauthRequest {}
+
+message BeginPasskeyReauthResponse {
+  string session_id = 1;
+  string options_json = 2;
+  // Relying party ID for this ceremony's origin; echo it in Signal API calls.
+  string rp_id = 3;
+}
+
+message FinishPasskeyReauthRequest {
+  string session_id = 1;
+  string credential_json = 2;
+}
+
+message FinishPasskeyReauthResponse {
+  string reauth_proof = 1;
+}
+
+message ListPasskeysRequest {}
+
+message ListPasskeysResponse {
+  repeated PasskeyInfo passkeys = 1;
+  // Relying party ID for passkey management on this hub; echo it in Signal
+  // API calls (the delete/deactivate flows have no Begin response).
+  string rp_id = 2;
+}
+
+message PasskeyInfo {
+  string id = 1;
+  string friendly_name = 2;
+  google.protobuf.Timestamp created_at = 3;
+  google.protobuf.Timestamp last_used_at = 4;
+  repeated string transports = 5;
+  // Base64url-encoded WebAuthn credential id (plaintext lookup key). Used by
+  // the browser Signal API after delete; not a secret.
+  string credential_id = 6;
+}
+
+message RenamePasskeyRequest {
+  string id = 1;
+  string friendly_name = 2;
+  // Required when password_set is true.
+  string current_password = 3;
+  // Required when password_set is false (passkey step-up).
+  string reauth_proof = 4;
+}
+
+message RenamePasskeyResponse {
+  PasskeyInfo passkey = 1;
+}
+
+message DeletePasskeyRequest {
+  string id = 1;
+  string current_password = 2;
+  string reauth_proof = 3;
+  string new_password = 4;
+}
+
+message DeletePasskeyResponse {}
+
+message DeactivatePasskeyAuthRequest {
+  string current_password = 1;
+  string reauth_proof = 2;
+  string new_password = 3;
+}
+
+message DeactivatePasskeyAuthResponse {}

--- a/site/content/docs/operating/configuration.md
+++ b/site/content/docs/operating/configuration.md
@@ -206,7 +206,6 @@ Changes fall into two classes, shown by `settings list`:
 | Setting key | Shape | Default | Class |
 | --- | --- | --- | --- |
 | `signup_enabled` | boolean | `false` | hot |
-| `email_verification_required` | boolean | `false` | hot (requires `smtp` first; the write is refused otherwise) |
 | `session_duration_seconds` | integer | `604800` (7d) | hot (minimum 300) |
 | `secure_cookies` | boolean | `false` | hot (changes the cookie name, so it signs everyone out) |
 | `public_url` | string | *(empty)* | hot (scheme+host only, no path) |
@@ -221,14 +220,18 @@ Solo mode omits the settings a single-user Hub has no use for, from `settings li
 
 | Omitted in solo | Because |
 | --- | --- |
-| `signup_enabled`, `email_verification_required` | Solo has no sign-up. |
+| `signup_enabled`, `smtp` | Solo has no sign-up and no outbound mail. |
 | `session_duration_seconds`, `secure_cookies` | Solo has no login, so there is no session and no cookie. |
 | `smtp` | Solo has nowhere to send mail. |
 | `captcha.*`, `rate_limit.*` | Solo enforces neither. |
 
 `public_url` stays: it sets the URL in the startup banner, and the `--hub` address you give a remote Worker.
 
-See [Accounts & Authentication](/docs/using/accounts/) for the sign-up/verification flows, and [Authentication Providers](/docs/operating/authentication-providers/) for OAuth/OIDC.
+See [Accounts & Authentication](/docs/using/accounts/) for sign-up, passkeys, verification, and password-reset flows, and [Authentication Providers](/docs/operating/authentication-providers/) for OAuth/OIDC.
+
+> **Note:** Email verification is not a separate setting. Once the `smtp` block is fully configured (`host` **and** `from_address`), the hub requires verification for new non-admin sign-ups and exposes forgot-password / worker registration email features. Removing or disabling SMTP turns verification off at runtime.
+>
+> **SMTP-enable transition:** users who signed up while SMTP was off keep `email_verified=false` in the database. When an operator later configures SMTP, those accounts are required to verify on the next request until they via `/verify-email` (ResendVerificationEmail issues a pending code against the stored primary email). No data migration is required. Admins stay exempt and are always stored as verified.
 
 ### Bot protection (captcha & rate limits)
 
@@ -602,7 +605,6 @@ leapmux control admin settings set secure_cookies true
 leapmux control admin settings set signup_enabled true
 leapmux control admin settings set smtp '{"host":"smtp.example.com","port":587,"username":"leapmux@example.com","from_address":"no-reply@example.com","tls_mode":"starttls"}'
 leapmux control admin settings set-secret smtp '{"password":"..."}'   # or read from your secret manager
-leapmux control admin settings set email_verification_required true   # requires the smtp key above
 leapmux control admin settings set session_duration_seconds 86400     # sign an idle user out after a day
 ```
 

--- a/site/content/docs/operating/encryption-and-data.md
+++ b/site/content/docs/operating/encryption-and-data.md
@@ -22,6 +22,7 @@ LeapMux keeps three kinds of persistent state:
 | --- | --- | --- |
 | Accounts, workspaces, Workers, sessions, API tokens | Hub database (`hub.db` or your SQL backend) | No (but secrets within it are hashed or encrypted — see below) |
 | OAuth provider client secrets and per-user OAuth access/refresh tokens | Hub database | **Yes** — encrypted with the keystore key |
+| Passkey credential public keys and WebAuthn ceremony session data | Hub database | **Yes** — encrypted with the keystore key (AAD binds each row) |
 | API-token / delegation-token secrets | Hub database | No — stored as HMAC-SHA256 **hashes** (peppered), never as plaintext or reversible ciphertext |
 | Worker public keys (for the E2EE handshake) | Hub database | No — public material, stored in the clear |
 | Agent transcripts, terminal I/O, worktree/session state | Worker's local SQLite (`worker.db`) | No |
@@ -33,15 +34,20 @@ LeapMux keeps three kinds of persistent state:
 
 The keystore encrypts secrets with **XChaCha20-Poly1305** (a 256-bit key, 24-byte random nonce per ciphertext). Each ciphertext records which key version produced it, so the Hub can pick the right key to decrypt as long as that key version is still in the ring.
 
-Exactly three secret types are encrypted at rest in the Hub database:
+Exactly these secret types are encrypted at rest in the Hub database:
 
 - `oauth_providers.client_secret` — the OAuth provider's client secret.
 - `oauth_tokens.access_token` — a user's OAuth access token.
 - `oauth_tokens.refresh_token` — a user's OAuth refresh token.
+- `passkey_credentials.public_key` — the WebAuthn credential public key bytes.
+- `webauthn_sessions.session_data` — ephemeral ceremony state for sign-up, login, registration, and reauth.
+- `webauthn_sessions.payload_json` — passkey-signup draft (username, email, display name) while the ceremony is in flight. Other ceremony kinds store `{}`.
 
 (Short-lived pending-signup OAuth tokens are also encrypted while a signup is in flight.)
 
-The keystore loads its versioned key ring from `encryption.key` (highest version = active) and uses it to encrypt and decrypt exactly those three columns in the Hub database; everything else — accounts, workspaces, Workers, hashed API-token secrets, and Worker public keys — is stored without the key.
+Each passkey and WebAuthn session row uses its own row id as **additional authenticated data**, so ciphertext cannot be swapped between rows.
+
+The keystore loads its versioned key ring from `encryption.key` (highest version = active) and uses it to encrypt and decrypt those columns in the Hub database; everything else — accounts, workspaces, Workers, hashed API-token secrets, passkey metadata that is not the public key (friendly names, credential ids, sign counts), and Worker public keys for E2EE — is stored without the key.
 
 The key lives in a separate file from the database, so a copy of the database alone leaves the encrypted OAuth secrets readable only as ciphertext — which is why the two must be backed up together.
 
@@ -132,7 +138,7 @@ Follow these steps in order. The `remove` step is guarded — it refuses to dele
    # Re-encrypted 7 secrets to key version 2.
    ```
 
-   This walks every OAuth provider secret and OAuth token still encrypted under an older version, decrypts it, and rewrites it under the active version. Rows already at the active version are skipped.
+   This walks every OAuth provider secret, OAuth token, and passkey credential public key still encrypted under an older version, decrypts it, and rewrites it under the active version. Rows already at the active version are skipped.
 
 4. **(Optional) Remove the retired version** once nothing references it, then restart the Hub.
 
@@ -143,7 +149,7 @@ Follow these steps in order. The `remove` step is guarded — it refuses to dele
    sudo systemctl restart leapmux-hub
    ```
 
-> **Warning:** `remove` permanently destroys a key version, so any ciphertext still encrypted under it would become undecryptable. As a guardrail, `remove` opens the database and **refuses** to delete a version that still encrypts OAuth provider secrets or OAuth tokens — it reports what still references the version and tells you to run `reencrypt` first. It also refuses to delete the **active** version (`cannot remove active key version N`) and errors if the version is not in the ring (`keystore: key version N not in ring`). `--version` is required and must be `>= 1`. Transient `pending_oauth_signups` are intentionally outside the guard — they auto-expire, so a half-finished signup simply fails and the user retries.
+> **Warning:** `remove` permanently destroys a key version, so any ciphertext still encrypted under it would become undecryptable. As a guardrail, `remove` opens the database and **refuses** to delete a version that still encrypts OAuth provider secrets, OAuth tokens, or passkey credential public keys — it reports what still refers to the version and tells you to run `reencrypt` first. It also refuses to delete the **active** version (`cannot remove active key version N`) and fails if the version is not in the ring (`keystore: key version N not in ring`). `--version` is required and must be `>= 1`. Transient rows are intentionally outside the guard: `pending_oauth_signups` and `webauthn_sessions` auto-expire, so a half-finished OAuth signup or WebAuthn ceremony simply fails and the user retries. Passkey `public_key` rows are scanned; `webauthn_sessions.session_data` is encrypted but never reencrypted because sessions expire within minutes.
 
 ### Rotation and API tokens
 

--- a/site/content/docs/operating/security.md
+++ b/site/content/docs/operating/security.md
@@ -49,7 +49,7 @@ The two columns below are the heart of the threat model. Treat the left column a
 
 | The Hub **can** see | The Hub **cannot** see |
 |---------------------|------------------------|
-| Account metadata: user names, emails, password hashes, OAuth tokens, session tokens | Agent chat transcripts, tool-call arguments, or tool outputs |
+| Account metadata: user names, emails, password hashes, OAuth tokens, session tokens, passkey credential metadata (friendly names, credential IDs, encrypted public keys) | Agent chat transcripts, tool-call arguments, or tool outputs |
 | Account and workspace records | Terminal I/O, shell history, or PTY state |
 | Workspace **titles**, tab positions, and tiling layout geometry | File contents, diffs, or git status |
 | Worker registration data: Worker ID, composite public keys, online status, last-seen time | Worker hostname, OS, or filesystem paths (sent only inside the encrypted channel) |
@@ -210,9 +210,29 @@ The bundled Worker that solo and dev modes auto-register is created in-process a
 
 The **desktop app** avoids the exposure differently: it always starts its in-process Hub with the TCP listener disabled, reaching it over a local Unix socket (named pipe on Windows) instead. There is no `--no-tcp` flag or setting — it is how the desktop app is built, and `leapmux solo` on the command line does not do it. So the desktop app opens no loopback port for its Hub, and the non-loopback warning above cannot apply to it. Tunnels you create yourself still bind a loopback TCP port, by design.
 
+## Passkey step-up
+
+Passkey management — adding, removing, or disabling passkeys — is treated as a **privileged account change**, not a casual settings tweak. The hub enforces a step-up check before any of these mutations land:
+
+| Your account today | Step-up required |
+| --- | --- |
+| Password set | Confirm your **current password**. |
+| Passkey-only (no password) | Authenticate with an **existing passkey** (a short-lived reauth proof). |
+| Removing your last passkey | Passkey step-up **and** setting a new password (you must retain *some* sign-in method). |
+| Disabling passkey sign-in entirely | Password confirmation, or passkey step-up plus setting a password when you have none. |
+
+Self-service **password reset** and admin **reset-password** both **delete every passkey** on the account. That is deliberate: a password reset is break-glass recovery, and leaving old passkeys registered would let someone who still holds a device sign back in without knowing the new password.
+
+WebAuthn ceremony state (in-flight sign-up, login, and reauth handshakes) is encrypted at rest with the same keystore as passkey public keys; see [Encryption & Data](/docs/operating/encryption-and-data/).
+
 ## At-rest encryption (separate from E2EE)
 
-Distinct from the channel E2EE above, the Hub encrypts a small set of stored secrets **at rest** using a versioned XChaCha20-Poly1305 key ring kept in an `encryption.key` file (mode `0600`, default `<DataDir>/encryption.key`, auto-generated on first run). Exactly three things are encrypted, all of them OAuth secrets: the OAuth provider client secrets, per-user OAuth access/refresh tokens, and the access/refresh tokens held for a pending signup. If the Hub's database is exfiltrated without the key file, those stay unreadable.
+Distinct from the channel E2EE above, the Hub encrypts a small set of stored secrets **at rest** using a versioned XChaCha20-Poly1305 key ring kept in an `encryption.key` file (mode `0600`, default `<DataDir>/encryption.key`, auto-generated on first run). Exactly these are encrypted:
+
+- OAuth provider client secrets and per-user OAuth access/refresh tokens (including pending-signup tokens).
+- **Passkey credential public keys** and **WebAuthn ceremony session payloads** (each row's ciphertext is bound to that row's id as additional authenticated data).
+
+If the Hub's database is exfiltrated without the key file, those fields stay unreadable.
 
 Be clear on what this does **not** cover, since "encrypted at rest" invites over-reading. It is not the Frontend↔Worker channel keys, and it does not touch agent or terminal content (which never reaches the Hub at all). Other credentials in the database are protected by their storage form rather than this key: passwords are Argon2id hashes and API/delegation token secrets are HMAC hashes — neither is reversible, so neither needs encrypting. Worker auth tokens, registration keys, and session tokens are stored **as-is**.
 

--- a/site/content/docs/reference/troubleshooting.md
+++ b/site/content/docs/reference/troubleshooting.md
@@ -19,7 +19,7 @@ A Worker (`leapmux worker`) dials *out* to the Hub and holds a single bidirectio
 The Worker process prints an error and exits. The error says that the Worker is unregistered, and it tells you to pass a registration key from the hub UI.
 
 **Cause**
-The Worker has no saved credentials (no `state.json` in its data dir) and you started it without a `--registration-key`. Bare Workers cannot self-register — registration is single-shot and gated entirely by possessing a valid key.
+The Worker has no saved credentials (no `state.json` in its data dir) and you started it without a `--registration-key`. Bare Workers cannot self-register — registration is single-shot and controlled entirely by possessing a valid key.
 
 **Fix**
 Mint a key in the Hub UI: open the sidebar **Workers** section, click the **+** (Register worker) button, and copy the generated command. It already includes the right Hub URL and key:
@@ -240,7 +240,24 @@ Sign-in is refused, and the form says only that the credentials are invalid.
 For security, the Hub returns the identical error for both an unknown username and a wrong password — there's no way to tell which from the message. Usernames are lowercase slugs; passwords are 8-128 printable ASCII characters, and a password may hold spaces.
 
 **Fix**
-Double-check the exact username (lowercase, hyphens, no spaces). If you've lost the password, have an admin reset it with `leapmux control admin user reset-password` (see [User passwords](/docs/operating/control-cli/#user-passwords)), which runs over RPC against the live Hub. When the Hub is stopped, `leapmux recover password reset` does the same work offline (see [Recovery](/docs/operating/recover/)); that command opens the Hub's database directly, so run it on the Hub host with the Hub stopped. Either way, every session and token the account holds is revoked. Note: solo mode has no login at all — if you expected a login page in solo mode, you won't get one; it auto-authenticates.
+Double-check the exact username (lowercase, hyphens, no spaces). If you've lost the password, have an admin reset it with `leapmux control admin user reset-password` (see [User passwords](/docs/operating/control-cli/#user-passwords)), which runs over RPC against the live Hub. When the Hub is stopped, `leapmux recover password reset` does the same work offline (see [Recovery](/docs/operating/recover/)); that command opens the Hub's database directly, so run it on the Hub host with the Hub stopped. Either way, every session, token, **and passkey** the account holds is revoked. Note: solo mode has no login at all — if you expected a login page in solo mode, you won't get one; it auto-authenticates.
+
+### Passkey sign-in fails or the authenticator never appears
+
+**Symptom**
+Choosing **Passkey** on the login or signup form does nothing useful, the browser shows a WebAuthn error, or the Hub refuses the ceremony.
+
+**Cause and fix**
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Browser never opens a passkey prompt | The page origin does not match the Hub's relying-party ID | Set `public_url` to the exact origin users open in the browser (`leapmux control admin settings set public_url https://hub.example.com`). Localhost and `127.0.0.1` are different RPIDs. |
+| "origin header is required" / ceremony fails immediately | The browser request omitted `Origin` | Use a normal browser navigation to the Hub UI; do not strip `Origin` in a reverse proxy for `/leapmux.v1.*` RPCs. |
+| Passkey-only account cannot add another passkey | Step-up reauth proof was already consumed | Complete passkey reauth again, then finish registration in the same flow. Do not reuse an old proof. |
+| Passkey login works but app access is blocked | SMTP is configured and the email is still unverified | Complete `/verify-email` (or use **Resend code**). Passkey login does not skip email verification. |
+| After password reset, passkey login fails | Expected: reset clears all passkeys | Sign in with the new password, then add passkeys again under **Profile → Passkeys**. |
+
+Self-service password reset (`/forgot-password`) also clears every passkey on the account when the reset completes — the same break-glass rule as admin and offline password reset.
 
 ### Almost every action is refused until you verify your email
 
@@ -248,10 +265,10 @@ Double-check the exact username (lowercase, hyphens, no spaces). If you've lost 
 After signing up you're stuck — almost every action is refused because your email is unverified, and you land on the **"Verify your email"** page.
 
 **Cause**
-The Hub runs with `email_verification_required` enabled, so non-admin users with an unverified email may only verify, log out, or change their email until they verify. Verification uses a 6-character code (display form `XXX-XXX`) that expires in 30 minutes with a 5-attempt budget.
+The hub has SMTP configured, so non-admin users with an unverified email may only verify, log out, or change their email until they verify. Verification uses a 6-character code (display form `XXX-XXX`) that expires in 30 minutes with a 5-attempt budget.
 
 **Fix**
-Enter the code from the verification email, or click the link in it. If you didn't receive it, use **Resend code** (60-second cooldown between resends). Email features require SMTP to be configured on the Hub — if the operator hasn't configured SMTP (`leapmux control admin settings set smtp …`), verification emails can't be sent at all (and enabling `email_verification_required` without SMTP is refused at write time). See [Configuration](/docs/operating/configuration/).
+Enter the code from the verification email, or click the link in it. If you didn't receive it, use **Resend code** (60-second cooldown between resends). Email features require SMTP to be configured on the Hub — if the operator hasn't configured SMTP (`leapmux control admin settings set smtp …`), verification is off and this requirement does not apply. See [Configuration](/docs/operating/configuration/).
 
 ### OAuth sign-in fails or the provider isn't shown
 

--- a/site/content/docs/using/accounts.md
+++ b/site/content/docs/using/accounts.md
@@ -62,28 +62,37 @@ The form fields are the same as setup:
 | --- | --- |
 | **Username** | Required. Lowercase slug, 1–32 characters. See [Username rules](#username-rules). |
 | **Display Name** | Optional; falls back to your username if left blank. |
-| **Email** | Optional, unless your operator requires verification. |
+| **Email** | Required. |
 | **New Password** | 8–128 printable ASCII characters, spaces included. See [Password requirements](#password-requirements). |
 | **Confirm Password** | Must match. |
+| **Sign-up method** | **Password** (default) or **Passkey**. Passkey sign-up registers a WebAuthn credential instead of setting a password. |
 
-The submit button reads **Sign up** (and **Signing up...** while submitting). It stays disabled until you have entered a username and a valid, matching password. A footer link, **"Already have an account? Sign in"**, takes you to the login page.
+The submit button reads **Sign up** or **Sign up with passkey** (and **Signing up...** while submitting). It stays disabled until you enter a username, a valid email, and (for password sign-up) a valid, matching password. A footer link, **"Already have an account? Sign in"**, takes you to the login page.
 
-If your operator has configured OAuth/OIDC providers, a list of provider buttons appears above the form under the verb **"Sign up with"** (for example, **"Sign up with GitHub"**), followed by the divider **"or create an account with email"**. See [Signing in with OAuth / OIDC](#signing-in-with-oauth--oidc).
+If your operator configures OAuth/OIDC providers, a list of provider buttons appears above the form under the verb **"Sign up with"** (for example, **"Sign up with GitHub"**), followed by the divider **"or create an account with email"**. See [Signing in with OAuth / OIDC](#signing-in-with-oauth--oidc).
 
-What happens after you submit depends on whether email verification is required:
+What happens after you submit depends on whether the hub has SMTP configured (see [Email verification](#email-verification)):
 
-- **Verification not required:** you are signed in immediately and taken to `/`.
-- **Verification required:** LeapMux tells you to check your email, and routes you to the email-verification screen. A failed verification email does **not** undo your signup — your account exists and you can request a fresh code.
+- **SMTP not configured:** you are signed in immediately and taken to `/`. Your email is stored as unverified in the database; the runtime requirement stays off until SMTP is configured.
+- **SMTP configured:** LeapMux sends a verification email and routes you to the email-verification screen. Signup is **fail-closed**: if the verification email cannot be sent, the account is not created and you see an error (retry when mail works).
 
 > **Note:** The username `solo` is rejected in all signup paths, and `admin` is additionally reserved for public signup and OAuth completion (it is allowed only in `/setup`). Self-service signups are never administrators.
 
 ## Logging in
 
-Visit `/login`. The page is headed **"LeapMux"** and has two fields — **Username** and **Password**.
+Visit `/login`. The page is headed **"LeapMux"** and starts with a **Username** field.
 
-Click **Sign in** (**Signing in...** while it works). The button is disabled until both fields are filled.
+A **Sign-in method** chooser always offers **Password** and **Passkey** (LeapMux does not reveal which methods an account supports before you submit):
+
+| Method | What you do |
+| --- | --- |
+| **Password** | Fill **Password**, then click **Sign in**. |
+| **Passkey** | Click **Sign in with passkey** and complete the WebAuthn prompt in your browser or device. |
+
+Click **Sign in** or **Sign in with passkey** (**Signing in...** while it works). The button stays disabled until the username is filled and any captcha challenge is solved. An account that cannot use the method you picked returns a generic failure (same shape as a wrong password).
 
 - A **"Sign up"** link appears in the footer only when self-service signup is enabled.
+- **Forgot password?** appears under the password form when the hub has SMTP configured (see [Forgot password](#forgot-password)).
 - If OAuth providers are configured, their buttons appear above the form under the verb **"Sign in with"** with an **"or"** divider.
 - If you were redirected to login from a protected page, you are sent back there after signing in (LeapMux only honors a same-site relative path, as an open-redirect safeguard).
 
@@ -91,7 +100,9 @@ Click **Sign in** (**Signing in...** while it works). The button is disabled unt
 
 ## Email verification
 
-Email verification is optional and controlled by the operator's `email_verification_required` setting (off by default; enabling it requires an SMTP server to be configured). When it is on, you must verify your email before you can use most of LeapMux.
+Email verification is **automatic whenever the operator configures SMTP** on the hub (`host` and `from_address` both set). There is no separate `email_verification_required` toggle — configuring mail is what turns verification on. When SMTP is absent, sign-ups skip verification entirely.
+
+When verification applies, you must verify your email before you can use most of LeapMux.
 
 ### Verifying your email
 
@@ -120,11 +131,58 @@ The code alphabet deliberately omits look-alike characters (no `0`, `1`, `I`, `O
 
 > **Tip:** If you wait too long and your code expires, press **Resend code** to get a fresh one. The screen confirms that a fresh code went to your inbox.
 
-> **Warning:** While verification is required and you are an unverified non-admin user, you can only view your own account, log out, change/verify your email, and resend the code. LeapMux refuses every other action until you verify. Administrators are exempt.
+> **Warning:** While verification applies and you are an unverified non-admin user, you can only view your own account, log out, change/verify your email, and resend the code. LeapMux refuses every other action until you verify. Administrators are exempt.
+
+## Passkeys
+
+Passkeys are WebAuthn credentials stored by your browser or device. They let you sign in without typing a password, and you can register more than one (for example, a laptop and a phone).
+
+### Signing up with a passkey
+
+On the **Sign Up** page, choose **Passkey** under **Sign-up method**, fill in username, display name, and email, then click **Sign up with passkey**. Your browser prompts you to create the credential. The account has **no password** until you set one later from your profile.
+
+If SMTP is configured, passkey sign-up follows the same verification path as password sign-up: you land on **Verify your email** until the code is accepted.
+
+### Signing in with a passkey
+
+Enter your username on the login page, choose **Passkey** in the **Sign-in method** chooser, then click **Sign in with passkey** and approve the WebAuthn prompt.
+
+You can still choose **Password** when your account has a password, even if passkeys are also registered. An account that cannot use the method you picked returns a generic failure.
+
+### Managing passkeys in your profile
+
+Open **Preferences → Account** (or **Profile** from the app menu). The **Passkeys** section lists every credential, when it was last used, and actions to rename or remove one.
+
+| Action | What it requires |
+| --- | --- |
+| **Add passkey** | Your current password, if you have one. OAuth-only accounts (or accounts with a verified email) can add a first passkey with your session alone. Passkey-only accounts verify with an existing passkey first. |
+| **Rename passkey** | Same step-up as add/remove: password or passkey verification. |
+| **Remove passkey** | Your password, or passkey step-up when you have no password. Removing your **last** passkey requires setting a password first. |
+| **Disable passkey sign-in** | Removes **all** passkeys. Passkey-only accounts must set a password as part of this flow. |
+
+These sensitive changes use a **step-up** check: password confirmation when you have a password, or a fresh passkey authentication when you do not.
+
+> **Note:** A stolen session on an OAuth-only account can register a first passkey. Completing **Forgot password** (when SMTP is configured and your email is verified) clears every passkey. Prefer setting a password soon after OAuth signup if you want that break-glass path.
+
+## Forgot password
+
+When SMTP is configured, the login page shows **Forgot password?** under the password form. It is hidden for passkey-only sign-in (there is no password to reset on that path).
+
+1. Open **Forgot password?** or visit `/forgot-password`.
+2. Enter your **email or username**.
+3. Click **Send reset link**.
+
+If an account with that address exists and its email is verified (when verification applies), LeapMux emails a one-hour reset link. The response is always the same whether or not an account matched — this prevents username probing.
+
+4. Open the link (or paste the token from `/reset-password?token=…`) and choose a new password.
+
+Completing a self-service reset **clears every passkey** on the account, revokes other sessions, and revokes API/delegation tokens — the same break-glass posture as an admin password reset. Set a new passkey afterward if you still want passwordless sign-in.
+
+If you signed up with a passkey and never set a password, use **Disable passkey sign-in** in your profile to add a password instead of the forgot-password flow.
 
 ## Signing in with OAuth / OIDC
 
-If your operator has configured one or more external identity providers — GitHub, Google, Apple, or a generic OIDC provider — you can sign in or sign up with them instead of (or in addition to) a password. Configuring providers is an operator task; see [Authentication Providers](/docs/operating/authentication-providers/).
+If your operator configures one or more external identity providers — GitHub, Google, Apple, or a generic OIDC provider — you can sign in or sign up with them instead of (or in addition to) a password. Configuring providers is an operator task; see [Authentication Providers](/docs/operating/authentication-providers/).
 
 ### The flow
 
@@ -228,9 +286,14 @@ Open the **"Profile"** dialog from the app to manage your account. It has up to 
 
 ### Password
 
-- The button reads **Change Password** if you already have a password, or **Set Password** if your account is OAuth-only.
-- If you have a password, a **Current Password** field appears and is required. OAuth-only users can set a password without one.
+- The button reads **Change Password** if you already have a password, or **Set Password** if your account is OAuth-only or passkey-only.
+- If you have a password, a **Current Password** field appears and is required.
+- Passkey-only accounts (no password, but at least one passkey) must click **Verify with passkey** before **Set Password**. OAuth-only accounts with zero passkeys can set a first password without that step.
 - On success the dialog confirms that it changed the password, or that it set the first one.
+
+### Passkeys
+
+See [Passkeys](#passkeys) above for the full passkey management surface in this dialog.
 
 ### Linked Accounts
 
@@ -243,5 +306,5 @@ Open the **"Profile"** dialog from the app to manage your account. It has up to 
 
 - [Settings & Preferences](/docs/using/settings/) — the full Profile dialog and other preferences.
 - [Authentication Providers](/docs/operating/authentication-providers/) — configuring OAuth/OIDC as an operator.
-- [Running LeapMux](/docs/operating/running-leapmux/) and [Configuration](/docs/operating/configuration/) — choosing a run mode and the `signup_enabled` / `email_verification_required` settings.
+- [Running LeapMux](/docs/operating/running-leapmux/) and [Configuration](/docs/operating/configuration/) — choosing a run mode, the `signup_enabled` setting, and SMTP (which controls email verification and password reset).
 - [Security & Threat Model](/docs/operating/security/) — what authentication does and does not protect.


### PR DESCRIPTION
## Motivation

A LeapMux account supported passwords and OAuth. That left three gaps.

There was no phishing-resistant credential: a leaked or guessed password was enough to sign in. There was no self-service password recovery, so a user who forgot a password went through an administrator or the offline break-glass CLI. And email verification lived behind an `email_verification_required` setting that an administrator kept in sync with the hub's actual mail capability by hand, so the setting could demand a verification that no relay could deliver.

This change makes passkeys a first-class credential with step-up protection for the management actions that can lock a user out, adds end-to-end self-service password reset, and derives email verification from SMTP configuration so the hub never demands a verification it cannot send.

## Modifications

- **New `webauthn` package** (`backend/internal/hub/webauthn/`): it derives the relying-party parameters per allowlisted origin with a strict full-origin match, so an origin the hub does not serve is refused at Begin with a clear error instead of failing at Finish after the user completed a biometric prompt; an originless desktop-local hub reports passkeys as cleanly unavailable. It runs the signup, login, registration, and reauth ceremonies over encrypted session rows, encrypts each stored public key under its own AAD, and detects a cloned authenticator by a non-advancing sign count.
- **New storage**: `passkey_credentials` and `webauthn_sessions` land identically on sqlite, postgres, and mysql, and `users` gains the pending password-reset columns. Ceremony rows are single-use through a conditional consume, so a Finish call cannot replay. New `storetest` conformance suites run every one of these against all nine backends.
- **Passkey RPCs and step-up**: `AuthService` gains passkey login and sign-up; `UserService` gains registration, reauth, list, rename, delete, and deactivate. A management action needs a step-up credential — a password for an account that has one, a single-use reauth proof for a passkey-only account. The step-up is verified outside the write transaction, because Argon2 and attestation parsing must never hold the SQLite writer lock, and it is re-derived from the locked row inside the transaction so a credential that changed in the window cannot authorize the write. Deleting the last passkey on a passkey-only account requires a new password and pivots to a deactivation that revokes other sessions and tokens.
- **Self-service password reset**: a SHA-256-hashed single-use token with a one-hour expiry, a per-account resend cooldown, and an attempt budget charged in SQL before Argon2 runs. Every response is uniformly empty, so the endpoint is not an account-enumeration oracle. A completed reset clears every passkey, and the same teardown runs from the admin reset and the offline break-glass path.
- **Email verification follows SMTP**: `createUserInTx` is now the one transaction every account-creation flavor shares (admin, password, OAuth, passkey), and it owns every account-creation invariant — an admin is always `email_verified`, an admin's address is promoted rather than left behind a verification the account can never reach, and a claimed address clears every competing pending row. A sign-up whose verification mail cannot be sent rolls the account back rather than leaving one that can never verify. A failed send on a later resend drops only the undelivered code and keeps the pending address, so the retry it invites is never blocked.
- **Rate limits, error classification, and key management**: a new `OpPasskeyManagement` budget covers all seven management RPCs, and the change-password budget now also counts a rejected reauth proof. One classifier maps every WebAuthn ceremony error to a connect code, so a cancelled platform prompt and an unserved origin answer the same way on every surface. `Login` refuses a passkey-only or OAuth-only account with the same answer as an unknown user, which closes an enumeration vector. `recover reencrypt` migrates passkey public keys, and key removal refuses while a passkey row still references the version.
- **Frontend**: passkey sign-in and sign-up behind a password/passkey chooser, full passkey management in Profile Settings, and new forgot-password and reset-password pages. A dismissed OS passkey prompt is a no-op rather than a raw spec-linked error banner. The resend cooldown survives a page reload, because `GetCurrentUser` now carries it. The captcha field mints a fresh challenge when the chooser changes the bound action, which the hub would otherwise refuse. The OAuth completion form lets a user supply an address that an untrusted provider omitted, instead of ending the sign-up with no field that can.
- **Bug fixes to pre-existing code**: `sanitizeRedirectURI` now refuses two open-redirect spellings a browser reads as an authority but Go's URL parser does not — `/\host`, where a WHATWG parser reads the backslash as a slash, and a control byte injected before `//host`, which `http.Redirect` passes through verbatim. The MySQL verification-attempt query had its SET clauses in an order that made the force-expiry fire one charge early on MySQL alone, because MySQL reads an already-updated column in a later clause; sqlite and postgres evaluate against the pre-update row and were unaffected. `RequestEmailChange` had no cooldown, no rate limit, and no captcha, so a signed-in user could send unlimited verification mail to any address; the mint is now conditional in SQL.

**Breaking changes** (in-repo callers are all updated):

- Every store method that compares against "now" takes an explicit `now time.Time`, and the attempt-budget methods also take `maxAttempts int64`, replacing a database-side `NOW()`/`strftime('now')` or an optional struct field. The compiler now refuses a call that omits the instant, and a fake clock replaces a real sleep in the tests.
- `SetPendingEmail` and the new `SetPendingPasswordReset` return `(bool, error)` and write only when the resend cooldown has elapsed.
- `NewUserService` takes a `*keystore.Keystore`; `NewAdminUserService` takes a `*settings.Manager`.
- `settings.KeyEmailVerificationRequired` and the `SMTPConfigured` cross-key rule are removed. `EmailVerificationEffective` is now `KeySMTP.Of(s).Enabled()`.
- Proto: six new `AuthService` RPCs and eight new `UserService` RPCs. A shared `EmailVerificationStatus` message replaces the copy-pasted verification field pairs on `LoginResponse`, `SignUpResponse`, `CompleteOAuthSignupResponse`, and `GetCurrentUserResponse`, and rides the two passkey finish responses. `User` gains `passkey_count`, `GetSystemInfoResponse` gains `passkey_enabled`, and `ChangePasswordRequest` gains `reauth_proof`.
- New dependency `go-webauthn/webauthn v0.17.4` on the backend and `@simplewebauthn/browser` on the frontend; the license notice is regenerated.

## Result

A user can register a passkey and sign in with a device biometric or a security key, instead of a password or alongside one, and manage those passkeys from Profile Settings — add, rename, remove, or disable passkey sign-in — behind a password confirmation or a second passkey prompt. Removing the last passkey on a passkey-only account walks the user through setting a password first, so the account cannot lock itself out.

A user who forgets a password resets it from the login page through a single-use emailed link. The reset revokes other sessions and tokens and clears every passkey on the account.

An operator no longer maintains an email-verification toggle. Verification is on exactly when SMTP is configured, and a sign-up whose verification mail cannot be delivered fails rather than leaving an account that can never verify. Passkey material and ceremony data are encrypted at rest, and the key-rotation and key-removal commands account for them.

Three Playwright suites drive the passkey lifecycle, the password reset, and the SMTP-controlled verification against a real hub, using a virtual WebAuthn authenticator and a loopback SMTP capture relay. The accounts, security, configuration, encryption, and troubleshooting documentation describes all of it.
