### PR TITLE
fix(frontend): Remove the static boot splash on client mount

### DIFF
--- a/frontend/src/entry-client.test.ts
+++ b/frontend/src/entry-client.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  BOOT_SPLASH_LABEL,
+  BOOT_SPLASH_STATIC_ID,
+  BOOT_SPLASH_TEST_ID,
+} from '~/lib/bootSplashTheme'
+
+/**
+ * The entry owns the boot handoff: it removes the static splash only after
+ * `mount()` returns. When mount throws, the splash must stay in the document,
+ * so the boot watchdog still owns that failure class. These tests evaluate
+ * the real entry module with `@solidjs/start/client` (and the entry's other
+ * side-effectful imports) mocked, so the module body runs in jsdom exactly as
+ * it runs in the browser. A source-text order pin used to guard this; it
+ * false-failed on a reformat and missed a removal moved into a `catch`, so
+ * the behavior is pinned directly instead.
+ */
+describe('entry-client boot handoff', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    document.body.innerHTML = `<div id="app"><div id="${BOOT_SPLASH_STATIC_ID}" data-testid="${BOOT_SPLASH_TEST_ID}"><p>${BOOT_SPLASH_LABEL}</p></div></div>`
+    vi.doMock('@solidjs/start/client', () => ({
+      mount: vi.fn(),
+      StartClient: () => null,
+    }))
+    vi.doMock('~/components/common/Toast', () => ({ showWarnToast: vi.fn() }))
+    vi.doMock('~/lib/ignorableErrorEvents', () => ({ installIgnorableErrorSuppressor: vi.fn() }))
+    vi.doMock('~/lib/installGlobalErrorSink', () => ({ installGlobalErrorSink: vi.fn() }))
+    vi.doMock('~/lib/renderPipelineWarmup', () => ({ scheduleRenderPipelineWarmup: vi.fn() }))
+  })
+
+  afterEach(() => {
+    vi.doUnmock('@solidjs/start/client')
+    vi.doUnmock('~/components/common/Toast')
+    vi.doUnmock('~/lib/ignorableErrorEvents')
+    vi.doUnmock('~/lib/installGlobalErrorSink')
+    vi.doUnmock('~/lib/renderPipelineWarmup')
+    document.body.replaceChildren()
+  })
+
+  it('removes the static splash after mount', async () => {
+    await import('~/entry-client')
+    expect(document.getElementById(BOOT_SPLASH_STATIC_ID)).toBeNull()
+  })
+
+  it('keeps the static splash for the watchdog when mount throws', async () => {
+    vi.doMock('@solidjs/start/client', () => ({
+      mount: () => {
+        throw new Error('entry graph fault')
+      },
+      StartClient: () => null,
+    }))
+    await expect(import('~/entry-client')).rejects.toThrow('entry graph fault')
+    expect(document.getElementById(BOOT_SPLASH_STATIC_ID)).not.toBeNull()
+  })
+})

--- a/frontend/src/entry-client.tsx
+++ b/frontend/src/entry-client.tsx
@@ -1,6 +1,7 @@
 // @refresh reload
 import { mount, StartClient } from '@solidjs/start/client'
 import { showWarnToast } from '~/components/common/Toast'
+import { removeStaticBootSplash } from '~/lib/bootSplashTheme'
 import { installIgnorableErrorSuppressor } from '~/lib/ignorableErrorEvents'
 import { installGlobalErrorSink } from '~/lib/installGlobalErrorSink'
 import { scheduleRenderPipelineWarmup } from '~/lib/renderPipelineWarmup'
@@ -37,6 +38,10 @@ export default function EntryClient(): null {
 }
 
 mount(() => <StartClient />, document.getElementById('app')!)
+
+// The SPA client mount leaves the static document splash in `#app` (see
+// removeStaticBootSplash for why); the entry removes it here, after mount.
+removeStaticBootSplash()
 
 // Warm the render workers (WASM engine, first grammar, remark processor) and
 // sweep the persisted render-artifact store once the browser is idle, so the

--- a/frontend/src/entry-server.tsx
+++ b/frontend/src/entry-server.tsx
@@ -58,9 +58,9 @@ export default createHandler(() => (
           <meta name="apple-mobile-web-app-capable" content="yes" />
           <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
           {/*
-            Zero-JS splash polarity + html/body fill for the Solid mount gap.
-            `bootSplashDocumentCss` is the only splash stylesheet — Solid's
-            `BootSplash` matches via `[data-testid]`.
+            Zero-JS splash polarity + html/body fill until the app stylesheet
+            takes over. `bootSplashDocumentCss` is the only splash stylesheet
+            — Solid's `BootSplash` matches via `[data-testid]`.
           */}
           <style>{bootSplashDocumentCss()}</style>
           {/*
@@ -79,13 +79,14 @@ export default createHandler(() => (
         </head>
         <body>
           {/*
-            Static boot splash (no SSR): Go serves this HTML as-is. Solid's
-            client mount replaces `#app` contents. Copy comes from
-            `~/lib/bootSplashTheme` — same module as `BootSplash`.
+            Static boot splash (no SSR): Go serves this HTML as-is. The SPA
+            mount appends into `#app` and clears nothing, so the client entry
+            removes this node after mount — see `removeStaticBootSplash` in
+            `~/lib/bootSplashTheme` (same module as `BootSplash`).
 
             `id="boot-splash"` is the success signal for
-            `bootFailureWatchdogScript`: mount removes it. Solid's fallback
-            splash keeps only `data-testid`.
+            `bootFailureWatchdogScript`: the client entry removes it. Solid's
+            fallback splash keeps only `data-testid`.
           */}
           <div id="app">
             <div

--- a/frontend/src/lib/bootSplashTheme.test.ts
+++ b/frontend/src/lib/bootSplashTheme.test.ts
@@ -19,6 +19,7 @@ import {
   bootSplashLight,
   bootThemeScript,
   parseBootPrefsThemeMode,
+  removeStaticBootSplash,
   resolveBootPolarity,
 } from './bootSplashTheme'
 
@@ -370,7 +371,8 @@ describe('bootFailureWatchdogScript', () => {
 
   it('does not treat a Solid BootSplash (testid only) as a failed static boot', () => {
     vi.useFakeTimers()
-    // Solid mount replaced #app: static id is gone, Suspense splash remains.
+    // Static id is gone (in production the entry removes it); the Suspense
+    // splash keeps only the testid.
     document.body.innerHTML = `<div id="app"><div data-testid="${BOOT_SPLASH_TEST_ID}" role="status"><p>${BOOT_SPLASH_LABEL}</p></div></div>`
     runWatchdog()
 
@@ -379,7 +381,7 @@ describe('bootFailureWatchdogScript', () => {
     expect(document.querySelector('[data-testid="boot-splash"]')).toBeInTheDocument()
   })
 
-  it('finishes when Solid mount removes the static splash before the timeout', async () => {
+  it('finishes when the static splash is removed before the timeout', async () => {
     vi.useFakeTimers()
     mountStaticSplash()
     runWatchdog()
@@ -410,6 +412,27 @@ describe('bootFailureWatchdogScript', () => {
 
     vi.advanceTimersByTime(BOOT_SPLASH_FAIL_TIMEOUT_MS + 1)
     expect(document.querySelector('[data-boot-failed]')).toBeNull()
+  })
+})
+
+describe('removeStaticBootSplash', () => {
+  afterEach(() => {
+    document.body.replaceChildren()
+  })
+
+  it('removes the static splash and leaves the mounted tree alone', () => {
+    document.body.innerHTML = `<div id="app"><div id="${BOOT_SPLASH_STATIC_ID}" data-testid="${BOOT_SPLASH_TEST_ID}"><p>${BOOT_SPLASH_LABEL}</p></div><div data-shell></div></div>`
+    removeStaticBootSplash()
+    expect(document.getElementById(BOOT_SPLASH_STATIC_ID)).toBeNull()
+    expect(document.querySelector('[data-testid="boot-splash"]')).toBeNull()
+    expect(document.querySelector('[data-shell]')).toBeInTheDocument()
+  })
+
+  it('is a no-op when the document shipped no static splash', () => {
+    // A document that never carried the static node must not throw.
+    document.body.innerHTML = `<div id="app"><div data-testid="${BOOT_SPLASH_TEST_ID}"><p>${BOOT_SPLASH_LABEL}</p></div></div>`
+    expect(() => removeStaticBootSplash()).not.toThrow()
+    expect(document.getElementById('app')!.childElementCount).toBe(1)
   })
 })
 

--- a/frontend/src/lib/bootSplashTheme.ts
+++ b/frontend/src/lib/bootSplashTheme.ts
@@ -1,7 +1,8 @@
 /**
- * Colours, copy, document CSS, and the blocking boot scripts for the zero-JS
- * splash. Shared by `entry-server.tsx` and `BootSplash` so the static HTML Go
- * serves and the Solid Suspense/AuthGuard chrome cannot drift.
+ * Colours, copy, document CSS, the blocking boot scripts, and the client-side
+ * removal of the static splash. Shared by `entry-server.tsx`,
+ * `entry-client.tsx`, and `BootSplash` so the static HTML Go serves and the
+ * Solid Suspense/AuthGuard chrome cannot drift.
  *
  * Palette comes from Default theme so the splash matches what `themeStore`
  * paints after hydration.
@@ -44,6 +45,29 @@ export const BOOT_SPLASH_TEST_ID = BOOT_SPLASH_DOM_KEY
  */
 export const BOOT_SPLASH_STATIC_ID = BOOT_SPLASH_DOM_KEY
 
+/**
+ * Remove the static document splash. The client entry calls this right after
+ * `mount()` returns. This doc is the canonical explanation of the handoff;
+ * the comments at the other sites point here.
+ *
+ * With `ssr: false`, the SPA mount is solid's plain `render()`. It appends
+ * into `#app` and removes no existing child. Without this call, the
+ * 100%-height splash keeps the booted app below the fold, and the watchdog
+ * fails the boot at 45s.
+ *
+ * The call runs AFTER mount on purpose. Mount is synchronous, so an entry
+ * graph that throws never reaches this call, and the watchdog still owns
+ * that failure class.
+ *
+ * A no-op when the document shipped no splash. In a hydrating build the node
+ * survives hydration — hydration claims only nodes that carry a hydration
+ * key, and the static splash carries none — so the call removes the node
+ * there too.
+ */
+export function removeStaticBootSplash(): void {
+  document.getElementById(BOOT_SPLASH_STATIC_ID)?.remove()
+}
+
 /** Visible label; keep the ellipsis character identical in both trees. */
 export const BOOT_SPLASH_LABEL = 'Loading LeapMux…'
 
@@ -68,8 +92,9 @@ export const BOOT_SPLASH_RELOAD_LABEL = 'Reload'
 
 /**
  * How long the static `#boot-splash` may remain before the watchdog treats
- * boot as failed. Solid mount removes that node; Suspense/AuthGuard splash
- * uses `data-testid` only, so a slow auth bootstrap does not trip this.
+ * boot as failed. The client entry removes that node right after `mount()`
+ * (see {@link removeStaticBootSplash}); Suspense/AuthGuard splash uses
+ * `data-testid` only, so a slow auth bootstrap does not trip this.
  *
  * Generous on purpose: mobile LTE cold start still finishes well under this,
  * and a tight budget would flash the failure panel on a working but slow path.
@@ -127,9 +152,9 @@ export function parseBootPrefsThemeMode(raw: string | null, nowMs: number): stri
 
 /**
  * Inline document CSS for the static splash, the Solid `BootSplash` (same
- * `data-testid`), and the html/body fill that covers the brief gap between
- * Solid `mount` clearing `#app` and the next splash paint. This is the only
- * splash stylesheet — do not reintroduce a vanilla-extract twin.
+ * `data-testid`), and the html/body fill that holds the splash geometry and
+ * polarity from first paint until the app stylesheet takes over. This is the
+ * only splash stylesheet — do not reintroduce a vanilla-extract twin.
  *
  * Body rules here match `~/styles/global.css.ts` (`position: fixed`, safe-area
  * padding, `#app` fill) so first paint already uses the geometry that lands
@@ -235,11 +260,11 @@ export function bootThemeScript(): string {
  * Only `<script>` load errors count. Favicon, manifest, and stylesheet `<link>`
  * failures must not tombstone the splash: they are common and non-fatal.
  *
- * Success signal: the static node `#boot-splash` is gone (Solid `mount`
- * replaces `#app`). A MutationObserver finishes the watchdog then (clears the
- * timer and removes the capture listener). The Suspense/AuthGuard `BootSplash`
- * keeps only `data-testid`, so a long auth bootstrap does not look like a
- * failed boot.
+ * Success signal: the static node `#boot-splash` is gone. The client entry
+ * removes it right after `mount()` (see {@link removeStaticBootSplash}). A
+ * MutationObserver finishes the watchdog then (clears the timer and removes
+ * the capture listener). The Suspense/AuthGuard `BootSplash` keeps only
+ * `data-testid`, so a long auth bootstrap does not look like a failed boot.
  */
 export function bootFailureWatchdogScript(): string {
   const id = BOOT_SPLASH_STATIC_ID

--- a/frontend/tests/e2e/185-mobile-startup-timing.spec.ts
+++ b/frontend/tests/e2e/185-mobile-startup-timing.spec.ts
@@ -31,12 +31,7 @@ import {
 } from './helpers/startupTiming'
 import { startTimingServer } from './helpers/timingFixture'
 import { COARSE_POINTER_METRICS } from './helpers/touch'
-import { loginViaToken } from './helpers/ui'
-
-/** Same shell oracle as loginViaUI: AppShell is up behind AuthGuard. */
-function shellTrigger(page: import('@playwright/test').Page) {
-  return page.getByTestId('app-menu-trigger').first().or(page.getByTestId('collapsed-new-tab-button').first())
-}
+import { appMenuTrigger, loginViaToken } from './helpers/ui'
 
 test.describe('mobile LTE cold-start timing', () => {
   test.describe.configure({ retries: 0 })
@@ -79,7 +74,7 @@ test.describe('mobile LTE cold-start timing', () => {
     // Cold authenticated boot: cookie already set, first document navigation.
     await page.goto('/', { waitUntil: 'commit' })
 
-    const shell = shellTrigger(page)
+    const shell = appMenuTrigger(page)
     await expect(shell).toBeVisible()
     sizeListener.markShellVisible()
 

--- a/frontend/tests/e2e/186-boot-splash-handoff.spec.ts
+++ b/frontend/tests/e2e/186-boot-splash-handoff.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from './fixtures'
+import { appMenuTrigger, loginViaToken } from './helpers/ui'
+
+/**
+ * The static splash in the served document must yield to the client app.
+ *
+ * With `ssr: false`, the build aliases `@solidjs/start/client` to its /spa
+ * variant. Its `mount()` is solid's plain `render()`: it appends into `#app`
+ * and removes no existing child. So the client entry removes the static
+ * splash itself, right after `mount()` returns. Before that call existed,
+ * the booted app stayed below the 100%-height splash, and the boot watchdog
+ * failed every load at 45s with "The app did not start in time."
+ *
+ * A visibility check alone cannot catch this bug. Playwright counts a
+ * below-the-fold shell as visible. So this spec pins the DOM handoff: the
+ * served document ships the splash, the entry removes it, and the shell
+ * becomes reachable.
+ */
+test.describe('static boot splash handoff', () => {
+  test('the entry removes the static splash and shows the shell', async ({ page, leapmuxServer }) => {
+    await loginViaToken(page, leapmuxServer.adminToken)
+
+    // The served document ships the splash. The check reads the response
+    // BODY — raw HTML. The client may remove the node before Playwright can
+    // observe the DOM, but the body keeps the original bytes. So the spec
+    // cannot pass vacuously when the document stops embedding a splash.
+    const response = await page.goto('/')
+    expect(response, 'goto(/) must return the document response').not.toBeNull()
+    expect(await response!.text()).toContain('id="boot-splash"')
+
+    // The handoff: the entry removes the static splash after mount. A
+    // regression leaves the node in `#app` forever, so this assertion fails
+    // by timeout instead of flaking.
+    await expect(page.locator('#boot-splash')).toHaveCount(0)
+
+    // The shared shell oracle — the same locator `loginViaUI` waits on, in
+    // whichever shell is mounted.
+    await expect(appMenuTrigger(page)).toBeVisible()
+  })
+})

--- a/frontend/tests/e2e/helpers/ui.ts
+++ b/frontend/tests/e2e/helpers/ui.ts
@@ -545,9 +545,10 @@ export async function waitForAgentIdle(page: Page, timeoutMs = 120_000) {
  * titlebar, so About and Preferences live under the tab bar's collapsed "+"
  * menu (`collapsed-new-tab-button`) instead. Only `AppShell` renders either,
  * and only behind `AuthGuard`, so this doubles as the marker that the
- * authenticated shell mounted — {@link loginViaUI} waits on it.
+ * authenticated shell mounted — {@link loginViaUI} waits on it, and the
+ * startup specs use it as the shared shell oracle.
  */
-function appMenuTrigger(page: Page): Locator {
+export function appMenuTrigger(page: Page): Locator {
   return page.getByTestId('app-menu-trigger').first().or(page.getByTestId('collapsed-new-tab-button')).first()
 }
 


### PR DESCRIPTION
## Motivation

In the SPA build (`ssr: false`), the client `mount()` is Solid's plain `render()`, which appends into `#app` and removes no existing child — so the static `#boot-splash` node stayed on screen after mount. The opaque, 100%-height splash kept the fully-booted app below the fold: the app kept running underneath (live channel traffic in the console; late replies silently dropped as "unknown correlation id" after their 15s client-side timeouts) with no network error anywhere, and the boot watchdog failed every load at 45s with "The app did not start in time. Check your network connection, then reload the page."

The visibility-based e2e added in #412 passed right over this, because Playwright counts a below-the-fold shell as visible. Related: #412 (mobile blank-screen cold start), #413 (boot splash stabilization).

## Modifications

- `entry-client.tsx` now calls `removeStaticBootSplash()` immediately after `mount()` returns.
- New canonical `removeStaticBootSplash()` exported from `frontend/src/lib/bootSplashTheme.ts`:
  ```ts
  export function removeStaticBootSplash(): void {
    document.getElementById(BOOT_SPLASH_STATIC_ID)?.remove()
  }
  ```
  It is a no-op when the document shipped no splash, and it also removes the node in hydrating builds (hydration claims only nodes with hydration keys, which the static splash lacks). The call runs after mount on purpose: mount is synchronous, so a throwing entry graph never reaches the removal and the watchdog still owns that failure class.
- New e2e `frontend/tests/e2e/186-boot-splash-handoff.spec.ts` pinning the splash-to-app handoff: asserts the served response body contains `id="boot-splash"` (so it can't pass vacuously if the document stops embedding a splash), asserts the node count reaches 0, and waits on the shared `appMenuTrigger` shell oracle — a visibility-only oracle cannot catch this bug.
- Replaced the brittle source-text order pin with behavioral unit tests: the new `entry-client.test.ts` evaluates the real entry module (with `@solidjs/start/client` and side-effectful imports mocked), covering "splash removed after mount" and "splash kept for the watchdog when mount throws". Added unit tests for `removeStaticBootSplash` in `bootSplashTheme.test.ts`.
- Cleanup: exported `appMenuTrigger()` from `frontend/tests/e2e/helpers/ui.ts` and dropped spec 185's local duplicate; corrected stale comments in `entry-server.tsx` and `bootSplashTheme.ts` that claimed "Solid mount replaces `#app`" — all sites now point to the `removeStaticBootSplash` doc comment as the one explanation.
- No breaking changes or deprecations. New exports: `removeStaticBootSplash()` from `bootSplashTheme.ts`, `appMenuTrigger()` from the e2e UI helpers.

## Result

On the SPA build, the boot splash now disappears the moment the client mounts. You no longer stare at "Loading LeapMux…" while the fully-booted app sits hidden below the fold — with the watchdog about to show "Could not start LeapMux" at 45s and background traffic dropping late replies as "unknown correlation id" from an app that was interactive but invisible. Hydrating builds get the leftover static node removed as well, and a mount that throws still leaves the splash up so the watchdog reports it as a failed boot.
