### PR TITLE
test(frontend): Fix the repo guards that could not fail

### DIFF
--- a/frontend/src/entry-client.test.ts
+++ b/frontend/src/entry-client.test.ts
@@ -16,11 +16,27 @@ import {
  * the behavior is pinned directly instead.
  */
 describe('entry-client boot handoff', () => {
+  /**
+   * The one `mount` that every test drives, through `mockImplementation`.
+   *
+   * A test must NOT call `vi.doMock('@solidjs/start/client', ...)` again to
+   * install a different `mount`. A second `vi.doMock` of one path cannot
+   * override the first one reliably: `vi.doMock` only queues the path, and
+   * vitest then resolves every consecutive queued mock in parallel and
+   * registers each one as its resolve call returns. The registration that
+   * wins is therefore the resolve call that finishes last, not the call the
+   * test wrote last. A `beforeEach` mock plus a per-test mock of this path
+   * passed on three CI platforms and failed on the loaded arm64 runner.
+   * One registration for each path keeps the order out of the result.
+   */
+  const mount = vi.fn<(code: () => unknown, element: Element) => void>()
+
   beforeEach(() => {
     vi.resetModules()
+    mount.mockReset()
     document.body.innerHTML = `<div id="app"><div id="${BOOT_SPLASH_STATIC_ID}" data-testid="${BOOT_SPLASH_TEST_ID}"><p>${BOOT_SPLASH_LABEL}</p></div></div>`
     vi.doMock('@solidjs/start/client', () => ({
-      mount: vi.fn(),
+      mount,
       StartClient: () => null,
     }))
     vi.doMock('~/components/common/Toast', () => ({ showWarnToast: vi.fn() }))
@@ -39,18 +55,27 @@ describe('entry-client boot handoff', () => {
   })
 
   it('removes the static splash after mount', async () => {
+    const splashAtMount: boolean[] = []
+    mount.mockImplementation(() => {
+      splashAtMount.push(document.getElementById(BOOT_SPLASH_STATIC_ID) !== null)
+    })
+
     await import('~/entry-client')
+
+    expect(mount).toHaveBeenCalledTimes(1)
+    expect(mount.mock.calls[0][1]).toBe(document.getElementById('app'))
+    // The removal runs after mount returns, so mount still sees the splash.
+    expect(splashAtMount).toEqual([true])
     expect(document.getElementById(BOOT_SPLASH_STATIC_ID)).toBeNull()
   })
 
   it('keeps the static splash for the watchdog when mount throws', async () => {
-    vi.doMock('@solidjs/start/client', () => ({
-      mount: () => {
-        throw new Error('entry graph fault')
-      },
-      StartClient: () => null,
-    }))
+    mount.mockImplementation(() => {
+      throw new Error('entry graph fault')
+    })
+
     await expect(import('~/entry-client')).rejects.toThrow('entry graph fault')
+
     expect(document.getElementById(BOOT_SPLASH_STATIC_ID)).not.toBeNull()
   })
 })

--- a/frontend/src/test-support/chatRowReads.test.ts
+++ b/frontend/src/test-support/chatRowReads.test.ts
@@ -1,7 +1,8 @@
-import { readdirSync, readFileSync } from 'node:fs'
-import { dirname, join, relative, resolve } from 'node:path'
+import { readFileSync } from 'node:fs'
+import { dirname, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
+import { collectE2EFiles } from '~/test-support/e2eFiles'
 
 // E2E guard: read a chat row through `readAttached`, never through a bare
 // `locator.evaluate` / `locator.evaluateAll`.
@@ -53,22 +54,9 @@ const CHAT_LOCATOR_MARKERS = [
 const RACY_READ = String.raw`\.\s*evaluate(?:All)?\s*\(`
 
 const frontendRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
-const e2eRoot = join(frontendRoot, 'tests', 'e2e')
 
 /** `const name = <expression>`, the only binding form the specs use for a locator. */
 const BINDING = /(?:const|let)\s+(\w+)\s*=\s*([^\n]*)/g
-
-function collectSpecFiles(dir: string): string[] {
-  const found: string[] = []
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    const full = join(dir, entry.name)
-    if (entry.isDirectory())
-      found.push(...collectSpecFiles(full))
-    else if (entry.name.endsWith('.ts'))
-      found.push(full)
-  }
-  return found
-}
 
 /**
  * The names in `source` that hold a chat locator.
@@ -120,7 +108,7 @@ function racyChatReads(source: string): Array<{ index: number, text: string }> {
 describe('e2e chat row reads', () => {
   it('never reads a chat row through a two-round-trip evaluate', () => {
     const offenders = new Set<string>()
-    for (const file of collectSpecFiles(e2eRoot)) {
+    for (const file of collectE2EFiles()) {
       const source = readFileSync(file, 'utf-8')
       for (const { index, text } of racyChatReads(source)) {
         const line = source.slice(0, index).split('\n').length

--- a/frontend/src/test-support/e2eFiles.test.ts
+++ b/frontend/src/test-support/e2eFiles.test.ts
@@ -1,0 +1,32 @@
+import { isAbsolute, join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { collectE2EFiles, e2eRoot } from '~/test-support/e2eFiles'
+
+// Three e2e guards -- `noNetworkIdleWait`, `chatRowReads` and
+// `visibleChatLocators` -- scan whatever this walk returns and then assert
+// their offender list is empty. An empty walk is a silent pass for all three at
+// once, so the non-emptiness is pinned HERE, one time, rather than in each of
+// them.
+
+describe('collectE2EFiles', () => {
+  it('finds the files the e2e guards scan', () => {
+    expect(collectE2EFiles().length, 'no e2e file found -- has tests/e2e/ moved?')
+      .toBeGreaterThanOrEqual(50)
+  })
+
+  it('returns an absolute .ts path for every file', () => {
+    const found = collectE2EFiles()
+
+    expect(found.every(file => file.endsWith('.ts'))).toBe(true)
+    expect(found.every(file => isAbsolute(file))).toBe(true)
+  })
+
+  it('includes a nested helper, not the specs alone', () => {
+    // A helper runs inside the same page and breaks the same rules, which is
+    // why the walk matches `.ts` rather than `.spec.ts`.
+    const found = collectE2EFiles()
+
+    expect(found).toContain(join(e2eRoot, 'helpers', 'ui.ts'))
+    expect(found.some(file => file.endsWith('.spec.ts'))).toBe(true)
+  })
+})

--- a/frontend/src/test-support/e2eFiles.ts
+++ b/frontend/src/test-support/e2eFiles.ts
@@ -1,0 +1,29 @@
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { collectFiles } from '~/test-support/sourceTree'
+
+const frontendRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
+
+/** The one sanctioned home for tests outside `src/`. */
+export const e2eRoot = join(frontendRoot, 'tests', 'e2e')
+
+/**
+ * Every e2e spec and helper, recursively, as an absolute path.
+ *
+ * The enumeration three repo guards scan -- `noNetworkIdleWait.test.ts` (no
+ * spec may wait for `networkidle`), `chatRowReads.test.ts` (no two-round-trip
+ * read on a chat locator) and `visibleChatLocators.test.ts` (no unscoped chat
+ * locator rooted at the page). All three carried a byte-identical copy of the
+ * walk, so a change to what counts as an e2e file -- a `.mts` helper, a
+ * fixtures directory to skip -- would have moved one guard and left the other
+ * two scanning a different set.
+ *
+ * `.ts` rather than `.spec.ts`: a helper under `tests/e2e/helpers/` runs inside
+ * the same page and breaks the same rules.
+ *
+ * NOT a `.test.ts`, so vitest does not collect this module as a suite of its
+ * own.
+ */
+export function collectE2EFiles(): string[] {
+  return collectFiles(e2eRoot, { matches: name => name.endsWith('.ts') })
+}

--- a/frontend/src/test-support/noControlBytesInSource.test.ts
+++ b/frontend/src/test-support/noControlBytesInSource.test.ts
@@ -1,7 +1,8 @@
-import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { readFileSync } from 'node:fs'
 import { dirname, join, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
+import { collectFiles } from '~/test-support/sourceTree'
 
 // Repo hygiene guard: a NUL byte (0x00) anywhere in a tracked source file makes
 // Git classify that file as BINARY. Once it does, `git diff` and `git show`
@@ -22,7 +23,6 @@ import { describe, expect, it } from 'vitest'
 
 const frontendRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
 const SOURCE_ROOTS = ['src', 'tests']
-const SKIP_DIRS = new Set(['node_modules', '.output', '.vinxi', 'dist', 'test-results'])
 const SOURCE_FILE = /\.(?:ts|tsx|js|jsx|css|json|md)$/
 
 interface Offender {
@@ -30,35 +30,33 @@ interface Offender {
   offset: number
 }
 
-function collectOffenders(dir: string, found: Offender[]): void {
-  if (!existsSync(dir))
-    return
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    if (SKIP_DIRS.has(entry.name))
-      continue
-    const full = join(dir, entry.name)
-    if (entry.isDirectory()) {
-      collectOffenders(full, found)
-      continue
-    }
-    if (!SOURCE_FILE.test(entry.name))
-      continue
-    const offset = readFileSync(full).indexOf(0x00)
-    if (offset !== -1)
-      found.push({ path: relative(frontendRoot, full), offset })
-  }
+/** Every source file under the guarded roots, as an absolute path. */
+function collectSourceFiles(): string[] {
+  return SOURCE_ROOTS.flatMap(root =>
+    collectFiles(join(frontendRoot, root), { matches: name => SOURCE_FILE.test(name) }),
+  )
 }
 
 describe('source hygiene', () => {
   it('has no NUL bytes in tracked source (git treats such files as binary and hides their diffs)', () => {
     const offenders: Offender[] = []
-    for (const root of SOURCE_ROOTS)
-      collectOffenders(join(frontendRoot, root), offenders)
+    for (const file of collectSourceFiles()) {
+      const offset = readFileSync(file).indexOf(0x00)
+      if (offset !== -1)
+        offenders.push({ path: relative(frontendRoot, file), offset })
+    }
 
     const detail = offenders.map(o => `${o.path} (byte ${o.offset})`).join('\n  ')
     expect(
       offenders,
       `A NUL byte makes Git treat the file as binary, so its diffs, blame and line-level merges stop working and every future change ships unreviewable. Write the escape \`\\u0000\` instead of a literal NUL -- the two are identical at runtime:\n  ${detail}`,
     ).toEqual([])
+  })
+
+  it('finds the files it is meant to be guarding', () => {
+    // Without this the case above passes vacuously the day a root moves or the
+    // extension list stops matching, which is exactly when it needs to fail.
+    expect(collectSourceFiles().length, 'no source file found -- has the layout moved?')
+      .toBeGreaterThanOrEqual(100)
   })
 })

--- a/frontend/src/test-support/noDuplicateModuleMocks.test.ts
+++ b/frontend/src/test-support/noDuplicateModuleMocks.test.ts
@@ -1,7 +1,9 @@
-import { readdirSync, readFileSync } from 'node:fs'
+import { readFileSync } from 'node:fs'
 import { dirname, join, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
+import { lineNumberAt, stripCommentLines } from '~/test-support/sourceScan'
+import { collectFiles } from '~/test-support/sourceTree'
 
 // Unit-test guard: each test file registers a mocked path one time only.
 //
@@ -26,53 +28,78 @@ import { describe, expect, it } from 'vitest'
 const frontendRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
 const srcRoot = join(frontendRoot, 'src')
 
-/** This file, which quotes the banned calls to describe them. */
-const selfPath = fileURLToPath(import.meta.url)
-
 /**
  * A `vi.mock` or `vi.doMock` call whose first argument is a string literal.
- * A call with a computed path is out of reach of a text scan, and rare enough
- * to leave to review.
+ *
+ * Spell both names out. `vi\.(?:do)?Mock\(` reads as if it covered the pair,
+ * but it matches `vi.doMock` and a `vi.Mock` that no API supplies. The name
+ * that nearly every file uses is `vi.mock`, with a lower-case m, so the
+ * collapsed form walks the whole tree and reports almost nothing.
+ *
+ * The scan runs over the whole file rather than line by line, so the `\s*`
+ * spans the break a formatter puts after the paren. A call with a computed
+ * path is out of reach of a text scan, and rare enough to leave to review.
  */
-const MOCK_CALL = /\bvi\.(?:do)?Mock\(\s*(['"`])([^'"`]+)\1/g
+const MOCK_CALL = /\bvi\.(?:mock|doMock)\(\s*(['"`])([^'"`]+)\1/g
 
-/**
- * A line whose first non-space characters open or continue a comment. The ban
- * has to be EXPLAINED somewhere, and the explanation quotes the call, so a
- * comment is not an offence. A trailing comment on a line of code still
- * counts -- move the note above the line.
- */
-const COMMENT_LINE = /^\s*(?:\/\/|\/\*|\*)/
-
-function collectUnitTestFiles(dir: string): string[] {
-  const found: string[] = []
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    const full = join(dir, entry.name)
-    if (entry.isDirectory())
-      found.push(...collectUnitTestFiles(full))
-    else if (/\.test\.tsx?$/.test(entry.name) && full !== selfPath)
-      found.push(full)
-  }
-  return found
+export interface DuplicateMock {
+  /** The mocked path, exactly as the calls spell it. */
+  path: string
+  /** The 1-based line of each call that registers the path, in file order. */
+  lines: number[]
 }
 
-function duplicateMockPaths(file: string): string[] {
-  const counts = new Map<string, number>()
-  for (const line of readFileSync(file, 'utf-8').split('\n')) {
-    if (COMMENT_LINE.test(line))
-      continue
-    for (const match of line.matchAll(MOCK_CALL))
-      counts.set(match[2], (counts.get(match[2]) ?? 0) + 1)
+/**
+ * Every path that `source` registers more than one time, with the offending
+ * lines.
+ *
+ * Takes the SOURCE rather than a path, so the cases below can drive it with a
+ * fixture instead of a file on disk.
+ */
+export function findDuplicateMocks(source: string): DuplicateMock[] {
+  const code = stripCommentLines(source)
+  const linesByPath = new Map<string, number[]>()
+  for (const match of code.matchAll(MOCK_CALL)) {
+    const path = match[2]
+    const lines = linesByPath.get(path) ?? []
+    lines.push(lineNumberAt(code, match.index))
+    linesByPath.set(path, lines)
   }
-  return [...counts].filter(([, count]) => count > 1).map(([path]) => path)
+  return [...linesByPath]
+    .filter(([, lines]) => lines.length > 1)
+    .map(([path, lines]) => ({ path, lines }))
+}
+
+const UNIT_TEST_FILE = /\.test\.tsx?$/
+
+/** Every co-located unit test under `src/`, as an absolute path. */
+function collectSrcTestFiles(): string[] {
+  return collectFiles(srcRoot, { matches: name => UNIT_TEST_FILE.test(name) })
+}
+
+/**
+ * A `vi.mock` or `vi.doMock` call, BUILT rather than written, so the tree scan
+ * does not read this file's own fixtures as real offences. `wrapped` puts the
+ * path on its own line, the way a formatter breaks a long call.
+ */
+function mockCall(fn: 'mock' | 'doMock', path: string, wrapped = false): string {
+  const argument = JSON.stringify(path)
+  return wrapped
+    ? `vi.${fn}(\n  ${argument},\n  () => ({}),\n)`
+    : `vi.${fn}(${argument}, () => ({}))`
+}
+
+/** A call form that must never count: an unmock, or the `vi.mocked` helper. */
+function nonMockCall(fn: 'unmock' | 'doUnmock' | 'mocked', path: string): string {
+  return `vi.${fn}(${JSON.stringify(path)})`
 }
 
 describe('unit-test module mocks', () => {
   it('registers each mocked path one time for each file', () => {
     const offenders: string[] = []
-    for (const file of collectUnitTestFiles(srcRoot)) {
-      for (const path of duplicateMockPaths(file))
-        offenders.push(`${relative(frontendRoot, file)}  registers "${path}" more than once`)
+    for (const file of collectSrcTestFiles()) {
+      for (const { path, lines } of findDuplicateMocks(readFileSync(file, 'utf-8')))
+        offenders.push(`${relative(frontendRoot, file)}:${lines.join(',')}  registers "${path}" ${lines.length} times`)
     }
     const hint = [
       'Two queued registrations of one path have no defined winner: vitest resolves the queued',
@@ -81,5 +108,70 @@ describe('unit-test module mocks', () => {
       'through the spy (one vi.fn at describe scope, mockImplementation for each test):',
     ].join(' ')
     expect(offenders, `${hint}\n  ${offenders.join('\n  ')}`).toEqual([])
+  })
+
+  it('finds the files it is meant to be guarding', () => {
+    // Without this the case above passes vacuously the day the layout moves or
+    // the walk stops matching, which is exactly when it needs to fail.
+    expect(collectSrcTestFiles().length, 'no unit test found -- has the layout moved?')
+      .toBeGreaterThanOrEqual(100)
+  })
+
+  it('reports a path that two vi.mock calls register, with both lines', () => {
+    const source = [
+      mockCall('mock', '~/lib/a'),
+      mockCall('mock', '~/lib/b'),
+      mockCall('mock', '~/lib/a'),
+    ].join('\n')
+
+    expect(findDuplicateMocks(source)).toEqual([{ path: '~/lib/a', lines: [1, 3] }])
+  })
+
+  it('reports a path that vi.mock and vi.doMock register once each', () => {
+    // The shape that started this: a hoisted mock of the path, plus a second
+    // one installed for a single case.
+    const source = [mockCall('mock', '~/lib/a'), mockCall('doMock', '~/lib/a')].join('\n')
+    expect(findDuplicateMocks(source)).toEqual([{ path: '~/lib/a', lines: [1, 2] }])
+  })
+
+  it('accepts one registration for each path', () => {
+    const source = [mockCall('doMock', '~/lib/a'), mockCall('mock', '~/lib/b')].join('\n')
+    expect(findDuplicateMocks(source)).toEqual([])
+  })
+
+  it('counts a call that the formatter wrapped across lines', () => {
+    // The scan reads the whole file, so the break after the paren does not
+    // hide the second registration.
+    const source = [mockCall('doMock', '~/lib/a'), mockCall('doMock', '~/lib/a', true)].join('\n')
+    expect(findDuplicateMocks(source)).toEqual([{ path: '~/lib/a', lines: [1, 2] }])
+  })
+
+  it('ignores a call that a comment quotes', () => {
+    const source = [
+      mockCall('doMock', '~/lib/a'),
+      `// ${mockCall('doMock', '~/lib/a')}`,
+      ` * ${mockCall('doMock', '~/lib/a')}`,
+    ].join('\n')
+
+    expect(findDuplicateMocks(source)).toEqual([])
+  })
+
+  it('ignores an unmock and the vi.mocked helper', () => {
+    const source = [
+      mockCall('doMock', '~/lib/a'),
+      nonMockCall('unmock', '~/lib/a'),
+      nonMockCall('doUnmock', '~/lib/a'),
+      nonMockCall('mocked', '~/lib/a'),
+    ].join('\n')
+
+    expect(findDuplicateMocks(source)).toEqual([])
+  })
+
+  it('keeps no regex state between calls', () => {
+    // MOCK_CALL is a /g/ literal shared by every call. `matchAll` clones it
+    // rather than advancing its `lastIndex`, and this pins that.
+    const source = [mockCall('doMock', '~/lib/a'), mockCall('mock', '~/lib/a')].join('\n')
+    expect(findDuplicateMocks(source)).toHaveLength(1)
+    expect(findDuplicateMocks(source)).toHaveLength(1)
   })
 })

--- a/frontend/src/test-support/noDuplicateModuleMocks.test.ts
+++ b/frontend/src/test-support/noDuplicateModuleMocks.test.ts
@@ -1,0 +1,85 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { dirname, join, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+// Unit-test guard: each test file registers a mocked path one time only.
+//
+// A second registration of one path does NOT reliably replace the first one.
+// `vi.mock` and `vi.doMock` register nothing by themselves -- they push the
+// path onto a queue. Before the next import, vitest groups the queue by
+// action, resolves every mock of a group in parallel, and registers each
+// result when its own resolve call returns. The registration that wins is the
+// resolve call that finishes last, not the call that the file wrote last.
+//
+// The failure is a heisenbug. Each factory is correct on its own, the wrong
+// one runs, and the assertion fails somewhere unrelated. The boot-handoff test
+// for `entry-client` paired a `beforeEach` mock of `@solidjs/start/client`
+// with a per-test mock of the same path. It passed on macOS, Windows and linux
+// amd64, and failed on the linux arm64 runner, where the full suite starves
+// the two resolve calls unevenly.
+//
+// Register the path one time, and vary the behavior through the spy: keep one
+// `vi.fn` at describe scope, give it to the single factory, and let each test
+// call `mockImplementation` on it. `src/entry-client.test.ts` shows the shape.
+
+const frontendRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const srcRoot = join(frontendRoot, 'src')
+
+/** This file, which quotes the banned calls to describe them. */
+const selfPath = fileURLToPath(import.meta.url)
+
+/**
+ * A `vi.mock` or `vi.doMock` call whose first argument is a string literal.
+ * A call with a computed path is out of reach of a text scan, and rare enough
+ * to leave to review.
+ */
+const MOCK_CALL = /\bvi\.(?:do)?Mock\(\s*(['"`])([^'"`]+)\1/g
+
+/**
+ * A line whose first non-space characters open or continue a comment. The ban
+ * has to be EXPLAINED somewhere, and the explanation quotes the call, so a
+ * comment is not an offence. A trailing comment on a line of code still
+ * counts -- move the note above the line.
+ */
+const COMMENT_LINE = /^\s*(?:\/\/|\/\*|\*)/
+
+function collectUnitTestFiles(dir: string): string[] {
+  const found: string[] = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory())
+      found.push(...collectUnitTestFiles(full))
+    else if (/\.test\.tsx?$/.test(entry.name) && full !== selfPath)
+      found.push(full)
+  }
+  return found
+}
+
+function duplicateMockPaths(file: string): string[] {
+  const counts = new Map<string, number>()
+  for (const line of readFileSync(file, 'utf-8').split('\n')) {
+    if (COMMENT_LINE.test(line))
+      continue
+    for (const match of line.matchAll(MOCK_CALL))
+      counts.set(match[2], (counts.get(match[2]) ?? 0) + 1)
+  }
+  return [...counts].filter(([, count]) => count > 1).map(([path]) => path)
+}
+
+describe('unit-test module mocks', () => {
+  it('registers each mocked path one time for each file', () => {
+    const offenders: string[] = []
+    for (const file of collectUnitTestFiles(srcRoot)) {
+      for (const path of duplicateMockPaths(file))
+        offenders.push(`${relative(frontendRoot, file)}  registers "${path}" more than once`)
+    }
+    const hint = [
+      'Two queued registrations of one path have no defined winner: vitest resolves the queued',
+      'mocks of a group in parallel and registers each one as its resolve call returns, so the',
+      'last resolve wins rather than the last line. Register the path once and vary the behavior',
+      'through the spy (one vi.fn at describe scope, mockImplementation for each test):',
+    ].join(' ')
+    expect(offenders, `${hint}\n  ${offenders.join('\n  ')}`).toEqual([])
+  })
+})

--- a/frontend/src/test-support/noMangledTestTitles.test.ts
+++ b/frontend/src/test-support/noMangledTestTitles.test.ts
@@ -1,7 +1,8 @@
-import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { readFileSync } from 'node:fs'
 import { dirname, join, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
+import { collectFiles } from '~/test-support/sourceTree'
 
 // Test-name guard: `test/prefer-lowercase-title` (from the antfu ESLint config)
 // rejects a suite or case title that starts with a capital, and its `--fix`
@@ -29,7 +30,6 @@ import { describe, expect, it } from 'vitest'
 
 const frontendRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
 const SOURCE_ROOTS = ['src', 'tests']
-const SKIP_DIRS = new Set(['node_modules', '.output', '.vinxi', 'dist', 'test-results'])
 const TEST_FILE = /\.(?:test|spec)\.(?:ts|tsx)$/
 
 // A title whose first word is a genuinely camelCase identifier trips the same
@@ -149,21 +149,11 @@ export function findMangledTitles(source: string, path: string): MangledTitle[] 
   return found
 }
 
-function collectOffenders(dir: string, found: MangledTitle[]): void {
-  if (!existsSync(dir))
-    return
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    if (SKIP_DIRS.has(entry.name))
-      continue
-    const full = join(dir, entry.name)
-    if (entry.isDirectory()) {
-      collectOffenders(full, found)
-      continue
-    }
-    if (!TEST_FILE.test(entry.name))
-      continue
-    found.push(...findMangledTitles(readFileSync(full, 'utf8'), relative(frontendRoot, full)))
-  }
+/** Every unit test and e2e spec under the guarded roots, as an absolute path. */
+function collectTestFiles(): string[] {
+  return SOURCE_ROOTS.flatMap(root =>
+    collectFiles(join(frontendRoot, root), { matches: name => TEST_FILE.test(name) }),
+  )
 }
 
 // The historical offenders, exactly as they stood before the repair. They are
@@ -213,8 +203,8 @@ function callSite(fn: string, title: string): string {
 describe('test-title casing', () => {
   it('has no title that the lint autofix mangled, under src/ or tests/', () => {
     const offenders: MangledTitle[] = []
-    for (const root of SOURCE_ROOTS)
-      collectOffenders(join(frontendRoot, root), offenders)
+    for (const file of collectTestFiles())
+      offenders.push(...findMangledTitles(readFileSync(file, 'utf8'), relative(frontendRoot, file)))
 
     const detail = offenders.map(o => `${o.path}:${o.line}  ${JSON.stringify(o.title)}`).join('\n  ')
     expect(
@@ -228,6 +218,13 @@ describe('test-title casing', () => {
       + `genuinely camelCase identifier, add it to CAMEL_CASE_IDENTIFIERS in ${relative(frontendRoot, fileURLToPath(import.meta.url))} `
       + `with the evidence:\n  ${detail}`,
     ).toEqual([])
+  })
+
+  it('finds the files it is meant to be guarding', () => {
+    // Without this the case above passes vacuously the day a root moves or the
+    // extension list stops matching, which is exactly when it needs to fail.
+    expect(collectTestFiles().length, 'no test file found -- has the layout moved?')
+      .toBeGreaterThanOrEqual(100)
   })
 
   it('detects every title the autofix mangled before the repair', () => {

--- a/frontend/src/test-support/noMirroredUnitTests.test.ts
+++ b/frontend/src/test-support/noMirroredUnitTests.test.ts
@@ -1,7 +1,8 @@
-import { existsSync, readdirSync } from 'node:fs'
+import { existsSync } from 'node:fs'
 import { dirname, join, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
+import { collectFiles } from '~/test-support/sourceTree'
 
 // Repo layout guard: unit tests are co-located next to the code they test
 // (`foo.ts` -> `foo.test.ts` in the same directory under `src/`). The old
@@ -17,28 +18,20 @@ import { describe, expect, it } from 'vitest'
 const frontendRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
 const testsRoot = join(frontendRoot, 'tests')
 
-function collectUnitTestFiles(dir: string): string[] {
-  if (!existsSync(dir))
-    return []
-  const found: string[] = []
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    const full = join(dir, entry.name)
-    if (entry.isDirectory()) {
-      // `tests/e2e/` is the one sanctioned home for tests outside `src/`.
-      if (relative(testsRoot, full) === 'e2e')
-        continue
-      found.push(...collectUnitTestFiles(full))
-    }
-    else if (/\.test\.(?:ts|tsx)$/.test(entry.name)) {
-      found.push(relative(frontendRoot, full))
-    }
-  }
-  return found
+const UNIT_TEST_FILE = /\.test\.(?:ts|tsx)$/
+
+/** Every unit test that strayed under `tests/`, as a repo-relative path. */
+function collectStrayUnitTests(): string[] {
+  return collectFiles(testsRoot, {
+    matches: name => UNIT_TEST_FILE.test(name),
+    // `tests/e2e/` is the one sanctioned home for tests outside `src/`.
+    alsoSkip: new Set(['e2e']),
+  }).map(file => relative(frontendRoot, file))
 }
 
 describe('unit-test co-location', () => {
   it('has no mirrored unit tests under tests/ (they must live beside the code in src/)', () => {
-    const stray = collectUnitTestFiles(testsRoot)
+    const stray = collectStrayUnitTests()
     expect(
       stray,
       `Unit tests must be co-located under src/ (foo.ts -> foo.test.ts). `

--- a/frontend/src/test-support/noNetworkIdleWait.test.ts
+++ b/frontend/src/test-support/noNetworkIdleWait.test.ts
@@ -1,7 +1,9 @@
-import { readdirSync, readFileSync } from 'node:fs'
-import { dirname, join, relative, resolve } from 'node:path'
+import { readFileSync } from 'node:fs'
+import { dirname, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
+import { collectE2EFiles } from '~/test-support/e2eFiles'
+import { stripCommentLines } from '~/test-support/sourceScan'
 
 // E2E guard: no spec or helper may wait for `networkidle`.
 //
@@ -30,7 +32,6 @@ import { describe, expect, it } from 'vitest'
 // discouraged for exactly this class of reason.
 
 const frontendRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
-const e2eRoot = join(frontendRoot, 'tests', 'e2e')
 
 /**
  * The string literal, in any quoting style. That covers
@@ -39,33 +40,15 @@ const e2eRoot = join(frontendRoot, 'tests', 'e2e')
  */
 const NETWORK_IDLE = /(['"`])networkidle\1/
 
-/**
- * A line whose first non-space characters open or continue a comment. The
- * ban has to be EXPLAINED somewhere, and the explanation has to name the
- * call, so a comment that quotes it is not an offence. A trailing comment on
- * a line of code still counts -- move the note above the line.
- */
-const COMMENT_LINE = /^\s*(?:\/\/|\/\*|\*)/
-
-function collectE2EFiles(dir: string): string[] {
-  const found: string[] = []
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    const full = join(dir, entry.name)
-    if (entry.isDirectory())
-      found.push(...collectE2EFiles(full))
-    else if (entry.name.endsWith('.ts'))
-      found.push(full)
-  }
-  return found
-}
-
 describe('e2e load-state waits', () => {
   it('never waits for networkidle', () => {
     const offenders: string[] = []
-    for (const file of collectE2EFiles(e2eRoot)) {
-      const lines = readFileSync(file, 'utf-8').split('\n')
+    for (const file of collectE2EFiles()) {
+      // The ban has to be EXPLAINED somewhere, and the explanation names the
+      // call, so the comment lines go before the scan reads them.
+      const lines = stripCommentLines(readFileSync(file, 'utf-8')).split('\n')
       lines.forEach((text, index) => {
-        if (COMMENT_LINE.test(text) || !NETWORK_IDLE.test(text))
+        if (!NETWORK_IDLE.test(text))
           return
         offenders.push(`${relative(frontendRoot, file)}:${index + 1}  ${text.trim()}`)
       })
@@ -75,6 +58,9 @@ describe('e2e load-state waits', () => {
       'solver workers mid-fetch and those requests stay in-flight forever, so the wait burns the',
       'whole 300s test budget. Wait for a locator the app renders instead:',
     ].join(' ')
+    // The case above passes vacuously if the walk returns nothing, so
+    // `e2eFiles.test.ts` pins that it does not -- once, for the three guards
+    // that share it.
     expect(offenders, `${hint}\n  ${offenders.join('\n  ')}`).toEqual([])
   })
 })

--- a/frontend/src/test-support/sourceScan.test.ts
+++ b/frontend/src/test-support/sourceScan.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import { lineNumberAt, stripCommentLines } from '~/test-support/sourceScan'
+
+// The two source-text guards read their whole verdict through these, so a hole
+// here reads as a clean suite rather than as a failure. Pin the openers each
+// one blanks, the line numbering it must preserve, and the boundaries.
+
+describe('stripCommentLines', () => {
+  it('blanks every line that opens or continues a comment', () => {
+    const source = [
+      'const a = 1',
+      '// a line comment',
+      '  /* a block opener',
+      '   * a block body',
+      '   */',
+      'const b = 2',
+    ].join('\n')
+
+    expect(stripCommentLines(source).split('\n')).toEqual([
+      'const a = 1',
+      '',
+      '',
+      '',
+      '',
+      'const b = 2',
+    ])
+  })
+
+  it('keeps a code line that carries a trailing comment', () => {
+    const source = 'const a = 1 // still code'
+    expect(stripCommentLines(source)).toBe(source)
+  })
+
+  it('keeps the line count, so a scan reports the original line number', () => {
+    const code = stripCommentLines(['// one', 'code', '// three', 'code'].join('\n'))
+    expect(code.split('\n')).toHaveLength(4)
+    expect(lineNumberAt(code, code.indexOf('code'))).toBe(2)
+  })
+
+  it('leaves an empty source empty', () => {
+    expect(stripCommentLines('')).toBe('')
+  })
+})
+
+describe('lineNumberAt', () => {
+  const source = ['first', 'second', 'third'].join('\n')
+
+  it('numbers from one', () => {
+    expect(lineNumberAt(source, 0)).toBe(1)
+  })
+
+  it('keeps a newline on the line it ends', () => {
+    // The index of the `\n` after `first` is still line 1; the character after
+    // it opens line 2.
+    expect(lineNumberAt(source, source.indexOf('\n'))).toBe(1)
+    expect(lineNumberAt(source, source.indexOf('\n') + 1)).toBe(2)
+  })
+
+  it('finds a later line', () => {
+    expect(lineNumberAt(source, source.indexOf('third'))).toBe(3)
+  })
+
+  it('reports the last line for an index past the end', () => {
+    expect(lineNumberAt(source, source.length + 100)).toBe(3)
+  })
+
+  it('reports the first line for an index below the start', () => {
+    // A caller that subtracts an offset past zero gets line 1, never 0 and
+    // never a crash.
+    expect(lineNumberAt(source, -5)).toBe(1)
+  })
+
+  it('reports the first line of an empty source', () => {
+    expect(lineNumberAt('', 0)).toBe(1)
+  })
+})

--- a/frontend/src/test-support/sourceScan.ts
+++ b/frontend/src/test-support/sourceScan.ts
@@ -1,0 +1,45 @@
+// Shared primitives for the repo guards that scan source TEXT rather than a
+// runtime: `noDuplicateModuleMocks.test.ts` and `noNetworkIdleWait.test.ts`.
+//
+// Both ban a construct, and both have to EXPLAIN the ban somewhere, so both
+// quote the construct in a comment. Each carried a byte-identical copy of the
+// comment-line pattern below, so a change to what counts as a comment -- a
+// fourth opener, a docblock style -- would have moved one guard and left the
+// other reading its own explanation as an offence.
+//
+// NOT a `.test.ts`, so vitest does not collect this module as a suite of its
+// own. Its cases live in `sourceScan.test.ts` beside it.
+
+/**
+ * A line whose first non-space characters open or continue a comment.
+ *
+ * A trailing comment on a line of code is NOT one of these -- the line still
+ * carries code, so it still counts, and a note about a banned call belongs
+ * above the line rather than after it.
+ */
+const COMMENT_LINE = /^\s*(?:\/\/|\/\*|\*)/
+
+/**
+ * `source` with every comment line replaced by an empty line.
+ *
+ * Blanking rather than deleting keeps the line count and every code line's
+ * number, so a scanner reports a position in the ORIGINAL file. It also leaves
+ * the newlines in place, so a pattern that spans lines with `\s*` still
+ * matches a call that the formatter wrapped.
+ */
+export function stripCommentLines(source: string): string {
+  return source
+    .split('\n')
+    .map(line => (COMMENT_LINE.test(line) ? '' : line))
+    .join('\n')
+}
+
+/** The 1-based number of the line that holds `index` in `source`. */
+export function lineNumberAt(source: string, index: number): number {
+  let line = 1
+  for (let i = 0; i < index && i < source.length; i++) {
+    if (source[i] === '\n')
+      line++
+  }
+  return line
+}

--- a/frontend/src/test-support/sourceTree.test.ts
+++ b/frontend/src/test-support/sourceTree.test.ts
@@ -1,0 +1,69 @@
+import { dirname, join, resolve, sep } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { collectFiles, SKIP_DIRS } from '~/test-support/sourceTree'
+
+// Eight repo guards read their whole verdict through this walk, so a hole here
+// reads as a clean suite rather than as a failure. Pin the filter, the skip
+// set a caller cannot drop, and the absent-directory result.
+
+const frontendRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const testSupportRoot = join(frontendRoot, 'src', 'test-support')
+
+/** The directory names on the way to `file`, so a skip test matches no substring. */
+function directoriesOf(file: string): string[] {
+  return file.split(sep).slice(0, -1)
+}
+
+describe('collectFiles', () => {
+  it('returns the absolute path of every file the filter accepts', () => {
+    const found = collectFiles(testSupportRoot, { matches: name => name.endsWith('.test.ts') })
+
+    expect(found).toContain(join(testSupportRoot, 'sourceTree.test.ts'))
+    expect(found.every(file => file.endsWith('.test.ts'))).toBe(true)
+    expect(found.length).toBeGreaterThanOrEqual(10)
+  })
+
+  it('rejects a file the filter declines', () => {
+    const found = collectFiles(testSupportRoot, { matches: name => name.endsWith('.test.ts') })
+    expect(found).not.toContain(join(testSupportRoot, 'sourceTree.ts'))
+  })
+
+  it('skips the package install and the build outputs', () => {
+    // A walk from the frontend root reaches node_modules unless the shared
+    // skip set holds, and a thousand packages of `package.json` is what a hole
+    // here looks like.
+    const found = collectFiles(frontendRoot, { matches: name => name === 'package.json' })
+
+    expect(found).toContain(join(frontendRoot, 'package.json'))
+    expect(found.filter(file => directoriesOf(file).some(dir => SKIP_DIRS.has(dir)))).toEqual([])
+  })
+
+  it('adds alsoSkip to the shared set rather than replacing it', () => {
+    const found = collectFiles(frontendRoot, {
+      matches: name => name === 'package.json',
+      alsoSkip: new Set(['src']),
+    })
+
+    expect(found).toContain(join(frontendRoot, 'package.json'))
+    expect(found.filter(file => directoriesOf(file).includes('node_modules'))).toEqual([])
+  })
+
+  it('skips a named directory anywhere in the walk', () => {
+    const srcRoot = join(frontendRoot, 'src')
+    const matches = (name: string): boolean => name.endsWith('.ts')
+    const all = collectFiles(srcRoot, { matches })
+    const withoutTestSupport = collectFiles(srcRoot, { matches, alsoSkip: new Set(['test-support']) })
+
+    expect(withoutTestSupport.length).toBeLessThan(all.length)
+    expect(withoutTestSupport.filter(file => directoriesOf(file).includes('test-support'))).toEqual([])
+  })
+
+  it('returns nothing when the filter accepts no file', () => {
+    expect(collectFiles(testSupportRoot, { matches: () => false })).toEqual([])
+  })
+
+  it('returns nothing for a directory that does not exist', () => {
+    expect(collectFiles(join(frontendRoot, 'no-such-directory'), { matches: () => true })).toEqual([])
+  })
+})

--- a/frontend/src/test-support/sourceTree.ts
+++ b/frontend/src/test-support/sourceTree.ts
@@ -1,0 +1,74 @@
+import { existsSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+// The file walk that every repo guard scanning the source tree runs.
+//
+// Eight guards carried a near-identical copy of it, and they had already
+// drifted: two skipped the package install and the build outputs, and six
+// skipped nothing at all. That is harmless only while each one happens to
+// start below a directory the outputs cannot reach, and nothing holds them
+// there -- a guard repointed at `frontendRoot` would have walked 1117 packages
+// and reported whatever it found in them as repo code.
+//
+// `styleFiles.ts` made the same move for the `.css.ts` walk that three style
+// guards shared. This is that walk generalized, and `collectStyleFiles` now
+// delegates to it.
+//
+// NOT a `.test.ts`, so vitest does not collect this module as a suite of its
+// own. Its cases live in `sourceTree.test.ts` beside it.
+
+/**
+ * The directories that no source scan may walk: the package install and the
+ * build outputs. Their contents are not repo code, and a guard that reports
+ * one of them reports something nobody can fix.
+ *
+ * Every `collectFiles` walk skips these. A caller adds to the set through
+ * `alsoSkip`; it cannot replace them.
+ */
+export const SKIP_DIRS: ReadonlySet<string> = new Set([
+  'node_modules',
+  '.output',
+  '.vinxi',
+  'dist',
+  'test-results',
+])
+
+export interface CollectFilesOptions {
+  /** Reports whether a file belongs in the result, from its basename. */
+  matches: (basename: string) => boolean
+  /** Directory basenames to skip in ADDITION to `SKIP_DIRS`. */
+  alsoSkip?: ReadonlySet<string>
+}
+
+/**
+ * Every file under `dir`, recursively, whose basename `matches` accepts, as an
+ * absolute path.
+ *
+ * Returns an empty array when `dir` is absent, so a guard aimed at a directory
+ * a later layout removes fails on its own emptiness check rather than on an
+ * ENOENT from the walk. Pair the call with a case that asserts the walk found
+ * something, or the guard passes vacuously the day its root moves.
+ */
+export function collectFiles(dir: string, options: CollectFilesOptions): string[] {
+  if (!existsSync(dir))
+    return []
+  const skip = options.alsoSkip === undefined
+    ? SKIP_DIRS
+    : new Set([...SKIP_DIRS, ...options.alsoSkip])
+  return walk(dir, options.matches, skip)
+}
+
+/** The recursive half, with the skip set merged one time by the caller. */
+function walk(dir: string, matches: (basename: string) => boolean, skip: ReadonlySet<string>): string[] {
+  const found: string[] = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (skip.has(entry.name))
+      continue
+    const full = join(dir, entry.name)
+    if (entry.isDirectory())
+      found.push(...walk(full, matches, skip))
+    else if (matches(entry.name))
+      found.push(full)
+  }
+  return found
+}

--- a/frontend/src/test-support/stableContextUsage.test.ts
+++ b/frontend/src/test-support/stableContextUsage.test.ts
@@ -1,9 +1,10 @@
-import { readdirSync, readFileSync } from 'node:fs'
+import { readFileSync } from 'node:fs'
 import { dirname, join, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 
 import { installedCopies } from '~/test-support/installedCopies'
+import { collectFiles } from '~/test-support/sourceTree'
 
 // Guards the two rules `createStableContext` runs on, both of which were
 // documented in a comment and enforced by nothing.
@@ -28,19 +29,12 @@ const frontendRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..'
 const srcRoot = join(frontendRoot, 'src')
 const helperPath = join(srcRoot, 'lib', 'createStableContext.ts')
 
-function collectSourceFiles(dir: string): string[] {
-  const found: string[] = []
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    const full = join(dir, entry.name)
-    if (entry.isDirectory())
-      found.push(...collectSourceFiles(full))
-    else if (/\.tsx?$/.test(entry.name) && !/\.(?:test|spec)\.tsx?$/.test(entry.name))
-      found.push(full)
-  }
-  return found
-}
+const SOURCE_FILE = /\.tsx?$/
+const TEST_FILE = /\.(?:test|spec)\.tsx?$/
 
-const sourceFiles = collectSourceFiles(srcRoot)
+const sourceFiles = collectFiles(srcRoot, {
+  matches: name => SOURCE_FILE.test(name) && !TEST_FILE.test(name),
+})
 
 describe('createStableContext usage', () => {
   it('is the only way a context is created', () => {

--- a/frontend/src/test-support/styleFiles.test.ts
+++ b/frontend/src/test-support/styleFiles.test.ts
@@ -1,0 +1,25 @@
+import { dirname, isAbsolute, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { collectStyleFiles } from '~/test-support/styleFiles'
+
+// Three style guards read their whole verdict through this walk, and
+// `focusRingsAreFocusVisible` already pins that it finds something. What no
+// guard pins is the definition itself: a `.css.ts` and nothing else.
+
+const frontendRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const srcRoot = join(frontendRoot, 'src')
+
+describe('collectStyleFiles', () => {
+  it('returns an absolute path for every .css.ts under the root', () => {
+    const found = collectStyleFiles(srcRoot)
+
+    expect(found).toContain(join(srcRoot, 'components', 'common', 'ButtonGroup.css.ts'))
+    expect(found.every(file => file.endsWith('.css.ts'))).toBe(true)
+    expect(found.every(file => isAbsolute(file))).toBe(true)
+  })
+
+  it('rejects a plain .ts module', () => {
+    expect(collectStyleFiles(srcRoot)).not.toContain(join(srcRoot, 'lib', 'agentProviders.ts'))
+  })
+})

--- a/frontend/src/test-support/styleFiles.ts
+++ b/frontend/src/test-support/styleFiles.ts
@@ -1,5 +1,4 @@
-import { readdirSync } from 'node:fs'
-import { join } from 'node:path'
+import { collectFiles } from '~/test-support/sourceTree'
 
 /**
  * Every `.css.ts` file under `dir`, recursively.
@@ -12,16 +11,11 @@ import { join } from 'node:path'
  * directory to skip, a second extension — would have moved one guard and left
  * the other scanning a different set.
  *
+ * The walk itself now lives in `~/test-support/sourceTree`, which the other
+ * repo guards share; this keeps the definition of a style file.
+ *
  * NOT a `.test.ts`, so vitest does not collect it as a suite of its own.
  */
 export function collectStyleFiles(dir: string): string[] {
-  const found: string[] = []
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    const full = join(dir, entry.name)
-    if (entry.isDirectory())
-      found.push(...collectStyleFiles(full))
-    else if (entry.name.endsWith('.css.ts'))
-      found.push(full)
-  }
-  return found
+  return collectFiles(dir, { matches: name => name.endsWith('.css.ts') })
 }

--- a/frontend/src/test-support/visibleChatLocators.test.ts
+++ b/frontend/src/test-support/visibleChatLocators.test.ts
@@ -1,7 +1,8 @@
-import { readdirSync, readFileSync } from 'node:fs'
+import { readFileSync } from 'node:fs'
 import { dirname, join, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
+import { collectE2EFiles, e2eRoot } from '~/test-support/e2eFiles'
 
 // E2E guard: a page-rooted chat locator must be scoped to what the user can
 // SEE. ChatView keeps a hidden premeasure copy of every row whose height is
@@ -31,7 +32,6 @@ const CHAT_TEST_IDS = [
 ]
 
 const frontendRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
-const e2eRoot = join(frontendRoot, 'tests', 'e2e')
 
 /** `page.locator('[data-testid="<chat id>"...]')` without a `:visible` filter. */
 const UNSCOPED = new RegExp(
@@ -39,22 +39,10 @@ const UNSCOPED = new RegExp(
   'g',
 )
 
-function collectSpecFiles(dir: string): string[] {
-  const found: string[] = []
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    const full = join(dir, entry.name)
-    if (entry.isDirectory())
-      found.push(...collectSpecFiles(full))
-    else if (entry.name.endsWith('.ts'))
-      found.push(full)
-  }
-  return found
-}
-
 describe('e2e chat locators', () => {
   it('never roots an unscoped chat locator at the page', () => {
     const offenders: string[] = []
-    for (const file of collectSpecFiles(e2eRoot)) {
+    for (const file of collectE2EFiles()) {
       // ui.ts is where the scoped helpers are DEFINED, so it holds the only
       // legitimate occurrences of the raw selectors.
       if (relative(e2eRoot, file) === join('helpers', 'ui.ts'))


### PR DESCRIPTION
## Motivation

The boot-handoff test for `entry-client` mocked `@solidjs/start/client` in
`beforeEach`, then mocked the same path again inside the throwing-mount test.
That does not reliably override the first registration.

`vi.mock` and `vi.doMock` register nothing by themselves — they push the path
onto a queue. Before the next import, vitest groups the queue by action,
resolves every mock of a group in parallel, and registers each result when its
own resolve call returns. The registration that wins is the resolve call that
finishes last, not the call that the file wrote last.

So the no-op `mount` from `beforeEach` could beat the throwing `mount` from the
test. The entry module then evaluated without a fault, the import resolved, and
`rejects.toThrow` failed. The race stayed hidden on macOS, Windows and linux
amd64, and lost on the loaded linux arm64 runner, where the full suite starves
the two resolve calls unevenly. The failure is a heisenbug: each factory is
correct on its own, the wrong one runs, and the assertion fails somewhere
unrelated.

The guard written to stop that heisenbug returning did not work. It matched
`vi\.(?:do)?Mock\(`, which covers `vi.doMock` and a `vi.Mock` that no API
supplies. The name is `vi.mock`, with a lower-case m, and every file but one
uses it, so the guard walked every unit test in the suite and could only ever
report the one that motivated it. Its single assertion — `offenders` is empty —
passed either way, so nothing showed the hole.

That shape is not unique to it. Every repo guard scans a tree and asserts an
empty result, which is a pass the day its root moves or its pattern stops
matching. `focusRingsAreFocusVisible` already carries the answer: a second case
that asserts the walk found something.

## Modifications

**The boot handoff**

- Keep one `mount` spy at describe scope, hand it to the single
  `@solidjs/start/client` factory, and let each test install its behavior with
  `mockImplementation`. `beforeEach` resets the spy.
- Assert that the entry calls `mount` one time, mounts into `#app`, and still
  shows the static splash while mount runs, so the "remove the splash after
  mount" order is pinned rather than assumed.

**The duplicate-mock guard**

- Spell both call names out, and drive the scan from a pure
  `findDuplicateMocks(source)` so cases can feed it a fixture.
- Scan the comment-stripped whole file rather than line by line, so a call the
  formatter wrapped after the paren still counts.
- Report the line of every offending call, not the file alone.
- Cover both spellings, the wrapped call, a quoted call in a comment, an unmock
  and `vi.mocked`. Each fixture call is built rather than written, so the tree
  scan does not read the guard's own examples as offences — which retires the
  self-exclusion that stood in for this.

**The scans that could not fail**

- Assert that each walk found something, so an empty one fails instead of
  passing. A guard with its own walk carries the case; the three e2e guards and
  the three style guards share theirs, so it sits with the helper and covers all
  three at once.

**The shared walk**

- Extract `collectFiles(dir, { matches, alsoSkip })` and one `SKIP_DIRS` into
  `sourceTree.ts`, and route all eight guards through it. Two skipped the
  package install and the build outputs; six skipped nothing, and nothing held
  them below a directory the outputs cannot reach. A caller adds to the skip set
  and cannot replace it.
- Extract `stripCommentLines` / `lineNumberAt` into `sourceScan.ts`, which
  `noNetworkIdleWait` carried a byte-identical copy of.
- Give the e2e enumeration one home in `e2eFiles.ts`, which three guards each
  carried a copy of, and delegate `collectStyleFiles` to the shared walk.
- Cover the shared helpers directly: the comment openers blanked and the line
  numbering preserved, the skip set a caller cannot replace, and the definition
  of an e2e file and of a stylesheet.

## Result

The boot-handoff test no longer depends on which of two parallel resolve calls
finishes first. The duplicate-mock guard reads every unit-test file in the suite
instead of one, and names the lines to fix. A guard whose root moves or whose
pattern stops matching now fails, where before it reported a clean tree. No
production code changes.
