### PR TITLE
fix(frontend): Keep a tab's branch when its worker link drops

### DIFF
--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -195,7 +195,6 @@ export const AppShell: Component = () => {
   const workerSection = useWorkerSection({
     getUserId: () => userId(),
     keyPinConfirmDialog,
-    clearRepoGitForWorker: workerId => repoGitStore.clearForWorker(workerId),
   })
 
   // Tell the channel manager who this page thinks it is, so an open the Hub
@@ -259,6 +258,9 @@ export const AppShell: Component = () => {
     // no other way to learn it, because a worker reconnecting changes nothing
     // about the candidate set.
     onlineWorkerIds: () => onlineWorkerIdSet(workerSection.workers()),
+    // A worker coming back re-asks for its agent tabs, and that reply must not
+    // land over a settings edit the user is making right now.
+    settingsPendingAxes: agentId => settingsLoading.pendingAxes(agentId),
   })
 
   // Mount the input-driven heartbeat for the active workspace. The

--- a/frontend/src/components/shell/AppShellDialogs.test.tsx
+++ b/frontend/src/components/shell/AppShellDialogs.test.tsx
@@ -10,9 +10,13 @@ import { showWarnToast } from '~/components/common/Toast'
 import { WorktreeAction } from '~/generated/leapmux/v1/common_pb'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
 import { createDialogState, createToggleDialog, createUpdatableDialogState } from '~/hooks/createDialogState'
+import { repoKey } from '~/stores/repoGit'
 import { createRepoGitStore } from '~/stores/repoGit.store'
+import { emitAddTab } from '~/stores/tabOps'
+import { installTestBridge } from '~/test-support/crdtBridge'
 import { makeInspectResp, makeWorktreeRemovalResp } from '~/test-support/gitBranchFixtures'
 import { pickMenuValue } from '~/test-support/menu'
+import { createTestTabStores } from '~/test-support/tabStores'
 import { AppShellDialogs } from './AppShellDialogs'
 
 // Replace the module wholesale, like the sibling DeleteBranchDialog suite.
@@ -38,11 +42,58 @@ vi.mock('~/components/common/Toast', () => ({
 // is (see below): this suite tests the PARENT's plumbing, not the dialogs' own
 // fields. The stubs surface the guard reason the parent computes so a test can
 // assert what the real dialog would disable submit on.
-vi.mock('~/components/shell/NewAgentDialog', () => ({
-  NewAgentDialog: (props: { blockedReason?: () => string | undefined, onClose: () => void }) => (
-    <div data-testid="new-agent-stub">{props.blockedReason?.() ?? ''}</div>
-  ),
-}))
+// The agent the stub reports as created, so a test can drive `onCreated`
+// without standing up the real dialog's worker and directory fields.
+//
+// Built with `create(AgentInfoSchema, ...)`, not as an object literal, so it
+// carries every field the wire supplies -- `status`, `agentProvider`,
+// `acceptsMessages` and the rest that `protoToAgentTabFields` reads. A literal
+// leaves them `undefined`, which no real response does.
+//
+// It is built inside the factory rather than in `vi.hoisted`, because
+// `vi.hoisted` runs before the static imports initialize and cannot name
+// `create`. The factory is async and runs lazily, so it can import both.
+vi.mock('~/components/shell/NewAgentDialog', async () => {
+  const { create } = await import('@bufbuild/protobuf')
+  const { AgentInfoSchema } = await import('~/generated/leapmux/v1/agent_pb')
+  // No `gitStatus`: the OpenAgent response carries none. The worker computes
+  // it in startup phase 1 and sends it on the STARTING broadcast, so the
+  // `git status` shell-out does not block the RPC.
+  const createdAgent = create(AgentInfoSchema, {
+    id: 'created-agent',
+    workerId: 'w1',
+    title: 'Agent Mimi',
+    workingDir: '/repo',
+  })
+  return {
+    // Two buttons, one for each answer the real dialog gives for
+    // `seedGitFromActiveTab`: the plain git mode may seed, every mode that
+    // redirects the working directory may not.
+    NewAgentDialog: (props: {
+      blockedReason?: () => string | undefined
+      onCreated: (agent: typeof createdAgent, opts: { seedGitFromActiveTab: boolean }) => void
+      onClose: () => void
+    }) => (
+      <>
+        <div data-testid="new-agent-stub">{props.blockedReason?.() ?? ''}</div>
+        <button
+          type="button"
+          data-testid="new-agent-created"
+          onClick={() => props.onCreated(createdAgent, { seedGitFromActiveTab: true })}
+        >
+          created
+        </button>
+        <button
+          type="button"
+          data-testid="new-agent-created-worktree"
+          onClick={() => props.onCreated(createdAgent, { seedGitFromActiveTab: false })}
+        >
+          created in a worktree
+        </button>
+      </>
+    ),
+  }
+})
 
 vi.mock('~/components/shell/NewTerminalDialog', () => ({
   NewTerminalDialog: (props: { blockedReason?: () => string | undefined, onClose: () => void }) => (
@@ -469,5 +520,134 @@ describe('appShellDialogs branch dialogs', () => {
 
       expect(await screen.findByTestId('new-agent-stub')).toHaveTextContent(/^$/)
     })
+  })
+})
+
+/**
+ * What the parent writes when the New Agent dialog reports a created agent.
+ *
+ * This one needs the operational stores the suite above deliberately leaves
+ * unfilled, because the assertion is about the tab that `openTabInFocusedTile`
+ * actually places. It gets its own render helper rather than widening
+ * `renderDialogs`, so the branch-dialog tests keep paying nothing for it.
+ */
+describe('appShellDialogs agent creation', () => {
+  function renderForCreate() {
+    const harness = installTestBridge({ workspaceId: 'ws1' })
+    const stores = createTestTabStores('ws1')
+    const repoGitStore = createRepoGitStore()
+    const dialogs = makeDialogs()
+    const props = {
+      dialogs,
+      activeWorkspace: () => ({ id: 'ws1' }),
+      isActiveWorkspaceMutatable: () => true,
+      layoutStore: stores.layoutStore,
+      view: stores.view,
+      metadata: stores.metadata,
+      selection: stores.selection,
+      repoGitStore,
+      // Called unguarded from the created-agent handler, on the next frame.
+      focusEditor: vi.fn(),
+      getCurrentTabContext: () => ({
+        workerId: 'w1',
+        workingDir: '/repo',
+        homeDir: '/home/u',
+        gitToplevel: '/repo',
+      }),
+    }
+    render(() => <AppShellDialogs {...(props as unknown as ComponentProps<typeof AppShellDialogs>)} />)
+    return { dialogs, repoGitStore, ...stores, rootTileId: harness.rootTileId }
+  }
+
+  /**
+   * An ACTIVE tab on a DIFFERENT worker, in the same directory the new agent
+   * opens in, with its repo already known.
+   *
+   * A different worker is what makes the seed observable: same-worker opens
+   * share a repo key and copy nothing. The directories must match, because
+   * `resolveOptimisticGitInfo` refuses to copy across a directory change.
+   */
+  function seedActiveTabOnOtherWorker(
+    stores: ReturnType<typeof renderForCreate>,
+  ) {
+    emitAddTab({
+      type: TabType.AGENT,
+      id: 'active',
+      tileId: stores.rootTileId,
+      position: 'p1',
+      workerId: 'w-other',
+    })
+    stores.metadata.patch('active', { workingDir: '/repo', gitToplevel: '/repo' })
+    stores.selection.setActive(stores.view.getAgentTab('active')!)
+    stores.repoGitStore.upsert(repoKey('w-other', '/repo'), {
+      workerId: 'w-other',
+      toplevel: '/repo',
+      branch: 'feature/sidebar',
+      gitStatusSeen: true,
+    })
+  }
+
+  // Both facts belong to `openedAgentTabFields`, whose doc comment states why:
+  // it carries `hydrated: true`, and it writes no repo entry because the
+  // OpenAgent response carries no git status.
+  it('marks the placed agent hydrated and writes no repo entry', async () => {
+    const { dialogs, repoGitStore, view, metadata } = renderForCreate()
+    dialogs.newAgent.open()
+
+    fireEvent.click(await screen.findByTestId('new-agent-created'))
+
+    await waitFor(() => expect(view.getAgentTab('created-agent')).toBeDefined())
+    // `isHydrated` reads the metadata row, not the assembled tab.
+    expect(
+      metadata.get('created-agent')?.hydrated,
+      'the hydrator must not re-ask for this tab',
+    ).toBe(true)
+    expect(view.getAgentTab('created-agent')?.gitToplevel, 'the response carries no repo identity').toBeUndefined()
+    expect(Object.keys(repoGitStore.repos())).toEqual([])
+  })
+
+  /**
+   * The OpenAgent response carries no git status, so without a seed the new tab
+   * renders outside its repository group for the whole of the agent's startup.
+   * The tab-bar path already seeds; this closes the gap for the dialog.
+   */
+  it('seeds the branch from the active tab when the agent opens in place', async () => {
+    const stores = renderForCreate()
+    seedActiveTabOnOtherWorker(stores)
+    stores.dialogs.newAgent.open()
+
+    fireEvent.click(await screen.findByTestId('new-agent-created'))
+
+    await waitFor(() => expect(stores.view.getAgentTab('created-agent')).toBeDefined())
+    expect(
+      stores.repoGitStore.get(repoKey('w1', '/repo'))?.branch,
+      'the sidebar can group the new tab before the worker reports',
+    ).toBe('feature/sidebar')
+  })
+
+  /**
+   * Every git mode except the plain one redirects the agent -- into a new or
+   * existing worktree, or onto a different branch. The active tab's branch is
+   * then the wrong answer for the directory the agent lands in, so a seed there
+   * would put a confidently wrong label on the tab rather than no label.
+   */
+  it('seeds nothing when the agent is redirected into a worktree', async () => {
+    const stores = renderForCreate()
+    seedActiveTabOnOtherWorker(stores)
+    stores.dialogs.newAgent.open()
+
+    fireEvent.click(await screen.findByTestId('new-agent-created-worktree'))
+
+    await waitFor(() => expect(stores.view.getAgentTab('created-agent')).toBeDefined())
+    expect(stores.repoGitStore.get(repoKey('w1', '/repo'))).toBeUndefined()
+  })
+
+  it('closes the dialog once the agent is placed', async () => {
+    const { dialogs } = renderForCreate()
+    dialogs.newAgent.open()
+
+    fireEvent.click(await screen.findByTestId('new-agent-created'))
+
+    await waitFor(() => expect(dialogs.newAgent.isOpen()).toBe(false))
   })
 })

--- a/frontend/src/components/shell/AppShellDialogs.tsx
+++ b/frontend/src/components/shell/AppShellDialogs.tsx
@@ -22,7 +22,7 @@ import { ChangeBranchDialog } from '~/components/workspace/ChangeBranchDialog'
 import { DeleteBranchDialog } from '~/components/workspace/DeleteBranchDialog'
 import { NewWorkspaceDialog } from '~/components/workspace/NewWorkspaceDialog'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
-import { openedTerminalMetadata, protoToAgentTabFields } from '~/stores/tab.helpers'
+import { openedAgentTabFields, openedTerminalMetadata, planOptimisticRepoGit } from '~/stores/tab.helpers'
 import { LastTabCloseDialog } from './LastTabCloseDialog'
 import { NewAgentDialog } from './NewAgentDialog'
 import { NewTerminalDialog } from './NewTerminalDialog'
@@ -136,24 +136,70 @@ interface AppShellDialogsProps {
 }
 
 export const AppShellDialogs: Component<AppShellDialogsProps> = (props) => {
-  // Full per-agent metadata lives on the Tab record now;
-  // protoToAgentTabFields also primes settingsLabelCache.
-  // `hydrated`: this `AgentInfo` came from the worker, so the hydrator has
-  // nothing to add and must not re-ask (see `TabMetadata.hydrated`).
-  const addAgentTabToFocusedTile = (agent: AgentInfo) => {
-    openTabInFocusedTile(
+  // Full per-agent metadata lives on the Tab record now. `openedAgentTabFields`
+  // also primes settingsLabelCache, and it carries `hydrated: true`: this
+  // `AgentInfo` came from the worker, so the hydrator has nothing to add and
+  // must not re-ask (see `TabMetadata.hydrated`).
+  //
+  // `seedGitFromActiveTab` copies the active tab's branch onto the new tab
+  // while the worker's own status is on its way. The OpenAgent response carries
+  // no git status -- the worker computes it in startup phase 1 and sends it on
+  // the STARTING broadcast -- so without the seed the tab renders outside its
+  // repository group for the whole startup. `useAgentOperations` already seeds
+  // on the tab-bar path.
+  //
+  // Only the caller knows whether the seed is safe. It is safe only when the
+  // agent lands in the directory the active tab is showing, which the plain
+  // git mode is the only one to guarantee.
+  /** The active tab to seed git from, or undefined when seeding is unsafe. */
+  const gitSeedSource = (seedGitFromActiveTab: boolean) =>
+    seedGitFromActiveTab
+      ? props.selection.activeTabForWorkspace(props.activeWorkspace()?.id ?? '')
+      : undefined
+
+  const addAgentTabToFocusedTile = (agent: AgentInfo, opts: { seedGitFromActiveTab: boolean }) => {
+    // `resolveOptimisticGitInfo`'s own guard still applies: it copies nothing
+    // unless the two tabs resolve to the same git directory.
+    const seed = planOptimisticRepoGit(
+      props.repoGitStore,
+      gitSeedSource(opts.seedGitFromActiveTab),
+      { workerId: agent.workerId, workingDir: agent.workingDir },
+    )
+    const placedTileId = openTabInFocusedTile(
       props,
       { type: TabType.AGENT, id: agent.id, workerId: agent.workerId },
-      { ...protoToAgentTabFields(agent.workerId, agent), hydrated: true },
+      // The seed first, so the worker's own answer wins wherever it has one.
+      { ...seed.fields, ...openedAgentTabFields(props.repoGitStore, agent) },
     )
+    // Placement can be refused, and a store entry written before it would be
+    // an orphan that no tab reads and nothing reclaims.
+    if (placedTileId)
+      seed.commit()
   }
 
-  const addTerminalTabToFocusedTile = (terminalId: string, workerId: string, workingDir: string, title: string) => {
-    openTabInFocusedTile(
+  // `shellStartDir` is what the worker was asked to start in, and it is what
+  // `effectiveGitDir` compares -- so it must reach the seed, exactly as it does
+  // in `useTerminalOperations`. Without it both sides collapse to `workingDir`
+  // and the directory guard can never reject.
+  const addTerminalTabToFocusedTile = (
+    terminalId: string,
+    workerId: string,
+    workingDir: string,
+    title: string,
+    opts: { seedGitFromActiveTab: boolean } = { seedGitFromActiveTab: false },
+  ) => {
+    const seed = planOptimisticRepoGit(
+      props.repoGitStore,
+      gitSeedSource(opts.seedGitFromActiveTab),
+      { workerId, workingDir },
+    )
+    const placedTileId = openTabInFocusedTile(
       props,
       { type: TabType.TERMINAL, id: terminalId, workerId },
-      openedTerminalMetadata({ title, workingDir }),
+      { ...seed.fields, ...openedTerminalMetadata({ title, workingDir }) },
     )
+    if (placedTileId)
+      seed.commit()
   }
 
   /**
@@ -183,9 +229,9 @@ export const AppShellDialogs: Component<AppShellDialogsProps> = (props) => {
           onRefreshProviders={props.onRefreshProviders}
           blockedReason={newTabBlockedReason}
           repoGitStore={props.repoGitStore}
-          onCreated={(agent) => {
+          onCreated={(agent, opts) => {
             props.dialogs.newAgent.close()
-            addAgentTabToFocusedTile(agent)
+            addAgentTabToFocusedTile(agent, opts)
             requestAnimationFrame(() => props.focusEditor())
           }}
           onClose={() => props.dialogs.newAgent.close()}
@@ -198,11 +244,11 @@ export const AppShellDialogs: Component<AppShellDialogsProps> = (props) => {
           defaultWorkingDir={props.getCurrentTabContext().workingDir}
           blockedReason={newTabBlockedReason}
           repoGitStore={props.repoGitStore}
-          onCreated={(terminalId, workerId, workingDir, title) => {
+          onCreated={(terminalId, workerId, workingDir, title, opts) => {
             props.dialogs.newTerminal.close()
             if (!props.activeWorkspace())
               return
-            addTerminalTabToFocusedTile(terminalId, workerId, workingDir, title)
+            addTerminalTabToFocusedTile(terminalId, workerId, workingDir, title, opts)
           }}
           onClose={() => props.dialogs.newTerminal.close()}
         />
@@ -342,8 +388,11 @@ export const AppShellDialogs: Component<AppShellDialogsProps> = (props) => {
             // immediate local UI write is needed (and the user isn't
             // looking at that workspace's tile to feel the latency).
             onAgentCreated={(agent) => {
+              // No git seed. This dialog reaches the agent branch only in
+              // CreateWorktree mode, so the agent lands in a NEW worktree on a
+              // different branch than the active tab shows.
               if (state.workspaceId === props.activeWorkspace()?.id)
-                addAgentTabToFocusedTile(agent)
+                addAgentTabToFocusedTile(agent, { seedGitFromActiveTab: false })
             }}
             onTerminalCreated={(terminalId, workerId, workingDir, title) => {
               if (state.workspaceId === props.activeWorkspace()?.id)

--- a/frontend/src/components/shell/NewAgentDialog.tsx
+++ b/frontend/src/components/shell/NewAgentDialog.tsx
@@ -17,6 +17,7 @@ import { WorkerSelector } from '~/components/shell/WorkerSelector'
 import { createDirectoryTreeState } from '~/hooks/createDirectoryTreeState'
 import { createSessionIdState } from '~/hooks/createSessionIdState'
 import { useAgentProviderSelection } from '~/hooks/useAgentProviderSelection'
+import { GitMode } from '~/hooks/useGitModeState'
 import { useWorkerDialog } from '~/hooks/useWorkerDialog'
 
 interface NewAgentDialogProps {
@@ -32,7 +33,16 @@ interface NewAgentDialogProps {
    * agent first and refusing placement second would orphan the agent.
    */
   blockedReason?: () => string | undefined
-  onCreated: (agent: AgentInfo) => void
+  /**
+   * `seedGitFromActiveTab` says whether the caller may copy the active tab's
+   * branch onto the new tab while the worker's own status is on its way.
+   *
+   * Only the plain "use this directory" mode may. Every other mode redirects
+   * the agent -- a new or existing worktree, or a different branch -- so the
+   * active tab's branch would be the wrong answer for the directory the agent
+   * actually lands in. This dialog is the only place that knows which mode ran.
+   */
+  onCreated: (agent: AgentInfo, opts: { seedGitFromActiveTab: boolean }) => void
   onClose: () => void
   repoGitStore: ReturnType<typeof createRepoGitStore>
 }
@@ -87,7 +97,9 @@ export const NewAgentDialog: Component<NewAgentDialogProps> = (props) => {
     })
     if (resp.agent) {
       recordProviderUse(provider)
-      props.onCreated(resp.agent)
+      props.onCreated(resp.agent, {
+        seedGitFromActiveTab: gitMode.gitMode() === GitMode.Current,
+      })
     }
   })
 

--- a/frontend/src/components/shell/NewTerminalDialog.tsx
+++ b/frontend/src/components/shell/NewTerminalDialog.tsx
@@ -13,6 +13,7 @@ import { DialogFormFooter, WorkerDialogShell } from '~/components/shell/WorkerDi
 import { WorkerSelector } from '~/components/shell/WorkerSelector'
 import { createDirectoryTreeState } from '~/hooks/createDirectoryTreeState'
 import { useAvailableShells } from '~/hooks/useAvailableShells'
+import { GitMode } from '~/hooks/useGitModeState'
 import { useWorkerDialog } from '~/hooks/useWorkerDialog'
 import { formatErrorMessage } from '~/lib/errors'
 import { DEFAULT_TERMINAL_COLS, DEFAULT_TERMINAL_ROWS } from '~/lib/terminal'
@@ -27,7 +28,21 @@ interface NewTerminalDialogProps {
    * pty first and refusing placement second would orphan it.
    */
   blockedReason?: () => string | undefined
-  onCreated: (terminalId: string, workerId: string, workingDir: string, title: string) => void
+  /**
+   * `seedGitFromActiveTab` says whether the caller may copy the active tab's
+   * branch onto the new tab until the worker's first status arrives.
+   *
+   * Only the plain "use this directory" mode may. Every other mode redirects
+   * the terminal into a worktree or onto another branch, where the active tab's
+   * branch is the wrong answer for the directory it lands in.
+   */
+  onCreated: (
+    terminalId: string,
+    workerId: string,
+    workingDir: string,
+    title: string,
+    opts: { seedGitFromActiveTab: boolean },
+  ) => void
   onClose: () => void
   repoGitStore: ReturnType<typeof createRepoGitStore>
 }
@@ -88,7 +103,9 @@ export const NewTerminalDialog: Component<NewTerminalDialogProps> = (props) => {
       workerId: worker.workerId(),
       ...gitMode.toGitFields(),
     })
-    props.onCreated(resp.terminalId, worker.workerId(), worker.workingDir(), resp.title)
+    props.onCreated(resp.terminalId, worker.workerId(), worker.workingDir(), resp.title, {
+      seedGitFromActiveTab: gitMode.gitMode() === GitMode.Current,
+    })
   })
 
   return (

--- a/frontend/src/components/shell/openSubagentTab.ts
+++ b/frontend/src/components/shell/openSubagentTab.ts
@@ -116,7 +116,7 @@ function placeChildTab(
   label: 'opened' | 'revived',
 ): OpenSubagentTabResult {
   const { view, selection, metadata } = deps
-  metadata.patch(childAgentId, buildMetadata(deps, item))
+  metadata.patch(childAgentId, buildMetadata(deps, item, workerId))
   emit({
     type: TabType.AGENT,
     id: childAgentId,
@@ -172,6 +172,7 @@ function parentKey(deps: OpenSubagentTabDeps, item: { parentAgentId?: string }, 
 function buildMetadata(
   deps: OpenSubagentTabDeps,
   item: { parentAgentId?: string, title?: string },
+  workerId: string,
 ): TabMetadata {
   const parent = item.parentAgentId ? deps.view.getAgentTab(item.parentAgentId) : undefined
   // workerId is NOT a metadata field: it lives on the projection, and the
@@ -186,7 +187,17 @@ function buildMetadata(
   //
   // Seed only title/workingDir/agentProvider + the optimistic git fields the
   // sidebar groups by until hydration lands.
-  const git = parent ? resolveOptimisticGitInfo(parent, { workingDir: parent.workingDir }) : undefined
+  //
+  // Copy the git fields only from a parent on the SAME worker. `gitToplevel` is
+  // half of the repo key, and `workerId` is the other half; this child takes
+  // the caller's `workerId`, which falls back to the tile's active agent when
+  // the row carries no `parentAgentId`. A parent on a different worker would
+  // put its own toplevel under this worker's id, where no probe ever wrote an
+  // entry -- the tab would then sit under a repo with no branch name.
+  const sameWorker = parent?.workerId === workerId
+  const git = parent && sameWorker
+    ? resolveOptimisticGitInfo(parent, { workingDir: parent.workingDir })
+    : undefined
   return {
     title: item.title || undefined,
     workingDir: parent?.workingDir,

--- a/frontend/src/components/shell/useAgentOperations.test.ts
+++ b/frontend/src/components/shell/useAgentOperations.test.ts
@@ -8,12 +8,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as workerRpc from '~/api/workerRpc'
 import { useAgentOperations } from '~/components/shell/useAgentOperations'
 import { AgentInfoSchema, AgentProvider, ContentCompression, MessageSource } from '~/generated/leapmux/v1/agent_pb'
-import { WorktreeAction } from '~/generated/leapmux/v1/common_pb'
+import { GitRepoStatusSchema, WorktreeAction } from '~/generated/leapmux/v1/common_pb'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
 import { KEY_MRU_AGENT_PROVIDERS, localStorageClearForTests, localStorageGet, localStorageSet } from '~/lib/browserStorage'
 import { ChannelError, channelNotOpenError } from '~/lib/channelError'
 import { createAgentSessionStore } from '~/stores/agentSession.store'
 import { createControlStore } from '~/stores/control.store'
+import { repoKey } from '~/stores/repoGit'
 import { createRepoGitStore } from '~/stores/repoGit.store'
 import { protoToAgentTabFields } from '~/stores/tab.helpers'
 import { emitAddTab } from '~/stores/tabOps'
@@ -65,6 +66,11 @@ vi.mock('~/components/common/Toast', async () => {
   }
 })
 
+// A throwaway store for the fixture mapper. `protoToAgentTabFields` writes the
+// repo entry that matches the `gitToplevel` it returns, so it takes one; these
+// fixtures only want the row fields.
+const fixtureStore = createRepoGitStore()
+
 let nextPosition = 0
 
 /**
@@ -112,6 +118,7 @@ function setup(storeWorkspaceId: string = 'ws-1', getWorkerId: () => string = ()
     forgetAgent: vi.fn(),
   } as any
 
+  const repoGitStore = createRepoGitStore()
   const ops = useAgentOperations({
     agentSessionStore,
     chatStore,
@@ -127,7 +134,7 @@ function setup(storeWorkspaceId: string = 'ws-1', getWorkerId: () => string = ()
     getCurrentTabContext: () => ({ workerId: getWorkerId(), workingDir: '/tmp' }),
     newAgentDialog: { open: vi.fn(), close: vi.fn(), isOpen: () => false },
     setNewAgentLoadingProvider: vi.fn(),
-    repoGitStore: createRepoGitStore(),
+    repoGitStore,
   })
 
   return {
@@ -136,6 +143,7 @@ function setup(storeWorkspaceId: string = 'ws-1', getWorkerId: () => string = ()
     agentSessionStore,
     controlStore,
     chatStore,
+    repoGitStore,
     ops,
     /** Place an agent on the seeded root tile — the only tile that exists. */
     add: (fields: { id: string } & Record<string, unknown>) =>
@@ -194,6 +202,108 @@ describe('useAgentOperations', () => {
             agentProvider: AgentProvider.CODEX,
             workingDir: '/tmp',
           }))
+        }
+        finally {
+          dispose()
+        }
+      })
+    })
+
+    /**
+     * What a freshly opened agent really shows in the sidebar.
+     *
+     * The OpenAgent response carries NO git status -- the worker computes it in
+     * startup phase 1 and sends it on the STARTING broadcast, so the
+     * `git status` shell-out does not block the RPC
+     * (`TestOpenAgent_ResponseHasNilGitStatus`). The row therefore gets no
+     * `gitToplevel` from the response, and the optimistic seed is the tab's
+     * only repo identity until the broadcast lands.
+     *
+     * That seed comes from the ACTIVE tab, which can be on a DIFFERENT worker:
+     * `resolveOptimisticGitInfo` compares working directories, never worker
+     * ids. So the new tab shows the other machine's branch for the length of
+     * the agent's startup. This test states that, so a change to it is a
+     * decision and not an accident.
+     */
+    it('shows the active tab\'s branch until the worker reports, even across workers', async () => {
+      await createRoot(async (dispose) => {
+        try {
+          mockListAvailableProviders.mockResolvedValue({ providers: [AgentProvider.CLAUDE_CODE] })
+          mockOpenAgent.mockResolvedValue({
+            agent: create(AgentInfoSchema, {
+              id: 'new-agent',
+              workerId: 'w-1',
+              // Matched to the active tab's dir on purpose: `resolveOptimisticGitInfo`
+              // compares the RESPONSE's working dir against the active tab's, and
+              // refuses to copy anything when they differ.
+              workingDir: '/repo',
+              agentProvider: AgentProvider.CLAUDE_CODE,
+              // No gitStatus: the shape the worker really sends.
+            }),
+          })
+
+          const { ops, view, add, repoGitStore } = setup()
+          add({ id: 'active', workerId: 'w-other', workingDir: '/repo', gitToplevel: '/repo' })
+          repoGitStore.upsert(repoKey('w-other', '/repo'), {
+            workerId: 'w-other',
+            toplevel: '/repo',
+            branch: 'on-another-machine',
+            gitStatusSeen: true,
+          })
+
+          await flush()
+          await ops.handleOpenAgent()
+          await flush()
+
+          const tab = view.getAgentTab('new-agent')
+          expect(tab?.gitToplevel, 'the row identity comes from the seed, not the response').toBe('/repo')
+          expect(
+            repoGitStore.get(repoKey('w-1', '/repo'))?.branch,
+            'the guess stands in until the STARTING broadcast replaces it',
+          ).toBe('on-another-machine')
+        }
+        finally {
+          dispose()
+        }
+      })
+    })
+
+    /**
+     * The row and the store must key the tab to the SAME repo.
+     *
+     * `seed` is spread BEFORE `agentFields` so the worker's own answer wins on
+     * the row, exactly as it wins in the store. Reverse the two and a response
+     * that resolves a different toplevel than the active tab's guess leaves the
+     * row pointing at one key while the authoritative entry sits under another,
+     * which is the divergence that shows a tab under the wrong repo group.
+     */
+    it('prefers the response\'s own toplevel over the active tab\'s guess on the row', async () => {
+      await createRoot(async (dispose) => {
+        try {
+          mockListAvailableProviders.mockResolvedValue({ providers: [AgentProvider.CLAUDE_CODE] })
+          mockOpenAgent.mockResolvedValue({
+            agent: create(AgentInfoSchema, {
+              id: 'new-agent',
+              workerId: 'w-1',
+              workingDir: '/repo',
+              agentProvider: AgentProvider.CLAUDE_CODE,
+              // A linked worktree: the same working dir resolves to a DEEPER
+              // toplevel here than the active tab recorded for its own worker.
+              gitStatus: create(GitRepoStatusSchema, { toplevel: '/repo/wt' }),
+            }),
+          })
+
+          const { ops, view, add } = setup()
+          add({ id: 'active', workerId: 'w-other', workingDir: '/repo', gitToplevel: '/repo' })
+
+          await flush()
+          await ops.handleOpenAgent()
+          await flush()
+
+          expect(
+            view.getAgentTab('new-agent')?.gitToplevel,
+            'the worker that owns this agent answered; the guess must not outrank it',
+          ).toBe('/repo/wt')
         }
         finally {
           dispose()
@@ -334,7 +444,7 @@ describe('useAgentOperations', () => {
             agentProvider: AgentProvider.CODEX,
             agentSessionId: 'thread-1',
           })
-          add({ id: agent.id, ...protoToAgentTabFields(agent.workerId, agent) })
+          add({ id: agent.id, ...protoToAgentTabFields(fixtureStore, agent.workerId, agent) })
           mockInterruptAgent.mockResolvedValue({})
 
           await ops.handleInterrupt('codex-1')
@@ -371,7 +481,7 @@ describe('useAgentOperations', () => {
               ],
             }],
           })
-          add({ id: agent.id, ...protoToAgentTabFields(agent.workerId, agent) })
+          add({ id: agent.id, ...protoToAgentTabFields(fixtureStore, agent.workerId, agent) })
           mockUpdateAgentSettings.mockRejectedValueOnce(new Error('boom'))
 
           await ops.handleAgentSettingChange('a-1', { sets: { opencode_mode: 'fast' } })
@@ -421,7 +531,7 @@ describe('useAgentOperations', () => {
               },
             ],
           })
-          add({ id: agent.id, ...protoToAgentTabFields(agent.workerId, agent) })
+          add({ id: agent.id, ...protoToAgentTabFields(fixtureStore, agent.workerId, agent) })
 
           // First call will fail; second succeeds.
           let rejectFirst!: (err: Error) => void
@@ -475,7 +585,7 @@ describe('useAgentOperations', () => {
               ],
             }],
           })
-          add({ id: agent.id, ...protoToAgentTabFields(agent.workerId, agent) })
+          add({ id: agent.id, ...protoToAgentTabFields(fixtureStore, agent.workerId, agent) })
           mockUpdateAgentSettings.mockRejectedValueOnce(new Error('boom'))
 
           await ops.handleAgentSettingChange('a-2', { sets: { opencode_mode: 'fast' } })
@@ -496,7 +606,7 @@ describe('useAgentOperations', () => {
         try {
           const { chatStore, ops, add } = setup()
           const agent = create(AgentInfoSchema, { id: 'a-1', workerId: 'w-1' })
-          add({ id: agent.id, ...protoToAgentTabFields(agent.workerId, agent) })
+          add({ id: agent.id, ...protoToAgentTabFields(fixtureStore, agent.workerId, agent) })
           chatStore.getMessages.mockReturnValue([{
             id: 'local-1',
             source: MessageSource.USER,
@@ -522,7 +632,7 @@ describe('useAgentOperations', () => {
         try {
           const { chatStore, ops, add } = setup()
           const agent = create(AgentInfoSchema, { id: 'a-2', workerId: 'w-1' })
-          add({ id: agent.id, ...protoToAgentTabFields(agent.workerId, agent) })
+          add({ id: agent.id, ...protoToAgentTabFields(fixtureStore, agent.workerId, agent) })
           chatStore.getMessages.mockReturnValue([{
             id: 'local-2',
             source: MessageSource.USER,
@@ -551,7 +661,7 @@ describe('useAgentOperations', () => {
           mockDeleteAgentMessage.mockReset()
           mockShowWarnToast.mockReset()
           const agent = create(AgentInfoSchema, { id: 'a-3', workerId: 'w-1' })
-          add({ id: agent.id, ...protoToAgentTabFields(agent.workerId, agent) })
+          add({ id: agent.id, ...protoToAgentTabFields(fixtureStore, agent.workerId, agent) })
           // A SERVER-persisted failed message (non-local id) so the deleteAgentMessage
           // cleanup path runs.
           chatStore.getMessages.mockReturnValue([{
@@ -584,7 +694,7 @@ describe('useAgentOperations', () => {
         try {
           const { view, chatStore, ops, add } = setup()
           const agent = create(AgentInfoSchema, { id: 'a-1', workerId: 'w-1' })
-          add({ id: agent.id, ...protoToAgentTabFields(agent.workerId, agent) })
+          add({ id: agent.id, ...protoToAgentTabFields(fixtureStore, agent.workerId, agent) })
           add({ id: 'a-1', title: 'Agent Olivia', workerId: 'w-1', workingDir: '/tmp' })
 
           // Never-resolving RPC to prove the UI mutation is synchronous.
@@ -611,7 +721,7 @@ describe('useAgentOperations', () => {
         try {
           const { ops, add } = setup()
           const agent = create(AgentInfoSchema, { id: 'a-remove', workerId: 'w-1' })
-          add({ id: agent.id, ...protoToAgentTabFields(agent.workerId, agent) })
+          add({ id: agent.id, ...protoToAgentTabFields(fixtureStore, agent.workerId, agent) })
           add({ id: 'a-remove', title: 'Agent Remove', workerId: 'w-1', workingDir: '/tmp' })
 
           mockCloseAgent.mockResolvedValueOnce({
@@ -639,7 +749,7 @@ describe('useAgentOperations', () => {
         try {
           const { view, ops, add } = setup()
           const agent = create(AgentInfoSchema, { id: 'a-fail', workerId: 'w-1' })
-          add({ id: agent.id, ...protoToAgentTabFields(agent.workerId, agent) })
+          add({ id: agent.id, ...protoToAgentTabFields(fixtureStore, agent.workerId, agent) })
           add({ id: 'a-fail', title: 'Agent Fail', workerId: 'w-1', workingDir: '/tmp' })
 
           mockCloseAgent.mockResolvedValueOnce({
@@ -669,7 +779,7 @@ describe('useAgentOperations', () => {
         try {
           const { view, ops, add } = setup()
           const agent = create(AgentInfoSchema, { id: 'a-reject', workerId: 'w-1' })
-          add({ id: agent.id, ...protoToAgentTabFields(agent.workerId, agent) })
+          add({ id: agent.id, ...protoToAgentTabFields(fixtureStore, agent.workerId, agent) })
           add({ id: 'a-reject', title: 'Agent Reject', workerId: 'w-1', workingDir: '/tmp' })
 
           const err = new Error('network down')
@@ -692,7 +802,7 @@ describe('useAgentOperations', () => {
         try {
           const { view, ops, add } = setup()
           const agent = create(AgentInfoSchema, { id: 'a-2', workerId: '' })
-          add({ id: agent.id, ...protoToAgentTabFields(agent.workerId, agent) })
+          add({ id: agent.id, ...protoToAgentTabFields(fixtureStore, agent.workerId, agent) })
           add({ id: 'a-2', title: 'Agent Liam', workerId: '', workingDir: '' })
 
           mockCloseAgent.mockClear()
@@ -742,7 +852,7 @@ describe('useAgentOperations', () => {
           const { view, ops, add } = setup()
           for (const id of ['a-root', 'a-child', 'a-grandchild']) {
             const agent = create(AgentInfoSchema, { id, workerId: 'w-1' })
-            add({ id, ...protoToAgentTabFields(agent.workerId, agent) })
+            add({ id, ...protoToAgentTabFields(fixtureStore, agent.workerId, agent) })
             add({ id, title: id, workerId: 'w-1', workingDir: '/tmp' })
           }
           // No parentAgentId on either child: the hydration that would set one
@@ -786,7 +896,7 @@ describe('useAgentOperations', () => {
           const { view, ops, add, harness } = setup()
           for (const id of ['a-root3', 'a-real']) {
             const agent = create(AgentInfoSchema, { id, workerId: 'w-1' })
-            add({ id, ...protoToAgentTabFields(agent.workerId, agent) })
+            add({ id, ...protoToAgentTabFields(fixtureStore, agent.workerId, agent) })
             add({ id, title: id, workerId: 'w-1', workingDir: '/tmp' })
           }
 
@@ -827,7 +937,7 @@ describe('useAgentOperations', () => {
           const { ops, add, chatStore, controlStore } = setup()
           for (const id of ['a-root4', 'a-kid']) {
             const agent = create(AgentInfoSchema, { id, workerId: 'w-1' })
-            add({ id, ...protoToAgentTabFields(agent.workerId, agent) })
+            add({ id, ...protoToAgentTabFields(fixtureStore, agent.workerId, agent) })
             add({ id, title: id, workerId: 'w-1', workingDir: '/tmp' })
           }
           const clearAgent = vi.spyOn(controlStore, 'clearAgent')
@@ -857,7 +967,7 @@ describe('useAgentOperations', () => {
           const { view, ops, add } = setup()
           for (const id of ['a-root2', 'a-child2']) {
             const agent = create(AgentInfoSchema, { id, workerId: 'w-1' })
-            add({ id, ...protoToAgentTabFields(agent.workerId, agent) })
+            add({ id, ...protoToAgentTabFields(fixtureStore, agent.workerId, agent) })
             add({ id, title: id, workerId: 'w-1', workingDir: '/tmp' })
           }
           mockCloseAgent.mockRejectedValueOnce(new Error('worker unreachable'))

--- a/frontend/src/components/shell/useAgentOperations.ts
+++ b/frontend/src/components/shell/useAgentOperations.ts
@@ -26,8 +26,7 @@ import { TabType } from '~/generated/leapmux/v1/workspace_pb'
 import { base64ToUint8Array } from '~/lib/base64'
 import { getInnerMessage, parseMessageContent } from '~/lib/messageParser'
 import { getMruProviders, touchMruProvider } from '~/lib/mruAgentProviders'
-import { migrateErrorHintFromForResolvedRepo, upsertRepoGitFromProtoStatus } from '~/stores/repoGit'
-import { protoToAgentTabFields, resolveOptimisticGitInfo, seedOptimisticRepoGit, setOptionValue } from '~/stores/tab.helpers'
+import { openedAgentTabFields, planOptimisticRepoGit, setOptionValue } from '~/stores/tab.helpers'
 import { emitRemoveTab, emitRemoveTabs, hasLiveTabRecord } from '~/stores/tabOps'
 import { openTabInFocusedTile } from './openTabInFocusedTile'
 import { warnUnlessPlaceableTab } from './placeableTabGuard'
@@ -172,39 +171,51 @@ export function useAgentOperations(props: UseAgentOperationsProps) {
         ...(sessionId ? { agentSessionId: sessionId } : {}),
       })
       if (resp.agent) {
+        // Seed git branch / origin from the active tab when both resolve to
+        // the same directory. Agent tabs have no shellStartDir --
+        // effectiveGitDir collapses to workingDir for them.
+        //
+        // The worker resolves the real values later. The OpenAgent response
+        // carries no git status: the worker computes it in startup phase 1 and
+        // sends it on the STARTING broadcast, because the `git status`
+        // shell-out would otherwise block the RPC. So this seed is what the
+        // sidebar shows until that broadcast lands.
+        //
+        // ONE read of the active tab feeds both the dir-match guard and the
+        // branch copy. A second read would let a later edit give the two
+        // different tabs.
+        const activeTab = props.selection.activeTabForWorkspace(workspaceId)
+        const seed = planOptimisticRepoGit(
+          props.repoGitStore,
+          activeTab,
+          { workerId: resp.agent.workerId, workingDir: resp.agent.workingDir },
+        )
         // Everything the OpenAgent response carries that the CRDT does not:
         // title, provider, status, session, option catalogs. This also primes
         // the settings-label cache with the agent's catalogs.
-        const agentFields = protoToAgentTabFields(resp.agent.workerId, resp.agent)
-        // Seed git branch / origin from the active tab when both resolve to
-        // the same directory; the authoritative values arrive later on the
-        // agent's first status update. Agent tabs have no shellStartDir —
-        // effectiveGitDir collapses to workingDir for them.
-        const seed = resolveOptimisticGitInfo(props.selection.activeTabForWorkspace(workspaceId), {
-          workingDir: agentFields.workingDir,
-        })
-        seedOptimisticRepoGit(
-          props.repoGitStore,
-          props.selection.activeTabForWorkspace(workspaceId),
-          { workerId: resp.agent.workerId, workingDir: agentFields.workingDir },
-        )
-        upsertRepoGitFromProtoStatus(props.repoGitStore, resp.agent.workerId, resp.agent.gitStatus, {
-          migrateErrorHintFrom: migrateErrorHintFromForResolvedRepo(
-            resp.agent.workerId,
-            { workingDir: agentFields.workingDir, gitToplevel: agentFields.gitToplevel },
-            resp.agent.gitStatus,
-          ),
-        })
+        //
         // `hydrated`: the OpenAgent response IS the worker's answer for this
         // tab, so `useTabHydrators` must not immediately re-ask. Its reply
         // would land without the pending-axis suppression the live settings
         // path applies, overwriting an optimistic edit made during the
         // round-trip.
-        openTabInFocusedTile(
+        const agentFields = openedAgentTabFields(props.repoGitStore, resp.agent)
+        const placedTileId = openTabInFocusedTile(
           props,
           { type: TabType.AGENT, id: resp.agent.id, workerId: resp.agent.workerId },
-          { ...agentFields, ...seed, hydrated: true },
+          // `seed.fields` FIRST, so the worker's own answer wins on the row for
+          // the same reason it wins in the store. The two halves of a tab's
+          // repo identity must not resolve a conflict in opposite directions.
+          //
+          // Today the response carries no toplevel, so the seed is the only
+          // source and the order changes nothing. It matters if the response
+          // ever carries one and it differs from the active tab's guess.
+          { ...seed.fields, ...agentFields },
         )
+        // Only now, because placement can be refused. Writing the store first
+        // leaves an entry that no tab reads and nothing reclaims.
+        if (placedTileId)
+          seed.commit()
         // Focus the editor after the reactive updates propagate to the DOM.
         requestAnimationFrame(() => props.focusEditor?.())
         return true

--- a/frontend/src/components/shell/useTabHydrators.test.ts
+++ b/frontend/src/components/shell/useTabHydrators.test.ts
@@ -100,12 +100,16 @@ function setup(workspaceId = 'ws-test') {
     ...stores,
     repoGitStore,
     harness,
-    mount: (onlineWorkerIds?: () => ReadonlySet<string>) =>
+    mount: (
+      onlineWorkerIds?: () => ReadonlySet<string>,
+      settingsPendingAxes?: (agentId: string) => ReadonlySet<string>,
+    ) =>
       useTabHydrators({
         view: stores.view,
         metadata: stores.metadata,
         repoGitStore,
         onlineWorkerIds,
+        settingsPendingAxes,
       }),
     add(type: TabType, id: string, workerId = 'w1', tileId = harness.rootTileId) {
       seq += 1
@@ -658,6 +662,87 @@ describe('useTabHydrators', () => {
       await flush()
 
       expect(mockListTerminals).toHaveBeenCalledTimes(initial)
+      d()
+    })
+
+    /**
+     * An agent tab has no re-arm of its own. A terminal re-arms on DISCONNECTED,
+     * which is why a terminal repaired itself after an outage and an agent did
+     * not -- its title, status and option catalogs froze at whatever was true
+     * before the link dropped, for the life of the page.
+     */
+    it('re-asks for an already hydrated agent when its worker comes back', async () => {
+      const s = setup()
+      const [online, setOnline] = createSignal<ReadonlySet<string>>(new Set(['w1']))
+      mockListAgents.mockResolvedValue({ agents: [agentInfo('a1', { title: 'Before' })], verdicts: [] })
+      const d = createRoot((dispose) => {
+        s.add(TabType.AGENT, 'a1')
+        s.mount(() => online())
+        return dispose
+      })
+      await flush()
+      await flush()
+      expect(s.view.getAgentTab('a1')?.title).toBe('Before')
+      const hydrated = mockListAgents.mock.calls.length
+
+      // The link drops and returns. The tab set never changed, and the tab is
+      // still `hydrated`.
+      setOnline(new Set<string>())
+      await flush()
+      mockListAgents.mockResolvedValue({ agents: [agentInfo('a1', { title: 'After' })], verdicts: [] })
+      setOnline(new Set(['w1']))
+      await flush()
+      await flush()
+
+      expect(mockListAgents.mock.calls.length, 'coming back is worth one more ask')
+        .toBeGreaterThan(hydrated)
+      expect(s.view.getAgentTab('a1')?.title, 'the tab catches up on what it missed').toBe('After')
+      d()
+    })
+
+    /**
+     * The re-ask is what makes this reachable: the batch can now run for a tab
+     * that has an in-flight settings edit. The live status handler already
+     * routes every catalog through `resolveSettingsTabFields`, and this batch
+     * must too, or the worker's older answer lands over what the user just
+     * chose.
+     */
+    it('keeps an in-flight settings edit when a re-ask reply lands', async () => {
+      const s = setup()
+      const [online, setOnline] = createSignal<ReadonlySet<string>>(new Set(['w1']))
+      // `currentValue` is the field the mapper reads. With any other name the
+      // reply carries no `optionValues` at all, and the test cannot fail.
+      const groups = [{
+        id: 'model',
+        label: 'Model',
+        currentValue: 'sonnet',
+        options: [{ id: 'sonnet', label: 'Sonnet' }, { id: 'opus', label: 'Opus' }],
+      }]
+      mockListAgents.mockResolvedValue({
+        agents: [agentInfo('a1', { optionGroups: groups })],
+        verdicts: [],
+      })
+      const d = createRoot((dispose) => {
+        s.add(TabType.AGENT, 'a1')
+        // The user is changing the model right now.
+        s.mount(() => online(), () => new Set(['model']))
+        return dispose
+      })
+      await flush()
+      await flush()
+
+      // The optimistic edit the user made while the reply was on its way.
+      s.metadata.patch('a1', { optionValues: { model: 'opus' } })
+      setOnline(new Set<string>())
+      await flush()
+      setOnline(new Set(['w1']))
+      await flush()
+      await flush()
+
+      expect(
+        s.view.getAgentTab('a1')?.optionValues?.model,
+        'the worker\'s older answer must not land over the pending axis',
+      ).toBe('opus')
       d()
     })
 

--- a/frontend/src/components/shell/useTabHydrators.ts
+++ b/frontend/src/components/shell/useTabHydrators.ts
@@ -1,15 +1,19 @@
 import type { createRepoGitStore } from '~/stores/repoGit.store'
 import type { TabMetadataStore } from '~/stores/tabMetadata.store'
 import type { TabView } from '~/stores/tabView'
-import { createEffect, createMemo, onCleanup, untrack } from 'solid-js'
+import { createEffect, createMemo, createSignal, onCleanup, untrack } from 'solid-js'
 import { getFileTabPath, listAgents, listTerminals } from '~/api/workerRpc'
 import { TabHydrationStatus } from '~/generated/leapmux/v1/common_pb'
 import { TerminalStatus } from '~/generated/leapmux/v1/terminal_pb'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
+import { resolveSettingsTabFields } from '~/hooks/agentEvents'
 import { createExponentialBackoff } from '~/lib/retry'
 import { sameKeys } from '~/lib/sameKeys'
 import { migrateErrorHintFromForResolvedRepo, upsertRepoGitFromProtoStatus } from '~/stores/repoGit'
 import { protoToAgentTabFields, tabKey, terminalMetadata } from '~/stores/tab.helpers'
+
+/** No axis is in flight. Shared so the common case allocates nothing. */
+const EMPTY_PENDING_AXES: ReadonlySet<string> = new Set()
 
 /**
  * Per-tab-type hydration of CRDT-projected tabs that arrived without
@@ -42,6 +46,17 @@ export interface UseTabHydratorsOpts {
    * its startup spinner, for the life of the page.
    */
   onlineWorkerIds?: () => ReadonlySet<string>
+  /**
+   * In-flight settings axes for an agent, so a re-ask cannot overwrite an
+   * optimistic edit the user made while the reply was on its way.
+   *
+   * The live status handler routes every catalog it applies through
+   * `resolveSettingsTabFields` for this reason. The batch below applied the
+   * `ListAgents` reply RAW, which was safe only while the batch could never run
+   * twice for one tab. It can now (see the worker-online re-ask), so it routes
+   * through the same suppression.
+   */
+  settingsPendingAxes?: (agentId: string) => ReadonlySet<string>
 }
 
 export function useTabHydrators(opts: UseTabHydratorsOpts): void {
@@ -55,6 +70,34 @@ export function useTabHydrators(opts: UseTabHydratorsOpts): void {
    * fields happened to arrive.
    */
   const isHydrated = (tabId: string): boolean => opts.metadata.get(tabId)?.hydrated === true
+
+  /**
+   * Agent tabs whose worker came back and that must be asked again, although
+   * they are already `hydrated`.
+   *
+   * An agent tab has no other re-arm. A terminal tab re-arms on DISCONNECTED,
+   * which is why a terminal repaired itself after an outage and an agent did
+   * not: its title, status and option catalogs stayed at whatever was true
+   * before the link dropped, for the life of the page.
+   *
+   * The set is what makes the flag re-armable WITHOUT making `hydrated` itself
+   * mean something weaker. A re-ask is safe only because the batch now applies
+   * the reply through `resolveSettingsTabFields`; see `settingsPendingAxes`.
+   */
+  const [reaskAgentTabIds, setReaskAgentTabIds] = createSignal<ReadonlySet<string>>(new Set())
+
+  const dropReask = (tabIds: Iterable<string>) => {
+    setReaskAgentTabIds((prev) => {
+      let next: Set<string> | undefined
+      for (const id of tabIds) {
+        if (!prev.has(id))
+          continue
+        next ??= new Set(prev)
+        next.delete(id)
+      }
+      return next ?? prev
+    })
+  }
 
   interface BaseSpec {
     predicate: (tab: Tab) => boolean
@@ -352,6 +395,42 @@ export function useTabHydrators(opts: UseTabHydratorsOpts): void {
     }
   }
 
+  /**
+   * Arm a re-ask for every agent tab of a worker that just came back.
+   *
+   * The generic worker-online effect inside `createTabHydration` resets the
+   * retry budget, but it selects from the CANDIDATE set -- and a `hydrated` tab
+   * is not a candidate, so it could never reach one. This marks those tabs so
+   * the predicate admits them, and the same effect then dispatches the batch.
+   *
+   * Keyed on the OFF -> ON transition, not on membership: the hub re-pushes the
+   * worker list on every `WORKERS_CHANGED` frame, and a worker that stayed
+   * online through all of them has nothing to re-ask.
+   */
+  if (opts.onlineWorkerIds) {
+    let wasOnline: ReadonlySet<string> | undefined
+    createEffect(() => {
+      const online = opts.onlineWorkerIds!()
+      // The FIRST reading is not a transition. Treating it as one would re-ask
+      // for every agent tab on a page load, right after the initial hydration.
+      const previous = wasOnline
+      wasOnline = online
+      if (!previous)
+        return
+      const cameOnline = [...online].filter(id => !previous.has(id))
+      if (cameOnline.length === 0)
+        return
+      untrack(() => {
+        const ids = opts.view.all()
+          .filter(t => t.type === TabType.AGENT && t.workerId && cameOnline.includes(t.workerId))
+          .map(t => t.id)
+        if (ids.length === 0)
+          return
+        setReaskAgentTabIds(prev => new Set([...prev, ...ids]))
+      })
+    })
+  }
+
   // FILE: GetFileTabPath populates the path/title via worker E2EE. The
   // WatchWorkerPrivateEvents stream's bootstrap reply covers the
   // late-joiner case, but if a tab lands before the private-event
@@ -395,11 +474,16 @@ export function useTabHydrators(opts: UseTabHydratorsOpts): void {
   // call instead of N.
   createTabHydration({
     kind: 'batched',
-    predicate: tab => tab.type === TabType.AGENT && Boolean(tab.workerId) && !isHydrated(tab.id),
+    predicate: tab => tab.type === TabType.AGENT
+      && Boolean(tab.workerId)
+      && (!isHydrated(tab.id) || reaskAgentTabIds().has(tab.id)),
     fetchBatch: async (workerId, tabs) => {
       const resp = await listAgents(workerId, { tabIds: tabs.map(t => t.id) })
       const byId = new Map(resp.agents.map(a => [a.id, a]))
       const resolved = new Set<string>()
+      // The ask happened, so drop the re-ask marks whatever the reply says. A
+      // tab the worker no longer knows must not stay armed and re-ask forever.
+      dropReask(tabs.map(t => t.id))
       for (const tab of tabs) {
         const agent = byId.get(tab.id)
         if (!agent)
@@ -415,10 +499,24 @@ export function useTabHydrators(opts: UseTabHydratorsOpts): void {
         // the race it used to have: `listAgents` is awaited, and a live status
         // push landing meanwhile would have made the pre-await snapshot a stale
         // basis for the comparison.
-        opts.metadata.patch(tab.id, protoToAgentTabFields(workerId, agent))
-        upsertRepoGitFromProtoStatus(opts.repoGitStore, workerId, agent.gitStatus, {
+        // NOT the raw mapper's settings fields. `resolveSettingsTabFields` is
+        // the same path the live status handler uses, and it keeps a per-axis
+        // value the user is editing right now instead of overwriting it with
+        // the worker's older answer. A re-ask makes that reachable: this batch
+        // can run for a tab that already has in-flight edits.
+        // The mapper writes the repo entry itself, from the same status it
+        // reads `gitToplevel` from, so the two halves cannot be written apart.
+        // This caller holds a LIVE tab, so it is the one that can compute the
+        // orphan-migration tip.
+        const fields = protoToAgentTabFields(opts.repoGitStore, workerId, agent, {
           migrateErrorHintFrom: migrateErrorHintFromForResolvedRepo(workerId, tab, agent.gitStatus),
         })
+        const settingsFields = resolveSettingsTabFields(
+          opts.view.getAgentTab(tab.id),
+          agent.optionGroups,
+          opts.settingsPendingAxes?.(tab.id) ?? EMPTY_PENDING_AXES,
+        )
+        opts.metadata.patch(tab.id, { ...fields, ...settingsFields })
         resolved.add(tab.id)
       }
       return { resolved, verdicts: resp.verdicts }

--- a/frontend/src/components/shell/useTabOperations.ts
+++ b/frontend/src/components/shell/useTabOperations.ts
@@ -26,7 +26,7 @@ import { createUpdatableDialogState } from '~/hooks/createDialogState'
 import { makeIdGenerator } from '~/lib/idGenerator'
 import { basename } from '~/lib/paths'
 import { MAX_BACKGROUND_CHAT_MESSAGES } from '~/stores/chat.store'
-import { descendantAgentTabs, resolveOptimisticGitInfo, seedOptimisticRepoGit, tabKey } from '~/stores/tab.helpers'
+import { descendantAgentTabs, planOptimisticRepoGit, tabKey } from '~/stores/tab.helpers'
 import { emitRemoveTab } from '~/stores/tabOps'
 import { openTabInFocusedTile } from './openTabInFocusedTile'
 import { focusTile, removeEmptyFloatingWindow } from './tileLifecycle'
@@ -631,8 +631,11 @@ export function useTabOperations(opts: UseTabOperationsOpts) {
     // only seeds when the two resolve to the same directory. Without it the tab
     // renders ungrouped until the next git-status refresh reaches it, even
     // though the answer was on screen at the moment of the open.
-    const gitSeed = resolveOptimisticGitInfo(activeTab(), { workingDir: ctx.workingDir })
-    seedOptimisticRepoGit(opts.repoGitStore, activeTab(), {
+    //
+    // ONE read of the active tab, and ONE seed call. Read twice, a later edit
+    // can decide the directory match against one tab and copy the branch from
+    // another.
+    const gitSeed = planOptimisticRepoGit(opts.repoGitStore, activeTab(), {
       workerId: ctx.workerId,
       workingDir: ctx.workingDir,
     })
@@ -640,7 +643,7 @@ export function useTabOperations(opts: UseTabOperationsOpts) {
       { view, layoutStore, selection, metadata },
       { type: TabType.FILE, id: tabId, workerId: ctx.workerId },
       {
-        ...gitSeed,
+        ...gitSeed.fields,
         filePath: path,
         workingDir: ctx.workingDir,
         title: fileName,
@@ -662,6 +665,8 @@ export function useTabOperations(opts: UseTabOperationsOpts) {
       showWarnToast('Cannot open the file', new Error('The workspace is not ready for a new tab yet.'))
       return
     }
+    // The tab exists, so the optimistic repo copy now has a reader.
+    gitSeed.commit()
 
     // E2EE worker-side path registration. The hub never sees the path; the
     // worker persists `(user_id, tab_id, file_path, working_dir)` and emits

--- a/frontend/src/components/shell/useTerminalOperations.ts
+++ b/frontend/src/components/shell/useTerminalOperations.ts
@@ -22,7 +22,7 @@ import { useAvailableShells } from '~/hooks/useAvailableShells'
 import { createInflightCache } from '~/lib/inflightCache'
 import { createSharedInputQueues } from '~/lib/inputQueue'
 import { DEFAULT_TERMINAL_COLS, DEFAULT_TERMINAL_ROWS, ENTER_KEY_CR } from '~/lib/terminal'
-import { openedTerminalMetadata, resolveOptimisticGitInfo, seedOptimisticRepoGit } from '~/stores/tab.helpers'
+import { openedTerminalMetadata, planOptimisticRepoGit } from '~/stores/tab.helpers'
 import { emitRemoveTab } from '~/stores/tabOps'
 import { openTabInFocusedTile } from './openTabInFocusedTile'
 import { warnUnlessPlaceableTab } from './placeableTabGuard'
@@ -172,20 +172,24 @@ export function useTerminalOperations(props: UseTerminalOperationsProps) {
       // the active tab -- so the guard could never reject, and "open a
       // terminal here" on a sibling worktree inherited the wrong repo's
       // branch, origin and diff badges.
-      const seed = resolveOptimisticGitInfo(activeTab, {
-        shellStartDir: args.shellStartDir,
-        workingDir: ctx.workingDir,
-      })
-      seedOptimisticRepoGit(props.repoGitStore, activeTab, {
+      //
+      // ONE call, so the guard and the row seed cannot be given different
+      // directories. Two calls meant two hand-built argument objects that had
+      // to agree.
+      const seed = planOptimisticRepoGit(props.repoGitStore, activeTab, {
         workerId: ctx.workerId,
         shellStartDir: args.shellStartDir,
         workingDir: ctx.workingDir,
       })
-      openTabInFocusedTile(
+      const placedTileId = openTabInFocusedTile(
         props,
         { type: TabType.TERMINAL, id: resp.terminalId, workerId: ctx.workerId },
-        { ...meta, ...seed },
+        { ...meta, ...seed.fields },
       )
+      // Only once the tab exists. Placement can be refused, and a store entry
+      // written before it would be an orphan nothing reclaims.
+      if (placedTileId)
+        seed.commit()
     }
     catch (err) {
       showWarnToast('Failed to open terminal', err)

--- a/frontend/src/components/shell/useWorkerSection.test.ts
+++ b/frontend/src/components/shell/useWorkerSection.test.ts
@@ -79,11 +79,8 @@ beforeEach(() => {
  * testable on its own, which it was not while it lived inline.
  */
 describe('useWorkerSection', () => {
-  function mount(
-    getUserId: () => string = () => 'u1',
-    clearRepoGitForWorker?: (workerId: string) => void,
-  ) {
-    return useWorkerSection({ getUserId, keyPinConfirmDialog: createDialogState(), clearRepoGitForWorker })
+  function mount(getUserId: () => string = () => 'u1') {
+    return useWorkerSection({ getUserId, keyPinConfirmDialog: createDialogState() })
   }
 
   it('fetches workers once the user id is known', async () => {
@@ -200,10 +197,18 @@ describe('useWorkerSection', () => {
     })
   })
 
-  it('clears keyed git state when a worker is deregistered', async () => {
+  /**
+   * Deregistration removes the worker from the list, and NOTHING else.
+   *
+   * It used to clear the worker's keyed git state too. That left every tab of
+   * the worker under its repo with no branch name, for the life of the page:
+   * nothing removes those tab rows, they keep `gitToplevel`, the sidebar groups
+   * a tab by that field, and the branch label comes from the store. It is the
+   * same defect the worker-offline sweep used to cause, from the other trigger.
+   */
+  it('removes the worker from the list and leaves its keyed git state alone', async () => {
     await createRoot(async (dispose) => {
-      const clearRepoGitForWorker = vi.fn()
-      const s = mount(() => 'u1', clearRepoGitForWorker)
+      const s = mount(() => 'u1')
       await flush()
 
       s.openWorkerSettings(worker('w1') as never)
@@ -216,7 +221,6 @@ describe('useWorkerSection', () => {
       await flush()
 
       expect(mockDeregisterWorker).toHaveBeenCalledWith({ workerId: 'w1' })
-      expect(clearRepoGitForWorker).toHaveBeenCalledWith('w1')
       expect(s.workers().map(w => w.id)).toEqual([])
 
       unmount()

--- a/frontend/src/components/shell/useWorkerSection.tsx
+++ b/frontend/src/components/shell/useWorkerSection.tsx
@@ -38,12 +38,8 @@ export interface UseWorkerSectionOpts {
    * that must be registered exactly once.
    */
   keyPinConfirmDialog: DialogState<KeyPinConfirmState>
-  /**
-   * Drop keyed git state for a worker that left the account. Called from the
-   * deregister success path so entries do not depend on the offline sweep
-   * (which may never run if the worker was already offline).
-   */
-  clearRepoGitForWorker?: (workerId: string) => void
+  // No `clearRepoGitForWorker`. See `onDeregistered` below for why the
+  // repo-keyed git store outlives a deregistration.
 }
 
 export interface WorkerSection {
@@ -130,9 +126,18 @@ export function useWorkerSection(opts: UseWorkerSectionOpts): WorkerSection {
           <WorkerSettingsDialog
             worker={target()}
             onClose={() => setDeregisterTarget(null)}
+            // The repo-keyed git store is NOT cleared here. Deregistration
+            // removes the worker from this list, and nothing removes that
+            // worker's tab rows: they keep `gitToplevel`, and the sidebar groups
+            // a tab by that field while it reads the branch label from the
+            // store. Clearing therefore left every tab of the worker under its
+            // repo with no branch name, for the life of the page, with no way
+            // back -- the same defect the worker-offline sweep used to cause.
+            //
+            // An entry is last-known working-tree state. The rows it labels
+            // outlive the deregistration, so it should too.
             onDeregistered={() => {
               const id = target().id
-              opts.clearRepoGitForWorker?.(id)
               setWorkers(prev => prev.filter(w => w.id !== id))
               setDeregisterTarget(null)
             }}

--- a/frontend/src/components/workspace/NewWorkspaceDialog.test.tsx
+++ b/frontend/src/components/workspace/NewWorkspaceDialog.test.tsx
@@ -226,6 +226,30 @@ describe('newWorkspaceDialog', () => {
     }))
   })
 
+  // Both facts belong to `openedAgentTabFields`, not to this call site; its
+  // doc comment states why each one holds.
+  //   - `hydrated: true` reaches the row.
+  //   - The row gets no `gitToplevel`, because the response carries no status.
+  it('marks the new agent hydrated and gives it no repo identity', async () => {
+    const props = renderDialog()
+
+    await submitDialog()
+
+    await waitFor(() => {
+      expect(props.onCreated).toHaveBeenCalledWith(NEW_WORKSPACE_ID)
+    })
+    expect(props.metadata.patch).toHaveBeenCalledWith('agent-1', expect.objectContaining({
+      hydrated: true,
+    }))
+    expect(props.metadata.patch).toHaveBeenCalledWith('agent-1', expect.not.objectContaining({
+      gitToplevel: expect.anything(),
+    }))
+    expect(
+      Object.keys(props.repoGitStore.repos()),
+      'no repo identity on the row, so none in the store either',
+    ).toEqual([])
+  })
+
   /**
    * Metadata BEFORE placement, the order `openTabInFocusedTile` documents and
    * every other open path follows. Placement is what makes the tab exist for

--- a/frontend/src/components/workspace/NewWorkspaceDialog.tsx
+++ b/frontend/src/components/workspace/NewWorkspaceDialog.tsx
@@ -25,7 +25,7 @@ import { useAgentProviderSelection } from '~/hooks/useAgentProviderSelection'
 import { useWorkerDialog } from '~/hooks/useWorkerDialog'
 import { seedTabIntoNewWorkspace } from '~/lib/crdt'
 import { sanitizeName } from '~/lib/validate'
-import { protoToAgentTabFields } from '~/stores/tab.helpers'
+import { openedAgentTabFields } from '~/stores/tab.helpers'
 import { errorText } from '~/styles/shared.css'
 
 interface NewWorkspaceDialogProps {
@@ -122,18 +122,16 @@ export const NewWorkspaceDialog: Component<NewWorkspaceDialogProps> = (props) =>
         // fan-out would otherwise be the first to supply them, and until it
         // landed the tab would render as a raw agent id.
         //
-        // `hydrated: true` for the same reason every other local-open path
-        // sets it: the OpenAgent response IS the worker's answer for this tab.
-        // Without it the tab matches `useTabHydrators`' `!isHydrated` predicate
-        // — which now runs over every workspace in the account, not just the
-        // active one — and a `ListAgents` round-trip fires immediately for an
-        // agent this client just created. That reply is applied raw, with none
-        // of the live handler's in-flight-settings suppression, so a settings
-        // edit made in the window before it lands is silently overwritten.
-        props.metadata.patch(agentResp.agent.id, {
-          ...protoToAgentTabFields(agentResp.agent.workerId, agentResp.agent),
-          hydrated: true,
-        })
+        // `openedAgentTabFields` carries `hydrated: true`, for the same reason
+        // every other local-open path needs it: the OpenAgent response IS the
+        // worker's answer for this tab. Without it the tab matches
+        // `useTabHydrators`' `!isHydrated` predicate — which now runs over every
+        // workspace in the account, not just the active one — and a `ListAgents`
+        // round-trip fires immediately for an agent this client just created.
+        // That reply is applied raw, with none of the live handler's
+        // in-flight-settings suppression, so a settings edit made in the window
+        // before it lands is silently overwritten.
+        props.metadata.patch(agentResp.agent.id, openedAgentTabFields(props.repoGitStore, agentResp.agent))
 
         // After the worker has spawned the agent, wait for the
         // `WorkspaceCreated` event to populate `WorkspaceContentsRecord
@@ -150,7 +148,13 @@ export const NewWorkspaceDialog: Component<NewWorkspaceDialogProps> = (props) =>
           workspaceId: wsResp.workspaceId,
           tabType: TabType.AGENT,
           tabId: agentResp.agent.id,
-          workerId: wid,
+          // The RESPONSE's worker id, not the local `wid` the RPC was routed
+          // to. `tab.workerId` comes from this projection register, and it is
+          // half of the repo key the sidebar reads a tab's branch with. The
+          // other half comes from the response. One identity, one source, so
+          // the two cannot disagree. The other two open paths already pass
+          // `agent.workerId` here.
+          workerId: agentResp.agent.workerId,
         })
       }
 

--- a/frontend/src/components/workspace/WorkspaceTabTree.tsx
+++ b/frontend/src/components/workspace/WorkspaceTabTree.tsx
@@ -91,9 +91,10 @@ export function tabBuildKey(t: Tab, store: RepoGitStore): string {
     isAgentTab(t) ? t.parentAgentId ?? '' : '',
     t.workerId ?? '',
     git.branchLabel ?? '',
-    // Prefer store toplevel so the fingerprint matches buildTree / tabBranchKey
-    // when tab metadata still lags a resolved repo identity.
-    git.toplevel ?? t.gitToplevel ?? '',
+    // The same resolution the tree itself uses, so the fingerprint matches
+    // buildTree / tabBranchKey -- including when the store says "not a git
+    // repository" and the row's stale toplevel must not win.
+    tabGitToplevelForKey(t, store),
     git.isWorktree ? '1' : '0',
     git.originUrl ?? '',
     git.diffStats.added,
@@ -1003,7 +1004,10 @@ function repoKeyAndLabel(tab: Tab, store: RepoGitStore): { key: string, label: s
   const git = repoGitView(tab, store)
   if (git.originUrl)
     return { key: git.originUrl, label: formatGitOriginUrl(git.originUrl) }
-  const toplevel = git.toplevel ?? tab.gitToplevel
+  // Through the shared helper, so the group key and the branch bucket resolve
+  // the toplevel the same way. A second copy of the chain here is what let a
+  // stale row value override the worker's "not a git repository" answer.
+  const toplevel = tabGitToplevelForKey(tab, store)
   if (toplevel) {
     const label = basename(toplevel) || toplevel
     return { key: repoKeyForLocal(toplevel), label }

--- a/frontend/src/components/workspace/branchKeys.test.ts
+++ b/frontend/src/components/workspace/branchKeys.test.ts
@@ -9,6 +9,7 @@ import {
   repoKeyForLocal,
   repoKeyTooltip,
   tabBranchKey,
+  tabGitToplevelForKey,
 } from './branchKeys'
 
 describe('branchNameSegment', () => {
@@ -124,5 +125,36 @@ describe('tabBranchKey', () => {
     local.upsert(repoKey('w1', '/repo'), { workerId: 'w1', toplevel: '/repo', branch: 'feature' })
     expect(tabBranchKey({ workerId: 'w1', workingDir: '/repo/pkg' }, local))
       .toBe(branchKey('feature', 'w1', '/repo'))
+  })
+
+  /**
+   * The worker answered "not a git repository" for this path, and the row's
+   * `gitToplevel` is stale -- the repository was removed while the link was
+   * down. Believing the row files the tab under a repository that is not there,
+   * with no branch name, for the rest of the page.
+   */
+  it('believes an explicit non-repo answer over a stale row toplevel', () => {
+    const local = createRepoGitStore()
+    local.upsert(repoKey('w1', '/gone'), {
+      workerId: 'w1',
+      toplevel: '',
+      errorHint: 'not a git repository',
+      gitStatusSeen: true,
+    })
+
+    expect(tabGitToplevelForKey({ workerId: 'w1', gitToplevel: '/gone' }, local)).toBe('')
+  })
+
+  // No key resolves without a worker id, so there is no answer to believe and
+  // the row is the only thing anyone knows.
+  it('keeps the row toplevel when no store key resolves', () => {
+    const local = createRepoGitStore()
+    expect(tabGitToplevelForKey({ gitToplevel: '/repo' }, local)).toBe('/repo')
+  })
+
+  // An unprobed key is not an answer either.
+  it('keeps the row toplevel when the store has no entry yet', () => {
+    const local = createRepoGitStore()
+    expect(tabGitToplevelForKey({ workerId: 'w1', gitToplevel: '/repo' }, local)).toBe('/repo')
   })
 })

--- a/frontend/src/components/workspace/branchKeys.ts
+++ b/frontend/src/components/workspace/branchKeys.ts
@@ -58,16 +58,34 @@ export function branchKey(branchName: string | null, workerId: string, gitToplev
  * returned the "(no branch)" key, which is exactly the drift above.
  */
 /**
- * Repo toplevel for structural keys (branch buckets, delete-branch tab sets).
- * Prefer the store's canonical identity over tab metadata, which can lag on
- * probe-path orphans and subdir agents until the next status broadcast.
+ * Repo toplevel for structural keys (branch buckets, delete-branch tab sets)
+ * and for the sidebar's repository grouping. The ONE place that answers "which
+ * repository is this tab in", so a caller cannot re-add the row fallback below.
+ *
+ * `repoGitView` already resolves the two sources correctly, and this trusts it:
+ *
+ *  - No store entry yet: the view returns the row's `gitToplevel`, so a tab
+ *    stays grouped from the moment it is opened, before any probe lands.
+ *  - An entry that resolved a repo: the view returns the store's toplevel,
+ *    which wins over tab metadata that can lag on probe-path orphans and
+ *    subdir agents.
+ *  - An entry that says "not a git repository": the view returns undefined,
+ *    and so does this. That answer came FROM the worker, so a stale row value
+ *    must not override it -- doing so filed the tab under a repository that
+ *    does not exist there, with no branch name, until the page reloaded.
+ *
+ * The row IS the fallback when no store key resolves at all, which happens for
+ * a tab with no `workerId`. There is no entry to believe or disbelieve then,
+ * and the row is the only thing anyone knows.
  */
 export function tabGitToplevelForKey(
   tab: Pick<Tab, 'workerId' | 'gitToplevel' | 'workingDir'>,
   store: RepoGitStore,
 ): string {
   const git = repoGitView(tab, store)
-  return git.toplevel ?? tab.gitToplevel ?? ''
+  if (!git.key)
+    return tab.gitToplevel ?? ''
+  return git.toplevel ?? ''
 }
 
 export function tabBranchKey(tab: Pick<Tab, 'workerId' | 'gitToplevel' | 'workingDir'>, store: RepoGitStore): string {

--- a/frontend/src/hooks/useWorkspaceConnection.repoGit.test.ts
+++ b/frontend/src/hooks/useWorkspaceConnection.repoGit.test.ts
@@ -1,0 +1,218 @@
+import type { UseWatchEventsStreamsOpts } from '~/hooks/useWatchEventsStreams'
+import { createRoot } from 'solid-js'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { AgentStatus } from '~/generated/leapmux/v1/agent_pb'
+import { TerminalStatus } from '~/generated/leapmux/v1/terminal_pb'
+import { TabType } from '~/generated/leapmux/v1/workspace_pb'
+import { createLoadingSignal } from '~/hooks/createLoadingSignal'
+import { useWorkspaceConnection } from '~/hooks/useWorkspaceConnection'
+import { createAgentSessionStore } from '~/stores/agentSession.store'
+import { createChatStore } from '~/stores/chat.store'
+import { createControlStore } from '~/stores/control.store'
+import { repoKey } from '~/stores/repoGit'
+import { createRepoGitStore } from '~/stores/repoGit.store'
+import { emitAddTab } from '~/stores/tabOps'
+import { installTestBridge } from '~/test-support/crdtBridge'
+import { createTestTabStores } from '~/test-support/tabStores'
+
+vi.mock('~/api/workerRpc', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/api/workerRpc')>()
+  return {
+    ...actual,
+    // The tail-reconcile effect asks for the newest page of every agent tab.
+    // Answered with an empty page so the hook's own promise chains settle.
+    listAgentMessages: vi.fn().mockResolvedValue({ messages: [], hasMore: false }),
+    channelManager: {
+      getOrOpenChannel: vi.fn().mockResolvedValue('ch-1'),
+      hasOpenChannelForWorker: vi.fn().mockReturnValue(true),
+      fatalCloseInfo: vi.fn(() => null),
+    },
+  }
+})
+
+vi.mock('~/components/common/Toast', () => ({
+  showWarnToast: vi.fn(),
+  showInfoToast: vi.fn(),
+  showWarnToastUnlessDisconnected: vi.fn(),
+}))
+
+/**
+ * The real stream hook dials a channel. Replaced with a capture so a test can
+ * report the offline / online transitions itself -- which is the whole input
+ * to the sweep effect under test.
+ */
+const streams = vi.hoisted(() => ({ opts: undefined as unknown }))
+
+vi.mock('~/hooks/useWatchEventsStreams', () => ({
+  useWatchEventsStreams: (opts: unknown) => {
+    streams.opts = opts
+    return { abortSignalFor: () => undefined }
+  },
+}))
+
+// The capture is module state, so it outlives a test. Reset it, or a mount that
+// installs nothing leaves the guard below reading the PREVIOUS test's callbacks
+// on a disposed root, and the assertions pass against the wrong hook.
+beforeEach(() => {
+  streams.opts = undefined
+})
+
+/** The captured stream callbacks, typed. */
+function streamOpts(): UseWatchEventsStreamsOpts {
+  if (!streams.opts)
+    throw new Error('useWorkspaceConnection did not open its watch streams')
+  return streams.opts as UseWatchEventsStreamsOpts
+}
+
+const WS = 'ws-repo-git-offline'
+const WORKER = 'w-1'
+const REPO = '/home/dev/repo'
+
+let nextPosition = 0
+
+/**
+ * One agent tab and one terminal tab on the same worker, over a real CRDT
+ * bridge, with the worker's repo already known to the git store.
+ *
+ * The agent tab is deliberately left UNSELECTED. A background tab is the whole
+ * case: the active tab is refreshed by AppShell whenever its context changes,
+ * so it repairs itself and can never show the defect.
+ */
+function mountConnection() {
+  const harness = installTestBridge({ workspaceId: WS })
+  const { view, metadata, selection } = createTestTabStores(WS)
+  const repoGitStore = createRepoGitStore()
+  const chatStore = createChatStore()
+
+  const place = (type: TabType, id: string) => {
+    nextPosition += 1
+    emitAddTab({ type, id, tileId: harness.rootTileId, position: `p${nextPosition}`, workerId: WORKER })
+  }
+  place(TabType.AGENT, 'a1')
+  place(TabType.TERMINAL, 't1')
+  // `workerId` is deliberately absent here: it lives on the projection, and
+  // the `emitAddTab` above carries it there. TabMetadata has no such field.
+  metadata.patch('a1', { workingDir: REPO, gitToplevel: REPO, agentStatus: AgentStatus.ACTIVE })
+  metadata.patch('t1', { workingDir: REPO, gitToplevel: REPO, terminalStatus: TerminalStatus.READY })
+
+  repoGitStore.upsert(repoKey(WORKER, REPO), {
+    workerId: WORKER,
+    toplevel: REPO,
+    branch: 'feature/sidebar',
+    originUrl: 'git@example.com:org/repo.git',
+    gitStatusSeen: true,
+  })
+
+  let dispose!: () => void
+  createRoot((d) => {
+    dispose = d
+    useWorkspaceConnection({
+      chatStore,
+      view,
+      metadata,
+      selection,
+      controlStore: createControlStore(),
+      agentSessionStore: createAgentSessionStore(),
+      repoGitStore,
+      settingsLoading: createLoadingSignal(),
+      getActiveWorkspaceId: () => WS,
+    })
+  })
+  return { dispose, repoGitStore, chatStore, view, metadata }
+}
+
+/**
+ * What a dropped worker link may and may not take with it.
+ *
+ * `useWatchEventsStreams` reports a worker offline for any transport-shaped
+ * failure -- a closed socket, a sleeping laptop, a restarted hub. The sweep
+ * that follows used to call `repoGitStore.clearForWorker`, which deleted the
+ * branch, the origin URL and the diff stats for every repo on that worker.
+ *
+ * Three rules kept a BACKGROUND tab from recovering. `useTabHydrators` re-asks
+ * only for a tab that is not `hydrated`, and an agent tab stays `hydrated` for
+ * the rest of the page. The worker sends a git status at that agent's own turn
+ * end. The catch-up replay after a reconnect carries one only for an agent
+ * promoted to FULL.
+ *
+ * Meanwhile `Tab.gitToplevel` survives the outage untouched, and
+ * `WorkspaceTabTree.repoKeyAndLabel` groups a tab by that field alone. So the
+ * sidebar kept the repo group and moved every tab under it to the no-branch
+ * bucket, until the user clicked the tab or the Files refresh button.
+ *
+ * The entry is last-known repo state, not a liveness claim. The store already
+ * keeps it across one transient bad probe ("keeping last-good repo state" in
+ * `RepoGitStore.refresh`), and `RepoGitState.nonRepoProbeIgnored` limits that
+ * to one. Permanent removal has its own caller: `useWorkerSection` clears on
+ * deregistration.
+ */
+describe('useWorkspaceConnection worker-offline sweep', () => {
+  it('keeps a background tab\'s branch and origin when the worker link drops', () => {
+    const { dispose, repoGitStore } = mountConnection()
+    try {
+      streamOpts().onWorkerOnline(WORKER, false)
+
+      const repo = repoGitStore.get(repoKey(WORKER, REPO))
+      expect(repo?.branch, 'a transport blip is not news about the working tree').toBe('feature/sidebar')
+      expect(repo?.originUrl).toBe('git@example.com:org/repo.git')
+    }
+    finally {
+      dispose()
+    }
+  })
+
+  it('still knows the branch after the link returns, with no tab click', () => {
+    const { dispose, repoGitStore } = mountConnection()
+    try {
+      streamOpts().onWorkerOnline(WORKER, false)
+      streamOpts().onWorkerOnline(WORKER, true)
+
+      expect(
+        repoGitStore.get(repoKey(WORKER, REPO))?.branch,
+        'a backgrounded agent tab gets no catch-up git status, so a drop here is permanent',
+      ).toBe('feature/sidebar')
+    }
+    finally {
+      dispose()
+    }
+  })
+
+  it('leaves a repo on a still-connected worker alone', () => {
+    const { dispose, repoGitStore } = mountConnection()
+    try {
+      repoGitStore.upsert(repoKey('w-2', REPO), { workerId: 'w-2', toplevel: REPO, branch: 'main' })
+      streamOpts().onWorkerOnline(WORKER, false)
+
+      expect(repoGitStore.get(repoKey('w-2', REPO))?.branch).toBe('main')
+    }
+    finally {
+      dispose()
+    }
+  })
+
+  it('still disconnects the worker\'s running terminals', () => {
+    const { dispose, view } = mountConnection()
+    try {
+      streamOpts().onWorkerOnline(WORKER, false)
+
+      expect(view.getTerminalTab('t1')?.status).toBe(TerminalStatus.DISCONNECTED)
+    }
+    finally {
+      dispose()
+    }
+  })
+
+  it('still drops its ACTIVE agents to INACTIVE and clears their streaming text', () => {
+    const { dispose, view, chatStore } = mountConnection()
+    try {
+      chatStore.streamingText.set('a1', 'half a sentence')
+      streamOpts().onWorkerOnline(WORKER, false)
+
+      expect(view.getAgentTab('a1')?.agentStatus).toBe(AgentStatus.INACTIVE)
+      expect(chatStore.streamingText.get('a1'), 'the process that would finish it is gone').toBe('')
+    }
+    finally {
+      dispose()
+    }
+  })
+})

--- a/frontend/src/hooks/useWorkspaceConnection.ts
+++ b/frontend/src/hooks/useWorkspaceConnection.ts
@@ -212,6 +212,14 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
     // sweep effect still iterates it as a no-op on every offline-set change).
     if (!workerId)
       return
+    // The link came BACK. Release this worker's optimistic branch pins, keeping
+    // the branch values: a pin says "a branch change succeeded, so ignore a
+    // broadcast that still reports the old branch", and a dropped link ends
+    // that claim. Only an agreeing refresh clears a pin otherwise, and a
+    // background tab issues none -- so a stamp made just before the worker died
+    // would label the tab for the rest of the page.
+    if (online && untrack(offlineWorkers).has(workerId))
+      repoGitStore.releaseBranchPinsForWorker(workerId)
     setOfflineWorkers((prev) => {
       const next = new Set(prev)
       if (online)
@@ -462,6 +470,31 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
 
   // When a worker goes offline, mark its running terminals disconnected and
   // clear stale streaming state for its agents.
+  //
+  // This effect deliberately does NOT sweep the repo-keyed git store. An entry
+  // there is the last known state of a working tree. It is not a claim about
+  // the link. Every other worker-sourced field on the tab row survives an
+  // outage the same way, and `RepoGitStore.refresh` keeps last-good state on
+  // its own side.
+  //
+  // A sweep here removed the branch with no way back. `Tab.gitToplevel`
+  // outlives the outage, and `WorkspaceTabTree.repoKeyAndLabel` groups a tab by
+  // that field alone. The branch label comes from this store. A dropped entry
+  // therefore put every tab of that worker under its repo with no branch name.
+  //
+  // Three separate rules kept a BACKGROUND tab from recovering. An agent tab
+  // stays `hydrated` for the life of the page, so `useTabHydrators` never
+  // re-asks. The worker sends a git status only at that agent's own turn end.
+  // The catch-up replay after a reconnect carries one only for an agent that
+  // the client promotes to FULL. So the user clicked each tab, or the Files
+  // refresh button, once per tab, after every dropped link.
+  //
+  // Permanent removal is a different event with its own caller. Worker
+  // deregistration clears through `useWorkerSection`.
+  //
+  // Keeping an entry has its own cost, and `RepoGitState.nonRepoProbeIgnored`
+  // pays it: a repo deleted during the outage would otherwise suppress every
+  // later "not a git repository" answer.
   createEffect(() => {
     const offline = offlineWorkers()
     if (offline.size === 0)
@@ -483,7 +516,6 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
             if (tab.agentStatus === AgentStatus.ACTIVE)
               metadata.patch(tab.id, { agentStatus: AgentStatus.INACTIVE })
           }
-          repoGitStore.clearForWorker(workerId)
         })
       }
     })

--- a/frontend/src/stores/repoGit.store.test.ts
+++ b/frontend/src/stores/repoGit.store.test.ts
@@ -664,6 +664,80 @@ describe('createRepoGitStore', () => {
       })
     })
 
+    /**
+     * The allowance above covers ONE answer, because one answer can be
+     * transient. Two in a row are the worker's real report.
+     *
+     * Without the limit the first non-repo answer suppresses every later one
+     * for the life of the page. A user whose worktree is removed while the
+     * link is down then keeps a branch label and a diff badge in the sidebar
+     * for a directory that does not exist, and the Files section never
+     * receives the "not a git repository" hint.
+     */
+    it('writes the non-repo stub on the second answer in a row', async () => {
+      await createRoot(async (dispose) => {
+        const store = createRepoGitStore()
+        const key = repoKey('worker1', '/repo')
+        store.upsert(key, { workerId: 'worker1', toplevel: '/repo', branch: 'main', gitStatusSeen: true })
+
+        const notARepo = {
+          repoRoot: '',
+          status: undefined,
+          files: [],
+          errorHint: 'not a git repository',
+        }
+
+        mockGetGitFileStatus.mockResolvedValueOnce(notARepo)
+        await store.refresh('worker1', '/repo', { repoKey: key })
+        expect(store.get(key)?.branch, 'one answer can be transient').toBe('main')
+
+        mockGetGitFileStatus.mockResolvedValueOnce(notARepo)
+        await store.refresh('worker1', '/repo', { repoKey: key })
+
+        const state = store.get(key)!
+        expect(state.toplevel, 'the second answer is believed').toBe('')
+        expect(state.branch).toBe('')
+        expect(state.errorHint).toBe('not a git repository')
+        dispose()
+      })
+    })
+
+    it('gives the allowance back after a real status lands between two non-repo answers', async () => {
+      await createRoot(async (dispose) => {
+        const store = createRepoGitStore()
+        const key = repoKey('worker1', '/repo')
+        store.upsert(key, { workerId: 'worker1', toplevel: '/repo', branch: 'main', gitStatusSeen: true })
+
+        const notARepo = {
+          repoRoot: '',
+          status: undefined,
+          files: [],
+          errorHint: 'not a git repository',
+        }
+
+        mockGetGitFileStatus.mockResolvedValueOnce(notARepo)
+        await store.refresh('worker1', '/repo', { repoKey: key })
+
+        // The repo answers, so the entry recovers and its allowance resets.
+        mockGetGitFileStatus.mockResolvedValueOnce({
+          repoRoot: '/repo',
+          status: { toplevel: '/repo', branch: 'main' },
+          files: [],
+          errorHint: '',
+        })
+        await store.refresh('worker1', '/repo', { repoKey: key })
+        expect(store.get(key)?.nonRepoProbeIgnored).toBe(false)
+
+        // A later single answer is transient again, so the branch survives it.
+        mockGetGitFileStatus.mockResolvedValueOnce(notARepo)
+        await store.refresh('worker1', '/repo', { repoKey: key })
+
+        expect(store.get(key)?.branch, 'the reset restores the allowance').toBe('main')
+        expect(store.get(key)?.toplevel).toBe('/repo')
+        dispose()
+      })
+    })
+
     it('persists errorHint on a non-repo probe using the path when repoKey is omitted', async () => {
       await createRoot(async (dispose) => {
         const store = createRepoGitStore()
@@ -892,15 +966,76 @@ describe('createRepoGitStore', () => {
     })
   })
 
-  describe('clearForWorker', () => {
-    it('removes every repo entry for the worker', () => {
+  /**
+   * The store exposes no per-worker clear, and must not grow one back.
+   *
+   * Dropping a worker's entries is never right while its tab rows survive. A
+   * row keeps `gitToplevel`, `WorkspaceTabTree.repoKeyAndLabel` groups the tab
+   * by that field, and the branch label comes from this store -- so a cleared
+   * entry puts every tab of that worker under its repo with no branch name.
+   * Neither event that used to call it removes the rows: a dropped link leaves
+   * them, and so does deregistration.
+   */
+  it('exposes no per-worker clear', () => {
+    expect(createRepoGitStore()).not.toHaveProperty('clearForWorker')
+  })
+
+  /**
+   * The cap is the store's only reclaim path, so it has to bite -- and it has
+   * to miss the entries a tab is reading, or it recreates the missing branch
+   * label that the removal of the sweeps exists to prevent.
+   */
+  describe('least-recently-used cap', () => {
+    const MAX = 256
+    const fill = (store: ReturnType<typeof createRepoGitStore>, from: number, to: number) => {
+      for (let i = from; i < to; i++)
+        store.upsert(repoKey('w1', `/r${i}`), { workerId: 'w1', toplevel: `/r${i}` })
+    }
+
+    // `get` is the tab-facing read and it MARKS the entry as recently used, so
+    // an assertion must not use it to look at an entry it is not pretending to
+    // render. `repos()` is the raw map and touches nothing.
+    const peek = (store: ReturnType<typeof createRepoGitStore>, key: string) => store.repos()[key as never]
+
+    it('drops the coldest entry once the cap is passed', () => {
       const store = createRepoGitStore()
-      store.upsert(repoKey('w1', '/a'), { workerId: 'w1', toplevel: '/a' })
-      store.upsert(repoKey('w1', '/b'), { workerId: 'w1', toplevel: '/b' })
-      store.upsert(repoKey('w2', '/c'), { workerId: 'w2', toplevel: '/c' })
-      store.clearForWorker('w1')
-      expect(store.keysForWorker('w1')).toEqual([])
-      expect(store.keysForWorker('w2')).toEqual([repoKey('w2', '/c')])
+      fill(store, 0, MAX)
+      expect(peek(store, repoKey('w1', '/r0')), 'still under the cap').toBeDefined()
+
+      // Written last, so /r0 is now the least recently used.
+      store.upsert(repoKey('w1', '/over'), { workerId: 'w1', toplevel: '/over' })
+
+      expect(peek(store, repoKey('w1', '/r0'))).toBeUndefined()
+      expect(peek(store, repoKey('w1', '/over'))).toBeDefined()
+      expect(store.keysForWorker('w1'), 'the index shrinks with the map').toHaveLength(MAX)
+    })
+
+    it('keeps an entry a tab keeps reading, however old the write', () => {
+      const store = createRepoGitStore()
+      const live = repoKey('w1', '/r0')
+      fill(store, 0, MAX)
+
+      // What the sidebar does for a tab on every render.
+      expect(store.get(live)).toBeDefined()
+      store.upsert(repoKey('w1', '/over'), { workerId: 'w1', toplevel: '/over' })
+
+      expect(peek(store, live), 'a read is what keeps a live tab\'s repo warm').toBeDefined()
+      expect(peek(store, repoKey('w1', '/r1')), 'the next-coldest went instead').toBeUndefined()
+    })
+
+    it('keeps a pinned entry, which holds in-flight optimistic state', () => {
+      const store = createRepoGitStore()
+      const pinned = repoKey('w1', '/r0')
+      store.upsert(pinned, {
+        workerId: 'w1',
+        toplevel: '/r0',
+        branch: 'feature/x',
+        branchPinnedUntilRefresh: true,
+      })
+      fill(store, 1, MAX + 1)
+
+      expect(peek(store, pinned)?.branch).toBe('feature/x')
+      expect(peek(store, repoKey('w1', '/r1')), 'the coldest unpinned entry went instead').toBeUndefined()
     })
   })
 })

--- a/frontend/src/stores/repoGit.store.ts
+++ b/frontend/src/stores/repoGit.store.ts
@@ -12,6 +12,7 @@ import {
   findCanonicalRepoKey,
   hasHealthyRepoForProbe,
   isUntrackedDirEntry,
+  markNonRepoProbeIgnored,
   patchFromGetGitFileStatus,
   patchFromNonRepoGetGitFileStatus,
   repoKey,
@@ -31,6 +32,19 @@ export {
 } from './repoGit'
 
 const ZERO_DIFF_STATS = { added: 0, deleted: 0, untracked: 0 }
+
+/**
+ * How many repo entries one page session keeps.
+ *
+ * Nothing else reclaims them: a dropped link keeps its entries, and so does a
+ * deregistration, because the tab rows they label survive both. The cap is the
+ * only limit, and each entry holds an uncapped `files` list.
+ *
+ * Set high on purpose. A real session touches a handful of repositories, so
+ * eviction should reach only a session that visited hundreds of distinct
+ * directories. See `evictLeastRecentlyUsed` for what it refuses to evict.
+ */
+const MAX_REPO_ENTRIES = 256
 
 function emptyRepoState(): RepoGitState {
   return {
@@ -65,6 +79,15 @@ export function createRepoGitStore() {
   const [workerKeyEpoch, setWorkerKeyEpoch] = createSignal(0)
   const workerKeys = new Map<string, Set<RepoKey>>()
 
+  /**
+   * Least-recently-used order, newest last. A plain `Map` keeps insertion
+   * order, so `delete` then `set` moves a key to the end.
+   *
+   * NOT reactive on purpose. `get` touches this on a read, and a signal write
+   * inside a tracked read would loop.
+   */
+  const touchOrder = new Map<RepoKey, true>()
+
   /** Global clock for ordering; each probe path has its own generation slot. */
   let clock = 0
   const probeGen = new Map<string, number>()
@@ -72,7 +95,32 @@ export function createRepoGitStore() {
   const lastCompletedByKey = new Map<RepoKey, { gen: number, keptPin: boolean }>()
   let loadingCount = 0
 
-  const get = (key: RepoKey): RepoGitState | undefined => repos[key]
+  /**
+   * Read WITHOUT touching the LRU order.
+   *
+   * The internal key scans (`findCanonicalRepoKey`, the pin helpers) read every
+   * key a worker owns. Touching there would make every entry equally recent and
+   * leave the order meaningless, so they use this.
+   */
+  const peek = (key: RepoKey): RepoGitState | undefined => repos[key]
+
+  /**
+   * Read AND mark the entry as recently used.
+   *
+   * This is the tab-facing read: `repoGitView` calls it for each tab the
+   * sidebar renders, so an entry that backs a live tab is touched on every
+   * render and can never be the least recently used one. That is what keeps
+   * eviction away from the rows whose branch label this store exists to
+   * supply.
+   */
+  const get = (key: RepoKey): RepoGitState | undefined => {
+    const state = repos[key]
+    if (state) {
+      touchOrder.delete(key)
+      touchOrder.set(key, true)
+    }
+    return state
+  }
 
   const bumpWorkerKeyIndex = () => setWorkerKeyEpoch(n => n + 1)
 
@@ -125,7 +173,7 @@ export function createRepoGitStore() {
 
   const pruneCompletedIfIdle = (key: RepoKey) => {
     const completed = lastCompletedByKey.get(key)
-    if (!completed || completed.keptPin || get(key)?.branchPinnedUntilRefresh)
+    if (!completed || completed.keptPin || peek(key)?.branchPinnedUntilRefresh)
       return
     for (const inflight of inflightByProbe.values()) {
       if (inflight.gen < completed.gen)
@@ -136,7 +184,7 @@ export function createRepoGitStore() {
 
   const dropCompletedKeepPinWhenUnpinned = (key: RepoKey) => {
     const completed = lastCompletedByKey.get(key)
-    if (completed && !get(key)?.branchPinnedUntilRefresh)
+    if (completed && !peek(key)?.branchPinnedUntilRefresh)
       completed.keptPin = false
     pruneCompletedIfIdle(key)
   }
@@ -145,6 +193,49 @@ export function createRepoGitStore() {
     const completed = lastCompletedByKey.get(key)
     if (completed)
       completed.keptPin = false
+  }
+
+  const clear = (key: RepoKey) => {
+    const prev = untrack(() => repos[key])
+    setRepos(produce((map) => {
+      delete map[key]
+    }))
+    lastCompletedByKey.delete(key)
+    touchOrder.delete(key)
+    if (prev)
+      unindexKey(key, prev.workerId)
+    else
+      unindexKey(key)
+  }
+
+  /**
+   * Evict the least recently used entries down to {@link MAX_REPO_ENTRIES}.
+   *
+   * Three keys are never evicted, because dropping them would recreate the
+   * defect this store exists to avoid -- a tab row that keeps `gitToplevel`
+   * while its entry is gone renders under a repository with no branch name:
+   *
+   *  - the key just written, which the caller is about to read;
+   *  - the focused key, which the Files section renders right now;
+   *  - a key with a branch pin, which holds in-flight optimistic state.
+   *
+   * A key that backs a live tab is touched by `get` on every sidebar render,
+   * so it stays at the recent end and eviction never reaches it. Only a
+   * directory the session visited once and abandoned goes cold.
+   */
+  const evictLeastRecentlyUsed = (justWritten: RepoKey) => {
+    if (touchOrder.size <= MAX_REPO_ENTRIES)
+      return
+    const focused = untrack(focusedKey)
+    for (const key of [...touchOrder.keys()]) {
+      if (touchOrder.size <= MAX_REPO_ENTRIES)
+        return
+      if (key === justWritten || key === focused)
+        continue
+      if (untrack(() => repos[key])?.branchPinnedUntilRefresh)
+        continue
+      clear(key)
+    }
   }
 
   const upsert = (key: RepoKey, patch: Partial<RepoGitState>) => {
@@ -156,6 +247,8 @@ export function createRepoGitStore() {
       const base = map[key] ?? emptyRepoState()
       map[key] = { ...base, ...rest }
     }))
+    touchOrder.delete(key)
+    touchOrder.set(key, true)
     const workerId = patch.workerId || prev?.workerId || repoKeyParts(key).workerId
     if (prev?.workerId && prev.workerId !== workerId)
       unindexKey(key, prev.workerId)
@@ -166,6 +259,7 @@ export function createRepoGitStore() {
       dropCompletedKeepPinWhenUnpinned(key)
     if ('branchPinnedUntilRefresh' in rest && rest.branchPinnedUntilRefresh === true)
       resetCompletedKeepPinForNewStamp(key)
+    evictLeastRecentlyUsed(key)
   }
 
   /** Keys this refresh may have stamped a branch pin onto. */
@@ -175,7 +269,7 @@ export function createRepoGitStore() {
       pinKeys.add(hintKey)
     pinKeys.add(repoKey(workerId, path))
     const canonical = findCanonicalRepoKey(
-      { get, repos: () => repos as Readonly<Record<RepoKey, RepoGitState>>, keysForWorker },
+      { get: peek, repos: () => repos as Readonly<Record<RepoKey, RepoGitState>>, keysForWorker },
       workerId,
       path,
     )
@@ -187,29 +281,37 @@ export function createRepoGitStore() {
   const clearBranchPins = (keys: Iterable<RepoKey>, opts?: { respectCompletedKeep?: boolean }) => {
     for (const key of keys) {
       const completed = lastCompletedByKey.get(key)
-      if (opts?.respectCompletedKeep && completed?.keptPin && get(key)?.branchPinnedUntilRefresh)
+      if (opts?.respectCompletedKeep && completed?.keptPin && peek(key)?.branchPinnedUntilRefresh)
         continue
-      if (get(key)?.branchPinnedUntilRefresh)
+      if (peek(key)?.branchPinnedUntilRefresh)
         upsert(key, { branchPinnedUntilRefresh: false })
     }
   }
 
-  const clear = (key: RepoKey) => {
-    const prev = untrack(() => repos[key])
-    setRepos(produce((map) => {
-      delete map[key]
-    }))
-    lastCompletedByKey.delete(key)
-    if (prev)
-      unindexKey(key, prev.workerId)
-    else
-      unindexKey(key)
+  /**
+   * Release every optimistic branch pin this worker holds, keeping the branch
+   * values themselves.
+   *
+   * A pin means "a branch change succeeded here, so ignore a metadata broadcast
+   * that still reports the old branch". A dropped link ends that claim: the
+   * checkout may never have completed, and the pin outlives it. Only a refresh
+   * that AGREES clears a pin, and a background tab issues no refresh -- so
+   * without this the sidebar can show a stamped branch for the rest of the page
+   * while the checkout sits on another one.
+   *
+   * The branch value stays, because it is still the last thing anyone knew.
+   */
+  const releaseBranchPinsForWorker = (workerId: string) => {
+    if (!workerId)
+      return
+    clearBranchPins(workerKeys.get(workerId) ?? [])
   }
 
   const clearAll = () => {
     const hadKeys = workerKeys.size > 0
     setRepos({})
     workerKeys.clear()
+    touchOrder.clear()
     lastCompletedByKey.clear()
     probeGen.clear()
     inflightByProbe.clear()
@@ -261,13 +363,15 @@ export function createRepoGitStore() {
     }
   }
 
-  const clearForWorker = (workerId: string) => {
-    if (!workerId)
-      return
-    const keys = [...(workerKeys.get(workerId) ?? [])]
-    for (const key of keys)
-      clear(key)
-  }
+  // There is deliberately NO `clearForWorker`. Both callers were removed,
+  // because dropping a worker's entries is never right while its tab rows
+  // survive: a row keeps `gitToplevel`, the sidebar groups on that field, and
+  // the branch label comes from here -- so a cleared entry puts every tab of
+  // that worker under its repo with no branch name. Neither a dropped link nor
+  // a deregistration removes the rows, so neither may remove the entries.
+  //
+  // `clear(key)` still exists for the one case that IS right: a single key whose
+  // repo identity was re-resolved elsewhere.
 
   /**
    * Refresh git file status for one probe path.
@@ -316,7 +420,7 @@ export function createRepoGitStore() {
       }
       const mapped = patchFromGetGitFileStatus(workerId, resp)
       if (!mapped) {
-        const lookup = { get, repos: () => repos as Readonly<Record<RepoKey, RepoGitState>>, keysForWorker }
+        const lookup = { get: peek, repos: () => repos as Readonly<Record<RepoKey, RepoGitState>>, keysForWorker }
         if (nonRepoKey && !hasHealthyRepoForProbe(lookup, workerId, path, nonRepoKey)) {
           const nonRepo = patchFromNonRepoGetGitFileStatus(workerId, resp, nonRepoKey)
           if (canApplyToKey(nonRepo.key)) {
@@ -333,8 +437,17 @@ export function createRepoGitStore() {
         else if (hasHealthyRepoForProbe(lookup, workerId, path, nonRepoKey)) {
           log.warn('ignored non-repo git status response; keeping last-good repo state', { workerId, path })
           writtenKey = findCanonicalRepoKey(lookup, workerId, path) ?? nonRepoKey
-          // Keep an optimistic branch pin across a transient non-repo probe.
-          // Entries for a deregistered/offline worker are dropped via clearForWorker.
+          // One answer can be transient, so this branch keeps the last-good
+          // repo state. Mark the allowance as used. The next non-repo answer
+          // for this path then writes the stub, because two answers in a row
+          // are the worker's real report.
+          //
+          // The mark is what limits the allowance. A worker that goes offline
+          // keeps its entries -- the branch is last-known state, and nothing
+          // re-seeds a background tab after a drop. Before the mark existed,
+          // an entry that outlived a deleted repo suppressed every later probe
+          // for the life of the page.
+          markNonRepoProbeIgnored({ ...lookup, upsert }, workerId, path, nonRepoKey)
         }
         realignFocusedKeyAfterRefresh(writtenKey, workerId, path, nonRepoKey)
         return writtenKey
@@ -512,7 +625,7 @@ export function createRepoGitStore() {
     upsert,
     clear,
     clearAll,
-    clearForWorker,
+    releaseBranchPinsForWorker,
     repos: () => repos as Readonly<Record<RepoKey, RepoGitState>>,
     keysForWorker,
     focusedKey,

--- a/frontend/src/stores/repoGit.test.ts
+++ b/frontend/src/stores/repoGit.test.ts
@@ -189,6 +189,24 @@ describe('migrateErrorHintFromForResolvedRepo', () => {
     const status = create(GitRepoStatusSchema, { toplevel: '/repo', branch: 'main' })
     expect(migrateErrorHintFromForResolvedRepo('w1', tab, status)).toBeUndefined()
   })
+
+  // A tip needs a tab that the store wrote BEFORE this status resolved. Derive
+  // the tab from the response itself and the two cases exclude each other, so
+  // there is never anything to migrate. Both shapes below are what
+  // `protoToAgentTabFields` produces for one response.
+  it('has nothing to migrate for a tab derived from this very status', () => {
+    const resolved = create(GitRepoStatusSchema, { toplevel: '/repo', branch: 'main' })
+    expect(
+      migrateErrorHintFromForResolvedRepo('w1', { workingDir: '/repo/pkg', gitToplevel: '/repo' }, resolved),
+      'a resolved toplevel is on the tab too, so there is no orphan key',
+    ).toBeUndefined()
+
+    const unresolved = create(GitRepoStatusSchema, { branch: 'main' })
+    expect(
+      migrateErrorHintFromForResolvedRepo('w1', { workingDir: '/repo/pkg' }, unresolved),
+      'an unresolved toplevel leaves no key to migrate TO',
+    ).toBeUndefined()
+  })
 })
 
 describe('patchFromNonRepoGetGitFileStatus', () => {

--- a/frontend/src/stores/repoGit.ts
+++ b/frontend/src/stores/repoGit.ts
@@ -43,6 +43,21 @@ export interface RepoGitState {
    * entry. Distinguishes a real status seed from an optimistic branch stamp.
    */
   gitStatusSeen?: boolean
+  /**
+   * Set when a probe answered "not a git repository" and this entry kept its
+   * last-good state instead. It makes that allowance ONE-SHOT: the next
+   * non-repo answer for the same path writes the stub.
+   *
+   * A single answer can be transient, so the first one is ignored. Two in a
+   * row are the worker's real report, and the repo is gone. Without the
+   * one-shot limit the first answer suppresses every later one for the life
+   * of the page, and the sidebar shows a branch and a diff badge for a
+   * directory that no longer exists.
+   *
+   * A real status clears the flag, so an entry that recovers gets its
+   * allowance back.
+   */
+  nonRepoProbeIgnored?: boolean
 }
 
 export interface RepoGitView {
@@ -313,9 +328,15 @@ export function isStampOnlyRepoGitState(state: RepoGitState | undefined): boolea
  * True when the entry is a real repo identity worth keeping across a
  * transient non-repo response. Stamp-only seeds are excluded so a first
  * probe can still write an `errorHint` stub.
+ *
+ * An entry that already ignored a non-repo answer is excluded too. That
+ * allowance covers ONE transient answer, never a repo the worker keeps
+ * reporting as gone. See {@link RepoGitState.nonRepoProbeIgnored}.
  */
 export function hasPreservableRepoGitState(state: RepoGitState | undefined): boolean {
   if (!state?.toplevel)
+    return false
+  if (state.nonRepoProbeIgnored)
     return false
   if (state.gitStatusSeen || hasHydratedRepoGitFields(state))
     return true
@@ -335,6 +356,28 @@ export function hasHealthyRepoForProbe(
   if (!canonical)
     return false
   return hasPreservableRepoGitState(store.get(canonical))
+}
+
+/**
+ * Record that a non-repo answer for `probePath` kept the last-good state.
+ * Marks every entry that {@link hasHealthyRepoForProbe} consults, so the next
+ * non-repo answer for the same path writes the stub instead.
+ *
+ * Call this ONLY on the branch that ignored the answer. The caller that writes
+ * the stub must not call it: that entry no longer claims to be a repo.
+ */
+export function markNonRepoProbeIgnored(
+  store: RepoGitLookup & Pick<RepoGitStore, 'upsert'>,
+  workerId: string,
+  probePath: string,
+  hintKey?: RepoKey,
+): void {
+  const mark = (key: RepoKey | undefined): void => {
+    if (key && hasPreservableRepoGitState(store.get(key)))
+      store.upsert(key, { nonRepoProbeIgnored: true })
+  }
+  mark(hintKey)
+  mark(findCanonicalRepoKey(store, workerId, probePath))
 }
 
 /**
@@ -363,6 +406,10 @@ export function applyFullGitStatusUpsert(
     branch,
     branchPinnedUntilRefresh,
     gitStatusSeen: true,
+    // The repo answered, so give back the one-shot allowance that a previous
+    // non-repo answer consumed. `upsert` merges, so this must be written and
+    // not omitted.
+    nonRepoProbeIgnored: false,
   })
   return mapped.key
 }
@@ -375,7 +422,10 @@ export function applyFullGitStatusUpsert(
  * keep a refresh-sourced hint on a hydrated entry.
  */
 export function upsertRepoGitFromProtoStatus(
-  store: RepoGitStore,
+  // The three methods it actually uses, like `applyFullGitStatusUpsert` next
+  // door. A narrower parameter says what the function touches, and lets a test
+  // pass a small fake instead of a reactive store.
+  store: Pick<RepoGitStore, 'get' | 'upsert' | 'clear'>,
   workerId: string,
   status: GitRepoStatus | undefined,
   opts?: UpsertRepoGitFromProtoOpts,
@@ -386,7 +436,9 @@ export function upsertRepoGitFromProtoStatus(
     return
 
   const prev = store.get(key)
-  let next: Partial<RepoGitState> = { ...patch, gitStatusSeen: true }
+  // `nonRepoProbeIgnored: false` for the same reason as in
+  // `applyFullGitStatusUpsert`: a real status restores the one-shot allowance.
+  let next: Partial<RepoGitState> = { ...patch, gitStatusSeen: true, nonRepoProbeIgnored: false }
 
   if (prev?.branchPinnedUntilRefresh)
     next.branch = prev.branch

--- a/frontend/src/stores/tab.helpers.test.ts
+++ b/frontend/src/stores/tab.helpers.test.ts
@@ -9,7 +9,13 @@ import { GitRepoStatusSchema } from '~/generated/leapmux/v1/common_pb'
 import { TerminalInfoSchema, TerminalProgress_State, TerminalStatus } from '~/generated/leapmux/v1/terminal_pb'
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
 import { clearSettingsLabelCache, getCachedSettingsGroupLabel } from '~/lib/settingsLabelCache'
-import { agentTabToInfo, deriveOptionGroupTabFields, descendantAgentTabs, isSameRepo, isSteerableAgentTab, isTabReadyForGitStatus, mruSteerableAgentTab, openedTerminalMetadata, protoToAgentTabFields, resolveOptimisticGitInfo, rootAgentIdFor, seedOptimisticRepoGit, setOptionValue, tabDisplayLabel, tabTooltipShowWhen, tabTooltipText, terminalMetadata, terminalProgressBarProps } from './tab.helpers'
+import { repoKey } from './repoGit'
+// Static, not `await import(...)` inside a test body. The dynamic form put the
+// module transform inside the test and charged it against `testTimeout`, which
+// failed a 5s test on a cold Vite cache. `./tab.helpers` already pulls
+// `./repoGit` into the static graph, so nothing here forces the dynamic form.
+import { createRepoGitStore } from './repoGit.store'
+import { agentTabToInfo, deriveOptionGroupTabFields, descendantAgentTabs, isSameRepo, isSteerableAgentTab, isTabReadyForGitStatus, mruSteerableAgentTab, openedAgentTabFields, openedTerminalMetadata, planOptimisticRepoGit, protoToAgentTabFields, resolveOptimisticGitInfo, rootAgentIdFor, setOptionValue, tabDisplayLabel, tabTooltipShowWhen, tabTooltipText, terminalMetadata, terminalProgressBarProps } from './tab.helpers'
 import { createTabMetadataStore } from './tabMetadata.store'
 
 // `tabDisplayLabel` is the shared "what should we render in the tab strip
@@ -202,16 +208,16 @@ describe('protoToAgentTabFields git status', () => {
   const status = () => create(GitRepoStatusSchema, { branch: 'main', toplevel: '/repo' })
 
   it('writes repo identity onto the tab when git status carries a toplevel', () => {
-    const fields = protoToAgentTabFields('wkr-1', agent(status()))
+    const fields = protoToAgentTabFields(createRepoGitStore(), 'wkr-1', agent(status()))
     expect(fields.gitToplevel).toBe('/repo')
   })
 
   it('reports no git identity for an agent with no status', () => {
-    expect(protoToAgentTabFields('wkr-1', agent(undefined)).gitToplevel).toBeUndefined()
+    expect(protoToAgentTabFields(createRepoGitStore(), 'wkr-1', agent(undefined)).gitToplevel).toBeUndefined()
   })
 
   it('leaves the rest of the payload alone', () => {
-    const fields = protoToAgentTabFields('wkr-1', agent(status()))
+    const fields = protoToAgentTabFields(createRepoGitStore(), 'wkr-1', agent(status()))
     expect(fields.workerId).toBe('wkr-1')
     expect(fields.workingDir).toBe('/repo')
   })
@@ -595,41 +601,146 @@ describe('resolveOptimisticGitInfo', () => {
   })
 })
 
-describe('seedOptimisticRepoGit', () => {
-  it('copies branch and origin onto a different worker key when dirs match', async () => {
-    const { createRepoGitStore } = await import('~/stores/repoGit.store')
-    const { repoKey } = await import('~/stores/repoGit')
-    const store = createRepoGitStore()
-    const active = agent({ workerId: 'w1', gitToplevel: '/r', workingDir: '/r' })
+describe('planOptimisticRepoGit', () => {
+  const activeOn = (workerId: string) => agent({ workerId, gitToplevel: '/r', workingDir: '/r' })
+  const seedSource = (store: ReturnType<typeof createRepoGitStore>, extra: Record<string, unknown> = {}) =>
     store.upsert(repoKey('w1', '/r'), {
       workerId: 'w1',
       toplevel: '/r',
       branch: 'main',
       originUrl: 'git@example.com:o/r.git',
       gitStatusSeen: true,
+      ...extra,
     })
 
-    seedOptimisticRepoGit(store, active, { workerId: 'w2', workingDir: '/r' })
+  it('copies branch and origin onto a different worker key when dirs match', () => {
+    const store = createRepoGitStore()
+    seedSource(store)
+
+    planOptimisticRepoGit(store, activeOn('w1'), { workerId: 'w2', workingDir: '/r' }).commit()
 
     expect(store.get(repoKey('w2', '/r'))?.branch).toBe('main')
     expect(store.get(repoKey('w2', '/r'))?.originUrl).toBe('git@example.com:o/r.git')
   })
 
-  it('does nothing when the new tab shares the active store key', async () => {
-    const { createRepoGitStore } = await import('~/stores/repoGit.store')
-    const { repoKey } = await import('~/stores/repoGit')
+  it('does nothing when the new tab shares the active store key', () => {
     const store = createRepoGitStore()
-    const active = agent({ workerId: 'w1', gitToplevel: '/r', workingDir: '/r' })
-    store.upsert(repoKey('w1', '/r'), {
-      workerId: 'w1',
-      toplevel: '/r',
-      branch: 'main',
-      originUrl: 'git@example.com:o/r.git',
-    })
+    seedSource(store)
 
-    seedOptimisticRepoGit(store, active, { workerId: 'w1', workingDir: '/r' })
+    planOptimisticRepoGit(store, activeOn('w1'), { workerId: 'w1', workingDir: '/r' }).commit()
 
     expect(store.get(repoKey('w1', '/r'))?.branch).toBe('main')
+  })
+
+  /**
+   * The plan resolves the row fields; only `commit` writes. An open whose tab
+   * placement is refused never commits, so it leaves no entry that no tab reads
+   * and nothing reclaims.
+   */
+  it('writes nothing until the caller commits', () => {
+    const store = createRepoGitStore()
+    seedSource(store)
+
+    const plan = planOptimisticRepoGit(store, activeOn('w1'), { workerId: 'w2', workingDir: '/r' })
+
+    expect(plan.fields.gitToplevel, 'the row half is ready immediately').toBe('/r')
+    expect(store.get(repoKey('w2', '/r')), 'the store half waits for the tab').toBeUndefined()
+  })
+
+  /**
+   * A confirmed answer and an unprobed key both leave `branch` and `originUrl`
+   * empty, so emptiness alone cannot tell them apart. `gitStatusSeen` can, and
+   * without it a guess from another machine overwrites what this worker said.
+   */
+  it('refuses to overwrite a worker-confirmed branchless repo', () => {
+    const store = createRepoGitStore()
+    seedSource(store)
+    // A detached HEAD on w2 whose short-SHA probe also failed: real repo, no
+    // branch name, and the worker said so.
+    store.upsert(repoKey('w2', '/r'), {
+      workerId: 'w2',
+      toplevel: '/r',
+      branch: '',
+      originUrl: '',
+      gitStatusSeen: true,
+    })
+
+    planOptimisticRepoGit(store, activeOn('w1'), { workerId: 'w2', workingDir: '/r' }).commit()
+
+    expect(store.get(repoKey('w2', '/r'))?.branch, 'the worker answered; a guess must not outrank it').toBe('')
+  })
+
+  it('still fills a key nothing has probed yet', () => {
+    const store = createRepoGitStore()
+    seedSource(store)
+    // An optimistic stamp with no status behind it: not a worker answer.
+    store.upsert(repoKey('w2', '/r'), { workerId: 'w2', toplevel: '/r', branch: '', originUrl: '' })
+
+    planOptimisticRepoGit(store, activeOn('w1'), { workerId: 'w2', workingDir: '/r' }).commit()
+
+    expect(store.get(repoKey('w2', '/r'))?.branch).toBe('main')
+  })
+})
+
+/**
+ * The tab fields for an agent this client just opened.
+ *
+ * The helper exists to carry `hydrated: true`, which every local-open path
+ * needs and each one used to write by hand. Without it `useTabHydrators` re-asks
+ * for an agent this client just created, and that reply lands without the
+ * pending-axis suppression, so it overwrites an in-flight settings edit.
+ */
+describe('openedAgentTabFields', () => {
+  const openedAgent = (gs: GitRepoStatus | undefined) => create(AgentInfoSchema, {
+    id: 'a1',
+    workerId: 'wkr-1',
+    workingDir: '/repo',
+    agentProvider: AgentProvider.CLAUDE_CODE,
+    gitStatus: gs,
+  })
+  const status = () => create(GitRepoStatusSchema, {
+    branch: 'main',
+    toplevel: '/repo',
+    originUrl: 'git@example.com:o/r.git',
+  })
+
+  // The flag is the reason the helper exists, so it is the one field the pure
+  // mapper must not supply and this helper must.
+  it('marks the tab hydrated, which the pure mapper does not', () => {
+    const agentInfo = openedAgent(undefined)
+
+    expect(openedAgentTabFields(createRepoGitStore(), agentInfo).hydrated).toBe(true)
+    expect(
+      protoToAgentTabFields(createRepoGitStore(), 'wkr-1', agentInfo),
+      'the mapper stays neutral: the hydrators set the flag centrally',
+    ).not.toHaveProperty('hydrated')
+  })
+
+  it('changes nothing else the pure mapper puts on the row', () => {
+    const agentInfo = openedAgent(status())
+
+    const { hydrated, ...rest } = openedAgentTabFields(createRepoGitStore(), agentInfo)
+
+    expect(hydrated).toBe(true)
+    expect(rest).toEqual(protoToAgentTabFields(createRepoGitStore(), 'wkr-1', agentInfo))
+  })
+
+  /**
+   * The OpenAgent response carries no git status. The worker computes it in
+   * startup phase 1 and sends it on the STARTING broadcast, so the `git status`
+   * shell-out does not block the RPC; `TestOpenAgent_ResponseHasNilGitStatus`
+   * holds it to that.
+   *
+   * So this is the shape every caller really passes, and the row must carry no
+   * repo identity. A `gitToplevel` with no matching store entry is what files a
+   * tab under a repo with no branch name.
+   */
+  it('puts no repo identity on the row for the status the response really carries', () => {
+    expect(openedAgentTabFields(createRepoGitStore(), openedAgent(undefined)).gitToplevel).toBeUndefined()
+  })
+
+  it('copies the toplevel onto the row when a status does resolve one', () => {
+    expect(openedAgentTabFields(createRepoGitStore(), openedAgent(status())).gitToplevel).toBe('/repo')
   })
 })
 

--- a/frontend/src/stores/tab.helpers.ts
+++ b/frontend/src/stores/tab.helpers.ts
@@ -1,4 +1,4 @@
-import type { RepoGitStore } from './repoGit'
+import type { RepoGitStore, UpsertRepoGitFromProtoOpts } from './repoGit'
 import type { AgentTab, Tab, TerminalTab } from './tab.types'
 import type { TerminalMeta } from './tabMetadata.store'
 import type { listTerminals } from '~/api/workerRpc'
@@ -10,14 +10,19 @@ import { TerminalProgress_State, TerminalStatus } from '~/generated/leapmux/v1/t
 import { TabType } from '~/generated/leapmux/v1/workspace_pb'
 import { basename } from '~/lib/paths'
 import { updateSettingsLabelCache } from '~/lib/settingsLabelCache'
-import { repoKey, repoKeyFromTab } from './repoGit'
+import { repoKey, repoKeyFromTab, upsertRepoGitFromProtoStatus } from './repoGit'
 import { isTerminalTab } from './tab.types'
 
 /**
- * Module note: pure helpers over `Tab` records — no signals, no
- * imperative API. Lives in its own module so test code can import
- * just `tabKey` / `parseTabKey` / proto-to-tab converters without
- * dragging in the store factory's reactive dependencies.
+ * Module note: helpers over `Tab` records — no signals. Lives in its own
+ * module so test code can import just `tabKey` / `parseTabKey` / proto-to-tab
+ * converters without dragging in the store factory's reactive dependencies.
+ *
+ * Every export here is pure EXCEPT these, and each one takes the store it
+ * writes: `planOptimisticRepoGit` copies a branch onto a repo key when its
+ * caller commits, and `protoToAgentTabFields` writes the repo entry that
+ * matches the `gitToplevel` it returns (and primes the settings-label cache).
+ * Add no other one without naming it here.
  */
 
 type ProtoTerminal = Awaited<ReturnType<typeof listTerminals>>['terminals'][number]
@@ -167,9 +172,33 @@ export function setOptionValue(map: Record<string, string> | undefined, id: stri
  * catalogs on every tab read. (The pure `deriveOptionGroupTabFields` no longer does
  * this itself.)
  *
+ * `gitToplevel` is HALF of a tab's repo identity. The repo-keyed store holds
+ * the other half, and the sidebar reads one from each: it groups a tab by the
+ * row field and labels the group from the store. A caller that writes the row
+ * and not the store files the tab under a repo with no branch name.
+ *
+ * So this function writes BOTH halves, and takes the store to do it. The
+ * pairing used to be a rule in this comment that each caller had to remember,
+ * and two of them did not. Now a caller cannot obtain the row fields without
+ * supplying the store that takes the other half.
+ *
+ * `opts` carries the orphan-migration tip, which only a caller holding a LIVE
+ * tab can compute (`migrateErrorHintFromForResolvedRepo`). A local open has no
+ * tab yet and passes none.
  */
-export function protoToAgentTabFields(workerId: string, agent: AgentInfo): Partial<AgentTab> {
+export function protoToAgentTabFields(
+  store: Pick<RepoGitStore, 'get' | 'upsert' | 'clear'>,
+  workerId: string,
+  agent: AgentInfo,
+  opts?: UpsertRepoGitFromProtoOpts,
+): Partial<AgentTab> {
   updateSettingsLabelCache(agent.agentProvider, agent.optionGroups)
+  // The store write lives HERE, in the same call that produces `gitToplevel`,
+  // so the two halves of a tab's repo identity cannot be written apart. A
+  // caller cannot obtain the row fields without handing over the store that
+  // takes the other half. Both halves read the same status, so both are
+  // skipped together when it carries no toplevel.
+  upsertRepoGitFromProtoStatus(store, workerId, agent.gitStatus, opts)
   return {
     title: agent.title || undefined,
     workerId,
@@ -483,41 +512,111 @@ export function resolveOptimisticGitInfo(
   return { gitToplevel: activeTab.gitToplevel }
 }
 
+/** What {@link planOptimisticRepoGit} hands back to an open path. */
+export interface OptimisticRepoGitPlan {
+  /** Row fields for the new tab. Empty when the directories do not match. */
+  fields: { gitToplevel?: string }
+  /**
+   * Write the store copy. Call this ONLY once the tab exists.
+   *
+   * Placement can still be refused, and a caller that wrote the entry first
+   * left one behind that no tab reads. Nothing reclaims such an entry, and
+   * `hasHealthyRepoForProbe` then treats it as a real repo for one probe.
+   */
+  commit: () => void
+}
+
 /**
- * Copy branch/origin/worktree from the active tab's repo store entry onto the
- * new tab's key when both resolve to the same git directory. Same-worker opens
- * share a key and need no copy; different workerIds need this to avoid a
- * sidebar flash under "(no branch)".
+ * Plan the optimistic copy of branch/origin/worktree from the active tab's repo
+ * entry onto the new tab's key, for the case where both resolve to the same git
+ * directory. Same-worker opens share a key and need no copy; different worker
+ * ids need this to avoid a sidebar flash with no branch name.
+ *
+ * ONE evaluation feeds both halves. The row fields and the store copy used to
+ * be resolved by two calls, from two hand-built argument objects that had to
+ * agree on `shellStartDir` -- and a caller that built them differently decided
+ * the directory match against one tab and copied the branch from another.
+ *
+ * The copy is DEFERRED rather than done here, so an open that fails to place
+ * its tab writes nothing. See {@link OptimisticRepoGitPlan.commit}.
  */
-export function seedOptimisticRepoGit(
+export function planOptimisticRepoGit(
   store: Pick<RepoGitStore, 'get' | 'upsert'>,
   activeTab: Tab | null | undefined,
   newTab: { workerId?: string, shellStartDir?: string, workingDir?: string },
-): void {
-  const seed = resolveOptimisticGitInfo(activeTab, newTab)
+): OptimisticRepoGitPlan {
+  const fields = resolveOptimisticGitInfo(activeTab, newTab)
+  const noop = { fields, commit: () => {} }
+
   const workerId = newTab.workerId ?? ''
-  if (!seed.gitToplevel || !workerId || !activeTab?.workerId)
-    return
+  if (!fields.gitToplevel || !workerId || !activeTab?.workerId)
+    return noop
   const fromKey = repoKeyFromTab(activeTab)
   if (!fromKey)
-    return
-  const from = store.get(fromKey)
-  if (!from?.toplevel)
-    return
-  const toKey = repoKey(workerId, seed.gitToplevel)
+    return noop
+  const toKey = repoKey(workerId, fields.gitToplevel)
   if (toKey === fromKey)
-    return
-  const existing = store.get(toKey)
-  if (existing?.originUrl || existing?.branch)
-    return
-  store.upsert(toKey, {
-    workerId,
-    toplevel: seed.gitToplevel,
-    branch: from.branch,
-    originUrl: from.originUrl,
-    isWorktree: from.isWorktree,
-    gitStatusSeen: from.gitStatusSeen,
-  })
+    return noop
+
+  const toplevel = fields.gitToplevel
+  return {
+    fields,
+    commit: () => {
+      // Read at COMMIT time, not at plan time. The worker's own answer can
+      // land between the two, and it must win.
+      const from = store.get(fromKey)
+      if (!from?.toplevel)
+        return
+      const existing = store.get(toKey)
+      // `gitStatusSeen` is the difference between "nothing probed this key
+      // yet" and "the worker answered, and this repo genuinely has no branch"
+      // -- a detached HEAD, or a non-repo stub. Both leave `branch` and
+      // `originUrl` empty, so the emptiness alone cannot tell them apart, and
+      // a guess would overwrite the worker's own answer with another
+      // machine's branch.
+      if (existing?.gitStatusSeen || existing?.originUrl || existing?.branch)
+        return
+      store.upsert(toKey, {
+        workerId,
+        toplevel,
+        branch: from.branch,
+        originUrl: from.originUrl,
+        isWorktree: from.isWorktree,
+        gitStatusSeen: from.gitStatusSeen,
+      })
+    },
+  }
+}
+
+/**
+ * Tab fields for an agent this client just opened, from the `AgentInfo` that
+ * the OpenAgent response carried. The sibling of {@link openedTerminalMetadata}.
+ *
+ * `hydrated: true` belongs to the helper, not to the call site. The OpenAgent
+ * response IS the worker's answer for this tab, so `useTabHydrators` must not
+ * re-ask. Its reply arrives without the pending-axis suppression that the live
+ * settings path applies, and it overwrites an optimistic settings edit made
+ * during the round trip. Every local-open path needs the flag, so a fourth one
+ * cannot ship without it.
+ *
+ * This helper writes NO repo-keyed git entry, and it needs none. The response
+ * carries no git status: the worker computes the status in startup phase 1 and
+ * sends it on the STARTING broadcast, because the `git status` shell-out would
+ * otherwise block the RPC. `TestOpenAgent_ResponseHasNilGitStatus` holds the
+ * worker to that. `protoToAgentTabFields` therefore writes no `gitToplevel`
+ * either, so the row and the store stay consistent -- both empty -- until
+ * `applyAgentStatusTabUpdate` writes the pair from the broadcast.
+ */
+export function openedAgentTabFields(
+  store: Pick<RepoGitStore, 'get' | 'upsert' | 'clear'>,
+  agent: AgentInfo,
+) {
+  // No orphan-migration tip: a local open has no live tab to compute one from.
+  //
+  // The return type is inferred, like `openedTerminalMetadata`'s: `hydrated`
+  // lives on `TabMetadata`, not on `AgentTab`, so `Partial<AgentTab>` would
+  // drop it.
+  return { ...protoToAgentTabFields(store, agent.workerId, agent), hydrated: true }
 }
 
 /**


### PR DESCRIPTION
## Motivation

A workspace tab's repository identity has two sources of truth: `Tab.gitToplevel` on the tab's own metadata row, and a repo-keyed store (`RepoGitStore`, keyed by `${workerId}\0${gitToplevel}`) that supplies the branch label the sidebar displays. The sidebar groups a tab by the row field but labels it from the store, so anything that empties the store while the row survives files the tab under its repository with no branch name.

Three separate triggers hit this. The worker-offline sweep in `useWorkspaceConnection.ts` called `clearForWorker` on every disconnect, and any transport-shaped failure reports a worker offline — a closed socket, a sleeping laptop, a restarted hub. `useWorkerSection` cleared the store again on deregistration, where the worker's tab rows survive untouched. And a freshly opened tab had no seed at all: the `OpenAgent` RPC deliberately returns no git status, because the worker computes it in startup phase 1 and sends it on a later STARTING broadcast so a `git status` shell-out never blocks the RPC (the backend test `TestOpenAgent_ResponseHasNilGitStatus` holds it to that).

Nothing repaired a stranded label on its own. An agent tab stays `hydrated` for the life of the page, so the hydrator never re-asks; the worker reports a git status only at that agent's own turn end; and the reconnect's catch-up replay carries one only for an agent promoted to FULL. The user had to click the tab, or the Files refresh button, once per tab, after every blip.

## Modifications

- Removed `clearForWorker` outright, along with both of its call sites: the offline sweep in `useWorkspaceConnection.ts` and the deregistration path in `useWorkerSection`. A store entry is last-known working-tree state, not a claim about the link, so neither event discards it now.
- Added `releaseBranchPinsForWorker`, a distinct new behaviour rather than a replacement for `clearForWorker`: on a worker's offline-to-online transition it clears only the optimistic `branchPinnedUntilRefresh` flag, keeping the branch value. A dropped link can no longer stand behind "this branch change succeeded, ignore stale broadcasts", and a background tab issues no refresh of its own to clear the pin.
- Added an LRU cap (`MAX_REPO_ENTRIES = 256`), needed because removing both sweeps left the store with no eviction at all. Eviction refuses the key just written, the focused key, and any pinned key. A `peek` (no recency touch, for internal key scans) is split from `get` (touches), so an entry backing a live tab is marked used on every sidebar render and eviction cannot reach it.
- Added a one-shot allowance for a transient probe answer (`nonRepoProbeIgnored` / `markNonRepoProbeIgnored`). One "not a git repository" answer is ignored and the last-good state kept; a second consecutive answer is believed and writes the stub. Without the limit, an entry that outlived a deleted repository suppressed every later probe for the life of the page. A real status restores the allowance.
- `seedOptimisticRepoGit` became `planOptimisticRepoGit`, returning `{fields, commit}`. `fields` seeds the row immediately; `commit()` performs the store write only once the tab exists, so an open whose placement is refused leaves no entry that no tab reads. `commit` re-reads the source at commit time, so a worker answer that lands in between wins.
- The optimistic seed now also consults `gitStatusSeen`. An unprobed key and a repository the worker confirmed has no branch both look empty, and the copy used to overwrite the second with another machine's branch.
- **Signature change:** `protoToAgentTabFields` now requires a store parameter and writes the store entry itself, in the same call that produces `gitToplevel`. A caller can no longer obtain one half of a tab's repository identity without supplying the store that takes the other half. A new `openedAgentTabFields` helper wraps it for the local-open paths and carries the `hydrated: true` flag each of them used to write by hand.
- **Signature change:** `NewAgentDialog.onCreated` and `NewTerminalDialog.onCreated` gained a `seedGitFromActiveTab` flag, true only for the plain `GitMode.Current`. The dialogs now seed a branch guess from the active tab, matching what the tab-bar path already did. Every other git mode redirects the tab into a worktree or onto another branch, where the active tab's branch is the wrong answer — so those modes skip the seed rather than put a confidently wrong label on the tab.
- `openSubagentTab.buildMetadata` gained a `workerId` parameter and copies the parent's git fields only when `parent?.workerId === workerId`, closing a latent case where a cross-worker parent's toplevel was written under a worker id nothing had probed.
- `useTabHydrators` re-asks for an agent tab when its worker returns. Only terminal tabs re-armed before, on DISCONNECTED, which is why an agent tab's title, status and option catalogs froze at whatever was true before the link dropped. The batch now applies the `ListAgents` reply through `resolveSettingsTabFields`, gated by a new `settingsPendingAxes` option, which is what makes a re-ask safe: it keeps an axis the user is editing instead of overwriting it.
- `tabGitToplevelForKey` in `branchKeys.ts` is now the single place that resolves which repository a tab is in. It believes an explicit "not a git repository" answer over a stale row toplevel, while still falling back to the row when no store key resolves or nothing has probed yet. `WorkspaceTabTree.tsx` routes both of its previously duplicated fallback chains through it.
- `NewWorkspaceDialog.tsx` places the tab with the `OpenAgent` response's own `workerId` instead of the local `wid`, so the row and the store read one identity from one source. The other two agent-open paths already did this.

## Result

- A background tab keeps its branch label across a dropped worker link, and across a worker deregistration. You no longer have to click each tab, or the Files refresh button, to bring the branch back after a blip.
- An agent tab catches up on its title, status and option catalogs when its worker comes back, instead of showing pre-outage values for the rest of the page — and a settings change you are making at that moment survives the catch-up.
- A repository deleted while its worker was unreachable is now reported as gone on the second probe, rather than keeping a stale branch and diff badge until you reload.
- A new agent or terminal opened from a dialog shows its branch immediately when it lands in the directory you were already looking at, instead of sitting outside its repository group for the whole of the agent's startup. An open that creates a worktree or switches branch shows no branch until the worker reports, which is the honest answer for a directory whose branch nothing has read yet.
