### PR TITLE
fix: Detach agent children and retry Windows file replace

### DIFF
--- a/backend/internal/cli/control/refresh_test.go
+++ b/backend/internal/cli/control/refresh_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"runtime"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -813,6 +814,30 @@ func TestAuthInterceptor_StopsWhenEveryRepairIsUsed(t *testing.T) {
 
 // --- the credential file the rotation could not write -----------------
 
+// blockCredentialSaves makes the next SaveCredentials for hubURL fail,
+// after LoadCredentials has already succeeded.
+//
+// chmod 0500 on the config directory is the Unix form: the existing
+// file stays readable (owner execute on the directory is enough) and
+// CreateTemp cannot create a sibling. Windows ignores a directory's
+// read-only bit for child creates, so the same chmod lets the save
+// succeed and swallows the rotation. A read-only credential FILE is
+// the Windows form: ReadFile still works and the replace cannot.
+func blockCredentialSaves(t *testing.T, hubURL string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		path, err := CredentialsPath(hubURL)
+		require.NoError(t, err)
+		require.NoError(t, os.Chmod(path, 0o400))
+		t.Cleanup(func() { _ = os.Chmod(path, 0o600) })
+		return
+	}
+	dir, err := ConfigDir()
+	require.NoError(t, err)
+	require.NoError(t, os.Chmod(dir, 0o500))
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+}
+
 // TestRefresh_AdoptsThePairItCouldNotSave is the failure that used to
 // destroy a credential.
 //
@@ -836,10 +861,7 @@ func TestRefresh_AdoptsThePairItCouldNotSave(t *testing.T) {
 	c, err := NewClient(rs.server.URL)
 	require.NoError(t, err)
 
-	// A config directory nothing can write to: the rotation reaches the hub
-	// and the save fails. The mode is restored before t.TempDir removes it.
-	require.NoError(t, os.Chmod(dir, 0o500))
-	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+	blockCredentialSaves(t, rs.server.URL)
 
 	err = c.EnsureFreshBearer(context.Background())
 	require.ErrorIs(t, err, ErrCredentialsNotSaved,
@@ -873,10 +895,7 @@ func TestAuthInterceptor_ReportsALocalDiskFailureAsSuchNotAsASignIn(t *testing.T
 	c, err := NewClient(hub.server.URL)
 	require.NoError(t, err)
 
-	// A config directory nothing can write to. The mode is restored before
-	// t.TempDir removes it.
-	require.NoError(t, os.Chmod(dir, 0o500))
-	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+	blockCredentialSaves(t, hub.server.URL)
 
 	err = hub.call(c)
 	require.Error(t, err)

--- a/backend/internal/util/atomicfile/atomicfile.go
+++ b/backend/internal/util/atomicfile/atomicfile.go
@@ -16,8 +16,8 @@ import (
 const tempSuffix = ".tmp"
 
 // WriteFile writes data to path atomically: it first writes the bytes
-// to a UNIQUE temporary file beside path with mode, then renames that
-// file onto path. On the success path the rename is the only observable
+// to a UNIQUE temporary file beside path with mode, then replaces path
+// with that file. On the success path the replace is the only observable
 // mutation, so a crash partway through cannot leave path truncated or
 // partially overwritten. On the failure path WriteFile removes the
 // temporary file so the next attempt starts from a clean state.
@@ -29,6 +29,11 @@ const tempSuffix = ".tmp"
 // bytes, and rename a mixed document onto path -- after which every
 // reader reports a parse failure. The credential file takes exactly that
 // shape, because every long-lived command rotates its token by itself.
+//
+// On Windows the replace is not one kernel call: a destination that
+// still has an open handle fails with ACCESS_DENIED, so replaceFile
+// retries a sharing conflict. It does not retry a directory or a
+// read-only destination; those cannot succeed.
 //
 // The bytes reach the disk before the rename, so a machine that loses
 // power right after the rename cannot replace the previous content
@@ -71,7 +76,7 @@ func WriteFile(path string, data []byte, mode os.FileMode) error {
 	if err := f.Close(); err != nil {
 		return err
 	}
-	if err := os.Rename(tmp, path); err != nil {
+	if err := replaceFile(tmp, path); err != nil {
 		return err
 	}
 	committed = true

--- a/backend/internal/util/atomicfile/atomicfile_test.go
+++ b/backend/internal/util/atomicfile/atomicfile_test.go
@@ -76,6 +76,11 @@ func TestWriteFile_NeverUsesTheNameDerivedFromTheDestination(t *testing.T) {
 // property under real contention. It cannot fail on demand -- an interleave
 // needs a write that the kernel splits -- so read it as a smoke test of the
 // unique name, not as the proof; the test above is the proof.
+//
+// Windows cannot replace a destination that still has an open handle, so
+// two writers of the same path get ACCESS_DENIED. replaceFile retries
+// that conflict; this case is what proves the retry lands a whole
+// document rather than leaving a sharing error for the caller.
 func TestWriteFile_ConcurrentWritersEachLandAWholeDocument(t *testing.T) {
 	t.Parallel()
 
@@ -105,6 +110,38 @@ func TestWriteFile_ConcurrentWritersEachLandAWholeDocument(t *testing.T) {
 	entries, err := os.ReadDir(dir)
 	require.NoError(t, err)
 	assert.Len(t, entries, 1, "every temporary file must be gone")
+}
+
+// TestWriteFile_ReadOnlyDestination pins the permanent Windows failure
+// that replaceFile must not retry: a sharing conflict is transient, a
+// read-only destination is not. Unix rename replaces a 0400 file when
+// the directory is writable.
+func TestWriteFile_ReadOnlyDestination(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "creds.json")
+	require.NoError(t, atomicfile.WriteFile(path, []byte("one"), 0o600))
+	require.NoError(t, os.Chmod(path, 0o400))
+	t.Cleanup(func() { _ = os.Chmod(path, 0o600) })
+
+	err := atomicfile.WriteFile(path, []byte("two"), 0o600)
+	if runtime.GOOS == "windows" {
+		require.Error(t, err, "Windows cannot replace a read-only file")
+		data, readErr := os.ReadFile(path)
+		require.NoError(t, readErr)
+		assert.Equal(t, "one", string(data))
+	} else {
+		require.NoError(t, err)
+		data, err := os.ReadFile(path)
+		require.NoError(t, err)
+		assert.Equal(t, "two", string(data))
+	}
+
+	entries, listErr := os.ReadDir(dir)
+	require.NoError(t, listErr)
+	require.Len(t, entries, 1, "a failed or successful replace must not leave a temporary file")
+	assert.Equal(t, "creds.json", entries[0].Name())
 }
 
 // TestWriteFile_RemovesTheTemporaryFileWhenTheRenameFails pins the failure

--- a/backend/internal/util/atomicfile/replace_other.go
+++ b/backend/internal/util/atomicfile/replace_other.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package atomicfile
+
+import "os"
+
+func replaceFile(oldpath, newpath string) error {
+	return os.Rename(oldpath, newpath)
+}

--- a/backend/internal/util/atomicfile/replace_windows.go
+++ b/backend/internal/util/atomicfile/replace_windows.go
@@ -1,0 +1,58 @@
+//go:build windows
+
+package atomicfile
+
+import (
+	"errors"
+	"os"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+// replaceAttempts is how many times a sharing conflict is retried.
+// Concurrent writers of one credential file hit ERROR_ACCESS_DENIED or
+// ERROR_SHARING_VIOLATION because Windows will not replace a destination
+// that still has an open handle. The conflict is transient: the other
+// writer's rename finishes and this one can replace. A directory or a
+// read-only destination is permanent and is not retried.
+const replaceAttempts = 8
+
+func replaceFile(oldpath, newpath string) error {
+	var err error
+	for i := range replaceAttempts {
+		err = os.Rename(oldpath, newpath)
+		if err == nil {
+			return nil
+		}
+		if destCannotReplace(newpath) || !isSharingConflict(err) {
+			return err
+		}
+		if i+1 < replaceAttempts {
+			time.Sleep(time.Millisecond << uint(i))
+		}
+	}
+	return err
+}
+
+func destCannotReplace(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	if info.IsDir() {
+		return true
+	}
+	// Windows maps FILE_ATTRIBUTE_READONLY to a mode with no write bit.
+	return info.Mode().Perm()&0o200 == 0
+}
+
+func isSharingConflict(err error) bool {
+	var link *os.LinkError
+	if errors.As(err, &link) {
+		err = link.Err
+	}
+	return errors.Is(err, windows.ERROR_ACCESS_DENIED) ||
+		errors.Is(err, windows.ERROR_SHARING_VIOLATION) ||
+		errors.Is(err, windows.ERROR_LOCK_VIOLATION)
+}

--- a/backend/internal/util/atomicfile/replace_windows_test.go
+++ b/backend/internal/util/atomicfile/replace_windows_test.go
@@ -1,0 +1,130 @@
+//go:build windows
+
+package atomicfile
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+)
+
+func TestDestCannotReplace_Directory(t *testing.T) {
+	t.Parallel()
+	assert.True(t, destCannotReplace(t.TempDir()),
+		"a directory at the destination can never succeed, so it must not be retried")
+}
+
+func TestDestCannotReplace_ReadOnlyFile(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "creds.json")
+	require.NoError(t, os.WriteFile(path, []byte("one"), 0o600))
+	require.NoError(t, os.Chmod(path, 0o400))
+	t.Cleanup(func() { _ = os.Chmod(path, 0o600) })
+
+	assert.True(t, destCannotReplace(path),
+		"a read-only destination is the same ACCESS_DENIED as a sharing conflict, and must not be retried")
+}
+
+func TestDestCannotReplace_WritableFile(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "creds.json")
+	require.NoError(t, os.WriteFile(path, []byte("one"), 0o600))
+	assert.False(t, destCannotReplace(path),
+		"a sharing conflict on a writable file is transient and must be retried")
+}
+
+func TestDestCannotReplace_MissingPath(t *testing.T) {
+	t.Parallel()
+	assert.False(t, destCannotReplace(filepath.Join(t.TempDir(), "absent")),
+		"a missing destination is not a permanent refusal")
+}
+
+func TestIsSharingConflict_RecognizesTheWindowsReplaceErrors(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, isSharingConflict(&os.LinkError{Err: windows.ERROR_ACCESS_DENIED}))
+	assert.True(t, isSharingConflict(&os.LinkError{Err: windows.ERROR_SHARING_VIOLATION}))
+	assert.True(t, isSharingConflict(&os.LinkError{Err: windows.ERROR_LOCK_VIOLATION}))
+	assert.True(t, isSharingConflict(windows.ERROR_ACCESS_DENIED),
+		"os.Rename wraps this in a LinkError, and a classifier that only matches the wrapper misses the errno itself")
+	assert.True(t, isSharingConflict(fmt.Errorf("rename: %w", &os.LinkError{Err: windows.ERROR_ACCESS_DENIED})))
+	assert.False(t, isSharingConflict(nil))
+	assert.False(t, isSharingConflict(os.ErrNotExist))
+	assert.False(t, isSharingConflict(&os.LinkError{Err: windows.ERROR_ALREADY_EXISTS}))
+}
+
+func TestWriteFile_DirectoryReadOnlyDoesNotBlockCreate(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "creds.json")
+	require.NoError(t, os.Chmod(dir, 0o500))
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	require.NoError(t, WriteFile(path, []byte("one"), 0o600),
+		"Windows ignores a directory's read-only bit for child creates; chmod 0500 on the config dir cannot stand in for a failed save")
+	require.NoError(t, WriteFile(path, []byte("two"), 0o600))
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "two", string(data))
+}
+
+func TestWriteFile_ExclusiveHandleBlocksReplaceUntilClosed(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "creds.json")
+	require.NoError(t, WriteFile(path, []byte("one"), 0o600))
+
+	h := openExclusive(t, path)
+	closed := false
+	t.Cleanup(func() {
+		if !closed {
+			_ = windows.CloseHandle(h)
+		}
+	})
+	assert.False(t, destCannotReplace(path),
+		"an exclusive handle is a sharing conflict, not a permanent refusal")
+	require.Error(t, WriteFile(path, []byte("two"), 0o600),
+		"Windows cannot replace a destination that still has an exclusive handle")
+
+	require.NoError(t, windows.CloseHandle(h))
+	closed = true
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "one", string(data), "the replace must not land while the exclusive handle is held")
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "the exhausted retry must not leave a temporary file")
+	assert.Equal(t, "creds.json", entries[0].Name())
+
+	require.NoError(t, WriteFile(path, []byte("two"), 0o600))
+	data, err = os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "two", string(data))
+}
+
+func openExclusive(t *testing.T, path string) windows.Handle {
+	t.Helper()
+	name, err := windows.UTF16PtrFromString(path)
+	require.NoError(t, err)
+	h, err := windows.CreateFile(
+		name,
+		windows.GENERIC_READ,
+		0,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_ATTRIBUTE_NORMAL,
+		0,
+	)
+	require.NoError(t, err)
+	return h
+}

--- a/backend/internal/worker/agent/acp_terminal_proc_unix.go
+++ b/backend/internal/worker/agent/acp_terminal_proc_unix.go
@@ -7,19 +7,22 @@ import (
 	"os/exec"
 	"syscall"
 	"time"
+
+	"github.com/leapmux/leapmux/util/procutil"
 )
 
-// configureACPTerminalCmd puts the child in its own process group so later
-// kill/Stop can reap grandchildren that inherit the pipes (Setpgid + group
-// SIGTERM, then WaitDelay force-kill). Without this, Process.Kill only hits
-// /bin/sh and a still-running child holds stdout/stderr open forever.
+// configureACPTerminalCmd starts the child in a new session so it cannot
+// steal leapmux solo's foreground tty (the SIGTTIN class DetachFromTerminal
+// documents). Setsid also makes the child a process-group leader, so later
+// kill/Stop can reap grandchildren that inherit the pipes (group SIGTERM,
+// then WaitDelay force-kill). Without this, Process.Kill only hits /bin/sh
+// and a still-running child holds stdout/stderr open forever. Do not set
+// Setpgid as well: Go runs setsid then setpgid, and setpgid on a session
+// leader fails with EPERM.
 func configureACPTerminalCmd(cmd *exec.Cmd) {
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	procutil.DetachFromTerminal(cmd)
 	cmd.Cancel = func() error {
-		if cmd.Process == nil {
-			return nil
-		}
-		return syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
+		return procutil.SignalProcessGroup(cmd, syscall.SIGTERM)
 	}
 	cmd.WaitDelay = 5 * time.Second
 }

--- a/backend/internal/worker/agent/acp_terminal_proc_unix_test.go
+++ b/backend/internal/worker/agent/acp_terminal_proc_unix_test.go
@@ -1,0 +1,22 @@
+//go:build unix
+
+package agent
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigureACPTerminalCmdStartsANewSession(t *testing.T) {
+	cmd := exec.CommandContext(context.Background(), "true")
+	configureACPTerminalCmd(cmd)
+	require.NotNil(t, cmd.SysProcAttr)
+	assert.True(t, cmd.SysProcAttr.Setsid, "ACP host commands must drop the worker ctty")
+	assert.False(t, cmd.SysProcAttr.Setpgid, "Setsid+Setpgid is EPERM at Start")
+	require.NotNil(t, cmd.Cancel)
+	require.NoError(t, cmd.Run(), "Setsid without Setpgid must be a valid Start")
+}

--- a/backend/internal/worker/agent/factory.go
+++ b/backend/internal/worker/agent/factory.go
@@ -1,12 +1,13 @@
 package agent
 
 import (
+	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -603,62 +604,81 @@ func checkBinaryAvailable(ctx context.Context, shellPath string, loginShell bool
 	return available, conclusive
 }
 
+// probeReachedPresent / probeReachedAbsent are printed by the inner
+// command so a login profile that exits before the probe cannot be
+// cached as "binary absent". Exit status alone cannot tell those apart:
+// both are ExitError.
+const (
+	probeReachedPresent = "__LEAPMUX_PROBE_REACHED__present"
+	probeReachedAbsent  = "__LEAPMUX_PROBE_REACHED__absent"
+)
+
 // probeBinary asks the shell whether binaryName resolves, and reports
 // whether the answer ESTABLISHES anything.
 //
 // The two are not the same, and conflating them is what froze a broken
-// environment as "not installed" for the worker's lifetime. `cmd.Run()`
-// returns an error for four different reasons, and only one of them is an
-// answer:
+// environment as "not installed" for the worker's lifetime. Presence is
+// the inner command's marker on stdout, not the shell's exit status:
 //
-//   - the shell ran and reported the binary absent (ExitError) — conclusive;
+//   - the inner command printed probeReachedPresent or Absent — conclusive;
 //   - the shell could not START at all (a $SHELL that is not executable, a
 //     missing interpreter, EACCES, fork failure under load) — proves
 //     nothing about the binary;
-//   - a login profile exited non-zero before reaching the probe — likewise;
-//   - ctx expired and CommandContext killed the process — likewise, and
-//     note the process reports an ExitError ("signal: killed") rather than
-//     the context error, so ctx must be checked separately.
+//   - a login profile exited before the inner command — no marker, likewise;
+//   - ctx expired and CommandContext killed the process — likewise.
 //
 // $SHELL reaches here unvalidated (terminal.ResolveDefaultShell does no
 // LookPath), so the start-failure case is reachable, not theoretical.
 func probeBinary(ctx context.Context, shellPath string, loginShell bool, binaryName string) (available, conclusive bool) {
 	shellName := terminal.ShellBaseName(shellPath)
+	quoted := posixQuote(binaryName)
 
 	var inner, flag string
 	switch {
 	case terminal.IsPwsh(shellName):
-		inner = fmt.Sprintf("if (Get-Command %s -ErrorAction SilentlyContinue) { exit 0 } else { exit 1 }", pwshQuote(binaryName))
+		inner = fmt.Sprintf(
+			"if (Get-Command %s -ErrorAction SilentlyContinue) { Write-Output '%s' } else { Write-Output '%s' }",
+			pwshQuote(binaryName), probeReachedPresent, probeReachedAbsent,
+		)
 		flag = "-Command"
 	case shellName == "nu":
-		inner = fmt.Sprintf("if (which %s | is-not-empty) { exit 0 } else { exit 1 }", nuQuote(binaryName))
+		inner = fmt.Sprintf(
+			"if (which %s | is-not-empty) { echo '%s' } else { echo '%s' }",
+			nuQuote(binaryName), probeReachedPresent, probeReachedAbsent,
+		)
 		flag = "-c"
 	case shellName == "tcsh" || shellName == "csh":
-		inner = fmt.Sprintf("which %s >& /dev/null", posixQuote(binaryName))
+		inner = fmt.Sprintf(
+			"which %s >& /dev/null && printf '%%s\\n' '%s' || printf '%%s\\n' '%s'",
+			quoted, probeReachedPresent, probeReachedAbsent,
+		)
 		flag = "-c"
 	default:
-		inner = fmt.Sprintf("command -v %s >/dev/null 2>&1", posixQuote(binaryName))
+		inner = fmt.Sprintf(
+			"if command -v %s >/dev/null 2>&1; then printf '%%s\\n' '%s'; else printf '%%s\\n' '%s'; fi",
+			quoted, probeReachedPresent, probeReachedAbsent,
+		)
 		flag = "-c"
 	}
 
-	var args []string
-	if loginShell {
-		args = append(terminal.LoginShellArgs(shellPath), flag, inner)
-	} else {
-		args = []string{flag, inner}
-	}
+	args := terminal.CommandArgs(shellPath, loginShell, flag, inner)
 
 	cmd := exec.CommandContext(ctx, shellPath, args...)
 	cmd.Dir = os.TempDir()
 	procutil.HideConsoleWindow(cmd)
-	err := cmd.Run()
-	if err == nil {
-		return true, ctx.Err() == nil
+	procutil.DetachFromTerminal(cmd)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	_ = cmd.Run()
+	if ctx.Err() != nil {
+		return false, false
 	}
-	// Only a real exit status means the shell ran and answered. Anything
-	// else (exec.Error, a permission fault, a fork failure) is a broken
-	// environment, and a killed process reports an ExitError too — so the
-	// context still has to be clean for the status to mean anything.
-	var exitErr *exec.ExitError
-	return false, errors.As(err, &exitErr) && ctx.Err() == nil
+	out := stdout.String()
+	if strings.Contains(out, probeReachedPresent) {
+		return true, true
+	}
+	if strings.Contains(out, probeReachedAbsent) {
+		return false, true
+	}
+	return false, false
 }

--- a/backend/internal/worker/agent/factory_test.go
+++ b/backend/internal/worker/agent/factory_test.go
@@ -2,8 +2,10 @@ package agent
 
 import (
 	"context"
+	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
@@ -382,6 +384,42 @@ func TestProbeBinaryInconclusiveWhenTheShellCannotStart(t *testing.T) {
 	assert.False(t, cached, "an inconclusive probe must not be cached")
 }
 
+// A login profile that exits before the inner command used to look like
+// "binary absent": both are ExitError. The reached marker is what
+// distinguishes them, and the miss must not be cached.
+func TestProbeBinaryInconclusiveWhenTheShellExitsBeforeTheProbe(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shebang stub cannot exec on Windows")
+	}
+	stub := filepath.Join(t.TempDir(), "shell")
+	require.NoError(t, os.WriteFile(stub, []byte("#!/bin/sh\nexit 1\n"), 0o755))
+
+	available, conclusive := probeBinary(context.Background(), stub, true, "claude")
+	assert.False(t, available)
+	assert.False(t, conclusive, "a shell that exits before the inner command establishes nothing")
+
+	_, cached := binaryAvailabilityCache.Load(binaryAvailabilityKey{stub, true, "claude"})
+	assert.False(t, cached, "an inconclusive probe must not be cached")
+}
+
+// Exit 0 without the reached marker used to look like "binary present".
+// A login profile that `exit 0`s before the inner command, or a stub
+// that ignores argv, must stay inconclusive.
+func TestProbeBinaryInconclusiveWhenTheShellExitsZeroWithoutAMarker(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shebang stub cannot exec on Windows")
+	}
+	stub := filepath.Join(t.TempDir(), "shell")
+	require.NoError(t, os.WriteFile(stub, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+
+	available, conclusive := probeBinary(context.Background(), stub, true, "claude")
+	assert.False(t, available)
+	assert.False(t, conclusive, "exit 0 without the reached marker establishes nothing")
+
+	_, cached := binaryAvailabilityCache.Load(binaryAvailabilityKey{stub, true, "claude"})
+	assert.False(t, cached, "an inconclusive probe must not be cached")
+}
+
 // A shell that runs and reports the binary absent IS an answer, and is
 // cached — that is the case the cache exists for.
 func TestProbeBinaryConclusiveWhenTheShellAnswers(t *testing.T) {
@@ -401,6 +439,17 @@ func TestProbeBinaryConclusiveWhenTheShellAnswers(t *testing.T) {
 	v, cached := binaryAvailabilityCache.Load(binaryAvailabilityKey{shell, false, absent})
 	require.True(t, cached, "a conclusive probe must be cached")
 	assert.Equal(t, false, v)
+}
+
+func TestProbeBinaryConclusiveWhenTheBinaryIsPresent(t *testing.T) {
+	shell, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skip("no POSIX shell on this machine")
+	}
+
+	available, conclusive := probeBinary(context.Background(), shell, false, "echo")
+	assert.True(t, conclusive, "the shell ran and answered")
+	assert.True(t, available, "echo is a POSIX builtin, so command -v must find it")
 }
 
 // A probe killed by an expired context reports an ExitError ("signal:

--- a/backend/internal/worker/agent/process.go
+++ b/backend/internal/worker/agent/process.go
@@ -331,11 +331,12 @@ func (p *processBase) PreambleOutput() string {
 	return strings.Join(p.preambleOutput, "\n")
 }
 
-// attachJobObject assigns a freshly-started command to a Windows kill-on-close
-// job object so that force-killing later reaps the whole process tree. Must
-// be called immediately after cmd.Start. Non-Windows is a no-op; a job
-// creation failure is logged but not fatal — the agent still works, we just
-// lose the tree-kill guarantee for that session.
+// attachJobObject assigns a freshly-started command to a kill group so
+// later force-kills reap the whole process tree (Windows job object;
+// Unix process group after Setsid/Setpgid). Must be called immediately
+// after cmd.Start. A job creation failure is logged but not fatal — the
+// agent still works, we just lose the tree-kill guarantee for that
+// session.
 func (p *processBase) attachJobObject(cmd *exec.Cmd) {
 	job, err := procutil.AssignCmd(cmd)
 	if err != nil {
@@ -384,7 +385,7 @@ func (p *processBase) startCmd(cmd *exec.Cmd, cancel func()) error {
 // stdin, stdout, and stderr pipes. On error it calls cancel() and returns.
 func setupProcessPipes(cmd *exec.Cmd, cancel func()) (stdin io.WriteCloser, stdout, stderr io.ReadCloser, err error) {
 	cmd.Cancel = func() error {
-		return cmd.Process.Signal(syscall.SIGTERM)
+		return procutil.SignalProcessGroup(cmd, syscall.SIGTERM)
 	}
 	cmd.WaitDelay = 5 * time.Second
 

--- a/backend/internal/worker/agent/shell.go
+++ b/backend/internal/worker/agent/shell.go
@@ -54,43 +54,26 @@ func buildShellWrappedCommand(ctx context.Context, spec shellWrapSpec) (*exec.Cm
 	}
 	shellName := terminal.ShellBaseName(spec.Shell)
 
-	var cmdArgs []string
+	var inner, flag string
 	switch {
 	case terminal.IsPwsh(shellName):
-		inner := buildPwshCommand(spec, delimiter, metaPrefix)
-		if spec.LoginShell {
-			cmdArgs = append(terminal.LoginShellArgs(spec.Shell), "-Command", inner)
-		} else {
-			cmdArgs = []string{"-Command", inner}
-		}
-	case shellName == "tcsh" || shellName == "csh":
-		inner := buildPosixCommand(spec, delimiter, metaPrefix)
-		if spec.LoginShell {
-			cmdArgs = []string{"-ic", inner} // tcsh: -l must be the only flag
-		} else {
-			cmdArgs = []string{"-c", inner}
-		}
+		inner = buildPwshCommand(spec, delimiter, metaPrefix)
+		flag = "-Command"
 	case shellName == "nu":
-		inner := buildNuCommand(spec, delimiter, metaPrefix)
-		if spec.LoginShell {
-			cmdArgs = append(terminal.LoginShellArgs(spec.Shell), "-c", inner)
-		} else {
-			cmdArgs = []string{"-c", inner}
-		}
+		inner = buildNuCommand(spec, delimiter, metaPrefix)
+		flag = "-c"
 	default:
-		// bash, zsh, fish, sh, ash, dash, ksh, xonsh, and unknown shells
-		inner := buildPosixCommand(spec, delimiter, metaPrefix)
-		if spec.LoginShell {
-			cmdArgs = append(terminal.LoginShellArgs(spec.Shell), "-c", inner)
-		} else {
-			cmdArgs = []string{"-c", inner}
-		}
+		// bash, zsh, fish, sh, ash, dash, ksh, xonsh, tcsh/csh, and unknown shells
+		inner = buildPosixCommand(spec, delimiter, metaPrefix)
+		flag = "-c"
 	}
+	cmdArgs := terminal.CommandArgs(spec.Shell, spec.LoginShell, flag, inner)
 
 	cmd := exec.CommandContext(ctx, spec.Shell, cmdArgs...)
 	cmd.Dir = spec.WorkingDir
 	envutil.ScrubAppImageEnv(cmd)
 	procutil.HideConsoleWindow(cmd)
+	procutil.DetachFromTerminal(cmd)
 	return cmd, delimiter, metaPrefix
 }
 

--- a/backend/internal/worker/agent/shell_detach_unix_test.go
+++ b/backend/internal/worker/agent/shell_detach_unix_test.go
@@ -1,0 +1,92 @@
+//go:build unix
+
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+func TestBuildShellWrappedCommandStartsANewSession(t *testing.T) {
+	for _, loginShell := range []bool{true, false} {
+		t.Run("loginShell="+strconv.FormatBool(loginShell), func(t *testing.T) {
+			cmd, _, _ := buildShellWrappedCommand(context.Background(), shellWrapSpec{
+				Shell:      "/bin/bash",
+				LoginShell: loginShell,
+				BinaryName: "claude",
+				WorkingDir: t.TempDir(),
+			})
+			require.NotNil(t, cmd.SysProcAttr, "LoginShell=%v: SysProcAttr must be set", loginShell)
+			assert.True(t, cmd.SysProcAttr.Setsid, "LoginShell=%v: child must start in a new session", loginShell)
+		})
+	}
+}
+
+func TestBuildShellWrappedCommandTcshLoginUsesIc(t *testing.T) {
+	cmd, _, _ := buildShellWrappedCommand(context.Background(), shellWrapSpec{
+		Shell:      "/bin/tcsh",
+		LoginShell: true,
+		BinaryName: "claude",
+		WorkingDir: t.TempDir(),
+	})
+	require.GreaterOrEqual(t, len(cmd.Args), 2)
+	assert.Equal(t, "-ic", cmd.Args[1], "tcsh rejects -l combined with -c")
+}
+
+func TestProbeBinaryRunsTheShellInItsOwnSession(t *testing.T) {
+	for _, loginShell := range []bool{true, false} {
+		t.Run("loginShell="+strconv.FormatBool(loginShell), func(t *testing.T) {
+			stub, sidFile := writeSessionRecordingStub(t)
+			t.Setenv("LEAPMUX_SID_FILE", sidFile)
+
+			available, conclusive := probeBinary(context.Background(), stub, loginShell, "claude")
+			require.True(t, conclusive, "stub shell must run to completion")
+			assert.True(t, available, "stub prints the present marker, so the probe treats the binary as present")
+
+			raw, err := os.ReadFile(sidFile)
+			require.NoError(t, err, "stub must record its session id")
+			childSid, err := strconv.Atoi(strings.TrimSpace(string(raw)))
+			require.NoError(t, err, "stub session id must be an integer")
+
+			parentSid, err := unix.Getsid(0)
+			require.NoError(t, err)
+			assert.NotEqual(t, parentSid, childSid,
+				"probe shell must run in its own session, not the worker's")
+		})
+	}
+}
+
+// writeSessionRecordingStub writes an executable stub that records its
+// own session id to $LEAPMUX_SID_FILE and exits 0, ignoring argv.
+// probeBinary passes -i -l -c …; this stub is the process exec starts,
+// so a missing Setsid still fails the session assertion.
+//
+// syscall.Getsid is not in the Linux syscall package, and GOOS=linux
+// go vet typechecks this file, so the stub reads /proc/self/stat (Linux)
+// or `ps -o sess=` (BSD/Darwin) instead of importing Getsid.
+func writeSessionRecordingStub(t *testing.T) (bin, sidFile string) {
+	t.Helper()
+	dir := t.TempDir()
+	sidFile = filepath.Join(dir, "sid")
+	bin = filepath.Join(dir, "shell")
+	script := `#!/bin/sh
+if [ -r /proc/self/stat ]; then
+	sid=$(sed 's/.*) //' /proc/self/stat | awk '{print $4}')
+else
+	sid=$(ps -p $$ -o sess=)
+fi
+printf '%s\n' "$sid" > "$LEAPMUX_SID_FILE"
+printf '%s\n' '` + probeReachedPresent + `'
+exit 0
+`
+	require.NoError(t, os.WriteFile(bin, []byte(script), 0o755))
+	return bin, sidFile
+}

--- a/backend/internal/worker/service/closed_tab_test.go
+++ b/backend/internal/worker/service/closed_tab_test.go
@@ -714,6 +714,26 @@ func TestShutdown_BroadcastsDisconnectNoticeToLiveWatchers(t *testing.T) {
 		"Shutdown must broadcast the disconnect notice to live watchers, not only persist it")
 }
 
+func TestShutdown_StopsRunningAgents(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc, _, _ := setupTestService(t)
+	_, err := svc.Agents.MockStartAgent(ctx, agent.Options{
+		AgentID:    "agent-1",
+		Options:    map[string]string{agent.OptionIDModel: "opus"},
+		WorkingDir: t.TempDir(),
+	}, svc.Output.NewSink("agent-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE))
+	require.NoError(t, err)
+	require.True(t, svc.Agents.HasAgent("agent-1"))
+
+	svc.Shutdown()
+
+	testutil.AssertEventually(t, func() bool {
+		return !svc.Agents.HasAgent("agent-1")
+	}, "Shutdown must StopAll agents; Setsid children do not die with the worker process group")
+}
+
 // TestShutdown_BroadcastsDisconnectNoticeBeforeDraining pins the ORDER, which
 // is the half that actually decides whether the user sees the notice.
 //

--- a/backend/internal/worker/service/service.go
+++ b/backend/internal/worker/service/service.go
@@ -644,6 +644,15 @@ func (svc *Service) Shutdown() {
 	// dispatcher goroutine while the worker receives a deregister/SIGTERM.
 	svc.Cleanup.Wait()
 
+	// Setsid (DetachFromTerminal, go-pty) takes agent CLIs out of the
+	// worker's process group. Ctrl+C and SIGHUP therefore no longer
+	// reap them. Stop them here, after startups have finished, while
+	// Output.SetShuttingDown already latched so background-task rows
+	// stay ACTIVE for the next boot.
+	if svc.Agents != nil {
+		svc.Agents.StopAll()
+	}
+
 	// Stop the tunnel idle reaper goroutine. The worker process is exiting, so
 	// correctness does not depend on it, but stopping it keeps the goroutine
 	// count tidy for an orderly shutdown and for tests that call Shutdown.

--- a/backend/internal/worker/terminal/login_shell.go
+++ b/backend/internal/worker/terminal/login_shell.go
@@ -34,7 +34,12 @@ func ShellBaseName(p string) string {
 
 // LoginShellArgs returns the flags needed to start the given shell as an
 // interactive login shell (no -c command). The returned slice is safe to
-// append to.
+// append to. The PTY path in Start uses this list; go-pty sets Setsid.
+//
+// A caller that runs a command string through a plain exec.Cmd (no pty)
+// must use CommandArgs and procutil.DetachFromTerminal. An interactive
+// shell otherwise inherits the parent's process group and controlling
+// terminal, and bash job control then sends SIGTTIN to that whole group.
 //
 //   - pwsh/pwsh-preview:        ["-Login"]  — PowerShell Core 6+
 //   - powershell(-preview):     nil  — Windows PowerShell 5.1 has no -Login
@@ -62,4 +67,21 @@ func LoginShellArgs(shellPath string) []string {
 	default:
 		return []string{"-i", "-l"}
 	}
+}
+
+// CommandArgs is the argv after the shell path for one command string.
+// loginShell adds LoginShellArgs, except tcsh/csh login which uses -ic
+// because tcsh rejects -l combined with any other flag.
+//
+// A caller that starts this argv through a plain exec.Cmd (no pty) must
+// call procutil.DetachFromTerminal on that command.
+func CommandArgs(shellPath string, loginShell bool, commandFlag, command string) []string {
+	name := ShellBaseName(shellPath)
+	if loginShell && (name == "tcsh" || name == "csh") {
+		return []string{"-ic", command}
+	}
+	if loginShell {
+		return append(LoginShellArgs(shellPath), commandFlag, command)
+	}
+	return []string{commandFlag, command}
 }

--- a/backend/internal/worker/terminal/login_shell_test.go
+++ b/backend/internal/worker/terminal/login_shell_test.go
@@ -59,6 +59,23 @@ func TestLoginShellArgs_WindowsPowerShellNoLogin(t *testing.T) {
 	assert.Equal(t, []string{"-Login"}, LoginShellArgs("pwsh"))
 }
 
+func TestCommandArgs(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, []string{"-i", "-l", "-c", "command -v claude"},
+		CommandArgs("/bin/bash", true, "-c", "command -v claude"))
+	assert.Equal(t, []string{"-c", "command -v claude"},
+		CommandArgs("/bin/bash", false, "-c", "command -v claude"))
+	assert.Equal(t, []string{"-ic", "which claude >& /dev/null"},
+		CommandArgs("/bin/tcsh", true, "-c", "which claude >& /dev/null"))
+	assert.Equal(t, []string{"-c", "which claude >& /dev/null"},
+		CommandArgs("/bin/tcsh", false, "-c", "which claude >& /dev/null"))
+	assert.Equal(t, []string{"-ic", "inner"},
+		CommandArgs("/bin/csh", true, "-c", "inner"))
+	assert.Equal(t, []string{"-Login", "-Command", "inner"},
+		CommandArgs("/usr/bin/pwsh", true, "-Command", "inner"))
+}
+
 func TestIsPwsh(t *testing.T) {
 	t.Parallel()
 

--- a/backend/util/procutil/procutil_other.go
+++ b/backend/util/procutil/procutil_other.go
@@ -18,6 +18,35 @@ const sighupGrace = 200 * time.Millisecond
 // no-op on Unix.
 func HideConsoleWindow(*exec.Cmd) {}
 
+// DetachFromTerminal starts the child in a new session (Setsid).
+// An interactive login shell (bash -i -l) otherwise inherits the
+// parent's process group and controlling terminal. Concurrent probes
+// then share that group: one calls tcsetpgrp, the next calls
+// kill(0, SIGTTIN), and the signal stops every process in the group,
+// including leapmux solo. A new session has no controlling terminal
+// and its own process group, so kill(0) cannot reach the parent.
+// /dev/tty in the child fails with ENXIO; that is the cost of the
+// detach. LeapMux elevation is the hub privilege prompt, not sudo,
+// ssh, or a tty askpass. Agent tools that need a controlling
+// terminal must use non-interactive auth, or they fail.
+//
+// The function merges into an existing SysProcAttr. It allocates a new
+// SysProcAttr only when cmd.SysProcAttr is nil. It clears Setpgid,
+// Pgid, Noctty, Foreground, and Setctty: Go's fork+exec runs setsid
+// first, then setpgid and TIOCNOTTY, and those fail with EPERM/ENOTTY
+// on a session leader so cmd.Start never runs.
+func DetachFromTerminal(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setsid = true
+	cmd.SysProcAttr.Setpgid = false
+	cmd.SysProcAttr.Pgid = 0
+	cmd.SysProcAttr.Noctty = false
+	cmd.SysProcAttr.Foreground = false
+	cmd.SysProcAttr.Setctty = false
+}
+
 // JobObject is a process-tree kill group. On Unix it wraps a process group
 // leader PID: Terminate sends SIGHUP (letting an interactive shell propagate
 // to its jobs), waits briefly, then SIGKILLs the group. Methods are safe on
@@ -26,11 +55,12 @@ type JobObject struct {
 	pgid atomic.Int32 // 0 once Terminate/Close has consumed it
 }
 
-// AssignCmd is a no-op on Unix. Callers that need tree-kill semantics for an
-// arbitrary child process should start it with Setpgid and use AssignPID.
-// Retained as a no-op so agent startup paths keep the pre-existing Unix
-// behavior of relying on SIGTERM propagation.
-func AssignCmd(*exec.Cmd) (*JobObject, error) { return nil, nil }
+// AssignCmd records cmd.Process as a process-group leader to tear down
+// on Terminate/Close. The child must already be a group leader (Setsid
+// or Setpgid). DetachFromTerminal provides that for no-pty login shells.
+func AssignCmd(cmd *exec.Cmd) (*JobObject, error) {
+	return AssignPID(cmd.Process.Pid)
+}
 
 // AssignPID records pid as the leader of a process group to be torn down on
 // Terminate/Close. The caller is responsible for ensuring pid was started
@@ -57,7 +87,9 @@ func (j *JobObject) Terminate() error {
 	}
 	_ = syscall.Kill(-int(pgid), syscall.SIGHUP)
 	time.Sleep(sighupGrace)
-	if err := syscall.Kill(-int(pgid), syscall.SIGKILL); err != nil && err != syscall.ESRCH {
+	// Darwin returns EPERM for kill(-pgid) after the group has exited,
+	// not ESRCH. The group is gone either way.
+	if err := syscall.Kill(-int(pgid), syscall.SIGKILL); err != nil && err != syscall.ESRCH && err != syscall.EPERM {
 		return err
 	}
 	return nil
@@ -67,4 +99,14 @@ func (j *JobObject) Terminate() error {
 // handle to release. Safe on nil receiver; idempotent.
 func (j *JobObject) Close() error {
 	return j.Terminate()
+}
+
+// SignalProcessGroup sends sig to the child's process group. The child
+// must be a group leader (Setsid or Setpgid). A nil cmd or Process is
+// a no-op.
+func SignalProcessGroup(cmd *exec.Cmd, sig syscall.Signal) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	return syscall.Kill(-cmd.Process.Pid, sig)
 }

--- a/backend/util/procutil/procutil_other_test.go
+++ b/backend/util/procutil/procutil_other_test.go
@@ -1,0 +1,64 @@
+//go:build !windows
+
+package procutil
+
+import (
+	"os/exec"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetachFromTerminalSetsSetsid(t *testing.T) {
+	cmd := exec.Command("true")
+	DetachFromTerminal(cmd)
+	require.NotNil(t, cmd.SysProcAttr)
+	assert.True(t, cmd.SysProcAttr.Setsid)
+}
+
+func TestDetachFromTerminalClearsSetpgidAndNoctty(t *testing.T) {
+	cmd := exec.Command("true")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true, Noctty: true, Pgid: 1, Foreground: true}
+	DetachFromTerminal(cmd)
+	require.NotNil(t, cmd.SysProcAttr)
+	assert.True(t, cmd.SysProcAttr.Setsid)
+	assert.False(t, cmd.SysProcAttr.Setpgid, "Setpgid after setsid is EPERM")
+	assert.False(t, cmd.SysProcAttr.Noctty, "Noctty after setsid is ENOTTY")
+	assert.False(t, cmd.SysProcAttr.Foreground)
+	assert.Equal(t, 0, cmd.SysProcAttr.Pgid)
+}
+
+func TestDetachFromTerminalIsIdempotent(t *testing.T) {
+	cmd := exec.Command("true")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true, Setpgid: true}
+	DetachFromTerminal(cmd)
+	require.NotNil(t, cmd.SysProcAttr)
+	assert.True(t, cmd.SysProcAttr.Setsid)
+	assert.False(t, cmd.SysProcAttr.Setpgid)
+}
+
+func TestDetachFromTerminalStartSucceedsAfterSetpgidWasSet(t *testing.T) {
+	cmd := exec.Command("true")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true, Noctty: true}
+	DetachFromTerminal(cmd)
+	require.NoError(t, cmd.Run(), "Setsid must not combine with Setpgid/Noctty at Start")
+}
+
+func TestAssignCmdRecordsThePidAsPgid(t *testing.T) {
+	cmd := exec.Command("sleep", "30")
+	DetachFromTerminal(cmd)
+	require.NoError(t, cmd.Start())
+	job, err := AssignCmd(cmd)
+	require.NoError(t, err)
+	require.NotNil(t, job)
+	require.NoError(t, job.Terminate())
+	err = cmd.Wait()
+	require.Error(t, err, "Terminate must kill the Setsid child")
+}
+
+func TestSignalProcessGroupIsNoopOnNilProcess(t *testing.T) {
+	require.NoError(t, SignalProcessGroup(nil, syscall.SIGTERM))
+	require.NoError(t, SignalProcessGroup(exec.Command("true"), syscall.SIGTERM))
+}

--- a/backend/util/procutil/procutil_windows.go
+++ b/backend/util/procutil/procutil_windows.go
@@ -29,6 +29,10 @@ func HideConsoleWindow(cmd *exec.Cmd) {
 	cmd.SysProcAttr.CreationFlags |= createNoWindow
 }
 
+// DetachFromTerminal is a no-op on Windows. Windows has no POSIX
+// controlling terminal and no job-control signalling (SIGTTIN).
+func DetachFromTerminal(*exec.Cmd) {}
+
 // JobObject wraps a Win32 job object configured with
 // JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE. Assigning a process to the job puts
 // the process and its descendants under a single kill group: closing the
@@ -126,4 +130,13 @@ func (j *JobObject) Close() error {
 		return nil
 	}
 	return windows.CloseHandle(windows.Handle(raw))
+}
+
+// SignalProcessGroup signals the child process. Windows has no POSIX
+// process-group kill; the job object attached after Start reaps descendants.
+func SignalProcessGroup(cmd *exec.Cmd, sig syscall.Signal) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	return cmd.Process.Signal(sig)
 }

--- a/backend/util/procutil/procutil_windows_test.go
+++ b/backend/util/procutil/procutil_windows_test.go
@@ -1,0 +1,34 @@
+//go:build windows
+
+package procutil
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetachFromTerminalDoesNotClearHideConsoleWindow(t *testing.T) {
+	cmd := exec.Command("true")
+	HideConsoleWindow(cmd)
+	require.NotNil(t, cmd.SysProcAttr)
+	require.True(t, cmd.SysProcAttr.HideWindow)
+
+	DetachFromTerminal(cmd)
+	require.NotNil(t, cmd.SysProcAttr)
+	assert.True(t, cmd.SysProcAttr.HideWindow,
+		"DetachFromTerminal must not replace SysProcAttr on Windows")
+}
+
+func TestDetachFromTerminalDoesNotAllocateSysProcAttr(t *testing.T) {
+	cmd := exec.Command("true")
+	DetachFromTerminal(cmd)
+	assert.Nil(t, cmd.SysProcAttr, "the Windows no-op must not allocate SysProcAttr")
+}
+
+func TestSignalProcessGroupIsNoopOnNilProcess(t *testing.T) {
+	require.NoError(t, SignalProcessGroup(nil, 0))
+	require.NoError(t, SignalProcessGroup(exec.Command("true"), 0))
+}

--- a/frontend/src/components/common/ElevationPromptHost.test.tsx
+++ b/frontend/src/components/common/ElevationPromptHost.test.tsx
@@ -1,7 +1,6 @@
 import type { Component } from 'solid-js'
 import { readFileSync } from 'node:fs'
-import { dirname, join, relative, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 import { Code, ConnectError } from '@connectrpc/connect'
 import { createMemoryHistory, MemoryRouter, Route } from '@solidjs/router'
 import { fireEvent, render, screen, within } from '@solidjs/testing-library'
@@ -12,7 +11,7 @@ import { elevationInterceptor } from '~/api/transport'
 import { Dialog } from '~/components/common/Dialog'
 import { ElevationPromptHost } from '~/components/common/ElevationPromptHost'
 import { elevationPrompting, promptForElevation, setElevationPrompter } from '~/lib/elevationPrompt'
-import { collectFiles } from '~/test-support/sourceTree'
+import { collectFiles, frontendRoot, posixRelative } from '~/test-support/sourceTree'
 
 // The account most of these tests run as: it holds a password, so the form
 // offers exactly one factor and the dialog is about the PROMPT rather than
@@ -428,7 +427,6 @@ describe('elevationPromptHost', () => {
   // mount, and such comments are exactly what the design needs: the surfaces
   // that stopped managing the modal stack say where that work went.
   it('mounts once, at the app root', () => {
-    const frontendRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', '..')
     const srcRoot = join(frontendRoot, 'src')
     const MOUNTS = /from\s+'[^']*\/ElevationPromptHost'|<ElevationPromptHost[\s/>]/
     const mounts = collectFiles(srcRoot, {
@@ -436,7 +434,7 @@ describe('elevationPromptHost', () => {
       alsoSkip: new Set(['generated']),
     })
       .filter(file => MOUNTS.test(readFileSync(file, 'utf-8')))
-      .map(file => relative(frontendRoot, file))
+      .map(file => posixRelative(frontendRoot, file))
       .sort()
 
     expect(

--- a/frontend/src/components/shell/UserMenuState.test.tsx
+++ b/frontend/src/components/shell/UserMenuState.test.tsx
@@ -1,12 +1,11 @@
 import type { LocationChange } from '@solidjs/router'
 import { readFileSync } from 'node:fs'
-import { dirname, join, relative, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 import { createMemoryHistory, MemoryRouter, Route } from '@solidjs/router'
 import { cleanup, render, waitFor } from '@solidjs/testing-library'
 import { afterEach, describe, expect, it } from 'vitest'
 import { DEFAULT_NAV_GROUP_ID } from '~/components/settings/navGroups'
-import { collectFiles } from '~/test-support/sourceTree'
+import { collectFiles, frontendRoot, posixRelative } from '~/test-support/sourceTree'
 import { closePreferences, openPreferences, PreferencesAddress, showPreferencesDialog } from './UserMenuState'
 
 /**
@@ -190,7 +189,6 @@ describe('preferences address', () => {
  * `ElevationPromptHost.test.tsx`, which pins the sibling registration.
  */
 describe('preferencesAddress mounting', () => {
-  const frontendRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', '..')
   const srcRoot = join(frontendRoot, 'src')
   // A JSX MOUNT, never the bare name: this module defines the component and
   // several files carry prose about it, and neither is a mount.
@@ -202,7 +200,7 @@ describe('preferencesAddress mounting', () => {
       alsoSkip: new Set(['generated']),
     })
       .filter(file => MOUNT.test(readFileSync(file, 'utf-8')))
-      .map(file => relative(frontendRoot, file))
+      .map(file => posixRelative(frontendRoot, file))
       .sort()
 
     expect(

--- a/frontend/src/test-support/chatRowReads.test.ts
+++ b/frontend/src/test-support/chatRowReads.test.ts
@@ -1,8 +1,7 @@
 import { readFileSync } from 'node:fs'
-import { dirname, relative, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import { collectE2EFiles } from '~/test-support/e2eFiles'
+import { frontendRoot, posixRelative } from '~/test-support/sourceTree'
 
 // E2E guard: read a chat row through `readAttached`, never through a bare
 // `locator.evaluate` / `locator.evaluateAll`.
@@ -52,8 +51,6 @@ const CHAT_LOCATOR_MARKERS = [
 
 /** The two-round-trip reads, as they appear after a receiver. */
 const RACY_READ = String.raw`\.\s*evaluate(?:All)?\s*\(`
-
-const frontendRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
 
 /** `const name = <expression>`, the only binding form the specs use for a locator. */
 const BINDING = /(?:const|let)\s+(\w+)\s*=\s*([^\n]*)/g
@@ -112,7 +109,7 @@ describe('e2e chat row reads', () => {
       const source = readFileSync(file, 'utf-8')
       for (const { index, text } of racyChatReads(source)) {
         const line = source.slice(0, index).split('\n').length
-        offenders.add(`${relative(frontendRoot, file)}:${line}  ${text}`)
+        offenders.add(`${posixRelative(frontendRoot, file)}:${line}  ${text}`)
       }
     }
     const hint = [

--- a/frontend/src/test-support/codeSurfacesArePaired.test.ts
+++ b/frontend/src/test-support/codeSurfacesArePaired.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs'
-import { dirname, join, relative, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
+import { frontendRoot, posixRelative } from '~/test-support/sourceTree'
 import { collectStyleFiles } from '~/test-support/styleFiles'
 
 // A highlighted surface is themed by TWO rules that must land on the same
@@ -24,7 +24,7 @@ import { collectStyleFiles } from '~/test-support/styleFiles'
 // directly could still pair them by hand on two different selectors, which a
 // text scan of a FILE cannot see.
 
-const srcRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const srcRoot = join(frontendRoot, 'src')
 /** Publishes `--code-*` from the resolved syntax variant. */
 const PUBLISHER = join(srcRoot, 'styles', 'global.css.ts')
 
@@ -44,7 +44,7 @@ describe('code surfaces are paired with their token colours', () => {
         continue
       const source = readFileSync(file, 'utf8')
       if (source.includes('codeSurfaceTheme(') || source.includes('shikiDualThemeColors('))
-        direct.push(relative(srcRoot, file))
+        direct.push(posixRelative(srcRoot, file))
     }
     expect(direct, `these call a code-surface primitive directly; use codeSurface() so the selectors cannot separate:\n  ${direct.join('\n  ')}`)
       .toEqual([])

--- a/frontend/src/test-support/e2eFiles.ts
+++ b/frontend/src/test-support/e2eFiles.ts
@@ -1,8 +1,5 @@
-import { dirname, join, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
-import { collectFiles } from '~/test-support/sourceTree'
-
-const frontendRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
+import { join } from 'node:path'
+import { collectFiles, frontendRoot } from '~/test-support/sourceTree'
 
 /** The one sanctioned home for tests outside `src/`. */
 export const e2eRoot = join(frontendRoot, 'tests', 'e2e')

--- a/frontend/src/test-support/focusRingsAreFocusVisible.test.ts
+++ b/frontend/src/test-support/focusRingsAreFocusVisible.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs'
-import { dirname, relative, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
+import { frontendRoot, posixRelative } from '~/test-support/sourceTree'
 import { collectStyleFiles } from '~/test-support/styleFiles'
 
 // A focus ring is drawn from `:focus-visible`, never from `:focus`.
@@ -27,7 +27,7 @@ import { collectStyleFiles } from '~/test-support/styleFiles'
 // guard can be absolute rather than carry an allowlist that a reader has to
 // argue with.
 
-const srcRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const srcRoot = join(frontendRoot, 'src')
 
 /**
  * A style-object key that selects `:focus` but not `:focus-visible` or
@@ -78,7 +78,7 @@ describe('focus rings are drawn from :focus-visible', () => {
         if (drawn.length === 0)
           continue
         offenders.push(
-          `${relative(srcRoot, file)} ${enclosingStyle(source, key.index)} `
+          `${posixRelative(srcRoot, file)} ${enclosingStyle(source, key.index)} `
           + `'${key[2]}' draws ${drawn.map(d => d[1]).join(', ')}`,
         )
       }

--- a/frontend/src/test-support/noControlBytesInSource.test.ts
+++ b/frontend/src/test-support/noControlBytesInSource.test.ts
@@ -1,8 +1,7 @@
 import { readFileSync } from 'node:fs'
-import { dirname, join, relative, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { collectFiles } from '~/test-support/sourceTree'
+import { collectFiles, frontendRoot, posixRelative } from '~/test-support/sourceTree'
 
 // Repo hygiene guard: a NUL byte (0x00) anywhere in a tracked source file makes
 // Git classify that file as BINARY. Once it does, `git diff` and `git show`
@@ -21,7 +20,6 @@ import { collectFiles } from '~/test-support/sourceTree'
 // `noMirroredUnitTests.test.ts` is: it runs in CI on every change with no extra
 // tooling, and it fails loudly with the offending path and byte offset.
 
-const frontendRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
 const SOURCE_ROOTS = ['src', 'tests']
 const SOURCE_FILE = /\.(?:ts|tsx|js|jsx|css|json|md)$/
 
@@ -43,7 +41,7 @@ describe('source hygiene', () => {
     for (const file of collectSourceFiles()) {
       const offset = readFileSync(file).indexOf(0x00)
       if (offset !== -1)
-        offenders.push({ path: relative(frontendRoot, file), offset })
+        offenders.push({ path: posixRelative(frontendRoot, file), offset })
     }
 
     const detail = offenders.map(o => `${o.path} (byte ${o.offset})`).join('\n  ')

--- a/frontend/src/test-support/noDuplicateModuleMocks.test.ts
+++ b/frontend/src/test-support/noDuplicateModuleMocks.test.ts
@@ -1,9 +1,8 @@
 import { readFileSync } from 'node:fs'
-import { dirname, join, relative, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { lineNumberAt, stripCommentLines } from '~/test-support/sourceScan'
-import { collectFiles } from '~/test-support/sourceTree'
+import { collectFiles, frontendRoot, posixRelative } from '~/test-support/sourceTree'
 
 // Unit-test guard: each test file registers a mocked path one time only.
 //
@@ -25,7 +24,6 @@ import { collectFiles } from '~/test-support/sourceTree'
 // `vi.fn` at describe scope, give it to the single factory, and let each test
 // call `mockImplementation` on it. `src/entry-client.test.ts` shows the shape.
 
-const frontendRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
 const srcRoot = join(frontendRoot, 'src')
 
 /**
@@ -99,7 +97,7 @@ describe('unit-test module mocks', () => {
     const offenders: string[] = []
     for (const file of collectSrcTestFiles()) {
       for (const { path, lines } of findDuplicateMocks(readFileSync(file, 'utf-8')))
-        offenders.push(`${relative(frontendRoot, file)}:${lines.join(',')}  registers "${path}" ${lines.length} times`)
+        offenders.push(`${posixRelative(frontendRoot, file)}:${lines.join(',')}  registers "${path}" ${lines.length} times`)
     }
     const hint = [
       'Two queued registrations of one path have no defined winner: vitest resolves the queued',

--- a/frontend/src/test-support/noImportCycles.test.ts
+++ b/frontend/src/test-support/noImportCycles.test.ts
@@ -1,8 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs'
-import { dirname, join, relative, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { dirname, join, resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { collectFiles } from '~/test-support/sourceTree'
+import { collectFiles, frontendRoot, posixRelative } from '~/test-support/sourceTree'
 
 // Module-graph guard: no import cycle in `src/`.
 //
@@ -33,7 +32,6 @@ import { collectFiles } from '~/test-support/sourceTree'
 // so it cannot capture an unassigned binding, and counting it would flag every
 // lazily loaded route.
 
-const frontendRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
 const srcRoot = join(frontendRoot, 'src')
 
 /**
@@ -129,15 +127,17 @@ function importsOf(file: string): string[] {
       continue
     const resolved = resolveSpecifier(match[2], file)
     if (resolved)
-      targets.add(relative(frontendRoot, resolved))
+      targets.add(posixRelative(frontendRoot, resolved))
   }
   for (const match of text.matchAll(BARE_IMPORT)) {
     const resolved = resolveSpecifier(match[1], file)
     if (resolved)
-      targets.add(relative(frontendRoot, resolved))
+      targets.add(posixRelative(frontendRoot, resolved))
   }
   return [...targets].sort()
 }
+
+let graphCache: Map<string, string[]> | undefined
 
 /**
  * The import graph over the hand-written modules of `src/`, keyed by
@@ -147,6 +147,8 @@ function importsOf(file: string): string[] {
  * can never sit on a cycle that the bundler evaluates.
  */
 function buildGraph(): Map<string, string[]> {
+  if (graphCache !== undefined)
+    return graphCache
   const files = collectFiles(srcRoot, {
     matches: name =>
       SOURCE_EXTENSIONS.some(extension => name.endsWith(extension))
@@ -156,7 +158,8 @@ function buildGraph(): Map<string, string[]> {
   })
   const graph = new Map<string, string[]>()
   for (const file of files)
-    graph.set(relative(frontendRoot, file), importsOf(file))
+    graph.set(posixRelative(frontendRoot, file), importsOf(file))
+  graphCache = graph
   return graph
 }
 
@@ -211,6 +214,10 @@ function findCycles(graph: Map<string, string[]>): string[][] {
 }
 
 describe('module graph', () => {
+  it('reuses one graph across cases', () => {
+    expect(buildGraph()).toBe(buildGraph())
+  })
+
   it('has no import cycle in src/', () => {
     const cycles = findCycles(buildGraph())
     expect(

--- a/frontend/src/test-support/noMangledTestTitles.test.ts
+++ b/frontend/src/test-support/noMangledTestTitles.test.ts
@@ -1,8 +1,8 @@
 import { readFileSync } from 'node:fs'
-import { dirname, join, relative, resolve } from 'node:path'
+import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
-import { collectFiles } from '~/test-support/sourceTree'
+import { collectFiles, frontendRoot, posixRelative } from '~/test-support/sourceTree'
 
 // Test-name guard: `test/prefer-lowercase-title` (from the antfu ESLint config)
 // rejects a suite or case title that starts with a capital, and its `--fix`
@@ -28,7 +28,6 @@ import { collectFiles } from '~/test-support/sourceTree'
 // runs in the `bun run test` everyone already runs, it needs no plugin
 // scaffolding, and it reports every offender in one message.
 
-const frontendRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
 const SOURCE_ROOTS = ['src', 'tests']
 const TEST_FILE = /\.(?:test|spec)\.(?:ts|tsx)$/
 
@@ -204,7 +203,7 @@ describe('test-title casing', () => {
   it('has no title that the lint autofix mangled, under src/ or tests/', () => {
     const offenders: MangledTitle[] = []
     for (const file of collectTestFiles())
-      offenders.push(...findMangledTitles(readFileSync(file, 'utf8'), relative(frontendRoot, file)))
+      offenders.push(...findMangledTitles(readFileSync(file, 'utf8'), posixRelative(frontendRoot, file)))
 
     const detail = offenders.map(o => `${o.path}:${o.line}  ${JSON.stringify(o.title)}`).join('\n  ')
     expect(
@@ -215,7 +214,7 @@ describe('test-title casing', () => {
       + 'do not suppress the lint rule. Lead with a lowercase phrase and write the name in full after '
       + 'it, per the vitest rule in CLAUDE.md: '
       + '`describe(\'default mono font stack (DEFAULT_MONO_FONT_FAMILY)\')`. If the first word is a '
-      + `genuinely camelCase identifier, add it to CAMEL_CASE_IDENTIFIERS in ${relative(frontendRoot, fileURLToPath(import.meta.url))} `
+      + `genuinely camelCase identifier, add it to CAMEL_CASE_IDENTIFIERS in ${posixRelative(frontendRoot, fileURLToPath(import.meta.url))} `
       + `with the evidence:\n  ${detail}`,
     ).toEqual([])
   })

--- a/frontend/src/test-support/noMirroredUnitTests.test.ts
+++ b/frontend/src/test-support/noMirroredUnitTests.test.ts
@@ -1,8 +1,7 @@
 import { existsSync } from 'node:fs'
-import { dirname, join, relative, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { collectFiles } from '~/test-support/sourceTree'
+import { collectFiles, frontendRoot, posixRelative } from '~/test-support/sourceTree'
 
 // Repo layout guard: unit tests are co-located next to the code they test
 // (`foo.ts` -> `foo.test.ts` in the same directory). The old `tests/unit/`
@@ -19,7 +18,6 @@ import { collectFiles } from '~/test-support/sourceTree'
 // `testFileNaming.test.ts` enforces them -- a `.test.ts` there must name the
 // module beside it, so the exemption cannot become a second mirror.
 
-const frontendRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
 const testsRoot = join(frontendRoot, 'tests')
 
 const UNIT_TEST_FILE = /\.test\.(?:ts|tsx)$/
@@ -33,7 +31,7 @@ function collectStrayUnitTests(): string[] {
     // `tests/unit/e2e/`, so the retired mirror this guard exists to keep
     // out could return under one directory name.
     skipPaths: new Set(['e2e']),
-  }).map(file => relative(frontendRoot, file))
+  }).map(file => posixRelative(frontendRoot, file))
 }
 
 describe('unit-test co-location', () => {

--- a/frontend/src/test-support/noNetworkIdleWait.test.ts
+++ b/frontend/src/test-support/noNetworkIdleWait.test.ts
@@ -1,9 +1,8 @@
 import { readFileSync } from 'node:fs'
-import { dirname, relative, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import { collectE2EFiles } from '~/test-support/e2eFiles'
 import { stripCommentLines } from '~/test-support/sourceScan'
+import { frontendRoot, posixRelative } from '~/test-support/sourceTree'
 
 // E2E guard: no spec or helper may wait for `networkidle`.
 //
@@ -31,8 +30,6 @@ import { stripCommentLines } from '~/test-support/sourceScan'
 // shell's own menu trigger. Playwright documents `networkidle` as
 // discouraged for exactly this class of reason.
 
-const frontendRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
-
 /**
  * The string literal, in any quoting style. That covers
  * `waitForLoadState('networkidle')`, `waitUntil: 'networkidle'`, and any
@@ -50,7 +47,7 @@ describe('e2e load-state waits', () => {
       lines.forEach((text, index) => {
         if (!NETWORK_IDLE.test(text))
           return
-        offenders.push(`${relative(frontendRoot, file)}:${index + 1}  ${text.trim()}`)
+        offenders.push(`${posixRelative(frontendRoot, file)}:${index + 1}  ${text.trim()}`)
       })
     }
     const hint = [

--- a/frontend/src/test-support/paletteColorsAreTokens.test.ts
+++ b/frontend/src/test-support/paletteColorsAreTokens.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs'
-import { dirname, join, relative, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
+import { frontendRoot, posixRelative } from '~/test-support/sourceTree'
 import { collectStyleFiles } from '~/test-support/styleFiles'
 
 // A colour that plays a palette ROLE must read the palette, never a literal.
@@ -18,7 +18,7 @@ import { collectStyleFiles } from '~/test-support/styleFiles'
 // if a new role needs one the catalogue grows it, which is what makes every
 // variant answer for it.
 
-const srcRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const srcRoot = join(frontendRoot, 'src')
 
 /** `color`, `backgroundColor` or `borderColor` set to a bare hex literal. */
 const ROLE_COLOR_LITERAL = /(?:^|[^\w-])(color|backgroundColor|borderColor)\s*:\s*'#[0-9a-f]{3,8}'/gi
@@ -43,7 +43,7 @@ describe('palette role colours come from the palette', () => {
         continue
       const source = readFileSync(file, 'utf8')
       for (const match of source.matchAll(ROLE_COLOR_LITERAL))
-        offenders.push(`${relative(srcRoot, file)}: ${match[0].trim()}`)
+        offenders.push(`${posixRelative(srcRoot, file)}: ${match[0].trim()}`)
     }
     expect(offenders, `these hardcode a colour the palette owns; read the token instead:\n  ${offenders.join('\n  ')}`)
       .toEqual([])

--- a/frontend/src/test-support/setupGateIsSingleSource.test.ts
+++ b/frontend/src/test-support/setupGateIsSingleSource.test.ts
@@ -1,9 +1,8 @@
 import { readFileSync } from 'node:fs'
-import { dirname, join, relative, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { stripCommentLines } from '~/test-support/sourceScan'
-import { collectFiles } from '~/test-support/sourceTree'
+import { collectFiles, frontendRoot, posixRelative } from '~/test-support/sourceTree'
 
 // Routing guard: the "this hub still needs a first administrator" rule has
 // exactly ONE spelling, `SetupGate`, mounted ONCE around the router outlet.
@@ -22,7 +21,6 @@ import { collectFiles } from '~/test-support/sourceTree'
 // two answers disagree. So this file asserts both halves here, in the fast
 // suite, rather than leaves them to the E2E that boots an unseeded hub.
 
-const frontendRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
 const srcRoot = join(frontendRoot, 'src')
 
 /** The component that owns the rule, and the module that defines the getter. */
@@ -54,7 +52,7 @@ function callers(): string[] {
     skipPaths: new Set(['test-support']),
   })
     .filter(file => /\bisSetupRequired\b/.test(stripCommentLines(readFileSync(file, 'utf8'))))
-    .map(file => relative(frontendRoot, file))
+    .map(file => posixRelative(frontendRoot, file))
     .sort()
 }
 

--- a/frontend/src/test-support/sourceTree.test.ts
+++ b/frontend/src/test-support/sourceTree.test.ts
@@ -1,13 +1,12 @@
-import { dirname, join, resolve, sep } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { existsSync } from 'node:fs'
+import { isAbsolute, join, sep } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { collectFiles, SKIP_DIRS } from '~/test-support/sourceTree'
+import { collectFiles, frontendRoot, posixRelative, SKIP_DIRS } from '~/test-support/sourceTree'
 
 // Eight repo guards read their whole verdict through this walk, so a hole here
 // reads as a clean suite rather than as a failure. Pin the filter, the skip
 // set a caller cannot drop, and the absent-directory result.
 
-const frontendRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
 const testSupportRoot = join(frontendRoot, 'src', 'test-support')
 
 /** The directory names on the way to `file`, so a skip test matches no substring. */
@@ -85,5 +84,40 @@ describe('collectFiles', () => {
 
   it('returns nothing for a directory that does not exist', () => {
     expect(collectFiles(join(frontendRoot, 'no-such-directory'), { matches: () => true })).toEqual([])
+  })
+})
+
+describe('posixRelative', () => {
+  // Windows CI failed five repo guards that compared path.relative output
+  // to literals like 'src/app.tsx'. path.relative uses '\' on Windows, so
+  // the walk found the file and the strings still disagreed. This case is
+  // that comparison: join() builds a native path, and the result must be
+  // the POSIX form every allow-list and toEqual() writes.
+  it('returns a slash-separated path so Windows matches POSIX literals', () => {
+    expect(posixRelative(frontendRoot, join(frontendRoot, 'src', 'app.tsx'))).toBe('src/app.tsx')
+    expect(posixRelative(frontendRoot, join(frontendRoot, 'src', 'lib', 'systemInfo.ts')))
+      .toBe('src/lib/systemInfo.ts')
+    expect(posixRelative(
+      frontendRoot,
+      join(frontendRoot, 'src', 'components', 'chat', 'results', 'CollapsibleContent.tsx'),
+    )).toBe('src/components/chat/results/CollapsibleContent.tsx')
+  })
+
+  it('returns an empty string when from and to are the same path', () => {
+    expect(posixRelative(frontendRoot, frontendRoot)).toBe('')
+  })
+
+  it('returns a parent-relative path with slashes', () => {
+    expect(posixRelative(join(frontendRoot, 'src'), join(frontendRoot, 'tests', 'e2e')))
+      .toBe('../tests/e2e')
+  })
+})
+
+describe('frontendRoot', () => {
+  it('is the frontend package directory', () => {
+    expect(isAbsolute(frontendRoot)).toBe(true)
+    expect(existsSync(join(frontendRoot, 'package.json'))).toBe(true)
+    expect(posixRelative(frontendRoot, join(frontendRoot, 'src', 'test-support', 'sourceTree.ts')))
+      .toBe('src/test-support/sourceTree.ts')
   })
 })

--- a/frontend/src/test-support/sourceTree.ts
+++ b/frontend/src/test-support/sourceTree.ts
@@ -1,5 +1,7 @@
 import { existsSync, readdirSync } from 'node:fs'
-import { join } from 'node:path'
+import { dirname, join, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { toPosixSeparators } from '~/lib/paths'
 
 // The file walk that every repo guard scanning the source tree runs.
 //
@@ -33,6 +35,17 @@ export const SKIP_DIRS: ReadonlySet<string> = new Set([
   'test-results',
 ])
 
+/**
+ * Absolute path of the frontend package root.
+ *
+ * Repo guards compare walk results against this directory. A file under
+ * `src/test-support/` used to recompute it with `../..` from
+ * `import.meta.url`. A file under `src/components/` used `../../..`.
+ * One hop that is wrong silently drops a file from a guard. This module
+ * sits in `src/test-support/`, so the hop lives here and nowhere else.
+ */
+export const frontendRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
+
 /** The empty default for `skipPaths`: no location is exempt. */
 const NO_PATHS: ReadonlySet<string> = new Set()
 
@@ -51,6 +64,19 @@ export interface CollectFilesOptions {
    * retired unit mirror out could be defeated by one directory name.
    */
   skipPaths?: ReadonlySet<string>
+}
+
+/**
+ * `path.relative(from, to)` with `/` separators on every platform.
+ *
+ * Repo guards compare against POSIX literals (`src/app.tsx`). On Windows,
+ * `path.relative` returns backslashes, so those comparisons fail even when
+ * the walk found the right file. An allow-list keyed by slash paths never
+ * matches. `skipPaths` already uses `/`. This is that convention for a
+ * path the walk did not produce.
+ */
+export function posixRelative(from: string, to: string): string {
+  return toPosixSeparators(relative(from, to))
 }
 
 /**

--- a/frontend/src/test-support/stableContextUsage.test.ts
+++ b/frontend/src/test-support/stableContextUsage.test.ts
@@ -1,10 +1,9 @@
 import { readFileSync } from 'node:fs'
-import { dirname, join, relative, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 import { installedCopies } from '~/test-support/installedCopies'
-import { collectFiles } from '~/test-support/sourceTree'
+import { collectFiles, frontendRoot, posixRelative } from '~/test-support/sourceTree'
 
 // Guards the two rules `createStableContext` runs on, both of which were
 // documented in a comment and enforced by nothing.
@@ -25,7 +24,6 @@ import { collectFiles } from '~/test-support/sourceTree'
 // Same shape as `noMirroredUnitTests.test.ts`: a source scan, because the thing
 // being guarded is a property of the source tree rather than of any runtime.
 
-const frontendRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
 const srcRoot = join(frontendRoot, 'src')
 const helperPath = join(srcRoot, 'lib', 'createStableContext.ts')
 
@@ -42,7 +40,7 @@ describe('createStableContext usage', () => {
       // The helper is where the one legitimate `createContext` call lives.
       .filter(file => file !== helperPath)
       .filter(file => /\bcreateContext\b/.test(readFileSync(file, 'utf8')))
-      .map(file => relative(frontendRoot, file))
+      .map(file => posixRelative(frontendRoot, file))
 
     expect(
       offenders,
@@ -58,7 +56,7 @@ describe('createStableContext usage', () => {
       const source = readFileSync(file, 'utf8')
       for (const [, key] of source.matchAll(/createStableContext(?:\s*<[^>]*>)?\s*\(\s*'([^']+)'/g)) {
         const owners = byKey.get(key) ?? []
-        owners.push(relative(frontendRoot, file))
+        owners.push(posixRelative(frontendRoot, file))
         byKey.set(key, owners)
       }
     }
@@ -87,7 +85,7 @@ describe('createStableContext usage', () => {
   // starts exercising a patch ordering the dev server has stopped running --
   // silently, and still green.
   it('resolves one shared solid-refresh, not a second nested copy', () => {
-    const copies = installedCopies('solid-refresh').map(p => relative(frontendRoot, p))
+    const copies = installedCopies('solid-refresh').map(p => posixRelative(frontendRoot, p))
 
     // Zero is a different problem from two, and the bump advice does not apply
     // to it: nothing to align ranges with if the package is not there.

--- a/frontend/src/test-support/storageKeysAreRegistered.test.ts
+++ b/frontend/src/test-support/storageKeysAreRegistered.test.ts
@@ -1,12 +1,11 @@
 import { readFileSync } from 'node:fs'
-import { dirname, join, relative, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 import * as browserStorage from '~/lib/browserStorage'
 import { LOCAL_KEY_SPECS, SESSION_KEY_SPECS } from '~/lib/browserStorage'
 import { lineNumberAt, stripCommentLines } from '~/test-support/sourceScan'
-import { collectFiles } from '~/test-support/sourceTree'
+import { collectFiles, frontendRoot, posixRelative } from '~/test-support/sourceTree'
 
 // Guards the two rules `browserStorage` runs on that its types cannot reach.
 //
@@ -31,7 +30,6 @@ import { collectFiles } from '~/test-support/sourceTree'
 // Same shape as `stableContextUsage.test.ts`: a source scan, because what is
 // being guarded is a property of the source tree rather than of any runtime.
 
-const frontendRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
 const srcRoot = join(frontendRoot, 'src')
 const gatewayPath = join(srcRoot, 'lib', 'browserStorage.ts')
 
@@ -79,7 +77,7 @@ describe('browser-storage keys', () => {
       // comment line of its own. See `sourceScan.ts`.
       const source = stripCommentLines(readFileSync(file, 'utf8'))
       for (const match of source.matchAll(DIRECT_ACCESS))
-        offenders.push(`${relative(frontendRoot, file)}:${lineNumberAt(source, match.index)}`)
+        offenders.push(`${posixRelative(frontendRoot, file)}:${lineNumberAt(source, match.index)}`)
     }
 
     expect(

--- a/frontend/src/test-support/testFileNaming.test.ts
+++ b/frontend/src/test-support/testFileNaming.test.ts
@@ -1,9 +1,8 @@
 import { existsSync, readFileSync } from 'node:fs'
-import { dirname, join, relative, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { collectE2EFiles } from '~/test-support/e2eFiles'
-import { collectFiles } from '~/test-support/sourceTree'
+import { collectFiles, frontendRoot, posixRelative } from '~/test-support/sourceTree'
 import { isPlaywrightSpec, isUnitTest, siblingModulePath } from '~/test-support/testFileNaming'
 
 // Repo layout guard: the file EXTENSION decides which runner collects a test,
@@ -23,7 +22,6 @@ import { isPlaywrightSpec, isUnitTest, siblingModulePath } from '~/test-support/
 // names no module it tests (a mistyped E2E spec, which vitest now collects and
 // Playwright ignores), and a runner config that stops enforcing its half.
 
-const frontendRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
 const srcRoot = join(frontendRoot, 'src')
 
 /** Every co-located unit test under `tests/e2e/`, as an absolute path. */
@@ -34,7 +32,7 @@ function collectE2EUnitTests(): string[] {
 describe('test file naming', () => {
   it('keeps every .spec file under tests/e2e, where Playwright collects it', () => {
     const strays = collectFiles(srcRoot, { matches: isPlaywrightSpec })
-      .map(file => relative(frontendRoot, file))
+      .map(file => posixRelative(frontendRoot, file))
 
     expect(
       strays,
@@ -51,7 +49,7 @@ describe('test file naming', () => {
     // would never run it.
     const orphans = collectE2EUnitTests()
       .filter(file => !existsSync(siblingModulePath(file)))
-      .map(file => relative(frontendRoot, file))
+      .map(file => posixRelative(frontendRoot, file))
 
     expect(
       orphans,

--- a/frontend/src/test-support/visibleChatLocators.test.ts
+++ b/frontend/src/test-support/visibleChatLocators.test.ts
@@ -1,8 +1,7 @@
 import { readFileSync } from 'node:fs'
-import { dirname, join, relative, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import { collectE2EFiles, e2eRoot } from '~/test-support/e2eFiles'
+import { frontendRoot, posixRelative } from '~/test-support/sourceTree'
 
 // E2E guard: a page-rooted chat locator must be scoped to what the user can
 // SEE. ChatView keeps a hidden premeasure copy of every row whose height is
@@ -31,8 +30,6 @@ const CHAT_TEST_IDS = [
   'message-delete-button',
 ]
 
-const frontendRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..')
-
 /** `page.locator('[data-testid="<chat id>"...]')` without a `:visible` filter. */
 const UNSCOPED = new RegExp(
   `page\\s*\\.\\s*locator\\(\\s*(['\`])\\[data-testid="(?:${CHAT_TEST_IDS.join('|')})"\\][^'\`]*\\1`,
@@ -45,14 +42,14 @@ describe('e2e chat locators', () => {
     for (const file of collectE2EFiles()) {
       // ui.ts is where the scoped helpers are DEFINED, so it holds the only
       // legitimate occurrences of the raw selectors.
-      if (relative(e2eRoot, file) === join('helpers', 'ui.ts'))
+      if (posixRelative(e2eRoot, file) === 'helpers/ui.ts')
         continue
       const source = readFileSync(file, 'utf-8')
       for (const match of source.matchAll(UNSCOPED)) {
         if (match[0].includes(':visible'))
           continue
         const line = source.slice(0, match.index).split('\n').length
-        offenders.push(`${relative(frontendRoot, file)}:${line}  ${match[0]}`)
+        offenders.push(`${posixRelative(frontendRoot, file)}:${line}  ${match[0]}`)
       }
     }
     const hint = [


### PR DESCRIPTION
## Motivation
- Concurrent binary probes start an interactive login shell with a plain `exec.Cmd`. The child inherits the worker controlling terminal. The probe then moves the foreground process group and sends `SIGTTIN` to the whole group. LeapMux in solo mode stops.
- ACP `Start` sets `Setsid` and `Setpgid`. Go runs `setsid`, then `setpgid`. `setpgid` on a session leader fails with `EPERM`, so the ACP process does not start.
- `probeBinary` treats the login-shell exit status as present or absent. A profile that exits before the inner command caches a wrong answer for the worker lifetime.
- `Setsid` removes agent CLIs from the worker process group. Ctrl+C and `SIGHUP` no longer reap those children, so they keep running after worker shutdown.
- Cancel signals only the `/bin/sh` wrapper. A grandchild keeps stdout and stderr open.
- Windows refuses a replace while another handle holds the destination file. `atomicfile.WriteFile` then fails, and a credential save looks like a failure.
- Credential-rotation tests set the config directory to mode `0500`. Windows ignores a directory read-only bit for child creates, so the save succeeds and the test does not block writes.
- Frontend scan tests compare `path.relative` results to POSIX literals. On Windows the relative path uses backslashes, so allow-lists and expected paths do not match.

## Modifications
- ACP host commands, shell-wrapped agent CLIs, and binary-probe shells call `procutil.DetachFromTerminal`. On Unix this sets `Setsid`. ACP no longer sets `Setpgid`, because `setpgid` after `setsid` fails with `EPERM`. `Setsid` still makes the child a process-group leader, so later kill can reap grandchildren.
- `setupProcessPipes` and ACP `cmd.Cancel` call `procutil.SignalProcessGroup` with `SIGTERM`. Unix sends the signal to `-pid`. Windows signals the process itself.
- `probeBinary` prints `__LEAPMUX_PROBE_REACHED__present` or `__absent` from the inner command. No marker means inconclusive. The miss is not cached.
- `terminal.CommandArgs` builds the argv after the shell path for one command string. tcsh/csh login stays `-ic` because tcsh rejects `-l` with any other flag. `factory.probeBinary` and `buildShellWrappedCommand` both call it. Callers that start this through a plain `exec.Cmd` (no pty) must also call `procutil.DetachFromTerminal`:
  ```go
  cmd := exec.Command(shell, terminal.CommandArgs(shell, loginShell, commandFlag, command)...)
  procutil.DetachFromTerminal(cmd)
  ```
- `Service.Shutdown` calls `Agents.StopAll()` after `Cleanup.Wait`. `Output.SetShuttingDown` is already latched, so background-task rows stay `ACTIVE` for the next boot.
- `DetachFromTerminal` merges into an existing `SysProcAttr` and clears `Setpgid`, `Pgid`, `Noctty`, `Foreground`, and `Setctty` so fork+exec does not fail with `EPERM` or `ENOTTY`. Windows `DetachFromTerminal` is a no-op and does not allocate or replace `SysProcAttr`.
- Unix `AssignCmd` now calls `AssignPID(cmd.Process.Pid)`. A Setsid child becomes a job that `Terminate` and `Close` can tear down. Callers in this PR already match the new return. This is an in-repo API in `procutil`, not a product break.
- Darwin treats `EPERM` on `kill(-pgid, SIGKILL)` as success after `SIGHUP`, because Darwin returns `EPERM` (not `ESRCH`) when the group is already gone.
- `WriteFile` calls `replaceFile` instead of a raw `os.Rename`. Unix still renames in one step. Windows retries a sharing conflict up to 8 times with exponential backoff. Windows does not retry a directory destination or a read-only file; those return `ACCESS_DENIED` as well, and a retry cannot succeed.
- `blockCredentialSaves` uses a read-only file (mode `0400`) on Windows. Tests pin that Unix rename still replaces a `0400` file when the directory is writable, Windows leaves the old bytes, and a failed or successful replace never leaves a `.tmp` file.
- `sourceTree.ts` exports `frontendRoot` and `posixRelative`. Scan tests and `e2eFiles` use those helpers instead of local `dirname` hops. `noImportCycles.test.ts` builds the module graph once and reuses it.

## Result
- Concurrent no-pty login-shell probes no longer stop LeapMux with `SIGTTIN`.
- ACP `Start` no longer fails with `EPERM` from `Setsid` plus `Setpgid`.
- A login profile that exits early no longer caches a false binary present or absent result.
- Worker shutdown stops detached agent CLIs. You no longer leave those processes running after Ctrl+C or `SIGHUP`.
- Cancel delivers `SIGTERM` to the process group, so grandchildren do not hold stdout and stderr open.
- Windows atomic writes succeed when a short-lived exclusive handle holds the destination. A permanent Windows refusal (read-only file or directory) still fails immediately.
- Credential-rotation tests on Windows actually block saves.
- Frontend repo guards match POSIX path literals on Windows CI.
