### PR TITLE
feat(ui): Align Preferences, OAuth pages, and CLI auth with Oat UI

### DIFF
--- a/backend/internal/authscope/authscope.go
+++ b/backend/internal/authscope/authscope.go
@@ -102,6 +102,11 @@ var grantableOrder = func() []leapmuxv1.Scope {
 // Closing at enforcement instead would put the rule in every gate, including
 // the Worker's, and a gate that forgot it would refuse a grant the consent
 // screen promised.
+//
+// The frontend mirrors this table (frontend
+// src/components/settings/account/scopeCatalogue.ts) so the register form can
+// lock implied scopes before it submits; TestFrontendImpliedByMatchesTheHubGraph
+// pins the two together.
 var impliedBy = map[leapmuxv1.Scope][]leapmuxv1.Scope{
 	leapmuxv1.Scope_SCOPE_ACCOUNT_WRITE:   {leapmuxv1.Scope_SCOPE_ACCOUNT_READ},
 	leapmuxv1.Scope_SCOPE_WORKSPACE_WRITE: {leapmuxv1.Scope_SCOPE_WORKSPACE_READ},

--- a/backend/internal/authscope/implied_by_mirror_internal_test.go
+++ b/backend/internal/authscope/implied_by_mirror_internal_test.go
@@ -1,0 +1,80 @@
+package authscope
+
+import (
+	"os"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The frontend keeps its own copy of impliedBy (scopeCatalogue.ts) so the
+// register/edit form can lock the scopes a ticked one implies before it
+// submits. Nothing else pins the two together: each side's tests check only
+// its own enum, so a graph edited on one side silently disagrees with the
+// other about what a grant expands to. This test is the pin, in the same
+// shape as the OAuth pages' palette pin: a Go test reads the frontend file,
+// and a graph that drifts fails the suite until both sides match.
+
+// scopeCataloguePath is the frontend mirror, relative to this package.
+const scopeCataloguePath = "../../../frontend/src/components/settings/account/scopeCatalogue.ts"
+
+// impliedEntryPattern matches one `[Scope.NAME]: [Scope.NAME, ...],` row of
+// the frontend IMPLIED_BY table.
+var impliedEntryPattern = regexp.MustCompile(`\[Scope\.([A-Z0-9_]+)\]:\s*\[([^\]]*)\]`)
+
+func TestFrontendImpliedByMatchesTheHubGraph(t *testing.T) {
+	raw, err := os.ReadFile(scopeCataloguePath)
+	if err != nil {
+		// FAIL, not skip: the target is a git-controlled source file, so a
+		// read failure means it moved or was renamed -- exactly the drift
+		// this pin exists to catch. Skipping here would silently disable it
+		// in every checkout that runs the suite.
+		t.Fatalf("scope catalogue not reachable from this checkout: %v", err)
+	}
+	scopeByName := map[string]leapmuxv1.Scope{}
+	for _, scope := range Grantable() {
+		scopeByName[scope.String()] = scope
+	}
+
+	frontend := map[leapmuxv1.Scope]map[leapmuxv1.Scope]bool{}
+	for _, m := range impliedEntryPattern.FindAllStringSubmatch(string(raw), -1) {
+		key, ok := scopeByName["SCOPE_"+m[1]]
+		require.Truef(t, ok, "IMPLIED_BY key Scope.%s is not a grantable scope", m[1])
+		frontend[key] = map[leapmuxv1.Scope]bool{}
+		for _, part := range strings.Split(m[2], ",") {
+			name := strings.TrimPrefix(strings.TrimSpace(part), "Scope.")
+			if name == "" {
+				continue
+			}
+			target, ok := scopeByName["SCOPE_"+name]
+			require.Truef(t, ok, "IMPLIED_BY maps %s to unknown scope %s", m[1], name)
+			frontend[key][target] = true
+		}
+	}
+	require.NotEmpty(t, frontend, "no IMPLIED_BY entries parsed; scopeCatalogue.ts changed shape?")
+
+	for key, implied := range impliedBy {
+		if !assert.Containsf(t, frontend, key,
+			"the hub closes %s, but the frontend catalogue states no implications for it", key) {
+			continue
+		}
+		want := frontend[key]
+		for _, target := range implied {
+			assert.Truef(t, want[target],
+				"the hub closes %s to include %s, but the frontend form does not lock it implied", key, target)
+		}
+		for target := range want {
+			assert.Truef(t, slices.Contains(implied, target),
+				"the frontend form locks %s implied by %s, but the hub does not close it", target, key)
+		}
+	}
+	for key := range frontend {
+		assert.Containsf(t, impliedBy, key,
+			"the frontend form states implications for %s, but the hub closes nothing there", key)
+	}
+}

--- a/backend/internal/cli/control/client.go
+++ b/backend/internal/cli/control/client.go
@@ -499,6 +499,19 @@ func (c *Client) UserService() leapmuxv1connect.UserServiceClient {
 	)
 }
 
+// AuthService returns a ConnectRPC client for the session surface
+// (GetCurrentUser). `auth status` and `whoami` call it as their hub check:
+// one authenticated read settles whether the credential still opens the
+// hub, and the interceptor beneath it makes the check self-healing -- a
+// stale access token rotates on the way through, and a revoked one ends in
+// invalid_grant with the credential file already deleted.
+func (c *Client) AuthService() leapmuxv1connect.AuthServiceClient {
+	return leapmuxv1connect.NewAuthServiceClient(
+		c.HTTPClient, c.connectURL,
+		connect.WithInterceptors(c.AuthInterceptor()),
+	)
+}
+
 // AdminSettingsService returns a ConnectRPC client for the hub's
 // AdminSettingsService. Admin commands deliberately build a hub client
 // directly rather than routing through the worker-IPC bridge: the

--- a/backend/internal/cli/control/cmd/admin.go
+++ b/backend/internal/cli/control/cmd/admin.go
@@ -15,7 +15,6 @@ import (
 	"github.com/leapmux/leapmux/internal/cli/control"
 	"github.com/leapmux/leapmux/internal/hub/ratelimit"
 	"github.com/leapmux/leapmux/internal/hub/service"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // An admin call reports the hub's refusal VERBATIM, through
@@ -104,15 +103,6 @@ func validateListLimit(limit int64) error {
 	return nil
 }
 
-// putTime writes one optional timestamp into an output row, omitting the
-// field when the hub sent none.
-func putTime(row map[string]any, key string, ts *timestamppb.Timestamp) {
-	if ts == nil {
-		return
-	}
-	row[key] = ts.AsTime().UTC().Format(timeFormat)
-}
-
 // settingValueJSON renders one SettingValue for the envelope.
 func settingValueJSON(v *leapmuxv1.SettingValue) map[string]any {
 	out := map[string]any{
@@ -173,8 +163,6 @@ func settingDescriptionText(key, summary string) string {
 	}
 	return summary
 }
-
-const timeFormat = "2006-01-02T15:04:05.000Z07:00"
 
 // RunAdminSettingsList implements `control admin settings list`.
 func RunAdminSettingsList(rawCtx any, args []string) error {

--- a/backend/internal/cli/control/cmd/auth.go
+++ b/backend/internal/cli/control/cmd/auth.go
@@ -184,31 +184,69 @@ func RunAuthLogin(rawCtx any, args []string) error {
 	}
 	ctx := context.Background()
 
-	if deviceCode {
-		scope, scopeErr := requestedScope(scopeFlag)
-		if scopeErr != nil {
-			return scopeErr
-		}
-		return runDeviceCodeLogin(ctx, hub, deviceName, scope)
-	}
+	// Every input is validated BEFORE the destructive cleanup below: a
+	// refused flag must not cost the machine its working credential.
 	scope, scopeErr := requestedScope(scopeFlag)
 	if scopeErr != nil {
 		return scopeErr
+	}
+	if !deviceCode && locallisten.IsLocal(hub) {
+		// The local-redirect flow needs a browser to reach BOTH the hub (to
+		// load the consent page) and this CLI (the loopback callback). A
+		// socket hub URL gives the browser no hub origin to visit — solo
+		// deployments need no login at all, and a socket-reached multi-user
+		// hub has an http(s) origin derived from its settings. State the
+		// working alternative instead of failing mysteriously.
+		return control.EmitError("invalid_request",
+			"--hub unix:/npipe: URLs cannot use the local-redirect flow (no browser-reachable hub origin); pass --device-code to authenticate in a browser against the hub's public origin")
+	}
+
+	// A login REPLACES whatever this machine already holds for the hub: the
+	// new credential lands in the same file, and the old one would otherwise
+	// stay live at the hub with no local file left to revoke it from -- a
+	// credential the account's Connected-apps list still shows, reachable by
+	// anybody who copied it, for as long as its refresh window runs.
+	//
+	// So this CLI warns about the existing login, revokes it on the hub, and
+	// deletes it locally BEFORE the flow starts. The revoke is best-effort by
+	// the same reading as logout's: the hub may be unreachable, and proceeding
+	// with the login is the user's answer -- but this CLI states the refusal,
+	// with the place to fix it by hand, rather than silently leaving a live
+	// row. An UNREADABLE file cannot be revoked (its tokens do not parse),
+	// but it must not survive either: the file goes, and the warning
+	// identifies the grant that may still live on the hub.
+	switch creds, loadErr := control.LoadCredentials(hub); {
+	case loadErr == nil:
+		_, _ = fmt.Fprintln(control.Out, "This CLI revokes the existing login for this hub before it signs in again:")
+		_, _ = fmt.Fprintf(control.Out, "  %s on %s\n", creds.Username, creds.HubURL)
+		if revokeErr := revokeBearer(hub, creds.AccessToken, creds.ClientIDOrBuiltIn()); revokeErr != nil {
+			_, _ = fmt.Fprintln(control.Out, "  warning: this CLI could not revoke it on the hub ("+revokeErr.Error()+
+				"); "+disconnectInPreferences)
+		}
+		if delErr := control.DeleteCredentials(hub); delErr != nil {
+			return control.EmitErrorWith("delete_failed", delErr)
+		}
+	case errors.Is(loadErr, control.ErrNotLoggedIn):
+		// No credential file: nothing to clean up.
+	default:
+		_, _ = fmt.Fprintln(control.Out, "The existing credential file for this hub does not parse ("+loadErr.Error()+
+			"); this CLI deletes it and cannot revoke its grant on the hub, so "+
+			disconnectInPreferences+" if the hub still lists it")
+		if delErr := control.DeleteCredentials(hub); delErr != nil {
+			return control.EmitErrorWith("delete_failed", delErr)
+		}
+	}
+
+	if deviceCode {
+		return runDeviceCodeLogin(ctx, hub, deviceName, scope)
 	}
 	return runLocalRedirectLogin(ctx, hub, deviceName, scope)
 }
 
 func runLocalRedirectLogin(ctx context.Context, hubURL, deviceName, scope string) error {
-	// The local-redirect flow needs a browser to reach BOTH the hub (to
-	// load the consent page) and this CLI (the loopback callback). A
-	// socket hub URL gives the browser no hub origin to visit — solo
-	// deployments need no login at all, and a socket-reached multi-user
-	// hub has an http(s) origin derived from its settings. State the
-	// working alternative instead of failing mysteriously.
-	if locallisten.IsLocal(hubURL) {
-		return control.EmitError("invalid_request",
-			"--hub unix:/npipe: URLs cannot use the local-redirect flow (no browser-reachable hub origin); pass --device-code to authenticate in a browser against the hub's public origin")
-	}
+	// The socket-hub refusal this flow needs already ran in RunAuthLogin,
+	// before the destructive cleanup: a refused flag must not cost the
+	// machine its working credential.
 	verifier := oauth2.GenerateVerifier()
 	challenge := pkce.S256(verifier)
 	state := id.Generate()
@@ -354,14 +392,11 @@ func exchangeAuthorizationCode(ctx context.Context, hubURL, code, verifier, redi
 // persistTokenResponse writes the freshly minted credential and retires the
 // one it replaces.
 //
-// The ORDER is deliberate: save first, revoke second. A crash between the
-// two leaves the user logged in with one abandoned row on the hub, which the
-// device list shows and the expiry sweep eventually removes. The reverse
-// order would leave them logged OUT with a credential file the hub
-// already refused -- the failure the user cannot fix without a browser.
-//
-// The revoke is best-effort for the same reason: a hub that is briefly
-// unreachable must not turn a successful login into a failed one.
+// The credential this login REPLACED never reaches this function: both
+// flows run behind RunAuthLogin's up-front cleanup, which revokes the
+// outgoing credential and deletes its file before the flow starts (see
+// there). Retirement has ONE owner, so a second revoke here would be dead
+// code that only a direct unit test exercises.
 func persistTokenResponse(hubURL string, body io.Reader, clientID, requestedScope string) error {
 	var out struct {
 		control.TokenResponseBody
@@ -371,8 +406,6 @@ func persistTokenResponse(hubURL string, body io.Reader, clientID, requestedScop
 	if err := json.NewDecoder(body).Decode(&out); err != nil {
 		return control.EmitErrorWith("token_exchange_failed", err)
 	}
-	// Read the outgoing credential BEFORE the new one overwrites the file.
-	previous, previousErr := control.LoadCredentials(hubURL)
 
 	now := time.Now()
 	creds := control.CredentialFile{
@@ -392,21 +425,6 @@ func persistTokenResponse(hubURL string, body io.Reader, clientID, requestedScop
 	if err := control.SaveCredentials(hubURL, creds); err != nil {
 		return control.EmitErrorWith("save_credentials_failed", err)
 	}
-	// Retire the credential this login replaced. Without this, each re-login
-	// abandons a row nobody revoked, whose plaintext refresh secret stays
-	// live for months on this machine's disk history and in the hub's table.
-	retirementWarning := ""
-	if previousErr == nil && previous.AccessToken != "" && previous.AccessToken != creds.AccessToken {
-		if err := revokeBearer(hubURL, previous.AccessToken, previous.ClientIDOrBuiltIn()); err != nil {
-			// Best-effort by design: the new credential is already on disk
-			// and the login succeeded. But it must not be SILENT, or the
-			// retirement reads as done on exactly the runs where it did not
-			// happen -- and the old refresh secret then stays live for the
-			// rest of its window.
-			retirementWarning = "the previous credential could not be revoked (" + err.Error() +
-				"); disconnect it under Preferences, Account, Connected apps"
-		}
-	}
 
 	result := map[string]any{
 		"hub_url":  hubURL,
@@ -414,23 +432,10 @@ func persistTokenResponse(hubURL string, body io.Reader, clientID, requestedScop
 		"user_id":  out.UserID,
 		"scope":    out.Scope,
 	}
-	// EVERY warning, joined, not the first one that matches. A `switch`
-	// reported one and discarded the rest, so a login that was refused part of
-	// its scope AND could not retire its predecessor said nothing about the
-	// credential still live on the hub -- the exact silence the retirement
-	// warning exists to break.
-	var warnings []string
 	if missing := control.MissingScopes(requestedScope, out.Scope); len(missing) > 0 {
 		// Say so HERE rather than letting the first call that needs one fail
 		// with a permission error that specifies nothing the user did.
-		warnings = append(warnings,
-			"these permissions were requested but not granted: "+strings.Join(missing, ", "))
-	}
-	if retirementWarning != "" {
-		warnings = append(warnings, retirementWarning)
-	}
-	if len(warnings) > 0 {
-		result["warning"] = strings.Join(warnings, "; ")
+		result["warning"] = "these permissions were requested but not granted: " + strings.Join(missing, ", ")
 	}
 	return control.EmitData(result)
 }
@@ -452,8 +457,8 @@ func RunAuthLogout(rawCtx any, args []string) error {
 	creds, err := control.LoadCredentials(hub)
 	if err == nil {
 		if revokeErr := revokeBearer(hub, creds.AccessToken, creds.ClientIDOrBuiltIn()); revokeErr != nil {
-			warning = "the credential could not be revoked on the hub (" + revokeErr.Error() +
-				"); it is gone from this machine, so disconnect it under Preferences, Account, Connected apps"
+			warning = "this CLI could not revoke the credential on the hub (" + revokeErr.Error() +
+				"); it is gone from this machine, so " + disconnectInPreferences
 		}
 	}
 	if err := control.DeleteCredentials(hub); err != nil {
@@ -478,13 +483,14 @@ func RunAuthList(rawCtx any, args []string) error {
 	}
 	out := make([]map[string]any, 0, len(files))
 	for _, c := range files {
-		out = append(out, map[string]any{
+		row := map[string]any{
 			"hub_url":  c.HubURL,
 			"username": c.Username,
 			"user_id":  c.UserID,
-			"expires":  c.ExpiresAt,
 			"scope":    c.Scope,
-		})
+		}
+		putWallTime(row, "expires", c.ExpiresAt)
+		out = append(out, row)
 	}
 	return control.EmitData(out)
 }
@@ -581,6 +587,13 @@ const (
 	maxCredentialPages = 500
 )
 
+// RunAuthStatus answers "can this machine still reach my account" -- a
+// question about the HUB's truth, not the credential file's. The file's own
+// fields print either way, and one authenticated GetCurrentUser confirms
+// them: confirmed answers carry the hub's username and admin flag, a refusal
+// is a signed-out state (the rotation the interceptor attempts has already
+// deleted the file), and an unreachable hub keeps the local answer useful
+// with a warning that states exactly what was not verified.
 func RunAuthStatus(rawCtx any, args []string) error {
 	hub, err := parseHubOnly(rawCtx, args, nil)
 	if err != nil {
@@ -591,24 +604,165 @@ func RunAuthStatus(rawCtx any, args []string) error {
 		return control.EmitErrorWith("not_logged_in", err)
 	}
 	status := map[string]any{
-		"hub_url":  creds.HubURL,
-		"username": creds.Username,
-		"user_id":  creds.UserID,
-		"expires":  creds.ExpiresAt,
-		"expired":  time.Now().After(creds.ExpiresAt),
+		"hub_url": creds.HubURL,
+		"user_id": creds.UserID,
+		// The file's zone is wherever it was written; printed UTC so every
+		// timestamp in a CLI envelope ends in Z (see putWallTime).
+		"expired": time.Now().After(creds.ExpiresAt),
 		// The access token above renews itself; this is the deadline that
 		// actually sends the user back to a browser.
 		"scope":    creds.Scope,
 		"token_id": creds.TokenID,
 	}
+	putWallTime(status, "expires", creds.ExpiresAt)
 	// Included only when the credential carries one: the field is zero on a
-	// credential written before the hub reported it, and a hand-built map has
-	// no omitzero to keep "0001-01-01T00:00:00Z" -- a nonsense date on the one
-	// deadline a reader acts on -- out of the JSON envelope.
-	if !creds.RefreshExpiresAt.IsZero() {
-		status["refresh_expires"] = creds.RefreshExpiresAt
+	// credential written before the hub reported it, and putWallTime's own
+	// zero guard keeps "0001-01-01T00:00:00.000Z" -- a nonsense date on the
+	// one deadline a reader acts on -- out of the JSON envelope.
+	putWallTime(status, "refresh_expires", creds.RefreshExpiresAt)
+
+	/*
+		THE HUB CHECK. The fields above are this machine's credential file,
+		which answers what the file says -- and a revoked credential's file
+		keeps saying "valid" until its stored expiry. One authenticated read
+		settles what the hub would actually do with the bearer:
+
+		  - confirmed: the hub's own username and admin flag join the answer,
+		    and the hub's username WINS -- the local copy is stale the moment
+		    an account is renamed;
+		  - refused: the credential opens nothing. The interceptor's refresh
+		    already deleted the file on an invalid_grant, so not_logged_in is
+		    the honest code, with the hub's reason attached;
+			  - unreachable: the hub could not be asked, so the local file is
+			    stated with a warning rather than failing -- status must stay
+			    useful offline, and the warning states exactly what was not
+			    verified.
+	*/
+	c, err := control.NewClient(hub)
+	if err != nil {
+		return control.EmitErrorWith("not_logged_in", err)
+	}
+	user, warning, outcome, err := hubCheck(c)
+	switch outcome {
+	case hubCheckRefused:
+		return control.EmitErrorWith("not_logged_in", err)
+	case hubCheckFailed:
+		return control.EmitErrorWith("rpc_failed", err)
+	case hubCheckLocalFallback:
+		status["hub_checked"] = false
+		status["username"] = creds.Username
+		status["warning"] = warning
+	default:
+		status["hub_checked"] = true
+		status["username"] = user.GetUsername()
+		status["is_admin"] = user.GetIsAdmin()
 	}
 	return control.EmitData(status)
+}
+
+// disconnectInPreferences identifies the one place a user revokes a credential
+// by hand when this CLI could not: the account's Connected-apps list. It is a
+// constant because three CLI warnings state it and a Preferences
+// reorganisation must move one string, not three. The path separator is ›,
+// the same character the Preferences search breadcrumb spells paths with, so
+// one spelling of "drill down through these" reaches the user everywhere.
+const disconnectInPreferences = "disconnect it under Preferences › Apps › Connected apps"
+
+// hubRefusedCredential reports an error that is the hub ANSWERING: this
+// credential opens nothing, and no retry will change that. The sentinel
+// cases are the refresh path's (the file is already deleted when they
+// surface); the code case is the hub's own Unauthenticated on a bearer it
+// revoked or no longer holds.
+func hubRefusedCredential(err error) bool {
+	return errors.Is(err, control.ErrNotLoggedIn) ||
+		errors.Is(err, control.ErrCredentialRejected) ||
+		connect.CodeOf(err) == connect.CodeUnauthenticated
+}
+
+// hubUnreachable reports an error that says the hub could not be ASKED --
+// down, timing out, unresolvable, or answering through a broken reverse
+// proxy -- which is a fact about the network rather than about the
+// credential, so the caller reports the local answer with a warning instead
+// of a failure.
+func hubUnreachable(err error) bool {
+	switch connect.CodeOf(err) {
+	case connect.CodeUnavailable, connect.CodeDeadlineExceeded,
+		// connect-go maps a proxy's 404 to Unimplemented and a 500 to
+		// Unknown: a misrouted or crashed proxy is the same "could not be
+		// asked" as one that is down, and the 502/503/504 family already
+		// arrives as Unavailable.
+		connect.CodeUnimplemented, connect.CodeUnknown:
+		return true
+	default:
+		return false
+	}
+}
+
+// hubCheckTimeout caps the whole confirmation read below, the token rotation
+// the interceptor performs beneath it included (doRefresh clamps its own
+// budget to this deadline). The local answer plus a warning is the designed
+// fallback, so a hung hub must not hold the command for the transport's full
+// 60-second default -- or the rotation's 30 -- before that fallback fires.
+const hubCheckTimeout = 5 * time.Second
+
+// hubUnconfirmedTail states, on every local-answer fallback, that the fields
+// the command printed are the file's, not the hub's. Both fallback warnings
+// end with it, so the two wordings cannot drift apart.
+const hubUnconfirmedTail = "the fields above are this machine's credential file, not the hub's answer"
+
+// hubUnconfirmedWarning states, on the unreachable fallback, exactly what
+// was not verified. One string, because `auth status` and `whoami` answer
+// the same question and must not word it differently.
+const hubUnconfirmedWarning = "the hub could not be reached to confirm this; " + hubUnconfirmedTail
+
+// hubCheckOutcome classifies what one authenticated GetCurrentUser read said
+// about this machine's credential.
+type hubCheckOutcome int
+
+const (
+	// hubCheckConfirmed: the hub answered with the account. The caller uses
+	// the hub's own username and admin flag.
+	hubCheckConfirmed hubCheckOutcome = iota
+	// hubCheckRefused: the credential opens nothing; the caller reports a
+	// signed-out state.
+	hubCheckRefused
+	// hubCheckLocalFallback: the hub could not be asked, or the credential
+	// lacks the account:read permission the read requires. The local answer
+	// stands with a warning.
+	hubCheckLocalFallback
+	// hubCheckFailed: an error this classification does not own.
+	hubCheckFailed
+)
+
+// hubCheck performs the one authenticated GetCurrentUser read that settles
+// whether the hub still honours this machine's credential. `auth status` and
+// `whoami` ask the same question through it, so the two commands classify a
+// refusal identically and word the fallback warning identically.
+//
+// A PermissionDenied answer is a LOCAL FALLBACK, not a refusal: the hub
+// answered, and the credential is valid for what it can do -- it merely
+// lacks the account:read permission GetCurrentUser requires (a credential
+// minted with `auth login --scope`). The identity fields it would confirm
+// come from the file instead.
+func hubCheck(c *control.Client) (user *leapmuxv1.User, warning string, outcome hubCheckOutcome, err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), hubCheckTimeout)
+	defer cancel()
+	me, callErr := c.AuthService().GetCurrentUser(ctx,
+		connect.NewRequest(&leapmuxv1.GetCurrentUserRequest{}))
+	switch {
+	case callErr == nil:
+		return me.Msg.GetUser(), "", hubCheckConfirmed, nil
+	case hubRefusedCredential(callErr):
+		return nil, "", hubCheckRefused,
+			fmt.Errorf("the hub refused this credential: %w", callErr)
+	case connect.CodeOf(callErr) == connect.CodePermissionDenied:
+		return nil, "this credential lacks the account:read permission, so the hub could not confirm it; " +
+			hubUnconfirmedTail, hubCheckLocalFallback, nil
+	case hubUnreachable(callErr):
+		return nil, hubUnconfirmedWarning, hubCheckLocalFallback, nil
+	default:
+		return nil, "", hubCheckFailed, callErr
+	}
 }
 
 // --- helpers ----------------------------------------------------------

--- a/backend/internal/cli/control/cmd/auth_test.go
+++ b/backend/internal/cli/control/cmd/auth_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -21,6 +22,8 @@ import (
 	"connectrpc.com/connect"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"google.golang.org/protobuf/proto"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	leapmuxv1connect "github.com/leapmux/leapmux/generated/proto/leapmux/v1/leapmuxv1connect"
@@ -112,12 +115,9 @@ func TestPersistTokenResponse_WarnsWhenAScopeWasNotGranted(t *testing.T) {
 		require.NoError(t, persistTokenResponse("https://hub.example", body, oauthapp.ControlCLIClientID, "admin:read"))
 	})
 
-	var env struct {
-		Data map[string]any `json:"data"`
-	}
-	require.NoError(t, json.Unmarshal(out, &env))
-	assert.Equal(t, "workspace:read", env.Data["scope"])
-	assert.Contains(t, env.Data["warning"], "admin:read",
+	data := envelopeData(t, out)
+	assert.Equal(t, "workspace:read", data["scope"])
+	assert.Contains(t, data["warning"], "admin:read",
 		"the warning must NAME the permission that was refused")
 
 	loaded, err := control.LoadCredentials("https://hub.example")
@@ -126,99 +126,71 @@ func TestPersistTokenResponse_WarnsWhenAScopeWasNotGranted(t *testing.T) {
 		"the file must record what was GRANTED, not what was asked")
 }
 
-// TestPersistTokenResponse_RevokesTheCredentialItReplaces pins the
-// save-then-revoke ORDER. A crash between the two must leave the user
-// logged IN with one abandoned row, never logged out holding a file the hub
-// already refused.
-func TestPersistTokenResponse_RevokesTheCredentialItReplaces(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("LEAPMUX_CONTROL_CONFIG_DIR", dir)
+// TestRunAuthLogin_WarnsWhenTheRevokeFails pins the best-effort half of the
+// up-front cleanup. A hub that refuses the revoke must not fail the login,
+// but the refusal must be STATED, with the one place the operator can finish
+// the job -- and that place must be the row the Preferences dialog actually
+// draws (Apps, not the Account group it moved out of).
+func TestRunAuthLogin_WarnsWhenTheRevokeFails(t *testing.T) {
+	t.Setenv("LEAPMUX_CONTROL_CONFIG_DIR", t.TempDir())
 
-	revoked := make(chan string, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/oauth/revoke", r.URL.Path)
-		require.NoError(t, r.ParseForm())
-		revoked <- r.FormValue("token")
-		w.WriteHeader(http.StatusOK)
+		switch r.URL.Path {
+		case "/oauth/revoke":
+			w.WriteHeader(http.StatusInternalServerError)
+		case "/oauth/device-authorization":
+			http.Error(w, "refused", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
 	}))
 	t.Cleanup(srv.Close)
+	liveCredentialFor(t, srv.URL)
 
-	require.NoError(t, control.SaveCredentials(srv.URL, control.CredentialFile{
-		HubURL:      srv.URL,
-		AccessToken: "lmx_a_old_secret",
-		UserID:      "user-1",
-		Username:    "alice",
-	}))
-
-	withCapturedStdout(t, func() {
-		body := strings.NewReader(`{
-			"access_token": "lmx_a_new_secret",
-			"refresh_token": "lmx_a_new_refresh",
-			"expires_in": 3600,
-			"user_id": "user-1",
-			"username": "alice"
-		}`)
-		require.NoError(t, persistTokenResponse(srv.URL, body, oauthapp.ControlCLIClientID, ""))
+	var runErr error
+	out := withCapturedStdout(t, func() {
+		runErr = RunAuthLogin(fakeCmdCtx{}, []string{"--hub", srv.URL, "--device-code"})
 	})
+	require.Error(t, runErr, "the failed authorization is the login's own error")
 
-	select {
-	case token := <-revoked:
-		assert.Equal(t, "lmx_a_old_secret", token, "the OUTGOING credential must be the one revoked")
-	case <-time.After(5 * time.Second):
-		t.Fatal("the replaced credential was never revoked")
-	}
-
-	loaded, err := control.LoadCredentials(srv.URL)
-	require.NoError(t, err)
-	assert.Equal(t, "lmx_a_new_secret", loaded.AccessToken, "the new credential must survive the revoke")
+	assert.Contains(t, string(out), "could not revoke",
+		"a revoke that did not happen must say so")
+	assert.Contains(t, string(out), "Preferences › Apps › Connected apps",
+		"the warning must name the group that holds the row, not the one a reorg removed")
+	_, err := control.LoadCredentials(srv.URL)
+	assert.ErrorIs(t, err, control.ErrNotLoggedIn,
+		"the local file goes either way: the cleanup stays locally idempotent")
 }
 
-// TestPersistTokenResponse_WarnsWhenTheOldCredentialSurvives pins the other
-// half of the retirement.
-//
-// The revoke is best-effort by design -- the new credential is already on
-// disk and the login succeeded -- but it must not be SILENT. revokeBearer
-// never read the status code, so a hub that refused the revoke produced a
-// clean result envelope while the old refresh secret stayed live for the
-// rest of its window, which is exactly what the retirement exists to stop.
-func TestPersistTokenResponse_WarnsWhenTheOldCredentialSurvives(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("LEAPMUX_CONTROL_CONFIG_DIR", dir)
+// TestRunAuthLogin_CleansUpAnUnreadableCredentialFile pins the corrupt-file
+// half of the cleanup. A file that does not parse carries tokens this CLI
+// cannot revoke, but the login must not leave it in place either: the file
+// goes, and the warning states that its grant may still live on the hub.
+func TestRunAuthLogin_CleansUpAnUnreadableCredentialFile(t *testing.T) {
+	t.Setenv("LEAPMUX_CONTROL_CONFIG_DIR", t.TempDir())
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/oauth/revoke", r.URL.Path)
-		// The hub refuses. A 2xx-only reader would call this success.
-		w.WriteHeader(http.StatusInternalServerError)
+		http.Error(w, "refused", http.StatusInternalServerError)
 	}))
 	t.Cleanup(srv.Close)
 
-	require.NoError(t, control.SaveCredentials(srv.URL, control.CredentialFile{
-		HubURL:      srv.URL,
-		AccessToken: "lmx_a_old_secret",
-		UserID:      "user-1",
-		Username:    "alice",
-	}))
-
-	out := withCapturedStdout(t, func() {
-		body := strings.NewReader(`{
-			"access_token": "lmx_a_new_secret",
-			"refresh_token": "lmx_a_new_refresh",
-			"expires_in": 3600,
-			"user_id": "user-1",
-			"username": "alice"
-		}`)
-		require.NoError(t, persistTokenResponse(srv.URL, body, oauthapp.ControlCLIClientID, ""))
-	})
-
-	assert.Contains(t, string(out), "could not be revoked",
-		"a retirement that did not happen must say so")
-	assert.Contains(t, string(out), "Preferences",
-		"the warning must state where the operator can finish the job")
-
-	// The login still succeeded: the new credential is on disk.
-	loaded, err := control.LoadCredentials(srv.URL)
+	path, err := control.CredentialsPath(srv.URL)
 	require.NoError(t, err)
-	assert.Equal(t, "lmx_a_new_secret", loaded.AccessToken)
+	require.NoError(t, os.WriteFile(path, []byte("{not credential json"), 0o600))
+
+	var runErr error
+	out := withCapturedStdout(t, func() {
+		runErr = RunAuthLogin(fakeCmdCtx{}, []string{"--hub", srv.URL, "--device-code"})
+	})
+	require.Error(t, runErr, "the failed authorization is the login's own error")
+
+	assert.Contains(t, string(out), "does not parse",
+		"an unreadable file must be reported, not silently overwritten")
+	assert.Contains(t, string(out), "cannot revoke",
+		"the warning must state what the CLI could not do about the grant")
+	_, err = control.LoadCredentials(srv.URL)
+	assert.ErrorIs(t, err, control.ErrNotLoggedIn,
+		"the unreadable file must not survive the login attempt")
 }
 
 // TestPersistTokenResponse_RejectsMalformedJSON pins the failure path:
@@ -296,9 +268,9 @@ func TestRunAuthLogout_RevokesAndRemovesCreds(t *testing.T) {
 //
 // The hub hard-deletes an api_tokens row once both of its deadlines close,
 // and it answers a bearer whose row it cannot find with 401. Reporting that
-// as a failed revoke told the user to finish the job under Preferences,
-// Account, Connected apps -- where the row is already gone, so there is
-// nothing to act on and the warning can only worry them.
+// as a failed revoke told the user to finish the job under
+// Preferences › Apps › Connected apps -- where the row is already gone, so
+// there is nothing to act on and the warning can only worry them.
 // TestRunAuthLogout_WarnsWhereToFinishTheJob pins the REFUSAL warning's
 // destination. The warning once named "Command-line credentials", a
 // Preferences row that no longer exists -- so the one user who needed it was
@@ -327,7 +299,7 @@ func TestRunAuthLogout_WarnsWhereToFinishTheJob(t *testing.T) {
 		Data map[string]string `json:"data"`
 	}
 	require.NoError(t, json.Unmarshal(out, &env))
-	assert.Contains(t, env.Data["warning"], "could not be revoked",
+	assert.Contains(t, env.Data["warning"], "could not revoke",
 		"a logout whose revoke failed must say so")
 	assert.Contains(t, env.Data["warning"], "Preferences",
 		"the warning must state where the operator can finish the job")
@@ -392,7 +364,7 @@ func TestRunAuthLogout_WarnsWhenTheHubRefusesTheRevoke(t *testing.T) {
 	out := withCapturedStdout(t, func() {
 		require.NoError(t, RunAuthLogout(fakeCmdCtx{}, []string{"--hub", srv.URL}))
 	})
-	assert.Contains(t, string(out), "could not be revoked")
+	assert.Contains(t, string(out), "could not revoke")
 	assert.Contains(t, string(out), "Preferences")
 }
 
@@ -453,13 +425,10 @@ func TestRunAuthStatus_ReportsExpiry(t *testing.T) {
 		err := RunAuthStatus(fakeCmdCtx{}, []string{"--hub", "https://hub.example"})
 		require.NoError(t, err)
 	})
-	var env struct {
-		Data map[string]any `json:"data"`
-	}
-	require.NoError(t, json.Unmarshal(out, &env))
-	assert.Equal(t, "alice", env.Data["username"])
-	assert.Equal(t, "u1", env.Data["user_id"])
-	assert.Equal(t, false, env.Data["expired"])
+	data := envelopeData(t, out)
+	assert.Equal(t, "alice", data["username"])
+	assert.Equal(t, "u1", data["user_id"])
+	assert.Equal(t, false, data["expired"])
 }
 
 // TestRunAuthStatus_ReportsExpired covers the expired-credentials
@@ -479,11 +448,8 @@ func TestRunAuthStatus_ReportsExpired(t *testing.T) {
 		err := RunAuthStatus(fakeCmdCtx{}, []string{"--hub", "https://hub.example"})
 		require.NoError(t, err)
 	})
-	var env struct {
-		Data map[string]any `json:"data"`
-	}
-	require.NoError(t, json.Unmarshal(out, &env))
-	assert.Equal(t, true, env.Data["expired"])
+	data := envelopeData(t, out)
+	assert.Equal(t, true, data["expired"])
 }
 
 // TestRunAuthStatus_NotLoggedInWhenMissing covers the negative
@@ -1035,4 +1001,364 @@ func TestCallbackHandlerReportsTheServerErrorParameter(t *testing.T) {
 	default:
 		t.Fatal("an empty callback must reach the CLI's error channel")
 	}
+}
+
+// --- the hub check behind auth status / whoami ------------------------
+//
+// Both commands print what the hub would actually DO with the bearer, not
+// what the credential file says: one authenticated GetCurrentUser, with
+// three endings -- confirmed (the hub's own username and admin flag),
+// refused (not logged in; the refresh path already deleted the file), and
+// unreachable (the local answer with a warning naming what was not
+// verified).
+
+// currentUserServer answers the one Connect RPC the hub check makes. The
+// client speaks binary proto, so the body is a marshalled message, not JSON.
+func currentUserServer(t *testing.T, username string, isAdmin bool) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/leapmux.v1.AuthService/GetCurrentUser" {
+			http.NotFound(w, r)
+			return
+		}
+		body, err := proto.Marshal(&leapmuxv1.GetCurrentUserResponse{
+			User: &leapmuxv1.User{Id: "u-hub", Username: username, IsAdmin: isAdmin},
+		})
+		require.NoError(t, err)
+		w.Header().Set("Content-Type", "application/proto")
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// currentUserPermissionDeniedServer answers GetCurrentUser the way the hub
+// answers a credential minted without account:read (`auth login --scope`):
+// the credential is valid, but this one read sits beyond its ceiling.
+func currentUserPermissionDeniedServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/leapmux.v1.AuthService/GetCurrentUser" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"code": "permission_denied"}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// liveCredentialFor writes a credential whose access token has not lapsed,
+// so the check goes straight to the RPC without a rotation first.
+func liveCredentialFor(t *testing.T, hubURL string) {
+	t.Helper()
+	require.NoError(t, control.SaveCredentials(hubURL, control.CredentialFile{
+		HubURL:      hubURL,
+		AccessToken: "lmx_a_at_status",
+		// A refresh secret, so the refusal's repair can RUN: without one the
+		// 401 has nothing to rotate and nothing to delete, and the file
+		// survives a refusal that proved it worthless.
+		RefreshToken: "lmx_a_rt_status",
+		Username:     "local-name",
+		UserID:       "u-local",
+		ExpiresAt:    time.Now().Add(time.Hour),
+		// The deadline a real login always carries, so the UTC assertions
+		// cover both printed timestamps.
+		RefreshExpiresAt: time.Now().Add(90 * 24 * time.Hour),
+	}))
+}
+
+func TestRunAuthStatus_ConfirmsWithTheHub(t *testing.T) {
+	t.Setenv("LEAPMUX_CONTROL_CONFIG_DIR", t.TempDir())
+	srv := currentUserServer(t, "renamed-on-the-hub", true)
+	liveCredentialFor(t, srv.URL)
+
+	out := withCapturedStdout(t, func() {
+		require.NoError(t, RunAuthStatus(fakeCmdCtx{}, []string{"--hub", srv.URL}))
+	})
+
+	data := envelopeData(t, out)
+	assert.Equal(t, true, data["hub_checked"])
+	// The hub's username WINS: the local copy is stale the moment an account
+	// is renamed, and status is exactly where that must not mislead.
+	assert.Equal(t, "renamed-on-the-hub", data["username"])
+	assert.Equal(t, true, data["is_admin"])
+	// The credential file's zone is wherever it was written; the OUTPUT is
+	// always UTC, so every deadline the CLI prints ends in Z and sorts beside
+	// the hub's own timestamps.
+	for _, key := range []string{"expires", "refresh_expires"} {
+		assert.Truef(t, strings.HasSuffix(data[key].(string), "Z"), "%s must end in Z", key)
+	}
+}
+
+// TestRunAuthList_PrintsUTC pins the same rule for `auth list`: its rows
+// read the credential FILE, whose zone is the writer's, and the envelope
+// must not leak it.
+func TestRunAuthList_PrintsUTC(t *testing.T) {
+	t.Setenv("LEAPMUX_CONTROL_CONFIG_DIR", t.TempDir())
+	srv := currentUserServer(t, "unused", false)
+	liveCredentialFor(t, srv.URL)
+
+	out := withCapturedStdout(t, func() {
+		require.NoError(t, RunAuthList(fakeCmdCtx{}, nil))
+	})
+
+	var env struct {
+		Data []map[string]any `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(out, &env))
+	require.Len(t, env.Data, 1)
+	assert.True(t, strings.HasSuffix(env.Data[0]["expires"].(string), "Z"),
+		"auth list must print the file's deadline in UTC")
+}
+
+func TestRunAuthStatus_WarnsWhenTheHubCannotBeAsked(t *testing.T) {
+	t.Setenv("LEAPMUX_CONTROL_CONFIG_DIR", t.TempDir())
+	// A server that is already closed: the URL stays valid, the hub is gone.
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	srv.Close()
+	liveCredentialFor(t, srv.URL)
+
+	out := withCapturedStdout(t, func() {
+		require.NoError(t, RunAuthStatus(fakeCmdCtx{}, []string{"--hub", srv.URL}))
+	})
+
+	data := envelopeData(t, out)
+	// Offline stays USEFUL: the local answer prints, and the warning names
+	// exactly what was not verified.
+	assert.Equal(t, false, data["hub_checked"])
+	assert.Equal(t, "local-name", data["username"])
+	assert.Contains(t, data["warning"], "could not be reached")
+}
+
+func TestRunAuthStatus_RefusedMeansSignedOut(t *testing.T) {
+	t.Setenv("LEAPMUX_CONTROL_CONFIG_DIR", t.TempDir())
+	// The hub answers the RPC itself with 401, and the rotation the
+	// interceptor then attempts with invalid_grant -- which deletes the
+	// credential file on the way through.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/leapmux.v1.AuthService/GetCurrentUser":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"code":"unauthenticated"}`))
+		case "/oauth/token":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	liveCredentialFor(t, srv.URL)
+
+	// An emitted error returns non-nil (it is what sets the exit code), so
+	// the assertion is on the envelope it wrote, not on NoError.
+	var runErr error
+	out := withCapturedStdout(t, func() {
+		runErr = RunAuthStatus(fakeCmdCtx{}, []string{"--hub", srv.URL})
+	})
+	require.Error(t, runErr)
+	assert.True(t, control.IsEmitted(runErr), "the refusal reached the user as an envelope")
+
+	env := envelopeError(t, out)
+	assert.Equal(t, "not_logged_in", env["code"],
+		"a credential the hub refused is a signed-out state, whatever the file said")
+	// And the file is GONE: the refusal cleaned up after itself, so the next
+	// command does not re-learn it.
+	_, err := control.LoadCredentials(srv.URL)
+	assert.ErrorIs(t, err, control.ErrNotLoggedIn)
+}
+
+func TestRunWhoami_ConfirmsWithTheHub(t *testing.T) {
+	t.Setenv("LEAPMUX_CONTROL_CONFIG_DIR", t.TempDir())
+	srv := currentUserServer(t, "hub-name", false)
+	liveCredentialFor(t, srv.URL)
+
+	out := withCapturedStdout(t, func() {
+		require.NoError(t, RunWhoami(fakeCmdCtx{}, []string{"--hub", srv.URL}))
+	})
+
+	data := envelopeData(t, out)
+	assert.Equal(t, "hub-name", data["username"])
+	assert.Equal(t, "u-hub", data["user_id"])
+	assert.Equal(t, false, data["is_admin"])
+}
+
+// TestRunAuthStatus_FallsBackWhenTheCredentialLacksAccountRead and the
+// whoami twin below pin the PermissionDenied classification: a valid
+// credential that merely lacks account:read is NOT a signed-out state and
+// NOT an rpc failure. The local answer stands with a warning that states
+// the permission the confirmation could not cross -- and whoami keeps
+// is_admin present (null, the honest unknown), so its direct endings carry
+// one shape.
+func TestRunAuthStatus_FallsBackWhenTheCredentialLacksAccountRead(t *testing.T) {
+	t.Setenv("LEAPMUX_CONTROL_CONFIG_DIR", t.TempDir())
+	srv := currentUserPermissionDeniedServer(t)
+	liveCredentialFor(t, srv.URL)
+
+	out := withCapturedStdout(t, func() {
+		require.NoError(t, RunAuthStatus(fakeCmdCtx{}, []string{"--hub", srv.URL}))
+	})
+
+	data := envelopeData(t, out)
+	assert.Equal(t, false, data["hub_checked"])
+	assert.Equal(t, "local-name", data["username"],
+		"a scope-limited credential still has a local identity to report")
+	assert.Contains(t, data["warning"], "account:read",
+		"the warning must name the permission the confirmation could not cross")
+}
+
+func TestRunWhoami_FallsBackWhenTheCredentialLacksAccountRead(t *testing.T) {
+	t.Setenv("LEAPMUX_CONTROL_CONFIG_DIR", t.TempDir())
+	srv := currentUserPermissionDeniedServer(t)
+	liveCredentialFor(t, srv.URL)
+
+	out := withCapturedStdout(t, func() {
+		require.NoError(t, RunWhoami(fakeCmdCtx{}, []string{"--hub", srv.URL}))
+	})
+
+	data := envelopeData(t, out)
+	assert.Equal(t, "local-name", data["username"])
+	assert.Nil(t, data["is_admin"],
+		"is_admin stays present on the fallback as null -- the one value this ending cannot know")
+	assert.Contains(t, data["warning"], "account:read")
+}
+
+// TestRunAuthLogin_CleansUpTheExistingLoginFirst pins the whole point of the
+// up-front cleanup: the old credential is revoked and deleted BEFORE the flow
+// starts, so a login that never completes still leaves no orphaned login
+// behind. The fake hub refuses the device authorization, which is exactly
+// the "attempting a login" that must not rescue the old credential.
+func TestRunAuthLogin_CleansUpTheExistingLoginFirst(t *testing.T) {
+	t.Setenv("LEAPMUX_CONTROL_CONFIG_DIR", t.TempDir())
+
+	revoked := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth/revoke":
+			revoked = true
+			w.WriteHeader(http.StatusOK)
+		case "/oauth/device-authorization":
+			// The flow dies here; the cleanup must already have happened.
+			http.Error(w, "refused", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	liveCredentialFor(t, srv.URL)
+
+	var runErr error
+	out := withCapturedStdout(t, func() {
+		runErr = RunAuthLogin(fakeCmdCtx{}, []string{"--hub", srv.URL, "--device-code"})
+	})
+	require.Error(t, runErr, "the failed authorization is the login's own error")
+
+	assert.True(t, revoked, "the existing login must be revoked before the flow starts")
+	_, err := control.LoadCredentials(srv.URL)
+	assert.ErrorIs(t, err, control.ErrNotLoggedIn,
+		"a login that never completed must not leave the old credential on disk")
+	assert.Contains(t, string(out), "existing login", "the cleanup warns before it cleans")
+	assert.Contains(t, string(out), "local-name", "the warning identifies the login it removes")
+}
+
+// TestRunAuthLogin_RefusedFlagKeepsTheExistingLogin pins the ORDER around
+// the up-front cleanup: every input is validated first, so a flag the CLI
+// refuses must not cost the machine its working credential. The scope below
+// is exactly the value splitScopeFlag exists to refuse.
+func TestRunAuthLogin_RefusedFlagKeepsTheExistingLogin(t *testing.T) {
+	t.Setenv("LEAPMUX_CONTROL_CONFIG_DIR", t.TempDir())
+
+	revoked := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/oauth/revoke" {
+			revoked = true
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	liveCredentialFor(t, srv.URL)
+
+	var runErr error
+	out := withCapturedStdout(t, func() {
+		runErr = RunAuthLogin(fakeCmdCtx{}, []string{"--hub", srv.URL, "--scope", ","})
+	})
+	require.Error(t, runErr)
+	assert.True(t, control.IsEmitted(runErr))
+	assert.Equal(t, "invalid_request", envelopeError(t, out)["code"],
+		"the refused flag is the login's own error")
+	assert.False(t, revoked, "a refused flag must not revoke the working credential")
+	_, err := control.LoadCredentials(srv.URL)
+	require.NoError(t, err, "a refused flag must not delete the working credential either")
+}
+
+// TestRunAuthStatus_FallsBackWhenTheProxyDropsTheRoute pins the transport
+// ending a status command meets behind a reverse proxy: a 404 -- which
+// connect maps to Unimplemented -- is a hub that could not be ASKED, so the
+// local answer stands with a warning, not an rpc_failed exit that hides the
+// fields the file still answers.
+func TestRunAuthStatus_FallsBackWhenTheProxyDropsTheRoute(t *testing.T) {
+	t.Setenv("LEAPMUX_CONTROL_CONFIG_DIR", t.TempDir())
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r) // a proxy that no longer routes the hub
+	}))
+	t.Cleanup(srv.Close)
+	liveCredentialFor(t, srv.URL)
+
+	out := withCapturedStdout(t, func() {
+		require.NoError(t, RunAuthStatus(fakeCmdCtx{}, []string{"--hub", srv.URL}))
+	})
+
+	data := envelopeData(t, out)
+	assert.Equal(t, false, data["hub_checked"])
+	assert.Equal(t, "local-name", data["username"])
+	assert.Contains(t, data["warning"], "could not be reached")
+}
+
+// TestRunAuthStatus_HungHubCannotHoldTheCommand pins the budget's promise:
+// the five-second cap bounds the WHOLE check, the interceptor's token
+// rotation included. A hub that accepts connections and never answers must
+// not hold `auth status` for the rotation's 30-second budget before the
+// local-answer fallback fires -- and a rotation that dies at the deadline
+// must read as unreachable, not as a refused credential, because the hub
+// never answered anything.
+func TestRunAuthStatus_HungHubCannotHoldTheCommand(t *testing.T) {
+	t.Setenv("LEAPMUX_CONTROL_CONFIG_DIR", t.TempDir())
+	hang := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-hang // accept, then stall every route the check touches
+	}))
+	// LIFO: unblock the stalled handlers BEFORE the server's Close waits
+	// for them.
+	t.Cleanup(srv.Close)
+	t.Cleanup(func() { close(hang) })
+	// The access token sits inside refreshSkew, so the check first tries to
+	// rotate it against the stalled hub.
+	require.NoError(t, control.SaveCredentials(srv.URL, control.CredentialFile{
+		HubURL:           srv.URL,
+		AccessToken:      "lmx_a_at_stale",
+		RefreshToken:     "lmx_a_rt_stale",
+		Username:         "local-name",
+		UserID:           "u-local",
+		ExpiresAt:        time.Now().Add(30 * time.Second),
+		RefreshExpiresAt: time.Now().Add(90 * 24 * time.Hour),
+	}))
+
+	started := time.Now()
+	out := withCapturedStdout(t, func() {
+		require.NoError(t, RunAuthStatus(fakeCmdCtx{}, []string{"--hub", srv.URL}))
+	})
+	assert.Less(t, time.Since(started).Seconds(), 15.0,
+		"a hung hub must not hold the command past the check's own budget")
+
+	data := envelopeData(t, out)
+	assert.Equal(t, false, data["hub_checked"])
+	assert.Equal(t, "local-name", data["username"],
+		"a rotation that could not run leaves the local identity, not a refusal")
 }

--- a/backend/internal/cli/control/cmd/output.go
+++ b/backend/internal/cli/control/cmd/output.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// The CLI envelope's timestamp helpers. They live here, outside the admin
+// verb tree they were born in, because every listing verb reads them: the
+// auth verbs print the credential file's own deadlines and the admin verbs
+// print the hub's -- one spelling of "a timestamp in a JSON envelope", so
+// every row a script reads parses by one rule.
+
+// timeFormat is the envelope's one timestamp layout: UTC, millisecond
+// precision, always ending in Z. A timestamp that carries a writer's offset
+// sorts wrongly beside the hub's own Z-ending ones, and a script reading
+// both cannot compare them without parsing zones first.
+const timeFormat = "2006-01-02T15:04:05.000Z07:00"
+
+// putTime writes one optional timestamp into an output row, omitting the
+// field when the hub sent none.
+func putTime(row map[string]any, key string, ts *timestamppb.Timestamp) {
+	if ts == nil {
+		return
+	}
+	row[key] = ts.AsTime().UTC().Format(timeFormat)
+}
+
+// putWallTime is putTime for a wall-clock time.Time -- the credential
+// file's own fields, saved in whatever zone wrote them (SaveCredentials
+// normalizes new writes to UTC; this keeps older files honest too).
+func putWallTime(row map[string]any, key string, ts time.Time) {
+	if ts.IsZero() {
+		return
+	}
+	row[key] = ts.UTC().Format(timeFormat)
+}

--- a/backend/internal/cli/control/cmd/workspace.go
+++ b/backend/internal/cli/control/cmd/workspace.go
@@ -47,10 +47,47 @@ func RunWhoami(rawCtx any, args []string) error {
 			"tab_type":  tabTypeName(resp.Msg.GetTabType()),
 		})
 	}
+
+	/*
+		The hub check, for the same reason `auth status` runs one: printing the
+		client's cached identity answers what the credential FILE says, and a
+		revoked credential's file keeps its username until something asks the
+		hub. hubCheck (shared with `auth status`) settles it -- confirmed
+		answers carry the hub's own username and admin flag; a refusal is an
+		honest not-logged-in; an unreachable or account:read-less credential
+		falls back to the cached identity with a warning that states what was
+		not verified.
+
+		is_admin stays present on the fallback (as null): the hub-confirmed
+		and fallback endings carry the same identity fields, and null is the
+		honest value for the one this ending cannot know -- a fabricated
+		false would tell an administrator's own machine the wrong flag
+		during an outage. The worker-IPC ending is the exception, and states
+		so where it emits (above): it answers from the spawn context the
+		worker holds, which carries no hub_url and no admin flag.
+	*/
+	user, warning, outcome, err := hubCheck(c)
+	switch outcome {
+	case hubCheckRefused:
+		return control.EmitErrorWith("not_logged_in", err)
+	case hubCheckFailed:
+		return control.EmitErrorWith("rpc_failed", err)
+	case hubCheckLocalFallback:
+		return control.EmitData(map[string]any{
+			"hub_url":  c.HubURL,
+			"user_id":  c.UserID,
+			"username": c.Username,
+			"is_admin": nil,
+			"warning":  warning,
+		})
+	case hubCheckConfirmed:
+		// The confirmed emit below is this outcome's return.
+	}
 	return control.EmitData(map[string]any{
 		"hub_url":  c.HubURL,
-		"user_id":  c.UserID,
-		"username": c.Username,
+		"user_id":  user.GetId(),
+		"username": user.GetUsername(),
+		"is_admin": user.GetIsAdmin(),
 	})
 }
 

--- a/backend/internal/cli/control/creds.go
+++ b/backend/internal/cli/control/creds.go
@@ -122,6 +122,14 @@ func SaveCredentials(hubURL string, creds CredentialFile) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return err
 	}
+	// One zone on disk: UTC. The writers mint deadlines with time.Now(),
+	// whose zone is the writer's, and a file that carries one machine's
+	// offset cannot be compared with the hub's own Z-ending timestamps
+	// (jq, a shell pipeline) without parsing zones first -- and every
+	// future command that prints a file deadline would otherwise have to
+	// remember a UTC conversion to keep its output honest.
+	creds.ExpiresAt = creds.ExpiresAt.UTC()
+	creds.RefreshExpiresAt = creds.RefreshExpiresAt.UTC()
 	data, err := json.MarshalIndent(creds, "", "  ")
 	if err != nil {
 		return err

--- a/backend/internal/cli/control/creds_test.go
+++ b/backend/internal/cli/control/creds_test.go
@@ -89,3 +89,36 @@ func TestListCredentialFiles_IgnoresAnInterruptedWrite(t *testing.T) {
 	require.Len(t, files, 1)
 	assert.Equal(t, "lmx_a_access_0", files[0].AccessToken)
 }
+
+// TestSaveCredentials_WritesUTC pins the file's one-zone rule: the writers
+// mint deadlines in the writer's local zone, and the stored file must carry
+// UTC so a reader can compare it with the hub's own Z-ending timestamps
+// without parsing zones first. The fixed +02:00 zone makes the assertion
+// fail even on a UTC machine.
+func TestSaveCredentials_WritesUTC(t *testing.T) {
+	t.Setenv("LEAPMUX_CONTROL_CONFIG_DIR", t.TempDir())
+	hubURL := "https://zone.example"
+	plusTwo := time.FixedZone("plus-two", 2*60*60)
+	creds := CredentialFile{
+		HubURL:           hubURL,
+		AccessToken:      "lmx_a_at_zone",
+		RefreshToken:     "lmx_a_rt_zone",
+		ExpiresAt:        time.Date(2026, 1, 2, 3, 4, 5, 0, plusTwo),
+		RefreshExpiresAt: time.Date(2026, 4, 2, 3, 4, 5, 0, plusTwo),
+	}
+	require.NoError(t, SaveCredentials(hubURL, creds))
+
+	path, err := CredentialsPath(hubURL)
+	require.NoError(t, err)
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), `"expires_at": "2026-01-02T01:04:05Z"`,
+		"the file carries UTC, not the writer's offset")
+	assert.Contains(t, string(raw), `"refresh_expires_at": "2026-04-02T01:04:05Z"`)
+
+	loaded, err := LoadCredentials(hubURL)
+	require.NoError(t, err)
+	assert.True(t, loaded.ExpiresAt.Equal(creds.ExpiresAt),
+		"normalizing the zone keeps the instant")
+	assert.True(t, loaded.RefreshExpiresAt.Equal(creds.RefreshExpiresAt))
+}

--- a/backend/internal/cli/control/elevate.go
+++ b/backend/internal/cli/control/elevate.go
@@ -166,7 +166,7 @@ func (c *Client) startElevation(ctx context.Context) (*DeviceGrant, error) {
 	// the caller reports the remedy instead of retrying.
 	//
 	// 403 decodes the BODY, because the hub states the one-step remedy there
-	// (allow elevation under Preferences, Account, App registrations). The
+	// (allow elevation under Preferences › Apps › App registrations). The
 	// sentinel's own two causes are both wrong for this refusal, and an
 	// operator who reads them retries a browser ceremony the hub keeps
 	// refusing.

--- a/backend/internal/cli/control/refresh.go
+++ b/backend/internal/cli/control/refresh.go
@@ -154,15 +154,23 @@ func (c *Client) adoptStoredBearer(creds *CredentialFile) bool {
 // bearerErrorCode maps a pre-call credential failure onto the code the
 // caller reports.
 //
-// Almost every one means "this call cannot authenticate". A rotation that
-// the hub committed and this process could not SAVE is the exception: the
-// token in memory is live and the fault is a local disk, so Unauthenticated
-// would send the operator to the login rather than to the file.
+// A permanent rejection and an unsaved rotation are the two failures that
+// say what the operator must fix: Unauthenticated sends them to the login,
+// and ErrCredentialsNotSaved's CodeInternal sends them to the file. Every
+// other failure here is a rotation that did not happen -- the hub could not
+// be asked -- and stamping that Unauthenticated would let one transient
+// network failure read as a revoked credential (hubCheck would report a
+// signed-out state for a credential that was fine). Unavailable states what
+// happened: the renewal could not reach the hub.
 func bearerErrorCode(err error) connect.Code {
-	if errors.Is(err, ErrCredentialsNotSaved) {
+	switch {
+	case errors.Is(err, ErrCredentialsNotSaved):
 		return connect.CodeInternal
+	case errors.Is(err, ErrCredentialRejected):
+		return connect.CodeUnauthenticated
+	default:
+		return connect.CodeUnavailable
 	}
-	return connect.CodeUnauthenticated
 }
 
 // freshBearer renews the credential and returns the token to present.
@@ -239,7 +247,7 @@ func (c *Client) doRefresh(ctx context.Context, presented *CredentialFile) (*Cre
 		return current, nil
 	}
 
-	// DETACHED from the caller's context, and this is the same rule the
+	// DETACHED from the caller's cancellation, and this is the same rule the
 	// hub's own handleRefresh states for the same exchange. A refresh
 	// rotates the token single-use: once the request reaches the hub, the
 	// old secret is unusable whatever happens next, so a cancellation between
@@ -247,6 +255,11 @@ func (c *Client) doRefresh(ctx context.Context, presented *CredentialFile) (*Cre
 	// secret the hub already rotated away. Presenting it later reads as a
 	// reuse, which the hub answers by REVOKING the row -- a credential that
 	// nothing was wrong with would end.
+	//
+	// Detachment drops the CANCELLATION, never the CAP: the budget below is
+	// still limited by the caller's own deadline when that deadline is
+	// nearer than refreshTimeout, so a caller that armed a short budget
+	// (hubCheck's five seconds) is held no longer than it asked to be.
 	//
 	// Three cancellations reach here, and the commonest is not the one that
 	// reads as obvious. Any verb that resolves an entity fans its lookups
@@ -257,7 +270,13 @@ func (c *Client) doRefresh(ctx context.Context, presented *CredentialFile) (*Cre
 	// follower as well, including one whose own deadline had ample time
 	// left. Last, `control events` installs signal.NotifyContext, so a
 	// Ctrl-C there cancels the stream's context and the refresh under it.
-	refreshCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), refreshTimeout)
+	budget := refreshTimeout
+	if deadline, ok := ctx.Deadline(); ok {
+		if remaining := time.Until(deadline); remaining < budget {
+			budget = remaining
+		}
+	}
+	refreshCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), budget)
 	defer cancel()
 	body, err := c.postRefresh(refreshCtx, current.RefreshToken, current.ClientIDOrBuiltIn())
 	if err != nil {

--- a/backend/internal/cli/control/refresh_test.go
+++ b/backend/internal/cli/control/refresh_test.go
@@ -982,14 +982,16 @@ func TestAuthInterceptor_ReportsALocalDiskFailureAsSuchNotAsASignIn(t *testing.T
 		"a rotation the file cannot record must stop the call, not ride it")
 }
 
-// TestBearerErrorCode_SeparatesALocalDiskFromABadCredential: the code the
+// TestBearerErrorCode_SeparatesTheFaultFromTheCredential: the code the
 // caller reads must not send an operator to the login when the fault is a
-// full disk.
-func TestBearerErrorCode_SeparatesALocalDiskFromABadCredential(t *testing.T) {
+// full disk -- and must not read a network failure as a revoked credential,
+// which hubCheck would report as a signed-out state for a credential that
+// was fine.
+func TestBearerErrorCode_SeparatesTheFaultFromTheCredential(t *testing.T) {
 	assert.Equal(t, connect.CodeInternal, bearerErrorCode(
 		fmt.Errorf("%w: no space left on device", ErrCredentialsNotSaved)))
 	assert.Equal(t, connect.CodeUnauthenticated, bearerErrorCode(ErrCredentialRejected))
-	assert.Equal(t, connect.CodeUnauthenticated, bearerErrorCode(errors.New("dial tcp: refused")))
+	assert.Equal(t, connect.CodeUnavailable, bearerErrorCode(errors.New("dial tcp: refused")))
 }
 
 // --- the reactive repair ----------------------------------------------

--- a/backend/internal/hub/mail/templates.go
+++ b/backend/internal/hub/mail/templates.go
@@ -233,13 +233,13 @@ func (r Renderer) AppCredentialIssuedEmail(to, appName, installationName string,
 	}
 	opening := "An app was authorized on your LeapMux account.\n"
 	action := "If this was you, nothing more is needed. If it was not, sign in and\n" +
-		"disconnect it under Preferences, Account, Connected apps:\n"
+		"disconnect it under Preferences › Apps › Connected apps:\n"
 	subject := "[LeapMux] An app was authorized on your account"
 	if byAdministrator {
 		opening = "An ADMINISTRATOR issued an app credential for your LeapMux account.\n" +
 			"You did not authorize this yourself.\n"
 		action = "If you did not expect it, revoke it and ask your administrator. Sign in\n" +
-			"and open Preferences, Account, Connected apps:\n"
+			"and open Preferences › Apps › Connected apps:\n"
 		subject = "[LeapMux] An administrator issued an app credential for you"
 	}
 	if administersHub {

--- a/backend/internal/hub/service/app_service.go
+++ b/backend/internal/hub/service/app_service.go
@@ -169,8 +169,25 @@ func (s *AppService) ListApps(
 	}
 	// An administrator edits the hub-wide catalogue AND their own private
 	// apps; everybody else sees what they registered. One statement answers
-	// both, on the IncludeHubWide flag.
-	params.IncludeHubWide = user.IsAdmin
+	// every shape, on the IncludeHubWide and HubWideOnly flags. A request
+	// that names one reach narrows it: the administration panel asks for
+	// the catalogue alone, so an administrator's own private rows do not
+	// cross the wire only to be discarded by a panel that cannot draw them.
+	switch vis := req.Msg.GetVisibility(); vis {
+	case leapmuxv1.AppVisibility_APP_VISIBILITY_UNSPECIFIED:
+		params.IncludeHubWide = user.IsAdmin
+	case leapmuxv1.AppVisibility_APP_VISIBILITY_PRIVATE:
+		params.IncludeHubWide = false
+	case leapmuxv1.AppVisibility_APP_VISIBILITY_HUB_WIDE:
+		if !user.IsAdmin {
+			return nil, connect.NewError(connect.CodePermissionDenied,
+				errors.New("only an administrator may list the hub-wide catalogue"))
+		}
+		params.HubWideOnly = true
+	default:
+		return nil, connect.NewError(connect.CodeInvalidArgument,
+			fmt.Errorf("unknown app visibility: %s", vis))
+	}
 	page, err := s.store.OAuthClients().List(ctx, params)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("list apps: %w", err))

--- a/backend/internal/hub/service/app_service_test.go
+++ b/backend/internal/hub/service/app_service_test.go
@@ -209,6 +209,54 @@ func TestAppService_HubWideAppNeedsAnAdministrator(t *testing.T) {
 	assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
 }
 
+// The reach filter, on the listing question it answers: HUB_WIDE asks for
+// the catalogue alone -- the administration panel's listing -- and PRIVATE
+// for the caller's own registrations, so a surface that draws one reach
+// does not fetch and discard the other. The catalogue's listing is an
+// administrator's alone, like every other question about editing it.
+func TestAppService_ReachFilterNarrowsTheListing(t *testing.T) {
+	t.Parallel()
+
+	env := setupAppService(t)
+	ctx := context.Background()
+	mine := env.registerApp(t, env.admin, "admin-private", nil)
+	shared := env.registerApp(t, env.admin, "hub-app", func(m *leapmuxv1.RegisterAppRequest) {
+		m.Visibility = leapmuxv1.AppVisibility_APP_VISIBILITY_HUB_WIDE
+	})
+
+	ids := func(resp *connect.Response[leapmuxv1.ListAppsResponse]) map[string]bool {
+		out := map[string]bool{}
+		for _, a := range resp.Msg.GetApps() {
+			out[a.GetClientId()] = true
+		}
+		return out
+	}
+
+	catalogue, err := env.client.ListApps(ctx, authedReq(&leapmuxv1.ListAppsRequest{
+		Visibility: leapmuxv1.AppVisibility_APP_VISIBILITY_HUB_WIDE,
+	}, env.admin))
+	require.NoError(t, err)
+	assert.True(t, ids(catalogue)[shared.GetApp().GetClientId()],
+		"the hub-wide listing answers with the catalogue")
+	assert.False(t, ids(catalogue)[mine.GetApp().GetClientId()],
+		"an administrator's own private registration must not ride along")
+
+	private, err := env.client.ListApps(ctx, authedReq(&leapmuxv1.ListAppsRequest{
+		Visibility: leapmuxv1.AppVisibility_APP_VISIBILITY_PRIVATE,
+	}, env.admin))
+	require.NoError(t, err)
+	assert.True(t, ids(private)[mine.GetApp().GetClientId()])
+	assert.False(t, ids(private)[shared.GetApp().GetClientId()],
+		"the private listing is the caller's own registrations alone")
+
+	_, err = env.client.ListApps(ctx, authedReq(&leapmuxv1.ListAppsRequest{
+		Visibility: leapmuxv1.AppVisibility_APP_VISIBILITY_HUB_WIDE,
+	}, env.user))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err),
+		"an ordinary account asking for the catalogue's listing is refused")
+}
+
 // A non-administrator's app cannot even ASK for an admin permission.
 //
 // The ceiling is refused at REGISTRATION rather than at the consent screen. A

--- a/backend/internal/hub/service/auth_password_reset.go
+++ b/backend/internal/hub/service/auth_password_reset.go
@@ -75,7 +75,7 @@ func (s *AuthService) RequestPasswordReset(ctx context.Context, req *connect.Req
 	// credential-bearing reset link, and the hub never verified it.
 	//
 	// An unverified administrator self-recovers with ResendVerificationEmail
-	// plus VerifyEmail, which Preferences, Account offers beside the
+	// plus VerifyEmail, which Preferences › Account offers beside the
 	// "(unverified)" badge. Resend is the leg that seeds a pending row from
 	// the stored address; RequestEmailChange does NOT, because its
 	// administrator branch writes the new address straight to the email

--- a/backend/internal/hub/service/auth_service.go
+++ b/backend/internal/hub/service/auth_service.go
@@ -429,7 +429,7 @@ func (s *AuthService) SignUp(ctx context.Context, req *connect.Request[leapmuxv1
 // confirmed. The login gate takes its own exemption through
 // auth.EmailVerificationFacts.Satisfied, so nothing blocks the administrator
 // -- but Forgot password stays closed for that address until they verify it
-// from Preferences, Account.
+// from Preferences › Account.
 func (s *AuthService) signUpSetupMode(ctx context.Context, username, displayName, email, passwordHash string) (*connect.Response[leapmuxv1.SignUpResponse], error) {
 	// Re-check to handle the race condition where another request created a
 	// user between the initial check and now.

--- a/backend/internal/hub/service/oauth_server_authorize.go
+++ b/backend/internal/hub/service/oauth_server_authorize.go
@@ -141,7 +141,7 @@ func (h *OAuthServerHandler) handleAuthorize(w http.ResponseWriter, r *http.Requ
 		App:              appDisplay(req.app),
 		Username:         user.Username,
 		RedirectLabel:    redirectLabel(req.registeredURI, req.redirectURI),
-		Permissions:      describeScopes(req.scopes),
+		Permissions:      describeScopeCatalogue(req.scopes),
 		RedirectURI:      req.redirectURI,
 		ClientID:         req.app.ClientID,
 		State:            req.state,

--- a/backend/internal/hub/service/oauth_server_device.go
+++ b/backend/internal/hub/service/oauth_server_device.go
@@ -217,7 +217,7 @@ func (h *OAuthServerHandler) renderDevicePage(w http.ResponseWriter, r *http.Req
 			data.App = &display
 			asked, parseErr := authscope.Parse(grant.RequestedScopes)
 			if parseErr == nil {
-				data.Permissions = describeScopes(asked)
+				data.Permissions = describeScopeCatalogue(asked)
 			}
 		}
 	}
@@ -310,7 +310,7 @@ func (h *OAuthServerHandler) approveOrDenyDevice(w http.ResponseWriter, r *http.
 			writePage(w, http.StatusOK, devicePageTmpl, devicePageData{
 				UserCode:     normalized,
 				App:          &display,
-				Permissions:  describeScopes(scopes),
+				Permissions:  describeScopeCatalogue(scopes),
 				ConfirmAdmin: true,
 			}, "")
 			return

--- a/backend/internal/hub/service/oauth_server_pages.go
+++ b/backend/internal/hub/service/oauth_server_pages.go
@@ -31,10 +31,190 @@ import (
 //
 // The style is inline and plain on purpose: the Go mux serves these outside the
 // SPA and its stylesheet.
+//
+// WHAT the style says is the app's own look, restated: the token values below
+// are a copy of LeapMux's DEFAULT palette pair (frontend
+// src/styles/themes/default.ts), and the rules are Oat's component shapes in
+// the subset of CSS a script-free page needs. The palette cannot be LINKED
+// here -- `default-src 'none'` is the defence that makes these pages safe to
+// render for a stranger arriving from a terminal -- so it is stated in the
+// document, and a reader's chosen variant cannot follow them: that choice
+// lives in the SPA's per-account storage, which these pages have no script to
+// read. The page follows the DEFAULT pair and the system's light/dark
+// preference, which is as close as a server-rendered page can come. When the
+// default palette changes, change the copy with it.
+
+// pageCSS is every page's stylesheet: the default palette as custom
+// properties (light, then dark under the system preference) and the shared
+// component rules. One copy, inside the chrome, so no page can drift.
+const pageCSS = `
+:root {
+  color-scheme: light dark;
+  --background: rgb(255 254 252);
+  --foreground: rgb(34 32 30);
+  --card: rgb(247 245 242);
+  --border: rgb(221 217 211);
+  --input: rgb(213 209 203);
+  --muted: rgb(237 235 231);
+  --muted-foreground: rgb(120 117 111);
+  --primary: rgb(13 148 136);
+  --primary-foreground: rgb(255 255 255);
+  --accent: rgb(222 235 225);
+  --danger: rgb(220 74 68);
+  --danger-subtle: rgb(253 235 233);
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: rgb(26 25 23);
+    --foreground: rgb(232 230 225);
+    --card: rgb(42 40 38);
+    --border: rgb(61 58 54);
+    --input: rgb(61 58 54);
+    --muted: rgb(46 43 40);
+    --muted-foreground: rgb(138 134 128);
+    --primary: rgb(20 184 166);
+    --primary-foreground: rgb(12 12 11);
+    --accent: rgb(45 62 50);
+    --danger: rgb(239 83 80);
+    --danger-subtle: rgb(50 30 28);
+  }
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  padding: 48px 16px;
+  background: var(--background);
+  color: var(--foreground);
+  font: 14px/1.5 system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+main { max-width: 520px; margin: 0 auto; }
+.card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 24px;
+}
+h1 { font-size: 20px; font-weight: 600; margin: 0 0 16px; }
+p { margin: 0 0 12px; }
+ul { margin: 0 0 12px; padding-left: 24px; }
+.alert {
+  border: 1px solid var(--danger);
+  background: var(--danger-subtle);
+  color: var(--danger);
+  padding: 8px 12px;
+  border-radius: 6px;
+  margin: 0 0 12px;
+}
+.identity { display: flex; align-items: center; gap: 12px; margin: 0 0 12px; }
+.identity img, .monogram { width: 48px; height: 48px; border-radius: 8px; flex: none; }
+.monogram {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--muted);
+  color: var(--muted-foreground);
+  font-size: 24px;
+}
+.identity strong { font-size: 18px; }
+.actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 24px; }
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 16px;
+  font: 500 14px/1.5 system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: var(--primary);
+  color: var(--primary-foreground);
+  border: 1px solid transparent;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.btn:hover { background: color-mix(in srgb, var(--primary), white 25%); }
+.btn-outline { background: transparent; color: var(--foreground); border-color: var(--border); }
+.btn-outline:hover { background: var(--accent); }
+.code-input {
+  width: 100%;
+  font: 24px/1.5 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  letter-spacing: 2px;
+  text-align: center;
+  padding: 8px;
+  background: var(--background);
+  color: var(--foreground);
+  border: 1px solid var(--input);
+  border-radius: 6px;
+}
+main.wide { max-width: 680px; }
+.scopes { list-style: none; margin: 0 0 12px; padding: 0; display: grid; gap: 10px; }
+.scope-category { display: block; font-weight: 600; margin-bottom: 4px; }
+.scopes ul { list-style: none; margin: 0; padding: 0; display: grid; gap: 4px; }
+/*
+ * The ENTRY row alone, never the family <li> around it. A ".scopes li"
+ * selector styled both levels as one flex row, and a narrow family (File,
+ * one short row) then laid that row BESIDE its label while wide families
+ * wrapped theirs under -- the label must always stand on its own line.
+ *
+ * NOWRAP is what keeps a description beside its token: with flex-wrap, a
+ * browser places items by their FULL content width before shrinking ever
+ * applies, so a long sentence moved to a line of its own however small its
+ * min-width. Unwrapped, the sentence is the one item that may shrink, and
+ * its text wraps INSIDE its own box, always starting beside the token.
+ */
+.scopes ul > li { display: flex; align-items: flex-start; gap: 8px; }
+/*
+ * The tick mark, restating Oat's own checkbox rule piece for piece -- 1rem
+ * square, radius-small corners, primary fill, and the check drawn through
+ * the same SVG mask in the primary foreground -- so the mark a consent page
+ * draws is pixel-identical to the checkbox the Preferences dialog ticks.
+ * A native checkbox could not be used: the disabled state that makes it a
+ * mark instead of a control is the one state every browser paints in its
+ * own grey, accent-color or not, and a dimmed tick contradicted the legend.
+ */
+.tick {
+  flex: none;
+  width: 1rem;
+  height: 1rem;
+  margin-top: 2px;
+  position: relative;
+  background-color: var(--background);
+  border: 1px solid var(--input);
+  border-radius: 0.125rem;
+}
+.granted > .tick { background-color: var(--primary); border-color: var(--primary); }
+.granted > .tick::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-color: var(--primary-foreground);
+  mask-position: center;
+  mask-repeat: no-repeat;
+  mask-size: 100%;
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='4'%3E%3Cpolyline points='20 6 9 17 4 12'/%3E%3C/svg%3E");
+}
+.scope-token { flex: none; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 13px; }
+.scope-sentence { flex: 1 1 0; min-width: 0; color: var(--muted-foreground); font-size: 13px; }
+.not-granted { opacity: 0.55; }
+/* The screen-reader spelling of the tick, for the mark itself is decorative. */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+.scope-note { color: var(--muted-foreground); font-size: 12px; }
+`
 
 // pageChrome wraps each page's body, so the shell exists in one place.
-const pageChrome = `<!doctype html><html><body style="font-family:sans-serif;max-width:520px;margin:48px auto;line-height:1.5;">
+const pageChrome = `<!doctype html><html><head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>LeapMux</title>
+<style>` + pageCSS + `</style>
+</head><body>
+<main class="card {{block "pageClass" .}}{{end}}">
 {{block "body" .}}{{end}}
+</main>
 </body></html>`
 
 // consentPageTmpl is the authorization-code consent form.
@@ -52,15 +232,14 @@ const pageChrome = `<!doctype html><html><body style="font-family:sans-serif;max
 // The hidden fields carry the whole request back to handleConsent, which
 // re-validates every one of them: the form is attacker-writable, and having
 // rendered a page makes nothing that comes back trustworthy.
-var consentPageTmpl = mustParsePage("consent", `{{define "body"}}
+var consentPageTmpl = mustParsePage("consent", `{{define "pageClass"}} wide{{end}}{{define "body"}}
 {{if .App.Verified}}<h1>Authorize {{.App.Name}}?</h1>
 {{else}}<h1>Authorize an unverified app?</h1>
-<p style="padding:8px 12px;border:1px solid #c00;border-radius:4px;">Nobody verified this app on this hub. It says its name is &ldquo;{{.App.Name}}&rdquo;. Continue only if you started this yourself.</p>
+<p class="alert">Nobody verified this app on this hub. It says its name is &ldquo;{{.App.Name}}&rdquo;. Continue only if you started this yourself.</p>
 {{end}}
 {{template "appIdentity" .App}}
 <p>It asks to use your account (<strong>{{.Username}}</strong>) and will return to {{.RedirectLabel}}.</p>
-{{if .Permissions}}<p>It would be able to:</p>
-<ul>{{range .Permissions}}<li>{{.}}</li>{{end}}</ul>
+{{if .Permissions}}{{template "permissions" .Permissions}}
 {{else}}<p>It asks for no permissions at all, so it would be able to do nothing with your account.</p>
 {{end}}
 <form method="POST" action="/oauth/consent">
@@ -72,8 +251,10 @@ var consentPageTmpl = mustParsePage("consent", `{{define "body"}}
   <input type="hidden" name="code_challenge" value="{{.CodeChallenge}}"/>
   <input type="hidden" name="scope" value="{{.Scope}}"/>
   <input type="hidden" name="installation_name" value="{{.InstallationName}}"/>
-  <button type="submit" name="decision" value="deny" style="padding:10px 16px;font-size:14px;">Deny</button>
-  <button type="submit" name="decision" value="allow" style="padding:10px 16px;font-size:14px;margin-left:8px;">Allow</button>
+  <div class="actions">
+    <button type="submit" name="decision" value="deny" class="btn btn-outline">Deny</button>
+    <button type="submit" name="decision" value="allow" class="btn">Allow</button>
+  </div>
 </form>
 {{end}}`)
 
@@ -82,11 +263,30 @@ var consentPageTmpl = mustParsePage("consent", `{{define "body"}}
 // A VERIFIED app shows its stored icon, served from this origin so the page's
 // img-src stays 'self'. An UNVERIFIED one shows a MONOGRAM -- the first letter
 // of its name in a neutral square -- which fetches nothing at all, so an
-// unverified registrant can neither borrow a well-known icon nor learn when the
-// consent page rendered and from which address.
+// unverified registrant can neither borrow a well-known icon nor learn when
+// the consent page rendered and from which address.
 const appIdentityTmpl = `{{define "appIdentity"}}
-<p>{{if .HasIcon}}<img src="/oauth/apps/{{.ClientID}}/icon" alt="" width="48" height="48" style="vertical-align:middle;border-radius:8px;"/>{{else}}<span aria-hidden="true" style="display:inline-block;width:48px;height:48px;line-height:48px;text-align:center;border-radius:8px;background:#e5e5e5;font-size:24px;vertical-align:middle;">{{.Monogram}}</span>{{end}}
-<strong style="margin-left:12px;font-size:18px;">{{.Name}}</strong></p>
+<p class="identity">{{if .HasIcon}}<img src="/oauth/apps/{{.ClientID}}/icon" alt="" width="48" height="48"/>{{else}}<span aria-hidden="true" class="monogram">{{.Monogram}}</span>{{end}}
+<strong>{{.Name}}</strong></p>
+{{end}}`
+
+// permissionsTmpl renders a grant as the WHOLE grantable vocabulary grouped
+// by family, the same shape the Preferences dialog's "Permissions this app
+// may ask for" list uses: the asked-for permissions ticked, the rest dimmed.
+//
+// The tick is a CSS-DRAWN mark, not a disabled native checkbox: browsers
+// paint disabled controls in their own grey whatever accent-color says, and
+// a tick that reads dimmed contradicts the legend beneath it. The mark is
+// decorative (aria-hidden); the granted/not-granted fact reaches a screen
+// reader as visually-hidden words beside the sentence.
+const permissionsTmpl = `{{define "permissions"}}
+<p>It would be able to:</p>
+<ul class="scopes">{{range .}}
+<li><span class="scope-category">{{.Label}}</span><ul>{{range .Entries}}
+<li class="{{if .Granted}}granted{{else}}not-granted{{end}}"><span class="tick" aria-hidden="true"></span><span class="scope-token">{{.Token}}</span><span class="scope-sentence">{{.Sentence}}<span class="visually-hidden"> ({{if .Granted}}granted{{else}}not granted{{end}})</span></span></li>{{end}}
+</ul></li>{{end}}
+</ul>
+<p class="scope-note">The app asks only for the ticked permissions. The dimmed permissions are not granted.</p>
 {{end}}`
 
 // devicePageTmpl is the device-code entry form, for the flow that runs when the
@@ -98,23 +298,25 @@ const appIdentityTmpl = `{{define "appIdentity"}}
 // registration supplies. A step-up that fell back to a requester-chosen label
 // would let a stolen credential label its own step-up with the owner's laptop
 // name.
-var devicePageTmpl = mustParsePage("device", `{{define "body"}}
+var devicePageTmpl = mustParsePage("device", `{{define "pageClass"}} wide{{end}}{{define "body"}}
 <h1>{{if .Elevating}}Verify an app credential{{else}}Authorize an app{{end}}</h1>
 {{if .Elevating}}<p>This grants an existing app credential the right to make sensitive changes for the next two hours. It issues nothing new.</p>
 {{with .Credential}}<p>The credential is <strong>{{.Name}}</strong>, added {{.Added}} (UTC).{{if .Revoked}} It was revoked, so verifying it grants nothing.{{end}}</p>
-{{end}}{{else if .App}}{{if not .App.Verified}}<p style="padding:8px 12px;border:1px solid #c00;border-radius:4px;">Nobody verified this app on this hub. It says its name is &ldquo;{{.App.Name}}&rdquo;.</p>
+{{end}}{{else if .App}}{{if not .App.Verified}}<p class="alert">Nobody verified this app on this hub. It says its name is &ldquo;{{.App.Name}}&rdquo;.</p>
 {{end}}{{template "appIdentity" .App}}
-{{if .ConfirmAdmin}}<p style="padding:8px 12px;border:1px solid #c00;border-radius:4px;">This code asks for <strong>hub administration</strong>. Authorizing it grants the app administrator authority over this hub. Continue only if you started this request yourself and meant to grant it.</p>
+{{if .ConfirmAdmin}}<p class="alert">This code asks for <strong>hub administration</strong>. Authorizing it grants the app administrator authority over this hub. Continue only if you started this request yourself and meant to grant it.</p>
 {{end}}
-{{if .Permissions}}<p>It would be able to:</p>
-<ul>{{range .Permissions}}<li>{{.}}</li>{{end}}</ul>
+{{if .Permissions}}{{template "permissions" .Permissions}}
+{{else}}<p>It asks for no permissions at all, so it would be able to do nothing with your account.</p>
 {{end}}{{end}}<p>Enter the code that the app shows:</p>
 <form method="POST" action="/oauth/device">
-<input name="user_code" value="{{.UserCode}}" pattern="[A-Za-z0-9-]{6,8}" autofocus required style="font-size:24px;letter-spacing:2px;text-align:center;width:100%;padding:8px;"/>
+<input name="user_code" value="{{.UserCode}}" pattern="[A-Za-z0-9-]{6,8}" autofocus required class="code-input"/>
 {{if .ConfirmAdmin}}<input type="hidden" name="admin_confirmed" value="1"/>
 {{end}}
-<p style="margin-top:16px;"><button type="submit" name="decision" value="deny" style="padding:10px 16px;">Deny</button>
-<button type="submit" name="decision" value="allow" style="padding:10px 16px;margin-left:8px;">Authorize</button></p>
+<div class="actions">
+<button type="submit" name="decision" value="deny" class="btn btn-outline">Deny</button>
+<button type="submit" name="decision" value="allow" class="btn">Authorize</button>
+</div>
 </form>
 {{end}}`)
 
@@ -158,7 +360,7 @@ type invalidRequestPageData struct {
 // text is a constant, so a failure is a programming error present at every
 // start rather than a condition a request can reach.
 func mustParsePage(name, body string) *template.Template {
-	return template.Must(template.New(name).Parse(pageChrome + appIdentityTmpl + body))
+	return template.Must(template.New(name).Parse(pageChrome + appIdentityTmpl + permissionsTmpl + body))
 }
 
 // appDisplayData is what a page says about one app. Every field comes from the
@@ -210,7 +412,7 @@ type consentPageData struct {
 	App              appDisplayData
 	Username         string
 	RedirectLabel    string
-	Permissions      []string
+	Permissions      []scopeCategoryView
 	RedirectURI      string
 	ClientID         string
 	State            string
@@ -238,7 +440,7 @@ type deviceCredential struct {
 type devicePageData struct {
 	UserCode    string
 	App         *appDisplayData
-	Permissions []string
+	Permissions []scopeCategoryView
 	// ConfirmAdmin re-renders the page as the SECOND step of an
 	// admin-reaching ask: the first Allow returned this page with the admin
 	// sentences stated beside a caution, and the form now carries
@@ -287,25 +489,125 @@ var scopeSentences = map[leapmuxv1.Scope]string{
 	leapmuxv1.Scope_SCOPE_ADMIN_APPS:      "Register, edit, vouch, retire and delete the hub's app registrations.",
 }
 
-// describeScopes renders a grant as the sentences a consent screen lists.
+// scopeCategories groups the grantable vocabulary the way scope.proto's own
+// sections do -- the same families the Preferences dialog's "Permissions this
+// app may ask for" list renders. A consent screen that grouped by anything
+// else would answer a question nobody asked.
 //
-// The order is the SET's canonical order, so two apps asking for the same
-// permissions show the same list. A scope with no sentence is dropped rather
-// than rendered as a token: the suite already fails for a missing one, so
-// reaching this branch means the vocabulary grew between a release and a
-// deployment, and a bullet a person cannot read is worse than one fewer.
-func describeScopes(set authscope.ScopeSet) []string {
-	scopes := set.Scopes()
+// ORDER is render order, and the membership is pinned by test: every
+// grantable scope appears exactly once, so a scope added to the proto fails
+// the suite until somebody writes its family here.
+var scopeCategories = []struct {
+	label  string
+	scopes []leapmuxv1.Scope
+}{
+	{"Account", []leapmuxv1.Scope{
+		leapmuxv1.Scope_SCOPE_ACCOUNT_READ,
+		leapmuxv1.Scope_SCOPE_ACCOUNT_WRITE,
+	}},
+	{"Workspace", []leapmuxv1.Scope{
+		leapmuxv1.Scope_SCOPE_WORKSPACE_READ,
+		leapmuxv1.Scope_SCOPE_WORKSPACE_WRITE,
+	}},
+	{"Worker", []leapmuxv1.Scope{
+		leapmuxv1.Scope_SCOPE_WORKER_READ,
+		leapmuxv1.Scope_SCOPE_WORKER_ADMIN,
+	}},
+	{"Agent", []leapmuxv1.Scope{
+		leapmuxv1.Scope_SCOPE_AGENT_READ,
+		leapmuxv1.Scope_SCOPE_AGENT_WRITE,
+	}},
+	{"Terminal", []leapmuxv1.Scope{
+		leapmuxv1.Scope_SCOPE_TERMINAL_READ,
+		leapmuxv1.Scope_SCOPE_TERMINAL_WRITE,
+	}},
+	{"File", []leapmuxv1.Scope{
+		leapmuxv1.Scope_SCOPE_FILE_READ,
+	}},
+	{"Git", []leapmuxv1.Scope{
+		leapmuxv1.Scope_SCOPE_GIT_READ,
+		leapmuxv1.Scope_SCOPE_GIT_WRITE,
+	}},
+	{"Tunnel", []leapmuxv1.Scope{
+		leapmuxv1.Scope_SCOPE_TUNNEL_OPEN,
+	}},
+	{"Hub administration", []leapmuxv1.Scope{
+		leapmuxv1.Scope_SCOPE_ADMIN_READ,
+		leapmuxv1.Scope_SCOPE_ADMIN_USERS,
+		leapmuxv1.Scope_SCOPE_ADMIN_SETTINGS,
+		leapmuxv1.Scope_SCOPE_ADMIN_WORKERS,
+		leapmuxv1.Scope_SCOPE_ADMIN_APPS,
+	}},
+}
+
+// scopeEntryView is one permission on a decision page: the wire token a
+// developer knows, the sentence a person acts on, and whether THIS grant
+// carries it.
+type scopeEntryView struct {
+	Token    string
+	Sentence string
+	Granted  bool
+}
+
+// scopeCategoryView is one family of permissions, as the page renders it.
+type scopeCategoryView struct {
+	Label   string
+	Entries []scopeEntryView
+}
+
+// describeScopeCatalogue renders a grant as the whole grantable vocabulary,
+// grouped by family, with the asked-for permissions ticked and the rest
+// dimmed.
+//
+// The WHOLE catalogue, not only the ask, because "which permission is NOT
+// granted" is half of what a reader deciding needs: a list of granted
+// sentences answers "what does it do" while leaving "does it also administer
+// my hub" to the imagination. The dimmed rows close that question without a
+// sentence of prose per negative.
+//
+// Categories with nothing granted are SKIPPED: a consent screen that listed
+// "Tunnel -- none" for an app that asked to read files would spend the
+// reader's attention on families that carry no decision. The empty GRANT is
+// still the caller's to state in prose (the page says "no permissions at
+// all" rather than rendering nineteen dimmed rows).
+func describeScopeCatalogue(set authscope.ScopeSet) []scopeCategoryView {
+	granted := map[leapmuxv1.Scope]bool{}
+	// No app ever holds an unscoped grant, but a page that rendered one as
+	// "no permissions at all" would be a silent lie about what was asked for:
+	// unscoped is the absence of a limit, not the absence of permissions.
 	if set.IsUnscoped() {
-		// No app ever holds an unscoped grant, but a page that rendered one as
-		// "SCOPE_ALL" would be a silent lie about what was asked for.
-		scopes = authscope.Grantable()
-	}
-	out := make([]string, 0, len(scopes))
-	for _, scope := range scopes {
-		if sentence, ok := scopeSentences[scope]; ok {
-			out = append(out, sentence)
+		for _, scope := range authscope.Grantable() {
+			granted[scope] = true
 		}
+	}
+	for _, scope := range set.Scopes() {
+		granted[scope] = true
+	}
+	out := make([]scopeCategoryView, 0, len(scopeCategories))
+	for _, category := range scopeCategories {
+		entries := make([]scopeEntryView, 0, len(category.scopes))
+		familyGranted := false
+		for _, scope := range category.scopes {
+			sentence := scopeSentences[scope]
+			isGranted := granted[scope]
+			familyGranted = familyGranted || isGranted
+			// The catalogue's membership test pins every entry to a grantable
+			// scope, so Token always answers here; the enum-name fallback is
+			// what a future drift renders while that test fails the build.
+			token, ok := authscope.Token(scope)
+			if !ok {
+				token = scope.String()
+			}
+			entries = append(entries, scopeEntryView{
+				Token:    token,
+				Sentence: sentence,
+				Granted:  isGranted,
+			})
+		}
+		if !familyGranted {
+			continue
+		}
+		out = append(out, scopeCategoryView{Label: category.label, Entries: entries})
 	}
 	return out
 }

--- a/backend/internal/hub/service/oauth_server_pages_internal_test.go
+++ b/backend/internal/hub/service/oauth_server_pages_internal_test.go
@@ -37,7 +37,7 @@ func TestConsentPagesEscapeEveryInterpolatedValue(t *testing.T) {
 			App:              appDisplayData{ClientID: payload, Name: payload, Monogram: payload},
 			Username:         payload,
 			RedirectLabel:    payload,
-			Permissions:      []string{payload},
+			Permissions:      []scopeCategoryView{{Label: payload, Entries: []scopeEntryView{{Token: payload, Sentence: payload}}}},
 			RedirectURI:      payload,
 			ClientID:         payload,
 			State:            payload,
@@ -58,7 +58,7 @@ func TestConsentPagesEscapeEveryInterpolatedValue(t *testing.T) {
 		writePage(w, 200, devicePageTmpl, devicePageData{
 			UserCode:    payload,
 			App:         &app,
-			Permissions: []string{payload},
+			Permissions: []scopeCategoryView{{Label: payload, Entries: []scopeEntryView{{Token: payload, Sentence: payload}}}},
 		}, "")
 		assertNoInjection(t, w.Body.String())
 	})
@@ -261,8 +261,11 @@ func TestEveryPageSharesOneChrome(t *testing.T) {
 		w := httptest.NewRecorder()
 		writePage(w, 200, tc.tmpl, tc.data, "")
 		page := w.Body.String()
-		assert.Truef(t, strings.HasPrefix(page, "<!doctype html><html><body style="), "page %q", tc.name)
-		assert.Truef(t, strings.HasSuffix(strings.TrimSpace(page), "</body></html>"), "page %q", tc.name)
+		// The chrome prefix now carries the shared <style> block; the suffix
+		// still closes the card, body and html the chrome opens.
+		assert.Truef(t, strings.HasPrefix(page, "<!doctype html><html><head>"), "page %q", tc.name)
+		assert.Truef(t, strings.Contains(page, "<style>"), "page %q carries the one stylesheet", tc.name)
+		assert.Truef(t, strings.HasSuffix(strings.TrimSpace(page), "</main>\n</body></html>"), "page %q", tc.name)
 	}
 }
 
@@ -284,23 +287,55 @@ func TestEveryGrantableScopeHasASentence(t *testing.T) {
 	}
 }
 
-// TestDescribeScopesUsesTheCanonicalOrder pins that two apps asking for the
-// same permissions show the same list.
-func TestDescribeScopesUsesTheCanonicalOrder(t *testing.T) {
+// TestScopeCategoriesCoverEveryGrantableScope is the catalogue's membership
+// pin: a scope added to the proto fails here until somebody states its
+// family, and one removed fails here rather than lingering as a row the page
+// renders for a permission no account can grant.
+func TestScopeCategoriesCoverEveryGrantableScope(t *testing.T) {
+	t.Parallel()
+
+	seen := map[leapmuxv1.Scope]int{}
+	for _, category := range scopeCategories {
+		assert.NotEmptyf(t, category.label, "a category carries a label")
+		for _, scope := range category.scopes {
+			seen[scope]++
+			_, hasToken := authscope.Token(scope)
+			assert.Truef(t, hasToken, "%s has no wire token", scope)
+			assert.NotEmptyf(t, scopeSentences[scope], "%s has no consent-screen sentence", scope)
+		}
+	}
+	for _, scope := range authscope.Grantable() {
+		assert.Equalf(t, 1, seen[scope], "%s must appear in exactly one category", scope)
+	}
+}
+
+// TestDescribeScopeCatalogue pins the two properties the page leans on: the
+// asked-for permissions are the ticked ones, and a family with nothing
+// granted is skipped rather than rendered as a wall of dimmed rows.
+func TestDescribeScopeCatalogue(t *testing.T) {
 	t.Parallel()
 
 	set := authscope.MustNew(
 		leapmuxv1.Scope_SCOPE_GIT_READ,
 		leapmuxv1.Scope_SCOPE_ACCOUNT_READ,
-		leapmuxv1.Scope_SCOPE_TERMINAL_READ,
 	)
-	assert.Equal(t, []string{
-		scopeSentences[leapmuxv1.Scope_SCOPE_ACCOUNT_READ],
-		scopeSentences[leapmuxv1.Scope_SCOPE_TERMINAL_READ],
-		scopeSentences[leapmuxv1.Scope_SCOPE_GIT_READ],
-	}, describeScopes(set))
+	out := describeScopeCatalogue(set)
 
-	assert.Empty(t, describeScopes(authscope.ScopeSet{}),
+	// Family order is the catalogue's own, and only the two touched families
+	// render.
+	require.Len(t, out, 2)
+	assert.Equal(t, "Account", out[0].Label)
+	assert.Equal(t, "Git", out[1].Label)
+
+	accountRead := out[0].Entries[0]
+	assert.True(t, accountRead.Granted)
+	assert.Equal(t, "account:read", accountRead.Token)
+	assert.Equal(t, scopeSentences[leapmuxv1.Scope_SCOPE_ACCOUNT_READ], accountRead.Sentence)
+	assert.False(t, out[0].Entries[1].Granted,
+		"the write half of the family is the NOT-GRANTED half the page dims")
+	assert.True(t, out[1].Entries[0].Granted)
+
+	assert.Empty(t, describeScopeCatalogue(authscope.ScopeSet{}),
 		"an empty grant lists nothing, and the page says so in prose instead")
 }
 

--- a/backend/internal/hub/service/oauth_server_palette_internal_test.go
+++ b/backend/internal/hub/service/oauth_server_palette_internal_test.go
@@ -1,0 +1,144 @@
+package service
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The OAuth pages state the default palette inline because `default-src
+// 'none'` forbids linking the SPA's stylesheet (see the pageCSS comment).
+// That makes the Go copy a hand-kept mirror of
+// frontend/src/styles/themes/default.ts, and a theme edit that forgets the
+// copy leaves the authorization screens a release behind the app with no
+// test failing. This test is the pin: every token pageCSS states must equal
+// the default palette's value for the same token, in both polarities.
+//
+// The page renames one token: the page's --danger-subtle is the palette's
+// --lm-danger-subtle (the page has no lm- namespace to keep).
+
+// palettePath is the default palette, relative to this package's directory.
+const palettePath = "../../../../frontend/src/styles/themes/default.ts"
+
+// tokenValuePattern matches one `'--token': 'value',` line of default.ts.
+var tokenValuePattern = regexp.MustCompile(`'(--[a-z0-9-]+)':\s*'([^']+)'`)
+
+// pageTokenPattern matches one `--token: value;` line of pageCSS.
+var pageTokenPattern = regexp.MustCompile(`(--[a-z0-9-]+):\s*([^;]+);`)
+
+// paletteVariant extracts the named variant object (`light` or `dark`) from
+// default.ts as a token map.
+func paletteVariant(t *testing.T, source, variant string) map[string]string {
+	t.Helper()
+	start := strings.Index(source, "const "+variant+" = {")
+	require.GreaterOrEqualf(t, start, 0,
+		"default.ts no longer declares a %s palette object", variant)
+	end := strings.Index(source[start:], "\n}")
+	require.NotEqualf(t, -1, end,
+		"default.ts no longer closes its %s palette object", variant)
+	out := map[string]string{}
+	for _, m := range tokenValuePattern.FindAllStringSubmatch(source[start:start+end], -1) {
+		out[m[1]] = m[2]
+	}
+	return out
+}
+
+// pageVariant extracts the light (:root) or dark (@media) custom-property
+// block from pageCSS as a token map.
+func pageVariant(t *testing.T, css, opener string) map[string]string {
+	t.Helper()
+	start := strings.Index(css, opener)
+	require.GreaterOrEqualf(t, start, 0, "pageCSS no longer declares %q", opener)
+	block := css[start:]
+	if end := strings.Index(block, "}"); end >= 0 {
+		block = block[:end]
+	}
+	out := map[string]string{}
+	for _, m := range pageTokenPattern.FindAllStringSubmatch(block, -1) {
+		out[m[1]] = strings.TrimSpace(m[2])
+	}
+	return out
+}
+
+func TestPageCSSMatchesTheDefaultPalette(t *testing.T) {
+	raw, err := os.ReadFile(palettePath)
+	if err != nil {
+		// FAIL, not skip: the palette is a git-controlled source file, so a
+		// read failure means it moved or was renamed -- exactly the drift
+		// this pin exists to catch. (The Oat test below keeps its skip:
+		// node_modules is genuinely absent until `bun install`.)
+		t.Fatalf("default palette not reachable from this checkout: %v", err)
+	}
+	source := string(raw)
+
+	// The page's name for the palette's --lm-danger-subtle.
+	pageNameForToken := map[string]string{
+		"--danger-subtle": "--lm-danger-subtle",
+	}
+
+	for _, variant := range []struct{ page, palette string }{
+		{":root {", "light"},
+		{"@media (prefers-color-scheme: dark) {\n  :root {", "dark"},
+	} {
+		page := pageVariant(t, pageCSS, variant.page)
+		palette := paletteVariant(t, source, variant.palette)
+		require.NotEmptyf(t, page, "pageCSS %s block states no tokens", variant.palette)
+		for name, value := range page {
+			paletteName := pageNameForToken[name]
+			if paletteName == "" {
+				paletteName = name
+			}
+			want, ok := palette[paletteName]
+			if !ok {
+				assert.Failf(t, "unknown pageCSS token",
+					"pageCSS states %s, which the default %s palette does not define; "+
+						"the page may only restate palette tokens", name, variant.palette)
+				continue
+			}
+			assert.Equalf(t, want, value,
+				"pageCSS %s: change the copy with the palette (see the pageCSS comment)",
+				name)
+		}
+	}
+}
+
+// The page's .tick rules restate Oat's own checkbox piece for piece (see
+// the .tick comment in pageCSS), which makes them a second hand-kept copy
+// of @knadh/oat's form stylesheet. This test pins the copy the same way the
+// palette test pins the palette: the check the tick draws is the byte-exact
+// SVG mask Oat's checkbox draws, so an Oat release that reshapes its mark
+// fails the suite here instead of leaving every consent page's tick a
+// release behind the Preferences dialog's checkboxes.
+
+// oatFormCSSPath is Oat's form stylesheet, relative to this package.
+const oatFormCSSPath = "../../../../frontend/node_modules/@knadh/oat/css/form.css"
+
+// oatMaskPattern matches the mask-image URL inside Oat's checked-checkbox
+// rule (form.css nests it under `input[type=checkbox]`'s `&:checked::after`).
+var oatMaskPattern = regexp.MustCompile(
+	`input\[type=checkbox\][^}]*&:checked::after\s*\{[^}]*mask-image:\s*url\("([^"]+)"\)`)
+
+// pageMaskPattern matches the mask-image URL of the page's granted tick.
+var pageMaskPattern = regexp.MustCompile(
+	`\.granted > \.tick::after\s*\{[^}]*mask-image:\s*url\("([^"]+)"\)`)
+
+func TestPageTickMatchesTheOatCheckbox(t *testing.T) {
+	raw, err := os.ReadFile(oatFormCSSPath)
+	if err != nil {
+		t.Skipf("Oat form stylesheet not reachable from this checkout: %v", err)
+	}
+	oat := oatMaskPattern.FindStringSubmatch(string(raw))
+	require.Lenf(t, oat, 2,
+		"Oat's checkbox rule no longer states a checked mask-image URL; "+
+			"the .tick copy in pageCSS must follow whatever shape it took")
+	page := pageMaskPattern.FindStringSubmatch(pageCSS)
+	require.Lenf(t, page, 2,
+		"pageCSS no longer draws the granted tick through a mask-image URL")
+	assert.Equalf(t, oat[1], page[1],
+		"the consent page's tick must draw the same check as Oat's own checkbox "+
+			"(see the .tick comment in pageCSS); copy the new mask or restyle both")
+}

--- a/backend/internal/hub/service/oauth_server_stepup.go
+++ b/backend/internal/hub/service/oauth_server_stepup.go
@@ -86,7 +86,7 @@ func (h *OAuthServerHandler) handleStepUpAuthorization(w http.ResponseWriter, r 
 	}
 	if !row.ClientElevationAllowed {
 		writeOAuthError(w, http.StatusForbidden, "unauthorized_client",
-			"this app is not allowed to verify a factor; its owner can allow it under Preferences, Account, App registrations")
+			"this app is not allowed to verify a factor; its owner can allow it under Preferences › Apps › App registrations")
 		return
 	}
 	// The installation label is what the REQUESTER calls itself, and it

--- a/backend/internal/hub/service/scope_catalogue_mirror_internal_test.go
+++ b/backend/internal/hub/service/scope_catalogue_mirror_internal_test.go
@@ -1,0 +1,68 @@
+package service
+
+import (
+	"os"
+	"regexp"
+	"testing"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The grantable vocabulary is grouped into families twice: the consent
+// screen's scopeCategories table (this package) and the Preferences
+// dialog's SCOPE_CATEGORIES catalogue (frontend
+// src/components/settings/account/scopeCatalogue.ts). Each side's own tests
+// pin only totality against the enum, so a scope moved between families --
+// or a renamed family -- passed both suites while the two surfaces
+// disagreed. This test is the pin between them, in the same shape as the
+// impliedBy mirror (backend/internal/authscope): family order, labels, and
+// membership must match exactly.
+
+const scopeCataloguePath = "../../../../frontend/src/components/settings/account/scopeCatalogue.ts"
+
+// catalogueTokenPattern matches one `label: 'Family'` header or one
+// `scope: Scope.NAME` entry of SCOPE_CATEGORIES, in file order. The
+// ScopeEntry interface's own `scope: Scope` field states no enum name, so
+// it cannot match.
+var catalogueTokenPattern = regexp.MustCompile(`(?:label: '([^']+)'|scope: Scope\.([A-Z0-9_]+))`)
+
+func TestScopeCategoriesMatchTheFrontendCatalogue(t *testing.T) {
+	raw, err := os.ReadFile(scopeCataloguePath)
+	if err != nil {
+		// FAIL, not skip: the target is a git-controlled source file, so a
+		// read failure means it moved or was renamed -- exactly the drift
+		// this pin exists to catch.
+		t.Fatalf("frontend scope catalogue not reachable from this checkout: %v", err)
+	}
+	type family struct {
+		label  string
+		scopes []leapmuxv1.Scope
+	}
+	var got []family
+	for _, m := range catalogueTokenPattern.FindAllStringSubmatch(string(raw), -1) {
+		switch {
+		case m[1] != "":
+			got = append(got, family{label: m[1]})
+		case m[2] != "":
+			value, ok := leapmuxv1.Scope_value["SCOPE_"+m[2]]
+			require.Truef(t, ok,
+				"scopeCatalogue.ts states Scope.%s, which the proto enum does not define", m[2])
+			require.NotEmpty(t, got, "a scope entry appears before any family label")
+			got[len(got)-1].scopes = append(got[len(got)-1].scopes, leapmuxv1.Scope(value))
+		}
+	}
+	require.NotEmpty(t, got,
+		"SCOPE_CATEGORIES no longer parses; update this test's pattern with its new shape")
+
+	require.Lenf(t, got, len(scopeCategories),
+		"the consent screen and the Preferences catalogue state different family counts")
+	for i, want := range scopeCategories {
+		assert.Equalf(t, want.label, got[i].label,
+			"family %d: the Preferences catalogue labels it %q where the consent screen says %q",
+			i, got[i].label, want.label)
+		assert.Equal(t, want.scopes, got[i].scopes,
+			"family "+want.label+": the Preferences catalogue and the consent screen disagree on membership or order")
+	}
+}

--- a/backend/internal/hub/store/generated_params_internal_test.go
+++ b/backend/internal/hub/store/generated_params_internal_test.go
@@ -51,6 +51,7 @@ func TestGeneratedInterfaceParamsAreAllowlisted(t *testing.T) {
 			"CallerIsAdmin":  "the app-ownership predicate's administrator arm: a bare boolean parameter that no column types, and CASTing it would type it on postgres alone",
 			"IncludeRevoked": "the retired-row widening arm of the app listings: a bare boolean parameter that no column types, bound as bool by the dialect wrapper",
 			"IncludeHubWide": "the catalogue-widening arm of the one app listing: a bare boolean parameter that no column types, bound as bool by the dialect wrapper",
+			"HubWideOnly":    "the catalogue-narrowing arm of the one app listing (its CASE expression loses the decltype on every dialect): a bare boolean parameter that no column types, bound as bool by the dialect wrapper",
 			"IconBytes":      "COALESCE(LENGTH(icon_blob), 0) loses its decltype; read through sqlutil.CoerceInt64, never bound",
 			// The elevation slide's requested deadline sits inside min()
 			// in the SET clause, which carries no column type, and sqlc
@@ -67,12 +68,14 @@ func TestGeneratedInterfaceParamsAreAllowlisted(t *testing.T) {
 			"CallerIsAdmin":  "the app-ownership predicate's administrator arm: a bare boolean parameter that no column types, and CASTing it would type it on postgres alone",
 			"IncludeRevoked": "the retired-row widening arm of the app listings: a bare boolean parameter that no column types, bound as bool by the dialect wrapper",
 			"IncludeHubWide": "the catalogue-widening arm of the one app listing: a bare boolean parameter that no column types, bound as bool by the dialect wrapper",
+			"HubWideOnly":    "the catalogue-narrowing arm of the one app listing (its CASE expression loses the decltype on every dialect): a bare boolean parameter that no column types, bound as bool by the dialect wrapper",
 			"IconBytes":      "COALESCE(LENGTH(icon_blob), 0) loses its decltype; read through sqlutil.CoerceInt64, never bound",
 		},
 		postgresGenPkg: {
 			"CallerIsAdmin":  "the app-ownership predicate's administrator arm: a bare boolean parameter that no column types, and CASTing it would type it on postgres alone",
 			"IncludeRevoked": "the retired-row widening arm of the app listings: a bare boolean parameter that no column types, bound as bool by the dialect wrapper",
 			"IncludeHubWide": "the catalogue-widening arm of the one app listing: a bare boolean parameter that no column types, bound as bool by the dialect wrapper",
+			"HubWideOnly":    "the catalogue-narrowing arm of the one app listing (its CASE expression loses the decltype on every dialect): a bare boolean parameter that no column types, bound as bool by the dialect wrapper",
 			"IconBytes":      "COALESCE(LENGTH(icon_blob), 0) loses its decltype; read through sqlutil.CoerceInt64, never bound",
 		},
 		workerGenPkg: {},

--- a/backend/internal/hub/store/mysql/convert.go
+++ b/backend/internal/hub/store/mysql/convert.go
@@ -234,8 +234,8 @@ func listRegistrationKeysAdminParams(cursor string, limit int64, now sqltime.MyS
 	})
 }
 
-func listOAuthClientsParams(userID, cursor string, limit int64, includeRevoked, includeHubWide bool) (gendb.ListOAuthClientsParams, error) {
-	return withCursor(cursor, limit, func(ct sqltime.MySQLNullTime, cid sql.NullString, fl int32) gendb.ListOAuthClientsParams {
-		return gendb.ListOAuthClientsParams{UserID: sql.NullString{String: userID, Valid: true}, IncludeRevoked: includeRevoked, IncludeHubWide: includeHubWide, CursorTime: ct, CursorID: cid, Limit: fl}
+func listOAuthClientsParams(userID string, p store.ListOAuthClientsParams) (gendb.ListOAuthClientsParams, error) {
+	return withCursor(p.Cursor, p.Limit, func(ct sqltime.MySQLNullTime, cid sql.NullString, fl int32) gendb.ListOAuthClientsParams {
+		return gendb.ListOAuthClientsParams{UserID: sql.NullString{String: userID, Valid: true}, IncludeRevoked: p.IncludeRevoked, IncludeHubWide: p.IncludeHubWide, HubWideOnly: p.HubWideOnly, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }

--- a/backend/internal/hub/store/mysql/db/queries/oauth_clients.sql
+++ b/backend/internal/hub/store/mysql/db/queries/oauth_clients.sql
@@ -57,6 +57,10 @@ FROM oauth_clients WHERE client_id = sqlc.arg(client_id);
 -- AND their own apps; everybody else sees what they registered. Keyset on
 -- (created_at DESC, client_id DESC), riding idx_oauth_clients_owner.
 --
+-- hub_wide_only narrows the same statement to the catalogue alone: the
+-- administration panel's listing, which must not carry the administrator's
+-- own private rows only for the caller to discard them.
+--
 -- include_revoked widens the page to retired rows, which the "include retired"
 -- listing asks for; the default keeps the live-only shape every authorize
 -- surface reads. The explicit column list drops the icon bytes for the same
@@ -67,8 +71,11 @@ SELECT client_id, owner_user_id, created_by_user_id, secret_hash, client_name,
        verified_at, verified_by_user_id, created_at, updated_at, revoked_at
 FROM oauth_clients
 WHERE (revoked_at IS NULL OR sqlc.arg(include_revoked))
-  AND (owner_user_id = sqlc.arg(user_id)
-       OR (owner_user_id IS NULL AND sqlc.arg(include_hub_wide)))
+  AND (CASE WHEN sqlc.arg(hub_wide_only)
+       THEN owner_user_id IS NULL
+       ELSE (owner_user_id = sqlc.arg(user_id)
+             OR (owner_user_id IS NULL AND sqlc.arg(include_hub_wide)))
+       END)
   AND (sqlc.narg(cursor_time) IS NULL
        OR created_at < sqlc.narg(cursor_time)
        OR (created_at = sqlc.narg(cursor_time) AND client_id < sqlc.narg(cursor_id)))

--- a/backend/internal/hub/store/mysql/oauth_clients.go
+++ b/backend/internal/hub/store/mysql/oauth_clients.go
@@ -143,7 +143,7 @@ func (s *oauthClientStore) List(ctx context.Context, p store.ListOAuthClientsPar
 	}
 	return queryPage(ctx, p.Limit,
 		func() (gendb.ListOAuthClientsParams, error) {
-			return listOAuthClientsParams(owner, p.Cursor, p.Limit, p.IncludeRevoked, p.IncludeHubWide)
+			return listOAuthClientsParams(owner, p)
 		},
 		s.conn.q.ListOAuthClients, fromListRow)
 }

--- a/backend/internal/hub/store/postgres/convert.go
+++ b/backend/internal/hub/store/postgres/convert.go
@@ -255,8 +255,8 @@ func rowsAffected(tag pgconn.CommandTag, err error) (int64, error) {
 	return tag.RowsAffected(), nil
 }
 
-func listOAuthClientsParams(userID, cursor string, limit int64, includeRevoked, includeHubWide bool) (gendb.ListOAuthClientsParams, error) {
-	return withCursor(cursor, limit, func(ct pgtime.NullTime, cid pgtype.Text, fl int32) gendb.ListOAuthClientsParams {
-		return gendb.ListOAuthClientsParams{UserID: pgtype.Text{String: userID, Valid: true}, IncludeRevoked: includeRevoked, IncludeHubWide: includeHubWide, CursorTime: ct, CursorID: cid, Limit: fl}
+func listOAuthClientsParams(userID string, p store.ListOAuthClientsParams) (gendb.ListOAuthClientsParams, error) {
+	return withCursor(p.Cursor, p.Limit, func(ct pgtime.NullTime, cid pgtype.Text, fl int32) gendb.ListOAuthClientsParams {
+		return gendb.ListOAuthClientsParams{UserID: pgtype.Text{String: userID, Valid: true}, IncludeRevoked: p.IncludeRevoked, IncludeHubWide: p.IncludeHubWide, HubWideOnly: p.HubWideOnly, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }

--- a/backend/internal/hub/store/postgres/db/queries/oauth_clients.sql
+++ b/backend/internal/hub/store/postgres/db/queries/oauth_clients.sql
@@ -68,6 +68,10 @@ FROM oauth_clients WHERE client_id = sqlc.arg(client_id);
 -- AND their own apps; everybody else sees what they registered. Keyset on
 -- (created_at DESC, client_id DESC), riding idx_oauth_clients_owner.
 --
+-- hub_wide_only narrows the same statement to the catalogue alone: the
+-- administration panel's listing, which must not carry the administrator's
+-- own private rows only for the caller to discard them.
+--
 -- include_revoked widens the page to retired rows, which the "include retired"
 -- listing asks for; the default keeps the live-only shape every authorize
 -- surface reads. The explicit column list drops the icon bytes for the same
@@ -78,8 +82,11 @@ SELECT client_id, owner_user_id, created_by_user_id, secret_hash, client_name,
        verified_at, verified_by_user_id, created_at, updated_at, revoked_at
 FROM oauth_clients
 WHERE (revoked_at IS NULL OR sqlc.arg(include_revoked))
-  AND (owner_user_id = sqlc.arg(user_id)
-       OR (owner_user_id IS NULL AND sqlc.arg(include_hub_wide)))
+  AND (CASE WHEN sqlc.arg(hub_wide_only)
+       THEN owner_user_id IS NULL
+       ELSE (owner_user_id = sqlc.arg(user_id)
+             OR (owner_user_id IS NULL AND sqlc.arg(include_hub_wide)))
+       END)
   AND (sqlc.narg(cursor_time)::timestamptz IS NULL
        OR created_at < sqlc.narg(cursor_time)::timestamptz
        OR (created_at = sqlc.narg(cursor_time)::timestamptz AND client_id < sqlc.narg(cursor_id)))

--- a/backend/internal/hub/store/postgres/oauth_clients.go
+++ b/backend/internal/hub/store/postgres/oauth_clients.go
@@ -164,7 +164,7 @@ func (s *oauthClientStore) List(ctx context.Context, p store.ListOAuthClientsPar
 	}
 	return queryPage(ctx, p.Limit,
 		func() (gendb.ListOAuthClientsParams, error) {
-			return listOAuthClientsParams(owner, p.Cursor, p.Limit, p.IncludeRevoked, p.IncludeHubWide)
+			return listOAuthClientsParams(owner, p)
 		},
 		s.conn.q.ListOAuthClients, fromListRow)
 }

--- a/backend/internal/hub/store/sqlite/convert.go
+++ b/backend/internal/hub/store/sqlite/convert.go
@@ -241,8 +241,8 @@ func rowsAffected(result sql.Result, err error) (int64, error) {
 	return sqlutil.RowsAffected(result, err, mapErr)
 }
 
-func listOAuthClientsParams(userID, cursor string, limit int64, includeRevoked, includeHubWide bool) (gendb.ListOAuthClientsParams, error) {
-	return withCursor(cursor, limit, func(ct sqltime.SQLiteNullTime, cid sql.NullString, fl int64) gendb.ListOAuthClientsParams {
-		return gendb.ListOAuthClientsParams{UserID: sql.NullString{String: userID, Valid: true}, IncludeRevoked: includeRevoked, IncludeHubWide: includeHubWide, CursorTime: ct, CursorID: cid, Limit: fl}
+func listOAuthClientsParams(userID string, p store.ListOAuthClientsParams) (gendb.ListOAuthClientsParams, error) {
+	return withCursor(p.Cursor, p.Limit, func(ct sqltime.SQLiteNullTime, cid sql.NullString, fl int64) gendb.ListOAuthClientsParams {
+		return gendb.ListOAuthClientsParams{UserID: sql.NullString{String: userID, Valid: true}, IncludeRevoked: p.IncludeRevoked, IncludeHubWide: p.IncludeHubWide, HubWideOnly: p.HubWideOnly, CursorTime: ct, CursorID: cid, Limit: fl}
 	})
 }

--- a/backend/internal/hub/store/sqlite/db/queries/oauth_clients.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/oauth_clients.sql
@@ -68,6 +68,10 @@ FROM oauth_clients WHERE client_id = sqlc.arg(client_id);
 -- AND their own apps; everybody else sees what they registered. Keyset on
 -- (created_at DESC, client_id DESC), riding idx_oauth_clients_owner.
 --
+-- hub_wide_only narrows the same statement to the catalogue alone: the
+-- administration panel's listing, which must not carry the administrator's
+-- own private rows only for the caller to discard them.
+--
 -- include_revoked widens the page to retired rows, which the "include retired"
 -- listing asks for; the default keeps the live-only shape every authorize
 -- surface reads. The explicit column list drops the icon bytes for the same
@@ -78,8 +82,11 @@ SELECT client_id, owner_user_id, created_by_user_id, secret_hash, client_name,
        verified_at, verified_by_user_id, created_at, updated_at, revoked_at
 FROM oauth_clients
 WHERE (revoked_at IS NULL OR sqlc.arg(include_revoked))
-  AND (owner_user_id = sqlc.arg(user_id)
-       OR (owner_user_id IS NULL AND sqlc.arg(include_hub_wide)))
+  AND (CASE WHEN sqlc.arg(hub_wide_only)
+       THEN owner_user_id IS NULL
+       ELSE (owner_user_id = sqlc.arg(user_id)
+             OR (owner_user_id IS NULL AND sqlc.arg(include_hub_wide)))
+       END)
   AND (sqlc.narg(cursor_time) IS NULL
        OR created_at < sqlc.narg(cursor_time)
        OR (created_at = sqlc.narg(cursor_time) AND client_id < sqlc.narg(cursor_id)))

--- a/backend/internal/hub/store/sqlite/oauth_clients.go
+++ b/backend/internal/hub/store/sqlite/oauth_clients.go
@@ -164,7 +164,7 @@ func (s *oauthClientStore) List(ctx context.Context, p store.ListOAuthClientsPar
 	}
 	return queryPage(ctx, p.Limit,
 		func() (gendb.ListOAuthClientsParams, error) {
-			return listOAuthClientsParams(owner, p.Cursor, p.Limit, p.IncludeRevoked, p.IncludeHubWide)
+			return listOAuthClientsParams(owner, p)
 		},
 		s.conn.q.ListOAuthClients, fromListRow)
 }

--- a/backend/internal/hub/store/types.go
+++ b/backend/internal/hub/store/types.go
@@ -1646,6 +1646,12 @@ type ListOAuthClientsParams struct {
 	// what an administrator's listing reads; the default keeps the page to
 	// the user's own registrations.
 	IncludeHubWide bool
+	// HubWideOnly narrows the page to the hub-wide catalogue alone,
+	// dropping the user's own registrations. It is the administration
+	// panel's listing: an administrator's own rows must not ride along only
+	// for the caller to discard them. The caller owns the administrator
+	// check -- the store does not repeat it.
+	HubWideOnly bool
 	// IncludeRevoked widens the page to retired rows, which the "include
 	// retired" listing asks for. The default keeps the live-only shape every
 	// authorize surface reads.

--- a/frontend/src/components/chat/toolStyles.css.ts
+++ b/frontend/src/components/chat/toolStyles.css.ts
@@ -276,7 +276,7 @@ export const mcpImage = style({
   width: 'auto',
   height: 'auto',
   objectFit: 'contain',
-  borderRadius: 'var(--radius-2)',
+  borderRadius: 'var(--radius-medium)',
   border: '1px solid var(--border)',
   marginTop: 'var(--space-1)',
   marginBottom: 'var(--space-1)',

--- a/frontend/src/components/common/CaptchaField.css.ts
+++ b/frontend/src/components/common/CaptchaField.css.ts
@@ -19,7 +19,7 @@ globalStyle('altcha-widget', {
     '--altcha-color-error': 'var(--danger)',
     '--altcha-color-error-content': 'var(--danger-foreground)',
     '--altcha-border-color': 'var(--border)',
-    '--altcha-border-radius': 'var(--radius-2)',
+    '--altcha-border-radius': 'var(--radius-medium)',
     '--altcha-checkbox-outline-color': 'var(--ring)',
     '--altcha-padding': 'var(--space-3)',
     '--altcha-max-width': '100%',

--- a/frontend/src/components/common/ConfirmDialog.tsx
+++ b/frontend/src/components/common/ConfirmDialog.tsx
@@ -1,5 +1,6 @@
 import type { Component, JSX } from 'solid-js'
 import { Show } from 'solid-js'
+import { actionsFooter } from '~/components/common/actionsFooter.css'
 import { ConfirmButton } from './ConfirmButton'
 import { Dialog } from './Dialog'
 
@@ -51,7 +52,7 @@ export const ConfirmDialog: Component<ConfirmDialogProps> = (props) => {
     >
       <form onSubmit={handleSubmit}>
         <section>{props.children}</section>
-        <footer>
+        <footer class={actionsFooter}>
           <button
             type="button"
             class="outline"

--- a/frontend/src/components/common/Dialog.css.ts
+++ b/frontend/src/components/common/Dialog.css.ts
@@ -315,11 +315,11 @@ export const body = style({
   outline: 'none',
 })
 
-// Footer inside dialog body
+// Footer inside dialog body: the padding alone. The actions layout (flex,
+// right-aligned, wrapping, space-2 gap) is the shared actionsFooter style
+// every dialog footer element carries, so the dialog states only the chrome
+// it owns -- the gap between the body and its actions.
 globalStyle(`${standard} > .${body} > footer, ${standard} > .${body} > form > footer`, {
-  display: 'flex',
-  justifyContent: 'flex-end',
-  gap: 'var(--space-2)',
   paddingBlockStart: 'var(--space-6)',
 })
 

--- a/frontend/src/components/common/ElevateForm.tsx
+++ b/frontend/src/components/common/ElevateForm.tsx
@@ -1,6 +1,7 @@
 import type { Component } from 'solid-js'
 import type { LinkedOAuthProvider } from '~/generated/leapmux/v1/auth_pb'
 import { createSignal, For, Show } from 'solid-js'
+import { actionsFooter } from '~/components/common/actionsFooter.css'
 import { useAuth } from '~/context/AuthContext'
 import { oauthReauthUrl } from '~/lib/elevation'
 import { formatErrorMessage } from '~/lib/errors'
@@ -174,16 +175,20 @@ export const ElevateForm: Component<{
               data-testid="elevate-password"
             />
           </label>
-          <button type="submit" disabled={busy() || !password()} data-testid="elevate-password-submit">
-            {busy() ? 'Verifying…' : 'Verify'}
-          </button>
+          <div class={actionsFooter}>
+            <button type="submit" disabled={busy() || !password()} data-testid="elevate-password-submit">
+              {busy() ? 'Verifying…' : 'Verify'}
+            </button>
+          </div>
         </form>
       </Show>
 
       <Show when={passkeyAvailable()}>
-        <button type="button" onClick={submitPasskey} disabled={busy()} data-testid="elevate-passkey">
-          Verify with passkey
-        </button>
+        <div class={actionsFooter}>
+          <button type="button" onClick={submitPasskey} disabled={busy()} data-testid="elevate-passkey">
+            Verify with passkey
+          </button>
+        </div>
       </Show>
 
       <Show when={hasElevatingProvider()}>

--- a/frontend/src/components/common/ForgotPasswordPage.tsx
+++ b/frontend/src/components/common/ForgotPasswordPage.tsx
@@ -2,6 +2,7 @@ import type { Component } from 'solid-js'
 import { A } from '@solidjs/router'
 import { createSignal, Show } from 'solid-js'
 import { authClient } from '~/api/clients'
+import { actionsFooter } from '~/components/common/actionsFooter.css'
 import { CaptchaSection } from '~/components/common/CaptchaSection'
 import { Spinner } from '~/components/common/Spinner'
 import { createCaptchaForm } from '~/lib/captchaForm'
@@ -67,10 +68,12 @@ export const ForgotPasswordPage: Component = () => {
             <Show when={error()}>
               <div class={errorText}>{error()}</div>
             </Show>
-            <button type="submit" disabled={submitting() || !identifier().trim() || captcha.blocksSubmit()}>
-              <Show when={submitting()}><Spinner /></Show>
-              {submitting() ? 'Sending…' : 'Send reset link'}
-            </button>
+            <div class={actionsFooter}>
+              <button type="submit" disabled={submitting() || !identifier().trim() || captcha.blocksSubmit()}>
+                <Show when={submitting()}><Spinner /></Show>
+                {submitting() ? 'Sending…' : 'Send reset link'}
+              </button>
+            </div>
           </form>
           <div class={styles.authFooter}>
             <A href="/login">Back to login</A>

--- a/frontend/src/components/common/KeyPinMismatchDialog.tsx
+++ b/frontend/src/components/common/KeyPinMismatchDialog.tsx
@@ -1,5 +1,6 @@
 import type { Component } from 'solid-js'
 import type { KeyPinDecision } from '~/lib/keyPinStore'
+import { actionsFooter } from '~/components/common/actionsFooter.css'
 import { ConfirmButton } from './ConfirmButton'
 import { Dialog } from './Dialog'
 
@@ -46,7 +47,7 @@ export const KeyPinMismatchDialog: Component<KeyPinMismatchDialogProps> = (props
           verify the worker's identity before accepting.
         </p>
       </section>
-      <footer>
+      <footer class={actionsFooter}>
         <button type="button" class="outline" onClick={handleReject} data-testid="key-pin-reject">
           Reject
         </button>

--- a/frontend/src/components/common/LoginPage.css.ts
+++ b/frontend/src/components/common/LoginPage.css.ts
@@ -27,7 +27,7 @@ export const oauthButton = style({
   'alignItems': 'center',
   'justifyContent': 'center',
   'padding': 'var(--space-3) var(--space-4)',
-  'borderRadius': 'var(--radius-2)',
+  'borderRadius': 'var(--radius-medium)',
   'border': '1px solid var(--border)',
   'backgroundColor': 'var(--surface)',
   'color': 'var(--foreground)',

--- a/frontend/src/components/common/LoginPage.tsx
+++ b/frontend/src/components/common/LoginPage.tsx
@@ -4,6 +4,7 @@ import type { Component } from 'solid-js'
 import type { OAuthProviderInfo } from '~/generated/leapmux/v1/auth_pb'
 import { A, useNavigate, useSearchParams } from '@solidjs/router'
 import { createEffect, createSignal, Show } from 'solid-js'
+import { actionsFooter } from '~/components/common/actionsFooter.css'
 import { CaptchaSection } from '~/components/common/CaptchaSection'
 import { OAuthProviderList } from '~/components/common/OAuthProviderList'
 import { PillGroup } from '~/components/common/PillGroup'
@@ -178,15 +179,17 @@ export const LoginPage: Component = () => {
           <Show when={auth.error()}>
             <div class={errorText}>{auth.error()}</div>
           </Show>
-          <button
-            type="submit"
-            disabled={submitting() || !canSubmit()}
-          >
-            <Show when={submitting()}><Spinner /></Show>
-            {submitting()
-              ? 'Signing in...'
-              : effectiveMethod() === 'passkey' ? 'Sign in with passkey' : 'Sign in'}
-          </button>
+          <div class={actionsFooter}>
+            <button
+              type="submit"
+              disabled={submitting() || !canSubmit()}
+            >
+              <Show when={submitting()}><Spinner /></Show>
+              {submitting()
+                ? 'Signing in...'
+                : effectiveMethod() === 'passkey' ? 'Sign in with passkey' : 'Sign in'}
+            </button>
+          </div>
           <Show when={isEmailEnabled() && effectiveMethod() === 'password'}>
             <div>
               <A href="/forgot-password">Forgot password?</A>

--- a/frontend/src/components/common/ResetPasswordPage.tsx
+++ b/frontend/src/components/common/ResetPasswordPage.tsx
@@ -2,6 +2,7 @@ import type { Component } from 'solid-js'
 import { A, useNavigate, useSearchParams } from '@solidjs/router'
 import { createSignal, Show } from 'solid-js'
 import { authClient } from '~/api/clients'
+import { actionsFooter } from '~/components/common/actionsFooter.css'
 import { CaptchaSection } from '~/components/common/CaptchaSection'
 import { Spinner } from '~/components/common/Spinner'
 import { createCaptchaForm } from '~/lib/captchaForm'
@@ -74,10 +75,12 @@ export const ResetPasswordPage: Component = () => {
             <Show when={error()}>
               <div class={errorText}>{error()}</div>
             </Show>
-            <button type="submit" disabled={submitting() || !passwordCanSubmit(pwProps) || captcha.blocksSubmit()}>
-              <Show when={submitting()}><Spinner /></Show>
-              {submitting() ? 'Resetting…' : 'Reset password'}
-            </button>
+            <div class={actionsFooter}>
+              <button type="submit" disabled={submitting() || !passwordCanSubmit(pwProps) || captcha.blocksSubmit()}>
+                <Show when={submitting()}><Spinner /></Show>
+                {submitting() ? 'Resetting…' : 'Reset password'}
+              </button>
+            </div>
           </form>
         </Show>
         <div class={styles.authFooter}>

--- a/frontend/src/components/common/SignupForm.tsx
+++ b/frontend/src/components/common/SignupForm.tsx
@@ -4,6 +4,7 @@ import type { Component, JSX } from 'solid-js'
 import type { EmailVerificationStatus, User } from '~/generated/leapmux/v1/auth_pb'
 import { createSignal, Show } from 'solid-js'
 import { authClient } from '~/api/clients'
+import { actionsFooter } from '~/components/common/actionsFooter.css'
 import { CaptchaSection } from '~/components/common/CaptchaSection'
 import { PillGroup } from '~/components/common/PillGroup'
 import { authMethodOptions, createAuthMethodSelection } from '~/lib/authMethodSelection'
@@ -215,12 +216,14 @@ export const SignupForm: Component<SignupFormProps> = (props) => {
         <Show when={error()}>
           <div class={errorText}>{error()}</div>
         </Show>
-        <button type="submit" disabled={submitting() || !canSubmit()}>
-          <Show when={submitting()}><Spinner /></Show>
-          {submitting()
-            ? props.submittingLabel
-            : effectiveMethod() === 'passkey' ? 'Sign up with passkey' : props.submitLabel}
-        </button>
+        <div class={actionsFooter}>
+          <button type="submit" disabled={submitting() || !canSubmit()}>
+            <Show when={submitting()}><Spinner /></Show>
+            {submitting()
+              ? props.submittingLabel
+              : effectiveMethod() === 'passkey' ? 'Sign up with passkey' : props.submitLabel}
+          </button>
+        </div>
       </form>
     </>
   )

--- a/frontend/src/components/common/VerifyEmailPage.tsx
+++ b/frontend/src/components/common/VerifyEmailPage.tsx
@@ -2,6 +2,7 @@ import type { Component } from 'solid-js'
 import { useNavigate, useSearchParams } from '@solidjs/router'
 import { createEffect, createSignal, Show } from 'solid-js'
 import { userClient } from '~/api/clients'
+import { actionsFooter } from '~/components/common/actionsFooter.css'
 import { useAuth } from '~/context/AuthContext'
 import { formatErrorMessage } from '~/lib/errors'
 import { stringParam } from '~/lib/searchParam'
@@ -124,13 +125,15 @@ export const VerifyEmailPage: Component = () => {
             maxlength={16}
             required
           />
-          <button
-            type="submit"
-            data-testid="verify-email-submit"
-            disabled={submitting()}
-          >
-            {submitting() ? 'Verifying…' : 'Verify'}
-          </button>
+          <div class={actionsFooter}>
+            <button
+              type="submit"
+              data-testid="verify-email-submit"
+              disabled={submitting()}
+            >
+              {submitting() ? 'Verifying…' : 'Verify'}
+            </button>
+          </div>
         </form>
         <Show when={error()}>
           {msg => <div class={errorText}>{msg()}</div>}
@@ -141,21 +144,23 @@ export const VerifyEmailPage: Component = () => {
         <Show when={resend.status()}>
           {msg => <div data-testid="verify-email-resend-status">{msg()}</div>}
         </Show>
-        <button
-          type="button"
-          data-testid="verify-email-resend"
-          onClick={() => {
-            // Clear the code error first. resend() clears only its own
-            // signals, so a stale "invalid or expired verification code"
-            // would otherwise render beside "A fresh code has been sent",
-            // which reads as though the new code was rejected too.
-            setError(null)
-            void resend.resend()
-          }}
-          disabled={resend.disabled()}
-        >
-          {resend.buttonLabel()}
-        </button>
+        <div class={actionsFooter}>
+          <button
+            type="button"
+            data-testid="verify-email-resend"
+            onClick={() => {
+              // Clear the code error first. resend() clears only its own
+              // signals, so a stale "invalid or expired verification code"
+              // would otherwise render beside "A fresh code has been sent",
+              // which reads as though the new code was rejected too.
+              setError(null)
+              void resend.resend()
+            }}
+            disabled={resend.disabled()}
+          >
+            {resend.buttonLabel()}
+          </button>
+        </div>
       </div>
     </div>
   )

--- a/frontend/src/components/common/actionsFooter.css.ts
+++ b/frontend/src/components/common/actionsFooter.css.ts
@@ -1,0 +1,19 @@
+import { style } from '@vanilla-extract/css'
+
+/**
+ * The one right-aligned row of actions: form footers, section actions, and
+ * credential-row button groups all render this, so alignment, spacing, and
+ * wrap behavior are stated once instead of spelled per surface.
+ *
+ * Wrapping is on so a row that outgrows a narrow panel stacks instead of
+ * overflowing; the gap is space-2, the spacing the dialog footer has always
+ * used. The one thing this style deliberately does NOT carry is the dialog
+ * footer's block padding -- that is the dialog's chrome, not the actions'
+ * convention, and the Dialog stylesheet keeps it.
+ */
+export const actionsFooter = style({
+  display: 'flex',
+  flexWrap: 'wrap',
+  justifyContent: 'flex-end',
+  gap: 'var(--space-2)',
+})

--- a/frontend/src/components/desktop/CliPathDialog.tsx
+++ b/frontend/src/components/desktop/CliPathDialog.tsx
@@ -2,6 +2,7 @@ import type { Component } from 'solid-js'
 import type { CliInstallResult, CliPathStatus, CliPathTargetKind } from '~/api/platformBridge'
 import { createSignal, Match, Show, Switch } from 'solid-js'
 import { platformBridge } from '~/api/platformBridge'
+import { actionsFooter } from '~/components/common/actionsFooter.css'
 import { ConfirmButton } from '~/components/common/ConfirmButton'
 import { Dialog } from '~/components/common/Dialog'
 import { useCopyButton } from '~/hooks/useCopyButton'
@@ -122,7 +123,7 @@ export const CliPathDialog: Component<CliPathDialogProps> = (props) => {
                       <code>{status.resolved}</code>
                     </p>
                   </section>
-                  <footer>
+                  <footer class={actionsFooter}>
                     <button type="button" class="outline" disabled={busy()} onClick={props.onClose}>
                       Dismiss
                     </button>
@@ -179,7 +180,7 @@ export const CliPathDialog: Component<CliPathDialogProps> = (props) => {
                       </p>
                     </Show>
                   </section>
-                  <footer>
+                  <footer class={actionsFooter}>
                     <button type="button" class="outline" disabled={busy()} onClick={props.onClose}>
                       Not now
                     </button>
@@ -259,7 +260,7 @@ export const CliPathDialog: Component<CliPathDialogProps> = (props) => {
                 </Match>
               </Switch>
             </section>
-            <footer>
+            <footer class={actionsFooter}>
               <Show when={outcomeValue.kind === 'needs_sudo' || outcomeValue.kind === 'parent_missing'}>
                 <button type="button" class="outline" onClick={copy}>
                   {copied() ? 'Copied' : 'Copy command'}

--- a/frontend/src/components/settings/PreferencesDialog.test.tsx
+++ b/frontend/src/components/settings/PreferencesDialog.test.tsx
@@ -17,6 +17,8 @@ const elevationExpiresAt = vi.hoisted(() => vi.fn((): { seconds: bigint, nanos: 
 vi.mock('~/api/clients', () => ({
   userClient: { listUserSettings, updateUserSetting: vi.fn(), resetUserSetting: vi.fn() },
   adminSettingsClient: { listSettings, updateSetting, updateSettingSecret: vi.fn(), resetSetting: vi.fn() },
+  // The hub-wide registrations row's custom editor lists apps through this.
+  appClient: { listApps: vi.fn().mockResolvedValue({ apps: [] }) },
   authClient: {},
 }))
 
@@ -69,6 +71,22 @@ afterEach(() => {
 })
 
 describe('preferencesDialog admin restriction', () => {
+  // The hub-wide register row reaches the ADMINISTRATION side alone (see
+  // ./registry/admin): an administrator gets it under Hub-wide Apps, and the
+  // user-level Apps section never lists it -- which is the whole reason the
+  // admin tier exists rather than a browser-registry entry.
+  it('renders the hub-wide registrations row for administrators alone', async () => {
+    isAdmin.mockReturnValue(true)
+    renderDialog('admin-apps')
+    await waitFor(() => expect(screen.getByText('Hub-wide app registrations')).toBeTruthy())
+
+    cleanup()
+    isAdmin.mockReturnValue(false)
+    renderDialog('admin-apps')
+    await waitFor(() => expect(screen.getByTestId('preferences-nav-appearance')).toBeTruthy())
+    expect(screen.queryByText('Hub-wide app registrations')).toBeNull()
+  })
+
   it('shows the administration groups only to admins', async () => {
     isAdmin.mockReturnValue(true)
     listSettings.mockResolvedValue({
@@ -272,11 +290,14 @@ describe('preferencesDialog solo mode', () => {
   // must be able to see what they authorized and disconnect it. Every row that
   // needs a factor to prove (a password, a passkey, an address) still hides,
   // because solo has no factor and no ceremony.
-  it('keeps Account for connected apps in solo, and hides the rows a factor would need', async () => {
+  it('hides Account in solo and keeps Apps for connected apps', async () => {
     solo.mockReturnValue(true)
     renderDialog()
     await waitFor(() => expect(screen.getByTestId('preferences-nav-appearance')).toBeTruthy())
-    expect(screen.getByTestId('preferences-nav-account')).toBeTruthy()
+    // Connected apps is an APPS row, so solo hides Account entirely and the
+    // app errand stays reachable.
+    expect(screen.queryByTestId('preferences-nav-account')).toBeNull()
+    expect(screen.getByTestId('preferences-nav-apps')).toBeTruthy()
     // Dual rows still render with the scope chip.
     expect(screen.getByTestId('scope-chip-appearance.theme')).toBeTruthy()
   })
@@ -356,9 +377,10 @@ describe('preferencesDialog solo mode', () => {
     renderDialog('admin-captcha')
     await waitFor(() => expect(screen.getByTestId('preferences-nav-appearance')).toBeTruthy())
     expect(screen.queryByTestId('preferences-nav-admin-captcha')).toBeNull()
-    // The FIRST visible group, which is Account: solo keeps it for connected
-    // apps, so the fallback stops there rather than at Appearance.
-    expect(screen.getByTestId('preferences-nav-account').getAttribute('aria-selected')).toBe('true')
+    // The FIRST visible group, which is Apps: solo hides Account entirely
+    // (connected apps is an Apps row), so the fallback stops there rather
+    // than at Appearance.
+    expect(screen.getByTestId('preferences-nav-apps').getAttribute('aria-selected')).toBe('true')
   })
 })
 
@@ -733,11 +755,11 @@ describe('preferencesDialog section order', () => {
   // The rows that need a factor still hide. Solo has no password, no passkey
   // and no address, so those editors would render controls whose ceremony
   // cannot run.
-  it('lands on Account in solo mode, which keeps its connected-apps row', async () => {
+  it('falls back from Account in solo mode, where Apps holds the connected-apps row', async () => {
     solo.mockReturnValue(true)
     renderDialog('account')
     await waitFor(() => expect(screen.getByTestId('preferences-nav-appearance')).toBeTruthy())
-    expect(screen.getByTestId('preferences-nav-account')).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByTestId('preferences-nav-apps')).toHaveAttribute('aria-selected', 'true')
   })
 })
 

--- a/frontend/src/components/settings/PreferencesDialog.tsx
+++ b/frontend/src/components/settings/PreferencesDialog.tsx
@@ -15,10 +15,18 @@ import { PreferencesNav } from './PreferencesNav'
 import { PreferencesSearch } from './PreferencesSearch'
 import { buildProtoRows } from './protoRegistry'
 import { createBrowserRows } from './registry'
+import { ADMIN_ROWS } from './registry/admin'
 import { breadcrumb, buildSearchIndex, matchSettings } from './search'
 import { SettingsPanel } from './SettingsPanel'
 import { descriptorNeedsElevation } from './types'
 
+/**
+ * The Preferences dialog over every settings row the signed-in account can
+ * reach: the user sections from the browser registry, and -- for an
+ * administrator -- the Administration sections from the hub's proto rows
+ * plus the registry's ADMINISTRATION tier (`./registry/admin`, which also
+ * states why that tier sits apart from the browser registry).
+ */
 interface PreferencesDialogProps {
   /**
    * The category id to show (a NAV_GROUPS id). An id whose group is hidden
@@ -62,10 +70,15 @@ export const PreferencesDialog: Component<PreferencesDialogProps> = (props) => {
   // context's typed, browser-overridable one rather than a merge onto a
   // store's value map, so the registry builds those — see
   // `createBrowserRows`.
+  //
+  // The hub-wide register row rides AFTER them: it is an administration row
+  // with no hub setting behind it (see ./registry/admin), and the group's
+  // other rows — the open-registration switch — state the hub's policy before
+  // the panel offers to act on it.
   const adminRows = createMemo(() => {
     if (!isAdmin())
       return []
-    return buildProtoRows(adminStore.state.descriptors, adminStore)
+    return [...buildProtoRows(adminStore.state.descriptors, adminStore), ...ADMIN_ROWS]
   })
 
   /**

--- a/frontend/src/components/settings/SettingRow.css.ts
+++ b/frontend/src/components/settings/SettingRow.css.ts
@@ -17,12 +17,12 @@ export const headerRow = style({
   minWidth: 0,
 })
 
+// Margin alone. The label is an <h3>, so Oat's heading rule owns the type:
+// size, weight, colour and break-word come from there, and restating them
+// here would only drift. The one thing a settings row must not take from a
+// page heading is its spacing, so the margins reset to zero.
 export const label = style({
-  fontSize: 'var(--text-6)',
-  fontWeight: 'var(--font-medium)',
-  color: 'var(--foreground)',
-  minWidth: 0,
-  overflowWrap: 'break-word',
+  margin: 0,
 })
 
 export const helpText = style({

--- a/frontend/src/components/settings/SettingRow.test.tsx
+++ b/frontend/src/components/settings/SettingRow.test.tsx
@@ -107,6 +107,10 @@ describe('settingRow control kinds', () => {
     ))
     const button = screen.getByTestId('setting-action-test.row')
     expect(button).toHaveAttribute('data-variant', 'danger')
+    // The FILLED danger chrome "Remove all" wears, not a small outline: a
+    // danger action ends a whole feature with no dialog of its own, so the
+    // button is the confirmation and carries the weight.
+    expect(button.getAttribute('class') ?? '').not.toContain('outline')
     fireEvent.click(button)
     expect(set).not.toHaveBeenCalled()
     expect(button).toHaveTextContent('Confirm?')

--- a/frontend/src/components/settings/SettingRow.tsx
+++ b/frontend/src/components/settings/SettingRow.tsx
@@ -2,6 +2,7 @@ import type { Component } from 'solid-js'
 import type { SettingBinding, SettingControl, SettingDescriptor } from './types'
 import ChevronDown from 'lucide-solid/icons/chevron-down'
 import { createMemo, createSignal, Show } from 'solid-js'
+import { actionsFooter } from '~/components/common/actionsFooter.css'
 import { ConfirmButton } from '~/components/common/ConfirmButton'
 import { DropdownMenu, DropdownMenuCheckableItem } from '~/components/common/DropdownMenu'
 import { Icon } from '~/components/common/Icon'
@@ -261,14 +262,26 @@ export const SettingRow: Component<SettingRowProps> = (props) => {
       }
       case 'action':
         return (
-          <ConfirmButton
-            class="small outline"
-            data-variant={c.danger ? 'danger' : undefined}
-            data-testid={`setting-action-${d().id}`}
-            onClick={() => void commit(true)}
-          >
-            {c.label}
-          </ConfirmButton>
+          // Right-aligned like every section action in the dialog: an action
+          // row is the closing line of its editor, and Oat's own dialog
+          // footers put their primaries there too.
+          <div class={actionsFooter}>
+            <ConfirmButton
+              /*
+                A danger action is the FILLED danger ConfirmButton, the same
+                chrome "Remove all" on the trusted-worker-keys panel wears: it
+                ends a whole feature in one request with no dialog of its own,
+                so the button itself is the confirmation and carries the weight.
+                A small outline here rendered a second danger idiom beside that
+                one, quieter than the ending it performs.
+              */
+              data-variant={c.danger ? 'danger' : undefined}
+              data-testid={`setting-action-${d().id}`}
+              onClick={() => void commit(true)}
+            >
+              {c.label}
+            </ConfirmButton>
+          </div>
         )
     }
   }
@@ -334,8 +347,17 @@ export const SettingRow: Component<SettingRowProps> = (props) => {
           reveal.observe(el)
       }}
     >
+      {/*
+        An H3, the Oat heading element a labelled block uses: the row is the
+        panel's one unit of structure, and a heading gives it a place in the
+        document outline a span cannot. The TYPE is Oat's own h3 rule,
+        deliberately -- the compact span size does not come back (the label
+        style's comment states the same rule). The zeroed margin alone is
+        stated here, because a settings row must not take a page heading's
+        spacing.
+      */}
       <div class={styles.headerRow}>
-        <span class={styles.label}>{d().label}</span>
+        <h3 class={styles.label}>{d().label}</h3>
         {scopeNote()}
       </div>
       <Show when={d().help}>

--- a/frontend/src/components/settings/account/AccountConnectedApps.tsx
+++ b/frontend/src/components/settings/account/AccountConnectedApps.tsx
@@ -4,6 +4,7 @@ import type { MyAPIToken } from '~/generated/leapmux/v1/user_pb'
 import { timestampDate } from '@bufbuild/protobuf/wkt'
 import { createMemo, createSignal, For, onMount, Show } from 'solid-js'
 import { userClient } from '~/api/clients'
+import { actionsFooter } from '~/components/common/actionsFooter.css'
 import { ConfirmDialog } from '~/components/common/ConfirmDialog'
 import { Spinner } from '~/components/common/Spinner'
 import { StatusLine } from '~/components/common/StatusLine'
@@ -252,26 +253,21 @@ export const AccountConnectedApps: Component = () => {
         <For each={connectedApps()}>
           {app => (
             <div class={styles.credentialGroup} data-testid={`connected-app-${app.clientId}`}>
-              <div class={styles.credentialGroupHeader}>
-                <div class={styles.credentialInfo}>
-                  <span class={styles.credentialName}>
-                    {app.clientName || 'Unnamed app'}
-                    <Show when={!app.verified}>
-                      {' '}
-                      <span class={styles.credentialBadgeWarning}>unverified</span>
-                    </Show>
-                  </span>
-                </div>
-                <div class={styles.credentialActions}>
-                  <button
-                    type="button"
-                    class={styles.credentialDanger}
-                    onClick={() => setDisconnectTarget(app)}
-                    disabled={busy()}
-                  >
-                    Disconnect
-                  </button>
-                </div>
+              {/*
+                The app's own line: its name and the vouch state, on the full
+                width. The Disconnect sits in a footer row under the
+                installations, so the app-level ending reads as the block's
+                closing action rather than as one more thing competing with
+                the name for the same line.
+              */}
+              <div class={styles.credentialInfo}>
+                <span class={styles.credentialName}>
+                  {app.clientName || 'Unnamed app'}
+                  <Show when={!app.verified}>
+                    {' '}
+                    <span class="badge" data-variant="warning">unverified</span>
+                  </Show>
+                </span>
               </div>
               <div class={styles.credentialGroupBody}>
                 <For each={app.installations}>
@@ -289,7 +285,7 @@ export const AccountConnectedApps: Component = () => {
                           {token.installationName || 'Unnamed installation'}
                           <Show when={administersHub(token)}>
                             {' '}
-                            <span class={styles.credentialBadgeWarning}>hub administration</span>
+                            <span class="badge" data-variant="warning">hub administration</span>
                           </Show>
                           {/*
                             This list deliberately does NOT render
@@ -312,10 +308,17 @@ export const AccountConnectedApps: Component = () => {
                           </span>
                         </Show>
                       </div>
-                      <div class={styles.credentialActions}>
+                      <div class={actionsFooter}>
+                        {/*
+                          An Oat danger OUTLINE: this control only OPENS the
+                          confirmation, whose primary carries the danger
+                          weight. Filling it here would paint the louder
+                          button on the step that still cancels.
+                        */}
                         <button
                           type="button"
-                          class={styles.credentialDanger}
+                          class="outline"
+                          data-variant="danger"
                           onClick={() => setRevokeTarget(token)}
                           disabled={busy()}
                         >
@@ -325,6 +328,17 @@ export const AccountConnectedApps: Component = () => {
                     </div>
                   )}
                 </For>
+              </div>
+              <div class={actionsFooter}>
+                <button
+                  type="button"
+                  class="outline"
+                  data-variant="danger"
+                  onClick={() => setDisconnectTarget(app)}
+                  disabled={busy()}
+                >
+                  Disconnect
+                </button>
               </div>
             </div>
           )}

--- a/frontend/src/components/settings/account/AccountEmail.tsx
+++ b/frontend/src/components/settings/account/AccountEmail.tsx
@@ -2,6 +2,7 @@ import type { Component } from 'solid-js'
 import { A } from '@solidjs/router'
 import { createMemo, createSignal, Show } from 'solid-js'
 import { userClient } from '~/api/clients'
+import { actionsFooter } from '~/components/common/actionsFooter.css'
 import { StatusLine } from '~/components/common/StatusLine'
 import { useAuth } from '~/context/AuthContext'
 import { KEY_EMAIL_CHANGE_DRAFT, sessionStorageGet, sessionStorageRemove, sessionStorageSet } from '~/lib/browserStorage'
@@ -124,7 +125,7 @@ export const AccountEmail: Component = () => {
         address when there is none.
       */}
       <Show when={auth.user()?.email && !auth.user()?.emailVerified && isEmailEnabled()}>
-        <div class="hstack gap-2">
+        <div class={actionsFooter}>
           <button type="button" onClick={() => void verification.resend()} disabled={verification.disabled()}>
             {verification.buttonLabel()}
           </button>
@@ -159,7 +160,7 @@ export const AccountEmail: Component = () => {
       <Show when={sameAsCurrent()}>
         <div class={errorText}>This is already your current email.</div>
       </Show>
-      <div>
+      <div class={actionsFooter}>
         <button
           type="button"
           onClick={() => void requestChange()}

--- a/frontend/src/components/settings/account/AccountLinkedProviders.test.tsx
+++ b/frontend/src/components/settings/account/AccountLinkedProviders.test.tsx
@@ -53,7 +53,9 @@ describe('accountLinkedProviders', () => {
     render(() => <AccountLinkedProviders />)
     expect(await screen.findByText('GitHub')).toBeInTheDocument()
 
+    // A ConfirmButton: the first click arms it, the second detaches.
     fireEvent.click(screen.getByRole('button', { name: 'Unlink' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Unlink?' }))
     await vi.waitFor(() => {
       expect(mockUnlink).toHaveBeenCalledWith({ providerId: 'github-1' })
     })
@@ -78,6 +80,7 @@ describe('accountLinkedProviders', () => {
     expect(screen.getByTestId('linked-disabled-github-1')).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Unlink' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Unlink?' }))
     await vi.waitFor(() => {
       expect(mockUnlink).toHaveBeenCalledWith({ providerId: 'github-1' })
     })
@@ -101,6 +104,7 @@ describe('accountLinkedProviders', () => {
 
     render(() => <AccountLinkedProviders />)
     fireEvent.click(await screen.findByRole('button', { name: 'Unlink' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Unlink?' }))
 
     expect(await screen.findByText(/only login method/)).toBeInTheDocument()
     expect(screen.queryByTestId('elevate-password')).not.toBeInTheDocument()
@@ -120,6 +124,7 @@ describe('accountLinkedProviders', () => {
     render(() => <AccountLinkedProviders />)
     const button = await screen.findByRole('button', { name: 'Unlink' })
     fireEvent.click(button)
+    fireEvent.click(screen.getByRole('button', { name: 'Unlink?' }))
 
     await vi.waitFor(() => {
       expect(mockRefreshUser).toHaveBeenCalledTimes(1)

--- a/frontend/src/components/settings/account/AccountLinkedProviders.tsx
+++ b/frontend/src/components/settings/account/AccountLinkedProviders.tsx
@@ -1,6 +1,8 @@
 import type { Component } from 'solid-js'
 import { For, Show } from 'solid-js'
 import { userClient } from '~/api/clients'
+import { actionsFooter } from '~/components/common/actionsFooter.css'
+import { ConfirmButton } from '~/components/common/ConfirmButton'
 import { StatusLine } from '~/components/common/StatusLine'
 import { useAuth } from '~/context/AuthContext'
 import { elevationPrompting } from '~/lib/elevationPrompt'
@@ -50,7 +52,7 @@ export const AccountLinkedProviders: Component = () => {
       </Show>
       <For each={providers()}>
         {provider => (
-          <div class={styles.linkedAccount}>
+          <div class={listStyles.credentialRow}>
             <span class={styles.linkedAccountName}>{provider.name}</span>
             {/*
               This panel lists a DISABLED provider, and must say so. The hub
@@ -66,14 +68,23 @@ export const AccountLinkedProviders: Component = () => {
                 Turned off by an administrator — you cannot sign in with it
               </span>
             </Show>
-            <button
-              type="button"
-              class={styles.linkedAccountUnlink}
-              onClick={() => void detach(provider.id)}
-              disabled={action.busy() === provider.id || elevationPrompting()}
-            >
-              {action.busy() === provider.id ? 'Unlinking...' : 'Unlink'}
-            </button>
+            {/*
+              A danger-styled ConfirmButton: unlinking ends a login method in
+              one request, with no dialog of its own, so the two-click arming
+              IS the confirmation -- the same guard every row-level destructive
+              control in Preferences carries.
+            */}
+            <div class={actionsFooter}>
+              <ConfirmButton
+                class="outline"
+                data-variant="danger"
+                confirmLabel="Unlink?"
+                onClick={() => void detach(provider.id)}
+                disabled={action.busy() === provider.id || elevationPrompting()}
+              >
+                {action.busy() === provider.id ? 'Unlinking...' : 'Unlink'}
+              </ConfirmButton>
+            </div>
           </div>
         )}
       </For>

--- a/frontend/src/components/settings/account/AccountPasskeys.test.tsx
+++ b/frontend/src/components/settings/account/AccountPasskeys.test.tsx
@@ -178,7 +178,9 @@ describe('accountPasskeys', () => {
     fireEvent.input(lastLabelled('Confirm Password'), { target: { value: 'newpass123' } })
     expect(screen.getByRole('button', { name: 'Remove passkey' })).toBeEnabled()
 
+    // The dialog's danger primary is a ConfirmButton: arm, then confirm.
     fireEvent.click(screen.getByRole('button', { name: 'Remove passkey' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm?' }))
     await vi.waitFor(() => {
       expect(mockDeletePasskey).toHaveBeenCalledWith({ id: 'pk-1', newPassword: 'newpass123' })
     })
@@ -257,6 +259,7 @@ describe('accountPasskeys', () => {
     expect(await screen.findByText('Laptop')).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: 'Remove' }))
     fireEvent.click(await screen.findByRole('button', { name: 'Remove passkey' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm?' }))
     await vi.waitFor(() => {
       expect(screen.queryByText('Laptop')).not.toBeInTheDocument()
     })
@@ -288,6 +291,7 @@ describe('accountPasskeys', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Remove' }))
     fireEvent.click(await screen.findByRole('button', { name: 'Remove passkey' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm?' }))
 
     await vi.waitFor(() => {
       expect(mockRefreshUser).toHaveBeenCalled()

--- a/frontend/src/components/settings/account/AccountPasskeys.tsx
+++ b/frontend/src/components/settings/account/AccountPasskeys.tsx
@@ -4,7 +4,9 @@ import type { PasskeyInfo } from '~/generated/leapmux/v1/user_pb'
 import { timestampDate } from '@bufbuild/protobuf/wkt'
 import { createSignal, For, onMount, Show } from 'solid-js'
 import { userClient } from '~/api/clients'
+import { actionsFooter } from '~/components/common/actionsFooter.css'
 import { Alert } from '~/components/common/Alert'
+import { ConfirmButton } from '~/components/common/ConfirmButton'
 import { Dialog } from '~/components/common/Dialog'
 import { passwordCanSubmit, PasswordFields } from '~/components/common/PasswordFields'
 import { Spinner } from '~/components/common/Spinner'
@@ -388,7 +390,7 @@ export const AccountPasskeys: Component = () => {
                   {passkey.lastUsedAt ? `Last used ${formatPasskeyDate(passkey)}` : `Added ${formatPasskeyDate(passkey)}`}
                 </span>
               </div>
-              <div class={listStyles.credentialActions}>
+              <div class={actionsFooter}>
                 <Show when={renamingId() === passkey.id}>
                   <button type="button" onClick={() => void saveRename(passkey.id)} disabled={working()}>
                     Save
@@ -397,7 +399,11 @@ export const AccountPasskeys: Component = () => {
                 </Show>
                 <Show when={renamingId() !== passkey.id}>
                   <button type="button" onClick={() => startRename(passkey)} disabled={working()}>Rename</button>
-                  <button type="button" class={listStyles.credentialDanger} onClick={() => openDelete(passkey)} disabled={working()}>
+                  {/*
+                    An Oat danger OUTLINE: this control only OPENS the removal
+                    dialog, whose primary carries the danger weight.
+                  */}
+                  <button type="button" class="outline" data-variant="danger" onClick={() => openDelete(passkey)} disabled={working()}>
                     Remove
                   </button>
                 </Show>
@@ -413,7 +419,7 @@ export const AccountPasskeys: Component = () => {
           remedy where "Add passkey" belongs. The alert above carries the same
           reason for anybody who never hovers.
         */}
-        <div class={listStyles.passkeyButtons}>
+        <div class={actionsFooter}>
           <Tooltip text={blockedReason()}>
             <button
               type="button"
@@ -439,9 +445,11 @@ export const AccountPasskeys: Component = () => {
               <input type="text" value={friendlyName()} onInput={e => setFriendlyName(e.currentTarget.value)} />
             </label>
             <StatusLine message={modalMessage()} />
-            <button type="button" onClick={() => void handleAddPasskey()} disabled={working()}>
-              {busy() ? 'Adding…' : 'Continue'}
-            </button>
+            <div class={actionsFooter}>
+              <button type="button" onClick={() => void handleAddPasskey()} disabled={working()}>
+                {busy() ? 'Adding…' : 'Continue'}
+              </button>
+            </div>
           </div>
         </Dialog>
       </Show>
@@ -462,9 +470,22 @@ export const AccountPasskeys: Component = () => {
               />
             </Show>
             <StatusLine message={modalMessage()} />
-            <button type="button" class={listStyles.credentialDanger} onClick={() => void handleDeletePasskey()} disabled={deleteConfirmDisabled()}>
-              {busy() ? 'Removing…' : 'Remove passkey'}
-            </button>
+            {/*
+              The danger primary of the dialog it lives in, so it wears the
+              same two-click arming every ConfirmDialog danger primary does --
+              this dialog is a raw Dialog only because of the password fields
+              above, and its ending should not read quieter for that.
+              Right-aligned like an Oat dialog footer's primary.
+            */}
+            <div class={actionsFooter}>
+              <ConfirmButton
+                data-variant="danger"
+                onClick={() => void handleDeletePasskey()}
+                disabled={deleteConfirmDisabled()}
+              >
+                {busy() ? 'Removing…' : 'Remove passkey'}
+              </ConfirmButton>
+            </div>
           </div>
         </Dialog>
       </Show>
@@ -483,9 +504,11 @@ export const AccountPasskeys: Component = () => {
               />
             </Show>
             <StatusLine message={modalMessage()} />
-            <button type="button" onClick={() => void handleDeactivate()} disabled={deactivateConfirmDisabled()}>
-              {busy() ? 'Disabling…' : 'Disable passkey sign-in'}
-            </button>
+            <div class={actionsFooter}>
+              <button type="button" onClick={() => void handleDeactivate()} disabled={deactivateConfirmDisabled()}>
+                {busy() ? 'Disabling…' : 'Disable passkey sign-in'}
+              </button>
+            </div>
           </div>
         </Dialog>
       </Show>

--- a/frontend/src/components/settings/account/AccountPassword.tsx
+++ b/frontend/src/components/settings/account/AccountPassword.tsx
@@ -1,6 +1,7 @@
 import type { Component } from 'solid-js'
 import { createSignal } from 'solid-js'
 import { userClient } from '~/api/clients'
+import { actionsFooter } from '~/components/common/actionsFooter.css'
 import { passwordCanSubmit, PasswordFields } from '~/components/common/PasswordFields'
 import { StatusLine } from '~/components/common/StatusLine'
 import { useAuth } from '~/context/AuthContext'
@@ -53,7 +54,7 @@ export const AccountPassword: Component = () => {
         labelClass={styles.fieldLabel}
       />
       <StatusLine message={action.message()} />
-      <div>
+      <div class={actionsFooter}>
         <button
           type="button"
           onClick={() => void change()}

--- a/frontend/src/components/settings/account/AccountProfile.tsx
+++ b/frontend/src/components/settings/account/AccountProfile.tsx
@@ -1,6 +1,7 @@
 import type { Component } from 'solid-js'
 import { createMemo, createSignal, onMount, Show } from 'solid-js'
 import { userClient } from '~/api/clients'
+import { actionsFooter } from '~/components/common/actionsFooter.css'
 import { StatusLine } from '~/components/common/StatusLine'
 import { UsernameField } from '~/components/common/UsernameField'
 import { useAuth } from '~/context/AuthContext'
@@ -87,7 +88,7 @@ export const AccountProfile: Component = () => {
         {err => <div class={errorText}>{err()}</div>}
       </Show>
       <StatusLine message={action.message()} />
-      <div>
+      <div class={actionsFooter}>
         <button type="button" onClick={() => void save()} disabled={action.running() || !dirty() || !!displayNameError()}>
           {action.running() ? 'Saving...' : 'Save Profile'}
         </button>

--- a/frontend/src/components/settings/account/AppRegistrations.test.tsx
+++ b/frontend/src/components/settings/account/AppRegistrations.test.tsx
@@ -1,6 +1,8 @@
 import { fireEvent, render, screen, waitFor, within } from '@solidjs/testing-library'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { AccountAppRegistrations } from './AccountAppRegistrations'
+import { AppClientType, AppVisibility } from '~/generated/leapmux/v1/app_pb'
+import { Scope } from '~/generated/leapmux/v1/scope_pb'
+import { AppRegistrations } from './AppRegistrations'
 
 const mockList = vi.fn()
 const mockRegister = vi.fn()
@@ -34,10 +36,10 @@ const app = {
   clientId: 'app-1',
   clientName: 'My integration',
   clientUri: 'https://example.com',
-  visibility: 1, // PRIVATE
-  clientType: 1, // PUBLIC
+  visibility: AppVisibility.PRIVATE,
+  clientType: AppClientType.PUBLIC,
   redirectUris: ['https://example.com/callback'],
-  scopes: [5, 13], // WORKSPACE_READ, FILE_READ -- see scope.proto
+  scopes: [Scope.WORKSPACE_READ, Scope.FILE_READ],
   grantTypes: ['authorization_code', 'refresh_token'],
   elevationAllowed: false,
   registrationSource: 'user',
@@ -60,7 +62,7 @@ describe('accountAppRegistrations', () => {
   })
 
   it('lists the account registrations', async () => {
-    render(() => <AccountAppRegistrations />)
+    render(() => <AppRegistrations />)
     expect(await screen.findByText('My integration')).toBeInTheDocument()
   })
 
@@ -68,7 +70,7 @@ describe('accountAppRegistrations', () => {
   // it. The same fact appears here so the owner learns it before somebody else
   // meets it, rather than only where it is too late to act.
   it('marks an unverified registration', async () => {
-    render(() => <AccountAppRegistrations />)
+    render(() => <AppRegistrations />)
     expect(await screen.findByText('unverified')).toBeInTheDocument()
   })
 
@@ -76,7 +78,7 @@ describe('accountAppRegistrations', () => {
     mockList.mockResolvedValue({
       apps: [{ ...app, verified: true, verifiedAt: { seconds: 1767225600n, nanos: 0 }, verifiedByUsername: 'ada' }],
     })
-    render(() => <AccountAppRegistrations />)
+    render(() => <AppRegistrations />)
     expect(await screen.findByText('verified by ada')).toBeInTheDocument()
     expect(screen.queryByText('unverified')).not.toBeInTheDocument()
   })
@@ -85,7 +87,7 @@ describe('accountAppRegistrations', () => {
   // It renders as tokens derived from the generated enum, so a scope added to
   // the proto appears without an edit here.
   it('renders the permission ceiling as scope tokens', async () => {
-    render(() => <AccountAppRegistrations />)
+    render(() => <AppRegistrations />)
     const ceiling = await screen.findByTestId('app-ceiling-app-1')
     expect(ceiling).toHaveTextContent('workspace:read')
     expect(ceiling).toHaveTextContent('file:read')
@@ -107,7 +109,7 @@ describe('accountAppRegistrations', () => {
       nextCursor: '',
       openRegistrationEnabled: false,
     })
-    render(() => <AccountAppRegistrations />)
+    render(() => <AppRegistrations />)
     expect(await screen.findByText('Page one app')).toBeInTheDocument()
     await waitFor(() => expect(screen.getByText('Page two app')).toBeInTheDocument())
     expect(mockList).toHaveBeenCalledTimes(2)
@@ -116,7 +118,7 @@ describe('accountAppRegistrations', () => {
 
   it('reports an account with no registrations', async () => {
     mockList.mockResolvedValue({ apps: [] })
-    render(() => <AccountAppRegistrations />)
+    render(() => <AppRegistrations />)
     expect(await screen.findByText(/No app registrations/)).toBeInTheDocument()
   })
 
@@ -124,13 +126,13 @@ describe('accountAppRegistrations', () => {
   // way app.proto documents the field -- and only when it is ON, because the
   // off state is the default nobody needs told about.
   it('states open registration beside the list, only while it is on', async () => {
-    const { unmount } = render(() => <AccountAppRegistrations />)
+    const { unmount } = render(() => <AppRegistrations />)
     expect(await screen.findByText('My integration')).toBeInTheDocument()
     expect(screen.queryByTestId('open-registration-note')).not.toBeInTheDocument()
     unmount()
 
     mockList.mockResolvedValue({ apps: [app], openRegistrationEnabled: true })
-    render(() => <AccountAppRegistrations />)
+    render(() => <AppRegistrations />)
     expect(await screen.findByTestId('open-registration-note')).toHaveTextContent(/Open registration is on/)
   })
 
@@ -141,7 +143,7 @@ describe('accountAppRegistrations', () => {
     mockList.mockResolvedValue({
       apps: [{ ...app, registrationSource: 'builtin', clientName: 'LeapMux control CLI' }],
     })
-    render(() => <AccountAppRegistrations />)
+    render(() => <AppRegistrations />)
     await screen.findByText('LeapMux control CLI')
     expect(screen.getByRole('button', { name: 'Retire' })).toBeDisabled()
   })
@@ -151,7 +153,7 @@ describe('accountAppRegistrations', () => {
     mockList
       .mockResolvedValueOnce({ apps: [app] })
       .mockResolvedValueOnce({ apps: [] })
-    render(() => <AccountAppRegistrations />)
+    render(() => <AppRegistrations />)
     await screen.findByText('My integration')
 
     fireEvent.click(screen.getByRole('button', { name: 'Retire' }))
@@ -169,7 +171,7 @@ describe('accountAppRegistrations', () => {
 
   it('keeps the registration when the retire fails', async () => {
     mockRevoke.mockRejectedValue(new Error('the hub refused'))
-    render(() => <AccountAppRegistrations />)
+    render(() => <AppRegistrations />)
     await screen.findByText('My integration')
 
     fireEvent.click(screen.getByRole('button', { name: 'Retire' }))
@@ -186,14 +188,14 @@ describe('accountAppRegistrations', () => {
   // than saying nothing.
   it('does not report an empty account when the load failed', async () => {
     mockList.mockRejectedValue(new Error('the hub is down'))
-    render(() => <AccountAppRegistrations />)
+    render(() => <AppRegistrations />)
     expect(await screen.findByText(/the hub is down/)).toBeInTheDocument()
     expect(screen.queryByText(/No app registrations/)).not.toBeInTheDocument()
   })
 
   describe('registering', () => {
     it('registers a private app with the permissions ticked', async () => {
-      render(() => <AccountAppRegistrations />)
+      render(() => <AppRegistrations />)
       await screen.findByText('My integration')
 
       fireEvent.click(screen.getByRole('button', { name: 'Register an app' }))
@@ -215,7 +217,7 @@ describe('accountAppRegistrations', () => {
     // an app with no name has nothing for a consent screen to show, and one
     // with no permission asks for nothing.
     it('refuses to submit without a name and at least one permission', async () => {
-      render(() => <AccountAppRegistrations />)
+      render(() => <AppRegistrations />)
       await screen.findByText('My integration')
       fireEvent.click(screen.getByRole('button', { name: 'Register an app' }))
 
@@ -234,7 +236,7 @@ describe('accountAppRegistrations', () => {
     // stays open showing it instead of closing on success.
     it('shows a confidential app secret once and keeps the form open', async () => {
       mockRegister.mockResolvedValue({ app, clientSecret: 'the-secret-value' })
-      render(() => <AccountAppRegistrations />)
+      render(() => <AppRegistrations />)
       await screen.findByText('My integration')
 
       fireEvent.click(screen.getByRole('button', { name: 'Register an app' }))
@@ -253,7 +255,7 @@ describe('accountAppRegistrations', () => {
     // A PUBLIC client gets no secret at all, which is the honest answer for a
     // binary a user holds: PKCE is what protects it.
     it('shows no secret for a public app', async () => {
-      render(() => <AccountAppRegistrations />)
+      render(() => <AppRegistrations />)
       await screen.findByText('My integration')
 
       fireEvent.click(screen.getByRole('button', { name: 'Register an app' }))
@@ -267,7 +269,7 @@ describe('accountAppRegistrations', () => {
 
     it('reports a refused registration and keeps what was typed', async () => {
       mockRegister.mockRejectedValue(new Error('client_name is required'))
-      render(() => <AccountAppRegistrations />)
+      render(() => <AppRegistrations />)
       await screen.findByText('My integration')
 
       fireEvent.click(screen.getByRole('button', { name: 'Register an app' }))
@@ -284,7 +286,7 @@ describe('accountAppRegistrations', () => {
   // picker, ignores the app's theme, and renders text and nothing else -- so
   // the second line each choice needs would be impossible.
   it('offers the app type as a radiogroup', async () => {
-    render(() => <AccountAppRegistrations />)
+    render(() => <AppRegistrations />)
     await screen.findByText('My integration')
     fireEvent.click(screen.getByRole('button', { name: 'Register an app' }))
 
@@ -293,12 +295,67 @@ describe('accountAppRegistrations', () => {
     expect(document.querySelector('select')).toBeNull()
   })
 
+  describe('the permission ceiling', () => {
+    // The hub closes a grant at the mint, so a ceiling that states a write
+    // without its read states a boundary the hub cannot deliver. The form
+    // shows the closure: ticking the write implies the read, checked and
+    // locked, and the request carries it.
+    it('checks and locks the read a ticked write implies', async () => {
+      render(() => <AppRegistrations />)
+      await screen.findByText('My integration')
+      fireEvent.click(screen.getByRole('button', { name: 'Register an app' }))
+
+      fireEvent.click(screen.getByLabelText('workspace:write'))
+      expect(screen.getByLabelText('workspace:read')).toBeChecked()
+      expect(screen.getByLabelText('workspace:read')).toBeDisabled()
+
+      fireEvent.input(screen.getByLabelText(/Name/), { target: { value: 'CI bot' } })
+      fireEvent.click(screen.getByRole('button', { name: 'Register' }))
+      await waitFor(() => expect(mockRegister).toHaveBeenCalled())
+      const sent = mockRegister.mock.calls[0]![0] as { scopes: number[] }
+      expect(sent.scopes).toEqual([Scope.WORKSPACE_READ, Scope.WORKSPACE_WRITE])
+    })
+
+    // The lock is derived from the ticked set, not stored beside it: untick
+    // the write and the read it dragged in goes with it, rather than lurking
+    // as a tick the owner never chose.
+    it('frees the implied read when the write is unticked', async () => {
+      render(() => <AppRegistrations />)
+      await screen.findByText('My integration')
+      fireEvent.click(screen.getByRole('button', { name: 'Register an app' }))
+
+      fireEvent.click(screen.getByLabelText('workspace:write'))
+      fireEvent.click(screen.getByLabelText('workspace:write'))
+
+      expect(screen.getByLabelText('workspace:read')).not.toBeChecked()
+      expect(screen.getByLabelText('workspace:read')).toBeEnabled()
+    })
+
+    // The catalogue groups by the families scope.proto itself sections into,
+    // and the checkbox's accessible name stays the bare token -- the name a
+    // consent screen and a stored grant both read.
+    it('groups the scopes by family with each token labelable', async () => {
+      render(() => <AppRegistrations />)
+      await screen.findByText('My integration')
+      fireEvent.click(screen.getByRole('button', { name: 'Register an app' }))
+
+      const fieldset = document.querySelector('fieldset')!
+      expect(within(fieldset).getByText('Account')).toBeInTheDocument()
+      expect(within(fieldset).getByText('Workspace')).toBeInTheDocument()
+      expect(within(fieldset).getByText('Hub administration')).toBeInTheDocument()
+      // The description sits OUTSIDE the label, so it cannot leak into the
+      // checkbox's accessible name.
+      const label = within(fieldset).getByText('workspace:read').closest('label')
+      expect(label?.textContent).not.toContain('Read workspaces')
+    })
+  })
+
   describe('editing', () => {
     // The form opens PRE-FILLED: an edit that started blank would let one
     // stray Save strip the redirect addresses and the permission ceiling the
     // registration already had.
     it('opens the form pre-filled and replaces the editable fields', async () => {
-      render(() => <AccountAppRegistrations />)
+      render(() => <AppRegistrations />)
       await screen.findByText('My integration')
 
       fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
@@ -320,7 +377,12 @@ describe('accountAppRegistrations', () => {
         replaceRedirectUris: true,
         redirectUris: ['https://example.com/callback'],
         replaceScopes: true,
-        scopes: [5, 14], // WORKSPACE_READ kept, FILE_READ dropped, GIT_READ added
+        // WORKSPACE_READ kept, FILE_READ dropped, GIT_READ added -- and
+        // WORKER_READ is implied by git:read. The hub stores the
+        // ceiling closed (RegisterApp runs scopes.Close()), so submitting the
+        // bare ticked set and submitting this differ only in who did the
+        // arithmetic.
+        scopes: [Scope.WORKSPACE_READ, Scope.WORKER_READ, Scope.GIT_READ],
       }))
       expect(await screen.findByText('App updated.')).toBeInTheDocument()
     })
@@ -331,7 +393,7 @@ describe('accountAppRegistrations', () => {
       mockList.mockResolvedValue({
         apps: [{ ...app, registrationSource: 'builtin', clientName: 'LeapMux control CLI' }],
       })
-      render(() => <AccountAppRegistrations />)
+      render(() => <AppRegistrations />)
       await screen.findByText('LeapMux control CLI')
       expect(screen.getByRole('button', { name: 'Edit' })).toBeDisabled()
     })
@@ -341,7 +403,7 @@ describe('accountAppRegistrations', () => {
     // the owner gets the hub's reason beside the values they chose.
     it('reports a refused edit and keeps what was typed', async () => {
       mockUpdate.mockRejectedValue(new Error('the hub refused'))
-      render(() => <AccountAppRegistrations />)
+      render(() => <AppRegistrations />)
       await screen.findByText('My integration')
 
       fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
@@ -358,7 +420,7 @@ describe('accountAppRegistrations', () => {
   describe('the step-up allowance', () => {
     // Allowing multiplies what the app's grant reaches, so it asks first.
     it('asks before allowing and then records it', async () => {
-      render(() => <AccountAppRegistrations />)
+      render(() => <AppRegistrations />)
       await screen.findByText('My integration')
 
       fireEvent.click(screen.getByRole('button', { name: 'Allow step-up' }))
@@ -371,7 +433,7 @@ describe('accountAppRegistrations', () => {
     // Refusing only reduces access, so it takes no dialog -- one click.
     it('refuses without a dialog and reports that live windows close', async () => {
       mockList.mockResolvedValue({ apps: [{ ...app, elevationAllowed: true }] })
-      render(() => <AccountAppRegistrations />)
+      render(() => <AppRegistrations />)
       await screen.findByText('My integration')
       expect(screen.getByText('step-up allowed')).toBeInTheDocument()
 
@@ -387,7 +449,7 @@ describe('accountAppRegistrations', () => {
       mockList.mockResolvedValue({
         apps: [{ ...app, registrationSource: 'builtin', clientName: 'LeapMux control CLI' }],
       })
-      render(() => <AccountAppRegistrations />)
+      render(() => <AppRegistrations />)
       await screen.findByText('LeapMux control CLI')
 
       expect(screen.getByRole('button', { name: 'Allow step-up' })).toBeEnabled()
@@ -399,14 +461,14 @@ describe('accountAppRegistrations', () => {
     // else's private apps from a non-admin, and self-vouching is exactly the
     // thing a vouch is not.
     it('offers no vouch control to an ordinary account', async () => {
-      render(() => <AccountAppRegistrations />)
+      render(() => <AppRegistrations />)
       await screen.findByText('My integration')
       expect(screen.queryByRole('button', { name: 'Vouch' })).not.toBeInTheDocument()
     })
 
     it('records an administrator\'s vouch', async () => {
       authState.admin = true
-      render(() => <AccountAppRegistrations />)
+      render(() => <AppRegistrations />)
       await screen.findByText('My integration')
 
       fireEvent.click(screen.getByRole('button', { name: 'Vouch' }))
@@ -419,12 +481,67 @@ describe('accountAppRegistrations', () => {
       mockList.mockResolvedValue({
         apps: [{ ...app, verified: true, verifiedAt: { seconds: 1767225600n, nanos: 0 }, verifiedByUsername: 'ada' }],
       })
-      render(() => <AccountAppRegistrations />)
+      render(() => <AppRegistrations />)
       await screen.findByText('verified by ada')
 
       fireEvent.click(screen.getByRole('button', { name: 'Withdraw vouch' }))
 
       await waitFor(() => expect(mockVerify).toHaveBeenCalledWith({ clientId: 'app-1', verified: false }))
+    })
+  })
+
+  // The ADMINISTRATION twin: the same editor wearing variant="hub-wide", the
+  // panel the Hub-wide Apps section renders. Its two differences are pinned
+  // here -- the registration it writes is HUB_WIDE, and the listing it asks
+  // for is the hub's own catalogue alone.
+  describe('the hub-wide variant', () => {
+    it('registers a hub-wide app', async () => {
+      render(() => <AppRegistrations variant="hub-wide" />)
+      await screen.findByTestId('hub-wide-app-registrations')
+
+      fireEvent.click(screen.getByRole('button', { name: 'Register a hub-wide app' }))
+      fireEvent.input(screen.getByLabelText(/Name/), { target: { value: 'Deploy bot' } })
+      fireEvent.click(screen.getByLabelText('workspace:read'))
+      fireEvent.click(screen.getByRole('button', { name: 'Register' }))
+
+      await waitFor(() => expect(mockRegister).toHaveBeenCalled())
+      const sent = mockRegister.mock.calls[0]![0] as { visibility: number, scopes: number[] }
+      // HUB_WIDE, the visibility only an administrator may send -- the row
+      // that renders this variant exists for administrators alone.
+      expect(sent.visibility).toBe(AppVisibility.HUB_WIDE)
+      expect(sent.scopes).toEqual([Scope.WORKSPACE_READ])
+    })
+
+    // The hub's own catalogue, not the administrator's second Apps list: the
+    // narrowing rides the REQUEST, so an administrator's private
+    // registrations never cross the wire to a panel that cannot draw them.
+    it('asks the hub for the hub-wide reach alone', async () => {
+      mockList.mockResolvedValue({
+        apps: [{ ...app, clientId: 'app-hub', clientName: 'Hub tool', visibility: 2 }],
+      })
+      render(() => <AppRegistrations variant="hub-wide" />)
+
+      expect(await screen.findByText('Hub tool')).toBeInTheDocument()
+      const sent = mockList.mock.calls[0]![0] as { visibility?: number }
+      expect(sent.visibility).toBe(AppVisibility.HUB_WIDE)
+      // The reach badge is the section's own title restated per row, so the
+      // variant does not draw it.
+      expect(screen.queryByText('hub-wide')).not.toBeInTheDocument()
+    })
+
+    it('asks for its whole editable set on the user panel', async () => {
+      mockList.mockResolvedValue({ apps: [app] })
+      render(() => <AppRegistrations />)
+
+      expect(await screen.findByTestId('app-registration-app-1')).toBeInTheDocument()
+      const sent = mockList.mock.calls[0]![0] as { visibility?: number }
+      expect(sent.visibility).toBeUndefined()
+    })
+
+    it('says so when the hub holds none', async () => {
+      mockList.mockResolvedValue({ apps: [] })
+      render(() => <AppRegistrations variant="hub-wide" />)
+      expect(await screen.findByText(/No hub-wide app registrations/)).toBeInTheDocument()
     })
   })
 })
@@ -444,7 +561,7 @@ describe('refresh generation guard', () => {
       .mockReturnValueOnce(stalePageTwo.promise)
       // A write path then fires a NEWER refresh, which answers in one page.
       .mockResolvedValueOnce({ apps: [newerApp], nextCursor: '', openRegistrationEnabled: false })
-    render(() => <AccountAppRegistrations />)
+    render(() => <AppRegistrations />)
 
     // The register form's success handler PREPENDS the row the response
     // carries, with no re-page -- so the new registration shows while the

--- a/frontend/src/components/settings/account/AppRegistrations.tsx
+++ b/frontend/src/components/settings/account/AppRegistrations.tsx
@@ -1,9 +1,12 @@
 import type { Component, JSX } from 'solid-js'
 import type { StatusMessage } from '~/components/common/StatusLine'
 import type { App } from '~/generated/leapmux/v1/app_pb'
+import type { Scope } from '~/generated/leapmux/v1/scope_pb'
 import { timestampDate } from '@bufbuild/protobuf/wkt'
-import { createSignal, For, onMount, Show, untrack } from 'solid-js'
+import { createMemo, createSignal, For, onMount, Show, untrack } from 'solid-js'
 import { appClient } from '~/api/clients'
+import { RelativeTimeAgo } from '~/components/chat/RelativeTime'
+import { actionsFooter } from '~/components/common/actionsFooter.css'
 import { ConfirmDialog } from '~/components/common/ConfirmDialog'
 import { PillGroup } from '~/components/common/PillGroup'
 import { Spinner } from '~/components/common/Spinner'
@@ -11,31 +14,12 @@ import { StatusLine } from '~/components/common/StatusLine'
 import { Tooltip } from '~/components/common/Tooltip'
 import { useAuth } from '~/context/AuthContext'
 import { AppClientType, AppVisibility } from '~/generated/leapmux/v1/app_pb'
-import { Scope } from '~/generated/leapmux/v1/scope_pb'
 import { useCopyButton } from '~/hooks/useCopyButton'
 import { formatErrorMessage } from '~/lib/errors'
 import * as styles from './credentialList.css'
 import { fetchAllPages, MAX_PAGES, PAGE_SIZE } from './fetchAllPages'
+import { closeScopes, impliedScopes, SCOPE_CATEGORIES } from './scopeCatalogue'
 import { scopeToken } from './scopeToken'
-
-/**
- * The grantable vocabulary, in the order scope.proto declares it.
- *
- * It is derived from the generated enum rather than typed again: a scope added
- * to the proto appears here without an edit, and one removed cannot linger as
- * a checkbox that registers nothing.
- *
- * The three NON-grantable values are excluded by name, because each is a
- * construction rather than a permission: UNSPECIFIED is "nobody classified
- * this", NEVER is a recorded refusal, and ALL is the absence of a limit, which
- * no registration may claim.
- */
-const NON_GRANTABLE: readonly Scope[] = [Scope.UNSPECIFIED, Scope.NEVER, Scope.ALL]
-
-const GRANTABLE_SCOPES: readonly Scope[] = Object.values(Scope)
-  .filter((v): v is Scope => typeof v === 'number')
-  .filter(scope => !NON_GRANTABLE.includes(scope))
-  .sort((a, b) => a - b)
 
 /**
  * The editable field set the register and edit forms share: name, home page,
@@ -60,8 +44,27 @@ function createAppFormFields(initial?: { name: string, uri: string, redirects: s
       : [...current, scope])
   }
 
+  /**
+   * The scopes the ticked set implies, whether or not they were ticked.
+   *
+   * A memo, not a plain function: the checkbox list reads it twice per row
+   * (checked and disabled), so a plain function would re-run the fixed
+   * point for every attribute of every row on every tick -- one derivation
+   * per change is the whole point.
+   *
+   * The hub closes a grant at the mint (RegisterApp stores
+   * `scopes.Close()`), so an implied scope renders CHECKED and DISABLED --
+   * unticking it would state a boundary the hub cannot deliver -- and the
+   * submitted set carries it, so what the owner ticked is exactly what the
+   * next ListApps reads back.
+   */
+  const implied = createMemo(() => impliedScopes(scopes()))
+
   const redirectList = () =>
     redirects().split('\n').map(line => line.trim()).filter(line => line !== '')
+
+  /** The submitted ceiling: the ticked set, closed the way the hub stores it. */
+  const closedScopes = () => closeScopes(scopes())
 
   const Fields: Component<{ afterRedirects?: JSX.Element }> = props => (
     <>
@@ -95,26 +98,73 @@ function createAppFormFields(initial?: { name: string, uri: string, redirects: s
       {props.afterRedirects}
       <fieldset>
         <legend>Permissions this app may ask for</legend>
-        <div class={styles.credentialScopeLine}>
-          <For each={GRANTABLE_SCOPES}>
-            {scope => (
-              <label class={styles.credentialScope}>
-                <input
-                  type="checkbox"
-                  checked={scopes().includes(scope)}
-                  onChange={() => toggleScope(scope)}
-                />
-                {' '}
-                {scopeToken(scope)}
-              </label>
+        {/*
+          Grouped the way scope.proto's own sections group it, each scope with
+          the sentence its proto comment states: a ceiling is a decision, and a
+          bare list of tokens makes the reader guess at what "workspace:write"
+          reaches. The accessible name of each checkbox stays the bare token,
+          which is the name a consent screen and a stored grant both read.
+        */}
+        <ul class={styles.scopeChoiceList}>
+          <For each={SCOPE_CATEGORIES}>
+            {category => (
+              <li class={styles.scopeChoiceCategory}>
+                <span class={styles.scopeChoiceLabel}>{category.label}</span>
+                <ul class={styles.scopeChoiceEntries}>
+                  <For each={category.entries}>
+                    {({ scope, description }) => (
+                      <li class={styles.scopeChoiceEntry}>
+                        <label>
+                          <input
+                            type="checkbox"
+                            checked={scopes().includes(scope) || implied().has(scope)}
+                            disabled={implied().has(scope)}
+                            onChange={() => toggleScope(scope)}
+                          />
+                          {' '}
+                          <span class={styles.scopeChoiceToken}>{scopeToken(scope)}</span>
+                        </label>
+                        <span class={styles.scopeChoiceDescription}>{description}</span>
+                      </li>
+                    )}
+                  </For>
+                </ul>
+              </li>
             )}
           </For>
-        </div>
+        </ul>
       </fieldset>
     </>
   )
 
-  return { Fields, name, uri, scopes, redirectList, setName }
+  return { Fields, name, uri, scopes, closedScopes, redirectList, setName }
+}
+
+/**
+ * The shared register/edit footer: Cancel (outline, left) before the primary
+ * verb (right), matching every dialog footer in the frontend.
+ *
+ * One component, because the two forms' footers were a verbatim pair -- the
+ * shared disable rule included -- and a pair is where the next edit lands on
+ * one side. The gate stays the caller's: both forms disable the primary on
+ * the same empty-name-or-no-scopes condition, expressed once at each call
+ * site from the fields it owns.
+ */
+function FormActions(props: {
+  busy: boolean
+  disabled: boolean
+  label: string
+  onCancel: () => void
+  onSubmit: () => void
+}) {
+  return (
+    <div class={actionsFooter}>
+      <button type="button" class="outline" onClick={() => props.onCancel()} disabled={props.busy}>Cancel</button>
+      <button type="button" onClick={() => props.onSubmit()} disabled={props.busy || props.disabled}>
+        {props.label}
+      </button>
+    </div>
+  )
 }
 
 /**
@@ -126,6 +176,14 @@ function createAppFormFields(initial?: { name: string, uri: string, redirects: s
  */
 const RegisterAppForm: Component<{
   busy: boolean
+  /**
+   * What the registration reaches. PRIVATE is the user panel's constant; the
+   * administration panel passes HUB_WIDE. It is a prop rather than a control
+   * in the form because the hub refuses hub-wide for anybody but an
+   * administrator -- a chooser most accounts are refused would be worse than
+   * no chooser, so each panel states the one visibility its caller may mean.
+   */
+  visibility: AppVisibility
   onCancel: () => void
   onRegistered: (message: string, app?: App) => void
   onError: (message: string) => void
@@ -150,12 +208,11 @@ const RegisterAppForm: Component<{
         clientName: fields.name().trim(),
         clientUri: fields.uri().trim(),
         redirectUris: fields.redirectList(),
-        scopes: fields.scopes(),
-        // PRIVATE always, from this panel. A hub-wide registration needs an
-        // administrator, and offering a control that most accounts are
-        // refused would be a worse answer than not offering it: the CLI's
-        // `--visibility hub-wide` is where an administrator does it.
-        visibility: AppVisibility.PRIVATE,
+        // CLOSED, as the hub would close it anyway: the ceiling is stored
+        // expanded, so submitting the bare ticked set and submitting this
+        // differ only in who did the arithmetic.
+        scopes: fields.closedScopes(),
+        visibility: props.visibility,
         clientType: clientType(),
       })
       if (resp.clientSecret) {
@@ -198,12 +255,18 @@ const RegisterAppForm: Component<{
                 />
               )}
             />
-            <div class="hstack gap-2">
-              <button type="button" onClick={() => void submit()} disabled={props.busy || fields.name().trim() === '' || fields.scopes().length === 0}>
-                Register
-              </button>
-              <button type="button" onClick={props.onCancel} disabled={props.busy}>Cancel</button>
-            </div>
+            {/*
+              CANCEL then the primary, matching every dialog footer in the
+              frontend: the quiet outline escape on the left, the verb that
+              does the thing on the right.
+            */}
+            <FormActions
+              busy={props.busy}
+              disabled={fields.name().trim() === '' || fields.scopes().length === 0}
+              label="Register"
+              onCancel={props.onCancel}
+              onSubmit={() => void submit()}
+            />
           </>
         )}
       >
@@ -214,7 +277,7 @@ const RegisterAppForm: Component<{
           <code data-testid="new-client-secret">{secret()}</code>
           <button type="button" onClick={() => void copy()}>{copied() ? 'Copied' : 'Copy'}</button>
         </div>
-        <div>
+        <div class={actionsFooter}>
           <button type="button" onClick={() => created() && props.onRegistered('App registered.', created()!)}>Done</button>
         </div>
       </Show>
@@ -259,7 +322,11 @@ const EditAppForm: Component<{
         replaceRedirectUris: true,
         redirectUris: fields.redirectList(),
         replaceScopes: true,
-        scopes: fields.scopes(),
+        // CLOSED, for the same reason the register path closes: the hub
+        // stores the expanded ceiling, and the edit pre-fills from what it
+        // stored -- a bare ticked set here would strip the implied scopes on
+        // every round trip through this form.
+        scopes: fields.closedScopes(),
       })
       props.onSaved('App updated.', resp.app)
     }
@@ -274,12 +341,13 @@ const EditAppForm: Component<{
   return (
     <div class="vstack gap-3" data-testid={`edit-app-form-${props.app.clientId}`}>
       <fields.Fields />
-      <div class="hstack gap-2">
-        <button type="button" onClick={() => void submit()} disabled={props.busy || fields.name().trim() === '' || fields.scopes().length === 0}>
-          Save
-        </button>
-        <button type="button" onClick={() => props.onCancel()} disabled={props.busy}>Cancel</button>
-      </div>
+      <FormActions
+        busy={props.busy}
+        disabled={fields.name().trim() === '' || fields.scopes().length === 0}
+        label="Save"
+        onCancel={props.onCancel}
+        onSubmit={() => void submit()}
+      />
     </div>
   )
 }
@@ -295,9 +363,22 @@ const EditAppForm: Component<{
  * authorizable to that account alone. An administrator's is hub-wide. One
  * column on the hub carries that whole rule, so there is no second flag here
  * that could disagree with what the list shows.
+ *
+ * TWO panels render this one editor. The default (the user-level Apps
+ * section) registers PRIVATE and lists what the caller's own listing answers.
+ * The `hub-wide` variant (the administration section) registers HUB_WIDE and
+ * asks the hub for the catalogue alone -- the registrations that reach
+ * everybody -- so an administrator reads one catalogue, not their private
+ * apps twice.
  */
-export const AccountAppRegistrations: Component = () => {
+export interface AppRegistrationsProps {
+  /** `'hub-wide'` lists and registers the hub's own registrations. */
+  variant?: 'user' | 'hub-wide'
+}
+
+export const AppRegistrations: Component<AppRegistrationsProps> = (props) => {
   const auth = useAuth()
+  const hubWide = () => (props.variant ?? 'user') === 'hub-wide'
   const [apps, setApps] = createSignal<App[]>([])
   const [loading, setLoading] = createSignal(true)
   // Distinct from `message`, which the write paths also use. Without it a hub
@@ -346,13 +427,22 @@ export const AccountAppRegistrations: Component = () => {
       // The hub's own switch rides the listing; the last page's value is the
       // current one, so the fetchPage callback records it as a side effect.
       let openRegistrationEnabled = false
+      // The reach rides the request, read ONCE before the pagination: the
+      // variant is fixed for the panel's life, and a reactive read inside
+      // the untracked page callback would re-evaluate per page for nothing.
+      const reach = hubWide() ? AppVisibility.HUB_WIDE : undefined
       const collected = await fetchAllPages(
         async (cursor) => {
           // includeRevoked: a retired app stays readable because a live
           // credential on one must still be explainable (app.proto states the
           // contract), and the retired badge and the gates below key on it --
           // without the flag the row vanishes on the refresh that retires it.
-          const resp = await appClient.listApps({ cursor, limit: PAGE_SIZE, includeRevoked: true })
+          const resp = await appClient.listApps({
+            cursor,
+            limit: PAGE_SIZE,
+            includeRevoked: true,
+            visibility: reach,
+          })
           openRegistrationEnabled = resp.openRegistrationEnabled
           return { items: resp.apps, nextCursor: resp.nextCursor }
         },
@@ -502,38 +592,40 @@ export const AccountAppRegistrations: Component = () => {
     }
   }
 
-  const describe = (app: App) => {
-    const parts: string[] = []
-    if (app.createdAt)
-      parts.push(`Registered ${timestampDate(app.createdAt).toLocaleDateString()}`)
+  /**
+   * The live-credential count, the one fact the row states beside the date.
+   * Empty when there are none, so the meta line renders no bare separator.
+   */
+  const liveCredentialNote = (app: App) => {
     const live = Number(app.liveCredentialCount)
-    if (live > 0)
-      parts.push(`${live} live credential${live === 1 ? '' : 's'}`)
-    return parts.join(' · ')
+    return live > 0 ? `${live} live credential${live === 1 ? '' : 's'}` : ''
   }
 
   return (
     <>
-      <div class="vstack gap-4" data-testid="app-registrations">
+      <div class="vstack gap-4" data-testid={hubWide() ? 'hub-wide-app-registrations' : 'app-registrations'}>
         <Show when={loading()}>
           <div class={styles.credentialListLoading}><Spinner /></div>
         </Show>
         <Show when={!loading() && !loadFailed() && apps().length === 0 && !creating()}>
           <p class={styles.credentialListEmpty}>
-            No app registrations. Register one to let a program ask for access to accounts on this hub.
+            {hubWide()
+              ? 'No hub-wide app registrations. Register one to let every account on this hub authorize it.'
+              : 'No app registrations. Register one to let a program ask for access to accounts on this hub.'}
           </p>
         </Show>
         {/*
           The state of the hub-wide switch, stated where its effects land. It
-          is a fact an administrator changed under Administration, Apps -- but
-          reading it only there would put it beside no app at all, and the
-          hub-wide rows this panel already lists for an administrator are the
-          ones the switch admits company for.
+          is a fact an administrator changed under Administration › Hub-wide
+          Apps -- but reading it only there would put it beside no app at all,
+          and the rows a listing already carries are the ones the switch
+          admits company for. The path separator is ›, the same character the
+          Preferences search breadcrumb spells paths with.
         */}
         <Show when={!loading() && !loadFailed() && openRegistration()}>
           <p class={styles.credentialListEmpty} data-testid="open-registration-note">
             Open registration is on: an app can register itself at /oauth/register without an
-            administrator. Administrators turn it off under Administration, Apps.
+            administrator. Administrators turn it off under Administration › Hub-wide Apps.
           </p>
         </Show>
         {/*
@@ -547,6 +639,11 @@ export const AccountAppRegistrations: Component = () => {
             <div class="vstack gap-3">
               <div class={styles.credentialRow} data-testid={`app-registration-${app.clientId}`}>
                 <div class={styles.credentialInfo}>
+                  {/*
+                    The name's line carries every chip that QUALIFIES the name
+                    -- the vouch, the reach, the app's kind -- so one glance
+                    answers "what am I looking at" without a second line.
+                  */}
                   <span class={styles.credentialName}>
                     {app.clientName || 'Unnamed app'}
                     {' '}
@@ -559,34 +656,70 @@ export const AccountAppRegistrations: Component = () => {
                         // (a vouch or a built-in) travels in this field, so a
                         // built-in registration reads verified here exactly as
                         // the consent page renders it.
-                        <span class={styles.credentialBadgeWarning}>unverified</span>
+                        <span class="badge" data-variant="warning">unverified</span>
                       }
                     >
-                      <span class={styles.credentialBadge}>
+                      <span class="badge" data-variant="success">
                         verified
                         {app.verifiedByUsername ? ` by ${app.verifiedByUsername}` : ''}
                       </span>
                     </Show>
-                    <Show when={app.visibility === AppVisibility.HUB_WIDE}>
+                    {/*
+                      The reach badge, absent from the hub-wide panel: every
+                      row there reaches everybody, so the badge would repeat
+                      the section's own title once per row.
+                    */}
+                    <Show when={app.visibility === AppVisibility.HUB_WIDE && !hubWide()}>
                       {' '}
-                      <span class={styles.credentialBadge}>hub-wide</span>
+                      <span class="badge outline">hub-wide</span>
                     </Show>
                     <Show when={app.elevationAllowed}>
                       {' '}
-                      <span class={styles.credentialBadge}>step-up allowed</span>
+                      <span class="badge outline">step-up allowed</span>
                     </Show>
                     <Show when={app.revokedAt}>
                       {' '}
-                      <span class={styles.credentialBadgeWarning}>retired</span>
+                      <span class="badge" data-variant="danger">retired</span>
+                    </Show>
+                    {' '}
+                    <Show
+                      when={app.clientType === AppClientType.CONFIDENTIAL}
+                      fallback={<span class="badge outline">public app</span>}
+                    >
+                      <span class="badge outline">confidential app</span>
                     </Show>
                   </span>
-                  <span class={styles.credentialSubRow}>
+                  {/*
+                    The metadata line, every part delimited by a middot: when
+                    it was registered, the registration date in the app's
+                    relative form (the same <RelativeTimeAgo> the chat and the
+                    file tree render, with the full local date and time on
+                    hover), the client id a developer copies into a config,
+                    and the live-credential count. A bare toLocaleDateString
+                    answered "8/29/2026" to a reader whose real question was
+                    "how long has this been here".
+                  */}
+                  <span class={styles.credentialMeta}>
+                    <Show when={app.createdAt}>
+                      {ts => (
+                        <>
+                          Registered
+                          {' '}
+                          <RelativeTimeAgo timestamp={timestampDate(ts()).toISOString()} />
+                          {' · '}
+                        </>
+                      )}
+                    </Show>
                     <code>{app.clientId}</code>
-                    <Show when={app.clientType === AppClientType.CONFIDENTIAL} fallback={<span>public app</span>}>
-                      <span>confidential app</span>
+                    <Show when={liveCredentialNote(app)}>
+                      {note => (
+                        <>
+                          {' · '}
+                          {note()}
+                        </>
+                      )}
                     </Show>
                   </span>
-                  <span class={styles.credentialMeta}>{describe(app)}</span>
                   <Show when={ceiling(app).length > 0}>
                     <span class={styles.credentialScopeLine} data-testid={`app-ceiling-${app.clientId}`}>
                       <For each={ceiling(app)}>
@@ -595,7 +728,7 @@ export const AccountAppRegistrations: Component = () => {
                     </span>
                   </Show>
                 </div>
-                <div class={styles.credentialActions}>
+                <div class={actionsFooter}>
                   {/*
                     Edit rewrites where a consent redirects, which is the most
                     dangerous write in the feature -- so it sits behind the
@@ -664,7 +797,10 @@ export const AccountAppRegistrations: Component = () => {
                     so the hub refuses to retire one. The control says so rather
                     than being offered and then failing.
 
-                    The tooltip takes NO ariaLabel: the button already reads
+                    An Oat danger OUTLINE, not a filled button: retiring asks in
+                    a dialog of its own, and this control only opens it -- the
+                    dialog's primary is where the danger weight belongs. The
+                    tooltip takes NO ariaLabel: the button already reads
                     "Retire", and ariaLabel would REPLACE that name with the whole
                     sentence -- a screen reader would announce a reason where the
                     verb belongs, and every by-name lookup would stop matching.
@@ -676,13 +812,14 @@ export const AccountAppRegistrations: Component = () => {
                     when={app.registrationSource !== 'builtin'}
                     fallback={(
                       <Tooltip text="This app ships with the hub, so it cannot be retired.">
-                        <button type="button" class={styles.credentialDanger} disabled>Retire</button>
+                        <button type="button" class="outline" data-variant="danger" disabled>Retire</button>
                       </Tooltip>
                     )}
                   >
                     <button
                       type="button"
-                      class={styles.credentialDanger}
+                      class="outline"
+                      data-variant="danger"
                       onClick={() => setTarget(app)}
                       disabled={busy() || app.revokedAt !== undefined}
                     >
@@ -712,15 +849,16 @@ export const AccountAppRegistrations: Component = () => {
         <Show
           when={creating()}
           fallback={(
-            <div>
+            <div class={actionsFooter}>
               <button type="button" onClick={() => setCreating(true)} disabled={busy()}>
-                Register an app
+                {hubWide() ? 'Register a hub-wide app' : 'Register an app'}
               </button>
             </div>
           )}
         >
           <RegisterAppForm
             busy={busy()}
+            visibility={hubWide() ? AppVisibility.HUB_WIDE : AppVisibility.PRIVATE}
             onCancel={() => setCreating(false)}
             onRegistered={(text, app) => {
               setCreating(false)

--- a/frontend/src/components/settings/account/accountFields.css.ts
+++ b/frontend/src/components/settings/account/accountFields.css.ts
@@ -36,38 +36,21 @@ export const unverifiedBadge = style({
   color: 'var(--warning)',
 })
 
-export const linkedAccount = style({
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'space-between',
-  padding: 'var(--space-2) var(--space-3)',
-  fontSize: 'var(--text-7)',
-  color: 'var(--foreground)',
-  backgroundColor: 'var(--card)',
-  border: '1px solid var(--border)',
-  borderRadius: 'var(--radius-2)',
-})
+/**
+ * One linked provider's card is a `credentialRow` (see
+ * `./credentialList.css.ts`): a COLUMN like every credential row, with the
+ * provider's name (and its disabled note) taking the full width and the
+ * Unlink in a footer row beneath them. The card style itself is shared, so
+ * the provider row and the credential row cannot drift apart.
+ */
 
 export const linkedAccountName = style({
-  flex: 1,
+  fontWeight: 'var(--font-medium)',
 })
 
 /** The note on a link whose provider an administrator turned off. */
 export const linkedAccountDisabled = style({
   fontSize: 'var(--text-8)',
   color: 'var(--muted-foreground)',
-  flex: 1,
   minWidth: 0,
-})
-
-export const linkedAccountUnlink = style({
-  'fontSize': 'var(--text-8)',
-  'color': 'var(--muted-foreground)',
-  'background': 'none',
-  'border': 'none',
-  'cursor': 'pointer',
-  'padding': 'var(--space-1) var(--space-2)',
-  ':hover': {
-    color: 'var(--danger)',
-  },
 })

--- a/frontend/src/components/settings/account/credentialList.css.ts
+++ b/frontend/src/components/settings/account/credentialList.css.ts
@@ -4,10 +4,15 @@ import { style } from '@vanilla-extract/css'
  * The style vocabulary the account's CREDENTIAL LISTS share.
  *
  * Two surfaces render the same row shape -- a name, a line of metadata, and a
- * couple of actions on the right: the passkeys and the command-line
+ * couple of actions in a footer row: the passkeys and the command-line
  * credentials. They used to read these names out of one component's private
  * stylesheet, which made a sibling import a file named after something it does
  * not render.
+ *
+ * The chips a row carries (verified, hub-wide, retired) are Oat `badge`
+ * variants rather than styles here, and a destructive action is an Oat danger
+ * button -- a second spelling of either could drift from the one every other
+ * panel wears.
  *
  * `./accountFields.css.ts` keeps the FIELD vocabulary (labels, the email
  * value, the provider rows) that the other account editors share.
@@ -25,24 +30,31 @@ export const credentialListEmpty = style({
   margin: 0,
 })
 
+/**
+ * One credential's card.
+ *
+ * A COLUMN: the entry's text takes the full width, and the actions sit in a
+ * footer row beneath it. Sharing one line squeezed the text into whatever the
+ * buttons left -- three of them on an app registration left less than half
+ * the card -- while the metadata they act on is the part worth reading.
+ */
 export const credentialRow = style({
   display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'space-between',
-  gap: 'var(--space-3)',
-  padding: 'var(--space-2) var(--space-3)',
+  flexDirection: 'column',
+  alignItems: 'stretch',
+  gap: 'var(--space-2)',
+  padding: 'var(--space-3)',
   fontSize: 'var(--text-7)',
   color: 'var(--foreground)',
   backgroundColor: 'var(--card)',
   border: '1px solid var(--border)',
-  borderRadius: 'var(--radius-2)',
+  borderRadius: 'var(--radius-medium)',
 })
 
 export const credentialInfo = style({
   display: 'flex',
   flexDirection: 'column',
   gap: 'var(--space-1)',
-  flex: 1,
   minWidth: 0,
 })
 
@@ -54,62 +66,6 @@ export const credentialMeta = style({
   fontSize: 'var(--text-8)',
   color: 'var(--muted-foreground)',
 })
-
-export const credentialActions = style({
-  display: 'flex',
-  gap: 'var(--space-2)',
-  flexShrink: 0,
-})
-
-export const credentialDanger = style({
-  color: 'var(--danger)',
-})
-
-/** The row of buttons that opens a passkey ceremony. */
-export const passkeyButtons = style({
-  display: 'flex',
-  gap: 'var(--space-3)',
-  flexWrap: 'wrap',
-})
-
-/**
- * A second line under the credential name, for a fact that qualifies it
- * rather than identifies it -- which app holds the credential, and which
- * installation of that app.
- */
-export const credentialSubRow = style({
-  display: 'flex',
-  alignItems: 'center',
-  gap: 'var(--space-2)',
-  flexWrap: 'wrap',
-  fontSize: 'var(--text-8)',
-  color: 'var(--muted-foreground)',
-})
-
-/**
- * A short chip beside a credential's name: "unverified", "hub administration".
- *
- * It carries its own colours through a variant rather than a caller-supplied
- * class, so a warning and a neutral note cannot be spelled two ways.
- */
-export const credentialBadge = style({
-  display: 'inline-flex',
-  alignItems: 'center',
-  padding: '1px var(--space-2)',
-  borderRadius: 'var(--radius-1)',
-  fontSize: 'var(--text-8)',
-  fontWeight: 'var(--font-medium)',
-  backgroundColor: 'var(--muted)',
-  color: 'var(--muted-foreground)',
-  border: '1px solid var(--border)',
-})
-
-/** credentialBadge for a fact the reader should weigh before continuing. */
-export const credentialBadgeWarning = style([credentialBadge, {
-  backgroundColor: 'var(--danger-subtle, var(--muted))',
-  color: 'var(--danger)',
-  borderColor: 'var(--danger)',
-}])
 
 /**
  * The permission list under a credential.
@@ -129,14 +85,14 @@ export const credentialScopeLine = style({
 /** One permission inside credentialScopeLine. */
 export const credentialScope = style({
   padding: '0 var(--space-1)',
-  borderRadius: 'var(--radius-1)',
+  borderRadius: 'var(--radius-small)',
   backgroundColor: 'var(--muted)',
   fontFamily: 'var(--font-mono)',
 })
 
 /**
- * One APP's block in the connected-apps list: its name and its Disconnect on
- * one line, its installations stacked under them.
+ * One APP's block in the connected-apps list: its name, its installations
+ * stacked under it, and the app-level ending in a footer row.
  *
  * The grouping is the panel's whole shape. One app holds one credential per
  * machine, so a flat list of credentials made "stop this app reaching my
@@ -150,28 +106,87 @@ export const credentialGroup = style({
   padding: 'var(--space-3)',
   backgroundColor: 'var(--card)',
   border: '1px solid var(--border)',
-  borderRadius: 'var(--radius-2)',
-})
-
-/** The app's own line: its name and identity on the left, Disconnect right. */
-export const credentialGroupHeader = style({
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'space-between',
-  gap: 'var(--space-3)',
+  borderRadius: 'var(--radius-medium)',
 })
 
 /**
  * The installations inside a group.
  *
- * Indented and separated from the app line above, so the two levels read as
- * "this app" and "on these machines" rather than as one flat list whose rows
- * happen to share a name.
+ * A plain stack: each installation is itself a bordered row, so the nesting
+ * reads from the cards alone -- an indent or a rule down the left edge drew
+ * structure the inner cards had already stated.
  */
 export const credentialGroupBody = style({
   display: 'flex',
   flexDirection: 'column',
   gap: 'var(--space-2)',
-  paddingLeft: 'var(--space-3)',
-  borderLeft: '1px solid var(--border)',
+})
+
+/**
+ * The category list the permission-ceiling fieldset renders.
+ *
+ * Plain UL markers, one indent per level, no bullets on the outer level: the
+ * legend already states what the list is, and the outer entries carry their
+ * own weight as family names. The structure is the grouping -- Account,
+ * Workspace, Worker -- that scope.proto's own sections state.
+ */
+export const scopeChoiceList = style({
+  margin: 0,
+  padding: 0,
+  listStyle: 'none',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 'var(--space-3)',
+})
+
+/** One family: its label and the scopes beneath it. */
+export const scopeChoiceCategory = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 'var(--space-1)',
+})
+
+export const scopeChoiceLabel = style({
+  fontSize: 'var(--text-7)',
+  fontWeight: 'var(--font-bold)',
+  color: 'var(--foreground)',
+})
+
+export const scopeChoiceEntries = style({
+  margin: 0,
+  paddingInlineStart: 'var(--space-5)',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 'var(--space-1)',
+})
+
+/**
+ * One scope: a checkbox row and its description beside it.
+ *
+ * The description sits OUTSIDE the label, so the checkbox's accessible name
+ * stays the bare token (`workspace:read`) -- the name a consent screen and a
+ * stored grant both read -- rather than the sentence explaining it.
+ *
+ * CENTER-aligned, not baseline: the label is a flex row whose first item is
+ * the checkbox, and a checkbox has no text baseline of its own -- CSS
+ * synthesizes one from its bottom margin edge -- so the label's baseline sat
+ * a few pixels under the token's text and a baseline-aligned description
+ * landed visibly below it. Centering the two boxes puts the description's
+ * line level with the token it explains.
+ */
+export const scopeChoiceEntry = style({
+  display: 'flex',
+  alignItems: 'center',
+  flexWrap: 'wrap',
+  gap: 'var(--space-2)',
+})
+
+export const scopeChoiceToken = style({
+  fontFamily: 'var(--font-mono)',
+})
+
+export const scopeChoiceDescription = style({
+  fontSize: 'var(--text-8)',
+  color: 'var(--muted-foreground)',
+  minWidth: 0,
 })

--- a/frontend/src/components/settings/account/scopeCatalogue.test.ts
+++ b/frontend/src/components/settings/account/scopeCatalogue.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import { Scope } from '~/generated/leapmux/v1/scope_pb'
+import { closeScopes, impliedScopes, SCOPE_CATEGORIES } from './scopeCatalogue'
+import { scopeToken } from './scopeToken'
+
+/**
+ * The three NON-grantable values, by name rather than number: each is a
+ * construction rather than a permission (UNSPECIFIED is "nobody classified
+ * this", NEVER a recorded refusal, ALL the absence of a limit), and a
+ * catalogue entry for one would be a checkbox that registers nothing.
+ */
+const NON_GRANTABLE: readonly Scope[] = [Scope.UNSPECIFIED, Scope.NEVER, Scope.ALL]
+
+const GRANTABLE: Scope[] = Object.values(Scope)
+  .filter((v): v is Scope => typeof v === 'number')
+  .filter(scope => !NON_GRANTABLE.includes(scope))
+
+/** Every catalogue entry, flattened, for the totality walks below. */
+const CATALOGUED = SCOPE_CATEGORIES.flatMap(c => c.entries.map(e => e.scope))
+
+describe('scopeCatalogue', () => {
+  // The ENUM is the vocabulary and the catalogue is its presentation. A scope
+  // added to the proto but not here renders no checkbox at all -- the
+  // registrant cannot ceiling it -- and one removed from the proto but not
+  // here renders a checkbox the hub refuses. Totality, each way, is what keeps
+  // the form honest without a second source of truth.
+  it('lists every grantable scope exactly once', () => {
+    expect([...CATALOGUED].sort((a, b) => a - b)).toEqual([...GRANTABLE].sort((a, b) => a - b))
+  })
+
+  it('offers no non-grantable value', () => {
+    for (const scope of NON_GRANTABLE)
+      expect(CATALOGUED).not.toContain(scope)
+  })
+
+  // A category with one entry is a heading that answers nothing, and an empty
+  // description is a scope the reader must take on faith. Both are cheaper to
+  // catch here than in review of a nineteen-line form.
+  it('lists and describes every entry', () => {
+    for (const category of SCOPE_CATEGORIES) {
+      expect(category.label.trim(), 'a category label').not.toBe('')
+      expect(category.entries.length, `${category.label} holds at least one scope`).toBeGreaterThan(0)
+      for (const entry of category.entries)
+        expect(entry.description.trim(), `${scopeToken(entry.scope)} carries its proto comment's sentence`).not.toBe('')
+    }
+  })
+
+  // The user's own example, stated as a test: tick workspace:write and
+  // workspace:read is implied. The disabled checkbox the form renders and
+  // the submitted closure both derive from this one rule.
+  it('implies the read half of a write', () => {
+    expect(impliedScopes([Scope.WORKSPACE_WRITE])).toEqual(new Set([Scope.WORKSPACE_READ]))
+  })
+
+  // The hub's ScopeSet.Close iterates to a fixed point, so terminal:write
+  // reaches worker:read through terminal:read -- a one-pass expansion would
+  // stop short and submit a set the hub widens anyway.
+  it('closes transitively', () => {
+    expect(closeScopes([Scope.TERMINAL_WRITE])).toEqual(
+      [Scope.WORKER_READ, Scope.TERMINAL_READ, Scope.TERMINAL_WRITE].sort((a, b) => a - b),
+    )
+    expect(closeScopes([Scope.AGENT_WRITE])).toEqual(
+      [Scope.WORKER_READ, Scope.AGENT_READ, Scope.AGENT_WRITE].sort((a, b) => a - b),
+    )
+  })
+
+  it('closes to the ticked set when nothing is implied', () => {
+    expect(closeScopes([Scope.WORKSPACE_READ])).toEqual([Scope.WORKSPACE_READ])
+  })
+
+  // Enum order is the canonical order the hub sorts a stored ceiling by, and
+  // the request reading the same way is what makes a round trip stable: what
+  // ListApps answers after a register is byte-for-byte what was submitted.
+  it('returns the closure in enum order', () => {
+    const closed = closeScopes([Scope.GIT_WRITE, Scope.WORKSPACE_READ])
+    expect(closed).toEqual([Scope.WORKSPACE_READ, Scope.WORKER_READ, Scope.GIT_READ, Scope.GIT_WRITE])
+  })
+})

--- a/frontend/src/components/settings/account/scopeCatalogue.ts
+++ b/frontend/src/components/settings/account/scopeCatalogue.ts
@@ -1,0 +1,238 @@
+import { Scope } from '~/generated/leapmux/v1/scope_pb'
+
+/**
+ * The grantable vocabulary as a person reads it: grouped the way scope.proto's
+ * section comments group it, each scope with the sentence its proto comment
+ * states.
+ *
+ * The ENUM is the vocabulary's source of truth and the catalogue is its
+ * presentation, so the two are pinned together by test: a scope added to the
+ * proto appears here only after somebody writes its sentence, and one removed
+ * fails the suite rather than lingering as a checkbox that registers nothing.
+ */
+export interface ScopeEntry {
+  scope: Scope
+  description: string
+}
+
+/** One proto section: "Account", "Workspace", ... */
+export interface ScopeCategory {
+  label: string
+  entries: ScopeEntry[]
+}
+
+export const SCOPE_CATEGORIES: readonly ScopeCategory[] = [
+  {
+    label: 'Account',
+    entries: [
+      {
+        scope: Scope.ACCOUNT_READ,
+        description: 'Read the signed-in account\'s profile: username, email, verification state, administrator flag.',
+      },
+      {
+        scope: Scope.ACCOUNT_WRITE,
+        description: 'Change the account\'s profile and preferences. No app reaches the credential surface.',
+      },
+    ],
+  },
+  {
+    label: 'Workspace',
+    entries: [
+      {
+        scope: Scope.WORKSPACE_READ,
+        description: 'Read workspaces, tabs and the layout document.',
+      },
+      {
+        scope: Scope.WORKSPACE_WRITE,
+        description: 'Create, rename, move and close workspaces and tabs, and submit layout operations.',
+      },
+    ],
+  },
+  {
+    label: 'Worker',
+    entries: [
+      {
+        scope: Scope.WORKER_READ,
+        description: 'List the account\'s workers and open a channel to one. Every other worker-surface scope implies it.',
+      },
+      {
+        scope: Scope.WORKER_ADMIN,
+        description: 'Administer the account\'s own workers: rename, deregister, and manage the registration keys that let a machine join.',
+      },
+    ],
+  },
+  {
+    label: 'Agent',
+    entries: [
+      {
+        scope: Scope.AGENT_READ,
+        description: 'Read coding-agent sessions: messages, plans, settings, todos.',
+      },
+      {
+        scope: Scope.AGENT_WRITE,
+        description: 'Drive a coding agent: send a prompt, answer a permission request, start, stop, or change its settings.',
+      },
+    ],
+  },
+  {
+    label: 'Terminal',
+    entries: [
+      {
+        scope: Scope.TERMINAL_READ,
+        description: 'Read terminal output and metadata. This is a monitoring dashboard.',
+      },
+      {
+        scope: Scope.TERMINAL_WRITE,
+        description: 'Type into a terminal. This is arbitrary code execution on the account\'s machine.',
+      },
+    ],
+  },
+  {
+    label: 'File',
+    entries: [
+      {
+        scope: Scope.FILE_READ,
+        description: 'Browse directories and read files on a worker.',
+      },
+    ],
+  },
+  {
+    label: 'Git',
+    entries: [
+      {
+        scope: Scope.GIT_READ,
+        description: 'Read git state: status, branches, diffs, log.',
+      },
+      {
+        scope: Scope.GIT_WRITE,
+        description: 'Mutate a repository: commit, push, create or delete a branch, manage a worktree.',
+      },
+    ],
+  },
+  {
+    label: 'Tunnel',
+    entries: [
+      {
+        scope: Scope.TUNNEL_OPEN,
+        description: 'Open a TCP tunnel through a worker.',
+      },
+    ],
+  },
+  {
+    label: 'Hub administration',
+    entries: [
+      {
+        scope: Scope.ADMIN_READ,
+        description: 'Read the hub\'s administrative inventory: users, settings, workers, sessions, credentials.',
+      },
+      {
+        scope: Scope.ADMIN_USERS,
+        description: 'Administer accounts: create, update, delete, reset a password, revoke sessions and credentials.',
+      },
+      {
+        scope: Scope.ADMIN_SETTINGS,
+        description: 'Change the hub\'s settings, including its security policy and its identity providers.',
+      },
+      {
+        scope: Scope.ADMIN_WORKERS,
+        description: 'Administer every worker on the hub, and the registration keys that admit one.',
+      },
+      {
+        scope: Scope.ADMIN_APPS,
+        description: 'Register, edit, vouch, retire and delete the hub\'s app registrations.',
+      },
+    ],
+  },
+]
+
+/**
+ * What a grant EXPANDS to: each key carries the scopes the hub adds to any
+ * grant that includes it.
+ *
+ * This is the frontend's mirror of `impliedBy` in backend
+ * internal/authscope, which expands a grant at the mint -- so a permission
+ * ceiling stored without its implied scopes is closed by the hub before it is
+ * stored (RegisterApp runs `scopes.Close()`), and the ceiling a consent screen
+ * checks against is closed the same way. The form therefore shows the closure
+ * the hub will perform: an implied scope renders checked and disabled, and
+ * the submitted set carries it, so what the owner ticked is exactly what the
+ * next ListApps reads back. The mirror is pinned to the backend table by
+ * TestFrontendImpliedByMatchesTheHubGraph, so the two cannot drift.
+ *
+ * Three families, each a case where granting one scope without the other
+ * would promise something the hub cannot deliver: every worker-surface scope
+ * needs the channel worker:read opens; every write implies its own read; and
+ * every admin:* scope implies admin:read, because administering a thing
+ * starts with listing it.
+ */
+const IMPLIED_BY: Readonly<Partial<Record<Scope, readonly Scope[]>>> = {
+  [Scope.ACCOUNT_WRITE]: [Scope.ACCOUNT_READ],
+  [Scope.WORKSPACE_WRITE]: [Scope.WORKSPACE_READ],
+  [Scope.WORKER_ADMIN]: [Scope.WORKER_READ],
+  [Scope.AGENT_READ]: [Scope.WORKER_READ],
+  [Scope.AGENT_WRITE]: [Scope.WORKER_READ, Scope.AGENT_READ],
+  [Scope.TERMINAL_READ]: [Scope.WORKER_READ],
+  [Scope.TERMINAL_WRITE]: [Scope.WORKER_READ, Scope.TERMINAL_READ],
+  [Scope.FILE_READ]: [Scope.WORKER_READ],
+  [Scope.GIT_READ]: [Scope.WORKER_READ],
+  [Scope.GIT_WRITE]: [Scope.WORKER_READ, Scope.GIT_READ],
+  [Scope.TUNNEL_OPEN]: [Scope.WORKER_READ],
+  [Scope.ADMIN_USERS]: [Scope.ADMIN_READ],
+  [Scope.ADMIN_SETTINGS]: [Scope.ADMIN_READ],
+  [Scope.ADMIN_WORKERS]: [Scope.ADMIN_READ],
+  [Scope.ADMIN_APPS]: [Scope.ADMIN_READ],
+}
+
+// Object.entries(IMPLIED_BY) returns numeric enum keys as STRINGS, and a Set
+// of numbers would never match one -- so each key is parsed once, here,
+// rather than on every walk of the table.
+const IMPLIED_BY_ENTRIES = Object.entries(IMPLIED_BY)
+  .map(([key, implied]) => [Number(key) as Scope, implied] as const)
+
+/**
+ * The closure of `selected`: the ticked scopes plus everything they imply,
+ * transitively -- the same fixed point the hub's ScopeSet.Close computes,
+ * iterated rather than assumed one pass deep so a future two-step
+ * implication is correct with no edit here.
+ *
+ * The one primitive both derived views read: what the form LOCKS is this
+ * closure minus the ticked set, and what it SUBMITS is the closure itself.
+ */
+function closure(selected: readonly Scope[]): Set<Scope> {
+  const closed = new Set(selected)
+  for (let added = true; added;) {
+    added = false
+    for (const [scope, implied] of IMPLIED_BY_ENTRIES) {
+      if (!closed.has(scope))
+        continue
+      for (const target of implied) {
+        if (!closed.has(target)) {
+          closed.add(target)
+          added = true
+        }
+      }
+    }
+  }
+  return closed
+}
+
+/**
+ * The scopes `selected` implies: the closure minus the ticked scopes
+ * themselves.
+ */
+export function impliedScopes(selected: readonly Scope[]): Set<Scope> {
+  const closed = closure(selected)
+  for (const scope of selected)
+    closed.delete(scope)
+  return closed
+}
+
+/**
+ * The set to SUBMIT: what was ticked, plus what the hub would add anyway.
+ *
+ * Sorted in enum order, the canonical order the hub sorts by, so the request
+ * reads the same as the stored ceiling it becomes.
+ */
+export function closeScopes(selected: readonly Scope[]): Scope[] {
+  return [...closure(selected)].sort((a, b) => a - b)
+}

--- a/frontend/src/components/settings/controls/KeyPinsControl.css.ts
+++ b/frontend/src/components/settings/controls/KeyPinsControl.css.ts
@@ -10,7 +10,7 @@ export const pinRow = style({
   'color': 'var(--foreground)',
   'backgroundColor': 'var(--card)',
   'border': '1px solid var(--border)',
-  'borderRadius': 'var(--radius-2)',
+  'borderRadius': 'var(--radius-medium)',
   'minWidth': 0,
   '@media': {
     // Phone: id on its own row so it keeps the full card width; date +

--- a/frontend/src/components/settings/controls/KeyPinsControl.tsx
+++ b/frontend/src/components/settings/controls/KeyPinsControl.tsx
@@ -1,5 +1,6 @@
 import type { Component } from 'solid-js'
 import { createMemo, createSignal, For, Show } from 'solid-js'
+import { actionsFooter } from '~/components/common/actionsFooter.css'
 import { ClippedText } from '~/components/common/ClippedText'
 import { ConfirmButton } from '~/components/common/ConfirmButton'
 import { Tooltip } from '~/components/common/Tooltip'
@@ -65,7 +66,7 @@ export const KeyPinsControl: Component = () => {
             </div>
           )}
         </For>
-        <div>
+        <div class={actionsFooter}>
           <ConfirmButton data-variant="danger" onClick={removeAll} data-testid="key-pins-remove-all">
             Remove all
           </ConfirmButton>

--- a/frontend/src/components/settings/controls/customEditors.tsx
+++ b/frontend/src/components/settings/controls/customEditors.tsx
@@ -1,16 +1,28 @@
+import type { Component } from 'solid-js'
 import type { CustomEditorComponent, CustomEditorId } from '../types'
-import { AccountAppRegistrations } from '../account/AccountAppRegistrations'
 import { AccountConnectedApps } from '../account/AccountConnectedApps'
 import { AccountEmail } from '../account/AccountEmail'
 import { AccountLinkedProviders } from '../account/AccountLinkedProviders'
 import { AccountPasskeys } from '../account/AccountPasskeys'
 import { AccountPassword } from '../account/AccountPassword'
 import { AccountProfile } from '../account/AccountProfile'
+import { AppRegistrations } from '../account/AppRegistrations'
 import { KeybindingsControl } from './KeybindingsControl'
 import { KeyPinsControl } from './KeyPinsControl'
 import { SyntaxThemeControl } from './SyntaxThemeControl'
 import { TerminalThemeControl } from './TerminalThemeControl'
 import { ThemeControl } from './ThemeControl'
+
+/**
+ * The administration twin of the account registrations panel: the same editor
+ * with `variant="hub-wide"`, so a hub-wide registration is registered with the
+ * form an administrator already knows instead of the CLI alone.
+ *
+ * A wrapper rather than a second registration form: the fields a hub-wide
+ * registration states are the fields a private one states, and a copied form
+ * is a second place a new editable field must reach.
+ */
+const HubWideAppRegistrations: Component = () => <AppRegistrations variant="hub-wide" />
 
 /**
  * The bespoke whole-setting editors a `{ kind: 'custom' }` control dispatches
@@ -50,7 +62,13 @@ export const CUSTOM_EDITORS: Record<CustomEditorId, CustomEditorComponent> = {
    * an in-flight authorization code, so this row DOES demand an elevated
    * session, unlike its neighbour above.
    */
-  accountAppRegistrations: AccountAppRegistrations,
+  accountAppRegistrations: AppRegistrations,
+  /**
+   * The ADMINISTRATION-side registrations panel — the hub's own catalogue,
+   * registering HUB_WIDE. Reachable only through the row PreferencesDialog
+   * appends for administrators; the account side above never renders it.
+   */
+  hubWideAppRegistrations: HubWideAppRegistrations,
   keyPins: KeyPinsControl,
   /**
    * The palette drop-down and the light/dark tri-switch, as one control.

--- a/frontend/src/components/settings/navGroups.ts
+++ b/frontend/src/components/settings/navGroups.ts
@@ -19,11 +19,11 @@ export const NAV_GROUPS: readonly NavGroup[] = [
   // preferences they adjust while they are already here, so a place under
   // seven of them put the errand behind the browsing.
   { id: 'account', title: 'Account', category: 'account', admin: false },
-  // Apps follows Account, because it is the same errand one step further out:
-  // Account holds the apps you AUTHORIZED, this holds the apps you REGISTERED.
-  // It is a user group, not an administration one -- an ordinary account may
-  // register an app for itself, and ownership rather than a role decides what
-  // each caller sees.
+  // Apps follows Account, and holds the whole app errand: what the account
+  // AUTHORIZED (Connected apps) and what it REGISTERED for others to
+  // authorize. It is a user group, not an administration one -- an ordinary
+  // account may register an app for itself, and ownership rather than a role
+  // decides what each caller sees.
   { id: 'apps', title: 'Apps', category: 'apps', admin: false },
   { id: 'appearance', title: 'Appearance', category: 'appearance', admin: false },
   { id: 'notifications', title: 'Notifications', category: 'notifications', admin: false },
@@ -35,15 +35,20 @@ export const NAV_GROUPS: readonly NavGroup[] = [
   { id: 'admin-general', title: 'General', category: 'general', admin: true },
   { id: 'admin-signup', title: 'Sign-up & Access', category: 'signup', admin: true },
   { id: 'admin-email', title: 'Email (SMTP)', category: 'email', admin: true },
-  { id: 'admin-captcha', title: 'Bot Protection', category: 'captcha', admin: true },
-  { id: 'admin-rate-limits', title: 'Rate Limits', category: 'rate-limits', admin: true },
-  { id: 'admin-limits', title: 'Limits & Timeouts', category: 'limits', admin: true },
   // The same category on the ADMINISTRATION side, which is where the hub's
   // own app settings live -- RFC 7591 open registration today. `advanced`
   // already appears on both sides for the same reason: one category can hold
   // a browser row and a hub row, and group.admin picks which source a group
   // draws from.
-  { id: 'admin-apps', title: 'Apps', category: 'apps', admin: true },
+  //
+  // TITLED "Hub-wide Apps" rather than "Apps": the user-level Apps section
+  // beside it holds what this ACCOUNT registered and authorized, and the two
+  // one-word titles read as the same list twice. The word the administration
+  // side adds is WHO the registration reaches -- every account on the hub.
+  { id: 'admin-apps', title: 'Hub-wide Apps', category: 'apps', admin: true },
+  { id: 'admin-captcha', title: 'Bot Protection', category: 'captcha', admin: true },
+  { id: 'admin-rate-limits', title: 'Rate Limits', category: 'rate-limits', admin: true },
+  { id: 'admin-limits', title: 'Limits & Timeouts', category: 'limits', admin: true },
   { id: 'admin-advanced', title: 'Advanced', category: 'advanced', admin: true },
 ]
 
@@ -56,9 +61,10 @@ export const NAV_GROUPS: readonly NavGroup[] = [
  * out, which is how the list and the landing section came to disagree.
  *
  * A deployment that HIDES that section still lands somewhere: solo mode hides
- * most Account rows, and the dialog resolves a requested id against the
- * visible groups (see `occupiedNavGroups`). Connected apps is the one Account
- * row solo KEEPS, because a solo hub authorizes apps like any other and its
- * owner must be able to disconnect one.
+ * every Account row, and the dialog resolves a requested id against the
+ * visible groups (see `occupiedNavGroups`). Connected apps -- now an Apps row,
+ * and the one solo keeps beside App registrations -- is why a solo hub still
+ * shows the section at all: it authorizes apps like any other and its owner
+ * must be able to disconnect one.
  */
 export const DEFAULT_NAV_GROUP_ID: string = NAV_GROUPS[0]!.id

--- a/frontend/src/components/settings/registry/admin.ts
+++ b/frontend/src/components/settings/registry/admin.ts
@@ -1,0 +1,28 @@
+import type { SettingRowModel } from '../types'
+import { CUSTOM_EDITOR_OWNS_ITS_VALUE } from './bindings'
+
+/**
+ * The ADMINISTRATION tier of the settings registry: rows that reach the
+ * Administration side alone and have no hub SETTING behind them.
+ *
+ * The browser registry (settings.ts) cannot hold these: its categories feed
+ * the USER sections, so an entry with category `apps` would also land in the
+ * user-level Apps section and double-list the admin form. This tier is the
+ * second source `groupRowsByNav`'s admin input draws from, beside the proto
+ * descriptor rows, so an administration row lives in the registry like every
+ * other row while the user groups never see it.
+ */
+export const ADMIN_ROWS: readonly SettingRowModel[] = [
+  {
+    descriptor: {
+      id: 'apps.hubWideRegistrations',
+      category: 'apps',
+      label: 'Hub-wide app registrations',
+      help: 'Apps every account on this hub may authorize. Registering one is an administrator\'s act, so the hub asks for a fresh proof first.',
+      keywords: ['app', 'oauth', 'register', 'hub-wide', 'client', 'redirect', 'secret', 'developer'],
+      scope: 'hub',
+      control: { kind: 'custom', id: 'hubWideAppRegistrations' },
+    },
+    binding: CUSTOM_EDITOR_OWNS_ITS_VALUE,
+  },
+]

--- a/frontend/src/components/settings/registry/bindings.ts
+++ b/frontend/src/components/settings/registry/bindings.ts
@@ -13,15 +13,16 @@ import type { DualPreference, FontTier } from '~/context/PreferencesContext'
 /**
  * The binding a row whose CUSTOM EDITOR owns its own value: none.
  *
- * Seven rows need it -- the six `account.*` rows and `advanced.keyPins`. Each
- * renders a bespoke editor that reads and writes through its own RPCs, so
- * there is no scalar for the registry to bind, and the row's `value`/`set`
- * pair is never called. The registry's base declaration still demands the
- * pair, because every VALUE-BACKED row needs it and a missing one is a dead
- * control; this is the one honest answer for a row that holds no value.
+ * Nine rows need it -- the six `account.*` rows, the two `apps.*`
+ * registration rows, and `advanced.keyPins`. Each renders a bespoke editor
+ * that reads and writes through its own RPCs, so there is no scalar for the
+ * registry to bind, and the row's `value`/`set` pair is never called. The
+ * registry's base declaration still demands the pair, because every
+ * VALUE-BACKED row needs it and a missing one is a dead control; this is the
+ * one honest answer for a row that holds no value.
  *
- * ONE shared object, not a fresh literal at each entry. Seven copies of the
- * same two no-op closures say nothing seven times, and a reader has to compare
+ * ONE shared object, not a fresh literal at each entry. Nine copies of the
+ * same two no-op closures say nothing nine times, and a reader has to compare
  * them to learn that they agree. Nothing mutates a binding -- the panel reads
  * `value`, `set` and the optional override members -- so the rows may share it.
  */

--- a/frontend/src/components/settings/registry/index.test.ts
+++ b/frontend/src/components/settings/registry/index.test.ts
@@ -5,7 +5,9 @@ import { createSignal } from 'solid-js'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { accountWireDescriptors, goldenAccountSchema } from '~/test-support/accountSchema'
 import { makeFakePrefs } from '~/test-support/preferencesFake'
+import { CUSTOM_EDITORS } from '../controls/customEditors'
 import { CATEGORY_IDS } from '../protoRegistry'
+import { ADMIN_ROWS } from './admin'
 import { CUSTOM_EDITOR_OWNS_ITS_VALUE } from './bindings'
 import { CLAIMED_PROTO_KEYS, createBrowserRows } from './index'
 import { browserSettings, buildBrowserReset } from './settings'
@@ -864,5 +866,33 @@ describe('createBrowserRows visibility', () => {
   it('yields one descriptor per entry, in declaration order', () => {
     expect(descriptorsOf(prefsWith({})).map(d => d.id))
       .toEqual(browserSettings.map(d => d.id))
+  })
+})
+
+// The ADMINISTRATION tier: rows that reach the Administration side alone and
+// have no hub setting behind them, so the browser registry cannot hold them
+// (its categories feed the USER sections). The same invariants the browser
+// registry's parity tests state hold here too — a known category, a registered
+// custom editor — because an admin row that escaped them would render a panel
+// the registry knows nothing about.
+describe('admin registry tier', () => {
+  it('has unique ids disjoint from the browser registry', () => {
+    const ids = ADMIN_ROWS.map(r => r.descriptor.id)
+    expect(new Set(ids).size).toBe(ids.length)
+    for (const id of ids)
+      expect(browserSettings.map(d => d.id), `admin row "${id}" must not also be a browser entry`).not.toContain(id)
+  })
+
+  it('places every row in a category the navigation knows', () => {
+    for (const row of ADMIN_ROWS)
+      expect(CATEGORY_IDS.has(row.descriptor.category), `row "${row.descriptor.id}" sits in "${row.descriptor.category}"`).toBe(true)
+  })
+
+  it('binds every custom control to a registered editor', () => {
+    for (const row of ADMIN_ROWS) {
+      const control = row.descriptor.control
+      if (control.kind === 'custom')
+        expect(CUSTOM_EDITORS, `row "${row.descriptor.id}"`).toHaveProperty(control.id)
+    }
   })
 })

--- a/frontend/src/components/settings/registry/settings.ts
+++ b/frontend/src/components/settings/registry/settings.ts
@@ -576,9 +576,15 @@ export const browserSettings: BrowserSettingDecl[] = [
     hidden: () => isSoloMode(),
     bind: () => CUSTOM_EDITOR_OWNS_ITS_VALUE,
   },
+  /*
+   * The APPS section, one errand in two halves: what this account AUTHORIZED
+   * first, then what it REGISTERED. The authorized half leads because it is
+   * the one an ordinary account returns to -- "what can reach my account" --
+   * while registering is the developer's afterthought.
+   */
   {
     id: 'account.connectedApps',
-    category: 'account',
+    category: 'apps',
     label: 'Connected apps',
     help: 'Apps you authorized, what each one may do, and how to disconnect it.',
     keywords: ['app', 'oauth', 'cli', 'token', 'device', 'revoke', 'disconnect', 'permission', 'scope'],
@@ -600,7 +606,7 @@ export const browserSettings: BrowserSettingDecl[] = [
     scope: 'account',
     control: { kind: 'custom', id: 'accountAppRegistrations' },
     sentinel: 'nullable',
-    // ELEVATED, unlike Connected apps beside it, and the asymmetry is the
+    // ELEVATED, unlike Connected apps above it, and the asymmetry is the
     // point. Disconnecting an app only reduces access. Editing a registration
     // rewrites where a consent redirects, so it diverts an in-flight
     // authorization code to an address the editor chose -- the most dangerous

--- a/frontend/src/components/settings/types.ts
+++ b/frontend/src/components/settings/types.ts
@@ -25,6 +25,7 @@ export const CUSTOM_EDITOR_IDS = [
   'accountLinkedProviders',
   'accountConnectedApps',
   'accountAppRegistrations',
+  'hubWideAppRegistrations',
   'keyPins',
   'theme',
   'terminalTheme',

--- a/frontend/src/components/shell/LastTabCloseDialog.tsx
+++ b/frontend/src/components/shell/LastTabCloseDialog.tsx
@@ -3,6 +3,7 @@ import type { InspectLastTabCloseResponse } from '~/generated/leapmux/v1/git_pb'
 import type { TabType as TabTypeT } from '~/generated/leapmux/v1/workspace_pb'
 import { createMemo, createUniqueId, Show } from 'solid-js'
 import * as workerRpc from '~/api/workerRpc'
+import { actionsFooter } from '~/components/common/actionsFooter.css'
 import { ConfirmButton } from '~/components/common/ConfirmButton'
 import { Dialog } from '~/components/common/Dialog'
 import { showWarnToast } from '~/components/common/Toast'
@@ -160,7 +161,7 @@ export const LastTabCloseDialog: Component<LastTabCloseDialogProps> = (props) =>
           <div class={warningText}>{props.state.errorHint}</div>
         </Show>
       </section>
-      <footer>
+      <footer class={actionsFooter}>
         <button type="button" class="outline" onClick={handleCancel}>
           Cancel
         </button>

--- a/frontend/src/components/shell/WorkerDialogShell.tsx
+++ b/frontend/src/components/shell/WorkerDialogShell.tsx
@@ -1,5 +1,6 @@
 import type { Component, JSX } from 'solid-js'
 import { Show } from 'solid-js'
+import { actionsFooter } from '~/components/common/actionsFooter.css'
 import { Dialog } from '~/components/common/Dialog'
 import { Spinner } from '~/components/common/Spinner'
 import { errorText } from '~/styles/shared.css'
@@ -57,7 +58,7 @@ export const WorkerDialogShell: Component<WorkerDialogShellProps> = (props) => {
           <div class={errorText}>{props.error}</div>
         </Show>
       </section>
-      <footer>{props.footer}</footer>
+      <footer class={actionsFooter}>{props.footer}</footer>
     </>
   )
   return (

--- a/frontend/src/components/workers/AddTunnelDialog.tsx
+++ b/frontend/src/components/workers/AddTunnelDialog.tsx
@@ -1,6 +1,7 @@
 import type { Component } from 'solid-js'
 import type { TunnelInfo } from '~/api/platformBridge'
 import { createMemo, createSignal, Show } from 'solid-js'
+import { actionsFooter } from '~/components/common/actionsFooter.css'
 import { Dialog } from '~/components/common/Dialog'
 import { Spinner } from '~/components/common/Spinner'
 import { useTunnel } from '~/context/TunnelContext'
@@ -202,7 +203,7 @@ export const AddTunnelDialog: Component<AddTunnelDialogProps> = (props) => {
           <div class={errorText}>{error()}</div>
         </Show>
 
-        <footer>
+        <footer class={actionsFooter}>
           <button type="button" class="outline" disabled={submitting.loading()} onClick={() => props.onClose()} data-testid="tunnel-cancel">
             Cancel
           </button>

--- a/frontend/src/components/workers/RegisterWorkerDialog.tsx
+++ b/frontend/src/components/workers/RegisterWorkerDialog.tsx
@@ -5,6 +5,7 @@ import Copy from 'lucide-solid/icons/copy'
 import Mail from 'lucide-solid/icons/mail'
 import { createMemo, createSignal, onCleanup, onMount, Show } from 'solid-js'
 import { workerClient } from '~/api/clients'
+import { actionsFooter } from '~/components/common/actionsFooter.css'
 import { Dialog } from '~/components/common/Dialog'
 import { Icon } from '~/components/common/Icon'
 import { Tooltip } from '~/components/common/Tooltip'
@@ -150,7 +151,7 @@ export const RegisterWorkerDialog: Component<RegisterWorkerDialogProps> = (props
           {msg => <p class={errorText}>{msg()}</p>}
         </Show>
       </section>
-      <footer>
+      <footer class={actionsFooter}>
         <button type="button" class="outline" onClick={() => props.onClose()}>Cancel</button>
 
         <Show when={registrationKey()}>

--- a/frontend/src/components/workers/WorkerSettingsDialog.tsx
+++ b/frontend/src/components/workers/WorkerSettingsDialog.tsx
@@ -2,6 +2,7 @@ import type { Component } from 'solid-js'
 import type { Worker } from '~/generated/leapmux/v1/worker_pb'
 import { Show } from 'solid-js'
 import { workerClient } from '~/api/clients'
+import { actionsFooter } from '~/components/common/actionsFooter.css'
 import { Dialog } from '~/components/common/Dialog'
 import { Spinner } from '~/components/common/Spinner'
 import { useDialogSubmit } from '~/hooks/useDialogSubmit'
@@ -37,7 +38,7 @@ export const WorkerSettingsDialog: Component<WorkerSettingsDialogProps> = (props
       <Show when={deregisterError()}>
         <div class={errorText}>{deregisterError()}</div>
       </Show>
-      <footer>
+      <footer class={actionsFooter}>
         <button class="outline" disabled={submitting.loading()} onClick={() => props.onClose()} data-testid="deregister-cancel">
           Cancel
         </button>

--- a/frontend/tests/e2e/009-elevation.spec.ts
+++ b/frontend/tests/e2e/009-elevation.spec.ts
@@ -15,7 +15,7 @@
 
 import { expect, test } from './fixtures'
 import { elevateSessionViaAPI, listMyAPITokensViaAPI, signUpViaAPI } from './helpers/api'
-import { loginViaToken, openAccountSettings } from './helpers/ui'
+import { loginViaToken, openAccountSettings, openSettingsAt } from './helpers/ui'
 
 const APP_HOME_URL_RE = /\/$/
 const PASSWORD = 'password123'
@@ -87,7 +87,8 @@ test.describe('session elevation', () => {
 
     await loginViaToken(page, cookie)
     await page.goto('/')
-    const prefs = await openAccountSettings(page)
+    // Connected apps lives in the APPS section, not Account.
+    const prefs = await openSettingsAt(page, 'apps')
     await expect(prefs.getByTestId('connected-apps')).toBeVisible()
     await expect(prefs.getByText('No connected apps.', { exact: false })).toBeVisible()
     await expect(page.getByRole('dialog', { name: 'Verify your identity' })).toHaveCount(0)

--- a/frontend/tests/e2e/080-turn-end-sound-preferences.spec.ts
+++ b/frontend/tests/e2e/080-turn-end-sound-preferences.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from './fixtures'
 import { armTurnEndSound, expectDoorbellCount, expectDoorbellQuiet } from './helpers/turnEndSound'
-import { getBrowserPref, loginViaToken, openAgentViaUI, openPreferencesDialog, sendMessage, waitForAgentIdle, waitForWorkspaceReady } from './helpers/ui'
+import { getBrowserPref, loginViaToken, openAgentViaUI, openSettingsAt, sendMessage, waitForAgentIdle, waitForWorkspaceReady } from './helpers/ui'
 
 /**
  * A prompt the agent cannot answer from the prompt alone, so the turn reports
@@ -25,8 +25,7 @@ test.describe('Turn End Sound Preferences', () => {
   test('should show the Turn End Sound row in the Notifications category', async ({ page, leapmuxServer }) => {
     await loginViaToken(page, leapmuxServer.adminToken)
     await page.goto('/')
-    await openPreferencesDialog(page, 'notifications')
-    const dialog = page.getByRole('dialog', { name: 'Preferences' })
+    const dialog = await openSettingsAt(page, 'notifications')
     await expect(dialog.getByText('Turn-end sound', { exact: true })).toBeVisible()
     await expect(dialog.getByRole('radio', { name: 'None' })).toBeVisible()
     await expect(dialog.getByRole('radio', { name: 'Ding Dong' })).toBeVisible()
@@ -35,8 +34,7 @@ test.describe('Turn End Sound Preferences', () => {
   test('should persist browser-level turn end sound in localStorage', async ({ page, leapmuxServer }) => {
     await loginViaToken(page, leapmuxServer.adminToken)
     await page.goto('/')
-    await openPreferencesDialog(page, 'notifications')
-    const dialog = page.getByRole('dialog', { name: 'Preferences' })
+    const dialog = await openSettingsAt(page, 'notifications')
     await expect(dialog.getByText('Turn-end sound', { exact: true })).toBeVisible()
 
     // The dual row edits whichever tier the scope chip selects; persisting to
@@ -61,8 +59,7 @@ test.describe('Turn End Sound Preferences', () => {
   test('should persist account-level turn end sound via API', async ({ page, leapmuxServer }) => {
     await loginViaToken(page, leapmuxServer.adminToken)
     await page.goto('/')
-    await openPreferencesDialog(page, 'notifications')
-    const dialog = page.getByRole('dialog', { name: 'Preferences' })
+    const dialog = await openSettingsAt(page, 'notifications')
     await expect(dialog.getByText('Turn-end sound', { exact: true })).toBeVisible()
     // Default scope: the row edits the ACCOUNT tier (the chip reads
     // "Account default" until an override exists).
@@ -78,8 +75,7 @@ test.describe('Turn End Sound Preferences', () => {
 
     // Reload and verify the account-level choice survived the round trip.
     await page.reload()
-    await openPreferencesDialog(page, 'notifications')
-    const reopened = page.getByRole('dialog', { name: 'Preferences' })
+    const reopened = await openSettingsAt(page, 'notifications')
     await expect(reopened.getByText('Turn-end sound', { exact: true })).toBeVisible()
     await expect(reopened.getByRole('radio', { name: 'Ding Dong' })).toBeChecked()
 
@@ -125,9 +121,9 @@ test.describe('Turn End Sound Preferences', () => {
     await expectDoorbellCount(page, 1)
 
     // Open and close the Preferences dialog (no full navigation)
-    await openPreferencesDialog(page)
-    await page.getByRole('dialog', { name: 'Preferences' }).getByLabel('Close').click()
-    await expect(page.getByRole('dialog', { name: 'Preferences' })).not.toBeVisible()
+    const dialog = await openSettingsAt(page)
+    await dialog.getByLabel('Close').click()
+    await expect(dialog).not.toBeVisible()
 
     await expectDoorbellQuiet(page, 1)
   })

--- a/frontend/tests/e2e/081-preferences-navigation.spec.ts
+++ b/frontend/tests/e2e/081-preferences-navigation.spec.ts
@@ -1,6 +1,6 @@
 import { motion } from '../../src/styles/tokens'
 import { expect, test } from './fixtures'
-import { loginViaToken, openPreferencesDialog } from './helpers/ui'
+import { loginViaToken, openSettingsAt } from './helpers/ui'
 
 test.describe('Preferences navigation', () => {
   test('opens via the menu and via Cmd/Ctrl+Comma', async ({ page, leapmuxServer }) => {
@@ -8,10 +8,10 @@ test.describe('Preferences navigation', () => {
     await page.goto('/')
 
     // Via the app menu.
-    await openPreferencesDialog(page)
+    const dialog = await openSettingsAt(page)
     await expect(page.getByTestId('preferences-nav-appearance')).toBeVisible()
-    await page.getByRole('dialog', { name: 'Preferences' }).getByLabel('Close').click()
-    await expect(page.getByRole('dialog', { name: 'Preferences' })).not.toBeVisible()
+    await dialog.getByLabel('Close').click()
+    await expect(dialog).not.toBeVisible()
 
     // Via the keyboard shortcut (the platform modifier + comma).
     const mod = process.platform === 'darwin' ? 'Meta' : 'Control'
@@ -22,8 +22,7 @@ test.describe('Preferences navigation', () => {
   test('walks categories through the tab list', async ({ page, leapmuxServer }) => {
     await loginViaToken(page, leapmuxServer.adminToken)
     await page.goto('/')
-    await openPreferencesDialog(page, 'appearance')
-    const dialog = page.getByRole('dialog', { name: 'Preferences' })
+    const dialog = await openSettingsAt(page, 'appearance')
 
     await dialog.getByTestId('preferences-nav-notifications').click()
     await expect(dialog.getByText('Turn-end sound', { exact: true })).toBeVisible()
@@ -60,8 +59,7 @@ test.describe('Preferences navigation', () => {
   test('returns to the requested section when asked for again while open', async ({ page, leapmuxServer }) => {
     await loginViaToken(page, leapmuxServer.adminToken)
     await page.goto('/')
-    await openPreferencesDialog(page, 'appearance')
-    const dialog = page.getByRole('dialog', { name: 'Preferences' })
+    const dialog = await openSettingsAt(page, 'appearance')
 
     await dialog.getByTestId('preferences-nav-advanced').click()
     await expect(dialog.getByTestId('preferences-nav-advanced')).toHaveAttribute('aria-selected', 'true')
@@ -79,8 +77,7 @@ test.describe('Preferences navigation', () => {
   test('opens on Account', async ({ page, leapmuxServer }) => {
     await loginViaToken(page, leapmuxServer.adminToken)
     await page.goto('/')
-    await openPreferencesDialog(page)
-    const dialog = page.getByRole('dialog', { name: 'Preferences' })
+    const dialog = await openSettingsAt(page)
 
     await expect(dialog.getByTestId('preferences-nav-account')).toHaveAttribute('aria-selected', 'true')
     await expect(dialog.locator('[data-setting-id="account.profile"]')).toBeVisible()
@@ -89,8 +86,7 @@ test.describe('Preferences navigation', () => {
   test('searching "volume" shows the two notifications rows with breadcrumbs', async ({ page, leapmuxServer }) => {
     await loginViaToken(page, leapmuxServer.adminToken)
     await page.goto('/')
-    await openPreferencesDialog(page, 'appearance')
-    const dialog = page.getByRole('dialog', { name: 'Preferences' })
+    const dialog = await openSettingsAt(page, 'appearance')
 
     const search = dialog.getByTestId('preferences-search')
     await search.fill('volume')
@@ -118,8 +114,7 @@ test.describe('Preferences navigation', () => {
   test('clears the search on Escape, and closes the dialog only once the query is empty', async ({ page, leapmuxServer }) => {
     await loginViaToken(page, leapmuxServer.adminToken)
     await page.goto('/')
-    await openPreferencesDialog(page, 'appearance')
-    const dialog = page.getByRole('dialog', { name: 'Preferences' })
+    const dialog = await openSettingsAt(page, 'appearance')
 
     const search = dialog.getByTestId('preferences-search')
     await search.fill('volume')

--- a/frontend/tests/e2e/082-preferences-scope.spec.ts
+++ b/frontend/tests/e2e/082-preferences-scope.spec.ts
@@ -1,6 +1,6 @@
 import type { Page } from '@playwright/test'
 import { expect, test } from './fixtures'
-import { getBrowserPrefValue, loginViaToken, openPreferencesDialog, pickTheme } from './helpers/ui'
+import { getBrowserPrefValue, loginViaToken, openSettingsAt, pickTheme } from './helpers/ui'
 
 /**
  * Read a browser-prefs field as a JSON string, for the substring assertions
@@ -31,8 +31,7 @@ test.describe('Preferences scope overrides', () => {
   test('overrides the theme on this device and clears back to the account default', async ({ page, leapmuxServer }) => {
     await loginViaToken(page, leapmuxServer.adminToken)
     await page.goto('/')
-    await openPreferencesDialog(page, 'appearance')
-    const dialog = page.getByRole('dialog', { name: 'Preferences' })
+    const dialog = await openSettingsAt(page, 'appearance')
 
     const chip = dialog.getByTestId('scope-chip-appearance.theme')
     await expect(chip).toHaveText(/Account default/)
@@ -65,8 +64,7 @@ test.describe('Preferences scope overrides', () => {
     const before = await resolvedMonoFamily(page)
     await expect(before).toBeTruthy()
 
-    await openPreferencesDialog(page, 'appearance')
-    const dialog = page.getByRole('dialog', { name: 'Preferences' })
+    const dialog = await openSettingsAt(page, 'appearance')
 
     // The whole {enabled, fonts} object is the override unit: switching the
     // toggle row onto the device tier overrides both halves at once.

--- a/frontend/tests/e2e/083-preferences-admin.spec.ts
+++ b/frontend/tests/e2e/083-preferences-admin.spec.ts
@@ -1,13 +1,12 @@
 import { expect, test } from './fixtures'
 import { loginViaAPI, TEST_ADMIN_PASSWORD, TEST_ADMIN_USERNAME } from './helpers/api'
-import { loginViaToken, openPreferencesDialog } from './helpers/ui'
+import { loginViaToken, openSettingsAt } from './helpers/ui'
 
 test.describe('Preferences administration groups', () => {
   test('admin sees the administration groups and can change session duration', async ({ page, leapmuxServer }) => {
     await loginViaToken(page, leapmuxServer.adminToken)
     await page.goto('/')
-    await openPreferencesDialog(page)
-    const dialog = page.getByRole('dialog', { name: 'Preferences' })
+    const dialog = await openSettingsAt(page)
 
     await expect(dialog.getByText('ADMINISTRATION')).toBeVisible()
     await expect(dialog.getByTestId('preferences-nav-admin-general')).toBeVisible()
@@ -24,10 +23,9 @@ test.describe('Preferences administration groups', () => {
     await input.press('Enter') /* the control commits on the DOM change event */
     await expect(row.getByText('Customized')).toBeVisible()
 
-    await page.getByRole('dialog', { name: 'Preferences' }).getByLabel('Close').click()
-    await expect(page.getByRole('dialog', { name: 'Preferences' })).not.toBeVisible()
-    await openPreferencesDialog(page, 'admin-general')
-    const reopened = page.getByRole('dialog', { name: 'Preferences' })
+    await dialog.getByLabel('Close').click()
+    await expect(dialog).not.toBeVisible()
+    const reopened = await openSettingsAt(page, 'admin-general')
     await expect(reopened.locator('[data-setting-id="session_duration_seconds"] input[type="number"]')).toHaveValue('7200')
 
     // Reset back to the default so the change cannot leak into a later test
@@ -46,8 +44,7 @@ test.describe('Preferences administration groups', () => {
   test('states an enforced toggle in the words of its switch', async ({ page, leapmuxServer }) => {
     await loginViaToken(page, leapmuxServer.adminToken)
     await page.goto('/')
-    await openPreferencesDialog(page, 'admin-signup')
-    const dialog = page.getByRole('dialog', { name: 'Preferences' })
+    const dialog = await openSettingsAt(page, 'admin-signup')
 
     const row = dialog.locator('[data-setting-id="signup_enabled"]')
     await expect(row).toBeVisible()
@@ -67,8 +64,7 @@ test.describe('Preferences administration groups', () => {
   test('states an enforced number with the unit of its control', async ({ page, leapmuxServer }) => {
     await loginViaToken(page, leapmuxServer.adminToken)
     await page.goto('/')
-    await openPreferencesDialog(page, 'admin-advanced')
-    const dialog = page.getByRole('dialog', { name: 'Preferences' })
+    const dialog = await openSettingsAt(page, 'admin-advanced')
 
     const row = dialog.locator('[data-setting-id="queue_budget.relay_bytes"]')
     await expect(row).toBeVisible()
@@ -93,8 +89,7 @@ test.describe('Preferences administration groups', () => {
   test('a public URL change reaches the passkey affordance without a reload', async ({ page, leapmuxServer }) => {
     await loginViaToken(page, leapmuxServer.adminToken)
     await page.goto('/')
-    await openPreferencesDialog(page, 'account')
-    const dialog = page.getByRole('dialog', { name: 'Preferences' })
+    const dialog = await openSettingsAt(page, 'account')
 
     // Scoped to the passkeys row: the verified-session banner at the top of
     // the Account section is a `role="alert"` too, so an unscoped alert
@@ -133,8 +128,7 @@ test.describe('Preferences administration groups', () => {
   test('non-admins do not see the administration groups', async ({ page, leapmuxServer }) => {
     await loginViaToken(page, leapmuxServer.newuserToken)
     await page.goto('/')
-    await openPreferencesDialog(page)
-    const dialog = page.getByRole('dialog', { name: 'Preferences' })
+    const dialog = await openSettingsAt(page)
 
     await expect(dialog.getByText('ADMINISTRATION')).not.toBeVisible()
     await expect(dialog.getByTestId('preferences-nav-admin-general')).not.toBeVisible()
@@ -169,8 +163,7 @@ test.describe('administration settings need a verified session', () => {
   test('prompts on the first write and applies it once the user verifies', async ({ page, leapmuxServer }) => {
     await loginViaToken(page, await unelevatedAdminSession(leapmuxServer.hubUrl))
     await page.goto('/')
-    await openPreferencesDialog(page, 'admin-general')
-    const dialog = page.getByRole('dialog', { name: 'Preferences' })
+    const dialog = await openSettingsAt(page, 'admin-general')
 
     const row = dialog.locator('[data-setting-id="session_duration_seconds"]')
     await expect(row).toBeVisible()
@@ -208,8 +201,7 @@ test.describe('administration settings need a verified session', () => {
   test('ends the window from the administration panel', async ({ page, leapmuxServer }) => {
     await loginViaToken(page, leapmuxServer.adminToken)
     await page.goto('/')
-    await openPreferencesDialog(page, 'admin-general')
-    const dialog = page.getByRole('dialog', { name: 'Preferences' })
+    const dialog = await openSettingsAt(page, 'admin-general')
 
     await expect(dialog.getByTestId('elevation-status')).toBeVisible()
     await dialog.getByTestId('elevation-drop').click()

--- a/frontend/tests/e2e/084-theme-picker.spec.ts
+++ b/frontend/tests/e2e/084-theme-picker.spec.ts
@@ -3,7 +3,7 @@ import { CODE_BLOCK_TINT_PERCENT } from '../../src/styles/codePalette'
 import { motion } from '../../src/styles/tokens'
 import { colorAlpha } from '../../src/test-support/color'
 import { expect, test } from './fixtures'
-import { getBrowserPrefValue, loginViaToken, openPreferencesDialog, pickTheme, resolvedColor } from './helpers/ui'
+import { getBrowserPrefValue, loginViaToken, openSettingsAt, pickTheme, resolvedColor } from './helpers/ui'
 
 /**
  * The palette actually reaches the page.
@@ -25,8 +25,7 @@ test.describe('Theme picker', () => {
   test('repaints the app and survives a reload', async ({ page, leapmuxServer }) => {
     await loginViaToken(page, leapmuxServer.adminToken)
     await page.goto('/')
-    await openPreferencesDialog(page, 'appearance')
-    const dialog = page.getByRole('dialog', { name: 'Preferences' })
+    const dialog = await openSettingsAt(page, 'appearance')
     const themeRow = dialog.locator('[data-setting-id="appearance.theme"]')
 
     const before = await backgroundVar(page)
@@ -58,7 +57,7 @@ test.describe('Theme picker', () => {
     // paired light and dark rule, and both halves need the positive statement.
     await loginViaToken(page, leapmuxServer.adminToken)
     await page.goto('/')
-    await openPreferencesDialog(page, 'appearance')
+    await openSettingsAt(page, 'appearance')
     const themeRow = page.locator('[data-setting-id="appearance.theme"]')
 
     await themeRow.getByRole('radiogroup', { name: 'Theme mode' }).getByRole('radio', { name: 'Light' }).click()
@@ -76,7 +75,7 @@ test.describe('Theme picker', () => {
     await expect(page.locator('html')).toHaveAttribute('data-ui-theme', 'gruvbox')
 
     // The dialog reads the same key, so it reports what the empty state wrote.
-    await openPreferencesDialog(page, 'appearance')
+    await openSettingsAt(page, 'appearance')
     const themeRow = page.locator('[data-setting-id="appearance.theme"]')
     await expect(themeRow.getByTestId('theme-chooser-name')).toHaveAttribute('data-value', 'gruvbox')
 
@@ -110,8 +109,7 @@ test.describe('Theme picker', () => {
   test('names the palettes Default borrows, per row', async ({ page, leapmuxServer }) => {
     await loginViaToken(page, leapmuxServer.adminToken)
     await page.goto('/')
-    await openPreferencesDialog(page, 'appearance')
-    const dialog = page.getByRole('dialog', { name: 'Preferences' })
+    const dialog = await openSettingsAt(page, 'appearance')
 
     // Each row's own menu names the palette Default borrows for that surface.
     // The option is keyed by theme id, so this reads the LABEL the picker chose.
@@ -133,8 +131,7 @@ test.describe('Theme picker', () => {
   test('previews the chosen palette in the chip beside its name', async ({ page, leapmuxServer }) => {
     await loginViaToken(page, leapmuxServer.adminToken)
     await page.goto('/')
-    await openPreferencesDialog(page, 'appearance')
-    const dialog = page.getByRole('dialog', { name: 'Preferences' })
+    const dialog = await openSettingsAt(page, 'appearance')
     const themeRow = dialog.locator('[data-setting-id="appearance.theme"]')
 
     await pickTheme(themeRow, 'gruvbox')
@@ -167,8 +164,7 @@ test.describe('Theme picker', () => {
   test('moves the terminal with the app while the terminal is left alone', async ({ page, leapmuxServer }) => {
     await loginViaToken(page, leapmuxServer.adminToken)
     await page.goto('/')
-    await openPreferencesDialog(page, 'appearance')
-    const dialog = page.getByRole('dialog', { name: 'Preferences' })
+    const dialog = await openSettingsAt(page, 'appearance')
     const themeRow = dialog.locator('[data-setting-id="appearance.theme"]')
     const terminalRow = dialog.locator('[data-setting-id="appearance.terminalTheme"]')
 
@@ -189,8 +185,7 @@ test.describe('Theme picker', () => {
   test('lets the terminal take its own palette and mode', async ({ page, leapmuxServer }) => {
     await loginViaToken(page, leapmuxServer.adminToken)
     await page.goto('/')
-    await openPreferencesDialog(page, 'appearance')
-    const dialog = page.getByRole('dialog', { name: 'Preferences' })
+    const dialog = await openSettingsAt(page, 'appearance')
     const themeRow = dialog.locator('[data-setting-id="appearance.theme"]')
     const terminalRow = dialog.locator('[data-setting-id="appearance.terminalTheme"]')
 
@@ -219,7 +214,7 @@ test.describe('Theme picker', () => {
     // change nothing on screen until the user adjusts it.
     await loginViaToken(page, leapmuxServer.adminToken)
     await page.goto('/')
-    await openPreferencesDialog(page, 'appearance')
+    await openSettingsAt(page, 'appearance')
     const themeRow = page.locator('[data-setting-id="appearance.theme"]')
     const terminalRow = page.locator('[data-setting-id="appearance.terminalTheme"]')
 
@@ -244,8 +239,7 @@ test.describe('Theme picker', () => {
   test('offers a syntax theme row that writes its own preference', async ({ page, leapmuxServer }) => {
     await loginViaToken(page, leapmuxServer.adminToken)
     await page.goto('/')
-    await openPreferencesDialog(page, 'appearance')
-    const dialog = page.getByRole('dialog', { name: 'Preferences' })
+    const dialog = await openSettingsAt(page, 'appearance')
     const syntaxRow = dialog.locator('[data-setting-id="appearance.syntaxTheme"]')
 
     const themeRow = dialog.locator('[data-setting-id="appearance.theme"]')
@@ -273,8 +267,7 @@ test.describe('Theme picker', () => {
   test('leaves the app and terminal alone when only the syntax theme changes', async ({ page, leapmuxServer }) => {
     await loginViaToken(page, leapmuxServer.adminToken)
     await page.goto('/')
-    await openPreferencesDialog(page, 'appearance')
-    const dialog = page.getByRole('dialog', { name: 'Preferences' })
+    const dialog = await openSettingsAt(page, 'appearance')
     const themeRow = dialog.locator('[data-setting-id="appearance.theme"]')
     const syntaxRow = dialog.locator('[data-setting-id="appearance.syntaxTheme"]')
 
@@ -291,8 +284,7 @@ test.describe('Theme picker', () => {
     // The two halves are one key, so a partial write must not reset the other.
     await loginViaToken(page, leapmuxServer.adminToken)
     await page.goto('/')
-    await openPreferencesDialog(page, 'appearance')
-    const dialog = page.getByRole('dialog', { name: 'Preferences' })
+    const dialog = await openSettingsAt(page, 'appearance')
     const themeRow = dialog.locator('[data-setting-id="appearance.theme"]')
 
     await pickTheme(themeRow, 'solarized')
@@ -327,7 +319,7 @@ test.describe('Theme picker', () => {
     // against a palette the syntax preference is no longer following.
     await loginViaToken(page, leapmuxServer.adminToken)
     await page.goto('/')
-    await openPreferencesDialog(page, 'appearance')
+    await openSettingsAt(page, 'appearance')
     const syntaxRow = page.locator('[data-setting-id="appearance.syntaxTheme"]')
 
     await pickTheme(syntaxRow, 'gruvbox')
@@ -349,7 +341,7 @@ test.describe('Theme picker', () => {
   async function openThemeMenu(page: Page, token: string) {
     await loginViaToken(page, token)
     await page.goto('/')
-    await openPreferencesDialog(page, 'appearance')
+    await openSettingsAt(page, 'appearance')
     const panel = page.locator('#preferences-panel')
     const trigger = panel.getByRole('button', { name: 'Theme', exact: true })
     const menu = panel.locator('[data-testid="theme-chooser-name-menu"][aria-label="Theme"]')
@@ -492,8 +484,7 @@ test.describe('Theme picker', () => {
     // in this file drives the same admin account.
     await loginViaToken(page, leapmuxServer.adminToken)
     await page.goto('/')
-    await openPreferencesDialog(page, 'appearance')
-    const dialog = page.getByRole('dialog', { name: 'Preferences' })
+    const dialog = await openSettingsAt(page, 'appearance')
     const themeRow = dialog.locator('[data-setting-id="appearance.theme"]')
     const syntaxRow = dialog.locator('[data-setting-id="appearance.syntaxTheme"]')
 
@@ -551,7 +542,7 @@ test.describe('color-scheme follows the app', () => {
     test('resolves light-dark() to the dark branch once the app is dark', async ({ page, leapmuxServer }) => {
       await loginViaToken(page, leapmuxServer.adminToken)
       await page.goto('/')
-      await openPreferencesDialog(page, 'appearance')
+      await openSettingsAt(page, 'appearance')
       const themeRow = page.locator('[data-setting-id="appearance.theme"]')
 
       await themeRow.getByRole('radiogroup', { name: 'Theme mode' }).getByRole('radio', { name: 'Dark' }).click()
@@ -569,7 +560,7 @@ test.describe('color-scheme follows the app', () => {
     test('resolves light-dark() to the light branch once the app is light', async ({ page, leapmuxServer }) => {
       await loginViaToken(page, leapmuxServer.adminToken)
       await page.goto('/')
-      await openPreferencesDialog(page, 'appearance')
+      await openSettingsAt(page, 'appearance')
       const themeRow = page.locator('[data-setting-id="appearance.theme"]')
 
       await themeRow.getByRole('radiogroup', { name: 'Theme mode' }).getByRole('radio', { name: 'Light' }).click()

--- a/frontend/tests/e2e/085-account-storage-isolation.spec.ts
+++ b/frontend/tests/e2e/085-account-storage-isolation.spec.ts
@@ -1,7 +1,7 @@
 import type { Page } from '@playwright/test'
 import { accountStorageKeyPrefix, KEY_CHANNEL_RELAY_SEQ, KEY_USER_EVENTS_RELAY_SEQ } from '../../src/lib/browserStorage'
 import { expect, test } from './fixtures'
-import { loginViaToken, openPreferencesDialog, pickTheme } from './helpers/ui'
+import { loginViaToken, openSettingsAt, pickTheme } from './helpers/ui'
 
 /**
  * Two accounts sharing one browser must not share stored state.
@@ -34,8 +34,7 @@ async function storageKeys(page: Page): Promise<string[]> {
 
 /** Pin the theme to a device override and set the palette, through the dialog. */
 async function overrideThemeOnThisDevice(page: Page, palette: string) {
-  await openPreferencesDialog(page, 'appearance')
-  const dialog = page.getByRole('dialog', { name: 'Preferences' })
+  const dialog = await openSettingsAt(page, 'appearance')
 
   const chip = dialog.getByTestId('scope-chip-appearance.theme')
   await chip.click()
@@ -81,8 +80,7 @@ test.describe('account storage isolation', () => {
     // paints `data-ui-theme="default"` at import time, so asserting the
     // attribute alone would match the pre-auth boot frame and hold even if this
     // account HAD inherited the admin's override.
-    await openPreferencesDialog(page, 'appearance')
-    const dialog = page.getByRole('dialog', { name: 'Preferences' })
+    const dialog = await openSettingsAt(page, 'appearance')
     await expect(dialog.getByTestId('scope-chip-appearance.theme')).toHaveText(/Account default/)
     await expect(page.locator('html')).toHaveAttribute('data-ui-theme', 'default')
     await page.keyboard.press('Escape')

--- a/frontend/tests/e2e/143-app-consent.spec.ts
+++ b/frontend/tests/e2e/143-app-consent.spec.ts
@@ -9,6 +9,8 @@
  * browser that walks the whole round trip shows that.
  */
 
+import { AppClientType, AppVisibility } from '../../src/generated/leapmux/v1/app_pb'
+import { Scope } from '../../src/generated/leapmux/v1/scope_pb'
 import { expect, test } from './fixtures'
 import { elevateSessionViaAPI, loginViaAPI, signUpViaAPI, TEST_ADMIN_PASSWORD, TEST_ADMIN_USERNAME } from './helpers/api'
 import { loginViaToken } from './helpers/ui'
@@ -21,9 +23,9 @@ import { loginViaToken } from './helpers/ui'
 const CONTROL_CLI_CLIENT_ID = 'leapmux-control-cli'
 
 /** A syntactically valid OAuth 2.1 authorization URL for a loopback listener. */
-function startURL(hubUrl: string, extra: Record<string, string> = {}): string {
+function startURL(hubUrl: string, extra: Record<string, string> = {}, clientId: string = CONTROL_CLI_CLIENT_ID): string {
   const params = new URLSearchParams({
-    client_id: CONTROL_CLI_CLIENT_ID,
+    client_id: clientId,
     response_type: 'code',
     code_challenge_method: 'S256',
     redirect_uri: 'http://127.0.0.1:54321/callback',
@@ -33,6 +35,38 @@ function startURL(hubUrl: string, extra: Record<string, string> = {}): string {
     ...extra,
   })
   return `${hubUrl}/oauth/authorize?${params.toString()}`
+}
+
+/**
+ * Register an UNVERIFIED app through the Connect RPC, as an elevated session.
+ *
+ * The built-in control CLI is verified BY CONSTRUCTION -- a registration
+ * source the build itself stands behind -- so the consent page's unverified
+ * branch, the branch this spec's heading assertions exist for, needs a
+ * registration nobody vouched for. Registering one is also the honest shape
+ * of the risk: open registration lets any caller be the registrant.
+ */
+async function registerUnverifiedApp(
+  request: import('@playwright/test').APIRequestContext,
+  hubUrl: string,
+  elevatedCookie: string,
+  name: string,
+  scopes: number[] = [Scope.WORKSPACE_READ],
+): Promise<string> {
+  const res = await request.post(`${hubUrl}/leapmux.v1.AppService/RegisterApp`, {
+    headers: { 'Content-Type': 'application/json', 'Cookie': elevatedCookie },
+    data: {
+      clientName: name,
+      clientUri: 'https://example.com',
+      redirectUris: ['http://127.0.0.1:54321/callback'],
+      scopes,
+      visibility: AppVisibility.PRIVATE,
+      clientType: AppClientType.PUBLIC,
+    },
+  })
+  expect(res.status(), await res.text()).toBe(200)
+  const json = await res.json() as { app: { clientId: string } }
+  return json.app.clientId
 }
 
 /**
@@ -49,9 +83,18 @@ async function freshAdminSession(hubUrl: string): Promise<string> {
 
 test.describe('app consent needs an elevated session', () => {
   test('bounces through /elevate and returns to the consent page', async ({ page, leapmuxServer }) => {
+    // The consent page renders its UNVERIFIED branch for a registered app;
+    // the built-in CLI is verified by construction, so its heading carries
+    // its own name instead.
+    const registrar = await freshAdminSession(leapmuxServer.hubUrl)
+    await elevateSessionViaAPI(leapmuxServer.hubUrl, registrar, TEST_ADMIN_PASSWORD)
+    const clientId = await registerUnverifiedApp(page.request, leapmuxServer.hubUrl, registrar, 'Consent e2e app')
+
+    // The BROWSER holds a SECOND, un-elevated session of the same account:
+    // the bounce is the first half of what this test walks.
     await loginViaToken(page, await freshAdminSession(leapmuxServer.hubUrl))
 
-    await page.goto(startURL(leapmuxServer.hubUrl))
+    await page.goto(startURL(leapmuxServer.hubUrl, {}, clientId))
 
     // Layer one: the hub sends the un-elevated session to the SPA prompt,
     // with the consent URL as the return address.
@@ -166,16 +209,66 @@ test.describe('app consent needs an elevated session', () => {
   // the hub's own words, so the heading is hub-authored and the name appears
   // inside a paragraph that says the app claims it.
   test('keeps an unverified app name out of the heading', async ({ page, leapmuxServer }) => {
+    // The phishing shape, stated as the registration's own choice of name.
+    const claimed = 'LeapMux Official Security Check'
     const cookie = await freshAdminSession(leapmuxServer.hubUrl)
     await elevateSessionViaAPI(leapmuxServer.hubUrl, cookie, TEST_ADMIN_PASSWORD)
+    const clientId = await registerUnverifiedApp(page.request, leapmuxServer.hubUrl, cookie, claimed)
     await loginViaToken(page, cookie)
 
-    await page.goto(startURL(leapmuxServer.hubUrl))
+    await page.goto(startURL(leapmuxServer.hubUrl, {}, clientId))
 
     const heading = page.getByRole('heading', { name: 'Authorize an unverified app?' })
     await expect(heading).toBeVisible()
-    await expect(heading).not.toContainText('LeapMux control CLI')
-    await expect(page.getByText(/Nobody has verified this app on this hub/)).toBeVisible()
+    await expect(heading).not.toContainText(claimed)
+    await expect(page.getByText('Nobody verified this app on this hub')).toBeVisible()
+  })
+
+  // The permission catalogue: the whole grantable vocabulary grouped by
+  // family, the asked-for permissions ticked, the rest dimmed. The four
+  // assertions are the layout contract -- a narrow family once laid its one
+  // row BESIDE its label, the ticked marks read as dimmed because disabled
+  // inputs grey out, and long sentences started on a line of their own.
+  test('renders the permission catalogue grouped by family', async ({ page, leapmuxServer }) => {
+    const cookie = await freshAdminSession(leapmuxServer.hubUrl)
+    await elevateSessionViaAPI(leapmuxServer.hubUrl, cookie, TEST_ADMIN_PASSWORD)
+    // workspace:read + file:read, which the hub closes with worker:read --
+    // three granted scopes across three families, each with an ungranted
+    // sibling to dim.
+    const clientId = await registerUnverifiedApp(page.request, leapmuxServer.hubUrl, cookie, 'Catalogue e2e app', [Scope.WORKSPACE_READ, Scope.FILE_READ])
+    await loginViaToken(page, cookie)
+
+    await page.goto(startURL(leapmuxServer.hubUrl, {}, clientId))
+
+    // WIDE: the catalogue is the widest thing the hub renders.
+    await expect(page.locator('main.wide')).toBeVisible()
+
+    const scopes = page.locator('.scopes')
+    // Ticked = exactly the closed grant: workspace:read, worker:read,
+    // file:read. The ungranted siblings carry no tick.
+    await expect(scopes.locator('li.granted')).toHaveCount(3)
+    const workspaceWrite = scopes.locator('li.not-granted').filter({ hasText: 'workspace:write' })
+    await expect(workspaceWrite).toHaveCount(1)
+    // The tick is PAINTED in the primary colour -- asserted on the mark's
+    // own background, because a computed accent-color proved nothing: the
+    // browsers ignore it on the disabled native checkbox this replaced.
+    await expect(scopes.locator('li.granted > .tick').first()).toHaveCSS('background-color', 'rgb(13, 148, 136)')
+
+    // The family label stands on its OWN line: the File label ends above
+    // where file:read begins.
+    const fileLabel = scopes.locator('.scope-category', { hasText: 'File' })
+    const fileToken = scopes.locator('.scope-token', { hasText: 'file:read' })
+    const labelBox = await fileLabel.boundingBox()
+    const tokenBox = await fileToken.boundingBox()
+    expect(labelBox && tokenBox).toBeTruthy()
+    expect(labelBox!.y + labelBox!.height).toBeLessThanOrEqual(tokenBox!.y + 1)
+
+    // A sentence begins BESIDE its token, never on a line of its own.
+    const sentenceBox = await page
+      .locator('.scope-sentence', { hasText: 'Browse and read files on your machines.' })
+      .boundingBox()
+    expect(sentenceBox).toBeTruthy()
+    expect(Math.abs(sentenceBox!.y - tokenBox!.y)).toBeLessThan(2)
   })
 
   // DENY returns to the app immediately, with the standard error.

--- a/frontend/tests/e2e/181-dialog-safe-area-geometry.spec.ts
+++ b/frontend/tests/e2e/181-dialog-safe-area-geometry.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from './fixtures'
-import { openPreferencesDialog } from './helpers/ui'
+import { openSettingsAt } from './helpers/ui'
 
 /**
  * Runtime geometry for modal safe-area insets.
@@ -193,7 +193,7 @@ test.describe('dialog safe-area geometry (portrait)', () => {
   }) => {
     void authenticatedWorkspace
     await applySimulatedSafeArea(page, IPHONE_PORTRAIT)
-    await openPreferencesDialog(page)
+    await openSettingsAt(page)
 
     const geometry = await readDialogGeometry(page)
     expect(geometry, 'open Preferences dialog + close button').not.toBeNull()
@@ -244,7 +244,7 @@ test.describe('dialog safe-area geometry (landscape notch)', () => {
   }) => {
     void authenticatedWorkspace
     await applySimulatedSafeArea(page, IPHONE_LANDSCAPE_NOTCH_RIGHT)
-    await openPreferencesDialog(page)
+    await openSettingsAt(page)
 
     const geometry = await readDialogGeometry(page)
     expect(geometry, 'open Preferences dialog + close button').not.toBeNull()

--- a/frontend/tests/e2e/helpers/ui.ts
+++ b/frontend/tests/e2e/helpers/ui.ts
@@ -878,10 +878,21 @@ export async function loginWithPasskeyViaUI(page: Page, username: string) {
   await appMenuTrigger(page).waitFor({ state: 'visible' })
 }
 
+/**
+ * Open Preferences on the given section and return the dialog locator, so
+ * the dialog's accessible name is stated once. A spec that needs the dialog
+ * after opening it at a section reads `const dialog = await
+ * openSettingsAt(page, 'apps')` instead of re-deriving the role lookup at
+ * every call site -- a rename of the dialog could not be half-applied.
+ */
+export async function openSettingsAt(page: Page, category?: string) {
+  await openPreferencesDialog(page, category)
+  return page.getByRole('dialog', { name: 'Preferences' })
+}
+
 /** Open Preferences on the account / profile section. */
 export async function openAccountSettings(page: Page) {
-  await openPreferencesDialog(page, 'account')
-  return page.getByRole('dialog', { name: 'Preferences' })
+  return openSettingsAt(page, 'account')
 }
 
 /**

--- a/proto/leapmux/v1/app.proto
+++ b/proto/leapmux/v1/app.proto
@@ -144,6 +144,12 @@ message ListAppsRequest {
   // Include registrations that were revoked. They stay readable because a live
   // credential on a retired app must still be explainable.
   bool include_revoked = 3;
+  // Narrow the listing to one reach. APP_VISIBILITY_UNSPECIFIED keeps the
+  // caller's whole editable set -- an administrator's own apps beside the
+  // hub-wide catalogue. HUB_WIDE asks for the catalogue alone (administrators
+  // only), and PRIVATE for the caller's own registrations, so a surface that
+  // draws one reach does not fetch and discard the other.
+  AppVisibility visibility = 4;
 }
 
 message ListAppsResponse {


### PR DESCRIPTION
## Motivation

- `auth status` / `whoami` trusted the local credential file: a stale username or a fabricated `is_admin: false` could be presented as fact, a network blip during token rotation read as a revoked credential, and an aborted re-login could orphan a live credential on the hub.
- The script-free OAuth decision pages (consent, device, error) were unstyled and showed only the requested scopes — users consented without seeing the whole permission catalogue — and nothing pinned the hub's palette, tick mark, scope grouping, or implied-scope graph to the frontend sources they must match.
- Administrators had no way to inspect hub-wide app registrations; the register/edit forms listed scopes flat (edits silently stripped implied scopes) and the settings UI carried bespoke styles diverging from Oat.
- Dialog action rows were hand-wrapped per file and overflowed on narrow panels, `--radius-2` uses remained, UI copy pointed at renamed Preferences paths, and the 143-app-consent e2e spec had shipped red in #422.

## Modifications

- **CLI auth**
  - `auth status` and `whoami` make one authenticated `GetCurrentUser` RPC (new `Client.AuthService()`) instead of trusting the credential file; a shared `hubCheck()` classifies the outcome, capped by a 5-second budget that includes token rotation:
    - confirmed: the hub's username and `is_admin` overwrite the stale local copy; status gains `hub_checked: true`
    - refused: `not_logged_in`
    - local fallback: unreachable hub, reverse-proxy misroute, or a credential lacking `account:read` — the local answer prints with a `warning` stating what was unverified, and `is_admin: null`
    - anything else: `rpc_failed`
  - Re-login validates every input before any destructive action, then revokes on the hub and deletes the existing credential before the OAuth flow starts — an aborted login orphans no live credential (the old save-then-revoke in `persistTokenResponse` is gone; retirement has one owner)
  - New `cmd/output.go` centralizes the envelope timestamp helpers: deadlines print as UTC millisecond strings ending in `Z`, and `SaveCredentials` normalizes stored deadlines to UTC
  - `bearerErrorCode` maps transient rotation failures to `Unavailable` instead of `Unauthenticated` (a network blip no longer reads as a revoked credential), and `doRefresh` clamps its budget to the caller's remaining deadline
- **Hub OAuth pages, store, proto**
  - The consent, device, and error pages share one embedded `pageCSS` — a copy of the frontend default palette (light + dark via `prefers-color-scheme`; the CSP `default-src 'none'` forbids linking the SPA stylesheet) with Oat-derived shapes
  - `describeScopeCatalogue` renders every grantable scope grouped into families: the requested ones ticked with a CSS tick byte-identical to Oat's checkbox mask, the rest dimmed, ungranted families skipped; the device page states an empty ask in prose
  - Three mirror-pin test suites hold the hand-copied Go tables against frontend sources (palette tokens vs `themes/default.ts`, the tick mask vs `@knadh/oat`'s form.css, scope families and the `impliedBy` graph vs `scopeCatalogue.ts`); missing or moved frontend files fail rather than skip
  - `ListAppsRequest.visibility` (proto field 4): UNSPECIFIED keeps today's behaviour, PRIVATE narrows to the caller's own registrations, and HUB_WIDE (admins only, else `PermissionDenied`) narrows to the hub-wide catalogue — backed by `store.ListOAuthClientsParams.HubWideOnly` and a `CASE WHEN hub_wide_only` branch in the MySQL, Postgres, and SQLite dialects
  - Emails and the step-up 403 point at the sections' current home ("Preferences › Apps › Connected apps" / "Preferences › Apps › App registrations")
- **Settings frontend**
  - `AccountAppRegistrations` is renamed `AppRegistrations` with a `variant: 'user' | 'hub-wide'` prop; the hub-wide variant registers with `AppVisibility.HUB_WIDE` and lists with `visibility: HUB_WIDE`, so an admin's private rows never cross the wire
  - A new ADMINISTRATION registry tier (`registry/admin.ts`) holds the admin-only "Hub-wide Apps" row; Connected apps moved into the Apps section, and solo mode now hides Account entirely and falls back to Apps
  - New `scopeCatalogue.ts` mirrors the backend's scope families and `IMPLIED_BY` graph with a memoized `closure()`; the register/edit forms render grouped checkboxes with one-sentence descriptions, show implied scopes checked-and-disabled, and submit the closed set — matching what the hub's `scopes.Close()` stores
  - Oat alignment: setting-row labels are h3; bespoke badge/danger styles replaced by Oat badge variants and danger ConfirmButtons (outline for dialog-opening triggers, filled for one-request destructive acts); credential rows stack text above a right-aligned actions footer; a shared `FormActions` unifies the register/edit footers; registration dates render via `RelativeTimeAgo`
- **Shared frontend styles**
  - One exported `actionsFooter` style (flex, wrap, right-aligned, space-2 gap) is stated explicitly on every dialog footer, and the Dialog stylesheet keeps only its own chrome
  - The auth forms (ElevateForm, Login, Signup, Forgot/Reset password, VerifyEmail) adopt the same convention, replacing the hand-wrapped `flex justify-end` divs and the `credentialActions`/`passkeyButtons` styles
  - `var(--radius-2)` → `var(--radius-medium)` in three css modules; no `--radius-2` uses remain
- **E2E**
  - One `openSettingsAt(page, category?)` helper opens Preferences at a section and returns the dialog locator, so the dialog's accessible name is stated once; seven specs migrated, `openAccountSettings` delegates
  - 143-app-consent is repaired via a `registerUnverifiedApp` helper (it had asserted the unverified consent branch for the built-in CLI that verification made impossible) and extended with an impersonation-shaped anti-phishing heading test and a bounding-box geometry test for the wide catalogue layout
- **Breaking/behavior changes**
  - The CLI envelope shape changes: `hub_checked`, `is_admin` (null on fallback), `warning`, whoami `hub_url`, millisecond UTC timestamps
  - A failed login now leaves the machine logged out by design
  - Internal renames: `AccountAppRegistrations` → `AppRegistrations`, `account.connectedApps` category `account` → `apps`
  - Dialog footers must now carry `actionsFooter` to get action-row layout

## Result

- The CLI reports hub-verified identity with honest unknowns (`is_admin: null` on fallback) and actionable warnings, never orphans a live credential on an aborted login, no longer misreads a transient failure as revocation, and prints UTC timestamps that compare cleanly with the hub in jq/shell.
- Users consent on brand-styled pages that show the full permission catalogue with the requested scopes ticked; admins get a Hub-wide Apps panel; scope pickers lock implied scopes and edits preserve the closure on round trips.
- Frontend/backend visual and semantic drift is pinned by mirror tests, dialog footers are uniform and wrap on narrow panels, and the e2e suite is green.
