### PR TITLE
feat(pi): Hide agent_settled, time the turn, honor willRetry

### DIFF
--- a/backend/internal/worker/agent/acp_common.go
+++ b/backend/internal/worker/agent/acp_common.go
@@ -294,6 +294,11 @@ func (b *acpBase) handleACPPromptResponse(resp json.RawMessage) {
 	b.mu.Lock()
 	assistantText := b.turnAssistantText.String()
 	b.turnAssistantText.Reset()
+	// BUG: this clear runs BEFORE enrichWithToolUses below reads the same
+	// field, so every ACP turn reports num_tool_uses:0 and the frontend
+	// suppresses the completion sound for all six ACP providers. The fix is to
+	// capture the count here and enrich from the captured value.
+	// https://github.com/leapmux/leapmux/issues/435
 	b.turnToolUses = 0
 	b.mu.Unlock()
 

--- a/backend/internal/worker/agent/pi.go
+++ b/backend/internal/worker/agent/pi.go
@@ -442,10 +442,10 @@ func (a *PiAgent) ClearContext() (string, bool) {
 	a.applyStateResponse(stateRaw)
 	a.mu.Lock()
 	a.currentTurnActive = false
-	// Drop the turn's start mark with the session. agent_start only takes a mark
-	// when none is held (so a retried run keeps the turn's original start), so a
-	// mark left behind by a turn this clear replaced would make the NEXT turn's
-	// divider report the time since the old turn began.
+	// Drop the turn's start mark with the session. agent_start takes a mark only
+	// when the agent holds none, so that a retried run keeps the turn's original
+	// start. A mark that survived the turn this clear replaced would then make
+	// the NEXT turn's divider report the time since the old turn began.
 	a.turnStartedAt = time.Time{}
 	a.sessionCostUsd = 0
 	a.sessionCostKnown = false

--- a/backend/internal/worker/agent/pi.go
+++ b/backend/internal/worker/agent/pi.go
@@ -38,9 +38,18 @@ type PiAgent struct {
 	workingDir    string
 	sink          OutputSink
 
-	sessionID         string // Pi's runtime sessionId (rotates on new_session)
-	sessionFile       string // Pi's persistent session file path (durable identifier)
-	currentTurnActive bool   // true between agent_start and agent_end
+	sessionID   string // Pi's runtime sessionId (rotates on new_session)
+	sessionFile string // Pi's persistent session file path (durable identifier)
+	// currentTurnActive is true while the turn is open. A run that Pi will
+	// auto-retry (agent_end with willRetry) keeps it true, because Pi restarts
+	// that run itself: Interrupt must still send an abort, and a user message
+	// must still steer rather than queue.
+	currentTurnActive bool
+	// turnStartedAt marks when the turn's FIRST agent_start arrived, so
+	// agent_end can report the turn's wall time. Pi's agent_end carries no
+	// duration of its own. Zero between turns, and zero for a turn whose start
+	// this worker never saw -- the divider then omits the duration.
+	turnStartedAt time.Time
 	// thinkingTokens is the per-phase generated-token estimate driving the
 	// thinking-indicator counter; see thinkingTokenEstimator and thinkingResetSink.
 	thinkingTokens thinkingTokenEstimator
@@ -76,6 +85,19 @@ type PiAgent struct {
 	// the instruction it was given. Dropped with the description on
 	// tool_execution_end, and cleared when the session is replaced.
 	toolCallPrompts pendingPrompts
+
+	// nowFn supplies the clock that times a turn. Production leaves it nil; a
+	// test installs a fixed clock so the reported duration is exact.
+	nowFn func() time.Time
+}
+
+// now reads the agent's clock. The zero value must work, because the tests
+// build a PiAgent as a struct literal and never reach NewPiAgent.
+func (a *PiAgent) now() time.Time {
+	if a.nowFn != nil {
+		return a.nowFn()
+	}
+	return time.Now()
 }
 
 // piResumeArgs builds the `--session` argument that reopens a prior Pi session,
@@ -420,6 +442,11 @@ func (a *PiAgent) ClearContext() (string, bool) {
 	a.applyStateResponse(stateRaw)
 	a.mu.Lock()
 	a.currentTurnActive = false
+	// Drop the turn's start mark with the session. agent_start only takes a mark
+	// when none is held (so a retried run keeps the turn's original start), so a
+	// mark left behind by a turn this clear replaced would make the NEXT turn's
+	// divider report the time since the old turn began.
+	a.turnStartedAt = time.Time{}
 	a.sessionCostUsd = 0
 	a.sessionCostKnown = false
 	a.latestContextUsage = nil

--- a/backend/internal/worker/agent/pi_output.go
+++ b/backend/internal/worker/agent/pi_output.go
@@ -82,10 +82,10 @@ type piQueueUpdateEnvelope struct {
 // auto-continue.
 //
 // WillRetry is Pi's own statement that it restarts this run itself. Pi's
-// session layer stamps it on every agent_end, and sets it true only while
-// retries are enabled, the retry budget is unspent, and the last assistant
-// message failed with a transient error. An older Pi omits the field, which
-// decodes to false -- the behavior LeapMux had before it read the field.
+// session layer stamps it on every agent_end. It is true only for three
+// conditions together: retries are enabled, the retry budget is unspent, and
+// the last assistant message failed with a transient error. An older Pi omits
+// the field, which decodes to false -- how LeapMux behaved before it read it.
 type piAgentEndEnvelope struct {
 	Messages []struct {
 		Role         string `json:"role"`
@@ -221,10 +221,12 @@ func (a *PiAgent) handlePiAgentEnd(raw []byte) {
 }
 
 // piTurnDurationMs measures one Pi turn in milliseconds. Pi's agent_end carries
-// no duration of its own, so the worker brackets the turn instead. It returns
-// nil when this worker never saw the turn start, or when the clock moved
-// backwards, so the persisted envelope carries no duration at all rather than a
-// false 0 -- the frontend tells those two apart.
+// no duration of its own, so the worker brackets the turn instead.
+//
+// It returns nil for a turn whose start this worker never saw, and for a clock
+// that moved backwards. The envelope then carries no duration at all, rather
+// than a false 0. The frontend tells those two apart: it draws no time for an
+// absent field, and "(0ms)" for a real zero.
 func piTurnDurationMs(startedAt, endedAt time.Time) *int64 {
 	if startedAt.IsZero() || endedAt.Before(startedAt) {
 		return nil

--- a/backend/internal/worker/agent/pi_output.go
+++ b/backend/internal/worker/agent/pi_output.go
@@ -190,6 +190,10 @@ func (a *PiAgent) handlePiAgentEnd(raw []byte) {
 	// really ends measures from the zero time and reports no duration at all.
 	startedAt := a.turnStartedAt
 	if !env.WillRetry {
+		// turnToolUses is write-only state for Pi: nothing enriches agent_end
+		// with num_tool_uses, so the turn-end event leaves the count unset and
+		// the frontend rings even for a turn that used no tool.
+		// https://github.com/leapmux/leapmux/issues/435
 		a.turnToolUses = 0
 		a.turnStartedAt = time.Time{}
 	}

--- a/backend/internal/worker/agent/pi_output.go
+++ b/backend/internal/worker/agent/pi_output.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/leapmux/leapmux/generated/contracts"
 
@@ -79,12 +80,19 @@ type piQueueUpdateEnvelope struct {
 // piAgentEndEnvelope captures the per-message stop info on agent_end so we
 // can inspect the final assistant turn's outcome and decide whether to
 // auto-continue.
+//
+// WillRetry is Pi's own statement that it restarts this run itself. Pi's
+// session layer stamps it on every agent_end, and sets it true only while
+// retries are enabled, the retry budget is unspent, and the last assistant
+// message failed with a transient error. An older Pi omits the field, which
+// decodes to false -- the behavior LeapMux had before it read the field.
 type piAgentEndEnvelope struct {
 	Messages []struct {
 		Role         string `json:"role"`
 		StopReason   string `json:"stopReason"`
 		ErrorMessage string `json:"errorMessage"`
 	} `json:"messages"`
+	WillRetry bool `json:"willRetry"`
 }
 
 // piRetryableWebSocketError is the exact errorMessage Pi emits for transient
@@ -110,8 +118,11 @@ func handlePiOutput(a *PiAgent, line *parsedLine) {
 		a.handlePiAgentStart()
 	case contracts.PiEventAgentEnd:
 		a.handlePiAgentEnd(line.Raw)
-	case contracts.PiEventTurnStart, contracts.PiEventTurnEnd, contracts.PiEventMessageStart:
-		// Lifecycle markers; no UI state change required.
+	case contracts.PiEventTurnStart, contracts.PiEventTurnEnd,
+		contracts.PiEventMessageStart, contracts.PiEventAgentSettled:
+		// Lifecycle markers; no UI state change required. `agent_settled` says
+		// only that Pi will not continue on its own after the agent_end that
+		// already drew the divider, so it adds nothing to the transcript.
 	case contracts.PiEventMessageUpdate:
 		a.handlePiMessageUpdate(line.Raw)
 	case contracts.PiEventMessageEnd:
@@ -147,17 +158,41 @@ func handlePiOutput(a *PiAgent, line *parsedLine) {
 }
 
 func (a *PiAgent) handlePiAgentStart() {
+	// Read the clock before the lock, so an injected clock never runs under mu.
+	startedAt := a.now()
 	a.mu.Lock()
 	a.currentTurnActive = true
+	// A retried run continues the turn that the first agent_start began, so the
+	// mark survives it and the divider reports the whole elapsed time instead of
+	// the last attempt alone. handlePiAgentEnd clears it when the turn ends.
+	if a.turnStartedAt.IsZero() {
+		a.turnStartedAt = startedAt
+	}
 	a.mu.Unlock()
 	// A fresh turn begins: start the thinking-token estimate from zero.
 	a.thinkingTokens.reset()
 }
 
 func (a *PiAgent) handlePiAgentEnd(raw []byte) {
+	// Decode once. The retry decision, the willRetry routing, and the auto-
+	// continue decision all read this same envelope.
+	var env piAgentEndEnvelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		slog.Warn("pi agent_end unmarshal failed", "agent_id", a.agentID, "error", err)
+	}
+
+	endedAt := a.now()
 	a.mu.Lock()
-	a.currentTurnActive = false
-	a.turnToolUses = 0
+	// A retry keeps the turn open: Pi restarts the run itself, so Interrupt must
+	// still send an abort and a user message must still steer the running turn.
+	a.currentTurnActive = env.WillRetry
+	// Read the mark BEFORE the clear below consumes it, or every turn that
+	// really ends measures from the zero time and reports no duration at all.
+	startedAt := a.turnStartedAt
+	if !env.WillRetry {
+		a.turnToolUses = 0
+		a.turnStartedAt = time.Time{}
+	}
 	a.mu.Unlock()
 	// Recover from any tool calls that didn't get a matching
 	// tool_execution_end (e.g. aborted turn). Otherwise the map retains the
@@ -169,12 +204,15 @@ func (a *PiAgent) handlePiAgentEnd(raw []byte) {
 	// away. Then refresh Pi's authoritative session stats asynchronously for the
 	// live popover; the stdout read loop must remain free to deliver that RPC
 	// response.
-	a.persistPiAgentEnd(raw, a.currentPiUsageSnapshot())
-	scheduleOrCancelAPIErrorAutoContinue(a.sink, isRetryablePiAgentEndFailure(raw), raw)
+	a.persistPiAgentEnd(raw, a.currentPiUsageSnapshot(), piTurnDurationMs(startedAt, endedAt), env.WillRetry)
+	// Pi retries the run itself when it says willRetry, so LeapMux must not send
+	// a second continuation for the same failure. Pi reports false once its own
+	// retry budget is spent, which is where LeapMux's auto-continue takes over
+	// as the last resort.
+	scheduleOrCancelAPIErrorAutoContinue(a.sink, !env.WillRetry && env.isRetryableFailure(), raw)
+	// The failed attempt's spans are dead either way: a retried run reopens its
+	// own, so the reset is unconditional.
 	a.sink.ResetSpans()
-	a.sink.BroadcastSessionInfo(map[string]any{
-		"pi_turn_active": false,
-	})
 	if a.canRequestPiSessionStats() {
 		go func() {
 			_, _ = a.refreshPiSessionStats(piSessionStatsTimeout(a.APITimeout()))
@@ -182,11 +220,22 @@ func (a *PiAgent) handlePiAgentEnd(raw []byte) {
 	}
 }
 
-func isRetryablePiAgentEndFailure(raw []byte) bool {
-	var env piAgentEndEnvelope
-	if err := json.Unmarshal(raw, &env); err != nil {
-		return false
+// piTurnDurationMs measures one Pi turn in milliseconds. Pi's agent_end carries
+// no duration of its own, so the worker brackets the turn instead. It returns
+// nil when this worker never saw the turn start, or when the clock moved
+// backwards, so the persisted envelope carries no duration at all rather than a
+// false 0 -- the frontend tells those two apart.
+func piTurnDurationMs(startedAt, endedAt time.Time) *int64 {
+	if startedAt.IsZero() || endedAt.Before(startedAt) {
+		return nil
 	}
+	ms := endedAt.Sub(startedAt).Milliseconds()
+	return &ms
+}
+
+// isRetryableFailure reports whether the turn ended on the one transient
+// failure LeapMux itself auto-continues past.
+func (env piAgentEndEnvelope) isRetryableFailure() bool {
 	// Walk from the end: only the final assistant message reflects the
 	// turn's final outcome; earlier assistant entries are intra-turn.
 	for i := len(env.Messages) - 1; i >= 0; i-- {

--- a/backend/internal/worker/agent/pi_output_test.go
+++ b/backend/internal/worker/agent/pi_output_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -214,18 +215,37 @@ func TestHandlePiOutput_AgentEnd_WillRetryDoesNotEndTurn(t *testing.T) {
 }
 
 // Pi retries the WebSocket failure itself when it says willRetry, so LeapMux
-// must not schedule a second continuation for the same failure.
-func TestHandlePiOutput_AgentEnd_WillRetrySuppressesAutoContinue(t *testing.T) {
+// must not schedule a second continuation for the same failure. willRetry is
+// the ONLY difference between these two envelopes: Pi reports false once its
+// own retry budget is spent, and that is where LeapMux's auto-continue takes
+// over as the last resort.
+func TestHandlePiOutput_AgentEnd_WillRetryDecidesAutoContinue(t *testing.T) {
 	t.Parallel()
 
-	sink := &recordingControlSink{}
-	a := newPiAgentWithSink(sink)
-	raw := []byte(`{"type":"agent_end","messages":[{"role":"assistant","stopReason":"error","errorMessage":"WebSocket error"}],"willRetry":true}`)
+	for _, tc := range []struct {
+		name      string
+		willRetry bool
+		schedules int
+		cancels   int
+	}{
+		{"Pi retries, so LeapMux stands down", true, 0, 1},
+		{"Pi is done retrying, so LeapMux continues", false, 1, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	handlePiOutput(a, parseLine(raw))
+			sink := &recordingControlSink{}
+			a := newPiAgentWithSink(sink)
+			raw := fmt.Appendf(nil,
+				`{"type":"agent_end","messages":[{"role":"assistant","stopReason":"error","errorMessage":"WebSocket error"}],"willRetry":%t}`,
+				tc.willRetry)
 
-	assert.Equal(t, 0, sink.AutoScheduleCount(), "Pi's own retry must not be doubled")
-	assert.Equal(t, 1, sink.AutoCancelCount())
+			handlePiOutput(a, parseLine(raw))
+
+			assert.Equal(t, tc.schedules, sink.AutoScheduleCount())
+			assert.Equal(t, tc.cancels, sink.AutoCancelCount())
+		})
+	}
 }
 
 func TestPiTurnDurationMs(t *testing.T) {

--- a/backend/internal/worker/agent/pi_output_test.go
+++ b/backend/internal/worker/agent/pi_output_test.go
@@ -95,7 +95,7 @@ func piPersistedAgentEnd(t *testing.T, sink *recordingControlSink, index int) ma
 
 // agent_settled reports only that Pi will not continue on its own after the
 // agent_end that already drew the divider. It must leave no trace at all,
-// because the default arm of the dispatch would persist it as a raw-JSON row.
+// because the dispatch's default case would persist it as a raw-JSON row.
 func TestHandlePiOutput_AgentSettled_PersistsNothing(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/worker/agent/pi_output_test.go
+++ b/backend/internal/worker/agent/pi_output_test.go
@@ -69,16 +69,19 @@ func TestHandlePiOutput_AgentEnd_PersistsResultDividerAndResets(t *testing.T) {
 	assert.Equal(t, 0, sink.SessionInfoCount())
 }
 
-// piClockFrom installs a clock that starts at a fixed instant and advances by
-// step on every read, so a test states the exact duration it expects.
-func piClockFrom(a *PiAgent, start time.Time, step time.Duration) {
-	reads := 0
-	a.nowFn = func() time.Time {
-		now := start.Add(time.Duration(reads) * step)
-		reads++
-		return now
-	}
+// piFakeClock pins the agent's clock at start and returns the function that
+// moves it. The caller advances between events, so a test reads as the timeline
+// it means and stays correct however many times a handler reads the clock --
+// a step-per-read clock silently re-times every case the moment a handler
+// gains or loses one call.
+func piFakeClock(a *PiAgent, start time.Time) (advance func(time.Duration)) {
+	now := start
+	a.nowFn = func() time.Time { return now }
+	return func(d time.Duration) { now = now.Add(d) }
 }
+
+// piEpoch is an arbitrary fixed instant. Only the differences matter.
+var piEpoch = time.Date(2026, 9, 2, 10, 0, 0, 0, time.UTC)
 
 // piPersistedAgentEnd decodes the nth persisted message as a JSON object.
 func piPersistedAgentEnd(t *testing.T, sink *recordingControlSink, index int) map[string]any {
@@ -113,10 +116,10 @@ func TestHandlePiOutput_AgentEnd_ReportsTurnDuration(t *testing.T) {
 
 	sink := &recordingControlSink{}
 	a := newPiAgentWithSink(sink)
-	base := time.Date(2026, 9, 2, 10, 0, 0, 0, time.UTC)
-	piClockFrom(a, base, 2500*time.Millisecond)
+	advance := piFakeClock(a, piEpoch)
 
 	handlePiOutput(a, parseLine([]byte(`{"type":"agent_start"}`)))
+	advance(2500 * time.Millisecond)
 	handlePiOutput(a, parseLine([]byte(`{"type":"agent_end","messages":[]}`)))
 
 	assert.Equal(t, float64(2500), piPersistedAgentEnd(t, sink, 0)["duration_ms"])
@@ -130,7 +133,8 @@ func TestHandlePiOutput_AgentEnd_ZeroLengthTurnReportsZero(t *testing.T) {
 
 	sink := &recordingControlSink{}
 	a := newPiAgentWithSink(sink)
-	piClockFrom(a, time.Date(2026, 9, 2, 10, 0, 0, 0, time.UTC), 0)
+	// The clock never advances, so the turn takes no measurable time at all.
+	piFakeClock(a, piEpoch)
 
 	handlePiOutput(a, parseLine([]byte(`{"type":"agent_start"}`)))
 	handlePiOutput(a, parseLine([]byte(`{"type":"agent_end","messages":[]}`)))
@@ -160,13 +164,15 @@ func TestHandlePiOutput_AgentEnd_SecondEndOmitsDuration(t *testing.T) {
 
 	sink := &recordingControlSink{}
 	a := newPiAgentWithSink(sink)
-	piClockFrom(a, time.Date(2026, 9, 2, 10, 0, 0, 0, time.UTC), time.Second)
+	advance := piFakeClock(a, piEpoch)
 
 	handlePiOutput(a, parseLine([]byte(`{"type":"agent_start"}`)))
+	advance(time.Second)
 	handlePiOutput(a, parseLine([]byte(`{"type":"agent_end","messages":[]}`)))
+	advance(time.Second)
 	handlePiOutput(a, parseLine([]byte(`{"type":"agent_end","messages":[]}`)))
 
-	assert.Contains(t, piPersistedAgentEnd(t, sink, 0), "duration_ms")
+	assert.Equal(t, float64(1000), piPersistedAgentEnd(t, sink, 0)["duration_ms"])
 	assert.NotContains(t, piPersistedAgentEnd(t, sink, 1), "duration_ms")
 }
 
@@ -177,12 +183,15 @@ func TestHandlePiOutput_AgentEnd_RetryKeepsTurnStartMark(t *testing.T) {
 
 	sink := &recordingControlSink{}
 	a := newPiAgentWithSink(sink)
-	piClockFrom(a, time.Date(2026, 9, 2, 10, 0, 0, 0, time.UTC), time.Second)
+	advance := piFakeClock(a, piEpoch)
 
-	// Clock reads: agent_start 0s, agent_end 1s, agent_start 2s, agent_end 3s.
+	// One turn, two runs: the attempt takes 1s, the backoff 1s, the retry 1s.
 	handlePiOutput(a, parseLine([]byte(`{"type":"agent_start"}`)))
+	advance(time.Second)
 	handlePiOutput(a, parseLine([]byte(`{"type":"agent_end","messages":[],"willRetry":true}`)))
+	advance(time.Second)
 	handlePiOutput(a, parseLine([]byte(`{"type":"agent_start"}`)))
+	advance(time.Second)
 	handlePiOutput(a, parseLine([]byte(`{"type":"agent_end","messages":[]}`)))
 
 	assert.Equal(t, float64(1000), piPersistedAgentEnd(t, sink, 0)["duration_ms"],
@@ -377,10 +386,11 @@ func TestHandlePiOutput_AgentEnd_AugmentsWithLatestUsageSnapshot(t *testing.T) {
 	a := newPiAgentWithSink(sink)
 	a.model = "gpt-5.5"
 	a.availableModels = []*ModelInfo{{Id: "gpt-5.5", ContextWindow: 200000}}
-	piClockFrom(a, time.Date(2026, 9, 2, 10, 0, 0, 0, time.UTC), 750*time.Millisecond)
+	advance := piFakeClock(a, piEpoch)
 
 	handlePiOutput(a, parseLine([]byte(`{"type":"agent_start"}`)))
 	handlePiOutput(a, parseLine([]byte(`{"type":"message_end","message":{"role":"assistant","usage":{"input":100,"output":10,"cacheRead":20,"cacheWrite":5,"totalTokens":135,"cost":{"total":0.00033}}}}`)))
+	advance(750 * time.Millisecond)
 	handlePiOutput(a, parseLine([]byte(`{"type":"agent_end","messages":[]}`)))
 
 	msgs := sink.Messages()

--- a/backend/internal/worker/agent/pi_output_test.go
+++ b/backend/internal/worker/agent/pi_output_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/worker/bgtask"
@@ -61,9 +62,185 @@ func TestHandlePiOutput_AgentEnd_PersistsResultDividerAndResets(t *testing.T) {
 	assert.True(t, msg.TurnEnd, "agent_end must route through PersistTurnEnd")
 
 	assert.Equal(t, 1, sink.ResetSpanCount(), "agent_end should reset spans")
-	require.Equal(t, 1, sink.SessionInfoCount())
-	info := sink.LastSessionInfo()
-	assert.Equal(t, false, info["pi_turn_active"])
+	// agent_end broadcasts no session info of its own. The usage snapshot is
+	// empty here and the get_session_stats refresh needs a live stdin, so a
+	// count above zero would mean a key came back.
+	assert.Equal(t, 0, sink.SessionInfoCount())
+}
+
+// piClockFrom installs a clock that starts at a fixed instant and advances by
+// step on every read, so a test states the exact duration it expects.
+func piClockFrom(a *PiAgent, start time.Time, step time.Duration) {
+	reads := 0
+	a.nowFn = func() time.Time {
+		now := start.Add(time.Duration(reads) * step)
+		reads++
+		return now
+	}
+}
+
+// piPersistedAgentEnd decodes the nth persisted message as a JSON object.
+func piPersistedAgentEnd(t *testing.T, sink *recordingControlSink, index int) map[string]any {
+	t.Helper()
+	msgs := sink.Messages()
+	require.Greater(t, len(msgs), index)
+	var persisted map[string]any
+	require.NoError(t, json.Unmarshal(msgs[index].Content, &persisted))
+	return persisted
+}
+
+// agent_settled reports only that Pi will not continue on its own after the
+// agent_end that already drew the divider. It must leave no trace at all,
+// because the default arm of the dispatch would persist it as a raw-JSON row.
+func TestHandlePiOutput_AgentSettled_PersistsNothing(t *testing.T) {
+	t.Parallel()
+
+	sink := &recordingControlSink{}
+	a := newPiAgentWithSink(sink)
+
+	handlePiOutput(a, parseLine([]byte(`{"type":"agent_settled"}`)))
+
+	assert.Equal(t, 0, sink.MessageCount(), "agent_settled must not reach the transcript")
+	assert.Equal(t, 0, sink.NotificationCount())
+	assert.Equal(t, 0, len(sink.PersistedControls()))
+	assert.Equal(t, 0, sink.ResetSpanCount())
+	assert.Equal(t, 0, sink.SessionInfoCount())
+}
+
+func TestHandlePiOutput_AgentEnd_ReportsTurnDuration(t *testing.T) {
+	t.Parallel()
+
+	sink := &recordingControlSink{}
+	a := newPiAgentWithSink(sink)
+	base := time.Date(2026, 9, 2, 10, 0, 0, 0, time.UTC)
+	piClockFrom(a, base, 2500*time.Millisecond)
+
+	handlePiOutput(a, parseLine([]byte(`{"type":"agent_start"}`)))
+	handlePiOutput(a, parseLine([]byte(`{"type":"agent_end","messages":[]}`)))
+
+	assert.Equal(t, float64(2500), piPersistedAgentEnd(t, sink, 0)["duration_ms"])
+}
+
+// A zero-length turn is a real measurement, so it persists 0 rather than
+// dropping the field: the frontend draws "(0ms)" for it and nothing at all for
+// an absent field.
+func TestHandlePiOutput_AgentEnd_ZeroLengthTurnReportsZero(t *testing.T) {
+	t.Parallel()
+
+	sink := &recordingControlSink{}
+	a := newPiAgentWithSink(sink)
+	piClockFrom(a, time.Date(2026, 9, 2, 10, 0, 0, 0, time.UTC), 0)
+
+	handlePiOutput(a, parseLine([]byte(`{"type":"agent_start"}`)))
+	handlePiOutput(a, parseLine([]byte(`{"type":"agent_end","messages":[]}`)))
+
+	persisted := piPersistedAgentEnd(t, sink, 0)
+	require.Contains(t, persisted, "duration_ms")
+	assert.Equal(t, float64(0), persisted["duration_ms"])
+}
+
+// An agent_end this worker did not see start (a process it adopted mid-turn)
+// has nothing to measure from, so it must omit the field rather than claim 0.
+func TestHandlePiOutput_AgentEnd_WithoutStartOmitsDuration(t *testing.T) {
+	t.Parallel()
+
+	sink := &recordingControlSink{}
+	a := newPiAgentWithSink(sink)
+
+	handlePiOutput(a, parseLine([]byte(`{"type":"agent_end","messages":[]}`)))
+
+	assert.NotContains(t, piPersistedAgentEnd(t, sink, 0), "duration_ms")
+}
+
+// The mark is consumed by the agent_end that ends the turn, so a stray second
+// agent_end reports no duration instead of the time since the turn began.
+func TestHandlePiOutput_AgentEnd_SecondEndOmitsDuration(t *testing.T) {
+	t.Parallel()
+
+	sink := &recordingControlSink{}
+	a := newPiAgentWithSink(sink)
+	piClockFrom(a, time.Date(2026, 9, 2, 10, 0, 0, 0, time.UTC), time.Second)
+
+	handlePiOutput(a, parseLine([]byte(`{"type":"agent_start"}`)))
+	handlePiOutput(a, parseLine([]byte(`{"type":"agent_end","messages":[]}`)))
+	handlePiOutput(a, parseLine([]byte(`{"type":"agent_end","messages":[]}`)))
+
+	assert.Contains(t, piPersistedAgentEnd(t, sink, 0), "duration_ms")
+	assert.NotContains(t, piPersistedAgentEnd(t, sink, 1), "duration_ms")
+}
+
+// A retried run continues the same turn, so the final divider reports the whole
+// elapsed time rather than the last attempt alone.
+func TestHandlePiOutput_AgentEnd_RetryKeepsTurnStartMark(t *testing.T) {
+	t.Parallel()
+
+	sink := &recordingControlSink{}
+	a := newPiAgentWithSink(sink)
+	piClockFrom(a, time.Date(2026, 9, 2, 10, 0, 0, 0, time.UTC), time.Second)
+
+	// Clock reads: agent_start 0s, agent_end 1s, agent_start 2s, agent_end 3s.
+	handlePiOutput(a, parseLine([]byte(`{"type":"agent_start"}`)))
+	handlePiOutput(a, parseLine([]byte(`{"type":"agent_end","messages":[],"willRetry":true}`)))
+	handlePiOutput(a, parseLine([]byte(`{"type":"agent_start"}`)))
+	handlePiOutput(a, parseLine([]byte(`{"type":"agent_end","messages":[]}`)))
+
+	assert.Equal(t, float64(1000), piPersistedAgentEnd(t, sink, 0)["duration_ms"],
+		"the retried attempt reports the elapsed time so far")
+	assert.Equal(t, float64(3000), piPersistedAgentEnd(t, sink, 1)["duration_ms"],
+		"the final divider spans from the FIRST agent_start")
+}
+
+// A run Pi restarts itself is not a turn end: it must not fire the turn-end
+// event, which drives the completion sound and the off-screen tab's dot.
+func TestHandlePiOutput_AgentEnd_WillRetryDoesNotEndTurn(t *testing.T) {
+	t.Parallel()
+
+	sink := &recordingControlSink{}
+	a := newPiAgentWithSink(sink)
+	a.turnToolUses = 3
+	handlePiOutput(a, parseLine([]byte(`{"type":"agent_start"}`)))
+
+	handlePiOutput(a, parseLine([]byte(
+		`{"type":"agent_end","messages":[{"role":"assistant","stopReason":"error","errorMessage":"overloaded"}],"willRetry":true}`)))
+
+	require.Equal(t, 1, sink.MessageCount())
+	assert.False(t, sink.Messages()[0].TurnEnd, "a retried run must not route through PersistTurnEnd")
+
+	a.mu.Lock()
+	turnActive, toolUses := a.currentTurnActive, a.turnToolUses
+	a.mu.Unlock()
+	assert.True(t, turnActive, "the turn stays open so Interrupt and steering still work")
+	assert.Equal(t, 3, toolUses, "a retried run keeps the turn's tool-use count")
+}
+
+// Pi retries the WebSocket failure itself when it says willRetry, so LeapMux
+// must not schedule a second continuation for the same failure.
+func TestHandlePiOutput_AgentEnd_WillRetrySuppressesAutoContinue(t *testing.T) {
+	t.Parallel()
+
+	sink := &recordingControlSink{}
+	a := newPiAgentWithSink(sink)
+	raw := []byte(`{"type":"agent_end","messages":[{"role":"assistant","stopReason":"error","errorMessage":"WebSocket error"}],"willRetry":true}`)
+
+	handlePiOutput(a, parseLine(raw))
+
+	assert.Equal(t, 0, sink.AutoScheduleCount(), "Pi's own retry must not be doubled")
+	assert.Equal(t, 1, sink.AutoCancelCount())
+}
+
+func TestPiTurnDurationMs(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 9, 2, 10, 0, 0, 0, time.UTC)
+
+	assert.Nil(t, piTurnDurationMs(time.Time{}, base), "an unobserved start has nothing to measure")
+	assert.Nil(t, piTurnDurationMs(base, base.Add(-time.Second)), "a backwards clock reports nothing")
+
+	require.NotNil(t, piTurnDurationMs(base, base))
+	assert.Equal(t, int64(0), *piTurnDurationMs(base, base))
+
+	require.NotNil(t, piTurnDurationMs(base, base.Add(1500*time.Millisecond)))
+	assert.Equal(t, int64(1500), *piTurnDurationMs(base, base.Add(1500*time.Millisecond)))
 }
 
 func TestHandlePiOutput_MessageUpdate_TextDelta_StreamsChunk(t *testing.T) {
@@ -180,7 +357,9 @@ func TestHandlePiOutput_AgentEnd_AugmentsWithLatestUsageSnapshot(t *testing.T) {
 	a := newPiAgentWithSink(sink)
 	a.model = "gpt-5.5"
 	a.availableModels = []*ModelInfo{{Id: "gpt-5.5", ContextWindow: 200000}}
+	piClockFrom(a, time.Date(2026, 9, 2, 10, 0, 0, 0, time.UTC), 750*time.Millisecond)
 
+	handlePiOutput(a, parseLine([]byte(`{"type":"agent_start"}`)))
 	handlePiOutput(a, parseLine([]byte(`{"type":"message_end","message":{"role":"assistant","usage":{"input":100,"output":10,"cacheRead":20,"cacheWrite":5,"totalTokens":135,"cost":{"total":0.00033}}}}`)))
 	handlePiOutput(a, parseLine([]byte(`{"type":"agent_end","messages":[]}`)))
 
@@ -193,6 +372,8 @@ func TestHandlePiOutput_AgentEnd_AugmentsWithLatestUsageSnapshot(t *testing.T) {
 	require.NoError(t, json.Unmarshal(result.Content, &persisted))
 	assert.Equal(t, "agent_end", persisted["type"])
 	assert.Equal(t, 0.00033, persisted["total_cost_usd"])
+	assert.Equal(t, float64(750), persisted["duration_ms"],
+		"the duration rides the same envelope as the usage fields")
 	usage, ok := persisted["context_usage"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, float64(100), usage["input_tokens"])
@@ -252,8 +433,9 @@ func TestHandlePiOutput_AgentEnd_UnexpectedMessagesShapeCancelsAutoContinue(t *t
 
 	sink := &recordingControlSink{}
 	a := newPiAgentWithSink(sink)
-	// messages is a string instead of an array — the inner unmarshal in
-	// isRetryablePiAgentEndFailure fails, so we fall through to cancel.
+	// messages is a string instead of an array — the envelope unmarshal in
+	// handlePiAgentEnd fails, so isRetryableFailure sees no messages and we
+	// fall through to cancel.
 	raw := []byte(`{"type":"agent_end","messages":"unexpected"}`)
 
 	handlePiOutput(a, parseLine(raw))

--- a/backend/internal/worker/agent/pi_protocol_test.go
+++ b/backend/internal/worker/agent/pi_protocol_test.go
@@ -18,6 +18,7 @@ func TestPiProtocolEventConstants(t *testing.T) {
 	cases := map[string]string{
 		"agent_start":           contracts.PiEventAgentStart,
 		"agent_end":             contracts.PiEventAgentEnd,
+		"agent_settled":         contracts.PiEventAgentSettled,
 		"turn_start":            contracts.PiEventTurnStart,
 		"turn_end":              contracts.PiEventTurnEnd,
 		"message_start":         contracts.PiEventMessageStart,

--- a/backend/internal/worker/agent/pi_test.go
+++ b/backend/internal/worker/agent/pi_test.go
@@ -750,6 +750,7 @@ func TestPi_ClearContext_RoundtripsNewSessionAndGetState(t *testing.T) {
 	})
 
 	rig.agent.currentTurnActive = true
+	rig.agent.turnStartedAt = time.Now().Add(-time.Hour)
 	rig.agent.sessionCostUsd = 1.23
 	rig.agent.sessionCostKnown = true
 	rig.agent.latestContextUsage = map[string]any{"input_tokens": int64(100)}
@@ -768,6 +769,9 @@ func TestPi_ClearContext_RoundtripsNewSessionAndGetState(t *testing.T) {
 	defer rig.agent.mu.Unlock()
 	assert.Equal(t, "/tmp/pi-new.jsonl", rig.agent.sessionFile)
 	assert.False(t, rig.agent.currentTurnActive, "ClearContext clears the turn flag")
+	// agent_start only takes a mark when none is held, so a mark left behind by
+	// the replaced session would inflate the NEXT turn's reported duration.
+	assert.True(t, rig.agent.turnStartedAt.IsZero(), "ClearContext drops the turn's start mark")
 	assert.False(t, rig.agent.sessionCostKnown, "ClearContext resets Pi usage state")
 	assert.Equal(t, 0.0, rig.agent.sessionCostUsd)
 	assert.Nil(t, rig.agent.latestContextUsage)

--- a/backend/internal/worker/agent/pi_usage.go
+++ b/backend/internal/worker/agent/pi_usage.go
@@ -328,11 +328,12 @@ func (a *PiAgent) augmentPiMessageEnd(raw []byte) []byte {
 	return augmented
 }
 
-// persistPiAgentEnd writes the agent_end divider. A run that Pi will retry is
-// NOT a turn end: it persists as a plain agent message, so the divider still
-// draws while the turn-end event -- the completion sound and the off-screen
-// tab's notification dot -- and the git-status refresh wait for the run that
-// really ends the turn.
+// persistPiAgentEnd writes the agent_end divider.
+//
+// A run that Pi will retry is NOT a turn end. It persists as a plain agent
+// message, so the divider still draws. The turn-end event and the git-status
+// refresh then wait for the run that really ends the turn. That event drives
+// the completion sound and the off-screen tab's notification dot.
 func (a *PiAgent) persistPiAgentEnd(raw []byte, snap piUsageSnapshot, durationMs *int64, willRetry bool) {
 	augmented := piAugmentAgentEnd(raw, snap, durationMs)
 	var err error

--- a/backend/internal/worker/agent/pi_usage.go
+++ b/backend/internal/worker/agent/pi_usage.go
@@ -48,7 +48,7 @@ type piSessionStats struct {
 
 // piUsageSnapshot captures the cost/context-usage state to ship to a
 // single broadcast call. The snapshot is single-use: callers consume it
-// once via sessionInfo() (broadcast payload) or piAugmentRawWithSnapshot
+// once via sessionInfo() (broadcast payload) or piAugmentAgentEnd
 // (persisted envelope) and drop it. The ContextUsage map is owned by
 // the snapshot — sessionInfo() and mutatePiUsageFields hand the map
 // directly to the consuming payload, so callers must not mutate it

--- a/backend/internal/worker/agent/pi_usage.go
+++ b/backend/internal/worker/agent/pi_usage.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/leapmux/leapmux/generated/contracts"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 )
 
 const piSessionStatsMaxWait = 2 * time.Second
@@ -67,7 +69,7 @@ func piSessionStatsTimeout(base time.Duration) time.Duration {
 
 // mutatePiUsageFields injects the broadcast-shaped usage fields into an
 // already-decoded Pi envelope. Both augmentPiMessageEnd and
-// piAugmentRawWithSnapshot funnel through this helper so the field set
+// piAugmentAgentEnd funnel through this helper so the field set
 // stays consistent across the message_end and agent_end persistence
 // paths. The injected keys are snake_case to match the rest of the
 // platform's session-info wire format (Claude/ACP/Pi all emit
@@ -137,12 +139,16 @@ func piSnapshotFromStats(stats piSessionStats) piUsageSnapshot {
 	return snap
 }
 
-// piAugmentRawWithSnapshot decodes raw, injects the broadcast-shaped
-// usage fields via mutatePiUsageFields, and re-marshals. Used by
-// persistPiAgentEnd; augmentPiMessageEnd inlines the same flow because
-// it needs to read `message.usage` from the same decoded map.
-func piAugmentRawWithSnapshot(raw []byte, snap piUsageSnapshot) []byte {
-	if !snap.HasTotalCost && len(snap.ContextUsage) == 0 {
+// piAugmentAgentEnd decodes an agent_end envelope, injects the
+// broadcast-shaped usage fields via mutatePiUsageFields plus the measured
+// turn duration, and re-marshals. augmentPiMessageEnd inlines the same
+// flow because it needs to read `message.usage` from the same decoded map.
+//
+// A nil durationMs injects nothing. Pi's agent_end carries no duration, so
+// an unmeasured turn must stay silent rather than claim a 0 ms turn -- the
+// frontend draws no time for an absent field and "(0ms)" for a real zero.
+func piAugmentAgentEnd(raw []byte, snap piUsageSnapshot, durationMs *int64) []byte {
+	if !snap.HasTotalCost && len(snap.ContextUsage) == 0 && durationMs == nil {
 		return raw
 	}
 	var obj map[string]any
@@ -150,6 +156,11 @@ func piAugmentRawWithSnapshot(raw []byte, snap piUsageSnapshot) []byte {
 		return raw
 	}
 	mutatePiUsageFields(obj, snap)
+	if durationMs != nil {
+		// The same field name Claude Code emits on its own `result` envelope,
+		// so one frontend read serves both providers.
+		obj["duration_ms"] = *durationMs
+	}
 	augmented, err := json.Marshal(obj)
 	if err != nil {
 		return raw
@@ -317,9 +328,20 @@ func (a *PiAgent) augmentPiMessageEnd(raw []byte) []byte {
 	return augmented
 }
 
-func (a *PiAgent) persistPiAgentEnd(raw []byte, snap piUsageSnapshot) {
-	augmented := piAugmentRawWithSnapshot(raw, snap)
-	if err := a.sink.PersistTurnEnd(augmented, SpanInfo{}); err != nil {
+// persistPiAgentEnd writes the agent_end divider. A run that Pi will retry is
+// NOT a turn end: it persists as a plain agent message, so the divider still
+// draws while the turn-end event -- the completion sound and the off-screen
+// tab's notification dot -- and the git-status refresh wait for the run that
+// really ends the turn.
+func (a *PiAgent) persistPiAgentEnd(raw []byte, snap piUsageSnapshot, durationMs *int64, willRetry bool) {
+	augmented := piAugmentAgentEnd(raw, snap, durationMs)
+	var err error
+	if willRetry {
+		err = a.sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, augmented, SpanInfo{})
+	} else {
+		err = a.sink.PersistTurnEnd(augmented, SpanInfo{})
+	}
+	if err != nil {
 		slog.Error("pi persist agent_end", "agent_id", a.agentID, "error", err)
 	}
 }

--- a/backend/internal/worker/agent/pi_usage_bench_test.go
+++ b/backend/internal/worker/agent/pi_usage_bench_test.go
@@ -76,10 +76,11 @@ func BenchmarkPersistPiAgentEnd(b *testing.B) {
 			"context_window":              int64(200000),
 		},
 	}
+	durationMs := int64(1234)
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		_ = piAugmentRawWithSnapshot(piAgentEndBenchPayload, snap)
+		_ = piAugmentAgentEnd(piAgentEndBenchPayload, snap, &durationMs)
 	}
 }
 

--- a/backend/internal/worker/agent/pi_usage_test.go
+++ b/backend/internal/worker/agent/pi_usage_test.go
@@ -79,21 +79,36 @@ func TestAugmentPiMessageEnd_TotalsAreCumulative(t *testing.T) {
 	assert.InDelta(t, 0.75, p2["total_cost_usd"], 1e-9, "total_cost_usd must be cumulative across message_ends")
 }
 
-// TestPiAugmentRawWithSnapshot_NoOpWhenSnapshotEmpty exercises the
-// fast-path: when the snapshot has no cost and no contextUsage, the
-// helper returns raw without re-marshalling.
-func TestPiAugmentRawWithSnapshot_NoOpWhenSnapshotEmpty(t *testing.T) {
+// TestPiAugmentAgentEnd_NoOpWhenNothingToInject exercises the fast-path:
+// with no cost, no contextUsage and no measured duration, the helper
+// returns raw without re-marshalling.
+func TestPiAugmentAgentEnd_NoOpWhenNothingToInject(t *testing.T) {
 	t.Parallel()
 
 	raw := []byte(`{"type":"agent_end","messages":[]}`)
-	out := piAugmentRawWithSnapshot(raw, piUsageSnapshot{})
+	out := piAugmentAgentEnd(raw, piUsageSnapshot{}, nil)
 	assert.Equal(t, string(raw), string(out))
 }
 
-// TestPiAugmentRawWithSnapshot_InjectsBothFields covers the persist path
-// for agent_end. Persisted shape uses snake_case (`total_cost_usd`,
-// `context_usage`) to match the broadcast wire format.
-func TestPiAugmentRawWithSnapshot_InjectsBothFields(t *testing.T) {
+// A measured duration alone is enough to enter the injection path, even
+// when the usage snapshot is empty.
+func TestPiAugmentAgentEnd_InjectsDurationWithEmptySnapshot(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`{"type":"agent_end","messages":[]}`)
+	durationMs := int64(0)
+	out := piAugmentAgentEnd(raw, piUsageSnapshot{}, &durationMs)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(out, &got))
+	assert.Equal(t, float64(0), got["duration_ms"], "a real zero must survive as a zero")
+	assert.NotContains(t, got, "total_cost_usd")
+}
+
+// TestPiAugmentAgentEnd_InjectsEveryField covers the persist path for
+// agent_end. Persisted shape uses snake_case (`total_cost_usd`,
+// `context_usage`, `duration_ms`) to match the broadcast wire format.
+func TestPiAugmentAgentEnd_InjectsEveryField(t *testing.T) {
 	t.Parallel()
 
 	raw := []byte(`{"type":"agent_end","messages":[]}`)
@@ -102,26 +117,28 @@ func TestPiAugmentRawWithSnapshot_InjectsBothFields(t *testing.T) {
 		TotalCostUsd: 0.42,
 		ContextUsage: map[string]any{"input_tokens": int64(100)},
 	}
-	out := piAugmentRawWithSnapshot(raw, snap)
+	durationMs := int64(2500)
+	out := piAugmentAgentEnd(raw, snap, &durationMs)
 
 	var got map[string]any
 	require.NoError(t, json.Unmarshal(out, &got))
 	assert.Equal(t, "agent_end", got["type"])
 	assert.InDelta(t, 0.42, got["total_cost_usd"], 1e-9)
+	assert.Equal(t, float64(2500), got["duration_ms"])
 	usage, ok := got["context_usage"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, float64(100), usage["input_tokens"])
 }
 
-// TestPiAugmentRawWithSnapshot_MalformedJSONReturnsRawUnchanged: the
-// helper does not panic and returns raw unchanged when the input is not
-// valid JSON.
-func TestPiAugmentRawWithSnapshot_MalformedJSONReturnsRawUnchanged(t *testing.T) {
+// TestPiAugmentAgentEnd_MalformedJSONReturnsRawUnchanged: the helper does
+// not panic and returns raw unchanged when the input is not valid JSON.
+func TestPiAugmentAgentEnd_MalformedJSONReturnsRawUnchanged(t *testing.T) {
 	t.Parallel()
 
 	raw := []byte(`not json`)
 	snap := piUsageSnapshot{HasTotalCost: true, TotalCostUsd: 1}
-	out := piAugmentRawWithSnapshot(raw, snap)
+	durationMs := int64(10)
+	out := piAugmentAgentEnd(raw, snap, &durationMs)
 	assert.Equal(t, string(raw), string(out))
 }
 

--- a/contracts/pi-protocol.json
+++ b/contracts/pi-protocol.json
@@ -3,6 +3,7 @@
   "events": {
     "AgentStart": "agent_start",
     "AgentEnd": "agent_end",
+    "AgentSettled": "agent_settled",
     "TurnStart": "turn_start",
     "TurnEnd": "turn_end",
     "MessageStart": "message_start",

--- a/frontend/src/components/chat/providers/pi/plugin.test.ts
+++ b/frontend/src/components/chat/providers/pi/plugin.test.ts
@@ -47,7 +47,9 @@ describe('pi classify', () => {
   })
 
   it('hides lifecycle markers without chat UI', () => {
-    for (const t of ['agent_start', 'turn_start', 'turn_end', 'message_start', 'tool_execution_update']) {
+    // agent_settled says only that Pi will not continue on its own after the
+    // agent_end that already drew the divider, so it has nothing to render.
+    for (const t of ['agent_start', 'agent_settled', 'turn_start', 'turn_end', 'message_start', 'tool_execution_update']) {
       expect(plugin.classify(input({ type: t }))).toEqual({ kind: 'hidden' })
     }
   })
@@ -58,21 +60,87 @@ describe('pi classify', () => {
 
   it('maps agent_end (stop) to a "Turn ended" divider model', () => {
     expect(plugin.resultDivider!({ type: 'agent_end', messages: [{ role: 'assistant', stopReason: 'stop' }] }))
-      .toEqual({ label: 'Turn ended' })
+      .toEqual({ label: 'Turn ended', turnContinues: false })
   })
 
   it('maps an aborted stopReason to a danger "Turn aborted" model', () => {
     expect(plugin.resultDivider!({ type: 'agent_end', messages: [{ role: 'assistant', stopReason: 'aborted' }] }))
-      .toEqual({ label: 'Turn aborted', isError: true })
+      .toEqual({ label: 'Turn aborted', isError: true, turnContinues: false })
   })
 
   it('maps an error stopReason to a danger "Turn failed — <msg>" model', () => {
     expect(plugin.resultDivider!({ type: 'agent_end', messages: [{ role: 'assistant', stopReason: 'error', errorMessage: 'rate limit' }] }))
-      .toEqual({ label: 'Turn failed — rate limit', isError: true })
+      .toEqual({ label: 'Turn failed — rate limit', isError: true, turnContinues: false })
   })
 
   it('returns null when the message is not agent_end', () => {
     expect(plugin.resultDivider!({ type: 'message_end' })).toBeNull()
+  })
+
+  describe('turn duration on the divider', () => {
+    // Pi's own agent_end carries no duration; the worker measures the turn and
+    // injects duration_ms under the same name Claude Code emits.
+    const ended = (extra: Record<string, unknown>, stopReason = 'stop'): string =>
+      plugin.resultDivider!({
+        type: 'agent_end',
+        messages: [{ role: 'assistant', stopReason, errorMessage: 'WebSocket error' }],
+        ...extra,
+      })!.label
+
+    it('appends the formatted duration to a completed turn', () => {
+      expect(ended({ duration_ms: 3200 })).toBe('Turn ended (3.2s)')
+    })
+
+    it('keeps the plain label when the worker measured nothing', () => {
+      expect(ended({})).toBe('Turn ended')
+    })
+
+    it('shows a real zero rather than dropping the suffix', () => {
+      expect(ended({ duration_ms: 0 })).toBe('Turn ended (0ms)')
+    })
+
+    it('ignores a non-numeric duration_ms', () => {
+      expect(ended({ duration_ms: 'soon' })).toBe('Turn ended')
+    })
+
+    it('appends the duration to the length-limit label', () => {
+      expect(ended({ duration_ms: 3200 }, 'length')).toBe('Turn ended (length limit) (3.2s)')
+    })
+
+    it('appends the duration to an aborted turn', () => {
+      expect(ended({ duration_ms: 45_000 }, 'aborted')).toBe('Turn aborted (45s)')
+    })
+
+    it('appends the duration after the error message', () => {
+      expect(ended({ duration_ms: 1500 }, 'error')).toBe('Turn failed — WebSocket error (1.5s)')
+    })
+  })
+
+  describe('a run Pi will retry', () => {
+    const retrying = plugin.resultDivider!({
+      type: 'agent_end',
+      willRetry: true,
+      duration_ms: 2100,
+      messages: [{ role: 'assistant', stopReason: 'error', errorMessage: 'overloaded' }],
+    })!
+
+    it('marks the divider auto-retry after the duration', () => {
+      expect(retrying.label).toBe('Turn failed — overloaded (2.1s) · auto-retry')
+    })
+
+    it('reports that the turn continues, so the thinking indicator stays up', () => {
+      expect(retrying.turnContinues).toBe(true)
+    })
+
+    it('adds no meta part when Pi does not retry', () => {
+      const model = plugin.resultDivider!({
+        type: 'agent_end',
+        duration_ms: 2100,
+        messages: [{ role: 'assistant', stopReason: 'error', errorMessage: 'overloaded' }],
+      })!
+      expect(model.label).toBe('Turn failed — overloaded (2.1s)')
+      expect(model.turnContinues).toBe(false)
+    })
   })
 
   it('renders a danger divider through the shared renderer end-to-end', () => {

--- a/frontend/src/components/chat/providers/pi/plugin.tsx
+++ b/frontend/src/components/chat/providers/pi/plugin.tsx
@@ -44,9 +44,17 @@ import {
   PiToolResultRenderer,
 } from './renderers'
 
-/** Pi event types that carry no UI surface (lifecycle markers / fan-out). */
+/**
+ * Pi event types that carry no UI surface (lifecycle markers / fan-out).
+ *
+ * `agent_settled` is one of them: it says only that Pi will not continue on its
+ * own after the `agent_end` that already drew the divider. The worker drops it
+ * before persisting, so this rule is what hides the rows a build before that
+ * change already wrote.
+ */
 const PI_HIDDEN_EVENT_TYPES = new Set<string>([
   PI_EVENT.AgentStart,
+  PI_EVENT.AgentSettled,
   PI_EVENT.TurnStart,
   PI_EVENT.TurnEnd,
   PI_EVENT.MessageStart,

--- a/frontend/src/components/chat/providers/pi/plugin.tsx
+++ b/frontend/src/components/chat/providers/pi/plugin.tsx
@@ -48,9 +48,9 @@ import {
  * Pi event types that carry no UI surface (lifecycle markers / fan-out).
  *
  * `agent_settled` is one of them: it says only that Pi will not continue on its
- * own after the `agent_end` that already drew the divider. The worker drops it
- * before persisting, so this rule is what hides the rows a build before that
- * change already wrote.
+ * own after the `agent_end` that already drew the divider. The worker now drops
+ * it before it persists anything, so this rule hides only the rows an earlier
+ * build already wrote.
  */
 const PI_HIDDEN_EVENT_TYPES = new Set<string>([
   PI_EVENT.AgentStart,

--- a/frontend/src/components/chat/providers/pi/renderers/resultDivider.tsx
+++ b/frontend/src/components/chat/providers/pi/renderers/resultDivider.tsx
@@ -1,6 +1,7 @@
 import type { ResultDividerModel } from '../../registry'
 import { PI_EVENT } from '~/generated/contracts/pi-protocol'
-import { isObject, pickString } from '~/lib/jsonPick'
+import { isObject, pickBool, pickNumber, pickString } from '~/lib/jsonPick'
+import { formatDuration, joinMetaParts } from '../../../rendererUtils'
 
 function lastAssistantMessage(messages: unknown): Record<string, unknown> | null {
   if (!Array.isArray(messages))
@@ -16,6 +17,16 @@ function lastAssistantMessage(messages: unknown): Record<string, unknown> | null
 /**
  * Pi `agent_end` → result_divider model, read from the last assistant message's
  * `stopReason`/`errorMessage`. Null when the message isn't an `agent_end`.
+ *
+ * Pi's envelope carries no duration of its own, so the worker measures the turn
+ * and injects `duration_ms` — the same field name Claude Code emits, read the
+ * same way. `pickNumber` returns null for an absent field, which is what tells
+ * an unmeasured turn (no time shown) from a real zero ("(0ms)").
+ *
+ * `willRetry` is Pi's statement that it restarts this run itself. The divider
+ * still draws, marked `auto-retry`, and `turnContinues` keeps the thinking
+ * indicator up for the backoff. "auto-retry" is the term the Pi notification
+ * renderer already uses for the `auto_retry_start` line that follows.
  */
 export function piResultDivider(parsed: unknown): ResultDividerModel | null {
   if (!isObject(parsed) || pickString(parsed, 'type') !== PI_EVENT.AgentEnd)
@@ -25,11 +36,22 @@ export function piResultDivider(parsed: unknown): ResultDividerModel | null {
   const stopReason = assistant ? pickString(assistant, 'stopReason') : ''
   const errorMessage = assistant ? pickString(assistant, 'errorMessage') : ''
 
-  if (stopReason === 'error')
-    return { label: errorMessage ? `Turn failed — ${errorMessage}` : 'Turn failed', isError: true }
+  const durationMs = pickNumber(parsed, 'duration_ms')
+  const suffix = durationMs !== null ? ` (${formatDuration(durationMs)})` : ''
+  const turnContinues = pickBool(parsed, 'willRetry')
+  const label = (base: string): string =>
+    joinMetaParts([base + suffix, turnContinues && 'auto-retry'])
+
+  if (stopReason === 'error') {
+    return {
+      label: label(errorMessage ? `Turn failed — ${errorMessage}` : 'Turn failed'),
+      isError: true,
+      turnContinues,
+    }
+  }
   if (stopReason === 'aborted')
-    return { label: 'Turn aborted', isError: true }
+    return { label: label('Turn aborted'), isError: true, turnContinues }
   if (stopReason === 'length')
-    return { label: 'Turn ended (length limit)' }
-  return { label: 'Turn ended' }
+    return { label: label('Turn ended (length limit)'), turnContinues }
+  return { label: label('Turn ended'), turnContinues }
 }

--- a/frontend/src/components/chat/providers/registry.ts
+++ b/frontend/src/components/chat/providers/registry.ts
@@ -140,6 +140,13 @@ export interface ResultDividerModel {
   isError?: boolean
   /** Optional multi-line detail block shown below the label. Omit (undefined), never empty. */
   detail?: string
+  /**
+   * The run failed but the provider restarts it on its own, so the turn is NOT
+   * over. `isAgentWorking` reads this, which is why the thinking indicator
+   * stays up for the length of an auto-retry backoff instead of going dark on
+   * a divider the turn continues past.
+   */
+  turnContinues?: boolean
 }
 
 /**

--- a/frontend/src/components/chat/providers/registry.ts
+++ b/frontend/src/components/chat/providers/registry.ts
@@ -142,9 +142,9 @@ export interface ResultDividerModel {
   detail?: string
   /**
    * The run failed but the provider restarts it on its own, so the turn is NOT
-   * over. `isAgentWorking` reads this, which is why the thinking indicator
-   * stays up for the length of an auto-retry backoff instead of going dark on
-   * a divider the turn continues past.
+   * over. `isAgentWorking` reads this. The thinking indicator therefore stays
+   * visible for the whole auto-retry backoff, instead of clearing on a divider
+   * that the turn continues past.
    */
   turnContinues?: boolean
 }

--- a/frontend/src/components/chat/rendererUtils.test.ts
+++ b/frontend/src/components/chat/rendererUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { formatCompactNumber, formatTokenCount, joinMetaParts } from './rendererUtils'
+import { formatCompactNumber, formatDuration, formatTokenCount, joinMetaParts } from './rendererUtils'
 
 describe('formatCompactNumber', () => {
   it('numbers below 1000 are returned as-is', () => {
@@ -130,5 +130,35 @@ describe('joinMetaParts', () => {
   it('returns an empty string when nothing is truthy', () => {
     expect(joinMetaParts([])).toBe('')
     expect(joinMetaParts([false, null, undefined, ''])).toBe('')
+  })
+})
+
+describe('formatDuration', () => {
+  it('sub-second values are whole milliseconds', () => {
+    expect(formatDuration(0)).toBe('0ms')
+    expect(formatDuration(865)).toBe('865ms')
+    expect(formatDuration(999)).toBe('999ms')
+  })
+
+  it('under ten seconds carries one decimal', () => {
+    expect(formatDuration(1000)).toBe('1.0s')
+    expect(formatDuration(3200)).toBe('3.2s')
+    // toFixed rounds half away from zero, so 3.25s reads "3.3s".
+    expect(formatDuration(3250)).toBe('3.3s')
+    // 9.999s stays on the decimal branch and rounds up, so the boundary below
+    // ten seconds reads "10.0s" while a real 10000ms reads "10s".
+    expect(formatDuration(9999)).toBe('10.0s')
+  })
+
+  it('ten seconds and above compose whole units', () => {
+    expect(formatDuration(10_000)).toBe('10s')
+    expect(formatDuration(65_000)).toBe('1m 5s')
+    expect(formatDuration(3_600_000)).toBe('1h')
+    expect(formatDuration(90_061_000)).toBe('1d 1h 1m 1s')
+  })
+
+  it('rounds a fractional millisecond count', () => {
+    expect(formatDuration(0.4)).toBe('0ms')
+    expect(formatDuration(999.6)).toBe('1000ms')
   })
 })

--- a/frontend/src/utils/agentState.test.ts
+++ b/frontend/src/utils/agentState.test.ts
@@ -110,6 +110,44 @@ describe('isAgentWorking', () => {
     ])).toBe(false)
   })
 
+  describe('a Pi transcript', () => {
+    const pi = (content: Uint8Array) =>
+      makeMessage({ source: MessageSource.AGENT, content, agentProvider: AgentProvider.PI })
+    const agentEnd = (extra: Record<string, unknown> = {}) =>
+      pi(rawContent({ type: 'agent_end', messages: [{ role: 'assistant', stopReason: 'stop' }], ...extra }))
+
+    it('skips a trailing hidden row and stops at the divider before it', () => {
+      // A build before the worker dropped agent_settled persisted it as a row.
+      // It classifies `hidden`, draws nothing, and must not report "working".
+      expect(isAgentWorking([
+        makeMsg(MessageSource.USER),
+        agentEnd(),
+        pi(rawContent({ type: 'agent_settled' })),
+      ])).toBe(false)
+    })
+
+    it('still reports working for a visible assistant reply', () => {
+      expect(isAgentWorking([
+        makeMsg(MessageSource.USER),
+        pi(rawContent({ type: 'message_end', message: { role: 'assistant', content: [{ type: 'text', text: 'hi' }] } })),
+      ])).toBe(true)
+    })
+
+    it('keeps working through a divider for a run Pi will retry', () => {
+      expect(isAgentWorking([
+        makeMsg(MessageSource.USER),
+        agentEnd({ willRetry: true, messages: [{ role: 'assistant', stopReason: 'error', errorMessage: 'overloaded' }] }),
+      ])).toBe(true)
+    })
+
+    it('stops at the divider once Pi will not retry', () => {
+      expect(isAgentWorking([
+        makeMsg(MessageSource.USER),
+        agentEnd({ messages: [{ role: 'assistant', stopReason: 'error', errorMessage: 'overloaded' }] }),
+      ])).toBe(false)
+    })
+  })
+
   it('skips USER message with deliveryError (agent never received it)', () => {
     expect(isAgentWorking([
       makeMsg(MessageSource.AGENT, rawContent({ type: 'result', subtype: 'turn_result' })),
@@ -201,13 +239,21 @@ describe('isAgentWorking', () => {
     ])).toBe(true)
   })
 
-  it('does NOT skip Claude system init (other system subtype is real progress)', () => {
-    // A bare assistant followed by a system init only — system init isn't a
-    // notification subtype, so it counts as progress and the agent appears
-    // to be working. Sanity check that the subtype filter isn't too broad.
+  it('does NOT skip a visible system subtype (real progress)', () => {
+    // A system subtype that is neither hidden nor status/api_retry renders as a
+    // notification and counts as progress. Sanity check that the subtype filter
+    // is not too broad.
+    expect(isAgentWorking([
+      makeMsg(MessageSource.AGENT, rawContent({ type: 'system', subtype: 'compact_boundary' })),
+    ])).toBe(true)
+  })
+
+  it('skips Claude system init, which the transcript hides', () => {
+    // `init` is in Claude's HIDDEN_SYSTEM_SUBTYPES, so the row draws nothing.
+    // A transcript holding only folded-away rows shows no work in progress.
     expect(isAgentWorking([
       makeMsg(MessageSource.AGENT, rawContent({ type: 'system', subtype: 'init', cwd: '/x' })),
-    ])).toBe(true)
+    ])).toBe(false)
   })
 
   it('treats AGENT-source wrapper containing context_cleared as turn boundary', () => {

--- a/frontend/src/utils/agentState.test.ts
+++ b/frontend/src/utils/agentState.test.ts
@@ -253,8 +253,8 @@ describe('isAgentWorking', () => {
 
   it('does NOT skip a visible system subtype (real progress)', () => {
     // A system subtype that is neither hidden nor status/api_retry renders as a
-    // notification and counts as progress. Sanity check that the subtype filter
-    // is not too broad.
+    // notification and counts as progress. This confirms that the subtype
+    // filter is not too broad.
     expect(isAgentWorking([
       makeMsg(MessageSource.AGENT, rawContent({ type: 'system', subtype: 'compact_boundary' })),
     ])).toBe(true)
@@ -397,9 +397,9 @@ describe('shouldShowThinkingIndicator', () => {
     )).toBe(true)
   })
 
-  // The user-visible end of the Pi auto-retry rule: during the backoff nothing
-  // streams and the registry knows nothing, so the divider's own `turnContinues`
-  // is the only thing keeping the indicator lit.
+  // The user-visible end of the Pi auto-retry rule. During the backoff nothing
+  // streams and the registry knows nothing about the tab. The divider's own
+  // `turnContinues` is therefore the only thing that keeps the indicator up.
   it('keeps the indicator lit for a Pi divider Pi will retry past', () => {
     const retrying = makeMessage({
       source: MessageSource.AGENT,

--- a/frontend/src/utils/agentState.test.ts
+++ b/frontend/src/utils/agentState.test.ts
@@ -133,17 +133,29 @@ describe('isAgentWorking', () => {
       ])).toBe(true)
     })
 
+    // willRetry is the only difference between these two: a divider Pi will
+    // retry past must keep the thinking indicator up for the whole backoff,
+    // where nothing streams and no other row arrives.
+    const failed = [{ role: 'assistant', stopReason: 'error', errorMessage: 'overloaded' }]
+
     it('keeps working through a divider for a run Pi will retry', () => {
       expect(isAgentWorking([
         makeMsg(MessageSource.USER),
-        agentEnd({ willRetry: true, messages: [{ role: 'assistant', stopReason: 'error', errorMessage: 'overloaded' }] }),
+        agentEnd({ willRetry: true, messages: failed }),
       ])).toBe(true)
     })
 
     it('stops at the divider once Pi will not retry', () => {
       expect(isAgentWorking([
         makeMsg(MessageSource.USER),
-        agentEnd({ messages: [{ role: 'assistant', stopReason: 'error', errorMessage: 'overloaded' }] }),
+        agentEnd({ willRetry: false, messages: failed }),
+      ])).toBe(false)
+    })
+
+    it('stops at the divider when Pi omits willRetry (an older build)', () => {
+      expect(isAgentWorking([
+        makeMsg(MessageSource.USER),
+        agentEnd({ messages: failed }),
       ])).toBe(false)
     })
   })
@@ -383,6 +395,45 @@ describe('shouldShowThinkingIndicator', () => {
       [makeMsg(MessageSource.USER)],
       '',
     )).toBe(true)
+  })
+
+  // The user-visible end of the Pi auto-retry rule: during the backoff nothing
+  // streams and the registry knows nothing, so the divider's own `turnContinues`
+  // is the only thing keeping the indicator lit.
+  it('keeps the indicator lit for a Pi divider Pi will retry past', () => {
+    const retrying = makeMessage({
+      source: MessageSource.AGENT,
+      content: rawContent({
+        type: 'agent_end',
+        willRetry: true,
+        messages: [{ role: 'assistant', stopReason: 'error', errorMessage: 'overloaded' }],
+      }),
+      agentProvider: AgentProvider.PI,
+    })
+    expect(shouldShowThinkingIndicator(
+      makeAgent({ agentProvider: AgentProvider.PI }),
+      {},
+      [makeMsg(MessageSource.USER), retrying],
+      '',
+    )).toBe(true)
+  })
+
+  it('clears the indicator once a Pi turn really ends', () => {
+    const ended = makeMessage({
+      source: MessageSource.AGENT,
+      content: rawContent({
+        type: 'agent_end',
+        willRetry: false,
+        messages: [{ role: 'assistant', stopReason: 'stop' }],
+      }),
+      agentProvider: AgentProvider.PI,
+    })
+    expect(shouldShowThinkingIndicator(
+      makeAgent({ agentProvider: AgentProvider.PI }),
+      {},
+      [makeMsg(MessageSource.USER), ended],
+      '',
+    )).toBe(false)
   })
 
   it('forces visible when this tab has active work, even with no streaming text', () => {

--- a/frontend/src/utils/agentState.ts
+++ b/frontend/src/utils/agentState.ts
@@ -128,6 +128,11 @@ function containsContextCleared(parsed: ParsedMessageContent): boolean {
  * provider's plugin, which classifies its closing envelope (Claude
  * `type:"result"`, Codex `turn/completed`, ACP `stopReason`, Pi `agent_end`)
  * as `result_divider`.
+ *
+ * A divider does not always end the turn. The plugin's `resultDivider` model
+ * reports `turnContinues` for a run the provider restarts on its own -- Pi
+ * draws one for an attempt it is about to auto-retry -- and this reports the
+ * agent still working for the length of that backoff.
  */
 export function isAgentWorking(msgs: AgentChatMessage[]): boolean {
   for (let i = msgs.length - 1; i >= 0; i--) {
@@ -176,10 +181,11 @@ export function isAgentWorking(msgs: AgentChatMessage[]): boolean {
     // restarted with a fresh context and is now idle — stop scanning.
     if (containsContextCleared(parsed))
       return false
-    // Empty notification wrappers are what the consolidator emits when
-    // every threaded message has been superseded — no progress signal.
-    if (parsed.wrapper && parsed.wrapper.messages.length === 0)
-      continue
+    // (An empty notification wrapper -- what the consolidator emits once every
+    // threaded message is superseded -- needs no branch of its own: every
+    // provider plugin classifies it `hidden`, so the skip above already took
+    // it. The tests below still pin that a transcript of them reports idle.)
+    //
     // Platform notifications, agent metadata, and provider lifecycle
     // events never indicate active work — keep scanning back.
     if (isNonProgressInner(getInnerMessage(parsed)))

--- a/frontend/src/utils/agentState.ts
+++ b/frontend/src/utils/agentState.ts
@@ -138,13 +138,27 @@ export function isAgentWorking(msgs: AgentChatMessage[]): boolean {
 
     const parsed = parseMessageContent(msg)
     const category = classifyAgentMessage(msg)
-    // A turn-end divider means the agent finished. An `unsupported_provider`
-    // message is one we cannot interpret at all (no registered plugin) -- it
-    // carries no signal that the agent is working, and treating it as progress
-    // would pin the thinking indicator on a misconfigured / version-skewed agent
-    // forever, so it likewise stops the scan as "not working".
-    if (category.kind === 'result_divider' || category.kind === 'unsupported_provider')
+    // An `unsupported_provider` message is one we cannot interpret at all (no
+    // registered plugin) -- it carries no signal that the agent is working, and
+    // treating it as progress would pin the thinking indicator on a
+    // misconfigured / version-skewed agent forever, so it stops the scan as
+    // "not working".
+    if (category.kind === 'unsupported_provider')
       return false
+    // A turn-end divider means the agent finished -- unless the provider says
+    // it restarts the run itself. Pi draws a divider for a failed attempt it is
+    // about to auto-retry, and the indicator must stay up for the whole
+    // backoff, where nothing streams and no other row arrives.
+    if (category.kind === 'result_divider') {
+      const model = pluginFor(msg.agentProvider)?.resultDivider?.(parsed.parentObject)
+      return model?.turnContinues === true
+    }
+    // A hidden row draws nothing, so it is no evidence either way. Keep
+    // scanning back for the last row that does draw. Stopping here reported
+    // "working" forever on a transcript whose last row the UI folds away --
+    // a Pi `agent_settled` persisted by a build before the worker dropped it.
+    if (category.kind === 'hidden')
+      continue
     // The subagent-end divider closes one subagent RUN: the worker writes one
     // each time that subagent's registry row reaches a final status.
     // `subagent_ended` is not a non-progress type, so without this guard the

--- a/frontend/tests/e2e/132-pi-agent-lifecycle.spec.ts
+++ b/frontend/tests/e2e/132-pi-agent-lifecycle.spec.ts
@@ -44,7 +44,13 @@ piTest.describe('Pi Agent Lifecycle', () => {
 
     // Pi emits agent_settled after agent_end. The worker drops it, so it must
     // never surface as a raw-JSON bubble.
-    const allText = (await messageContents(page).allTextContents()).join(' ')
+    //
+    // Count the rows first. An absence assertion over an empty locator passes
+    // for the wrong reason, so this fails loudly if the message list is ever
+    // renamed out from under the helper.
+    const contents = messageContents(page)
+    expect(await contents.count()).toBeGreaterThan(0)
+    const allText = (await contents.allTextContents()).join(' ')
     expect(allText).not.toContain('agent_settled')
   })
 

--- a/frontend/tests/e2e/132-pi-agent-lifecycle.spec.ts
+++ b/frontend/tests/e2e/132-pi-agent-lifecycle.spec.ts
@@ -1,4 +1,4 @@
-import { isMaybeVisible, messageContents, sendMessage, waitForAgentIdle } from './helpers/ui'
+import { ARITHMETIC_PROMPT, isMaybeVisible, messageContents, sendMessage, waitForAgentIdle } from './helpers/ui'
 import { expect, PI_E2E_SKIP_REASON, piTest } from './pi-fixtures'
 
 piTest.skip(!!PI_E2E_SKIP_REASON, PI_E2E_SKIP_REASON || '')
@@ -16,7 +16,9 @@ piTest.describe('Pi Agent Lifecycle', () => {
     const tabsBefore = await tabs.count()
     expect(tabsBefore).toBeGreaterThan(0)
 
-    const closeBtn = page.locator('[data-testid="tab"] [data-testid="close-tab"]').first()
+    // TabBar renders the close button as `tab-close`; this spec alone had the
+    // two words reversed, so it waited out the full timeout on every run.
+    const closeBtn = page.locator('[data-testid="tab"] [data-testid="tab-close"]').first()
     await expect(closeBtn).toBeVisible()
     await closeBtn.click()
     const confirmBtn = page.locator('button:has-text("Close")')
@@ -26,6 +28,24 @@ piTest.describe('Pi Agent Lifecycle', () => {
 
     // The close must take effect.
     await expect(tabs).toHaveCount(Math.max(tabsBefore - 1, 0))
+  })
+
+  piTest('turn-end divider reports the duration, and agent_settled stays hidden', async ({ authenticatedPiWorkspace, page }) => {
+    void authenticatedPiWorkspace // fixture trigger
+    await sendMessage(page, ARITHMETIC_PROMPT)
+    await waitForAgentIdle(page, 180_000)
+
+    // Pi's agent_end carries no duration; the worker measures the turn and
+    // injects duration_ms, so the divider always names a time.
+    // `:visible` scoping is required — ChatView renders every unmeasured row
+    // twice, so an unscoped locator can pick the offscreen copy.
+    const divider = page.locator('[data-testid="result-divider"]:visible').last()
+    await expect(divider).toHaveText(/^Turn ended \(.+\)$/)
+
+    // Pi emits agent_settled after agent_end. The worker drops it, so it must
+    // never surface as a raw-JSON bubble.
+    const allText = (await messageContents(page).allTextContents()).join(' ')
+    expect(allText).not.toContain('agent_settled')
   })
 
   piTest('clear context via /clear command resets Pi session', async ({ authenticatedPiWorkspace, page }) => {


### PR DESCRIPTION
## Motivation
Pi's persisted `agent_end` event carried no turn duration, unlike Claude
Code's `result` envelope, so the frontend could not show a duration for a
Pi turn. Pi's own message timestamps cannot supply it either: they mark
request starts, not ends, so `last - first` would omit the final response
and would report about 0 ms for a one-message turn.

Pi 0.84 also added an `agent_settled` event, emitted after a run fully
settles. LeapMux did not know the token, so the worker's default case
persisted it and the renderer drew it as a raw-JSON bubble at the end of
every turn. That row also pinned the thinking indicator, because the
working-state scan stops at the first row it cannot classify.

Separately, Pi has its own retry mechanism, and LeapMux has an
auto-continue mechanism that also retries on API errors. Both matched the
same error string (`websocket.?error`), so a retryable failure triggered
both mechanisms and continued the turn twice. This change makes LeapMux
honor Pi's own `willRetry` signal and treats its own auto-continue as the
last resort.

This work also found two pre-existing defects in the adjacent turn-end
tool-use count — every ACP provider reports 0, and Pi reports nothing —
filed together as #435. A fix changes when a completion sound plays for
real turns across six ACP providers plus Pi, so it is deliberately out of
scope here. Both sites now carry a comment pointing at the issue.

## Modifications
- `PiAgent` tracks `turnStartedAt`, set on the first `agent_start` of a
  turn so a retried run keeps the turn's original start, plus an
  injectable `nowFn` clock for tests. `handlePiAgentEnd` computes
  `duration_ms` and injects it into the persisted `agent_end` envelope.
  A nil duration (turn start never observed, or a backwards clock) omits
  the field instead of reporting a false `0`, because the frontend
  distinguishes "no time shown" from "(0ms)".
- `piAgentEndEnvelope` gained `WillRetry bool`. When Pi reports it will
  retry the run itself, LeapMux keeps `currentTurnActive` true (so
  Interrupt and steering still work), persists via `PersistMessage`
  instead of `PersistTurnEnd` (the divider still draws, but the
  turn-end effects — completion sound, off-screen tab notification dot,
  git-status refresh — wait for the run that really ends the turn),
  keeps `turnToolUses` and `turnStartedAt`, and skips its own
  `scheduleOrCancelAPIErrorAutoContinue`. This fixes the double-retry
  bug described above.
- New `agent_settled` event added to `contracts/pi-protocol.json`,
  routed to the no-op lifecycle-marker case so it never reaches the
  transcript as a raw-JSON row.
- Refactor: `isRetryablePiAgentEndFailure(raw []byte)` became the method
  `(env piAgentEndEnvelope) isRetryableFailure()`, decoding the envelope
  once. `piAugmentRawWithSnapshot` renamed to `piAugmentAgentEnd` and
  now takes a `*int64` duration.
- Dead code removed: `handlePiAgentEnd` no longer broadcasts
  `{"pi_turn_active": false}` — it was only ever broadcast as false and
  no frontend code read it.
- `ClearContext` also drops the turn-start mark, since `agent_start` now
  takes a mark only when none is held.
- Frontend: `agent_settled` added to `PI_HIDDEN_EVENT_TYPES`, which
  hides the rows an earlier build already persisted. The `agent_end` ->
  `result_divider` model reads the worker-injected `duration_ms` and
  appends a formatted duration to every label it already draws
  (`Turn ended (3.2s)`, `Turn aborted (3.2s)`,
  `Turn failed — WebSocket error (3.2s)`, etc.), and reads `willRetry`
  to mark the divider `· auto-retry`. New optional, provider-neutral
  field `ResultDividerModel.turnContinues` in `registry.ts`.
- `isAgentWorking` now consults `turnContinues` instead of treating any
  `result_divider` as finished, so the thinking indicator stays visible
  during a Pi auto-retry backoff. It also skips rows classified
  `hidden` instead of stopping at them, for any provider, which removed
  a now-unreachable branch and corrected a stale test whose premise
  (Claude's `init` counts as progress) no longer held.
- New unit tests for the pre-existing shared `formatDuration` helper,
  which had none.
- E2E: new case asserting the divider names a duration and that
  `agent_settled` never appears, verified against the real `pi` binary.
  Also fixed a pre-existing locator typo in the same spec
  (`[data-testid="close-tab"]` never matched TabBar's actual
  `tab-close`), so that test had been failing on its full 120s timeout
  on every run; it now passes in about 1s.

No breaking changes. New: `contracts.PiEventAgentSettled`; persisted Pi
`agent_end` carries an optional `duration_ms` field, using the same
field name as Claude Code's `result` envelope so one frontend read
serves both.

## Result
A Pi turn's divider now shows its duration, the same as Claude Code's,
and `agent_settled` no longer appears as a raw-JSON bubble at the end of
every turn. A turn that Pi retries itself no longer double-continues,
and its completion sound, notification dot, and git-status refresh wait
for the run that actually ends the turn. The thinking indicator stays
visible during a Pi auto-retry backoff instead of appearing to finish
early, and no longer stays lit forever on a transcript whose last row
the UI folds away.
