### PR TITLE
fix: Correct defects across agent startup, terminals, and menus

### DIFF
--- a/backend/internal/worker/agent/acp_effort.go
+++ b/backend/internal/worker/agent/acp_effort.go
@@ -10,10 +10,7 @@ package agent
 import (
 	"maps"
 	"slices"
-	"sort"
 	"strings"
-
-	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 )
 
 // acpEffortConfigOptionIDs are the well-known ids ACP providers use for a reasoning-effort
@@ -45,21 +42,32 @@ func acpEffortConfigOption(options []acpConfigOption) (acpConfigOption, bool) {
 }
 
 // effortRank ranks reasoning-effort option values by intensity (higher = more effort),
-// so a thought_level select can be ordered strongest-first. Covers the standard CLI
-// names plus their common separator/spelling variants; a value absent here sorts after
-// every ranked value (see sortEffortOptionsDescending). Keys are lowercase; lookups go
+// so a thought_level select can be ordered strongest-first. A value absent here sorts
+// after every ranked value (see sortEffortsDescending). Keys are lowercase; lookups go
 // through effortRankOf, which lowercases first so a server reporting "High"/"LOW" is
 // still ranked rather than dumped into the unranked tail.
-var effortRank = map[string]int{
-	"off": 0, "none": 0,
-	"minimal": 1, "min": 1,
-	"low":    2,
-	"medium": 3, "med": 3, "moderate": 3, "balanced": 3, "standard": 3,
-	"high":  4,
-	"xhigh": 5, "x-high": 5, "very-high": 5, "very_high": 5, "extra-high": 5,
-	"max":       6,
-	"ultra":     7,
-	"ultracode": 8,
+//
+// DERIVED from effortLadder, which is the one declaration of the axis -- so a level
+// added there is ranked, labelled and placed in Codex's menu by that one edit, and no
+// second table can fall behind. It ranks every provider's levels: ZCode's sort through
+// it too (zcodeEffortsWithAuto).
+//
+// Rank 0 is the ladder's LAST rung and means "thinking off". Two call sites depend on
+// that: chooseDefaultEffort skips it, and raiseEffortOffNone treats it as the state to
+// replace. So a level that IS thinking must not sit on that rung -- which is why
+// `enabled`, ZCode's on/off toggle, shares the `minimal` rung instead.
+var effortRank = buildEffortRank()
+
+func buildEffortRank() map[string]int {
+	ranks := make(map[string]int)
+	// The ladder is strongest first and rank counts UP, so the last rung is 0.
+	top := len(effortLadder) - 1
+	for i, rung := range effortLadder {
+		for _, level := range rung {
+			ranks[level.ID] = top - i
+		}
+	}
+	return ranks
 }
 
 // effortRankOf looks up a value's intensity rank case-insensitively. Returns
@@ -67,29 +75,6 @@ var effortRank = map[string]int{
 func effortRankOf(id string) (int, bool) {
 	r, ok := effortRank[strings.ToLower(id)]
 	return r, ok
-}
-
-// sortEffortOptionsDescending reorders effort options in place strongest-first by
-// effortRank. A value absent from effortRank (e.g. a provider-specific variant like
-// "default") sorts after every ranked value, preserving its order among other
-// unranked values.
-//
-// The comparator is a strict weak ordering -- ranked-before-unranked is decided
-// directly rather than via "incomparable" -- so an unranked value sitting between two
-// ranked ones can no longer act as a barrier that leaves the ranked pair mis-ordered
-// (e.g. [low, default, high] now yields [high, low, default], not [low, default, high]).
-func sortEffortOptionsDescending(opts []*leapmuxv1.AvailableOption) {
-	sort.SliceStable(opts, func(i, j int) bool {
-		ri, oki := effortRankOf(opts[i].GetId())
-		rj, okj := effortRankOf(opts[j].GetId())
-		if oki != okj {
-			return oki // a ranked value sorts before an unranked one
-		}
-		if !oki {
-			return false // both unranked: keep their relative (server-reported) order
-		}
-		return ri > rj // both ranked: strongest first
-	})
 }
 
 // chooseDefaultEffort picks the reasoning-effort value to install when a model first

--- a/backend/internal/worker/agent/acp_options.go
+++ b/backend/internal/worker/agent/acp_options.go
@@ -359,7 +359,7 @@ func buildOptionGroup(option acpConfigOption, current string) *leapmuxv1.Availab
 	option.Options = appendConfigOptionValueIfMissing(option.Options, current)
 	opts := buildOptionValues(option, nil)
 	if isEffortConfigOption(option) {
-		sortEffortOptionsDescending(opts)
+		sortEffortsDescending(opts)
 	}
 	return &leapmuxv1.AvailableOptionGroup{
 		Id:           option.ID,

--- a/backend/internal/worker/agent/codex.go
+++ b/backend/internal/worker/agent/codex.go
@@ -983,26 +983,34 @@ func (a *CodexAgent) queryAvailableModels(timeout time.Duration) []*ModelInfo {
 // so Codex applies its own default.
 //
 // The slice order IS the menu order: optionGroupsForAgent maps it into the
-// option group unchanged, and the frontend renders the options in order. Add a
-// new tier at its rank, never at the end -- codexEffortName looks an entry up
-// by id, so appending satisfies the label lookup while putting the tier in the
-// wrong place in every picker. TestCodexDefaultEffortsRankOrder enforces this
-// against the shared effortRank table, so a misplaced tier fails the build.
+// option group unchanged, and the frontend renders the options in order. It is
+// DERIVED from effortLadder rather than written out, so a tier cannot be put in
+// the wrong place: this file states only WHICH tiers Codex offers, and the
+// ladder states what comes before what.
 //
 // Every tier the live CLI reports should appear here, so the static fallback
 // offers the same menu the running session does. A tier that is absent is no
 // longer a labeling hazard: both paths resolve their label through effortLabel,
 // so an unlisted id renders capitalized like its siblings rather than raw.
-var codexDefaultEfforts = []*EffortInfo{
-	codexAutoEffort(),
-	effortTier("ultra"),
-	effortTier("max"),
-	effortTier(EffortXHigh),
-	effortTier(EffortHigh),
-	effortTier("medium"),
-	effortTier("low"),
-	effortTier("minimal"),
-	effortTier("none"),
+var codexDefaultEfforts = buildCodexDefaultEfforts()
+
+// codexEffortIDs is WHICH levels Codex offers. The ORDER comes from
+// effortLadder, so this states membership only: Codex has no `ultracode` rung
+// and no separate `off`, and listing it here in ladder order would be a second
+// statement of the ordering that a level moved in the ladder could fall behind.
+var codexEffortIDs = map[string]bool{
+	"ultra": true, "max": true, EffortXHigh: true, EffortHigh: true,
+	"medium": true, "low": true, "minimal": true, "none": true,
+}
+
+func buildCodexDefaultEfforts() []*EffortInfo {
+	efforts := []*EffortInfo{codexAutoEffort()}
+	for _, id := range effortLadderIDs() {
+		if codexEffortIDs[id] {
+			efforts = append(efforts, effortTier(id))
+		}
+	}
+	return efforts
 }
 
 // codexAutoEffort is the LeapMux-side "auto" sentinel. The CLI never reports it,

--- a/backend/internal/worker/agent/copilot_test.go
+++ b/backend/internal/worker/agent/copilot_test.go
@@ -575,7 +575,7 @@ func TestACPConfigOption_EffortSortedStrongestFirst(t *testing.T) {
 // (low ahead of high); the strict-weak-ordering comparator now sorts the ranked pair.
 func TestSortEffortOptionsDescending_RanksUnrankedLast(t *testing.T) {
 	opts := []*leapmuxv1.AvailableOption{{Id: "low"}, {Id: "default"}, {Id: "high"}}
-	sortEffortOptionsDescending(opts)
+	sortEffortsDescending(opts)
 	ids := func() []string {
 		out := make([]string, len(opts))
 		for i, o := range opts {
@@ -591,7 +591,7 @@ func TestSortEffortOptionsDescending_RanksUnrankedLast(t *testing.T) {
 // values keep their relative (server-reported) order while sorting after ranked ones.
 func TestSortEffortOptionsDescending_StableAmongUnranked(t *testing.T) {
 	opts := []*leapmuxv1.AvailableOption{{Id: "alpha"}, {Id: "high"}, {Id: "beta"}, {Id: "low"}}
-	sortEffortOptionsDescending(opts)
+	sortEffortsDescending(opts)
 	ids := make([]string, len(opts))
 	for i, o := range opts {
 		ids[i] = o.GetId()
@@ -605,7 +605,7 @@ func TestSortEffortOptionsDescending_StableAmongUnranked(t *testing.T) {
 // tail -- effortRankOf lowercases before the lookup.
 func TestSortEffortOptionsDescending_CaseInsensitive(t *testing.T) {
 	opts := []*leapmuxv1.AvailableOption{{Id: "LOW"}, {Id: "High"}, {Id: "Medium"}}
-	sortEffortOptionsDescending(opts)
+	sortEffortsDescending(opts)
 	ids := make([]string, len(opts))
 	for i, o := range opts {
 		ids[i] = o.GetId()
@@ -619,7 +619,7 @@ func TestSortEffortOptionsDescending_CaseInsensitive(t *testing.T) {
 // mid-tier synonym is not stranded after every ranked value.
 func TestSortEffortOptionsDescending_KnownSynonyms(t *testing.T) {
 	opts := []*leapmuxv1.AvailableOption{{Id: "moderate"}, {Id: "very_high"}, {Id: "minimal"}}
-	sortEffortOptionsDescending(opts)
+	sortEffortsDescending(opts)
 	ids := make([]string, len(opts))
 	for i, o := range opts {
 		ids[i] = o.GetId()

--- a/backend/internal/worker/agent/effort_labels.go
+++ b/backend/internal/worker/agent/effort_labels.go
@@ -5,31 +5,94 @@ import (
 	"strings"
 )
 
-// effortLabels is the display label for each reasoning-effort id, shared by
-// every provider.
+// effortLevel is one reasoning-effort id and how it reads.
+type effortLevel struct {
+	// ID is the spelling a provider reports.
+	ID string
+	// Label is how that id READS. Shared by every provider: "xhigh" is "Extra
+	// High" whoever offers it. Empty for a SPELLING VARIANT no menu draws under
+	// that spelling -- effortLabel capitalizes such an id instead.
+	Label string
+}
+
+// effortRung is every id that asks for the SAME amount of thinking. The first is
+// the canonical spelling; the rest are variants a provider may report instead,
+// and a menu never offers two of them at once.
+type effortRung []effortLevel
+
+// effortLadder is the ONE declaration of the reasoning-effort axis: which levels
+// exist, how each one reads, and which asks for more thinking than which.
+//
+// STRONGEST FIRST, and the order is load-bearing three times over. It is the
+// menu order Codex's static catalog renders (codexDefaultEfforts), it is the
+// rank every provider's levels sort by (effortRank), and it is the label table
+// every provider draws from (effortLabels). All three used to be written out
+// separately and two tests existed only to hold them together; a level added
+// here now moves in every one of them at once.
 //
 // Which ids a provider offers IS provider-specific, and so are the
 // DESCRIPTIONS: Claude's mirror the CLI's own /effort copy, Codex's come from
-// the live model/list response, and each `auto` sentinel identifies its own agent.
-// The LABEL is not -- "xhigh" reads "Extra High" whoever offers it. Before this
-// table claude.go, codex.go and pi_settings.go each spelled it out and cursor.go
-// special-cased it to "XHigh", so the four could disagree and did: correcting
-// one of them by hand is exactly what this table makes unnecessary.
-var effortLabels = map[string]string{
-	EffortAuto: "Auto",
-	"off":      "Off",
-	"none":     "None",
-	// ZCode's on/off toggle for a model that offers no ladder: GLM-5-Turbo
-	// declares `enabled` and `off` where GLM-5.3 declares low/high/max.
-	"enabled":   "Enabled",
-	"minimal":   "Minimal",
-	"low":       "Low",
-	"medium":    "Medium",
-	EffortHigh:  "High",
-	EffortXHigh: "Extra High",
-	"max":       "Max",
-	"ultra":     "Ultra",
-	"ultracode": "Ultracode",
+// the live model/list response, and each `auto` sentinel identifies its own
+// agent. The LABEL is not. Before this ladder, claude.go, codex.go and
+// pi_settings.go each spelled it out and cursor.go special-cased it to "XHigh",
+// so the four could disagree and did.
+//
+// `EffortAuto` is deliberately absent. It is not a strength -- it means "send no
+// level at all" -- so it must never sort, and each caller that offers it puts it
+// first by hand. effortLabels carries its label separately.
+var effortLadder = []effortRung{
+	{{ID: "ultracode", Label: "Ultracode"}},
+	{{ID: "ultra", Label: "Ultra"}},
+	{{ID: "max", Label: "Max"}},
+	{{ID: EffortXHigh, Label: "Extra High"}, {ID: "x-high"}, {ID: "very-high"}, {ID: "very_high"}, {ID: "extra-high"}},
+	{{ID: EffortHigh, Label: "High"}},
+	{{ID: "medium", Label: "Medium"}, {ID: "med"}, {ID: "moderate"}, {ID: "balanced"}, {ID: "standard"}},
+	{{ID: "low", Label: "Low"}},
+	// `enabled` is ZCode's on/off toggle for a model that offers no ladder:
+	// GLM-5-Turbo declares `enabled` and `off` where GLM-5.3 declares
+	// low/high/max. It shares this rung with `minimal` -- the weakest level that
+	// is still THINKING -- because the rung below is rank 0, and rank 0 means
+	// thinking off: chooseDefaultEffort skips it and raiseEffortOffNone treats
+	// it as the state to replace. It keeps a label of its own, because a menu
+	// does draw it.
+	{{ID: "minimal", Label: "Minimal"}, {ID: "min"}, {ID: "enabled", Label: "Enabled"}},
+	// The floor, and rank 0. `none` and `off` ask for the same amount of
+	// thinking -- none -- but a menu draws whichever word its provider reports,
+	// so both keep a label. Nothing may sort below this rung.
+	{{ID: "none", Label: "None"}, {ID: "off", Label: "Off"}},
+}
+
+// effortLabels is the display label for each reasoning-effort id, derived from
+// effortLadder plus the `auto` sentinel that is not on it.
+//
+// A spelling VARIANT carries no entry. A provider reports one spelling or the
+// other, never both, and effortLabel falls back to a capitalized form -- so a
+// daemon that reports "x-high" reads as "X-High" rather than as a raw token,
+// while the canonical "xhigh" reads "Extra High".
+var effortLabels = buildEffortLabels()
+
+func buildEffortLabels() map[string]string {
+	labels := map[string]string{EffortAuto: "Auto"}
+	for _, rung := range effortLadder {
+		for _, level := range rung {
+			if level.Label != "" {
+				labels[level.ID] = level.Label
+			}
+		}
+	}
+	return labels
+}
+
+// effortLadderIDs returns the canonical id of every rung, strongest first.
+//
+// The menu order for a provider that spells its own catalog by hand, so that
+// catalog states WHICH levels it offers and this states the order they come in.
+func effortLadderIDs() []string {
+	ids := make([]string, 0, len(effortLadder))
+	for _, rung := range effortLadder {
+		ids = append(ids, rung[0].ID)
+	}
+	return ids
 }
 
 // effortLabel returns the shared display label for an effort id.
@@ -51,55 +114,44 @@ func effortTier(id string) *EffortInfo {
 	return &EffortInfo{Id: id, Name: effortLabel(id)}
 }
 
-// effortStrength ranks a reasoning level by how much thinking it asks for.
+// sortEffortsDescending orders levels strongest first, in place, by effortRank.
+//
+// ONE ladder ranks every provider's levels, and it lives with the rest of the
+// effort axis in `acp_effort.go`. This function exists because two element types
+// carry those levels -- `*EffortInfo` for a catalog entry and
+// `*leapmuxv1.AvailableOption` for an ACP config option -- and both answer
+// `GetId()`. A second table would order the same word differently in two menus:
+// the pair that preceded this one already disagreed about `none` against `off`,
+// and only one of them ranked `x-high` and `med`.
 //
 // The app lists the levels STRONGEST FIRST. Codex's own catalog
-// (codexDefaultEfforts) states that order by hand, and this table repeats its
-// ladder for the providers whose levels arrive as DATA and therefore in whatever
-// order the source wrote them: ZCode reads them from the user's `config.json`,
-// which ships GLM-5.3 as `["low", "max", "high"]`, and listing that verbatim put
-// the weakest level at the top of the menu and the ladder out of order under it.
-//
-// Only the order matters, not the numbers; the gaps leave room for a level a CLI
-// adds between two of these.
-//
-// `enabled` is ZCode's on/off toggle for a model that offers no tiers
-// (GLM-5-Turbo gives `enabled` and `off`). Only its position ABOVE `off` is
-// load-bearing -- a model offers the ladder or the toggle, never both.
-var effortStrength = map[string]int{
-	"ultracode": 100,
-	"ultra":     90,
-	"max":       80,
-	EffortXHigh: 70,
-	EffortHigh:  60,
-	"medium":    50,
-	"low":       40,
-	"enabled":   30,
-	"minimal":   20,
-	"none":      10,
-	"off":       0,
-}
-
-// sortEffortsByStrength orders levels strongest first, in place.
+// (codexDefaultEfforts) states that order by hand; this sort supplies it for the
+// providers whose levels arrive as DATA and therefore in whatever order the
+// source wrote them. ZCode reads them from the user's `config.json`, which ships
+// GLM-5.3 as `["low", "max", "high"]`, and listing that verbatim put the weakest
+// level at the top of the menu and the ladder out of order under it.
 //
 // A level the ladder does not rank keeps its given position relative to the
 // other unranked ones and sorts BEHIND every ranked one: a level a CLI adds
 // mid-release has no claim to a place in the middle of the ladder, and a stable
-// sort keeps the source's own order among such levels.
+// sort keeps the source's own order among such levels. The comparator is a
+// strict weak ordering -- ranked-before-unranked is decided directly rather than
+// through "incomparable" -- so an unranked level between two ranked ones cannot
+// act as a barrier that leaves the ranked pair out of order.
 //
 // `EffortAuto` is not on the ladder and must not be passed here. It is not a
 // strength -- it means "send no level at all" -- and every caller puts it first
 // by hand, ahead of whatever this returns.
-func sortEffortsByStrength(efforts []*EffortInfo) {
-	sort.SliceStable(efforts, func(i, j int) bool {
-		left, leftOK := effortStrength[strings.ToLower(efforts[i].GetId())]
-		right, rightOK := effortStrength[strings.ToLower(efforts[j].GetId())]
+func sortEffortsDescending[T interface{ GetId() string }](items []T) {
+	sort.SliceStable(items, func(i, j int) bool {
+		left, leftOK := effortRankOf(items[i].GetId())
+		right, rightOK := effortRankOf(items[j].GetId())
 		if leftOK != rightOK {
-			return leftOK
+			return leftOK // a ranked level sorts before an unranked one
 		}
 		if !leftOK {
-			return false
+			return false // both unranked: keep their given order
 		}
-		return left > right
+		return left > right // both ranked: strongest first
 	})
 }

--- a/backend/internal/worker/agent/effort_labels.go
+++ b/backend/internal/worker/agent/effort_labels.go
@@ -1,6 +1,9 @@
 package agent
 
-import "strings"
+import (
+	"sort"
+	"strings"
+)
 
 // effortLabels is the display label for each reasoning-effort id, shared by
 // every provider.
@@ -13,9 +16,12 @@ import "strings"
 // special-cased it to "XHigh", so the four could disagree and did: correcting
 // one of them by hand is exactly what this table makes unnecessary.
 var effortLabels = map[string]string{
-	EffortAuto:  "Auto",
-	"off":       "Off",
-	"none":      "None",
+	EffortAuto: "Auto",
+	"off":      "Off",
+	"none":     "None",
+	// ZCode's on/off toggle for a model that offers no ladder: GLM-5-Turbo
+	// declares `enabled` and `off` where GLM-5.3 declares low/high/max.
+	"enabled":   "Enabled",
 	"minimal":   "Minimal",
 	"low":       "Low",
 	"medium":    "Medium",
@@ -43,4 +49,57 @@ func effortLabel(id string) string {
 // one exists.
 func effortTier(id string) *EffortInfo {
 	return &EffortInfo{Id: id, Name: effortLabel(id)}
+}
+
+// effortStrength ranks a reasoning level by how much thinking it asks for.
+//
+// The app lists the levels STRONGEST FIRST. Codex's own catalog
+// (codexDefaultEfforts) states that order by hand, and this table repeats its
+// ladder for the providers whose levels arrive as DATA and therefore in whatever
+// order the source wrote them: ZCode reads them from the user's `config.json`,
+// which ships GLM-5.3 as `["low", "max", "high"]`, and listing that verbatim put
+// the weakest level at the top of the menu and the ladder out of order under it.
+//
+// Only the order matters, not the numbers; the gaps leave room for a level a CLI
+// adds between two of these.
+//
+// `enabled` is ZCode's on/off toggle for a model that offers no tiers
+// (GLM-5-Turbo gives `enabled` and `off`). Only its position ABOVE `off` is
+// load-bearing -- a model offers the ladder or the toggle, never both.
+var effortStrength = map[string]int{
+	"ultracode": 100,
+	"ultra":     90,
+	"max":       80,
+	EffortXHigh: 70,
+	EffortHigh:  60,
+	"medium":    50,
+	"low":       40,
+	"enabled":   30,
+	"minimal":   20,
+	"none":      10,
+	"off":       0,
+}
+
+// sortEffortsByStrength orders levels strongest first, in place.
+//
+// A level the ladder does not rank keeps its given position relative to the
+// other unranked ones and sorts BEHIND every ranked one: a level a CLI adds
+// mid-release has no claim to a place in the middle of the ladder, and a stable
+// sort keeps the source's own order among such levels.
+//
+// `EffortAuto` is not on the ladder and must not be passed here. It is not a
+// strength -- it means "send no level at all" -- and every caller puts it first
+// by hand, ahead of whatever this returns.
+func sortEffortsByStrength(efforts []*EffortInfo) {
+	sort.SliceStable(efforts, func(i, j int) bool {
+		left, leftOK := effortStrength[strings.ToLower(efforts[i].GetId())]
+		right, rightOK := effortStrength[strings.ToLower(efforts[j].GetId())]
+		if leftOK != rightOK {
+			return leftOK
+		}
+		if !leftOK {
+			return false
+		}
+		return left > right
+	})
 }

--- a/backend/internal/worker/agent/effort_labels_test.go
+++ b/backend/internal/worker/agent/effort_labels_test.go
@@ -1,0 +1,92 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func effortIDs(efforts []*EffortInfo) []string {
+	ids := make([]string, 0, len(efforts))
+	for _, e := range efforts {
+		ids = append(ids, e.GetId())
+	}
+	return ids
+}
+
+// The menu reads top to bottom, so the strongest level belongs at the top. A
+// provider whose levels arrive as DATA gets them in whatever order the source
+// wrote them: ZCode's own `config.json` states GLM-5.3 as `["low", "max",
+// "high"]`, which led the menu with the weakest level.
+func TestSortEffortsByStrength_OrdersTheLadderStrongestFirst(t *testing.T) {
+	t.Parallel()
+
+	efforts := []*EffortInfo{effortTier("low"), effortTier("max"), effortTier(EffortHigh)}
+	sortEffortsByStrength(efforts)
+	assert.Equal(t, []string{"max", "high", "low"}, effortIDs(efforts))
+
+	full := []*EffortInfo{
+		effortTier("none"), effortTier("minimal"), effortTier("low"), effortTier("medium"),
+		effortTier(EffortHigh), effortTier(EffortXHigh), effortTier("max"), effortTier("ultra"),
+		effortTier("ultracode"),
+	}
+	sortEffortsByStrength(full)
+	assert.Equal(t, []string{
+		"ultracode", "ultra", "max", "xhigh", "high", "medium", "low", "minimal", "none",
+	}, effortIDs(full))
+}
+
+// The whole ladder, spelled by hand in codexDefaultEfforts, is the order this
+// table exists to repeat. The two must not drift: a level moved in one and not
+// the other would order the same word differently in two menus.
+func TestSortEffortsByStrength_AgreesWithTheCodexCatalogOrder(t *testing.T) {
+	t.Parallel()
+
+	// Auto is not a strength and never reaches the sort, so it is dropped first.
+	tail := append([]*EffortInfo(nil), codexDefaultEfforts[1:]...)
+	want := effortIDs(tail)
+
+	shuffled := []*EffortInfo{tail[3], tail[0], tail[6], tail[1], tail[5], tail[2], tail[7], tail[4]}
+	sortEffortsByStrength(shuffled)
+	assert.Equal(t, want, effortIDs(shuffled))
+}
+
+// A model that offers a toggle rather than a ladder: ZCode gives GLM-5-Turbo
+// `enabled` and `off`, and "thinking on" must not sort under "thinking off".
+func TestSortEffortsByStrength_RanksTheOnOffToggle(t *testing.T) {
+	t.Parallel()
+
+	efforts := []*EffortInfo{effortTier("off"), effortTier("enabled")}
+	sortEffortsByStrength(efforts)
+	assert.Equal(t, []string{"enabled", "off"}, effortIDs(efforts))
+}
+
+// A level a CLI adds mid-release has no claim to a place inside the ladder, and
+// the source's own order is the only thing left to rank such levels by.
+func TestSortEffortsByStrength_KeepsUnrankedLevelsLastAndInOrder(t *testing.T) {
+	t.Parallel()
+
+	efforts := []*EffortInfo{
+		effortTier("zeta"), effortTier("low"), effortTier("alpha"), effortTier("max"),
+	}
+	sortEffortsByStrength(efforts)
+	assert.Equal(t, []string{"max", "low", "zeta", "alpha"}, effortIDs(efforts))
+}
+
+func TestSortEffortsByStrength_MatchesTheLadderWithoutRegardToCase(t *testing.T) {
+	t.Parallel()
+
+	efforts := []*EffortInfo{{Id: "LOW"}, {Id: "Max"}}
+	sortEffortsByStrength(efforts)
+	assert.Equal(t, []string{"Max", "LOW"}, effortIDs(efforts))
+}
+
+// Every ranked level also has to READ as one: a level in the ladder that the
+// label table never heard of would sort correctly and render as a raw token.
+func TestEffortStrength_EveryRankedLevelHasALabel(t *testing.T) {
+	t.Parallel()
+
+	for id := range effortStrength {
+		assert.Containsf(t, effortLabels, id, "level %q is ranked but has no shared label", id)
+	}
+}

--- a/backend/internal/worker/agent/effort_labels_test.go
+++ b/backend/internal/worker/agent/effort_labels_test.go
@@ -1,12 +1,19 @@
 package agent
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func effortIDs(efforts []*EffortInfo) []string {
+// effortIDs reads the ids off a list of levels, for an assertion about ORDER.
+//
+// Generic over the same constraint sortEffortsDescending takes, because the two
+// element types that carry a level both reach these tests: `*EffortInfo` for a
+// catalog entry and `*leapmuxv1.AvailableOption` for an ACP config option.
+func effortIDs[T interface{ GetId() string }](efforts []T) []string {
 	ids := make([]string, 0, len(efforts))
 	for _, e := range efforts {
 		ids = append(ids, e.GetId())
@@ -18,11 +25,11 @@ func effortIDs(efforts []*EffortInfo) []string {
 // provider whose levels arrive as DATA gets them in whatever order the source
 // wrote them: ZCode's own `config.json` states GLM-5.3 as `["low", "max",
 // "high"]`, which led the menu with the weakest level.
-func TestSortEffortsByStrength_OrdersTheLadderStrongestFirst(t *testing.T) {
+func TestSortEffortsDescending_OrdersTheLadderStrongestFirst(t *testing.T) {
 	t.Parallel()
 
 	efforts := []*EffortInfo{effortTier("low"), effortTier("max"), effortTier(EffortHigh)}
-	sortEffortsByStrength(efforts)
+	sortEffortsDescending(efforts)
 	assert.Equal(t, []string{"max", "high", "low"}, effortIDs(efforts))
 
 	full := []*EffortInfo{
@@ -30,16 +37,17 @@ func TestSortEffortsByStrength_OrdersTheLadderStrongestFirst(t *testing.T) {
 		effortTier(EffortHigh), effortTier(EffortXHigh), effortTier("max"), effortTier("ultra"),
 		effortTier("ultracode"),
 	}
-	sortEffortsByStrength(full)
+	sortEffortsDescending(full)
 	assert.Equal(t, []string{
 		"ultracode", "ultra", "max", "xhigh", "high", "medium", "low", "minimal", "none",
 	}, effortIDs(full))
 }
 
-// The whole ladder, spelled by hand in codexDefaultEfforts, is the order this
-// table exists to repeat. The two must not drift: a level moved in one and not
-// the other would order the same word differently in two menus.
-func TestSortEffortsByStrength_AgreesWithTheCodexCatalogOrder(t *testing.T) {
+// The sort and Codex's static menu must agree, and now they agree BY
+// CONSTRUCTION: both read effortLadder. The test stays because the two reach it
+// by different routes -- the sort through effortRank, the menu through
+// effortLadderIDs -- and a change to either derivation could still part them.
+func TestSortEffortsDescending_AgreesWithTheCodexCatalogOrder(t *testing.T) {
 	t.Parallel()
 
 	// Auto is not a strength and never reaches the sort, so it is dropped first.
@@ -47,46 +55,163 @@ func TestSortEffortsByStrength_AgreesWithTheCodexCatalogOrder(t *testing.T) {
 	want := effortIDs(tail)
 
 	shuffled := []*EffortInfo{tail[3], tail[0], tail[6], tail[1], tail[5], tail[2], tail[7], tail[4]}
-	sortEffortsByStrength(shuffled)
+	sortEffortsDescending(shuffled)
 	assert.Equal(t, want, effortIDs(shuffled))
 }
 
 // A model that offers a toggle rather than a ladder: ZCode gives GLM-5-Turbo
 // `enabled` and `off`, and "thinking on" must not sort under "thinking off".
-func TestSortEffortsByStrength_RanksTheOnOffToggle(t *testing.T) {
+func TestSortEffortsDescending_RanksTheOnOffToggle(t *testing.T) {
 	t.Parallel()
 
 	efforts := []*EffortInfo{effortTier("off"), effortTier("enabled")}
-	sortEffortsByStrength(efforts)
+	sortEffortsDescending(efforts)
 	assert.Equal(t, []string{"enabled", "off"}, effortIDs(efforts))
 }
 
 // A level a CLI adds mid-release has no claim to a place inside the ladder, and
 // the source's own order is the only thing left to rank such levels by.
-func TestSortEffortsByStrength_KeepsUnrankedLevelsLastAndInOrder(t *testing.T) {
+func TestSortEffortsDescending_KeepsUnrankedLevelsLastAndInOrder(t *testing.T) {
 	t.Parallel()
 
 	efforts := []*EffortInfo{
 		effortTier("zeta"), effortTier("low"), effortTier("alpha"), effortTier("max"),
 	}
-	sortEffortsByStrength(efforts)
+	sortEffortsDescending(efforts)
 	assert.Equal(t, []string{"max", "low", "zeta", "alpha"}, effortIDs(efforts))
 }
 
-func TestSortEffortsByStrength_MatchesTheLadderWithoutRegardToCase(t *testing.T) {
+func TestSortEffortsDescending_MatchesTheLadderWithoutRegardToCase(t *testing.T) {
 	t.Parallel()
 
 	efforts := []*EffortInfo{{Id: "LOW"}, {Id: "Max"}}
-	sortEffortsByStrength(efforts)
+	sortEffortsDescending(efforts)
 	assert.Equal(t, []string{"Max", "LOW"}, effortIDs(efforts))
 }
 
-// Every ranked level also has to READ as one: a level in the ladder that the
-// label table never heard of would sort correctly and render as a raw token.
-func TestEffortStrength_EveryRankedLevelHasALabel(t *testing.T) {
+// The label table and the ladder must cover the same levels, and the check runs
+// in BOTH directions because each direction catches a different defect.
+//
+// Ranked with no label renders a raw token in a menu that sorts correctly.
+// Labelled with no rank is the one this diff was written for: `enabled` reached
+// the label table first, and a level that nothing ranks sorts silently into the
+// tail -- under `off`, for the toggle model where "off" is the other option.
+// Only the second direction fails on that, so only it would have caught it.
+func TestEffortRank_AgreesWithTheLabelTableInBothDirections(t *testing.T) {
 	t.Parallel()
 
-	for id := range effortStrength {
+	for id := range effortRank {
+		// The ladder carries separator and spelling variants that no menu draws
+		// (`x-high` for `xhigh`, `med` for `medium`); a variant needs no label
+		// of its own, only a rank equal to the spelling it stands in for.
+		if _, isVariant := effortLabels[id]; !isVariant {
+			rank, ok := effortRankOf(id)
+			require.True(t, ok, "unreachable: id came from effortRank")
+			var canonical []string
+			for labelled := range effortLabels {
+				if r, ranked := effortRankOf(labelled); ranked && r == rank {
+					canonical = append(canonical, labelled)
+				}
+			}
+			assert.NotEmptyf(t, canonical,
+				"level %q is ranked %d, has no label, and shares its rank with no labelled level, so nothing draws it", id, rank)
+			continue
+		}
 		assert.Containsf(t, effortLabels, id, "level %q is ranked but has no shared label", id)
 	}
+
+	for id := range effortLabels {
+		if id == EffortAuto {
+			// Auto is not a strength -- it means "send no level at all" -- and
+			// sortEffortsDescending must never see it. See its doc.
+			continue
+		}
+		_, ranked := effortRankOf(id)
+		assert.Truef(t, ranked,
+			"level %q has a label but no rank, so it sorts below every ranked level, `off` included", id)
+	}
+}
+
+// `enabled` is ZCode's on/off toggle for a model that offers no ladder, and its
+// rank carries two obligations that are easy to break independently.
+func TestEffortRank_RanksTheOnOffToggleAboveOff(t *testing.T) {
+	t.Parallel()
+
+	enabled, ok := effortRankOf("enabled")
+	require.True(t, ok)
+	assert.Positivef(t, enabled,
+		"rank 0 means THINKING OFF: chooseDefaultEffort skips it and raiseEffortOffNone replaces it, "+
+			"so a model already thinking would read as one that is not")
+	assert.Less(t, effortRank["off"], enabled, "thinking on must not sort under thinking off")
+	assert.Less(t, enabled, effortRank[EffortHigh],
+		"it must stay under a real level, so chooseDefaultEffort prefers one whenever a ladder offers it")
+
+	// The pick a real ladder makes must not change because `enabled` joined the
+	// table: it is only ever offered beside `off`.
+	assert.Equal(t, EffortHigh, chooseDefaultEffort(acpConfigOption{Options: []acpConfigOptionValue{
+		{Value: "low"}, {Value: EffortHigh}, {Value: "max"},
+	}}))
+	assert.Equal(t, "enabled", chooseDefaultEffort(acpConfigOption{Options: []acpConfigOptionValue{
+		{Value: "off"}, {Value: "enabled"},
+	}}), "a toggle axis stuck at off must be raised to on, not left there")
+}
+
+// The ladder is the single declaration of the axis, and these are the
+// properties every derived table needs from it. Each one used to be a second
+// hand-written statement that could fall behind.
+func TestEffortLadder_IsTheOneDeclarationOfTheAxis(t *testing.T) {
+	t.Parallel()
+
+	seen := map[string]bool{}
+	for i, rung := range effortLadder {
+		require.NotEmptyf(t, rung, "rung %d is empty, so it ranks nothing", i)
+		require.NotEmptyf(t, rung[0].Label,
+			"the canonical id of rung %d draws no label, but a menu shows it", i)
+		for _, level := range rung {
+			assert.Falsef(t, seen[level.ID], "id %q appears on two rungs, so its rank is ambiguous", level.ID)
+			seen[level.ID] = true
+			assert.Equal(t, strings.ToLower(level.ID), level.ID,
+				"effortRankOf lowercases before the lookup, so a capitalized key is unreachable")
+		}
+	}
+
+	// Rank counts UP from the last rung, and rank 0 is the "thinking off"
+	// sentinel chooseDefaultEffort and raiseEffortOffNone both test for.
+	for _, level := range effortLadder[len(effortLadder)-1] {
+		rank, ok := effortRankOf(level.ID)
+		require.True(t, ok)
+		assert.Zerof(t, rank, "%q is on the last rung, which MUST be the thinking-off rank", level.ID)
+	}
+	for _, rung := range effortLadder[:len(effortLadder)-1] {
+		rank, _ := effortRankOf(rung[0].ID)
+		assert.Positivef(t, rank, "%q is a level that thinks, so it must not carry the thinking-off rank", rung[0].ID)
+	}
+
+	// Every id on one rung ranks the same, and every rung outranks the next.
+	for i, rung := range effortLadder {
+		want, _ := effortRankOf(rung[0].ID)
+		for _, level := range rung[1:] {
+			got, ok := effortRankOf(level.ID)
+			require.Truef(t, ok, "%q is on the ladder but unranked", level.ID)
+			assert.Equalf(t, want, got, "%q shares a rung with %q, so it must share its rank", level.ID, rung[0].ID)
+		}
+		if i > 0 {
+			above, _ := effortRankOf(effortLadder[i-1][0].ID)
+			assert.Greaterf(t, above, want, "the ladder reads strongest first, so rung %d must outrank rung %d", i-1, i)
+		}
+	}
+
+	// Codex states WHICH levels it offers; the ladder states their order.
+	for id := range codexEffortIDs {
+		assert.Containsf(t, seen, id, "codex offers %q, which is not on the ladder, so nothing ranks it", id)
+	}
+	assert.Equal(t, EffortAuto, codexDefaultEfforts[0].GetId(), "the LeapMux auto sentinel leads the menu")
+	want := []string{}
+	for _, id := range effortLadderIDs() {
+		if codexEffortIDs[id] {
+			want = append(want, id)
+		}
+	}
+	assert.Equal(t, want, effortIDs(codexDefaultEfforts[1:]),
+		"the static Codex catalog must read in ladder order")
 }

--- a/backend/internal/worker/agent/zcode_config.go
+++ b/backend/internal/worker/agent/zcode_config.go
@@ -412,7 +412,7 @@ func buildZCodeCatalog(cfg zcodeConfigFile) (zcodeCatalog, []zcodeProviderSkip) 
 			Kind:       kind,
 			APIFormat:  zcodeAPIFormat(c.provider.Kind),
 			BaseURL:    c.baseURL,
-			Label:      nameOrID(c.provider.Name, c.providerID),
+			Label:      zcodeProviderLabel(c.providerID, c.provider.Name),
 			Source:     zcodeRegistrySource(c.provider.Source),
 			APIKey:     &zcodeRegistryAPIKey{Source: zcodeAPIKeySourceInline, Value: c.apiKey},
 			// An empty slice, never nil: the app-server's schema requires the
@@ -470,11 +470,64 @@ func zcodeModelOrder(models map[string]zcodeConfigModel) []string {
 	return ids
 }
 
+// zcodeModelName picks how one model READS: its configured `name`, or its id.
+//
+// The id wins when the name differs from it by CASE alone. ZCode ships
+// GLM-5-Turbo with `"name": "glm-5-turbo"`, while the id is the spelling the CLI
+// itself uses everywhere the model is named -- the config key, the composite id
+// in `session.updated.model`, and its own catalog. A lowercase copy of the id
+// carries nothing the id does not, so it is not a name.
+//
+// A name that differs by more than case DOES carry something the id cannot, so
+// it wins. That is the same rule zcodeEffortTier applies to a level's label.
+func zcodeModelName(modelID string, model zcodeConfigModel) string {
+	name := strings.TrimSpace(model.Name)
+	if name == "" || strings.EqualFold(name, modelID) {
+		return modelID
+	}
+	return name
+}
+
+// zcodeBuiltinProviderLabels names the providers the ZCode CLI creates itself.
+//
+// The CLI writes these six entries into `config.json`, and it writes their names
+// WRONG: an installation that has logged into both Z.ai plans holds
+// `builtin:zai-coding-plan` and `builtin:zai-start-plan` under the SAME name,
+// "Z.ai - Coding Plan", and the BigModel start plan arrives as
+// "BigModel- Coding Plan". A model list that took those names verbatim offered
+// two rows that read identically and resumed different plans.
+//
+// The ids are the CLI's own constants (`gs` in its bundle: the Z.ai and BigModel
+// families crossed with the API-key, Coding Plan and Start Plan kinds), so this
+// table can be exact about which provider each one IS. Every other provider id
+// -- one the user added -- keeps the name the user gave it.
+var zcodeBuiltinProviderLabels = map[string]string{
+	"builtin:zai":                  "Z.ai - API Key",
+	"builtin:zai-coding-plan":      "Z.ai - Coding Plan",
+	"builtin:zai-start-plan":       "Z.ai - Start Plan",
+	"builtin:bigmodel":             "BigModel - API Key",
+	"builtin:bigmodel-coding-plan": "BigModel - Coding Plan",
+	"builtin:bigmodel-start-plan":  "BigModel - Start Plan",
+}
+
+// zcodeProviderLabel names one provider, correcting the CLI's own built-ins.
+//
+// ONE label serves both the registry push and LeapMux's catalog. The registry's
+// copy is display-only -- the app-server resolves a model by the composite
+// `providerID/modelID`, never by a label -- so a second, uncorrected spelling
+// would only be a copy that can disagree with what the user sees.
+func zcodeProviderLabel(providerID, configuredName string) string {
+	if label, ok := zcodeBuiltinProviderLabels[providerID]; ok {
+		return label
+	}
+	return nameOrID(configuredName, providerID)
+}
+
 // zcodeRegistryModelFor translates one configured model into its registry entry.
 func zcodeRegistryModelFor(modelID string, model zcodeConfigModel) zcodeRegistryModel {
 	entry := zcodeRegistryModel{
 		ModelID: modelID,
-		Label:   model.Name,
+		Label:   zcodeModelName(modelID, model),
 	}
 	if model.Limit != nil {
 		entry.ContextWindow = model.Limit.Context
@@ -517,6 +570,18 @@ const (
 	zcodeModalityVideo = "video"
 )
 
+// zcodeModelDisplayName joins a model's name to the provider that serves it.
+//
+// A provider label is never empty in practice -- zcodeProviderLabel falls back
+// to the provider id -- so the guard is for a caller that has no provider to
+// name at all, and it produces the bare model name rather than empty brackets.
+func zcodeModelDisplayName(modelName, providerLabel string) string {
+	if providerLabel == "" {
+		return modelName
+	}
+	return fmt.Sprintf("%s (%s)", modelName, providerLabel)
+}
+
 // zcodeModelInfo projects one configured model into LeapMux's catalog entry.
 //
 // The thought levels come from the model's own `reasoning.variants`: they are
@@ -524,25 +589,36 @@ const (
 // so a hardcoded list would offer a level the app-server refuses.
 func zcodeModelInfo(composite, providerLabel, modelID string, model zcodeConfigModel) *ModelInfo {
 	info := &ModelInfo{
-		Id:          composite,
-		DisplayName: nameOrID(model.Name, modelID),
-		// The SAME model id is offered by more than one ZCode provider (a coding plan
-		// and a plain API key reach the same GLM model), so the provider is what tells
-		// two otherwise identical rows apart. Its configured display name reads far
-		// better than the `builtin:...` id underneath it.
-		Description: providerLabel,
+		Id: composite,
+		// The provider is PART OF THE NAME, not a description beside it. The same
+		// model id is offered by more than one ZCode provider -- a coding plan, a
+		// start plan and a plain API key all reach GLM-5.3-Flash -- and a
+		// description renders as a tooltip, so the list showed two or three rows
+		// that read identically and resumed different plans. Which one a row spends
+		// is the first thing the reader needs, so it goes where a reader sees it.
+		//
+		// Every row carries it, including an installation that configured one
+		// provider: which provider a model runs on is a fact about the model, not
+		// something that becomes true once a second provider exists, and a suffix
+		// that appears the day a user adds one reads as a different model.
+		DisplayName: zcodeModelDisplayName(zcodeModelName(modelID, model), providerLabel),
 	}
 	if model.Limit != nil {
 		info.ContextWindow = model.Limit.Context
 	}
 	if r := model.Reasoning; r != nil && r.Enabled && len(r.Variants) > 0 {
 		efforts := make([]*EffortInfo, 0, len(r.Variants)+1)
-		// Auto is LeapMux's sentinel for "do not send setThoughtLevel at all", so a
-		// user can keep whatever default the app-server resolves for the model.
-		efforts = append(efforts, zcodeAutoEffort)
 		for _, v := range r.Variants {
 			efforts = append(efforts, zcodeEffortTier(v, "", ""))
 		}
+		// Strongest first, because `config.json` states the variants in no order at
+		// all: ZCode ships GLM-5.3 as `["low", "max", "high"]`, and a menu built in
+		// that order led with the weakest level. See sortEffortsByStrength.
+		sortEffortsByStrength(efforts)
+		// Auto is LeapMux's sentinel for "do not send setThoughtLevel at all", so a
+		// user can keep whatever default the app-server resolves for the model. It
+		// leads the list, and it is not a strength, so it joins AFTER the sort.
+		efforts = append([]*EffortInfo{zcodeAutoEffort}, efforts...)
 		info.SupportedEfforts = efforts
 		info.DefaultEffort = r.DefaultVariant
 		if info.DefaultEffort == "" {

--- a/backend/internal/worker/agent/zcode_config.go
+++ b/backend/internal/worker/agent/zcode_config.go
@@ -401,6 +401,16 @@ func buildZCodeCatalog(cfg zcodeConfigFile) (zcodeCatalog, []zcodeProviderSkip) 
 	// the user inside an error string.
 	sort.Slice(skipped, func(i, j int) bool { return skipped[i].ProviderID < skipped[j].ProviderID })
 
+	// Which configured names more than one candidate carries. A name that names
+	// two providers names neither, so zcodeProviderLabel replaces it with the
+	// label the id composes -- see it for the CLI defect this repairs.
+	nameCount := map[string]int{}
+	for _, c := range candidates {
+		if name := strings.TrimSpace(c.provider.Name); name != "" {
+			nameCount[name]++
+		}
+	}
+
 	catalog := zcodeCatalog{
 		modalities: map[string][]string{},
 		refs:       map[string]zcodeModelRef{},
@@ -412,7 +422,7 @@ func buildZCodeCatalog(cfg zcodeConfigFile) (zcodeCatalog, []zcodeProviderSkip) 
 			Kind:       kind,
 			APIFormat:  zcodeAPIFormat(c.provider.Kind),
 			BaseURL:    c.baseURL,
-			Label:      zcodeProviderLabel(c.providerID, c.provider.Name),
+			Label:      zcodeProviderLabel(c.providerID, c.provider.Name, nameCount[strings.TrimSpace(c.provider.Name)] > 1),
 			Source:     zcodeRegistrySource(c.provider.Source),
 			APIKey:     &zcodeRegistryAPIKey{Source: zcodeAPIKeySourceInline, Value: c.apiKey},
 			// An empty slice, never nil: the app-server's schema requires the
@@ -480,47 +490,144 @@ func zcodeModelOrder(models map[string]zcodeConfigModel) []string {
 //
 // A name that differs by more than case DOES carry something the id cannot, so
 // it wins. That is the same rule zcodeEffortTier applies to a level's label.
+//
+// The "no name given" half routes through nameOrID, which every other naming
+// helper in this file already uses, so this states ONE added rule on top of the
+// shared one rather than a second answer to the same question.
 func zcodeModelName(modelID string, model zcodeConfigModel) string {
-	name := strings.TrimSpace(model.Name)
-	if name == "" || strings.EqualFold(name, modelID) {
+	name := nameOrID(model.Name, modelID)
+	if strings.EqualFold(name, modelID) {
 		return modelID
 	}
 	return name
 }
 
-// zcodeBuiltinProviderLabels names the providers the ZCode CLI creates itself.
+// zcodeBuiltinPrefix marks a provider the ZCode CLI created itself. The CLI
+// composes such an id as `builtin:<family>[-<kind>]`.
+const zcodeBuiltinPrefix = "builtin:"
+
+// zcodeProviderFamilies and zcodeProviderPlans decompose a built-in provider id.
 //
-// The CLI writes these six entries into `config.json`, and it writes their names
-// WRONG: an installation that has logged into both Z.ai plans holds
-// `builtin:zai-coding-plan` and `builtin:zai-start-plan` under the SAME name,
-// "Z.ai - Coding Plan", and the BigModel start plan arrives as
-// "BigModel- Coding Plan". A model list that took those names verbatim offered
-// two rows that read identically and resumed different plans.
+// The CLI's own ids are that cross product (`gs` in its bundle: the Z.ai and
+// BigModel families crossed with the API-key, Coding Plan and Start Plan kinds),
+// so LeapMux states the two axes rather than the six products they make. A
+// seventh built-in the CLI adds -- `builtin:zai-pro-plan` -- is then named
+// correctly with no change here, where a table of six literals would have let it
+// fall through to the CLI's own name.
 //
-// The ids are the CLI's own constants (`gs` in its bundle: the Z.ai and BigModel
-// families crossed with the API-key, Coding Plan and Start Plan kinds), so this
-// table can be exact about which provider each one IS. Every other provider id
-// -- one the user added -- keeps the name the user gave it.
-var zcodeBuiltinProviderLabels = map[string]string{
-	"builtin:zai":                  "Z.ai - API Key",
-	"builtin:zai-coding-plan":      "Z.ai - Coding Plan",
-	"builtin:zai-start-plan":       "Z.ai - Start Plan",
-	"builtin:bigmodel":             "BigModel - API Key",
-	"builtin:bigmodel-coding-plan": "BigModel - Coding Plan",
-	"builtin:bigmodel-start-plan":  "BigModel - Start Plan",
+// Neither axis is derivable from its id: "Z.ai" is not a case fold of `zai`, and
+// "API Key" is not a fold of the empty suffix.
+var (
+	zcodeProviderFamilies = map[string]string{
+		"zai":      "Z.ai",
+		"bigmodel": "BigModel",
+	}
+	zcodeProviderPlans = map[string]string{
+		"":             "API Key",
+		"coding-plan":  "Coding Plan",
+		"start-plan":   "Start Plan",
+		"pro-plan":     "Pro Plan",
+		"lite-plan":    "Lite Plan",
+		"max-plan":     "Max Plan",
+		"free-plan":    "Free Plan",
+		"api-key":      "API Key",
+		"subscription": "Subscription",
+	}
+)
+
+// zcodeBuiltinProviderLabel composes the display label for a provider the CLI
+// created, or "" for an id it did not.
+//
+// An unknown FAMILY returns "": LeapMux has nothing to call it, so the CLI's own
+// name is still the best answer. An unknown PLAN is title-cased from its own
+// suffix, which reads correctly for anything the CLI is likely to add.
+func zcodeBuiltinProviderLabel(providerID string) string {
+	rest, ok := strings.CutPrefix(providerID, zcodeBuiltinPrefix)
+	if !ok {
+		return ""
+	}
+	family, plan, _ := strings.Cut(rest, "-")
+	familyLabel, known := zcodeProviderFamilies[family]
+	if !known {
+		return ""
+	}
+	planLabel, known := zcodeProviderPlans[plan]
+	if !known {
+		planLabel = titleCaseHyphenated(plan)
+	}
+	return familyLabel + " - " + planLabel
 }
 
-// zcodeProviderLabel names one provider, correcting the CLI's own built-ins.
+// titleCaseHyphenated turns `pro-plan` into `Pro Plan`.
+func titleCaseHyphenated(s string) string {
+	words := strings.Split(s, "-")
+	for i, w := range words {
+		words[i] = capitalizeFirst(w)
+	}
+	return strings.Join(words, " ")
+}
+
+// zcodeProviderLabel returns the display label for one provider, correcting the
+// CLI's own built-ins where their names are unusable.
+//
+// The CLI writes a built-in's name WRONG in two ways. An installation logged
+// into both Z.ai plans holds `builtin:zai-coding-plan` and
+// `builtin:zai-start-plan` under the SAME name, "Z.ai - Coding Plan"; and the
+// BigModel start plan arrives as "BigModel- Coding Plan", which is simply
+// incorrect. A model list that took those verbatim offered rows that read
+// identically and resumed different plans.
+//
+// `collides` says another enabled provider carries this same name, which is the
+// first of those two. The composed label ALSO wins when the id's own plan
+// disagrees with the configured name, which is the second: the CLI names the
+// plan in the id, and an id that says `start-plan` beside a name that says
+// "Coding Plan" cannot both be right, and the id is the one the CLI resolves by.
+//
+// Otherwise the configured name stands. A user who renames `builtin:zai` to
+// "Work account" in their own `config.json` means it, and LeapMux never writes
+// that file -- so discarding the rename would leave a user with no way to tell
+// two accounts apart and no message saying why.
 //
 // ONE label serves both the registry push and LeapMux's catalog. The registry's
 // copy is display-only -- the app-server resolves a model by the composite
 // `providerID/modelID`, never by a label -- so a second, uncorrected spelling
 // would only be a copy that can disagree with what the user sees.
-func zcodeProviderLabel(providerID, configuredName string) string {
-	if label, ok := zcodeBuiltinProviderLabels[providerID]; ok {
-		return label
+func zcodeProviderLabel(providerID, configuredName string, collides bool) string {
+	builtin := zcodeBuiltinProviderLabel(providerID)
+	if builtin == "" {
+		return nameOrID(configuredName, providerID)
 	}
-	return nameOrID(configuredName, providerID)
+	name := strings.TrimSpace(configuredName)
+	if name == "" || collides || zcodeNameContradictsPlan(providerID, name) {
+		return builtin
+	}
+	return name
+}
+
+// zcodeNameContradictsPlan reports that a built-in's configured name claims a
+// DIFFERENT plan from the one its id states.
+//
+// The check is on the plan words alone, so a genuine rename ("Work account")
+// keeps its name: it claims no plan at all. It catches exactly the CLI's own
+// defect, where `builtin:bigmodel-start-plan` arrives named "BigModel- Coding
+// Plan".
+func zcodeNameContradictsPlan(providerID, configuredName string) bool {
+	rest, ok := strings.CutPrefix(providerID, zcodeBuiltinPrefix)
+	if !ok {
+		return false
+	}
+	_, plan, _ := strings.Cut(rest, "-")
+	mine := zcodeProviderPlans[plan]
+	lower := strings.ToLower(configuredName)
+	for suffix, label := range zcodeProviderPlans {
+		if suffix == plan || label == mine {
+			continue
+		}
+		if strings.Contains(lower, strings.ToLower(label)) {
+			return true
+		}
+	}
+	return false
 }
 
 // zcodeRegistryModelFor translates one configured model into its registry entry.
@@ -574,7 +681,7 @@ const (
 //
 // A provider label is never empty in practice -- zcodeProviderLabel falls back
 // to the provider id -- so the guard is for a caller that has no provider to
-// name at all, and it produces the bare model name rather than empty brackets.
+// label at all, and it produces the bare model name rather than empty brackets.
 func zcodeModelDisplayName(modelName, providerLabel string) string {
 	if providerLabel == "" {
 		return modelName
@@ -607,19 +714,16 @@ func zcodeModelInfo(composite, providerLabel, modelID string, model zcodeConfigM
 		info.ContextWindow = model.Limit.Context
 	}
 	if r := model.Reasoning; r != nil && r.Enabled && len(r.Variants) > 0 {
-		efforts := make([]*EffortInfo, 0, len(r.Variants)+1)
+		efforts := make([]*EffortInfo, 0, len(r.Variants))
 		for _, v := range r.Variants {
 			efforts = append(efforts, zcodeEffortTier(v, "", ""))
 		}
-		// Strongest first, because `config.json` states the variants in no order at
-		// all: ZCode ships GLM-5.3 as `["low", "max", "high"]`, and a menu built in
-		// that order led with the weakest level. See sortEffortsByStrength.
-		sortEffortsByStrength(efforts)
-		// Auto is LeapMux's sentinel for "do not send setThoughtLevel at all", so a
-		// user can keep whatever default the app-server resolves for the model. It
-		// leads the list, and it is not a strength, so it joins AFTER the sort.
-		efforts = append([]*EffortInfo{zcodeAutoEffort}, efforts...)
-		info.SupportedEfforts = efforts
+		// Auto first -- LeapMux's sentinel for "do not send setThoughtLevel at
+		// all", so a user can keep whatever default the app-server resolves --
+		// then the variants strongest first, because `config.json` states them in
+		// no order at all: ZCode ships GLM-5.3 as `["low", "max", "high"]`, and a
+		// menu built in that order led with the weakest level.
+		info.SupportedEfforts = zcodeEffortsWithAuto(efforts)
 		info.DefaultEffort = r.DefaultVariant
 		if info.DefaultEffort == "" {
 			info.DefaultEffort = EffortAuto

--- a/backend/internal/worker/agent/zcode_config_test.go
+++ b/backend/internal/worker/agent/zcode_config_test.go
@@ -213,10 +213,7 @@ func TestZCodeModelInfo_OrdersAToggleModelAndNamesItByItsID(t *testing.T) {
 	require.Len(t, catalog.Models, 1)
 	model := catalog.Models[0]
 	assert.Equal(t, "GLM-5-Turbo (Z.ai - API Key)", model.DisplayName)
-	efforts := []string{}
-	for _, e := range model.SupportedEfforts {
-		efforts = append(efforts, e.GetId())
-	}
+	efforts := effortIDs(model.SupportedEfforts)
 	assert.Equal(t, []string{EffortAuto, "enabled", "off"}, efforts,
 		"thinking on must not sort under thinking off")
 	assert.Equal(t, "enabled", model.DefaultEffort)
@@ -252,16 +249,17 @@ func TestZCodeModelInfo_EffortsComeFromTheModelsOwnVariants(t *testing.T) {
 
 	reasoning := byID["builtin:zai/GLM-5.3"]
 	require.NotNil(t, reasoning)
-	assert.Equal(t, "GLM-5.3 (Z.ai - API Key)", reasoning.DisplayName,
+	// "Z.ai" is what this provider is CONFIGURED as, it names no other provider,
+	// and it claims no plan its id contradicts -- so it stands. LeapMux composes
+	// a label from the id only where the configured name is unusable; see
+	// TestZCodeProviderLabel_CorrectsTheCLIsOwnBuiltins.
+	assert.Equal(t, "GLM-5.3 (Z.ai)", reasoning.DisplayName,
 		"the provider is part of the NAME: three ZCode providers offer this model id, and a description renders only as a tooltip")
 	assert.Empty(t, reasoning.Description,
 		"the provider moved into the name, so a description repeating it would be a tooltip that says the label again")
 	assert.Equal(t, int64(200000), reasoning.GetContextWindow())
 	assert.Equal(t, "high", reasoning.DefaultEffort)
-	efforts := []string{}
-	for _, e := range reasoning.SupportedEfforts {
-		efforts = append(efforts, e.GetId())
-	}
+	efforts := effortIDs(reasoning.SupportedEfforts)
 	assert.Equal(t, []string{EffortAuto, "max", "high", "low"}, efforts,
 		"auto leads, then the model's own variants strongest first -- config order states no ladder")
 
@@ -270,7 +268,7 @@ func TestZCodeModelInfo_EffortsComeFromTheModelsOwnVariants(t *testing.T) {
 	plain := byID["builtin:zai/GLM-5.3-Flash"]
 	require.NotNil(t, plain)
 	assert.Empty(t, plain.SupportedEfforts)
-	assert.Equal(t, "GLM-5.3 Flash (Z.ai - API Key)", plain.DisplayName)
+	assert.Equal(t, "GLM-5.3 Flash (Z.ai)", plain.DisplayName)
 }
 
 // ZCode ships GLM-5-Turbo with `"name": "glm-5-turbo"` while its id -- the
@@ -288,36 +286,103 @@ func TestZCodeModelName_PrefersTheIDOverACaseVariantOfIt(t *testing.T) {
 	assert.Equal(t, "GLM-5.3 Flash", zcodeModelName("GLM-5.3-Flash", zcodeConfigModel{Name: "GLM-5.3 Flash"}))
 }
 
-// The CLI writes these six providers itself, and it writes two of their names
-// wrong: an installation logged into both Z.ai plans holds the coding plan and
-// the start plan under one name, so the model list offered two rows that read
-// identically and resumed different plans.
+// The CLI creates these providers itself and writes two of their names wrong:
+// an installation logged into both Z.ai plans holds the coding plan and the
+// start plan under ONE name, so the model list offered two rows that read
+// identically and resumed different plans; and the BigModel start plan arrives
+// named for the coding plan.
 func TestZCodeProviderLabel_CorrectsTheCLIsOwnBuiltins(t *testing.T) {
 	t.Parallel()
 
+	// A name two providers share names neither of them.
 	assert.Equal(t, "Z.ai - Start Plan",
-		zcodeProviderLabel("builtin:zai-start-plan", "Z.ai - Coding Plan"))
+		zcodeProviderLabel("builtin:zai-start-plan", "Z.ai - Coding Plan", true))
 	assert.Equal(t, "Z.ai - Coding Plan",
-		zcodeProviderLabel("builtin:zai-coding-plan", "Z.ai - Coding Plan"))
+		zcodeProviderLabel("builtin:zai-coding-plan", "Z.ai - Coding Plan", true))
+	// A name that claims a plan the id contradicts is wrong even when it is
+	// unique -- an installation holding only the BigModel start plan hits this.
 	assert.Equal(t, "BigModel - Start Plan",
-		zcodeProviderLabel("builtin:bigmodel-start-plan", "BigModel- Coding Plan"))
-	assert.Equal(t, "Z.ai - API Key", zcodeProviderLabel("builtin:zai", ""))
+		zcodeProviderLabel("builtin:bigmodel-start-plan", "BigModel- Coding Plan", false))
+	assert.Equal(t, "Z.ai - API Key", zcodeProviderLabel("builtin:zai", "", false))
+}
 
-	// A provider the USER added keeps the name the user gave it, and falls back to
-	// its id when it has none.
-	assert.Equal(t, "My Gateway", zcodeProviderLabel("my-gateway", "My Gateway"))
-	assert.Equal(t, "my-gateway", zcodeProviderLabel("my-gateway", "   "))
+// The user's own edit of a built-in's name STANDS. LeapMux never writes
+// `config.json`, so a rename is deliberate -- and discarding it leaves a user
+// holding two accounts with no way to tell them apart and no message saying why.
+func TestZCodeProviderLabel_KeepsARenamedBuiltin(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "Work account", zcodeProviderLabel("builtin:zai", "Work account", false))
+	assert.Equal(t, "Personal", zcodeProviderLabel("builtin:zai-coding-plan", "Personal", false))
+	// Until it collides, at which point it names neither provider.
+	assert.Equal(t, "Z.ai - Coding Plan", zcodeProviderLabel("builtin:zai-coding-plan", "Work account", true))
+}
+
+// The ids are a CROSS PRODUCT the CLI composes, so LeapMux states the two axes
+// rather than the products. A plan the CLI adds later is named from its own
+// suffix instead of falling through to whatever the CLI called it.
+func TestZCodeBuiltinProviderLabel_ComposesTheIDRatherThanListingProducts(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "Z.ai - API Key", zcodeBuiltinProviderLabel("builtin:zai"))
+	assert.Equal(t, "Z.ai - Coding Plan", zcodeBuiltinProviderLabel("builtin:zai-coding-plan"))
+	assert.Equal(t, "BigModel - Start Plan", zcodeBuiltinProviderLabel("builtin:bigmodel-start-plan"))
+	// The seventh built-in, which a table of six literals would have missed.
+	assert.Equal(t, "Z.ai - Pro Plan", zcodeBuiltinProviderLabel("builtin:zai-pro-plan"))
+	assert.Equal(t, "BigModel - Team Plan", zcodeBuiltinProviderLabel("builtin:bigmodel-team-plan"))
+
+	// A family LeapMux does not know has no label to compose, so the CLI's own
+	// name is still the best answer.
+	assert.Empty(t, zcodeBuiltinProviderLabel("builtin:someone-else"))
+	assert.Empty(t, zcodeBuiltinProviderLabel("my-gateway"))
+}
+
+// A provider the USER added keeps the name the user gave it, and falls back to
+// its id when it has none.
+func TestZCodeProviderLabel_LeavesAUserAddedProviderAlone(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "My Gateway", zcodeProviderLabel("my-gateway", "My Gateway", false))
+	assert.Equal(t, "my-gateway", zcodeProviderLabel("my-gateway", "   ", false))
+	// Even a collision leaves it alone: LeapMux has no better name for it.
+	assert.Equal(t, "My Gateway", zcodeProviderLabel("my-gateway", "My Gateway", true))
 }
 
 // The provider is part of the model's NAME because three ZCode providers offer
 // the same model id, and a description renders only as a tooltip.
-func TestZCodeModelDisplayName_NamesTheProviderThatServesTheModel(t *testing.T) {
+func TestZCodeModelDisplayName_LabelsTheProviderThatServesTheModel(t *testing.T) {
 	t.Parallel()
 
 	assert.Equal(t, "GLM-5.3-Flash (Z.ai - Start Plan)",
 		zcodeModelDisplayName("GLM-5.3-Flash", "Z.ai - Start Plan"))
 	assert.Equal(t, "GLM-5.3-Flash", zcodeModelDisplayName("GLM-5.3-Flash", ""),
 		"no provider to name draws no empty brackets")
+}
+
+// The user's rename survives the whole catalog build, not just the unit below
+// it. This is the half the collision test cannot show: `buildZCodeCatalog`
+// decides "collides" from every candidate's name, so a rename that names one
+// provider only has to reach the row.
+func TestBuildZCodeCatalog_KeepsAUserRenamedBuiltin(t *testing.T) {
+	t.Parallel()
+
+	catalog := zcodeTestCatalog(t, `{
+      "provider": {
+        "builtin:zai": {"name": "Work account", "kind": "anthropic", "enabled": true,
+          "options": {"apiKey": "k"}, "models": {"GLM-5.3-Flash": {}}},
+        "builtin:zai-coding-plan": {"name": "Z.ai - Coding Plan", "kind": "anthropic", "enabled": true,
+          "options": {"apiKey": "k"}, "models": {"GLM-5.3-Flash": {}}}
+      }
+    }`)
+
+	names := []string{}
+	for _, m := range catalog.Models {
+		names = append(names, m.DisplayName)
+	}
+	assert.ElementsMatch(t, []string{
+		"GLM-5.3-Flash (Work account)",
+		"GLM-5.3-Flash (Z.ai - Coding Plan)",
+	}, names, "a rename that names ONE provider is the user's own and must stand")
 }
 
 // The two plans a user is most likely to hold at once, end to end: the rows must

--- a/backend/internal/worker/agent/zcode_config_test.go
+++ b/backend/internal/worker/agent/zcode_config_test.go
@@ -184,6 +184,44 @@ func TestZCodeRegistryModelFor_ReasoningAndModalityFlags(t *testing.T) {
 	assert.True(t, entry.SupportsVideo)
 }
 
+// The registry's label and the catalog's name are ONE spelling, so the push and
+// what the user sees cannot disagree. Most configured models name themselves not
+// at all, and the id -- never the empty string -- is what stands in.
+func TestZCodeRegistryModelFor_LabelsTheModelTheWayTheCatalogNamesIt(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "GLM-5.3", zcodeRegistryModelFor("GLM-5.3", zcodeConfigModel{}).Label,
+		"a model with no configured name pushed an EMPTY label before")
+	assert.Equal(t, "GLM-5-Turbo", zcodeRegistryModelFor("GLM-5-Turbo", zcodeConfigModel{Name: "glm-5-turbo"}).Label)
+	assert.Equal(t, "GLM-5.3 Flash", zcodeRegistryModelFor("GLM-5.3-Flash", zcodeConfigModel{Name: "GLM-5.3 Flash"}).Label)
+}
+
+// GLM-5-Turbo is the model that offers a TOGGLE rather than a ladder, and the
+// one whose configured name is a lowercase copy of its id. Both rules meet on
+// this one row, so the row is checked whole.
+func TestZCodeModelInfo_OrdersAToggleModelAndNamesItByItsID(t *testing.T) {
+	t.Parallel()
+
+	catalog := zcodeTestCatalog(t, `{
+      "provider": {
+        "builtin:zai": {"kind": "anthropic", "enabled": true, "options": {"apiKey": "k"},
+          "models": {"GLM-5-Turbo": {"name": "glm-5-turbo",
+            "reasoning": {"enabled": true, "variants": ["enabled", "off"], "defaultVariant": "enabled"}}}}
+      }
+    }`)
+
+	require.Len(t, catalog.Models, 1)
+	model := catalog.Models[0]
+	assert.Equal(t, "GLM-5-Turbo (Z.ai - API Key)", model.DisplayName)
+	efforts := []string{}
+	for _, e := range model.SupportedEfforts {
+		efforts = append(efforts, e.GetId())
+	}
+	assert.Equal(t, []string{EffortAuto, "enabled", "off"}, efforts,
+		"thinking on must not sort under thinking off")
+	assert.Equal(t, "enabled", model.DefaultEffort)
+}
+
 func TestZCodeRegistryModelFor_ReasoningDisabledOrEmptyIsOmitted(t *testing.T) {
 	t.Parallel()
 
@@ -214,24 +252,104 @@ func TestZCodeModelInfo_EffortsComeFromTheModelsOwnVariants(t *testing.T) {
 
 	reasoning := byID["builtin:zai/GLM-5.3"]
 	require.NotNil(t, reasoning)
-	assert.Equal(t, "GLM-5.3", reasoning.DisplayName)
-	assert.Equal(t, "Z.ai", reasoning.Description,
-		"the provider's configured display name distinguishes two providers offering the same model id")
+	assert.Equal(t, "GLM-5.3 (Z.ai - API Key)", reasoning.DisplayName,
+		"the provider is part of the NAME: three ZCode providers offer this model id, and a description renders only as a tooltip")
+	assert.Empty(t, reasoning.Description,
+		"the provider moved into the name, so a description repeating it would be a tooltip that says the label again")
 	assert.Equal(t, int64(200000), reasoning.GetContextWindow())
 	assert.Equal(t, "high", reasoning.DefaultEffort)
 	efforts := []string{}
 	for _, e := range reasoning.SupportedEfforts {
 		efforts = append(efforts, e.GetId())
 	}
-	assert.Equal(t, []string{EffortAuto, "low", "high", "max"}, efforts,
-		"auto leads, then the model's own variants in their configured order")
+	assert.Equal(t, []string{EffortAuto, "max", "high", "low"}, efforts,
+		"auto leads, then the model's own variants strongest first -- config order states no ladder")
 
 	// A model with no reasoning block declares no effort axis at all, rather than a
 	// hardcoded low/medium/high the app-server would refuse.
 	plain := byID["builtin:zai/GLM-5.3-Flash"]
 	require.NotNil(t, plain)
 	assert.Empty(t, plain.SupportedEfforts)
-	assert.Equal(t, "GLM-5.3 Flash", plain.DisplayName)
+	assert.Equal(t, "GLM-5.3 Flash (Z.ai - API Key)", plain.DisplayName)
+}
+
+// ZCode ships GLM-5-Turbo with `"name": "glm-5-turbo"` while its id -- the
+// config key, and the spelling in `session.updated.model` -- is `GLM-5-Turbo`. A
+// lowercase copy of the id is not a name.
+func TestZCodeModelName_PrefersTheIDOverACaseVariantOfIt(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "GLM-5-Turbo", zcodeModelName("GLM-5-Turbo", zcodeConfigModel{Name: "glm-5-turbo"}))
+	assert.Equal(t, "GLM-5-Turbo", zcodeModelName("GLM-5-Turbo", zcodeConfigModel{Name: "  GLM-5-TURBO  "}))
+	assert.Equal(t, "GLM-5.3", zcodeModelName("GLM-5.3", zcodeConfigModel{}),
+		"no name at all leaves the id")
+
+	// A name that differs by MORE than case carries something the id cannot.
+	assert.Equal(t, "GLM-5.3 Flash", zcodeModelName("GLM-5.3-Flash", zcodeConfigModel{Name: "GLM-5.3 Flash"}))
+}
+
+// The CLI writes these six providers itself, and it writes two of their names
+// wrong: an installation logged into both Z.ai plans holds the coding plan and
+// the start plan under one name, so the model list offered two rows that read
+// identically and resumed different plans.
+func TestZCodeProviderLabel_CorrectsTheCLIsOwnBuiltins(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "Z.ai - Start Plan",
+		zcodeProviderLabel("builtin:zai-start-plan", "Z.ai - Coding Plan"))
+	assert.Equal(t, "Z.ai - Coding Plan",
+		zcodeProviderLabel("builtin:zai-coding-plan", "Z.ai - Coding Plan"))
+	assert.Equal(t, "BigModel - Start Plan",
+		zcodeProviderLabel("builtin:bigmodel-start-plan", "BigModel- Coding Plan"))
+	assert.Equal(t, "Z.ai - API Key", zcodeProviderLabel("builtin:zai", ""))
+
+	// A provider the USER added keeps the name the user gave it, and falls back to
+	// its id when it has none.
+	assert.Equal(t, "My Gateway", zcodeProviderLabel("my-gateway", "My Gateway"))
+	assert.Equal(t, "my-gateway", zcodeProviderLabel("my-gateway", "   "))
+}
+
+// The provider is part of the model's NAME because three ZCode providers offer
+// the same model id, and a description renders only as a tooltip.
+func TestZCodeModelDisplayName_NamesTheProviderThatServesTheModel(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "GLM-5.3-Flash (Z.ai - Start Plan)",
+		zcodeModelDisplayName("GLM-5.3-Flash", "Z.ai - Start Plan"))
+	assert.Equal(t, "GLM-5.3-Flash", zcodeModelDisplayName("GLM-5.3-Flash", ""),
+		"no provider to name draws no empty brackets")
+}
+
+// The two plans a user is most likely to hold at once, end to end: the rows must
+// read apart, and the start plan must not claim to be the coding plan.
+func TestBuildZCodeCatalog_TellsTwoBuiltinPlansApart(t *testing.T) {
+	t.Parallel()
+
+	catalog := zcodeTestCatalog(t, `{
+      "provider": {
+        "builtin:zai-coding-plan": {"name": "Z.ai - Coding Plan", "kind": "anthropic", "enabled": true,
+          "options": {"apiKey": "k"}, "models": {"GLM-5.3-Flash": {}}},
+        "builtin:zai-start-plan": {"name": "Z.ai - Coding Plan", "kind": "anthropic", "enabled": true,
+          "options": {"apiKey": "k"}, "models": {"GLM-5.3-Flash": {}}}
+      }
+    }`)
+
+	names := []string{}
+	for _, m := range catalog.Models {
+		names = append(names, m.DisplayName)
+	}
+	assert.ElementsMatch(t, []string{
+		"GLM-5.3-Flash (Z.ai - Coding Plan)",
+		"GLM-5.3-Flash (Z.ai - Start Plan)",
+	}, names)
+
+	// The registry push carries the corrected label too: one spelling, so the two
+	// cannot drift.
+	labels := []string{}
+	for _, p := range catalog.Providers {
+		labels = append(labels, p.Label)
+	}
+	assert.ElementsMatch(t, []string{"Z.ai - Coding Plan", "Z.ai - Start Plan"}, labels)
 }
 
 func TestZCodeModelInfo_DefaultEffortFallsBackToAuto(t *testing.T) {

--- a/backend/internal/worker/agent/zcode_settings.go
+++ b/backend/internal/worker/agent/zcode_settings.go
@@ -191,10 +191,7 @@ func (a *zcodeAgent) applySettingsSnapshotLocked(snap *zcodeSettingsSnapshot) {
 		}
 	}
 	if tl := snap.ThoughtLevel; tl != nil {
-		// Auto leads the list: it is LeapMux's "send no level" sentinel, and every
-		// model accepts it because it produces no RPC at all.
 		levels := make([]*EffortInfo, 0, len(tl.Available)+1)
-		levels = append(levels, zcodeAutoEffort)
 		available := make(map[string]bool, len(tl.Available))
 		for _, l := range tl.Available {
 			if l.Value == "" {
@@ -203,6 +200,16 @@ func (a *zcodeAgent) applySettingsSnapshotLocked(snap *zcodeSettingsSnapshot) {
 			available[l.Value] = true
 			levels = append(levels, zcodeEffortTier(l.Value, l.Label, l.Description))
 		}
+		// Strongest first, exactly as the configured catalog orders them
+		// (zcodeModelInfo). The app-server reports the levels in the order the
+		// model's own configuration lists them, which is the order this replaces --
+		// so without the same sort here the menu reordered itself the moment the
+		// agent reported its first snapshot.
+		sortEffortsByStrength(levels)
+		// Auto leads the list: it is LeapMux's "send no level" sentinel, and every
+		// model accepts it because it produces no RPC at all. It is not a strength,
+		// so it joins after the sort.
+		levels = append([]*EffortInfo{zcodeAutoEffort}, levels...)
 		if !tl.Enabled || len(available) == 0 {
 			// The model offers no thought level at all. Auto alone keeps the axis
 			// selectable-but-inert rather than showing a level the model would refuse.

--- a/backend/internal/worker/agent/zcode_settings.go
+++ b/backend/internal/worker/agent/zcode_settings.go
@@ -49,6 +49,29 @@ var zcodeAutoEffort = &EffortInfo{
 	Description: "Use ZCode's default thought level for the model",
 }
 
+// zcodeEffortsWithAuto orders a model's thought levels for the menu: Auto first,
+// then the rest strongest first. It sorts `levels` in place and returns the new
+// slice.
+//
+// One function for the two places that build such a list -- the configured
+// catalog (zcodeModelInfo) and the live snapshot that REPLACES it for the
+// running model (applySettingsSnapshotLocked). Built separately, the two ordered
+// the same levels differently and the menu reordered itself under the reader the
+// moment the first snapshot landed.
+//
+// It also discharges sortEffortsDescending's one caller obligation. Auto is not
+// a strength -- it means "send no level at all" -- so it must not reach the
+// sort, and putting it back afterwards is the step a caller can forget.
+func zcodeEffortsWithAuto(levels []*EffortInfo) []*EffortInfo {
+	sortEffortsDescending(levels)
+	// A fresh slice with room for both, rather than a prepend onto the caller's:
+	// `append` to a one-element literal reallocates anyway, and a caller sized
+	// for the levels alone.
+	out := make([]*EffortInfo, 0, len(levels)+1)
+	out = append(out, zcodeAutoEffort)
+	return append(out, levels...)
+}
+
 // zcodeEffortTier builds the display entry for one ZCode thought level.
 //
 // ZCode spells a level as a bare id ("low", "max", "enabled") and repeats that id as
@@ -191,7 +214,23 @@ func (a *zcodeAgent) applySettingsSnapshotLocked(snap *zcodeSettingsSnapshot) {
 		}
 	}
 	if tl := snap.ThoughtLevel; tl != nil {
-		levels := make([]*EffortInfo, 0, len(tl.Available)+1)
+		// The model offers no thought level at all. Auto alone keeps the axis
+		// selectable-but-inert rather than showing a level the model would refuse.
+		//
+		// Checked BEFORE the list is built, because this branch discards it: the
+		// build, the sort and the prepend all ran under a.mu for a result nothing
+		// read. The `available` half cannot move up with it -- it counts the
+		// non-empty values, which only the loop knows.
+		offAxis := func() {
+			a.observedThoughtLevels = []*EffortInfo{zcodeAutoEffort}
+			a.observedThoughtDefault = EffortAuto
+			a.thoughtLevel = EffortAuto
+		}
+		if !tl.Enabled {
+			offAxis()
+			return
+		}
+		levels := make([]*EffortInfo, 0, len(tl.Available))
 		available := make(map[string]bool, len(tl.Available))
 		for _, l := range tl.Available {
 			if l.Value == "" {
@@ -200,25 +239,16 @@ func (a *zcodeAgent) applySettingsSnapshotLocked(snap *zcodeSettingsSnapshot) {
 			available[l.Value] = true
 			levels = append(levels, zcodeEffortTier(l.Value, l.Label, l.Description))
 		}
-		// Strongest first, exactly as the configured catalog orders them
-		// (zcodeModelInfo). The app-server reports the levels in the order the
-		// model's own configuration lists them, which is the order this replaces --
-		// so without the same sort here the menu reordered itself the moment the
-		// agent reported its first snapshot.
-		sortEffortsByStrength(levels)
-		// Auto leads the list: it is LeapMux's "send no level" sentinel, and every
-		// model accepts it because it produces no RPC at all. It is not a strength,
-		// so it joins after the sort.
-		levels = append([]*EffortInfo{zcodeAutoEffort}, levels...)
-		if !tl.Enabled || len(available) == 0 {
-			// The model offers no thought level at all. Auto alone keeps the axis
-			// selectable-but-inert rather than showing a level the model would refuse.
-			a.observedThoughtLevels = []*EffortInfo{zcodeAutoEffort}
-			a.observedThoughtDefault = EffortAuto
-			a.thoughtLevel = EffortAuto
+		if len(available) == 0 {
+			offAxis()
 			return
 		}
-		a.observedThoughtLevels = levels
+		// Auto first, then the levels strongest first, exactly as the configured
+		// catalog orders them (zcodeModelInfo). The app-server reports the levels
+		// in the order the model's own configuration lists them, which is the
+		// order this replaces -- so without the same sort the menu reordered
+		// itself the moment the agent reported its first snapshot.
+		a.observedThoughtLevels = zcodeEffortsWithAuto(levels)
 		a.observedThoughtDefault = tl.DefaultLevel
 		if a.observedThoughtDefault == "" {
 			a.observedThoughtDefault = EffortAuto

--- a/backend/internal/worker/agent/zcode_settings_test.go
+++ b/backend/internal/worker/agent/zcode_settings_test.go
@@ -83,7 +83,43 @@ func TestApplySettingsSnapshot_ReadsTheAuthoritativeCurrentFields(t *testing.T) 
 	for _, level := range a.observedThoughtLevels {
 		ids = append(ids, level.GetId())
 	}
-	assert.Equal(t, []string{EffortAuto, "low", "high"}, ids, "auto leads the list as the send-nothing sentinel")
+	assert.Equal(t, []string{EffortAuto, "high", "low"}, ids,
+		"auto leads the list as the send-nothing sentinel, then the levels strongest first -- the same order the configured catalog uses, so the menu does not reorder itself when the first snapshot lands")
+}
+
+// The two lists of levels are built in two places -- the configured catalog
+// (zcodeModelInfo) and this snapshot -- and the second REPLACES the first for the
+// running model. Ordered differently, the menu would reorder itself the moment
+// the agent reported its first snapshot, under a user reading it.
+func TestApplySettingsSnapshot_OrdersTheLevelsLikeTheConfiguredCatalog(t *testing.T) {
+	t.Parallel()
+
+	catalog := zcodeTestCatalog(t, `{
+      "provider": {"builtin:zai": {"kind": "openai", "options": {"apiKey": "k"},
+        "models": {"GLM-5.3": {"reasoning": {"enabled": true, "variants": ["low", "max", "high"]}}}}}
+    }`)
+	require.Len(t, catalog.Models, 1)
+	fromConfig := []string{}
+	for _, level := range catalog.Models[0].SupportedEfforts {
+		fromConfig = append(fromConfig, level.GetId())
+	}
+
+	a := newZCodeTestAgent(t, &recordingControlSink{})
+	// The app-server reports the levels in the model's own configured order, which
+	// is exactly the order that states no ladder.
+	zcodeApplySettings(t, a, `{
+      "thoughtLevel": {"enabled": true, "current": "high",
+                       "available": [{"value":"low"},{"value":"max"},{"value":"high"}]}
+    }`)
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	fromSnapshot := []string{}
+	for _, level := range a.observedThoughtLevels {
+		fromSnapshot = append(fromSnapshot, level.GetId())
+	}
+	assert.Equal(t, []string{EffortAuto, "max", "high", "low"}, fromSnapshot)
+	assert.Equal(t, fromConfig, fromSnapshot, "the live list must not reorder the menu")
 }
 
 // A patch carries only the axes that changed. An absent axis must leave the agent's
@@ -340,7 +376,7 @@ func TestZCodeModelsForUI_OverridesOnlyTheCurrentModelsEfforts(t *testing.T) {
 			for _, e := range m.SupportedEfforts {
 				ids = append(ids, e.GetId())
 			}
-			assert.Equal(t, []string{EffortAuto, "low", "high", "max"}, ids,
+			assert.Equal(t, []string{EffortAuto, "max", "high", "low"}, ids,
 				"the shared catalog entry must not be mutated")
 		}
 	}

--- a/backend/internal/worker/agent/zcode_settings_test.go
+++ b/backend/internal/worker/agent/zcode_settings_test.go
@@ -79,10 +79,7 @@ func TestApplySettingsSnapshot_ReadsTheAuthoritativeCurrentFields(t *testing.T) 
 	assert.Equal(t, "high", a.thoughtLevel)
 	assert.Equal(t, "low", a.observedThoughtDefault)
 
-	ids := []string{}
-	for _, level := range a.observedThoughtLevels {
-		ids = append(ids, level.GetId())
-	}
+	ids := effortIDs(a.observedThoughtLevels)
 	assert.Equal(t, []string{EffortAuto, "high", "low"}, ids,
 		"auto leads the list as the send-nothing sentinel, then the levels strongest first -- the same order the configured catalog uses, so the menu does not reorder itself when the first snapshot lands")
 }
@@ -114,10 +111,7 @@ func TestApplySettingsSnapshot_OrdersTheLevelsLikeTheConfiguredCatalog(t *testin
 
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	fromSnapshot := []string{}
-	for _, level := range a.observedThoughtLevels {
-		fromSnapshot = append(fromSnapshot, level.GetId())
-	}
+	fromSnapshot := effortIDs(a.observedThoughtLevels)
 	assert.Equal(t, []string{EffortAuto, "max", "high", "low"}, fromSnapshot)
 	assert.Equal(t, fromConfig, fromSnapshot, "the live list must not reorder the menu")
 }
@@ -314,10 +308,7 @@ func TestZCodeOptionGroups_ExposesModelThoughtLevelAndMode(t *testing.T) {
 
 	modelGroup := optionids.GroupByID(groups, OptionIDModel)
 	require.NotNil(t, modelGroup)
-	modelIDs := []string{}
-	for _, option := range modelGroup.GetOptions() {
-		modelIDs = append(modelIDs, option.GetId())
-	}
+	modelIDs := effortIDs(modelGroup.GetOptions())
 	assert.Contains(t, modelIDs, "builtin:zai/GLM-5.3")
 	assert.Contains(t, modelIDs, "acme/acme-1")
 	assert.Equal(t, "builtin:zai/GLM-5.3", modelGroup.GetCurrentValue())
@@ -356,10 +347,7 @@ func TestZCodeModelsForUI_OverridesOnlyTheCurrentModelsEfforts(t *testing.T) {
 
 	live := byID["builtin:zai/GLM-5.3"]
 	require.NotNil(t, live)
-	liveIDs := []string{}
-	for _, e := range live.SupportedEfforts {
-		liveIDs = append(liveIDs, e.GetId())
-	}
+	liveIDs := effortIDs(live.SupportedEfforts)
 	assert.Equal(t, []string{EffortAuto, "turbo"}, liveIDs)
 	assert.Equal(t, "turbo", live.DefaultEffort)
 
@@ -372,10 +360,7 @@ func TestZCodeModelsForUI_OverridesOnlyTheCurrentModelsEfforts(t *testing.T) {
 	// fallback the picker shows before an agent runs.
 	for _, m := range a.catalog.Models {
 		if m.GetId() == "builtin:zai/GLM-5.3" {
-			ids := []string{}
-			for _, e := range m.SupportedEfforts {
-				ids = append(ids, e.GetId())
-			}
+			ids := effortIDs(m.SupportedEfforts)
 			assert.Equal(t, []string{EffortAuto, "max", "high", "low"}, ids,
 				"the shared catalog entry must not be mutated")
 		}

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -2883,7 +2883,8 @@ func (svc *Service) resolveResumeSessionID(agentID, currentSessionID string, res
 // An INTERACTIVE caller does not race a startup that is already in flight for
 // the same tab: it waits for that startup and reports its outcome. The wait is
 // what keeps a message sent inside the open path's startup window; see the
-// comment on it below.
+// comment on it below. It is limited by the budget the CLIENT gives the RPC,
+// because every interactive caller holds its response open across it.
 //
 // It takes no context. The startup context is rooted at bgCtx() and created
 // here, because it is the agent PROCESS's lifetime -- the provider builds its
@@ -2907,24 +2908,40 @@ func (svc *Service) ensureAgentRunning(agentID string, preResolvedResumeSessionI
 	// "agent is not running": the user's first message never reaches the CLI
 	// that the open path brings up a second later, and nothing retries it.
 	//
-	// Only an INTERACTIVE caller waits. It holds a user's message and has
-	// nowhere to put it, so the wait is what keeps that message. The resume
-	// sweep has nothing to lose: the startup it would wait for produces the very
-	// process the sweep wants, so skipping is the same outcome sooner -- and a
-	// sweep worker parked here would hold up the shutdown that joins it.
+	// Only an INTERACTIVE caller waits; see startPriority.joinsInFlightStartup.
 	//
 	// Before the lifecycle lock, because the wait is long compared with
 	// everything under it and a CloseAgent for this same tab needs that lock to
 	// tear the startup down. Re-check HasAgent after: a startup that this caller
 	// waited for and that succeeded is exactly the outcome to report.
 	//
+	// The LIMIT is the caller's budget, not the process's. agentStartupTimeout
+	// is what the spawned CLI gets to come up (five minutes by default); the
+	// client gives this RPC roughly 1.5x agentAPITimeout and gives up there, and
+	// every one of these callers holds the response until this returns. Waiting
+	// past that point converts a message this worker DOES deliver into a send
+	// the sender is told failed, under a Retry button that sends it twice. So
+	// the wait ends inside the client's own budget and the caller reports what
+	// it always reported for a startup it cannot join.
+	//
+	// A wait that a CLOSE ended is not an outcome to start a replacement on.
+	// cancelAndClear wakes this waiter as its FIRST teardown step, several
+	// steps before the close stamps closed_at -- so the closed-tab guard below
+	// would still read an open row and this would spawn a process for a tab the
+	// user just closed, which nothing would ever stop.
+	//
 	// The claim below still stands on its own. A startup that begins between
 	// this wait and that claim is refused as before -- a window of microseconds
 	// where there was one of seconds.
-	if priority == interactiveStart {
-		if !svc.AgentStartup.awaitInFlight(agentID, svc.agentStartupTimeout()) {
+	if priority.joinsInFlightStartup() {
+		limit := svc.agentAPITimeout()
+		wait := svc.AgentStartup.awaitInFlight(agentID, limit)
+		switch {
+		case wait.closed:
+			return fmt.Errorf("agent %s was closed while its startup was in flight", agentID)
+		case !wait.settled:
 			slog.Warn("ensureAgentRunning: a startup already in flight did not finish in time",
-				"agent_id", agentID, "timeout", svc.agentStartupTimeout())
+				"agent_id", agentID, "limit", limit)
 		}
 		if svc.Agents.HasAgent(agentID) {
 			return nil

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -2880,6 +2880,11 @@ func (svc *Service) resolveResumeSessionID(agentID, currentSessionID string, res
 // Shutdown's WaitForInFlight drains it. Registering at one call site left the
 // three message-driven callers without any of them.
 //
+// An INTERACTIVE caller does not race a startup that is already in flight for
+// the same tab: it waits for that startup and reports its outcome. The wait is
+// what keeps a message sent inside the open path's startup window; see the
+// comment on it below.
+//
 // It takes no context. The startup context is rooted at bgCtx() and created
 // here, because it is the agent PROCESS's lifetime -- the provider builds its
 // exec.CommandContext from it -- and a caller's context is the wrong lifetime
@@ -2890,6 +2895,40 @@ func (svc *Service) resolveResumeSessionID(agentID, currentSessionID string, res
 func (svc *Service) ensureAgentRunning(agentID string, preResolvedResumeSessionID *string, priority startPriority) error {
 	if svc.Agents.HasAgent(agentID) {
 		return nil
+	}
+
+	// Join a startup that is ALREADY producing the process this caller needs,
+	// rather than race it and then refuse.
+	//
+	// The open path holds no manager entry until its final handoff, so HasAgent
+	// stays false for the whole of it -- and a message that lands in that window
+	// takes this path. Without the wait, begin below finds the id claimed and
+	// this returns an error, which SendAgentMessage records on the row as
+	// "agent is not running": the user's first message never reaches the CLI
+	// that the open path brings up a second later, and nothing retries it.
+	//
+	// Only an INTERACTIVE caller waits. It holds a user's message and has
+	// nowhere to put it, so the wait is what keeps that message. The resume
+	// sweep has nothing to lose: the startup it would wait for produces the very
+	// process the sweep wants, so skipping is the same outcome sooner -- and a
+	// sweep worker parked here would hold up the shutdown that joins it.
+	//
+	// Before the lifecycle lock, because the wait is long compared with
+	// everything under it and a CloseAgent for this same tab needs that lock to
+	// tear the startup down. Re-check HasAgent after: a startup that this caller
+	// waited for and that succeeded is exactly the outcome to report.
+	//
+	// The claim below still stands on its own. A startup that begins between
+	// this wait and that claim is refused as before -- a window of microseconds
+	// where there was one of seconds.
+	if priority == interactiveStart {
+		if !svc.AgentStartup.awaitInFlight(agentID, svc.agentStartupTimeout()) {
+			slog.Warn("ensureAgentRunning: a startup already in flight did not finish in time",
+				"agent_id", agentID, "timeout", svc.agentStartupTimeout())
+		}
+		if svc.Agents.HasAgent(agentID) {
+			return nil
+		}
 	}
 
 	// Serialize this cold-start against any concurrent auto-start or restart for the same

--- a/backend/internal/worker/service/agent_auto_start_test.go
+++ b/backend/internal/worker/service/agent_auto_start_test.go
@@ -326,3 +326,75 @@ func TestEnsureAgentRunning_ShutdownDrainsAMessageDrivenColdStart(t *testing.T) 
 	}
 	<-done
 }
+
+// TestSendAgentMessage_DuringAnOpenStartupIsDelivered is the handler-level form
+// of the defect a user reported as a first message that vanished.
+//
+// The open path holds no manager entry until its final handoff, so HasAgent is
+// false for the whole of its startup and a message that lands in that window
+// takes the auto-start branch. That branch used to find the tab's id claimed by
+// the open's own startup and record "agent is not running" on the row: the CLI
+// came up a second later and nothing ever handed it what the user typed. The
+// send must join that startup instead, and deliver.
+func TestSendAgentMessage_DuringAnOpenStartupIsDelivered(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc, d, w := setupTestService(t)
+	// A fake clock, so the assertion that the handler WAITS cannot lose to a
+	// real timer, and a regression that refuses again fails in milliseconds
+	// rather than after the whole startup budget.
+	clock := newFakeStartupClock()
+	svc.AgentStartup.clock = clock
+
+	// A start that REGISTERS in the manager, not a stub that returns success and
+	// leaves it empty: the delivery this test is about is the SendInput that
+	// follows, and it needs a process to reach.
+	svc.startAgentFn = svc.Agents.MockStartAgent
+	t.Cleanup(func() { svc.Agents.StopAgent("agent-1") })
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID:            "agent-1",
+		WorkingDir:    t.TempDir(),
+		HomeDir:       t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+	}))
+
+	// Stand in for the open path's in-flight startup.
+	require.NotNil(t, svc.AgentStartup.begin("agent-1", func() {}))
+
+	sent := make(chan struct{})
+	go func() {
+		defer close(sent)
+		dispatch(d, "SendAgentMessage", &leapmuxv1.SendAgentMessageRequest{
+			AgentId: "agent-1",
+			Content: "hello",
+		}, w)
+	}()
+
+	clock.waitArmed(t)
+	select {
+	case <-sent:
+		require.FailNow(t, "the send answered while the tab's own startup was still running")
+	default:
+	}
+
+	// The open path finishes and hands over its process.
+	svc.AgentStartup.succeed("agent-1")
+	svc.AgentStartup.finish()
+
+	select {
+	case <-sent:
+	case <-time.After(10 * time.Second):
+		require.FailNow(t, "the send never resumed after the startup it waited for finished")
+	}
+	require.Empty(t, w.errors)
+
+	rows, err := svc.Queries.ListMessagesByAgentID(ctx, db.ListMessagesByAgentIDParams{
+		AgentID: "agent-1",
+		Limit:   10,
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Empty(t, rows[0].DeliveryError,
+		"the message was refused although the tab had a process coming; nothing ever retries it")
+}

--- a/backend/internal/worker/service/agent_control_ipc.go
+++ b/backend/internal/worker/service/agent_control_ipc.go
@@ -154,7 +154,9 @@ func (svc *Service) remintAgentControlIPC(opts agent.Options, phase string) ([]s
 type agentLauncher func(context.Context, agent.Options, agent.OutputSink) (map[string]string, error)
 
 // startPriority states whether a user is waiting on a cold start. It decides
-// one thing: whether the spawn draws on the manager's startup permit pool.
+// two things: whether the spawn draws on the manager's startup permit pool
+// (see launcher), and whether the caller joins a startup that already holds the
+// agent instead of refusing (see joinsInFlightStartup).
 //
 // It is a type rather than a bare bool so the four ensureAgentRunning call
 // sites read as what they are. Three of them answer a request the user is
@@ -166,7 +168,9 @@ const (
 	// interactiveStart is a spawn a user is waiting on. It takes no permit and
 	// never queues: the send path calls the cold start INLINE, and the client
 	// gives that RPC about fifteen seconds, so a wait would fail a send whose
-	// message row is already durable.
+	// message row is already durable. The one wait it does take -- joining a
+	// startup that is already producing the process this caller needs -- is
+	// limited by that same client budget, not by the process startup budget.
 	interactiveStart startPriority = iota
 	// backgroundStart is a spawn nobody is waiting on. It draws on the permit
 	// pool, so the boot sweep cannot run more handshakes at once than the
@@ -180,6 +184,18 @@ func (p startPriority) launcher(svc *Service) agentLauncher {
 		return svc.startBackgroundAgent
 	}
 	return svc.startAgent
+}
+
+// joinsInFlightStartup answers whether this priority WAITS for a startup that
+// already holds the agent, instead of refusing at once.
+//
+// Only an interactive caller waits. It holds a user's message and has nowhere
+// to put it, so the wait is what keeps that message. The resume sweep has
+// nothing to lose: the startup it would wait for produces the very process the
+// sweep wants, so skipping is the same outcome sooner -- and a sweep worker
+// parked on that wait would hold up the Shutdown that joins the sweep.
+func (p startPriority) joinsInFlightStartup() bool {
+	return p == interactiveStart
 }
 
 // mintAndLaunch mints the relaunch's control socket, hands the env vars to the

--- a/backend/internal/worker/service/agent_control_ipc_test.go
+++ b/backend/internal/worker/service/agent_control_ipc_test.go
@@ -702,13 +702,15 @@ func TestRemintControlIPC_AFailedMintStillReleasesTheDelegation(t *testing.T) {
 }
 
 // TestEnsureAgentRunning_RefusesWhileAnotherStartupHoldsTheAgent pins the claim
-// AgentStartup.begin makes.
+// AgentStartup.begin makes, on the one path that reaches it: a startup that
+// holds the agent for longer than the caller can wait.
 //
 // An OpenAgent startup holds no manager entry until its final handoff, so
 // HasAgent is false while one is in flight -- and the send gate refuses only a
 // PERMANENT startup failure. A message that lands in that window used to spawn a
 // second process for the same tab, and its begin() overwrote the open's registry
-// entry, so a later CloseAgent cancelled the wrong context.
+// entry, so a later CloseAgent cancelled the wrong context. The claim is what
+// stops that; this test drives the wait past its bound to reach it.
 func TestEnsureAgentRunning_RefusesWhileAnotherStartupHoldsTheAgent(t *testing.T) {
 	t.Parallel()
 
@@ -716,6 +718,10 @@ func TestEnsureAgentRunning_RefusesWhileAnotherStartupHoldsTheAgent(t *testing.T
 	rec := newStartRecorder()
 	rec.install(svc)
 	seedOpenAgent(t, svc, "agent-1", true)
+	// A fake clock, so the give-up costs no wall time and the assertion below
+	// about the caller WAITING first cannot lose to a real timer.
+	clock := newFakeStartupClock()
+	svc.AgentStartup.clock = clock
 
 	// Stand in for the open path's in-flight startup.
 	openCtx, openCancel := context.WithCancel(context.Background())
@@ -724,14 +730,99 @@ func TestEnsureAgentRunning_RefusesWhileAnotherStartupHoldsTheAgent(t *testing.T
 	require.NotNil(t, openHandle)
 	t.Cleanup(func() { svc.AgentStartup.finish() })
 
-	require.Error(t, svc.ensureAgentRunning("agent-1", nil, interactiveStart),
-		"a cold start ran while another startup held the agent; that spawns a second process for one tab")
+	errCh := make(chan error, 1)
+	go func() { errCh <- svc.ensureAgentRunning("agent-1", nil, interactiveStart) }()
+
+	assert.Equal(t, svc.agentStartupTimeout(), clock.waitArmed(t),
+		"the wait must be armed for the same budget the startup it waits on has")
+	select {
+	case <-errCh:
+		require.FailNow(t, "refused while the startup was still in flight; the user's message had a process coming")
+	default:
+	}
+
+	clock.fire(t)
+	select {
+	case err := <-errCh:
+		require.Error(t, err,
+			"a cold start ran while another startup held the agent; that spawns a second process for one tab")
+	case <-time.After(10 * time.Second):
+		require.FailNow(t, "the wait outlived its own bound")
+	}
 	assert.Empty(t, rec.ids())
 
 	// The open's handle must still be the registered one, so a close reaches IT.
 	svc.AgentStartup.cancelAndClear("agent-1", keepWorktreeOnClose)
 	assert.ErrorIs(t, openCtx.Err(), context.Canceled,
 		"the auto-start displaced the open's registry entry; a close then cancels the wrong context")
+}
+
+// TestEnsureAgentRunning_WaitsForTheStartupThatHoldsTheAgent is the other half,
+// and it is the one a user feels.
+//
+// A message sent inside the open path's startup window takes the auto-start
+// path, because HasAgent is false until that startup's final handoff. Refusing
+// there loses the message outright: SendAgentMessage records "agent is not
+// running" on the row, the open path brings the CLI up a second later, and
+// nothing ever hands it what the user typed. Joining the startup that is already
+// running is what keeps that message.
+func TestEnsureAgentRunning_WaitsForTheStartupThatHoldsTheAgent(t *testing.T) {
+	t.Parallel()
+
+	svc, _, _ := setupTestService(t)
+	rec := newStartRecorder()
+	rec.install(svc)
+	seedOpenAgent(t, svc, "agent-1", true)
+	clock := newFakeStartupClock()
+	svc.AgentStartup.clock = clock
+
+	openHandle := svc.AgentStartup.begin("agent-1", func() {})
+	require.NotNil(t, openHandle)
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- svc.ensureAgentRunning("agent-1", nil, interactiveStart) }()
+
+	clock.waitArmed(t)
+	assert.Empty(t, rec.ids(), "it must not spawn a second process for the tab that is already starting")
+
+	// The open path finishes.
+	svc.AgentStartup.succeed("agent-1")
+	svc.AgentStartup.finish()
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err, "the startup it waited for finished, so the message has a process to reach")
+	case <-time.After(10 * time.Second):
+		require.FailNow(t, "the caller never resumed after the startup it waited for finished")
+	}
+	assert.Equal(t, []string{"agent-1"}, rec.ids(),
+		"the agent must be running once the wait is over, or the message has nowhere to go")
+}
+
+// TestEnsureAgentRunning_BackgroundStartDoesNotWaitForAnotherStartup pins the
+// asymmetry. The resume sweep has no message to lose: the startup it would wait
+// for produces the very process it wants, so skipping is the same outcome
+// sooner -- and a sweep worker parked on that wait holds up the Shutdown that
+// joins the sweep.
+func TestEnsureAgentRunning_BackgroundStartDoesNotWaitForAnotherStartup(t *testing.T) {
+	t.Parallel()
+
+	svc, _, _ := setupTestService(t)
+	rec := newStartRecorder()
+	rec.install(svc)
+	seedOpenAgent(t, svc, "agent-1", true)
+	clock := newFakeStartupClock()
+	svc.AgentStartup.clock = clock
+
+	require.NotNil(t, svc.AgentStartup.begin("agent-1", func() {}))
+	t.Cleanup(func() { svc.AgentStartup.finish() })
+
+	require.Error(t, svc.ensureAgentRunning("agent-1", nil, backgroundStart))
+	assert.Empty(t, rec.ids())
+
+	clock.mu.Lock()
+	defer clock.mu.Unlock()
+	assert.Empty(t, clock.timers, "the sweep must not wait on a startup that is already doing its work")
 }
 
 // requireAgentRow is a small readability helper for the tests above.

--- a/backend/internal/worker/service/agent_control_ipc_test.go
+++ b/backend/internal/worker/service/agent_control_ipc_test.go
@@ -733,8 +733,15 @@ func TestEnsureAgentRunning_RefusesWhileAnotherStartupHoldsTheAgent(t *testing.T
 	errCh := make(chan error, 1)
 	go func() { errCh <- svc.ensureAgentRunning("agent-1", nil, interactiveStart) }()
 
-	assert.Equal(t, svc.agentStartupTimeout(), clock.waitArmed(t),
-		"the wait must be armed for the same budget the startup it waits on has")
+	// The CLIENT's budget, not the process's. Every interactive caller holds
+	// its RPC response open across this wait, and the client abandons that RPC
+	// at roughly 1.5x the API timeout -- so a wait armed for the five-minute
+	// startup timeout would report a send as failed that this worker goes on to
+	// deliver, under a Retry button that then sends it twice.
+	assert.Equal(t, svc.agentAPITimeout(), clock.waitArmed(t),
+		"the wait must end inside the budget the client gives the RPC that holds it")
+	assert.Less(t, svc.agentAPITimeout(), svc.agentStartupTimeout(),
+		"a wait as long as the whole startup budget is the defect this assertion exists to prevent")
 	select {
 	case <-errCh:
 		require.FailNow(t, "refused while the startup was still in flight; the user's message had a process coming")
@@ -747,7 +754,7 @@ func TestEnsureAgentRunning_RefusesWhileAnotherStartupHoldsTheAgent(t *testing.T
 		require.Error(t, err,
 			"a cold start ran while another startup held the agent; that spawns a second process for one tab")
 	case <-time.After(10 * time.Second):
-		require.FailNow(t, "the wait outlived its own bound")
+		require.FailNow(t, "the wait outlived its own limit")
 	}
 	assert.Empty(t, rec.ids())
 
@@ -823,6 +830,49 @@ func TestEnsureAgentRunning_BackgroundStartDoesNotWaitForAnotherStartup(t *testi
 	clock.mu.Lock()
 	defer clock.mu.Unlock()
 	assert.Empty(t, clock.timers, "the sweep must not wait on a startup that is already doing its work")
+}
+
+// TestEnsureAgentRunning_RefusesWhenACloseEndedTheStartupItWaitedFor pins the
+// one outcome of the wait that must NOT produce a process.
+//
+// cancelAndClear wakes every waiter as its FIRST teardown step -- several steps
+// before the close stamps closed_at. A waiter that read only "the startup
+// settled" therefore found HasAgent false, read a row whose ClosedAt is still
+// NULL, and cold-started a tab the user had just closed. Nothing stops such a
+// process: the close it raced already ran its own teardown.
+func TestEnsureAgentRunning_RefusesWhenACloseEndedTheStartupItWaitedFor(t *testing.T) {
+	t.Parallel()
+
+	svc, _, _ := setupTestService(t)
+	rec := newStartRecorder()
+	rec.install(svc)
+	seedOpenAgent(t, svc, "agent-1", true)
+	clock := newFakeStartupClock()
+	svc.AgentStartup.clock = clock
+
+	// Stand in for the open path's in-flight startup.
+	require.NotNil(t, svc.AgentStartup.begin("agent-1", func() {}))
+	t.Cleanup(func() { svc.AgentStartup.finish() })
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- svc.ensureAgentRunning("agent-1", nil, interactiveStart) }()
+	clock.waitArmed(t)
+
+	// The user closes the tab. The row still reads OPEN at this point, exactly
+	// as it does for the whole of the close's own teardown.
+	svc.AgentStartup.cancelAndClear("agent-1", keepWorktreeOnClose)
+	row := requireAgentRow(t, svc, "agent-1")
+	require.False(t, row.ClosedAt.Valid,
+		"the premise: the close has not stamped closed_at yet, so that guard cannot carry this")
+
+	select {
+	case err := <-errCh:
+		require.Error(t, err, "a close ended the startup, so there is no process to wait for and none to start")
+	case <-time.After(10 * time.Second):
+		require.FailNow(t, "the caller never resumed after the close released it")
+	}
+	assert.Empty(t, rec.ids(),
+		"it started a process for a tab the user closed; the close already ran its teardown, so nothing stops it")
 }
 
 // requireAgentRow is a small readability helper for the tests above.

--- a/backend/internal/worker/service/startupstate.go
+++ b/backend/internal/worker/service/startupstate.go
@@ -76,6 +76,49 @@ type startupEntry struct {
 	// goroutine is reading.
 	closeDisposition closeWorktreeDisposition
 	closeRaced       bool
+	// done is closed when this startup stops being IN FLIGHT -- when succeed,
+	// fail or cancelAndClear takes the entry out of the map. awaitInFlight
+	// waits on it, so a caller that finds the id claimed can wait for the claim
+	// holder instead of refusing.
+	//
+	// Only an entry that begin created carries one. The entry fail installs is a
+	// finished record with no goroutine behind it, and awaitInFlight skips a
+	// failed entry for the same reason begin does not refuse on one.
+	done chan struct{}
+}
+
+// release closes e.done, so every awaitInFlight waiting on this startup stops
+// waiting. The caller holds r.mu and has already taken the entry out of the
+// map, which is what makes the close happen exactly once: begin is the only
+// writer of an in-flight entry, and one entry leaves the map one time.
+func (e *startupEntry) release() {
+	if e != nil && e.done != nil {
+		close(e.done)
+	}
+}
+
+// startupTimerClock is the time source awaitInFlight bounds its wait with.
+// Production uses systemStartupClock; the registry's tests substitute a fake
+// that fires on demand, so a test about the give-up path spends no wall time
+// and a test about the wait NOT giving up cannot lose to a real timer on a
+// loaded machine.
+//
+// It mirrors streamevents.retryClock deliberately: the same two-value
+// NewTimer, so the codebase has one shape for "a timer a test can drive".
+type startupTimerClock interface {
+	// NewTimer starts a timer for d, returning the channel it delivers on and a
+	// stop func that releases it -- time.Timer's C/Stop pair without the
+	// concrete type. The caller must call stop exactly once, whether or not it
+	// consumed the delivery.
+	NewTimer(d time.Duration) (<-chan time.Time, func())
+}
+
+// systemStartupClock is the production startupTimerClock: a plain time.NewTimer.
+type systemStartupClock struct{}
+
+func (systemStartupClock) NewTimer(d time.Duration) (<-chan time.Time, func()) {
+	t := time.NewTimer(d)
+	return t.C, func() { t.Stop() }
 }
 
 // startupCore is the shared state-machine for tracking a set of in-flight
@@ -92,10 +135,14 @@ type startupCore struct {
 	mu      sync.Mutex
 	entries map[string]*startupEntry
 	wg      sync.WaitGroup
+	// clock is the time source awaitInFlight bounds its wait with. Set once by
+	// newStartupCore and never reassigned in production, so a waiter reads it
+	// without the mutex; a test substitutes a fake before it starts one.
+	clock startupTimerClock
 }
 
 func newStartupCore() startupCore {
-	return startupCore{entries: make(map[string]*startupEntry)}
+	return startupCore{entries: make(map[string]*startupEntry), clock: systemStartupClock{}}
 }
 
 // begin records an entry in STARTING state, adds one to the in-flight counter,
@@ -126,10 +173,53 @@ func (r *startupCore) begin(id string, cancel context.CancelFunc) *startupEntry 
 	if existing, busy := r.entries[id]; busy && !existing.failed {
 		return nil
 	}
-	entry := &startupEntry{cancel: cancel, resizeSignal: make(chan struct{}, 1)}
+	entry := &startupEntry{
+		cancel:       cancel,
+		resizeSignal: make(chan struct{}, 1),
+		done:         make(chan struct{}),
+	}
 	r.entries[id] = entry
 	r.wg.Add(1)
 	return entry
+}
+
+// awaitInFlight blocks until no startup for id is in flight, and reports
+// whether it reached that state inside `within`. It returns true at once when
+// the id is unclaimed, and when the entry holding it already FAILED -- the two
+// states in which begin hands out the claim.
+//
+// It exists so a caller that must have a running process can wait for the
+// startup that is already producing one, rather than refuse. The refusal is
+// what a user saw as a message that vanished: a message sent inside the open
+// path's startup window reached ensureAgentRunning, which found the id claimed
+// and reported "not running", and nothing ever handed that message to the
+// process the open path then started.
+//
+// The wait is bounded because a startup goroutine can be stuck on a provider
+// that never answers, and the caller is answering a user. On a timeout the
+// caller keeps whatever it does today for a startup it cannot join.
+func (r *startupCore) awaitInFlight(id string, within time.Duration) bool {
+	// Take the channel itself under the lock, not the entry: every other field
+	// of an entry belongs to the goroutine that owns it or to a caller holding
+	// r.mu, and reading one out here would be the one place that reads an entry
+	// unguarded.
+	r.mu.Lock()
+	var done chan struct{}
+	if entry, busy := r.entries[id]; busy && !entry.failed {
+		done = entry.done
+	}
+	r.mu.Unlock()
+	if done == nil {
+		return true
+	}
+	expired, stop := r.clock.NewTimer(within)
+	defer stop()
+	select {
+	case <-done:
+		return true
+	case <-expired:
+		return false
+	}
 }
 
 // finish marks one startup goroutine as returned. Always called via `defer` at
@@ -171,6 +261,7 @@ func (r *startupCore) succeed(id string) {
 	r.mu.Lock()
 	entry := r.entries[id]
 	delete(r.entries, id)
+	entry.release()
 	r.mu.Unlock()
 	if entry != nil && entry.evictTimer != nil {
 		entry.evictTimer.Stop()
@@ -191,9 +282,14 @@ func (r *startupCore) fail(id, startupError string) {
 		}
 	})
 	r.mu.Lock()
-	// Stop any prior pending eviction if fail is called twice.
-	if prev, ok := r.entries[id]; ok && prev.evictTimer != nil {
-		prev.evictTimer.Stop()
+	// Stop any prior pending eviction if fail is called twice, and release the
+	// startup this failure replaces: an awaited startup that FAILS has stopped
+	// being in flight just as surely as one that succeeded.
+	if prev, ok := r.entries[id]; ok {
+		if prev.evictTimer != nil {
+			prev.evictTimer.Stop()
+		}
+		prev.release()
 	}
 	r.entries[id] = entry
 	r.mu.Unlock()
@@ -217,6 +313,7 @@ func (r *startupCore) cancelAndClear(id string, disposition closeWorktreeDisposi
 	if entry != nil {
 		entry.closeDisposition = disposition
 		entry.closeRaced = true
+		entry.release()
 	}
 	r.mu.Unlock()
 	if entry == nil {

--- a/backend/internal/worker/service/startupstate.go
+++ b/backend/internal/worker/service/startupstate.go
@@ -8,11 +8,11 @@ import (
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 )
 
-// failedEntryTTL bounds how long a terminal-state failure entry lingers
-// in the registry after fail() so long-lived workers with user churn
-// don't accumulate entries for never-closed failed tabs. The DB
+// failedEntryTTL limits how long a FINISHED failure entry stays in the
+// registry after fail(), so a long-lived worker with user churn does not
+// accumulate entries for failed tabs that nobody closes. The DB
 // startup_error column is the authoritative source across restarts, so
-// expiry just evicts the in-memory copy; subsequent reads fall back to
+// expiry only evicts the in-memory copy; a later read falls back to
 // the DB path.
 const failedEntryTTL = 5 * time.Minute
 
@@ -97,7 +97,7 @@ func (e *startupEntry) release() {
 	}
 }
 
-// startupTimerClock is the time source awaitInFlight bounds its wait with.
+// startupTimerClock is the time source awaitInFlight limits its wait with.
 // Production uses systemStartupClock; the registry's tests substitute a fake
 // that fires on demand, so a test about the give-up path spends no wall time
 // and a test about the wait NOT giving up cannot lose to a real timer on a
@@ -105,6 +105,8 @@ func (e *startupEntry) release() {
 //
 // It mirrors streamevents.retryClock deliberately: the same two-value
 // NewTimer, so the codebase has one shape for "a timer a test can drive".
+// The two are byte-for-byte the same type and could share one; see
+// https://github.com/leapmux/leapmux/issues/437.
 type startupTimerClock interface {
 	// NewTimer starts a timer for d, returning the channel it delivers on and a
 	// stop func that releases it -- time.Timer's C/Stop pair without the
@@ -135,7 +137,7 @@ type startupCore struct {
 	mu      sync.Mutex
 	entries map[string]*startupEntry
 	wg      sync.WaitGroup
-	// clock is the time source awaitInFlight bounds its wait with. Set once by
+	// clock is the time source awaitInFlight limits its wait with. Set once by
 	// newStartupCore and never reassigned in production, so a waiter reads it
 	// without the mutex; a test substitutes a fake before it starts one.
 	clock startupTimerClock
@@ -183,10 +185,22 @@ func (r *startupCore) begin(id string, cancel context.CancelFunc) *startupEntry 
 	return entry
 }
 
-// awaitInFlight blocks until no startup for id is in flight, and reports
-// whether it reached that state inside `within`. It returns true at once when
-// the id is unclaimed, and when the entry holding it already FAILED -- the two
-// states in which begin hands out the claim.
+// startupWait is what awaitInFlight learned about the startup it waited for.
+type startupWait struct {
+	// settled is false when the wait reached its limit while the startup still
+	// held the id. The caller then knows nothing about that startup's outcome.
+	settled bool
+	// closed reports that a CLOSE ended the startup, rather than a success or a
+	// failure of its own. A caller must not start a replacement process on this
+	// outcome: the tab is going away, and the DB row that says so is written
+	// several steps later, so the closed_at guard downstream still reads false.
+	closed bool
+}
+
+// awaitInFlight blocks until no startup for id is in flight, and reports what
+// ended it. It settles at once when the id is unclaimed, and when the entry
+// holding it already FAILED -- the two states in which begin hands out the
+// claim.
 //
 // It exists so a caller that must have a running process can wait for the
 // startup that is already producing one, rather than refuse. The refusal is
@@ -195,30 +209,33 @@ func (r *startupCore) begin(id string, cancel context.CancelFunc) *startupEntry 
 // and reported "not running", and nothing ever handed that message to the
 // process the open path then started.
 //
-// The wait is bounded because a startup goroutine can be stuck on a provider
-// that never answers, and the caller is answering a user. On a timeout the
-// caller keeps whatever it does today for a startup it cannot join.
-func (r *startupCore) awaitInFlight(id string, within time.Duration) bool {
-	// Take the channel itself under the lock, not the entry: every other field
-	// of an entry belongs to the goroutine that owns it or to a caller holding
-	// r.mu, and reading one out here would be the one place that reads an entry
-	// unguarded.
+// The wait has a LIMIT because a startup goroutine can stop on a provider that
+// never answers, and the caller answers a user. On a timeout the caller keeps
+// whatever it does today for a startup it cannot join.
+func (r *startupCore) awaitInFlight(id string, limit time.Duration) startupWait {
+	// Take the entry under the lock and read only its done channel here: every
+	// other field belongs to the goroutine that owns the entry or to a caller
+	// holding r.mu, and the one field this function needs afterwards --
+	// closeRaced -- it reads back through dispositionOf, which takes r.mu.
 	r.mu.Lock()
-	var done chan struct{}
-	if entry, busy := r.entries[id]; busy && !entry.failed {
-		done = entry.done
+	var entry *startupEntry
+	if e, busy := r.entries[id]; busy && !e.failed {
+		entry = e
 	}
 	r.mu.Unlock()
-	if done == nil {
-		return true
+	if entry == nil {
+		return startupWait{settled: true}
 	}
-	expired, stop := r.clock.NewTimer(within)
+	expired, stop := r.clock.NewTimer(limit)
 	defer stop()
 	select {
-	case <-done:
-		return true
+	case <-entry.done:
+		// cancelAndClear stamps closeRaced on this same entry BEFORE it closes
+		// done, so the read below sees the close that woke this waiter.
+		_, closed := r.dispositionOf(entry)
+		return startupWait{settled: true, closed: closed}
 	case <-expired:
-		return false
+		return startupWait{}
 	}
 }
 
@@ -367,7 +384,7 @@ func (r *startupCore) takePendingResize(id string) (cols, rows uint16, ok bool) 
 	return cols, rows, true
 }
 
-// waitForPendingResize is takePendingResize with a bounded wait. Used
+// waitForPendingResize is takePendingResize with a limited wait. Used
 // before the shell is spawned so the PTY can be sized correctly on the
 // first call to cmd.Start — otherwise the shell paints its first prompt
 // at the placeholder 80x24 and zsh's SIGWINCH handler leaves a

--- a/backend/internal/worker/service/startupstate_test.go
+++ b/backend/internal/worker/service/startupstate_test.go
@@ -283,7 +283,7 @@ func (c *fakeStartupClock) fire(t *testing.T) {
 // TestStartupCore_AwaitInFlightReturnsAtOnceWhenNothingHoldsTheID pins the two
 // states in which begin hands out the claim: an id nobody holds, and one whose
 // entry already FAILED. A wait in either is a wait for a startup that is not
-// running, and the caller would pay the whole bound for nothing.
+// running, and the caller would pay the whole limit for nothing.
 func TestStartupCore_AwaitInFlightReturnsAtOnceWhenNothingHoldsTheID(t *testing.T) {
 	t.Parallel()
 
@@ -291,10 +291,10 @@ func TestStartupCore_AwaitInFlightReturnsAtOnceWhenNothingHoldsTheID(t *testing.
 	clock := newFakeStartupClock()
 	core.clock = clock
 
-	assert.True(t, core.awaitInFlight("tab-unclaimed", time.Hour))
+	assert.Equal(t, startupWait{settled: true}, core.awaitInFlight("tab-unclaimed", time.Hour))
 
 	core.fail("tab-failed", "claude: command not found")
-	assert.True(t, core.awaitInFlight("tab-failed", time.Hour))
+	assert.Equal(t, startupWait{settled: true}, core.awaitInFlight("tab-failed", time.Hour))
 
 	clock.mu.Lock()
 	defer clock.mu.Unlock()
@@ -307,13 +307,23 @@ func TestStartupCore_AwaitInFlightReturnsAtOnceWhenNothingHoldsTheID(t *testing.
 func TestStartupCore_AwaitInFlightWaitsForTheStartupThatHoldsTheID(t *testing.T) {
 	t.Parallel()
 
+	// `closed` tells the three transitions apart, and it is the whole reason the
+	// wait reports more than "it settled": a caller that must have a process
+	// starts one on a startup that ENDED, and must not on one a close TORE
+	// DOWN -- the tab is going away, and the row that says so is not written
+	// yet.
 	for _, tc := range []struct {
 		name string
 		end  func(core *startupCore)
+		want startupWait
 	}{
-		{"succeed", func(core *startupCore) { core.succeed("tab-1") }},
-		{"fail", func(core *startupCore) { core.fail("tab-1", "boom") }},
-		{"cancelAndClear", func(core *startupCore) { core.cancelAndClear("tab-1", keepWorktreeOnClose) }},
+		{"succeed", func(core *startupCore) { core.succeed("tab-1") }, startupWait{settled: true}},
+		{"fail", func(core *startupCore) { core.fail("tab-1", "boom") }, startupWait{settled: true}},
+		{
+			"cancelAndClear",
+			func(core *startupCore) { core.cancelAndClear("tab-1", keepWorktreeOnClose) },
+			startupWait{settled: true, closed: true},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -323,7 +333,7 @@ func TestStartupCore_AwaitInFlightWaitsForTheStartupThatHoldsTheID(t *testing.T)
 			core.clock = clock
 			require.NotNil(t, core.begin("tab-1", func() {}))
 
-			done := make(chan bool, 1)
+			done := make(chan startupWait, 1)
 			go func() { done <- core.awaitInFlight("tab-1", time.Hour) }()
 
 			clock.waitArmed(t)
@@ -335,8 +345,8 @@ func TestStartupCore_AwaitInFlightWaitsForTheStartupThatHoldsTheID(t *testing.T)
 
 			tc.end(&core)
 			select {
-			case ok := <-done:
-				assert.True(t, ok, "the holder finished, so the wait must report success")
+			case got := <-done:
+				assert.Equal(t, tc.want, got, "the holder finished, so the wait must report how")
 			case <-time.After(10 * time.Second):
 				require.FailNow(t, "the wait never returned after the holder finished")
 			}
@@ -346,10 +356,10 @@ func TestStartupCore_AwaitInFlightWaitsForTheStartupThatHoldsTheID(t *testing.T)
 	}
 }
 
-// TestStartupCore_AwaitInFlightGivesUpOnTheBound pins the bound. A startup
-// goroutine can be stuck on a provider that never answers, and the caller is
-// answering a user; an unbounded wait would hold that answer for ever.
-func TestStartupCore_AwaitInFlightGivesUpOnTheBound(t *testing.T) {
+// TestStartupCore_AwaitInFlightGivesUpOnItsLimit pins the limit. A startup
+// goroutine can stop on a provider that never answers, and the caller answers a
+// user; a wait with no limit would hold that answer for ever.
+func TestStartupCore_AwaitInFlightGivesUpOnItsLimit(t *testing.T) {
 	t.Parallel()
 
 	core := newStartupCore()
@@ -357,16 +367,17 @@ func TestStartupCore_AwaitInFlightGivesUpOnTheBound(t *testing.T) {
 	core.clock = clock
 	require.NotNil(t, core.begin("tab-1", func() {}))
 
-	done := make(chan bool, 1)
+	done := make(chan startupWait, 1)
 	go func() { done <- core.awaitInFlight("tab-1", 90*time.Second) }()
 
-	assert.Equal(t, 90*time.Second, clock.waitArmed(t), "the wait must be armed for the bound it was given")
+	assert.Equal(t, 90*time.Second, clock.waitArmed(t), "the wait must be armed for the limit it was given")
 	clock.fire(t)
 	select {
-	case ok := <-done:
-		assert.False(t, ok, "a wait that expired must report that it did")
+	case got := <-done:
+		assert.Equal(t, startupWait{}, got,
+			"a wait that expired must report that it settled nothing, and must not claim a close")
 	case <-time.After(10 * time.Second):
-		require.FailNow(t, "the wait outlived its own bound")
+		require.FailNow(t, "the wait outlived its own limit")
 	}
 
 	core.cancelAndClear("tab-1", keepWorktreeOnClose)
@@ -386,7 +397,7 @@ func TestStartupCore_AwaitInFlightIsSafeForManyWaiters(t *testing.T) {
 	require.NotNil(t, core.begin("tab-1", func() {}))
 
 	const waiters = 8
-	done := make(chan bool, waiters)
+	done := make(chan startupWait, waiters)
 	for range waiters {
 		go func() { done <- core.awaitInFlight("tab-1", time.Hour) }()
 	}
@@ -395,8 +406,8 @@ func TestStartupCore_AwaitInFlightIsSafeForManyWaiters(t *testing.T) {
 	core.succeed("tab-1")
 	for range waiters {
 		select {
-		case ok := <-done:
-			assert.True(t, ok)
+		case got := <-done:
+			assert.Equal(t, startupWait{settled: true}, got)
 		case <-time.After(10 * time.Second):
 			require.FailNow(t, "a waiter was left behind by the wake-up")
 		}
@@ -443,9 +454,12 @@ func TestStartupCore_ReleasingTheSameStartupTwiceIsSafe(t *testing.T) {
 
 			tc.first(&core)
 			assert.NotPanics(t, func() { tc.then(&core) })
-			// Whatever the pair did, the id must be waitable again without a
-			// wait: nothing is in flight for it any more.
-			assert.True(t, core.awaitInFlight("tab-1", time.Hour))
+			// Whatever the pair did, the id must settle again without a wait:
+			// nothing is in flight for it any more. It settles as UNCLAIMED
+			// rather than as closed, because the entry the close stamped is
+			// out of the map -- a later caller sees a free id, not a stale
+			// close.
+			assert.Equal(t, startupWait{settled: true}, core.awaitInFlight("tab-1", time.Hour))
 
 			core.finish()
 			core.WaitForInFlight()

--- a/backend/internal/worker/service/startupstate_test.go
+++ b/backend/internal/worker/service/startupstate_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -218,4 +219,236 @@ func TestStartupCore_BeginReclaimsAFailedEntry(t *testing.T) {
 	require.NotNil(t, h, "a retry after a failed startup must be able to claim the tab again")
 	core.finish()
 	core.WaitForInFlight()
+}
+
+// fakeStartupClock is a deterministic startupTimerClock. NewTimer records the
+// requested delay and hands back a channel the test fires explicitly, so
+// nothing in awaitInFlight is timed by the wall clock: a test can hold a wait
+// in its armed-but-not-expired window for as long as it likes, and a test about
+// the give-up path spends no wall time reaching it.
+//
+// Timers fire in arm order, one per fire() call, which is also the order a real
+// clock would fire them in for the one-wait-at-a-time shape awaitInFlight has.
+type fakeStartupClock struct {
+	mu     sync.Mutex
+	timers []chan time.Time
+	fired  int
+	delays []time.Duration
+	armed  chan struct{} // buffered(1); pinged on every NewTimer
+}
+
+func newFakeStartupClock() *fakeStartupClock {
+	return &fakeStartupClock{armed: make(chan struct{}, 1)}
+}
+
+func (c *fakeStartupClock) NewTimer(d time.Duration) (<-chan time.Time, func()) {
+	ch := make(chan time.Time, 1)
+	c.mu.Lock()
+	c.timers = append(c.timers, ch)
+	c.delays = append(c.delays, d)
+	c.mu.Unlock()
+	// Buffered(1) and non-blocking: a pending ping already covers the waiter's
+	// next check, so a dropped send loses nothing.
+	select {
+	case c.armed <- struct{}{}:
+	default:
+	}
+	return ch, func() {}
+}
+
+// waitArmed blocks until a timer is armed, which is the signal that the code
+// under test chose to WAIT rather than answer at once.
+func (c *fakeStartupClock) waitArmed(t *testing.T) time.Duration {
+	t.Helper()
+	select {
+	case <-c.armed:
+	case <-time.After(10 * time.Second):
+		require.FailNow(t, "no wait was armed; the caller answered without waiting")
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.delays[len(c.delays)-1]
+}
+
+// fire expires the oldest timer that has not fired yet.
+func (c *fakeStartupClock) fire(t *testing.T) {
+	t.Helper()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	require.Less(t, c.fired, len(c.timers), "no armed timer left to fire")
+	c.timers[c.fired] <- time.Now()
+	c.fired++
+}
+
+// TestStartupCore_AwaitInFlightReturnsAtOnceWhenNothingHoldsTheID pins the two
+// states in which begin hands out the claim: an id nobody holds, and one whose
+// entry already FAILED. A wait in either is a wait for a startup that is not
+// running, and the caller would pay the whole bound for nothing.
+func TestStartupCore_AwaitInFlightReturnsAtOnceWhenNothingHoldsTheID(t *testing.T) {
+	t.Parallel()
+
+	core := newStartupCore()
+	clock := newFakeStartupClock()
+	core.clock = clock
+
+	assert.True(t, core.awaitInFlight("tab-unclaimed", time.Hour))
+
+	core.fail("tab-failed", "claude: command not found")
+	assert.True(t, core.awaitInFlight("tab-failed", time.Hour))
+
+	clock.mu.Lock()
+	defer clock.mu.Unlock()
+	assert.Empty(t, clock.timers, "neither state may arm a timer")
+}
+
+// TestStartupCore_AwaitInFlightWaitsForTheStartupThatHoldsTheID is the wait
+// itself: it must not return while the claim holder is still running, and it
+// must return the moment that holder is done.
+func TestStartupCore_AwaitInFlightWaitsForTheStartupThatHoldsTheID(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		end  func(core *startupCore)
+	}{
+		{"succeed", func(core *startupCore) { core.succeed("tab-1") }},
+		{"fail", func(core *startupCore) { core.fail("tab-1", "boom") }},
+		{"cancelAndClear", func(core *startupCore) { core.cancelAndClear("tab-1", keepWorktreeOnClose) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			core := newStartupCore()
+			clock := newFakeStartupClock()
+			core.clock = clock
+			require.NotNil(t, core.begin("tab-1", func() {}))
+
+			done := make(chan bool, 1)
+			go func() { done <- core.awaitInFlight("tab-1", time.Hour) }()
+
+			clock.waitArmed(t)
+			select {
+			case <-done:
+				require.FailNow(t, "the wait returned while the startup still held the id")
+			default:
+			}
+
+			tc.end(&core)
+			select {
+			case ok := <-done:
+				assert.True(t, ok, "the holder finished, so the wait must report success")
+			case <-time.After(10 * time.Second):
+				require.FailNow(t, "the wait never returned after the holder finished")
+			}
+			core.finish()
+			core.WaitForInFlight()
+		})
+	}
+}
+
+// TestStartupCore_AwaitInFlightGivesUpOnTheBound pins the bound. A startup
+// goroutine can be stuck on a provider that never answers, and the caller is
+// answering a user; an unbounded wait would hold that answer for ever.
+func TestStartupCore_AwaitInFlightGivesUpOnTheBound(t *testing.T) {
+	t.Parallel()
+
+	core := newStartupCore()
+	clock := newFakeStartupClock()
+	core.clock = clock
+	require.NotNil(t, core.begin("tab-1", func() {}))
+
+	done := make(chan bool, 1)
+	go func() { done <- core.awaitInFlight("tab-1", 90*time.Second) }()
+
+	assert.Equal(t, 90*time.Second, clock.waitArmed(t), "the wait must be armed for the bound it was given")
+	clock.fire(t)
+	select {
+	case ok := <-done:
+		assert.False(t, ok, "a wait that expired must report that it did")
+	case <-time.After(10 * time.Second):
+		require.FailNow(t, "the wait outlived its own bound")
+	}
+
+	core.cancelAndClear("tab-1", keepWorktreeOnClose)
+	core.finish()
+	core.WaitForInFlight()
+}
+
+// TestStartupCore_AwaitInFlightIsSafeForManyWaiters pins that the done signal is
+// a broadcast, not a handoff: every send that lands in one startup window waits
+// on the same entry, and closing the channel is what wakes all of them.
+func TestStartupCore_AwaitInFlightIsSafeForManyWaiters(t *testing.T) {
+	t.Parallel()
+
+	core := newStartupCore()
+	clock := newFakeStartupClock()
+	core.clock = clock
+	require.NotNil(t, core.begin("tab-1", func() {}))
+
+	const waiters = 8
+	done := make(chan bool, waiters)
+	for range waiters {
+		go func() { done <- core.awaitInFlight("tab-1", time.Hour) }()
+	}
+	clock.waitArmed(t)
+
+	core.succeed("tab-1")
+	for range waiters {
+		select {
+		case ok := <-done:
+			assert.True(t, ok)
+		case <-time.After(10 * time.Second):
+			require.FailNow(t, "a waiter was left behind by the wake-up")
+		}
+	}
+	core.finish()
+	core.WaitForInFlight()
+}
+
+// TestStartupCore_ReleasingTheSameStartupTwiceIsSafe pins that the done signal
+// is closed once per entry. The three state transitions all release, and each
+// takes the entry out of the map first -- so a second transition for the same
+// id finds nothing and closes nothing. Closing a closed channel panics, and
+// that panic would land on whichever of them ran second.
+func TestStartupCore_ReleasingTheSameStartupTwiceIsSafe(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name  string
+		first func(core *startupCore)
+		then  func(core *startupCore)
+	}{
+		{"succeed then succeed",
+			func(c *startupCore) { c.succeed("tab-1") },
+			func(c *startupCore) { c.succeed("tab-1") }},
+		{"succeed then cancelAndClear",
+			func(c *startupCore) { c.succeed("tab-1") },
+			func(c *startupCore) { c.cancelAndClear("tab-1", keepWorktreeOnClose) }},
+		{"succeed then fail",
+			func(c *startupCore) { c.succeed("tab-1") },
+			func(c *startupCore) { c.fail("tab-1", "boom") }},
+		{"cancelAndClear then succeed",
+			func(c *startupCore) { c.cancelAndClear("tab-1", keepWorktreeOnClose) },
+			func(c *startupCore) { c.succeed("tab-1") }},
+		{"fail then fail",
+			func(c *startupCore) { c.fail("tab-1", "boom") },
+			func(c *startupCore) { c.fail("tab-1", "boom again") }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			core := newStartupCore()
+			core.clock = newFakeStartupClock()
+			require.NotNil(t, core.begin("tab-1", func() {}))
+
+			tc.first(&core)
+			assert.NotPanics(t, func() { tc.then(&core) })
+			// Whatever the pair did, the id must be waitable again without a
+			// wait: nothing is in flight for it any more.
+			assert.True(t, core.awaitInFlight("tab-1", time.Hour))
+
+			core.finish()
+			core.WaitForInFlight()
+		})
+	}
 }

--- a/backend/internal/worker/terminal/manager.go
+++ b/backend/internal/worker/terminal/manager.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"sync"
+	"time"
 
 	"github.com/leapmux/leapmux/util/validate"
 )
@@ -42,20 +44,34 @@ type TerminalSnapshot struct {
 	Screen []byte
 }
 
+// defaultReadDrainGrace is how long the exit goroutine waits for the reader to
+// finish before it runs the exit handler anyway. Reaching it means a process
+// this worker could not kill still holds the tty open, and a longer wait does
+// not change that. The value only has to cover the scheduling of a reader the
+// kernel already woke.
+const defaultReadDrainGrace = 2 * time.Second
+
 // Manager tracks active terminal sessions.
 type Manager struct {
 	mu        sync.RWMutex
 	terminals map[string]*Terminal     // terminalID -> Terminal
 	meta      map[string]TerminalMeta  // terminalID -> metadata
 	exitDone  map[string]chan struct{} // terminalID -> closed when the exit-handler goroutine has finished
+	// readDrainGrace limits the exit goroutine's wait for the reader. A field
+	// rather than a constant so a test can drive the give-up path without
+	// spending the real grace on it. Written only at construction -- by
+	// NewManager, or by a test before it installs a terminal -- so no lock
+	// guards it.
+	readDrainGrace time.Duration
 }
 
 // NewManager creates a new terminal Manager.
 func NewManager() *Manager {
 	return &Manager{
-		terminals: make(map[string]*Terminal),
-		meta:      make(map[string]TerminalMeta),
-		exitDone:  make(map[string]chan struct{}),
+		terminals:      make(map[string]*Terminal),
+		meta:           make(map[string]TerminalMeta),
+		exitDone:       make(map[string]chan struct{}),
+		readDrainGrace: defaultReadDrainGrace,
 	}
 }
 
@@ -128,11 +144,20 @@ func (m *Manager) installTerminal(id string, t *Terminal, exitFn ExitHandler, co
 		// for its whole life -- the user reopens an exited tab and the last
 		// thing the shell printed is missing.
 		//
-		// The wait is bounded. waitForExit terminates the job object, which
-		// reaps the whole process group, BEFORE it closes exitCh -- so by the
-		// time t.Wait returns nothing holds the PTY slave open and readOutput's
-		// next read ends it.
-		t.WaitForReadDrained()
+		// What ends the reader is waitForExit closing the child side of the pty,
+		// which it does right after it closes exitCh. The reaped child does not
+		// end it: this process holds the child side too, and on Linux a master
+		// read ends only when the last descriptor for the tty is gone. The
+		// bound covers the holders this worker cannot reach -- see
+		// Terminal.waitForReadDrained. A shell that leaves none behind never
+		// reaches it.
+		if !t.waitForReadDrained(m.readDrainGrace) {
+			slog.Warn("terminal reader did not drain after the shell exited; "+
+				"persisting the screen without its last output",
+				"terminal_id", id,
+				"grace", m.readDrainGrace,
+			)
+		}
 		if exitFn != nil {
 			exitFn(id, exitCode)
 		}

--- a/backend/internal/worker/terminal/manager.go
+++ b/backend/internal/worker/terminal/manager.go
@@ -47,8 +47,13 @@ type TerminalSnapshot struct {
 // defaultReadDrainGrace is how long the exit goroutine waits for the reader to
 // finish before it runs the exit handler anyway. Reaching it means a process
 // this worker could not kill still holds the tty open, and a longer wait does
-// not change that. The value only has to cover the scheduling of a reader the
-// kernel already woke.
+// not change that.
+//
+// The value only has to cover the scheduling of a reader the kernel already
+// woke, because waitForReadDrained starts it only after the child side of the
+// pty is closed -- the act that wakes that reader. Measured from the exit
+// instead, this grace would also have to absorb the Windows console-host
+// flush, which happens between the two.
 const defaultReadDrainGrace = 2 * time.Second
 
 // Manager tracks active terminal sessions.
@@ -56,12 +61,16 @@ type Manager struct {
 	mu        sync.RWMutex
 	terminals map[string]*Terminal     // terminalID -> Terminal
 	meta      map[string]TerminalMeta  // terminalID -> metadata
-	exitDone  map[string]chan struct{} // terminalID -> closed when the exit-handler goroutine has finished
+	exitDone  map[string]chan struct{} // terminalID -> closed once the exit-handler goroutine returned
 	// readDrainGrace limits the exit goroutine's wait for the reader. A field
 	// rather than a constant so a test can drive the give-up path without
 	// spending the real grace on it. Written only at construction -- by
 	// NewManager, or by a test before it installs a terminal -- so no lock
 	// guards it.
+	//
+	// A test reaching into an unexported field, and a REAL timer deciding what
+	// a deterministic clock should: startupCore.clock does the same job the
+	// other way. See https://github.com/leapmux/leapmux/issues/437.
 	readDrainGrace time.Duration
 }
 
@@ -121,7 +130,7 @@ func (m *Manager) StartTerminal(ctx context.Context, opts Options, outputFn Outp
 // Notify when the terminal exits but keep it in the map so that
 // ScreenSnapshot and ListTerminals still work. The entry is removed by
 // RemoveTerminal (explicit close). The freshly-allocated exitDone chan
-// is closed once the exit handler has finished, so WaitForExit callers
+// is closed once the exit handler returned, so WaitForExit callers
 // observe a definitive "the exit goroutine is done" signal.
 func (m *Manager) installTerminal(id string, t *Terminal, exitFn ExitHandler, composeMeta func(prev TerminalMeta) TerminalMeta) {
 	done := make(chan struct{})
@@ -148,9 +157,9 @@ func (m *Manager) installTerminal(id string, t *Terminal, exitFn ExitHandler, co
 		// which it does right after it closes exitCh. The reaped child does not
 		// end it: this process holds the child side too, and on Linux a master
 		// read ends only when the last descriptor for the tty is gone. The
-		// bound covers the holders this worker cannot reach -- see
-		// Terminal.waitForReadDrained. A shell that leaves none behind never
-		// reaches it.
+		// grace covers the holders this worker cannot reach -- see
+		// Terminal.waitForReadDrained, which starts it only once that close
+		// finished. A shell that leaves no such holder behind never reaches it.
 		if !t.waitForReadDrained(m.readDrainGrace) {
 			slog.Warn("terminal reader did not drain after the shell exited; "+
 				"persisting the screen without its last output",
@@ -253,6 +262,20 @@ func (m *Manager) RestartTerminal(
 		if !prev.IsExited() {
 			return fmt.Errorf("%w: %s", ErrTerminalStillRunning, opts.ID)
 		}
+		// Release the pty this restart REPLACES, before the new one takes its
+		// place in the map. Nothing else ever does: installTerminal overwrites
+		// the entry, and RemoveTerminal only ever stops whichever terminal is
+		// current by then, so every restart used to leave the old master (and
+		// on Windows the old ConPTY pipes) open for the life of the Worker.
+		//
+		// It also ends a reader that the drain grace gave up on. Such a reader
+		// still holds the screen buffer that Respawn hands to the NEW terminal,
+		// so without this Stop the dead shell's last bytes could land in the
+		// restarted session's screen -- at an offset the client already read.
+		// Stop closes the master, which ends that parked Read at once, and
+		// ScreenBuffer.WriteAndDeliver serializes whatever chunk is in flight
+		// ahead of the new reader's first write.
+		prev.Stop()
 		t, err = prev.Respawn(ctx, opts, outputFn)
 	} else {
 		t, err = startWithScreenBuffer(ctx, opts, NewScreenBufferWithOffset(fallbackOffset), outputFn)
@@ -345,9 +368,12 @@ func (m *Manager) IsExited(terminalID string) bool {
 	return t.IsExited()
 }
 
-// WaitForReadDrained blocks until the terminal's read goroutine has
-// drained (see Terminal.WaitForReadDrained). Returns false if the
-// terminal is unknown.
+// WaitForReadDrained blocks until the terminal's read goroutine drained (see
+// Terminal.waitForReadDrained). Returns false if the terminal is unknown.
+//
+// It waits with NO limit, which is why it is a test-only entry point: every
+// caller of it stops the terminal first, so the reader is already ending.
+// Production waits through installTerminal, which passes the manager's grace.
 func (m *Manager) WaitForReadDrained(terminalID string) bool {
 	m.mu.RLock()
 	t, ok := m.terminals[terminalID]
@@ -356,7 +382,7 @@ func (m *Manager) WaitForReadDrained(terminalID string) bool {
 	if !ok {
 		return false
 	}
-	t.WaitForReadDrained()
+	t.waitForReadDrained(0)
 	return true
 }
 

--- a/backend/internal/worker/terminal/pty_unix.go
+++ b/backend/internal/worker/terminal/pty_unix.go
@@ -1,0 +1,44 @@
+//go:build !windows
+
+package terminal
+
+import (
+	pty "github.com/aymanbagabas/go-pty"
+)
+
+// closePTYChildSide closes the pty end the child process wrote through: the
+// slave (tty). The kernel then hands the master reader every byte still
+// buffered and ends the next read with EIO, so readOutput drains and returns.
+//
+// go-pty keeps its own slave descriptor open in THIS process for the pty's
+// whole life (see unixPty), which is why the close has to happen here. Linux
+// ends a master read only when the LAST descriptor for the slave closes, so the
+// child exiting is not enough: without this close readOutput blocks for ever
+// and nothing that waits on the reader ever runs. Darwin hides the defect,
+// because it revokes the tty when the session leader exits.
+//
+// Closing the slave does not disturb a child that is still alive. Stop calls
+// this before it closes the master, and the child holds descriptors of its own
+// for the same tty.
+//
+// Terminal.closeChildSide is the only caller, and its once-guard is required by
+// the Windows implementation rather than by this one.
+func closePTYChildSide(p pty.Pty) {
+	u, ok := p.(pty.UnixPty)
+	if !ok {
+		// Unreachable: pty.New returns a unixPty on every non-Windows target.
+		// Close the whole pty rather than leave the reader blocked for ever.
+		// That costs the last unread chunk, which is better than a reader
+		// that never finishes.
+		_ = p.Close()
+		return
+	}
+	_ = u.Slave().Close()
+}
+
+// closePTYWorkerSide closes the end this process reads and writes through: the
+// master (ptmx). unixPty.Close closes both ends, and the already-closed slave
+// only makes it report an error that no caller acts on.
+func closePTYWorkerSide(p pty.Pty) {
+	_ = p.Close()
+}

--- a/backend/internal/worker/terminal/pty_windows.go
+++ b/backend/internal/worker/terminal/pty_windows.go
@@ -1,0 +1,51 @@
+//go:build windows
+
+package terminal
+
+import (
+	pty "github.com/aymanbagabas/go-pty"
+	"golang.org/x/sys/windows"
+)
+
+// closePTYChildSide closes the pty end the child process wrote through: the
+// pseudoconsole. The console host flushes what it still holds into the output
+// pipe and exits, which ends readOutput's next read with a broken pipe, so the
+// reader drains and returns.
+//
+// go-pty keeps the pseudoconsole open for the pty's whole life, and the console
+// host owns the only remaining write handle for the output pipe (see newPty in
+// that package). The child exiting therefore closes nothing: without this call
+// readOutput blocks for ever and nothing that waits on the reader ever runs.
+//
+// It closes the pseudoconsole ALONE, not the pipes that conPty.Close would take
+// with it. A pipe that closes here is a pipe the reader can no longer read, and
+// the bytes the console host just flushed into it are exactly the ones this
+// path exists to keep. closePTYWorkerSide closes them afterwards.
+//
+// Terminal.closeChildSide guards this with a sync.Once, which this
+// implementation requires: ClosePseudoConsole takes a raw handle that go-pty
+// does not clear, so a second call closes a handle this process no longer owns.
+func closePTYChildSide(p pty.Pty) {
+	c, ok := p.(pty.ConPty)
+	if !ok {
+		// Unreachable: pty.New returns a conPty on Windows. Close the whole pty
+		// rather than leave the reader blocked for ever. That costs the last
+		// unread chunk, which is better than a reader that never finishes.
+		_ = p.Close()
+		return
+	}
+	windows.ClosePseudoConsole(windows.Handle(c.Fd()))
+}
+
+// closePTYWorkerSide closes the ends this process reads and writes through: the
+// ConPTY input and output pipes. It does NOT route through conPty.Close, which
+// would close the pseudoconsole a second time.
+func closePTYWorkerSide(p pty.Pty) {
+	c, ok := p.(pty.ConPty)
+	if !ok {
+		_ = p.Close()
+		return
+	}
+	_ = c.InputPipe().Close()
+	_ = c.OutputPipe().Close()
+}

--- a/backend/internal/worker/terminal/terminal.go
+++ b/backend/internal/worker/terminal/terminal.go
@@ -302,10 +302,40 @@ type Terminal struct {
 	// cmd.Wait() in a separate goroutine, so a closed exitCh does NOT
 	// imply screenBuf writes have stopped — wait on this instead.
 	readDoneCh chan struct{}
+	// childSideClosedCh is closed once the natural-exit path finished closing
+	// the child side of the pty, which is the act that ends the reader.
+	//
+	// It exists so a caller that waits for the drain measures only the
+	// READER's own scheduling, as the drain grace claims to. exitCh closes
+	// first, and on Windows the close between the two blocks until the console
+	// host flushes -- so a grace started at exitCh would spend itself on that
+	// flush and give up before the reader ever ran.
+	//
+	// Only waitForExit closes it. Stop's own close does not, because Stop
+	// discards the unread output by design and nothing waits for its drain.
+	childSideClosedCh chan struct{}
 	// childSideOnce guards closePTYChildSide. Both the natural-exit path and
 	// Stop reach it, and on Windows it must run exactly once — see the Windows
 	// implementation for what a second call closes.
 	childSideOnce sync.Once
+	// ptyMu serializes a pty TEARDOWN against a pty CALL. Resize and SendInput
+	// take it for reading; closeChildSide and closeWorkerSide take it for
+	// writing.
+	//
+	// It exists because a natural exit now tears the pty down, and that path
+	// holds neither t.mu nor the `stopped` flag those two methods check: only
+	// Stop sets `stopped`, and a terminal that exits on its own stays in the
+	// manager until the user closes the tab. On Windows the teardown is
+	// ClosePseudoConsole on a raw handle that go-pty never clears, and go-pty's
+	// conPty takes its OWN mutex around both Close and Resize for exactly this
+	// reason -- so a resize that straddles the close would call
+	// ResizePseudoConsole on a handle another goroutine is closing.
+	//
+	// readOutput stays OUTSIDE it. Its Read blocks until the teardown ends it,
+	// so a reader holding this lock would deadlock the writer that must run to
+	// wake it. That is safe: on Windows Read uses the output pipe, which
+	// ClosePseudoConsole does not touch.
+	ptyMu sync.RWMutex
 }
 
 // Options configures a new Terminal.
@@ -432,14 +462,15 @@ func startWithScreenBuffer(ctx context.Context, opts Options, screenBuf *ScreenB
 	}
 
 	t := &Terminal{
-		id:         opts.ID,
-		cmd:        cmd,
-		ptmx:       ptmx,
-		jobObject:  jobObject,
-		outputFn:   wrappedOutput,
-		screenBuf:  screenBuf,
-		exitCh:     make(chan struct{}),
-		readDoneCh: make(chan struct{}),
+		id:                opts.ID,
+		cmd:               cmd,
+		ptmx:              ptmx,
+		jobObject:         jobObject,
+		outputFn:          wrappedOutput,
+		screenBuf:         screenBuf,
+		exitCh:            make(chan struct{}),
+		readDoneCh:        make(chan struct{}),
+		childSideClosedCh: make(chan struct{}),
 	}
 
 	go func() {
@@ -461,12 +492,16 @@ func startWithScreenBuffer(ctx context.Context, opts Options, screenBuf *ScreenB
 // SendInput writes data to the PTY.
 func (t *Terminal) SendInput(data []byte) error {
 	t.mu.Lock()
-	defer t.mu.Unlock()
-
 	if t.stopped {
+		t.mu.Unlock()
 		return fmt.Errorf("terminal is stopped")
 	}
+	t.mu.Unlock()
 
+	// ptyMu, not t.mu: `stopped` covers only a Stop, and a terminal that exited
+	// on its own tore its child side down without setting it. See ptyMu.
+	t.ptyMu.RLock()
+	defer t.ptyMu.RUnlock()
 	_, err := t.ptmx.Write(data)
 	return err
 }
@@ -474,12 +509,14 @@ func (t *Terminal) SendInput(data []byte) error {
 // Resize changes the terminal dimensions.
 func (t *Terminal) Resize(cols, rows uint16) error {
 	t.mu.Lock()
-	defer t.mu.Unlock()
-
 	if t.stopped {
+		t.mu.Unlock()
 		return fmt.Errorf("terminal is stopped")
 	}
+	t.mu.Unlock()
 
+	t.ptyMu.RLock()
+	defer t.ptyMu.RUnlock()
 	return t.ptmx.Resize(int(cols), int(rows))
 }
 
@@ -491,14 +528,21 @@ func (t *Terminal) Resize(cols, rows uint16) error {
 // Both pty ends close here, child side first. A forced stop discards whatever
 // the child wrote and nobody read yet, which is the point: the caller wants the
 // session gone, not drained.
+//
+// `stopped` is claimed under t.mu and the lock is RELEASED before the closes.
+// On Windows the child-side close blocks until the console host flushes, and a
+// natural exit can already be inside that call -- so holding t.mu across it
+// would stall every SendInput and Resize for the length of a flush this
+// terminal is not even performing. The claim is what makes the early return
+// above correct; the closes need only ptyMu, which they take themselves.
 func (t *Terminal) Stop() {
 	t.mu.Lock()
-	defer t.mu.Unlock()
-
 	if t.stopped {
+		t.mu.Unlock()
 		return
 	}
 	t.stopped = true
+	t.mu.Unlock()
 
 	t.closeChildSide()
 	t.closeWorkerSide()
@@ -521,36 +565,55 @@ func (t *Terminal) Wait() int {
 	return t.exitCode
 }
 
-// WaitForReadDrained blocks until readOutput has returned, after which
-// the screen buffer's cumulative offset is stable. Only returns once
-// the PTY is closed (via Stop or natural child exit).
-func (t *Terminal) WaitForReadDrained() {
-	<-t.readDoneCh
-}
-
-// waitForReadDrained is WaitForReadDrained with a bound, and reports whether
-// the reader finished inside it.
+// waitForReadDrained blocks until readOutput returns, after which the screen
+// buffer's cumulative offset is stable, and reports whether the reader finished
+// inside `within`. A non-positive `within` waits with no limit.
 //
-// The bound exists for a pty this worker cannot end. The natural-exit path
+// The limit exists for a pty this worker cannot end. The natural-exit path
 // closes the child side, and on a Unix tty that ends the reader only once the
 // LAST descriptor for it is gone -- so a descendant that escaped the shell's
 // kill group (a setsid daemon that inherited the tty) holds the reader open,
-// and this process cannot reach that descendant. On Windows the close itself
-// waits on the console host, which a parked output handler holds up. An
-// unbounded wait would strand the caller for ever in both cases. Giving up
-// returns a screen that can be one chunk short of the shell's last write, which
-// is what the caller received before the drain wait existed at all.
+// and this process cannot reach that descendant. A wait with no limit would
+// strand the caller for ever. Giving up returns a screen that can be one chunk
+// short of the shell's last write, which is what the caller received before the
+// drain wait existed at all.
+//
+// `within` is spent TWICE at most: once waiting for the child side to close --
+// the act that ends the reader, and not instant on Windows -- and once waiting
+// for the reader itself. Measured as one budget from the exit, the flush would
+// consume the grace and it would expire before the reader was ever scheduled.
+// Stop never closes childSideClosedCh, so a caller that stopped the terminal
+// takes the direct path below -- it discards the unread output by design.
 func (t *Terminal) waitForReadDrained(within time.Duration) bool {
 	if within <= 0 {
 		<-t.readDoneCh
 		return true
 	}
-	timer := time.NewTimer(within)
-	defer timer.Stop()
+	// TWO waits, each with its OWN budget of `within`, because each can hang for
+	// a different reason and neither may spend the other's budget.
+	//
+	// The close is itself a wait: on Windows ClosePseudoConsole blocks until the
+	// console host drains the output pipe, which a parked output handler can
+	// hold up for ever. One shared timer would put that flush inside the
+	// reader's grace and give up before the reader was ever scheduled -- on the
+	// one platform this whole path exists for. No timer at all would strand the
+	// caller there instead, which loses the exit outright.
+	closed := time.NewTimer(within)
+	defer closed.Stop()
+	select {
+	case <-t.childSideClosedCh:
+	case <-t.readDoneCh:
+		// Already finished, by Stop's close or by the child's own EOF.
+		return true
+	case <-closed.C:
+		return false
+	}
+	drained := time.NewTimer(within)
+	defer drained.Stop()
 	select {
 	case <-t.readDoneCh:
 		return true
-	case <-timer.C:
+	case <-drained.C:
 		return false
 	}
 }
@@ -558,10 +621,16 @@ func (t *Terminal) waitForReadDrained(within time.Duration) bool {
 // closeChildSide closes the pty end the child process wrote through, at most
 // once per terminal. The reader then drains what the child left behind and
 // returns; see closePTYChildSide for the per-platform mechanism.
+//
+// Under ptyMu, so no Resize or SendInput is inside a pty call while the handle
+// under it closes. The Once is INSIDE the lock, so a second caller waits for
+// the first close rather than returning while it is still in flight.
 func (t *Terminal) closeChildSide() {
 	if t.ptmx == nil {
 		return
 	}
+	t.ptyMu.Lock()
+	defer t.ptyMu.Unlock()
 	t.childSideOnce.Do(func() { closePTYChildSide(t.ptmx) })
 }
 
@@ -572,6 +641,8 @@ func (t *Terminal) closeWorkerSide() {
 	if t.ptmx == nil {
 		return
 	}
+	t.ptyMu.Lock()
+	defer t.ptyMu.Unlock()
 	closePTYWorkerSide(t.ptmx)
 }
 
@@ -686,12 +757,18 @@ func (t *Terminal) waitForExit() {
 	// Buffered output survives: both platforms hand the reader what is already
 	// there before they end the read.
 	//
-	// It runs AFTER exitCh, so no waiter on the exit is gated on it. On Windows
-	// this closes the pseudoconsole, which blocks until the console host
-	// flushes; a handler that parks the reader mid-chunk therefore parks this
-	// call too. Exiting is the fact the child established, and it is reported
-	// either way -- only the drain waits, and that wait is bounded.
+	// It runs AFTER exitCh, so nothing that waits on the exit has to wait for
+	// it. On Windows this closes the pseudoconsole, which blocks until the
+	// console host flushes; a handler that parks the reader mid-chunk therefore
+	// parks this call too. Exiting is the fact the child established, and it is
+	// reported either way -- only the drain waits, and that wait has a limit.
+	//
+	// childSideClosedCh is what keeps that limit measuring what it claims to.
+	// installTerminal's exit goroutine wakes on exitCh, so without this signal
+	// its grace would start HERE and the console-host flush would run inside
+	// it -- on the one platform this whole path exists for.
 	t.closeChildSide()
+	close(t.childSideClosedCh)
 
 	slog.Info("terminal exited",
 		"terminal_id", t.id,

--- a/backend/internal/worker/terminal/terminal.go
+++ b/backend/internal/worker/terminal/terminal.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"sync"
+	"time"
 
 	pty "github.com/aymanbagabas/go-pty"
 
@@ -301,6 +302,10 @@ type Terminal struct {
 	// cmd.Wait() in a separate goroutine, so a closed exitCh does NOT
 	// imply screenBuf writes have stopped — wait on this instead.
 	readDoneCh chan struct{}
+	// childSideOnce guards closePTYChildSide. Both the natural-exit path and
+	// Stop reach it, and on Windows it must run exactly once — see the Windows
+	// implementation for what a second call closes.
+	childSideOnce sync.Once
 }
 
 // Options configures a new Terminal.
@@ -479,9 +484,13 @@ func (t *Terminal) Resize(cols, rows uint16) error {
 }
 
 // Stop terminates the terminal session and every process spawned beneath
-// the shell. Closing the PTY master triggers the kernel's normal hang-up
+// the shell. Closing the PTY triggers the kernel's normal hang-up
 // flow; Terminate then reaps anything still alive in the shell's kill
 // group (JobObject on Windows, process-group SIGHUP+SIGKILL on Unix).
+//
+// Both pty ends close here, child side first. A forced stop discards whatever
+// the child wrote and nobody read yet, which is the point: the caller wants the
+// session gone, not drained.
 func (t *Terminal) Stop() {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -491,7 +500,8 @@ func (t *Terminal) Stop() {
 	}
 	t.stopped = true
 
-	_ = t.ptmx.Close()
+	t.closeChildSide()
+	t.closeWorkerSide()
 	if err := t.jobObject.Terminate(); err != nil {
 		slog.Debug("terminal job object terminate failed",
 			"terminal_id", t.id,
@@ -516,6 +526,53 @@ func (t *Terminal) Wait() int {
 // the PTY is closed (via Stop or natural child exit).
 func (t *Terminal) WaitForReadDrained() {
 	<-t.readDoneCh
+}
+
+// waitForReadDrained is WaitForReadDrained with a bound, and reports whether
+// the reader finished inside it.
+//
+// The bound exists for a pty this worker cannot end. The natural-exit path
+// closes the child side, and on a Unix tty that ends the reader only once the
+// LAST descriptor for it is gone -- so a descendant that escaped the shell's
+// kill group (a setsid daemon that inherited the tty) holds the reader open,
+// and this process cannot reach that descendant. On Windows the close itself
+// waits on the console host, which a parked output handler holds up. An
+// unbounded wait would strand the caller for ever in both cases. Giving up
+// returns a screen that can be one chunk short of the shell's last write, which
+// is what the caller received before the drain wait existed at all.
+func (t *Terminal) waitForReadDrained(within time.Duration) bool {
+	if within <= 0 {
+		<-t.readDoneCh
+		return true
+	}
+	timer := time.NewTimer(within)
+	defer timer.Stop()
+	select {
+	case <-t.readDoneCh:
+		return true
+	case <-timer.C:
+		return false
+	}
+}
+
+// closeChildSide closes the pty end the child process wrote through, at most
+// once per terminal. The reader then drains what the child left behind and
+// returns; see closePTYChildSide for the per-platform mechanism.
+func (t *Terminal) closeChildSide() {
+	if t.ptmx == nil {
+		return
+	}
+	t.childSideOnce.Do(func() { closePTYChildSide(t.ptmx) })
+}
+
+// closeWorkerSide closes the ends this process reads and writes through. Only
+// Stop calls it: a terminal that exited on its own keeps them open so
+// ScreenSnapshot and a later restart still work off the same instance.
+func (t *Terminal) closeWorkerSide() {
+	if t.ptmx == nil {
+		return
+	}
+	closePTYWorkerSide(t.ptmx)
 }
 
 // IsExited returns true if the terminal process has exited.
@@ -620,6 +677,21 @@ func (t *Terminal) waitForExit() {
 		)
 	}
 	close(t.exitCh)
+
+	// End the reader now that the shell and its kill group are gone. Nothing
+	// else will: the pty stays open for a terminal that exited on its own --
+	// the manager keeps the entry so restart-via-Enter can respawn into the
+	// same screen buffer -- and this process holds the child side of it, so
+	// readOutput would block on a pty that can never produce another byte.
+	// Buffered output survives: both platforms hand the reader what is already
+	// there before they end the read.
+	//
+	// It runs AFTER exitCh, so no waiter on the exit is gated on it. On Windows
+	// this closes the pseudoconsole, which blocks until the console host
+	// flushes; a handler that parks the reader mid-chunk therefore parks this
+	// call too. Exiting is the fact the child established, and it is reported
+	// either way -- only the drain waits, and that wait is bounded.
+	t.closeChildSide()
 
 	slog.Info("terminal exited",
 		"terminal_id", t.id,

--- a/backend/internal/worker/terminal/terminal_test.go
+++ b/backend/internal/worker/terminal/terminal_test.go
@@ -170,6 +170,38 @@ func TestTerminal_SendInputAfterStop(t *testing.T) {
 	assert.Error(t, term.SendInput([]byte("echo fail"+testutil.TestShellEnter())), "expected error sending input after stop")
 }
 
+// TestTerminal_StopAfterANaturalExitIsSafe pins the second teardown of a pty
+// this worker already tore down once.
+//
+// A shell that exits on its own closes the child side of its pty, and the tab
+// stays in the manager until the user closes it -- so the close that follows
+// runs Stop on a terminal whose child side is already gone. On Windows that
+// side is the pseudoconsole, whose handle go-pty does not clear, and a second
+// ClosePseudoConsole closes a handle this process no longer owns.
+func TestTerminal_StopAfterANaturalExitIsSafe(t *testing.T) {
+	term, err := Start(context.Background(), Options{
+		ID:         "test-natural-exit-stop",
+		Shell:      testutil.TestShell(),
+		WorkingDir: t.TempDir(),
+	}, func([]byte, int64, []Signal) {})
+	require.NoError(t, err, "Start")
+	t.Cleanup(term.Stop)
+
+	require.NoError(t, term.SendInput([]byte("exit"+testutil.TestShellEnter())), "SendInput")
+	term.Wait()
+	select {
+	case <-term.readDoneCh:
+	case <-time.After(30 * time.Second):
+		require.FailNow(t, "the reader never ended after the shell exited on its own")
+	}
+
+	assert.NotPanics(t, func() {
+		term.Stop()
+		term.Stop()
+	}, "a close after a natural exit tore the pty down a second time")
+	assert.True(t, term.IsExited())
+}
+
 func TestTerminal_IsExited(t *testing.T) {
 	term, err := Start(context.Background(), Options{
 		ID:         "test-exited",
@@ -284,12 +316,9 @@ func TestManager_ExitNotification(t *testing.T) {
 // handler that runs first snapshots a screen the reader can still grow, and a
 // natural exit persists only once, so the row keeps the truncated copy.
 //
-// The two signals are driven by hand rather than by a real shell. Through a
-// PTY the reader wins this race on any unloaded machine -- waitForExit polls
-// for the process group's death before it closes exitCh, which hands the reader
-// all the time it needs -- so a shell-driven version of this test passes
-// whether the wait is there or not. That is exactly how the loss reached CI:
-// visible only on a runner slow enough to lose the race.
+// The two signals are driven by hand rather than by a real shell, so the order
+// is asserted rather than raced for. What ENDS a real reader is the subject of
+// TestManager_NaturalExitRunsTheExitHandler; this test covers only the wait.
 func TestInstallTerminal_ExitHandlerWaitsForTheReaderToDrain(t *testing.T) {
 	m := NewManager()
 	const id = "tm-exit-order"
@@ -323,6 +352,150 @@ func TestInstallTerminal_ExitHandlerWaitsForTheReaderToDrain(t *testing.T) {
 		require.Fail(t, "the exit handler never ran after the reader drained")
 	}
 	m.WaitForExit(id)
+}
+
+// TestInstallTerminal_ExitHandlerGivesUpOnAReaderThatNeverDrains pins the bound
+// on that wait. A tty can outlive the kill group that this worker can reach --
+// a setsid descendant that inherited it keeps every descriptor for it open --
+// and the reader for such a pty never returns. The handler is the only persist
+// a natural exit performs, so waiting for ever would lose the exit code and the
+// screen outright. A screen one chunk short is the better answer.
+func TestInstallTerminal_ExitHandlerGivesUpOnAReaderThatNeverDrains(t *testing.T) {
+	m := NewManager()
+	// A real grace would spend itself on every run of this test for nothing:
+	// the reader here is one that never drains, by construction.
+	m.readDrainGrace = 10 * time.Millisecond
+	const id = "tm-exit-stuck-reader"
+
+	term := &Terminal{
+		id:         id,
+		exitCh:     make(chan struct{}),
+		readDoneCh: make(chan struct{}),
+		screenBuf:  NewScreenBuffer(),
+	}
+	ran := make(chan struct{})
+	m.installTerminal(id, term, func(string, int) { close(ran) },
+		func(TerminalMeta) TerminalMeta { return TerminalMeta{} })
+
+	// The child is reaped and the reader never finishes.
+	close(term.exitCh)
+	select {
+	case <-ran:
+	case <-time.After(10 * time.Second):
+		require.Fail(t, "the exit handler never ran for a reader that never drained")
+	}
+	m.WaitForExit(id)
+}
+
+// readerEnded reports whether the terminal's read goroutine has returned. It
+// reaches into the manager because the drain signal is what the assertion is
+// about and no exported call answers it without blocking.
+func readerEnded(m *Manager, id string) bool {
+	m.mu.RLock()
+	t, ok := m.terminals[id]
+	m.mu.RUnlock()
+	if !ok {
+		return false
+	}
+	select {
+	case <-t.readDoneCh:
+		return true
+	default:
+		return false
+	}
+}
+
+// TestManager_NaturalExitRunsTheExitHandler pins that a shell which exits on
+// its own reaches the exit handler, carrying the output it wrote last, with no
+// caller stopping the terminal first.
+//
+// Nothing about the child ends the reader. This process holds the child side of
+// the pty open for the pty's whole life -- go-pty's slave descriptor on Unix,
+// the pseudoconsole on Windows -- and a master read ends only when the last
+// descriptor for the tty is gone, so the reaped shell leaves the reader blocked
+// on a pty that can never produce another byte. waitForExit closing that side
+// is what ends it. Darwin is the one platform that hides the defect, because it
+// revokes the tty when the session leader exits.
+func TestManager_NaturalExitRunsTheExitHandler(t *testing.T) {
+	m := NewManager()
+	const id = "tm-natural-exit"
+	const marker = "natural_exit_marker"
+	const lastMarker = "natural_exit_last_write"
+
+	type exitReport struct {
+		code    int
+		screen  []byte
+		drained bool
+	}
+	exited := make(chan exitReport, 1)
+	require.NoError(t, m.StartTerminal(context.Background(), Options{
+		ID:         id,
+		Shell:      testutil.TestShell(),
+		WorkingDir: t.TempDir(),
+		Cols:       200,
+		Rows:       24,
+	}, func([]byte, int64, []Signal) {}, func(tid string, code int) {
+		// Snapshot the way the service's exit handler does: this is the only
+		// persist a natural exit performs, so what is on the screen HERE is
+		// what the tab keeps.
+		screen, _, _ := m.ScreenSnapshotSince(tid, 0)
+		// Read the drain signal HERE, not after: the handler runs either
+		// because the reader ended or because the bound expired, and only this
+		// point tells the two apart. Asserting on the handler alone would pass
+		// on the give-up path and hide the very defect this test covers.
+		exited <- exitReport{code: code, screen: screen, drained: readerEnded(m, tid)}
+	}))
+	t.Cleanup(func() { m.RemoveTerminal(id) })
+
+	// Echo a marker first and wait for it, so the shell is past its init
+	// scripts and the exit below cannot be read before them.
+	require.NoError(t, m.SendInput(id, []byte("echo "+marker+testutil.TestShellEnter())))
+	testutil.AssertEventually(t, func() bool {
+		screen, _, _ := m.ScreenSnapshotSince(id, 0)
+		return bytes.Contains(screen, []byte(marker))
+	}, "expected the shell to echo the marker")
+
+	// cmd.exe under ConPTY does not propagate `exit N` to its OS exit code on
+	// the GitHub runner, so ask for a bare exit there and assert only that the
+	// handler ran. The persisted-code contract is covered cross-platform by the
+	// service's own tests.
+	exitArg := " 7"
+	if runtime.GOOS == "windows" {
+		exitArg = ""
+	}
+	// The LAST thing the shell writes, sent back to back with the exit and
+	// deliberately NOT waited for. Those bytes are the ones the drain is about:
+	// they can still sit unread in the pty when the child is reaped, and a
+	// handler that snapshots without them persists a screen missing the last
+	// thing the user saw. Two writes rather than one line, so no shell's
+	// command separator (`;` against cmd.exe's `&`) gets in the way.
+	require.NoError(t, m.SendInput(id, []byte("echo "+lastMarker+testutil.TestShellEnter())))
+	require.NoError(t, m.SendInput(id, []byte("exit"+exitArg+testutil.TestShellEnter())))
+
+	var got exitReport
+	select {
+	case got = <-exited:
+	case <-time.After(30 * time.Second):
+		require.Fail(t, "the exit handler never ran for a shell that exited on its own")
+	}
+
+	require.True(t, got.drained,
+		"the natural exit must end the reader; the handler only ran because the bound expired")
+
+	if runtime.GOOS != "windows" {
+		assert.Equal(t, 7, got.code, "the handler must carry the shell's own exit code")
+		// The drain is what puts these here: the shell wrote them before it
+		// exited, and the handler snapshots after the reader applied them.
+		assert.Contains(t, string(got.screen), marker,
+			"the screen the handler persists must carry the shell's output")
+		assert.Contains(t, string(got.screen), lastMarker,
+			"the shell's LAST write was lost; the handler snapshotted before the reader applied it")
+	}
+
+	// The child side of the pty is closed twice on this path: once by the
+	// natural exit above, once by this close. On Windows an unguarded second
+	// close would close a pseudoconsole handle this process no longer owns.
+	m.RemoveTerminal(id)
 }
 
 func TestManager_StopAll(t *testing.T) {

--- a/backend/internal/worker/terminal/terminal_test.go
+++ b/backend/internal/worker/terminal/terminal_test.go
@@ -202,6 +202,75 @@ func TestTerminal_StopAfterANaturalExitIsSafe(t *testing.T) {
 	assert.True(t, term.IsExited())
 }
 
+// TestTerminal_ResizeRacingANaturalExitIsSafe drives the window the pty lock
+// exists for.
+//
+// A shell that exits on its own tears its pty down from waitForExit, and that
+// path holds neither t.mu nor the `stopped` flag Resize and SendInput check --
+// only Stop sets `stopped`, and a naturally-exited tab stays in the manager
+// until the user closes it. So a resize the user fires as the shell ends runs
+// against a pty another goroutine is closing. On Windows that is
+// ClosePseudoConsole against ResizePseudoConsole on ONE raw handle, and go-pty
+// takes its own mutex around that pair for exactly this reason -- which the
+// per-platform close bypasses, so Terminal.ptyMu is what serializes them.
+//
+// WHERE IT BITES is Windows, and this says so because the test passes on Unix
+// either way: there the close takes the slave and the resize takes the master,
+// two different descriptors and no shared state, so even `-race` reports
+// nothing with the lock removed. On the windows-latest CI job the same run
+// drives two console APIs at one handle. Read a Unix pass as a smoke test --
+// no panic, no hang, and the exit still lands -- and the Windows job as the
+// assertion.
+func TestTerminal_ResizeRacingANaturalExitIsSafe(t *testing.T) {
+	term, err := Start(context.Background(), Options{
+		ID:         "test-resize-race-natural-exit",
+		Shell:      testutil.TestShell(),
+		WorkingDir: t.TempDir(),
+		Cols:       80,
+		Rows:       24,
+	}, func([]byte, int64, []Signal) {})
+	require.NoError(t, err, "Start")
+	t.Cleanup(term.Stop)
+
+	// Keep resizing and writing for the whole of the exit, so at least one call
+	// lands inside the teardown however the scheduler orders them. Errors are
+	// expected once the pty is gone; a PANIC is not, and neither is a hang.
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	for i := range 4 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			assert.NotPanics(t, func() {
+				for n := 0; ; n++ {
+					select {
+					case <-stop:
+						return
+					default:
+					}
+					_ = term.Resize(uint16(80+(n+i)%20), 24)
+					_ = term.SendInput([]byte(""))
+				}
+			}, "a pty call that straddled the natural-exit teardown panicked")
+		}(i)
+	}
+
+	require.NoError(t, term.SendInput([]byte("exit"+testutil.TestShellEnter())), "SendInput")
+	term.Wait()
+	select {
+	case <-term.readDoneCh:
+	case <-time.After(30 * time.Second):
+		require.FailNow(t, "the reader never ended after the shell exited on its own")
+	}
+	close(stop)
+	wg.Wait()
+
+	assert.True(t, term.IsExited())
+	// And the close that follows still runs, on a pty one of those calls may
+	// have been inside.
+	assert.NotPanics(t, term.Stop)
+}
+
 func TestTerminal_IsExited(t *testing.T) {
 	term, err := Start(context.Background(), Options{
 		ID:         "test-exited",
@@ -323,24 +392,27 @@ func TestInstallTerminal_ExitHandlerWaitsForTheReaderToDrain(t *testing.T) {
 	m := NewManager()
 	const id = "tm-exit-order"
 
-	// No PTY: only the two channels installTerminal orders against.
+	// No PTY: only the channels installTerminal orders against.
 	term := &Terminal{
-		id:         id,
-		exitCh:     make(chan struct{}),
-		readDoneCh: make(chan struct{}),
-		screenBuf:  NewScreenBuffer(),
+		id:                id,
+		exitCh:            make(chan struct{}),
+		readDoneCh:        make(chan struct{}),
+		childSideClosedCh: make(chan struct{}),
+		screenBuf:         NewScreenBuffer(),
 	}
 	ran := make(chan struct{})
 	m.installTerminal(id, term, func(string, int) { close(ran) },
 		func(TerminalMeta) TerminalMeta { return TerminalMeta{} })
 
-	// The child is reaped, and the reader has not finished.
+	// The child is reaped and the child side of the pty is closed, in the order
+	// waitForExit performs them. The reader has not finished.
 	close(term.exitCh)
+	close(term.childSideClosedCh)
 	select {
 	case <-ran:
 		require.Fail(t, "the exit handler ran while the reader could still write the screen it persists")
 	case <-time.After(100 * time.Millisecond):
-		// The window only bounds a "has not happened yet" claim, so a slow
+		// The window only limits a "has not happened yet" claim, so a slow
 		// machine can only make this case weaker, never make it fail wrongly.
 		// Without the wait the handler runs at once and this fails every run.
 	}
@@ -354,7 +426,7 @@ func TestInstallTerminal_ExitHandlerWaitsForTheReaderToDrain(t *testing.T) {
 	m.WaitForExit(id)
 }
 
-// TestInstallTerminal_ExitHandlerGivesUpOnAReaderThatNeverDrains pins the bound
+// TestInstallTerminal_ExitHandlerGivesUpOnAReaderThatNeverDrains pins the limit
 // on that wait. A tty can outlive the kill group that this worker can reach --
 // a setsid descendant that inherited it keeps every descriptor for it open --
 // and the reader for such a pty never returns. The handler is the only persist
@@ -368,17 +440,20 @@ func TestInstallTerminal_ExitHandlerGivesUpOnAReaderThatNeverDrains(t *testing.T
 	const id = "tm-exit-stuck-reader"
 
 	term := &Terminal{
-		id:         id,
-		exitCh:     make(chan struct{}),
-		readDoneCh: make(chan struct{}),
-		screenBuf:  NewScreenBuffer(),
+		id:                id,
+		exitCh:            make(chan struct{}),
+		readDoneCh:        make(chan struct{}),
+		childSideClosedCh: make(chan struct{}),
+		screenBuf:         NewScreenBuffer(),
 	}
 	ran := make(chan struct{})
 	m.installTerminal(id, term, func(string, int) { close(ran) },
 		func(TerminalMeta) TerminalMeta { return TerminalMeta{} })
 
-	// The child is reaped and the reader never finishes.
+	// The child is reaped, the child side is closed, and the reader never
+	// finishes.
 	close(term.exitCh)
+	close(term.childSideClosedCh)
 	select {
 	case <-ran:
 	case <-time.After(10 * time.Second):
@@ -387,7 +462,56 @@ func TestInstallTerminal_ExitHandlerGivesUpOnAReaderThatNeverDrains(t *testing.T
 	m.WaitForExit(id)
 }
 
-// readerEnded reports whether the terminal's read goroutine has returned. It
+// TestInstallTerminal_TheGraceStartsAtTheChildSideClose pins WHERE the drain
+// grace begins, which is the difference between the grace measuring what its
+// own comment claims and measuring something else entirely.
+//
+// waitForExit closes exitCh FIRST and the child side of the pty after it, and
+// installTerminal's goroutine wakes on exitCh. On Windows the close between the
+// two blocks until the console host flushes -- so a grace started at the exit
+// would spend itself on that flush and give up before the reader was ever
+// scheduled, losing the shell's last output on the one platform this whole path
+// exists for.
+func TestInstallTerminal_TheGraceStartsAtTheChildSideClose(t *testing.T) {
+	m := NewManager()
+	// Each phase below takes well under the grace on its own, and their SUM
+	// takes well over it -- so this passes only if the two phases hold separate
+	// budgets, and fails for one shared budget started at the exit.
+	m.readDrainGrace = 500 * time.Millisecond
+	const phase = 300 * time.Millisecond
+	const id = "tm-exit-late-child-close"
+
+	term := &Terminal{
+		id:                id,
+		exitCh:            make(chan struct{}),
+		readDoneCh:        make(chan struct{}),
+		childSideClosedCh: make(chan struct{}),
+		screenBuf:         NewScreenBuffer(),
+	}
+	drained := make(chan bool, 1)
+	m.installTerminal(id, term, func(string, int) { drained <- readerEnded(m, id) },
+		func(TerminalMeta) TerminalMeta { return TerminalMeta{} })
+
+	// The child is reaped. The close that ends the reader takes a while --
+	// stand in for the console-host flush.
+	close(term.exitCh)
+	time.Sleep(phase)
+	close(term.childSideClosedCh)
+	// Only NOW does the reader wake, and it takes a while of its own.
+	time.Sleep(phase)
+	close(term.readDoneCh)
+
+	select {
+	case ok := <-drained:
+		assert.True(t, ok,
+			"the flush before the child-side close spent the reader's own grace; the two need separate budgets")
+	case <-time.After(10 * time.Second):
+		require.Fail(t, "the exit handler never ran")
+	}
+	m.WaitForExit(id)
+}
+
+// readerEnded reports whether the terminal's read goroutine returned. It
 // reaches into the manager because the drain signal is what the assertion is
 // about and no exported call answers it without blocking.
 func readerEnded(m *Manager, id string) bool {
@@ -418,6 +542,11 @@ func readerEnded(m *Manager, id string) bool {
 // revokes the tty when the session leader exits.
 func TestManager_NaturalExitRunsTheExitHandler(t *testing.T) {
 	m := NewManager()
+	// A LONGER grace than production's, because this test asserts that the
+	// reader drained and the production value is what decides that on a loaded
+	// runner. Shortening it would make the flake worse, and zero would remove
+	// the limit entirely, which turns `drained` into a tautology.
+	m.readDrainGrace = 30 * time.Second
 	const id = "tm-natural-exit"
 	const marker = "natural_exit_marker"
 	const lastMarker = "natural_exit_last_write"
@@ -440,7 +569,7 @@ func TestManager_NaturalExitRunsTheExitHandler(t *testing.T) {
 		// what the tab keeps.
 		screen, _, _ := m.ScreenSnapshotSince(tid, 0)
 		// Read the drain signal HERE, not after: the handler runs either
-		// because the reader ended or because the bound expired, and only this
+		// because the reader ended or because the grace expired, and only this
 		// point tells the two apart. Asserting on the handler alone would pass
 		// on the give-up path and hide the very defect this test covers.
 		exited <- exitReport{code: code, screen: screen, drained: readerEnded(m, tid)}
@@ -480,7 +609,7 @@ func TestManager_NaturalExitRunsTheExitHandler(t *testing.T) {
 	}
 
 	require.True(t, got.drained,
-		"the natural exit must end the reader; the handler only ran because the bound expired")
+		"the natural exit must end the reader; the handler only ran because the grace expired")
 
 	if runtime.GOOS != "windows" {
 		assert.Equal(t, 7, got.code, "the handler must carry the shell's own exit code")

--- a/frontend/src/components/backgroundtasks/BackgroundTaskList.css.ts
+++ b/frontend/src/components/backgroundtasks/BackgroundTaskList.css.ts
@@ -218,7 +218,7 @@ export const taskTitleCommand = style({
 // One clipped line, like the title. The activity text a provider reports
 // ("Running <what>", a tool name, a token tally) is often longer than the
 // sidebar is wide, so the full string is on the tooltip that ClippedText
-// attaches -- see renderSecondary in the component.
+// attaches -- see the secondary line in `rowBody` in the component.
 export const taskSecondary = style({
   fontSize: 'var(--text-8)',
   color: 'var(--muted-foreground)',

--- a/frontend/src/components/backgroundtasks/BackgroundTaskList.test.tsx
+++ b/frontend/src/components/backgroundtasks/BackgroundTaskList.test.tsx
@@ -1,8 +1,12 @@
+import type { BackgroundTaskItem as ProtoBackgroundTaskItem } from '~/generated/proto/leapmux/v1/agent_pb'
 import type { BackgroundTaskItem } from '~/stores/chatBackgroundTasks'
 import { fireEvent, render } from '@solidjs/testing-library'
+import { createStore } from 'solid-js/store'
 import { describe, expect, it, vi } from 'vitest'
 import { BackgroundTaskList } from '~/components/backgroundtasks/BackgroundTaskList'
 import * as styles from '~/components/backgroundtasks/BackgroundTaskList.css'
+import { BackgroundTaskKind, BackgroundTaskStatus } from '~/generated/proto/leapmux/v1/agent_pb'
+import { createBackgroundTaskStore } from '~/stores/chatBackgroundTaskStore'
 import { clippedText } from '~/styles/shared.css'
 import { hoverForTooltip, stubClipped, stubFitting } from '~/test-support/clipStub'
 import { classSelector } from '~/test-support/composedClass'
@@ -15,6 +19,25 @@ function row(over: Partial<BackgroundTaskItem> & { rowKey: string }): Background
     status: over.status ?? 'running',
     ...over,
   }
+}
+
+/** One wire row, for the cases that drive the real store rather than a literal list. */
+function protoTask(id: string, title: string, activeForm: string): ProtoBackgroundTaskItem {
+  return {
+    id,
+    kind: BackgroundTaskKind.SUBAGENT,
+    status: BackgroundTaskStatus.RUNNING,
+    title,
+    activeForm,
+    childAgentId: '',
+    parentAgentId: '',
+    groupKey: '',
+    groupLabel: '',
+    description: '',
+    createdAt: '',
+    updatedAt: '',
+    endedAt: '',
+  } as ProtoBackgroundTaskItem
 }
 
 /**
@@ -614,5 +637,143 @@ describe('backgroundTaskList load failure', () => {
     expect(rowsText(container)).not.toContain('Could not load background tasks')
     expect(queryByTestId('bg-task-empty')).not.toBeNull()
     expect(queryByTestId('bg-task-load-failed')).toBeNull()
+  })
+})
+
+/**
+ * What a row must NOT rebuild when one of its fields changes.
+ *
+ * The registry arrives whole on every broadcast, so a subagent that reports
+ * progress every few seconds redraws the section that often. A row rebuilt from
+ * scratch takes its tooltip and its animations with it: the full-title tooltip
+ * the pointer was resting on closed and reopened, and the status dot restarted
+ * its pulse -- both under a cursor that never moved.
+ *
+ * The store half is `setReconciled` in `~/stores/chatPerAgentStore`, which is
+ * what keeps a row's identity across the broadcast. These cases hold the
+ * component half: one field changing must update ONE binding.
+ */
+describe('backgroundTaskList in-place updates', () => {
+  /** A store-backed list, which is the shape the sidebar actually renders. */
+  function renderLiveList(initial: BackgroundTaskItem[]) {
+    const [tasks, setTasks] = createStore<BackgroundTaskItem[]>(initial)
+    const result = render(() => <BackgroundTaskList variant="sidebar" tasks={tasks} />)
+    return { ...result, setTasks }
+  }
+
+  it('leaves the title and the status dot alone when the activity changes', () => {
+    const { container, setTasks } = renderLiveList([
+      row({ rowKey: 't1', title: 'Review the diff', status: 'running', activity: 'reading' }),
+    ])
+    const titleBefore = titles(container)[0]!
+    const dotBefore = container.querySelector('[data-testid="bg-task-status-dot"]')!
+    const rowBefore = container.querySelector('[data-testid="bg-task-row"]')!
+
+    setTasks(0, 'activity', 'writing')
+
+    expect(secondaries(container)[0]!.textContent).toBe('writing')
+    expect(titles(container)[0]).toBe(titleBefore)
+    expect(container.querySelector('[data-testid="bg-task-status-dot"]')).toBe(dotBefore)
+    expect(container.querySelector('[data-testid="bg-task-row"]')).toBe(rowBefore)
+  })
+
+  it('updates the title in place when the title changes', () => {
+    const { container, setTasks } = renderLiveList([
+      row({ rowKey: 't1', title: 'Untitled work', status: 'running', activity: 'reading' }),
+    ])
+    const titleBefore = titles(container)[0]!
+
+    setTasks(0, 'title', 'Review the diff')
+
+    expect(titles(container)[0]).toBe(titleBefore)
+    expect(titleBefore.textContent).toBe('Review the diff')
+  })
+
+  // `data-status` is what the E2E suite selects a finished row by, and the
+  // strike-through class is how a finished row reads. Both were correct only
+  // because the row used to be rebuilt; a row that survives has to carry them
+  // reactively.
+  it('follows a status change on the row and its dot without rebuilding either', () => {
+    const { container, setTasks } = renderLiveList([
+      row({ rowKey: 't1', title: 'Review the diff', status: 'running', activity: 'reading' }),
+    ])
+    const rowBefore = container.querySelector<HTMLElement>('[data-testid="bg-task-row"]')!
+    const dotBefore = container.querySelector<HTMLElement>('[data-testid="bg-task-status-dot"]')!
+
+    setTasks(0, 'status', 'completed')
+
+    expect(container.querySelector('[data-testid="bg-task-row"]')).toBe(rowBefore)
+    expect(rowBefore.dataset.status).toBe('completed')
+    expect(classes(rowBefore)).toContain(styles.taskStruck)
+    expect(container.querySelector('[data-testid="bg-task-status-dot"]')).toBe(dotBefore)
+    expect(classes(dotBefore)).toContain(styles.statusDotSuccess)
+  })
+
+  // The row becomes clickable only once the worker reports the child agent id,
+  // which arrives in a later broadcast than the row itself.
+  it('turns into a button once the child agent id arrives', () => {
+    const [tasks, setTasks] = createStore<BackgroundTaskItem[]>([
+      row({ rowKey: 't1', title: 'Review the diff', status: 'running' }),
+    ])
+    const { container } = render(() => (
+      <BackgroundTaskList variant="sidebar" tasks={tasks} onOpenSubagent={() => {}} />
+    ))
+    expect(container.querySelector('[data-testid="bg-task-row"]')!.tagName).toBe('DIV')
+
+    setTasks(0, 'childAgentId', 'c1')
+
+    const el = container.querySelector<HTMLElement>('[data-testid="bg-task-row"]')!
+    expect(el.tagName).toBe('BUTTON')
+    expect(el.dataset.childAgentId).toBe('c1')
+  })
+
+  /**
+   * The reported bug, end to end, through the real store.
+   *
+   * The worker rebroadcasts the WHOLE registry whenever one row changes, so this
+   * is the path the sidebar actually takes -- and the one the two halves of the
+   * fix have to survive together. The tooltip is what made it visible: a
+   * tooltip closes with the element it is attached to, so a row rebuilt under a
+   * stationary pointer blinks.
+   */
+  it('keeps a hovered title tooltip open across a whole-registry rebroadcast', () => {
+    vi.useFakeTimers()
+    try {
+      const store = createBackgroundTaskStore()
+      const long = 'A title far wider than the row that holds it'
+      store.replace('a1', [protoTask('t1', long, 'reading')])
+      const { container } = render(() => (
+        <BackgroundTaskList variant="sidebar" tasks={store.get('a1')} />
+      ))
+
+      const title = titles(container)[0]!
+      stubClipped(title)
+      expect(hoverForTooltip(title)?.textContent).toBe(long)
+
+      store.replace('a1', [protoTask('t1', long, 'writing')])
+
+      expect(secondaries(container)[0]!.textContent).toBe('writing')
+      expect(titles(container)[0]).toBe(title)
+      expect(document.querySelector('[role="tooltip"]')?.textContent).toBe(long)
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+
+  // The other half of the same rebroadcast: a dot that is rebuilt restarts its
+  // pulse from the top, which reads as a blink on a row that only reported new
+  // activity.
+  it('keeps the status dot across a whole-registry rebroadcast', () => {
+    const store = createBackgroundTaskStore()
+    store.replace('a1', [protoTask('t1', 'Review the diff', 'reading')])
+    const { container } = render(() => (
+      <BackgroundTaskList variant="sidebar" tasks={store.get('a1')} />
+    ))
+    const dot = container.querySelector('[data-testid="bg-task-status-dot"]')!
+
+    store.replace('a1', [protoTask('t1', 'Review the diff', 'writing')])
+
+    expect(container.querySelector('[data-testid="bg-task-status-dot"]')).toBe(dot)
   })
 })

--- a/frontend/src/components/backgroundtasks/BackgroundTaskList.test.tsx
+++ b/frontend/src/components/backgroundtasks/BackgroundTaskList.test.tsx
@@ -646,8 +646,8 @@ describe('backgroundTaskList load failure', () => {
  * The registry arrives whole on every broadcast, so a subagent that reports
  * progress every few seconds redraws the section that often. A row rebuilt from
  * scratch takes its tooltip and its animations with it: the full-title tooltip
- * the pointer was resting on closed and reopened, and the status dot restarted
- * its pulse -- both under a cursor that never moved.
+ * under the pointer closed and reopened, and the status dot restarted its pulse
+ * -- both under a cursor that never moved.
  *
  * The store half is `setReconciled` in `~/stores/chatPerAgentStore`, which is
  * what keeps a row's identity across the broadcast. These cases hold the
@@ -710,21 +710,129 @@ describe('backgroundTaskList in-place updates', () => {
   })
 
   // The row becomes clickable only once the worker reports the child agent id,
-  // which arrives in a later broadcast than the row itself.
-  it('turns into a button once the child agent id arrives', () => {
+  // which arrives in a later broadcast than the row itself -- so the TAG cannot
+  // depend on it. A `Show` keyed on the id swapped a <div> for a <button> and
+  // rebuilt the whole row body at exactly the moment the user is watching that
+  // row spawn: the title tooltip closed and the status dot's pulse restarted,
+  // which is the flicker every other case here exists to prevent.
+  it('becomes clickable without rebuilding the row when the child agent id arrives', () => {
     const [tasks, setTasks] = createStore<BackgroundTaskItem[]>([
       row({ rowKey: 't1', title: 'Review the diff', status: 'running' }),
+    ])
+    const onOpenSubagent = vi.fn()
+    const { container } = render(() => (
+      <BackgroundTaskList variant="sidebar" tasks={tasks} onOpenSubagent={onOpenSubagent} />
+    ))
+    const rowBefore = container.querySelector<HTMLElement>('[data-testid="bg-task-row"]')!
+    const dotBefore = container.querySelector('[data-testid="bg-task-status-dot"]')!
+    // Always a button, so nothing about the id can change the element.
+    expect(rowBefore.tagName).toBe('BUTTON')
+    // ...but not yet an ENABLED one: there is no transcript to open.
+    expect(rowBefore.getAttribute('aria-disabled')).toBe('true')
+    expect(classes(rowBefore)).toContain(styles.taskRowStatic)
+    fireEvent.click(rowBefore)
+    expect(onOpenSubagent).not.toHaveBeenCalled()
+
+    setTasks(0, 'childAgentId', 'c1')
+
+    expect(container.querySelector('[data-testid="bg-task-row"]')).toBe(rowBefore)
+    expect(container.querySelector('[data-testid="bg-task-status-dot"]')).toBe(dotBefore)
+    expect(rowBefore.dataset.childAgentId).toBe('c1')
+    expect(rowBefore.getAttribute('aria-disabled')).toBeNull()
+    expect(classes(rowBefore)).not.toContain(styles.taskRowStatic)
+    fireEvent.click(rowBefore)
+    expect(onOpenSubagent).toHaveBeenCalledTimes(1)
+  })
+
+  // `aria-disabled`, never the `disabled` attribute. A disabled control
+  // dispatches no pointer event of its own OR to its descendants, so the row's
+  // own title tooltip would be unreachable for as long as the subagent spawns --
+  // and that tooltip is the only route to a clipped title.
+  it('leaves a not-yet-openable row able to show its own title tooltip', () => {
+    vi.useFakeTimers()
+    try {
+      const long = 'A title far wider than the row that holds it'
+      const [tasks] = createStore<BackgroundTaskItem[]>([
+        row({ rowKey: 't1', title: long, status: 'running' }),
+      ])
+      const { container } = render(() => (
+        <BackgroundTaskList variant="sidebar" tasks={tasks} onOpenSubagent={() => {}} />
+      ))
+      const el = container.querySelector<HTMLButtonElement>('[data-testid="bg-task-row"]')!
+      expect(el.getAttribute('aria-disabled')).toBe('true')
+      expect(el.disabled).toBe(false)
+
+      const title = titles(container)[0]!
+      stubClipped(title)
+      expect(hoverForTooltip(title)?.textContent).toBe(long)
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+
+  // A shell row can never open a transcript, so it is not a button at all --
+  // the tag still follows the one field that cannot change over a row's life.
+  it('draws a shell row as a plain element', () => {
+    const [tasks] = createStore<BackgroundTaskItem[]>([
+      row({ rowKey: 't1', title: 'npm test', kind: 'shell', status: 'running' }),
     ])
     const { container } = render(() => (
       <BackgroundTaskList variant="sidebar" tasks={tasks} onOpenSubagent={() => {}} />
     ))
     expect(container.querySelector('[data-testid="bg-task-row"]')!.tagName).toBe('DIV')
+  })
 
-    setTasks(0, 'childAgentId', 'c1')
+  /**
+   * The same guarantee for a GROUPED row, which is where a real Claude workflow
+   * puts every subagent it spawns.
+   *
+   * `groupBackgroundTasks` builds fresh group objects on every run, and the
+   * memo it feeds re-runs on any status change, because the sort reads
+   * `status`. Iterating those objects with `For` -- which reconciles by
+   * reference -- therefore tore down and rebuilt every row of the section
+   * whenever ANY row in the list changed status, however well the store
+   * reconciled the items underneath. Every other case in this describe uses an
+   * ungrouped fixture and passes either way.
+   */
+  it('keeps a grouped row and its dot across a status change elsewhere in the group', () => {
+    const { container, setTasks } = renderLiveList([
+      row({ rowKey: 't1', title: 'Review the diff', status: 'running', groupKey: 'wf:x', groupLabel: 'Workflow' }),
+      row({ rowKey: 't2', title: 'Write the tests', status: 'pending', groupKey: 'wf:x', groupLabel: 'Workflow' }),
+    ])
+    const rowsBefore = [...container.querySelectorAll('[data-testid="bg-task-row"]')]
+    const dotsBefore = [...container.querySelectorAll('[data-testid="bg-task-status-dot"]')]
+    expect(rowsBefore).toHaveLength(2)
 
-    const el = container.querySelector<HTMLElement>('[data-testid="bg-task-row"]')!
-    expect(el.tagName).toBe('BUTTON')
-    expect(el.dataset.childAgentId).toBe('c1')
+    // The SECOND row finishes. The first one did not change at all.
+    setTasks(1, 'status', 'completed')
+
+    const rowsAfter = [...container.querySelectorAll('[data-testid="bg-task-row"]')]
+    expect(rowsAfter[0]).toBe(rowsBefore[0])
+    expect([...container.querySelectorAll('[data-testid="bg-task-status-dot"]')][0]).toBe(dotsBefore[0])
+    expect(rowsAfter.map(el => (el as HTMLElement).dataset.status)).toEqual(['running', 'completed'])
+  })
+
+  it('keeps a hovered tooltip on a grouped row across a rebroadcast', () => {
+    vi.useFakeTimers()
+    try {
+      const long = 'A grouped title far wider than the row that holds it'
+      const { container, setTasks } = renderLiveList([
+        row({ rowKey: 't1', title: long, status: 'running', groupKey: 'wf:x', groupLabel: 'Workflow' }),
+        row({ rowKey: 't2', title: 'Write the tests', status: 'pending', groupKey: 'wf:x', groupLabel: 'Workflow' }),
+      ])
+      const title = titles(container)[0]!
+      stubClipped(title)
+      expect(hoverForTooltip(title)?.textContent).toBe(long)
+
+      setTasks(1, 'status', 'running')
+
+      expect(titles(container)[0]).toBe(title)
+      expect(document.querySelector('[role="tooltip"]')?.textContent).toBe(long)
+    }
+    finally {
+      vi.useRealTimers()
+    }
   })
 
   /**

--- a/frontend/src/components/backgroundtasks/BackgroundTaskList.tsx
+++ b/frontend/src/components/backgroundtasks/BackgroundTaskList.tsx
@@ -219,64 +219,78 @@ export const BackgroundTaskList: Component<BackgroundTaskListProps> = (props) =>
   // JSX read of `.ungrouped`/`.groups`), and only when the visible rows change.
   const grouped = createMemo(() => groupBackgroundTasks(sortBackgroundTasks(visible())))
 
-  // Status reads as COLOR on one constant dot, not as a different glyph per
-  // state. Six shapes made the column a legend to memorize; one dot in the
-  // status palette (in progress / succeeded / failed) is legible at a glance,
-  // and an in-progress dot pulses so activity is visible without a spinner.
-  // The exact state stays available as the dot's accessible name and tooltip,
-  // and as the row's `data-status`, which is what tests and E2E select on.
-  //
-  // Rendered at the right end of the title line, as a flex sibling of the
-  // title -- see titleRow in the stylesheet.
-  const renderStatusDot = (item: BackgroundTaskItem): JSX.Element => (
-    <StatusDot
-      class={statusDotClass(item.status)}
-      label={backgroundTaskStatusLabel(item.status)}
-      tooltip
-      testId="bg-task-status-dot"
-    />
-  )
-
-  const kindIcon = (item: BackgroundTaskItem): JSX.Element => {
-    if (item.kind === 'shell')
-      return <Terminal class={styles.taskIcon} size={14} />
-    return <Bot class={styles.taskIcon} size={14} />
-  }
-
-  // The line is clipped to one line, so ClippedText offers the full string on
-  // hover. An explanatory tip is passed as the DETAIL, so it stands under the
-  // label rather than in its place -- a clipped label keeps its route back even
-  // when the row also has an explanation. A detail also shows while the label
-  // fits, because it carries what the label cannot.
-  const renderSecondary = (item: BackgroundTaskItem, title: string): JSX.Element => {
-    const text = secondary(item, title)
-    if (!text)
-      return null
-    return (
-      <ClippedText
-        text={text}
-        class={styles.taskSecondary}
-        detail={secondaryTooltip(item)}
-      />
-    )
-  }
-
-  // The row's inner content and its data attributes are identical for both
-  // element kinds; only the tag and the click handler differ. Building them once
-  // keeps the clickable and static rows from drifting apart.
+  /**
+   * The row's inner content and its data attributes are identical for both
+   * element kinds; only the tag and the click handler differ. Building them once
+   * keeps the clickable and static rows from drifting apart.
+   *
+   * Every part of it is a reactive EXPRESSION on one field, never a helper that
+   * returns an element. That distinction is the whole point of this shape. A
+   * `{renderStatusDot(item)}` re-runs its whole body whenever any field it reads
+   * changes and puts a NEW element in place of the old one, so a task that
+   * reported progress lost the tooltip the pointer was resting on and restarted
+   * the pulse on its status dot. A prop getter updates one attribute of an
+   * element that stays.
+   *
+   * `~/stores/chatPerAgentStore`'s `setReconciled` is the other half: without a
+   * store that keeps a row's identity across a broadcast, `<For>` would rebuild
+   * the row before any of this could matter.
+   */
   const rowBody = (item: BackgroundTaskItem): JSX.Element => {
-    // Cleaned once per row: the title line renders it and the echo guard in
-    // `secondary` compares against it.
-    const title = rowTitle(item)
+    // A memo, because two bindings read it -- the title line, and the echo guard
+    // in `secondary` -- and a row must not clean its title twice per update or
+    // let the two reads disagree.
+    const title = createMemo(() => rowTitle(item))
+    const secondaryText = createMemo(() => secondary(item, title()))
     return (
       <>
-        {kindIcon(item)}
+        {/* `Show`, not a function that returns one icon or the other: a kind
+            that changed would otherwise replace the element rather than swap
+            the branch. */}
+        <Show
+          when={item.kind === 'shell'}
+          fallback={<Bot class={styles.taskIcon} size={14} />}
+        >
+          <Terminal class={styles.taskIcon} size={14} />
+        </Show>
         <div class={styles.taskBody}>
           <div class={styles.titleRow}>
-            <ClippedText text={title} class={titleClass(item)} />
-            {renderStatusDot(item)}
+            <ClippedText text={title()} class={titleClass(item)} />
+            {/* Status reads as COLOR on one constant dot, not as a different
+                glyph per state. Six shapes made the column a legend to
+                memorize; one dot in the status palette (in progress /
+                succeeded / failed) is legible at a glance, and an in-progress
+                dot pulses so activity is visible without a spinner. The exact
+                state stays available as the dot's accessible name and tooltip,
+                and as the row's `data-status`, which is what tests and E2E
+                select on.
+
+                At the right end of the title line, as a flex sibling of the
+                title -- see titleRow in the stylesheet. */}
+            <StatusDot
+              class={statusDotClass(item.status)}
+              label={backgroundTaskStatusLabel(item.status)}
+              tooltip
+              testId="bg-task-status-dot"
+            />
           </div>
-          {renderSecondary(item, title)}
+          {/* The line is clipped to one line, so ClippedText offers the full
+              string on hover. An explanatory tip is passed as the DETAIL, so it
+              stands under the label rather than in its place -- a clipped label
+              keeps its route back even when the row also has an explanation. A
+              detail also shows while the label fits, because it carries what
+              the label cannot.
+
+              `Show` compares its condition by TRUTHINESS, so an activity string
+              that changes from one non-empty value to another updates the text
+              in place and never rebuilds the label. */}
+          <Show when={secondaryText()}>
+            <ClippedText
+              text={secondaryText()}
+              class={styles.taskSecondary}
+              detail={secondaryTooltip(item)}
+            />
+          </Show>
         </div>
       </>
     )
@@ -284,20 +298,30 @@ export const BackgroundTaskList: Component<BackgroundTaskListProps> = (props) =>
 
   // `extraClass` carries taskRowStatic for the non-clickable row, which drops
   // the pointer cursor taskRow sets for the clickable one.
+  //
+  // GETTERS, because Solid spreads this object inside a render effect and reads
+  // each property there: a plain value is read once and then never again. Every
+  // field that can change while the row lives is one -- the status a task
+  // finishes with, and the child agent id a subagent gets only once it spawns.
+  // A frozen `data-status` would be invisible on screen and wrong for every E2E
+  // locator that selects on it.
   const rowAttrs = (item: BackgroundTaskItem, extraClass?: string) => ({
     'class': extraClass ? `${styles.taskRow} ${extraClass}` : styles.taskRow,
-    'classList': { [styles.taskStruck]: !isActiveBackgroundTaskStatus(item.status) },
+    get 'classList'() { return { [styles.taskStruck]: !isActiveBackgroundTaskStatus(item.status) } },
     'data-testid': 'bg-task-row',
-    'data-status': item.status,
-    'data-kind': item.kind,
-    'data-child-agent-id': item.childAgentId ?? '',
+    get 'data-status'() { return item.status },
+    get 'data-kind'() { return item.kind },
+    get 'data-child-agent-id'() { return item.childAgentId ?? '' },
   })
 
   const renderRow = (item: BackgroundTaskItem): JSX.Element => {
-    const clickable = opensSubagentTranscript(item) && !!props.onOpenSubagent
+    // An accessor, not a value: a subagent row becomes clickable only once the
+    // worker reports the child agent id, which arrives in a later broadcast --
+    // and the row now survives that broadcast instead of being rebuilt by it.
+    const clickable = () => opensSubagentTranscript(item) && !!props.onOpenSubagent
     return (
       <Show
-        when={clickable}
+        when={clickable()}
         fallback={<div {...rowAttrs(item, styles.taskRowStatic)}>{rowBody(item)}</div>}
       >
         <button type="button" {...rowAttrs(item)} onClick={() => props.onOpenSubagent?.(item)}>

--- a/frontend/src/components/backgroundtasks/BackgroundTaskList.tsx
+++ b/frontend/src/components/backgroundtasks/BackgroundTaskList.tsx
@@ -47,8 +47,9 @@ interface BackgroundTaskListProps {
  * subset, which let a new kind ship reachable only through All -- the tab list
  * and the empty messages have to be one declaration for that to be impossible.
  *
- * A new kind still needs two things this cannot force: an arm in
- * `protoBackgroundTaskToStore`, and an icon in `kindIcon` below.
+ * A new kind still needs two things this cannot force: a case in
+ * `protoBackgroundTaskToStore`, and a case in the kind-icon `Show` inside
+ * `rowBody` below.
  */
 const KIND_TABS_META: Record<BackgroundTaskKindFilter, { label: string, empty: string }> = {
   all: { label: 'All', empty: 'No background tasks' },
@@ -218,6 +219,14 @@ export const BackgroundTaskList: Component<BackgroundTaskListProps> = (props) =>
   // Memoized so a broadcast tick re-runs sort+group once (not twice, once per
   // JSX read of `.ungrouped`/`.groups`), and only when the visible rows change.
   const grouped = createMemo(() => groupBackgroundTasks(sortBackgroundTasks(visible())))
+  // The keys alone, so the group `For` below reconciles on a primitive that
+  // survives the memo rebuilding its group objects. Its own memo, so a recompute
+  // that leaves the set of groups unchanged does not re-run the `For` at all.
+  const groupKeys = createMemo(
+    () => grouped().groups.map(g => g.key),
+    undefined,
+    { equals: (a, b) => a.length === b.length && a.every((k, i) => k === b[i]) },
+  )
 
   /**
    * The row's inner content and its data attributes are identical for both
@@ -228,9 +237,9 @@ export const BackgroundTaskList: Component<BackgroundTaskListProps> = (props) =>
    * returns an element. That distinction is the whole point of this shape. A
    * `{renderStatusDot(item)}` re-runs its whole body whenever any field it reads
    * changes and puts a NEW element in place of the old one, so a task that
-   * reported progress lost the tooltip the pointer was resting on and restarted
-   * the pulse on its status dot. A prop getter updates one attribute of an
-   * element that stays.
+   * reported progress lost the tooltip under the pointer and restarted the pulse
+   * on its status dot. A prop getter updates one attribute of an element that
+   * stays.
    *
    * `~/stores/chatPerAgentStore`'s `setReconciled` is the other half: without a
    * store that keeps a row's identity across a broadcast, `<For>` would rebuild
@@ -305,9 +314,16 @@ export const BackgroundTaskList: Component<BackgroundTaskListProps> = (props) =>
   // finishes with, and the child agent id a subagent gets only once it spawns.
   // A frozen `data-status` would be invisible on screen and wrong for every E2E
   // locator that selects on it.
-  const rowAttrs = (item: BackgroundTaskItem, extraClass?: string) => ({
-    'class': extraClass ? `${styles.taskRow} ${extraClass}` : styles.taskRow,
-    get 'classList'() { return { [styles.taskStruck]: !isActiveBackgroundTaskStatus(item.status) } },
+  const rowAttrs = (item: BackgroundTaskItem, clickable?: () => boolean) => ({
+    'class': styles.taskRow,
+    get 'classList'() {
+      return {
+        [styles.taskStruck]: !isActiveBackgroundTaskStatus(item.status),
+        // taskRowStatic drops the pointer cursor taskRow sets. A getter, because
+        // a subagent row becomes clickable mid-life -- see renderRow.
+        [styles.taskRowStatic]: clickable ? !clickable() : true,
+      }
+    },
     'data-testid': 'bg-task-row',
     get 'data-status'() { return item.status },
     get 'data-kind'() { return item.kind },
@@ -315,19 +331,33 @@ export const BackgroundTaskList: Component<BackgroundTaskListProps> = (props) =>
   })
 
   const renderRow = (item: BackgroundTaskItem): JSX.Element => {
-    // An accessor, not a value: a subagent row becomes clickable only once the
-    // worker reports the child agent id, which arrives in a later broadcast --
-    // and the row now survives that broadcast instead of being rebuilt by it.
+    // The TAG is decided by fields that never change over a row's life, so the
+    // element survives every broadcast. `childAgentId` is not one of them: the
+    // worker reports it a broadcast or two after the row itself, and a `Show`
+    // keyed on it swapped a <div> for a <button> at exactly the moment the user
+    // is watching that row -- rebuilding its whole body, closing the title
+    // tooltip under the pointer and restarting the status dot's pulse. That is
+    // the flicker the rest of this component exists to remove.
+    //
+    // So a subagent row that the caller can open is ALWAYS a <button>, and the
+    // arrival of the id only flips one attribute on it.
+    const openable = item.kind === 'subagent' && !!props.onOpenSubagent
     const clickable = () => opensSubagentTranscript(item) && !!props.onOpenSubagent
+    if (!openable)
+      return <div {...rowAttrs(item)}>{rowBody(item)}</div>
     return (
-      <Show
-        when={clickable()}
-        fallback={<div {...rowAttrs(item, styles.taskRowStatic)}>{rowBody(item)}</div>}
+      <button
+        type="button"
+        {...rowAttrs(item, clickable)}
+        // aria-disabled, never the `disabled` attribute: a disabled control
+        // dispatches no pointer event of its own OR to its descendants, which
+        // would kill the row's own title tooltip for as long as the subagent is
+        // still spawning.
+        aria-disabled={clickable() ? undefined : 'true'}
+        onClick={() => clickable() && props.onOpenSubagent?.(item)}
       >
-        <button type="button" {...rowAttrs(item)} onClick={() => props.onOpenSubagent?.(item)}>
-          {rowBody(item)}
-        </button>
-      </Show>
+        {rowBody(item)}
+      </button>
     )
   }
 
@@ -369,13 +399,25 @@ export const BackgroundTaskList: Component<BackgroundTaskListProps> = (props) =>
           )}
         >
           <For each={grouped().ungrouped}>{item => renderRow(item)}</For>
-          <For each={grouped().groups}>
-            {group => (
-              <>
-                <ClippedText text={groupHeading(group.label)} class={styles.groupHeader} />
-                <For each={group.items}>{item => renderRow(item)}</For>
-              </>
-            )}
+          {/* Keyed by the group KEY, not by the group object. `groupBackgroundTasks`
+              builds fresh `{key, label, items}` objects on every run and `For`
+              reconciles by reference, so iterating the objects tore down and
+              rebuilt every grouped row whenever the memo re-ran -- which any
+              status change does, because the sort reads `status`. That is the
+              same flicker `setReconciled` removes for the ungrouped rows, and it
+              reached every row of a Claude workflow, which groups its subagents.
+              `For` compares primitives by value, and a group key is unique by
+              construction. */}
+          <For each={groupKeys()}>
+            {(key) => {
+              const group = createMemo(() => grouped().groups.find(g => g.key === key))
+              return (
+                <>
+                  <ClippedText text={groupHeading(group()?.label ?? key)} class={styles.groupHeader} />
+                  <For each={group()?.items ?? []}>{item => renderRow(item)}</For>
+                </>
+              )
+            }}
           </For>
         </Show>
       </div>

--- a/frontend/src/components/chat/providers/acp/extractors/plan.test.ts
+++ b/frontend/src/components/chat/providers/acp/extractors/plan.test.ts
@@ -24,18 +24,18 @@ describe('acpPlanFromEntries', () => {
       { content: 'five', status: 'unknown' },
     ])
     expect(source?.todos).toEqual([
-      { content: 'one', status: 'pending', activeForm: '' },
-      { content: 'two', status: 'completed', activeForm: '' },
-      { content: 'three', status: 'in_progress', activeForm: '' },
-      { content: 'four', status: 'pending', activeForm: '' },
-      { content: 'five', status: 'pending', activeForm: '' },
+      { rowKey: '0:one', content: 'one', status: 'pending', activeForm: '' },
+      { rowKey: '1:two', content: 'two', status: 'completed', activeForm: '' },
+      { rowKey: '2:three', content: 'three', status: 'in_progress', activeForm: '' },
+      { rowKey: '3:four', content: 'four', status: 'pending', activeForm: '' },
+      { rowKey: '4:five', content: 'five', status: 'pending', activeForm: '' },
     ])
   })
 
   it('coerces missing content to empty string', () => {
     const source = acpPlanFromEntries([{ status: 'completed' } as never])
     expect(source?.todos).toEqual([
-      { content: '', status: 'completed', activeForm: '' },
+      { rowKey: '0:', content: '', status: 'completed', activeForm: '' },
     ])
   })
 })

--- a/frontend/src/components/chat/providers/acp/extractors/plan.ts
+++ b/frontend/src/components/chat/providers/acp/extractors/plan.ts
@@ -1,6 +1,6 @@
 import type { TodoListSource } from '../../../todoListMessage'
 import type { TodoItem } from '~/stores/chatTodos'
-import { normalizeTodoStatus } from '~/stores/chatTodos'
+import { normalizeTodoStatus, todoRowKey } from '~/stores/chatTodos'
 
 interface AcpPlanEntry {
   priority?: string
@@ -19,11 +19,17 @@ export function acpPlanFromEntries(
   if (!entries)
     return null
 
-  const todos: TodoItem[] = entries.map(e => ({
-    content: e?.content ?? '',
-    status: normalizeTodoStatus(e?.status),
-    activeForm: '',
-  }))
+  const todos: TodoItem[] = entries.map((e, i) => {
+    const content = e?.content ?? ''
+    return {
+      // ACP sends a whole plan with no ids, so position plus content is the
+      // identity -- see TodoItem.rowKey.
+      rowKey: todoRowKey(undefined, i, content),
+      content,
+      status: normalizeTodoStatus(e?.status),
+      activeForm: '',
+    }
+  })
 
   return {
     toolName: 'Plan',

--- a/frontend/src/components/chat/providers/claude/extractors/todo.test.ts
+++ b/frontend/src/components/chat/providers/claude/extractors/todo.test.ts
@@ -33,9 +33,9 @@ describe('claudeTodoWriteFromInput', () => {
       toolName: 'TodoWrite',
       title: '3 tasks',
       todos: [
-        { content: 'Do A', status: 'pending', activeForm: 'Doing A' },
-        { content: 'Do B', status: 'in_progress', activeForm: 'Doing B' },
-        { content: 'Do C', status: 'completed', activeForm: 'Doing C' },
+        { rowKey: '0:Do A', content: 'Do A', status: 'pending', activeForm: 'Doing A' },
+        { rowKey: '1:Do B', content: 'Do B', status: 'in_progress', activeForm: 'Doing B' },
+        { rowKey: '2:Do C', content: 'Do C', status: 'completed', activeForm: 'Doing C' },
       ],
     })
   })
@@ -52,7 +52,7 @@ describe('claudeTodoWriteFromInput', () => {
       todos: [{ status: 'unknown' }],
     })
     expect(source?.todos).toEqual([
-      { content: '', status: 'pending', activeForm: '' },
+      { rowKey: '0:', content: '', status: 'pending', activeForm: '' },
     ])
   })
 })

--- a/frontend/src/components/chat/providers/codex/extractors/plan.test.ts
+++ b/frontend/src/components/chat/providers/codex/extractors/plan.test.ts
@@ -28,9 +28,9 @@ describe('codexTurnPlanFromParams', () => {
       ],
     })
     expect(source?.todos).toEqual([
-      { content: 'one', status: 'pending', activeForm: 'one' },
-      { content: 'two', status: 'in_progress', activeForm: 'two' },
-      { content: 'three', status: 'completed', activeForm: 'three' },
+      { rowKey: '0:one', content: 'one', status: 'pending', activeForm: 'one' },
+      { rowKey: '1:two', content: 'two', status: 'in_progress', activeForm: 'two' },
+      { rowKey: '2:three', content: 'three', status: 'completed', activeForm: 'three' },
     ])
     expect(source?.title).toBe('3 tasks')
   })

--- a/frontend/src/components/chat/providers/codex/extractors/plan.ts
+++ b/frontend/src/components/chat/providers/codex/extractors/plan.ts
@@ -2,18 +2,23 @@ import type { TodoListSource } from '../../../todoListMessage'
 import type { TodoItem } from '~/stores/chatTodos'
 import { pickString } from '~/lib/jsonPick'
 import { pluralize } from '~/lib/plural'
-import { normalizeTodoStatus } from '~/stores/chatTodos'
+import { normalizeTodoStatus, todoRowKey } from '~/stores/chatTodos'
 import { CODEX_ITEM } from '~/types/toolMessages'
 
 /** Convert a Codex plan array (from turn/plan/updated) to TodoItem[]. */
 function codexPlanToTodos(plan: unknown[]): TodoItem[] {
-  return plan.flatMap((entry) => {
+  return plan.flatMap((entry, i) => {
     if (typeof entry !== 'object' || entry === null)
       return []
     const step = String((entry as Record<string, unknown>).step || '')
     if (!step)
       return []
     return [{
+      // Codex re-sends the whole plan with no ids, so position plus content is
+      // the identity -- see TodoItem.rowKey. The index is the entry's place in
+      // the RAW plan, which is stable across a re-send even where a skipped
+      // entry makes it differ from the output index.
+      rowKey: todoRowKey(undefined, i, step),
       content: step,
       status: normalizeTodoStatus((entry as Record<string, unknown>).status),
       activeForm: step,

--- a/frontend/src/components/chat/providers/todoPlanRendering.test.tsx
+++ b/frontend/src/components/chat/providers/todoPlanRendering.test.tsx
@@ -89,8 +89,8 @@ describe('claude TodoWrite renders via shared TodoListMessage', () => {
   it('renders the pluralized title and todo content', () => {
     const { container } = renderClaudeToolUse('TodoWrite', {
       todos: [
-        { content: 'first task', status: 'pending', activeForm: 'doing first' },
-        { content: 'second task', status: 'in_progress', activeForm: 'doing second' },
+        { rowKey: 'first task', content: 'first task', status: 'pending', activeForm: 'doing first' },
+        { rowKey: 'second task', content: 'second task', status: 'in_progress', activeForm: 'doing second' },
       ],
     })
     const text = container.textContent ?? ''
@@ -152,7 +152,7 @@ describe('claude TaskUpdate renders a single-row card', () => {
       taskId: '42',
       status: 'completed',
     }, {
-      getTodoById: id => id === '42' ? { id: '42', content: 'Stored subject', status: 'pending', activeForm: '' } : undefined,
+      getTodoById: id => id === '42' ? { id: '42', rowKey: '42', content: 'Stored subject', status: 'pending', activeForm: '' } : undefined,
     })
     const text = container.textContent ?? ''
     expect(text).toContain('Stored subject')
@@ -166,7 +166,7 @@ describe('claude TaskUpdate renders a single-row card', () => {
       subject: 'Fresh subject from this patch',
       status: 'in_progress',
     }, {
-      getTodoById: id => id === '7' ? { id: '7', content: 'Stale stored subject', status: 'pending', activeForm: '' } : undefined,
+      getTodoById: id => id === '7' ? { id: '7', rowKey: '7', content: 'Stale stored subject', status: 'pending', activeForm: '' } : undefined,
     })
     const text = container.textContent ?? ''
     expect(text).toContain('Fresh subject from this patch')
@@ -178,7 +178,7 @@ describe('claude TaskUpdate renders a single-row card', () => {
       taskId: '8',
       status: 'deleted',
     }, {
-      getTodoById: id => id === '8' ? { id: '8', content: 'Will be removed', status: 'completed', activeForm: '' } : undefined,
+      getTodoById: id => id === '8' ? { id: '8', rowKey: '8', content: 'Will be removed', status: 'completed', activeForm: '' } : undefined,
     })
     const text = container.textContent ?? ''
     expect(text).toContain('Will be removed')
@@ -339,8 +339,8 @@ describe('opencode plan renders via shared TodoListMessage', () => {
     const { container } = renderOpenCodePlan({
       sessionUpdate: 'plan',
       entries: [
-        { content: 'opencode entry one', status: 'pending' },
-        { content: 'opencode entry two', status: 'completed' },
+        { rowKey: 'opencode entry one', content: 'opencode entry one', status: 'pending' },
+        { rowKey: 'opencode entry two', content: 'opencode entry two', status: 'completed' },
       ],
     })
     const text = container.textContent ?? ''

--- a/frontend/src/components/chat/todoListMessage.test.tsx
+++ b/frontend/src/components/chat/todoListMessage.test.tsx
@@ -34,7 +34,7 @@ describe('todoListMessage', () => {
    */
   it('renders the to-do list in its wrapping variant', () => {
     const { container } = renderMessage([
-      { id: '1', content: LONG, status: 'pending', activeForm: '' },
+      { id: '1', rowKey: '1', content: LONG, status: 'pending', activeForm: '' },
     ])
 
     const list = container.querySelector(classSelector(todoStyles.todoList))!
@@ -45,7 +45,7 @@ describe('todoListMessage', () => {
   // the clip off through CSS rather than by rendering a different element.
   it('keeps the label on the shared clipping element', () => {
     const { container } = renderMessage([
-      { id: '1', content: LONG, status: 'pending', activeForm: '' },
+      { id: '1', rowKey: '1', content: LONG, status: 'pending', activeForm: '' },
     ])
 
     const label = container.querySelector(classSelector(todoStyles.todoText))!

--- a/frontend/src/components/chat/widgets/ThinkingIndicator.test.tsx
+++ b/frontend/src/components/chat/widgets/ThinkingIndicator.test.tsx
@@ -284,9 +284,9 @@ describe('thinking indicator chips', () => {
 
   it('renders the todos counter as done/total plus a noun', () => {
     const todos: TodoItem[] = [
-      { content: 'a', status: 'completed', activeForm: '' },
-      { content: 'b', status: 'in_progress', activeForm: 'doing b' },
-      { content: 'c', status: 'pending', activeForm: '' },
+      { rowKey: 'a', content: 'a', status: 'completed', activeForm: '' },
+      { rowKey: 'b', content: 'b', status: 'in_progress', activeForm: 'doing b' },
+      { rowKey: 'c', content: 'c', status: 'pending', activeForm: '' },
     ]
     const { getByTestId } = renderChips({ todos })
     expect(getByTestId('thinking-todos-chip')).toHaveTextContent('1/3 to-dos')
@@ -294,14 +294,14 @@ describe('thinking indicator chips', () => {
   })
 
   it('uses the singular noun for a one-item to-do list', () => {
-    const todos: TodoItem[] = [{ content: 'a', status: 'pending', activeForm: '' }]
+    const todos: TodoItem[] = [{ rowKey: 'a', content: 'a', status: 'pending', activeForm: '' }]
     const { getByTestId } = renderChips({ todos })
     expect(getByTestId('thinking-todos-chip')).toHaveTextContent('0/1 to-do')
   })
 
   it('hides the todos chip when all todos are deleted', () => {
     const todos: TodoItem[] = [
-      { content: 'a', status: 'deleted', activeForm: '' },
+      { rowKey: 'a', content: 'a', status: 'deleted', activeForm: '' },
     ]
     const { queryByTestId } = renderChips({ todos })
     expect(queryByTestId('thinking-todos-chip')).toBeNull()
@@ -316,7 +316,7 @@ describe('thinking indicator chips', () => {
   // rotating verb leads, and the counters trail it, middot-separated. The verb
   // is outside the separator chain, so leading it adds no middot of its own.
   it('orders the verb before the counters, separated by middots', () => {
-    const todos: TodoItem[] = [{ content: 'a', status: 'pending', activeForm: '' }]
+    const todos: TodoItem[] = [{ rowKey: 'a', content: 'a', status: 'pending', activeForm: '' }]
     const { getByTestId, getByText } = renderChips({ thinkingTokens: 500, backgroundTasks: running(2), todos })
     // The odometer is aria-hidden; getByText finds the screen-reader copy.
     const tokens = getByText('500 tokens')

--- a/frontend/src/components/common/DropdownMenu.test.tsx
+++ b/frontend/src/components/common/DropdownMenu.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, fireEvent, render, screen } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
 import { popoverCard } from '~/styles/popover.css'
 import { motion } from '~/styles/tokens'
+import { hoverForTooltip, stubClipped } from '~/test-support/clipStub'
 import { pointerEvent } from '~/test-support/pointer'
 import { DropdownMenu, DropdownMenuCheckableItem, DropdownMenuItemContent } from './DropdownMenu'
 import { Tooltip } from './Tooltip'
@@ -715,5 +716,97 @@ describe('dropdownMenuCheckableItem', () => {
 
     const checkbox = screen.getByRole('checkbox', { hidden: true }) as HTMLInputElement
     expect(checkbox.style.pointerEvents).toBe('none')
+  })
+
+  // The reason `detail` is a slot rather than text a caller appends to the
+  // label: the label clips, so anything inside it goes with the ellipsis.
+  it('draws a detail outside the label, and announces it as part of the item', () => {
+    render(() => (
+      <DropdownMenuCheckableItem
+        kind="radio"
+        label="Build the thing"
+        detail="4h ago"
+        checked={false}
+        data-testid="row"
+        onSelect={() => {}}
+      />
+    ))
+
+    // Its OWN element, so the label's ellipsis cannot reach it.
+    expect(screen.getByTestId('row-label').textContent).toBe('Build the thing')
+    expect(screen.getByText('4h ago')).toBeInTheDocument()
+    // Content, not decoration: unlike `leading`, it is not aria-hidden.
+    expect(screen.getByRole('menuitemradio', { name: /4h ago/ })).toBeInTheDocument()
+  })
+
+  it('draws no detail element for an item that has none', () => {
+    render(() => (
+      <DropdownMenuCheckableItem kind="radio" label="Alpha" checked={false} data-testid="row" onSelect={() => {}} />
+    ))
+
+    expect(screen.getByRole('menuitemradio').textContent?.trim()).toBe('Alpha')
+  })
+
+  // `revealClippedLabel` is OPT-IN, and this is the case that keeps it so. The
+  // caller here wraps the item in a Tooltip that carries the reason it is
+  // disabled; `Tooltip` keeps at most one open, so a second tooltip inside the
+  // button would dismiss that reason and replace it with a verbatim repeat of
+  // the label.
+  it('opens no tooltip of its own on a clipped label by default', () => {
+    vi.useFakeTimers()
+    try {
+      render(() => (
+        <DropdownMenuCheckableItem
+          kind="radio"
+          label="A label far wider than the row that holds it"
+          checked={false}
+          data-testid="row"
+          onSelect={() => {}}
+        />
+      ))
+
+      const label = screen.getByTestId('row-label')
+      stubClipped(label)
+      expect(hoverForTooltip(label)).toBeNull()
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+
+  // A caller that wraps no tooltip of its own sets the flag, and its clipped
+  // labels keep a route back. `LoadingMenu` is that caller.
+  it('reveals the whole label on hover once the caller asks for it', () => {
+    vi.useFakeTimers()
+    try {
+      render(() => (
+        <DropdownMenuCheckableItem
+          kind="radio"
+          label="A label far wider than the row that holds it"
+          checked={false}
+          revealClippedLabel
+          data-testid="row"
+          onSelect={() => {}}
+        />
+      ))
+
+      const label = screen.getByTestId('row-label')
+      stubClipped(label)
+      expect(hoverForTooltip(label)?.textContent).toBe('A label far wider than the row that holds it')
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+
+  // The label test id is DERIVED from the item's own, so a test can address the
+  // label rather than the whole row -- whose text also holds the detail, and
+  // whose detail may be a clock that ticks while the test reads it.
+  it('gives the label no test id of its own when the item has none', () => {
+    render(() => (
+      <DropdownMenuCheckableItem kind="radio" label="Alpha" checked={false} revealClippedLabel onSelect={() => {}} />
+    ))
+
+    expect(document.querySelector('[data-testid$="-label"]')).toBeNull()
   })
 })

--- a/frontend/src/components/common/DropdownMenu.test.tsx
+++ b/frontend/src/components/common/DropdownMenu.test.tsx
@@ -1,10 +1,12 @@
 /// <reference types="vitest/globals" />
 import { cleanup, fireEvent, render, screen } from '@solidjs/testing-library'
-import { describe, expect, it, vi } from 'vitest'
-import { popoverCard } from '~/styles/popover.css'
+import { beforeAll, describe, expect, it, onTestFinished, vi } from 'vitest'
+import { DIALOG_HEIGHT_VAR, popoverCard, popoverFieldMenuClamp, popoverMenuClamp, TRIGGER_WIDTH_VAR } from '~/styles/popover.css'
 import { motion } from '~/styles/tokens'
-import { hoverForTooltip, stubClipped } from '~/test-support/clipStub'
+import { hoverForTooltip, stubClipped, stubRect } from '~/test-support/clipStub'
+import { classSelector } from '~/test-support/composedClass'
 import { pointerEvent } from '~/test-support/pointer'
+import { installControllableResizeObserver, triggerResizeObserverForSync } from '~/test-support/resizeObserverStub'
 import { DropdownMenu, DropdownMenuCheckableItem, DropdownMenuItemContent } from './DropdownMenu'
 import { Tooltip } from './Tooltip'
 
@@ -725,7 +727,7 @@ describe('dropdownMenuCheckableItem', () => {
       <DropdownMenuCheckableItem
         kind="radio"
         label="Build the thing"
-        detail="4h ago"
+        detail={() => '4h ago'}
         checked={false}
         data-testid="row"
         onSelect={() => {}}
@@ -808,5 +810,137 @@ describe('dropdownMenuCheckableItem', () => {
     ))
 
     expect(document.querySelector('[data-testid$="-label"]')).toBeNull()
+  })
+})
+
+// A popover is in the top layer: it is positioned against the viewport and
+// inherits no width from the form its trigger sits in. Left uncapped, one long
+// option made a menu wider than the dialog that opened it, and a list of fifty
+// ran off the bottom of the screen with the rows past the edge unreachable --
+// `calcPopoverPosition` clamps where a popover STARTS, not how large it grows.
+describe('dropdownMenu size caps', () => {
+  const MENU = 'sized-menu'
+
+  beforeAll(() => {
+    installControllableResizeObserver()
+  })
+
+  function renderMenu(opts: { container?: HTMLElement, matchTriggerWidth?: boolean } = {}) {
+    return render(
+      () => (
+        <DropdownMenu
+          aria-label="Things"
+          data-testid={MENU}
+          matchTriggerWidth={opts.matchTriggerWidth}
+          trigger={p => <button {...p} type="button">Open</button>}
+        >
+          <li>Alpha</li>
+        </DropdownMenu>
+      ),
+      opts.container ? { container: opts.container } : undefined,
+    )
+  }
+
+  // `hidden: true`, because the dialog case below renders into a `<dialog>`
+  // that is not `open`, which puts its whole subtree outside the accessibility
+  // tree.
+  const triggerButton = () => screen.getByRole('button', { name: 'Open', hidden: true })
+
+  function openMenu() {
+    fireEvent.click(triggerButton())
+  }
+
+  // The clamp is what makes a row past the bottom edge REACHABLE. Before it,
+  // only an `as="card"` popover carried one, so every list-shaped menu in the
+  // app -- ThemeChooser's palette among them -- could not be scrolled to.
+  it('clamps a menu-shaped popover, and a card keeps its own class', () => {
+    renderMenu()
+    expect(screen.getByTestId(MENU).matches(classSelector(popoverMenuClamp))).toBe(true)
+    // The width cap is NOT part of it. A kebab is a 24px icon button, and a
+    // menu capped at that leaves a column too narrow to read a row.
+    expect(screen.getByTestId(MENU).matches(classSelector(popoverFieldMenuClamp))).toBe(false)
+    cleanup()
+
+    renderMenu({ matchTriggerWidth: true })
+    expect(screen.getByTestId(MENU).matches(classSelector(popoverFieldMenuClamp))).toBe(true)
+    cleanup()
+
+    render(() => (
+      <DropdownMenu as="card" aria-label="Card" data-testid="card-menu" trigger={p => <button {...p} type="button">Open</button>}>
+        <div>Body</div>
+      </DropdownMenu>
+    ))
+    const card = screen.getByTestId('card-menu')
+    expect(card.matches(classSelector(popoverCard))).toBe(true)
+  })
+
+  // The regression this split exists to prevent: a kebab is a ~24px icon button,
+  // and a menu capped at its trigger is a 24px column with every row
+  // unreadable. Every context menu in the app has such a trigger.
+  it('does not cap a kebab-triggered menu at its trigger', () => {
+    renderMenu()
+    openMenu()
+    const popover = screen.getByTestId(MENU)
+    // Neither the class that reads the property nor a value for it to read.
+    expect(popover.matches(classSelector(popoverFieldMenuClamp))).toBe(false)
+    expect(popover.style.getPropertyValue(TRIGGER_WIDTH_VAR)).toBe('')
+    // ...while the clamp it DOES take is the one that makes a long list
+    // reachable, which is universal.
+    expect(popover.matches(classSelector(popoverMenuClamp))).toBe(true)
+    expect(popover.style.getPropertyValue(DIALOG_HEIGHT_VAR)).toBe('')
+  })
+
+  // A menu that did not ask to follow its trigger must not be measured against
+  // it either: a stray custom property is a cap waiting to be applied.
+  it('writes no trigger width unless the caller asked to follow it', () => {
+    renderMenu()
+    openMenu()
+    expect(screen.getByTestId(MENU).style.getPropertyValue(TRIGGER_WIDTH_VAR)).toBe('')
+  })
+
+  it('writes the trigger width onto the popover, and follows it when it changes', () => {
+    renderMenu({ matchTriggerWidth: true })
+    const trigger = triggerButton()
+    const popover = screen.getByTestId(MENU)
+
+    // Nothing while closed: a cap only matters for a popover on screen, and
+    // measuring at mount is what made it go stale.
+    expect(popover.style.getPropertyValue(TRIGGER_WIDTH_VAR)).toBe('')
+
+    openMenu()
+    // jsdom measures every box as zero, so this pass proves only that the
+    // component measured the trigger and wrote the result.
+    expect(popover.style.getPropertyValue(TRIGGER_WIDTH_VAR)).toBe('0px')
+
+    // A window is dragged narrower with no event of its own. A cap measured
+    // once at open would be wrong from then on, and silently.
+    stubRect(trigger, { width: 317 })
+    triggerResizeObserverForSync(trigger)
+    expect(popover.style.getPropertyValue(TRIGGER_WIDTH_VAR)).toBe('317px')
+  })
+
+  // A menu taller than the dialog it opens in reads as a second window over the
+  // page rather than as the open form of a field inside it.
+  it('caps the height at the dialog that holds the trigger', () => {
+    const dialog = document.createElement('dialog')
+    document.body.append(dialog)
+    onTestFinished(() => dialog.remove())
+
+    renderMenu({ container: dialog })
+    openMenu()
+    const popover = screen.getByTestId(MENU)
+    expect(popover.style.getPropertyValue(DIALOG_HEIGHT_VAR)).toBe('0px')
+
+    stubRect(dialog, { height: 480 })
+    triggerResizeObserverForSync(dialog)
+    expect(popover.style.getPropertyValue(DIALOG_HEIGHT_VAR)).toBe('480px')
+  })
+
+  // A menu no dialog holds writes nothing, so the stylesheet's fallback leaves
+  // it the viewport clamp: a sidebar selector must not be capped at zero.
+  it('writes no dialog height for a menu outside one', () => {
+    renderMenu()
+    openMenu()
+    expect(screen.getByTestId(MENU).style.getPropertyValue(DIALOG_HEIGHT_VAR)).toBe('')
   })
 })

--- a/frontend/src/components/common/DropdownMenu.tsx
+++ b/frontend/src/components/common/DropdownMenu.tsx
@@ -5,7 +5,8 @@ import { createEffect, createSignal, createUniqueId, on, onCleanup, Show } from 
 import { Dynamic } from 'solid-js/web'
 import { calcPopoverPosition } from '~/lib/popoverPosition'
 import { popoverCard } from '~/styles/popover.css'
-import { clippedText, menuItemContent, menuItemShortcut } from '~/styles/shared.css'
+import { clippedText, menuItemContent, menuItemDetail } from '~/styles/shared.css'
+import { ClippedText } from './ClippedText'
 import { attachContextMenuGesture, holdIsOverMenu, pressAnchorRect } from './contextMenuGesture'
 import { dismissActiveTooltip } from './Tooltip'
 
@@ -239,7 +240,7 @@ export function DropdownMenuItemContent(props: DropdownMenuItemContentProps) {
           author's decision, not a mechanical swap. */}
       <span class={clippedText}>{props.label}</span>
       <Show when={props.shortcut}>
-        {shortcut => <span class={menuItemShortcut}>{shortcut()}</span>}
+        {shortcut => <span class={menuItemDetail}>{shortcut()}</span>}
       </Show>
     </span>
   )
@@ -265,6 +266,32 @@ export interface DropdownMenuCheckableItemProps {
    * passed here sets `aria-hidden`.
    */
   'leading'?: JSXElement
+  /**
+   * A short note at the RIGHT end of the row -- the age of a session, the
+   * shortcut of a command.
+   *
+   * It never shrinks and never wraps, so it stays readable while a long `label`
+   * clips beside it. That is the whole reason it is a slot of its own rather
+   * than text a caller appends to `label`: text inside the label is inside the
+   * ellipsis, so the row that most needs its timestamp is the row that loses it.
+   *
+   * Content, not decoration, so it is NOT `aria-hidden`: a screen reader reads
+   * it as part of the item, which is what `leading` deliberately withholds for
+   * a colour swatch.
+   */
+  'detail'?: JSXElement
+  /**
+   * Show the whole `label` in a tooltip once the row clips it.
+   *
+   * OFF by default, and the default is not caution about the cost. An item
+   * whose CALLER wraps it in a `Tooltip` -- `~/components/chat/settingsShared`
+   * puts the option's description, or the reason the group is read-only, on the
+   * whole button -- can hold only one open tooltip at a time, so a second one
+   * that repeats the label verbatim would dismiss the description that explains
+   * the option. A caller that wraps no tooltip of its own sets this, and its
+   * clipped labels keep a route back.
+   */
+  'revealClippedLabel'?: boolean
   /** Invoked on activation. Not called while `disabled`. */
   'onSelect': () => void
 }
@@ -281,6 +308,14 @@ export interface DropdownMenuCheckableItemProps {
  * that mistake impossible.
  */
 export function DropdownMenuCheckableItem(props: DropdownMenuCheckableItemProps) {
+  // Derived from the item's own test id, so a test can address the LABEL rather
+  // than the whole row -- whose text now also holds the detail, and whose detail
+  // may be a clock that ticks while the test reads it.
+  const labelTestId = () => {
+    const testId = props['data-testid']
+    return testId === undefined ? undefined : `${testId}-label`
+  }
+
   return (
     <button
       // A <button> defaults to type="submit". This item toggles a preference, so
@@ -312,13 +347,29 @@ export function DropdownMenuCheckableItem(props: DropdownMenuCheckableItemProps)
             letting a caller supply one. `display: contents` keeps the wrapper
             out of the flex layout, so the swatch sits exactly where it did. */}
         <span aria-hidden="true" style={{ display: 'contents' }}>{props.leading}</span>
-        {/* The raw style, not `ClippedText`, although `label` is a string. A
-            caller already wraps this whole button in a `Tooltip` that carries
-            the option's DESCRIPTION. A second tooltip inside it would dismiss
-            that one -- `Tooltip` keeps at most one open -- and replace the
-            description with a verbatim repeat of the label, which is a net
-            loss. The fix is one tooltip chosen by the item, not two nested. */}
-        <span class={clippedText}>{props.label}</span>
+        {/* Two spellings of one label, and the caller picks. `ClippedText`
+            pairs the ellipsis with the tooltip that reads the rest, which is
+            what a row of unbounded titles needs. The raw style is for the
+            caller that wraps this whole button in a `Tooltip` of its own: a
+            second tooltip would dismiss that one -- `Tooltip` keeps at most one
+            open -- and replace the option's DESCRIPTION with a verbatim repeat
+            of the label. See `revealClippedLabel`. */}
+        <Show
+          when={props.revealClippedLabel}
+          fallback={<span class={clippedText} data-testid={labelTestId()}>{props.label}</span>}
+        >
+          <ClippedText text={props.label} testId={labelTestId()} />
+        </Show>
+        {/* The callback form, and it is load-bearing: `Show` memoizes `when`,
+            so `props.detail` is read ONCE per tracking cycle. A caller whose
+            detail is an expression (`LoadingMenu` renders one from the option)
+            has a getter behind that prop, and a second read there builds a
+            second element -- one to test for presence and a different one on
+            screen. An empty detail draws nothing, which is what an option with
+            no note wants. */}
+        <Show when={props.detail}>
+          {detail => <span class={menuItemDetail}>{detail()}</span>}
+        </Show>
       </span>
     </button>
   )

--- a/frontend/src/components/common/DropdownMenu.tsx
+++ b/frontend/src/components/common/DropdownMenu.tsx
@@ -4,7 +4,8 @@ import type { PopoverAnchor, PopoverPositionOptions } from '~/lib/popoverPositio
 import { createEffect, createSignal, createUniqueId, on, onCleanup, Show } from 'solid-js'
 import { Dynamic } from 'solid-js/web'
 import { calcPopoverPosition } from '~/lib/popoverPosition'
-import { popoverCard } from '~/styles/popover.css'
+import { createRafResizeObserver } from '~/lib/resizeObserver'
+import { DIALOG_HEIGHT_VAR, popoverCard, popoverFieldMenuClamp, popoverMenuClamp, TRIGGER_WIDTH_VAR } from '~/styles/popover.css'
 import { clippedText, menuItemContent, menuItemDetail } from '~/styles/shared.css'
 import { ClippedText } from './ClippedText'
 import { attachContextMenuGesture, holdIsOverMenu, pressAnchorRect } from './contextMenuGesture'
@@ -209,6 +210,23 @@ export interface DropdownMenuProps {
   /** CSS class on the popover element. */
   'class'?: string
 
+  /**
+   * The trigger is a FIELD, so the menu is capped at its width.
+   *
+   * A field's menu is the open form of the control the user clicked: the two
+   * read as one control when their edges line up, and a row longer than the
+   * field clips instead of pushing the box out over the page.
+   *
+   * Opt-in, because a trigger is not always a field. A kebab is a 24px icon
+   * button, and a menu capped at that leaves a column too narrow to read a
+   * single row. Only a caller that knows the shape of its own trigger asks --
+   * `LoadingMenu` does, and nothing else should without being one.
+   *
+   * The HEIGHT clamp needs no flag: it follows the dialog, and every menu
+   * belongs inside whatever box holds it.
+   */
+  'matchTriggerWidth'?: boolean
+
   /** data-testid on the popover element. */
   'data-testid'?: string
 
@@ -278,8 +296,16 @@ export interface DropdownMenuCheckableItemProps {
    * Content, not decoration, so it is NOT `aria-hidden`: a screen reader reads
    * it as part of the item, which is what `leading` deliberately withholds for
    * a colour swatch.
+   *
+   * An ACCESSOR, not an element. A JSX prop compiles to a getter, so a caller
+   * whose detail is an expression rebuilds it on every read -- and a presence
+   * test plus a draw is two reads, which produced one element to test and a
+   * different one on screen. A function reference is free to read, so presence
+   * is `!== undefined` and the element is built exactly once, where it is drawn.
+   * That also lets a detail be a legitimately falsy `0` or `''`, which a
+   * truthiness gate would have dropped.
    */
-  'detail'?: JSXElement
+  'detail'?: () => JSXElement
   /**
    * Show the whole `label` in a tooltip once the row clips it.
    *
@@ -367,8 +393,8 @@ export function DropdownMenuCheckableItem(props: DropdownMenuCheckableItemProps)
             second element -- one to test for presence and a different one on
             screen. An empty detail draws nothing, which is what an option with
             no note wants. */}
-        <Show when={props.detail}>
-          {detail => <span class={menuItemDetail}>{detail()}</span>}
+        <Show when={props.detail !== undefined}>
+          <span class={menuItemDetail}>{props.detail?.()}</span>
         </Show>
       </span>
     </button>
@@ -431,6 +457,43 @@ export function DropdownMenu(props: DropdownMenuProps) {
   const getAnchorElement = (): Element | undefined => {
     const anchor = getAnchor()
     return anchor instanceof Element ? anchor : undefined
+  }
+
+  /**
+   * Whether this popover is MENU-shaped: a list of rows, sized to follow the
+   * control it opens from.
+   *
+   * A card popover is not. It carries its own content and its own width, so
+   * capping it at the trigger would squeeze an agent-info card into a kebab.
+   */
+  const isMenuShaped = () => props.as === undefined || props.as === 'menu' || props.as === 'div'
+
+  /**
+   * Measure the caps a menu popover follows: the trigger's width, and the height
+   * of the dialog that holds it. See `popoverMenuClamp`.
+   *
+   * Measured rather than inherited, because the popover is in the top layer: it
+   * is positioned against the viewport and its size answers to nothing in the
+   * form the trigger sits in. The dialog is found FROM the trigger, so the box a
+   * menu belongs to is a fact about where that trigger sits and not something
+   * each call site has to declare -- and a menu no dialog holds writes nothing,
+   * leaving the stylesheet's viewport fallback.
+   */
+  const applyCaps = () => {
+    if (!popoverEl || !isMenuShaped())
+      return
+    const anchor = getAnchorElement()
+    if (!anchor)
+      return
+    // The width only where the caller says its trigger is a FIELD. A kebab is a
+    // 24px icon button, and capping its menu at that leaves every row
+    // unreadable -- so this is not something a menu may assume about its own
+    // trigger.
+    if (props.matchTriggerWidth)
+      popoverEl.style.setProperty(TRIGGER_WIDTH_VAR, `${anchor.getBoundingClientRect().width}px`)
+    const dialog = anchor.closest('dialog')
+    if (dialog)
+      popoverEl.style.setProperty(DIALOG_HEIGHT_VAR, `${dialog.getBoundingClientRect().height}px`)
   }
 
   const reposition = () => {
@@ -640,11 +703,31 @@ export function DropdownMenu(props: DropdownMenuProps) {
       // ResizeObserver fires once on observe() with the current size, then on
       // every change -- reposition() only moves the popover, never resizes it,
       // so this can't loop.
-      if (typeof ResizeObserver !== 'undefined' && popoverEl) {
+      if (popoverEl) {
         resizeObserver?.disconnect()
-        resizeObserver = new ResizeObserver(() => reposition())
-        resizeObserver.observe(popoverEl)
+        // The SAME observer measures the caps below, so one delivery does one
+        // read-and-write pass. `createRafResizeObserver`, because `applyCaps`
+        // writes onto the popover this same observer watches: a write made
+        // inside the delivery phase resizes an observed element, which is the
+        // "ResizeObserver loop completed with undelivered notifications" case
+        // that helper defers a frame to avoid.
+        resizeObserver = createRafResizeObserver(() => {
+          applyCaps()
+          reposition()
+        })
+        resizeObserver?.observe(popoverEl)
+        // The anchor and the dialog that holds it, because a cap that is
+        // measured once at open is wrong the moment either changes -- a window
+        // dragged narrower, a dialog that relayouts under a phone's keyboard --
+        // and a stale cap is invisible until the day it is wrong.
+        const anchor = getAnchorElement()
+        if (anchor)
+          resizeObserver?.observe(anchor)
+        const dialog = anchor?.closest('dialog')
+        if (dialog)
+          resizeObserver?.observe(dialog)
       }
+      applyCaps()
 
       getAnchorElement()?.setAttribute('aria-expanded', 'true')
 
@@ -852,6 +935,13 @@ export function DropdownMenu(props: DropdownMenuProps) {
     return null
   }
 
+  const popoverClass = () => {
+    const shape = props.as === 'card'
+      ? popoverCard
+      : (props.matchTriggerWidth ? popoverFieldMenuClamp : popoverMenuClamp)
+    return props.class ? `${shape} ${props.class}` : shape
+  }
+
   // `data-headless` marks a dropdown with no trigger -- one opened only by
   // right-click or long press. The host then collapses to `display: contents` and
   // adds no flex item to the row that mounts it; see ~/styles/popover.css.ts.
@@ -872,7 +962,11 @@ export function DropdownMenu(props: DropdownMenuProps) {
         popover="auto"
         id={menuId}
         ref={popoverRefCallback}
-        class={props.as === 'card' ? (props.class ? `${popoverCard} ${props.class}` : popoverCard) : props.class}
+        // A card takes `popoverCard`; every other shape is a MENU and takes the
+        // menu clamp, which is what stops a long list running off the bottom of
+        // the screen with the rows past the edge unreachable. Before it, only
+        // the card branch was clamped at all.
+        class={popoverClass()}
         data-testid={props['data-testid']}
         aria-label={props['aria-label']}
         // `tabIndex` so the popover itself can hold focus. That is what makes

--- a/frontend/src/components/common/LoadingMenu.css.ts
+++ b/frontend/src/components/common/LoadingMenu.css.ts
@@ -1,4 +1,34 @@
 import { style } from '@vanilla-extract/css'
+import { popoverBase } from '~/styles/popover.css'
+
+/**
+ * The custom property that carries the TRIGGER's measured width to the popover.
+ *
+ * Written by `LoadingMenu`, which measures the trigger and sets it on the
+ * popover element; read by `popover` below. The name is spelled here and read
+ * through this constant at the one call site, so the two cannot drift.
+ *
+ * A custom property rather than an inline `max-width`, because the cap is one
+ * term of a `min()` that also holds the viewport clamp: written as a whole
+ * declaration from TypeScript, that arithmetic would live in the component and
+ * not in the stylesheet.
+ */
+export const TRIGGER_WIDTH_VAR = '--loading-menu-trigger-width'
+
+/** The trigger's width, or the viewport when nothing measured it yet. */
+const triggerWidth = `var(${TRIGGER_WIDTH_VAR}, 100vw)`
+
+/**
+ * The custom property that carries the height of the DIALOG holding the trigger.
+ *
+ * Written by `LoadingMenu` the same way as the width above, and absent for a
+ * menu that no dialog holds -- a sidebar selector, a toolbar -- which then keeps
+ * the viewport clamp alone.
+ */
+export const DIALOG_HEIGHT_VAR = '--loading-menu-dialog-height'
+
+/** The dialog's height, or the viewport when the menu is in no dialog. */
+const dialogHeight = `var(${DIALOG_HEIGHT_VAR}, 100vh)`
 
 /** Shaped like the field it replaces, so a form row keeps its rhythm. */
 export const trigger = style({
@@ -29,10 +59,79 @@ export const trigger = style({
   },
 })
 
-export const triggerText = style({
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap',
+/**
+ * The trigger's label takes the free space, so the chevron stays at the right
+ * end and the detail sits between them.
+ *
+ * Decoration only: `ClippedText` owns the clip rule, which is why this class
+ * does not restate `overflow`, `text-overflow` or `white-space`.
+ */
+export const triggerLabel = style({
+  flexGrow: 1,
+})
+
+/**
+ * The menu's own popover box: never wider than its trigger, never taller than
+ * the viewport, and scrollable on both axes.
+ *
+ * Without it the box has no limit in either direction. `calcPopoverPosition`
+ * clamps where the popover STARTS, not how large it grows, so a directory with
+ * fifty resumable sessions ran off the bottom of the screen with the rows below
+ * the fold unreachable, and one long session title made the menu wider than the
+ * dialog that holds it.
+ *
+ * Three rules, and each answers one of those:
+ *
+ *  - The width follows the TRIGGER. A menu is the open form of the control the
+ *    user clicked, so it reads as one control when the two edges line up, and a
+ *    title longer than the field clips instead of pushing the box out over the
+ *    page. `min()` keeps the viewport clamp as well, for a trigger that is
+ *    itself near the width of a phone screen.
+ *  - `min-width` is restated because Oat's own `ot-dropdown [popover]` rule sets
+ *    `min-width: 12rem`, and a min-width ALWAYS beats a max-width. A trigger
+ *    narrower than 12rem would keep a popover wider than itself, which is
+ *    exactly the case the cap exists for.
+ *  - The height follows the DIALOG that holds the trigger, not the viewport. A
+ *    dialog is a box a reader takes in as one thing, and a menu taller than it
+ *    reads as a second window over the page rather than as the open form of a
+ *    field inside it. The viewport clamp stays as the outer term, for a menu no
+ *    dialog holds and for a dialog as tall as the screen.
+ *  - `overflow: auto` on both axes. The vertical half is what makes a long list
+ *    reachable; the horizontal half is the swipe that reaches a row too wide to
+ *    fit -- a narrow field on a phone, where the checked-state radio and the
+ *    age take room the title cannot give up.
+ *
+ * NOT `popoverColumnClamp`: that class caps both axes at the viewport, which is
+ * the answer for a card that has neither a trigger nor a dialog to follow.
+ */
+export const popover = style([popoverBase, {
+  flexDirection: 'column',
+  maxWidth: `min(${triggerWidth}, calc(100vw - var(--space-4) * 2))`,
+  minWidth: `min(12rem, ${triggerWidth})`,
+  maxHeight: `min(${dialogHeight}, calc(100vh - var(--space-6) * 2))`,
+  overflow: 'auto',
+  // A swipe that reaches the end of the list must not carry on into the dialog
+  // behind the menu.
+  overscrollBehavior: 'contain',
+}])
+
+/**
+ * The scrolling half of a FILTERED menu.
+ *
+ * The filter box is the reason this exists: with the whole popover scrolling,
+ * the box scrolls away with the first few rows, and the control that narrows a
+ * long list is missing exactly while the list is long. So the rows scroll
+ * inside their own box and the filter keeps its place above them.
+ *
+ * `min-height: 0` is load-bearing. A flex item's automatic minimum size is its
+ * content, so without this the list refuses to shrink, the popover overflows
+ * instead, and the filter box scrolls away after all.
+ */
+export const filteredList = style({
+  flex: '1 1 auto',
+  minHeight: 0,
+  overflow: 'auto',
+  overscrollBehavior: 'contain',
 })
 
 /** The heading `<optgroup label>` used to draw. */
@@ -47,6 +146,8 @@ export const filterInput = style({
   width: '100%',
   margin: 0,
   marginBlockEnd: 'var(--space-1)',
+  // The box stays put while the rows scroll under it; see `filteredList`.
+  flexShrink: 0,
 })
 
 export const emptyNote = style({

--- a/frontend/src/components/common/LoadingMenu.css.ts
+++ b/frontend/src/components/common/LoadingMenu.css.ts
@@ -1,34 +1,4 @@
 import { style } from '@vanilla-extract/css'
-import { popoverBase } from '~/styles/popover.css'
-
-/**
- * The custom property that carries the TRIGGER's measured width to the popover.
- *
- * Written by `LoadingMenu`, which measures the trigger and sets it on the
- * popover element; read by `popover` below. The name is spelled here and read
- * through this constant at the one call site, so the two cannot drift.
- *
- * A custom property rather than an inline `max-width`, because the cap is one
- * term of a `min()` that also holds the viewport clamp: written as a whole
- * declaration from TypeScript, that arithmetic would live in the component and
- * not in the stylesheet.
- */
-export const TRIGGER_WIDTH_VAR = '--loading-menu-trigger-width'
-
-/** The trigger's width, or the viewport when nothing measured it yet. */
-const triggerWidth = `var(${TRIGGER_WIDTH_VAR}, 100vw)`
-
-/**
- * The custom property that carries the height of the DIALOG holding the trigger.
- *
- * Written by `LoadingMenu` the same way as the width above, and absent for a
- * menu that no dialog holds -- a sidebar selector, a toolbar -- which then keeps
- * the viewport clamp alone.
- */
-export const DIALOG_HEIGHT_VAR = '--loading-menu-dialog-height'
-
-/** The dialog's height, or the viewport when the menu is in no dialog. */
-const dialogHeight = `var(${DIALOG_HEIGHT_VAR}, 100vh)`
 
 /** Shaped like the field it replaces, so a form row keeps its rhythm. */
 export const trigger = style({
@@ -69,51 +39,6 @@ export const trigger = style({
 export const triggerLabel = style({
   flexGrow: 1,
 })
-
-/**
- * The menu's own popover box: never wider than its trigger, never taller than
- * the viewport, and scrollable on both axes.
- *
- * Without it the box has no limit in either direction. `calcPopoverPosition`
- * clamps where the popover STARTS, not how large it grows, so a directory with
- * fifty resumable sessions ran off the bottom of the screen with the rows below
- * the fold unreachable, and one long session title made the menu wider than the
- * dialog that holds it.
- *
- * Three rules, and each answers one of those:
- *
- *  - The width follows the TRIGGER. A menu is the open form of the control the
- *    user clicked, so it reads as one control when the two edges line up, and a
- *    title longer than the field clips instead of pushing the box out over the
- *    page. `min()` keeps the viewport clamp as well, for a trigger that is
- *    itself near the width of a phone screen.
- *  - `min-width` is restated because Oat's own `ot-dropdown [popover]` rule sets
- *    `min-width: 12rem`, and a min-width ALWAYS beats a max-width. A trigger
- *    narrower than 12rem would keep a popover wider than itself, which is
- *    exactly the case the cap exists for.
- *  - The height follows the DIALOG that holds the trigger, not the viewport. A
- *    dialog is a box a reader takes in as one thing, and a menu taller than it
- *    reads as a second window over the page rather than as the open form of a
- *    field inside it. The viewport clamp stays as the outer term, for a menu no
- *    dialog holds and for a dialog as tall as the screen.
- *  - `overflow: auto` on both axes. The vertical half is what makes a long list
- *    reachable; the horizontal half is the swipe that reaches a row too wide to
- *    fit -- a narrow field on a phone, where the checked-state radio and the
- *    age take room the title cannot give up.
- *
- * NOT `popoverColumnClamp`: that class caps both axes at the viewport, which is
- * the answer for a card that has neither a trigger nor a dialog to follow.
- */
-export const popover = style([popoverBase, {
-  flexDirection: 'column',
-  maxWidth: `min(${triggerWidth}, calc(100vw - var(--space-4) * 2))`,
-  minWidth: `min(12rem, ${triggerWidth})`,
-  maxHeight: `min(${dialogHeight}, calc(100vh - var(--space-6) * 2))`,
-  overflow: 'auto',
-  // A swipe that reaches the end of the list must not carry on into the dialog
-  // behind the menu.
-  overscrollBehavior: 'contain',
-}])
 
 /**
  * The scrolling half of a FILTERED menu.

--- a/frontend/src/components/common/LoadingMenu.test.tsx
+++ b/frontend/src/components/common/LoadingMenu.test.tsx
@@ -1,7 +1,11 @@
 import { cleanup, fireEvent, render, screen, within } from '@solidjs/testing-library'
-import { afterEach, describe, expect, it, vi } from 'vitest'
-import { menuOptions, menuTrigger, menuTriggerText, pickMenuValue } from '~/test-support/menu'
+import { afterEach, beforeAll, describe, expect, it, onTestFinished, vi } from 'vitest'
+import { clippedText } from '~/styles/shared.css'
+import { hoverForTooltip, stubClipped, stubRect } from '~/test-support/clipStub'
+import { menuOptions, menuOptionValues, menuTrigger, menuTriggerText, pickMenuValue } from '~/test-support/menu'
+import { installControllableResizeObserver, triggerResizeObserverForSync } from '~/test-support/resizeObserverStub'
 import { LoadingMenu } from './LoadingMenu'
+import { DIALOG_HEIGHT_VAR, TRIGGER_WIDTH_VAR } from './LoadingMenu.css'
 
 afterEach(() => {
   cleanup()
@@ -210,6 +214,104 @@ describe('the one-of-N menu (LoadingMenu)', () => {
     })
   })
 
+  describe('the detail column', () => {
+    const dated = [
+      { value: 'a', label: 'Alpha', detail: { text: '3d ago' } },
+      { value: 'b', label: 'Beta' },
+    ]
+
+    // The reason the detail is a slot and not text appended to the label: the
+    // label clips, so anything inside it goes with the ellipsis.
+    it('draws the detail outside the label, so a clipped label cannot take it', () => {
+      renderMenu({ options: dated })
+      const label = screen.getByTestId('loading-menu-option-a-label')
+      expect(label.textContent).toBe('Alpha')
+      expect(screen.getByTestId('loading-menu-option-a').textContent).toContain('3d ago')
+    })
+
+    it('draws nothing beside a label with no detail', () => {
+      renderMenu({ options: dated })
+      expect(screen.getByTestId('loading-menu-option-b').textContent?.trim()).toBe('Beta')
+    })
+
+    // The caller's element wins over its text, and both name the same thing.
+    // `SessionSelect` supplies a live `RelativeTime` here.
+    it('prefers the caller-rendered detail over its text', () => {
+      renderMenu({
+        options: [{ value: 'a', label: 'Alpha', detail: { text: '3d ago', render: () => <em>three days</em> } }],
+      })
+      const row = screen.getByTestId('loading-menu-option-a')
+      expect(row.querySelector('em')?.textContent).toBe('three days')
+      expect(row.textContent).not.toContain('3d ago')
+    })
+
+    // A renderer that ran once per row would put one DOM node in two places,
+    // and the trigger and the row both draw the detail.
+    it('runs the renderer again for the trigger, rather than moving one node', () => {
+      const drawDetail = vi.fn(() => <em>three days</em>)
+      renderMenu({
+        value: 'a',
+        options: [{ value: 'a', label: 'Alpha', detail: { text: '3d ago', render: drawDetail } }],
+      })
+      // Twice: the row and the trigger. Once would mean one DOM node asked to
+      // sit in two places, and it would appear in whichever drew it last.
+      expect(drawDetail).toHaveBeenCalledTimes(2)
+      expect(menuTrigger(MENU).querySelector('em')?.textContent).toBe('three days')
+      expect(screen.getByTestId('loading-menu-option-a').querySelector('em')?.textContent).toBe('three days')
+    })
+
+    // Picking a session must not drop its age from the field. The three other
+    // trigger states describe the LIST, so no option's detail belongs there.
+    it('shows the selected option detail on the trigger, and only for a real match', () => {
+      const { unmount } = renderMenu({ value: 'a', options: dated })
+      expect(menuTriggerText(MENU)).toContain('3d ago')
+      unmount()
+
+      renderMenu({ value: 'a', options: dated, loadingLabel: 'Loading things...' })
+      expect(menuTriggerText(MENU)).not.toContain('3d ago')
+    })
+
+    // The label alone is not the row. `SessionSelect` moved the age of a
+    // session out of the label, and a filter that read the label alone would
+    // have dropped the "sessions from days ago" search with it.
+    it('filters on the detail as well as the label', () => {
+      renderMenu({ options: dated, filter: true })
+      fireEvent.input(screen.getByTestId('loading-menu-filter'), { target: { value: '3d' } })
+      expect(menuOptionValues(MENU)).toEqual(['a'])
+    })
+  })
+
+  // Every row holds whatever the user's data is long enough to be -- a branch
+  // name, a session title -- so a clipped label needs a route back to the rest.
+  it('gives the whole label on hover once a row clips it', () => {
+    vi.useFakeTimers()
+    try {
+      renderMenu({ options: [{ value: 'a', label: 'A label far wider than the row that holds it' }] })
+      const label = screen.getByTestId('loading-menu-option-a-label')
+      stubClipped(label)
+      expect(hoverForTooltip(label)?.textContent).toBe('A label far wider than the row that holds it')
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+
+  // The TRIGGER clips too, and it is the narrower of the two: the field is one
+  // row of a dialog, so the picked option's label is the one a user is most
+  // likely to be unable to read in full.
+  it('gives the whole trigger label on hover once the field clips it', () => {
+    vi.useFakeTimers()
+    try {
+      renderMenu({ value: 'a', options: [{ value: 'a', label: 'A picked option far wider than the field' }] })
+      const label = menuTrigger(MENU).querySelector<HTMLElement>(`.${clippedText}`)!
+      stubClipped(label)
+      expect(hoverForTooltip(label)?.textContent).toBe('A picked option far wider than the field')
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('warms its caller through onOpen, the seam focus used to be', () => {
     // `WorkerSelector` prefetches the metadata for the workers it is about to
     // list. The `<select>` hung that on `focus`; a menu has only the open.
@@ -218,6 +320,69 @@ describe('the one-of-N menu (LoadingMenu)', () => {
     expect(onOpen).not.toHaveBeenCalled()
     fireEvent.click(menuTrigger(MENU))
     expect(onOpen).toHaveBeenCalledTimes(1)
+  })
+})
+
+// The popover is in the top layer: it is positioned against the viewport and
+// inherits no width from the form its trigger sits in. Left uncapped, one long
+// option made the menu wider than the dialog that opened it, and a list of
+// fifty ran off the bottom of the screen.
+describe('loadingMenu width cap', () => {
+  beforeAll(() => {
+    installControllableResizeObserver()
+  })
+
+  it('writes the trigger width onto the popover, and follows it when it changes', () => {
+    renderMenu()
+    const trigger = menuTrigger(MENU)
+    const popover = screen.getByTestId(MENU)
+
+    // jsdom measures every box as zero, so the first pass proves only that the
+    // component measured the trigger and wrote the result.
+    expect(popover.style.getPropertyValue(TRIGGER_WIDTH_VAR)).toBe('0px')
+
+    // A dialog relayouts under a phone's keyboard and a window is dragged
+    // narrower, both with no event of their own. A cap measured once at mount
+    // would be wrong from then on, and silently.
+    stubRect(trigger, { width: 317 })
+    triggerResizeObserverForSync(trigger)
+    expect(popover.style.getPropertyValue(TRIGGER_WIDTH_VAR)).toBe('317px')
+  })
+
+  // A menu taller than the dialog it opens in reads as a second window over the
+  // page rather than as the open form of a field inside it.
+  it('caps the height at the dialog that holds the trigger', () => {
+    const dialog = document.createElement('dialog')
+    document.body.append(dialog)
+    onTestFinished(() => dialog.remove())
+
+    const onChange = vi.fn()
+    render(
+      () => (
+        <LoadingMenu
+          ariaLabel="Thing"
+          value=""
+          onChange={onChange}
+          emptyLabel="No things"
+          options={[{ value: 'a', label: 'Alpha' }]}
+          data-testid={MENU}
+        />
+      ),
+      { container: dialog },
+    )
+    const popover = screen.getByTestId(MENU)
+    expect(popover.style.getPropertyValue(DIALOG_HEIGHT_VAR)).toBe('0px')
+
+    stubRect(dialog, { height: 480 })
+    triggerResizeObserverForSync(dialog)
+    expect(popover.style.getPropertyValue(DIALOG_HEIGHT_VAR)).toBe('480px')
+  })
+
+  // A menu no dialog holds writes nothing, so the stylesheet's fallback leaves
+  // it the viewport clamp: a sidebar selector must not be capped at zero.
+  it('writes no dialog height for a menu outside one', () => {
+    renderMenu()
+    expect(screen.getByTestId(MENU).style.getPropertyValue(DIALOG_HEIGHT_VAR)).toBe('')
   })
 })
 

--- a/frontend/src/components/common/LoadingMenu.test.tsx
+++ b/frontend/src/components/common/LoadingMenu.test.tsx
@@ -1,11 +1,9 @@
 import { cleanup, fireEvent, render, screen, within } from '@solidjs/testing-library'
-import { afterEach, beforeAll, describe, expect, it, onTestFinished, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { clippedText } from '~/styles/shared.css'
-import { hoverForTooltip, stubClipped, stubRect } from '~/test-support/clipStub'
-import { menuOptions, menuOptionValues, menuTrigger, menuTriggerText, pickMenuValue } from '~/test-support/menu'
-import { installControllableResizeObserver, triggerResizeObserverForSync } from '~/test-support/resizeObserverStub'
+import { hoverForTooltip, stubClipped } from '~/test-support/clipStub'
+import { menuOptionLabels, menuOptions, menuOptionValues, menuTrigger, menuTriggerText, openMenu, pickMenuValue } from '~/test-support/menu'
 import { LoadingMenu } from './LoadingMenu'
-import { DIALOG_HEIGHT_VAR, TRIGGER_WIDTH_VAR } from './LoadingMenu.css'
 
 afterEach(() => {
   cleanup()
@@ -216,7 +214,7 @@ describe('the one-of-N menu (LoadingMenu)', () => {
 
   describe('the detail column', () => {
     const dated = [
-      { value: 'a', label: 'Alpha', detail: { text: '3d ago' } },
+      { value: 'a', label: 'Alpha', detail: { text: () => '3d ago' } },
       { value: 'b', label: 'Beta' },
     ]
 
@@ -238,8 +236,11 @@ describe('the one-of-N menu (LoadingMenu)', () => {
     // `SessionSelect` supplies a live `RelativeTime` here.
     it('prefers the caller-rendered detail over its text', () => {
       renderMenu({
-        options: [{ value: 'a', label: 'Alpha', detail: { text: '3d ago', render: () => <em>three days</em> } }],
+        options: [{ value: 'a', label: 'Alpha', detail: { text: () => '3d ago', render: () => <em>three days</em> } }],
       })
+      // The renderer is deferred to the first OPEN; the text stands until then.
+      expect(screen.getByTestId('loading-menu-option-a').textContent).toContain('3d ago')
+      openMenu(MENU)
       const row = screen.getByTestId('loading-menu-option-a')
       expect(row.querySelector('em')?.textContent).toBe('three days')
       expect(row.textContent).not.toContain('3d ago')
@@ -251,8 +252,12 @@ describe('the one-of-N menu (LoadingMenu)', () => {
       const drawDetail = vi.fn(() => <em>three days</em>)
       renderMenu({
         value: 'a',
-        options: [{ value: 'a', label: 'Alpha', detail: { text: '3d ago', render: drawDetail } }],
+        options: [{ value: 'a', label: 'Alpha', detail: { text: () => '3d ago', render: drawDetail } }],
       })
+      // ONCE while closed: the trigger is always on screen, and the row's own
+      // copy waits for the open that reveals it.
+      expect(drawDetail).toHaveBeenCalledTimes(1)
+      openMenu(MENU)
       // Twice: the row and the trigger. Once would mean one DOM node asked to
       // sit in two places, and it would appear in whichever drew it last.
       expect(drawDetail).toHaveBeenCalledTimes(2)
@@ -287,6 +292,7 @@ describe('the one-of-N menu (LoadingMenu)', () => {
     vi.useFakeTimers()
     try {
       renderMenu({ options: [{ value: 'a', label: 'A label far wider than the row that holds it' }] })
+      openMenu(MENU)
       const label = screen.getByTestId('loading-menu-option-a-label')
       stubClipped(label)
       expect(hoverForTooltip(label)?.textContent).toBe('A label far wider than the row that holds it')
@@ -312,6 +318,36 @@ describe('the one-of-N menu (LoadingMenu)', () => {
     }
   })
 
+  // What a menu nobody opened must NOT allocate. `DropdownMenu` mounts its
+  // children eagerly, so the per-row cost is paid by every mounted menu at rest
+  // -- fifty rows for a full session list, and `BranchSelect`'s list has no
+  // upper limit. A row is still mounted and still readable; only the parts that
+  // exist for an interaction wait for one.
+  it('allocates no per-row tooltip or live detail until it is opened', () => {
+    const drawDetail = vi.fn(() => <em>three days</em>)
+    renderMenu({
+      options: [
+        { value: 'a', label: 'Alpha', detail: { text: () => '3d ago', render: drawDetail } },
+        { value: 'b', label: 'Beta', detail: { text: () => '5d ago', render: drawDetail } },
+      ],
+    })
+
+    // The rows ARE there, so every closed-menu assertion still holds.
+    expect(menuOptionValues(MENU)).toEqual(['a', 'b'])
+    expect(menuOptionLabels(MENU)).toEqual(['Alpha', 'Beta'])
+    // ...but no row drew the caller's element, and no row's label owns a
+    // tooltip: a Tooltip renders a wrapper around its target, and the plain
+    // branch renders the bare span instead.
+    expect(drawDetail).not.toHaveBeenCalled()
+    expect(screen.getByTestId('loading-menu-option-a').textContent).toContain('3d ago')
+
+    openMenu(MENU)
+
+    expect(drawDetail).toHaveBeenCalled()
+    expect(screen.getByTestId('loading-menu-option-a').querySelector('em')?.textContent)
+      .toBe('three days')
+  })
+
   it('warms its caller through onOpen, the seam focus used to be', () => {
     // `WorkerSelector` prefetches the metadata for the workers it is about to
     // list. The `<select>` hung that on `focus`; a menu has only the open.
@@ -320,69 +356,6 @@ describe('the one-of-N menu (LoadingMenu)', () => {
     expect(onOpen).not.toHaveBeenCalled()
     fireEvent.click(menuTrigger(MENU))
     expect(onOpen).toHaveBeenCalledTimes(1)
-  })
-})
-
-// The popover is in the top layer: it is positioned against the viewport and
-// inherits no width from the form its trigger sits in. Left uncapped, one long
-// option made the menu wider than the dialog that opened it, and a list of
-// fifty ran off the bottom of the screen.
-describe('loadingMenu width cap', () => {
-  beforeAll(() => {
-    installControllableResizeObserver()
-  })
-
-  it('writes the trigger width onto the popover, and follows it when it changes', () => {
-    renderMenu()
-    const trigger = menuTrigger(MENU)
-    const popover = screen.getByTestId(MENU)
-
-    // jsdom measures every box as zero, so the first pass proves only that the
-    // component measured the trigger and wrote the result.
-    expect(popover.style.getPropertyValue(TRIGGER_WIDTH_VAR)).toBe('0px')
-
-    // A dialog relayouts under a phone's keyboard and a window is dragged
-    // narrower, both with no event of their own. A cap measured once at mount
-    // would be wrong from then on, and silently.
-    stubRect(trigger, { width: 317 })
-    triggerResizeObserverForSync(trigger)
-    expect(popover.style.getPropertyValue(TRIGGER_WIDTH_VAR)).toBe('317px')
-  })
-
-  // A menu taller than the dialog it opens in reads as a second window over the
-  // page rather than as the open form of a field inside it.
-  it('caps the height at the dialog that holds the trigger', () => {
-    const dialog = document.createElement('dialog')
-    document.body.append(dialog)
-    onTestFinished(() => dialog.remove())
-
-    const onChange = vi.fn()
-    render(
-      () => (
-        <LoadingMenu
-          ariaLabel="Thing"
-          value=""
-          onChange={onChange}
-          emptyLabel="No things"
-          options={[{ value: 'a', label: 'Alpha' }]}
-          data-testid={MENU}
-        />
-      ),
-      { container: dialog },
-    )
-    const popover = screen.getByTestId(MENU)
-    expect(popover.style.getPropertyValue(DIALOG_HEIGHT_VAR)).toBe('0px')
-
-    stubRect(dialog, { height: 480 })
-    triggerResizeObserverForSync(dialog)
-    expect(popover.style.getPropertyValue(DIALOG_HEIGHT_VAR)).toBe('480px')
-  })
-
-  // A menu no dialog holds writes nothing, so the stylesheet's fallback leaves
-  // it the viewport clamp: a sidebar selector must not be capped at zero.
-  it('writes no dialog height for a menu outside one', () => {
-    renderMenu()
-    expect(screen.getByTestId(MENU).style.getPropertyValue(DIALOG_HEIGHT_VAR)).toBe('')
   })
 })
 

--- a/frontend/src/components/common/LoadingMenu.tsx
+++ b/frontend/src/components/common/LoadingMenu.tsx
@@ -1,6 +1,6 @@
 import type { Component, JSX } from 'solid-js'
 import ChevronDown from 'lucide-solid/icons/chevron-down'
-import { createEffect, createMemo, createSignal, For, Match, on, onCleanup, Show, Switch } from 'solid-js'
+import { createMemo, createSignal, For, Match, Show, Switch } from 'solid-js'
 import { ClippedText } from '~/components/common/ClippedText'
 import { DropdownMenu, DropdownMenuCheckableItem } from '~/components/common/DropdownMenu'
 import { Icon } from '~/components/common/Icon'
@@ -19,8 +19,15 @@ export interface LoadingMenuOptionDetail {
   /**
    * The text form. The filter matches it beside the label, and it is what the
    * row shows unless {@link LoadingMenuOptionDetail.render} replaces it.
+   *
+   * A FUNCTION, read at FILTER time, because a detail can be a moving value.
+   * `SessionSelect` draws a live `RelativeTime` and its text is that same age:
+   * held as a plain string, the string froze at whatever instant the option
+   * list was last built while the element beside it kept ticking, so a row
+   * that read "4h ago" was matched against "3h ago" and typing what was on
+   * screen emptied the list.
    */
-  text: string
+  text: () => string
   /**
    * Draws the detail in place of {@link LoadingMenuOptionDetail.text} -- a live
    * `RelativeTime`, whose own tooltip states the full timestamp.
@@ -39,6 +46,15 @@ export interface LoadingMenuOption {
   label: string
   group?: string
   detail?: LoadingMenuOptionDetail
+  /**
+   * This row survives the filter, whatever the query.
+   *
+   * For a row that is not one of the things the list holds but a way OUT of it:
+   * `SessionSelect`'s "Start a new session" and "Enter a session ID...". A query
+   * that matches no session is exactly when a user needs those, and filtering
+   * them left an empty menu whose only escape was to clear the query.
+   */
+  pinned?: boolean
 }
 
 export interface LoadingMenuProps {
@@ -129,16 +145,27 @@ export interface LoadingMenuProps {
 const FILTER_MIN_OPTIONS = 12
 
 /**
- * Draw one option's detail: the caller's own element when it gave a renderer,
- * and the plain text otherwise.
+ * The renderer for one option's detail: the caller's own element when it gave
+ * one, and the plain text otherwise. Undefined for an option with no detail.
  *
  * One function for the two sites that draw a detail -- the row and the trigger
- * -- so neither can forget that `render` takes precedence over `text`.
+ * -- so neither can forget that `render` takes precedence over `text`. It hands
+ * back a FUNCTION rather than an element, so the element is built where it is
+ * drawn: the trigger and the row each need their own, and one DOM node cannot
+ * sit in two places.
+ *
+ * `live` false takes the TEXT even when a renderer exists. A caller's element
+ * can be expensive -- `SessionSelect`'s is a live `RelativeTime` that subscribes
+ * to the shared ticker -- and a row inside a menu nobody has opened should not
+ * pay for it. The two read the same, because the text IS what the element draws.
  */
-function renderDetail(detail: LoadingMenuOptionDetail | undefined): JSX.Element | undefined {
+function detailRenderer(
+  detail: LoadingMenuOptionDetail | undefined,
+  live = true,
+): (() => JSX.Element) | undefined {
   if (detail === undefined)
     return undefined
-  return detail.render ? detail.render() : detail.text
+  return () => (live && detail.render ? detail.render() : detail.text())
 }
 
 /**
@@ -159,10 +186,11 @@ function renderDetail(detail: LoadingMenuOptionDetail | undefined): JSX.Element 
  */
 export const LoadingMenu: Component<LoadingMenuProps> = (props) => {
   const [query, setQuery] = createSignal('')
-  // Signals, not plain `let`s: the effect that caps the popover at the trigger's
-  // width needs both elements, and it must run when the second one arrives.
+  // Whether the menu has ever been opened; see `items`. One-way: it never goes
+  // back to false, so a reopen mounts nothing again.
+  const [everOpened, setEverOpened] = createSignal(false)
+  // A signal, not a plain `let`: `select` reads it to dismiss a filtered menu.
   const [popoverEl, setPopoverEl] = createSignal<HTMLElement>()
-  const [triggerEl, setTriggerEl] = createSignal<HTMLElement>()
   let filterEl: HTMLInputElement | undefined
 
   const testId = () => props['data-testid'] ?? 'loading-menu'
@@ -208,57 +236,26 @@ export const LoadingMenu: Component<LoadingMenuProps> = (props) => {
     // The DETAIL matches too, and it has to: the age of a session moved out of
     // the label and into that slot, so a filter that read the label alone would
     // silently drop the "sessions from days ago" search the label used to serve.
+    //
+    // A PINNED option survives every query. Such a row is not one of the things
+    // the list holds -- it is a way OUT of the list, and `SessionSelect` marks
+    // both of its own that way. Filtering them removed the escape hatch at the
+    // one moment it is needed: a user whose session is not here types its title,
+    // gets "No matches", and now has neither "Enter a session ID..." nor "Start
+    // a new session" to reach. Clearing the query was the only route back.
     return props.options.filter(o =>
-      o.label.toLowerCase().includes(q) || (o.detail?.text.toLowerCase().includes(q) ?? false),
+      o.pinned === true
+      || o.label.toLowerCase().includes(q)
+      || (o.detail?.text().toLowerCase().includes(q) ?? false),
     )
   })
 
-  /**
-   * Cap the popover at the trigger's width and at the height of the dialog that
-   * holds it; see `popover` in `./LoadingMenu.css.ts`.
-   *
-   * Measured rather than inherited, because the popover is in the top layer:
-   * it is positioned against the viewport and its size answers to nothing in
-   * the form the trigger sits in.
-   *
-   * The dialog is found from the TRIGGER, not passed in: the app renders a real
-   * `<dialog>`, so the box a menu belongs to is a fact about where the trigger
-   * sits and not something each of the six call sites should have to declare. A
-   * menu no dialog holds -- a sidebar selector, a toolbar -- writes nothing, and
-   * the stylesheet's fallback leaves it the viewport clamp.
-   *
-   * The observer keeps both caps correct after that first measurement. A dialog
-   * that relayouts under a phone's keyboard, or a window the user drags
-   * smaller, changes either measurement with no event of its own -- and a stale
-   * cap is invisible until the day it is wrong. `apply()` runs once outside the
-   * observer as well, because an observer reports the first size on its own
-   * schedule and a stub reports nothing at all.
-   *
-   * `on`, so the two elements arrive as arguments: the effect re-runs when
-   * either changes, and its cleanup disconnects the observer that holds the
-   * pair it replaced.
-   */
-  createEffect(on([triggerEl, popoverEl], ([trigger, popover]) => {
-    if (!trigger || !popover)
-      return
-    const dialog = trigger.closest('dialog')
-    const apply = () => {
-      popover.style.setProperty(styles.TRIGGER_WIDTH_VAR, `${trigger.getBoundingClientRect().width}px`)
-      if (dialog)
-        popover.style.setProperty(styles.DIALOG_HEIGHT_VAR, `${dialog.getBoundingClientRect().height}px`)
-    }
-    apply()
-    if (typeof ResizeObserver === 'undefined')
-      return
-    const observer = new ResizeObserver(apply)
-    observer.observe(trigger)
-    if (dialog)
-      observer.observe(dialog)
-    onCleanup(() => observer.disconnect())
-  }))
+  /** The option the value names, or undefined when the list does not hold it. */
+  const selected = () => props.options.find(o => o.value === props.value)
 
   /**
-   * The label on the trigger. Four states, not three.
+   * What the trigger shows: its label, and the detail beside it. Four states,
+   * not three.
    *
    * A value that matches NO option is its own case, and it is not the empty
    * list: falling through to `emptyLabel` made the trigger read "No workers
@@ -269,40 +266,25 @@ export const LoadingMenu: Component<LoadingMenuProps> = (props) => {
    *
    * `placeholder` stays for the genuinely EMPTY value -- the "pick one" prompt
    * that `BranchSelect` and `WorktreeSelect` render before a choice is made.
+   *
+   * ONE accessor for both, because they are one decision. The trigger is the
+   * closed form of the selected ROW, so it carries the same two columns -- and
+   * a detail belongs beside a REAL match only, since the other three states
+   * describe the LIST rather than a row. Derived twice, a fifth state added to
+   * the label would reach the detail's guard silently or not at all.
    */
-  /** The option the value names, or undefined when the list does not hold it. */
-  const selected = () => props.options.find(o => o.value === props.value)
-
-  const triggerText = () => {
+  const triggerState = (): { label: string, detail?: LoadingMenuOptionDetail } => {
     const loadingLabel = props.loadingLabel
     if (loadingLabel !== undefined)
-      return loadingLabel
+      return { label: loadingLabel }
     if (isEmpty())
-      return props.emptyLabel
+      return { label: props.emptyLabel }
     const match = selected()
     if (match)
-      return match.label
+      return { label: match.label, detail: match.detail }
     if (props.value === '')
-      return props.placeholder ?? props.emptyLabel
-    return props.value
-  }
-
-  /**
-   * The detail of the selected option, which the trigger draws beside its label.
-   *
-   * The trigger is the closed form of the ROW, so it carries the same two
-   * columns. Without it, picking a session replaced "Build the thing, 4 hours
-   * ago" with the title alone -- and the age is half of what tells two attempts
-   * at one task apart.
-   *
-   * Only for a REAL match: the other three trigger states draw a message about
-   * the list (loading, empty, a value the list lost), and no option's detail
-   * belongs beside any of them.
-   */
-  const triggerDetail = (): LoadingMenuOptionDetail | undefined => {
-    if (props.loadingLabel !== undefined || isEmpty())
-      return undefined
-    return selected()?.detail
+      return { label: props.placeholder ?? props.emptyLabel }
+    return { label: props.value }
   }
 
   const select = (value: string) => {
@@ -356,8 +338,21 @@ export const LoadingMenu: Component<LoadingMenuProps> = (props) => {
                 // whatever the user's data is long enough to be: a branch name,
                 // a session title. Clipped with no route back is the state a
                 // tooltip exists to prevent.
-                revealClippedLabel
-                detail={renderDetail(option.detail)}
+                //
+                // Deferred to the first OPEN, and that is the whole reason this
+                // is a prop rather than always-on. `DropdownMenu` renders its
+                // children on MOUNT, and `ClippedText` wraps every instance in
+                // a `Tooltip` -- a MutationObserver and listeners on two
+                // elements, per row. Paid eagerly that is one such allocation
+                // per option of every menu on screen, open or not: fifty for a
+                // full session list, and `BranchSelect`'s list has no upper
+                // limit at all. A row nobody has seen needs no route back.
+                revealClippedLabel={everOpened()}
+                // Same deferral, same reason: `SessionSelect`'s detail is a live
+                // `RelativeTime` that subscribes to the shared ticker, so an
+                // unopened picker held one subscriber per session. The text form
+                // renders until then, so the row reads the same either way.
+                detail={detailRenderer(option.detail, everOpened())}
                 checked={option.value === props.value}
                 data-testid={`loading-menu-option-${option.value}`}
                 onSelect={() => select(option.value)}
@@ -373,10 +368,13 @@ export const LoadingMenu: Component<LoadingMenuProps> = (props) => {
     <DropdownMenu
       aria-label={props.ariaLabel}
       as={filtering() ? 'div' : 'menu'}
-      class={styles.popover}
+      // This menu's trigger IS a field -- it is shaped like the input it
+      // replaces -- so the popover follows its width. See the prop.
+      matchTriggerWidth
       popoverRef={setPopoverEl}
       onToggle={(open) => {
         if (open) {
+          setEverOpened(true)
           props.onOpen?.()
           // Put the caret in the filter box. `popover="auto"` moves focus
           // nowhere on its own, so without this the filter buys back none of
@@ -394,15 +392,6 @@ export const LoadingMenu: Component<LoadingMenuProps> = (props) => {
       trigger={triggerProps => (
         <button
           {...triggerProps}
-          // Both refs run, and the order does not matter: `DropdownMenu`
-          // positions the popover against this element, and this component
-          // measures it for the width cap. Solid merges the spread with the
-          // attribute and the attribute wins, so dropping the first call here
-          // would leave the menu anchored to nothing.
-          ref={(el) => {
-            triggerProps.ref(el)
-            setTriggerEl(el)
-          }}
           type="button"
           class={styles.trigger}
           aria-label={props.ariaLabel}
@@ -419,11 +408,11 @@ export const LoadingMenu: Component<LoadingMenuProps> = (props) => {
               hover once the field is too narrow to hold it. The trigger's own
               `aria-label` names the control, so the tooltip adds the value and
               never renames the button. */}
-          <ClippedText text={triggerText()} class={styles.triggerLabel} />
-          <Show when={triggerDetail()}>
+          <ClippedText text={triggerState().label} class={styles.triggerLabel} />
+          <Show when={triggerState().detail}>
             {/* The row's own class, because the trigger IS the closed form of
                 the selected row: the same label, the same trailing note. */}
-            {detail => <span class={menuItemDetail}>{renderDetail(detail())}</span>}
+            {detail => <span class={menuItemDetail}>{detailRenderer(detail())?.()}</span>}
           </Show>
           <Icon icon={ChevronDown} size="xs" aria-hidden="true" />
         </button>

--- a/frontend/src/components/common/LoadingMenu.tsx
+++ b/frontend/src/components/common/LoadingMenu.tsx
@@ -1,15 +1,44 @@
-import type { Component } from 'solid-js'
+import type { Component, JSX } from 'solid-js'
 import ChevronDown from 'lucide-solid/icons/chevron-down'
-import { createMemo, createSignal, For, Match, Show, Switch } from 'solid-js'
+import { createEffect, createMemo, createSignal, For, Match, on, onCleanup, Show, Switch } from 'solid-js'
+import { ClippedText } from '~/components/common/ClippedText'
 import { DropdownMenu, DropdownMenuCheckableItem } from '~/components/common/DropdownMenu'
 import { Icon } from '~/components/common/Icon'
+import { menuItemDetail } from '~/styles/shared.css'
 import * as styles from './LoadingMenu.css'
+
+/**
+ * The short note one option carries at the right end of its row: the age of a
+ * session, the size of a file.
+ *
+ * It is a slot of its own rather than text appended to the label, because the
+ * label CLIPS. Text inside the label is inside the ellipsis, so the row with a
+ * title long enough to need its timestamp is the row that loses it.
+ */
+export interface LoadingMenuOptionDetail {
+  /**
+   * The text form. The filter matches it beside the label, and it is what the
+   * row shows unless {@link LoadingMenuOptionDetail.render} replaces it.
+   */
+  text: string
+  /**
+   * Draws the detail in place of {@link LoadingMenuOptionDetail.text} -- a live
+   * `RelativeTime`, whose own tooltip states the full timestamp.
+   *
+   * A FUNCTION and not an element, for two reasons. The trigger and the row
+   * both draw the detail, and one DOM node cannot sit in two places. And an
+   * element built with the option list is built for every row of every menu on
+   * screen, open or not, because `DropdownMenu` renders its children eagerly.
+   */
+  render?: () => JSX.Element
+}
 
 /** One choice. `group` puts it under a heading; entries keep their given order. */
 export interface LoadingMenuOption {
   value: string
   label: string
   group?: string
+  detail?: LoadingMenuOptionDetail
 }
 
 export interface LoadingMenuProps {
@@ -100,6 +129,19 @@ export interface LoadingMenuProps {
 const FILTER_MIN_OPTIONS = 12
 
 /**
+ * Draw one option's detail: the caller's own element when it gave a renderer,
+ * and the plain text otherwise.
+ *
+ * One function for the two sites that draw a detail -- the row and the trigger
+ * -- so neither can forget that `render` takes precedence over `text`.
+ */
+function renderDetail(detail: LoadingMenuOptionDetail | undefined): JSX.Element | undefined {
+  if (detail === undefined)
+    return undefined
+  return detail.render ? detail.render() : detail.text
+}
+
+/**
  * A one-of-N menu that survives the loading -> loaded transition.
  *
  * Replaces the native `<select>` this used to wrap; see the dropdown rule in
@@ -117,7 +159,10 @@ const FILTER_MIN_OPTIONS = 12
  */
 export const LoadingMenu: Component<LoadingMenuProps> = (props) => {
   const [query, setQuery] = createSignal('')
-  let popoverEl: HTMLElement | undefined
+  // Signals, not plain `let`s: the effect that caps the popover at the trigger's
+  // width needs both elements, and it must run when the second one arrives.
+  const [popoverEl, setPopoverEl] = createSignal<HTMLElement>()
+  const [triggerEl, setTriggerEl] = createSignal<HTMLElement>()
   let filterEl: HTMLInputElement | undefined
 
   const testId = () => props['data-testid'] ?? 'loading-menu'
@@ -160,8 +205,57 @@ export const LoadingMenu: Component<LoadingMenuProps> = (props) => {
     const q = query().trim().toLowerCase()
     if (!filtering() || q === '')
       return props.options
-    return props.options.filter(o => o.label.toLowerCase().includes(q))
+    // The DETAIL matches too, and it has to: the age of a session moved out of
+    // the label and into that slot, so a filter that read the label alone would
+    // silently drop the "sessions from days ago" search the label used to serve.
+    return props.options.filter(o =>
+      o.label.toLowerCase().includes(q) || (o.detail?.text.toLowerCase().includes(q) ?? false),
+    )
   })
+
+  /**
+   * Cap the popover at the trigger's width and at the height of the dialog that
+   * holds it; see `popover` in `./LoadingMenu.css.ts`.
+   *
+   * Measured rather than inherited, because the popover is in the top layer:
+   * it is positioned against the viewport and its size answers to nothing in
+   * the form the trigger sits in.
+   *
+   * The dialog is found from the TRIGGER, not passed in: the app renders a real
+   * `<dialog>`, so the box a menu belongs to is a fact about where the trigger
+   * sits and not something each of the six call sites should have to declare. A
+   * menu no dialog holds -- a sidebar selector, a toolbar -- writes nothing, and
+   * the stylesheet's fallback leaves it the viewport clamp.
+   *
+   * The observer keeps both caps correct after that first measurement. A dialog
+   * that relayouts under a phone's keyboard, or a window the user drags
+   * smaller, changes either measurement with no event of its own -- and a stale
+   * cap is invisible until the day it is wrong. `apply()` runs once outside the
+   * observer as well, because an observer reports the first size on its own
+   * schedule and a stub reports nothing at all.
+   *
+   * `on`, so the two elements arrive as arguments: the effect re-runs when
+   * either changes, and its cleanup disconnects the observer that holds the
+   * pair it replaced.
+   */
+  createEffect(on([triggerEl, popoverEl], ([trigger, popover]) => {
+    if (!trigger || !popover)
+      return
+    const dialog = trigger.closest('dialog')
+    const apply = () => {
+      popover.style.setProperty(styles.TRIGGER_WIDTH_VAR, `${trigger.getBoundingClientRect().width}px`)
+      if (dialog)
+        popover.style.setProperty(styles.DIALOG_HEIGHT_VAR, `${dialog.getBoundingClientRect().height}px`)
+    }
+    apply()
+    if (typeof ResizeObserver === 'undefined')
+      return
+    const observer = new ResizeObserver(apply)
+    observer.observe(trigger)
+    if (dialog)
+      observer.observe(dialog)
+    onCleanup(() => observer.disconnect())
+  }))
 
   /**
    * The label on the trigger. Four states, not three.
@@ -176,18 +270,39 @@ export const LoadingMenu: Component<LoadingMenuProps> = (props) => {
    * `placeholder` stays for the genuinely EMPTY value -- the "pick one" prompt
    * that `BranchSelect` and `WorktreeSelect` render before a choice is made.
    */
+  /** The option the value names, or undefined when the list does not hold it. */
+  const selected = () => props.options.find(o => o.value === props.value)
+
   const triggerText = () => {
     const loadingLabel = props.loadingLabel
     if (loadingLabel !== undefined)
       return loadingLabel
     if (isEmpty())
       return props.emptyLabel
-    const match = props.options.find(o => o.value === props.value)
+    const match = selected()
     if (match)
       return match.label
     if (props.value === '')
       return props.placeholder ?? props.emptyLabel
     return props.value
+  }
+
+  /**
+   * The detail of the selected option, which the trigger draws beside its label.
+   *
+   * The trigger is the closed form of the ROW, so it carries the same two
+   * columns. Without it, picking a session replaced "Build the thing, 4 hours
+   * ago" with the title alone -- and the age is half of what tells two attempts
+   * at one task apart.
+   *
+   * Only for a REAL match: the other three trigger states draw a message about
+   * the list (loading, empty, a value the list lost), and no option's detail
+   * belongs beside any of them.
+   */
+  const triggerDetail = (): LoadingMenuOptionDetail | undefined => {
+    if (props.loadingLabel !== undefined || isEmpty())
+      return undefined
+    return selected()?.detail
   }
 
   const select = (value: string) => {
@@ -196,7 +311,7 @@ export const LoadingMenu: Component<LoadingMenuProps> = (props) => {
     // dismiss it, which also means an item click does not either. Closing here
     // is what that trade costs, and only the item knows the action ran.
     if (filtering()) {
-      popoverEl?.hidePopover()
+      popoverEl()?.hidePopover()
       setQuery('')
     }
   }
@@ -236,6 +351,13 @@ export const LoadingMenu: Component<LoadingMenuProps> = (props) => {
               <DropdownMenuCheckableItem
                 kind="radio"
                 label={option.label}
+                // This menu wraps no tooltip of its own around an item, so the
+                // label may own one -- and it must, because the rows hold
+                // whatever the user's data is long enough to be: a branch name,
+                // a session title. Clipped with no route back is the state a
+                // tooltip exists to prevent.
+                revealClippedLabel
+                detail={renderDetail(option.detail)}
                 checked={option.value === props.value}
                 data-testid={`loading-menu-option-${option.value}`}
                 onSelect={() => select(option.value)}
@@ -251,7 +373,8 @@ export const LoadingMenu: Component<LoadingMenuProps> = (props) => {
     <DropdownMenu
       aria-label={props.ariaLabel}
       as={filtering() ? 'div' : 'menu'}
-      popoverRef={el => (popoverEl = el)}
+      class={styles.popover}
+      popoverRef={setPopoverEl}
       onToggle={(open) => {
         if (open) {
           props.onOpen?.()
@@ -271,6 +394,15 @@ export const LoadingMenu: Component<LoadingMenuProps> = (props) => {
       trigger={triggerProps => (
         <button
           {...triggerProps}
+          // Both refs run, and the order does not matter: `DropdownMenu`
+          // positions the popover against this element, and this component
+          // measures it for the width cap. Solid merges the spread with the
+          // attribute and the attribute wins, so dropping the first call here
+          // would leave the menu anchored to nothing.
+          ref={(el) => {
+            triggerProps.ref(el)
+            setTriggerEl(el)
+          }}
           type="button"
           class={styles.trigger}
           aria-label={props.ariaLabel}
@@ -283,7 +415,16 @@ export const LoadingMenu: Component<LoadingMenuProps> = (props) => {
           data-value={props.value}
           disabled={disabled()}
         >
-          <span class={styles.triggerText}>{triggerText()}</span>
+          {/* `ClippedText`, so the title of the picked session is readable on
+              hover once the field is too narrow to hold it. The trigger's own
+              `aria-label` names the control, so the tooltip adds the value and
+              never renames the button. */}
+          <ClippedText text={triggerText()} class={styles.triggerLabel} />
+          <Show when={triggerDetail()}>
+            {/* The row's own class, because the trigger IS the closed form of
+                the selected row: the same label, the same trailing note. */}
+            {detail => <span class={menuItemDetail}>{renderDetail(detail())}</span>}
+          </Show>
           <Icon icon={ChevronDown} size="xs" aria-hidden="true" />
         </button>
       )}
@@ -314,7 +455,7 @@ export const LoadingMenu: Component<LoadingMenuProps> = (props) => {
           that panel two nested menus. The unfiltered form needs none of this --
           `DropdownMenu` renders a real `<menu>` there. */}
       <Show when={filtering()} fallback={items()}>
-        <div role="menu" aria-label={props.ariaLabel}>{items()}</div>
+        <div role="menu" aria-label={props.ariaLabel} class={styles.filteredList}>{items()}</div>
       </Show>
     </DropdownMenu>
   )

--- a/frontend/src/components/common/Tooltip.test.tsx
+++ b/frontend/src/components/common/Tooltip.test.tsx
@@ -417,6 +417,26 @@ describe('tooltip on a disabled control', () => {
     expect(description?.textContent).toBe('Open the hub over HTTPS to add a passkey.')
   })
 
+  // A disabled control is inert for its whole SUBTREE, so a target INSIDE one
+  // is as unreachable as the control itself. `ClippedText` puts its target
+  // exactly there -- the label inside a control -- so a clipped value inside a
+  // disabled menu trigger had no route back at all until the ancestor counted.
+  it('describes a target that sits inside a disabled control', () => {
+    render(() => (
+      <button type="button" disabled>
+        <Tooltip text="feature/a-branch-name-far-wider-than-the-field">
+          <span>feature/a-branch-name…</span>
+        </Tooltip>
+      </button>
+    ))
+
+    const label = screen.getByText('feature/a-branch-name…')
+    const describedBy = label.getAttribute('aria-describedby')
+    expect(describedBy).toBeTruthy()
+    expect(document.getElementById(describedBy!)?.textContent)
+      .toBe('feature/a-branch-name-far-wider-than-the-field')
+  })
+
   // A dialog that greys out a destructive action states WHY in its body, and
   // wraps the control so a reader who hovers learns it too. Without
   // `describedBy` the same sentence reaches the accessibility tree twice, and

--- a/frontend/src/components/common/Tooltip.tsx
+++ b/frontend/src/components/common/Tooltip.tsx
@@ -78,21 +78,58 @@ type TooltipTarget = Element & {
 }
 
 /**
- * True when the browser will not dispatch a pointer event to this element.
+ * Every element type that can carry `disabled`. A `<span>` cannot, so its own
+ * disabled state is always the state of the control that ENCLOSES it.
+ */
+const DISABLEABLE = 'button, input, select, textarea, fieldset, optgroup, option'
+
+/**
+ * The control whose disabled state governs `el`: `el` itself when it can be
+ * disabled, otherwise the nearest one that encloses it, or null when none does.
+ *
+ * It matches on element TYPE rather than on `:disabled` deliberately. jsdom
+ * resolves the `:disabled` pseudo-class through the element's own window and
+ * throws for a node that is not in a document yet -- which is every node before
+ * SolidJS inserts the tree it just built.
+ */
+function disablingHost(el: Element): Element | null {
+  return el.closest(DISABLEABLE)
+}
+
+/**
+ * True when the browser will not dispatch a pointer event to this element
+ * ITSELF, which is the question the wrapper's box answers.
  *
  * `:disabled` rather than the `disabled` property, so a control disabled by an
  * enclosing `<fieldset>` counts as well. `aria-disabled` is the other half: it
  * looks disabled and takes pointer events, so a tooltip on it needs no wrapper
  * -- but this component still owes the description below, because a screen
  * reader reads it as unavailable and the reader deserves the reason either way.
+ *
+ * Deliberately NOT an ancestor test, although a disabled control is inert for
+ * its whole subtree. The wrapper this drives sits INSIDE that subtree too, so a
+ * box there catches nothing -- it would only add a layout box to every label
+ * inside every disabled control, for a hover that still cannot happen. The
+ * description below is the route that does work, and it does use the ancestor.
  */
 function targetRefusesPointerEvents(el: Element): boolean {
   return el.matches(':disabled')
 }
 
-/** True when the element presents itself as unavailable, by either mechanism. */
+/**
+ * True when the element presents itself as unavailable, by any mechanism.
+ *
+ * The ENCLOSING control counts. A disabled form control is inert for its whole
+ * subtree, so a `<span>` inside a disabled `<button>` is as unhoverable as the
+ * button -- and `ClippedText` puts its target exactly there, on the label
+ * INSIDE a control. Without the ancestor, a clipped value inside a disabled
+ * control had no route back at all: no hover, and no description either.
+ */
 function targetIsDisabled(el: Element): boolean {
-  return targetRefusesPointerEvents(el) || el.getAttribute('aria-disabled') === 'true'
+  if (el.getAttribute('aria-disabled') === 'true')
+    return true
+  const host = disablingHost(el)
+  return host !== null && host.matches(':disabled')
 }
 
 /** True if the element's computed overflow on either axis clips its content. */
@@ -322,6 +359,13 @@ export function Tooltip(props: TooltipProps) {
     sync()
     const observer = new MutationObserver(sync)
     observer.observe(target, { attributes: true, attributeFilter: ['disabled', 'aria-disabled'] })
+    // The ENCLOSING control too, when the target is not one itself: a label
+    // inside a button is disabled by that button, so watching only the label
+    // would leave the description missing for as long as the control stays
+    // disabled -- exactly the window the description exists to cover.
+    const host = disablingHost(target)
+    if (host && host !== target)
+      observer.observe(host, { attributes: true, attributeFilter: ['disabled', 'aria-disabled'] })
     onCleanup(() => observer.disconnect())
   })
 

--- a/frontend/src/components/settings/SettingsPanel.css.ts
+++ b/frontend/src/components/settings/SettingsPanel.css.ts
@@ -9,6 +9,21 @@ export const panel = style({
   // vanilla-extract emits unlayered rules, so restating padding wins without a
   // specificity fight (the same mechanic as `~/components/common/ErrorFallback.css.ts`).
   padding: 0,
+  // Beat Oat's `[role="tabpanel"]:not([hidden]) { animation: fade-in-up .3s both }`
+  // the same way, and this one is not cosmetic.
+  //
+  // `fade-in-up` ends on `transform: translateY(0)`, and `animation-fill-mode:
+  // both` RETAINS that final keyframe -- so the panel keeps an identity
+  // transform for ever. A transform, identity or not, makes an element the
+  // containing block for every `position: fixed` descendant, and this panel
+  // holds the Preferences dialog's menus. `calcPopoverPosition` places those in
+  // VIEWPORT coordinates, so they resolve against the panel instead: the damage
+  // is hidden while the popover is in the top layer and appears on the way out,
+  // as a menu that jumps by the dialog's own offset while it closes.
+  //
+  // Dropped rather than replaced with an opacity-only fade: Oat ships one
+  // keyframe set and a second copy here would be a fade this project then owns.
+  animation: 'none',
 })
 
 // Drop the list's outer top padding so the first row sits flush with the panel

--- a/frontend/src/components/shell/ResumeSessionField.test.tsx
+++ b/frontend/src/components/shell/ResumeSessionField.test.tsx
@@ -59,6 +59,9 @@ const textInput = () => screen.queryByPlaceholderText(/^Session ID/)
 
 const refreshButton = () => screen.getByTestId('session-field-refresh')
 
+/** The way back to the menu, which only the text-box state offers. */
+const pickFromListButton = () => screen.queryByTestId('session-field-pick-from-list')
+
 // A harness whose working directory can CHANGE, which the fixed-prop one above
 // cannot express. The directory is the field's most-used key: the user picks it
 // from a tree while the dialog stays open.
@@ -219,13 +222,13 @@ describe('resumeSessionField', () => {
     listAgentSessions.mockResolvedValueOnce(response('ses_a'))
     renderField()
     await flush()
-    expect(menuOptionValues(MENU)).toEqual(['', 'ses_a', TYPE_A_HANDLE_VALUE])
+    expect(menuOptionValues(MENU)).toEqual(['', TYPE_A_HANDLE_VALUE, 'ses_a'])
 
     listAgentSessions.mockResolvedValue(response('ses_a', 'ses_b'))
     fireEvent.click(refreshButton())
     await flush()
 
-    expect(menuOptionValues(MENU)).toEqual(['', 'ses_a', 'ses_b', TYPE_A_HANDLE_VALUE])
+    expect(menuOptionValues(MENU)).toEqual(['', TYPE_A_HANDLE_VALUE, 'ses_a', 'ses_b'])
   })
 
   it('refuses a second fetch while one is in flight', async () => {
@@ -338,6 +341,50 @@ describe('resumeSessionField', () => {
     expect(textInput()).toBeInTheDocument()
     // The sentinel is not a handle, so it must never reach the state.
     expect(state.trimmed()).toBe('')
+  })
+
+  // The route INTO the text box is a menu row, so the route out cannot be one.
+  // Without this button, a user who picked "Enter a session ID…" by mistake was
+  // held in the text box for the life of the dialog: nothing else clears that
+  // state, and the field re-keys only on a change of worker, directory or
+  // provider.
+  it('returns to the menu from the text box, dropping what was typed', async () => {
+    listAgentSessions.mockResolvedValue(response('ses_a'))
+    const { state } = renderField()
+    await flush()
+
+    pickMenuValue(MENU, TYPE_A_HANDLE_VALUE)
+    fireEvent.input(textInput()!, { target: { value: 'ses_from_elsewhere' } })
+    expect(state.trimmed()).toBe('ses_from_elsewhere')
+
+    fireEvent.click(pickFromListButton()!)
+
+    expect(menuTrigger(MENU)).toBeInTheDocument()
+    expect(textInput()).toBeNull()
+    // Cleared, exactly as the row that switched TO the text box clears a picked
+    // handle: a typed handle is not one the menu can offer, so carrying it back
+    // would leave the trigger showing raw text the list does not hold.
+    expect(state.trimmed()).toBe('')
+    expect(menuTriggerText(MENU)).toBe('Start a new session')
+  })
+
+  // The button states a way back that exists. With no list to return to,
+  // pressing it would put the same text box straight back.
+  it('offers no way back while the text box is the only control', async () => {
+    listAgentSessions.mockResolvedValue(response())
+    renderField()
+    await flush()
+
+    expect(textInput()).toBeInTheDocument()
+    expect(pickFromListButton()).toBeNull()
+  })
+
+  it('offers no way back while the menu is already showing', async () => {
+    listAgentSessions.mockResolvedValue(response('ses_a'))
+    renderField()
+    await flush()
+
+    expect(pickFromListButton()).toBeNull()
   })
 
   // The error travels with the FIELD, so it survives the swap -- and whichever

--- a/frontend/src/components/shell/ResumeSessionField.tsx
+++ b/frontend/src/components/shell/ResumeSessionField.tsx
@@ -2,7 +2,9 @@ import type { Component } from 'solid-js'
 import type { AgentProvider } from '~/generated/proto/leapmux/v1/agent_pb'
 import type { SessionIdState } from '~/hooks/createSessionIdState'
 import type { UseResumableSessionsArgs } from '~/hooks/useResumableSessions'
+import List from 'lucide-solid/icons/list'
 import { createEffect, createSignal, on, Show } from 'solid-js'
+import { IconButton } from '~/components/common/IconButton'
 import { LabeledField } from '~/components/common/LabeledField'
 import { RefreshButton } from '~/components/common/RefreshButton'
 import { RESUME_SESSION_ERROR_ID, RESUME_SESSION_LABEL } from '~/components/shell/resumeSession'
@@ -89,6 +91,22 @@ export const ResumeSessionField: Component<ResumeSessionFieldProps> = (props) =>
   // typing. `settled()` distinguishes the two.
   const showMenu = () => !typing() && (!settled() || sessions().length > 0)
 
+  /**
+   * Whether the field offers a way back to the menu.
+   *
+   * The route in is a row of the menu, so the route out cannot be. Without this
+   * a user who picked "Enter a session ID…" -- to read a handle off another
+   * machine, or by mistake -- was left in the text box for as long as the
+   * dialog stayed open: nothing else clears `typing`, and the effect above
+   * fires only when the worker, the directory or the provider CHANGES. Changing
+   * the directory and changing it back was the whole way out.
+   *
+   * Offered only while a list exists to return to. With none, `showMenu()`
+   * would put the text input straight back and the button would do nothing
+   * visible.
+   */
+  const canReturnToMenu = () => typing() && sessions().length > 0
+
   return (
     <LabeledField
       label={RESUME_SESSION_LABEL}
@@ -114,12 +132,35 @@ export const ResumeSessionField: Component<ResumeSessionFieldProps> = (props) =>
         know all three -- pressing it then would do nothing at all.
       */
       actions={(
-        <RefreshButton
-          onClick={() => void refresh()}
-          disabled={loading() || source() === null}
-          title="Refresh sessions"
-          data-testid="session-field-refresh"
-        />
+        <>
+          {/*
+            The way back out of the text box; see `canReturnToMenu`.
+
+            It clears the value, exactly as the row that switches TO the text
+            box does. A handle typed by hand is not one the menu can offer, so
+            carrying it back would leave the trigger showing raw text the list
+            does not hold -- and, for a handle that fails validation, the error
+            underneath with no control to correct it.
+          */}
+          <Show when={canReturnToMenu()}>
+            <IconButton
+              icon={List}
+              size="sm"
+              onClick={() => {
+                props.state.setValue('')
+                setTyping(false)
+              }}
+              title="Pick from the session list"
+              data-testid="session-field-pick-from-list"
+            />
+          </Show>
+          <RefreshButton
+            onClick={() => void refresh()}
+            disabled={loading() || source() === null}
+            title="Refresh sessions"
+            data-testid="session-field-refresh"
+          />
+        </>
       )}
     >
       <Show when={showMenu()} fallback={<SessionIdInput state={props.state} />}>
@@ -138,6 +179,7 @@ export const ResumeSessionField: Component<ResumeSessionFieldProps> = (props) =>
           sessions={sessions()}
           loading={loading()}
           invalid={props.state.error() !== null}
+          isFilePath={props.state.isFilePath()}
         />
       </Show>
     </LabeledField>

--- a/frontend/src/components/shell/SessionIdInput.tsx
+++ b/frontend/src/components/shell/SessionIdInput.tsx
@@ -1,6 +1,6 @@
 import type { Component } from 'solid-js'
 import type { SessionIdState } from '~/hooks/createSessionIdState'
-import { RESUME_SESSION_ERROR_ID, RESUME_SESSION_LABEL } from '~/components/shell/resumeSession'
+import { RESUME_SESSION_ERROR_ID, RESUME_SESSION_LABEL, resumeHandlePlaceholder } from '~/components/shell/resumeSession'
 
 interface SessionIdInputProps {
   state: SessionIdState
@@ -17,7 +17,9 @@ interface SessionIdInputProps {
  * The placeholder states both shapes for a provider whose session is a FILE,
  * because such a provider takes either one and the field used to invite the
  * wrong one: it said "Session ID" for every provider, and the worker then
- * refused a Pi session ID with "path must be absolute".
+ * refused a Pi session ID with "path must be absolute". It comes from
+ * `resumeHandlePlaceholder`, which is declared beside the menu row that opens
+ * this box so the two cannot name different sets of shapes.
  *
  * `LabeledField`'s label is a plain `div`, so the input has no accessible name
  * of its own and carries an explicit `aria-label`. Without it the PLACEHOLDER
@@ -33,6 +35,6 @@ export const SessionIdInput: Component<SessionIdInputProps> = props => (
     aria-describedby={props.state.error() ? RESUME_SESSION_ERROR_ID : undefined}
     value={props.state.value()}
     onInput={e => props.state.setValue(e.currentTarget.value)}
-    placeholder={props.state.isFilePath() ? 'Session ID or file path' : 'Session ID'}
+    placeholder={resumeHandlePlaceholder(props.state.isFilePath())}
   />
 )

--- a/frontend/src/components/shell/SessionSelect.test.tsx
+++ b/frontend/src/components/shell/SessionSelect.test.tsx
@@ -1,15 +1,23 @@
 import type { AgentSessionSummary } from '~/generated/proto/leapmux/v1/agent_pb'
 import { cleanup, fireEvent, render, screen } from '@solidjs/testing-library'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { RESUME_SESSION_ERROR_ID } from '~/components/shell/resumeSession'
+import { RESUME_SESSION_ERROR_ID, typeAHandleLabel } from '~/components/shell/resumeSession'
 import {
   NEW_SESSION_LABEL,
+  sessionOptionDetail,
   sessionOptionLabel,
   SessionSelect,
-  TYPE_A_HANDLE_LABEL,
   TYPE_A_HANDLE_VALUE,
 } from '~/components/shell/SessionSelect'
-import { menuOptions, menuOptionValues, menuTriggerText, pickMenuValue } from '~/test-support/menu'
+import { clippedText } from '~/styles/shared.css'
+import { hoverForTooltip, stubClipped } from '~/test-support/clipStub'
+import {
+  menuOptionLabels,
+  menuOptions,
+  menuOptionValues,
+  menuTriggerText,
+  pickMenuValue,
+} from '~/test-support/menu'
 
 afterEach(() => {
   cleanup()
@@ -37,6 +45,7 @@ function renderSelect(overrides: Partial<Parameters<typeof SessionSelect>[0]> = 
       sessions={[summary()]}
       loading={false}
       invalid={false}
+      isFilePath={false}
       {...overrides}
     />
   ))
@@ -44,21 +53,55 @@ function renderSelect(overrides: Partial<Parameters<typeof SessionSelect>[0]> = 
 }
 
 describe('sessionOptionLabel', () => {
-  it('states the title and how long ago the session ran', () => {
-    expect(sessionOptionLabel(summary(), NOW)).toBe('Build the thing — 1h ago')
+  it('states the title', () => {
+    expect(sessionOptionLabel(summary())).toBe('Build the thing')
   })
 
   // Pi stores no title and a Claude session has none until its title pass
   // runs, so the handle stands in -- a string the user can recognise, unlike a
   // placeholder that would read the same on every such row.
   it('falls back to the handle when the store recorded no title', () => {
-    expect(sessionOptionLabel(summary({ title: '', sessionId: 'ses_abc' }), NOW)).toBe('ses_abc — 1h ago')
-    expect(sessionOptionLabel(summary({ title: '   ', sessionId: 'ses_abc' }), NOW)).toBe('ses_abc — 1h ago')
+    expect(sessionOptionLabel(summary({ title: '', sessionId: 'ses_abc' }))).toBe('ses_abc')
+    expect(sessionOptionLabel(summary({ title: '   ', sessionId: 'ses_abc' }))).toBe('ses_abc')
   })
 
-  it('omits the age when the store recorded no time', () => {
-    expect(sessionOptionLabel(summary({ updatedAt: '' }), NOW)).toBe('Build the thing')
-    expect(sessionOptionLabel(summary({ updatedAt: 'not a timestamp' }), NOW)).toBe('Build the thing')
+  // The age is a column of its own, so a title long enough to clip does not
+  // take the timestamp with it.
+  it('leaves the age out, whatever the store recorded', () => {
+    expect(sessionOptionLabel(summary({ updatedAt: '' }))).toBe('Build the thing')
+    expect(sessionOptionLabel(summary())).toBe('Build the thing')
+  })
+})
+
+describe('sessionOptionDetail', () => {
+  it('states how long ago the session ran, as text the filter can match', () => {
+    expect(sessionOptionDetail(summary(), NOW)?.text).toBe('1h ago')
+  })
+
+  // No time, no column: an empty detail would draw a gap at the right end of
+  // the row and give the filter an empty string to match everything with.
+  it('gives no detail when the store recorded no time', () => {
+    expect(sessionOptionDetail(summary({ updatedAt: '' }), NOW)).toBeUndefined()
+    expect(sessionOptionDetail(summary({ updatedAt: 'not a timestamp' }), NOW)).toBeUndefined()
+  })
+
+  // The rendered form is `RelativeTime`, not the plain text: that is what puts
+  // the full local date and time one hover away from a row that has room for
+  // "4h ago" and nothing more.
+  it('renders the age as a timestamp whose hover states the full date', () => {
+    vi.useFakeTimers()
+    try {
+      const detail = sessionOptionDetail(summary(), NOW)
+      const { container } = render(() => <>{detail!.render!()}</>)
+
+      // Wrapper -> the span Tooltip resolves as its target.
+      const target = container.firstElementChild!.firstElementChild as HTMLElement
+      expect(target.textContent).toContain('ago')
+      expect(hoverForTooltip(target)?.textContent).toContain('2026')
+    }
+    finally {
+      vi.useRealTimers()
+    }
   })
 })
 
@@ -70,19 +113,31 @@ describe('sessionSelect', () => {
         summary({ sessionId: 'ses_b', title: 'Older', updatedAt: '2026-08-30T12:00:00.000Z' }),
       ],
     })
-    expect(menuOptionValues(MENU)).toEqual(['', 'ses_a', 'ses_b', TYPE_A_HANDLE_VALUE])
+    expect(menuOptionValues(MENU)).toEqual(['', TYPE_A_HANDLE_VALUE, 'ses_a', 'ses_b'])
   })
 
   // The list holds only what this worker can enumerate, so a handle from
   // another machine, one a tab already holds open, and one past the worker's
   // cap are all missing from it. Without this row a directory with a single
   // session would take typing away entirely.
-  it('ends with a row that hands the field back to its text box', () => {
+  it('offers a row that hands the field back to its text box, above the sessions', () => {
     const { onChange } = renderSelect({ sessions: [summary({ sessionId: 'ses_a' })] })
-    expect(menuOptions(MENU).at(-1)).toBe(TYPE_A_HANDLE_LABEL)
+    // Second, beside the other row that is not a session: at the bottom it sat
+    // under a list that runs to the worker's cap, so the answer to "my session
+    // is not here" was the one row a user had to scroll to find.
+    expect(menuOptions(MENU)[1]).toBe(typeAHandleLabel(false))
 
     pickMenuValue(MENU, TYPE_A_HANDLE_VALUE)
     expect(onChange).toHaveBeenCalledWith(TYPE_A_HANDLE_VALUE)
+  })
+
+  // The row is the one sentence a user reads BEFORE the text box exists, so it
+  // has to invite the same shapes the box's placeholder does. Pi's session is a
+  // file, and a row that said "Enter a session ID…" invited the shape the
+  // worker then refused with "path must be absolute".
+  it('invites a file path too when the provider takes one', () => {
+    renderSelect({ isFilePath: true, sessions: [summary({ sessionId: 'ses_a' })] })
+    expect(menuOptions(MENU)[1]).toBe('Enter a session ID or a file path…')
   })
 
   it('marks the trigger invalid and points it at the field error', () => {
@@ -149,7 +204,9 @@ describe('sessionSelect', () => {
     expect(menuOptionValues(MENU)).toEqual(['ses_b'])
   })
 
-  it('filters on the age as well as the title, because both are in the label', () => {
+  // The age left the label for a column of its own. The filter reads both, so
+  // the search the label used to serve still works.
+  it('filters on the age as well as the title', () => {
     renderSelect({
       sessions: [
         summary({ sessionId: 'ses_recent', title: 'Recent', updatedAt: new Date().toISOString() }),
@@ -158,6 +215,43 @@ describe('sessionSelect', () => {
     })
     fireEvent.input(screen.getByTestId('loading-menu-filter'), { target: { value: 'y ago' } })
     expect(menuOptionValues(MENU)).toEqual(['ses_ancient'])
+  })
+
+  // The requirement the two columns exist for: a title with no length limit
+  // must not be able to push the timestamp out of the row.
+  it('keeps the age beside a title far too long for the row', () => {
+    const title = Array.from({ length: 40 }, (_, i) => `Refactor step ${i}`).join(', ')
+    renderSelect({ sessions: [summary({ sessionId: 'ses_long', title })] })
+
+    const row = screen.getByTestId('loading-menu-option-ses_long')
+    expect(row.textContent).toContain('ago')
+    // The label clips; the detail beside it does not, so the two are separate
+    // elements and only the first carries the clipping style.
+    const label = screen.getByTestId('loading-menu-option-ses_long-label')
+    expect(label.textContent).toBe(title)
+    expect(label.className.split(/\s+/)).toContain(clippedText)
+    expect(label.contains(screen.getByText(/ago/))).toBe(false)
+  })
+
+  // A clipped title is unreadable, and the tooltip is the only way back to it.
+  it('gives the whole title on hover once the row clips it', () => {
+    vi.useFakeTimers()
+    try {
+      const title = 'Teach the parser to accept a trailing comma in every list'
+      renderSelect({ sessions: [summary({ sessionId: 'ses_long', title })] })
+
+      const label = screen.getByTestId('loading-menu-option-ses_long-label')
+      stubClipped(label)
+      expect(hoverForTooltip(label)?.textContent).toBe(title)
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('shows the title alone in the option labels', () => {
+    renderSelect({ sessions: [summary({ sessionId: 'ses_a', title: 'Newest' })] })
+    expect(menuOptionLabels(MENU)).toEqual([NEW_SESSION_LABEL, typeAHandleLabel(false), 'Newest'])
   })
 
   it('names itself for a screen reader with the field label', () => {

--- a/frontend/src/components/shell/SessionSelect.test.tsx
+++ b/frontend/src/components/shell/SessionSelect.test.tsx
@@ -16,6 +16,7 @@ import {
   menuOptions,
   menuOptionValues,
   menuTriggerText,
+  openMenu,
   pickMenuValue,
 } from '~/test-support/menu'
 
@@ -75,14 +76,40 @@ describe('sessionOptionLabel', () => {
 
 describe('sessionOptionDetail', () => {
   it('states how long ago the session ran, as text the filter can match', () => {
-    expect(sessionOptionDetail(summary(), NOW)?.text).toBe('1h ago')
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(NOW)
+      expect(sessionOptionDetail(summary())?.text()).toBe('1h ago')
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+
+  // The whole point of the accessor: it is read at FILTER time, so it states the
+  // age the row is SHOWING rather than the one it showed when the option list
+  // was built. Frozen, it drifted away from the live `RelativeTime` beside it,
+  // and typing the age on screen emptied the list.
+  it('re-reads the clock on every call, so it cannot drift from the drawn age', () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(NOW)
+      const detail = sessionOptionDetail(summary())!
+      expect(detail.text()).toBe('1h ago')
+
+      vi.setSystemTime(new Date(NOW.getTime() + 3 * 60 * 60 * 1000))
+      expect(detail.text()).toBe('4h ago')
+    }
+    finally {
+      vi.useRealTimers()
+    }
   })
 
   // No time, no column: an empty detail would draw a gap at the right end of
   // the row and give the filter an empty string to match everything with.
   it('gives no detail when the store recorded no time', () => {
-    expect(sessionOptionDetail(summary({ updatedAt: '' }), NOW)).toBeUndefined()
-    expect(sessionOptionDetail(summary({ updatedAt: 'not a timestamp' }), NOW)).toBeUndefined()
+    expect(sessionOptionDetail(summary({ updatedAt: '' }))).toBeUndefined()
+    expect(sessionOptionDetail(summary({ updatedAt: 'not a timestamp' }))).toBeUndefined()
   })
 
   // The rendered form is `RelativeTime`, not the plain text: that is what puts
@@ -91,7 +118,7 @@ describe('sessionOptionDetail', () => {
   it('renders the age as a timestamp whose hover states the full date', () => {
     vi.useFakeTimers()
     try {
-      const detail = sessionOptionDetail(summary(), NOW)
+      const detail = sessionOptionDetail(summary())
       const { container } = render(() => <>{detail!.render!()}</>)
 
       // Wrapper -> the span Tooltip resolves as its target.
@@ -200,8 +227,23 @@ describe('sessionSelect', () => {
     const filter = screen.getByTestId('loading-menu-filter')
     expect(filter).toBeInTheDocument()
 
+    // The two rows that are not sessions survive: they are the ways OUT of the
+    // list, and a query is exactly when a user reaches for one. See below.
     fireEvent.input(filter, { target: { value: 'flaky' } })
-    expect(menuOptionValues(MENU)).toEqual(['ses_b'])
+    expect(menuOptionValues(MENU)).toEqual(['', TYPE_A_HANDLE_VALUE, 'ses_b'])
+  })
+
+  // The moment those two rows matter most is the moment a filter would hide
+  // them: a user whose session is not here types its title, sees nothing match,
+  // and needs "Enter a session ID..." right then. Filtered away, the only route
+  // back was to clear the query first.
+  it('keeps the rows that leave the list, whatever the query matches', () => {
+    renderSelect({ sessions: [summary({ sessionId: 'ses_a', title: 'Refactor the parser' })] })
+
+    fireEvent.input(screen.getByTestId('loading-menu-filter'), { target: { value: 'zzz no match' } })
+
+    expect(menuOptionValues(MENU)).toEqual(['', TYPE_A_HANDLE_VALUE])
+    expect(menuOptionLabels(MENU)).toEqual([NEW_SESSION_LABEL, typeAHandleLabel(false)])
   })
 
   // The age left the label for a column of its own. The filter reads both, so
@@ -214,7 +256,7 @@ describe('sessionSelect', () => {
       ],
     })
     fireEvent.input(screen.getByTestId('loading-menu-filter'), { target: { value: 'y ago' } })
-    expect(menuOptionValues(MENU)).toEqual(['ses_ancient'])
+    expect(menuOptionValues(MENU)).toEqual(['', TYPE_A_HANDLE_VALUE, 'ses_ancient'])
   })
 
   // The requirement the two columns exist for: a title with no length limit
@@ -239,6 +281,7 @@ describe('sessionSelect', () => {
     try {
       const title = 'Teach the parser to accept a trailing comma in every list'
       renderSelect({ sessions: [summary({ sessionId: 'ses_long', title })] })
+      openMenu(MENU)
 
       const label = screen.getByTestId('loading-menu-option-ses_long-label')
       stubClipped(label)

--- a/frontend/src/components/shell/SessionSelect.tsx
+++ b/frontend/src/components/shell/SessionSelect.tsx
@@ -75,8 +75,9 @@ export function sessionOptionLabel(session: AgentSessionSummary): string {
  *
  * `text` keeps the filter working over the age. `LoadingMenu` matches the
  * detail beside the label, so typing `d` still narrows to sessions from days
- * ago. It is a plain string measured against ONE instant, which is what a
- * substring filter can match; the element beside it is what the reader sees.
+ * ago. It is read at FILTER time and against the same clock the element draws
+ * from, so the two can never state different ages; the element beside it is
+ * what the reader sees.
  *
  * `RelativeTimeAgo` supplies that element, so a row states the age in the form
  * every timestamp in the app takes, and hovering it gives the full local date
@@ -86,13 +87,17 @@ export function sessionOptionLabel(session: AgentSessionSummary): string {
  */
 export function sessionOptionDetail(
   session: AgentSessionSummary,
-  now: Date,
 ): LoadingMenuOptionDetail | undefined {
   const updated = session.updatedAt ? new Date(session.updatedAt) : null
   if (updated === null || Number.isNaN(updated.getTime()))
     return undefined
   return {
-    text: `${formatCompactAge(updated, now)} ago`,
+    // Read fresh at filter time, against the SAME clock the element beside it
+    // draws from: `formatCompactAge`'s own default `new Date()`. As a frozen
+    // string it was measured at whatever instant the options memo last ran,
+    // while `RelativeTimeAgo` kept ticking -- so a row that read "4h ago" was
+    // matched against "3h ago" and typing what was on screen emptied the list.
+    text: () => `${formatCompactAge(updated)} ago`,
     render: () => <RelativeTimeAgo timestamp={session.updatedAt} />,
   }
 }
@@ -111,14 +116,13 @@ export const SessionSelect: Component<SessionSelectProps> = (props) => {
   // reference, so a plain `.map()` here would rebuild every row per keystroke.
   // `BranchSelect` documents the same constraint.
   const options = createMemo(() => {
-    // One instant for the whole list, so two rows recorded a second apart
-    // cannot be measured against two different "now"s.
-    const now = new Date()
     return [
       // A real, selectable choice — not the synthetic prompt row `BranchSelect`
       // was corrected for injecting. `placeholder` covers the untouched state;
       // this is how a user takes a pick BACK.
-      { value: '', label: NEW_SESSION_LABEL },
+      // `pinned`, like the row below it: both are ways to LEAVE the list, so a
+      // query that narrows the list must not take them with it.
+      { value: '', label: NEW_SESSION_LABEL, pinned: true },
       // Second, beside the other row that is not a session. The two of them are
       // the ways to leave the list, and the list itself runs to the worker's
       // cap: at the bottom this row sat under a scroll the user had to reach the
@@ -126,11 +130,11 @@ export const SessionSelect: Component<SessionSelectProps> = (props) => {
       // here". It is needed exactly because the list holds only what this worker
       // can enumerate — a handle from another machine, one already open in a
       // tab, and one past the cap are all missing from it.
-      { value: TYPE_A_HANDLE_VALUE, label: typeAHandleLabel(props.isFilePath) },
+      { value: TYPE_A_HANDLE_VALUE, label: typeAHandleLabel(props.isFilePath), pinned: true },
       ...props.sessions.map(session => ({
         value: session.sessionId,
         label: sessionOptionLabel(session),
-        detail: sessionOptionDetail(session, now),
+        detail: sessionOptionDetail(session),
       })),
     ]
   })

--- a/frontend/src/components/shell/SessionSelect.tsx
+++ b/frontend/src/components/shell/SessionSelect.tsx
@@ -1,8 +1,10 @@
 import type { Component } from 'solid-js'
+import type { LoadingMenuOptionDetail } from '~/components/common/LoadingMenu'
 import type { AgentSessionSummary } from '~/generated/proto/leapmux/v1/agent_pb'
 import { createMemo } from 'solid-js'
+import { RelativeTimeAgo } from '~/components/chat/RelativeTime'
 import { LoadingMenu } from '~/components/common/LoadingMenu'
-import { RESUME_SESSION_ERROR_ID, RESUME_SESSION_LABEL } from '~/components/shell/resumeSession'
+import { RESUME_SESSION_ERROR_ID, RESUME_SESSION_LABEL, typeAHandleLabel } from '~/components/shell/resumeSession'
 import { formatCompactAge } from '~/lib/dateFormat'
 
 interface SessionSelectProps {
@@ -26,6 +28,14 @@ interface SessionSelectProps {
    * attributes from one `error()` read.
    */
   invalid: boolean
+  /**
+   * The selected provider's session is a FILE, so its handle may be a path.
+   *
+   * It reaches only the row that hands the field to its text box, which is the
+   * one sentence a user reads BEFORE that box exists: for Pi it has to invite a
+   * path as well as an ID, exactly as the placeholder inside the box does.
+   */
+  isFilePath: boolean
 }
 
 /** The row that withdraws a pick and starts a fresh session instead. */
@@ -42,9 +52,6 @@ export const NEW_SESSION_LABEL = 'Start a new session'
  */
 export const TYPE_A_HANDLE_VALUE = '\u0000type-a-handle'
 
-/** The row that swaps the menu for the text box. */
-export const TYPE_A_HANDLE_LABEL = 'Enter a session ID…'
-
 /**
  * Build one menu row's label.
  *
@@ -52,27 +59,51 @@ export const TYPE_A_HANDLE_LABEL = 'Enter a session ID…'
  * "Untitled": Pi stores no title at all and a Claude session has none until its
  * title pass runs, and a handle the user can recognise beats a word that
  * describes every such row identically.
- *
- * The age is part of the LABEL, not a second column, because `LoadingMenu`
- * filters by substring over the label — so with it there, typing `d` narrows to
- * sessions from days ago as well as to titles containing a `d`.
  */
-export function sessionOptionLabel(session: AgentSessionSummary, now: Date): string {
-  const title = session.title.trim() || session.sessionId
+export function sessionOptionLabel(session: AgentSessionSummary): string {
+  return session.title.trim() || session.sessionId
+}
+
+/**
+ * Build one menu row's trailing note: how long ago the session last ran.
+ *
+ * A DETAIL and not part of the label, although the label used to carry it. A
+ * title has no length limit, and a row clips its label with an ellipsis -- so
+ * an age inside the label was cut off first on exactly the rows where two
+ * attempts at one task can be told apart by nothing else. The detail column
+ * never shrinks.
+ *
+ * `text` keeps the filter working over the age. `LoadingMenu` matches the
+ * detail beside the label, so typing `d` still narrows to sessions from days
+ * ago. It is a plain string measured against ONE instant, which is what a
+ * substring filter can match; the element beside it is what the reader sees.
+ *
+ * `RelativeTimeAgo` supplies that element, so a row states the age in the form
+ * every timestamp in the app takes, and hovering it gives the full local date
+ * and time. It parses the timestamp again and renders nothing for an
+ * unparseable one -- the same rule as the guard here, which is why an
+ * unparseable timestamp produces no detail at all rather than an empty column.
+ */
+export function sessionOptionDetail(
+  session: AgentSessionSummary,
+  now: Date,
+): LoadingMenuOptionDetail | undefined {
   const updated = session.updatedAt ? new Date(session.updatedAt) : null
   if (updated === null || Number.isNaN(updated.getTime()))
-    return title
-  return `${title} — ${formatCompactAge(updated, now)} ago`
+    return undefined
+  return {
+    text: `${formatCompactAge(updated, now)} ago`,
+    render: () => <RelativeTimeAgo timestamp={session.updatedAt} />,
+  }
 }
 
 /**
  * The resume-session picker: a filtered menu over the sessions the worker
  * offered.
  *
- * The label does NOT tick the way `RelativeTime` does. The options memo
- * recomputes only when the session list changes, so an age shown here is fixed
- * for as long as the dialog stays open — correct for a control that lives for
- * seconds, and it keeps a menu out of `createSharedTicker`'s subscriber list.
+ * Each row states a title and an age, in two columns rather than one string.
+ * The title clips with an ellipsis and gives the rest back on hover; the age
+ * keeps its place at the right end however long the title is.
  */
 export const SessionSelect: Component<SessionSelectProps> = (props) => {
   // A memo, and it is load-bearing: `LoadingMenu`'s `visible` memo re-reads
@@ -88,16 +119,19 @@ export const SessionSelect: Component<SessionSelectProps> = (props) => {
       // was corrected for injecting. `placeholder` covers the untouched state;
       // this is how a user takes a pick BACK.
       { value: '', label: NEW_SESSION_LABEL },
+      // Second, beside the other row that is not a session. The two of them are
+      // the ways to leave the list, and the list itself runs to the worker's
+      // cap: at the bottom this row sat under a scroll the user had to reach the
+      // end of, which is the wrong place for the answer to "my session is not
+      // here". It is needed exactly because the list holds only what this worker
+      // can enumerate — a handle from another machine, one already open in a
+      // tab, and one past the cap are all missing from it.
+      { value: TYPE_A_HANDLE_VALUE, label: typeAHandleLabel(props.isFilePath) },
       ...props.sessions.map(session => ({
         value: session.sessionId,
-        label: sessionOptionLabel(session, now),
+        label: sessionOptionLabel(session),
+        detail: sessionOptionDetail(session, now),
       })),
-      // Last, because it is the escape hatch rather than a session. The list
-      // holds only what this worker can enumerate, so a handle from another
-      // machine, one already open in a tab, and one past the worker's cap are
-      // all missing from it — and without this row a directory with a single
-      // session would leave no way to type any of them.
-      { value: TYPE_A_HANDLE_VALUE, label: TYPE_A_HANDLE_LABEL },
     ]
   })
 

--- a/frontend/src/components/shell/resumeSession.ts
+++ b/frontend/src/components/shell/resumeSession.ts
@@ -17,3 +17,26 @@ export const RESUME_SESSION_LABEL = 'Resume an existing session'
  * controls never render together, so one id serves both and cannot collide.
  */
 export const RESUME_SESSION_ERROR_ID = 'session-id-error'
+
+/**
+ * The placeholder of the text box.
+ *
+ * Declared beside the label of the menu row that OPENS that text box, because
+ * the two state one fact: which shapes of handle the selected provider accepts.
+ * Pi's session is a FILE, so it takes a path as well as an ID; every other
+ * provider issues an opaque token. While the row read "Enter a session ID…" for
+ * Pi, the one sentence a user reads BEFORE choosing named the wrong set, and the
+ * box it opened then contradicted it.
+ *
+ * Two functions rather than one phrase, because the two sentences differ in
+ * grammar and not in fact: a placeholder is a noun phrase, and a menu row is an
+ * instruction.
+ */
+export function resumeHandlePlaceholder(isFilePath: boolean): string {
+  return isFilePath ? 'Session ID or file path' : 'Session ID'
+}
+
+/** The label of the menu row that swaps the menu for the text box. */
+export function typeAHandleLabel(isFilePath: boolean): string {
+  return isFilePath ? 'Enter a session ID or a file path…' : 'Enter a session ID…'
+}

--- a/frontend/src/components/todo/TodoList.test.tsx
+++ b/frontend/src/components/todo/TodoList.test.tsx
@@ -11,7 +11,7 @@ import { classSelector } from '~/test-support/composedClass'
 describe('todoList', () => {
   it('renders the deleted checkbox + strike-through for a deleted row', () => {
     const { container } = render(() => (
-      <TodoList todos={[{ id: '1', content: 'gone task', status: 'deleted', activeForm: '' }]} />
+      <TodoList todos={[{ id: '1', rowKey: '1', content: 'gone task', status: 'deleted', activeForm: '' }]} />
     ))
     // The strike-through is applied to the row that wraps the checkbox.
     // vanilla-extract hashes class names but always retains the source
@@ -24,7 +24,7 @@ describe('todoList', () => {
 
   it('renders activeForm (not content) for in_progress rows', () => {
     const { container } = render(() => (
-      <TodoList todos={[{ id: '2', content: 'Run tests', status: 'in_progress', activeForm: 'Running tests' }]} />
+      <TodoList todos={[{ id: '2', rowKey: '2', content: 'Run tests', status: 'in_progress', activeForm: 'Running tests' }]} />
     ))
     expect(container.textContent).toContain('Running tests')
     expect(container.textContent).not.toContain('Run tests')
@@ -35,10 +35,10 @@ describe('todoList', () => {
     const { container } = render(() => (
       <TodoList
         todos={[
-          { id: 'a', content: 'still pending', status: 'pending', activeForm: '' },
-          { id: 'b', content: 'doing now', status: 'in_progress', activeForm: 'Working on it' },
-          { id: 'c', content: 'all done', status: 'completed', activeForm: '' },
-          { id: 'd', content: 'removed', status: 'deleted', activeForm: '' },
+          { id: 'a', rowKey: 'a', content: 'still pending', status: 'pending', activeForm: '' },
+          { id: 'b', rowKey: 'b', content: 'doing now', status: 'in_progress', activeForm: 'Working on it' },
+          { id: 'c', rowKey: 'c', content: 'all done', status: 'completed', activeForm: '' },
+          { id: 'd', rowKey: 'd', content: 'removed', status: 'deleted', activeForm: '' },
         ]}
       />
     ))
@@ -61,7 +61,7 @@ describe('todoList', () => {
    */
   it('follows an in-place status change into the label and the row class', () => {
     const [todos, setTodos] = createStore<TodoItem[]>([
-      { id: '1', content: 'Run tests', status: 'pending', activeForm: 'Running tests' },
+      { id: '1', rowKey: '1', content: 'Run tests', status: 'pending', activeForm: 'Running tests' },
     ])
     const { container } = render(() => <TodoList todos={todos} />)
     expect(container.textContent).toContain('Run tests')
@@ -83,7 +83,7 @@ describe('todoList', () => {
   // route to a description and to a label the row had to clip.
   it('clips the label to one line', () => {
     const { container } = render(() => (
-      <TodoList todos={[{ id: '1', content: 'A label wider than the sidebar', status: 'pending', activeForm: '' }]} />
+      <TodoList todos={[{ id: '1', rowKey: '1', content: 'A label wider than the sidebar', status: 'pending', activeForm: '' }]} />
     ))
     const text = container.querySelector(classSelector(styles.todoText))!
     expect(text.textContent).toBe('A label wider than the sidebar')
@@ -101,7 +101,7 @@ describe('todoList', () => {
    * what a unit test can see; the rules it selects are asserted in the browser.
    */
   it('marks the list for wrapping only in the full variant', () => {
-    const todos: TodoItem[] = [{ id: '1', content: 'Run tests', status: 'pending', activeForm: '' }]
+    const todos: TodoItem[] = [{ id: '1', rowKey: '1', content: 'Run tests', status: 'pending', activeForm: '' }]
 
     const compact = render(() => <TodoList todos={todos} />)
     expect(compact.container.firstElementChild!.className).not.toMatch(/todoListWrapping/)
@@ -117,10 +117,10 @@ describe('todoList', () => {
     const { container } = render(() => (
       <TodoList
         todos={[
-          { id: '1', content: 'done', status: 'completed', activeForm: '' },
-          { id: '2', content: 'gone', status: 'deleted', activeForm: '' },
-          { id: '3', content: 'todo', status: 'pending', activeForm: '' },
-          { id: '4', content: 'now', status: 'in_progress', activeForm: '' },
+          { id: '1', rowKey: '1', content: 'done', status: 'completed', activeForm: '' },
+          { id: '2', rowKey: '2', content: 'gone', status: 'deleted', activeForm: '' },
+          { id: '3', rowKey: '3', content: 'todo', status: 'pending', activeForm: '' },
+          { id: '4', rowKey: '4', content: 'now', status: 'in_progress', activeForm: '' },
         ]}
       />
     ))
@@ -133,9 +133,9 @@ describe('todoList', () => {
     const { container } = render(() => (
       <TodoList
         todos={[
-          { id: '1', content: 'first', status: 'pending', activeForm: '' },
-          { id: '2', content: 'second', status: 'pending', activeForm: '' },
-          { id: '3', content: 'third', status: 'pending', activeForm: '' },
+          { id: '1', rowKey: '1', content: 'first', status: 'pending', activeForm: '' },
+          { id: '2', rowKey: '2', content: 'second', status: 'pending', activeForm: '' },
+          { id: '3', rowKey: '3', content: 'third', status: 'pending', activeForm: '' },
         ]}
       />
     ))
@@ -171,7 +171,7 @@ describe('todoList label tooltip', () => {
   it('shows the label and its description together when a task has one', () => {
     const { container } = render(() => (
       <TodoList
-        todos={[{ id: '1', content: 'Task with details', status: 'pending', activeForm: '', description: 'Long-form explanation' }]}
+        todos={[{ id: '1', rowKey: '1', content: 'Task with details', status: 'pending', activeForm: '', description: 'Long-form explanation' }]}
       />
     ))
     // Shown although the label fits: the description is the part the row
@@ -184,7 +184,7 @@ describe('todoList label tooltip', () => {
   it('uses the in-progress label, not the content, in that tooltip', () => {
     const { container } = render(() => (
       <TodoList
-        todos={[{ id: '2', content: 'Run tests', status: 'in_progress', activeForm: 'Running tests', description: 'The whole suite' }]}
+        todos={[{ id: '2', rowKey: '2', content: 'Run tests', status: 'in_progress', activeForm: 'Running tests', description: 'The whole suite' }]}
       />
     ))
     const tip = hover(labelOf(container))!
@@ -196,7 +196,7 @@ describe('todoList label tooltip', () => {
   // on a label that fits, and it must not render a blank second line.
   it('treats an empty description as absent', () => {
     const { container } = render(() => (
-      <TodoList todos={[{ id: '1', content: 'Short', status: 'pending', activeForm: '', description: '' }]} />
+      <TodoList todos={[{ id: '1', rowKey: '1', content: 'Short', status: 'pending', activeForm: '', description: '' }]} />
     ))
     const label = labelOf(container)
     stubFitting(label)
@@ -210,7 +210,7 @@ describe('todoList label tooltip', () => {
   // at all. Now it gets one, but only once its label is actually clipped.
   it('gives a task without a description the full label once it is clipped', () => {
     const { container } = render(() => (
-      <TodoList todos={[{ id: '1', content: 'A label far wider than this row', status: 'pending', activeForm: '' }]} />
+      <TodoList todos={[{ id: '1', rowKey: '1', content: 'A label far wider than this row', status: 'pending', activeForm: '' }]} />
     ))
     const label = labelOf(container)
     stubFitting(label)
@@ -231,7 +231,7 @@ describe('todoList label tooltip', () => {
    */
   it('follows an in-place description change', () => {
     const [todos, setTodos] = createStore<TodoItem[]>([
-      { id: '1', content: 'Run tests', status: 'pending', activeForm: '' },
+      { id: '1', rowKey: '1', content: 'Run tests', status: 'pending', activeForm: '' },
     ])
     const { container } = render(() => <TodoList todos={todos} />)
     const label = labelOf(container)

--- a/frontend/src/stores/chat.store.test.ts
+++ b/frontend/src/stores/chat.store.test.ts
@@ -4395,8 +4395,10 @@ describe('createChatStore', () => {
 
         await store.loadInitialMessages('w1', 'a1')
         expect(store.todos.get('a1')).toEqual([
-          { id: undefined, content: 'Write tests', status: 'completed', activeForm: 'Writing tests', description: undefined },
-          { id: undefined, content: 'Deploy', status: 'in_progress', activeForm: 'Deploying', description: undefined },
+          // No id from this provider, so the reconciliation key is the row's
+          // position paired with its content -- see TodoItem.rowKey.
+          { id: undefined, rowKey: '0:Write tests', content: 'Write tests', status: 'completed', activeForm: 'Writing tests', description: undefined },
+          { id: undefined, rowKey: '1:Deploy', content: 'Deploy', status: 'in_progress', activeForm: 'Deploying', description: undefined },
         ])
         dispose()
       })

--- a/frontend/src/stores/chatBackgroundTaskStore.test.ts
+++ b/frontend/src/stores/chatBackgroundTaskStore.test.ts
@@ -30,6 +30,52 @@ describe('createBackgroundTaskStore', () => {
     expect(store.get('a1')[0].activity).toBe('working')
   })
 
+  // The registry arrives WHOLE on every broadcast, so one subagent's new
+  // activity string used to hand the sidebar a fresh object for every row. The
+  // list reconciles by reference, so all of them were torn down and rebuilt --
+  // which closed the tooltip under the pointer and restarted each status dot's
+  // pulse.
+  it('replace keeps the identity of a row whose fields did not change', () => {
+    const store = createBackgroundTaskStore()
+    store.replace('a1', [
+      proto('t1', BackgroundTaskStatus.RUNNING, 'reading'),
+      proto('t2', BackgroundTaskStatus.RUNNING, 'reading'),
+    ])
+    const [first, second] = store.get('a1')
+
+    store.replace('a1', [
+      proto('t1', BackgroundTaskStatus.RUNNING, 'reading'),
+      proto('t2', BackgroundTaskStatus.RUNNING, 'writing'),
+    ])
+
+    expect(store.get('a1')[0]).toBe(first)
+    expect(store.get('a1')[1]).toBe(second)
+    expect(store.get('a1')[1]!.activity).toBe('writing')
+  })
+
+  it('replace still adds, drops and reorders rows', () => {
+    const store = createBackgroundTaskStore()
+    store.replace('a1', [proto('t1', BackgroundTaskStatus.RUNNING), proto('t2', BackgroundTaskStatus.RUNNING)])
+
+    store.replace('a1', [proto('t2', BackgroundTaskStatus.COMPLETED), proto('t3', BackgroundTaskStatus.PENDING)])
+
+    expect(store.get('a1').map(t => t.rowKey)).toEqual(['t2', 't3'])
+    expect(store.get('a1').map(t => t.status)).toEqual(['completed', 'pending'])
+  })
+
+  // A reconcile writes THROUGH the store proxy, and an agent with no rows holds
+  // the one empty array every other agent reads as its default.
+  it('replace into a cleared agent leaves every other agent empty', () => {
+    const store = createBackgroundTaskStore()
+    store.replace('a1', [proto('t1', BackgroundTaskStatus.RUNNING)])
+    store.clear('a1')
+
+    store.replace('a1', [proto('t2', BackgroundTaskStatus.RUNNING)])
+
+    expect(store.get('a1').map(t => t.rowKey)).toEqual(['t2'])
+    expect(store.get('a2')).toEqual([])
+  })
+
   it('replace skips an identical re-broadcast', () => {
     const store = createBackgroundTaskStore()
     store.replace('a1', [proto('t1', BackgroundTaskStatus.RUNNING)])

--- a/frontend/src/stores/chatBackgroundTaskStore.ts
+++ b/frontend/src/stores/chatBackgroundTaskStore.ts
@@ -2,7 +2,7 @@ import type { BackgroundTaskItem } from './chatBackgroundTasks'
 import type { BackgroundTaskItem as ProtoBackgroundTaskItem } from '~/generated/proto/leapmux/v1/agent_pb'
 import { shallowEqualArraysDeep } from '~/lib/shallowEqual'
 import { protoBackgroundTaskToStore } from './chatBackgroundTasks'
-import { createPerAgentStore } from './chatPerAgentStore'
+import { createPerAgentListStore, createPerAgentStore } from './chatPerAgentStore'
 
 // ---------------------------------------------------------------------------
 // Background-task registry slice
@@ -21,7 +21,9 @@ import { createPerAgentStore } from './chatPerAgentStore'
 // ---------------------------------------------------------------------------
 
 export function createBackgroundTaskStore() {
-  const base = createPerAgentStore<BackgroundTaskItem[]>([])
+  // A LIST store, so the row key that identifies a row across broadcasts is
+  // declared once here rather than at each write. See createPerAgentListStore.
+  const base = createPerAgentListStore<BackgroundTaskItem>('rowKey')
   const failed = createPerAgentStore<boolean>(false)
   return {
     get: base.get,
@@ -60,7 +62,7 @@ export function createBackgroundTaskStore() {
      * DOM alone. The broadcast that carries one subagent's new activity string
      * carries the whole registry with it, so a plain replace rebuilt every row
      * on screen: the tooltip under the pointer closed and reopened, and every
-     * status dot restarted its pulse. See `PerAgentStore.setReconciled`.
+     * status dot restarted its pulse. See `PerAgentListStore.setReconciled`.
      */
     replace(agentId: string, protoTasks: ProtoBackgroundTaskItem[]) {
       if (failed.get(agentId))
@@ -69,7 +71,7 @@ export function createBackgroundTaskStore() {
       const prev = base.byAgent[agentId]
       if (prev && shallowEqualArraysDeep(prev, next))
         return
-      base.setReconciled(agentId, next, 'rowKey')
+      base.setReconciled(agentId, next)
     },
     /** Record that the worker could not answer for this agent's registry. */
     markLoadFailed(agentId: string) {

--- a/frontend/src/stores/chatBackgroundTaskStore.ts
+++ b/frontend/src/stores/chatBackgroundTaskStore.ts
@@ -54,6 +54,13 @@ export function createBackgroundTaskStore() {
      * A successful load clears the failure flag, and that write happens even
      * when the rows are unchanged: a retry that returns the same (empty) list
      * is still the answer that the registry is reachable again.
+     *
+     * The write RECONCILES by row key rather than replacing the array, so a row
+     * whose fields did not change keeps its identity and the sidebar leaves its
+     * DOM alone. The broadcast that carries one subagent's new activity string
+     * carries the whole registry with it, so a plain replace rebuilt every row
+     * on screen: the tooltip under the pointer closed and reopened, and every
+     * status dot restarted its pulse. See `PerAgentStore.setReconciled`.
      */
     replace(agentId: string, protoTasks: ProtoBackgroundTaskItem[]) {
       if (failed.get(agentId))
@@ -62,7 +69,7 @@ export function createBackgroundTaskStore() {
       const prev = base.byAgent[agentId]
       if (prev && shallowEqualArraysDeep(prev, next))
         return
-      base.set(agentId, next)
+      base.setReconciled(agentId, next, 'rowKey')
     },
     /** Record that the worker could not answer for this agent's registry. */
     markLoadFailed(agentId: string) {

--- a/frontend/src/stores/chatPerAgentStore.test.ts
+++ b/frontend/src/stores/chatPerAgentStore.test.ts
@@ -100,6 +100,61 @@ describe('createPerAgentStore', () => {
     })
   })
 
+  // The reason the method exists: a UI that renders these entries as rows
+  // reconciles by REFERENCE, so a replace that hands over all-new objects tears
+  // down and rebuilds every row on screen -- losing the tooltip under the
+  // pointer and restarting each row's animation.
+  it('setReconciled keeps the identity of an entry that did not change', () => {
+    createRoot((dispose) => {
+      const store = createPerAgentStore<{ id: string, n: number }[]>([])
+      store.set('a', [{ id: 'x', n: 1 }, { id: 'y', n: 1 }])
+      const [x, y] = store.get('a')
+
+      store.setReconciled('a', [{ id: 'x', n: 1 }, { id: 'y', n: 2 }], 'id')
+
+      expect(store.get('a')[0]).toBe(x)
+      expect(store.get('a')[1]).toBe(y)
+      expect(store.get('a')[1]!.n).toBe(2)
+      dispose()
+    })
+  })
+
+  it('setReconciled adds, drops and reorders entries by key', () => {
+    createRoot((dispose) => {
+      const store = createPerAgentStore<{ id: string, n: number }[]>([])
+      store.set('a', [{ id: 'x', n: 1 }, { id: 'y', n: 2 }])
+
+      store.setReconciled('a', [{ id: 'y', n: 2 }, { id: 'z', n: 3 }], 'id')
+
+      expect(store.get('a').map(e => e.id)).toEqual(['y', 'z'])
+      expect(store.get('a').map(e => e.n)).toEqual([2, 3])
+      dispose()
+    })
+  })
+
+  // `reconcile` writes its diff THROUGH the store proxy into the object
+  // underneath, and the empty value is one object shared by every unset agent.
+  // Reconciling into it would give every other agent this agent's rows.
+  it('setReconciled leaves the shared empty value alone', () => {
+    createRoot((dispose) => {
+      const empty: { id: string }[] = []
+      const store = createPerAgentStore<{ id: string }[]>(empty)
+
+      store.setReconciled('a', [{ id: 'x' }], 'id')
+      expect(store.get('a').map(e => e.id)).toEqual(['x'])
+      expect(empty).toEqual([])
+      expect(store.get('b')).toEqual([])
+
+      // The same hazard through the other door: a CLEARED agent holds the
+      // shared empty as its value, not undefined.
+      store.clear('a')
+      store.setReconciled('a', [{ id: 'z' }], 'id')
+      expect(store.get('a').map(e => e.id)).toEqual(['z'])
+      expect(empty).toEqual([])
+      dispose()
+    })
+  })
+
   it('set replaces (does not index-merge) a shorter array, and clear empties it', () => {
     // The pendingOutbound/todos slices depend on this: setting a shorter array
     // must drop the trailing entries, not keep them via SolidJS index-merge.

--- a/frontend/src/stores/chatPerAgentStore.test.ts
+++ b/frontend/src/stores/chatPerAgentStore.test.ts
@@ -1,6 +1,6 @@
 import { createRoot } from 'solid-js'
 import { describe, expect, it } from 'vitest'
-import { createPerAgentStore } from '~/stores/chatPerAgentStore'
+import { createPerAgentListStore, createPerAgentStore } from '~/stores/chatPerAgentStore'
 
 describe('createPerAgentStore', () => {
   it('returns the configured empty value for an unset agent', () => {
@@ -106,11 +106,11 @@ describe('createPerAgentStore', () => {
   // pointer and restarting each row's animation.
   it('setReconciled keeps the identity of an entry that did not change', () => {
     createRoot((dispose) => {
-      const store = createPerAgentStore<{ id: string, n: number }[]>([])
+      const store = createPerAgentListStore<{ id: string, n: number }>('id')
       store.set('a', [{ id: 'x', n: 1 }, { id: 'y', n: 1 }])
       const [x, y] = store.get('a')
 
-      store.setReconciled('a', [{ id: 'x', n: 1 }, { id: 'y', n: 2 }], 'id')
+      store.setReconciled('a', [{ id: 'x', n: 1 }, { id: 'y', n: 2 }])
 
       expect(store.get('a')[0]).toBe(x)
       expect(store.get('a')[1]).toBe(y)
@@ -121,10 +121,10 @@ describe('createPerAgentStore', () => {
 
   it('setReconciled adds, drops and reorders entries by key', () => {
     createRoot((dispose) => {
-      const store = createPerAgentStore<{ id: string, n: number }[]>([])
+      const store = createPerAgentListStore<{ id: string, n: number }>('id')
       store.set('a', [{ id: 'x', n: 1 }, { id: 'y', n: 2 }])
 
-      store.setReconciled('a', [{ id: 'y', n: 2 }, { id: 'z', n: 3 }], 'id')
+      store.setReconciled('a', [{ id: 'y', n: 2 }, { id: 'z', n: 3 }])
 
       expect(store.get('a').map(e => e.id)).toEqual(['y', 'z'])
       expect(store.get('a').map(e => e.n)).toEqual([2, 3])
@@ -137,10 +137,10 @@ describe('createPerAgentStore', () => {
   // Reconciling into it would give every other agent this agent's rows.
   it('setReconciled leaves the shared empty value alone', () => {
     createRoot((dispose) => {
-      const empty: { id: string }[] = []
-      const store = createPerAgentStore<{ id: string }[]>(empty)
+      const store = createPerAgentListStore<{ id: string }>('id')
+      const empty = store.get('untouched')
 
-      store.setReconciled('a', [{ id: 'x' }], 'id')
+      store.setReconciled('a', [{ id: 'x' }])
       expect(store.get('a').map(e => e.id)).toEqual(['x'])
       expect(empty).toEqual([])
       expect(store.get('b')).toEqual([])
@@ -148,9 +148,30 @@ describe('createPerAgentStore', () => {
       // The same hazard through the other door: a CLEARED agent holds the
       // shared empty as its value, not undefined.
       store.clear('a')
-      store.setReconciled('a', [{ id: 'z' }], 'id')
+      store.setReconciled('a', [{ id: 'z' }])
       expect(store.get('a').map(e => e.id)).toEqual(['z'])
       expect(empty).toEqual([])
+      dispose()
+    })
+  })
+
+  // The key is declared on the STORE, so it cannot differ between two writes to
+  // one dataset, and a misspelling is a compile error rather than a silent fall
+  // back to a positional merge -- which is worse than a rebuild, because a row
+  // then keeps its DOM identity while its content shifts under the pointer.
+  it('setReconciled reconciles every write under the one key the store declares', () => {
+    createRoot((dispose) => {
+      const store = createPerAgentListStore<{ id: string, n: number }>('id')
+      store.set('a', [{ id: 'x', n: 1 }, { id: 'y', n: 2 }])
+      const [x] = store.get('a')
+
+      // Reordered AND changed: a positional merge would rewrite entry 0 in
+      // place and the identity below would follow the wrong row.
+      store.setReconciled('a', [{ id: 'y', n: 9 }, { id: 'x', n: 1 }])
+
+      expect(store.get('a').map(e => e.id)).toEqual(['y', 'x'])
+      expect(store.get('a')[1]).toBe(x)
+      expect(store.get('a')[0]!.n).toBe(9)
       dispose()
     })
   })

--- a/frontend/src/stores/chatPerAgentStore.ts
+++ b/frontend/src/stores/chatPerAgentStore.ts
@@ -21,29 +21,19 @@ export interface PerAgentStore<T> {
    * The value for an agent, or the configured empty value when unset. The empty
    * value is a SHARED reference handed to every unset/cleared agent, so callers
    * MUST treat a `get` result as read-only -- mutating it in place (e.g. `.push`
-   * on an array empty) would corrupt the default for every other agent. Every
-   * write path replaces the whole leaf (spread into a fresh value), never mutates
-   * one. (Object.freeze on the empty would catch a violation but breaks Solid's
-   * store proxy, which caches a $PROXY property on the wrapped value.)
+   * on an array empty) would corrupt the default for every other agent.
+   * `set`, `clear` and `remove` replace the whole leaf (spread into a fresh
+   * value), never mutate one. (Object.freeze on the empty would catch a
+   * violation but breaks Solid's store proxy, which caches a $PROXY property on
+   * the wrapped value.)
+   *
+   * `createPerAgentListStore`'s `setReconciled` is the ONE write path that
+   * mutates a leaf in place, which is the whole point of it -- see its own doc
+   * for the invariant that makes that safe.
    */
   get: (agentId: string) => T
   /** Replace an agent's value. */
   set: (agentId: string, value: T) => void
-  /**
-   * Replace an agent's LIST value, matching entries by `key` so that an entry
-   * whose fields did not change keeps its identity and its per-field signals.
-   *
-   * Use this for a leaf a UI renders as rows. `set` replaces the array whole,
-   * so every entry is a new object, `<For>` reconciles by REFERENCE, and one
-   * changed field therefore tears down and rebuilds every row on screen. That
-   * is not merely wasteful: a rebuilt row loses the tooltip the pointer was
-   * resting on and restarts the CSS animation on its status dot, so the
-   * sidebar's background-task rows flickered whenever any one of them reported
-   * progress.
-   *
-   * `key` names the field that identifies an entry across updates.
-   */
-  setReconciled: (agentId: string, value: T, key: string) => void
   /** Reset an agent's value to the configured empty value. */
   clear: (agentId: string) => void
   /**
@@ -61,7 +51,10 @@ export interface PerAgentStore<T> {
   readonly byAgent: Record<string, T>
 }
 
-export function createPerAgentStore<T>(empty: T): PerAgentStore<T> {
+// The spine both public factories build on: the store, its raw path setter, and
+// the four write paths that replace a leaf whole. The setter is handed back
+// because the LIST factory needs the one write that does not replace a leaf.
+function createSpine<T>(empty: T) {
   const [state, setState] = createStore<{ byAgent: Record<string, T> }>({ byAgent: {} })
   // Replace the leaf with the value form of the path setter (NOT the updater
   // form -- `(prev) => value` reconciles/merges an object or array leaf into the
@@ -70,11 +63,64 @@ export function createPerAgentStore<T>(empty: T): PerAgentStore<T> {
   // functions, so this is the same direct replace each slice spelled inline.
   const write = (agentId: string, value: T) =>
     setState('byAgent', agentId, value as never)
-  return {
+  const api: PerAgentStore<T> = {
     get: agentId => state.byAgent[agentId] ?? empty,
     set: write,
-    setReconciled: (agentId, value, key) => {
-      const prev = state.byAgent[agentId]
+    clear: agentId => write(agentId, empty),
+    remove: agentId => setState('byAgent', produce((map) => {
+      delete map[agentId]
+    })),
+    get byAgent() {
+      return state.byAgent
+    },
+  }
+  return { api, setState }
+}
+
+export function createPerAgentStore<T>(empty: T): PerAgentStore<T> {
+  return createSpine(empty).api
+}
+
+/** A per-agent store whose leaf is a LIST the UI renders as rows. */
+export interface PerAgentListStore<E> extends PerAgentStore<E[]> {
+  /**
+   * Replace an agent's list, matching entries by the store's key so an entry
+   * whose fields did not change keeps its identity and its per-field signals.
+   *
+   * `set` replaces the array whole, so every entry is a new object, `<For>`
+   * reconciles by REFERENCE, and one changed field therefore tears down and
+   * rebuilds every row on screen. That is not merely wasteful: a rebuilt row
+   * loses the tooltip under the pointer and restarts the CSS animation on its
+   * status dot, so the sidebar's background-task rows flickered whenever any one
+   * of them reported progress.
+   *
+   * It is the one write path that MUTATES the stored array rather than replacing
+   * it, so `value` must be an array this store may own: a fresh one per call,
+   * never a list another agent's leaf also holds.
+   */
+  setReconciled: (agentId: string, value: E[]) => void
+}
+
+/**
+ * A per-agent list store, keyed for reconciliation by `key`.
+ *
+ * The key is declared ONCE, on the store, rather than passed per write: it is a
+ * property of the element type, so two call sites cannot reconcile one dataset
+ * under two identity rules, and `keyof E` makes a misspelling a compile error
+ * instead of a silent fall back to a positional merge -- which is worse than a
+ * rebuild, because a row then keeps its DOM identity while its content shifts
+ * under a stationary pointer.
+ *
+ * The empty value is `[]` and it is SHARED, exactly as `createPerAgentStore`
+ * documents, which is what `setReconciled` guards against below.
+ */
+export function createPerAgentListStore<E extends object>(key: keyof E & string): PerAgentListStore<E> {
+  const empty: E[] = []
+  const { api, setState } = createSpine<E[]>(empty)
+  return {
+    ...api,
+    setReconciled: (agentId, value) => {
+      const prev = api.byAgent[agentId]
       // Never reconcile INTO the empty value. `reconcile` applies its diff by
       // writing through the store proxy to the object underneath, and that
       // object is the ONE default handed to every unset and cleared agent -- so
@@ -87,17 +133,13 @@ export function createPerAgentStore<T>(empty: T): PerAgentStore<T> {
       // cleared agent holds exactly that, so the bare comparison let the
       // reconcile through on the second write to any agent that was cleared.
       if (prev === undefined || unwrap(prev) === empty) {
-        write(agentId, value)
+        api.set(agentId, value)
         return
       }
-      setState('byAgent', agentId, reconcile(value as never, { key }) as never)
+      setState('byAgent', agentId, reconcile(value, { key }) as never)
     },
-    clear: agentId => write(agentId, empty),
-    remove: agentId => setState('byAgent', produce((map) => {
-      delete map[agentId]
-    })),
     get byAgent() {
-      return state.byAgent
+      return api.byAgent
     },
   }
 }

--- a/frontend/src/stores/chatPerAgentStore.ts
+++ b/frontend/src/stores/chatPerAgentStore.ts
@@ -1,4 +1,4 @@
-import { createStore, produce } from 'solid-js/store'
+import { createStore, produce, reconcile, unwrap } from 'solid-js/store'
 
 // ---------------------------------------------------------------------------
 // Per-agent store spine
@@ -29,6 +29,21 @@ export interface PerAgentStore<T> {
   get: (agentId: string) => T
   /** Replace an agent's value. */
   set: (agentId: string, value: T) => void
+  /**
+   * Replace an agent's LIST value, matching entries by `key` so that an entry
+   * whose fields did not change keeps its identity and its per-field signals.
+   *
+   * Use this for a leaf a UI renders as rows. `set` replaces the array whole,
+   * so every entry is a new object, `<For>` reconciles by REFERENCE, and one
+   * changed field therefore tears down and rebuilds every row on screen. That
+   * is not merely wasteful: a rebuilt row loses the tooltip the pointer was
+   * resting on and restarts the CSS animation on its status dot, so the
+   * sidebar's background-task rows flickered whenever any one of them reported
+   * progress.
+   *
+   * `key` names the field that identifies an entry across updates.
+   */
+  setReconciled: (agentId: string, value: T, key: string) => void
   /** Reset an agent's value to the configured empty value. */
   clear: (agentId: string) => void
   /**
@@ -58,6 +73,25 @@ export function createPerAgentStore<T>(empty: T): PerAgentStore<T> {
   return {
     get: agentId => state.byAgent[agentId] ?? empty,
     set: write,
+    setReconciled: (agentId, value, key) => {
+      const prev = state.byAgent[agentId]
+      // Never reconcile INTO the empty value. `reconcile` applies its diff by
+      // writing through the store proxy to the object underneath, and that
+      // object is the ONE default handed to every unset and cleared agent -- so
+      // reconciling a two-row list into it would give every other agent those
+      // two rows. There is nothing to preserve in an absent or empty leaf
+      // anyway, so a plain replace is also the whole answer here.
+      //
+      // `unwrap`, not a bare `===`: a read through the store hands back a PROXY
+      // of the empty value, which is never identical to the value itself. A
+      // cleared agent holds exactly that, so the bare comparison let the
+      // reconcile through on the second write to any agent that was cleared.
+      if (prev === undefined || unwrap(prev) === empty) {
+        write(agentId, value)
+        return
+      }
+      setState('byAgent', agentId, reconcile(value as never, { key }) as never)
+    },
     clear: agentId => write(agentId, empty),
     remove: agentId => setState('byAgent', produce((map) => {
       delete map[agentId]

--- a/frontend/src/stores/chatTodoStore.test.ts
+++ b/frontend/src/stores/chatTodoStore.test.ts
@@ -23,7 +23,7 @@ describe('chatTodoStore', () => {
       store.replace('a1', [protoTodo('t1', 'Run tests', TodoStatus.IN_PROGRESS)])
       store.replace('a2', [protoTodo('t2', 'Write docs')])
       expect(store.get('a1')).toEqual([
-        { id: 't1', content: 'Run tests', status: 'in_progress', activeForm: '', description: undefined },
+        { id: 't1', rowKey: 't1', content: 'Run tests', status: 'in_progress', activeForm: '', description: undefined },
       ])
       expect(store.getById('a1', 't1')?.status).toBe('in_progress')
       expect(store.get('a2').map(t => t.id)).toEqual(['t2'])
@@ -40,9 +40,14 @@ describe('chatTodoStore', () => {
       // stored array reference is preserved (reactive consumers don't re-run).
       store.replace('a1', [protoTodo('t1', 'Run tests')])
       expect(store.get('a1')).toBe(first)
-      // A genuine change replaces the list (new reference).
+      // A genuine change RECONCILES: the row keeps its identity, and only the
+      // field that changed changes. A whole-array replace handed `<For>` a new
+      // object for every row, so one to-do finishing rebuilt the whole list --
+      // closing the tooltip under the pointer and restarting the in-progress
+      // row's animation.
+      const firstRow = first[0]
       store.replace('a1', [protoTodo('t1', 'Run tests', TodoStatus.COMPLETED)])
-      expect(store.get('a1')).not.toBe(first)
+      expect(store.get('a1')[0]).toBe(firstRow)
       expect(store.getById('a1', 't1')?.status).toBe('completed')
       dispose()
     }))

--- a/frontend/src/stores/chatTodoStore.ts
+++ b/frontend/src/stores/chatTodoStore.ts
@@ -1,7 +1,7 @@
 import type { TodoItem } from './chatTodos'
 import type { TodoItem as ProtoTodoItem } from '~/generated/proto/leapmux/v1/agent_pb'
 import { shallowEqualArraysDeep } from '~/lib/shallowEqual'
-import { createPerAgentStore } from './chatPerAgentStore'
+import { createPerAgentListStore } from './chatPerAgentStore'
 import { protoTodoToStore } from './chatTodos'
 
 // ---------------------------------------------------------------------------
@@ -14,7 +14,12 @@ import { protoTodoToStore } from './chatTodos'
 // ---------------------------------------------------------------------------
 
 export function createTodoStore() {
-  const base = createPerAgentStore<TodoItem[]>([])
+  // A LIST store: the rows are rendered as rows, so they reconcile by key. A
+  // plain replace handed `<For>` all-new objects on every broadcast, which tore
+  // down and rebuilt every row -- closing the tooltip under the pointer and
+  // restarting the in-progress row's animation, exactly as the background-task
+  // rows did before `setReconciled`.
+  const base = createPerAgentListStore<TodoItem>('rowKey')
   return {
     get: base.get,
     /** Lookup a todo by id within an agent's list, or undefined if none matches. */
@@ -37,7 +42,7 @@ export function createTodoStore() {
       const prev = base.byAgent[agentId]
       if (prev && shallowEqualArraysDeep(prev, next))
         return
-      base.set(agentId, next)
+      base.setReconciled(agentId, next)
     },
   }
 }

--- a/frontend/src/stores/chatTodos.test.ts
+++ b/frontend/src/stores/chatTodos.test.ts
@@ -2,7 +2,7 @@ import type { TodoItem } from '~/stores/chatTodos'
 import { create } from '@bufbuild/protobuf'
 import { describe, expect, it } from 'vitest'
 import { TodoItemSchema, TodoStatus } from '~/generated/proto/leapmux/v1/agent_pb'
-import { isFinishedTodoStatus, normalizeTodoStatus, protoTodoToStore, rawTodosToItems, sortTodos, todoDisplayLabel, todoProgress } from '~/stores/chatTodos'
+import { isFinishedTodoStatus, normalizeTodoStatus, protoTodoToStore, rawTodosToItems, sortTodos, todoDisplayLabel, todoProgress, todoRowKey } from '~/stores/chatTodos'
 
 describe('chatTodos', () => {
   describe('normalizeTodoStatus', () => {
@@ -49,23 +49,54 @@ describe('chatTodos', () => {
     })
   })
 
+  // The key a UI reconciles a to-do row by. An incremental provider gives an
+  // id; a snapshot-only one gives none and re-sends the whole list, so there
+  // POSITION is the identity.
+  describe('todoRowKey', () => {
+    it('takes the provider id when there is one, whatever the position', () => {
+      expect(todoRowKey('t1', 0, 'Run tests')).toBe('t1')
+      expect(todoRowKey('t1', 7, 'Run tests')).toBe('t1')
+    })
+
+    it('pairs the position with the content when the provider gives no id', () => {
+      expect(todoRowKey(undefined, 0, 'Run tests')).toBe('0:Run tests')
+      expect(todoRowKey(undefined, 2, 'Run tests')).toBe('2:Run tests')
+    })
+
+    // The property the reconcile needs: two rows of one list never collide, so
+    // no row can take another's identity and its content with it.
+    it('separates two rows that differ only in position, or only in content', () => {
+      expect(todoRowKey(undefined, 0, 'Same')).not.toBe(todoRowKey(undefined, 1, 'Same'))
+      expect(todoRowKey(undefined, 0, 'A')).not.toBe(todoRowKey(undefined, 0, 'B'))
+    })
+
+    // An empty content is a real case -- `rawTodosToItems` coerces a missing
+    // field to '' -- and it must still produce a key that separates rows.
+    it('still separates rows whose content is empty', () => {
+      expect(todoRowKey(undefined, 0, '')).toBe('0:')
+      expect(todoRowKey(undefined, 0, '')).not.toBe(todoRowKey(undefined, 1, ''))
+    })
+  })
+
   describe('protoTodoToStore', () => {
     it('maps the proto enum to the canonical string union', () => {
       const t = create(TodoItemSchema, { id: 't1', content: 'c', status: TodoStatus.IN_PROGRESS, activeForm: 'doing c', description: 'why c' })
-      expect(protoTodoToStore(t)).toEqual({ id: 't1', content: 'c', status: 'in_progress', activeForm: 'doing c', description: 'why c' })
+      expect(protoTodoToStore(t, 0)).toEqual({ id: 't1', rowKey: 't1', content: 'c', status: 'in_progress', activeForm: 'doing c', description: 'why c' })
     })
 
     it('coerces empty id/description to undefined', () => {
       const t = create(TodoItemSchema, { id: '', content: 'c', status: TodoStatus.COMPLETED, activeForm: '', description: '' })
-      const out = protoTodoToStore(t)
+      const out = protoTodoToStore(t, 3)
       expect(out.id).toBeUndefined()
+      // No id, so the key is the row's position paired with its content.
+      expect(out.rowKey).toBe('3:c')
       expect(out.description).toBeUndefined()
       expect(out.status).toBe('completed')
     })
 
     it('defaults an unspecified status to pending', () => {
       const t = create(TodoItemSchema, { content: 'c', status: TodoStatus.UNSPECIFIED, activeForm: '' })
-      expect(protoTodoToStore(t).status).toBe('pending')
+      expect(protoTodoToStore(t, 0).status).toBe('pending')
     })
   })
 
@@ -77,22 +108,22 @@ describe('chatTodos', () => {
 
     it('coerces fields and normalizes status', () => {
       expect(rawTodosToItems([{ content: 'a', status: 'inProgress', activeForm: 'doing a' }])).toEqual([
-        { content: 'a', status: 'in_progress', activeForm: 'doing a' },
+        { rowKey: '0:a', content: 'a', status: 'in_progress', activeForm: 'doing a' },
       ])
     })
 
     it('tolerates missing fields with empty-string defaults', () => {
-      expect(rawTodosToItems([{}])).toEqual([{ content: '', status: 'pending', activeForm: '' }])
+      expect(rawTodosToItems([{}])).toEqual([{ rowKey: '0:', content: '', status: 'pending', activeForm: '' }])
     })
   })
 
   describe('todoProgress', () => {
     it('counts completed vs total excluding deleted', () => {
       const todos = [
-        { content: 'a', status: 'completed' as const, activeForm: '' },
-        { content: 'b', status: 'in_progress' as const, activeForm: 'doing b' },
-        { content: 'c', status: 'pending' as const, activeForm: '' },
-        { content: 'd', status: 'deleted' as const, activeForm: '' },
+        { rowKey: '0:a', content: 'a', status: 'completed' as const, activeForm: '' },
+        { rowKey: 'b', content: 'b', status: 'in_progress' as const, activeForm: 'doing b' },
+        { rowKey: 'c', content: 'c', status: 'pending' as const, activeForm: '' },
+        { rowKey: 'd', content: 'd', status: 'deleted' as const, activeForm: '' },
       ]
       expect(todoProgress(todos)).toEqual({ done: 1, total: 3 })
     })
@@ -103,8 +134,8 @@ describe('chatTodos', () => {
 
     it('counts all-non-deleted as done when all completed', () => {
       const todos = [
-        { content: 'a', status: 'completed' as const, activeForm: '' },
-        { content: 'b', status: 'completed' as const, activeForm: '' },
+        { rowKey: '0:a', content: 'a', status: 'completed' as const, activeForm: '' },
+        { rowKey: 'b', content: 'b', status: 'completed' as const, activeForm: '' },
       ]
       expect(todoProgress(todos)).toEqual({ done: 2, total: 2 })
     })
@@ -113,7 +144,7 @@ describe('chatTodos', () => {
 
 describe('sortTodos', () => {
   const todo = (content: string, status: TodoItem['status']): TodoItem =>
-    ({ content, status, activeForm: '' })
+    ({ rowKey: content, content, status, activeForm: '' })
 
   it('puts in-progress first, then what is left, then what is done', () => {
     const sorted = sortTodos([

--- a/frontend/src/stores/chatTodos.ts
+++ b/frontend/src/stores/chatTodos.ts
@@ -19,6 +19,19 @@ export interface TodoItem {
    * this undefined.
    */
   id?: string
+  /**
+   * The identity a UI reconciles this row by across a rebroadcast.
+   *
+   * `id` when the provider gives one. A snapshot-only provider gives none, and
+   * for such a list POSITION is the identity -- the provider re-sends the whole
+   * list and row 3 is row 3 -- so the key pairs the position with the content.
+   * A row whose content is unchanged at its position then keeps its DOM through
+   * a status change, which is the common update; a row whose content changed is
+   * a different task and correctly replaces it.
+   *
+   * Derived, never sent: {@link todoRowKey} is its one writer.
+   */
+  rowKey: string
   content: string
   status: 'pending' | 'in_progress' | 'completed' | 'deleted'
   activeForm: string
@@ -89,11 +102,24 @@ export function todoDisplayLabel(todo: { status: TodoItem['status'], content: st
 }
 
 /**
+ * The reconciliation key for one to-do row; see {@link TodoItem.rowKey}.
+ *
+ * `index` is the row's position in the list the provider sent, which is the only
+ * identity a snapshot-only provider offers.
+ */
+export function todoRowKey(id: string | undefined, index: number, content: string): string {
+  return id || `${index}:${content}`
+}
+
+/**
  * Convert a server-authoritative proto TodoItem (delivered via
  * ListAgentMessages or AgentTodosChanged) into the store shape. Maps
  * the proto TodoStatus enum to the canonical string union.
+ *
+ * `index` is the row's position in the list, which {@link todoRowKey} needs for
+ * a provider that sends no id.
  */
-export function protoTodoToStore(t: ProtoTodoItem): TodoItem {
+export function protoTodoToStore(t: ProtoTodoItem, index: number): TodoItem {
   let status: TodoItem['status'] = 'pending'
   if (t.status === TodoStatus.IN_PROGRESS)
     status = 'in_progress'
@@ -103,6 +129,7 @@ export function protoTodoToStore(t: ProtoTodoItem): TodoItem {
     status = 'deleted'
   return {
     id: t.id || undefined,
+    rowKey: todoRowKey(t.id || undefined, index, t.content),
     content: t.content,
     status,
     activeForm: t.activeForm,
@@ -118,11 +145,15 @@ export function protoTodoToStore(t: ProtoTodoItem): TodoItem {
 export function rawTodosToItems(raw: unknown): TodoItem[] {
   if (!Array.isArray(raw))
     return []
-  return raw.map((t: Record<string, unknown>) => ({
-    content: String(t.content || ''),
-    status: normalizeTodoStatus(t.status),
-    activeForm: String(t.activeForm || ''),
-  }))
+  return raw.map((t: Record<string, unknown>, i: number) => {
+    const content = String(t.content || '')
+    return {
+      rowKey: todoRowKey(undefined, i, content),
+      content,
+      status: normalizeTodoStatus(t.status),
+      activeForm: String(t.activeForm || ''),
+    }
+  })
 }
 
 /**

--- a/frontend/src/styles/popover.css.ts
+++ b/frontend/src/styles/popover.css.ts
@@ -44,6 +44,14 @@ globalStyle('ot-dropdown[data-headless]', {
  * Single-sourced here so a new popover can't re-discover the "stays visible after close" /
  * "margin:auto re-centers" / "eats the next click while closing" bugs the hard way.
  */
+/**
+ * How close a popover may come to the edge of the screen. Written once, because
+ * `popoverColumnClamp` and `popoverMenuClamp` both state it and a menu's own
+ * clamp is the viewport term of a `min()`.
+ */
+const VIEWPORT_MAX_WIDTH = 'calc(100vw - var(--space-4) * 2)'
+const VIEWPORT_MAX_HEIGHT = 'calc(100vh - var(--space-6) * 2)'
+
 export const popoverBase = style({
   position: 'fixed',
   margin: 0,
@@ -75,9 +83,70 @@ export const popoverBase = style({
  */
 export const popoverColumnClamp = style([popoverBase, {
   flexDirection: 'column',
-  maxWidth: 'calc(100vw - var(--space-4) * 2)',
-  maxHeight: 'calc(100vh - var(--space-6) * 2)',
+  maxWidth: VIEWPORT_MAX_WIDTH,
+  maxHeight: VIEWPORT_MAX_HEIGHT,
   overflowY: 'auto',
+}])
+
+/**
+ * The custom properties `DropdownMenu` measures onto its popover, so a MENU can
+ * follow the control it opens from instead of the whole viewport.
+ *
+ * The names are spelled here and read through these constants at the one place
+ * that writes them, so the stylesheet and the component cannot drift.
+ */
+export const TRIGGER_WIDTH_VAR = '--dropdown-trigger-width'
+export const DIALOG_HEIGHT_VAR = '--dropdown-dialog-height'
+
+/**
+ * The clamp EVERY menu popover takes: `popoverColumnClamp`, with the dialog that
+ * holds the trigger as a tighter height limit than the viewport.
+ *
+ * `calcPopoverPosition` clamps where a popover STARTS, not how large it grows,
+ * so a menu of fifty rows ran off the bottom of the screen and the rows past the
+ * bottom edge could not be reached at all. A dialog is also a box the reader
+ * takes in as one thing, and a menu taller than it reads as a second window over
+ * the page rather than as the open form of a field inside it. The viewport stays
+ * as the outer term, for a menu no dialog holds.
+ *
+ * `overflow` on BOTH axes, where `popoverColumnClamp` scrolls only vertically:
+ * the horizontal half is the swipe that reaches a row too wide to fit, on a
+ * narrow field where the checked-state radio and a detail take room the label
+ * cannot give up.
+ *
+ * Deliberately NO width rule. See `popoverFieldMenuClamp`.
+ */
+const triggerWidth = `var(${TRIGGER_WIDTH_VAR}, 100vw)`
+const dialogHeight = `var(${DIALOG_HEIGHT_VAR}, 100vh)`
+
+export const popoverMenuClamp = style([popoverColumnClamp, {
+  maxHeight: `min(${dialogHeight}, ${VIEWPORT_MAX_HEIGHT})`,
+  overflow: 'auto',
+  // A swipe that reaches the end of the list must not carry on into whatever
+  // sits behind the menu.
+  overscrollBehavior: 'contain',
+}])
+
+/**
+ * The extra clamp a FIELD-shaped menu takes: never wider than its own trigger.
+ *
+ * A field's menu is the open form of the control the user clicked, so the two
+ * read as one control when their edges line up, and a row longer than the field
+ * clips instead of pushing the box out over the page.
+ *
+ * OPT-IN, and that is the whole point of the split. A menu's trigger is not
+ * always a field: a kebab is a 24px icon button, and capping its menu at its
+ * trigger leaves a 24px column with every row unreadable. Only a caller that
+ * knows its trigger is field-shaped asks for this -- `DropdownMenu`'s
+ * `matchTriggerWidth`, which `LoadingMenu` sets and nothing else does.
+ *
+ * `min-width` is restated because Oat's own `ot-dropdown [popover]` rule sets
+ * `min-width: 12rem`, and a min-width ALWAYS beats a max-width -- a trigger
+ * narrower than 12rem would otherwise keep a popover wider than itself.
+ */
+export const popoverFieldMenuClamp = style([popoverMenuClamp, {
+  maxWidth: `min(${triggerWidth}, ${VIEWPORT_MAX_WIDTH})`,
+  minWidth: `min(12rem, ${triggerWidth})`,
 }])
 
 /**

--- a/frontend/src/styles/shared.css.ts
+++ b/frontend/src/styles/shared.css.ts
@@ -119,7 +119,19 @@ export const menuItemContent = style({
   minWidth: 0,
 })
 
-export const menuItemShortcut = style({
+/**
+ * The slot at the RIGHT end of a menu item: a short note that the row keeps
+ * whole while the label beside it clips.
+ *
+ * Two kinds of note go in it -- a keyboard shortcut, and the age of the thing
+ * the row names. It is named for the SLOT rather than for either one, because a
+ * class called `menuItemShortcut` on a timestamp makes every reader decide
+ * which meaning applies.
+ *
+ * `flex-shrink: 0` is the whole point. The label takes the squeeze and ends in
+ * an ellipsis; the note stays readable at any label length.
+ */
+export const menuItemDetail = style({
   marginLeft: 'auto',
   flexShrink: 0,
   color: 'var(--muted-foreground)',

--- a/frontend/src/test-support/menu.ts
+++ b/frontend/src/test-support/menu.ts
@@ -19,15 +19,32 @@ import { fireEvent, screen, within } from '@solidjs/testing-library'
  *     `hidden: true`. The role is still asserted -- these have to be
  *     `menuitemradio`, which is what makes the group a one-of-N choice.
  */
+/**
+ * The selector that finds an option's LABEL inside its row.
+ *
+ * `DropdownMenuCheckableItem` derives the label's test id from the row's own by
+ * appending this suffix; the Playwright counterpart is `menuOptionLabel` in
+ * `tests/e2e/helpers/ui.ts`. Spelled once on each side.
+ */
+export const MENU_LABEL_SELECTOR = '[data-testid$="-label"]'
+
 function popover(testId: string): HTMLElement {
   return screen.getByTestId(testId)
 }
 
+/**
+ * Every option row one menu offers, in order.
+ *
+ * The one place the role that makes this group a one-of-N choice is spelled, so
+ * the three readers below cannot disagree about what an option IS.
+ */
+function menuItems(testId: string): HTMLElement[] {
+  return within(popover(testId)).queryAllByRole('menuitemradio', { hidden: true })
+}
+
 /** The option labels one menu offers, in order. */
 export function menuOptions(testId: string): string[] {
-  return within(popover(testId))
-    .queryAllByRole('menuitemradio', { hidden: true })
-    .map(el => el.textContent?.trim() ?? '')
+  return menuItems(testId).map(el => el.textContent?.trim() ?? '')
 }
 
 /**
@@ -41,9 +58,21 @@ export function menuOptions(testId: string): string[] {
  * which is what makes one suffix match every menu.
  */
 export function menuOptionLabels(testId: string): string[] {
-  return within(popover(testId))
-    .queryAllByRole('menuitemradio', { hidden: true })
-    .map(el => el.querySelector('[data-testid$="-label"]')?.textContent?.trim() ?? '')
+  return menuItems(testId).map(el => el.querySelector(MENU_LABEL_SELECTOR)?.textContent?.trim() ?? '')
+}
+
+/**
+ * Open one menu, as a user does, by clicking its trigger.
+ *
+ * Required before an assertion about what a ROW draws. `LoadingMenu` defers the
+ * expensive part of a row -- its label tooltip, and a caller's live detail
+ * element -- to the first open, because `DropdownMenu` mounts its children
+ * eagerly and a menu nobody opened would otherwise allocate one Tooltip per
+ * option. The rows themselves are always mounted, so `menuOptions`,
+ * `menuOptionLabels` and `menuOptionValues` need no open.
+ */
+export function openMenu(testId: string): void {
+  fireEvent.click(menuTrigger(testId))
 }
 
 /** Activate the option with this exact label. */
@@ -70,7 +99,5 @@ export function menuTriggerText(testId: string): string {
 
 /** The option VALUES one menu offers, for a caller that asserted on `<option value>`. */
 export function menuOptionValues(testId: string): string[] {
-  return within(popover(testId))
-    .queryAllByRole('menuitemradio', { hidden: true })
-    .map(el => el.getAttribute('data-testid')?.replace(/^loading-menu-option-/, '') ?? '')
+  return menuItems(testId).map(el => el.getAttribute('data-testid')?.replace(/^loading-menu-option-/, '') ?? '')
 }

--- a/frontend/src/test-support/menu.ts
+++ b/frontend/src/test-support/menu.ts
@@ -30,6 +30,22 @@ export function menuOptions(testId: string): string[] {
     .map(el => el.textContent?.trim() ?? '')
 }
 
+/**
+ * The option LABELS one menu offers, in order.
+ *
+ * Distinct from {@link menuOptions}, which reads the whole row: a row that
+ * carries a DETAIL -- the age of a session -- holds that text as well, and an
+ * age is a moving target. Use this whenever the assertion is about the label.
+ *
+ * `DropdownMenuCheckableItem` derives the label's test id from the row's own,
+ * which is what makes one suffix match every menu.
+ */
+export function menuOptionLabels(testId: string): string[] {
+  return within(popover(testId))
+    .queryAllByRole('menuitemradio', { hidden: true })
+    .map(el => el.querySelector('[data-testid$="-label"]')?.textContent?.trim() ?? '')
+}
+
 /** Activate the option with this exact label. */
 export function pickMenuOption(testId: string, label: string | RegExp): void {
   fireEvent.click(within(popover(testId)).getByRole('menuitemradio', { name: label, hidden: true }))

--- a/frontend/tests/e2e/192-session-picker.spec.ts
+++ b/frontend/tests/e2e/192-session-picker.spec.ts
@@ -101,18 +101,56 @@ test.describe('Session picker in the New Agent dialog', () => {
     await expect(trigger).toBeEnabled()
     await openMenu(dialog, SESSION_MENU)
 
-    // Exactly one resumable session, between the row that withdraws a pick and
-    // the row that hands the field back to its text box. The Keeper's session
-    // is still open AND in another directory, so it is absent on both counts.
+    // Exactly one resumable session, UNDER the two rows that are not sessions:
+    // the one that withdraws a pick and the one that hands the field back to
+    // its text box. The Keeper's session is still open AND in another
+    // directory, so it is absent on both counts.
     const options = dialog.getByTestId(SESSION_MENU).getByRole('menuitemradio')
     await expect(options).toHaveCount(3)
     await expect(options.first()).toHaveText(NEW_SESSION_ROW)
-    await expect(options.last()).toHaveText(TYPE_A_HANDLE_ROW)
+    await expect(options.nth(1)).toHaveText(TYPE_A_HANDLE_ROW)
 
-    const sessionRow = options.nth(1)
-    const sessionLabel = (await sessionRow.textContent())?.trim() ?? ''
+    // The menu opens over a dialog, so it must not outgrow the control it
+    // belongs to or the dialog that holds it. One long session title used to
+    // make it wider than the dialog, and a long list made it taller.
+    const triggerBox = await trigger.boundingBox()
+    const dialogBox = await dialog.boundingBox()
+    const menuBox = await dialog.getByTestId(SESSION_MENU).boundingBox()
+    expect(menuBox!.width).toBeLessThanOrEqual(triggerBox!.width + 1)
+    expect(menuBox!.height).toBeLessThanOrEqual(dialogBox!.height + 1)
+
+    const sessionRow = options.nth(2)
+    const sessionValue = (await sessionRow.getAttribute('data-testid'))!
+      .replace('loading-menu-option-', '')
+    // The TITLE, not the row's whole text: the row also carries the age, which
+    // is a live relative time and can tick between this read and the assertion
+    // below. Every row states one beside its title, and it stays put however
+    // long that title is.
+    const sessionTitle = (await sessionRow
+      .getByTestId(`loading-menu-option-${sessionValue}-label`)
+      .textContent())?.trim() ?? ''
+    await expect(sessionRow).toContainText('ago')
+
     await sessionRow.click()
-    await expect(trigger).toContainText(sessionLabel)
+    await expect(trigger).toHaveAttribute('data-value', sessionValue)
+    await expect(trigger).toContainText(sessionTitle)
+
+    // The route into the text box is a menu row, so the route out is a button
+    // on the field. Without it a mistaken pick held the user in the text box
+    // for as long as the dialog stayed open.
+    await openMenu(dialog, SESSION_MENU)
+    await dialog.getByTestId(SESSION_MENU)
+      .getByRole('menuitemradio', { name: TYPE_A_HANDLE_ROW })
+      .click()
+    await expect(dialog.getByPlaceholder(/^Session ID/)).toBeVisible()
+    await dialog.getByTestId('session-field-pick-from-list').click()
+    await expect(trigger).toBeVisible()
+    // The way back withdraws the pick, so the field starts from the top.
+    await expect(trigger).toHaveAttribute('data-value', '')
+
+    await openMenu(dialog, SESSION_MENU)
+    await dialog.getByTestId(`loading-menu-option-${sessionValue}`).click()
+    await expect(trigger).toHaveAttribute('data-value', sessionValue)
 
     await dialog.getByRole('button', { name: 'Create' }).click()
     await expect(page.getByRole('heading', { name: 'New Agent' })).toBeHidden()

--- a/frontend/tests/e2e/192-session-picker.spec.ts
+++ b/frontend/tests/e2e/192-session-picker.spec.ts
@@ -1,9 +1,11 @@
+import { typeAHandleLabel } from '../../src/components/shell/resumeSession'
 import { expect, test } from './fixtures'
 import { createWorkspaceViaAPI, openAgentViaAPI } from './helpers/api'
 import {
   ARITHMETIC_PROMPT,
   expectAssistantAnswer,
   loginViaToken,
+  menuOptionLabel,
   openMenu,
   openWorkspace,
   sendMessage,
@@ -19,7 +21,9 @@ import {
 
 const SESSION_MENU = 'session-select-menu'
 const NEW_SESSION_ROW = 'Start a new session'
-const TYPE_A_HANDLE_ROW = 'Enter a session ID…'
+// From the app's own declaration, so the row's wording and this locator cannot
+// drift. `false`: the Claude provider's session is an id, not a file path.
+const TYPE_A_HANDLE_ROW = typeAHandleLabel(false)
 
 /**
  * The resume field's session picker, end to end.
@@ -113,9 +117,25 @@ test.describe('Session picker in the New Agent dialog', () => {
     // The menu opens over a dialog, so it must not outgrow the control it
     // belongs to or the dialog that holds it. One long session title used to
     // make it wider than the dialog, and a long list made it taller.
+    //
+    // The assertions read the resolved CAPS, not the drawn box. This menu holds
+    // three short rows, so its box is well inside both limits whether or not any
+    // limit exists -- a measurement alone would pass against an uncapped
+    // popover and state nothing. The caps are the thing under test: they are
+    // what a fifty-session list and a title wider than the field run into.
+    const menu = dialog.getByTestId(SESSION_MENU)
     const triggerBox = await trigger.boundingBox()
     const dialogBox = await dialog.boundingBox()
-    const menuBox = await dialog.getByTestId(SESSION_MENU).boundingBox()
+    const caps = await menu.evaluate((el) => {
+      const s = getComputedStyle(el)
+      return { maxWidth: s.maxWidth, maxHeight: s.maxHeight, overflow: s.overflowY }
+    })
+    expect(Number.parseFloat(caps.maxWidth)).toBeLessThanOrEqual(triggerBox!.width + 1)
+    expect(Number.parseFloat(caps.maxHeight)).toBeLessThanOrEqual(dialogBox!.height + 1)
+    // The cap only makes the rows past it UNREACHABLE unless the box scrolls.
+    expect(caps.overflow).toBe('auto')
+
+    const menuBox = await menu.boundingBox()
     expect(menuBox!.width).toBeLessThanOrEqual(triggerBox!.width + 1)
     expect(menuBox!.height).toBeLessThanOrEqual(dialogBox!.height + 1)
 
@@ -126,9 +146,7 @@ test.describe('Session picker in the New Agent dialog', () => {
     // is a live relative time and can tick between this read and the assertion
     // below. Every row states one beside its title, and it stays put however
     // long that title is.
-    const sessionTitle = (await sessionRow
-      .getByTestId(`loading-menu-option-${sessionValue}-label`)
-      .textContent())?.trim() ?? ''
+    const sessionTitle = (await menuOptionLabel(sessionRow).textContent())?.trim() ?? ''
     await expect(sessionRow).toContainText('ago')
 
     await sessionRow.click()

--- a/frontend/tests/e2e/helpers/ui.ts
+++ b/frontend/tests/e2e/helpers/ui.ts
@@ -1765,3 +1765,16 @@ export async function menuOptionTexts(scope: Locator, base: string): Promise<str
   await openMenu(scope, base)
   return scope.getByTestId(base).getByRole('menuitemradio').allTextContents()
 }
+
+/**
+ * One option row's LABEL, which is not the same as its text.
+ *
+ * A row also carries its DETAIL -- the age of a session -- and an age is a
+ * moving target: read the whole row and an assertion can lose to the clock
+ * between the read and the compare. `DropdownMenuCheckableItem` derives this
+ * test id from the row's own, and `src/test-support/menu.ts` spells the same
+ * suffix for the vitest side.
+ */
+export function menuOptionLabel(row: Locator): Locator {
+  return row.locator('[data-testid$="-label"]')
+}


### PR DESCRIPTION
## Motivation

Several independent defects surfaced from using the app, and a deep review of
the fix for one of them (the tab-lifecycle race) surfaced more, including
some pre-existing ones nearby. None of the six areas below share a root
cause; they are grouped here because they land in the same PR, not because
they are related.

- A message typed into a tab in the instant after it opened could vanish: the
  worker had no record of the agent yet, so the send took the auto-start path,
  found the id already claimed, and gave up without retrying.
- A shell that exited on its own left the terminal tab showing neither its
  final output nor that it had exited, because nothing closed the pty's
  child side for a natural exit — masked on macOS, reproducible on Linux.
- Any popover shaped like a menu (a 12-row theme palette, a 50-session list)
  could run off the bottom of the screen with no way to reach the rest.
- The sidebar's background-task and to-do rows tore down and rebuilt on every
  registry broadcast from the worker, closing an open tooltip and restarting
  a status-dot animation under a pointer that never moved.
- The session picker mixed up wording between the list and the manual-entry
  box for file-path sessions (Pi), let a long title push the age off the row,
  and buried the manual-entry option at the bottom of a capped list.
- ZCode's effort and provider/model menus followed `config.json`'s arbitrary
  ordering (weakest level first), reordered themselves the moment a live
  snapshot arrived, and showed duplicate or malformed provider/model labels.

## Modifications

**Reasoning-effort ladder and ZCode catalog** (`effort_labels.go`,
`zcode_config.go`, `zcode_settings.go`, `codex.go`)
- One ordered `effortLadder` replaces three hand-written, disagreeing
  tables; `effortRank`, `effortLabels`, and Codex's static menu all derive
  from it, and a generic `sortEffortsDescending[T]` replaces two near-duplicate
  sorts.
- ZCode's effort menus now sort strongest-first through one shared
  `zcodeEffortsWithAuto`, used by both the static catalog and the live
  snapshot, so the menu no longer reorders itself.
- `enabled` — ZCode's on/off toggle for a model that offers no ladder
  (GLM-5-Turbo) — joins the existing `minimal` rung, so "thinking on" can
  never sort below `off`. Rank 0 stays reserved for "thinking off", which
  `chooseDefaultEffort` and `raiseEffortOffNone` both depend on.
- `zcodeBuiltinProviderLabel` and `zcodeModelDisplayName` correct duplicate
  and malformed provider/model labels the CLI reports (e.g. two Z.ai plans
  both named "Z.ai - Coding Plan"), while still honoring a genuine user
  rename.

**Worker agent startup race** (`agent.go`, `agent_control_ipc.go`,
`startupstate.go`)
- `ensureAgentRunning` now awaits an in-flight startup before the claim
  check, for interactive sends only — the background resume sweep still
  refuses immediately. The wait is bounded by the RPC timeout, not the
  multi-minute process-startup timeout.
- A startup ended by the tab closing is never treated as success, so a
  closed tab is not cold-started behind the user.

**Terminal pty lifecycle** (`terminal.go`, `pty_unix.go`, `pty_windows.go`,
`manager.go`)
- A terminal that exits on its own now closes the pty's child side, so the
  exit handler runs, and the exit code, final screen, and `TerminalClosed`
  event are persisted on Linux (previously masked by macOS's different tty
  behavior).
- Exit handling waits for the reader with a bounded grace instead of
  forever, and pty teardown is now serialized against a concurrent
  `Resize`/`SendInput` via a new `Terminal.ptyMu`.
- `closeChildSide` is idempotent, and `RestartTerminal` now stops the
  terminal it replaces, so a stale reader can no longer overwrite the new
  terminal's screen buffer.
- Breaking (internal only): `Terminal.WaitForReadDrained` is replaced by an
  unexported bounded `waitForReadDrained`; the test-only
  `Manager.WaitForReadDrained` entry point is preserved.

**Menus, popovers, and tooltips** (`DropdownMenu.tsx`, `LoadingMenu.tsx`,
`Tooltip.tsx`, `popover.css.ts`, `shared.css.ts`)
- Every menu-shaped popover is now height-clamped to its dialog (or the
  viewport) and scrolls its overflow, instead of running off-screen.
- Width-matching to the trigger is opt-in (`matchTriggerWidth`); menu items
  gain a right-aligned `detail` slot and an opt-in `revealClippedLabel`
  tooltip, and their per-row `Tooltip`/detail cost is deferred to first
  open instead of paid by every mounted menu.
- `Tooltip`'s disabled-detection also covers the enclosing disabled
  ancestor, so a clipped label inside a disabled control still gets a
  description.
- Fixed a Preferences-dialog popover-positioning bug caused by Oat's
  `fill-mode: both` tab-panel animation.
- Breaking (internal only): `menuItemShortcut` renamed to `menuItemDetail`
  in `shared.css.ts`; `LoadingMenu.css.ts`'s `triggerText` renamed to
  `triggerLabel`. All call sites updated.

**Sidebar rows and per-agent stores** (`BackgroundTaskList.tsx`,
`chatBackgroundTaskStore.ts`, `chatTodoStore.ts`, `chatPerAgentStore.ts`,
`chatTodos.ts`)
- Background-task and to-do sidebar rows are now built from reactive
  getters bound to individual attributes, instead of being torn down and
  rebuilt on every whole-registry broadcast.
- Grouped rows key by a stable id (`groupKeys()`) instead of by a freshly
  built group object each render.
- A new `createPerAgentListStore.setReconciled` (keyed SolidJS `reconcile`)
  backs both stores, and `TodoItem` gains a `rowKey` fallback for providers
  that resend whole snapshots with no stable id.
- Breaking (internal only): `protoTodoToStore` takes a new `index`
  argument.

**Session picker** (`SessionSelect.tsx`, `ResumeSessionField.tsx`,
`resumeSession.ts`, `SessionIdInput.tsx`)
- Session age moved out of the option label into a live `detail` column
  drawn from the same clock its filter text reads, so a long title can no
  longer push the age off the row and typing no longer empties the list.
- "Enter a session ID…" moved from last to second, under "Start a new
  session".
- The list row and the manual-entry box now share one label/placeholder
  pair (`typeAHandleLabel`/`resumeHandlePlaceholder`) that names a file
  path for providers whose session is a file (Pi), and a new button returns
  from the text box to the menu.
- Breaking (internal only): `sessionOptionLabel` dropped its `now: Date`
  parameter; `TYPE_A_HANDLE_LABEL` is replaced by `typeAHandleLabel()`.

## Result

- A message typed the instant a tab opens is delivered instead of lost.
- A shell that exits on its own (Ctrl-D, `exit`) shows its final output and
  its closed state reliably on Linux, and restarting a terminal can no
  longer overwrite the new session with a dead shell's trailing bytes.
- Long popovers — theme palettes, session lists, directory pickers — stay
  on screen and scroll instead of running off the bottom.
- Sidebar task and to-do rows stop flickering (tooltips closing, status
  dots restarting) on every worker broadcast.
- The session picker shows session age clearly, keeps filtering usable
  while typing, gives consistent instructions for file-path sessions (Pi),
  and offers a way back to the list from manual entry.
- ZCode's effort and provider/model menus show deduplicated labels sorted
  strongest-first, and stop reordering themselves when a live snapshot
  arrives.
