### PR TITLE
fix(desktop): Intercept the macOS minimize before AppKit acts

### DIFF
--- a/desktop/rust/Cargo.lock
+++ b/desktop/rust/Cargo.lock
@@ -2149,14 +2149,11 @@ name = "leapmux-desktop"
 version = "0.0.0"
 dependencies = [
  "base64 0.23.1",
- "block2",
  "dirs 6.0.0",
  "gdk",
  "gtk",
  "libc",
  "objc2",
- "objc2-app-kit",
- "objc2-foundation",
  "prost",
  "prost-build",
  "serde",

--- a/desktop/rust/Cargo.toml
+++ b/desktop/rust/Cargo.toml
@@ -46,29 +46,19 @@ gtk = "0.18"
 gdk = "0.18"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-# The NSWindowDidMiniaturizeNotification observer; see
+# The runtime subclass that overrides `-[NSWindow miniaturize:]`; see
 # `tray/minimize_macos.rs`. Tauri 2 emits no Minimized window event and tao
-# tracks the state without reporting it, so the AppKit notification is the only
-# signal that catches every way a window can be miniaturized.
+# tracks the state without reporting it, so the shell calls AppKit itself. It
+# overrides that method rather than answering
+# NSWindowDidMiniaturizeNotification, because a miniaturize cannot be undone
+# once AppKit performs it.
 #
-# Tauri re-exports objc2 only under `target_os = "ios"`, so this file must list
-# these four itself. All four are already in Cargo.lock at these versions
-# through tao/muda/tray-icon, so the entries add direct edges and no new
-# packages.
-#
-# The objc2-foundation feature list is what makes
-# `addObserverForName:object:queue:usingBlock:` available. Drop one and the
-# method simply does not exist, with no hint as to which is missing.
+# `objc2` alone: the override needs the class builder, `msg_send!` and `sel!`,
+# and none of the AppKit or Foundation types. Tauri re-exports objc2 only under
+# `target_os = "ios"`, so this file must list it itself. It is already in
+# Cargo.lock at this version through tao/muda/tray-icon, so the entry adds a
+# direct edge and no new package.
 objc2 = "0.6"
-objc2-app-kit = { version = "0.3", default-features = false, features = ["std", "NSWindow"] }
-objc2-foundation = { version = "0.3", default-features = false, features = [
-    "std",
-    "NSNotification",
-    "NSOperation",
-    "NSString",
-    "block2",
-] }
-block2 = "0.6"
 
 [target.'cfg(windows)'.dependencies]
 # Only the SID lookup that ACLs the named pipe, and the pipe's own error codes,

--- a/desktop/rust/src/file_save.rs
+++ b/desktop/rust/src/file_save.rs
@@ -423,7 +423,7 @@ impl SaveStreamRegistry {
             // branches below.
             Err(err) if err.kind() == io::ErrorKind::NotFound => return,
             Err(err) => {
-                eprintln!("leapmux: sweep read dir {}: {err}", dir.display());
+                crate::shell_log!("sweep read dir {}: {err}", dir.display());
                 return;
             }
         };
@@ -435,7 +435,7 @@ impl SaveStreamRegistry {
             let entry = match entry {
                 Ok(entry) => entry,
                 Err(err) => {
-                    eprintln!("leapmux: sweep read dir entry in {}: {err}", dir.display());
+                    crate::shell_log!("sweep read dir entry in {}: {err}", dir.display());
                     continue;
                 }
             };
@@ -448,7 +448,7 @@ impl SaveStreamRegistry {
             let ft = match entry.file_type() {
                 Ok(ft) => ft,
                 Err(err) => {
-                    eprintln!("leapmux: sweep file type {}: {err}", entry.path().display());
+                    crate::shell_log!("sweep file type {}: {err}", entry.path().display());
                     continue;
                 }
             };
@@ -460,10 +460,7 @@ impl SaveStreamRegistry {
                 continue;
             }
             if let Err(err) = std::fs::remove_file(&path) {
-                eprintln!(
-                    "leapmux: sweep orphan save partial {}: {err}",
-                    path.display()
-                );
+                crate::shell_log!("sweep orphan save partial {}: {err}", path.display());
             }
         }
     }

--- a/desktop/rust/src/main.rs
+++ b/desktop/rust/src/main.rs
@@ -102,6 +102,44 @@ const SHOW_ABOUT_MENU_ID: &str = "show-about";
 const SHOW_PREFERENCES_MENU_ID: &str = "show-preferences";
 #[cfg(target_os = "macos")]
 const OPEN_WEB_INSPECTOR_MENU_ID: &str = "open-web-inspector";
+/// Write one diagnostic line from the shell to standard error.
+///
+/// ONE prefix for the whole binary, so `grep leapmux-desktop:` returns the
+/// whole log. Before this macro the same program wrote four spellings --
+/// `leapmux-desktop:`, `leapmux:`, and three lines with no prefix at all -- and
+/// `grep` on any one of them found a part of the log and hid the rest.
+///
+/// `desktop-sidecar:` in `sidecar.rs` is the deliberate exception, and it must
+/// stay: it marks a line that the SIDECAR wrote, which is another program's
+/// output that this shell only forwards.
+///
+/// A macro and not a function, because `eprintln!` takes format arguments that
+/// borrow from the call site.
+macro_rules! shell_log {
+    ($($arg:tt)*) => {
+        eprintln!("leapmux-desktop: {}", format_args!($($arg)*))
+    };
+}
+pub(crate) use shell_log;
+
+/// The label of the one window that `tauri.conf.json` declares.
+///
+/// Every lookup and every window-event filter in the shell spells it through
+/// this constant, so a typo at a call site is a compile error rather than a
+/// hook that never fires. Two JSON files hold the same text and no Rust
+/// constant can bind either: `tauri.conf.json` declares the window, and
+/// `capabilities/default.json` lists `"windows": ["main"]`, which is what gives
+/// that window its `core:window:*` permissions. A rename must edit all three,
+/// and a capability that matches no window denies every window command from
+/// the webview at run time, with nothing to see at compile time.
+///
+/// It is NOT contract material. The webview reaches its own window with
+/// `getCurrentWindow()` and spells no label, so the value crosses no language
+/// boundary.
+///
+/// Not to be confused with `tray::TRAY_ID`, which carries the same text for the
+/// tray icon.
+pub(crate) const MAIN_WINDOW_LABEL: &str = "main";
 pub(crate) const SIDECAR_PROTOCOL_VERSION: &str = "1";
 pub(crate) const DEV_SIDECAR_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(30);
 // CONNECT_TIMEOUT is the outer loop budget for "endpoint reachable +
@@ -275,8 +313,8 @@ struct TunnelConfigInput {
 fn recover<T>(m: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
     m.lock().unwrap_or_else(|e| {
         if !POISON_WARNED.swap(true, Ordering::Relaxed) {
-            eprintln!(
-                "warning: recovered a poisoned mutex; the desktop shell is in a degraded state (see issue #277)"
+            shell_log!(
+                "recovered a poisoned mutex; the desktop shell is in a degraded state (see issue #277)"
             );
         }
         e.into_inner()
@@ -339,7 +377,7 @@ fn start_sidecar_reader_thread(
                 Ok(frame) => handle_sidecar_frame(&app_handle, &pending, frame),
                 Err(err) => {
                     if err.kind() != io::ErrorKind::UnexpectedEof {
-                        eprintln!("sidecar frame read error: {err}");
+                        crate::shell_log!("sidecar frame read error: {err}");
                     }
                     recover(&pending).clear();
                     break;
@@ -367,7 +405,7 @@ fn start_sidecar_writer_thread(
         let mut writer = writer;
         while let Some(frame) = rx.blocking_recv() {
             if let Err(err) = write_frame(&mut writer, &frame) {
-                eprintln!("sidecar frame write error: {err}");
+                crate::shell_log!("sidecar frame write error: {err}");
                 break;
             }
         }
@@ -527,7 +565,7 @@ impl DesktopShell {
 
     fn set_zoom(&self, zoom: f64) -> Result<(), String> {
         let clamped = zoom.clamp(0.5, 3.0);
-        if let Some(window) = self.app_handle.get_webview_window("main") {
+        if let Some(window) = self.app_handle.get_webview_window(MAIN_WINDOW_LABEL) {
             window
                 .set_zoom(clamped)
                 .map_err(|err| format!("set webview zoom: {err}"))?;
@@ -1366,8 +1404,8 @@ async fn set_desktop_behavior(
     let _serialized = state.push_lock.lock().await;
     let mut refusals: Vec<tray::BehaviorRefusal> = Vec::new();
     let mut record = |refusal: tray::BehaviorRefusal| {
-        eprintln!(
-            "leapmux-desktop: the system refused {}: {}",
+        shell_log!(
+            "the system refused {}: {}",
             refusal.setting, refusal.message
         );
         refusals.push(refusal);
@@ -1389,7 +1427,7 @@ async fn set_desktop_behavior(
     // the other way round leaves a user with no tray and no window, which is
     // the exact state this step exists to prevent.
     let visible = app
-        .get_webview_window("main")
+        .get_webview_window(MAIN_WINDOW_LABEL)
         .and_then(|window| window.is_visible().ok())
         .unwrap_or(false);
     let launch_was_wrong = launch.launch_was_wrong(behavior.start_minimized, state.is_enabled());
@@ -1417,7 +1455,7 @@ async fn set_desktop_behavior(
     //    `window()`, so the login item cannot reach the file even by accident:
     //    the cached type does not carry that field at all.
     if let Err(err) = shell.save_desktop_behavior(behavior.window()).await {
-        eprintln!("leapmux-desktop: cache the window behaviour: {err}");
+        crate::shell_log!("cache the window behaviour: {err}");
     }
 
     if refusals.is_empty() {
@@ -1551,7 +1589,7 @@ fn reset_webview_zoom(shell: State<'_, Arc<DesktopShell>>) -> Result<(), String>
 // --- Window/app helpers ---
 
 fn open_main_web_inspector(app: &AppHandle) {
-    if let Some(window) = app.get_webview_window("main") {
+    if let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) {
         window.open_devtools();
     }
 }
@@ -1757,7 +1795,7 @@ fn main() {
             let _ = (app, event);
         })
         .on_window_event(|window, event| {
-            if window.label() != "main" {
+            if window.label() != MAIN_WINDOW_LABEL {
                 return;
             }
 
@@ -1781,6 +1819,10 @@ fn main() {
                             // HIDE, never close: closing destroys the webview
                             // and every open tab's client state with it.
                             api.prevent_close();
+                            // Recorded, so the startup safety net does not read
+                            // this window as a frontend that never ran and pull
+                            // it back five seconds in.
+                            state.record_hide_to_tray();
                             let _ = window.hide();
                             return;
                         }
@@ -1804,7 +1846,7 @@ fn main() {
             // one. Drop the native decorations so the frontend can draw its
             // own drag region and window controls end-to-end.
             #[cfg(any(target_os = "linux", target_os = "windows"))]
-            if let Some(w) = app.get_webview_window("main") {
+            if let Some(w) = app.get_webview_window(MAIN_WINDOW_LABEL) {
                 let _ = w.set_decorations(false);
             }
 
@@ -1812,7 +1854,7 @@ fn main() {
             // ProseMirror can receive Tab/Shift+Tab keydowns. See
             // `tabfix_linux.rs` for the rationale.
             #[cfg(target_os = "linux")]
-            if let Some(w) = app.get_webview_window("main") {
+            if let Some(w) = app.get_webview_window(MAIN_WINDOW_LABEL) {
                 tabfix_linux::install(&w);
             }
 
@@ -1873,7 +1915,7 @@ fn main() {
 
             let runtime_state = shell.runtime_state();
             if runtime_state.connected && runtime_state.shell_mode == ShellMode::Distributed {
-                if let Some(window) = app.get_webview_window("main") {
+                if let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) {
                     let target_url = Url::parse(&runtime_state.hub_url)
                         .map_err(|err| format!("parse reattach hub url: {err}"))?;
                     window
@@ -1975,16 +2017,42 @@ fn main() {
         .build(tauri::generate_context!())
         .expect("error while building LeapMux desktop")
         .run(|app, event| {
-            if let RunEvent::ExitRequested { api, .. } = event {
-                if let Some(shell) = app.try_state::<Arc<DesktopShell>>() {
-                    if !shell.exit_in_progress.load(Ordering::SeqCst) {
-                        // The save handles are dropped inside `handle_app_exit`,
-                        // which every exit route reaches -- including the ones
-                        // that latch `exit_in_progress` before this arm runs.
-                        api.prevent_exit();
-                        handle_app_exit(shell.inner().clone());
+            match event {
+                RunEvent::ExitRequested { api, .. } => {
+                    if let Some(shell) = app.try_state::<Arc<DesktopShell>>() {
+                        if !shell.exit_in_progress.load(Ordering::SeqCst) {
+                            // The save handles are dropped inside
+                            // `handle_app_exit`, which every exit route reaches
+                            // -- including the ones that latch
+                            // `exit_in_progress` before this arm runs.
+                            api.prevent_exit();
+                            handle_app_exit(shell.inner().clone());
+                        }
                     }
                 }
+                // macOS: a click on the Dock icon of an application with no
+                // visible window. LeapMux hides its window for a close and for
+                // a minimize, and it registers no `LSUIElement`, so the Dock
+                // icon stays. AppKit's own default does nothing for a window
+                // that `orderOut:` took off the screen list, which leaves the
+                // icon looking broken and the tray icon as the only route back.
+                //
+                // `show_main_window` is the same entry point the tray click,
+                // the tray menu item and the single-instance callback share, so
+                // every request that the operating system makes for this
+                // application reveals the window by one rule.
+                //
+                // A login launch that asked to start hidden keeps its window
+                // hidden. AppKit sends this for a RE-open and not for the first
+                // launch, which a probe confirmed: a delegate that implements
+                // `applicationShouldHandleReopen:hasVisibleWindows:` receives
+                // nothing while the application starts with no window.
+                #[cfg(target_os = "macos")]
+                RunEvent::Reopen {
+                    has_visible_windows,
+                    ..
+                } if !has_visible_windows => tray::show_main_window(app),
+                _ => {}
             }
         });
 }

--- a/desktop/rust/src/sidecar.rs
+++ b/desktop/rust/src/sidecar.rs
@@ -106,7 +106,7 @@ fn bootstrap_dev_sidecar(sidecar_path: &Path) -> Result<SidecarBootstrap, String
         // socket is not ours to unlink -- /tmp is sticky -- so binding here would just
         // fail. Take a private endpoint.
         Err(err) => {
-            eprintln!("leapmux: cannot use dev sidecar endpoint {endpoint}: {err}");
+            crate::shell_log!("cannot use dev sidecar endpoint {endpoint}: {err}");
             endpoint = private_endpoint;
         }
     }
@@ -187,6 +187,10 @@ fn start_sidecar_stderr_thread(stderr: impl Read + Send + 'static) {
     thread::spawn(move || {
         let reader = BufReader::new(stderr);
         for line in reader.lines().map_while(Result::ok) {
+            // The one `eprintln!` that `shell_log!` must not replace. This
+            // forwards what the SIDECAR wrote, so the prefix marks another
+            // program's output and reading it as a shell line would misattribute
+            // every sidecar error.
             eprintln!("desktop-sidecar: {line}");
         }
     });
@@ -267,8 +271,8 @@ fn request_sidecar_shutdown(endpoint: &str) -> bool {
         Some(pid) => format!("process {pid}"),
         None => "an unidentified process".to_string(),
     };
-    eprintln!(
-        "leapmux: a sidecar ({holder}) is holding {endpoint} and did not shut down \
+    crate::shell_log!(
+        "a sidecar ({holder}) is holding {endpoint} and did not shut down \
          when asked; starting on a private endpoint instead. Stop it manually if it \
          should not be running -- in SOLO mode it also holds the shared DB's runtime \
          lease, so ConnectSolo will keep failing until it is gone (a launcher-mode \

--- a/desktop/rust/src/tray/minimize_linux.rs
+++ b/desktop/rust/src/tray/minimize_linux.rs
@@ -45,7 +45,9 @@ pub(crate) fn install(window: &WebviewWindow, state: Arc<TrayState>) {
         // main thread and unmaps the widget, and unmapping a widget from
         // inside its own state-event emission asks GTK to tear down what it is
         // still dispatching.
-        glib::idle_add_local_once(move || super::handle_minimize(&state, &webview));
+        glib::idle_add_local_once(move || {
+            super::handle_minimize(&state, &webview);
+        });
         glib::Propagation::Proceed
     });
 }

--- a/desktop/rust/src/tray/minimize_macos.rs
+++ b/desktop/rust/src/tray/minimize_macos.rs
@@ -1,67 +1,242 @@
-//! macOS: catch a minimize through `NSWindowDidMiniaturizeNotification`.
+//! macOS: turn a minimize REQUEST into a hide, before AppKit performs it.
 //!
-//! Every way a window can be miniaturized converges on `performMiniaturize:` --
-//! the yellow traffic light, Cmd+M, the Window menu's Minimize item, and a
-//! title-bar double click -- and every one of them posts this notification. So
-//! one observer covers them all, where intercepting any single affordance would
-//! leave the others behaving differently from the preference.
+//! Every way a window can be miniaturized reaches `-[NSWindow miniaturize:]`.
+//! The yellow traffic light's action IS that selector, with the window as its
+//! target. `performMiniaturize:` -- Cmd+M, the Window menu's Minimize item and
+//! a title-bar double click -- calls it in turn. And tauri's own
+//! `Window::minimize` calls it directly. So one override covers every
+//! affordance, where intercepting a single one would leave the others
+//! disobeying the preference.
 //!
-//! AppKit offers no veto. There is no `windowShouldMiniaturize:`, and the
-//! notification is posted AFTER the animation finishes, so the window visibly
-//! genies into the Dock before the tile disappears. That artefact is accepted:
-//! the alternative is to intercept only the affordances the app itself owns,
-//! which makes the yellow button disobey a setting the menu item honours.
+//! An override, and not an `NSWindowDidMiniaturizeNotification` observer,
+//! because a miniaturize CANNOT be undone once AppKit performs it. There is no
+//! `windowShouldMiniaturize:`, and the notification arrives when the window is
+//! already miniaturized. Neither way out of that state works:
+//!
+//!   * `deminiaturize:` puts the window back ON SCREEN, every time. It is
+//!     asynchronous, so it does nothing in the turn that calls it and finishes
+//!     after the `orderOut:` on the next line -- which restores the window the
+//!     shell just hid. Ordering the window out first does not help either: it
+//!     re-shows a window that is already off the screen list.
+//!   * `orderOut:` alone leaves the window miniaturized, and the Dock tile
+//!     follows `isMiniaturized` rather than the screen list. The window
+//!     disappears and its tile stays in the Dock, which is the state the
+//!     preference exists to prevent.
+//!
+//! So the window must never enter the miniaturized state at all. The override
+//! hides it instead of calling `super`, which leaves it off screen and NOT
+//! miniaturized: no Dock tile, and no minimize animation to undo.
+//!
+//! The subclass is built at RUNTIME and set on the one main window, so tao's
+//! own window class stays the superclass and keeps its overrides. Swizzling
+//! `-[NSWindow miniaturize:]` on that class instead would divert every other
+//! window in the process too, and would then need a check on the receiver to
+//! exclude them again.
 
+use std::ffi::CStr;
 use std::ptr::NonNull;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
-use block2::RcBlock;
-use objc2::rc::Retained;
-use objc2::runtime::AnyObject;
-use objc2_app_kit::NSWindowDidMiniaturizeNotification;
-use objc2_foundation::{NSNotification, NSNotificationCenter};
-use tauri::WebviewWindow;
+use objc2::runtime::{AnyClass, AnyObject, ClassBuilder, Sel};
+use objc2::{msg_send, sel};
+use tauri::{AppHandle, Manager, WebviewWindow};
 
 use super::TrayState;
 
-/// Install the minimize hook on the main window.
+/// The name of the runtime subclass. An Objective-C class name is a
+/// process-wide identifier that every loaded framework shares, so it carries
+/// the product prefix.
+const SUBCLASS_NAME: &CStr = c"LeapMuxMainWindow";
+
+/// What the override needs to answer a minimize.
+///
+/// A process global, because what it describes is one. The shell has one main
+/// window, and `objc_allocateClassPair` refuses a name that is already
+/// registered, so the subclass exists at most once.
+struct MinimizeHook {
+    state: Arc<TrayState>,
+    app: AppHandle,
+}
+
+static HOOK: OnceLock<MinimizeHook> = OnceLock::new();
+
+/// Install the minimize override on the main window.
+///
+/// Each branch below logs before it returns. Without the override a minimize
+/// keeps its ordinary behaviour, which looks like "LeapMux ignores my setting",
+/// and a silent return leaves the user nothing to report it with.
 pub(crate) fn install(window: &WebviewWindow, state: Arc<TrayState>) {
     let Ok(ns_window) = window.ns_window() else {
+        eprintln!("leapmux-desktop: the main window has no NSWindow; a minimize cannot hide it");
         return;
     };
     let Some(object) = NonNull::new(ns_window.cast::<AnyObject>()) else {
+        eprintln!("leapmux-desktop: the main window's NSWindow is null; a minimize cannot hide it");
         return;
     };
-    let webview = window.clone();
-    let block = RcBlock::new(move |_: NonNull<NSNotification>| {
-        // Posted on the main thread, because the observer is registered with a
-        // nil queue.
-        super::handle_minimize(&state, &webview);
-    });
-    // SAFETY: `object` is the live NSWindow that tauri owns and outlives the
-    // observer, and the block is copied by the notification center and only
-    // invoked on the main thread.
-    let observer = unsafe {
-        NSNotificationCenter::defaultCenter().addObserverForName_object_queue_usingBlock(
-            Some(NSWindowDidMiniaturizeNotification),
-            Some(object.as_ref()),
-            None,
-            &block,
-        )
+    // SAFETY: `ns_window` is the live NSWindow that tauri owns and keeps for
+    // the length of the process, and `install` runs on the main thread, where
+    // every call below belongs.
+    let object = unsafe { object.as_ref() };
+
+    // The hook is published BEFORE the class changes. The override reads it, so
+    // a window that carries the subclass must never find it missing.
+    if HOOK
+        .set(MinimizeHook {
+            state,
+            app: window.app_handle().clone(),
+        })
+        .is_err()
+    {
+        // Already installed. Setting the class a second time would make the
+        // subclass its own superclass.
+        eprintln!("leapmux-desktop: the minimize override is already installed");
+        return;
+    }
+    let Some(subclass) = build_subclass(object.class()) else {
+        eprintln!(
+            "leapmux-desktop: the runtime refused the {} class; a minimize cannot hide the window",
+            SUBCLASS_NAME.to_string_lossy()
+        );
+        return;
     };
-    // The observer lives for the process. Dropping the token DEREGISTERS it,
-    // which would leave the hook silently installed-but-dead, so ownership goes
-    // to the notification center instead.
-    let _ = Retained::into_raw(observer);
+    // SAFETY: `subclass` was built with this window's own class as its
+    // superclass, so it adds one method and changes no instance layout.
+    unsafe { AnyObject::set_class(object, subclass) };
 }
 
-/// Take the window out of the Dock before hiding it.
+/// Build the subclass that overrides `miniaturize:`.
 ///
-/// `orderOut:` on a still-miniaturized window leaves it miniaturized, and tao's
-/// `set_focus` is a no-op while `isMiniaturized()` holds -- so the next
-/// "Show LeapMux" would produce an unfocused window behind whatever the user
-/// moved on to. Deminiaturizing first, in the same run-loop turn, is what makes
-/// the restore path work.
-pub(crate) fn prepare_hide(window: &WebviewWindow) {
-    let _ = window.unminimize();
+/// `superclass` is the class the window carries right now, which is tao's, so
+/// the subclass inherits every override tao installed.
+fn build_subclass(superclass: &AnyClass) -> Option<&'static AnyClass> {
+    let mut builder = ClassBuilder::new(SUBCLASS_NAME, superclass)?;
+    // SAFETY: the function has the shape `-[NSWindow miniaturize:]` is called
+    // with -- an object receiver, the selector, one object argument, and no
+    // return value.
+    //
+    // The argument types are placeholders on purpose. Spelling the receiver
+    // `&AnyObject` makes the cast a `for<'a>` function pointer, and
+    // `MethodImplementation` is implemented for one specific lifetime, so the
+    // named form fails to compile with "not general enough".
+    unsafe {
+        builder.add_method(sel!(miniaturize:), miniaturize as extern "C-unwind" fn(_, _, _));
+    }
+    Some(builder.register())
+}
+
+/// `-[NSWindow miniaturize:]` on the main window.
+///
+/// `super` runs for every answer except "hide": the preference keeps the window
+/// in the Dock, the tray failed to build, or -- impossible, because `install`
+/// publishes the hook before it sets the class -- the hook is absent. Each of
+/// those means the ordinary minimize, which is the safe direction, because the
+/// user keeps a window they can reach.
+extern "C-unwind" fn miniaturize(this: &AnyObject, _cmd: Sel, sender: *mut AnyObject) {
+    if hide_instead_of_minimizing() {
+        return;
+    }
+    let Some(superclass) = subclass_superclass() else {
+        return;
+    };
+    // SAFETY: `superclass` is the class the window carried before `install`
+    // replaced it, and `miniaturize:` takes one object and returns nothing.
+    let _: () = unsafe { msg_send![super(this, superclass), miniaturize: sender] };
+}
+
+/// Hide the main window if the live policy turns a minimize into a hide.
+///
+/// Returns whether it hid, which is what decides `super`.
+fn hide_instead_of_minimizing() -> bool {
+    let Some(hook) = HOOK.get() else {
+        return false;
+    };
+    let Some(window) = hook.app.get_webview_window("main") else {
+        return false;
+    };
+    super::handle_minimize(&hook.state, &window)
+}
+
+/// The class the main window carried before `install` replaced it.
+///
+/// Looked up through the SUBCLASS by name, never through the receiver's own
+/// class. A KVO observer on the window makes that receiver's class a further
+/// subclass of this one, and `this.class().superclass()` would then answer the
+/// subclass itself and send `miniaturize:` straight back into this module.
+fn subclass_superclass() -> Option<&'static AnyClass> {
+    AnyClass::get(SUBCLASS_NAME)?.superclass()
+}
+
+#[cfg(test)]
+mod tests {
+    use objc2::runtime::{AnyClass, ClassBuilder, NSObject};
+    use objc2::sel;
+
+    use super::{build_subclass, subclass_superclass, SUBCLASS_NAME};
+
+    // The class surgery `install` performs, on a plain `NSObject` rather than
+    // the main window: the Objective-C runtime is available in any process, and
+    // a window server is not. It pins what the compiler cannot.
+    //
+    // ONE test for the whole contract, because a class name registers once per
+    // process. Split across several, the assertions would race for the single
+    // registration that any one of them can make.
+    #[test]
+    fn the_subclass_registers_once_and_answers_super_through_its_own_name() {
+        let object = NSObject::new();
+        let superclass = object.class();
+
+        // The build. The subclass registers, it carries the override, and the
+        // class the window arrived with stays its superclass, so tao's own
+        // overrides survive.
+        let subclass = build_subclass(superclass).expect("the runtime must accept the subclass");
+        assert_eq!(subclass.name(), SUBCLASS_NAME);
+        assert!(
+            subclass.instance_method(sel!(miniaturize:)).is_some(),
+            "the override must be on the subclass"
+        );
+        assert_eq!(
+            subclass.superclass().map(AnyClass::name),
+            Some(superclass.name()),
+            "the window's own class must stay the superclass"
+        );
+
+        // A second build must REFUSE. `install` sets the class only when the
+        // build succeeds, so a name that silently produced a second class would
+        // let a repeat install make the subclass its own superclass.
+        assert!(build_subclass(superclass).is_none());
+
+        // The `super` target, which the override sends `miniaturize:` to.
+        assert_eq!(
+            subclass_superclass().map(AnyClass::name),
+            Some(superclass.name())
+        );
+
+        // The recursion guard. A KVO observer on the window replaces that
+        // window's class with a further subclass of this one, so the RECEIVER's
+        // superclass becomes the subclass itself -- and an override that read
+        // its super target there would send `miniaturize:` back into itself
+        // until the stack ran out. The stand-in below has the shape KVO's
+        // generated class has, under a name only this test owns.
+        let receiver_class = ClassBuilder::new(c"LeapMuxMainWindowTestObserver", subclass)
+            .expect("the stand-in for a KVO subclass must register")
+            .register();
+
+        // The two lookups now part company, which is the whole reason this
+        // module resolves `super` through the registered NAME.
+        assert_eq!(
+            receiver_class.superclass().map(AnyClass::name),
+            Some(SUBCLASS_NAME),
+            "reading the super target off the receiver would recurse"
+        );
+        assert_eq!(
+            subclass_superclass().map(AnyClass::name),
+            Some(superclass.name()),
+            "reading it off the name reaches the class the window arrived with"
+        );
+        assert_ne!(
+            subclass_superclass().map(AnyClass::name),
+            receiver_class.superclass().map(AnyClass::name)
+        );
+    }
 }

--- a/desktop/rust/src/tray/minimize_macos.rs
+++ b/desktop/rust/src/tray/minimize_macos.rs
@@ -1,45 +1,52 @@
 //! macOS: turn a minimize REQUEST into a hide, before AppKit performs it.
 //!
-//! Every way a window can be miniaturized reaches `-[NSWindow miniaturize:]`.
-//! The yellow traffic light's action IS that selector, with the window as its
-//! target. `performMiniaturize:` -- Cmd+M, the Window menu's Minimize item and
-//! a title-bar double click -- calls it in turn. And tauri's own
-//! `Window::minimize` calls it directly. So one override covers every
-//! affordance, where intercepting a single one would leave the others
-//! disobeying the preference.
+//! Every affordance that LeapMux offers reaches `-[NSWindow miniaturize:]`. The
+//! yellow traffic light's action IS that selector, with the window as its
+//! target, for a plain click and for an Option-click alike.
+//! `performMiniaturize:` -- Cmd+M, the Window menu's Minimize item and a
+//! title-bar double click -- calls it in turn. And tauri's own
+//! `Window::minimize` calls it directly. So one override covers them all. An
+//! override on a single affordance would leave the others disobeying the
+//! preference.
+//!
+//! `-[NSApplication miniaturizeAll:]` is the measured exception. It
+//! miniaturizes the window without the selector, so the override does not see
+//! it. LeapMux builds no menu item that sends it, and the yellow button does
+//! not send it either. So no affordance of this application reaches that path.
 //!
 //! An override, and not an `NSWindowDidMiniaturizeNotification` observer,
-//! because a miniaturize CANNOT be undone once AppKit performs it. There is no
+//! because nothing can undo a miniaturize once AppKit performs it. There is no
 //! `windowShouldMiniaturize:`, and the notification arrives when the window is
 //! already miniaturized. Neither way out of that state works:
 //!
 //!   * `deminiaturize:` puts the window back ON SCREEN, every time. It is
-//!     asynchronous, so it does nothing in the turn that calls it and finishes
-//!     after the `orderOut:` on the next line -- which restores the window the
-//!     shell just hid. Ordering the window out first does not help either: it
-//!     re-shows a window that is already off the screen list.
+//!     asynchronous, so it does nothing in the turn that calls it. It finishes
+//!     after the `orderOut:` on the next line, and restores the window that the
+//!     shell just hid. An `orderOut:` first does not help either: it re-shows a
+//!     window that is already off the screen list.
 //!   * `orderOut:` alone leaves the window miniaturized, and the Dock tile
 //!     follows `isMiniaturized` rather than the screen list. The window
-//!     disappears and its tile stays in the Dock, which is the state the
+//!     disappears and its tile stays in the Dock, which is the state that the
 //!     preference exists to prevent.
 //!
 //! So the window must never enter the miniaturized state at all. The override
-//! hides it instead of calling `super`, which leaves it off screen and NOT
+//! hides the window and skips `super`, which leaves it off screen and NOT
 //! miniaturized: no Dock tile, and no minimize animation to undo.
 //!
-//! The subclass is built at RUNTIME and set on the one main window, so tao's
-//! own window class stays the superclass and keeps its overrides. Swizzling
-//! `-[NSWindow miniaturize:]` on that class instead would divert every other
-//! window in the process too, and would then need a check on the receiver to
-//! exclude them again.
+//! `install` builds the subclass at RUNTIME and sets it on the one main
+//! window, so tao's own window class stays the superclass and keeps its
+//! overrides. A swizzle of `-[NSWindow miniaturize:]` on `NSWindow` itself
+//! would divert every window in the process, including the panels that AppKit
+//! opens, and would then need a check on the receiver to exclude them again.
 
 use std::ffi::CStr;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::ptr::NonNull;
 use std::sync::{Arc, OnceLock};
 
 use objc2::runtime::{AnyClass, AnyObject, ClassBuilder, Sel};
 use objc2::{msg_send, sel};
-use tauri::{AppHandle, Manager, WebviewWindow};
+use tauri::WebviewWindow;
 
 use super::TrayState;
 
@@ -48,195 +55,405 @@ use super::TrayState;
 /// the product prefix.
 const SUBCLASS_NAME: &CStr = c"LeapMuxMainWindow";
 
+/// The prefix that Key-Value Observing (KVO) gives to the class it generates.
+/// See the diagnostic in `install`.
+const KVO_CLASS_PREFIX: &[u8] = b"NSKVONotifying_";
+
 /// What the override needs to answer a minimize.
 ///
-/// A process global, because what it describes is one. The shell has one main
-/// window, and `objc_allocateClassPair` refuses a name that is already
-/// registered, so the subclass exists at most once.
+/// A process global, because what it describes is one. `build_subclass`
+/// answers `None` for a second install, so at most one window in the process
+/// ever carries the override, and the fields below always describe THAT
+/// window.
 struct MinimizeHook {
-    state: Arc<TrayState>,
-    app: AppHandle,
+    /// The class that the window carried before `install` replaced it, which
+    /// is the target of `super`.
+    ///
+    /// Recorded here, never read off the receiver. A KVO observer on the window
+    /// makes the receiver's class a further subclass of this module's own, and
+    /// `this.class().superclass()` would then answer that subclass and send
+    /// `miniaturize:` straight back into this module.
+    superclass: &'static AnyClass,
+    /// Answers one minimize on the window that `install` hooked. Reports
+    /// whether it hid that window.
+    ///
+    /// A closure over the `WebviewWindow` and the `TrayState` that `install`
+    /// received, so the override acts on the window it was given and looks
+    /// none up by label. It is also the seam that the tests drive: a
+    /// `WebviewWindow` needs a running application, and a stub answer does not.
+    answer: Box<dyn Fn() -> bool + Send + Sync>,
 }
 
 static HOOK: OnceLock<MinimizeHook> = OnceLock::new();
 
 /// Install the minimize override on the main window.
 ///
-/// Each branch below logs before it returns. Without the override a minimize
-/// keeps its ordinary behaviour, which looks like "LeapMux ignores my setting",
-/// and a silent return leaves the user nothing to report it with.
+/// Each branch below writes a message before it returns. Without the override
+/// a minimize keeps its ordinary behaviour. That looks like "LeapMux ignores my
+/// setting", and a silent return leaves the user nothing to report it with.
+///
+/// Standard error, and not the `BehaviorRefusal` channel that a failed tray
+/// icon and a refused login item use. That channel exists for a failure the
+/// MACHINE causes, which varies per user and needs the message on the
+/// Preferences row. Every branch here is impossible by construction instead:
+/// `tauri.conf.json` declares one window, `tray::install` calls this once for
+/// the process, and no test spends the class name. And the fallback strands
+/// nobody, because the ordinary minimize leaves a window in the Dock.
 pub(crate) fn install(window: &WebviewWindow, state: Arc<TrayState>) {
     let Ok(ns_window) = window.ns_window() else {
-        eprintln!("leapmux-desktop: the main window has no NSWindow; a minimize cannot hide it");
+        crate::shell_log!("the main window has no NSWindow; a minimize cannot hide it");
         return;
     };
     let Some(object) = NonNull::new(ns_window.cast::<AnyObject>()) else {
-        eprintln!("leapmux-desktop: the main window's NSWindow is null; a minimize cannot hide it");
+        crate::shell_log!("the main window's NSWindow is null; a minimize cannot hide it");
         return;
     };
     // SAFETY: `ns_window` is the live NSWindow that tauri owns and keeps for
     // the length of the process, and `install` runs on the main thread, where
     // every call below belongs.
     let object = unsafe { object.as_ref() };
+    let superclass = object.class();
 
-    // The hook is published BEFORE the class changes. The override reads it, so
-    // a window that carries the subclass must never find it missing.
-    if HOOK
-        .set(MinimizeHook {
-            state,
-            app: window.app_handle().clone(),
-        })
-        .is_err()
-    {
-        // Already installed. Setting the class a second time would make the
-        // subclass its own superclass.
-        eprintln!("leapmux-desktop: the minimize override is already installed");
-        return;
+    // `AnyObject::class` is `object_getClass`, so it answers the LIVE class. A
+    // KVO observer that AppKit added before this point makes that class a
+    // generated subclass. The runtime then restores the original class when the
+    // last observer goes away, and takes this override with it.
+    //
+    // This reports the condition and installs anyway. No first-party code
+    // observes a key path on the NSWindow, the override works until that
+    // restore, and a message is the only way anybody finds the cause afterwards.
+    if superclass.name().to_bytes().starts_with(KVO_CLASS_PREFIX) {
+        crate::shell_log!(
+            "the main window is under Key-Value Observing as {}; \
+             a minimize stops hiding it if that observer goes away",
+            superclass.name().to_string_lossy()
+        );
     }
-    let Some(subclass) = build_subclass(object.class()) else {
-        eprintln!(
-            "leapmux-desktop: the runtime refused the {} class; a minimize cannot hide the window",
+
+    let Some(subclass) = build_subclass(SUBCLASS_NAME, superclass) else {
+        // The name is taken, so either `install` ran twice or another bundle
+        // registered it. Either way this window keeps the ordinary minimize.
+        crate::shell_log!(
+            "the {} class already exists; a minimize cannot hide the window",
             SUBCLASS_NAME.to_string_lossy()
         );
         return;
     };
-    // SAFETY: `subclass` was built with this window's own class as its
-    // superclass, so it adds one method and changes no instance layout.
-    unsafe { AnyObject::set_class(object, subclass) };
+    // `install` publishes the hook BEFORE it changes the class, so a window
+    // that carries the subclass never finds the hook missing.
+    let window = window.clone();
+    if HOOK
+        .set(MinimizeHook {
+            superclass,
+            answer: Box::new(move || super::handle_minimize(&state, &window)),
+        })
+        .is_err()
+    {
+        // Impossible: `build_subclass` answers `None` for a second install, so
+        // a second call returns above. The arm stays, because `OnceLock::set`
+        // reports a `Result` that nothing else can rule out. It returns before
+        // the class changes, so the window keeps the ordinary minimize.
+        crate::shell_log!("a minimize override is already published; this one is dropped");
+        return;
+    }
+    // SAFETY: `build_subclass` built `subclass` with this window's own class as
+    // its superclass and added no instance variable, so the two classes have
+    // the same instance size and the object keeps its layout.
+    let replaced = unsafe { AnyObject::set_class(object, subclass) };
+    if !std::ptr::eq(replaced, superclass) {
+        // objc2 asks the caller to check what `set_class` replaced. A different
+        // class here means that something swizzled the window between the read
+        // above and this line. `super` then points at the class that the other
+        // party expected to keep.
+        crate::shell_log!(
+            "the main window changed class to {} during install; \
+             a minimize may not hide it",
+            replaced.name().to_string_lossy()
+        );
+    }
 }
 
 /// Build the subclass that overrides `miniaturize:`.
 ///
-/// `superclass` is the class the window carries right now, which is tao's, so
-/// the subclass inherits every override tao installed.
-fn build_subclass(superclass: &AnyClass) -> Option<&'static AnyClass> {
-    let mut builder = ClassBuilder::new(SUBCLASS_NAME, superclass)?;
-    // SAFETY: the function has the shape `-[NSWindow miniaturize:]` is called
-    // with -- an object receiver, the selector, one object argument, and no
-    // return value.
+/// `superclass` is the class that the window carries right now, which is tao's,
+/// so the subclass inherits every override that tao installed.
+///
+/// `name` is `SUBCLASS_NAME` in the shell. Each test passes its own name,
+/// because `objc_registerClassPair` cannot be undone and a name registers once
+/// for the whole process.
+///
+/// Answers `None` when the runtime refuses the name, which includes a second
+/// install. That refusal is what keeps one window, and one only, carrying the
+/// override.
+fn build_subclass(name: &CStr, superclass: &AnyClass) -> Option<&'static AnyClass> {
+    let mut builder = ClassBuilder::new(name, superclass)?;
+    // SAFETY: the function has the shape that `-[NSWindow miniaturize:]` is
+    // called with -- an object receiver, the selector, one object argument, and
+    // no return value. `the_override_matches_the_signature_of_nswindow_miniaturize`
+    // compares the registered encoding against AppKit's own, because objc2
+    // cannot: wry turns on `objc2/disable-encoding-assertions`, and cargo
+    // unifies that feature onto the one objc2 build that this crate links, so
+    // `add_method` checks the argument COUNT and nothing else.
     //
-    // The argument types are placeholders on purpose. Spelling the receiver
+    // The argument types are placeholders on purpose. The receiver spelled
     // `&AnyObject` makes the cast a `for<'a>` function pointer, and
     // `MethodImplementation` is implemented for one specific lifetime, so the
     // named form fails to compile with "not general enough".
     unsafe {
-        builder.add_method(sel!(miniaturize:), miniaturize as extern "C-unwind" fn(_, _, _));
+        builder.add_method(
+            sel!(miniaturize:),
+            miniaturize as extern "C-unwind" fn(_, _, _),
+        );
     }
     Some(builder.register())
 }
 
 /// `-[NSWindow miniaturize:]` on the main window.
 ///
-/// `super` runs for every answer except "hide": the preference keeps the window
-/// in the Dock, the tray failed to build, or -- impossible, because `install`
-/// publishes the hook before it sets the class -- the hook is absent. Each of
-/// those means the ordinary minimize, which is the safe direction, because the
-/// user keeps a window they can reach.
+/// `super` runs for every answer except "hide". The preference keeps the window
+/// in the Dock, the tray failed to build, or the answer itself failed. Each one
+/// means the ordinary minimize, which is the safe direction, because the user
+/// keeps a window they can reach.
+///
+/// The answer runs inside `catch_unwind`, because a panic that unwinds into the
+/// AppKit frame that sent `miniaturize:` skips every Objective-C cleanup on the
+/// way out, and reports a stack with no LeapMux frame in it. tao installs the
+/// same barrier at each of its own callbacks (`stop_app_on_panic`). A panic
+/// reads as "not hidden", so the ordinary minimize proceeds.
 extern "C-unwind" fn miniaturize(this: &AnyObject, _cmd: Sel, sender: *mut AnyObject) {
-    if hide_instead_of_minimizing() {
+    let hook = HOOK.get();
+    let hidden = hook.is_some_and(|hook| {
+        catch_unwind(AssertUnwindSafe(|| (hook.answer)())).unwrap_or_else(|_| {
+            crate::shell_log!("the minimize policy panicked; the window minimizes as usual");
+            false
+        })
+    });
+    if hidden {
         return;
     }
-    let Some(superclass) = subclass_superclass() else {
+    // The hook holds the class that `install` replaced. `install` publishes the
+    // hook before it changes the class, so no window can carry this override
+    // without one -- but a missing hook must still reach `super`, and the
+    // registered subclass knows the same class by name.
+    let Some(superclass) = hook
+        .map(|hook| hook.superclass)
+        .or_else(|| AnyClass::get(SUBCLASS_NAME).and_then(AnyClass::superclass))
+    else {
         return;
     };
-    // SAFETY: `superclass` is the class the window carried before `install`
-    // replaced it, and `miniaturize:` takes one object and returns nothing.
+    // SAFETY: `superclass` is the class that the window carried before
+    // `install` replaced it, and `miniaturize:` takes one object and returns
+    // nothing.
     let _: () = unsafe { msg_send![super(this, superclass), miniaturize: sender] };
-}
-
-/// Hide the main window if the live policy turns a minimize into a hide.
-///
-/// Returns whether it hid, which is what decides `super`.
-fn hide_instead_of_minimizing() -> bool {
-    let Some(hook) = HOOK.get() else {
-        return false;
-    };
-    let Some(window) = hook.app.get_webview_window("main") else {
-        return false;
-    };
-    super::handle_minimize(&hook.state, &window)
-}
-
-/// The class the main window carried before `install` replaced it.
-///
-/// Looked up through the SUBCLASS by name, never through the receiver's own
-/// class. A KVO observer on the window makes that receiver's class a further
-/// subclass of this one, and `this.class().superclass()` would then answer the
-/// subclass itself and send `miniaturize:` straight back into this module.
-fn subclass_superclass() -> Option<&'static AnyClass> {
-    AnyClass::get(SUBCLASS_NAME)?.superclass()
 }
 
 #[cfg(test)]
 mod tests {
-    use objc2::runtime::{AnyClass, ClassBuilder, NSObject};
-    use objc2::sel;
+    use std::ffi::CStr;
+    use std::ptr;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
-    use super::{build_subclass, subclass_superclass, SUBCLASS_NAME};
+    use objc2::rc::Retained;
+    use objc2::runtime::{AnyClass, AnyObject, ClassBuilder, NSObject, Sel};
+    use objc2::{msg_send, sel, ClassType};
 
-    // The class surgery `install` performs, on a plain `NSObject` rather than
-    // the main window: the Objective-C runtime is available in any process, and
-    // a window server is not. It pins what the compiler cannot.
-    //
-    // ONE test for the whole contract, because a class name registers once per
-    // process. Split across several, the assertions would race for the single
-    // registration that any one of them can make.
+    use super::{build_subclass, MinimizeHook, HOOK, SUBCLASS_NAME};
+
+    /// How many times a stand-in superclass answered `miniaturize:`.
+    static SUPER_CALLS: AtomicUsize = AtomicUsize::new(0);
+    /// What the stub hook answers for the next `miniaturize:`.
+    static HOOK_HIDES: AtomicBool = AtomicBool::new(false);
+    /// Whether the stub hook panics instead of answering.
+    static HOOK_PANICS: AtomicBool = AtomicBool::new(false);
+
+    extern "C-unwind" fn count_miniaturize(_this: &AnyObject, _cmd: Sel, _sender: *mut AnyObject) {
+        SUPER_CALLS.fetch_add(1, Ordering::SeqCst);
+    }
+
+    /// A stand-in for tao's window class: it answers `miniaturize:` and counts.
+    ///
+    /// Rooted at `NSObject` rather than `NSWindow`, so a test can create an
+    /// instance of a subclass without a window server.
+    fn stub_window_class(name: &CStr) -> &'static AnyClass {
+        let mut builder =
+            ClassBuilder::new(name, NSObject::class()).expect("the stand-in class must register");
+        // SAFETY: the same shape as the override under test.
+        unsafe {
+            builder.add_method(
+                sel!(miniaturize:),
+                count_miniaturize as extern "C-unwind" fn(_, _, _),
+            );
+        }
+        builder.register()
+    }
+
+    /// Whether `class` defines `miniaturize:` ITSELF.
+    ///
+    /// `instance_method` is `class_getInstanceMethod`, which searches the
+    /// superclasses too. Every superclass in this module answers
+    /// `miniaturize:`, so that call reports `Some` for a subclass that adds
+    /// nothing at all. `instance_methods` is `class_copyMethodList`, which
+    /// lists the class's own methods alone.
+    fn defines_miniaturize(class: &AnyClass) -> bool {
+        class
+            .instance_methods()
+            .iter()
+            .any(|method| method.name() == sel!(miniaturize:))
+    }
+
+    // The class that `install` builds: it registers, it carries the override,
+    // and the class that the window arrived with stays its superclass, so tao's
+    // own overrides survive.
     #[test]
-    fn the_subclass_registers_once_and_answers_super_through_its_own_name() {
-        let object = NSObject::new();
-        let superclass = object.class();
+    fn the_subclass_keeps_the_window_class_as_its_superclass() {
+        let superclass = stub_window_class(c"LeapMuxSubclassShapeBase");
+        let subclass = build_subclass(c"LeapMuxSubclassShape", superclass)
+            .expect("the runtime must accept the subclass");
 
-        // The build. The subclass registers, it carries the override, and the
-        // class the window arrived with stays its superclass, so tao's own
-        // overrides survive.
-        let subclass = build_subclass(superclass).expect("the runtime must accept the subclass");
-        assert_eq!(subclass.name(), SUBCLASS_NAME);
+        assert_eq!(subclass.name().to_bytes(), b"LeapMuxSubclassShape");
         assert!(
-            subclass.instance_method(sel!(miniaturize:)).is_some(),
-            "the override must be on the subclass"
+            defines_miniaturize(subclass),
+            "the override must be on the subclass and not inherited"
         );
         assert_eq!(
             subclass.superclass().map(AnyClass::name),
             Some(superclass.name()),
             "the window's own class must stay the superclass"
         );
+    }
 
-        // A second build must REFUSE. `install` sets the class only when the
-        // build succeeds, so a name that silently produced a second class would
-        // let a repeat install make the subclass its own superclass.
-        assert!(build_subclass(superclass).is_none());
+    // A second build under the same name must REFUSE. `install` sets the class
+    // only when the build succeeds, so a name that silently produced a second
+    // class would let a repeat install make the subclass its own superclass --
+    // and would let a second window carry the override, which every field of
+    // `MinimizeHook` assumes cannot happen.
+    #[test]
+    fn a_second_build_under_the_same_name_is_refused() {
+        let superclass = stub_window_class(c"LeapMuxSecondBuildBase");
+        assert!(build_subclass(c"LeapMuxSecondBuild", superclass).is_some());
+        assert!(build_subclass(c"LeapMuxSecondBuild", superclass).is_none());
+    }
 
-        // The `super` target, which the override sends `miniaturize:` to.
+    // The Objective-C signature of the override, against AppKit's own.
+    //
+    // objc2 verifies this itself, but not here: wry turns on
+    // `objc2/disable-encoding-assertions`, and cargo unifies that feature onto
+    // the one objc2 build that this crate links, so `add_method` checks the
+    // argument COUNT alone. A changed argument type or return type would
+    // register a method whose encoding contradicts the way AppKit calls it, and
+    // the first real minimize would read its arguments from the wrong place.
+    //
+    // `NSWindow` resolves in any process that links AppKit, and the test
+    // creates no window, so this needs no window server.
+    #[test]
+    fn the_override_matches_the_signature_of_nswindow_miniaturize() {
+        let nswindow = AnyClass::get(c"NSWindow").expect("AppKit must register NSWindow");
+        let appkit = nswindow
+            .instance_method(sel!(miniaturize:))
+            .expect("NSWindow must answer miniaturize:");
+        let subclass = build_subclass(c"LeapMuxSignatureShape", nswindow)
+            .expect("the runtime must accept the subclass");
+        assert!(
+            defines_miniaturize(subclass),
+            "without its own method the comparison below reads NSWindow twice"
+        );
+        let ours = subclass
+            .instance_method(sel!(miniaturize:))
+            .expect("the override must be on the subclass");
+
         assert_eq!(
-            subclass_superclass().map(AnyClass::name),
-            Some(superclass.name())
-        );
-
-        // The recursion guard. A KVO observer on the window replaces that
-        // window's class with a further subclass of this one, so the RECEIVER's
-        // superclass becomes the subclass itself -- and an override that read
-        // its super target there would send `miniaturize:` back into itself
-        // until the stack ran out. The stand-in below has the shape KVO's
-        // generated class has, under a name only this test owns.
-        let receiver_class = ClassBuilder::new(c"LeapMuxMainWindowTestObserver", subclass)
-            .expect("the stand-in for a KVO subclass must register")
-            .register();
-
-        // The two lookups now part company, which is the whole reason this
-        // module resolves `super` through the registered NAME.
-        assert_eq!(
-            receiver_class.superclass().map(AnyClass::name),
-            Some(SUBCLASS_NAME),
-            "reading the super target off the receiver would recurse"
+            ours.return_type().to_bytes(),
+            appkit.return_type().to_bytes(),
+            "the override must return what AppKit returns"
         );
         assert_eq!(
-            subclass_superclass().map(AnyClass::name),
-            Some(superclass.name()),
-            "reading it off the name reaches the class the window arrived with"
+            ours.arguments_count(),
+            appkit.arguments_count(),
+            "the override must take the arguments AppKit passes"
         );
-        assert_ne!(
-            subclass_superclass().map(AnyClass::name),
-            receiver_class.superclass().map(AnyClass::name)
-        );
+        for index in 0..appkit.arguments_count() {
+            assert_eq!(
+                ours.argument_type(index).map(|ty| ty.to_bytes().to_vec()),
+                appkit.argument_type(index).map(|ty| ty.to_bytes().to_vec()),
+                "argument {index} must carry AppKit's encoding"
+            );
+        }
+    }
+
+    // The whole dispatch, end to end: the Objective-C runtime calls the
+    // override, the override reads the live answer, and `super` runs for every
+    // answer except "hide". It also pins the barrier that keeps a panic out of
+    // the AppKit frame that sent `miniaturize:`.
+    //
+    // ONE test, because `HOOK` publishes once for the process. It drives every
+    // answer through the two statics that the stub `answer` reads on each call,
+    // the way the real one reads `TrayState`.
+    #[test]
+    fn the_override_calls_super_unless_the_answer_hides_the_window() {
+        let superclass = stub_window_class(c"LeapMuxDispatchBase");
+        let subclass = build_subclass(c"LeapMuxDispatch", superclass)
+            .expect("the runtime must accept the subclass");
+        HOOK.set(MinimizeHook {
+            superclass,
+            answer: Box::new(|| {
+                assert!(
+                    !HOOK_PANICS.load(Ordering::SeqCst),
+                    "the minimize policy failed"
+                );
+                HOOK_HIDES.load(Ordering::SeqCst)
+            }),
+        })
+        .unwrap_or_else(|_| panic!("only this test publishes the hook"));
+        // SAFETY: `subclass` descends from `NSObject`, which answers `new`.
+        let window: Retained<AnyObject> = unsafe { msg_send![subclass, new] };
+        let minimize = || {
+            // SAFETY: the receiver carries the override, and `miniaturize:`
+            // takes one object and returns nothing.
+            let _: () = unsafe { msg_send![&*window, miniaturize: ptr::null_mut::<AnyObject>()] };
+            SUPER_CALLS.load(Ordering::SeqCst)
+        };
+
+        // "Keep in the Dock": the ordinary minimize must proceed.
+        HOOK_HIDES.store(false, Ordering::SeqCst);
+        assert_eq!(minimize(), 1, "super must run when the answer does not hide");
+
+        // "Hide to the menu bar": the window must never reach `super`, or it
+        // enters the miniaturized state that this module exists to prevent.
+        HOOK_HIDES.store(true, Ordering::SeqCst);
+        assert_eq!(minimize(), 1, "super must not run when the answer hides");
+
+        // And back, because the override reads the answer on every click. A
+        // preference that the user changes mid-session must reach the next
+        // minimize.
+        HOOK_HIDES.store(false, Ordering::SeqCst);
+        assert_eq!(minimize(), 2, "the answer is read on every call");
+
+        // A panic must stop at the override. Without `catch_unwind` it unwinds
+        // through the Objective-C frames that dispatched the selector, and this
+        // assertion never runs.
+        //
+        // The panic report is left alone on purpose. `std::panic::set_hook` is
+        // process-global, and `cargo test` runs this file beside ninety other
+        // tests on a thread pool, so a silencing hook would swallow a real
+        // failure in one of them. libtest captures the expected report instead,
+        // and prints it only when THIS test fails.
+        HOOK_PANICS.store(true, Ordering::SeqCst);
+        let calls = minimize();
+        HOOK_PANICS.store(false, Ordering::SeqCst);
+        assert_eq!(calls, 3, "a panic must leave the ordinary minimize alone");
+    }
+
+    // No test may register the name that `install` passes: `install` reaches
+    // `set_class` only when the build succeeds, so a test that spent the name
+    // would disable the override for the whole process.
+    //
+    // The guard is one-directional. `objc_registerClassPair` cannot be undone
+    // and libtest fixes no order, so an offending test is caught only on the
+    // runs where this one starts first. Each test above therefore also names
+    // its own class, which is what makes the collision impossible rather than
+    // merely detected.
+    #[test]
+    fn no_test_spends_the_class_name_that_the_shell_installs_under() {
+        assert!(AnyClass::get(SUBCLASS_NAME).is_none());
     }
 }

--- a/desktop/rust/src/tray/minimize_windows.rs
+++ b/desktop/rust/src/tray/minimize_windows.rs
@@ -31,7 +31,7 @@ pub(crate) fn on_resized(window: &Window) {
     let Some(state) = app.try_state::<Arc<TrayState>>() else {
         return;
     };
-    let Some(webview) = app.get_webview_window("main") else {
+    let Some(webview) = app.get_webview_window(crate::MAIN_WINDOW_LABEL) else {
         return;
     };
     if webview.is_minimized().unwrap_or(false) {

--- a/desktop/rust/src/tray/minimize_windows.rs
+++ b/desktop/rust/src/tray/minimize_windows.rs
@@ -35,6 +35,8 @@ pub(crate) fn on_resized(window: &Window) {
         return;
     };
     if webview.is_minimized().unwrap_or(false) {
+        // The answer is for macOS, which asks before AppKit acts. Here the
+        // minimize already happened, so there is nothing left to let proceed.
         super::handle_minimize(state.inner(), &webview);
     }
 }

--- a/desktop/rust/src/tray/mod.rs
+++ b/desktop/rust/src/tray/mod.rs
@@ -857,16 +857,18 @@ pub(crate) fn apply_launch_visibility(
 
 /// The policy answer for a minimize, and the hide it may call for.
 ///
-/// The three platform hooks funnel here so the decision is made once.
-pub(crate) fn handle_minimize(state: &TrayState, window: &tauri::WebviewWindow) {
+/// The three platform hooks funnel here so the decision is made once. Linux and
+/// Windows REACT to a minimize the operating system already performed. macOS
+/// INTERCEPTS the request before AppKit performs it, and reads the answer to
+/// decide whether to let the ordinary minimize proceed.
+///
+/// Returns whether the window was hidden.
+pub(crate) fn handle_minimize(state: &TrayState, window: &tauri::WebviewWindow) -> bool {
     if state.window_action(WindowIntent::Minimized) != WindowAction::HideWindow {
-        return;
+        return false;
     }
-    // macOS must leave the miniaturized state before it leaves the screen; see
-    // `minimize_macos::prepare_hide`.
-    #[cfg(target_os = "macos")]
-    minimize_macos::prepare_hide(window);
     let _ = window.hide();
+    true
 }
 
 /// Build the tray from the device cache, decide the launch, and register both
@@ -1020,6 +1022,47 @@ mod tests {
     fn minimize_stays_on_the_taskbar_when_the_tray_is_disabled() {
         let (_, minimize) = actions(false, TrayOnClose::Tray, TrayOnMinimize::Tray);
         assert_eq!(minimize, WindowAction::LeaveMinimized);
+    }
+
+    // The answer the macOS override reads at the moment of the click, from the
+    // LIVE state rather than the free function above. It calls `super` -- the
+    // ordinary minimize -- for every answer except `HideWindow`, so a state
+    // that reports `HideWindow` while no icon exists would hide a window with
+    // nothing to bring it back, and one that reports `LeaveMinimized` after the
+    // user chose the tray would put the window in the Dock they asked to skip.
+    #[test]
+    fn the_live_state_hides_on_minimize_only_with_an_icon_and_the_tray_choice() {
+        let state = TrayState::new();
+        let choose = |tray_enabled: bool, on_minimize: TrayOnMinimize| {
+            state.enabled.store(tray_enabled, Ordering::SeqCst);
+            state.store_policy(&WindowBehavior {
+                tray_enabled,
+                tray_on_minimize: on_minimize,
+                ..WindowBehavior::default()
+            });
+            state.window_action(WindowIntent::Minimized)
+        };
+
+        assert_eq!(choose(true, TrayOnMinimize::Tray), WindowAction::HideWindow);
+
+        // The three answers that must leave the ordinary minimize alone. Each
+        // one reaches `super` on macOS, so the window still goes to the Dock.
+        assert_eq!(
+            choose(true, TrayOnMinimize::Taskbar),
+            WindowAction::LeaveMinimized
+        );
+        assert_eq!(
+            choose(false, TrayOnMinimize::Tray),
+            WindowAction::LeaveMinimized
+        );
+        assert_eq!(
+            choose(false, TrayOnMinimize::Taskbar),
+            WindowAction::LeaveMinimized
+        );
+
+        // And back, because the override reads the state on every click. A
+        // preference the user changes mid-session must reach the next minimize.
+        assert_eq!(choose(true, TrayOnMinimize::Tray), WindowAction::HideWindow);
     }
 
     #[test]

--- a/desktop/rust/src/tray/mod.rs
+++ b/desktop/rust/src/tray/mod.rs
@@ -9,9 +9,10 @@
 //! can decide before the webview exists.
 //!
 //! Everything that DECIDES lives in the pure functions below -- `window_action`,
-//! `must_reveal_window`, `launch_visibility`, `is_autostart_launch` -- so the
-//! policy is unit-testable without an `AppHandle` or a real window. The rest of
-//! this module is the adapter that calls them.
+//! `must_reveal_window`, `launch_visibility`, `reachable_visibility`,
+//! `launch_is_applied`, `is_autostart_launch` -- so the policy is unit-testable
+//! without an `AppHandle` or a real window. The rest of this module is the
+//! adapter that calls them.
 
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::{Arc, Mutex};
@@ -373,13 +374,50 @@ pub(crate) fn must_reveal_window(
 /// `launch_visibility` already applies this rule when it decides; the startup
 /// safety net applies it again, because the tray can fail to build between the
 /// decision and the deadline.
-pub(crate) fn reachable_visibility(
-    visibility: LaunchVisibility,
-    tray_enabled: bool,
-) -> LaunchVisibility {
+fn reachable_visibility(visibility: LaunchVisibility, tray_enabled: bool) -> LaunchVisibility {
     match visibility {
         LaunchVisibility::Hidden if !tray_enabled => LaunchVisibility::Normal,
         other => other,
+    }
+}
+
+/// Where the main window sits right now, as the startup safety net reads it.
+///
+/// A struct of NAMED fields rather than two `bool` parameters. The one call
+/// site passes two probes of the same type, and swapped they would compile,
+/// pass every test, and make the net raise a window that is already up.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct WindowPlacement {
+    visible: bool,
+    minimized: bool,
+}
+
+/// Whether the window already sits where `visibility` asks, so the startup
+/// safety net has nothing to repair.
+///
+/// A miniaturized macOS window reports `is_visible() == false`. So a bare
+/// visibility probe read a `Minimized` launch as a frontend that never ran, and
+/// the net showed the window and minimized it again. That raised it in front of
+/// the user five seconds into a login they asked to start out of the way. On
+/// macOS the second minimize also runs through the live policy, so a tray icon
+/// that the first push created hid the window instead.
+///
+/// Windows and Linux report an ordinary minimized window as VISIBLE, so they
+/// never reached that fault. They do reach one state that changes here. A
+/// window can be both hidden and minimized on both platforms, because `SW_HIDE`
+/// leaves `WS_MINIMIZE` set and tao's Linux flag survives a hide. The net now
+/// leaves that window alone too.
+///
+/// A probe that fails reads as NOT applied, and the net applies the launch
+/// again. That direction costs one raised window, and the other one costs an
+/// application that the user cannot see. `Hidden` needs no repair, because
+/// `apply_launch_visibility` performs nothing for it, and `reachable_visibility`
+/// already downgraded a launch that no tray icon can undo.
+fn launch_is_applied(visibility: LaunchVisibility, placement: WindowPlacement) -> bool {
+    match visibility {
+        LaunchVisibility::Normal => placement.visible,
+        LaunchVisibility::Minimized => placement.visible || placement.minimized,
+        LaunchVisibility::Hidden => true,
     }
 }
 
@@ -569,6 +607,17 @@ pub(crate) struct TrayState {
     enabled: AtomicBool,
     on_close: AtomicU8,
     on_minimize: AtomicU8,
+    /// Whether the policy hid the window since the process started.
+    ///
+    /// The startup safety net exists for a frontend that never ran, and it
+    /// reads "no window on screen" as that failure. A close or a minimize that
+    /// went to the tray produces the same observation for the opposite reason,
+    /// so the net must leave it alone -- otherwise a user who reaches the tray
+    /// inside the five-second deadline watches the window come straight back.
+    ///
+    /// Only the two policy hides set it, and nothing clears it: once the user
+    /// put the window away, they own it for the rest of the session.
+    hid_to_tray: AtomicBool,
     /// Built at most once and never dropped; visibility is toggled instead.
     icon: Mutex<Option<TrayIcon<tauri::Wry>>>,
     /// Serializes `set_desktop_behavior`. Tauri gives each invocation its own
@@ -589,6 +638,7 @@ impl TrayState {
             enabled: AtomicBool::new(false),
             on_close: AtomicU8::new(defaults.tray_on_close.code()),
             on_minimize: AtomicU8::new(defaults.tray_on_minimize.code()),
+            hid_to_tray: AtomicBool::new(false),
             icon: Mutex::new(None),
             push_lock: tokio::sync::Mutex::new(()),
         }
@@ -597,6 +647,16 @@ impl TrayState {
     /// Whether an icon exists right now.
     pub(crate) fn is_enabled(&self) -> bool {
         self.enabled.load(Ordering::SeqCst)
+    }
+
+    /// Record that the policy put the window in the tray. See `hid_to_tray`.
+    pub(crate) fn record_hide_to_tray(&self) {
+        self.hid_to_tray.store(true, Ordering::SeqCst);
+    }
+
+    /// Whether the policy put the window in the tray at any point.
+    fn hid_to_tray(&self) -> bool {
+        self.hid_to_tray.load(Ordering::SeqCst)
     }
 
     fn on_close(&self) -> TrayOnClose {
@@ -784,7 +844,7 @@ fn build_tray(app: &AppHandle) -> Result<TrayIcon<tauri::Wry>, String> {
 pub(crate) fn show_main_window(app: &AppHandle) {
     let handle = app.clone();
     let _ = app.run_on_main_thread(move || {
-        let Some(window) = handle.get_webview_window("main") else {
+        let Some(window) = handle.get_webview_window(crate::MAIN_WINDOW_LABEL) else {
             return;
         };
         let _ = window.unminimize();
@@ -818,7 +878,7 @@ pub(crate) fn apply_launch_visibility(
     visibility: LaunchVisibility,
     geometry: Option<&proto::DesktopConfig>,
 ) {
-    let Some(window) = app.get_webview_window("main") else {
+    let Some(window) = app.get_webview_window(crate::MAIN_WINDOW_LABEL) else {
         return;
     };
     // No geometry means the safety net, which repairs the visibility alone and
@@ -857,17 +917,31 @@ pub(crate) fn apply_launch_visibility(
 
 /// The policy answer for a minimize, and the hide it may call for.
 ///
-/// The three platform hooks funnel here so the decision is made once. Linux and
-/// Windows REACT to a minimize the operating system already performed. macOS
-/// INTERCEPTS the request before AppKit performs it, and reads the answer to
-/// decide whether to let the ordinary minimize proceed.
+/// The three platform hooks funnel here, so this function makes the decision
+/// once. Linux and Windows REACT to a minimize that the operating system
+/// already performed. macOS INTERCEPTS the request before AppKit performs it,
+/// and reads the answer to decide whether to let the ordinary minimize proceed.
 ///
-/// Returns whether the window was hidden.
+/// Reports whether it hid the window.
 pub(crate) fn handle_minimize(state: &TrayState, window: &tauri::WebviewWindow) -> bool {
+    minimize_hides(state, || {
+        state.record_hide_to_tray();
+        let _ = window.hide();
+    })
+}
+
+/// `handle_minimize` with the hide injected.
+///
+/// A test supplies a closure, so both halves stay pinned: the answer that the
+/// macOS override reads to decide `super`, and the hide that the answer stands
+/// for. Tauri's mock runtime pins neither, because its `hide` does nothing and
+/// its `is_visible` always reports `true`. `handle_minimize` therefore keeps no
+/// branch of its own. It holds the one call that no unit test can reach.
+fn minimize_hides(state: &TrayState, hide: impl FnOnce()) -> bool {
     if state.window_action(WindowIntent::Minimized) != WindowAction::HideWindow {
         return false;
     }
-    let _ = window.hide();
+    hide();
     true
 }
 
@@ -889,11 +963,11 @@ pub(crate) fn install(
         // A tray that cannot be created is not a launch failure. The policy
         // records the effective state, so nothing will hide a window the user
         // could not get back.
-        eprintln!("leapmux-desktop: {err}");
+        crate::shell_log!("{err}");
     }
 
     let visibility = launch_visibility(autostart_launch, behavior.start_minimized, state.is_enabled());
-    if let Some(window) = app.get_webview_window("main") {
+    if let Some(window) = app.get_webview_window(crate::MAIN_WINDOW_LABEL) {
         install_minimize_hook(&window, state.clone());
     }
     app.manage(state);
@@ -929,15 +1003,9 @@ pub(crate) const STARTUP_REVEAL_DEADLINE: std::time::Duration =
 pub(crate) fn spawn_startup_safety_net(handle: AppHandle, autostart_launch: bool) {
     std::thread::spawn(move || {
         std::thread::sleep(STARTUP_REVEAL_DEADLINE);
-        let Some(window) = handle.get_webview_window("main") else {
+        let Some(window) = handle.get_webview_window(crate::MAIN_WINDOW_LABEL) else {
             return;
         };
-        // The frontend did its job, so the net has nothing to repair. A probe
-        // that fails reads as NOT visible, which reveals: that direction costs
-        // a raised window, and the other one costs an app the user cannot see.
-        if window.is_visible().unwrap_or(false) {
-            return;
-        }
         let visibility = match handle.try_state::<Arc<LaunchState>>() {
             Some(launch) => launch.peek(),
             // `setup` has not decided yet, so this fires while a blocking call
@@ -948,15 +1016,30 @@ pub(crate) fn spawn_startup_safety_net(handle: AppHandle, autostart_launch: bool
             None if autostart_launch => return,
             None => LaunchVisibility::Normal,
         };
-        let tray_enabled = handle
-            .try_state::<Arc<TrayState>>()
-            .is_some_and(|tray| tray.is_enabled());
-        apply_launch_visibility(&handle, reachable_visibility(visibility, tray_enabled), None);
+        let tray = handle.try_state::<Arc<TrayState>>();
+        // The user reached the tray inside the deadline, so the missing window
+        // is their choice and not the failure this net repairs.
+        if tray.as_ref().is_some_and(|tray| tray.hid_to_tray()) {
+            return;
+        }
+        let tray_enabled = tray.is_some_and(|tray| tray.is_enabled());
+        let visibility = reachable_visibility(visibility, tray_enabled);
+        // The launch already arrived where it asked for, so the net has nothing
+        // to repair. This asks about the DECIDED state and not about
+        // visibility alone; see `launch_is_applied`.
+        let placement = WindowPlacement {
+            visible: window.is_visible().unwrap_or(false),
+            minimized: window.is_minimized().unwrap_or(false),
+        };
+        if launch_is_applied(visibility, placement) {
+            return;
+        }
+        apply_launch_visibility(&handle, visibility, None);
     });
 }
 
 /// Install the platform's minimize hook on the main window.
-pub(crate) fn install_minimize_hook(window: &tauri::WebviewWindow, state: Arc<TrayState>) {
+fn install_minimize_hook(window: &tauri::WebviewWindow, state: Arc<TrayState>) {
     #[cfg(target_os = "linux")]
     minimize_linux::install(window, state);
     #[cfg(target_os = "macos")]
@@ -1025,44 +1108,59 @@ mod tests {
     }
 
     // The answer the macOS override reads at the moment of the click, from the
-    // LIVE state rather than the free function above. It calls `super` -- the
-    // ordinary minimize -- for every answer except `HideWindow`, so a state
-    // that reports `HideWindow` while no icon exists would hide a window with
-    // nothing to bring it back, and one that reports `LeaveMinimized` after the
-    // user chose the tray would put the window in the Dock they asked to skip.
+    // LIVE state rather than the free function above, together with the hide
+    // that the answer stands for. The override calls `super` -- the ordinary
+    // minimize -- for every answer except `HideWindow`, so a state that reports
+    // `HideWindow` while no icon exists would hide a window with nothing to
+    // bring it back, and one that reports `LeaveMinimized` after the user chose
+    // the tray would put the window in the Dock they asked to skip.
+    //
+    // The second and third tuple fields are what no other test reaches. An
+    // inverted answer in `minimize_hides` flips the second. A hide that moves
+    // out of the `HideWindow` branch flips the third. Every assertion over
+    // `window_action` alone passes through both mistakes.
     #[test]
     fn the_live_state_hides_on_minimize_only_with_an_icon_and_the_tray_choice() {
         let state = TrayState::new();
         let choose = |tray_enabled: bool, on_minimize: TrayOnMinimize| {
             state.enabled.store(tray_enabled, Ordering::SeqCst);
+            // `store_policy` writes the two choices and nothing else, so the
+            // icon's presence is the separate store above.
             state.store_policy(&WindowBehavior {
-                tray_enabled,
                 tray_on_minimize: on_minimize,
                 ..WindowBehavior::default()
             });
-            state.window_action(WindowIntent::Minimized)
+            let mut hid = false;
+            let answer = state.window_action(WindowIntent::Minimized);
+            (answer, minimize_hides(&state, || hid = true), hid)
         };
 
-        assert_eq!(choose(true, TrayOnMinimize::Tray), WindowAction::HideWindow);
+        assert_eq!(
+            choose(true, TrayOnMinimize::Tray),
+            (WindowAction::HideWindow, true, true)
+        );
 
         // The three answers that must leave the ordinary minimize alone. Each
         // one reaches `super` on macOS, so the window still goes to the Dock.
         assert_eq!(
             choose(true, TrayOnMinimize::Taskbar),
-            WindowAction::LeaveMinimized
+            (WindowAction::LeaveMinimized, false, false)
         );
         assert_eq!(
             choose(false, TrayOnMinimize::Tray),
-            WindowAction::LeaveMinimized
+            (WindowAction::LeaveMinimized, false, false)
         );
         assert_eq!(
             choose(false, TrayOnMinimize::Taskbar),
-            WindowAction::LeaveMinimized
+            (WindowAction::LeaveMinimized, false, false)
         );
 
         // And back, because the override reads the state on every click. A
         // preference the user changes mid-session must reach the next minimize.
-        assert_eq!(choose(true, TrayOnMinimize::Tray), WindowAction::HideWindow);
+        assert_eq!(
+            choose(true, TrayOnMinimize::Tray),
+            (WindowAction::HideWindow, true, true)
+        );
     }
 
     #[test]
@@ -1114,6 +1212,98 @@ mod tests {
                 assert_eq!(reachable_visibility(launch, tray), launch);
             }
         }
+    }
+
+    fn placement(visible: bool, minimized: bool) -> WindowPlacement {
+        WindowPlacement { visible, minimized }
+    }
+
+    // The case the safety net used to get wrong. A miniaturized macOS window
+    // reports `is_visible() == false`, so a bare visibility probe read a
+    // `Minimized` launch as a frontend that never ran, and the net raised the
+    // window in front of the user and minimized it again five seconds into a
+    // login they asked to start out of the way.
+    #[test]
+    fn a_minimized_launch_that_reached_the_dock_needs_no_repair() {
+        assert!(launch_is_applied(
+            LaunchVisibility::Minimized,
+            placement(false, true)
+        ));
+    }
+
+    #[test]
+    fn a_launch_that_left_no_window_anywhere_needs_repair() {
+        assert!(!launch_is_applied(
+            LaunchVisibility::Minimized,
+            placement(false, false)
+        ));
+        assert!(!launch_is_applied(
+            LaunchVisibility::Normal,
+            placement(false, false)
+        ));
+        // A minimized window is not a `Normal` launch either: the frontend
+        // never showed it, and the net owes the user the window they asked for.
+        assert!(!launch_is_applied(
+            LaunchVisibility::Normal,
+            placement(false, true)
+        ));
+    }
+
+    #[test]
+    fn a_visible_window_satisfies_every_launch() {
+        for launch in [
+            LaunchVisibility::Normal,
+            LaunchVisibility::Minimized,
+            LaunchVisibility::Hidden,
+        ] {
+            assert!(
+                launch_is_applied(launch, placement(true, false)),
+                "{launch:?} must leave a visible window alone"
+            );
+        }
+    }
+
+    // `Hidden` survives `reachable_visibility` only with a tray icon to come
+    // back from, and `apply_launch_visibility` performs nothing for it, so the
+    // net must never touch that window whatever the probes report.
+    #[test]
+    fn a_hidden_launch_never_asks_the_net_for_anything() {
+        for visible in [true, false] {
+            for minimized in [true, false] {
+                assert!(launch_is_applied(
+                    LaunchVisibility::Hidden,
+                    placement(visible, minimized)
+                ));
+            }
+        }
+    }
+
+    // The other reason a window can be off screen inside the deadline: the user
+    // reached the tray. The net must leave that window alone, or it comes
+    // straight back and the preference reads as broken.
+    #[test]
+    fn a_hide_to_the_tray_is_recorded_for_the_startup_safety_net() {
+        let state = TrayState::new();
+        assert!(!state.hid_to_tray(), "a fresh state hid nothing");
+
+        // The choice that leaves the ordinary minimize alone records nothing.
+        state.enabled.store(true, Ordering::SeqCst);
+        state.store_policy(&WindowBehavior {
+            tray_on_minimize: TrayOnMinimize::Taskbar,
+            ..WindowBehavior::default()
+        });
+        assert!(!minimize_hides(&state, || state.record_hide_to_tray()));
+        assert!(!state.hid_to_tray());
+
+        // The choice that hides records it, and nothing clears it afterwards.
+        state.store_policy(&WindowBehavior {
+            tray_on_minimize: TrayOnMinimize::Tray,
+            ..WindowBehavior::default()
+        });
+        assert!(minimize_hides(&state, || state.record_hide_to_tray()));
+        assert!(state.hid_to_tray());
+        state.enabled.store(false, Ordering::SeqCst);
+        assert!(state.hid_to_tray(), "the user still owns the window");
     }
 
     // The stale-cache repair, which `must_reveal_window` consumes. The launch

--- a/site/content/docs/using/settings.md
+++ b/site/content/docs/using/settings.md
@@ -188,8 +188,6 @@ What LeapMux does when you close the last window: **Hide to the tray** (**Hide t
 
 What LeapMux does when you minimize a window: **Hide to the tray**, or **Keep in the taskbar**. On macOS the two options read **Hide to the menu bar** and **Keep in the Dock**. The built-in default keeps it in the taskbar.
 
-On macOS the window plays its minimize animation into the Dock before the tile disappears. macOS gives an application no way to intercept a minimize before it happens. Every Mac app with this feature shows the same behaviour.
-
 ### Start at login
 
 Registers LeapMux with your operating system's login items, so it starts when you sign in to the computer. Off by default. Some systems ask you to approve the login item the first time. A system that declines it reports so on this row.


### PR DESCRIPTION
## Motivation

Before this branch, macOS caught a window minimize only after AppKit had
already performed it: an `NSWindowDidMiniaturizeNotification` observer fired,
and the code then tried to reverse the effect with `deminiaturize:` +
`orderOut:`. That is racy and visible. `deminiaturize:` is asynchronous, so
the `orderOut:` on the next line ran against a window that was still
miniaturized; the deminiaturize then finished and put the window back on
screen. `orderOut:` alone did not work either, because the Dock tile follows
`isMiniaturized` rather than the screen list, so the window disappeared while
its tile stayed in the Dock. The user documentation stated the limitation: it
said that macOS gives an application no way to intercept a minimize before it
happens, and that the window therefore always animates into the Dock first.

That approach also interacted badly with the pre-existing login-launch safety
net. `-[NSWindow isVisible]` is false for a miniaturized window, so the net
always misread a `Minimized` login launch as a frontend that never started,
raised the window five seconds in, and minimized it again. Intercepting the
minimize changes what that second minimize does: it now runs through the live
tray preference, so with a tray icon enabled it hides the window instead of
returning it to the Dock. The net needed a real answer, not only the minimize
path.

## Modifications

- Replaced the observer with a runtime Objective-C subclass of the main
  window's `NSWindow` class (through `objc2`'s `ClassBuilder`) that overrides
  `-[NSWindow miniaturize:]`. The override runs before AppKit enters the
  miniaturized state: it hides the window and skips `super` when the
  preference says "hide to the menu bar", and otherwise forwards to `super`,
  resolved from the class that `install` replaced rather than from the
  receiver's live class, so a Key-Value Observing subclass installed later
  cannot make `super` call back into this module. The answer runs inside
  `catch_unwind`, because a panic that unwinds into the AppKit frame which
  sent `miniaturize:` skips every Objective-C cleanup on the way out and
  reports a stack with no LeapMux frame in it. A panic now reads as "not
  hidden" and the ordinary minimize proceeds.
- Dropped the `objc2-app-kit`, `objc2-foundation` and `block2` direct
  dependencies that the observer needed. The override needs only `objc2`.
- `handle_minimize` now returns `bool` (whether it hid the window), because
  macOS reads that answer to decide whether to let the ordinary minimize
  proceed. Linux and Windows still react to a minimize the operating system
  already performed, and ignore it. The shared decision moved into a
  `minimize_hides` helper that takes the hide as an injected closure, so a
  test pins both halves without a real window.
- Repaired the startup safety net. A named `WindowPlacement { visible,
  minimized }` and a pure `launch_is_applied(visibility, placement)` replace
  the bare visibility probe, so a miniaturized window satisfies a `Minimized`
  launch. `TrayState` also records a policy hide (`hid_to_tray`), which the
  net reads first, so a close or a minimize that reaches the tray inside the
  five-second deadline is no longer undone.
- Added a `RunEvent::Reopen` arm (macOS only) that routes a Dock-icon click
  on an application with no visible window into the existing
  `tray::show_main_window`. AppKit performs no default action for a window
  that `orderOut:` took off the screen list, so the Dock icon was inert once
  the window reached the tray. macOS sends this event for a re-open and never
  for the first launch, so a login launch that asked to start hidden stays
  hidden.
- Added `MAIN_WINDOW_LABEL` in place of twelve bare `"main"` window-label
  literals, so a typo at a call site is a compile error rather than a lookup
  that never matches.
- Added a `shell_log!` macro, used from `tray/`, `file_save.rs` and
  `sidecar.rs`, in place of four different stderr spellings. One `grep` now
  finds every diagnostic the shell writes. `sidecar.rs` keeps one deliberate
  exception, with a comment: the thread that forwards the sidecar's own
  stderr keeps the distinct `desktop-sidecar:` prefix, because those lines
  are another program's output.
- Deleted the documentation paragraph in `site/content/docs/using/settings.md`
  that the new implementation makes false.
- Added tests: the subclass keeps the window's own class as its superclass; a
  second build under the same name is refused, which is what keeps at most one
  window carrying the override; the registered method's Objective-C encoding
  is compared field by field against `NSWindow`'s real `miniaturize:`, which
  is necessary because `wry` turns on `objc2/disable-encoding-assertions` and
  objc2 therefore checks only the argument count; and an end-to-end dispatch
  test drives a stub subclass through the real Objective-C runtime to pin that
  `super` runs for every answer except "hide", that the preference is read on
  every click, and that a panic still leaves the ordinary minimize alone. Each
  one was verified to fail against the broken code it covers.

## Result

- A minimize with **Hide to the menu bar** no longer animates into the Dock
  first. The window never enters the miniaturized state, so there is no Dock
  tile and no animation to undo.
- A click on the Dock icon brings a hidden window back, where it previously
  did nothing.
- A login launch that starts minimized no longer flies out of the Dock and
  back five seconds later, and a window put in the menu bar within those five
  seconds stays there.
- `-[NSApplication miniaturizeAll:]` still bypasses the override. No LeapMux
  affordance sends it: there is no "Minimize All" menu item, and an
  Option-click on the yellow traffic light reaches `miniaturize:` and is
  intercepted. The module documentation names the exception.
