### PR TITLE
feat(agent): Start new Codex sessions on the account default model

### DIFF
--- a/backend/internal/worker/agent/catalog.go
+++ b/backend/internal/worker/agent/catalog.go
@@ -26,6 +26,25 @@ type ModelInfo struct {
 	Hidden bool
 }
 
+// accountDefaultModelEntry builds the leading catalog entry that means "let the
+// CLI pick the account's own default model". A provider whose CLI resolves the
+// model itself puts this first in its static catalog, and DefaultModel then
+// returns the sentinel for a new agent of that provider.
+//
+// The entry carries no efforts and no context window on purpose. The effort menu
+// appears once the concrete model is known, which keeps a fresh launch from
+// forwarding an effort the resolved model may not offer. One helper for every
+// provider makes that omission impossible to lose: a caller states the wording of
+// the description and nothing else.
+func accountDefaultModelEntry(description string) *ModelInfo {
+	return &ModelInfo{
+		Id:          DefaultModelSentinel,
+		DisplayName: "Default (recommended)",
+		Description: description,
+		IsDefault:   true,
+	}
+}
+
 func (m *ModelInfo) GetId() string {
 	if m == nil {
 		return ""

--- a/backend/internal/worker/agent/catalog_test.go
+++ b/backend/internal/worker/agent/catalog_test.go
@@ -1,0 +1,38 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAccountDefaultModelEntry pins the shape every provider's account-default
+// row must have. The absent SupportedEfforts is load-bearing, not an oversight:
+// effortGroupForModel returns nil on an empty effort list, which is what hides
+// the effort menu until the CLI resolves a concrete model -- and that in turn is
+// what keeps a fresh launch from forwarding an effort the resolved model may not
+// offer. One helper makes that omission impossible for a new provider to lose.
+func TestAccountDefaultModelEntry(t *testing.T) {
+	t.Parallel()
+
+	entry := accountDefaultModelEntry("Use the account's default model")
+
+	assert.Equal(t, DefaultModelSentinel, entry.Id)
+	assert.Equal(t, "Default (recommended)", entry.DisplayName, "every provider shows one label")
+	assert.Equal(t, "Use the account's default model", entry.Description)
+	assert.True(t, entry.IsDefault, "a new tab starts on the account default")
+	assert.Empty(t, entry.SupportedEfforts, "the effort menu appears only once the model resolves")
+	assert.Zero(t, entry.ContextWindow, "an unresolved model has no context window to report")
+	assert.False(t, entry.Hidden, "the account default must be selectable")
+
+	// Both providers that carry the sentinel go through the helper, so the row
+	// cannot drift between them.
+	for _, catalog := range [][]*ModelInfo{codexDefaultModels, claudeCodeAvailableModels} {
+		row := FindAvailableModel(catalog, DefaultModelSentinel)
+		require.NotNil(t, row)
+		assert.Equal(t, "Default (recommended)", row.DisplayName)
+		assert.Empty(t, row.SupportedEfforts)
+		assert.Zero(t, row.ContextWindow)
+	}
+}

--- a/backend/internal/worker/agent/claude.go
+++ b/backend/internal/worker/agent/claude.go
@@ -1542,14 +1542,13 @@ const (
 // any account, including non-Opus tiers) starts on it, and buildModelEffortArgs
 // omits --model so the CLI resolves it to that account's concrete default --
 // which get_settings then reports back, so the tab settles on the real model
-// after startup. It carries no efforts: the effort menu appears once the
-// concrete model is known, which also keeps a fresh launch from forwarding an
-// --effort the resolved model may not support. The concrete models follow in
+// after startup. accountDefaultModelEntry states why it carries no efforts.
+// The concrete models follow in
 // most→least powerful order, matching Claude Code's own ordering ("Fable for the
 // hardest problems, Opus for complex work, Sonnet for most tasks, Haiku for
 // quick questions").
 var claudeCodeAvailableModels = []*ModelInfo{
-	{Id: DefaultModelSentinel, DisplayName: "Default (recommended)", Description: "Use your account's default model", IsDefault: true},
+	accountDefaultModelEntry("Use your account's default model"),
 	// Fable 5 is 1M-context only; its canonical id carries the [1m] marker so it
 	// matches the live CLI's "claude-fable-5[1m]" (normalizeClaudeCodeModel
 	// collapses every Fable spelling, bare "fable" included, to "fable[1m]"). The

--- a/backend/internal/worker/agent/codex.go
+++ b/backend/internal/worker/agent/codex.go
@@ -839,17 +839,17 @@ func codexEffortValue(effort string) (string, bool) {
 	return effort, true
 }
 
-// codexThreadParams builds the request params shared by thread/start and thread/resume,
-// so the launch (StartCodex) and clear-context (ClearContext) paths construct the thread
-// the same way and a new thread field is added once. The serviceTier field is included
-// only when codexServiceTierValue reports a non-default tier. StartCodex appends threadId
-// itself for the resume case.
+// codexThreadParams builds the params shared by thread/start and thread/resume.
+// It omits an account-default model so Codex can resolve it. It includes a concrete
+// model so a resumed thread keeps its effective or user-selected model.
 func codexThreadParams(model, cwd, approvalPolicy, sandboxPolicy, serviceTier string) map[string]interface{} {
 	params := map[string]interface{}{
-		"model":          model,
 		"cwd":            cwd,
 		"approvalPolicy": approvalPolicy,
 		"sandbox":        sandboxPolicy,
+	}
+	if !UsesAccountDefaultModel(model) {
+		params["model"] = model
 	}
 	if st := codexServiceTierValue(serviceTier); st != nil {
 		params["serviceTier"] = *st
@@ -1112,30 +1112,14 @@ func (a *CodexAgent) queryAvailableModels(timeout time.Duration) []*ModelInfo {
 	return models
 }
 
-// Default Codex efforts (auto first, then strongest → weakest) used as
-// static fallback. "auto" is a LeapMux-side sentinel: the CLI never reports
-// or accepts it, but selecting it causes LeapMux to omit reasoning_effort
-// so Codex applies its own default.
-//
-// The slice order IS the menu order: optionGroupsForAgent maps it into the
-// option group unchanged, and the frontend renders the options in order. It is
-// DERIVED from effortLadder rather than written out, so a tier cannot be put in
-// the wrong place: this file states only WHICH tiers Codex offers, and the
-// ladder states what comes before what.
-//
-// Every tier the live CLI reports should appear here, so the static fallback
-// offers the same menu the running session does. A tier that is absent is no
-// longer a labeling hazard: both paths resolve their label through effortLabel,
-// so an unlisted id renders capitalized like its siblings rather than raw.
+// codexDefaultEfforts contains all effort levels in the Codex fallback catalog.
+// The order matches the menu. Each model selects its supported subset below.
 var codexDefaultEfforts = buildCodexDefaultEfforts()
 
-// codexEffortIDs is WHICH levels Codex offers. The ORDER comes from
-// effortLadder, so this states membership only: Codex has no `ultracode` rung
-// and no separate `off`, and listing it here in ladder order would be a second
-// statement of the ordering that a level moved in the ladder could fall behind.
+// codexEffortIDs states membership. effortLadder supplies the order.
 var codexEffortIDs = map[string]bool{
 	"ultra": true, "max": true, EffortXHigh: true, EffortHigh: true,
-	"medium": true, "low": true, "minimal": true, "none": true,
+	"medium": true, "low": true,
 }
 
 func buildCodexDefaultEfforts() []*EffortInfo {
@@ -1143,6 +1127,21 @@ func buildCodexDefaultEfforts() []*EffortInfo {
 	for _, id := range effortLadderIDs() {
 		if codexEffortIDs[id] {
 			efforts = append(efforts, effortTier(id))
+		}
+	}
+	return efforts
+}
+
+// codexSupportedEfforts returns auto followed by the requested levels in menu order.
+func codexSupportedEfforts(ids ...string) []*EffortInfo {
+	selected := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		selected[id] = true
+	}
+	efforts := []*EffortInfo{codexAutoEffort()}
+	for _, effort := range codexDefaultEfforts[1:] {
+		if selected[effort.Id] {
+			efforts = append(efforts, effort)
 		}
 	}
 	return efforts
@@ -1159,14 +1158,24 @@ func codexAutoEffort() *EffortInfo {
 	}
 }
 
+var (
+	codexEffortsWithUltra = codexSupportedEfforts("ultra", "max", EffortXHigh, EffortHigh, "medium", "low")
+	codexEffortsWithMax   = codexSupportedEfforts("max", EffortXHigh, EffortHigh, "medium", "low")
+	codexEffortsToXHigh   = codexSupportedEfforts(EffortXHigh, EffortHigh, "medium", "low")
+)
+
+// codexDefaultModels contains the general model catalog from Codex 0.152.1.
+// model/list supplies account-specific models, such as Daybreak, at runtime.
 var codexDefaultModels = []*ModelInfo{
-	{Id: "gpt-5.4", DisplayName: "GPT-5.4", Description: "Latest frontier agentic coding model", IsDefault: true, DefaultEffort: "high", SupportedEfforts: codexDefaultEfforts, ContextWindow: 1_050_000},
-	{Id: "gpt-5.4-mini", DisplayName: "GPT-5.4 Mini", Description: "Smaller frontier agentic coding model", DefaultEffort: "high", SupportedEfforts: codexDefaultEfforts, ContextWindow: 400_000},
-	{Id: "gpt-5.3-codex", DisplayName: "GPT-5.3 Codex", Description: "Frontier Codex-optimized agentic coding model", DefaultEffort: "high", SupportedEfforts: codexDefaultEfforts, ContextWindow: 400_000},
-	{Id: "gpt-5.2-codex", DisplayName: "GPT-5.2 Codex", Description: "Frontier agentic coding model", DefaultEffort: "high", SupportedEfforts: codexDefaultEfforts, ContextWindow: 400_000},
-	{Id: "gpt-5.2", DisplayName: "GPT-5.2", Description: "Optimized for professional work and long-running agents", DefaultEffort: "high", SupportedEfforts: codexDefaultEfforts, ContextWindow: 256_000},
-	{Id: "gpt-5.1-codex-max", DisplayName: "GPT-5.1 Codex Max", Description: "Codex-optimized model for deep and fast reasoning", DefaultEffort: "high", SupportedEfforts: codexDefaultEfforts, ContextWindow: 400_000},
-	{Id: "gpt-5.1-codex-mini", DisplayName: "GPT-5.1 Codex Mini", Description: "Optimized for Codex; cheaper, faster, but less capable", DefaultEffort: "high", SupportedEfforts: codexDefaultEfforts, ContextWindow: 400_000},
+	{Id: DefaultModelSentinel, DisplayName: "Default (recommended)", Description: "Use the account's default Codex model", IsDefault: true},
+	{Id: "gpt-5.6-sol", DisplayName: "GPT-5.6-Sol", Description: "Reliable agentic workhorse for everyday tasks.", DefaultEffort: "low", SupportedEfforts: codexEffortsWithUltra, ContextWindow: 1_050_000},
+	{Id: "gpt-5.6-terra", DisplayName: "GPT-5.6-Terra", Description: "Balanced agentic coding model for everyday work.", DefaultEffort: "medium", SupportedEfforts: codexEffortsWithUltra, ContextWindow: 1_050_000},
+	{Id: "gpt-5.6-luna", DisplayName: "GPT-5.6-Luna", Description: "Fast and affordable agentic coding model.", DefaultEffort: "medium", SupportedEfforts: codexEffortsWithMax, ContextWindow: 1_050_000},
+	{Id: "gpt-5.5", DisplayName: "GPT-5.5", Description: "Proven previous-generation model for coding and general work.", DefaultEffort: "medium", SupportedEfforts: codexEffortsToXHigh, ContextWindow: 1_050_000},
+	{Id: "gpt-5.4", DisplayName: "GPT-5.4", Description: "Strong model for everyday coding.", DefaultEffort: "medium", SupportedEfforts: codexEffortsToXHigh, ContextWindow: 1_050_000},
+	{Id: "gpt-5.4-mini", DisplayName: "GPT-5.4-Mini", Description: "Small, fast, and cost-efficient model for simpler coding tasks.", DefaultEffort: "medium", SupportedEfforts: codexEffortsToXHigh, ContextWindow: 400_000},
+	{Id: "gpt-5.3-codex-spark", DisplayName: "GPT-5.3-Codex-Spark", Description: "Ultra-fast coding model.", DefaultEffort: "high", SupportedEfforts: codexEffortsToXHigh, ContextWindow: 128_000},
+	{Id: "gpt-5.2", DisplayName: "GPT-5.2", Description: "Optimized for professional work and long-running agents.", DefaultEffort: "medium", SupportedEfforts: codexEffortsToXHigh, ContextWindow: 400_000},
 }
 
 // codexBinaryCandidates lists the executable names to probe for Codex, in

--- a/backend/internal/worker/agent/codex.go
+++ b/backend/internal/worker/agent/codex.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 	"time"
 
@@ -256,6 +257,7 @@ func StartCodex(ctx context.Context, opts Options, sink OutputSink) (Agent, erro
 
 	// 5. Query available models (best-effort; don't fail startup if this fails).
 	a.availableModels = a.queryAvailableModels(timeout)
+	a.reconcileModelCatalog()
 
 	// 6. Publish the active thread settings. The lifecycle response owns the
 	// settings that thread/start accepts. Turn-only settings keep their requested
@@ -684,7 +686,7 @@ func (a *CodexAgent) sendTurnStart(
 		"threadId": threadID,
 		"input":    input,
 	}
-	if s.model != "" {
+	if !UsesAccountDefaultModel(s.model) {
 		params["model"] = s.model
 	}
 	if e, ok := codexEffortValue(s.effort); ok {
@@ -817,6 +819,12 @@ func codexCollaborationModeObject(mode, model, effort string) map[string]interfa
 	if e, ok := codexEffortValue(effort); ok {
 		reasoningEffort = e
 	}
+	// settings.model is a required non-empty string: Codex answers an omitted field
+	// with "missing field 'model'", a null with "invalid type: null, expected a
+	// string", and an empty string with the same unknown-model error as any other
+	// unknown id. So this field cannot carry the account-default rule that
+	// codexThreadParams applies. The caller must supply a concrete model, which
+	// UpdateSettings enforces by requiring a relaunch to reach the account default.
 	return map[string]interface{}{
 		"mode": mode,
 		"settings": map[string]interface{}{
@@ -840,8 +848,13 @@ func codexEffortValue(effort string) (string, bool) {
 }
 
 // codexThreadParams builds the params shared by thread/start and thread/resume.
+// StartCodex and ClearContext both call it, so the launch path and the
+// clear-context path construct the thread the same way and a new thread field is
+// added once, here.
+//
 // It omits an account-default model so Codex can resolve it. It includes a concrete
-// model so a resumed thread keeps its effective or user-selected model.
+// model so a resumed thread keeps its effective or user-selected model. It never
+// sets threadId: startOrResumeThread adds that for the resume case.
 func codexThreadParams(model, cwd, approvalPolicy, sandboxPolicy, serviceTier string) map[string]interface{} {
 	params := map[string]interface{}{
 		"cwd":            cwd,
@@ -960,12 +973,25 @@ func (a *CodexAgent) OptionGroups() []*leapmuxv1.AvailableOptionGroup {
 func (a *CodexAgent) UpdateSettings(options optionmap.Map) SettingsApplyResult {
 	a.mu.Lock()
 	curEffort := a.effort
+	curModel := a.model
 	// Switching to EffortAuto can't be done live: Codex's session config
 	// remembers the last reasoning_effort across turns, so simply
 	// omitting the field on the next turn keeps the prior effort
 	// applied. A restart is the only way to hand control back to the
 	// CLI's own default.
 	if IsEffortAutoTransition(options[OptionIDEffort], curEffort) {
+		a.mu.Unlock()
+		return restartRequiredSettings(options)
+	}
+	// Switching to the account default can't be done live either, and for the same
+	// shape of reason as the effort sentinel above. thread/start resolves an omitted
+	// model, but turn/start sends the stored string as it is, and Codex rejects the
+	// literal id "default" ("The 'default' model is not supported"). A relaunch runs
+	// codexThreadParams again, which omits the model and lets Codex resolve it.
+	// Test the sentinel EXACTLY, not UsesAccountDefaultModel: in this map an empty
+	// value means "not supplied" (see the axis loop below), so the wider test would
+	// demand a restart on every edit that leaves the model alone.
+	if m := options[OptionIDModel]; m == DefaultModelSentinel && m != curModel {
 		a.mu.Unlock()
 		return restartRequiredSettings(options)
 	}
@@ -1035,6 +1061,7 @@ func (a *CodexAgent) queryAvailableModels(timeout time.Duration) []*ModelInfo {
 			DisplayName               string `json:"displayName"`
 			IsDefault                 bool   `json:"isDefault"`
 			Hidden                    bool   `json:"hidden"`
+			Description               string `json:"description"`
 			DefaultReasoningEffort    string `json:"defaultReasoningEffort"`
 			SupportedReasoningEfforts []struct {
 				ReasoningEffort string `json:"reasoningEffort"`
@@ -1092,6 +1119,9 @@ func (a *CodexAgent) queryAvailableModels(timeout time.Duration) []*ModelInfo {
 			description = d.Description
 			contextWindow = d.ContextWindow
 		}
+		if description == "" {
+			description = m.Description
+		}
 		if displayName == "" {
 			displayName = m.DisplayName
 		}
@@ -1112,11 +1142,79 @@ func (a *CodexAgent) queryAvailableModels(timeout time.Duration) []*ModelInfo {
 	return models
 }
 
+// reconcileModelCatalog repairs the two gaps between what model/list reports and
+// what the picker must offer. It runs once at startup, after applyThreadResult has
+// settled a.model, and it is the Codex twin of Claude's ensureSettledModelListed.
+//
+// Gap one: model/list never reports the account-default sentinel, unlike the
+// Claude CLI, which lists it itself. Without the row a user who picks a concrete
+// model can never return to "let my account decide" for the life of the tab, and
+// the option would appear before the first launch and then vanish. The sentinel
+// leads the list, matching the static catalog's order.
+//
+// Gap two: the settled model can be one model/list omits -- a model the account
+// retired between the thread resuming and this query, for instance. An unlisted
+// current model leaves the picker with no selected row and no effort menu, so the
+// static catalog's entry is inserted at its canonical slot.
+//
+// No-op on an empty live list: queryAvailableModels failed or the CLI reported
+// nothing, and OptionGroups then falls back to the static catalog, which already
+// carries both the sentinel and every shipped model. Appending here would replace
+// that full fallback with a singleton.
+func (a *CodexAgent) reconcileModelCatalog() {
+	if len(a.availableModels) == 0 {
+		return
+	}
+	if FindAvailableModel(a.availableModels, DefaultModelSentinel) == nil {
+		if sentinel := FindAvailableModel(codexDefaultModels, DefaultModelSentinel); sentinel != nil {
+			a.availableModels = slices.Insert(a.availableModels, 0, sentinel)
+		}
+	}
+	if UsesAccountDefaultModel(a.model) || FindAvailableModel(a.availableModels, a.model) != nil {
+		return
+	}
+	entry := FindAvailableModel(codexDefaultModels, a.model)
+	if entry == nil {
+		return
+	}
+	// Drop the settled model at its slot in the static catalog's order rather than
+	// at the end, so a retired model does not sort below a newer one it outranks.
+	// The inserted pointer is the shared static entry, which every consumer reads
+	// and none mutates -- modelOptionGroup projects it into fresh protos.
+	rank := codexCanonicalModelRank(a.model)
+	insertAt := len(a.availableModels)
+	for i, m := range a.availableModels {
+		if codexCanonicalModelRank(m.GetId()) > rank {
+			insertAt = i
+			break
+		}
+	}
+	a.availableModels = slices.Insert(a.availableModels, insertAt, entry)
+}
+
+// codexCanonicalModelRank returns modelID's index in codexDefaultModels, whose
+// order is the canonical picker order (the sentinel first, then newest to oldest,
+// then the retired models). A model the static catalog omits ranks last, so it
+// sorts after every catalog-known model.
+func codexCanonicalModelRank(modelID string) int {
+	if i := slices.IndexFunc(codexDefaultModels, func(m *ModelInfo) bool {
+		return m.GetId() == modelID
+	}); i >= 0 {
+		return i
+	}
+	return len(codexDefaultModels)
+}
+
 // codexDefaultEfforts contains all effort levels in the Codex fallback catalog.
-// The order matches the menu. Each model selects its supported subset below.
+// The order matches the menu. Each model selects a supported window of it below.
+//
+// Every tier the live CLI reports must appear here, so the static fallback offers
+// the same menu the running session does. codexEffortsDownFrom fails at startup on
+// a tier this list omits, so a forgotten tier cannot shrink a menu in silence.
 var codexDefaultEfforts = buildCodexDefaultEfforts()
 
 // codexEffortIDs states membership. effortLadder supplies the order.
+// Codex offers no `ultracode` rung and no separate `off` level.
 var codexEffortIDs = map[string]bool{
 	"ultra": true, "max": true, EffortXHigh: true, EffortHigh: true,
 	"medium": true, "low": true,
@@ -1132,19 +1230,25 @@ func buildCodexDefaultEfforts() []*EffortInfo {
 	return efforts
 }
 
-// codexSupportedEfforts returns auto followed by the requested levels in menu order.
-func codexSupportedEfforts(ids ...string) []*EffortInfo {
-	selected := make(map[string]bool, len(ids))
-	for _, id := range ids {
-		selected[id] = true
-	}
-	efforts := []*EffortInfo{codexAutoEffort()}
-	for _, effort := range codexDefaultEfforts[1:] {
-		if selected[effort.Id] {
-			efforts = append(efforts, effort)
+// codexEffortsDownFrom returns auto followed by every tier from top down to the
+// weakest one Codex offers. Each model states only its strongest tier, so a menu
+// cannot skip a rung or fall out of ladder order: the window comes from
+// codexDefaultEfforts, which effortLadder already orders.
+//
+// It panics on a tier codexDefaultEfforts omits. Every argument is a literal in
+// this file and codexDefaultEfforts is derived at build time, so no runtime input
+// reaches it -- the panic fires on the first `go test` of this package, never on a
+// running worker. A silent filter instead shortened the menu with no diagnostic.
+func codexEffortsDownFrom(top string) []*EffortInfo {
+	tiers := codexDefaultEfforts[1:]
+	for i, tier := range tiers {
+		if tier.Id == top {
+			// The literal has capacity 1, so append allocates a new array and the
+			// returned slice never aliases codexDefaultEfforts.
+			return append([]*EffortInfo{codexAutoEffort()}, tiers[i:]...)
 		}
 	}
-	return efforts
+	panic("codex: effort tier " + top + " is not in codexDefaultEfforts")
 }
 
 // codexAutoEffort is the LeapMux-side "auto" sentinel. The CLI never reports it,
@@ -1159,23 +1263,37 @@ func codexAutoEffort() *EffortInfo {
 }
 
 var (
-	codexEffortsWithUltra = codexSupportedEfforts("ultra", "max", EffortXHigh, EffortHigh, "medium", "low")
-	codexEffortsWithMax   = codexSupportedEfforts("max", EffortXHigh, EffortHigh, "medium", "low")
-	codexEffortsToXHigh   = codexSupportedEfforts(EffortXHigh, EffortHigh, "medium", "low")
+	codexEffortsFromUltra = codexEffortsDownFrom("ultra")
+	codexEffortsFromMax   = codexEffortsDownFrom("max")
+	codexEffortsFromXHigh = codexEffortsDownFrom(EffortXHigh)
 )
 
-// codexDefaultModels contains the general model catalog from Codex 0.152.1.
-// model/list supplies account-specific models, such as Daybreak, at runtime.
+// codexDefaultModels is the static fallback model catalog. The selectable rows
+// mirror what Codex 0.152.1 reports from model/list, in its order. model/list adds
+// the account-specific models, such as Daybreak, at runtime.
+//
+// A model the current app server no longer lists stays here Hidden rather than
+// leaving the file. queryAvailableModels reads this list for the Description and
+// the ContextWindow that model/list never reports, and modelDependentGroups reads
+// it for a stopped agent, so a session still pinned to a retired model keeps its
+// effort tiers and its context meter. The picker skips a Hidden row; a lookup by
+// id still finds it.
 var codexDefaultModels = []*ModelInfo{
-	{Id: DefaultModelSentinel, DisplayName: "Default (recommended)", Description: "Use the account's default Codex model", IsDefault: true},
-	{Id: "gpt-5.6-sol", DisplayName: "GPT-5.6-Sol", Description: "Reliable agentic workhorse for everyday tasks.", DefaultEffort: "low", SupportedEfforts: codexEffortsWithUltra, ContextWindow: 1_050_000},
-	{Id: "gpt-5.6-terra", DisplayName: "GPT-5.6-Terra", Description: "Balanced agentic coding model for everyday work.", DefaultEffort: "medium", SupportedEfforts: codexEffortsWithUltra, ContextWindow: 1_050_000},
-	{Id: "gpt-5.6-luna", DisplayName: "GPT-5.6-Luna", Description: "Fast and affordable agentic coding model.", DefaultEffort: "medium", SupportedEfforts: codexEffortsWithMax, ContextWindow: 1_050_000},
-	{Id: "gpt-5.5", DisplayName: "GPT-5.5", Description: "Proven previous-generation model for coding and general work.", DefaultEffort: "medium", SupportedEfforts: codexEffortsToXHigh, ContextWindow: 1_050_000},
-	{Id: "gpt-5.4", DisplayName: "GPT-5.4", Description: "Strong model for everyday coding.", DefaultEffort: "medium", SupportedEfforts: codexEffortsToXHigh, ContextWindow: 1_050_000},
-	{Id: "gpt-5.4-mini", DisplayName: "GPT-5.4-Mini", Description: "Small, fast, and cost-efficient model for simpler coding tasks.", DefaultEffort: "medium", SupportedEfforts: codexEffortsToXHigh, ContextWindow: 400_000},
-	{Id: "gpt-5.3-codex-spark", DisplayName: "GPT-5.3-Codex-Spark", Description: "Ultra-fast coding model.", DefaultEffort: "high", SupportedEfforts: codexEffortsToXHigh, ContextWindow: 128_000},
-	{Id: "gpt-5.2", DisplayName: "GPT-5.2", Description: "Optimized for professional work and long-running agents.", DefaultEffort: "medium", SupportedEfforts: codexEffortsToXHigh, ContextWindow: 400_000},
+	accountDefaultModelEntry("Use the account's default Codex model"),
+	{Id: "gpt-5.6-sol", DisplayName: "GPT-5.6-Sol", Description: "Reliable agentic workhorse for everyday tasks", DefaultEffort: "low", SupportedEfforts: codexEffortsFromUltra, ContextWindow: 1_050_000},
+	{Id: "gpt-5.6-terra", DisplayName: "GPT-5.6-Terra", Description: "Balanced agentic coding model for everyday work", DefaultEffort: "medium", SupportedEfforts: codexEffortsFromUltra, ContextWindow: 1_050_000},
+	{Id: "gpt-5.6-luna", DisplayName: "GPT-5.6-Luna", Description: "Fast and affordable agentic coding model", DefaultEffort: "medium", SupportedEfforts: codexEffortsFromMax, ContextWindow: 1_050_000},
+	{Id: "gpt-5.5", DisplayName: "GPT-5.5", Description: "Proven previous-generation model for coding and general work", DefaultEffort: "medium", SupportedEfforts: codexEffortsFromXHigh, ContextWindow: 1_050_000},
+	{Id: "gpt-5.4", DisplayName: "GPT-5.4", Description: "Strong model for everyday coding", DefaultEffort: "medium", SupportedEfforts: codexEffortsFromXHigh, ContextWindow: 1_050_000},
+	{Id: "gpt-5.4-mini", DisplayName: "GPT-5.4-Mini", Description: "Small, fast, and cost-efficient model for simpler coding tasks", DefaultEffort: "medium", SupportedEfforts: codexEffortsFromXHigh, ContextWindow: 400_000},
+	{Id: "gpt-5.3-codex-spark", DisplayName: "GPT-5.3-Codex-Spark", Description: "Ultra-fast coding model", DefaultEffort: "high", SupportedEfforts: codexEffortsFromXHigh, ContextWindow: 128_000},
+	// Retired below: Codex 0.152.1 lists none of these, so they carry their last
+	// known metadata and stay out of the picker.
+	{Id: "gpt-5.2", DisplayName: "GPT-5.2", Description: "Optimized for professional work and long-running agents", DefaultEffort: "high", SupportedEfforts: codexEffortsFromXHigh, ContextWindow: 256_000, Hidden: true},
+	{Id: "gpt-5.3-codex", DisplayName: "GPT-5.3 Codex", Description: "Frontier Codex-optimized agentic coding model", DefaultEffort: "high", SupportedEfforts: codexEffortsFromXHigh, ContextWindow: 400_000, Hidden: true},
+	{Id: "gpt-5.2-codex", DisplayName: "GPT-5.2 Codex", Description: "Frontier agentic coding model", DefaultEffort: "high", SupportedEfforts: codexEffortsFromXHigh, ContextWindow: 400_000, Hidden: true},
+	{Id: "gpt-5.1-codex-max", DisplayName: "GPT-5.1 Codex Max", Description: "Codex-optimized model for deep and fast reasoning", DefaultEffort: "high", SupportedEfforts: codexEffortsFromXHigh, ContextWindow: 400_000, Hidden: true},
+	{Id: "gpt-5.1-codex-mini", DisplayName: "GPT-5.1 Codex Mini", Description: "Optimized for Codex; cheaper, faster, but less capable", DefaultEffort: "high", SupportedEfforts: codexEffortsFromXHigh, ContextWindow: 400_000, Hidden: true},
 }
 
 // codexBinaryCandidates lists the executable names to probe for Codex, in
@@ -1261,7 +1379,11 @@ func init() {
 }
 
 // codexModelDisplayName generates a human-readable display name from a Codex
-// model ID (e.g. "gpt-5.4-mini" → "GPT-5.4 Mini", "o4-mini" → "o4-mini").
+// model ID (e.g. "gpt-4.1-mini" → "GPT-4.1 Mini", "o4-mini" → "o4-mini"). It is
+// the last fallback in queryAvailableModels: codexDefaultModels wins, then the
+// name model/list reports, so this runs only for a model that neither supplies.
+// Do not draw an example from codexDefaultModels -- the catalog spells the
+// current models the way the CLI does ("GPT-5.4-Mini"), which this differs from.
 func codexModelDisplayName(id string) string {
 	prefix := ""
 	rest := id

--- a/backend/internal/worker/agent/codex_resume_test.go
+++ b/backend/internal/worker/agent/codex_resume_test.go
@@ -39,6 +39,42 @@ func TestCodexStartOrResumeThread(t *testing.T) {
 		assert.Equal(t, "thread/resume", sent[0].Method)
 	})
 
+	t.Run("pins concrete models and resolves a leftover default", func(t *testing.T) {
+		for _, test := range []struct {
+			name          string
+			storedModel   string
+			responseModel string
+			wantModel     string
+		}{
+			{name: "resolved account default", storedModel: "gpt-5.6-sol", responseModel: "gpt-5.6-sol", wantModel: "gpt-5.6-sol"},
+			{name: "user selection", storedModel: "gpt-5.6-luna", responseModel: "gpt-5.6-luna", wantModel: "gpt-5.6-luna"},
+			{name: "legacy concrete selection", storedModel: "gpt-5.4", responseModel: "gpt-5.4", wantModel: "gpt-5.4"},
+			{name: "interrupted startup default", storedModel: DefaultModelSentinel, responseModel: "gpt-5.6-sol"},
+		} {
+			t.Run(test.name, func(t *testing.T) {
+				a, _, requests := newCodexAgentForRPC(t, func(string) json.RawMessage {
+					return json.RawMessage(`{"thread":{"id":"thread-old"},"model":"` + test.responseModel + `"}`)
+				})
+				a.model = test.storedModel
+				params := codexThreadParams(test.storedModel, "/work", CodexDefaultApprovalPolicy, CodexDefaultSandboxPolicy, CodexDefaultServiceTier)
+
+				thread, err := a.startOrResumeThread(params, "thread-old", timeout)
+				require.NoError(t, err)
+				a.applyThreadResult(thread)
+
+				sent := requests()
+				require.Len(t, sent, 1)
+				assert.Equal(t, "thread/resume", sent[0].Method)
+				if test.wantModel == "" {
+					assert.NotContains(t, sent[0].Params, "model")
+				} else {
+					assert.Equal(t, test.wantModel, sent[0].Params["model"])
+				}
+				assert.Equal(t, test.responseModel, a.model)
+			})
+		}
+	})
+
 	// An RPC error arrives as a delivered body rather than as a transport error,
 	// so the agent's own message is only in the response. The failure must carry
 	// it: "carried no thread ID" identifies the symptom and hides the reason.

--- a/backend/internal/worker/agent/codex_resume_test.go
+++ b/backend/internal/worker/agent/codex_resume_test.go
@@ -39,38 +39,56 @@ func TestCodexStartOrResumeThread(t *testing.T) {
 		assert.Equal(t, "thread/resume", sent[0].Method)
 	})
 
-	t.Run("pins concrete models and resolves a leftover default", func(t *testing.T) {
+	// codexThreadParams sends a concrete model and omits the account default, and
+	// applyThreadResult then adopts whatever model the response reports. The two
+	// halves are asserted separately: a row whose stored model equals its response
+	// model proves nothing about the second half, so every row here either omits the
+	// model on the wire or reports a DIFFERENT model back.
+	t.Run("pins concrete models and adopts the reported one", func(t *testing.T) {
+		t.Parallel()
+
 		for _, test := range []struct {
-			name          string
-			storedModel   string
+			name string
+			// storedModel is a.model at launch, and what codexThreadParams reads.
+			storedModel string
+			// responseModel is the effective model Codex reports back.
 			responseModel string
-			wantModel     string
+			// wantModelOmitted states the wire shape explicitly, so a row that omits
+			// wantModel cannot assert omission by accident. "model" absent and "model"
+			// present but empty are different requests, and only the first is correct.
+			wantModelOmitted bool
+			// resumeID is empty for the thread/start path.
+			resumeID   string
+			wantMethod string
 		}{
-			{name: "resolved account default", storedModel: "gpt-5.6-sol", responseModel: "gpt-5.6-sol", wantModel: "gpt-5.6-sol"},
-			{name: "user selection", storedModel: "gpt-5.6-luna", responseModel: "gpt-5.6-luna", wantModel: "gpt-5.6-luna"},
-			{name: "legacy concrete selection", storedModel: "gpt-5.4", responseModel: "gpt-5.4", wantModel: "gpt-5.4"},
-			{name: "interrupted startup default", storedModel: DefaultModelSentinel, responseModel: "gpt-5.6-sol"},
+			{name: "user selection is pinned and kept", storedModel: "gpt-5.6-luna", responseModel: "gpt-5.6-luna", resumeID: "thread-old", wantMethod: "thread/resume"},
+			{name: "retired selection is pinned and clamped by codex", storedModel: "gpt-5.2", responseModel: "gpt-5.6-sol", resumeID: "thread-old", wantMethod: "thread/resume"},
+			{name: "interrupted startup default resolves on resume", storedModel: DefaultModelSentinel, responseModel: "gpt-5.6-sol", wantModelOmitted: true, resumeID: "thread-old", wantMethod: "thread/resume"},
+			{name: "new session omits the account default", storedModel: DefaultModelSentinel, responseModel: "gpt-5.6-sol", wantModelOmitted: true, wantMethod: "thread/start"},
+			{name: "new session pins a concrete model", storedModel: "gpt-5.6-terra", responseModel: "gpt-5.6-terra", wantMethod: "thread/start"},
 		} {
 			t.Run(test.name, func(t *testing.T) {
+				t.Parallel()
+
 				a, _, requests := newCodexAgentForRPC(t, func(string) json.RawMessage {
-					return json.RawMessage(`{"thread":{"id":"thread-old"},"model":"` + test.responseModel + `"}`)
+					return json.RawMessage(`{"thread":{"id":"thread-1"},"model":"` + test.responseModel + `"}`)
 				})
 				a.model = test.storedModel
 				params := codexThreadParams(test.storedModel, "/work", CodexDefaultApprovalPolicy, CodexDefaultSandboxPolicy, CodexDefaultServiceTier)
 
-				thread, err := a.startOrResumeThread(params, "thread-old", timeout)
+				thread, err := a.startOrResumeThread(params, test.resumeID, timeout)
 				require.NoError(t, err)
 				a.applyThreadResult(thread)
 
 				sent := requests()
 				require.Len(t, sent, 1)
-				assert.Equal(t, "thread/resume", sent[0].Method)
-				if test.wantModel == "" {
-					assert.NotContains(t, sent[0].Params, "model")
+				assert.Equal(t, test.wantMethod, sent[0].Method)
+				if test.wantModelOmitted {
+					assert.NotContains(t, sent[0].Params, "model", "the account default lets Codex resolve the model")
 				} else {
-					assert.Equal(t, test.wantModel, sent[0].Params["model"])
+					assert.Equal(t, test.storedModel, sent[0].Params["model"], "a concrete model is pinned on the wire")
 				}
-				assert.Equal(t, test.responseModel, a.model)
+				assert.Equal(t, test.responseModel, a.model, "the agent adopts the model the response reports")
 			})
 		}
 	})

--- a/backend/internal/worker/agent/codex_settings_test.go
+++ b/backend/internal/worker/agent/codex_settings_test.go
@@ -7,7 +7,9 @@ import (
 	"os"
 	"sync"
 	"testing"
+	"time"
 
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -254,6 +256,87 @@ func TestCodexUpdateSettings_AutoNoOpWhenAlreadyAuto(t *testing.T) {
 	assert.Equal(t, "auto", agent.effort)
 }
 
+func TestDefaultModel_CodexUsesAccountDefaultSentinel(t *testing.T) {
+	t.Setenv("LEAPMUX_CODEX_DEFAULT_MODEL", "")
+
+	assert.Equal(t, DefaultModelSentinel, DefaultModel(leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX))
+}
+
+func TestDefaultModel_CodexUsesEnvironmentOverride(t *testing.T) {
+	t.Setenv("LEAPMUX_CODEX_DEFAULT_MODEL", "gpt-5.6-terra")
+
+	assert.Equal(t, "gpt-5.6-terra", DefaultModel(leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX))
+}
+
+func TestCodexFallbackCatalogMatchesCurrentAppServer(t *testing.T) {
+	t.Parallel()
+
+	type fallbackModel struct {
+		id            string
+		displayName   string
+		description   string
+		isDefault     bool
+		defaultEffort string
+		efforts       []string
+		contextWindow int64
+	}
+	actual := make([]fallbackModel, 0, len(codexDefaultModels))
+	for _, model := range codexDefaultModels {
+		var efforts []string
+		for _, effort := range model.SupportedEfforts {
+			efforts = append(efforts, effort.Id)
+		}
+		actual = append(actual, fallbackModel{
+			id:            model.Id,
+			displayName:   model.DisplayName,
+			description:   model.Description,
+			isDefault:     model.IsDefault,
+			defaultEffort: model.DefaultEffort,
+			efforts:       efforts,
+			contextWindow: model.ContextWindow,
+		})
+	}
+	assert.Equal(t, []fallbackModel{
+		{id: DefaultModelSentinel, displayName: "Default (recommended)", description: "Use the account's default Codex model", isDefault: true},
+		{id: "gpt-5.6-sol", displayName: "GPT-5.6-Sol", description: "Reliable agentic workhorse for everyday tasks.", defaultEffort: "low", efforts: []string{EffortAuto, "ultra", "max", EffortXHigh, EffortHigh, "medium", "low"}, contextWindow: 1_050_000},
+		{id: "gpt-5.6-terra", displayName: "GPT-5.6-Terra", description: "Balanced agentic coding model for everyday work.", defaultEffort: "medium", efforts: []string{EffortAuto, "ultra", "max", EffortXHigh, EffortHigh, "medium", "low"}, contextWindow: 1_050_000},
+		{id: "gpt-5.6-luna", displayName: "GPT-5.6-Luna", description: "Fast and affordable agentic coding model.", defaultEffort: "medium", efforts: []string{EffortAuto, "max", EffortXHigh, EffortHigh, "medium", "low"}, contextWindow: 1_050_000},
+		{id: "gpt-5.5", displayName: "GPT-5.5", description: "Proven previous-generation model for coding and general work.", defaultEffort: "medium", efforts: []string{EffortAuto, EffortXHigh, EffortHigh, "medium", "low"}, contextWindow: 1_050_000},
+		{id: "gpt-5.4", displayName: "GPT-5.4", description: "Strong model for everyday coding.", defaultEffort: "medium", efforts: []string{EffortAuto, EffortXHigh, EffortHigh, "medium", "low"}, contextWindow: 1_050_000},
+		{id: "gpt-5.4-mini", displayName: "GPT-5.4-Mini", description: "Small, fast, and cost-efficient model for simpler coding tasks.", defaultEffort: "medium", efforts: []string{EffortAuto, EffortXHigh, EffortHigh, "medium", "low"}, contextWindow: 400_000},
+		{id: "gpt-5.3-codex-spark", displayName: "GPT-5.3-Codex-Spark", description: "Ultra-fast coding model.", defaultEffort: "high", efforts: []string{EffortAuto, EffortXHigh, EffortHigh, "medium", "low"}, contextWindow: 128_000},
+		{id: "gpt-5.2", displayName: "GPT-5.2", description: "Optimized for professional work and long-running agents.", defaultEffort: "medium", efforts: []string{EffortAuto, EffortXHigh, EffortHigh, "medium", "low"}, contextWindow: 400_000},
+	}, actual)
+}
+
+func TestCodexQueryAvailableModelsDoesNotInjectAccountDefault(t *testing.T) {
+	t.Parallel()
+
+	agent, _, requests := newCodexAgentForRPC(t, func(string) json.RawMessage {
+		return json.RawMessage(`{"data":[
+			{"id":"gpt-5.6-sol","model":"gpt-5.6-sol","displayName":"gpt-5.6-sol","isDefault":true,"defaultReasoningEffort":"low","supportedReasoningEfforts":[
+				{"reasoningEffort":"low","description":"Low"},
+				{"reasoningEffort":"high","description":"High"}
+			]},
+			{"id":"hidden-model","model":"hidden-model","displayName":"Hidden","hidden":true,"supportedReasoningEfforts":[]}
+		]}`)
+	})
+
+	models := agent.queryAvailableModels(time.Second)
+
+	require.Len(t, models, 1)
+	assert.Equal(t, "gpt-5.6-sol", models[0].Id)
+	assert.Equal(t, "GPT-5.6-Sol", models[0].DisplayName)
+	assert.True(t, models[0].IsDefault)
+	assert.Equal(t, "low", models[0].DefaultEffort)
+	assert.Equal(t, int64(1_050_000), models[0].ContextWindow)
+	assert.Equal(t, []string{EffortAuto, EffortHigh, "low"}, effortIDs(models[0].SupportedEfforts))
+	assert.Nil(t, FindAvailableModel(models, DefaultModelSentinel))
+	sent := requests()
+	require.Len(t, sent, 1)
+	assert.Equal(t, "model/list", sent[0].Method)
+}
+
 // TestCodexThreadParams covers the request params shared by thread/start and thread/resume that
 // StartCodex and ClearContext build identically via codexThreadParams. The model/cwd/approvalPolicy/
 // sandbox axes are stamped verbatim; serviceTier is included ONLY when codexServiceTierValue reports
@@ -278,19 +361,17 @@ func TestCodexThreadParams(t *testing.T) {
 	empty := codexThreadParams("gpt-5.4", "/work", CodexDefaultApprovalPolicy, CodexDefaultSandboxPolicy, "")
 	_, hasEmptyTier := empty["serviceTier"]
 	assert.False(t, hasEmptyTier, "an empty tier omits serviceTier")
+
+	accountDefault := codexThreadParams(DefaultModelSentinel, "/work", CodexDefaultApprovalPolicy, CodexDefaultSandboxPolicy, CodexDefaultServiceTier)
+	assert.NotContains(t, accountDefault, "model", "the account default lets Codex resolve the model")
+
+	unsetModel := codexThreadParams("", "/work", CodexDefaultApprovalPolicy, CodexDefaultSandboxPolicy, CodexDefaultServiceTier)
+	assert.NotContains(t, unsetModel, "model", "an unset model lets Codex resolve the model")
 }
 
-// The static fallback effort list is BOTH the id -> name lookup
-// (codexEffortName) and the ordered menu every codexDefaultModels entry
-// advertises. Only the second role constrains the order, and only the first
-// one fails visibly when it is wrong -- so appending a tier satisfies the
-// label lookup while placing it wrongly in every picker, which is exactly how
-// "max" first landed after "none".
+// The fallback effort list supplies labels and menu order. Each model selects
+// a subset, which must keep that order.
 func TestCodexDefaultEffortsRankOrder(t *testing.T) {
-	// The expected order is DERIVED from the shared effortRank table, not
-	// written out again here. A hand-written list is a third copy of the
-	// ordering, and a tier appended at the end can be added to the list and the
-	// slice in one edit, which is the mistake this test exists to catch.
 	require.NotEmpty(t, codexDefaultEfforts)
 	require.Equal(t, EffortAuto, codexDefaultEfforts[0].Id, "the LeapMux auto sentinel leads the menu")
 
@@ -306,34 +387,37 @@ func TestCodexDefaultEffortsRankOrder(t *testing.T) {
 			"codexDefaultEfforts is the menu order: %q ranks above %q, so it must come first", tiers[i-1].Id, e.Id)
 	}
 
-	// Every tier carries a label, and it is the SHARED table's label -- the live
-	// catalog resolves the same way, so the two paths cannot spell one tier two
-	// ways.
+	// Every tier uses the shared label.
 	for _, e := range codexDefaultEfforts {
 		assert.NotEmpty(t, e.Name, "effort %q needs a display name", e.Id)
 		assert.Equal(t, effortLabel(e.Id), e.Name, "effort %q must take the shared label", e.Id)
 		assert.NotEqual(t, e.Id, e.Name, "effort %q must carry a display label, not its raw id", e.Id)
 	}
 
-	// The models that advertise the list inherit that order verbatim.
-	want := make([]string, 0, len(codexDefaultEfforts))
-	for _, e := range codexDefaultEfforts {
-		want = append(want, e.Id)
+	known := make(map[string]bool, len(codexDefaultEfforts))
+	for _, effort := range codexDefaultEfforts {
+		known[effort.Id] = true
 	}
 	for _, m := range codexDefaultModels {
-		require.NotEmpty(t, m.SupportedEfforts, "model %q advertises no efforts", m.Id)
-		ids := make([]string, 0, len(m.SupportedEfforts))
-		for _, e := range m.SupportedEfforts {
-			ids = append(ids, e.Id)
+		if m.Id == DefaultModelSentinel {
+			assert.Empty(t, m.SupportedEfforts, "the unresolved model has no effort catalog")
+			continue
 		}
-		assert.Equal(t, want, ids, "model %q must offer the tiers in rank order", m.Id)
+		require.NotEmpty(t, m.SupportedEfforts, "model %q advertises no efforts", m.Id)
+		require.Equal(t, EffortAuto, m.SupportedEfforts[0].Id, "model %q must offer auto first", m.Id)
+		for i, effort := range m.SupportedEfforts[1:] {
+			require.True(t, known[effort.Id], "model %q has unknown effort %q", m.Id, effort.Id)
+			if i == 0 {
+				continue
+			}
+			previousRank, _ := effortRankOf(m.SupportedEfforts[i].Id)
+			rank, _ := effortRankOf(effort.Id)
+			assert.Greater(t, previousRank, rank, "model %q must list efforts in rank order", m.Id)
+		}
 	}
 }
 
-// The live CLI (codex-cli 0.147.0) reports an "ultra" reasoning effort above
-// "max" on every current model. A tier missing from codexDefaultEfforts leaves
-// the static fallback offering a menu the running session does not, and
-// effortRank sorts it into the unranked tail.
+// Codex reports Ultra for models that support automatic delegation.
 func TestCodexOffersUltraEffort(t *testing.T) {
 	var ultra *EffortInfo
 	for _, e := range codexDefaultEfforts {
@@ -343,6 +427,12 @@ func TestCodexOffersUltraEffort(t *testing.T) {
 	}
 	require.NotNil(t, ultra, "the live CLI reports an \"ultra\" tier; the fallback catalog must offer it too")
 	assert.Equal(t, "Ultra", ultra.Name, "the tier carries its shared label")
+	sol := FindAvailableModel(codexDefaultModels, "gpt-5.6-sol")
+	luna := FindAvailableModel(codexDefaultModels, "gpt-5.6-luna")
+	require.NotNil(t, sol)
+	require.NotNil(t, luna)
+	assert.Contains(t, effortIDs(sol.SupportedEfforts), "ultra")
+	assert.NotContains(t, effortIDs(luna.SupportedEfforts), "ultra")
 	// A tier the CLI ships before this catalog catches up still renders
 	// capitalized, not as a raw lowercase id beside its siblings.
 	assert.Equal(t, "Turbo", effortLabel("turbo"), "an unlisted tier is capitalized, not raw")

--- a/backend/internal/worker/agent/codex_settings_test.go
+++ b/backend/internal/worker/agent/codex_settings_test.go
@@ -268,7 +268,12 @@ func TestDefaultModel_CodexUsesEnvironmentOverride(t *testing.T) {
 	assert.Equal(t, "gpt-5.6-terra", DefaultModel(leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX))
 }
 
-func TestCodexFallbackCatalogMatchesCurrentAppServer(t *testing.T) {
+// TestCodexFallbackCatalogIsPinned restates codexDefaultModels so an unintended
+// edit fails loudly. It cannot detect a catalog that has drifted from the app
+// server, because both sides are hand-written here -- the name says "pinned", not
+// "matches the CLI", so nobody reads it as the stronger guarantee. Re-copy the
+// selectable rows from `codex app-server` model/list when Codex ships a release.
+func TestCodexFallbackCatalogIsPinned(t *testing.T) {
 	t.Parallel()
 
 	type fallbackModel struct {
@@ -276,6 +281,7 @@ func TestCodexFallbackCatalogMatchesCurrentAppServer(t *testing.T) {
 		displayName   string
 		description   string
 		isDefault     bool
+		hidden        bool
 		defaultEffort string
 		efforts       []string
 		contextWindow int64
@@ -291,6 +297,7 @@ func TestCodexFallbackCatalogMatchesCurrentAppServer(t *testing.T) {
 			displayName:   model.DisplayName,
 			description:   model.Description,
 			isDefault:     model.IsDefault,
+			hidden:        model.Hidden,
 			defaultEffort: model.DefaultEffort,
 			efforts:       efforts,
 			contextWindow: model.ContextWindow,
@@ -298,14 +305,18 @@ func TestCodexFallbackCatalogMatchesCurrentAppServer(t *testing.T) {
 	}
 	assert.Equal(t, []fallbackModel{
 		{id: DefaultModelSentinel, displayName: "Default (recommended)", description: "Use the account's default Codex model", isDefault: true},
-		{id: "gpt-5.6-sol", displayName: "GPT-5.6-Sol", description: "Reliable agentic workhorse for everyday tasks.", defaultEffort: "low", efforts: []string{EffortAuto, "ultra", "max", EffortXHigh, EffortHigh, "medium", "low"}, contextWindow: 1_050_000},
-		{id: "gpt-5.6-terra", displayName: "GPT-5.6-Terra", description: "Balanced agentic coding model for everyday work.", defaultEffort: "medium", efforts: []string{EffortAuto, "ultra", "max", EffortXHigh, EffortHigh, "medium", "low"}, contextWindow: 1_050_000},
-		{id: "gpt-5.6-luna", displayName: "GPT-5.6-Luna", description: "Fast and affordable agentic coding model.", defaultEffort: "medium", efforts: []string{EffortAuto, "max", EffortXHigh, EffortHigh, "medium", "low"}, contextWindow: 1_050_000},
-		{id: "gpt-5.5", displayName: "GPT-5.5", description: "Proven previous-generation model for coding and general work.", defaultEffort: "medium", efforts: []string{EffortAuto, EffortXHigh, EffortHigh, "medium", "low"}, contextWindow: 1_050_000},
-		{id: "gpt-5.4", displayName: "GPT-5.4", description: "Strong model for everyday coding.", defaultEffort: "medium", efforts: []string{EffortAuto, EffortXHigh, EffortHigh, "medium", "low"}, contextWindow: 1_050_000},
-		{id: "gpt-5.4-mini", displayName: "GPT-5.4-Mini", description: "Small, fast, and cost-efficient model for simpler coding tasks.", defaultEffort: "medium", efforts: []string{EffortAuto, EffortXHigh, EffortHigh, "medium", "low"}, contextWindow: 400_000},
-		{id: "gpt-5.3-codex-spark", displayName: "GPT-5.3-Codex-Spark", description: "Ultra-fast coding model.", defaultEffort: "high", efforts: []string{EffortAuto, EffortXHigh, EffortHigh, "medium", "low"}, contextWindow: 128_000},
-		{id: "gpt-5.2", displayName: "GPT-5.2", description: "Optimized for professional work and long-running agents.", defaultEffort: "medium", efforts: []string{EffortAuto, EffortXHigh, EffortHigh, "medium", "low"}, contextWindow: 400_000},
+		{id: "gpt-5.6-sol", displayName: "GPT-5.6-Sol", description: "Reliable agentic workhorse for everyday tasks", defaultEffort: "low", efforts: []string{EffortAuto, "ultra", "max", EffortXHigh, EffortHigh, "medium", "low"}, contextWindow: 1_050_000},
+		{id: "gpt-5.6-terra", displayName: "GPT-5.6-Terra", description: "Balanced agentic coding model for everyday work", defaultEffort: "medium", efforts: []string{EffortAuto, "ultra", "max", EffortXHigh, EffortHigh, "medium", "low"}, contextWindow: 1_050_000},
+		{id: "gpt-5.6-luna", displayName: "GPT-5.6-Luna", description: "Fast and affordable agentic coding model", defaultEffort: "medium", efforts: []string{EffortAuto, "max", EffortXHigh, EffortHigh, "medium", "low"}, contextWindow: 1_050_000},
+		{id: "gpt-5.5", displayName: "GPT-5.5", description: "Proven previous-generation model for coding and general work", defaultEffort: "medium", efforts: []string{EffortAuto, EffortXHigh, EffortHigh, "medium", "low"}, contextWindow: 1_050_000},
+		{id: "gpt-5.4", displayName: "GPT-5.4", description: "Strong model for everyday coding", defaultEffort: "medium", efforts: []string{EffortAuto, EffortXHigh, EffortHigh, "medium", "low"}, contextWindow: 1_050_000},
+		{id: "gpt-5.4-mini", displayName: "GPT-5.4-Mini", description: "Small, fast, and cost-efficient model for simpler coding tasks", defaultEffort: "medium", efforts: []string{EffortAuto, EffortXHigh, EffortHigh, "medium", "low"}, contextWindow: 400_000},
+		{id: "gpt-5.3-codex-spark", displayName: "GPT-5.3-Codex-Spark", description: "Ultra-fast coding model", defaultEffort: "high", efforts: []string{EffortAuto, EffortXHigh, EffortHigh, "medium", "low"}, contextWindow: 128_000},
+		{id: "gpt-5.2", displayName: "GPT-5.2", description: "Optimized for professional work and long-running agents", isDefault: false, hidden: true, defaultEffort: "high", efforts: []string{EffortAuto, EffortXHigh, EffortHigh, "medium", "low"}, contextWindow: 256_000},
+		{id: "gpt-5.3-codex", displayName: "GPT-5.3 Codex", description: "Frontier Codex-optimized agentic coding model", hidden: true, defaultEffort: "high", efforts: []string{EffortAuto, EffortXHigh, EffortHigh, "medium", "low"}, contextWindow: 400_000},
+		{id: "gpt-5.2-codex", displayName: "GPT-5.2 Codex", description: "Frontier agentic coding model", hidden: true, defaultEffort: "high", efforts: []string{EffortAuto, EffortXHigh, EffortHigh, "medium", "low"}, contextWindow: 400_000},
+		{id: "gpt-5.1-codex-max", displayName: "GPT-5.1 Codex Max", description: "Codex-optimized model for deep and fast reasoning", hidden: true, defaultEffort: "high", efforts: []string{EffortAuto, EffortXHigh, EffortHigh, "medium", "low"}, contextWindow: 400_000},
+		{id: "gpt-5.1-codex-mini", displayName: "GPT-5.1 Codex Mini", description: "Optimized for Codex; cheaper, faster, but less capable", hidden: true, defaultEffort: "high", efforts: []string{EffortAuto, EffortXHigh, EffortHigh, "medium", "low"}, contextWindow: 400_000},
 	}, actual)
 }
 
@@ -331,6 +342,9 @@ func TestCodexQueryAvailableModelsDoesNotInjectAccountDefault(t *testing.T) {
 	assert.Equal(t, "low", models[0].DefaultEffort)
 	assert.Equal(t, int64(1_050_000), models[0].ContextWindow)
 	assert.Equal(t, []string{EffortAuto, EffortHigh, "low"}, effortIDs(models[0].SupportedEfforts))
+	// The RAW query reports exactly what model/list carries, and Codex never lists
+	// the sentinel. reconcileModelCatalog is what puts the row back afterwards --
+	// see TestCodexReconcileModelCatalog.
 	assert.Nil(t, FindAvailableModel(models, DefaultModelSentinel))
 	sent := requests()
 	require.Len(t, sent, 1)
@@ -338,8 +352,9 @@ func TestCodexQueryAvailableModelsDoesNotInjectAccountDefault(t *testing.T) {
 }
 
 // TestCodexThreadParams covers the request params shared by thread/start and thread/resume that
-// StartCodex and ClearContext build identically via codexThreadParams. The model/cwd/approvalPolicy/
-// sandbox axes are stamped verbatim; serviceTier is included ONLY when codexServiceTierValue reports
+// StartCodex and ClearContext build identically via codexThreadParams. The cwd/approvalPolicy/
+// sandbox axes are stamped verbatim; the model is included only for a concrete id, and an
+// account-default model is omitted so Codex resolves it; serviceTier is included ONLY when codexServiceTierValue reports
 // a non-default tier (so the default/unset tier leaves Codex's normal tier untouched).
 func TestCodexThreadParams(t *testing.T) {
 	t.Parallel()
@@ -414,10 +429,19 @@ func TestCodexDefaultEffortsRankOrder(t *testing.T) {
 			rank, _ := effortRankOf(effort.Id)
 			assert.Greater(t, previousRank, rank, "model %q must list efforts in rank order", m.Id)
 		}
+		// Each model now carries a WINDOW of the ladder, not the whole of it, so a
+		// default effort can fall outside the model's own menu. effortGroupForModel
+		// marks the default per option, so an unofferable default marks nothing and
+		// codexEffortRefreshFallback then writes that id into the live effort.
+		assert.Contains(t, effortIDs(m.SupportedEfforts), m.DefaultEffort,
+			"model %q must offer its own default effort %q", m.Id, m.DefaultEffort)
 	}
 }
 
-// Codex reports Ultra for models that support automatic delegation.
+// The live CLI (codex-cli 0.152.1) reports an "ultra" effort above "max" on
+// GPT-5.6 Sol and Terra, and not on Luna. A tier that codexDefaultEfforts omits
+// leaves the static fallback offering a menu the running session does not, and
+// effortRank sorts the omitted tier into the unranked tail.
 func TestCodexOffersUltraEffort(t *testing.T) {
 	var ultra *EffortInfo
 	for _, e := range codexDefaultEfforts {
@@ -442,4 +466,286 @@ func TestCodexOffersUltraEffort(t *testing.T) {
 	maxRank, ok := effortRankOf("max")
 	require.True(t, ok)
 	assert.Greater(t, ultraRank, maxRank, "\"ultra\" is stronger than \"max\"")
+}
+
+// TestCodexUpdateSettings_AccountDefaultRequiresRestart pins the model twin of the
+// effort-auto guard. turn/start sends the stored model string as it is, and Codex
+// rejects the literal id "default" ("The 'default' model is not supported"), so a
+// live switch to the account default must ask for a relaunch instead of writing
+// the sentinel into a.model where the next turn would forward it.
+func TestCodexUpdateSettings_AccountDefaultRequiresRestart(t *testing.T) {
+	t.Parallel()
+
+	agent, _, _ := newCodexAgentForRPC(t, func(string) json.RawMessage {
+		return json.RawMessage(`{}`)
+	})
+	agent.model = "gpt-5.6-sol"
+
+	result := agent.UpdateSettings(map[string]string{OptionIDModel: DefaultModelSentinel})
+
+	assert.False(t, result.AppliedLive, "a switch to the account default needs a relaunch")
+	assert.Equal(t, "gpt-5.6-sol", agent.model, "the sentinel must never reach a.model on a live agent")
+
+	// An edit that leaves the model alone carries no model key, which reads as an
+	// empty value. That is "not supplied", not "the account default", so it must
+	// apply live -- the whole reason this guard tests the sentinel exactly.
+	unrelated := agent.UpdateSettings(map[string]string{OptionIDEffort: "high"})
+	assert.True(t, unrelated.AppliedLive, "an edit on another axis must not demand a relaunch")
+	assert.Equal(t, "gpt-5.6-sol", agent.model)
+	assert.Equal(t, "high", agent.effort)
+
+	// Re-selecting the model the agent already runs is a no-op, not a relaunch.
+	same := agent.UpdateSettings(map[string]string{OptionIDModel: "gpt-5.6-sol"})
+	assert.True(t, same.AppliedLive, "re-selecting the current model applies live")
+}
+
+// A concrete model still applies live: the restart guard must not catch every
+// model change, only the move to the account default.
+func TestCodexUpdateSettings_ConcreteModelAppliesLive(t *testing.T) {
+	t.Parallel()
+
+	agent, _, _ := newCodexAgentForRPC(t, func(string) json.RawMessage {
+		return json.RawMessage(`{}`)
+	})
+	agent.model = "gpt-5.6-sol"
+
+	result := agent.UpdateSettings(map[string]string{OptionIDModel: "gpt-5.6-luna"})
+
+	assert.True(t, result.AppliedLive, "a concrete model applies without a relaunch")
+	assert.Equal(t, "gpt-5.6-luna", agent.model)
+}
+
+// TestCodexSendTurnStartOmitsAccountDefaultModel covers the wire shape directly:
+// turn/start must carry no model key for the account default, exactly as
+// codexThreadParams omits it for thread/start.
+func TestCodexSendTurnStartOmitsAccountDefaultModel(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name        string
+		model       string
+		wantOmitted bool
+	}{
+		{name: "account default sentinel", model: DefaultModelSentinel, wantOmitted: true},
+		{name: "unset model", model: "", wantOmitted: true},
+		{name: "concrete model", model: "gpt-5.6-sol"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			a, _, requests := newCodexAgentForRPC(t, func(string) json.RawMessage {
+				return json.RawMessage(`{}`)
+			})
+			a.threadID = "thread-1"
+			go func() {
+				// turn/start resolves only at turn end, so the ack comes from the
+				// turn/started notification. Release it so the send returns.
+				time.Sleep(10 * time.Millisecond)
+				a.mu.Lock()
+				ack := a.turnStartAck
+				a.turnStartAck = nil
+				a.mu.Unlock()
+				if ack != nil {
+					close(ack)
+				}
+			}()
+
+			err := a.sendTurnStart("thread-1", []map[string]interface{}{{"type": "text", "text": "hi"}}, turnSettings{
+				model:          test.model,
+				approvalPolicy: CodexDefaultApprovalPolicy,
+			})
+			require.NoError(t, err)
+
+			sent := requests()
+			require.Len(t, sent, 1)
+			assert.Equal(t, "turn/start", sent[0].Method)
+			if test.wantOmitted {
+				assert.NotContains(t, sent[0].Params, "model", "the account default lets Codex keep its resolved model")
+			} else {
+				assert.Equal(t, test.model, sent[0].Params["model"])
+			}
+		})
+	}
+}
+
+// TestCodexEffortsDownFrom pins the ladder cut: a window runs from its top tier to
+// the weakest one Codex offers, always behind the auto sentinel, and an unknown
+// tier fails at once rather than silently shortening a menu.
+func TestCodexEffortsDownFrom(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, []string{EffortAuto, "ultra", "max", EffortXHigh, EffortHigh, "medium", "low"}, effortIDs(codexEffortsDownFrom("ultra")))
+	assert.Equal(t, []string{EffortAuto, EffortXHigh, EffortHigh, "medium", "low"}, effortIDs(codexEffortsDownFrom(EffortXHigh)))
+	assert.Equal(t, []string{EffortAuto, "low"}, effortIDs(codexEffortsDownFrom("low")))
+
+	// "minimal" is on effortLadder but not in codexEffortIDs. A filter dropped such
+	// an id and returned a short menu; the cut refuses it.
+	assert.Panics(t, func() { codexEffortsDownFrom("minimal") }, "a tier Codex does not offer must fail loudly")
+	assert.Panics(t, func() { codexEffortsDownFrom("nonsense") }, "a typo must fail loudly")
+
+	// The returned slice must not alias codexDefaultEfforts, or one model's menu
+	// could rewrite another's.
+	window := codexEffortsDownFrom("ultra")
+	window[1] = &EffortInfo{Id: "scribbled"}
+	assert.Equal(t, "ultra", codexDefaultEfforts[1].Id, "the shared catalog must be untouched")
+}
+
+// TestCodexRetiredModelsStayResolvable pins the retirement rule: a model the
+// current app server no longer lists stays in the catalog Hidden, so a session
+// still pinned to it keeps its effort tiers and its context window while the
+// picker stops offering it.
+func TestCodexRetiredModelsStayResolvable(t *testing.T) {
+	t.Parallel()
+
+	for _, id := range []string{"gpt-5.2", "gpt-5.3-codex", "gpt-5.2-codex", "gpt-5.1-codex-max", "gpt-5.1-codex-mini"} {
+		model := FindAvailableModel(codexDefaultModels, id)
+		require.NotNil(t, model, "a retired model must stay resolvable by id: %q", id)
+		assert.True(t, model.Hidden, "retired model %q must not appear in the picker", id)
+		assert.NotEmpty(t, model.SupportedEfforts, "retired model %q keeps its effort tiers", id)
+		assert.NotZero(t, model.ContextWindow, "retired model %q keeps its context window", id)
+		assert.NotEmpty(t, model.Description, "retired model %q keeps its description", id)
+	}
+
+	// A Hidden row must never take the default badge away from the sentinel.
+	assert.Equal(t, DefaultModelSentinel, DefaultModel(leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX))
+}
+
+// TestCodexQueryAvailableModelsKeepsTheReportedDescription covers a model the
+// static catalog does not carry -- an account-specific one, which is exactly what
+// model/list exists to supply. Its description must come from the report rather
+// than render blank.
+func TestCodexQueryAvailableModelsKeepsTheReportedDescription(t *testing.T) {
+	t.Parallel()
+
+	agent, _, _ := newCodexAgentForRPC(t, func(string) json.RawMessage {
+		return json.RawMessage(`{"data":[
+			{"id":"gpt-daybreak-blue-latest","model":"gpt-daybreak-blue-latest","displayName":"Daybreak Blue","description":"Latest frontier model for defensive cybersecurity work.","defaultReasoningEffort":"low","supportedReasoningEfforts":[{"reasoningEffort":"low","description":"Low"}]},
+			{"id":"gpt-5.6-sol","model":"gpt-5.6-sol","displayName":"gpt-5.6-sol","description":"the CLI wording","supportedReasoningEfforts":[{"reasoningEffort":"low","description":"Low"}]}
+		]}`)
+	})
+
+	models := agent.queryAvailableModels(time.Second)
+
+	require.Len(t, models, 2)
+	assert.Equal(t, "Daybreak Blue", models[0].DisplayName)
+	assert.Equal(t, "Latest frontier model for defensive cybersecurity work.", models[0].Description,
+		"a model the static catalog lacks keeps the description the CLI reported")
+
+	// The curated wording still wins for a model the catalog does carry.
+	assert.Equal(t, "Reliable agentic workhorse for everyday tasks", models[1].Description)
+	assert.Equal(t, "GPT-5.6-Sol", models[1].DisplayName)
+}
+
+// TestCodexReconcileModelCatalog covers the two gaps between what model/list
+// reports and what the picker must offer: the account-default sentinel, which the
+// Codex CLI never lists, and a settled model the live list omits.
+func TestCodexReconcileModelCatalog(t *testing.T) {
+	t.Parallel()
+
+	live := func() []*ModelInfo {
+		return []*ModelInfo{
+			{Id: "gpt-5.6-sol", DisplayName: "GPT-5.6-Sol"},
+			{Id: "gpt-5.4", DisplayName: "GPT-5.4"},
+		}
+	}
+
+	t.Run("adds the account default so a tab can return to it", func(t *testing.T) {
+		t.Parallel()
+
+		a, _, _ := newCodexAgentForRPC(t, func(string) json.RawMessage { return json.RawMessage(`{}`) })
+		a.availableModels = live()
+		a.model = "gpt-5.6-sol"
+
+		a.reconcileModelCatalog()
+
+		require.NotNil(t, FindAvailableModel(a.availableModels, DefaultModelSentinel),
+			"without the sentinel a user can never return to the account default")
+		assert.Equal(t, DefaultModelSentinel, a.availableModels[0].Id, "the sentinel leads the picker")
+		assert.Empty(t, a.availableModels[0].SupportedEfforts, "the unresolved entry carries no effort menu")
+	})
+
+	t.Run("keeps a settled model the live list omits", func(t *testing.T) {
+		t.Parallel()
+
+		a, _, _ := newCodexAgentForRPC(t, func(string) json.RawMessage { return json.RawMessage(`{}`) })
+		a.availableModels = live()
+		a.model = "gpt-5.2" // retired: present in the static catalog, absent from model/list
+
+		a.reconcileModelCatalog()
+
+		settled := FindAvailableModel(a.availableModels, "gpt-5.2")
+		require.NotNil(t, settled, "an unlisted current model leaves the picker unselected")
+		assert.NotZero(t, settled.ContextWindow, "the reinstated entry carries its capabilities")
+		// gpt-5.2 is retired, so it sorts after every current model.
+		assert.Equal(t, []string{DefaultModelSentinel, "gpt-5.6-sol", "gpt-5.4", "gpt-5.2"}, modelIDsOf(a.availableModels))
+	})
+
+	t.Run("leaves a listed model and an already-present sentinel alone", func(t *testing.T) {
+		t.Parallel()
+
+		a, _, _ := newCodexAgentForRPC(t, func(string) json.RawMessage { return json.RawMessage(`{}`) })
+		a.availableModels = append([]*ModelInfo{{Id: DefaultModelSentinel}}, live()...)
+		a.model = "gpt-5.4"
+
+		a.reconcileModelCatalog()
+
+		assert.Equal(t, []string{DefaultModelSentinel, "gpt-5.6-sol", "gpt-5.4"}, modelIDsOf(a.availableModels),
+			"a complete catalog is left untouched")
+	})
+
+	t.Run("no-ops on an empty live list so the static fallback survives", func(t *testing.T) {
+		t.Parallel()
+
+		a, _, _ := newCodexAgentForRPC(t, func(string) json.RawMessage { return json.RawMessage(`{}`) })
+		a.model = "gpt-5.6-sol"
+
+		a.reconcileModelCatalog()
+
+		assert.Empty(t, a.availableModels,
+			"a singleton here would replace the full static fallback OptionGroups uses")
+	})
+
+	// An account-specific model is exactly what model/list exists to supply, and the
+	// static catalog cannot know it. It must not push a catalog-known model out of
+	// position when the settled model is inserted beside it.
+	t.Run("ranks an account-specific model after every known one", func(t *testing.T) {
+		t.Parallel()
+
+		a, _, _ := newCodexAgentForRPC(t, func(string) json.RawMessage { return json.RawMessage(`{}`) })
+		a.availableModels = []*ModelInfo{
+			{Id: "gpt-daybreak-blue-latest", DisplayName: "Daybreak Blue"},
+			{Id: "gpt-5.4", DisplayName: "GPT-5.4"},
+		}
+		a.model = "gpt-5.6-sol" // known to the static catalog, absent from this live list
+
+		a.reconcileModelCatalog()
+
+		// The insert positions the SETTLED model only; it never reorders what
+		// model/list reported, whose order is the CLI's own. Daybreak ranks last
+		// because neither catalog knows it, so gpt-5.6-sol lands before it -- and
+		// gpt-5.4 keeps the place the CLI gave it, behind Daybreak.
+		assert.Equal(t, []string{DefaultModelSentinel, "gpt-5.6-sol", "gpt-daybreak-blue-latest", "gpt-5.4"},
+			modelIDsOf(a.availableModels))
+	})
+
+	t.Run("leaves an unknown settled model unlisted", func(t *testing.T) {
+		t.Parallel()
+
+		a, _, _ := newCodexAgentForRPC(t, func(string) json.RawMessage { return json.RawMessage(`{}`) })
+		a.availableModels = live()
+		a.model = "gpt-9-unreleased"
+
+		a.reconcileModelCatalog()
+
+		assert.Nil(t, FindAvailableModel(a.availableModels, "gpt-9-unreleased"),
+			"a model neither catalog knows carries no capabilities to surface")
+	})
+}
+
+func modelIDsOf(models []*ModelInfo) []string {
+	ids := make([]string, 0, len(models))
+	for _, m := range models {
+		ids = append(ids, m.Id)
+	}
+	return ids
 }

--- a/backend/internal/worker/agent/effort_labels_test.go
+++ b/backend/internal/worker/agent/effort_labels_test.go
@@ -52,13 +52,25 @@ func TestSortEffortsDescending_AgreesWithTheCodexCatalogOrder(t *testing.T) {
 	t.Parallel()
 
 	// Auto is not a strength and never reaches the sort, so it is dropped first.
-	tail := append([]*EffortInfo(nil), codexDefaultEfforts[1:]...)
+	tail := slices.Clone(codexDefaultEfforts[1:])
 	want := effortIDs(tail)
 
+	// A plain reversal is NOT a sufficient input: sortEffortsDescending could be
+	// implemented as slices.Reverse and still turn reverse(want) back into want.
+	// Rotating leaves most adjacent pairs already in correct relative order, so
+	// only a rank-aware sort recovers the full order.
 	shuffled := slices.Clone(tail)
-	slices.Reverse(shuffled)
+	shuffled = append(shuffled[3:], shuffled[:3]...)
+	require.NotEqual(t, want, effortIDs(shuffled), "the input must start out of order")
 	sortEffortsDescending(shuffled)
 	assert.Equal(t, want, effortIDs(shuffled))
+
+	// The same input must defeat a reversal-only implementation, which is the
+	// mistake a reversed input cannot catch.
+	reverseOnly := slices.Clone(tail)
+	reverseOnly = append(reverseOnly[3:], reverseOnly[:3]...)
+	slices.Reverse(reverseOnly)
+	assert.NotEqual(t, want, effortIDs(reverseOnly), "a reversal alone must not reproduce the order")
 }
 
 // A model that offers a toggle rather than a ladder: ZCode gives GLM-5-Turbo

--- a/backend/internal/worker/agent/effort_labels_test.go
+++ b/backend/internal/worker/agent/effort_labels_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
@@ -54,7 +55,8 @@ func TestSortEffortsDescending_AgreesWithTheCodexCatalogOrder(t *testing.T) {
 	tail := append([]*EffortInfo(nil), codexDefaultEfforts[1:]...)
 	want := effortIDs(tail)
 
-	shuffled := []*EffortInfo{tail[3], tail[0], tail[6], tail[1], tail[5], tail[2], tail[7], tail[4]}
+	shuffled := slices.Clone(tail)
+	slices.Reverse(shuffled)
 	sortEffortsDescending(shuffled)
 	assert.Equal(t, want, effortIDs(shuffled))
 }

--- a/backend/internal/worker/agent/factory.go
+++ b/backend/internal/worker/agent/factory.go
@@ -55,13 +55,19 @@ const DefaultAPITimeout = config.DefaultAPITimeout
 // that don't recognize newer effort names (e.g. "xhigh") still work.
 const EffortAuto = contracts.EffortAuto
 
-// DefaultModelSentinel means "let the agent select the account's default model."
-// Claude Code reports this option. LeapMux uses it as a startup placeholder for
-// Codex. Codex replaces it with the concrete model from the lifecycle response.
+// DefaultModelSentinel is the model id that means "let the agent select the
+// account's default model" -- the model-side analogue of EffortAuto above. Claude
+// Code reports the sentinel in its own model list. LeapMux stores the sentinel for
+// a new Codex session, and Codex replaces it with the concrete model that the
+// thread/start lifecycle response reports.
 const DefaultModelSentinel = contracts.DefaultModelSentinel
 
 // UsesAccountDefaultModel reports whether the model lets the agent select the
 // account default. An empty value and DefaultModelSentinel have this meaning.
+//
+// Every site that puts a model on the wire must call this. One two-clause check
+// keeps the omit-the-model decision the same at every site, so a forgotten
+// sentinel clause becomes a missing call rather than a silent wrong branch.
 func UsesAccountDefaultModel(model string) bool {
 	return model == "" || model == DefaultModelSentinel
 }

--- a/backend/internal/worker/agent/factory.go
+++ b/backend/internal/worker/agent/factory.go
@@ -55,19 +55,13 @@ const DefaultAPITimeout = config.DefaultAPITimeout
 // that don't recognize newer effort names (e.g. "xhigh") still work.
 const EffortAuto = contracts.EffortAuto
 
-// DefaultModelSentinel is the model id meaning "let the CLI pick the account's
-// own default model". Claude Code reports it as a distinct entry in the
-// initialize response (displayName "Default (recommended)"); selecting it makes
-// the provider omit --model at launch (and relaunch on a live switch) so the CLI
-// resolves it to the concrete model, which get_settings then reports back -- the
-// model-side analogue of EffortAuto.
+// DefaultModelSentinel means "let the agent select the account's default model."
+// Claude Code reports this option. LeapMux uses it as a startup placeholder for
+// Codex. Codex replaces it with the concrete model from the lifecycle response.
 const DefaultModelSentinel = contracts.DefaultModelSentinel
 
-// UsesAccountDefaultModel reports whether a (normalized) model id means "no concrete
-// model -- let the CLI pick the account default": an empty id or the
-// DefaultModelSentinel. Centralizing the two-clause check keeps the "omit --model"
-// decision identical at every site and makes a forgotten sentinel clause a missing
-// call rather than a silent wrong branch.
+// UsesAccountDefaultModel reports whether the model lets the agent select the
+// account default. An empty value and DefaultModelSentinel have this meaning.
 func UsesAccountDefaultModel(model string) bool {
 	return model == "" || model == DefaultModelSentinel
 }

--- a/backend/internal/worker/agent/manager.go
+++ b/backend/internal/worker/agent/manager.go
@@ -599,18 +599,23 @@ func (m *Manager) ClearContext(agentID string) (string, bool) {
 // withModelGroupDefaultMarked reduces the projected "model" option group to these three
 // arguments on every OptionGroups read. Priority:
 //  1. The explicit LEAPMUX_*_DEFAULT_MODEL operator override.
-//  2. A provider-reported default that the list designates. Claude Code reports
-//     DefaultModelSentinel. Codex reports its resolved concrete default.
-//  3. The provider's configured default. When the list contains it, return it;
-//     when the list omits it (an account-specific list whose configured default
-//     isn't offered, e.g. a Claude CLI reporting concrete models but no "default"
-//     sentinel), fall back to the highest-preference entry present so the picker
-//     still shows a badge.
+//  2. The DefaultModelSentinel entry, for a provider that reports the sentinel in
+//     its own catalog (Claude Code today). It tracks the account's own default
+//     across plan tiers (e.g. Sonnet vs Fable).
+//  3. The provider's configured default, when the list contains it. Codex's
+//     configured default is the sentinel too, and reconcileModelCatalog keeps the
+//     sentinel in the live catalog, so Codex badges the sentinel at this step for
+//     a stopped AND a running agent.
+//  4. A default the list itself designates -- what queryAvailableModels copied
+//     from the CLI's own isDefault. Reached when the configured default is absent
+//     from this account's list, so a stale registry default cannot move the badge
+//     off the model the CLI marked.
+//  5. The highest-preference entry present, so the picker always shows a badge.
 //
 // Returning "" means "don't touch the list's existing default": that's the case for a
 // provider with no configured default at all (ACP providers registered with nil
 // defaultModels, which self-mark the currently-selected model in buildACPModels). The
-// step-3 fallback is gated on a non-empty configured default precisely so it doesn't
+// steps 4 and 5 run only for a non-empty configured default, precisely so they don't
 // clobber that per-agent marking.
 func defaultModelIDForList(ids []string, marked, first string, provider leapmuxv1.AgentProvider) string {
 	if env := DefaultModelEnvOverride(provider); env != "" {
@@ -633,11 +638,9 @@ func defaultModelIDForList(ids []string, marked, first string, provider leapmuxv
 			return id
 		}
 	}
-	// Only Claude Code reports the sentinel in its live catalog. Codex keeps the
-	// sentinel until a lifecycle response reports a concrete model. It follows the
-	// configured-default path below. Other providers can use "default" as an
-	// ordinary model ID.
-	if provider == leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE && slices.Contains(ids, DefaultModelSentinel) {
+	// Each provider states for itself whether its catalog reports the sentinel, so
+	// this ladder stays provider-neutral. Only Claude Code answers true today.
+	if ProviderFor(provider).ReportsDefaultModelSentinel() && slices.Contains(ids, DefaultModelSentinel) {
 		return DefaultModelSentinel
 	}
 	configured := DefaultModel(provider)

--- a/backend/internal/worker/agent/manager.go
+++ b/backend/internal/worker/agent/manager.go
@@ -599,9 +599,8 @@ func (m *Manager) ClearContext(agentID string) (string, bool) {
 // withModelGroupDefaultMarked reduces the projected "model" option group to these three
 // arguments on every OptionGroups read. Priority:
 //  1. The explicit LEAPMUX_*_DEFAULT_MODEL operator override.
-//  2. A provider-reported default the list itself designates -- for Claude Code
-//     this is the CLI's DefaultModelSentinel ("default") entry, which tracks the
-//     account's own default across plan tiers (e.g. Sonnet vs Fable).
+//  2. A provider-reported default that the list designates. Claude Code reports
+//     DefaultModelSentinel. Codex reports its resolved concrete default.
 //  3. The provider's configured default. When the list contains it, return it;
 //     when the list omits it (an account-specific list whose configured default
 //     isn't offered, e.g. a Claude CLI reporting concrete models but no "default"
@@ -634,10 +633,10 @@ func defaultModelIDForList(ids []string, marked, first string, provider leapmuxv
 			return id
 		}
 	}
-	// DefaultModelSentinel is a Claude-Code-specific concept (the CLI's "default"
-	// entry); gate the check to that provider so a non-Claude provider that
-	// happens to report a model literally id'd "default" doesn't get its
-	// self-marked/CLI-marked badge hijacked onto that entry.
+	// Only Claude Code reports the sentinel in its live catalog. Codex keeps the
+	// sentinel until a lifecycle response reports a concrete model. It follows the
+	// configured-default path below. Other providers can use "default" as an
+	// ordinary model ID.
 	if provider == leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE && slices.Contains(ids, DefaultModelSentinel) {
 		return DefaultModelSentinel
 	}

--- a/backend/internal/worker/agent/manager_test.go
+++ b/backend/internal/worker/agent/manager_test.go
@@ -1021,9 +1021,10 @@ func TestModelGroupDefault_ToleratesNilAndHiddenEntries(t *testing.T) {
 	}, codex), "the designated default outranks the first-entry fallback")
 }
 
-// TestModelGroupDefault_SentinelIsClaudeOnly verifies that only Claude Code gives
-// a provider-reported "default" entry sentinel priority. A non-Claude Agent Client
-// Protocol provider can use "default" as an ordinary model ID.
+// TestModelGroupDefault_SentinelIsClaudeOnly verifies that only Claude Code treats
+// an entry with the id "default" as the sentinel and prefers it. For every other
+// provider "default" is an ordinary model id, so the self-marked current model
+// must keep the badge.
 func TestModelGroupDefault_SentinelIsClaudeOnly(t *testing.T) {
 	t.Setenv("LEAPMUX_OPENCODE_DEFAULT_MODEL", "") // hermetic: ignore any ambient override
 	t.Setenv("LEAPMUX_CLAUDE_DEFAULT_MODEL", "")
@@ -1186,4 +1187,59 @@ func TestModelGroupDefault_EmptyAndAllNilCatalogs(t *testing.T) {
 	got := withModelGroupDefaultMarked(groups, claude)
 	require.Len(t, got, 1)
 	assert.Same(t, other, got[0], "no model group -> the input is returned untouched")
+}
+
+// TestReportsDefaultModelSentinel pins the per-provider answer that
+// defaultModelIDForList dispatches on. Only Claude Code's own catalog lists the
+// sentinel as a selectable entry, so only Claude gives it the default badge; for
+// every other provider "default" is an ordinary model id.
+func TestReportsDefaultModelSentinel(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, claudeProvider{}.ReportsDefaultModelSentinel(), "the Claude CLI reports a \"default\" entry itself")
+	assert.False(t, codexProvider{}.ReportsDefaultModelSentinel(), "Codex resolves the sentinel to a concrete model at startup")
+	assert.False(t, zcodeProvider{}.ReportsDefaultModelSentinel(), "ZCode names every model explicitly")
+	assert.False(t, noopProvider{}.ReportsDefaultModelSentinel(), "a provider must opt in, not inherit Claude's answer")
+
+	// The dispatcher must agree with the plugin for every registered provider, so a
+	// new provider cannot be added to the enum and miss the decision.
+	for _, provider := range []leapmuxv1.AgentProvider{
+		leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+		leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX,
+		leapmuxv1.AgentProvider_AGENT_PROVIDER_OPENCODE,
+	} {
+		want := provider == leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE
+		assert.Equal(t, want, ProviderFor(provider).ReportsDefaultModelSentinel(), "provider %s", provider)
+	}
+}
+
+// TestModelGroupDefault_CodexBadgesTheSentinelOnceReconciled covers the badge for
+// a RUNNING Codex agent. reconcileModelCatalog puts the account-default row back
+// into the live catalog that model/list omits, and DefaultModel(CODEX) is that
+// same sentinel, so the ladder badges it at the configured-default step -- ahead
+// of the concrete model the CLI marked isDefault. Before the reconciliation the
+// sentinel was absent from a live list and the badge landed on that concrete
+// model instead, so this pins which of the two the picker highlights.
+func TestModelGroupDefault_CodexBadgesTheSentinelOnceReconciled(t *testing.T) {
+	t.Setenv("LEAPMUX_CODEX_DEFAULT_MODEL", "") // hermetic: ignore any ambient override
+	codex := leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX
+	require.Equal(t, DefaultModelSentinel, DefaultModel(codex), "precondition: Codex's configured default is the sentinel")
+
+	reconciled := []*ModelInfo{
+		accountDefaultModelEntry("Use the account's default Codex model"),
+		{Id: "gpt-5.6-sol", DisplayName: "GPT-5.6-Sol", IsDefault: true},
+		{Id: "gpt-5.4", DisplayName: "GPT-5.4"},
+	}
+	assert.Equal(t, DefaultModelSentinel, derivedModelDefault(t, reconciled, codex),
+		"the account default carries the badge once the sentinel is listed")
+
+	// A live list the reconciliation never touched (it no-ops on an empty catalog,
+	// and an older persisted catalog can lack the row) still badges the model the
+	// CLI marked, rather than badging nothing.
+	rawLive := []*ModelInfo{
+		{Id: "gpt-5.6-sol", DisplayName: "GPT-5.6-Sol", IsDefault: true},
+		{Id: "gpt-5.4", DisplayName: "GPT-5.4"},
+	}
+	assert.Equal(t, "gpt-5.6-sol", derivedModelDefault(t, rawLive, codex),
+		"with no sentinel listed the CLI's own default keeps the badge")
 }

--- a/backend/internal/worker/agent/manager_test.go
+++ b/backend/internal/worker/agent/manager_test.go
@@ -1021,11 +1021,9 @@ func TestModelGroupDefault_ToleratesNilAndHiddenEntries(t *testing.T) {
 	}, codex), "the designated default outranks the first-entry fallback")
 }
 
-// TestWithDefaultModelMarked_SentinelIsClaudeOnly verifies the DefaultModelSentinel
-// ("default") badge rule is scoped to Claude Code. A non-Claude ACP provider whose
-// live list happens to contain a model literally id'd "default" must NOT have its
-// self-marked current-model badge hijacked onto that entry -- the sentinel is a
-// Claude-Code concept, so for other providers "default" is just another model id.
+// TestModelGroupDefault_SentinelIsClaudeOnly verifies that only Claude Code gives
+// a provider-reported "default" entry sentinel priority. A non-Claude Agent Client
+// Protocol provider can use "default" as an ordinary model ID.
 func TestModelGroupDefault_SentinelIsClaudeOnly(t *testing.T) {
 	t.Setenv("LEAPMUX_OPENCODE_DEFAULT_MODEL", "") // hermetic: ignore any ambient override
 	t.Setenv("LEAPMUX_CLAUDE_DEFAULT_MODEL", "")

--- a/backend/internal/worker/agent/options.go
+++ b/backend/internal/worker/agent/options.go
@@ -108,6 +108,15 @@ func EffortSupportedByModel(groups []*leapmuxv1.AvailableOptionGroup, provider l
 // effort for the running session to validate -- mirroring ValidateLaunchOptions, which deliberately
 // does NOT validate model/effort against the seed.
 func ModelEffortKnown(groups []*leapmuxv1.AvailableOptionGroup, provider leapmuxv1.AgentProvider, model string) bool {
+	// The account default is a placeholder, not a concrete model. Its catalog entry
+	// carries no efforts on purpose, so an empty effort sub-group here means "not yet
+	// resolved" and never "this model offers no tier". Report it as unknown, so the
+	// running session validates the effort and resetEffortToAutoIfUnsupported keeps
+	// the user's choice instead of clamping it against an empty list. claude.go's
+	// definedEfforts already answers the same way for the same input.
+	if UsesAccountDefaultModel(model) {
+		return false
+	}
 	mg := optionids.GroupByID(groups, OptionIDModel)
 	if mg == nil {
 		return false

--- a/backend/internal/worker/agent/options_test.go
+++ b/backend/internal/worker/agent/options_test.go
@@ -197,6 +197,25 @@ func TestModelEffortKnown(t *testing.T) {
 		"the hidden current model is known via the top-level effort group")
 	assert.False(t, ModelEffortKnown(hiddenCatalog, claude, "future-model"),
 		"a model that is neither selectable nor the current value is unknown even with an effort group present")
+
+	// The account-default sentinel is SELECTABLE and carries no efforts, so the
+	// selectable-option loop would report it known and every tier unsupported --
+	// which makes resetEffortToAutoIfUnsupported clamp a user's effort to auto.
+	// "Unresolved" is not "offers nothing": haiku above is genuinely effort-less
+	// and must stay known, while the sentinel must not.
+	sentinelModels := []*ModelInfo{
+		accountDefaultModelEntry("Use your account's default model"),
+		{Id: "sonnet", DisplayName: "Sonnet", DefaultEffort: "high", SupportedEfforts: []*EffortInfo{{Id: "auto"}, {Id: "high"}}},
+	}
+	sentinelCatalog := []*leapmuxv1.AvailableOptionGroup{modelOptionGroup(sentinelModels, DefaultModelSentinel, effortSubGroups)}
+	require.NotNil(t, findAvailableOptionByID(optionids.GroupByID(sentinelCatalog, OptionIDModel), DefaultModelSentinel),
+		"the sentinel IS a selectable option, which is what makes the loop report it known")
+	assert.False(t, ModelEffortKnown(sentinelCatalog, claude, DefaultModelSentinel),
+		"the account default has not resolved to a concrete model, so its effort set is unknown")
+	assert.False(t, ModelEffortKnown(sentinelCatalog, claude, ""),
+		"an unset model means the account default too")
+	assert.True(t, ModelEffortKnown(sentinelCatalog, claude, "sonnet"),
+		"a concrete model beside the sentinel is still known")
 }
 
 // TestOptionStateApply_AuthoritativeDropsStaleOutOfListValue is the regression guard for

--- a/backend/internal/worker/agent/provider.go
+++ b/backend/internal/worker/agent/provider.go
@@ -174,6 +174,13 @@ type Provider interface {
 	// child tab is read-only. Defaults to false (noopProvider); only Codex
 	// overrides it to true.
 	SupportsChildSteering() bool
+	// ReportsDefaultModelSentinel reports whether this provider's own model
+	// catalog lists DefaultModelSentinel as a selectable entry meaning "the
+	// account default". Only such a provider gives that entry the default badge
+	// (see defaultModelIDForList). Another provider may report an ordinary model
+	// literally id'd "default", and its badge must stay where the catalog put it.
+	// Defaults to false (noopProvider); only Claude Code overrides it to true.
+	ReportsDefaultModelSentinel() bool
 	// ResolveResumeHandle checks the client-supplied handle and returns the
 	// value that must reach argv, or reports why this provider cannot resume
 	// from it.
@@ -333,6 +340,11 @@ func (noopProvider) EndsSubagentTranscript([]byte) bool { return false }
 // cannot steer a subagent conversation inside their own process. Only Codex
 // overrides it to true (its collab child threads accept host-initiated turns).
 func (noopProvider) SupportsChildSteering() bool { return false }
+
+// ReportsDefaultModelSentinel defaults to false: a provider whose CLI reports
+// concrete model ids only must keep the default badge on the entry its own
+// catalog designates, even when one of those ids happens to be "default".
+func (noopProvider) ReportsDefaultModelSentinel() bool { return false }
 
 // defaultTurnEndToolUses reads a top-level "num_tool_uses" number. Every
 // provider shipped today puts it there, but the decision stays behind the
@@ -536,12 +548,23 @@ func (codexProvider) PermissionModeFromRawInput(string) (string, bool) { return 
 // child routes through the owner process's ChildSteerer.
 func (codexProvider) SupportsChildSteering() bool { return true }
 
+// ReportsDefaultModelSentinel is false: Codex stores the sentinel until the
+// thread/start lifecycle response reports a concrete model, and model/list never
+// returns it, so Codex badges the model the CLI itself marks.
+func (codexProvider) ReportsDefaultModelSentinel() bool { return false }
+
 type claudeProvider struct {
 	noopProvider
 }
 
 // ListStoredSessions reads Claude Code's own transcripts; see
 // claude_sessions.go.
+// ReportsDefaultModelSentinel is true: the Claude CLI lists a "default" entry in
+// its own initialize response, and convertClaudeModels owns that reserved id, so
+// the sentinel is a real selectable option that tracks the account's default
+// across plan tiers.
+func (claudeProvider) ReportsDefaultModelSentinel() bool { return true }
+
 func (claudeProvider) ListStoredSessions(ctx context.Context, q StoredSessionQuery) ([]StoredSession, error) {
 	return claudeStoredSessions(ctx, q)
 }

--- a/backend/internal/worker/agent/zcode_provider.go
+++ b/backend/internal/worker/agent/zcode_provider.go
@@ -154,3 +154,7 @@ func (zcodeProvider) EndsSubagentTranscript([]byte) bool { return false }
 // SupportsChildSteering is false: a ZCode subagent runs to completion and takes no
 // further message.
 func (zcodeProvider) SupportsChildSteering() bool { return false }
+
+// ReportsDefaultModelSentinel is false: ZCode's catalog names every model
+// explicitly, so no entry stands for the account default.
+func (zcodeProvider) ReportsDefaultModelSentinel() bool { return false }

--- a/backend/internal/worker/service/open_async_startup_test.go
+++ b/backend/internal/worker/service/open_async_startup_test.go
@@ -505,90 +505,83 @@ func TestPersistConfirmedAgentSettingsPreservesPreStartPermissionModeChange(t *t
 }
 
 // TestPersistConfirmedAgentSettingsAppliesConfirmedModelDespiteOtherAxisChange
-// guards the compare-and-swap regression: when the user changes ONE axis (effort)
-// mid-startup, the provider's confirmed resolution of an UNCHANGED axis (the model
-// sentinel -> a concrete model) must still be persisted. A whole-blob compare
-// against the launch options would discard the entire confirmed blob here, leaving
-// the row stuck on the unresolved "default" sentinel.
+// verifies that a concurrent effort change does not discard a resolved model.
 func TestPersistConfirmedAgentSettingsAppliesConfirmedModelDespiteOtherAxisChange(t *testing.T) {
-	t.Parallel()
+	for _, test := range []struct {
+		name            string
+		provider        leapmuxv1.AgentProvider
+		permissionMode  string
+		resolvedModel   string
+		initialEffort   string
+		changedEffort   string
+		confirmedEffort string
+	}{
+		{name: "claude", provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, permissionMode: agent.PermissionModeDefault, resolvedModel: "claude-opus", initialEffort: "high", changedEffort: "low", confirmedEffort: "high"},
+		{name: "codex", provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX, permissionMode: agent.CodexDefaultApprovalPolicy, resolvedModel: "gpt-5.6-sol", initialEffort: agent.EffortAuto, changedEffort: "high", confirmedEffort: "low"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 
-	ctx := context.Background()
-	svc, _, _ := setupTestService(t)
-	defer drainAllInFlight(svc)
+			ctx := context.Background()
+			svc, _, _ := setupTestService(t)
+			defer drainAllInFlight(svc)
 
-	agentID := "agent-effort-change-mid-startup"
-	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
-		ID:         agentID,
-		WorkingDir: t.TempDir(),
-		HomeDir:    t.TempDir(),
-		Title:      "effort change",
-		Options: marshalOptions(map[string]string{
-			agent.OptionIDModel:          agent.DefaultModelSentinel,
-			agent.OptionIDEffort:         "high",
-			agent.OptionIDPermissionMode: agent.PermissionModeDefault,
-		}),
-		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
-		Resumed:       0,
-	}))
+			agentID := "agent-model-resolution-" + test.name
+			initialOptions := OptionMap{
+				agent.OptionIDModel:          agent.DefaultModelSentinel,
+				agent.OptionIDEffort:         test.initialEffort,
+				agent.OptionIDPermissionMode: test.permissionMode,
+			}
+			require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+				ID:            agentID,
+				WorkingDir:    t.TempDir(),
+				HomeDir:       t.TempDir(),
+				Title:         "model resolution",
+				Options:       marshalOptions(initialOptions),
+				AgentProvider: test.provider,
+			}))
 
-	// The subprocess was launched with the sentinel model and effort=high.
-	initialOpts := agent.Options{
-		AgentID: agentID,
-		Options: map[string]string{
-			agent.OptionIDModel:          agent.DefaultModelSentinel,
-			agent.OptionIDEffort:         "high",
-			agent.OptionIDPermissionMode: agent.PermissionModeDefault,
-		},
-		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+			initialOpts := agent.Options{AgentID: agentID, Options: initialOptions, AgentProvider: test.provider}
+			latestOptions := initialOptions.Clone()
+			latestOptions[agent.OptionIDEffort] = test.changedEffort
+			require.NoError(t, svc.Queries.SetAgentOptions(ctx, db.SetAgentOptionsParams{
+				Options: marshalOptions(latestOptions),
+				ID:      agentID,
+			}))
+			latestRow, err := svc.Queries.GetAgentByID(ctx, agentID)
+			require.NoError(t, err)
+			latestOpts := applyDBSettingsToAgentOptions(initialOpts, &latestRow)
+
+			confirmed := confirmedSettingsPreservingStartupChanges(
+				map[string]string{
+					agent.OptionIDModel:  test.resolvedModel,
+					agent.OptionIDEffort: test.confirmedEffort,
+				},
+				initialOpts,
+				latestOpts,
+			)
+			assert.Equal(t, test.resolvedModel, confirmed[agent.OptionIDModel])
+			assert.NotContains(t, confirmed, agent.OptionIDEffort)
+
+			activeRow, err := svc.persistConfirmedAgentSettingsPreservingStartedSettings(
+				agentID,
+				latestRow.Options,
+				latestOpts,
+				confirmed,
+				latestRow.OptionGroups,
+			)
+			require.NoError(t, err)
+			persisted := loadOptions(activeRow.Options, activeRow.AgentProvider)
+			assert.Equal(t, test.resolvedModel, persisted[agent.OptionIDModel])
+			assert.Equal(t, test.changedEffort, persisted[agent.OptionIDEffort])
+
+			row, err := svc.Queries.GetAgentByID(ctx, agentID)
+			require.NoError(t, err)
+			stored := loadOptions(row.Options, row.AgentProvider)
+			assert.Equal(t, test.resolvedModel, stored[agent.OptionIDModel])
+			assert.Equal(t, test.changedEffort, stored[agent.OptionIDEffort])
+		})
 	}
-
-	// The user lowers effort while startup is finishing; the DB row diverges from
-	// the launch options on the effort axis only.
-	require.NoError(t, svc.Queries.SetAgentOptions(ctx, db.SetAgentOptionsParams{
-		Options: marshalOptions(map[string]string{
-			agent.OptionIDModel:          agent.DefaultModelSentinel,
-			agent.OptionIDEffort:         "low",
-			agent.OptionIDPermissionMode: agent.PermissionModeDefault,
-		}),
-		ID: agentID,
-	}))
-	latestRow, err := svc.Queries.GetAgentByID(ctx, agentID)
-	require.NoError(t, err)
-	latestOpts := applyDBSettingsToAgentOptions(initialOpts, &latestRow)
-
-	// The provider confirms the launch settings: the sentinel resolved to a
-	// concrete model, and effort=high (what it launched with).
-	confirmed := confirmedSettingsPreservingStartupChanges(
-		map[string]string{
-			agent.OptionIDModel:  "claude-opus",
-			agent.OptionIDEffort: "high",
-		},
-		initialOpts,
-		latestOpts,
-	)
-	// The changed effort axis is dropped from the confirmed blob; the unchanged
-	// model axis is kept.
-	assert.Equal(t, "claude-opus", confirmed[agent.OptionIDModel])
-	assert.NotContains(t, confirmed, agent.OptionIDEffort)
-
-	activeRow, err := svc.persistConfirmedAgentSettingsPreservingStartedSettings(
-		agentID,
-		latestRow.Options,
-		latestOpts,
-		confirmed,
-		latestRow.OptionGroups,
-	)
-	require.NoError(t, err)
-	persisted := loadOptions(activeRow.Options, activeRow.AgentProvider)
-	assert.Equal(t, "claude-opus", persisted[agent.OptionIDModel], "confirmed model resolution must survive")
-	assert.Equal(t, "low", persisted[agent.OptionIDEffort], "user's mid-startup effort change must be preserved")
-
-	row, err := svc.Queries.GetAgentByID(ctx, agentID)
-	require.NoError(t, err)
-	stored := loadOptions(row.Options, row.AgentProvider)
-	assert.Equal(t, "claude-opus", stored[agent.OptionIDModel])
-	assert.Equal(t, "low", stored[agent.OptionIDEffort])
 }
 
 // TestPersistConfirmedAgentSettings_AppliesConfirmedModelWhenColumnLacksDefaultAxis guards the

--- a/backend/internal/worker/service/open_async_startup_test.go
+++ b/backend/internal/worker/service/open_async_startup_test.go
@@ -506,7 +506,11 @@ func TestPersistConfirmedAgentSettingsPreservesPreStartPermissionModeChange(t *t
 
 // TestPersistConfirmedAgentSettingsAppliesConfirmedModelDespiteOtherAxisChange
 // verifies that a concurrent effort change does not discard a resolved model.
+// A whole-blob compare against the launch options would discard the entire
+// confirmed blob here, and leave the row on the unresolved "default" sentinel.
 func TestPersistConfirmedAgentSettingsAppliesConfirmedModelDespiteOtherAxisChange(t *testing.T) {
+	t.Parallel()
+
 	for _, test := range []struct {
 		name            string
 		provider        leapmuxv1.AgentProvider
@@ -560,6 +564,8 @@ func TestPersistConfirmedAgentSettingsAppliesConfirmedModelDespiteOtherAxisChang
 				initialOpts,
 				latestOpts,
 			)
+			// The changed effort axis leaves the confirmed blob. The unchanged model
+			// axis stays.
 			assert.Equal(t, test.resolvedModel, confirmed[agent.OptionIDModel])
 			assert.NotContains(t, confirmed, agent.OptionIDEffort)
 
@@ -572,8 +578,8 @@ func TestPersistConfirmedAgentSettingsAppliesConfirmedModelDespiteOtherAxisChang
 			)
 			require.NoError(t, err)
 			persisted := loadOptions(activeRow.Options, activeRow.AgentProvider)
-			assert.Equal(t, test.resolvedModel, persisted[agent.OptionIDModel])
-			assert.Equal(t, test.changedEffort, persisted[agent.OptionIDEffort])
+			assert.Equal(t, test.resolvedModel, persisted[agent.OptionIDModel], "the confirmed model resolution must survive")
+			assert.Equal(t, test.changedEffort, persisted[agent.OptionIDEffort], "the user's mid-startup effort change must be preserved")
 
 			row, err := svc.Queries.GetAgentByID(ctx, agentID)
 			require.NoError(t, err)

--- a/backend/internal/worker/service/options_test.go
+++ b/backend/internal/worker/service/options_test.go
@@ -205,3 +205,53 @@ func TestParseOptionGroups_AllOrNothing(t *testing.T) {
 	assert.Nil(t, parseOptionGroups("[]"))
 	assert.Nil(t, parseOptionGroups("{not json"))
 }
+
+// TestResetEffortToAutoIfUnsupported_KeepsEffortOnTheAccountDefault is the guard
+// for silent data loss on a stopped agent. The account-default sentinel is a
+// SELECTABLE model whose catalog entry carries no efforts, so a catalog lookup
+// reports every tier unsupported. Clamping on that answer discards a user's
+// effort on ANY edit -- including an edit that never touched the effort axis --
+// and resolveProviderDefaults only refills an EMPTY effort, so the choice is gone
+// for good. An unresolved model must be left for the running session to validate.
+func TestResetEffortToAutoIfUnsupported_KeepsEffortOnTheAccountDefault(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name     string
+		provider leapmuxv1.AgentProvider
+	}{
+		{name: "codex", provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX},
+		{name: "claude", provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			// No agent is registered under this id, so OptionGroups serves the static
+			// fallback -- exactly the catalog a settings edit on a STOPPED agent sees.
+			manager := agent.NewManager(nil)
+			catalog := manager.OptionGroups("not-running", test.provider, agent.DefaultModelSentinel)
+			require.NotEmpty(t, catalog)
+
+			// An edit on an unrelated axis: the effort is merely inherited from the
+			// stored row, and explicitEffort is empty because the client sent none.
+			inherited := OptionMap{agent.OptionIDModel: agent.DefaultModelSentinel, agent.OptionIDEffort: "high"}
+			resetEffortToAutoIfUnsupported(test.provider, inherited, catalog, agent.DefaultModelSentinel, agent.DefaultModelSentinel, "")
+			assert.Equal(t, "high", inherited[agent.OptionIDEffort],
+				"an edit on another axis must not discard the stored effort")
+
+			// An explicit effort on a stopped agent still sitting on the sentinel.
+			explicit := OptionMap{agent.OptionIDModel: agent.DefaultModelSentinel, agent.OptionIDEffort: "high"}
+			resetEffortToAutoIfUnsupported(test.provider, explicit, catalog, agent.DefaultModelSentinel, agent.DefaultModelSentinel, "high")
+			assert.Equal(t, "high", explicit[agent.OptionIDEffort],
+				"an explicitly chosen effort must stick until the model resolves")
+
+			// Switching TO the sentinel with no effort sent still resets, so the
+			// account's own default model picks its own tier. That clause is
+			// untouched by the unresolved-model guard.
+			switched := OptionMap{agent.OptionIDModel: agent.DefaultModelSentinel, agent.OptionIDEffort: "high"}
+			resetEffortToAutoIfUnsupported(test.provider, switched, catalog, "some-other-model", agent.DefaultModelSentinel, "")
+			assert.Equal(t, agent.EffortAuto, switched[agent.OptionIDEffort],
+				"a model switch with no explicit effort still hands the tier back to the agent")
+		})
+	}
+}

--- a/backend/internal/worker/service/options_test.go
+++ b/backend/internal/worker/service/options_test.go
@@ -63,6 +63,15 @@ func TestResolveProviderDefaults(t *testing.T) {
 	assert.Equal(t, "sonnet", kept[agent.OptionIDModel], "an explicit value is left untouched")
 }
 
+func TestResolveProviderDefaults_CodexUsesAccountDefaultSentinel(t *testing.T) {
+	t.Setenv("LEAPMUX_CODEX_DEFAULT_MODEL", "")
+
+	codex := resolveProviderDefaults(OptionMap{}, leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX)
+
+	assert.Equal(t, agent.DefaultModelSentinel, codex[agent.OptionIDModel])
+	assert.Equal(t, agent.EffortAuto, codex[agent.OptionIDEffort])
+}
+
 // TestOptionsChangeDelta pins the minimal-delta the settings-edit CAS persists: a changed or
 // added key carries its new value, a removed key carries "" (the wire merge deletes it), and
 // an unchanged key is omitted -- so a concurrent server-initiated refresh's keys aren't

--- a/frontend/tests/e2e/102-codex-plan-mode.spec.ts
+++ b/frontend/tests/e2e/102-codex-plan-mode.spec.ts
@@ -13,7 +13,7 @@ const REVISE_PLAN_PROMPT
 async function configureCodexPlanMode(page: Page) {
   await openSettingsMenu(page, 'collaboration_mode')
   await page.locator('[data-testid="collaboration_mode-plan"]').click()
-  await expectSettingsChip(page, 'GPT-5.4 Mini')
+  await expectSettingsChip(page, 'GPT-5.4-Mini')
   await expectSettingsChip(page, 'Plan Mode')
 }
 

--- a/site/content/docs/using/coding-agents.md
+++ b/site/content/docs/using/coding-agents.md
@@ -262,8 +262,11 @@ For providers that support a plan mode, **Shift+Tab** in the editor toggles betw
 
 **Codex** — Fast Mode, Effort, Model, Workflow, Network Access, Sandbox Policy, Approval Policy, plus a **Bypass permissions** item.
 
-- Default model **GPT-5.4** (`gpt-5.4`); also offered: gpt-5.4-mini, gpt-5.3-codex, gpt-5.2-codex, gpt-5.2, gpt-5.1-codex-max, gpt-5.1-codex-mini.
-- Effort tiers: Auto, Ultra, Max, Extra High, High, Medium, Low, Minimal, None.
+- Default model **Default (recommended)** (your Codex account's own pick); also offered: GPT-5.6-Sol, GPT-5.6-Terra, GPT-5.6-Luna, GPT-5.5, GPT-5.4, GPT-5.4-Mini, GPT-5.3-Codex-Spark. A running agent lists whatever models your Codex account offers, so an account-specific model appears here too.
+- Effort tiers depend on the model:
+  - **GPT-5.6-Sol** and **GPT-5.6-Terra** offer the full set: Auto, Ultra, Max, Extra High, High, Medium, Low.
+  - **GPT-5.6-Luna** offers Auto, Max, Extra High, High, Medium, Low.
+  - The other models offer Auto, Extra High, High, Medium, Low.
 - Approval Policy: **Full Auto** (`never`), **Suggest & Approve** (`on-request`, the default), **Auto-edit** (`untrusted`).
 - Sandbox defaults to **Workspace Write** (also Full Access / Read Only); Network defaults to **Restricted** (also Enabled).
 - The **Bypass permissions** item sets network = enabled, sandbox = full access, and approval = Full Auto in one click.


### PR DESCRIPTION
## Motivation
Codex pinned every new session to a fixed model. Claude Code already started new sessions on the account's default model. A user who set an account default model for Codex still got a fixed model on each new session.

Giving Codex the same account-default sentinel exposed a bug in the shared effort logic. `ModelEffortKnown` treated the sentinel as a model with zero supported effort tiers, because its catalog entry deliberately carries no efforts until the CLI resolves a concrete model. `resetEffortToAutoIfUnsupported` then judged every tier unsupported and reset the user's chosen effort to `auto` on any settings edit of a stopped agent, including an edit that never touched effort. Nothing logged it, and `resolveProviderDefaults` only refills an empty effort, so the choice was gone for good. Claude Code has carried the same sentinel all along, so the bug reached it too.

The static Codex model catalog also drifted from the shipped CLI. The picker offered retired models, and it left account-specific models with no description.

## Modifications
- New Codex sessions start on the account default model. `codexThreadParams` and `sendTurnStart` omit the `model` field on the wire when the model is the account default (empty or the `DefaultModelSentinel`), so Codex resolves the concrete model itself.
- A live switch to the account default cannot apply to a running session: `turn/start` sends the stored model string as it is, and Codex refuses the literal string `"default"`. Selecting it now asks for a relaunch, the model twin of the existing effort-auto guard. The guard tests the sentinel by exact match, because an empty value in the settings map means "axis not touched", so a wider test would force a restart on every unrelated edit.
- The nested `collaborationMode.settings.model` field cannot carry that rule at all: Codex rejects it omitted, null and empty alike. The reason is recorded at the site, and the sentinel is stopped at the entry instead.
- `accountDefaultModelEntry` now builds the sentinel catalog row in one place. Claude's catalog calls it too, so its load-bearing empty effort list cannot be lost by a provider that adopts the sentinel later.
- A new `reconcileModelCatalog` step runs once after startup. It reinserts the sentinel row, because Codex's CLI never reports it, so a running tab can return to the account default. It also reinserts a settled model that the live list omits, at its canonical rank, so the picker keeps an effort menu and a context window for it.
- The static Codex catalog now matches codex-cli 0.152.1. Selectable models: gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, gpt-5.5, gpt-5.4, gpt-5.4-mini, gpt-5.3-codex-spark. Five older models stay resolvable by id for a session still pinned to one, but leave the picker.
- Each model advertises a window of the effort ladder through a new `codexEffortsDownFrom` helper instead of three hand-written lists, so a menu cannot skip a rung or fall out of ladder order. An unknown tier now fails at startup, where the previous filter shortened the menu in silence. The tiers `"minimal"` and `"none"` leave `codexEffortIDs`, because the live Codex CLI never offered them; no tier a user could select is removed.
- `queryAvailableModels` reads the live `description` field, so an account-specific model the static catalog does not know (for example Daybreak) shows its own description instead of a blank line.
- Data-loss fix: `ModelEffortKnown` returns `false` for the account default. An unresolved model is not a model that offers nothing, so its effort is left for the running session to validate. This fixes Codex and Claude Code together.
- `defaultModelIDForList` no longer tests `AGENT_PROVIDER_CLAUDE_CODE` in shared code. It calls a new `Provider.ReportsDefaultModelSentinel()` method: `true` only for Claude Code, and `false` with a stated reason for Codex, ZCode and the no-op provider.
- One display name changes from "GPT-5.4 Mini" to "GPT-5.4-Mini", matching what the CLI reports. The plan-mode E2E spec asserts the new chip text.
- The coding-agents docs page describes Codex's default model as **Default (recommended)**, lists the refreshed model set, and states the effort tiers per model: GPT-5.6-Sol and GPT-5.6-Terra offer the full ladder (Auto, Ultra, Max, Extra High, High, Medium, Low); GPT-5.6-Luna drops Ultra and keeps Max; every other model offers Auto, Extra High, High, Medium, Low.

## Result
A new Codex session that does not name a model starts on the account's own default, the same way Claude Code already does, and a running tab can return to that default.

Editing an unrelated setting no longer discards the effort tier you chose, on Codex and on Claude Code.

Codex no longer fails a turn after telling you the message was delivered. Sending on a tab switched to the account default previously produced `The 'default' model is not supported` from Codex, after LeapMux had already acknowledged the message.

The model picker offers what the installed CLI actually supports, shows account-specific models with their real descriptions, and still shows a working effort menu and context window for a session pinned to a retired model.
