### PR TITLE
fix: Gate IMAGE payloads by agent:read, render SVG, title Agent cards

### DIFF
--- a/backend/internal/audit/identity.go
+++ b/backend/internal/audit/identity.go
@@ -184,5 +184,5 @@ var identityComparisonSites = map[string]string{
 	// next, and a colliding client-minted id would suppress a tombstone the real
 	// owner's tab was due. BuildTabSync refuses an unminted owner outright rather
 	// than reporting every row on the machine.
-	"internal/worker/bootstrap.payloadTabIDsForOwner": "TestBuildTabSync_RefusesWithoutARegisteredOwner",
+	"internal/worker/bootstrap.payloadTabIDsByType": "TestBuildTabSync_RefusesWithoutARegisteredOwner",
 }

--- a/backend/internal/cli/control/resolve/resolver_test.go
+++ b/backend/internal/cli/control/resolve/resolver_test.go
@@ -290,7 +290,7 @@ func TestResolve_FixedTabTypeRejectsContradictingFlag(t *testing.T) {
 // The contradiction message prints BOTH sides through TabTypeWireName, so a
 // kind that function does not name reads as `--tab-type "" contradicts this
 // command's implicit type ""`. FILE has been in the enum all along and IMAGE
-// joined it, and neither was named -- so this pins the round trip for every
+// joined it, and neither was stated -- so this pins the round trip for every
 // kind rather than the two the message happened to cover.
 func TestResolve_ContradictionNamesEveryTabKind(t *testing.T) {
 	kinds := []struct {

--- a/backend/internal/worker/agent/codex_output_test.go
+++ b/backend/internal/worker/agent/codex_output_test.go
@@ -1144,7 +1144,7 @@ func TestHandleCodexOutput_DynamicToolCallCompletedDoesNotBroadcastStreamEnd(t *
 }
 
 // Both image items are ordinary tool items and take the ordinary tool path.
-// They used to fall to handleItemCompleted's default arm instead: the completed
+// They used to fall to handleItemCompleted's default branch instead: the completed
 // row persisted with a span id that nothing had opened and nothing then closed,
 // so the transcript drew a rail that stayed open for the rest of the turn.
 func TestHandleCodexOutput_ImageItemsOpenAndCloseASpan(t *testing.T) {

--- a/backend/internal/worker/bootstrap/bootstrap.go
+++ b/backend/internal/worker/bootstrap/bootstrap.go
@@ -479,6 +479,17 @@ func BuildTabSync(queries *db.Queries, owner userid.UserID) (*leapmuxv1.WorkerTa
 		return nil, errors.New("tab sync: no registered owner yet")
 	}
 
+	// ONE read of worker_tab_payloads, bucketed by kind, for every
+	// payload-backed branch below. The switch runs once per TabType, so a
+	// per-branch read scanned the whole table again for each kind and threw
+	// away the rows of the other -- O(kinds x rows) on a path that runs on
+	// every hub connect and reconnect, and that grows with each payload-backed
+	// kind added later.
+	payloadIDs, err := payloadTabIDsByType(ctx, queries, owner)
+	if err != nil {
+		return nil, fmt.Errorf("list payload-backed tab ids: %w", err)
+	}
+
 	var tabs []*leapmuxv1.TabRef
 	// One default-less switch over every TabType, so `exhaustive` (enabled in
 	// .golangci.yml) fails the BUILD when a type is added. That matters more here
@@ -515,11 +526,11 @@ func BuildTabSync(queries *db.Queries, owner userid.UserID) (*leapmuxv1.WorkerTa
 			// only within a user, and a stale second owner's rows can outlive a
 			// deregister (ClearState removes state.json, not worker.db).
 			//
-			// Filtered by KIND as well, because one table now holds both: a row
+			// Bucketed by KIND as well, because one table now holds both: a row
 			// reported under the wrong type would be tombstoned by the hub, which
 			// matches nothing, and the real row would go unreported and be
 			// tombstoned for real.
-			ids, err = payloadTabIDsForOwner(ctx, queries, owner, tabType)
+			ids = payloadIDs[tabType]
 		case leapmuxv1.TabType_TAB_TYPE_UNSPECIFIED:
 			// Not a hostable tab type; nothing to report.
 			continue
@@ -535,20 +546,25 @@ func BuildTabSync(queries *db.Queries, owner userid.UserID) (*leapmuxv1.WorkerTa
 	return &leapmuxv1.WorkerTabInventory{Tabs: tabs}, nil
 }
 
-// payloadTabIDsForOwner returns owner's tab ids of one payload-backed kind,
-// dropping any row belonging to a different user or a different kind. See the
-// FILE/IMAGE case of BuildTabSync for why both filters matter.
-func payloadTabIDsForOwner(ctx context.Context, queries *db.Queries, owner userid.UserID, tabType leapmuxv1.TabType) ([]string, error) {
+// payloadTabIDsByType returns owner's tab ids grouped by payload-backed kind,
+// from ONE read of the table. Rows belonging to a different user are dropped.
+// See the FILE/IMAGE branch of BuildTabSync for why the owner filter matters.
+//
+// Grouped rather than filtered per kind: the caller asks once per TabType, and
+// re-reading the whole table for each one scanned every IMAGE row to answer for
+// FILE and every FILE row to answer for IMAGE.
+func payloadTabIDsByType(ctx context.Context, queries *db.Queries, owner userid.UserID) (map[leapmuxv1.TabType][]string, error) {
 	rows, err := queries.ListAllWorkerTabPayloads(ctx)
 	if err != nil {
 		return nil, err
 	}
-	ids := make([]string, 0, len(rows))
+	ids := make(map[leapmuxv1.TabType][]string)
 	for _, row := range rows {
-		if !owner.Matches(row.UserID) || leapmuxv1.TabType(row.TabType) != tabType {
+		if !owner.Matches(row.UserID) {
 			continue
 		}
-		ids = append(ids, row.TabID)
+		tabType := leapmuxv1.TabType(row.TabType)
+		ids[tabType] = append(ids[tabType], row.TabID)
 	}
 	return ids, nil
 }

--- a/backend/internal/worker/db/migrations/00001_initial.sql
+++ b/backend/internal/worker/db/migrations/00001_initial.sql
@@ -402,12 +402,13 @@ CREATE INDEX idx_agent_background_tasks_child ON agent_background_tasks(child_ag
 -- worktree_tab_liveness above: one definition of the per-type predicate, not N
 -- that must agree.
 --
--- user_id is '' for agents and terminals and REAL for file tabs, and that
--- asymmetry is deliberate rather than a placeholder. It mirrors
--- worktree_tabs.user_id exactly (see worktree_tab_liveness): agent and terminal
--- ids are minted server-side and globally unique, so they need no owner to
--- disambiguate them, while a file tab id is minted client-side as
--- `file-<millis>-<counter>` and is unique only within the client that made it.
+-- user_id is '' for agents and terminals and REAL for payload-backed tabs
+-- (FILE and IMAGE), and that asymmetry is deliberate rather than a placeholder.
+-- It mirrors worktree_tabs.user_id exactly (see worktree_tab_liveness): agent
+-- and terminal ids are minted server-side and globally unique, so they need no
+-- owner to disambiguate them, while a payload-backed tab id is minted
+-- client-side as `<kind>-<millis>-<counter>` and is unique only within the
+-- client that made it.
 -- A reader scopes with `(user_id = '' OR user_id = ?)`, and
 -- worker_tab_payloads' own `CHECK (user_id <> '')` is what makes the '' case
 -- provably unable to match a payload-backed row.

--- a/backend/internal/worker/db/queries/worktrees.sql
+++ b/backend/internal/worker/db/queries/worktrees.sql
@@ -34,14 +34,15 @@ UPDATE worktrees SET branch_name = ? WHERE id = ?;
 DELETE FROM worktrees WHERE rowid IN (SELECT w.rowid FROM worktrees w WHERE w.deleted_at IS NOT NULL AND w.deleted_at < sqlc.arg(cutoff) LIMIT 1000);
 
 -- name: AddWorktreeTab :exec
--- user_id is set only for FILE links (it scopes the worktree_tab_liveness join
--- against worker_tab_payloads); AGENT/TERMINAL links pass '' since their ids are
--- globally unique.
+-- user_id is set for every payload-backed link, FILE and IMAGE alike (it scopes
+-- the worktree_tab_liveness join against worker_tab_payloads, which is keyed by
+-- (user_id, tab_id)); AGENT/TERMINAL links pass '' since their ids are globally
+-- unique.
 INSERT INTO worktree_tabs (worktree_id, tab_type, tab_id, user_id) VALUES (?, ?, ?, ?) ON CONFLICT DO NOTHING;
 
 -- name: RemoveWorktreeTab :exec
--- user_id is part of the key: FILE links carry the owning user (see the
--- worktree_tabs DDL), so an unbound user_id would delete a different user's
+-- user_id is part of the key: payload-backed links carry the owning user (see
+-- the worktree_tabs DDL), so an unbound user_id would delete a different user's
 -- link to the same worktree with the same tab_id. AGENT/TERMINAL callers pass
 -- '' -- exactly what AddWorktreeTab wrote for them.
 DELETE FROM worktree_tabs WHERE worktree_id = ? AND tab_type = ? AND tab_id = ? AND user_id = ?;

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -1167,10 +1167,12 @@ func registerAgentHandlers(d registrar, svc *Service) {
 					// applies: this bus multiplexes agent and terminal tab
 					// renames beside the tab-payload events, and a rename's title
 					// is exactly what the agent:read / terminal:read scopes
-					// govern. A caller granted file:read alone keeps the
-					// file-tab events and the renames of file tabs, and hears
-					// nothing about agents or terminals it holds no scope to
-					// read.
+					// govern. An IMAGE payload states an agent id, a message seq
+					// and a title, so agent:read governs it too -- the stream's
+					// file:read floor admits the FILE payloads and nothing else.
+					// A caller granted file:read alone keeps the file-tab events
+					// and the renames of file tabs, and hears nothing about
+					// agents or terminals it holds no scope to read.
 					if !privateEventVisible(caller, evt) {
 						return nil
 					}
@@ -1204,6 +1206,26 @@ func registerAgentHandlers(d registrar, svc *Service) {
 			// way a deleted working dir does: the git probes fail and the close
 			// path takes its tolerant branch. Per-kind required fields are
 			// likewise the store's (see tabPayloadType).
+			//
+			// The kind is read here for the same per-kind scope gate the stream
+			// and GetTabPayload apply: an IMAGE payload states an agent, so
+			// minting a reference to one is not something file:read authorizes
+			// on its own.
+			tabType, err := tabPayloadType(r.GetPayload())
+			if err != nil {
+				sendInvalidArgument(sender, err.Error())
+				return
+			}
+			if !callerReadsTabType(caller, tabType) {
+				sendPermissionDenied(sender, "scope required for this tab kind")
+				return
+			}
+			// Only a payload the CALLER got wrong is INVALID_ARGUMENT. A
+			// marshal or a database failure is the worker's own fault and
+			// answers INTERNAL, because the two demand opposite responses from
+			// the client: fix the request, or retry it. Reporting a full disk
+			// as a bad argument makes the client roll its optimistic tab back
+			// and tell the user nothing worth acting on.
 			if err := svc.TabPayloads.Register(bgCtx(), RegisterTabPayloadParams{
 				UserID:  caller.UserID.String(),
 				TabID:   r.GetTabId(),
@@ -1242,6 +1264,16 @@ func registerAgentHandlers(d registrar, svc *Service) {
 				return
 			}
 			sendInternalError(sender, err.Error())
+			return
+		}
+		// The same per-kind gate the private-event stream applies. Without it
+		// this one-shot read hands a file:read-only caller the agent id, the
+		// message seq and the title of an IMAGE payload that the stream
+		// withholds -- one route open and the other shut is not a gate.
+		// A payload this binary cannot parse fails closed, as it does there.
+		tabType, err := tabPayloadType(payload)
+		if err != nil || !callerReadsTabType(caller, tabType) {
+			sendNotFoundError(sender, "tab payload not found")
 			return
 		}
 		sendProtoResponse(sender, &leapmuxv1.GetTabPayloadResponse{Payload: payload})
@@ -3763,21 +3795,55 @@ func messageToProto(m *db.Message) *leapmuxv1.AgentChatMessage {
 	}
 }
 
-// privateEventVisible reports whether this stream's caller may see one
-// private event. File-tab events ride the stream's own file:read floor; a tab
-// rename is governed by the scope of the tab KIND it names, exactly as
-// WatchEvents partitions its agent and terminal sections.
-func privateEventVisible(caller channel.Caller, evt *leapmuxv1.WorkerPrivateEvent) bool {
-	renamed := evt.GetTabRenamed()
-	if renamed == nil {
-		return true
-	}
-	switch renamed.GetTabType() {
-	case leapmuxv1.TabType_TAB_TYPE_AGENT:
-		return caller.Allows(leapmuxv1.Scope_SCOPE_AGENT_READ)
+// tabTypeReadScope returns the scope that governs the facts a tab of this kind
+// carries, and whether any scope beyond the stream's own file:read floor
+// applies.
+//
+// An AGENT or a TERMINAL tab's title, and an IMAGE payload's agent id, message
+// seq and title, all describe a transcript or a session. agent:read and
+// terminal:read are what govern those. A FILE tab's path describes neither, so
+// it rides the file:read floor that every caller of these RPCs already holds.
+//
+// The switch lists every kind and has no default, so `exhaustive` fails the
+// build when a new TabType arrives without an answer here. A default would
+// silently give the next payload-backed kind the FILE answer, which is how the
+// IMAGE payload reached a file:read-only caller in the first place.
+func tabTypeReadScope(tabType leapmuxv1.TabType) (leapmuxv1.Scope, bool) {
+	switch tabType {
+	case leapmuxv1.TabType_TAB_TYPE_AGENT, leapmuxv1.TabType_TAB_TYPE_IMAGE:
+		return leapmuxv1.Scope_SCOPE_AGENT_READ, true
 	case leapmuxv1.TabType_TAB_TYPE_TERMINAL:
-		return caller.Allows(leapmuxv1.Scope_SCOPE_TERMINAL_READ)
-	default:
-		return true
+		return leapmuxv1.Scope_SCOPE_TERMINAL_READ, true
+	case leapmuxv1.TabType_TAB_TYPE_FILE, leapmuxv1.TabType_TAB_TYPE_UNSPECIFIED:
+		return leapmuxv1.Scope_SCOPE_UNSPECIFIED, false
 	}
+	return leapmuxv1.Scope_SCOPE_UNSPECIFIED, false
+}
+
+// callerReadsTabType reports whether this caller may learn the facts a tab of
+// this kind carries.
+func callerReadsTabType(caller channel.Caller, tabType leapmuxv1.TabType) bool {
+	scope, governed := tabTypeReadScope(tabType)
+	return !governed || caller.Allows(scope)
+}
+
+// privateEventVisible reports whether this stream's caller may see one
+// private event. A FILE payload rides the stream's own file:read floor; a tab
+// rename and an IMAGE payload are governed by the scope of the tab KIND they
+// name, exactly as WatchEvents partitions its agent and terminal sections.
+//
+// A payload this binary cannot parse fails closed. It cannot state its kind,
+// so it cannot state which scope governs it.
+func privateEventVisible(caller channel.Caller, evt *leapmuxv1.WorkerPrivateEvent) bool {
+	if renamed := evt.GetTabRenamed(); renamed != nil {
+		return callerReadsTabType(caller, renamed.GetTabType())
+	}
+	if registered := evt.GetTabPayloadRegistered(); registered != nil {
+		tabType, err := tabPayloadType(registered.GetPayload())
+		if err != nil {
+			return false
+		}
+		return callerReadsTabType(caller, tabType)
+	}
+	return true
 }

--- a/backend/internal/worker/service/agent_private_events_scope_test.go
+++ b/backend/internal/worker/service/agent_private_events_scope_test.go
@@ -27,7 +27,7 @@ func TestPrivateEventVisibleGatesRenamesByTabKind(t *testing.T) {
 		TabRenamed: &leapmuxv1.TabRenamed{TabId: "t1", TabType: leapmuxv1.TabType_TAB_TYPE_TERMINAL, Title: "secret title"},
 	}}
 	fileEvent := &leapmuxv1.WorkerPrivateEvent{Event: &leapmuxv1.WorkerPrivateEvent_TabPayloadRegistered{
-		TabPayloadRegistered: &leapmuxv1.TabPayloadRegistered{TabId: "f1"},
+		TabPayloadRegistered: &leapmuxv1.TabPayloadRegistered{TabId: "f1", Payload: filePayloadFor("/repo/a.txt")},
 	}}
 
 	assert.False(t, privateEventVisible(fileOnly, agentRename),
@@ -39,6 +39,77 @@ func TestPrivateEventVisibleGatesRenamesByTabKind(t *testing.T) {
 
 	assert.True(t, privateEventVisible(agentAndFile, agentRename),
 		"an agent:read caller reads agent tab titles")
+}
+
+// An IMAGE payload states an agent id, a message seq and a tool-derived title.
+// Those are facts about a transcript, which is what agent:read governs -- and
+// file:read does not imply it (contracts/scopes.json gives SCOPE_FILE_READ only
+// SCOPE_WORKER_READ). The stream is gated on file:read alone, so without a
+// per-kind gate every IMAGE row of the bootstrap replay told a file:read-only
+// caller which agents exist and which messages the user opened.
+func TestPrivateEventVisibleGatesImagePayloadsByAgentScope(t *testing.T) {
+	fileOnly := channel.Caller{UserID: userid.MustNew("u1"), Scopes: mustScopes("file:read")}
+	agentAndFile := channel.Caller{UserID: userid.MustNew("u1"), Scopes: mustScopes("file:read agent:read")}
+
+	imageEvent := &leapmuxv1.WorkerPrivateEvent{Event: &leapmuxv1.WorkerPrivateEvent_TabPayloadRegistered{
+		TabPayloadRegistered: &leapmuxv1.TabPayloadRegistered{
+			TabId:   "i1",
+			Payload: imagePayloadFor("agent-a", 42, 0, "mcp__playwright__screenshot"),
+		},
+	}}
+	fileEvent := &leapmuxv1.WorkerPrivateEvent{Event: &leapmuxv1.WorkerPrivateEvent_TabPayloadRegistered{
+		TabPayloadRegistered: &leapmuxv1.TabPayloadRegistered{TabId: "f1", Payload: filePayloadFor("/repo/a.txt")},
+	}}
+
+	assert.False(t, privateEventVisible(fileOnly, imageEvent),
+		"a file:read caller must not learn an image tab's agent, seq or title")
+	assert.True(t, privateEventVisible(agentAndFile, imageEvent),
+		"an agent:read caller reads image payloads")
+	assert.True(t, privateEventVisible(fileOnly, fileEvent),
+		"a FILE payload still rides the stream's own file:read floor")
+}
+
+// A payload this binary cannot parse states no kind, so it states no scope
+// either. Failing closed is the only answer that cannot leak: the alternative
+// hands an unknown future payload to whichever caller happens to be listening.
+func TestPrivateEventVisibleRefusesAnUndecodablePayload(t *testing.T) {
+	fileOnly := channel.Caller{UserID: userid.MustNew("u1"), Scopes: mustScopes("file:read")}
+	everything := channel.Caller{UserID: userid.MustNew("u1"), Scopes: mustScopes("file:read agent:read terminal:read")}
+
+	noKind := &leapmuxv1.WorkerPrivateEvent{Event: &leapmuxv1.WorkerPrivateEvent_TabPayloadRegistered{
+		TabPayloadRegistered: &leapmuxv1.TabPayloadRegistered{TabId: "x1", Payload: &leapmuxv1.TabPayload{}},
+	}}
+
+	assert.False(t, privateEventVisible(fileOnly, noKind))
+	assert.False(t, privateEventVisible(everything, noKind),
+		"a payload with no kind is withheld from every caller, not just an unprivileged one")
+}
+
+// The revoke event carries a bare tab id and no payload, so it states nothing
+// about an agent and needs no per-kind gate. It must keep flowing, or a peer
+// that closed an image tab would leave a phantom on every other client.
+func TestPrivateEventVisiblePassesRevocations(t *testing.T) {
+	fileOnly := channel.Caller{UserID: userid.MustNew("u1"), Scopes: mustScopes("file:read")}
+	revoked := &leapmuxv1.WorkerPrivateEvent{Event: &leapmuxv1.WorkerPrivateEvent_TabPayloadRevoked{
+		TabPayloadRevoked: &leapmuxv1.TabPayloadRevoked{TabId: "i1"},
+	}}
+	assert.True(t, privateEventVisible(fileOnly, revoked))
+}
+
+func filePayloadFor(path string) *leapmuxv1.TabPayload {
+	return &leapmuxv1.TabPayload{
+		WorkingDir: "/repo",
+		Kind:       &leapmuxv1.TabPayload_File{File: &leapmuxv1.FileTabPayload{FilePath: path}},
+	}
+}
+
+func imagePayloadFor(agentID string, seq int64, index int32, title string) *leapmuxv1.TabPayload {
+	return &leapmuxv1.TabPayload{
+		WorkingDir: "/repo",
+		Kind: &leapmuxv1.TabPayload_Image{Image: &leapmuxv1.ImageTabPayload{
+			AgentId: agentID, Seq: seq, ImageIndex: index, Title: title,
+		}},
+	}
 }
 
 func mustScopes(tokens string) authscope.ScopeSet {

--- a/backend/internal/worker/service/close_tab.go
+++ b/backend/internal/worker/service/close_tab.go
@@ -625,7 +625,8 @@ func (svc *Service) closeTabForConvergence(
 // offline path from destroying a clean worktree the identical online close kept.
 //
 // userID is empty for AGENT and TERMINAL, whose links are written owner-blind; a
-// FILE tab's id is unique only within a user, so its owner is required.
+// payload-backed tab's id (FILE or IMAGE) is unique only within a user, so its
+// owner is required.
 func (svc *Service) CloseTabForReconcile(tabType leapmuxv1.TabType, userID, tabID string) {
 	svc.closeTabForConvergence(tabType, userID, tabID, dropWorktreeLink)
 }

--- a/backend/internal/worker/service/git.go
+++ b/backend/internal/worker/service/git.go
@@ -2079,8 +2079,8 @@ var errNoTabWorkingDir = errors.New("tab has no working directory recorded")
 
 // getTabWorkingDir resolves the directory a tab's git questions are answered
 // from. Every tab type has one: agents and terminals carry it on their own row,
-// and a file tab carries the working dir of the tab it was opened from (see the
-// worker_tab_payloads.working_dir column comment).
+// and a payload-backed tab (FILE or IMAGE) carries the working dir of the tab it
+// was opened from (see the worker_tab_payloads.working_dir column comment).
 //
 // userID is only consulted for payload-backed tabs -- FILE and IMAGE -- whose
 // ids are unique within a user
@@ -2090,8 +2090,9 @@ var errNoTabWorkingDir = errors.New("tab has no working directory recorded")
 //
 // That latitude stops at this function. `hasOtherNonWorktreeTabOnBranch` takes
 // the same string and requires a real owner whatever the closing tab's type is,
-// because its FILE leg always runs: an agent close still has to see the user's
-// file tabs to know whether it is the last tab on the branch.
+// because its payload-backed scan always runs: an agent close still has to see
+// the user's file and image tabs to know whether it is the last tab on the
+// branch.
 func (svc *Service) getTabWorkingDir(ctx context.Context, tabType leapmuxv1.TabType, tabID, userID string) (string, error) {
 	dir, err := svc.readTabWorkingDir(ctx, tabType, tabID, userID)
 	if err != nil {
@@ -2143,7 +2144,7 @@ func (svc *Service) readTabWorkingDir(ctx context.Context, tabType leapmuxv1.Tab
 // Enforced by branchInfoProbe, which is allocated once per call and shared by
 // every per-type scan under it. It used to be a SetLimit on each scan's OWN
 // errgroup -- and those scans run concurrently, so the number here was the
-// number per LEG: 12 with agents+terminals, 18 once the file-tab leg landed,
+// number per SCAN: 12 with agents+terminals, 18 once the file-tab scan landed,
 // 24 for the next tab type. Holding the budget at the fork site instead makes
 // it independent of how the callers are fanned out.
 const branchProbeConcurrency = 6
@@ -2156,16 +2157,16 @@ const branchProbeConcurrency = 6
 // file tab still open on it, and closing that file tab would announce the same
 // with the agent still running.
 //
-// userID scopes the FILE leg only; see getTabWorkingDir.
+// userID scopes the payload-backed scan only; see getTabWorkingDir.
 func (svc *Service) hasOtherNonWorktreeTabOnBranch(ctx context.Context, tabType leapmuxv1.TabType, tabID, userID, repoRoot, branchName string) (bool, error) {
-	// Validate the owner BEFORE anything is launched. The FILE leg needs it
-	// (see its launch below), and refusing after the other two scans are
+	// Validate the owner BEFORE anything is launched. The payload-backed scan
+	// needs it (see its launch below), and refusing after the other two scans are
 	// already running would abandon their goroutines: nothing would reach the
 	// single g.Wait(), so their errors would be dropped and their rev-parse
 	// forks left to be torn down by the deferred cancel().
 	owner, ok := userid.New(userID)
 	if !ok {
-		return false, errors.New("branch sibling scan: owner required to scope the file-tab leg")
+		return false, errors.New("branch sibling scan: owner required to scope the payload-backed scan")
 	}
 
 	// gitPathInfo lookups dedupe at two levels:
@@ -2247,8 +2248,8 @@ func (svc *Service) hasOtherNonWorktreeTabOnBranch(ctx context.Context, tabType 
 //
 // The self-skip matches on (tab_type, tab_id), not on tab_id alone. Across the
 // unified relation an id is not unique by itself: agent and terminal ids are
-// globally unique, but a file tab id is minted client-side as
-// `file-<millis>-<counter>` and only unique within a user, so a bare id match
+// globally unique, but a payload-backed tab id is minted client-side as
+// `<kind>-<millis>-<counter>` and only unique within a user, so a bare id match
 // could drop a DIFFERENT tab that happens to share the string -- counting one
 // fewer sibling and prompting to delete a branch someone is still on.
 func (svc *Service) collectTabDirs(ctx context.Context, query string, args []any, selfType leapmuxv1.TabType, selfID string) ([]string, error) {

--- a/backend/internal/worker/service/orphan_reconciler_gc_test.go
+++ b/backend/internal/worker/service/orphan_reconciler_gc_test.go
@@ -223,7 +223,7 @@ func TestWorktreeLiveness_CountAndCandidates_AcrossTabTypes(t *testing.T) {
 // that teardown applies.
 //
 // The arm used to hand-roll its own teardown, diverging from the AGENT and
-// TERMINAL arms. It now routes through closePayloadTabCommon like they do, with
+// TERMINAL branches. It now routes through closePayloadTabCommon like they do, with
 // dropWorktreeLink -- the same policy an ONLINE KEEP close uses. That is what
 // KEEP means: a zero-link worktree is excluded from
 // ListOrphanCandidateWorktrees, so the DIRECTORY SURVIVES rather than being

--- a/backend/internal/worker/service/orphan_reconciler_testsupport_test.go
+++ b/backend/internal/worker/service/orphan_reconciler_testsupport_test.go
@@ -10,7 +10,7 @@ import (
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
 )
 
-// filePayload builds the FILE arm of a TabPayload for the reconciler tests,
+// filePayload builds the FILE branch of a TabPayload for the reconciler tests,
 // which care about which rows survive rather than what is in them.
 func filePayload(filePath string) *leapmuxv1.TabPayload {
 	return &leapmuxv1.TabPayload{

--- a/backend/internal/worker/service/tab_payload.go
+++ b/backend/internal/worker/service/tab_payload.go
@@ -41,6 +41,10 @@ func NewTabPayloadStore(q *db.Queries, events *PrivateEventsBus) *TabPayloadStor
 
 // Register persists a (user_id, tab_id, tab_type, payload, working_dir) row and
 // broadcasts TabPayloadRegistered on the owner's private-event stream.
+//
+// Every error a bad request produces wraps ErrInvalidTabPayload; a marshal or a
+// database failure does not. The two are separate answers on the wire, and only
+// the second is worth a retry.
 func (s *TabPayloadStore) Register(ctx context.Context, p RegisterTabPayloadParams) error {
 	owner, ok := userid.New(p.UserID)
 	if !ok || p.TabID == "" || p.Payload == nil {
@@ -338,8 +342,10 @@ func (s *TabPayloadStore) Get(ctx context.Context, userID, tabID string) (*leapm
 }
 
 // TabTypeOf reports which kind of tab a stored payload belongs to, without
-// decoding the payload itself -- the column is there precisely so a reader that
-// only needs the kind pays nothing for the blob.
+// decoding the payload itself. The read still fetches the blob, because
+// GetWorkerTabPayload is a `SELECT *`; what the column saves is the
+// proto.Unmarshal, and the ability to answer for a row this binary cannot
+// parse.
 //
 // Returns ErrTabPayloadNotFound when no row exists, so a caller can tell "this
 // tab is an IMAGE tab" from "this tab is already closed".

--- a/backend/internal/worker/service/tab_payload_test.go
+++ b/backend/internal/worker/service/tab_payload_test.go
@@ -453,7 +453,7 @@ func TestTabPayload_ImageArm(t *testing.T) {
 	}
 }
 
-// TestTabPayload_RefusesAPayloadWithNoKind pins the default arm: a payload
+// TestTabPayload_RefusesAPayloadWithNoKind pins the default branch: a payload
 // whose oneof is unset specifies no tab, so there is nothing to store it as.
 func TestTabPayload_RefusesAPayloadWithNoKind(t *testing.T) {
 	t.Parallel()
@@ -468,7 +468,7 @@ func TestTabPayload_RefusesAPayloadWithNoKind(t *testing.T) {
 // TestTabPayload_ImageWorkingDirIsNotDerived pins the one place the two kinds
 // genuinely differ: a FILE tab with no stated working dir falls back to the
 // file's own directory, and an IMAGE tab has no file to fall back to. An
-// unnamed one stays blank and simply joins no branch group -- inventing a
+// one with no stated dir stays blank and simply joins no branch group -- inventing a
 // directory for it would put the tab in a repo the user never opened it from.
 func TestTabPayload_ImageWorkingDirIsNotDerived(t *testing.T) {
 	t.Parallel()

--- a/backend/internal/worker/service/tab_payload_testsupport_test.go
+++ b/backend/internal/worker/service/tab_payload_testsupport_test.go
@@ -6,7 +6,7 @@ import (
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 )
 
-// fileTabPayload builds the FILE arm of a TabPayload, which is what almost
+// fileTabPayload builds the FILE branch of a TabPayload, which is what almost
 // every test in this package registers. Kept here rather than repeated at each
 // call site so a change to the payload shape is one edit.
 func fileTabPayload(filePath, workingDir string) *leapmuxv1.TabPayload {

--- a/desktop/rust/src/tray/minimize_macos.rs
+++ b/desktop/rust/src/tray/minimize_macos.rs
@@ -67,6 +67,7 @@ use std::ptr::{self, NonNull};
 use std::sync::{Arc, OnceLock};
 
 use objc2::ffi::class_addMethod;
+use objc2::rc::Retained;
 use objc2::runtime::{AnyClass, AnyObject, Imp, Sel};
 use objc2::{msg_send, sel};
 use tauri::WebviewWindow;
@@ -97,13 +98,28 @@ struct MinimizeHook {
     /// carries the override, and a `super` relative to the receiver's own
     /// class sends `miniaturize:` straight back into this module.
     super_class: &'static AnyClass,
-    /// The address of the window that the policy applies to.
+    /// The window that the policy applies to.
     ///
     /// Every tao window in the process shares the class that carries the
-    /// override, so the override must recognise its own window. An address
-    /// identifies it: tauri owns the main window for the length of the
-    /// process, and `answer` holds a `WebviewWindow` for it besides.
-    window: usize,
+    /// override, so the override must recognise its own window.
+    ///
+    /// A WEAK reference, not an address. An address identifies a window only
+    /// while that window lives, and a raw `usize` cannot tell a live window
+    /// from a dead one: once the original is released, the allocator may hand
+    /// a later window the same address, and that window would inherit the
+    /// hide-to-tray policy -- its yellow button would make it vanish with no
+    /// Dock tile and no tray entry that states it. A weak reference answers
+    /// `None` instead, and the override falls through to the ordinary
+    /// minimize, which is the safe direction.
+    ///
+    /// Nothing else anchors it. The `WebviewWindow` clone that `answer`
+    /// captures is a label-keyed handle over the runtime dispatcher and holds
+    /// no retain on the `NSWindow`.
+    ///
+    /// Weak rather than strong on purpose: a strong reference would keep the
+    /// window alive for the life of the process, which is a leak that hides
+    /// the very lifetime question this field exists to answer.
+    window: WeakWindow,
     /// Answers one minimize on the window that `install` hooked. Reports
     /// whether it hid that window.
     ///
@@ -112,6 +128,38 @@ struct MinimizeHook {
     /// none up by label. It is also the seam that the tests drive: a
     /// `WebviewWindow` needs a running application, and a stub answer does not.
     answer: Box<dyn Fn() -> bool + Send + Sync>,
+}
+
+/// A weak reference to the hooked window, storable in a process global.
+///
+/// `objc2::rc::Weak` is neither `Send` nor `Sync`, because a general
+/// Objective-C object may be neither. This one is safe to share:
+///
+/// - `objc_storeWeak` / `objc_loadWeak` / `objc_destroyWeak` are thread safe by
+///   contract; the runtime serializes them on its own side table.
+/// - Every access here happens on the MAIN thread. `install` runs from
+///   `tray::install` during setup, and `miniaturize` runs from an AppKit
+///   dispatch, which is main-thread by definition.
+/// - The value lives in a `static OnceLock`, so it is never dropped and no
+///   destructor races anything.
+struct WeakWindow(objc2::rc::Weak<AnyObject>);
+
+// SAFETY: see the type's own doc. The wrapper adds no access of its own; it
+// only lets the reference sit in a `static`.
+unsafe impl Send for WeakWindow {}
+// SAFETY: same.
+unsafe impl Sync for WeakWindow {}
+
+/// Whether `this` is the window the policy was installed for.
+///
+/// A dead reference answers `false`, so a window that took the dead one's
+/// address keeps the ordinary minimize rather than inheriting a policy that was
+/// never meant for it.
+fn is_hooked_window(hook: &MinimizeHook, this: *const AnyObject) -> bool {
+    hook.window
+        .0
+        .load()
+        .is_some_and(|live| ptr::eq(Retained::as_ptr(&live), this))
 }
 
 static HOOK: OnceLock<MinimizeHook> = OnceLock::new();
@@ -171,7 +219,12 @@ pub(crate) fn install(window: &WebviewWindow, state: Arc<TrayState>) {
     if HOOK
         .set(MinimizeHook {
             super_class,
-            window: ptr::from_ref(object) as usize,
+            // SAFETY: `object` is the live `NSWindow` that `install` was given;
+            // `Weak::from_retained` needs a strong reference, so this borrows
+            // one for the length of the call and lets it go again.
+            window: WeakWindow(objc2::rc::Weak::from_retained(unsafe {
+                &Retained::retain(ptr::from_ref(object).cast_mut()).expect("the window is live")
+            })),
             answer: Box::new(move || super::handle_minimize(&state, &hooked)),
         })
         .is_err()
@@ -202,7 +255,7 @@ pub(crate) fn install(window: &WebviewWindow, state: Arc<TrayState>) {
 /// and the runtime removes that subclass again when the last observer goes
 /// away. `-class` answers past it, which is where an override survives.
 ///
-/// Answers `None` when the window does not inherit from the class it names.
+/// Answers `None` when the window does not inherit from the class it states.
 /// `-class` is a method like any other, and an override that answers an
 /// unrelated class would put `miniaturize:` on a class whose own instances
 /// then run the policy for a window they are not.
@@ -310,7 +363,7 @@ extern "C-unwind" fn miniaturize(this: &AnyObject, _cmd: Sel, sender: *mut AnyOb
     // Every tao window in the process shares the class that carries this
     // override. The main window is the one with a policy, so the rest fall
     // through to the ordinary minimize.
-    if ptr::from_ref(this) as usize == hook.window {
+    if is_hooked_window(hook, ptr::from_ref(this)) {
         let hidden = catch_unwind(AssertUnwindSafe(|| (hook.answer)())).unwrap_or_else(|_| {
             crate::shell_log!("the minimize policy panicked; the window minimizes as usual");
             false
@@ -335,7 +388,10 @@ mod tests {
     use objc2::runtime::{AnyClass, AnyObject, ClassBuilder, Method, NSObject, Sel};
     use objc2::{msg_send, sel, ClassType};
 
-    use super::{add_override, defines_miniaturize, window_class, MinimizeHook, HOOK};
+    use super::{
+        add_override, defines_miniaturize, is_hooked_window, window_class, MinimizeHook, WeakWindow,
+        HOOK,
+    };
 
     /// The prefix that Key-Value Observing gives to the class it generates.
     const KVO_CLASS_PREFIX: &[u8] = b"NSKVONotifying_";
@@ -379,7 +435,7 @@ mod tests {
     /// A stand-in for tao's `TaoWindow`: it adds nothing, so `miniaturize:`
     /// reaches it only through the override that a test installs.
     ///
-    /// Each test names its own classes, because `objc_registerClassPair` cannot
+    /// Each test registers its own classes, because `objc_registerClassPair` cannot
     /// be undone and a name registers once for the whole process.
     fn stub_subclass(name: &CStr, superclass: &AnyClass) -> &'static AnyClass {
         ClassBuilder::new(name, superclass)
@@ -581,7 +637,7 @@ mod tests {
         let other: Retained<AnyObject> = unsafe { msg_send![installed_class, new] };
         HOOK.set(MinimizeHook {
             super_class: base,
-            window: ptr::from_ref(&*window) as usize,
+            window: WeakWindow(objc2::rc::Weak::from_retained(&window)),
             answer: Box::new(|| {
                 assert!(
                     !HOOK_PANICS.load(Ordering::SeqCst),
@@ -639,5 +695,45 @@ mod tests {
         let calls = minimize(&window);
         HOOK_PANICS.store(false, Ordering::SeqCst);
         assert_eq!(calls, 4, "a panic must leave the ordinary minimize alone");
+    }
+
+    // A window that took the hooked window's ADDRESS after it died must not
+    // inherit its policy.
+    //
+    // Every tao window in the process shares the class that carries the
+    // override, so the override recognises its own window itself. It used to
+    // compare a raw `usize`, which cannot tell a live window from a dead one:
+    // once the original is released, the allocator may hand a later window the
+    // same address, and that window's yellow button would then hide it with no
+    // Dock tile and no tray entry that states it. A weak reference answers
+    // `None` instead, and the caller falls through to the ordinary minimize.
+    //
+    // It drives `is_hooked_window` rather than the selector, because `HOOK`
+    // publishes once per process and the dispatch test above owns it.
+    #[test]
+    fn a_dead_window_reference_matches_no_receiver() {
+        let base = stub_window_class(c"LeapMuxWeakBase");
+        let class = stub_subclass(c"LeapMuxWeak", base);
+        // SAFETY: `class` descends from `NSObject`, which answers `new`.
+        let window: Retained<AnyObject> = unsafe { msg_send![class, new] };
+        let address = ptr::from_ref(&*window);
+        let hook = MinimizeHook {
+            super_class: base,
+            window: WeakWindow(objc2::rc::Weak::from_retained(&window)),
+            answer: Box::new(|| false),
+        };
+
+        assert!(
+            is_hooked_window(&hook, address),
+            "the live window it was installed for must match"
+        );
+
+        // The last strong reference goes, so the weak one empties.
+        drop(window);
+
+        assert!(
+            !is_hooked_window(&hook, address),
+            "a later window at the same address must not inherit the policy"
+        );
     }
 }

--- a/frontend/src/components/chat/ChatImageViewer.test.tsx
+++ b/frontend/src/components/chat/ChatImageViewer.test.tsx
@@ -2,6 +2,7 @@ import type { AgentChatMessage } from '~/generated/proto/leapmux/v1/agent_pb'
 import { render, waitFor } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
 import { AgentProvider } from '~/generated/proto/leapmux/v1/agent_pb'
+import { MAX_INLINE_IMAGE_BASE64_LEN } from '~/lib/imageBlocks'
 import { makeMessage, rawContent } from '~/test-support/messageFactory'
 import { ChatImageViewer, decodeImageBytes } from './ChatImageViewer'
 import './providers/claude'
@@ -11,7 +12,7 @@ import './providers/testMocks'
 const PNG_BASE64 = 'iVBORw0KGgo='
 const PNG_BYTES = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]
 
-describe('decodeimagebytes', () => {
+describe('decodeImageBytes', () => {
   it('decodes inline base64 with its stated mime type', () => {
     const decoded = decodeImageBytes({ data: PNG_BASE64, mimeType: 'image/png' })
     expect(decoded?.mimeType).toBe('image/png')
@@ -34,6 +35,31 @@ describe('decodeimagebytes', () => {
 
   it('refuses a non-base64 data URL', () => {
     expect(decodeImageBytes({ url: 'data:image/png,rawbytes' })).toBeNull()
+  })
+
+  // The tab addresses its image by (agent, seq, index) and re-resolves it at
+  // open time, so the source it decodes is not necessarily the one the click
+  // validated -- a same-seq message merge can move index N. Applying the SAME
+  // policy the transcript row applies is what keeps the two from disagreeing.
+  it('decodes an SVG, which the transcript row draws and the file viewer already did', () => {
+    const decoded = decodeImageBytes({ data: PNG_BASE64, mimeType: 'image/svg+xml' })
+    expect(decoded?.mimeType).toBe('image/svg+xml')
+  })
+
+  it('refuses a type the row refuses, so the two cannot disagree', () => {
+    expect(decodeImageBytes({ data: PNG_BASE64, mimeType: 'application/pdf' })).toBeNull()
+  })
+
+  it('refuses a payload past the inline size cap', () => {
+    const huge = 'A'.repeat(MAX_INLINE_IMAGE_BASE64_LEN + 1)
+    expect(decodeImageBytes({ data: huge, mimeType: 'image/png' })).toBeNull()
+  })
+
+  // A parameter must not reach the Blob type, or the tab and the row describe
+  // the same bytes two ways.
+  it('drops a data-URL parameter from the mime it hands the blob', () => {
+    const decoded = decodeImageBytes({ url: `data:image/png;charset=utf-8;base64,${PNG_BASE64}` })
+    expect(decoded?.mimeType).toBe('image/png')
   })
 
   it('refuses a data URL with no comma', () => {
@@ -114,10 +140,10 @@ describe('chatImageViewer', () => {
     expect(container.querySelector('img')).toBeNull()
   })
 
-  // The guard arm. An image block can be legitimate and carry nothing -- an
+  // The guard branch. An image block can be legitimate and carry nothing -- an
   // Anthropic `source:{type:'file'}`, or an MCP server that states a type and
   // no payload -- and it keeps its index so the row and this tab still agree.
-  // Without the arm this resolves `ready`, decodes to nothing, and the tab sits
+  // Without the branch this resolves `ready`, decodes to nothing, and the tab sits
   // on "Loading image…" forever.
   it('says so when the reference resolves to bytes it cannot decode', async () => {
     const { container } = renderViewer(claudeImageMessage([{ type: 'image', mimeType: 'image/png' }]))

--- a/frontend/src/components/chat/ChatImageViewer.tsx
+++ b/frontend/src/components/chat/ChatImageViewer.tsx
@@ -5,6 +5,7 @@ import { createEffect, createMemo, createSignal, Match, on, onCleanup, Switch } 
 import * as styles from '~/components/fileviewer/FileViewer.css'
 import { ImageRender } from '~/components/fileviewer/ImageFileView'
 import { base64ToUint8Array } from '~/lib/base64'
+import { imageRenderInfo, parseDataImageUrl } from '~/lib/imageBlocks'
 import { resolveChatImage } from './chatImageResolve'
 
 /**
@@ -95,12 +96,16 @@ export function ChatImageViewer(props: {
           {(resolution() as { status: 'error', message: string }).message}
         </div>
       </Match>
-      {/* Resolved, and the bytes will not decode. This branch is REACHED, not
-          defensive: `imageRenderInfo` gates the click target on the shape of the
-          source and never on whether the payload decodes, so base64 the browser
-          refuses lands here, and so does an image block that states a MIME type
-          and carries nothing. A sentence beats the `fallback` below, which would
-          otherwise say "Loading image…" forever on a tab that will never load. */}
+      {/* Resolved, and the bytes will not decode. `ImageResultView` draws a
+          click target only for an image `imageRenderInfo` accepts, and this
+          decoder now asks the same function, so a picture the row drew always
+          decodes here.
+          It stays reachable on purpose for the case the click cannot cover: the
+          tab stores (agent, seq, index) rather than the bytes, so a message that
+          merges in place can put a different source at index N between the click
+          and the re-resolve. The alternative is the `fallback` below --
+          "Loading image…" forever, on a tab that will never load. A sentence
+          beats a spinner. */}
       <Match when={resolution().status === 'ready'}>
         <div class={styles.errorState}>
           This image cannot be displayed here.
@@ -113,16 +118,26 @@ export function ChatImageViewer(props: {
 /**
  * Turn a resolved source into bytes the blob URL can hold.
  *
- * Only inline base64 is decodable here. An image the agent named by URL was
+ * Only inline base64 is decodable here. An image the agent gave as a URL was
  * never inlined in the transcript either -- the chat row shows it as a link for
  * the same anti-exfiltration reason -- so there is nothing local to open, and
  * such an image never becomes a tab (see the click handler in ImageResultView).
+ *
+ * It applies the SAME `imageRenderInfo` policy the transcript row applies, from
+ * the same module, so the tab and the row can never disagree about which
+ * pictures are displayable. The tab addresses its image by (agent, seq, index)
+ * and re-resolves it at open time, so the source it decodes is not necessarily
+ * the one the click validated: a same-seq message merge can move index N.
+ * Without the check here a 40 MB payload, or a type the row refuses, would
+ * reach a Blob that the
+ * row beside it refuses to draw.
  */
 export function decodeImageBytes(source: { data?: string, url?: string, mimeType?: string }): { content: Uint8Array, mimeType: string } | null {
-  const inline = source.data
-    ? { base64: source.data, mimeType: source.mimeType }
-    : parseDataUrl(source.url)
-  if (!inline?.base64 || !inline.mimeType)
+  const info = imageRenderInfo(source)
+  if (!info.src)
+    return null
+  const inline = parseDataImageUrl(info.src)
+  if (!inline)
     return null
   try {
     return { content: base64ToUint8Array(inline.base64), mimeType: inline.mimeType }
@@ -130,17 +145,4 @@ export function decodeImageBytes(source: { data?: string, url?: string, mimeType
   catch {
     return null
   }
-}
-
-/** Split a `data:<mime>;base64,<payload>` URL. Returns null for anything else. */
-function parseDataUrl(url: string | undefined): { base64: string, mimeType: string } | null {
-  if (!url?.startsWith('data:'))
-    return null
-  const comma = url.indexOf(',')
-  if (comma < 0)
-    return null
-  const meta = url.slice('data:'.length, comma)
-  if (!meta.toLowerCase().endsWith(';base64'))
-    return null
-  return { base64: url.slice(comma + 1), mimeType: meta.slice(0, meta.length - ';base64'.length) }
 }

--- a/frontend/src/components/chat/chatImageResolve.test.ts
+++ b/frontend/src/components/chat/chatImageResolve.test.ts
@@ -38,7 +38,7 @@ function deps(overrides: Partial<Parameters<typeof resolveChatImage>[1]> = {}) {
 
 const ref = { workerId: 'w1', agentId: 'a1', seq: 7n, imageIndex: 0 }
 
-describe('messagetoolresultimages', () => {
+describe('messageToolResultImages', () => {
   it('routes through the message provider plugin, keeping wire order', () => {
     expect(messageToolResultImages(claudeImageMessage(['first', 'second'])).map(i => i.data))
       .toEqual(['first', 'second'])
@@ -55,7 +55,7 @@ describe('messagetoolresultimages', () => {
   })
 })
 
-describe('imagefrommessage', () => {
+describe('imageFromMessage', () => {
   it('picks the image at the index', () => {
     expect(imageFromMessage(claudeImageMessage(['first', 'second']), 1)?.data).toBe('second')
   })
@@ -65,7 +65,7 @@ describe('imagefrommessage', () => {
   })
 })
 
-describe('resolvechatimage', () => {
+describe('resolveChatImage', () => {
   it('resolves from the loaded window without fetching', async () => {
     const fetchMessageBySeq = vi.fn(async () => undefined)
     const result = await resolveChatImage(ref, deps({

--- a/frontend/src/components/chat/providers/agentResultRendering.test.tsx
+++ b/frontend/src/components/chat/providers/agentResultRendering.test.tsx
@@ -46,11 +46,26 @@ function agentToolResult(resultContent: string, toolUseResult?: Record<string, u
   }
 }
 
-function renderAgentResult(resultContent: string, toolUseResult?: Record<string, unknown>): HTMLElement {
+function renderAgentResult(
+  resultContent: string,
+  toolUseResult?: Record<string, unknown>,
+  toolUseInput?: Record<string, unknown>,
+): HTMLElement {
   const category: MessageCategory = { kind: 'tool_result' }
+  const toolUseParsed = toolUseInput
+    ? {
+        rawText: '',
+        topLevel: null,
+        parentObject: {
+          type: 'assistant',
+          message: { role: 'assistant', content: [{ type: 'tool_use', name: 'Agent', input: toolUseInput }] },
+        },
+        wrapper: null,
+      }
+    : undefined
   const result = renderMessageContent(
     agentToolResult(resultContent, toolUseResult),
-    { spanType: 'Agent' },
+    { spanType: 'Agent', toolUseParsed },
     category,
     AgentProvider.CLAUDE_CODE,
   )
@@ -63,7 +78,7 @@ describe('claude Agent tool_result rendering: an async launch', () => {
   // about the work, so it belongs in the field list rather than the headline.
   it('shows the task in the header rather than the agent id', () => {
     const text = renderAgentResult(HARNESS_TEXT, asyncLaunch()).textContent ?? ''
-    expect(text).toContain('Agent \'Verify V1 theme pair freeze\' launched asynchronously')
+    expect(text).toContain('Agent "Verify V1 theme pair freeze" launched asynchronously')
   })
 
   it('lists the agent id, the model and the output file', () => {
@@ -107,7 +122,7 @@ describe('claude Agent tool_result rendering: an async launch', () => {
   it('caps an overlong task description so the outcome stays in the header', () => {
     const description = 'Audit every renderer that clips a one-line header '.repeat(4)
     const text = renderAgentResult(HARNESS_TEXT, asyncLaunch({ description })).textContent ?? ''
-    expect(text).toContain('\u2026\' launched asynchronously')
+    expect(text).toContain('\u2026" launched asynchronously')
     expect(text).not.toContain(description)
   })
 
@@ -115,7 +130,7 @@ describe('claude Agent tool_result rendering: an async launch', () => {
     const text = renderAgentResult(HARNESS_TEXT, asyncLaunch({
       description: 'Freeze the theme pairs\nand then audit them',
     })).textContent ?? ''
-    expect(text).toContain('Agent \'Freeze the theme pairs\' launched asynchronously')
+    expect(text).toContain('Agent "Freeze the theme pairs" launched asynchronously')
     expect(text).not.toContain('and then audit them')
   })
 
@@ -144,7 +159,7 @@ describe('claude Agent tool_result rendering: a remote launch', () => {
       prompt: PROMPT,
       outputFile: OUTPUT_FILE,
     }).textContent ?? ''
-    expect(text).toContain('Agent \'Audit the migration\' launched remotely')
+    expect(text).toContain('Agent "Audit the migration" launched remotely')
     expect(text).toContain('Task ID:')
     expect(text).toContain('task-remote-1')
     expect(text).toContain('Session:')
@@ -189,6 +204,40 @@ describe('claude Agent tool_result rendering: a finished run', () => {
   it('falls through to the catch-all when there is no structured payload at all', () => {
     const text = renderAgentResult('just text').textContent ?? ''
     expect(text).not.toContain('Agent ID:')
+  })
+
+  // A synchronous result omits `description`. The paired tool_use input carries
+  // the model-written task title, so the header shows it instead of the agent id.
+  it('shows the paired tool_use description for a synchronous result', () => {
+    const text = renderAgentResult(
+      '',
+      {
+        status: 'completed',
+        agentId: 'a7bcba10b2b861663',
+        content: [{ type: 'text', text: 'The tide comes in twice a day.' }],
+        resolvedModel: 'claude-opus-5[1m]',
+      },
+      { description: 'SCAN triage + angle recommendation' },
+    ).textContent ?? ''
+    expect(text).toContain('Agent "SCAN triage + angle recommendation" completed')
+    expect(text).not.toContain('Agent a7bcba10b2b861663 completed')
+  })
+
+  // The paired input is the NEW description source, so its blank case must
+  // fall through to the id exactly as a blank result description does.
+  it('falls back to the agent id when the paired tool_use description is blank', () => {
+    const text = renderAgentResult(
+      '',
+      {
+        status: 'completed',
+        agentId: 'a7bcba10b2b861663',
+        content: [{ type: 'text', text: 'The tide comes in twice a day.' }],
+        resolvedModel: 'claude-opus-5[1m]',
+      },
+      { description: '   ' },
+    ).textContent ?? ''
+    expect(text).toContain('Agent a7bcba10b2b861663 completed')
+    expect(text).not.toContain('Agent "')
   })
 })
 
@@ -257,7 +306,7 @@ describe('claude Agent tool_result rendering: field-list edge cases', () => {
       agentId: 'a1',
       description: 'Something',
     })
-    expect(container.textContent).toContain('Agent \'Something\' launched asynchronously')
+    expect(container.textContent).toContain('Agent "Something" launched asynchronously')
     expect(container.textContent).not.toContain('Prompt')
   })
 

--- a/frontend/src/components/chat/providers/claude/extractors/agent.test.ts
+++ b/frontend/src/components/chat/providers/claude/extractors/agent.test.ts
@@ -23,6 +23,56 @@ describe('claudeAgentFromToolResult', () => {
     const source = claudeAgentFromToolResult({ status: 'async_launched', agentId: 'a1' }, HARNESS_TEXT)
     expect(source?.content).toBe('')
   })
+
+  // A synchronous result omits `description`. The paired tool_use input carries
+  // the model-written task title, so the extractor fills the gap from it.
+  it('takes the description from the paired tool_use input for a sync result', () => {
+    const source = claudeAgentFromToolResult(
+      { status: 'completed', agentId: 'a1' },
+      'The report.',
+      { description: 'SCAN triage + angle recommendation' },
+    )
+    expect(source?.description).toBe('SCAN triage + angle recommendation')
+  })
+
+  it('prefers a non-blank result description over the paired input', () => {
+    const source = claudeAgentFromToolResult(
+      { status: 'async_launched', description: 'From result', agentId: 'a1' },
+      '',
+      { description: 'From input' },
+    )
+    expect(source?.description).toBe('From result')
+  })
+
+  it('falls back to the paired input when the result description is blank', () => {
+    const source = claudeAgentFromToolResult(
+      { status: 'completed', description: '  ', agentId: 'a1' },
+      '',
+      { description: 'From input' },
+    )
+    expect(source?.description).toBe('From input')
+  })
+
+  it('keeps the agent ID fallback when neither payload supplies a description', () => {
+    const source = claudeAgentFromToolResult(
+      { status: 'completed', agentId: 'a1' },
+      '',
+      { description: '' },
+    )
+    expect(source?.description).toBe('')
+    expect(source?.agentId).toBe('a1')
+  })
+
+  // The input side trims too: a whitespace-only input description is not a
+  // real one, and the header would render `Agent "   " completed` without it.
+  it('treats a whitespace-only paired input description as absent', () => {
+    const source = claudeAgentFromToolResult(
+      { status: 'completed', agentId: 'a1' },
+      '',
+      { description: '   ' },
+    )
+    expect(source?.description).toBe('')
+  })
 })
 
 describe('agent report text', () => {

--- a/frontend/src/components/chat/providers/claude/extractors/agent.ts
+++ b/frontend/src/components/chat/providers/claude/extractors/agent.ts
@@ -60,19 +60,31 @@ export function claudeAgentResultIsLaunch(source: ClaudeAgentResult): boolean {
  * None of that is about the subagent that the user reads, so treating it as
  * the card's body buried the one thing that is: what the agent was asked to do.
  *
+ * An optional `toolInput` supplies the paired tool_use input. A synchronous
+ * result carries no `description`, but the tool_use that opened the span does —
+ * the model writes one in every `Agent` call. When the result omits its own
+ * description, the paired input fills the gap.
+ *
  * Returns null when the payload is not an object, so the dispatch entry can fall
  * through to the catch-all.
  */
 export function claudeAgentFromToolResult(
   toolUseResult: Record<string, unknown> | undefined,
   resultContent: string,
+  toolInput?: Record<string, unknown>,
 ): ClaudeAgentResult | null {
   if (!isObject(toolUseResult))
     return null
   const status = pickString(toolUseResult, 'status', 'completed')
+  // Prefer a non-blank result description, then fall back to the paired
+  // tool_use input's description, then leave empty for the agent ID fallback.
+  // Trim before the test: `pickString` preserves whitespace, and a blank
+  // description is not a real one.
+  const resultDescription = pickString(toolUseResult, 'description').trim()
+  const inputDescription = toolInput ? pickString(toolInput, 'description').trim() : ''
   const source: ClaudeAgentResult = {
     status,
-    description: pickString(toolUseResult, 'description'),
+    description: resultDescription || inputDescription,
     agentId: pickString(toolUseResult, 'agentId'),
     taskId: pickString(toolUseResult, 'taskId'),
     sessionUrl: pickString(toolUseResult, 'sessionUrl'),

--- a/frontend/src/components/chat/providers/claude/extractors/mcp.ts
+++ b/frontend/src/components/chat/providers/claude/extractors/mcp.ts
@@ -86,9 +86,14 @@ export function claudeMcpFromToolResult(args: ClaudeMcpFromToolResultArgs): McpT
     server: formatClaudeMcpServerName(parsed.serverName),
     tool: parsed.toolName,
     argsJson,
-    // When the call is flagged as an error, drop content to avoid double-
-    // rendering it (the error string already carries the text).
-    content: args.isError ? [] : content,
+    // When the call is flagged as an error, drop the TEXT to avoid rendering
+    // it twice -- the `error` string above is the joined text of these same
+    // blocks. The images stay: nothing else carries them, so dropping them hid
+    // the screenshot a failed MCP tool returned (Playwright returns one), and
+    // it left the row with fewer images than `Provider.toolResultImages`
+    // numbers for the message -- which is the index an already-open image tab
+    // addresses by, permanently.
+    content: args.isError ? content.filter(item => item.type === 'image') : content,
     structuredJson: prettifyStructuredJson(args.toolUseResult?.structuredContent),
     error,
     status,

--- a/frontend/src/components/chat/providers/claude/toolResults/agent.tsx
+++ b/frontend/src/components/chat/providers/claude/toolResults/agent.tsx
@@ -44,14 +44,15 @@ function clipDescription(description: string): string {
 /**
  * The header line. A launch gives the TASK, because that is the thing the user
  * recognizes and the only human-written string in the payload; the agent id is a
- * generated token that says nothing about the work. A finished sync run carries
- * no description at all, so it falls back to the id.
+ * generated token that says nothing about the work. A finished sync run now
+ * receives its description from the paired tool_use input when the result omits
+ * one, so the id fallback fires only when neither payload supplies a description.
  */
 function agentTitle(source: ClaudeAgentResult): string {
   const status = formatAgentStatus(source.status)
   const description = clipDescription(source.description)
   if (description)
-    return `Agent '${description}' ${status}`
+    return `Agent "${description}" ${status}`
   const id = source.agentId || source.taskId
   return id ? `Agent ${id} ${status}` : `Agent ${status}`
 }

--- a/frontend/src/components/chat/providers/claude/toolResults/index.tsx
+++ b/frontend/src/components/chat/providers/claude/toolResults/index.tsx
@@ -111,7 +111,7 @@ const TOOL_RESULT_ENTRIES: Record<string, ToolResultEntry> = {
   },
 
   [CLAUDE_TOOL.AGENT]: (info, ctx) => {
-    const source = claudeAgentFromToolResult(info.toolUseResult, info.resultContent)
+    const source = claudeAgentFromToolResult(info.toolUseResult, info.resultContent, info.toolInput)
     if (!source)
       return null
     return <AgentResultView source={source} context={ctx} />

--- a/frontend/src/components/chat/providers/codex/renderers/image.tsx
+++ b/frontend/src/components/chat/providers/codex/renderers/image.tsx
@@ -57,7 +57,7 @@ export const CodexImageGenerationRenderer = defineCodexRenderer({
  * Codex `imageView`: the `view_image` tool.
  *
  * The item is `{id, path}` and carries no pixels -- Codex attaches the image
- * to the model's context, not to the transcript. A header naming the file is
+ * to the model's context, not to the transcript. A header that states the file is
  * everything this row can say.
  */
 export const CodexImageViewRenderer = defineCodexRenderer({

--- a/frontend/src/components/chat/providers/imageRendering.test.tsx
+++ b/frontend/src/components/chat/providers/imageRendering.test.tsx
@@ -42,10 +42,13 @@ function renderToolUse(provider: AgentProvider, toolUse: Record<string, unknown>
 // Claude
 // ---------------------------------------------------------------------------
 
-function claudeToolResult(content: unknown, toolUseResult?: Record<string, unknown>) {
+function claudeToolResult(content: unknown, toolUseResult?: Record<string, unknown>, isError = false) {
   return {
     type: 'user',
-    message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'r1', content }] },
+    message: {
+      role: 'user',
+      content: [{ type: 'tool_result', tool_use_id: 'r1', content, ...(isError ? { is_error: true } : {}) }],
+    },
     ...(toolUseResult ? { tool_use_result: toolUseResult } : {}),
   }
 }
@@ -152,7 +155,7 @@ describe('codex image items', () => {
     expect(container.textContent ?? '').toContain('usageLimitExceeded')
   })
 
-  it('names the file for imageView, which carries no pixels', () => {
+  it('states the file for imageView, which carries no pixels', () => {
     const item = { type: 'imageView', id: 'view-1', path: '/repo/shot.png' }
     const { container } = renderToolUse(AgentProvider.CODEX, { item, threadId: 't1' }, 'imageView')
     expect(container.querySelector('img')).toBeNull()
@@ -225,9 +228,20 @@ describe('pi read on an image', () => {
 // ---------------------------------------------------------------------------
 
 describe('shared image guardrails', () => {
-  it('refuses SVG, which can carry script and is not sandboxed', () => {
+  // SVG DRAWS. Every consumer mounts through `ImageRender`, which builds a blob
+  // URL for an `<img>`, and an `<img>` renders SVG in secure static mode: no
+  // script, no external fetch. The file viewer already drew on-disk SVGs the
+  // same way, so refusing an agent's cost the diagram and bought nothing.
+  it('draws an SVG, the same way the file viewer renders one off disk', () => {
     const { container } = renderToolResult(AgentProvider.CLAUDE_CODE, claudeToolResult(
       [{ type: 'image', source: { type: 'base64', media_type: 'image/svg+xml', data: 'PHN2Zy8+' } }],
+    ), { spanType: 'Read' } as RenderContext)
+    expect(container.querySelector('img')).not.toBeNull()
+  })
+
+  it('refuses a type no `<img>` can draw', () => {
+    const { container } = renderToolResult(AgentProvider.CLAUDE_CODE, claudeToolResult(
+      [{ type: 'image', source: { type: 'base64', media_type: 'application/pdf', data: 'JVBERi0=' } }],
     ), { spanType: 'Read' } as RenderContext)
     expect(container.querySelector('img')).toBeNull()
     expect(container.textContent ?? '').toContain('unsupported format')
@@ -252,6 +266,26 @@ function imagesOf(provider: AgentProvider, parsedMessage: unknown, spanType?: st
 }
 
 describe('provider toolResultImages', () => {
+  // A FAILED MCP call used to drop its whole content, images and all, because
+  // the `error` string already carries the joined TEXT. Nothing else carries
+  // the pixels, so a Playwright screenshot of the failure vanished from the
+  // row -- and the row then showed fewer images than `toolResultImages`
+  // numbers for that message, which is the index an open image tab addresses
+  // by, permanently.
+  it('claude keeps the images a failed MCP call returned, and the tab still numbers them', () => {
+    const payload = claudeToolResult([
+      { type: 'text', text: 'the tool failed' },
+      { type: 'image', data: PNG, mimeType: 'image/png' },
+    ], undefined, true)
+    const { container } = renderToolResult(
+      AgentProvider.CLAUDE_CODE,
+      payload,
+      { spanType: 'mcp__x__y' } as RenderContext,
+    )
+    expect(container.querySelectorAll('img')).toHaveLength(1)
+    expect(imagesOf(AgentProvider.CLAUDE_CODE, payload, 'mcp__x__y')).toHaveLength(1)
+  })
+
   it('claude keeps wire order across mixed blocks', () => {
     const images = imagesOf(AgentProvider.CLAUDE_CODE, claudeToolResult([
       { type: 'image', data: 'first', mimeType: 'image/png' },
@@ -285,7 +319,7 @@ describe('provider toolResultImages', () => {
     expect(images.every(i => i.dimensions === undefined)).toBe(true)
   })
 
-  // The zero-block case takes the same arm as the one-block case, so the
+  // The zero-block case takes the same branch as the one-block case, so the
   // structured payload is still the answer: a Read on an image that sent no
   // content block at all is exactly what it describes.
   it('claude falls back to the structured payload when the blocks carry no image', () => {
@@ -325,7 +359,7 @@ describe('provider toolResultImages', () => {
       ],
     })
     expect(images.map(i => i.data)).toEqual(['first', 'second'])
-    // The block's own `uri` wins over the tool input, because it names the
+    // The block's own `uri` wins over the tool input, because it states the
     // file THIS image came from when a tool returned several.
     expect(images.map(i => i.filePath)).toEqual(['/repo/shot.png', '/repo/other.png'])
   })
@@ -417,7 +451,7 @@ describe('opening a tool-result image', () => {
     expect(onOpenImage).toHaveBeenCalledWith(expect.objectContaining({ index: 1 }))
   })
 
-  it('reports the file path when the provider named one, so the file itself opens', () => {
+  it('reports the file path when the provider stated one, so the file itself opens', () => {
     const onOpenImage = vi.fn()
     const { container } = renderToolResult(
       AgentProvider.CLAUDE_CODE,
@@ -432,7 +466,7 @@ describe('opening a tool-result image', () => {
     expect(onOpenImage).toHaveBeenCalledWith(expect.objectContaining({ index: 0, filePath: '/repo/shot.png' }))
   })
 
-  it('names the tab the way the row names itself, not the raw tool name', () => {
+  it('titles the tab the way the row titles itself, not the raw tool name', () => {
     // The MCP body already holds the provider-computed "Server / tool" pair,
     // so the tab reads "Playwright / screenshot" rather than the span type's
     // `mcp__playwright__screenshot`.

--- a/frontend/src/components/chat/providers/mcpToolCallRendering.test.tsx
+++ b/frontend/src/components/chat/providers/mcpToolCallRendering.test.tsx
@@ -194,13 +194,21 @@ describe('claude MCP tool_result rendering', () => {
     expect(container.textContent ?? '').toContain('[image: image/png]')
   })
 
-  it('falls back to a placeholder for unsupported MIME types (e.g. svg)', () => {
+  // SVG is allowlisted: an `<img>` renders it in secure static mode, which is
+  // how the file viewer has always drawn one off disk.
+  it('draws an svg an MCP server returned', () => {
     const parsed = makeMcpToolResult([
-      { type: 'image', mimeType: 'image/svg+xml', data: '<svg/>' },
+      { type: 'image', mimeType: 'image/svg+xml', data: 'PHN2Zy8+' },
     ])
-    const { container } = renderClaudeToolResult(parsed, {
-      spanType: 'mcp__server__svg',
-    })
+    const { container } = renderClaudeToolResult(parsed, { spanType: 'mcp__server__svg' })
+    expect(container.querySelector('img')).not.toBeNull()
+  })
+
+  it('falls back to a placeholder for a type no `<img>` can draw', () => {
+    const parsed = makeMcpToolResult([
+      { type: 'image', mimeType: 'application/pdf', data: 'JVBERi0=' },
+    ])
+    const { container } = renderClaudeToolResult(parsed, { spanType: 'mcp__server__doc' })
     expect(container.querySelector('img')).toBeNull()
     expect(container.textContent ?? '').toContain('unsupported format')
   })

--- a/frontend/src/components/chat/results/imageResult.test.ts
+++ b/frontend/src/components/chat/results/imageResult.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { imageRenderInfo, imageReservationMatchesDecoded, imageReservationStyle } from './imageResult'
+import { imageRenderInfo } from '~/lib/imageBlocks'
+import { imageReservationMatchesDecoded, imageReservationStyle } from './imageResult'
 
-describe('imagereservationstyle', () => {
+describe('imageReservationStyle', () => {
   // The width formula must reproduce exactly what auto layout yields after
   // the image decodes: height = min(h, h/w * containerWidth, MAX_HEIGHT).
   it('clamps by natural width for images that fit', () => {
@@ -28,7 +29,7 @@ describe('imagereservationstyle', () => {
   })
 })
 
-describe('imagereservationmatchesdecoded', () => {
+describe('imageReservationMatchesDecoded', () => {
   it('rejects decoded dimensions that preserve ratio but not absolute size', () => {
     expect(imageReservationMatchesDecoded(
       { width: 100, height: 50 },
@@ -44,7 +45,7 @@ describe('imagereservationmatchesdecoded', () => {
   })
 })
 
-describe('imagerenderinfo', () => {
+describe('imageRenderInfo', () => {
   it('returns no-data when neither data nor url is present', () => {
     expect(imageRenderInfo({})).toEqual({ reason: 'no-data' })
     expect(imageRenderInfo({ mimeType: 'image/png' })).toEqual({ reason: 'no-data' })
@@ -62,9 +63,16 @@ describe('imagerenderinfo', () => {
     expect(result.src).toBe('data:image/png;base64,AAAA')
   })
 
-  it('refuses non-allowlisted mime types (e.g. svg)', () => {
-    expect(imageRenderInfo({ mimeType: 'image/svg+xml', data: 'AAAA' }))
+  // SVG is allowlisted -- every consumer mounts through `<img>`, which renders
+  // it in secure static mode. A document type is not.
+  it('refuses a non-allowlisted mime type', () => {
+    expect(imageRenderInfo({ mimeType: 'application/pdf', data: 'AAAA' }))
       .toEqual({ reason: 'unsupported-mime' })
+  })
+
+  it('accepts svg, the same type the file viewer renders off disk', () => {
+    expect(imageRenderInfo({ mimeType: 'image/svg+xml', data: 'AAAA' }))
+      .toEqual({ src: 'data:image/svg+xml;base64,AAAA', via: 'inline' })
   })
 
   it('refuses base64 without an explicit mime type', () => {
@@ -97,7 +105,7 @@ describe('imagerenderinfo', () => {
   })
 
   it('refuses pre-formed data: URLs with non-allowlisted mime', () => {
-    expect(imageRenderInfo({ url: 'data:image/svg+xml;base64,XYZ=' }))
+    expect(imageRenderInfo({ url: 'data:application/pdf;base64,XYZ=' }))
       .toEqual({ reason: 'unsupported-mime' })
   })
 

--- a/frontend/src/components/chat/results/imageResult.tsx
+++ b/frontend/src/components/chat/results/imageResult.tsx
@@ -1,8 +1,8 @@
 import type { JSX } from 'solid-js'
 import type { RenderContext } from '../messageRenderers'
-import type { ImageResultSource } from '~/lib/imageBlocks'
+import type { ImageResultSource, ImageSkipReason } from '~/lib/imageBlocks'
 import { createMemo, createSignal, For, Show } from 'solid-js'
-import { MAX_INLINE_IMAGE_BASE64_LEN, RENDERABLE_IMAGE_MIME_TYPES } from '~/lib/imageBlocks'
+import { imageRenderInfo, imageSkipPlaceholder } from '~/lib/imageBlocks'
 import { sniffImageDimensionsFromDataUrl } from '~/lib/imageDimensions'
 import { TOOL_IMAGE_MAX_HEIGHT_PX, toolImage, toolImageButton, toolImageRow, toolInputSummary } from '../toolStyles.css'
 
@@ -16,67 +16,16 @@ import { TOOL_IMAGE_MAX_HEIGHT_PX, toolImage, toolImageButton, toolImageRow, too
  * components. Nothing here knows which provider it is serving.
  */
 
-/** Why an image is shown as a placeholder rather than inline. */
-export type ImageSkipReason = 'no-data' | 'unsupported-mime' | 'too-large' | 'external-url' | 'unknown-shape'
-
 /**
- * Decision-tree for rendering an image source:
+ * The render policy (`imageRenderInfo`, `ImageSkipReason`, the MIME allowlist
+ * and the size cap) lives in `~/lib/imageBlocks`, beside the parser.
  *
- *   - Inline base64 + allowlisted MIME + under size cap → `<img src="data:...">`.
- *   - Already-formed `data:` URL with allowlisted MIME → render as-is.
- *   - http(s) URL → not rendered inline; the placeholder shows the URL as a
- *     link so the user can open it in a new tab.
- *   - Anything else → text placeholder so the user knows an image was
- *     returned but we're not rendering it (unknown MIME, bare base64
- *     without MIME, oversized inline data, etc.).
+ * It moved because this row is not its only consumer. `imageBlockToMarkdown`
+ * feeds every quote, scroll-rail preview and Markdown body, and the IMAGE tab's
+ * `decodeImageBytes` builds a Blob from the same source -- neither can import a
+ * component module, so while the policy lived here both hand-copied the size cap
+ * and neither applied the MIME allowlist. One policy, three destinations.
  */
-export function imageRenderInfo(source: ImageResultSource): {
-  src?: string
-  via?: 'inline'
-  reason?: ImageSkipReason
-} {
-  const url = source.url
-  if (url) {
-    // Already a complete data: URL — accept iff its MIME is allowlisted.
-    const DATA_URL_PREFIX = 'data:'
-    if (url.startsWith(DATA_URL_PREFIX)) {
-      const comma = url.indexOf(',')
-      if (comma < 0)
-        return { reason: 'unknown-shape' }
-      const meta = url.slice(DATA_URL_PREFIX.length, comma).toLowerCase()
-      // Require the base64 marker, because the two other readers of the same URL
-      // do. `decodeImageBytes` (the IMAGE tab) and `sniffImageDimensionsFromDataUrl`
-      // both refuse a percent-encoded payload, so accepting one here drew a
-      // clickable image whose tab then said "This image cannot be displayed here."
-      // and whose row lost its size reservation.
-      if (!meta.endsWith(';base64'))
-        return { reason: 'unknown-shape' }
-      const semi = meta.indexOf(';')
-      const mime = semi < 0 ? meta : meta.slice(0, semi)
-      if (!RENDERABLE_IMAGE_MIME_TYPES.has(mime))
-        return { reason: 'unsupported-mime' }
-      if (url.length - comma - 1 > MAX_INLINE_IMAGE_BASE64_LEN)
-        return { reason: 'too-large' }
-      return { src: url, via: 'inline' }
-    }
-    // http(s) URL — show as an opt-in external link via the placeholder.
-    if (url.startsWith('http://') || url.startsWith('https://'))
-      return { reason: 'external-url' }
-    return { reason: 'unknown-shape' }
-  }
-
-  const data = source.data
-  if (!data)
-    return { reason: 'no-data' }
-
-  // Plain base64 — only render when MIME is explicitly provided + allowlisted.
-  const mime = (source.mimeType ?? '').toLowerCase()
-  if (!RENDERABLE_IMAGE_MIME_TYPES.has(mime))
-    return { reason: 'unsupported-mime' }
-  if (data.length > MAX_INLINE_IMAGE_BASE64_LEN)
-    return { reason: 'too-large' }
-  return { src: `data:${mime};base64,${data}`, via: 'inline' }
-}
 
 /**
  * Inline style reserving an image's exact final box before it decodes, so
@@ -213,15 +162,9 @@ function ImageResultPlaceholder(props: {
     const url = props.source.url ?? ''
     return url.startsWith('http://') || url.startsWith('https://') ? url : ''
   }
-  const label = () => {
-    const mime = props.source.mimeType
-    const suffix = mime ? `: ${mime}` : ''
-    if (props.reason === 'too-large')
-      return `[image${suffix} — too large to render inline]`
-    if (props.reason === 'unsupported-mime')
-      return `[image${suffix} — unsupported format]`
-    return `[image${suffix}]`
-  }
+  // The same wording the Markdown path emits, from the one helper -- a reader
+  // who meets the same refused image in a quote reads the same sentence.
+  const label = () => imageSkipPlaceholder(props.reason, props.source.mimeType)
   return (
     <div class={toolImageRow}>
       <Show

--- a/frontend/src/components/chat/results/mcpToolCall.test.tsx
+++ b/frontend/src/components/chat/results/mcpToolCall.test.tsx
@@ -23,7 +23,10 @@ describe('parsemcpcontentitem', () => {
       .toEqual({ type: 'image', source: { mimeType: 'image/png', data: 'base64...' } })
   })
 
-  it('parses image blocks (mimeType + url)', () => {
+  // The already-normalized `urlOrData` shape, whose value can be a URL or bare
+  // base64. The raw MCP `url` key is a different branch, covered in
+  // `lib/imageBlocks.test.ts`.
+  it('parses image blocks (mimeType + urlOrData holding a URL)', () => {
     expect(parseMcpContentItem({ type: 'image', mimeType: 'image/png', urlOrData: 'https://example.com/x.png' }))
       .toEqual({ type: 'image', source: { mimeType: 'image/png', url: 'https://example.com/x.png' } })
   })

--- a/frontend/src/components/common/SvgIconFrame.test.tsx
+++ b/frontend/src/components/common/SvgIconFrame.test.tsx
@@ -46,7 +46,7 @@ describe('svgIconFrame (SvgIconFrame)', () => {
     expect(renderFrame({ 'data-testid': 'my-glyph' }).getAttribute('data-testid')).toBe('my-glyph')
   })
 
-  // The default: a glyph inside a button that a tooltip already names is
+  // The default: a glyph inside a button that a tooltip already labels is
   // decoration, and a second nameless node in the accessibility tree is noise.
   it('hides a glyph that carries no role and no accessible name', () => {
     expect(renderFrame().getAttribute('aria-hidden')).toBe('true')

--- a/frontend/src/components/common/SvgIconFrame.tsx
+++ b/frontend/src/components/common/SvgIconFrame.tsx
@@ -28,7 +28,7 @@ function hasA11yProp(props: object): boolean {
  * It also matches lucide's ACCESSIBILITY default: a glyph with no role and no
  * `aria-*` prop is decoration, so it carries `aria-hidden="true"` and stays out
  * of the accessibility tree. Almost every call site is a glyph inside a button
- * that a tooltip already names, where a second nameless node is noise.
+ * that a tooltip already labels, where a second nameless node is noise.
  *
  * lucide skips its `aria-hidden` when the caller passes children, because there
  * children are extra content inside a complete icon. This frame takes the icon

--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -496,6 +496,18 @@ export const AppShell: Component = () => {
     return section?.sectionType === SectionType.WORKSPACES_ARCHIVED
   })
 
+  // Whether ONE NAMED workspace can be mutated. Per id, because a dialog can act
+  // on a workspace the user is not looking at. Answers false for an absent one
+  // -- deleted remotely while a dialog holds its id -- which is the same
+  // refusal archival earns and the same one the caller needs.
+  const isWorkspaceMutatableById = (workspaceId: string): boolean => {
+    const sectionId = sectionStore.getSectionForWorkspace(workspaceId)
+    const archived = sectionId
+      ? sectionStore.state.sections.find(s => s.id === sectionId)?.sectionType === SectionType.WORKSPACES_ARCHIVED
+      : false
+    return isWorkspaceMutatable(workspaceStore.state.workspaces.find(w => w.id === workspaceId), archived)
+  }
+
   // Whether the active workspace can be mutated
   const isActiveWorkspaceMutatable = createMemo(() =>
     isWorkspaceMutatable(activeWorkspace() ?? undefined, isActiveWorkspaceArchived()),
@@ -1313,7 +1325,7 @@ export const AppShell: Component = () => {
           newBranch,
         )}
         activeWorkspace={activeWorkspace}
-        isActiveWorkspaceMutatable={isActiveWorkspaceMutatable}
+        isWorkspaceMutatable={isWorkspaceMutatableById}
         getCurrentTabContext={getCurrentTabContext}
         agentOps={agentOps}
         termOps={termOps}

--- a/frontend/src/components/shell/AppShellDialogs.test.tsx
+++ b/frontend/src/components/shell/AppShellDialogs.test.tsx
@@ -220,7 +220,7 @@ function renderDialogs(
     tabOps: tabOps as unknown as ReturnType<typeof useTabOperations>,
     activeWorkspace,
     onSelectWorkspace,
-    isActiveWorkspaceMutatable: () => opts.mutatable ?? true,
+    isWorkspaceMutatable: () => opts.mutatable ?? true,
     layoutStore: { placementTileId, firstLeafIdFor } as unknown as ComponentProps<typeof AppShellDialogs>['layoutStore'],
     repoGitStore,
     getCurrentTabContext: () => ({
@@ -659,7 +659,7 @@ describe('appShellDialogs agent creation', () => {
     const props = {
       dialogs,
       activeWorkspace: () => ({ id: 'ws1' }),
-      isActiveWorkspaceMutatable: () => true,
+      isWorkspaceMutatable: () => true,
       layoutStore: stores.layoutStore,
       view: stores.view,
       metadata: stores.metadata,

--- a/frontend/src/components/shell/AppShellDialogs.tsx
+++ b/frontend/src/components/shell/AppShellDialogs.tsx
@@ -147,7 +147,12 @@ interface AppShellDialogsProps {
   onBranchChanged?: (repo: RepoRef, newBranch: string) => void
   activeWorkspace: () => { id: string } | null
   /** False while the active workspace is archived — read-only, so no new tabs. */
-  isActiveWorkspaceMutatable: () => boolean
+  /**
+   * Whether a NAMED workspace takes mutation. Per id, not per active workspace:
+   * a dialog can act on a workspace the user is not looking at, and the guard
+   * has to answer for the one the RPC is for.
+   */
+  isWorkspaceMutatable: (workspaceId: string) => boolean
   getCurrentTabContext: () => TabContext
   agentOps: ReturnType<typeof useAgentOperations>
   termOps: ReturnType<typeof useTerminalOperations>
@@ -264,7 +269,13 @@ export const AppShellDialogs: Component<AppShellDialogsProps> = (props) => {
     // had not delivered, and the refusal that follows is silent: the RPC has
     // already made the agent and the worktree, and nothing places a tab.
     const target = workspaceId ?? active.id
-    if (target === active.id && !props.isActiveWorkspaceMutatable())
+    // Asked about the TARGET, not only when the target IS the active workspace.
+    // An archived workspace takes no tab either way, and a branch row of one is
+    // reachable while another workspace is active -- so scoping this to
+    // `target === active.id` left Create enabled over exactly the workspace
+    // that refuses the tab, and the refusal arrives only after the RPC has made
+    // the agent.
+    if (!props.isWorkspaceMutatable(target))
       return 'This workspace is archived. Unarchive it to create tabs.'
     // `firstLeafIdFor` answers for ANY workspace and is null exactly when
     // `placementTileId()` would be empty, which is the state this reason names.

--- a/frontend/src/components/shell/useAgentOperations.test.ts
+++ b/frontend/src/components/shell/useAgentOperations.test.ts
@@ -211,7 +211,7 @@ describe('useAgentOperations', () => {
       })
     })
 
-    // The branch context menu names WHERE the agent runs. Without the
+    // The branch context menu states WHERE the agent runs. Without the
     // override, an agent started from a branch row on another machine would
     // open on whichever worker the focused tab happens to sit on.
     it('opens on the target\'s worker and directory when one is given', async () => {
@@ -447,7 +447,7 @@ describe('useAgentOperations', () => {
     // The dialog is the fallback when neither the target nor the context
     // resolves a whole (worker, directory) pair -- and it has to open ON the
     // target. An `open({})` here would drop what the caller did know and ask
-    // the user for a Worker and a path the branch row already named.
+    // the user for a Worker and a path the branch row already stated.
     it('opens the dialog on the target when the pair is incomplete', async () => {
       await createRoot(async (dispose) => {
         try {

--- a/frontend/src/components/shell/useTabHydrators.ts
+++ b/frontend/src/components/shell/useTabHydrators.ts
@@ -478,9 +478,19 @@ export function useTabHydrators(opts: UseTabHydratorsOpts): void {
         return
       const resp = await getTabPayload(tab.workerId, { tabId: tab.id })
       const payload = tabPayloadView(resp.payload)
-      // A payload this client cannot read is left un-hydrated on purpose: the
-      // tab then renders as unsupported rather than as an empty FILE tab, and a
-      // client that does understand it still resolves it.
+      // A payload this client cannot read patches nothing, and the tab is still
+      // marked hydrated by `runFor` -- which is correct, however it reads.
+      // The worker ANSWERED; asking again would return the same bytes this
+      // build still could not decode, so leaving the tab un-hydrated would only
+      // spin the retry loop forever.
+      //
+      // What the tab then shows is the open problem, not this early return.
+      // `tabView`'s assembly falls to its FILE branch for a kind it does not
+      // know, so such a tab renders as a file viewer with no path, which holds
+      // "Loading..." for the life of the session. The app has no
+      // unsupported-tab state to render instead. Do NOT restate this as "left
+      // un-hydrated on purpose" -- an earlier comment here claimed exactly
+      // that, and no such branch has ever existed.
       if (!payload)
         return
       // The patch is `tabPayloadMetadata`, shared with the private-event

--- a/frontend/src/components/shell/useTabOperations.ts
+++ b/frontend/src/components/shell/useTabOperations.ts
@@ -24,7 +24,7 @@ import { WorktreeAction } from '~/generated/proto/leapmux/v1/common_pb'
 import { TabType } from '~/generated/proto/leapmux/v1/workspace_pb'
 import { createUpdatableDialogState } from '~/hooks/createDialogState'
 import { makeIdGenerator } from '~/lib/idGenerator'
-import { basename } from '~/lib/paths'
+import { basename, isAbsolute } from '~/lib/paths'
 import { fileTabPayload, imageTabPayload } from '~/lib/tabPayload'
 import { MAX_BACKGROUND_CHAT_MESSAGES } from '~/stores/chat.store'
 import { descendantAgentTabs, planOptimisticRepoGit, tabKey } from '~/stores/tab.helpers'
@@ -828,7 +828,15 @@ export function useTabOperations(opts: UseTabOperationsOpts) {
     workingDir: string
   }) => {
     const at = { workerId: image.workerId, workingDir: image.workingDir }
-    if (image.filePath) {
+    // Only an ABSOLUTE path reaches the file viewer. The worker refuses a
+    // relative one, because `git -C` would resolve it against the worker
+    // process's cwd and answer for the wrong repository. A provider states this
+    // path from its own tool input (`rawInput.path`, `args.filePath`,
+    // `savedPath`) and nothing upstream promises it is absolute, so a relative
+    // one added the tab, failed the registration and rolled back -- a tab that
+    // flashed and vanished with no message. The transcript's own copy is the
+    // better answer there: a smaller picture beats no picture.
+    if (image.filePath && isAbsolute(image.filePath)) {
       handleFileOpen(image.filePath, undefined, at)
       return
     }

--- a/frontend/src/components/shell/useTerminalOperations.test.ts
+++ b/frontend/src/components/shell/useTerminalOperations.test.ts
@@ -389,7 +389,7 @@ describe('useterminaloperations.handleopenterminalwithshell', () => {
     expect(terminalLoadingFlips).toEqual([])
   })
 
-  // The branch context menu names WHERE the terminal runs. Without the
+  // The branch context menu states WHERE the terminal runs. Without the
   // override, a shell picked from a branch row on another machine would open
   // on whichever worker the focused tab happens to sit on.
   it('opens on the target\'s worker and directory when one is given', async () => {
@@ -420,7 +420,7 @@ describe('useterminaloperations.handleopenterminalwithshell', () => {
   // The dialog is the fallback when neither the target nor the context resolves
   // a whole (worker, directory) pair -- and it has to open ON the target. An
   // `open({})` here would drop what the caller did know and ask the user for a
-  // Worker and a path the branch row already named.
+  // Worker and a path the branch row already stated.
   it('opens the dialog on the target when the pair is incomplete', async () => {
     const dialogOpen = vi.fn()
     const { ops } = setupForOpen({ ctx: { workerId: '', workingDir: '' }, dialogOpen })

--- a/frontend/src/components/workspace/BranchContextMenu.test.tsx
+++ b/frontend/src/components/workspace/BranchContextMenu.test.tsx
@@ -66,7 +66,7 @@ async function openMenu(trigger: HTMLElement) {
 }
 
 describe('branchContextMenu', () => {
-  // One item per git mode, so the label the user picks names the radio they
+  // One item per git mode, so the label the user picks states the radio they
   // then see. A single "Change branch..." made the mode invisible until the
   // dialog opened.
   describe('the three change items', () => {
@@ -203,7 +203,7 @@ describe('branchContextMenu', () => {
     })
 
     // The shortcut opens a dialog for the CURRENT tab context, not for this
-    // branch, so naming a key here would name one that does something else.
+    // branch, so stating a key here would state one that does something else.
     it('shows no keyboard-shortcut hint on the dialog items', async () => {
       const { trigger } = renderMenu()
       await openMenu(trigger)

--- a/frontend/src/components/workspace/BranchContextMenu.tsx
+++ b/frontend/src/components/workspace/BranchContextMenu.tsx
@@ -106,7 +106,7 @@ export const BranchContextMenu: Component<BranchContextMenuProps> = (props) => {
           its own radio already selected. One item per mode, because a single
           "Change branch..." made the user open the dialog to discover that
           "Create new worktree" lived inside it. The labels are the dialog's own
-          radio labels, so the item the user picks names what they then see. */}
+          radio labels, so the item the user picks states what they then see. */}
       {changeItem('Switch to branch...', GitMode.SwitchBranch)}
       {changeItem('Create new branch...', GitMode.CreateBranch)}
       {changeItem('Create new worktree...', GitMode.CreateWorktree)}

--- a/frontend/src/hooks/createWorkerScopedList.ts
+++ b/frontend/src/hooks/createWorkerScopedList.ts
@@ -1,0 +1,106 @@
+import type { Accessor } from 'solid-js'
+import { createEffect, on, untrack } from 'solid-js'
+import { createGuardedFetch } from '~/hooks/createGuardedFetch'
+
+/** The fetch args every worker-scoped list takes: at minimum, which worker. */
+export interface WorkerScopedArgs {
+  workerId: string
+}
+
+export interface CreateWorkerScopedListOpts<Args extends WorkerScopedArgs, Resp> {
+  /** The fetch args, or null to skip. A null source keeps the cached list. */
+  source: Accessor<Args | null>
+  fetch: (args: Args, signal: AbortSignal) => Promise<Resp>
+  /** Store the answer. Runs only on success. */
+  applySuccess: (resp: Resp, args: Args) => void
+  /** Drop the previous worker's answer, before the new fetch starts. */
+  clear: () => void
+  onError?: (err: unknown) => void
+}
+
+export interface WorkerScopedList {
+  loading: Accessor<boolean>
+  /**
+   * Re-run the fetch for the current source. The source-driven effect fires on
+   * a workerId TRANSITION only, so a transient failure on the current worker
+   * would otherwise leave the caller with no list and no way back. No-op while
+   * the source returns null.
+   */
+  refresh: () => Promise<void>
+}
+
+/**
+ * The retry-and-clear policy every per-worker list obeys, in one place.
+ *
+ * `useAvailableShells` and `useAvailableProviders` each held their own copy of
+ * this skeleton -- the same success sentinel, the same `on(workerId)` effect
+ * with the same two early returns, the same clear-then-`untrack(source)`
+ * sequence, and the same `refresh`. Only the payload each stores differed. Two
+ * copies of a rule this subtle is one copy too many: the sentinel in particular
+ * has a comment in both explaining a past bug, and a fix to one would not have
+ * reached the other.
+ *
+ * Three properties this owns, and no caller restates:
+ *
+ *   - The sentinel advances ONLY on success, so a failed fetch lets the next
+ *     tick with the same workerId retry rather than short-circuit on a stale
+ *     value. Stamping it before the fetch locks the caller out of recovering
+ *     from a transient failure until the user switches workers and back.
+ *   - It tracks the workerId SCALAR, not the source accessor. Caller closures
+ *     build a fresh args object every tick, so tracking the accessor re-fires
+ *     the effect on identity churn that changes nothing.
+ *   - It clears BEFORE the fetch, so the previous worker's answer can never be
+ *     offered for the new one during the window the fetch is in flight.
+ */
+export function createWorkerScopedList<Args extends WorkerScopedArgs, Resp>(
+  opts: CreateWorkerScopedListOpts<Args, Resp>,
+): WorkerScopedList {
+  let lastLoadedWorkerId = ''
+
+  const fetcher = createGuardedFetch<Args, Resp>({
+    fetch: opts.fetch,
+    applySuccess: (resp, args) => {
+      opts.applySuccess(resp, args)
+      lastLoadedWorkerId = args.workerId
+    },
+    onError: (err) => {
+      opts.onError?.(err)
+      opts.clear()
+    },
+  })
+
+  // `GuardedFetchRun<Args>` is a conditional type that picks a no-argument
+  // signature when `Args` is `void`. TypeScript cannot resolve it while `Args`
+  // is still a type parameter, so it falls back to the intersection of both
+  // branches and rejects a plain `Args`. The `extends WorkerScopedArgs` bound
+  // already excludes the `void` branch, so this states the arm that applies.
+  const run = fetcher.run as (args: Args | null) => Promise<void>
+
+  const workerIdFromSource = (): string | null => opts.source()?.workerId ?? null
+  createEffect(on(workerIdFromSource, (workerId) => {
+    if (!workerId)
+      return
+    if (workerId === lastLoadedWorkerId)
+      return
+    opts.clear()
+    // The `on()` already subscribes through `workerIdFromSource`; read the rest
+    // of the args untracked.
+    const args = untrack<Args | null>(opts.source)
+    if (args === null)
+      return
+    void run(args)
+  }))
+
+  const refresh = async (): Promise<void> => {
+    const args = untrack<Args | null>(opts.source)
+    if (args === null)
+      return
+    // `lastLoadedWorkerId` is deliberately NOT cleared here. The source-driven
+    // effect consults it on a workerId TRANSITION only, so a manual refresh
+    // against the current worker just re-fetches and re-stamps it on success --
+    // or leaves it untouched on failure, which preserves the retry rule above.
+    await run(args)
+  }
+
+  return { loading: fetcher.loading, refresh }
+}

--- a/frontend/src/hooks/useAvailableProviders.ts
+++ b/frontend/src/hooks/useAvailableProviders.ts
@@ -1,8 +1,8 @@
 import type { Accessor } from 'solid-js'
 import type { AgentProvider } from '~/generated/proto/leapmux/v1/agent_pb'
-import { createEffect, createSignal, on, untrack } from 'solid-js'
+import { createSignal } from 'solid-js'
 import * as workerRpc from '~/api/workerRpc'
-import { createGuardedFetch } from '~/hooks/createGuardedFetch'
+import { createWorkerScopedList } from '~/hooks/createWorkerScopedList'
 
 export interface UseAvailableProvidersArgs {
   workerId: string
@@ -28,7 +28,7 @@ export interface UseAvailableProvidersResult {
 
 /**
  * Reactive wrapper around the ListAvailableProviders worker RPC, for a surface
- * that asks about ONE named worker on demand.
+ * that asks about ONE stated worker on demand.
  *
  * The sibling of {@link import('./useAvailableShells').useAvailableShells}, and
  * deliberately the same shape: `source` returns the fetch args or `null` to
@@ -41,7 +41,7 @@ export interface UseAvailableProvidersResult {
  * it. That one scans for whichever worker the ACTIVE TAB is on, and it carries
  * its own abort-and-supersede rules plus a keep-the-previous-list-on-failure
  * policy for that moving target. This hook answers for a worker the caller
- * names, which is what a branch row needs: the branch's own machine, not the
+ * states, which is what a branch row needs: the branch's own machine, not the
  * machine the current tab happens to sit on.
  */
 export function useAvailableProviders(
@@ -50,48 +50,17 @@ export function useAvailableProviders(
 ): UseAvailableProvidersResult {
   const [providers, setProviders] = createSignal<AgentProvider[] | undefined>(undefined)
 
-  // Advances only on a SUCCESSFUL load, so a failed fetch lets the next
-  // reactive tick with the same workerId retry instead of short-circuiting on
-  // a stale sentinel. Same rule as useAvailableShells, for the same reason.
-  let lastLoadedWorkerId = ''
-
-  const fetcher = createGuardedFetch<UseAvailableProvidersArgs, Awaited<ReturnType<typeof workerRpc.listAvailableProviders>>>({
+  // Every rule about WHEN to fetch, when to retry and when to clear lives in
+  // `createWorkerScopedList`. This hook keeps only the payload it stores.
+  const list = createWorkerScopedList<UseAvailableProvidersArgs, Awaited<ReturnType<typeof workerRpc.listAvailableProviders>>>({
+    source,
     fetch: (args, signal) => workerRpc.listAvailableProviders(args.workerId, { signal }),
-    applySuccess: (resp, args) => {
-      setProviders([...resp.providers])
-      lastLoadedWorkerId = args.workerId
-    },
-    onError: (err) => {
-      onError?.(err)
-      setProviders(undefined)
-    },
+    applySuccess: resp => setProviders([...resp.providers]),
+    // The previous worker's list is not an answer for this one, and
+    // `undefined` is the "not asked yet" state a caller distinguishes from `[]`.
+    clear: () => setProviders(undefined),
+    onError,
   })
 
-  // Track the workerId scalar, not the source accessor: caller closures build a
-  // fresh args object every tick, and only the workerId triggers the fetch.
-  const workerIdFromSource = (): string | null => source()?.workerId ?? null
-  createEffect(on(workerIdFromSource, (workerId) => {
-    if (!workerId)
-      return
-    if (workerId === lastLoadedWorkerId)
-      return
-    // The previous worker's list is not an answer for this one. Clear it before
-    // the fetch so a caller cannot offer a provider the new worker may not have.
-    setProviders(undefined)
-    // The `on()` already subscribes through `workerIdFromSource`; read the rest
-    // of the args untracked.
-    const args = untrack(source)
-    if (args === null)
-      return
-    void fetcher.run(args)
-  }))
-
-  const refresh = async (): Promise<void> => {
-    const args = untrack(source)
-    if (args === null)
-      return
-    await fetcher.run(args)
-  }
-
-  return { providers, loading: fetcher.loading, refresh }
+  return { providers, loading: list.loading, refresh: list.refresh }
 }

--- a/frontend/src/hooks/useAvailableShells.ts
+++ b/frontend/src/hooks/useAvailableShells.ts
@@ -1,7 +1,7 @@
 import type { Accessor } from 'solid-js'
-import { createEffect, createSignal, on, untrack } from 'solid-js'
+import { createSignal } from 'solid-js'
 import * as workerRpc from '~/api/workerRpc'
-import { createGuardedFetch } from '~/hooks/createGuardedFetch'
+import { createWorkerScopedList } from '~/hooks/createWorkerScopedList'
 
 export interface UseAvailableShellsArgs {
   workerId: string
@@ -61,60 +61,29 @@ export function useAvailableShells(
   const [serverDefault, setServerDefault] = createSignal('')
   const [userSelectedShell, setUserSelectedShell] = createSignal<string | null>(null)
 
-  // `lastLoadedWorkerId` advances only on a SUCCESSFUL listAvailableShells
-  // — a failed fetch leaves it unchanged so the next reactive tick with
-  // the same workerId can retry instead of short-circuiting on a stale
-  // sentinel. Assigning before the fetch (as an earlier revision did)
-  // would lock the dialog out of recovering from a transient failure
-  // until the user switched workers and back.
-  let lastLoadedWorkerId = ''
-
-  const fetcher = createGuardedFetch<UseAvailableShellsArgs, Awaited<ReturnType<typeof workerRpc.listAvailableShells>>>({
+  // Every rule about WHEN to fetch, when to retry and when to clear lives in
+  // `createWorkerScopedList`. This hook keeps only the state it stores: the
+  // server default beside the list, and the user's explicit override.
+  const list = createWorkerScopedList<UseAvailableShellsArgs, Awaited<ReturnType<typeof workerRpc.listAvailableShells>>>({
+    source,
     fetch: args => workerRpc.listAvailableShells(args.workerId, args),
-    applySuccess: (resp, args) => {
+    applySuccess: (resp) => {
       setShells(resp.shells)
       setServerDefault(resp.defaultShell)
-      lastLoadedWorkerId = args.workerId
       onLoaded?.()
     },
-    onError: (err) => {
-      onError?.(err)
+    // The override is cleared with the list, so `shell()` falls back to '' while
+    // the new fetch is in flight. Without it the dialog reports the PREVIOUS
+    // worker's default during the transition -- a leaked selection -- and a
+    // create gate that only checks `shell() !== ''` would let the user submit a
+    // shell the new worker may not have.
+    clear: () => {
       setShells([])
       setServerDefault('')
+      setUserSelectedShell(null)
     },
+    onError,
   })
-
-  // Track `source()?.workerId` rather than the source accessor itself.
-  // Caller closures typically build a fresh args object each tick, so
-  // `on(source, ...)` would re-fire the effect on every identity change
-  // upstream — merely a re-read that allocates a new object — even when the
-  // workerId, the only field that gates the fetch, is unchanged. Tracking the
-  // workerId scalar means identity churn that doesn't change worker stays a
-  // no-op tick on the memo, not a full effect run.
-  const workerIdFromSource = (): string | null => source()?.workerId ?? null
-  createEffect(on(workerIdFromSource, (workerId) => {
-    if (!workerId)
-      return
-    if (workerId === lastLoadedWorkerId)
-      return
-    // Worker changed (or the previous workerId never resolved) — clear
-    // the cached shells / serverDefault and the explicit override so
-    // shell() falls back to '' while the new fetch is in flight. Without
-    // this clear, the dialog reports the previous worker's default
-    // (effectively a leaked selection) during the transition window and
-    // an isTerminalCreateDisabled gate that only checks shell() != ''
-    // would let the user submit with a shell the new worker may not
-    // even have.
-    setShells([])
-    setServerDefault('')
-    setUserSelectedShell(null)
-    // Pull the rest of the fetch args out of `source()` untracked (the
-    // on() already subscribes via `workerIdFromSource`).
-    const args = untrack(source)
-    if (args === null)
-      return
-    void fetcher.run(args)
-  }))
 
   const defaultShell = () => {
     const s = shells()
@@ -122,24 +91,12 @@ export function useAvailableShells(
   }
   const shell = () => userSelectedShell() ?? defaultShell()
 
-  const refresh = async (): Promise<void> => {
-    const args = untrack(source)
-    if (args === null)
-      return
-    // Don't clear lastLoadedWorkerId here; the source-driven effect
-    // only consults it on a workerId TRANSITION, so a manual refresh
-    // against the current worker just re-fetches and re-stamps it on
-    // success (or leaves it untouched on failure, preserving the
-    // retry-allowed invariant).
-    await fetcher.run(args)
-  }
-
   return {
     shells,
     defaultShell,
     shell,
     setShell: setUserSelectedShell,
-    loading: fetcher.loading,
-    refresh,
+    loading: list.loading,
+    refresh: list.refresh,
   }
 }

--- a/frontend/src/lib/contentBlocks.test.ts
+++ b/frontend/src/lib/contentBlocks.test.ts
@@ -174,7 +174,7 @@ describe('markdownImageFormatter', () => {
   })
 })
 
-describe('splittoolresultcontent', () => {
+describe('splitToolResultContent', () => {
   it('returns the same text as joinContentParagraphs with images skipped', () => {
     const blocks = [
       { type: 'text', text: 'before' },
@@ -226,5 +226,64 @@ describe('splittoolresultcontent', () => {
     ], { text: 'text' })
     expect(text).toBe('')
     expect(images).toEqual([])
+  })
+})
+
+describe('forEachContentBlock guarantees', () => {
+  // `kinds[block.type]` reached Object.prototype: a block whose `type` is
+  // `constructor` or `toString` answered a truthy value, took the text path,
+  // read a non-string field and was skipped -- so `formatOther` never saw it.
+  // `type` is agent-supplied wire JSON, so any provider can send one.
+  it('hands a block whose type is an Object.prototype key to formatOther', () => {
+    const seen: string[] = []
+    joinContentParagraphs(
+      [
+        { type: 'constructor', text: 'x' },
+        { type: 'toString', text: 'y' },
+        { type: 'valueOf' },
+        { type: '__proto__' },
+      ],
+      { text: 'text' },
+      (block) => {
+        seen.push(String(block.type))
+        return null
+      },
+    )
+    expect(seen).toEqual(['constructor', 'toString', 'valueOf', '__proto__'])
+  })
+
+  // The ordering guarantee an image tab's permanent `imageIndex` rests on.
+  it('visits every non-kinds block exactly once, in wire order', () => {
+    const seen: unknown[] = []
+    joinContentParagraphs(
+      [
+        { type: 'text', text: 'a' },
+        { type: 'image', id: 1 },
+        { type: 'text', text: 'b' },
+        { type: 'image', id: 2 },
+      ],
+      { text: 'text' },
+      (block) => {
+        seen.push(block.id)
+        return null
+      },
+    )
+    expect(seen).toEqual([1, 2])
+  })
+
+  // The same walk feeds both sinks, so the index a tab stores and the text a
+  // quote shows come from one traversal rather than two that must agree.
+  it('splitToolResultContent numbers images by that same order', () => {
+    const { text, images } = splitToolResultContent(
+      [
+        { type: 'image', mimeType: 'image/png', data: 'FIRST' },
+        { type: 'text', text: 'between' },
+        { type: 'constructor', mimeType: 'image/png', data: 'SECOND' },
+        { type: 'image', mimeType: 'image/png', data: 'THIRD' },
+      ],
+      { text: 'text' },
+    )
+    expect(text).toBe('between')
+    expect(images.map(i => i.data)).toEqual(['FIRST', 'THIRD'])
   })
 })

--- a/frontend/src/lib/contentBlocks.ts
+++ b/frontend/src/lib/contentBlocks.ts
@@ -136,32 +136,70 @@ export function joinContentParagraphs(
   kinds: Record<string, string>,
   formatOther: BlockFormatter = markdownImageFormatter,
 ): string {
+  const join = createParagraphJoiner()
+  forEachContentBlock(content, kinds, join.append, (block) => {
+    const formatted = formatOther(block)
+    if (typeof formatted === 'string')
+      join.append(formatted)
+  })
+  return join.text()
+}
+
+/**
+ * Walk the blocks once, and send each to the sink its `type` selects.
+ *
+ * `onOther` runs EXACTLY ONCE for each block that is an object and whose `type`
+ * is not an own key of `kinds`, in wire order, with no short circuit.
+ *
+ * `Object.hasOwn`, and not a plain lookup. `kinds[block.type]` answers a TRUTHY
+ * `Object.prototype` member for a block whose `type` is `constructor`,
+ * `toString`, `valueOf`, `hasOwnProperty` or `__proto__` -- and `type` is
+ * agent-supplied wire JSON, so any provider can send one. Such a block took the
+ * text path, read a non-string field, and `continue`d: `formatOther` never saw
+ * it, so an image it carried was dropped from the text with no error.
+ */
+function forEachContentBlock(
+  content: ContentBlock[] | null | undefined,
+  kinds: Record<string, string>,
+  onText: (text: string) => void,
+  onOther: (block: ContentBlock) => void,
+): void {
   if (!content)
-    return ''
-  let out = ''
-  const append = (chunk: string) => {
-    if (chunk === '')
-      return
-    if (out !== '') {
-      const trailing = (out.match(/\n*$/)?.[0] ?? '').length
-      if (trailing < 2)
-        out += '\n'.repeat(2 - trailing)
-    }
-    out += chunk
-  }
+    return
   for (const block of content) {
     if (!isObject(block))
       continue
-    const field = kinds[block.type as string]
-    if (field) {
-      const v = block[field]
-      if (typeof v === 'string')
-        append(v)
+    const type = block.type as string
+    if (Object.hasOwn(kinds, type)) {
+      const value = block[kinds[type]]
+      if (typeof value === 'string')
+        onText(value)
       continue
     }
-    const formatted = formatOther(block)
-    if (typeof formatted === 'string')
-      append(formatted)
+    onOther(block)
   }
-  return out
+}
+
+/**
+ * The "at least two newlines between non-empty entries" accumulator.
+ *
+ * "At least two" handles content that already ends with newlines: it pads up to
+ * two and never trims down, so `"A\n"` + `"B"` gives `"A\n\nB"` while
+ * `"A\n\n\n"` + `"B"` stays `"A\n\n\nB"`.
+ */
+function createParagraphJoiner(): { append: (chunk: string) => void, text: () => string } {
+  let out = ''
+  return {
+    append(chunk: string) {
+      if (chunk === '')
+        return
+      if (out !== '') {
+        const trailing = (out.match(/\n*$/)?.[0] ?? '').length
+        if (trailing < 2)
+          out += '\n'.repeat(2 - trailing)
+      }
+      out += chunk
+    },
+    text: () => out,
+  }
 }

--- a/frontend/src/lib/imageBlocks.test.ts
+++ b/frontend/src/lib/imageBlocks.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { imageBlockToMarkdown, MAX_INLINE_IMAGE_BASE64_LEN, parseImageBlock } from './imageBlocks'
 
-describe('parseimageblock', () => {
+describe('parseImageBlock', () => {
   it('parses the Anthropic base64 shape (Claude Read, MCP bridge, notebook output)', () => {
     expect(parseImageBlock({ type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'AAAA' } }))
       .toEqual({ data: 'AAAA', mimeType: 'image/png' })
@@ -52,7 +52,7 @@ describe('parseimageblock', () => {
   })
 
   it('keeps a payload-less image block so the row can say an image was returned', () => {
-    // Anthropic's `source:{type:'file'}` names a file on Anthropic's servers,
+    // Anthropic's `source:{type:'file'}` states a file on Anthropic's servers,
     // and an MCP server may state only a MIME type. Dropping either would make
     // the image vanish from the transcript with no trace.
     expect(parseImageBlock({ type: 'image', source: { type: 'file', file_id: 'f1' } })).toEqual({})
@@ -74,7 +74,7 @@ describe('parseimageblock', () => {
     expect(parseImageBlock('image' as never)).toBeNull()
   })
 
-  // An empty `data` is no payload, not an empty payload: the arms below it must
+  // An empty `data` is no payload, not an empty payload: the branches below it must
   // still get their turn, and the source must end up renderable-as-nothing
   // rather than as a zero-length base64 the renderer would build a data URL out
   // of.
@@ -97,7 +97,7 @@ describe('parseimageblock', () => {
   })
 })
 
-describe('imageblocktomarkdown', () => {
+describe('imageBlockToMarkdown', () => {
   it('embeds base64 with a mime type', () => {
     expect(imageBlockToMarkdown({ data: 'AAAA', mimeType: 'image/png' }))
       .toBe('![image](data:image/png;base64,AAAA)')
@@ -184,5 +184,34 @@ describe('imageBlockFilePath platform shapes', () => {
   it('leaves a POSIX path alone, percent-decoding it', () => {
     expect(parseImageBlock({ type: 'image', data: 'AAAA', mimeType: 'image/png', uri: 'file:///home/alice/a%20b.png' }))
       .toMatchObject({ filePath: '/home/alice/a b.png' })
+  })
+})
+
+describe('imageBlockToMarkdown MIME allowlist', () => {
+  // The allowlist lived in the transcript row's component, which a lib module
+  // cannot import -- so this path hand-copied the size cap and had no allowlist
+  // at all. Both now come from `imageRenderInfo`, so the two destinations agree
+  // on which types embed.
+  it('refuses a type the transcript row refuses, and says which type', () => {
+    expect(imageBlockToMarkdown({ data: 'AAAA', mimeType: 'application/pdf' }))
+      .toBe('[image: application/pdf — unsupported format]')
+  })
+
+  it('refuses that type given as a data URL', () => {
+    expect(imageBlockToMarkdown({ url: 'data:application/pdf;base64,AAAA' })).toBeNull()
+  })
+
+  // SVG IS allowlisted: every consumer mounts through `<img>`, which renders it
+  // in secure static mode, and the file viewer already drew on-disk SVGs the
+  // same way. Refusing it here served no guarantee the element does not already
+  // give.
+  it('embeds an SVG, the same way the file viewer renders one off disk', () => {
+    expect(imageBlockToMarkdown({ data: 'AAAA', mimeType: 'image/svg+xml' }))
+      .toBe('![image](data:image/svg+xml;base64,AAAA)')
+  })
+
+  it('still embeds a raster type', () => {
+    expect(imageBlockToMarkdown({ data: 'AAAA', mimeType: 'image/png' }))
+      .toBe('![image](data:image/png;base64,AAAA)')
   })
 })

--- a/frontend/src/lib/imageBlocks.ts
+++ b/frontend/src/lib/imageBlocks.ts
@@ -48,7 +48,7 @@ export type ImageResultSource = ImageBlockSource & { dimensions?: ImageDimension
  *
  * An image block with no renderable payload yields a source whose `data` and
  * `url` are both absent, rather than null. A block can be a legitimate image
- * and still carry nothing -- an Anthropic `source:{type:'file'}` names a file
+ * and still carry nothing -- an Anthropic `source:{type:'file'}` states a file
  * on Anthropic's servers, and an MCP server may state a MIME type with no
  * payload. Keeping it lets the renderer say "an image was returned, and here
  * is why you cannot see it" (`imageRenderInfo` answers `no-data`) instead of
@@ -143,10 +143,23 @@ export function parseImageBlock(block: ContentBlock): ImageBlockSource | null {
 }
 
 /**
- * MIME types LeapMux renders inline. SVG is excluded deliberately: an SVG can
- * carry script, and although a browser refuses to run it inside `<img>`, the
- * allowlist is what keeps that guarantee from resting on the mount point a
- * future caller happens to pick.
+ * MIME types LeapMux renders inline.
+ *
+ * The list exists for the SIZE CAP and for one policy in one place, not as a
+ * script defence. Every consumer mounts an image through `ImageRender`, which
+ * builds a blob URL and hands it to an `<img>` -- and an `<img>` renders SVG in
+ * SECURE STATIC MODE, where no script runs, no external resource loads and no
+ * declarative animation plays. That is a property of the element, not of this
+ * set.
+ *
+ * SVG is therefore included. Excluding it refused an agent's diagram while the
+ * file viewer rendered the identical bytes off disk through the SAME
+ * `ImageRender`, which is an inconsistency rather than a policy.
+ *
+ * One real cost: `sniffImageDimensionsFromDataUrl` reads intrinsic dimensions
+ * from a raster header, and an SVG has none, so an SVG row reserves no box and
+ * falls back to measure-on-load. That costs one scroll adjustment when it
+ * decodes; it does not affect what is rendered.
  */
 export const RENDERABLE_IMAGE_MIME_TYPES = new Set<string>([
   'image/png',
@@ -154,6 +167,7 @@ export const RENDERABLE_IMAGE_MIME_TYPES = new Set<string>([
   'image/gif',
   'image/webp',
   'image/avif',
+  'image/svg+xml',
 ])
 
 /**
@@ -203,6 +217,7 @@ function imageBlockFilePath(block: Record<string, unknown>): string | undefined 
   const uri = pickString(block, 'uri', undefined)
   if (!uri || !uri.startsWith('file://'))
     return undefined
+  let pathname: string
   try {
     const parsed = new URL(uri)
     const path = decodeURIComponent(parsed.pathname)
@@ -220,32 +235,164 @@ function imageBlockFilePath(block: Record<string, unknown>): string | undefined 
   catch {
     return undefined
   }
+  // A LITERAL `%` that is not valid percent-encoding makes decodeURIComponent
+  // throw, and an agent that builds the uri by pasting a path after `file://`
+  // sends one for any file named `50%off.png`. The raw pathname is the right
+  // answer there: it is what the caller asked to open, and the only cost of
+  // skipping the decode is that a genuinely encoded name stays encoded --
+  // whereas returning undefined silently downgrades the click to the
+  // transcript's downsampled copy, with nothing to explain why.
+  try {
+    return decodeURIComponent(pathname) || undefined
+  }
+  catch {
+    return pathname || undefined
+  }
+}
+
+/** Why an image draws as a placeholder rather than inline. */
+export type ImageSkipReason = 'no-data' | 'unsupported-mime' | 'too-large' | 'external-url' | 'unknown-shape'
+
+/**
+ * Split a `data:<mime>[;<param>...];base64,<payload>` URL.
+ *
+ * ONE reader, because two disagreed. `imageRenderInfo` accepted a data URL with
+ * no `;base64` and the image-tab decoder refused it, so such an image drew
+ * inline with a click target and then opened a tab that said it could not
+ * display the picture -- the branch that decoder's own comment calls
+ * unreachable. Requiring `;base64` in the one parser is what makes it
+ * unreachable in fact.
+ *
+ * `mimeType` is the essence alone: `data:image/png;charset=utf-8;base64,...`
+ * answers `image/png`. A parameter that reached a Blob type made the tab and the
+ * row describe the same bytes two ways, and the allowlist below is keyed on the
+ * essence.
+ */
+export function parseDataImageUrl(url: string | undefined): { mimeType: string, base64: string } | null {
+  if (!url?.startsWith('data:'))
+    return null
+  const comma = url.indexOf(',')
+  if (comma < 0)
+    return null
+  const params = url.slice('data:'.length, comma).split(';')
+  const mimeType = (params.shift() ?? '').toLowerCase()
+  if (!params.some(param => param.toLowerCase() === 'base64'))
+    return null
+  return { mimeType, base64: url.slice(comma + 1) }
+}
+
+/**
+ * Whether an image source draws inline, and if not, why.
+ *
+ * The single render policy for every destination. It lives beside the parser
+ * rather than in the transcript row, because the row is not the only consumer:
+ * `imageBlockToMarkdown` feeds every quote, preview and Markdown body, and it
+ * used to embed a 50 MB payload that the row next to it refused.
+ *
+ *   - inline base64 + allowlisted MIME + under the cap -> `<img src="data:...">`
+ *   - an already-formed `data:` URL, on the same terms
+ *   - an http(s) URL -> not drawn; the caller shows an open link, so the
+ *     transcript fetches from no remote host on its own
+ *   - anything else -> a placeholder, so the reader still learns an image came
+ *     back
+ */
+export function imageRenderInfo(source: ImageBlockSource): {
+  src?: string
+  via?: 'inline'
+  reason?: ImageSkipReason
+} {
+  const url = source.url
+  if (url) {
+    if (url.startsWith('data:')) {
+      const parsed = parseDataImageUrl(url)
+      if (!parsed)
+        return { reason: 'unknown-shape' }
+      return renderPolicy(parsed.mimeType, parsed.base64, url)
+    }
+    // An http(s) URL is shown as an opt-in external link by the caller.
+    if (url.startsWith('http://') || url.startsWith('https://'))
+      return { reason: 'external-url' }
+    return { reason: 'unknown-shape' }
+  }
+
+  const data = source.data
+  if (!data)
+    return { reason: 'no-data' }
+  const mimeType = (source.mimeType ?? '').toLowerCase()
+  return renderPolicy(mimeType, data, `data:${mimeType};base64,${data}`)
+}
+
+/**
+ * The allowlist and the cap, applied once. Both shapes above normalize to
+ * (mime, base64) first, so neither can be checked against a different length
+ * than the other renders.
+ */
+function renderPolicy(mimeType: string, base64: string, src: string): {
+  src?: string
+  via?: 'inline'
+  reason?: ImageSkipReason
+} {
+  if (!RENDERABLE_IMAGE_MIME_TYPES.has(mimeType))
+    return { reason: 'unsupported-mime' }
+  if (base64.length > MAX_INLINE_IMAGE_BASE64_LEN)
+    return { reason: 'too-large' }
+  return { src, via: 'inline' }
 }
 
 /**
  * Render an image block as Markdown, for the text-only contexts that have no
  * place to mount a component (a quote, a scroll-rail preview, a Markdown body).
  *
- * Base64 becomes an inline `![image](data:...)`, which embeds when the
- * surrounding renderer is Markdown-aware. An external URL becomes a
+ * A renderable image becomes an inline `![image](data:...)`, which embeds when
+ * the surrounding renderer is Markdown-aware. An external URL becomes a
  * `[image](url)` LINK, not an embed, so rendering it never fetches from a
  * third-party host.
+ *
+ * It asks `imageRenderInfo`, the SAME policy the transcript row asks, so the two
+ * destinations can never disagree about which pictures are safe to embed. This
+ * path used to skip that policy entirely, and `rehypeBlockRemoteImages` lets a
+ * `data:` src through -- so an `image/svg+xml` or a 50 MB payload embedded here
+ * after the row beside it had already refused to draw it.
+ *
+ * Anything the policy refuses returns null and the caller omits the block,
+ * which is what this function has always done for a shape it could not render.
+ * The row is where a refused image still leaves a visible trace, through
+ * {@link imageSkipPlaceholder}; a Markdown body has no box to put one in.
  */
 export function imageBlockToMarkdown(source: ImageBlockSource): string | null {
-  if (source.data && source.mimeType) {
-    if (source.data.length > MAX_INLINE_IMAGE_BASE64_LEN)
-      return `[image: ${source.mimeType} — too large to embed]`
-    return `![image](data:${source.mimeType};base64,${source.data})`
+  const info = imageRenderInfo(source)
+  if (info.src)
+    return `![image](${info.src})`
+  if (info.reason === 'external-url' && source.url)
+    return `[image](${source.url})`
+  // A refused image still leaves a trace, so a reader learns one came back.
+  if (info.reason === 'too-large')
+    return source.mimeType ? `[image: ${source.mimeType} — too large to embed]` : '[image: too large to embed]'
+  // `unsupported-mime` says something only when a type was actually stated --
+  // an `image/svg+xml`, which the allowlist refuses and this path used to
+  // embed. Without a type the block carries nothing to describe, and this
+  // function has always omitted such a block; so has `no-data`.
+  if (info.reason === 'unsupported-mime' && source.mimeType)
+    return `[image: ${source.mimeType} — unsupported format]`
+  return null
+}
+
+/**
+ * The text a destination shows in place of an image it will not draw.
+ *
+ * One wording for the transcript row and for the Markdown path, so a reader who
+ * sees the same refused image in a quote and in the transcript reads the same
+ * sentence. The MIME type is included when the wire carried one, because
+ * "unsupported format" without the format is a question rather than an answer.
+ */
+export function imageSkipPlaceholder(reason: ImageSkipReason | undefined, mimeType?: string): string {
+  const suffix = mimeType ? `: ${mimeType}` : ''
+  switch (reason) {
+    case 'too-large':
+      return `[image${suffix} — too large to render inline]`
+    case 'unsupported-mime':
+      return `[image${suffix} — unsupported format]`
+    default:
+      return `[image${suffix}]`
   }
-  const url = source.url
-  if (!url)
-    return null
-  if (!url.startsWith('data:'))
-    return `[image](${url})`
-  // The same cap on an already-formed data URL. Measured past the comma, so it
-  // compares the payload and not the `data:<mime>;base64,` preamble.
-  const comma = url.indexOf(',')
-  if (comma >= 0 && url.length - comma - 1 > MAX_INLINE_IMAGE_BASE64_LEN)
-    return '[image: too large to embed]'
-  return `![image](${url})`
 }

--- a/frontend/src/lib/imageDimensions.ts
+++ b/frontend/src/lib/imageDimensions.ts
@@ -30,6 +30,10 @@
  */
 
 import { base64ToUint8Array } from './base64'
+// A VALUE import, unlike imageBlocks' own `import type { ImageDimensions }`
+// back here -- that one erases at build time, so the two modules form no
+// runtime cycle.
+import { parseDataImageUrl } from './imageBlocks'
 
 export interface ImageDimensions {
   width: number
@@ -49,17 +53,14 @@ const MAX_SANE_DIMENSION_PX = 65535
  * Sniff intrinsic dimensions from a `data:<mime>;base64,<payload>` URL.
  * Returns null for non-base64 data URLs, unsupported formats, and any
  * payload whose header cannot be parsed with certainty.
+ *
+ * The split itself comes from `~/lib/imageBlocks`, the one reader of a data URL
+ * in the app. This module used to hold a third copy of it, and the copies
+ * disagreed about whether `;base64` was required.
  */
 export function sniffImageDimensionsFromDataUrl(dataUrl: string): ImageDimensions | null {
-  if (!dataUrl.startsWith('data:'))
-    return null
-  const comma = dataUrl.indexOf(',')
-  if (comma < 0)
-    return null
-  const meta = dataUrl.slice(5, comma)
-  if (!meta.toLowerCase().endsWith(';base64'))
-    return null
-  return sniffImageDimensionsFromBase64(dataUrl.slice(comma + 1))
+  const parsed = parseDataImageUrl(dataUrl)
+  return parsed ? sniffImageDimensionsFromBase64(parsed.base64) : null
 }
 
 /** Sniff intrinsic dimensions from a bare base64 payload. */

--- a/frontend/src/lib/tabPayload.test.ts
+++ b/frontend/src/lib/tabPayload.test.ts
@@ -3,13 +3,13 @@ import { describe, expect, it } from 'vitest'
 import { TabPayloadSchema } from '~/generated/proto/leapmux/v1/worker_private_pb'
 import { fileTabPayload, imageTabPayload, tabPayloadView } from './tabPayload'
 
-describe('tabpayloadview', () => {
-  it('decodes the file arm', () => {
+describe('tabPayloadView', () => {
+  it('decodes the file branch', () => {
     const payload = create(TabPayloadSchema, fileTabPayload('/repo/a.ts', '/repo'))
     expect(tabPayloadView(payload)).toEqual({ kind: 'file', filePath: '/repo/a.ts', workingDir: '/repo' })
   })
 
-  it('decodes the image arm', () => {
+  it('decodes the image branch', () => {
     const payload = create(TabPayloadSchema, imageTabPayload({
       agentId: 'a1',
       seq: 42n,
@@ -31,7 +31,7 @@ describe('tabpayloadview', () => {
     expect(tabPayloadView(undefined)).toBeNull()
   })
 
-  it('returns null for a payload naming no kind', () => {
+  it('returns null for a payload stating no kind', () => {
     // A tab kind a newer peer registered. Returning a half-built `file` view
     // would render it as an empty FILE tab, which is worse than saying nothing.
     expect(tabPayloadView(create(TabPayloadSchema, { workingDir: '/repo' }))).toBeNull()

--- a/frontend/src/test-support/composedResetsAreLayered.test.ts
+++ b/frontend/src/test-support/composedResetsAreLayered.test.ts
@@ -36,7 +36,7 @@ const INLINE_RESET = /style\(\[\s*\{\s*all:\s*'unset'/g
 /** `all: 'unset'` written as a declaration. */
 const BARE_RESET = /\ball:\s*'unset'/
 
-/** The absolute path of the `.css.ts` file that `spec` names, or undefined. */
+/** The absolute path of the `.css.ts` file that `spec` states, or undefined. */
 function resolveStyleModule(importer: string, spec: string): string | undefined {
   if (spec.startsWith('~/'))
     return join(srcRoot, `${spec.slice(2)}.ts`)

--- a/frontend/tests/e2e/159-branch-context-menu.spec.ts
+++ b/frontend/tests/e2e/159-branch-context-menu.spec.ts
@@ -57,7 +57,7 @@ test.describe('Branch context menu', () => {
       await expect(page.getByRole('menuitem', { name })).toBeVisible()
     await expect(page.getByRole('menuitem', { name: 'Change branch...' })).toHaveCount(0)
 
-    // A worktree workspace, so the delete item names the worktree. The change
+    // A worktree workspace, so the delete item states the worktree. The change
     // items keep their names: a worktree has a branch checked out either way.
     await expect(page.getByRole('menuitem', { name: 'Delete worktree...' })).toBeVisible()
     await expect(page.getByRole('menuitem', { name: 'Delete branch...' })).toHaveCount(0)
@@ -203,7 +203,7 @@ test.describe('Branch context menu', () => {
   })
 
   // The glyph row's counterpart to the shell-item test above, and the same
-  // scope: it pins the WIRING, not the directory. A provider glyph names the
+  // scope: it pins the WIRING, not the directory. A provider glyph states the
   // branch worker's own provider list, which is the half a mount-time fetch
   // would have taken from the active tab's worker instead.
   test('opens an agent from the menu\'s provider glyph', async ({
@@ -229,7 +229,7 @@ test.describe('Branch context menu', () => {
     const before = await agentTabs.count()
     await openBranchMenu(page, branchGroupRow(page))
     // The first provider the branch's Worker reports. Which one it is depends
-    // on what the test machine has installed, so the test names none.
+    // on what the test machine has installed, so the test states none.
     await page.locator('menu[popover]:visible [data-testid^="menu-new-agent-"]').first().click()
 
     await expect(agentTabs).toHaveCount(before + 1)
@@ -242,7 +242,7 @@ test.describe('Branch context menu', () => {
   // the user is not looking at. The new tab is placed on the ACTIVE workspace's
   // focused tile, so the row's own workspace has to become active first -- and
   // in the same tick, because the placement follows the switch synchronously.
-  // Without it the pty is created on the Worker and no tab ever references it.
+  // Without it the pty is created on the Worker and no tab ever points at it.
   //
   // Both workspaces sit on the one Worker the fixture starts, so this pins the
   // WORKSPACE axis only. The Worker axis is the branch row's own `workerId`,
@@ -329,7 +329,7 @@ test.describe('Branch context menu', () => {
 
     const dialog = page.getByRole('dialog')
     await expect(dialog.getByRole('heading', { name: 'New Agent' })).toBeVisible()
-    // The repository the branch row named. `NewAgentDialog` remaps a worktree
+    // The repository the branch row stated. `NewAgentDialog` remaps a worktree
     // root to the canonical repo root for its git options, exactly as it does
     // from the tab bar (see 072), so this is the repo root either way.
     await expect(dialog.getByPlaceholder('Enter path...')).toHaveValue(realRepoDir)

--- a/frontend/tests/e2e/178-subagent-spawn-has-no-span.spec.ts
+++ b/frontend/tests/e2e/178-subagent-spawn-has-no-span.spec.ts
@@ -30,8 +30,11 @@ import { ASSISTANT_BUBBLE_SELECTOR, sendMessage, waitForAgentIdle } from './help
  *
  * The middle part is the TASK title when the payload carries one -- a launch
  * does, quoted and with spaces in it -- and the agent id when it does not, which
- * is the case for a finished synchronous run. The alternation covers both while
- * keeping each side anchored.
+ * is the fallback when neither the result nor the paired tool_use input supplies
+ * a description. The alternation covers both while keeping each side anchored.
+ *
+ * A synchronous result now receives its description from the paired tool_use
+ * input, so the quoted form appears for synchronous runs as well.
  *
  * NOT `.+?`, which this pattern used and which fails in both directions: `.`
  * matches a space, so it crosses out of the header into ordinary assistant prose
@@ -41,16 +44,15 @@ import { ASSISTANT_BUBBLE_SELECTOR, sendMessage, waitForAgentIdle } from './help
  * the spawn card renders. `.` also does not match a newline, so a model-written
  * title with a line break made the locator find nothing.
  *
- * Inside the quotes: `[\s\S]*?`, LAZY, and not `[^']*`. The title is model prose,
- * so an apostrophe in it is ordinary ("the parser's callers") -- and `[^']*`
- * stops dead at that apostrophe, then demands a status where the next letter
- * sits, so the whole locator matched nothing and the assertion failed red
- * against a card that rendered correctly. `[\s\S]` spans a newline, and the lazy
- * quantifier stops at the FIRST quote that a status follows rather than running
- * to the last quote on the page. `\S+` keeps the bare-id form from crossing a
- * space.
+ * Inside the quotes: `[\s\S]*?`, LAZY, and not `[^"]*`. The title is model
+ * prose, so a double quote in it is possible -- and `[^"]*` stops dead at that
+ * quote, then demands a status where the next character sits, so the whole
+ * locator matched nothing and the assertion failed red against a card that
+ * rendered correctly. `[\s\S]` spans a newline, and the lazy quantifier stops at
+ * the FIRST quote that a status follows rather than running to the last quote on
+ * the page. `\S+` keeps the bare-id form from crossing a space.
  */
-const AGENT_RESULT_HEADER = /Agent (?:'[\s\S]*?'|\S+) (?:completed|failed|launched asynchronously|launched remotely)/
+const AGENT_RESULT_HEADER = /Agent (?:"[\s\S]*?"|\S+) (?:completed|failed|launched asynchronously|launched remotely)/
 /** The Agent tool's own card title, which carries the subagent type. */
 const AGENT_TYPE = 'general-purpose'
 

--- a/frontend/tests/e2e/helpers/api.test.ts
+++ b/frontend/tests/e2e/helpers/api.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { TabType } from '~/generated/proto/leapmux/v1/workspace_pb'
+import { tabTypeFromProtoName } from './api'
+
+// A `.test.ts` under tests/e2e/ runs in `task test-frontend` -- no browser, no
+// hub, milliseconds. The E2E suite never sees it.
+describe('tabTypeFromProtoName', () => {
+  // The regression this replaced a hand-written table for: the table listed
+  // four names, IMAGE was missing, and `listTabsViaAPI` threw on any workspace
+  // that held an image tab -- so a spec failed in teardown rather than in its
+  // own assertion.
+  it('answers every value the TabType enum declares', () => {
+    expect(tabTypeFromProtoName('TAB_TYPE_UNSPECIFIED')).toBe(TabType.UNSPECIFIED)
+    expect(tabTypeFromProtoName('TAB_TYPE_AGENT')).toBe(TabType.AGENT)
+    expect(tabTypeFromProtoName('TAB_TYPE_TERMINAL')).toBe(TabType.TERMINAL)
+    expect(tabTypeFromProtoName('TAB_TYPE_FILE')).toBe(TabType.FILE)
+    expect(tabTypeFromProtoName('TAB_TYPE_IMAGE')).toBe(TabType.IMAGE)
+  })
+
+  // Throwing is the contract: a tab this helper cannot classify must not be
+  // silently dropped from a cleanup sweep.
+  it('throws for a name the enum does not declare, naming the tab', () => {
+    expect(() => tabTypeFromProtoName('TAB_TYPE_BOGUS', 'tab-9'))
+      .toThrow(/unrecognized tab_type "TAB_TYPE_BOGUS" for tab tab-9/)
+    expect(() => tabTypeFromProtoName('')).toThrow(/unrecognized tab_type ""/)
+  })
+})

--- a/frontend/tests/e2e/helpers/api.ts
+++ b/frontend/tests/e2e/helpers/api.ts
@@ -3,6 +3,8 @@
 // ──────────────────────────────────────────────
 
 import type { ChannelManager } from '../../../src/lib/channel'
+import { enumFromJson } from '@bufbuild/protobuf'
+import { TabTypeSchema } from '../../../src/generated/proto/leapmux/v1/workspace_pb'
 import { solveCaptchaViaAPI } from './altcha'
 import { createTestChannelManager } from './e2e-channel'
 
@@ -760,13 +762,6 @@ async function listTabsViaAPI(
   cookie: string,
   workspaceId: string,
 ): Promise<{ tabType: number, tabId: string, workerId: string }[]> {
-  const { TabType } = await import('../../../src/generated/proto/leapmux/v1/workspace_pb')
-  const tabTypeByName: Record<string, number> = {
-    TAB_TYPE_UNSPECIFIED: TabType.UNSPECIFIED,
-    TAB_TYPE_AGENT: TabType.AGENT,
-    TAB_TYPE_TERMINAL: TabType.TERMINAL,
-    TAB_TYPE_FILE: TabType.FILE,
-  }
   const res = await fetch(`${hubUrl}/leapmux.v1.WorkspaceService/ListTabs`, {
     method: 'POST',
     headers: authedHeaders(cookie),
@@ -777,12 +772,33 @@ async function listTabsViaAPI(
   const body = await res.json() as { tabs?: { tabType?: string, tabId?: string, workerId?: string }[] }
   return (body.tabs ?? [])
     .filter(t => t.tabId)
-    .map((t) => {
-      const tabType = tabTypeByName[t.tabType ?? '']
-      if (tabType === undefined)
-        throw new Error(`listTabsViaAPI: unrecognized tab_type ${JSON.stringify(t.tabType)} for tab ${t.tabId}`)
-      return { tabType, tabId: t.tabId!, workerId: t.workerId ?? '' }
-    })
+    .map(t => ({
+      tabType: tabTypeFromProtoName(t.tabType ?? '', t.tabId!),
+      tabId: t.tabId!,
+      workerId: t.workerId ?? '',
+    }))
+}
+
+/**
+ * The TabType a protojson `tab_type` name stands for.
+ *
+ * Reflection over the generated enum, NOT a hand-written table. The table this
+ * replaced listed four names and was already one short: `TAB_TYPE_IMAGE` was
+ * missing, so `listTabsViaAPI` threw on any workspace that held an image tab,
+ * and every spec sharing that fixture failed in teardown rather than in the
+ * assertion it was written for.
+ *
+ * It still THROWS on a name the enum does not declare, which is the contract
+ * the caller needs: a tab this helper cannot classify must not be silently
+ * dropped from a cleanup sweep.
+ */
+export function tabTypeFromProtoName(name: string, tabId?: string): number {
+  try {
+    return enumFromJson(TabTypeSchema, name as never) as number
+  }
+  catch {
+    throw new Error(`listTabsViaAPI: unrecognized tab_type ${JSON.stringify(name)}${tabId ? ` for tab ${tabId}` : ''}`)
+  }
 }
 
 /**

--- a/proto/leapmux/v1/worker_private.proto
+++ b/proto/leapmux/v1/worker_private.proto
@@ -152,7 +152,7 @@ message GetTabPayloadRequest {
 message GetTabPayloadResponse {
   // Always set on a successful response: a tab with no row answers NOT_FOUND
   // rather than OK with an unset payload, so a reader that sees this field
-  // absent is reading a payload arm its build does not know.
+  // absent is reading a payload branch its build does not know.
   TabPayload payload = 1;
 }
 

--- a/site/content/docs/using/coding-agents.md
+++ b/site/content/docs/using/coding-agents.md
@@ -155,11 +155,10 @@ Click one to open it in its own tab, where you can zoom it (fit, 100%, or any st
 
 Not every image renders inline:
 
-- **SVG** is never rendered. An SVG can carry script, and the transcript does not sandbox it.
 - **Images above about 5 MB** show a placeholder instead of the picture.
 - **An image the agent gives by URL** shows an **open ↗** link instead of the picture. Rendering it would fetch from that host, which the transcript never does on its own.
 
-Which providers can return an image at all depends on the provider — Claude Code, Codex, Pi, OpenCode, Kilo, and Goose all can.
+Every provider except ZCode can return an image: Claude Code, Codex, Pi, and each ACP provider (OpenCode, Cursor, GitHub Copilot, Kilo, Goose, Reasonix). ZCode's app server turns an image part into a placeholder string before it reaches LeapMux, so there is no picture left to draw.
 
 ### The todo / plan sidebar
 

--- a/site/content/docs/using/control-cli.md
+++ b/site/content/docs/using/control-cli.md
@@ -223,7 +223,7 @@ Almost every command needs to know which entity to act on. Rather than hand-roll
 | Flag | Env default | Notes |
 | --- | --- | --- |
 | `--tab-id` | `$LEAPMUX_CONTROL_TAB_ID` | The agent/terminal/file tab |
-| `--tab-type` | (none) | `agent` or `terminal`; auto-detected when omitted. Not on `agent`/`terminal` commands, which pin the type; hidden on `tab list`, which reuses the flag as an output filter. |
+| `--tab-type` | (none) | `agent`, `terminal`, `file` or `image`; auto-detected when omitted. Not on `agent`/`terminal` commands, which pin the type; hidden on `tab list`, which reuses the flag as an output filter. |
 | `--tile-id` | (none) | Derivable from `--tab-id` |
 | `--workspace-id` | (none) | Derivable from `--tab-id` / `--tile-id` |
 | `--worker-id` | `$LEAPMUX_CONTROL_WORKER_ID` | The host Worker |


### PR DESCRIPTION
## Motivation

IMAGE tab payloads state an agent id, a message seq, and a tool-derived title — transcript facts governed by `agent:read` — yet the private-event stream was only floored at `file:read`. A `file:read`-only caller could therefore learn which agents exist and which messages the user opened, fetch the payload itself via `GetTabPayload`, and even register IMAGE payloads of its own; a kind-based gate only existed for renames.

Frontend image handling had accumulated disagreeing copies of a single policy. The MIME allowlist and base64 size cap lived inside a chat component, so the Markdown/quote path hand-copied the cap and skipped the allowlist entirely, the image tab carried yet another data-URL parser that disagreed with the rest, and SVG rendered in the file viewer but not in chat. Images returned by *failed* MCP tool calls were silently discarded, which also permanently desynced the index an already-open image tab addresses.

The same pass surfaced several smaller latent bugs: the macOS hide-to-tray hook held a raw window address that could match a reused address after the original window is deallocated; the archived-workspace guard only protected the *active* workspace, so Create on an archived branch row ran the RPC and silently orphaned the worker-side agent and worktree; synchronous Claude Agent results always showed the opaque agent id because the sync payload omits the description; content blocks whose `type` collides with an `Object.prototype` key (`constructor`, `toString`, …) were silently dropped; and e2e cleanup threw on any workspace holding an image tab.

## Modifications

- **Scope-gate IMAGE payloads (backend)**: new `tabTypeReadScope`/`callerReadsTabType` helpers (an exhaustive switch, so a new TabType without a scope answer fails the build) now gate three previously inconsistent routes: `TabPayloadRegistered` events are filtered per caller (undecodable payloads fail closed), `RegisterTabPayload` answers PERMISSION_DENIED, and `GetTabPayload` answers NOT_FOUND instead of handing over a payload the stream withholds. FILE and TERMINAL keep their existing floors; `TabPayloadRevoked` still flows.
- **Single payload scan in `BuildTabSync`**: `payloadTabIDsByType` reads `worker_tab_payloads` once and buckets ids by kind, replacing one full scan per payload kind on a path that runs on every hub connect/reconnect.
- **One image render policy (frontend)**: `imageRenderInfo`, `ImageSkipReason`, `parseDataImageUrl`, and `imageSkipPlaceholder` moved to `~/lib/imageBlocks`, next to the allowlist and size cap. The transcript row, `imageBlockToMarkdown`, and the image tab's decoder all route through the same decision; `sniffImageDimensionsFromDataUrl` delegates to the shared parser.
- **SVG renders**: `image/svg+xml` joined `RENDERABLE_IMAGE_MIME_TYPES`; every consumer mounts through a blob-URL `<img>`, so SVG renders in secure static mode — the same way the file viewer already drew on-disk SVGs.
- **Failed MCP calls keep their images**: `claudeMcpFromToolResult` drops only text blocks when `is_error` is set (the `error` string already carries the joined text) and keeps image blocks.
- **Image tab validates before decoding**: the tab re-resolves `(agent, seq, index)` at open time, so the source now goes through `imageRenderInfo` first — a payload the row refuses (oversized, non-allowlisted MIME, stray data-URL parameter in the MIME) can never reach the Blob.
- **Per-workspace archival guard**: `AppShellDialogs` takes `isWorkspaceMutatable(workspaceId)` (backed by `isWorkspaceMutatableById` in AppShell), so Create is blocked before the RPC for an archived target even when a different workspace is active.
- **Relative image paths**: `handleChatImageOpen` requires an absolute path before opening the file viewer; relative paths fall back to the transcript's downsampled copy instead of a FILE tab whose worker-side registration fails and vanishes.
- **Smaller fixes**: `forEachContentBlock` with `Object.hasOwn` replaces the prototype-chain lookup in `contentBlocks.ts`; `createWorkerScopedList` dedupes the identical fetch skeletons of `useAvailableShells`/`useAvailableProviders`; `imageBlockFilePath` falls back to the raw pathname when `decodeURIComponent` throws (e.g. `50%off.png`); the Claude agent card sources its header description from the paired `Agent` tool_use input for sync runs and quotes it with `"` instead of `'` (titles often contain apostrophes); the macOS minimize hook stores a weak window reference (`WeakWindow`) so a deallocated window's reused address no longer matches; e2e `tabTypeFromProtoName` handles `TAB_TYPE_IMAGE`; docs now advertise `file`/`image` `--tab-type` values and the per-provider image coverage.

## Result

- A `file:read`-only caller can no longer see, fetch, or register IMAGE payloads — they now require `agent:read` on every route.
- SVG images render inline in transcripts, quotes and Markdown bodies, and the image viewer tab, matching the file viewer's existing behavior for on-disk SVGs.
- Screenshots returned by failed MCP tools (e.g. Playwright) stay in the transcript, and already-open image tabs keep addressing the right image instead of desyncing.
- Clicking an image whose tool reported a relative path opens the transcript's copy instead of a file tab that flashes and disappears.
- Create-tab dialogs block archived workspaces with "This workspace is archived…" before any RPC runs, so no more silently orphaned agents/worktrees.
- Completed synchronous Agent cards show the model-written task title (e.g. `Agent "Fix the parser's callers" completed`) instead of the raw agent id.
- Hide-to-tray on macOS no longer risks capturing an unrelated window that happened to reuse a deallocated window's address.
- Hub reconnects do one `worker_tab_payloads` scan instead of one per payload kind, and e2e cleanup no longer fails on workspaces that hold image tabs.
