### PR TITLE
feat(agents): Add smart and bypass permission presets per provider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,8 @@ before building).
   credential-rejected). `retry.json` — the events-rejection retry policy.
   `worker-vocab.json` — notification-type tokens, the notification-thread
   discriminator, the Codex rate-limit token, and the model sentinels.
+  `goose-protocol.json` — Goose permission modes. `copilot-permissions.json` —
+  the identifiers for Copilot Assisted Approval and Allow All.
   `providers.json` — AgentProvider display names / CLI aliases / parse
   aliases (agentlabels and agentProviderLabel consume the generated tables).
   `scopes.json` — the scope vocabulary: wire tokens, Preferences

--- a/backend/internal/worker/agent/acp_common.go
+++ b/backend/internal/worker/agent/acp_common.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"maps"
 	"slices"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -159,9 +160,25 @@ type acpBase struct {
 	// the old syncsPermissionMode/syncsPrimaryAgent bool pair so the illegal "both set"
 	// state is unrepresentable and every family-conditional site reads one field.
 	modeChannel acpModeChannel
-	// orderPermissionModes applies a provider order to each rebuilt permission list.
-	// Goose uses it to put Smart Approve first. Other providers leave it nil.
-	orderPermissionModes func([]*leapmuxv1.AvailableOption)
+	// preferredFirstMode, when non-empty, is the permission-mode id this provider lists
+	// first in every rebuilt permission list. Goose declares smart_approve, its safe
+	// new-session mode. "" keeps the order the server reports.
+	//
+	// Position 0 is not only a display order: secondaryGroup stamps
+	// defaultOrFirstOption(options) as the group's DefaultValue, and
+	// reconcileCurrentOptionID re-seeds the current selection from the same option. So
+	// the preferred mode is also the one this provider falls back to.
+	preferredFirstMode string
+	// decorateOptionGroups lets a provider add or drop groups that no ACP channel ever
+	// reports. Copilot's Assisted Approval rides the launch flags, so no server payload
+	// carries it, and the base must surface it in the catalog AND in every result derived
+	// from that catalog -- SettingsSnapshot builds its settlements from OptionGroups, and
+	// Go resolves that call to the BASE method however the provider embeds acpBase. A
+	// provider that only overrode OptionGroups would therefore report a group the UI shows
+	// but no snapshot settles. nil leaves the base catalog alone.
+	//
+	// It runs OUTSIDE b.mu, because the base body holds the lock for its whole span.
+	decorateOptionGroups func([]*leapmuxv1.AvailableOptionGroup) []*leapmuxv1.AvailableOptionGroup
 	// secondaryChannelOnce/secondaryChannelCache memoize the resolved secondary channel.
 	// modeChannel is fixed at construction (configure) and the channel's field/list POINTERS
 	// and closures all capture b (stable), so the resolution is invariant for the agent's
@@ -636,9 +653,7 @@ func (b *acpBase) buildSecondaryChannel() acpSecondaryChannel {
 		sc.available = &b.availableModes
 		sc.rebuild = func(modes []acpModeInfo, reported string) {
 			if rebuilt := buildACPModes(modes, reported, nil); len(rebuilt) > 0 {
-				if b.orderPermissionModes != nil {
-					b.orderPermissionModes(rebuilt)
-				}
+				orderModesPreferredFirst(rebuilt, b.preferredFirstMode)
 				b.availableModes = rebuilt
 			}
 		}
@@ -2088,8 +2103,7 @@ type acpStartSpec[T any] struct {
 	provider       leapmuxv1.AgentProvider                    // registry key; lets acpStart seed b.secondaryFallback from the provider's registration
 	providerName   string                                     // process/log name, e.g. "cursor"
 	binaryName     string                                     // CLI binary to launch
-	baseArgs       []string                                   // args after the binary, e.g. {"acp"}
-	baseArgsFor    func(Options) []string                     // option-dependent args; overrides baseArgs when set
+	baseArgs       []string                                   // args after the binary, e.g. {"acp"}; a provider whose args depend on the launch options builds them at the call site (see copilotBaseArgs)
 	rcMarkerEnvKey string                                     // provider rc marker stripped + re-added on a login shell (e.g. "KILO_CLIENT"); "" if none
 	sessionConfig  acpSessionConfig                           // zero value -> acpDefaultSessionConfig
 	newAgent       func() *T                                  // construct a zero-value concrete agent
@@ -2111,15 +2125,11 @@ func acpStart[T any](ctx context.Context, opts Options, sink OutputSink, spec ac
 		cancel()
 		return nil, err
 	}
-	baseArgs := spec.baseArgs
-	if spec.baseArgsFor != nil {
-		baseArgs = spec.baseArgsFor(opts)
-	}
 	wrap := shellWrapSpec{
 		Shell:      opts.Shell,
 		LoginShell: opts.LoginShell,
 		Launch:     launch,
-		BaseArgs:   baseArgs,
+		BaseArgs:   spec.baseArgs,
 		WorkingDir: opts.WorkingDir,
 	}
 	if spec.rcMarkerEnvKey != "" {
@@ -2232,6 +2242,16 @@ var (
 // the secondary group. One body serves every ACP family; the axis specifics come from
 // secondaryChannel and the per-provider secondaryFallback, so no provider overrides this.
 func (b *acpBase) OptionGroups() []*leapmuxv1.AvailableOptionGroup {
+	groups := b.baseOptionGroups()
+	if b.decorateOptionGroups != nil {
+		return b.decorateOptionGroups(groups)
+	}
+	return groups
+}
+
+// baseOptionGroups builds the catalog from the ACP channels alone. Split from
+// OptionGroups so the decorator runs after the lock is released.
+func (b *acpBase) baseOptionGroups() []*leapmuxv1.AvailableOptionGroup {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	var groups []*leapmuxv1.AvailableOptionGroup
@@ -2615,18 +2635,35 @@ func (b *acpBase) trySetStartupModel(requested string) {
 // the model, the mode is mandatory: a rejected mode returns an error so the caller
 // aborts startup.
 //
+// One case never aborts: a mode LeapMux itself chose (the new-session safe default)
+// that this session's own mode list does not offer. Goose declares smart_approve as
+// its safe default, and a build that reports no such mode would otherwise fail every
+// new session with "unknown mode" -- a mode the user never asked for killing the tab.
+// The session keeps the mode the handshake reported instead, and the warning names
+// what happened. An EXPLICIT request still aborts, so a typed --permission-mode that
+// this build cannot enter is reported rather than silently downgraded. Claude
+// (isAutoModeUnavailableError) and Copilot (the assisted-approval relaunch) degrade
+// their own safe defaults the same way.
+//
 // The current mode is read under b.mu: startACPHandshake starts the reader
 // goroutine before Start* reaches this point, and that goroutine can write
 // permissionMode concurrently (syncConfigOptionModeLocked for Copilot/Goose/Cursor).
 // This mirrors trySetStartupModel's locked read of b.model.
-func (b *acpBase) applyStartupPermissionMode(requested string) error {
+func (b *acpBase) applyStartupPermissionMode(requested string, defaulted bool) error {
 	if requested == "" {
 		return nil
 	}
 	b.mu.Lock()
 	current := b.permissionMode
+	available := b.availableModes
 	b.mu.Unlock()
 	if requested == current {
+		return nil
+	}
+	if defaulted && len(available) > 0 && !hasACPOption(available, requested) {
+		slog.Warn("this session does not offer the safe default permission mode; keeping the mode it reported",
+			"provider", b.providerName, "agent_id", b.agentID,
+			"requested", requested, "current", current)
 		return nil
 	}
 	return b.setSecondary(requested)
@@ -2643,9 +2680,7 @@ func (b *acpBase) applyStartupPermissionMode(requested string) error {
 // Used by ACP providers that track a permission mode (Copilot, Goose, Cursor).
 func (b *acpBase) applyHandshakeMode(handshake *acpSessionResult, defaultMode string) {
 	modes := buildACPModes(handshake.Modes, handshake.CurrentModeID, nil)
-	if b.orderPermissionModes != nil {
-		b.orderPermissionModes(modes)
-	}
+	orderModesPreferredFirst(modes, b.preferredFirstMode)
 	mode := handshake.CurrentModeID
 	if mode == "" {
 		mode = defaultMode
@@ -2688,7 +2723,8 @@ func (b *acpBase) applySecondaryStartup(handshake *acpSessionResult, opts Option
 func (b *acpBase) applyPermissionModeStartup(handshake *acpSessionResult, opts Options, defaultMode, requestedModel string) error {
 	return b.applySecondaryStartup(handshake, opts, requestedModel, func() error {
 		b.applyHandshakeMode(handshake, defaultMode)
-		return b.applyStartupPermissionMode(opts.PermissionMode())
+		return b.applyStartupPermissionMode(
+			opts.PermissionMode(), opts.NewSessionDefaultOptionIDs[OptionIDPermissionMode])
 	})
 }
 
@@ -2882,14 +2918,15 @@ func buildConfigOptionSelect(options []acpConfigOption, hiddenFilter func(string
 // mode or the primary agent) from the `mode` select of a configOptions payload. It
 // writes the available-option list and the current value into the caller-supplied
 // fields, and reports the new value, whether the current value changed, and whether
-// the available list changed. orderOptions applies a provider order before comparison.
-// The caller must hold b.mu. Shared by
+// the available list changed. preferredFirst, when non-empty, lists that option id
+// first before the comparison, so the rebuilt list matches what the handshake path
+// produced and an unchanged catalog compares equal. The caller must hold b.mu. Shared by
 // syncConfigOptionModeLocked and syncConfigOptionPrimaryAgentLocked, which differ
-// only in the hidden filter and the two target fields.
+// only in the hidden filter, the preferred first option, and the two target fields.
 func (b *acpBase) syncConfigOptionSelectLocked(
 	options []acpConfigOption,
 	hiddenFilter func(string) bool,
-	orderOptions func([]*leapmuxv1.AvailableOption),
+	preferredFirst string,
 	available *[]*leapmuxv1.AvailableOption,
 	currentField *string,
 ) (value string, changed, listChanged bool) {
@@ -2897,9 +2934,7 @@ func (b *acpBase) syncConfigOptionSelectLocked(
 	if !ok {
 		return "", false, false
 	}
-	if orderOptions != nil {
-		orderOptions(built)
-	}
+	orderModesPreferredFirst(built, preferredFirst)
 	// The len>0 guard mirrors the model channel (applyConfigOptionModelsLocked): an
 	// update that rebuilds to an empty list never blanks a populated picker.
 	if len(built) > 0 && !protoSliceEqual(*available, built) {
@@ -2929,7 +2964,7 @@ func (b *acpBase) syncConfigOptionSelectLocked(
 // b.mu. Used by ACP providers whose configOptions `mode` maps to the permission
 // mode (Copilot, Goose, Cursor).
 func (b *acpBase) syncConfigOptionModeLocked(options []acpConfigOption) (string, bool, bool) {
-	return b.syncConfigOptionSelectLocked(options, nil, b.orderPermissionModes, &b.availableModes, &b.permissionMode)
+	return b.syncConfigOptionSelectLocked(options, nil, b.preferredFirstMode, &b.availableModes, &b.permissionMode)
 }
 
 // syncConfigOptionPrimaryAgentLocked refreshes currentPrimaryAgent and
@@ -2940,7 +2975,7 @@ func (b *acpBase) syncConfigOptionModeLocked(options []acpConfigOption) (string,
 // primary-agent switch is reflected -- the mirror of syncConfigOptionModeLocked for
 // the permission-mode providers.
 func (b *acpBase) syncConfigOptionPrimaryAgentLocked(options []acpConfigOption) (string, bool, bool) {
-	return b.syncConfigOptionSelectLocked(options, b.primaryAgentHiddenFilter, nil, &b.availablePrimaryAgents, &b.currentPrimaryAgent)
+	return b.syncConfigOptionSelectLocked(options, b.primaryAgentHiddenFilter, "", &b.availablePrimaryAgents, &b.currentPrimaryAgent)
 }
 
 // acpRefreshMap builds the PersistSettingsRefresh delta for the ACP providers. model and mode
@@ -2997,6 +3032,29 @@ func buildACPModes(modes []acpModeInfo, currentModeID string, filter func(id str
 		})
 	}
 	return result
+}
+
+// orderModesPreferredFirst moves the option whose id is `preferred` to the front of
+// options, and keeps every other option in the order the server reported. An empty
+// `preferred`, an absent id, or an empty list leaves the slice untouched.
+//
+// A provider declares the id once (acpBase.preferredFirstMode) and every site that
+// rebuilds its list calls this, so the handshake list, the live config-option list and
+// the static fallback list cannot disagree about which mode comes first. That matters
+// beyond the drawing order: secondaryGroup reads position 0 for the group's
+// DefaultValue, and reconcileCurrentOptionID re-seeds the current selection from it.
+//
+// sort.SliceStable rather than a shift, matching sortEffortsDescending: the predicate
+// is a strict weak ordering with two classes (the preferred id, and everything else),
+// so a server that reports the preferred id TWICE leaves both copies at the front and
+// rotates nothing.
+func orderModesPreferredFirst(options []*leapmuxv1.AvailableOption, preferred string) {
+	if preferred == "" {
+		return
+	}
+	sort.SliceStable(options, func(i, j int) bool {
+		return options[i].GetId() == preferred && options[j].GetId() != preferred
+	})
 }
 
 func parseACPConfigOptions(raw json.RawMessage) []acpConfigOption {

--- a/backend/internal/worker/agent/acp_common.go
+++ b/backend/internal/worker/agent/acp_common.go
@@ -159,6 +159,9 @@ type acpBase struct {
 	// the old syncsPermissionMode/syncsPrimaryAgent bool pair so the illegal "both set"
 	// state is unrepresentable and every family-conditional site reads one field.
 	modeChannel acpModeChannel
+	// orderPermissionModes applies a provider order to each rebuilt permission list.
+	// Goose uses it to put Smart Approve first. Other providers leave it nil.
+	orderPermissionModes func([]*leapmuxv1.AvailableOption)
 	// secondaryChannelOnce/secondaryChannelCache memoize the resolved secondary channel.
 	// modeChannel is fixed at construction (configure) and the channel's field/list POINTERS
 	// and closures all capture b (stable), so the resolution is invariant for the agent's
@@ -633,6 +636,9 @@ func (b *acpBase) buildSecondaryChannel() acpSecondaryChannel {
 		sc.available = &b.availableModes
 		sc.rebuild = func(modes []acpModeInfo, reported string) {
 			if rebuilt := buildACPModes(modes, reported, nil); len(rebuilt) > 0 {
+				if b.orderPermissionModes != nil {
+					b.orderPermissionModes(rebuilt)
+				}
 				b.availableModes = rebuilt
 			}
 		}
@@ -2083,6 +2089,7 @@ type acpStartSpec[T any] struct {
 	providerName   string                                     // process/log name, e.g. "cursor"
 	binaryName     string                                     // CLI binary to launch
 	baseArgs       []string                                   // args after the binary, e.g. {"acp"}
+	baseArgsFor    func(Options) []string                     // option-dependent args; overrides baseArgs when set
 	rcMarkerEnvKey string                                     // provider rc marker stripped + re-added on a login shell (e.g. "KILO_CLIENT"); "" if none
 	sessionConfig  acpSessionConfig                           // zero value -> acpDefaultSessionConfig
 	newAgent       func() *T                                  // construct a zero-value concrete agent
@@ -2104,11 +2111,15 @@ func acpStart[T any](ctx context.Context, opts Options, sink OutputSink, spec ac
 		cancel()
 		return nil, err
 	}
+	baseArgs := spec.baseArgs
+	if spec.baseArgsFor != nil {
+		baseArgs = spec.baseArgsFor(opts)
+	}
 	wrap := shellWrapSpec{
 		Shell:      opts.Shell,
 		LoginShell: opts.LoginShell,
 		Launch:     launch,
-		BaseArgs:   spec.baseArgs,
+		BaseArgs:   baseArgs,
 		WorkingDir: opts.WorkingDir,
 	}
 	if spec.rcMarkerEnvKey != "" {
@@ -2632,6 +2643,9 @@ func (b *acpBase) applyStartupPermissionMode(requested string) error {
 // Used by ACP providers that track a permission mode (Copilot, Goose, Cursor).
 func (b *acpBase) applyHandshakeMode(handshake *acpSessionResult, defaultMode string) {
 	modes := buildACPModes(handshake.Modes, handshake.CurrentModeID, nil)
+	if b.orderPermissionModes != nil {
+		b.orderPermissionModes(modes)
+	}
 	mode := handshake.CurrentModeID
 	if mode == "" {
 		mode = defaultMode
@@ -2868,18 +2882,23 @@ func buildConfigOptionSelect(options []acpConfigOption, hiddenFilter func(string
 // mode or the primary agent) from the `mode` select of a configOptions payload. It
 // writes the available-option list and the current value into the caller-supplied
 // fields, and reports the new value, whether the current value changed, and whether
-// the available list changed. The caller must hold b.mu. Shared by
+// the available list changed. orderOptions applies a provider order before comparison.
+// The caller must hold b.mu. Shared by
 // syncConfigOptionModeLocked and syncConfigOptionPrimaryAgentLocked, which differ
 // only in the hidden filter and the two target fields.
 func (b *acpBase) syncConfigOptionSelectLocked(
 	options []acpConfigOption,
 	hiddenFilter func(string) bool,
+	orderOptions func([]*leapmuxv1.AvailableOption),
 	available *[]*leapmuxv1.AvailableOption,
 	currentField *string,
 ) (value string, changed, listChanged bool) {
 	built, current, ok := buildConfigOptionSelect(options, hiddenFilter)
 	if !ok {
 		return "", false, false
+	}
+	if orderOptions != nil {
+		orderOptions(built)
 	}
 	// The len>0 guard mirrors the model channel (applyConfigOptionModelsLocked): an
 	// update that rebuilds to an empty list never blanks a populated picker.
@@ -2910,7 +2929,7 @@ func (b *acpBase) syncConfigOptionSelectLocked(
 // b.mu. Used by ACP providers whose configOptions `mode` maps to the permission
 // mode (Copilot, Goose, Cursor).
 func (b *acpBase) syncConfigOptionModeLocked(options []acpConfigOption) (string, bool, bool) {
-	return b.syncConfigOptionSelectLocked(options, nil, &b.availableModes, &b.permissionMode)
+	return b.syncConfigOptionSelectLocked(options, nil, b.orderPermissionModes, &b.availableModes, &b.permissionMode)
 }
 
 // syncConfigOptionPrimaryAgentLocked refreshes currentPrimaryAgent and
@@ -2921,7 +2940,7 @@ func (b *acpBase) syncConfigOptionModeLocked(options []acpConfigOption) (string,
 // primary-agent switch is reflected -- the mirror of syncConfigOptionModeLocked for
 // the permission-mode providers.
 func (b *acpBase) syncConfigOptionPrimaryAgentLocked(options []acpConfigOption) (string, bool, bool) {
-	return b.syncConfigOptionSelectLocked(options, b.primaryAgentHiddenFilter, &b.availablePrimaryAgents, &b.currentPrimaryAgent)
+	return b.syncConfigOptionSelectLocked(options, b.primaryAgentHiddenFilter, nil, &b.availablePrimaryAgents, &b.currentPrimaryAgent)
 }
 
 // acpRefreshMap builds the PersistSettingsRefresh delta for the ACP providers. model and mode

--- a/backend/internal/worker/agent/acp_refresh_test.go
+++ b/backend/internal/worker/agent/acp_refresh_test.go
@@ -135,7 +135,7 @@ func TestCopilotClearContextKeepsNonHighEffortOverModelRaise(t *testing.T) {
 
 	agent, requests := newACPAgentForRPCWithRequestResponder(t,
 		func() *CopilotCLIAgent {
-			a := &CopilotCLIAgent{}
+			a := newCopilotCLIAgent("", false)
 			a.modeChannel = modeChannelPermissionMode
 			return a
 		},

--- a/backend/internal/worker/agent/claude.go
+++ b/backend/internal/worker/agent/claude.go
@@ -858,7 +858,10 @@ func claudeModelSubGroups(m *ModelInfo) []*leapmuxv1.AvailableOptionGroup {
 // "auto" when the startup probe rejected it (so the UI can't offer a mode this
 // Claude Code instance can't enter).
 func livePermissionModeGroup(static *leapmuxv1.AvailableOptionGroup, current string, autoAvail bool) *leapmuxv1.AvailableOptionGroup {
-	if static != nil && !autoAvail {
+	if static != nil && autoAvail {
+		static = cloneOptionGroupTemplate(static)
+		static.DefaultValue = PermissionModeAuto
+	} else if static != nil {
 		// Hide "auto" when the startup probe rejected it: filter the template (never mutate
 		// the shared static group) so the UI can't offer a mode this Claude Code instance
 		// can't enter. liveGroup then overlays the live current value and supplies the
@@ -2411,4 +2414,7 @@ func init() {
 	setModelIDNormalizer(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, normalizeClaudeCodeModel)
 	// model + permissionMode (static group) + effort (built from the model catalog).
 	setAdditionalOptionIDs(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, OptionIDEffort)
+	setNewAgentOptionDefaults(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, map[string]string{
+		OptionIDPermissionMode: PermissionModeAuto,
+	})
 }

--- a/backend/internal/worker/agent/claude.go
+++ b/backend/internal/worker/agent/claude.go
@@ -15,21 +15,13 @@ import (
 	"sync"
 	"time"
 
+	"github.com/leapmux/leapmux/generated/contracts"
+
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/util/envutil"
 	"github.com/leapmux/leapmux/internal/util/optionids"
 	"github.com/leapmux/leapmux/internal/util/optionmap"
 	"github.com/leapmux/leapmux/util/validate"
-)
-
-// Claude Code permission mode values.
-const (
-	PermissionModeDefault           = "default"
-	PermissionModePlan              = "plan"
-	PermissionModeAcceptEdits       = "acceptEdits"
-	PermissionModeBypassPermissions = "bypassPermissions"
-	PermissionModeDontAsk           = "dontAsk"
-	PermissionModeAuto              = "auto"
 )
 
 // autoModeUnavailableErrorPrefix is the prefix of the error message Claude
@@ -368,7 +360,7 @@ func (a *ClaudeCodeAgent) runStartupHandshake(ctx context.Context, opts Options)
 	}
 
 	TraceStartupPhase(opts.AgentID, "before_permission_mode")
-	resp, err := a.applyStartupPermissionMode(ctx, StringOrDefault(opts.PermissionMode(), PermissionModeDefault), timeout)
+	resp, err := a.applyStartupPermissionMode(ctx, StringOrDefault(opts.PermissionMode(), contracts.ClaudeModeDefault), timeout)
 	if err != nil {
 		return a.formatStartupError("set_permission_mode", err)
 	}
@@ -856,12 +848,15 @@ func claudeModelSubGroups(m *ModelInfo) []*leapmuxv1.AvailableOptionGroup {
 // livePermissionModeGroup builds a writable permission-mode group from the
 // provider's static template, setting the confirmed current value and hiding
 // "auto" when the startup probe rejected it (so the UI can't offer a mode this
-// Claude Code instance can't enter).
+// Claude Code instance can't enter). The group's DefaultValue always comes from the
+// template -- see the comment on the branch below.
 func livePermissionModeGroup(static *leapmuxv1.AvailableOptionGroup, current string, autoAvail bool) *leapmuxv1.AvailableOptionGroup {
-	if static != nil && autoAvail {
-		static = cloneOptionGroupTemplate(static)
-		static.DefaultValue = PermissionModeAuto
-	} else if static != nil {
+	// DefaultValue stays the TEMPLATE's default and is never rewritten to the
+	// new-session mode. The catalog is served to resumed sessions too, which never
+	// receive that mode, and setNewAgentOptionDefaults already declares it in one
+	// place; a second, probe-conditional source would make default_value mean
+	// "the provider default" here and "what a fresh session requests" there.
+	if static != nil && !autoAvail {
 		// Hide "auto" when the startup probe rejected it: filter the template (never mutate
 		// the shared static group) so the UI can't offer a mode this Claude Code instance
 		// can't enter. liveGroup then overlays the live current value and supplies the
@@ -875,7 +870,7 @@ func livePermissionModeGroup(static *leapmuxv1.AvailableOptionGroup, current str
 		// the current value selectable guarantees the "current is always an option" invariant
 		// regardless of how autoAvail drifts, mirroring buildOptionGroup's injection for ACP.
 		static = filterGroupOptions(static, func(o *leapmuxv1.AvailableOption) bool {
-			return o.GetId() != PermissionModeAuto || o.GetId() == current
+			return o.GetId() != contracts.ClaudeModeAuto || o.GetId() == current
 		})
 	}
 	return liveGroup(static, current)
@@ -1227,7 +1222,7 @@ func (a *ClaudeCodeAgent) applyPermissionModeLive(mode string) (applied, confirm
 		// this, OptionGroups would keep filtering "auto" out of the picker even though the session
 		// is running it. (livePermissionModeGroup still keeps the current value selectable as a
 		// backstop, but updating the flag makes the catalog state accurate, not just self-correcting.)
-		if resp.Mode == PermissionModeAuto {
+		if resp.Mode == contracts.ClaudeModeAuto {
 			a.autoModeAvailable = true
 		}
 		a.mu.Unlock()
@@ -1952,23 +1947,32 @@ func (a *ClaudeCodeAgent) sendApplyFlagSettings(ctx context.Context, flagSetting
 // intended state. Transient probe errors are treated as unavailable so the
 // UI does not offer a mode the agent cannot enter.
 func (a *ClaudeCodeAgent) applyStartupPermissionMode(ctx context.Context, requested string, timeout time.Duration) (claudeCodeControlResult, error) {
-	if requested == PermissionModeAuto {
-		resp, err := a.sendSetPermissionMode(ctx, PermissionModeAuto, timeout)
-		switch {
-		case err == nil:
+	if requested == contracts.ClaudeModeAuto {
+		resp, err := a.sendSetPermissionMode(ctx, contracts.ClaudeModeAuto, timeout)
+		if err == nil {
 			a.setAutoModeAvailable(true)
 			return resp, nil
-		case isAutoModeUnavailableError(err):
+		}
+		// EVERY new session requests auto (setNewAgentOptionDefaults), so this branch
+		// decides whether a failure here costs the picker one entry or costs the user the
+		// whole tab. Fall back on ANY error, not only the CLI's own "cannot set permission
+		// mode to auto": a timeout, a transport error or a reworded refusal says just as
+		// little about whether the session can run in default. The probe branch below
+		// already treats a transient failure as unavailable for the same reason. A
+		// fallback that also fails still returns its error, so a genuinely broken session
+		// is still reported.
+		if isAutoModeUnavailableError(err) {
 			slog.Warn("requested auto permission mode is unavailable; falling back to default",
 				"agent_id", a.agentID)
-			a.setAutoModeAvailable(false)
-			return a.sendSetPermissionMode(ctx, PermissionModeDefault, timeout)
-		default:
-			return claudeCodeControlResult{}, err
+		} else {
+			slog.Warn("auto permission mode failed (transient); falling back to default",
+				"agent_id", a.agentID, "error", err)
 		}
+		a.setAutoModeAvailable(false)
+		return a.sendSetPermissionMode(ctx, contracts.ClaudeModeDefault, timeout)
 	}
 
-	if _, err := a.sendSetPermissionMode(ctx, PermissionModeAuto, timeout); err != nil {
+	if _, err := a.sendSetPermissionMode(ctx, contracts.ClaudeModeAuto, timeout); err != nil {
 		if !isAutoModeUnavailableError(err) {
 			slog.Warn("auto-mode probe failed (transient); treating as unavailable",
 				"agent_id", a.agentID, "error", err)
@@ -2367,37 +2371,37 @@ func init() {
 		[]*leapmuxv1.AvailableOptionGroup{{
 			Id:           OptionIDPermissionMode,
 			Label:        "Permission Mode",
-			DefaultValue: PermissionModeDefault,
+			DefaultValue: contracts.ClaudeModeDefault,
 			Mutable:      true,
 			Order:        OptionOrderPermissionMode,
 			Options: []*leapmuxv1.AvailableOption{
 				{
-					Id:          PermissionModeDefault,
+					Id:          contracts.ClaudeModeDefault,
 					Name:        "Default",
 					Description: "Standard behavior, prompts for dangerous operations.",
 				},
 				{
-					Id:          PermissionModePlan,
+					Id:          contracts.ClaudeModePlan,
 					Name:        "Plan Mode",
 					Description: "Planning mode, no actual tool execution.",
 				},
 				{
-					Id:          PermissionModeAcceptEdits,
+					Id:          contracts.ClaudeModeAcceptEdits,
 					Name:        "Accept Edits",
 					Description: "Auto-accept file edit operations.",
 				},
 				{
-					Id:          PermissionModeBypassPermissions,
+					Id:          contracts.ClaudeModeBypassPermissions,
 					Name:        "Bypass Permissions",
 					Description: "Bypass all permission checks (requires allowDangerouslySkipPermissions).",
 				},
 				{
-					Id:          PermissionModeDontAsk,
+					Id:          contracts.ClaudeModeDontAsk,
 					Name:        "Don't Ask",
 					Description: "Don't prompt for permissions, deny if not pre-approved.",
 				},
 				{
-					Id:          PermissionModeAuto,
+					Id:          contracts.ClaudeModeAuto,
 					Name:        "Auto Mode",
 					Description: "Uses an AI classifier to auto-approve safe tool calls and falls back to prompting for risky ones.",
 				},
@@ -2414,7 +2418,11 @@ func init() {
 	setModelIDNormalizer(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, normalizeClaudeCodeModel)
 	// model + permissionMode (static group) + effort (built from the model catalog).
 	setAdditionalOptionIDs(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, OptionIDEffort)
-	setNewAgentOptionDefaults(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, map[string]string{
-		OptionIDPermissionMode: PermissionModeAuto,
+	setPermissionDefaults(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, PermissionDefaults{
+		// A new session asks for Auto Mode; a CLI that cannot enter it degrades to
+		// Default at startup, which is also where a resumed session with no stored mode
+		// lands.
+		NewSession: map[string]string{OptionIDPermissionMode: contracts.ClaudeModeAuto},
+		Fallback:   contracts.ClaudeModeDefault,
 	})
 }

--- a/backend/internal/worker/agent/claude_catalog_test.go
+++ b/backend/internal/worker/agent/claude_catalog_test.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/leapmux/leapmux/generated/contracts"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -33,12 +35,12 @@ func TestClaudeCodePermissionModeOptions_AllDescriptionsPopulated(t *testing.T) 
 	require.NotNil(t, permGroup, "permission-mode option group not found")
 
 	wantIDs := []string{
-		PermissionModeDefault,
-		PermissionModePlan,
-		PermissionModeAcceptEdits,
-		PermissionModeBypassPermissions,
-		PermissionModeDontAsk,
-		PermissionModeAuto,
+		contracts.ClaudeModeDefault,
+		contracts.ClaudeModePlan,
+		contracts.ClaudeModeAcceptEdits,
+		contracts.ClaudeModeBypassPermissions,
+		contracts.ClaudeModeDontAsk,
+		contracts.ClaudeModeAuto,
 	}
 	options := permGroup.GetOptions()
 	require.Len(t, options, len(wantIDs), "expected 6 permission modes")
@@ -60,37 +62,37 @@ func TestClaudeCodePermissionModeOptions_AllDescriptionsPopulated(t *testing.T) 
 func TestFilterPermissionModeGroup_AutoAvailable(t *testing.T) {
 	staticGroup := AvailableOptionGroupsForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)[0]
 
-	got := livePermissionModeGroup(staticGroup, PermissionModePlan, true)
+	got := livePermissionModeGroup(staticGroup, contracts.ClaudeModePlan, true)
 
 	// When auto is available, the options list is shared (unfiltered) and the
 	// current value is overlaid onto a fresh live group.
 	assert.Len(t, got.GetOptions(), 6)
-	assert.Equal(t, PermissionModePlan, got.GetCurrentValue())
-	assert.Equal(t, PermissionModeAuto, got.GetDefaultValue())
+	assert.Equal(t, contracts.ClaudeModePlan, got.GetCurrentValue())
+	assert.Equal(t, contracts.ClaudeModeDefault, got.GetDefaultValue())
 }
 
 func TestFilterPermissionModeGroup_AutoUnavailable(t *testing.T) {
 	staticGroup := AvailableOptionGroupsForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)[0]
 
-	got := livePermissionModeGroup(staticGroup, PermissionModeDefault, false)
+	got := livePermissionModeGroup(staticGroup, contracts.ClaudeModeDefault, false)
 
 	require.NotSame(t, staticGroup, got, "filtered result must be a fresh copy")
 	assert.Equal(t, staticGroup.GetId(), got.GetId())
 	assert.Equal(t, staticGroup.GetLabel(), got.GetLabel())
-	assert.Equal(t, PermissionModeDefault, got.GetDefaultValue())
+	assert.Equal(t, contracts.ClaudeModeDefault, got.GetDefaultValue())
 
 	ids := make([]string, 0, len(got.GetOptions()))
 	for _, o := range got.GetOptions() {
 		ids = append(ids, o.GetId())
 		assert.NotEmptyf(t, o.GetDescription(), "mode %q: Description must be preserved after filtering", o.GetId())
 	}
-	assert.NotContains(t, ids, PermissionModeAuto, "auto must be filtered out")
+	assert.NotContains(t, ids, contracts.ClaudeModeAuto, "auto must be filtered out")
 	assert.ElementsMatch(t, []string{
-		PermissionModeDefault,
-		PermissionModePlan,
-		PermissionModeAcceptEdits,
-		PermissionModeBypassPermissions,
-		PermissionModeDontAsk,
+		contracts.ClaudeModeDefault,
+		contracts.ClaudeModePlan,
+		contracts.ClaudeModeAcceptEdits,
+		contracts.ClaudeModeBypassPermissions,
+		contracts.ClaudeModeDontAsk,
 	}, ids, "remaining modes should include dontAsk and all non-auto modes")
 }
 
@@ -102,33 +104,41 @@ func TestFilterPermissionModeGroup_AutoUnavailable(t *testing.T) {
 func TestLivePermissionModeGroup_KeepsCurrentAutoWhenUnavailable(t *testing.T) {
 	staticGroup := AvailableOptionGroupsForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)[0]
 
-	got := livePermissionModeGroup(staticGroup, PermissionModeAuto, false)
+	got := livePermissionModeGroup(staticGroup, contracts.ClaudeModeAuto, false)
 
-	assert.Equal(t, PermissionModeAuto, got.GetCurrentValue())
+	assert.Equal(t, contracts.ClaudeModeAuto, got.GetCurrentValue())
 	ids := make([]string, 0, len(got.GetOptions()))
 	for _, o := range got.GetOptions() {
 		ids = append(ids, o.GetId())
 	}
-	assert.Contains(t, ids, PermissionModeAuto,
+	assert.Contains(t, ids, contracts.ClaudeModeAuto,
 		"the current value must stay selectable even when autoModeAvailable is false")
 
 	// The filter still hides auto when it is NOT the current value (the ordinary unavailable case).
-	hidden := livePermissionModeGroup(staticGroup, PermissionModePlan, false)
+	hidden := livePermissionModeGroup(staticGroup, contracts.ClaudeModePlan, false)
 	hiddenIDs := make([]string, 0, len(hidden.GetOptions()))
 	for _, o := range hidden.GetOptions() {
 		hiddenIDs = append(hiddenIDs, o.GetId())
 	}
-	assert.NotContains(t, hiddenIDs, PermissionModeAuto,
+	assert.NotContains(t, hiddenIDs, contracts.ClaudeModeAuto,
 		"auto is still hidden when it is unavailable and not the current value")
 }
 
 func TestLivePermissionModeGroup_EmptyCurrentFallsBackToDefault(t *testing.T) {
 	staticGroup := AvailableOptionGroupsForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)[0]
 
-	// An empty current uses Auto when the session offers Auto.
+	// An empty current must resolve to the template's default rather than rendering a
+	// blank selection (delegated to liveGroup's empty-current fallback). The default is
+	// the TEMPLATE's, on both branches: a session that cannot enter Auto Mode must not
+	// be shown Auto Mode as its default either.
 	got := livePermissionModeGroup(staticGroup, "", true)
-	assert.Equal(t, PermissionModeAuto, got.GetCurrentValue())
-	assert.Equal(t, PermissionModeAuto, got.GetDefaultValue())
+	assert.Equal(t, staticGroup.GetDefaultValue(), got.GetCurrentValue())
+	assert.Equal(t, contracts.ClaudeModeDefault, got.GetCurrentValue())
+	assert.Equal(t, contracts.ClaudeModeDefault, got.GetDefaultValue())
+
+	unavailable := livePermissionModeGroup(staticGroup, "", false)
+	assert.Equal(t, contracts.ClaudeModeDefault, unavailable.GetCurrentValue())
+	assert.Equal(t, contracts.ClaudeModeDefault, unavailable.GetDefaultValue())
 }
 
 func TestIsAutoModeUnavailableError(t *testing.T) {
@@ -166,7 +176,7 @@ func TestClaudeCodeAgent_AvailableOptionGroupsFiltersAutoWhenUnavailable(t *test
 	permGroup := optionids.GroupByID(groups, OptionIDPermissionMode)
 	require.NotNil(t, permGroup)
 	for _, o := range permGroup.GetOptions() {
-		assert.NotEqual(t, PermissionModeAuto, o.GetId(), "auto must not appear when autoModeAvailable is false")
+		assert.NotEqual(t, contracts.ClaudeModeAuto, o.GetId(), "auto must not appear when autoModeAvailable is false")
 	}
 
 	agent.autoModeAvailable = true
@@ -175,7 +185,7 @@ func TestClaudeCodeAgent_AvailableOptionGroupsFiltersAutoWhenUnavailable(t *test
 	require.NotNil(t, permGroup)
 	found := false
 	for _, o := range permGroup.GetOptions() {
-		if o.GetId() == PermissionModeAuto {
+		if o.GetId() == contracts.ClaudeModeAuto {
 			found = true
 			break
 		}

--- a/backend/internal/worker/agent/claude_catalog_test.go
+++ b/backend/internal/worker/agent/claude_catalog_test.go
@@ -66,6 +66,7 @@ func TestFilterPermissionModeGroup_AutoAvailable(t *testing.T) {
 	// current value is overlaid onto a fresh live group.
 	assert.Len(t, got.GetOptions(), 6)
 	assert.Equal(t, PermissionModePlan, got.GetCurrentValue())
+	assert.Equal(t, PermissionModeAuto, got.GetDefaultValue())
 }
 
 func TestFilterPermissionModeGroup_AutoUnavailable(t *testing.T) {
@@ -76,6 +77,7 @@ func TestFilterPermissionModeGroup_AutoUnavailable(t *testing.T) {
 	require.NotSame(t, staticGroup, got, "filtered result must be a fresh copy")
 	assert.Equal(t, staticGroup.GetId(), got.GetId())
 	assert.Equal(t, staticGroup.GetLabel(), got.GetLabel())
+	assert.Equal(t, PermissionModeDefault, got.GetDefaultValue())
 
 	ids := make([]string, 0, len(got.GetOptions()))
 	for _, o := range got.GetOptions() {
@@ -123,11 +125,10 @@ func TestLivePermissionModeGroup_KeepsCurrentAutoWhenUnavailable(t *testing.T) {
 func TestLivePermissionModeGroup_EmptyCurrentFallsBackToDefault(t *testing.T) {
 	staticGroup := AvailableOptionGroupsForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)[0]
 
-	// An empty current must resolve to the template's default rather than rendering a
-	// blank selection (delegated to liveGroup's empty-current fallback).
+	// An empty current uses Auto when the session offers Auto.
 	got := livePermissionModeGroup(staticGroup, "", true)
-	assert.Equal(t, staticGroup.GetDefaultValue(), got.GetCurrentValue())
-	assert.Equal(t, PermissionModeDefault, got.GetCurrentValue())
+	assert.Equal(t, PermissionModeAuto, got.GetCurrentValue())
+	assert.Equal(t, PermissionModeAuto, got.GetDefaultValue())
 }
 
 func TestIsAutoModeUnavailableError(t *testing.T) {

--- a/backend/internal/worker/agent/claude_livesettings_test.go
+++ b/backend/internal/worker/agent/claude_livesettings_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/leapmux/leapmux/generated/contracts"
+
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/util/optionids"
 	"github.com/stretchr/testify/assert"
@@ -358,7 +360,7 @@ func TestRefreshSettingsFromAgent_DoesNotReportPermissionMode(t *testing.T) {
 	require.NoError(t, err)
 	defer stopTestAgent(a)
 
-	a.confirmedPermissionMode = PermissionModeDefault
+	a.confirmedPermissionMode = contracts.ClaudeModeDefault
 	a.refreshSettingsFromAgent(5 * time.Second)
 
 	require.Equal(t, 1, sink.SettingsRefreshCount())
@@ -506,13 +508,13 @@ func TestUpdateSettings_PermissionModeChange(t *testing.T) {
 	a := newTestAgentWithControlProtocol(t)
 	defer stopTestAgent(a)
 
-	a.confirmedPermissionMode = PermissionModeDefault
+	a.confirmedPermissionMode = contracts.ClaudeModeDefault
 
 	result := a.UpdateSettings(map[string]string{
-		OptionIDPermissionMode: PermissionModePlan,
+		OptionIDPermissionMode: contracts.ClaudeModePlan,
 	})
 	assert.True(t, result.AppliedLive, "should return true for permission mode change")
-	assert.Equal(t, PermissionModePlan, a.confirmedPermissionMode)
+	assert.Equal(t, contracts.ClaudeModePlan, a.confirmedPermissionMode)
 }
 
 func TestUpdateSettings_ConfirmedPermissionSupersedesDeferredRequest(t *testing.T) {
@@ -520,10 +522,10 @@ func TestUpdateSettings_ConfirmedPermissionSupersedesDeferredRequest(t *testing.
 
 	a := newTestAgentWithControlProtocol(t)
 	defer stopTestAgent(a)
-	a.confirmedPermissionMode = PermissionModeDefault
+	a.confirmedPermissionMode = contracts.ClaudeModeDefault
 	a.deferredPermissionModeReqID = "older-request"
 
-	result := a.UpdateSettings(map[string]string{OptionIDPermissionMode: PermissionModePlan})
+	result := a.UpdateSettings(map[string]string{OptionIDPermissionMode: contracts.ClaudeModePlan})
 
 	require.True(t, result.AppliedLive)
 	assert.Empty(t, a.deferredPermissionModeReqID)
@@ -541,11 +543,11 @@ func TestUpdateSettings_AutoSwitchClearsStaleAutoModeAvailable(t *testing.T) {
 	defer stopTestAgent(a)
 
 	a.autoModeAvailable = false // a transient startup probe failure left this stale
-	a.confirmedPermissionMode = PermissionModeDefault
+	a.confirmedPermissionMode = contracts.ClaudeModeDefault
 
-	result := a.UpdateSettings(map[string]string{OptionIDPermissionMode: PermissionModeAuto})
+	result := a.UpdateSettings(map[string]string{OptionIDPermissionMode: contracts.ClaudeModeAuto})
 	require.True(t, result.AppliedLive, "a live permission-mode switch should not request a restart")
-	assert.Equal(t, PermissionModeAuto, a.confirmedPermissionMode)
+	assert.Equal(t, contracts.ClaudeModeAuto, a.confirmedPermissionMode)
 	assert.True(t, a.autoModeAvailable,
 		"a successful live switch to auto clears the stale autoModeAvailable=false so the picker offers auto again")
 }
@@ -566,7 +568,7 @@ func newTestAgentWithDeferredPermissionMode(t *testing.T) *ClaudeCodeAgent {
 		},
 		noopSink{})
 	require.NoError(t, err)
-	a.confirmedPermissionMode = PermissionModeDefault
+	a.confirmedPermissionMode = contracts.ClaudeModeDefault
 	return a
 }
 
@@ -582,11 +584,11 @@ func TestUpdateSettings_PermissionModeDeferredAck(t *testing.T) {
 	a := newTestAgentWithDeferredPermissionMode(t)
 	defer stopTestAgent(a)
 
-	result := a.UpdateSettings(map[string]string{OptionIDPermissionMode: PermissionModePlan})
+	result := a.UpdateSettings(map[string]string{OptionIDPermissionMode: contracts.ClaudeModePlan})
 	assert.True(t, result.AppliedLive, "a deferred set_permission_mode ack must not request a restart")
 	assert.Equal(t, OptionSettlementUnresolved, result.Settlements[OptionIDPermissionMode].State,
 		"a deferred acknowledgement must not claim that the provider confirmed the mode")
-	assert.Equal(t, PermissionModePlan, a.confirmedPermissionMode,
+	assert.Equal(t, contracts.ClaudeModePlan, a.confirmedPermissionMode,
 		"the requested mode is recorded optimistically while the ack is pending")
 }
 
@@ -602,16 +604,16 @@ func TestClaudeHandleControlResponse_DeferredModeReconcilesInMemory(t *testing.T
 	sink := &testSink{}
 	a := &ClaudeCodeAgent{sink: sink}
 	// The live path recorded "plan" optimistically and remembered the deferred toggle's id.
-	a.confirmedPermissionMode = PermissionModePlan
+	a.confirmedPermissionMode = contracts.ClaudeModePlan
 	a.deferredPermissionModeReqID = "req-1"
 
 	// The deferred control_response for THAT request: the CLI actually settled on acceptEdits.
 	a.claudeCodeHandleControlResponse([]byte(
 		`{"type":"control_response","response":{"subtype":"success","request_id":"req-1","response":{"mode":"acceptEdits"}}}`))
 
-	assert.Equal(t, PermissionModeAcceptEdits, a.confirmedPermissionMode,
+	assert.Equal(t, contracts.ClaudeModeAcceptEdits, a.confirmedPermissionMode,
 		"the in-memory confirmed mode is reconciled to the CLI's applied mode")
-	require.Equal(t, []string{PermissionModeAcceptEdits}, sink.permissionModes,
+	require.Equal(t, []string{contracts.ClaudeModeAcceptEdits}, sink.permissionModes,
 		"the persisted row + broadcast are reconciled to the applied mode too")
 	assert.Empty(t, a.deferredPermissionModeReqID, "the consumed deferred id is cleared")
 }
@@ -625,14 +627,14 @@ func TestClaudeHandleControlResponse_IgnoresUncorrelatedMode(t *testing.T) {
 
 	sink := &testSink{}
 	a := &ClaudeCodeAgent{sink: sink}
-	a.confirmedPermissionMode = PermissionModePlan
+	a.confirmedPermissionMode = contracts.ClaudeModePlan
 	a.deferredPermissionModeReqID = "req-current"
 
 	// A stale ack for a different (already-superseded) request.
 	a.claudeCodeHandleControlResponse([]byte(
 		`{"type":"control_response","response":{"subtype":"success","request_id":"req-stale","response":{"mode":"default"}}}`))
 
-	assert.Equal(t, PermissionModePlan, a.confirmedPermissionMode,
+	assert.Equal(t, contracts.ClaudeModePlan, a.confirmedPermissionMode,
 		"an uncorrelated ack must not clobber the confirmed mode")
 	assert.Empty(t, sink.permissionModes, "no broadcast for an uncorrelated ack")
 	assert.Equal(t, "req-current", a.deferredPermissionModeReqID,
@@ -649,13 +651,13 @@ func TestClaudeHandleControlResponse_DeferredAutoClearsStaleAutoModeAvailable(t 
 	sink := &testSink{}
 	a := &ClaudeCodeAgent{sink: sink}
 	a.autoModeAvailable = false // a transient startup probe failure left this stale
-	a.confirmedPermissionMode = PermissionModeAuto
+	a.confirmedPermissionMode = contracts.ClaudeModeAuto
 	a.deferredPermissionModeReqID = "req-auto"
 
 	a.claudeCodeHandleControlResponse([]byte(
 		`{"type":"control_response","response":{"subtype":"success","request_id":"req-auto","response":{"mode":"auto"}}}`))
 
-	assert.Equal(t, PermissionModeAuto, a.confirmedPermissionMode)
+	assert.Equal(t, contracts.ClaudeModeAuto, a.confirmedPermissionMode)
 	assert.True(t, a.autoModeAvailable,
 		"a deferred ack confirming auto clears the stale autoModeAvailable=false")
 	assert.Empty(t, a.deferredPermissionModeReqID, "the consumed deferred id is cleared")
@@ -679,11 +681,11 @@ func TestUpdateSettings_PermissionModeGenuineError(t *testing.T) {
 		noopSink{})
 	require.NoError(t, err)
 	defer stopTestAgent(a)
-	a.confirmedPermissionMode = PermissionModeDefault
+	a.confirmedPermissionMode = contracts.ClaudeModeDefault
 
-	result := a.UpdateSettings(map[string]string{OptionIDPermissionMode: PermissionModePlan})
+	result := a.UpdateSettings(map[string]string{OptionIDPermissionMode: contracts.ClaudeModePlan})
 	assert.False(t, result.AppliedLive, "a genuine set_permission_mode error must request a restart")
-	assert.Equal(t, PermissionModeDefault, a.confirmedPermissionMode,
+	assert.Equal(t, contracts.ClaudeModeDefault, a.confirmedPermissionMode,
 		"the confirmed mode is unchanged when the change was rejected")
 }
 
@@ -709,18 +711,18 @@ func TestUpdateSettings_CombinedChangePermissionFailureDefersBroadcast(t *testin
 	require.NoError(t, err)
 	defer stopTestAgent(a)
 	a.model = "opus[1m]"
-	a.confirmedPermissionMode = PermissionModeDefault
+	a.confirmedPermissionMode = contracts.ClaudeModeDefault
 
 	result := a.UpdateSettings(map[string]string{
 		OptionIDModel:          "sonnet",
-		OptionIDPermissionMode: PermissionModePlan,
+		OptionIDPermissionMode: contracts.ClaudeModePlan,
 	})
 	assert.False(t, result.AppliedLive, "a combined change whose permission-mode apply fails must request a restart")
 	assert.Equal(t, 0, sink.SettingsRefreshCount(),
 		"the half-applied model must NOT be read back/broadcast when a later axis fails")
 	assert.Equal(t, "opus[1m]", a.model,
 		"a.model stays at its pre-change value (the refresh is deferred) until the restart applies it")
-	assert.Equal(t, PermissionModeDefault, a.confirmedPermissionMode,
+	assert.Equal(t, contracts.ClaudeModeDefault, a.confirmedPermissionMode,
 		"the rejected permission mode is unchanged")
 }
 
@@ -1080,7 +1082,7 @@ func TestHelperProcessWithControlProtocol(t *testing.T) {
 	state := map[string]interface{}{
 		"model":                 "opus[1m]",
 		"effort":                "high",
-		"mode":                  PermissionModeDefault,
+		"mode":                  contracts.ClaudeModeDefault,
 		"outputStyle":           "default",
 		"fastMode":              nil,
 		"alwaysThinkingEnabled": nil,
@@ -1133,7 +1135,7 @@ func TestHelperProcessWithControlProtocol(t *testing.T) {
 			}
 			mode := msg.Request.Mode
 			if mode == "" {
-				mode = PermissionModeDefault
+				mode = contracts.ClaudeModeDefault
 			}
 			state["mode"] = mode
 			responseBody = map[string]interface{}{"mode": mode}

--- a/backend/internal/worker/agent/claude_output.go
+++ b/backend/internal/worker/agent/claude_output.go
@@ -333,9 +333,9 @@ func (a *ClaudeCodeAgent) processAssistantBlocks(env *messageEnvelope) {
 
 			switch block.Name {
 			case ToolNameEnterPlanMode:
-				a.sink.StorePlanModeToolUse(block.ID, PermissionModePlan)
+				a.sink.StorePlanModeToolUse(block.ID, contracts.ClaudeModePlan)
 			case ToolNameExitPlanMode:
-				a.sink.StorePlanModeToolUse(block.ID, PermissionModeDefault)
+				a.sink.StorePlanModeToolUse(block.ID, contracts.ClaudeModeDefault)
 			}
 
 			// A subagent spawn opens no span (claudeToolSpawnsSubagent). Its
@@ -924,7 +924,7 @@ func (a *ClaudeCodeAgent) claudeCodeHandleControlResponse(content []byte) {
 		a.confirmedPermissionMode = mode
 		// The deferred ack confirming "auto" proves the session can enter it; clear a stale
 		// autoModeAvailable=false (see applyPermissionModeLive) so the picker offers auto again.
-		if mode == PermissionModeAuto {
+		if mode == contracts.ClaudeModeAuto {
 			a.autoModeAvailable = true
 		}
 	}
@@ -1236,9 +1236,9 @@ func (a *ClaudeCodeAgent) detectPlanModeFromToolResult(env *messageEnvelope) {
 
 		resultLower := strings.ToLower(resultText)
 		confirmed := false
-		if targetMode == PermissionModePlan && strings.Contains(resultLower, "entered plan mode") {
+		if targetMode == contracts.ClaudeModePlan && strings.Contains(resultLower, "entered plan mode") {
 			confirmed = true
-		} else if targetMode == PermissionModeDefault && strings.Contains(resultLower, "approved your plan") {
+		} else if targetMode == contracts.ClaudeModeDefault && strings.Contains(resultLower, "approved your plan") {
 			confirmed = true
 		}
 

--- a/backend/internal/worker/agent/claude_output_test.go
+++ b/backend/internal/worker/agent/claude_output_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/leapmux/leapmux/generated/contracts"
+
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/worker/bgtask"
 	"github.com/stretchr/testify/assert"
@@ -844,7 +846,7 @@ func TestHandleOutput_PlanModeEnterExit(t *testing.T) {
 
 	modes := sink.PermissionModes()
 	require.Len(t, modes, 1)
-	assert.Equal(t, PermissionModePlan, modes[0])
+	assert.Equal(t, contracts.ClaudeModePlan, modes[0])
 }
 
 func TestHandleOutput_PlanModeEnter_StringToolUseResult(t *testing.T) {
@@ -878,7 +880,7 @@ func TestHandleOutput_PlanModeEnter_StringToolUseResult(t *testing.T) {
 
 	modes := sink.PermissionModes()
 	require.Len(t, modes, 1)
-	assert.Equal(t, PermissionModePlan, modes[0])
+	assert.Equal(t, contracts.ClaudeModePlan, modes[0])
 }
 
 func TestHandleOutput_MultipleToolUses(t *testing.T) {

--- a/backend/internal/worker/agent/claude_test.go
+++ b/backend/internal/worker/agent/claude_test.go
@@ -14,6 +14,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/leapmux/leapmux/generated/contracts"
+
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/util/envutil"
 	"github.com/leapmux/leapmux/internal/util/testutil"
@@ -600,7 +602,7 @@ func TestAgent_StartTimeoutCleansUpProcess(t *testing.T) {
 		go a.readOutputLoop(scanner)
 
 		// Replicate the startup handshake from StartClaudeCode().
-		mode := StringOrDefault(opts.PermissionMode(), PermissionModeDefault)
+		mode := StringOrDefault(opts.PermissionMode(), contracts.ClaudeModeDefault)
 		requestID := generateRequestID()
 		ch := make(chan claudeCodeControlResult, 1)
 		a.registerPendingControl(requestID, ch)
@@ -989,55 +991,68 @@ func TestApplyStartupPermissionMode(t *testing.T) {
 			name:      "AutoAccepted",
 			agentID:   "handshake-auto-ok",
 			script:    "success",
-			requested: PermissionModeAuto,
+			requested: contracts.ClaudeModeAuto,
 			wantAuto:  true,
-			wantMode:  PermissionModeAuto,
-			wantModes: []string{PermissionModeAuto},
+			wantMode:  contracts.ClaudeModeAuto,
+			wantModes: []string{contracts.ClaudeModeAuto},
 		},
 		{
 			name:      "AutoRejectedFallsBack",
 			agentID:   "handshake-auto-reject",
 			script:    "error:Cannot set permission mode to auto: auto mode disabled by settings|success",
-			requested: PermissionModeAuto,
+			requested: contracts.ClaudeModeAuto,
 			wantAuto:  false,
-			wantMode:  PermissionModeDefault,
-			wantModes: []string{PermissionModeAuto, PermissionModeDefault},
+			wantMode:  contracts.ClaudeModeDefault,
+			wantModes: []string{contracts.ClaudeModeAuto, contracts.ClaudeModeDefault},
 		},
 		{
-			name:          "AutoTransientErrorPropagates",
-			agentID:       "handshake-auto-transient",
-			script:        "error:some unrelated runtime error",
-			requested:     PermissionModeAuto,
+			// EVERY new session requests auto, so a transient failure here must cost the
+			// picker one entry and not the whole tab -- the same rule NonAutoProbeTransient
+			// below already applies to the probe. A session that is genuinely broken still
+			// fails, because the fallback call's own error propagates (AutoAndFallbackFail).
+			name:      "AutoTransientErrorFallsBack",
+			agentID:   "handshake-auto-transient",
+			script:    "error:some unrelated runtime error|success",
+			requested: contracts.ClaudeModeAuto,
+			wantAuto:  false,
+			wantMode:  contracts.ClaudeModeDefault,
+			wantModes: []string{contracts.ClaudeModeAuto, contracts.ClaudeModeDefault},
+		},
+		{
+			name:          "AutoAndFallbackFail",
+			agentID:       "handshake-auto-both-fail",
+			script:        "error:some unrelated runtime error|error:transport is gone",
+			requested:     contracts.ClaudeModeAuto,
 			wantAuto:      false,
-			wantModes:     []string{PermissionModeAuto},
-			wantErrSubstr: "some unrelated runtime error",
+			wantModes:     []string{contracts.ClaudeModeAuto, contracts.ClaudeModeDefault},
+			wantErrSubstr: "transport is gone",
 		},
 		{
 			name:      "NonAutoProbesAutoAvailable",
 			agentID:   "handshake-probe-ok",
 			script:    "success|success",
-			requested: PermissionModeDefault,
+			requested: contracts.ClaudeModeDefault,
 			wantAuto:  true,
-			wantMode:  PermissionModeDefault,
-			wantModes: []string{PermissionModeAuto, PermissionModeDefault},
+			wantMode:  contracts.ClaudeModeDefault,
+			wantModes: []string{contracts.ClaudeModeAuto, contracts.ClaudeModeDefault},
 		},
 		{
 			name:      "NonAutoProbeRejected",
 			agentID:   "handshake-probe-reject",
 			script:    "error:Cannot set permission mode to auto: auto mode disabled by settings|success",
-			requested: PermissionModePlan,
+			requested: contracts.ClaudeModePlan,
 			wantAuto:  false,
-			wantMode:  PermissionModePlan,
-			wantModes: []string{PermissionModeAuto, PermissionModePlan},
+			wantMode:  contracts.ClaudeModePlan,
+			wantModes: []string{contracts.ClaudeModeAuto, contracts.ClaudeModePlan},
 		},
 		{
 			name:      "NonAutoProbeTransient",
 			agentID:   "handshake-probe-transient",
 			script:    "error:some unrelated runtime error|success",
-			requested: PermissionModeDefault,
+			requested: contracts.ClaudeModeDefault,
 			wantAuto:  false,
-			wantMode:  PermissionModeDefault,
-			wantModes: []string{PermissionModeAuto, PermissionModeDefault},
+			wantMode:  contracts.ClaudeModeDefault,
+			wantModes: []string{contracts.ClaudeModeAuto, contracts.ClaudeModeDefault},
 		},
 	}
 

--- a/backend/internal/worker/agent/codex.go
+++ b/backend/internal/worker/agent/codex.go
@@ -1376,6 +1376,10 @@ func init() {
 	// Seed the sandbox/network/collaboration/service-tier defaults into a fresh agent's
 	// launch options; resolveProviderDefaults applies these for every provider uniformly.
 	setProviderOptionDefaults(leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX, codexOptionDefaults())
+	// Codex has no new-session safe default: Suggest & Approve already asks.
+	setPermissionDefaults(leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX, PermissionDefaults{
+		Fallback: CodexDefaultApprovalPolicy,
+	})
 }
 
 // codexModelDisplayName generates a human-readable display name from a Codex

--- a/backend/internal/worker/agent/copilot.go
+++ b/backend/internal/worker/agent/copilot.go
@@ -108,6 +108,7 @@ func (a *CopilotCLIAgent) OptionGroups() []*leapmuxv1.AvailableOptionGroup {
 			template = filterGroupOptions(template, func(option *leapmuxv1.AvailableOption) bool {
 				return option.GetId() == contracts.CopilotPermissionValueOff
 			})
+			template.DefaultValue = contracts.CopilotPermissionValueOff
 			template.Mutable = false
 		}
 		filtered = append(filtered, liveGroup(template, a.assistedApprovalValue()))
@@ -172,8 +173,8 @@ func init() {
 			OptionOrderProviderFourth,
 			contracts.CopilotPermissionValueOff,
 			[]optDef{
-				{Id: contracts.CopilotPermissionValueOff, Name: "Off", Default: true},
-				{Id: contracts.CopilotPermissionValueOn, Name: "On", Description: "Approve safe tool calls and ask about other calls. This also enables all experimental Copilot features."},
+				{Id: contracts.CopilotPermissionValueOff, Name: "Off"},
+				{Id: contracts.CopilotPermissionValueOn, Name: "On", Description: "Approve safe tool calls and ask about other calls. This also enables all experimental Copilot features.", Default: true},
 			},
 		),
 	)

--- a/backend/internal/worker/agent/copilot.go
+++ b/backend/internal/worker/agent/copilot.go
@@ -2,8 +2,13 @@ package agent
 
 import (
 	"context"
+	"log/slog"
+	"strings"
 
+	"github.com/leapmux/leapmux/generated/contracts"
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/util/optionids"
+	"github.com/leapmux/leapmux/internal/util/optionmap"
 )
 
 const (
@@ -17,23 +22,58 @@ const (
 // them, matching the ids the live `session/set_config_option` channel reports.
 const (
 	CopilotConfigReasoningEffort = "reasoning_effort"
-	CopilotConfigAllowAll        = "allow_all"
+	CopilotConfigAllowAll        = contracts.CopilotPermissionGroupAllowAll
 )
 
 // CopilotCLIAgent manages a single Copilot CLI ACP process.
 type CopilotCLIAgent struct {
 	acpBase
+	assistedApproval            string
+	assistedApprovalUnavailable bool
+}
+
+const copilotAssistedApprovalUnavailableText = "--assisted-approval is only supported in non-interactive prompt mode"
+
+func copilotBaseArgs(opts Options) []string {
+	args := []string{"--acp", "--stdio"}
+	if opts.Get(contracts.CopilotPermissionGroupAssistedApproval) == contracts.CopilotPermissionValueOn {
+		args = append(args, "--experimental", "--assisted-approval")
+	}
+	return args
 }
 
 // StartCopilotCLI starts a Copilot CLI ACP agent process and performs the handshake.
 func StartCopilotCLI(ctx context.Context, opts Options, sink OutputSink) (Agent, error) {
+	started, err := startCopilotCLI(ctx, opts, sink, false)
+	if err == nil || !opts.NewSessionDefaultOptionIDs[contracts.CopilotPermissionGroupAssistedApproval] ||
+		!isCopilotAssistedApprovalUnavailable(err) {
+		return started, err
+	}
+
+	slog.Warn("Copilot Assisted Approval is unavailable for ACP; using Off for the new session",
+		"agent_id", opts.AgentID)
+	fallback := opts
+	fallback.Options = opts.Options.Clone()
+	fallback.Options[contracts.CopilotPermissionGroupAssistedApproval] = contracts.CopilotPermissionValueOff
+	return startCopilotCLI(ctx, fallback, sink, true)
+}
+
+func startCopilotCLI(ctx context.Context, opts Options, sink OutputSink, assistedApprovalUnavailable bool) (Agent, error) {
 	return acpStart(ctx, opts, sink, acpStartSpec[CopilotCLIAgent]{
 		provider:     leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT,
 		providerName: "copilot",
 		binaryName:   "copilot",
-		baseArgs:     []string{"--acp", "--stdio"},
-		newAgent:     func() *CopilotCLIAgent { return &CopilotCLIAgent{} },
-		base:         func(a *CopilotCLIAgent) *acpBase { return &a.acpBase },
+		baseArgsFor:  copilotBaseArgs,
+		newAgent: func() *CopilotCLIAgent {
+			return &CopilotCLIAgent{
+				assistedApprovalUnavailable: assistedApprovalUnavailable,
+				assistedApproval: StringOrDefault(
+					opts.Get(contracts.CopilotPermissionGroupAssistedApproval),
+					contracts.CopilotPermissionValueOff,
+				),
+			}
+		},
+		base: func(a *CopilotCLIAgent) *acpBase { return &a.acpBase },
 		configure: func(a *CopilotCLIAgent) {
 			a.modeChannel = modeChannelPermissionMode
 			// Copilot's reasoning-effort axis is the convention id "reasoning_effort", not the
@@ -44,6 +84,66 @@ func StartCopilotCLI(ctx context.Context, opts Options, sink OutputSink) (Agent,
 			return a.applyPermissionModeStartup(handshake, opts, CopilotCLIModeAgent, opts.Model())
 		},
 	})
+}
+
+func isCopilotAssistedApprovalUnavailable(err error) bool {
+	return err != nil && strings.Contains(err.Error(), copilotAssistedApprovalUnavailableText)
+}
+
+func (a *CopilotCLIAgent) OptionGroups() []*leapmuxv1.AvailableOptionGroup {
+	groups := a.acpBase.OptionGroups()
+	assistedID := contracts.CopilotPermissionGroupAssistedApproval
+	filtered := make([]*leapmuxv1.AvailableOptionGroup, 0, len(groups)+1)
+	for _, group := range groups {
+		if group.GetId() != assistedID {
+			filtered = append(filtered, group)
+		}
+	}
+	template := optionids.GroupByID(
+		AvailableOptionGroupsForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT),
+		assistedID,
+	)
+	if template != nil {
+		if a.assistedApprovalUnavailable {
+			template = filterGroupOptions(template, func(option *leapmuxv1.AvailableOption) bool {
+				return option.GetId() == contracts.CopilotPermissionValueOff
+			})
+			template.Mutable = false
+		}
+		filtered = append(filtered, liveGroup(template, a.assistedApprovalValue()))
+	}
+	return filtered
+}
+
+func (a *CopilotCLIAgent) assistedApprovalValue() string {
+	return StringOrDefault(a.assistedApproval, contracts.CopilotPermissionValueOff)
+}
+
+func (a *CopilotCLIAgent) addAssistedApproval(result SettingsApplyResult) SettingsApplyResult {
+	if result.SurfacedOptions == nil {
+		result.SurfacedOptions = optionmap.Map{}
+	}
+	if result.Settlements == nil {
+		result.Settlements = OptionSettlements{}
+	}
+	value := a.assistedApprovalValue()
+	result.SurfacedOptions[contracts.CopilotPermissionGroupAssistedApproval] = value
+	result.Settlements[contracts.CopilotPermissionGroupAssistedApproval] = OptionSettlement{
+		State: OptionSettlementConfirmed,
+		Value: &value,
+	}
+	return result
+}
+
+func (a *CopilotCLIAgent) SettingsSnapshot() SettingsApplyResult {
+	return a.addAssistedApproval(a.acpBase.SettingsSnapshot())
+}
+
+func (a *CopilotCLIAgent) UpdateSettings(options optionmap.Map) SettingsApplyResult {
+	if requested := options[contracts.CopilotPermissionGroupAssistedApproval]; requested != "" && requested != a.assistedApprovalValue() {
+		return restartRequiredSettings(options)
+	}
+	return a.addAssistedApproval(a.acpBase.UpdateSettings(options))
 }
 
 func fallbackCopilotCLIModes() []*leapmuxv1.AvailableOption {
@@ -65,4 +165,20 @@ func init() {
 		"LEAPMUX_COPILOT_DEFAULT_MODEL", "copilot",
 		CopilotConfigReasoningEffort, CopilotConfigAllowAll,
 	)
+	addStaticOptionGroups(leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT,
+		selectGroup(
+			contracts.CopilotPermissionGroupAssistedApproval,
+			"Assisted Approval",
+			OptionOrderProviderFourth,
+			contracts.CopilotPermissionValueOff,
+			[]optDef{
+				{Id: contracts.CopilotPermissionValueOff, Name: "Off", Default: true},
+				{Id: contracts.CopilotPermissionValueOn, Name: "On", Description: "Approve safe tool calls and ask about other calls. This also enables all experimental Copilot features."},
+			},
+		),
+	)
+	setNewAgentOptionDefaults(leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT, map[string]string{
+		contracts.CopilotPermissionGroupAssistedApproval: contracts.CopilotPermissionValueOn,
+		contracts.CopilotPermissionGroupAllowAll:         contracts.CopilotPermissionValueOff,
+	})
 }

--- a/backend/internal/worker/agent/copilot.go
+++ b/backend/internal/worker/agent/copilot.go
@@ -20,10 +20,7 @@ const (
 // Copilot's server-driven ACP config-option ids (surfaced as mutable option groups,
 // not static templates). Declared in KnownOptionIDs so a not-running agent validates
 // them, matching the ids the live `session/set_config_option` channel reports.
-const (
-	CopilotConfigReasoningEffort = "reasoning_effort"
-	CopilotConfigAllowAll        = contracts.CopilotPermissionGroupAllowAll
-)
+const CopilotConfigReasoningEffort = "reasoning_effort"
 
 // CopilotCLIAgent manages a single Copilot CLI ACP process.
 type CopilotCLIAgent struct {
@@ -32,46 +29,94 @@ type CopilotCLIAgent struct {
 	assistedApprovalUnavailable bool
 }
 
-const copilotAssistedApprovalUnavailableText = "--assisted-approval is only supported in non-interactive prompt mode"
+const (
+	copilotAssistedApprovalFlag = "--assisted-approval"
+	// The Copilot CLI's own refusal text. Matching it is the only signal the CLI gives;
+	// the match feeds a per-binary capability record, so a reworded message costs one
+	// failed launch per worker process rather than a permanently broken tab.
+	copilotAssistedApprovalUnavailableText = copilotAssistedApprovalFlag + " is only supported in non-interactive prompt mode"
+)
 
 func copilotBaseArgs(opts Options) []string {
 	args := []string{"--acp", "--stdio"}
 	if opts.Get(contracts.CopilotPermissionGroupAssistedApproval) == contracts.CopilotPermissionValueOn {
-		args = append(args, "--experimental", "--assisted-approval")
+		args = append(args, "--experimental", copilotAssistedApprovalFlag)
 	}
 	return args
 }
 
+// copilotBinaryName is the CLI this provider launches, and the key the
+// assisted-approval capability is remembered under.
+const copilotBinaryName = "copilot"
+
+// newCopilotCLIAgent builds the agent AND wires its catalog decorator. Every
+// construction goes through here, in production and in tests, because the decorator is
+// what puts Assisted Approval into the base catalog: an agent built without it reports a
+// catalog with no such group and a snapshot that never settles one, and nothing else
+// would say so. Wiring it in the one constructor rather than at each call site is what
+// makes that mistake impossible rather than merely documented.
+func newCopilotCLIAgent(assistedApproval string, assistedApprovalUnavailable bool) *CopilotCLIAgent {
+	a := &CopilotCLIAgent{
+		assistedApproval:            StringOrDefault(assistedApproval, contracts.CopilotPermissionValueOff),
+		assistedApprovalUnavailable: assistedApprovalUnavailable,
+	}
+	a.decorateOptionGroups = a.copilotOptionGroups
+	return a
+}
+
 // StartCopilotCLI starts a Copilot CLI ACP agent process and performs the handshake.
+//
+// Some Copilot builds reject --assisted-approval in Agent Client Protocol mode. That is a
+// property of the INSTALLED CLI, so the first launch that hits it records the capability
+// for the whole worker process: every later launch of that binary -- a second tab, a
+// restart, a clear-context relaunch -- starts with the flag off on the FIRST attempt
+// instead of paying a failed spawn and a full second handshake each time.
+//
+// The downgrade applies only to a value LeapMux chose. An explicitly requested Assisted
+// Approval still surfaces the startup error, so a user who asks for it learns that this
+// CLI cannot do it rather than silently running without it.
 func StartCopilotCLI(ctx context.Context, opts Options, sink OutputSink) (Agent, error) {
-	started, err := startCopilotCLI(ctx, opts, sink, false)
-	if err == nil || !opts.NewSessionDefaultOptionIDs[contracts.CopilotPermissionGroupAssistedApproval] ||
-		!isCopilotAssistedApprovalUnavailable(err) {
+	assisted := contracts.CopilotPermissionGroupAssistedApproval
+	defaulted := opts.NewSessionDefaultOptionIDs[assisted]
+	wantsAssisted := opts.Get(assisted) == contracts.CopilotPermissionValueOn
+	unsupported := BinaryFlagUnsupported(opts.Shell, opts.LoginShell, copilotBinaryName, copilotAssistedApprovalFlag)
+
+	if wantsAssisted && defaulted && unsupported {
+		return startCopilotCLI(ctx, copilotWithoutAssistedApproval(opts), sink, true)
+	}
+
+	started, err := startCopilotCLI(ctx, opts, sink, wantsAssisted && unsupported)
+	if err == nil || !isCopilotAssistedApprovalUnavailable(err) {
+		return started, err
+	}
+	MarkBinaryFlagUnsupported(opts.Shell, opts.LoginShell, copilotBinaryName, copilotAssistedApprovalFlag)
+	if !defaulted {
 		return started, err
 	}
 
-	slog.Warn("Copilot Assisted Approval is unavailable for ACP; using Off for the new session",
+	slog.Warn("Copilot Assisted Approval is unavailable for ACP; using Off for this session",
 		"agent_id", opts.AgentID)
-	fallback := opts
-	fallback.Options = opts.Options.Clone()
-	fallback.Options[contracts.CopilotPermissionGroupAssistedApproval] = contracts.CopilotPermissionValueOff
-	return startCopilotCLI(ctx, fallback, sink, true)
+	return startCopilotCLI(ctx, copilotWithoutAssistedApproval(opts), sink, true)
+}
+
+// copilotWithoutAssistedApproval returns opts with Assisted Approval turned off, without
+// touching the caller's map.
+func copilotWithoutAssistedApproval(opts Options) Options {
+	out := opts
+	out.Options = opts.Options.Clone()
+	out.Options[contracts.CopilotPermissionGroupAssistedApproval] = contracts.CopilotPermissionValueOff
+	return out
 }
 
 func startCopilotCLI(ctx context.Context, opts Options, sink OutputSink, assistedApprovalUnavailable bool) (Agent, error) {
 	return acpStart(ctx, opts, sink, acpStartSpec[CopilotCLIAgent]{
 		provider:     leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT,
 		providerName: "copilot",
-		binaryName:   "copilot",
-		baseArgsFor:  copilotBaseArgs,
+		binaryName:   copilotBinaryName,
+		baseArgs:     copilotBaseArgs(opts),
 		newAgent: func() *CopilotCLIAgent {
-			return &CopilotCLIAgent{
-				assistedApprovalUnavailable: assistedApprovalUnavailable,
-				assistedApproval: StringOrDefault(
-					opts.Get(contracts.CopilotPermissionGroupAssistedApproval),
-					contracts.CopilotPermissionValueOff,
-				),
-			}
+			return newCopilotCLIAgent(
+				opts.Get(contracts.CopilotPermissionGroupAssistedApproval), assistedApprovalUnavailable)
 		},
 		base: func(a *CopilotCLIAgent) *acpBase { return &a.acpBase },
 		configure: func(a *CopilotCLIAgent) {
@@ -86,13 +131,54 @@ func startCopilotCLI(ctx context.Context, opts Options, sink OutputSink, assiste
 	})
 }
 
+// resolveCopilotOptionConflicts settles Copilot's two permission axes. It is wired at
+// registration in provider.go.
+//
+// The rule runs in ONE direction: turning Assisted Approval on turns Allow All off.
+// Assisted Approval narrows what runs without asking, so leaving the broader Allow All
+// beside it would make the narrowing meaningless.
+//
+// The reverse does NOT hold. Allow All is a runtime config option the ACP server owns,
+// while Assisted Approval rides the launch flags -- so clearing it takes a process
+// restart, and a restart in the middle of a turn is a far worse answer than letting the
+// broader permission simply win. Allow All already supersedes Assisted Approval while
+// both are on, so the combination is redundant rather than contradictory.
+//
+// It also settles only a conflict the REQUEST creates. When neither axis is in the
+// request, a stored combination came from somewhere this resolver never saw -- a settings
+// refresh folds the server's own Allow All in without passing through here -- and
+// rewriting it would turn a permission axis off during an unrelated edit, such as a model
+// change, which the user never asked for.
+func resolveCopilotOptionConflicts(current, requested optionmap.Map) optionmap.Map {
+	resolved := current.Merge(requested)
+	assisted := contracts.CopilotPermissionGroupAssistedApproval
+	allowAll := contracts.CopilotPermissionGroupAllowAll
+	on := contracts.CopilotPermissionValueOn
+	if resolved[assisted] != on || resolved[allowAll] != on {
+		return resolved
+	}
+	if requested[assisted] == on {
+		resolved[allowAll] = contracts.CopilotPermissionValueOff
+	}
+	return resolved
+}
+
 func isCopilotAssistedApprovalUnavailable(err error) bool {
 	return err != nil && strings.Contains(err.Error(), copilotAssistedApprovalUnavailableText)
 }
 
-func (a *CopilotCLIAgent) OptionGroups() []*leapmuxv1.AvailableOptionGroup {
-	groups := a.acpBase.OptionGroups()
+// copilotOptionGroups is the acpBase.decorateOptionGroups hook: it appends the Assisted
+// Approval group, which rides the launch flags and so reaches the base through no ACP
+// channel. Wired in configure, NOT written as an OptionGroups override -- an override
+// would leave acpBase.SettingsSnapshot building its settlements from the undecorated
+// catalog, so the UI would show a group nothing ever settled.
+func (a *CopilotCLIAgent) copilotOptionGroups(groups []*leapmuxv1.AvailableOptionGroup) []*leapmuxv1.AvailableOptionGroup {
 	assistedID := contracts.CopilotPermissionGroupAssistedApproval
+	// Assisted Approval is a LeapMux-owned static group backed by launch flags, so the
+	// base never emits it today. The drop is a standing guard, not dead code: the base
+	// surfaces any non-reserved config option the server reports under its own id, so a
+	// Copilot build that ever reported this id would yield TWO groups under one key, and
+	// the frontend keys its option submenus by group id.
 	filtered := make([]*leapmuxv1.AvailableOptionGroup, 0, len(groups)+1)
 	for _, group := range groups {
 		if group.GetId() != assistedID {
@@ -120,31 +206,14 @@ func (a *CopilotCLIAgent) assistedApprovalValue() string {
 	return StringOrDefault(a.assistedApproval, contracts.CopilotPermissionValueOff)
 }
 
-func (a *CopilotCLIAgent) addAssistedApproval(result SettingsApplyResult) SettingsApplyResult {
-	if result.SurfacedOptions == nil {
-		result.SurfacedOptions = optionmap.Map{}
-	}
-	if result.Settlements == nil {
-		result.Settlements = OptionSettlements{}
-	}
-	value := a.assistedApprovalValue()
-	result.SurfacedOptions[contracts.CopilotPermissionGroupAssistedApproval] = value
-	result.Settlements[contracts.CopilotPermissionGroupAssistedApproval] = OptionSettlement{
-		State: OptionSettlementConfirmed,
-		Value: &value,
-	}
-	return result
-}
-
-func (a *CopilotCLIAgent) SettingsSnapshot() SettingsApplyResult {
-	return a.addAssistedApproval(a.acpBase.SettingsSnapshot())
-}
-
+// UpdateSettings refuses an Assisted Approval change in place: the axis is a launch flag,
+// so only a relaunch can move it. Every other axis, and the settlement for this one, come
+// from the base, which reads the decorated catalog.
 func (a *CopilotCLIAgent) UpdateSettings(options optionmap.Map) SettingsApplyResult {
 	if requested := options[contracts.CopilotPermissionGroupAssistedApproval]; requested != "" && requested != a.assistedApprovalValue() {
 		return restartRequiredSettings(options)
 	}
-	return a.addAssistedApproval(a.acpBase.UpdateSettings(options))
+	return a.acpBase.UpdateSettings(options)
 }
 
 func fallbackCopilotCLIModes() []*leapmuxv1.AvailableOption {
@@ -164,7 +233,7 @@ func init() {
 		StartCopilotCLI,
 		fallbackCopilotCLIModes(),
 		"LEAPMUX_COPILOT_DEFAULT_MODEL", "copilot",
-		CopilotConfigReasoningEffort, CopilotConfigAllowAll,
+		CopilotConfigReasoningEffort, contracts.CopilotPermissionGroupAllowAll,
 	)
 	addStaticOptionGroups(leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT,
 		selectGroup(
@@ -172,14 +241,36 @@ func init() {
 			"Assisted Approval",
 			OptionOrderProviderFourth,
 			contracts.CopilotPermissionValueOff,
+			// Off is the DEFAULT: the value a session runs at when nothing sets this axis,
+			// which is what an empty current resolves to and what a first settlement is
+			// measured against. That a NEW session asks for On is a different fact, and
+			// setNewAgentOptionDefaults below is its one home -- a resumed session never
+			// receives it, and stamping it here would announce a spurious
+			// "Assisted Approval (Off)" the moment such a session settled the axis.
 			[]optDef{
-				{Id: contracts.CopilotPermissionValueOff, Name: "Off"},
-				{Id: contracts.CopilotPermissionValueOn, Name: "On", Description: "Approve safe tool calls and ask about other calls. This also enables all experimental Copilot features.", Default: true},
+				{Id: contracts.CopilotPermissionValueOff, Name: "Off", Default: true},
+				{
+					Id: contracts.CopilotPermissionValueOn, Name: "On",
+					Description: "Approve safe tool calls and ask about other calls. This also enables all experimental Copilot features.",
+					// Assisted Approval narrows what runs without a prompt, so the broader
+					// Allow All cannot stand beside it. Declaring the consequence lets the
+					// picker say so before the click; resolveCopilotOptionConflicts is what
+					// actually applies it, and the two must state the same rule.
+					Clears: []*leapmuxv1.OptionSideEffect{{
+						GroupId: contracts.CopilotPermissionGroupAllowAll,
+						Value:   contracts.CopilotPermissionValueOff,
+					}},
+				},
 			},
 		),
 	)
-	setNewAgentOptionDefaults(leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT, map[string]string{
-		contracts.CopilotPermissionGroupAssistedApproval: contracts.CopilotPermissionValueOn,
-		contracts.CopilotPermissionGroupAllowAll:         contracts.CopilotPermissionValueOff,
+	setPermissionDefaults(leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT, PermissionDefaults{
+		NewSession: map[string]string{
+			contracts.CopilotPermissionGroupAssistedApproval: contracts.CopilotPermissionValueOn,
+			contracts.CopilotPermissionGroupAllowAll:         contracts.CopilotPermissionValueOff,
+		},
+		// Copilot's permission-mode axis is separate from the two axes above, and Agent
+		// is the mode its session starts in.
+		Fallback: CopilotCLIModeAgent,
 	})
 }

--- a/backend/internal/worker/agent/copilot_output_test.go
+++ b/backend/internal/worker/agent/copilot_output_test.go
@@ -3,7 +3,9 @@ package agent
 import (
 	"testing"
 
+	"github.com/leapmux/leapmux/generated/contracts"
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/util/optionids"
 	"github.com/stretchr/testify/require"
 )
 
@@ -162,11 +164,12 @@ func TestHandleCopilotOutput_ConfigOptionUpdateSurfacesGenericGroup(t *testing.T
 	input := `{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"config_option_update","configOptions":[{"id":"thoughtLevel","category":"thought_level","name":"Thought Level","currentValue":"high","options":[{"value":"low","name":"Low"},{"value":"high","name":"High"}]}]}}}`
 	agent.HandleOutput([]byte(input))
 
-	// The option group is surfaced after the mapped permission-mode group.
+	// The runtime option and static Assisted Approval group are both present.
 	groups := agent.OptionGroups()
-	require.Len(t, groups, 2)
-	require.Equal(t, OptionIDPermissionMode, groups[0].GetId())
-	require.Equal(t, "thoughtLevel", groups[1].GetId())
+	require.Len(t, groups, 3)
+	require.NotNil(t, optionids.GroupByID(groups, OptionIDPermissionMode))
+	require.NotNil(t, optionids.GroupByID(groups, "thoughtLevel"))
+	require.NotNil(t, optionids.GroupByID(groups, contracts.CopilotPermissionGroupAssistedApproval))
 
 	// The value persists via a settings refresh carrying the live mode (in its field)
 	// and the option value (in extras); no primaryAgent key for a permission-mode

--- a/backend/internal/worker/agent/copilot_output_test.go
+++ b/backend/internal/worker/agent/copilot_output_test.go
@@ -10,16 +10,13 @@ import (
 )
 
 func newCopilotAgentWithSink(sink OutputSink) *CopilotCLIAgent {
-	a := &CopilotCLIAgent{
-		acpBase: acpBase{
-			jsonrpcBase: jsonrpcBase{processBase: processBase{
-				agentID:      "test-agent",
-				providerName: "copilot",
-			}},
-			sink:      sink,
-			sessionID: "test-session",
-		},
-	}
+	a := newCopilotCLIAgent("", false)
+	a.jsonrpcBase = jsonrpcBase{processBase: processBase{
+		agentID:      "test-agent",
+		providerName: "copilot",
+	}}
+	a.sink = sink
+	a.sessionID = "test-session"
 	a.modeChannel = modeChannelPermissionMode
 	a.sink = newThinkingResetSink(a.sink, &a.thinkingTokens)
 	return a

--- a/backend/internal/worker/agent/copilot_test.go
+++ b/backend/internal/worker/agent/copilot_test.go
@@ -7,10 +7,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
 
+	"github.com/leapmux/leapmux/generated/contracts"
 	"github.com/leapmux/leapmux/internal/util/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -44,15 +46,20 @@ func newCopilotAgentForRPCWithResponder(t *testing.T, respond func(method string
 
 func installFakeCopilotCLI(t *testing.T, scenario string) {
 	installFakeACPCLI(t, fakeACPCLISpec{
-		binary:    "copilot",
-		helperRun: "TestHelperProcessCopilotCLI",
-		wantEnv:   "GO_WANT_HELPER_PROCESS_COPILOT",
-		env:       []string{"LEAPMUX_COPILOT_TEST_SCENARIO=" + scenario},
+		binary:      "copilot",
+		helperRun:   "TestHelperProcessCopilotCLI",
+		wantEnv:     "GO_WANT_HELPER_PROCESS_COPILOT",
+		env:         []string{"LEAPMUX_COPILOT_TEST_SCENARIO=" + scenario},
+		forwardArgs: true,
 	})
 }
 
 func TestHelperProcessCopilotCLI(*testing.T) {
 	scenario := os.Getenv("LEAPMUX_COPILOT_TEST_SCENARIO")
+	if scenario == "assisted-unavailable" && slices.Contains(os.Args, "--assisted-approval") {
+		_, _ = fmt.Fprintln(os.Stderr, copilotAssistedApprovalUnavailableText)
+		os.Exit(1)
+	}
 	runFakeACPServer("GO_WANT_HELPER_PROCESS_COPILOT", func(method string) (string, bool, bool) {
 		switch method {
 		case acpMethodInitialize:
@@ -78,6 +85,40 @@ func TestHelperProcessCopilotCLI(*testing.T) {
 	})
 }
 
+func TestStartCopilotCLIFallsBackWhenNewSessionDefaultIsUnavailable(t *testing.T) {
+	installFakeCopilotCLI(t, "assisted-unavailable")
+
+	provider, err := StartCopilotCLI(context.Background(), Options{
+		AgentID:       "copilot-fallback",
+		WorkingDir:    t.TempDir(),
+		Shell:         testutil.TestShell(),
+		LoginShell:    false,
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT,
+		Options: map[string]string{
+			contracts.CopilotPermissionGroupAssistedApproval: contracts.CopilotPermissionValueOn,
+		},
+		NewSessionDefaultOptionIDs: map[string]bool{
+			contracts.CopilotPermissionGroupAssistedApproval: true,
+		},
+	}, &testSink{})
+	require.NoError(t, err)
+
+	agent := provider.(*CopilotCLIAgent)
+	t.Cleanup(func() {
+		agent.Stop()
+		_ = agent.Wait()
+	})
+
+	assert.True(t, agent.assistedApprovalUnavailable)
+	group := optionids.GroupByID(agent.OptionGroups(), contracts.CopilotPermissionGroupAssistedApproval)
+	require.NotNil(t, group)
+	assert.False(t, group.GetMutable())
+	require.Len(t, group.GetOptions(), 1)
+	assert.Equal(t, contracts.CopilotPermissionValueOff, group.GetOptions()[0].GetId())
+	assert.Equal(t, contracts.CopilotPermissionValueOff,
+		agent.SettingsSnapshot().SurfacedOptions[contracts.CopilotPermissionGroupAssistedApproval])
+}
+
 func TestBuildCopilotSessionRequest_NewSession(t *testing.T) {
 	method, params := buildACPSessionRequest("", "/workspace", acpMethodSessionNew, acpMethodSessionLoad)
 	assert.Equal(t, acpMethodSessionNew, method)
@@ -96,6 +137,63 @@ func TestBuildCopilotSessionRequest_LoadSession(t *testing.T) {
 	require.NoError(t, json.Unmarshal(params, &parsed))
 	assert.Equal(t, "/workspace", parsed["cwd"])
 	assert.Equal(t, "session-123", parsed["sessionId"])
+}
+
+func TestCopilotBaseArgsEnableAssistedApproval(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, []string{"--acp", "--stdio"}, copilotBaseArgs(Options{}))
+	assert.Equal(t, []string{"--acp", "--stdio", "--experimental", "--assisted-approval"},
+		copilotBaseArgs(Options{Options: map[string]string{
+			contracts.CopilotPermissionGroupAssistedApproval: contracts.CopilotPermissionValueOn,
+		}}))
+}
+
+func TestCopilotAssistedApprovalOptionGroup(t *testing.T) {
+	t.Parallel()
+
+	agent := &CopilotCLIAgent{acpBase: acpBase{
+		modeChannel:       modeChannelPermissionMode,
+		secondaryFallback: fallbackCopilotCLIModes(),
+	}}
+	agent.assistedApproval = contracts.CopilotPermissionValueOn
+
+	group := optionids.GroupByID(agent.OptionGroups(), contracts.CopilotPermissionGroupAssistedApproval)
+	require.NotNil(t, group)
+	assert.Equal(t, "Assisted Approval", group.GetLabel())
+	assert.Equal(t, contracts.CopilotPermissionValueOn, group.GetCurrentValue())
+	assert.Equal(t, []string{contracts.CopilotPermissionValueOff, contracts.CopilotPermissionValueOn},
+		[]string{group.GetOptions()[0].GetId(), group.GetOptions()[1].GetId()})
+	assert.Equal(t, contracts.CopilotPermissionValueOn,
+		agent.SettingsSnapshot().SurfacedOptions[contracts.CopilotPermissionGroupAssistedApproval])
+}
+
+func TestCopilotAssistedApprovalChangeRequiresRestart(t *testing.T) {
+	t.Parallel()
+
+	agent := &CopilotCLIAgent{assistedApproval: contracts.CopilotPermissionValueOff}
+	result := agent.UpdateSettings(map[string]string{
+		contracts.CopilotPermissionGroupAssistedApproval: contracts.CopilotPermissionValueOn,
+	})
+	assert.False(t, result.AppliedLive)
+}
+
+func TestCopilotAssistedApprovalUnavailable(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, isCopilotAssistedApprovalUnavailable(fmt.Errorf(
+		"initialize: %s", copilotAssistedApprovalUnavailableText,
+	)))
+	assert.False(t, isCopilotAssistedApprovalUnavailable(fmt.Errorf("initialize: authentication failed")))
+
+	agent := &CopilotCLIAgent{assistedApprovalUnavailable: true}
+	group := optionids.GroupByID(agent.OptionGroups(), contracts.CopilotPermissionGroupAssistedApproval)
+	require.NotNil(t, group)
+	assert.False(t, group.GetMutable())
+	require.Len(t, group.GetOptions(), 1)
+	assert.Equal(t, contracts.CopilotPermissionValueOff, group.GetOptions()[0].GetId())
+	assert.Equal(t, contracts.CopilotPermissionValueOff,
+		agent.SettingsSnapshot().SurfacedOptions[contracts.CopilotPermissionGroupAssistedApproval])
 }
 
 func TestStartCopilotCLI_NewSessionHandshake(t *testing.T) {
@@ -289,9 +387,11 @@ func TestCopilotAvailableOptionGroupsFallsBack(t *testing.T) {
 	}}
 
 	groups := agent.OptionGroups()
-	require.Len(t, groups, 1)
-	assert.Equal(t, "permissionMode", groups[0].GetId())
-	assert.Equal(t, CopilotCLIModeAgent, groups[0].GetOptions()[0].GetId())
+	require.Len(t, groups, 2)
+	mode := optionids.GroupByID(groups, OptionIDPermissionMode)
+	require.NotNil(t, mode)
+	assert.Equal(t, CopilotCLIModeAgent, mode.GetOptions()[0].GetId())
+	require.NotNil(t, optionids.GroupByID(groups, contracts.CopilotPermissionGroupAssistedApproval))
 }
 
 func TestDefaultModel_CopilotUsesEnvOverride(t *testing.T) {

--- a/backend/internal/worker/agent/copilot_test.go
+++ b/backend/internal/worker/agent/copilot_test.go
@@ -115,6 +115,7 @@ func TestStartCopilotCLIFallsBackWhenNewSessionDefaultIsUnavailable(t *testing.T
 	assert.False(t, group.GetMutable())
 	require.Len(t, group.GetOptions(), 1)
 	assert.Equal(t, contracts.CopilotPermissionValueOff, group.GetOptions()[0].GetId())
+	assert.Equal(t, contracts.CopilotPermissionValueOff, group.GetDefaultValue())
 	assert.Equal(t, contracts.CopilotPermissionValueOff,
 		agent.SettingsSnapshot().SurfacedOptions[contracts.CopilotPermissionGroupAssistedApproval])
 }
@@ -162,6 +163,7 @@ func TestCopilotAssistedApprovalOptionGroup(t *testing.T) {
 	require.NotNil(t, group)
 	assert.Equal(t, "Assisted Approval", group.GetLabel())
 	assert.Equal(t, contracts.CopilotPermissionValueOn, group.GetCurrentValue())
+	assert.Equal(t, contracts.CopilotPermissionValueOn, group.GetDefaultValue())
 	assert.Equal(t, []string{contracts.CopilotPermissionValueOff, contracts.CopilotPermissionValueOn},
 		[]string{group.GetOptions()[0].GetId(), group.GetOptions()[1].GetId()})
 	assert.Equal(t, contracts.CopilotPermissionValueOn,
@@ -192,6 +194,7 @@ func TestCopilotAssistedApprovalUnavailable(t *testing.T) {
 	assert.False(t, group.GetMutable())
 	require.Len(t, group.GetOptions(), 1)
 	assert.Equal(t, contracts.CopilotPermissionValueOff, group.GetOptions()[0].GetId())
+	assert.Equal(t, contracts.CopilotPermissionValueOff, group.GetDefaultValue())
 	assert.Equal(t, contracts.CopilotPermissionValueOff,
 		agent.SettingsSnapshot().SurfacedOptions[contracts.CopilotPermissionGroupAssistedApproval])
 }

--- a/backend/internal/worker/agent/copilot_test.go
+++ b/backend/internal/worker/agent/copilot_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/leapmux/leapmux/generated/contracts"
+	"github.com/leapmux/leapmux/internal/util/optionmap"
 	"github.com/leapmux/leapmux/internal/util/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -24,7 +25,7 @@ import (
 func newCopilotAgentForRPC(t *testing.T) (*CopilotCLIAgent, func() []recordedRequest) {
 	return newACPAgentForRPC(t,
 		func() *CopilotCLIAgent {
-			a := &CopilotCLIAgent{}
+			a := newCopilotCLIAgent("", false)
 			a.modeChannel = modeChannelPermissionMode
 			return a
 		},
@@ -35,7 +36,7 @@ func newCopilotAgentForRPC(t *testing.T) (*CopilotCLIAgent, func() []recordedReq
 func newCopilotAgentForRPCWithResponder(t *testing.T, respond func(method string) json.RawMessage) (*CopilotCLIAgent, func() []recordedRequest) {
 	return newACPAgentForRPCWithResponder(t,
 		func() *CopilotCLIAgent {
-			a := &CopilotCLIAgent{}
+			a := newCopilotCLIAgent("", false)
 			a.modeChannel = modeChannelPermissionMode
 			return a
 		},
@@ -120,6 +121,30 @@ func TestStartCopilotCLIFallsBackWhenNewSessionDefaultIsUnavailable(t *testing.T
 		agent.SettingsSnapshot().SurfacedOptions[contracts.CopilotPermissionGroupAssistedApproval])
 }
 
+// The counterpart of the fallback above, and the contract the troubleshooting page
+// states: an EXPLICITLY requested Assisted Approval is never downgraded. A user who asks
+// for it on a CLI that cannot do it must see the startup error, not a session running
+// silently without the option they chose.
+func TestStartCopilotCLIFailsWhenAnExplicitRequestIsUnavailable(t *testing.T) {
+	installFakeCopilotCLI(t, "assisted-unavailable")
+
+	provider, err := StartCopilotCLI(context.Background(), Options{
+		AgentID:       "copilot-explicit",
+		WorkingDir:    t.TempDir(),
+		Shell:         testutil.TestShell(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT,
+		Options: map[string]string{
+			contracts.CopilotPermissionGroupAssistedApproval: contracts.CopilotPermissionValueOn,
+		},
+		// No NewSessionDefaultOptionIDs: the value came from the user, not from LeapMux.
+	}, &testSink{})
+	if provider != nil {
+		t.Cleanup(func() { provider.Stop(); _ = provider.Wait() })
+	}
+	require.Error(t, err, "an explicit request must surface the CLI's refusal")
+	assert.True(t, isCopilotAssistedApprovalUnavailable(err))
+}
+
 func TestBuildCopilotSessionRequest_NewSession(t *testing.T) {
 	method, params := buildACPSessionRequest("", "/workspace", acpMethodSessionNew, acpMethodSessionLoad)
 	assert.Equal(t, acpMethodSessionNew, method)
@@ -153,31 +178,140 @@ func TestCopilotBaseArgsEnableAssistedApproval(t *testing.T) {
 func TestCopilotAssistedApprovalOptionGroup(t *testing.T) {
 	t.Parallel()
 
-	agent := &CopilotCLIAgent{acpBase: acpBase{
-		modeChannel:       modeChannelPermissionMode,
-		secondaryFallback: fallbackCopilotCLIModes(),
-	}}
-	agent.assistedApproval = contracts.CopilotPermissionValueOn
+	agent := newCopilotCLIAgent(contracts.CopilotPermissionValueOn, false)
+	agent.modeChannel = modeChannelPermissionMode
+	agent.secondaryFallback = fallbackCopilotCLIModes()
 
 	group := optionids.GroupByID(agent.OptionGroups(), contracts.CopilotPermissionGroupAssistedApproval)
 	require.NotNil(t, group)
 	assert.Equal(t, "Assisted Approval", group.GetLabel())
 	assert.Equal(t, contracts.CopilotPermissionValueOn, group.GetCurrentValue())
-	assert.Equal(t, contracts.CopilotPermissionValueOn, group.GetDefaultValue())
+	// DefaultValue is Off: the value a session runs at when nothing sets this axis, which
+	// is what an empty current resolves to and what a first settlement is measured
+	// against. That a NEW session asks for On lives in NewAgentOptionDefaults instead, so
+	// a resumed session settling this axis is not announced as a change it never made.
+	assert.Equal(t, contracts.CopilotPermissionValueOff, group.GetDefaultValue())
 	assert.Equal(t, []string{contracts.CopilotPermissionValueOff, contracts.CopilotPermissionValueOn},
 		[]string{group.GetOptions()[0].GetId(), group.GetOptions()[1].GetId()})
 	assert.Equal(t, contracts.CopilotPermissionValueOn,
 		agent.SettingsSnapshot().SurfacedOptions[contracts.CopilotPermissionGroupAssistedApproval])
 }
 
+// The Assisted Approval group must reach the BASE catalog, not only an override. Go
+// resolves acpBase.SettingsSnapshot's own OptionGroups call to the base method, so a
+// provider that decorated only the override would surface a group in the UI that no
+// snapshot ever settles -- the frontend would then hold an unresolved axis forever.
+func TestCopilotAssistedApprovalReachesTheBaseCatalog(t *testing.T) {
+	agent, _ := newCopilotAgentForRPC(t)
+	assistedID := contracts.CopilotPermissionGroupAssistedApproval
+
+	// There is no OptionGroups override left to consult: the decorator runs inside the
+	// base method, so these two reads are the same call, which is exactly the property
+	// under test.
+	require.NotNil(t, optionids.GroupByID(agent.OptionGroups(), assistedID),
+		"the base catalog carries the decorated group")
+	snapshot := agent.SettingsSnapshot()
+	assert.Equal(t, contracts.CopilotPermissionValueOff, snapshot.SurfacedOptions[assistedID],
+		"a snapshot built from that same catalog settles the group, with no hand-patching")
+	assert.Equal(t, OptionSettlementConfirmed, snapshot.Settlements[assistedID].State)
+}
+
+// The static groups carry explicit display slots, and the composer sorts by that field
+// rather than by slice position, so the order lives in GetOrder and nothing else pins it.
+// The declared side effect and the resolver are two statements of ONE rule: the picker
+// tells the user what a click will do, and the resolver does it. This asserts they agree,
+// because a declaration that drifted from the behavior is worse than none -- it would
+// promise the user an outcome the worker does not produce.
+func TestCopilotAssistedApprovalDeclaresWhatTheResolverDoes(t *testing.T) {
+	t.Parallel()
+
+	group := optionids.GroupByID(
+		AvailableOptionGroupsForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT),
+		contracts.CopilotPermissionGroupAssistedApproval)
+	require.NotNil(t, group)
+
+	var on *leapmuxv1.AvailableOption
+	for _, option := range group.GetOptions() {
+		if option.GetId() == contracts.CopilotPermissionValueOn {
+			on = option
+		} else {
+			assert.Empty(t, option.GetClears(), "only turning the axis ON settles anything")
+		}
+	}
+	require.NotNil(t, on)
+	require.Len(t, on.GetClears(), 1)
+	assert.Equal(t, contracts.CopilotPermissionGroupAllowAll, on.GetClears()[0].GetGroupId())
+	assert.Equal(t, contracts.CopilotPermissionValueOff, on.GetClears()[0].GetValue())
+
+	// The resolver produces exactly what the option declares.
+	resolved := resolveCopilotOptionConflicts(
+		optionmap.Map{contracts.CopilotPermissionGroupAllowAll: contracts.CopilotPermissionValueOn},
+		optionmap.Map{contracts.CopilotPermissionGroupAssistedApproval: contracts.CopilotPermissionValueOn})
+	for _, effect := range on.GetClears() {
+		assert.Equal(t, effect.GetValue(), resolved[effect.GetGroupId()],
+			"the resolver settles %s exactly as the option declares", effect.GetGroupId())
+	}
+}
+
+func TestCopilotStaticGroupsCarryTheirDisplayOrder(t *testing.T) {
+	t.Parallel()
+
+	groups := AvailableOptionGroupsForProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT)
+	assert.Equal(t, OptionOrderProviderFourth,
+		optionids.GroupByID(groups, contracts.CopilotPermissionGroupAssistedApproval).GetOrder())
+	assert.Equal(t, OptionOrderPermissionMode,
+		optionids.GroupByID(groups, OptionIDPermissionMode).GetOrder())
+	for _, group := range groups {
+		assert.Greater(t, group.GetOrder(), OptionOrderModel,
+			"every provider group sorts after the model group: %s", group.GetId())
+	}
+}
+
 func TestCopilotAssistedApprovalChangeRequiresRestart(t *testing.T) {
 	t.Parallel()
 
-	agent := &CopilotCLIAgent{assistedApproval: contracts.CopilotPermissionValueOff}
+	agent := newCopilotCLIAgent(contracts.CopilotPermissionValueOff, false)
 	result := agent.UpdateSettings(map[string]string{
 		contracts.CopilotPermissionGroupAssistedApproval: contracts.CopilotPermissionValueOn,
 	})
 	assert.False(t, result.AppliedLive)
+}
+
+// The assisted-approval capability belongs to the INSTALLED CLI, not to the agent that
+// discovered it, so it is remembered for the worker process: a second tab and every
+// restart must start with the flag off on the FIRST attempt instead of paying a failed
+// spawn, and a relaunch must not resurrect a flag this binary already refused.
+func TestCopilotBinaryFlagCapabilityIsRememberedPerBinary(t *testing.T) {
+	shell := "/bin/zsh-" + t.Name()
+
+	assert.False(t, BinaryFlagUnsupported(shell, false, copilotBinaryName, copilotAssistedApprovalFlag),
+		"an unprobed binary is not known to refuse the flag")
+
+	MarkBinaryFlagUnsupported(shell, false, copilotBinaryName, copilotAssistedApprovalFlag)
+	assert.True(t, BinaryFlagUnsupported(shell, false, copilotBinaryName, copilotAssistedApprovalFlag))
+
+	// The record is per shell, per login-shell mode, per binary and per flag, so it
+	// cannot leak onto another launch configuration.
+	assert.False(t, BinaryFlagUnsupported(shell, true, copilotBinaryName, copilotAssistedApprovalFlag))
+	assert.False(t, BinaryFlagUnsupported(shell, false, "other-cli", copilotAssistedApprovalFlag))
+	assert.False(t, BinaryFlagUnsupported(shell, false, copilotBinaryName, "--other-flag"))
+}
+
+func TestCopilotWithoutAssistedApprovalDoesNotMutateTheCaller(t *testing.T) {
+	t.Parallel()
+
+	opts := Options{Options: optionmap.Map{
+		contracts.CopilotPermissionGroupAssistedApproval: contracts.CopilotPermissionValueOn,
+	}}
+	off := copilotWithoutAssistedApproval(opts)
+
+	assert.Equal(t, contracts.CopilotPermissionValueOff,
+		off.Options[contracts.CopilotPermissionGroupAssistedApproval])
+	assert.Equal(t, contracts.CopilotPermissionValueOn,
+		opts.Options[contracts.CopilotPermissionGroupAssistedApproval],
+		"the caller's launch map must be untouched")
+	assert.Equal(t, []string{"--acp", "--stdio"}, copilotBaseArgs(off),
+		"the downgraded options carry no assisted-approval flag")
 }
 
 func TestCopilotAssistedApprovalUnavailable(t *testing.T) {
@@ -188,7 +322,7 @@ func TestCopilotAssistedApprovalUnavailable(t *testing.T) {
 	)))
 	assert.False(t, isCopilotAssistedApprovalUnavailable(fmt.Errorf("initialize: authentication failed")))
 
-	agent := &CopilotCLIAgent{assistedApprovalUnavailable: true}
+	agent := newCopilotCLIAgent("", true)
 	group := optionids.GroupByID(agent.OptionGroups(), contracts.CopilotPermissionGroupAssistedApproval)
 	require.NotNil(t, group)
 	assert.False(t, group.GetMutable())
@@ -384,10 +518,9 @@ func TestCopilotCancelSessionSendsACPMethod(t *testing.T) {
 func TestCopilotAvailableOptionGroupsFallsBack(t *testing.T) {
 	// configure sets both the channel and the static fallback list; OptionGroups serves
 	// that fallback before the session reports a permission-mode catalog.
-	agent := &CopilotCLIAgent{acpBase: acpBase{
-		modeChannel:       modeChannelPermissionMode,
-		secondaryFallback: fallbackCopilotCLIModes(),
-	}}
+	agent := newCopilotCLIAgent("", false)
+	agent.modeChannel = modeChannelPermissionMode
+	agent.secondaryFallback = fallbackCopilotCLIModes()
 
 	groups := agent.OptionGroups()
 	require.Len(t, groups, 2)
@@ -411,7 +544,7 @@ func TestApplyStartupPermissionMode_PushesWhenDiffers(t *testing.T) {
 	agent, requests := newCopilotAgentForRPC(t)
 	agent.permissionMode = CopilotCLIModeAgent
 
-	require.NoError(t, agent.applyStartupPermissionMode(CopilotCLIModePlan))
+	require.NoError(t, agent.applyStartupPermissionMode(CopilotCLIModePlan, false))
 
 	assert.Equal(t, CopilotCLIModePlan, agent.permissionMode)
 	recorded := requests()
@@ -424,7 +557,7 @@ func TestApplyStartupPermissionMode_NoopWhenMatchesCurrent(t *testing.T) {
 	agent, requests := newCopilotAgentForRPC(t)
 	agent.permissionMode = CopilotCLIModePlan
 
-	require.NoError(t, agent.applyStartupPermissionMode(CopilotCLIModePlan))
+	require.NoError(t, agent.applyStartupPermissionMode(CopilotCLIModePlan, false))
 
 	assert.Empty(t, requests(), "no set_mode when the request already matches the server's current")
 }
@@ -433,7 +566,7 @@ func TestApplyStartupPermissionMode_NoopWhenEmpty(t *testing.T) {
 	agent, requests := newCopilotAgentForRPC(t)
 	agent.permissionMode = CopilotCLIModeAgent
 
-	require.NoError(t, agent.applyStartupPermissionMode(""))
+	require.NoError(t, agent.applyStartupPermissionMode("", false))
 
 	assert.Empty(t, requests(), "an empty requested mode is a no-op")
 }
@@ -447,8 +580,32 @@ func TestApplyStartupPermissionMode_RejectionIsFatal(t *testing.T) {
 	})
 	agent.permissionMode = CopilotCLIModeAgent
 
-	err := agent.applyStartupPermissionMode(CopilotCLIModePlan)
+	err := agent.applyStartupPermissionMode(CopilotCLIModePlan, false)
 	require.Error(t, err, "a rejected mode must surface so the caller aborts startup")
+}
+
+// A mode LeapMux chose, not the user, must not kill the session when this build does not
+// offer it: the safe default degrades to whatever mode the handshake reported. Goose is
+// the provider that ships one (smart_approve), and a build without that mode would
+// otherwise fail EVERY new session.
+func TestApplyStartupPermissionMode_SafeDefaultDegradesWhenUnavailable(t *testing.T) {
+	agent, requests := newCopilotAgentForRPCWithResponder(t, func(method string) json.RawMessage {
+		if method == acpMethodSessionSetMode {
+			return json.RawMessage(`{"code":-32602,"message":"unknown mode"}`)
+		}
+		return json.RawMessage(`{}`)
+	})
+	agent.permissionMode = CopilotCLIModeAgent
+	agent.availableModes = []*leapmuxv1.AvailableOption{{Id: CopilotCLIModeAgent}}
+
+	require.NoError(t, agent.applyStartupPermissionMode(CopilotCLIModePlan, true),
+		"a safe default this session does not offer must not abort startup")
+	assert.Empty(t, requests(), "the mode is never pushed, so the session keeps the one it reported")
+	assert.Equal(t, CopilotCLIModeAgent, agent.permissionMode)
+
+	// The same mode asked for EXPLICITLY still aborts, so a typed --permission-mode this
+	// build cannot enter is reported rather than silently downgraded.
+	require.Error(t, agent.applyStartupPermissionMode(CopilotCLIModePlan, false))
 }
 
 // seedReasoningEffort surfaces a Copilot-shaped reasoning_effort config option, as a

--- a/backend/internal/worker/agent/cursor.go
+++ b/backend/internal/worker/agent/cursor.go
@@ -336,6 +336,9 @@ func init() {
 		"cursor-agent",
 	)
 	setModelIDNormalizer(leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR, normalizeCursorModelID)
+	setPermissionDefaults(leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR, PermissionDefaults{
+		Fallback: CursorCLIModeAgent,
+	})
 }
 
 // cursorSubagentFromToolCall detects Cursor's Task delegation tool_call

--- a/backend/internal/worker/agent/factory.go
+++ b/backend/internal/worker/agent/factory.go
@@ -199,12 +199,12 @@ type agentFactoryEntry struct {
 	// uniformly for every provider, so a new provider declares its seeds here rather
 	// than the service layer growing a per-provider branch.
 	providerOptionDefaults map[string]string
-	// newAgentOptionDefaults contains safe permission values for a new session.
-	// The service does not apply these values to resumed or stored sessions.
-	newAgentOptionDefaults map[string]string
-	envModelKey            string   // e.g. "LEAPMUX_CLAUDE_DEFAULT_MODEL"
-	envEffortKey           string   // e.g. "LEAPMUX_CLAUDE_DEFAULT_EFFORT"
-	binaryNames            []string // preferred first; e.g. {"codex", "codex-x86_64-pc-windows-msvc"}
+	// permissionDefaults holds this provider's two permission-policy answers in one
+	// place, so a reader sees both at once and neither can be changed alone.
+	permissionDefaults PermissionDefaults
+	envModelKey        string   // e.g. "LEAPMUX_CLAUDE_DEFAULT_MODEL"
+	envEffortKey       string   // e.g. "LEAPMUX_CLAUDE_DEFAULT_EFFORT"
+	binaryNames        []string // preferred first; e.g. {"codex", "codex-x86_64-pc-windows-msvc"}
 	// launchResolver replaces the binaryNames probe for a provider whose program is
 	// not a bare name the login shell can resolve (see launchResolverFunc). When set,
 	// binaryNames is unused for both availability and launch.
@@ -374,16 +374,43 @@ func setProviderOptionDefaults(provider leapmuxv1.AgentProvider, defaults map[st
 	mutateFactoryEntry(provider, func(e *agentFactoryEntry) { e.providerOptionDefaults = defaults })
 }
 
-// setNewAgentOptionDefaults declares defaults that apply only when a request
-// creates a session without a resume handle.
-func setNewAgentOptionDefaults(provider leapmuxv1.AgentProvider, defaults map[string]string) {
-	mutateFactoryEntry(provider, func(e *agentFactoryEntry) { e.newAgentOptionDefaults = defaults })
+// PermissionDefaults is a provider's complete permission-policy declaration: what a NEW
+// session asks for, and what a session that stored nothing falls back to.
+//
+// The two live together because they are one policy read at two moments, and because
+// keeping them apart let them contradict each other: Goose declared `smart_approve` as
+// its new-session mode in one file and `auto` -- the very mode its bypass shortcut
+// selects -- as its fallback in another, so every RESUMED Goose session opened with
+// permission prompts disabled. One struct in one call puts both under the reader's eye.
+//
+// They stay two FIELDS because they are genuinely two values: Claude asks for Auto Mode
+// but falls back to Default, since a CLI that cannot enter Auto must still start.
+type PermissionDefaults struct {
+	// NewSession is the option id->value set stamped only into a session opened WITHOUT a
+	// resume handle. A provider may name several ids: Copilot sets both of its axes.
+	NewSession map[string]string
+	// Fallback is the permission mode for a session that carries no stored one -- a
+	// resume, a relaunch, or a row written before the axis existed. "" means the provider
+	// has no permission-mode axis at all, and the option is left unset.
+	Fallback string
 }
 
-// NewAgentOptionDefaults returns the safe defaults for a new session.
+// setPermissionDefaults declares a provider's permission policy. Called from the
+// provider's own init(), so the values live in that provider's file.
+func setPermissionDefaults(provider leapmuxv1.AgentProvider, defaults PermissionDefaults) {
+	mutateFactoryEntry(provider, func(e *agentFactoryEntry) { e.permissionDefaults = defaults })
+}
+
+// NewAgentOptionDefaults returns the safe option values for a new session.
 // The returned map is shared and read-only.
 func NewAgentOptionDefaults(provider leapmuxv1.AgentProvider) map[string]string {
-	return agentFactoryRegistry[provider].newAgentOptionDefaults
+	return agentFactoryRegistry[provider].permissionDefaults.NewSession
+}
+
+// FallbackPermissionMode returns the mode a session with no stored one takes, or "" for a
+// provider with no permission-mode axis.
+func FallbackPermissionMode(provider leapmuxv1.AgentProvider) string {
+	return agentFactoryRegistry[provider].permissionDefaults.Fallback
 }
 
 // addStaticOptionGroups appends provider-owned groups to the static catalog.
@@ -709,6 +736,36 @@ type binaryAvailabilityKey struct {
 	shellPath  string
 	loginShell bool
 	binaryName string
+}
+
+// binaryFlagUnsupportedCache remembers, for this worker process, that one binary
+// rejected one launch flag. A capability belongs to the INSTALLED CLI, not to the agent
+// that happened to discover it: without this, a second tab repeats the failed spawn, and
+// every restart of the same tab forgets and fails again -- which turns a stored option
+// into a tab that can never start.
+//
+// Only a NEGATIVE result is stored, and only from a launch the CLI itself refused, so
+// there is nothing to invalidate: a flag a binary accepts is never recorded, and an
+// upgraded CLI is a new worker process.
+var binaryFlagUnsupportedCache sync.Map // binaryFlagKey -> struct{}
+
+type binaryFlagKey struct {
+	binaryAvailabilityKey
+	flag string
+}
+
+// MarkBinaryFlagUnsupported records that binaryName rejected flag under this shell.
+func MarkBinaryFlagUnsupported(shellPath string, loginShell bool, binaryName, flag string) {
+	binaryFlagUnsupportedCache.Store(
+		binaryFlagKey{binaryAvailabilityKey{shellPath, loginShell, binaryName}, flag}, struct{}{})
+}
+
+// BinaryFlagUnsupported reports whether a previous launch in this worker process proved
+// that binaryName rejects flag under this shell.
+func BinaryFlagUnsupported(shellPath string, loginShell bool, binaryName, flag string) bool {
+	_, found := binaryFlagUnsupportedCache.Load(
+		binaryFlagKey{binaryAvailabilityKey{shellPath, loginShell, binaryName}, flag})
+	return found
 }
 
 // checkBinaryAvailable answers whether one binary resolves, and whether

--- a/backend/internal/worker/agent/factory.go
+++ b/backend/internal/worker/agent/factory.go
@@ -107,7 +107,7 @@ const EffortHigh = "high"
 // plan-execution path does.
 type ExitHandler func(agentID string, exitCode int, err error, stopped bool)
 
-// Options configures a new ClaudeCodeAgent.
+// Options configures one agent process start.
 type Options struct {
 	AgentID         string
 	WorkingDir      string
@@ -118,13 +118,17 @@ type Options struct {
 	// a specific axis via Model()/Effort()/PermissionMode()/Get(id). It is the same
 	// optionmap.Map type the service layer (OptionMap) and the Agent interface use,
 	// so a launch option set flows to/from those boundaries without a conversion.
-	Options        optionmap.Map
-	StartupTimeout time.Duration           // Timeout for the startup handshake (default: 5m)
-	APITimeout     time.Duration           // Timeout for JSON-RPC requests (default: 10s)
-	Shell          string                  // Default shell path (always set when using shell wrapper)
-	LoginShell     bool                    // If true, use interactive+login shell flags
-	HomeDir        string                  // User's home directory (reads Claude Code settings; expands `~` when the Pi rule CHECKS a resume handle -- Pi expands it again itself)
-	AgentProvider  leapmuxv1.AgentProvider // Coding agent provider (default: CLAUDE_CODE)
+	Options optionmap.Map
+	// NewSessionDefaultOptionIDs records which option values came from the
+	// safe defaults for a new session. A provider can fall back when its local
+	// CLI does not support one of these defaults. Explicit values are absent.
+	NewSessionDefaultOptionIDs map[string]bool
+	StartupTimeout             time.Duration           // Timeout for the startup handshake (default: 5m)
+	APITimeout                 time.Duration           // Timeout for JSON-RPC requests (default: 10s)
+	Shell                      string                  // Default shell path (always set when using shell wrapper)
+	LoginShell                 bool                    // If true, use interactive+login shell flags
+	HomeDir                    string                  // User's home directory (reads Claude Code settings; expands `~` when the Pi rule CHECKS a resume handle -- Pi expands it again itself)
+	AgentProvider              leapmuxv1.AgentProvider // Coding agent provider (default: CLAUDE_CODE)
 	// ExtraEnv is appended verbatim to the spawned process's
 	// environment after the provider-specific env-var setup. The
 	// service.Service populates this with LEAPMUX_CONTROL_* so the
@@ -195,6 +199,9 @@ type agentFactoryEntry struct {
 	// uniformly for every provider, so a new provider declares its seeds here rather
 	// than the service layer growing a per-provider branch.
 	providerOptionDefaults map[string]string
+	// newAgentOptionDefaults contains safe permission values for a new session.
+	// The service does not apply these values to resumed or stored sessions.
+	newAgentOptionDefaults map[string]string
 	envModelKey            string   // e.g. "LEAPMUX_CLAUDE_DEFAULT_MODEL"
 	envEffortKey           string   // e.g. "LEAPMUX_CLAUDE_DEFAULT_EFFORT"
 	binaryNames            []string // preferred first; e.g. {"codex", "codex-x86_64-pc-windows-msvc"}
@@ -365,6 +372,26 @@ func PersistedOnlyOptionIDs(provider leapmuxv1.AgentProvider) map[string]bool {
 // after registerAgentFactory; a provider with none (most) need not call it.
 func setProviderOptionDefaults(provider leapmuxv1.AgentProvider, defaults map[string]string) {
 	mutateFactoryEntry(provider, func(e *agentFactoryEntry) { e.providerOptionDefaults = defaults })
+}
+
+// setNewAgentOptionDefaults declares defaults that apply only when a request
+// creates a session without a resume handle.
+func setNewAgentOptionDefaults(provider leapmuxv1.AgentProvider, defaults map[string]string) {
+	mutateFactoryEntry(provider, func(e *agentFactoryEntry) { e.newAgentOptionDefaults = defaults })
+}
+
+// NewAgentOptionDefaults returns the safe defaults for a new session.
+// The returned map is shared and read-only.
+func NewAgentOptionDefaults(provider leapmuxv1.AgentProvider) map[string]string {
+	return agentFactoryRegistry[provider].newAgentOptionDefaults
+}
+
+// addStaticOptionGroups appends provider-owned groups to the static catalog.
+// A live provider must also include each group in its settings snapshot.
+func addStaticOptionGroups(provider leapmuxv1.AgentProvider, groups ...*leapmuxv1.AvailableOptionGroup) {
+	mutateFactoryEntry(provider, func(e *agentFactoryEntry) {
+		e.optionGroups = append(e.optionGroups, groups...)
+	})
 }
 
 // ProviderOptionDefaults returns the provider-specific seed option values (id->default)

--- a/backend/internal/worker/agent/factory_test.go
+++ b/backend/internal/worker/agent/factory_test.go
@@ -140,14 +140,19 @@ func TestPermissionModeOrDefault(t *testing.T) {
 		mode     string
 		want     string
 	}{
-		{"claude empty", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, "", PermissionModeDefault},
-		{"claude default", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, PermissionModeDefault, PermissionModeDefault},
+		{"claude empty", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, "", contracts.ClaudeModeDefault},
+		{"claude default", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, contracts.ClaudeModeDefault, contracts.ClaudeModeDefault},
 		{"codex empty", leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX, "", CodexDefaultApprovalPolicy},
-		{"codex legacy db default", leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX, PermissionModeDefault, CodexDefaultApprovalPolicy},
+		{"codex legacy db default", leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX, contracts.ClaudeModeDefault, CodexDefaultApprovalPolicy},
 		{"codex explicit", leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX, "never", "never"},
-		{"cursor legacy db default", leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR, PermissionModeDefault, CursorCLIModeAgent},
-		{"copilot legacy db default", leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT, PermissionModeDefault, CopilotCLIModeAgent},
-		{"goose legacy db default", leapmuxv1.AgentProvider_AGENT_PROVIDER_GOOSE, PermissionModeDefault, GooseCLIModeAuto},
+		{"cursor legacy db default", leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR, contracts.ClaudeModeDefault, CursorCLIModeAgent},
+		{"copilot legacy db default", leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT, contracts.ClaudeModeDefault, CopilotCLIModeAgent},
+		// Goose's fallback is Smart Approve, never Auto: Auto is the value Goose's own
+		// BYPASS preset selects, so a resumed session with no stored mode would otherwise
+		// open with every permission prompt disabled.
+		{"goose empty", leapmuxv1.AgentProvider_AGENT_PROVIDER_GOOSE, "", contracts.GooseModeSmartApprove},
+		{"goose legacy db default", leapmuxv1.AgentProvider_AGENT_PROVIDER_GOOSE, contracts.ClaudeModeDefault, contracts.GooseModeSmartApprove},
+		{"goose explicit auto", leapmuxv1.AgentProvider_AGENT_PROVIDER_GOOSE, contracts.GooseModeAuto, contracts.GooseModeAuto},
 		{"opencode no top-level default", leapmuxv1.AgentProvider_AGENT_PROVIDER_OPENCODE, "", ""},
 		{"reasonix no permission mode", leapmuxv1.AgentProvider_AGENT_PROVIDER_REASONIX, "", ""},
 		{"zcode empty", leapmuxv1.AgentProvider_AGENT_PROVIDER_ZCODE, "", contracts.ZCodeDefaultMode},
@@ -279,7 +284,7 @@ func TestKnownOptionIDs(t *testing.T) {
 	copilot := leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT
 	assert.True(t, has(copilot, OptionIDPermissionMode))
 	assert.True(t, has(copilot, CopilotConfigReasoningEffort))
-	assert.True(t, has(copilot, CopilotConfigAllowAll))
+	assert.True(t, has(copilot, contracts.CopilotPermissionGroupAllowAll))
 	assert.True(t, has(copilot, contracts.CopilotPermissionGroupAssistedApproval))
 	assert.False(t, has(copilot, OptionIDEffort), "copilot uses reasoning_effort, not the well-known effort")
 
@@ -324,19 +329,90 @@ func TestKnownOptionIDs(t *testing.T) {
 	assert.Equal(t, map[string]bool{OptionIDModel: true}, unknown)
 }
 
-func TestNewAgentOptionDefaults(t *testing.T) {
+// A provider's SAFE new-session mode must never be the mode its own bypass preset
+// selects, and neither must its fallback for a session that stored none. Goose shipped
+// exactly that: its fallback was `auto`, which is also its declared bypass, so every
+// resumed Goose session opened with permission prompts disabled.
+//
+// The bypass values are the frontend plugins' (providers/*/plugin.tsx and stubs/*.tsx),
+// which Go cannot import, so they are restated here. That is the point: this test is the
+// thing that fails when the two drift.
+func TestSafePermissionDefaultsAreNeverAProviderBypassMode(t *testing.T) {
 	t.Parallel()
 
-	assert.Equal(t, map[string]string{OptionIDPermissionMode: PermissionModeAuto},
-		NewAgentOptionDefaults(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE))
-	assert.Equal(t, map[string]string{OptionIDPermissionMode: contracts.GooseModeSmartApprove},
-		NewAgentOptionDefaults(leapmuxv1.AgentProvider_AGENT_PROVIDER_GOOSE))
-	assert.Equal(t, map[string]string{
-		contracts.CopilotPermissionGroupAssistedApproval: contracts.CopilotPermissionValueOn,
-		contracts.CopilotPermissionGroupAllowAll:         contracts.CopilotPermissionValueOff,
-	}, NewAgentOptionDefaults(leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT))
-	assert.Empty(t, NewAgentOptionDefaults(leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX))
-	assert.Empty(t, NewAgentOptionDefaults(leapmuxv1.AgentProvider_AGENT_PROVIDER_ZCODE))
+	bypassModes := map[leapmuxv1.AgentProvider]string{
+		leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE: contracts.ClaudeModeBypassPermissions,
+		leapmuxv1.AgentProvider_AGENT_PROVIDER_GOOSE:       contracts.GooseModeAuto,
+		leapmuxv1.AgentProvider_AGENT_PROVIDER_ZCODE:       contracts.ZCodeModeYolo,
+	}
+	for provider, bypass := range bypassModes {
+		t.Run(provider.String(), func(t *testing.T) {
+			if safe := NewAgentOptionDefaults(provider)[OptionIDPermissionMode]; safe != "" {
+				assert.NotEqual(t, bypass, safe,
+					"a new session must not open in the mode the bypass shortcut selects")
+			}
+			assert.NotEqual(t, bypass, FallbackPermissionMode(provider),
+				"a session that stored no mode must not fall back to the bypass mode")
+		})
+	}
+}
+
+// Both halves of every provider's PermissionDefaults, asserted side by side. They live in
+// one struct so a reader sees them together; pinning them in one test is the same idea,
+// and it is what shows that Claude ASKS for one mode and FALLS BACK to another.
+func TestPermissionDefaults(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		provider     leapmuxv1.AgentProvider
+		wantNew      map[string]string
+		wantFallback string
+	}{
+		{
+			// Claude asks for Auto and falls back to Default: a CLI that cannot enter Auto
+			// must still start.
+			provider:     leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+			wantNew:      map[string]string{OptionIDPermissionMode: contracts.ClaudeModeAuto},
+			wantFallback: contracts.ClaudeModeDefault,
+		},
+		{
+			// Goose uses Smart Approve for both. The fallback must never be its `auto`,
+			// which is the mode its bypass shortcut selects.
+			provider:     leapmuxv1.AgentProvider_AGENT_PROVIDER_GOOSE,
+			wantNew:      map[string]string{OptionIDPermissionMode: contracts.GooseDefaultMode},
+			wantFallback: contracts.GooseDefaultMode,
+		},
+		{
+			// Copilot's safe defaults name two axes that are NOT the permission mode, so
+			// its fallback covers a third axis entirely.
+			provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT,
+			wantNew: map[string]string{
+				contracts.CopilotPermissionGroupAssistedApproval: contracts.CopilotPermissionValueOn,
+				contracts.CopilotPermissionGroupAllowAll:         contracts.CopilotPermissionValueOff,
+			},
+			wantFallback: CopilotCLIModeAgent,
+		},
+		// A provider whose starting policy already asks before acting declares no safe
+		// default, and only a fallback.
+		{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX, wantFallback: CodexDefaultApprovalPolicy},
+		{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_ZCODE, wantFallback: contracts.ZCodeDefaultMode},
+		{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR, wantFallback: CursorCLIModeAgent},
+		// A provider with no permission-mode axis at all declares neither half, and the
+		// option is left unset rather than stamped with a value it cannot accept.
+		{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_PI},
+		{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_REASONIX},
+		{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_OPENCODE},
+	}
+	for _, tc := range cases {
+		t.Run(tc.provider.String(), func(t *testing.T) {
+			if tc.wantNew == nil {
+				assert.Empty(t, NewAgentOptionDefaults(tc.provider))
+			} else {
+				assert.Equal(t, tc.wantNew, NewAgentOptionDefaults(tc.provider))
+			}
+			assert.Equal(t, tc.wantFallback, FallbackPermissionMode(tc.provider))
+		})
+	}
 }
 
 // TestRegisteredSecondaryFallback verifies acpStart's secondary-fallback seeding sources the SAME

--- a/backend/internal/worker/agent/factory_test.go
+++ b/backend/internal/worker/agent/factory_test.go
@@ -280,6 +280,7 @@ func TestKnownOptionIDs(t *testing.T) {
 	assert.True(t, has(copilot, OptionIDPermissionMode))
 	assert.True(t, has(copilot, CopilotConfigReasoningEffort))
 	assert.True(t, has(copilot, CopilotConfigAllowAll))
+	assert.True(t, has(copilot, contracts.CopilotPermissionGroupAssistedApproval))
 	assert.False(t, has(copilot, OptionIDEffort), "copilot uses reasoning_effort, not the well-known effort")
 
 	// OpenCode / Kilo surface their per-model reasoning under the well-known "effort"
@@ -321,6 +322,21 @@ func TestKnownOptionIDs(t *testing.T) {
 	// An unknown provider yields just {model}.
 	unknown := KnownOptionIDs(leapmuxv1.AgentProvider_AGENT_PROVIDER_UNSPECIFIED)
 	assert.Equal(t, map[string]bool{OptionIDModel: true}, unknown)
+}
+
+func TestNewAgentOptionDefaults(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, map[string]string{OptionIDPermissionMode: PermissionModeAuto},
+		NewAgentOptionDefaults(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE))
+	assert.Equal(t, map[string]string{OptionIDPermissionMode: contracts.GooseModeSmartApprove},
+		NewAgentOptionDefaults(leapmuxv1.AgentProvider_AGENT_PROVIDER_GOOSE))
+	assert.Equal(t, map[string]string{
+		contracts.CopilotPermissionGroupAssistedApproval: contracts.CopilotPermissionValueOn,
+		contracts.CopilotPermissionGroupAllowAll:         contracts.CopilotPermissionValueOff,
+	}, NewAgentOptionDefaults(leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT))
+	assert.Empty(t, NewAgentOptionDefaults(leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX))
+	assert.Empty(t, NewAgentOptionDefaults(leapmuxv1.AgentProvider_AGENT_PROVIDER_ZCODE))
 }
 
 // TestRegisteredSecondaryFallback verifies acpStart's secondary-fallback seeding sources the SAME

--- a/backend/internal/worker/agent/goose.go
+++ b/backend/internal/worker/agent/goose.go
@@ -10,13 +10,6 @@ import (
 	"github.com/leapmux/leapmux/internal/worker/bgtask"
 )
 
-const (
-	GooseCLIModeAuto         = contracts.GooseModeAuto
-	GooseCLIModeApprove      = contracts.GooseModeApprove
-	GooseCLIModeSmartApprove = contracts.GooseModeSmartApprove
-	GooseCLIModeChat         = contracts.GooseModeChat
-)
-
 // Goose's server-driven ACP config-option ids (surfaced as mutable option groups,
 // not static templates). Declared in KnownOptionIDs so a not-running agent validates
 // them, matching the ids the live `session/set_config_option` channel reports. Goose
@@ -42,7 +35,9 @@ func StartGooseCLI(ctx context.Context, opts Options, sink OutputSink) (Agent, e
 		base:         func(a *GooseCLIAgent) *acpBase { return &a.acpBase },
 		configure: func(a *GooseCLIAgent) {
 			a.modeChannel = modeChannelPermissionMode
-			a.orderPermissionModes = putGooseSmartApproveFirst
+			// Smart Approve is Goose's safe new-session mode, so it leads every rebuilt
+			// list and is the mode the group badges as its default.
+			a.preferredFirstMode = contracts.GooseModeSmartApprove
 			// Goose's reasoning-effort axis is the convention id "thinking_effort", not the
 			// well-known "effort" -- declare it so the env-effort override maps onto it.
 			a.effortConfigID = GooseConfigThinkingEffort
@@ -55,29 +50,23 @@ func StartGooseCLI(ctx context.Context, opts Options, sink OutputSink) (Agent, e
 			a.subagentFromToolCallUpdate = gooseSubagentFromToolCallUpdate
 		},
 		afterHandshake: func(a *GooseCLIAgent, handshake *acpSessionResult, opts Options) error {
-			return a.applyPermissionModeStartup(handshake, opts, GooseCLIModeAuto, opts.Model())
+			return a.applyPermissionModeStartup(handshake, opts, contracts.GooseModeAuto, opts.Model())
 		},
 	})
 }
 
-func putGooseSmartApproveFirst(modes []*leapmuxv1.AvailableOption) {
-	for index, mode := range modes {
-		if mode.GetId() != contracts.GooseModeSmartApprove || index == 0 {
-			continue
-		}
-		copy(modes[1:index+1], modes[:index])
-		modes[0] = mode
-		return
-	}
-}
-
+// fallbackGooseCLIModes lists Goose's modes in Goose's own order, then applies the same
+// preferred-first rule the live catalog applies. Ordering here rather than hand-writing
+// the result keeps the static fallback and every rebuilt list in agreement.
 func fallbackGooseCLIModes() []*leapmuxv1.AvailableOption {
-	return []*leapmuxv1.AvailableOption{
-		{Id: GooseCLIModeSmartApprove, Name: "Smart Approve"},
-		{Id: GooseCLIModeAuto, Name: "Auto"},
-		{Id: GooseCLIModeApprove, Name: "Approve"},
-		{Id: GooseCLIModeChat, Name: "Chat"},
+	modes := []*leapmuxv1.AvailableOption{
+		{Id: contracts.GooseModeAuto, Name: "Auto"},
+		{Id: contracts.GooseModeApprove, Name: "Approve"},
+		{Id: contracts.GooseModeSmartApprove, Name: "Smart Approve"},
+		{Id: contracts.GooseModeChat, Name: "Chat"},
 	}
+	orderModesPreferredFirst(modes, contracts.GooseModeSmartApprove)
+	return modes
 }
 
 // gooseSubagentFromToolCall detects Goose's spawn tool_call by the structured
@@ -267,7 +256,11 @@ func init() {
 		"LEAPMUX_GOOSE_DEFAULT_MODEL", "goose",
 		GooseConfigThinkingEffort, GooseConfigProvider,
 	)
-	setNewAgentOptionDefaults(leapmuxv1.AgentProvider_AGENT_PROVIDER_GOOSE, map[string]string{
-		OptionIDPermissionMode: contracts.GooseModeSmartApprove,
+	setPermissionDefaults(leapmuxv1.AgentProvider_AGENT_PROVIDER_GOOSE, PermissionDefaults{
+		// Both halves are Smart Approve. The fallback must NOT be Goose's own `auto`,
+		// which is the mode its bypass shortcut selects: a resumed session with no stored
+		// mode would then open with every permission prompt disabled.
+		NewSession: map[string]string{OptionIDPermissionMode: contracts.GooseDefaultMode},
+		Fallback:   contracts.GooseDefaultMode,
 	})
 }

--- a/backend/internal/worker/agent/goose.go
+++ b/backend/internal/worker/agent/goose.go
@@ -5,15 +5,16 @@ import (
 	"encoding/json"
 	"log/slog"
 
+	"github.com/leapmux/leapmux/generated/contracts"
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/worker/bgtask"
 )
 
 const (
-	GooseCLIModeAuto         = "auto"
-	GooseCLIModeApprove      = "approve"
-	GooseCLIModeSmartApprove = "smart_approve"
-	GooseCLIModeChat         = "chat"
+	GooseCLIModeAuto         = contracts.GooseModeAuto
+	GooseCLIModeApprove      = contracts.GooseModeApprove
+	GooseCLIModeSmartApprove = contracts.GooseModeSmartApprove
+	GooseCLIModeChat         = contracts.GooseModeChat
 )
 
 // Goose's server-driven ACP config-option ids (surfaced as mutable option groups,
@@ -41,6 +42,7 @@ func StartGooseCLI(ctx context.Context, opts Options, sink OutputSink) (Agent, e
 		base:         func(a *GooseCLIAgent) *acpBase { return &a.acpBase },
 		configure: func(a *GooseCLIAgent) {
 			a.modeChannel = modeChannelPermissionMode
+			a.orderPermissionModes = putGooseSmartApproveFirst
 			// Goose's reasoning-effort axis is the convention id "thinking_effort", not the
 			// well-known "effort" -- declare it so the env-effort override maps onto it.
 			a.effortConfigID = GooseConfigThinkingEffort
@@ -58,11 +60,22 @@ func StartGooseCLI(ctx context.Context, opts Options, sink OutputSink) (Agent, e
 	})
 }
 
+func putGooseSmartApproveFirst(modes []*leapmuxv1.AvailableOption) {
+	for index, mode := range modes {
+		if mode.GetId() != contracts.GooseModeSmartApprove || index == 0 {
+			continue
+		}
+		copy(modes[1:index+1], modes[:index])
+		modes[0] = mode
+		return
+	}
+}
+
 func fallbackGooseCLIModes() []*leapmuxv1.AvailableOption {
 	return []*leapmuxv1.AvailableOption{
+		{Id: GooseCLIModeSmartApprove, Name: "Smart Approve"},
 		{Id: GooseCLIModeAuto, Name: "Auto"},
 		{Id: GooseCLIModeApprove, Name: "Approve"},
-		{Id: GooseCLIModeSmartApprove, Name: "Smart Approve"},
 		{Id: GooseCLIModeChat, Name: "Chat"},
 	}
 }
@@ -254,4 +267,7 @@ func init() {
 		"LEAPMUX_GOOSE_DEFAULT_MODEL", "goose",
 		GooseConfigThinkingEffort, GooseConfigProvider,
 	)
+	setNewAgentOptionDefaults(leapmuxv1.AgentProvider_AGENT_PROVIDER_GOOSE, map[string]string{
+		OptionIDPermissionMode: contracts.GooseModeSmartApprove,
+	})
 }

--- a/backend/internal/worker/agent/goose_test.go
+++ b/backend/internal/worker/agent/goose_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/leapmux/leapmux/generated/contracts"
 	"github.com/leapmux/leapmux/internal/util/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -95,7 +96,7 @@ func TestStartGooseCLI_NewSessionHandshake(t *testing.T) {
 
 	assert.Equal(t, "goose-new", agent.sessionID)
 	assert.Equal(t, "default-model", agent.model)
-	assert.Equal(t, GooseCLIModeAuto, agent.permissionMode)
+	assert.Equal(t, contracts.GooseModeAuto, agent.permissionMode)
 	require.Len(t, agent.availableModels, 2)
 	assert.Equal(t, "default-model", agent.availableModels[0].GetId())
 	groups := agent.OptionGroups()
@@ -114,7 +115,57 @@ func TestFallbackGooseModesPutSmartApproveFirst(t *testing.T) {
 
 	modes := fallbackGooseCLIModes()
 	require.NotEmpty(t, modes)
-	assert.Equal(t, GooseCLIModeSmartApprove, modes[0].GetId())
+	assert.Equal(t, contracts.GooseModeSmartApprove, modes[0].GetId())
+	// The rest keep Goose's own order, so the fallback and a live catalog agree.
+	rest := make([]string, 0, len(modes)-1)
+	for _, mode := range modes[1:] {
+		rest = append(rest, mode.GetId())
+	}
+	assert.Equal(t, []string{contracts.GooseModeAuto, contracts.GooseModeApprove, contracts.GooseModeChat}, rest)
+}
+
+// orderModesPreferredFirst is the one ordering rule every rebuilt permission list uses,
+// so its edges decide what the picker shows and which option position 0 badges as the
+// group default.
+func TestOrderModesPreferredFirst(t *testing.T) {
+	t.Parallel()
+
+	ids := func(modes []*leapmuxv1.AvailableOption) []string {
+		out := make([]string, 0, len(modes))
+		for _, mode := range modes {
+			out = append(out, mode.GetId())
+		}
+		return out
+	}
+	modes := func(values ...string) []*leapmuxv1.AvailableOption {
+		out := make([]*leapmuxv1.AvailableOption, 0, len(values))
+		for _, value := range values {
+			out = append(out, &leapmuxv1.AvailableOption{Id: value})
+		}
+		return out
+	}
+
+	cases := []struct {
+		name      string
+		in        []*leapmuxv1.AvailableOption
+		preferred string
+		want      []string
+	}{
+		{"moves the preferred mode to the front", modes("a", "b", "c"), "c", []string{"c", "a", "b"}},
+		{"leaves a list already led by it alone", modes("c", "a", "b"), "c", []string{"c", "a", "b"}},
+		{"leaves a list that omits it alone", modes("a", "b"), "c", []string{"a", "b"}},
+		{"orders nothing without a preferred mode", modes("a", "b"), "", []string{"a", "b"}},
+		{"handles an empty list", modes(), "c", []string{}},
+		// A server that reports the id twice must not rotate the others: both copies
+		// land at the front and every other mode keeps its reported position.
+		{"keeps the order under a duplicate", modes("c", "a", "c", "b"), "c", []string{"c", "c", "a", "b"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			orderModesPreferredFirst(tc.in, tc.preferred)
+			assert.Equal(t, tc.want, ids(tc.in))
+		})
+	}
 }
 
 func TestStartGooseCLI_LoadSessionUsesResumeID(t *testing.T) {
@@ -138,7 +189,7 @@ func TestStartGooseCLI_LoadSessionUsesResumeID(t *testing.T) {
 
 	assert.Equal(t, "goose-resume", agent.sessionID)
 	assert.Equal(t, "fast-model", agent.model)
-	assert.Equal(t, GooseCLIModeApprove, agent.permissionMode)
+	assert.Equal(t, contracts.GooseModeApprove, agent.permissionMode)
 }
 
 // A resume the agent refuses fails the whole start, for every ACP provider:
@@ -186,17 +237,17 @@ func TestStartGooseCLI_RefusedNewSessionIsNotReportedAsAResume(t *testing.T) {
 func TestGooseUpdateSettingsSendsLiveACPRequests(t *testing.T) {
 	agent, requests := newGooseAgentForRPC(t)
 	agent.availableModes = []*leapmuxv1.AvailableOption{
-		{Id: GooseCLIModeAuto, Name: "Auto"},
-		{Id: GooseCLIModeApprove, Name: "Approve"},
+		{Id: contracts.GooseModeAuto, Name: "Auto"},
+		{Id: contracts.GooseModeApprove, Name: "Approve"},
 	}
 
 	updated := agent.UpdateSettings(map[string]string{
 		OptionIDModel:          "fast-model",
-		OptionIDPermissionMode: GooseCLIModeApprove,
+		OptionIDPermissionMode: contracts.GooseModeApprove,
 	})
 	require.True(t, updated.AppliedLive)
 	assert.Equal(t, "fast-model", agent.model)
-	assert.Equal(t, GooseCLIModeApprove, agent.permissionMode)
+	assert.Equal(t, contracts.GooseModeApprove, agent.permissionMode)
 
 	recorded := requests()
 	require.Len(t, recorded, 2)
@@ -204,7 +255,7 @@ func TestGooseUpdateSettingsSendsLiveACPRequests(t *testing.T) {
 	assert.Equal(t, acpConfigOptionIDModel, recorded[0].Params["configId"])
 	assert.Equal(t, "fast-model", recorded[0].Params["value"])
 	assert.Equal(t, acpMethodSessionSetMode, recorded[1].Method)
-	assert.Equal(t, GooseCLIModeApprove, recorded[1].Params["modeId"])
+	assert.Equal(t, contracts.GooseModeApprove, recorded[1].Params["modeId"])
 }
 
 func TestGooseCancelSessionSendsACPMethod(t *testing.T) {
@@ -228,7 +279,7 @@ func TestGooseAvailableOptionGroupsFallsBack(t *testing.T) {
 	groups := agent.OptionGroups()
 	require.Len(t, groups, 1)
 	assert.Equal(t, "permissionMode", groups[0].GetId())
-	assert.Equal(t, GooseCLIModeSmartApprove, groups[0].GetOptions()[0].GetId())
+	assert.Equal(t, contracts.GooseModeSmartApprove, groups[0].GetOptions()[0].GetId())
 }
 
 func TestDefaultModel_GooseUsesEnvOverride(t *testing.T) {

--- a/backend/internal/worker/agent/goose_test.go
+++ b/backend/internal/worker/agent/goose_test.go
@@ -106,7 +106,15 @@ func TestStartGooseCLI_NewSessionHandshake(t *testing.T) {
 	for _, opt := range modeGroup.GetOptions() {
 		modeNames = append(modeNames, opt.GetName())
 	}
-	assert.Equal(t, []string{"Auto", "Approve", "Smart Approve", "Chat"}, modeNames)
+	assert.Equal(t, []string{"Smart Approve", "Auto", "Approve", "Chat"}, modeNames)
+}
+
+func TestFallbackGooseModesPutSmartApproveFirst(t *testing.T) {
+	t.Parallel()
+
+	modes := fallbackGooseCLIModes()
+	require.NotEmpty(t, modes)
+	assert.Equal(t, GooseCLIModeSmartApprove, modes[0].GetId())
 }
 
 func TestStartGooseCLI_LoadSessionUsesResumeID(t *testing.T) {
@@ -220,7 +228,7 @@ func TestGooseAvailableOptionGroupsFallsBack(t *testing.T) {
 	groups := agent.OptionGroups()
 	require.Len(t, groups, 1)
 	assert.Equal(t, "permissionMode", groups[0].GetId())
-	assert.Equal(t, GooseCLIModeAuto, groups[0].GetOptions()[0].GetId())
+	assert.Equal(t, GooseCLIModeSmartApprove, groups[0].GetOptions()[0].GetId())
 }
 
 func TestDefaultModel_GooseUsesEnvOverride(t *testing.T) {

--- a/backend/internal/worker/agent/options.go
+++ b/backend/internal/worker/agent/options.go
@@ -229,6 +229,9 @@ type optDef struct {
 	Default       bool
 	ContextWindow int64
 	SubGroups     []*leapmuxv1.AvailableOptionGroup
+	// Clears names the other option values this one settles as a side effect, so the
+	// picker can say so before the click. See AvailableOption.clears in the proto.
+	Clears []*leapmuxv1.OptionSideEffect
 }
 
 // selectGroup builds a mutable (user-writable) option group from option
@@ -243,6 +246,7 @@ func selectGroup(id, label string, order int32, current string, defs []optDef) *
 			Description:   d.Description,
 			ContextWindow: d.ContextWindow,
 			SubGroups:     d.SubGroups,
+			Clears:        d.Clears,
 		})
 		if d.Default {
 			def = d.Id

--- a/backend/internal/worker/agent/provider.go
+++ b/backend/internal/worker/agent/provider.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/leapmux/leapmux/generated/contracts"
+	"github.com/leapmux/leapmux/internal/util/optionmap"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/worker/todoevents"
@@ -78,6 +79,10 @@ type Provider interface {
 	// mode/approval policy -- the value stamped under the "permissionMode"
 	// option id when the agent carries no explicit selection.
 	DefaultPermissionMode() string
+	// ResolveOptionConflicts merges requested values over current values and
+	// resolves provider-specific conflicts. The service calls this before it
+	// writes the optimistic option map.
+	ResolveOptionConflicts(current, requested map[string]string) map[string]string
 	// PlanModePermissionMode returns the permission mode an APPROVED plan-mode
 	// transition of the given kind switches the agent to, when the user selected
 	// none in the approval banner.
@@ -294,6 +299,10 @@ func (noopProvider) ListStoredSessions(context.Context, StoredSessionQuery) ([]S
 }
 
 func (noopProvider) DefaultPermissionMode() string { return "" }
+
+func (noopProvider) ResolveOptionConflicts(current, requested map[string]string) map[string]string {
+	return optionmap.Map(current).Merge(requested)
+}
 
 // IsSelfDisplayingControlTool defaults to false: a provider that doesn't echo control
 // answers into its own transcript relies on the service layer's synthetic display row.
@@ -873,7 +882,8 @@ type acpProvider struct {
 	// read -- but each keeps it in a different place and shape, so the function
 	// lives in that provider's own file and is wired here at registration, the
 	// way validateAttachment already is. Nil lists nothing.
-	listStoredSessions func(ctx context.Context, q StoredSessionQuery) ([]StoredSession, error)
+	listStoredSessions     func(ctx context.Context, q StoredSessionQuery) ([]StoredSession, error)
+	resolveOptionConflicts func(current, requested map[string]string) map[string]string
 }
 
 // ListStoredSessions dispatches to the reader the registration supplied. The
@@ -900,12 +910,38 @@ func (p acpProvider) DefaultPermissionMode() string {
 	return p.defaultPermissionMode
 }
 
+func (p acpProvider) ResolveOptionConflicts(current, requested map[string]string) map[string]string {
+	if p.resolveOptionConflicts != nil {
+		return p.resolveOptionConflicts(current, requested)
+	}
+	return p.noopProvider.ResolveOptionConflicts(current, requested)
+}
+
+func resolveCopilotOptionConflicts(current, requested map[string]string) map[string]string {
+	resolved := optionmap.Map(current).Merge(requested)
+	assisted := contracts.CopilotPermissionGroupAssistedApproval
+	allowAll := contracts.CopilotPermissionGroupAllowAll
+	if resolved[assisted] != contracts.CopilotPermissionValueOn ||
+		resolved[allowAll] != contracts.CopilotPermissionValueOn {
+		return resolved
+	}
+
+	if requested[assisted] == contracts.CopilotPermissionValueOn {
+		resolved[allowAll] = contracts.CopilotPermissionValueOff
+	} else if requested[allowAll] == contracts.CopilotPermissionValueOn {
+		resolved[assisted] = contracts.CopilotPermissionValueOff
+	} else {
+		resolved[allowAll] = contracts.CopilotPermissionValueOff
+	}
+	return resolved
+}
+
 func init() {
 	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX, codexProvider{})
 	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, claudeProvider{})
 	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_PI, piProvider{})
 	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR, acpProvider{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR, defaultPermissionMode: CursorCLIModeAgent, listStoredSessions: cursorStoredSessions})
-	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT, acpProvider{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT, defaultPermissionMode: CopilotCLIModeAgent, listStoredSessions: copilotStoredSessions})
+	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT, acpProvider{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT, defaultPermissionMode: CopilotCLIModeAgent, listStoredSessions: copilotStoredSessions, resolveOptionConflicts: resolveCopilotOptionConflicts})
 	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_KILO, acpProvider{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_KILO, questionRequestContext: opencodeQuestionRequestContext, listStoredSessions: kiloStoredSessions})
 	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_OPENCODE, acpProvider{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_OPENCODE, questionRequestContext: opencodeQuestionRequestContext, listStoredSessions: opencodeStoredSessions})
 	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_GOOSE, acpProvider{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_GOOSE, defaultPermissionMode: GooseCLIModeAuto, listStoredSessions: gooseStoredSessions})

--- a/backend/internal/worker/agent/provider.go
+++ b/backend/internal/worker/agent/provider.go
@@ -75,14 +75,11 @@ type Provider interface {
 	// IsInterrupt reports whether raw input contains a provider interrupt
 	// frame. The normal frontend path uses the InterruptAgent RPC instead.
 	IsInterrupt(content string) bool
-	// DefaultPermissionMode returns the provider-native default permission
-	// mode/approval policy -- the value stamped under the "permissionMode"
-	// option id when the agent carries no explicit selection.
-	DefaultPermissionMode() string
 	// ResolveOptionConflicts merges requested values over current values and
-	// resolves provider-specific conflicts. The service calls this before it
-	// writes the optimistic option map.
-	ResolveOptionConflicts(current, requested map[string]string) map[string]string
+	// settles any pair of this provider's own option values that cannot hold at
+	// once. The service calls it before it writes the optimistic option map, on
+	// both the launch path and the settings-edit path.
+	ResolveOptionConflicts(current, requested optionmap.Map) optionmap.Map
 	// PlanModePermissionMode returns the permission mode an APPROVED plan-mode
 	// transition of the given kind switches the agent to, when the user selected
 	// none in the approval banner.
@@ -298,10 +295,10 @@ func (noopProvider) ListStoredSessions(context.Context, StoredSessionQuery) ([]S
 	return nil, nil
 }
 
-func (noopProvider) DefaultPermissionMode() string { return "" }
-
-func (noopProvider) ResolveOptionConflicts(current, requested map[string]string) map[string]string {
-	return optionmap.Map(current).Merge(requested)
+// ResolveOptionConflicts defaults to a plain merge: a provider whose option axes are
+// independent has no conflict to settle.
+func (noopProvider) ResolveOptionConflicts(current, requested optionmap.Map) optionmap.Map {
+	return current.Merge(requested)
 }
 
 // IsSelfDisplayingControlTool defaults to false: a provider that doesn't echo control
@@ -413,12 +410,20 @@ func IsInterruptRequest(provider leapmuxv1.AgentProvider, content string) bool {
 // PermissionModeOrDefault normalizes an empty permission mode to the
 // provider-native default. It also treats the historical DB schema default
 // "default" as unset for providers whose native default is different.
+// PermissionModeStoredSentinel is the literal an OLDER agents.options row can carry for a
+// provider that never had a mode named "default". It is a cross-provider DB value, so it
+// is spelled here and NOT as contracts.ClaudeModeDefault: that constant means Claude
+// Code's own Default mode, and reading it while deciding about a Codex or ZCode row would
+// claim Claude's vocabulary governs a provider that never used it. The two strings
+// coincide, and that coincidence is not a shared meaning.
+const PermissionModeStoredSentinel = "default"
+
 func PermissionModeOrDefault(provider leapmuxv1.AgentProvider, mode string) string {
-	defaultMode := ProviderFor(provider).DefaultPermissionMode()
+	defaultMode := FallbackPermissionMode(provider)
 	if mode == "" {
 		return defaultMode
 	}
-	if mode == PermissionModeDefault && defaultMode != "" && defaultMode != PermissionModeDefault {
+	if mode == PermissionModeStoredSentinel && defaultMode != "" && defaultMode != PermissionModeStoredSentinel {
 		return defaultMode
 	}
 	return mode
@@ -509,8 +514,6 @@ func (codexProvider) IsInterrupt(content string) bool {
 	}
 	return msg.Method == "turn/interrupt"
 }
-
-func (codexProvider) DefaultPermissionMode() string { return CodexDefaultApprovalPolicy }
 
 // Codex consumes control responses internally (only a serverRequest/resolved
 // metadata notification returns), so it never self-displays the answer.
@@ -625,8 +628,6 @@ func (claudeProvider) IsInterrupt(content string) bool {
 	return msg.Request.Subtype == "interrupt"
 }
 
-func (claudeProvider) DefaultPermissionMode() string { return PermissionModeDefault }
-
 // Claude re-emits AskUserQuestion / ExitPlanMode answers as a user-envelope
 // tool_result in its own transcript, so the rail marks that ingested row directly
 // (claudeUserEnvelopeMarkType) and no synthetic display row is persisted for them. The single
@@ -652,9 +653,9 @@ func (claudeProvider) PlanModeControl(toolName string) PlanModeControlKind {
 func (claudeProvider) PlanModePermissionMode(kind PlanModeControlKind) string {
 	switch kind {
 	case PlanModeControlEnter:
-		return PermissionModePlan
+		return contracts.ClaudeModePlan
 	case PlanModeControlExit:
-		return PermissionModeAcceptEdits
+		return contracts.ClaudeModeAcceptEdits
 	case PlanModeControlNone, PlanModeControlPrompt:
 		return ""
 	}
@@ -837,8 +838,6 @@ func (piProvider) IsInterrupt(content string) bool {
 	return msg.Type == "abort"
 }
 
-func (piProvider) DefaultPermissionMode() string { return "" }
-
 // Pi consumes extension_ui_response on stdin without echoing the answer to stdout,
 // so it never self-displays a control answer.
 func (piProvider) IsSelfDisplayingControlTool(string) bool { return false }
@@ -862,8 +861,7 @@ func (piProvider) PermissionModeFromRawInput(string) (string, bool) { return "",
 // the no-op embedding.
 type acpProvider struct {
 	noopProvider
-	provider              leapmuxv1.AgentProvider
-	defaultPermissionMode string
+	provider leapmuxv1.AgentProvider
 	// questionRequestContext prunes an OpenCode-protocol `question.asked` request to the minimal
 	// context persisted alongside the native answer (the question headers the frontend labels its
 	// values with). Non-nil ONLY for the ACP providers that speak that question protocol (OpenCode,
@@ -882,8 +880,13 @@ type acpProvider struct {
 	// read -- but each keeps it in a different place and shape, so the function
 	// lives in that provider's own file and is wired here at registration, the
 	// way validateAttachment already is. Nil lists nothing.
-	listStoredSessions     func(ctx context.Context, q StoredSessionQuery) ([]StoredSession, error)
-	resolveOptionConflicts func(current, requested map[string]string) map[string]string
+	listStoredSessions func(ctx context.Context, q StoredSessionQuery) ([]StoredSession, error)
+	// resolveOptionConflicts settles this provider's own mutually exclusive option
+	// values. Non-nil ONLY for Copilot, whose Assisted Approval and Allow All axes
+	// exclude each other; nil merges with no conflict rule. The rule reads that
+	// provider's own vocabulary, so the function lives in that provider's file and is
+	// wired here at registration, the way listStoredSessions above already is.
+	resolveOptionConflicts func(current, requested optionmap.Map) optionmap.Map
 }
 
 // ListStoredSessions dispatches to the reader the registration supplied. The
@@ -906,45 +909,22 @@ func (acpProvider) IsInterrupt(content string) bool {
 	return msg.Method == "session/cancel" || msg.Method == "cancel"
 }
 
-func (p acpProvider) DefaultPermissionMode() string {
-	return p.defaultPermissionMode
-}
-
-func (p acpProvider) ResolveOptionConflicts(current, requested map[string]string) map[string]string {
+func (p acpProvider) ResolveOptionConflicts(current, requested optionmap.Map) optionmap.Map {
 	if p.resolveOptionConflicts != nil {
 		return p.resolveOptionConflicts(current, requested)
 	}
 	return p.noopProvider.ResolveOptionConflicts(current, requested)
 }
 
-func resolveCopilotOptionConflicts(current, requested map[string]string) map[string]string {
-	resolved := optionmap.Map(current).Merge(requested)
-	assisted := contracts.CopilotPermissionGroupAssistedApproval
-	allowAll := contracts.CopilotPermissionGroupAllowAll
-	if resolved[assisted] != contracts.CopilotPermissionValueOn ||
-		resolved[allowAll] != contracts.CopilotPermissionValueOn {
-		return resolved
-	}
-
-	if requested[assisted] == contracts.CopilotPermissionValueOn {
-		resolved[allowAll] = contracts.CopilotPermissionValueOff
-	} else if requested[allowAll] == contracts.CopilotPermissionValueOn {
-		resolved[assisted] = contracts.CopilotPermissionValueOff
-	} else {
-		resolved[allowAll] = contracts.CopilotPermissionValueOff
-	}
-	return resolved
-}
-
 func init() {
 	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX, codexProvider{})
 	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, claudeProvider{})
 	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_PI, piProvider{})
-	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR, acpProvider{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR, defaultPermissionMode: CursorCLIModeAgent, listStoredSessions: cursorStoredSessions})
-	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT, acpProvider{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT, defaultPermissionMode: CopilotCLIModeAgent, listStoredSessions: copilotStoredSessions, resolveOptionConflicts: resolveCopilotOptionConflicts})
+	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR, acpProvider{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR, listStoredSessions: cursorStoredSessions})
+	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT, acpProvider{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT, listStoredSessions: copilotStoredSessions, resolveOptionConflicts: resolveCopilotOptionConflicts})
 	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_KILO, acpProvider{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_KILO, questionRequestContext: opencodeQuestionRequestContext, listStoredSessions: kiloStoredSessions})
 	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_OPENCODE, acpProvider{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_OPENCODE, questionRequestContext: opencodeQuestionRequestContext, listStoredSessions: opencodeStoredSessions})
-	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_GOOSE, acpProvider{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_GOOSE, defaultPermissionMode: GooseCLIModeAuto, listStoredSessions: gooseStoredSessions})
+	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_GOOSE, acpProvider{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_GOOSE, listStoredSessions: gooseStoredSessions})
 	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_REASONIX, acpProvider{provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_REASONIX, validateAttachment: reasonixValidateAttachment, listStoredSessions: reasonixStoredSessions})
 	RegisterProvider(leapmuxv1.AgentProvider_AGENT_PROVIDER_ZCODE, zcodeProvider{})
 }

--- a/backend/internal/worker/agent/provider_test.go
+++ b/backend/internal/worker/agent/provider_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/leapmux/leapmux/generated/contracts"
+	"github.com/leapmux/leapmux/internal/util/optionmap"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -18,36 +19,66 @@ func TestCopilotResolveOptionConflicts(t *testing.T) {
 	provider := ProviderFor(leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT)
 	cases := []struct {
 		name      string
-		current   map[string]string
-		requested map[string]string
-		want      map[string]string
+		current   optionmap.Map
+		requested optionmap.Map
+		want      optionmap.Map
 	}{
 		{
 			name:      "assisted approval disables allow all",
 			current:   map[string]string{contracts.CopilotPermissionGroupAllowAll: contracts.CopilotPermissionValueOn},
-			requested: map[string]string{contracts.CopilotPermissionGroupAssistedApproval: contracts.CopilotPermissionValueOn},
-			want: map[string]string{
+			requested: optionmap.Map{contracts.CopilotPermissionGroupAssistedApproval: contracts.CopilotPermissionValueOn},
+			want: optionmap.Map{
 				contracts.CopilotPermissionGroupAssistedApproval: contracts.CopilotPermissionValueOn,
 				contracts.CopilotPermissionGroupAllowAll:         contracts.CopilotPermissionValueOff,
 			},
 		},
 		{
-			name:      "allow all disables assisted approval",
+			// The reverse of the rule above does NOT hold. Clearing Assisted Approval takes
+			// a process restart, because that axis rides the launch flags, and a bypass
+			// click that restarts the CLI mid-turn is a worse answer than letting the
+			// broader permission win -- Allow All already supersedes it while both are on.
+			name:      "allow all leaves assisted approval alone",
 			current:   map[string]string{contracts.CopilotPermissionGroupAssistedApproval: contracts.CopilotPermissionValueOn},
-			requested: map[string]string{contracts.CopilotPermissionGroupAllowAll: contracts.CopilotPermissionValueOn},
-			want: map[string]string{
-				contracts.CopilotPermissionGroupAssistedApproval: contracts.CopilotPermissionValueOff,
+			requested: optionmap.Map{contracts.CopilotPermissionGroupAllowAll: contracts.CopilotPermissionValueOn},
+			want: optionmap.Map{
+				contracts.CopilotPermissionGroupAssistedApproval: contracts.CopilotPermissionValueOn,
 				contracts.CopilotPermissionGroupAllowAll:         contracts.CopilotPermissionValueOn,
 			},
 		},
 		{
 			name:    "assisted approval wins one conflicting request",
-			current: map[string]string{},
-			requested: map[string]string{
+			current: optionmap.Map{},
+			requested: optionmap.Map{
 				contracts.CopilotPermissionGroupAssistedApproval: contracts.CopilotPermissionValueOn,
 				contracts.CopilotPermissionGroupAllowAll:         contracts.CopilotPermissionValueOn,
 			},
-			want: map[string]string{
+			want: optionmap.Map{
+				contracts.CopilotPermissionGroupAssistedApproval: contracts.CopilotPermissionValueOn,
+				contracts.CopilotPermissionGroupAllowAll:         contracts.CopilotPermissionValueOff,
+			},
+		},
+		{
+			// The resolver runs on EVERY settings edit. A both-on state it never produced
+			// (a settings refresh folds the server's own Allow All in without passing
+			// through here) must survive an edit to an unrelated axis: turning a
+			// permission off during a model change is a change the user never asked for.
+			name: "an unrelated edit leaves a stored conflict alone",
+			current: optionmap.Map{
+				contracts.CopilotPermissionGroupAssistedApproval: contracts.CopilotPermissionValueOn,
+				contracts.CopilotPermissionGroupAllowAll:         contracts.CopilotPermissionValueOn,
+			},
+			requested: optionmap.Map{OptionIDModel: "gpt-5"},
+			want: optionmap.Map{
+				contracts.CopilotPermissionGroupAssistedApproval: contracts.CopilotPermissionValueOn,
+				contracts.CopilotPermissionGroupAllowAll:         contracts.CopilotPermissionValueOn,
+				OptionIDModel:                                    "gpt-5",
+			},
+		},
+		{
+			name:      "a non-conflicting request passes through",
+			current:   map[string]string{contracts.CopilotPermissionGroupAssistedApproval: contracts.CopilotPermissionValueOn},
+			requested: optionmap.Map{contracts.CopilotPermissionGroupAllowAll: contracts.CopilotPermissionValueOff},
+			want: optionmap.Map{
 				contracts.CopilotPermissionGroupAssistedApproval: contracts.CopilotPermissionValueOn,
 				contracts.CopilotPermissionGroupAllowAll:         contracts.CopilotPermissionValueOff,
 			},

--- a/backend/internal/worker/agent/provider_test.go
+++ b/backend/internal/worker/agent/provider_test.go
@@ -4,12 +4,62 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/leapmux/leapmux/generated/contracts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/util/agentlabels"
 )
+
+func TestCopilotResolveOptionConflicts(t *testing.T) {
+	t.Parallel()
+
+	provider := ProviderFor(leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT)
+	cases := []struct {
+		name      string
+		current   map[string]string
+		requested map[string]string
+		want      map[string]string
+	}{
+		{
+			name:      "assisted approval disables allow all",
+			current:   map[string]string{contracts.CopilotPermissionGroupAllowAll: contracts.CopilotPermissionValueOn},
+			requested: map[string]string{contracts.CopilotPermissionGroupAssistedApproval: contracts.CopilotPermissionValueOn},
+			want: map[string]string{
+				contracts.CopilotPermissionGroupAssistedApproval: contracts.CopilotPermissionValueOn,
+				contracts.CopilotPermissionGroupAllowAll:         contracts.CopilotPermissionValueOff,
+			},
+		},
+		{
+			name:      "allow all disables assisted approval",
+			current:   map[string]string{contracts.CopilotPermissionGroupAssistedApproval: contracts.CopilotPermissionValueOn},
+			requested: map[string]string{contracts.CopilotPermissionGroupAllowAll: contracts.CopilotPermissionValueOn},
+			want: map[string]string{
+				contracts.CopilotPermissionGroupAssistedApproval: contracts.CopilotPermissionValueOff,
+				contracts.CopilotPermissionGroupAllowAll:         contracts.CopilotPermissionValueOn,
+			},
+		},
+		{
+			name:    "assisted approval wins one conflicting request",
+			current: map[string]string{},
+			requested: map[string]string{
+				contracts.CopilotPermissionGroupAssistedApproval: contracts.CopilotPermissionValueOn,
+				contracts.CopilotPermissionGroupAllowAll:         contracts.CopilotPermissionValueOn,
+			},
+			want: map[string]string{
+				contracts.CopilotPermissionGroupAssistedApproval: contracts.CopilotPermissionValueOn,
+				contracts.CopilotPermissionGroupAllowAll:         contracts.CopilotPermissionValueOff,
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := provider.ResolveOptionConflicts(tc.current, tc.requested)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
 
 // Two handlers answer for the same tab, and they must agree about which CLI a
 // request means. OpenAgent spawns Claude Code for a request that omits the

--- a/backend/internal/worker/agent/zcode.go
+++ b/backend/internal/worker/agent/zcode.go
@@ -725,4 +725,8 @@ func init() {
 	// normalizer accepts a backslash spelling so a re-spelling is not read as a
 	// model switch.
 	setModelIDNormalizer(leapmuxv1.AgentProvider_AGENT_PROVIDER_ZCODE, normalizeZCodeModelID)
+	// ZCode ships no safe-mode preset; Build is the mode a session with none takes.
+	setPermissionDefaults(leapmuxv1.AgentProvider_AGENT_PROVIDER_ZCODE, PermissionDefaults{
+		Fallback: contracts.ZCodeDefaultMode,
+	})
 }

--- a/backend/internal/worker/agent/zcode_control_test.go
+++ b/backend/internal/worker/agent/zcode_control_test.go
@@ -951,7 +951,8 @@ func TestZCodeProvider_TheFalseCapabilitiesAreDeliberate(t *testing.T) {
 	assert.Empty(t, provider.SyntheticInterruptNotice())
 	_, ok := provider.PermissionModeFromRawInput(`{"mode":"yolo"}`)
 	assert.False(t, ok, "ZCode's mode changes ride session/setMode, never a raw stdin frame")
-	assert.Equal(t, contracts.ZCodeDefaultMode, provider.DefaultPermissionMode())
+	assert.Equal(t, contracts.ZCodeDefaultMode,
+		FallbackPermissionMode(leapmuxv1.AgentProvider_AGENT_PROVIDER_ZCODE))
 }
 
 func TestZCodeProvider_IsRegistered(t *testing.T) {

--- a/backend/internal/worker/agent/zcode_provider.go
+++ b/backend/internal/worker/agent/zcode_provider.go
@@ -61,6 +61,10 @@ func (zcodeProvider) IsInterrupt(content string) bool {
 // DefaultPermissionMode is ZCode's own default session mode.
 func (zcodeProvider) DefaultPermissionMode() string { return contracts.ZCodeDefaultMode }
 
+func (zcodeProvider) ResolveOptionConflicts(current, requested map[string]string) map[string]string {
+	return noopProvider{}.ResolveOptionConflicts(current, requested)
+}
+
 // IsSelfDisplayingControlTool is false: the app-server does not echo a control
 // answer into its event stream, so the service's synthetic answer row is the only
 // record of it.

--- a/backend/internal/worker/agent/zcode_provider.go
+++ b/backend/internal/worker/agent/zcode_provider.go
@@ -11,7 +11,12 @@ import (
 
 // zcodeProvider is the stateless wire-format plugin for ZCode. It answers the
 // questions the service layer asks without a running agent.
-type zcodeProvider struct{}
+// zcodeProvider embeds noopProvider for the interface defaults ZCode does not override,
+// the way every other provider does. The methods below state a ZCode-specific decision;
+// a default ZCode simply takes needs no method here.
+type zcodeProvider struct {
+	noopProvider
+}
 
 // Classify groups ZCode's consolidatable notifications.
 //
@@ -56,13 +61,6 @@ func (zcodeProvider) IsInterrupt(content string) bool {
 		return false
 	}
 	return msg.Method == ZCodeMethodSessionStop
-}
-
-// DefaultPermissionMode is ZCode's own default session mode.
-func (zcodeProvider) DefaultPermissionMode() string { return contracts.ZCodeDefaultMode }
-
-func (zcodeProvider) ResolveOptionConflicts(current, requested map[string]string) map[string]string {
-	return noopProvider{}.ResolveOptionConflicts(current, requested)
 }
 
 // IsSelfDisplayingControlTool is false: the app-server does not echo a control

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -141,7 +141,8 @@ func registerAgentHandlers(d registrar, svc *Service) {
 			// (model/effort/permissionMode/provider options), filled with provider
 			// defaults for any missing well-known and provider-specific ids.
 			requested := mergeOptions(nil, r.GetOptions())
-			options := resolveLaunchOptions(requested, agentProvider, r.GetAgentSessionId() != "")
+			launch := resolveLaunchOptions(requested, agentProvider, r.GetAgentSessionId() != "")
+			options := launch.Options
 			// Reject a spawn whose EXPLICITLY-requested permission mode isn't valid for the provider, so a
 			// typo'd --permission-mode fails fast with a clear error instead of reaching the provider and
 			// dying at startup (Claude fails startup on a bad set_permission_mode). Model and effort are
@@ -268,9 +269,7 @@ func registerAgentHandlers(d registrar, svc *Service) {
 			agentOpts := svc.baseAgentOptions(agentID, plan.PlannedWorkingDir, agentProvider)
 			agentOpts.ResumeSessionID = r.GetAgentSessionId()
 			agentOpts.Options = options
-			agentOpts.NewSessionDefaultOptionIDs = newSessionDefaultOptionIDs(
-				requested, agentProvider, r.GetAgentSessionId() != "",
-			)
+			agentOpts.NewSessionDefaultOptionIDs = launch.DefaultedIDs
 			agentOpts.ExtraEnv = remoteEnvs
 
 			agent.TraceStartupPhase(agentID, "before_response")
@@ -2062,12 +2061,19 @@ func (svc *Service) relaunchForStartupSettingsChange(agentID string, provider le
 	return active, true
 }
 
+// applyDBSettingsToAgentOptions overlays the row's stored settings onto launch options.
+// Every relaunch -- a settings restart, a clear-context, a cold start, a plan-execution
+// relaunch -- funnels through here, so this is also where the defaulted-id set is
+// rebuilt: it is derived from the OpenAgent request, which no relaunch has, and a stale
+// or absent set silently disables a provider's launch fallback (Copilot then fails every
+// restart on a CLI that rejects --assisted-approval).
 func applyDBSettingsToAgentOptions(opts agent.Options, dbAgent *db.Agent) agent.Options {
 	o := loadOptions(dbAgent.Options, dbAgent.AgentProvider)
 	if o[agent.OptionIDPermissionMode] == "" {
 		o[agent.OptionIDPermissionMode] = agent.PermissionModeOrDefault(dbAgent.AgentProvider, "")
 	}
 	opts.Options = o
+	opts.NewSessionDefaultOptionIDs = defaultSourcedOptionIDs(o, dbAgent.AgentProvider)
 	return opts
 }
 
@@ -2543,7 +2549,7 @@ func (svc *Service) sanitizeIncomingOptions(agentID string, provider leapmuxv1.A
 	catalog := svc.Agents.OptionGroups(agentID, provider, newModel)
 
 	accepted := svc.acceptExposedOptions(agentID, provider, incoming, catalog)
-	newOptions := OptionMap(agent.ProviderFor(provider).ResolveOptionConflicts(oldOptions, accepted))
+	newOptions := agent.ProviderFor(provider).ResolveOptionConflicts(oldOptions, accepted)
 	resetEffortToAutoIfUnsupported(provider, newOptions, catalog, oldModel, newModel, accepted[agent.OptionIDEffort])
 
 	// Stamp the provider's default permission mode only when it actually has one.
@@ -2634,6 +2640,7 @@ func (svc *Service) applySettingsViaRestart(dbAgent db.Agent, newOptions OptionM
 	agentOpts := svc.baseAgentOptions(agentID, dbAgent.WorkingDir, provider)
 	agentOpts.ResumeSessionID = resumeSessionID
 	agentOpts.Options = newOptions
+	agentOpts.NewSessionDefaultOptionIDs = defaultSourcedOptionIDs(newOptions, provider)
 
 	sink := svc.Output.NewSink(agentID, provider)
 

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -141,10 +141,7 @@ func registerAgentHandlers(d registrar, svc *Service) {
 			// (model/effort/permissionMode/provider options), filled with provider
 			// defaults for any missing well-known and provider-specific ids.
 			requested := mergeOptions(nil, r.GetOptions())
-			options := resolveProviderDefaults(requested, agentProvider)
-			if options[agent.OptionIDPermissionMode] == "" {
-				options[agent.OptionIDPermissionMode] = agent.PermissionModeOrDefault(agentProvider, "")
-			}
+			options := resolveLaunchOptions(requested, agentProvider, r.GetAgentSessionId() != "")
 			// Reject a spawn whose EXPLICITLY-requested permission mode isn't valid for the provider, so a
 			// typo'd --permission-mode fails fast with a clear error instead of reaching the provider and
 			// dying at startup (Claude fails startup on a bad set_permission_mode). Model and effort are
@@ -271,6 +268,9 @@ func registerAgentHandlers(d registrar, svc *Service) {
 			agentOpts := svc.baseAgentOptions(agentID, plan.PlannedWorkingDir, agentProvider)
 			agentOpts.ResumeSessionID = r.GetAgentSessionId()
 			agentOpts.Options = options
+			agentOpts.NewSessionDefaultOptionIDs = newSessionDefaultOptionIDs(
+				requested, agentProvider, r.GetAgentSessionId() != "",
+			)
 			agentOpts.ExtraEnv = remoteEnvs
 
 			agent.TraceStartupPhase(agentID, "before_response")
@@ -1040,7 +1040,7 @@ func registerAgentHandlers(d registrar, svc *Service) {
 			// confirmed settlements and keeps its optimistic value for unresolved axes.
 			sendProtoResponse(sender, &leapmuxv1.UpdateAgentSettingsResponse{
 				OptionSettlements: protoOptionSettlements(settingsResponseSettlements(
-					r.GetSettings().GetOptions(), newOptions, settledOptions, applyResult,
+					oldOptions, r.GetSettings().GetOptions(), newOptions, settledOptions, applyResult,
 				)),
 			})
 		})
@@ -2353,12 +2353,16 @@ func applyConfirmedSettlements(options OptionMap, result agent.SettingsApplyResu
 // settingsResponseSettlements returns each requested axis and each axis that
 // changed as a result of the request.
 func settingsResponseSettlements(
+	prior OptionMap,
 	requested map[string]string,
 	optimistic, settled OptionMap,
 	result agent.SettingsApplyResult,
 ) agent.OptionSettlements {
 	ids := make(map[string]struct{}, len(requested))
 	for id := range requested {
+		ids[id] = struct{}{}
+	}
+	for id := range optionsChangeDelta(prior, optimistic) {
 		ids[id] = struct{}{}
 	}
 	for id := range optionsChangeDelta(optimistic, settled) {
@@ -2539,7 +2543,7 @@ func (svc *Service) sanitizeIncomingOptions(agentID string, provider leapmuxv1.A
 	catalog := svc.Agents.OptionGroups(agentID, provider, newModel)
 
 	accepted := svc.acceptExposedOptions(agentID, provider, incoming, catalog)
-	newOptions := mergeOptions(oldOptions, accepted)
+	newOptions := OptionMap(agent.ProviderFor(provider).ResolveOptionConflicts(oldOptions, accepted))
 	resetEffortToAutoIfUnsupported(provider, newOptions, catalog, oldModel, newModel, accepted[agent.OptionIDEffort])
 
 	// Stamp the provider's default permission mode only when it actually has one.

--- a/backend/internal/worker/service/agent_settings_test.go
+++ b/backend/internal/worker/service/agent_settings_test.go
@@ -557,7 +557,7 @@ func TestUpdateAgentSettings_InheritedUnsupportedEffortResets(t *testing.T) {
 		Options: marshalOptions(map[string]string{
 			agent.OptionIDModel:          "sonnet",
 			agent.OptionIDEffort:         retiredEffort,
-			agent.OptionIDPermissionMode: agent.PermissionModeDefault,
+			agent.OptionIDPermissionMode: contracts.ClaudeModeDefault,
 		}),
 	}))
 	registerAgentWatch(svc, w.channelID, "agent-1", leapmuxv1.WatchMode_WATCH_MODE_FULL, w)
@@ -566,7 +566,7 @@ func TestUpdateAgentSettings_InheritedUnsupportedEffortResets(t *testing.T) {
 	// inherited via the merge, not explicitly sent.
 	dispatch(d, "UpdateAgentSettings", &leapmuxv1.UpdateAgentSettingsRequest{
 		AgentId:  "agent-1",
-		Settings: &leapmuxv1.AgentSettings{Options: map[string]string{agent.OptionIDPermissionMode: agent.PermissionModePlan}},
+		Settings: &leapmuxv1.AgentSettings{Options: map[string]string{agent.OptionIDPermissionMode: contracts.ClaudeModePlan}},
 	}, w)
 
 	require.Empty(t, w.errors)
@@ -575,7 +575,7 @@ func TestUpdateAgentSettings_InheritedUnsupportedEffortResets(t *testing.T) {
 	got := loadOptions(dbAgent.Options, leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)
 	assert.Equal(t, agent.EffortAuto, got[agent.OptionIDEffort],
 		"an inherited effort the unchanged model no longer offers resets to auto")
-	assert.Equal(t, agent.PermissionModePlan, got[agent.OptionIDPermissionMode],
+	assert.Equal(t, contracts.ClaudeModePlan, got[agent.OptionIDPermissionMode],
 		"the actual edit (permission mode) still applies")
 	assert.Equal(t, "sonnet", got[agent.OptionIDModel], "the model is unchanged")
 }
@@ -881,7 +881,7 @@ func TestUpdateAgentSettings_DropsForeignNonSecondaryAxes(t *testing.T) {
 		foreign  string
 	}{
 		{"effort against Cursor", leapmuxv1.AgentProvider_AGENT_PROVIDER_CURSOR, agent.OptionIDEffort},
-		{"allow_all against Claude", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, agent.CopilotConfigAllowAll},
+		{"allow_all against Claude", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, contracts.CopilotPermissionGroupAllowAll},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1876,6 +1876,49 @@ func TestSettingsResponseSettlements_ReportsConfirmedRemovalAndUnresolvedValue(t
 	assert.Equal(t, agent.OptionSettlementConfirmed, got["removed_option"].State)
 	assert.Nil(t, got["removed_option"].Value)
 	assert.Equal(t, agent.OptionSettlementUnresolved, got["service_tier"].State)
+}
+
+// Every RELAUNCH must carry the safe-default provenance, which only the OpenAgent request
+// knew. A restart that dropped it silently disabled Copilot's launch fallback, so a
+// stored Assisted Approval that the CLI refuses left the tab with no process on every
+// attempt -- and nothing said why.
+func TestApplySettingsViaRestartCarriesSafeDefaultProvenance(t *testing.T) {
+	ctx := context.Background()
+	svc, _, _ := setupTestService(t)
+	agentID := "copilot-restart-provenance"
+
+	stored := map[string]string{
+		// The value a new Copilot session receives, now replayed from the row.
+		contracts.CopilotPermissionGroupAssistedApproval: contracts.CopilotPermissionValueOn,
+		agent.OptionIDModel: "gpt-5",
+	}
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID:            agentID,
+		WorkingDir:    t.TempDir(),
+		HomeDir:       t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT,
+		Options:       marshalOptions(stored),
+	}))
+
+	launched := make(chan agent.Options, 1)
+	svc.startAgentFn = func(_ context.Context, opts agent.Options, _ agent.OutputSink) (map[string]string, error) {
+		launched <- opts
+		return opts.Options, nil
+	}
+
+	dbAgent, err := svc.Queries.GetAgentByID(ctx, agentID)
+	require.NoError(t, err)
+	svc.applySettingsViaRestart(dbAgent, OptionMap(stored))
+
+	select {
+	case opts := <-launched:
+		assert.True(t, opts.NewSessionDefaultOptionIDs[contracts.CopilotPermissionGroupAssistedApproval],
+			"a value still equal to the safe default keeps the provider's launch fallback armed")
+		assert.False(t, opts.NewSessionDefaultOptionIDs[agent.OptionIDModel],
+			"an axis with no safe default is never reported as default-sourced")
+	case <-time.After(5 * time.Second):
+		t.Fatal("the restart did not launch within 5 seconds")
+	}
 }
 
 func TestSettingsResponseSettlementsReportsIndirectCopilotConflict(t *testing.T) {

--- a/backend/internal/worker/service/agent_settings_test.go
+++ b/backend/internal/worker/service/agent_settings_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/leapmux/leapmux/generated/contracts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
@@ -1869,12 +1870,40 @@ func TestSettingsResponseSettlements_ReportsConfirmedRemovalAndUnresolvedValue(t
 		"service_tier":     "fast",
 	}
 
-	got := settingsResponseSettlements(requested, OptionMap(requested), settled, result)
+	got := settingsResponseSettlements(OptionMap(requested), requested, OptionMap(requested), settled, result)
 	assert.Equal(t, agent.OptionSettlementConfirmed, got["reasoning_effort"].State)
 	assert.Equal(t, confirmedValue, *got["reasoning_effort"].Value)
 	assert.Equal(t, agent.OptionSettlementConfirmed, got["removed_option"].State)
 	assert.Nil(t, got["removed_option"].Value)
 	assert.Equal(t, agent.OptionSettlementUnresolved, got["service_tier"].State)
+}
+
+func TestSettingsResponseSettlementsReportsIndirectCopilotConflict(t *testing.T) {
+	t.Parallel()
+
+	prior := OptionMap{
+		contracts.CopilotPermissionGroupAssistedApproval: contracts.CopilotPermissionValueOn,
+		contracts.CopilotPermissionGroupAllowAll:         contracts.CopilotPermissionValueOff,
+	}
+	optimistic := OptionMap{
+		contracts.CopilotPermissionGroupAssistedApproval: contracts.CopilotPermissionValueOff,
+		contracts.CopilotPermissionGroupAllowAll:         contracts.CopilotPermissionValueOn,
+	}
+	result := agent.SettingsApplyResult{
+		AppliedLive: true,
+		SurfacedOptions: map[string]string{
+			contracts.CopilotPermissionGroupAssistedApproval: contracts.CopilotPermissionValueOff,
+			contracts.CopilotPermissionGroupAllowAll:         contracts.CopilotPermissionValueOn,
+		},
+	}
+
+	got := settingsResponseSettlements(prior,
+		map[string]string{contracts.CopilotPermissionGroupAllowAll: contracts.CopilotPermissionValueOn},
+		optimistic, optimistic, result)
+	require.Contains(t, got, contracts.CopilotPermissionGroupAssistedApproval)
+	assert.Equal(t, contracts.CopilotPermissionValueOff,
+		*got[contracts.CopilotPermissionGroupAssistedApproval].Value)
+	require.Contains(t, got, contracts.CopilotPermissionGroupAllowAll)
 }
 
 // TestReportModelChange verifies the settings_changed notification reports a model

--- a/backend/internal/worker/service/control_response_test.go
+++ b/backend/internal/worker/service/control_response_test.go
@@ -1281,7 +1281,7 @@ func TestSendControlResponse_EnterPlanModeAllowTrimsRequestID(t *testing.T) {
 	dbAgent, err := svc.Queries.GetAgentByID(ctx, "agent-1")
 	require.NoError(t, err)
 	got := loadOptions(dbAgent.Options, leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)
-	assert.Equal(t, agent.PermissionModePlan, got[agent.OptionIDPermissionMode],
+	assert.Equal(t, contracts.ClaudeModePlan, got[agent.OptionIDPermissionMode],
 		"a whitespace-padded request_id must still apply the EnterPlanMode transition")
 }
 
@@ -1356,12 +1356,12 @@ func TestApplyControlResponsePlanModeMutations(t *testing.T) {
 	require.Equal(t, agent.PlanModeControlEnter, plan.resolution.PlanModeControl)
 
 	before := loadOptions(dbAgent.Options, leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)[agent.OptionIDPermissionMode]
-	require.NotEqual(t, agent.PermissionModePlan, before, "sanity: the agent is not already in plan mode")
+	require.NotEqual(t, contracts.ClaudeModePlan, before, "sanity: the agent is not already in plan mode")
 
 	svc.applyControlResponsePlanModeMutations("agent-1", dbAgent, plan)
 	dbAgent, err = svc.Queries.GetAgentByID(ctx, "agent-1")
 	require.NoError(t, err)
-	assert.Equal(t, agent.PermissionModePlan, loadOptions(dbAgent.Options, leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)[agent.OptionIDPermissionMode],
+	assert.Equal(t, contracts.ClaudeModePlan, loadOptions(dbAgent.Options, leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)[agent.OptionIDPermissionMode],
 		"an approved EnterPlanMode applies the plan-mode switch")
 
 	// A request-gone answer (no stored request to resolve the transition) mutates nothing.
@@ -1369,11 +1369,11 @@ func TestApplyControlResponsePlanModeMutations(t *testing.T) {
 	gonePlan := svc.buildControlResponsePlan("agent-1", dbAgent, content)
 	require.False(t, gonePlan.requestMeta.Loaded, "sanity: the request is gone")
 	// Reset to Default so a no-op is distinguishable from a re-applied Enter transition (which sets Plan).
-	dbAgent = svc.setAgentPermissionModeWithAgent(dbAgent, agent.PermissionModeDefault)
+	dbAgent = svc.setAgentPermissionModeWithAgent(dbAgent, contracts.ClaudeModeDefault)
 	svc.applyControlResponsePlanModeMutations("agent-1", dbAgent, gonePlan)
 	dbAgent, err = svc.Queries.GetAgentByID(ctx, "agent-1")
 	require.NoError(t, err)
-	assert.Equal(t, agent.PermissionModeDefault, loadOptions(dbAgent.Options, leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)[agent.OptionIDPermissionMode],
+	assert.Equal(t, contracts.ClaudeModeDefault, loadOptions(dbAgent.Options, leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)[agent.OptionIDPermissionMode],
 		"a request-gone answer resolves no transition, so it mutates nothing")
 }
 
@@ -1648,11 +1648,11 @@ func TestResolveTargetMode(t *testing.T) {
 	t.Parallel()
 
 	// The frontend's attached permission mode wins when present.
-	assert.Equal(t, agent.PermissionModePlan, resolveTargetMode(agent.PermissionModePlan, agent.PermissionModeDefault))
+	assert.Equal(t, contracts.ClaudeModePlan, resolveTargetMode(contracts.ClaudeModePlan, contracts.ClaudeModeDefault))
 	// Empty falls back to the caller's default -- the ONE thing the plan-prompt path
-	// (PermissionModeDefault) and the ExitPlanMode path (PermissionModeAcceptEdits) differ on.
-	assert.Equal(t, agent.PermissionModeDefault, resolveTargetMode("", agent.PermissionModeDefault))
-	assert.Equal(t, agent.PermissionModeAcceptEdits, resolveTargetMode("", agent.PermissionModeAcceptEdits))
+	// (contracts.ClaudeModeDefault) and the ExitPlanMode path (contracts.ClaudeModeAcceptEdits) differ on.
+	assert.Equal(t, contracts.ClaudeModeDefault, resolveTargetMode("", contracts.ClaudeModeDefault))
+	assert.Equal(t, contracts.ClaudeModeAcceptEdits, resolveTargetMode("", contracts.ClaudeModeAcceptEdits))
 }
 
 // TestPersistControlResponseRow_EmptyContentPersistsRowNotDropped pins the marshal-boundary
@@ -1914,7 +1914,7 @@ func TestProcessControlResponse(t *testing.T) {
 		}{
 			{
 				"claude", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
-				agent.ToolNameExitPlanMode, agent.PermissionModeAcceptEdits,
+				agent.ToolNameExitPlanMode, contracts.ClaudeModeAcceptEdits,
 			},
 			{
 				"zcode", leapmuxv1.AgentProvider_AGENT_PROVIDER_ZCODE,

--- a/backend/internal/worker/service/open_async_startup_test.go
+++ b/backend/internal/worker/service/open_async_startup_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/leapmux/leapmux/generated/contracts"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
@@ -226,12 +228,12 @@ func TestRelaunchForStartupSettingsChangeUsesInjectedStarter(t *testing.T) {
 	initialOptions := map[string]string{
 		agent.OptionIDModel:          "opus[1m]",
 		agent.OptionIDEffort:         "high",
-		agent.OptionIDPermissionMode: agent.PermissionModeDefault,
+		agent.OptionIDPermissionMode: contracts.ClaudeModeDefault,
 	}
 	relaunchOptions := map[string]string{
 		agent.OptionIDModel:          "sonnet",
 		agent.OptionIDEffort:         agent.EffortAuto,
-		agent.OptionIDPermissionMode: agent.PermissionModePlan,
+		agent.OptionIDPermissionMode: contracts.ClaudeModePlan,
 	}
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
 		ID:            agentID,
@@ -276,7 +278,7 @@ func TestRelaunchForStartupSettingsChangeUsesInjectedStarter(t *testing.T) {
 	got := loadOptions(stored.Options, provider)
 	assert.Equal(t, "sonnet", got[agent.OptionIDModel])
 	assert.Equal(t, agent.EffortAuto, got[agent.OptionIDEffort])
-	assert.Equal(t, agent.PermissionModePlan, got[agent.OptionIDPermissionMode])
+	assert.Equal(t, contracts.ClaudeModePlan, got[agent.OptionIDPermissionMode])
 }
 
 func TestOpenAgent_RawPermissionModeChangedDuringStartupSurvivesActiveBroadcast(t *testing.T) {
@@ -305,7 +307,7 @@ func TestOpenAgent_RawPermissionModeChangedDuringStartupSurvivesActiveBroadcast(
 			return nil, ctx.Err()
 		}
 		confirmed := opts.Options
-		confirmed[agent.OptionIDPermissionMode] = agent.PermissionModeDefault
+		confirmed[agent.OptionIDPermissionMode] = contracts.ClaudeModeDefault
 		return confirmed, nil
 	}
 
@@ -336,7 +338,7 @@ func TestOpenAgent_RawPermissionModeChangedDuringStartupSurvivesActiveBroadcast(
 
 	row, err := svc.Queries.GetAgentByID(ctx, agentID)
 	require.NoError(t, err)
-	require.Equal(t, agent.PermissionModePlan, loadOptions(row.Options, row.AgentProvider)[agent.OptionIDPermissionMode])
+	require.Equal(t, contracts.ClaudeModePlan, loadOptions(row.Options, row.AgentProvider)[agent.OptionIDPermissionMode])
 
 	wWatch := newTestWriter()
 	dispatch(d, "WatchEvents", &leapmuxv1.WatchEventsRequest{
@@ -369,11 +371,11 @@ func TestOpenAgent_RawPermissionModeChangedDuringStartupSurvivesActiveBroadcast(
 	}, 5*time.Second, 20*time.Millisecond, "expected ACTIVE broadcast after releasing startup")
 
 	require.NotNil(t, activeStatus)
-	assert.Equal(t, agent.PermissionModePlan, optionids.CurrentValue(activeStatus.GetOptionGroups(), agent.OptionIDPermissionMode))
+	assert.Equal(t, contracts.ClaudeModePlan, optionids.CurrentValue(activeStatus.GetOptionGroups(), agent.OptionIDPermissionMode))
 
 	row, err = svc.Queries.GetAgentByID(ctx, agentID)
 	require.NoError(t, err)
-	assert.Equal(t, agent.PermissionModePlan, loadOptions(row.Options, row.AgentProvider)[agent.OptionIDPermissionMode])
+	assert.Equal(t, contracts.ClaudeModePlan, loadOptions(row.Options, row.AgentProvider)[agent.OptionIDPermissionMode])
 }
 
 func TestPersistConfirmedAgentSettingsPreservesLatePermissionModeChange(t *testing.T) {
@@ -392,7 +394,7 @@ func TestPersistConfirmedAgentSettingsPreservesLatePermissionModeChange(t *testi
 		Options: marshalOptions(map[string]string{
 			agent.OptionIDModel:          "opus",
 			agent.OptionIDEffort:         "high",
-			agent.OptionIDPermissionMode: agent.PermissionModeDefault,
+			agent.OptionIDPermissionMode: contracts.ClaudeModeDefault,
 		}),
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
 		Resumed:       0,
@@ -403,7 +405,7 @@ func TestPersistConfirmedAgentSettingsPreservesLatePermissionModeChange(t *testi
 		Options: map[string]string{
 			agent.OptionIDModel:          "opus",
 			agent.OptionIDEffort:         "high",
-			agent.OptionIDPermissionMode: agent.PermissionModeDefault,
+			agent.OptionIDPermissionMode: contracts.ClaudeModeDefault,
 		},
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
 	}
@@ -421,7 +423,7 @@ func TestPersistConfirmedAgentSettingsPreservesLatePermissionModeChange(t *testi
 		Options: marshalOptions(map[string]string{
 			agent.OptionIDModel:          "opus",
 			agent.OptionIDEffort:         "high",
-			agent.OptionIDPermissionMode: agent.PermissionModePlan,
+			agent.OptionIDPermissionMode: contracts.ClaudeModePlan,
 		}),
 		ID: agentID,
 	}))
@@ -430,15 +432,15 @@ func TestPersistConfirmedAgentSettingsPreservesLatePermissionModeChange(t *testi
 		agentID,
 		snapRow.Options,
 		latestOpts,
-		map[string]string{agent.OptionIDPermissionMode: agent.PermissionModeDefault},
+		map[string]string{agent.OptionIDPermissionMode: contracts.ClaudeModeDefault},
 		snapRow.OptionGroups,
 	)
 	require.NoError(t, err)
-	assert.Equal(t, agent.PermissionModePlan, loadOptions(activeRow.Options, activeRow.AgentProvider)[agent.OptionIDPermissionMode])
+	assert.Equal(t, contracts.ClaudeModePlan, loadOptions(activeRow.Options, activeRow.AgentProvider)[agent.OptionIDPermissionMode])
 
 	row, err := svc.Queries.GetAgentByID(ctx, agentID)
 	require.NoError(t, err)
-	assert.Equal(t, agent.PermissionModePlan, loadOptions(row.Options, row.AgentProvider)[agent.OptionIDPermissionMode])
+	assert.Equal(t, contracts.ClaudeModePlan, loadOptions(row.Options, row.AgentProvider)[agent.OptionIDPermissionMode])
 }
 
 func TestPersistConfirmedAgentSettingsPreservesPreStartPermissionModeChange(t *testing.T) {
@@ -457,7 +459,7 @@ func TestPersistConfirmedAgentSettingsPreservesPreStartPermissionModeChange(t *t
 		Options: marshalOptions(map[string]string{
 			agent.OptionIDModel:          "opus",
 			agent.OptionIDEffort:         "high",
-			agent.OptionIDPermissionMode: agent.PermissionModePlan,
+			agent.OptionIDPermissionMode: contracts.ClaudeModePlan,
 		}),
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
 		Resumed:       0,
@@ -468,7 +470,7 @@ func TestPersistConfirmedAgentSettingsPreservesPreStartPermissionModeChange(t *t
 		Options: map[string]string{
 			agent.OptionIDModel:          "opus",
 			agent.OptionIDEffort:         "high",
-			agent.OptionIDPermissionMode: agent.PermissionModeDefault,
+			agent.OptionIDPermissionMode: contracts.ClaudeModeDefault,
 		},
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
 	}
@@ -478,12 +480,12 @@ func TestPersistConfirmedAgentSettingsPreservesPreStartPermissionModeChange(t *t
 	startedOpts.Options = map[string]string{
 		agent.OptionIDModel:          "opus",
 		agent.OptionIDEffort:         "high",
-		agent.OptionIDPermissionMode: agent.PermissionModePlan,
+		agent.OptionIDPermissionMode: contracts.ClaudeModePlan,
 	}
 	latestOpts := startedOpts
 
 	confirmed := confirmedSettingsPreservingStartupChanges(
-		map[string]string{agent.OptionIDPermissionMode: agent.PermissionModeDefault},
+		map[string]string{agent.OptionIDPermissionMode: contracts.ClaudeModeDefault},
 		initialOpts,
 		latestOpts,
 	)
@@ -497,11 +499,11 @@ func TestPersistConfirmedAgentSettingsPreservesPreStartPermissionModeChange(t *t
 		preRow.OptionGroups,
 	)
 	require.NoError(t, err)
-	assert.Equal(t, agent.PermissionModePlan, loadOptions(activeRow.Options, activeRow.AgentProvider)[agent.OptionIDPermissionMode])
+	assert.Equal(t, contracts.ClaudeModePlan, loadOptions(activeRow.Options, activeRow.AgentProvider)[agent.OptionIDPermissionMode])
 
 	row, err := svc.Queries.GetAgentByID(ctx, agentID)
 	require.NoError(t, err)
-	assert.Equal(t, agent.PermissionModePlan, loadOptions(row.Options, row.AgentProvider)[agent.OptionIDPermissionMode])
+	assert.Equal(t, contracts.ClaudeModePlan, loadOptions(row.Options, row.AgentProvider)[agent.OptionIDPermissionMode])
 }
 
 // TestPersistConfirmedAgentSettingsAppliesConfirmedModelDespiteOtherAxisChange
@@ -520,7 +522,7 @@ func TestPersistConfirmedAgentSettingsAppliesConfirmedModelDespiteOtherAxisChang
 		changedEffort   string
 		confirmedEffort string
 	}{
-		{name: "claude", provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, permissionMode: agent.PermissionModeDefault, resolvedModel: "claude-opus", initialEffort: "high", changedEffort: "low", confirmedEffort: "high"},
+		{name: "claude", provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, permissionMode: contracts.ClaudeModeDefault, resolvedModel: "claude-opus", initialEffort: "high", changedEffort: "low", confirmedEffort: "high"},
 		{name: "codex", provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX, permissionMode: agent.CodexDefaultApprovalPolicy, resolvedModel: "gpt-5.6-sol", initialEffort: agent.EffortAuto, changedEffort: "high", confirmedEffort: "low"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -612,7 +614,7 @@ func TestPersistConfirmedAgentSettings_AppliesConfirmedModelWhenColumnLacksDefau
 		Title: "cleared default axis",
 		Options: marshalOptions(map[string]string{
 			agent.OptionIDModel:          agent.DefaultModelSentinel,
-			agent.OptionIDPermissionMode: agent.PermissionModeDefault,
+			agent.OptionIDPermissionMode: contracts.ClaudeModeDefault,
 		}),
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
 	}))

--- a/backend/internal/worker/service/open_default_effort_test.go
+++ b/backend/internal/worker/service/open_default_effort_test.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"sync"
 	"testing"
 	"time"
 
@@ -15,6 +14,35 @@ import (
 	"github.com/leapmux/leapmux/internal/worker/agent"
 )
 
+// openAgentAndCapture dispatches OpenAgent and returns the launch options the service
+// handed startAgentFn. It fails the test when the RPC reports an error or the start never
+// runs, so a caller asserts on the options alone. The service and the response writer come
+// back for the cases that also read the response or the persisted row.
+//
+// Six tests in this file drove the same capture-and-await skeleton by hand, in two
+// spellings (a buffered channel, and a mutex plus a done channel). One helper is the only
+// way the timeout, the error check and the locking stay identical across them.
+func openAgentAndCapture(t *testing.T, req *leapmuxv1.OpenAgentRequest) (*Service, *testResponseWriter, agent.Options) {
+	t.Helper()
+	svc, d, w := setupTestService(t)
+	started := make(chan agent.Options, 1)
+	svc.startAgentFn = func(_ context.Context, opts agent.Options, _ agent.OutputSink) (map[string]string, error) {
+		started <- opts
+		return opts.Options, nil
+	}
+
+	dispatch(d, "OpenAgent", req, w)
+	require.Empty(t, w.errors, "OpenAgent should succeed")
+
+	select {
+	case opts := <-started:
+		return svc, w, opts
+	case <-time.After(5 * time.Second):
+		t.Fatal("startAgentFn did not run within 5 seconds")
+		return nil, nil, agent.Options{}
+	}
+}
+
 func TestOpenAgentAppliesSafePermissionDefaultsToNewSessions(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -24,7 +52,7 @@ func TestOpenAgentAppliesSafePermissionDefaultsToNewSessions(t *testing.T) {
 		{
 			name:     "claude auto",
 			provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
-			want:     map[string]string{agent.OptionIDPermissionMode: agent.PermissionModeAuto},
+			want:     map[string]string{agent.OptionIDPermissionMode: contracts.ClaudeModeAuto},
 		},
 		{
 			name:     "goose smart approve",
@@ -42,92 +70,70 @@ func TestOpenAgentAppliesSafePermissionDefaultsToNewSessions(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			svc, d, w := setupTestService(t)
-			started := make(chan agent.Options, 1)
-			svc.startAgentFn = func(_ context.Context, opts agent.Options, _ agent.OutputSink) (map[string]string, error) {
-				started <- opts
-				return opts.Options, nil
-			}
-
-			dispatch(d, "OpenAgent", &leapmuxv1.OpenAgentRequest{
+			_, _, opts := openAgentAndCapture(t, &leapmuxv1.OpenAgentRequest{
 				WorkingDir:    t.TempDir(),
 				AgentProvider: tc.provider,
-			}, w)
-			require.Empty(t, w.errors)
-
-			select {
-			case opts := <-started:
-				for id, value := range tc.want {
-					assert.Equal(t, value, opts.Get(id))
-				}
-			case <-time.After(5 * time.Second):
-				t.Fatal("startAgentFn did not run within 5 seconds")
+			})
+			for id, value := range tc.want {
+				assert.Equal(t, value, opts.Get(id))
 			}
 		})
 	}
 }
 
+// A resumed session receives no safe default: it keeps whatever it had, and falls back to
+// the PROVIDER's own default for an axis it never stored.
+//
+// The assertions are exact values rather than "not the safe value". Goose's provider
+// default and its safe default are the same mode, so a NotEqual could not tell "the safe
+// default was skipped" from "the safe default was applied", and it passed on the very
+// value this change exists to avoid -- Goose's earlier fallback was `auto`, which is the
+// mode Goose's own BYPASS preset selects.
+//
+// resolveLaunchOptions' own decision (a resumed request marks NO id) is asserted in
+// options_test.go. What reaches the provider here is the launch funnel's re-derivation
+// from the resulting values, which is all a later restart can read.
 func TestOpenAgentDoesNotApplySafePermissionDefaultsToResumedSessions(t *testing.T) {
 	cases := []struct {
-		name       string
-		provider   leapmuxv1.AgentProvider
-		safeOption string
-		safeValue  string
+		name        string
+		provider    leapmuxv1.AgentProvider
+		option      string
+		wantResumed string
+		// wantDefaulted is what the launch funnel derives from the resulting VALUE, which
+		// is the only thing a relaunch can read. It is true only where the provider's own
+		// fallback happens to equal its safe default.
+		wantDefaulted bool
 	}{
-		{"claude auto", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, agent.OptionIDPermissionMode, agent.PermissionModeAuto},
-		{"goose smart approve", leapmuxv1.AgentProvider_AGENT_PROVIDER_GOOSE, agent.OptionIDPermissionMode, contracts.GooseModeSmartApprove},
-		{"copilot assisted approval", leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT, contracts.CopilotPermissionGroupAssistedApproval, contracts.CopilotPermissionValueOn},
+		{"claude falls back to default", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, agent.OptionIDPermissionMode, contracts.ClaudeModeDefault, false},
+		{"goose falls back to smart approve, never its bypass mode", leapmuxv1.AgentProvider_AGENT_PROVIDER_GOOSE, agent.OptionIDPermissionMode, contracts.GooseModeSmartApprove, true},
+		{"copilot leaves assisted approval unset", leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT, contracts.CopilotPermissionGroupAssistedApproval, "", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			svc, d, w := setupTestService(t)
-			started := make(chan agent.Options, 1)
-			svc.startAgentFn = func(_ context.Context, opts agent.Options, _ agent.OutputSink) (map[string]string, error) {
-				started <- opts
-				return opts.Options, nil
-			}
-
-			dispatch(d, "OpenAgent", &leapmuxv1.OpenAgentRequest{
+			_, _, opts := openAgentAndCapture(t, &leapmuxv1.OpenAgentRequest{
 				WorkingDir:     t.TempDir(),
 				AgentProvider:  tc.provider,
 				AgentSessionId: "resume-session",
-			}, w)
-			require.Empty(t, w.errors)
-
-			select {
-			case opts := <-started:
-				assert.NotEqual(t, tc.safeValue, opts.Get(tc.safeOption))
-			case <-time.After(5 * time.Second):
-				t.Fatal("startAgentFn did not run within 5 seconds")
-			}
+			})
+			assert.Equal(t, tc.wantResumed, opts.Get(tc.option))
+			assert.Equal(t, tc.wantDefaulted, opts.NewSessionDefaultOptionIDs[tc.option])
 		})
 	}
 }
 
 func TestOpenAgentExplicitPermissionOptionsOverrideSafeDefaults(t *testing.T) {
-	svc, d, w := setupTestService(t)
-	started := make(chan agent.Options, 1)
-	svc.startAgentFn = func(_ context.Context, opts agent.Options, _ agent.OutputSink) (map[string]string, error) {
-		started <- opts
-		return opts.Options, nil
-	}
-
-	dispatch(d, "OpenAgent", &leapmuxv1.OpenAgentRequest{
+	_, _, opts := openAgentAndCapture(t, &leapmuxv1.OpenAgentRequest{
 		WorkingDir:    t.TempDir(),
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT,
 		Options: map[string]string{
 			contracts.CopilotPermissionGroupAllowAll: contracts.CopilotPermissionValueOn,
 		},
-	}, w)
-	require.Empty(t, w.errors)
-
-	select {
-	case opts := <-started:
-		assert.Equal(t, contracts.CopilotPermissionValueOn, opts.Get(contracts.CopilotPermissionGroupAllowAll))
-		assert.Equal(t, contracts.CopilotPermissionValueOff, opts.Get(contracts.CopilotPermissionGroupAssistedApproval))
-	case <-time.After(5 * time.Second):
-		t.Fatal("startAgentFn did not run within 5 seconds")
-	}
+	})
+	assert.Equal(t, contracts.CopilotPermissionValueOn, opts.Get(contracts.CopilotPermissionGroupAllowAll),
+		"the explicit request wins over the safe default")
+	// Requesting Allow All leaves Assisted Approval at its safe default: clearing that
+	// axis costs a process restart, and Allow All already supersedes it.
+	assert.Equal(t, contracts.CopilotPermissionValueOn, opts.Get(contracts.CopilotPermissionGroupAssistedApproval))
 }
 
 // TestOpenAgent_DefaultsEffortToAuto verifies that when the OpenAgent
@@ -136,37 +142,13 @@ func TestOpenAgentExplicitPermissionOptionsOverrideSafeDefaults(t *testing.T) {
 // LeapMux to a specific effort name that older CLIs may not recognize).
 func TestOpenAgent_DefaultsEffortToAuto(t *testing.T) {
 	ctx := context.Background()
-	svc, d, w := setupTestService(t)
-
-	var capturedMu sync.Mutex
-	var captured agent.Options
-	done := make(chan struct{})
-	svc.startAgentFn = func(_ context.Context, opts agent.Options, _ agent.OutputSink) (map[string]string, error) {
-		capturedMu.Lock()
-		captured = opts
-		capturedMu.Unlock()
-		close(done)
-		return map[string]string{}, nil
-	}
-
-	dispatch(d, "OpenAgent", &leapmuxv1.OpenAgentRequest{
+	svc, w, captured := openAgentAndCapture(t, &leapmuxv1.OpenAgentRequest{
 		WorkingDir:    t.TempDir(),
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
-	}, w)
-
-	require.Empty(t, w.errors, "OpenAgent should succeed")
+	})
 	require.Len(t, w.responses, 1)
 
-	select {
-	case <-done:
-	case <-time.After(5 * time.Second):
-		t.Fatal("startAgentFn not invoked within 5s")
-	}
-
-	capturedMu.Lock()
-	effort := captured.Effort()
-	capturedMu.Unlock()
-	assert.Equal(t, "auto", effort,
+	assert.Equal(t, "auto", captured.Effort(),
 		"agent.Options.Effort should default to \"auto\" (CLI picks its own default)")
 
 	var resp leapmuxv1.OpenAgentResponse
@@ -189,36 +171,11 @@ func TestOpenAgent_DefaultsEffortToAuto(t *testing.T) {
 func TestOpenAgent_RespectsEnvOverride(t *testing.T) {
 	t.Setenv("LEAPMUX_CLAUDE_DEFAULT_EFFORT", "high")
 
-	svc, d, w := setupTestService(t)
-
-	var capturedMu sync.Mutex
-	var captured agent.Options
-	done := make(chan struct{})
-	svc.startAgentFn = func(_ context.Context, opts agent.Options, _ agent.OutputSink) (map[string]string, error) {
-		capturedMu.Lock()
-		captured = opts
-		capturedMu.Unlock()
-		close(done)
-		return map[string]string{}, nil
-	}
-
-	dispatch(d, "OpenAgent", &leapmuxv1.OpenAgentRequest{
+	_, _, captured := openAgentAndCapture(t, &leapmuxv1.OpenAgentRequest{
 		WorkingDir:    t.TempDir(),
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
-	}, w)
-
-	require.Empty(t, w.errors, "OpenAgent should succeed")
-
-	select {
-	case <-done:
-	case <-time.After(5 * time.Second):
-		t.Fatal("startAgentFn not invoked within 5s")
-	}
-
-	capturedMu.Lock()
-	effort := captured.Effort()
-	capturedMu.Unlock()
-	assert.Equal(t, "high", effort,
+	})
+	assert.Equal(t, "high", captured.Effort(),
 		"env var LEAPMUX_CLAUDE_DEFAULT_EFFORT should override the \"auto\" default")
 }
 
@@ -228,36 +185,11 @@ func TestOpenAgent_RespectsEnvOverride(t *testing.T) {
 func TestOpenAgent_PreservesExplicitEffort(t *testing.T) {
 	t.Setenv("LEAPMUX_CLAUDE_DEFAULT_EFFORT", "high")
 
-	svc, d, w := setupTestService(t)
-
-	var capturedMu sync.Mutex
-	var captured agent.Options
-	done := make(chan struct{})
-	svc.startAgentFn = func(_ context.Context, opts agent.Options, _ agent.OutputSink) (map[string]string, error) {
-		capturedMu.Lock()
-		captured = opts
-		capturedMu.Unlock()
-		close(done)
-		return map[string]string{}, nil
-	}
-
-	dispatch(d, "OpenAgent", &leapmuxv1.OpenAgentRequest{
+	_, _, captured := openAgentAndCapture(t, &leapmuxv1.OpenAgentRequest{
 		WorkingDir:    t.TempDir(),
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
 		Options:       map[string]string{agent.OptionIDEffort: "medium"},
-	}, w)
-
-	require.Empty(t, w.errors, "OpenAgent should succeed")
-
-	select {
-	case <-done:
-	case <-time.After(5 * time.Second):
-		t.Fatal("startAgentFn not invoked within 5s")
-	}
-
-	capturedMu.Lock()
-	effort := captured.Effort()
-	capturedMu.Unlock()
-	assert.Equal(t, "medium", effort,
+	})
+	assert.Equal(t, "medium", captured.Effort(),
 		"explicit effort in OpenAgent request should win over env var override")
 }

--- a/backend/internal/worker/service/open_default_effort_test.go
+++ b/backend/internal/worker/service/open_default_effort_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/leapmux/leapmux/generated/contracts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
@@ -13,6 +14,121 @@ import (
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/worker/agent"
 )
+
+func TestOpenAgentAppliesSafePermissionDefaultsToNewSessions(t *testing.T) {
+	cases := []struct {
+		name     string
+		provider leapmuxv1.AgentProvider
+		want     map[string]string
+	}{
+		{
+			name:     "claude auto",
+			provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+			want:     map[string]string{agent.OptionIDPermissionMode: agent.PermissionModeAuto},
+		},
+		{
+			name:     "goose smart approve",
+			provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_GOOSE,
+			want:     map[string]string{agent.OptionIDPermissionMode: contracts.GooseModeSmartApprove},
+		},
+		{
+			name:     "copilot assisted approval",
+			provider: leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT,
+			want: map[string]string{
+				contracts.CopilotPermissionGroupAssistedApproval: contracts.CopilotPermissionValueOn,
+				contracts.CopilotPermissionGroupAllowAll:         contracts.CopilotPermissionValueOff,
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc, d, w := setupTestService(t)
+			started := make(chan agent.Options, 1)
+			svc.startAgentFn = func(_ context.Context, opts agent.Options, _ agent.OutputSink) (map[string]string, error) {
+				started <- opts
+				return opts.Options, nil
+			}
+
+			dispatch(d, "OpenAgent", &leapmuxv1.OpenAgentRequest{
+				WorkingDir:    t.TempDir(),
+				AgentProvider: tc.provider,
+			}, w)
+			require.Empty(t, w.errors)
+
+			select {
+			case opts := <-started:
+				for id, value := range tc.want {
+					assert.Equal(t, value, opts.Get(id))
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("startAgentFn did not run within 5 seconds")
+			}
+		})
+	}
+}
+
+func TestOpenAgentDoesNotApplySafePermissionDefaultsToResumedSessions(t *testing.T) {
+	cases := []struct {
+		name       string
+		provider   leapmuxv1.AgentProvider
+		safeOption string
+		safeValue  string
+	}{
+		{"claude auto", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, agent.OptionIDPermissionMode, agent.PermissionModeAuto},
+		{"goose smart approve", leapmuxv1.AgentProvider_AGENT_PROVIDER_GOOSE, agent.OptionIDPermissionMode, contracts.GooseModeSmartApprove},
+		{"copilot assisted approval", leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT, contracts.CopilotPermissionGroupAssistedApproval, contracts.CopilotPermissionValueOn},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc, d, w := setupTestService(t)
+			started := make(chan agent.Options, 1)
+			svc.startAgentFn = func(_ context.Context, opts agent.Options, _ agent.OutputSink) (map[string]string, error) {
+				started <- opts
+				return opts.Options, nil
+			}
+
+			dispatch(d, "OpenAgent", &leapmuxv1.OpenAgentRequest{
+				WorkingDir:     t.TempDir(),
+				AgentProvider:  tc.provider,
+				AgentSessionId: "resume-session",
+			}, w)
+			require.Empty(t, w.errors)
+
+			select {
+			case opts := <-started:
+				assert.NotEqual(t, tc.safeValue, opts.Get(tc.safeOption))
+			case <-time.After(5 * time.Second):
+				t.Fatal("startAgentFn did not run within 5 seconds")
+			}
+		})
+	}
+}
+
+func TestOpenAgentExplicitPermissionOptionsOverrideSafeDefaults(t *testing.T) {
+	svc, d, w := setupTestService(t)
+	started := make(chan agent.Options, 1)
+	svc.startAgentFn = func(_ context.Context, opts agent.Options, _ agent.OutputSink) (map[string]string, error) {
+		started <- opts
+		return opts.Options, nil
+	}
+
+	dispatch(d, "OpenAgent", &leapmuxv1.OpenAgentRequest{
+		WorkingDir:    t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT,
+		Options: map[string]string{
+			contracts.CopilotPermissionGroupAllowAll: contracts.CopilotPermissionValueOn,
+		},
+	}, w)
+	require.Empty(t, w.errors)
+
+	select {
+	case opts := <-started:
+		assert.Equal(t, contracts.CopilotPermissionValueOn, opts.Get(contracts.CopilotPermissionGroupAllowAll))
+		assert.Equal(t, contracts.CopilotPermissionValueOff, opts.Get(contracts.CopilotPermissionGroupAssistedApproval))
+	case <-time.After(5 * time.Second):
+		t.Fatal("startAgentFn did not run within 5 seconds")
+	}
+}
 
 // TestOpenAgent_DefaultsEffortToAuto verifies that when the OpenAgent
 // request omits the effort, the backend fills it in with the "auto"

--- a/backend/internal/worker/service/options.go
+++ b/backend/internal/worker/service/options.go
@@ -70,33 +70,61 @@ func resolveProviderDefaults(options OptionMap, provider leapmuxv1.AgentProvider
 	return out
 }
 
-// resolveNewAgentDefaults adds safe permission values only for a new session.
-// Explicit request values take precedence.
-func resolveNewAgentDefaults(options OptionMap, provider leapmuxv1.AgentProvider, resumed bool) OptionMap {
-	resolved := options.Clone()
-	for id := range newSessionDefaultOptionIDs(options, provider, resumed) {
-		resolved[id] = agent.NewAgentOptionDefaults(provider)[id]
-	}
-	return resolved
+// launchOptions is one launch decision in one value: the complete resolved option set,
+// and the ids whose value came from the new-session safe defaults rather than from the
+// request. The two travel together because a provider's launch fallback keys on the
+// second -- Copilot may downgrade Assisted Approval only when LeapMux, not the user,
+// chose it -- and deriving them apart let the set claim an id the conflict resolver had
+// since overwritten.
+type launchOptions struct {
+	Options OptionMap
+	// DefaultedIDs is never nil, so a caller can index it without a check.
+	DefaultedIDs map[string]bool
 }
 
-// resolveLaunchOptions fills all launch defaults and resolves provider conflicts.
-// The original request decides which explicit value wins against a safe default.
-func resolveLaunchOptions(options OptionMap, provider leapmuxv1.AgentProvider, resumed bool) OptionMap {
-	resolved := resolveProviderDefaults(resolveNewAgentDefaults(options, provider, resumed), provider)
+// resolveLaunchOptions fills every launch default and settles the provider's option
+// conflicts. An explicit request value always beats a safe default, and a safe default
+// applies only to a session opened without a resume handle.
+func resolveLaunchOptions(options OptionMap, provider leapmuxv1.AgentProvider, resumed bool) launchOptions {
+	safeDefaults := agent.NewAgentOptionDefaults(provider)
+	defaulted := map[string]bool{}
+	resolved := options.Clone()
+	if !resumed {
+		for id, value := range safeDefaults {
+			if options[id] == "" {
+				resolved[id] = value
+				defaulted[id] = true
+			}
+		}
+	}
+	resolved = resolveProviderDefaults(resolved, provider)
 	if resolved[agent.OptionIDPermissionMode] == "" {
 		resolved[agent.OptionIDPermissionMode] = agent.PermissionModeOrDefault(provider, "")
 	}
-	return OptionMap(agent.ProviderFor(provider).ResolveOptionConflicts(resolved, options))
+	resolved = agent.ProviderFor(provider).ResolveOptionConflicts(resolved, options)
+	// The conflict resolver can overwrite a safe default: a request for Copilot's Allow
+	// All turns Assisted Approval off. The id then no longer describes a defaulted
+	// value, so drop it -- a provider's launch fallback must not fire for a value the
+	// user's own request produced.
+	for id := range defaulted {
+		if resolved[id] != safeDefaults[id] {
+			delete(defaulted, id)
+		}
+	}
+	return launchOptions{Options: resolved, DefaultedIDs: defaulted}
 }
 
-func newSessionDefaultOptionIDs(options OptionMap, provider leapmuxv1.AgentProvider, resumed bool) map[string]bool {
-	if resumed {
-		return nil
-	}
+// defaultSourcedOptionIDs rebuilds the defaulted-id set from VALUES alone, for a launch
+// that replays a stored option map rather than a request -- a restart, a clear-context
+// relaunch, or a cold start. The agents.options column records what each axis IS, never
+// where it came from, so an explicitly chosen value that happens to equal the safe
+// default is indistinguishable here and counts as defaulted. That is deliberate: a
+// provider whose CLI cannot accept the value then degrades, instead of leaving the tab
+// with no process at all on every relaunch.
+func defaultSourcedOptionIDs(options OptionMap, provider leapmuxv1.AgentProvider) map[string]bool {
 	ids := map[string]bool{}
-	for id := range agent.NewAgentOptionDefaults(provider) {
-		if options[id] == "" {
+	for id, value := range agent.NewAgentOptionDefaults(provider) {
+		if options[id] == value {
 			ids[id] = true
 		}
 	}

--- a/backend/internal/worker/service/options.go
+++ b/backend/internal/worker/service/options.go
@@ -70,6 +70,39 @@ func resolveProviderDefaults(options OptionMap, provider leapmuxv1.AgentProvider
 	return out
 }
 
+// resolveNewAgentDefaults adds safe permission values only for a new session.
+// Explicit request values take precedence.
+func resolveNewAgentDefaults(options OptionMap, provider leapmuxv1.AgentProvider, resumed bool) OptionMap {
+	resolved := options.Clone()
+	for id := range newSessionDefaultOptionIDs(options, provider, resumed) {
+		resolved[id] = agent.NewAgentOptionDefaults(provider)[id]
+	}
+	return resolved
+}
+
+// resolveLaunchOptions fills all launch defaults and resolves provider conflicts.
+// The original request decides which explicit value wins against a safe default.
+func resolveLaunchOptions(options OptionMap, provider leapmuxv1.AgentProvider, resumed bool) OptionMap {
+	resolved := resolveProviderDefaults(resolveNewAgentDefaults(options, provider, resumed), provider)
+	if resolved[agent.OptionIDPermissionMode] == "" {
+		resolved[agent.OptionIDPermissionMode] = agent.PermissionModeOrDefault(provider, "")
+	}
+	return OptionMap(agent.ProviderFor(provider).ResolveOptionConflicts(resolved, options))
+}
+
+func newSessionDefaultOptionIDs(options OptionMap, provider leapmuxv1.AgentProvider, resumed bool) map[string]bool {
+	if resumed {
+		return nil
+	}
+	ids := map[string]bool{}
+	for id := range agent.NewAgentOptionDefaults(provider) {
+		if options[id] == "" {
+			ids[id] = true
+		}
+	}
+	return ids
+}
+
 // sortedOptionKeys returns the sorted union of keys across the given maps.
 func sortedOptionKeys(mapsToMerge ...OptionMap) []string {
 	keys := make(map[string]struct{})

--- a/backend/internal/worker/service/options_test.go
+++ b/backend/internal/worker/service/options_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"testing"
 
+	"github.com/leapmux/leapmux/generated/contracts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -70,6 +71,35 @@ func TestResolveProviderDefaults_CodexUsesAccountDefaultSentinel(t *testing.T) {
 
 	assert.Equal(t, agent.DefaultModelSentinel, codex[agent.OptionIDModel])
 	assert.Equal(t, agent.EffortAuto, codex[agent.OptionIDEffort])
+}
+
+func TestResolveNewAgentDefaultsAppliesOnlyToFreshSessions(t *testing.T) {
+	t.Parallel()
+
+	claude := leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE
+	fresh := resolveLaunchOptions(OptionMap{}, claude, false)
+	assert.Equal(t, agent.PermissionModeAuto, fresh[agent.OptionIDPermissionMode])
+
+	resumed := resolveLaunchOptions(OptionMap{}, claude, true)
+	assert.NotEqual(t, agent.PermissionModeAuto, resumed[agent.OptionIDPermissionMode])
+	assert.Empty(t, newSessionDefaultOptionIDs(OptionMap{}, claude, true))
+
+	explicit := resolveLaunchOptions(OptionMap{agent.OptionIDPermissionMode: agent.PermissionModeDefault}, claude, false)
+	assert.Equal(t, agent.PermissionModeDefault, explicit[agent.OptionIDPermissionMode])
+	assert.Empty(t, newSessionDefaultOptionIDs(
+		OptionMap{agent.OptionIDPermissionMode: agent.PermissionModeDefault}, claude, false,
+	))
+}
+
+func TestResolveNewAgentDefaultsHonorsExplicitCopilotAllowAll(t *testing.T) {
+	t.Parallel()
+
+	provider := leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT
+	got := resolveLaunchOptions(OptionMap{
+		contracts.CopilotPermissionGroupAllowAll: contracts.CopilotPermissionValueOn,
+	}, provider, false)
+	assert.Equal(t, contracts.CopilotPermissionValueOn, got[contracts.CopilotPermissionGroupAllowAll])
+	assert.Equal(t, contracts.CopilotPermissionValueOff, got[contracts.CopilotPermissionGroupAssistedApproval])
 }
 
 // TestOptionsChangeDelta pins the minimal-delta the settings-edit CAS persists: a changed or

--- a/backend/internal/worker/service/options_test.go
+++ b/backend/internal/worker/service/options_test.go
@@ -78,17 +78,29 @@ func TestResolveNewAgentDefaultsAppliesOnlyToFreshSessions(t *testing.T) {
 
 	claude := leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE
 	fresh := resolveLaunchOptions(OptionMap{}, claude, false)
-	assert.Equal(t, agent.PermissionModeAuto, fresh[agent.OptionIDPermissionMode])
+	assert.Equal(t, contracts.ClaudeModeAuto, fresh.Options[agent.OptionIDPermissionMode])
+	assert.True(t, fresh.DefaultedIDs[agent.OptionIDPermissionMode])
 
+	// A resumed session keeps the provider's own default, and Claude's is "default".
 	resumed := resolveLaunchOptions(OptionMap{}, claude, true)
-	assert.NotEqual(t, agent.PermissionModeAuto, resumed[agent.OptionIDPermissionMode])
-	assert.Empty(t, newSessionDefaultOptionIDs(OptionMap{}, claude, true))
+	assert.Equal(t, contracts.ClaudeModeDefault, resumed.Options[agent.OptionIDPermissionMode])
+	assert.Empty(t, resumed.DefaultedIDs)
 
-	explicit := resolveLaunchOptions(OptionMap{agent.OptionIDPermissionMode: agent.PermissionModeDefault}, claude, false)
-	assert.Equal(t, agent.PermissionModeDefault, explicit[agent.OptionIDPermissionMode])
-	assert.Empty(t, newSessionDefaultOptionIDs(
-		OptionMap{agent.OptionIDPermissionMode: agent.PermissionModeDefault}, claude, false,
-	))
+	explicit := resolveLaunchOptions(OptionMap{agent.OptionIDPermissionMode: contracts.ClaudeModeDefault}, claude, false)
+	assert.Equal(t, contracts.ClaudeModeDefault, explicit.Options[agent.OptionIDPermissionMode])
+	assert.Empty(t, explicit.DefaultedIDs)
+}
+
+// A resumed session must never fall back to a mode that IS the provider's bypass. Goose
+// declares auto as its bypass preset, so the resumed fallback has to be smart_approve.
+func TestResolveLaunchOptionsResumedGooseDoesNotFallBackToBypass(t *testing.T) {
+	t.Parallel()
+
+	goose := leapmuxv1.AgentProvider_AGENT_PROVIDER_GOOSE
+	resumed := resolveLaunchOptions(OptionMap{}, goose, true)
+	assert.Equal(t, contracts.GooseModeSmartApprove, resumed.Options[agent.OptionIDPermissionMode])
+	assert.NotEqual(t, contracts.GooseModeAuto, resumed.Options[agent.OptionIDPermissionMode])
+	assert.Empty(t, resumed.DefaultedIDs, "a resumed session receives no safe default")
 }
 
 func TestResolveNewAgentDefaultsHonorsExplicitCopilotAllowAll(t *testing.T) {
@@ -98,8 +110,56 @@ func TestResolveNewAgentDefaultsHonorsExplicitCopilotAllowAll(t *testing.T) {
 	got := resolveLaunchOptions(OptionMap{
 		contracts.CopilotPermissionGroupAllowAll: contracts.CopilotPermissionValueOn,
 	}, provider, false)
-	assert.Equal(t, contracts.CopilotPermissionValueOn, got[contracts.CopilotPermissionGroupAllowAll])
-	assert.Equal(t, contracts.CopilotPermissionValueOff, got[contracts.CopilotPermissionGroupAssistedApproval])
+	assert.Equal(t, contracts.CopilotPermissionValueOn, got.Options[contracts.CopilotPermissionGroupAllowAll],
+		"the explicit request is never overwritten")
+	// Requesting Allow All does NOT clear Assisted Approval: that axis rides the launch
+	// flags, so clearing it costs a restart, and Allow All already supersedes it while
+	// both are on. Only the reverse direction settles.
+	assert.Equal(t, contracts.CopilotPermissionValueOn, got.Options[contracts.CopilotPermissionGroupAssistedApproval])
+	assert.True(t, got.DefaultedIDs[contracts.CopilotPermissionGroupAssistedApproval],
+		"the safe default survived the resolver, so it is still default-sourced")
+	assert.False(t, got.DefaultedIDs[contracts.CopilotPermissionGroupAllowAll],
+		"an explicitly requested id is never default-sourced")
+}
+
+// The other direction DOES settle, and it drops the id from the defaulted set: an
+// Assisted Approval request overwrites the Allow All safe default, so a launch fallback
+// must not treat the result as a value LeapMux chose.
+func TestResolveLaunchOptionsAssistedApprovalRequestClearsAllowAll(t *testing.T) {
+	t.Parallel()
+
+	got := resolveLaunchOptions(OptionMap{
+		contracts.CopilotPermissionGroupAssistedApproval: contracts.CopilotPermissionValueOn,
+		contracts.CopilotPermissionGroupAllowAll:         contracts.CopilotPermissionValueOn,
+	}, leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT, false)
+	assert.Equal(t, contracts.CopilotPermissionValueOn, got.Options[contracts.CopilotPermissionGroupAssistedApproval])
+	assert.Equal(t, contracts.CopilotPermissionValueOff, got.Options[contracts.CopilotPermissionGroupAllowAll])
+	assert.Empty(t, got.DefaultedIDs, "both axes were requested, so neither is default-sourced")
+}
+
+// defaultSourcedOptionIDs is what every RELAUNCH uses, because a stored row carries no
+// record of the original request. It reports an id whose stored value still equals the
+// safe default, so a provider's launch fallback survives a restart.
+func TestDefaultSourcedOptionIDs(t *testing.T) {
+	t.Parallel()
+
+	copilot := leapmuxv1.AgentProvider_AGENT_PROVIDER_GITHUB_COPILOT
+	stored := OptionMap{
+		contracts.CopilotPermissionGroupAssistedApproval: contracts.CopilotPermissionValueOn,
+		contracts.CopilotPermissionGroupAllowAll:         contracts.CopilotPermissionValueOff,
+	}
+	assert.Equal(t, map[string]bool{
+		contracts.CopilotPermissionGroupAssistedApproval: true,
+		contracts.CopilotPermissionGroupAllowAll:         true,
+	}, defaultSourcedOptionIDs(stored, copilot))
+
+	edited := stored.Clone()
+	edited[contracts.CopilotPermissionGroupAllowAll] = contracts.CopilotPermissionValueOn
+	assert.False(t, defaultSourcedOptionIDs(edited, copilot)[contracts.CopilotPermissionGroupAllowAll],
+		"a value that differs from the safe default is not default-sourced")
+
+	assert.Empty(t, defaultSourcedOptionIDs(OptionMap{}, leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX),
+		"a provider with no safe defaults reports none")
 }
 
 // TestOptionsChangeDelta pins the minimal-delta the settings-edit CAS persists: a changed or

--- a/backend/internal/worker/service/output_cleanup_callsites_test.go
+++ b/backend/internal/worker/service/output_cleanup_callsites_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/leapmux/leapmux/generated/contracts"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -96,7 +98,7 @@ func TestInitiatePlanExecutionRestart_ClearsPendingControlRequests(t *testing.T)
 	dbAgent, err := svc.Queries.GetAgentByID(ctx, "agent-plan")
 	require.NoError(t, err)
 
-	svc.initiatePlanExecutionRestart("agent-plan", agent.PermissionModeDefault, dbAgent, "Execute the plan.")
+	svc.initiatePlanExecutionRestart("agent-plan", contracts.ClaudeModeDefault, dbAgent, "Execute the plan.")
 
 	assertControlRequestsCleared(t, ctx, svc, w, "agent-plan", requestID)
 }

--- a/contracts/claude-protocol.json
+++ b/contracts/claude-protocol.json
@@ -1,0 +1,12 @@
+{
+  "_readme": "Claude Code permission modes that both the Go provider and the TypeScript plugin use. Anthropic owns these wire values: the worker sends them in set_permission_mode, and the browser plugin builds its permission presets and its plan-mode toggle from the same strings. defaultMode is the mode a Claude session with no stored one falls back to; the mode a NEW session requests is Auto, and setNewAgentOptionDefaults in claude.go is that fact's one home.",
+  "modes": {
+    "Default": "default",
+    "Plan": "plan",
+    "AcceptEdits": "acceptEdits",
+    "BypassPermissions": "bypassPermissions",
+    "DontAsk": "dontAsk",
+    "Auto": "auto"
+  },
+  "defaultMode": "Default"
+}

--- a/contracts/claude-protocol.schema.json
+++ b/contracts/claude-protocol.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "claude-protocol.schema.json",
+  "title": "Claude Code permission mode vocabulary",
+  "description": "Every table is a map from the identifier both languages spell (PascalCase, so the Go constant and the TS key derive from one name) to the literal Claude Code sends. A table may never be empty: an empty one would emit an enum no dispatch can match, and the generator's own coverage check would have nothing to compare.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["_readme", "modes", "defaultMode"],
+  "$defs": {
+    "table": {
+      "type": "object",
+      "minProperties": 1,
+      "propertyNames": { "pattern": "^[A-Z][A-Za-z0-9]*$" },
+      "additionalProperties": { "type": "string", "minLength": 1 }
+    }
+  },
+  "properties": {
+    "_readme": { "type": "string", "minLength": 1 },
+    "modes": { "$ref": "#/$defs/table" },
+    "defaultMode": {
+      "description": "The key in `modes` a fresh Claude Code session falls back to. A key, not a literal, so it cannot name a mode the table does not carry -- the generator checks the membership.",
+      "type": "string",
+      "pattern": "^[A-Z][A-Za-z0-9]*$"
+    }
+  }
+}

--- a/contracts/copilot-permissions.json
+++ b/contracts/copilot-permissions.json
@@ -1,0 +1,11 @@
+{
+  "_readme": "Permission identifiers that both the Go worker and the TypeScript plugin use for GitHub Copilot. Assisted Approval is a LeapMux option backed by Copilot launch flags. Allow All is the config option that the Copilot Agent Client Protocol server reports. The values are the shared two-state vocabulary for both groups.",
+  "groups": {
+    "AssistedApproval": "copilot_assisted_approval",
+    "AllowAll": "allow_all"
+  },
+  "values": {
+    "Off": "off",
+    "On": "on"
+  }
+}

--- a/contracts/copilot-permissions.schema.json
+++ b/contracts/copilot-permissions.schema.json
@@ -2,28 +2,21 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "copilot-permissions.schema.json",
   "title": "GitHub Copilot permission identifiers",
+  "description": "Every table is a map from the identifier both languages spell (PascalCase, so the Go constant and the TS key derive from one name) to the literal on the wire. A table may never be empty: an empty one would emit an enum no dispatch can match, and the generator's own coverage check would have nothing to compare.",
   "type": "object",
   "additionalProperties": false,
   "required": ["_readme", "groups", "values"],
+  "$defs": {
+    "table": {
+      "type": "object",
+      "minProperties": 1,
+      "propertyNames": { "pattern": "^[A-Z][A-Za-z0-9]*$" },
+      "additionalProperties": { "type": "string", "minLength": 1 }
+    }
+  },
   "properties": {
     "_readme": { "type": "string", "minLength": 1 },
-    "groups": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["AssistedApproval", "AllowAll"],
-      "properties": {
-        "AssistedApproval": { "type": "string", "pattern": "^[A-Za-z][A-Za-z0-9_]*$" },
-        "AllowAll": { "type": "string", "pattern": "^[A-Za-z][A-Za-z0-9_]*$" }
-      }
-    },
-    "values": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["Off", "On"],
-      "properties": {
-        "Off": { "type": "string", "minLength": 1 },
-        "On": { "type": "string", "minLength": 1 }
-      }
-    }
+    "groups": { "$ref": "#/$defs/table" },
+    "values": { "$ref": "#/$defs/table" }
   }
 }

--- a/contracts/copilot-permissions.schema.json
+++ b/contracts/copilot-permissions.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "copilot-permissions.schema.json",
+  "title": "GitHub Copilot permission identifiers",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["_readme", "groups", "values"],
+  "properties": {
+    "_readme": { "type": "string", "minLength": 1 },
+    "groups": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["AssistedApproval", "AllowAll"],
+      "properties": {
+        "AssistedApproval": { "type": "string", "pattern": "^[A-Za-z][A-Za-z0-9_]*$" },
+        "AllowAll": { "type": "string", "pattern": "^[A-Za-z][A-Za-z0-9_]*$" }
+      }
+    },
+    "values": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["Off", "On"],
+      "properties": {
+        "Off": { "type": "string", "minLength": 1 },
+        "On": { "type": "string", "minLength": 1 }
+      }
+    }
+  }
+}

--- a/contracts/goose-protocol.json
+++ b/contracts/goose-protocol.json
@@ -1,9 +1,10 @@
 {
-  "_readme": "Goose permission modes that both the Go provider and the TypeScript plugin use. Goose owns these wire values. The order puts Smart Approve first because LeapMux presents it as the safe default for a new session.",
+  "_readme": "Goose permission modes that both the Go provider and the TypeScript plugin use. Goose owns these wire values. The key order carries no meaning: the Go provider decides the order it lists the modes in, and orderModesPreferredFirst applies it. defaultMode is the mode a session with no stored one falls back to; it is Smart Approve rather than Auto because Auto is the mode Goose's own bypass preset selects.",
   "modes": {
     "SmartApprove": "smart_approve",
     "Auto": "auto",
     "Approve": "approve",
     "Chat": "chat"
-  }
+  },
+  "defaultMode": "SmartApprove"
 }

--- a/contracts/goose-protocol.json
+++ b/contracts/goose-protocol.json
@@ -1,0 +1,9 @@
+{
+  "_readme": "Goose permission modes that both the Go provider and the TypeScript plugin use. Goose owns these wire values. The order puts Smart Approve first because LeapMux presents it as the safe default for a new session.",
+  "modes": {
+    "SmartApprove": "smart_approve",
+    "Auto": "auto",
+    "Approve": "approve",
+    "Chat": "chat"
+  }
+}

--- a/contracts/goose-protocol.schema.json
+++ b/contracts/goose-protocol.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "goose-protocol.schema.json",
+  "title": "Goose permission mode vocabulary",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["_readme", "modes"],
+  "properties": {
+    "_readme": { "type": "string", "minLength": 1 },
+    "modes": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["SmartApprove", "Auto", "Approve", "Chat"],
+      "properties": {
+        "SmartApprove": { "type": "string", "minLength": 1 },
+        "Auto": { "type": "string", "minLength": 1 },
+        "Approve": { "type": "string", "minLength": 1 },
+        "Chat": { "type": "string", "minLength": 1 }
+      }
+    }
+  }
+}

--- a/contracts/goose-protocol.schema.json
+++ b/contracts/goose-protocol.schema.json
@@ -2,21 +2,25 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "goose-protocol.schema.json",
   "title": "Goose permission mode vocabulary",
+  "description": "Every table is a map from the identifier both languages spell (PascalCase, so the Go constant and the TS key derive from one name) to the literal Goose sends. A table may never be empty: an empty one would emit an enum no dispatch can match, and the generator's own coverage check would have nothing to compare.",
   "type": "object",
   "additionalProperties": false,
-  "required": ["_readme", "modes"],
+  "required": ["_readme", "modes", "defaultMode"],
+  "$defs": {
+    "table": {
+      "type": "object",
+      "minProperties": 1,
+      "propertyNames": { "pattern": "^[A-Z][A-Za-z0-9]*$" },
+      "additionalProperties": { "type": "string", "minLength": 1 }
+    }
+  },
   "properties": {
     "_readme": { "type": "string", "minLength": 1 },
-    "modes": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["SmartApprove", "Auto", "Approve", "Chat"],
-      "properties": {
-        "SmartApprove": { "type": "string", "minLength": 1 },
-        "Auto": { "type": "string", "minLength": 1 },
-        "Approve": { "type": "string", "minLength": 1 },
-        "Chat": { "type": "string", "minLength": 1 }
-      }
+    "modes": { "$ref": "#/$defs/table" },
+    "defaultMode": {
+      "description": "The key in `modes` a fresh Goose session runs on. A key, not a literal, so it cannot name a mode the table does not carry -- the generator checks the membership.",
+      "type": "string",
+      "pattern": "^[A-Z][A-Za-z0-9]*$"
     }
   }
 }

--- a/frontend/src/components/chat/AgentEditorPanel.tsx
+++ b/frontend/src/components/chat/AgentEditorPanel.tsx
@@ -40,6 +40,7 @@ import { ControlRequestActions, ControlRequestContent } from './ControlRequestBa
 import { useControlResponseHandling } from './controlResponseHandling'
 import { MarkdownEditor } from './markdownEditor/MarkdownEditor'
 import { providerFor } from './providers/registry'
+import { permissionPresetAvailable } from './providerSettings'
 import {
   OPTION_ID_MODEL,
   optionGroup,
@@ -227,9 +228,9 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
   const currentOptionValues = () => optionValuesFromGroups(props.agent?.optionGroups)
   const bypass = createMemo<BypassController | undefined>(() => {
     const settings = props.agent?.agentProvider
-      ? providerFor(props.agent.agentProvider)?.bypassSettings
+      ? providerFor(props.agent.agentProvider)?.permissionPresets?.bypass
       : undefined
-    return settings && props.onSettingChange
+    return permissionPresetAvailable(settings, props.agent?.optionGroups) && props.onSettingChange
       ? { settings, apply: props.onSettingChange }
       : undefined
   })

--- a/frontend/src/components/chat/composer/ComposerPlusMenu.test.tsx
+++ b/frontend/src/components/chat/composer/ComposerPlusMenu.test.tsx
@@ -2,6 +2,7 @@ import type { AvailableOptionGroup } from '~/generated/proto/leapmux/v1/agent_pb
 import { cleanup, fireEvent, render, screen } from '@solidjs/testing-library'
 import { batch, createSignal } from 'solid-js'
 import { describe, expect, it, vi } from 'vitest'
+import { CODEX_BYPASS_SETTINGS } from '~/generated/contracts/codex-bypass'
 import { AgentProvider } from '~/generated/proto/leapmux/v1/agent_pb'
 import { popoverCard } from '~/styles/popover.css'
 import { stubBranchMenuActions } from '~/test-support/branchMenu'
@@ -35,6 +36,7 @@ function renderMenu(opts: {
   directory?: string
   homeDir?: string
   branchStats?: { added: number, deleted: number, untracked: number }
+  settingsDispatcher?: boolean
 } = {}) {
   const onSettingChange = vi.fn()
   const onAttachFile = vi.fn()
@@ -46,7 +48,7 @@ function renderMenu(opts: {
       optionGroups={opts.groups ?? []}
       optionValues={opts.values ?? {}}
       agentProvider={opts.provider}
-      onSettingChange={onSettingChange}
+      onSettingChange={opts.settingsDispatcher === false ? undefined : onSettingChange}
       onAttachFile={onAttachFile}
       canAttach={opts.canAttach ?? true}
       disabledReason={opts.disabledReason}
@@ -315,7 +317,7 @@ describe('composerPlusMenu', () => {
 
     expect(onSettingChange).toHaveBeenCalledTimes(1)
     const change = onSettingChange.mock.calls[0]![0] as { sets: Record<string, string> }
-    expect(Object.keys(change.sets).length).toBeGreaterThan(1)
+    expect(change).toEqual(CODEX_BYPASS_SETTINGS)
   })
 
   it('disables a provider action whose axes are already applied', () => {
@@ -388,6 +390,35 @@ describe('composerPlusMenu', () => {
     })
 
     expect(screen.getByTestId('composer-smart-permissions')).toBeDisabled()
+  })
+
+  it('keeps a multi-axis permission action enabled until every target is active', () => {
+    renderMenu({
+      provider: AgentProvider.CODEX,
+      groups: [
+        group('network_access', 'Network', 10, ['restricted', 'enabled']),
+        group('sandbox_policy', 'Sandbox', 20, ['workspace-write', 'danger-full-access']),
+        group('permissionMode', 'Approval', 30, ['on-request', 'never']),
+      ],
+      values: {
+        network_access: 'enabled',
+        sandbox_policy: 'danger-full-access',
+        permissionMode: 'on-request',
+      },
+    })
+
+    expect(screen.getByTestId('composer-bypass-permissions')).toBeEnabled()
+  })
+
+  it('disables permission actions when no settings dispatcher exists', () => {
+    renderMenu({
+      provider: AgentProvider.CLAUDE_CODE,
+      groups: [group('permissionMode', 'Permission Mode', 10, ['default', 'auto', 'bypassPermissions'])],
+      settingsDispatcher: false,
+    })
+
+    expect(screen.getByTestId('composer-smart-permissions')).toBeDisabled()
+    expect(screen.getByTestId('composer-bypass-permissions')).toBeDisabled()
   })
 
   it('disables attach during a control request, and says why', () => {

--- a/frontend/src/components/chat/composer/ComposerPlusMenu.test.tsx
+++ b/frontend/src/components/chat/composer/ComposerPlusMenu.test.tsx
@@ -78,6 +78,7 @@ describe('composerPlusMenu structure freeze', () => {
 
   function renderLive(sources: {
     groups: () => AvailableOptionGroup[]
+    provider?: AgentProvider
     branch?: () => string | undefined
     isWorktree?: () => boolean
   }) {
@@ -85,6 +86,7 @@ describe('composerPlusMenu structure freeze', () => {
       <ComposerPlusMenu
         optionGroups={sources.groups()}
         optionValues={{}}
+        agentProvider={sources.provider}
         onSettingChange={vi.fn()}
         onAttachFile={vi.fn()}
         canAttach
@@ -235,6 +237,24 @@ describe('composerPlusMenu structure freeze', () => {
 
     expect(rowIds(), 'the second push waits for the next open').toEqual(filled)
   })
+
+  it('disables a held permission action when its capability disappears', async () => {
+    const [groups, setGroups] = createSignal<AvailableOptionGroup[]>([
+      group('network_access', 'Network', 10, ['restricted', 'enabled']),
+      group('sandbox_policy', 'Sandbox', 20, ['workspace-write', 'danger-full-access']),
+      group('permissionMode', 'Approval', 30, ['on-request', 'never']),
+    ])
+    renderLive({ groups, provider: AgentProvider.CODEX })
+
+    await fireEvent.click(screen.getByTestId('composer-plus-trigger'))
+    const bypass = screen.getByTestId('composer-bypass-permissions')
+    expect(bypass).toBeEnabled()
+
+    setGroups([group('permissionMode', 'Approval', 30, ['on-request', 'never'])])
+    await Promise.resolve()
+
+    expect(bypass, 'the held row stays visible but cannot apply a stale preset').toBeDisabled()
+  })
 })
 
 /**
@@ -291,10 +311,7 @@ describe('composerPlusMenu', () => {
       ],
     })
 
-    const action = screen.getAllByRole('menuitem', { hidden: true })
-      .find(el => (el.textContent ?? '').toLowerCase().includes('bypass'))
-    expect(action).toBeDefined()
-    await fireEvent.click(action!)
+    await fireEvent.click(screen.getByTestId('composer-bypass-permissions'))
 
     expect(onSettingChange).toHaveBeenCalledTimes(1)
     const change = onSettingChange.mock.calls[0]![0] as { sets: Record<string, string> }
@@ -311,10 +328,66 @@ describe('composerPlusMenu', () => {
       ],
     })
 
-    const action = screen.getAllByRole('menuitem', { hidden: true })
-      .find(el => (el.textContent ?? '').toLowerCase().includes('bypass'))
+    const action = screen.getByTestId('composer-bypass-permissions')
     expect(action).toBeDisabled()
     expect(onSettingChange).not.toHaveBeenCalled()
+  })
+
+  it('shows smart immediately above bypass when both presets are usable', () => {
+    const { container } = renderMenu({
+      provider: AgentProvider.CLAUDE_CODE,
+      groups: [group('permissionMode', 'Permission Mode', 10, ['default', 'auto', 'bypassPermissions'])],
+    })
+
+    const actions = [...container.querySelectorAll('[data-testid="composer-smart-permissions"], [data-testid="composer-bypass-permissions"]')]
+    expect(actions.map(action => action.textContent)).toEqual(['Smart permissions', 'Bypass permissions'])
+  })
+
+  it('hides a permission action when one target group or value is unavailable', () => {
+    renderMenu({
+      provider: AgentProvider.CODEX,
+      groups: [
+        group('sandbox_policy', 'Sandbox', 20, ['workspace-write', 'danger-full-access']),
+        group('permissionMode', 'Approval', 30, ['on-request', 'never']),
+      ],
+    })
+
+    expect(screen.queryByTestId('composer-bypass-permissions')).toBeNull()
+
+    cleanup()
+    renderMenu({
+      provider: AgentProvider.CODEX,
+      groups: [
+        group('network_access', 'Network', 10, ['restricted']),
+        group('sandbox_policy', 'Sandbox', 20, ['workspace-write', 'danger-full-access']),
+        group('permissionMode', 'Approval', 30, ['on-request', 'never']),
+      ],
+    })
+
+    expect(screen.queryByTestId('composer-bypass-permissions')).toBeNull()
+  })
+
+  it('hides a permission action when a target group is read-only', () => {
+    renderMenu({
+      provider: AgentProvider.CLAUDE_CODE,
+      groups: [{
+        ...group('permissionMode', 'Permission Mode', 10, ['default', 'auto', 'bypassPermissions']),
+        mutable: false,
+      }],
+    })
+
+    expect(screen.queryByTestId('composer-smart-permissions')).toBeNull()
+    expect(screen.queryByTestId('composer-bypass-permissions')).toBeNull()
+  })
+
+  it('disables Smart permissions when all target values are active', () => {
+    renderMenu({
+      provider: AgentProvider.CLAUDE_CODE,
+      groups: [group('permissionMode', 'Permission Mode', 10, ['default', 'auto', 'bypassPermissions'])],
+      values: { permissionMode: 'auto' },
+    })
+
+    expect(screen.getByTestId('composer-smart-permissions')).toBeDisabled()
   })
 
   it('disables attach during a control request, and says why', () => {

--- a/frontend/src/components/chat/composer/ComposerPlusMenu.tsx
+++ b/frontend/src/components/chat/composer/ComposerPlusMenu.tsx
@@ -1,5 +1,5 @@
 import type { JSX } from 'solid-js'
-import type { ProviderSettingChangeHandler, ProviderSettingsAction } from '~/components/chat/providerSettings'
+import type { ProviderPermissionPreset, ProviderSettingChangeHandler } from '~/components/chat/providerSettings'
 import type { WorkingTreeInfo } from '~/components/common/WorkingTree'
 import type { BranchMenuActions } from '~/components/workspace/branchActions'
 import type { AgentProvider, AvailableOptionGroup } from '~/generated/proto/leapmux/v1/agent_pb'
@@ -9,6 +9,7 @@ import Paperclip from 'lucide-solid/icons/paperclip'
 import Plus from 'lucide-solid/icons/plus'
 import { createMemo, createSignal, For, Show } from 'solid-js'
 import { pluginFor } from '~/components/chat/providers/registry'
+import { permissionPresetAvailable } from '~/components/chat/providerSettings'
 import { hasOptions, resolvedCurrent } from '~/components/chat/settingsGroups'
 import { DropdownMenu, DropdownMenuCheckableItem } from '~/components/common/DropdownMenu'
 import { Icon } from '~/components/common/Icon'
@@ -29,7 +30,7 @@ export interface ComposerPlusMenuProps {
   optionGroups: AvailableOptionGroup[] | undefined
   /** Optimistic option-value map keyed by group id. */
   optionValues: Record<string, string>
-  /** Provider, used to resolve the mode axis label and declared actions. */
+  /** Provider, used to resolve the mode axis label and permission presets. */
   agentProvider?: AgentProvider
   /** Dispatch a settings change (any axis). Optional to match the panel's `onChange?`. */
   onSettingChange?: ProviderSettingChangeHandler
@@ -40,7 +41,7 @@ export interface ComposerPlusMenuProps {
   /**
    * Whether the composer accepts input at all (false for a non-steerable
    * subagent). Such a composer can neither send nor apply a settings change,
-   * so the settings submenus, the provider actions, and attach all honour it.
+   * so the settings submenus, the permission actions, and attach all honour it.
    * The view toggles below stay live: they are local preferences.
    */
   /**
@@ -120,7 +121,7 @@ function sortedGroups(groups: AvailableOptionGroup[] | undefined): AvailableOpti
  */
 interface MenuStructure {
   groupIds: string[]
-  actions: ProviderSettingsAction[]
+  permissionActions: PermissionAction[]
   branchName?: string
   /**
    * Frozen WITH the branch name, because it names the destructive item rather
@@ -145,12 +146,42 @@ interface MenuStructure {
 
 /** Whether `s` draws anything BETWEEN the attach item and the view toggles. */
 function hasMenuRows(s: MenuStructure): boolean {
-  return s.groupIds.length > 0 || !!s.branchName || !!s.agentInfo || s.actions.length > 0
+  return s.groupIds.length > 0 || !!s.branchName || !!s.agentInfo || s.permissionActions.length > 0
+}
+
+type PermissionActionKind = 'smart' | 'bypass'
+
+interface PermissionAction {
+  kind: PermissionActionKind
+  label: string
+  testId: string
+  preset: ProviderPermissionPreset
+}
+
+const PERMISSION_ACTIONS: ReadonlyArray<Omit<PermissionAction, 'preset'>> = [
+  { kind: 'smart', label: 'Smart permissions', testId: 'composer-smart-permissions' },
+  { kind: 'bypass', label: 'Bypass permissions', testId: 'composer-bypass-permissions' },
+]
+
+function permissionActionsFor(
+  provider: AgentProvider | undefined,
+  groups: AvailableOptionGroup[] | undefined,
+): PermissionAction[] {
+  const presets = pluginFor(provider)?.permissionPresets
+  if (!presets)
+    return []
+  const actions: PermissionAction[] = []
+  for (const action of PERMISSION_ACTIONS) {
+    const preset = presets[action.kind]
+    if (permissionPresetAvailable(preset, groups))
+      actions.push({ ...action, preset })
+  }
+  return actions
 }
 
 /**
  * The composer's `[+]` menu: attach file, settings (one submenu per option
- * group + provider actions), send-mode toggle, and status-bar toggle. This is
+ * group + permission actions), send-mode toggle, and status-bar toggle. This is
  * the single comprehensive settings surface — the status-bar chips are
  * quick-access shortcuts to the same groups via the same `onSettingChange`.
  */
@@ -162,8 +193,7 @@ export function ComposerPlusMenu(props: ComposerPlusMenuProps): JSX.Element {
     equals: shallowEqualArrays,
   })
 
-  // Provider-declared action buttons (e.g. Codex "Bypass permissions").
-  const liveActions = createMemo<ProviderSettingsAction[]>(() => pluginFor(props.agentProvider)?.settingsActions ?? [])
+  const livePermissionActions = createMemo(() => permissionActionsFor(props.agentProvider, props.optionGroups))
 
   const [open, setOpen] = createSignal(false)
 
@@ -171,7 +201,7 @@ export function ComposerPlusMenu(props: ComposerPlusMenuProps): JSX.Element {
    * Everything that decides WHICH ROWS EXIST, held still while the menu is open.
    *
    * The menu is drawn from live props, and a status push supplies groups, a
-   * branch, agent info and provider actions -- each of which inserts rows ABOVE
+   * branch, agent info and permission actions -- each of which inserts rows ABOVE
    * the two toggles at the bottom. A pointer already aimed at "Send with Enter"
    * then lands on whatever slid into its place, and one of those is a provider
    * action that applies a setting the moment the user clicks it.
@@ -210,7 +240,7 @@ export function ComposerPlusMenu(props: ComposerPlusMenuProps): JSX.Element {
     const branchActions = props.branchActions
     return {
       groupIds: liveGroupIds(),
-      actions: liveActions(),
+      permissionActions: livePermissionActions(),
       branchName: branchActions ? props.workingTree.name || undefined : undefined,
       isWorktree: props.workingTree.isWorktree,
       branchActions,
@@ -219,7 +249,7 @@ export function ComposerPlusMenu(props: ComposerPlusMenuProps): JSX.Element {
   })
 
   const groupIds = () => structure().groupIds
-  const actions = () => structure().actions
+  const permissionActions = () => structure().permissionActions
   const branchName = () => structure().branchName
   const agentInfo = () => structure().agentInfo
   /** The held facts of the branch submenu, or undefined when it draws none. */
@@ -231,7 +261,7 @@ export function ComposerPlusMenu(props: ComposerPlusMenuProps): JSX.Element {
   // Whether anything renders BETWEEN the attach item and the view toggles. Both
   // rules that fence that region are drawn only when it is non-empty: a fresh
   // tab before its first status push has no groups, no branch, no agent info and
-  // no provider actions, and two unconditional rules then landed side by side.
+  // no permission actions, and two unconditional rules then landed side by side.
   //
   // Derived from the HELD snapshot through the same predicate the freeze reads,
   // so the rules, the rows they fence, and the decision to hold them still
@@ -242,6 +272,11 @@ export function ComposerPlusMenu(props: ComposerPlusMenuProps): JSX.Element {
     if (props.disabledReason)
       return props.disabledReason
     return props.canAttach ? undefined : 'Attach is unavailable during a control request'
+  }
+
+  const permissionActionAvailable = (action: PermissionAction) => {
+    const currentPreset = pluginFor(props.agentProvider)?.permissionPresets?.[action.kind]
+    return currentPreset === action.preset && permissionPresetAvailable(currentPreset, props.optionGroups)
   }
 
   return (
@@ -379,17 +414,17 @@ export function ComposerPlusMenu(props: ComposerPlusMenuProps): JSX.Element {
         )}
       </Show>
 
-      <Show when={actions().length > 0}>
+      <Show when={permissionActions().length > 0}>
         <hr />
-        <For each={actions()}>
+        <For each={permissionActions()}>
           {action => (
             <button
               role="menuitem"
               data-testid={action.testId}
-              disabled={!!props.disabledReason || Object.entries(action.sets).every(
+              disabled={!!props.disabledReason || !permissionActionAvailable(action) || Object.entries(action.preset.sets).every(
                 ([k, v]) => resolvedCurrent(props.optionGroups, props.optionValues, k) === v,
               )}
-              onClick={() => props.onSettingChange?.({ sets: { ...action.sets } })}
+              onClick={() => props.onSettingChange?.({ sets: { ...action.preset.sets } })}
             >
               {action.label}
             </button>

--- a/frontend/src/components/chat/composer/ComposerPlusMenu.tsx
+++ b/frontend/src/components/chat/composer/ComposerPlusMenu.tsx
@@ -421,7 +421,7 @@ export function ComposerPlusMenu(props: ComposerPlusMenuProps): JSX.Element {
             <button
               role="menuitem"
               data-testid={action.testId}
-              disabled={!!props.disabledReason || !permissionActionAvailable(action) || Object.entries(action.preset.sets).every(
+              disabled={!props.onSettingChange || !!props.disabledReason || !permissionActionAvailable(action) || Object.entries(action.preset.sets).every(
                 ([k, v]) => resolvedCurrent(props.optionGroups, props.optionValues, k) === v,
               )}
               onClick={() => props.onSettingChange?.({ sets: { ...action.preset.sets } })}

--- a/frontend/src/components/chat/composer/ComposerPlusMenu.tsx
+++ b/frontend/src/components/chat/composer/ComposerPlusMenu.tsx
@@ -193,7 +193,14 @@ export function ComposerPlusMenu(props: ComposerPlusMenuProps): JSX.Element {
     equals: shallowEqualArrays,
   })
 
-  const livePermissionActions = createMemo(() => permissionActionsFor(props.agentProvider, props.optionGroups))
+  // `equals` for the same reason liveGroupIds carries one: a status push re-broadcasts
+  // the whole catalog, and permissionActionsFor allocates a fresh array of fresh objects
+  // every call. Without this, an identical catalog still produced a new value, the
+  // `structure` memo re-ran, and `For` destroyed and rebuilt both permission rows.
+  const livePermissionActions = createMemo(() => permissionActionsFor(props.agentProvider, props.optionGroups), undefined, {
+    equals: (a, b) => a.length === b.length
+      && a.every((action, i) => action.kind === b[i]!.kind && action.preset === b[i]!.preset),
+  })
 
   const [open, setOpen] = createSignal(false)
 

--- a/frontend/src/components/chat/composer/OptionGroupPopover.tsx
+++ b/frontend/src/components/chat/composer/OptionGroupPopover.tsx
@@ -4,7 +4,7 @@ import type { SettingsItem } from '~/components/chat/settingsGroups'
 import type { DropdownTriggerProps } from '~/components/common/DropdownMenu'
 import type { AvailableOptionGroup } from '~/generated/proto/leapmux/v1/agent_pb'
 import { createMemo, createSignal } from 'solid-js'
-import { optionGroup, resolvedCurrent } from '~/components/chat/settingsGroups'
+import { optionGroup, optionSideEffectText, resolvedCurrent } from '~/components/chat/settingsGroups'
 import { OptionGroupMenuItems } from '~/components/chat/settingsShared'
 import { DropdownMenu } from '~/components/common/DropdownMenu'
 import { shallowEqualArraysDeep } from '~/lib/shallowEqual'
@@ -89,7 +89,15 @@ export function OptionGroupPopover(props: OptionGroupPopoverProps): JSX.Element 
   const items = createMemo<SettingsItem[]>(
     () => {
       const g = group()
-      return g ? g.options.map(o => ({ label: o.name || o.id, value: o.id, tooltip: o.description || undefined })) : []
+      if (!g)
+        return []
+      // The side-effect sentence rides the tooltip rather than a fourth key, so the
+      // shallow comparator below stays exact on a 3-key literal.
+      return g.options.map((o) => {
+        const alsoSets = optionSideEffectText(props.optionGroups, o)
+        const tooltip = [o.description || undefined, alsoSets].filter(Boolean).join(' ')
+        return { label: o.name || o.id, value: o.id, tooltip: tooltip || undefined }
+      })
     },
     [],
     { equals: shallowEqualArraysDeep },

--- a/frontend/src/components/chat/controls/ExitPlanModeControl.test.tsx
+++ b/frontend/src/components/chat/controls/ExitPlanModeControl.test.tsx
@@ -107,6 +107,27 @@ describe('exitPlanModeActions', () => {
     expect(decoded.permissionMode).toBe('bypassPermissions')
   })
 
+  // A preset that switches some axis OTHER than the permission mode cannot be applied
+  // through this banner at all: the approval travels as one control response, and the
+  // only part of a preset that response can carry is the mode. Copilot's bypass sets
+  // `allow_all`, so the switch must not be drawn -- drawing it produced a checkbox that
+  // silently did nothing once the preset type stopped guaranteeing a permissionMode key.
+  it('draws no bypass switch for a preset that carries no permission mode', () => {
+    render(() => (
+      <ExitPlanModeActions
+        request={makeRequest('req-77', 'agent-7')}
+        askState={createAskQuestionState()}
+        onRespond={vi.fn().mockResolvedValue(undefined)}
+        hasEditorContent={false}
+        onTriggerSend={() => {}}
+        bypass={{ settings: { sets: { allow_all: 'on' } }, apply: vi.fn() }}
+      />
+    ))
+
+    expect(screen.queryByTestId('plan-bypass-permissions-checkbox')).toBeNull()
+    expect(screen.getByTestId('plan-clear-context-checkbox')).toBeInTheDocument()
+  })
+
   it('sends allow response without permissionMode for normal approve', () => {
     const onRespond = vi.fn().mockResolvedValue(undefined)
     const request = makeRequest('req-42', 'agent-5')

--- a/frontend/src/components/chat/controls/ExitPlanModeControl.tsx
+++ b/frontend/src/components/chat/controls/ExitPlanModeControl.tsx
@@ -95,7 +95,7 @@ export const ExitPlanModeActions: Component<ActionsProps> = (props) => {
       onSendFeedback={handleReject}
       negativeAction={{ label: 'Reject', testId: 'plan-reject-btn', onSelect: handleReject }}
       positiveAction={{ label: 'Approve', testId: 'plan-approve-btn', onSelect: handleApprove }}
-      switches={() => planApprovalSwitches(planApproval, props.bypass)}
+      switches={() => planApprovalSwitches(planApproval)}
     />
   )
 }

--- a/frontend/src/components/chat/controls/planApproval.ts
+++ b/frontend/src/components/chat/controls/planApproval.ts
@@ -4,6 +4,7 @@ import type { ActionsProps } from './types'
 import type { PermissionMode } from '~/utils/controlResponse'
 
 import { createMemo, createSignal } from 'solid-js'
+import { OPTION_ID_PERMISSION_MODE } from '~/components/chat/settingsGroups'
 import { computePercentage } from '~/components/chat/widgets/ContextUsageGrid'
 
 export interface PlanApprovalState {
@@ -12,6 +13,18 @@ export interface PlanApprovalState {
   bypassPermissions: Accessor<boolean>
   setBypassPermissions: (v: boolean) => void
   permissionMode: Accessor<PermissionMode | undefined>
+  /**
+   * The permission mode this provider's bypass preset selects, or undefined when the
+   * preset carries no permission mode at all.
+   *
+   * The approval travels as ONE control response, so the only part of a preset this
+   * banner can apply is the mode it puts in that response. A preset that switches some
+   * other axis (Copilot's bypass sets `allow_all`) cannot be applied here, and the
+   * switch is not drawn — rather than drawn and silently doing nothing, which is what
+   * a bare `sets.permissionMode` read produced once the preset type stopped
+   * guaranteeing that key.
+   */
+  bypassMode: Accessor<PermissionMode | undefined>
   contextPct: Accessor<number | null>
 }
 
@@ -23,13 +36,14 @@ export function createPlanApprovalState(props: Pick<ActionsProps, 'contextUsage'
     const pct = computePercentage(props.contextUsage, props.modelContextWindow, props.agentProvider)
     return pct !== null ? Math.round(pct) : null
   })
-  const permissionMode = () => bypassPermissions() ? props.bypass?.settings.sets.permissionMode : undefined
+  const bypassMode = () => props.bypass?.settings.sets[OPTION_ID_PERMISSION_MODE]
+  const permissionMode = () => bypassPermissions() ? bypassMode() : undefined
 
-  return { clearContext, setClearContext, bypassPermissions, setBypassPermissions, contextPct, permissionMode }
+  return { clearContext, setClearContext, bypassPermissions, setBypassPermissions, contextPct, permissionMode, bypassMode }
 }
 
 /** Builds the shared option list for a plan approval. */
-export function planApprovalSwitches(state: PlanApprovalState, bypass?: ActionsProps['bypass']): ControlRequestSwitch[] {
+export function planApprovalSwitches(state: PlanApprovalState): ControlRequestSwitch[] {
   return [
     {
       id: 'plan-clear-context-checkbox',
@@ -38,7 +52,7 @@ export function planApprovalSwitches(state: PlanApprovalState, bypass?: ActionsP
       onChange: state.setClearContext,
       suffix: state.contextPct() !== null ? ` (${state.contextPct()}%)` : undefined,
     },
-    ...(bypass
+    ...(state.bypassMode()
       ? [{
           id: 'plan-bypass-permissions-checkbox',
           label: 'Bypass Permissions',

--- a/frontend/src/components/chat/providerSettings.ts
+++ b/frontend/src/components/chat/providerSettings.ts
@@ -1,4 +1,5 @@
 import type { AvailableOptionGroup } from '~/generated/proto/leapmux/v1/agent_pb'
+import { optionGroup, valueValidForGroup } from './settingsGroups'
 
 /** One atomic change to one or more provider settings. */
 export interface ProviderSettingChange {
@@ -7,10 +8,17 @@ export interface ProviderSettingChange {
 
 export type ProviderSettingChangeHandler = (change: ProviderSettingChange) => void | Promise<void>
 
-/** One provider-native permission preset. */
-export interface ProviderPermissionPreset extends ProviderSettingChange {
-  sets: Record<string, string>
-}
+/**
+ * One provider-native permission preset: the complete settings change that selects it.
+ *
+ * A preset names whatever axes ITS provider needs, and nothing more — Claude switches
+ * one permission mode, Codex switches network, sandbox and approval together, and
+ * Copilot switches an axis that is not the permission mode at all. So no key is
+ * guaranteed, and a consumer that needs a specific one must check for it (see
+ * `./controls/planApproval`, which draws its switch only for a preset that carries a
+ * permission mode).
+ */
+export type ProviderPermissionPreset = ProviderSettingChange
 
 /** The standard permission presets that a provider can offer. */
 export interface ProviderPermissionPresets {
@@ -35,6 +43,6 @@ export function permissionPresetAvailable(
   if (entries.length === 0)
     return false
   return entries.every(([groupId, value]) =>
-    groups?.some(group => group.id === groupId && group.mutable && group.options.some(option => option.id === value)) ?? false,
+    !!optionGroup(groups, groupId)?.mutable && valueValidForGroup(groups, groupId, value),
   )
 }

--- a/frontend/src/components/chat/providerSettings.ts
+++ b/frontend/src/components/chat/providerSettings.ts
@@ -1,4 +1,4 @@
-import type { PermissionMode } from '~/utils/controlResponse'
+import type { AvailableOptionGroup } from '~/generated/proto/leapmux/v1/agent_pb'
 
 /** One atomic change to one or more provider settings. */
 export interface ProviderSettingChange {
@@ -7,20 +7,34 @@ export interface ProviderSettingChange {
 
 export type ProviderSettingChangeHandler = (change: ProviderSettingChange) => void | Promise<void>
 
-/** The complete settings change that disables a provider's permission prompts. */
-export interface ProviderBypassSettings extends ProviderSettingChange {
-  sets: { permissionMode: PermissionMode } & Record<string, string>
+/** One provider-native permission preset. */
+export interface ProviderPermissionPreset extends ProviderSettingChange {
+  sets: Record<string, string>
+}
+
+/** The standard permission presets that a provider can offer. */
+export interface ProviderPermissionPresets {
+  smart?: ProviderPermissionPreset
+  bypass?: ProviderPermissionPreset
 }
 
 /** A usable bypass action. The UI receives it only when both parts exist. */
 export interface BypassController {
-  settings: ProviderBypassSettings
+  settings: ProviderPermissionPreset
   apply: ProviderSettingChangeHandler
 }
 
-/** A provider action that applies several settings together. */
-export interface ProviderSettingsAction {
-  label: string
-  testId: string
-  sets: Record<string, string>
+/** Reports whether the catalog offers every group and value in a preset. */
+export function permissionPresetAvailable(
+  preset: ProviderPermissionPreset | undefined,
+  groups: AvailableOptionGroup[] | undefined,
+): preset is ProviderPermissionPreset {
+  if (!preset)
+    return false
+  const entries = Object.entries(preset.sets)
+  if (entries.length === 0)
+    return false
+  return entries.every(([groupId, value]) =>
+    groups?.some(group => group.id === groupId && group.mutable && group.options.some(option => option.id === value)) ?? false,
+  )
 }

--- a/frontend/src/components/chat/providers/acp/registerACPProvider.ts
+++ b/frontend/src/components/chat/providers/acp/registerACPProvider.ts
@@ -1,7 +1,7 @@
 import type { Component } from 'solid-js'
 import type { ActionsProps, ContentProps } from '../../controls/types'
 import type { MessageCategory } from '../../messageClassification'
-import type { ProviderBypassSettings } from '../../providerSettings'
+import type { ProviderPermissionPresets } from '../../providerSettings'
 import type { AttachmentCapabilities, Provider, ProviderAskUserQuestion } from '../registry'
 import type { AgentProvider } from '~/generated/proto/leapmux/v1/agent_pb'
 import type { PermissionMode } from '~/utils/controlResponse'
@@ -65,8 +65,8 @@ export interface ACPProviderOptions {
    * Omit to disable plan-mode wiring (e.g. Goose has no plan mode).
    */
   planValue?: string
-  /** Complete settings change for the Bypass Permissions switch. */
-  bypassSettings?: ProviderBypassSettings
+  /** Provider-native presets for standard permission actions. */
+  permissionPresets?: ProviderPermissionPresets
   /** Question-handling hooks for providers that override the default ACP path. */
   questionHandling?: ACPQuestionHandling
   /**
@@ -161,8 +161,8 @@ export function registerACPProvider(opts: ACPProviderOptions): void {
     ControlActions: opts.ControlActions ?? ACPControlActions,
   }
 
-  if (opts.bypassSettings !== undefined)
-    plugin.bypassSettings = opts.bypassSettings
+  if (opts.permissionPresets !== undefined)
+    plugin.permissionPresets = opts.permissionPresets
   if (opts.planValue !== undefined)
     plugin.planMode = planModeFromConfig(sc, opts.planValue)
   const triggerModeGroupKey = triggerModeGroupKeyForConfig(sc)

--- a/frontend/src/components/chat/providers/claude/plugin.test.ts
+++ b/frontend/src/components/chat/providers/claude/plugin.test.ts
@@ -7,6 +7,17 @@ import { input } from '../testUtils'
 // Side-effect import to register the Claude plugin.
 import './plugin'
 
+describe('claude permission presets', () => {
+  const plugin = providerFor(AgentProvider.CLAUDE_CODE)!
+
+  it('maps smart and bypass permissions to Claude modes', () => {
+    expect(plugin.permissionPresets).toEqual({
+      smart: { sets: { permissionMode: 'auto' } },
+      bypass: { sets: { permissionMode: 'bypassPermissions' } },
+    })
+  })
+})
+
 describe('claude clearsThinkingTokensForMessage', () => {
   const plugin = providerFor(AgentProvider.CLAUDE_CODE)!
 

--- a/frontend/src/components/chat/providers/claude/plugin.tsx
+++ b/frontend/src/components/chat/providers/claude/plugin.tsx
@@ -366,7 +366,10 @@ function claudeContextUsageFromMessage(parsed: ParsedMessageContent): ContextUsa
 }
 
 const claudeCodePlugin: Provider = {
-  bypassSettings: { sets: { permissionMode: 'bypassPermissions' } },
+  permissionPresets: {
+    smart: { sets: { permissionMode: 'auto' } },
+    bypass: { sets: { permissionMode: 'bypassPermissions' } },
+  },
   contextBufferPct: CLAUDE_AUTOCOMPACT_BUFFER_PCT,
   attachments: {
     text: true,

--- a/frontend/src/components/chat/providers/claude/plugin.tsx
+++ b/frontend/src/components/chat/providers/claude/plugin.tsx
@@ -3,6 +3,7 @@ import type { MessageCategory } from '../../messageClassification'
 import type { ClassificationContext, ClassificationInput, Provider, SpanRole } from '../registry'
 import type { ParsedMessageContent } from '~/lib/messageParser'
 import type { ContextUsageInfo, RateLimitInfo } from '~/stores/agentSession.store'
+import { CLAUDE_DEFAULT_MODE, CLAUDE_MODE } from '~/generated/contracts/claude-protocol'
 import { NOTIFICATION_TYPE } from '~/generated/contracts/worker-vocab'
 import { AgentProvider } from '~/generated/proto/leapmux/v1/agent_pb'
 import { getMessageContent, joinContentParagraphs } from '~/lib/contentBlocks'
@@ -367,8 +368,8 @@ function claudeContextUsageFromMessage(parsed: ParsedMessageContent): ContextUsa
 
 const claudeCodePlugin: Provider = {
   permissionPresets: {
-    smart: { sets: { permissionMode: 'auto' } },
-    bypass: { sets: { permissionMode: 'bypassPermissions' } },
+    smart: { sets: { permissionMode: CLAUDE_MODE.Auto } },
+    bypass: { sets: { permissionMode: CLAUDE_MODE.BypassPermissions } },
   },
   contextBufferPct: CLAUDE_AUTOCOMPACT_BUFFER_PCT,
   attachments: {
@@ -377,7 +378,7 @@ const claudeCodePlugin: Provider = {
     pdf: true,
     binary: false,
   },
-  planMode: buildPlanMode('permissionMode', 'plan', 'default'),
+  planMode: buildPlanMode('permissionMode', CLAUDE_MODE.Plan, CLAUDE_DEFAULT_MODE),
   // The trigger's mode segment shows the permission mode (which is also Claude's
   // plan axis, so it naturally reads "Plan Mode" when in plan).
   triggerModeGroupKey: 'permissionMode',

--- a/frontend/src/components/chat/providers/codex/CodexControlRequest.tsx
+++ b/frontend/src/components/chat/providers/codex/CodexControlRequest.tsx
@@ -264,7 +264,7 @@ const CodexPlanModePromptActions: Component<ActionsProps> = (props) => {
         onSelect: () => sendCodexPlanPromptResponse(props.request.agentId, props.onRespond, buildDenyResponse(props.request.requestId, '')),
       }}
       positiveAction={{ label: 'Approve', testId: 'control-allow-btn', onSelect: handleApprove }}
-      switches={() => planApprovalSwitches(planApproval, props.bypass)}
+      switches={() => planApprovalSwitches(planApproval)}
     />
   )
 }

--- a/frontend/src/components/chat/providers/codex/plugin.test.ts
+++ b/frontend/src/components/chat/providers/codex/plugin.test.ts
@@ -841,20 +841,14 @@ describe('codex settings config', () => {
     expect(plugin.planMode!.currentMode({})).toBe(DEFAULT_CODEX_COLLABORATION_MODE)
   })
 
-  it('declares the complete bypass settings', () => {
-    expect(plugin.bypassSettings?.sets.permissionMode).toBe('never')
-  })
-
-  it('declares a "Bypass permissions" settings action that sets network/sandbox/approval together', () => {
-    expect(plugin.settingsActions).toEqual([{
-      label: 'Bypass permissions',
-      testId: 'codex-bypass-permissions',
-      sets: {
+  it('declares one complete bypass permission preset', () => {
+    expect(plugin.permissionPresets).toEqual({
+      bypass: { sets: {
         network_access: 'enabled',
         sandbox_policy: 'danger-full-access',
         permissionMode: 'never',
-      },
-    }])
+      } },
+    })
   })
 })
 

--- a/frontend/src/components/chat/providers/codex/plugin.tsx
+++ b/frontend/src/components/chat/providers/codex/plugin.tsx
@@ -337,7 +337,7 @@ const CODEX_METHOD_TO_SEGMENT_KIND: Record<string, CommandStreamSegment['kind']>
 }
 
 const codexPlugin: Provider = {
-  bypassSettings: CODEX_BYPASS_SETTINGS,
+  permissionPresets: { bypass: CODEX_BYPASS_SETTINGS },
   // Seed a new Codex agent with its default collaboration mode.
   defaultProviderOptions: { [CODEX_OPTION_COLLABORATION_MODE]: DEFAULT_CODEX_COLLABORATION_MODE },
   // Codex accepts an option selection AND a free-text note together, so the
@@ -373,13 +373,6 @@ const codexPlugin: Provider = {
   // Codex's mode axis -- not the approval policy. It reads "Plan Mode" when the
   // workflow sits at its plan value.
   triggerModeGroupKey: CODEX_OPTION_COLLABORATION_MODE,
-  // The settings panel's declarative "Bypass permissions" button: one click
-  // sets network access, sandbox policy, and approval policy together.
-  settingsActions: [{
-    label: 'Bypass permissions',
-    testId: 'codex-bypass-permissions',
-    sets: { ...CODEX_BYPASS_SETTINGS.sets },
-  }],
   classify(input: ClassificationInput, context?: ClassificationContext): MessageCategory {
     const parent = input.parentObject
     const wrapper = input.wrapper

--- a/frontend/src/components/chat/providers/pi/plugin.test.ts
+++ b/frontend/src/components/chat/providers/pi/plugin.test.ts
@@ -31,7 +31,7 @@ describe('pi plugin metadata', () => {
   })
 
   it('does not advertise a permission mode for Pi', () => {
-    expect(plugin.bypassSettings).toBeUndefined()
+    expect(plugin.permissionPresets).toBeUndefined()
   })
 })
 

--- a/frontend/src/components/chat/providers/registry.ts
+++ b/frontend/src/components/chat/providers/registry.ts
@@ -13,7 +13,7 @@ import type { ActionsProps, AskQuestionState, ContentProps, Question } from '../
 import type { MessageCategory } from '../messageClassification'
 import type { RenderContext } from '../messageRenderers'
 import type { ControlResponseDeriver } from '../persistedControlResponse'
-import type { ProviderBypassSettings, ProviderSettingsAction } from '../providerSettings'
+import type { ProviderPermissionPresets } from '../providerSettings'
 import type { AgentInfo, AgentProvider, MessageSource } from '~/generated/proto/leapmux/v1/agent_pb'
 import type { ImageResultSource } from '~/lib/imageBlocks'
 import type { ParsedMessageContent } from '~/lib/messageParser'
@@ -434,8 +434,8 @@ export interface Provider {
   /** Reports whether typed feedback needs a separate user message. */
   controlFeedbackAsFollowUpMessage?: (payload: Record<string, unknown>) => boolean
 
-  /** The complete settings change that disables permission prompts. */
-  bypassSettings?: ProviderBypassSettings
+  /** Provider-native presets for standard permission actions. */
+  permissionPresets?: ProviderPermissionPresets
 
   /**
    * Plan mode toggle configuration. Providers define which option group +
@@ -468,13 +468,6 @@ export interface Provider {
    * wasn't at the plan value.
    */
   triggerModeGroupKey?: string
-
-  /**
-   * Declarative action buttons surfaced in the settings panel that set several
-   * option groups at once (e.g. Codex's "Bypass permissions"). Rendered by the
-   * generic panel; each entry dispatches one change per `sets` entry.
-   */
-  settingsActions?: ProviderSettingsAction[]
 
   /** Optional control request content component for this provider. */
   ControlContent?: Component<ContentProps>

--- a/frontend/src/components/chat/providers/stubs/copilot.test.ts
+++ b/frontend/src/components/chat/providers/stubs/copilot.test.ts
@@ -7,7 +7,6 @@ import './copilot'
 
 const MODE_AGENT = 'https://agentclientprotocol.com/protocol/session-modes#agent'
 const MODE_PLAN = 'https://agentclientprotocol.com/protocol/session-modes#plan'
-const MODE_AUTOPILOT = 'https://agentclientprotocol.com/protocol/session-modes#autopilot'
 
 describe('copilot provider', () => {
   const plugin = providerFor(AgentProvider.GITHUB_COPILOT)!
@@ -19,8 +18,11 @@ describe('copilot provider', () => {
     expect(plugin.planMode?.currentMode({ optionValues: { permissionMode: '' } })).toBe(MODE_AGENT)
   })
 
-  it('uses autopilot as bypass permission mode', () => {
-    expect(plugin.bypassSettings?.sets.permissionMode).toBe(MODE_AUTOPILOT)
+  it('maps smart and bypass permissions to the two permission axes', () => {
+    expect(plugin.permissionPresets).toEqual({
+      smart: { sets: { copilot_assisted_approval: 'on' } },
+      bypass: { sets: { allow_all: 'on' } },
+    })
   })
 
   it('declares plan mode on the permissionMode group and defaults to agent', () => {

--- a/frontend/src/components/chat/providers/stubs/copilot.tsx
+++ b/frontend/src/components/chat/providers/stubs/copilot.tsx
@@ -1,13 +1,16 @@
+import { COPILOT_PERMISSION_GROUP, COPILOT_PERMISSION_VALUE } from '~/generated/contracts/copilot-permissions'
 import { AgentProvider } from '~/generated/proto/leapmux/v1/agent_pb'
 import { registerACPProvider } from '../acp/registerACPProvider'
 
 const COPILOT_MODE_AGENT = 'https://agentclientprotocol.com/protocol/session-modes#agent'
 const COPILOT_MODE_PLAN = 'https://agentclientprotocol.com/protocol/session-modes#plan'
-const COPILOT_MODE_AUTOPILOT = 'https://agentclientprotocol.com/protocol/session-modes#autopilot'
 
 registerACPProvider({
   provider: AgentProvider.GITHUB_COPILOT,
   defaultPermissionMode: COPILOT_MODE_AGENT,
   planValue: COPILOT_MODE_PLAN,
-  bypassSettings: { sets: { permissionMode: COPILOT_MODE_AUTOPILOT } },
+  permissionPresets: {
+    smart: { sets: { [COPILOT_PERMISSION_GROUP.AssistedApproval]: COPILOT_PERMISSION_VALUE.On } },
+    bypass: { sets: { [COPILOT_PERMISSION_GROUP.AllowAll]: COPILOT_PERMISSION_VALUE.On } },
+  },
 })

--- a/frontend/src/components/chat/providers/stubs/goose.test.ts
+++ b/frontend/src/components/chat/providers/stubs/goose.test.ts
@@ -7,14 +7,18 @@ import { gooseSubagentToolRequestName, isGooseSubagentToolRequest } from './goos
 import { describeACPStubBasics } from './stubBasics'
 
 const MODE_AUTO = 'auto'
+const MODE_SMART_APPROVE = 'smart_approve'
 
 describe('goose provider', () => {
   const plugin = providerFor(AgentProvider.GOOSE)!
 
   describeACPStubBasics(plugin, { text: true, image: true, pdf: true, binary: true })
 
-  it('uses auto as bypass permission mode', () => {
-    expect(plugin.bypassSettings?.sets.permissionMode).toBe(MODE_AUTO)
+  it('maps smart and bypass permissions to Goose modes', () => {
+    expect(plugin.permissionPresets).toEqual({
+      smart: { sets: { permissionMode: MODE_SMART_APPROVE } },
+      bypass: { sets: { permissionMode: MODE_AUTO } },
+    })
   })
 
   it('has no plan mode', () => {

--- a/frontend/src/components/chat/providers/stubs/goose.tsx
+++ b/frontend/src/components/chat/providers/stubs/goose.tsx
@@ -1,5 +1,5 @@
 import type { MessageCategory } from '../../messageClassification'
-import type { PermissionMode } from '~/utils/controlResponse'
+import { GOOSE_MODE } from '~/generated/contracts/goose-protocol'
 import { AgentProvider } from '~/generated/proto/leapmux/v1/agent_pb'
 import { registerACPProvider } from '../acp/registerACPProvider'
 import { isGooseSubagentToolRequest } from './gooseShape'
@@ -9,8 +9,6 @@ import { isGooseSubagentToolRequest } from './gooseShape'
 // ./gooseShape.ts to avoid an import cycle through registerACPProvider (which
 // pulls in the renderers that read the name extractor).
 export { gooseSubagentToolRequestName, isGooseSubagentToolRequest } from './gooseShape'
-
-const GOOSE_MODE_AUTO = 'auto' as PermissionMode
 
 // Goose's classify hook for tool_call_update: recognize the subagent
 // tool-request _meta and emit a `subagent_tool_request` tool_use category so
@@ -24,7 +22,10 @@ function classifyGooseToolCallUpdate(parent: Record<string, unknown>): MessageCa
 
 registerACPProvider({
   provider: AgentProvider.GOOSE,
-  defaultPermissionMode: GOOSE_MODE_AUTO,
-  bypassSettings: { sets: { permissionMode: GOOSE_MODE_AUTO } },
+  defaultPermissionMode: GOOSE_MODE.Auto,
+  permissionPresets: {
+    smart: { sets: { permissionMode: GOOSE_MODE.SmartApprove } },
+    bypass: { sets: { permissionMode: GOOSE_MODE.Auto } },
+  },
   classifyToolCallUpdate: classifyGooseToolCallUpdate,
 })

--- a/frontend/src/components/chat/providers/stubs/goose.tsx
+++ b/frontend/src/components/chat/providers/stubs/goose.tsx
@@ -1,5 +1,5 @@
 import type { MessageCategory } from '../../messageClassification'
-import { GOOSE_MODE } from '~/generated/contracts/goose-protocol'
+import { GOOSE_DEFAULT_MODE, GOOSE_MODE } from '~/generated/contracts/goose-protocol'
 import { AgentProvider } from '~/generated/proto/leapmux/v1/agent_pb'
 import { registerACPProvider } from '../acp/registerACPProvider'
 import { isGooseSubagentToolRequest } from './gooseShape'
@@ -22,7 +22,7 @@ function classifyGooseToolCallUpdate(parent: Record<string, unknown>): MessageCa
 
 registerACPProvider({
   provider: AgentProvider.GOOSE,
-  defaultPermissionMode: GOOSE_MODE.Auto,
+  defaultPermissionMode: GOOSE_DEFAULT_MODE,
   permissionPresets: {
     smart: { sets: { permissionMode: GOOSE_MODE.SmartApprove } },
     bypass: { sets: { permissionMode: GOOSE_MODE.Auto } },

--- a/frontend/src/components/chat/providers/stubs/reasonix.test.ts
+++ b/frontend/src/components/chat/providers/stubs/reasonix.test.ts
@@ -17,7 +17,7 @@ describe('reasonix provider', () => {
 
   it('has no runtime mode: no plan mode, permission mode, or bypass', () => {
     expect(plugin.planMode).toBeUndefined()
-    expect(plugin.bypassSettings).toBeUndefined()
+    expect(plugin.permissionPresets).toBeUndefined()
     // modelOnly: no mode axis, so the trigger renders no third (mode) segment.
     expect(plugin.triggerModeGroupKey).toBeUndefined()
   })

--- a/frontend/src/components/chat/providers/zcode/plugin.test.ts
+++ b/frontend/src/components/chat/providers/zcode/plugin.test.ts
@@ -45,7 +45,9 @@ describe('zcode plugin metadata', () => {
 
   it('carries its mode axis on the permission-mode channel', () => {
     expect(plugin.triggerModeGroupKey).toBe('permissionMode')
-    expect(plugin.bypassSettings?.sets.permissionMode).toBe(ZCODE_MODE.Yolo)
+    expect(plugin.permissionPresets).toEqual({
+      bypass: { sets: { permissionMode: ZCODE_MODE.Yolo } },
+    })
   })
 
   it('configures plan mode against the same axis, defaulting to build', () => {

--- a/frontend/src/components/chat/providers/zcode/plugin.tsx
+++ b/frontend/src/components/chat/providers/zcode/plugin.tsx
@@ -5,7 +5,7 @@ import type { RenderContext } from '../../messageRenderers'
 import type { ClassificationInput, Provider, SpanRole, ToolResultMeta } from '../registry'
 import type { ParsedMessageContent } from '~/lib/messageParser'
 import type { ContextUsageInfo } from '~/stores/agentSession.store'
-import { ZCODE_EVENT, ZCODE_MODE, ZCODE_TOOL, ZCODE_TOOL_KIND } from '~/generated/contracts/zcode-protocol'
+import { ZCODE_DEFAULT_MODE, ZCODE_EVENT, ZCODE_MODE, ZCODE_TOOL, ZCODE_TOOL_KIND } from '~/generated/contracts/zcode-protocol'
 import { AgentProvider } from '~/generated/proto/leapmux/v1/agent_pb'
 import { isObject, pickNumber, pickObject, pickString } from '~/lib/jsonPick'
 import { buildDenyResponse, getToolInput } from '~/utils/controlResponse'
@@ -269,9 +269,9 @@ const zcodePlugin: Provider = {
   permissionPresets: { bypass: { sets: { permissionMode: ZCODE_MODE.Yolo } } },
   planMode: {
     groupKey: 'permissionMode',
-    currentMode: agent => agent.optionValues?.permissionMode ?? ZCODE_MODE.Build,
+    currentMode: agent => agent.optionValues?.permissionMode ?? ZCODE_DEFAULT_MODE,
     planValue: ZCODE_MODE.Plan,
-    defaultValue: ZCODE_MODE.Build,
+    defaultValue: ZCODE_DEFAULT_MODE,
   },
 
   classify(input: ClassificationInput): MessageCategory {

--- a/frontend/src/components/chat/providers/zcode/plugin.tsx
+++ b/frontend/src/components/chat/providers/zcode/plugin.tsx
@@ -266,7 +266,7 @@ const zcodePlugin: Provider = {
   // ZCode's mode axis rides LeapMux's permission-mode channel, so the mode chip and
   // the plan toggle drive `session/setMode`.
   triggerModeGroupKey: 'permissionMode',
-  bypassSettings: { sets: { permissionMode: ZCODE_MODE.Yolo } },
+  permissionPresets: { bypass: { sets: { permissionMode: ZCODE_MODE.Yolo } } },
   planMode: {
     groupKey: 'permissionMode',
     currentMode: agent => agent.optionValues?.permissionMode ?? ZCODE_MODE.Build,

--- a/frontend/src/components/chat/settingsGroups.test.ts
+++ b/frontend/src/components/chat/settingsGroups.test.ts
@@ -1,6 +1,6 @@
-import type { AvailableOptionGroup } from '~/generated/proto/leapmux/v1/agent_pb'
+import type { AvailableOption, AvailableOptionGroup } from '~/generated/proto/leapmux/v1/agent_pb'
 import { describe, expect, it } from 'vitest'
-import { groupHasOptions, hasOptions } from './settingsGroups'
+import { groupHasOptions, hasOptions, optionSideEffectText } from './settingsGroups'
 
 function group(id: string, optionIds: string[]): AvailableOptionGroup {
   return {
@@ -49,5 +49,41 @@ describe('groupHasOptions', () => {
     // Pre-handshake. Both composer settings surfaces read this, so neither may
     // throw on the undefined catalog.
     expect(groupHasOptions(undefined, 'model')).toBe(false)
+  })
+})
+
+describe('optionSideEffectText', () => {
+  const catalog = [
+    { id: 'allow_all', label: 'Allow All', options: [{ id: 'off', name: 'Off' }, { id: 'on', name: 'On' }] },
+    { id: 'copilot_assisted_approval', label: 'Assisted Approval', options: [] },
+  ] as unknown as AvailableOptionGroup[]
+  const option = (clears: { groupId: string, value: string }[]) =>
+    ({ id: 'on', name: 'On', clears }) as unknown as AvailableOption
+
+  it('names the group and value a selection also settles, using catalog labels', () => {
+    expect(optionSideEffectText(catalog, option([{ groupId: 'allow_all', value: 'off' }])))
+      .toBe('Also sets Allow All to Off.')
+  })
+
+  it('returns nothing for an option that settles nothing else', () => {
+    expect(optionSideEffectText(catalog, option([]))).toBeUndefined()
+  })
+
+  it('treats an absent clears field as settling nothing', () => {
+    // A catalog object does not always come from a decoded proto -- the tab store and
+    // the tests build option literals by hand, and a picker renders whatever it holds.
+    expect(optionSideEffectText(catalog, { id: 'on', name: 'On' } as unknown as AvailableOption))
+      .toBeUndefined()
+  })
+
+  it('skips a side effect whose group the catalog does not carry', () => {
+    // A worker can name a group this session never reported; describing it by its wire
+    // id would say less than saying nothing.
+    expect(optionSideEffectText(catalog, option([{ groupId: 'absent', value: 'off' }]))).toBeUndefined()
+  })
+
+  it('falls back to the wire ids when the group is present but the value is not', () => {
+    expect(optionSideEffectText(catalog, option([{ groupId: 'allow_all', value: 'unknown' }])))
+      .toBe('Also sets Allow All to unknown.')
   })
 })

--- a/frontend/src/components/chat/settingsGroups.ts
+++ b/frontend/src/components/chat/settingsGroups.ts
@@ -1,4 +1,4 @@
-import type { AvailableOptionGroup } from '~/generated/proto/leapmux/v1/agent_pb'
+import type { AvailableOption, AvailableOptionGroup } from '~/generated/proto/leapmux/v1/agent_pb'
 import { equals } from '@bufbuild/protobuf'
 import { EFFORT_AUTO } from '~/generated/contracts/worker-vocab'
 import { AvailableOptionGroupSchema } from '~/generated/proto/leapmux/v1/agent_pb'
@@ -52,6 +52,32 @@ export function optionGroup(optionGroups: AvailableOptionGroup[] | undefined, id
  */
 export function hasOptions(group: AvailableOptionGroup | undefined): boolean {
   return !!group && group.options.length > 0
+}
+
+/**
+ * The sentence describing what selecting `option` ALSO changes, or undefined when it
+ * changes nothing else.
+ *
+ * The worker declares the consequence on the option itself (AvailableOption.clears), so
+ * the picker can say it before the click instead of leaving the user to notice that a
+ * second axis moved. Labels come from the live catalog, so the sentence names what the
+ * user sees rather than the wire ids.
+ */
+export function optionSideEffectText(
+  optionGroups: AvailableOptionGroup[] | undefined,
+  option: AvailableOption,
+): string | undefined {
+  // `?? []` because a catalog object does not always come from a decoded proto: the tab
+  // store and the tests build option literals by hand, and a missing repeated field must
+  // read as "settles nothing" rather than throw while a picker is rendering.
+  const parts = (option.clears ?? []).map((effect) => {
+    const target = optionGroup(optionGroups, effect.groupId)
+    if (!target)
+      return undefined
+    const value = target.options.find(o => o.id === effect.value)
+    return `${target.label || effect.groupId} to ${value?.name || effect.value}`
+  }).filter((part): part is string => !!part)
+  return parts.length > 0 ? `Also sets ${parts.join(' and ')}.` : undefined
 }
 
 /** Whether the catalog holds `id` AND that group offers at least one option. */

--- a/frontend/tests/e2e/025-no-worker-settings.spec.ts
+++ b/frontend/tests/e2e/025-no-worker-settings.spec.ts
@@ -1,4 +1,4 @@
-import { createWorkspaceViaAPI, deleteWorkspaceViaAPI, openAgentViaAPI } from './helpers/api'
+import { createWorkspaceViaAPI, deleteWorkspaceViaAPI, openPinnedModeAgentViaAPI } from './helpers/api'
 import { ARITHMETIC_PROMPT, expectAssistantAnswer, expectSettingsChip, expectUserMessage, loginViaToken, messageBubbles, openSettingsMenu, openWorkspace, visibleOnly } from './helpers/ui'
 import { ensureWorkerOnline, expect, restartWorker, stopWorker, processTest as test, waitForWorkerOffline } from './process-control-fixtures'
 
@@ -8,7 +8,7 @@ test.describe('Settings and /clear after Worker restart', () => {
 
     const { hubUrl, adminToken, workerId } = separateHubWorker
     const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, 'Worker Restart Settings Test')
-    await openAgentViaAPI(hubUrl, adminToken, workerId, workspaceId)
+    await openPinnedModeAgentViaAPI(hubUrl, adminToken, workerId, workspaceId)
     try {
       await loginViaToken(page, adminToken)
       await openWorkspace(page, workspaceId)

--- a/frontend/tests/e2e/044-agent-settings.spec.ts
+++ b/frontend/tests/e2e/044-agent-settings.spec.ts
@@ -1,5 +1,5 @@
 import { MODEL_NONDETERMINISM_RETRIES } from './helpers/modelRetries'
-import { ARITHMETIC_PROMPT, assistantBubbles, chooseSettingsOption, expectAssistantAnswer, expectSettingsChip, openAgentViaUI, openPlusMenu, openSettingsMenu, SECOND_ARITHMETIC_ANSWER, SECOND_ARITHMETIC_PROMPT, settingsBar, settingsGroupTrigger, visibleOnly, waitForSettingsHydrated, waitForSettingsIdle } from './helpers/ui'
+import { applyPermissionPreset, ARITHMETIC_PROMPT, assistantBubbles, chooseSettingsOption, expectAssistantAnswer, expectSettingsChip, openAgentViaUI, openPlusMenu, openSettingsMenu, permissionModeOffered, SECOND_ARITHMETIC_ANSWER, SECOND_ARITHMETIC_PROMPT, settingsBar, settingsGroupTrigger, visibleOnly, waitForSettingsHydrated, waitForSettingsIdle } from './helpers/ui'
 import { expect, restartWorker, stopWorker, processTest as test } from './process-control-fixtures'
 
 test.describe('Agent Settings', () => {
@@ -18,20 +18,24 @@ test.describe('Agent Settings', () => {
   test('permission shortcuts use the Claude modes that the session offers', async ({ authenticatedWorkspace, page }) => {
     void authenticatedWorkspace
     await waitForSettingsHydrated(page)
-    const menu = await openPlusMenu(page)
-    const bypass = menu.getByTestId('composer-bypass-permissions')
-    const smart = menu.getByTestId('composer-smart-permissions')
-    await expect(bypass).toBeVisible()
-    const smartOffered = await smart.isVisible()
+    // Claude's Smart preset sets permissionMode=auto, and livePermissionModeGroup drops
+    // the auto option exactly when the startup probe rejected it. So the picker decides
+    // whether the shortcut must be there -- asserted either way, rather than skipped.
+    const autoOffered = await permissionModeOffered(page, 'auto')
 
-    await bypass.click()
-    await waitForSettingsIdle(page)
+    const menu = await openPlusMenu(page)
+    const smart = menu.getByTestId('composer-smart-permissions')
+    await expect(menu.getByTestId('composer-bypass-permissions')).toBeVisible()
+    if (autoOffered)
+      await expect(smart).toBeVisible()
+    else
+      await expect(smart).toHaveCount(0)
+
+    await applyPermissionPreset(page, 'bypass')
     await expectSettingsChip(page, 'Bypass Permissions')
 
-    if (smartOffered) {
-      await openPlusMenu(page)
-      await page.getByTestId('composer-smart-permissions').click()
-      await waitForSettingsIdle(page)
+    if (autoOffered) {
+      await applyPermissionPreset(page, 'smart')
       await expectSettingsChip(page, 'Auto Mode')
     }
   })
@@ -598,9 +602,14 @@ test.describe('Agent Settings', () => {
     // Open a second agent tab
     await openAgentViaUI(page)
 
-    // A new session requests Auto Mode and falls back to Default when unavailable.
+    // A new session requests Auto Mode, and the Claude CLI decides whether it can enter
+    // it. The picker offers "auto" exactly when the startup probe accepted it, so it
+    // pins WHICH mode to expect -- an either/or regex would also pass if the safe
+    // default stopped being applied at all, and this is the only unpinned agent left in
+    // the suite.
     await waitForSettingsHydrated(page)
-    await expectSettingsChip(page, /Auto Mode|Default/)
+    const expectedMode = await permissionModeOffered(page, 'auto') ? 'Auto Mode' : 'Default'
+    await expectSettingsChip(page, expectedMode)
 
     // Switch the new agent to Plan Mode
     await chooseSettingsOption(page, 'permissionMode-plan')
@@ -608,7 +617,7 @@ test.describe('Agent Settings', () => {
     await waitForSettingsIdle(page)
 
     // Verify the notification appears in the new agent's chat (not the first agent's)
-    await expect(visibleOnly(page.getByText(/Mode \((Auto Mode|Default) → Plan Mode\)/))).toBeVisible()
+    await expect(visibleOnly(page.getByText(`Mode (${expectedMode} → Plan Mode)`))).toBeVisible()
 
     // Switch back to the first agent tab
     const agentTabs = page.locator('[data-testid="tab"][data-tab-type="agent"]')

--- a/frontend/tests/e2e/044-agent-settings.spec.ts
+++ b/frontend/tests/e2e/044-agent-settings.spec.ts
@@ -1,5 +1,5 @@
 import { MODEL_NONDETERMINISM_RETRIES } from './helpers/modelRetries'
-import { ARITHMETIC_PROMPT, chooseSettingsOption, expectAssistantAnswer, expectSettingsChip, openAgentViaUI, openPlusMenu, openSettingsMenu, SECOND_ARITHMETIC_ANSWER, SECOND_ARITHMETIC_PROMPT, settingsBar, settingsGroupTrigger, visibleOnly, waitForSettingsHydrated, waitForSettingsIdle } from './helpers/ui'
+import { ARITHMETIC_PROMPT, assistantBubbles, chooseSettingsOption, expectAssistantAnswer, expectSettingsChip, openAgentViaUI, openPlusMenu, openSettingsMenu, SECOND_ARITHMETIC_ANSWER, SECOND_ARITHMETIC_PROMPT, settingsBar, settingsGroupTrigger, visibleOnly, waitForSettingsHydrated, waitForSettingsIdle } from './helpers/ui'
 import { expect, restartWorker, stopWorker, processTest as test } from './process-control-fixtures'
 
 test.describe('Agent Settings', () => {
@@ -207,7 +207,7 @@ test.describe('Agent Settings', () => {
     expect(await effortOptions(), 'and Sonnet still does on the way back').toEqual(onSonnet)
   })
 
-  test('ultracode effort settles and keeps the composer writable', async ({ authenticatedWorkspace, page }) => {
+  test('ultracode effort is selectable and keeps the agent working', async ({ authenticatedWorkspace, page }) => {
     void authenticatedWorkspace // fixture trigger
     const trigger = settingsBar(page)
     await expect(trigger).toBeVisible()
@@ -216,19 +216,24 @@ test.describe('Agent Settings', () => {
     await expect(page.locator('[data-testid="effort-ultracode"]')).toBeVisible()
     await page.keyboard.press('Escape')
 
-    // Select Ultracode. Some accounts keep it, and other accounts settle on
-    // Extra High. Both results confirm that the CLI processed the change.
+    // Select ultracode. CI accounts lack the dynamic-workflows entitlement, so
+    // the CLI gracefully downgrades to xhigh (apply_flag_settings no-ops and
+    // get_settings reports ultracode:false). We therefore assert the agent
+    // stays functional rather than that the selection persists as ultracode.
     await chooseSettingsOption(page, 'effort-ultracode')
     await waitForSettingsIdle(page)
 
-    const effortMenu = await openSettingsMenu(page, 'effort')
-    await expect(effortMenu.locator(
-      '[data-testid="effort-ultracode"] input[type="radio"]:checked, [data-testid="effort-xhigh"] input[type="radio"]:checked',
-    )).toHaveCount(1)
-
     const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
-    await expect(editor).toHaveAttribute('contenteditable', 'true')
+    await editor.click()
+    // Use a distinctive sentinel word as the answer, not a number. A numeric
+    // answer would be unsafe here because the "Took Ns" bubble's duration
+    // (e.g. "Took 11s") shares data-role="agent" and would substring-match a
+    // numeric sentinel like "11", letting the test pass on the duration bubble
+    // even if the agent never answered.
+    await page.keyboard.type('Reply with exactly the word PINEAPPLE and nothing else.')
+    await page.keyboard.press('Meta+Enter')
+    await expect(assistantBubbles(page).filter({ hasText: 'PINEAPPLE' })).toBeVisible()
   })
 
   test('Extended Thinking label reflects model', async ({ authenticatedWorkspace, page }) => {

--- a/frontend/tests/e2e/044-agent-settings.spec.ts
+++ b/frontend/tests/e2e/044-agent-settings.spec.ts
@@ -1,5 +1,5 @@
 import { MODEL_NONDETERMINISM_RETRIES } from './helpers/modelRetries'
-import { ARITHMETIC_PROMPT, assistantBubbles, chooseSettingsOption, expectAssistantAnswer, expectSettingsChip, openAgentViaUI, openPlusMenu, openSettingsMenu, SECOND_ARITHMETIC_ANSWER, SECOND_ARITHMETIC_PROMPT, settingsBar, settingsGroupTrigger, visibleOnly, waitForSettingsHydrated, waitForSettingsIdle } from './helpers/ui'
+import { ARITHMETIC_PROMPT, chooseSettingsOption, expectAssistantAnswer, expectSettingsChip, openAgentViaUI, openPlusMenu, openSettingsMenu, SECOND_ARITHMETIC_ANSWER, SECOND_ARITHMETIC_PROMPT, settingsBar, settingsGroupTrigger, visibleOnly, waitForSettingsHydrated, waitForSettingsIdle } from './helpers/ui'
 import { expect, restartWorker, stopWorker, processTest as test } from './process-control-fixtures'
 
 test.describe('Agent Settings', () => {
@@ -13,6 +13,27 @@ test.describe('Agent Settings', () => {
     // instant it becomes visible sees "…" and nothing else, forever.
     await expectSettingsChip(page, 'Sonnet')
     await expectSettingsChip(page, 'Default')
+  })
+
+  test('permission shortcuts use the Claude modes that the session offers', async ({ authenticatedWorkspace, page }) => {
+    void authenticatedWorkspace
+    await waitForSettingsHydrated(page)
+    const menu = await openPlusMenu(page)
+    const bypass = menu.getByTestId('composer-bypass-permissions')
+    const smart = menu.getByTestId('composer-smart-permissions')
+    await expect(bypass).toBeVisible()
+    const smartOffered = await smart.isVisible()
+
+    await bypass.click()
+    await waitForSettingsIdle(page)
+    await expectSettingsChip(page, 'Bypass Permissions')
+
+    if (smartOffered) {
+      await openPlusMenu(page)
+      await page.getByTestId('composer-smart-permissions').click()
+      await waitForSettingsIdle(page)
+      await expectSettingsChip(page, 'Auto Mode')
+    }
   })
 
   test('switch permission modes', async ({ authenticatedWorkspace, page }) => {
@@ -186,7 +207,7 @@ test.describe('Agent Settings', () => {
     expect(await effortOptions(), 'and Sonnet still does on the way back').toEqual(onSonnet)
   })
 
-  test('ultracode effort is selectable and keeps the agent working', async ({ authenticatedWorkspace, page }) => {
+  test('ultracode effort settles and keeps the composer writable', async ({ authenticatedWorkspace, page }) => {
     void authenticatedWorkspace // fixture trigger
     const trigger = settingsBar(page)
     await expect(trigger).toBeVisible()
@@ -195,24 +216,19 @@ test.describe('Agent Settings', () => {
     await expect(page.locator('[data-testid="effort-ultracode"]')).toBeVisible()
     await page.keyboard.press('Escape')
 
-    // Select ultracode. CI accounts lack the dynamic-workflows entitlement, so
-    // the CLI gracefully downgrades to xhigh (apply_flag_settings no-ops and
-    // get_settings reports ultracode:false). We therefore assert the agent
-    // stays functional rather than that the selection persists as ultracode.
+    // Select Ultracode. Some accounts keep it, and other accounts settle on
+    // Extra High. Both results confirm that the CLI processed the change.
     await chooseSettingsOption(page, 'effort-ultracode')
     await waitForSettingsIdle(page)
 
+    const effortMenu = await openSettingsMenu(page, 'effort')
+    await expect(effortMenu.locator(
+      '[data-testid="effort-ultracode"] input[type="radio"]:checked, [data-testid="effort-xhigh"] input[type="radio"]:checked',
+    )).toHaveCount(1)
+
     const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
-    await editor.click()
-    // Use a distinctive sentinel word as the answer, not a number. A numeric
-    // answer would be unsafe here because the "Took Ns" bubble's duration
-    // (e.g. "Took 11s") shares data-role="agent" and would substring-match a
-    // numeric sentinel like "11", letting the test pass on the duration bubble
-    // even if the agent never answered.
-    await page.keyboard.type('Reply with exactly the word PINEAPPLE and nothing else.')
-    await page.keyboard.press('Meta+Enter')
-    await expect(assistantBubbles(page).filter({ hasText: 'PINEAPPLE' })).toBeVisible()
+    await expect(editor).toHaveAttribute('contenteditable', 'true')
   })
 
   test('Extended Thinking label reflects model', async ({ authenticatedWorkspace, page }) => {
@@ -577,10 +593,9 @@ test.describe('Agent Settings', () => {
     // Open a second agent tab
     await openAgentViaUI(page)
 
-    // The new tab should also start with Default mode, once its agent has
-    // reported an option catalog -- until then the trigger reads "… · Auto".
+    // A new session requests Auto Mode and falls back to Default when unavailable.
     await waitForSettingsHydrated(page)
-    await expectSettingsChip(page, 'Default')
+    await expectSettingsChip(page, /Auto Mode|Default/)
 
     // Switch the new agent to Plan Mode
     await chooseSettingsOption(page, 'permissionMode-plan')
@@ -588,7 +603,7 @@ test.describe('Agent Settings', () => {
     await waitForSettingsIdle(page)
 
     // Verify the notification appears in the new agent's chat (not the first agent's)
-    await expect(visibleOnly(page.getByText('Mode (Default → Plan Mode)'))).toBeVisible()
+    await expect(visibleOnly(page.getByText(/Mode \((Auto Mode|Default) → Plan Mode\)/))).toBeVisible()
 
     // Switch back to the first agent tab
     const agentTabs = page.locator('[data-testid="tab"][data-tab-type="agent"]')

--- a/frontend/tests/e2e/110-copilot-basic-chat.spec.ts
+++ b/frontend/tests/e2e/110-copilot-basic-chat.spec.ts
@@ -1,5 +1,5 @@
-import { COPILOT_E2E_SKIP_REASON, copilotTest } from './copilot-fixtures'
-import { ARITHMETIC_PROMPT, expectAssistantAnswer, sendMessage, waitForAgentIdle } from './helpers/ui'
+import { COPILOT_E2E_SKIP_REASON, copilotTest, expect } from './copilot-fixtures'
+import { ARITHMETIC_PROMPT, expectAssistantAnswer, openPlusMenu, openSettingsMenu, sendMessage, waitForAgentIdle, waitForSettingsIdle } from './helpers/ui'
 
 copilotTest.skip(!!COPILOT_E2E_SKIP_REASON, COPILOT_E2E_SKIP_REASON || '')
 
@@ -9,5 +9,34 @@ copilotTest.describe('Copilot Basic Chat', () => {
     await sendMessage(page, ARITHMETIC_PROMPT)
     await waitForAgentIdle(page, 120_000)
     await expectAssistantAnswer(page)
+  })
+
+  copilotTest('permission shortcuts switch Assisted Approval and Allow All', async ({ authenticatedCopilotWorkspace, page }) => {
+    void authenticatedCopilotWorkspace
+    await openSettingsMenu(page, 'allow_all')
+    let menu = await openPlusMenu(page)
+    const smart = menu.getByTestId('composer-smart-permissions')
+    const bypass = menu.getByTestId('composer-bypass-permissions')
+    await expect(bypass).toBeVisible()
+    if (await smart.count() === 0)
+      return
+
+    await expect(smart).toBeDisabled()
+    await bypass.click()
+    await waitForSettingsIdle(page)
+
+    let group = await openSettingsMenu(page, 'allow_all')
+    await expect(group.locator('[data-testid="allow_all-on"] input[type="radio"]')).toBeChecked()
+    group = await openSettingsMenu(page, 'copilot_assisted_approval')
+    await expect(group.locator('[data-testid="copilot_assisted_approval-off"] input[type="radio"]')).toBeChecked()
+
+    menu = await openPlusMenu(page)
+    await menu.getByTestId('composer-smart-permissions').click()
+    await waitForSettingsIdle(page)
+
+    group = await openSettingsMenu(page, 'copilot_assisted_approval')
+    await expect(group.locator('[data-testid="copilot_assisted_approval-on"] input[type="radio"]')).toBeChecked()
+    group = await openSettingsMenu(page, 'allow_all')
+    await expect(group.locator('[data-testid="allow_all-off"] input[type="radio"]')).toBeChecked()
   })
 })

--- a/frontend/tests/e2e/110-copilot-basic-chat.spec.ts
+++ b/frontend/tests/e2e/110-copilot-basic-chat.spec.ts
@@ -18,10 +18,9 @@ copilotTest.describe('Copilot Basic Chat', () => {
     const smart = menu.getByTestId('composer-smart-permissions')
     const bypass = menu.getByTestId('composer-bypass-permissions')
     await expect(bypass).toBeVisible()
-    if (await smart.count() === 0)
-      return
-
-    await expect(smart).toBeDisabled()
+    const smartOffered = await smart.count() > 0
+    if (smartOffered)
+      await expect(smart).toBeDisabled()
     await bypass.click()
     await waitForSettingsIdle(page)
 
@@ -29,6 +28,9 @@ copilotTest.describe('Copilot Basic Chat', () => {
     await expect(group.locator('[data-testid="allow_all-on"] input[type="radio"]')).toBeChecked()
     group = await openSettingsMenu(page, 'copilot_assisted_approval')
     await expect(group.locator('[data-testid="copilot_assisted_approval-off"] input[type="radio"]')).toBeChecked()
+
+    if (!smartOffered)
+      return
 
     menu = await openPlusMenu(page)
     await menu.getByTestId('composer-smart-permissions').click()

--- a/frontend/tests/e2e/110-copilot-basic-chat.spec.ts
+++ b/frontend/tests/e2e/110-copilot-basic-chat.spec.ts
@@ -1,5 +1,5 @@
 import { COPILOT_E2E_SKIP_REASON, copilotTest, expect } from './copilot-fixtures'
-import { ARITHMETIC_PROMPT, expectAssistantAnswer, openPlusMenu, openSettingsMenu, sendMessage, waitForAgentIdle, waitForSettingsIdle } from './helpers/ui'
+import { applyPermissionPreset, ARITHMETIC_PROMPT, expectAssistantAnswer, openPlusMenu, openSettingsMenu, sendMessage, waitForAgentIdle } from './helpers/ui'
 
 copilotTest.skip(!!COPILOT_E2E_SKIP_REASON, COPILOT_E2E_SKIP_REASON || '')
 
@@ -13,29 +13,32 @@ copilotTest.describe('Copilot Basic Chat', () => {
 
   copilotTest('permission shortcuts switch Assisted Approval and Allow All', async ({ authenticatedCopilotWorkspace, page }) => {
     void authenticatedCopilotWorkspace
-    await openSettingsMenu(page, 'allow_all')
-    let menu = await openPlusMenu(page)
-    const smart = menu.getByTestId('composer-smart-permissions')
-    const bypass = menu.getByTestId('composer-bypass-permissions')
-    await expect(bypass).toBeVisible()
-    const smartOffered = await smart.count() > 0
-    if (smartOffered)
-      await expect(smart).toBeDisabled()
-    await bypass.click()
-    await waitForSettingsIdle(page)
+    // The Smart preset sets copilot_assisted_approval=on. A CLI that rejects
+    // --assisted-approval leaves that group frozen to Off, and the shortcut must then be
+    // absent -- asserted either way, so a shortcut that stops rendering cannot pass.
+    const approvalGroup = await openSettingsMenu(page, 'copilot_assisted_approval')
+    const assistedOffered = await approvalGroup
+      .locator('[data-testid="copilot_assisted_approval-on"]')
+      .count() > 0
 
+    const menu = await openPlusMenu(page)
+    const smart = menu.getByTestId('composer-smart-permissions')
+    await expect(menu.getByTestId('composer-bypass-permissions')).toBeVisible()
+    if (assistedOffered)
+      await expect(smart).toBeDisabled()
+    else
+      await expect(smart).toHaveCount(0)
+
+    await applyPermissionPreset(page, 'bypass')
     let group = await openSettingsMenu(page, 'allow_all')
     await expect(group.locator('[data-testid="allow_all-on"] input[type="radio"]')).toBeChecked()
     group = await openSettingsMenu(page, 'copilot_assisted_approval')
     await expect(group.locator('[data-testid="copilot_assisted_approval-off"] input[type="radio"]')).toBeChecked()
 
-    if (!smartOffered)
+    if (!assistedOffered)
       return
 
-    menu = await openPlusMenu(page)
-    await menu.getByTestId('composer-smart-permissions').click()
-    await waitForSettingsIdle(page)
-
+    await applyPermissionPreset(page, 'smart')
     group = await openSettingsMenu(page, 'copilot_assisted_approval')
     await expect(group.locator('[data-testid="copilot_assisted_approval-on"] input[type="radio"]')).toBeChecked()
     group = await openSettingsMenu(page, 'allow_all')

--- a/frontend/tests/e2e/115-goose-basic-chat.spec.ts
+++ b/frontend/tests/e2e/115-goose-basic-chat.spec.ts
@@ -1,5 +1,5 @@
 import { expect, GOOSE_E2E_SKIP_REASON, gooseTest } from './goose-fixtures'
-import { ARITHMETIC_PROMPT, expectAssistantAnswer, openPlusMenu, openSettingsMenu, sendMessage, waitForAgentIdle, waitForSettingsHydrated, waitForSettingsIdle } from './helpers/ui'
+import { applyPermissionPreset, ARITHMETIC_PROMPT, expectAssistantAnswer, openPlusMenu, openSettingsMenu, sendMessage, waitForAgentIdle, waitForSettingsHydrated } from './helpers/ui'
 
 gooseTest.skip(!!GOOSE_E2E_SKIP_REASON, GOOSE_E2E_SKIP_REASON || '')
 
@@ -14,17 +14,16 @@ gooseTest.describe('Goose Basic Chat', () => {
   gooseTest('permission shortcuts switch Smart Approve and Auto', async ({ authenticatedGooseWorkspace, page }) => {
     void authenticatedGooseWorkspace
     await waitForSettingsHydrated(page)
-    let menu = await openPlusMenu(page)
+    const menu = await openPlusMenu(page)
+    // A new Goose session starts in Smart Approve, so the Smart shortcut is already
+    // applied and therefore disabled.
     await expect(menu.getByTestId('composer-smart-permissions')).toBeDisabled()
-    await menu.getByTestId('composer-bypass-permissions').click()
-    await waitForSettingsIdle(page)
 
+    await applyPermissionPreset(page, 'bypass')
     let group = await openSettingsMenu(page, 'permissionMode')
     await expect(group.locator('[data-testid="permissionMode-auto"] input[type="radio"]')).toBeChecked()
 
-    menu = await openPlusMenu(page)
-    await menu.getByTestId('composer-smart-permissions').click()
-    await waitForSettingsIdle(page)
+    await applyPermissionPreset(page, 'smart')
     group = await openSettingsMenu(page, 'permissionMode')
     await expect(group.locator('[data-testid="permissionMode-smart_approve"] input[type="radio"]')).toBeChecked()
   })

--- a/frontend/tests/e2e/115-goose-basic-chat.spec.ts
+++ b/frontend/tests/e2e/115-goose-basic-chat.spec.ts
@@ -1,5 +1,5 @@
-import { GOOSE_E2E_SKIP_REASON, gooseTest } from './goose-fixtures'
-import { ARITHMETIC_PROMPT, expectAssistantAnswer, sendMessage, waitForAgentIdle } from './helpers/ui'
+import { expect, GOOSE_E2E_SKIP_REASON, gooseTest } from './goose-fixtures'
+import { ARITHMETIC_PROMPT, expectAssistantAnswer, openPlusMenu, openSettingsMenu, sendMessage, waitForAgentIdle, waitForSettingsHydrated, waitForSettingsIdle } from './helpers/ui'
 
 gooseTest.skip(!!GOOSE_E2E_SKIP_REASON, GOOSE_E2E_SKIP_REASON || '')
 
@@ -9,5 +9,23 @@ gooseTest.describe('Goose Basic Chat', () => {
     await sendMessage(page, ARITHMETIC_PROMPT)
     await waitForAgentIdle(page, 120_000)
     await expectAssistantAnswer(page)
+  })
+
+  gooseTest('permission shortcuts switch Smart Approve and Auto', async ({ authenticatedGooseWorkspace, page }) => {
+    void authenticatedGooseWorkspace
+    await waitForSettingsHydrated(page)
+    let menu = await openPlusMenu(page)
+    await expect(menu.getByTestId('composer-smart-permissions')).toBeDisabled()
+    await menu.getByTestId('composer-bypass-permissions').click()
+    await waitForSettingsIdle(page)
+
+    let group = await openSettingsMenu(page, 'permissionMode')
+    await expect(group.locator('[data-testid="permissionMode-auto"] input[type="radio"]')).toBeChecked()
+
+    menu = await openPlusMenu(page)
+    await menu.getByTestId('composer-smart-permissions').click()
+    await waitForSettingsIdle(page)
+    group = await openSettingsMenu(page, 'permissionMode')
+    await expect(group.locator('[data-testid="permissionMode-smart_approve"] input[type="radio"]')).toBeChecked()
   })
 })

--- a/frontend/tests/e2e/190-zcode-basic-chat.spec.ts
+++ b/frontend/tests/e2e/190-zcode-basic-chat.spec.ts
@@ -1,4 +1,4 @@
-import { ARITHMETIC_PROMPT, assistantBubbles, chooseSettingsOption, expectAssistantAnswer, expectSettingsChip, messageContents, openPlusMenu, openSettingsMenu, sendMessage, settingsBar, waitForAgentIdle, waitForControlBanner, waitForSettingsHydrated, waitForSettingsIdle } from './helpers/ui'
+import { applyPermissionPreset, ARITHMETIC_PROMPT, assistantBubbles, chooseSettingsOption, expectAssistantAnswer, expectSettingsChip, messageContents, openPlusMenu, openSettingsMenu, sendMessage, settingsBar, waitForAgentIdle, waitForControlBanner, waitForSettingsHydrated } from './helpers/ui'
 import { expect, ZCODE_E2E_SKIP_REASON, zcodeTest } from './zcode-fixtures'
 
 zcodeTest.skip(!!ZCODE_E2E_SKIP_REASON, ZCODE_E2E_SKIP_REASON || '')
@@ -59,9 +59,9 @@ zcodeTest.describe('ZCode Mode Switch', () => {
     void authenticatedZCodeWorkspace
     await waitForSettingsHydrated(page)
     const menu = await openPlusMenu(page)
+    // ZCode declares no Smart preset, so only the bypass shortcut is drawn.
     await expect(menu.getByTestId('composer-smart-permissions')).toHaveCount(0)
-    await menu.getByTestId('composer-bypass-permissions').click()
-    await waitForSettingsIdle(page)
+    await applyPermissionPreset(page, 'bypass')
     await expectSettingsChip(page, 'Yolo')
   })
 

--- a/frontend/tests/e2e/190-zcode-basic-chat.spec.ts
+++ b/frontend/tests/e2e/190-zcode-basic-chat.spec.ts
@@ -1,4 +1,4 @@
-import { ARITHMETIC_PROMPT, assistantBubbles, chooseSettingsOption, expectAssistantAnswer, expectSettingsChip, messageContents, openSettingsMenu, sendMessage, settingsBar, waitForAgentIdle, waitForControlBanner } from './helpers/ui'
+import { ARITHMETIC_PROMPT, assistantBubbles, chooseSettingsOption, expectAssistantAnswer, expectSettingsChip, messageContents, openPlusMenu, openSettingsMenu, sendMessage, settingsBar, waitForAgentIdle, waitForControlBanner, waitForSettingsHydrated, waitForSettingsIdle } from './helpers/ui'
 import { expect, ZCODE_E2E_SKIP_REASON, zcodeTest } from './zcode-fixtures'
 
 zcodeTest.skip(!!ZCODE_E2E_SKIP_REASON, ZCODE_E2E_SKIP_REASON || '')
@@ -55,6 +55,16 @@ zcodeTest.describe('ZCode Permission Prompt', () => {
 })
 
 zcodeTest.describe('ZCode Mode Switch', () => {
+  zcodeTest('offers only the bypass permission shortcut', async ({ authenticatedZCodeWorkspace, page }) => {
+    void authenticatedZCodeWorkspace
+    await waitForSettingsHydrated(page)
+    const menu = await openPlusMenu(page)
+    await expect(menu.getByTestId('composer-smart-permissions')).toHaveCount(0)
+    await menu.getByTestId('composer-bypass-permissions').click()
+    await waitForSettingsIdle(page)
+    await expectSettingsChip(page, 'Yolo')
+  })
+
   zcodeTest('the mode chip starts on Build and can switch to Plan and Yolo', async ({ authenticatedZCodeWorkspace, page }) => {
     void authenticatedZCodeWorkspace
     await expect(settingsBar(page)).toBeVisible()

--- a/frontend/tests/e2e/fixtures.ts
+++ b/frontend/tests/e2e/fixtures.ts
@@ -225,7 +225,9 @@ export const test = base.extend<
     )
     // Open an initial agent — workspace creation on the hub no longer
     // auto-creates one (that was the old worker behavior).
-    await openAgentViaAPI(hubUrl, adminToken, workerId, workspaceId)
+    await openAgentViaAPI(hubUrl, adminToken, workerId, workspaceId, undefined, {
+      optionValues: { permissionMode: 'default' },
+    })
     await use({ workspaceId })
 
     // Teardown (best effort): stop the workspace's agents on the worker, THEN

--- a/frontend/tests/e2e/fixtures.ts
+++ b/frontend/tests/e2e/fixtures.ts
@@ -16,7 +16,7 @@ import {
   getUserId,
   getWorkerId,
   loginViaAPI,
-  openAgentViaAPI,
+  openPinnedModeAgentViaAPI,
   signUpViaAPI,
   TEST_ADMIN_DISPLAY_NAME,
   TEST_ADMIN_PASSWORD,
@@ -225,9 +225,7 @@ export const test = base.extend<
     )
     // Open an initial agent — workspace creation on the hub no longer
     // auto-creates one (that was the old worker behavior).
-    await openAgentViaAPI(hubUrl, adminToken, workerId, workspaceId, undefined, {
-      optionValues: { permissionMode: 'default' },
-    })
+    await openPinnedModeAgentViaAPI(hubUrl, adminToken, workerId, workspaceId)
     await use({ workspaceId })
 
     // Teardown (best effort): stop the workspace's agents on the worker, THEN

--- a/frontend/tests/e2e/helpers/api.ts
+++ b/frontend/tests/e2e/helpers/api.ts
@@ -603,6 +603,9 @@ export async function openAgentViaAPI(
 ): Promise<string> {
   const { OpenAgentRequestSchema, OpenAgentResponseSchema } = await import('../../../src/generated/proto/leapmux/v1/agent_pb')
   const channel = await getTestChannel(hubUrl, cookie)
+  // The proto carries the model AND every option-group value under the `options` map,
+  // not as a top-level field; create() would silently drop a spread `{ model }`, opening
+  // the agent at the provider default instead of the requested one.
   const initialOptions = {
     ...options?.optionValues,
     ...(options?.model ? { model: options.model } : {}),
@@ -658,6 +661,29 @@ export async function openAgentViaAPI(
     userEvents,
   })
   return resp.agent.id
+}
+
+/**
+ * Open an agent with the permission mode pinned to `default`.
+ *
+ * A new session otherwise starts on the provider's safe default — Claude Code requests
+ * Auto Mode — and the installed CLI decides whether it can enter that mode, so the
+ * resulting mode varies by machine. Every spec that asserts one EXACT mode string, or a
+ * "Mode (X → Y)" notification, opens its agent through here.
+ *
+ * A spec that means to exercise the safe default must NOT use this helper. It should
+ * open the agent plainly and read the offered modes to decide what to expect, the way
+ * `044-agent-settings.spec.ts` does.
+ */
+export async function openPinnedModeAgentViaAPI(
+  hubUrl: string,
+  cookie: string,
+  workerId: string,
+  workspaceId: string,
+): Promise<string> {
+  return openAgentViaAPI(hubUrl, cookie, workerId, workspaceId, undefined, {
+    optionValues: { permissionMode: 'default' },
+  })
 }
 
 // ---- Hub API helpers (Workspace CRUD) ----

--- a/frontend/tests/e2e/helpers/api.ts
+++ b/frontend/tests/e2e/helpers/api.ts
@@ -583,6 +583,8 @@ export async function openAgentViaAPI(
   workingDir?: string,
   options?: {
     model?: string
+    /** Initial values for any provider option group. */
+    optionValues?: Record<string, string>
     createWorktree?: boolean
     worktreeBranch?: string
     worktreeBaseBranch?: string
@@ -601,6 +603,10 @@ export async function openAgentViaAPI(
 ): Promise<string> {
   const { OpenAgentRequestSchema, OpenAgentResponseSchema } = await import('../../../src/generated/proto/leapmux/v1/agent_pb')
   const channel = await getTestChannel(hubUrl, cookie)
+  const initialOptions = {
+    ...options?.optionValues,
+    ...(options?.model ? { model: options.model } : {}),
+  }
 
   // No workspace announcement. A channel carries no workspace set at all, so a
   // workspace created after the cached ChannelManager handshook needs no extra
@@ -614,10 +620,7 @@ export async function openAgentViaAPI(
       workerId,
       workingDir: workingDir ?? '',
       ...(options?.title ? { title: options.title } : {}),
-      // The proto carries model under the `options` map, not a top-level `model`
-      // field; create() would silently drop a spread `{ model }`, opening
-      // the agent at the provider default instead of the requested model.
-      ...(options?.model ? { options: { model: options.model } } : {}),
+      ...(Object.keys(initialOptions).length > 0 ? { options: initialOptions } : {}),
       ...(options?.agentProvider ? { agentProvider: options.agentProvider } : {}),
       ...(options?.createWorktree ? { createWorktree: true, worktreeBranch: options.worktreeBranch ?? '' } : {}),
       ...(options?.worktreeBaseBranch ? { worktreeBaseBranch: options.worktreeBaseBranch } : {}),

--- a/frontend/tests/e2e/helpers/ui.ts
+++ b/frontend/tests/e2e/helpers/ui.ts
@@ -1186,6 +1186,27 @@ async function ensureExpanded(trigger: Locator) {
   await expect(trigger).toHaveAttribute('aria-expanded', 'true')
 }
 
+/**
+ * Whether the agent's permission-mode picker currently offers one option id.
+ *
+ * A permission shortcut is drawn only when the session offers every value its preset
+ * sets, so a spec that must know which shortcut to expect asks the picker rather than
+ * guessing from the provider. Leaves every composer menu closed.
+ */
+export async function permissionModeOffered(page: Page, modeId: string): Promise<boolean> {
+  const group = await openSettingsMenu(page, 'permissionMode')
+  const offered = await group.locator(`[data-testid="permissionMode-${modeId}"]`).count() > 0
+  await closeComposerMenus(page)
+  return offered
+}
+
+/** Apply one composer permission preset and wait for the settings round-trip. */
+export async function applyPermissionPreset(page: Page, kind: 'smart' | 'bypass') {
+  const menu = await openPlusMenu(page)
+  await menu.getByTestId(`composer-${kind}-permissions`).click()
+  await waitForSettingsIdle(page)
+}
+
 /** Open the composer's `[+]` menu and leave it open. */
 export async function openPlusMenu(page: Page): Promise<Locator> {
   const plus = page.locator('[data-testid="composer-plus-trigger"]')

--- a/frontend/tests/e2e/process-control-fixtures.ts
+++ b/frontend/tests/e2e/process-control-fixtures.ts
@@ -18,7 +18,7 @@ import {
   listOnlineWorkerIDsViaAPI,
   loginViaAPI,
   mintRegistrationKeyViaAPI,
-  openAgentViaAPI,
+  openPinnedModeAgentViaAPI,
   signUpViaAPI,
   TEST_ADMIN_DISPLAY_NAME,
   TEST_ADMIN_PASSWORD,
@@ -514,9 +514,7 @@ export const processTest = base.extend<
       adminToken,
       `e2e-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
     )
-    await openAgentViaAPI(hubUrl, adminToken, workerId, workspaceId, undefined, {
-      optionValues: { permissionMode: 'default' },
-    })
+    await openPinnedModeAgentViaAPI(hubUrl, adminToken, workerId, workspaceId)
     await use({ workspaceId })
     // Stop the workspace's agents on the worker BEFORE the hub soft-delete -- the
     // same cascade the browser app runs (deleteWorkspaceViaAPI only does the hub

--- a/frontend/tests/e2e/process-control-fixtures.ts
+++ b/frontend/tests/e2e/process-control-fixtures.ts
@@ -514,7 +514,9 @@ export const processTest = base.extend<
       adminToken,
       `e2e-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
     )
-    await openAgentViaAPI(hubUrl, adminToken, workerId, workspaceId)
+    await openAgentViaAPI(hubUrl, adminToken, workerId, workspaceId, undefined, {
+      optionValues: { permissionMode: 'default' },
+    })
     await use({ workspaceId })
     // Stop the workspace's agents on the worker BEFORE the hub soft-delete -- the
     // same cascade the browser app runs (deleteWorkspaceViaAPI only does the hub

--- a/proto/leapmux/v1/agent.proto
+++ b/proto/leapmux/v1/agent.proto
@@ -262,6 +262,22 @@ message AvailableOption {
   // the frontend recompute those dependent groups the instant the model selection
   // changes, instead of waiting for the worker to re-emit them after a relaunch.
   repeated AvailableOptionGroup sub_groups = 5;
+  // clears carries the OTHER option values this one settles as a side effect, so the
+  // picker can say so before the click rather than leaving the user to notice afterwards
+  // that a second axis moved. GitHub Copilot's Assisted Approval "On" clears Allow All:
+  // Assisted Approval narrows what runs without a prompt, so the broader permission
+  // cannot stand beside it.
+  //
+  // It states a CONSEQUENCE, not a prohibition. The reverse selection stays legal, and
+  // the worker settles the axes either way -- this only lets the UI describe what the
+  // worker is about to do.
+  repeated OptionSideEffect clears = 6;
+}
+
+// OptionSideEffect names one option value that another option's selection settles.
+message OptionSideEffect {
+  string group_id = 1;  // The group whose value changes (e.g. "allow_all")
+  string value = 2;     // The value that group takes (e.g. "off")
 }
 
 // AvailableOptionGroup is one axis of agent configuration. ALL agent options

--- a/scripts/generate-contracts.mjs
+++ b/scripts/generate-contracts.mjs
@@ -1779,7 +1779,56 @@ ${rows}
 }
 
 // ---------------------------------------------------------------------------
-// provider protocols: a coding agent's own wire vocabulary (zcode, pi)
+// GitHub Copilot permission identifiers
+// ---------------------------------------------------------------------------
+
+export function checkCopilotPermissions(c) {
+  mustBe(new Set(Object.values(c.groups)).size === Object.keys(c.groups).length, 'copilot-permissions.json', 'group identifiers must be unique')
+  mustBe(new Set(Object.values(c.values)).size === Object.keys(c.values).length, 'copilot-permissions.json', 'value identifiers must be unique')
+  return {}
+}
+
+export function emitGoCopilotPermissions(c) {
+  const groups = Object.entries(c.groups)
+    .map(([name, value]) => ({ name: `CopilotPermissionGroup${name}`, value: jsonString(value) }))
+  const values = Object.entries(c.values)
+    .map(([name, value]) => ({ name: `CopilotPermissionValue${name}`, value: jsonString(value) }))
+  return `${GO_HEADER('copilot-permissions.json')}package contracts
+
+// CopilotPermissionGroup* identify the two Copilot permission axes.
+const (
+${goConstBlock(groups)}
+)
+
+// CopilotPermissionValue* are the values that both permission axes use.
+const (
+${goConstBlock(values)}
+)
+`
+}
+
+export function emitTsCopilotPermissions(c) {
+  const groups = Object.entries(c.groups)
+    .map(([name, value]) => `  ${name}: ${jsonString(value)},`)
+    .join('\n')
+  const values = Object.entries(c.values)
+    .map(([name, value]) => `  ${name}: ${jsonString(value)},`)
+    .join('\n')
+  return `${TS_HEADER('copilot-permissions.json')}
+/** The option group identifiers for Copilot permission controls. */
+export const COPILOT_PERMISSION_GROUP = {
+${groups}
+} as const
+
+/** The values that both Copilot permission controls use. */
+export const COPILOT_PERMISSION_VALUE = {
+${values}
+} as const
+`
+}
+
+// ---------------------------------------------------------------------------
+// provider protocols: a coding agent's own wire vocabulary (zcode, pi, goose)
 // ---------------------------------------------------------------------------
 
 /**
@@ -1810,6 +1859,15 @@ const PROVIDER_PROTOCOLS = [
       { key: 'modes', goTable: 'Mode', tsTable: 'MODE', tsType: 'ZCodeMode', doc: 'session modes, carried on LeapMux\'s permission-mode axis' },
       { key: 'resultTypes', goTable: 'Result', tsTable: 'RESULT', tsType: 'ZCodeResult', doc: '`turn.completed.resultType`' },
       { key: 'decisions', goTable: 'Decision', tsTable: 'DECISION', tsType: 'ZCodeDecision', doc: '`permission.resolved.decision`' },
+    ],
+  },
+  {
+    name: 'goose-protocol',
+    goPrefix: 'Goose',
+    tsPrefix: 'GOOSE',
+    title: 'Goose',
+    tables: [
+      { key: 'modes', goTable: 'Mode', tsTable: 'MODE', tsType: 'GooseMode', doc: 'permission modes' },
     ],
   },
   {
@@ -2293,6 +2351,15 @@ const DOMAINS = [
       checkCodexBypass(c)
       out['backend/generated/contracts/codex-bypass.go'] = emitGoCodexBypass(c)
       out['frontend/src/generated/contracts/codex-bypass.ts'] = emitTsCodexBypass(c)
+    },
+  },
+  {
+    name: 'copilot-permissions',
+    emit(out, read) {
+      const c = read('copilot-permissions')
+      checkCopilotPermissions(c)
+      out['backend/generated/contracts/copilot-permissions.go'] = emitGoCopilotPermissions(c)
+      out['frontend/src/generated/contracts/copilot-permissions.ts'] = emitTsCopilotPermissions(c)
     },
   },
   {

--- a/scripts/generate-contracts.mjs
+++ b/scripts/generate-contracts.mjs
@@ -1779,56 +1779,7 @@ ${rows}
 }
 
 // ---------------------------------------------------------------------------
-// GitHub Copilot permission identifiers
-// ---------------------------------------------------------------------------
-
-export function checkCopilotPermissions(c) {
-  mustBe(new Set(Object.values(c.groups)).size === Object.keys(c.groups).length, 'copilot-permissions.json', 'group identifiers must be unique')
-  mustBe(new Set(Object.values(c.values)).size === Object.keys(c.values).length, 'copilot-permissions.json', 'value identifiers must be unique')
-  return {}
-}
-
-export function emitGoCopilotPermissions(c) {
-  const groups = Object.entries(c.groups)
-    .map(([name, value]) => ({ name: `CopilotPermissionGroup${name}`, value: jsonString(value) }))
-  const values = Object.entries(c.values)
-    .map(([name, value]) => ({ name: `CopilotPermissionValue${name}`, value: jsonString(value) }))
-  return `${GO_HEADER('copilot-permissions.json')}package contracts
-
-// CopilotPermissionGroup* identify the two Copilot permission axes.
-const (
-${goConstBlock(groups)}
-)
-
-// CopilotPermissionValue* are the values that both permission axes use.
-const (
-${goConstBlock(values)}
-)
-`
-}
-
-export function emitTsCopilotPermissions(c) {
-  const groups = Object.entries(c.groups)
-    .map(([name, value]) => `  ${name}: ${jsonString(value)},`)
-    .join('\n')
-  const values = Object.entries(c.values)
-    .map(([name, value]) => `  ${name}: ${jsonString(value)},`)
-    .join('\n')
-  return `${TS_HEADER('copilot-permissions.json')}
-/** The option group identifiers for Copilot permission controls. */
-export const COPILOT_PERMISSION_GROUP = {
-${groups}
-} as const
-
-/** The values that both Copilot permission controls use. */
-export const COPILOT_PERMISSION_VALUE = {
-${values}
-} as const
-`
-}
-
-// ---------------------------------------------------------------------------
-// provider protocols: a coding agent's own wire vocabulary (zcode, pi, goose)
+// provider protocols: a coding agent's own wire vocabulary (zcode, claude, goose, copilot, pi)
 // ---------------------------------------------------------------------------
 
 /**
@@ -1838,8 +1789,11 @@ ${values}
  * They share one emitter because they pose one problem. A provider's envelope `type`
  * and payload `kind` are dispatch keys on BOTH sides -- the Go worker classifies the
  * row, the TS plugin renders it -- so the two copies must agree exactly, and a
- * one-character drift silently stops rendering rather than failing a build. Neither
- * language owns the values: the agent's vendor does.
+ * one-character drift silently stops rendering rather than failing a build. The agent's
+ * vendor usually owns the values, and neither language does. A domain where LeapMux owns
+ * part of the vocabulary (copilot-permissions) states that in its own `preamble`, which
+ * replaces the default sentence in both emitted headers -- a generated comment that
+ * claims the wrong owner is worse than none.
  *
  * `goPrefix` and `tsPrefix` build the emitted identifiers, so a table needs no
  * per-constant name entry: the Go constant is `<goPrefix><Table><Key>` and the TS key
@@ -1868,6 +1822,31 @@ const PROVIDER_PROTOCOLS = [
     title: 'Goose',
     tables: [
       { key: 'modes', goTable: 'Mode', tsTable: 'MODE', tsType: 'GooseMode', doc: 'permission modes' },
+    ],
+  },
+  {
+    name: 'claude-protocol',
+    goPrefix: 'Claude',
+    tsPrefix: 'CLAUDE',
+    title: 'Claude Code',
+    tables: [
+      { key: 'modes', goTable: 'Mode', tsTable: 'MODE', tsType: 'ClaudeMode', doc: 'permission modes' },
+    ],
+  },
+  {
+    name: 'copilot-permissions',
+    goPrefix: 'CopilotPermission',
+    tsPrefix: 'COPILOT_PERMISSION',
+    title: 'GitHub Copilot',
+    preamble: [
+      'Copilot\'s permission vocabulary. GitHub owns `allow_all` and the two values;',
+      'LeapMux owns `copilot_assisted_approval`, the axis its launch flags drive. Both',
+      'sides read them -- the Go worker builds the option group, the browser plugin builds',
+      'the preset -- so they are generated from one file rather than hand-copied into two.',
+    ].join('\n// '),
+    tables: [
+      { key: 'groups', goTable: 'Group', tsTable: 'GROUP', tsType: 'CopilotPermissionGroup', doc: 'permission option-group ids' },
+      { key: 'values', goTable: 'Value', tsTable: 'VALUE', tsType: 'CopilotPermissionValue', doc: 'permission values, shared by both axes' },
     ],
   },
   {
@@ -1922,12 +1901,13 @@ export function emitGoProviderProtocol(spec, p) {
   const extra = p.defaultMode == null
     ? ''
     : `\n// ${spec.goPrefix}DefaultMode is the mode a fresh session runs on.\nconst ${spec.goPrefix}DefaultMode = ${spec.goPrefix}Mode${p.defaultMode}\n`
-  return `${GO_HEADER(`${spec.name}.json`)}package contracts
-
-// ${spec.title}'s wire vocabulary. These literals are dispatch keys on BOTH sides --
+  const preamble = spec.preamble ?? `${spec.title}'s wire vocabulary. These literals are dispatch keys on BOTH sides --
 // the Go worker classifies each row, the browser plugin renders it -- so they are
 // generated from one file rather than hand-copied into two. ${spec.title}'s vendor owns
-// the values; LeapMux follows them.
+// the values; LeapMux follows them.`
+  return `${GO_HEADER(`${spec.name}.json`)}package contracts
+
+// ${preamble}
 
 ${blocks.join('\n\n')}
 ${extra}`
@@ -1942,9 +1922,10 @@ export function emitTsProviderProtocol(spec, p) {
   const extra = p.defaultMode == null
     ? ''
     : `\n/** The mode a fresh ${spec.title} session runs on. */\nexport const ${spec.tsPrefix}_DEFAULT_MODE = ${spec.tsPrefix}_MODE.${p.defaultMode}\n`
+  const preamble = spec.preamble ?? `${spec.title}'s wire vocabulary, generated from contracts/${spec.name}.json. The Go
+// provider reads the same tables, so the two can no longer drift by a character.`
   return `${TS_HEADER(`${spec.name}.json`)}
-// ${spec.title}'s wire vocabulary, generated from contracts/${spec.name}.json. The Go
-// provider reads the same tables, so the two can no longer drift by a character.
+// ${preamble}
 
 ${blocks.join('\n\n')}
 ${extra}`
@@ -2351,15 +2332,6 @@ const DOMAINS = [
       checkCodexBypass(c)
       out['backend/generated/contracts/codex-bypass.go'] = emitGoCodexBypass(c)
       out['frontend/src/generated/contracts/codex-bypass.ts'] = emitTsCodexBypass(c)
-    },
-  },
-  {
-    name: 'copilot-permissions',
-    emit(out, read) {
-      const c = read('copilot-permissions')
-      checkCopilotPermissions(c)
-      out['backend/generated/contracts/copilot-permissions.go'] = emitGoCopilotPermissions(c)
-      out['frontend/src/generated/contracts/copilot-permissions.ts'] = emitTsCopilotPermissions(c)
     },
   },
   {

--- a/scripts/generate-contracts.test.mjs
+++ b/scripts/generate-contracts.test.mjs
@@ -19,6 +19,7 @@ import { describe, expect, it } from 'bun:test'
 import {
   bufDescriptor,
   checkCodexBypass,
+  checkCopilotPermissions,
   checkDesktop,
   checkHeaders,
   checkListen,
@@ -38,6 +39,7 @@ import {
   DESKTOP_RS_BEHAVIOR_NAMES,
   DESKTOP_RS_MACOS_ONLY_EVENTS,
   DESKTOP_TS_BEHAVIOR_NAMES,
+  emitGoCopilotPermissions,
   emitGoDesktop,
   emitGoHeaders,
   emitGoListen,
@@ -46,6 +48,7 @@ import {
   emitGoValidate,
   emitGoWire,
   emitRsDesktop,
+  emitTsCopilotPermissions,
   emitTsDesktop,
   emitTsHeaders,
   emitTsListen,
@@ -449,6 +452,55 @@ describe('checkCodexBypass', () => {
   })
 })
 
+describe('checkCopilotPermissions', () => {
+  const valid = () => ({
+    groups: {
+      AssistedApproval: 'copilot_assisted_approval',
+      AllowAll: 'allow_all',
+    },
+    values: { Off: 'off', On: 'on' },
+  })
+
+  it('accepts unique group and value identifiers', () => {
+    expect(checkCopilotPermissions(valid())).toEqual({})
+  })
+
+  it('rejects duplicate group or value identifiers', () => {
+    expectContractError(() => checkCopilotPermissions({
+      ...valid(),
+      groups: { AssistedApproval: 'allow_all', AllowAll: 'allow_all' },
+    }), 'group identifiers must be unique')
+    expectContractError(() => checkCopilotPermissions({
+      ...valid(),
+      values: { Off: 'on', On: 'on' },
+    }), 'value identifiers must be unique')
+  })
+})
+
+describe('copilot permission emitters', () => {
+  const contract = {
+    groups: {
+      AssistedApproval: 'copilot_assisted_approval',
+      AllowAll: 'allow_all',
+    },
+    values: { Off: 'off', On: 'on' },
+  }
+
+  it('emits matching identifiers for Go and TypeScript', () => {
+    const go = emitGoCopilotPermissions(contract)
+    const ts = emitTsCopilotPermissions(contract)
+    for (const value of ['copilot_assisted_approval', 'allow_all', 'off', 'on']) {
+      expect(go).toContain(JSON.stringify(value))
+      expect(ts).toContain(JSON.stringify(value))
+    }
+  })
+
+  it('is deterministic', () => {
+    expect(emitGoCopilotPermissions(contract)).toBe(emitGoCopilotPermissions(contract))
+    expect(emitTsCopilotPermissions(contract)).toBe(emitTsCopilotPermissions(contract))
+  })
+})
+
 // The pool the worker and the browser dialogs both name tabs from. The schema
 // holds the per-name shape; these are the two relations it cannot express.
 describe('checkTabNames', () => {
@@ -576,7 +628,9 @@ describe('generate', () => {
     expect(Object.keys(files).sort()).toEqual([
       'backend/generated/contracts/captcha.go',
       'backend/generated/contracts/codex-bypass.go',
+      'backend/generated/contracts/copilot-permissions.go',
       'backend/generated/contracts/desktop.go',
+      'backend/generated/contracts/goose-protocol.go',
       'backend/generated/contracts/headers.go',
       'backend/generated/contracts/listen.go',
       'backend/generated/contracts/pi-protocol.go',
@@ -594,7 +648,9 @@ describe('generate', () => {
       'desktop/rust/src/generated/contracts.rs',
       'frontend/src/generated/contracts/captcha.ts',
       'frontend/src/generated/contracts/codex-bypass.ts',
+      'frontend/src/generated/contracts/copilot-permissions.ts',
       'frontend/src/generated/contracts/desktop.ts',
+      'frontend/src/generated/contracts/goose-protocol.ts',
       'frontend/src/generated/contracts/headers.ts',
       'frontend/src/generated/contracts/listen.ts',
       'frontend/src/generated/contracts/pi-protocol.ts',

--- a/scripts/generate-contracts.test.mjs
+++ b/scripts/generate-contracts.test.mjs
@@ -370,7 +370,7 @@ describe('emitters', () => {
   })
 })
 
-// The provider-protocol domains (zcode, pi) carry an agent's OWN wire vocabulary, and
+// The provider-protocol domains (ZCode, Goose, Pi) carry an agent's OWN wire vocabulary, and
 // both languages dispatch on the literals -- so the checks below are what stop a table
 // from reaching one side and not the other, or from carrying two branches the wire
 // cannot tell apart.

--- a/scripts/generate-contracts.test.mjs
+++ b/scripts/generate-contracts.test.mjs
@@ -19,7 +19,6 @@ import { describe, expect, it } from 'bun:test'
 import {
   bufDescriptor,
   checkCodexBypass,
-  checkCopilotPermissions,
   checkDesktop,
   checkHeaders,
   checkListen,
@@ -39,7 +38,6 @@ import {
   DESKTOP_RS_BEHAVIOR_NAMES,
   DESKTOP_RS_MACOS_ONLY_EVENTS,
   DESKTOP_TS_BEHAVIOR_NAMES,
-  emitGoCopilotPermissions,
   emitGoDesktop,
   emitGoHeaders,
   emitGoListen,
@@ -48,7 +46,6 @@ import {
   emitGoValidate,
   emitGoWire,
   emitRsDesktop,
-  emitTsCopilotPermissions,
   emitTsDesktop,
   emitTsHeaders,
   emitTsListen,
@@ -370,7 +367,8 @@ describe('emitters', () => {
   })
 })
 
-// The provider-protocol domains (ZCode, Goose, Pi) carry an agent's OWN wire vocabulary, and
+// The provider-protocol domains (ZCode, Goose, Copilot, Pi) carry the wire vocabulary the two
+// languages dispatch on, and
 // both languages dispatch on the literals -- so the checks below are what stop a table
 // from reaching one side and not the other, or from carrying two branches the wire
 // cannot tell apart.
@@ -449,55 +447,6 @@ describe('checkCodexBypass', () => {
       () => checkCodexBypass({ settings: [{ id: 'permissionMode', value: 'never', planOption: false }] }),
       'at least one plan option is required',
     )
-  })
-})
-
-describe('checkCopilotPermissions', () => {
-  const valid = () => ({
-    groups: {
-      AssistedApproval: 'copilot_assisted_approval',
-      AllowAll: 'allow_all',
-    },
-    values: { Off: 'off', On: 'on' },
-  })
-
-  it('accepts unique group and value identifiers', () => {
-    expect(checkCopilotPermissions(valid())).toEqual({})
-  })
-
-  it('rejects duplicate group or value identifiers', () => {
-    expectContractError(() => checkCopilotPermissions({
-      ...valid(),
-      groups: { AssistedApproval: 'allow_all', AllowAll: 'allow_all' },
-    }), 'group identifiers must be unique')
-    expectContractError(() => checkCopilotPermissions({
-      ...valid(),
-      values: { Off: 'on', On: 'on' },
-    }), 'value identifiers must be unique')
-  })
-})
-
-describe('copilot permission emitters', () => {
-  const contract = {
-    groups: {
-      AssistedApproval: 'copilot_assisted_approval',
-      AllowAll: 'allow_all',
-    },
-    values: { Off: 'off', On: 'on' },
-  }
-
-  it('emits matching identifiers for Go and TypeScript', () => {
-    const go = emitGoCopilotPermissions(contract)
-    const ts = emitTsCopilotPermissions(contract)
-    for (const value of ['copilot_assisted_approval', 'allow_all', 'off', 'on']) {
-      expect(go).toContain(JSON.stringify(value))
-      expect(ts).toContain(JSON.stringify(value))
-    }
-  })
-
-  it('is deterministic', () => {
-    expect(emitGoCopilotPermissions(contract)).toBe(emitGoCopilotPermissions(contract))
-    expect(emitTsCopilotPermissions(contract)).toBe(emitTsCopilotPermissions(contract))
   })
 })
 
@@ -627,6 +576,7 @@ describe('generate', () => {
     const files = generate(join(ROOT, 'contracts'), DESCRIPTOR)
     expect(Object.keys(files).sort()).toEqual([
       'backend/generated/contracts/captcha.go',
+      'backend/generated/contracts/claude-protocol.go',
       'backend/generated/contracts/codex-bypass.go',
       'backend/generated/contracts/copilot-permissions.go',
       'backend/generated/contracts/desktop.go',
@@ -647,6 +597,7 @@ describe('generate', () => {
       'backend/generated/contracts/zcode-protocol.go',
       'desktop/rust/src/generated/contracts.rs',
       'frontend/src/generated/contracts/captcha.ts',
+      'frontend/src/generated/contracts/claude-protocol.ts',
       'frontend/src/generated/contracts/codex-bypass.ts',
       'frontend/src/generated/contracts/copilot-permissions.ts',
       'frontend/src/generated/contracts/desktop.ts',
@@ -666,6 +617,40 @@ describe('generate', () => {
       'frontend/src/generated/contracts/worker-vocab.ts',
       'frontend/src/generated/contracts/zcode-protocol.ts',
     ])
+  })
+
+  // The two domains this change added ride the shared PROVIDER_PROTOCOLS path rather than
+  // bespoke emitters, so these pin what that path gives them and the bespoke one did not.
+  it('emits the shared provider-protocol shape for the newest domains', () => {
+    const files = generate(join(ROOT, 'contracts'), DESCRIPTOR)
+
+    // A TS union type per table -- the bespoke Copilot emitter produced none.
+    const copilotTs = files['frontend/src/generated/contracts/copilot-permissions.ts']
+    expect(copilotTs).toContain('export type CopilotPermissionGroup =')
+    expect(copilotTs).toContain('export type CopilotPermissionValue =')
+    // The identifiers both languages already import must not move.
+    expect(copilotTs).toContain('export const COPILOT_PERMISSION_GROUP = {')
+    expect(files['backend/generated/contracts/copilot-permissions.go'])
+      .toContain('CopilotPermissionGroupAssistedApproval = "copilot_assisted_approval"')
+    // LeapMux owns one of the two Copilot ids, so the domain overrides the shared
+    // header rather than claiming the vendor owns every value in the file.
+    expect(files['backend/generated/contracts/copilot-permissions.go'])
+      .not
+      .toContain('vendor owns\n// the values')
+
+    // Goose's fallback mode now comes from the contract instead of being spelled in Go
+    // and in TypeScript by hand.
+    expect(files['backend/generated/contracts/goose-protocol.go'])
+      .toContain('GooseDefaultMode = GooseModeSmartApprove')
+    expect(files['frontend/src/generated/contracts/goose-protocol.ts'])
+      .toContain('export const GOOSE_DEFAULT_MODE = GOOSE_MODE.SmartApprove')
+
+    // Claude's modes are the last permission vocabulary that was spelled by hand in both
+    // languages; the plugin and the worker now read this one table.
+    expect(files['backend/generated/contracts/claude-protocol.go'])
+      .toContain('ClaudeModeBypassPermissions = "bypassPermissions"')
+    expect(files['frontend/src/generated/contracts/claude-protocol.ts'])
+      .toContain('export const CLAUDE_DEFAULT_MODE = CLAUDE_MODE.Default')
   })
 
   it('fails loudly when a registered domain is missing its contract file', () => {

--- a/site/content/docs/reference/glossary.md
+++ b/site/content/docs/reference/glossary.md
@@ -107,7 +107,7 @@ One named thing an app may do, such as `file:read` or `terminal:write`. A grant 
 
 ### Permission mode
 
-A per-agent setting that controls when the agent asks before it acts. Examples include Claude Code Auto Mode, Goose Smart Approve, GitHub Copilot Assisted Approval, and provider bypass modes. The composer's **[+]** menu offers Smart permissions and Bypass permissions shortcuts when the current session supports them. See [Coding Agents](/docs/using/coding-agents/).
+A per-agent setting that controls when the agent asks before it acts. Examples include Claude Code Auto Mode, Goose Smart Approve, and each provider's bypass mode. Change it from the composer's mode chip or its **[+]** menu. That menu also offers the Smart permissions and Bypass permissions shortcuts, which select these values for you when the session supports them. A provider can carry a separate permission option group beside this axis, such as GitHub Copilot Assisted Approval. See [Coding Agents](/docs/using/coding-agents/).
 
 ### Post-quantum encryption
 

--- a/site/content/docs/reference/glossary.md
+++ b/site/content/docs/reference/glossary.md
@@ -107,7 +107,7 @@ One named thing an app may do, such as `file:read` or `terminal:write`. A grant 
 
 ### Permission mode
 
-A per-agent setting that controls how often the agent asks before it acts — for example Claude Code's **Default**, **Plan Mode**, and **Bypass Permissions**, or Codex's approval policies. Change it from the composer's mode chip or its **[+]** menu. See [Coding Agents](/docs/using/coding-agents/).
+A per-agent setting that controls when the agent asks before it acts. Examples include Claude Code Auto Mode, Goose Smart Approve, GitHub Copilot Assisted Approval, and provider bypass modes. The composer's **[+]** menu offers Smart permissions and Bypass permissions shortcuts when the current session supports them. See [Coding Agents](/docs/using/coding-agents/).
 
 ### Post-quantum encryption
 

--- a/site/content/docs/reference/troubleshooting.md
+++ b/site/content/docs/reference/troubleshooting.md
@@ -427,18 +427,20 @@ The agent subprocess couldn't be launched or didn't complete its startup handsha
 - If startup is legitimately slow, raise the timeout: `leapmux worker --agent-startup-timeout 10m` (or the equivalent key in config). The flag exists on the Worker only; in solo/dev the embedded worker reads the timeout from the `timeouts` setting: `leapmux control admin settings set timeouts '{"agent_startup_seconds":600}'`. See [Configuration](/docs/admin/configuration/).
 - Reopen the agent once the underlying CLI issue is fixed.
 
-### A model, effort, or permission-mode change seems to "reset" the agent
+### A setting change seems to "reset" the agent
 
 **Symptom**
-Changing the model or effort from a composer chip or the **[+]** menu restarts the agent.
+Changing a setting from a composer chip or the **[+]** menu restarts the agent.
 
 **Cause**
-Most settings changes are applied **live**, without a restart: switching effort to a concrete level (e.g. high → xhigh) and changing the permission mode are applied in place for both Claude Code and Codex.
+Most settings changes apply **live**. Some settings control process launch arguments and require a restart. Copilot Assisted Approval is one example. LeapMux adds `--experimental` and `--assisted-approval` when this option is on. This option also enables all Copilot experimental features.
 
-A restart happens only when you switch effort back to **Auto** — the CLI must relaunch without an `--effort` flag. Changing the model resets effort to Auto, so it restarts too. The change is applied optimistically and rolled back on failure.
+Some Copilot CLI versions reject Assisted Approval with Agent Client Protocol (ACP) mode. LeapMux retries a new session with the safe default switched off. It hides Assisted Approval for that session. An explicit request still fails and shows the startup error.
+
+An effort change to **Auto** also requires a restart because LeapMux must remove the `--effort` argument. A model change can reset effort to Auto. Reasonix also fixes its model at process launch.
 
 **Fix**
-No action needed — wait for the agent to come back up. If it fails to restart, you'll see the start failure described above; resolve that.
+Wait for the agent to start again. If the start fails, use the startup error guidance above.
 
 ## Docker
 

--- a/site/content/docs/reference/troubleshooting.md
+++ b/site/content/docs/reference/troubleshooting.md
@@ -435,7 +435,7 @@ Changing a setting from a composer chip or the **[+]** menu restarts the agent.
 **Cause**
 Most settings changes apply **live**. Some settings control process launch arguments and require a restart. Copilot Assisted Approval is one example. LeapMux adds `--experimental` and `--assisted-approval` when this option is on. This option also enables all Copilot experimental features.
 
-Some Copilot CLI versions reject Assisted Approval with Agent Client Protocol (ACP) mode. LeapMux retries a new session with the safe default switched off. It hides Assisted Approval for that session. An explicit request still fails and shows the startup error.
+Some Copilot CLI versions reject Assisted Approval with Agent Client Protocol (ACP) mode. LeapMux retries a new session with the safe default switched off, and locks Assisted Approval to Off for that session. It also remembers that this CLI refuses the flag, so every later session and every restart starts with the flag off. An explicit request still fails and shows the startup error.
 
 An effort change to **Auto** also requires a restart because LeapMux must remove the `--effort` argument. A model change can reset effort to Auto. Reasonix also fixes its model at process launch.
 

--- a/site/content/docs/using/coding-agents.md
+++ b/site/content/docs/using/coding-agents.md
@@ -158,7 +158,7 @@ Not every image renders inline:
 - **Images above about 5 MB** show a placeholder instead of the picture.
 - **An image the agent gives by URL** shows an **open ↗** link instead of the picture. Rendering it would fetch from that host, which the transcript never does on its own.
 
-Every provider except ZCode can return an image: Claude Code, Codex, Pi, and each ACP provider (OpenCode, Cursor, GitHub Copilot, Kilo, Goose, Reasonix). ZCode's app server turns an image part into a placeholder string before it reaches LeapMux, so there is no picture left to draw.
+Every provider except ZCode can return an image: Claude Code, Codex, Pi, and each Agent Client Protocol (ACP) provider (OpenCode, Cursor, GitHub Copilot, Kilo, Goose, Reasonix). ZCode's app server turns an image part into a placeholder string before it reaches LeapMux, so there is no picture left to draw.
 
 ### The todo / plan sidebar
 
@@ -237,7 +237,7 @@ The **[+]** menu holds every axis, including provider-specific options that have
 
 Providers can add two adjacent permission shortcuts. **Smart permissions** selects the provider's safety-assisted mode. **Bypass permissions** disables permission prompts. Smart permissions is always directly above Bypass permissions. A shortcut appears only when the session offers every setting and value that the preset needs.
 
-Claude Code blocks an unsafe action in Auto Mode. Goose and GitHub Copilot ask for manual approval when their safety check does not approve an action.
+Each safety-assisted mode approves the calls it judges safe and asks about the others. Claude Code Auto Mode uses a classifier for that decision. Goose Smart Approve and GitHub Copilot Assisted Approval do the same.
 
 You can hide the status bar with **[+] > Show status bar**. The **[+]** menu still gives access to all status bar settings.
 
@@ -291,16 +291,16 @@ For providers that support a plan mode, **Shift+Tab** in the editor toggles betw
 | Provider | Default model | Default mode | Notes |
 | --- | --- | --- | --- |
 | Cursor | `auto` | `agent` | Has plan mode. |
-| GitHub Copilot | (CLI default) | `agent` | A new session enables Assisted Approval when the installed CLI supports it with Agent Client Protocol (ACP). Bypass permissions enables Allow All. Autopilot remains a workflow mode. |
+| GitHub Copilot | (CLI default) | `agent` | A new session enables Assisted Approval when the installed CLI supports it with ACP. Bypass permissions enables Allow All. Autopilot stays a permission mode, and no shortcut selects it. |
 | Goose | (CLI default) | `smart_approve` | Smart permissions selects Smart Approve. Bypass permissions selects Auto. Goose has no plan mode. |
 | OpenCode | (CLI default) | Primary Agent `build` | Has plan mode. |
 | Kilo | (CLI default) | Primary Agent `code` | Has plan mode. |
 
 In the UI you pick these as named radio options (**Auto**, **Agent**, **Autopilot**, **Build**, **Code**, and so on); the literal mode IDs above are only typed directly when driving an agent with `leapmux control agent set --permission-mode`.
 
-GitHub Copilot also has **Assisted Approval** and **Allow All** option groups. These options cannot both be on. Enabling one turns the other off. Assisted Approval launches Copilot with `--experimental` and `--assisted-approval`. Therefore, Assisted Approval also enables all Copilot experimental features.
+GitHub Copilot also has **Assisted Approval** and **Allow All** option groups. Assisted Approval narrows what runs without a prompt, so turning it on turns Allow All off. The picker states that consequence on the option itself. Allow All is the broader permission and supersedes Assisted Approval, so turning Allow All on leaves Assisted Approval as it is. Assisted Approval launches Copilot with `--experimental` and `--assisted-approval`. Therefore, Assisted Approval also enables all Copilot experimental features, and a change to it restarts the CLI.
 
-Some Copilot CLI versions reject Assisted Approval with ACP mode. LeapMux retries a new session with Assisted Approval off when only the safe default caused this error. LeapMux then hides the unavailable option. An explicit Assisted Approval request still reports the error.
+Some Copilot CLI versions reject Assisted Approval with ACP mode. LeapMux retries a new session with Assisted Approval off when only the safe default caused this error. LeapMux then locks the option to Off for that session. An explicit Assisted Approval request still reports the error.
 
 **Reasonix** — a **Model** selector only; it has no permission mode, no plan mode, and no bypass. Default model **DeepSeek Flash** (`deepseek-flash`); also offered: DeepSeek Pro, MiMo Pro, MiMo Flash (the MiMo models need `MIMO_API_KEY`). Reasonix fixes its model at launch, so switching the model restarts the agent. It is text-only — image, PDF, and binary attachments aren't supported — and still shows per-request approval banners.
 

--- a/site/content/docs/using/coding-agents.md
+++ b/site/content/docs/using/coding-agents.md
@@ -64,7 +64,7 @@ Open the **New agent** dialog from the workspace, then fill in the fields below 
 | **Git options** | Appears once a Worker is selected. Lets you start the agent on the current branch, switch branches, create a branch, or create/use a worktree. See [Worktrees & Branches](/docs/using/worktrees-and-branches/). |
 
 {{< callout type="info" >}}
-The dialog has **no model, effort, or permission-mode fields**. A new agent always starts with the provider's defaults; you change the model, reasoning effort, and permission mode afterward from the composer's status-bar chips or its **[+]** menu (see [Changing settings mid-session](#changing-settings-mid-session)).
+The dialog has **no model, effort, or permission-mode fields**. A new session uses the provider defaults and LeapMux's safe permission default. Claude Code requests Auto Mode and falls back to Default when Auto Mode is unavailable. Goose requests Smart Approve. GitHub Copilot requests Assisted Approval and disables Allow All. A resumed session keeps its stored settings. Change settings from the composer after the session starts (see [Changing settings mid-session](#changing-settings-mid-session)).
 {{< /callout >}}
 
 LeapMux remembers your most recently used provider and pre-selects it (when it is available on the chosen Worker), so you usually only have to pick a directory and click **Create**.
@@ -227,16 +227,22 @@ Its plan prompt is titled from the **ExitPlanMode** tool and shows the plan the 
 
 ### Other providers
 
-Cursor, GitHub Copilot, Goose, OpenCode, Kilo, and Reasonix render a permission banner whose title comes from the tool call (default **Permission Request**) and whose buttons come from the options the agent offered. An **& Bypass Permissions** option appears only for Goose and GitHub Copilot, which declare a bypass mode; Cursor, OpenCode, Kilo, and Reasonix declare none. Cursor, OpenCode, and Kilo plug in their own richer question handling where they support it.
+Cursor, GitHub Copilot, Goose, OpenCode, Kilo, and Reasonix render a permission banner. Its title comes from the tool call, and its default title is **Permission Request**. The buttons come from the options that the agent offered. Goose and GitHub Copilot also offer **& Bypass Permissions**. That button uses the same Bypass permissions preset as the composer menu. Cursor, OpenCode, Kilo, and Reasonix have no bypass preset. Cursor, OpenCode, and Kilo use their own question controls where available.
 
 ## Changing settings mid-session
 
 Beneath the editor box is a status bar with one chip per setting axis — the git branch, and the agent's current model, reasoning effort, and mode. Click a chip to change that axis.
 
-The **[+]** menu holds every axis, including the provider-specific options that get no chip, each as a submenu. It also holds **Agent info** (context usage, rate limits, session). You can hide the status bar with **[+] > Show status bar**; the **[+]** menu still reaches everything the bar shows.
+The **[+]** menu holds every axis, including provider-specific options that have no chip. Each axis has a submenu. The menu also holds **Agent info** for context usage, rate limits, and the session.
+
+Providers can add two adjacent permission shortcuts. **Smart permissions** selects the provider's safety-assisted mode. **Bypass permissions** disables permission prompts. Smart permissions is always directly above Bypass permissions. A shortcut appears only when the session offers every setting and value that the preset needs.
+
+Claude Code blocks an unsafe action in Auto Mode. Goose and GitHub Copilot ask for manual approval when their safety check does not approve an action.
+
+You can hide the status bar with **[+] > Show status bar**. The **[+]** menu still gives access to all status bar settings.
 
 {{< callout type="info" >}}
-Most settings changes apply **live**, without a restart: a concrete model or effort change and a permission-mode change take effect in place (the change is optimistic and rolls back if it fails). A restart happens when the provider can't apply the change to the running process — typically switching effort back to **Auto** or the Claude Code model back to **Default (recommended)**, which must relaunch the CLI without the flag — and for providers that fix the model at launch (Reasonix).
+Most settings changes apply **live**. LeapMux restarts the provider when a launch flag must change. Examples include Copilot Assisted Approval, effort **Auto**, Claude Code **Default (recommended)**, and a Reasonix model change. The interface applies each change optimistically and restores the prior value after a failure.
 {{< /callout >}}
 
 A picker shows radio items for up to 7 options and switches to a searchable list above that.
@@ -257,9 +263,10 @@ For providers that support a plan mode, **Shift+Tab** in the editor toggles betw
 - Effort tiers depend on the model:
   - **Fable 5**, **Opus (1M context)**, **Sonnet**, and **Sonnet (1M context)** offer the full set: Auto, Ultracode, Max, Extra High, High, Medium, Low.
   - **Haiku** has no effort tiers at all — the effort selector is hidden entirely when Haiku is the model, and the Worker never sends an effort flag for Haiku.
-- Permission modes: **Default** (the default), **Plan Mode**, **Accept Edits**, **Bypass Permissions**, **Don't Ask**, **Auto Mode**.
+- Permission modes: **Default**, **Plan Mode**, **Accept Edits**, **Bypass Permissions**, **Don't Ask**, **Auto Mode**. A new session uses Auto Mode when the session offers it. Otherwise, it uses Default.
+- Permission shortcuts: Smart permissions selects **Auto Mode**. Bypass permissions selects **Bypass Permissions**.
 
-**Codex** — Fast Mode, Effort, Model, Workflow, Network Access, Sandbox Policy, Approval Policy, plus a **Bypass permissions** item.
+**Codex** — Fast Mode, Effort, Model, Workflow, Network Access, Sandbox Policy, Approval Policy, plus a **Bypass permissions** shortcut.
 
 - Default model **Default (recommended)** (your Codex account's own pick); also offered: GPT-5.6-Sol, GPT-5.6-Terra, GPT-5.6-Luna, GPT-5.5, GPT-5.4, GPT-5.4-Mini, GPT-5.3-Codex-Spark. A running agent lists whatever models your Codex account offers, so an account-specific model appears here too.
 - Effort tiers depend on the model:
@@ -268,7 +275,7 @@ For providers that support a plan mode, **Shift+Tab** in the editor toggles betw
   - The other models offer Auto, Extra High, High, Medium, Low.
 - Approval Policy: **Full Auto** (`never`), **Suggest & Approve** (`on-request`, the default), **Auto-edit** (`untrusted`).
 - Sandbox defaults to **Workspace Write** (also Full Access / Read Only); Network defaults to **Restricted** (also Enabled).
-- The **Bypass permissions** item sets network = enabled, sandbox = full access, and approval = Full Auto in one click.
+- The **Bypass permissions** shortcut sets network to enabled, sandbox to full access, and approval to Full Auto in one change.
 
 **Pi** — **Thinking Level** (effort) and **Model**. Default model **glm-5.3**. Pi has no permission mode, no plan mode, and no bypass.
 
@@ -277,18 +284,23 @@ For providers that support a plan mode, **Shift+Tab** in the editor toggles betw
 - The models come from your own `~/.zcode/v2/config.json`, so the list is whatever that installation is signed in to. Each entry names its ZCode provider, which is what tells two rows apart when a plan and an API key both reach the same model. LeapMux orders them the way ZCode does and starts on the first — for the Z.ai plans that is **GLM-5.3**.
 - Thought levels are per model and also come from that configuration: **Low / High / Max** on GLM-5.3 and GLM-5.3-Flash, **Enabled / Off** on GLM-5-Turbo. **Auto** means the model's own default rather than no level at all.
 - Modes: **Plan**, **Build** (the default), **Edit**, **Yolo**. Shift+Tab toggles Plan, and Yolo is the bypass mode. ZCode's own `auto` mode is not offered: the shipped build denies every tool call under it.
+- Permission shortcuts: ZCode offers Bypass permissions for **Yolo**. It has no Smart permissions shortcut.
 
 **Other providers** — a single option group plus a model selector. Each axis gets its own chip, and each chip shows the current value.
 
 | Provider | Default model | Default mode | Notes |
 | --- | --- | --- | --- |
 | Cursor | `auto` | `agent` | Has plan mode. |
-| GitHub Copilot | (CLI default) | `agent` | Has plan and autopilot. |
-| Goose | (CLI default) | `auto` | Bypass = `auto` — Goose's default mode already is its bypass mode; **no plan mode**. |
+| GitHub Copilot | (CLI default) | `agent` | A new session enables Assisted Approval when the installed CLI supports it with Agent Client Protocol (ACP). Bypass permissions enables Allow All. Autopilot remains a workflow mode. |
+| Goose | (CLI default) | `smart_approve` | Smart permissions selects Smart Approve. Bypass permissions selects Auto. Goose has no plan mode. |
 | OpenCode | (CLI default) | Primary Agent `build` | Has plan mode. |
 | Kilo | (CLI default) | Primary Agent `code` | Has plan mode. |
 
 In the UI you pick these as named radio options (**Auto**, **Agent**, **Autopilot**, **Build**, **Code**, and so on); the literal mode IDs above are only typed directly when driving an agent with `leapmux control agent set --permission-mode`.
+
+GitHub Copilot also has **Assisted Approval** and **Allow All** option groups. These options cannot both be on. Enabling one turns the other off. Assisted Approval launches Copilot with `--experimental` and `--assisted-approval`. Therefore, Assisted Approval also enables all Copilot experimental features.
+
+Some Copilot CLI versions reject Assisted Approval with ACP mode. LeapMux retries a new session with Assisted Approval off when only the safe default caused this error. LeapMux then hides the unavailable option. An explicit Assisted Approval request still reports the error.
 
 **Reasonix** — a **Model** selector only; it has no permission mode, no plan mode, and no bypass. Default model **DeepSeek Flash** (`deepseek-flash`); also offered: DeepSeek Pro, MiMo Pro, MiMo Flash (the MiMo models need `MIMO_API_KEY`). Reasonix fixes its model at launch, so switching the model restarts the agent. It is text-only — image, PDF, and binary attachments aren't supported — and still shows per-request approval banners.
 
@@ -312,8 +324,8 @@ Picking a session is the manual path; most resumption happens automatically. Age
 
 ## Per-provider differences worth knowing
 
-- **Defaults vary by provider.** Claude Code starts in **Default** permission mode (it will ask before risky actions); Codex starts in **Suggest & Approve**. Both ask before doing dangerous things unless you bypass.
-- **Bypass is a deliberate, sticky choice.** The "& Bypass Permissions" / "Bypass permissions" actions stop the agent asking for approval for the rest of the session (Codex's button also opens the sandbox and network). Use them only when you trust the working directory and the task.
+- **Defaults vary by provider.** A new Claude Code session requests Auto Mode. A new Goose session uses Smart Approve. A new GitHub Copilot session uses Assisted Approval. Codex starts in Suggest & Approve. Resumed sessions keep their stored settings.
+- **Bypass is a deliberate, sticky choice.** The bypass controls stop the agent from asking for approval. Codex also opens the sandbox and network. Use bypass only when you trust the working directory and the task.
 - **Attachment support differs by provider** (see the [attachments table](#attachments)) — every provider takes text, but image, PDF and other-binary support varies. Reasonix takes text only, and ZCode takes an image only on a model that declares image input.
 - **Pi is minimal** — model and thinking level only, no permission/plan/bypass controls.
 - **ZCode borrows the desktop application's account.** Its models, credentials and thought levels all come from `~/.zcode/v2/config.json`, so what an agent can run matches what the ZCode application itself can run on that machine.


### PR DESCRIPTION
## Motivation

The composer offered no permission shortcut at all. A bypass was reachable only from a permission banner's **& Bypass Permissions** button (Goose and GitHub Copilot) or from a Codex-only settings-panel action, and there was no "safe middle" preset anywhere — a new session simply started on whatever its provider's own default happened to be.

The plumbing under those defaults had also drifted apart per provider. Each one decided its new-session mode and its fallback mode in a different, ad hoc place, and the two had fallen out of step: a resumed Goose session with no stored mode fell back to `auto`, which is also the mode Goose's own bypass preset selects, so it opened with every permission prompt silently disabled. Startup was equally brittle — a permission mode that LeapMux picked but the installed CLI could not enter aborted the whole tab, and after a restart a stored option the CLI refuses could leave the tab with no process at all and nothing naming the cause.

## Modifications

- Added one-click **Smart permissions** and **Bypass permissions** rows to the composer's `[+]` menu, gated by a new `permissionPresetAvailable()` check that shows a preset only when every option group it targets exists, is mutable, and offers the target value. Claude Code and Goose each gained a genuine smart preset (`auto` / `smart_approve`) beside their bypass preset.
- **Breaking (internal):** the frontend `Provider` plugin interface replaces `bypassSettings` + `settingsActions` with a single `permissionPresets: { smart?, bypass? }`. `ProviderBypassSettings`, which guaranteed a `permissionMode` key, is replaced by `ProviderPermissionPreset`, which guarantees nothing — so the plan-approval **Bypass Permissions** switch now renders only for a preset that actually carries a permission mode, instead of drawing a checkbox that silently does nothing. The Go `Provider` interface likewise drops `DefaultPermissionMode()` for `ResolveOptionConflicts(current, requested optionmap.Map) optionmap.Map`. Every call site is updated in this PR.
- Each provider now declares one `PermissionDefaults{NewSession, Fallback}` in its own `init()`, replacing the two separate declarations that let Goose's fallback drift into its bypass mode. `TestSafePermissionDefaultsAreNeverAProviderBypassMode` refuses that drift for Claude, Goose and ZCode.
- Added a Copilot **Assisted Approval** axis, backed by the `--experimental --assisted-approval` launch flags. Whether the installed CLI accepts them is remembered per binary for the worker process, so a later launch skips a known-failing attempt instead of paying a second spawn; the value is downgraded to Off only when LeapMux chose it, never when the user asked for it explicitly.
- A new `resolveLaunchOptions` funnel returns the resolved options and their provenance as one value, and every relaunch path rebuilds that provenance from the stored row. Startup keeps the mode the handshake reported when a LeapMux-picked mode is unavailable, and Claude's auto-mode fallback now treats any launch error the way it already treated the CLI's own refusal text.
- Copilot's two permission axes settle in one direction: Assisted Approval turns Allow All off, but not the reverse, because clearing Assisted Approval costs a process restart. A new `AvailableOption.clears` proto field (`OptionSideEffect{group_id, value}`) declares that consequence, and the picker states it in the option's tooltip.
- Claude's, Goose's and Copilot's permission vocabularies moved into generated contracts through the shared `PROVIDER_PROTOCOLS` table, which gained an optional `preamble` because LeapMux — not GitHub — owns the `copilot_assisted_approval` identifier.

## Result

You can switch an agent between assisted and unrestricted permission handling from the composer, and each shortcut appears only where the provider and the running session actually support it. A resumed Goose session no longer opens with every prompt disabled. A CLI that rejects a default LeapMux chose degrades to a working session instead of killing the tab, and it stays fixed across restarts rather than failing again each time. An option that changes a second setting says so before you click it.
