### PR TITLE
feat(sidebar): Add section and workspace row menus

### DIFF
--- a/backend/internal/hub/service/section_position_internal_test.go
+++ b/backend/internal/hub/service/section_position_internal_test.go
@@ -1,0 +1,208 @@
+package service
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/hub/store"
+)
+
+// nextSectionPosition places a new custom section directly above "Archived".
+//
+// The rule used to be reconstructed from two scanned anchors -- the last CUSTOM
+// position and the Archived position -- and handed to lexorank.Mid as a pair.
+// That holds only while the user leaves the seeded order alone. MoveSection
+// writes any position a client asks for and every section is draggable, so the
+// pair could arrive DESCENDING, which lexorank.between does not take: it
+// answered a rank below Archived, or a rank equal to a live section.
+//
+// These cases pin the ORDER-derived rule instead. Each one states the sidebar
+// it describes, because the scan must ignore the other sidebar entirely.
+
+// One section of a sidebar, spelled short so a case reads as a list.
+func sec(sidebar leapmuxv1.Sidebar, sectionType leapmuxv1.SectionType, position string) store.WorkspaceSection {
+	return store.WorkspaceSection{SectionType: sectionType, Sidebar: sidebar, Position: position}
+}
+
+const (
+	left  = leapmuxv1.Sidebar_SIDEBAR_LEFT
+	right = leapmuxv1.Sidebar_SIDEBAR_RIGHT
+
+	inProgress = leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_IN_PROGRESS
+	archived   = leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_ARCHIVED
+	custom     = leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_CUSTOM
+	workers    = leapmuxv1.SectionType_SECTION_TYPE_WORKERS
+)
+
+// The seeded layout, in the (sidebar, position) order ListByUserID returns.
+func seededSections() []store.WorkspaceSection {
+	return []store.WorkspaceSection{
+		sec(left, inProgress, "n"),
+		sec(left, archived, "nn"),
+		sec(left, workers, "nnn"),
+	}
+}
+
+func TestNextSectionPosition(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		sections []store.WorkspaceSection
+		sidebar  leapmuxv1.Sidebar
+		// The row the result must sort AFTER, and the row it must sort BEFORE.
+		// An empty string means "no bound on that side".
+		after  string
+		before string
+	}{
+		{
+			name:     "lands between In progress and Archived on a seeded sidebar",
+			sections: seededSections(),
+			sidebar:  left,
+			after:    "n",
+			before:   "nn",
+		},
+		{
+			name: "lands after an existing custom section and still above Archived",
+			sections: []store.WorkspaceSection{
+				sec(left, inProgress, "n"),
+				sec(left, custom, "ng"),
+				sec(left, archived, "nn"),
+			},
+			sidebar: left,
+			after:   "ng",
+			before:  "nn",
+		},
+		{
+			// The defect the ordered rule exists for: the pair the old scan
+			// built was descending here, so lexorank answered a rank BELOW
+			// Archived and every later create repeated it.
+			name: "stays above Archived when a custom section was dragged below it",
+			sections: []store.WorkspaceSection{
+				sec(left, inProgress, "n"),
+				sec(left, archived, "nn"),
+				sec(left, custom, "nng"),
+			},
+			sidebar: left,
+			after:   "n",
+			before:  "nn",
+		},
+		{
+			// The mirror defect, which needed no byte wrap: with no custom
+			// section the old code called Mid("", archivedPos), and `before`
+			// knows only Archived -- not the row that now precedes it. It
+			// answered "ng", byte-identical to the dragged Workers row.
+			name: "does not collide with a built-in dragged above Archived",
+			sections: []store.WorkspaceSection{
+				sec(left, inProgress, "n"),
+				sec(left, workers, "ng"),
+				sec(left, archived, "nn"),
+			},
+			sidebar: left,
+			after:   "ng",
+			before:  "nn",
+		},
+		{
+			// The right sidebar carries no Archived anchor, so the section
+			// appends past the last row there.
+			name: "appends past the last section of a sidebar with no Archived",
+			sections: []store.WorkspaceSection{
+				sec(left, inProgress, "n"),
+				sec(left, archived, "nn"),
+				sec(right, workers, "n"),
+			},
+			sidebar: right,
+			after:   "n",
+			before:  "",
+		},
+		{
+			name:     "heads a sidebar whose Archived row sorts first",
+			sections: []store.WorkspaceSection{sec(left, archived, "n")},
+			sidebar:  left,
+			after:    "",
+			before:   "n",
+		},
+		{
+			name:     "answers a usable rank for an empty sidebar",
+			sections: nil,
+			sidebar:  right,
+			after:    "",
+			before:   "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := nextSectionPosition(tc.sections, tc.sidebar)
+			require.NotEmpty(t, got, "a section with no position cannot be ordered at all")
+
+			if tc.after != "" {
+				assert.Greater(t, got, tc.after, "must sort after %q", tc.after)
+			}
+			if tc.before != "" {
+				assert.Less(t, got, tc.before, "must sort before %q", tc.before)
+			}
+			// A rank equal to a live row is the collision the ordered rule
+			// removes, so no section of this sidebar may share it.
+			for _, s := range tc.sections {
+				if s.Sidebar == tc.sidebar {
+					assert.NotEqual(t, s.Position, got, "collides with an existing section")
+				}
+			}
+		})
+	}
+}
+
+// Two creates in a row must not land on the same rank, whichever sidebar they
+// go to -- a collision is what the old First() fallback produced.
+//
+// The new row is inserted in (sidebar, position) order rather than appended,
+// because that is the order ListByUserID guarantees and the scan reads.
+func TestNextSectionPositionDoesNotRepeatItself(t *testing.T) {
+	t.Parallel()
+
+	for _, sidebar := range []leapmuxv1.Sidebar{left, right} {
+		sections := seededSections()
+		first := nextSectionPosition(sections, sidebar)
+		sections = insertOrdered(sections, sec(sidebar, custom, first))
+		second := nextSectionPosition(sections, sidebar)
+
+		assert.NotEqual(t, first, second, "sidebar %v", sidebar)
+
+		sections = insertOrdered(sections, sec(sidebar, custom, second))
+		assert.NotEqual(t, second, nextSectionPosition(sections, sidebar), "sidebar %v", sidebar)
+	}
+}
+
+// Put `row` where ListByUserID's `ORDER BY sidebar, position` would put it.
+func insertOrdered(sections []store.WorkspaceSection, row store.WorkspaceSection) []store.WorkspaceSection {
+	out := append([]store.WorkspaceSection{}, sections...)
+	out = append(out, row)
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Sidebar != out[j].Sidebar {
+			return out[i].Sidebar < out[j].Sidebar
+		}
+		return out[i].Position < out[j].Position
+	})
+	return out
+}
+
+// The scan reads one sidebar and ignores the other, so a section on the far
+// side can neither anchor nor displace this one.
+func TestNextSectionPositionIgnoresTheOtherSidebar(t *testing.T) {
+	t.Parallel()
+
+	withRightNoise := append(seededSections(),
+		sec(right, custom, "a"),
+		sec(right, archived, "z"),
+	)
+	assert.Equal(t,
+		nextSectionPosition(seededSections(), left),
+		nextSectionPosition(withRightNoise, left))
+}

--- a/backend/internal/hub/service/section_service.go
+++ b/backend/internal/hub/service/section_service.go
@@ -55,13 +55,7 @@ func (s *SectionService) ListSections(
 
 	protoSections := make([]*leapmuxv1.Section, len(sections))
 	for i, sec := range sections {
-		protoSections[i] = &leapmuxv1.Section{
-			Id:          sec.ID,
-			Name:        sec.Name,
-			Position:    sec.Position,
-			SectionType: sec.SectionType,
-			Sidebar:     sec.Sidebar,
-		}
+		protoSections[i] = sectionToProto(sec)
 	}
 
 	protoItems := make([]*leapmuxv1.SectionItem, len(items))
@@ -100,45 +94,11 @@ func (s *SectionService) CreateSection(
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("sidebar must be LEFT or RIGHT"))
 	}
 
-	// Find the position between the last custom section and "Archived".
 	sections, err := s.store.WorkspaceSections().ListByUserID(ctx, user.ID)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
-
-	// The scan follows the REQUESTED sidebar, not always the left one. The
-	// right sidebar holds no Archived anchor and no custom section, so a
-	// left-only scan left both ends empty there and every new section fell to
-	// lexorank.First() -- always "n", which collides with the first built-in
-	// section already on that side.
-	var lastCustomPos, archivedPos, lastPos string
-	for _, sec := range sections {
-		if sec.Sidebar != sidebar {
-			continue
-		}
-		if sec.SectionType == leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_CUSTOM {
-			lastCustomPos = sec.Position
-		}
-		if sec.SectionType == leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_ARCHIVED {
-			archivedPos = sec.Position
-		}
-		// ListByUserID orders by (sidebar, position), so the last row of this
-		// sidebar carries its highest position.
-		lastPos = sec.Position
-	}
-
-	var position string
-	switch {
-	case lastCustomPos != "" && archivedPos != "":
-		position = lexorank.Mid(lastCustomPos, archivedPos)
-	case archivedPos != "":
-		position = lexorank.Mid("", archivedPos)
-	case lastPos != "":
-		// No Archived anchor on this sidebar: append past its last section.
-		position = lexorank.After(lastPos)
-	default:
-		position = lexorank.First()
-	}
+	position := nextSectionPosition(sections, sidebar)
 
 	sectionID := id.Generate()
 	if err := s.store.WorkspaceSections().Create(ctx, store.CreateWorkspaceSectionParams{
@@ -156,13 +116,13 @@ func (s *SectionService) CreateSection(
 	// got only the id would have to re-derive the lexorank rule to place the
 	// section in its own list, which is a second source of truth for the order.
 	return connect.NewResponse(&leapmuxv1.CreateSectionResponse{
-		Section: &leapmuxv1.Section{
-			Id:          sectionID,
+		Section: sectionToProto(store.WorkspaceSection{
+			ID:          sectionID,
 			Name:        name,
 			Position:    position,
 			SectionType: leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_CUSTOM,
 			Sidebar:     sidebar,
-		},
+		}),
 	}), nil
 }
 
@@ -187,7 +147,7 @@ func (s *SectionService) RenameSection(
 	// transaction here (only DeleteSection has one), so this is a read that
 	// precedes the update rather than one inside it; a section deleted in the
 	// window between them still lands on the rows == 0 branch below.
-	if _, err := s.requireCustomSection(ctx, user.ID, req.Msg.GetSectionId(), "rename"); err != nil {
+	if err := s.requireCustomSection(ctx, user.ID, req.Msg.GetSectionId(), "rename"); err != nil {
 		return nil, err
 	}
 
@@ -220,7 +180,7 @@ func (s *SectionService) DeleteSection(
 	// Same pre-flight as RenameSection: separate "gone" from "built-in" while
 	// the answer is still available. Inside the transaction the delete's own
 	// `section_type = custom` filter collapses both into rows == 0.
-	if _, err := s.requireCustomSection(ctx, user.ID, sectionID, "delete"); err != nil {
+	if err := s.requireCustomSection(ctx, user.ID, sectionID, "delete"); err != nil {
 		return nil, err
 	}
 
@@ -358,6 +318,52 @@ var errSectionDeleteRollback = errors.New("section delete: roll back to surface 
 // the same mechanism loadOwnedWorkspaceOr403 uses -- so this, the package's
 // OTHER resource-ownership predicate, cannot fail open by matching a blank
 // workspace_sections.user_id against a caller whose id never got populated.
+// sectionToProto projects one stored section onto the wire.
+//
+// ONE mapping for every handler that answers with a Section, so a new field
+// cannot reach ListSections and miss CreateSection.
+func sectionToProto(sec store.WorkspaceSection) *leapmuxv1.Section {
+	return &leapmuxv1.Section{
+		Id:          sec.ID,
+		Name:        sec.Name,
+		Position:    sec.Position,
+		SectionType: sec.SectionType,
+		Sidebar:     sec.Sidebar,
+	}
+}
+
+// nextSectionPosition gives a new custom section its place on `sidebar`.
+//
+// The rule is one rule: a custom section lands directly above "Archived", and
+// at the end when that sidebar holds no Archived row. `sections` arrives in
+// (sidebar, position) order from ListByUserID, so the row before Archived is
+// simply the previous row of the same sidebar.
+//
+// It reads the ORDER rather than reconstructing it from section types, because
+// MoveSection writes any position a client asks for. The earlier code kept the
+// last CUSTOM position and the Archived position and called lexorank.Mid on the
+// pair, which breaks as soon as a user drags a section past another: a custom
+// section below Archived made the pair descending, and lexorank.between
+// documents that it takes an ascending pair. A descending pair also produced a
+// rank equal to the second argument, which collides with a live section.
+//
+// Every empty-string case falls out of lexorank.Mid's own semantics, so this
+// needs no special case: Mid("", archived) heads the sidebar, Mid(prev, "")
+// appends past prev, and Mid("", "") answers First() for an empty sidebar.
+func nextSectionPosition(sections []store.WorkspaceSection, sidebar leapmuxv1.Sidebar) string {
+	var prev string
+	for _, sec := range sections {
+		if sec.Sidebar != sidebar {
+			continue
+		}
+		if sec.SectionType == leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_ARCHIVED {
+			return lexorank.Mid(prev, sec.Position)
+		}
+		prev = sec.Position
+	}
+	return lexorank.Mid(prev, "")
+}
+
 func (s *SectionService) requireOwnedSection(ctx context.Context, userID userid.UserID, sectionID string) (*store.WorkspaceSection, error) {
 	section, err := s.store.WorkspaceSections().GetByID(ctx, sectionID)
 	if err != nil {
@@ -372,7 +378,8 @@ func (s *SectionService) requireOwnedSection(ctx context.Context, userID userid.
 	return section, nil
 }
 
-// requireCustomSection loads an owned section and refuses a built-in one.
+// requireCustomSection refuses a section that is missing, not the caller's, or
+// built-in.
 //
 // Rename and Delete apply to CUSTOM sections only, and both store queries carry
 // that rule as their own `section_type = custom` filter -- which is what keeps
@@ -386,22 +393,22 @@ func (s *SectionService) requireOwnedSection(ctx context.Context, userID userid.
 // archived-workspace guard uses, so two near-identical state rules answer with
 // one code rather than two.
 //
-// `verb` names the refused operation in the message, so a client that logs the
+// `verb` states the refused operation in the message, so a client that logs the
 // error alone still knows what was refused.
 func (s *SectionService) requireCustomSection(
 	ctx context.Context, userID userid.UserID, sectionID, verb string,
-) (*store.WorkspaceSection, error) {
+) error {
 	section, err := s.requireOwnedSection(ctx, userID, sectionID)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if section.SectionType != leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_CUSTOM {
-		return nil, connect.NewError(
+		return connect.NewError(
 			connect.CodeFailedPrecondition,
 			fmt.Errorf("cannot %s a built-in section", verb),
 		)
 	}
-	return section, nil
+	return nil
 }
 
 func (s *SectionService) MoveSection(

--- a/backend/internal/hub/service/section_service.go
+++ b/backend/internal/hub/service/section_service.go
@@ -93,15 +93,27 @@ func (s *SectionService) CreateSection(
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("name: %w", err))
 	}
 
+	// The same rule MoveSection applies, so a section cannot be created into a
+	// sidebar it could not then be moved to.
+	sidebar := req.Msg.GetSidebar()
+	if sidebar != leapmuxv1.Sidebar_SIDEBAR_LEFT && sidebar != leapmuxv1.Sidebar_SIDEBAR_RIGHT {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("sidebar must be LEFT or RIGHT"))
+	}
+
 	// Find the position between the last custom section and "Archived".
 	sections, err := s.store.WorkspaceSections().ListByUserID(ctx, user.ID)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 
-	var lastCustomPos, archivedPos string
+	// The scan follows the REQUESTED sidebar, not always the left one. The
+	// right sidebar holds no Archived anchor and no custom section, so a
+	// left-only scan left both ends empty there and every new section fell to
+	// lexorank.First() -- always "n", which collides with the first built-in
+	// section already on that side.
+	var lastCustomPos, archivedPos, lastPos string
 	for _, sec := range sections {
-		if sec.Sidebar != leapmuxv1.Sidebar_SIDEBAR_LEFT {
+		if sec.Sidebar != sidebar {
 			continue
 		}
 		if sec.SectionType == leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_CUSTOM {
@@ -110,14 +122,21 @@ func (s *SectionService) CreateSection(
 		if sec.SectionType == leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_ARCHIVED {
 			archivedPos = sec.Position
 		}
+		// ListByUserID orders by (sidebar, position), so the last row of this
+		// sidebar carries its highest position.
+		lastPos = sec.Position
 	}
 
 	var position string
-	if lastCustomPos != "" && archivedPos != "" {
+	switch {
+	case lastCustomPos != "" && archivedPos != "":
 		position = lexorank.Mid(lastCustomPos, archivedPos)
-	} else if archivedPos != "" {
+	case archivedPos != "":
 		position = lexorank.Mid("", archivedPos)
-	} else {
+	case lastPos != "":
+		// No Archived anchor on this sidebar: append past its last section.
+		position = lexorank.After(lastPos)
+	default:
 		position = lexorank.First()
 	}
 
@@ -128,13 +147,22 @@ func (s *SectionService) CreateSection(
 		Name:        name,
 		Position:    position,
 		SectionType: leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_CUSTOM,
-		Sidebar:     leapmuxv1.Sidebar_SIDEBAR_LEFT,
+		Sidebar:     sidebar,
 	}); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 
+	// The whole row, because the SERVER computed the position. A client that
+	// got only the id would have to re-derive the lexorank rule to place the
+	// section in its own list, which is a second source of truth for the order.
 	return connect.NewResponse(&leapmuxv1.CreateSectionResponse{
-		SectionId: sectionID,
+		Section: &leapmuxv1.Section{
+			Id:          sectionID,
+			Name:        name,
+			Position:    position,
+			SectionType: leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_CUSTOM,
+			Sidebar:     sidebar,
+		},
 	}), nil
 }
 
@@ -152,6 +180,17 @@ func (s *SectionService) RenameSection(
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("name: %w", err))
 	}
 
+	// Diagnose the two refusals apart BEFORE the write. The query carries its
+	// own `section_type = custom` filter, so a built-in came back as rows == 0
+	// and the handler could only answer "not found or not a custom section" --
+	// a message that admits it cannot tell the caller which. There is no
+	// transaction here (only DeleteSection has one), so this is a read that
+	// precedes the update rather than one inside it; a section deleted in the
+	// window between them still lands on the rows == 0 branch below.
+	if _, err := s.requireCustomSection(ctx, user.ID, req.Msg.GetSectionId(), "rename"); err != nil {
+		return nil, err
+	}
+
 	rows, err := s.store.WorkspaceSections().Rename(ctx, store.RenameWorkspaceSectionParams{
 		Name:   name,
 		ID:     req.Msg.GetSectionId(),
@@ -161,7 +200,7 @@ func (s *SectionService) RenameSection(
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	if rows == 0 {
-		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("section not found or not a custom section"))
+		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("section not found"))
 	}
 
 	return connect.NewResponse(&leapmuxv1.RenameSectionResponse{}), nil
@@ -177,6 +216,13 @@ func (s *SectionService) DeleteSection(
 	}
 
 	sectionID := req.Msg.GetSectionId()
+
+	// Same pre-flight as RenameSection: separate "gone" from "built-in" while
+	// the answer is still available. Inside the transaction the delete's own
+	// `section_type = custom` filter collapses both into rows == 0.
+	if _, err := s.requireCustomSection(ctx, user.ID, sectionID, "delete"); err != nil {
+		return nil, err
+	}
 
 	// The whole move-then-delete sequence runs in one transaction: the
 	// previous code looped N `Set` calls and then a `Delete` outside
@@ -282,7 +328,7 @@ func (s *SectionService) DeleteSection(
 		return nil
 	}); err != nil {
 		if notFound {
-			return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("section not found or not a custom section"))
+			return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("section not found"))
 		}
 		if errors.Is(err, store.ErrSectionNotEmpty) {
 			return nil, connect.NewError(connect.CodeFailedPrecondition, store.ErrSectionNotEmpty)
@@ -322,6 +368,38 @@ func (s *SectionService) requireOwnedSection(ctx context.Context, userID userid.
 	}
 	if !userID.Matches(section.UserID) {
 		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("section not found"))
+	}
+	return section, nil
+}
+
+// requireCustomSection loads an owned section and refuses a built-in one.
+//
+// Rename and Delete apply to CUSTOM sections only, and both store queries carry
+// that rule as their own `section_type = custom` filter -- which is what keeps
+// the invariant true for any caller. What the filter cannot do is SAY which
+// rule refused: a built-in and a missing row both come back as zero rows, so
+// the handler answered NotFound for both and its own message admitted it
+// ("not found or not a custom section").
+//
+// FailedPrecondition for the built-in, because the section exists, the caller
+// owns it, and its STATE forbids the operation -- the same code the sibling
+// archived-workspace guard uses, so two near-identical state rules answer with
+// one code rather than two.
+//
+// `verb` names the refused operation in the message, so a client that logs the
+// error alone still knows what was refused.
+func (s *SectionService) requireCustomSection(
+	ctx context.Context, userID userid.UserID, sectionID, verb string,
+) (*store.WorkspaceSection, error) {
+	section, err := s.requireOwnedSection(ctx, userID, sectionID)
+	if err != nil {
+		return nil, err
+	}
+	if section.SectionType != leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_CUSTOM {
+		return nil, connect.NewError(
+			connect.CodeFailedPrecondition,
+			fmt.Errorf("cannot %s a built-in section", verb),
+		)
 	}
 	return section, nil
 }

--- a/backend/internal/hub/service/section_service_test.go
+++ b/backend/internal/hub/service/section_service_test.go
@@ -282,10 +282,19 @@ func TestSectionService_CreateSection(t *testing.T) {
 
 	// Create a custom section.
 	resp, err := env.client.CreateSection(context.Background(), authedReq(
-		&leapmuxv1.CreateSectionRequest{Name: "My Custom"}, env.token))
+		&leapmuxv1.CreateSectionRequest{Name: "My Custom", Sidebar: leapmuxv1.Sidebar_SIDEBAR_LEFT}, env.token))
 	require.NoError(t, err)
 
-	assert.NotEmpty(t, resp.Msg.GetSectionId())
+	// The whole row, not just the id: the SERVER computes the position, and a
+	// client that had to re-derive it would be a second source of truth for the
+	// section order.
+	created := resp.Msg.GetSection()
+	require.NotNil(t, created)
+	assert.NotEmpty(t, created.GetId())
+	assert.Equal(t, "My Custom", created.GetName())
+	assert.NotEmpty(t, created.GetPosition())
+	assert.Equal(t, leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_CUSTOM, created.GetSectionType())
+	assert.Equal(t, leapmuxv1.Sidebar_SIDEBAR_LEFT, created.GetSidebar())
 
 	// Verify it appears in the list.
 	listResp, _ := env.client.ListSections(context.Background(), authedReq(
@@ -299,7 +308,7 @@ func TestSectionService_CreateSection_EmptyName(t *testing.T) {
 	env := setupSectionTest(t)
 
 	_, err := env.client.CreateSection(context.Background(), authedReq(
-		&leapmuxv1.CreateSectionRequest{Name: ""}, env.token))
+		&leapmuxv1.CreateSectionRequest{Name: "", Sidebar: leapmuxv1.Sidebar_SIDEBAR_LEFT}, env.token))
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
 }
@@ -314,8 +323,8 @@ func TestSectionService_RenameSection(t *testing.T) {
 
 	// Create a section first.
 	createResp, _ := env.client.CreateSection(context.Background(), authedReq(
-		&leapmuxv1.CreateSectionRequest{Name: "Old Name"}, env.token))
-	sectionID := createResp.Msg.GetSectionId()
+		&leapmuxv1.CreateSectionRequest{Name: "Old Name", Sidebar: leapmuxv1.Sidebar_SIDEBAR_LEFT}, env.token))
+	sectionID := createResp.Msg.GetSection().GetId()
 
 	// Rename it.
 	_, err := env.client.RenameSection(context.Background(), authedReq(
@@ -332,6 +341,142 @@ func TestSectionService_RenameSection(t *testing.T) {
 		}
 	}
 	assert.Fail(t, "section not found after rename")
+}
+
+// The two built-in workspace sections cannot be renamed or deleted, and this is
+// the first coverage of that rule.
+//
+// The store queries have always carried it as their own `section_type = custom`
+// filter, so it HELD -- what it could not do is say which rule refused. A
+// built-in and a missing row both came back as zero rows, so both answered
+// NotFound with a message that admitted the ambiguity ("not found or not a
+// custom section"). The handlers now separate the two, so these assertions are
+// about the diagnosis and not about the enforcement.
+func TestSectionService_RenameSection_RefusesBuiltIn(t *testing.T) {
+	t.Parallel()
+
+	env := setupSectionTest(t)
+	ctx := context.Background()
+
+	for _, sectionType := range []leapmuxv1.SectionType{
+		leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_IN_PROGRESS,
+		leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_ARCHIVED,
+	} {
+		sectionID := seededSectionID(t, env, sectionType)
+
+		_, err := env.client.RenameSection(ctx, authedReq(
+			&leapmuxv1.RenameSectionRequest{SectionId: sectionID, Name: "Renamed"}, env.token))
+		require.Error(t, err, "%v must not be renamable", sectionType)
+		assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err),
+			"the section exists and the caller owns it; only its state forbids the rename")
+		assert.Contains(t, err.Error(), "built-in section")
+
+		// And the row is untouched.
+		section, getErr := env.store.WorkspaceSections().GetByID(ctx, sectionID)
+		require.NoError(t, getErr)
+		assert.NotEqual(t, "Renamed", section.Name)
+	}
+}
+
+func TestSectionService_DeleteSection_RefusesBuiltIn(t *testing.T) {
+	t.Parallel()
+
+	env := setupSectionTest(t)
+	ctx := context.Background()
+
+	for _, sectionType := range []leapmuxv1.SectionType{
+		leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_IN_PROGRESS,
+		leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_ARCHIVED,
+	} {
+		sectionID := seededSectionID(t, env, sectionType)
+
+		_, err := env.client.DeleteSection(ctx, authedReq(
+			&leapmuxv1.DeleteSectionRequest{SectionId: sectionID}, env.token))
+		require.Error(t, err, "%v must not be deletable", sectionType)
+		assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+		assert.Contains(t, err.Error(), "built-in section")
+
+		_, getErr := env.store.WorkspaceSections().GetByID(ctx, sectionID)
+		require.NoError(t, getErr, "the section must still be there")
+	}
+}
+
+// The other half of the split: an id that names nothing is still NotFound, so
+// the two outcomes a single code could not distinguish are now distinguishable.
+func TestSectionService_RenameSection_NotFoundOnBogusID(t *testing.T) {
+	t.Parallel()
+
+	env := setupSectionTest(t)
+
+	_, err := env.client.RenameSection(context.Background(), authedReq(
+		&leapmuxv1.RenameSectionRequest{SectionId: "section-id-that-does-not-exist", Name: "New Name"}, env.token))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+}
+
+// A custom section on the RIGHT sidebar gets a position past that sidebar's
+// last section.
+//
+// The scan used to be hard-coded to the left sidebar, where "between the last
+// custom section and Archived" is a well-defined place. The right sidebar has
+// neither anchor, so both ends came back empty and every new section fell to
+// lexorank.First() -- always "n", colliding with the first built-in section
+// already there.
+func TestSectionService_CreateSection_RightSidebarAppendsPastTheLast(t *testing.T) {
+	t.Parallel()
+
+	env := setupSectionTest(t)
+	ctx := context.Background()
+
+	before := mustListSections(t, env, userid.MustNew(env.userID))
+	var lastRightPos string
+	for _, sec := range before {
+		if sec.Sidebar == leapmuxv1.Sidebar_SIDEBAR_RIGHT {
+			lastRightPos = sec.Position
+		}
+	}
+	require.NotEmpty(t, lastRightPos, "the seeded set must put at least one section on the right")
+
+	resp, err := env.client.CreateSection(ctx, authedReq(
+		&leapmuxv1.CreateSectionRequest{Name: "Right Custom", Sidebar: leapmuxv1.Sidebar_SIDEBAR_RIGHT}, env.token))
+	require.NoError(t, err)
+	created := resp.Msg.GetSection()
+	require.NotNil(t, created)
+
+	assert.Equal(t, leapmuxv1.Sidebar_SIDEBAR_RIGHT, created.GetSidebar())
+	assert.Greater(t, created.GetPosition(), lastRightPos,
+		"a right-sidebar section must sort after the sections already there")
+
+	// Two in a row must not collide either, which is what a First() fallback
+	// would produce.
+	second, err := env.client.CreateSection(ctx, authedReq(
+		&leapmuxv1.CreateSectionRequest{Name: "Right Custom 2", Sidebar: leapmuxv1.Sidebar_SIDEBAR_RIGHT}, env.token))
+	require.NoError(t, err)
+	assert.NotEqual(t, created.GetPosition(), second.Msg.GetSection().GetPosition())
+}
+
+func TestSectionService_CreateSection_RejectsUnspecifiedSidebar(t *testing.T) {
+	t.Parallel()
+
+	env := setupSectionTest(t)
+
+	_, err := env.client.CreateSection(context.Background(), authedReq(
+		&leapmuxv1.CreateSectionRequest{Name: "Nowhere"}, env.token))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err),
+		"MoveSection applies the same rule, so a section cannot be created into a sidebar it could not be moved to")
+}
+
+// The id of the seeded section of one built-in type.
+func seededSectionID(t *testing.T, env *sectionTestEnv, sectionType leapmuxv1.SectionType) string {
+	t.Helper()
+	for _, sec := range mustListSections(t, env, userid.MustNew(env.userID)) {
+		if sec.SectionType == sectionType {
+			return sec.ID
+		}
+	}
+	require.FailNowf(t, "no seeded section", "type %v", sectionType)
+	return ""
 }
 
 func TestSectionService_RenameSection_EmptyName(t *testing.T) {
@@ -355,8 +500,8 @@ func TestSectionService_DeleteSection(t *testing.T) {
 
 	// Create a section, then delete it.
 	createResp, _ := env.client.CreateSection(context.Background(), authedReq(
-		&leapmuxv1.CreateSectionRequest{Name: "Temp Section"}, env.token))
-	sectionID := createResp.Msg.GetSectionId()
+		&leapmuxv1.CreateSectionRequest{Name: "Temp Section", Sidebar: leapmuxv1.Sidebar_SIDEBAR_LEFT}, env.token))
+	sectionID := createResp.Msg.GetSection().GetId()
 
 	_, err := env.client.DeleteSection(context.Background(), authedReq(
 		&leapmuxv1.DeleteSectionRequest{SectionId: sectionID}, env.token))
@@ -390,9 +535,9 @@ func TestSectionService_DeleteSection_WithItems(t *testing.T) {
 
 	// Create a custom section and assign a workspace to it.
 	createResp, err := env.client.CreateSection(ctx, authedReq(
-		&leapmuxv1.CreateSectionRequest{Name: "Custom With Items"}, env.token))
+		&leapmuxv1.CreateSectionRequest{Name: "Custom With Items", Sidebar: leapmuxv1.Sidebar_SIDEBAR_LEFT}, env.token))
 	require.NoError(t, err)
-	customID := createResp.Msg.GetSectionId()
+	customID := createResp.Msg.GetSection().GetId()
 
 	_, err = env.client.MoveWorkspace(ctx, authedReq(
 		&leapmuxv1.MoveWorkspaceRequest{
@@ -487,9 +632,9 @@ func TestSectionService_DeleteSection_ReassignsPositionsOnMerge(t *testing.T) {
 	// Create a custom section and drop wsCustom into it at "n" too —
 	// the colliding position that the bug exploited.
 	createResp, err := env.client.CreateSection(ctx, authedReq(
-		&leapmuxv1.CreateSectionRequest{Name: "Custom"}, env.token))
+		&leapmuxv1.CreateSectionRequest{Name: "Custom", Sidebar: leapmuxv1.Sidebar_SIDEBAR_LEFT}, env.token))
 	require.NoError(t, err)
-	customID := createResp.Msg.GetSectionId()
+	customID := createResp.Msg.GetSection().GetId()
 	_, err = env.client.MoveWorkspace(ctx, authedReq(
 		&leapmuxv1.MoveWorkspaceRequest{
 			WorkspaceId: wsCustom,

--- a/backend/internal/hub/service/section_service_test.go
+++ b/backend/internal/hub/service/section_service_test.go
@@ -362,7 +362,7 @@ func TestSectionService_RenameSection_RefusesBuiltIn(t *testing.T) {
 		leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_IN_PROGRESS,
 		leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_ARCHIVED,
 	} {
-		sectionID := seededSectionID(t, env, sectionType)
+		sectionID := sectionIDOfType(t, env.store, env.userID, sectionType)
 
 		_, err := env.client.RenameSection(ctx, authedReq(
 			&leapmuxv1.RenameSectionRequest{SectionId: sectionID, Name: "Renamed"}, env.token))
@@ -388,7 +388,7 @@ func TestSectionService_DeleteSection_RefusesBuiltIn(t *testing.T) {
 		leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_IN_PROGRESS,
 		leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_ARCHIVED,
 	} {
-		sectionID := seededSectionID(t, env, sectionType)
+		sectionID := sectionIDOfType(t, env.store, env.userID, sectionType)
 
 		_, err := env.client.DeleteSection(ctx, authedReq(
 			&leapmuxv1.DeleteSectionRequest{SectionId: sectionID}, env.token))
@@ -401,7 +401,7 @@ func TestSectionService_DeleteSection_RefusesBuiltIn(t *testing.T) {
 	}
 }
 
-// The other half of the split: an id that names nothing is still NotFound, so
+// The other half of the split: an id that matches nothing is still NotFound, so
 // the two outcomes a single code could not distinguish are now distinguishable.
 func TestSectionService_RenameSection_NotFoundOnBogusID(t *testing.T) {
 	t.Parallel()
@@ -465,18 +465,6 @@ func TestSectionService_CreateSection_RejectsUnspecifiedSidebar(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err),
 		"MoveSection applies the same rule, so a section cannot be created into a sidebar it could not be moved to")
-}
-
-// The id of the seeded section of one built-in type.
-func seededSectionID(t *testing.T, env *sectionTestEnv, sectionType leapmuxv1.SectionType) string {
-	t.Helper()
-	for _, sec := range mustListSections(t, env, userid.MustNew(env.userID)) {
-		if sec.SectionType == sectionType {
-			return sec.ID
-		}
-	}
-	require.FailNowf(t, "no seeded section", "type %v", sectionType)
-	return ""
 }
 
 func TestSectionService_RenameSection_EmptyName(t *testing.T) {

--- a/backend/internal/hub/service/workspace_service.go
+++ b/backend/internal/hub/service/workspace_service.go
@@ -105,7 +105,7 @@ func loadOwnedWorkspaceOr403(ctx context.Context, st store.Store, workspaceID st
 // Hiding the menu item is not enforcement. RenameWorkspace is reachable from
 // the CLI (`leapmux workspace rename`) and from any client, and an archived
 // workspace is read-only everywhere else in the app: the tab bar's `+`
-// disappears, the branch menu is hidden, and `isWorkspaceMutatable` names the
+// disappears, the branch menu is hidden, and `isWorkspaceMutatable` states the
 // rule outright.
 //
 // FailedPrecondition, not NotFound: the workspace is well-formed and the caller
@@ -114,11 +114,15 @@ func loadOwnedWorkspaceOr403(ctx context.Context, st store.Store, workspaceID st
 // `section_type = custom` -- would collapse the outcome into the existing
 // `rows == 0` -> NotFound, which already means "not found or not owner".
 //
+// `verb` gives the message the refused operation, so this guard serves the next
+// archived-workspace rule without reporting a rename that never ran. The
+// sibling `requireCustomSection` takes the same parameter for the same reason.
+//
 // It FAILS OPEN for an unminted caller: the adapters answer `(false, nil)` when
 // `userid.OwnerFilter` refuses, because binding "" would match every
 // blank-owner row rather than none. That is safe only because `MustGetUser` and
 // `loadOwnedWorkspaceOr403` already ran and rejected such a caller.
-func refuseArchivedWorkspace(ctx context.Context, tx store.Store, workspaceID string, userID userid.UserID) error {
+func refuseArchivedWorkspace(ctx context.Context, tx store.Store, workspaceID string, userID userid.UserID, verb string) error {
 	archived, err := tx.WorkspaceSectionItems().IsInArchivedSection(ctx, store.IsWorkspaceInArchivedSectionParams{
 		UserID:      userID,
 		WorkspaceID: workspaceID,
@@ -127,7 +131,7 @@ func refuseArchivedWorkspace(ctx context.Context, tx store.Store, workspaceID st
 		return connect.NewError(connect.CodeInternal, fmt.Errorf("check archived section: %w", err))
 	}
 	if archived {
-		return connect.NewError(connect.CodeFailedPrecondition, errors.New("cannot rename an archived workspace"))
+		return connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("cannot %s an archived workspace", verb))
 	}
 	return nil
 }
@@ -284,7 +288,7 @@ func (s *WorkspaceService) RenameWorkspace(
 			// rename commit or abort together -- an archive landing between a
 			// check outside and the update would otherwise slip through. It is
 			// a read, so it is safe under storetest.NewDoubleRunStore.
-			if err := refuseArchivedWorkspace(ctx, tx, req.Msg.GetWorkspaceId(), user.ID); err != nil {
+			if err := refuseArchivedWorkspace(ctx, tx, req.Msg.GetWorkspaceId(), user.ID, "rename"); err != nil {
 				return "", crdt.LifecyclePayload{}, nil, err
 			}
 			rows, err := tx.Workspaces().Rename(ctx, store.RenameWorkspaceParams{

--- a/backend/internal/hub/service/workspace_service.go
+++ b/backend/internal/hub/service/workspace_service.go
@@ -99,6 +99,39 @@ func loadOwnedWorkspaceOr403(ctx context.Context, st store.Store, workspaceID st
 	return ws, nil
 }
 
+// refuseArchivedWorkspace refuses a mutation of a workspace that sits in the
+// caller's Archived section.
+//
+// Hiding the menu item is not enforcement. RenameWorkspace is reachable from
+// the CLI (`leapmux workspace rename`) and from any client, and an archived
+// workspace is read-only everywhere else in the app: the tab bar's `+`
+// disappears, the branch menu is hidden, and `isWorkspaceMutatable` names the
+// rule outright.
+//
+// FailedPrecondition, not NotFound: the workspace is well-formed and the caller
+// owns it, and only its STATE forbids the write. Folding the rule into the
+// store as an anti-join -- the way the section queries carry
+// `section_type = custom` -- would collapse the outcome into the existing
+// `rows == 0` -> NotFound, which already means "not found or not owner".
+//
+// It FAILS OPEN for an unminted caller: the adapters answer `(false, nil)` when
+// `userid.OwnerFilter` refuses, because binding "" would match every
+// blank-owner row rather than none. That is safe only because `MustGetUser` and
+// `loadOwnedWorkspaceOr403` already ran and rejected such a caller.
+func refuseArchivedWorkspace(ctx context.Context, tx store.Store, workspaceID string, userID userid.UserID) error {
+	archived, err := tx.WorkspaceSectionItems().IsInArchivedSection(ctx, store.IsWorkspaceInArchivedSectionParams{
+		UserID:      userID,
+		WorkspaceID: workspaceID,
+	})
+	if err != nil {
+		return connect.NewError(connect.CodeInternal, fmt.Errorf("check archived section: %w", err))
+	}
+	if archived {
+		return connect.NewError(connect.CodeFailedPrecondition, errors.New("cannot rename an archived workspace"))
+	}
+	return nil
+}
+
 // readWorkspaceOrNotFound loads a workspace for reading and collapses the two
 // existence-revealing codes into notFound.
 //
@@ -245,6 +278,13 @@ func (s *WorkspaceService) RenameWorkspace(
 		Fn: func(tx store.Store) (string, crdt.LifecyclePayload, []*leapmuxv1.CrdtOp, error) {
 			ws, err := loadOwnedWorkspaceOr403(ctx, tx, req.Msg.GetWorkspaceId(), user.ID, "only workspace owner can modify workspace state")
 			if err != nil {
+				return "", crdt.LifecyclePayload{}, nil, err
+			}
+			// Inside the same transaction as the write, so the guard and the
+			// rename commit or abort together -- an archive landing between a
+			// check outside and the update would otherwise slip through. It is
+			// a read, so it is safe under storetest.NewDoubleRunStore.
+			if err := refuseArchivedWorkspace(ctx, tx, req.Msg.GetWorkspaceId(), user.ID); err != nil {
 				return "", crdt.LifecyclePayload{}, nil, err
 			}
 			rows, err := tx.Workspaces().Rename(ctx, store.RenameWorkspaceParams{

--- a/backend/internal/hub/service/workspace_service_test.go
+++ b/backend/internal/hub/service/workspace_service_test.go
@@ -14,7 +14,6 @@ import (
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/hub/auth"
 	"github.com/leapmux/leapmux/internal/hub/crdt"
-	"github.com/leapmux/leapmux/internal/hub/password"
 	"github.com/leapmux/leapmux/internal/hub/service"
 	"github.com/leapmux/leapmux/internal/hub/store"
 	"github.com/leapmux/leapmux/internal/hub/store/storetest"
@@ -195,7 +194,7 @@ func TestWorkspaceService_LocateTile_NotFoundForUnknownTile(t *testing.T) {
 }
 
 // TestWorkspaceService_LocateTile_TransientManagerErrorIsRetryable pins the
-// registry.Get failure arm: when the caller's manager cannot be bootstrapped,
+// registry.Get failure case: when the caller's manager cannot be bootstrapped,
 // the caller must get a retryable Internal, not NotFound. NotFound is a
 // permanent answer -- the CLI tile resolver stops looking -- so a DB blip
 // during manager bootstrap would report a tile that exists as gone. Every
@@ -257,7 +256,7 @@ func setupLocateTileEnv(t *testing.T, userID string) *locateTileEnv {
 // --- RenameWorkspace ---
 //
 // An archived workspace is read-only everywhere in the app: the tab bar's `+`
-// disappears, the branch menu is hidden, and `isWorkspaceMutatable` names the
+// disappears, the branch menu is hidden, and `isWorkspaceMutatable` states the
 // rule. Hiding the menu item is not enforcement, though -- RenameWorkspace is
 // reachable from the CLI and from any client -- so the hub refuses it too.
 //
@@ -268,11 +267,12 @@ func setupLocateTileEnv(t *testing.T, userID string) *locateTileEnv {
 // transaction.
 func seedUserWithSections(t *testing.T, st store.Store, username string) *store.User {
 	t.Helper()
-	hash, err := password.Hash("testpass")
-	require.NoError(t, err)
+	// A literal, not `password.Hash`: nothing here verifies a password, and
+	// deriving one costs an Argon2id pass over 19 MiB per call. `storetest`
+	// seeds the same way.
 	user, err := service.CreateUser(context.Background(), st, service.CreateUserParams{
 		Username:              username,
-		PasswordHash:          hash,
+		PasswordHash:          "hash-" + username,
 		DisplayName:           username,
 		FirstCredentialExempt: true,
 	})
@@ -370,7 +370,9 @@ func TestWorkspaceService_RenameWorkspace_RefusesArchived(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err),
 		"the workspace is well-formed and owned; only its state forbids the write")
-	assert.Contains(t, err.Error(), "archived")
+	// The VERB, not just "archived": the guard takes it as a parameter so the
+	// next mutation that adopts it cannot report a rename that never ran.
+	assert.Contains(t, err.Error(), "cannot rename an archived workspace")
 
 	// The guard aborts the transaction, so the title is untouched.
 	ws, getErr := st.Workspaces().GetByID(ctx, workspaceID)

--- a/backend/internal/hub/service/workspace_service_test.go
+++ b/backend/internal/hub/service/workspace_service_test.go
@@ -14,6 +14,7 @@ import (
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/hub/auth"
 	"github.com/leapmux/leapmux/internal/hub/crdt"
+	"github.com/leapmux/leapmux/internal/hub/password"
 	"github.com/leapmux/leapmux/internal/hub/service"
 	"github.com/leapmux/leapmux/internal/hub/store"
 	"github.com/leapmux/leapmux/internal/hub/store/storetest"
@@ -251,4 +252,207 @@ func setupLocateTileEnv(t *testing.T, userID string) *locateTileEnv {
 	_, err := registry.Get(context.Background(), userID)
 	require.NoError(t, err)
 	return &locateTileEnv{mgr: mgr, registry: registry}
+}
+
+// --- RenameWorkspace ---
+//
+// An archived workspace is read-only everywhere in the app: the tab bar's `+`
+// disappears, the branch menu is hidden, and `isWorkspaceMutatable` names the
+// rule. Hiding the menu item is not enforcement, though -- RenameWorkspace is
+// reachable from the CLI and from any client -- so the hub refuses it too.
+//
+// The user goes through service.CreateUser rather than storetest.SeedUser:
+// SeedUser writes the user row alone, and a user with no sections can never
+// have an archived workspace, so every assertion below would pass vacuously.
+// CreateUser is the production path and seeds the defaults in the same
+// transaction.
+func seedUserWithSections(t *testing.T, st store.Store, username string) *store.User {
+	t.Helper()
+	hash, err := password.Hash("testpass")
+	require.NoError(t, err)
+	user, err := service.CreateUser(context.Background(), st, service.CreateUserParams{
+		Username:              username,
+		PasswordHash:          hash,
+		DisplayName:           username,
+		FirstCredentialExempt: true,
+	})
+	require.NoError(t, err)
+	return user
+}
+
+// The id of the seeded section of one built-in type, for `userID`.
+func sectionIDOfType(t *testing.T, st store.Store, userID string, sectionType leapmuxv1.SectionType) string {
+	t.Helper()
+	sections, err := st.WorkspaceSections().ListByUserID(context.Background(), userid.MustNew(userID))
+	require.NoError(t, err)
+	for _, sec := range sections {
+		if sec.SectionType == sectionType {
+			return sec.ID
+		}
+	}
+	require.FailNowf(t, "no seeded section", "type %v", sectionType)
+	return ""
+}
+
+func placeWorkspaceInSection(t *testing.T, st store.Store, userID, workspaceID, sectionID string) {
+	t.Helper()
+	require.NoError(t, st.WorkspaceSectionItems().Set(context.Background(), store.SetWorkspaceSectionItemParams{
+		UserID:      userid.MustNew(userID),
+		WorkspaceID: workspaceID,
+		SectionID:   sectionID,
+		Position:    "n",
+	}))
+}
+
+func TestWorkspaceService_RenameWorkspace_RenamesALiveWorkspace(t *testing.T) {
+	t.Parallel()
+
+	st := hubtestutil.OpenTestStore(t)
+	ctx := context.Background()
+	user := seedUserWithSections(t, st, "rename-live")
+	workspaceID := storetest.SeedWorkspace(t, st, user.ID, "before")
+	placeWorkspaceInSection(t, st, user.ID, workspaceID,
+		sectionIDOfType(t, st, user.ID, leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_IN_PROGRESS))
+
+	svc := service.NewWorkspaceService(st, nil)
+	authCtx := auth.WithUser(ctx, &auth.UserInfo{ID: userid.MustNew(user.ID)})
+	_, err := svc.RenameWorkspace(authCtx, connect.NewRequest(&leapmuxv1.RenameWorkspaceRequest{
+		WorkspaceId: workspaceID,
+		Title:       "after",
+	}))
+	require.NoError(t, err)
+
+	ws, err := st.Workspaces().GetByID(ctx, workspaceID)
+	require.NoError(t, err)
+	assert.Equal(t, "after", ws.Title)
+}
+
+// An UNPLACED workspace is not archived. A workspace created by the CLI has no
+// section item until the client files it, and the sidebar shows it under In
+// progress; refusing the rename there would break the ordinary case.
+func TestWorkspaceService_RenameWorkspace_RenamesAnUnplacedWorkspace(t *testing.T) {
+	t.Parallel()
+
+	st := hubtestutil.OpenTestStore(t)
+	ctx := context.Background()
+	user := seedUserWithSections(t, st, "rename-unplaced")
+	workspaceID := storetest.SeedWorkspace(t, st, user.ID, "before")
+
+	svc := service.NewWorkspaceService(st, nil)
+	authCtx := auth.WithUser(ctx, &auth.UserInfo{ID: userid.MustNew(user.ID)})
+	_, err := svc.RenameWorkspace(authCtx, connect.NewRequest(&leapmuxv1.RenameWorkspaceRequest{
+		WorkspaceId: workspaceID,
+		Title:       "after",
+	}))
+	require.NoError(t, err)
+
+	ws, err := st.Workspaces().GetByID(ctx, workspaceID)
+	require.NoError(t, err)
+	assert.Equal(t, "after", ws.Title)
+}
+
+func TestWorkspaceService_RenameWorkspace_RefusesArchived(t *testing.T) {
+	t.Parallel()
+
+	st := hubtestutil.OpenTestStore(t)
+	ctx := context.Background()
+	user := seedUserWithSections(t, st, "rename-archived")
+	workspaceID := storetest.SeedWorkspace(t, st, user.ID, "before")
+	placeWorkspaceInSection(t, st, user.ID, workspaceID,
+		sectionIDOfType(t, st, user.ID, leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_ARCHIVED))
+
+	svc := service.NewWorkspaceService(st, nil)
+	authCtx := auth.WithUser(ctx, &auth.UserInfo{ID: userid.MustNew(user.ID)})
+	_, err := svc.RenameWorkspace(authCtx, connect.NewRequest(&leapmuxv1.RenameWorkspaceRequest{
+		WorkspaceId: workspaceID,
+		Title:       "after",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err),
+		"the workspace is well-formed and owned; only its state forbids the write")
+	assert.Contains(t, err.Error(), "archived")
+
+	// The guard aborts the transaction, so the title is untouched.
+	ws, getErr := st.Workspaces().GetByID(ctx, workspaceID)
+	require.NoError(t, getErr)
+	assert.Equal(t, "before", ws.Title)
+}
+
+// Unarchiving is a MoveWorkspace, which stays unguarded by design -- archive
+// and unarchive are the same call, distinguished only by the section id. A
+// workspace moved back out becomes renamable again.
+func TestWorkspaceService_RenameWorkspace_AllowedAgainAfterUnarchive(t *testing.T) {
+	t.Parallel()
+
+	st := hubtestutil.OpenTestStore(t)
+	ctx := context.Background()
+	user := seedUserWithSections(t, st, "rename-unarchived")
+	workspaceID := storetest.SeedWorkspace(t, st, user.ID, "before")
+	placeWorkspaceInSection(t, st, user.ID, workspaceID,
+		sectionIDOfType(t, st, user.ID, leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_ARCHIVED))
+	placeWorkspaceInSection(t, st, user.ID, workspaceID,
+		sectionIDOfType(t, st, user.ID, leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_IN_PROGRESS))
+
+	svc := service.NewWorkspaceService(st, nil)
+	authCtx := auth.WithUser(ctx, &auth.UserInfo{ID: userid.MustNew(user.ID)})
+	_, err := svc.RenameWorkspace(authCtx, connect.NewRequest(&leapmuxv1.RenameWorkspaceRequest{
+		WorkspaceId: workspaceID,
+		Title:       "after",
+	}))
+	require.NoError(t, err)
+
+	ws, err := st.Workspaces().GetByID(ctx, workspaceID)
+	require.NoError(t, err)
+	assert.Equal(t, "after", ws.Title)
+}
+
+// Another user's archived workspace does not make the caller's own workspace
+// unrenamable: the query filters on the CALLER's section items.
+func TestWorkspaceService_RenameWorkspace_ArchivedForAnotherUserDoesNotBlock(t *testing.T) {
+	t.Parallel()
+
+	st := hubtestutil.OpenTestStore(t)
+	ctx := context.Background()
+	owner := seedUserWithSections(t, st, "rename-owner")
+	other := seedUserWithSections(t, st, "rename-other")
+	workspaceID := storetest.SeedWorkspace(t, st, owner.ID, "before")
+	placeWorkspaceInSection(t, st, owner.ID, workspaceID,
+		sectionIDOfType(t, st, owner.ID, leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_IN_PROGRESS))
+	// The OTHER user files the same workspace id into THEIR archive.
+	placeWorkspaceInSection(t, st, other.ID, workspaceID,
+		sectionIDOfType(t, st, other.ID, leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_ARCHIVED))
+
+	svc := service.NewWorkspaceService(st, nil)
+	authCtx := auth.WithUser(ctx, &auth.UserInfo{ID: userid.MustNew(owner.ID)})
+	_, err := svc.RenameWorkspace(authCtx, connect.NewRequest(&leapmuxv1.RenameWorkspaceRequest{
+		WorkspaceId: workspaceID,
+		Title:       "after",
+	}))
+	require.NoError(t, err)
+
+	ws, err := st.Workspaces().GetByID(ctx, workspaceID)
+	require.NoError(t, err)
+	assert.Equal(t, "after", ws.Title)
+}
+
+// Archive then delete is a normal flow, and Delete stays unguarded.
+func TestWorkspaceService_DeleteWorkspace_StillWorksOnAnArchivedWorkspace(t *testing.T) {
+	t.Parallel()
+
+	st := hubtestutil.OpenTestStore(t)
+	ctx := context.Background()
+	user := seedUserWithSections(t, st, "delete-archived")
+	workspaceID := storetest.SeedWorkspace(t, st, user.ID, "doomed")
+	placeWorkspaceInSection(t, st, user.ID, workspaceID,
+		sectionIDOfType(t, st, user.ID, leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_ARCHIVED))
+
+	svc := service.NewWorkspaceService(st, nil)
+	authCtx := auth.WithUser(ctx, &auth.UserInfo{ID: userid.MustNew(user.ID)})
+	_, err := svc.DeleteWorkspace(authCtx, connect.NewRequest(&leapmuxv1.DeleteWorkspaceRequest{
+		WorkspaceId: workspaceID,
+	}))
+	require.NoError(t, err)
+
+	_, getErr := st.Workspaces().GetByID(ctx, workspaceID)
+	require.ErrorIs(t, getErr, store.ErrNotFound)
 }

--- a/backend/internal/hub/store/mysql/db/queries/workspace_section_items.sql
+++ b/backend/internal/hub/store/mysql/db/queries/workspace_section_items.sql
@@ -45,6 +45,9 @@ WHERE section_id = ?;
 SELECT EXISTS(SELECT 1 FROM workspace_section_items WHERE section_id = ?) AS has_items;
 
 -- name: IsWorkspaceInArchivedSection :one
+-- Section type is a parameter, not the literal 3 this used to carry: a
+-- SectionType renumber must propagate rather than silently change which
+-- sections count as archived. See RenameWorkspaceSection.
 SELECT COUNT(*) > 0 AS is_archived FROM workspace_section_items wsi
 JOIN workspace_sections ws ON wsi.section_id = ws.id
-WHERE wsi.user_id = ? AND wsi.workspace_id = ? AND ws.section_type = 3;
+WHERE wsi.user_id = ? AND wsi.workspace_id = ? AND ws.section_type = ?;

--- a/backend/internal/hub/store/mysql/db/queries/workspace_sections.sql
+++ b/backend/internal/hub/store/mysql/db/queries/workspace_sections.sql
@@ -11,8 +11,13 @@ ORDER BY sidebar, position;
 SELECT * FROM workspace_sections WHERE id = ?;
 
 -- name: RenameWorkspaceSection :execresult
+-- The section type is a PARAMETER, not the literal 1 this used to carry.
+-- SectionType is a proto enum, and a renumber there would silently change
+-- which sections this matches -- if 1 came to mean a built-in type, the
+-- sibling delete below would start matching the sections it exists to
+-- protect. Binding the enum makes a renumber propagate instead.
 UPDATE workspace_sections SET name = ?
-WHERE id = ? AND user_id = ? AND section_type = 1;
+WHERE id = ? AND user_id = ? AND section_type = ?;
 
 -- name: UpdateWorkspaceSectionPosition :exec
 UPDATE workspace_sections SET position = ?
@@ -23,11 +28,13 @@ UPDATE workspace_sections SET sidebar = ?, position = ?
 WHERE id = ? AND user_id = ?;
 
 -- name: DeleteWorkspaceSection :execresult
+-- Section type is a parameter; see RenameWorkspaceSection above.
 DELETE FROM workspace_sections
-WHERE id = ? AND user_id = ? AND section_type = 1;
+WHERE id = ? AND user_id = ? AND section_type = ?;
 
 -- name: HasDefaultSectionsForUser :one
+-- Section type is a parameter; see RenameWorkspaceSection above.
 SELECT EXISTS(
   SELECT 1 FROM workspace_sections
-  WHERE user_id = ? AND section_type != 1
+  WHERE user_id = ? AND section_type != ?
 );

--- a/backend/internal/hub/store/mysql/workspace_section_items.go
+++ b/backend/internal/hub/store/mysql/workspace_section_items.go
@@ -3,6 +3,8 @@ package mysql
 import (
 	"context"
 
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
 	"github.com/leapmux/leapmux/internal/util/userid"
@@ -103,6 +105,10 @@ func (s *workspaceSectionItemStore) IsInArchivedSection(ctx context.Context, p s
 	ok, err := s.conn.q.IsWorkspaceInArchivedSection(ctx, gendb.IsWorkspaceInArchivedSectionParams{
 		UserID:      owner,
 		WorkspaceID: p.WorkspaceID,
+		// Bound from the enum rather than spelled as a literal in the SQL, so a
+		// SectionType renumber propagates instead of silently changing which
+		// sections count as archived.
+		SectionType: leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_ARCHIVED,
 	})
 	return ok, mapErr(err)
 }

--- a/backend/internal/hub/store/mysql/workspace_sections.go
+++ b/backend/internal/hub/store/mysql/workspace_sections.go
@@ -3,6 +3,8 @@ package mysql
 import (
 	"context"
 
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/mysql/generated/db"
 	"github.com/leapmux/leapmux/internal/util/userid"
@@ -70,6 +72,11 @@ func (s *workspaceSectionStore) Rename(ctx context.Context, p store.RenameWorksp
 		Name:   p.Name,
 		ID:     p.ID,
 		UserID: owner,
+		// A built-in section has a fixed name, so the query matches custom
+		// sections only. The type is BOUND from the enum rather than spelled as
+		// a literal in the SQL: a renumber then propagates instead of silently
+		// changing which sections this matches.
+		SectionType: leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_CUSTOM,
 	}))
 }
 
@@ -118,6 +125,10 @@ func (s *workspaceSectionStore) Delete(ctx context.Context, p store.DeleteWorksp
 	return rowsAffected(s.conn.q.DeleteWorkspaceSection(ctx, gendb.DeleteWorkspaceSectionParams{
 		ID:     p.ID,
 		UserID: owner,
+		// Custom sections only, bound from the enum. This is the dangerous one:
+		// were the literal to drift onto a built-in type, delete would start
+		// matching the very sections it exists to protect.
+		SectionType: leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_CUSTOM,
 	}))
 }
 
@@ -128,6 +139,11 @@ func (s *workspaceSectionStore) HasDefaultForUser(ctx context.Context, userID us
 		// blank-owner row rather than none. See userid.OwnerFilter.
 		return false, nil
 	}
-	exists, err := s.conn.q.HasDefaultSectionsForUser(ctx, owner)
+	exists, err := s.conn.q.HasDefaultSectionsForUser(ctx, gendb.HasDefaultSectionsForUserParams{
+		UserID: owner,
+		// "Has any NON-custom section", i.e. has the defaults been seeded.
+		// Bound from the enum for the same reason as the two above.
+		SectionType: leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_CUSTOM,
+	})
 	return exists, mapErr(err)
 }

--- a/backend/internal/hub/store/postgres/db/queries/workspace_section_items.sql
+++ b/backend/internal/hub/store/postgres/db/queries/workspace_section_items.sql
@@ -37,6 +37,9 @@ WHERE section_id = $1;
 SELECT EXISTS(SELECT 1 FROM workspace_section_items WHERE section_id = $1) AS has_items;
 
 -- name: IsWorkspaceInArchivedSection :one
+-- Section type is a parameter, not the literal 3 this used to carry: a
+-- SectionType renumber must propagate rather than silently change which
+-- sections count as archived. See RenameWorkspaceSection.
 SELECT COUNT(*) > 0 AS is_archived FROM workspace_section_items wsi
 JOIN workspace_sections ws ON wsi.section_id = ws.id
-WHERE wsi.user_id = $1 AND wsi.workspace_id = $2 AND ws.section_type = 3;
+WHERE wsi.user_id = $1 AND wsi.workspace_id = $2 AND ws.section_type = $3;

--- a/backend/internal/hub/store/postgres/db/queries/workspace_sections.sql
+++ b/backend/internal/hub/store/postgres/db/queries/workspace_sections.sql
@@ -11,8 +11,13 @@ ORDER BY sidebar, position;
 SELECT * FROM workspace_sections WHERE id = $1;
 
 -- name: RenameWorkspaceSection :execresult
+-- The section type is a PARAMETER, not the literal 1 this used to carry.
+-- SectionType is a proto enum, and a renumber there would silently change
+-- which sections this matches -- if 1 came to mean a built-in type, the
+-- sibling delete below would start matching the sections it exists to
+-- protect. Binding the enum makes a renumber propagate instead.
 UPDATE workspace_sections SET name = $1
-WHERE id = $2 AND user_id = $3 AND section_type = 1;
+WHERE id = $2 AND user_id = $3 AND section_type = $4;
 
 -- name: UpdateWorkspaceSectionPosition :exec
 UPDATE workspace_sections SET position = $1
@@ -23,11 +28,13 @@ UPDATE workspace_sections SET sidebar = $1, position = $2
 WHERE id = $3 AND user_id = $4;
 
 -- name: DeleteWorkspaceSection :execresult
+-- Section type is a parameter; see RenameWorkspaceSection above.
 DELETE FROM workspace_sections
-WHERE id = $1 AND user_id = $2 AND section_type = 1;
+WHERE id = $1 AND user_id = $2 AND section_type = $3;
 
 -- name: HasDefaultSectionsForUser :one
+-- Section type is a parameter; see RenameWorkspaceSection above.
 SELECT EXISTS(
   SELECT 1 FROM workspace_sections
-  WHERE user_id = $1 AND section_type != 1
+  WHERE user_id = $1 AND section_type != $2
 );

--- a/backend/internal/hub/store/postgres/workspace_section_items.go
+++ b/backend/internal/hub/store/postgres/workspace_section_items.go
@@ -3,6 +3,8 @@ package postgres
 import (
 	"context"
 
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/postgres/generated/db"
 	"github.com/leapmux/leapmux/internal/util/userid"
@@ -103,6 +105,10 @@ func (s *workspaceSectionItemStore) IsInArchivedSection(ctx context.Context, p s
 	ok, err := s.conn.q.IsWorkspaceInArchivedSection(ctx, gendb.IsWorkspaceInArchivedSectionParams{
 		UserID:      owner,
 		WorkspaceID: p.WorkspaceID,
+		// Bound from the enum rather than spelled as a literal in the SQL, so a
+		// SectionType renumber propagates instead of silently changing which
+		// sections count as archived.
+		SectionType: leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_ARCHIVED,
 	})
 	return ok, mapErr(err)
 }

--- a/backend/internal/hub/store/postgres/workspace_sections.go
+++ b/backend/internal/hub/store/postgres/workspace_sections.go
@@ -3,6 +3,8 @@ package postgres
 import (
 	"context"
 
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/postgres/generated/db"
 	"github.com/leapmux/leapmux/internal/util/userid"
@@ -70,6 +72,11 @@ func (s *workspaceSectionStore) Rename(ctx context.Context, p store.RenameWorksp
 		Name:   p.Name,
 		ID:     p.ID,
 		UserID: owner,
+		// A built-in section has a fixed name, so the query matches custom
+		// sections only. The type is BOUND from the enum rather than spelled as
+		// a literal in the SQL: a renumber then propagates instead of silently
+		// changing which sections this matches.
+		SectionType: leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_CUSTOM,
 	}))
 }
 
@@ -118,6 +125,10 @@ func (s *workspaceSectionStore) Delete(ctx context.Context, p store.DeleteWorksp
 	return rowsAffected(s.conn.q.DeleteWorkspaceSection(ctx, gendb.DeleteWorkspaceSectionParams{
 		ID:     p.ID,
 		UserID: owner,
+		// Custom sections only, bound from the enum. This is the dangerous one:
+		// were the literal to drift onto a built-in type, delete would start
+		// matching the very sections it exists to protect.
+		SectionType: leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_CUSTOM,
 	}))
 }
 
@@ -128,6 +139,11 @@ func (s *workspaceSectionStore) HasDefaultForUser(ctx context.Context, userID us
 		// blank-owner row rather than none. See userid.OwnerFilter.
 		return false, nil
 	}
-	exists, err := s.conn.q.HasDefaultSectionsForUser(ctx, owner)
+	exists, err := s.conn.q.HasDefaultSectionsForUser(ctx, gendb.HasDefaultSectionsForUserParams{
+		UserID: owner,
+		// "Has any NON-custom section", i.e. has the defaults been seeded.
+		// Bound from the enum for the same reason as the two above.
+		SectionType: leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_CUSTOM,
+	})
 	return exists, mapErr(err)
 }

--- a/backend/internal/hub/store/section_type_numbering_test.go
+++ b/backend/internal/hub/store/section_type_numbering_test.go
@@ -1,0 +1,70 @@
+package store_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+)
+
+// Every migration that hard-codes a SectionType number, and what it uses it
+// for. A migration is frozen history: it cannot take a query parameter the way
+// the queries in `db/queries/` now do, so these numbers are the one place where
+// a renumber of `SectionType` would go unnoticed.
+var sectionTypeMigrations = []string{
+	filepath.Join("sqlite", "db", "migrations", "00001_initial.sql"),
+	filepath.Join("postgres", "db", "migrations", "00001_initial.sql"),
+	filepath.Join("mysql", "db", "migrations", "00001_initial.sql"),
+}
+
+// A user may hold any number of custom sections and exactly one of every other
+// type. All three migrations encode that as `section_type <> 1` -- a partial
+// unique index on sqlite and postgres, a generated column on mysql -- and each
+// also defaults the column to 1.
+//
+// Renumber `SECTION_TYPE_WORKSPACES_CUSTOM` and the constraint silently swaps
+// which type a user may hold many of: the new 1 becomes unconstrained, and
+// custom sections become unique per user, so the second one a user creates
+// fails on an index nobody edited.
+//
+// The queries no longer need this pin. `RenameWorkspaceSection`,
+// `DeleteWorkspaceSection`, `HasDefaultSectionsForUser` and
+// `IsWorkspaceInArchivedSection` all bind the type as a parameter from the enum
+// itself, so a renumber propagates through them. Only the schema is left.
+func TestSectionTypeCustomIsOneInEveryMigration(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, leapmuxv1.SectionType(1), leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_CUSTOM,
+		"the migrations below spell this number; renumbering it needs a migration, not just a proto edit")
+
+	for _, rel := range sectionTypeMigrations {
+		data, err := os.ReadFile(rel)
+		require.NoError(t, err, "read %s", rel)
+		sql := string(data)
+		assert.Contains(t, sql, "section_type <> 1",
+			"%s encodes SECTION_TYPE_WORKSPACES_CUSTOM as the literal 1", rel)
+		assert.Contains(t, sql, "section_type INT",
+			"%s declares the column this constraint is on", rel)
+	}
+}
+
+// The default a bare INSERT falls back to is the same number, so a row written
+// without an explicit type is a CUSTOM section.
+func TestSectionTypeColumnDefaultsToCustom(t *testing.T) {
+	t.Parallel()
+
+	for _, rel := range sectionTypeMigrations {
+		data, err := os.ReadFile(rel)
+		require.NoError(t, err, "read %s", rel)
+		assert.True(t,
+			strings.Contains(string(data), "section_type INTEGER NOT NULL DEFAULT 1") ||
+				strings.Contains(string(data), "section_type INT NOT NULL DEFAULT 1"),
+			"%s must default section_type to SECTION_TYPE_WORKSPACES_CUSTOM (%d)",
+			rel, leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_CUSTOM)
+	}
+}

--- a/backend/internal/hub/store/section_type_numbering_test.go
+++ b/backend/internal/hub/store/section_type_numbering_test.go
@@ -43,14 +43,37 @@ func TestSectionTypeCustomIsOneInEveryMigration(t *testing.T) {
 		"the migrations below spell this number; renumbering it needs a migration, not just a proto edit")
 
 	for _, rel := range sectionTypeMigrations {
-		data, err := os.ReadFile(rel)
-		require.NoError(t, err, "read %s", rel)
-		sql := string(data)
+		sql := statementsOf(t, rel)
 		assert.Contains(t, sql, "section_type <> 1",
 			"%s encodes SECTION_TYPE_WORKSPACES_CUSTOM as the literal 1", rel)
-		assert.Contains(t, sql, "section_type INT",
-			"%s declares the column this constraint is on", rel)
+		// The STATEMENT that carries the rule, not merely the number. A whole
+		// file search passes on the comment beside the constraint, so deleting
+		// the constraint and keeping the comment would leave this green.
+		hasPartialIndex := strings.Contains(sql, "ON workspace_sections(user_id, section_type) WHERE section_type <> 1")
+		hasGeneratedColumn := strings.Contains(sql, "AS (CASE WHEN section_type <> 1 THEN section_type END)")
+		assert.True(t, hasPartialIndex || hasGeneratedColumn,
+			"%s must carry the one-per-type rule as a partial unique index or a generated column", rel)
 	}
+}
+
+// One migration's SQL with every `--` comment line removed.
+//
+// The assertions below search for statement text, and a comment that merely
+// DISCUSSES the constraint satisfies a whole-file substring search just as well
+// as the constraint itself -- which would let a dropped index pass.
+func statementsOf(t *testing.T, rel string) string {
+	t.Helper()
+	data, err := os.ReadFile(rel)
+	require.NoError(t, err, "read %s", rel)
+	var b strings.Builder
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "--") {
+			continue
+		}
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	return b.String()
 }
 
 // The default a bare INSERT falls back to is the same number, so a row written
@@ -59,11 +82,10 @@ func TestSectionTypeColumnDefaultsToCustom(t *testing.T) {
 	t.Parallel()
 
 	for _, rel := range sectionTypeMigrations {
-		data, err := os.ReadFile(rel)
-		require.NoError(t, err, "read %s", rel)
+		sql := statementsOf(t, rel)
 		assert.True(t,
-			strings.Contains(string(data), "section_type INTEGER NOT NULL DEFAULT 1") ||
-				strings.Contains(string(data), "section_type INT NOT NULL DEFAULT 1"),
+			strings.Contains(sql, "section_type INTEGER NOT NULL DEFAULT 1") ||
+				strings.Contains(sql, "section_type INT NOT NULL DEFAULT 1"),
 			"%s must default section_type to SECTION_TYPE_WORKSPACES_CUSTOM (%d)",
 			rel, leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_CUSTOM)
 	}

--- a/backend/internal/hub/store/sqlite/db/queries/workspace_section_items.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/workspace_section_items.sql
@@ -41,6 +41,9 @@ WHERE section_id = ?;
 SELECT EXISTS(SELECT 1 FROM workspace_section_items WHERE section_id = ?) AS has_items;
 
 -- name: IsWorkspaceInArchivedSection :one
+-- Section type is a parameter, not the literal 3 this used to carry: a
+-- SectionType renumber must propagate rather than silently change which
+-- sections count as archived. See RenameWorkspaceSection.
 SELECT COUNT(*) > 0 AS is_archived FROM workspace_section_items wsi
 JOIN workspace_sections ws ON wsi.section_id = ws.id
-WHERE wsi.user_id = ? AND wsi.workspace_id = ? AND ws.section_type = 3;
+WHERE wsi.user_id = ? AND wsi.workspace_id = ? AND ws.section_type = ?;

--- a/backend/internal/hub/store/sqlite/db/queries/workspace_sections.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/workspace_sections.sql
@@ -11,8 +11,13 @@ ORDER BY sidebar, position;
 SELECT * FROM workspace_sections WHERE id = ?;
 
 -- name: RenameWorkspaceSection :execresult
+-- The section type is a PARAMETER, not the literal 1 this used to carry.
+-- SectionType is a proto enum, and a renumber there would silently change
+-- which sections this matches -- if 1 came to mean a built-in type, the
+-- sibling delete below would start matching the sections it exists to
+-- protect. Binding the enum makes a renumber propagate instead.
 UPDATE workspace_sections SET name = ?
-WHERE id = ? AND user_id = ? AND section_type = 1;
+WHERE id = ? AND user_id = ? AND section_type = ?;
 
 -- name: UpdateWorkspaceSectionPosition :exec
 UPDATE workspace_sections SET position = ?
@@ -23,11 +28,13 @@ UPDATE workspace_sections SET sidebar = ?, position = ?
 WHERE id = ? AND user_id = ?;
 
 -- name: DeleteWorkspaceSection :execresult
+-- Section type is a parameter; see RenameWorkspaceSection above.
 DELETE FROM workspace_sections
-WHERE id = ? AND user_id = ? AND section_type = 1;
+WHERE id = ? AND user_id = ? AND section_type = ?;
 
 -- name: HasDefaultSectionsForUser :one
+-- Section type is a parameter; see RenameWorkspaceSection above.
 SELECT EXISTS(
   SELECT 1 FROM workspace_sections
-  WHERE user_id = ? AND section_type != 1
+  WHERE user_id = ? AND section_type != ?
 );

--- a/backend/internal/hub/store/sqlite/workspace_section_items.go
+++ b/backend/internal/hub/store/sqlite/workspace_section_items.go
@@ -3,6 +3,8 @@ package sqlite
 import (
 	"context"
 
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/sqlite/generated/db"
 	"github.com/leapmux/leapmux/internal/util/userid"
@@ -106,6 +108,10 @@ func (s *workspaceSectionItemStore) IsInArchivedSection(ctx context.Context, p s
 	ok, err := s.conn.q.IsWorkspaceInArchivedSection(ctx, gendb.IsWorkspaceInArchivedSectionParams{
 		UserID:      owner,
 		WorkspaceID: p.WorkspaceID,
+		// Bound from the enum rather than spelled as a literal in the SQL, so a
+		// SectionType renumber propagates instead of silently changing which
+		// sections count as archived.
+		SectionType: leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_ARCHIVED,
 	})
 	return ok, mapErr(err)
 }

--- a/backend/internal/hub/store/sqlite/workspace_sections.go
+++ b/backend/internal/hub/store/sqlite/workspace_sections.go
@@ -139,11 +139,11 @@ func (s *workspaceSectionStore) HasDefaultForUser(ctx context.Context, userID us
 		// blank-owner row rather than none. See userid.OwnerFilter.
 		return false, nil
 	}
-	n, err := s.conn.q.HasDefaultSectionsForUser(ctx, gendb.HasDefaultSectionsForUserParams{
+	exists, err := s.conn.q.HasDefaultSectionsForUser(ctx, gendb.HasDefaultSectionsForUserParams{
 		UserID: owner,
 		// "Has any NON-custom section", i.e. has the defaults been seeded.
 		// Bound from the enum for the same reason as the two above.
 		SectionType: leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_CUSTOM,
 	})
-	return n, mapErr(err)
+	return exists, mapErr(err)
 }

--- a/backend/internal/hub/store/sqlite/workspace_sections.go
+++ b/backend/internal/hub/store/sqlite/workspace_sections.go
@@ -3,6 +3,8 @@ package sqlite
 import (
 	"context"
 
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+
 	"github.com/leapmux/leapmux/internal/hub/store"
 	gendb "github.com/leapmux/leapmux/internal/hub/store/sqlite/generated/db"
 	"github.com/leapmux/leapmux/internal/util/userid"
@@ -70,6 +72,11 @@ func (s *workspaceSectionStore) Rename(ctx context.Context, p store.RenameWorksp
 		Name:   p.Name,
 		ID:     p.ID,
 		UserID: owner,
+		// A built-in section has a fixed name, so the query matches custom
+		// sections only. The type is BOUND from the enum rather than spelled as
+		// a literal in the SQL: a renumber then propagates instead of silently
+		// changing which sections this matches.
+		SectionType: leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_CUSTOM,
 	}))
 }
 
@@ -118,6 +125,10 @@ func (s *workspaceSectionStore) Delete(ctx context.Context, p store.DeleteWorksp
 	return rowsAffected(s.conn.q.DeleteWorkspaceSection(ctx, gendb.DeleteWorkspaceSectionParams{
 		ID:     p.ID,
 		UserID: owner,
+		// Custom sections only, bound from the enum. This is the dangerous one:
+		// were the literal to drift onto a built-in type, delete would start
+		// matching the very sections it exists to protect.
+		SectionType: leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_CUSTOM,
 	}))
 }
 
@@ -128,6 +139,11 @@ func (s *workspaceSectionStore) HasDefaultForUser(ctx context.Context, userID us
 		// blank-owner row rather than none. See userid.OwnerFilter.
 		return false, nil
 	}
-	n, err := s.conn.q.HasDefaultSectionsForUser(ctx, owner)
+	n, err := s.conn.q.HasDefaultSectionsForUser(ctx, gendb.HasDefaultSectionsForUserParams{
+		UserID: owner,
+		// "Has any NON-custom section", i.e. has the defaults been seeded.
+		// Bound from the enum for the same reason as the two above.
+		SectionType: leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_CUSTOM,
+	})
 	return n, mapErr(err)
 }

--- a/backend/internal/util/lexorank/lexorank.go
+++ b/backend/internal/util/lexorank/lexorank.go
@@ -56,7 +56,18 @@ func before(s string) string {
 }
 
 // between returns a rank between a and b where a < b.
+//
+// It normalizes a descending pair rather than trusting the caller. The midpoint
+// test below subtracts one byte from another, so a descending pair wrapped the
+// unsigned result and the function answered a rank on the wrong side of b -- or,
+// for two adjacent characters, a rank EQUAL to b, which collides with the row
+// that b identifies. The TypeScript port computes the same subtraction on a signed
+// number and did not wrap, so the two implementations also disagreed.
 func between(a, b string) string {
+	if a >= b {
+		a, b = b, a
+	}
+
 	// Pad a and b to the same length for comparison.
 	maxLen := len(a)
 	if len(b) > maxLen {

--- a/backend/internal/util/lexorank/lexorank_test.go
+++ b/backend/internal/util/lexorank/lexorank_test.go
@@ -94,3 +94,35 @@ func TestBefore(t *testing.T) {
 		b = prev
 	}
 }
+
+// Mid takes a DESCENDING pair without answering a rank that collides with one
+// of its arguments, or one that sits outside them.
+//
+// between's midpoint test subtracts one byte from another. A descending pair
+// wrapped the unsigned result, so the function reported a gap where there was
+// none: it answered a rank on the wrong side of b, and for two adjacent
+// characters a rank EQUAL to b -- which collides with the row b identifies, and two
+// rows that share a rank are ordered by whatever the SQL planner picks.
+//
+// SectionService.CreateSection reached this whenever a user dragged a section
+// past another, because MoveSection writes any position a client asks for.
+func TestMidNormalizesADescendingPair(t *testing.T) {
+	pairs := [][2]string{
+		{"nng", "nn"}, // a custom section dragged below Archived
+		{"o", "n"},    // adjacent characters: the collision case
+		{"n", "a"},
+		{"zz", "aa"},
+		{"nn", "n"},
+	}
+
+	for _, p := range pairs {
+		hi, lo := p[0], p[1]
+		m := Mid(hi, lo)
+
+		assert.Greater(t, m, lo, "Mid(%q, %q) must sort after the lower bound", hi, lo)
+		assert.Less(t, m, hi, "Mid(%q, %q) must sort before the upper bound", hi, lo)
+		// Mid is symmetric now, so neither caller order can produce a
+		// different answer.
+		assert.Equal(t, Mid(lo, hi), m, "Mid(%q, %q) must not depend on the argument order", hi, lo)
+	}
+}

--- a/backend/internal/util/testutil/paths.go
+++ b/backend/internal/util/testutil/paths.go
@@ -1,0 +1,42 @@
+package testutil
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// NativeAbsPath renders a POSIX-style path literal as a NATIVE absolute path.
+//
+// A POSIX literal cannot stand in for one. An absolute path on Windows carries
+// a volume, so filepath.IsAbs("/repo/a.go") is FALSE there. A guard that asks
+// filepath.IsAbs then refuses the fixture, for a reason the test never meant to
+// assert.
+//
+// That failure lands far from the literal and describes the wrong thing. The
+// code under test answers "not absolute" correctly, and the assertion that
+// fails reports the behavior the test exists to pin.
+//
+// The paths this builds are fictional and never reach the filesystem. They only
+// have to be absolute, and to survive a round trip through storage unchanged.
+//
+// Use this for a fixture path that production code checks for absoluteness.
+// Prefer t.TempDir for a path that a test opens.
+func NativeAbsPath(posixPath string) string {
+	return filepath.FromSlash(nativePathVolume + posixPath)
+}
+
+// nativePathVolume is the volume component of the test binary's working
+// directory: "" on POSIX (where the literals are already absolute), "C:"/"D:"/...
+// on Windows. Derived rather than hardcoded so NativeAbsPath states a volume
+// that exists on whatever host runs the suite.
+var nativePathVolume = func() string {
+	wd, err := os.Getwd()
+	if err != nil {
+		// Only reachable if the cwd was unlinked mid-run. Returning "" keeps
+		// NativeAbsPath total; on Windows the result is then not absolute, so
+		// the guard under test refuses it and the test fails loudly rather
+		// than quietly exercising some other path.
+		return ""
+	}
+	return filepath.VolumeName(wd)
+}()

--- a/backend/internal/util/testutil/paths_test.go
+++ b/backend/internal/util/testutil/paths_test.go
@@ -1,0 +1,63 @@
+package testutil_test
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/leapmux/leapmux/internal/util/testutil"
+)
+
+// TestNativeAbsPath_IsAbsoluteOnEveryHost pins the one property every caller
+// depends on, against the SAME filepath.IsAbs the guards under test apply.
+//
+// Without it the platform assumption is only implied by the fixtures. A host
+// where it does not hold then reports many unrelated failures about ownership,
+// reaping and scope -- which is exactly how the POSIX-literal version surfaced
+// on Windows.
+func TestNativeAbsPath_IsAbsoluteOnEveryHost(t *testing.T) {
+	t.Parallel()
+
+	for _, p := range []string{"/r", "/mine-a", "/r/a.go", "/repo/pkg/README.md"} {
+		got := testutil.NativeAbsPath(p)
+		assert.True(t, filepath.IsAbs(got),
+			"NativeAbsPath(%q) = %q must be absolute on %s", p, got, runtime.GOOS)
+	}
+}
+
+// A caller that stores a fixture path and compares it later needs the path to
+// be in cleaned form already, or filepath.Clean rewrites the separators and the
+// two spellings stop matching.
+func TestNativeAbsPath_IsAlreadyCleaned(t *testing.T) {
+	t.Parallel()
+
+	for _, p := range []string{"/r", "/r/a.go", "/repo/pkg/README.md"} {
+		got := testutil.NativeAbsPath(p)
+		assert.Equal(t, got, filepath.Clean(got),
+			"NativeAbsPath(%q) = %q must already be cleaned on %s", p, got, runtime.GOOS)
+	}
+}
+
+// The volume is what a POSIX literal lacks, and Windows is the only host that
+// requires one. This case states why NativeAbsPath exists at all.
+func TestNativeAbsPath_CarriesAVolumeOnWindows(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS != "windows" {
+		assert.Equal(t, "/r/a.go", testutil.NativeAbsPath("/r/a.go"),
+			"a POSIX host needs no rewrite, so the literal passes through unchanged")
+		return
+	}
+	assert.NotEmpty(t, filepath.VolumeName(testutil.NativeAbsPath("/r/a.go")),
+		"an absolute path on Windows carries a volume")
+}
+
+// Distinct literals must stay distinct, or a test that seeds two rows and
+// expects two answers gets one.
+func TestNativeAbsPath_KeepsDistinctLiteralsDistinct(t *testing.T) {
+	t.Parallel()
+
+	assert.NotEqual(t, testutil.NativeAbsPath("/r/a.go"), testutil.NativeAbsPath("/r/b.go"))
+}

--- a/backend/internal/worker/service/agent_private_events_scope_test.go
+++ b/backend/internal/worker/service/agent_private_events_scope_test.go
@@ -1,15 +1,38 @@
 package service
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/authscope"
+	"github.com/leapmux/leapmux/internal/util/testutil"
 	"github.com/leapmux/leapmux/internal/util/userid"
 	"github.com/leapmux/leapmux/internal/worker/channel"
 )
+
+// TestPrivateEventFixturesStateAKindOnEveryHost pins the precondition every
+// case below depends on, against the SAME tabPayloadType the code under test
+// calls: each fixture payload must state a kind on the running host.
+//
+// privateEventVisible fails closed on a payload it cannot classify, so a
+// fixture the host rejects makes a visibility assertion fail while reporting
+// the scope gate -- the behavior the test exists to pin and the one part of it
+// that is correct. This case reports the fixture instead.
+func TestPrivateEventFixturesStateAKindOnEveryHost(t *testing.T) {
+	t.Parallel()
+
+	fileKind, err := tabPayloadType(filePayloadFor("/repo/a.txt"))
+	require.NoErrorf(t, err, "the FILE fixture must state a kind on %s", runtime.GOOS)
+	assert.Equal(t, leapmuxv1.TabType_TAB_TYPE_FILE, fileKind)
+
+	imageKind, err := tabPayloadType(imagePayloadFor("agent-a", 42, 0, "mcp__playwright__screenshot"))
+	require.NoErrorf(t, err, "the IMAGE fixture must state a kind on %s", runtime.GOOS)
+	assert.Equal(t, leapmuxv1.TabType_TAB_TYPE_IMAGE, imageKind)
+}
 
 // A tab rename's title is exactly what the agent:read / terminal:read scopes
 // govern, and the private-events bus multiplexes those renames beside the
@@ -96,16 +119,26 @@ func TestPrivateEventVisiblePassesRevocations(t *testing.T) {
 	assert.True(t, privateEventVisible(fileOnly, revoked))
 }
 
-func filePayloadFor(path string) *leapmuxv1.TabPayload {
+// filePayloadFor builds a FILE payload from a POSIX-style path literal.
+//
+// The literal goes through testutil.NativeAbsPath because privateEventVisible
+// reaches tabPayloadType, which asks filepath.IsAbs whether the file_path is
+// absolute. That question is platform-specific: "/repo/a.txt" is NOT absolute
+// on Windows, so a raw literal makes tabPayloadType fail closed and every
+// assertion below that expects a visible FILE event fails there for a reason
+// none of them is about. TestPrivateEventFixturesStateAKindOnEveryHost pins it.
+func filePayloadFor(posixPath string) *leapmuxv1.TabPayload {
 	return &leapmuxv1.TabPayload{
-		WorkingDir: "/repo",
-		Kind:       &leapmuxv1.TabPayload_File{File: &leapmuxv1.FileTabPayload{FilePath: path}},
+		WorkingDir: testutil.NativeAbsPath("/repo"),
+		Kind: &leapmuxv1.TabPayload_File{File: &leapmuxv1.FileTabPayload{
+			FilePath: testutil.NativeAbsPath(posixPath),
+		}},
 	}
 }
 
 func imagePayloadFor(agentID string, seq int64, index int32, title string) *leapmuxv1.TabPayload {
 	return &leapmuxv1.TabPayload{
-		WorkingDir: "/repo",
+		WorkingDir: testutil.NativeAbsPath("/repo"),
 		Kind: &leapmuxv1.TabPayload_Image{Image: &leapmuxv1.ImageTabPayload{
 			AgentId: agentID, Seq: seq, ImageIndex: index, Title: title,
 		}},

--- a/backend/internal/worker/service/orphan_reconciler_test.go
+++ b/backend/internal/worker/service/orphan_reconciler_test.go
@@ -15,6 +15,7 @@ import (
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/util/sqlitedb"
+	"github.com/leapmux/leapmux/internal/util/testutil"
 	workerdb "github.com/leapmux/leapmux/internal/worker/db"
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
 	"github.com/leapmux/leapmux/internal/worker/service"
@@ -96,7 +97,7 @@ func TestOrphanReconciler_FileTab_MissingOnHub_Revoked(t *testing.T) {
 
 	// Local row that the hub no longer knows about.
 	require.NoError(t, files.Register(ctx, service.RegisterTabPayloadParams{
-		UserID: "user-1", TabID: "ghost", Payload: filePayload(absTestPath("/r/a.go")),
+		UserID: "user-1", TabID: "ghost", Payload: filePayload(testutil.NativeAbsPath("/r/a.go")),
 	}))
 	setFake("user-1", nil, nil)
 
@@ -271,7 +272,7 @@ func TestOrphanReconciler_ListError_DoesNotPanic_DoesNotCloseRows(t *testing.T) 
 	ctx := context.Background()
 
 	require.NoError(t, files.Register(ctx, service.RegisterTabPayloadParams{
-		UserID: "user-1", TabID: "live", Payload: filePayload(absTestPath("/r/a.go")),
+		UserID: "user-1", TabID: "live", Payload: filePayload(testutil.NativeAbsPath("/r/a.go")),
 	}))
 	require.NoError(t, q.CreateAgent(ctx, db.CreateAgentParams{
 		ID: "live-agent", AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX,
@@ -300,7 +301,7 @@ func TestOrphanReconciler_TriggerRunsPassImmediately(t *testing.T) {
 	defer cancel()
 
 	require.NoError(t, files.Register(ctx, service.RegisterTabPayloadParams{
-		UserID: "user-1", TabID: "ghost", Payload: filePayload(absTestPath("/r/a.go")),
+		UserID: "user-1", TabID: "ghost", Payload: filePayload(testutil.NativeAbsPath("/r/a.go")),
 	}))
 	setFake("user-1", nil, nil)
 
@@ -313,7 +314,7 @@ func TestOrphanReconciler_TriggerRunsPassImmediately(t *testing.T) {
 
 	// Add another orphan and confirm Trigger fires a fresh pass.
 	require.NoError(t, files.Register(ctx, service.RegisterTabPayloadParams{
-		UserID: "user-1", TabID: "ghost2", Payload: filePayload(absTestPath("/r/b.go")),
+		UserID: "user-1", TabID: "ghost2", Payload: filePayload(testutil.NativeAbsPath("/r/b.go")),
 	}))
 	rec.Trigger()
 	require.Eventually(t, func() bool {
@@ -347,7 +348,7 @@ func TestOrphanReconciler_RetriesAfterHubListFailure(t *testing.T) {
 	defer cancel()
 
 	require.NoError(t, files.Register(ctx, service.RegisterTabPayloadParams{
-		UserID: "user-1", TabID: "ghost", Payload: filePayload(absTestPath("/r/a.go")),
+		UserID: "user-1", TabID: "ghost", Payload: filePayload(testutil.NativeAbsPath("/r/a.go")),
 	}))
 	// The startup pass and any retry before the switch below both fail.
 	setFake("user-1", nil, errors.New("channel not ready"))
@@ -413,10 +414,10 @@ func TestOrphanReconciler_FileTab_SharedTabIDStaysWithItsOwner(t *testing.T) {
 
 	const sharedTabID = "file-1700000000000-1"
 	require.NoError(t, files.Register(ctx, service.RegisterTabPayloadParams{
-		UserID: "user-a", TabID: sharedTabID, Payload: filePayload(absTestPath("/r/a.go")),
+		UserID: "user-a", TabID: sharedTabID, Payload: filePayload(testutil.NativeAbsPath("/r/a.go")),
 	}))
 	require.NoError(t, files.Register(ctx, service.RegisterTabPayloadParams{
-		UserID: "user-b", TabID: sharedTabID, Payload: filePayload(absTestPath("/r/b.go")),
+		UserID: "user-b", TabID: sharedTabID, Payload: filePayload(testutil.NativeAbsPath("/r/b.go")),
 	}))
 
 	// The hub knows both rows, each naming its own owner. Neither is absent,
@@ -432,9 +433,9 @@ func TestOrphanReconciler_FileTab_SharedTabIDStaysWithItsOwner(t *testing.T) {
 	byUser := tabPayloadsByUser(t, q, ctx)
 	require.Contains(t, byUser, "user-a")
 	require.Contains(t, byUser, "user-b")
-	assert.Equal(t, absTestPath("/r/a.go"), filePathOf(t, byUser["user-a"]),
+	assert.Equal(t, testutil.NativeAbsPath("/r/a.go"), filePathOf(t, byUser["user-a"]),
 		"user-a must be reconciled against user-a's hub row, not user-b's")
-	assert.Equal(t, absTestPath("/r/b.go"), filePathOf(t, byUser["user-b"]),
+	assert.Equal(t, testutil.NativeAbsPath("/r/b.go"), filePathOf(t, byUser["user-b"]),
 		"user-b's row must survive on its own hub row")
 }
 
@@ -457,10 +458,10 @@ func TestOrphanReconciler_FileTab_SharedTabIDReapsOnlyTheStaleOwner(t *testing.T
 
 	const sharedTabID = "file-1700000000000-1"
 	require.NoError(t, files.Register(ctx, service.RegisterTabPayloadParams{
-		UserID: "user-a", TabID: sharedTabID, Payload: filePayload(absTestPath("/r/a.go")),
+		UserID: "user-a", TabID: sharedTabID, Payload: filePayload(testutil.NativeAbsPath("/r/a.go")),
 	}))
 	require.NoError(t, files.Register(ctx, service.RegisterTabPayloadParams{
-		UserID: "user-b", TabID: sharedTabID, Payload: filePayload(absTestPath("/r/b.go")),
+		UserID: "user-b", TabID: sharedTabID, Payload: filePayload(testutil.NativeAbsPath("/r/b.go")),
 	}))
 
 	// Only user-a's tab survives at the hub.
@@ -472,7 +473,7 @@ func TestOrphanReconciler_FileTab_SharedTabIDReapsOnlyTheStaleOwner(t *testing.T
 
 	byUser := tabPayloadsByUser(t, q, ctx)
 	require.Contains(t, byUser, "user-a", "the hub-known owner's row must survive")
-	assert.Equal(t, absTestPath("/r/a.go"), filePathOf(t, byUser["user-a"]),
+	assert.Equal(t, testutil.NativeAbsPath("/r/a.go"), filePathOf(t, byUser["user-a"]),
 		"and must not be confused with a stranger's row")
 	assert.NotContains(t, byUser, "user-b",
 		"the owner the hub no longer knows about must be reaped, not shielded by the collision")
@@ -495,15 +496,15 @@ func TestOrphanReconciler_FileTab_OutOfScopeOwnerIsNotReaped(t *testing.T) {
 	ctx := context.Background()
 
 	require.NoError(t, files.Register(ctx, service.RegisterTabPayloadParams{
-		UserID: "user-a", TabID: "file-a", Payload: filePayload(absTestPath("/r/a.go")),
+		UserID: "user-a", TabID: "file-a", Payload: filePayload(testutil.NativeAbsPath("/r/a.go")),
 	}))
 	require.NoError(t, files.Register(ctx, service.RegisterTabPayloadParams{
-		UserID: "user-b", TabID: "file-b", Payload: filePayload(absTestPath("/r/b.go")),
+		UserID: "user-b", TabID: "file-b", Payload: filePayload(testutil.NativeAbsPath("/r/b.go")),
 	}))
 	// Link user-b's tab to a worktree: the reap drops that link FIRST, so an
 	// unscoped reap is observable here even before the file-tab row goes.
 	_, cwErr := q.CreateWorktree(ctx, db.CreateWorktreeParams{
-		ID: "wt-b", WorktreePath: absTestPath("/r/b"), RepoRoot: absTestPath("/r"), BranchName: "b",
+		ID: "wt-b", WorktreePath: testutil.NativeAbsPath("/r/b"), RepoRoot: testutil.NativeAbsPath("/r"), BranchName: "b",
 	})
 	require.NoError(t, cwErr)
 	require.NoError(t, q.AddWorktreeTab(ctx, db.AddWorktreeTabParams{
@@ -543,7 +544,7 @@ func TestOrphanReconciler_UndeclaredScopeReapsNothing(t *testing.T) {
 	ctx := context.Background()
 
 	require.NoError(t, files.Register(ctx, service.RegisterTabPayloadParams{
-		UserID: "user-a", TabID: "file-a", Payload: filePayload(absTestPath("/r/a.go")),
+		UserID: "user-a", TabID: "file-a", Payload: filePayload(testutil.NativeAbsPath("/r/a.go")),
 	}))
 	require.NoError(t, q.CreateAgent(ctx, db.CreateAgentParams{
 		ID: "agent-a", AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX,
@@ -652,7 +653,7 @@ func TestOrphanReconciler_OnConvergedReportsOnlyAConvergedPass(t *testing.T) {
 	defer cancel()
 
 	require.NoError(t, files.Register(ctx, service.RegisterTabPayloadParams{
-		UserID: "user-1", TabID: "ghost", Payload: filePayload(absTestPath("/r/a.go")),
+		UserID: "user-1", TabID: "ghost", Payload: filePayload(testutil.NativeAbsPath("/r/a.go")),
 	}))
 	setFake("user-1", nil, errors.New("channel not ready"))
 
@@ -702,7 +703,7 @@ func TestOrphanReconciler_NoOnConvergedHookIsFine(t *testing.T) {
 	defer cancel()
 
 	require.NoError(t, files.Register(ctx, service.RegisterTabPayloadParams{
-		UserID: "user-1", TabID: "ghost", Payload: filePayload(absTestPath("/r/a.go")),
+		UserID: "user-1", TabID: "ghost", Payload: filePayload(testutil.NativeAbsPath("/r/a.go")),
 	}))
 	setFake("user-1", nil, nil)
 

--- a/backend/internal/worker/service/tab_payload_test.go
+++ b/backend/internal/worker/service/tab_payload_test.go
@@ -2,9 +2,6 @@ package service_test
 
 import (
 	"context"
-	"os"
-	"path/filepath"
-	"runtime"
 	"testing"
 	"time"
 
@@ -15,14 +12,15 @@ import (
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/util/sqlitedb"
+	"github.com/leapmux/leapmux/internal/util/testutil"
 	"github.com/leapmux/leapmux/internal/util/userid"
 	workerdb "github.com/leapmux/leapmux/internal/worker/db"
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
 	"github.com/leapmux/leapmux/internal/worker/service"
 )
 
-// absTestPath renders a POSIX-style path literal as a NATIVE absolute path, for
-// the fixtures in this file and in orphan_reconciler_test.go.
+// Every fixture path in this file and in orphan_reconciler_test.go goes through
+// testutil.NativeAbsPath.
 //
 // The absoluteness guards these tests drive -- TabPayloadStore.Register's
 // filepath.IsAbs on file_path, and normalizeWorkingDir's on working_dir -- are
@@ -38,25 +36,6 @@ import (
 // every platform. They only have to be absolute, and to survive the round trip
 // through the database unchanged (Register stores file_path verbatim and
 // normalizeWorkingDir does not canonicalize, so they do).
-func absTestPath(p string) string {
-	return filepath.FromSlash(testPathVolume + p)
-}
-
-// testPathVolume is the volume component of the test binary's working directory:
-// "" on POSIX (where the literals are already absolute), "C:"/"D:"/... on
-// Windows. Derived rather than hardcoded so absTestPath names a volume that
-// exists on whatever host is running.
-var testPathVolume = func() string {
-	wd, err := os.Getwd()
-	if err != nil {
-		// Only reachable if the cwd was unlinked mid-run. Returning "" keeps
-		// absTestPath total; on Windows the result is then not absolute, so
-		// Register refuses it and the test fails loudly rather than quietly
-		// exercising some other path.
-		return ""
-	}
-	return filepath.VolumeName(wd)
-}()
 
 // newTabPayloadTestStore creates a worker DB and TabPayloadStore for
 // tests. Returns the store along with the bus so tests can subscribe.
@@ -72,33 +51,18 @@ func newTabPayloadTestStore(t *testing.T) (*service.TabPayloadStore, *service.Pr
 	return service.NewTabPayloadStore(q, bus), bus, q
 }
 
-// TestAbsTestPath_IsAbsoluteOnEveryHost pins the one property every fixture in
-// this package leans on, against the SAME filepath.IsAbs the code under test
-// applies. Without it the platform assumption is only implied by the fixtures,
-// and a host where it does not hold reports fifteen unrelated "must be absolute"
-// failures in tests about ownership and reaping -- which is exactly how the
-// POSIX-literal version surfaced on Windows.
-func TestAbsTestPath_IsAbsoluteOnEveryHost(t *testing.T) {
-	t.Parallel()
-
-	for _, p := range []string{"/r", "/mine-a", "/r/a.go", "/repo/pkg/README.md"} {
-		got := absTestPath(p)
-		assert.True(t, filepath.IsAbs(got), "absTestPath(%q) = %q must be absolute on %s", p, got, runtime.GOOS)
-	}
-}
-
 func TestTabPayload_RegisterAndGet(t *testing.T) {
 	t.Parallel()
 
 	store, _, _ := newTabPayloadTestStore(t)
 	ctx := context.Background()
 	require.NoError(t, store.Register(ctx, service.RegisterTabPayloadParams{
-		UserID: "user-1", TabID: "t1", Payload: filePayloadIn(absTestPath("/repo/pkg/README.md"), absTestPath("/repo")),
+		UserID: "user-1", TabID: "t1", Payload: filePayloadIn(testutil.NativeAbsPath("/repo/pkg/README.md"), testutil.NativeAbsPath("/repo")),
 	}))
 	loc, err := store.Get(ctx, "user-1", "t1")
 	require.NoError(t, err)
-	assert.Equal(t, absTestPath("/repo/pkg/README.md"), loc.GetFile().GetFilePath())
-	assert.Equal(t, absTestPath("/repo"), loc.GetWorkingDir(),
+	assert.Equal(t, testutil.NativeAbsPath("/repo/pkg/README.md"), loc.GetFile().GetFilePath())
+	assert.Equal(t, testutil.NativeAbsPath("/repo"), loc.GetWorkingDir(),
 		"the originating tab's working dir is stored as given, not re-derived from the file's own directory")
 }
 
@@ -112,11 +76,11 @@ func TestTabPayload_RegisterWithoutWorkingDirFallsBackToFileDir(t *testing.T) {
 	store, _, _ := newTabPayloadTestStore(t)
 	ctx := context.Background()
 	require.NoError(t, store.Register(ctx, service.RegisterTabPayloadParams{
-		UserID: "user-1", TabID: "t1", Payload: filePayload(absTestPath("/repo/pkg/README.md")),
+		UserID: "user-1", TabID: "t1", Payload: filePayload(testutil.NativeAbsPath("/repo/pkg/README.md")),
 	}))
 	loc, err := store.Get(ctx, "user-1", "t1")
 	require.NoError(t, err)
-	assert.Equal(t, absTestPath("/repo/pkg"), loc.GetWorkingDir())
+	assert.Equal(t, testutil.NativeAbsPath("/repo/pkg"), loc.GetWorkingDir())
 }
 
 // Whitespace is not a working dir. The fallback is keyed on "the caller named
@@ -130,11 +94,11 @@ func TestTabPayload_RegisterTreatsBlankWorkingDirAsAbsent(t *testing.T) {
 	store, _, _ := newTabPayloadTestStore(t)
 	ctx := context.Background()
 	require.NoError(t, store.Register(ctx, service.RegisterTabPayloadParams{
-		UserID: "user-1", TabID: "t1", Payload: filePayloadIn(absTestPath("/repo/pkg/README.md"), "   "),
+		UserID: "user-1", TabID: "t1", Payload: filePayloadIn(testutil.NativeAbsPath("/repo/pkg/README.md"), "   "),
 	}))
 	loc, err := store.Get(ctx, "user-1", "t1")
 	require.NoError(t, err)
-	assert.Equal(t, absTestPath("/repo/pkg"), loc.GetWorkingDir())
+	assert.Equal(t, testutil.NativeAbsPath("/repo/pkg"), loc.GetWorkingDir())
 }
 
 // A relative working dir is refused for the same reason a relative file_path
@@ -150,7 +114,7 @@ func TestTabPayload_RegisterRefusesRelativeWorkingDir(t *testing.T) {
 	ctx := context.Background()
 	for _, dir := range []string{".", "..", "../peer-repo", "src", "./x"} {
 		err := store.Register(ctx, service.RegisterTabPayloadParams{
-			UserID: "user-1", TabID: "t1", Payload: filePayloadIn(absTestPath("/repo/pkg/README.md"), dir),
+			UserID: "user-1", TabID: "t1", Payload: filePayloadIn(testutil.NativeAbsPath("/repo/pkg/README.md"), dir),
 		})
 		require.Error(t, err, "working_dir %q must be refused", dir)
 		// The WORKING_DIR guard, named: file_path's guard rejects with the same
@@ -174,15 +138,15 @@ func TestTabPayload_RegisterOverwritesWorkingDir(t *testing.T) {
 	store, _, _ := newTabPayloadTestStore(t)
 	ctx := context.Background()
 	require.NoError(t, store.Register(ctx, service.RegisterTabPayloadParams{
-		UserID: "user-1", TabID: "t1", Payload: filePayloadIn(absTestPath("/repo/a.go"), absTestPath("/repo")),
+		UserID: "user-1", TabID: "t1", Payload: filePayloadIn(testutil.NativeAbsPath("/repo/a.go"), testutil.NativeAbsPath("/repo")),
 	}))
 	require.NoError(t, store.Register(ctx, service.RegisterTabPayloadParams{
-		UserID: "user-1", TabID: "t1", Payload: filePayloadIn(absTestPath("/wt/a.go"), absTestPath("/wt")),
+		UserID: "user-1", TabID: "t1", Payload: filePayloadIn(testutil.NativeAbsPath("/wt/a.go"), testutil.NativeAbsPath("/wt")),
 	}))
 	loc, err := store.Get(ctx, "user-1", "t1")
 	require.NoError(t, err)
-	assert.Equal(t, absTestPath("/wt/a.go"), loc.GetFile().GetFilePath())
-	assert.Equal(t, absTestPath("/wt"), loc.GetWorkingDir())
+	assert.Equal(t, testutil.NativeAbsPath("/wt/a.go"), loc.GetFile().GetFilePath())
+	assert.Equal(t, testutil.NativeAbsPath("/wt"), loc.GetWorkingDir())
 }
 
 func TestTabPayload_GetMissingReturnsNotFound(t *testing.T) {
@@ -199,7 +163,7 @@ func TestTabPayload_RevokeRemovesAndEmits(t *testing.T) {
 	store, bus, _ := newTabPayloadTestStore(t)
 	ctx := context.Background()
 	require.NoError(t, store.Register(ctx, service.RegisterTabPayloadParams{
-		UserID: "user-1", TabID: "t1", Payload: filePayload(absTestPath("/repo/a.go")),
+		UserID: "user-1", TabID: "t1", Payload: filePayload(testutil.NativeAbsPath("/repo/a.go")),
 	}))
 
 	// Subscribe as the owner; expect a Revoked event after revoke.
@@ -243,11 +207,11 @@ func TestTabPayload_SnapshotForOwnerBindsTheOwner(t *testing.T) {
 	store, _, _ := newTabPayloadTestStore(t)
 	ctx := context.Background()
 	require.NoError(t, store.Register(ctx, service.RegisterTabPayloadParams{
-		UserID: "user-1", TabID: "t1", Payload: filePayload(absTestPath("/mine-a"))}))
+		UserID: "user-1", TabID: "t1", Payload: filePayload(testutil.NativeAbsPath("/mine-a"))}))
 	require.NoError(t, store.Register(ctx, service.RegisterTabPayloadParams{
-		UserID: "user-1", TabID: "t2", Payload: filePayload(absTestPath("/mine-b"))}))
+		UserID: "user-1", TabID: "t2", Payload: filePayload(testutil.NativeAbsPath("/mine-b"))}))
 	require.NoError(t, store.Register(ctx, service.RegisterTabPayloadParams{
-		UserID: "user-2", TabID: "t3", Payload: filePayload(absTestPath("/theirs"))}))
+		UserID: "user-2", TabID: "t3", Payload: filePayload(testutil.NativeAbsPath("/theirs"))}))
 
 	mine, err := store.SnapshotForOwner(ctx, userid.MustNew("user-1"))
 	require.NoError(t, err)
@@ -256,12 +220,12 @@ func TestTabPayload_SnapshotForOwnerBindsTheOwner(t *testing.T) {
 		mine[0].GetTabPayloadRegistered().GetPayload().GetFile().GetFilePath(),
 		mine[1].GetTabPayloadRegistered().GetPayload().GetFile().GetFilePath(),
 	}
-	assert.ElementsMatch(t, []string{absTestPath("/mine-a"), absTestPath("/mine-b")}, paths)
+	assert.ElementsMatch(t, []string{testutil.NativeAbsPath("/mine-a"), testutil.NativeAbsPath("/mine-b")}, paths)
 
 	theirs, err := store.SnapshotForOwner(ctx, userid.MustNew("user-2"))
 	require.NoError(t, err)
 	require.Len(t, theirs, 1)
-	assert.Equal(t, absTestPath("/theirs"), theirs[0].GetTabPayloadRegistered().GetPayload().GetFile().GetFilePath())
+	assert.Equal(t, testutil.NativeAbsPath("/theirs"), theirs[0].GetTabPayloadRegistered().GetPayload().GetFile().GetFilePath())
 
 	// An unminted owner reaches no row, rather than falling back to every row.
 	none, err := store.SnapshotForOwner(ctx, userid.UserID{})
@@ -275,7 +239,7 @@ func TestTabPayload_SnapshotAndSubscribe_RaceFreeBootstrap(t *testing.T) {
 	store, bus, _ := newTabPayloadTestStore(t)
 	ctx := context.Background()
 	require.NoError(t, store.Register(ctx, service.RegisterTabPayloadParams{
-		UserID: "user-1", TabID: "tBootstrap", Payload: filePayload(absTestPath("/repo/seed")),
+		UserID: "user-1", TabID: "tBootstrap", Payload: filePayload(testutil.NativeAbsPath("/repo/seed")),
 	}))
 
 	// SnapshotAndSubscribe must replay the existing row before any
@@ -304,7 +268,7 @@ func TestTabPayload_SnapshotAndSubscribe_RaceFreeBootstrap(t *testing.T) {
 	// A live Register after subscribe should arrive after the bootstrap
 	// snapshot.
 	require.NoError(t, store.Register(ctx, service.RegisterTabPayloadParams{
-		UserID: "user-1", TabID: "tLive", Payload: filePayload(absTestPath("/repo/live")),
+		UserID: "user-1", TabID: "tLive", Payload: filePayload(testutil.NativeAbsPath("/repo/live")),
 	}))
 
 	collected := []*leapmuxv1.WorkerPrivateEvent{}
@@ -327,8 +291,8 @@ func TestTabPayload_RegisterRequiresAllFields(t *testing.T) {
 
 	store, _, _ := newTabPayloadTestStore(t)
 	cases := []service.RegisterTabPayloadParams{
-		{UserID: "", TabID: "t1", Payload: filePayload(absTestPath("/p"))},
-		{UserID: "user-1", TabID: "", Payload: filePayload(absTestPath("/p"))},
+		{UserID: "", TabID: "t1", Payload: filePayload(testutil.NativeAbsPath("/p"))},
+		{UserID: "user-1", TabID: "", Payload: filePayload(testutil.NativeAbsPath("/p"))},
 		{UserID: "user-1", TabID: "t1", Payload: filePayload("")},
 	}
 	for _, c := range cases {
@@ -365,13 +329,13 @@ func TestTabPayloadStore_RefusesBlankOwner(t *testing.T) {
 		UserID:     "",
 		TabID:      "shared-tab",
 		TabType:    int64(leapmuxv1.TabType_TAB_TYPE_FILE),
-		Payload:    mustMarshalFilePayload(absTestPath("/blank/a.go"), ""),
+		Payload:    mustMarshalFilePayload(testutil.NativeAbsPath("/blank/a.go"), ""),
 		WorkingDir: "",
 	}), "the schema must refuse a blank owner even when sqlc is driven directly")
 
 	// A real owner's row, which every control below resolves against.
 	require.NoError(t, store.Register(ctx, service.RegisterTabPayloadParams{
-		UserID: "user-1", TabID: "shared-tab", Payload: filePayload(absTestPath("/real/a.go")),
+		UserID: "user-1", TabID: "shared-tab", Payload: filePayload(testutil.NativeAbsPath("/real/a.go")),
 	}))
 
 	// The Go guards. Each pairs a blank-owner refusal with a real-owner
@@ -385,7 +349,7 @@ func TestTabPayloadStore_RefusesBlankOwner(t *testing.T) {
 
 		loc, err := store.Get(ctx, "user-1", "shared-tab")
 		require.NoError(t, err, "control: a real owner still resolves")
-		assert.Equal(t, absTestPath("/real/a.go"), loc.GetFile().GetFilePath())
+		assert.Equal(t, testutil.NativeAbsPath("/real/a.go"), loc.GetFile().GetFilePath())
 	})
 
 	t.Run("revoke", func(t *testing.T) {
@@ -416,7 +380,7 @@ func TestTabPayload_ImageArm(t *testing.T) {
 	ctx := context.Background()
 
 	require.NoError(t, store.Register(ctx, service.RegisterTabPayloadParams{
-		UserID: "user-1", TabID: "img-1", Payload: imagePayload("agent-1", 42, 1, absTestPath("/repo")),
+		UserID: "user-1", TabID: "img-1", Payload: imagePayload("agent-1", 42, 1, testutil.NativeAbsPath("/repo")),
 	}))
 
 	got, err := store.Get(ctx, "user-1", "img-1")
@@ -424,7 +388,7 @@ func TestTabPayload_ImageArm(t *testing.T) {
 	assert.Equal(t, "agent-1", got.GetImage().GetAgentId())
 	assert.Equal(t, int64(42), got.GetImage().GetSeq())
 	assert.Equal(t, int32(1), got.GetImage().GetImageIndex())
-	assert.Equal(t, absTestPath("/repo"), got.GetWorkingDir())
+	assert.Equal(t, testutil.NativeAbsPath("/repo"), got.GetWorkingDir())
 	// The pixels are the one thing that must never be here.
 	assert.Nil(t, got.GetFile())
 
@@ -460,7 +424,7 @@ func TestTabPayload_RefusesAPayloadWithNoKind(t *testing.T) {
 
 	store, _, _ := newTabPayloadTestStore(t)
 	err := store.Register(context.Background(), service.RegisterTabPayloadParams{
-		UserID: "user-1", TabID: "t1", Payload: &leapmuxv1.TabPayload{WorkingDir: absTestPath("/repo")},
+		UserID: "user-1", TabID: "t1", Payload: &leapmuxv1.TabPayload{WorkingDir: testutil.NativeAbsPath("/repo")},
 	})
 	require.Error(t, err)
 }
@@ -522,7 +486,7 @@ func TestTabPayload_CallerFaultsCarryTheInvalidSentinel(t *testing.T) {
 	}{
 		{
 			name:   "a missing required field",
-			params: service.RegisterTabPayloadParams{UserID: "user-1", TabID: "", Payload: filePayload(absTestPath("/repo/a.txt"))},
+			params: service.RegisterTabPayloadParams{UserID: "user-1", TabID: "", Payload: filePayload(testutil.NativeAbsPath("/repo/a.txt"))},
 		},
 		{
 			name:   "a payload that specifies no kind",
@@ -558,7 +522,7 @@ func TestTabPayload_TabTypeOfReportsNotFoundDistinctly(t *testing.T) {
 	assert.ErrorIs(t, err, service.ErrTabPayloadNotFound)
 
 	require.NoError(t, store.Register(ctx, service.RegisterTabPayloadParams{
-		UserID: "user-1", TabID: "img-1", Payload: imagePayload("agent-1", 7, 0, absTestPath("/repo")),
+		UserID: "user-1", TabID: "img-1", Payload: imagePayload("agent-1", 7, 0, testutil.NativeAbsPath("/repo")),
 	}))
 	got, err := store.TabTypeOf(ctx, "user-1", "img-1")
 	require.NoError(t, err)

--- a/frontend/src/components/chat/composer/ComposerPlusMenu.tsx
+++ b/frontend/src/components/chat/composer/ComposerPlusMenu.tsx
@@ -70,7 +70,7 @@ export interface ComposerPlusMenuProps {
   /** Toggle Enter-key mode. */
   onToggleEnterMode: () => void
   /**
-   * The checkout the branch submenu names, resolved from {@link repoGitView}.
+   * The checkout the branch submenu identifies, resolved from {@link repoGitView}.
    * The submenu renders only when its `name` is set, matching the status-bar
    * chip.
    *
@@ -125,7 +125,7 @@ interface MenuStructure {
   permissionActions: PermissionAction[]
   branchName?: string
   /**
-   * Frozen WITH the branch name, because it names the destructive item rather
+   * Frozen WITH the branch name, because it identifies the destructive item rather
    * than merely labelling it. A live kind under a held name lets "Delete
    * branch..." become "Delete worktree..." beneath a pointer already aimed at
    * it, which is the same hazard as a row sliding into that place — the user

--- a/frontend/src/components/chat/composer/ComposerPlusMenu.tsx
+++ b/frontend/src/components/chat/composer/ComposerPlusMenu.tsx
@@ -19,6 +19,7 @@ import { WorkingTreeIcon, WorkingTreeTooltip } from '~/components/common/Working
 import { BranchContextMenu } from '~/components/workspace/BranchContextMenu'
 import { shallowEqualArrays } from '~/lib/shallowEqual'
 import { formatShortcut } from '~/lib/shortcuts/display'
+import { menuSubTrigger, menuSubTriggerLabel } from '~/styles/shared.css'
 import * as styles from './composer.css'
 import { OptionGroupPopover } from './OptionGroupPopover'
 
@@ -379,11 +380,11 @@ export function ComposerPlusMenu(props: ComposerPlusMenuProps): JSX.Element {
               >
                 <button
                   role="menuitem"
-                  class={styles.subTrigger}
+                  class={menuSubTrigger}
                   data-testid="composer-plus-branch"
                   {...triggerProps}
                 >
-                  <span class={styles.subTriggerLabel}>
+                  <span class={menuSubTriggerLabel}>
                     <WorkingTreeIcon isWorktree={branch().isWorktree} size="xs" />
                     {branch().name}
                   </span>
@@ -401,7 +402,7 @@ export function ComposerPlusMenu(props: ComposerPlusMenuProps): JSX.Element {
             trigger={triggerProps => (
               <button
                 role="menuitem"
-                class={styles.subTrigger}
+                class={menuSubTrigger}
                 data-testid="composer-agent-info"
                 {...triggerProps}
               >
@@ -486,7 +487,7 @@ function PlusGroupSubmenu(props: {
       trigger={(triggerProps, view) => (
         <button
           role="menuitem"
-          class={styles.subTrigger}
+          class={menuSubTrigger}
           data-testid={`composer-group-${props.groupId}`}
           {...triggerProps}
         >

--- a/frontend/src/components/chat/composer/OptionGroupPopover.test.tsx
+++ b/frontend/src/components/chat/composer/OptionGroupPopover.test.tsx
@@ -39,11 +39,18 @@ function renderPopover(opts: {
       )}
     />
   ))
-  return { onChange, trigger: screen.getByTestId('trigger') }
+  const trigger = screen.getByTestId('trigger')
+  // OPENED, because the items mount only while the popover is open: the
+  // enclosing menu's roving focus queries `[role=menuitem]` over its whole
+  // subtree, so a closed submenu's items would be phantom ArrowDown stops.
+  // `vitest.setup.ts` stubs `showPopover` and dispatches `toggle`, which is
+  // what drives that gate.
+  fireEvent.click(trigger)
+  return { onChange, trigger }
 }
 
-// The options live inside a `popover` <menu>, which is inaccessible until the
-// popover opens — and jsdom stubs the Popover API, so it never does. Role
+// The options live inside a `popover` <menu>, which stays inaccessible to a
+// plain role query even while open, because jsdom stubs the Popover API. Role
 // queries therefore pass `hidden: true`; the roles themselves are the point of
 // the assertions.
 /**
@@ -164,6 +171,7 @@ describe('optionGroupPopover', () => {
       />
     ))
 
+    fireEvent.click(screen.getByTestId('trigger'))
     const before = screen.getByTestId('model-sonnet')
     // Fresh objects, identical values -- exactly what a status push delivers.
     setGroups([group({ options: options.map(o => ({ ...o })), currentValue: 'opus' })])
@@ -256,6 +264,10 @@ describe('optionGroupPopover', () => {
     await fireEvent.click(screen.getByTestId('model-legacy'))
     expect(onChange, 'a withdrawn option relaunches nothing').not.toHaveBeenCalled()
 
+    // Picking dismisses the popover, and the rows mount only while it is open,
+    // so the second pick reopens first -- which is the sequence the user
+    // performs too.
+    await fireEvent.click(screen.getByTestId('trigger'))
     // ...while a row the catalog still offers applies as usual.
     await fireEvent.click(screen.getByTestId('model-sonnet'))
     expect(onChange).toHaveBeenCalledWith({ sets: { model: 'sonnet' } })

--- a/frontend/src/components/chat/composer/composer.css.ts
+++ b/frontend/src/components/chat/composer/composer.css.ts
@@ -145,24 +145,12 @@ export const plusPopover = style([composerMenuPopover, {
 }])
 
 // --- Submenu (nested DropdownMenu for each option group under `[+]` ▸ settings) ---
-
-export const subTrigger = style({
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'space-between',
-  width: '100%',
-})
-
-/**
- * The leading half of a submenu trigger, for an item whose label carries an icon
- * (the branch item). `subTrigger` pushes its two children apart, so the icon and
- * the text need one box between them or the chevron separates them instead.
- */
-export const subTriggerLabel = style([clippedText, {
-  display: 'inline-flex',
-  alignItems: 'center',
-  gap: 'var(--space-2)',
-}])
+//
+// The trigger row and its label live in `~/styles/shared.css.ts` as
+// `menuSubTrigger` / `menuSubTriggerLabel`: every submenu trigger in the app is
+// that shape, and this is not the composer's own vocabulary. Only the popover
+// below is composer-specific, because it stacks against the composer's own
+// z-index band.
 
 export const subPopover = style([composerMenuPopover, {
   padding: 'var(--space-1)',

--- a/frontend/src/components/common/DropdownMenu.test.tsx
+++ b/frontend/src/components/common/DropdownMenu.test.tsx
@@ -944,3 +944,62 @@ describe('dropdownMenu size caps', () => {
     expect(screen.getByTestId(MENU).style.getPropertyValue(DIALOG_HEIGHT_VAR)).toBe('')
   })
 })
+
+// A nested menu renders INLINE, so its items are descendants of the enclosing
+// popover whether or not that nested menu is open -- and a popover that is not
+// showing is `display: none`. Arrowing onto such an item calls `.focus()` on a
+// hidden element, which is a silent no-op: the roving focus stalls at that
+// index and type-ahead matches text nobody can see.
+describe('dropdownMenu roving focus across a nested submenu', () => {
+  function renderNested() {
+    render(() => (
+      <DropdownMenu
+        id="outer"
+        data-testid="outer-popover"
+        trigger={triggerProps => <button data-testid="outer-trigger" {...triggerProps}>Open</button>}
+      >
+        <button role="menuitem" data-testid="first">Alpha</button>
+        <DropdownMenu
+          id="inner"
+          data-testid="inner-popover"
+          trigger={triggerProps => <button role="menuitem" data-testid="sub-trigger" {...triggerProps}>More</button>}
+        >
+          <button role="menuitem" data-testid="hidden-item">Zulu hidden</button>
+        </DropdownMenu>
+        <button role="menuitem" data-testid="last">Omega</button>
+      </DropdownMenu>
+    ))
+    fireEvent.click(screen.getByTestId('outer-trigger'))
+    return screen.getByTestId('outer-popover')
+  }
+
+  it('skips a closed submenu item, so ArrowDown reaches the item after it', () => {
+    const popover = renderNested()
+
+    // Alpha, the submenu TRIGGER (its own item), then Omega. The submenu's
+    // own item is not among them while it is closed.
+    fireEvent.keyDown(popover, { key: 'ArrowDown' })
+    expect(document.activeElement).toBe(screen.getByTestId('first'))
+    fireEvent.keyDown(popover, { key: 'ArrowDown' })
+    expect(document.activeElement).toBe(screen.getByTestId('sub-trigger'))
+    fireEvent.keyDown(popover, { key: 'ArrowDown' })
+    expect(document.activeElement).toBe(screen.getByTestId('last'))
+  })
+
+  it('does not type-ahead onto a closed submenu item', () => {
+    const popover = renderNested()
+
+    // `Zulu` is the only text starting with Z, and it is inside the closed
+    // submenu. Focus must not move to it.
+    fireEvent.keyDown(popover, { key: 'z' })
+    expect(document.activeElement).not.toBe(screen.getByTestId('hidden-item'))
+  })
+
+  it('reaches the submenu item once the submenu is open', () => {
+    const popover = renderNested()
+    fireEvent.click(screen.getByTestId('sub-trigger'))
+
+    fireEvent.keyDown(popover, { key: 'z' })
+    expect(document.activeElement).toBe(screen.getByTestId('hidden-item'))
+  })
+})

--- a/frontend/src/components/common/DropdownMenu.test.tsx
+++ b/frontend/src/components/common/DropdownMenu.test.tsx
@@ -18,7 +18,7 @@ describe('dropdownMenu', () => {
   it('renders trailing shortcut text in menu item content', () => {
     render(() => (
       <button role="menuitem">
-        <DropdownMenuItemContent label="New agent..." shortcut="Ctrl+Shift+N" />
+        <DropdownMenuItemContent label="New agent..." detail="Ctrl+Shift+N" />
       </button>
     ))
 

--- a/frontend/src/components/common/DropdownMenu.tsx
+++ b/frontend/src/components/common/DropdownMenu.tsx
@@ -559,8 +559,31 @@ export function DropdownMenu(props: DropdownMenuProps) {
   // is no `[popovertarget]` (this component deliberately renders none), and it
   // queries `[role="menuitem"]` while these items carry `menuitemradio`.
 
+  /**
+   * Whether `el` sits inside a nested popover that is CLOSED.
+   *
+   * A nested menu renders inline, so its items are descendants of this popover
+   * whether or not it is open -- and a `popover` that is not showing is
+   * `display: none`. Arrowing onto such an item calls `.focus()` on a hidden
+   * element, which is a silent no-op: the roving focus stalls at that index,
+   * and type-ahead matches text nobody can see.
+   *
+   * The walk stops at THIS popover, so an item of this menu is never excluded
+   * by this menu's own open state.
+   */
+  const insideClosedSubPopover = (el: HTMLElement): boolean => {
+    for (let node = el.parentElement; node && node !== popoverEl; node = node.parentElement) {
+      if (node.hasAttribute('popover') && !node.matches(':popover-open'))
+        return true
+    }
+    return false
+  }
+
   const menuItems = (): HTMLElement[] =>
-    popoverEl ? [...popoverEl.querySelectorAll<HTMLElement>(MENU_ITEM_SELECTOR)] : []
+    popoverEl
+      ? [...popoverEl.querySelectorAll<HTMLElement>(MENU_ITEM_SELECTOR)]
+          .filter(el => !insideClosedSubPopover(el))
+      : []
 
   /**
    * Move focus to `index`, wrapping at both ends.

--- a/frontend/src/components/common/DropdownMenu.tsx
+++ b/frontend/src/components/common/DropdownMenu.tsx
@@ -245,7 +245,21 @@ export interface DropdownMenuProps {
 
 export interface DropdownMenuItemContentProps {
   label: JSX.Element
-  shortcut?: string
+  /**
+   * A short note at the RIGHT end of the row, which the row keeps whole while
+   * the label beside it clips.
+   *
+   * Named for the SLOT, not for one of its contents -- the same reason the
+   * `menuItemDetail` class it renders into carries that name. It holds a
+   * keyboard shortcut on the titlebar items and the remembered git mode on the
+   * section menu's repository rows, and a prop called `shortcut` on the second
+   * of those would be a lie.
+   *
+   * A plain string, unlike `DropdownMenuCheckableItem.detail`, which is an
+   * accessor because its callers build a LIVE element (a ticking clock) and a
+   * presence test plus a draw would build two. Nothing here needs that.
+   */
+  detail?: string
 }
 
 export function DropdownMenuItemContent(props: DropdownMenuItemContentProps) {
@@ -257,8 +271,8 @@ export function DropdownMenuItemContent(props: DropdownMenuItemContentProps) {
           component -- that changes a shared prop contract, so it is the
           author's decision, not a mechanical swap. */}
       <span class={clippedText}>{props.label}</span>
-      <Show when={props.shortcut}>
-        {shortcut => <span class={menuItemDetail}>{shortcut()}</span>}
+      <Show when={props.detail}>
+        {detail => <span class={menuItemDetail}>{detail()}</span>}
       </Show>
     </span>
   )

--- a/frontend/src/components/common/NewTabMenuItems.tsx
+++ b/frontend/src/components/common/NewTabMenuItems.tsx
@@ -102,7 +102,7 @@ export const NewTabMenuItems: Component<NewTabMenuItemsProps> = (props) => {
         >
           <DropdownMenuItemContent
             label="New agent..."
-            shortcut={props.shortcuts ? getShortcutHintsText('app.newAgentDialog') : undefined}
+            detail={props.shortcuts ? getShortcutHintsText('app.newAgentDialog') : undefined}
           />
         </button>
       </Tooltip>
@@ -116,7 +116,7 @@ export const NewTabMenuItems: Component<NewTabMenuItemsProps> = (props) => {
         >
           <DropdownMenuItemContent
             label="New terminal..."
-            shortcut={props.shortcuts ? getShortcutHintsText('app.newTerminalDialog') : undefined}
+            detail={props.shortcuts ? getShortcutHintsText('app.newTerminalDialog') : undefined}
           />
         </button>
       </Tooltip>

--- a/frontend/src/components/common/SubMenu.tsx
+++ b/frontend/src/components/common/SubMenu.tsx
@@ -1,0 +1,64 @@
+import type { Component, JSX } from 'solid-js'
+import ChevronRight from 'lucide-solid/icons/chevron-right'
+import { createSignal, Show } from 'solid-js'
+import { menuSubTrigger, menuSubTriggerLabel } from '~/styles/shared.css'
+import { DropdownMenu } from './DropdownMenu'
+import { Icon } from './Icon'
+
+export interface SubMenuProps {
+  /** The trigger row's label. */
+  'label': JSX.Element
+  /** What the popover IS. `div` for a panel that must survive a click inside it. */
+  'as'?: 'menu' | 'div'
+  /** data-testid on the trigger row. */
+  'data-testid'?: string
+  /** data-testid on the popover. */
+  'popoverTestId'?: string
+  /** Accessible name for the popover. */
+  'aria-label'?: string
+  'children': JSX.Element
+}
+
+/**
+ * A menu item that opens a nested menu.
+ *
+ * It exists for the `<Show>`, which is not cosmetic. `DropdownMenu` renders its
+ * children eagerly, and the parent's keyboard navigation queries
+ * `[role=menuitem]` over the WHOLE popover subtree -- so a closed submenu's
+ * items are still matched. ArrowDown then calls `.focus()` on a `display:none`
+ * element, which is a silent no-op: the focus stalls, and type-ahead matches
+ * text nobody can see. Mounting the children only while the submenu is open
+ * removes the phantom items and the eager render cost together.
+ *
+ * Every nested menu in the app goes through this, so no call site can forget
+ * the gate. The trigger's chevron and its layout come with it.
+ *
+ * Known gap: `ArrowRight` does not open a submenu. `DropdownMenu` handles
+ * Escape, Up, Down, Home, End and type-ahead only, and the roving focus lands
+ * on the trigger, from which Enter opens the popover.
+ */
+export const SubMenu: Component<SubMenuProps> = (props) => {
+  const [open, setOpen] = createSignal(false)
+  return (
+    <DropdownMenu
+      as={props.as}
+      onToggle={setOpen}
+      data-testid={props.popoverTestId}
+      aria-label={props['aria-label']}
+      trigger={triggerProps => (
+        <button
+          type="button"
+          role="menuitem"
+          class={menuSubTrigger}
+          data-testid={props['data-testid']}
+          {...triggerProps}
+        >
+          <span class={menuSubTriggerLabel}>{props.label}</span>
+          <Icon icon={ChevronRight} size="xs" />
+        </button>
+      )}
+    >
+      <Show when={open()}>{props.children}</Show>
+    </DropdownMenu>
+  )
+}

--- a/frontend/src/components/common/SubMenu.tsx
+++ b/frontend/src/components/common/SubMenu.tsx
@@ -1,37 +1,60 @@
 import type { Component, JSX } from 'solid-js'
+import type { DropdownMenuProps } from './DropdownMenu'
 import ChevronRight from 'lucide-solid/icons/chevron-right'
 import { createSignal, Show } from 'solid-js'
 import { menuSubTrigger, menuSubTriggerLabel } from '~/styles/shared.css'
 import { DropdownMenu } from './DropdownMenu'
 import { Icon } from './Icon'
 
-export interface SubMenuProps {
+/**
+ * The `DropdownMenu` props a nested menu may set for itself.
+ *
+ * `as` carries all three variants, not just `menu` and `div`: the composer's
+ * "Agent info" panel is `card`, and a wrapper that cannot express it forces
+ * that call site back to a hand-rolled `DropdownMenu` -- which is the per-site
+ * drift this component exists to end.
+ *
+ * `open`, `popoverRef` and `contextMenuFor` are deliberately NOT here. This
+ * component owns the open state, because that is what the `<Show>` below reads.
+ */
+type ForwardedMenuProps = Pick<
+  DropdownMenuProps,
+  'as' | 'class' | 'placement' | 'matchTriggerWidth' | 'aria-label'
+>
+
+export interface SubMenuProps extends ForwardedMenuProps {
   /** The trigger row's label. */
   'label': JSX.Element
-  /** What the popover IS. `div` for a panel that must survive a click inside it. */
-  'as'?: 'menu' | 'div'
   /** data-testid on the trigger row. */
   'data-testid'?: string
   /** data-testid on the popover. */
   'popoverTestId'?: string
-  /** Accessible name for the popover. */
-  'aria-label'?: string
+  /**
+   * Told when this submenu opens or closes.
+   *
+   * Forwarded rather than consumed: the `<Show>` below is driven by this
+   * component's own signal, so a caller that needs to reset state or start a
+   * fetch scoped to THIS submenu can still hear about it. Without that, such a
+   * caller had to re-implement the whole open gate and lose the fix.
+   */
+  'onToggle'?: (open: boolean) => void
   'children': JSX.Element
 }
 
 /**
  * A menu item that opens a nested menu.
  *
- * It exists for the `<Show>`, which is not cosmetic. `DropdownMenu` renders its
- * children eagerly, and the parent's keyboard navigation queries
- * `[role=menuitem]` over the WHOLE popover subtree -- so a closed submenu's
- * items are still matched. ArrowDown then calls `.focus()` on a `display:none`
- * element, which is a silent no-op: the focus stalls, and type-ahead matches
- * text nobody can see. Mounting the children only while the submenu is open
- * removes the phantom items and the eager render cost together.
+ * It bundles the trigger row -- its chevron and its layout -- with a `<Show>`
+ * that mounts the children only while the submenu is open, so a nested menu
+ * costs nothing until someone opens it.
  *
- * Every nested menu in the app goes through this, so no call site can forget
- * the gate. The trigger's chevron and its layout come with it.
+ * The `<Show>` is an OPTIMIZATION, not the keyboard fix. `DropdownMenu` renders
+ * its children eagerly and its roving focus queries `[role=menuitem]` over the
+ * whole popover subtree, but it now skips an item inside a nested popover that
+ * is closed -- so a submenu built without this component is still correct for
+ * ArrowDown and type-ahead. That is why the composer's three nested menus,
+ * which cannot use this component (one needs `as="card"`, one supplies its own
+ * trigger, one is a whole component of its own), are safe as they are.
  *
  * Known gap: `ArrowRight` does not open a submenu. `DropdownMenu` handles
  * Escape, Up, Down, Home, End and type-ahead only, and the roving focus lands
@@ -42,7 +65,13 @@ export const SubMenu: Component<SubMenuProps> = (props) => {
   return (
     <DropdownMenu
       as={props.as}
-      onToggle={setOpen}
+      class={props.class}
+      placement={props.placement}
+      matchTriggerWidth={props.matchTriggerWidth}
+      onToggle={(open) => {
+        setOpen(open)
+        props.onToggle?.(open)
+      }}
       data-testid={props.popoverTestId}
       aria-label={props['aria-label']}
       trigger={triggerProps => (

--- a/frontend/src/components/common/moreHorizontalTrigger.tsx
+++ b/frontend/src/components/common/moreHorizontalTrigger.tsx
@@ -7,6 +7,16 @@ import { IconButton } from './IconButton'
 export interface MoreHorizontalTriggerOptions {
   'class'?: string
   'data-testid'?: string
+  /**
+   * Tooltip text, which `IconButton` renders as a `<Tooltip ariaLabel>` -- so
+   * it is also the button's ACCESSIBLE NAME.
+   *
+   * A row menu leaves it unset: the row beside it already says what the menu
+   * acts on, and every row would otherwise announce the same word. A trigger
+   * that stands alone (a section header, a titlebar) must set it, or it
+   * announces as an unnamed button.
+   */
+  'title'?: string
 }
 
 // Builds the DropdownMenu `trigger` render-prop for the standard
@@ -24,6 +34,7 @@ export function moreHorizontalTrigger(
       icon={MoreHorizontal}
       size="sm"
       class={opts.class}
+      title={opts.title}
       ref={triggerProps.ref}
       aria-expanded={triggerProps['aria-expanded']}
       data-testid={opts['data-testid']}

--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -328,7 +328,8 @@ export const AppShell: Component = () => {
   createEffect(() => {
     if (searchParams.newWorkspace === 'true') {
       newWorkspaceDialog.open({
-        preselectedWorkerId: searchParams.workerId as string | undefined,
+        // A worker and no directory: the URL names a machine, not a repository.
+        startPoint: { kind: 'directory', workerId: searchParams.workerId as string | undefined },
       })
       setSearchParams({ newWorkspace: undefined, workerId: undefined }, { replace: true })
     }

--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -1,16 +1,20 @@
 import type { Component } from 'solid-js'
-import type { AppShellDialogStates, ChangeBranchState, DeleteBranchState, KeyPinConfirmState, NewTabTarget, NewWorkspacePayload, WorkspaceConfirmPayload } from './AppShellDialogs'
+import type { AppShellDialogStates, ChangeBranchState, DeleteBranchState, EmptyArchiveConfirmPayload, KeyPinConfirmState, NewTabTarget, NewWorkspacePayload, SectionConfirmPayload, WorkspaceConfirmPayload } from './AppShellDialogs'
+import type { SectionNamePayload } from './SectionNameDialog'
 import type { SidebarElementsOpts } from './SidebarElements'
 import type { TabContext } from './tabContext'
 import type { CliPathStatus } from '~/api/platformBridge'
 import type { BranchRefActions } from '~/components/workspace/branchActions'
+import type { WorkspaceStartActions, WorkspaceStartAt } from '~/components/workspace/workspaceStartActions'
+import type { WorkspaceStartPoint } from '~/components/workspace/workspaceStartPoint'
 import type { BranchRef } from '~/components/workspace/WorkspaceTabTree'
 import type { AgentProvider } from '~/generated/proto/leapmux/v1/agent_pb'
+import type { Section, Sidebar } from '~/generated/proto/leapmux/v1/section_pb'
 import type { ChangeBranchMode } from '~/hooks/useGitModeState'
 import type { SavedViewportScroll } from '~/stores/chatTypes'
 import { useLocation, useSearchParams } from '@solidjs/router'
-import { createEffect, createMemo, createSignal, on, onCleanup, Show } from 'solid-js'
-import { isTauriApp, platformBridge } from '~/api/platformBridge'
+import { createEffect, createMemo, createResource, createSignal, on, onCleanup, Show } from 'solid-js'
+import { getRuntimeState, isTauriApp, platformBridge } from '~/api/platformBridge'
 import { apiLoadingTimeoutMs, workspaceBootstrapTimeoutMs } from '~/api/transport'
 import { setExpectedUserId } from '~/api/workerRpc'
 import { CliPathDialog } from '~/components/desktop/CliPathDialog'
@@ -170,6 +174,9 @@ export const AppShell: Component = () => {
   const newWorkspaceDialog = createDialogState<NewWorkspacePayload>()
   const confirmDeleteWsDialog = createDialogState<WorkspaceConfirmPayload>()
   const confirmArchiveWsDialog = createDialogState<WorkspaceConfirmPayload>()
+  const confirmEmptyArchiveDialog = createDialogState<EmptyArchiveConfirmPayload>()
+  const sectionNameDialog = createDialogState<SectionNamePayload>()
+  const confirmDeleteSectionDialog = createDialogState<SectionConfirmPayload>()
   const keyPinConfirmDialog = createDialogState<KeyPinConfirmState>()
   const changeBranchDialog = createDialogState<ChangeBranchState>()
   const deleteBranchDialog = createDialogState<DeleteBranchState>()
@@ -497,21 +504,46 @@ export const AppShell: Component = () => {
     return section?.sectionType === SectionType.WORKSPACES_ARCHIVED
   })
 
-  // Whether ONE NAMED workspace can be mutated. Per id, because a dialog can act
-  // on a workspace the user is not looking at. Answers false for an absent one
-  // -- deleted remotely while a dialog holds its id -- which is the same
-  // refusal archival earns and the same one the caller needs.
+  // Whether ONE NAMED workspace can be mutated. Per id, because a dialog can
+  // act on a workspace that the user does not look at.
   const isWorkspaceMutatableById = (workspaceId: string): boolean => {
+    // An ABSENT workspace -- deleted remotely while a dialog holds its id --
+    // is not mutatable. That is the same refusal archival earns, and the same
+    // one the caller needs.
+    //
+    // The presence test lives here, not in `isWorkspaceMutatable`, which takes
+    // an archived flag and answers about archival alone. This function holds
+    // the id, so only it can test for presence.
+    if (!workspaceStore.state.workspaces.some(w => w.id === workspaceId))
+      return false
     const sectionId = sectionStore.getSectionForWorkspace(workspaceId)
     const archived = sectionId
       ? sectionStore.state.sections.find(s => s.id === sectionId)?.sectionType === SectionType.WORKSPACES_ARCHIVED
       : false
-    return isWorkspaceMutatable(workspaceStore.state.workspaces.find(w => w.id === workspaceId), archived)
+    return isWorkspaceMutatable(archived)
   }
+
+  /**
+   * Whether the desktop shell runs its own bundled sidecar.
+   *
+   * One resource for the whole SIDEBAR, which mounts a workspace row menu per
+   * row and would otherwise ask per menu. Each menu pairs it with the worker's
+   * own `autoRegistered` flag through `isLocalWorker`.
+   *
+   * `OpenInEditorButton` keeps its own resource: it sits outside this tree, it
+   * holds no worker, and `localSolo` alone is the whole gate it needs -- see
+   * the note there.
+   *
+   * Asked of the Rust shell rather than derived from the URL: under
+   * `task dev-desktop` the webview points at http://localhost:4328, so a URL
+   * check misclassifies a solo run as non-solo.
+   */
+  const [runtimeState] = createResource(() => getRuntimeState())
+  const localSolo = () => runtimeState()?.capabilities.localSolo ?? false
 
   // Whether the active workspace can be mutated
   const isActiveWorkspaceMutatable = createMemo(() =>
-    isWorkspaceMutatable(activeWorkspace() ?? undefined, isActiveWorkspaceArchived()),
+    isWorkspaceMutatable(isActiveWorkspaceArchived()),
   )
 
   // Active tab derived state
@@ -678,6 +710,9 @@ export const AppShell: Component = () => {
     newWorkspace: newWorkspaceDialog,
     confirmDeleteWs: confirmDeleteWsDialog,
     confirmArchiveWs: confirmArchiveWsDialog,
+    confirmEmptyArchive: confirmEmptyArchiveDialog,
+    sectionName: sectionNameDialog,
+    confirmDeleteSection: confirmDeleteSectionDialog,
     lastTabConfirm: tabOps.lastTabConfirmDialog,
     keyPinConfirm: keyPinConfirmDialog,
     changeBranch: changeBranchDialog,
@@ -921,10 +956,27 @@ export const AppShell: Component = () => {
    * derives from it, so the placement inside `run` already resolves against the
    * new workspace -- there is nothing to await.
    */
-  const atBranch = (ref: BranchRef, run: (target: NewTabTarget) => void) => {
-    if (ref.workspaceId && ref.workspaceId !== workspace.activeWorkspaceId())
-      handleSelectWorkspace(ref.workspaceId)
-    run({ workerId: ref.workerId, workingDir: ref.gitToplevel })
+  const atStartPoint = (at: WorkspaceStartAt, run: (target: NewTabTarget) => void) => {
+    if (at.workspaceId && at.workspaceId !== workspace.activeWorkspaceId())
+      handleSelectWorkspace(at.workspaceId)
+    run({ workerId: at.workerId, workingDir: at.workingDir })
+  }
+
+  /** The branch flavour: a `BranchRef` is one checkout of one workspace. */
+  const atBranch = (ref: BranchRef, run: (target: NewTabTarget) => void) =>
+    atStartPoint({ workspaceId: ref.workspaceId, workerId: ref.workerId, workingDir: ref.gitToplevel }, run)
+
+  /**
+   * The two tab-creation actions a workspace ROW offers, over the same seam as
+   * the branch ones above.
+   *
+   * Both open the DIALOG rather than starting a tab outright: a workspace spans
+   * N repositories on up to N workers, so an inline provider or shell list
+   * would have to fan out per repository on every menu open.
+   */
+  const workspaceStartActions: WorkspaceStartActions = {
+    onNewAgentAt: at => atStartPoint(at, target => newAgentDialog.open(target)),
+    onNewTerminalAt: at => atStartPoint(at, target => newTerminalDialog.open(target)),
   }
 
   /**
@@ -969,6 +1021,11 @@ export const AppShell: Component = () => {
   const handleConfirmArchiveWorkspace = (workspaceId: string): Promise<boolean> =>
     new Promise((resolve) => {
       confirmArchiveWsDialog.open({ workspaceId, resolve })
+    })
+
+  const handleConfirmEmptyArchive = (count: number): Promise<boolean> =>
+    new Promise((resolve) => {
+      confirmEmptyArchiveDialog.open({ count, resolve })
     })
 
   // Post-archive cleanup
@@ -1092,14 +1149,27 @@ export const AppShell: Component = () => {
     selection,
     loadSections,
     onSelectWorkspace: handleSelectWorkspace,
-    onNewWorkspace: (sectionId: string | null) => {
-      newWorkspaceDialog.open({ targetSectionId: sectionId })
+    onNewWorkspace: (sectionId: string | null, startPoint: WorkspaceStartPoint) => {
+      newWorkspaceDialog.open({ targetSectionId: sectionId, startPoint })
     },
     onRefreshWorkspaces: () => loadWorkspaces(),
     onDeleteWorkspace: handleDeleteWorkspace,
     onConfirmDelete: handleConfirmDeleteWorkspace,
     onConfirmArchive: handleConfirmArchiveWorkspace,
+    onConfirmEmptyArchive: handleConfirmEmptyArchive,
     onPostArchiveWorkspace: handlePostArchiveWorkspace,
+    onNewSection: (sidebar: Sidebar) => sectionNameDialog.open({ mode: 'create', sidebar }),
+    onRenameSection: (section: Section) => sectionNameDialog.open({
+      mode: 'rename',
+      sidebar: section.sidebar,
+      sectionId: section.id,
+      initialName: section.name,
+    }),
+    onDeleteSection: (section: Section) => confirmDeleteSectionDialog.open({
+      sectionId: section.id,
+      sectionName: section.name,
+    }),
+    workspaceStartActions,
     getCurrentTabContext,
     getMruAgentContext,
     get fileTreePath() { return fileTreePath() },
@@ -1125,6 +1195,7 @@ export const AppShell: Component = () => {
       return active?.type === TabType.FILE
     },
     get workers() { return workerSection.workers() },
+    get localSolo() { return localSolo() },
     workerInfoFn: workerSection.workerInfoFn,
     channelStatusFn: workerSection.channelStatusFn,
     onAddTunnel: workerSection.openAddTunnel,
@@ -1320,6 +1391,7 @@ export const AppShell: Component = () => {
 
       <AppShellDialogs
         dialogs={dialogs}
+        loadSections={loadSections}
         onBranchChanged={(repo, newBranch) => handleBranchChanged(
           { repoGitStore },
           repo,

--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -1,6 +1,7 @@
 import type { Component } from 'solid-js'
 import type { AppShellDialogStates, ChangeBranchState, DeleteBranchState, EmptyArchiveConfirmPayload, KeyPinConfirmState, NewTabTarget, NewWorkspacePayload, SectionConfirmPayload, WorkspaceConfirmPayload } from './AppShellDialogs'
 import type { SectionNamePayload } from './SectionNameDialog'
+import type { SectionActions } from './sectionUtils'
 import type { SidebarElementsOpts } from './SidebarElements'
 import type { TabContext } from './tabContext'
 import type { CliPathStatus } from '~/api/platformBridge'
@@ -9,7 +10,6 @@ import type { WorkspaceStartActions, WorkspaceStartAt } from '~/components/works
 import type { WorkspaceStartPoint } from '~/components/workspace/workspaceStartPoint'
 import type { BranchRef } from '~/components/workspace/WorkspaceTabTree'
 import type { AgentProvider } from '~/generated/proto/leapmux/v1/agent_pb'
-import type { Section, Sidebar } from '~/generated/proto/leapmux/v1/section_pb'
 import type { ChangeBranchMode } from '~/hooks/useGitModeState'
 import type { SavedViewportScroll } from '~/stores/chatTypes'
 import { useLocation, useSearchParams } from '@solidjs/router'
@@ -246,7 +246,7 @@ export const AppShell: Component = () => {
   // to drop or re-add on a remote change, and no active-workspace filter — every
   // workspace's tabs are derived from the same state at the same time.
   //
-  // A tab whose tile_id names a node this client does not have yet is handled
+  // A tab whose tile_id identifies a node this client does not have yet is handled
   // inside `tabView`, by holding it at its last resolved placement. The hub
   // orders a split's EntityMaterialized frames before the batch that anchors a
   // tab to them, so the routine make-grid race is gone; see `tabView.ts` for
@@ -335,7 +335,7 @@ export const AppShell: Component = () => {
   createEffect(() => {
     if (searchParams.newWorkspace === 'true') {
       newWorkspaceDialog.open({
-        // A worker and no directory: the URL names a machine, not a repository.
+        // A worker and no directory: the URL identifies a machine, not a repository.
         startPoint: { kind: 'directory', workerId: searchParams.workerId as string | undefined },
       })
       setSearchParams({ newWorkspace: undefined, workerId: undefined }, { replace: true })
@@ -345,7 +345,7 @@ export const AppShell: Component = () => {
   // Constant-true today: `(app).tsx` has exactly one leaf (`/`) and
   // hasWorkspaceDesktopChrome matches it, so every guard below always passes.
   // It is kept, not inlined away, because it is the predicate the documented
-  // extension path in `(app).tsx` names: adding a non-workspace leaf under
+  // extension path in `(app).tsx` describes: adding a non-workspace leaf under
   // `(app)/` is a type error at the layout (AppShell takes no children), but
   // nothing would stop these three EFFECTS from running on it -- and one of
   // them activates a workspace, mounting the whole per-workspace machinery
@@ -538,12 +538,29 @@ export const AppShell: Component = () => {
    * `task dev-desktop` the webview points at http://localhost:4328, so a URL
    * check misclassifies a solo run as non-solo.
    */
-  const [runtimeState] = createResource(() => getRuntimeState())
+  // The rejection is CAUGHT rather than left to the resource. Solid re-throws a
+  // rejected resource from the accessor, `platformBridge` caches the rejected
+  // promise for the life of the page, and `localSolo` is read from every
+  // workspace row menu -- so one failed IPC call would replace the whole shell
+  // with the route's error boundary. Not knowing whether this is a solo desktop
+  // means treating it as not one, which hides two menu items.
+  const [runtimeState] = createResource(async () =>
+    getRuntimeState().catch((err: unknown) => {
+      log.warn('get_runtime_state failed; treating this as a non-solo shell', err)
+      return undefined
+    }),
+  )
   const localSolo = () => runtimeState()?.capabilities.localSolo ?? false
 
-  // Whether the active workspace can be mutated
+  // Whether the active workspace can be mutated.
+  //
+  // The presence test is HERE and not inside `isWorkspaceMutatable`, which now
+  // answers about archival alone. An absent workspace -- deleted remotely while
+  // this client still marks it active -- takes no mutation either, and without
+  // this test the memo answered `true` for it: no section means not archived.
+  // `isWorkspaceMutatableById` makes the same test for the same reason.
   const isActiveWorkspaceMutatable = createMemo(() =>
-    isWorkspaceMutatable(isActiveWorkspaceArchived()),
+    !!activeWorkspace() && isWorkspaceMutatable(isActiveWorkspaceArchived()),
   )
 
   // Active tab derived state
@@ -1023,6 +1040,25 @@ export const AppShell: Component = () => {
       confirmArchiveWsDialog.open({ workspaceId, resolve })
     })
 
+  /**
+   * The three section-CRUD callbacks, bundled once. See `SectionActions`.
+   *
+   * A stable object built at setup: the three are plain callbacks over dialog
+   * handles, so nothing here needs to stay reactive.
+   */
+  const sectionActions: SectionActions = {
+    onNew: sidebar => sectionNameDialog.open({ mode: 'create', sidebar }),
+    onRename: section => sectionNameDialog.open({
+      mode: 'rename',
+      sectionId: section.id,
+      initialName: section.name,
+    }),
+    onDelete: section => confirmDeleteSectionDialog.open({
+      sectionId: section.id,
+      sectionName: section.name,
+    }),
+  }
+
   const handleConfirmEmptyArchive = (count: number): Promise<boolean> =>
     new Promise((resolve) => {
       confirmEmptyArchiveDialog.open({ count, resolve })
@@ -1158,17 +1194,7 @@ export const AppShell: Component = () => {
     onConfirmArchive: handleConfirmArchiveWorkspace,
     onConfirmEmptyArchive: handleConfirmEmptyArchive,
     onPostArchiveWorkspace: handlePostArchiveWorkspace,
-    onNewSection: (sidebar: Sidebar) => sectionNameDialog.open({ mode: 'create', sidebar }),
-    onRenameSection: (section: Section) => sectionNameDialog.open({
-      mode: 'rename',
-      sidebar: section.sidebar,
-      sectionId: section.id,
-      initialName: section.name,
-    }),
-    onDeleteSection: (section: Section) => confirmDeleteSectionDialog.open({
-      sectionId: section.id,
-      sectionName: section.name,
-    }),
+    sectionActions,
     workspaceStartActions,
     getCurrentTabContext,
     getMruAgentContext,
@@ -1241,7 +1267,7 @@ export const AppShell: Component = () => {
   // through props.
   //
   // The only decision left is desktop vs mobile. The "workspace not found"
-  // arm went away with the per-workspace URL, and there is deliberately no arm
+  // case went away with the per-workspace URL, and there is deliberately no case
   // for a non-workspace route and no route outlet — see the note on the `(app)`
   // layout, which is where such a case would have to be reintroduced.
 
@@ -1369,8 +1395,8 @@ export const AppShell: Component = () => {
   return (
     <TunnelProvider store={workerSection.tunnelStore}>
       {/*
-        Rendered unconditionally. There used to be a "workspace not found" arm
-        here, for a URL naming a workspace the user does not own. No URL names
+        Rendered unconditionally. There used to be a "workspace not found" case
+        here, for a URL naming a workspace the user does not own. No URL identifies
         one any more: the active id is either this user's own click on their own
         sidebar, or a saved id that `resolveActiveWorkspace` has already checked
         against the loaded list — so the dead-end 404 has no way to be reached,

--- a/frontend/src/components/shell/AppShellDialogs.test.tsx
+++ b/frontend/src/components/shell/AppShellDialogs.test.tsx
@@ -13,6 +13,7 @@ import { createDialogState, createUpdatableDialogState } from '~/hooks/createDia
 import { GitMode } from '~/hooks/useGitModeState'
 import { repoKey } from '~/stores/repoGit'
 import { createRepoGitStore } from '~/stores/repoGit.store'
+import { createSectionStore } from '~/stores/section.store'
 import { emitAddTab } from '~/stores/tabOps'
 import { installTestBridge } from '~/test-support/crdtBridge'
 import { makeInspectResp, makeWorktreeRemovalResp } from '~/test-support/gitBranchFixtures'
@@ -170,6 +171,9 @@ function makeDialogs(): AppShellDialogStates {
     newWorkspace: createDialogState(),
     confirmDeleteWs: createDialogState(),
     confirmArchiveWs: createDialogState(),
+    confirmEmptyArchive: createDialogState(),
+    sectionName: createDialogState(),
+    confirmDeleteSection: createDialogState(),
     lastTabConfirm: createUpdatableDialogState(),
     keyPinConfirm: createDialogState(),
     changeBranch: createDialogState(),
@@ -768,5 +772,67 @@ describe('appShellDialogs agent creation', () => {
     fireEvent.click(await screen.findByTestId('new-agent-created'))
 
     await waitFor(() => expect(dialogs.newAgent.value()).toBeNull())
+  })
+})
+
+/**
+ * The two confirms whose COPY lives only here: one prompt for the whole
+ * archive, and one that states where a deleted section's workspaces go.
+ */
+describe('appShellDialogs section and bulk confirms', () => {
+  function renderConfirms() {
+    const dialogs = makeDialogs()
+    const props = {
+      dialogs,
+      activeWorkspace: () => null,
+      isActiveWorkspaceMutatable: () => true,
+      loadSections: async () => {},
+      sectionStore: createSectionStore(),
+    }
+    render(() => <AppShellDialogs {...(props as unknown as ComponentProps<typeof AppShellDialogs>)} />)
+    return dialogs
+  }
+
+  it('names the count in the empty-archive confirm, and says it is not atomic', async () => {
+    const dialogs = renderConfirms()
+    const resolve = vi.fn()
+    dialogs.confirmEmptyArchive.open({ count: 3, resolve })
+
+    expect(await screen.findByText(/Delete 3 archived workspaces\?/)).toBeInTheDocument()
+    // Each workspace is its own RPC, so a failure part way through leaves the
+    // rest in the archive. The prompt has to say so.
+    expect(screen.getByText(/failure part way through/)).toBeInTheDocument()
+  })
+
+  it('says "workspace", singular, for one', async () => {
+    const dialogs = renderConfirms()
+    dialogs.confirmEmptyArchive.open({ count: 1, resolve: vi.fn() })
+
+    expect(await screen.findByText(/Delete 1 archived workspace\?/)).toBeInTheDocument()
+  })
+
+  it('resolves the empty-archive promise both ways', async () => {
+    const dialogs = renderConfirms()
+    const resolve = vi.fn()
+    dialogs.confirmEmptyArchive.open({ count: 2, resolve })
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancel' }))
+    expect(resolve).toHaveBeenCalledWith(false)
+    expect(dialogs.confirmEmptyArchive.value()).toBeNull()
+
+    const second = vi.fn()
+    dialogs.confirmEmptyArchive.open({ count: 2, resolve: second })
+    // ConfirmButton arms on the first click and fires on the second.
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete all' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Confirm?' }))
+    expect(second).toHaveBeenCalledWith(true)
+  })
+
+  it('states where a deleted section\'s workspaces go, which is what the hub does', async () => {
+    const dialogs = renderConfirms()
+    dialogs.confirmDeleteSection.open({ sectionId: 'sec-1', sectionName: 'Reviews' })
+
+    expect(await screen.findByText(/Delete "Reviews"\? Its workspaces move to In progress\./))
+      .toBeInTheDocument()
   })
 })

--- a/frontend/src/components/shell/AppShellDialogs.test.tsx
+++ b/frontend/src/components/shell/AppShellDialogs.test.tsx
@@ -195,12 +195,12 @@ function renderDialogs(
   })
   // `placementTileId` answers where a new tab would land — `''` means no
   // projected tree. `hasPlaceableTab` asks exactly this, so one knob drives
-  // every guard-reason arm.
+  // every guard-reason case.
   const placementTileId = vi.fn(() => opts.placementTileId ?? '')
   // The guard now asks PER WORKSPACE, because a branch dialog places into the
   // branch's own workspace and not into the active one. `readyWorkspaceIds`
-  // names the workspaces whose tree has arrived; with it unset every workspace
-  // answers the way `placementTileId` does, which is what the arms that only
+  // lists the workspaces whose tree has arrived; with it unset every workspace
+  // answers the way `placementTileId` does, which is what the cases that only
   // exercise the active workspace mean.
   const firstLeafIdFor = vi.fn((workspaceId: string) =>
     (opts.readyWorkspaceIds ? (opts.readyWorkspaceIds.includes(workspaceId) ? 'tile-1' : null) : (opts.placementTileId || null)))
@@ -340,7 +340,7 @@ describe('appShellDialogs branch dialogs', () => {
 
   it('delete branch: a replacing open() re-points the dialog at the new repo', async () => {
     // `createDialogState.open()` replaces a payload without a null step, and
-    // its own suite names this consumer. A keyed <Show> re-runs the children
+    // its own suite covers this consumer. A keyed <Show> re-runs the children
     // function on that identity change, so the second repo's dialog reports
     // the second repo. A non-keyed <Show> would keep the first payload,
     // because its condition memo collapses every truthy value to one.
@@ -427,7 +427,7 @@ describe('appShellDialogs branch dialogs', () => {
   // the payload itself rather than an accessor the close disposes. These pin
   // the two slots where a stale read would strand a promise forever: the
   // workspace confirms resolve a `new Promise` that AppShell awaits with no
-  // timeout, and keyPinConfirm's resolve gates every later key-pin prompt
+  // timeout, and keyPinConfirm's resolve controls every later key-pin prompt
   // through KeyPinStore's confirm chain. Both call resolve NEXT TO their
   // close, so before keyed they were correct only by statement order.
   it.each([
@@ -574,7 +574,7 @@ describe('appShellDialogs branch dialogs', () => {
   // creation dialogs must not create the worker-side agent/pty when there is
   // nowhere to place it — the placement refusal arrives only after the RPC,
   // and the resource it strands has no tab to reach it by. The parent hands
-  // the dialogs the reason; these pin its outcomes, one per arm.
+  // the dialogs the reason; these pin its outcomes, one per case.
   describe('new-tab guard reason', () => {
     it('tells the dialogs to block creation when there is no workspace at all', async () => {
       const { dialogs } = renderDialogs(() => null)
@@ -592,7 +592,7 @@ describe('appShellDialogs branch dialogs', () => {
     })
 
     it('blocks when the active workspace is archived', async () => {
-      // An archived workspace keeps its tree, so only the mutatability arm
+      // An archived workspace keeps its tree, so only the mutatability case
       // fires — the same refusal every quick-action path applies.
       const { dialogs } = renderDialogs(() => ({ id: 'ws1' }), { placementTileId: 'tile-1', mutatable: false })
       dialogs.newAgent.open({})
@@ -611,7 +611,7 @@ describe('appShellDialogs branch dialogs', () => {
       expect(await screen.findByTestId('new-terminal-target')).toHaveTextContent('w1|/repo')
     })
 
-    it('prefills the branch\'s own checkout when the target names one', async () => {
+    it('prefills the branch\'s own checkout when the target identifies one', async () => {
       const { dialogs } = renderDialogs(() => ({ id: 'ws1' }), { placementTileId: 'tile-1' })
       dialogs.newAgent.open({ workerId: 'w2', workingDir: '/other/worktree' })
       dialogs.newTerminal.open({ workerId: 'w2', workingDir: '/other/worktree' })
@@ -793,7 +793,7 @@ describe('appShellDialogs section and bulk confirms', () => {
     return dialogs
   }
 
-  it('names the count in the empty-archive confirm, and says it is not atomic', async () => {
+  it('states the count in the empty-archive confirm, and says it is not atomic', async () => {
     const dialogs = renderConfirms()
     const resolve = vi.fn()
     dialogs.confirmEmptyArchive.open({ count: 3, resolve })

--- a/frontend/src/components/shell/AppShellDialogs.tsx
+++ b/frontend/src/components/shell/AppShellDialogs.tsx
@@ -1,5 +1,6 @@
 import type { Component } from 'solid-js'
 import type { LastTabConfirmState } from './LastTabCloseDialog'
+import type { SectionNamePayload } from './SectionNameDialog'
 import type { TabContext } from './tabContext'
 import type { useAgentOperations } from './useAgentOperations'
 import type { useTabOperations } from './useTabOperations'
@@ -31,6 +32,8 @@ import { NewAgentDialog } from './NewAgentDialog'
 import { NewTerminalDialog } from './NewTerminalDialog'
 import { openTabInFocusedTile } from './openTabInFocusedTile'
 import { placeWorkspaceInSection } from './placeWorkspaceInSection'
+import { SectionNameDialog } from './SectionNameDialog'
+import { useSectionOperations } from './useSectionOperations'
 
 export interface KeyPinConfirmState {
   workerId: string
@@ -103,6 +106,25 @@ export interface WorkspaceConfirmPayload {
 }
 
 /**
+ * Open-time payload for the "Empty archive" confirm.
+ *
+ * The COUNT, not a workspace id: this is one prompt for the whole set. The
+ * per-workspace confirm is suppressed deliberately -- `confirmDeleteWs` is a
+ * single-slot dialog state, so N concurrent opens would drop N-1 resolvers and
+ * leave those awaits pending forever.
+ */
+export interface EmptyArchiveConfirmPayload {
+  count: number
+  resolve: (confirmed: boolean) => void
+}
+
+/** Open-time payload for the "Delete section" confirm. */
+export interface SectionConfirmPayload {
+  sectionId: string
+  sectionName: string
+}
+
+/**
  * Open-time payload for the NewWorkspaceDialog. Both fields are optional:
  *   - `startPoint` says what the dialog already knows: a repository the section
  *     works on (from a section header menu row), or a worker alone
@@ -132,6 +154,9 @@ export interface AppShellDialogStates {
   newWorkspace: DialogState<NewWorkspacePayload>
   confirmDeleteWs: DialogState<WorkspaceConfirmPayload>
   confirmArchiveWs: DialogState<WorkspaceConfirmPayload>
+  confirmEmptyArchive: DialogState<EmptyArchiveConfirmPayload>
+  sectionName: DialogState<SectionNamePayload>
+  confirmDeleteSection: DialogState<SectionConfirmPayload>
   // The only updatable one: LastTabCloseDialog patches its own payload after
   // a status refresh. That capability is what keeps its <Show> non-keyed.
   lastTabConfirm: UpdatableDialogState<LastTabConfirmState>
@@ -150,7 +175,6 @@ interface AppShellDialogsProps {
    */
   onBranchChanged?: (repo: RepoRef, newBranch: string) => void
   activeWorkspace: () => { id: string } | null
-  /** False while the active workspace is archived — read-only, so no new tabs. */
   /**
    * Whether a NAMED workspace takes mutation. Per id, not per active workspace:
    * a dialog can act on a workspace the user is not looking at, and the guard
@@ -168,6 +192,7 @@ interface AppShellDialogsProps {
   sectionStore: ReturnType<typeof createSectionStore>
   focusEditor: () => void
   loadWorkspaces: () => Promise<void>
+  loadSections: () => Promise<void>
   /** Makes a workspace the active one. There is no per-workspace URL to go to. */
   onSelectWorkspace: (id: string) => void
   availableProviders?: AgentProvider[]
@@ -176,6 +201,12 @@ interface AppShellDialogsProps {
 }
 
 export const AppShellDialogs: Component<AppShellDialogsProps> = (props) => {
+  const sectionOps = useSectionOperations({
+    // eslint-disable-next-line solid/reactivity -- the store is a stable object, and loadSections a stable callback
+    sectionStore: props.sectionStore,
+    loadSections: () => props.loadSections(),
+  })
+
   // Full per-agent metadata lives on the Tab record now. `openedAgentTabFields`
   // also primes settingsLabelCache, and it carries `hydrated: true`: this
   // `AgentInfo` came from the worker, so the hydrator has nothing to add and
@@ -388,6 +419,63 @@ export const AppShellDialogs: Component<AppShellDialogsProps> = (props) => {
           >
             <p>Are you sure you want to delete this workspace? This cannot be undone.</p>
           </ConfirmDialog>
+        )}
+      </Show>
+
+      <Show when={props.dialogs.confirmEmptyArchive.value()} keyed>
+        {state => (
+          <ConfirmDialog
+            title="Empty archive"
+            confirmLabel="Delete all"
+            danger
+            onConfirm={() => {
+              state.resolve(true)
+              props.dialogs.confirmEmptyArchive.close()
+            }}
+            onCancel={() => {
+              state.resolve(false)
+              props.dialogs.confirmEmptyArchive.close()
+            }}
+          >
+            {/* The count, because this is the one prompt for the whole set --
+                and the "not all at once" sentence, because there is no
+                transaction: each workspace is its own RPC, so a failure part
+                way through leaves the archive partly emptied. */}
+            <p>
+              {`Delete ${state.count} archived workspace${state.count === 1 ? '' : 's'}? This cannot be undone, and a failure part way through leaves the rest in the archive.`}
+            </p>
+          </ConfirmDialog>
+        )}
+      </Show>
+
+      <Show when={props.dialogs.confirmDeleteSection.value()} keyed>
+        {state => (
+          <ConfirmDialog
+            title="Delete section"
+            confirmLabel="Delete"
+            danger
+            onConfirm={() => {
+              props.dialogs.confirmDeleteSection.close()
+              void sectionOps.deleteSection(state.sectionId)
+            }}
+            onCancel={() => props.dialogs.confirmDeleteSection.close()}
+          >
+            {/* What the hub actually does inside the delete transaction, so the
+                sentence cannot drift from the behaviour. */}
+            <p>{`Delete "${state.sectionName}"? Its workspaces move to In progress.`}</p>
+          </ConfirmDialog>
+        )}
+      </Show>
+
+      <Show when={props.dialogs.sectionName.value()} keyed>
+        {payload => (
+          <SectionNameDialog
+            payload={payload}
+            onSubmit={name => payload.mode === 'create'
+              ? sectionOps.createSection(name, payload.sidebar)
+              : sectionOps.renameSection(payload.sectionId!, name)}
+            onClose={() => props.dialogs.sectionName.close()}
+          />
         )}
       </Show>
 

--- a/frontend/src/components/shell/AppShellDialogs.tsx
+++ b/frontend/src/components/shell/AppShellDialogs.tsx
@@ -4,6 +4,7 @@ import type { TabContext } from './tabContext'
 import type { useAgentOperations } from './useAgentOperations'
 import type { useTabOperations } from './useTabOperations'
 import type { useTerminalOperations } from './useTerminalOperations'
+import type { WorkspaceStartPoint } from '~/components/workspace/workspaceStartPoint'
 import type { AgentInfo, AgentProvider } from '~/generated/proto/leapmux/v1/agent_pb'
 import type { DialogState, UpdatableDialogState } from '~/hooks/createDialogState'
 import type { ChangeBranchMode } from '~/hooks/useGitModeState'
@@ -103,14 +104,17 @@ export interface WorkspaceConfirmPayload {
 
 /**
  * Open-time payload for the NewWorkspaceDialog. Both fields are optional:
- *   - `preselectedWorkerId` seeds the worker dropdown (`?newWorkspace=true&workerId=`
- *     from the URL, or the workspace-sidebar "+ workspace" button on a specific worker).
- *   - `targetSectionId` is the section the freshly-created workspace will be moved into
- *     post-CreateWorkspace (a left-sidebar "+" inside a section header).
- * The shortcut path opens with `{}` (no preselection, default section).
+ *   - `startPoint` says what the dialog already knows: a repository the section
+ *     works on (from a section header menu row), or a worker alone
+ *     (`?newWorkspace=true&workerId=` from the URL). Omit it for "no target",
+ *     which is the same thing as `{ kind: 'directory' }` -- the default is
+ *     applied at ONE place, where this payload reaches the dialog.
+ *   - `targetSectionId` is the section the freshly-created workspace will be
+ *     moved into post-CreateWorkspace (a section header menu's own section).
+ * The shortcut path opens with `{}` (no target, default section).
  */
 export interface NewWorkspacePayload {
-  preselectedWorkerId?: string
+  startPoint?: WorkspaceStartPoint
   targetSectionId?: string | null
 }
 
@@ -350,7 +354,7 @@ export const AppShellDialogs: Component<AppShellDialogsProps> = (props) => {
           <NewWorkspaceDialog
             metadata={props.metadata}
             repoGitStore={props.repoGitStore}
-            preselectedWorkerId={payload.preselectedWorkerId}
+            startPoint={payload.startPoint ?? { kind: 'directory' }}
             availableProviders={props.availableProviders}
             onRefreshProviders={props.onRefreshProviders}
             onCreated={(workspaceId) => {

--- a/frontend/src/components/shell/AppShellDialogs.tsx
+++ b/frontend/src/components/shell/AppShellDialogs.tsx
@@ -313,7 +313,7 @@ export const AppShellDialogs: Component<AppShellDialogsProps> = (props) => {
     if (!props.isWorkspaceMutatable(target))
       return 'This workspace is archived. Unarchive it to create tabs.'
     // `firstLeafIdFor` answers for ANY workspace and is null exactly when
-    // `placementTileId()` would be empty, which is the state this reason names.
+    // `placementTileId()` would be empty, which is the state this reason describes.
     if (!props.layoutStore.firstLeafIdFor(target))
       return 'The workspace view is not ready yet. Try again in a moment.'
     return undefined
@@ -456,7 +456,12 @@ export const AppShellDialogs: Component<AppShellDialogsProps> = (props) => {
             danger
             onConfirm={() => {
               props.dialogs.confirmDeleteSection.close()
-              void sectionOps.deleteSection(state.sectionId)
+              // The toast lives HERE, not in the operation. The confirm is
+              // already dismissed by the time the RPC settles, so this call
+              // site owns the only surface left to report a failure on -- and
+              // `useSectionOperations` keeps one policy for all three.
+              sectionOps.deleteSection(state.sectionId)
+                .catch(err => showWarnToast('Failed to delete section', err))
             }}
             onCancel={() => props.dialogs.confirmDeleteSection.close()}
           >
@@ -473,7 +478,7 @@ export const AppShellDialogs: Component<AppShellDialogsProps> = (props) => {
             payload={payload}
             onSubmit={name => payload.mode === 'create'
               ? sectionOps.createSection(name, payload.sidebar)
-              : sectionOps.renameSection(payload.sectionId!, name)}
+              : sectionOps.renameSection(payload.sectionId, name)}
             onClose={() => props.dialogs.sectionName.close()}
           />
         )}

--- a/frontend/src/components/shell/CollapsibleSidebar.test.tsx
+++ b/frontend/src/components/shell/CollapsibleSidebar.test.tsx
@@ -1,6 +1,7 @@
 import type { SidebarSectionDef } from './CollapsibleSidebar'
 import { fireEvent, render, screen } from '@solidjs/testing-library'
 import Folder from 'lucide-solid/icons/folder'
+import { createSignal } from 'solid-js'
 import { describe, expect, it, vi } from 'vitest'
 import { CollapsibleSidebar } from './CollapsibleSidebar'
 
@@ -222,6 +223,68 @@ describe('collapsibleSidebar', () => {
 
     // Should now have 1 handle (between A and C)
     expect(screen.getAllByTestId('pane-resize-handle')).toHaveLength(1)
+  })
+
+  describe('headerActions', () => {
+    it('renders the actions of a COLLAPSED section', () => {
+      renderSidebar({
+        sections: [
+          makeSection({ id: 'a', title: 'Section A', headerActions: () => <button type="button" data-testid="hdr-a" /> }),
+          makeSection({ id: 'b', title: 'Section B' }),
+        ],
+        initialOpenSections: { a: false, b: true },
+      })
+
+      // The Archived section ships closed, and its menu is the only route to
+      // Unarchive all / Empty archive / the section CRUD.
+      expect(screen.getByTestId('hdr-a')).toBeInTheDocument()
+    })
+
+    it('keeps the SAME node across a rebuild of the section list', () => {
+      const build = vi.fn(() => <button type="button" data-testid="hdr-a" />)
+      const [sections, setSections] = createSignal<SidebarSectionDef[]>([
+        makeSection({ id: 'a', title: 'Section A', headerActions: build }),
+      ])
+      // A LIVE list, not the plain array `renderSidebar` takes:
+      // `buildSectionDefs()` is a plain function, not a memo, so every
+      // workspace create, rename or move mints a whole new def array. That is
+      // the churn this test is about.
+      render(() => (
+        <CollapsibleSidebar
+          sections={sections()}
+          side="left"
+          isCollapsed={false}
+          onExpand={() => {}}
+        />
+      ))
+
+      const first = screen.getByTestId('hdr-a')
+      expect(build).toHaveBeenCalledTimes(1)
+
+      // A fresh def array for the same section id -- one workspace rename.
+      setSections([makeSection({ id: 'a', title: 'Section A', headerActions: build })])
+
+      // The call count alone is vacuous: the old inline form also evaluated
+      // once on first render. The node identity is what says the trigger --
+      // and any popover anchored to it -- survived.
+      expect(build).toHaveBeenCalledTimes(1)
+      expect(screen.getByTestId('hdr-a')).toBe(first)
+    })
+
+    it('renders no actions box for a section that supplies none', () => {
+      renderSidebar({
+        sections: [
+          makeSection({ id: 'a', title: 'Section A', headerActions: () => <button type="button" data-testid="hdr-a" /> }),
+          makeSection({ id: 'b', title: 'Section B' }),
+        ],
+      })
+
+      // The box is a real flex item, so an empty one still takes a slot in the
+      // header row. Counted against the section that HAS actions, so the
+      // assertion cannot pass by both headers rendering the same thing.
+      expect(screen.getByText('Section A').parentElement?.childElementCount).toBe(2)
+      expect(screen.getByText('Section B').parentElement?.childElementCount).toBe(1)
+    })
   })
 
   it('renders collapsed rail when isCollapsed is true', () => {

--- a/frontend/src/components/shell/CollapsibleSidebar.tsx
+++ b/frontend/src/components/shell/CollapsibleSidebar.tsx
@@ -37,8 +37,20 @@ export interface SidebarSectionDef {
   visible?: boolean
   /** Default open state when no persisted state exists. Default: true. */
   defaultOpen?: boolean
-  /** Actions rendered in the section header's right side. */
-  headerActions?: JSX.Element
+  /**
+   * Section header actions factory.  Called once when the section first
+   * mounts, exactly like {@link content}, and for the same reason: the
+   * returned node must survive every reactive update of the section list.
+   *
+   * A plain `JSX.Element` in this slot re-evaluated on every `sectionById()`
+   * change, and `buildSectionDefs()` is a plain function rather than a memo --
+   * so each workspace create, rename or move minted a fresh trigger element and
+   * killed any popover anchored to the old one.
+   *
+   * Solid's `JSX.Element` union excludes functions, so a producer that forgets
+   * the `() =>` is a compile error rather than a menu that closes itself.
+   */
+  headerActions?: () => JSX.Element
   /**
    * Rail-only section: no expandable content panel; only shows in the rail.
    * In the expanded sidebar it renders `content` at the bottom without a collapsible header.
@@ -228,6 +240,10 @@ export const CollapsibleSidebar: Component<CollapsibleSidebarProps> = (props) =>
             // Content is rendered once per section mount. Reactive props inside
             // the returned JSX update fine-grainedly via SolidJS prop getters.
             const renderedContent = section().content()
+            // Rendered once per section mount, for the same reason as the
+            // content above: a header action holds a popover trigger, and a
+            // node rebuilt under an open popover takes the popover with it.
+            const renderedHeaderActions = section().headerActions?.()
 
             const sectionOpen = () => isOpen(id)
 
@@ -367,7 +383,14 @@ export const CollapsibleSidebar: Component<CollapsibleSidebarProps> = (props) =>
                       </div>
                     </Show>
                     <span class={styles.sidebarTitle}>{section().title}</span>
-                    <Show when={sectionOpen() && section().headerActions}>
+                    {/* NOT gated on `sectionOpen()`. The Archived section
+                        ships `defaultOpen: false`, and its header menu is the
+                        only route to Unarchive all, Empty archive and the
+                        section CRUD -- so gating on open made those items
+                        unreachable until the user expanded the section, and
+                        "Collapse all" removed the menu that offers "Expand
+                        all". */}
+                    <Show when={renderedHeaderActions}>
                       <div
                         class={styles.sidebarHeaderActions}
                         onClick={(e) => {
@@ -375,7 +398,7 @@ export const CollapsibleSidebar: Component<CollapsibleSidebarProps> = (props) =>
                           e.preventDefault()
                         }}
                       >
-                        {section().headerActions}
+                        {renderedHeaderActions}
                       </div>
                     </Show>
                   </div>

--- a/frontend/src/components/shell/CollapsibleSidebar.tsx
+++ b/frontend/src/components/shell/CollapsibleSidebar.tsx
@@ -383,13 +383,17 @@ export const CollapsibleSidebar: Component<CollapsibleSidebarProps> = (props) =>
                       </div>
                     </Show>
                     <span class={styles.sidebarTitle}>{section().title}</span>
-                    {/* NOT gated on `sectionOpen()`. The Archived section
-                        ships `defaultOpen: false`, and its header menu is the
-                        only route to Unarchive all, Empty archive and the
-                        section CRUD -- so gating on open made those items
-                        unreachable until the user expanded the section, and
-                        "Collapse all" removed the menu that offers "Expand
-                        all". */}
+                    {/* `sectionOpen()` does NOT control this. The Archived
+                        section ships `defaultOpen: false`, and its header menu
+                        is the only route to Unarchive all, Empty archive and
+                        the section CRUD -- so a check on `sectionOpen()` made
+                        those items unreachable until the user expanded the
+                        section, and "Collapse all" removed the menu that offers
+                        "Expand all".
+
+                        A header action that reveals something INSIDE its own
+                        section must expand the section first, which
+                        `buildSectionDef` does through its `revealing` helper. */}
                     <Show when={renderedHeaderActions}>
                       <div
                         class={styles.sidebarHeaderActions}

--- a/frontend/src/components/shell/CustomTitlebar.tsx
+++ b/frontend/src/components/shell/CustomTitlebar.tsx
@@ -109,10 +109,10 @@ export const CustomTitlebar: Component<CustomTitlebarProps> = (props) => {
             <DropdownMenuItemContent label={maximizeLabel()} />
           </button>
           <button role="menuitem" onClick={() => openWebInspector()}>
-            <DropdownMenuItemContent label="Open Web Inspector" shortcut={getShortcutHintsText('app.openWebInspector')} />
+            <DropdownMenuItemContent label="Open Web Inspector" detail={getShortcutHintsText('app.openWebInspector')} />
           </button>
           <button role="menuitem" onClick={() => quitApp()}>
-            <DropdownMenuItemContent label="Quit" shortcut={getShortcutHintsText('app.quit')} />
+            <DropdownMenuItemContent label="Quit" detail={getShortcutHintsText('app.quit')} />
           </button>
         </Show>
       </DropdownMenu>

--- a/frontend/src/components/shell/GitOptions.test.tsx
+++ b/frontend/src/components/shell/GitOptions.test.tsx
@@ -67,7 +67,7 @@ describe('indexBranches.existingNames', () => {
 
   it('local branches contribute only their exact name', () => {
     // Locals with slashes ("feature/foo") must NOT yield "foo" — the
-    // suffix strip is gated on isRemote and we preserve that
+    // suffix strip depends on isRemote and we preserve that
     // asymmetry.
     const set = existingNames([entry('main'), entry('feature/foo')])
     expect([...set].toSorted()).toEqual(['feature/foo', 'main'])
@@ -389,8 +389,8 @@ describe('gitOptions activeMode ownership', () => {
 
   it('clamps a seed mode that is not in the enabled set', async () => {
     // A seed outside `props.modes` leaves EVERY radio unchecked -- each row is
-    // gated on `enabledModes().has` -- while the emit effect still reports that
-    // mode, so the dialog submits an intent it never showed. The remembered
+    // `enabledModes().has` -- while the emit effect still reports that mode, so
+    // the dialog submits an intent it never showed. The remembered
     // per-repository mode makes that reachable: a mode stored from a dialog
     // that offers all five can arrive at one that offers three.
     const [mode] = createSignal<GitMode>(GitMode.UseWorktree)
@@ -451,6 +451,66 @@ describe('gitOptions activeMode ownership', () => {
     ))
 
     await waitFor(() => expect(screen.getByLabelText('Create new worktree')).toBeChecked())
+  })
+
+  // The active mode is DERIVED from the enabled set, not repaired when the set
+  // changes. A narrowing that still CONTAINS the user's pick must therefore
+  // keep it -- the old reset effect wiped it, along with the cached branch
+  // list, the worktrees and all three selections.
+  it('keeps a still-valid pick when the enabled set narrows', async () => {
+    const [mode] = createSignal<GitMode>(GitMode.Current)
+    const [modes, setModes] = createSignal<GitMode[]>([
+      GitMode.Current,
+      GitMode.SwitchBranch,
+      GitMode.CreateBranch,
+    ])
+
+    render(() => (
+      <GitOptions
+        workerId="w1"
+        selectedPath="/repo"
+        gitInfo={makeGitInfo()}
+        gitMode={mode}
+        onGitModeChange={vi.fn()}
+        modes={modes()}
+      />
+    ))
+
+    await waitFor(() => expect(screen.getByLabelText('Use current state')).toBeChecked())
+    // CreateBranch, not SwitchBranch: the narrowed set's DEFAULT is
+    // SwitchBranch, so picking that would pass either way.
+    fireEvent.click(screen.getByLabelText('Create new branch'))
+    await waitFor(() => expect(screen.getByLabelText('Create new branch')).toBeChecked())
+
+    setModes([GitMode.SwitchBranch, GitMode.CreateBranch])
+
+    await waitFor(() => expect(screen.getByLabelText('Create new branch')).toBeChecked())
+    expect(screen.getByLabelText('Switch to branch')).not.toBeChecked()
+  })
+
+  // The other half: a narrowing that EXCLUDES the pick re-derives to the
+  // default rather than leaving every radio unchecked while the hidden mode
+  // keeps emitting.
+  it('re-derives to the default when the enabled set drops the pick', async () => {
+    const [mode] = createSignal<GitMode>(GitMode.Current)
+    const [modes, setModes] = createSignal<GitMode[]>([GitMode.Current, GitMode.SwitchBranch])
+
+    render(() => (
+      <GitOptions
+        workerId="w1"
+        selectedPath="/repo"
+        gitInfo={makeGitInfo()}
+        gitMode={mode}
+        onGitModeChange={vi.fn()}
+        modes={modes()}
+      />
+    ))
+
+    await waitFor(() => expect(screen.getByLabelText('Use current state')).toBeChecked())
+
+    setModes([GitMode.SwitchBranch, GitMode.CreateBranch])
+
+    await waitFor(() => expect(screen.getByLabelText('Switch to branch')).toBeChecked())
   })
 
   it('honours a seed inside DEFAULT_GIT_MODES when modes is the empty array', async () => {

--- a/frontend/src/components/shell/GitOptions.test.tsx
+++ b/frontend/src/components/shell/GitOptions.test.tsx
@@ -387,6 +387,92 @@ describe('gitOptions activeMode ownership', () => {
     expect(screen.getByLabelText('Use current state')).toBeInTheDocument()
   })
 
+  it('clamps a seed mode that is not in the enabled set', async () => {
+    // A seed outside `props.modes` leaves EVERY radio unchecked -- each row is
+    // gated on `enabledModes().has` -- while the emit effect still reports that
+    // mode, so the dialog submits an intent it never showed. The remembered
+    // per-repository mode makes that reachable: a mode stored from a dialog
+    // that offers all five can arrive at one that offers three.
+    const [mode] = createSignal<GitMode>(GitMode.UseWorktree)
+    const onGitModeChange = vi.fn()
+
+    render(() => (
+      <GitOptions
+        workerId="w1"
+        selectedPath="/repo"
+        gitInfo={makeGitInfo()}
+        gitMode={mode}
+        onGitModeChange={onGitModeChange}
+        modes={[GitMode.SwitchBranch, GitMode.CreateBranch, GitMode.CreateWorktree]}
+      />
+    ))
+
+    // The first enabled mode, because Current is not enabled either.
+    await waitFor(() => expect(screen.getByLabelText('Switch to branch')).toBeChecked())
+    await waitFor(() => expect(onGitModeChange).toHaveBeenCalled())
+    const firstIntent = onGitModeChange.mock.calls[0][0] as { mode: GitMode }
+    expect(firstIntent.mode).toBe(GitMode.SwitchBranch)
+  })
+
+  it('clamps to Current when the enabled set includes it', async () => {
+    const [mode] = createSignal<GitMode>(GitMode.UseWorktree)
+    const onGitModeChange = vi.fn()
+
+    render(() => (
+      <GitOptions
+        workerId="w1"
+        selectedPath="/repo"
+        gitInfo={makeGitInfo()}
+        gitMode={mode}
+        onGitModeChange={onGitModeChange}
+        modes={[GitMode.Current, GitMode.SwitchBranch]}
+      />
+    ))
+
+    await waitFor(() => expect(screen.getByLabelText('Use current state')).toBeChecked())
+    expect(screen.getByLabelText('Switch to branch')).not.toBeChecked()
+  })
+
+  it('passes a seed that IS in the enabled set through unchanged', async () => {
+    // The guard rail on the clamp above: a legitimate seed must not be
+    // rewritten to the default.
+    const [mode] = createSignal<GitMode>(GitMode.CreateWorktree)
+    const onGitModeChange = vi.fn()
+
+    render(() => (
+      <GitOptions
+        workerId="w1"
+        selectedPath="/repo"
+        gitInfo={makeGitInfo()}
+        gitMode={mode}
+        onGitModeChange={onGitModeChange}
+        modes={[GitMode.SwitchBranch, GitMode.CreateBranch, GitMode.CreateWorktree]}
+      />
+    ))
+
+    await waitFor(() => expect(screen.getByLabelText('Create new worktree')).toBeChecked())
+  })
+
+  it('honours a seed inside DEFAULT_GIT_MODES when modes is the empty array', async () => {
+    // The second guard rail: an empty `modes` falls back to the default set,
+    // so the clamp must judge the seed against THAT set and not refuse it.
+    const [mode] = createSignal<GitMode>(GitMode.UseWorktree)
+    const onGitModeChange = vi.fn()
+
+    render(() => (
+      <GitOptions
+        workerId="w1"
+        selectedPath="/repo"
+        gitInfo={makeGitInfo()}
+        gitMode={mode}
+        onGitModeChange={onGitModeChange}
+        modes={[]}
+      />
+    ))
+
+    await waitFor(() => expect(screen.getByLabelText('Use existing worktree')).toBeChecked())
+  })
+
   it('resets the mode to the default when the selected path changes', async () => {
     // Switching repos invalidates every selection the mode depends on --
     // checkout branch, base branch, worktree path, and the fetched lists

--- a/frontend/src/components/shell/GitOptions.tsx
+++ b/frontend/src/components/shell/GitOptions.tsx
@@ -140,12 +140,6 @@ export function indexBranches(branches: readonly GitBranchEntry[]): BranchIndex 
 }
 
 /**
- * Per-mode dirty-worktree warning copy. Exported so tests can pin the
- * exact strings shown for each mode without rendering the full GitOptions
- * component (which depends on auth context, RPC mocks, etc.). Returns null
- * for modes that don't surface a dirty-tree warning.
- */
-/**
  * A `Record`, not a `switch` with a `default`: a sixth mode added to `GitMode`
  * is then a compile error here rather than a mode that silently falls through
  * to "no warning". `null` states that a mode deliberately shows none.
@@ -158,6 +152,12 @@ const DIRTY_WARNINGS: Record<GitMode, string | null> = {
   [GitMode.UseWorktree]: null,
 }
 
+/**
+ * Per-mode dirty-worktree warning copy. Exported so tests can pin the exact
+ * strings shown for each mode without rendering the full GitOptions component
+ * (which depends on auth context, RPC mocks, etc.). Returns null for a mode
+ * that surfaces no dirty-tree warning.
+ */
 export function dirtyWarningCopy(mode: GitMode): string | null {
   return DIRTY_WARNINGS[mode]
 }
@@ -193,14 +193,17 @@ export const GitOptions: Component<GitOptionsProps> = (props) => {
   // `.mode` for its own conditional renders, but that value never
   // re-enters GitOptions.
   //
-  // CLAMPED to the enabled set. A seed outside `props.modes` leaves every radio
-  // unchecked -- each row is gated on `enabledModes().has` -- while the emit
-  // effect still reports that mode's intent, so the dialog submits a mode it
-  // never showed. The remembered per-repository mode makes that reachable: a
-  // mode stored from one dialog can be absent from the next one's set.
+  // The active mode is DERIVED, not stored. A mode outside the enabled set
+  // leaves every radio unchecked -- each row is `enabledModes().has` -- while
+  // the emit effect still reports that mode's intent, so the dialog submits a
+  // mode it never showed. The remembered per-repository mode makes that
+  // reachable: a mode stored by one dialog can be absent from the next one's
+  // set. Deriving makes the state unrepresentable rather than repairing it at
+  // the two moments it can arise (the seed, and a set that narrows later).
   const clampMode = (mode: GitMode): GitMode =>
     enabledModes().has(mode) ? mode : defaultMode()
-  const [activeMode, setActiveMode] = createSignal<GitMode>(untrack(() => clampMode(props.gitMode())))
+  const [rawMode, setRawMode] = createSignal<GitMode>(untrack(() => props.gitMode()))
+  const activeMode = createMemo(() => clampMode(rawMode()))
 
   // Branch-name UX. CreateBranch and CreateWorktree are mutually
   // exclusive radios that both render the same "Branch name" input +
@@ -400,18 +403,18 @@ export const GitOptions: Component<GitOptionsProps> = (props) => {
   // currentIntent memo + emit effect below picks up the change and
   // notifies the parent in the same flush.
   //
-  // `props.modes` is a dependency too. A parent that NARROWS the set after
-  // mount would otherwise leave the active mode outside it -- every radio
-  // unchecked, and the hidden mode still emitting -- which is the same defect
-  // the seed clamp above fixes, arriving one render later.
-  createEffect(on(() => [props.workerId, props.selectedPath, props.modes] as const, () => {
+  // `props.modes` is deliberately NOT a dependency: `activeMode` is derived
+  // through `clampMode`, so a set that narrows re-derives on its own and needs
+  // no reset -- which also stops a narrowing from discarding the branch list,
+  // the worktrees and all three selections along with a still-valid pick.
+  createEffect(on(() => [props.workerId, props.selectedPath] as const, () => {
     batch(() => {
       setInternalBranches([])
       setWorktrees([])
       setSelectedCheckoutBranch('')
       setSelectedBaseBranch('')
       setSelectedWorktreePath('')
-      setActiveMode(defaultMode())
+      setRawMode(defaultMode())
     })
   }, { defer: true }))
 
@@ -512,8 +515,8 @@ export const GitOptions: Component<GitOptionsProps> = (props) => {
     </>
   )
 
-  // Per-mode row: enabledModes() gates the whole block, the active mode
-  // gates the sub-content. Callers own the `<div class={radioSubContent}>`
+  // Per-mode row: enabledModes() controls the whole block, the active mode
+  // controls the sub-content. Callers own the `<div class={radioSubContent}>`
   // wrapper inside `children` so the Current mode can omit it when there's
   // no branch to display (an empty wrapper would still take a `gap` slot
   // in `radioGroup`).
@@ -528,7 +531,7 @@ export const GitOptions: Component<GitOptionsProps> = (props) => {
           type="radio"
           name="git-mode"
           checked={activeMode() === rp.mode}
-          onChange={() => setActiveMode(rp.mode)}
+          onChange={() => setRawMode(rp.mode)}
         />
         {GIT_MODE_LABELS[rp.mode]}
       </label>

--- a/frontend/src/components/shell/GitOptions.tsx
+++ b/frontend/src/components/shell/GitOptions.tsx
@@ -12,7 +12,7 @@ import { Tooltip } from '~/components/common/Tooltip'
 import { WorktreeSelect } from '~/components/shell/WorktreeSelect'
 import { BranchSelect } from '~/components/workspace/BranchSelect'
 import { createGuardedFetch } from '~/hooks/createGuardedFetch'
-import { GitMode } from '~/hooks/useGitModeState'
+import { GIT_MODE_LABELS, GitMode } from '~/hooks/useGitModeState'
 import { createLogger } from '~/lib/logger'
 import { detectFlavor, join, parentDirectory, tildify } from '~/lib/paths'
 import { stripRemotePrefix, validateBranchName } from '~/lib/validate'
@@ -55,7 +55,7 @@ interface GitOptionsProps {
    * Pre-seed the parent's intent via `useGitModeState(initial)` to
    * select a non-default starting mode.
    */
-  modes?: GitMode[]
+  modes?: readonly GitMode[]
   /**
    * Pre-fetched branches list. When set, GitOptions reads its branches
    * from this accessor instead of issuing its own ListGitBranches RPC.
@@ -81,7 +81,7 @@ interface GitOptionsProps {
   onRefreshBranches?: () => void
 }
 
-const DEFAULT_GIT_MODES: GitMode[] = [
+const DEFAULT_GIT_MODES: readonly GitMode[] = [
   GitMode.Current,
   GitMode.SwitchBranch,
   GitMode.CreateBranch,
@@ -145,17 +145,21 @@ export function indexBranches(branches: readonly GitBranchEntry[]): BranchIndex 
  * component (which depends on auth context, RPC mocks, etc.). Returns null
  * for modes that don't surface a dirty-tree warning.
  */
+/**
+ * A `Record`, not a `switch` with a `default`: a sixth mode added to `GitMode`
+ * is then a compile error here rather than a mode that silently falls through
+ * to "no warning". `null` states that a mode deliberately shows none.
+ */
+const DIRTY_WARNINGS: Record<GitMode, string | null> = {
+  [GitMode.Current]: null,
+  [GitMode.SwitchBranch]: 'The working copy has uncommitted changes. Switching branches may fail or discard changes.',
+  [GitMode.CreateBranch]: 'The working copy has uncommitted changes. Creating a new branch will include them.',
+  [GitMode.CreateWorktree]: 'The selected working copy has uncommitted changes that will not be transferred to the new worktree.',
+  [GitMode.UseWorktree]: null,
+}
+
 export function dirtyWarningCopy(mode: GitMode): string | null {
-  switch (mode) {
-    case GitMode.SwitchBranch:
-      return 'The working copy has uncommitted changes. Switching branches may fail or discard changes.'
-    case GitMode.CreateBranch:
-      return 'The working copy has uncommitted changes. Creating a new branch will include them.'
-    case GitMode.CreateWorktree:
-      return 'The selected working copy has uncommitted changes that will not be transferred to the new worktree.'
-    default:
-      return null
-  }
+  return DIRTY_WARNINGS[mode]
 }
 
 /** The branch-name error node's id, so its input can point at it. */
@@ -188,7 +192,15 @@ export const GitOptions: Component<GitOptionsProps> = (props) => {
   // (e.g. `useGitModeState.gitMode`) reflects the emitted intent's
   // `.mode` for its own conditional renders, but that value never
   // re-enters GitOptions.
-  const [activeMode, setActiveMode] = createSignal<GitMode>(untrack(() => props.gitMode()))
+  //
+  // CLAMPED to the enabled set. A seed outside `props.modes` leaves every radio
+  // unchecked -- each row is gated on `enabledModes().has` -- while the emit
+  // effect still reports that mode's intent, so the dialog submits a mode it
+  // never showed. The remembered per-repository mode makes that reachable: a
+  // mode stored from one dialog can be absent from the next one's set.
+  const clampMode = (mode: GitMode): GitMode =>
+    enabledModes().has(mode) ? mode : defaultMode()
+  const [activeMode, setActiveMode] = createSignal<GitMode>(untrack(() => clampMode(props.gitMode())))
 
   // Branch-name UX. CreateBranch and CreateWorktree are mutually
   // exclusive radios that both render the same "Branch name" input +
@@ -387,7 +399,12 @@ export const GitOptions: Component<GitOptionsProps> = (props) => {
   // activeMode signal is reset to the dialog's default mode here; the
   // currentIntent memo + emit effect below picks up the change and
   // notifies the parent in the same flush.
-  createEffect(on(() => [props.workerId, props.selectedPath] as const, () => {
+  //
+  // `props.modes` is a dependency too. A parent that NARROWS the set after
+  // mount would otherwise leave the active mode outside it -- every radio
+  // unchecked, and the hidden mode still emitting -- which is the same defect
+  // the seed clamp above fixes, arriving one render later.
+  createEffect(on(() => [props.workerId, props.selectedPath, props.modes] as const, () => {
     batch(() => {
       setInternalBranches([])
       setWorktrees([])
@@ -500,7 +517,11 @@ export const GitOptions: Component<GitOptionsProps> = (props) => {
   // wrapper inside `children` so the Current mode can omit it when there's
   // no branch to display (an empty wrapper would still take a `gap` slot
   // in `radioGroup`).
-  const ModeRadio: Component<{ mode: GitMode, label: string, children?: JSX.Element }> = rp => (
+  //
+  // The label comes from the shared table, NOT from a prop: pairing a mode with
+  // another mode's label is then impossible, and the menu item that opens this
+  // dialog on that radio reads the same table.
+  const ModeRadio: Component<{ mode: GitMode, children?: JSX.Element }> = rp => (
     <Show when={enabledModes().has(rp.mode)}>
       <label class={radioRow}>
         <input
@@ -509,7 +530,7 @@ export const GitOptions: Component<GitOptionsProps> = (props) => {
           checked={activeMode() === rp.mode}
           onChange={() => setActiveMode(rp.mode)}
         />
-        {rp.label}
+        {GIT_MODE_LABELS[rp.mode]}
       </label>
       <Show when={activeMode() === rp.mode}>
         {rp.children}
@@ -521,7 +542,7 @@ export const GitOptions: Component<GitOptionsProps> = (props) => {
     <div class="vstack gap-2">
       <div class={labelRow}>Git options</div>
       <div class={radioGroup}>
-        <ModeRadio mode={GitMode.Current} label="Use current state">
+        <ModeRadio mode={GitMode.Current}>
           <Show when={props.gitInfo.info().currentBranch}>
             <div class={radioSubContent}>
               <div class={pathPreview}>
@@ -532,7 +553,7 @@ export const GitOptions: Component<GitOptionsProps> = (props) => {
           </Show>
         </ModeRadio>
 
-        <ModeRadio mode={GitMode.SwitchBranch} label="Switch to branch">
+        <ModeRadio mode={GitMode.SwitchBranch}>
           <div class={radioSubContent}>
             {renderDirtyWarning(GitMode.SwitchBranch)}
             {renderBranchSelect({
@@ -552,14 +573,14 @@ export const GitOptions: Component<GitOptionsProps> = (props) => {
           </div>
         </ModeRadio>
 
-        <ModeRadio mode={GitMode.CreateBranch} label="Create new branch">
+        <ModeRadio mode={GitMode.CreateBranch}>
           <div class={radioSubContent}>
             {renderDirtyWarning(GitMode.CreateBranch)}
             {renderBranchNameAndBase()}
           </div>
         </ModeRadio>
 
-        <ModeRadio mode={GitMode.CreateWorktree} label="Create new worktree">
+        <ModeRadio mode={GitMode.CreateWorktree}>
           <div class={radioSubContent}>
             {renderDirtyWarning(GitMode.CreateWorktree)}
             {renderBranchNameAndBase()}
@@ -573,7 +594,7 @@ export const GitOptions: Component<GitOptionsProps> = (props) => {
           </div>
         </ModeRadio>
 
-        <ModeRadio mode={GitMode.UseWorktree} label="Use existing worktree">
+        <ModeRadio mode={GitMode.UseWorktree}>
           <div class={radioSubContent}>
             <WorktreeSelect
               value={selectedWorktreePath()}

--- a/frontend/src/components/shell/LeftSidebar.tsx
+++ b/frontend/src/components/shell/LeftSidebar.tsx
@@ -26,6 +26,18 @@ export const LeftSidebar: Component<LeftSidebarProps> = (props) => {
   // Register workspace DnD handlers with the unified SectionDragProvider.
   // This allows workspace dragging to work through the shared DragDropProvider
   // instead of requiring a separate nested provider (which would shadow section DnD).
+  //
+  // Registered HERE but global in effect, and that matters now that a custom
+  // workspace section can be created on the RIGHT sidebar. One
+  // `SectionDragProvider` wraps both sidebars (see AppShell), and
+  // `handleWorkspaceDragEnd` resolves its sections from the store rather than
+  // from this sidebar -- so it serves a row dragged in either one, and
+  // `RightSidebar` deliberately registers nothing (a second registration would
+  // run the same handler twice per drop).
+  //
+  // The property this depends on: LeftSidebar is always mounted. A layout that
+  // rendered the right sidebar alone would leave every workspace drag with no
+  // handler and no error.
   const disposeWsDragHandler = addExternalDragHandler(wsOps.handleWorkspaceDragEnd)
   // eslint-disable-next-line solid/reactivity -- overlay renderer is called from DragOverlay, not a tracked scope
   const disposeWsOverlayRenderer = addExternalOverlayRenderer((draggable: any) => {

--- a/frontend/src/components/shell/OpenInEditorButton.tsx
+++ b/frontend/src/components/shell/OpenInEditorButton.tsx
@@ -52,6 +52,14 @@ export const OpenInEditorButton: Component<OpenInEditorButtonProps> = (props) =>
   // the webview points at http://localhost:4328, so a URL-based check would
   // wrongly classify a solo run as non-solo. The runtime state's `localSolo`
   // capability flag reflects the actual sidecar shell mode.
+  //
+  // `localSolo` ALONE, deliberately -- not `~/lib/workerLocality`'s
+  // `isLocalWorker`, which additionally requires the worker to be the bundled
+  // auto-registered one. This component takes a `workingDir` and no
+  // `workerId`, so it has no worker to ask about; the directory it opens is
+  // whatever the active tab reports. A surface that DOES hold a worker id (the
+  // workspace row menu's Repository submenu) must use `isLocalWorker`, because
+  // a solo desktop can also hold registrations for remote machines.
   const [runtimeState] = createResource(() => getRuntimeState())
   const eligible = () => runtimeState()?.capabilities.localSolo ?? false
 

--- a/frontend/src/components/shell/OpenInEditorButton.tsx
+++ b/frontend/src/components/shell/OpenInEditorButton.tsx
@@ -60,7 +60,12 @@ export const OpenInEditorButton: Component<OpenInEditorButtonProps> = (props) =>
   // whatever the active tab reports. A surface that DOES hold a worker id (the
   // workspace row menu's Repository submenu) must use `isLocalWorker`, because
   // a solo desktop can also hold registrations for remote machines.
-  const [runtimeState] = createResource(() => getRuntimeState())
+  // Caught for the same reason AppShell catches it: Solid re-throws a rejected
+  // resource from the accessor, and `platformBridge` caches the rejected
+  // promise, so one failed IPC call would take out every render that reads it.
+  const [runtimeState] = createResource(async () =>
+    getRuntimeState().catch(() => undefined),
+  )
   const eligible = () => runtimeState()?.capabilities.localSolo ?? false
 
   const [editors, { refetch: refetchEditors }] = createResource<DetectedEditor[], boolean>(

--- a/frontend/src/components/shell/RightSidebar.fileTreeOps.test.tsx
+++ b/frontend/src/components/shell/RightSidebar.fileTreeOps.test.tsx
@@ -24,7 +24,11 @@ vi.mock('./CollapsibleSidebar', () => ({
 
 vi.mock('./useWorkspaceOperations', () => ({
   useWorkspaceOperations: () => ({
-    buildSectionGroups: (sections: any[]) => sections.map(section => ({ section })),
+    buildSectionGroups: (sections: any[]) => sections.map(section => ({ section, workspaces: [] })),
+    // `useSidebarCore` projects every group through this to build its one
+    // per-section memo, so a double that omits it fails at render rather than
+    // at the assertion.
+    getWorkspacesForGroup: () => [],
   }),
 }))
 

--- a/frontend/src/components/shell/SectionNameDialog.test.tsx
+++ b/frontend/src/components/shell/SectionNameDialog.test.tsx
@@ -18,9 +18,10 @@ function renderDialog(
 }
 
 const CREATE: SectionNamePayload = { mode: 'create', sidebar: Sidebar.LEFT }
+// No `sidebar`: the payload is a union now, and a rename has no sidebar to
+// carry. Adding one back is a compile error rather than a field nobody reads.
 const RENAME: SectionNamePayload = {
   mode: 'rename',
-  sidebar: Sidebar.LEFT,
   sectionId: 'sec-1',
   initialName: 'Old Name',
 }
@@ -95,6 +96,29 @@ describe('sectionNameDialog', () => {
 
     expect(await screen.findByText('section limit reached')).toBeInTheDocument()
     expect(props.onClose).not.toHaveBeenCalled()
+    // And the dialog is USABLE again. `useDialogSubmit` releases both
+    // `submitting` and its re-entrancy latch in a `finally`; if either leaked,
+    // the user would face an error message over a permanently disabled Create
+    // button, with Cancel as the only way out -- and the assertions above
+    // would still pass.
+    await waitFor(() => expect(submitButton().disabled).toBe(false))
+  })
+
+  it('submits again after a failure, so one rejection does not wedge it', async () => {
+    const onSubmit = vi.fn()
+      .mockRejectedValueOnce(new Error('section limit reached'))
+      .mockResolvedValueOnce(undefined)
+    const props = renderDialog(CREATE, { onSubmit })
+
+    fireEvent.input(nameInput(), { target: { value: 'Reviews' } })
+    fireEvent.click(submitButton())
+    expect(await screen.findByText('section limit reached')).toBeInTheDocument()
+
+    await waitFor(() => expect(submitButton().disabled).toBe(false))
+    fireEvent.click(submitButton())
+
+    await waitFor(() => expect(props.onClose).toHaveBeenCalledOnce())
+    expect(onSubmit).toHaveBeenCalledTimes(2)
   })
 
   it('cancels without submitting', () => {

--- a/frontend/src/components/shell/SectionNameDialog.test.tsx
+++ b/frontend/src/components/shell/SectionNameDialog.test.tsx
@@ -1,0 +1,107 @@
+import type { SectionNamePayload } from './SectionNameDialog'
+import { fireEvent, render, screen, waitFor } from '@solidjs/testing-library'
+import { describe, expect, it, vi } from 'vitest'
+import { Sidebar } from '~/generated/proto/leapmux/v1/section_pb'
+import { SectionNameDialog } from './SectionNameDialog'
+
+function renderDialog(
+  payload: SectionNamePayload,
+  overrides: { onSubmit?: (name: string) => Promise<void>, onClose?: () => void } = {},
+) {
+  const props = {
+    payload,
+    onSubmit: overrides.onSubmit ?? vi.fn(async () => {}),
+    onClose: overrides.onClose ?? vi.fn(),
+  }
+  render(() => <SectionNameDialog {...props} />)
+  return props
+}
+
+const CREATE: SectionNamePayload = { mode: 'create', sidebar: Sidebar.LEFT }
+const RENAME: SectionNamePayload = {
+  mode: 'rename',
+  sidebar: Sidebar.LEFT,
+  sectionId: 'sec-1',
+  initialName: 'Old Name',
+}
+
+function nameInput(): HTMLInputElement {
+  return screen.getByTestId('title-input') as HTMLInputElement
+}
+
+function submitButton(): HTMLButtonElement {
+  return screen.getByRole('button', { name: /^(Create|Rename)$/ }) as HTMLButtonElement
+}
+
+describe('sectionNameDialog', () => {
+  it('opens empty and refuses an empty name when creating', () => {
+    renderDialog(CREATE)
+
+    expect(screen.getByText('New section')).toBeInTheDocument()
+    expect(nameInput().value).toBe('')
+    expect(submitButton().disabled).toBe(true)
+  })
+
+  it('opens on the current name when renaming', () => {
+    renderDialog(RENAME)
+
+    expect(screen.getByText('Rename section')).toBeInTheDocument()
+    expect(nameInput().value).toBe('Old Name')
+    expect(submitButton().disabled).toBe(false)
+  })
+
+  it('submits the name and then closes', async () => {
+    const onSubmit = vi.fn(async () => {})
+    const props = renderDialog(CREATE, { onSubmit })
+
+    fireEvent.input(nameInput(), { target: { value: 'Reviews' } })
+    fireEvent.click(submitButton())
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith('Reviews'))
+    await waitFor(() => expect(props.onClose).toHaveBeenCalledOnce())
+  })
+
+  it('submits the CLEANED name, because the hub sanitizes whatever arrives', async () => {
+    // Raw text would leave the sidebar showing one name while the hub stored
+    // another until the next refresh.
+    const onSubmit = vi.fn(async () => {})
+    renderDialog(CREATE, { onSubmit })
+
+    fireEvent.input(nameInput(), { target: { value: '  Code\u200Breview\u00A0board  ' } })
+    fireEvent.click(submitButton())
+
+    // Trimmed, the zero-width space dropped, and the no-break space folded to
+    // an ordinary one -- the same rule `commitRename` applies to a workspace.
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith('Codereview board'))
+  })
+
+  it('refuses a name that cleans to nothing', () => {
+    renderDialog(CREATE)
+
+    fireEvent.input(nameInput(), { target: { value: '\u200B\uFEFF\u00AD' } })
+    expect(submitButton().disabled).toBe(true)
+  })
+
+  it('shows the failure in its own error row and stays open', async () => {
+    // The dialog owns the error surface, which is why `useSectionOperations`
+    // lets the create and the rename REJECT instead of toasting.
+    const onSubmit = vi.fn(async () => {
+      throw new Error('section limit reached')
+    })
+    const props = renderDialog(CREATE, { onSubmit })
+
+    fireEvent.input(nameInput(), { target: { value: 'Reviews' } })
+    fireEvent.click(submitButton())
+
+    expect(await screen.findByText('section limit reached')).toBeInTheDocument()
+    expect(props.onClose).not.toHaveBeenCalled()
+  })
+
+  it('cancels without submitting', () => {
+    const props = renderDialog(RENAME)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(props.onSubmit).not.toHaveBeenCalled()
+    expect(props.onClose).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/components/shell/SectionNameDialog.tsx
+++ b/frontend/src/components/shell/SectionNameDialog.tsx
@@ -1,0 +1,90 @@
+import type { Component } from 'solid-js'
+import type { Sidebar } from '~/generated/proto/leapmux/v1/section_pb'
+import { Show } from 'solid-js'
+import { actionsFooter } from '~/components/common/actionsFooter.css'
+import { Dialog } from '~/components/common/Dialog'
+import { createTitleState } from '~/hooks/createTitleState'
+import { useDialogSubmit } from '~/hooks/useDialogSubmit'
+import { errorText } from '~/styles/shared.css'
+import { TitleInput } from './TitleInput'
+import { DialogFormFooter } from './WorkerDialogShell'
+
+/** Open-time payload for {@link SectionNameDialog}. */
+export interface SectionNamePayload {
+  mode: 'create' | 'rename'
+  /** Which sidebar a CREATED section lands on. Ignored for a rename. */
+  sidebar: Sidebar
+  /** The section being renamed. Absent for a create. */
+  sectionId?: string
+  /** The name the field starts with. Empty for a create. */
+  initialName?: string
+}
+
+interface SectionNameDialogProps {
+  payload: SectionNamePayload
+  /**
+   * Do the work. Resolves once the RPC settled; the dialog closes after.
+   * Rejecting shows the message in the dialog's own error row.
+   */
+  onSubmit: (name: string) => Promise<void>
+  onClose: () => void
+}
+
+/**
+ * Name a sidebar section, for both creating one and renaming one.
+ *
+ * ONE dialog for the two, because they differ only in their title, their submit
+ * label and their starting value -- and a second component would be a second
+ * place the name rule lives. The field is `TitleInput`, so a section name and a
+ * workspace title are validated and drawn identically.
+ */
+export const SectionNameDialog: Component<SectionNameDialogProps> = (props) => {
+  // Read ONCE, both of them. The caller's `<Show>` is keyed, so a different
+  // payload remounts this component rather than mutating a half-typed field
+  // under the user.
+  /* eslint-disable solid/reactivity -- one-time initial values; see above */
+  const creating = props.payload.mode === 'create'
+  const name = createTitleState(() => props.payload.initialName ?? '')
+  /* eslint-enable solid/reactivity */
+  const { submitting, error, formHandler } = useDialogSubmit({
+    fallback: creating ? 'Failed to create section' : 'Failed to rename section',
+  })
+
+  // Submit sends the CLEANED name: the hub applies `SanitizeName` to whatever
+  // arrives, so raw text would leave the sidebar and the hub disagreeing.
+  const submitDisabled = () => submitting.loading() || !name.cleaned() || !!name.error()
+
+  const handleSubmit = formHandler(submitDisabled, async () => {
+    await props.onSubmit(name.cleaned())
+    props.onClose()
+  })
+
+  return (
+    <Dialog
+      title={creating ? 'New section' : 'Rename section'}
+      busy={submitting.loading()}
+      onClose={() => props.onClose()}
+      data-testid="section-name-dialog"
+    >
+      <form onSubmit={handleSubmit}>
+        <section>
+          <div class="vstack gap-4">
+            <TitleInput state={name} />
+          </div>
+          <Show when={error()}>
+            <div class={errorText}>{error()}</div>
+          </Show>
+        </section>
+        <footer class={actionsFooter}>
+          <DialogFormFooter
+            submitting={submitting.loading()}
+            submitDisabled={submitDisabled()}
+            submitLabel={creating ? 'Create' : 'Rename'}
+            submittingLabel={creating ? 'Creating...' : 'Renaming...'}
+            onClose={() => props.onClose()}
+          />
+        </footer>
+      </form>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/shell/SectionNameDialog.tsx
+++ b/frontend/src/components/shell/SectionNameDialog.tsx
@@ -9,16 +9,28 @@ import { errorText } from '~/styles/shared.css'
 import { TitleInput } from './TitleInput'
 import { DialogFormFooter } from './WorkerDialogShell'
 
-/** Open-time payload for {@link SectionNameDialog}. */
-export interface SectionNamePayload {
-  mode: 'create' | 'rename'
-  /** Which sidebar a CREATED section lands on. Ignored for a rename. */
-  sidebar: Sidebar
-  /** The section being renamed. Absent for a create. */
-  sectionId?: string
-  /** The name the field starts with. Empty for a create. */
-  initialName?: string
-}
+/**
+ * Open-time payload for {@link SectionNameDialog}.
+ *
+ * A UNION, so each mode carries exactly what it needs and nothing it does not.
+ * One interface with `sidebar` documented "ignored for a rename" and an
+ * optional `sectionId` forced the rename call site to assert the id was
+ * present -- and a payload built without one would have reached the RPC as
+ * `undefined` instead of failing to compile.
+ */
+export type SectionNamePayload
+  = | {
+    mode: 'create'
+    /** Which sidebar the created section lands on. */
+    sidebar: Sidebar
+  }
+  | {
+    mode: 'rename'
+    /** The section being renamed. */
+    sectionId: string
+    /** The name the field starts with. */
+    initialName: string
+  }
 
 interface SectionNameDialogProps {
   payload: SectionNamePayload
@@ -43,8 +55,9 @@ export const SectionNameDialog: Component<SectionNameDialogProps> = (props) => {
   // payload remounts this component rather than mutating a half-typed field
   // under the user.
   /* eslint-disable solid/reactivity -- one-time initial values; see above */
-  const creating = props.payload.mode === 'create'
-  const name = createTitleState(() => props.payload.initialName ?? '')
+  const payload = props.payload
+  const creating = payload.mode === 'create'
+  const name = createTitleState(() => (payload.mode === 'rename' ? payload.initialName : ''))
   /* eslint-enable solid/reactivity */
   const { submitting, error, formHandler } = useDialogSubmit({
     fallback: creating ? 'Failed to create section' : 'Failed to rename section',

--- a/frontend/src/components/shell/SidebarElements.test.ts
+++ b/frontend/src/components/shell/SidebarElements.test.ts
@@ -56,7 +56,11 @@ const STATIC_PASSTHROUGHS = new Set([
   'onDeleteWorkspace',
   'onConfirmDelete',
   'onConfirmArchive',
+  'onConfirmEmptyArchive',
   'onPostArchiveWorkspace',
+  'onNewSection',
+  'onRenameSection',
+  'onDeleteSection',
   'getCurrentTabContext',
   'getMruAgentContext',
   'onFileSelect',
@@ -102,7 +106,11 @@ function trackedOpts() {
     onDeleteWorkspace: noop,
     onConfirmDelete: noop,
     onConfirmArchive: noop,
+    onConfirmEmptyArchive: noop,
     onPostArchiveWorkspace: noop,
+    onNewSection: noop,
+    onRenameSection: noop,
+    onDeleteSection: noop,
     getCurrentTabContext: tabContext,
     getMruAgentContext: () => ({ workingDir: '/repo', homeDir: '/home/u' }),
     get fileTreePath() {
@@ -145,6 +153,13 @@ function trackedOpts() {
       reads.push('workers')
       return []
     },
+    // Counted, because it is REACTIVE: it comes from a `createResource` over
+    // the desktop shell's runtime state, so an eager read here would put the
+    // whole sidebar back on the remount-per-change path.
+    get localSolo() {
+      reads.push('localSolo')
+      return false
+    },
     workerInfoFn: () => undefined,
     channelStatusFn: () => undefined,
     onAddTunnel: noop,
@@ -155,6 +170,7 @@ function trackedOpts() {
     // A real bundle, not omitted: the pass-through assertion below compares
     // identities, and two `undefined`s compare equal without proving anything.
     branchActions: stubBranchRefActions(),
+    workspaceStartActions: { onNewAgentAt: noop, onNewTerminalAt: noop },
   } as unknown as SidebarElementsOpts
   return { opts, reads }
 }

--- a/frontend/src/components/shell/SidebarElements.test.ts
+++ b/frontend/src/components/shell/SidebarElements.test.ts
@@ -58,9 +58,8 @@ const STATIC_PASSTHROUGHS = new Set([
   'onConfirmArchive',
   'onConfirmEmptyArchive',
   'onPostArchiveWorkspace',
-  'onNewSection',
-  'onRenameSection',
-  'onDeleteSection',
+  // One bundle now, not three parallel fields. See `SectionActions`.
+  'sectionActions',
   'getCurrentTabContext',
   'getMruAgentContext',
   'onFileSelect',
@@ -108,9 +107,7 @@ function trackedOpts() {
     onConfirmArchive: noop,
     onConfirmEmptyArchive: noop,
     onPostArchiveWorkspace: noop,
-    onNewSection: noop,
-    onRenameSection: noop,
-    onDeleteSection: noop,
+    sectionActions: { onNew: noop, onRename: noop, onDelete: noop },
     getCurrentTabContext: tabContext,
     getMruAgentContext: () => ({ workingDir: '/repo', homeDir: '/home/u' }),
     get fileTreePath() {
@@ -190,7 +187,7 @@ describe('buildCommonSidebarProps', () => {
     expect(reads).toEqual([])
   })
 
-  it('forwards a pass-through prop it never names', () => {
+  it('forwards a pass-through prop it never lists', () => {
     // The forward list is gone -- mergeProps carries every pass-through -- so
     // this is what pins that the mechanism is actually wired. It also covers
     // what the Proxy guard below no longer can: mergeProps reads descriptors

--- a/frontend/src/components/shell/SidebarElements.tsx
+++ b/frontend/src/components/shell/SidebarElements.tsx
@@ -3,6 +3,9 @@ import type { mruAgentEditorDeps } from './mruAgentEditorDeps'
 import type { TabContext } from './tabContext'
 import type { useTerminalOperations } from './useTerminalOperations'
 import type { BranchRefActions } from '~/components/workspace/branchActions'
+import type { WorkspaceStartActions } from '~/components/workspace/workspaceStartActions'
+import type { WorkspaceStartPoint } from '~/components/workspace/workspaceStartPoint'
+import type { Section, Sidebar } from '~/generated/proto/leapmux/v1/section_pb'
 import type { Worker } from '~/generated/proto/leapmux/v1/worker_pb'
 import type { Workspace } from '~/generated/proto/leapmux/v1/workspace_pb'
 import type { WorkerInfo } from '~/lib/workerInfoCache'
@@ -34,12 +37,18 @@ export interface SidebarElementsOpts {
   selection: TabSelectionStore
   loadSections: () => Promise<void>
   onSelectWorkspace: (id: string) => void
-  onNewWorkspace: (sectionId: string | null) => void
+  /** Open the New workspace dialog, into `sectionId` and from `startPoint`. */
+  onNewWorkspace: (sectionId: string | null, startPoint: WorkspaceStartPoint) => void
   onRefreshWorkspaces: () => void
   onDeleteWorkspace: (deletedId: string, nextWorkspaceId: string | null) => void
   onConfirmDelete: (workspaceId: string) => Promise<boolean>
   onConfirmArchive: (workspaceId: string) => Promise<boolean>
+  onConfirmEmptyArchive: (count: number) => Promise<boolean>
   onPostArchiveWorkspace: (workspaceId: string) => void
+  /** Open the New section dialog for `sidebar`. */
+  onNewSection: (sidebar: Sidebar) => void
+  onRenameSection: (section: Section) => void
+  onDeleteSection: (section: Section) => void
   getCurrentTabContext: () => TabContext
   getMruAgentContext: () => Pick<TabContext, 'workingDir' | 'homeDir'>
   fileTreePath: string
@@ -63,6 +72,11 @@ export interface SidebarElementsOpts {
   activeTabReady: boolean
   // Worker section
   workers: Worker[]
+  /**
+   * Whether the desktop shell runs its own bundled sidecar. See
+   * `~/lib/workerLocality`.
+   */
+  localSolo: boolean
   workerInfoFn: (id: string) => WorkerInfo | null
   channelStatusFn: (id: string) => ChannelStatus
   onAddTunnel: (worker: Worker) => void
@@ -74,6 +88,8 @@ export interface SidebarElementsOpts {
   getTileOrderForWorkspace: (workspaceId: string) => readonly string[]
   /** Branch-menu callbacks, unbound. Each branch row binds them to its own ref. */
   branchActions?: BranchRefActions
+  /** Open a new agent / terminal at one of a workspace's checkouts. */
+  workspaceStartActions?: WorkspaceStartActions
 }
 
 interface SidebarDisplayOpts {

--- a/frontend/src/components/shell/SidebarElements.tsx
+++ b/frontend/src/components/shell/SidebarElements.tsx
@@ -1,11 +1,11 @@
 import type { Accessor, JSX } from 'solid-js'
 import type { mruAgentEditorDeps } from './mruAgentEditorDeps'
+import type { SectionActions } from './sectionUtils'
 import type { TabContext } from './tabContext'
 import type { useTerminalOperations } from './useTerminalOperations'
 import type { BranchRefActions } from '~/components/workspace/branchActions'
 import type { WorkspaceStartActions } from '~/components/workspace/workspaceStartActions'
 import type { WorkspaceStartPoint } from '~/components/workspace/workspaceStartPoint'
-import type { Section, Sidebar } from '~/generated/proto/leapmux/v1/section_pb'
 import type { Worker } from '~/generated/proto/leapmux/v1/worker_pb'
 import type { Workspace } from '~/generated/proto/leapmux/v1/workspace_pb'
 import type { WorkerInfo } from '~/lib/workerInfoCache'
@@ -45,10 +45,7 @@ export interface SidebarElementsOpts {
   onConfirmArchive: (workspaceId: string) => Promise<boolean>
   onConfirmEmptyArchive: (count: number) => Promise<boolean>
   onPostArchiveWorkspace: (workspaceId: string) => void
-  /** Open the New section dialog for `sidebar`. */
-  onNewSection: (sidebar: Sidebar) => void
-  onRenameSection: (section: Section) => void
-  onDeleteSection: (section: Section) => void
+  sectionActions: SectionActions
   getCurrentTabContext: () => TabContext
   getMruAgentContext: () => Pick<TabContext, 'workingDir' | 'homeDir'>
   fileTreePath: string
@@ -140,7 +137,7 @@ export function buildCommonSidebarProps(opts: SidebarElementsOpts, display?: Sid
   //
   // Only the DERIVED entries are written out: the display block (defaulted or
   // renamed), the three fields read off the current tab context, and the two
-  // handlers gated on the archived state. Later sources win, so these shadow
+  // handlers that depend on the archived state. Later sources win, so these shadow
   // `opts` where the names would collide -- none do today.
   //
   // The trade: five shell-internal fields (mruEditorDeps, getCurrentTabContext,

--- a/frontend/src/components/shell/TabBar.test.tsx
+++ b/frontend/src/components/shell/TabBar.test.tsx
@@ -128,7 +128,7 @@ vi.mock('~/components/common/DropdownMenu', async () => {
       return (
         <span>
           <span>{props.label}</span>
-          {props.shortcut ? <span>{props.shortcut}</span> : null}
+          {props.detail ? <span>{props.detail}</span> : null}
         </span>
       )
     },

--- a/frontend/src/components/shell/TileActionsMenu.tsx
+++ b/frontend/src/components/shell/TileActionsMenu.tsx
@@ -102,7 +102,7 @@ export const TileActionsMenu: Component<TileActionsMenuProps> = (props) => {
           >
             <DropdownMenuItemContent
               label={pop().label}
-              shortcut={getShortcutHintsText('app.toggleFloatingTab')}
+              detail={getShortcutHintsText('app.toggleFloatingTab')}
             />
           </button>
         )}
@@ -117,7 +117,7 @@ export const TileActionsMenu: Component<TileActionsMenuProps> = (props) => {
               <Show when={props.withIcons}><Icon icon={action.icon} size="sm" /></Show>
               <DropdownMenuItemContent
                 label={action.label}
-                shortcut={getShortcutHintsText(action.shortcutId)}
+                detail={getShortcutHintsText(action.shortcutId)}
               />
             </button>
           )}

--- a/frontend/src/components/shell/TileActionsMenu.tsx
+++ b/frontend/src/components/shell/TileActionsMenu.tsx
@@ -34,7 +34,7 @@ export interface SplitActionDef {
  * mapping. Both the dropdown menu (this file) and the inline IconButton row
  * (`Tile.tsx`) iterate over this so the labels can't drift independently.
  *
- * direction names the divider line: 'vertical' makes a `|` divider with two
+ * direction describes the divider line: 'vertical' makes a `|` divider with two
  * side-by-side panes (icon: Columns2); 'horizontal' makes a `-` divider with
  * two stacked panes (icon: Rows2).
  */

--- a/frontend/src/components/shell/UserMenuItems.test.tsx
+++ b/frontend/src/components/shell/UserMenuItems.test.tsx
@@ -47,10 +47,10 @@ vi.mock('~/api/platformBridge', async (importOriginal) => {
 })
 
 vi.mock('~/components/common/DropdownMenu', () => ({
-  DropdownMenuItemContent: (props: { label: string, shortcut?: string }) => (
+  DropdownMenuItemContent: (props: { label: string, detail?: string }) => (
     <span>
       <span>{props.label}</span>
-      {props.shortcut ? <span>{props.shortcut}</span> : null}
+      {props.detail ? <span>{props.detail}</span> : null}
     </span>
   ),
 }))

--- a/frontend/src/components/shell/UserMenuItems.tsx
+++ b/frontend/src/components/shell/UserMenuItems.tsx
@@ -54,7 +54,7 @@ export const UserMenuItems: Component = () => {
     <>
       <AppAboutMenuItem />
       <button role="menuitem" onClick={() => openPreferences()}>
-        <DropdownMenuItemContent label="Preferences..." shortcut={getShortcutHintsText('app.openPreferences')} />
+        <DropdownMenuItemContent label="Preferences..." detail={getShortcutHintsText('app.openPreferences')} />
       </button>
 
       {/*

--- a/frontend/src/components/shell/WorkspaceSectionMenu.test.tsx
+++ b/frontend/src/components/shell/WorkspaceSectionMenu.test.tsx
@@ -2,7 +2,7 @@ import type { Tab } from '~/stores/tab.types'
 import { create } from '@bufbuild/protobuf'
 import { fireEvent, render, screen, within } from '@solidjs/testing-library'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { isSectionFilterShown, resetWorkspaceListStateForTests, workspaceSortOrder } from '~/components/workspace/workspaceListState'
+import { isSectionFilterShown, resetWorkspaceListStateForTests, toggleSectionFilter, workspaceSortOrder } from '~/components/workspace/workspaceListState'
 import { gitModeStickyKey, rememberStickyGitMode } from '~/components/workspace/workspaceStartPoint'
 import { SectionSchema, SectionType, Sidebar } from '~/generated/proto/leapmux/v1/section_pb'
 import { TabType } from '~/generated/proto/leapmux/v1/workspace_pb'
@@ -14,7 +14,7 @@ import { WorkspaceSectionMenu } from './WorkspaceSectionMenu'
 
 /**
  * The REAL `DropdownMenu`. See `WorkspaceContextMenu.test.tsx` for why a mock
- * is worse than useless here: it drops `onToggle`, which is what gates this
+ * is worse than useless here: it drops `onToggle`, which is what controls this
  * menu's entire repository list.
  */
 
@@ -50,6 +50,11 @@ function renderMenu(overrides: Partial<Parameters<typeof WorkspaceSectionMenu>[0
     onCollapseAll: noop,
     onExpandAll: noop,
     onNewWorkspace: noop as Parameters<typeof WorkspaceSectionMenu>[0]['onNewWorkspace'],
+    // The UNFILTERED archive, which is what the two bulk items act on. The
+    // default follows `getWorkspaceIds` so a test that overrides one row list
+    // still describes a consistent section; the archive tests override it.
+    hasArchivedWorkspaces: () => true,
+    onToggleFilter: noop,
     onUnarchiveAll: noop,
     onEmptyArchive: noop,
     onNewSection: noop,
@@ -90,7 +95,7 @@ describe('workspaceSectionMenu', () => {
     resetWorkspaceListStateForTests()
   })
 
-  it('names the trigger after its section, so it is not an unnamed button', () => {
+  it('labels the trigger after its section, so it is not an unnamed button', () => {
     renderMenu()
     expect(screen.getByTestId(triggerId(IN_PROGRESS))).toHaveAccessibleName('In progress actions')
   })
@@ -110,14 +115,24 @@ describe('workspaceSectionMenu', () => {
     ])
   })
 
-  it('offers the filter toggle as a checkbox, reflecting whether the box is open', () => {
-    renderMenu()
+  // The menu REPORTS the toggle rather than performing it. The filter box lives
+  // in the section body, and this menu opens while the section is collapsed --
+  // where a hidden input takes no focus. The section def expands first, so it
+  // owns the write; the checkbox only mirrors the state.
+  it('reports the filter toggle and mirrors whether the box is open', () => {
+    const onToggleFilter = vi.fn()
+    renderMenu({ onToggleFilter })
     openMenu()
 
     const toggle = screen.getByTestId('sidebar-filter-workspaces')
     expect(toggle).toHaveAttribute('aria-checked', 'false')
     fireEvent.click(toggle)
-    expect(isSectionFilterShown(IN_PROGRESS.id)).toBe(true)
+    expect(onToggleFilter).toHaveBeenCalledOnce()
+    // It did NOT write the state itself.
+    expect(isSectionFilterShown(IN_PROGRESS.id)).toBe(false)
+
+    toggleSectionFilter(IN_PROGRESS.id)
+    expect(screen.getByTestId('sidebar-filter-workspaces')).toHaveAttribute('aria-checked', 'true')
   })
 
   describe('the Sort by submenu', () => {
@@ -293,12 +308,35 @@ describe('workspaceSectionMenu', () => {
     })
 
     it('hides the bulk operations while the archive is empty', () => {
-      renderMenu({ section: ARCHIVED, canCreate: false, getWorkspaceIds: () => [] })
+      renderMenu({
+        section: ARCHIVED,
+        canCreate: false,
+        getWorkspaceIds: () => [],
+        hasArchivedWorkspaces: () => false,
+      })
       openMenu(ARCHIVED)
 
       const items = itemsOf('sidebar-section-menu-workspaces_archived-popover')
       expect(items).not.toContain('Unarchive all')
       expect(items).not.toContain('Empty archive...')
+    })
+
+    // The gate reads the UNFILTERED archive, not the rows on screen. Reading
+    // the filtered list hid an archive full of workspaces behind a filter that
+    // matched none of them -- and, the other way round, offered an
+    // irreversible "Empty archive..." for fifty while the user could see one.
+    it('keeps the bulk operations while a filter hides every row', () => {
+      renderMenu({
+        section: ARCHIVED,
+        canCreate: false,
+        getWorkspaceIds: () => [],
+        hasArchivedWorkspaces: () => true,
+      })
+      openMenu(ARCHIVED)
+
+      const items = itemsOf('sidebar-section-menu-workspaces_archived-popover')
+      expect(items).toContain('Unarchive all')
+      expect(items).toContain('Empty archive...')
     })
 
     it('offers no rename or delete of the section itself', () => {

--- a/frontend/src/components/shell/WorkspaceSectionMenu.test.tsx
+++ b/frontend/src/components/shell/WorkspaceSectionMenu.test.tsx
@@ -1,0 +1,353 @@
+import type { Tab } from '~/stores/tab.types'
+import { create } from '@bufbuild/protobuf'
+import { fireEvent, render, screen, within } from '@solidjs/testing-library'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { isSectionFilterShown, resetWorkspaceListStateForTests, workspaceSortOrder } from '~/components/workspace/workspaceListState'
+import { gitModeStickyKey, rememberStickyGitMode } from '~/components/workspace/workspaceStartPoint'
+import { SectionSchema, SectionType, Sidebar } from '~/generated/proto/leapmux/v1/section_pb'
+import { TabType } from '~/generated/proto/leapmux/v1/workspace_pb'
+import { GitMode } from '~/hooks/useGitModeState'
+import { localStorageClearForTests, setStorageAccount } from '~/lib/browserStorage'
+import { repoKey } from '~/stores/repoGit'
+import { createRepoGitStore } from '~/stores/repoGit.store'
+import { WorkspaceSectionMenu } from './WorkspaceSectionMenu'
+
+/**
+ * The REAL `DropdownMenu`. See `WorkspaceContextMenu.test.tsx` for why a mock
+ * is worse than useless here: it drops `onToggle`, which is what gates this
+ * menu's entire repository list.
+ */
+
+function makeSection(name: string, sectionType: SectionType, sidebar = Sidebar.LEFT) {
+  return create(SectionSchema, { id: `sec-${sectionType}`, name, position: 'n', sectionType, sidebar })
+}
+
+const IN_PROGRESS = makeSection('In progress', SectionType.WORKSPACES_IN_PROGRESS)
+const ARCHIVED = makeSection('Archived', SectionType.WORKSPACES_ARCHIVED)
+const CUSTOM = makeSection('My Section', SectionType.WORKSPACES_CUSTOM)
+
+function tabsAndStore(toplevels: readonly string[], workerId = 'w1') {
+  const store = createRepoGitStore()
+  const tabs: Tab[] = toplevels.map((toplevel, i) => {
+    store.upsert(repoKey(workerId, toplevel), { workerId, toplevel, branch: 'main' })
+    return { id: `t${i}`, workspaceId: 'ws-1', type: TabType.AGENT, workerId, gitToplevel: toplevel } as Tab
+  })
+  return { store, tabs }
+}
+
+function noop() {}
+
+function renderMenu(overrides: Partial<Parameters<typeof WorkspaceSectionMenu>[0]> = {}) {
+  const { store, tabs } = tabsAndStore([])
+  const props = {
+    section: IN_PROGRESS,
+    canCreate: true,
+    getTabs: () => tabs,
+    getWorkspaceIds: () => ['ws-1'],
+    repoGitStore: store,
+    hasActiveWorkspace: () => false,
+    onRevealActiveWorkspace: noop,
+    onCollapseAll: noop,
+    onExpandAll: noop,
+    onNewWorkspace: noop as Parameters<typeof WorkspaceSectionMenu>[0]['onNewWorkspace'],
+    onUnarchiveAll: noop,
+    onEmptyArchive: noop,
+    onNewSection: noop,
+    onRenameSection: noop,
+    onDeleteSection: noop,
+    ...overrides,
+  }
+  render(() => <WorkspaceSectionMenu {...props} />)
+  return props
+}
+
+function triggerId(section: typeof IN_PROGRESS): string {
+  const slug = section === ARCHIVED
+    ? 'workspaces_archived'
+    : section === CUSTOM ? 'workspaces_custom' : 'workspaces_in_progress'
+  return `sidebar-section-menu-${slug}`
+}
+
+function openMenu(section = IN_PROGRESS) {
+  fireEvent.click(screen.getByTestId(triggerId(section)))
+}
+
+/** The item labels of one popover, in order. `hidden: true` — see the row menu's test. */
+function itemsOf(testId: string): string[] {
+  return within(screen.getByTestId(testId))
+    .queryAllByRole('menuitem', { hidden: true })
+    .map(el => el.textContent?.trim() ?? '')
+}
+
+function inProgressItems(): string[] {
+  return itemsOf('sidebar-section-menu-workspaces_in_progress-popover')
+}
+
+describe('workspaceSectionMenu', () => {
+  beforeEach(() => {
+    localStorageClearForTests()
+    setStorageAccount('u-1')
+    resetWorkspaceListStateForTests()
+  })
+
+  it('names the trigger after its section, so it is not an unnamed button', () => {
+    renderMenu()
+    expect(screen.getByTestId(triggerId(IN_PROGRESS))).toHaveAccessibleName('In progress actions')
+  })
+
+  it('offers the create item, the view items and the section CRUD, in that order', () => {
+    renderMenu()
+    openMenu()
+
+    // `Filter workspaces` is a `menuitemcheckbox` and not a `menuitem`, so it
+    // is asserted separately below; this is the command order.
+    expect(inProgressItems()).toEqual([
+      'New workspace...',
+      'Sort by',
+      'Collapse all',
+      'Expand all',
+      'New section...',
+    ])
+  })
+
+  it('offers the filter toggle as a checkbox, reflecting whether the box is open', () => {
+    renderMenu()
+    openMenu()
+
+    const toggle = screen.getByTestId('sidebar-filter-workspaces')
+    expect(toggle).toHaveAttribute('aria-checked', 'false')
+    fireEvent.click(toggle)
+    expect(isSectionFilterShown(IN_PROGRESS.id)).toBe(true)
+  })
+
+  describe('the Sort by submenu', () => {
+    it('mounts its items only once it is opened', () => {
+      // `DropdownMenu` renders children eagerly and the parent's keyboard
+      // navigation queries the whole subtree, so a closed submenu's items would
+      // be phantom stops for ArrowDown and type-ahead.
+      renderMenu()
+      openMenu()
+      expect(screen.queryByTestId('workspace-sort-key-name')).not.toBeInTheDocument()
+
+      fireEvent.click(screen.getByTestId('sidebar-sort-by'))
+      expect(screen.getByTestId('workspace-sort-key-name')).toBeInTheDocument()
+    })
+
+    it('carries the criterion and the order as two independent radio groups', () => {
+      renderMenu()
+      openMenu()
+      fireEvent.click(screen.getByTestId('sidebar-sort-by'))
+
+      const popover = screen.getByTestId('sidebar-sort-by-popover')
+      expect(within(popover).getAllByRole('group', { hidden: true })
+        .map(g => g.getAttribute('aria-label'))).toEqual(['Sort by', 'Order'])
+      expect(screen.getByTestId('workspace-sort-key-manual')).toHaveAttribute('aria-checked', 'true')
+    })
+
+    it('picks a criterion WITHOUT closing, so the order is still reachable', () => {
+      // The whole reason the submenu is `as="div"`: a `menu` popover dismisses
+      // on any click inside it.
+      renderMenu()
+      openMenu()
+      fireEvent.click(screen.getByTestId('sidebar-sort-by'))
+
+      fireEvent.click(screen.getByTestId('workspace-sort-key-name'))
+      expect(workspaceSortOrder().key).toBe('name')
+      expect(screen.getByTestId('workspace-sort-direction-desc')).toBeInTheDocument()
+
+      fireEvent.click(screen.getByTestId('workspace-sort-direction-desc'))
+      expect(workspaceSortOrder()).toEqual({ key: 'name', direction: 'desc' })
+    })
+
+    it('words the order radios for the criterion in force', () => {
+      renderMenu()
+      openMenu()
+      fireEvent.click(screen.getByTestId('sidebar-sort-by'))
+      fireEvent.click(screen.getByTestId('workspace-sort-key-created'))
+
+      expect(screen.getByTestId('workspace-sort-direction-desc').textContent).toContain('Newest first')
+    })
+  })
+
+  it('offers Reveal active workspace only while this section holds it', () => {
+    renderMenu({ hasActiveWorkspace: () => true })
+    openMenu()
+    expect(inProgressItems()).toContain('Reveal active workspace')
+  })
+
+  it('disables Collapse all and Expand all for an empty section', () => {
+    renderMenu({ getWorkspaceIds: () => [] })
+    openMenu()
+
+    const popover = screen.getByTestId('sidebar-section-menu-workspaces_in_progress-popover')
+    // `queryAllByRole` skips disabled items, so read the buttons directly.
+    const labels = [...popover.querySelectorAll('button')].map(b => `${b.textContent?.trim()}:${b.disabled}`)
+    expect(labels).toContain('Collapse all:true')
+    expect(labels).toContain('Expand all:true')
+  })
+
+  describe('the repository group', () => {
+    it('lists nothing until the menu is OPENED', () => {
+      // The gate is a memo, not a `<Show>`: a `<Show>` hides the DOM and keeps
+      // the subscriptions, so every section's menu would re-scan every tab on
+      // every reactive tick while closed.
+      const { store, tabs } = tabsAndStore(['/home/me/leapmux'])
+      renderMenu({ getTabs: () => tabs, repoGitStore: store })
+
+      expect(screen.queryByText('New workspace in')).not.toBeInTheDocument()
+
+      openMenu()
+      expect(screen.getByText('New workspace in')).toBeInTheDocument()
+    })
+
+    it('renders neither the group nor its header when there is no repository', () => {
+      renderMenu()
+      openMenu()
+      expect(screen.queryByText('New workspace in')).not.toBeInTheDocument()
+    })
+
+    it('offers one row per repository, and reports its start point', () => {
+      const { store, tabs } = tabsAndStore(['/home/me/leapmux', '/home/me/api'])
+      const onNewWorkspace = vi.fn()
+      renderMenu({ getTabs: () => tabs, repoGitStore: store, onNewWorkspace })
+      openMenu()
+
+      expect(inProgressItems()).toEqual(expect.arrayContaining(['leapmux', 'api']))
+
+      fireEvent.click(screen.getByText('leapmux'))
+      expect(onNewWorkspace).toHaveBeenCalledWith({
+        kind: 'repo',
+        workerId: 'w1',
+        gitToplevel: '/home/me/leapmux',
+        isWorktree: false,
+        currentBranch: 'main',
+      })
+    })
+
+    it('reports a bare directory start point for the plain New workspace item', () => {
+      const onNewWorkspace = vi.fn()
+      renderMenu({ onNewWorkspace })
+      openMenu()
+      fireEvent.click(screen.getByTestId('sidebar-new-workspace'))
+      expect(onNewWorkspace).toHaveBeenCalledWith({ kind: 'directory' })
+    })
+
+    it('shows the remembered git mode as the row detail, in the dialog vocabulary', () => {
+      const { store, tabs } = tabsAndStore(['/home/me/leapmux'])
+      rememberStickyGitMode(gitModeStickyKey('w1', '/home/me/leapmux'), GitMode.CreateWorktree)
+      renderMenu({ getTabs: () => tabs, repoGitStore: store })
+      openMenu()
+
+      expect(screen.getByRole('menuitem', { name: /leapmux/, hidden: true }).textContent)
+        .toContain('Create new worktree')
+    })
+
+    it('shows NO detail for a repository nothing is remembered for', () => {
+      // A row that says "Use current state" for a repository nobody has started
+      // a workspace in states a default as though it were a memory.
+      const { store, tabs } = tabsAndStore(['/home/me/leapmux'])
+      renderMenu({ getTabs: () => tabs, repoGitStore: store })
+      openMenu()
+
+      expect(screen.getByRole('menuitem', { name: /leapmux/, hidden: true }).textContent?.trim())
+        .toBe('leapmux')
+    })
+
+    it('omits a repository whose worker is offline', () => {
+      const { store, tabs } = tabsAndStore(['/home/me/leapmux'])
+      renderMenu({ getTabs: () => tabs, repoGitStore: store, isWorkerOnline: () => false })
+      openMenu()
+
+      expect(screen.queryByText('New workspace in')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('the archived section', () => {
+    it('offers no create item at all', () => {
+      // A workspace created into Archived is born read-only, which is why
+      // `canAddToSection` refuses it.
+      const { store, tabs } = tabsAndStore(['/home/me/leapmux'])
+      renderMenu({ section: ARCHIVED, canCreate: false, getTabs: () => tabs, repoGitStore: store })
+      openMenu(ARCHIVED)
+
+      const items = itemsOf('sidebar-section-menu-workspaces_archived-popover')
+      expect(items).not.toContain('New workspace...')
+      expect(screen.queryByText('New workspace in')).not.toBeInTheDocument()
+      // And the In-progress-only test id stays off it, or every Playwright
+      // lookup for it fails strict mode.
+      expect(screen.queryByTestId('sidebar-new-workspace')).not.toBeInTheDocument()
+    })
+
+    it('offers the bulk operations', () => {
+      renderMenu({ section: ARCHIVED, canCreate: false })
+      openMenu(ARCHIVED)
+
+      expect(itemsOf('sidebar-section-menu-workspaces_archived-popover')).toEqual([
+        'Sort by',
+        'Collapse all',
+        'Expand all',
+        'Unarchive all',
+        'Empty archive...',
+        'New section...',
+      ])
+    })
+
+    it('hides the bulk operations while the archive is empty', () => {
+      renderMenu({ section: ARCHIVED, canCreate: false, getWorkspaceIds: () => [] })
+      openMenu(ARCHIVED)
+
+      const items = itemsOf('sidebar-section-menu-workspaces_archived-popover')
+      expect(items).not.toContain('Unarchive all')
+      expect(items).not.toContain('Empty archive...')
+    })
+
+    it('offers no rename or delete of the section itself', () => {
+      // The hub refuses both for a built-in section, so showing them would be
+      // an item that always fails.
+      renderMenu({ section: ARCHIVED, canCreate: false })
+      openMenu(ARCHIVED)
+
+      const items = itemsOf('sidebar-section-menu-workspaces_archived-popover')
+      expect(items).not.toContain('Rename section...')
+      expect(items).not.toContain('Delete section...')
+    })
+  })
+
+  describe('a custom section', () => {
+    it('offers rename and delete of the section itself', () => {
+      renderMenu({ section: CUSTOM })
+      openMenu(CUSTOM)
+
+      const items = itemsOf('sidebar-section-menu-workspaces_custom-popover')
+      expect(items).toContain('Rename section...')
+      expect(items).toContain('Delete section...')
+    })
+
+    it('reports each section action', () => {
+      const onNewSection = vi.fn()
+      const onRenameSection = vi.fn()
+      const onDeleteSection = vi.fn()
+      renderMenu({ section: CUSTOM, onNewSection, onRenameSection, onDeleteSection })
+      openMenu(CUSTOM)
+
+      fireEvent.click(screen.getByText('New section...'))
+      fireEvent.click(screen.getByText('Rename section...'))
+      fireEvent.click(screen.getByText('Delete section...'))
+      expect(onNewSection).toHaveBeenCalledOnce()
+      expect(onRenameSection).toHaveBeenCalledOnce()
+      expect(onDeleteSection).toHaveBeenCalledOnce()
+    })
+  })
+
+  it('reports the two bulk view actions', () => {
+    const onCollapseAll = vi.fn()
+    const onExpandAll = vi.fn()
+    renderMenu({ onCollapseAll, onExpandAll })
+    openMenu()
+
+    fireEvent.click(screen.getByText('Collapse all'))
+    fireEvent.click(screen.getByText('Expand all'))
+    expect(onCollapseAll).toHaveBeenCalledOnce()
+    expect(onExpandAll).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/components/shell/WorkspaceSectionMenu.tsx
+++ b/frontend/src/components/shell/WorkspaceSectionMenu.tsx
@@ -12,10 +12,9 @@ import { listRepoStartPoints } from '~/components/workspace/repoStartPoints'
 import {
   isSectionFilterShown,
   setWorkspaceSortOrder,
-  toggleSectionFilter,
   workspaceSortOrder,
 } from '~/components/workspace/workspaceListState'
-import { readStickyGitMode, startPointDialogSetup } from '~/components/workspace/workspaceStartPoint'
+import { gitModeStickyKey, readStickyGitMode } from '~/components/workspace/workspaceStartPoint'
 import { SectionType } from '~/generated/proto/leapmux/v1/section_pb'
 import { GIT_MODE_LABELS } from '~/hooks/useGitModeState'
 import { getShortcutHintsText } from '~/lib/shortcuts/display'
@@ -53,7 +52,18 @@ export interface WorkspaceSectionMenuProps {
   onRevealActiveWorkspace: () => void
   onCollapseAll: () => void
   onExpandAll: () => void
+  /** Show or hide this section's filter box, expanding the section to show it. */
+  onToggleFilter: () => void
   onNewWorkspace: (startPoint: WorkspaceStartPoint) => void
+  /**
+   * Whether the ARCHIVE holds anything, unfiltered.
+   *
+   * Deliberately not `getWorkspaceIds().length`: that is the filtered view, and
+   * the two operations below act on the whole archive. Gating them on the view
+   * hid them while a filter matched nothing, and offered "Empty archive..." --
+   * which cannot be undone -- while the user could see one row of fifty.
+   */
+  hasArchivedWorkspaces: () => boolean
   /** Archived only: move every archived workspace back to In progress. */
   onUnarchiveAll: () => void
   /** Archived only: delete every archived workspace, after one confirm. */
@@ -76,7 +86,7 @@ export interface WorkspaceSectionMenuProps {
  * The trigger is `moreHorizontalTrigger`, NOT `rowContextMenuTrigger`: the
  * latter adds the `menuTrigger` class, whose `opacity: 0` reveal depends on
  * sitting inside a hovered row's `sidebarActions` box. A section header is not
- * a row, which is the case that helper's own comment names.
+ * a row, which is the case that helper's own comment describes.
  */
 export const WorkspaceSectionMenu: Component<WorkspaceSectionMenuProps> = (props) => {
   const [menuOpen, setMenuOpen] = createSignal(false)
@@ -90,7 +100,7 @@ export const WorkspaceSectionMenu: Component<WorkspaceSectionMenuProps> = (props
   /**
    * The repositories this section works on.
    *
-   * Gated on `menuOpen()`, and it must be the MEMO rather than a `<Show>`
+   * `menuOpen()` restricts it, and it must be the MEMO rather than a `<Show>`
    * around the rows: a `<Show>` hides the DOM and keeps the subscriptions, so
    * every section's menu would re-scan every tab on every reactive tick while
    * closed. `FileActionsMenu` documents the same trap for its info rows.
@@ -98,23 +108,57 @@ export const WorkspaceSectionMenu: Component<WorkspaceSectionMenuProps> = (props
   const repos = createMemo(() => {
     if (!menuOpen() || !props.canCreate)
       return []
-    return listRepoStartPoints(props.getTabs(), props.repoGitStore, {
+    const rows = listRepoStartPoints(props.getTabs(), props.repoGitStore, {
       workerInfoFn: props.workerInfoFn,
       isWorkerOnline: props.isWorkerOnline,
       limit: MAX_REPO_ROWS,
     })
+    // The remembered mode is resolved HERE, inside the gate, so each row is a
+    // pure projection of one snapshot: the label and the note come from the
+    // same read, and no storage access happens while a row renders.
+    //
+    // `detail` is the stored mode's own label, verbatim from the table the
+    // dialog's radios read -- a second vocabulary here would be exactly the
+    // duplication that table exists to remove. Undefined when nothing is
+    // remembered, rather than a placeholder: a row that reads "Use current
+    // state" for a repository nobody has started a workspace in states a
+    // default as though it were a memory. It must also never read "Manual",
+    // which the Sort by submenu binds to a sort key two items below.
+    return rows.map((row) => {
+      const sp = row.startPoint
+      const mode = readStickyGitMode(gitModeStickyKey(sp.workerId, sp.gitToplevel))
+      return { ...row, detail: mode === undefined ? undefined : GIT_MODE_LABELS[mode] }
+    })
   })
 
-  const hasWorkspaces = () => props.getWorkspaceIds().length > 0
+  /**
+   * Whether this section shows any row.
+   *
+   * A memo, because three items read it and `DropdownMenu` renders its children
+   * eagerly -- so this would otherwise run the row projection three times per
+   * tick in every section's menu, open or closed. `menuOpen()` deliberately
+   * does NOT restrict it: `disabled` describes the action, not the menu, and a
+   * check on the menu state would disable the second item the moment a click on
+   * the first closed the popover. The projection itself is memoized per section
+   * upstream, so one read costs a map lookup.
+   *
+   * It answers about the VISIBLE rows, which is what Collapse all and Expand
+   * all act on. The archive operations below ask a different question, because
+   * they act on the whole archive.
+   */
+  const hasWorkspaces = createMemo(() => props.getWorkspaceIds().length > 0)
 
   return (
     <DropdownMenu
       onToggle={setMenuOpen}
       data-testid={`sidebar-section-menu-${sectionTypeTestId(props.section.sectionType)}-popover`}
       aria-label={`${props.section.name} actions`}
+      // `title` is a GETTER. The section name is live now, and reading it
+      // eagerly would rebuild the options object -- and with it the trigger
+      // element -- on every rename, taking any open popover with it.
       trigger={moreHorizontalTrigger({
         'data-testid': `sidebar-section-menu-${sectionTypeTestId(props.section.sectionType)}`,
-        'title': `${props.section.name} actions`,
+        get 'title'() { return `${props.section.name} actions` },
       })}
     >
       <Show when={props.canCreate}>
@@ -152,15 +196,7 @@ export const WorkspaceSectionMenu: Component<WorkspaceSectionMenuProps> = (props
                   data-testid="sidebar-new-workspace-repo"
                   onClick={() => props.onNewWorkspace(repo.startPoint)}
                 >
-                  <DropdownMenuItemContent
-                    label={repo.label}
-                    // The stored mode's own label, verbatim from the table the
-                    // dialog's radios read. A second vocabulary here would be
-                    // exactly the duplication that table exists to remove --
-                    // and it must not read "Manual", which the Sort by submenu
-                    // binds to a sort key two items below.
-                    detail={detailForRepo(repo.startPoint)}
-                  />
+                  <DropdownMenuItemContent label={repo.label} detail={repo.detail} />
                 </button>
               )}
             </For>
@@ -173,12 +209,17 @@ export const WorkspaceSectionMenu: Component<WorkspaceSectionMenuProps> = (props
         <hr />
       </Show>
 
+      {/* Through a prop, not `toggleSectionFilter` directly: the box lives in
+          the section BODY, and this menu opens while the section is collapsed
+          -- where a hidden input cannot take focus and the checkbox would
+          report itself checked for a control nobody can see. The section def
+          expands first, the same rule "Reveal active workspace" follows. */}
       <DropdownMenuCheckableItem
         kind="checkbox"
         label="Filter workspaces"
         checked={isSectionFilterShown(props.section.id)}
         data-testid="sidebar-filter-workspaces"
-        onSelect={() => toggleSectionFilter(props.section.id)}
+        onSelect={() => props.onToggleFilter()}
       />
 
       {/* The submenu is `as="div"`: it holds TWO independent radio groups, and
@@ -241,7 +282,7 @@ export const WorkspaceSectionMenu: Component<WorkspaceSectionMenuProps> = (props
       {/* Hidden when the archive is empty: "Unarchive all" and "Empty
           archive..." on nothing are two items that do nothing, and the second
           one asks for a confirmation first. */}
-      <Show when={isArchived() && hasWorkspaces()}>
+      <Show when={isArchived() && props.hasArchivedWorkspaces()}>
         <hr />
         <button type="button" role="menuitem" onClick={() => props.onUnarchiveAll()}>
           Unarchive all
@@ -265,17 +306,4 @@ export const WorkspaceSectionMenu: Component<WorkspaceSectionMenuProps> = (props
       </Show>
     </DropdownMenu>
   )
-}
-
-/**
- * The row's right-hand note: the git mode this repository was last started
- * with, or nothing at all when none is remembered.
- *
- * Undefined rather than a placeholder. A row that says "Use current state" for
- * a repository nobody has started a workspace in states a default as though it
- * were a memory.
- */
-function detailForRepo(startPoint: WorkspaceStartPoint): string | undefined {
-  const mode = readStickyGitMode(startPointDialogSetup(startPoint).stickyKey)
-  return mode === undefined ? undefined : GIT_MODE_LABELS[mode]
 }

--- a/frontend/src/components/shell/WorkspaceSectionMenu.tsx
+++ b/frontend/src/components/shell/WorkspaceSectionMenu.tsx
@@ -1,0 +1,281 @@
+import type { Component } from 'solid-js'
+import type { WorkspaceStartPoint } from '~/components/workspace/workspaceStartPoint'
+import type { Section } from '~/generated/proto/leapmux/v1/section_pb'
+import type { WorkerInfo } from '~/lib/workerInfoCache'
+import type { RepoGitStore } from '~/stores/repoGit'
+import type { Tab } from '~/stores/tab.types'
+import { createMemo, createSignal, For, Show } from 'solid-js'
+import { DropdownMenu, DropdownMenuCheckableItem, DropdownMenuItemContent } from '~/components/common/DropdownMenu'
+import { moreHorizontalTrigger } from '~/components/common/moreHorizontalTrigger'
+import { SubMenu } from '~/components/common/SubMenu'
+import { listRepoStartPoints } from '~/components/workspace/repoStartPoints'
+import {
+  isSectionFilterShown,
+  setWorkspaceSortOrder,
+  toggleSectionFilter,
+  workspaceSortOrder,
+} from '~/components/workspace/workspaceListState'
+import { readStickyGitMode, startPointDialogSetup } from '~/components/workspace/workspaceStartPoint'
+import { SectionType } from '~/generated/proto/leapmux/v1/section_pb'
+import { GIT_MODE_LABELS } from '~/hooks/useGitModeState'
+import { getShortcutHintsText } from '~/lib/shortcuts/display'
+import {
+  sortDirectionLabel,
+  sortKeyLabel,
+  WORKSPACE_SORT_DIRECTIONS,
+  WORKSPACE_SORT_KEYS,
+} from '~/lib/workspaceSort'
+import { dangerMenuItem, menuSectionHeader } from '~/styles/shared.css'
+import { sectionTypeTestId } from './sectionUtils'
+
+/**
+ * How many repositories the "New workspace in" group offers.
+ *
+ * A cap rather than the whole list: the group is a shortcut past the directory
+ * picker, and a menu longer than the screen is not a shortcut. The dialog's own
+ * directory tree reaches everything else.
+ */
+const MAX_REPO_ROWS = 8
+
+export interface WorkspaceSectionMenuProps {
+  section: Section
+  /** Whether a workspace may be created into this section. */
+  canCreate: boolean
+  /** Every tab of every workspace this section holds. */
+  getTabs: () => Tab[]
+  /** The workspaces this section holds, in the order the rows are drawn. */
+  getWorkspaceIds: () => string[]
+  repoGitStore: RepoGitStore
+  workerInfoFn?: (id: string) => WorkerInfo | null
+  isWorkerOnline?: (workerId: string) => boolean
+  /** Whether the active workspace is one of this section's. */
+  hasActiveWorkspace: () => boolean
+  onRevealActiveWorkspace: () => void
+  onCollapseAll: () => void
+  onExpandAll: () => void
+  onNewWorkspace: (startPoint: WorkspaceStartPoint) => void
+  /** Archived only: move every archived workspace back to In progress. */
+  onUnarchiveAll: () => void
+  /** Archived only: delete every archived workspace, after one confirm. */
+  onEmptyArchive: () => void
+  onNewSection: () => void
+  onRenameSection: () => void
+  onDeleteSection: () => void
+}
+
+/**
+ * The section header's menu, replacing the `+` that only opened the New
+ * workspace dialog.
+ *
+ * Three things it fixes. `SectionService`'s create, rename and delete were
+ * implemented and tested server-side with no UI at all. The dialog re-asked
+ * which worker and which directory for a repository the section already works
+ * on. And Archived had no header action whatsoever, so its bulk operations had
+ * nowhere to live.
+ *
+ * The trigger is `moreHorizontalTrigger`, NOT `rowContextMenuTrigger`: the
+ * latter adds the `menuTrigger` class, whose `opacity: 0` reveal depends on
+ * sitting inside a hovered row's `sidebarActions` box. A section header is not
+ * a row, which is the case that helper's own comment names.
+ */
+export const WorkspaceSectionMenu: Component<WorkspaceSectionMenuProps> = (props) => {
+  const [menuOpen, setMenuOpen] = createSignal(false)
+
+  const isArchived = () => props.section.sectionType === SectionType.WORKSPACES_ARCHIVED
+  // The hub refuses a rename or a delete of a built-in section, so the two
+  // items are hidden rather than shown and refused. That refusal is the real
+  // enforcement; this is the second layer over it.
+  const isCustom = () => props.section.sectionType === SectionType.WORKSPACES_CUSTOM
+
+  /**
+   * The repositories this section works on.
+   *
+   * Gated on `menuOpen()`, and it must be the MEMO rather than a `<Show>`
+   * around the rows: a `<Show>` hides the DOM and keeps the subscriptions, so
+   * every section's menu would re-scan every tab on every reactive tick while
+   * closed. `FileActionsMenu` documents the same trap for its info rows.
+   */
+  const repos = createMemo(() => {
+    if (!menuOpen() || !props.canCreate)
+      return []
+    return listRepoStartPoints(props.getTabs(), props.repoGitStore, {
+      workerInfoFn: props.workerInfoFn,
+      isWorkerOnline: props.isWorkerOnline,
+      limit: MAX_REPO_ROWS,
+    })
+  })
+
+  const hasWorkspaces = () => props.getWorkspaceIds().length > 0
+
+  return (
+    <DropdownMenu
+      onToggle={setMenuOpen}
+      data-testid={`sidebar-section-menu-${sectionTypeTestId(props.section.sectionType)}-popover`}
+      aria-label={`${props.section.name} actions`}
+      trigger={moreHorizontalTrigger({
+        'data-testid': `sidebar-section-menu-${sectionTypeTestId(props.section.sectionType)}`,
+        'title': `${props.section.name} actions`,
+      })}
+    >
+      <Show when={props.canCreate}>
+        <button
+          type="button"
+          role="menuitem"
+          // Kept on the ITEM, and still only on In progress. `DropdownMenu`
+          // renders children eagerly into the DOM, so an unconditional test id
+          // would put one node per workspace section in the document and every
+          // Playwright lookup would fail strict mode.
+          data-testid={props.section.sectionType === SectionType.WORKSPACES_IN_PROGRESS ? 'sidebar-new-workspace' : undefined}
+          onClick={() => props.onNewWorkspace({ kind: 'directory' })}
+        >
+          <DropdownMenuItemContent
+            label="New workspace..."
+            detail={getShortcutHintsText('app.newWorkspaceDialog')}
+          />
+        </button>
+
+        {/* The group and its header disappear together when there is no
+            repository to offer. An empty group header, or a separator over
+            nothing, is a menu describing a list that is not there. */}
+        <Show when={repos().length > 0}>
+          <div role="group" aria-label="New workspace in">
+            <div class={menuSectionHeader} aria-hidden="true">New workspace in</div>
+            <For each={repos()}>
+              {repo => (
+                <button
+                  type="button"
+                  role="menuitem"
+                  // One shared test id, not one per repository: the key joins
+                  // a worker id and a path with a control byte, which is not
+                  // something a CSS selector can carry. Scoped to this
+                  // section's popover, `.first()` is unambiguous.
+                  data-testid="sidebar-new-workspace-repo"
+                  onClick={() => props.onNewWorkspace(repo.startPoint)}
+                >
+                  <DropdownMenuItemContent
+                    label={repo.label}
+                    // The stored mode's own label, verbatim from the table the
+                    // dialog's radios read. A second vocabulary here would be
+                    // exactly the duplication that table exists to remove --
+                    // and it must not read "Manual", which the Sort by submenu
+                    // binds to a sort key two items below.
+                    detail={detailForRepo(repo.startPoint)}
+                  />
+                </button>
+              )}
+            </For>
+          </div>
+        </Show>
+        {/* RESERVED: the future "Clone repository..." and "Create empty
+            repository..." items land here, after their own <hr/>. The rule is
+            that the <hr/> arrives WITH the first item -- a trailing rule over
+            nothing is a bug, which is why the group above carries its own. */}
+        <hr />
+      </Show>
+
+      <DropdownMenuCheckableItem
+        kind="checkbox"
+        label="Filter workspaces"
+        checked={isSectionFilterShown(props.section.id)}
+        data-testid="sidebar-filter-workspaces"
+        onSelect={() => toggleSectionFilter(props.section.id)}
+      />
+
+      {/* The submenu is `as="div"`: it holds TWO independent radio groups, and
+          a `menu` popover dismisses on any click inside it -- so picking a
+          criterion would close the panel before the user reached the order.
+          `FilesSortMenu` is the working precedent and states the same reason.
+          `as="div"` is also why the `role="menu"` / `role="group"` scaffolding
+          below is written out by hand. */}
+      <SubMenu
+        label="Sort by"
+        as="div"
+        data-testid="sidebar-sort-by"
+        popoverTestId="sidebar-sort-by-popover"
+      >
+        <div role="menu" aria-label="Sort workspaces">
+          <div role="group" aria-label="Sort by">
+            <div class={menuSectionHeader} aria-hidden="true">Sort by</div>
+            <For each={WORKSPACE_SORT_KEYS}>
+              {key => (
+                <DropdownMenuCheckableItem
+                  kind="radio"
+                  label={sortKeyLabel(key)}
+                  checked={workspaceSortOrder().key === key}
+                  data-testid={`workspace-sort-key-${key}`}
+                  onSelect={() => setWorkspaceSortOrder({ ...workspaceSortOrder(), key })}
+                />
+              )}
+            </For>
+          </div>
+          <hr />
+          <div role="group" aria-label="Order">
+            <div class={menuSectionHeader} aria-hidden="true">Order</div>
+            <For each={WORKSPACE_SORT_DIRECTIONS}>
+              {direction => (
+                <DropdownMenuCheckableItem
+                  kind="radio"
+                  label={sortDirectionLabel(workspaceSortOrder().key, direction)}
+                  checked={workspaceSortOrder().direction === direction}
+                  data-testid={`workspace-sort-direction-${direction}`}
+                  onSelect={() => setWorkspaceSortOrder({ ...workspaceSortOrder(), direction })}
+                />
+              )}
+            </For>
+          </div>
+        </div>
+      </SubMenu>
+
+      <button type="button" role="menuitem" disabled={!hasWorkspaces()} onClick={() => props.onCollapseAll()}>
+        Collapse all
+      </button>
+      <button type="button" role="menuitem" disabled={!hasWorkspaces()} onClick={() => props.onExpandAll()}>
+        Expand all
+      </button>
+      <Show when={props.hasActiveWorkspace()}>
+        <button type="button" role="menuitem" onClick={() => props.onRevealActiveWorkspace()}>
+          Reveal active workspace
+        </button>
+      </Show>
+
+      {/* Hidden when the archive is empty: "Unarchive all" and "Empty
+          archive..." on nothing are two items that do nothing, and the second
+          one asks for a confirmation first. */}
+      <Show when={isArchived() && hasWorkspaces()}>
+        <hr />
+        <button type="button" role="menuitem" onClick={() => props.onUnarchiveAll()}>
+          Unarchive all
+        </button>
+        <button type="button" role="menuitem" class={dangerMenuItem} onClick={() => props.onEmptyArchive()}>
+          Empty archive...
+        </button>
+      </Show>
+
+      <hr />
+      <button type="button" role="menuitem" data-testid="sidebar-new-section" onClick={() => props.onNewSection()}>
+        New section...
+      </button>
+      <Show when={isCustom()}>
+        <button type="button" role="menuitem" onClick={() => props.onRenameSection()}>
+          Rename section...
+        </button>
+        <button type="button" role="menuitem" class={dangerMenuItem} onClick={() => props.onDeleteSection()}>
+          Delete section...
+        </button>
+      </Show>
+    </DropdownMenu>
+  )
+}
+
+/**
+ * The row's right-hand note: the git mode this repository was last started
+ * with, or nothing at all when none is remembered.
+ *
+ * Undefined rather than a placeholder. A row that says "Use current state" for
+ * a repository nobody has started a workspace in states a default as though it
+ * were a memory.
+ */
+function detailForRepo(startPoint: WorkspaceStartPoint): string | undefined {
+  const mode = readStickyGitMode(startPointDialogSetup(startPoint).stickyKey)
+  return mode === undefined ? undefined : GIT_MODE_LABELS[mode]
+}

--- a/frontend/src/components/shell/buildSectionDef.tsx
+++ b/frontend/src/components/shell/buildSectionDef.tsx
@@ -3,7 +3,9 @@ import type { SidebarSectionDef } from './CollapsibleSidebar'
 import type { WorkspaceOperations } from './useWorkspaceOperations'
 import type { FilesSectionHandle } from '~/components/tree/FilesSection'
 import type { BranchRefActions } from '~/components/workspace/branchActions'
-import type { Section } from '~/generated/proto/leapmux/v1/section_pb'
+import type { WorkspaceStartActions } from '~/components/workspace/workspaceStartActions'
+import type { WorkspaceStartPoint } from '~/components/workspace/workspaceStartPoint'
+import type { Section, Sidebar } from '~/generated/proto/leapmux/v1/section_pb'
 import type { Worker } from '~/generated/proto/leapmux/v1/worker_pb'
 import type { Workspace } from '~/generated/proto/leapmux/v1/workspace_pb'
 import type { WorkerInfo } from '~/lib/workerInfoCache'
@@ -22,17 +24,20 @@ import { IconButton } from '~/components/common/IconButton'
 import { TodoList } from '~/components/todo/TodoList'
 import { FilesSection, FilesSectionHeaderActions } from '~/components/tree/FilesSection'
 import { WorkerSectionContent } from '~/components/workers/WorkerSectionContent'
+import { setWorkspacesExpanded } from '~/components/workspace/expandedWorkspaces'
+import { revealWorkspaceRow } from '~/components/workspace/revealWorkspaceRow'
 import { emptySection as emptySectionStyle } from '~/components/workspace/workspaceList.css'
 import { WorkspaceSectionContent } from '~/components/workspace/WorkspaceSectionContent'
 import { SectionType } from '~/generated/proto/leapmux/v1/section_pb'
 import { flavorFromOs } from '~/lib/paths'
-import { shortcutHint } from '~/lib/shortcuts/display'
 import { isWorkerKnownOnline } from '~/lib/workerLiveness'
+import { isLocalWorker } from '~/lib/workerLocality'
 import { countActiveBackgroundTasks } from '~/stores/chatBackgroundTasks'
 import { todoProgress } from '~/stores/chatTodos'
 import { focusedRepoKeyFromTab, gitStatusProbePath } from '~/stores/repoGit'
 import * as csStyles from './CollapsibleSidebar.css'
 import { getSectionIcon, isWorkspaceSection, sectionTypeTestId } from './sectionUtils'
+import { WorkspaceSectionMenu } from './WorkspaceSectionMenu'
 
 /**
  * All dependencies needed to build a `SidebarSectionDef` for any section type.
@@ -46,8 +51,17 @@ export interface SectionDefContext {
   wsOps: WorkspaceOperations
   getWorkspacesForGroup: (sectionId: string) => Workspace[]
   activeWorkspaceId: string | null
-  onNewWorkspace: (sectionId: string | null) => void
+  /** Open the New workspace dialog, into `sectionId` and from `startPoint`. */
+  onNewWorkspace: (sectionId: string | null, startPoint: WorkspaceStartPoint) => void
   onSelectWorkspace: (id: string) => void
+  /** Expand a collapsed section, so a revealed row has a box to scroll into. */
+  expandSection?: (sectionId: string) => void
+  /** Open the New section dialog for `sidebar`. */
+  onNewSection: (sidebar: Sidebar) => void
+  onRenameSection: (section: Section) => void
+  onDeleteSection: (section: Section) => void
+  /** Open a new agent / terminal at one of a workspace's checkouts. */
+  workspaceStartActions?: WorkspaceStartActions
   view?: TabView
   selection?: TabSelectionStore
   onTabClick?: (type: number, id: string) => void
@@ -93,6 +107,12 @@ export interface SectionDefContext {
 
   // Workers section
   workers: Worker[]
+  /**
+   * Whether the desktop shell runs its own bundled sidecar. Half of the
+   * "is this worker local" test; the other half is the worker's own
+   * `autoRegistered` flag. See `~/lib/workerLocality`.
+   */
+  localSolo: boolean
   workerInfoFn: (id: string) => WorkerInfo | null
   channelStatusFn: (id: string) => ChannelStatus
   onAddTunnel: (worker: Worker) => void
@@ -115,6 +135,9 @@ export function buildSectionDef(
   const sectionId = section.id
 
   if (isWorkspaceSection(sectionType)) {
+    // The workspaces this section holds, for every item that acts on the whole
+    // section: the repository list, Collapse/Expand all, and Reveal.
+    const workspaceIds = () => ctx.getWorkspacesForGroup(sectionId).map(w => w.id)
     return {
       id: sectionId,
       title: section.name,
@@ -123,30 +146,46 @@ export function buildSectionDef(
       defaultOpen: sectionType !== SectionType.WORKSPACES_ARCHIVED,
       collapsible: true,
       draggable: true,
-      // `undefined`, never `() => undefined`: the `<Show>` in
-      // CollapsibleSidebar tests the FACTORY, so a factory that returns
-      // nothing is still truthy and renders an empty actions box.
-      headerActions: ctx.wsOps.canAddToSection(section)
-        ? () => (
-            <IconButton
-              icon={Plus}
-              iconSize="sm"
-              size="md"
-              title={shortcutHint(`New workspace in ${section.name}`, 'app.newWorkspaceDialog')}
-              data-testid={sectionType === SectionType.WORKSPACES_IN_PROGRESS ? 'sidebar-new-workspace' : undefined}
-              onClick={(e) => {
-                e.stopPropagation()
-                e.preventDefault()
-                ctx.onNewWorkspace(sectionId)
-              }}
-            />
-          )
-        : undefined,
+      // A MENU, not the `+` it replaces. Archived gains a header action it
+      // never had: `canAddToSection` refuses it (a workspace created there
+      // would be born read-only), so the old `+` was absent and the bulk
+      // archive operations and the section CRUD had nowhere to live.
+      headerActions: () => (
+        <WorkspaceSectionMenu
+          section={section}
+          canCreate={ctx.wsOps.canAddToSection(section)}
+          getTabs={() => workspaceIds().flatMap(id => ctx.view?.forWorkspace(id) ?? [])}
+          getWorkspaceIds={workspaceIds}
+          repoGitStore={ctx.gitStatusStore}
+          workerInfoFn={ctx.workerInfoFn}
+          isWorkerOnline={workerId => isWorkerKnownOnline(ctx.workers, workerId)}
+          hasActiveWorkspace={() => {
+            const active = ctx.activeWorkspaceId
+            return active !== null && workspaceIds().includes(active)
+          }}
+          onRevealActiveWorkspace={() => {
+            const active = ctx.activeWorkspaceId
+            if (!active)
+              return
+            ctx.expandSection?.(sectionId)
+            revealWorkspaceRow(active)
+          }}
+          onCollapseAll={() => setWorkspacesExpanded(workspaceIds(), false)}
+          onExpandAll={() => setWorkspacesExpanded(workspaceIds(), true)}
+          onNewWorkspace={startPoint => ctx.onNewWorkspace(sectionId, startPoint)}
+          onUnarchiveAll={() => void ctx.wsOps.unarchiveAll()}
+          onEmptyArchive={() => void ctx.wsOps.emptyArchive()}
+          onNewSection={() => ctx.onNewSection(section.sidebar)}
+          onRenameSection={() => ctx.onRenameSection(section)}
+          onDeleteSection={() => ctx.onDeleteSection(section)}
+        />
+      ),
       testId: `section-header-${sectionTypeTestId(sectionType)}`,
       content: () => (
         <WorkspaceSectionContent
           workspaces={ctx.getWorkspacesForGroup(sectionId)}
           sectionId={sectionId}
+          sectionName={section.name}
           activeWorkspaceId={ctx.activeWorkspaceId}
           sections={ctx.sectionStore.state.sections}
           onSelect={ctx.onSelectWorkspace}
@@ -169,6 +208,11 @@ export function buildSectionDef(
           tabItemOps={ctx.tabItemOps}
           workerInfoFn={ctx.workerInfoFn}
           isWorkerKnownOnline={workerId => isWorkerKnownOnline(ctx.workers, workerId)}
+          // Derived here, beside the liveness predicate and exactly the same
+          // way: one line off `ctx.workers` and one flag, rather than a prop
+          // threaded down the whole sidebar chain.
+          isLocalWorkerFn={workerId => isLocalWorker(ctx.workers, workerId, ctx.localSolo)}
+          startActions={ctx.workspaceStartActions}
           branchActions={ctx.branchActions}
           repoGitStore={ctx.gitStatusStore}
         />

--- a/frontend/src/components/shell/buildSectionDef.tsx
+++ b/frontend/src/components/shell/buildSectionDef.tsx
@@ -1,11 +1,12 @@
 import type { Accessor } from 'solid-js'
 import type { SidebarSectionDef } from './CollapsibleSidebar'
+import type { SectionActions } from './sectionUtils'
 import type { WorkspaceOperations } from './useWorkspaceOperations'
 import type { FilesSectionHandle } from '~/components/tree/FilesSection'
 import type { BranchRefActions } from '~/components/workspace/branchActions'
 import type { WorkspaceStartActions } from '~/components/workspace/workspaceStartActions'
 import type { WorkspaceStartPoint } from '~/components/workspace/workspaceStartPoint'
-import type { Section, Sidebar } from '~/generated/proto/leapmux/v1/section_pb'
+import type { Section } from '~/generated/proto/leapmux/v1/section_pb'
 import type { Worker } from '~/generated/proto/leapmux/v1/worker_pb'
 import type { Workspace } from '~/generated/proto/leapmux/v1/workspace_pb'
 import type { WorkerInfo } from '~/lib/workerInfoCache'
@@ -27,6 +28,7 @@ import { WorkerSectionContent } from '~/components/workers/WorkerSectionContent'
 import { setWorkspacesExpanded } from '~/components/workspace/expandedWorkspaces'
 import { revealWorkspaceRow } from '~/components/workspace/revealWorkspaceRow'
 import { emptySection as emptySectionStyle } from '~/components/workspace/workspaceList.css'
+import { isSectionFilterShown, toggleSectionFilter } from '~/components/workspace/workspaceListState'
 import { WorkspaceSectionContent } from '~/components/workspace/WorkspaceSectionContent'
 import { SectionType } from '~/generated/proto/leapmux/v1/section_pb'
 import { flavorFromOs } from '~/lib/paths'
@@ -49,17 +51,14 @@ export interface SectionDefContext {
 
   // Workspace operations
   wsOps: WorkspaceOperations
-  getWorkspacesForGroup: (sectionId: string) => Workspace[]
+  getWorkspacesForGroup: (sectionId: string) => readonly Workspace[]
   activeWorkspaceId: string | null
   /** Open the New workspace dialog, into `sectionId` and from `startPoint`. */
   onNewWorkspace: (sectionId: string | null, startPoint: WorkspaceStartPoint) => void
   onSelectWorkspace: (id: string) => void
   /** Expand a collapsed section, so a revealed row has a box to scroll into. */
   expandSection?: (sectionId: string) => void
-  /** Open the New section dialog for `sidebar`. */
-  onNewSection: (sidebar: Sidebar) => void
-  onRenameSection: (section: Section) => void
-  onDeleteSection: (section: Section) => void
+  sectionActions: SectionActions
   /** Open a new agent / terminal at one of a workspace's checkouts. */
   workspaceStartActions?: WorkspaceStartActions
   view?: TabView
@@ -134,6 +133,36 @@ export function buildSectionDef(
   const sectionType = section.sectionType
   const sectionId = section.id
 
+  /**
+   * The section as the STORE holds it now, not as this call captured it.
+   *
+   * `headerActions()` and `content()` run once per section MOUNT, so whatever
+   * they close over outlives every later `buildSectionDefs()`. The captured
+   * object is a store proxy, so a local patch still reaches it -- but
+   * `loadSections` writes through `sectionIdentity.stabilize`, which mints a
+   * fresh object for any row whose fields changed, and a locally created
+   * section never entered that cache at all. The captured proxy then detaches
+   * and keeps the values it had, while the header title beside it updates.
+   *
+   * Only the fields a mounted node reads go through this. `title`, `railTitle`,
+   * `defaultOpen` and `testId` stay on `section`, because `buildSectionDefs()`
+   * re-runs and `CollapsibleSidebar` re-reads them from the fresh def.
+   */
+  const liveSection = () => ctx.sectionStore.state.sections.find(s => s.id === sectionId) ?? section
+
+  /**
+   * Run `action` with this section open.
+   *
+   * Header actions render while a section is COLLAPSED, and a collapsed body is
+   * `visibility: hidden` inside a zero-height row -- so anything that reveals a
+   * node inside it scrolls a box with no height and the user sees nothing. Any
+   * header action that points INTO its own section goes through this.
+   */
+  const revealing = (action: () => void) => () => {
+    ctx.expandSection?.(sectionId)
+    action()
+  }
+
   if (isWorkspaceSection(sectionType)) {
     // The workspaces this section holds, for every item that acts on the whole
     // section: the repository list, Collapse/Expand all, and Reveal.
@@ -152,7 +181,7 @@ export function buildSectionDef(
       // archive operations and the section CRUD had nowhere to live.
       headerActions: () => (
         <WorkspaceSectionMenu
-          section={section}
+          section={liveSection()}
           canCreate={ctx.wsOps.canAddToSection(section)}
           getTabs={() => workspaceIds().flatMap(id => ctx.view?.forWorkspace(id) ?? [])}
           getWorkspaceIds={workspaceIds}
@@ -163,21 +192,26 @@ export function buildSectionDef(
             const active = ctx.activeWorkspaceId
             return active !== null && workspaceIds().includes(active)
           }}
-          onRevealActiveWorkspace={() => {
+          onRevealActiveWorkspace={revealing(() => {
             const active = ctx.activeWorkspaceId
-            if (!active)
-              return
-            ctx.expandSection?.(sectionId)
-            revealWorkspaceRow(active)
+            if (active)
+              revealWorkspaceRow(active)
+          })}
+          // Only SHOWING the box expands the section; hiding it must not.
+          onToggleFilter={() => {
+            if (!isSectionFilterShown(sectionId))
+              ctx.expandSection?.(sectionId)
+            toggleSectionFilter(sectionId)
           }}
           onCollapseAll={() => setWorkspacesExpanded(workspaceIds(), false)}
           onExpandAll={() => setWorkspacesExpanded(workspaceIds(), true)}
           onNewWorkspace={startPoint => ctx.onNewWorkspace(sectionId, startPoint)}
+          hasArchivedWorkspaces={() => ctx.wsOps.archivedWorkspaceIds().length > 0}
           onUnarchiveAll={() => void ctx.wsOps.unarchiveAll()}
           onEmptyArchive={() => void ctx.wsOps.emptyArchive()}
-          onNewSection={() => ctx.onNewSection(section.sidebar)}
-          onRenameSection={() => ctx.onRenameSection(section)}
-          onDeleteSection={() => ctx.onDeleteSection(section)}
+          onNewSection={() => ctx.sectionActions.onNew(liveSection().sidebar)}
+          onRenameSection={() => ctx.sectionActions.onRename(liveSection())}
+          onDeleteSection={() => ctx.sectionActions.onDelete(liveSection())}
         />
       ),
       testId: `section-header-${sectionTypeTestId(sectionType)}`,
@@ -185,7 +219,7 @@ export function buildSectionDef(
         <WorkspaceSectionContent
           workspaces={ctx.getWorkspacesForGroup(sectionId)}
           sectionId={sectionId}
-          sectionName={section.name}
+          sectionName={liveSection().name}
           activeWorkspaceId={ctx.activeWorkspaceId}
           sections={ctx.sectionStore.state.sections}
           onSelect={ctx.onSelectWorkspace}
@@ -233,10 +267,10 @@ export function buildSectionDef(
       headerActions: () => (
         <FilesSectionHeaderActions
           handle={ctx.filesSectionHandle}
-          onLocateFile={() => {
+          onLocateFile={revealing(() => {
             if (ctx.activeFilePath)
               ctx.onFileSelect(ctx.activeFilePath)
-          }}
+          })}
           // Not on the handle: a refresh also re-reads git status, which the
           // section does not own.
           onRefresh={() => {

--- a/frontend/src/components/shell/buildSectionDef.tsx
+++ b/frontend/src/components/shell/buildSectionDef.tsx
@@ -123,8 +123,11 @@ export function buildSectionDef(
       defaultOpen: sectionType !== SectionType.WORKSPACES_ARCHIVED,
       collapsible: true,
       draggable: true,
+      // `undefined`, never `() => undefined`: the `<Show>` in
+      // CollapsibleSidebar tests the FACTORY, so a factory that returns
+      // nothing is still truthy and renders an empty actions box.
       headerActions: ctx.wsOps.canAddToSection(section)
-        ? (
+        ? () => (
             <IconButton
               icon={Plus}
               iconSize="sm"
@@ -183,7 +186,7 @@ export function buildSectionDef(
       collapsible: true,
       draggable: true,
       testId: `section-header-${sectionTypeTestId(sectionType)}`,
-      headerActions: (
+      headerActions: () => (
         <FilesSectionHeaderActions
           handle={ctx.filesSectionHandle}
           onLocateFile={() => {
@@ -295,7 +298,7 @@ export function buildSectionDef(
       draggable: true,
       defaultSize: 0.15,
       testId: `section-header-${sectionTypeTestId(sectionType)}`,
-      headerActions: (
+      headerActions: () => (
         <IconButton
           icon={Plus}
           iconSize="sm"

--- a/frontend/src/components/shell/sectionUtils.test.ts
+++ b/frontend/src/components/shell/sectionUtils.test.ts
@@ -75,7 +75,7 @@ describe('sectionTypeTestId', () => {
   })
 
   it('falls back to String(sectionType) for an unmapped value', () => {
-    // The default arm keeps an unknown enum value renderable rather than
+    // The default case keeps an unknown enum value renderable rather than
     // throwing -- a forward-compatible new section type still produces a slug.
     expect(sectionTypeTestId(999 as unknown as SectionType)).toBe('999')
   })

--- a/frontend/src/components/shell/sectionUtils.test.ts
+++ b/frontend/src/components/shell/sectionUtils.test.ts
@@ -96,15 +96,13 @@ describe('getSectionIcon', () => {
 })
 
 describe('isWorkspaceMutatable', () => {
-  it('returns true for a non-archived workspace', () => {
-    expect(isWorkspaceMutatable({ createdBy: 'user-1' }, false)).toBe(true)
+  it('returns true for a live workspace', () => {
+    expect(isWorkspaceMutatable(false)).toBe(true)
   })
 
-  it('returns false for archived workspace', () => {
-    expect(isWorkspaceMutatable({ createdBy: 'user-1' }, true)).toBe(false)
-  })
-
-  it('returns false when workspace is undefined', () => {
-    expect(isWorkspaceMutatable(undefined, false)).toBe(false)
+  it('returns false for an archived workspace', () => {
+    // Archival is the ONE thing that blocks mutation. Access is owner-only, so
+    // there is no second axis for this predicate to weigh.
+    expect(isWorkspaceMutatable(true)).toBe(false)
   })
 })

--- a/frontend/src/components/shell/sectionUtils.ts
+++ b/frontend/src/components/shell/sectionUtils.ts
@@ -1,5 +1,5 @@
 import type { LucideIcon } from 'lucide-solid'
-import type { Section } from '~/generated/proto/leapmux/v1/section_pb'
+import type { Section, Sidebar } from '~/generated/proto/leapmux/v1/section_pb'
 import Archive from 'lucide-solid/icons/archive'
 import Folder from 'lucide-solid/icons/folder'
 import FolderTree from 'lucide-solid/icons/folder-tree'
@@ -67,4 +67,25 @@ export function getSectionIcon(section: Section): LucideIcon {
     default:
       return Folder
   }
+}
+
+/**
+ * The three section-CRUD callbacks the sidebar hands to every section header
+ * menu.
+ *
+ * ONE bundle rather than three parallel fields declared in three interfaces
+ * that only forward them. A fourth section action then touches one type and one
+ * forwarding site instead of three, and the three layers cannot drift on a
+ * signature or a doc comment. It follows `WorkspaceStartActions`, which already
+ * groups the row's two tab-creation callbacks the same way.
+ *
+ * Only plain callbacks belong in a bundle like this. A reactive value
+ * (`localSolo`) must stay a flat field, because a nested object read once
+ * freezes it.
+ */
+export interface SectionActions {
+  /** Open the New section dialog for `sidebar`. */
+  onNew: (sidebar: Sidebar) => void
+  onRename: (section: Section) => void
+  onDelete: (section: Section) => void
 }

--- a/frontend/src/components/shell/sectionUtils.ts
+++ b/frontend/src/components/shell/sectionUtils.ts
@@ -37,16 +37,15 @@ export function isMoveTargetSection(sectionType: SectionType): boolean {
 }
 
 /**
- * Whether a workspace can be mutated (create agents/terminals, rename, etc.).
- * Ownership is not a parameter: access is owner-only, so every workspace the
- * client can see is the current user's own — only archival gates mutation.
+ * Whether a workspace can be mutated: create agents and terminals, rename it.
+ *
+ * Archival is the ONE thing that blocks mutation, and this signature says so.
+ * The `workspace` parameter it used to take was never read for its
+ * `createdBy` -- a vestige of the removed sharing model, used only as a
+ * presence check -- and it forced every caller that holds an archived FLAG but
+ * no workspace object to invent one.
  */
-export function isWorkspaceMutatable(
-  workspace: { createdBy: string } | undefined,
-  isArchived: boolean,
-): boolean {
-  if (!workspace)
-    return false
+export function isWorkspaceMutatable(isArchived: boolean): boolean {
   return !isArchived
 }
 

--- a/frontend/src/components/shell/useSectionOperations.test.ts
+++ b/frontend/src/components/shell/useSectionOperations.test.ts
@@ -37,6 +37,8 @@ function harness(sections: Section[] = []) {
 
 describe('useSectionOperations', () => {
   beforeEach(() => {
+    // `clearAllMocks` clears the CALL history but keeps any implementation a
+    // case installed, so every rejection below is `...Once`.
     vi.clearAllMocks()
   })
 
@@ -66,15 +68,17 @@ describe('useSectionOperations', () => {
       h.dispose()
     })
 
-    it('sends nothing for a name that cleans to nothing', async () => {
+    // REJECTS rather than resolving. A resolve is the dialog's success signal,
+    // so a quiet return closed the dialog as though a section had been made.
+    it('rejects a name that cleans to nothing, and sends nothing', async () => {
       const h = harness()
-      await h.ops.createSection('   ', Sidebar.LEFT)
+      await expect(h.ops.createSection('   ', Sidebar.LEFT)).rejects.toThrow(/needs a name/)
       expect(mockCreateSection).not.toHaveBeenCalled()
       h.dispose()
     })
 
     it('rejects rather than toasting, so the dialog shows the failure once', async () => {
-      mockCreateSection.mockRejectedValue(new Error('nope'))
+      mockCreateSection.mockRejectedValueOnce(new Error('nope'))
       const h = harness()
 
       await expect(h.ops.createSection('Reviews', Sidebar.LEFT)).rejects.toThrow('nope')
@@ -105,7 +109,7 @@ describe('useSectionOperations', () => {
     })
 
     it('leaves the row alone when the RPC fails', async () => {
-      mockRenameSection.mockRejectedValue(new Error('nope'))
+      mockRenameSection.mockRejectedValueOnce(new Error('nope'))
       const h = harness([section('sec-1', 'Old')])
 
       await expect(h.ops.renameSection('sec-1', 'New')).rejects.toThrow('nope')
@@ -113,9 +117,9 @@ describe('useSectionOperations', () => {
       h.dispose()
     })
 
-    it('sends nothing for a name that cleans to nothing', async () => {
+    it('rejects a name that cleans to nothing, and sends nothing', async () => {
       const h = harness([section('sec-1', 'Old')])
-      await h.ops.renameSection('sec-1', '​')
+      await expect(h.ops.renameSection('sec-1', '​')).rejects.toThrow(/needs a name/)
       expect(mockRenameSection).not.toHaveBeenCalled()
       h.dispose()
     })
@@ -136,14 +140,35 @@ describe('useSectionOperations', () => {
       h.dispose()
     })
 
-    it('toasts rather than rejecting: its confirm dialog is already gone', async () => {
-      mockDeleteSection.mockRejectedValue(new Error('nope'))
+    // One policy for the module: all three reject, and the confirm's call site
+    // owns the toast. A caller that swallowed the rejection here would leave a
+    // new call site free to pick up the wrong surface by accident.
+    it('rejects when the RPC fails, and keeps the row', async () => {
+      mockDeleteSection.mockRejectedValueOnce(new Error('nope'))
       const h = harness([section('sec-1', 'Reviews')])
+
+      await expect(h.ops.deleteSection('sec-1')).rejects.toThrow('nope')
+
+      expect(mockShowWarnToast).not.toHaveBeenCalled()
+      expect(h.sectionStore.state.sections).toHaveLength(1)
+      h.dispose()
+    })
+
+    // The reload runs AFTER the section is already gone, so a failure there is
+    // not a failed delete. Reporting it as one told the user a completed
+    // destructive operation had failed.
+    it('reports a failed refresh separately, and keeps the row deleted', async () => {
+      const h = harness([section('sec-1', 'Reviews')])
+      h.loadSections.mockRejectedValueOnce(new Error('offline'))
 
       await h.ops.deleteSection('sec-1')
 
-      expect(mockShowWarnToast).toHaveBeenCalledWith('Failed to delete section', expect.any(Error))
-      expect(h.sectionStore.state.sections).toHaveLength(1)
+      expect(mockDeleteSection).toHaveBeenCalled()
+      expect(h.sectionStore.state.sections).toHaveLength(0)
+      expect(mockShowWarnToast).toHaveBeenCalledWith(
+        'Deleted the section, but could not refresh the sidebar',
+        expect.any(Error),
+      )
       h.dispose()
     })
   })

--- a/frontend/src/components/shell/useSectionOperations.test.ts
+++ b/frontend/src/components/shell/useSectionOperations.test.ts
@@ -1,0 +1,150 @@
+import type { Section } from '~/generated/proto/leapmux/v1/section_pb'
+import { createRoot } from 'solid-js'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { SectionType, Sidebar } from '~/generated/proto/leapmux/v1/section_pb'
+import { createSectionStore } from '~/stores/section.store'
+import { useSectionOperations } from './useSectionOperations'
+
+const mockCreateSection = vi.fn<(req: { name: string, sidebar: Sidebar }) => Promise<{ section?: Section }>>()
+const mockRenameSection = vi.fn<(req: { sectionId: string, name: string }) => Promise<unknown>>()
+const mockDeleteSection = vi.fn<(req: { sectionId: string }) => Promise<unknown>>()
+const mockShowWarnToast = vi.fn()
+
+vi.mock('~/api/clients', () => ({
+  sectionClient: {
+    createSection: (...args: unknown[]) => mockCreateSection(...args as [{ name: string, sidebar: Sidebar }]),
+    renameSection: (...args: unknown[]) => mockRenameSection(...args as [{ sectionId: string, name: string }]),
+    deleteSection: (...args: unknown[]) => mockDeleteSection(...args as [{ sectionId: string }]),
+  },
+}))
+
+vi.mock('~/components/common/Toast', () => ({
+  showWarnToast: (...args: unknown[]) => mockShowWarnToast(...args),
+}))
+
+function section(id: string, name: string, sectionType = SectionType.WORKSPACES_CUSTOM): Section {
+  return { id, name, position: 'n', sectionType, sidebar: Sidebar.LEFT } as Section
+}
+
+function harness(sections: Section[] = []) {
+  const loadSections = vi.fn(async () => {})
+  return createRoot((dispose) => {
+    const sectionStore = createSectionStore()
+    sectionStore.setSections(sections)
+    return { dispose, sectionStore, loadSections, ops: useSectionOperations({ sectionStore, loadSections }) }
+  })
+}
+
+describe('useSectionOperations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('createSection', () => {
+    it('stores the row the SERVER computed, position and all', async () => {
+      // The response carries the whole section because the server owns the
+      // lexorank. Re-deriving it here would be a second source of truth for the
+      // section order.
+      const created = section('sec-new', 'Reviews')
+      mockCreateSection.mockResolvedValue({ section: created })
+      const h = harness()
+
+      await h.ops.createSection('Reviews', Sidebar.LEFT)
+
+      expect(mockCreateSection).toHaveBeenCalledWith({ name: 'Reviews', sidebar: Sidebar.LEFT })
+      expect(h.sectionStore.state.sections).toEqual([created])
+      h.dispose()
+    })
+
+    it('sends the cleaned name, because the hub sanitizes whatever arrives', async () => {
+      mockCreateSection.mockResolvedValue({ section: section('sec-new', 'Reviews') })
+      const h = harness()
+
+      await h.ops.createSection('  Reviews  ', Sidebar.RIGHT)
+
+      expect(mockCreateSection).toHaveBeenCalledWith({ name: 'Reviews', sidebar: Sidebar.RIGHT })
+      h.dispose()
+    })
+
+    it('sends nothing for a name that cleans to nothing', async () => {
+      const h = harness()
+      await h.ops.createSection('   ', Sidebar.LEFT)
+      expect(mockCreateSection).not.toHaveBeenCalled()
+      h.dispose()
+    })
+
+    it('rejects rather than toasting, so the dialog shows the failure once', async () => {
+      mockCreateSection.mockRejectedValue(new Error('nope'))
+      const h = harness()
+
+      await expect(h.ops.createSection('Reviews', Sidebar.LEFT)).rejects.toThrow('nope')
+      expect(mockShowWarnToast).not.toHaveBeenCalled()
+      expect(h.sectionStore.state.sections).toEqual([])
+      h.dispose()
+    })
+
+    it('rejects a response with no section, rather than storing nothing quietly', async () => {
+      mockCreateSection.mockResolvedValue({})
+      const h = harness()
+
+      await expect(h.ops.createSection('Reviews', Sidebar.LEFT)).rejects.toThrow(/No section/)
+      h.dispose()
+    })
+  })
+
+  describe('renameSection', () => {
+    it('renames the stored row', async () => {
+      mockRenameSection.mockResolvedValue({})
+      const h = harness([section('sec-1', 'Old')])
+
+      await h.ops.renameSection('sec-1', '  New  ')
+
+      expect(mockRenameSection).toHaveBeenCalledWith({ sectionId: 'sec-1', name: 'New' })
+      expect(h.sectionStore.state.sections[0].name).toBe('New')
+      h.dispose()
+    })
+
+    it('leaves the row alone when the RPC fails', async () => {
+      mockRenameSection.mockRejectedValue(new Error('nope'))
+      const h = harness([section('sec-1', 'Old')])
+
+      await expect(h.ops.renameSection('sec-1', 'New')).rejects.toThrow('nope')
+      expect(h.sectionStore.state.sections[0].name).toBe('Old')
+      h.dispose()
+    })
+
+    it('sends nothing for a name that cleans to nothing', async () => {
+      const h = harness([section('sec-1', 'Old')])
+      await h.ops.renameSection('sec-1', '​')
+      expect(mockRenameSection).not.toHaveBeenCalled()
+      h.dispose()
+    })
+  })
+
+  describe('deleteSection', () => {
+    it('drops the row and re-reads the sections', async () => {
+      // The hub re-stamps every relocated item's lexorank, and those positions
+      // are the server's to compute.
+      mockDeleteSection.mockResolvedValue({})
+      const h = harness([section('sec-1', 'Reviews')])
+
+      await h.ops.deleteSection('sec-1')
+
+      expect(mockDeleteSection).toHaveBeenCalledWith({ sectionId: 'sec-1' })
+      expect(h.sectionStore.state.sections).toEqual([])
+      expect(h.loadSections).toHaveBeenCalledOnce()
+      h.dispose()
+    })
+
+    it('toasts rather than rejecting: its confirm dialog is already gone', async () => {
+      mockDeleteSection.mockRejectedValue(new Error('nope'))
+      const h = harness([section('sec-1', 'Reviews')])
+
+      await h.ops.deleteSection('sec-1')
+
+      expect(mockShowWarnToast).toHaveBeenCalledWith('Failed to delete section', expect.any(Error))
+      expect(h.sectionStore.state.sections).toHaveLength(1)
+      h.dispose()
+    })
+  })
+})

--- a/frontend/src/components/shell/useSectionOperations.ts
+++ b/frontend/src/components/shell/useSectionOperations.ts
@@ -1,0 +1,86 @@
+import type { Sidebar } from '~/generated/proto/leapmux/v1/section_pb'
+import type { createSectionStore } from '~/stores/section.store'
+import { sectionClient } from '~/api/clients'
+import { showWarnToast } from '~/components/common/Toast'
+import { cleanName } from '~/lib/validate'
+
+export interface UseSectionOperationsProps {
+  sectionStore: ReturnType<typeof createSectionStore>
+  /** Re-read the sections and their items from the hub. */
+  loadSections: () => Promise<void>
+}
+
+/**
+ * Create, rename and delete a custom sidebar section.
+ *
+ * The sibling of {@link useWorkspaceOperations}: same shape (RPC, then the
+ * optimistic store write, then a warning toast on failure), a different noun.
+ * All three RPCs were implemented and tested server-side with no caller at all
+ * until the section header menu reached them.
+ *
+ * The hub refuses a rename or a delete of a BUILT-IN section, so the menu hides
+ * both items for In progress and Archived. That is a second layer over a rule
+ * that already holds -- see `requireCustomSection` in the hub.
+ */
+export function useSectionOperations(props: UseSectionOperationsProps) {
+  const store = props.sectionStore
+
+  /**
+   * Create a custom section on `sidebar`.
+   *
+   * The response carries the whole row, so the store gets the server's own
+   * lexorank position. A response with only the id would leave this function
+   * re-deriving the position rule -- a second source of truth for the section
+   * order -- or refetching the list.
+   */
+  const createSection = async (name: string, sidebar: Sidebar): Promise<void> => {
+    // The CLEANED name, not the raw one: the hub applies `SanitizeName` to
+    // whatever arrives, so raw text leaves the sidebar and the hub disagreeing
+    // until the next refresh. Same rule as `commitRename` for a workspace.
+    const cleaned = cleanName(name)
+    if (!cleaned)
+      return
+    // NOT caught here, unlike `deleteSection` below. Both of the name
+    // operations run from a dialog that owns an error row, and a toast on top
+    // of that row would report one failure twice in two voices.
+    const resp = await sectionClient.createSection({ name: cleaned, sidebar })
+    const section = resp.section
+    if (!section)
+      throw new Error('No section in response')
+    store.addSection(section)
+  }
+
+  const renameSection = async (sectionId: string, name: string): Promise<void> => {
+    const cleaned = cleanName(name)
+    if (!cleaned)
+      return
+    await sectionClient.renameSection({ sectionId, name: cleaned })
+    store.updateSection(sectionId, { name: cleaned })
+  }
+
+  /**
+   * Delete a custom section. Its workspaces move to In progress, which is what
+   * the hub does inside the delete transaction.
+   *
+   * This one DOES toast: it runs from a confirm dialog that has no error row of
+   * its own and is already dismissed by the time the RPC settles.
+   *
+   * The sections are re-read afterwards rather than patched: the hub re-stamps
+   * every relocated item's lexorank to append past the existing In-progress
+   * items, and those positions are the server's to compute.
+   */
+  const deleteSection = async (sectionId: string): Promise<void> => {
+    try {
+      await sectionClient.deleteSection({ sectionId })
+      store.removeSection(sectionId)
+      await props.loadSections()
+    }
+    catch (err) {
+      showWarnToast('Failed to delete section', err)
+    }
+  }
+
+  return { createSection, renameSection, deleteSection }
+}
+
+export type SectionOperations = ReturnType<typeof useSectionOperations>

--- a/frontend/src/components/shell/useSectionOperations.ts
+++ b/frontend/src/components/shell/useSectionOperations.ts
@@ -11,10 +11,29 @@ export interface UseSectionOperationsProps {
 }
 
 /**
+ * The cleaned name, or a rejection.
+ *
+ * The hub applies `SanitizeName` to whatever arrives, so a caller that sent the
+ * raw text would leave the sidebar and the hub disagreeing until the next
+ * refresh -- the same rule `commitRename` follows for a workspace.
+ */
+function requireName(name: string): string {
+  const cleaned = cleanName(name)
+  if (!cleaned)
+    throw new Error('A section needs a name')
+  return cleaned
+}
+
+/**
  * Create, rename and delete a custom sidebar section.
  *
- * The sibling of {@link useWorkspaceOperations}: same shape (RPC, then the
- * optimistic store write, then a warning toast on failure), a different noun.
+ * The sibling of {@link useWorkspaceOperations}, with a different noun and a
+ * different error policy. All three operations REJECT, and the caller decides
+ * how to report it: the two name operations run from a dialog that owns an
+ * error row, and the delete runs from a confirm that is already dismissed, so
+ * its call site adds the toast. One policy per module, so a new call site
+ * cannot pick up the wrong surface by accident.
+ *
  * All three RPCs were implemented and tested server-side with no caller at all
  * until the section header menu reached them.
  *
@@ -34,15 +53,12 @@ export function useSectionOperations(props: UseSectionOperationsProps) {
    * order -- or refetching the list.
    */
   const createSection = async (name: string, sidebar: Sidebar): Promise<void> => {
-    // The CLEANED name, not the raw one: the hub applies `SanitizeName` to
-    // whatever arrives, so raw text leaves the sidebar and the hub disagreeing
-    // until the next refresh. Same rule as `commitRename` for a workspace.
-    const cleaned = cleanName(name)
-    if (!cleaned)
-      return
-    // NOT caught here, unlike `deleteSection` below. Both of the name
-    // operations run from a dialog that owns an error row, and a toast on top
-    // of that row would report one failure twice in two voices.
+    // THROWS rather than returning. A resolve is the dialog's success signal,
+    // so returning here closed it as though a section had been created. The
+    // dialog's own submit guard already blocks an empty name, which makes this
+    // unreachable today -- and that is exactly why it must fail loudly if that
+    // guard ever loosens.
+    const cleaned = requireName(name)
     const resp = await sectionClient.createSection({ name: cleaned, sidebar })
     const section = resp.section
     if (!section)
@@ -51,9 +67,7 @@ export function useSectionOperations(props: UseSectionOperationsProps) {
   }
 
   const renameSection = async (sectionId: string, name: string): Promise<void> => {
-    const cleaned = cleanName(name)
-    if (!cleaned)
-      return
+    const cleaned = requireName(name)
     await sectionClient.renameSection({ sectionId, name: cleaned })
     store.updateSection(sectionId, { name: cleaned })
   }
@@ -62,21 +76,21 @@ export function useSectionOperations(props: UseSectionOperationsProps) {
    * Delete a custom section. Its workspaces move to In progress, which is what
    * the hub does inside the delete transaction.
    *
-   * This one DOES toast: it runs from a confirm dialog that has no error row of
-   * its own and is already dismissed by the time the RPC settles.
-   *
    * The sections are re-read afterwards rather than patched: the hub re-stamps
    * every relocated item's lexorank to append past the existing In-progress
-   * items, and those positions are the server's to compute.
+   * items, and those positions are the server's to compute. That reload is
+   * NOT part of the delete's success: it runs after the section is already
+   * gone, so a failure there must not report the delete as failed. It re-raises
+   * under its own message instead.
    */
   const deleteSection = async (sectionId: string): Promise<void> => {
+    await sectionClient.deleteSection({ sectionId })
+    store.removeSection(sectionId)
     try {
-      await sectionClient.deleteSection({ sectionId })
-      store.removeSection(sectionId)
       await props.loadSections()
     }
     catch (err) {
-      showWarnToast('Failed to delete section', err)
+      showWarnToast('Deleted the section, but could not refresh the sidebar', err)
     }
   }
 

--- a/frontend/src/components/shell/useSidebarCore.tsx
+++ b/frontend/src/components/shell/useSidebarCore.tsx
@@ -1,10 +1,11 @@
 import type { SectionDefContext } from './buildSectionDef'
 import type { SidebarSectionDef } from './CollapsibleSidebar'
+import type { SectionActions } from './sectionUtils'
 import type { FilesSectionHandle } from '~/components/tree/FilesSection'
 import type { BranchRefActions } from '~/components/workspace/branchActions'
 import type { WorkspaceStartActions } from '~/components/workspace/workspaceStartActions'
 import type { WorkspaceStartPoint } from '~/components/workspace/workspaceStartPoint'
-import type { Section, Sidebar } from '~/generated/proto/leapmux/v1/section_pb'
+import type { Sidebar } from '~/generated/proto/leapmux/v1/section_pb'
 import type { Worker } from '~/generated/proto/leapmux/v1/worker_pb'
 import type { Workspace } from '~/generated/proto/leapmux/v1/workspace_pb'
 import type { WorkerInfo } from '~/lib/workerInfoCache'
@@ -50,10 +51,7 @@ export interface SidebarCommonProps {
   onPostArchiveWorkspace?: (workspaceId: string) => void
 
   // Sections
-  /** Open the New section dialog for `sidebar`. */
-  onNewSection: (sidebar: Sidebar) => void
-  onRenameSection: (section: Section) => void
-  onDeleteSection: (section: Section) => void
+  sectionActions: SectionActions
 
   // Display
   isCollapsed: boolean
@@ -190,23 +188,43 @@ export function useSidebarCore(props: SidebarCommonProps, side: Sidebar) {
   )
 
   /**
+   * Each section's rows in the order they are drawn: the model order from
+   * `buildSectionGroups`, narrowed by that section's filter and put in the
+   * global sort order.
+   *
+   * ONE memo for the whole sidebar, keyed by section id. Every consumer reads
+   * the same array per tick -- the rows, the header menu's Collapse all, its
+   * repository list and its enabled state. Producing it per read instead cost a
+   * fresh filter pass, a fresh sort and two array copies six to eight times per
+   * section on every tick of a GLOBAL signal.
+   *
+   * A map rather than a memo per section: a `createMemo` minted inside an
+   * arbitrary render read belongs to that computation and dies with it, and an
+   * id-keyed cache of them would leak one per deleted section.
+   */
+  const workspacesBySection = createMemo(() => {
+    const groups = sectionGroups()
+    const bySection = new Map<string, readonly Workspace[]>()
+    for (const group of groups)
+      bySection.set(group.section.id, wsOps.getWorkspacesForGroup(group.section.id, groups))
+    return bySection
+  })
+
+  /**
    * Creates a `SectionDefContext` from the SolidJS component props, using
    * property getters to preserve reactivity through the SolidJS proxy chain.
    */
   const createCtx = (): SectionDefContext => ({
     sectionStore: store,
     wsOps,
-    getWorkspacesForGroup: sectionId =>
-      wsOps.getWorkspacesForGroup(sectionId, sectionGroups()),
+    getWorkspacesForGroup: sectionId => workspacesBySection().get(sectionId) ?? [],
     get activeWorkspaceId() { return props.activeWorkspaceId },
     onNewWorkspace: props.onNewWorkspace,
     onSelectWorkspace: props.onSelectWorkspace,
     // Captured from CollapsibleSidebar's ref callback, so a section menu can
     // open its own section before revealing a row inside it.
     expandSection: (sectionId: string) => expandSection?.(sectionId),
-    onNewSection: props.onNewSection,
-    onRenameSection: props.onRenameSection,
-    onDeleteSection: props.onDeleteSection,
+    get sectionActions() { return props.sectionActions },
     get view() { return props.view },
     get selection() { return props.selection },
     get onTabClick() { return props.onTabClick },

--- a/frontend/src/components/shell/useSidebarCore.tsx
+++ b/frontend/src/components/shell/useSidebarCore.tsx
@@ -2,7 +2,9 @@ import type { SectionDefContext } from './buildSectionDef'
 import type { SidebarSectionDef } from './CollapsibleSidebar'
 import type { FilesSectionHandle } from '~/components/tree/FilesSection'
 import type { BranchRefActions } from '~/components/workspace/branchActions'
-import type { Sidebar } from '~/generated/proto/leapmux/v1/section_pb'
+import type { WorkspaceStartActions } from '~/components/workspace/workspaceStartActions'
+import type { WorkspaceStartPoint } from '~/components/workspace/workspaceStartPoint'
+import type { Section, Sidebar } from '~/generated/proto/leapmux/v1/section_pb'
 import type { Worker } from '~/generated/proto/leapmux/v1/worker_pb'
 import type { Workspace } from '~/generated/proto/leapmux/v1/workspace_pb'
 import type { WorkerInfo } from '~/lib/workerInfoCache'
@@ -38,12 +40,20 @@ export interface SidebarCommonProps {
   activeWorkspaceId: string | null
   loadSections: () => Promise<void>
   onSelectWorkspace: (id: string) => void
-  onNewWorkspace: (sectionId: string | null) => void
+  /** Open the New workspace dialog, into `sectionId` and from `startPoint`. */
+  onNewWorkspace: (sectionId: string | null, startPoint: WorkspaceStartPoint) => void
   onRefreshWorkspaces: () => void | Promise<void>
   onDeleteWorkspace: (deletedId: string, nextWorkspaceId: string | null) => void
   onConfirmDelete?: (workspaceId: string) => Promise<boolean>
   onConfirmArchive?: (workspaceId: string) => Promise<boolean>
+  onConfirmEmptyArchive?: (count: number) => Promise<boolean>
   onPostArchiveWorkspace?: (workspaceId: string) => void
+
+  // Sections
+  /** Open the New section dialog for `sidebar`. */
+  onNewSection: (sidebar: Sidebar) => void
+  onRenameSection: (section: Section) => void
+  onDeleteSection: (section: Section) => void
 
   // Display
   isCollapsed: boolean
@@ -91,9 +101,16 @@ export interface SidebarCommonProps {
   getTileOrderForWorkspace?: (workspaceId: string) => readonly string[]
   /** Branch-menu callbacks, unbound. Each branch row binds them to its own ref. */
   branchActions?: BranchRefActions
+  /** Open a new agent / terminal at one of a workspace's checkouts. */
+  workspaceStartActions?: WorkspaceStartActions
 
   // Workers
   workers: Worker[]
+  /**
+   * Whether the desktop shell runs its own bundled sidecar. Half of the
+   * "is this worker local" test. See `~/lib/workerLocality`.
+   */
+  localSolo: boolean
   workerInfoFn: (id: string) => WorkerInfo | null
   channelStatusFn: (id: string) => ChannelStatus
   onAddTunnel: (worker: Worker) => void
@@ -153,6 +170,9 @@ export function useSidebarCore(props: SidebarCommonProps, side: Sidebar) {
     onDeleteWorkspace: props.onDeleteWorkspace,
     onConfirmDelete: props.onConfirmDelete,
     onConfirmArchive: props.onConfirmArchive,
+    onConfirmEmptyArchive: props.onConfirmEmptyArchive,
+    // The `recent` sort ranks a workspace by its most recently activated tab.
+    getTabsForWorkspace: (wsId: string) => props.view?.forWorkspace(wsId) ?? [],
     onPostArchiveWorkspace: (workspaceId) => {
       const archivedSection = store.getArchivedSection()
       if (archivedSection && expandSection)
@@ -181,12 +201,19 @@ export function useSidebarCore(props: SidebarCommonProps, side: Sidebar) {
     get activeWorkspaceId() { return props.activeWorkspaceId },
     onNewWorkspace: props.onNewWorkspace,
     onSelectWorkspace: props.onSelectWorkspace,
+    // Captured from CollapsibleSidebar's ref callback, so a section menu can
+    // open its own section before revealing a row inside it.
+    expandSection: (sectionId: string) => expandSection?.(sectionId),
+    onNewSection: props.onNewSection,
+    onRenameSection: props.onRenameSection,
+    onDeleteSection: props.onDeleteSection,
     get view() { return props.view },
     get selection() { return props.selection },
     get onTabClick() { return props.onTabClick },
     get tabItemOps() { return props.tabItemOps },
     get getTileOrderForWorkspace() { return props.getTileOrderForWorkspace },
     get branchActions() { return props.branchActions },
+    get workspaceStartActions() { return props.workspaceStartActions },
     get workerId() { return props.workerId },
     get workingDir() { return props.workingDir },
     get gitToplevel() { return props.gitToplevel },
@@ -210,6 +237,7 @@ export function useSidebarCore(props: SidebarCommonProps, side: Sidebar) {
     get activeBackgroundTasksFailed() { return props.activeBackgroundTasksFailed },
     get onOpenBackgroundTask() { return props.onOpenBackgroundTask },
     get workers() { return props.workers },
+    get localSolo() { return props.localSolo },
     workerInfoFn: props.workerInfoFn,
     channelStatusFn: props.channelStatusFn,
     onAddTunnel: props.onAddTunnel,

--- a/frontend/src/components/shell/useSidebarCore.tsx
+++ b/frontend/src/components/shell/useSidebarCore.tsx
@@ -149,7 +149,6 @@ export function useSidebarCore(props: SidebarCommonProps, side: Sidebar) {
     sectionStore: store,
     loadSections: props.loadSections,
     onSelectWorkspace: props.onSelectWorkspace,
-    onNewWorkspace: props.onNewWorkspace,
     onRefreshWorkspaces: props.onRefreshWorkspaces,
     onDeleteWorkspace: props.onDeleteWorkspace,
     onConfirmDelete: props.onConfirmDelete,

--- a/frontend/src/components/shell/useWorkspaceOperations.test.ts
+++ b/frontend/src/components/shell/useWorkspaceOperations.test.ts
@@ -386,6 +386,7 @@ describe('useWorkspaceOperations commitRename', () => {
 function bulkHarness(archivedIds: readonly string[], opts: {
   onConfirmEmptyArchive?: (count: number) => Promise<boolean>
   onConfirmDelete?: (workspaceId: string) => Promise<boolean>
+  onRefreshWorkspaces?: () => void
 } = {}) {
   const inProgress = section('s-progress', SectionType.WORKSPACES_IN_PROGRESS)
   const archived = section('s-archived', SectionType.WORKSPACES_ARCHIVED)
@@ -399,7 +400,7 @@ function bulkHarness(archivedIds: readonly string[], opts: {
       sectionStore,
       loadSections: async () => {},
       onSelectWorkspace: () => {},
-      onRefreshWorkspaces: () => {},
+      onRefreshWorkspaces: opts.onRefreshWorkspaces ?? (() => {}),
       onDeleteWorkspace: () => {},
       onConfirmDelete: opts.onConfirmDelete,
       onConfirmEmptyArchive: opts.onConfirmEmptyArchive,
@@ -496,6 +497,71 @@ describe('useWorkspaceOperations emptyArchive', () => {
     await h.ops.emptyArchive()
     expect(onConfirmEmptyArchive).not.toHaveBeenCalled()
     expect(mockDeleteWorkspace).not.toHaveBeenCalled()
+    h.dispose()
+  })
+
+  // The confirm is an unbounded await, and any workspace lifecycle event
+  // reloads the sections under it. Deleting the pre-confirm snapshot would
+  // destroy a workspace somebody had just taken OUT of the archive.
+  it('deletes only what is still archived when the archive changed under the confirm', async () => {
+    let store: ReturnType<typeof createSectionStore> | undefined
+    const h = bulkHarness(['w1', 'w2', 'w3'], {
+      onConfirmEmptyArchive: async () => {
+        // w2 was unarchived on another device while the prompt was up.
+        store!.setItems([item('w1', 's-archived', 'p0'), item('w3', 's-archived', 'p2')])
+        return true
+      },
+    })
+    store = h.sectionStore
+
+    await h.ops.emptyArchive()
+
+    expect(mockDeleteWorkspace.mock.calls.map(c => c[0].workspaceId)).toEqual(['w1', 'w3'])
+    h.dispose()
+  })
+
+  // ...and the mirror: a workspace archived DURING the prompt was never part of
+  // the count the user agreed to, so it survives.
+  it('deletes no more than the count the confirm named', async () => {
+    let store: ReturnType<typeof createSectionStore> | undefined
+    const h = bulkHarness(['w1'], {
+      onConfirmEmptyArchive: async () => {
+        store!.setItems([item('w1', 's-archived', 'p0'), item('late', 's-archived', 'p1')])
+        return true
+      },
+    })
+    store = h.sectionStore
+
+    await h.ops.emptyArchive()
+
+    expect(mockDeleteWorkspace.mock.calls.map(c => c[0].workspaceId)).toEqual(['w1'])
+    h.dispose()
+  })
+
+  // Both refresh calls are full-collection RPCs, so a per-item refresh fetches
+  // N-1 states nobody ever sees.
+  it('refreshes the lists ONCE for the whole batch, not once per workspace', async () => {
+    const onRefreshWorkspaces = vi.fn()
+    const h = bulkHarness(['w1', 'w2', 'w3'], {
+      onConfirmEmptyArchive: async () => true,
+      onRefreshWorkspaces,
+    })
+
+    await h.ops.emptyArchive()
+
+    expect(mockDeleteWorkspace).toHaveBeenCalledTimes(3)
+    expect(onRefreshWorkspaces).toHaveBeenCalledTimes(1)
+    h.dispose()
+  })
+
+  // A single delete keeps its own refresh: only the bulk caller opts out.
+  it('still refreshes once for a single delete', async () => {
+    const onRefreshWorkspaces = vi.fn()
+    const h = bulkHarness(['w1'], { onConfirmDelete: async () => true, onRefreshWorkspaces })
+
+    await h.ops.deleteWorkspace('w1')
+
+    expect(onRefreshWorkspaces).toHaveBeenCalledTimes(1)
     h.dispose()
   })
 
@@ -606,5 +672,143 @@ describe('useWorkspaceOperations getWorkspacesForGroup', () => {
     const v = viewOrder(['a'])
     expect(v.ids()).toEqual(['w0'])
     v.dispose()
+  })
+})
+
+// ----- Archived workspaces refuse a rename -----
+//
+// The hub answers `RenameWorkspace` on an archived workspace with
+// FailedPrecondition. The row menu hides its Rename item, but the row also
+// renames on DOUBLE-CLICK, which reaches `startRename` directly -- so the guard
+// belongs to the operation, not to the item.
+
+describe('useWorkspaceOperations startRename', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('opens the input for a workspace that is not archived', () => {
+    const h = bulkHarness([])
+    h.sectionStore.setItems([item('ws-live', 's-progress', 'p0')])
+    h.ops.startRename(ws('ws-live'))
+    expect(h.ops.renamingWorkspaceId()).toBe('ws-live')
+    h.dispose()
+  })
+
+  it('refuses an archived workspace, so no input opens', () => {
+    const h = bulkHarness(['ws-archived'])
+    h.ops.startRename(ws('ws-archived'))
+    expect(h.ops.renamingWorkspaceId()).toBeNull()
+    h.dispose()
+  })
+
+  // The row's grip stays draggable while the input is open, so the workspace
+  // can be archived between opening the input and committing it.
+  it('sends no rename when the workspace was archived while the input was open', async () => {
+    const h = bulkHarness([])
+    h.sectionStore.setItems([item('ws-1', 's-progress', 'p0')])
+    h.ops.startRename(ws('ws-1'))
+    h.ops.onRenameInput('a new name')
+
+    h.sectionStore.setItems([item('ws-1', 's-archived', 'p0')])
+    await h.ops.commitRename()
+
+    expect(mockRenameWorkspace).not.toHaveBeenCalled()
+    expect(h.ops.renamingWorkspaceId()).toBeNull()
+    h.dispose()
+  })
+})
+
+// ----- Same-section reordering follows the view order -----
+//
+// A row drop resolves through the row's own `ws-<id>` droppable, which every
+// row registers whatever the sort is. Suppressing the reorder is the HANDLER's
+// job: dropping the sortable primitive instead also removed the droppable a
+// CROSS-section drop needs to find a row.
+
+describe('useWorkspaceOperations handleWorkspaceDragEnd', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorageClearForTests()
+    setStorageAccount('u-1')
+    resetWorkspaceListStateForTests()
+  })
+
+  function dragHarness() {
+    const inProgress = section('s-progress', SectionType.WORKSPACES_IN_PROGRESS)
+    const other = section('s-other', SectionType.WORKSPACES_CUSTOM)
+    return createRoot((dispose) => {
+      const sectionStore = createSectionStore()
+      sectionStore.setSections([inProgress, other])
+      sectionStore.setItems([
+        item('ws-a', 's-progress', 'a'),
+        item('ws-b', 's-progress', 'b'),
+        item('ws-c', 's-other', 'a'),
+      ])
+      const ops = useWorkspaceOperations({
+        workspaces: () => ['ws-a', 'ws-b', 'ws-c'].map(ws),
+        activeWorkspaceId: () => null,
+        sectionStore,
+        loadSections: async () => {},
+        onSelectWorkspace: () => {},
+        onRefreshWorkspaces: () => {},
+        onDeleteWorkspace: () => {},
+      })
+      return { dispose, ops, sectionStore }
+    })
+  }
+
+  /** One row dropped onto another, as solid-dnd reports it. */
+  function drop(h: ReturnType<typeof dragHarness>, from: string, fromSection: string, onto: string, ontoSection: string) {
+    h.ops.handleWorkspaceDragEnd({
+      draggable: { id: `ws-${from}`, data: { sectionId: fromSection } },
+      droppable: { id: `ws-${onto}`, data: { sectionId: ontoSection } },
+    } as never)
+  }
+
+  it('reorders within a section under the default manual sort', () => {
+    const h = dragHarness()
+    drop(h, 'a', 's-progress', 'b', 's-progress')
+    expect(mockMoveWorkspace).toHaveBeenCalledOnce()
+    h.dispose()
+  })
+
+  it('does not reorder within a section while a non-manual sort is active', () => {
+    const h = dragHarness()
+    setWorkspaceSortOrder({ key: 'name', direction: 'asc' })
+    drop(h, 'a', 's-progress', 'b', 's-progress')
+    expect(mockMoveWorkspace).not.toHaveBeenCalled()
+    h.dispose()
+  })
+
+  it('does not reorder within a section while that section is filtered', () => {
+    const h = dragHarness()
+    toggleSectionFilter('s-progress')
+    setSectionFilterQuery('s-progress', 'a')
+    drop(h, 'a', 's-progress', 'b', 's-progress')
+    expect(mockMoveWorkspace).not.toHaveBeenCalled()
+    h.dispose()
+  })
+
+  // The half the primitive swap silently removed: a CROSS-section drop still
+  // resolves the target ROW, so the workspace lands before it rather than at
+  // the end of whichever section body happened to be nearest.
+  it('still moves across sections onto a row while a non-manual sort is active', () => {
+    const h = dragHarness()
+    setWorkspaceSortOrder({ key: 'name', direction: 'asc' })
+    drop(h, 'a', 's-progress', 'c', 's-other')
+    expect(mockMoveWorkspace).toHaveBeenCalledOnce()
+    expect(mockMoveWorkspace.mock.calls[0][0].sectionId).toBe('s-other')
+    h.dispose()
+  })
+
+  it('still moves across sections onto a row while the source section is filtered', () => {
+    const h = dragHarness()
+    toggleSectionFilter('s-progress')
+    setSectionFilterQuery('s-progress', 'a')
+    drop(h, 'a', 's-progress', 'c', 's-other')
+    expect(mockMoveWorkspace).toHaveBeenCalledOnce()
+    expect(mockMoveWorkspace.mock.calls[0][0].sectionId).toBe('s-other')
+    h.dispose()
   })
 })

--- a/frontend/src/components/shell/useWorkspaceOperations.test.ts
+++ b/frontend/src/components/shell/useWorkspaceOperations.test.ts
@@ -1,10 +1,18 @@
 import type { Section, SectionItem } from '~/generated/proto/leapmux/v1/section_pb'
 import type { Workspace } from '~/generated/proto/leapmux/v1/workspace_pb'
+import type { Tab } from '~/stores/tab.types'
 import { createRoot } from 'solid-js'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useWorkspaceOperations } from '~/components/shell/useWorkspaceOperations'
+import {
+  resetWorkspaceListStateForTests,
+  setSectionFilterQuery,
+  setWorkspaceSortOrder,
+  toggleSectionFilter,
+} from '~/components/workspace/workspaceListState'
 import { SectionType } from '~/generated/proto/leapmux/v1/section_pb'
 import { TabType } from '~/generated/proto/leapmux/v1/workspace_pb'
+import { localStorageClearForTests, setStorageAccount } from '~/lib/browserStorage'
 import { createSectionStore } from '~/stores/section.store'
 
 interface TabRefLike { tabType: TabType, tabId: string }
@@ -13,6 +21,7 @@ interface WorkerTabsLike { workerId: string, tabs: TabRefLike[] }
 const mockDeleteWorkspace = vi.fn<(req: { workspaceId: string }) => Promise<{ workerTabs: WorkerTabsLike[] }>>()
 const mockRenameWorkspace = vi.fn<(req: { workspaceId: string, title: string }) => Promise<unknown>>()
 const mockCleanupWorkspace = vi.fn<(workerId: string, req: { tabs: TabRefLike[] }) => Promise<unknown>>()
+const mockMoveWorkspace = vi.fn<(req: { workspaceId: string, sectionId: string, position: string }) => Promise<unknown>>()
 const mockShowWarnToast = vi.fn()
 
 vi.mock('~/api/clients', () => ({
@@ -20,7 +29,13 @@ vi.mock('~/api/clients', () => ({
     deleteWorkspace: (...args: unknown[]) => mockDeleteWorkspace(...args as [{ workspaceId: string }]),
     renameWorkspace: (...args: unknown[]) => mockRenameWorkspace(...args as [{ workspaceId: string, title: string }]),
   },
-  sectionClient: {},
+  sectionClient: {
+    // Stubbed, and its ABSENCE used to hide a bug: `moveWorkspace` threw on
+    // `undefined.moveWorkspace`, the hook's own catch swallowed it into a
+    // toast, and every test that moved a workspace passed for the wrong
+    // reason.
+    moveWorkspace: (...args: unknown[]) => mockMoveWorkspace(...args as [{ workspaceId: string, sectionId: string, position: string }]),
+  },
 }))
 
 vi.mock('~/api/workerRpc', () => ({
@@ -357,5 +372,239 @@ describe('useWorkspaceOperations commitRename', () => {
   ])('sends nothing for %s', async (_label, typed) => {
     await rename(typed)
     expect(mockRenameWorkspace).not.toHaveBeenCalled()
+  })
+})
+
+// ----- Bulk archive operations -----
+
+/**
+ * The hook wired to a populated section store, for the two bulk operations.
+ *
+ * They read the ARCHIVED section's items at the start of each run, so the store
+ * has to be real rather than empty.
+ */
+function bulkHarness(archivedIds: readonly string[], opts: {
+  onConfirmEmptyArchive?: (count: number) => Promise<boolean>
+  onConfirmDelete?: (workspaceId: string) => Promise<boolean>
+} = {}) {
+  const inProgress = section('s-progress', SectionType.WORKSPACES_IN_PROGRESS)
+  const archived = section('s-archived', SectionType.WORKSPACES_ARCHIVED)
+  return createRoot((dispose) => {
+    const sectionStore = createSectionStore()
+    sectionStore.setSections([inProgress, archived])
+    sectionStore.setItems(archivedIds.map((id, i) => item(id, 's-archived', `p${i}`)))
+    const ops = useWorkspaceOperations({
+      workspaces: () => archivedIds.map(ws),
+      activeWorkspaceId: () => null,
+      sectionStore,
+      loadSections: async () => {},
+      onSelectWorkspace: () => {},
+      onRefreshWorkspaces: () => {},
+      onDeleteWorkspace: () => {},
+      onConfirmDelete: opts.onConfirmDelete,
+      onConfirmEmptyArchive: opts.onConfirmEmptyArchive,
+    })
+    return { dispose, ops, sectionStore }
+  })
+}
+
+describe('useWorkspaceOperations unarchiveAll', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockMoveWorkspace.mockResolvedValue({})
+  })
+
+  it('moves every archived workspace to In progress', async () => {
+    const h = bulkHarness(['w1', 'w2', 'w3'])
+    await h.ops.unarchiveAll()
+    expect(mockMoveWorkspace.mock.calls.map(c => c[0].workspaceId)).toEqual(['w1', 'w2', 'w3'])
+    expect(mockMoveWorkspace.mock.calls.every(c => c[0].sectionId === 's-progress')).toBe(true)
+    h.dispose()
+  })
+
+  it('gives every move a DISTINCT position', async () => {
+    // This is what separates the sequential loop from `Promise.all`.
+    // `moveWorkspace` computes `appendPosition(getItemsForSection(...))`, which
+    // reads `items.at(-1)` BEFORE its await while the store write lands after
+    // it -- so a parallel fan-out hands every call the identical lexorank and
+    // the sidebar shuffles the whole set on the next refresh.
+    const h = bulkHarness(['w1', 'w2', 'w3'])
+    await h.ops.unarchiveAll()
+    const positions = mockMoveWorkspace.mock.calls.map(c => c[0].position)
+    expect(new Set(positions).size).toBe(positions.length)
+    h.dispose()
+  })
+
+  it('does nothing for an empty archive', async () => {
+    const h = bulkHarness([])
+    await h.ops.unarchiveAll()
+    expect(mockMoveWorkspace).not.toHaveBeenCalled()
+    h.dispose()
+  })
+
+  it('warns for the workspace that failed and still moves the rest', async () => {
+    // Both callees catch and toast, so "the loop continued" is true for every
+    // loop shape including none. The TOAST is what says which one failed.
+    mockMoveWorkspace.mockImplementation(async (req) => {
+      if (req.workspaceId === 'w2')
+        throw new Error('nope')
+      return {}
+    })
+    const h = bulkHarness(['w1', 'w2', 'w3'])
+    await h.ops.unarchiveAll()
+    expect(mockMoveWorkspace).toHaveBeenCalledTimes(3)
+    expect(mockShowWarnToast).toHaveBeenCalledTimes(1)
+    expect(mockShowWarnToast.mock.calls[0][0]).toBe('Failed to move workspace')
+    h.dispose()
+  })
+})
+
+describe('useWorkspaceOperations emptyArchive', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDeleteWorkspace.mockResolvedValue({ workerTabs: [] })
+  })
+
+  it('asks ONCE, naming the count, and never asks per workspace', async () => {
+    // The per-workspace confirm is not merely noisy: `confirmDeleteWsDialog` is
+    // a single-slot dialog state, so N concurrent opens drop N-1 resolvers and
+    // those awaits never settle.
+    const onConfirmEmptyArchive = vi.fn(async () => true)
+    const onConfirmDelete = vi.fn(async () => true)
+    const h = bulkHarness(['w1', 'w2', 'w3'], { onConfirmEmptyArchive, onConfirmDelete })
+
+    await h.ops.emptyArchive()
+
+    expect(onConfirmEmptyArchive).toHaveBeenCalledTimes(1)
+    expect(onConfirmEmptyArchive).toHaveBeenCalledWith(3)
+    expect(onConfirmDelete).not.toHaveBeenCalled()
+    expect(mockDeleteWorkspace.mock.calls.map(c => c[0].workspaceId)).toEqual(['w1', 'w2', 'w3'])
+    h.dispose()
+  })
+
+  it('deletes nothing when the confirm is declined', async () => {
+    const h = bulkHarness(['w1', 'w2'], { onConfirmEmptyArchive: async () => false })
+    await h.ops.emptyArchive()
+    expect(mockDeleteWorkspace).not.toHaveBeenCalled()
+    h.dispose()
+  })
+
+  it('does not ask at all for an empty archive', async () => {
+    // "Delete 0 archived workspaces?" is a prompt with no answer worth giving.
+    const onConfirmEmptyArchive = vi.fn(async () => true)
+    const h = bulkHarness([], { onConfirmEmptyArchive })
+    await h.ops.emptyArchive()
+    expect(onConfirmEmptyArchive).not.toHaveBeenCalled()
+    expect(mockDeleteWorkspace).not.toHaveBeenCalled()
+    h.dispose()
+  })
+
+  it('warns for the workspace that failed and still deletes the rest', async () => {
+    mockDeleteWorkspace.mockImplementation(async (req) => {
+      if (req.workspaceId === 'w2')
+        throw new Error('nope')
+      return { workerTabs: [] }
+    })
+    const h = bulkHarness(['w1', 'w2', 'w3'], { onConfirmEmptyArchive: async () => true })
+    await h.ops.emptyArchive()
+    expect(mockDeleteWorkspace).toHaveBeenCalledTimes(3)
+    expect(mockShowWarnToast).toHaveBeenCalledTimes(1)
+    expect(mockShowWarnToast.mock.calls[0][0]).toBe('Failed to delete workspace')
+    h.dispose()
+  })
+})
+
+// ----- The view order: filter, then sort -----
+//
+// `getWorkspacesForGroup` is the ONE place the row list is produced, so every
+// consumer -- the rows, the header menu's Collapse all, the repository list --
+// sees the same order.
+
+function viewOrder(
+  titles: readonly string[],
+  opts: { mru?: Record<string, number> } = {},
+): { ids: () => string[], dispose: () => void } {
+  const inProgress = section('s-progress', SectionType.WORKSPACES_IN_PROGRESS)
+  const workspaces = titles.map((title, i) => ({ id: `w${i}`, title, createdAt: `2026-0${i + 1}-01` } as Workspace))
+  return createRoot((dispose) => {
+    const sectionStore = createSectionStore()
+    sectionStore.setSections([inProgress])
+    sectionStore.setItems(workspaces.map((w, i) => item(w.id, 's-progress', `p${i}`)))
+    const ops = useWorkspaceOperations({
+      workspaces: () => workspaces,
+      activeWorkspaceId: () => null,
+      sectionStore,
+      loadSections: async () => {},
+      onSelectWorkspace: () => {},
+      onRefreshWorkspaces: () => {},
+      onDeleteWorkspace: () => {},
+      getTabsForWorkspace: (wsId: string) => {
+        const mru = opts.mru?.[wsId]
+        return mru === undefined ? [] : [{ mru } as Tab]
+      },
+    })
+    return {
+      dispose,
+      ids: () => ops.getWorkspacesForGroup('s-progress', ops.buildSectionGroups([inProgress])).map(w => w.id),
+    }
+  })
+}
+
+describe('useWorkspaceOperations getWorkspacesForGroup', () => {
+  beforeEach(() => {
+    localStorageClearForTests()
+    setStorageAccount('u-1')
+    resetWorkspaceListStateForTests()
+  })
+
+  it('returns the lexorank order under the default manual sort', () => {
+    const v = viewOrder(['Charlie', 'alpha', 'Bravo'])
+    expect(v.ids()).toEqual(['w0', 'w1', 'w2'])
+    v.dispose()
+  })
+
+  it('applies the global sort', () => {
+    const v = viewOrder(['Charlie', 'alpha', 'Bravo'])
+    setWorkspaceSortOrder({ key: 'name', direction: 'asc' })
+    expect(v.ids()).toEqual(['w1', 'w2', 'w0'])
+    v.dispose()
+  })
+
+  it('ranks by the most recently activated TAB under the recent sort', () => {
+    const v = viewOrder(['a', 'b', 'c'], { mru: { w0: 1, w1: 9, w2: 5 } })
+    setWorkspaceSortOrder({ key: 'recent', direction: 'desc' })
+    expect(v.ids()).toEqual(['w1', 'w2', 'w0'])
+    v.dispose()
+  })
+
+  it('applies the section filter', () => {
+    const v = viewOrder(['gentle-amber-fox', 'Bold Blue Bear', 'amber tooling'])
+    toggleSectionFilter('s-progress')
+    setSectionFilterQuery('s-progress', 'amber')
+    expect(v.ids()).toEqual(['w0', 'w2'])
+    v.dispose()
+  })
+
+  it('ignores a filter aimed at a DIFFERENT section', () => {
+    const v = viewOrder(['gentle-amber-fox', 'Bold Blue Bear'])
+    toggleSectionFilter('s-other')
+    setSectionFilterQuery('s-other', 'amber')
+    expect(v.ids()).toEqual(['w0', 'w1'])
+    v.dispose()
+  })
+
+  it('filters BEFORE it sorts, so the sort sees the narrowed list', () => {
+    const v = viewOrder(['zeta amber', 'Bold Blue Bear', 'alpha amber'])
+    toggleSectionFilter('s-progress')
+    setSectionFilterQuery('s-progress', 'amber')
+    setWorkspaceSortOrder({ key: 'name', direction: 'asc' })
+    expect(v.ids()).toEqual(['w2', 'w0'])
+    v.dispose()
+  })
+
+  it('answers empty for a section that does not exist', () => {
+    const v = viewOrder(['a'])
+    expect(v.ids()).toEqual(['w0'])
+    v.dispose()
   })
 })

--- a/frontend/src/components/shell/useWorkspaceOperations.test.ts
+++ b/frontend/src/components/shell/useWorkspaceOperations.test.ts
@@ -54,7 +54,6 @@ function harness(opts: HarnessOpts = {}) {
       sectionStore: createSectionStore(),
       loadSections: async () => {},
       onSelectWorkspace: () => {},
-      onNewWorkspace: () => {},
       onRefreshWorkspaces: () => {},
       onDeleteWorkspace: opts.onDeleteWorkspace ?? (() => {}),
     }),
@@ -226,7 +225,6 @@ function groupsFor(workspaces: Workspace[], sections: Section[], items: SectionI
       sectionStore,
       loadSections: async () => {},
       onSelectWorkspace: () => {},
-      onNewWorkspace: () => {},
       onRefreshWorkspaces: () => {},
       onDeleteWorkspace: () => {},
     })

--- a/frontend/src/components/shell/useWorkspaceOperations.ts
+++ b/frontend/src/components/shell/useWorkspaceOperations.ts
@@ -7,7 +7,7 @@ import { createSignal } from 'solid-js'
 import { sectionClient, workspaceClient } from '~/api/clients'
 import * as workerRpc from '~/api/workerRpc'
 import { showWarnToast } from '~/components/common/Toast'
-import { sectionFilterQuery, workspaceSortOrder } from '~/components/workspace/workspaceListState'
+import { canReorderWithinSection, sectionFilterQuery, workspaceSortOrder } from '~/components/workspace/workspaceListState'
 import { SectionType } from '~/generated/proto/leapmux/v1/section_pb'
 import { appendPosition, mid } from '~/lib/lexorank'
 import { cleanName } from '~/lib/validate'
@@ -167,7 +167,30 @@ export function useWorkspaceOperations(props: UseWorkspaceOperationsProps) {
   // Workspace operations
   // ---------------------------------------------------------------------------
 
+  const getSectionId = (workspaceId: string): string | undefined => {
+    return store.getSectionForWorkspace(workspaceId)
+  }
+
+  const isWorkspaceArchived = (workspaceId: string): boolean => {
+    const archivedSection = store.getArchivedSection()
+    if (!archivedSection)
+      return false
+    return getSectionId(workspaceId) === archivedSection.id
+  }
+
+  /**
+   * Open the inline rename input for one workspace row.
+   *
+   * It refuses an ARCHIVED workspace, because the hub does: `RenameWorkspace`
+   * answers FailedPrecondition there. Hiding the menu item is not enough -- the
+   * row's own double-click reaches this directly, so a user could open the
+   * input, type a name, and collect a "Failed to rename workspace" toast for a
+   * control the app offered. `WorkspaceTabTree.startEditing` guards the sibling
+   * tab operation the same way, for the same reason.
+   */
   const startRename = (workspace: Workspace) => {
+    if (isWorkspaceArchived(workspace.id))
+      return
     setRenamingWorkspaceId(workspace.id)
     setRenameValue(workspace.title || 'Untitled')
   }
@@ -194,6 +217,14 @@ export function useWorkspaceOperations(props: UseWorkspaceOperationsProps) {
     // `renameTab` uses for exactly this reason.
     const title = cleanName(renameValue())
     if (!id || !title) {
+      cancelRename()
+      return
+    }
+    // Archived between opening the input and committing it. `startRename`
+    // refuses an archived workspace, but the row's grip stays draggable while
+    // the input is open, so a user can drag the row onto Archived and the blur
+    // then commits into a rename the hub answers with FailedPrecondition.
+    if (isWorkspaceArchived(id)) {
       cancelRename()
       return
     }
@@ -264,6 +295,15 @@ export function useWorkspaceOperations(props: UseWorkspaceOperationsProps) {
     return null
   }
 
+  /** Re-read the lists a delete invalidated, then hand the caller the next id. */
+  const finishDelete = async (workspaceId: string) => {
+    await Promise.all([props.onRefreshWorkspaces(), props.loadSections()])
+    if (props.onDeleteWorkspace) {
+      const nextId = findFirstNonArchivedWorkspaceId()
+      props.onDeleteWorkspace(workspaceId, nextId)
+    }
+  }
+
   /**
    * Delete one workspace, WITHOUT asking.
    *
@@ -271,7 +311,7 @@ export function useWorkspaceOperations(props: UseWorkspaceOperationsProps) {
    * set instead of N times. It is not exported: every caller outside this hook
    * goes through `deleteWorkspace` and gets the confirm.
    */
-  const performDelete = async (workspaceId: string) => {
+  const performDelete = async (workspaceId: string, refresh = true) => {
     const done = startWorkspaceLoading(workspaceId)
     try {
       // 1. Hub soft-deletes the workspace and answers with each hosting worker
@@ -294,12 +334,13 @@ export function useWorkspaceOperations(props: UseWorkspaceOperationsProps) {
         ),
       )
 
-      await Promise.all([props.onRefreshWorkspaces(), props.loadSections()])
-
-      if (props.onDeleteWorkspace) {
-        const nextId = findFirstNonArchivedWorkspaceId()
-        props.onDeleteWorkspace(workspaceId, nextId)
-      }
+      // A bulk caller passes `refresh: false` and runs this ONCE for the whole
+      // set. Both calls are full-collection RPCs, so a per-item refresh costs
+      // 2N round trips to fetch N-1 states nobody sees. The two steps move
+      // together because `findFirstNonArchivedWorkspaceId` reads the store the
+      // refresh just wrote.
+      if (refresh)
+        await finishDelete(workspaceId)
     }
     catch (err) {
       showWarnToast('Failed to delete workspace', err)
@@ -310,11 +351,17 @@ export function useWorkspaceOperations(props: UseWorkspaceOperationsProps) {
   }
 
   /**
-   * The workspaces currently in the Archived section, in sidebar order.
+   * The workspaces currently in the Archived section, unfiltered and in sidebar
+   * order.
    *
    * Read fresh at the start of each bulk operation rather than passed in: the
    * loops below await between iterations, and the caller's snapshot would be
    * one lifecycle event out of date.
+   *
+   * The section menu shows its two bulk items from this, and both operations
+   * act on it -- so the menu can no longer offer an irreversible "Empty
+   * archive" for a set the user cannot see, nor hide it while the archive is
+   * full.
    */
   const archivedWorkspaceIds = (): string[] => {
     const archivedSection = store.getArchivedSection()
@@ -368,8 +415,18 @@ export function useWorkspaceOperations(props: UseWorkspaceOperationsProps) {
       if (!confirmed)
         return
     }
-    for (const workspaceId of workspaceIds)
-      await performDelete(workspaceId)
+    // The INTERSECTION of what the user confirmed with what is still archived.
+    // The confirm is an unbounded await, and any workspace lifecycle event
+    // reloads the sections under it -- so a workspace unarchived meanwhile is
+    // in the snapshot but must not be deleted. Deleting the fresh list instead
+    // would have the mirror fault: a workspace archived during the dialog was
+    // never part of the count the user agreed to.
+    const stillArchived = new Set(archivedWorkspaceIds())
+    const doomed = workspaceIds.filter(id => stillArchived.has(id))
+    for (const workspaceId of doomed)
+      await performDelete(workspaceId, false)
+    if (doomed.length > 0)
+      await finishDelete(doomed[doomed.length - 1])
   }
 
   const deleteWorkspace = async (workspaceId: string) => {
@@ -379,17 +436,6 @@ export function useWorkspaceOperations(props: UseWorkspaceOperationsProps) {
         return
     }
     await performDelete(workspaceId)
-  }
-
-  const getSectionId = (workspaceId: string): string | undefined => {
-    return store.getSectionForWorkspace(workspaceId)
-  }
-
-  const isWorkspaceArchived = (workspaceId: string): boolean => {
-    const archivedSection = store.getArchivedSection()
-    if (!archivedSection)
-      return false
-    return getSectionId(workspaceId) === archivedSection.id
   }
 
   const canAddToSection = (section: Section): boolean => {
@@ -444,6 +490,12 @@ export function useWorkspaceOperations(props: UseWorkspaceOperationsProps) {
       targetSectionId = droppable.data?.sectionId as string
 
       if (fromSectionId === targetSectionId) {
+        // A same-section reorder has no meaning while the view order differs
+        // from the model order, which is what a non-manual sort or a live
+        // filter produces. The rows stay sortable so a CROSS-section drop can
+        // still resolve a row target; only this case is suppressed.
+        if (!canReorderWithinSection(targetSectionId))
+          return
         const items = store.getItemsForSection(targetSectionId)
         const dragIdx = items.findIndex(i => i.workspaceId === wsId)
         const dropIdx = items.findIndex(i => i.workspaceId === targetWsId)
@@ -512,8 +564,13 @@ export function useWorkspaceOperations(props: UseWorkspaceOperationsProps) {
    * the header menu's Collapse all, the repository list -- sees the same list.
    * `buildSectionGroups` above answers the MODEL order (lexorank); the filter
    * and the sort are applied here, on top of it.
+   *
+   * It is a plain function, and `useSidebarCore` calls it once per section
+   * inside one memo. Calling it per read instead cost a fresh filter pass, a
+   * fresh sort and two array copies six to eight times per section on every
+   * tick of a global signal.
    */
-  const getWorkspacesForGroup = (sectionId: string, groups: SectionGroup[]): Workspace[] => {
+  const getWorkspacesForGroup = (sectionId: string, groups: SectionGroup[]): readonly Workspace[] => {
     const group = groups.find(g => g.section.id === sectionId)
     if (!group)
       return []
@@ -528,7 +585,6 @@ export function useWorkspaceOperations(props: UseWorkspaceOperationsProps) {
 
     // Grouping
     buildSectionGroups,
-    getWorkspacesForGroup,
 
     // Operations
     startRename,
@@ -537,6 +593,7 @@ export function useWorkspaceOperations(props: UseWorkspaceOperationsProps) {
     moveWorkspace,
     archiveWorkspace,
     unarchiveWorkspace,
+    getWorkspacesForGroup,
     unarchiveAll,
     emptyArchive,
     archivedWorkspaceIds,

--- a/frontend/src/components/shell/useWorkspaceOperations.ts
+++ b/frontend/src/components/shell/useWorkspaceOperations.ts
@@ -1,14 +1,17 @@
 import type { Section } from '~/generated/proto/leapmux/v1/section_pb'
 import type { Workspace } from '~/generated/proto/leapmux/v1/workspace_pb'
 import type { createSectionStore } from '~/stores/section.store'
+import type { Tab } from '~/stores/tab.types'
 
 import { createSignal } from 'solid-js'
 import { sectionClient, workspaceClient } from '~/api/clients'
 import * as workerRpc from '~/api/workerRpc'
 import { showWarnToast } from '~/components/common/Toast'
+import { sectionFilterQuery, workspaceSortOrder } from '~/components/workspace/workspaceListState'
 import { SectionType } from '~/generated/proto/leapmux/v1/section_pb'
 import { appendPosition, mid } from '~/lib/lexorank'
 import { cleanName } from '~/lib/validate'
+import { filterWorkspaces, sortWorkspaces } from '~/lib/workspaceSort'
 import { isWorkspaceSection } from './sectionUtils'
 
 export interface SectionGroup {
@@ -26,6 +29,20 @@ export interface UseWorkspaceOperationsProps {
   onDeleteWorkspace: (deletedId: string, nextWorkspaceId: string | null) => void
   onConfirmDelete?: (workspaceId: string) => Promise<boolean>
   onConfirmArchive?: (workspaceId: string) => Promise<boolean>
+  /**
+   * Confirm emptying the archive, naming the number of workspaces. ONE prompt
+   * for the whole operation -- the per-workspace confirm is suppressed, and it
+   * would be unusable anyway: `confirmDeleteWsDialog` is a single-slot dialog
+   * state, so N concurrent opens drop N-1 resolvers and those awaits never
+   * settle.
+   */
+  onConfirmEmptyArchive?: (count: number) => Promise<boolean>
+  /**
+   * A workspace's tabs, for the `recent` sort. Optional: a caller with no tab
+   * projection (the section-grouping unit tests) leaves every workspace
+   * unranked, which sorts them by title instead.
+   */
+  getTabsForWorkspace?: (workspaceId: string) => Tab[]
   onPostArchiveWorkspace?: (workspaceId: string) => void
 }
 
@@ -247,12 +264,14 @@ export function useWorkspaceOperations(props: UseWorkspaceOperationsProps) {
     return null
   }
 
-  const deleteWorkspace = async (workspaceId: string) => {
-    if (props.onConfirmDelete) {
-      const confirmed = await props.onConfirmDelete(workspaceId)
-      if (!confirmed)
-        return
-    }
+  /**
+   * Delete one workspace, WITHOUT asking.
+   *
+   * Split out of `deleteWorkspace` so `emptyArchive` can ask once for the whole
+   * set instead of N times. It is not exported: every caller outside this hook
+   * goes through `deleteWorkspace` and gets the confirm.
+   */
+  const performDelete = async (workspaceId: string) => {
     const done = startWorkspaceLoading(workspaceId)
     try {
       // 1. Hub soft-deletes the workspace and answers with each hosting worker
@@ -288,6 +307,78 @@ export function useWorkspaceOperations(props: UseWorkspaceOperationsProps) {
     finally {
       done()
     }
+  }
+
+  /**
+   * The workspaces currently in the Archived section, in sidebar order.
+   *
+   * Read fresh at the start of each bulk operation rather than passed in: the
+   * loops below await between iterations, and the caller's snapshot would be
+   * one lifecycle event out of date.
+   */
+  const archivedWorkspaceIds = (): string[] => {
+    const archivedSection = store.getArchivedSection()
+    if (!archivedSection)
+      return []
+    return store.getItemsForSection(archivedSection.id).map(i => i.workspaceId)
+  }
+
+  /**
+   * Move every archived workspace back to In progress.
+   *
+   * SEQUENTIAL, and that is the whole implementation note. `moveWorkspace`
+   * computes `appendPosition(getItemsForSection(...))`, which reads
+   * `items.at(-1)` BEFORE its await while the store write lands after it -- so a
+   * parallel fan-out hands every call the identical lexorank and the sidebar
+   * shuffles the whole set on the next refresh.
+   *
+   * There is no transaction: each move is its own RPC, so a failure part way
+   * through leaves the archive partly emptied. Each failed move raises its own
+   * warning toast, which is the whole safety story.
+   */
+  const unarchiveAll = async () => {
+    const inProgressSection = store.getInProgressSection()
+    if (!inProgressSection)
+      return
+    for (const workspaceId of archivedWorkspaceIds())
+      await moveWorkspace(workspaceId, inProgressSection.id)
+  }
+
+  /**
+   * Delete every archived workspace, after ONE confirm naming the count.
+   *
+   * Sequential for the same reason as `unarchiveAll`, and for a second one:
+   * suppressing the per-workspace confirm is what makes the operation usable at
+   * all, and the dialog state behind it holds one payload, so N concurrent
+   * opens would drop N-1 resolvers and hang.
+   *
+   * Not a transaction either. A failure part way through leaves the archive
+   * partly emptied, with one warning toast per failed workspace.
+   */
+  const emptyArchive = async () => {
+    const workspaceIds = archivedWorkspaceIds()
+    // Nothing to confirm and nothing to do. `archiveWorkspace` and
+    // `unarchiveWorkspace` guard a missing SECTION; nothing guarded an empty
+    // item list, and asking "delete 0 workspaces?" is a prompt with no answer
+    // worth giving.
+    if (workspaceIds.length === 0)
+      return
+    if (props.onConfirmEmptyArchive) {
+      const confirmed = await props.onConfirmEmptyArchive(workspaceIds.length)
+      if (!confirmed)
+        return
+    }
+    for (const workspaceId of workspaceIds)
+      await performDelete(workspaceId)
+  }
+
+  const deleteWorkspace = async (workspaceId: string) => {
+    if (props.onConfirmDelete) {
+      const confirmed = await props.onConfirmDelete(workspaceId)
+      if (!confirmed)
+        return
+    }
+    await performDelete(workspaceId)
   }
 
   const getSectionId = (workspaceId: string): string | undefined => {
@@ -395,9 +486,39 @@ export function useWorkspaceOperations(props: UseWorkspaceOperationsProps) {
   // Reactive helpers for content factories
   // ---------------------------------------------------------------------------
 
+  /**
+   * How recently a workspace was used: the highest `mru` across its tabs.
+   *
+   * Undefined when the caller supplied no tab accessor, or when no tab of the
+   * workspace was activated this session -- `mru` is a per-session counter, so
+   * "none" is a real answer and `sortWorkspaces` pins it last.
+   */
+  const workspaceRecency = (workspaceId: string): number | undefined => {
+    const tabs = props.getTabsForWorkspace?.(workspaceId)
+    if (!tabs || tabs.length === 0)
+      return undefined
+    let best: number | undefined
+    for (const tab of tabs) {
+      if (tab.mru !== undefined && (best === undefined || tab.mru > best))
+        best = tab.mru
+    }
+    return best
+  }
+
+  /**
+   * One section's workspaces, in the order the rows are drawn.
+   *
+   * The ONE place the view order is produced, so every consumer -- the rows,
+   * the header menu's Collapse all, the repository list -- sees the same list.
+   * `buildSectionGroups` above answers the MODEL order (lexorank); the filter
+   * and the sort are applied here, on top of it.
+   */
   const getWorkspacesForGroup = (sectionId: string, groups: SectionGroup[]): Workspace[] => {
     const group = groups.find(g => g.section.id === sectionId)
-    return group?.workspaces ?? []
+    if (!group)
+      return []
+    const filtered = filterWorkspaces(group.workspaces, sectionFilterQuery(sectionId) ?? '')
+    return sortWorkspaces(filtered, workspaceSortOrder(), workspaceRecency)
   }
 
   return {
@@ -416,6 +537,9 @@ export function useWorkspaceOperations(props: UseWorkspaceOperationsProps) {
     moveWorkspace,
     archiveWorkspace,
     unarchiveWorkspace,
+    unarchiveAll,
+    emptyArchive,
+    archivedWorkspaceIds,
     deleteWorkspace,
     canAddToSection,
     isWorkspaceArchived,

--- a/frontend/src/components/shell/useWorkspaceOperations.ts
+++ b/frontend/src/components/shell/useWorkspaceOperations.ts
@@ -22,7 +22,6 @@ export interface UseWorkspaceOperationsProps {
   sectionStore: ReturnType<typeof createSectionStore>
   loadSections: () => Promise<void>
   onSelectWorkspace: (id: string) => void
-  onNewWorkspace: (sectionId: string | null) => void
   onRefreshWorkspaces: () => void | Promise<void>
   onDeleteWorkspace: (deletedId: string, nextWorkspaceId: string | null) => void
   onConfirmDelete?: (workspaceId: string) => Promise<boolean>

--- a/frontend/src/components/workspace/BranchContextMenu.test.tsx
+++ b/frontend/src/components/workspace/BranchContextMenu.test.tsx
@@ -22,7 +22,7 @@ const listShells = workerRpc.listAvailableShells as unknown as ReturnType<typeof
 // The Popover API stubs come from `vitest.setup.ts`, and this suite needs THOSE
 // rather than bare `vi.fn()` replacements: they dispatch the `toggle` event and
 // answer `:popover-open`, which is how the menu learns that it opened -- and the
-// two worker-list fetches below are gated on exactly that.
+// two worker-list fetches below depend on exactly that.
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -57,6 +57,18 @@ function menuItem(label: string): HTMLElement {
 }
 
 /** Open the menu and let the two on-open list fetches settle. */
+/**
+ * Click one item, reopening the menu first when a previous click dismissed it.
+ *
+ * The items mount only while the menu is open, so a test that picks several in
+ * a row has to reopen between them -- which is what a user does too.
+ */
+async function clickItem(trigger: HTMLElement, label: string) {
+  if (!screen.queryByText(label))
+    await fireEvent.click(trigger)
+  await fireEvent.click(screen.getByText(label))
+}
+
 async function openMenu(trigger: HTMLElement) {
   await fireEvent.click(trigger)
   // Both list hooks resolve on a microtask; flush it so the provider row and
@@ -102,13 +114,13 @@ describe('branchContextMenu', () => {
     expect(actions.onChangeBranch).not.toHaveBeenCalled()
   })
 
-  // The DELETE item names what it destroys. On a worktree row it removes a
+  // The DELETE item states what it destroys. On a worktree row it removes a
   // whole directory, and "Delete branch..." there is how a user destroys a
   // directory they meant to keep. The CHANGE items keep their names on both,
   // because a worktree has a branch checked out and the dialog still changes
   // that branch.
   describe('on a worktree row', () => {
-    it('names the delete item after the worktree', async () => {
+    it('labels the delete item after the worktree', async () => {
       const { trigger } = renderMenu(undefined, true)
       await fireEvent.click(trigger)
 
@@ -195,8 +207,8 @@ describe('branchContextMenu', () => {
     it('routes the two dialog items to their own actions', async () => {
       const { actions, trigger } = renderMenu()
       await openMenu(trigger)
-      await fireEvent.click(screen.getByText('New agent...'))
-      await fireEvent.click(screen.getByText('New terminal...'))
+      await clickItem(trigger, 'New agent...')
+      await clickItem(trigger, 'New terminal...')
 
       expect(actions.onNewAgentAdvanced).toHaveBeenCalledTimes(1)
       expect(actions.onNewTerminalAdvanced).toHaveBeenCalledTimes(1)
@@ -249,9 +261,11 @@ describe('branchContextMenu', () => {
     it('fires no action while disabled', async () => {
       const { actions, trigger } = renderMenu(reason)
       await openMenu(trigger)
-      await fireEvent.click(screen.getByText('Switch to branch...'))
-      await fireEvent.click(screen.getByText('Delete branch...'))
-      await fireEvent.click(screen.getByText('New agent...'))
+      await clickItem(trigger, 'Switch to branch...')
+      await clickItem(trigger, 'Delete branch...')
+      await clickItem(trigger, 'New agent...')
+      if (!screen.queryByTestId(`menu-new-agent-${AgentProvider.CODEX}`))
+        await fireEvent.click(trigger)
       await fireEvent.click(screen.getByTestId(`menu-new-agent-${AgentProvider.CODEX}`))
       expect(actions.onChangeBranch).not.toHaveBeenCalled()
       expect(actions.onDeleteBranch).not.toHaveBeenCalled()

--- a/frontend/src/components/workspace/BranchContextMenu.tsx
+++ b/frontend/src/components/workspace/BranchContextMenu.tsx
@@ -24,7 +24,7 @@ interface BranchContextMenuProps extends ContextMenuTargetProps {
    */
   'workerId': string
   /**
-   * True iff the row's checkout is a linked worktree. It names the DELETE item
+   * True iff the row's checkout is a linked worktree. It labels the DELETE item
    * only: deleting a worktree removes a whole directory, and calling that
    * "Delete branch..." is how a user destroys a directory they meant to keep.
    *
@@ -102,7 +102,13 @@ export const BranchContextMenu: Component<BranchContextMenuProps> = (props) => {
       onToggle={setMenuOpen}
       data-testid={props['data-testid']}
     >
-      {/* The three modes the Change branch dialog offers, each opening it with
+      {/* These children mount eagerly, which is safe even while this menu
+          serves as a SUBMENU (the composer's `[+]` branch item):
+          `DropdownMenu`'s roving focus skips an item inside a nested popover
+          that is closed, so they are not ArrowDown stops or type-ahead
+          matches until this menu opens.
+
+          The three modes the Change branch dialog offers, each opening it with
           its own radio already selected. One item per mode, because a single
           "Change branch..." made the user open the dialog to discover that
           "Create new worktree" lived inside it.

--- a/frontend/src/components/workspace/BranchContextMenu.tsx
+++ b/frontend/src/components/workspace/BranchContextMenu.tsx
@@ -10,7 +10,7 @@ import { Tooltip } from '~/components/common/Tooltip'
 import { workingTreeDeleteLabel } from '~/components/common/WorkingTree'
 import { useAvailableProviders } from '~/hooks/useAvailableProviders'
 import { useAvailableShells } from '~/hooks/useAvailableShells'
-import { GitMode } from '~/hooks/useGitModeState'
+import { GitMode, gitModeMenuLabel } from '~/hooks/useGitModeState'
 import { dangerMenuItem } from '~/styles/shared.css'
 
 interface BranchContextMenuProps extends ContextMenuTargetProps {
@@ -79,8 +79,8 @@ export const BranchContextMenu: Component<BranchContextMenuProps> = (props) => {
   const { providers } = useAvailableProviders(listSource)
   const { shells, defaultShell } = useAvailableShells(listSource)
 
-  /** One change item. The three differ only in their label and their mode. */
-  const changeItem = (label: string, mode: ChangeBranchMode) => (
+  /** One change item. The three differ only in their mode. */
+  const changeItem = (mode: ChangeBranchMode) => (
     // The reason goes through <Tooltip>, which works on a disabled control and
     // leaves the item its own name. A `title` this long BECOMES the accessible
     // name, so a screen reader announced the reason in place of the label.
@@ -90,7 +90,7 @@ export const BranchContextMenu: Component<BranchContextMenuProps> = (props) => {
         disabled={Boolean(props.disabledReason)}
         onClick={() => props.actions.onChangeBranch(mode)}
       >
-        {label}
+        {gitModeMenuLabel(mode)}
       </button>
     </Tooltip>
   )
@@ -105,11 +105,15 @@ export const BranchContextMenu: Component<BranchContextMenuProps> = (props) => {
       {/* The three modes the Change branch dialog offers, each opening it with
           its own radio already selected. One item per mode, because a single
           "Change branch..." made the user open the dialog to discover that
-          "Create new worktree" lived inside it. The labels are the dialog's own
-          radio labels, so the item the user picks states what they then see. */}
-      {changeItem('Switch to branch...', GitMode.SwitchBranch)}
-      {changeItem('Create new branch...', GitMode.CreateBranch)}
-      {changeItem('Create new worktree...', GitMode.CreateWorktree)}
+          "Create new worktree" lived inside it.
+
+          The label comes from `gitModeMenuLabel`, which is the dialog's own
+          radio label plus the three dots an item that opens a dialog carries.
+          One table, so the item the user picks states what they then see -- and
+          renaming a radio cannot leave this menu stating the old name. */}
+      {changeItem(GitMode.SwitchBranch)}
+      {changeItem(GitMode.CreateBranch)}
+      {changeItem(GitMode.CreateWorktree)}
       <hr />
       <Tooltip text={props.disabledReason}>
         <button

--- a/frontend/src/components/workspace/ChangeBranchDialog.tsx
+++ b/frontend/src/components/workspace/ChangeBranchDialog.tsx
@@ -23,7 +23,7 @@ import { useAgentProviderSelection } from '~/hooks/useAgentProviderSelection'
 import { useAvailableShells } from '~/hooks/useAvailableShells'
 import { useChangeBranchInspect } from '~/hooks/useChangeBranchInspect'
 import { useDialogSubmit } from '~/hooks/useDialogSubmit'
-import { changeBranchInitialIntent, fieldsForCreateWorktree, GitMode, isChangeBranchMode, useGitModeState } from '~/hooks/useGitModeState'
+import { CHANGE_BRANCH_MODES, changeBranchInitialIntent, fieldsForCreateWorktree, GitMode, isChangeBranchMode, useGitModeState } from '~/hooks/useGitModeState'
 import { formatErrorMessage } from '~/lib/errors'
 import { createLogger } from '~/lib/logger'
 import { flavorFromOs } from '~/lib/paths'
@@ -346,7 +346,10 @@ export const ChangeBranchDialog: Component<ChangeBranchDialogProps> = (props) =>
               gitInfo={pathInfo}
               gitMode={gitMode.gitMode}
               onGitModeChange={gitMode.handleGitModeChange}
-              modes={[GitMode.SwitchBranch, GitMode.CreateBranch, GitMode.CreateWorktree]}
+              // The constant, not a hand-copied literal: `isChangeBranchMode`
+              // above validates the submitted intent against it, so a spelled
+              // list here could offer a radio the submit path then refuses.
+              modes={CHANGE_BRANCH_MODES}
               preloadedBranches={inspect.branches}
               preloadedBranchesLoading={inspect.branchesLoading}
               onRefreshBranches={inspect.refresh}

--- a/frontend/src/components/workspace/NewWorkspaceDialog.test.tsx
+++ b/frontend/src/components/workspace/NewWorkspaceDialog.test.tsx
@@ -67,7 +67,7 @@ vi.mock('~/lib/crdt', async importOriginal => ({
 
 // The real tree issues its own `listDirectory` round-trips and renders nothing
 // this dialog's submit path depends on. Stub it down to the one thing the
-// dialog reads back from it -- the selected working directory, which gates
+// dialog reads back from it -- the selected working directory, which controls
 // submit.
 vi.mock('~/components/tree/DirectoryTree', () => ({
   DirectoryTree: (props: { onSelect: (path: string) => void }) => (
@@ -124,7 +124,7 @@ function renderDialog(overrides: Partial<Parameters<typeof NewWorkspaceDialog>[0
 }
 
 /**
- * Drive the dialog to a submittable state and click Create. Submit is gated on
+ * Drive the dialog to a submittable state and click Create. Submit depends on
  * a selected worker (arrives with the `listWorkers` mock) AND a non-empty
  * working directory, which only the directory tree can supply.
  */

--- a/frontend/src/components/workspace/NewWorkspaceDialog.test.tsx
+++ b/frontend/src/components/workspace/NewWorkspaceDialog.test.tsx
@@ -1,3 +1,4 @@
+import type { WorkspaceStartPoint } from './workspaceStartPoint'
 import type { TabMetadataStore } from '~/stores/tabMetadata.store'
 import { create } from '@bufbuild/protobuf'
 import { fireEvent, render, screen, waitFor } from '@solidjs/testing-library'
@@ -6,17 +7,21 @@ import { workspaceClient } from '~/api/clients'
 import * as workerRpc from '~/api/workerRpc'
 import { AgentInfoSchema, AgentProvider, AgentStatus, OpenAgentResponseSchema } from '~/generated/proto/leapmux/v1/agent_pb'
 import { CreateWorkspaceResponseSchema, DeleteWorkspaceResponseSchema, TabType } from '~/generated/proto/leapmux/v1/workspace_pb'
+import { GitMode } from '~/hooks/useGitModeState'
+import { localStorageClearForTests, localStorageSet, PREFIX_WORKSPACE_GIT_MODE, setStorageAccount } from '~/lib/browserStorage'
 import { seedTabIntoNewWorkspace } from '~/lib/crdt'
 import { createRepoGitStore } from '~/stores/repoGit.store'
 /// <reference types="vitest/globals" />
 import { withPreferences } from '~/test-support/preferencesProvider'
 import { NewWorkspaceDialog } from './NewWorkspaceDialog'
+import { gitModeStickyKey, readStickyGitMode } from './workspaceStartPoint'
 
 // Hoisted alongside the `vi.mock` factories below, which read them. A plain
 // `const` would be in its temporal dead zone when the factories run.
-const { WORKER_ID, WORKING_DIR, NEW_WORKSPACE_ID } = vi.hoisted(() => ({
+const { WORKER_ID, WORKING_DIR, REPO_DIR, NEW_WORKSPACE_ID } = vi.hoisted(() => ({
   WORKER_ID: 'w1',
   WORKING_DIR: '/home/u/proj',
+  REPO_DIR: '/home/u/leapmux',
   NEW_WORKSPACE_ID: 'ws-new',
 }))
 
@@ -44,6 +49,10 @@ vi.mock('~/stores/workerInfo.store', () => ({
 vi.mock('~/api/workerRpc', () => ({
   openAgent: vi.fn(),
   getGitInfo: vi.fn(),
+  // GitOptions issues both of these as soon as it mounts, which a seeded
+  // path-info snapshot makes happen on the first paint.
+  listGitBranches: vi.fn(async () => ({ branches: [] })),
+  listGitWorktrees: vi.fn(async () => ({ worktrees: [] })),
   listDirectory: vi.fn(),
   statFile: vi.fn(async () => ({ info: { modTime: '2026-01-01T00:00:00Z' } })),
 }))
@@ -104,6 +113,7 @@ function renderDialog(overrides: Partial<Parameters<typeof NewWorkspaceDialog>[0
   const props = {
     onCreated: vi.fn(),
     onClose: vi.fn(),
+    startPoint: { kind: 'directory' } as WorkspaceStartPoint,
     availableProviders: [AgentProvider.CLAUDE_CODE],
     metadata: { patch: vi.fn() } as unknown as TabMetadataStore,
     repoGitStore: createRepoGitStore(),
@@ -380,6 +390,91 @@ describe('newWorkspaceDialog', () => {
       expect(workerRpc.openAgent).not.toHaveBeenCalled()
       expect(workspaceClient.deleteWorkspace).not.toHaveBeenCalled()
       expect(props.onCreated).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('a repo start point', () => {
+    const REPO_START: WorkspaceStartPoint = {
+      kind: 'repo',
+      workerId: WORKER_ID,
+      gitToplevel: REPO_DIR,
+      isWorktree: false,
+      currentBranch: 'main',
+    }
+
+    beforeEach(() => {
+      localStorageClearForTests()
+      setStorageAccount('u-1')
+    })
+
+    it('opens ready to submit, with no directory to pick', async () => {
+      // The whole point of the start point: the menu already knows the worker
+      // and the repository, so the dialog must not re-ask for either.
+      renderDialog({ startPoint: REPO_START })
+
+      const createButton = await screen.findByRole('button', { name: 'Create' }) as HTMLButtonElement
+      await waitFor(() => expect(createButton.disabled).toBe(false))
+      fireEvent.click(createButton)
+
+      await waitFor(() => expect(workerRpc.openAgent).toHaveBeenCalledOnce())
+      expect(vi.mocked(workerRpc.openAgent).mock.calls[0][1])
+        .toMatchObject({ workerId: WORKER_ID, workingDir: REPO_DIR })
+    })
+
+    it('paints the git options straight away, with no loading spinner', async () => {
+      // The seeded snapshot is what keeps `skipLoadingFlash` armed. Without it
+      // the pre-filled dialog shows "Loading branch info" for a round trip.
+      renderDialog({ startPoint: REPO_START })
+
+      expect(await screen.findByLabelText('Use current state')).toBeInTheDocument()
+      expect(screen.queryByText(/loading branch info/i)).not.toBeInTheDocument()
+    })
+
+    it('opens on the mode this repository was last submitted with', async () => {
+      localStorageSet(`${PREFIX_WORKSPACE_GIT_MODE}${gitModeStickyKey(WORKER_ID, REPO_DIR)}`, 'create-worktree')
+      renderDialog({ startPoint: REPO_START })
+
+      await waitFor(() => expect(screen.getByLabelText('Create new worktree')).toBeChecked())
+    })
+
+    it('remembers the mode on a successful submit', async () => {
+      renderDialog({ startPoint: REPO_START })
+
+      const createButton = await screen.findByRole('button', { name: 'Create' }) as HTMLButtonElement
+      await waitFor(() => expect(createButton.disabled).toBe(false))
+      fireEvent.click(await screen.findByLabelText('Create new branch'))
+      fireEvent.click(createButton)
+
+      await waitFor(() => {
+        expect(readStickyGitMode(gitModeStickyKey(WORKER_ID, REPO_DIR))).toBe(GitMode.CreateBranch)
+      })
+    })
+
+    it('remembers nothing when the submit fails', async () => {
+      // A mode the user selected and then lost to an error is not what they
+      // work with, so the next dialog must not open on it.
+      vi.mocked(workerRpc.openAgent).mockRejectedValue(new Error('worker exploded'))
+      renderDialog({ startPoint: REPO_START })
+
+      const createButton = await screen.findByRole('button', { name: 'Create' }) as HTMLButtonElement
+      await waitFor(() => expect(createButton.disabled).toBe(false))
+      fireEvent.click(await screen.findByLabelText('Create new branch'))
+      fireEvent.click(createButton)
+
+      expect(await screen.findByText('worker exploded')).toBeInTheDocument()
+      expect(readStickyGitMode(gitModeStickyKey(WORKER_ID, REPO_DIR))).toBeUndefined()
+    })
+
+    it('remembers nothing for a directory that is not a repository', async () => {
+      // The key means "a repository root or a worktree root", which is exactly
+      // what `showGitOptions()` guarantees. A plain directory has no mode to
+      // remember.
+      renderDialog()
+
+      await submitDialog()
+
+      await waitFor(() => expect(workerRpc.openAgent).toHaveBeenCalledOnce())
+      expect(readStickyGitMode(gitModeStickyKey(WORKER_ID, WORKING_DIR))).toBeUndefined()
     })
   })
 })

--- a/frontend/src/components/workspace/NewWorkspaceDialog.tsx
+++ b/frontend/src/components/workspace/NewWorkspaceDialog.tsx
@@ -115,7 +115,7 @@ export const NewWorkspaceDialog: Component<NewWorkspaceDialogProps> = (props) =>
 
       const wid = worker.workerId()
       const provider = agentProvider()
-      // submitDisabled gates on noProviders(); reaching here with
+      // submitDisabled reads noProviders(); reaching here with
       // provider===undefined would mean the submit slipped past the
       // guard, so fail loudly before the proto serializer turns it into
       // enum 0.

--- a/frontend/src/components/workspace/NewWorkspaceDialog.tsx
+++ b/frontend/src/components/workspace/NewWorkspaceDialog.tsx
@@ -1,4 +1,5 @@
 import type { Component } from 'solid-js'
+import type { WorkspaceStartPoint } from './workspaceStartPoint'
 import type { AgentProvider } from '~/generated/proto/leapmux/v1/agent_pb'
 import type { createRepoGitStore } from '~/stores/repoGit.store'
 import type { TabMetadataStore } from '~/stores/tabMetadata.store'
@@ -22,14 +23,26 @@ import { createDirectoryTreeState } from '~/hooks/createDirectoryTreeState'
 import { createSessionIdState } from '~/hooks/createSessionIdState'
 import { createTitleState } from '~/hooks/createTitleState'
 import { useAgentProviderSelection } from '~/hooks/useAgentProviderSelection'
+import { initialIntentForMode } from '~/hooks/useGitModeState'
 import { useWorkerDialog } from '~/hooks/useWorkerDialog'
 import { seedTabIntoNewWorkspace } from '~/lib/crdt'
 import { openedAgentTabFields } from '~/stores/tab.helpers'
+import {
+  gitModeStickyKey,
+  readStickyGitMode,
+  rememberStickyGitMode,
+  startPointDialogSetup,
+} from './workspaceStartPoint'
 
 interface NewWorkspaceDialogProps {
   onCreated: (workspaceId: string) => void
   onClose: () => void
-  preselectedWorkerId?: string
+  /**
+   * Where the workspace starts from. Read ONCE at mount -- the dialog's `<Show>`
+   * is keyed, so a different start point remounts the whole form rather than
+   * mutating a half-filled one under the user.
+   */
+  startPoint: WorkspaceStartPoint
   availableProviders?: AgentProvider[]
   onRefreshProviders?: () => void
   /**
@@ -43,10 +56,28 @@ interface NewWorkspaceDialogProps {
 }
 
 export const NewWorkspaceDialog: Component<NewWorkspaceDialogProps> = (props) => {
+  // Read once: `useWorkerDialog`'s sub-hooks take their seeds as plain
+  // one-time values, and the keyed `<Show>` at the call site remounts this
+  // component whenever the start point changes.
+  // eslint-disable-next-line solid/reactivity -- one-time initial values
+  const setup = startPointDialogSetup(props.startPoint)
+  const seededMode = readStickyGitMode(setup.stickyKey)
+
   const { submit: { submitting, error, formHandler }, worker, gitMode, pathInfo } = useWorkerDialog({
     submit: { fallback: 'Failed to create workspace' },
-    // eslint-disable-next-line solid/reactivity -- one-time initial value
-    worker: { preselectedWorkerId: props.preselectedWorkerId },
+    worker: {
+      preselectedWorkerId: setup.workerId,
+      defaultWorkingDir: setup.workingDir,
+    },
+    // The mode this repository was last started with, so the form opens on the
+    // answer the user gave last time rather than on `Use current state`.
+    // `GitOptions` clamps a seed outside its enabled set, and this dialog
+    // enables all five, so any stored mode survives.
+    gitMode: seededMode === undefined ? undefined : { initialIntent: initialIntentForMode(seededMode) },
+    // A seeded snapshot, so `GitOptionsLoader` mounts `GitOptions` on the first
+    // paint instead of showing the "Loading branch info" spinner while the
+    // probe confirms what the menu already knew.
+    pathInfo: { seed: setup.pathInfoSeed },
   })
   const tree = createDirectoryTreeState()
   // A word slug, not the worker's tab-name pool: a workspace carries no
@@ -102,6 +133,13 @@ export const NewWorkspaceDialog: Component<NewWorkspaceDialogProps> = (props) =>
 
       if (agentResp.agent) {
         recordProviderUse(provider)
+        // Remember the git mode for THIS repository, from the live worker and
+        // directory rather than from the start point -- the user may have
+        // navigated somewhere else in the dialog. `showGitOptions()` is the
+        // guarantee that the path is a repository root or a worktree root,
+        // which is exactly what the key means.
+        if (pathInfo.showGitOptions())
+          rememberStickyGitMode(gitModeStickyKey(wid, worker.workingDir()), gitMode.gitMode())
         // Seed the agent's METADATA first, BEFORE the placement below -- the
         // same order `openTabInFocusedTile` documents and every other open path
         // follows. Placement is what makes the tab exist for the projection, and

--- a/frontend/src/components/workspace/WorkspaceContextMenu.test.tsx
+++ b/frontend/src/components/workspace/WorkspaceContextMenu.test.tsx
@@ -18,7 +18,7 @@ import { withPreferences } from '~/test-support/preferencesProvider'
  * the "jsdom lacks the popover API" mock this file used to carry was obsolete.
  * It also actively hid three things: it dropped `onToggle` on the floor, so a
  * missing `onToggle={setMenuOpen}` (the likeliest bug in a menu whose whole
- * content is gated on it) passed green; it FLATTENED every submenu into the
+ * content depends on it) passed green; it FLATTENED every submenu into the
  * parent's item list, so an order assertion could not fail on a nesting
  * mistake; and it nulled out the item-content components this menu needs.
  */
@@ -83,7 +83,7 @@ function renderMenu(overrides: Partial<Parameters<typeof WorkspaceContextMenu>[0
   return props
 }
 
-/** Open the menu, as a user does. Every item below is gated on it. */
+/** Open the menu, as a user does. Every item below depends on it. */
 function openMenu() {
   fireEvent.click(screen.getByTestId('workspace-row-menu-trigger'))
 }
@@ -107,7 +107,7 @@ function itemsOf(testId: string): string[] {
 describe('workspaceContextMenu', () => {
   it('reads no tab of any workspace until it is OPENED', () => {
     // `DropdownMenu` renders children eagerly, so the items are in the DOM
-    // either way -- what `onToggle` gates is the WORK. One of these mounts per
+    // either way -- what `onToggle` controls is the WORK. One of these mounts per
     // workspace row, and it serves the right-click menu too, so an ungated
     // build walks every tab of every workspace on every reactive tick.
     //
@@ -265,19 +265,45 @@ describe('workspaceContextMenu', () => {
       })
     })
 
-    it('offers no target for a repository whose worker is offline', () => {
-      // Opening an agent needs the machine the repository is on, so an offline
-      // repository is not a place to start.
+    // "No checkout" and "no REACHABLE checkout" are different states, and the
+    // no-target item is only right for the first. It means "follow the current
+    // tab context", so offering it for the second started an agent somewhere
+    // else entirely -- a machine the user never picked.
+    it('refuses to start, and says why, when every checkout is on an offline worker', () => {
       const { store, tabs } = tabsAndStore([{ toplevel: '/home/me/leapmux' }])
+      const startActions = stubWorkspaceStartActions()
       renderMenu({
         getTabs: () => tabs,
         repoGitStore: store,
         isWorkerOnline: () => false,
-        startActions: stubWorkspaceStartActions(),
+        startActions,
       })
       openMenu()
 
-      expect(screen.getByTestId('workspace-new-agent').textContent).toBe('New agent...')
+      const item = screen.getByTestId('workspace-new-agent') as HTMLButtonElement
+      expect(item.textContent).toBe('New agent...')
+      expect(item).toBeDisabled()
+      fireEvent.click(item)
+      expect(startActions.onNewAgentAt).not.toHaveBeenCalled()
+    })
+
+    // The other half: a workspace with NO checkout at all keeps the no-target
+    // item, because a freshly created workspace has no tabs and that row most
+    // needs a way in.
+    it('keeps the no-target item for a workspace with no checkout', () => {
+      const startActions = stubWorkspaceStartActions()
+      renderMenu({ isWorkerOnline: () => false, startActions })
+      openMenu()
+
+      const item = screen.getByTestId('workspace-new-agent') as HTMLButtonElement
+      expect(item.textContent).toBe('New agent...')
+      expect(item).not.toBeDisabled()
+      fireEvent.click(item)
+      expect(startActions.onNewAgentAt).toHaveBeenCalledWith({
+        workspaceId: 'ws-1',
+        workerId: '',
+        workingDir: '',
+      })
     })
   })
 
@@ -347,7 +373,7 @@ describe('workspaceContextMenu', () => {
   })
 
   describe('the info block', () => {
-    it('names the workspace, its section and its tab count', () => {
+    it('reports the workspace, its section and its tab count', () => {
       const { store, tabs } = tabsAndStore([{ toplevel: '/home/me/leapmux' }])
       renderMenu({ getTabs: () => tabs, repoGitStore: store })
       openMenu()
@@ -383,7 +409,7 @@ describe('workspaceContextMenu', () => {
     // `contextmenu` so light-dismiss cannot eat the menu it just opened.
     vi.useFakeTimers()
     try {
-      // The info block is the open-gated content, so its presence is what says
+      // The info block is the content that depends on the open state, so its presence is what says
       // the menu really opened rather than merely being mounted.
       expect(screen.queryByTestId('workspace-info-button')).not.toBeInTheDocument()
       row.dispatchEvent(new MouseEvent('contextmenu', { clientX: 10, clientY: 10, bubbles: true, cancelable: true }))

--- a/frontend/src/components/workspace/WorkspaceContextMenu.test.tsx
+++ b/frontend/src/components/workspace/WorkspaceContextMenu.test.tsx
@@ -1,194 +1,398 @@
+import type { Tab } from '~/stores/tab.types'
 import { create } from '@bufbuild/protobuf'
-import { render, screen } from '@solidjs/testing-library'
+import { fireEvent, render, screen, within } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
 import { WorkspaceContextMenu } from '~/components/workspace/WorkspaceContextMenu'
 import { SectionSchema, SectionType, Sidebar } from '~/generated/proto/leapmux/v1/section_pb'
+import { TabType } from '~/generated/proto/leapmux/v1/workspace_pb'
+import { repoKey } from '~/stores/repoGit'
+import { createRepoGitStore } from '~/stores/repoGit.store'
+import { stubWorkspaceStartActions } from '~/test-support/branchMenu'
+import { withPreferences } from '~/test-support/preferencesProvider'
 
 /**
- * Records what the mocked DropdownMenu last received for `contextMenuFor`. A
- * holder object rather than a bare `let`: TS cannot see the assignment inside the
- * `vi.mock` factory, so it would narrow a `let` to `undefined` at every read.
+ * The REAL `DropdownMenu`, not a mock.
+ *
+ * `vitest.setup.ts` stubs `showPopover` / `hidePopover` / `:popover-open`, and
+ * `DropdownMenu.test.tsx` drives 40+ open/close tests against those stubs -- so
+ * the "jsdom lacks the popover API" mock this file used to carry was obsolete.
+ * It also actively hid three things: it dropped `onToggle` on the floor, so a
+ * missing `onToggle={setMenuOpen}` (the likeliest bug in a menu whose whole
+ * content is gated on it) passed green; it FLATTENED every submenu into the
+ * parent's item list, so an order assertion could not fail on a nesting
+ * mistake; and it nulled out the item-content components this menu needs.
  */
-const captured: { contextMenuFor?: () => HTMLElement | undefined } = {}
 
-// Mock DropdownMenu to render children directly (jsdom lacks popover API).
-vi.mock('~/components/common/DropdownMenu', () => ({
-  DropdownMenu(props: any) {
-    // eslint-disable-next-line solid/reactivity -- capturing the accessor itself for the assertion, not reading it
-    captured.contextMenuFor = props.contextMenuFor
-    // Render trigger (if function, call with dummy props) and children
-    const trigger = () => typeof props.trigger === 'function'
-      ? props.trigger({
-          'aria-expanded': true,
-          'ref': () => {},
-          'onPointerDown': () => {},
-          'onClick': () => {},
-        })
-      : props.trigger
-    return (
-      <>
-        {trigger()}
-        {props.children}
-      </>
-    )
-  },
-}))
+function makeSection(id: string, name: string, sectionType: SectionType) {
+  return create(SectionSchema, { id, name, position: '', sectionType, sidebar: Sidebar.LEFT })
+}
 
-function makeSection(
-  id: string,
-  name: string,
-  sectionType: SectionType,
-) {
-  return create(SectionSchema, {
-    id,
-    name,
-    position: '',
-    sectionType,
-    sidebar: Sidebar.LEFT,
+const IN_PROGRESS = makeSection('sec-ip', 'In Progress', SectionType.WORKSPACES_IN_PROGRESS)
+const CUSTOM = makeSection('sec-custom', 'My Section', SectionType.WORKSPACES_CUSTOM)
+const ARCHIVED = makeSection('sec-archived', 'Archived', SectionType.WORKSPACES_ARCHIVED)
+
+interface RepoSeed {
+  workerId?: string
+  toplevel: string
+  originUrl?: string
+}
+
+function tabsAndStore(seeds: readonly RepoSeed[]) {
+  const store = createRepoGitStore()
+  const tabs: Tab[] = []
+  seeds.forEach((seed, i) => {
+    const workerId = seed.workerId ?? 'w1'
+    store.upsert(repoKey(workerId, seed.toplevel), {
+      workerId,
+      toplevel: seed.toplevel,
+      branch: 'main',
+      originUrl: seed.originUrl ?? '',
+    })
+    tabs.push({
+      id: `t${i}`,
+      workspaceId: 'ws-1',
+      type: TabType.AGENT,
+      workerId,
+      gitToplevel: seed.toplevel,
+    } as Tab)
   })
+  return { store, tabs }
 }
 
 function noop() {}
 
-const defaultProps = {
-  isArchived: false,
-  sections: [] as ReturnType<typeof makeSection>[],
-  currentSectionId: 'sec-ip',
-  onRename: noop,
-  onMoveTo: noop as (sectionId: string) => void,
-  onArchive: noop,
-  onUnarchive: noop,
-  onDelete: noop,
+function renderMenu(overrides: Partial<Parameters<typeof WorkspaceContextMenu>[0]> = {}) {
+  const { store, tabs } = tabsAndStore([])
+  const props = {
+    workspaceId: 'ws-1',
+    workspaceTitle: 'gentle-amber-fox',
+    sectionName: 'In Progress',
+    isArchived: false,
+    sections: [IN_PROGRESS, CUSTOM],
+    currentSectionId: 'sec-ip',
+    getTabs: () => tabs,
+    repoGitStore: store,
+    onRename: noop,
+    onMoveTo: noop as (sectionId: string) => void,
+    onArchive: noop,
+    onUnarchive: noop,
+    onDelete: noop,
+    ...overrides,
+  }
+  render(withPreferences(() => <WorkspaceContextMenu {...props} />))
+  return props
+}
+
+/** Open the menu, as a user does. Every item below is gated on it. */
+function openMenu() {
+  fireEvent.click(screen.getByTestId('workspace-row-menu-trigger'))
+}
+
+/**
+ * The item labels of ONE popover, in order. Submenus are not flattened in.
+ *
+ * `hidden: true` because a closed popover is outside the accessibility tree,
+ * and the stubs in `vitest.setup.ts` toggle a data attribute rather than the
+ * real popover state -- so jsdom keeps applying the UA `display: none`. The
+ * info block is dropped: it is a `menuitem` (deliberately -- see
+ * `MenuInfoButton`), but it is a block of rows and not a command.
+ */
+function itemsOf(testId: string): string[] {
+  return within(screen.getByTestId(testId))
+    .queryAllByRole('menuitem', { hidden: true })
+    .filter(el => el.dataset.testid !== 'workspace-info-button')
+    .map(el => el.textContent?.trim() ?? '')
 }
 
 describe('workspaceContextMenu', () => {
-  it('hides Move-to when isArchived is true', () => {
-    const sections = [
-      makeSection('sec-ip', 'In Progress', SectionType.WORKSPACES_IN_PROGRESS),
-      makeSection('sec-custom', 'My Section', SectionType.WORKSPACES_CUSTOM),
-    ]
-    render(() => (
-      <WorkspaceContextMenu
-        {...defaultProps}
-        isArchived={true}
-        sections={sections}
-      />
-    ))
-    expect(screen.queryByText('Move to')).not.toBeInTheDocument()
-    // Unarchive should be visible instead of Archive
-    expect(screen.getByText('Unarchive')).toBeInTheDocument()
-    expect(screen.queryByText('Archive')).not.toBeInTheDocument()
+  it('reads no tab of any workspace until it is OPENED', () => {
+    // `DropdownMenu` renders children eagerly, so the items are in the DOM
+    // either way -- what `onToggle` gates is the WORK. One of these mounts per
+    // workspace row, and it serves the right-click menu too, so an ungated
+    // build walks every tab of every workspace on every reactive tick.
+    //
+    // The repository-derived label is the observable half of that gate, and a
+    // dropped `onToggle` leaves it stuck on the no-repository shape forever.
+    const { store, tabs } = tabsAndStore([{ toplevel: '/home/me/leapmux' }])
+    renderMenu({ getTabs: () => tabs, repoGitStore: store })
+
+    expect(screen.getByTestId('workspace-new-agent').textContent).toBe('New agent...')
+    expect(screen.queryByTestId('workspace-info-button')).not.toBeInTheDocument()
+
+    openMenu()
+
+    expect(screen.getByTestId('workspace-new-agent').textContent).toBe('New agent in leapmux...')
+    expect(screen.getByTestId('workspace-info-button')).toBeInTheDocument()
   })
 
-  it('hides Move-to when no other target sections exist', () => {
-    // Only one workspace section — the current one
-    const sections = [
-      makeSection('sec-ip', 'In Progress', SectionType.WORKSPACES_IN_PROGRESS),
-      makeSection('sec-archived', 'Archived', SectionType.WORKSPACES_ARCHIVED),
-      makeSection('sec-files', 'Files', SectionType.FILES),
-    ]
-    render(() => (
-      <WorkspaceContextMenu
-        {...defaultProps}
-        sections={sections}
-        currentSectionId="sec-ip"
-      />
-    ))
-    // Move to should not be visible because the only target sections
-    // are the current section, archived (excluded), and files (excluded)
-    expect(screen.queryByText('Move to')).not.toBeInTheDocument()
+  it('offers rename, move, archive and delete on a live workspace, in that order', () => {
+    renderMenu()
+    openMenu()
+
+    expect(itemsOf('workspace-context-menu')).toEqual([
+      'New agent...',
+      'New terminal...',
+      'Rename',
+      'Move to',
+      'Archive',
+      'Delete',
+    ])
   })
 
-  it('shows Move-to when other target sections exist', () => {
-    const sections = [
-      makeSection('sec-ip', 'In Progress', SectionType.WORKSPACES_IN_PROGRESS),
-      makeSection('sec-custom', 'My Section', SectionType.WORKSPACES_CUSTOM),
-    ]
-    render(() => (
-      <WorkspaceContextMenu
-        {...defaultProps}
-        sections={sections}
-        currentSectionId="sec-ip"
-      />
-    ))
-    expect(screen.getByText('Move to')).toBeInTheDocument()
-    // The submenu should list the custom section but not the current section
-    expect(screen.getByText('My Section')).toBeInTheDocument()
-    expect(screen.queryByText('In Progress')).not.toBeInTheDocument()
+  it('hides rename on an archived workspace', () => {
+    // `isWorkspaceMutatable` says archival is the one thing that blocks
+    // mutation, and the tab bar already routes the sibling operation through
+    // `canRenameTab(archived, tab)`. This row was the one surface ignoring it.
+    renderMenu({ isArchived: true, sections: [IN_PROGRESS, ARCHIVED], currentSectionId: 'sec-archived' })
+    openMenu()
+
+    const items = itemsOf('workspace-context-menu')
+    expect(items).not.toContain('Rename')
+    expect(items).toContain('Delete')
   })
 
-  it('excludes current section from Move-to list', () => {
-    const sections = [
-      makeSection('sec-ip', 'In Progress', SectionType.WORKSPACES_IN_PROGRESS),
-      makeSection('sec-custom1', 'Alpha', SectionType.WORKSPACES_CUSTOM),
-      makeSection('sec-custom2', 'Beta', SectionType.WORKSPACES_CUSTOM),
-    ]
-    render(() => (
-      <WorkspaceContextMenu
-        {...defaultProps}
-        sections={sections}
-        currentSectionId="sec-custom1"
-      />
-    ))
-    // Alpha (current section) should not appear; others should
-    expect(screen.queryByText('Alpha')).not.toBeInTheDocument()
-    expect(screen.getByText('In Progress')).toBeInTheDocument()
-    expect(screen.getByText('Beta')).toBeInTheDocument()
+  it('hides the tab-creation items on an archived workspace', () => {
+    renderMenu({ isArchived: true, sections: [IN_PROGRESS, ARCHIVED], currentSectionId: 'sec-archived' })
+    openMenu()
+
+    const items = itemsOf('workspace-context-menu')
+    expect(items.some(i => i.startsWith('New agent'))).toBe(false)
+    expect(items.some(i => i.startsWith('New terminal'))).toBe(false)
   })
 
-  it('shows Archive for non-archived workspaces', () => {
-    render(() => (
-      <WorkspaceContextMenu
-        {...defaultProps}
-        isArchived={false}
-        sections={[makeSection('sec-ip', 'In Progress', SectionType.WORKSPACES_IN_PROGRESS)]}
-      />
-    ))
-    expect(screen.getByText('Archive')).toBeInTheDocument()
-    expect(screen.queryByText('Unarchive')).not.toBeInTheDocument()
+  it('keeps Move to on an archived workspace', () => {
+    // Moving writes `workspace_section_items.section_id`, which is not a
+    // mutation OF the workspace -- and it is the only way to unarchive into a
+    // SPECIFIC custom section, because Unarchive always targets In progress.
+    renderMenu({ isArchived: true, sections: [IN_PROGRESS, CUSTOM, ARCHIVED], currentSectionId: 'sec-archived' })
+    openMenu()
+
+    expect(itemsOf('workspace-context-menu')).toContain('Move to')
   })
 
-  it('shows Unarchive for archived workspaces', () => {
-    render(() => (
-      <WorkspaceContextMenu
-        {...defaultProps}
-        isArchived={true}
-        sections={[makeSection('sec-archived', 'Archived', SectionType.WORKSPACES_ARCHIVED)]}
-        currentSectionId="sec-archived"
-      />
-    ))
-    expect(screen.getByText('Unarchive')).toBeInTheDocument()
-    expect(screen.queryByText('Archive')).not.toBeInTheDocument()
+  it('swaps Archive for Unarchive once archived', () => {
+    renderMenu({ isArchived: true, sections: [IN_PROGRESS, ARCHIVED], currentSectionId: 'sec-archived' })
+    openMenu()
+
+    const items = itemsOf('workspace-context-menu')
+    expect(items).toContain('Unarchive')
+    expect(items).not.toContain('Archive')
   })
 
-  it('always offers rename and delete (owner-only access: every visible workspace is our own)', () => {
-    render(() => (
-      <WorkspaceContextMenu
-        {...defaultProps}
-        sections={[makeSection('sec-ip', 'In Progress', SectionType.WORKSPACES_IN_PROGRESS)]}
-      />
-    ))
-    expect(screen.getByText('Rename')).toBeInTheDocument()
-    expect(screen.getByText('Delete')).toBeInTheDocument()
-    expect(screen.getByText('Archive')).toBeInTheDocument()
+  describe('move to', () => {
+    it('lists every other workspace section, and no other kind', () => {
+      renderMenu({
+        sections: [
+          IN_PROGRESS,
+          makeSection('sec-a', 'Alpha', SectionType.WORKSPACES_CUSTOM),
+          ARCHIVED,
+          makeSection('sec-files', 'Files', SectionType.FILES),
+        ],
+        currentSectionId: 'sec-ip',
+      })
+      openMenu()
+      fireEvent.click(screen.getByTestId('workspace-move-to'))
+
+      expect(itemsOf('workspace-move-to-popover')).toEqual(['Alpha'])
+    })
+
+    it('is absent when nothing else can hold the workspace', () => {
+      renderMenu({ sections: [IN_PROGRESS, ARCHIVED], currentSectionId: 'sec-ip' })
+      openMenu()
+
+      expect(itemsOf('workspace-context-menu')).not.toContain('Move to')
+      expect(screen.queryByTestId('workspace-move-to')).not.toBeInTheDocument()
+    })
+
+    it('reports the chosen section', () => {
+      const onMoveTo = vi.fn()
+      renderMenu({ onMoveTo })
+      openMenu()
+      fireEvent.click(screen.getByTestId('workspace-move-to'))
+      fireEvent.click(within(screen.getByTestId('workspace-move-to-popover')).getByText('My Section'))
+
+      expect(onMoveTo).toHaveBeenCalledWith('sec-custom')
+    })
   })
 
-  // One representative for the six row menus. The other five wrappers forward the
-  // same prop through the same two lines, and `DropdownMenu` owns everything that
-  // happens after -- covered in ~/components/common/DropdownMenu.test.tsx.
-  it('forwards contextMenuFor so the row itself opens the menu', () => {
-    // No reset first: the assertion is identity against a FRESH element, so a
-    // stale capture from an earlier render fails rather than passing by accident.
+  describe('tab creation, by repository count', () => {
+    it('offers a bare item, with no target, for a workspace with no repository', () => {
+      // The row that most needs a way in: a freshly created workspace has no
+      // tabs at all.
+      const startActions = stubWorkspaceStartActions()
+      renderMenu({ startActions })
+      openMenu()
+      fireEvent.click(screen.getByTestId('workspace-new-agent'))
+
+      expect(screen.getByTestId('workspace-new-agent').textContent).toBe('New agent...')
+      expect(startActions.onNewAgentAt).toHaveBeenCalledWith({ workspaceId: 'ws-1', workerId: '', workingDir: '' })
+    })
+
+    it('renders FLAT for one repository, with no submenu to click through', () => {
+      const { store, tabs } = tabsAndStore([{ toplevel: '/home/me/leapmux' }])
+      const startActions = stubWorkspaceStartActions()
+      renderMenu({ getTabs: () => tabs, repoGitStore: store, startActions })
+      openMenu()
+
+      expect(screen.getByTestId('workspace-new-agent').textContent).toBe('New agent in leapmux...')
+      expect(screen.queryByTestId('workspace-new-agent-popover')).not.toBeInTheDocument()
+
+      fireEvent.click(screen.getByTestId('workspace-new-agent'))
+      expect(startActions.onNewAgentAt).toHaveBeenCalledWith({
+        workspaceId: 'ws-1',
+        workerId: 'w1',
+        workingDir: '/home/me/leapmux',
+      })
+    })
+
+    it('renders a submenu for two repositories', () => {
+      const { store, tabs } = tabsAndStore([
+        { toplevel: '/home/me/alpha' },
+        { toplevel: '/home/me/beta' },
+      ])
+      const startActions = stubWorkspaceStartActions()
+      renderMenu({ getTabs: () => tabs, repoGitStore: store, startActions })
+      openMenu()
+      fireEvent.click(screen.getByTestId('workspace-new-terminal'))
+
+      expect(itemsOf('workspace-new-terminal-popover').toSorted()).toEqual(['alpha', 'beta'])
+
+      fireEvent.click(within(screen.getByTestId('workspace-new-terminal-popover')).getByText('beta'))
+      expect(startActions.onNewTerminalAt).toHaveBeenCalledWith({
+        workspaceId: 'ws-1',
+        workerId: 'w1',
+        workingDir: '/home/me/beta',
+      })
+    })
+
+    it('offers no target for a repository whose worker is offline', () => {
+      // Opening an agent needs the machine the repository is on, so an offline
+      // repository is not a place to start.
+      const { store, tabs } = tabsAndStore([{ toplevel: '/home/me/leapmux' }])
+      renderMenu({
+        getTabs: () => tabs,
+        repoGitStore: store,
+        isWorkerOnline: () => false,
+        startActions: stubWorkspaceStartActions(),
+      })
+      openMenu()
+
+      expect(screen.getByTestId('workspace-new-agent').textContent).toBe('New agent...')
+    })
+  })
+
+  describe('the Repository submenu', () => {
+    it('offers Copy repository URL for a repository that has an origin', () => {
+      const { store, tabs } = tabsAndStore([
+        { toplevel: '/home/me/leapmux', originUrl: 'https://example.com/o/r.git' },
+      ])
+      renderMenu({ getTabs: () => tabs, repoGitStore: store })
+      openMenu()
+      fireEvent.click(screen.getByTestId('workspace-repository'))
+
+      expect(itemsOf('workspace-repository-popover')).toEqual(['Copy repository URL'])
+    })
+
+    it('is absent for a remote worker with no origin, which offers nothing', () => {
+      // Both desktop items open the LOCAL Finder or editor, so a remote
+      // worker's absolute path either does not exist here or -- worse -- exists
+      // and is a different directory.
+      const { store, tabs } = tabsAndStore([{ toplevel: '/home/me/leapmux' }])
+      renderMenu({ getTabs: () => tabs, repoGitStore: store, isLocalWorkerFn: () => false })
+      openMenu()
+
+      expect(screen.queryByTestId('workspace-repository')).not.toBeInTheDocument()
+    })
+
+    it('offers Reveal in file manager only for a LOCAL worker', () => {
+      const { store, tabs } = tabsAndStore([{ toplevel: '/home/me/leapmux' }])
+      renderMenu({ getTabs: () => tabs, repoGitStore: store, isLocalWorkerFn: () => true })
+      openMenu()
+      fireEvent.click(screen.getByTestId('workspace-repository'))
+
+      expect(itemsOf('workspace-repository-popover')).toContain('Reveal in file manager')
+    })
+
+    it('groups the actions per repository once there is more than one', () => {
+      const { store, tabs } = tabsAndStore([
+        { toplevel: '/home/me/alpha', originUrl: 'https://example.com/o/a.git' },
+        { toplevel: '/home/me/beta', originUrl: 'https://example.com/o/b.git' },
+      ])
+      renderMenu({ getTabs: () => tabs, repoGitStore: store })
+      openMenu()
+      fireEvent.click(screen.getByTestId('workspace-repository'))
+
+      const popover = screen.getByTestId('workspace-repository-popover')
+      expect(within(popover).getAllByRole('group', { hidden: true }).map(g => g.getAttribute('aria-label')).toSorted())
+        .toEqual(['example.com/o/a', 'example.com/o/b'])
+      expect(itemsOf('workspace-repository-popover'))
+        .toEqual(['Copy repository URL', 'Copy repository URL'])
+    })
+
+    it('stays available on an ARCHIVED workspace, because it mutates nothing', () => {
+      const { store, tabs } = tabsAndStore([
+        { toplevel: '/home/me/leapmux', originUrl: 'https://example.com/o/r.git' },
+      ])
+      renderMenu({
+        getTabs: () => tabs,
+        repoGitStore: store,
+        isArchived: true,
+        sections: [IN_PROGRESS, ARCHIVED],
+        currentSectionId: 'sec-archived',
+      })
+      openMenu()
+
+      expect(screen.getByTestId('workspace-repository')).toBeInTheDocument()
+    })
+  })
+
+  describe('the info block', () => {
+    it('names the workspace, its section and its tab count', () => {
+      const { store, tabs } = tabsAndStore([{ toplevel: '/home/me/leapmux' }])
+      renderMenu({ getTabs: () => tabs, repoGitStore: store })
+      openMenu()
+
+      const info = screen.getByTestId('workspace-info-button')
+      expect(info.textContent).toContain('gentle-amber-fox')
+      expect(info.textContent).toContain('In Progress')
+      expect(info.textContent).toContain('leapmux')
+    })
+
+    it('omits the repository row when the workspace spans more than one', () => {
+      const { store, tabs } = tabsAndStore([
+        { toplevel: '/home/me/alpha' },
+        { toplevel: '/home/me/beta' },
+      ])
+      renderMenu({ getTabs: () => tabs, repoGitStore: store })
+      openMenu()
+
+      expect(screen.getByTestId('workspace-info-button').textContent).not.toContain('Repository')
+    })
+  })
+
+  // One representative for the six row menus. The other five wrappers forward
+  // the same prop through the same two lines, and `DropdownMenu` owns
+  // everything after -- covered in ~/components/common/DropdownMenu.test.tsx.
+  it('opens from a right-click on the row it is given', () => {
     const row = document.createElement('div')
+    document.body.append(row)
+    renderMenu({ contextMenuFor: () => row })
 
-    render(() => (
-      <WorkspaceContextMenu
-        {...defaultProps}
-        contextMenuFor={() => row}
-        sections={[makeSection('sec-ip', 'In Progress', SectionType.WORKSPACES_IN_PROGRESS)]}
-      />
-    ))
-
-    expect(captured.contextMenuFor?.()).toBe(row)
+    // Fake timers because the gesture defers the open by a tick -- see
+    // `attachContextMenuGesture`, which opens after the platform's own
+    // `contextmenu` so light-dismiss cannot eat the menu it just opened.
+    vi.useFakeTimers()
+    try {
+      // The info block is the open-gated content, so its presence is what says
+      // the menu really opened rather than merely being mounted.
+      expect(screen.queryByTestId('workspace-info-button')).not.toBeInTheDocument()
+      row.dispatchEvent(new MouseEvent('contextmenu', { clientX: 10, clientY: 10, bubbles: true, cancelable: true }))
+      vi.runAllTimers()
+      expect(screen.getByTestId('workspace-info-button')).toBeInTheDocument()
+    }
+    finally {
+      vi.useRealTimers()
+      row.remove()
+    }
   })
 })

--- a/frontend/src/components/workspace/WorkspaceContextMenu.tsx
+++ b/frontend/src/components/workspace/WorkspaceContextMenu.tsx
@@ -7,7 +7,7 @@ import { DropdownMenu } from '~/components/common/DropdownMenu'
 import { Icon } from '~/components/common/Icon'
 import { rowContextMenuTrigger } from '~/components/common/moreHorizontalTrigger'
 import { isMoveTargetSection } from '~/components/shell/sectionUtils'
-import { dangerMenuItem } from '~/styles/shared.css'
+import { dangerMenuItem, menuSubTrigger } from '~/styles/shared.css'
 
 interface WorkspaceContextMenuProps extends ContextMenuTargetProps {
   isArchived: boolean
@@ -30,7 +30,7 @@ export const WorkspaceContextMenu: Component<WorkspaceContextMenuProps> = (props
       <Show when={!props.isArchived && props.sections.some(s => s.id !== props.currentSectionId && isMoveTargetSection(s.sectionType))}>
         <DropdownMenu
           trigger={triggerProps => (
-            <button role="menuitem" class="sub-trigger" {...triggerProps}>
+            <button role="menuitem" class={menuSubTrigger} {...triggerProps}>
               Move to
               <Icon icon={ChevronRight} size="xs" />
             </button>

--- a/frontend/src/components/workspace/WorkspaceContextMenu.tsx
+++ b/frontend/src/components/workspace/WorkspaceContextMenu.tsx
@@ -1,18 +1,47 @@
 import type { Component } from 'solid-js'
+import type { RepoStartPoint } from './repoStartPoints'
+import type { WorkspaceStartActions, WorkspaceStartAt } from './workspaceStartActions'
 import type { ContextMenuTargetProps } from '~/components/common/DropdownMenu'
+import type { MenuInfoRow } from '~/components/common/MenuInfoRows'
 import type { Section } from '~/generated/proto/leapmux/v1/section_pb'
-import ChevronRight from 'lucide-solid/icons/chevron-right'
-import { For, Show } from 'solid-js'
+import type { WorkerInfo } from '~/lib/workerInfoCache'
+import type { RepoGitStore } from '~/stores/repoGit'
+import type { Tab } from '~/stores/tab.types'
+import { createMemo, createResource, createSignal, For, Show } from 'solid-js'
+import { platformBridge, revealInFileManager } from '~/api/platformBridge'
 import { DropdownMenu } from '~/components/common/DropdownMenu'
-import { Icon } from '~/components/common/Icon'
+import { MenuInfoButton } from '~/components/common/MenuInfoRows'
 import { rowContextMenuTrigger } from '~/components/common/moreHorizontalTrigger'
+import { SubMenu } from '~/components/common/SubMenu'
 import { isMoveTargetSection } from '~/components/shell/sectionUtils'
-import { dangerMenuItem, menuSubTrigger } from '~/styles/shared.css'
+import { usePreferences } from '~/context/PreferencesContext'
+import { copyTextToClipboard } from '~/lib/clipboard'
+import { loadDetectedEditors, preferredEditor, resolvePreferredEditor } from '~/lib/externalEditors'
+import { prettifyJson } from '~/lib/jsonFormat'
+import { createLogger } from '~/lib/logger'
+import { repoGitView } from '~/stores/repoGit'
+import { dangerMenuItem, menuSectionHeader } from '~/styles/shared.css'
+import { listRepoStartPoints } from './repoStartPoints'
+
+const log = createLogger('workspace-context-menu')
 
 interface WorkspaceContextMenuProps extends ContextMenuTargetProps {
+  workspaceId: string
+  workspaceTitle: string
+  /** The section the row sits in, for the info block. */
+  sectionName: string
   isArchived: boolean
   sections: Section[]
   currentSectionId: string | undefined
+  /** This workspace's tabs. */
+  getTabs: () => Tab[]
+  repoGitStore: RepoGitStore
+  workerInfoFn?: (id: string) => WorkerInfo | null
+  isWorkerOnline?: (workerId: string) => boolean
+  /** Whether a worker runs on THIS machine. See `~/lib/workerLocality`. */
+  isLocalWorkerFn?: (workerId: string) => boolean
+  /** Open a new agent / terminal at one of this workspace's checkouts. */
+  startActions?: WorkspaceStartActions
   onRename: () => void
   onMoveTo: (sectionId: string) => void
   onArchive: () => void
@@ -21,48 +50,306 @@ interface WorkspaceContextMenuProps extends ContextMenuTargetProps {
 }
 
 export const WorkspaceContextMenu: Component<WorkspaceContextMenuProps> = (props) => {
-  return (
-    <DropdownMenu trigger={rowContextMenuTrigger()} contextMenuFor={props.contextMenuFor}>
-      <button role="menuitem" onClick={() => props.onRename()}>
-        Rename
-      </button>
+  // Gated for the same reason `BranchContextMenu` gates its two worker lists,
+  // with more force: one of these mounts per workspace ROW, and it serves the
+  // right-click menu as well, so each nested submenu is another eagerly-mounted
+  // popover per row.
+  const [menuOpen, setMenuOpen] = createSignal(false)
+  const prefs = usePreferences()
 
-      <Show when={!props.isArchived && props.sections.some(s => s.id !== props.currentSectionId && isMoveTargetSection(s.sectionType))}>
-        <DropdownMenu
-          trigger={triggerProps => (
-            <button role="menuitem" class={menuSubTrigger} {...triggerProps}>
-              Move to
-              <Icon icon={ChevronRight} size="xs" />
+  /** Every repository this workspace has a checkout in. */
+  const repos = createMemo((): RepoStartPoint[] => {
+    if (!menuOpen())
+      return []
+    return listRepoStartPoints(props.getTabs(), props.repoGitStore, {
+      workerInfoFn: props.workerInfoFn,
+    })
+  })
+
+  /**
+   * The repositories a new tab can actually be opened in.
+   *
+   * Filtered by worker liveness, unlike {@link repos}: opening an agent needs
+   * the machine the repository is on. The unfiltered list still backs the
+   * `Repository` submenu, whose items copy a URL the store already holds and
+   * open local paths -- neither of which needs the remote worker.
+   */
+  const startableRepos = createMemo((): RepoStartPoint[] => {
+    const online = props.isWorkerOnline
+    return online ? repos().filter(r => online(r.startPoint.workerId)) : repos()
+  })
+
+  const isLocal = (workerId: string) => props.isLocalWorkerFn?.(workerId) ?? false
+  const anyLocal = () => repos().some(r => isLocal(r.startPoint.workerId))
+
+  // Detected editors, fetched on open and only where a local checkout could use
+  // one. `loadDetectedEditors` caches module-wide, so the second row's menu
+  // pays nothing.
+  const [editors] = createResource(
+    () => menuOpen() && anyLocal(),
+    async (eligible: boolean) => (eligible ? loadDetectedEditors() : []),
+    { initialValue: [] },
+  )
+  // Named WITHOUT persisting: the label must not write a preference just by
+  // rendering. The launch below goes through `resolvePreferredEditor`, which
+  // pins whatever it picked.
+  const namedEditor = () => preferredEditor(editors(), prefs.preferredEditorId())
+
+  const moveTargets = () => props.sections.filter(
+    s => s.id !== props.currentSectionId && isMoveTargetSection(s.sectionType),
+  )
+
+  const infoRows = createMemo((): MenuInfoRow[] => {
+    // The memo, not a `<Show>`: `DropdownMenu` renders children eagerly and a
+    // `createMemo` runs its body at setup, so an ungated builder would walk
+    // every tab of every workspace on every reactive tick.
+    if (!menuOpen())
+      return []
+    const rows: MenuInfoRow[] = [
+      { label: 'Workspace:', value: props.workspaceTitle },
+      { label: 'Section:', value: props.sectionName },
+      { label: 'Tabs:', value: String(props.getTabs().length) },
+    ]
+    // Only when it is unambiguous. Two repositories cannot share one row, and
+    // the `Repository` submenu below lists them all anyway.
+    if (repos().length === 1)
+      rows.push({ label: 'Repository:', value: repos()[0].label })
+    return rows
+  })
+
+  // Carries the workspace id, which no row shows and which the CLI takes.
+  const infoJson = () => prettifyJson({
+    workspaceId: props.workspaceId,
+    title: props.workspaceTitle,
+    section: props.sectionName,
+    tabs: props.getTabs().length,
+    repositories: repos().map(r => ({
+      label: r.label,
+      workerId: r.startPoint.workerId,
+      path: r.startPoint.gitToplevel,
+    })),
+  })
+
+  const startAt = (repo: RepoStartPoint): WorkspaceStartAt => ({
+    workspaceId: props.workspaceId,
+    workerId: repo.startPoint.workerId,
+    workingDir: repo.startPoint.gitToplevel,
+  })
+
+  /**
+   * The no-target start: this workspace, and no checkout.
+   *
+   * An empty worker and directory mean "follow the current tab context", which
+   * the handler resolves AFTER switching to this workspace -- so the dialog
+   * opens against this workspace even though the row that asked was not the
+   * active one.
+   */
+  const startAtWorkspace = (): WorkspaceStartAt => ({
+    workspaceId: props.workspaceId,
+    workerId: '',
+    workingDir: '',
+  })
+
+  /**
+   * One tab-creation entry, in the shape the repository count calls for.
+   *
+   * Zero repositories still offers the item, with no target: a freshly created
+   * workspace has no tabs, and that is exactly the row that most needs a way
+   * in. One repository renders FLAT -- a submenu holding a single item is a
+   * click the user should not have to make.
+   */
+  const startItems = (verb: string, run: (at: WorkspaceStartAt) => void, testId: string) => (
+    <Show
+      when={startableRepos().length > 0}
+      fallback={(
+        <button
+          type="button"
+          role="menuitem"
+          data-testid={testId}
+          onClick={() => run(startAtWorkspace())}
+        >
+          {`${verb}...`}
+        </button>
+      )}
+    >
+      <Show
+        when={startableRepos().length > 1}
+        fallback={(
+          <button
+            type="button"
+            role="menuitem"
+            data-testid={testId}
+            onClick={() => run(startAt(startableRepos()[0]))}
+          >
+            {`${verb} in ${startableRepos()[0].label}...`}
+          </button>
+        )}
+      >
+        <SubMenu label={`${verb} in`} data-testid={testId} popoverTestId={`${testId}-popover`}>
+          <For each={startableRepos()}>
+            {repo => (
+              <button type="button" role="menuitem" onClick={() => run(startAt(repo))}>
+                {repo.label}
+              </button>
+            )}
+          </For>
+        </SubMenu>
+      </Show>
+    </Show>
+  )
+
+  /** The read-only actions that hang off ONE repository. */
+  const repoActions = (repo: RepoStartPoint) => {
+    const originUrl = () => {
+      const tab = { workerId: repo.startPoint.workerId, gitToplevel: repo.startPoint.gitToplevel }
+      return repoGitView(tab, props.repoGitStore).originUrl
+    }
+    const local = () => isLocal(repo.startPoint.workerId)
+    return (
+      <>
+        {/* Hidden with no origin: there is no URL to copy. */}
+        <Show when={originUrl()}>
+          {url => (
+            <button type="button" role="menuitem" onClick={() => void copyTextToClipboard(url())}>
+              Copy repository URL
             </button>
           )}
-        >
-          <For each={props.sections.filter(s => s.id !== props.currentSectionId && isMoveTargetSection(s.sectionType))}>
-            {section => (
+        </Show>
+        {/* Both of these open the LOCAL Finder or the LOCAL editor, so a
+            remote worker's absolute path either does not exist here or --
+            worse -- exists and is a different directory. */}
+        <Show when={local()}>
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => void revealInFileManager(repo.startPoint.gitToplevel)}
+          >
+            Reveal in file manager
+          </button>
+          <Show when={namedEditor()}>
+            {editor => (
               <button
+                type="button"
                 role="menuitem"
-                onClick={() => props.onMoveTo(section.id)}
+                onClick={() => {
+                  const target = resolvePreferredEditor(editors(), prefs.preferredEditorId(), prefs.setPreferredEditorId)
+                  if (!target)
+                    return
+                  platformBridge.openInEditor(target.id, repo.startPoint.gitToplevel).catch((err: unknown) => {
+                    log.warn('open_in_editor failed', { id: target.id, err })
+                  })
+                }}
               >
+                {`Open in ${editor().displayName}`}
+              </button>
+            )}
+          </Show>
+        </Show>
+      </>
+    )
+  }
+
+  /** Whether one repository offers any action at all. */
+  const hasRepoActions = (repo: RepoStartPoint) => {
+    const tab = { workerId: repo.startPoint.workerId, gitToplevel: repo.startPoint.gitToplevel }
+    return Boolean(repoGitView(tab, props.repoGitStore).originUrl) || isLocal(repo.startPoint.workerId)
+  }
+
+  return (
+    <DropdownMenu
+      trigger={rowContextMenuTrigger({ 'data-testid': 'workspace-row-menu-trigger' })}
+      contextMenuFor={props.contextMenuFor}
+      onToggle={setMenuOpen}
+      data-testid="workspace-context-menu"
+    >
+      <MenuInfoButton
+        rows={infoRows()}
+        copyText={infoJson}
+        toastMessage="Workspace info copied to clipboard"
+        data-testid="workspace-info-button"
+      />
+      <Show when={infoRows().length > 0}>
+        <hr />
+      </Show>
+
+      {/* Absent when archived. `isWorkspaceMutatable` says archival is the one
+          thing that blocks mutation, and every other surface already obeys it:
+          the tab bar drops its `+`, and the branch row hides its whole menu. A
+          route that survives here would be the one way in that every other
+          surface forbids. */}
+      <Show when={!props.isArchived}>
+        {startItems('New agent', at => props.startActions?.onNewAgentAt(at), 'workspace-new-agent')}
+        {startItems('New terminal', at => props.startActions?.onNewTerminalAt(at), 'workspace-new-terminal')}
+      </Show>
+
+      {/* Copying a URL, revealing a directory and opening an editor mutate
+          nothing, so this stays for an archived workspace. */}
+      <Show when={repos().some(hasRepoActions)}>
+        <SubMenu label="Repository" data-testid="workspace-repository" popoverTestId="workspace-repository-popover">
+          <Show
+            when={repos().length > 1}
+            fallback={repoActions(repos()[0])}
+          >
+            <For each={repos()}>
+              {repo => (
+                <Show when={hasRepoActions(repo)}>
+                  <div role="group" aria-label={repo.label}>
+                    <div class={menuSectionHeader} aria-hidden="true">{repo.label}</div>
+                    {repoActions(repo)}
+                  </div>
+                </Show>
+              )}
+            </For>
+          </Show>
+        </SubMenu>
+      </Show>
+
+      <hr />
+
+      {/* Renaming an archived workspace is a MUTATION, and the tab bar already
+          routes the sibling operation through `canRenameTab(archived, tab)`.
+          This row was the one surface ignoring the rule its own predicate
+          states. */}
+      <Show when={!props.isArchived}>
+        <button type="button" role="menuitem" onClick={() => props.onRename()}>
+          Rename
+        </button>
+      </Show>
+
+      {/* KEPT while archived. Moving a workspace writes
+          `workspace_section_items.section_id`, which is not a mutation OF the
+          workspace -- `MoveWorkspace` is unguarded in the hub by design, since
+          archive and unarchive are the same call. It is also the only way to
+          unarchive into a SPECIFIC custom section, because `Unarchive` below
+          always targets In progress. `isMoveTargetSection` excludes Archived
+          as a target, so for an archived workspace every other workspace
+          section is legal -- the list is non-empty exactly when it is useful. */}
+      <Show when={moveTargets().length > 0}>
+        <SubMenu label="Move to" data-testid="workspace-move-to" popoverTestId="workspace-move-to-popover">
+          <For each={moveTargets()}>
+            {section => (
+              <button type="button" role="menuitem" onClick={() => props.onMoveTo(section.id)}>
                 {section.name}
               </button>
             )}
           </For>
-        </DropdownMenu>
+        </SubMenu>
       </Show>
 
       <Show when={!props.isArchived}>
-        <button role="menuitem" onClick={() => props.onArchive()}>
+        <button type="button" role="menuitem" onClick={() => props.onArchive()}>
           Archive
         </button>
       </Show>
 
       <Show when={props.isArchived}>
-        <button role="menuitem" onClick={() => props.onUnarchive()}>
+        <button type="button" role="menuitem" onClick={() => props.onUnarchive()}>
           Unarchive
         </button>
       </Show>
 
       <hr />
-      <button role="menuitem" class={dangerMenuItem} onClick={() => props.onDelete()}>
+      <button type="button" role="menuitem" class={dangerMenuItem} onClick={() => props.onDelete()}>
         Delete
       </button>
     </DropdownMenu>

--- a/frontend/src/components/workspace/WorkspaceContextMenu.tsx
+++ b/frontend/src/components/workspace/WorkspaceContextMenu.tsx
@@ -2,28 +2,22 @@ import type { Component } from 'solid-js'
 import type { RepoStartPoint } from './repoStartPoints'
 import type { WorkspaceStartActions, WorkspaceStartAt } from './workspaceStartActions'
 import type { ContextMenuTargetProps } from '~/components/common/DropdownMenu'
-import type { MenuInfoRow } from '~/components/common/MenuInfoRows'
 import type { Section } from '~/generated/proto/leapmux/v1/section_pb'
 import type { WorkerInfo } from '~/lib/workerInfoCache'
 import type { RepoGitStore } from '~/stores/repoGit'
 import type { Tab } from '~/stores/tab.types'
-import { createMemo, createResource, createSignal, For, Show } from 'solid-js'
-import { platformBridge, revealInFileManager } from '~/api/platformBridge'
+import { createMemo, createSignal, For, Show } from 'solid-js'
 import { DropdownMenu } from '~/components/common/DropdownMenu'
 import { MenuInfoButton } from '~/components/common/MenuInfoRows'
 import { rowContextMenuTrigger } from '~/components/common/moreHorizontalTrigger'
 import { SubMenu } from '~/components/common/SubMenu'
 import { isMoveTargetSection } from '~/components/shell/sectionUtils'
-import { usePreferences } from '~/context/PreferencesContext'
-import { copyTextToClipboard } from '~/lib/clipboard'
-import { loadDetectedEditors, preferredEditor, resolvePreferredEditor } from '~/lib/externalEditors'
-import { prettifyJson } from '~/lib/jsonFormat'
-import { createLogger } from '~/lib/logger'
-import { repoGitView } from '~/stores/repoGit'
-import { dangerMenuItem, menuSectionHeader } from '~/styles/shared.css'
+import { dangerMenuItem } from '~/styles/shared.css'
 import { listRepoStartPoints } from './repoStartPoints'
-
-const log = createLogger('workspace-context-menu')
+import { workspaceInfoJson, workspaceInfoRows } from './workspaceMenuInfo'
+import { menuItem } from './workspaceMenuItem'
+import { WorkspaceRepositoryMenu } from './WorkspaceRepositoryMenu'
+import { WorkspaceStartMenuItems } from './WorkspaceStartMenuItems'
 
 interface WorkspaceContextMenuProps extends ContextMenuTargetProps {
   workspaceId: string
@@ -49,13 +43,21 @@ interface WorkspaceContextMenuProps extends ContextMenuTargetProps {
   onDelete: () => void
 }
 
+/**
+ * One workspace row's menu, and the same menu on a right-click of the row.
+ *
+ * It composes rather than owning: the info projection is pure
+ * (`workspaceMenuInfo`), the tab-creation shapes are
+ * {@link WorkspaceStartMenuItems}, and the repository actions -- with the
+ * editor probe that only they use -- are {@link WorkspaceRepositoryMenu}. What
+ * stays here is the menu's own shape: which blocks appear, in what order, and
+ * which of them an ARCHIVED workspace keeps.
+ */
 export const WorkspaceContextMenu: Component<WorkspaceContextMenuProps> = (props) => {
-  // Gated for the same reason `BranchContextMenu` gates its two worker lists,
-  // with more force: one of these mounts per workspace ROW, and it serves the
-  // right-click menu as well, so each nested submenu is another eagerly-mounted
-  // popover per row.
+  // Deferred for the same reason `BranchContextMenu` defers its two worker
+  // lists, with more force: one of these mounts per workspace ROW, and it
+  // serves the right-click menu as well.
   const [menuOpen, setMenuOpen] = createSignal(false)
-  const prefs = usePreferences()
 
   /** Every repository this workspace has a checkout in. */
   const repos = createMemo((): RepoStartPoint[] => {
@@ -80,55 +82,23 @@ export const WorkspaceContextMenu: Component<WorkspaceContextMenuProps> = (props
   })
 
   const isLocal = (workerId: string) => props.isLocalWorkerFn?.(workerId) ?? false
-  const anyLocal = () => repos().some(r => isLocal(r.startPoint.workerId))
 
-  // Detected editors, fetched on open and only where a local checkout could use
-  // one. `loadDetectedEditors` caches module-wide, so the second row's menu
-  // pays nothing.
-  const [editors] = createResource(
-    () => menuOpen() && anyLocal(),
-    async (eligible: boolean) => (eligible ? loadDetectedEditors() : []),
-    { initialValue: [] },
-  )
-  // Named WITHOUT persisting: the label must not write a preference just by
-  // rendering. The launch below goes through `resolvePreferredEditor`, which
-  // pins whatever it picked.
-  const namedEditor = () => preferredEditor(editors(), prefs.preferredEditorId())
+  const info = () => ({
+    workspaceId: props.workspaceId,
+    title: props.workspaceTitle,
+    sectionName: props.sectionName,
+    tabCount: props.getTabs().length,
+    repos: repos(),
+  })
+
+  // The memo, not a `<Show>`: `DropdownMenu` renders children eagerly and a
+  // `createMemo` runs its body at setup, so an ungated builder would walk every
+  // tab of every workspace on every reactive tick.
+  const infoRows = createMemo(() => (menuOpen() ? workspaceInfoRows(info()) : []))
 
   const moveTargets = () => props.sections.filter(
     s => s.id !== props.currentSectionId && isMoveTargetSection(s.sectionType),
   )
-
-  const infoRows = createMemo((): MenuInfoRow[] => {
-    // The memo, not a `<Show>`: `DropdownMenu` renders children eagerly and a
-    // `createMemo` runs its body at setup, so an ungated builder would walk
-    // every tab of every workspace on every reactive tick.
-    if (!menuOpen())
-      return []
-    const rows: MenuInfoRow[] = [
-      { label: 'Workspace:', value: props.workspaceTitle },
-      { label: 'Section:', value: props.sectionName },
-      { label: 'Tabs:', value: String(props.getTabs().length) },
-    ]
-    // Only when it is unambiguous. Two repositories cannot share one row, and
-    // the `Repository` submenu below lists them all anyway.
-    if (repos().length === 1)
-      rows.push({ label: 'Repository:', value: repos()[0].label })
-    return rows
-  })
-
-  // Carries the workspace id, which no row shows and which the CLI takes.
-  const infoJson = () => prettifyJson({
-    workspaceId: props.workspaceId,
-    title: props.workspaceTitle,
-    section: props.sectionName,
-    tabs: props.getTabs().length,
-    repositories: repos().map(r => ({
-      label: r.label,
-      workerId: r.startPoint.workerId,
-      path: r.startPoint.gitToplevel,
-    })),
-  })
 
   const startAt = (repo: RepoStartPoint): WorkspaceStartAt => ({
     workspaceId: props.workspaceId,
@@ -150,111 +120,6 @@ export const WorkspaceContextMenu: Component<WorkspaceContextMenuProps> = (props
     workingDir: '',
   })
 
-  /**
-   * One tab-creation entry, in the shape the repository count calls for.
-   *
-   * Zero repositories still offers the item, with no target: a freshly created
-   * workspace has no tabs, and that is exactly the row that most needs a way
-   * in. One repository renders FLAT -- a submenu holding a single item is a
-   * click the user should not have to make.
-   */
-  const startItems = (verb: string, run: (at: WorkspaceStartAt) => void, testId: string) => (
-    <Show
-      when={startableRepos().length > 0}
-      fallback={(
-        <button
-          type="button"
-          role="menuitem"
-          data-testid={testId}
-          onClick={() => run(startAtWorkspace())}
-        >
-          {`${verb}...`}
-        </button>
-      )}
-    >
-      <Show
-        when={startableRepos().length > 1}
-        fallback={(
-          <button
-            type="button"
-            role="menuitem"
-            data-testid={testId}
-            onClick={() => run(startAt(startableRepos()[0]))}
-          >
-            {`${verb} in ${startableRepos()[0].label}...`}
-          </button>
-        )}
-      >
-        <SubMenu label={`${verb} in`} data-testid={testId} popoverTestId={`${testId}-popover`}>
-          <For each={startableRepos()}>
-            {repo => (
-              <button type="button" role="menuitem" onClick={() => run(startAt(repo))}>
-                {repo.label}
-              </button>
-            )}
-          </For>
-        </SubMenu>
-      </Show>
-    </Show>
-  )
-
-  /** The read-only actions that hang off ONE repository. */
-  const repoActions = (repo: RepoStartPoint) => {
-    const originUrl = () => {
-      const tab = { workerId: repo.startPoint.workerId, gitToplevel: repo.startPoint.gitToplevel }
-      return repoGitView(tab, props.repoGitStore).originUrl
-    }
-    const local = () => isLocal(repo.startPoint.workerId)
-    return (
-      <>
-        {/* Hidden with no origin: there is no URL to copy. */}
-        <Show when={originUrl()}>
-          {url => (
-            <button type="button" role="menuitem" onClick={() => void copyTextToClipboard(url())}>
-              Copy repository URL
-            </button>
-          )}
-        </Show>
-        {/* Both of these open the LOCAL Finder or the LOCAL editor, so a
-            remote worker's absolute path either does not exist here or --
-            worse -- exists and is a different directory. */}
-        <Show when={local()}>
-          <button
-            type="button"
-            role="menuitem"
-            onClick={() => void revealInFileManager(repo.startPoint.gitToplevel)}
-          >
-            Reveal in file manager
-          </button>
-          <Show when={namedEditor()}>
-            {editor => (
-              <button
-                type="button"
-                role="menuitem"
-                onClick={() => {
-                  const target = resolvePreferredEditor(editors(), prefs.preferredEditorId(), prefs.setPreferredEditorId)
-                  if (!target)
-                    return
-                  platformBridge.openInEditor(target.id, repo.startPoint.gitToplevel).catch((err: unknown) => {
-                    log.warn('open_in_editor failed', { id: target.id, err })
-                  })
-                }}
-              >
-                {`Open in ${editor().displayName}`}
-              </button>
-            )}
-          </Show>
-        </Show>
-      </>
-    )
-  }
-
-  /** Whether one repository offers any action at all. */
-  const hasRepoActions = (repo: RepoStartPoint) => {
-    const tab = { workerId: repo.startPoint.workerId, gitToplevel: repo.startPoint.gitToplevel }
-    return Boolean(repoGitView(tab, props.repoGitStore).originUrl) || isLocal(repo.startPoint.workerId)
-  }
-
   return (
     <DropdownMenu
       trigger={rowContextMenuTrigger({ 'data-testid': 'workspace-row-menu-trigger' })}
@@ -264,7 +129,7 @@ export const WorkspaceContextMenu: Component<WorkspaceContextMenuProps> = (props
     >
       <MenuInfoButton
         rows={infoRows()}
-        copyText={infoJson}
+        copyText={() => workspaceInfoJson(info())}
         toastMessage="Workspace info copied to clipboard"
         data-testid="workspace-info-button"
       />
@@ -278,31 +143,34 @@ export const WorkspaceContextMenu: Component<WorkspaceContextMenuProps> = (props
           route that survives here would be the one way in that every other
           surface forbids. */}
       <Show when={!props.isArchived}>
-        {startItems('New agent', at => props.startActions?.onNewAgentAt(at), 'workspace-new-agent')}
-        {startItems('New terminal', at => props.startActions?.onNewTerminalAt(at), 'workspace-new-terminal')}
+        <WorkspaceStartMenuItems
+          verb="New agent"
+          repos={repos}
+          startableRepos={startableRepos}
+          run={at => props.startActions?.onNewAgentAt(at)}
+          startAtWorkspace={startAtWorkspace}
+          startAt={startAt}
+          data-testid="workspace-new-agent"
+        />
+        <WorkspaceStartMenuItems
+          verb="New terminal"
+          repos={repos}
+          startableRepos={startableRepos}
+          run={at => props.startActions?.onNewTerminalAt(at)}
+          startAtWorkspace={startAtWorkspace}
+          startAt={startAt}
+          data-testid="workspace-new-terminal"
+        />
       </Show>
 
       {/* Copying a URL, revealing a directory and opening an editor mutate
           nothing, so this stays for an archived workspace. */}
-      <Show when={repos().some(hasRepoActions)}>
-        <SubMenu label="Repository" data-testid="workspace-repository" popoverTestId="workspace-repository-popover">
-          <Show
-            when={repos().length > 1}
-            fallback={repoActions(repos()[0])}
-          >
-            <For each={repos()}>
-              {repo => (
-                <Show when={hasRepoActions(repo)}>
-                  <div role="group" aria-label={repo.label}>
-                    <div class={menuSectionHeader} aria-hidden="true">{repo.label}</div>
-                    {repoActions(repo)}
-                  </div>
-                </Show>
-              )}
-            </For>
-          </Show>
-        </SubMenu>
-      </Show>
+      <WorkspaceRepositoryMenu
+        repos={repos}
+        repoGitStore={props.repoGitStore}
+        isLocal={isLocal}
+        menuOpen={menuOpen}
+      />
 
       <hr />
 
@@ -311,9 +179,7 @@ export const WorkspaceContextMenu: Component<WorkspaceContextMenuProps> = (props
           This row was the one surface ignoring the rule its own predicate
           states. */}
       <Show when={!props.isArchived}>
-        <button type="button" role="menuitem" onClick={() => props.onRename()}>
-          Rename
-        </button>
+        {menuItem('Rename', () => props.onRename())}
       </Show>
 
       {/* KEPT while archived. Moving a workspace writes
@@ -327,25 +193,17 @@ export const WorkspaceContextMenu: Component<WorkspaceContextMenuProps> = (props
       <Show when={moveTargets().length > 0}>
         <SubMenu label="Move to" data-testid="workspace-move-to" popoverTestId="workspace-move-to-popover">
           <For each={moveTargets()}>
-            {section => (
-              <button type="button" role="menuitem" onClick={() => props.onMoveTo(section.id)}>
-                {section.name}
-              </button>
-            )}
+            {section => menuItem(section.name, () => props.onMoveTo(section.id))}
           </For>
         </SubMenu>
       </Show>
 
       <Show when={!props.isArchived}>
-        <button type="button" role="menuitem" onClick={() => props.onArchive()}>
-          Archive
-        </button>
+        {menuItem('Archive', () => props.onArchive())}
       </Show>
 
       <Show when={props.isArchived}>
-        <button type="button" role="menuitem" onClick={() => props.onUnarchive()}>
-          Unarchive
-        </button>
+        {menuItem('Unarchive', () => props.onUnarchive())}
       </Show>
 
       <hr />

--- a/frontend/src/components/workspace/WorkspaceRepositoryMenu.tsx
+++ b/frontend/src/components/workspace/WorkspaceRepositoryMenu.tsx
@@ -1,0 +1,147 @@
+import type { Component } from 'solid-js'
+import type { RepoStartPoint } from './repoStartPoints'
+import type { RepoGitStore } from '~/stores/repoGit'
+import { createMemo, createResource, For, Show } from 'solid-js'
+import { platformBridge, revealInFileManager } from '~/api/platformBridge'
+import { SubMenu } from '~/components/common/SubMenu'
+import { usePreferences } from '~/context/PreferencesContext'
+import { copyTextToClipboard } from '~/lib/clipboard'
+import { loadDetectedEditors, preferredEditor, resolvePreferredEditor } from '~/lib/externalEditors'
+import { createLogger } from '~/lib/logger'
+import { repoGitView } from '~/stores/repoGit'
+import { menuSectionHeader } from '~/styles/shared.css'
+import { menuItem } from './workspaceMenuItem'
+
+const log = createLogger('workspace-repository-menu')
+
+export interface WorkspaceRepositoryMenuProps {
+  /** Every repository this workspace has a checkout in. */
+  repos: () => readonly RepoStartPoint[]
+  repoGitStore: RepoGitStore
+  /** Whether a worker runs on THIS machine. See `~/lib/workerLocality`. */
+  isLocal: (workerId: string) => boolean
+  /** Whether the enclosing menu is open, so the editor probe waits for it. */
+  menuOpen: () => boolean
+}
+
+/**
+ * The read-only actions that hang off a workspace's repositories.
+ *
+ * Its own component because the editor probe belongs to it and to nothing else:
+ * the only consumer of `loadDetectedEditors` here is the "Open in ..." item, so
+ * the resource travels with the item rather than being a prop the row menu
+ * threads through.
+ *
+ * Every action here mutates nothing, so the submenu stays for an ARCHIVED
+ * workspace: copying a URL, revealing a directory and opening an editor are all
+ * reads.
+ */
+export const WorkspaceRepositoryMenu: Component<WorkspaceRepositoryMenuProps> = (props) => {
+  const prefs = usePreferences()
+
+  const anyLocal = () => props.repos().some(r => props.isLocal(r.startPoint.workerId))
+
+  // Fetched on open, and only where a local checkout could use one.
+  // `loadDetectedEditors` caches module-wide, so the second row's menu pays
+  // nothing.
+  const [editors] = createResource(
+    () => props.menuOpen() && anyLocal(),
+    async (eligible: boolean) => {
+      if (!eligible)
+        return []
+      // Caught here: `initialValue` does NOT suppress a rejection, and Solid
+      // re-throws one from the accessor. `namedEditor()` is read inside this
+      // menu's JSX, so a sidecar that cannot answer `ListEditors` would replace
+      // the whole shell with the route's error boundary instead of hiding one
+      // item.
+      try {
+        return await loadDetectedEditors()
+      }
+      catch (err: unknown) {
+        log.warn('list_editors failed; offering no editor', { err })
+        return []
+      }
+    },
+    { initialValue: [] },
+  )
+  // Named WITHOUT persisting: the label must not write a preference just by
+  // rendering. The launch below goes through `resolvePreferredEditor`, which
+  // pins whatever it picked.
+  const namedEditor = () => preferredEditor(editors(), prefs.preferredEditorId())
+
+  /**
+   * Each repository with the two facts its actions depend on.
+   *
+   * Resolved ONCE per repository. "Does this offer anything" is asked twice --
+   * for the submenu itself and again for each row inside it -- and the actions
+   * then need the same origin URL a third time. Answering it in one place is
+   * also what keeps the submenu's own condition and its rows from disagreeing
+   * after a later edit to either.
+   */
+  const repoRows = createMemo(() => props.repos().map((repo) => {
+    const tab = { workerId: repo.startPoint.workerId, gitToplevel: repo.startPoint.gitToplevel }
+    return {
+      repo,
+      originUrl: repoGitView(tab, props.repoGitStore).originUrl,
+      local: props.isLocal(repo.startPoint.workerId),
+    }
+  }))
+
+  type RepoRow = ReturnType<typeof repoRows>[number]
+
+  /** Whether one repository offers any action at all. */
+  const hasRepoActions = (row: RepoRow) => Boolean(row.originUrl) || row.local
+
+  const repoActions = (row: RepoRow) => {
+    const toplevel = row.repo.startPoint.gitToplevel
+    return (
+      <>
+        {/* Hidden with no origin: there is no URL to copy. */}
+        <Show when={row.originUrl}>
+          {url => menuItem('Copy repository URL', () => void copyTextToClipboard(url()))}
+        </Show>
+        {/* Both of these open the LOCAL Finder or the LOCAL editor, so a
+            remote worker's absolute path either does not exist here or --
+            worse -- exists and is a different directory. */}
+        <Show when={row.local}>
+          {menuItem('Reveal in file manager', () => void revealInFileManager(toplevel))}
+          <Show when={namedEditor()}>
+            {editor => menuItem(`Open in ${editor().displayName}`, () => {
+              const target = resolvePreferredEditor(editors(), prefs.preferredEditorId(), prefs.setPreferredEditorId)
+              if (!target)
+                return
+              platformBridge.openInEditor(target.id, toplevel).catch((err: unknown) => {
+                log.warn('open_in_editor failed', { id: target.id, err })
+              })
+            })}
+          </Show>
+        </Show>
+      </>
+    )
+  }
+
+  return (
+    <Show when={repoRows().some(hasRepoActions)}>
+      <SubMenu label="Repository" data-testid="workspace-repository" popoverTestId="workspace-repository-popover">
+        {/* The shape follows the repository COUNT, not the actionable count:
+            one repository reads better flat, and a lone group header over a
+            single list says nothing. */}
+        <Show
+          when={repoRows().length > 1}
+          fallback={repoActions(repoRows()[0])}
+        >
+          <For each={repoRows()}>
+            {row => (
+              <Show when={hasRepoActions(row)}>
+                <div role="group" aria-label={row.repo.label}>
+                  <div class={menuSectionHeader} aria-hidden="true">{row.repo.label}</div>
+                  {repoActions(row)}
+                </div>
+              </Show>
+            )}
+          </For>
+        </Show>
+      </SubMenu>
+    </Show>
+  )
+}

--- a/frontend/src/components/workspace/WorkspaceSectionContent.tsx
+++ b/frontend/src/components/workspace/WorkspaceSectionContent.tsx
@@ -16,7 +16,7 @@ import { Spinner } from '~/components/common/Spinner'
 import { Tooltip } from '~/components/common/Tooltip'
 import { WORKSPACE_DROP_PREFIX } from '~/components/shell/TabDragContext'
 import { attachDragActivators } from '~/lib/dragActivators'
-import { createGuardedDraggableRow, createGuardedSortableRow } from '~/lib/dragRow'
+import { createGuardedSortableRow } from '~/lib/dragRow'
 import { DiffStatsBadge, LabelWithDiffStats } from '../tree/gitStatusUtils'
 import * as shared from '../tree/sharedTree.css'
 import { sidebarActions } from '../tree/sidebarActions.css'
@@ -38,7 +38,7 @@ function applyDirective(directive: { ref: unknown }, el: HTMLElement) {
 }
 
 export interface WorkspaceSectionContentProps {
-  workspaces: Workspace[]
+  workspaces: readonly Workspace[]
   sectionId: string
   /** The section's display name, for each row menu's info block. */
   sectionName: string
@@ -112,10 +112,11 @@ export const WorkspaceSectionContent: Component<WorkspaceSectionContentProps> = 
   // ---------------------------------------------------------------------------
 
   // Which rows are expanded is APP state, not this instance's: one sidebar
-  // mounts this component once per workspace section, and the app mounts the
-  // sidebar twice. `~/components/workspace/expandedWorkspaces` owns the signal
-  // and the sessionStorage write for all of them -- a per-instance signal wrote
-  // the whole set back with no merge and erased every other instance's rows.
+  // mounts this component once per workspace section, and a custom workspace
+  // section can sit on the other sidebar.
+  // `~/components/workspace/expandedWorkspaces` owns the signal and the
+  // sessionStorage write for all of them -- a per-instance signal wrote the
+  // whole set back with no merge and erased every other instance's rows.
 
   // Auto-expand the active workspace when it changes (if it has tabs).
   createEffect(() => {
@@ -160,20 +161,18 @@ export const WorkspaceSectionContent: Component<WorkspaceSectionContentProps> = 
    */
   const canReorder = () => canReorderWithinSection(props.sectionId)
 
-  /**
-   * The `<For>` key carries the reorder MODE, not the workspace id alone.
-   *
-   * A solid-dnd primitive cannot be created conditionally on a later re-render,
-   * and the two modes need DIFFERENT primitives: a sortable registers a
-   * between-row drop target, and a plain draggable registers none. Putting the
-   * mode in the key remounts the row when it flips, which happens only when the
-   * user picks a sort or types a filter -- exactly when the list is being
-   * rebuilt anyway.
-   */
-  const rowKeys = () => workspaceIds().map(id => `${canReorder() ? 's' : 'd'}\u0000${id}`)
-  const idOfRowKey = (rowKey: string) => rowKey.slice(rowKey.indexOf('\u0000') + 1)
-
   return (
+    // An EMPTY id list is what suppresses the reorder, and it is enough: with
+    // no id registered, `initialIndex()` and `currentIndex()` are both -1, so
+    // every sortable reports the identity transform and no row shifts to open a
+    // gap. The rows stay SORTABLE either way.
+    //
+    // Swapping each row to a plain draggable instead looked equivalent and was
+    // not. `createSortable` registers a droppable under the same id, and that
+    // droppable is the only thing `handleWorkspaceDragEnd` can resolve a ROW
+    // target from -- so dropping a workspace onto a row of another section fell
+    // through to the nearest section BODY centre, which for sections of unequal
+    // height is not always the section the user aimed at.
     <SortableProvider ids={canReorder() ? props.workspaces.map(w => `ws-${w.id}`) : []}>
       <div
         ref={droppable}
@@ -219,24 +218,14 @@ export const WorkspaceSectionContent: Component<WorkspaceSectionContentProps> = 
             </div>
           )}
         >
-          <For each={rowKeys()}>
-            {(rowKey) => {
-              const id = idOfRowKey(rowKey)
+          <For each={workspaceIds()}>
+            {(id) => {
               const workspace = () => workspaceById().get(id)!
 
-              // Read ONCE per row, deliberately: a solid-dnd primitive cannot
-              // be created conditionally on a later re-render. The `<For>` key
-              // above carries the mode, so a flip remounts the row and this
-              // decision is made again with it.
-              const dragRow = canReorderWithinSection(props.sectionId)
-                ? createGuardedSortableRow(`ws-${id}`, {
-                    sectionId: props.sectionId,
-                    workspaceId: id,
-                  })
-                : createGuardedDraggableRow(`ws-${id}`, {
-                    sectionId: props.sectionId,
-                    workspaceId: id,
-                  })
+              const dragRow = createGuardedSortableRow(`ws-${id}`, {
+                sectionId: props.sectionId,
+                workspaceId: id,
+              })
               const wsDroppable = createDroppable(`${WORKSPACE_DROP_PREFIX}${id}`)
               const isActive = () => id === props.activeWorkspaceId
               const isRenaming = () => props.renamingWorkspaceId === id

--- a/frontend/src/components/workspace/WorkspaceSectionContent.tsx
+++ b/frontend/src/components/workspace/WorkspaceSectionContent.tsx
@@ -1,5 +1,6 @@
 import type { Component } from 'solid-js'
 import type { BranchRefActions } from './branchActions'
+import type { WorkspaceStartActions } from './workspaceStartActions'
 import type { Section } from '~/generated/proto/leapmux/v1/section_pb'
 import type { TabType, Workspace } from '~/generated/proto/leapmux/v1/workspace_pb'
 import type { WorkerInfo } from '~/lib/workerInfoCache'
@@ -15,13 +16,20 @@ import { Spinner } from '~/components/common/Spinner'
 import { Tooltip } from '~/components/common/Tooltip'
 import { WORKSPACE_DROP_PREFIX } from '~/components/shell/TabDragContext'
 import { attachDragActivators } from '~/lib/dragActivators'
-import { createGuardedSortableRow } from '~/lib/dragRow'
+import { createGuardedDraggableRow, createGuardedSortableRow } from '~/lib/dragRow'
 import { DiffStatsBadge, LabelWithDiffStats } from '../tree/gitStatusUtils'
 import * as shared from '../tree/sharedTree.css'
 import { sidebarActions } from '../tree/sidebarActions.css'
 import { isWorkspaceExpanded, setWorkspacesExpanded, toggleWorkspaceExpanded } from './expandedWorkspaces'
 import { WorkspaceContextMenu } from './WorkspaceContextMenu'
 import * as styles from './workspaceList.css'
+import {
+  canReorderWithinSection,
+  isSectionFilterShown,
+  sectionFilterQuery,
+  setSectionFilterQuery,
+  toggleSectionFilter,
+} from './workspaceListState'
 import { sumDiffStatsFromTabs, WorkspaceTabTree } from './WorkspaceTabTree'
 
 /** solid-dnd directives are callable but typed as objects; this wraps the unsafe cast. */
@@ -32,6 +40,8 @@ function applyDirective(directive: { ref: unknown }, el: HTMLElement) {
 export interface WorkspaceSectionContentProps {
   workspaces: Workspace[]
   sectionId: string
+  /** The section's display name, for each row menu's info block. */
+  sectionName: string
   activeWorkspaceId: string | null
   sections: Section[]
   onSelect: (id: string) => void
@@ -71,6 +81,14 @@ export interface WorkspaceSectionContentProps {
    */
   workerInfoFn?: (id: string) => WorkerInfo | null
   isWorkerKnownOnline?: (workerId: string) => boolean
+  /**
+   * Whether a worker runs on THIS machine, so the row menu may offer the two
+   * actions that open the LOCAL Finder and the LOCAL editor. See
+   * `~/lib/workerLocality`.
+   */
+  isLocalWorkerFn?: (workerId: string) => boolean
+  /** Open a new agent / terminal at one of a workspace's checkouts. */
+  startActions?: WorkspaceStartActions
   /** Branch-menu callbacks, unbound. Each branch row binds them to its own ref. */
   branchActions?: BranchRefActions
   repoGitStore: ReturnType<typeof createRepoGitStore>
@@ -133,8 +151,30 @@ export const WorkspaceSectionContent: Component<WorkspaceSectionContentProps> = 
     return map
   })
 
+  /**
+   * Whether this section's rows may be dragged to a new position within it.
+   *
+   * False while a non-manual sort or a live filter makes the view order differ
+   * from the model order -- the state in which "insert here" has no meaning.
+   * See `canReorderWithin`.
+   */
+  const canReorder = () => canReorderWithinSection(props.sectionId)
+
+  /**
+   * The `<For>` key carries the reorder MODE, not the workspace id alone.
+   *
+   * A solid-dnd primitive cannot be created conditionally on a later re-render,
+   * and the two modes need DIFFERENT primitives: a sortable registers a
+   * between-row drop target, and a plain draggable registers none. Putting the
+   * mode in the key remounts the row when it flips, which happens only when the
+   * user picks a sort or types a filter -- exactly when the list is being
+   * rebuilt anyway.
+   */
+  const rowKeys = () => workspaceIds().map(id => `${canReorder() ? 's' : 'd'}\u0000${id}`)
+  const idOfRowKey = (rowKey: string) => rowKey.slice(rowKey.indexOf('\u0000') + 1)
+
   return (
-    <SortableProvider ids={props.workspaces.map(w => `ws-${w.id}`)}>
+    <SortableProvider ids={canReorder() ? props.workspaces.map(w => `ws-${w.id}`) : []}>
       <div
         ref={droppable}
         class={styles.sectionItems}
@@ -142,17 +182,61 @@ export const WorkspaceSectionContent: Component<WorkspaceSectionContentProps> = 
           [styles.sectionHeaderDropTarget]: droppable.isActiveDroppable,
         }}
       >
+        {/* In the section BODY, not in the header menu's popover: that keeps
+            the menu a plain `menu` (a `div` popover would force a per-item
+            close) and leaves the box usable while the menu is shut. */}
+        <Show when={isSectionFilterShown(props.sectionId)}>
+          <div class={styles.filterRow}>
+            <input
+              type="text"
+              class={styles.filterInput}
+              aria-label={`Filter ${props.sectionName}`}
+              data-testid={`workspace-filter-${props.sectionId}`}
+              placeholder="Filter workspaces"
+              value={sectionFilterQuery(props.sectionId) ?? ''}
+              onInput={e => setSectionFilterQuery(props.sectionId, e.currentTarget.value)}
+              onKeyDown={(e) => {
+                // Escape closes the box rather than reaching the sidebar, which
+                // would leave a narrowed list with no visible reason for it.
+                if (e.key === 'Escape') {
+                  e.stopPropagation()
+                  toggleSectionFilter(props.sectionId)
+                }
+              }}
+              ref={(el) => {
+                requestAnimationFrame(() => el.focus())
+              }}
+            />
+          </div>
+        </Show>
         <Show
           when={props.workspaces.length > 0}
-          fallback={<div class={styles.emptySection}>No workspaces</div>}
+          fallback={(
+            <div class={styles.emptySection}>
+              {isSectionFilterShown(props.sectionId) && (sectionFilterQuery(props.sectionId) ?? '') !== ''
+                ? 'No matching workspaces'
+                : 'No workspaces'}
+            </div>
+          )}
         >
-          <For each={workspaceIds()}>
-            {(id) => {
+          <For each={rowKeys()}>
+            {(rowKey) => {
+              const id = idOfRowKey(rowKey)
               const workspace = () => workspaceById().get(id)!
-              const dragRow = createGuardedSortableRow(`ws-${id}`, {
-                sectionId: props.sectionId,
-                workspaceId: id,
-              })
+
+              // Read ONCE per row, deliberately: a solid-dnd primitive cannot
+              // be created conditionally on a later re-render. The `<For>` key
+              // above carries the mode, so a flip remounts the row and this
+              // decision is made again with it.
+              const dragRow = canReorderWithinSection(props.sectionId)
+                ? createGuardedSortableRow(`ws-${id}`, {
+                    sectionId: props.sectionId,
+                    workspaceId: id,
+                  })
+                : createGuardedDraggableRow(`ws-${id}`, {
+                    sectionId: props.sectionId,
+                    workspaceId: id,
+                  })
               const wsDroppable = createDroppable(`${WORKSPACE_DROP_PREFIX}${id}`)
               const isActive = () => id === props.activeWorkspaceId
               const isRenaming = () => props.renamingWorkspaceId === id
@@ -265,9 +349,18 @@ export const WorkspaceSectionContent: Component<WorkspaceSectionContentProps> = 
                         <Show when={!isRenaming()}>
                           <WorkspaceContextMenu
                             contextMenuFor={rowEl}
+                            workspaceId={id}
+                            workspaceTitle={title()}
+                            sectionName={props.sectionName}
                             isArchived={props.isArchived(id)}
                             sections={props.sections}
                             currentSectionId={props.sectionId}
+                            getTabs={() => tabsFor(id)}
+                            repoGitStore={props.repoGitStore}
+                            workerInfoFn={props.workerInfoFn}
+                            isWorkerOnline={props.isWorkerKnownOnline}
+                            isLocalWorkerFn={props.isLocalWorkerFn}
+                            startActions={props.startActions}
                             onRename={() => props.onRename(workspace())}
                             onMoveTo={targetSectionId => props.onMoveTo(id, targetSectionId)}
                             onArchive={() => props.onArchive(id)}

--- a/frontend/src/components/workspace/WorkspaceSectionContent.tsx
+++ b/frontend/src/components/workspace/WorkspaceSectionContent.tsx
@@ -8,19 +8,18 @@ import type { createRepoGitStore } from '~/stores/repoGit.store'
 import type { Tab, TabItemOps } from '~/stores/tab.types'
 import { createDroppable, SortableProvider } from '@thisbeyond/solid-dnd'
 import ChevronRight from 'lucide-solid/icons/chevron-right'
-import { createEffect, createMemo, createSignal, For, Show } from 'solid-js'
+import { createEffect, createMemo, For, Show } from 'solid-js'
 import { DragHandle } from '~/components/common/DragHandle'
 import { createContextMenuAnchor } from '~/components/common/DropdownMenu'
 import { Spinner } from '~/components/common/Spinner'
 import { Tooltip } from '~/components/common/Tooltip'
 import { WORKSPACE_DROP_PREFIX } from '~/components/shell/TabDragContext'
-import { KEY_EXPANDED_WORKSPACES, sessionStorageSet } from '~/lib/browserStorage'
 import { attachDragActivators } from '~/lib/dragActivators'
 import { createGuardedSortableRow } from '~/lib/dragRow'
 import { DiffStatsBadge, LabelWithDiffStats } from '../tree/gitStatusUtils'
 import * as shared from '../tree/sharedTree.css'
 import { sidebarActions } from '../tree/sidebarActions.css'
-import { readExpandedWorkspaceIds } from './expandedWorkspaces'
+import { isWorkspaceExpanded, setWorkspacesExpanded, toggleWorkspaceExpanded } from './expandedWorkspaces'
 import { WorkspaceContextMenu } from './WorkspaceContextMenu'
 import * as styles from './workspaceList.css'
 import { sumDiffStatsFromTabs, WorkspaceTabTree } from './WorkspaceTabTree'
@@ -94,43 +93,17 @@ export const WorkspaceSectionContent: Component<WorkspaceSectionContentProps> = 
   // transformer" warnings.
   // ---------------------------------------------------------------------------
 
-  // Track which workspaces have their tab tree expanded (independent of selection).
-  // Restore from sessionStorage so expanded state survives page refresh.
-  const [expandedIds, setExpandedIds] = createSignal<Set<string>>(readExpandedWorkspaceIds())
-
-  function isExpanded(id: string): boolean {
-    return expandedIds().has(id)
-  }
-
-  function toggleExpanded(id: string) {
-    setExpandedIds((prev) => {
-      const next = new Set(prev)
-      if (next.has(id))
-        next.delete(id)
-      else
-        next.add(id)
-      return next
-    })
-  }
-
-  // Persist expanded state to sessionStorage.
-  createEffect(() => {
-    const ids = expandedIds()
-    sessionStorageSet(KEY_EXPANDED_WORKSPACES, [...ids])
-  })
+  // Which rows are expanded is APP state, not this instance's: one sidebar
+  // mounts this component once per workspace section, and the app mounts the
+  // sidebar twice. `~/components/workspace/expandedWorkspaces` owns the signal
+  // and the sessionStorage write for all of them -- a per-instance signal wrote
+  // the whole set back with no merge and erased every other instance's rows.
 
   // Auto-expand the active workspace when it changes (if it has tabs).
   createEffect(() => {
     const activeId = props.activeWorkspaceId
-    if (activeId && props.getTabsForWorkspace(activeId).length > 0) {
-      setExpandedIds((prev) => {
-        if (prev.has(activeId))
-          return prev
-        const next = new Set(prev)
-        next.add(activeId)
-        return next
-      })
-    }
+    if (activeId && props.getTabsForWorkspace(activeId).length > 0)
+      setWorkspacesExpanded([activeId], true)
   })
 
   // The active workspace used to be forked onto separate `tabs` /
@@ -238,16 +211,16 @@ export const WorkspaceSectionContent: Component<WorkspaceSectionContentProps> = 
                     // Collapsing only sets `visibility: hidden` on the children
                     // wrapper, so the leaves stay in the DOM and counting them
                     // cannot tell expanded from collapsed. Expose the bit.
-                    data-expanded={isExpanded(id) ? 'true' : 'false'}
+                    data-expanded={isWorkspaceExpanded(id) ? 'true' : 'false'}
                   >
                     <DragHandle activators={dragRow.gripActivators} testId="workspace-drag-handle" />
                     <ChevronRight
                       size={14}
-                      class={`${shared.chevron} ${isExpanded(id) ? shared.chevronExpanded : ''}`}
+                      class={`${shared.chevron} ${isWorkspaceExpanded(id) ? shared.chevronExpanded : ''}`}
                       data-testid={`workspace-chevron-${id}`}
                       onClick={(e) => {
                         e.stopPropagation()
-                        toggleExpanded(id)
+                        toggleWorkspaceExpanded(id)
                       }}
                     />
                     <Show
@@ -306,7 +279,7 @@ export const WorkspaceSectionContent: Component<WorkspaceSectionContentProps> = 
                     </div>
                   </div>
                   <div
-                    class={`${shared.childrenWrapper} ${isExpanded(id) ? shared.childrenWrapperExpanded : ''}`}
+                    class={`${shared.childrenWrapper} ${isWorkspaceExpanded(id) ? shared.childrenWrapperExpanded : ''}`}
                     data-testid={`workspace-children-${id}`}
                   >
                     <div class={shared.childrenInner}>

--- a/frontend/src/components/workspace/WorkspaceStartMenuItems.tsx
+++ b/frontend/src/components/workspace/WorkspaceStartMenuItems.tsx
@@ -1,0 +1,80 @@
+import type { Component } from 'solid-js'
+import type { RepoStartPoint } from './repoStartPoints'
+import type { WorkspaceStartAt } from './workspaceStartActions'
+import { For, Show } from 'solid-js'
+import { SubMenu } from '~/components/common/SubMenu'
+import { Tooltip } from '~/components/common/Tooltip'
+import { menuItem } from './workspaceMenuItem'
+
+export interface WorkspaceStartMenuItemsProps {
+  /** The verb the item leads with: "New agent" or "New terminal". */
+  'verb': string
+  /** Every repository this workspace has a checkout in. */
+  'repos': () => readonly RepoStartPoint[]
+  /** Those on a reachable worker -- the ones a tab can actually open in. */
+  'startableRepos': () => readonly RepoStartPoint[]
+  'run': (at: WorkspaceStartAt) => void
+  /** The no-target start: this workspace, and no checkout. */
+  'startAtWorkspace': () => WorkspaceStartAt
+  'startAt': (repo: RepoStartPoint) => WorkspaceStartAt
+  'data-testid': string
+}
+
+/**
+ * One tab-creation entry, in the shape the repository count calls for.
+ *
+ * Three shapes, and the third state is the one worth naming:
+ *
+ *  - NO checkout: the item still opens, with no target. A freshly created
+ *    workspace has no tabs, and that is exactly the row that most needs a way
+ *    in. An empty worker and directory mean "follow the current tab context".
+ *  - Checkouts, none REACHABLE: the item is disabled and says why. It cannot
+ *    borrow the no-target shape, because "follow the current tab context"
+ *    would start an agent on a machine the user never picked.
+ *  - One reachable checkout renders FLAT; more than one opens a submenu. A
+ *    submenu holding a single item is a click the user should not have to make.
+ */
+export const WorkspaceStartMenuItems: Component<WorkspaceStartMenuItemsProps> = (props) => {
+  const allTargetsOffline = () => props.repos().length > 0 && props.startableRepos().length === 0
+
+  return (
+    <Show
+      when={!allTargetsOffline()}
+      fallback={(
+        <Tooltip text="Every machine this workspace is checked out on is offline.">
+          <button type="button" role="menuitem" data-testid={props['data-testid']} disabled>
+            {`${props.verb}...`}
+          </button>
+        </Tooltip>
+      )}
+    >
+      <Show
+        when={props.startableRepos().length > 0}
+        fallback={menuItem(
+          `${props.verb}...`,
+          () => props.run(props.startAtWorkspace()),
+          props['data-testid'],
+        )}
+      >
+        <Show
+          when={props.startableRepos().length > 1}
+          fallback={menuItem(
+            `${props.verb} in ${props.startableRepos()[0].label}...`,
+            () => props.run(props.startAt(props.startableRepos()[0])),
+            props['data-testid'],
+          )}
+        >
+          <SubMenu
+            label={`${props.verb} in`}
+            data-testid={props['data-testid']}
+            popoverTestId={`${props['data-testid']}-popover`}
+          >
+            <For each={props.startableRepos()}>
+              {repo => menuItem(repo.label, () => props.run(props.startAt(repo)))}
+            </For>
+          </SubMenu>
+        </Show>
+      </Show>
+    </Show>
+  )
+}

--- a/frontend/src/components/workspace/WorkspaceTabTree.test.ts
+++ b/frontend/src/components/workspace/WorkspaceTabTree.test.ts
@@ -683,11 +683,11 @@ describe('buildTree branch tilde inputs', () => {
 // Two workers holding the same branch at the same path under each home
 // directory render two rows whose name, kind and shortened directory are all
 // identical — and Delete on one of them removes the other machine's directory.
-// The row's tooltip names the worker exactly when that can happen.
+// The row's tooltip identifies the worker exactly when that can happen.
 describe('buildTree branch workerLabel', () => {
   const twoWorkers = (id: string) => (id === 'w1' ? posixLookup() : { ...posixLookup(), name: 'worker-b' })
 
-  it('names the worker when the branch appears on more than one', () => {
+  it('identifies the worker when the branch appears on more than one', () => {
     const { tabs, repoSeeds } = tabsWithSeeds([
       { id: '1', workerId: 'w1', gitOriginUrl: 'https://github.com/o/r.git', gitBranch: 'main', gitToplevel: '/home/u/Workspaces/r' },
       { id: '2', workerId: 'w2', gitOriginUrl: 'https://github.com/o/r.git', gitBranch: 'main', gitToplevel: '/home/u/Workspaces/r' },

--- a/frontend/src/components/workspace/WorkspaceTabTree.test.ts
+++ b/frontend/src/components/workspace/WorkspaceTabTree.test.ts
@@ -7,7 +7,7 @@ import { tildify } from '~/lib/paths'
 import { repoKey } from '~/stores/repoGit'
 import { createRepoGitStore } from '~/stores/repoGit.store'
 import { repoKeyForLocal } from './branchKeys'
-import { buildTree, formatGitOriginUrl, nestSubagentTabs, sumDiffStatsFromTabs, tabBuildKey, workerProjectionsEqual } from './WorkspaceTabTree'
+import { buildTree, nestSubagentTabs, sumDiffStatsFromTabs, tabBuildKey, workerProjectionsEqual } from './WorkspaceTabTree'
 
 interface RepoGitSeed {
   workerId?: string
@@ -176,47 +176,6 @@ function tabsWithSeeds(
   }
   return { tabs, repoSeeds: [...seedByKey.values()] }
 }
-
-describe('formatGitOriginUrl', () => {
-  it('strips https protocol', () => {
-    expect(formatGitOriginUrl('https://github.com/org/repo.git'))
-      .toBe('github.com/org/repo')
-  })
-
-  it('strips http protocol', () => {
-    expect(formatGitOriginUrl('http://github.com/org/repo.git'))
-      .toBe('github.com/org/repo')
-  })
-
-  it('converts SSH format', () => {
-    expect(formatGitOriginUrl('git@github.com:org/repo.git'))
-      .toBe('github.com/org/repo')
-  })
-
-  it('strips trailing .git', () => {
-    expect(formatGitOriginUrl('https://github.com/org/repo.git'))
-      .toBe('github.com/org/repo')
-  })
-
-  it('handles URL without .git suffix', () => {
-    expect(formatGitOriginUrl('https://github.com/org/repo'))
-      .toBe('github.com/org/repo')
-  })
-
-  it('strips trailing slash', () => {
-    expect(formatGitOriginUrl('https://github.com/org/repo/'))
-      .toBe('github.com/org/repo')
-  })
-
-  it('returns empty string for empty input', () => {
-    expect(formatGitOriginUrl('')).toBe('')
-  })
-
-  it('handles SSH with nested path', () => {
-    expect(formatGitOriginUrl('git@gitlab.com:group/subgroup/repo.git'))
-      .toBe('gitlab.com/group/subgroup/repo')
-  })
-})
 
 describe('buildTree', () => {
   it('returns empty tree for empty input', () => {

--- a/frontend/src/components/workspace/WorkspaceTabTree.tsx
+++ b/frontend/src/components/workspace/WorkspaceTabTree.tsx
@@ -23,8 +23,8 @@ import { createStableContext } from '~/lib/createStableContext'
 import { attachDragActivators } from '~/lib/dragActivators'
 import { createGuardedDraggableRow } from '~/lib/dragRow'
 import { createKeyedRows, createKeyLookup, createStableKeys, KeyedFor } from '~/lib/keyedRows'
-import { flavorFromOs, tildify } from '~/lib/paths'
 import { shallowEqualArrays, shallowEqualExcept } from '~/lib/shallowEqual'
+import { tildifyForWorker, workerPathFlavor } from '~/lib/workerPaths'
 import { diffStatsFromRepo, repoGitView } from '~/stores/repoGit'
 import { canCloseTab, canRenameTab, tabDisplayLabel, tabKey, tabTooltipShowWhen, tabTooltipText, terminalProgressBarProps, terminalProgressVisible } from '~/stores/tab.helpers'
 import { isAgentTab, isTerminalTab } from '~/stores/tab.types'
@@ -1350,34 +1350,6 @@ export function buildTree(
   })
 
   return { groups, ungrouped: sort(ungrouped) }
-}
-
-/**
- * The path flavor to shorten a worker's paths with, or undefined when the
- * worker has not reported its OS.
- *
- * Undefined rather than a default, because `flavorFromOs(undefined)` answers
- * `'posix'` — which would force posix onto a Windows worker with no system info
- * yet, and stop `C:\Users\u\repo` from compressing at all. Undefined lets
- * `tildify` sniff the flavor from the path instead.
- */
-function workerPathFlavor(info: WorkerInfo | null | undefined): PathFlavor | undefined {
-  return info?.os ? flavorFromOs(info.os) : undefined
-}
-
-/**
- * Tilde-compress a worker-side absolute path for the collision suffix.
- *
- * One spelling of the rule for the whole tree: this suffix and the row's own
- * tooltip must shorten the same path the same way, or a row reads
- * `~/repos/foo` while its tooltip reads `/Users/x/repos/foo`. The tooltip gets
- * there by handing `WorkingTreeRows` the same `homeDir` and `flavor` this
- * function derives, so both end in one `tildify` call with equal arguments.
- * Returns the path unchanged while the worker's system info is absent — a
- * correct long path beats a wrong short one.
- */
-function tildifyForWorker(path: string, info: WorkerInfo | null | undefined): string {
-  return tildify(path, info?.homeDir, workerPathFlavor(info))
 }
 
 /**

--- a/frontend/src/components/workspace/WorkspaceTabTree.tsx
+++ b/frontend/src/components/workspace/WorkspaceTabTree.tsx
@@ -163,7 +163,7 @@ export function workerProjectionsEqual(
  * its own `Tab` objects can predate the last hydration or rename. Both dialogs
  * freeze what they get at open time -- `DeleteBranchDialog` counts tabs by type
  * and reads a `workingDir` off one of them -- so the snapshot they freeze had
- * better be the current one. A key that no longer resolves names a tab closed
+ * better be the current one. A key that no longer resolves identifies a tab closed
  * since the last rebuild; dropping it is the point, not a loss.
  */
 function buildBranchRef(workspaceId: string, b: BranchGroup, liveTab: (key: string) => Tab | undefined): BranchRef {
@@ -206,7 +206,7 @@ function parentAgentIdOf(tab: Tab): string | undefined {
 export function nestSubagentTabs(tabs: readonly Tab[]): TabNode[] {
   // Keyed by the composite tabKey, not by a bare id. `tabKey` is namespaced by
   // TYPE precisely because an AGENT and a TERMINAL tab can share an id, and a
-  // parent link only ever names an AGENT -- so a bare-id lookup let a non-agent
+  // parent link only ever identifies an AGENT -- so a bare-id lookup let a non-agent
   // tab resolve to the agent's node, push it into the forest twice, and drop the
   // non-agent row entirely.
   const agentNodeKey = (id: string) => tabKey({ type: TabType.AGENT, id } as Tab)
@@ -428,7 +428,7 @@ interface RowSelectionContextValue {
   isCollapsed: (key: string) => boolean
   toggleCollapsed: (key: string) => void
   /**
-   * The tab a key names RIGHT NOW, straight off `props.tabs` -- never off the
+   * The tab a key identifies RIGHT NOW, straight off `props.tabs` -- never off the
    * cached tree. Reactive: reading it inside a row subscribes that row to its
    * own tab, so a metadata-only change (a rename, a hydrated title/provider, a
    * terminal status flip) updates the row in place without rebuilding the tree.
@@ -1202,7 +1202,7 @@ export function buildTree(
     const workerId = tab.workerId ?? ''
     const gitToplevel = tabGitToplevelForKey(tab, store, git)
     // Through the shared function, not a second copy of its body. This IS the
-    // "the sidebar groups its tree by it" caller tabBranchKey's own doc names,
+    // "the sidebar groups its tree by it" caller tabBranchKey's own doc describes,
     // and the composer's delete-branch dialog collects its tab list by the same
     // function -- a second membership test here would let the dialog report a
     // different set of affected tabs than the tree shows. The resolved view

--- a/frontend/src/components/workspace/WorkspaceTabTree.tsx
+++ b/frontend/src/components/workspace/WorkspaceTabTree.tsx
@@ -23,7 +23,7 @@ import { createStableContext } from '~/lib/createStableContext'
 import { attachDragActivators } from '~/lib/dragActivators'
 import { createGuardedDraggableRow } from '~/lib/dragRow'
 import { createKeyedRows, createKeyLookup, createStableKeys, KeyedFor } from '~/lib/keyedRows'
-import { basename, flavorFromOs, tildify } from '~/lib/paths'
+import { flavorFromOs, tildify } from '~/lib/paths'
 import { shallowEqualArrays, shallowEqualExcept } from '~/lib/shallowEqual'
 import { diffStatsFromRepo, repoGitView } from '~/stores/repoGit'
 import { canCloseTab, canRenameTab, tabDisplayLabel, tabKey, tabTooltipShowWhen, tabTooltipText, terminalProgressBarProps, terminalProgressVisible } from '~/stores/tab.helpers'
@@ -40,7 +40,7 @@ import {
   branchNameSegment,
   collapseKeyForBranch,
   isLocalRepoKey,
-  repoKeyForLocal,
+  repoKeyAndLabel,
   repoKeyTooltip,
   tabBranchKey,
   tabGitToplevelForKey,
@@ -1122,52 +1122,6 @@ interface RepoGroup {
 interface TabTree {
   groups: RepoGroup[]
   ungrouped: Tab[]
-}
-
-const SSH_ORIGIN_RE = /^git@([^:]+):(.+)$/
-const PROTOCOL_PREFIX_RE = /^https?:\/\//
-const TRAILING_DOT_GIT_RE = /\.git$/
-const TRAILING_SLASH_RE = /\/$/
-
-export function formatGitOriginUrl(url: string): string {
-  if (!url)
-    return ''
-  let result = url
-  // Convert SSH format: git@github.com:org/repo -> github.com/org/repo
-  const sshMatch = result.match(SSH_ORIGIN_RE)
-  if (sshMatch)
-    result = `${sshMatch[1]}/${sshMatch[2]}`
-  // Strip protocols
-  result = result.replace(PROTOCOL_PREFIX_RE, '')
-  // Strip trailing .git
-  result = result.replace(TRAILING_DOT_GIT_RE, '')
-  // Strip trailing slash
-  result = result.replace(TRAILING_SLASH_RE, '')
-  return result
-}
-
-/**
- * Computes the grouping key and display label for a tab's repository. Order
- * of precedence:
- *   1. gitOriginUrl — a remote we can format nicely.
- *   2. gitToplevel — an origin-less local repo; the toplevel path makes
- *      distinct repos distinct.
- * Tabs that lack both fall through to the ungrouped bucket.
- */
-function repoKeyAndLabel(tab: Tab, store: RepoGitStore): { key: string, label: string } | null {
-  const git = repoGitView(tab, store)
-  if (git.originUrl)
-    return { key: git.originUrl, label: formatGitOriginUrl(git.originUrl) }
-  // Through the shared helper, so the group key and the branch bucket resolve
-  // the toplevel the same way. A second copy of the chain here is what let a
-  // stale row value override the worker's "not a git repository" answer. The
-  // view resolved once at the top carries through.
-  const toplevel = tabGitToplevelForKey(tab, store, git)
-  if (toplevel) {
-    const label = basename(toplevel) || toplevel
-    return { key: repoKeyForLocal(toplevel), label }
-  }
-  return null
 }
 
 /**

--- a/frontend/src/components/workspace/branchKeys.test.ts
+++ b/frontend/src/components/workspace/branchKeys.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import { repoGitView, repoKey } from '~/stores/repoGit'
 import { createRepoGitStore } from '~/stores/repoGit.store'
 import {
@@ -93,7 +93,14 @@ describe('collapseKeyForBranch', () => {
 })
 
 describe('tabBranchKey', () => {
-  const store = createRepoGitStore()
+  // A FRESH store per case. One store shared across the block made the cases
+  // order-dependent: `agrees with branchKey for the same triple` seeds
+  // `w1 /repo -> main` and the next case overwrites that same key with `''`,
+  // so a reordered or `.only`-run case read a different fixture.
+  let store = createRepoGitStore()
+  beforeEach(() => {
+    store = createRepoGitStore()
+  })
   const tab = (gitToplevel?: string, workerId?: string) => ({ gitToplevel, workerId })
 
   function seedBranch(workerId: string, gitToplevel: string, branch: string) {
@@ -183,7 +190,11 @@ describe('branchKeys accept a precomputed view', () => {
 })
 
 describe('repoKeyAndLabel', () => {
-  const store = createRepoGitStore()
+  // A FRESH store per case, for the same reason as `tabBranchKey` above.
+  let store = createRepoGitStore()
+  beforeEach(() => {
+    store = createRepoGitStore()
+  })
 
   function seedRepo(workerId: string, toplevel: string, patch: Record<string, unknown>) {
     store.upsert(repoKey(workerId, toplevel), { workerId, toplevel, ...patch })
@@ -229,7 +240,9 @@ describe('repoKeyAndLabel', () => {
 })
 
 describe('formatGitOriginUrl', () => {
-  it('strips https protocol', () => {
+  // One case covers the protocol strip AND the `.git` strip; a second case
+  // asserting the identical input and expectation covered nothing more.
+  it('strips the https protocol and the trailing .git', () => {
     expect(formatGitOriginUrl('https://github.com/org/repo.git'))
       .toBe('github.com/org/repo')
   })
@@ -241,11 +254,6 @@ describe('formatGitOriginUrl', () => {
 
   it('converts SSH format', () => {
     expect(formatGitOriginUrl('git@github.com:org/repo.git'))
-      .toBe('github.com/org/repo')
-  })
-
-  it('strips trailing .git', () => {
-    expect(formatGitOriginUrl('https://github.com/org/repo.git'))
       .toBe('github.com/org/repo')
   })
 

--- a/frontend/src/components/workspace/branchKeys.test.ts
+++ b/frontend/src/components/workspace/branchKeys.test.ts
@@ -5,7 +5,9 @@ import {
   branchKey,
   branchNameSegment,
   collapseKeyForBranch,
+  formatGitOriginUrl,
   isLocalRepoKey,
+  repoKeyAndLabel,
   repoKeyForLocal,
   repoKeyTooltip,
   tabBranchKey,
@@ -177,5 +179,92 @@ describe('branchKeys accept a precomputed view', () => {
     const view = repoGitView(tab, store)
     expect(tabBranchKey(tab, store, view))
       .toBe(tabBranchKey(tab, store))
+  })
+})
+
+describe('repoKeyAndLabel', () => {
+  const store = createRepoGitStore()
+
+  function seedRepo(workerId: string, toplevel: string, patch: Record<string, unknown>) {
+    store.upsert(repoKey(workerId, toplevel), { workerId, toplevel, ...patch })
+  }
+
+  it('keys an origin-backed repo by its raw origin URL, labelled for reading', () => {
+    seedRepo('w1', '/repo', { originUrl: 'git@github.com:org/repo.git' })
+    expect(repoKeyAndLabel({ workerId: 'w1', gitToplevel: '/repo' }, store))
+      .toEqual({ key: 'git@github.com:org/repo.git', label: 'github.com/org/repo' })
+  })
+
+  it('gives two clones of one origin on two workers the same key', () => {
+    seedRepo('w1', '/a', { originUrl: 'https://example.com/o/r.git' })
+    seedRepo('w2', '/b', { originUrl: 'https://example.com/o/r.git' })
+    expect(repoKeyAndLabel({ workerId: 'w1', gitToplevel: '/a' }, store)?.key)
+      .toBe(repoKeyAndLabel({ workerId: 'w2', gitToplevel: '/b' }, store)?.key)
+  })
+
+  it('keys an origin-less repo by its toplevel, labelled with the basename', () => {
+    seedRepo('w1', '/home/me/alpha', {})
+    expect(repoKeyAndLabel({ workerId: 'w1', gitToplevel: '/home/me/alpha' }, store))
+      .toEqual({ key: repoKeyForLocal('/home/me/alpha'), label: 'alpha' })
+  })
+
+  it('keeps two origin-less repos on one worker apart', () => {
+    seedRepo('w1', '/home/me/alpha', {})
+    seedRepo('w1', '/home/me/beta', {})
+    expect(repoKeyAndLabel({ workerId: 'w1', gitToplevel: '/home/me/alpha' }, store)?.key)
+      .not
+      .toBe(repoKeyAndLabel({ workerId: 'w1', gitToplevel: '/home/me/beta' }, store)?.key)
+  })
+
+  it('answers null for a tab with neither an origin nor a toplevel', () => {
+    expect(repoKeyAndLabel({ workerId: 'w1' }, store)).toBeNull()
+  })
+
+  it('accepts a pre-resolved view rather than resolving a second time', () => {
+    seedRepo('w1', '/repo', { originUrl: 'https://example.com/o/r.git' })
+    const tab = { workerId: 'w1', gitToplevel: '/repo' }
+    expect(repoKeyAndLabel(tab, store, repoGitView(tab, store)))
+      .toEqual(repoKeyAndLabel(tab, store))
+  })
+})
+
+describe('formatGitOriginUrl', () => {
+  it('strips https protocol', () => {
+    expect(formatGitOriginUrl('https://github.com/org/repo.git'))
+      .toBe('github.com/org/repo')
+  })
+
+  it('strips http protocol', () => {
+    expect(formatGitOriginUrl('http://github.com/org/repo.git'))
+      .toBe('github.com/org/repo')
+  })
+
+  it('converts SSH format', () => {
+    expect(formatGitOriginUrl('git@github.com:org/repo.git'))
+      .toBe('github.com/org/repo')
+  })
+
+  it('strips trailing .git', () => {
+    expect(formatGitOriginUrl('https://github.com/org/repo.git'))
+      .toBe('github.com/org/repo')
+  })
+
+  it('handles URL without .git suffix', () => {
+    expect(formatGitOriginUrl('https://github.com/org/repo'))
+      .toBe('github.com/org/repo')
+  })
+
+  it('strips trailing slash', () => {
+    expect(formatGitOriginUrl('https://github.com/org/repo/'))
+      .toBe('github.com/org/repo')
+  })
+
+  it('returns empty string for empty input', () => {
+    expect(formatGitOriginUrl('')).toBe('')
+  })
+
+  it('handles SSH with nested path', () => {
+    expect(formatGitOriginUrl('git@gitlab.com:group/subgroup/repo.git'))
+      .toBe('gitlab.com/group/subgroup/repo')
   })
 })

--- a/frontend/src/components/workspace/branchKeys.ts
+++ b/frontend/src/components/workspace/branchKeys.ts
@@ -20,6 +20,7 @@
 
 import type { RepoGitStore, RepoGitView } from '~/stores/repoGit'
 import type { Tab } from '~/stores/tab.types'
+import { basename } from '~/lib/paths'
 import { repoGitView } from '~/stores/repoGit'
 
 const KEY_SEP = '\x00'
@@ -117,6 +118,71 @@ export function isLocalRepoKey(key: string): boolean {
  */
 export function repoKeyTooltip(key: string): string {
   return isLocalRepoKey(key) ? key.slice(LOCAL_PREFIX.length) : key
+}
+
+const SSH_ORIGIN_RE = /^git@([^:]+):(.+)$/
+const PROTOCOL_PREFIX_RE = /^https?:\/\//
+const TRAILING_DOT_GIT_RE = /\.git$/
+const TRAILING_SLASH_RE = /\/$/
+
+/**
+ * An origin URL as a person reads it: `git@github.com:org/repo.git` becomes
+ * `github.com/org/repo`.
+ *
+ * Display only. The KEY is always the raw origin URL, so two spellings of one
+ * remote stay two repos rather than merging under a prettified name.
+ */
+export function formatGitOriginUrl(url: string): string {
+  if (!url)
+    return ''
+  let result = url
+  // Convert SSH format: git@github.com:org/repo -> github.com/org/repo
+  const sshMatch = result.match(SSH_ORIGIN_RE)
+  if (sshMatch)
+    result = `${sshMatch[1]}/${sshMatch[2]}`
+  // Strip protocols
+  result = result.replace(PROTOCOL_PREFIX_RE, '')
+  // Strip trailing .git
+  result = result.replace(TRAILING_DOT_GIT_RE, '')
+  // Strip trailing slash
+  result = result.replace(TRAILING_SLASH_RE, '')
+  return result
+}
+
+/**
+ * The grouping key and the display label for a tab's repository. Order of
+ * precedence:
+ *   1. gitOriginUrl -- a remote we can format nicely.
+ *   2. gitToplevel -- an origin-less local repo; the toplevel path makes
+ *      distinct repos distinct.
+ * A tab that has neither answers null, and its caller buckets it as ungrouped.
+ *
+ * It lives HERE, beside `branchKey` and `repoKeyForLocal`, because it is the
+ * repo half of the same composite-key rule: the sidebar tree groups by it, and
+ * the section header menu lists the repos a section works on by it. Two copies
+ * would let those two disagree about which checkouts are one repository.
+ *
+ * NOT the same `repoKey` as `~/stores/repoGit`, which keys the git store by
+ * `(workerId, gitToplevel)`. This one keys by REPO IDENTITY, so two clones of
+ * one origin on two workers share it.
+ */
+export function repoKeyAndLabel(
+  tab: Pick<Tab, 'workerId' | 'gitToplevel' | 'workingDir'>,
+  store: RepoGitStore,
+  git: RepoGitView = repoGitView(tab, store),
+): { key: string, label: string } | null {
+  if (git.originUrl)
+    return { key: git.originUrl, label: formatGitOriginUrl(git.originUrl) }
+  // Through the shared helper, so the group key and the branch bucket resolve
+  // the toplevel the same way. A second copy of the chain here is what let a
+  // stale row value override the worker's "not a git repository" answer. The
+  // view resolved once at the top carries through.
+  const toplevel = tabGitToplevelForKey(tab, store, git)
+  if (toplevel) {
+    const label = basename(toplevel) || toplevel
+    return { key: repoKeyForLocal(toplevel), label }
+  }
+  return null
 }
 
 /** Composite key for the per-row collapse state (repo + branch). */

--- a/frontend/src/components/workspace/branchKeys.ts
+++ b/frontend/src/components/workspace/branchKeys.ts
@@ -45,20 +45,6 @@ export function branchKey(branchName: string | null, workerId: string, gitToplev
 }
 
 /**
- * The branch group a tab belongs to.
- *
- * Every surface that answers "which tabs are on this branch" must use this one
- * function: the sidebar groups its tree by it, and the composer's branch chip
- * collects the tab list it hands to the delete-branch dialog by it. A second
- * membership test would let the dialog report a different set of affected tabs
- * than the tree shows.
- *
- * The parameter is a `Pick` of the real tab, not a structural shape with three
- * optional fields. Every field being optional made a `BranchGroup` -- which
- * carries `branchName`, not `gitBranch` -- a valid argument that silently
- * returned the "(no branch)" key, which is exactly the drift above.
- */
-/**
  * Repo toplevel for structural keys (branch buckets, delete-branch tab sets)
  * and for the sidebar's repository grouping. The ONE place that answers "which
  * repository is this tab in", so a caller cannot re-add the row fallback below.
@@ -93,6 +79,20 @@ export function tabGitToplevelForKey(
   return git.toplevel ?? ''
 }
 
+/**
+ * The branch group a tab belongs to.
+ *
+ * Every surface that answers "which tabs are on this branch" must use this one
+ * function: the sidebar groups its tree by it, and the composer's branch chip
+ * collects the tab list it hands to the delete-branch dialog by it. A second
+ * membership test would let the dialog report a different set of affected tabs
+ * than the tree shows.
+ *
+ * The parameter is a `Pick` of the real tab, not a structural shape with three
+ * optional fields. Every field being optional made a `BranchGroup` -- which
+ * carries `branchName`, not `gitBranch` -- a valid argument that silently
+ * returned the "(no branch)" key, which is exactly the drift above.
+ */
 export function tabBranchKey(
   tab: Pick<Tab, 'workerId' | 'gitToplevel' | 'workingDir'>,
   store: RepoGitStore,
@@ -185,7 +185,17 @@ export function repoKeyAndLabel(
   return null
 }
 
+/**
+ * Join `parts` into one key with the separator this module owns.
+ *
+ * Exported so a caller that needs a composite of its own does not concatenate a
+ * control byte inline, which is the rule this module's own doc states.
+ */
+export function compositeKey(...parts: string[]): string {
+  return parts.join(KEY_SEP)
+}
+
 /** Composite key for the per-row collapse state (repo + branch). */
 export function collapseKeyForBranch(repoKey: string, branchKey: string): string {
-  return `${repoKey}${KEY_SEP}${branchKey}`
+  return compositeKey(repoKey, branchKey)
 }

--- a/frontend/src/components/workspace/expandedWorkspaces.test.ts
+++ b/frontend/src/components/workspace/expandedWorkspaces.test.ts
@@ -1,0 +1,131 @@
+import { createRoot } from 'solid-js'
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  KEY_EXPANDED_WORKSPACES,
+  sessionStorageClearForTests,
+  sessionStorageGet,
+  sessionStorageSet,
+  setStorageAccount,
+} from '~/lib/browserStorage'
+import {
+  isWorkspaceExpanded,
+  resetExpandedWorkspacesForTests,
+  setWorkspacesExpanded,
+  toggleWorkspaceExpanded,
+} from './expandedWorkspaces'
+
+/**
+ * The regression this module exists for: the expanded set is ONE document, and
+ * several components read it at once.
+ *
+ * Every test that matters here has two readers. Comparing what a single reader
+ * writes against what it reads back proves nothing -- the broken per-instance
+ * version passed that, because each instance seeded from the same stored value
+ * and only diverged after the first toggle.
+ */
+
+/** The stored set, as a sorted array so the assertions do not depend on order. */
+function storedIds(): string[] {
+  return [...(sessionStorageGet<string[]>(KEY_EXPANDED_WORKSPACES) ?? [])].sort()
+}
+
+/**
+ * A reader, as a component is: it reads through the module's accessor inside
+ * its own reactive root, and it can toggle.
+ */
+function reader() {
+  return createRoot(dispose => ({
+    dispose,
+    sees: (id: string) => isWorkspaceExpanded(id),
+    toggle: (id: string) => toggleWorkspaceExpanded(id),
+  }))
+}
+
+describe('expandedWorkspaces', () => {
+  beforeEach(() => {
+    sessionStorageClearForTests()
+    setStorageAccount('u-1')
+    resetExpandedWorkspacesForTests()
+  })
+
+  it('shows one reader the row a SECOND reader expanded', () => {
+    const a = reader()
+    const b = reader()
+    a.toggle('ws-1')
+    expect(b.sees('ws-1')).toBe(true)
+    a.dispose()
+    b.dispose()
+  })
+
+  it('keeps each reader expansions when the other toggles', () => {
+    const a = reader()
+    const b = reader()
+    a.toggle('ws-a')
+    b.toggle('ws-b')
+    expect(a.sees('ws-a')).toBe(true)
+    expect(a.sees('ws-b')).toBe(true)
+    expect(b.sees('ws-a')).toBe(true)
+    expect(storedIds()).toEqual(['ws-a', 'ws-b'])
+    a.dispose()
+    b.dispose()
+  })
+
+  it('persists both readers rows rather than the last writer alone', () => {
+    const a = reader()
+    const b = reader()
+    a.toggle('ws-a')
+    b.toggle('ws-b')
+    a.toggle('ws-c')
+    expect(storedIds()).toEqual(['ws-a', 'ws-b', 'ws-c'])
+    a.dispose()
+    b.dispose()
+  })
+
+  it('restores the stored set on the first access', () => {
+    sessionStorageSet(KEY_EXPANDED_WORKSPACES, ['ws-x', 'ws-y'])
+    resetExpandedWorkspacesForTests()
+    expect(isWorkspaceExpanded('ws-x')).toBe(true)
+    expect(isWorkspaceExpanded('ws-y')).toBe(true)
+    expect(isWorkspaceExpanded('ws-z')).toBe(false)
+  })
+
+  it('collapses a row back off', () => {
+    toggleWorkspaceExpanded('ws-1')
+    toggleWorkspaceExpanded('ws-1')
+    expect(isWorkspaceExpanded('ws-1')).toBe(false)
+    expect(storedIds()).toEqual([])
+  })
+
+  describe('setWorkspacesExpanded', () => {
+    it('collapses only the ids it is given', () => {
+      toggleWorkspaceExpanded('mine-1')
+      toggleWorkspaceExpanded('mine-2')
+      toggleWorkspaceExpanded('theirs')
+      setWorkspacesExpanded(['mine-1', 'mine-2'], false)
+      expect(isWorkspaceExpanded('mine-1')).toBe(false)
+      expect(isWorkspaceExpanded('mine-2')).toBe(false)
+      expect(isWorkspaceExpanded('theirs')).toBe(true)
+    })
+
+    it('expands every id it is given without disturbing the rest', () => {
+      toggleWorkspaceExpanded('theirs')
+      setWorkspacesExpanded(['mine-1', 'mine-2'], true)
+      expect(storedIds()).toEqual(['mine-1', 'mine-2', 'theirs'])
+    })
+
+    it('accepts an empty list', () => {
+      toggleWorkspaceExpanded('ws-1')
+      setWorkspacesExpanded([], false)
+      expect(storedIds()).toEqual(['ws-1'])
+    })
+
+    it('writes nothing when every id already holds the requested state', () => {
+      toggleWorkspaceExpanded('ws-1')
+      sessionStorageSet(KEY_EXPANDED_WORKSPACES, ['sentinel'])
+      setWorkspacesExpanded(['ws-1'], true)
+      // A no-op keeps the signal identity, so the persist effect never re-runs
+      // and the sentinel survives.
+      expect(storedIds()).toEqual(['sentinel'])
+    })
+  })
+})

--- a/frontend/src/components/workspace/expandedWorkspaces.test.ts
+++ b/frontend/src/components/workspace/expandedWorkspaces.test.ts
@@ -128,4 +128,43 @@ describe('expandedWorkspaces', () => {
       expect(storedIds()).toEqual(['sentinel'])
     })
   })
+
+  // The account switch is the whole reason this module carries a seed latch,
+  // and nothing exercised it. A subscribed reader must SEE the change: the
+  // reset writes the module's `EMPTY` constant, which is referentially equal to
+  // the un-seeded value, so Solid's `===` equality drops that write -- a reader
+  // that only re-read on notification stayed on the previous account's set.
+  it('re-reads under the new account when the namespace moves', () => {
+    // Both accounts' documents are written first, so the switch has something
+    // to find. The key is account-scoped, so each write lands under whichever
+    // account is current.
+    setStorageAccount('u-2')
+    sessionStorageSet(KEY_EXPANDED_WORKSPACES, ['ws-owned-by-2'])
+    setStorageAccount('u-1')
+    sessionStorageSet(KEY_EXPANDED_WORKSPACES, ['ws-owned-by-1'])
+    resetExpandedWorkspacesForTests()
+
+    const r = reader()
+    expect(r.sees('ws-owned-by-1')).toBe(true)
+
+    setStorageAccount('u-2')
+
+    expect(r.sees('ws-owned-by-1')).toBe(false)
+    expect(r.sees('ws-owned-by-2')).toBe(true)
+    r.dispose()
+  })
+
+  // The mirror must not carry one account's rows into another's sidebar, even
+  // when the second account has nothing stored.
+  it('does not leak one account\'s expanded rows into an account with none', () => {
+    setStorageAccount('u-1')
+    const r = reader()
+    r.toggle('ws-1')
+    expect(r.sees('ws-1')).toBe(true)
+
+    setStorageAccount('u-2')
+
+    expect(r.sees('ws-1')).toBe(false)
+    r.dispose()
+  })
 })

--- a/frontend/src/components/workspace/expandedWorkspaces.ts
+++ b/frontend/src/components/workspace/expandedWorkspaces.ts
@@ -1,11 +1,5 @@
-import { createEffect, createRoot, createSignal } from 'solid-js'
-import {
-  hasStorageAccount,
-  KEY_EXPANDED_WORKSPACES,
-  onStorageAccountChange,
-  sessionStorageGet,
-  sessionStorageSet,
-} from '~/lib/browserStorage'
+import { createAccountScopedSignal } from '~/lib/accountScopedSignal'
+import { KEY_EXPANDED_WORKSPACES, sessionStorageGet, sessionStorageSet } from '~/lib/browserStorage'
 
 /**
  * Which workspace rows have their tab tree expanded, for the WHOLE app.
@@ -13,9 +7,9 @@ import {
  * One module-scope signal, because the set is one document under one key and
  * several components read it at once. `sections/defaults.go` seeds In progress
  * AND Archived into the left sidebar, and `CollapsibleSidebar` calls
- * `content()` for every expandable section -- so one sidebar already mounts two
- * `WorkspaceSectionContent` instances. The app then mounts the sidebar twice
- * (the desktop pane and the mobile overlay), which doubles it again.
+ * `content()` for every expandable section -- so one sidebar mounts one
+ * `WorkspaceSectionContent` per workspace section, and a custom workspace
+ * section can now live on the right sidebar as well.
  *
  * Each instance used to hold its own `createSignal(readExpandedWorkspaceIds())`
  * and write the WHOLE set back with no merge, so expanding a row in one
@@ -23,76 +17,28 @@ import {
  * is no divergence at mount -- every instance reads the same value -- so the
  * bug only appears after the first toggle.
  *
- * The mirror belongs to the account it was read for, so it re-reads when the
- * namespace moves.
+ * The lifecycle (lazy first read, quiet persist, re-read on an account switch)
+ * belongs to `~/lib/accountScopedSignal`, which `workspaceListState` shares.
  */
 
 const EMPTY: ReadonlySet<string> = new Set()
 
-/**
- * Whether sessionStorage was read for the CURRENT account yet.
- *
- * The read is lazy rather than done at import time: this module is imported
- * when the bundle loads, and `AuthContext` calls `setStorageAccount` only once
- * the identity resolves. An account-scoped read before that throws.
- *
- * Declared ahead of the `createRoot` below, not beside `ensureSeeded`: Solid
- * flushes the root's effects at the end of the `createRoot` call, so the
- * persist effect reads this binding while the module body is still running.
- */
-let seeded = false
-
-function readStoredIds(): ReadonlySet<string> {
-  const stored = sessionStorageGet<string[]>(KEY_EXPANDED_WORKSPACES)
-  return stored ? new Set(stored) : EMPTY
-}
-
-// `createRoot`, because module scope has no owner: the effect below would
-// otherwise be created outside any reactive root, never dispose, and log
-// Solid's "computations created outside a `createRoot`" warning. The root is
-// never disposed on purpose -- it lives as long as the module does.
-const { expandedIds, setExpandedIds } = createRoot(() => {
-  const [ids, setIds] = createSignal<ReadonlySet<string>>(EMPTY)
-
-  createEffect(() => {
-    const current = ids()
-    // Skip until the first read landed. Before an account is set, a write
-    // throws (an account-scoped key has no namespace to resolve under), and
-    // writing the empty placeholder would erase the stored set anyway.
-    if (!seeded)
-      return
-    sessionStorageSet(KEY_EXPANDED_WORKSPACES, [...current])
-  })
-
-  return { expandedIds: ids, setExpandedIds: setIds }
-})
-
-function ensureSeeded(): void {
-  if (seeded || !hasStorageAccount())
-    return
-  seeded = true
-  setExpandedIds(readStoredIds())
-}
-
-// The namespace moved, so the mirror belongs to the account that left. Drop it
-// and let the next access re-read under the new one. `setStorageAccount` calls
-// this synchronously, before the identity signal notifies, so no render can
-// observe the old set under the new account.
-onStorageAccountChange(() => {
-  seeded = false
-  setExpandedIds(EMPTY)
+const expanded = createAccountScopedSignal<ReadonlySet<string>>(EMPTY, {
+  read: () => {
+    const stored = sessionStorageGet<string[]>(KEY_EXPANDED_WORKSPACES)
+    return stored ? new Set(stored) : EMPTY
+  },
+  write: current => sessionStorageSet(KEY_EXPANDED_WORKSPACES, [...current]),
 })
 
 /** Whether `workspaceId`'s tab tree is expanded. Reactive. */
 export function isWorkspaceExpanded(workspaceId: string): boolean {
-  ensureSeeded()
-  return expandedIds().has(workspaceId)
+  return expanded.get().has(workspaceId)
 }
 
 /** Flip `workspaceId` between expanded and collapsed. */
 export function toggleWorkspaceExpanded(workspaceId: string): void {
-  ensureSeeded()
-  setExpandedIds((prev) => {
+  expanded.set((prev) => {
     const next = new Set(prev)
     if (next.has(workspaceId))
       next.delete(workspaceId)
@@ -109,16 +55,15 @@ export function toggleWorkspaceExpanded(workspaceId: string): void {
  * "Collapse all" / "Expand all" and the other sections' rows are not its to
  * touch. That is exactly the merge the per-instance signals could not do.
  */
-export function setWorkspacesExpanded(workspaceIds: readonly string[], expanded: boolean): void {
-  ensureSeeded()
-  setExpandedIds((prev) => {
+export function setWorkspacesExpanded(workspaceIds: readonly string[], expandedState: boolean): void {
+  expanded.set((prev) => {
     const next = new Set(prev)
     let changed = false
     for (const id of workspaceIds) {
-      if (expanded === next.has(id))
+      if (expandedState === next.has(id))
         continue
       changed = true
-      if (expanded)
+      if (expandedState)
         next.add(id)
       else
         next.delete(id)
@@ -136,6 +81,5 @@ export function setWorkspacesExpanded(workspaceIds: readonly string[], expanded:
  * this module already read it, needs the next access to read again.
  */
 export function resetExpandedWorkspacesForTests(): void {
-  seeded = false
-  setExpandedIds(EMPTY)
+  expanded.reset()
 }

--- a/frontend/src/components/workspace/expandedWorkspaces.ts
+++ b/frontend/src/components/workspace/expandedWorkspaces.ts
@@ -1,7 +1,141 @@
-import { KEY_EXPANDED_WORKSPACES, sessionStorageGet } from '~/lib/browserStorage'
+import { createEffect, createRoot, createSignal } from 'solid-js'
+import {
+  hasStorageAccount,
+  KEY_EXPANDED_WORKSPACES,
+  onStorageAccountChange,
+  sessionStorageGet,
+  sessionStorageSet,
+} from '~/lib/browserStorage'
 
-/** Reads the persisted expanded-workspace IDs from sessionStorage. */
-export function readExpandedWorkspaceIds(): Set<string> {
+/**
+ * Which workspace rows have their tab tree expanded, for the WHOLE app.
+ *
+ * One module-scope signal, because the set is one document under one key and
+ * several components read it at once. `sections/defaults.go` seeds In progress
+ * AND Archived into the left sidebar, and `CollapsibleSidebar` calls
+ * `content()` for every expandable section -- so one sidebar already mounts two
+ * `WorkspaceSectionContent` instances. The app then mounts the sidebar twice
+ * (the desktop pane and the mobile overlay), which doubles it again.
+ *
+ * Each instance used to hold its own `createSignal(readExpandedWorkspaceIds())`
+ * and write the WHOLE set back with no merge, so expanding a row in one
+ * instance stored a set that omitted every row the others had expanded. There
+ * is no divergence at mount -- every instance reads the same value -- so the
+ * bug only appears after the first toggle.
+ *
+ * The mirror belongs to the account it was read for, so it re-reads when the
+ * namespace moves.
+ */
+
+const EMPTY: ReadonlySet<string> = new Set()
+
+/**
+ * Whether sessionStorage was read for the CURRENT account yet.
+ *
+ * The read is lazy rather than done at import time: this module is imported
+ * when the bundle loads, and `AuthContext` calls `setStorageAccount` only once
+ * the identity resolves. An account-scoped read before that throws.
+ *
+ * Declared ahead of the `createRoot` below, not beside `ensureSeeded`: Solid
+ * flushes the root's effects at the end of the `createRoot` call, so the
+ * persist effect reads this binding while the module body is still running.
+ */
+let seeded = false
+
+function readStoredIds(): ReadonlySet<string> {
   const stored = sessionStorageGet<string[]>(KEY_EXPANDED_WORKSPACES)
-  return stored ? new Set(stored) : new Set()
+  return stored ? new Set(stored) : EMPTY
+}
+
+// `createRoot`, because module scope has no owner: the effect below would
+// otherwise be created outside any reactive root, never dispose, and log
+// Solid's "computations created outside a `createRoot`" warning. The root is
+// never disposed on purpose -- it lives as long as the module does.
+const { expandedIds, setExpandedIds } = createRoot(() => {
+  const [ids, setIds] = createSignal<ReadonlySet<string>>(EMPTY)
+
+  createEffect(() => {
+    const current = ids()
+    // Skip until the first read landed. Before an account is set, a write
+    // throws (an account-scoped key has no namespace to resolve under), and
+    // writing the empty placeholder would erase the stored set anyway.
+    if (!seeded)
+      return
+    sessionStorageSet(KEY_EXPANDED_WORKSPACES, [...current])
+  })
+
+  return { expandedIds: ids, setExpandedIds: setIds }
+})
+
+function ensureSeeded(): void {
+  if (seeded || !hasStorageAccount())
+    return
+  seeded = true
+  setExpandedIds(readStoredIds())
+}
+
+// The namespace moved, so the mirror belongs to the account that left. Drop it
+// and let the next access re-read under the new one. `setStorageAccount` calls
+// this synchronously, before the identity signal notifies, so no render can
+// observe the old set under the new account.
+onStorageAccountChange(() => {
+  seeded = false
+  setExpandedIds(EMPTY)
+})
+
+/** Whether `workspaceId`'s tab tree is expanded. Reactive. */
+export function isWorkspaceExpanded(workspaceId: string): boolean {
+  ensureSeeded()
+  return expandedIds().has(workspaceId)
+}
+
+/** Flip `workspaceId` between expanded and collapsed. */
+export function toggleWorkspaceExpanded(workspaceId: string): void {
+  ensureSeeded()
+  setExpandedIds((prev) => {
+    const next = new Set(prev)
+    if (next.has(workspaceId))
+      next.delete(workspaceId)
+    else
+      next.add(workspaceId)
+    return next
+  })
+}
+
+/**
+ * Expand or collapse every id in `workspaceIds`, leaving every other id alone.
+ *
+ * A SET operation rather than a replace, because the caller is one section's
+ * "Collapse all" / "Expand all" and the other sections' rows are not its to
+ * touch. That is exactly the merge the per-instance signals could not do.
+ */
+export function setWorkspacesExpanded(workspaceIds: readonly string[], expanded: boolean): void {
+  ensureSeeded()
+  setExpandedIds((prev) => {
+    const next = new Set(prev)
+    let changed = false
+    for (const id of workspaceIds) {
+      if (expanded === next.has(id))
+        continue
+      changed = true
+      if (expanded)
+        next.add(id)
+      else
+        next.delete(id)
+    }
+    // Identity-stable on a no-op, so a "Collapse all" on an already-collapsed
+    // section notifies nothing and writes nothing.
+    return changed ? next : prev
+  })
+}
+
+/**
+ * Drop the in-memory mirror. FOR TESTS ONLY.
+ *
+ * A suite that swaps the storage account, or that seeds sessionStorage after
+ * this module already read it, needs the next access to read again.
+ */
+export function resetExpandedWorkspacesForTests(): void {
+  seeded = false
+  setExpandedIds(EMPTY)
 }

--- a/frontend/src/components/workspace/repoStartPoints.test.ts
+++ b/frontend/src/components/workspace/repoStartPoints.test.ts
@@ -233,13 +233,13 @@ describe('listRepoStartPoints', () => {
   })
 
   describe('labels', () => {
-    it('names an origin-backed repository the way the tree does', () => {
+    it('labels an origin-backed repository the way the tree does', () => {
       const store = storeWith([{ gitToplevel: '/x', originUrl: 'git@github.com:org/leapmux.git' }])
       const out = listRepoStartPoints([tab({ gitToplevel: '/x' })], store)
       expect(out[0].label).toBe('github.com/org/leapmux')
     })
 
-    it('names an origin-less repository by its directory', () => {
+    it('labels an origin-less repository by its directory', () => {
       const store = storeWith([{ gitToplevel: '/home/me/alpha' }])
       const out = listRepoStartPoints([tab({ gitToplevel: '/home/me/alpha' })], store)
       expect(out[0].label).toBe('alpha')
@@ -256,7 +256,7 @@ describe('listRepoStartPoints', () => {
       expect(out.map(e => e.label).toSorted()).toEqual(['a', 'b'])
     })
 
-    it('names the worker once the list spans more than one', () => {
+    it('labels the worker once the list spans more than one', () => {
       const store = storeWith([
         { workerId: 'w1', gitToplevel: '/leapmux' },
         { workerId: 'w2', gitToplevel: '/api' },
@@ -305,7 +305,11 @@ describe('listRepoStartPoints', () => {
       expect(out.map(e => e.label).toSorted()).toEqual(['alpha', 'beta'])
     })
 
-    it('gives every entry a distinct key', () => {
+    // One repository at the same path on two machines is two places to start,
+    // so the (worker, toplevel) pair -- the thing the dialog is opened with --
+    // must differ. The entries used to carry a separate `key` field for this,
+    // which nothing outside its own test ever read.
+    it('keeps one path on two workers as two distinct start points', () => {
       const store = storeWith([
         { workerId: 'w1', gitToplevel: '/repo' },
         { workerId: 'w2', gitToplevel: '/repo' },
@@ -314,7 +318,11 @@ describe('listRepoStartPoints', () => {
         tab({ workerId: 'w1', gitToplevel: '/repo' }),
         tab({ workerId: 'w2', gitToplevel: '/repo' }),
       ], store, { workerInfoFn })
-      expect(new Set(out.map(e => e.key)).size).toBe(2)
+
+      const pairs = out.map(e => `${e.startPoint.workerId}@${e.startPoint.gitToplevel}`)
+      expect(new Set(pairs).size).toBe(2)
+      // And the labels disambiguate them, or the two rows read the same.
+      expect(new Set(out.map(e => e.label)).size).toBe(2)
     })
   })
 })

--- a/frontend/src/components/workspace/repoStartPoints.test.ts
+++ b/frontend/src/components/workspace/repoStartPoints.test.ts
@@ -1,0 +1,320 @@
+import type { WorkerInfo } from '~/lib/workerInfoCache'
+import type { Tab } from '~/stores/tab.types'
+import { describe, expect, it } from 'vitest'
+import { TabType } from '~/generated/proto/leapmux/v1/workspace_pb'
+import { repoKey } from '~/stores/repoGit'
+import { createRepoGitStore } from '~/stores/repoGit.store'
+import { listRepoStartPoints } from './repoStartPoints'
+
+interface RepoSeed {
+  workerId?: string
+  gitToplevel: string
+  branch?: string
+  originUrl?: string
+  isWorktree?: boolean
+}
+
+function storeWith(seeds: readonly RepoSeed[]) {
+  const store = createRepoGitStore()
+  for (const seed of seeds) {
+    const workerId = seed.workerId ?? 'w1'
+    store.upsert(repoKey(workerId, seed.gitToplevel), {
+      workerId,
+      toplevel: seed.gitToplevel,
+      branch: seed.branch ?? '',
+      originUrl: seed.originUrl ?? '',
+      isWorktree: seed.isWorktree ?? false,
+    })
+  }
+  return store
+}
+
+let nextTabId = 0
+function tab(fields: Partial<Tab> = {}): Tab {
+  nextTabId += 1
+  return {
+    id: `t${nextTabId}`,
+    workspaceId: 'ws-1',
+    type: TabType.AGENT,
+    workerId: 'w1',
+    ...fields,
+  } as Tab
+}
+
+const WORKERS: Record<string, WorkerInfo> = {
+  w1: { name: 'mini', os: 'darwin', arch: 'arm64', homeDir: '/Users/me', version: '', commitHash: '', buildTime: '', updatedAt: 0 },
+  w2: { name: 'devbox', os: 'linux', arch: 'amd64', homeDir: '/home/me', version: '', commitHash: '', buildTime: '', updatedAt: 0 },
+}
+const workerInfoFn = (id: string): WorkerInfo | null => WORKERS[id] ?? null
+
+describe('listRepoStartPoints', () => {
+  it('returns nothing for no tabs', () => {
+    expect(listRepoStartPoints([], createRepoGitStore())).toEqual([])
+  })
+
+  it('collapses every tab of one checkout into a single entry', () => {
+    const store = storeWith([{ gitToplevel: '/repo', branch: 'main' }])
+    const tabs = [
+      tab({ gitToplevel: '/repo' }),
+      tab({ gitToplevel: '/repo' }),
+      tab({ gitToplevel: '/repo' }),
+    ]
+    const out = listRepoStartPoints(tabs, store)
+    expect(out).toHaveLength(1)
+    expect(out[0].startPoint).toEqual({
+      kind: 'repo',
+      workerId: 'w1',
+      gitToplevel: '/repo',
+      isWorktree: false,
+      currentBranch: 'main',
+    })
+  })
+
+  it('drops a tab with no repository at all', () => {
+    const store = createRepoGitStore()
+    expect(listRepoStartPoints([tab({ gitToplevel: undefined })], store)).toEqual([])
+  })
+
+  it('drops a tab with no worker', () => {
+    const store = storeWith([{ gitToplevel: '/repo' }])
+    expect(listRepoStartPoints([tab({ workerId: undefined, gitToplevel: '/repo' })], store)).toEqual([])
+  })
+
+  describe('worktrees', () => {
+    it('drops a worktree whose repository also has a normal checkout here', () => {
+      // The dialog can create a worktree from the main checkout, so listing
+      // both is one place to start too many.
+      const store = storeWith([
+        { gitToplevel: '/repo', originUrl: 'https://x/o/r.git' },
+        { gitToplevel: '/wt/feature', originUrl: 'https://x/o/r.git', isWorktree: true },
+      ])
+      const out = listRepoStartPoints([
+        tab({ gitToplevel: '/repo' }),
+        tab({ gitToplevel: '/wt/feature' }),
+      ], store)
+      expect(out.map(e => e.startPoint.gitToplevel)).toEqual(['/repo'])
+    })
+
+    it('keeps a worktree when its repository has no normal checkout here', () => {
+      // The only place anyone knows.
+      const store = storeWith([
+        { gitToplevel: '/wt/feature', originUrl: 'https://x/o/r.git', isWorktree: true },
+      ])
+      const out = listRepoStartPoints([tab({ gitToplevel: '/wt/feature' })], store)
+      expect(out).toHaveLength(1)
+      expect(out[0].startPoint.isWorktree).toBe(true)
+    })
+
+    it('keeps a worktree whose main checkout is on a DIFFERENT worker', () => {
+      // One machine's main checkout says nothing about another machine's
+      // worktrees, and neither can substitute for the other.
+      const store = storeWith([
+        { workerId: 'w1', gitToplevel: '/repo', originUrl: 'https://x/o/r.git' },
+        { workerId: 'w2', gitToplevel: '/wt/feature', originUrl: 'https://x/o/r.git', isWorktree: true },
+      ])
+      const out = listRepoStartPoints([
+        tab({ workerId: 'w1', gitToplevel: '/repo' }),
+        tab({ workerId: 'w2', gitToplevel: '/wt/feature' }),
+      ], store)
+      expect(out).toHaveLength(2)
+    })
+  })
+
+  it('keeps two clones of one origin as two entries', () => {
+    // Same repository identity, two working copies. Both are real places to
+    // start, and the dialog cannot substitute one for the other.
+    const store = storeWith([
+      { gitToplevel: '/a/leapmux', originUrl: 'https://x/o/r.git' },
+      { gitToplevel: '/b/leapmux', originUrl: 'https://x/o/r.git' },
+    ])
+    const out = listRepoStartPoints([
+      tab({ gitToplevel: '/a/leapmux' }),
+      tab({ gitToplevel: '/b/leapmux' }),
+    ], store)
+    expect(out.map(e => e.startPoint.gitToplevel).toSorted()).toEqual(['/a/leapmux', '/b/leapmux'])
+  })
+
+  describe('order', () => {
+    it('puts the most recently activated checkout first', () => {
+      const store = storeWith([{ gitToplevel: '/a' }, { gitToplevel: '/b' }, { gitToplevel: '/c' }])
+      const out = listRepoStartPoints([
+        tab({ gitToplevel: '/a', mru: 3 }),
+        tab({ gitToplevel: '/b', mru: 9 }),
+        tab({ gitToplevel: '/c', mru: 5 }),
+      ], store)
+      expect(out.map(e => e.startPoint.gitToplevel)).toEqual(['/b', '/c', '/a'])
+    })
+
+    it('takes a checkout recency from its most recent tab', () => {
+      const store = storeWith([{ gitToplevel: '/a' }, { gitToplevel: '/b' }])
+      const out = listRepoStartPoints([
+        tab({ gitToplevel: '/a', mru: 1 }),
+        tab({ gitToplevel: '/a', mru: 20 }),
+        tab({ gitToplevel: '/b', mru: 10 }),
+      ], store)
+      expect(out.map(e => e.startPoint.gitToplevel)).toEqual(['/a', '/b'])
+    })
+
+    it('breaks a no-activation tie by creation, newest first', () => {
+      // `mru` is a session counter, so a workspace nobody touched this session
+      // carries none at all.
+      const store = storeWith([{ gitToplevel: '/a' }, { gitToplevel: '/b' }])
+      const out = listRepoStartPoints([
+        tab({ gitToplevel: '/a', createdAt: '2026-01-01T00:00:00Z' }),
+        tab({ gitToplevel: '/b', createdAt: '2026-02-01T00:00:00Z' }),
+      ], store)
+      expect(out.map(e => e.startPoint.gitToplevel)).toEqual(['/b', '/a'])
+    })
+
+    it('puts an activated checkout ahead of a never-activated one', () => {
+      const store = storeWith([{ gitToplevel: '/a' }, { gitToplevel: '/b' }])
+      const out = listRepoStartPoints([
+        tab({ gitToplevel: '/a', createdAt: '2099-01-01T00:00:00Z' }),
+        tab({ gitToplevel: '/b', mru: 1 }),
+      ], store)
+      expect(out.map(e => e.startPoint.gitToplevel)).toEqual(['/b', '/a'])
+    })
+
+    it('falls back to the label, so the order is total and stable', () => {
+      const store = storeWith([{ gitToplevel: '/zeta' }, { gitToplevel: '/alpha' }])
+      const out = listRepoStartPoints([
+        tab({ gitToplevel: '/zeta' }),
+        tab({ gitToplevel: '/alpha' }),
+      ], store)
+      expect(out.map(e => e.label)).toEqual(['alpha', 'zeta'])
+    })
+  })
+
+  it('keeps at most `limit` entries, most recent first', () => {
+    const store = storeWith([{ gitToplevel: '/a' }, { gitToplevel: '/b' }, { gitToplevel: '/c' }])
+    const out = listRepoStartPoints([
+      tab({ gitToplevel: '/a', mru: 1 }),
+      tab({ gitToplevel: '/b', mru: 2 }),
+      tab({ gitToplevel: '/c', mru: 3 }),
+    ], store, { limit: 2 })
+    expect(out.map(e => e.startPoint.gitToplevel)).toEqual(['/c', '/b'])
+  })
+
+  describe('offline workers', () => {
+    it('omits a repository whose worker is offline', () => {
+      // The row opens a dialog that cannot probe the path, list its branches or
+      // start an agent -- a trap rather than a shortcut.
+      const store = storeWith([
+        { workerId: 'w1', gitToplevel: '/on' },
+        { workerId: 'w2', gitToplevel: '/off' },
+      ])
+      const out = listRepoStartPoints([
+        tab({ workerId: 'w1', gitToplevel: '/on' }),
+        tab({ workerId: 'w2', gitToplevel: '/off' }),
+      ], store, { isWorkerOnline: id => id === 'w1' })
+      expect(out.map(e => e.startPoint.gitToplevel)).toEqual(['/on'])
+    })
+
+    it('lists every repository when no liveness predicate is supplied', () => {
+      const store = storeWith([{ workerId: 'w2', gitToplevel: '/off' }])
+      const out = listRepoStartPoints([tab({ workerId: 'w2', gitToplevel: '/off' })], store)
+      expect(out).toHaveLength(1)
+    })
+
+    it('does not let an offline worker keep its repository alive as a worktree anchor', () => {
+      // The main checkout is filtered out BEFORE the worktree collapse, so the
+      // reachable worktree survives rather than being dropped in favour of a
+      // checkout nobody can reach.
+      const store = storeWith([
+        { workerId: 'w2', gitToplevel: '/repo', originUrl: 'https://x/o/r.git' },
+        { workerId: 'w2', gitToplevel: '/wt', originUrl: 'https://x/o/r.git', isWorktree: true },
+      ])
+      const out = listRepoStartPoints([
+        tab({ workerId: 'w2', gitToplevel: '/repo' }),
+        tab({ workerId: 'w2', gitToplevel: '/wt' }),
+      ], store, { isWorkerOnline: () => true })
+      expect(out.map(e => e.startPoint.gitToplevel)).toEqual(['/repo'])
+    })
+  })
+
+  describe('labels', () => {
+    it('names an origin-backed repository the way the tree does', () => {
+      const store = storeWith([{ gitToplevel: '/x', originUrl: 'git@github.com:org/leapmux.git' }])
+      const out = listRepoStartPoints([tab({ gitToplevel: '/x' })], store)
+      expect(out[0].label).toBe('github.com/org/leapmux')
+    })
+
+    it('names an origin-less repository by its directory', () => {
+      const store = storeWith([{ gitToplevel: '/home/me/alpha' }])
+      const out = listRepoStartPoints([tab({ gitToplevel: '/home/me/alpha' })], store)
+      expect(out[0].label).toBe('alpha')
+    })
+
+    it('omits the worker while every entry is on one worker', () => {
+      // On a solo desktop every row would carry the same prefix, which says
+      // nothing and eats the width the repository name needs.
+      const store = storeWith([{ gitToplevel: '/a' }, { gitToplevel: '/b' }])
+      const out = listRepoStartPoints([
+        tab({ gitToplevel: '/a' }),
+        tab({ gitToplevel: '/b' }),
+      ], store, { workerInfoFn })
+      expect(out.map(e => e.label).toSorted()).toEqual(['a', 'b'])
+    })
+
+    it('names the worker once the list spans more than one', () => {
+      const store = storeWith([
+        { workerId: 'w1', gitToplevel: '/leapmux' },
+        { workerId: 'w2', gitToplevel: '/api' },
+      ])
+      const out = listRepoStartPoints([
+        tab({ workerId: 'w1', gitToplevel: '/leapmux' }),
+        tab({ workerId: 'w2', gitToplevel: '/api' }),
+      ], store, { workerInfoFn })
+      expect(out.map(e => e.label).toSorted()).toEqual(['devbox · api', 'mini · leapmux'])
+    })
+
+    it('falls back to the worker id when its system info has not arrived', () => {
+      const store = storeWith([
+        { workerId: 'w1', gitToplevel: '/a' },
+        { workerId: 'w9', gitToplevel: '/b' },
+      ])
+      const out = listRepoStartPoints([
+        tab({ workerId: 'w1', gitToplevel: '/a' }),
+        tab({ workerId: 'w9', gitToplevel: '/b' }),
+      ], store, { workerInfoFn })
+      expect(out.map(e => e.label).toSorted()).toEqual(['mini · a', 'w9 · b'])
+    })
+
+    it('appends a tilde-compressed path when two entries would read the same', () => {
+      const store = storeWith([
+        { gitToplevel: '/Users/me/a/leapmux' },
+        { gitToplevel: '/Users/me/b/leapmux' },
+      ])
+      const out = listRepoStartPoints([
+        tab({ gitToplevel: '/Users/me/a/leapmux' }),
+        tab({ gitToplevel: '/Users/me/b/leapmux' }),
+      ], store, { workerInfoFn })
+      expect(out.map(e => e.label).toSorted())
+        .toEqual(['leapmux (~/a/leapmux)', 'leapmux (~/b/leapmux)'])
+    })
+
+    it('leaves an unambiguous label alone', () => {
+      const store = storeWith([
+        { gitToplevel: '/Users/me/alpha' },
+        { gitToplevel: '/Users/me/beta' },
+      ])
+      const out = listRepoStartPoints([
+        tab({ gitToplevel: '/Users/me/alpha' }),
+        tab({ gitToplevel: '/Users/me/beta' }),
+      ], store, { workerInfoFn })
+      expect(out.map(e => e.label).toSorted()).toEqual(['alpha', 'beta'])
+    })
+
+    it('gives every entry a distinct key', () => {
+      const store = storeWith([
+        { workerId: 'w1', gitToplevel: '/repo' },
+        { workerId: 'w2', gitToplevel: '/repo' },
+      ])
+      const out = listRepoStartPoints([
+        tab({ workerId: 'w1', gitToplevel: '/repo' }),
+        tab({ workerId: 'w2', gitToplevel: '/repo' }),
+      ], store, { workerInfoFn })
+      expect(new Set(out.map(e => e.key)).size).toBe(2)
+    })
+  })
+})

--- a/frontend/src/components/workspace/repoStartPoints.ts
+++ b/frontend/src/components/workspace/repoStartPoints.ts
@@ -1,0 +1,222 @@
+import type { WorkspaceRepoStartPoint } from './workspaceStartPoint'
+import type { WorkerInfo } from '~/lib/workerInfoCache'
+import type { RepoGitStore } from '~/stores/repoGit'
+import type { Tab } from '~/stores/tab.types'
+import { tildifyForWorker } from '~/lib/workerPaths'
+import { repoGitView } from '~/stores/repoGit'
+import { repoKeyAndLabel, tabGitToplevelForKey } from './branchKeys'
+
+/**
+ * A repository a section already works on, ready to start a workspace in.
+ *
+ * The recency-ordered sibling of `sumDiffStatsFromTabs`: both answer a question
+ * about a tab list without building the full tab tree. `buildTree` allocates
+ * two collision passes, per-branch diff sums and a Map per repository, and it
+ * sorts remote-before-local then by label -- and a header menu wants the
+ * repositories the user touched most recently.
+ */
+export interface RepoStartPoint {
+  /** Stable identity for a keyed `<For>`: the (worker, toplevel) pair. */
+  key: string
+  /**
+   * What the row reads.
+   *
+   * `<repository>` normally, `<worker> · <repository>` once the list spans more
+   * than one worker, and either of those plus a tilde-compressed path once two
+   * entries would otherwise read identically. The same "add context only where
+   * it disambiguates" rule the branch rows follow.
+   */
+  label: string
+  /** Where a workspace started here begins. */
+  startPoint: WorkspaceRepoStartPoint
+}
+
+export interface ListRepoStartPointsOptions {
+  /** Worker display info, for the worker segment of a label and its home directory. */
+  workerInfoFn?: (id: string) => WorkerInfo | null
+  /**
+   * Whether a worker can be reached. A repository on an unreachable worker is
+   * OMITTED, because its row opens a dialog that cannot probe the path, cannot
+   * list its branches and cannot start an agent -- a trap rather than a
+   * shortcut. `isWorkerKnownOnline` is the intended argument: it fails open, so
+   * a fleet list that has not arrived hides nothing.
+   */
+  isWorkerOnline?: (workerId: string) => boolean
+  /** Keep at most this many entries, most recent first. */
+  limit?: number
+}
+
+/** One checkout: every tab that shares a (worker, toplevel) pair. */
+interface Checkout {
+  workerId: string
+  gitToplevel: string
+  /** Repository identity, so two checkouts of one repository can be compared. */
+  repoKey: string
+  repoLabel: string
+  isWorktree: boolean
+  currentBranch: string
+  /** The highest activation counter across the checkout's tabs, or -1 for none. */
+  mru: number
+  /** The newest `createdAt` across the checkout's tabs. */
+  createdAt: string
+}
+
+const KEY_SEP = '\x00'
+
+/**
+ * The repositories `tabs` are checked out in, most recently used first.
+ *
+ * The input is ONE SECTION's tabs, so a section's menu offers the repositories
+ * that section works on rather than every repository in the account.
+ *
+ * This is a SESSION view, not a durable registry. It reads `repoGitStore`,
+ * which is capped at 256 entries with LRU eviction and fills as tabs hydrate,
+ * so the answer means "the repositories this session has seen" and it grows
+ * over the life of the page.
+ *
+ * A linked worktree is dropped when its own repository also has a normal
+ * checkout here: the dialog can create a worktree from that checkout, so
+ * listing both is one place to start too many. A repository known ONLY through
+ * its worktrees keeps them, because they are the only places anyone knows.
+ */
+export function listRepoStartPoints(
+  tabs: readonly Tab[],
+  store: RepoGitStore,
+  opts: ListRepoStartPointsOptions = {},
+): RepoStartPoint[] {
+  const checkouts = new Map<string, Checkout>()
+
+  for (const tab of tabs) {
+    const workerId = tab.workerId
+    if (!workerId)
+      continue
+    // Resolved ONCE per tab and threaded into both helpers below. Each
+    // resolution may run the canonical-repo-key scan for a toplevel-less tab.
+    const git = repoGitView(tab, store)
+    const rk = repoKeyAndLabel(tab, store, git)
+    if (!rk)
+      continue
+    const gitToplevel = tabGitToplevelForKey(tab, store, git)
+    if (!gitToplevel)
+      continue
+
+    const key = `${workerId}${KEY_SEP}${gitToplevel}`
+    const existing = checkouts.get(key)
+    if (!existing) {
+      checkouts.set(key, {
+        workerId,
+        gitToplevel,
+        repoKey: rk.key,
+        repoLabel: rk.label,
+        isWorktree: git.isWorktree === true,
+        currentBranch: git.branchLabel ?? '',
+        mru: tab.mru ?? -1,
+        createdAt: tab.createdAt ?? '',
+      })
+      continue
+    }
+    // Merge: the checkout is as recent as its most recent tab, and any tab that
+    // knows the branch or the worktree disposition supplies it.
+    existing.mru = Math.max(existing.mru, tab.mru ?? -1)
+    if ((tab.createdAt ?? '') > existing.createdAt)
+      existing.createdAt = tab.createdAt ?? ''
+    if (!existing.currentBranch && git.branchLabel)
+      existing.currentBranch = git.branchLabel
+    if (git.isWorktree !== undefined)
+      existing.isWorktree = git.isWorktree
+  }
+
+  let entries = [...checkouts.values()]
+
+  if (opts.isWorkerOnline)
+    entries = entries.filter(c => opts.isWorkerOnline!(c.workerId))
+
+  entries = dropRedundantWorktrees(entries)
+
+  entries.sort(compareCheckouts)
+
+  if (opts.limit !== undefined && entries.length > opts.limit)
+    entries = entries.slice(0, opts.limit)
+
+  return labelCheckouts(entries, opts.workerInfoFn)
+}
+
+/**
+ * Drop each worktree whose own repository also has a normal checkout on the
+ * same worker.
+ *
+ * Grouped by `(workerId, repoKey)` rather than by `repoKey` alone: the same
+ * repository cloned on two machines is two places to start, and one machine's
+ * main checkout says nothing about the other machine's worktrees.
+ */
+function dropRedundantWorktrees(entries: Checkout[]): Checkout[] {
+  const hasMainCheckout = new Set<string>()
+  for (const c of entries) {
+    if (!c.isWorktree)
+      hasMainCheckout.add(`${c.workerId}${KEY_SEP}${c.repoKey}`)
+  }
+  return entries.filter(c => !c.isWorktree || !hasMainCheckout.has(`${c.workerId}${KEY_SEP}${c.repoKey}`))
+}
+
+/**
+ * Most recently used first.
+ *
+ * `mru` is a monotonic COUNTER, not a timestamp (see `BaseTab.mru`): it orders
+ * and nothing more, and a workspace whose tabs were never activated this
+ * session carries none at all. Those fall to `createdAt`, then to the labels,
+ * so the order is total and stable across renders.
+ */
+function compareCheckouts(a: Checkout, b: Checkout): number {
+  if (a.mru !== b.mru)
+    return b.mru - a.mru
+  if (a.createdAt !== b.createdAt)
+    return a.createdAt < b.createdAt ? 1 : -1
+  if (a.repoLabel !== b.repoLabel)
+    return a.repoLabel < b.repoLabel ? -1 : 1
+  return a.gitToplevel < b.gitToplevel ? -1 : 1
+}
+
+/** Build each row's label, adding context only where it disambiguates. */
+function labelCheckouts(
+  entries: Checkout[],
+  workerInfoFn?: (id: string) => WorkerInfo | null,
+): RepoStartPoint[] {
+  // The worker segment appears only once the list spans more than one worker.
+  // On a solo desktop every row would otherwise carry the same prefix, which
+  // says nothing and eats the width the repository name needs.
+  const multiWorker = new Set(entries.map(c => c.workerId)).size > 1
+
+  const baseLabel = (c: Checkout): string => {
+    if (!multiWorker)
+      return c.repoLabel
+    const name = workerInfoFn?.(c.workerId)?.name || c.workerId
+    return `${name} · ${c.repoLabel}`
+  }
+
+  const seen = new Map<string, number>()
+  for (const c of entries) {
+    const base = baseLabel(c)
+    seen.set(base, (seen.get(base) ?? 0) + 1)
+  }
+
+  return entries.map((c) => {
+    const base = baseLabel(c)
+    // Two checkouts read the same: two clones of one repository on one worker,
+    // or two unrelated repositories whose directories share a basename. The
+    // path is the only thing that tells them apart.
+    const label = (seen.get(base) ?? 0) > 1
+      ? `${base} (${tildifyForWorker(c.gitToplevel, workerInfoFn?.(c.workerId))})`
+      : base
+    return {
+      key: `${c.workerId}${KEY_SEP}${c.gitToplevel}`,
+      label,
+      startPoint: {
+        kind: 'repo',
+        workerId: c.workerId,
+        gitToplevel: c.gitToplevel,
+        isWorktree: c.isWorktree,
+        currentBranch: c.currentBranch || undefined,
+      },
+    }
+  })
+}

--- a/frontend/src/components/workspace/repoStartPoints.ts
+++ b/frontend/src/components/workspace/repoStartPoints.ts
@@ -1,10 +1,10 @@
 import type { WorkspaceRepoStartPoint } from './workspaceStartPoint'
 import type { WorkerInfo } from '~/lib/workerInfoCache'
-import type { RepoGitStore } from '~/stores/repoGit'
+import type { RepoGitStore, RepoKey } from '~/stores/repoGit'
 import type { Tab } from '~/stores/tab.types'
 import { tildifyForWorker } from '~/lib/workerPaths'
-import { repoGitView } from '~/stores/repoGit'
-import { repoKeyAndLabel, tabGitToplevelForKey } from './branchKeys'
+import { repoGitView, repoKey } from '~/stores/repoGit'
+import { compositeKey, repoKeyAndLabel, tabGitToplevelForKey } from './branchKeys'
 
 /**
  * A repository a section already works on, ready to start a workspace in.
@@ -16,8 +16,6 @@ import { repoKeyAndLabel, tabGitToplevelForKey } from './branchKeys'
  * repositories the user touched most recently.
  */
 export interface RepoStartPoint {
-  /** Stable identity for a keyed `<For>`: the (worker, toplevel) pair. */
-  key: string
   /**
    * What the row reads.
    *
@@ -61,8 +59,6 @@ interface Checkout {
   createdAt: string
 }
 
-const KEY_SEP = '\x00'
-
 /**
  * The repositories `tabs` are checked out in, most recently used first.
  *
@@ -84,7 +80,7 @@ export function listRepoStartPoints(
   store: RepoGitStore,
   opts: ListRepoStartPointsOptions = {},
 ): RepoStartPoint[] {
-  const checkouts = new Map<string, Checkout>()
+  const checkouts = new Map<RepoKey, Checkout>()
 
   for (const tab of tabs) {
     const workerId = tab.workerId
@@ -100,7 +96,9 @@ export function listRepoStartPoints(
     if (!gitToplevel)
       continue
 
-    const key = `${workerId}${KEY_SEP}${gitToplevel}`
+    // The git store's own key space for a checkout, so this bucket and the
+    // store cannot disagree about what one checkout is.
+    const key = repoKey(workerId, gitToplevel)
     const existing = checkouts.get(key)
     if (!existing) {
       checkouts.set(key, {
@@ -150,12 +148,15 @@ export function listRepoStartPoints(
  * main checkout says nothing about the other machine's worktrees.
  */
 function dropRedundantWorktrees(entries: Checkout[]): Checkout[] {
+  // NOT the store's `repoKey`: `c.repoKey` is a repository IDENTITY -- an
+  // origin URL, or a local marker -- and not a toplevel, so that key space
+  // would be a lie here.
   const hasMainCheckout = new Set<string>()
   for (const c of entries) {
     if (!c.isWorktree)
-      hasMainCheckout.add(`${c.workerId}${KEY_SEP}${c.repoKey}`)
+      hasMainCheckout.add(compositeKey(c.workerId, c.repoKey))
   }
-  return entries.filter(c => !c.isWorktree || !hasMainCheckout.has(`${c.workerId}${KEY_SEP}${c.repoKey}`))
+  return entries.filter(c => !c.isWorktree || !hasMainCheckout.has(compositeKey(c.workerId, c.repoKey)))
 }
 
 /**
@@ -208,7 +209,6 @@ function labelCheckouts(
       ? `${base} (${tildifyForWorker(c.gitToplevel, workerInfoFn?.(c.workerId))})`
       : base
     return {
-      key: `${c.workerId}${KEY_SEP}${c.gitToplevel}`,
       label,
       startPoint: {
         kind: 'repo',

--- a/frontend/src/components/workspace/revealWorkspaceRow.ts
+++ b/frontend/src/components/workspace/revealWorkspaceRow.ts
@@ -8,16 +8,19 @@ import { setWorkspacesExpanded } from './expandedWorkspaces'
  * ref up through the section list to serve one menu item would put a second
  * handle on every row.
  *
- * EVERY visible copy is scrolled, because the app mounts the sidebar twice --
- * the desktop pane and the mobile overlay -- and only one of them is on screen.
- * `scrollIntoView` on a hidden element does nothing, so scrolling both is
- * correct rather than merely harmless.
+ * ONE node, so `querySelector` rather than a loop over every match. `AppShell`
+ * mounts the desktop layer or the mobile one, never both; each layer builds
+ * each sidebar once; a section lives on one sidebar; and a workspace lands in
+ * one section. A row that is present but not on screen belongs to a sidebar
+ * collapsed to its rail, which is `display: none` -- `scrollIntoView` there
+ * does nothing, and there is no second copy to try instead.
  *
  * The caller expands the SECTION first when it is collapsed; a row inside a
  * collapsed section has no box to scroll to.
  */
 export function revealWorkspaceRow(workspaceId: string): void {
   setWorkspacesExpanded([workspaceId], true)
-  for (const el of document.querySelectorAll(`[data-testid="workspace-item-${CSS.escape(workspaceId)}"]`))
-    el.scrollIntoView({ block: 'nearest' })
+  document
+    .querySelector(`[data-testid="workspace-item-${CSS.escape(workspaceId)}"]`)
+    ?.scrollIntoView({ block: 'nearest' })
 }

--- a/frontend/src/components/workspace/revealWorkspaceRow.ts
+++ b/frontend/src/components/workspace/revealWorkspaceRow.ts
@@ -1,0 +1,23 @@
+import { setWorkspacesExpanded } from './expandedWorkspaces'
+
+/**
+ * Bring one workspace row into view, with its tab tree open.
+ *
+ * A DOM read, deliberately: the row lives inside a scroll container the sidebar
+ * owns, several components below whoever asks for the reveal, and threading a
+ * ref up through the section list to serve one menu item would put a second
+ * handle on every row.
+ *
+ * EVERY visible copy is scrolled, because the app mounts the sidebar twice --
+ * the desktop pane and the mobile overlay -- and only one of them is on screen.
+ * `scrollIntoView` on a hidden element does nothing, so scrolling both is
+ * correct rather than merely harmless.
+ *
+ * The caller expands the SECTION first when it is collapsed; a row inside a
+ * collapsed section has no box to scroll to.
+ */
+export function revealWorkspaceRow(workspaceId: string): void {
+  setWorkspacesExpanded([workspaceId], true)
+  for (const el of document.querySelectorAll(`[data-testid="workspace-item-${CSS.escape(workspaceId)}"]`))
+    el.scrollIntoView({ block: 'nearest' })
+}

--- a/frontend/src/components/workspace/workspaceList.css.ts
+++ b/frontend/src/components/workspace/workspaceList.css.ts
@@ -193,6 +193,33 @@ globalStyle(`${item}${itemDropTarget}:hover > ${sidebarActions} ${menuTrigger}`,
   opacity: 0,
 })
 
+/**
+ * The per-section filter box, shown by the header menu's "Filter workspaces"
+ * toggle.
+ *
+ * It sits in the section BODY rather than inside the menu popover, which keeps
+ * the menu a plain `menu` (a `div` popover would force a per-item close) and
+ * leaves the box usable while the menu is closed.
+ */
+export const filterRow = style({
+  padding: 'var(--space-1) var(--space-2)',
+})
+
+export const filterInput = style({
+  'width': '100%',
+  'fontSize': 'var(--text-7)',
+  'color': 'var(--foreground)',
+  'backgroundColor': 'var(--background)',
+  'border': '1px solid var(--border)',
+  'borderRadius': 'var(--radius-small)',
+  'padding': '0 var(--space-2)',
+  'outline': 'none',
+  'minWidth': 0,
+  ':focus-visible': {
+    boxShadow: '0 0 0 2px var(--ring)',
+  },
+})
+
 export const emptySection = style({
   padding: 'var(--space-2) var(--space-4)',
   paddingLeft: 'var(--space-4)',

--- a/frontend/src/components/workspace/workspaceListState.test.ts
+++ b/frontend/src/components/workspace/workspaceListState.test.ts
@@ -1,0 +1,153 @@
+import { createRoot } from 'solid-js'
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  KEY_WORKSPACE_SORT,
+  localStorageClearForTests,
+  localStorageGet,
+  localStorageSet,
+  setStorageAccount,
+} from '~/lib/browserStorage'
+import { DEFAULT_WORKSPACE_SORT_ORDER } from '~/lib/workspaceSort'
+import {
+  canReorderWithinSection,
+  isSectionFilterShown,
+  resetWorkspaceListStateForTests,
+  sectionFilterQuery,
+  setSectionFilterQuery,
+  setWorkspaceSortOrder,
+  toggleSectionFilter,
+  workspaceSortOrder,
+} from './workspaceListState'
+
+/**
+ * One sidebar mounts one `WorkspaceSectionContent` per workspace section, the
+ * app mounts the sidebar twice, and the section header MENU is a fourth reader
+ * outside all of them. So every test below has two readers -- a single reader
+ * agreeing with itself proves nothing about the state this module exists to
+ * share.
+ */
+function reader() {
+  return createRoot(dispose => ({
+    dispose,
+    order: () => workspaceSortOrder(),
+    filter: (sectionId: string) => sectionFilterQuery(sectionId),
+    canReorder: (sectionId: string) => canReorderWithinSection(sectionId),
+  }))
+}
+
+describe('workspaceListState', () => {
+  beforeEach(() => {
+    localStorageClearForTests()
+    setStorageAccount('u-1')
+    resetWorkspaceListStateForTests()
+  })
+
+  describe('the sort order', () => {
+    it('starts on the manual order, which is the lexorank one', () => {
+      expect(workspaceSortOrder()).toEqual(DEFAULT_WORKSPACE_SORT_ORDER)
+    })
+
+    it('shows one reader the order a SECOND reader set', () => {
+      const a = reader()
+      const b = reader()
+      a.dispose()
+      setWorkspaceSortOrder({ key: 'name', direction: 'desc' })
+      expect(b.order()).toEqual({ key: 'name', direction: 'desc' })
+      b.dispose()
+    })
+
+    it('persists the order, and restores it on the next read', () => {
+      setWorkspaceSortOrder({ key: 'recent', direction: 'desc' })
+      expect(localStorageGet(KEY_WORKSPACE_SORT)).toEqual({ key: 'recent', direction: 'desc' })
+
+      resetWorkspaceListStateForTests()
+      expect(workspaceSortOrder()).toEqual({ key: 'recent', direction: 'desc' })
+    })
+
+    it('falls back to the default for a stored value that no longer parses', () => {
+      localStorageSet(KEY_WORKSPACE_SORT, { key: 'colour', direction: 'asc' })
+      resetWorkspaceListStateForTests()
+      expect(workspaceSortOrder()).toEqual(DEFAULT_WORKSPACE_SORT_ORDER)
+    })
+
+    it('writes nothing before the first read, so it cannot erase a stored order', () => {
+      localStorageSet(KEY_WORKSPACE_SORT, { key: 'created', direction: 'asc' })
+      resetWorkspaceListStateForTests()
+      // No read yet: the stored value must still be there.
+      expect(localStorageGet(KEY_WORKSPACE_SORT)).toEqual({ key: 'created', direction: 'asc' })
+    })
+  })
+
+  describe('the per-section filter', () => {
+    it('is hidden for every section until it is toggled', () => {
+      expect(isSectionFilterShown('sec-a')).toBe(false)
+      expect(sectionFilterQuery('sec-a')).toBeUndefined()
+    })
+
+    it('opens EMPTY rather than absent, so "open" and "typed" are one value', () => {
+      toggleSectionFilter('sec-a')
+      expect(isSectionFilterShown('sec-a')).toBe(true)
+      expect(sectionFilterQuery('sec-a')).toBe('')
+    })
+
+    it('clears the query when it closes', () => {
+      toggleSectionFilter('sec-a')
+      setSectionFilterQuery('sec-a', 'amber')
+      toggleSectionFilter('sec-a')
+      expect(sectionFilterQuery('sec-a')).toBeUndefined()
+
+      toggleSectionFilter('sec-a')
+      expect(sectionFilterQuery('sec-a')).toBe('')
+    })
+
+    it('keeps two sections independent', () => {
+      toggleSectionFilter('sec-a')
+      setSectionFilterQuery('sec-a', 'amber')
+      expect(isSectionFilterShown('sec-b')).toBe(false)
+      expect(sectionFilterQuery('sec-b')).toBeUndefined()
+    })
+
+    it('shows one reader what a SECOND reader typed', () => {
+      const a = reader()
+      const b = reader()
+      toggleSectionFilter('sec-a')
+      setSectionFilterQuery('sec-a', 'amber')
+      expect(a.filter('sec-a')).toBe('amber')
+      expect(b.filter('sec-a')).toBe('amber')
+      a.dispose()
+      b.dispose()
+    })
+
+    it('is NOT persisted: a filter that survives a reload hides rows silently', () => {
+      toggleSectionFilter('sec-a')
+      setSectionFilterQuery('sec-a', 'amber')
+      resetWorkspaceListStateForTests()
+      expect(isSectionFilterShown('sec-a')).toBe(false)
+    })
+  })
+
+  describe('canReorderWithinSection', () => {
+    it('allows reordering by default', () => {
+      expect(canReorderWithinSection('sec-a')).toBe(true)
+    })
+
+    it('refuses in EVERY section once a non-manual sort is picked', () => {
+      // The sort is global, so one pick changes every section at once.
+      setWorkspaceSortOrder({ key: 'name', direction: 'asc' })
+      expect(canReorderWithinSection('sec-a')).toBe(false)
+      expect(canReorderWithinSection('sec-b')).toBe(false)
+    })
+
+    it('refuses in the FILTERED section alone', () => {
+      toggleSectionFilter('sec-a')
+      setSectionFilterQuery('sec-a', 'amber')
+      expect(canReorderWithinSection('sec-a')).toBe(false)
+      expect(canReorderWithinSection('sec-b')).toBe(true)
+    })
+
+    it('still allows reordering while the filter box is open but empty', () => {
+      toggleSectionFilter('sec-a')
+      expect(canReorderWithinSection('sec-a')).toBe(true)
+    })
+  })
+})

--- a/frontend/src/components/workspace/workspaceListState.test.ts
+++ b/frontend/src/components/workspace/workspaceListState.test.ts
@@ -20,11 +20,11 @@ import {
 } from './workspaceListState'
 
 /**
- * One sidebar mounts one `WorkspaceSectionContent` per workspace section, the
- * app mounts the sidebar twice, and the section header MENU is a fourth reader
- * outside all of them. So every test below has two readers -- a single reader
- * agreeing with itself proves nothing about the state this module exists to
- * share.
+ * One sidebar mounts one `WorkspaceSectionContent` per workspace section, a
+ * custom workspace section can sit on the other sidebar, and the section header
+ * MENU is a further reader outside all of them. So every test below has two
+ * readers -- a single reader agreeing with itself proves nothing about the
+ * state this module exists to share.
  */
 function reader() {
   return createRoot(dispose => ({
@@ -149,5 +149,41 @@ describe('workspaceListState', () => {
       toggleSectionFilter('sec-a')
       expect(canReorderWithinSection('sec-a')).toBe(true)
     })
+  })
+
+  // The account switch is the whole reason this module carries a seed latch,
+  // and nothing exercised it. The reset writes `DEFAULT_WORKSPACE_SORT_ORDER`,
+  // a module-level constant, so on the un-seeded path Solid's `===` equality
+  // drops that write -- a reader that only re-read on notification stayed on
+  // the previous account's order.
+  it('re-reads the sort order under the new account', () => {
+    setStorageAccount('u-2')
+    localStorageSet(KEY_WORKSPACE_SORT, { key: 'created', direction: 'asc' })
+    setStorageAccount('u-1')
+    localStorageSet(KEY_WORKSPACE_SORT, { key: 'name', direction: 'desc' })
+    resetWorkspaceListStateForTests()
+
+    const r = reader()
+    expect(r.order()).toEqual({ key: 'name', direction: 'desc' })
+
+    setStorageAccount('u-2')
+
+    expect(r.order()).toEqual({ key: 'created', direction: 'asc' })
+    r.dispose()
+  })
+
+  // The filter is NOT persisted, so a switch must leave the incoming account
+  // with none -- its section ids are not the outgoing account's.
+  it('drops every section filter when the account moves', () => {
+    setStorageAccount('u-1')
+    resetWorkspaceListStateForTests()
+    toggleSectionFilter('sec-1')
+    setSectionFilterQuery('sec-1', 'infra')
+    expect(isSectionFilterShown('sec-1')).toBe(true)
+
+    setStorageAccount('u-2')
+
+    expect(isSectionFilterShown('sec-1')).toBe(false)
+    expect(sectionFilterQuery('sec-1')).toBeUndefined()
   })
 })

--- a/frontend/src/components/workspace/workspaceListState.ts
+++ b/frontend/src/components/workspace/workspaceListState.ts
@@ -1,12 +1,6 @@
 import type { WorkspaceSortOrder } from '~/lib/workspaceSort'
-import { createEffect, createRoot, createSignal } from 'solid-js'
-import {
-  hasStorageAccount,
-  KEY_WORKSPACE_SORT,
-  localStorageGet,
-  localStorageSet,
-  onStorageAccountChange,
-} from '~/lib/browserStorage'
+import { createAccountScopedSignal } from '~/lib/accountScopedSignal'
+import { KEY_WORKSPACE_SORT, localStorageGet, localStorageSet } from '~/lib/browserStorage'
 import {
   canReorderWithin as canReorderForOrder,
   DEFAULT_WORKSPACE_SORT_ORDER,
@@ -17,10 +11,10 @@ import {
  * How the sidebar's workspace lists are ordered and narrowed.
  *
  * Module scope for the same reason as `~/components/workspace/expandedWorkspaces`:
- * one sidebar mounts one `WorkspaceSectionContent` per workspace section, the
- * app mounts the sidebar twice, and the section HEADER MENU is a fourth reader
- * that sits outside all of them. Per-instance state would let the menu's radio
- * disagree with the list it claims to order.
+ * one sidebar mounts one `WorkspaceSectionContent` per workspace section, and
+ * the section HEADER MENU is a further reader that sits outside all of them.
+ * Per-instance state would let the menu's radio disagree with the list it
+ * claims to order.
  *
  * The two halves differ deliberately:
  *
@@ -29,63 +23,27 @@ import {
  *    this in" that the reorder rule below would then have to ask twice.
  *  - The FILTER is per section and NOT persisted. A filter that survived a
  *    reload would hide workspaces the user has forgotten they filtered, which
- *    reads as data loss rather than as a view.
+ *    reads as data loss rather than as a view. It is still account-scoped, so
+ *    it does not follow one account's sections into another's sidebar.
  */
 
 const EMPTY_FILTERS: ReadonlyMap<string, string> = new Map()
 
-/**
- * Whether localStorage was read for the CURRENT account yet.
- *
- * Declared ahead of the `createRoot` below: Solid flushes the root's effects at
- * the end of that call, so the persist effect reads this while the module body
- * is still running.
- */
-let seeded = false
-
-const { sortOrder, setSortOrder, filters, setFilters } = createRoot(() => {
-  const [order, setOrder] = createSignal<WorkspaceSortOrder>(DEFAULT_WORKSPACE_SORT_ORDER)
-  /** `undefined` for a section means the filter input is not shown at all. */
-  const [byId, setById] = createSignal<ReadonlyMap<string, string>>(EMPTY_FILTERS)
-
-  createEffect(() => {
-    const current = order()
-    // Before an account is set, a write throws -- an account-scoped key has no
-    // namespace to resolve under -- and writing the default would overwrite a
-    // stored preference this module has not read yet.
-    if (!seeded)
-      return
-    localStorageSet(KEY_WORKSPACE_SORT, current)
-  })
-
-  return { sortOrder: order, setSortOrder: setOrder, filters: byId, setFilters: setById }
+const sort = createAccountScopedSignal<WorkspaceSortOrder>(DEFAULT_WORKSPACE_SORT_ORDER, {
+  read: () => parseWorkspaceSortOrder(localStorageGet(KEY_WORKSPACE_SORT)),
+  write: order => localStorageSet(KEY_WORKSPACE_SORT, order),
 })
 
-function ensureSeeded(): void {
-  if (seeded || !hasStorageAccount())
-    return
-  seeded = true
-  setSortOrder(parseWorkspaceSortOrder(localStorageGet(KEY_WORKSPACE_SORT)))
-}
-
-// The namespace moved, so the order belongs to the account that left. Drop it
-// and let the next access re-read under the new one. The filters go with it:
-// they name sections of the account that left.
-onStorageAccountChange(() => {
-  seeded = false
-  setSortOrder(DEFAULT_WORKSPACE_SORT_ORDER)
-  setFilters(EMPTY_FILTERS)
-})
+/** `undefined` for a section means the filter input is not shown at all. */
+const filters = createAccountScopedSignal<ReadonlyMap<string, string>>(EMPTY_FILTERS)
 
 /** The order every workspace section is drawn in. Reactive. */
 export function workspaceSortOrder(): WorkspaceSortOrder {
-  ensureSeeded()
-  return sortOrder()
+  return sort.get()
 }
 
 export function setWorkspaceSortOrder(order: WorkspaceSortOrder): void {
-  ensureSeeded()
-  setSortOrder(order)
+  sort.set(order)
 }
 
 /**
@@ -95,17 +53,17 @@ export function setWorkspaceSortOrder(order: WorkspaceSortOrder): void {
  * cannot drift: an open-but-empty input is `''`, and a closed one is absent.
  */
 export function sectionFilterQuery(sectionId: string): string | undefined {
-  return filters().get(sectionId)
+  return filters.get().get(sectionId)
 }
 
 /** Whether `sectionId` shows its filter input. */
 export function isSectionFilterShown(sectionId: string): boolean {
-  return filters().has(sectionId)
+  return filters.get().has(sectionId)
 }
 
 /** Show or hide `sectionId`'s filter input. Hiding clears the query with it. */
 export function toggleSectionFilter(sectionId: string): void {
-  setFilters((prev) => {
+  filters.set((prev) => {
     const next = new Map(prev)
     if (next.has(sectionId))
       next.delete(sectionId)
@@ -116,7 +74,7 @@ export function toggleSectionFilter(sectionId: string): void {
 }
 
 export function setSectionFilterQuery(sectionId: string, query: string): void {
-  setFilters((prev) => {
+  filters.set((prev) => {
     if (prev.get(sectionId) === query)
       return prev
     const next = new Map(prev)
@@ -137,7 +95,6 @@ export function canReorderWithinSection(sectionId: string): boolean {
 
 /** Drop the order and every filter. FOR TESTS ONLY. */
 export function resetWorkspaceListStateForTests(): void {
-  seeded = false
-  setSortOrder(DEFAULT_WORKSPACE_SORT_ORDER)
-  setFilters(EMPTY_FILTERS)
+  sort.reset()
+  filters.reset()
 }

--- a/frontend/src/components/workspace/workspaceListState.ts
+++ b/frontend/src/components/workspace/workspaceListState.ts
@@ -1,0 +1,143 @@
+import type { WorkspaceSortOrder } from '~/lib/workspaceSort'
+import { createEffect, createRoot, createSignal } from 'solid-js'
+import {
+  hasStorageAccount,
+  KEY_WORKSPACE_SORT,
+  localStorageGet,
+  localStorageSet,
+  onStorageAccountChange,
+} from '~/lib/browserStorage'
+import {
+  canReorderWithin as canReorderForOrder,
+  DEFAULT_WORKSPACE_SORT_ORDER,
+  parseWorkspaceSortOrder,
+} from '~/lib/workspaceSort'
+
+/**
+ * How the sidebar's workspace lists are ordered and narrowed.
+ *
+ * Module scope for the same reason as `~/components/workspace/expandedWorkspaces`:
+ * one sidebar mounts one `WorkspaceSectionContent` per workspace section, the
+ * app mounts the sidebar twice, and the section HEADER MENU is a fourth reader
+ * that sits outside all of them. Per-instance state would let the menu's radio
+ * disagree with the list it claims to order.
+ *
+ * The two halves differ deliberately:
+ *
+ *  - The SORT is one global order, persisted per account. One list is one
+ *    order, and a per-section sort would be a second answer to "what order is
+ *    this in" that the reorder rule below would then have to ask twice.
+ *  - The FILTER is per section and NOT persisted. A filter that survived a
+ *    reload would hide workspaces the user has forgotten they filtered, which
+ *    reads as data loss rather than as a view.
+ */
+
+const EMPTY_FILTERS: ReadonlyMap<string, string> = new Map()
+
+/**
+ * Whether localStorage was read for the CURRENT account yet.
+ *
+ * Declared ahead of the `createRoot` below: Solid flushes the root's effects at
+ * the end of that call, so the persist effect reads this while the module body
+ * is still running.
+ */
+let seeded = false
+
+const { sortOrder, setSortOrder, filters, setFilters } = createRoot(() => {
+  const [order, setOrder] = createSignal<WorkspaceSortOrder>(DEFAULT_WORKSPACE_SORT_ORDER)
+  /** `undefined` for a section means the filter input is not shown at all. */
+  const [byId, setById] = createSignal<ReadonlyMap<string, string>>(EMPTY_FILTERS)
+
+  createEffect(() => {
+    const current = order()
+    // Before an account is set, a write throws -- an account-scoped key has no
+    // namespace to resolve under -- and writing the default would overwrite a
+    // stored preference this module has not read yet.
+    if (!seeded)
+      return
+    localStorageSet(KEY_WORKSPACE_SORT, current)
+  })
+
+  return { sortOrder: order, setSortOrder: setOrder, filters: byId, setFilters: setById }
+})
+
+function ensureSeeded(): void {
+  if (seeded || !hasStorageAccount())
+    return
+  seeded = true
+  setSortOrder(parseWorkspaceSortOrder(localStorageGet(KEY_WORKSPACE_SORT)))
+}
+
+// The namespace moved, so the order belongs to the account that left. Drop it
+// and let the next access re-read under the new one. The filters go with it:
+// they name sections of the account that left.
+onStorageAccountChange(() => {
+  seeded = false
+  setSortOrder(DEFAULT_WORKSPACE_SORT_ORDER)
+  setFilters(EMPTY_FILTERS)
+})
+
+/** The order every workspace section is drawn in. Reactive. */
+export function workspaceSortOrder(): WorkspaceSortOrder {
+  ensureSeeded()
+  return sortOrder()
+}
+
+export function setWorkspaceSortOrder(order: WorkspaceSortOrder): void {
+  ensureSeeded()
+  setSortOrder(order)
+}
+
+/**
+ * What `sectionId`'s filter input holds, or undefined while it is not shown.
+ *
+ * ONE value for both questions, so "is the input open" and "what is typed"
+ * cannot drift: an open-but-empty input is `''`, and a closed one is absent.
+ */
+export function sectionFilterQuery(sectionId: string): string | undefined {
+  return filters().get(sectionId)
+}
+
+/** Whether `sectionId` shows its filter input. */
+export function isSectionFilterShown(sectionId: string): boolean {
+  return filters().has(sectionId)
+}
+
+/** Show or hide `sectionId`'s filter input. Hiding clears the query with it. */
+export function toggleSectionFilter(sectionId: string): void {
+  setFilters((prev) => {
+    const next = new Map(prev)
+    if (next.has(sectionId))
+      next.delete(sectionId)
+    else
+      next.set(sectionId, '')
+    return next
+  })
+}
+
+export function setSectionFilterQuery(sectionId: string, query: string): void {
+  setFilters((prev) => {
+    if (prev.get(sectionId) === query)
+      return prev
+    const next = new Map(prev)
+    next.set(sectionId, query)
+    return next
+  })
+}
+
+/**
+ * Whether `sectionId`'s rows may be dragged to a new position within it.
+ *
+ * The bound form of `~/lib/workspaceSort`'s predicate: the sort is global and
+ * the filter is this section's.
+ */
+export function canReorderWithinSection(sectionId: string): boolean {
+  return canReorderForOrder(workspaceSortOrder(), sectionFilterQuery(sectionId) ?? '')
+}
+
+/** Drop the order and every filter. FOR TESTS ONLY. */
+export function resetWorkspaceListStateForTests(): void {
+  seeded = false
+  setSortOrder(DEFAULT_WORKSPACE_SORT_ORDER)
+  setFilters(EMPTY_FILTERS)
+}

--- a/frontend/src/components/workspace/workspaceMenuInfo.test.ts
+++ b/frontend/src/components/workspace/workspaceMenuInfo.test.ts
@@ -1,0 +1,69 @@
+import type { RepoStartPoint } from './repoStartPoints'
+import { describe, expect, it } from 'vitest'
+import { workspaceInfoJson, workspaceInfoRows } from './workspaceMenuInfo'
+
+/**
+ * The info projection is pure, so it is tested without mounting a menu -- which
+ * is the point of extracting it from `WorkspaceContextMenu`.
+ */
+function repo(label: string, workerId = 'w1', gitToplevel = '/home/me/repo'): RepoStartPoint {
+  return { label, startPoint: { kind: 'repo', workerId, gitToplevel, isWorktree: false } }
+}
+
+const base = {
+  workspaceId: 'ws-1',
+  title: 'My workspace',
+  sectionName: 'In progress',
+  tabCount: 3,
+  repos: [] as RepoStartPoint[],
+}
+
+describe('workspaceInfoRows', () => {
+  it('reports the workspace, its section and its tab count', () => {
+    expect(workspaceInfoRows(base)).toEqual([
+      { label: 'Workspace:', value: 'My workspace' },
+      { label: 'Section:', value: 'In progress' },
+      { label: 'Tabs:', value: '3' },
+    ])
+  })
+
+  it('adds the repository row only when there is exactly one', () => {
+    const one = workspaceInfoRows({ ...base, repos: [repo('leapmux')] })
+    expect(one.at(-1)).toEqual({ label: 'Repository:', value: 'leapmux' })
+  })
+
+  // Two repositories cannot share one row, and the Repository submenu lists
+  // them all anyway.
+  it('omits the repository row for two or more', () => {
+    const two = workspaceInfoRows({ ...base, repos: [repo('alpha'), repo('beta', 'w2')] })
+    expect(two.map(r => r.label)).not.toContain('Repository:')
+  })
+
+  it('reports a zero tab count rather than dropping the row', () => {
+    expect(workspaceInfoRows({ ...base, tabCount: 0 }).at(-1)).toEqual({ label: 'Tabs:', value: '0' })
+  })
+})
+
+describe('workspaceInfoJson', () => {
+  // The id is the whole reason the copy exists: no row shows it, and the CLI
+  // takes it.
+  it('carries the workspace id, which no row shows', () => {
+    const parsed = JSON.parse(workspaceInfoJson(base))
+    expect(parsed.workspaceId).toBe('ws-1')
+  })
+
+  it('lists every repository with its worker and path, however many there are', () => {
+    const parsed = JSON.parse(workspaceInfoJson({
+      ...base,
+      repos: [repo('alpha', 'w1', '/a'), repo('beta', 'w2', '/b')],
+    }))
+    expect(parsed.repositories).toEqual([
+      { label: 'alpha', workerId: 'w1', path: '/a' },
+      { label: 'beta', workerId: 'w2', path: '/b' },
+    ])
+  })
+
+  it('answers valid JSON for a workspace with no repository', () => {
+    expect(JSON.parse(workspaceInfoJson(base)).repositories).toEqual([])
+  })
+})

--- a/frontend/src/components/workspace/workspaceMenuInfo.ts
+++ b/frontend/src/components/workspace/workspaceMenuInfo.ts
@@ -1,0 +1,48 @@
+import type { RepoStartPoint } from './repoStartPoints'
+import type { MenuInfoRow } from '~/components/common/MenuInfoRows'
+import { prettifyJson } from '~/lib/jsonFormat'
+
+/** Everything the workspace row menu's info block reports. */
+export interface WorkspaceMenuInfo {
+  workspaceId: string
+  title: string
+  sectionName: string
+  tabCount: number
+  repos: readonly RepoStartPoint[]
+}
+
+/**
+ * The rows the info block shows.
+ *
+ * The repository row appears only when it is UNAMBIGUOUS. Two repositories
+ * cannot share one row, and the `Repository` submenu lists them all anyway.
+ */
+export function workspaceInfoRows(info: WorkspaceMenuInfo): MenuInfoRow[] {
+  const rows: MenuInfoRow[] = [
+    { label: 'Workspace:', value: info.title },
+    { label: 'Section:', value: info.sectionName },
+    { label: 'Tabs:', value: String(info.tabCount) },
+  ]
+  if (info.repos.length === 1)
+    rows.push({ label: 'Repository:', value: info.repos[0].label })
+  return rows
+}
+
+/**
+ * The same information as JSON, for the copy button.
+ *
+ * It carries the workspace ID, which no row shows and which the CLI takes.
+ */
+export function workspaceInfoJson(info: WorkspaceMenuInfo): string {
+  return prettifyJson({
+    workspaceId: info.workspaceId,
+    title: info.title,
+    section: info.sectionName,
+    tabs: info.tabCount,
+    repositories: info.repos.map(r => ({
+      label: r.label,
+      workerId: r.startPoint.workerId,
+      path: r.startPoint.gitToplevel,
+    })),
+  })
+}

--- a/frontend/src/components/workspace/workspaceMenuItem.tsx
+++ b/frontend/src/components/workspace/workspaceMenuItem.tsx
@@ -1,0 +1,18 @@
+import type { JSX } from 'solid-js'
+
+/**
+ * One plain command row of a workspace menu.
+ *
+ * The row menu renders this shape in six places -- three tab-creation shapes
+ * and three repository actions -- across two components, so the markup is
+ * written once here. A row inside a `<For>` carries no test id: the popover it
+ * sits in already has one, and one id per repository would be a selector
+ * nobody can predict.
+ */
+export function menuItem(label: string, onClick: () => void, testId?: string): JSX.Element {
+  return (
+    <button type="button" role="menuitem" data-testid={testId} onClick={onClick}>
+      {label}
+    </button>
+  )
+}

--- a/frontend/src/components/workspace/workspaceStartActions.ts
+++ b/frontend/src/components/workspace/workspaceStartActions.ts
@@ -1,0 +1,33 @@
+/**
+ * Where a new tab opened from a workspace row starts.
+ *
+ * `workspaceId` is here for the same reason it is on a `BranchRef`: the sidebar
+ * lists EVERY workspace's rows, so the row the user clicked often belongs to a
+ * workspace they are not looking at, and the tab has to land in that one rather
+ * than in whichever is active.
+ */
+export interface WorkspaceStartAt {
+  workspaceId: string
+  workerId: string
+  workingDir: string
+}
+
+/**
+ * The two tab-creation actions a workspace row offers.
+ *
+ * A type of its own rather than a synthetic {@link BranchRef}: that type
+ * promises `branchName` and `tabs`, and a fake ref survives exactly until
+ * someone reads them. A workspace row knows a repository, not a branch.
+ *
+ * Both open a DIALOG rather than an inline provider/shell list.
+ * `BranchContextMenu` can afford `useAvailableProviders` and
+ * `useAvailableShells` because one branch menu is one `workerId`; a workspace
+ * spans N repositories on up to N workers, so an inline list would have to fan
+ * out per repository on every open.
+ */
+export interface WorkspaceStartActions {
+  /** Open the New agent dialog, pre-filled with this checkout. */
+  onNewAgentAt: (at: WorkspaceStartAt) => void
+  /** Open the New terminal dialog, pre-filled with this checkout. */
+  onNewTerminalAt: (at: WorkspaceStartAt) => void
+}

--- a/frontend/src/components/workspace/workspaceStartPoint.test.ts
+++ b/frontend/src/components/workspace/workspaceStartPoint.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { GitMode } from '~/hooks/useGitModeState'
+import { localStorageClearForTests, localStorageSet, PREFIX_WORKSPACE_GIT_MODE, setStorageAccount } from '~/lib/browserStorage'
+import {
+  gitModeStickyKey,
+  readStickyGitMode,
+  rememberStickyGitMode,
+  startPointDialogSetup,
+} from './workspaceStartPoint'
+
+/**
+ * `assertNever` gives exhaustiveness for ADDING a variant; it gives no coverage
+ * that an existing arm is right. These tests are that coverage: one case per
+ * variant, asserting the whole returned setup.
+ */
+describe('startPointDialogSetup', () => {
+  it('asks for nothing on a bare directory start point', () => {
+    expect(startPointDialogSetup({ kind: 'directory' })).toEqual({ workerId: undefined })
+  })
+
+  it('preselects a worker without pre-filling a directory', () => {
+    // The `?newWorkspace=true&workerId=` route names a machine and nothing
+    // else, so the user still picks the directory.
+    expect(startPointDialogSetup({ kind: 'directory', workerId: 'w1' }))
+      .toEqual({ workerId: 'w1' })
+  })
+
+  it('pre-fills worker, directory, snapshot and sticky key for a repo root', () => {
+    expect(startPointDialogSetup({
+      kind: 'repo',
+      workerId: 'w1',
+      gitToplevel: '/home/me/leapmux',
+      isWorktree: false,
+      currentBranch: 'main',
+    })).toEqual({
+      workerId: 'w1',
+      workingDir: '/home/me/leapmux',
+      pathInfoSeed: {
+        isGitRepo: true,
+        isRepoRoot: true,
+        isWorktreeRoot: false,
+        repoRoot: '/home/me/leapmux',
+        repoDirName: 'leapmux',
+        currentBranch: 'main',
+      },
+      stickyKey: gitModeStickyKey('w1', '/home/me/leapmux'),
+    })
+  })
+
+  it('leaves repoRoot EMPTY for a worktree, so the probe supplies the real one', () => {
+    // Seeding `repoRoot` with a worktree toplevel makes
+    // `GitOptions.worktreePath()` suggest a new worktree nested under the
+    // existing worktree's parent instead of the repository's.
+    const setup = startPointDialogSetup({
+      kind: 'repo',
+      workerId: 'w1',
+      gitToplevel: '/home/me/wt/feature',
+      isWorktree: true,
+      currentBranch: 'feature',
+    })
+    expect(setup.pathInfoSeed).toEqual({
+      isGitRepo: true,
+      isRepoRoot: false,
+      isWorktreeRoot: true,
+      repoRoot: '',
+      repoDirName: '',
+      currentBranch: 'feature',
+    })
+    // The working directory is still the worktree: that IS where the agent
+    // starts.
+    expect(setup.workingDir).toBe('/home/me/wt/feature')
+  })
+
+  it('seeds an empty branch when the caller does not know one', () => {
+    const setup = startPointDialogSetup({
+      kind: 'repo',
+      workerId: 'w1',
+      gitToplevel: '/repo',
+      isWorktree: false,
+    })
+    expect(setup.pathInfoSeed?.currentBranch).toBe('')
+  })
+
+  it('keys the worktree and its main repository separately', () => {
+    // Both checkouts are real places to start, and they deserve different
+    // remembered modes.
+    const main = startPointDialogSetup({ kind: 'repo', workerId: 'w1', gitToplevel: '/repo', isWorktree: false })
+    const wt = startPointDialogSetup({ kind: 'repo', workerId: 'w1', gitToplevel: '/repo-wt/x', isWorktree: true })
+    expect(main.stickyKey).not.toBe(wt.stickyKey)
+  })
+
+  it('keys the same path on two workers separately', () => {
+    const a = startPointDialogSetup({ kind: 'repo', workerId: 'w1', gitToplevel: '/repo', isWorktree: false })
+    const b = startPointDialogSetup({ kind: 'repo', workerId: 'w2', gitToplevel: '/repo', isWorktree: false })
+    expect(a.stickyKey).not.toBe(b.stickyKey)
+  })
+})
+
+describe('sticky git mode', () => {
+  beforeEach(() => {
+    localStorageClearForTests()
+    setStorageAccount('u-1')
+  })
+
+  it('round-trips a mode under its repository key', () => {
+    const key = gitModeStickyKey('w1', '/repo')
+    rememberStickyGitMode(key, GitMode.CreateWorktree)
+    expect(readStickyGitMode(key)).toBe(GitMode.CreateWorktree)
+  })
+
+  it('remembers nothing for a repository never submitted', () => {
+    expect(readStickyGitMode(gitModeStickyKey('w1', '/other'))).toBeUndefined()
+  })
+
+  it('keeps two repositories independent', () => {
+    rememberStickyGitMode(gitModeStickyKey('w1', '/a'), GitMode.CreateBranch)
+    rememberStickyGitMode(gitModeStickyKey('w1', '/b'), GitMode.UseWorktree)
+    expect(readStickyGitMode(gitModeStickyKey('w1', '/a'))).toBe(GitMode.CreateBranch)
+    expect(readStickyGitMode(gitModeStickyKey('w1', '/b'))).toBe(GitMode.UseWorktree)
+  })
+
+  it('is a no-op without a key, rather than writing a keyless entry', () => {
+    rememberStickyGitMode(undefined, GitMode.CreateBranch)
+    expect(readStickyGitMode(undefined)).toBeUndefined()
+  })
+
+  it('answers undefined for a stored value that no longer names a mode', () => {
+    // The whole reason a TOKEN is stored: a value from a previous build must
+    // fall back rather than select whichever mode now holds that slot.
+    localStorageSet(`${PREFIX_WORKSPACE_GIT_MODE}w1:/repo`, 'rebase-onto')
+    expect(readStickyGitMode(gitModeStickyKey('w1', '/repo'))).toBeUndefined()
+  })
+
+  it('answers undefined for a stored enum NUMBER', () => {
+    localStorageSet(`${PREFIX_WORKSPACE_GIT_MODE}w1:/repo`, 3)
+    expect(readStickyGitMode(gitModeStickyKey('w1', '/repo'))).toBeUndefined()
+  })
+
+  it('stores Current, which is a real answer and not "nothing remembered"', () => {
+    const key = gitModeStickyKey('w1', '/repo')
+    rememberStickyGitMode(key, GitMode.Current)
+    expect(readStickyGitMode(key)).toBe(GitMode.Current)
+  })
+})

--- a/frontend/src/components/workspace/workspaceStartPoint.test.ts
+++ b/frontend/src/components/workspace/workspaceStartPoint.test.ts
@@ -10,7 +10,7 @@ import {
 
 /**
  * `assertNever` gives exhaustiveness for ADDING a variant; it gives no coverage
- * that an existing arm is right. These tests are that coverage: one case per
+ * that an existing case is right. These tests are that coverage: one case per
  * variant, asserting the whole returned setup.
  */
 describe('startPointDialogSetup', () => {
@@ -19,7 +19,7 @@ describe('startPointDialogSetup', () => {
   })
 
   it('preselects a worker without pre-filling a directory', () => {
-    // The `?newWorkspace=true&workerId=` route names a machine and nothing
+    // The `?newWorkspace=true&workerId=` route identifies a machine and nothing
     // else, so the user still picks the directory.
     expect(startPointDialogSetup({ kind: 'directory', workerId: 'w1' }))
       .toEqual({ workerId: 'w1' })
@@ -124,7 +124,7 @@ describe('sticky git mode', () => {
     expect(readStickyGitMode(undefined)).toBeUndefined()
   })
 
-  it('answers undefined for a stored value that no longer names a mode', () => {
+  it('answers undefined for a stored value that no longer identifies a mode', () => {
     // The whole reason a TOKEN is stored: a value from a previous build must
     // fall back rather than select whichever mode now holds that slot.
     localStorageSet(`${PREFIX_WORKSPACE_GIT_MODE}w1:/repo`, 'rebase-onto')

--- a/frontend/src/components/workspace/workspaceStartPoint.ts
+++ b/frontend/src/components/workspace/workspaceStartPoint.ts
@@ -68,6 +68,9 @@ export type WorkspaceStartPoint
   // yields a directory, after which the existing `openAgent` call runs
   // unchanged.
 
+/** The `repo` variant alone, for the surfaces that only produce that one. */
+export type WorkspaceRepoStartPoint = Extract<WorkspaceStartPoint, { kind: 'repo' }>
+
 /**
  * The storage key a repository's last-used git mode is remembered under.
  *

--- a/frontend/src/components/workspace/workspaceStartPoint.ts
+++ b/frontend/src/components/workspace/workspaceStartPoint.ts
@@ -1,0 +1,166 @@
+import type { GitMode } from '~/hooks/useGitModeState'
+import type { GitPathInfoSeed } from '~/hooks/useGitPathInfo'
+import { gitModeFromToken, gitModeToken } from '~/hooks/useGitModeState'
+import { assertNever } from '~/lib/assertNever'
+import { localStorageGet, localStorageSet, PREFIX_WORKSPACE_GIT_MODE } from '~/lib/browserStorage'
+import { basename } from '~/lib/paths'
+
+/**
+ * Where a new workspace starts FROM.
+ *
+ * The section header menu picks one of these and hands it to the New workspace
+ * dialog, which turns it into a pre-filled form. The point of the type is that
+ * the menu never re-asks what the app already knows: starting a second agent on
+ * a repository the user already has open should not mean picking the worker and
+ * walking the directory tree again.
+ *
+ * Two more variants are designed for and NOT implemented: cloning a remote
+ * repository, and creating an empty one. Neither has an RPC on any worker or
+ * hub service today, so both are backend work. They are named here because the
+ * shape has to hold them without a redesign -- see the note on why they cannot
+ * be `GitMode` radios below.
+ */
+export type WorkspaceStartPoint
+  = | {
+    /** No repository target: the user picks the directory in the dialog. */
+    kind: 'directory'
+    /**
+     * A worker to preselect while still leaving the directory to the user.
+     *
+     * The `?newWorkspace=true&workerId=` route names a machine and nothing
+     * else, which is this rather than a `repo` start point.
+     */
+    workerId?: string
+  }
+  | {
+    /** A repository checkout the app has already seen this session. */
+    kind: 'repo'
+    workerId: string
+    /**
+     * The checkout's own toplevel -- the worktree root for a linked
+     * worktree, NOT the main repository.
+     */
+    gitToplevel: string
+    /**
+     * Whether `gitToplevel` is a linked worktree.
+     *
+     * Required, and not decoration. `useChangeBranchInspect` documents the
+     * failure: seeding `repoRoot` with a WORKTREE toplevel makes
+     * `GitOptions.worktreePath()` suggest a new worktree nested under the
+     * existing worktree's parent instead of the repository's.
+     */
+    isWorktree: boolean
+    /** The branch the checkout is on, when the caller knows it. */
+    currentBranch?: string
+  }
+  // FUTURE: { kind: 'clone', workerId, remoteUrl, parentDir }
+  // FUTURE: { kind: 'init',  workerId, directory }
+  //
+  // Why neither can be a sixth `GitMode` radio, which is the obvious-looking
+  // place for them: `useGitPathInfo` computes
+  // `showGitOptions = isGitRepo && (isRepoRoot || isWorktreeRoot)`, and
+  // `GitOptionsLoader` mounts its children only on it. A clone target does not
+  // exist yet and an init target is not a repository, so both report
+  // `isGitRepo=false` and `GitOptions` never renders there at all. `GitFields`
+  // has no wire slot either -- it projects onto seven `OpenAgent`/`OpenTerminal`
+  // proto fields and there is no `clone_url` among them. The slot each needs is
+  // a new dialog COLUMN plus a submit PRELUDE that calls the future RPC and
+  // yields a directory, after which the existing `openAgent` call runs
+  // unchanged.
+
+/**
+ * The storage key a repository's last-used git mode is remembered under.
+ *
+ * `(workerId, gitToplevel)` on BOTH sides, and that is the whole contract: the
+ * menu holds the pair on its start point, and the dialog holds it as
+ * `worker.workingDir()` while `pathInfo.showGitOptions()` is true -- which is
+ * exactly the guarantee that the path is a repository root or a worktree root.
+ *
+ * Do NOT key on the repo key (an origin URL) on one side and a path on the
+ * other: they are different spaces and every read would miss. Do NOT key on
+ * `info().repoRoot` either, which for a worktree is the main repository and
+ * would merge two checkouts that deserve different answers.
+ *
+ * The `:` join follows `PREFIX_FILES_SORT_ORDER`, which composes the same pair.
+ */
+export function gitModeStickyKey(workerId: string, gitToplevel: string): string {
+  return `${workerId}:${gitToplevel}`
+}
+
+/** What a start point pre-fills in the New workspace dialog. */
+export interface WorkspaceStartPointSetup {
+  /** Worker to preselect, or undefined to let the dialog pick. */
+  workerId?: string
+  /** Working directory to pre-fill, or undefined for the worker's default. */
+  workingDir?: string
+  /**
+   * Pre-filled git-path snapshot, so `GitOptions` paints on the first render
+   * instead of showing the "Loading branch info" spinner while the probe runs.
+   */
+  pathInfoSeed?: GitPathInfoSeed
+  /** Key for the remembered git mode, or undefined when nothing is remembered. */
+  stickyKey?: string
+}
+
+/**
+ * Project a start point onto the dialog's pre-fill.
+ *
+ * There is deliberately NO `form` field and no render map. It would be
+ * single-valued today, read by nobody, and a second place recording which forms
+ * exist. `assertNever` already turns a new variant into a compile error, and
+ * one error stops the build; the commit that adds the second form adds the
+ * field with it.
+ */
+export function startPointDialogSetup(sp: WorkspaceStartPoint): WorkspaceStartPointSetup {
+  switch (sp.kind) {
+    case 'directory':
+      return { workerId: sp.workerId }
+    case 'repo':
+      return {
+        workerId: sp.workerId,
+        workingDir: sp.gitToplevel,
+        // The same seeding rule `useChangeBranchInspect` states: a worktree
+        // toplevel is NOT the repository root, so leave `repoRoot` empty and
+        // let the probe supply the authoritative one. `GitOptions` hides the
+        // worktree-path preview until it lands.
+        pathInfoSeed: {
+          isGitRepo: true,
+          isRepoRoot: !sp.isWorktree,
+          isWorktreeRoot: sp.isWorktree,
+          repoRoot: sp.isWorktree ? '' : sp.gitToplevel,
+          repoDirName: sp.isWorktree ? '' : basename(sp.gitToplevel),
+          currentBranch: sp.currentBranch ?? '',
+        },
+        stickyKey: gitModeStickyKey(sp.workerId, sp.gitToplevel),
+      }
+    default:
+      return assertNever(sp)
+  }
+}
+
+/**
+ * The git mode this repository was last started with, or undefined when
+ * nothing is remembered (or what is remembered no longer names a mode).
+ *
+ * The menu shows it as the row's detail, and the dialog opens on it. Both read
+ * THIS function, so the row cannot promise a mode the dialog then does not
+ * select.
+ */
+export function readStickyGitMode(stickyKey: string | undefined): GitMode | undefined {
+  if (!stickyKey)
+    return undefined
+  return gitModeFromToken(localStorageGet<string>(`${PREFIX_WORKSPACE_GIT_MODE}${stickyKey}`))
+}
+
+/**
+ * Remember `mode` for this repository.
+ *
+ * Called on a SUCCESSFUL submit only: a mode the user selected and then
+ * abandoned is not what they work with, and remembering it would seed the next
+ * dialog from a decision that was cancelled.
+ */
+export function rememberStickyGitMode(stickyKey: string | undefined, mode: GitMode): void {
+  if (!stickyKey)
+    return
+  localStorageSet(`${PREFIX_WORKSPACE_GIT_MODE}${stickyKey}`, gitModeToken(mode))
+}

--- a/frontend/src/components/workspace/workspaceStartPoint.ts
+++ b/frontend/src/components/workspace/workspaceStartPoint.ts
@@ -27,7 +27,7 @@ export type WorkspaceStartPoint
     /**
      * A worker to preselect while still leaving the directory to the user.
      *
-     * The `?newWorkspace=true&workerId=` route names a machine and nothing
+     * The `?newWorkspace=true&workerId=` route identifies a machine and nothing
      * else, which is this rather than a `repo` start point.
      */
     workerId?: string
@@ -143,7 +143,7 @@ export function startPointDialogSetup(sp: WorkspaceStartPoint): WorkspaceStartPo
 
 /**
  * The git mode this repository was last started with, or undefined when
- * nothing is remembered (or what is remembered no longer names a mode).
+ * nothing is remembered (or what is remembered no longer identifies a mode).
  *
  * The menu shows it as the row's detail, and the dialog opens on it. Both read
  * THIS function, so the row cannot promise a mode the dialog then does not

--- a/frontend/src/hooks/createWorkerDialogContext.test.ts
+++ b/frontend/src/hooks/createWorkerDialogContext.test.ts
@@ -97,6 +97,58 @@ describe('createWorkerDialogContext worker auto-selection', () => {
     })
   })
 
+  // The worker and the directory are ONE choice. A caller that gives both means
+  // "this directory ON THAT MACHINE", so substituting the machine must not keep
+  // the path: an absolute path is a different place elsewhere, and the worse
+  // case is that it exists there and is the wrong tree.
+  it('drops the working directory when it substitutes a worker for an offline preselect', async () => {
+    mockWorkers([
+      { id: 'w-1', online: true },
+      { id: 'w-2', online: false },
+    ])
+    await createRoot(async (dispose) => {
+      const state = createWorkerDialogContext({
+        preselectedWorkerId: 'w-2',
+        defaultWorkingDir: '/home/me/on-the-other-machine',
+      })
+      await flush()
+      expect(state.workerId()).toBe('w-1')
+      expect(state.workingDir()).toBe('')
+      dispose()
+    })
+  })
+
+  // ...and keeps it when the preselected worker IS the one it settles on,
+  // which is the ordinary pre-filled case.
+  it('keeps the working directory when the preselected worker is online', async () => {
+    mockWorkers([
+      { id: 'w-1', online: true },
+      { id: 'w-2', online: true },
+    ])
+    await createRoot(async (dispose) => {
+      const state = createWorkerDialogContext({
+        preselectedWorkerId: 'w-2',
+        defaultWorkingDir: '/home/me/repo',
+      })
+      await flush()
+      expect(state.workerId()).toBe('w-2')
+      expect(state.workingDir()).toBe('/home/me/repo')
+      dispose()
+    })
+  })
+
+  // No preselect means the caller named no machine, so a default directory is
+  // not a claim about one and survives.
+  it('keeps a default directory when no worker was preselected', async () => {
+    mockWorkers([{ id: 'w-1', online: true }])
+    await createRoot(async (dispose) => {
+      const state = createWorkerDialogContext({ defaultWorkingDir: '/home/me/repo' })
+      await flush()
+      expect(state.workingDir()).toBe('/home/me/repo')
+      dispose()
+    })
+  })
+
   it('falls back to the first online worker when no preselected id is provided', async () => {
     mockWorkers([
       { id: 'w-1', online: true },
@@ -123,7 +175,7 @@ describe('createWorkerDialogContext worker auto-selection', () => {
   })
 
   it('does not overwrite an existing workerId on a subsequent fetchWorkers (handleRefresh path)', async () => {
-    // Regression guard: fetchWorkers is gated on `!workerId()`. The
+    // Regression guard: fetchWorkers depends on `!workerId()`. The
     // refresh button calls fetchWorkers again, but a worker the user
     // explicitly picked must survive — fetchWorkers must not re-run
     // the preselect logic once a worker is already set.
@@ -620,7 +672,7 @@ describe('createWorkerDialogContext getHomeDir accessor', () => {
     // (falsy) to decide whether to run fetchWorkers. With singleWorkerId='',
     // that path leaked through — fetchWorkers ran AND then attempted
     // setWorkerId(online[0].id), which the throwing wrapped setter
-    // (gated on `!== undefined`) rejected with "rejected — dialog is
+    // (which tests `!== undefined`) rejected with "rejected — dialog is
     // locked to ''". The fix is `locked = options.singleWorkerId !== undefined`,
     // matching the setter wrap's gate so the two stay in lockstep.
     vi.mocked(workerClient.listWorkers).mockResolvedValue({

--- a/frontend/src/hooks/createWorkerDialogContext.ts
+++ b/frontend/src/hooks/createWorkerDialogContext.ts
@@ -124,6 +124,14 @@ export function createWorkerDialogContext(options: WorkerDialogContextOptions = 
           ? online.find(b => b.id === options.preselectedWorkerId)
           : undefined
         setWorkerId((preferred ?? online[0]).id)
+        // The worker and the directory are ONE choice. A caller that gives both
+        // means "this directory ON THAT MACHINE"; when the machine turns out to
+        // be offline and another is substituted, the directory does not carry
+        // over -- an absolute path is a different place on a different machine,
+        // and the worse case is that it EXISTS there and is the wrong tree.
+        // Clearing it makes the dialog ask, which is the honest question.
+        if (options.preselectedWorkerId && !preferred && options.defaultWorkingDir)
+          setWorkingDir('')
       }
       return online.length > 0
     }

--- a/frontend/src/hooks/useGitModeState.test.ts
+++ b/frontend/src/hooks/useGitModeState.test.ts
@@ -342,7 +342,7 @@ describe('isChangeBranchMode', () => {
     // Defensive: `current` (excluded from CHANGE_BRANCH_MODES) and
     // `use-worktree` (a different dialog's mode) must both fail. A
     // dialog opened against an unseeded useGitModeState would briefly
-    // observe Current — the predicate rejects it so submit stays gated.
+    // observe Current — the predicate rejects it so submit stays refused.
     expect(isChangeBranchMode(GitMode.Current)).toBe(false)
     expect(isChangeBranchMode(GitMode.UseWorktree)).toBe(false)
   })
@@ -383,10 +383,10 @@ describe('fieldsForCheckoutBranch', () => {
     })
   })
 
-  it('forwards an empty target verbatim — the dialog gates submit, not this projection', () => {
-    // Defensive: the helper does not own validation. Submit-gating lives
+  it('forwards an empty target verbatim — the dialog controls submit, not this projection', () => {
+    // Defensive: the helper does not own validation. The submit rule lives
     // in dialogValidation. An empty checkoutBranch must round-trip
-    // verbatim so the gating layer can refuse it without a magic
+    // verbatim so the validating layer can refuse it without a magic
     // sentinel.
     expect(fieldsForCheckoutBranch({
       mode: GitMode.SwitchBranch,

--- a/frontend/src/hooks/useGitModeState.test.ts
+++ b/frontend/src/hooks/useGitModeState.test.ts
@@ -8,7 +8,12 @@ import {
   fieldsForCreateBranch,
   fieldsForCreateWorktree,
   fieldsForUseWorktree,
+  GIT_MODE_LABELS,
   GitMode,
+  gitModeFromToken,
+  gitModeMenuLabel,
+  gitModeToken,
+  initialIntentForMode,
   isChangeBranchMode,
   useGitModeState,
 } from '~/hooks/useGitModeState'
@@ -605,5 +610,100 @@ describe('changeBranchInitialIntent', () => {
   it('mints a fresh object per call, so a mutation cannot leak', () => {
     const first = changeBranchInitialIntent(GitMode.CreateBranch)
     expect(changeBranchInitialIntent(GitMode.CreateBranch)).not.toBe(first)
+  })
+})
+
+// ----- Labels and the serialized token -----
+//
+// Two tables keyed by GitMode, and both are exhaustive by construction
+// (`Record<GitMode, …>`). The pinned tuple below is what makes THAT claim
+// checkable from a test: a sixth mode fails the compile at the table and this
+// tuple, so neither can be updated alone.
+//
+// Do NOT iterate `Object.values(GitMode)` instead. An unannotated numeric enum
+// emits reverse mappings, so it yields TEN entries -- five names and five
+// numbers -- and type-checks clean as `GitMode[]`.
+const ALL_GIT_MODES = [
+  GitMode.Current,
+  GitMode.SwitchBranch,
+  GitMode.CreateBranch,
+  GitMode.CreateWorktree,
+  GitMode.UseWorktree,
+] as const
+
+describe('the mode label table (GIT_MODE_LABELS)', () => {
+  it('covers every mode of the pinned tuple', () => {
+    expect(Object.keys(GIT_MODE_LABELS).length).toBe(ALL_GIT_MODES.length)
+    for (const mode of ALL_GIT_MODES)
+      expect(GIT_MODE_LABELS[mode]).toBeTruthy()
+  })
+
+  it('gives every mode a distinct name', () => {
+    const labels = ALL_GIT_MODES.map(m => GIT_MODE_LABELS[m])
+    expect(new Set(labels).size).toBe(labels.length)
+  })
+})
+
+describe('gitModeMenuLabel', () => {
+  it('is the radio label plus the three dots a dialog-opening item carries', () => {
+    for (const mode of ALL_GIT_MODES)
+      expect(gitModeMenuLabel(mode)).toBe(`${GIT_MODE_LABELS[mode]}...`)
+  })
+
+  it('uses ASCII dots, not an ellipsis character', () => {
+    expect(gitModeMenuLabel(GitMode.SwitchBranch).endsWith('...')).toBe(true)
+    expect(gitModeMenuLabel(GitMode.SwitchBranch)).not.toContain('\u2026')
+  })
+})
+
+describe('gitModeToken / gitModeFromToken', () => {
+  it('round-trips every mode', () => {
+    for (const mode of ALL_GIT_MODES)
+      expect(gitModeFromToken(gitModeToken(mode))).toBe(mode)
+  })
+
+  it('mints a distinct token per mode', () => {
+    const tokens = ALL_GIT_MODES.map(m => gitModeToken(m))
+    expect(new Set(tokens).size).toBe(tokens.length)
+  })
+
+  it('never stores the enum NUMBER, which reordering would invalidate', () => {
+    for (const mode of ALL_GIT_MODES)
+      expect(Number.isNaN(Number(gitModeToken(mode)))).toBe(true)
+  })
+
+  it('refuses anything a previous build or a hand edit could have left behind', () => {
+    expect(gitModeFromToken(undefined)).toBeUndefined()
+    expect(gitModeFromToken(null)).toBeUndefined()
+    expect(gitModeFromToken('')).toBeUndefined()
+    expect(gitModeFromToken('no-such-mode')).toBeUndefined()
+    // A stored NUMBER is the exact shape this type exists to reject: it would
+    // resolve to a different mode after the enum is reordered.
+    expect(gitModeFromToken(0)).toBeUndefined()
+    expect(gitModeFromToken('0')).toBeUndefined()
+    expect(gitModeFromToken({ mode: 'current' })).toBeUndefined()
+  })
+})
+
+describe('initialIntentForMode', () => {
+  it('returns an intent carrying the requested mode, for all five', () => {
+    for (const mode of ALL_GIT_MODES)
+      expect(initialIntentForMode(mode).mode).toBe(mode)
+  })
+
+  it('leaves every value field empty, because GitOptions owns them', () => {
+    for (const mode of ALL_GIT_MODES) {
+      const intent = initialIntentForMode(mode) as Record<string, unknown>
+      for (const [key, value] of Object.entries(intent)) {
+        if (key === 'mode')
+          continue
+        expect(value === '' || value === null).toBe(true)
+      }
+    }
+  })
+
+  it('agrees with changeBranchInitialIntent on the three modes they share', () => {
+    for (const mode of CHANGE_BRANCH_MODES)
+      expect(changeBranchInitialIntent(mode)).toEqual(initialIntentForMode(mode))
   })
 })

--- a/frontend/src/hooks/useGitModeState.ts
+++ b/frontend/src/hooks/useGitModeState.ts
@@ -5,8 +5,12 @@ import { shallowEqual } from '~/lib/shallowEqual'
  * Identifiers for the GitOptions modes. Numeric enum (not string union)
  * so the comparison sites compile down to integer equality and TS
  * narrows discriminator-style switches exhaustively across the variants
- * of {@link GitModeIntent}. Values are frontend-only (never serialized
- * over the wire), so reordering is safe within this file.
+ * of {@link GitModeIntent}.
+ *
+ * The NUMBERS are frontend-only and never leave memory, so reordering the
+ * members stays safe. Anything that outlives the page -- the remembered
+ * per-repository mode in browser storage -- stores a {@link GitModeToken}
+ * instead, which is what keeps that promise true.
  */
 export enum GitMode {
   Current,
@@ -14,6 +18,120 @@ export enum GitMode {
   CreateBranch,
   CreateWorktree,
   UseWorktree,
+}
+
+/**
+ * The name each mode goes by, EVERYWHERE it is named.
+ *
+ * One table so the dialog's radio and the menu item that opens the dialog on
+ * that radio cannot drift: the item the user picks names what they then see.
+ * `GitOptions` and `BranchContextMenu` held nine literals between them before
+ * this, and pairing a mode with another mode's label was a plain typo away.
+ *
+ * `Record<GitMode, string>` makes a sixth mode a compile error rather than an
+ * item that renders `undefined`.
+ *
+ * It lives HERE rather than in `GitOptions.tsx` because `BranchContextMenu`
+ * renders once per branch row of every workspace, and `GitOptions.tsx` pulls in
+ * `random-word-slugs`, `workerRpc`, `BranchSelect`, `WorktreeSelect` and
+ * `validate`. This module imports `solid-js` and `~/lib/shallowEqual`, and both
+ * surfaces already import it -- so the table costs no new import edge.
+ */
+export const GIT_MODE_LABELS: Record<GitMode, string> = {
+  [GitMode.Current]: 'Use current state',
+  [GitMode.SwitchBranch]: 'Switch to branch',
+  [GitMode.CreateBranch]: 'Create new branch',
+  [GitMode.CreateWorktree]: 'Create new worktree',
+  [GitMode.UseWorktree]: 'Use existing worktree',
+}
+
+/**
+ * The serialized spelling of a mode, for anything that outlives the page.
+ *
+ * A token rather than the enum's number, because {@link GitMode}'s own doc
+ * licenses reordering its members -- and it can only keep doing so while no
+ * stored value depends on the numbering. A stale number would silently select
+ * a different mode after a reorder; a stale token resolves to nothing and the
+ * caller falls back.
+ */
+export type GitModeToken
+  = | 'current'
+    | 'switch-branch'
+    | 'create-branch'
+    | 'create-worktree'
+    | 'use-worktree'
+
+/**
+ * A `Record`, so a sixth mode is a compile error rather than a mode that
+ * silently cannot be remembered.
+ */
+const GIT_MODE_TOKENS: Record<GitMode, GitModeToken> = {
+  [GitMode.Current]: 'current',
+  [GitMode.SwitchBranch]: 'switch-branch',
+  [GitMode.CreateBranch]: 'create-branch',
+  [GitMode.CreateWorktree]: 'create-worktree',
+  [GitMode.UseWorktree]: 'use-worktree',
+}
+
+/** The token to store for `mode`. */
+export function gitModeToken(mode: GitMode): GitModeToken {
+  return GIT_MODE_TOKENS[mode]
+}
+
+/**
+ * The mode a stored token names, or undefined for anything else.
+ *
+ * `unknown` rather than `GitModeToken`, because the argument comes back off the
+ * wire of browser storage: a previous build, a hand edit, or a truncated write
+ * can put any JSON there.
+ */
+export function gitModeFromToken(stored: unknown): GitMode | undefined {
+  if (typeof stored !== 'string')
+    return undefined
+  for (const [mode, token] of Object.entries(GIT_MODE_TOKENS)) {
+    if (token === stored)
+      return Number(mode) as GitMode
+  }
+  return undefined
+}
+
+/**
+ * The seed intent for a dialog opened directly on `mode`.
+ *
+ * Every field is empty, because the values belong to GitOptions: it owns the
+ * branch picker, the name input and the base-branch picker, and it emits a
+ * complete intent for its active mode on its first flush. What this seed
+ * carries is the MODE alone, which GitOptions reads once (untracked) to paint
+ * the correct radio on the first render.
+ *
+ * A dialog that seeds nothing paints its default mode first and swaps a moment
+ * later, so every menu item that opens the dialog on its own mode would flash
+ * the same one before landing.
+ */
+export function initialIntentForMode(mode: GitMode): GitModeIntent {
+  switch (mode) {
+    case GitMode.Current:
+      return { mode }
+    case GitMode.SwitchBranch:
+      return { mode, checkoutBranch: '', checkoutBranchError: null }
+    case GitMode.CreateBranch:
+      return { mode, createBranch: '', createBranchError: null, createBranchBase: '' }
+    case GitMode.CreateWorktree:
+      return { mode, worktreeBranch: '', worktreeBranchError: null, worktreeBaseBranch: '' }
+    case GitMode.UseWorktree:
+      return { mode, useWorktreePath: '' }
+  }
+}
+
+/**
+ * The same name as a MENU item that opens a dialog on that mode.
+ *
+ * The three ASCII dots are the whole difference from {@link GIT_MODE_LABELS},
+ * and they belong to the menu: an item that opens a dialog says so, and a radio
+ * inside that dialog does not.
+ */
+export function gitModeMenuLabel(mode: GitMode): string {
+  return `${GIT_MODE_LABELS[mode]}...`
 }
 
 /**
@@ -56,25 +174,12 @@ export function isChangeBranchMode(mode: GitMode): mode is ChangeBranchMode {
 /**
  * The seed intent for a ChangeBranchDialog opened directly on `mode`.
  *
- * Every field is empty, because the values belong to GitOptions: it owns the
- * branch picker, the name input and the base-branch picker, and it emits a
- * complete intent for its active mode on its first flush. What this seed
- * carries is the MODE alone, which GitOptions reads once (untracked) to paint
- * the correct radio on the first render.
- *
- * A dialog that seeds nothing paints `SwitchBranch` first and swaps a moment
- * later, so the three menu items that open this dialog would all flash the
- * same mode before landing on their own.
+ * A narrowing delegate to {@link initialIntentForMode}, which covers all five
+ * modes. The narrow signature is what the dialog wants -- it offers three -- and
+ * a second copy of the per-mode field lists is what this avoids.
  */
 export function changeBranchInitialIntent(mode: ChangeBranchMode): GitModeIntent {
-  switch (mode) {
-    case GitMode.SwitchBranch:
-      return { mode, checkoutBranch: '', checkoutBranchError: null }
-    case GitMode.CreateBranch:
-      return { mode, createBranch: '', createBranchError: null, createBranchBase: '' }
-    case GitMode.CreateWorktree:
-      return { mode, worktreeBranch: '', worktreeBranchError: null, worktreeBaseBranch: '' }
-  }
+  return initialIntentForMode(mode)
 }
 
 export interface GitFields {

--- a/frontend/src/hooks/useGitPathInfo.test.ts
+++ b/frontend/src/hooks/useGitPathInfo.test.ts
@@ -759,5 +759,106 @@ describe('useGitPathInfo', () => {
         })
       })
     })
+
+    it('keeps the seed while the worker id has not arrived yet', async () => {
+      // A pre-filled dialog mounts with `workerId() === ''`:
+      // `createWorkerDialogContext` resolves the id from `listWorkers`, and it
+      // must stay empty until then so submit cannot arm against a worker that
+      // is not online. This branch runs in that window, and discarding the
+      // seed there left showGitOptions() false -- so `skipLoadingFlash` did
+      // not fire and the dialog painted the spinner it was seeded to avoid.
+      await new Promise<void>((done) => {
+        createRoot(async (dispose) => {
+          const [workerId] = createSignal('')
+          const [path] = createSignal('/repo')
+          const info = useGitPathInfo(workerId, path, {
+            seed: { isGitRepo: true, isRepoRoot: true, currentBranch: 'main' },
+          })
+          await flush()
+          expect(getGitInfo).not.toHaveBeenCalled()
+          expect(info.showGitOptions()).toBe(true)
+          expect(info.info().currentBranch).toBe('main')
+          dispose()
+          done()
+        })
+      })
+    })
+
+    it('shows no spinner when the worker id lands on a seeded snapshot', async () => {
+      // `skipLoadingFlash` reads showGitOptions(), so keeping the seed is what
+      // makes the probe silent. This is the user-visible half of the test
+      // above.
+      const probe = deferred<GetGitInfoResponse>()
+      getGitInfo.mockReturnValueOnce(probe.promise)
+      await new Promise<void>((done) => {
+        createRoot(async (dispose) => {
+          const [workerId, setWorkerId] = createSignal('')
+          const [path] = createSignal('/repo')
+          const info = useGitPathInfo(workerId, path, {
+            seed: { isGitRepo: true, isRepoRoot: true, currentBranch: 'main' },
+          })
+          await flush()
+          setWorkerId('A')
+          await flush()
+          expect(getGitInfo).toHaveBeenCalledTimes(1)
+          expect(info.loading()).toBe(false)
+          expect(info.showGitOptions()).toBe(true)
+          probe.resolve(gitResp({ currentBranch: 'feature-x' }))
+          await flush()
+          expect(info.info().currentBranch).toBe('feature-x')
+          dispose()
+          done()
+        })
+      })
+    })
+
+    it('drops the seed once a probe answered and the worker id is cleared', async () => {
+      // The other half of the rule: after a real answer the seed is
+      // superseded, so clearing the worker must clear the snapshot rather than
+      // resurrecting the repository the dialog no longer targets.
+      getGitInfo.mockResolvedValueOnce(gitResp({ currentBranch: 'feature-x' }))
+      await new Promise<void>((done) => {
+        createRoot(async (dispose) => {
+          const [workerId, setWorkerId] = createSignal('')
+          const [path] = createSignal('/repo')
+          const info = useGitPathInfo(workerId, path, {
+            seed: { isGitRepo: true, isRepoRoot: true, currentBranch: 'main' },
+          })
+          setWorkerId('A')
+          await flush()
+          expect(info.info().currentBranch).toBe('feature-x')
+
+          setWorkerId('')
+          await flush()
+          expect(info.info().isGitRepo).toBe(false)
+          expect(info.info().currentBranch).toBe('')
+          expect(info.showGitOptions()).toBe(false)
+          dispose()
+          done()
+        })
+      })
+    })
+
+    it('drops the seed once a probe FAILED and the worker id is cleared', async () => {
+      getGitInfo.mockRejectedValueOnce(new Error('boom'))
+      await new Promise<void>((done) => {
+        createRoot(async (dispose) => {
+          const [workerId, setWorkerId] = createSignal('')
+          const [path] = createSignal('/repo')
+          const info = useGitPathInfo(workerId, path, {
+            seed: { isGitRepo: true, isRepoRoot: true, currentBranch: 'main' },
+          })
+          setWorkerId('A')
+          await flush()
+          expect(info.showGitOptions()).toBe(false)
+
+          setWorkerId('')
+          await flush()
+          expect(info.info().isGitRepo).toBe(false)
+          dispose()
+          done()
+        })
+      })
+    })
   })
 })

--- a/frontend/src/hooks/useGitPathInfo.test.ts
+++ b/frontend/src/hooks/useGitPathInfo.test.ts
@@ -241,7 +241,7 @@ describe('useGitPathInfo', () => {
         expect(remap).toHaveBeenCalledTimes(1)
         expect(remap).toHaveBeenCalledWith('/main/repo')
         // Second probe lands on the canonical repo root — remap must
-        // NOT fire again (it's one-shot, gated on the firstProbeSeen flag).
+        // NOT fire again (it's one-shot, and the firstProbeSeen flag controls it).
         expect(getGitInfo).toHaveBeenCalledTimes(2)
         expect(remap).toHaveBeenCalledTimes(1)
         dispose()
@@ -341,7 +341,7 @@ describe('useGitPathInfo', () => {
   })
 
   it('remapWorktreeRoot option: stays one-shot even when a later probe also returns isWorktreeRoot=true', async () => {
-    // The remap is gated on the firstProbeSeen flag. Once the first
+    // The firstProbeSeen flag controls the remap. Once the first
     // probe lands (worktree or not), subsequent worktree-root probes
     // must NOT fire it again — otherwise a worker/path switch could
     // spuriously rewrite the user's chosen working dir.

--- a/frontend/src/hooks/useGitPathInfo.ts
+++ b/frontend/src/hooks/useGitPathInfo.ts
@@ -126,6 +126,14 @@ export function useGitPathInfo(
   let firstProbeSeen = false
   let firstProbeWorkerId = ''
 
+  // Whether ANY probe has answered for this hook, success or failure.
+  //
+  // Distinct from `firstProbeSeen`, which is a per-(worker, path) gate that
+  // `fetch()` deliberately rewinds when either goes empty. This one only ever
+  // goes true, and it is what tells a seed that is still the caller's best
+  // knowledge from one that a real answer already replaced.
+  let probeAnswered = false
+
   // Memo so downstream `on()` effects don't refire when info() updates
   // without changing the boolean (e.g. the post-seed probe lands and
   // fills in currentBranch but showGitOptions stays true).
@@ -173,6 +181,7 @@ export function useGitPathInfo(
         if (!shallowEqual(info(), next))
           setInfo(next)
       }
+      probeAnswered = true
       if (!firstProbeSeen) {
         firstProbeSeen = true
         firstProbeWorkerId = args.wid
@@ -189,6 +198,7 @@ export function useGitPathInfo(
       // cancel, transient network) and the user manually navigates to
       // a canonical path before the next probe lands, we shouldn't
       // remap them out of their explicit choice.
+      probeAnswered = true
       firstProbeSeen = true
       firstProbeWorkerId = args.wid
     },
@@ -203,7 +213,22 @@ export function useGitPathInfo(
     const wid = workerId()
     const p = path()
     if (!wid || !p) {
-      resetToEmpty()
+      // KEEP a seed that no probe has answered yet.
+      //
+      // A dialog opened against a known repo passes `seed`, but its worker id
+      // arrives one tick later -- `createWorkerDialogContext` resolves it from
+      // `listWorkers`, and it must stay '' until then so `dialogValidation`
+      // cannot arm submit against a worker that is not online. This branch runs
+      // in that window, and discarding the seed there left `info()` empty, so
+      // `showGitOptions()` was false, so `skipLoadingFlash` did not fire -- and
+      // a pre-filled dialog painted the "Loading branch info" spinner it was
+      // seeded to avoid.
+      //
+      // Once a probe HAS answered, the seed is superseded and clearing is
+      // correct: the caller cleared the worker or the path, and the last-known
+      // repository is no longer what the form is about.
+      if (!options.seed || probeAnswered)
+        resetToEmpty()
       firstProbeSeen = false
       firstProbeWorkerId = ''
       await fetcher.run(null)

--- a/frontend/src/hooks/useWorkspaceConnection.repoGit.test.ts
+++ b/frontend/src/hooks/useWorkspaceConnection.repoGit.test.ts
@@ -136,7 +136,7 @@ function mountConnection() {
  * promoted to FULL.
  *
  * Meanwhile `Tab.gitToplevel` survives the outage untouched, and
- * `WorkspaceTabTree.repoKeyAndLabel` groups a tab by that field alone. So the
+ * `branchKeys.repoKeyAndLabel` groups a tab by that field alone. So the
  * sidebar kept the repo group and moved every tab under it to the no-branch
  * bucket, until the user clicked the tab or the Files refresh button.
  *

--- a/frontend/src/hooks/useWorkspaceConnection.ts
+++ b/frontend/src/hooks/useWorkspaceConnection.ts
@@ -45,7 +45,7 @@ function warnChatHistoryLoadFailed(err: unknown): void {
 /**
  * Which tabs a worker going offline affects.
  *
- * Both arms filter on `workerId`, and that is the whole point: this walks
+ * Both cases filter on `workerId`, and that is the whole point: this walks
  * `view.all()` — every tab in the ACCOUNT, not one workspace — so a tab hosted
  * by any other worker is still perfectly connected.
  */
@@ -506,7 +506,7 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
   // its own side.
   //
   // A sweep here removed the branch with no way back. `Tab.gitToplevel`
-  // outlives the outage, and `WorkspaceTabTree.repoKeyAndLabel` groups a tab by
+  // outlives the outage, and `branchKeys.repoKeyAndLabel` groups a tab by
   // that field alone. The branch label comes from this store. A dropped entry
   // therefore put every tab of that worker under its repo with no branch name.
   //

--- a/frontend/src/lib/accountScopedSignal.ts
+++ b/frontend/src/lib/accountScopedSignal.ts
@@ -1,0 +1,124 @@
+import { createEffect, createRoot, createSignal } from 'solid-js'
+import { hasStorageAccount, onStorageAccountChange } from '~/lib/browserStorage'
+
+/**
+ * How a value survives a reload, for {@link createAccountScopedSignal}.
+ *
+ * Omit it for state that must NOT outlive the page: the signal then keeps the
+ * account scoping and the reset, and writes nothing.
+ */
+export interface AccountScopedPersistence<T> {
+  /** Read the stored value for the CURRENT account. */
+  read: () => T
+  /** Write `value` under the current account. */
+  write: (value: T) => void
+}
+
+export interface AccountScopedSignal<T> {
+  /** The current value. Reactive. Seeds from storage on the first access. */
+  get: () => T
+  set: (next: T | ((prev: T) => T)) => void
+  /** Drop the mirror and re-read. FOR TESTS ONLY. */
+  reset: () => void
+}
+
+/**
+ * A module-scope signal that belongs to the signed-in account.
+ *
+ * Several sidebar modules need the same four things, and each hand-rolled copy
+ * was a place to get one of them wrong:
+ *
+ *  - ONE signal for the whole app, because the value is one document under one
+ *    key and several components read it at once. A per-component signal wrote
+ *    the whole value back with no merge and erased what the others held.
+ *  - A LAZY first read. The module is imported when the bundle loads, and
+ *    `AuthContext` calls `setStorageAccount` only once the identity resolves;
+ *    an account-scoped read before that throws.
+ *  - A persist effect that stays quiet until that first read, so it cannot
+ *    overwrite a stored value the module has not seen.
+ *  - A re-read when the account namespace moves, because the mirror belongs to
+ *    the account it was read for.
+ *
+ * `createRoot`, because module scope has no owner: the effect would otherwise
+ * be created outside any reactive root, never dispose, and log Solid's
+ * "computations created outside a `createRoot`" warning. The root is never
+ * disposed on purpose -- it lives as long as the module does.
+ */
+export function createAccountScopedSignal<T>(
+  defaultValue: T,
+  persist?: AccountScopedPersistence<T>,
+): AccountScopedSignal<T> {
+  /**
+   * Whether storage was read for the CURRENT account yet.
+   *
+   * Declared ahead of the `createRoot` below: Solid flushes the root's effects
+   * at the end of that call, so the persist effect reads this binding while
+   * this function is still running.
+   */
+  let seeded = false
+
+  const [value, setValue] = createRoot(() => {
+    const [read, write] = createSignal<T>(defaultValue)
+    if (persist) {
+      createEffect(() => {
+        const current = read()
+        // Skip until the first read landed. Before an account is set a write
+        // throws, and writing the placeholder would erase the stored value.
+        if (!seeded)
+          return
+        persist.write(current)
+      })
+    }
+    return [read, write] as const
+  })
+
+  function ensureSeeded(): void {
+    if (seeded || !hasStorageAccount())
+      return
+    seeded = true
+    if (persist)
+      setValue(() => persist.read())
+  }
+
+  // The namespace moved, so the mirror belongs to the account that left.
+  //
+  // It re-seeds EAGERLY rather than waiting for the next access. Writing the
+  // default alone is a no-op whenever that default is a module-level constant:
+  // Solid's default equality is `===`, so the write notifies nobody and every
+  // computation already subscribed keeps the previous account's value. Reading
+  // the incoming account here notifies whenever the two differ.
+  //
+  // `setStorageAccount` assigns the account before it notifies, so
+  // `hasStorageAccount()` is already true inside this callback.
+  const onAccountMoved = () => {
+    seeded = false
+    setValue(() => defaultValue)
+    ensureSeeded()
+  }
+
+  // Through a NAMED function, so `reset` can register it again.
+  onStorageAccountChange(onAccountMoved)
+
+  return {
+    get: () => {
+      ensureSeeded()
+      return value()
+    },
+    set: (next) => {
+      ensureSeeded()
+      setValue(typeof next === 'function' ? (next as (prev: T) => T) : () => next)
+    },
+    reset: () => {
+      seeded = false
+      setValue(() => defaultValue)
+      // `resetStorageAccountForTests` CLEARS every account listener, and the
+      // suite runs it before each test -- so a module that subscribed at import
+      // time is unsubscribed for the whole file, and its account-switch
+      // behaviour disappears from every test with no failure to show for it.
+      // Registering again here is what makes that behaviour reachable at all.
+      // The listeners live in a Set keyed by reference, so this is a no-op in
+      // production, where nothing calls `reset`.
+      onStorageAccountChange(onAccountMoved)
+    },
+  }
+}

--- a/frontend/src/lib/browserStorage.ts
+++ b/frontend/src/lib/browserStorage.ts
@@ -163,6 +163,7 @@ export const KEY_KEY_PINS = 'key-pins'
 export const KEY_DIRECTORY_SELECTOR_SHOW_HIDDEN = 'directory-selector-show-hidden'
 export const KEY_PREFERRED_EDITOR = 'preferred-editor'
 export const KEY_ACTIVE_WORKSPACE = 'active-workspace'
+export const KEY_WORKSPACE_SORT = 'workspace-sort'
 export const KEY_USER_EVENTS_RELAY_SEQ = 'user-events-relay-seq'
 export const KEY_CHANNEL_RELAY_SEQ = 'channel-relay-seq'
 
@@ -287,6 +288,10 @@ export const LOCAL_KEY_SPECS = {
   // only record of where the app should reopen, since the URL no longer carries
   // the workspace id.
   [KEY_ACTIVE_WORKSPACE]: { match: 'exact', scope: 'account', ttlMs: YEAR_MS },
+  // How the sidebar orders every workspace section. A preference the user set
+  // once, like the browser preferences above -- so a year, not the seven days a
+  // per-directory cache takes.
+  [KEY_WORKSPACE_SORT]: { match: 'exact', scope: 'account', ttlMs: YEAR_MS },
   // High-water mark for the desktop userevents relay ids (see useUserEvents).
   // Device-scoped: see the note above the table.
   [KEY_USER_EVENTS_RELAY_SEQ]: { match: 'exact', scope: 'device', ttlMs: YEAR_MS },

--- a/frontend/src/lib/browserStorage.ts
+++ b/frontend/src/lib/browserStorage.ts
@@ -175,6 +175,7 @@ export const PREFIX_WORKER_INFO = 'worker-info:'
 export const PREFIX_LOCAL_MESSAGES = 'local-messages:'
 export const PREFIX_FILES_SHOW_HIDDEN = 'files-show-hidden:'
 export const PREFIX_FILES_SORT_ORDER = 'files-sort-order:'
+export const PREFIX_WORKSPACE_GIT_MODE = 'workspace-git-mode:'
 export const PREFIX_CHAT_ROW_HEIGHTS = 'chat-row-heights:'
 
 /** sessionStorage dynamic key prefixes. */
@@ -301,6 +302,12 @@ export const LOCAL_KEY_SPECS = {
   [PREFIX_LOCAL_MESSAGES]: { match: 'prefix', scope: 'account', ttlMs: 7 * DAY_MS },
   [PREFIX_FILES_SHOW_HIDDEN]: { match: 'prefix', scope: 'account', ttlMs: 7 * DAY_MS },
   [PREFIX_FILES_SORT_ORDER]: { match: 'prefix', scope: 'account', ttlMs: 7 * DAY_MS },
+  // The git mode a repository was last started with, keyed by
+  // `<workerId>:<gitToplevel>` (see `gitModeStickyKey`). The TTL is the only
+  // thing limiting growth -- there is one entry per repository the user ever
+  // starts a workspace in -- and `readDynamic` refreshes it on read, so a
+  // repository in weekly use never expires while an abandoned one does.
+  [PREFIX_WORKSPACE_GIT_MODE]: { match: 'prefix', scope: 'account', ttlMs: 7 * DAY_MS },
   // Measured chat-row heights (see chatRowHeightPersistence). A warm-start
   // cache: stale entries are harmless (each row's key digest must match its
   // live heightKey to hydrate), so the TTL only limits storage growth.

--- a/frontend/src/lib/externalEditors.ts
+++ b/frontend/src/lib/externalEditors.ts
@@ -102,10 +102,25 @@ export function resolvePreferredEditor(
   pinned: string | undefined,
   persist: (id: string) => void,
 ): DetectedEditor | undefined {
-  if (editors.length === 0)
-    return undefined
-  const target = editors.find(e => e.id === pinned) ?? editors[0]
-  if (target.id !== pinned)
+  const target = preferredEditor(editors, pinned)
+  if (target && target.id !== pinned)
     persist(target.id)
   return target
+}
+
+/**
+ * The same pick, WITHOUT the write.
+ *
+ * For a caller that only has to NAME the editor -- a menu item that reads
+ * "Open in Zed" -- and must not persist anything while it merely renders.
+ * Split out rather than re-derived at that call site, so the label and the
+ * launch cannot disagree about which editor "the default" is.
+ */
+export function preferredEditor(
+  editors: DetectedEditor[],
+  pinned: string | undefined,
+): DetectedEditor | undefined {
+  if (editors.length === 0)
+    return undefined
+  return editors.find(e => e.id === pinned) ?? editors[0]
 }

--- a/frontend/src/lib/fileSort.test.ts
+++ b/frontend/src/lib/fileSort.test.ts
@@ -2,6 +2,7 @@ import type { FileSortFields, FileSortOrder } from './fileSort'
 import { describe, expect, it } from 'vitest'
 import {
   compareNames,
+  compareOptionalValue,
   DEFAULT_FILE_SORT_ORDER,
   fileExtension,
   makeFileComparator,
@@ -303,5 +304,41 @@ describe('makeFileComparator', () => {
         expect(sorted(entries, o), `${key}/${direction}`).toEqual(sorted(entries.toReversed(), o))
       }
     }
+  })
+})
+
+// The rule both sorts share, stated once. `undefined` for a tie is what lets a
+// caller write `compareOptionalValue(...) ?? byName(a, b)` without `??`
+// swallowing a real comparison result of 0.
+describe('compareOptionalValue', () => {
+  it('orders two present values, and flips with the direction', () => {
+    expect(compareOptionalValue(1, 2, 1)).toBe(-1)
+    expect(compareOptionalValue(1, 2, -1)).toBe(1)
+  })
+
+  it('answers undefined for a tie, so the caller breaks it', () => {
+    expect(compareOptionalValue(5, 5, 1)).toBeUndefined()
+    expect(compareOptionalValue(undefined, undefined, 1)).toBeUndefined()
+  })
+
+  // The pin happens BEFORE the direction flip, so "unknown" never migrates to
+  // the top under `desc`.
+  it('sorts an absent value LAST under both directions', () => {
+    expect(compareOptionalValue(undefined, 5, 1)).toBe(1)
+    expect(compareOptionalValue(undefined, 5, -1)).toBe(1)
+    expect(compareOptionalValue(5, undefined, 1)).toBe(-1)
+    expect(compareOptionalValue(5, undefined, -1)).toBe(-1)
+  })
+
+  // A real 0 is a value, not an absence -- which is why the caller maps its
+  // own "absent" spelling to `undefined` rather than relying on falsiness.
+  it('treats 0 as a present value', () => {
+    expect(compareOptionalValue(0, 5, 1)).toBe(-1)
+    expect(compareOptionalValue(0, undefined, 1)).toBe(-1)
+  })
+
+  it('orders strings the same way', () => {
+    expect(compareOptionalValue('a', 'b', 1)).toBe(-1)
+    expect(compareOptionalValue('b', 'a', 1)).toBe(1)
   })
 })

--- a/frontend/src/lib/fileSort.ts
+++ b/frontend/src/lib/fileSort.ts
@@ -129,6 +129,37 @@ export interface FileSortFields<T> {
 }
 
 /**
+ * Compare two optional values, or `undefined` when the caller must break the
+ * tie itself.
+ *
+ * The rule both this module and `~/lib/workspaceSort` need, stated once: an
+ * ABSENT value sorts LAST under both directions, because the pin happens before
+ * the direction flip -- so "unknown" never migrates to the top. Two present and
+ * equal values, and two absent ones, are a tie.
+ *
+ * It answers `undefined` for a tie rather than `0`, so a caller can write
+ * `compareOptionalValue(...) ?? byName(a, b)` without `??` swallowing a real
+ * comparison result of `0`.
+ *
+ * A caller whose "absent" is an empty string rather than `undefined` passes
+ * `value || undefined`, which keeps that choice at the call site.
+ */
+export function compareOptionalValue<V extends string | number>(
+  av: V | undefined,
+  bv: V | undefined,
+  flip: number,
+): number | undefined {
+  if (av === undefined || bv === undefined) {
+    if (av === bv)
+      return undefined
+    return av === undefined ? 1 : -1
+  }
+  if (av === bv)
+    return undefined
+  return (av < bv ? -1 : 1) * flip
+}
+
+/**
  * Builds the comparator for one sort order.
  *
  * The rules, in order:
@@ -160,32 +191,23 @@ export function makeFileComparator<T>(order: FileSortOrder, fields: FileSortFiel
     switch (order.key) {
       case 'name':
         return byName(a, b) * flip
-      case 'size': {
-        const aSize = fields.size(a)
-        const bSize = fields.size(b)
-        if (aSize === undefined || bSize === undefined) {
-          if (aSize !== bSize)
-            return aSize === undefined ? 1 : -1
-          return byName(a, b)
-        }
-        return (aSize === bSize ? byName(a, b) : (aSize < bSize ? -1 : 1) * flip)
-      }
-      case 'modified': {
-        const aTime = fields.modTime(a)
-        const bTime = fields.modTime(b)
-        if (!aTime || !bTime) {
-          if (Boolean(aTime) !== Boolean(bTime))
-            return aTime ? -1 : 1
-          return byName(a, b)
-        }
+      case 'size':
+        // A size of 0 is a real size, so only `undefined` counts as absent.
+        return compareOptionalValue(fields.size(a), fields.size(b), flip) ?? byName(a, b)
+      case 'modified':
         // The worker writes every modification time in one fixed-width UTC
         // layout (`modTimeLayout` in the worker's file.go: RFC3339 with all
         // nine nanosecond digits), so a lexicographic compare is a
         // chronological one and needs no parsing. Anything that varies the
         // width -- a stock RFC3339Nano, which trims trailing zeros -- silently
         // breaks that.
-        return aTime === bTime ? byName(a, b) : (aTime < bTime ? -1 : 1) * flip
-      }
+        //
+        // An EMPTY string means "not reported", so it maps to `undefined`.
+        return compareOptionalValue(
+          fields.modTime(a) || undefined,
+          fields.modTime(b) || undefined,
+          flip,
+        ) ?? byName(a, b)
       case 'type': {
         const aExt = fileExtension(fields.name(a))
         const bExt = fileExtension(fields.name(b))

--- a/frontend/src/lib/lexorank.test.ts
+++ b/frontend/src/lib/lexorank.test.ts
@@ -147,3 +147,35 @@ describe('appendPosition', () => {
     expect([...ranks].sort()).toEqual(ranks)
   })
 })
+
+describe('mid with a descending pair', () => {
+  // `between` subtracts one character code from another to find a gap. Given a
+  // descending pair it reported a gap where there was none: for two adjacent
+  // characters it answered a rank EQUAL to the lower bound, which collides with
+  // the row that bound names, and two rows that share a rank are ordered by
+  // whatever the SQL planner picks.
+  //
+  // The Go original computes the same subtraction on a `byte`, so a descending
+  // pair wrapped there instead of going negative -- the two ports disagreed on
+  // the same input. Both now normalize the pair.
+  const descending: readonly (readonly [string, string])[] = [
+    ['nng', 'nn'], // a custom section dragged below Archived
+    ['o', 'n'], // adjacent characters: the collision case
+    ['n', 'a'],
+    ['zz', 'aa'],
+    ['nn', 'n'],
+  ]
+
+  it('answers a rank strictly between the two, whichever order they arrive in', () => {
+    for (const [hi, lo] of descending) {
+      const m = mid(hi, lo)
+      expect(m > lo, `mid(${hi}, ${lo}) = ${m} must sort after ${lo}`).toBe(true)
+      expect(m < hi, `mid(${hi}, ${lo}) = ${m} must sort before ${hi}`).toBe(true)
+    }
+  })
+
+  it('does not depend on the argument order', () => {
+    for (const [hi, lo] of descending)
+      expect(mid(hi, lo)).toBe(mid(lo, hi))
+  })
+})

--- a/frontend/src/lib/lexorank.ts
+++ b/frontend/src/lib/lexorank.ts
@@ -78,7 +78,18 @@ function before(s: string): string {
   return s.slice(0, -1) + MIN_CHAR + MID_CHAR
 }
 
+/**
+ * A rank between `a` and `b`, where `a < b`.
+ *
+ * A descending pair is normalized rather than trusted. The midpoint test below
+ * subtracts one character code from another; for two adjacent characters a
+ * descending pair answers a rank EQUAL to `b`, which collides with the row `b`
+ * names. The Go original computes the same subtraction on a `byte`, where a
+ * descending pair wraps instead — so the two implementations disagreed as well.
+ */
 function between(a: string, b: string): string {
+  if (a >= b)
+    [a, b] = [b, a]
   const maxLen = Math.max(a.length, b.length)
   const pa = padRight(a, maxLen)
   const pb = padRight(b, maxLen)

--- a/frontend/src/lib/workerLocality.test.ts
+++ b/frontend/src/lib/workerLocality.test.ts
@@ -1,0 +1,36 @@
+import type { Worker } from '~/generated/proto/leapmux/v1/worker_pb'
+import { describe, expect, it } from 'vitest'
+import { isLocalWorker } from './workerLocality'
+
+function worker(id: string, autoRegistered: boolean): Worker {
+  return { id, autoRegistered } as Worker
+}
+
+const WORKERS = [worker('local', true), worker('remote', false)]
+
+describe('isLocalWorker', () => {
+  it('accepts the auto-registered worker of a solo desktop', () => {
+    expect(isLocalWorker(WORKERS, 'local', true)).toBe(true)
+  })
+
+  it('refuses a registered remote worker even on a solo desktop', () => {
+    expect(isLocalWorker(WORKERS, 'remote', true)).toBe(false)
+  })
+
+  it('refuses every worker when the shell is not solo', () => {
+    expect(isLocalWorker(WORKERS, 'local', false)).toBe(false)
+    expect(isLocalWorker(WORKERS, 'remote', false)).toBe(false)
+  })
+
+  it('refuses a worker id the list does not mention', () => {
+    expect(isLocalWorker(WORKERS, 'gone', true)).toBe(false)
+  })
+
+  it('refuses an empty worker id', () => {
+    expect(isLocalWorker(WORKERS, '', true)).toBe(false)
+  })
+
+  it('refuses when the list is empty', () => {
+    expect(isLocalWorker([], 'local', true)).toBe(false)
+  })
+})

--- a/frontend/src/lib/workerLocality.ts
+++ b/frontend/src/lib/workerLocality.ts
@@ -1,0 +1,43 @@
+import type { Worker } from '~/generated/proto/leapmux/v1/worker_pb'
+
+/**
+ * Whether a worker runs on THIS machine, so a path it reports names a
+ * directory the local Finder and the local editor can open.
+ *
+ * The one place that answers it, because the answer gates two bridge calls
+ * that are silently wrong otherwise: `revealInFileManager` and `openInEditor`
+ * always act locally, and a workspace's repository commonly lives on a remote
+ * worker where the same absolute path either does not exist or -- worse --
+ * exists and is a different directory.
+ *
+ * Two conditions, both required:
+ *
+ *  - `localSolo`: the desktop shell runs its own bundled sidecar, so "this
+ *    machine" is a thing at all. A browser tab pointed at a remote hub has no
+ *    local anything.
+ *  - `autoRegistered`: the worker IS that bundled sidecar. A solo desktop can
+ *    also hold registrations for remote machines, and those are not local.
+ *
+ * It lives here rather than in `~/lib/workerLiveness`, whose doc promises it
+ * never probes anything beyond the `Worker` proto -- this asks the desktop
+ * shell as well, through the caller.
+ *
+ * `localSolo` is a PARAMETER rather than a read, because `getRuntimeState()` is
+ * async and reaches components through a `createResource`. A synchronous
+ * accessor cannot read it.
+ *
+ * Do NOT add an `isTauriApp()` term. Its absence at `OpenInEditorButton` is
+ * deliberate and documented: under `task dev-desktop` the webview points at
+ * http://localhost:4328, so a URL check misclassifies a solo run as non-solo.
+ * `localSolo` comes from the Rust shell's own capability flag and is the whole
+ * gate.
+ */
+export function isLocalWorker(
+  workers: readonly Worker[],
+  workerId: string,
+  localSolo: boolean,
+): boolean {
+  if (!localSolo || !workerId)
+    return false
+  return workers.find(w => w.id === workerId)?.autoRegistered === true
+}

--- a/frontend/src/lib/workerLocality.ts
+++ b/frontend/src/lib/workerLocality.ts
@@ -4,7 +4,7 @@ import type { Worker } from '~/generated/proto/leapmux/v1/worker_pb'
  * Whether a worker runs on THIS machine, so a path it reports names a
  * directory the local Finder and the local editor can open.
  *
- * The one place that answers it, because the answer gates two bridge calls
+ * The one place that answers it, because the answer controls two bridge calls
  * that are silently wrong otherwise: `revealInFileManager` and `openInEditor`
  * always act locally, and a workspace's repository commonly lives on a remote
  * worker where the same absolute path either does not exist or -- worse --

--- a/frontend/src/lib/workerPaths.ts
+++ b/frontend/src/lib/workerPaths.ts
@@ -1,0 +1,31 @@
+import type { PathFlavor } from '~/lib/paths'
+import type { WorkerInfo } from '~/lib/workerInfoCache'
+import { flavorFromOs, tildify } from '~/lib/paths'
+
+/**
+ * The path flavor to shorten a worker's paths with, or undefined when the
+ * worker has not reported its OS.
+ *
+ * Undefined rather than a default, because `flavorFromOs(undefined)` answers
+ * `'posix'` -- which would force posix onto a Windows worker with no system
+ * info yet, and stop `C:\Users\u\repo` from compressing at all. Undefined lets
+ * `tildify` sniff the flavor from the path instead.
+ */
+export function workerPathFlavor(info: WorkerInfo | null | undefined): PathFlavor | undefined {
+  return info?.os ? flavorFromOs(info.os) : undefined
+}
+
+/**
+ * Tilde-compress a worker-side absolute path for display.
+ *
+ * ONE spelling of the rule for every surface that shows a worker's path: the
+ * sidebar tree's branch-collision suffix, its row tooltip, and the section
+ * header menu's repository rows. Two copies let a row read `~/repos/foo` while
+ * its tooltip reads `/Users/x/repos/foo`.
+ *
+ * Returns the path unchanged while the worker's system info is absent -- a
+ * correct long path beats a wrong short one.
+ */
+export function tildifyForWorker(path: string, info: WorkerInfo | null | undefined): string {
+  return tildify(path, info?.homeDir, workerPathFlavor(info))
+}

--- a/frontend/src/lib/workspaceSort.test.ts
+++ b/frontend/src/lib/workspaceSort.test.ts
@@ -1,0 +1,199 @@
+import type { WorkspaceSortKey, WorkspaceSortOrder } from './workspaceSort'
+import type { Workspace } from '~/generated/proto/leapmux/v1/workspace_pb'
+import { describe, expect, it } from 'vitest'
+import {
+  canReorderWithin,
+  DEFAULT_WORKSPACE_SORT_ORDER,
+  filterWorkspaces,
+  parseWorkspaceSortOrder,
+  sortDirectionLabel,
+  sortKeyLabel,
+  sortWorkspaces,
+  WORKSPACE_SORT_DIRECTIONS,
+  WORKSPACE_SORT_KEYS,
+} from './workspaceSort'
+
+function ws(id: string, title: string, createdAt = ''): Workspace {
+  return { id, title, createdAt } as Workspace
+}
+
+function order(key: WorkspaceSortKey, direction: 'asc' | 'desc' = 'asc'): WorkspaceSortOrder {
+  return { key, direction }
+}
+
+const NO_RECENCY = () => undefined
+
+function ids(list: readonly Workspace[]): string[] {
+  return list.map(w => w.id)
+}
+
+describe('sortKeyLabel', () => {
+  it('names every key', () => {
+    for (const key of WORKSPACE_SORT_KEYS)
+      expect(sortKeyLabel(key)).toBeTruthy()
+  })
+})
+
+describe('sortDirectionLabel', () => {
+  it('answers for every (key, direction) pair, including manual', () => {
+    // The menu draws both order radios whatever the key is, so a missing entry
+    // would throw on the lookup rather than degrade.
+    for (const key of WORKSPACE_SORT_KEYS) {
+      for (const direction of WORKSPACE_SORT_DIRECTIONS)
+        expect(sortDirectionLabel(key, direction)).toBeTruthy()
+    }
+  })
+
+  it('words the direction for the criterion, not generically', () => {
+    expect(sortDirectionLabel('name', 'asc')).not.toBe(sortDirectionLabel('created', 'asc'))
+  })
+})
+
+describe('parseWorkspaceSortOrder', () => {
+  it('accepts a well-formed order', () => {
+    expect(parseWorkspaceSortOrder({ key: 'name', direction: 'desc' }))
+      .toEqual({ key: 'name', direction: 'desc' })
+  })
+
+  it.each([
+    ['null', null],
+    ['a string', 'name'],
+    ['a number', 3],
+    ['an unknown key', { key: 'colour', direction: 'asc' }],
+    ['an unknown direction', { key: 'name', direction: 'sideways' }],
+    ['a missing direction', { key: 'name' }],
+  ])('falls back to the default for %s', (_label, raw) => {
+    // An unrecognized key would otherwise reach the direction-label lookup,
+    // which throws.
+    expect(parseWorkspaceSortOrder(raw)).toEqual(DEFAULT_WORKSPACE_SORT_ORDER)
+  })
+
+  it('defaults to the manual order, which is the lexorank one', () => {
+    expect(DEFAULT_WORKSPACE_SORT_ORDER.key).toBe('manual')
+  })
+})
+
+describe('sortWorkspaces', () => {
+  const list = [ws('c', 'Charlie', '2026-03-01'), ws('a', 'alpha', '2026-01-01'), ws('b', 'Bravo', '2026-02-01')]
+
+  it('leaves the manual order untouched, in either direction', () => {
+    // That order IS the lexorank the caller already assembled; re-deriving it
+    // would be a second answer to what the model says.
+    expect(ids(sortWorkspaces(list, order('manual'), NO_RECENCY))).toEqual(['c', 'a', 'b'])
+    expect(ids(sortWorkspaces(list, order('manual', 'desc'), NO_RECENCY))).toEqual(['c', 'a', 'b'])
+  })
+
+  it('does not mutate its input', () => {
+    const input = [...list]
+    sortWorkspaces(input, order('name'), NO_RECENCY)
+    expect(ids(input)).toEqual(['c', 'a', 'b'])
+  })
+
+  it('sorts by name, case-insensitively, in both directions', () => {
+    expect(ids(sortWorkspaces(list, order('name'), NO_RECENCY))).toEqual(['a', 'b', 'c'])
+    expect(ids(sortWorkspaces(list, order('name', 'desc'), NO_RECENCY))).toEqual(['c', 'b', 'a'])
+  })
+
+  it('sorts by creation in both directions', () => {
+    expect(ids(sortWorkspaces(list, order('created'), NO_RECENCY))).toEqual(['a', 'b', 'c'])
+    expect(ids(sortWorkspaces(list, order('created', 'desc'), NO_RECENCY))).toEqual(['c', 'b', 'a'])
+  })
+
+  it('sorts by recency in both directions', () => {
+    const recency = (id: string) => ({ a: 3, b: 1, c: 2 })[id]
+    expect(ids(sortWorkspaces(list, order('recent'), recency))).toEqual(['b', 'c', 'a'])
+    expect(ids(sortWorkspaces(list, order('recent', 'desc'), recency))).toEqual(['a', 'c', 'b'])
+  })
+
+  it('pins a workspace with NO recency last under both directions', () => {
+    // `mru` is a per-session counter, so "never activated this session" is a
+    // real answer -- and it must not migrate to the top when the direction
+    // flips.
+    const recency = (id: string) => (id === 'b' ? undefined : 1)
+    expect(ids(sortWorkspaces(list, order('recent'), recency)).at(-1)).toBe('b')
+    expect(ids(sortWorkspaces(list, order('recent', 'desc'), recency)).at(-1)).toBe('b')
+  })
+
+  it('breaks a recency tie by title, so the order is total', () => {
+    const recency = () => 5
+    expect(ids(sortWorkspaces(list, order('recent'), recency))).toEqual(['a', 'b', 'c'])
+  })
+
+  it('breaks a creation tie by title', () => {
+    const tied = [ws('c', 'Charlie', '2026-01-01'), ws('a', 'alpha', '2026-01-01')]
+    expect(ids(sortWorkspaces(tied, order('created'), NO_RECENCY))).toEqual(['a', 'c'])
+  })
+
+  it('pins a workspace with no creation time last', () => {
+    const partial = [ws('a', 'alpha'), ws('b', 'Bravo', '2026-01-01')]
+    expect(ids(sortWorkspaces(partial, order('created'), NO_RECENCY))).toEqual(['b', 'a'])
+    expect(ids(sortWorkspaces(partial, order('created', 'desc'), NO_RECENCY))).toEqual(['b', 'a'])
+  })
+
+  it('handles an empty list and a single entry', () => {
+    expect(sortWorkspaces([], order('name'), NO_RECENCY)).toEqual([])
+    expect(ids(sortWorkspaces([ws('a', 'alpha')], order('recent'), NO_RECENCY))).toEqual(['a'])
+  })
+
+  it('sorts an untitled workspace without throwing', () => {
+    const untitled = [ws('b', ''), ws('a', 'alpha')]
+    expect(ids(sortWorkspaces(untitled, order('name'), NO_RECENCY))).toEqual(['b', 'a'])
+  })
+})
+
+describe('filterWorkspaces', () => {
+  const list = [ws('a', 'gentle-amber-fox'), ws('b', 'Bold Blue Bear'), ws('c', 'amber tooling')]
+
+  it('keeps everything for an empty query', () => {
+    expect(ids(filterWorkspaces(list, ''))).toEqual(['a', 'b', 'c'])
+    expect(ids(filterWorkspaces(list, '   '))).toEqual(['a', 'b', 'c'])
+  })
+
+  it('matches a substring, case-insensitively', () => {
+    expect(ids(filterWorkspaces(list, 'AMBER'))).toEqual(['a', 'c'])
+  })
+
+  it('trims the query', () => {
+    expect(ids(filterWorkspaces(list, '  bear  '))).toEqual(['b'])
+  })
+
+  it('answers empty when nothing matches', () => {
+    expect(filterWorkspaces(list, 'zzz')).toEqual([])
+  })
+
+  it('does not mutate its input', () => {
+    const input = [...list]
+    filterWorkspaces(input, 'amber')
+    expect(ids(input)).toEqual(['a', 'b', 'c'])
+  })
+})
+
+describe('canReorderWithin', () => {
+  it('allows reordering under the manual order with no filter', () => {
+    expect(canReorderWithin(order('manual'), '')).toBe(true)
+    expect(canReorderWithin(order('manual', 'desc'), '')).toBe(true)
+  })
+
+  it('refuses under EVERY non-manual key', () => {
+    // The sort is global, so one non-manual pick disables reordering in every
+    // section at once. Only the between-row drop targets go: the grip stays,
+    // and move-to-section and drag-to-archive keep working.
+    for (const key of WORKSPACE_SORT_KEYS) {
+      if (key === 'manual')
+        continue
+      for (const direction of WORKSPACE_SORT_DIRECTIONS)
+        expect(canReorderWithin(order(key, direction), '')).toBe(false)
+    }
+  })
+
+  it('refuses while a filter narrows the list', () => {
+    expect(canReorderWithin(order('manual'), 'amber')).toBe(false)
+  })
+
+  it('allows reordering while the filter box is OPEN but empty', () => {
+    // An open input is not a narrowed list, and the view order still equals
+    // the model order.
+    expect(canReorderWithin(order('manual'), '')).toBe(true)
+    expect(canReorderWithin(order('manual'), '   ')).toBe(true)
+  })
+})

--- a/frontend/src/lib/workspaceSort.test.ts
+++ b/frontend/src/lib/workspaceSort.test.ts
@@ -197,3 +197,30 @@ describe('canReorderWithin', () => {
     expect(canReorderWithin(order('manual'), '   ')).toBe(true)
   })
 })
+
+// The default state -- manual order, no filter -- must not allocate. Both
+// functions are called for every section on every tick, and a fresh array
+// breaks reference equality for every memo downstream of them.
+describe('the identity paths return the input itself', () => {
+  const list = [ws('a', 'Alpha'), ws('b', 'Beta')]
+
+  it('sortWorkspaces returns the same array under the manual order', () => {
+    expect(sortWorkspaces(list, { key: 'manual', direction: 'asc' }, () => undefined)).toBe(list)
+  })
+
+  it('filterWorkspaces returns the same array for an empty query', () => {
+    expect(filterWorkspaces(list, '')).toBe(list)
+    expect(filterWorkspaces(list, '   ')).toBe(list)
+  })
+
+  it('still returns a NEW array whenever it does work', () => {
+    expect(sortWorkspaces(list, { key: 'name', direction: 'asc' }, () => undefined)).not.toBe(list)
+    expect(filterWorkspaces(list, 'alpha')).not.toBe(list)
+  })
+
+  it('never mutates the input', () => {
+    const before = list.map(w => w.id)
+    sortWorkspaces(list, { key: 'name', direction: 'desc' }, () => undefined)
+    expect(list.map(w => w.id)).toEqual(before)
+  })
+})

--- a/frontend/src/lib/workspaceSort.ts
+++ b/frontend/src/lib/workspaceSort.ts
@@ -1,0 +1,169 @@
+import type { Workspace } from '~/generated/proto/leapmux/v1/workspace_pb'
+import { assertNever } from '~/lib/assertNever'
+import { compareNames } from '~/lib/fileSort'
+
+/**
+ * The value the workspace list is ordered by.
+ *
+ * `manual` is the lexorank order the user built by dragging, and it is the
+ * default. The other three are derived, so while one of them is active the view
+ * order and the model order differ -- which is what makes a same-section drag
+ * undefined. See {@link canReorderWithin}.
+ */
+export type WorkspaceSortKey = 'manual' | 'name' | 'recent' | 'created'
+
+export type WorkspaceSortDirection = 'asc' | 'desc'
+
+export interface WorkspaceSortOrder {
+  key: WorkspaceSortKey
+  direction: WorkspaceSortDirection
+}
+
+export const DEFAULT_WORKSPACE_SORT_ORDER: WorkspaceSortOrder = { key: 'manual', direction: 'asc' }
+
+export const WORKSPACE_SORT_KEYS: readonly WorkspaceSortKey[] = ['manual', 'name', 'recent', 'created']
+export const WORKSPACE_SORT_DIRECTIONS: readonly WorkspaceSortDirection[] = ['asc', 'desc']
+
+const SORT_KEY_LABELS: Record<WorkspaceSortKey, string> = {
+  manual: 'Manual',
+  name: 'Name',
+  recent: 'Recently active',
+  created: 'Created',
+}
+
+/**
+ * Direction labels follow the criterion, because "ascending" says nothing
+ * useful about a recency counter or a creation time. The same rule the file
+ * sort applies, for the same reason.
+ */
+const DIRECTION_LABELS: Record<WorkspaceSortKey, Record<WorkspaceSortDirection, string>> = {
+  // `manual` ignores the direction entirely, but it still needs a pair: the
+  // menu draws both radios whatever the key is, and a missing entry would
+  // throw on the lookup.
+  manual: { asc: 'Ascending', desc: 'Descending' },
+  name: { asc: 'A → Z', desc: 'Z → A' },
+  recent: { asc: 'Least recent first', desc: 'Most recent first' },
+  created: { asc: 'Oldest first', desc: 'Newest first' },
+}
+
+export function sortKeyLabel(key: WorkspaceSortKey): string {
+  return SORT_KEY_LABELS[key]
+}
+
+export function sortDirectionLabel(key: WorkspaceSortKey, direction: WorkspaceSortDirection): string {
+  return DIRECTION_LABELS[key][direction]
+}
+
+/**
+ * Validates a value read back from browser storage.
+ *
+ * The stored shape is arbitrary JSON that a previous build (or a hand edit) may
+ * have written, and an unrecognized key would otherwise reach
+ * `DIRECTION_LABELS[key]` -- which throws rather than degrading.
+ */
+export function parseWorkspaceSortOrder(raw: unknown): WorkspaceSortOrder {
+  if (!raw || typeof raw !== 'object')
+    return DEFAULT_WORKSPACE_SORT_ORDER
+  const { key, direction } = raw as { key?: unknown, direction?: unknown }
+  if (!WORKSPACE_SORT_KEYS.includes(key as WorkspaceSortKey)
+    || !WORKSPACE_SORT_DIRECTIONS.includes(direction as WorkspaceSortDirection)) {
+    return DEFAULT_WORKSPACE_SORT_ORDER
+  }
+  return { key: key as WorkspaceSortKey, direction: direction as WorkspaceSortDirection }
+}
+
+/**
+ * How recently a workspace was used: the highest `mru` across its tabs, or
+ * undefined for a workspace no tab of which was activated this session.
+ *
+ * `mru` is a monotonic COUNTER, not a timestamp (see `BaseTab.mru`): it orders
+ * and nothing more, it is per session, and a workspace can genuinely have none.
+ */
+export type WorkspaceRecencyFn = (workspaceId: string) => number | undefined
+
+/**
+ * Order one section's workspaces.
+ *
+ * `manual` returns the input untouched -- that IS the lexorank order the caller
+ * already assembled, and re-deriving it here would be a second answer to what
+ * the model already says.
+ *
+ * Every other key falls back to the title, so the order is total and does not
+ * shuffle between two renders of the same list. A workspace with no recency
+ * sorts LAST under both directions: the pin happens before the direction flip,
+ * so "never used this session" never migrates to the top.
+ *
+ * Returns a NEW array; the input is not mutated.
+ */
+export function sortWorkspaces(
+  workspaces: readonly Workspace[],
+  order: WorkspaceSortOrder,
+  recencyOf: WorkspaceRecencyFn,
+): Workspace[] {
+  if (order.key === 'manual')
+    return [...workspaces]
+
+  const flip = order.direction === 'desc' ? -1 : 1
+  const byTitle = (a: Workspace, b: Workspace) => compareNames(a.title || '', b.title || '')
+
+  return [...workspaces].sort((a, b) => {
+    switch (order.key) {
+      case 'name':
+        return byTitle(a, b) * flip
+      case 'recent': {
+        const ar = recencyOf(a.id)
+        const br = recencyOf(b.id)
+        if (ar === undefined || br === undefined) {
+          if (ar !== br)
+            return ar === undefined ? 1 : -1
+          return byTitle(a, b)
+        }
+        return ar === br ? byTitle(a, b) : (ar < br ? -1 : 1) * flip
+      }
+      case 'created': {
+        // The hub writes every timestamp in one fixed-width layout, so a
+        // lexicographic compare is a chronological one and needs no parsing.
+        const ac = a.createdAt
+        const bc = b.createdAt
+        if (!ac || !bc) {
+          if (Boolean(ac) !== Boolean(bc))
+            return ac ? -1 : 1
+          return byTitle(a, b)
+        }
+        return ac === bc ? byTitle(a, b) : (ac < bc ? -1 : 1) * flip
+      }
+      // `manual` returned above, so this arm is unreachable -- but naming every
+      // key rather than writing a `default` is what makes a NEW key a compile
+      // error here.
+      case 'manual':
+        return 0
+      default:
+        return assertNever(order.key)
+    }
+  })
+}
+
+/** Keep the workspaces whose title matches `query`, case-insensitively. */
+export function filterWorkspaces(workspaces: readonly Workspace[], query: string): Workspace[] {
+  const needle = query.trim().toLowerCase()
+  if (!needle)
+    return [...workspaces]
+  return workspaces.filter(w => (w.title || '').toLowerCase().includes(needle))
+}
+
+/**
+ * Whether a workspace may be dragged to a new position WITHIN its section.
+ *
+ * A workspace drag does three jobs -- reorder within a section, move to another
+ * section, and archive by dropping on Archived -- and only the first is
+ * undefined when the view order differs from the model order. So this suppresses
+ * the between-row drop targets and nothing else: the grip stays, and both
+ * cross-section jobs keep working.
+ *
+ * The sort is GLOBAL, so a non-manual key disables reordering in every section
+ * at once. The filter is per section, and an EMPTY query does not disable
+ * anything -- the input being open is not the same as the list being narrowed.
+ */
+export function canReorderWithin(order: WorkspaceSortOrder, filterQuery: string): boolean {
+  return order.key === 'manual' && filterQuery.trim() === ''
+}

--- a/frontend/src/lib/workspaceSort.ts
+++ b/frontend/src/lib/workspaceSort.ts
@@ -1,6 +1,6 @@
 import type { Workspace } from '~/generated/proto/leapmux/v1/workspace_pb'
 import { assertNever } from '~/lib/assertNever'
-import { compareNames } from '~/lib/fileSort'
+import { compareNames, compareOptionalValue } from '~/lib/fileSort'
 
 /**
  * The value the workspace list is ordered by.
@@ -93,48 +93,44 @@ export type WorkspaceRecencyFn = (workspaceId: string) => number | undefined
  * sorts LAST under both directions: the pin happens before the direction flip,
  * so "never used this session" never migrates to the top.
  *
- * Returns a NEW array; the input is not mutated.
+ * Never mutates the input. Returns the input ITSELF when the order needs no
+ * work, so a downstream memo can still compare by reference; treat the result
+ * as read-only either way.
  */
 export function sortWorkspaces(
   workspaces: readonly Workspace[],
   order: WorkspaceSortOrder,
   recencyOf: WorkspaceRecencyFn,
-): Workspace[] {
+): readonly Workspace[] {
   if (order.key === 'manual')
-    return [...workspaces]
+    return workspaces
 
   const flip = order.direction === 'desc' ? -1 : 1
   const byTitle = (a: Workspace, b: Workspace) => compareNames(a.title || '', b.title || '')
+
+  // Resolved ONCE per workspace, not once per comparison. `recencyOf` scans
+  // every tab of a workspace to find its highest activation counter, and a
+  // comparator runs O(n log n) times.
+  const recency = order.key === 'recent'
+    ? new Map(workspaces.map(w => [w.id, recencyOf(w.id)]))
+    : undefined
 
   return [...workspaces].sort((a, b) => {
     switch (order.key) {
       case 'name':
         return byTitle(a, b) * flip
-      case 'recent': {
-        const ar = recencyOf(a.id)
-        const br = recencyOf(b.id)
-        if (ar === undefined || br === undefined) {
-          if (ar !== br)
-            return ar === undefined ? 1 : -1
-          return byTitle(a, b)
-        }
-        return ar === br ? byTitle(a, b) : (ar < br ? -1 : 1) * flip
-      }
-      case 'created': {
+      case 'recent':
+        // A counter of 0 is a real value, so only `undefined` is absent.
+        return compareOptionalValue(recency!.get(a.id), recency!.get(b.id), flip) ?? byTitle(a, b)
+      case 'created':
         // The hub writes every timestamp in one fixed-width layout, so a
         // lexicographic compare is a chronological one and needs no parsing.
-        const ac = a.createdAt
-        const bc = b.createdAt
-        if (!ac || !bc) {
-          if (Boolean(ac) !== Boolean(bc))
-            return ac ? -1 : 1
-          return byTitle(a, b)
-        }
-        return ac === bc ? byTitle(a, b) : (ac < bc ? -1 : 1) * flip
-      }
-      // `manual` returned above, so this arm is unreachable -- but naming every
-      // key rather than writing a `default` is what makes a NEW key a compile
-      // error here.
+        // An EMPTY string means "not reported", so it maps to `undefined`.
+        return compareOptionalValue(a.createdAt || undefined, b.createdAt || undefined, flip)
+          ?? byTitle(a, b)
+      // `manual` returned above, so this case is unreachable -- but listing
+      // every key rather than writing a `default` is what makes a NEW key a
+      // compile error here.
       case 'manual':
         return 0
       default:
@@ -143,11 +139,16 @@ export function sortWorkspaces(
   })
 }
 
-/** Keep the workspaces whose title matches `query`, case-insensitively. */
-export function filterWorkspaces(workspaces: readonly Workspace[], query: string): Workspace[] {
+/**
+ * Keep the workspaces whose title matches `query`, case-insensitively.
+ *
+ * Returns the input ITSELF for an empty query, for the same reason
+ * {@link sortWorkspaces} does. Never mutates it.
+ */
+export function filterWorkspaces(workspaces: readonly Workspace[], query: string): readonly Workspace[] {
   const needle = query.trim().toLowerCase()
   if (!needle)
-    return [...workspaces]
+    return workspaces
   return workspaces.filter(w => (w.title || '').toLowerCase().includes(needle))
 }
 

--- a/frontend/src/stores/repoGit.store.test.ts
+++ b/frontend/src/stores/repoGit.store.test.ts
@@ -970,7 +970,7 @@ describe('createRepoGitStore', () => {
    * The store exposes no per-worker clear, and must not grow one back.
    *
    * Dropping a worker's entries is never right while its tab rows survive. A
-   * row keeps `gitToplevel`, `WorkspaceTabTree.repoKeyAndLabel` groups the tab
+   * row keeps `gitToplevel`, `branchKeys.repoKeyAndLabel` groups the tab
    * by that field, and the branch label comes from this store -- so a cleared
    * entry puts every tab of that worker under its repo with no branch name.
    * Neither event that used to call it removes the rows: a dropped link leaves

--- a/frontend/src/styles/shared.css.ts
+++ b/frontend/src/styles/shared.css.ts
@@ -128,6 +128,35 @@ export const dangerMenuItem = style({
   color: 'var(--danger)',
 })
 
+/**
+ * A menu item that OPENS A SUBMENU: its label at one end, its chevron at the
+ * other.
+ *
+ * Shared because every submenu trigger in the app is this same shape -- the
+ * composer's `[+]` groups, the sidebar's section menu, the workspace row menu.
+ * It lived in the composer's own stylesheet while the sidebar's copy carried a
+ * `class="sub-trigger"` that matched no rule at all, so one surface was styled
+ * and the other silently was not.
+ */
+export const menuSubTrigger = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  width: '100%',
+})
+
+/**
+ * The leading half of a submenu trigger, for an item whose label carries an
+ * icon (the branch item). `menuSubTrigger` pushes its two children apart, so
+ * the icon and the text need one box between them or the chevron separates
+ * them instead.
+ */
+export const menuSubTriggerLabel = style([clippedText, {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 'var(--space-2)',
+}])
+
 export const menuSectionHeader = style({
   fontSize: 'var(--text-8)',
   fontWeight: 'var(--font-bold)',

--- a/frontend/src/test-support/branchMenu.ts
+++ b/frontend/src/test-support/branchMenu.ts
@@ -1,5 +1,6 @@
 import type { Mock } from 'vitest'
 import type { BranchMenuActions, BranchRefActions } from '~/components/workspace/branchActions'
+import type { WorkspaceStartActions } from '~/components/workspace/workspaceStartActions'
 import { vi } from 'vitest'
 
 /** A {@link BranchMenuActions} bundle whose every action is a spy. */
@@ -39,5 +40,23 @@ export function stubBranchRefActions(): StubBranchRefActions {
     onNewAgentAdvanced: vi.fn(),
     onNewTerminalWithShell: vi.fn(),
     onNewTerminalAdvanced: vi.fn(),
+  }
+}
+
+/** A {@link WorkspaceStartActions} bundle whose every action is a spy. */
+export type StubWorkspaceStartActions = { [K in keyof WorkspaceStartActions]: Mock<WorkspaceStartActions[K]> }
+
+/**
+ * The workspace ROW's two tab-creation actions, as spies.
+ *
+ * Shared for the same reason as the branch bundles above: a third action added
+ * to {@link WorkspaceStartActions} makes every caller fail to compile in ONE
+ * place, instead of silently leaving the new item unwired in each suite that
+ * hand-rolled its own pair.
+ */
+export function stubWorkspaceStartActions(): StubWorkspaceStartActions {
+  return {
+    onNewAgentAt: vi.fn(),
+    onNewTerminalAt: vi.fn(),
   }
 }

--- a/frontend/tests/e2e/004-registration.spec.ts
+++ b/frontend/tests/e2e/004-registration.spec.ts
@@ -1,7 +1,6 @@
 import { expect, test } from './fixtures'
 import { loginViaUI } from './helpers/ui'
-
-const NEW_WORKSPACE_RE = /New workspace/
+import { openNewWorkspaceDialog } from './helpers/worktree'
 
 test.describe('Worker Registration', () => {
   // In dev mode, the worker is auto-registered with name "Local".
@@ -12,9 +11,10 @@ test.describe('Worker Registration', () => {
     // in the new workspace dialog. The initial onMount fetch should find it.
     await loginViaUI(page)
 
-    // Open the new workspace dialog
-    await page.getByLabel(NEW_WORKSPACE_RE).first().click()
-    await expect(page.getByRole('heading', { name: 'New Workspace' })).toBeVisible()
+    // Through the shared helper: the section header's `+` is a MENU now, so
+    // "New workspace..." is an item inside it and the accessible name this
+    // used to click no longer exists on any button.
+    await openNewWorkspaceDialog(page)
 
     // The initial fetch on mount should find the worker (already online).
     // Verify the worker name appears in the dropdown (dev mode uses "Local")
@@ -24,9 +24,10 @@ test.describe('Worker Registration', () => {
   test('should refresh worker list when clicking refresh button', async ({ page }) => {
     await loginViaUI(page)
 
-    // Open the new workspace dialog
-    await page.getByLabel(NEW_WORKSPACE_RE).first().click()
-    await expect(page.getByRole('heading', { name: 'New Workspace' })).toBeVisible()
+    // Through the shared helper: the section header's `+` is a MENU now, so
+    // "New workspace..." is an item inside it and the accessible name this
+    // used to click no longer exists on any button.
+    await openNewWorkspaceDialog(page)
 
     // Wait for initial load to find the worker
     await expect(page.getByTestId('worker-select-menu-trigger')).toContainText('Local')
@@ -41,9 +42,10 @@ test.describe('Worker Registration', () => {
   test('should not spin refresh button when selecting a directory', async ({ page }) => {
     await loginViaUI(page)
 
-    // Open the new workspace dialog
-    await page.getByLabel(NEW_WORKSPACE_RE).first().click()
-    await expect(page.getByRole('heading', { name: 'New Workspace' })).toBeVisible()
+    // Through the shared helper: the section header's `+` is a MENU now, so
+    // "New workspace..." is an item inside it and the accessible name this
+    // used to click no longer exists on any button.
+    await openNewWorkspaceDialog(page)
 
     // Wait for initial load to find the worker and directory tree
     await expect(page.getByTestId('worker-select-menu-trigger')).toContainText('Local')
@@ -66,9 +68,10 @@ test.describe('Worker Registration', () => {
   test('should show updated worker list when dialog is re-opened', async ({ page }) => {
     await loginViaUI(page)
 
-    // Open the new workspace dialog
-    await page.getByLabel(NEW_WORKSPACE_RE).first().click()
-    await expect(page.getByRole('heading', { name: 'New Workspace' })).toBeVisible()
+    // Through the shared helper: the section header's `+` is a MENU now, so
+    // "New workspace..." is an item inside it and the accessible name this
+    // used to click no longer exists on any button.
+    await openNewWorkspaceDialog(page)
 
     // Wait for initial load
     await expect(page.getByTestId('worker-select-menu-trigger')).toContainText('Local')
@@ -78,8 +81,7 @@ test.describe('Worker Registration', () => {
     await expect(page.getByRole('heading', { name: 'New Workspace' })).not.toBeVisible()
 
     // Re-open the dialog
-    await page.getByLabel(NEW_WORKSPACE_RE).first().click()
-    await expect(page.getByRole('heading', { name: 'New Workspace' })).toBeVisible()
+    await openNewWorkspaceDialog(page)
 
     // The re-mount fetch should find the worker
     await expect(page.getByTestId('worker-select-menu-trigger')).toContainText('Local')

--- a/frontend/tests/e2e/011-workspace-ux.spec.ts
+++ b/frontend/tests/e2e/011-workspace-ux.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from './fixtures'
 import { createWorkspaceViaAPI, deleteWorkspaceViaAPI } from './helpers/api'
 import { getRecordedToasts } from './helpers/toast'
 import { loginViaToken, openWorkspace, workspaceRow } from './helpers/ui'
+import { openNewWorkspaceDialog } from './helpers/worktree'
 
 test.describe('Workspace UX Enhancements', () => {
   test('should auto-activate first workspace on app home', async ({ page, leapmuxServer }) => {
@@ -26,19 +27,17 @@ test.describe('Workspace UX Enhancements', () => {
     }
   })
 
-  test('should open new workspace dialog from sidebar + button', async ({ page, leapmuxServer }) => {
+  test('should open new workspace dialog from the section header menu', async ({ page, leapmuxServer }) => {
     await loginViaToken(page, leapmuxServer.adminToken)
     // Navigate to app home first
     await page.goto('/')
     await expect(page.locator('[data-testid="section-header-workspaces_in_progress"]')).toBeVisible()
 
-    // Click the sidebar + button
-    await page.locator('[data-testid="sidebar-new-workspace"]').click()
+    // The header carries a menu now, and "New workspace..." is an item in it.
+    await openNewWorkspaceDialog(page)
 
-    // New workspace dialog should appear
-    await expect(page.getByRole('heading', { name: 'New Workspace' })).toBeVisible()
-
-    // Close dialog without creating
+    // Close dialog without creating. The menu popover closed behind the item's
+    // own click, so this Escape reaches the dialog rather than the popover.
     await page.keyboard.press('Escape')
     await expect(page.getByRole('heading', { name: 'New Workspace' })).not.toBeVisible()
   })
@@ -165,7 +164,9 @@ test.describe('Workspace UX Enhancements', () => {
       const deleteTarget = workspaceRow(page, workspaceId1)
       await deleteTarget.hover()
       await deleteTarget.locator('button').first().click()
-      await page.getByRole('menuitem', { name: 'Delete' }).click()
+      // `exact`: the row menu's info block joins every row into its own
+      // accessible name, and Playwright matches a name by substring.
+      await page.getByRole('menuitem', { name: 'Delete', exact: true }).click()
 
       // Confirm the delete via ConfirmDialog (danger mode: arm then confirm)
       const dialog = page.locator('dialog')

--- a/frontend/tests/e2e/013-workspace-context-menu.spec.ts
+++ b/frontend/tests/e2e/013-workspace-context-menu.spec.ts
@@ -5,6 +5,14 @@ import { COARSE_POINTER_METRICS, touchDown } from './helpers/touch'
 import { workspaceRow } from './helpers/ui'
 
 /**
+ * The workspace row menu carries an INFO BLOCK and repository-named items now,
+ * and Playwright matches an accessible name by SUBSTRING unless told otherwise
+ * -- so `{ name: 'Delete' }` also matched the info block (whose name is every
+ * row of it joined) and `{ name: 'Archive' }` also matched
+ * "New agent in archived-branch...". Every lookup below is `exact`.
+ */
+
+/**
  * The context menu's item visibility (Rename / Share / Archive vs. Unarchive /
  * Delete / Move-to) and the owner-only filter are unit-tested in
  * `src/components/workspace/WorkspaceContextMenu.test.tsx`. This e2e exercises
@@ -20,7 +28,7 @@ test.describe('Workspace Context Menu', () => {
     // ── Rename ──────────────────────────────────────────────────────────────
     await workspaceItem.hover()
     await workspaceItem.locator('button').first().click()
-    await page.getByRole('menuitem', { name: 'Rename' }).click()
+    await page.getByRole('menuitem', { name: 'Rename', exact: true }).click()
 
     const renameInput = workspaceItem.locator('input')
     await expect(renameInput).toBeVisible()
@@ -38,7 +46,7 @@ test.describe('Workspace Context Menu', () => {
 
     await workspaceItem.hover()
     await workspaceItem.locator('button').first().click()
-    await page.getByRole('menuitem', { name: 'Delete' }).click()
+    await page.getByRole('menuitem', { name: 'Delete', exact: true }).click()
 
     const dialog = page.locator('dialog')
     await expect(dialog).toBeVisible()
@@ -67,7 +75,9 @@ test.describe('Workspace Context Menu', () => {
     await page.mouse.down({ button: 'right' })
     await page.mouse.up({ button: 'right' })
 
-    const renameItem = page.getByRole('menuitem', { name: 'Rename' })
+    // Scoped to THIS row: the popover belongs to the row that owns it, and
+    // every row on screen carries one.
+    const renameItem = workspaceItem.getByRole('menuitem', { name: 'Rename', exact: true })
     await expect(renameItem).toBeVisible()
 
     // Still visible a moment later: the menu opens after the release, so the
@@ -97,11 +107,17 @@ test.describe('Workspace Context Menu', () => {
       const x = box.x + box.width / 2
       const y = box.y + box.height / 2
 
+      // Scoped to THIS row, not to the page. The menu's popover is a DOM child
+      // of the row that owns it, and every other row on screen has one too --
+      // so a page-global lookup answers for whichever row happens to have a
+      // menu open, which is not what either assertion below means.
+      const renameItem = workspaceItem.getByRole('menuitem', { name: 'Rename', exact: true })
+
       // ── A press that travels is a scroll, not a menu ────────────────────────
       const scrolling = await touchDown(page, x, y)
       await scrolling.moveTo(x, y + 60)
       await scrolling.end()
-      await expect(page.getByRole('menuitem', { name: 'Rename' })).toBeHidden()
+      await expect(renameItem).toBeHidden()
       await expect(workspaceItem).not.toHaveAttribute('data-press-hold')
 
       // ── A press that stays put opens the menu, while it is still down ───────
@@ -114,7 +130,6 @@ test.describe('Workspace Context Menu', () => {
       // with the finger still on the glass. (This used to wait for the accent
       // tint to reach full instead, which is no longer a state that lasts --
       // the tint yields the moment the menu it was promising arrives.)
-      const renameItem = page.getByRole('menuitem', { name: 'Rename' })
       await expect(renameItem).toBeVisible()
       await expect(workspaceItem).not.toHaveAttribute('data-press-hold')
 

--- a/frontend/tests/e2e/014-workspace-archive.spec.ts
+++ b/frontend/tests/e2e/014-workspace-archive.spec.ts
@@ -5,6 +5,14 @@ import { loginViaToken, openTreeContextMenu, openWorkspace, treeRow, workspaceRo
 
 const frontendDir = path.resolve(import.meta.dirname, '../..')
 
+/**
+ * The workspace row menu carries an INFO BLOCK and repository-named items now,
+ * and Playwright matches an accessible name by SUBSTRING unless told otherwise
+ * -- so `{ name: 'Delete' }` also matched the info block (whose name is every
+ * row of it joined) and `{ name: 'Archive' }` also matched
+ * "New agent in archived-branch...". Every lookup below is `exact`.
+ */
+
 /** Open the context menu for a workspace item that's already located by testid. */
 async function openContextMenu(item: ReturnType<import('@playwright/test').Page['locator']>) {
   await item.hover()
@@ -17,7 +25,7 @@ test.describe('Workspace Archive', () => {
 
     // Open context menu and click Archive (top-level menu item)
     await openContextMenu(workspaceItem)
-    await page.getByRole('menuitem', { name: 'Archive' }).click()
+    await page.getByRole('menuitem', { name: 'Archive', exact: true }).click()
 
     // Confirmation dialog should appear
     const dialog = page.locator('dialog')
@@ -41,7 +49,7 @@ test.describe('Workspace Archive', () => {
 
     // Open context menu and click Archive (top-level menu item)
     await openContextMenu(workspaceItem)
-    await page.getByRole('menuitem', { name: 'Archive' }).click()
+    await page.getByRole('menuitem', { name: 'Archive', exact: true }).click()
 
     // Confirmation dialog should appear
     const dialog = page.locator('dialog')
@@ -60,7 +68,7 @@ test.describe('Workspace Archive', () => {
 
     // Archive the workspace first: open context menu using the workspace item directly
     await openContextMenu(workspaceItem)
-    await page.getByRole('menuitem', { name: 'Archive' }).click()
+    await page.getByRole('menuitem', { name: 'Archive', exact: true }).click()
     await page.locator('dialog').getByRole('button', { name: 'Archive' }).click()
 
     // Wait for the archived section to appear (auto-expanded)
@@ -69,7 +77,7 @@ test.describe('Workspace Archive', () => {
 
     // Now unarchive it: open context menu using the workspace item directly
     await openContextMenu(workspaceItem)
-    await page.getByRole('menuitem', { name: 'Unarchive' }).click()
+    await page.getByRole('menuitem', { name: 'Unarchive', exact: true }).click()
 
     // Workspace is active again — add-tab buttons should be visible
     await expect(page.locator('[data-testid^="new-agent-button"]').first()).toBeVisible()
@@ -83,23 +91,28 @@ test.describe('Workspace Archive', () => {
     await openContextMenu(workspaceItem)
 
     // "Move to" should not be visible (no other non-archived, non-shared sections to move to)
-    await expect(page.getByRole('menuitem', { name: 'Move to' })).not.toBeVisible()
+    await expect(page.getByRole('menuitem', { name: 'Move to', exact: true })).not.toBeVisible()
 
     // Other menu items should be present
-    await expect(page.getByRole('menuitem', { name: 'Rename' })).toBeVisible()
-    await expect(page.getByRole('menuitem', { name: 'Archive' })).toBeVisible()
+    await expect(page.getByRole('menuitem', { name: 'Rename', exact: true })).toBeVisible()
+    await expect(page.getByRole('menuitem', { name: 'Archive', exact: true })).toBeVisible()
   })
 
-  test('should only show valid workspace sections in Move-to menu', async ({ page, authenticatedWorkspace }) => {
+  test('leaks no non-workspace section into the row menu', async ({ page, authenticatedWorkspace }) => {
     const workspaceItem = workspaceRow(page, authenticatedWorkspace.workspaceId)
 
-    // Open context menu
     await openContextMenu(workspaceItem)
 
-    // Shared, Files, To-dos should NOT appear as menu items for move targets
-    const menuItems = page.getByRole('menuitem')
-    const allLabels = await menuItems.allTextContents()
-    expect(allLabels).not.toContain('Shared')
+    // Files and To-dos are sections, but not ones a workspace can live in, so
+    // no item of this menu may name them.
+    //
+    // This does NOT exercise the Move-to submenu, and its old name claimed it
+    // did. The submenu mounts its items only while it is open (see `SubMenu`),
+    // and this fixture has one workspace section, so Move-to is not offered at
+    // all. `isMoveTargetSection`'s filter is covered where it can actually be
+    // driven: `WorkspaceContextMenu.test.tsx` ("lists every other workspace
+    // section, and no other kind") and 195's custom-section flow.
+    const allLabels = await page.getByRole('menuitem').allTextContents()
     expect(allLabels).not.toContain('Files')
     expect(allLabels).not.toContain('To-dos')
   })
@@ -109,7 +122,7 @@ test.describe('Workspace Archive', () => {
 
     // Archive the workspace
     await openContextMenu(workspaceItem)
-    await page.getByRole('menuitem', { name: 'Archive' }).click()
+    await page.getByRole('menuitem', { name: 'Archive', exact: true }).click()
     await page.locator('dialog').getByRole('button', { name: 'Archive' }).click()
 
     // The archived section should be visible and expanded (auto-expand)
@@ -131,7 +144,7 @@ test.describe('Workspace Archive', () => {
 
     // Archive the workspace
     await openContextMenu(workspaceItem)
-    await page.getByRole('menuitem', { name: 'Archive' }).click()
+    await page.getByRole('menuitem', { name: 'Archive', exact: true }).click()
     await page.locator('dialog').getByRole('button', { name: 'Archive' }).click()
 
     // Tabs should still be visible (read-only) after archiving
@@ -164,7 +177,7 @@ test.describe('Workspace Archive', () => {
       // Archive the workspace
       const wsItem = workspaceRow(page, workspaceId)
       await openContextMenu(wsItem)
-      await page.getByRole('menuitem', { name: 'Archive' }).click()
+      await page.getByRole('menuitem', { name: 'Archive', exact: true }).click()
       await page.locator('dialog').getByRole('button', { name: 'Archive' }).click()
 
       // Wait for archived section to appear
@@ -215,7 +228,7 @@ test.describe('Workspace Archive', () => {
       // Archive the workspace
       const wsItem = workspaceRow(page, workspaceId)
       await openContextMenu(wsItem)
-      await page.getByRole('menuitem', { name: 'Archive' }).click()
+      await page.getByRole('menuitem', { name: 'Archive', exact: true }).click()
       await page.locator('dialog').getByRole('button', { name: 'Archive' }).click()
 
       // Wait for archived section
@@ -259,7 +272,7 @@ test.describe('Workspace Archive', () => {
       // Archive the workspace
       const wsItem = workspaceRow(page, workspaceId)
       await openContextMenu(wsItem)
-      await page.getByRole('menuitem', { name: 'Archive' }).click()
+      await page.getByRole('menuitem', { name: 'Archive', exact: true }).click()
       await page.locator('dialog').getByRole('button', { name: 'Archive' }).click()
 
       // Wait for archived section
@@ -287,7 +300,7 @@ test.describe('Workspace Archive', () => {
 
     // Open context menu and click Delete
     await openContextMenu(workspaceItem)
-    await page.getByRole('menuitem', { name: 'Delete' }).click()
+    await page.getByRole('menuitem', { name: 'Delete', exact: true }).click()
 
     // ConfirmDialog should appear (not native dialog)
     const dialog = page.locator('dialog')

--- a/frontend/tests/e2e/014-workspace-archive.spec.ts
+++ b/frontend/tests/e2e/014-workspace-archive.spec.ts
@@ -111,7 +111,9 @@ test.describe('Workspace Archive', () => {
     // and this fixture has one workspace section, so Move-to is not offered at
     // all. `isMoveTargetSection`'s filter is covered where it can actually be
     // driven: `WorkspaceContextMenu.test.tsx` ("lists every other workspace
-    // section, and no other kind") and 195's custom-section flow.
+    // section, and no other kind"), and in a real browser by 195's
+    // "a custom section can be created, renamed and deleted from the menu",
+    // which creates the second section the submenu needs and then opens it.
     const allLabels = await page.getByRole('menuitem').allTextContents()
     expect(allLabels).not.toContain('Files')
     expect(allLabels).not.toContain('To-dos')

--- a/frontend/tests/e2e/159-branch-context-menu.spec.ts
+++ b/frontend/tests/e2e/159-branch-context-menu.spec.ts
@@ -111,7 +111,10 @@ test.describe('Branch context menu', () => {
     const wsRow = workspaceRow(page, workspaceId)
     await wsRow.hover()
     await wsRow.locator('button').first().click()
-    await page.getByRole('menuitem', { name: 'Archive' }).click()
+    // `exact`: this is the WORKSPACE row's menu, which now also offers
+    // "New agent in archived-branch..." -- and Playwright matches an
+    // accessible name by substring unless told otherwise.
+    await page.getByRole('menuitem', { name: 'Archive', exact: true }).click()
     await page.locator('dialog').getByRole('button', { name: 'Archive' }).click()
     await expect(page.locator('[data-testid="section-header-workspaces_archived"]')).toBeVisible()
 

--- a/frontend/tests/e2e/159-branch-context-menu.spec.ts
+++ b/frontend/tests/e2e/159-branch-context-menu.spec.ts
@@ -98,7 +98,8 @@ test.describe('Branch context menu', () => {
     // earlier test expanded still has one. Archiving moves this workspace to
     // another section, so the unscoped locator drifted onto a live workspace's
     // row and read its menu as this row's.
-    // `:visible` as well, because the shell mounts the sidebar twice.
+    // `:visible` as well, because a collapsed sidebar keeps its rows mounted
+    // under `display: none`.
     const row = page
       .locator(`[data-testid="workspace-children-${workspaceId}"] [data-testid="tab-tree-branch-group"]:visible`)
       .first()
@@ -287,7 +288,8 @@ test.describe('Branch context menu', () => {
 
     // Scoped to the AWAY subtree: `branchGroupRow` takes the first visible row
     // in the whole sidebar, which is the active workspace's. `:visible` as well,
-    // because the shell mounts the sidebar twice.
+    // because a collapsed sidebar keeps its rows mounted under
+    // `display: none`.
     const awayBranchRow = page
       .locator(`[data-testid="workspace-children-${awayWs}"] [data-testid="tab-tree-branch-group"]:visible`)
       .first()

--- a/frontend/tests/e2e/180-dialog-mobile-scroll.spec.ts
+++ b/frontend/tests/e2e/180-dialog-mobile-scroll.spec.ts
@@ -30,10 +30,11 @@ test.describe('creation dialog on a phone', () => {
   test.use({ viewport: { width: 390, height: 667 } })
 
   test('body scrolls as one container; header and footer stay pinned; the scrollbar sits at the dialog edge', async ({ page, authenticatedWorkspace }) => {
-    // The sidebar's new-workspace button lives behind the workspaces drawer on
-    // a phone; open the drawer first.
+    // The section header menu that holds "New workspace..." lives behind the
+    // workspaces drawer on a phone; open the drawer first.
     await page.getByRole('button', { name: 'Toggle workspaces' }).click()
-    await page.locator('[data-testid="sidebar-new-workspace"]').click()
+    await page.locator('[data-testid="sidebar-section-menu-workspaces_in_progress"]').click()
+    await page.locator('[data-testid="sidebar-new-workspace"]:visible').click()
     await expect(page.getByRole('heading', { name: 'New workspace', level: 2 })).toBeVisible()
 
     // The dialog's directory tree makes the body genuinely taller than the

--- a/frontend/tests/e2e/181-dialog-safe-area-geometry.spec.ts
+++ b/frontend/tests/e2e/181-dialog-safe-area-geometry.spec.ts
@@ -83,28 +83,43 @@ async function applySimulatedSafeArea(
 /**
  * Open New Workspace.
  *
+ * A LOCAL copy, not `helpers/worktree`'s. It differs on three things this spec
+ * is about, and folding it in would leak all of them into 070-073:
+ *   - a THIRD branch for the desktop drawer, which the shared helper has no
+ *     concept of;
+ *   - raw `isVisible().catch()` rather than the helper's `expectAnyVisible`,
+ *     because on this band a control can report visible while still translated
+ *     off-screen;
+ *   - a looser heading match plus the Close-button assertion, which is the
+ *     geometry this file measures.
+ *
  * On the phone band the control lives behind the workspaces drawer — always
- * open the drawer first (same as 180-dialog-mobile-scroll). `isVisible()` is
- * not enough: the button can report visible while still translated off-screen.
- * On the desktop band (≥ sm), prefer the sidebar control and fall back to the
- * empty-state create button when the sidebar is collapsed to a rail.
+ * open the drawer first (same as 180-dialog-mobile-scroll).
+ *
+ * "New workspace..." is an ITEM of the section header menu now, so every
+ * branch opens the menu first. A closed `popover="auto"` is `display: none`,
+ * which is why the availability probes read the TRIGGER.
  */
 async function openNewWorkspaceDialog(page: import('@playwright/test').Page) {
-  const sidebarBtn = page.locator('[data-testid="sidebar-new-workspace"]')
+  const sectionMenu = page.locator('[data-testid="sidebar-section-menu-workspaces_in_progress"]')
+  const newWorkspaceItem = page.locator('[data-testid="sidebar-new-workspace"]:visible')
   const createBtn = page.locator('[data-testid="create-workspace-button"]')
   const toggle = page.getByRole('button', { name: 'Toggle workspaces' })
   const phoneBand = (page.viewportSize()?.width ?? 0) < 640
 
   if (phoneBand) {
     await toggle.click()
-    await sidebarBtn.click()
+    await sectionMenu.click()
+    await newWorkspaceItem.click()
   }
-  else if (await sidebarBtn.isVisible().catch(() => false)) {
-    await sidebarBtn.click()
+  else if (await sectionMenu.isVisible().catch(() => false)) {
+    await sectionMenu.click()
+    await newWorkspaceItem.click()
   }
   else if (await toggle.isVisible().catch(() => false)) {
     await toggle.click()
-    await sidebarBtn.click()
+    await sectionMenu.click()
+    await newWorkspaceItem.click()
   }
   else {
     await createBtn.click()

--- a/frontend/tests/e2e/195-sidebar-section-menu.spec.ts
+++ b/frontend/tests/e2e/195-sidebar-section-menu.spec.ts
@@ -1,0 +1,185 @@
+import type { Locator, Page } from '@playwright/test'
+import path from 'node:path'
+import { expect, test } from './fixtures'
+import { openAgentViaAPI } from './helpers/api'
+import { workspaceRow } from './helpers/ui'
+
+/**
+ * The section header's menu, which replaced the `+`.
+ *
+ * The item SET is unit-tested in `WorkspaceSectionMenu.test.tsx`. What needs a
+ * real browser is what jsdom cannot answer: that the trigger renders while the
+ * section is COLLAPSED (the archived section ships closed, and its menu is the
+ * only route to the bulk operations), that a repository row really pre-fills
+ * the dialog against a live worker, and that Collapse all touches one section's
+ * rows and no other's.
+ *
+ * Every `getByRole('menuitem')` below is `exact`. Playwright matches an
+ * accessible name by SUBSTRING otherwise, and this menu holds items whose names
+ * contain one another ("Unarchive all" inside "Archive", "New workspace..."
+ * beside a repository row).
+ */
+
+const frontendDir = path.resolve(import.meta.dirname, '../..')
+
+function sectionMenuTrigger(page: Page, slug: string): Locator {
+  return page.locator(`[data-testid="sidebar-section-menu-${slug}"]:visible`).first()
+}
+
+function sectionMenuPopover(page: Page, slug: string): Locator {
+  return page.locator(`[data-testid="sidebar-section-menu-${slug}-popover"]`)
+}
+
+function sectionHeader(page: Page, slug: string): Locator {
+  return page.locator(`[data-testid="section-header-${slug}"]:visible`).first()
+}
+
+/**
+ * Open one section's menu, idempotently.
+ *
+ * A second click on an already-open trigger CLOSES it, so the retry has to
+ * check before it clicks -- the same shape `ensureExpanded` uses.
+ */
+async function openSectionMenu(page: Page, slug: string, anyItem: string | Locator): Promise<Locator> {
+  const trigger = sectionMenuTrigger(page, slug)
+  const popover = sectionMenuPopover(page, slug)
+  const item = typeof anyItem === 'string'
+    ? popover.getByRole('menuitem', { name: anyItem, exact: true })
+    : anyItem
+  await expect(async () => {
+    if (!await item.isVisible())
+      await trigger.click()
+    await expect(item).toBeVisible()
+  }).toPass()
+  return popover
+}
+
+/**
+ * Open a section's menu and click one of its items, retried TOGETHER.
+ *
+ * Same reasoning as `clickRowMenuItem` in `helpers/ui`: the sidebar re-renders
+ * on workspace, worker and todo changes, so the menu can close between the open
+ * and the click -- and a retry that covers only the open leaves the click
+ * waiting on an item that will never be visible again.
+ */
+async function clickSectionMenuItem(page: Page, slug: string, itemName: string) {
+  const trigger = sectionMenuTrigger(page, slug)
+  const item = sectionMenuPopover(page, slug).getByRole('menuitem', { name: itemName, exact: true })
+  await expect(async () => {
+    if (!await item.isVisible())
+      await trigger.click()
+    await expect(item).toBeVisible()
+    await item.click()
+  }).toPass()
+}
+
+/** Archive the fixture's workspace through its row menu. */
+async function archiveWorkspace(page: Page, workspaceId: string) {
+  const row = workspaceRow(page, workspaceId)
+  await row.hover()
+  await row.locator('button').first().click()
+  await page.getByRole('menuitem', { name: 'Archive', exact: true }).click()
+  await page.locator('dialog').getByRole('button', { name: 'Archive' }).click()
+  await expect(sectionHeader(page, 'workspaces_archived')).toBeVisible()
+}
+
+test.describe('sidebar section menu', () => {
+  test('a repository row pre-fills the New workspace dialog', async ({ page, authenticatedWorkspace, leapmuxServer }) => {
+    const { hubUrl, adminToken, workerId } = leapmuxServer
+    // A second agent in this repository's own checkout, so the section's tabs
+    // carry a git toplevel the menu can offer.
+    await openAgentViaAPI(hubUrl, adminToken, workerId, authenticatedWorkspace.workspaceId, frontendDir)
+    await page.reload()
+    await expect(workspaceRow(page, authenticatedWorkspace.workspaceId)).toBeVisible()
+
+    // Addressed by its test id, not by a name: the row's LABEL is the formatted
+    // origin URL for a repository that has one, which this spec would otherwise
+    // have to predict.
+    const repoRow = sectionMenuPopover(page, 'workspaces_in_progress')
+      .getByTestId('sidebar-new-workspace-repo')
+      .first()
+    // Open and click as one retried unit -- the repository group appears only
+    // once the tab's git state lands, so the first opens can find no row.
+    await expect(async () => {
+      await openSectionMenu(page, 'workspaces_in_progress', repoRow)
+      await repoRow.click()
+    }).toPass()
+
+    await expect(page.getByRole('heading', { name: 'New Workspace' })).toBeVisible()
+    // The worker the repository is on, not "pick one".
+    await expect(page.getByTestId('worker-select-menu-trigger')).toContainText('Local')
+    // The seeded path-info snapshot means the git options paint on the FIRST
+    // render rather than after a probe round trip.
+    await expect(page.getByLabel('Use current state')).toBeVisible()
+  })
+
+  test('the archived section menu opens while the section is COLLAPSED', async ({ page, authenticatedWorkspace }) => {
+    await archiveWorkspace(page, authenticatedWorkspace.workspaceId)
+
+    // Archiving auto-expands the section; collapse it again so the menu is
+    // asked for from the state the section actually ships in.
+    await sectionHeader(page, 'workspaces_archived').click()
+
+    const popover = await openSectionMenu(page, 'workspaces_archived', 'Unarchive all')
+    await expect(popover.getByRole('menuitem', { name: 'Empty archive...', exact: true })).toBeVisible()
+    // No create items: a workspace created into Archived is born read-only.
+    await expect(popover.getByRole('menuitem', { name: 'New workspace...', exact: true })).toHaveCount(0)
+  })
+
+  test('Unarchive all empties the archive back into In progress', async ({ page, authenticatedWorkspace }) => {
+    await archiveWorkspace(page, authenticatedWorkspace.workspaceId)
+
+    await clickSectionMenuItem(page, 'workspaces_archived', 'Unarchive all')
+
+    // The row is back, and the archive offers no bulk operations any more.
+    await expect(workspaceRow(page, authenticatedWorkspace.workspaceId)).toBeVisible()
+    const reopened = await openSectionMenu(page, 'workspaces_archived', 'New section...')
+    await expect(reopened.getByRole('menuitem', { name: 'Unarchive all', exact: true })).toHaveCount(0)
+  })
+
+  test('Collapse all collapses the rows of THAT section', async ({ page, authenticatedWorkspace }) => {
+    const workspaceItem = workspaceRow(page, authenticatedWorkspace.workspaceId)
+    // The active workspace auto-expands once it has a tab.
+    await expect(workspaceItem).toHaveAttribute('data-expanded', 'true')
+
+    await clickSectionMenuItem(page, 'workspaces_in_progress', 'Collapse all')
+
+    // `workspaceRow` is `:visible`-scoped on purpose: the app mounts the
+    // sidebar twice, so an unscoped lookup matches the off-screen copy too.
+    await expect(workspaceItem).toHaveAttribute('data-expanded', 'false')
+
+    await clickSectionMenuItem(page, 'workspaces_in_progress', 'Expand all')
+    await expect(workspaceItem).toHaveAttribute('data-expanded', 'true')
+  })
+
+  test('a custom section can be created, renamed and deleted from the menu', async ({ page, authenticatedWorkspace }) => {
+    await expect(workspaceRow(page, authenticatedWorkspace.workspaceId)).toBeVisible()
+
+    await clickSectionMenuItem(page, 'workspaces_in_progress', 'New section...')
+
+    const dialog = page.locator('[data-testid="section-name-dialog"]')
+    await expect(dialog).toBeVisible()
+    await dialog.getByTestId('title-input').fill('Reviews')
+    await dialog.getByRole('button', { name: 'Create' }).click()
+
+    const custom = page.locator('[data-testid="section-header-workspaces_custom"]:visible').first()
+    await expect(custom).toBeVisible()
+    await expect(custom).toContainText('Reviews')
+
+    // Rename. Only a CUSTOM section offers this -- the hub refuses a built-in.
+    await clickSectionMenuItem(page, 'workspaces_custom', 'Rename section...')
+    await expect(dialog).toBeVisible()
+    await dialog.getByTestId('title-input').fill('Code review')
+    await dialog.getByRole('button', { name: 'Rename' }).click()
+    await expect(custom).toContainText('Code review')
+
+    // Delete, through the confirm that states where the workspaces go.
+    await clickSectionMenuItem(page, 'workspaces_custom', 'Delete section...')
+    const confirm = page.locator('dialog:visible')
+    await expect(confirm).toContainText('Its workspaces move to In progress')
+    await confirm.getByRole('button', { name: 'Delete' }).click()
+    await confirm.getByRole('button', { name: 'Confirm?' }).click()
+
+    await expect(custom).toHaveCount(0)
+  })
+})

--- a/frontend/tests/e2e/195-sidebar-section-menu.spec.ts
+++ b/frontend/tests/e2e/195-sidebar-section-menu.spec.ts
@@ -1,8 +1,8 @@
 import type { Locator, Page } from '@playwright/test'
 import path from 'node:path'
 import { expect, test } from './fixtures'
-import { openAgentViaAPI } from './helpers/api'
-import { workspaceRow } from './helpers/ui'
+import { createWorkspaceViaAPI, openAgentViaAPI } from './helpers/api'
+import { clickRowMenuItem, openRowMenu, workspaceRow } from './helpers/ui'
 
 /**
  * The section header's menu, which replaced the `+`.
@@ -37,40 +37,24 @@ function sectionHeader(page: Page, slug: string): Locator {
 /**
  * Open one section's menu, idempotently.
  *
- * A second click on an already-open trigger CLOSES it, so the retry has to
- * check before it clicks -- the same shape `ensureExpanded` uses.
+ * Through the shared `openRowMenu`, which already retries the open as one unit
+ * because the sidebar re-renders on workspace, worker and todo changes. It
+ * takes `null` for the row: a section header's trigger is always painted, so
+ * there is nothing to hover first.
  */
 async function openSectionMenu(page: Page, slug: string, anyItem: string | Locator): Promise<Locator> {
-  const trigger = sectionMenuTrigger(page, slug)
   const popover = sectionMenuPopover(page, slug)
   const item = typeof anyItem === 'string'
     ? popover.getByRole('menuitem', { name: anyItem, exact: true })
     : anyItem
-  await expect(async () => {
-    if (!await item.isVisible())
-      await trigger.click()
-    await expect(item).toBeVisible()
-  }).toPass()
+  await openRowMenu(null, sectionMenuTrigger(page, slug), item)
   return popover
 }
 
-/**
- * Open a section's menu and click one of its items, retried TOGETHER.
- *
- * Same reasoning as `clickRowMenuItem` in `helpers/ui`: the sidebar re-renders
- * on workspace, worker and todo changes, so the menu can close between the open
- * and the click -- and a retry that covers only the open leaves the click
- * waiting on an item that will never be visible again.
- */
+/** Open a section's menu and click one of its items, retried TOGETHER. */
 async function clickSectionMenuItem(page: Page, slug: string, itemName: string) {
-  const trigger = sectionMenuTrigger(page, slug)
   const item = sectionMenuPopover(page, slug).getByRole('menuitem', { name: itemName, exact: true })
-  await expect(async () => {
-    if (!await item.isVisible())
-      await trigger.click()
-    await expect(item).toBeVisible()
-    await item.click()
-  }).toPass()
+  await clickRowMenuItem(null, sectionMenuTrigger(page, slug), item)
 }
 
 /** Archive the fixture's workspace through its row menu. */
@@ -126,6 +110,37 @@ test.describe('sidebar section menu', () => {
     await expect(popover.getByRole('menuitem', { name: 'New workspace...', exact: true })).toHaveCount(0)
   })
 
+  // The filter box lives in the section BODY, and this menu opens while the
+  // section is collapsed -- where a hidden input takes no focus and the
+  // checkbox would report itself checked for a control nobody can see. The
+  // section def expands first, the same rule "Reveal active workspace"
+  // follows. jsdom cannot show this: a collapsed body is `visibility: hidden`
+  // inside a zero-height row, which only a real layout produces.
+  test('Filter workspaces expands the section it belongs to', async ({ page, authenticatedWorkspace }) => {
+    await archiveWorkspace(page, authenticatedWorkspace.workspaceId)
+    // Archiving auto-expands the section; collapse it again. `data-closed` is
+    // the section's own state -- a collapsed BODY still reports a box, so the
+    // rows inside it are not a usable signal here.
+    const section = sectionHeader(page, 'workspaces_archived')
+    // The SUMMARY row is the toggle; the pane around it is not.
+    await page.locator('[data-testid="section-header-workspaces_archived-summary"]:visible').first().click()
+    await expect(section).toHaveAttribute('data-closed', '')
+
+    // By its test id, not by role: this row is a `menuitemcheckbox`, so the
+    // `menuitem` lookup the other items use never matches it.
+    const toggle = sectionMenuPopover(page, 'workspaces_archived').getByTestId('sidebar-filter-workspaces')
+    await clickRowMenuItem(null, sectionMenuTrigger(page, 'workspaces_archived'), toggle)
+
+    // The section opened, and the box it opened for takes text. Without the
+    // expand-first rule the input mounts inside a `visibility: hidden` body,
+    // so it is never `:visible` and never focusable.
+    await expect(section).not.toHaveAttribute('data-closed', '')
+    const filter = page.locator('[data-testid^="workspace-filter-"]:visible').first()
+    await expect(filter).toBeVisible()
+    await filter.fill('no-such-workspace')
+    await expect(workspaceRow(page, authenticatedWorkspace.workspaceId)).toHaveCount(0)
+  })
+
   test('Unarchive all empties the archive back into In progress', async ({ page, authenticatedWorkspace }) => {
     await archiveWorkspace(page, authenticatedWorkspace.workspaceId)
 
@@ -144,12 +159,46 @@ test.describe('sidebar section menu', () => {
 
     await clickSectionMenuItem(page, 'workspaces_in_progress', 'Collapse all')
 
-    // `workspaceRow` is `:visible`-scoped on purpose: the app mounts the
-    // sidebar twice, so an unscoped lookup matches the off-screen copy too.
+    // `workspaceRow` is `:visible`-scoped on purpose: a sidebar collapsed to
+    // its rail keeps its rows mounted under `display: none`, so an unscoped
+    // lookup can match a row nobody can see.
     await expect(workspaceItem).toHaveAttribute('data-expanded', 'false')
 
     await clickSectionMenuItem(page, 'workspaces_in_progress', 'Expand all')
     await expect(workspaceItem).toHaveAttribute('data-expanded', 'true')
+  })
+
+  // The isolation the header comment promises, which the single-section case
+  // above cannot show: "Collapse all" is a SET operation over one section's
+  // ids, and a regression to writing the whole set back would still pass a
+  // test that owns every row on screen.
+  test('Collapse all leaves ANOTHER section\'s rows expanded', async ({ page, authenticatedWorkspace, leapmuxServer }) => {
+    const second = await createWorkspaceViaAPI(leapmuxServer.hubUrl, leapmuxServer.adminToken, 'second-ws')
+    await openAgentViaAPI(
+      leapmuxServer.hubUrl,
+      leapmuxServer.adminToken,
+      leapmuxServer.workerId,
+      second,
+      frontendDir,
+    )
+    await page.reload()
+
+    const first = workspaceRow(page, authenticatedWorkspace.workspaceId)
+    const other = workspaceRow(page, second)
+    await expect(other).toBeVisible()
+
+    // Both expanded, both in In progress; then archive the second so the two
+    // sit in DIFFERENT sections.
+    await archiveWorkspace(page, second)
+    await expect(sectionHeader(page, 'workspaces_archived')).toBeVisible()
+    await page.locator(`[data-testid="workspace-chevron-${second}"]:visible`).first().click()
+    await expect(other).toHaveAttribute('data-expanded', 'true')
+    await expect(first).toHaveAttribute('data-expanded', 'true')
+
+    await clickSectionMenuItem(page, 'workspaces_in_progress', 'Collapse all')
+
+    await expect(first).toHaveAttribute('data-expanded', 'false')
+    await expect(other).toHaveAttribute('data-expanded', 'true')
   })
 
   test('a custom section can be created, renamed and deleted from the menu', async ({ page, authenticatedWorkspace }) => {
@@ -172,6 +221,28 @@ test.describe('sidebar section menu', () => {
     await dialog.getByTestId('title-input').fill('Code review')
     await dialog.getByRole('button', { name: 'Rename' }).click()
     await expect(custom).toContainText('Code review')
+
+    // With a second workspace section on screen, the row menu offers Move to --
+    // and this is the ONLY place in the suite that opens a `SubMenu` in a real
+    // browser. Every item behind one (Move to, Repository, New agent in <repo>)
+    // is otherwise covered only under vitest, where `showPopover`/`hidePopover`
+    // are stubbed, so a nested popover that never opens would pass everything.
+    const row = workspaceRow(page, authenticatedWorkspace.workspaceId)
+    await clickRowMenuItem(
+      row,
+      row.locator('button').first(),
+      page.getByRole('menuitem', { name: 'Move to', exact: true }),
+    )
+    const moveTo = page.locator('[data-testid="workspace-move-to-popover"]')
+    await expect(moveTo.getByRole('menuitem', { name: 'Code review', exact: true })).toBeVisible()
+    // `isMoveTargetSection` keeps a workspace out of a section it cannot live
+    // in, which is what 014 claimed to cover and could not.
+    await expect(moveTo.getByRole('menuitem', { name: 'Files', exact: true })).toHaveCount(0)
+    await expect(moveTo.getByRole('menuitem', { name: 'To-dos', exact: true })).toHaveCount(0)
+
+    await moveTo.getByRole('menuitem', { name: 'Code review', exact: true }).click()
+    await expect(custom.locator('..').locator(`[data-testid="workspace-item-${authenticatedWorkspace.workspaceId}"]`))
+      .toHaveCount(1)
 
     // Delete, through the confirm that states where the workspaces go.
     await clickSectionMenuItem(page, 'workspaces_custom', 'Delete section...')

--- a/frontend/tests/e2e/helpers/ui.ts
+++ b/frontend/tests/e2e/helpers/ui.ts
@@ -795,7 +795,7 @@ export async function openAgentViaUI(page: Page) {
  * a proxy we invented for the tests.
  *
  * Emphatically NOT the tree root node, which this used to wait for. That node is
- * gated only on `workerId` (available from the CRDT TabRecord immediately) and
+ * dependent only on `workerId` (available from the CRDT TabRecord immediately) and
  * renders against a `props.workingDir || '~'` fallback, so it attaches while the
  * dir is still empty -- i.e. it was already on screen at exactly the moment the
  * race it was supposed to close was open, and the specs kept their original
@@ -1372,10 +1372,13 @@ export async function renameTabViaUI(page: Page, tab: Locator, newTitle: string)
  * Shared by the file-tree three-dot menu and the branch-group one, which differ
  * only in how their trigger is addressed.
  */
-async function openRowMenu(row: Locator, trigger: Locator, item: Locator) {
+export async function openRowMenu(row: Locator | null, trigger: Locator, item: Locator) {
   await expect(async () => {
     if (!await item.isVisible()) {
-      await row.hover()
+      // A row menu's trigger is `opacity: 0` until its row is hovered. A
+      // SECTION HEADER's trigger is always painted, so that caller passes
+      // `null` rather than a row to hover.
+      await row?.hover()
       await trigger.click()
     }
     await expect(item).toBeVisible()
@@ -1389,7 +1392,7 @@ async function openRowMenu(row: Locator, trigger: Locator, item: Locator) {
  * and clicking, so the caller's invariant -- "this item got clicked" -- is what
  * gets retried.
  */
-async function clickRowMenuItem(row: Locator, trigger: Locator, item: Locator) {
+export async function clickRowMenuItem(row: Locator | null, trigger: Locator, item: Locator) {
   await expect(async () => {
     await openRowMenu(row, trigger, item)
     await item.click()

--- a/frontend/tests/e2e/helpers/worktree.ts
+++ b/frontend/tests/e2e/helpers/worktree.ts
@@ -130,18 +130,41 @@ export async function waitForAppPageReady(page: Page) {
 }
 
 /**
- * Open the "New Workspace" dialog by clicking whichever button is available.
- * The left sidebar may be collapsed (rail mode), hiding `sidebar-new-workspace`.
- * Fall back to the empty-state `create-workspace-button` in the main area.
+ * Open the "New Workspace" dialog by whichever route is available.
+ *
+ * The In-progress section header carries a MENU now, and "New workspace..." is
+ * an item inside it -- so the availability probe has to read the TRIGGER, not
+ * the item. A closed `popover="auto"` is `display: none`, so probing the item
+ * would answer "not visible" every single time, send every caller down the
+ * empty-state fallback, and time out wherever that button does not exist.
+ *
+ * The left sidebar may still be collapsed (rail mode), which hides the section
+ * header entirely; the empty-state `create-workspace-button` is the fallback
+ * for that.
+ *
+ * Open-and-click is retried as one unit, following `clickRowMenuItem`: the
+ * sidebar re-renders on workspace, worker and todo changes, so the menu can
+ * vanish between opening it and clicking inside it.
  */
 export async function openNewWorkspaceDialog(page: Page) {
-  const sidebarBtn = page.locator('[data-testid="sidebar-new-workspace"]')
+  const sectionMenu = page.locator('[data-testid="sidebar-section-menu-workspaces_in_progress"]')
   const createBtn = page.locator('[data-testid="create-workspace-button"]')
-  await expectAnyVisible(sidebarBtn, createBtn)
-  if (await isMaybeVisible(sidebarBtn))
-    await sidebarBtn.click()
-  else
+  await expectAnyVisible(sectionMenu, createBtn)
+  if (await isMaybeVisible(sectionMenu)) {
+    const item = page.locator('[data-testid="sidebar-new-workspace"]:visible')
+    await expect(async () => {
+      // Idempotent open, the way `ensureExpanded` does it: a second click on an
+      // already-open trigger CLOSES the menu, which is exactly what a naive
+      // retry would do.
+      if (!await item.isVisible())
+        await sectionMenu.click()
+      await expect(item).toBeVisible()
+      await item.click()
+    }).toPass()
+  }
+  else {
     await createBtn.click()
+  }
   await expect(page.getByRole('heading', { name: 'New Workspace' })).toBeVisible()
 }
 

--- a/proto/leapmux/v1/section.proto
+++ b/proto/leapmux/v1/section.proto
@@ -64,10 +64,18 @@ message ListSectionsResponse {
 
 message CreateSectionRequest {
   string name = 1;
+  // Which sidebar the new section belongs to. Must be LEFT or RIGHT --
+  // MoveSection applies the same rule, so a section cannot be created into a
+  // sidebar it could not be moved to.
+  Sidebar sidebar = 2;
 }
 
 message CreateSectionResponse {
-  string section_id = 1;
+  // The created section, complete. The SERVER computes the lexorank position,
+  // so a response carrying only the id would leave the client either
+  // duplicating that rule -- a second source of truth for section order -- or
+  // refetching the whole list to learn where its own section landed.
+  Section section = 1;
 }
 
 message RenameSectionRequest {


### PR DESCRIPTION
## Motivation

The section header showed only a `+` button for workspace creation. The
backend already supported section rename, delete, and archive operations,
but no UI exposed them, and the collapsed archived section had no other
route to its bulk operations.

The workspace row menu showed no workspace id and offered no way to start
a new agent or terminal on a specific repository.

`lexorank.between` had a bug on a descending pair: the midpoint math
subtracted one unsigned byte from another, wrapped, and returned a rank
outside the given bound — or, for two adjacent characters, a rank equal to
the bound that collided with a live row. This bug matters more now,
because `MoveSection` lets a client drag a section to any position, which
can produce a descending pair.

An archived workspace stayed read-only in the UI, but `RenameWorkspace`
stayed reachable from the CLI or any other client, so a rename could still
reach an archived workspace outside the UI.

## Modifications

- Add `WorkspaceSectionMenu`: section rename and delete, archive bulk
  operations (unarchive all, empty archive), a sort submenu, a filter
  toggle, collapse/expand all, and reveal-active-workspace. It replaces
  the section header's `+` button.
- Change `SidebarSectionDef.headerActions` from an element to a factory
  function, mounted once per section. This keeps the menu's identity
  stable across re-renders. Before this change, a workspace create,
  rename, or move re-created the element and closed any open popover.
  **Breaking: `SidebarSectionDef.headerActions` signature change.**
- Add `SectionNameDialog` (one component shared by create and rename) and
  `useSectionOperations`.
- Expand the workspace row menu: an info block with the workspace id,
  per-repository "New agent" and "New terminal" actions, and a
  "Repository" submenu (copy URL, reveal in file manager, open in
  editor). The file-manager and editor actions appear only for a worker
  on the local machine.
- Change `NewWorkspaceDialog` to take a `startPoint` (`directory` or
  `repo`) instead of a bare `preselectedWorkerId`. A `repo` start point
  pre-fills the worker, the directory, a git-path snapshot, and the git
  mode last used for that repository. **Breaking:
  `NewWorkspaceDialogProps.preselectedWorkerId` replaced by a required
  `startPoint`.**
- Move row expansion, sort, and filter state from per-instance signals to
  one account-scoped module signal each. A section renders once per
  sidebar, so one instance's write used to discard another instance's
  state silently.
- Add a per-section filter box. Suppress drag reordering whenever the
  view order no longer matches the manual lexorank order.
- Fix `lexorank.between` on a descending pair, in the Go implementation
  and its TypeScript port.
- Replace the four-branch "new custom section position" switch with
  `nextSectionPosition`, an order-derived rule that reads the
  `(sidebar, position)` order the store already guarantees.
- Add an explicit `sidebar` field to `CreateSectionRequest`; the server no
  longer hardcodes `LEFT`. **Breaking: a request that omits `sidebar` is
  now rejected with `InvalidArgument`.**
- Change `CreateSectionResponse` to return the whole `Section` instead of
  only an id. **Breaking: this reuses field 1 (`section_id`, string) with
  an incompatible wire type (`section`, `Section`).**
- Add a `refuseArchivedWorkspace` guard on `RenameWorkspace`, in the same
  transaction as the write, so a rename of an archived workspace fails
  from every caller, not only the UI.
- Distinguish "not found" from "built-in" on `RenameSection` and
  `DeleteSection` via `requireCustomSection`; a built-in section now
  answers `FailedPrecondition` instead of an ambiguous `NotFound`.
- Rename `DropdownMenuItemContent.shortcut` to `detail`. **Breaking.**
- Fix `DropdownMenu` roving focus and type-ahead to skip an item inside a
  closed nested popover.
- Add the `SubMenu` component, `workspaceSort.ts`,
  `createAccountScopedSignal`, `workerLocality.isLocalWorker`, and
  `workerPaths` as shared primitives, replacing logic duplicated across
  several sidebar modules.
- Change section-type numbers from SQL literals to bound query
  parameters across all three store dialects, so a proto renumber
  propagates without a manual edit.
- Add the e2e spec `195-sidebar-section-menu.spec.ts`, covering the
  section menu end to end, including the Move-to submenu and the
  collapsed-section case.
- Drop the unread `workspace` parameter from `isWorkspaceMutatable`.
  **Breaking: `isWorkspaceMutatable` signature change**; each caller now
  passes its own presence test.
- Add required props to `WorkspaceContextMenuProps` and
  `WorkspaceSectionContentProps`. **Breaking.**

## Result

A user opens a full menu from the section header, even while the section
stays collapsed. The archived section ships collapsed, and its menu is the
only route to the new bulk operations.

The workspace row menu shows the workspace id and lets a user start a new
agent or terminal on any repository the workspace touches, or copy,
reveal, or open that repository directly. The app disables an action that
only a local worker can do, and states the reason.

A new workspace, when started from a repository, pre-fills the worker,
the directory, and the git mode last used for that repository.

A custom section created after a section drag no longer takes a position
that collides with a live row. The API refuses a rename of an archived
workspace from every caller, not only the app's UI.
