### PR TITLE
feat(pill-group)!: Add robust sliding segmented controls

### DIFF
--- a/NOTICE.html
+++ b/NOTICE.html
@@ -816,6 +816,7 @@ body {
 <li><a href="#diff-900-bsd-3-clause">diff 9.0.0 (BSD-3-Clause)</a></li>
 <li><a href="#fracturedjsonjs-501-mit">fracturedjsonjs 5.0.1 (MIT)</a></li>
 <li><a href="#fzstd-011-mit">fzstd 0.1.1 (MIT)</a></li>
+<li><a href="#lightningcss-1330-mpl-20">lightningcss 1.33.0 (MPL-2.0)</a></li>
 <li><a href="#lucide-solid-1340-isc">lucide-solid 1.34.0 (ISC)</a></li>
 <li><a href="#random-word-slugs-017-mit">random-word-slugs 0.1.7 (MIT)</a></li>
 <li><a href="#rehype-stringify-1001-mit">rehype-stringify 10.0.1 (MIT)</a></li>
@@ -104590,6 +104591,381 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+</code></pre>
+<h3 id="lightningcss-1330-mpl-20">lightningcss 1.33.0 (MPL-2.0)</h3>
+<pre><code> Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+means each individual or legal entity that creates, contributes to
+the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+means the combination of the Contributions of others (if any) used
+by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+means Source Code Form to which the initial Contributor has attached
+the notice in Exhibit A, the Executable Form of such Source Code
+Form, and Modifications of such Source Code Form, in each case
+including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+means
+
+(a) that the initial Contributor has attached the notice described
+in Exhibit B to the Covered Software; or
+
+(b) that the Covered Software was made available under the terms of
+version 1.1 or earlier of the License, but not also under the
+terms of a Secondary License.
+
+1.6. "Executable Form"
+means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+means a work that combines Covered Software with other material, in
+a separate file or files, that is not Covered Software.
+
+1.8. "License"
+means this document.
+
+1.9. "Licensable"
+means having the right to grant, to the maximum extent possible,
+whether at the time of the initial grant or subsequently, any and
+all of the rights conveyed by this License.
+
+1.10. "Modifications"
+means any of the following:
+
+(a) any file in Source Code Form that results from an addition to,
+deletion from, or modification of the contents of Covered
+Software; or
+
+(b) any new file in Source Code Form that contains any Covered
+Software.
+
+1.11. "Patent Claims" of a Contributor
+means any patent claim(s), including without limitation, method,
+process, and apparatus claims, in any patent Licensable by such
+Contributor that would be infringed, but for the grant of the
+License, by the making, using, selling, offering for sale, having
+made, import, or transfer of either its Contributions or its
+Contributor Version.
+
+1.12. "Secondary License"
+means either the GNU General Public License, Version 2.0, the GNU
+Lesser General Public License, Version 2.1, the GNU Affero General
+Public License, Version 3.0, or any later versions of those
+licenses.
+
+1.13. "Source Code Form"
+means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+means an individual or a legal entity exercising rights under this
+License. For legal entities, "You" includes any entity that
+controls, is controlled by, or is under common control with You. For
+purposes of this definition, "control" means (a) the power, direct
+or indirect, to cause the direction or management of such entity,
+whether by contract or otherwise, or (b) ownership of more than
+fifty percent (50%) of the outstanding shares or beneficial
+ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+Licensable by such Contributor to use, reproduce, make available,
+modify, display, perform, distribute, and otherwise exploit its
+Contributions, either on an unmodified basis, with Modifications, or
+as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+for sale, have made, import, and otherwise transfer either its
+Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+or
+
+(b) for infringements caused by: (i) Your and any other third party's
+modifications of Covered Software, or (ii) the combination of its
+Contributions with other software (except as part of its Contributor
+Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+Form, as described in Section 3.1, and You must inform recipients of
+the Executable Form how they can obtain a copy of such Source Code
+Form by reasonable means in a timely manner, at a charge no more
+than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+License, or sublicense it under different terms, provided that the
+license for the Executable Form does not attempt to limit or alter
+the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+* *
+* 6. Disclaimer of Warranty *
+* ------------------------- *
+* *
+* Covered Software is provided under this License on an "as is" *
+* basis, without warranty of any kind, either expressed, implied, or *
+* statutory, including, without limitation, warranties that the *
+* Covered Software is free of defects, merchantable, fit for a *
+* particular purpose or non-infringing. The entire risk as to the *
+* quality and performance of the Covered Software is with You. *
+* Should any Covered Software prove defective in any respect, You *
+* (not any Contributor) assume the cost of any necessary servicing, *
+* repair, or correction. This disclaimer of warranty constitutes an *
+* essential part of this License. No use of any Covered Software is *
+* authorized under this License except under this disclaimer. *
+* *
+************************************************************************
+
+************************************************************************
+* *
+* 7. Limitation of Liability *
+* -------------------------- *
+* *
+* Under no circumstances and under no legal theory, whether tort *
+* (including negligence), contract, or otherwise, shall any *
+* Contributor, or anyone who distributes Covered Software as *
+* permitted above, be liable to You for any direct, indirect, *
+* special, incidental, or consequential damages of any character *
+* including, without limitation, damages for lost profits, loss of *
+* goodwill, work stoppage, computer failure or malfunction, or any *
+* and all other commercial damages or losses, even if such party *
+* shall have been informed of the possibility of such damages. This *
+* limitation of liability shall not apply to liability for death or *
+* personal injury resulting from such party's negligence to the *
+* extent applicable law prohibits such limitation. Some *
+* jurisdictions do not allow the exclusion or limitation of *
+* incidental or consequential damages, so this exclusion and *
+* limitation may not apply to You. *
+* *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+This Source Code Form is "Incompatible With Secondary Licenses", as
+defined by the Mozilla Public License, v. 2.0.
 </code></pre>
 <h3 id="lucide-solid-1340-isc">lucide-solid 1.34.0 (ISC)</h3>
 <pre><code>ISC License

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -720,6 +720,7 @@ For the latest version, see [NOTICE.md on GitHub](https://github.com/leapmux/lea
 - [diff 9.0.0 (BSD-3-Clause)](#diff-900-bsd-3-clause)
 - [fracturedjsonjs 5.0.1 (MIT)](#fracturedjsonjs-501-mit)
 - [fzstd 0.1.1 (MIT)](#fzstd-011-mit)
+- [lightningcss 1.33.0 (MPL-2.0)](#lightningcss-1330-mpl-20)
 - [lucide-solid 1.34.0 (ISC)](#lucide-solid-1340-isc)
 - [random-word-slugs 0.1.7 (MIT)](#random-word-slugs-017-mit)
 - [rehype-stringify 10.0.1 (MIT)](#rehype-stringify-1001-mit)
@@ -106617,6 +106618,384 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+```
+
+### lightningcss 1.33.0 (MPL-2.0)
+
+```
+ Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+means each individual or legal entity that creates, contributes to
+the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+means the combination of the Contributions of others (if any) used
+by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+means Source Code Form to which the initial Contributor has attached
+the notice in Exhibit A, the Executable Form of such Source Code
+Form, and Modifications of such Source Code Form, in each case
+including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+means
+
+(a) that the initial Contributor has attached the notice described
+in Exhibit B to the Covered Software; or
+
+(b) that the Covered Software was made available under the terms of
+version 1.1 or earlier of the License, but not also under the
+terms of a Secondary License.
+
+1.6. "Executable Form"
+means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+means a work that combines Covered Software with other material, in
+a separate file or files, that is not Covered Software.
+
+1.8. "License"
+means this document.
+
+1.9. "Licensable"
+means having the right to grant, to the maximum extent possible,
+whether at the time of the initial grant or subsequently, any and
+all of the rights conveyed by this License.
+
+1.10. "Modifications"
+means any of the following:
+
+(a) any file in Source Code Form that results from an addition to,
+deletion from, or modification of the contents of Covered
+Software; or
+
+(b) any new file in Source Code Form that contains any Covered
+Software.
+
+1.11. "Patent Claims" of a Contributor
+means any patent claim(s), including without limitation, method,
+process, and apparatus claims, in any patent Licensable by such
+Contributor that would be infringed, but for the grant of the
+License, by the making, using, selling, offering for sale, having
+made, import, or transfer of either its Contributions or its
+Contributor Version.
+
+1.12. "Secondary License"
+means either the GNU General Public License, Version 2.0, the GNU
+Lesser General Public License, Version 2.1, the GNU Affero General
+Public License, Version 3.0, or any later versions of those
+licenses.
+
+1.13. "Source Code Form"
+means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+means an individual or a legal entity exercising rights under this
+License. For legal entities, "You" includes any entity that
+controls, is controlled by, or is under common control with You. For
+purposes of this definition, "control" means (a) the power, direct
+or indirect, to cause the direction or management of such entity,
+whether by contract or otherwise, or (b) ownership of more than
+fifty percent (50%) of the outstanding shares or beneficial
+ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+Licensable by such Contributor to use, reproduce, make available,
+modify, display, perform, distribute, and otherwise exploit its
+Contributions, either on an unmodified basis, with Modifications, or
+as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+for sale, have made, import, and otherwise transfer either its
+Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+or
+
+(b) for infringements caused by: (i) Your and any other third party's
+modifications of Covered Software, or (ii) the combination of its
+Contributions with other software (except as part of its Contributor
+Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+Form, as described in Section 3.1, and You must inform recipients of
+the Executable Form how they can obtain a copy of such Source Code
+Form by reasonable means in a timely manner, at a charge no more
+than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+License, or sublicense it under different terms, provided that the
+license for the Executable Form does not attempt to limit or alter
+the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+* *
+* 6. Disclaimer of Warranty *
+* ------------------------- *
+* *
+* Covered Software is provided under this License on an "as is" *
+* basis, without warranty of any kind, either expressed, implied, or *
+* statutory, including, without limitation, warranties that the *
+* Covered Software is free of defects, merchantable, fit for a *
+* particular purpose or non-infringing. The entire risk as to the *
+* quality and performance of the Covered Software is with You. *
+* Should any Covered Software prove defective in any respect, You *
+* (not any Contributor) assume the cost of any necessary servicing, *
+* repair, or correction. This disclaimer of warranty constitutes an *
+* essential part of this License. No use of any Covered Software is *
+* authorized under this License except under this disclaimer. *
+* *
+************************************************************************
+
+************************************************************************
+* *
+* 7. Limitation of Liability *
+* -------------------------- *
+* *
+* Under no circumstances and under no legal theory, whether tort *
+* (including negligence), contract, or otherwise, shall any *
+* Contributor, or anyone who distributes Covered Software as *
+* permitted above, be liable to You for any direct, indirect, *
+* special, incidental, or consequential damages of any character *
+* including, without limitation, damages for lost profits, loss of *
+* goodwill, work stoppage, computer failure or malfunction, or any *
+* and all other commercial damages or losses, even if such party *
+* shall have been informed of the possibility of such damages. This *
+* limitation of liability shall not apply to liability for death or *
+* personal injury resulting from such party's negligence to the *
+* extent applicable law prohibits such limitation. Some *
+* jurisdictions do not allow the exclusion or limitation of *
+* incidental or consequential damages, so this exclusion and *
+* limitation may not apply to You. *
+* *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+This Source Code Form is "Incompatible With Secondary Licenses", as
+defined by the Mozilla Public License, v. 2.0.
 ```
 
 ### lucide-solid 1.34.0 (ISC)

--- a/frontend/src/components/common/AuthMethodPillGroup.test.tsx
+++ b/frontend/src/components/common/AuthMethodPillGroup.test.tsx
@@ -1,0 +1,48 @@
+import { cleanup, render, screen } from '@solidjs/testing-library'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createAuthMethodSelection } from '~/lib/authMethodSelection'
+import { AuthMethodPillGroup } from './AuthMethodPillGroup'
+
+vi.mock('~/lib/systemInfo', async () => {
+  const mock = await import('~/test-support/systemInfoMock')
+  return mock.systemInfoMock
+})
+
+const { resetSystemInfoMock, setSystemInfoMock } = await import('~/test-support/systemInfoMock')
+
+function renderGroup() {
+  const selection = createAuthMethodSelection('login')
+  render(() => <AuthMethodPillGroup label="Sign-in method" selection={selection} />)
+}
+
+beforeEach(() => resetSystemInfoMock())
+afterEach(() => cleanup())
+
+describe('auth method pill group (AuthMethodPillGroup)', () => {
+  it('offers both methods when a ceremony can run', () => {
+    setSystemInfoMock({ passkeyBlocker: null })
+    renderGroup()
+    expect(screen.getAllByRole('radio').map(radio => radio.textContent))
+      .toEqual(['Password', 'Passkey'])
+  })
+
+  it.each([
+    ['insecure-context' as const, /secure page/i],
+    ['no-webauthn' as const, /does not support passkeys/i],
+  ])('keeps a refused passkey and explains %s', (blocker, expected) => {
+    setSystemInfoMock({ passkeyBlocker: blocker })
+    renderGroup()
+    const passkey = screen.getByRole('radio', { name: 'Passkey' })
+    expect(passkey).toHaveAttribute('aria-disabled', 'true')
+    expect(passkey).not.toBeDisabled()
+    const descriptionId = passkey.getAttribute('aria-describedby')
+    expect(descriptionId).toBeTruthy()
+    expect(document.getElementById(descriptionId!)?.textContent).toMatch(expected)
+  })
+
+  it('drops passkey when the hub does not serve this origin', () => {
+    setSystemInfoMock({ passkeyBlocker: 'origin-not-allowed' })
+    renderGroup()
+    expect(screen.getAllByRole('radio').map(radio => radio.textContent)).toEqual(['Password'])
+  })
+})

--- a/frontend/src/components/common/AuthMethodPillGroup.tsx
+++ b/frontend/src/components/common/AuthMethodPillGroup.tsx
@@ -1,0 +1,35 @@
+import type { PillOptions } from './PillGroup'
+import type { AuthMethod, AuthMethodSelection } from '~/lib/authMethodSelection'
+import { passkeyBlocker } from '~/lib/systemInfo'
+import { passkeyBlockerMessage } from '~/lib/webauthn'
+import { PillGroup } from './PillGroup'
+
+function authMethodOptions(): PillOptions<AuthMethod> {
+  const password = { key: 'password' as const, label: 'Password' }
+  const blocker = passkeyBlocker()
+  if (blocker === 'origin-not-allowed')
+    return [password]
+  return [
+    password,
+    {
+      key: 'passkey',
+      label: 'Passkey',
+      disabledReason: blocker ? passkeyBlockerMessage(blocker) : undefined,
+    },
+  ]
+}
+
+/** The shared authentication-method control for each credential form. */
+export function AuthMethodPillGroup(props: {
+  label: string
+  selection: AuthMethodSelection
+}) {
+  return (
+    <PillGroup
+      label={props.label}
+      options={authMethodOptions()}
+      selectedKey={props.selection.effectiveMethod()}
+      onSelect={props.selection.select}
+    />
+  )
+}

--- a/frontend/src/components/common/FilterTabBar.test.tsx
+++ b/frontend/src/components/common/FilterTabBar.test.tsx
@@ -2,62 +2,14 @@
 import { fireEvent, render } from '@solidjs/testing-library'
 import { createSignal } from 'solid-js'
 import { describe, expect, it, vi } from 'vitest'
-import { FilterTabBar, nextFilterTab } from './FilterTabBar'
+import { FilterTabBar } from './FilterTabBar'
 
 /**
  * A filter bar is a TAB SET: picking a tab swaps the region below it. role=tab
  * brings a keyboard contract with it -- Tab reaches the set, the arrows move
  * within it -- which is what this pins.
  */
-describe('nextFilterTab', () => {
-  const keys = ['all', 'changed', 'staged', 'unstaged'] as const
-
-  it('moves forward and backward', () => {
-    expect(nextFilterTab(keys, 'changed', 'ArrowRight')).toBe('staged')
-    expect(nextFilterTab(keys, 'changed', 'ArrowLeft')).toBe('all')
-    expect(nextFilterTab(keys, 'changed', 'ArrowDown')).toBe('staged')
-    expect(nextFilterTab(keys, 'changed', 'ArrowUp')).toBe('all')
-  })
-
-  it('wraps at both ends', () => {
-    expect(nextFilterTab(keys, 'unstaged', 'ArrowRight')).toBe('all')
-    expect(nextFilterTab(keys, 'all', 'ArrowLeft')).toBe('unstaged')
-  })
-
-  it('jumps to the ends with Home and End', () => {
-    expect(nextFilterTab(keys, 'staged', 'Home')).toBe('all')
-    expect(nextFilterTab(keys, 'staged', 'End')).toBe('unstaged')
-  })
-
-  it('ignores keys the tab bar does not own', () => {
-    expect(nextFilterTab(keys, 'staged', 'a')).toBeUndefined()
-    expect(nextFilterTab(keys, 'staged', 'Enter')).toBeUndefined()
-  })
-
-  // The modulo arithmetic divides by the key count, so an empty set would
-  // return NaN-indexed undefined for a key the bar DOES own -- a caller cannot
-  // tell that apart from "not my key" and would preventDefault on it.
-  it('owns no key when the set is empty', () => {
-    expect(nextFilterTab([] as const, 'all', 'ArrowRight')).toBeUndefined()
-    expect(nextFilterTab([] as const, 'all', 'Home')).toBeUndefined()
-  })
-
-  // A current value outside the set (a filter restored from storage after the
-  // tabs changed) starts from the first tab rather than walking from -1.
-  it('starts from the first tab when the current key is absent', () => {
-    expect(nextFilterTab(keys, 'gone' as 'all', 'ArrowRight')).toBe('changed')
-  })
-
-  // A one-tab set wraps onto itself in both directions rather than off the end.
-  it('stays on the only tab of a single-tab set', () => {
-    const one = ['all'] as const
-    expect(nextFilterTab(one, 'all', 'ArrowRight')).toBe('all')
-    expect(nextFilterTab(one, 'all', 'ArrowLeft')).toBe('all')
-    expect(nextFilterTab(one, 'all', 'End')).toBe('all')
-  })
-})
-
-describe('filterTabBar', () => {
+describe('filter tab bar (FilterTabBar)', () => {
   const tabs = [
     { key: 'all', label: 'All' },
     { key: 'subagent', label: 'Subagents' },

--- a/frontend/src/components/common/FilterTabBar.tsx
+++ b/frontend/src/components/common/FilterTabBar.tsx
@@ -1,5 +1,7 @@
 import type { JSX } from 'solid-js'
-import { For, onCleanup } from 'solid-js'
+import { For } from 'solid-js'
+import { createKeyedElementRefs } from '~/lib/keyedElementRefs'
+import { nextRovingValue } from '~/lib/rovingFocus'
 import * as styles from './FilterTabBar.css'
 
 /** One tab: the value it selects, and the text it shows. */
@@ -26,36 +28,6 @@ export interface FilterTabBarProps<K extends string> {
 }
 
 /**
- * Which tab an arrow/Home/End keypress moves to, or undefined for a key the tab
- * bar does not own.
- *
- * Pure and exported so the contract role=tab requires (Tab reaches the SET, the
- * arrows move within it, and both ends wrap) is testable on its own. Unbounded
- * in K: the pill groups (`PillGroup`) adopt it for one-of-N choices whose
- * values are booleans or nulls, not just the tab bar's string keys.
- */
-export function nextFilterTab<K>(keys: readonly K[], current: K, key: string): K | undefined {
-  if (keys.length === 0)
-    return undefined
-  const i = keys.indexOf(current)
-  const cur = i < 0 ? 0 : i
-  switch (key) {
-    case 'ArrowRight':
-    case 'ArrowDown':
-      return keys[(cur + 1) % keys.length]
-    case 'ArrowLeft':
-    case 'ArrowUp':
-      return keys[(cur - 1 + keys.length) % keys.length]
-    case 'Home':
-      return keys[0]
-    case 'End':
-      return keys[keys.length - 1]
-    default:
-      return undefined
-  }
-}
-
-/**
  * A row of filter tabs over one region.
  *
  * A real TAB SET, not a row of toggle buttons: picking a tab swaps the content
@@ -71,7 +43,7 @@ export function nextFilterTab<K>(keys: readonly K[], current: K, key: string): K
 export function FilterTabBar<K extends string>(props: FilterTabBarProps<K>): JSX.Element {
   // Focus has to follow selection for the roving tabindex to work, hence the
   // element refs: the tab that leaves the tab order must hand focus over.
-  const tabEls = new Map<K, HTMLButtonElement>()
+  const tabEls = createKeyedElementRefs<K, HTMLButtonElement>()
 
   const selectTab = (key: K) => {
     props.onSelect(key)
@@ -79,11 +51,11 @@ export function FilterTabBar<K extends string>(props: FilterTabBarProps<K>): JSX
   }
 
   const onKeyDown = (e: KeyboardEvent) => {
-    const next = nextFilterTab(props.tabs.map(t => t.key), props.active, e.key)
+    const next = nextRovingValue(props.tabs.map(t => t.key), props.active, e)
     if (next === undefined)
       return
     e.preventDefault()
-    selectTab(next)
+    selectTab(next.value)
   }
 
   return (
@@ -104,19 +76,7 @@ export function FilterTabBar<K extends string>(props: FilterTabBarProps<K>): JSX
             aria-selected={props.active === tab.key}
             aria-controls={props.panelId}
             tabIndex={props.active === tab.key ? 0 : -1}
-            ref={(el) => {
-              tabEls.set(tab.key, el)
-              // Solid does not re-invoke a ref with null on disposal, so a
-              // caller whose `tabs` shrink would otherwise leave a detached
-              // button in the map -- and `selectTab` would move focus to it,
-              // which lands on `<body>` and takes the arrow keys with it. The
-              // identity check keeps a remove-then-re-add of the same key from
-              // deleting the NEW element's entry.
-              onCleanup(() => {
-                if (tabEls.get(tab.key) === el)
-                  tabEls.delete(tab.key)
-              })
-            }}
+            ref={el => tabEls.register(tab.key, el)}
             // `selectTab`, not `props.onSelect` alone: the roving tabindex moves
             // to this tab, so focus has to move with it. WebKit does not focus a
             // button on click, which would otherwise leave `tabIndex={0}` here

--- a/frontend/src/components/common/LoginPage.test.tsx
+++ b/frontend/src/components/common/LoginPage.test.tsx
@@ -553,7 +553,8 @@ describe('loginPage', () => {
 
     // The lookup itself is half the assertion: the pill keeps its own name.
     const passkey = screen.getByRole('radio', { name: 'Passkey' })
-    expect(passkey).toBeDisabled()
+    expect(passkey).toHaveAttribute('aria-disabled', 'true')
+    expect(passkey).not.toBeDisabled()
     expect(passkey).not.toHaveAttribute('title')
     expect(reasonOf(passkey)).toMatch(expected)
     expect(screen.getByLabelText('Password')).toBeInTheDocument()

--- a/frontend/src/components/common/LoginPage.tsx
+++ b/frontend/src/components/common/LoginPage.tsx
@@ -5,13 +5,13 @@ import type { OAuthProviderInfo } from '~/generated/proto/leapmux/v1/auth_pb'
 import { A, useNavigate, useSearchParams } from '@solidjs/router'
 import { createEffect, createSignal, Show } from 'solid-js'
 import { actionsFooter } from '~/components/common/actionsFooter.css'
+import { AuthMethodPillGroup } from '~/components/common/AuthMethodPillGroup'
 import { CaptchaSection } from '~/components/common/CaptchaSection'
 import { OAuthProviderList } from '~/components/common/OAuthProviderList'
-import { PillGroup } from '~/components/common/PillGroup'
 import { Spinner } from '~/components/common/Spinner'
 import { useAuth } from '~/context/AuthContext'
 import { USERNAME_SOLO } from '~/generated/contracts/validate'
-import { authMethodOptions, createAuthMethodSelection } from '~/lib/authMethodSelection'
+import { createAuthMethodSelection } from '~/lib/authMethodSelection'
 import { createCaptchaForm } from '~/lib/captchaForm'
 import { postAuthNavigate } from '~/lib/postAuthNavigate'
 import { stringParam } from '~/lib/searchParam'
@@ -181,11 +181,9 @@ export const LoginPage: Component = () => {
               autocomplete="username"
             />
           </label>
-          <PillGroup
+          <AuthMethodPillGroup
             label="Sign-in method"
-            options={authMethodOptions()}
-            selected={v => effectiveMethod() === v}
-            onSelect={methodSelection.select}
+            selection={methodSelection}
           />
           <Show when={effectiveMethod() === 'password'}>
             <label>

--- a/frontend/src/components/common/PillGroup.css.ts
+++ b/frontend/src/components/common/PillGroup.css.ts
@@ -1,45 +1,107 @@
 import { style } from '@vanilla-extract/css'
 
+/** One content-sized control with one outer border. */
 export const pillGroup = style({
-  display: 'flex',
-  flexDirection: 'row',
-  gap: 'var(--space-2)',
-})
-
-/** Shape and metrics shared by both pill states; only the colors differ. */
-const pillBase = style({
-  'padding': 'var(--space-2) var(--space-4)',
-  'borderRadius': 'var(--radius-medium)',
-  'fontWeight': 'var(--font-normal)',
-  'cursor': 'pointer',
-  // A governed group keeps its colors and dims as a whole, so the selection it
-  // shows stays readable while the pointer says it is not the thing to click.
-  ':disabled': {
-    cursor: 'default',
-    opacity: 0.55,
-  },
-})
-
-export const pillOption = style([pillBase, {
+  position: 'relative',
+  isolation: 'isolate',
+  display: 'inline-flex',
+  width: 'max-content',
+  gap: 0,
+  overflow: 'hidden',
   backgroundColor: 'var(--card)',
-  color: 'var(--muted-foreground)',
   border: '1px solid var(--border)',
-  selectors: {
-    // Hover changes the border only. The background stays `--card`, which is
-    // what the unhovered pill already uses. Excluded while disabled: a pill
-    // that lights up under the pointer promises a click it refuses.
-    '&:hover:not(:disabled)': {
-      borderColor: 'var(--muted-foreground)',
+  borderRadius: 'var(--radius-medium)',
+})
+
+/**
+ * Dim a governed group as one control. The active value remains readable, and
+ * the pointer shows that this control refuses input.
+ */
+export const pillGroupDisabled = style({
+  opacity: 0.55,
+})
+
+/** The primary fill that moves between the segments. */
+export const selectionIndicator = style({
+  position: 'absolute',
+  insetBlock: 0,
+  left: 0,
+  zIndex: 0,
+  backgroundColor: 'var(--primary)',
+  pointerEvents: 'none',
+  transitionProperty: 'none',
+})
+
+/** Dim the fill when the selected option refuses input on its own. */
+export const selectionIndicatorDimmed = style({
+  opacity: 0.55,
+})
+
+/** Enable motion only for a selection change after the first measurement. */
+export const selectionIndicatorMoves = style({
+  'transition': 'transform var(--transition), width var(--transition)',
+  '@media': {
+    '(prefers-reduced-motion: reduce)': {
+      transitionProperty: 'none',
     },
   },
-}])
+})
 
-export const pillOptionActive = style([pillBase, {
-  backgroundColor: 'var(--primary)',
-  // The label reads from the palette, never from a literal. Every variant
-  // publishes `--primary-foreground` against its own `--primary`, and 21 of
-  // the 30 set it to black -- a literal white is unreadable on those, down to
-  // 1.49:1 on Ayu Mirage. `themes.test.ts` floors this exact pair at 3:1.
+/** Shape and metrics that each segment shares. */
+export const pillOption = style({
+  position: 'relative',
+  zIndex: 1,
+  flexShrink: 0,
+  padding: 'var(--space-2) var(--space-4)',
+  border: 0,
+  borderRadius: 0,
+  backgroundColor: 'transparent',
+  color: 'var(--muted-foreground)',
+  fontWeight: 'var(--font-normal)',
+  opacity: 1,
+  cursor: 'pointer',
+  selectors: {
+    '&:hover:not(:disabled)': {
+      backgroundColor: 'var(--accent)',
+      color: 'var(--foreground)',
+    },
+    '&:active:not(:disabled)': {
+      transform: 'none',
+    },
+    // The group clips its contents to the outer radius. Keep the focus ring
+    // inside each segment so clipping cannot hide it.
+    '&:focus-visible': {
+      outline: '2px solid var(--ring)',
+      outlineOffset: '-2px',
+    },
+    '&:disabled': {
+      cursor: 'default',
+    },
+  },
+})
+
+/** Keep each boundary visible above the moving fill. */
+export const pillOptionSeparated = style({
+  borderInlineStart: '1px solid var(--border)',
+})
+
+/** Dim one refused option without dimming the other segments. */
+export const pillOptionDimmed = style({
+  opacity: 0.55,
+})
+
+/**
+ * The moving indicator supplies this segment's background.
+ *
+ * Read the label from the palette. A literal white label is unreadable on many
+ * light primary colors. The theme tests verify this color pair.
+ */
+export const pillOptionActive = style({
   color: 'var(--primary-foreground)',
-  border: '1px solid var(--primary)',
-}])
+  selectors: {
+    '&:hover:not(:disabled)': {
+      backgroundColor: 'transparent',
+      color: 'var(--primary-foreground)',
+    },
+  },
+})

--- a/frontend/src/components/common/PillGroup.css.ts
+++ b/frontend/src/components/common/PillGroup.css.ts
@@ -6,6 +6,7 @@ export const pillGroup = style({
   isolation: 'isolate',
   display: 'inline-flex',
   width: 'max-content',
+  maxWidth: '100%',
   gap: 0,
   overflow: 'hidden',
   backgroundColor: 'var(--card)',
@@ -13,63 +14,45 @@ export const pillGroup = style({
   borderRadius: 'var(--radius-medium)',
 })
 
-/**
- * Dim a governed group as one control. The active value remains readable, and
- * the pointer shows that this control refuses input.
- */
+/** Dim a group that refuses all changes. */
 export const pillGroupDisabled = style({
   opacity: 0.55,
 })
 
-/** The primary fill that moves between the segments. */
-export const selectionIndicator = style({
-  position: 'absolute',
-  insetBlock: 0,
-  left: 0,
-  zIndex: 0,
-  backgroundColor: 'var(--primary)',
-  pointerEvents: 'none',
-  transitionProperty: 'none',
-})
-
-/** Dim the fill when the selected option refuses input on its own. */
-export const selectionIndicatorDimmed = style({
-  opacity: 0.55,
-})
-
-/** Enable motion only for a selection change after the first measurement. */
-export const selectionIndicatorMoves = style({
-  'transition': 'transform var(--transition), width var(--transition)',
-  '@media': {
-    '(prefers-reduced-motion: reduce)': {
-      transitionProperty: 'none',
-    },
-  },
-})
-
-/** Shape and metrics that each segment shares. */
-export const pillOption = style({
-  position: 'relative',
-  zIndex: 1,
-  flexShrink: 0,
+/** Metrics that the real buttons and their visual copies share. */
+const pillOptionLayout = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  minWidth: 0,
+  flexShrink: 1,
   padding: 'var(--space-2) var(--space-4)',
   border: 0,
   borderRadius: 0,
+  fontSize: 'var(--text-7)',
+  lineHeight: 'var(--leading-normal)',
+  fontWeight: 'var(--font-normal)',
+  whiteSpace: 'normal',
+  overflowWrap: 'anywhere',
+})
+
+/** Shape and behavior for each real radio. */
+export const pillOption = style([pillOptionLayout, {
+  position: 'relative',
+  zIndex: 1,
   backgroundColor: 'transparent',
   color: 'var(--muted-foreground)',
-  fontWeight: 'var(--font-normal)',
   opacity: 1,
   cursor: 'pointer',
+  transitionProperty: 'none',
   selectors: {
-    '&:hover:not(:disabled)': {
+    '&:hover:not(:disabled):not([aria-disabled="true"]):not([aria-checked="true"])': {
       backgroundColor: 'var(--accent)',
       color: 'var(--foreground)',
     },
-    '&:active:not(:disabled)': {
+    '&:active:not(:disabled):not([aria-disabled="true"]):not([aria-checked="true"])': {
       transform: 'none',
     },
-    // The group clips its contents to the outer radius. Keep the focus ring
-    // inside each segment so clipping cannot hide it.
     '&:focus-visible': {
       outline: '2px solid var(--ring)',
       outlineOffset: '-2px',
@@ -78,30 +61,126 @@ export const pillOption = style({
       cursor: 'default',
     },
   },
-})
+}])
 
-/** Keep each boundary visible above the moving fill. */
+/** Keep each boundary visible between adjacent segments. */
 export const pillOptionSeparated = style({
   borderInlineStart: '1px solid var(--border)',
 })
 
-/** Dim one refused option without dimming the other segments. */
+/** Dim an unavailable option that is not selected. */
 export const pillOptionDimmed = style({
   opacity: 0.55,
 })
 
-/**
- * The moving indicator supplies this segment's background.
- *
- * Read the label from the palette. A literal white label is unreadable on many
- * light primary colors. The theme tests verify this color pair.
- */
+/** Mark an option that can receive focus but refuses selection. */
+export const pillOptionUnavailable = style({
+  cursor: 'not-allowed',
+})
+
+/** Paint the complete selected state when the sliding layers are unavailable. */
 export const pillOptionActive = style({
-  color: 'var(--primary-foreground)',
-  selectors: {
-    '&:hover:not(:disabled)': {
-      backgroundColor: 'transparent',
+  'backgroundColor': 'var(--primary)',
+  'color': 'var(--primary-foreground)',
+  'selectors': {
+    '&:hover:not(:disabled):not([aria-disabled="true"])': {
+      backgroundColor: 'var(--primary)',
       color: 'var(--primary-foreground)',
+    },
+    '&:focus-visible': {
+      outlineColor: 'var(--primary-foreground)',
+    },
+  },
+  '@media': {
+    '(forced-colors: active)': {
+      forcedColorAdjust: 'none',
+      backgroundColor: 'Highlight',
+      color: 'HighlightText',
+      selectors: {
+        '&:hover:not(:disabled):not([aria-disabled="true"])': {
+          backgroundColor: 'Highlight',
+          color: 'HighlightText',
+        },
+        '&:focus-visible': {
+          outlineColor: 'HighlightText',
+        },
+      },
+    },
+  },
+})
+
+/** Mark the selected target after the fill reaches it. */
+export const pillOptionSelectedTarget = style({
+  'boxShadow': 'inset 0 0 0 2px var(--primary)',
+  'selectors': {
+    '&:focus-visible': {
+      boxShadow: 'inset 0 0 0 4px var(--primary)',
+      outlineColor: 'var(--primary-foreground)',
+    },
+  },
+  '@media': {
+    '(forced-colors: active)': {
+      boxShadow: 'inset 0 0 0 2px Highlight',
+      selectors: {
+        '&:focus-visible': {
+          boxShadow: 'inset 0 0 0 4px Highlight',
+          outlineColor: 'HighlightText',
+        },
+      },
+    },
+  },
+})
+
+const selectionWindow = style({
+  position: 'absolute',
+  inset: 0,
+  clipPath: 'inset(0 var(--pill-selection-right) 0 var(--pill-selection-left))',
+  pointerEvents: 'none',
+  transitionProperty: 'none',
+})
+
+/** The moving primary background. The real selected button remains outlined. */
+export const selectionFill = style([selectionWindow, {
+  'zIndex': 0,
+  'backgroundColor': 'var(--primary)',
+  '@media': {
+    '(forced-colors: active)': {
+      forcedColorAdjust: 'none',
+      backgroundColor: 'Highlight',
+    },
+  },
+}])
+
+/** Active-color label copies that move with the primary background. */
+export const selectionLabels = style([selectionWindow, {
+  'zIndex': 2,
+  'display': 'flex',
+  'color': 'var(--primary-foreground)',
+  '@media': {
+    '(forced-colors: active)': {
+      forcedColorAdjust: 'none',
+      color: 'HighlightText',
+    },
+  },
+}])
+
+/** One label copy. It has the exact metrics of its real radio. */
+export const selectionLabel = style([pillOptionLayout, {
+  backgroundColor: 'transparent',
+  color: 'inherit',
+  selectors: {
+    '&::before': {
+      content: 'attr(data-label)',
+    },
+  },
+}])
+
+/** Slide both clipped layers after the first valid measurement. */
+export const selectionWindowMoves = style({
+  'transition': 'clip-path var(--transition)',
+  '@media': {
+    '(prefers-reduced-motion: reduce)': {
+      transitionProperty: 'none',
     },
   },
 })

--- a/frontend/src/components/common/PillGroup.test.tsx
+++ b/frontend/src/components/common/PillGroup.test.tsx
@@ -1,15 +1,16 @@
 import { fireEvent, render, screen } from '@solidjs/testing-library'
-import { describe, expect, it, vi } from 'vitest'
+import { createSignal } from 'solid-js'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { installControllableResizeObserver, triggerResizeObserversSync } from '~/test-support/resizeObserverStub'
 import { PillGroup } from './PillGroup'
+import * as styles from './PillGroup.css'
 
 /**
- * The preference pills are one-of-N groups, so they carry radiogroup/radio
- * semantics rather than aria-pressed.
+ * These controls contain one required choice. Radio semantics give the group
+ * its accessible name, selected state, and position information.
  *
- * They shipped as four identical stateless buttons; aria-pressed fixed the
- * "stateless" half and still described the wrong widget — a toggle button
- * announces "pressed", promises it can be un-pressed, and carries no group name
- * and no set position. These pin what a screen reader can actually reach.
+ * The old controls used identical stateless buttons. `aria-pressed` would
+ * describe toggle buttons, which promise that the reader can clear a choice.
  */
 describe('pillGroup', () => {
   const options = [
@@ -23,35 +24,32 @@ describe('pillGroup', () => {
       <PillGroup
         label="Theme"
         options={options}
-        selected={v => v === current}
+        selected={value => value === current}
         onSelect={onSelect}
       />
     ))
     return onSelect
   }
 
-  it('exposes a named group, not a row of anonymous buttons', () => {
+  it('exposes a group with an accessible name', () => {
     renderGroup('dark')
-    // The visible <h3> is not associated with the group in the a11y tree, so
-    // the aria-label is the only name AT ever announces on entry.
+    // A visible heading does not associate itself with this group. The label
+    // prop supplies the name that assistive technology announces.
     expect(screen.getByRole('radiogroup', { name: 'Theme' })).toBeTruthy()
     expect(screen.getAllByRole('radio')).toHaveLength(3)
   })
 
-  it('selects without submitting the form it sits in', () => {
-    // A bare <button> inside a <form> defaults to type="submit". The pills
-    // shipped without an explicit type, so choosing "Passkey" on the login
-    // page SUBMITTED the login form with the username and nothing else: the
-    // submit button went to "Signing in..." and stayed there, and the E2E
-    // helper waited two minutes for a button that never re-enabled.
+  it('selects without submitting its form', () => {
+    // A button in a form submits by default. The old Passkey option started an
+    // incomplete login request and left the submit button unavailable.
     const onSelect = vi.fn()
-    const onSubmit = vi.fn((e: Event) => e.preventDefault())
+    const onSubmit = vi.fn((event: Event) => event.preventDefault())
     render(() => (
       <form onSubmit={onSubmit}>
         <PillGroup
           label="Theme"
           options={options}
-          selected={v => v === null}
+          selected={value => value === null}
           onSelect={onSelect}
         />
         <button type="submit">Go</button>
@@ -64,22 +62,21 @@ describe('pillGroup', () => {
     expect(onSubmit).not.toHaveBeenCalled()
   })
 
-  it('marks exactly one option checked', () => {
+  it('marks exactly one option as checked', () => {
     renderGroup('dark')
-    expect(screen.getByRole('radio', { name: 'Dark' }).getAttribute('aria-checked')).toBe('true')
-    expect(screen.getByRole('radio', { name: 'Light' }).getAttribute('aria-checked')).toBe('false')
-    expect(screen.getByRole('radio', { name: 'Use account default' }).getAttribute('aria-checked')).toBe('false')
+    expect(screen.getByRole('radio', { name: 'Dark' })).toHaveAttribute('aria-checked', 'true')
+    expect(screen.getByRole('radio', { name: 'Light' })).toHaveAttribute('aria-checked', 'false')
+    expect(screen.getByRole('radio', { name: 'Use account default' })).toHaveAttribute('aria-checked', 'false')
   })
 
   it('puts only the checked option in the tab order', () => {
-    // Roving tabindex is what the role requires: Tab reaches the GROUP, the
-    // arrows move within it. Without it every pill is its own tab stop.
+    // Tab enters the group once. Arrow keys then move within the group.
     renderGroup('dark')
-    expect(screen.getByRole('radio', { name: 'Dark' }).getAttribute('tabindex')).toBe('0')
-    expect(screen.getByRole('radio', { name: 'Light' }).getAttribute('tabindex')).toBe('-1')
+    expect(screen.getByRole('radio', { name: 'Dark' })).toHaveAttribute('tabindex', '0')
+    expect(screen.getByRole('radio', { name: 'Light' })).toHaveAttribute('tabindex', '-1')
   })
 
-  it('moves the selection with the arrow keys, wrapping at the ends', () => {
+  it('moves the selection with arrow keys and wraps at each end', () => {
     const onSelect = renderGroup('dark')
     const group = screen.getByRole('radiogroup', { name: 'Theme' })
 
@@ -90,7 +87,7 @@ describe('pillGroup', () => {
     expect(onSelect).toHaveBeenLastCalledWith(null)
   })
 
-  it('jumps to the ends with Home and End', () => {
+  it('moves to each end with Home and End', () => {
     const onSelect = renderGroup('dark')
     const group = screen.getByRole('radiogroup', { name: 'Theme' })
 
@@ -101,27 +98,39 @@ describe('pillGroup', () => {
     expect(onSelect).toHaveBeenLastCalledWith('light')
   })
 
-  it('ignores keys it does not own', () => {
+  it('ignores keys that the group does not own', () => {
     const onSelect = renderGroup('dark')
     fireEvent.keyDown(screen.getByRole('radiogroup', { name: 'Theme' }), { key: 'a' })
     expect(onSelect).not.toHaveBeenCalled()
   })
 
-  it('wraps from the last option forward', () => {
+  it('wraps forward from the last option', () => {
     const onSelect = renderGroup('light')
     fireEvent.keyDown(screen.getByRole('radiogroup', { name: 'Theme' }), { key: 'ArrowRight' })
     expect(onSelect).toHaveBeenLastCalledWith(null)
   })
+
+  it('does not draw an empty group', () => {
+    const result = render(() => (
+      <PillGroup
+        label="Empty choice"
+        options={[]}
+        selected={() => false}
+        onSelect={vi.fn()}
+      />
+    ))
+    expect(screen.queryByRole('radiogroup', { name: 'Empty choice' })).toBeNull()
+    expect(result.container.childElementCount).toBe(0)
+  })
 })
 
 /**
- * A stored browser preference can hold a value that matches no option: the
- * value is read back through an unchecked cast, so a renamed or retired
- * enum value survives in storage. Anchoring the tab stop on the selection
- * left EVERY pill at -1 there, Tab skipped the whole radiogroup, and the
- * arrow keys the group handles reached nothing.
+ * A stale stored value can match no current option.
+ *
+ * Browser storage uses an unchecked cast. A removed enum value can therefore
+ * survive a schema change. The group must remain reachable in this state.
  */
-describe('pillGroup with nothing selected', () => {
+describe('pillGroup with no selected option', () => {
   const options = [
     { value: 'send', label: 'Send' },
     { value: 'newline', label: 'Newline' },
@@ -133,32 +142,30 @@ describe('pillGroup with nothing selected', () => {
       <PillGroup
         label="Enter key"
         options={options}
-        selected={v => v === 'gone-from-the-schema'}
+        selected={value => value === 'gone-from-the-schema'}
         onSelect={onSelect}
       />
     ))
     return onSelect
   }
 
-  it('keeps one pill in the tab order', () => {
+  it('keeps one option in the tab order', () => {
     renderUnmatched()
-    const tabIndexes = screen.getAllByRole('radio').map(el => el.getAttribute('tabindex'))
+    const tabIndexes = screen.getAllByRole('radio').map(element => element.getAttribute('tabindex'))
     expect(tabIndexes).toEqual(['0', '-1', '-1'])
   })
 
-  it('checks none of them', () => {
-    // APG allows an UNCHECKED radio to hold the tab stop; it does not allow
-    // the group to claim a selection the caller does not have.
+  it('does not check an option', () => {
+    // The radio pattern permits an unchecked radio to own the tab stop. The
+    // group must not claim a selection that the caller does not have.
     renderUnmatched()
-    expect(screen.getAllByRole('radio').map(el => el.getAttribute('aria-checked')))
+    expect(screen.getAllByRole('radio').map(element => element.getAttribute('aria-checked')))
       .toEqual(['false', 'false', 'false'])
   })
 
-  it('moves to the SECOND option on ArrowRight, and reaches the first with Home', () => {
-    // Focus sits on the pill that carries the tab stop, which is the first
-    // one, so the arrow moves relative to it. Deriving the origin from the
-    // (absent) selection made ArrowRight land on the first option instead,
-    // which is where focus already was.
+  it('moves from the roving option when an arrow key selects', () => {
+    // Focus starts on the first option. ArrowRight must therefore select the
+    // second option instead of restarting at the first option.
     const onSelect = renderUnmatched()
     const group = screen.getByRole('radiogroup', { name: 'Enter key' })
 
@@ -171,11 +178,10 @@ describe('pillGroup with nothing selected', () => {
 })
 
 /**
- * A group another control governs: the theme chooser's mode pills while the
- * palette is "Match UI".
+ * Another control governs this group and prevents all changes.
  *
- * It must keep SHOWING its selection -- that is what tells the user which mode
- * the governing control produced -- while refusing every way of changing it.
+ * The terminal theme uses this state while it matches the user interface. Its
+ * visible selection shows the mode that the governing control produced.
  */
 describe('pillGroup disabled', () => {
   const options = [
@@ -190,25 +196,25 @@ describe('pillGroup disabled', () => {
         label="Terminal theme mode"
         options={options}
         disabled
-        selected={v => v === current}
+        selected={value => value === current}
         onSelect={onSelect}
       />
     ))
     return onSelect
   }
 
-  it('still reports which option is selected', () => {
+  it('reports its selected option', () => {
     renderDisabled('dark')
     expect(screen.getByRole('radio', { name: 'Dark' })).toHaveAttribute('aria-checked', 'true')
     expect(screen.getByRole('radio', { name: 'System' })).toHaveAttribute('aria-checked', 'false')
   })
 
-  it('takes the whole group out of the tab order', () => {
-    // The roving index normally parks a tab stop on the selected pill. Leaving
-    // it there would put Tab on a control that refuses every key.
+  it('removes the group from the tab order', () => {
+    // A disabled group cannot leave a tab stop on a control that refuses every
+    // keyboard input.
     renderDisabled('dark')
     const radios = screen.getAllByRole('radio')
-    expect(radios.every(r => r.getAttribute('tabindex') === '-1')).toBe(true)
+    expect(radios.every(radio => radio.getAttribute('tabindex') === '-1')).toBe(true)
     for (const radio of radios)
       expect(radio).toBeDisabled()
   })
@@ -219,24 +225,30 @@ describe('pillGroup disabled', () => {
     expect(onSelect).not.toHaveBeenCalled()
   })
 
-  it('refuses the arrow keys, which the GROUP handles rather than the pills', () => {
-    // The native `disabled` attribute stops the click, but the keydown listener
-    // sits on the radiogroup wrapper and would still fire.
+  it('refuses the keys that the group handles', () => {
+    // The native disabled attribute stops a button click. The group still
+    // receives its own keyboard events, so it must refuse them separately.
     const onSelect = renderDisabled('dark')
     const group = screen.getByRole('radiogroup', { name: 'Terminal theme mode' })
     for (const key of ['ArrowRight', 'ArrowLeft', 'Home', 'End'])
       fireEvent.keyDown(group, { key })
     expect(onSelect).not.toHaveBeenCalled()
   })
+
+  it('dims the full group without dimming each option twice', () => {
+    renderDisabled('dark')
+    const group = screen.getByRole('radiogroup', { name: 'Terminal theme mode' })
+    expect(group).toHaveClass(styles.pillGroupDisabled)
+    for (const radio of screen.getAllByRole('radio'))
+      expect(radio).not.toHaveClass(styles.pillOptionDimmed)
+  })
 })
 
 /**
- * ONE refused option, rather than the whole group.
+ * One option can refuse input without disabling the full group.
  *
- * Shown-and-refused is for an option the reader can get back -- the Passkey
- * pill on a page that is not secure. Hiding it leaves somebody whose only
- * credential is a passkey at a dead end with nothing to read, so the pill
- * stays and carries the reason.
+ * A passkey option on an insecure page is restorable. Keep it visible so the
+ * reader can learn why it is unavailable.
  */
 describe('pillGroup with one refused option', () => {
   const reason = 'A browser runs a passkey only on a secure page.'
@@ -249,16 +261,16 @@ describe('pillGroup with one refused option', () => {
           { value: 'password', label: 'Password' },
           { value: 'passkey', label: 'Passkey', disabledReason: reason },
         ]}
-        selected={v => v === current}
+        selected={value => value === current}
         onSelect={onSelect}
       />
     ))
     return onSelect
   }
 
-  it('keeps the pill, its name, and the reason', () => {
+  it('keeps the option, its accessible name, and its reason', () => {
     renderGroup('password')
-    // The lookup itself is half of it: the reason must not become the name.
+    // The reason describes the button. It must not replace the button name.
     const passkey = screen.getByRole('radio', { name: 'Passkey' })
     expect(passkey).toBeDisabled()
     expect(passkey).not.toHaveAttribute('title')
@@ -267,7 +279,7 @@ describe('pillGroup with one refused option', () => {
     expect(document.getElementById(describedBy!)?.textContent).toBe(reason)
   })
 
-  it('leaves the other pills live', () => {
+  it('keeps the other options available', () => {
     const onSelect = renderGroup('passkey')
     const password = screen.getByRole('radio', { name: 'Password' })
     expect(password).toBeEnabled()
@@ -275,23 +287,174 @@ describe('pillGroup with one refused option', () => {
     expect(onSelect).toHaveBeenCalledWith('password')
   })
 
-  // An arrow key that lands on a refused pill strands the group: the pill
-  // takes no tab stop, so focus goes nowhere and the next arrow moves relative
-  // to a value the user cannot reach.
-  it('skips the refused pill with the arrow keys', () => {
+  it('skips the refused option with arrow keys', () => {
+    // A refused option has no tab stop. Moving focus to it would leave the
+    // group without a valid keyboard origin.
     const onSelect = renderGroup('password')
     fireEvent.keyDown(screen.getByRole('radiogroup', { name: 'Sign-in method' }), { key: 'ArrowRight' })
     expect(onSelect).not.toHaveBeenCalledWith('passkey')
   })
 
-  // The tab stop follows the SELECTION, and a selection that is itself refused
-  // has to hand it on -- a group with no tab stop is a group Tab cannot enter.
-  it('moves the tab stop off a refused selection', () => {
+  it('moves the tab stop from a refused selection', () => {
     renderGroup('passkey')
     expect(screen.getByRole('radio', { name: 'Password' })).toHaveAttribute('tabindex', '0')
     expect(screen.getByRole('radio', { name: 'Passkey' })).toHaveAttribute('tabindex', '-1')
-    // Still CHECKED, because that is what the stored value says. The APG
-    // radiogroup rule allows an unchecked radio to hold the tab stop.
+    // The stored value still selects Passkey. The radio pattern permits another
+    // unchecked radio to own the tab stop.
     expect(screen.getByRole('radio', { name: 'Passkey' })).toHaveAttribute('aria-checked', 'true')
+    expect(getIndicator(screen.getByRole('radiogroup', { name: 'Sign-in method' })))
+      .toHaveClass(styles.selectionIndicatorDimmed)
+  })
+})
+
+interface StubGeometry {
+  left: number
+  width: number
+}
+
+function stubGeometry(element: HTMLElement, geometry: StubGeometry): void {
+  Object.defineProperties(element, {
+    offsetLeft: { configurable: true, get: () => geometry.left },
+    offsetWidth: { configurable: true, get: () => geometry.width },
+  })
+}
+
+function getIndicator(group: HTMLElement): HTMLElement | null {
+  return group.querySelector(':scope > [aria-hidden="true"]')
+}
+
+/** The moving fill follows reactive selection and layout changes. */
+describe('pillGroup selection indicator', () => {
+  const first = { value: 'first', label: 'First' }
+  const second = { value: 'second', label: 'A wider second option' }
+
+  beforeEach(() => installControllableResizeObserver())
+
+  it('mounts and removes the control when its option list changes', () => {
+    const [options, setOptions] = createSignal<(typeof first)[]>([])
+    render(() => (
+      <PillGroup
+        label="Loaded options"
+        options={options()}
+        selected={value => value === first.value}
+        onSelect={vi.fn()}
+      />
+    ))
+    expect(screen.queryByRole('radiogroup', { name: 'Loaded options' })).toBeNull()
+
+    setOptions([first])
+    const group = screen.getByRole('radiogroup', { name: 'Loaded options' })
+    stubGeometry(screen.getByRole('radio', { name: first.label }), { left: 0, width: 70 })
+    triggerResizeObserversSync()
+    expect(getIndicator(group)).toHaveStyle({ transform: 'translateX(0px)', width: '70px' })
+
+    setOptions([])
+    expect(screen.queryByRole('radiogroup', { name: 'Loaded options' })).toBeNull()
+  })
+
+  it('starts at the selected segment and moves to a segment with another width', () => {
+    const [current, setCurrent] = createSignal(first.value)
+    render(() => (
+      <PillGroup
+        label="Measured options"
+        options={[first, second]}
+        selected={value => value === current()}
+        onSelect={setCurrent}
+      />
+    ))
+
+    const group = screen.getByRole('radiogroup', { name: 'Measured options' })
+    const firstRadio = screen.getByRole('radio', { name: first.label })
+    const secondRadio = screen.getByRole('radio', { name: second.label })
+    stubGeometry(firstRadio, { left: 0, width: 70 })
+    stubGeometry(secondRadio, { left: 70, width: 150 })
+    triggerResizeObserversSync()
+
+    const indicator = getIndicator(group)
+    expect(indicator).toHaveAttribute('aria-hidden', 'true')
+    expect(indicator).toHaveStyle({ transform: 'translateX(0px)', width: '70px' })
+    expect(indicator).not.toHaveClass(styles.selectionIndicatorMoves)
+
+    fireEvent.click(secondRadio)
+
+    expect(getIndicator(group)).toHaveStyle({ transform: 'translateX(70px)', width: '150px' })
+    expect(getIndicator(group)).toHaveClass(styles.selectionIndicatorMoves)
+  })
+
+  it('adds and removes the indicator without entrance motion', () => {
+    const [current, setCurrent] = createSignal('missing')
+    render(() => (
+      <PillGroup
+        label="Optional selection"
+        options={[first, second]}
+        selected={value => value === current()}
+        onSelect={setCurrent}
+      />
+    ))
+
+    const group = screen.getByRole('radiogroup', { name: 'Optional selection' })
+    const firstRadio = screen.getByRole('radio', { name: first.label })
+    stubGeometry(firstRadio, { left: 0, width: 70 })
+    expect(getIndicator(group)).toBeNull()
+
+    setCurrent(first.value)
+
+    expect(getIndicator(group)).toHaveStyle({ transform: 'translateX(0px)', width: '70px' })
+    expect(getIndicator(group)).not.toHaveClass(styles.selectionIndicatorMoves)
+
+    setCurrent('missing')
+    expect(getIndicator(group)).toBeNull()
+  })
+
+  it('corrects resized geometry without selection motion', () => {
+    const geometry = { left: 70, width: 150 }
+    render(() => (
+      <PillGroup
+        label="Resized options"
+        options={[first, second]}
+        selected={value => value === second.value}
+        onSelect={vi.fn()}
+      />
+    ))
+
+    const group = screen.getByRole('radiogroup', { name: 'Resized options' })
+    stubGeometry(screen.getByRole('radio', { name: first.label }), { left: 0, width: 70 })
+    stubGeometry(screen.getByRole('radio', { name: second.label }), geometry)
+    triggerResizeObserversSync()
+    expect(getIndicator(group)).toHaveStyle({ transform: 'translateX(70px)', width: '150px' })
+
+    geometry.left = 90
+    geometry.width = 180
+    triggerResizeObserversSync()
+
+    expect(getIndicator(group)).toHaveStyle({ transform: 'translateX(90px)', width: '180px' })
+    expect(getIndicator(group)).not.toHaveClass(styles.selectionIndicatorMoves)
+  })
+
+  it('corrects a reorder without treating it as a selection change', () => {
+    const [options, setOptions] = createSignal([first, second])
+    const firstGeometry = { left: 0, width: 70 }
+    const secondGeometry = { left: 70, width: 150 }
+    render(() => (
+      <PillGroup
+        label="Reordered options"
+        options={options()}
+        selected={value => value === second.value}
+        onSelect={vi.fn()}
+      />
+    ))
+
+    const group = screen.getByRole('radiogroup', { name: 'Reordered options' })
+    stubGeometry(screen.getByRole('radio', { name: first.label }), firstGeometry)
+    stubGeometry(screen.getByRole('radio', { name: second.label }), secondGeometry)
+    triggerResizeObserversSync()
+    expect(getIndicator(group)).toHaveStyle({ transform: 'translateX(70px)', width: '150px' })
+
+    firstGeometry.left = 150
+    secondGeometry.left = 0
+    setOptions([second, first])
+
+    expect(getIndicator(group)).toHaveStyle({ transform: 'translateX(0px)', width: '150px' })
+    expect(getIndicator(group)).not.toHaveClass(styles.selectionIndicatorMoves)
   })
 })

--- a/frontend/src/components/common/PillGroup.test.tsx
+++ b/frontend/src/components/common/PillGroup.test.tsx
@@ -1,3 +1,4 @@
+import type { PillOptions } from './PillGroup'
 import { fireEvent, render, screen } from '@solidjs/testing-library'
 import { createSignal } from 'solid-js'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -12,19 +13,19 @@ import * as styles from './PillGroup.css'
  * The old controls used identical stateless buttons. `aria-pressed` would
  * describe toggle buttons, which promise that the reader can clear a choice.
  */
-describe('pillGroup', () => {
+describe('pill group (PillGroup)', () => {
   const options = [
-    { value: null, label: 'Use account default' },
-    { value: 'dark', label: 'Dark' },
-    { value: 'light', label: 'Light' },
-  ]
+    { key: null, label: 'Use account default' },
+    { key: 'dark', label: 'Dark' },
+    { key: 'light', label: 'Light' },
+  ] as const
 
   function renderGroup(current: string | null, onSelect = vi.fn()) {
     render(() => (
       <PillGroup
         label="Theme"
         options={options}
-        selected={value => value === current}
+        selectedKey={current}
         onSelect={onSelect}
       />
     ))
@@ -49,7 +50,7 @@ describe('pillGroup', () => {
         <PillGroup
           label="Theme"
           options={options}
-          selected={value => value === null}
+          selectedKey={null}
           onSelect={onSelect}
         />
         <button type="submit">Go</button>
@@ -60,6 +61,22 @@ describe('pillGroup', () => {
 
     expect(onSelect).toHaveBeenCalledWith('dark')
     expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('does not select the current option again', () => {
+    const onSelect = renderGroup('dark')
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Dark' }))
+
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('does not select the current option again with Home', () => {
+    const onSelect = renderGroup(null)
+
+    fireEvent.keyDown(screen.getByRole('radiogroup', { name: 'Theme' }), { key: 'Home' })
+
+    expect(onSelect).not.toHaveBeenCalled()
   })
 
   it('marks exactly one option as checked', () => {
@@ -76,7 +93,7 @@ describe('pillGroup', () => {
     expect(screen.getByRole('radio', { name: 'Light' })).toHaveAttribute('tabindex', '-1')
   })
 
-  it('moves the selection with arrow keys and wraps at each end', () => {
+  it('moves right and then returns from the focused option', () => {
     const onSelect = renderGroup('dark')
     const group = screen.getByRole('radiogroup', { name: 'Theme' })
 
@@ -84,7 +101,37 @@ describe('pillGroup', () => {
     expect(onSelect).toHaveBeenLastCalledWith('light')
 
     fireEvent.keyDown(group, { key: 'ArrowLeft' })
-    expect(onSelect).toHaveBeenLastCalledWith(null)
+    expect(document.activeElement).toBe(screen.getByRole('radio', { name: 'Dark' }))
+    expect(onSelect).toHaveBeenCalledTimes(1)
+  })
+
+  it('continues from the focused option while selection remains pending', () => {
+    const onSelect = renderGroup('dark')
+    const group = screen.getByRole('radiogroup', { name: 'Theme' })
+
+    screen.getByRole('radio', { name: 'Dark' }).focus()
+    fireEvent.keyDown(group, { key: 'ArrowRight' })
+    expect(document.activeElement).toBe(screen.getByRole('radio', { name: 'Light' }))
+
+    fireEvent.keyDown(group, { key: 'ArrowLeft' })
+    expect(document.activeElement).toBe(screen.getByRole('radio', { name: 'Dark' }))
+    expect(onSelect).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves modified navigation keys to the browser', () => {
+    const onSelect = renderGroup('dark')
+    const group = screen.getByRole('radiogroup', { name: 'Theme' })
+    const event = new KeyboardEvent('keydown', {
+      key: 'ArrowLeft',
+      altKey: true,
+      bubbles: true,
+      cancelable: true,
+    })
+
+    group.dispatchEvent(event)
+
+    expect(event.defaultPrevented).toBe(false)
+    expect(onSelect).not.toHaveBeenCalled()
   })
 
   it('moves to each end with Home and End', () => {
@@ -109,19 +156,6 @@ describe('pillGroup', () => {
     fireEvent.keyDown(screen.getByRole('radiogroup', { name: 'Theme' }), { key: 'ArrowRight' })
     expect(onSelect).toHaveBeenLastCalledWith(null)
   })
-
-  it('does not draw an empty group', () => {
-    const result = render(() => (
-      <PillGroup
-        label="Empty choice"
-        options={[]}
-        selected={() => false}
-        onSelect={vi.fn()}
-      />
-    ))
-    expect(screen.queryByRole('radiogroup', { name: 'Empty choice' })).toBeNull()
-    expect(result.container.childElementCount).toBe(0)
-  })
 })
 
 /**
@@ -130,19 +164,19 @@ describe('pillGroup', () => {
  * Browser storage uses an unchecked cast. A removed enum value can therefore
  * survive a schema change. The group must remain reachable in this state.
  */
-describe('pillGroup with no selected option', () => {
+describe('pill group with no selected option', () => {
   const options = [
-    { value: 'send', label: 'Send' },
-    { value: 'newline', label: 'Newline' },
-    { value: 'smart', label: 'Smart' },
-  ]
+    { key: 'send', label: 'Send' },
+    { key: 'newline', label: 'Newline' },
+    { key: 'smart', label: 'Smart' },
+  ] as const
 
   function renderUnmatched(onSelect = vi.fn()) {
     render(() => (
       <PillGroup
         label="Enter key"
         options={options}
-        selected={value => value === 'gone-from-the-schema'}
+        selectedKey="gone-from-the-schema"
         onSelect={onSelect}
       />
     ))
@@ -177,18 +211,144 @@ describe('pillGroup with no selected option', () => {
   })
 })
 
+describe('pill group option identity', () => {
+  it.each([
+    ['no', []],
+    ['five', [
+      { key: 'one', label: 'One' },
+      { key: 'two', label: 'Two' },
+      { key: 'three', label: 'Three' },
+      { key: 'four', label: 'Four' },
+      { key: 'five', label: 'Five' },
+    ]],
+  ])('rejects %s options', (_description, options) => {
+    expect(() => render(() => (
+      <PillGroup
+        label="Invalid count"
+        options={options as unknown as PillOptions<string>}
+        selectedKey="one"
+        onSelect={vi.fn()}
+      />
+    ))).toThrow(/one through four options/i)
+  })
+
+  it('keeps the focused radio when fresh records carry the same values', () => {
+    const [options, setOptions] = createSignal<PillOptions<string>>([
+      { key: 'password', label: 'Password' },
+      { key: 'passkey', label: 'Passkey' },
+    ])
+    render(() => (
+      <PillGroup
+        label="Sign-in method"
+        options={options()}
+        selectedKey="password"
+        onSelect={vi.fn()}
+      />
+    ))
+    const password = screen.getByRole('radio', { name: 'Password' })
+    password.focus()
+
+    setOptions([
+      { key: 'password', label: 'Password' },
+      { key: 'passkey', label: 'Passkey' },
+    ])
+
+    expect(screen.getByRole('radio', { name: 'Password' })).toBe(password)
+    expect(document.activeElement).toBe(password)
+  })
+
+  it('moves focus when the focused option leaves the group', async () => {
+    const password = { key: 'password', label: 'Password' }
+    const passkey = { key: 'passkey', label: 'Passkey' }
+    const [options, setOptions] = createSignal<PillOptions<string>>([password, passkey])
+    render(() => (
+      <PillGroup
+        label="Sign-in method"
+        options={options()}
+        selectedKey="passkey"
+        onSelect={vi.fn()}
+      />
+    ))
+    screen.getByRole('radio', { name: 'Passkey' }).focus()
+
+    setOptions([password])
+
+    await vi.waitFor(() => {
+      expect(document.activeElement).toBe(screen.getByRole('radio', { name: 'Password' }))
+    })
+  })
+
+  it('rejects duplicate option keys', () => {
+    expect(() => render(() => (
+      <PillGroup
+        label="Duplicate values"
+        options={[
+          { key: 'same', label: 'First' },
+          { key: 'same', label: 'Second' },
+        ]}
+        selectedKey="same"
+        onSelect={vi.fn()}
+      />
+    ))).toThrow(/unique option keys/i)
+  })
+
+  it('rejects an empty disabled reason', () => {
+    expect(() => render(() => (
+      <PillGroup
+        label="Empty reason"
+        options={[{ key: 'blocked', label: 'Blocked', disabledReason: '' }]}
+        selectedKey="blocked"
+        onSelect={vi.fn()}
+      />
+    ))).toThrow(/non-empty disabled reason/i)
+  })
+
+  it('selects undefined and NaN values with arrow keys', () => {
+    const onUndefined = vi.fn()
+    const { unmount } = render(() => (
+      <PillGroup
+        label="Undefined value"
+        options={[
+          { key: 'defined', label: 'Defined' },
+          { key: undefined, label: 'Undefined' },
+        ]}
+        selectedKey="defined"
+        onSelect={onUndefined}
+      />
+    ))
+    fireEvent.keyDown(screen.getByRole('radiogroup', { name: 'Undefined value' }), { key: 'ArrowRight' })
+    expect(onUndefined).toHaveBeenCalledWith(undefined)
+    unmount()
+
+    const onNaN = vi.fn()
+    render(() => (
+      <PillGroup
+        label="NaN value"
+        options={[
+          { key: 0, label: 'Zero' },
+          { key: Number.NaN, label: 'Not a number' },
+        ]}
+        selectedKey={0}
+        onSelect={onNaN}
+      />
+    ))
+    fireEvent.keyDown(screen.getByRole('radiogroup', { name: 'NaN value' }), { key: 'ArrowRight' })
+    expect(onNaN).toHaveBeenCalledWith(Number.NaN)
+  })
+})
+
 /**
  * Another control governs this group and prevents all changes.
  *
  * The terminal theme uses this state while it matches the user interface. Its
  * visible selection shows the mode that the governing control produced.
  */
-describe('pillGroup disabled', () => {
+describe('pill group disabled', () => {
   const options = [
-    { value: 'system', label: 'System' },
-    { value: 'light', label: 'Light' },
-    { value: 'dark', label: 'Dark' },
-  ]
+    { key: 'system', label: 'System' },
+    { key: 'light', label: 'Light' },
+    { key: 'dark', label: 'Dark' },
+  ] as const
 
   function renderDisabled(current: string, onSelect = vi.fn()) {
     render(() => (
@@ -196,7 +356,7 @@ describe('pillGroup disabled', () => {
         label="Terminal theme mode"
         options={options}
         disabled
-        selected={value => value === current}
+        selectedKey={current}
         onSelect={onSelect}
       />
     ))
@@ -250,7 +410,7 @@ describe('pillGroup disabled', () => {
  * A passkey option on an insecure page is restorable. Keep it visible so the
  * reader can learn why it is unavailable.
  */
-describe('pillGroup with one refused option', () => {
+describe('pill group with one refused option', () => {
   const reason = 'A browser runs a passkey only on a secure page.'
 
   function renderGroup(current: string, onSelect = vi.fn()) {
@@ -258,10 +418,10 @@ describe('pillGroup with one refused option', () => {
       <PillGroup
         label="Sign-in method"
         options={[
-          { value: 'password', label: 'Password' },
-          { value: 'passkey', label: 'Passkey', disabledReason: reason },
+          { key: 'password', label: 'Password' },
+          { key: 'passkey', label: 'Passkey', disabledReason: reason },
         ]}
-        selected={value => value === current}
+        selectedKey={current}
         onSelect={onSelect}
       />
     ))
@@ -272,7 +432,8 @@ describe('pillGroup with one refused option', () => {
     renderGroup('password')
     // The reason describes the button. It must not replace the button name.
     const passkey = screen.getByRole('radio', { name: 'Passkey' })
-    expect(passkey).toBeDisabled()
+    expect(passkey).toHaveAttribute('aria-disabled', 'true')
+    expect(passkey).not.toBeDisabled()
     expect(passkey).not.toHaveAttribute('title')
     const describedBy = passkey.getAttribute('aria-describedby')
     expect(describedBy).toBeTruthy()
@@ -287,174 +448,127 @@ describe('pillGroup with one refused option', () => {
     expect(onSelect).toHaveBeenCalledWith('password')
   })
 
-  it('skips the refused option with arrow keys', () => {
-    // A refused option has no tab stop. Moving focus to it would leave the
-    // group without a valid keyboard origin.
+  it('focuses the refused option without selecting it', () => {
+    // Keyboard focus lets a sighted user open the explanation. Activation
+    // still leaves the selection unchanged.
     const onSelect = renderGroup('password')
-    fireEvent.keyDown(screen.getByRole('radiogroup', { name: 'Sign-in method' }), { key: 'ArrowRight' })
-    expect(onSelect).not.toHaveBeenCalledWith('passkey')
+    const password = screen.getByRole('radio', { name: 'Password' })
+    const passkey = screen.getByRole('radio', { name: 'Passkey' })
+    password.focus()
+
+    fireEvent.keyDown(password, { key: 'ArrowRight' })
+
+    expect(document.activeElement).toBe(passkey)
+    expect(onSelect).not.toHaveBeenCalled()
+    fireEvent.click(passkey)
+    expect(onSelect).not.toHaveBeenCalled()
   })
 
   it('moves the tab stop from a refused selection', () => {
     renderGroup('passkey')
-    expect(screen.getByRole('radio', { name: 'Password' })).toHaveAttribute('tabindex', '0')
-    expect(screen.getByRole('radio', { name: 'Passkey' })).toHaveAttribute('tabindex', '-1')
-    // The stored value still selects Passkey. The radio pattern permits another
-    // unchecked radio to own the tab stop.
+    expect(screen.getByRole('radio', { name: 'Password' })).toHaveAttribute('tabindex', '-1')
+    expect(screen.getByRole('radio', { name: 'Passkey' })).toHaveAttribute('tabindex', '0')
     expect(screen.getByRole('radio', { name: 'Passkey' })).toHaveAttribute('aria-checked', 'true')
-    expect(getIndicator(screen.getByRole('radiogroup', { name: 'Sign-in method' })))
-      .toHaveClass(styles.selectionIndicatorDimmed)
+    expect(screen.getByRole('radio', { name: 'Passkey' })).not.toHaveClass(styles.pillOptionDimmed)
+  })
+
+  it('keeps an all-refused group keyboard-reachable', () => {
+    const onSelect = vi.fn()
+    render(() => (
+      <PillGroup
+        label="Unavailable methods"
+        options={[
+          { key: 'first', label: 'First', disabledReason: 'First is unavailable.' },
+          { key: 'second', label: 'Second', disabledReason: 'Second is unavailable.' },
+        ]}
+        selectedKey="first"
+        onSelect={onSelect}
+      />
+    ))
+    const first = screen.getByRole('radio', { name: 'First' })
+    const second = screen.getByRole('radio', { name: 'Second' })
+    expect(first).toHaveAttribute('tabindex', '0')
+
+    first.focus()
+    fireEvent.keyDown(first, { key: 'ArrowRight' })
+
+    expect(document.activeElement).toBe(second)
+    expect(onSelect).not.toHaveBeenCalled()
   })
 })
 
-interface StubGeometry {
-  left: number
-  width: number
-}
-
-function stubGeometry(element: HTMLElement, geometry: StubGeometry): void {
-  Object.defineProperties(element, {
+function stubSelectionGeometry(
+  group: HTMLElement,
+  radio: HTMLElement,
+  geometry: { groupWidth: number, left: number, width: number },
+): void {
+  Object.defineProperties(group, {
+    clientWidth: { configurable: true, get: () => geometry.groupWidth },
+  })
+  Object.defineProperties(radio, {
     offsetLeft: { configurable: true, get: () => geometry.left },
     offsetWidth: { configurable: true, get: () => geometry.width },
   })
 }
 
-function getIndicator(group: HTMLElement): HTMLElement | null {
-  return group.querySelector(':scope > [aria-hidden="true"]')
-}
-
-/** The moving fill follows reactive selection and layout changes. */
-describe('pillGroup selection indicator', () => {
-  const first = { value: 'first', label: 'First' }
-  const second = { value: 'second', label: 'A wider second option' }
+describe('pill group sliding selection', () => {
+  const first = { key: 'first', label: 'First' }
+  const second = { key: 'second', label: 'A wider second option' }
 
   beforeEach(() => installControllableResizeObserver())
 
-  it('mounts and removes the control when its option list changes', () => {
-    const [options, setOptions] = createSignal<(typeof first)[]>([])
-    render(() => (
-      <PillGroup
-        label="Loaded options"
-        options={options()}
-        selected={value => value === first.value}
-        onSelect={vi.fn()}
-      />
-    ))
-    expect(screen.queryByRole('radiogroup', { name: 'Loaded options' })).toBeNull()
-
-    setOptions([first])
-    const group = screen.getByRole('radiogroup', { name: 'Loaded options' })
-    stubGeometry(screen.getByRole('radio', { name: first.label }), { left: 0, width: 70 })
-    triggerResizeObserversSync()
-    expect(getIndicator(group)).toHaveStyle({ transform: 'translateX(0px)', width: '70px' })
-
-    setOptions([])
-    expect(screen.queryByRole('radiogroup', { name: 'Loaded options' })).toBeNull()
-  })
-
-  it('starts at the selected segment and moves to a segment with another width', () => {
-    const [current, setCurrent] = createSignal(first.value)
+  it('keeps the selected button as a fallback until geometry is valid', () => {
     render(() => (
       <PillGroup
         label="Measured options"
         options={[first, second]}
-        selected={value => value === current()}
-        onSelect={setCurrent}
+        selectedKey="first"
+        onSelect={vi.fn()}
       />
     ))
-
     const group = screen.getByRole('radiogroup', { name: 'Measured options' })
     const firstRadio = screen.getByRole('radio', { name: first.label })
-    const secondRadio = screen.getByRole('radio', { name: second.label })
-    stubGeometry(firstRadio, { left: 0, width: 70 })
-    stubGeometry(secondRadio, { left: 70, width: 150 })
+    expect(firstRadio).toHaveClass(styles.pillOptionActive)
+    expect(group.querySelector('[data-pill-selection-fill]')).toBeNull()
+
+    stubSelectionGeometry(group, firstRadio, { groupWidth: 220, left: 0, width: 70 })
     triggerResizeObserversSync()
 
-    const indicator = getIndicator(group)
-    expect(indicator).toHaveAttribute('aria-hidden', 'true')
-    expect(indicator).toHaveStyle({ transform: 'translateX(0px)', width: '70px' })
-    expect(indicator).not.toHaveClass(styles.selectionIndicatorMoves)
+    const fill = group.querySelector<HTMLElement>('[data-pill-selection-fill]')
+    expect(fill).not.toBeNull()
+    expect(fill!.style.getPropertyValue('--pill-selection-left')).toBe('0px')
+    expect(fill!.style.getPropertyValue('--pill-selection-right')).toBe('150px')
+    expect(firstRadio).toHaveClass(styles.pillOptionSelectedTarget)
+    expect(firstRadio).not.toHaveClass(styles.pillOptionActive)
+  })
+
+  it('moves the paired fill and label layers when selection changes', () => {
+    const [selected, setSelected] = createSignal(first.key)
+    render(() => (
+      <PillGroup
+        label="Sliding options"
+        options={[first, second]}
+        selectedKey={selected()}
+        onSelect={setSelected}
+      />
+    ))
+    const group = screen.getByRole('radiogroup', { name: 'Sliding options' })
+    const firstRadio = screen.getByRole('radio', { name: first.label })
+    const secondRadio = screen.getByRole('radio', { name: second.label })
+    stubSelectionGeometry(group, firstRadio, { groupWidth: 220, left: 0, width: 70 })
+    stubSelectionGeometry(group, secondRadio, { groupWidth: 220, left: 70, width: 150 })
+    triggerResizeObserversSync()
 
     fireEvent.click(secondRadio)
 
-    expect(getIndicator(group)).toHaveStyle({ transform: 'translateX(70px)', width: '150px' })
-    expect(getIndicator(group)).toHaveClass(styles.selectionIndicatorMoves)
-  })
-
-  it('adds and removes the indicator without entrance motion', () => {
-    const [current, setCurrent] = createSignal('missing')
-    render(() => (
-      <PillGroup
-        label="Optional selection"
-        options={[first, second]}
-        selected={value => value === current()}
-        onSelect={setCurrent}
-      />
-    ))
-
-    const group = screen.getByRole('radiogroup', { name: 'Optional selection' })
-    const firstRadio = screen.getByRole('radio', { name: first.label })
-    stubGeometry(firstRadio, { left: 0, width: 70 })
-    expect(getIndicator(group)).toBeNull()
-
-    setCurrent(first.value)
-
-    expect(getIndicator(group)).toHaveStyle({ transform: 'translateX(0px)', width: '70px' })
-    expect(getIndicator(group)).not.toHaveClass(styles.selectionIndicatorMoves)
-
-    setCurrent('missing')
-    expect(getIndicator(group)).toBeNull()
-  })
-
-  it('corrects resized geometry without selection motion', () => {
-    const geometry = { left: 70, width: 150 }
-    render(() => (
-      <PillGroup
-        label="Resized options"
-        options={[first, second]}
-        selected={value => value === second.value}
-        onSelect={vi.fn()}
-      />
-    ))
-
-    const group = screen.getByRole('radiogroup', { name: 'Resized options' })
-    stubGeometry(screen.getByRole('radio', { name: first.label }), { left: 0, width: 70 })
-    stubGeometry(screen.getByRole('radio', { name: second.label }), geometry)
-    triggerResizeObserversSync()
-    expect(getIndicator(group)).toHaveStyle({ transform: 'translateX(70px)', width: '150px' })
-
-    geometry.left = 90
-    geometry.width = 180
-    triggerResizeObserversSync()
-
-    expect(getIndicator(group)).toHaveStyle({ transform: 'translateX(90px)', width: '180px' })
-    expect(getIndicator(group)).not.toHaveClass(styles.selectionIndicatorMoves)
-  })
-
-  it('corrects a reorder without treating it as a selection change', () => {
-    const [options, setOptions] = createSignal([first, second])
-    const firstGeometry = { left: 0, width: 70 }
-    const secondGeometry = { left: 70, width: 150 }
-    render(() => (
-      <PillGroup
-        label="Reordered options"
-        options={options()}
-        selected={value => value === second.value}
-        onSelect={vi.fn()}
-      />
-    ))
-
-    const group = screen.getByRole('radiogroup', { name: 'Reordered options' })
-    stubGeometry(screen.getByRole('radio', { name: first.label }), firstGeometry)
-    stubGeometry(screen.getByRole('radio', { name: second.label }), secondGeometry)
-    triggerResizeObserversSync()
-    expect(getIndicator(group)).toHaveStyle({ transform: 'translateX(70px)', width: '150px' })
-
-    firstGeometry.left = 150
-    secondGeometry.left = 0
-    setOptions([second, first])
-
-    expect(getIndicator(group)).toHaveStyle({ transform: 'translateX(0px)', width: '150px' })
-    expect(getIndicator(group)).not.toHaveClass(styles.selectionIndicatorMoves)
+    const fill = group.querySelector<HTMLElement>('[data-pill-selection-fill]')
+    const labels = group.querySelector<HTMLElement>('[data-pill-selection-labels]')
+    expect(fill).toHaveClass(styles.selectionWindowMoves)
+    expect(labels).toHaveClass(styles.selectionWindowMoves)
+    expect(fill!.style.getPropertyValue('--pill-selection-left')).toBe('70px')
+    expect(fill!.style.getPropertyValue('--pill-selection-right')).toBe('0px')
+    expect([...labels!.querySelectorAll('[data-label]')].map(label => label.getAttribute('data-label')))
+      .toEqual(['First', 'A wider second option'])
+    expect(secondRadio).toHaveClass(styles.pillOptionSelectedTarget)
   })
 })

--- a/frontend/src/components/common/PillGroup.tsx
+++ b/frontend/src/components/common/PillGroup.tsx
@@ -1,353 +1,407 @@
-import type { JSXElement } from 'solid-js'
 import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show } from 'solid-js'
+import { createKeyedElementRefs } from '~/lib/keyedElementRefs'
 import { createRafResizeObserver } from '~/lib/resizeObserver'
-import { nextFilterTab } from './FilterTabBar'
+import { nextRovingValue } from '~/lib/rovingFocus'
+import { sameValueZero, shallowEqualMapKeyArrays } from '~/lib/shallowEqual'
 import * as styles from './PillGroup.css'
 import { Tooltip } from './Tooltip'
 
 /** One choice in a {@link PillGroup}. */
-export interface PillOptionSpec<T> {
-  value: T
-  label: JSXElement
-  /**
-   * Refuse this option and explain the reason.
-   *
-   * Keep an option visible when the reader can restore it. The option shows
-   * what exists and what action restores it. Remove options that the
-   * deployment does not support.
-   *
-   * The tooltip works on a disabled button. Its reason does not replace the
-   * accessible name of the button.
-   */
+export interface PillOptionSpec<K> {
+  /** The unique selection key. */
+  key: K
+  label: string
+  /** A non-empty reason that makes this option unavailable. */
   disabledReason?: string
 }
 
-interface IndicatorMetrics {
+/** One through four fixed choices. Use a menu for any other list. */
+export type PillOptions<K>
+  = | readonly [PillOptionSpec<K>]
+    | readonly [PillOptionSpec<K>, PillOptionSpec<K>]
+    | readonly [PillOptionSpec<K>, PillOptionSpec<K>, PillOptionSpec<K>]
+    | readonly [PillOptionSpec<K>, PillOptionSpec<K>, PillOptionSpec<K>, PillOptionSpec<K>]
+
+export const PILL_OPTION_LIMIT = 4
+
+type PillOptionState
+  = | { kind: 'enabled' }
+    | { kind: 'option-refused', reason: string }
+    | { kind: 'group-refused' }
+
+const ENABLED: PillOptionState = { kind: 'enabled' }
+const GROUP_REFUSED: PillOptionState = { kind: 'group-refused' }
+
+interface SelectionMetrics {
   left: number
-  width: number
+  right: number
 }
 
-/**
- * One radio in the group.
- *
- * Selection once used only a CSS class at twelve call sites. A screen reader
- * then described each option as the same stateless button.
- *
- * A radio gives the correct one-of-N semantics. A toggle button would promise
- * that the reader can clear the selected option. This control does not permit
- * that action. A toggle button also lacks the group and set position.
- *
- * A radiogroup can announce "Theme, Dark, radio button, checked, 2 of 3."
- *
- * Keep this component private. A radio outside a radiogroup does not give the
- * reader the required group context. Use `aria-pressed` for a real two-state
- * button that the reader can clear.
- */
+/** One radio in the group. */
 function PillOption(props: {
   selected: boolean
-  /** Whether this radio holds the single tab stop for the group. */
-  roving: boolean
-  /** Whether this radio refuses an input. */
-  disabled: boolean
-  /** Whether this option dims independently from the group. */
-  dimmed: boolean
-  /** Whether a divider precedes this option. */
+  selectionOverlayReady: boolean
+  selectionSettled: boolean
+  tabStop: boolean
+  state: PillOptionState
   separated: boolean
-  /** Why this option refuses an input. */
-  disabledReason?: string
   onClick: () => void
-  ref?: (el: HTMLButtonElement) => void
-  children: JSXElement
+  onFocus: () => void
+  ref: (element: HTMLButtonElement) => void
+  children: string
 }) {
+  const optionRefused = () => props.state.kind === 'option-refused'
+  const groupRefused = () => props.state.kind === 'group-refused'
   const pill = () => (
     <button
-      // A button in a form submits by default. This button only selects an
-      // option, so it must never submit the form.
-      //
-      // The old default made the Passkey option submit the login form. The
-      // incomplete request left the submit button in its "Signing in" state.
       type="button"
       class={styles.pillOption}
       classList={{
-        [styles.pillOptionActive]: props.selected,
-        [styles.pillOptionDimmed]: props.dimmed,
+        [styles.pillOptionActive]: props.selected && !props.selectionOverlayReady,
+        [styles.pillOptionSelectedTarget]: props.selected
+          && props.selectionOverlayReady
+          && props.selectionSettled,
+        [styles.pillOptionDimmed]: optionRefused() && !props.selected,
         [styles.pillOptionSeparated]: props.separated,
+        [styles.pillOptionUnavailable]: optionRefused(),
       }}
       role="radio"
       aria-checked={props.selected}
-      // The native attribute supplies `aria-disabled` through the browser. It
-      // also removes the radio from the tab order.
-      disabled={props.disabled}
-      // The roving option owns the tab stop. Do not derive this value directly
-      // from `selected`. A stale stored value can match no current option.
-      //
-      // The radio pattern permits an unchecked radio to own the tab stop. This
-      // keeps the group reachable when no option is checked.
-      tabIndex={props.roving && !props.disabled ? 0 : -1}
-      ref={el => props.ref?.(el)}
-      onClick={() => props.onClick()}
+      aria-disabled={optionRefused() ? 'true' : undefined}
+      disabled={groupRefused()}
+      tabIndex={props.tabStop && !groupRefused() ? 0 : -1}
+      ref={props.ref}
+      onClick={props.onClick}
+      onFocus={props.onFocus}
     >
       {props.children}
     </button>
   )
 
-  // A tooltip adds listeners and an observer. Mount it only when it has a
-  // reason to show.
   return (
-    <Show when={props.disabledReason} fallback={pill()}>
+    <Show
+      when={props.state.kind === 'option-refused' ? props.state.reason : undefined}
+      fallback={pill()}
+    >
       {reason => <Tooltip text={reason()}>{pill()}</Tooltip>}
     </Show>
   )
 }
 
-/**
- * A one-of-N segmented control with radiogroup semantics.
- *
- * The label gives the group its accessible name. A visible heading above the
- * group does not create this association in the accessibility tree.
- *
- * Arrow, Home, and End keys use the shared roving-tabindex calculation from
- * FilterTabBar. This keeps one keyboard implementation for both controls.
- */
-export function PillGroup<T>(props: {
+function optionMap<K>(label: string, options: readonly PillOptionSpec<K>[]): Map<K, PillOptionSpec<K>> {
+  if (options.length < 1 || options.length > PILL_OPTION_LIMIT)
+    throw new RangeError(`PillGroup "${label}" requires one through four options.`)
+  const byKey = new Map<K, PillOptionSpec<K>>()
+  for (const option of options) {
+    if (byKey.has(option.key))
+      throw new TypeError(`PillGroup "${label}" requires unique option keys.`)
+    if (option.disabledReason !== undefined && option.disabledReason.trim() === '')
+      throw new TypeError(`PillGroup "${label}" requires a non-empty disabled reason.`)
+    byKey.set(option.key, option)
+  }
+  return byKey
+}
+
+/** A segmented one-of-N control with radio semantics. */
+export function PillGroup<K>(props: {
   label: string
-  options: PillOptionSpec<T>[]
-  selected: (value: T) => boolean
-  onSelect: (value: T) => void
-  /**
-   * Show the current selection and refuse changes.
-   *
-   * The theme chooser uses this state while "Match UI theme" controls its mode.
-   * The visible selection shows the value that the governing control produced.
-   * It also shows what disabling that control will restore.
-   */
+  options: PillOptions<K>
+  selectedKey: K
+  onSelect: (key: K) => void
+  /** Show the current selection and refuse all changes. */
   disabled?: boolean
 }) {
-  // `<For>` keeps a row when its position changes. It does not call the ref
-  // again after that move. Store elements by value so focus and indicator
-  // measurements continue to use the correct button.
-  const els = new Map<T, HTMLButtonElement>()
-  const noSelection = Symbol('no selection')
-  const [indicatorMetrics, setIndicatorMetrics] = createSignal<IndicatorMetrics>()
-  const [indicatorMoves, setIndicatorMoves] = createSignal(false)
+  const optionsByKey = createMemo(() => optionMap(props.label, props.options))
+  const optionKeys = createMemo(
+    () => [...optionsByKey().keys()],
+    [],
+    { equals: shallowEqualMapKeyArrays },
+  )
+  const optionEls = createKeyedElementRefs<K, HTMLButtonElement>()
+  const [focusedKey, setFocusedKey] = createSignal<{ value: K }>()
+  const [selectionMetrics, setSelectionMetrics] = createSignal<SelectionMetrics>()
+  const [selectionMoves, setSelectionMoves] = createSignal(false)
+  const [selectionSettled, setSelectionSettled] = createSignal(true)
   let groupEl: HTMLDivElement | undefined
+  let selectionFillEl: HTMLSpanElement | undefined
   let resizeObserver: ReturnType<typeof createRafResizeObserver>
-  let measureScheduled = false
-  let measureFrame: number | undefined
-  let pendingMotion = false
-  let hasIndicatorMetrics = false
+  let geometryObserver: MutationObserver | undefined
+  let hasSelectionMetrics = false
+  let selectionMotionGeneration = 0
 
-  /** Whether the group or the option refuses an input. */
-  const refused = (opt: PillOptionSpec<T>) =>
-    props.disabled === true || opt.disabledReason !== undefined
+  const settleSelectionAfterMotion = () => {
+    const generation = ++selectionMotionGeneration
+    requestAnimationFrame(() => {
+      if (generation !== selectionMotionGeneration)
+        return
+      const animations = selectionFillEl?.getAnimations?.() ?? []
+      if (animations.length === 0) {
+        setSelectionSettled(true)
+        return
+      }
+      void Promise.allSettled(animations.map(animation => animation.finished)).then(() => {
+        if (generation === selectionMotionGeneration)
+          setSelectionSettled(true)
+      })
+    })
+  }
 
-  /** The option that supplies the active fill. */
-  const selectedOption = () => props.options.find(opt => props.selected(opt.value))
+  const stateFor = (option: PillOptionSpec<K>): PillOptionState => {
+    if (props.disabled === true)
+      return GROUP_REFUSED
+    if (option.disabledReason !== undefined)
+      return { kind: 'option-refused', reason: option.disabledReason }
+    return ENABLED
+  }
 
-  /** The values that a keyboard input can reach. */
-  const reachable = createMemo(() => props.options.filter(opt => !refused(opt)).map(opt => opt.value))
+  const focusableOptions = () => [...optionsByKey().values()]
+    .filter(option => stateFor(option).kind !== 'group-refused')
 
-  /**
-   * The option that owns the single tab stop.
-   *
-   * Use the selected option when it accepts input. Otherwise, use the first
-   * reachable option. A stored browser preference can match no current option
-   * after a schema change.
-   *
-   * A refused selection passes the tab stop to a reachable option. The radio
-   * pattern permits an unchecked radio to own that tab stop.
-   *
-   * A group with no reachable option keeps the calculated owner, but the
-   * disabled button receives `tabIndex=-1`. The group still reports a selected
-   * value when one exists.
-   */
-  const rovingIndex = createMemo(() => {
-    const selected = props.options.findIndex(opt => props.selected(opt.value))
-    if (selected >= 0 && !refused(props.options[selected]!))
-      return selected
-    const firstReachable = props.options.findIndex(opt => !refused(opt))
-    if (firstReachable >= 0)
-      return firstReachable
-    return selected < 0 ? 0 : selected
-  })
-
-  const measureIndicator = (move: boolean) => {
-    const option = selectedOption()
-    const selectedEl = option === undefined ? undefined : els.get(option.value)
-    if (!groupEl || !selectedEl?.isConnected) {
-      hasIndicatorMetrics = false
-      setIndicatorMoves(false)
-      setIndicatorMetrics(undefined)
+  const measureSelection = (move: boolean) => {
+    const selected = optionsByKey().get(props.selectedKey)
+    const selectedEl = selected === undefined ? undefined : optionEls.get(selected.key)
+    if (!groupEl || !selectedEl?.isConnected || groupEl.clientWidth <= 0) {
+      selectionMotionGeneration++
+      hasSelectionMetrics = false
+      setSelectionMoves(false)
+      setSelectionSettled(true)
+      setSelectionMetrics(undefined)
       return
     }
 
-    // DOM offsets round to whole CSS pixels, but text can give a segment a
-    // fractional width. Normalize viewport rectangles against an ancestor
-    // scale so the fill keeps the exact layout size during dialog motion.
     const groupRect = groupEl.getBoundingClientRect()
     const selectedRect = selectedEl.getBoundingClientRect()
     const layoutWidth = Number.parseFloat(getComputedStyle(groupEl).width)
-    const hasViewportGeometry = groupRect.width > 0
+    const validViewportGeometry = groupRect.width > 0
       && selectedRect.width > 0
       && Number.isFinite(layoutWidth)
       && layoutWidth > 0
-    const scaleX = hasViewportGeometry ? groupRect.width / layoutWidth : 1
-    const left = hasViewportGeometry
+    const scaleX = validViewportGeometry ? groupRect.width / layoutWidth : 1
+    const rawLeft = validViewportGeometry
       ? (selectedRect.left - groupRect.left) / scaleX - groupEl.clientLeft + groupEl.scrollLeft
       : selectedEl.offsetLeft
-    const width = hasViewportGeometry ? selectedRect.width / scaleX : selectedEl.offsetWidth
+    const rawWidth = validViewportGeometry ? selectedRect.width / scaleX : selectedEl.offsetWidth
+    const left = Math.max(0, rawLeft)
+    const availableWidth = Math.max(0, groupEl.clientWidth - left)
+    const width = Math.min(Math.max(0, rawWidth), availableWidth)
+    const right = Math.max(0, groupEl.clientWidth - left - width)
 
-    // An existing indicator can move between selections. The first valid
-    // measurement must appear at its destination without entrance motion.
-    setIndicatorMoves(move && hasIndicatorMetrics)
-    hasIndicatorMetrics = true
-    setIndicatorMetrics({ left, width })
+    const selectionChanged = move && hasSelectionMetrics
+    const startsMotion = selectionChanged
+      && (typeof matchMedia !== 'function' || !matchMedia('(prefers-reduced-motion: reduce)').matches)
+    if (selectionChanged)
+      setSelectionMoves(true)
+    if (startsMotion) {
+      setSelectionSettled(false)
+    }
+    else if (selectionChanged) {
+      setSelectionSettled(true)
+    }
+    else if (!hasSelectionMetrics) {
+      setSelectionMoves(false)
+      setSelectionSettled(true)
+    }
+    hasSelectionMetrics = true
+    setSelectionMetrics({ left, right })
+    if (startsMotion || !selectionSettled())
+      settleSelectionAfterMotion()
   }
 
-  /** Measure after Solid commits option changes to the DOM. */
-  const scheduleIndicatorMeasure = (move: boolean) => {
-    pendingMotion ||= move
-    if (measureScheduled)
-      return
+  const tabOwner = createMemo<{ value: K } | undefined>(() => {
+    const focused = focusedKey()
+    if (focused !== undefined) {
+      const option = optionsByKey().get(focused.value)
+      if (option !== undefined && stateFor(option).kind !== 'group-refused')
+        return focused
+    }
 
-    measureScheduled = true
-    let firedSynchronously = false
-    const frame = requestAnimationFrame(() => {
-      firedSynchronously = true
-      measureScheduled = false
-      measureFrame = undefined
-      const shouldMove = pendingMotion
-      pendingMotion = false
-      measureIndicator(shouldMove)
-    })
+    const selected = optionsByKey().get(props.selectedKey)
+    if (selected !== undefined && stateFor(selected).kind !== 'group-refused')
+      return { value: selected.key }
 
-    // The test environment runs requestAnimationFrame synchronously. Do not
-    // retain a completed frame in that environment.
-    if (measureScheduled && !firedSynchronously)
-      measureFrame = frame
+    const first = focusableOptions()[0]
+    return first === undefined ? undefined : { value: first.key }
+  })
+
+  const focus = (key: K) => {
+    optionEls.get(key)?.focus()
   }
 
-  let previousSelection: T | typeof noSelection = noSelection
-  createEffect(() => {
-    const option = selectedOption()
-    const selection = option === undefined ? noSelection : option.value
-    const changedSelection = previousSelection !== noSelection
-      && selection !== noSelection
-      && !Object.is(previousSelection, selection)
-    previousSelection = selection
-    scheduleIndicatorMeasure(changedSelection)
-  })
+  const ownsTabStop = (key: K) => {
+    const owner = tabOwner()
+    return owner !== undefined && sameValueZero(key, owner.value)
+  }
 
-  onMount(() => {
-    // Observe every segment because a label or loaded font can change one
-    // segment without changing the selected value.
-    resizeObserver = createRafResizeObserver(() => measureIndicator(false))
-    if (groupEl)
-      resizeObserver?.observe(groupEl)
-    for (const el of els.values())
-      resizeObserver?.observe(el)
-    scheduleIndicatorMeasure(false)
-  })
-
-  onCleanup(() => {
-    resizeObserver?.disconnect()
-    if (measureFrame !== undefined)
-      cancelAnimationFrame(measureFrame)
-    measureScheduled = false
-    pendingMotion = false
-  })
-
-  const selectAt = (value: T | undefined) => {
-    const opt = props.options.find(option => option.value === value)
-    if (!opt || refused(opt))
+  const select = (key: K) => {
+    const option = optionsByKey().get(key)
+    if (option === undefined)
       return
-    props.onSelect(opt.value)
-    els.get(opt.value)?.focus()
+    focus(key)
+    if (stateFor(option).kind !== 'enabled' || sameValueZero(key, props.selectedKey))
+      return
+    props.onSelect(key)
   }
 
   const onKeyDown = (event: KeyboardEvent) => {
-    const values = reachable()
-    if (values.length === 0)
+    const focusable = focusableOptions()
+    const owner = tabOwner()
+    if (owner === undefined)
       return
-
-    // Focus sits on the option that owns the tab stop. Start the keyboard
-    // calculation there when no selected value exists. A missing origin would
-    // make each arrow start from the first option.
-    const origin = props.options[rovingIndex()]?.value
-    const next = nextFilterTab(values, values.includes(origin!) ? origin : values[0], event.key)
+    const next = nextRovingValue(focusable.map(option => option.key), owner.value, event)
     if (next === undefined)
       return
     event.preventDefault()
-    selectAt(next)
+    select(next.value)
   }
 
-  // An empty radiogroup exposes no choice and draws a two-pixel border box.
-  // Render nothing until at least one option exists.
+  const onFocusOut = (event: FocusEvent) => {
+    const destination = event.relatedTarget
+    if (!(destination instanceof Node) || !groupEl?.contains(destination))
+      setFocusedKey(undefined)
+  }
+
+  const restoreFocusAfterRemoval = (element: HTMLButtonElement) => {
+    onCleanup(() => {
+      if (document.activeElement !== element)
+        return
+      setFocusedKey(undefined)
+      queueMicrotask(() => {
+        if (!groupEl?.isConnected)
+          return
+        const active = document.activeElement
+        if (active !== document.body && active !== document.documentElement)
+          return
+        const owner = tabOwner()
+        if (owner !== undefined)
+          focus(owner.value)
+      })
+    })
+  }
+
+  let previousSelection: { value: K } | undefined
+  createEffect(() => {
+    const selected = optionsByKey().get(props.selectedKey)
+    const current = selected === undefined ? undefined : { value: selected.key }
+    const move = previousSelection !== undefined
+      && current !== undefined
+      && !sameValueZero(previousSelection.value, current.value)
+    previousSelection = current
+    measureSelection(move)
+  })
+
+  onMount(() => {
+    resizeObserver = createRafResizeObserver(() => measureSelection(false))
+    if (groupEl)
+      resizeObserver?.observe(groupEl)
+    for (const key of optionKeys()) {
+      const element = optionEls.get(key)
+      if (element)
+        resizeObserver?.observe(element)
+    }
+
+    if (groupEl && typeof MutationObserver !== 'undefined') {
+      geometryObserver = new MutationObserver(() => measureSelection(false))
+      for (let element: HTMLElement | null = groupEl; element; element = element.parentElement) {
+        geometryObserver.observe(element, { attributes: true })
+      }
+    }
+    measureSelection(false)
+  })
+
+  onCleanup(() => {
+    selectionMotionGeneration++
+    resizeObserver?.disconnect()
+    geometryObserver?.disconnect()
+  })
+
+  const selectionStyle = (metrics: SelectionMetrics) => ({
+    '--pill-selection-left': `${metrics.left}px`,
+    '--pill-selection-right': `${metrics.right}px`,
+  })
+
   return (
-    <Show when={props.options.length > 0}>
-      <div
-        ref={(el) => {
-          groupEl = el
-          resizeObserver?.observe(el)
-          onCleanup(() => {
-            resizeObserver?.unobserve(el)
-            if (groupEl === el)
-              groupEl = undefined
-          })
-        }}
-        class={styles.pillGroup}
-        classList={{ [styles.pillGroupDisabled]: props.disabled === true }}
-        role="radiogroup"
-        aria-label={props.label}
-        onKeyDown={onKeyDown}
-      >
-        <Show when={indicatorMetrics()}>
-          {metrics => (
+    <div
+      ref={(element) => {
+        groupEl = element
+        onCleanup(() => {
+          if (groupEl === element)
+            groupEl = undefined
+        })
+      }}
+      class={styles.pillGroup}
+      classList={{ [styles.pillGroupDisabled]: props.disabled === true }}
+      role="radiogroup"
+      aria-label={props.label}
+      onKeyDown={onKeyDown}
+      onFocusOut={onFocusOut}
+    >
+      <Show when={selectionMetrics()}>
+        {metrics => (
+          <>
             <span
-              class={styles.selectionIndicator}
-              classList={{
-                [styles.selectionIndicatorDimmed]: props.disabled !== true
-                  && selectedOption()?.disabledReason !== undefined,
-                [styles.selectionIndicatorMoves]: indicatorMoves(),
-              }}
-              aria-hidden="true"
-              style={{
-                transform: `translateX(${metrics().left}px)`,
-                width: `${metrics().width}px`,
-              }}
-            />
-          )}
-        </Show>
-        <For each={props.options}>
-          {(opt, index) => (
-            <PillOption
-              selected={props.selected(opt.value)}
-              roving={index() === rovingIndex()}
-              disabled={refused(opt)}
-              dimmed={props.disabled !== true && opt.disabledReason !== undefined}
-              separated={index() > 0}
-              disabledReason={opt.disabledReason}
-              onClick={() => selectAt(opt.value)}
-              ref={(el) => {
-                els.set(opt.value, el)
-                resizeObserver?.observe(el)
-                // Solid does not call a ref with null during disposal. A shorter
-                // option list could otherwise retain a detached button.
-                //
-                // Remove only the matching entry. A remove-and-add operation can
-                // give the same value to a new element before cleanup runs.
+              data-pill-selection-fill
+              ref={(element) => {
+                selectionFillEl = element
                 onCleanup(() => {
-                  resizeObserver?.unobserve(el)
-                  if (els.get(opt.value) === el)
-                    els.delete(opt.value)
+                  if (selectionFillEl === element)
+                    selectionFillEl = undefined
                 })
               }}
+              class={styles.selectionFill}
+              classList={{ [styles.selectionWindowMoves]: selectionMoves() }}
+              aria-hidden="true"
+              style={selectionStyle(metrics())}
+            />
+            <div
+              data-pill-selection-labels
+              class={styles.selectionLabels}
+              classList={{ [styles.selectionWindowMoves]: selectionMoves() }}
+              aria-hidden="true"
+              style={selectionStyle(metrics())}
             >
-              {opt.label}
-            </PillOption>
-          )}
-        </For>
-      </div>
-    </Show>
+              <For each={optionKeys()}>
+                {(key, index) => (
+                  <Show when={optionsByKey().get(key)}>
+                    {option => (
+                      <span
+                        class={styles.selectionLabel}
+                        classList={{ [styles.pillOptionSeparated]: index() > 0 }}
+                        data-label={option().label}
+                      />
+                    )}
+                  </Show>
+                )}
+              </For>
+            </div>
+          </>
+        )}
+      </Show>
+      <For each={optionKeys()}>
+        {(key, index) => (
+          <Show when={optionsByKey().get(key)}>
+            {option => (
+              <PillOption
+                selected={sameValueZero(key, props.selectedKey)}
+                selectionOverlayReady={selectionMetrics() !== undefined}
+                selectionSettled={selectionSettled()}
+                tabStop={ownsTabStop(key)}
+                state={stateFor(option())}
+                separated={index() > 0}
+                onClick={() => select(key)}
+                onFocus={() => setFocusedKey({ value: key })}
+                ref={(element) => {
+                  optionEls.register(key, element)
+                  resizeObserver?.observe(element)
+                  onCleanup(() => resizeObserver?.unobserve(element))
+                  restoreFocusAfterRemoval(element)
+                }}
+              >
+                {option().label}
+              </PillOption>
+            )}
+          </Show>
+        )}
+      </For>
+    </div>
   )
 }

--- a/frontend/src/components/common/PillGroup.tsx
+++ b/frontend/src/components/common/PillGroup.tsx
@@ -1,51 +1,59 @@
 import type { JSXElement } from 'solid-js'
-import { createMemo, For, onCleanup, Show } from 'solid-js'
+import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show } from 'solid-js'
+import { createRafResizeObserver } from '~/lib/resizeObserver'
 import { nextFilterTab } from './FilterTabBar'
 import * as styles from './PillGroup.css'
 import { Tooltip } from './Tooltip'
 
-/** One choice of a {@link PillGroup}. */
+/** One choice in a {@link PillGroup}. */
 export interface PillOptionSpec<T> {
   value: T
   label: JSXElement
   /**
-   * Refuse THIS option, and say why.
+   * Refuse this option and explain the reason.
    *
-   * Shown-and-refused rather than removed, for an option the reader can get
-   * back: an option that vanishes leaves somebody who needs it with no way to
-   * learn that it exists or what would restore it. Remove an option instead
-   * when the deployment simply does not have it -- there the reason is not the
-   * reader's to act on, and a permanently dead pill is only noise.
+   * Keep an option visible when the reader can restore it. The option shows
+   * what exists and what action restores it. Remove options that the
+   * deployment does not support.
    *
-   * The reason reaches the reader through `<Tooltip>`, so it works on the
-   * disabled pill and does not become the pill's accessible name.
+   * The tooltip works on a disabled button. Its reason does not replace the
+   * accessible name of the button.
    */
   disabledReason?: string
 }
 
+interface IndicatorMetrics {
+  left: number
+  width: number
+}
+
 /**
- * One pill, as a member of a one-of-N group (role=radio).
+ * One radio in the group.
  *
- * Selection used to be a CSS class alone, twelve times over, so a screen reader
- * read each group as identical stateless buttons. `aria-pressed` fixed the
- * "stateless" half and still described the wrong widget: these groups are all
- * one-of-N, and a toggle button announces "pressed" with no group name and no
- * set position, while promising it can be un-pressed (clicking the selected
- * pill does nothing). role=radio inside a named role=radiogroup announces
- * "Theme, Dark, radio button, checked, 2 of 3".
+ * Selection once used only a CSS class at twelve call sites. A screen reader
+ * then described each option as the same stateless button.
  *
- * Not exported: a pill outside a PillGroup has no radiogroup to belong to, and
- * a lone role=radio is worse than a plain button. A genuine two-state control
- * is a different widget — a button with `aria-pressed`, which announces that
- * un-pressing is available. Do not use this one there.
+ * A radio gives the correct one-of-N semantics. A toggle button would promise
+ * that the reader can clear the selected option. This control does not permit
+ * that action. A toggle button also lacks the group and set position.
+ *
+ * A radiogroup can announce "Theme, Dark, radio button, checked, 2 of 3."
+ *
+ * Keep this component private. A radio outside a radiogroup does not give the
+ * reader the required group context. Use `aria-pressed` for a real two-state
+ * button that the reader can clear.
  */
 function PillOption(props: {
   selected: boolean
-  /** Whether this pill is the group's single tab stop. See PillGroup. */
+  /** Whether this radio holds the single tab stop for the group. */
   roving: boolean
-  /** Show the selection, refuse the click. See PillGroup. */
+  /** Whether this radio refuses an input. */
   disabled: boolean
-  /** Why THIS pill is refused, when it is refused on its own account. */
+  /** Whether this option dims independently from the group. */
+  dimmed: boolean
+  /** Whether a divider precedes this option. */
+  separated: boolean
+  /** Why this option refuses an input. */
   disabledReason?: string
   onClick: () => void
   ref?: (el: HTMLButtonElement) => void
@@ -53,26 +61,28 @@ function PillOption(props: {
 }) {
   const pill = () => (
     <button
-      // A bare <button> inside a <form> defaults to type="submit", so every
-      // pill click SUBMITTED the form it sat in. On the login page that
-      // meant choosing "Passkey" started a sign-in with the username the
-      // user had just typed and nothing else -- the button went to
-      // "Signing in..." and stayed there. A pill selects; it never submits.
+      // A button in a form submits by default. This button only selects an
+      // option, so it must never submit the form.
+      //
+      // The old default made the Passkey option submit the login form. The
+      // incomplete request left the submit button in its "Signing in" state.
       type="button"
-      class={props.selected ? styles.pillOptionActive : styles.pillOption}
+      class={styles.pillOption}
+      classList={{
+        [styles.pillOptionActive]: props.selected,
+        [styles.pillOptionDimmed]: props.dimmed,
+        [styles.pillOptionSeparated]: props.separated,
+      }}
       role="radio"
       aria-checked={props.selected}
-      // The NATIVE attribute, which assistive tech maps to `aria-disabled` on
-      // its own. It also removes the pill from the tab order, so the roving
-      // index below cannot hand the group a tab stop it refuses to act on.
+      // The native attribute supplies `aria-disabled` through the browser. It
+      // also removes the radio from the tab order.
       disabled={props.disabled}
-      // Roving: Tab reaches the GROUP, arrows move within it (see PillGroup).
-      // Keyed on `roving`, NOT on `selected`: a group whose stored value
-      // matches no option has nothing selected, and anchoring the tab stop
-      // on the selection made every pill -1 there — Tab skipped the whole
-      // radiogroup and the arrow keys, which the group handles, reached
-      // nothing. `aria-checked` stays on `selected`, because the APG
-      // radiogroup rule allows an unchecked radio to hold the tab stop.
+      // The roving option owns the tab stop. Do not derive this value directly
+      // from `selected`. A stale stored value can match no current option.
+      //
+      // The radio pattern permits an unchecked radio to own the tab stop. This
+      // keeps the group reachable when no option is checked.
       tabIndex={props.roving && !props.disabled ? 0 : -1}
       ref={el => props.ref?.(el)}
       onClick={() => props.onClick()}
@@ -80,9 +90,9 @@ function PillOption(props: {
       {props.children}
     </button>
   )
-  // Wrapped only when there is something to say. A Tooltip mounts its own
-  // wrapper, listeners and attribute observer even with nothing to show, and
-  // most pills carry no reason at all.
+
+  // A tooltip adds listeners and an observer. Mount it only when it has a
+  // reason to show.
   return (
     <Show when={props.disabledReason} fallback={pill()}>
       {reason => <Tooltip text={reason()}>{pill()}</Tooltip>}
@@ -91,14 +101,13 @@ function PillOption(props: {
 }
 
 /**
- * A one-of-N pill group: the radiogroup wrapper, its accessible name, and the
- * arrow-key contract the role requires.
+ * A one-of-N segmented control with radiogroup semantics.
  *
- * `label` is what assistive tech announces on entry and is the piece a row of
- * bare buttons never had -- the visible <h3> above each group is not associated
- * with it in the accessibility tree. The arrow/Home/End math adopts the pure
- * `nextFilterTab` from FilterTabBar rather than duplicating it, so the tab bar
- * and the pill groups keep one roving-tabindex implementation.
+ * The label gives the group its accessible name. A visible heading above the
+ * group does not create this association in the accessibility tree.
+ *
+ * Arrow, Home, and End keys use the shared roving-tabindex calculation from
+ * FilterTabBar. This keeps one keyboard implementation for both controls.
  */
 export function PillGroup<T>(props: {
   label: string
@@ -106,101 +115,239 @@ export function PillGroup<T>(props: {
   selected: (value: T) => boolean
   onSelect: (value: T) => void
   /**
-   * Show the current selection and refuse to change it.
+   * Show the current selection and refuse changes.
    *
-   * For a group another control governs -- the theme chooser's mode pills while
-   * "Match UI theme" is on. The pills stay VISIBLE rather than disappearing,
-   * because what they display is the answer the governing control produced, and
-   * a user who cannot see it cannot tell what turning the switch off would give
-   * them.
+   * The theme chooser uses this state while "Match UI theme" controls its mode.
+   * The visible selection shows the value that the governing control produced.
+   * It also shows what disabling that control will restore.
    */
   disabled?: boolean
 }) {
-  // Keyed by option value, not by index: `<For>` reuses a row it MOVES
-  // without re-invoking its ref, so an index-keyed array points at the
-  // wrong button after a reorder and `selectAt` moves focus to a pill the
-  // user did not pick. FilterTabBar keys its tabs the same way, and for the
-  // same reason.
+  // `<For>` keeps a row when its position changes. It does not call the ref
+  // again after that move. Store elements by value so focus and indicator
+  // measurements continue to use the correct button.
   const els = new Map<T, HTMLButtonElement>()
+  const noSelection = Symbol('no selection')
+  const [indicatorMetrics, setIndicatorMetrics] = createSignal<IndicatorMetrics>()
+  const [indicatorMoves, setIndicatorMoves] = createSignal(false)
+  let groupEl: HTMLDivElement | undefined
+  let resizeObserver: ReturnType<typeof createRafResizeObserver>
+  let measureScheduled = false
+  let measureFrame: number | undefined
+  let pendingMotion = false
+  let hasIndicatorMetrics = false
 
-  /** Refused, by the group's own flag or by the option's own reason. */
+  /** Whether the group or the option refuses an input. */
   const refused = (opt: PillOptionSpec<T>) =>
     props.disabled === true || opt.disabledReason !== undefined
 
-  /** The values a key can move to. A refused pill is not one of them. */
-  const reachable = createMemo(() => props.options.filter(o => !refused(o)).map(o => o.value))
+  /** The option that supplies the active fill. */
+  const selectedOption = () => props.options.find(opt => props.selected(opt.value))
+
+  /** The values that a keyboard input can reach. */
+  const reachable = createMemo(() => props.options.filter(opt => !refused(opt)).map(opt => opt.value))
 
   /**
-   * The option that holds the group's single tab stop.
+   * The option that owns the single tab stop.
    *
-   * The selected one, or the first REACHABLE one — a browser preference read
-   * back from storage can hold a value that matches no option, and a group
-   * that no key can reach is a group the user cannot change. A selection that
-   * is itself refused hands the tab stop on for the same reason: the APG
-   * radiogroup rule allows an unchecked radio to hold it, and a refused pill
-   * takes no tab stop at all (see `tabIndex` on PillOption).
+   * Use the selected option when it accepts input. Otherwise, use the first
+   * reachable option. A stored browser preference can match no current option
+   * after a schema change.
    *
-   * With EVERY option refused there is nothing to hand it to, so it stays on
-   * the selection (or the first pill) and `tabIndex` resolves it to -1.
+   * A refused selection passes the tab stop to a reachable option. The radio
+   * pattern permits an unchecked radio to own that tab stop.
+   *
+   * A group with no reachable option keeps the calculated owner, but the
+   * disabled button receives `tabIndex=-1`. The group still reports a selected
+   * value when one exists.
    */
   const rovingIndex = createMemo(() => {
-    const selected = props.options.findIndex(o => props.selected(o.value))
+    const selected = props.options.findIndex(opt => props.selected(opt.value))
     if (selected >= 0 && !refused(props.options[selected]!))
       return selected
-    const firstReachable = props.options.findIndex(o => !refused(o))
+    const firstReachable = props.options.findIndex(opt => !refused(opt))
     if (firstReachable >= 0)
       return firstReachable
     return selected < 0 ? 0 : selected
   })
 
+  const measureIndicator = (move: boolean) => {
+    const option = selectedOption()
+    const selectedEl = option === undefined ? undefined : els.get(option.value)
+    if (!groupEl || !selectedEl?.isConnected) {
+      hasIndicatorMetrics = false
+      setIndicatorMoves(false)
+      setIndicatorMetrics(undefined)
+      return
+    }
+
+    // DOM offsets round to whole CSS pixels, but text can give a segment a
+    // fractional width. Normalize viewport rectangles against an ancestor
+    // scale so the fill keeps the exact layout size during dialog motion.
+    const groupRect = groupEl.getBoundingClientRect()
+    const selectedRect = selectedEl.getBoundingClientRect()
+    const layoutWidth = Number.parseFloat(getComputedStyle(groupEl).width)
+    const hasViewportGeometry = groupRect.width > 0
+      && selectedRect.width > 0
+      && Number.isFinite(layoutWidth)
+      && layoutWidth > 0
+    const scaleX = hasViewportGeometry ? groupRect.width / layoutWidth : 1
+    const left = hasViewportGeometry
+      ? (selectedRect.left - groupRect.left) / scaleX - groupEl.clientLeft + groupEl.scrollLeft
+      : selectedEl.offsetLeft
+    const width = hasViewportGeometry ? selectedRect.width / scaleX : selectedEl.offsetWidth
+
+    // An existing indicator can move between selections. The first valid
+    // measurement must appear at its destination without entrance motion.
+    setIndicatorMoves(move && hasIndicatorMetrics)
+    hasIndicatorMetrics = true
+    setIndicatorMetrics({ left, width })
+  }
+
+  /** Measure after Solid commits option changes to the DOM. */
+  const scheduleIndicatorMeasure = (move: boolean) => {
+    pendingMotion ||= move
+    if (measureScheduled)
+      return
+
+    measureScheduled = true
+    let firedSynchronously = false
+    const frame = requestAnimationFrame(() => {
+      firedSynchronously = true
+      measureScheduled = false
+      measureFrame = undefined
+      const shouldMove = pendingMotion
+      pendingMotion = false
+      measureIndicator(shouldMove)
+    })
+
+    // The test environment runs requestAnimationFrame synchronously. Do not
+    // retain a completed frame in that environment.
+    if (measureScheduled && !firedSynchronously)
+      measureFrame = frame
+  }
+
+  let previousSelection: T | typeof noSelection = noSelection
+  createEffect(() => {
+    const option = selectedOption()
+    const selection = option === undefined ? noSelection : option.value
+    const changedSelection = previousSelection !== noSelection
+      && selection !== noSelection
+      && !Object.is(previousSelection, selection)
+    previousSelection = selection
+    scheduleIndicatorMeasure(changedSelection)
+  })
+
+  onMount(() => {
+    // Observe every segment because a label or loaded font can change one
+    // segment without changing the selected value.
+    resizeObserver = createRafResizeObserver(() => measureIndicator(false))
+    if (groupEl)
+      resizeObserver?.observe(groupEl)
+    for (const el of els.values())
+      resizeObserver?.observe(el)
+    scheduleIndicatorMeasure(false)
+  })
+
+  onCleanup(() => {
+    resizeObserver?.disconnect()
+    if (measureFrame !== undefined)
+      cancelAnimationFrame(measureFrame)
+    measureScheduled = false
+    pendingMotion = false
+  })
+
   const selectAt = (value: T | undefined) => {
-    const opt = props.options.find(o => o.value === value)
+    const opt = props.options.find(option => option.value === value)
     if (!opt || refused(opt))
       return
     props.onSelect(opt.value)
     els.get(opt.value)?.focus()
   }
-  const onKeyDown = (e: KeyboardEvent) => {
+
+  const onKeyDown = (event: KeyboardEvent) => {
     const values = reachable()
     if (values.length === 0)
       return
-    // The arrow origin is the pill that CARRIES the tab stop, which is
-    // where focus sits. Deriving it from the selection instead passed
-    // undefined for a group with none, and every arrow key then moved
-    // relative to the first option whatever was focused.
+
+    // Focus sits on the option that owns the tab stop. Start the keyboard
+    // calculation there when no selected value exists. A missing origin would
+    // make each arrow start from the first option.
     const origin = props.options[rovingIndex()]?.value
-    const next = nextFilterTab(values, values.includes(origin!) ? origin : values[0], e.key)
+    const next = nextFilterTab(values, values.includes(origin!) ? origin : values[0], event.key)
     if (next === undefined)
       return
-    e.preventDefault()
+    event.preventDefault()
     selectAt(next)
   }
+
+  // An empty radiogroup exposes no choice and draws a two-pixel border box.
+  // Render nothing until at least one option exists.
   return (
-    <div class={styles.pillGroup} role="radiogroup" aria-label={props.label} onKeyDown={onKeyDown}>
-      <For each={props.options}>
-        {(opt, i) => (
-          <PillOption
-            selected={props.selected(opt.value)}
-            roving={i() === rovingIndex()}
-            disabled={refused(opt)}
-            disabledReason={opt.disabledReason}
-            onClick={() => selectAt(opt.value)}
-            ref={(el) => {
-              els.set(opt.value, el)
-              // Solid does not re-invoke a ref with null on disposal, so a
-              // shrinking option list would leave a detached button in the
-              // map. The identity check keeps a remove-then-re-add of the
-              // same value from deleting the NEW element's entry.
-              onCleanup(() => {
-                if (els.get(opt.value) === el)
-                  els.delete(opt.value)
-              })
-            }}
-          >
-            {opt.label}
-          </PillOption>
-        )}
-      </For>
-    </div>
+    <Show when={props.options.length > 0}>
+      <div
+        ref={(el) => {
+          groupEl = el
+          resizeObserver?.observe(el)
+          onCleanup(() => {
+            resizeObserver?.unobserve(el)
+            if (groupEl === el)
+              groupEl = undefined
+          })
+        }}
+        class={styles.pillGroup}
+        classList={{ [styles.pillGroupDisabled]: props.disabled === true }}
+        role="radiogroup"
+        aria-label={props.label}
+        onKeyDown={onKeyDown}
+      >
+        <Show when={indicatorMetrics()}>
+          {metrics => (
+            <span
+              class={styles.selectionIndicator}
+              classList={{
+                [styles.selectionIndicatorDimmed]: props.disabled !== true
+                  && selectedOption()?.disabledReason !== undefined,
+                [styles.selectionIndicatorMoves]: indicatorMoves(),
+              }}
+              aria-hidden="true"
+              style={{
+                transform: `translateX(${metrics().left}px)`,
+                width: `${metrics().width}px`,
+              }}
+            />
+          )}
+        </Show>
+        <For each={props.options}>
+          {(opt, index) => (
+            <PillOption
+              selected={props.selected(opt.value)}
+              roving={index() === rovingIndex()}
+              disabled={refused(opt)}
+              dimmed={props.disabled !== true && opt.disabledReason !== undefined}
+              separated={index() > 0}
+              disabledReason={opt.disabledReason}
+              onClick={() => selectAt(opt.value)}
+              ref={(el) => {
+                els.set(opt.value, el)
+                resizeObserver?.observe(el)
+                // Solid does not call a ref with null during disposal. A shorter
+                // option list could otherwise retain a detached button.
+                //
+                // Remove only the matching entry. A remove-and-add operation can
+                // give the same value to a new element before cleanup runs.
+                onCleanup(() => {
+                  resizeObserver?.unobserve(el)
+                  if (els.get(opt.value) === el)
+                    els.delete(opt.value)
+                })
+              }}
+            >
+              {opt.label}
+            </PillOption>
+          )}
+        </For>
+      </div>
+    </Show>
   )
 }

--- a/frontend/src/components/common/RecoverCompletePage.tsx
+++ b/frontend/src/components/common/RecoverCompletePage.tsx
@@ -3,10 +3,10 @@ import { A, useNavigate, useSearchParams } from '@solidjs/router'
 import { createSignal, Show } from 'solid-js'
 import { authClient } from '~/api/clients'
 import { actionsFooter } from '~/components/common/actionsFooter.css'
+import { AuthMethodPillGroup } from '~/components/common/AuthMethodPillGroup'
 import { CaptchaSection } from '~/components/common/CaptchaSection'
-import { PillGroup } from '~/components/common/PillGroup'
 import { Spinner } from '~/components/common/Spinner'
-import { authMethodOptions, createAuthMethodSelection } from '~/lib/authMethodSelection'
+import { createAuthMethodSelection } from '~/lib/authMethodSelection'
 import { createCaptchaForm } from '~/lib/captchaForm'
 import { stringParam } from '~/lib/searchParam'
 import { passkeyErrorMessage, startRegistration } from '~/lib/webauthn'
@@ -96,11 +96,9 @@ export const RecoverCompletePage: Component = () => {
           )}
         >
           <form class="vstack gap-4" onSubmit={handleSubmit}>
-            <PillGroup
+            <AuthMethodPillGroup
               label="Recovery method"
-              options={authMethodOptions()}
-              selected={v => effectiveMethod() === v}
-              onSelect={methodSelection.select}
+              selection={methodSelection}
             />
             <Show when={effectiveMethod() === 'password'}>
               <PasswordFields

--- a/frontend/src/components/common/SignupForm.test.tsx
+++ b/frontend/src/components/common/SignupForm.test.tsx
@@ -163,7 +163,8 @@ describe('signup form passkey path', () => {
     renderForm()
 
     const passkey = screen.getByRole('radio', { name: 'Passkey' })
-    expect(passkey).toBeDisabled()
+    expect(passkey).toHaveAttribute('aria-disabled', 'true')
+    expect(passkey).not.toBeDisabled()
     expect(passkey).not.toHaveAttribute('title')
     expect(reasonOf(passkey)).toMatch(expected)
     expect(screen.getByLabelText('New Password')).toBeInTheDocument()

--- a/frontend/src/components/common/SignupForm.tsx
+++ b/frontend/src/components/common/SignupForm.tsx
@@ -5,9 +5,9 @@ import type { EmailVerificationStatus, User } from '~/generated/proto/leapmux/v1
 import { createSignal, Show } from 'solid-js'
 import { authClient } from '~/api/clients'
 import { actionsFooter } from '~/components/common/actionsFooter.css'
+import { AuthMethodPillGroup } from '~/components/common/AuthMethodPillGroup'
 import { CaptchaSection } from '~/components/common/CaptchaSection'
-import { PillGroup } from '~/components/common/PillGroup'
-import { authMethodOptions, createAuthMethodSelection } from '~/lib/authMethodSelection'
+import { createAuthMethodSelection } from '~/lib/authMethodSelection'
 import { createCaptchaForm } from '~/lib/captchaForm'
 import { isEmailEnabled } from '~/lib/systemInfo'
 import { sanitizeDisplayName, sanitizeSlug, validateEmail, validateReservedUsername } from '~/lib/validate'
@@ -194,15 +194,12 @@ export const SignupForm: Component<SignupFormProps> = (props) => {
         {/*
           Offered on every sign-up surface, `/setup` included: the hub accepts
           a passkey for the first administrator too, and creates that account
-          as an admin exactly as password sign-up does. `authMethodOptions`
-          decides what the pills show, and it drops the passkey option on a
-          hub that runs no ceremonies at this origin.
+          as an admin exactly as password sign-up does. The shared method
+          control drops passkey when this hub runs no ceremonies here.
         */}
-        <PillGroup
+        <AuthMethodPillGroup
           label="Sign-up method"
-          options={authMethodOptions()}
-          selected={v => effectiveMethod() === v}
-          onSelect={methodSelection.select}
+          selection={methodSelection}
         />
         <Show when={effectiveMethod() === 'password'}>
           <PasswordFields

--- a/frontend/src/components/common/SignupPage.test.tsx
+++ b/frontend/src/components/common/SignupPage.test.tsx
@@ -22,7 +22,7 @@ vi.mock('~/lib/systemInfo', () => ({
   isSoloMode: () => false,
   isEmailEnabled: () => false,
   // The hub serves no passkey ceremony at this origin, so the form offers no
-  // Passkey pill at all. `authMethodOptions` reads the blocker directly.
+  // Passkey pill at all. The shared method control reads the blocker directly.
   passkeyBlocker: () => 'origin-not-allowed',
   loadSystemInfo: () => Promise.resolve(),
   isSignupEnabled: () => mockIsSignupEnabled(),

--- a/frontend/src/components/common/ThemeChooser.tsx
+++ b/frontend/src/components/common/ThemeChooser.tsx
@@ -1,3 +1,4 @@
+import type { PillOptions } from '~/components/common/PillGroup'
 import type { ResolvedThemeMode, TerminalThemeValue, ThemeMode, ThemeSurface, ThemeValue, ThemeVariant } from '~/styles/themes'
 import ChevronDown from 'lucide-solid/icons/chevron-down'
 import { createMemo, createSignal, For, on, Show } from 'solid-js'
@@ -11,7 +12,7 @@ import { DEFAULT_THEME_ID, isThemeId, MATCH_UI, resolveVariant, themeById, theme
 import * as styles from './ThemeChooser.css'
 
 // Typed with the DOMAIN type, not `string`. `PillGroup` is generic in its
-// option value, so a `string`-typed list here was the only reason the pill
+// option key, so a `string`-typed list here was the only reason the pill
 // handler had to cast on the way back into a `ThemeValue` -- a cast that would
 // have gone on compiling if a mode were renamed or dropped.
 //
@@ -19,11 +20,11 @@ import * as styles from './ThemeChooser.css'
 // `isThemeMode` below is how this file asks. Deriving MODES from this list
 // instead would point the dependency the wrong way: the theme library would
 // then need a component's option list to say what a mode is.
-const MODE_OPTIONS: { value: ThemeMode, label: string }[] = [
-  { value: 'system', label: 'System' },
-  { value: 'light', label: 'Light' },
-  { value: 'dark', label: 'Dark' },
-]
+const MODE_OPTIONS = [
+  { key: 'system', label: 'System' },
+  { key: 'light', label: 'Light' },
+  { key: 'dark', label: 'Dark' },
+] as const satisfies PillOptions<ThemeMode>
 
 export interface ThemeChooserProps<T extends ThemeValue | TerminalThemeValue> {
   value: T
@@ -122,7 +123,7 @@ export function ThemeChooser<T extends ThemeValue | TerminalThemeValue>(
 
   const selectedMode = (): ThemeMode => {
     const mode = effective().mode
-    return isThemeMode(mode) ? mode : MODE_OPTIONS[0]!.value
+    return isThemeMode(mode) ? mode : MODE_OPTIONS[0].key
   }
 
   /** The polarity on screen, which is the one the variant menu edits. */
@@ -335,7 +336,7 @@ export function ThemeChooser<T extends ThemeValue | TerminalThemeValue>(
         label={modeLabel()}
         options={MODE_OPTIONS}
         disabled={matching()}
-        selected={value => value === selectedMode()}
+        selectedKey={selectedMode()}
         onSelect={mode => commit({ mode })}
       />
 

--- a/frontend/src/components/settings/PreferencesNav.tsx
+++ b/frontend/src/components/settings/PreferencesNav.tsx
@@ -1,9 +1,10 @@
 import type { Component, JSX } from 'solid-js'
 import type { NavGroup } from './navGroups'
 import ChevronDown from 'lucide-solid/icons/chevron-down'
-import { createMemo, For, onCleanup, Show } from 'solid-js'
+import { createMemo, For, Show } from 'solid-js'
 import { DropdownMenu, DropdownMenuCheckableItem } from '~/components/common/DropdownMenu'
-import { nextFilterTab } from '~/components/common/FilterTabBar'
+import { createKeyedElementRefs } from '~/lib/keyedElementRefs'
+import { nextRovingValue } from '~/lib/rovingFocus'
 import { menuSectionHeader } from '~/styles/shared.css'
 import * as styles from './PreferencesDialog.css'
 
@@ -38,7 +39,7 @@ function optionLabel(group: NavGroup, restart: boolean): string {
  * The dialog's category navigation.
  *
  * Desktop: a real tab list (role=tablist, roving tabindex, arrow keys via
- * `nextFilterTab`), with labelled PREFERENCES and ADMINISTRATION dividers.
+ * `nextRovingValue`), with labelled PREFERENCES and ADMINISTRATION dividers.
  *
  * Compact (phone): an oat-styled DropdownMenu with matching section headers —
  * one tap opens an in-app menu instead of the OS native picker.
@@ -96,17 +97,17 @@ export const PreferencesNav: Component<PreferencesNavProps> = (props) => {
     </DropdownMenu>
   )
 
-  const tabEls = new Map<string, HTMLButtonElement>()
+  const tabEls = createKeyedElementRefs<string, HTMLButtonElement>()
   const select = (id: string) => {
     props.onSelect(id)
     tabEls.get(id)?.focus()
   }
   const onKeyDown = (e: KeyboardEvent) => {
-    const next = nextFilterTab(ids(), props.active.id, e.key)
+    const next = nextRovingValue(ids(), props.active.id, e)
     if (next === undefined)
       return
     e.preventDefault()
-    select(next)
+    select(next.value)
   }
 
   return (
@@ -139,13 +140,7 @@ export const PreferencesNav: Component<PreferencesNavProps> = (props) => {
                 aria-controls="preferences-panel"
                 tabIndex={props.active.id === group.id ? 0 : -1}
                 data-testid={`preferences-nav-${group.id}`}
-                ref={(el) => {
-                  tabEls.set(group.id, el)
-                  onCleanup(() => {
-                    if (tabEls.get(group.id) === el)
-                      tabEls.delete(group.id)
-                  })
-                }}
+                ref={el => tabEls.register(group.id, el)}
                 onClick={() => select(group.id)}
               >
                 {group.title}

--- a/frontend/src/components/settings/account/AppRegistrations.tsx
+++ b/frontend/src/components/settings/account/AppRegistrations.tsx
@@ -248,10 +248,10 @@ const RegisterAppForm: Component<{
                 <PillGroup
                   label="App type"
                   options={[
-                    { value: AppClientType.PUBLIC, label: 'Public (a binary a user holds)' },
-                    { value: AppClientType.CONFIDENTIAL, label: 'Confidential (a server you run)' },
+                    { key: AppClientType.PUBLIC, label: 'Public (a binary a user holds)' },
+                    { key: AppClientType.CONFIDENTIAL, label: 'Confidential (a server you run)' },
                   ]}
-                  selected={value => clientType() === value}
+                  selectedKey={clientType()}
                   onSelect={setClientType}
                 />
               )}

--- a/frontend/src/components/settings/controls/EnumControl.tsx
+++ b/frontend/src/components/settings/controls/EnumControl.tsx
@@ -1,7 +1,8 @@
-import type { Component, JSX } from 'solid-js'
+import type { Component } from 'solid-js'
+import type { PillOptions, PillOptionSpec } from '~/components/common/PillGroup'
 import { Show } from 'solid-js'
 import { LoadingMenu } from '~/components/common/LoadingMenu'
-import { PillGroup } from '~/components/common/PillGroup'
+import { PILL_OPTION_LIMIT, PillGroup } from '~/components/common/PillGroup'
 import * as styles from '../SettingRow.css'
 
 export interface EnumOption {
@@ -19,13 +20,18 @@ export interface EnumControlProps {
   onChange: (value: string) => void | Promise<boolean | void>
 }
 
-/** Enums with at most this many options render as radio pills. */
-const PILL_MAX_OPTIONS = 4
+function isPillOptions(options: readonly PillOptionSpec<string>[]): options is PillOptions<string> {
+  return options.length > 0 && options.length <= PILL_OPTION_LIMIT
+}
+
+function fixedPillOptions(options: readonly EnumOption[]): PillOptions<string> | undefined {
+  const pills = options.map(option => ({ key: option.value, label: option.label }))
+  return isPillOptions(pills) ? pills : undefined
+}
 
 /**
- * One-of-N choice. Few options render as the promoted PillGroup (radiogroup
- * semantics); more than PILL_MAX_OPTIONS would overflow a row of pills, so
- * they render as a `LoadingMenu` -- see the dropdown rule in CLAUDE.md. The
+ * One-of-N choice. A short list renders as PillGroup with radio semantics.
+ * A longer list renders as `LoadingMenu`; see the dropdown rule in CLAUDE.md. The
  * branch lives inside a `<Show>` so a change in the option count re-renders
  * rather than being captured once at setup.
  *
@@ -45,25 +51,13 @@ export const EnumControl: Component<EnumControlProps> = (props) => {
   const selectedHelp = (): string | undefined =>
     props.options.find(o => o.value === props.value)?.help
 
-  const pills = (): JSX.Element => (
-    <PillGroup
-      label={props.ariaLabel}
-      options={props.options}
-      selected={v => v === props.value}
-      onSelect={props.onChange}
-    />
-  )
+  const pills = () => fixedPillOptions(props.options)
   return (
     <>
       <Show
-        // An EMPTY list takes the menu branch, although zero is fewer than
-        // PILL_MAX_OPTIONS. `PillGroup` has nothing to render for it and drew a
-        // blank row where the control belongs, while `LoadingMenu` answers for
-        // exactly this state with a disabled trigger that says so -- which is
-        // also what makes the required `emptyLabel` below reachable at all.
-        // `LoadingMenu` derives the empty state from the options it is given,
-        // so this branch and that one cannot disagree about which it is.
-        when={props.options.length > 0 && props.options.length <= PILL_MAX_OPTIONS}
+        // An empty list uses the menu branch. `LoadingMenu` then shows the
+        // disabled trigger that states this condition.
+        when={pills()}
         fallback={(
           <LoadingMenu
             ariaLabel={props.ariaLabel}
@@ -81,7 +75,14 @@ export const EnumControl: Component<EnumControlProps> = (props) => {
           />
         )}
       >
-        {pills()}
+        {options => (
+          <PillGroup
+            label={props.ariaLabel}
+            options={options()}
+            selectedKey={props.value}
+            onSelect={props.onChange}
+          />
+        )}
       </Show>
       <Show when={selectedHelp()}>
         {help => <div class={styles.helpText}>{help()}</div>}

--- a/frontend/src/components/workspace/ChangeBranchDialog.tsx
+++ b/frontend/src/components/workspace/ChangeBranchDialog.tsx
@@ -363,11 +363,11 @@ export const ChangeBranchDialog: Component<ChangeBranchDialogProps> = (props) =>
                 <PillGroup
                   label="Open as"
                   options={[
-                    { value: TabType.AGENT, label: 'Agent' },
-                    { value: TabType.TERMINAL, label: 'Terminal' },
+                    { key: TabType.AGENT, label: 'Agent' },
+                    { key: TabType.TERMINAL, label: 'Terminal' },
                   ]}
-                  selected={v => v === worktreeTabType()}
-                  onSelect={v => setWorktreeTabType(v as WorktreeTabType)}
+                  selectedKey={worktreeTabType()}
+                  onSelect={setWorktreeTabType}
                 />
               </div>
               <Switch>

--- a/frontend/src/hooks/usePreferencesForIdentity.test.tsx
+++ b/frontend/src/hooks/usePreferencesForIdentity.test.tsx
@@ -48,6 +48,7 @@ vi.mock('~/lib/systemInfo', () => ({
   isSoloMode: () => false,
   // A multi-user hub: every caller signs in, and none of the solo facts hold.
   isAutoAuthenticated: () => false,
+  isPasswordSetupGate: () => false,
   passwordSetupRequired: () => false,
   soloPasswordSet: () => false,
   loadSystemInfo: vi.fn().mockResolvedValue(undefined),
@@ -79,11 +80,11 @@ function themeReply(mode: string) {
 
 /** A promise plus its resolvers, for pinning completion order. */
 function deferred<T>() {
-  let resolve!: (v: T) => void
-  let reject!: (e: unknown) => void
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res
-    reject = rej
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
   })
   // An unhandled rejection is reported before the code under test can
   // attach its own handler, so the promise is kept handled from the start.
@@ -97,9 +98,10 @@ function flushMicrotasks(): Promise<void> {
 }
 
 /**
- * The production nesting: the auth provider, the preferences provider
- * inside it, and one component inside BOTH that installs the trigger —
- * which is exactly where `PreferencesApplier` sits in `app.tsx`.
+ * Reproduce the production provider order.
+ *
+ * The preferences provider sits inside the auth provider. Its child installs
+ * the identity trigger, as `PreferencesApplier` does in `app.tsx`.
  */
 function renderApp() {
   let auth: AuthState | undefined
@@ -121,11 +123,10 @@ function renderApp() {
 }
 
 /**
- * Write `prefs` into `userId`'s namespace, then leave the page with no account.
+ * Write `prefs` into the namespace for `userId`. Then remove the active account.
  *
- * The seed has to be in place BEFORE the identity arrives: the provider reads
- * the device tier from the account-change notification, so a document written
- * afterwards is not what that notification carries.
+ * The provider reads the device tier from the account-change notification.
+ * Therefore, the seed must exist before the identity arrives.
  */
 function seedDeviceTierFor(userId: string, prefs: BrowserPreferences) {
   setStorageAccount(userId)
@@ -143,9 +144,8 @@ async function renderBootstrapped() {
 beforeEach(() => {
   vi.clearAllMocks()
   localStorageClearForTests()
-  // These cases drive the identity themselves, through the real AuthProvider.
-  // The suite's default sign-in would make the first resolved identity look
-  // like a no-op change.
+  // These cases drive the identity through the real AuthProvider. The default
+  // test identity would make the first resolved identity look unchanged.
   resetStorageAccountForTests()
   getCurrentUser.mockRejectedValue(unauthenticated())
   login.mockResolvedValue({ user: user('u1') })
@@ -161,10 +161,9 @@ afterEach(() => {
 })
 
 describe('usePreferencesForIdentity', () => {
-  // THE live bug. The provider loads once at its own mount, above the
-  // router, so the one attempt a visitor gets is spent before any
-  // credential exists. Without this trigger the stored theme, fonts and
-  // keybindings never applied after a sign-in through the form.
+  // The provider loads once when it mounts above the router. That request can
+  // run before a visitor supplies credentials. This trigger applies stored
+  // preferences after the visitor signs in through the form.
   it('reloads once after a sign-in that follows a failed anonymous load', async () => {
     listUserSettings.mockRejectedValueOnce(unauthenticated())
     listUserSettings.mockResolvedValue(themeReply('dark'))
@@ -197,9 +196,9 @@ describe('usePreferencesForIdentity', () => {
     expect(listUserSettings).toHaveBeenCalledTimes(3)
   })
 
-  // Signing back in as the SAME account is still an identity change: the
-  // sign-out recorded that nothing is loaded, so the account tier has to be
-  // read again rather than kept from before the sign-out.
+  // Signing in again as the same account is still an identity change. The
+  // sign-out records that no account tier is loaded, so the provider reads it
+  // again.
   it('reloads after a sign-out and a sign-in as the same user', async () => {
     listUserSettings.mockRejectedValueOnce(unauthenticated())
     listUserSettings.mockResolvedValue(themeReply('dark'))
@@ -210,17 +209,17 @@ describe('usePreferencesForIdentity', () => {
 
     await app.auth().logout()
     await flushMicrotasks()
-    // A signed-out page has no account tier to read, so the sign-out itself
-    // must not issue a load that can only answer Unauthenticated.
+    // A signed-out page has no account tier. The sign-out must not issue a
+    // request that can only return Unauthenticated.
     expect(listUserSettings).toHaveBeenCalledTimes(2)
 
     await app.auth().login('u1', 'pw')
     await waitFor(() => expect(listUserSettings).toHaveBeenCalledTimes(3))
   })
 
-  // The provider's own mount load carries the SAME session cookie the
-  // bootstrap authenticates with, so it already read this identity's
-  // settings. A second load here would double every ordinary page view.
+  // The mount request carries the session cookie that bootstrap uses. It reads
+  // this identity's settings, so another request would duplicate each normal
+  // page load.
   it('does not reload for the identity the mount load already covered', async () => {
     getCurrentUser.mockResolvedValue({ user: user('u1') })
     listUserSettings.mockResolvedValue(themeReply('dark'))
@@ -232,8 +231,8 @@ describe('usePreferencesForIdentity', () => {
     expect(listUserSettings).toHaveBeenCalledTimes(1)
   })
 
-  // The identity is what changes, not the User object: `refreshUser`
-  // replaces it with an equal one, and a re-render replaces nothing at all.
+  // The identity controls reloads, not the User object. `refreshUser` replaces
+  // the object with an equal value. A render changes neither value.
   it('does not reload while the identity stays the same', async () => {
     getCurrentUser.mockResolvedValue({ user: user('u1') })
     listUserSettings.mockResolvedValue(themeReply('dark'))
@@ -248,7 +247,7 @@ describe('usePreferencesForIdentity', () => {
     expect(listUserSettings).toHaveBeenCalledTimes(1)
   })
 
-  // A failed login leaves the visitor exactly where they were.
+  // A failed login does not change the visitor's identity.
   it('does not reload when the login is refused', async () => {
     listUserSettings.mockRejectedValueOnce(unauthenticated())
     const app = await renderBootstrapped()
@@ -261,9 +260,8 @@ describe('usePreferencesForIdentity', () => {
     expect(listUserSettings).toHaveBeenCalledTimes(1)
   })
 
-  // The mount load is still IN FLIGHT when the sign-in issues its own, so
-  // the two can finish in either order. `loadSeq` is what keeps the newer
-  // answer on screen.
+  // The mount request remains active when the sign-in issues another request.
+  // Either request can finish first. `loadSeq` keeps the newer reply on screen.
   it('drops a stale reply from the load the sign-in superseded', async () => {
     const stale = deferred<{ descriptors: never[], values: unknown[] }>()
     listUserSettings.mockReturnValueOnce(stale.promise)
@@ -278,10 +276,9 @@ describe('usePreferencesForIdentity', () => {
     expect(app.prefs().theme().mode).toBe('dark')
   })
 
-  // The same rule for the FAILURE half: the anonymous load rejects with
-  // Unauthenticated after the sign-in load succeeded, and recording it would
-  // state a load error for the rest of the session over settings that are
-  // on screen.
+  // The same rule applies to a stale failure. An anonymous request can reject
+  // after the sign-in request succeeds. That rejection must not replace the
+  // settings with an error.
   it('drops a stale failure from the load the sign-in superseded', async () => {
     const stale = deferred<{ descriptors: never[], values: unknown[] }>()
     listUserSettings.mockReturnValueOnce(stale.promise)
@@ -297,9 +294,8 @@ describe('usePreferencesForIdentity', () => {
     expect(app.prefs().theme().mode).toBe('dark')
   })
 
-  // The per-key WRITE sequence is the other guard this path relies on: the
-  // reload stamps every key when it is issued, so a key the user writes
-  // while it is in flight keeps the value the write returned.
+  // The sequence for each key protects writes during a reload. The reload
+  // records each key when it starts. A later write keeps its returned value.
   it('leaves a key written during the reload at the value the write returned', async () => {
     const pending = deferred<{ descriptors: never[], values: unknown[] }>()
     listUserSettings.mockRejectedValueOnce(unauthenticated())
@@ -316,22 +312,21 @@ describe('usePreferencesForIdentity', () => {
     await app.prefs().dual.theme.setAccount({ name: 'default', mode: 'light' })
     expect(app.prefs().theme().mode).toBe('light')
 
-    // The reload answers with the value the account held BEFORE that write.
+    // The reload returns the value from before that write.
     pending.resolve(themeReply('dark'))
     await flushMicrotasks()
     expect(app.prefs().theme().mode).toBe('light')
     expect(app.prefs().accountCustomized().theme).toBe(true)
   })
 
-  // The DEVICE half does not live in this hook: the provider subscribes to
-  // `onStorageAccountChange`, which fires from inside `setStorageAccount` --
-  // synchronously with the identity write, which an effect cannot be. These two
-  // cases hold that wiring from the outside, through `login`, so the seed is
-  // proved by the transition rather than by a call.
+  // This hook does not control the device tier. The provider subscribes to
+  // `onStorageAccountChange`, which runs inside `setStorageAccount`. Thus, the
+  // device tier changes with the identity write. These cases verify that
+  // behavior through `login`.
   it('seeds the device tier as the first identity is written, with no reload', async () => {
     listUserSettings.mockResolvedValue({ descriptors: [], values: [] })
-    // u1's document, written before anyone signs in. That is the ordinary
-    // shape: the page loads with no identity and the account arrives after.
+    // Write the document for u1 before sign-in. A normal page starts without an
+    // identity and receives the account later.
     seedDeviceTierFor('u1', { theme: { name: 'nord', mode: 'dark' } })
 
     const app = await renderBootstrapped()
@@ -339,17 +334,14 @@ describe('usePreferencesForIdentity', () => {
 
     await app.auth().login('u1', 'pw')
 
-    // No `waitFor`: the seed runs inside `setStorageAccount`, which
-    // `AuthContext` calls as it writes the identity, so the value is already in
-    // place by the time anything can observe the new identity. An effect-driven
-    // seed would need a flush here, and every consumer that reads once at mount
-    // would have taken the default.
+    // Do not use `waitFor` here. `AuthContext` calls `setStorageAccount` as it
+    // writes the identity. The seed therefore exists before a consumer can
+    // observe the new identity.
     expect(app.prefs().theme()).toEqual({ name: 'nord', mode: 'dark' })
   })
 
-  // A user switch with no page reload. The device tier used to be read once and
-  // never again, so every signal kept the PREVIOUS user's values and the dialog
-  // reported them as "This device" over the new user's own account settings.
+  // A user can change without a page reload. The provider must read the new
+  // device tier. Otherwise, each signal keeps the previous user's values.
   it('re-seeds the device tier when one user replaces another', async () => {
     listUserSettings.mockResolvedValue({ descriptors: [], values: [] })
     seedDeviceTierFor('u1', { theme: { name: 'nord', mode: 'dark' } })
@@ -361,17 +353,13 @@ describe('usePreferencesForIdentity', () => {
     login.mockResolvedValue({ user: user('u2') })
     await app.auth().login('u2', 'pw')
 
-    // u2 has written nothing on this device, so they get the defaults rather
-    // than u1's palette.
+    // u2 wrote nothing on this device, so the provider uses the defaults.
     await waitFor(() => expect(app.prefs().theme()).toEqual({ name: 'default', mode: 'system' }))
   })
 
-  // A sign-out is client-side: this provider and everything under it stay
-  // mounted, and the namespace deliberately keeps pointing at the account that
-  // LEFT so its teardown writes still land. Both tiers therefore still hold that
-  // account's values, and `PreferencesApplier` keeps painting them -- so the
-  // sign-in page would render in the palette and fonts of whoever used the
-  // browser last.
+  // A client-side sign-out keeps this provider mounted. The namespace still
+  // points to the old account for its teardown writes. Both tiers must return
+  // to defaults, or the sign-in page uses the old account's appearance.
   it('returns both tiers to their defaults on a sign-out', async () => {
     listUserSettings.mockResolvedValue({
       descriptors: [],
@@ -395,8 +383,8 @@ describe('usePreferencesForIdentity', () => {
     expect(app.prefs().accountCustomized()).toEqual({})
   })
 
-  // Nothing to READ for a signed-out page: the account request would answer
-  // Unauthenticated and record an error over a screen that shows no account row.
+  // A signed-out page has no account tier to read. A request would return
+  // Unauthenticated and show an irrelevant error.
   it('loads nothing on a sign-out', async () => {
     listUserSettings.mockResolvedValue({ descriptors: [], values: [] })
     const app = await renderBootstrapped()

--- a/frontend/src/hooks/usePreferencesForIdentity.test.tsx
+++ b/frontend/src/hooks/usePreferencesForIdentity.test.tsx
@@ -9,6 +9,7 @@ import { AuthProvider, useAuth } from '~/context/AuthContext'
 import { PreferencesProvider, usePreferences } from '~/context/PreferencesContext'
 import { KEY_BROWSER_PREFS, localStorageClearForTests, localStorageSet, resetStorageAccountForTests, setStorageAccount } from '~/lib/browserStorage'
 import { TEST_USER_ID } from '~/test-support/crdtBridge'
+import { resetSystemInfoMock } from '~/test-support/systemInfoMock'
 import { usePreferencesForIdentity } from './usePreferencesForIdentity'
 
 const getCurrentUser = vi.hoisted(() => vi.fn())
@@ -44,20 +45,10 @@ vi.mock('~/api/platformBridge', () => ({
   platformBridge: { resetTunnels: vi.fn().mockResolvedValue(undefined) },
 }))
 
-vi.mock('~/lib/systemInfo', () => ({
-  isSoloMode: () => false,
-  // A multi-user hub: every caller signs in, and none of the solo facts hold.
-  isAutoAuthenticated: () => false,
-  isPasswordSetupGate: () => false,
-  passwordSetupRequired: () => false,
-  soloPasswordSet: () => false,
-  loadSystemInfo: vi.fn().mockResolvedValue(undefined),
-  isSystemInfoLoaded: () => true,
-  isCaptchaEnabled: () => false,
-  getAltchaAlgorithm: () => '',
-  getCaptchaProvider: () => 1,
-  getCaptchaSiteKey: () => '',
-}))
+vi.mock('~/lib/systemInfo', async () => {
+  const mock = await import('~/test-support/systemInfoMock')
+  return mock.systemInfoMock
+})
 
 /** The hub's answer for a page that carries no session cookie. */
 function unauthenticated(): ConnectError {
@@ -143,6 +134,8 @@ async function renderBootstrapped() {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  // The shared defaults describe the multi-user hub that these cases need.
+  resetSystemInfoMock()
   localStorageClearForTests()
   // These cases drive the identity through the real AuthProvider. The default
   // test identity would make the first resolved identity look unchanged.

--- a/frontend/src/lib/authMethodSelection.test.ts
+++ b/frontend/src/lib/authMethodSelection.test.ts
@@ -1,6 +1,6 @@
 import { createRoot } from 'solid-js'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { authMethodOptions, createAuthMethodSelection } from './authMethodSelection'
+import { createAuthMethodSelection } from './authMethodSelection'
 
 vi.mock('~/lib/systemInfo', async () => {
   const m = await import('~/test-support/systemInfoMock')
@@ -102,61 +102,5 @@ describe('createAuthMethodSelection', () => {
       expect(b.effectiveMethod()).toBe('password')
       dispose()
     })
-  })
-})
-
-/**
- * The pills BOTH forms render, stated once.
- *
- * Two shapes of refusal, and they are not the same to a reader: one is a
- * property of where they stand and they can move, the other is a
- * property of the deployment and identical for every visitor. An answer that
- * differed between the login form and the sign-up form would be a bug neither
- * file could show.
- */
-describe('authMethodOptions', () => {
-  beforeEach(() => {
-    resetSystemInfoMock()
-  })
-
-  it('offers both methods when a ceremony can run', () => {
-    setSystemInfoMock({ passkeyBlocker: null })
-    expect(authMethodOptions()).toEqual([
-      { value: 'password', label: 'Password' },
-      { value: 'passkey', label: 'Passkey', disabledReason: undefined },
-    ])
-  })
-
-  // The BROWSER refuses: the pill stays and carries the reason, because
-  // hiding it leaves somebody whose only credential is a passkey with no way
-  // to sign in and nothing to read.
-  it.each([
-    ['insecure-context' as const, /secure page/i],
-    ['no-webauthn' as const, /does not support passkeys/i],
-  ])('keeps a refused passkey pill and says why for %s', (blocker, expected) => {
-    setSystemInfoMock({ passkeyBlocker: blocker })
-    const options = authMethodOptions()
-    expect(options.map(o => o.value)).toEqual(['password', 'passkey'])
-    expect(options[1]!.disabledReason).toMatch(expected)
-  })
-
-  // The HUB refuses: the pill goes. It is a property of the deployment,
-  // identical for every visitor, and a permanently dead pill is noise.
-  it('drops the passkey pill when the hub does not serve this origin', () => {
-    setSystemInfoMock({ passkeyBlocker: 'origin-not-allowed' })
-    expect(authMethodOptions().map(o => o.value)).toEqual(['password'])
-  })
-
-  // Whatever the pills show, the password option survives -- it is the only
-  // way to sign in once the other one is refused.
-  it.each([
-    ['insecure-context' as const],
-    ['no-webauthn' as const],
-    ['origin-not-allowed' as const],
-  ])('always leaves the password option live under %s', (blocker) => {
-    setSystemInfoMock({ passkeyBlocker: blocker })
-    const password = authMethodOptions().find(o => o.value === 'password')
-    expect(password).toBeDefined()
-    expect(password!.disabledReason).toBeUndefined()
   })
 })

--- a/frontend/src/lib/authMethodSelection.ts
+++ b/frontend/src/lib/authMethodSelection.ts
@@ -1,10 +1,8 @@
 import type { Accessor } from 'solid-js'
-import type { PillOptionSpec } from '~/components/common/PillGroup'
 import type { CaptchaAction } from '~/generated/contracts/captcha'
 
 import { createSignal } from 'solid-js'
 import { passkeyBlocker } from '~/lib/systemInfo'
-import { passkeyBlockerMessage } from '~/lib/webauthn'
 
 /** The two credential kinds the login and sign-up forms offer. */
 export type AuthMethod = 'password' | 'passkey'
@@ -65,39 +63,4 @@ export function createAuthMethodSelection(kind: AuthMethodKind): AuthMethodSelec
   const captchaAction = (): AuthCaptchaAction => CAPTCHA_ACTIONS[kind][effectiveMethod()]
 
   return { effectiveMethod, select: setMethod, captchaAction }
-}
-
-/**
- * The method pills a sign-in or sign-up form offers.
- *
- * ONE statement of the rule, because both forms ask the same question and an
- * answer that differed between them would be a bug nobody could see from
- * either file.
- *
- * Two shapes of refusal, and they are not the same to a reader:
- *
- *   - The BROWSER refuses (the page is not secure, or it has no WebAuthn at
- *     all). The pill STAYS, disabled, carrying the reason. It is a property of
- *     where the reader stands, and they can move: hiding it leaves somebody
- *     whose only credential is a passkey with no way to sign in and nothing
- *     to read.
- *   - The HUB does not run ceremonies at this origin. The pill GOES. It is a
- *     property of the deployment, identical for every visitor, and a
- *     permanently dead pill on the sign-in page of a hub without passkeys is
- *     noise rather than help.
- *
- * The account panel still explains the hub's refusal in full, to the one
- * audience that can do something about it -- somebody already signed in.
- */
-export function authMethodOptions(): PillOptionSpec<AuthMethod>[] {
-  const options: PillOptionSpec<AuthMethod>[] = [{ value: 'password', label: 'Password' }]
-  const blocker = passkeyBlocker()
-  if (blocker === 'origin-not-allowed')
-    return options
-  options.push({
-    value: 'passkey',
-    label: 'Passkey',
-    disabledReason: blocker ? passkeyBlockerMessage(blocker) : undefined,
-  })
-  return options
 }

--- a/frontend/src/lib/keyedElementRefs.test.ts
+++ b/frontend/src/lib/keyedElementRefs.test.ts
@@ -1,0 +1,41 @@
+import { createRoot } from 'solid-js'
+import { describe, expect, it } from 'vitest'
+import { createKeyedElementRefs } from './keyedElementRefs'
+
+describe('createKeyedElementRefs', () => {
+  it('removes an element when its owner is disposed', () => {
+    const refs = createKeyedElementRefs<string, HTMLButtonElement>()
+    const element = document.createElement('button')
+    let dispose!: () => void
+    createRoot((rootDispose) => {
+      dispose = rootDispose
+      refs.register('one', element)
+    })
+
+    expect(refs.get('one')).toBe(element)
+    dispose()
+    expect(refs.get('one')).toBeUndefined()
+  })
+
+  it('does not delete a replacement when the old owner is disposed', () => {
+    const refs = createKeyedElementRefs<string, HTMLButtonElement>()
+    const oldElement = document.createElement('button')
+    const newElement = document.createElement('button')
+    let disposeOld!: () => void
+    let disposeNew!: () => void
+    createRoot((dispose) => {
+      disposeOld = dispose
+      refs.register('one', oldElement)
+    })
+    createRoot((dispose) => {
+      disposeNew = dispose
+      refs.register('one', newElement)
+    })
+
+    disposeOld()
+    expect(refs.get('one')).toBe(newElement)
+
+    disposeNew()
+    expect(refs.get('one')).toBeUndefined()
+  })
+})

--- a/frontend/src/lib/keyedElementRefs.ts
+++ b/frontend/src/lib/keyedElementRefs.ts
@@ -1,0 +1,21 @@
+import { onCleanup } from 'solid-js'
+
+export interface KeyedElementRefs<K, E extends Element> {
+  get: (key: K) => E | undefined
+  register: (key: K, element: E) => void
+}
+
+/** Keep one live element for each key and remove only the element that leaves. */
+export function createKeyedElementRefs<K, E extends Element>(): KeyedElementRefs<K, E> {
+  const elements = new Map<K, E>()
+  return {
+    get: key => elements.get(key),
+    register: (key, element) => {
+      elements.set(key, element)
+      onCleanup(() => {
+        if (elements.get(key) === element)
+          elements.delete(key)
+      })
+    },
+  }
+}

--- a/frontend/src/lib/rovingFocus.test.ts
+++ b/frontend/src/lib/rovingFocus.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { nextRovingValue } from './rovingFocus'
+
+describe('nextRovingValue', () => {
+  const values = ['all', 'changed', 'staged', 'unstaged'] as const
+  const event = (key: string, modifiers: Partial<KeyboardEvent> = {}) => ({
+    altKey: false,
+    ctrlKey: false,
+    key,
+    metaKey: false,
+    ...modifiers,
+  })
+
+  it('moves forward and backward', () => {
+    expect(nextRovingValue(values, 'changed', event('ArrowRight'))).toEqual({ value: 'staged' })
+    expect(nextRovingValue(values, 'changed', event('ArrowLeft'))).toEqual({ value: 'all' })
+    expect(nextRovingValue(values, 'changed', event('ArrowDown'))).toEqual({ value: 'staged' })
+    expect(nextRovingValue(values, 'changed', event('ArrowUp'))).toEqual({ value: 'all' })
+  })
+
+  it('wraps at both ends', () => {
+    expect(nextRovingValue(values, 'unstaged', event('ArrowRight'))).toEqual({ value: 'all' })
+    expect(nextRovingValue(values, 'all', event('ArrowLeft'))).toEqual({ value: 'unstaged' })
+  })
+
+  it('moves to each end with Home and End', () => {
+    expect(nextRovingValue(values, 'staged', event('Home'))).toEqual({ value: 'all' })
+    expect(nextRovingValue(values, 'staged', event('End'))).toEqual({ value: 'unstaged' })
+  })
+
+  it('ignores keys that the control does not own', () => {
+    expect(nextRovingValue(values, 'staged', event('a'))).toBeUndefined()
+    expect(nextRovingValue(values, 'staged', event('Enter'))).toBeUndefined()
+  })
+
+  it('ignores browser and platform shortcuts', () => {
+    expect(nextRovingValue(values, 'staged', event('ArrowLeft', { altKey: true }))).toBeUndefined()
+    expect(nextRovingValue(values, 'staged', event('ArrowLeft', { ctrlKey: true }))).toBeUndefined()
+    expect(nextRovingValue(values, 'staged', event('ArrowLeft', { metaKey: true }))).toBeUndefined()
+  })
+
+  it('owns no key when the set is empty', () => {
+    expect(nextRovingValue([] as const, 'all', event('ArrowRight'))).toBeUndefined()
+    expect(nextRovingValue([] as const, 'all', event('Home'))).toBeUndefined()
+  })
+
+  it('starts from the first value when the current value is absent', () => {
+    expect(nextRovingValue(values, 'gone' as 'all', event('ArrowRight'))).toEqual({ value: 'changed' })
+  })
+
+  it('stays on the only value in a single-value set', () => {
+    const one = ['all'] as const
+    expect(nextRovingValue(one, 'all', event('ArrowRight'))).toEqual({ value: 'all' })
+    expect(nextRovingValue(one, 'all', event('ArrowLeft'))).toEqual({ value: 'all' })
+    expect(nextRovingValue(one, 'all', event('End'))).toEqual({ value: 'all' })
+  })
+
+  it('returns undefined and NaN values as tagged destinations', () => {
+    expect(nextRovingValue(['set', undefined], 'set', event('ArrowRight')))
+      .toEqual({ value: undefined })
+    expect(nextRovingValue([0, Number.NaN], 0, event('ArrowRight')))
+      .toEqual({ value: Number.NaN })
+    expect(nextRovingValue([0, Number.NaN], Number.NaN, event('ArrowLeft')))
+      .toEqual({ value: 0 })
+  })
+})

--- a/frontend/src/lib/rovingFocus.ts
+++ b/frontend/src/lib/rovingFocus.ts
@@ -1,0 +1,40 @@
+import { sameValueZero } from './shallowEqual'
+
+export interface RovingDestination<T> {
+  value: T
+}
+
+type RovingKeyEvent = Pick<KeyboardEvent, 'altKey' | 'ctrlKey' | 'key' | 'metaKey'>
+
+/** Find the destination for one radio or tab navigation key. */
+export function nextRovingValue<T>(
+  values: readonly T[],
+  current: T,
+  event: RovingKeyEvent,
+): RovingDestination<T> | undefined {
+  if (event.altKey || event.ctrlKey || event.metaKey || values.length === 0)
+    return undefined
+
+  const found = values.findIndex(value => sameValueZero(value, current))
+  const index = found < 0 ? 0 : found
+  let destination: number
+  switch (event.key) {
+    case 'ArrowRight':
+    case 'ArrowDown':
+      destination = (index + 1) % values.length
+      break
+    case 'ArrowLeft':
+    case 'ArrowUp':
+      destination = (index - 1 + values.length) % values.length
+      break
+    case 'Home':
+      destination = 0
+      break
+    case 'End':
+      destination = values.length - 1
+      break
+    default:
+      return undefined
+  }
+  return { value: values[destination]! }
+}

--- a/frontend/src/lib/shallowEqual.test.ts
+++ b/frontend/src/lib/shallowEqual.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
-import { shallowEqual, shallowEqualArrays, shallowEqualArraysDeep, shallowEqualExcept, shallowEqualSets } from './shallowEqual'
+import { sameValueZero, shallowEqual, shallowEqualArrays, shallowEqualArraysDeep, shallowEqualExcept, shallowEqualMapKeyArrays, shallowEqualSets } from './shallowEqual'
 
-describe('shallowequal', () => {
+describe('shallow object equality', () => {
   it('returns true for same reference', () => {
     const obj = { a: 1 }
     expect(shallowEqual(obj, obj)).toBe(true)
@@ -32,7 +32,7 @@ describe('shallowequal', () => {
   })
 })
 
-describe('shallowequalarrays', () => {
+describe('shallow array equality', () => {
   it('returns true for same reference', () => {
     const arr = [1, 2, 3]
     expect(shallowEqualArrays(arr, arr)).toBe(true)
@@ -69,7 +69,21 @@ describe('shallowequalarrays', () => {
   })
 })
 
-describe('shallowequalarraysdeep', () => {
+describe('map key equality (sameValueZero)', () => {
+  it('matches map key identity for NaN and signed zero', () => {
+    expect(sameValueZero(Number.NaN, Number.NaN)).toBe(true)
+    expect(sameValueZero(-0, 0)).toBe(true)
+    expect(shallowEqualMapKeyArrays([Number.NaN, -0], [Number.NaN, 0])).toBe(true)
+  })
+
+  it('still compares objects by identity', () => {
+    const key = {}
+    expect(shallowEqualMapKeyArrays([key], [key])).toBe(true)
+    expect(shallowEqualMapKeyArrays([{}], [{}])).toBe(false)
+  })
+})
+
+describe('deep shallow-array equality', () => {
   it('compares object elements by shallowEqual (recurses one level)', () => {
     expect(shallowEqualArraysDeep([{ a: 1 }], [{ a: 1 }])).toBe(true)
     expect(shallowEqualArraysDeep([{ a: 1, b: 2 }], [{ a: 1, b: 2 }])).toBe(true)
@@ -81,7 +95,7 @@ describe('shallowequalarraysdeep', () => {
   })
 })
 
-describe('shallowequalsets', () => {
+describe('shallow set equality', () => {
   it('returns true for same reference', () => {
     const set = new Set(['a'])
     expect(shallowEqualSets(set, set)).toBe(true)
@@ -97,7 +111,7 @@ describe('shallowequalsets', () => {
   })
 })
 
-describe('shallowequalexcept', () => {
+describe('shallow object equality with excluded keys', () => {
   it('ignores skip keys when comparing', () => {
     expect(shallowEqualExcept(
       { a: 1, ts: 100 },

--- a/frontend/src/lib/shallowEqual.ts
+++ b/frontend/src/lib/shallowEqual.ts
@@ -39,9 +39,19 @@ function arraysEqualBy(
   return true
 }
 
+/** Equality that matches Set, Map, and Array.includes. */
+export function sameValueZero(a: unknown, b: unknown): boolean {
+  return Object.is(a, b) || (a === 0 && b === 0)
+}
+
 /** Element-wise `Object.is` equality for two arrays. Same-reference early-exit. */
 export function shallowEqualArrays(a: readonly unknown[], b: readonly unknown[]): boolean {
   return arraysEqualBy(a, b, Object.is)
+}
+
+/** Element-wise SameValueZero equality for arrays that contain map keys. */
+export function shallowEqualMapKeyArrays(a: readonly unknown[], b: readonly unknown[]): boolean {
+  return arraysEqualBy(a, b, sameValueZero)
 }
 
 /** Unordered `Object.is` equality for two sets. Same-reference early-exit. */

--- a/frontend/tests/e2e/196-pill-group.spec.ts
+++ b/frontend/tests/e2e/196-pill-group.spec.ts
@@ -11,8 +11,13 @@ async function openThemeModes(page: Page, token: string): Promise<Locator> {
     .getByRole('radiogroup', { name: 'Theme mode' })
 }
 
-function selectionIndicator(group: Locator): Locator {
-  return group.locator(':scope > [aria-hidden="true"]')
+async function openAppTypes(page: Page, token: string): Promise<Locator> {
+  await loginViaToken(page, token)
+  await page.goto('/')
+  const dialog = await openSettingsAt(page, 'apps')
+  const registrations = dialog.locator('[data-setting-id="apps.registrations"]')
+  await registrations.getByRole('button', { name: 'Register an app' }).click()
+  return registrations.getByRole('radiogroup', { name: 'App type' })
 }
 
 async function selectMode(group: Locator, label: string): Promise<Locator> {
@@ -23,29 +28,11 @@ async function selectMode(group: Locator, label: string): Promise<Locator> {
   return radio
 }
 
-async function indicatorDelta(indicator: Locator, radio: Locator) {
-  const indicatorBox = await indicator.boundingBox()
-  const radioBox = await radio.boundingBox()
-  if (!indicatorBox || !radioBox)
-    return null
-  return {
-    left: indicatorBox.x - radioBox.x,
-    top: indicatorBox.y - radioBox.y,
-    width: indicatorBox.width - radioBox.width,
-    height: indicatorBox.height - radioBox.height,
-  }
+function selectionIndicator(group: Locator): Locator {
+  return group.locator(':scope > [data-pill-selection-fill]')
 }
 
-async function expectIndicatorAt(indicator: Locator, radio: Locator): Promise<void> {
-  await expect.poll(async () => {
-    const delta = await indicatorDelta(indicator, radio)
-    return delta === null
-      ? Number.POSITIVE_INFINITY
-      : Math.max(...Object.values(delta).map(value => Math.abs(value)))
-  }).toBeLessThanOrEqual(0.05)
-}
-
-test.describe('Pill group segmented control', () => {
+test.describe('pill group segmented control', () => {
   test('renders one content-sized control with dividers and an active fill', async ({ page, leapmuxServer }) => {
     const group = await openThemeModes(page, leapmuxServer.adminToken)
     const indicator = selectionIndicator(group)
@@ -64,6 +51,7 @@ test.describe('Pill group segmented control', () => {
           borderRadius: style.borderRadius,
           borderInlineStartWidth: style.borderInlineStartWidth,
           backgroundColor: style.backgroundColor,
+          checked: button.getAttribute('aria-checked') === 'true',
         }
       })
       const groupRect = element.getBoundingClientRect()
@@ -96,11 +84,11 @@ test.describe('Pill group segmented control', () => {
       expect(layout.boxes[index - 1]!.right).toBeCloseTo(layout.boxes[index]!.left, 1)
       expect(layout.boxes[index]!.borderInlineStartWidth).toBe('1px')
       expect(layout.boxes[index]!.borderRadius).toBe('0px')
-      expect(layout.boxes[index]!.backgroundColor).toBe('rgba(0, 0, 0, 0)')
     }
+    for (const box of layout.boxes.filter(box => !box.checked))
+      expect(box.backgroundColor).toBe('rgba(0, 0, 0, 0)')
 
     const selected = group.getByRole('radio', { checked: true })
-    await expectIndicatorAt(indicator, selected)
 
     const tokens = await page.evaluate(() => {
       const root = getComputedStyle(document.documentElement)
@@ -112,7 +100,9 @@ test.describe('Pill group segmented control', () => {
     })
     expect(await indicator.evaluate(element => getComputedStyle(element).backgroundColor))
       .toBe(await resolvedColor(page, tokens.primary))
-    expect(await selected.evaluate(element => getComputedStyle(element).color))
+    expect(await selected.evaluate(element => getComputedStyle(element).backgroundColor))
+      .toBe('rgba(0, 0, 0, 0)')
+    expect(await group.locator(':scope > [data-pill-selection-labels]').evaluate(element => getComputedStyle(element).color))
       .toBe(await resolvedColor(page, tokens.primaryForeground))
     expect(await group.getByRole('radio', { checked: false }).first().evaluate(element => getComputedStyle(element).color))
       .toBe(await resolvedColor(page, tokens.mutedForeground))
@@ -126,15 +116,57 @@ test.describe('Pill group segmented control', () => {
       .toBe('1')
   })
 
-  test('moves the active fill between segments when motion is allowed', async ({ page, leapmuxServer }) => {
-    await page.emulateMedia({ reducedMotion: 'no-preference' })
+  test('keeps the active fill and label colors paired while sliding', async ({ page, leapmuxServer }) => {
+    const group = await openThemeModes(page, leapmuxServer.adminToken)
+    const system = await selectMode(group, 'System')
+    const dark = group.getByRole('radio', { name: 'Dark' })
+    await dark.click()
+    await expect(dark).toHaveAttribute('aria-checked', 'true')
+    const tokens = await page.evaluate(() => {
+      const root = getComputedStyle(document.documentElement)
+      return {
+        primary: root.getPropertyValue('--primary').trim(),
+        primaryForeground: root.getPropertyValue('--primary-foreground').trim(),
+      }
+    })
+    expect(await system.evaluate(element => getComputedStyle(element).backgroundColor))
+      .toBe('rgba(0, 0, 0, 0)')
+    expect(await dark.evaluate(element => getComputedStyle(element).transitionProperty))
+      .toBe('none')
+    expect(await selectionIndicator(group).evaluate(element => getComputedStyle(element).backgroundColor))
+      .toBe(await resolvedColor(page, tokens.primary))
+    expect(await group.locator(':scope > [data-pill-selection-labels]').evaluate(element => getComputedStyle(element).color))
+      .toBe(await resolvedColor(page, tokens.primaryForeground))
+  })
+
+  test('uses the accent background only for an unselected hover', async ({ page, leapmuxServer }) => {
+    const group = await openThemeModes(page, leapmuxServer.adminToken)
+    await expect(selectionIndicator(group)).toHaveCount(1)
+    const selected = group.getByRole('radio', { checked: true })
+    const unselected = group.getByRole('radio', { checked: false }).first()
+    const accent = await page.evaluate(() => getComputedStyle(document.documentElement).getPropertyValue('--accent').trim())
+
+    await selected.hover()
+    expect(await selected.evaluate(element => getComputedStyle(element).backgroundColor))
+      .toBe('rgba(0, 0, 0, 0)')
+
+    await unselected.hover()
+    expect(await unselected.evaluate(element => getComputedStyle(element).backgroundColor))
+      .toBe(await resolvedColor(page, accent))
+  })
+
+  test('slides the active fill between segments', async ({ page, leapmuxServer }) => {
     const group = await openThemeModes(page, leapmuxServer.adminToken)
     const indicator = selectionIndicator(group)
-    const system = await selectMode(group, 'System')
-    await expectIndicatorAt(indicator, system)
+    await expect(indicator).toHaveCount(1)
+    await selectMode(group, 'System')
+    await indicator.evaluate(async (element) => {
+      await new Promise<void>(resolve => requestAnimationFrame(() => requestAnimationFrame(() => resolve())))
+      await Promise.allSettled(element.getAnimations().map(animation => animation.finished))
+    })
 
-    const transitionedProperties = await group.evaluate(element => new Promise<string[]>((resolve, reject) => {
-      const fill = element.querySelector<HTMLElement>(':scope > [aria-hidden="true"]')
+    const transitionedProperty = await group.evaluate(element => new Promise<string>((resolve, reject) => {
+      const fill = element.querySelector<HTMLElement>(':scope > [data-pill-selection-fill]')
       const target = [...element.querySelectorAll<HTMLButtonElement>(':scope > button')]
         .find(button => button.textContent === 'Dark')
       if (!fill || !target) {
@@ -142,49 +174,113 @@ test.describe('Pill group segmented control', () => {
         return
       }
 
-      const properties = new Set<string>()
-      const timeout = window.setTimeout(() => {
-        reject(new Error(`Missing transitions: ${[...properties].join(', ')}`))
-      }, 2000)
+      const timeout = window.setTimeout(() => reject(new Error('The selection did not slide.')), 2000)
       fill.addEventListener('transitionrun', (event) => {
-        properties.add(event.propertyName)
-        if (properties.has('transform') && properties.has('width')) {
-          window.clearTimeout(timeout)
-          resolve([...properties])
-        }
+        if (event.propertyName !== 'clip-path')
+          return
+        window.clearTimeout(timeout)
+        resolve(event.propertyName)
       })
       target.click()
     }))
 
-    expect(transitionedProperties).toContain('transform')
-    expect(transitionedProperties).toContain('width')
+    expect(transitionedProperty).toBe('clip-path')
     const dark = group.getByRole('radio', { name: 'Dark' })
     await expect(dark).toHaveAttribute('aria-checked', 'true')
-    await expectIndicatorAt(indicator, dark)
+    expect(await dark.evaluate(element => getComputedStyle(element).boxShadow)).toBe('none')
+
+    await indicator.evaluate(async (element) => {
+      await Promise.allSettled(element.getAnimations().map(animation => animation.finished))
+    })
+    expect(await dark.evaluate(element => getComputedStyle(element).boxShadow)).not.toBe('none')
   })
 
-  test('moves the active fill without visible motion when motion is reduced', async ({ page, leapmuxServer }) => {
+  test('settles without a slide when motion is reduced', async ({ page, leapmuxServer }) => {
     await page.emulateMedia({ reducedMotion: 'reduce' })
     const group = await openThemeModes(page, leapmuxServer.adminToken)
     const indicator = selectionIndicator(group)
-    const system = await selectMode(group, 'System')
-    await expectIndicatorAt(indicator, system)
+    await selectMode(group, 'System')
 
-    const dark = group.getByRole('radio', { name: 'Dark' })
-    await dark.click()
-    await expect(dark).toHaveAttribute('aria-checked', 'true')
-    await expectIndicatorAt(indicator, dark)
+    const state = await group.evaluate(element => new Promise<{
+      animations: number
+      checked: string | null
+      shadow: string
+    }>((resolve, reject) => {
+      const fill = element.querySelector<HTMLElement>(':scope > [data-pill-selection-fill]')
+      const target = [...element.querySelectorAll<HTMLButtonElement>(':scope > button')]
+        .find(button => button.textContent === 'Dark')
+      if (!fill || !target) {
+        reject(new Error('The segmented control is incomplete.'))
+        return
+      }
+      target.click()
+      requestAnimationFrame(() => resolve({
+        animations: fill.getAnimations().length,
+        checked: target.getAttribute('aria-checked'),
+        shadow: getComputedStyle(target).boxShadow,
+      }))
+    }))
 
-    expect(await page.evaluate(() => matchMedia('(prefers-reduced-motion: reduce)').matches)).toBe(true)
-    // Oat restricts every reduced transition to 0.01 ms with an important
-    // global rule. This duration produces no visible movement.
-    const transitionMs = await indicator.evaluate((element) => {
-      const durationList = getComputedStyle(element).transitionDuration
-      const durations = durationList.split(',').map(value =>
-        Number.parseFloat(value) * (value.trim().endsWith('ms') ? 1 : 1000))
-      return Math.max(...durations)
+    expect(state.checked).toBe('true')
+    expect(state.animations).toBe(0)
+    expect(state.shadow).not.toBe('none')
+    await expect(indicator).toHaveCount(1)
+  })
+
+  test('shows keyboard focus on the selected segment', async ({ page, leapmuxServer }) => {
+    const group = await openThemeModes(page, leapmuxServer.adminToken)
+    const selected = group.getByRole('radio', { checked: true })
+    await page.keyboard.press('Tab')
+    await selected.focus()
+
+    const colors = await selected.evaluate((element) => {
+      const root = getComputedStyle(document.documentElement)
+      return {
+        outline: getComputedStyle(element).outlineColor,
+        outlineStyle: getComputedStyle(element).outlineStyle,
+        selectedForeground: root.getPropertyValue('--primary-foreground').trim(),
+      }
     })
-    expect(transitionMs).toBeLessThanOrEqual(0.01)
-    expect(await indicator.evaluate(element => element.getAnimations().length)).toBe(0)
+    expect(colors.outlineStyle).toBe('solid')
+    expect(colors.outline).toBe(await resolvedColor(page, colors.selectedForeground))
+  })
+
+  test('keeps the selected segment distinct in forced colors', async ({ page, leapmuxServer }) => {
+    await page.emulateMedia({ forcedColors: 'active' })
+    const group = await openThemeModes(page, leapmuxServer.adminToken)
+    const selected = group.getByRole('radio', { checked: true })
+    const unselected = group.getByRole('radio', { checked: false }).first()
+
+    await expect(selected).toHaveAttribute('aria-checked', 'true')
+    expect(await selectionIndicator(group).evaluate(element => getComputedStyle(element).backgroundColor))
+      .not
+      .toBe(await unselected.evaluate(element => getComputedStyle(element).backgroundColor))
+  })
+
+  test('keeps every segment inside a narrow settings row', async ({ page, leapmuxServer }) => {
+    const group = await openAppTypes(page, leapmuxServer.adminToken)
+    await page.setViewportSize({ width: 375, height: 800 })
+    const layout = await group.evaluate((element) => {
+      const container = element.closest<HTMLElement>('[data-setting-id]')
+      if (!container)
+        throw new Error('The segmented control has no settings row.')
+      const groupRect = element.getBoundingClientRect()
+      const containerRect = container.getBoundingClientRect()
+      return {
+        groupLeft: groupRect.left,
+        groupRight: groupRect.right,
+        containerLeft: containerRect.left,
+        containerRight: containerRect.right,
+        viewportWidth: window.innerWidth,
+        maxButtonOverflow: Math.max(...[...element.querySelectorAll<HTMLButtonElement>('[role="radio"]')]
+          .map(button => button.scrollWidth - button.clientWidth)),
+      }
+    })
+
+    expect(layout.groupLeft).toBeGreaterThanOrEqual(layout.containerLeft)
+    expect(layout.groupRight).toBeLessThanOrEqual(layout.containerRight)
+    expect(layout.groupLeft).toBeGreaterThanOrEqual(0)
+    expect(layout.groupRight).toBeLessThanOrEqual(layout.viewportWidth)
+    expect(layout.maxButtonOverflow).toBeLessThanOrEqual(1)
   })
 })

--- a/frontend/tests/e2e/196-pill-group.spec.ts
+++ b/frontend/tests/e2e/196-pill-group.spec.ts
@@ -1,0 +1,190 @@
+import type { Locator, Page } from '@playwright/test'
+import { expect, test } from './fixtures'
+import { loginViaToken, openSettingsAt, resolvedColor } from './helpers/ui'
+
+async function openThemeModes(page: Page, token: string): Promise<Locator> {
+  await loginViaToken(page, token)
+  await page.goto('/')
+  const dialog = await openSettingsAt(page, 'appearance')
+  return dialog
+    .locator('[data-setting-id="appearance.theme"]')
+    .getByRole('radiogroup', { name: 'Theme mode' })
+}
+
+function selectionIndicator(group: Locator): Locator {
+  return group.locator(':scope > [aria-hidden="true"]')
+}
+
+async function selectMode(group: Locator, label: string): Promise<Locator> {
+  const radio = group.getByRole('radio', { name: label })
+  if (await radio.getAttribute('aria-checked') !== 'true')
+    await radio.click()
+  await expect(radio).toHaveAttribute('aria-checked', 'true')
+  return radio
+}
+
+async function indicatorDelta(indicator: Locator, radio: Locator) {
+  const indicatorBox = await indicator.boundingBox()
+  const radioBox = await radio.boundingBox()
+  if (!indicatorBox || !radioBox)
+    return null
+  return {
+    left: indicatorBox.x - radioBox.x,
+    top: indicatorBox.y - radioBox.y,
+    width: indicatorBox.width - radioBox.width,
+    height: indicatorBox.height - radioBox.height,
+  }
+}
+
+async function expectIndicatorAt(indicator: Locator, radio: Locator): Promise<void> {
+  await expect.poll(async () => {
+    const delta = await indicatorDelta(indicator, radio)
+    return delta === null
+      ? Number.POSITIVE_INFINITY
+      : Math.max(...Object.values(delta).map(value => Math.abs(value)))
+  }).toBeLessThanOrEqual(0.05)
+}
+
+test.describe('Pill group segmented control', () => {
+  test('renders one content-sized control with dividers and an active fill', async ({ page, leapmuxServer }) => {
+    const group = await openThemeModes(page, leapmuxServer.adminToken)
+    const indicator = selectionIndicator(group)
+    await expect(indicator).toHaveCount(1)
+
+    const layout = await group.evaluate((element) => {
+      const groupStyle = getComputedStyle(element)
+      const buttons = [...element.querySelectorAll<HTMLButtonElement>(':scope > button')]
+      const boxes = buttons.map((button) => {
+        const rect = button.getBoundingClientRect()
+        const style = getComputedStyle(button)
+        return {
+          left: rect.left,
+          right: rect.right,
+          width: rect.width,
+          borderRadius: style.borderRadius,
+          borderInlineStartWidth: style.borderInlineStartWidth,
+          backgroundColor: style.backgroundColor,
+        }
+      })
+      const groupRect = element.getBoundingClientRect()
+      return {
+        gap: groupStyle.columnGap,
+        borderStyle: groupStyle.borderTopStyle,
+        borderWidth: groupStyle.borderTopWidth,
+        borderRadius: groupStyle.borderRadius,
+        groupWidth: groupRect.width,
+        groupLeft: groupRect.left,
+        groupRight: groupRect.right,
+        boxes,
+      }
+    })
+
+    expect(layout.gap).toBe('0px')
+    expect(layout.borderStyle).toBe('solid')
+    expect(layout.borderWidth).toBe('1px')
+    expect(Number.parseFloat(layout.borderRadius)).toBeGreaterThan(0)
+    expect(layout.boxes).toHaveLength(3)
+    expect(layout.boxes[0]!.left).toBeCloseTo(layout.groupLeft + 1, 1)
+    expect(layout.boxes.at(-1)!.right).toBeCloseTo(layout.groupRight - 1, 1)
+    expect(layout.groupWidth).toBeCloseTo(
+      layout.boxes.reduce((width, box) => width + box.width, 0) + 2,
+      1,
+    )
+    expect(new Set(layout.boxes.map(box => Math.round(box.width))).size).toBeGreaterThan(1)
+
+    for (let index = 1; index < layout.boxes.length; index++) {
+      expect(layout.boxes[index - 1]!.right).toBeCloseTo(layout.boxes[index]!.left, 1)
+      expect(layout.boxes[index]!.borderInlineStartWidth).toBe('1px')
+      expect(layout.boxes[index]!.borderRadius).toBe('0px')
+      expect(layout.boxes[index]!.backgroundColor).toBe('rgba(0, 0, 0, 0)')
+    }
+
+    const selected = group.getByRole('radio', { checked: true })
+    await expectIndicatorAt(indicator, selected)
+
+    const tokens = await page.evaluate(() => {
+      const root = getComputedStyle(document.documentElement)
+      return {
+        primary: root.getPropertyValue('--primary').trim(),
+        primaryForeground: root.getPropertyValue('--primary-foreground').trim(),
+        mutedForeground: root.getPropertyValue('--muted-foreground').trim(),
+      }
+    })
+    expect(await indicator.evaluate(element => getComputedStyle(element).backgroundColor))
+      .toBe(await resolvedColor(page, tokens.primary))
+    expect(await selected.evaluate(element => getComputedStyle(element).color))
+      .toBe(await resolvedColor(page, tokens.primaryForeground))
+    expect(await group.getByRole('radio', { checked: false }).first().evaluate(element => getComputedStyle(element).color))
+      .toBe(await resolvedColor(page, tokens.mutedForeground))
+
+    const governedGroup = page
+      .locator('[data-setting-id="appearance.terminalTheme"]')
+      .getByRole('radiogroup', { name: 'Terminal theme mode' })
+    await expect(governedGroup.getByRole('radio').first()).toBeDisabled()
+    expect(await governedGroup.evaluate(element => getComputedStyle(element).opacity)).toBe('0.55')
+    expect(await governedGroup.getByRole('radio').first().evaluate(element => getComputedStyle(element).opacity))
+      .toBe('1')
+  })
+
+  test('moves the active fill between segments when motion is allowed', async ({ page, leapmuxServer }) => {
+    await page.emulateMedia({ reducedMotion: 'no-preference' })
+    const group = await openThemeModes(page, leapmuxServer.adminToken)
+    const indicator = selectionIndicator(group)
+    const system = await selectMode(group, 'System')
+    await expectIndicatorAt(indicator, system)
+
+    const transitionedProperties = await group.evaluate(element => new Promise<string[]>((resolve, reject) => {
+      const fill = element.querySelector<HTMLElement>(':scope > [aria-hidden="true"]')
+      const target = [...element.querySelectorAll<HTMLButtonElement>(':scope > button')]
+        .find(button => button.textContent === 'Dark')
+      if (!fill || !target) {
+        reject(new Error('The segmented control is incomplete.'))
+        return
+      }
+
+      const properties = new Set<string>()
+      const timeout = window.setTimeout(() => {
+        reject(new Error(`Missing transitions: ${[...properties].join(', ')}`))
+      }, 2000)
+      fill.addEventListener('transitionrun', (event) => {
+        properties.add(event.propertyName)
+        if (properties.has('transform') && properties.has('width')) {
+          window.clearTimeout(timeout)
+          resolve([...properties])
+        }
+      })
+      target.click()
+    }))
+
+    expect(transitionedProperties).toContain('transform')
+    expect(transitionedProperties).toContain('width')
+    const dark = group.getByRole('radio', { name: 'Dark' })
+    await expect(dark).toHaveAttribute('aria-checked', 'true')
+    await expectIndicatorAt(indicator, dark)
+  })
+
+  test('moves the active fill without visible motion when motion is reduced', async ({ page, leapmuxServer }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' })
+    const group = await openThemeModes(page, leapmuxServer.adminToken)
+    const indicator = selectionIndicator(group)
+    const system = await selectMode(group, 'System')
+    await expectIndicatorAt(indicator, system)
+
+    const dark = group.getByRole('radio', { name: 'Dark' })
+    await dark.click()
+    await expect(dark).toHaveAttribute('aria-checked', 'true')
+    await expectIndicatorAt(indicator, dark)
+
+    expect(await page.evaluate(() => matchMedia('(prefers-reduced-motion: reduce)').matches)).toBe(true)
+    // Oat restricts every reduced transition to 0.01 ms with an important
+    // global rule. This duration produces no visible movement.
+    const transitionMs = await indicator.evaluate((element) => {
+      const durationList = getComputedStyle(element).transitionDuration
+      const durations = durationList.split(',').map(value =>
+        Number.parseFloat(value) * (value.trim().endsWith('ms') ? 1 : 1000))
+      return Math.max(...durations)
+    })
+    expect(transitionMs).toBeLessThanOrEqual(0.01)
+    expect(await indicator.evaluate(element => element.getAnimations().length)).toBe(0)
+  })
+})

--- a/scripts/generate-contracts.test.mjs
+++ b/scripts/generate-contracts.test.mjs
@@ -1,15 +1,13 @@
-// Tests for generate-contracts.mjs, run by `bun test` via `task test-scripts`.
+// `task test-scripts` runs these tests for generate-contracts.mjs.
 //
-// The checks and emitters are pure functions, so every failure mode is
-// testable without staging or buf. What carries the risk:
-//   - the derivation arithmetic (a wrong sum here is a wrong wire limit
-//     everywhere, silently),
-//   - the name tables (a mangled or duplicated entry means one side compiles
-//     against a constant the other side never got),
-//   - determinism (non-deterministic output defeats the mtime-preserving
-//     publish and makes every `task generate` a Vite hard-refresh).
-// The generate() orchestration is tested against the REAL contracts/ dir,
-// the same way validate-json.test.mjs pins its rule table to the real tree.
+// Pure checks and emitters make each failure testable without staging or buf.
+// Three areas carry risk:
+//   - Incorrect arithmetic silently changes each derived wire limit.
+//   - An incorrect name table can make one side omit a shared constant.
+//   - Non-deterministic output defeats publication that preserves modification
+//     times. Vite then refreshes after each `task generate` command.
+// `generate()` uses the real contracts directory in its integration test.
+// validate-json.test.mjs tests its rule table against the real tree too.
 
 import { cpSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -99,9 +97,8 @@ describe('deriveWire', () => {
   })
 
   it('matches the values both sides shipped before contracts existed', () => {
-    // The frozen pre-contract values: Go wire.go / rekey.go and TS
-    // reassembler.ts / channelSession.ts. If a migration changed a number,
-    // this is the line that goes red and forces the retune to be deliberate.
+    // Freeze the values from the Go and TypeScript sources before the contract.
+    // A migration that changes one value must also update this assertion.
     const d = deriveWire(WIRE)
     expect(d.maxPlaintextPerChunkBytes).toBe(65519)
     expect(d.maxReassembledMessageSizeBytes).toBe(16842752)
@@ -150,9 +147,8 @@ describe('checkWire', () => {
   })
 
   it('rejects a name-table key flattenWire does not provide', () => {
-    // A key listed in a table but missing from the flattened object renders
-    // as the literal "undefined" in generated code. The coverage check turns
-    // that into a ContractError naming the key.
+    // A table key that is absent from the flat object emits `undefined`.
+    // The coverage check returns a ContractError that identifies the key.
     expectContractError(
       () => checkWire({ ...WIRE, protocolVersion: undefined }),
       'name table',
@@ -160,8 +156,8 @@ describe('checkWire', () => {
   })
 
   it('rejects a hard nonce limit at or below the soft limit', () => {
-    // The soft trigger must fire before the wrap bound, or the session
-    // rekeys only once it has already passed the point of refusal.
+    // The soft trigger must run before the wrap limit. Otherwise, the session
+    // rekeys after it passes the refusal point.
     expectContractError(
       () => checkWire({ ...WIRE, noise: { softNonceLimit: WIRE.noise.softNonceLimit, hardNonceLimit: WIRE.noise.softNonceLimit } }),
       '< noise.hardNonceLimit',
@@ -187,8 +183,8 @@ describe('checkHeaders / checkRetry', () => {
   })
 
   it('rejects a header with no name-table entry instead of emitting nothing', () => {
-    // The emitters iterate the name tables, so a JSON key without an entry
-    // would pass every check and never be emitted on either side.
+    // The emitters iterate the name tables. A JSON key without an entry would
+    // pass the checks but reach neither output.
     expectContractError(
       () => checkHeaders({ ...HEADERS, elevationFoo: 'Leapmux-Elevation-Foo' }),
       'has no HEADERS_GO_NAMES entry',
@@ -210,9 +206,8 @@ describe('checkHeaders / checkRetry', () => {
   })
 
   it('rejects a policy with no name-table entry instead of emitting "undefined"', () => {
-    // A policy the name tables do not know would emit Go consts named
-    // undefinedInitial and a TS export literally named "undefined" -- both
-    // compile. The bijection makes it a loud generation failure.
+    // An unknown policy would emit `undefinedInitial` in Go and `undefined` in
+    // TypeScript. Both outputs compile. The bijection makes generation fail.
     expectContractError(
       () => checkRetry({ policies: { connect: { initialMs: 1, maxMs: 2, multiplier: 2, jitterFactor: 0, maxAttempts: 1 } } }),
       'has no RETRY_GO_NAMES entry',
@@ -246,9 +241,8 @@ describe('name tables', () => {
 describe('emitters', () => {
   it('produces gofmt-stable const blocks (aligned pads)', () => {
     const go = emitGoWire(WIRE, deriveWire(WIRE))
-    // gofmt aligns consecutive const values by padding to the longest name;
-    // a misaligned block means `gofmt -l` flags the generated file and the
-    // publish turns into a permanent diff.
+    // gofmt aligns consecutive constants with padding. A misaligned block
+    // makes `gofmt -l` report the generated file after each publication.
     expect(go).toContain('NoiseAEADAuthTagSize             = 16')
     expect(go).toContain('DefaultMaxReassembledMessageSize = 16842752')
   })
@@ -263,10 +257,9 @@ describe('emitters', () => {
   })
 
   it('emits both Noise nonce limits, driven by the name tables', () => {
-    // The hard limit was the last hand-restated two-language mirror of the
-    // Noise limit family; both sides now read one wire.json value, and the
-    // emitters route the names through WIRE_GO_NAMES/WIRE_TS_NAMES like
-    // every other wire constant.
+    // The hard limit was the last manual mirror in the Noise limit family.
+    // Both languages now read one wire.json value. The emitters use the shared
+    // Go and TypeScript name tables.
     const go = emitGoWire(WIRE, deriveWire(WIRE))
     expect(go).toContain('const HardNonceLimit = uint64(4294967295)')
     const ts = emitTsWire(WIRE, deriveWire(WIRE))
@@ -275,10 +268,9 @@ describe('emitters', () => {
   })
 
   it('emits every Tauri event the shell and webview spell, including the log and menu events', () => {
-    // sidecar:log and the two menu events stayed hand-spelled on both sides
-    // after the first four were contracted; a one-side rename of any of the
-    // seven killed a listener with nothing red. The name tables carry all of
-    // them now.
+    // Both sides once stated `sidecar:log` and the two menu events manually.
+    // A change on one side could disable a listener without a failure. The name
+    // tables now contain all seven events.
     const d = readContract('desktop')
     const rs = emitRsDesktop(d)
     expect(rs).toContain('pub const EVENT_SIDECAR_LOG: &str = "sidecar:log"')
@@ -289,12 +281,9 @@ describe('emitters', () => {
   })
 
   it('shields the macOS-only menu consts from dead_code off macOS', () => {
-    // The menu events are emitted solely from #[cfg(target_os = "macos")]
-    // code (the native app menu; Linux and Windows render the menu in the
-    // webview), so `cargo clippy --all-targets -- -D warnings` on the
-    // Linux/Windows CI runners saw the consts as dead and failed the build.
-    // allow, not expect: on macOS the consts are used and expect(dead_code)
-    // would itself warn there.
+    // Only macOS code emits the menu events. Linux and Windows render the menu
+    // in the webview. Their CI jobs therefore see these constants as unused.
+    // Use `allow`, because `expect(dead_code)` would warn on macOS.
     const d = readContract('desktop')
     const rs = emitRsDesktop(d)
     expect(rs).toContain('#[cfg_attr(not(target_os = "macos"), allow(dead_code))]\npub const EVENT_MENU_SHOW_ABOUT: &str = "menu:show-about"')
@@ -305,15 +294,15 @@ describe('emitters', () => {
   it('emits durations as const expressions, not runtime values', () => {
     const go = emitGoWire(WIRE, deriveWire(WIRE))
     expect(go).toContain('SessionKeyMaxAge      = time.Duration(3600000) * time.Millisecond')
-    // A true const is load-bearing: desktop/go/frame.go derives
-    // maxFrameSize from channelwire limits in a const expression.
+    // This output must remain a constant. desktop/go/frame.go uses the channel
+    // limits in the constant expression for maxFrameSize.
     expect(go).not.toContain('var ')
   })
 
   it('quotes strings as Go and TS both accept', () => {
     expect(emitGoHeaders(HEADERS)).toContain('"Leapmux-Elevation-Required"')
-    // The TS emitter uses JSON.stringify too: double quotes, matching the
-    // repo's eslint style for generated string literals.
+    // The TypeScript emitter uses JSON.stringify. It produces the double quotes
+    // that the ESLint rules require for generated string literals.
     expect(emitTsHeaders(HEADERS)).toContain('"Leapmux-Elevation-Required"')
   })
 
@@ -327,8 +316,8 @@ describe('emitters', () => {
   })
 
   it('emits the multiplier on the Go side too, so both sides can consume it', () => {
-    // The Go backoff previously hard-coded the doubling; the contract value
-    // must reach Go or editing it moves only the browser's schedule.
+    // Go once contained a fixed backoff multiplier. The contract must now send
+    // the multiplier to Go and the browser.
     const go = emitGoRetry(RETRY)
     expect(go).toContain('EventsRejectionRetryMultiplier  = 2')
   })
@@ -347,10 +336,11 @@ describe('emitters', () => {
     const agentEnum = enumValues(DESCRIPTOR, 'leapmux/v1/agent.proto', 'AgentProvider')
     const ts = emitTsProviders(p, agentEnum)
     expect(ts).toContain('export const ALL_PROVIDERS: readonly AgentProvider[] = [')
-    // Proto order, matching the Go twin's AllProviders.
+    // Keep Protocol Buffer order to match AllProviders in Go.
     expect(ts.indexOf('AgentProvider.CLAUDE_CODE')).toBeLessThan(ts.indexOf('AgentProvider.CODEX'))
-    // The browser never parses provider strings (the CLI and admin RPCs do,
-    // via the Go twin), so the TS emitter must not ship a dead parse table.
+    // The browser does not parse provider strings. The command-line interface
+    // and admin remote procedure calls use the Go table. Do not emit an unused
+    // TypeScript parse table.
     expect(ts).not.toContain('PROVIDER_PARSE_ALIASES')
   })
 
@@ -367,11 +357,9 @@ describe('emitters', () => {
   })
 })
 
-// The provider-protocol domains (ZCode, Goose, Copilot, Pi) carry the wire vocabulary the two
-// languages dispatch on, and
-// both languages dispatch on the literals -- so the checks below are what stop a table
-// from reaching one side and not the other, or from carrying two branches the wire
-// cannot tell apart.
+// The provider-protocol domains define the wire vocabulary for two languages.
+// Both languages dispatch on these literals. These checks prevent a table from
+// reaching only one language. They also reject indistinguishable wire cases.
 describe('checkProviderProtocol', () => {
   const spec = {
     name: 'test-protocol',
@@ -390,8 +378,8 @@ describe('checkProviderProtocol', () => {
     expectContractError(() => checkProviderProtocol(spec, { ...ok(), events: {} }), 'events is missing or empty')
   })
 
-  // A table added to the JSON but not to PROVIDER_PROTOCOLS emits nothing, so one side
-  // would read a vocabulary the other never got.
+  // A JSON table outside PROVIDER_PROTOCOLS emits nothing. One language could
+  // then read vocabulary that the other language lacks.
   it('rejects a table the spec does not declare', () => {
     expectContractError(
       () => checkProviderProtocol(spec, { ...ok(), decisions: { Allow: 'allow' } }),
@@ -399,7 +387,7 @@ describe('checkProviderProtocol', () => {
     )
   })
 
-  // Two keys with one literal make two dispatch branches indistinguishable on the wire.
+  // Two keys with one literal make two dispatch cases identical on the wire.
   it('rejects a repeated literal inside one table', () => {
     expectContractError(
       () => checkProviderProtocol(spec, { ...ok(), events: { A: 'a', B: 'a' } }),
@@ -450,8 +438,8 @@ describe('checkCodexBypass', () => {
   })
 })
 
-// The pool the worker and the browser dialogs both name tabs from. The schema
-// holds the per-name shape; these are the two relations it cannot express.
+// The worker and browser dialogs both use this pool for tab titles. The schema
+// holds each title shape but cannot express these two relations.
 describe('checkTabNames', () => {
   const ok = () => ({
     titlePrefixes: { agent: 'Agent', terminal: 'Terminal' },
@@ -466,9 +454,9 @@ describe('checkTabNames', () => {
     expect(checkTabNames(ok())).toEqual({})
   })
 
-  // Two equal prefixes collapse "Agent Gabe" and "Terminal Gabe" into one
-  // title, and plan-mode auto-rename keys on the agent prefix alone -- it
-  // would start overwriting terminal titles.
+  // Equal prefixes collapse "Agent Gabe" and "Terminal Gabe" into one title.
+  // Plan mode uses the agent prefix for automatic renames. It could then
+  // overwrite terminal titles.
   it('rejects equal title prefixes', () => {
     expectContractError(
       () => checkTabNames({ ...ok(), titlePrefixes: { agent: 'Tab', terminal: 'Tab' } }),
@@ -476,9 +464,8 @@ describe('checkTabNames', () => {
     )
   })
 
-  // uniqueItems in the schema catches an exact repeat; sorting is what makes
-  // a near-repeat visible to the reviewer who has to apply the rules the
-  // schema cannot express.
+  // The schema uses uniqueItems to find an exact repeat. Sorting also makes a
+  // near-repeat visible during review.
   it('rejects an unsorted list', () => {
     expectContractError(
       () => checkTabNames({ ...ok(), names: ['Ada', 'Gabe', 'Bella', 'Tim'] }),
@@ -506,8 +493,8 @@ describe('checkListen', () => {
     expect(checkListen(ok())).toEqual({})
   })
 
-  // listenset.Parse compares the wildcard token BEFORE it tries netip or falls
-  // through to a host name, so a sentinel spelled like a host would shadow it.
+  // listenset.Parse checks the wildcard token before an address or host name.
+  // A sentinel that resembles a host would hide that host.
   it('rejects an anyHost spelled like a host', () => {
     expectContractError(() => checkListen({ ...ok(), anyHost: '0.0.0.0' }), 'is spelled like a host')
     expectContractError(() => checkListen({ ...ok(), anyHost: '::' }), 'is spelled like a host')
@@ -520,8 +507,8 @@ describe('checkListen', () => {
     expectContractError(() => checkListen({ ...ok(), maxExtraAddresses: 2.5 }), 'integer >= 1')
   })
 
-  // A token with no name-table entry emits NOTHING, silently, so one side
-  // would compile against a constant the other never received.
+  // A token without a name-table entry emits nothing. One side could compile
+  // against a constant that the other side lacks.
   it('rejects a source token no name table renders', () => {
     expectContractError(
       () => checkListen({ ...ok(), addressSources: { ...ok().addressSources, proxied: 'd' } }),
@@ -619,34 +606,33 @@ describe('generate', () => {
     ])
   })
 
-  // The two domains this change added ride the shared PROVIDER_PROTOCOLS path rather than
-  // bespoke emitters, so these pin what that path gives them and the bespoke one did not.
+  // These two domains use the shared PROVIDER_PROTOCOLS path. These assertions
+  // verify the output that their old custom emitters did not supply.
   it('emits the shared provider-protocol shape for the newest domains', () => {
     const files = generate(join(ROOT, 'contracts'), DESCRIPTOR)
 
-    // A TS union type per table -- the bespoke Copilot emitter produced none.
+    // Emit one TypeScript union for each table. The old Copilot emitter omitted it.
     const copilotTs = files['frontend/src/generated/contracts/copilot-permissions.ts']
     expect(copilotTs).toContain('export type CopilotPermissionGroup =')
     expect(copilotTs).toContain('export type CopilotPermissionValue =')
-    // The identifiers both languages already import must not move.
+    // Preserve the identifiers that both languages import.
     expect(copilotTs).toContain('export const COPILOT_PERMISSION_GROUP = {')
     expect(files['backend/generated/contracts/copilot-permissions.go'])
       .toContain('CopilotPermissionGroupAssistedApproval = "copilot_assisted_approval"')
-    // LeapMux owns one of the two Copilot ids, so the domain overrides the shared
-    // header rather than claiming the vendor owns every value in the file.
+    // LeapMux owns one of the two Copilot identifiers. The domain therefore
+    // overrides the shared header instead of assigning every value to the vendor.
     expect(files['backend/generated/contracts/copilot-permissions.go'])
       .not
       .toContain('vendor owns\n// the values')
 
-    // Goose's fallback mode now comes from the contract instead of being spelled in Go
-    // and in TypeScript by hand.
+    // The contract now supplies the Goose fallback mode to Go and TypeScript.
     expect(files['backend/generated/contracts/goose-protocol.go'])
       .toContain('GooseDefaultMode = GooseModeSmartApprove')
     expect(files['frontend/src/generated/contracts/goose-protocol.ts'])
       .toContain('export const GOOSE_DEFAULT_MODE = GOOSE_MODE.SmartApprove')
 
-    // Claude's modes are the last permission vocabulary that was spelled by hand in both
-    // languages; the plugin and the worker now read this one table.
+    // Claude modes were the last manual permission vocabulary in both languages.
+    // The plugin and worker now read this table.
     expect(files['backend/generated/contracts/claude-protocol.go'])
       .toContain('ClaudeModeBypassPermissions = "bypassPermissions"')
     expect(files['frontend/src/generated/contracts/claude-protocol.ts'])
@@ -654,10 +640,10 @@ describe('generate', () => {
   })
 
   it('fails loudly when a registered domain is missing its contract file', () => {
-    // A typo'd or renamed contracts/<name>.json used to skip its emitter
-    // silently; sync-generated then pruned the domain's outputs as orphans
-    // and the failure surfaced as compile errors pointing at generated code.
-    // Every registered domain must ship its file, and the error must name it.
+    // An incorrect contracts/<name>.json path once skipped its emitter.
+    // sync-generated then removed the outputs as orphans. The compiler reported
+    // the generated code instead of the missing contract. Report the contract
+    // path during generation.
     const partial = mkdtempSync(join(tmpdir(), 'contracts-partial-'))
     cpSync(join(ROOT, 'contracts'), partial, { recursive: true })
     rmSync(join(partial, 'desktop.json'))
@@ -685,9 +671,9 @@ describe('checkProviders', () => {
   })
 
   it('rejects a provider whose prefix-stripped suffix is not a valid TS member', () => {
-    // Same constraint as scopes: emitTsProviders interpolates the stripped
-    // suffix into AgentProvider.<suffix>, and a digit-leading value (legal
-    // protobuf) emits invalid TypeScript while the Go twin compiles.
+    // emitTsProviders inserts the suffix into AgentProvider.<suffix>. Protobuf
+    // permits an initial digit, but TypeScript does not. Reject it before Go and
+    // TypeScript produce different results.
     const p = { providers: { AGENT_PROVIDER_2FA_CODEX: { displayName: 'X', cliAlias: 'x', parseAliases: [] } } }
     expectContractError(() => checkProviders(p, ['AGENT_PROVIDER_UNSPECIFIED', 'AGENT_PROVIDER_2FA_CODEX']), 'not a valid TS member name')
   })
@@ -737,9 +723,8 @@ describe('checkScopes / checkTheme / checkValidate', () => {
   })
 
   it('rejects a proto enum value in neither scopes nor nonGrantable', () => {
-    // The partition check is the headline cross-check: without it, a scope
-    // added to the proto passes generation and every surface silently omits
-    // it (no token, no sentence, no checkbox).
+    // The partition check covers every Protocol Buffer scope. Without it, a new
+    // scope can pass generation but disappear from every user interface.
     const scopes = {
       SCOPE_ACCOUNT_READ: { token: 'account:read', description: 'd', consentSentence: 'c' },
     }
@@ -788,10 +773,9 @@ describe('checkScopes / checkTheme / checkValidate', () => {
   })
 
   it('rejects an astral code point both emitters would mis-encode', () => {
-    // tsClassSource emits 4-hex-digit \uXXXX escapes: an astral point becomes
-    // a valid BMP escape plus a literal digit, and goRangeTable writes uint16
-    // fields. Only a refusedAscii astral point compiles in Go at all -- while
-    // the browser class still matches the wrong characters.
+    // tsClassSource emits four-digit Unicode escapes. An astral point becomes a
+    // Basic Multilingual Plane escape plus a digit. goRangeTable also writes
+    // uint16 fields. Reject astral points before the languages disagree.
     expectContractError(() => checkValidate({
       name: { byteLimit: 1, invisibleFormat: [[128545, 128545]], whitespaceFold: [[1, 2]] },
       session: { byteLimit: 1, filePathByteLimit: 2, invisibleFormat: [[1, 1]], refusedControl: [[0, 1]], refusedAscii: [[2, 2]] },
@@ -810,10 +794,9 @@ describe('checkScopes / checkTheme / checkValidate', () => {
   })
 
   it('rejects a refusedAscii range whose hi end alone is astral', () => {
-    // The guard used to destructure only `lo`: [34, 128545] passed every
-    // check, and tsClassSource emitted \u0022-\u1f621, which a JS regex
-    // silently reads as U+0022-U+1F62 plus the literal "1" -- a different
-    // character set than Go's rune list, with no error anywhere.
+    // The old guard checked only `lo`. Thus, [34, 128545] passed and emitted an
+    // incorrect JavaScript range. Check both ends before the languages receive
+    // different character sets.
     expectContractError(() => checkValidate({
       name: { byteLimit: 1, invisibleFormat: [[1, 2]], whitespaceFold: [[3, 4]] },
       session: { byteLimit: 1, filePathByteLimit: 2, invisibleFormat: [[1, 2]], refusedControl: [[0, 1]], refusedAscii: [[34, 128545]] },
@@ -823,9 +806,8 @@ describe('checkScopes / checkTheme / checkValidate', () => {
   })
 
   it('rejects an inverted refusedAscii range', () => {
-    // An inverted entry built a character class the browser cannot compile
-    // ("range out of order") at module load, while Go silently omitted the
-    // rune from its list.
+    // An inverted entry makes the browser reject its character class. Go would
+    // instead omit the rune. Reject the entry during generation.
     expectContractError(() => checkValidate({
       name: { byteLimit: 1, invisibleFormat: [[1, 2]], whitespaceFold: [[3, 4]] },
       session: { byteLimit: 1, filePathByteLimit: 2, invisibleFormat: [[1, 2]], refusedControl: [[0, 1]], refusedAscii: [[2, 2]] },
@@ -835,10 +817,8 @@ describe('checkScopes / checkTheme / checkValidate', () => {
   })
 
   it('rejects a session file-path cap that is not larger than the token cap', () => {
-    // The two caps hold a RELATION, not two independent numbers: a session file
-    // path carries a directory prefix a token never does, and applying the token
-    // cap to a path refused every real one. An edit that lowers the file-path cap
-    // to the token cap must fail generation rather than reintroduce that refusal.
+    // These caps form one relation. A session file path contains a directory
+    // prefix that a token lacks. The file-path cap must stay above the token cap.
     expectContractError(() => checkValidate({
       name: { byteLimit: 1, invisibleFormat: [[1, 2]], whitespaceFold: [[3, 4]] },
       session: { byteLimit: 1, filePathByteLimit: 1, invisibleFormat: [[1, 2]], refusedControl: [[0, 1]], refusedAscii: [[2, 2]] },
@@ -849,9 +829,8 @@ describe('checkScopes / checkTheme / checkValidate', () => {
   })
 
   it('rejects a reserved username the Go const mangle cannot spell', () => {
-    // goReservedUsernames builds `Username<Name>` by case-mangling alone; a
-    // hyphen in the name emits invalid Go that fails at go build, not at
-    // generation. The check must fail generation with the username named.
+    // goReservedUsernames builds `Username<Name>` with case changes only. A
+    // hyphen produces invalid Go. Generation must identify that username.
     expectContractError(() => checkValidate({
       name: { byteLimit: 1, invisibleFormat: [[1, 2]], whitespaceFold: [[3, 4]] },
       session: { byteLimit: 1, filePathByteLimit: 2, invisibleFormat: [[1, 2]], refusedControl: [[0, 1]], refusedAscii: [[2, 2]] },
@@ -862,8 +841,8 @@ describe('checkScopes / checkTheme / checkValidate', () => {
   })
 
   it('rejects a session.invisibleFormat that diverges from the frozen name rule', () => {
-    // The repetition is the point: a name-rule change must not silently move
-    // what a token may hold. The generator enforces it next to the data.
+    // This repetition is intentional. A change to the identifier rules must not
+    // change the token rules. The generator checks both beside the data.
     expectContractError(() => checkValidate({
       name: { byteLimit: 1, invisibleFormat: [[1, 2]], whitespaceFold: [[3, 4]] },
       session: { byteLimit: 1, filePathByteLimit: 2, invisibleFormat: [[1, 3]], refusedControl: [[0, 1]], refusedAscii: [[2, 2]] },
@@ -874,9 +853,8 @@ describe('checkScopes / checkTheme / checkValidate', () => {
   })
 
   it('rejects a rename for a page token the contract never lists', () => {
-    // A rename whose key is absent from oauthPage.tokens is dead data: the
-    // emitter iterates only the listed tokens, so the page never defines the
-    // CSS variable and every rule reading it renders unset.
+    // A rename outside oauthPage.tokens is unused data. The emitter iterates the
+    // token list, so the page would omit the corresponding CSS variable.
     const theme = {
       light: { '--background': 'a', '--lm-danger-subtle': 'x' },
       dark: { '--background': 'c', '--lm-danger-subtle': 'y' },
@@ -886,9 +864,9 @@ describe('checkScopes / checkTheme / checkValidate', () => {
   })
 
   it('rejects a scope whose prefix-stripped suffix is not a valid TS member', () => {
-    // emitTsScopes interpolates the stripped suffix into Scope.<suffix>; a
-    // digit-leading value (legal protobuf) emits invalid TypeScript while
-    // the Go twin compiles, so the two sides fail asymmetrically.
+    // emitTsScopes inserts the suffix into Scope.<suffix>. Protocol Buffers
+    // permit an initial digit, but TypeScript does not. Reject the value before
+    // only one language fails.
     expectContractError(() => checkScopes({
       nonGrantable: ['SCOPE_UNSPECIFIED'],
       scopes: { SCOPE_2FA: { token: 'account:2fa', description: 'd', consentSentence: 'c' } },
@@ -902,10 +880,9 @@ describe('subtractRanges / nameStripClass', () => {
   it('removes the whitespace folds from Cc, keeping the format set whole', () => {
     const v = readContract('validate')
     const cls = nameStripClass(v)
-    // The class the browser shipped before contracts existed, frozen: C0
-    // minus the fold block, C1 minus NEL, then the format characters. The
-    // derived control half carries no name (it has none); the format half
-    // keeps the annotation straight from the contract.
+    // Freeze the browser class from before contracts existed. It contains C0
+    // without the fold block, C1 without the Next Line control, and the format
+    // characters. Only the format half receives annotations from the contract.
     expect(cls).toEqual([
       [0, 8],
       [14, 31],
@@ -928,12 +905,12 @@ describe('subtractRanges / nameStripClass', () => {
     const go = emitGoValidate(v)
     expect(go).toContain('{Lo: 0x00AD, Hi: 0x00AD, Stride: 1}, // SOFT HYPHEN')
     expect(go).toContain('{Lo: 0x0009, Hi: 0x000D, Stride: 1}, // TAB, LF, VERTICAL TAB, FORM FEED, CARRIAGE RETURN')
-    // The refused-ASCII runes carry their names from the contract too, so the
-    // Go prose cannot go stale against the JSON.
+    // The contract also supplies the labels for refused ASCII runes. The Go
+    // comments therefore stay consistent with the JSON.
     expect(go).toContain('var SessionRefusedASCII = []rune{0x0022, 0x0024, 0x0025, 0x005C} // QUOTATION MARK, DOLLAR SIGN, PERCENT SIGN, REVERSE SOLIDUS')
     const ts = emitTsValidate(v)
-    // The TS side carries the same names as a companion comment block above
-    // each class const; the class BODY itself stays pure regex syntax.
+    // TypeScript emits the same labels in a comment above each class constant.
+    // The class body contains only regular-expression syntax.
     expect(ts).toContain('*   \\u00ad  SOFT HYPHEN')
     expect(ts).toContain('*   \\u0022  QUOTATION MARK')
     const classLine = ts.split('\n').find(l => l.includes('SESSION_FORBIDDEN_CLASS ='))
@@ -985,9 +962,8 @@ describe('checkSessionInfo', () => {
   })
 
   it('accepts the same token in two DIFFERENT tables', () => {
-    // running_tool.tool_name and a hypothetical future tier field of the same
-    // name are fields of different objects; only a repeat WITHIN one object is
-    // ambiguous. The check must not over-reach into a cross-table ban.
+    // Fields in different objects can use the same key. Only a repeated key in
+    // one object is ambiguous. Do not reject a key across separate tables.
     expect(() => checkSessionInfo(sessionInfo({
       runningToolFields: { ToolName: 'tool_name' },
       rateLimitFields: { ToolName: 'tool_name' },
@@ -995,20 +971,17 @@ describe('checkSessionInfo', () => {
   })
 
   it('rejects an empty table rather than emitting an empty const block', () => {
-    // goConstBlock takes Math.max of an empty list, which is -Infinity: the
-    // emitter would produce unparseable Go instead of failing here.
+    // goConstBlock applies Math.max to the list. An empty list produces
+    // negative infinity and invalid Go. Reject it before emission.
     expectContractError(
       () => checkSessionInfo(sessionInfo({ contextUsageFields: {} })),
       'contextUsageFields must hold at least one entry',
     )
   })
 
-  // The one token LeapMux does not own. Claude Code writes `total_cost_usd` on
-  // its own `result` line, the worker persists that line unchanged, and the
-  // browser reads the persisted row through this constant -- while the Go
-  // decoder reads it through a struct tag, which takes a literal and cannot
-  // follow a rename. Without this pin a rename generates cleanly, passes every
-  // test, and blanks the per-turn cost on every Claude result divider.
+  // LeapMux does not own this token. Claude Code writes `total_cost_usd` in its
+  // result. The worker stores it unchanged. The browser uses this constant, but
+  // Go uses a literal struct tag. This assertion prevents a one-sided rename.
   it('rejects a rename of the cost token Claude Code itself writes', () => {
     expectContractError(
       () => checkSessionInfo(sessionInfo({
@@ -1018,10 +991,9 @@ describe('checkSessionInfo', () => {
     )
   })
 
-  // A table added to the JSON and to its schema, but forgotten in
-  // SESSION_INFO_TABLES, emits no Go and no TS and says nothing -- the first
-  // report would be an undefined-constant build failure that never names the
-  // contract.
+  // A table outside SESSION_INFO_TABLES emits no Go or TypeScript. The compiler
+  // would report an undefined constant without identifying the contract. Make
+  // generation report the missing registration.
   it('rejects a contract table that no SESSION_INFO_TABLES entry renders', () => {
     expectContractError(
       () => checkSessionInfo(sessionInfo({ compactionFields: { PreTokens: 'pre_tokens' } })),
@@ -1045,10 +1017,9 @@ describe('checkSessionInfo', () => {
   })
 
   it('emits the running_tool vocabulary the Claude tool_progress path needs', () => {
-    // The badge reads these names off the wire. A rename that reached only one
-    // side used to be invisible until the badge stopped updating. Matched with
-    // a regex because goConstBlock pads the `=` to the widest name in the
-    // block, so the exact spacing shifts whenever a sibling entry is added.
+    // The badge reads these fields from the wire. A one-sided rename can stop
+    // its updates. Use a regular expression because goConstBlock aligns each
+    // equals sign with the longest identifier.
     const go = emitGoSessionInfo(readContract('session-info'))
     for (const [name, token] of [
       ['SessionInfoKeyRunningTool', 'running_tool'],
@@ -1063,19 +1034,17 @@ describe('checkSessionInfo', () => {
 })
 
 describe('checkWorkerVocab / checkDesktop', () => {
-  // A valid windowBehavior block, spread into every negative desktop fixture
-  // below so each one fails for the reason it states. Without it a fixture
-  // reaches `Object.keys(undefined)` the moment a check is reordered, and the
-  // test would then pass on a TypeError rather than on the ContractError it
-  // asserts.
+  // Supply a valid windowBehavior block to each negative desktop fixture. Each
+  // fixture must fail with its expected ContractError, not an unrelated
+  // TypeError after check order changes.
   const behavior = () => ({
     trayOnClose: { tray: 'tray', quit: 'quit' },
     trayOnMinimize: { tray: 'tray', taskbar: 'taskbar' },
     startMinimized: { window: 'window', minimized: 'minimized' },
   })
 
-  // Valid launchVisibility and windowMode blocks, for the same reason as
-  // `behavior()`: the checks below them must be reachable without a TypeError.
+  // Supply valid launchVisibility and windowMode blocks too. The later checks
+  // must remain reachable without a TypeError.
   const launch = () => ({
     normal: 'normal',
     minimized: 'minimized',
@@ -1087,10 +1056,8 @@ describe('checkWorkerVocab / checkDesktop', () => {
     fullscreen: 'fullscreen',
   })
 
-  // A COMPLETE event set, for a fixture whose asserted failure lies past the
-  // tauriEvents coverage check. The abbreviated four-event literals below
-  // predate that check and survive only because their own failure fires
-  // first.
+  // Supply every event when a fixture must pass the tauriEvents coverage check.
+  // Older four-event fixtures fail before they reach that check.
   const events = () => ({
     channelMessage: 'c:m',
     channelClose: 'c:c',
@@ -1140,9 +1107,8 @@ describe('checkWorkerVocab / checkDesktop', () => {
   })
 
   it('rejects a thread-wrapper token that collides with a notification type', () => {
-    // The browser's thread probe routes on obj.type === NOTIFICATION_THREAD_TYPE;
-    // a notification type with the same token would be misrouted into the
-    // wrapper branch.
+    // The browser routes thread probes through NOTIFICATION_THREAD_TYPE. An
+    // equal notification token would enter the wrong processing case.
     expectContractError(() => checkWorkerVocab({
       notificationTypes: { AgentError: 'notification_thread' },
       workerAuthoredNotificationTypes: ['AgentError'],
@@ -1212,13 +1178,13 @@ describe('checkWorkerVocab / checkDesktop', () => {
   })
 
   it('rejects a macOS-only event key that no name table carries', () => {
-    // A typo in DESKTOP_RS_MACOS_ONLY_EVENTS would silently stop annotating
-    // the const it meant, and the off-macOS clippy failure would come back.
+    // An incorrect DESKTOP_RS_MACOS_ONLY_EVENTS key would omit its annotation.
+    // Clippy would then report the constant outside macOS.
     DESKTOP_RS_MACOS_ONLY_EVENTS.add('noSuchEvent')
     try {
       expectContractError(() => checkDesktop({
         envVars: { devEndpoint: 'A_X', binaryHash: 'B_Y', devFrontend: 'C_Z' },
-      devFrontendUrl: 'http://localhost:4328',
+        devFrontendUrl: 'http://localhost:4328',
         tauriEvents: { channelMessage: 'c:m', channelClose: 'c:c', userEventsMessage: 'u:m', userEventsClose: 'u:c' },
         windowBehavior: behavior(),
       }), 'missing from DESKTOP_RS_EVENT_NAMES')
@@ -1229,8 +1195,7 @@ describe('checkWorkerVocab / checkDesktop', () => {
   })
 
   it('rejects one setting whose two tokens are the same string', () => {
-    // A setting with one token offers no choice: the pill group would render
-    // two options that store the same value.
+    // Equal tokens give the pill group two options that store one value.
     expectContractError(() => checkDesktop({
       envVars: { devEndpoint: 'A_X', binaryHash: 'B_Y', devFrontend: 'C_Z' },
       devFrontendUrl: 'http://localhost:4328',
@@ -1241,9 +1206,9 @@ describe('checkWorkerVocab / checkDesktop', () => {
     }), 'windowBehavior.trayOnClose declares one token twice')
   })
 
-  // The grouping is DATA now, so a setting the name tables have never heard of
-  // is still checked -- which is the order a real change arrives in. The old
-  // checker-only table made the uniqueness rule skip such a setting entirely.
+  // The data now supplies the groups. Therefore, the checker can process a new
+  // setting before its name-table entry exists. The old checker table skipped
+  // that setting.
   it('checks token uniqueness for a setting no name table knows yet', () => {
     expectContractError(() => checkDesktop({
       envVars: { devEndpoint: 'A_X', binaryHash: 'B_Y', devFrontend: 'C_Z' },
@@ -1256,18 +1221,17 @@ describe('checkWorkerVocab / checkDesktop', () => {
   })
 
   it('accepts one token shared by two DIFFERENT settings', () => {
-    // `tray` is the token of both close-to-tray and minimize-to-tray in the shipped
-    // contract. A uniqueness check across the whole block -- the obvious
-    // reading of the rule above -- would refuse it.
+    // The shipped contract uses `tray` for close-to-tray and minimize-to-tray.
+    // Check uniqueness inside each setting, not across the full block.
     const d = readContract('desktop')
     expect(Object.keys(d.windowBehavior)).toEqual(['trayOnClose', 'trayOnMinimize', 'startMinimized'])
     expect(d.windowBehavior.trayOnClose.tray).toBe(d.windowBehavior.trayOnMinimize.tray)
     expect(() => checkDesktop(d)).not.toThrow()
   })
 
-  // launchVisibility is ONE choice, unlike windowBehavior, so its rule is the
-  // opposite: every token must differ. Two launch states that read alike on
-  // the wire would make `parseLaunchVisibility` answer the wrong one.
+  // launchVisibility is one choice, unlike windowBehavior. Each token must
+  // differ. Equal wire values would make `parseLaunchVisibility` return the
+  // wrong state.
   it('rejects two launch-visibility states sharing one token', () => {
     expectContractError(() => checkDesktop({
       envVars: { devEndpoint: 'A_X', binaryHash: 'B_Y', devFrontend: 'C_Z' },
@@ -1290,10 +1254,9 @@ describe('checkWorkerVocab / checkDesktop', () => {
     }), 'has no DESKTOP_RS_LAUNCH_NAMES entry')
   })
 
-  // windowMode is ONE choice like launchVisibility, but all THREE languages
-  // spell it: the Go config persists the token, the Rust shell matches it at
-  // launch, and the webview reads and writes it. It was three hand-written
-  // mirrors before, and no proto enum restates it now.
+  // windowMode is one choice in three languages. Go stores the token, Rust
+  // reads it at launch, and the webview reads and writes it. The contract
+  // replaces three manual copies.
   it('rejects two window modes sharing one token', () => {
     expectContractError(() => checkDesktop({
       envVars: { devEndpoint: 'A_X', binaryHash: 'B_Y', devFrontend: 'C_Z' },
@@ -1312,10 +1275,9 @@ describe('checkWorkerVocab / checkDesktop', () => {
     expect(emitTsDesktop(d)).toContain('export const WINDOW_MODE_NORMAL = "normal" as const')
   })
 
-  // The pair the contract exists to hold together: `LaunchVisibility::as_str`
-  // in Rust writes these, `parseLaunchVisibility` in the webview reads them,
-  // and that parse falls back to `normal` for anything it does not know -- so
-  // a one-sided rename hides a window with nothing failing.
+  // Rust writes these values through `LaunchVisibility::as_str`. The webview
+  // reads them through `parseLaunchVisibility`. An unknown value falls back to
+  // `normal`, so a one-sided change can hide a window without an error.
   it('emits the launch-visibility tokens for both Rust and TS', () => {
     const d = readContract('desktop')
     expect(emitRsDesktop(d)).toContain('pub const LAUNCH_VISIBILITY_HIDDEN: &str = "hidden"')
@@ -1332,8 +1294,9 @@ describe('checkWorkerVocab / checkDesktop', () => {
   })
 
   it('emits the hub DevFrontend env var to Go and Rust', () => {
-    // Debug sidecar spawn writes this; solo reads it into -dev-frontend. A
-    // one-sided rename leaves TCP extras on the embedded SPA again.
+    // The debug sidecar writes this value. Solo mode reads it into
+    // `-dev-frontend`. A one-sided change leaves TCP extras on the embedded
+    // single-page application.
     const d = readContract('desktop')
     expect(d.envVars.devFrontend).toBe('LEAPMUX_HUB_DEV_FRONTEND')
     expect(emitGoDesktop(d)).toContain('EnvDevFrontend = "LEAPMUX_HUB_DEV_FRONTEND"')
@@ -1341,17 +1304,16 @@ describe('checkWorkerVocab / checkDesktop', () => {
   })
 
   it('emits the frame cap to Go and Rust from one contract value', () => {
-    // The frame budget was three hand-restated copies (derived Go const,
-    // hardcoded Rust const, restated-literal test); it is one contract value
-    // now, so the twin emissions must both carry it.
+    // The frame budget once had three manual copies. One contract value now
+    // supplies the Go and Rust outputs.
     const d = readContract('desktop')
     expect(emitGoDesktop(d)).toContain(`const MaxFrameSizeBytes = ${d.maxFrameSizeBytes}`)
     expect(emitRsDesktop(d)).toContain(`pub const MAX_FRAME_SIZE_BYTES: u64 = ${d.maxFrameSizeBytes};`)
   })
 
   it('emits the DEV frontend URL to Go and Rust from one contract value', () => {
-    // Debug webview and sidecar DevProxy must share this origin; a one-sided
-    // rename leaves Network Access extras on the wrong Vite port.
+    // The debug webview and sidecar DevProxy must share this origin. A one-sided
+    // change sends Network Access extras to the wrong Vite port.
     const d = readContract('desktop')
     expect(d.devFrontendUrl).toBe('http://localhost:4328')
     expect(emitGoDesktop(d)).toContain('DevFrontendURL = "http://localhost:4328"')
@@ -1359,15 +1321,14 @@ describe('checkWorkerVocab / checkDesktop', () => {
   })
 
   it('emits the window-behaviour tokens to all three languages from one contract value', () => {
-    // These are the one setting family a THIRD language spells, so the three
-    // emissions are what keeps the hub's validator, the webview's parse and
-    // the shell's match on the same strings.
+    // Three languages use this setting family. These outputs keep the hub
+    // validator, webview parser, and shell matcher on the same strings.
     const d = readContract('desktop')
     const go = emitGoDesktop(d)
     const ts = emitTsDesktop(d)
     const rs = emitRsDesktop(d)
-    // The FLAT `<setting><Value>` keys the name tables use; the contract nests
-    // one object per setting, and only the emitted names stay flat.
+    // The name tables use flat `<setting><Value>` keys. The contract keeps one
+    // nested object for each setting. Only emitted identifiers remain flat.
     const flat = {
       trayOnCloseTray: d.windowBehavior.trayOnClose.tray,
       trayOnCloseQuit: d.windowBehavior.trayOnClose.quit,
@@ -1377,8 +1338,8 @@ describe('checkWorkerVocab / checkDesktop', () => {
       startMinimizedMinimized: d.windowBehavior.startMinimized.minimized,
     }
     for (const [key, token] of Object.entries(flat)) {
-      // goConstBlock pads the names into a column, so match the separator
-      // loosely rather than pinning the alignment.
+      // goConstBlock aligns the identifiers in a column. Match the separator
+      // without depending on that spacing.
       expect(go).toMatch(new RegExp(`${DESKTOP_GO_BEHAVIOR_NAMES[key]} += "${token}"`))
       expect(ts).toContain(`export const ${DESKTOP_TS_BEHAVIOR_NAMES[key]} = "${token}" as const`)
       expect(rs).toContain(`pub const ${DESKTOP_RS_BEHAVIOR_NAMES[key]}: &str = "${token}";`)
@@ -1386,9 +1347,8 @@ describe('checkWorkerVocab / checkDesktop', () => {
   })
 
   it('gives every window-behaviour key a distinct name in each language', () => {
-    // A duplicated table entry would emit one constant twice and leave the
-    // other token with no name at all -- the failure the coverage check
-    // cannot see, because both keys are present.
+    // A repeated table entry emits one constant twice and omits another token.
+    // The coverage check cannot find this because both keys exist.
     for (const table of [DESKTOP_GO_BEHAVIOR_NAMES, DESKTOP_RS_BEHAVIOR_NAMES, DESKTOP_TS_BEHAVIOR_NAMES]) {
       const names = Object.values(table)
       expect(new Set(names).size).toBe(names.length)
@@ -1398,8 +1358,8 @@ describe('checkWorkerVocab / checkDesktop', () => {
 
 describe('enumValues', () => {
   it('reads enum names from a buf descriptor, reserved values absent', () => {
-    // The real descriptor: reserved slot 3 must not appear, or the providers
-    // cross-check would demand metadata for a provider that cannot exist.
+    // Use the real descriptor. Reserved slot 3 must stay absent. Otherwise, the
+    // provider check requests metadata for a provider that cannot exist.
     const set = DESCRIPTOR
     const names = enumValues(set, 'leapmux/v1/agent.proto', 'AgentProvider')
     expect(names).toContain('AGENT_PROVIDER_CLAUDE_CODE')


### PR DESCRIPTION
## Motivation

Pill groups rendered as separate buttons even though they represented one required choice. Their predicate-based API also allowed selection, focus, and element identity to disagree.

A sliding segmented control needs more than motion alone. The fill, label contrast, unavailable options, narrow layouts, reduced motion, and forced colors must stay correct through every selection and layout change.

## Modifications

- Render each pill group as one segmented control with dividers and a sliding selection fill.
- Slide paired fill and label layers so active text keeps its palette contrast throughout the transition.
- Apply the accent background only to unselected hover states, and show the selected border after the slide finishes.
- Preserve a static selected fallback when geometry is unavailable. Recalculate geometry after size and ancestor attribute changes.
- Keep unavailable options keyboard-focusable with `aria-disabled`, tooltip reasons, and guarded activation.
- Preserve focus across fresh option records and option removal. Suppress writes when the selected key does not change.
- (Breaking) Replace `PillOptionSpec.value` with `PillOptionSpec.key`, replace the `selected` predicate with `selectedKey`, restrict labels to strings, and require one to four options through `PillOptions`.
- (Breaking) Remove `nextFilterTab` and `authMethodOptions`. Add `nextRovingValue`, `createKeyedElementRefs`, and `AuthMethodPillGroup` as their focused replacements.
- Update every caller and add unit and browser coverage for keyboard navigation, animation timing, hover, focus, reduced motion, forced colors, and narrow settings layouts.
- Reuse the complete system-information mock in preference tests and add the Lightning CSS license to both notice formats.

## Result

Users see one cohesive segmented control with smooth selection motion. Selected options no longer receive an accent hover fill, and their border appears only after motion completes.

Keyboard focus stays stable when options change. Unavailable choices remain discoverable without becoming selectable. Reduced-motion users get the final state without a slide, and forced-color users retain a visible selection.

Consumers must migrate to keyed string-labelled `PillOptions`, pass `selectedKey`, and replace the removed helper exports.
