### PR TITLE
feat(workspace): Make archiving a real lifecycle operation

### DIFF
--- a/backend/hub/server.go
+++ b/backend/hub/server.go
@@ -757,7 +757,7 @@ func NewServer(cfg *config.Config, opts ...ServerOption) (*Server, error) {
 	sectionPath, sectionHandler := leapmuxv1connect.NewSectionServiceHandler(sectionSvc, connectOpts)
 	mux.Handle(sectionPath, sectionHandler)
 
-	workspaceSvc := service.NewWorkspaceService(st, crdtRegistry)
+	workspaceSvc := service.NewWorkspaceService(st, crdtRegistry, reconcileNudger)
 	workspacePath, workspaceHandler := leapmuxv1connect.NewWorkspaceServiceHandler(workspaceSvc, connectOpts)
 	mux.Handle(workspacePath, workspaceHandler)
 

--- a/backend/internal/audit/identity.go
+++ b/backend/internal/audit/identity.go
@@ -39,7 +39,7 @@ var identityComparisonSites = map[string]string{
 	// stronger notice is the safe answer for an actor the hub cannot identify.
 	"internal/hub/service.issuedByAnotherPerson": "TestIssuedByAnotherPerson_BlankIdKeepsTheAlarm",
 	// The package's other resource-ownership predicate.
-	"internal/hub/service.(*SectionService).requireOwnedSection": "TestMoveSectionDeniesZeroCallerOnBlankOwnedSection",
+	"internal/hub/service.requireOwnedSection": "TestMoveSectionDeniesZeroCallerOnBlankOwnedSection",
 	// Decides whether a request may see one registered app. A PRIVATE app is
 	// visible to its owner alone, so a zero caller must resolve none: an
 	// unauthenticated stage (the device-code first hop) reaches hub-wide apps

--- a/backend/internal/hub/auth/delegation_procedures_test.go
+++ b/backend/internal/hub/auth/delegation_procedures_test.go
@@ -125,15 +125,16 @@ var newlyDelegationReachable = map[string]string{
 	// through a named RPC instead of an op body. workspace:write is the honest
 	// unit for both, and splitting them would need a scope whose only member
 	// is "delete a workspace", which no consent screen could explain.
-	leapmuxv1connect.WorkspaceServiceCreateWorkspaceProcedure: "SubmitOps already mutates the whole layout document; workspace:write is the honest unit",
-	leapmuxv1connect.WorkspaceServiceRenameWorkspaceProcedure: "SubmitOps already mutates the whole layout document; workspace:write is the honest unit",
-	leapmuxv1connect.WorkspaceServiceDeleteWorkspaceProcedure: "SubmitOps already mutates the whole layout document; workspace:write is the honest unit",
-	leapmuxv1connect.SectionServiceListSectionsProcedure:      "the sidebar is layout, which SubmitOps already reaches",
-	leapmuxv1connect.SectionServiceCreateSectionProcedure:     "the sidebar is layout, which SubmitOps already reaches",
-	leapmuxv1connect.SectionServiceRenameSectionProcedure:     "the sidebar is layout, which SubmitOps already reaches",
-	leapmuxv1connect.SectionServiceDeleteSectionProcedure:     "the sidebar is layout, which SubmitOps already reaches",
-	leapmuxv1connect.SectionServiceMoveSectionProcedure:       "the sidebar is layout, which SubmitOps already reaches",
-	leapmuxv1connect.SectionServiceMoveWorkspaceProcedure:     "the sidebar is layout, which SubmitOps already reaches",
+	leapmuxv1connect.WorkspaceServiceCreateWorkspaceProcedure:          "SubmitOps already mutates the whole layout document; workspace:write is the honest unit",
+	leapmuxv1connect.WorkspaceServiceRenameWorkspaceProcedure:          "SubmitOps already mutates the whole layout document; workspace:write is the honest unit",
+	leapmuxv1connect.WorkspaceServiceSetWorkspaceArchiveStateProcedure: "SubmitOps already mutates the whole layout document; workspace:write is the honest unit",
+	leapmuxv1connect.WorkspaceServiceDeleteWorkspaceProcedure:          "SubmitOps already mutates the whole layout document; workspace:write is the honest unit",
+	leapmuxv1connect.SectionServiceListSectionsProcedure:               "the sidebar is layout, which SubmitOps already reaches",
+	leapmuxv1connect.SectionServiceCreateSectionProcedure:              "the sidebar is layout, which SubmitOps already reaches",
+	leapmuxv1connect.SectionServiceRenameSectionProcedure:              "the sidebar is layout, which SubmitOps already reaches",
+	leapmuxv1connect.SectionServiceDeleteSectionProcedure:              "the sidebar is layout, which SubmitOps already reaches",
+	leapmuxv1connect.SectionServiceMoveSectionProcedure:                "the sidebar is layout, which SubmitOps already reaches",
+	leapmuxv1connect.SectionServiceMoveWorkspaceProcedure:              "the sidebar is layout, which SubmitOps already reaches",
 }
 
 // TestDelegationCeilingAdmitsTheFormerAllowlistAndOnlyRecordedAdditions is the

--- a/backend/internal/hub/auth/procedure_scopes.go
+++ b/backend/internal/hub/auth/procedure_scopes.go
@@ -221,15 +221,16 @@ var procedureScopes = map[string]ScopeRequirement{
 	leapmuxv1connect.AppServiceDeleteAppProcedure:              Requires(leapmuxv1.Scope_SCOPE_ADMIN_APPS),
 
 	// --- WorkspaceService ---------------------------------------------------
-	leapmuxv1connect.WorkspaceServiceListWorkspacesProcedure:  Requires(leapmuxv1.Scope_SCOPE_WORKSPACE_READ),
-	leapmuxv1connect.WorkspaceServiceGetWorkspaceProcedure:    Requires(leapmuxv1.Scope_SCOPE_WORKSPACE_READ),
-	leapmuxv1connect.WorkspaceServiceListTabsProcedure:        Requires(leapmuxv1.Scope_SCOPE_WORKSPACE_READ),
-	leapmuxv1connect.WorkspaceServiceGetTabProcedure:          Requires(leapmuxv1.Scope_SCOPE_WORKSPACE_READ),
-	leapmuxv1connect.WorkspaceServiceLocateTabProcedure:       Requires(leapmuxv1.Scope_SCOPE_WORKSPACE_READ),
-	leapmuxv1connect.WorkspaceServiceLocateTileProcedure:      Requires(leapmuxv1.Scope_SCOPE_WORKSPACE_READ),
-	leapmuxv1connect.WorkspaceServiceCreateWorkspaceProcedure: Requires(leapmuxv1.Scope_SCOPE_WORKSPACE_WRITE),
-	leapmuxv1connect.WorkspaceServiceRenameWorkspaceProcedure: Requires(leapmuxv1.Scope_SCOPE_WORKSPACE_WRITE),
-	leapmuxv1connect.WorkspaceServiceDeleteWorkspaceProcedure: Requires(leapmuxv1.Scope_SCOPE_WORKSPACE_WRITE),
+	leapmuxv1connect.WorkspaceServiceListWorkspacesProcedure:           Requires(leapmuxv1.Scope_SCOPE_WORKSPACE_READ),
+	leapmuxv1connect.WorkspaceServiceGetWorkspaceProcedure:             Requires(leapmuxv1.Scope_SCOPE_WORKSPACE_READ),
+	leapmuxv1connect.WorkspaceServiceListTabsProcedure:                 Requires(leapmuxv1.Scope_SCOPE_WORKSPACE_READ),
+	leapmuxv1connect.WorkspaceServiceGetTabProcedure:                   Requires(leapmuxv1.Scope_SCOPE_WORKSPACE_READ),
+	leapmuxv1connect.WorkspaceServiceLocateTabProcedure:                Requires(leapmuxv1.Scope_SCOPE_WORKSPACE_READ),
+	leapmuxv1connect.WorkspaceServiceLocateTileProcedure:               Requires(leapmuxv1.Scope_SCOPE_WORKSPACE_READ),
+	leapmuxv1connect.WorkspaceServiceCreateWorkspaceProcedure:          Requires(leapmuxv1.Scope_SCOPE_WORKSPACE_WRITE),
+	leapmuxv1connect.WorkspaceServiceRenameWorkspaceProcedure:          Requires(leapmuxv1.Scope_SCOPE_WORKSPACE_WRITE),
+	leapmuxv1connect.WorkspaceServiceSetWorkspaceArchiveStateProcedure: Requires(leapmuxv1.Scope_SCOPE_WORKSPACE_WRITE),
+	leapmuxv1connect.WorkspaceServiceDeleteWorkspaceProcedure:          Requires(leapmuxv1.Scope_SCOPE_WORKSPACE_WRITE),
 
 	// --- SectionService: the sidebar's own layout ---------------------------
 	leapmuxv1connect.SectionServiceListSectionsProcedure:  Requires(leapmuxv1.Scope_SCOPE_WORKSPACE_READ),

--- a/backend/internal/hub/crdt/manager.go
+++ b/backend/internal/hub/crdt/manager.go
@@ -1295,13 +1295,24 @@ func (m *Manager) processBatch(ctx context.Context, in SubmitInput, batch *leapm
 	// m.state's history it's immutable, so the goroutine can safely
 	// read from it after the manager mutex is released. auditWG
 	// drains on Stop() so log breadcrumbs always make it out.
+	// The nudge set is the union of two resolutions, and they read DIFFERENT
+	// generations on purpose: a tombstone's worker id is what the batch just
+	// removed (preState), and a move's is what it just wrote (working).
+	//
+	// Both are resolved NOW, before any goroutine spawns, so a background
+	// goroutine captures only these small maps instead of the whole
+	// (potentially multi-MB) UserCrdtState. After m.state = working below,
+	// preState is otherwise GC-eligible; capturing it in the goroutine would
+	// pin the old generation for the CanUseWorker DB lookup.
+	workerIDs := tombstonedTabWorkerIDs(batch, preState)
+	nudgeWorkerIDs := make([]string, 0, len(workerIDs))
+	for _, workerID := range workerIDs {
+		nudgeWorkerIDs = append(nudgeWorkerIDs, workerID)
+	}
+	for _, workerID := range movedTabWorkerIDs(batch, preState, working) {
+		nudgeWorkerIDs = append(nudgeWorkerIDs, workerID)
+	}
 	if containsTombstoneTab(batch) {
-		// Resolve the tombstoned tabs' worker ids from preState NOW, before
-		// spawning, so the audit goroutine captures only this small map instead
-		// of the whole (potentially multi-MB) UserCrdtState. After m.state =
-		// working below, preState is otherwise GC-eligible; capturing it in the
-		// goroutine would pin the old generation for the CanUseWorker DB lookup.
-		workerIDs := tombstonedTabWorkerIDs(batch, preState)
 		if !in.Internal {
 			m.auditWG.Add(1)
 			go func() {
@@ -1322,10 +1333,20 @@ func (m *Manager) processBatch(ctx context.Context, in SubmitInput, batch *leapm
 				m.auditOrphanTabTombstones(in, batch, res, workerIDs)
 			}()
 		}
+	}
+	{
 		// Nudge each affected worker to reconcile now rather than on its hourly
-		// tick. Reuses the map the audit already computed -- the tombstoned tabs'
-		// hosting workers ARE the set that has local state to release -- so this
-		// costs no extra query.
+		// tick.
+		//
+		// The set spans TOMBSTONES and MOVES, because both change what the Hub
+		// answers about a tab and the Worker caches that answer. A tombstone
+		// leaves local state to release. A move changes the tab's workspace, and
+		// with it the archive state the Worker stores per row -- so without
+		// this, a tab moved OUT of an archived workspace keeps refusing the
+		// user's messages until the hourly tick, on a tab the sidebar shows as
+		// live. Creating a tab is deliberately absent: see movedTabWorkerIDs.
+		// Neither map costs an extra query; both come from state already in
+		// hand.
 		//
 		// NOT gated on !in.Internal the way the audit is, and the gate now sits
 		// on the audit alone so that is actually true: an internal batch is
@@ -1346,10 +1367,10 @@ func (m *Manager) processBatch(ctx context.Context, in SubmitInput, batch *leapm
 		// lock and, on a refused control frame, fences the connection. Keeping
 		// all of that off the submit path costs one goroutine. Mirrors the
 		// audit's rationale above.
-		if m.reconcileNudger != nil {
-			seen := make(map[string]struct{}, len(workerIDs))
-			targets := make([]string, 0, len(workerIDs))
-			for _, workerID := range workerIDs {
+		if m.reconcileNudger != nil && len(nudgeWorkerIDs) > 0 {
+			seen := make(map[string]struct{}, len(nudgeWorkerIDs))
+			targets := make([]string, 0, len(nudgeWorkerIDs))
+			for _, workerID := range nudgeWorkerIDs {
 				if workerID == "" {
 					continue
 				}

--- a/backend/internal/hub/crdt/manager_audit.go
+++ b/backend/internal/hub/crdt/manager_audit.go
@@ -29,6 +29,67 @@ func containsTombstoneTab(batch *leapmuxv1.OpBatch) bool {
 	return false
 }
 
+// movedTabWorkerIDs resolves, for each op that MOVES an existing tab, the
+// worker id that hosts it after the batch.
+//
+// A move changes the tab's workspace, and with it the archive state the Hub
+// answers for that tab. The Worker caches that answer per row
+// (agents.workspace_archived, terminals.workspace_archived), so without a nudge
+// the cache is repaired only at the hourly tick. The visible failure is a tab
+// moved OUT of an archived workspace: its row keeps the flag, so every message
+// the user sends it answers "agent belongs to an archived workspace" for up to
+// an hour, on a tab the sidebar shows as live.
+//
+// It deliberately does NOT report a tab the batch CREATED. A fresh row is born
+// ACTIVE, which is right for every workspace except an archived one, and
+// nudging on each open would put a reconcile pass on the most common tab
+// operation there is -- the cost the "adding a tab has no local state to
+// release" tests pin. A tab created directly into an archived workspace is
+// reachable only from the CLI (the browser blocks it) and converges on the
+// next pass.
+//
+// tile_id is the workspace proxy: a tile belongs to one root, so a
+// cross-workspace move necessarily rewrites it. A ReviveTab always counts,
+// because it re-materializes a tab whose workspace nothing tracked while it
+// was shelled out.
+func movedTabWorkerIDs(batch *leapmuxv1.OpBatch, pre, post *leapmuxv1.UserCrdtState) map[string]string {
+	out := make(map[string]string)
+	for _, op := range batch.GetOps() {
+		var tabID string
+		alwaysNudge := false
+		switch body := op.GetBody().(type) {
+		case *leapmuxv1.CrdtOp_SetTabRegister:
+			tabID = body.SetTabRegister.GetTabId()
+		case *leapmuxv1.CrdtOp_ReviveTab:
+			tabID = body.ReviveTab.GetTab().GetTabId()
+			alwaysNudge = true
+		default:
+			continue
+		}
+		if tabID == "" {
+			continue
+		}
+		after := post.GetTabs()[tabID]
+		if after == nil {
+			continue
+		}
+		if !alwaysNudge {
+			before := pre.GetTabs()[tabID]
+			if before == nil {
+				// A create, not a move.
+				continue
+			}
+			if before.GetTileId().GetValue() == after.GetTileId().GetValue() {
+				continue
+			}
+		}
+		if wid := after.GetWorkerId().GetValue(); wid != "" {
+			out[tabID] = wid
+		}
+	}
+	return out
+}
+
 // tombstonedTabWorkerIDs resolves, for each TombstoneTab op in batch, the worker
 // id the tab was pinned to in the pre-commit state. It runs SYNCHRONOUSLY at the
 // spawn site (processBatch, before the audit goroutine is launched) so the

--- a/backend/internal/hub/crdt/manager_audit_test.go
+++ b/backend/internal/hub/crdt/manager_audit_test.go
@@ -613,6 +613,79 @@ func TestManager_TombstoneNudgesTheHostingWorker(t *testing.T) {
 		"the hosting worker must be nudged exactly once for a batch that closed two of its tabs")
 }
 
+// TestManager_MoveAcrossWorkspacesNudgesTheHostingWorker pins the second reason
+// a worker gets nudged.
+//
+// A Worker caches each tab's archive state per row, and a MOVE is what changes
+// the Hub's answer for that tab without closing it. Before the nudge covered
+// moves, a tab dragged out of an archived workspace kept workspace_archived = 1
+// until the worker's hourly tick, so every message the user sent it answered
+// "agent belongs to an archived workspace" on a tab the sidebar showed as live.
+//
+// The companion assertion is the one that keeps this cheap: a tab CREATE must
+// still not nudge, or the most common tab operation would put a reconcile pass
+// on the worker every time.
+func TestManager_MoveAcrossWorkspacesNudgesTheHostingWorker(t *testing.T) {
+	nudger := &recordingNudger{}
+	j := newFakeJournal()
+	mgr := crdt.NewManager(userid.MustNew("user-1"), j, orphanTabAuthChecker{},
+		slog.New(slog.NewJSONHandler(io.Discard, nil)), newIncrementingClock(1_000),
+		crdt.WithReconcileNudger(nudger))
+	require.NoError(t, mgr.Bootstrap(context.Background()))
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { _ = mgr.Start(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		mgr.Stop()
+	})
+
+	seedRootInternal(t, mgr, "ws-1", "root-1")
+	seedRootInternal(t, mgr, "ws-2", "root-2")
+	_, err := mgr.SubmitInternal(context.Background(), crdt.SubmitInput{
+		Batches: []*leapmuxv1.OpBatch{addTabBatch(t, "seed-a", "tab-a", "root-1", "w-host", "p1")},
+	})
+	require.NoError(t, err)
+	mgr.WaitForNudges()
+	require.Empty(t, nudger.snapshot(), "creating a tab must not nudge")
+
+	// Re-register the SAME tab against the other workspace's tile. That is what
+	// a cross-workspace move is at this layer.
+	_, err = mgr.SubmitInternal(context.Background(), crdt.SubmitInput{
+		Batches: []*leapmuxv1.OpBatch{{
+			BatchId: "move-a",
+			Ops: []*leapmuxv1.CrdtOp{
+				{OpId: "move-a-tile", Body: &leapmuxv1.CrdtOp_SetTabRegister{SetTabRegister: &leapmuxv1.SetTabRegisterOp{
+					TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: "tab-a",
+					Field: &leapmuxv1.SetTabRegisterOp_TileId{TileId: "root-2"},
+				}}},
+			},
+		}},
+	})
+	require.NoError(t, err)
+	mgr.WaitForNudges()
+
+	assert.Equal(t, []string{"w-host"}, nudger.snapshot(),
+		"a tab that changed workspace must nudge its worker, so the cached archive state is repaired")
+
+	// A re-register that does NOT change the tile is a reorder, not a move, and
+	// changes no archive answer.
+	_, err = mgr.SubmitInternal(context.Background(), crdt.SubmitInput{
+		Batches: []*leapmuxv1.OpBatch{{
+			BatchId: "reorder-a",
+			Ops: []*leapmuxv1.CrdtOp{
+				{OpId: "reorder-a-pos", Body: &leapmuxv1.CrdtOp_SetTabRegister{SetTabRegister: &leapmuxv1.SetTabRegisterOp{
+					TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: "tab-a",
+					Field: &leapmuxv1.SetTabRegisterOp_Position{Position: "p9"},
+				}}},
+			},
+		}},
+	})
+	require.NoError(t, err)
+	mgr.WaitForNudges()
+	assert.Equal(t, []string{"w-host"}, nudger.snapshot(),
+		"a reorder inside one workspace changes no archive answer, so it must not nudge again")
+}
+
 // TestManager_InternalTombstoneNudgesTheHostingWorker covers the path a
 // workspace delete actually takes. applyLifecycleDelete tombstones the
 // workspace's tabs via SubmitInternal, so the batch arrives with Internal=true.

--- a/backend/internal/hub/service/reconcile_nudger.go
+++ b/backend/internal/hub/service/reconcile_nudger.go
@@ -7,8 +7,9 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/workermgr"
 )
 
-// ReconcileNudger tells a worker to run its orphan reconciler now, over the
-// Connect stream it already holds. It implements crdt.ReconcileNudger.
+// ReconcileNudger tells a worker to reconcile tab deletion and workspace
+// archive state now, over the Connect stream it already holds. It implements
+// crdt.ReconcileNudger.
 //
 // Why this exists: closing a tab is a CRDT op, and the worker learns of it
 // either through the E2EE close RPC or -- when that never arrives -- through its

--- a/backend/internal/hub/service/section_service.go
+++ b/backend/internal/hub/service/section_service.go
@@ -365,7 +365,11 @@ func nextSectionPosition(sections []store.WorkspaceSection, sidebar leapmuxv1.Si
 }
 
 func (s *SectionService) requireOwnedSection(ctx context.Context, userID userid.UserID, sectionID string) (*store.WorkspaceSection, error) {
-	section, err := s.store.WorkspaceSections().GetByID(ctx, sectionID)
+	return requireOwnedSection(ctx, s.store, userID, sectionID)
+}
+
+func requireOwnedSection(ctx context.Context, st store.Store, userID userid.UserID, sectionID string) (*store.WorkspaceSection, error) {
+	section, err := st.WorkspaceSections().GetByID(ctx, sectionID)
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("section not found"))
@@ -450,18 +454,50 @@ func (s *SectionService) MoveWorkspace(
 		return nil, err
 	}
 
-	workspaceID := req.Msg.GetWorkspaceId()
-
-	if _, err := s.requireOwnedSection(ctx, user.ID, req.Msg.GetSectionId()); err != nil {
-		return nil, err
-	}
-
-	if err := s.store.WorkspaceSectionItems().Set(ctx, store.SetWorkspaceSectionItemParams{
-		UserID:      user.ID,
-		WorkspaceID: workspaceID,
-		SectionID:   req.Msg.GetSectionId(),
-		Position:    req.Msg.GetPosition(),
+	if err := s.store.RunInTransaction(ctx, func(tx store.Store) error {
+		workspaceID := req.Msg.GetWorkspaceId()
+		if _, err := loadOwnedWorkspaceOr403(ctx, tx, workspaceID, user.ID, "only workspace owner can move workspace"); err != nil {
+			return err
+		}
+		destination, err := requireOwnedSection(ctx, tx, user.ID, req.Msg.GetSectionId())
+		if err != nil {
+			return err
+		}
+		switch destination.SectionType {
+		case leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_CUSTOM,
+			leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_IN_PROGRESS,
+			leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_ARCHIVED:
+			// These section types contain workspaces.
+		default:
+			return connect.NewError(connect.CodeInvalidArgument,
+				fmt.Errorf("section %s cannot contain workspaces", destination.ID))
+		}
+		currentlyArchived, err := tx.WorkspaceSectionItems().IsInArchivedSection(ctx, store.IsWorkspaceInArchivedSectionParams{
+			UserID:      user.ID,
+			WorkspaceID: workspaceID,
+		})
+		if err != nil {
+			return fmt.Errorf("read workspace archive state: %w", err)
+		}
+		destinationArchived := destination.SectionType == leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_ARCHIVED
+		if currentlyArchived != destinationArchived {
+			return connect.NewError(connect.CodeFailedPrecondition,
+				fmt.Errorf("MoveWorkspace cannot move a workspace into or out of Archived"))
+		}
+		if err := tx.WorkspaceSectionItems().Set(ctx, store.SetWorkspaceSectionItemParams{
+			UserID:      user.ID,
+			WorkspaceID: workspaceID,
+			SectionID:   destination.ID,
+			Position:    req.Msg.GetPosition(),
+		}); err != nil {
+			return err
+		}
+		return nil
 	}); err != nil {
+		var connectErr *connect.Error
+		if errors.As(err, &connectErr) {
+			return nil, connectErr
+		}
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 

--- a/backend/internal/hub/service/section_service.go
+++ b/backend/internal/hub/service/section_service.go
@@ -201,14 +201,7 @@ func (s *SectionService) DeleteSection(
 			return err
 		}
 
-		var inProgressID string
-		for _, sec := range sections {
-			if sec.SectionType == leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_IN_PROGRESS {
-				inProgressID = sec.ID
-				break
-			}
-		}
-
+		inProgressID := findSectionOfType(sections, leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_IN_PROGRESS)
 		if inProgressID == "" {
 			return fmt.Errorf("in_progress section not found")
 		}
@@ -231,16 +224,8 @@ func (s *SectionService) DeleteSection(
 			return err
 		}
 		// Find the highest position currently in in_progress so we
-		// can extend past it. ListByUser already orders by
-		// (ws.position, wsi.position, wsi.workspace_id), so the last
-		// in-progress entry in iteration order is the one to append
-		// after.
-		lastInProgressPos := ""
-		for _, item := range allItems {
-			if item.SectionID == inProgressID {
-				lastInProgressPos = item.Position
-			}
-		}
+		// can extend past it.
+		lastInProgressPos := lastPositionInSection(allItems, inProgressID)
 		// Walk source items in the same sort order so the relocated
 		// block keeps its original relative order in the destination.
 		for _, item := range allItems {
@@ -364,6 +349,57 @@ func nextSectionPosition(sections []store.WorkspaceSection, sidebar leapmuxv1.Si
 	return lexorank.Mid(prev, "")
 }
 
+// requireWorkspaceSection refuses a section that cannot hold a workspace.
+//
+// Shared by the sidebar move and the archive move, so a section type added
+// later cannot become legal for one of them and refused by the other.
+func requireWorkspaceSection(section *store.WorkspaceSection) error {
+	switch section.SectionType {
+	case leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_CUSTOM,
+		leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_IN_PROGRESS,
+		leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_ARCHIVED:
+		return nil
+	default:
+		return connect.NewError(connect.CodeInvalidArgument,
+			fmt.Errorf("section %s cannot contain workspaces", section.ID))
+	}
+}
+
+// findSectionOfType returns the id of the user's section of this type, or ""
+// when they have none. Only a BUILT-IN type answers usefully: a user holds at
+// most one of each, while CUSTOM sections repeat.
+func findSectionOfType(sections []store.WorkspaceSection, sectionType leapmuxv1.SectionType) string {
+	for _, section := range sections {
+		if section.SectionType == sectionType {
+			return section.ID
+		}
+	}
+	return ""
+}
+
+// lastPositionInSection returns the greatest lexorank currently held in
+// sectionID, or "" when the section is empty. Pair it with lexorank.After to
+// append past everything already there.
+//
+// It depends on the ORDER its argument arrives in:
+// WorkspaceSectionItems().ListByUser orders by (ws.position, wsi.position,
+// wsi.workspace_id), so one section's rows are contiguous and the last one this
+// loop sees holds the greatest position within it. A caller that sorts the
+// slice differently must not use this function.
+//
+// Two callers share it -- DeleteSection's relocation and the archive move --
+// because both append into a built-in section, and a second hand-written scan
+// is where the two would drift.
+func lastPositionInSection(items []store.WorkspaceSectionItem, sectionID string) string {
+	last := ""
+	for _, item := range items {
+		if item.SectionID == sectionID {
+			last = item.Position
+		}
+	}
+	return last
+}
+
 func (s *SectionService) requireOwnedSection(ctx context.Context, userID userid.UserID, sectionID string) (*store.WorkspaceSection, error) {
 	return requireOwnedSection(ctx, s.store, userID, sectionID)
 }
@@ -463,14 +499,8 @@ func (s *SectionService) MoveWorkspace(
 		if err != nil {
 			return err
 		}
-		switch destination.SectionType {
-		case leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_CUSTOM,
-			leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_IN_PROGRESS,
-			leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_ARCHIVED:
-			// These section types contain workspaces.
-		default:
-			return connect.NewError(connect.CodeInvalidArgument,
-				fmt.Errorf("section %s cannot contain workspaces", destination.ID))
+		if err := requireWorkspaceSection(destination); err != nil {
+			return err
 		}
 		currentlyArchived, err := tx.WorkspaceSectionItems().IsInArchivedSection(ctx, store.IsWorkspaceInArchivedSectionParams{
 			UserID:      user.ID,

--- a/backend/internal/hub/service/section_service_test.go
+++ b/backend/internal/hub/service/section_service_test.go
@@ -22,15 +22,17 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/service"
 	"github.com/leapmux/leapmux/internal/hub/store"
 	"github.com/leapmux/leapmux/internal/hub/store/sqlite"
+	"github.com/leapmux/leapmux/internal/hub/store/storetest"
 	"github.com/leapmux/leapmux/internal/util/id"
 	"github.com/leapmux/leapmux/internal/util/sqlitedb"
 )
 
 type sectionTestEnv struct {
-	client leapmuxv1connect.SectionServiceClient
-	store  store.Store
-	token  string
-	userID string
+	client          leapmuxv1connect.SectionServiceClient
+	workspaceClient leapmuxv1connect.WorkspaceServiceClient
+	store           store.Store
+	token           string
+	userID          string
 }
 
 func setupSectionTest(t *testing.T) *sectionTestEnv {
@@ -50,6 +52,9 @@ func setupSectionTest(t *testing.T) *sectionTestEnv {
 	opts := connect.WithInterceptors(interceptor)
 	path, handler := leapmuxv1connect.NewSectionServiceHandler(sectionSvc, opts)
 	mux.Handle(path, handler)
+	workspacePath, workspaceHandler := leapmuxv1connect.NewWorkspaceServiceHandler(
+		service.NewWorkspaceService(st, nil, nil), opts)
+	mux.Handle(workspacePath, workspaceHandler)
 
 	server := httptest.NewUnstartedServer(mux)
 	server.EnableHTTP2 = true
@@ -60,6 +65,9 @@ func setupSectionTest(t *testing.T) *sectionTestEnv {
 		server.Client(),
 		server.URL,
 		connect.WithGRPC(),
+	)
+	workspaceClient := leapmuxv1connect.NewWorkspaceServiceClient(
+		server.Client(), server.URL, connect.WithGRPC(),
 	)
 
 	hash, _ := password.Hash("testpass")
@@ -82,10 +90,11 @@ func setupSectionTest(t *testing.T) *sectionTestEnv {
 	require.NoError(t, err)
 
 	return &sectionTestEnv{
-		client: client,
-		store:  st,
-		token:  token,
-		userID: userID,
+		client:          client,
+		workspaceClient: workspaceClient,
+		store:           st,
+		token:           token,
+		userID:          userID,
 	}
 }
 
@@ -738,18 +747,18 @@ func TestSectionService_MoveWorkspace(t *testing.T) {
 	listResp, _ := env.client.ListSections(context.Background(), authedReq(
 		&leapmuxv1.ListSectionsRequest{}, env.token))
 
-	var archivedID string
+	var inProgressID string
 	for _, s := range listResp.Msg.GetSections() {
-		if s.GetSectionType() == leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_ARCHIVED {
-			archivedID = s.GetId()
+		if s.GetSectionType() == leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_IN_PROGRESS {
+			inProgressID = s.GetId()
 		}
 	}
 
-	// Move the workspace to the archived section.
+	// A generic move keeps an active workspace inside the active boundary.
 	_, err = env.client.MoveWorkspace(context.Background(), authedReq(
 		&leapmuxv1.MoveWorkspaceRequest{
 			WorkspaceId: workspaceID,
-			SectionId:   archivedID,
+			SectionId:   inProgressID,
 			Position:    "n",
 		}, env.token))
 	require.NoError(t, err)
@@ -759,8 +768,81 @@ func TestSectionService_MoveWorkspace(t *testing.T) {
 		&leapmuxv1.ListSectionsRequest{}, env.token))
 	items := listResp2.Msg.GetItems()
 	require.Len(t, items, 1)
-	assert.Equal(t, archivedID, items[0].GetSectionId())
+	assert.Equal(t, inProgressID, items[0].GetSectionId())
 	assert.Equal(t, workspaceID, items[0].GetWorkspaceId())
+}
+
+func TestSectionService_MoveWorkspace_RefusesArchiveBoundary(t *testing.T) {
+	t.Parallel()
+
+	env := setupSectionTest(t)
+	ctx := context.Background()
+	workspaceID := storetest.SeedWorkspace(t, env.store, env.userID, "archive boundary")
+	sections, err := env.client.ListSections(ctx, authedReq(&leapmuxv1.ListSectionsRequest{}, env.token))
+	require.NoError(t, err)
+	var inProgressID, archivedID, filesID string
+	for _, section := range sections.Msg.GetSections() {
+		switch section.GetSectionType() {
+		case leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_IN_PROGRESS:
+			inProgressID = section.GetId()
+		case leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_ARCHIVED:
+			archivedID = section.GetId()
+		case leapmuxv1.SectionType_SECTION_TYPE_FILES:
+			filesID = section.GetId()
+		default:
+			// This test uses only the three section types above.
+		}
+	}
+	require.NotEmpty(t, inProgressID)
+	require.NotEmpty(t, archivedID)
+	require.NotEmpty(t, filesID)
+
+	_, err = env.client.MoveWorkspace(ctx, authedReq(&leapmuxv1.MoveWorkspaceRequest{
+		WorkspaceId: workspaceID, SectionId: filesID, Position: "a",
+	}, env.token))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+
+	_, err = env.client.MoveWorkspace(ctx, authedReq(&leapmuxv1.MoveWorkspaceRequest{
+		WorkspaceId: workspaceID, SectionId: archivedID, Position: "a",
+	}, env.token))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+
+	_, err = env.workspaceClient.SetWorkspaceArchiveState(ctx, authedReq(&leapmuxv1.SetWorkspaceArchiveStateRequest{
+		WorkspaceId:  workspaceID,
+		ArchiveState: leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED,
+	}, env.token))
+	require.NoError(t, err)
+	_, err = env.client.MoveWorkspace(ctx, authedReq(&leapmuxv1.MoveWorkspaceRequest{
+		WorkspaceId: workspaceID, SectionId: inProgressID, Position: "b",
+	}, env.token))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+}
+
+func TestSectionService_MoveWorkspace_RefusesForeignWorkspace(t *testing.T) {
+	t.Parallel()
+
+	env := setupSectionTest(t)
+	ctx := context.Background()
+	foreign := storetest.SeedUser(t, env.store, "move-foreign-owner")
+	workspaceID := storetest.SeedWorkspace(t, env.store, foreign.ID, "foreign")
+	sections, err := env.client.ListSections(ctx, authedReq(&leapmuxv1.ListSectionsRequest{}, env.token))
+	require.NoError(t, err)
+	var inProgressID string
+	for _, section := range sections.Msg.GetSections() {
+		if section.GetSectionType() == leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_IN_PROGRESS {
+			inProgressID = section.GetId()
+			break
+		}
+	}
+
+	_, err = env.client.MoveWorkspace(ctx, authedReq(&leapmuxv1.MoveWorkspaceRequest{
+		WorkspaceId: workspaceID, SectionId: inProgressID, Position: "a",
+	}, env.token))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
 }
 
 func TestSectionService_IsWorkspaceInArchivedSection(t *testing.T) {
@@ -779,13 +861,13 @@ func TestSectionService_IsWorkspaceInArchivedSection(t *testing.T) {
 	// Load the seeded sections and find their IDs.
 	listResp, _ := env.client.ListSections(context.Background(), authedReq(
 		&leapmuxv1.ListSectionsRequest{}, env.token))
-	var inProgressID, archivedID string
+	var inProgressID string
 	for _, s := range listResp.Msg.GetSections() {
 		switch s.GetSectionType() {
 		case leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_IN_PROGRESS:
 			inProgressID = s.GetId()
 		case leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_ARCHIVED:
-			archivedID = s.GetId()
+			// The lifecycle operation resolves the built-in Archived section.
 		default:
 			// Only the two workspace sections are needed to drive this test.
 		}
@@ -809,9 +891,13 @@ func TestSectionService_IsWorkspaceInArchivedSection(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, archived)
 
-	// Move to Archived.
-	_, _ = env.client.MoveWorkspace(context.Background(), authedReq(
-		&leapmuxv1.MoveWorkspaceRequest{WorkspaceId: workspaceID, SectionId: archivedID, Position: "a"}, env.token))
+	// Cross the boundary through the workspace lifecycle operation.
+	_, err = env.workspaceClient.SetWorkspaceArchiveState(context.Background(), authedReq(
+		&leapmuxv1.SetWorkspaceArchiveStateRequest{
+			WorkspaceId:  workspaceID,
+			ArchiveState: leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED,
+		}, env.token))
+	require.NoError(t, err)
 	archived, err = env.store.WorkspaceSectionItems().IsInArchivedSection(context.Background(), store.IsWorkspaceInArchivedSectionParams{
 		UserID:      userid.MustNew(env.userID),
 		WorkspaceID: workspaceID,
@@ -819,9 +905,13 @@ func TestSectionService_IsWorkspaceInArchivedSection(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, archived)
 
-	// Move back to In Progress.
-	_, _ = env.client.MoveWorkspace(context.Background(), authedReq(
-		&leapmuxv1.MoveWorkspaceRequest{WorkspaceId: workspaceID, SectionId: inProgressID, Position: "a"}, env.token))
+	// Return through the same lifecycle operation.
+	_, err = env.workspaceClient.SetWorkspaceArchiveState(context.Background(), authedReq(
+		&leapmuxv1.SetWorkspaceArchiveStateRequest{
+			WorkspaceId:  workspaceID,
+			ArchiveState: leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ACTIVE,
+		}, env.token))
+	require.NoError(t, err)
 	archived, err = env.store.WorkspaceSectionItems().IsInArchivedSection(context.Background(), store.IsWorkspaceInArchivedSectionParams{
 		UserID:      userid.MustNew(env.userID),
 		WorkspaceID: workspaceID,

--- a/backend/internal/hub/service/worker_connector_service.go
+++ b/backend/internal/hub/service/worker_connector_service.go
@@ -731,7 +731,7 @@ func (s *WorkerConnectorService) handleWorkspaceTabsSync(
 	// rows can collide. It would not be safe across owners -- tab ids are
 	// client-chosen, and the worker's report carries no user axis at all, so a
 	// cross-owner collision would be unresolvable on this side.
-	hubByKey := make(map[tabKey]store.WorkspaceTabRow, len(hubTabs))
+	hubByKey := make(map[tabKey]store.WorkerTabStateRow, len(hubTabs))
 	for _, ht := range hubTabs {
 		hubByKey[tabKey{tabType: ht.TabType, tabID: ht.TabID}] = ht
 	}

--- a/backend/internal/hub/service/worker_reconciler_service.go
+++ b/backend/internal/hub/service/worker_reconciler_service.go
@@ -59,20 +59,21 @@ func (s *WorkerReconcilerService) ListOwnedTabsForWorker(
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("list owned tabs: %w", err))
 	}
-	out := make([]*leapmuxv1.OwnedTab, 0, len(rows))
+	out := make([]*leapmuxv1.WorkerTabState, 0, len(rows))
 	for _, r := range rows {
 		// UserId is redundant with OwnerUserId today (the query binds one
 		// owner) but stays per-row: it is what the reconciler keys its
 		// (tab_type, tab_id, user_id) comparison by, since a FILE tab id is
 		// unique only within a user.
-		out = append(out, &leapmuxv1.OwnedTab{
-			TabType: r.TabType,
-			TabId:   r.TabID,
-			UserId:  r.UserID,
+		out = append(out, &leapmuxv1.WorkerTabState{
+			TabType:      r.TabType,
+			TabId:        r.TabID,
+			UserId:       r.UserID,
+			ArchiveState: r.ArchiveState,
 		})
 	}
 	return connect.NewResponse(&leapmuxv1.ListOwnedTabsForWorkerResponse{
-		Tabs:        out,
+		TabStates:   out,
 		OwnerUserId: registeredBy.String(),
 	}), nil
 }

--- a/backend/internal/hub/service/worker_reconciler_service_test.go
+++ b/backend/internal/hub/service/worker_reconciler_service_test.go
@@ -56,14 +56,46 @@ func TestListOwnedTabsForWorker_ScopedToRegistrant(t *testing.T) {
 	resp, err := service.NewWorkerReconcilerService(st).ListOwnedTabsForWorker(ctx, req)
 	require.NoError(t, err)
 
-	require.Len(t, resp.Msg.GetTabs(), 1, "a foreign owner's row must not be listed")
-	got := resp.Msg.GetTabs()[0]
+	require.Len(t, resp.Msg.GetTabStates(), 1, "a foreign owner's row must not be listed")
+	got := resp.Msg.GetTabStates()[0]
 	assert.Equal(t, userA.ID, got.GetUserId())
 	assert.Equal(t, sharedTabID, got.GetTabId())
 	assert.Equal(t, leapmuxv1.TabType_TAB_TYPE_FILE, got.GetTabType(),
 		"alice's row, not bob's identically-named one")
+	assert.Equal(t, leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ACTIVE, got.GetArchiveState())
 	assert.Equal(t, userA.ID, resp.Msg.GetOwnerUserId(),
 		"the response must declare the owner it is authoritative for")
+}
+
+func TestListOwnedTabsForWorker_ReturnsArchivedState(t *testing.T) {
+	t.Parallel()
+
+	st := hubtestutil.OpenTestStore(t)
+	ctx := context.Background()
+	owner := storetest.SeedUser(t, st, "reconcile-archived-owner")
+	worker := storetest.SeedWorker(t, st, owner.ID)
+	workspaceID := storetest.SeedWorkspace(t, st, owner.ID, "archived")
+	ownerID := userid.MustNew(owner.ID)
+	require.NoError(t, st.WorkspaceSections().Create(ctx, store.CreateWorkspaceSectionParams{
+		ID: "archived-section", UserID: ownerID, Name: "Archived", Position: "z",
+		SectionType: leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_ARCHIVED,
+		Sidebar:     leapmuxv1.Sidebar_SIDEBAR_LEFT,
+	}))
+	require.NoError(t, st.WorkspaceSectionItems().Set(ctx, store.SetWorkspaceSectionItemParams{
+		UserID: ownerID, WorkspaceID: workspaceID, SectionID: "archived-section", Position: "a",
+	}))
+	require.NoError(t, st.WorkspaceTabIndex().UpsertOwned(ctx, store.UpsertOwnedTabParams{
+		UserID: ownerID, WorkspaceID: workspaceID, WorkerID: worker.ID,
+		TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabID: "archived-agent", TileID: "tile", Position: "a",
+	}))
+
+	req := connect.NewRequest(&leapmuxv1.ListOwnedTabsForWorkerRequest{})
+	req.Header().Set("Authorization", "Bearer "+worker.AuthToken)
+	resp, err := service.NewWorkerReconcilerService(st).ListOwnedTabsForWorker(ctx, req)
+	require.NoError(t, err)
+	require.Len(t, resp.Msg.GetTabStates(), 1)
+	assert.Equal(t, leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED,
+		resp.Msg.GetTabStates()[0].GetArchiveState())
 }
 
 // TestListOwnedTabsForWorker_RejectsUnauthenticated keeps the bearer gate
@@ -121,8 +153,8 @@ func TestListOwnedTabsForWorker_ReachableThroughTheAuthInterceptor(t *testing.T)
 
 	resp, err := client.ListOwnedTabsForWorker(ctx, req)
 	require.NoError(t, err, "a worker's own auth_token must reach the reconciler RPC")
-	require.Len(t, resp.Msg.GetTabs(), 1)
-	assert.Equal(t, "agent-live", resp.Msg.GetTabs()[0].GetTabId())
+	require.Len(t, resp.Msg.GetTabStates(), 1)
+	assert.Equal(t, "agent-live", resp.Msg.GetTabStates()[0].GetTabId())
 	assert.Equal(t, owner.ID, resp.Msg.GetOwnerUserId())
 }
 

--- a/backend/internal/hub/service/workspace_service.go
+++ b/backend/internal/hub/service/workspace_service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/crdt"
 	"github.com/leapmux/leapmux/internal/hub/store"
 	"github.com/leapmux/leapmux/internal/util/id"
+	"github.com/leapmux/leapmux/internal/util/lexorank"
 	"github.com/leapmux/leapmux/internal/util/userid"
 	"github.com/leapmux/leapmux/util/validate"
 )
@@ -21,8 +22,13 @@ import (
 // This service owns the workspace metadata table plus read-only tab
 // views fed by the CRDT manager's workspace_tab_rendered index.
 type WorkspaceService struct {
-	store    store.Store
-	registry *crdt.Registry
+	store           store.Store
+	registry        *crdt.Registry
+	reconcileNudger workspaceReconcileNudger
+}
+
+type workspaceReconcileNudger interface {
+	NudgeReconcile(workerID string)
 }
 
 // NewWorkspaceService creates a new WorkspaceService. registry is optional;
@@ -37,10 +43,12 @@ type WorkspaceService struct {
 func NewWorkspaceService(
 	st store.Store,
 	registry *crdt.Registry,
+	reconcileNudger workspaceReconcileNudger,
 ) *WorkspaceService {
 	return &WorkspaceService{
-		store:    st,
-		registry: registry,
+		store:           st,
+		registry:        registry,
+		reconcileNudger: reconcileNudger,
 	}
 }
 
@@ -313,6 +321,110 @@ func (s *WorkspaceService) RenameWorkspace(
 	}
 
 	return connect.NewResponse(&leapmuxv1.RenameWorkspaceResponse{}), nil
+}
+
+// SetWorkspaceArchiveState moves a workspace across the archive boundary and
+// returns the authoritative Worker fan-out from the same transaction.
+func (s *WorkspaceService) SetWorkspaceArchiveState(
+	ctx context.Context,
+	req *connect.Request[leapmuxv1.SetWorkspaceArchiveStateRequest],
+) (*connect.Response[leapmuxv1.SetWorkspaceArchiveStateResponse], error) {
+	user, err := auth.MustGetUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := rejectDelegationBearer(user, "workspace lifecycle mutation"); err != nil {
+		return nil, err
+	}
+
+	requested := req.Msg.GetArchiveState()
+	if requested != leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ACTIVE &&
+		requested != leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("archive_state must be ACTIVE or ARCHIVED"))
+	}
+
+	workspaceID := req.Msg.GetWorkspaceId()
+	var workerTabs []*leapmuxv1.WorkerTabs
+	err = s.store.RunInTransaction(ctx, func(tx store.Store) error {
+		if _, err := loadOwnedWorkspaceOr403(ctx, tx, workspaceID, user.ID, "only workspace owner can modify workspace state"); err != nil {
+			return err
+		}
+
+		currentlyArchived, err := tx.WorkspaceSectionItems().IsInArchivedSection(ctx, store.IsWorkspaceInArchivedSectionParams{
+			UserID:      user.ID,
+			WorkspaceID: workspaceID,
+		})
+		if err != nil {
+			return fmt.Errorf("read workspace archive state: %w", err)
+		}
+		requestArchived := requested == leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED
+		if currentlyArchived == requestArchived {
+			workerTabs = nil
+			return nil
+		}
+
+		destinationType := leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_IN_PROGRESS
+		if requestArchived {
+			destinationType = leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_ARCHIVED
+		}
+		sections, err := tx.WorkspaceSections().ListByUserID(ctx, user.ID)
+		if err != nil {
+			return fmt.Errorf("list workspace sections: %w", err)
+		}
+		var destinationID string
+		for _, section := range sections {
+			if section.SectionType == destinationType {
+				destinationID = section.ID
+				break
+			}
+		}
+		if destinationID == "" {
+			return fmt.Errorf("built-in destination section %s not found", destinationType)
+		}
+
+		items, err := tx.WorkspaceSectionItems().ListByUser(ctx, user.ID)
+		if err != nil {
+			return fmt.Errorf("list workspace section items: %w", err)
+		}
+		lastPosition := ""
+		for _, item := range items {
+			if item.SectionID == destinationID {
+				lastPosition = item.Position
+			}
+		}
+		if err := tx.WorkspaceSectionItems().Set(ctx, store.SetWorkspaceSectionItemParams{
+			UserID:      user.ID,
+			WorkspaceID: workspaceID,
+			SectionID:   destinationID,
+			Position:    lexorank.After(lastPosition),
+		}); err != nil {
+			return fmt.Errorf("move workspace across archive boundary: %w", err)
+		}
+
+		tabs, err := tx.WorkspaceTabIndex().ListOwnedTabsByWorkspace(ctx, store.ListOwnedTabsByWorkspaceParams{
+			UserID:      user.ID,
+			WorkspaceID: workspaceID,
+		})
+		if err != nil {
+			return fmt.Errorf("list workspace tabs: %w", err)
+		}
+		workerTabs = groupTabsByWorker(tabs)
+		return nil
+	})
+	if err != nil {
+		var connectErr *connect.Error
+		if errors.As(err, &connectErr) {
+			return nil, connectErr
+		}
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+
+	if s.reconcileNudger != nil {
+		for _, tabs := range workerTabs {
+			s.reconcileNudger.NudgeReconcile(tabs.GetWorkerId())
+		}
+	}
+	return connect.NewResponse(&leapmuxv1.SetWorkspaceArchiveStateResponse{WorkerTabs: workerTabs}), nil
 }
 
 func (s *WorkspaceService) DeleteWorkspace(

--- a/backend/internal/hub/service/workspace_service.go
+++ b/backend/internal/hub/service/workspace_service.go
@@ -324,7 +324,13 @@ func (s *WorkspaceService) RenameWorkspace(
 }
 
 // SetWorkspaceArchiveState moves a workspace across the archive boundary and
-// returns the authoritative Worker fan-out from the same transaction.
+// nudges every Worker that hosts one of its tabs.
+//
+// The nudge IS the delivery. The Worker applies the Hub's authoritative state
+// through the same code its reconcile pass uses, so a client-side fan-out over
+// the returned tab list would be a second path to the same effect -- one that
+// exists only while a browser session is open, and that an archive from any
+// other client would skip.
 func (s *WorkspaceService) SetWorkspaceArchiveState(
 	ctx context.Context,
 	req *connect.Request[leapmuxv1.SetWorkspaceArchiveStateRequest],
@@ -344,7 +350,7 @@ func (s *WorkspaceService) SetWorkspaceArchiveState(
 	}
 
 	workspaceID := req.Msg.GetWorkspaceId()
-	var workerTabs []*leapmuxv1.WorkerTabs
+	var workerIDs []string
 	err = s.store.RunInTransaction(ctx, func(tx store.Store) error {
 		if _, err := loadOwnedWorkspaceOr403(ctx, tx, workspaceID, user.ID, "only workspace owner can modify workspace state"); err != nil {
 			return err
@@ -358,47 +364,43 @@ func (s *WorkspaceService) SetWorkspaceArchiveState(
 			return fmt.Errorf("read workspace archive state: %w", err)
 		}
 		requestArchived := requested == leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED
-		if currentlyArchived == requestArchived {
-			workerTabs = nil
-			return nil
-		}
 
-		destinationType := leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_IN_PROGRESS
-		if requestArchived {
-			destinationType = leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_ARCHIVED
-		}
-		sections, err := tx.WorkspaceSections().ListByUserID(ctx, user.ID)
-		if err != nil {
-			return fmt.Errorf("list workspace sections: %w", err)
-		}
-		var destinationID string
-		for _, section := range sections {
-			if section.SectionType == destinationType {
-				destinationID = section.ID
-				break
+		// The section move is the only step this skips when the workspace
+		// already sits on the requested side. The nudge below still runs, so
+		// the RPC ASSERTS the state its name claims rather than applying a
+		// transition.
+		//
+		// That difference is the recovery path. When a Worker misses its nudge
+		// -- a refused control frame, a reconnect -- the caller's remedy is to
+		// ask again, and a repeat that nudged nobody would do nothing, leaving
+		// those processes running until the Worker's hourly tick. Every step
+		// below is idempotent: the Worker's UPDATE changes a row only when the
+		// flag differs, and the nudge is best-effort by contract.
+		// An explicit destination moves the workspace even when it is already
+		// on the requested side, because "Move to <section>" on an archived
+		// workspace is one call now: unarchive AND land where the user asked.
+		explicitDestination := req.Msg.GetDestinationSectionId()
+		if currentlyArchived != requestArchived || explicitDestination != "" {
+			destinationID, err := resolveArchiveDestination(ctx, tx, user.ID, explicitDestination, requestArchived)
+			if err != nil {
+				return err
 			}
-		}
-		if destinationID == "" {
-			return fmt.Errorf("built-in destination section %s not found", destinationType)
-		}
-
-		items, err := tx.WorkspaceSectionItems().ListByUser(ctx, user.ID)
-		if err != nil {
-			return fmt.Errorf("list workspace section items: %w", err)
-		}
-		lastPosition := ""
-		for _, item := range items {
-			if item.SectionID == destinationID {
-				lastPosition = item.Position
+			position := req.Msg.GetPosition()
+			if position == "" {
+				items, err := tx.WorkspaceSectionItems().ListByUser(ctx, user.ID)
+				if err != nil {
+					return fmt.Errorf("list workspace section items: %w", err)
+				}
+				position = appendPositionAfter(lastPositionInSection(items, destinationID), workspaceID)
 			}
-		}
-		if err := tx.WorkspaceSectionItems().Set(ctx, store.SetWorkspaceSectionItemParams{
-			UserID:      user.ID,
-			WorkspaceID: workspaceID,
-			SectionID:   destinationID,
-			Position:    lexorank.After(lastPosition),
-		}); err != nil {
-			return fmt.Errorf("move workspace across archive boundary: %w", err)
+			if err := tx.WorkspaceSectionItems().Set(ctx, store.SetWorkspaceSectionItemParams{
+				UserID:      user.ID,
+				WorkspaceID: workspaceID,
+				SectionID:   destinationID,
+				Position:    position,
+			}); err != nil {
+				return fmt.Errorf("move workspace across archive boundary: %w", err)
+			}
 		}
 
 		tabs, err := tx.WorkspaceTabIndex().ListOwnedTabsByWorkspace(ctx, store.ListOwnedTabsByWorkspaceParams{
@@ -408,7 +410,7 @@ func (s *WorkspaceService) SetWorkspaceArchiveState(
 		if err != nil {
 			return fmt.Errorf("list workspace tabs: %w", err)
 		}
-		workerTabs = groupTabsByWorker(tabs)
+		workerIDs = distinctWorkerIDs(tabs)
 		return nil
 	})
 	if err != nil {
@@ -420,11 +422,67 @@ func (s *WorkspaceService) SetWorkspaceArchiveState(
 	}
 
 	if s.reconcileNudger != nil {
-		for _, tabs := range workerTabs {
-			s.reconcileNudger.NudgeReconcile(tabs.GetWorkerId())
+		for _, workerID := range workerIDs {
+			s.reconcileNudger.NudgeReconcile(workerID)
 		}
 	}
-	return connect.NewResponse(&leapmuxv1.SetWorkspaceArchiveStateResponse{WorkerTabs: workerTabs}), nil
+	return connect.NewResponse(&leapmuxv1.SetWorkspaceArchiveStateResponse{}), nil
+}
+
+// resolveArchiveDestination answers which section the workspace lands in.
+//
+// With no explicit id it is the built-in section for the requested side. With
+// one, the section must be the caller's, must be able to hold a workspace, and
+// must sit on the side the request asks for -- so a destination cannot
+// contradict archive_state, and this parameter can never become a second,
+// unguarded way to archive a workspace.
+func resolveArchiveDestination(ctx context.Context, tx store.Store, userID userid.UserID, explicitID string, requestArchived bool) (string, error) {
+	sections, err := tx.WorkspaceSections().ListByUserID(ctx, userID)
+	if err != nil {
+		return "", fmt.Errorf("list workspace sections: %w", err)
+	}
+	if explicitID == "" {
+		destinationType := leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_IN_PROGRESS
+		if requestArchived {
+			destinationType = leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_ARCHIVED
+		}
+		destinationID := findSectionOfType(sections, destinationType)
+		if destinationID == "" {
+			return "", fmt.Errorf("built-in destination section %s not found", destinationType)
+		}
+		return destinationID, nil
+	}
+	destination, err := requireOwnedSection(ctx, tx, userID, explicitID)
+	if err != nil {
+		return "", err
+	}
+	if err := requireWorkspaceSection(destination); err != nil {
+		return "", err
+	}
+	destinationArchived := destination.SectionType == leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_ARCHIVED
+	if destinationArchived != requestArchived {
+		return "", connect.NewError(connect.CodeInvalidArgument,
+			fmt.Errorf("destination section %s is on the other side of the archive boundary than the requested state", destination.ID))
+	}
+	return destination.ID, nil
+}
+
+// distinctWorkerIDs reduces a workspace's owned tabs to the workers that host
+// them, in first-seen order so the nudges go out deterministically.
+func distinctWorkerIDs(tabs []store.OwnedTabRef) []string {
+	seen := make(map[string]struct{}, len(tabs))
+	out := make([]string, 0, len(tabs))
+	for _, tab := range tabs {
+		if tab.WorkerID == "" {
+			continue
+		}
+		if _, dup := seen[tab.WorkerID]; dup {
+			continue
+		}
+		seen[tab.WorkerID] = struct{}{}
+		out = append(out, tab.WorkerID)
+	}
+	return out
 }
 
 func (s *WorkspaceService) DeleteWorkspace(
@@ -500,6 +558,44 @@ func (s *WorkspaceService) DeleteWorkspace(
 	return connect.NewResponse(&leapmuxv1.DeleteWorkspaceResponse{
 		WorkerTabs: workerTabs,
 	}), nil
+}
+
+// appendPositionAfter returns a rank that sorts after last and that no OTHER
+// workspace can mint, by suffixing a deterministic tie-break derived from
+// workspaceID.
+//
+// lexorank.After alone is not enough here. It answers last+"n" for everybody,
+// and this transaction reads `last` and writes the new rank at READ COMMITTED
+// -- so two unarchives that overlap both read the same tail and both store the
+// identical rank. Two items in a tie come back in planner-defined order, which
+// the user sees as the sidebar reshuffling the whole set on every refresh. The
+// suffix makes the collision impossible instead of relying on the caller to
+// serialize, which only the one client loop does today and which a second
+// browser or a second device defeats.
+//
+// The tie-break appends to the rank rather than replacing it, so ordering
+// against every existing item is unchanged; it decides only the order BETWEEN
+// two workspaces that raced into the same slot, and it decides it the same way
+// on every read.
+func appendPositionAfter(last, workspaceID string) string {
+	const alphabet = "abcdefghijklmnopqrstuvwxyz"
+	// FNV-1a over the workspace id, rendered in the rank alphabet. A hash
+	// rather than the raw id, because a rank may hold only [a-z].
+	var h uint32 = 2166136261
+	for i := 0; i < len(workspaceID); i++ {
+		h ^= uint32(workspaceID[i])
+		h *= 16777619
+	}
+	var suffix [6]byte
+	for i := range suffix {
+		suffix[i] = alphabet[h%uint32(len(alphabet))]
+		h /= uint32(len(alphabet))
+	}
+	// The LAST character skips 'a'. lexorank pads a short rank with 'a' before
+	// it compares (see padRight), so a rank ending in 'a' ties with the same
+	// rank without it -- which is the collision this function exists to remove.
+	suffix[len(suffix)-1] = alphabet[1+uint32(suffix[len(suffix)-1]-'a')%uint32(len(alphabet)-1)]
+	return lexorank.After(last) + string(suffix[:])
 }
 
 // groupTabsByWorker turns the flat (worker_id, tab_type, tab_id) read into the

--- a/backend/internal/hub/service/workspace_service_test.go
+++ b/backend/internal/hub/service/workspace_service_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/store"
 	"github.com/leapmux/leapmux/internal/hub/store/storetest"
 	hubtestutil "github.com/leapmux/leapmux/internal/hub/testutil"
+	"github.com/leapmux/leapmux/internal/util/id"
 	"github.com/leapmux/leapmux/internal/util/userid"
 )
 
@@ -355,40 +356,189 @@ func TestWorkspaceService_SetWorkspaceArchiveState_TransitionsAndGroupsWorkers(t
 	nudges := &nudgeRecorder{}
 	svc := service.NewWorkspaceService(st, nil, nudges)
 	authCtx := auth.WithUser(ctx, &auth.UserInfo{ID: owner})
-	archive := func(state leapmuxv1.WorkspaceArchiveState) *leapmuxv1.SetWorkspaceArchiveStateResponse {
-		resp, err := svc.SetWorkspaceArchiveState(authCtx, connect.NewRequest(&leapmuxv1.SetWorkspaceArchiveStateRequest{
+	archive := func(state leapmuxv1.WorkspaceArchiveState) {
+		_, err := svc.SetWorkspaceArchiveState(authCtx, connect.NewRequest(&leapmuxv1.SetWorkspaceArchiveStateRequest{
 			WorkspaceId: workspaceID, ArchiveState: state,
 		}))
 		require.NoError(t, err)
-		return resp.Msg
 	}
 
-	archived := archive(leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED)
-	require.Len(t, archived.GetWorkerTabs(), 2)
-	tabsByWorker := make(map[string][]string)
-	for _, group := range archived.GetWorkerTabs() {
-		for _, tab := range group.GetTabs() {
-			tabsByWorker[group.GetWorkerId()] = append(tabsByWorker[group.GetWorkerId()], tab.GetTabId())
-		}
-	}
-	assert.ElementsMatch(t, []string{"agent-a", "file-a"}, tabsByWorker[workerA.ID])
-	assert.Equal(t, []string{"terminal-b"}, tabsByWorker[workerB.ID])
+	archive(leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED)
+	// The Hub owns the Worker delivery, so the nudge set IS the observable.
+	// Every worker hosting one of this workspace's tabs must be told once,
+	// including the one that hosts only a payload-backed tab.
 	item, err := st.WorkspaceSectionItems().Get(ctx, store.GetWorkspaceSectionItemParams{UserID: owner, WorkspaceID: workspaceID})
 	require.NoError(t, err)
 	assert.Equal(t, archivedID, item.SectionID)
-	assert.Equal(t, "xn", item.Position, "the Hub appends after the current destination tail")
+	// The rank sorts after the destination's tail; its exact spelling carries a
+	// per-workspace tie-break, so assert the ORDER rather than the literal.
+	archivedPosition := item.Position
+	assert.Greater(t, archivedPosition, "x", "the Hub appends after the current destination tail")
 	assert.ElementsMatch(t, []string{workerA.ID, workerB.ID}, nudges.snapshot())
 
-	idempotent := archive(leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED)
-	assert.Empty(t, idempotent.GetWorkerTabs())
-	assert.Len(t, nudges.snapshot(), 2, "an idempotent request has no affected Worker")
+	// A repeat is the caller's remedy after a Worker missed its nudge, so it
+	// must nudge every one again. Only the section move is skipped.
+	archive(leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED)
+	assert.Len(t, nudges.snapshot(), 4, "a repeat nudges every affected Worker again")
+	item, err = st.WorkspaceSectionItems().Get(ctx, store.GetWorkspaceSectionItemParams{UserID: owner, WorkspaceID: workspaceID})
+	require.NoError(t, err)
+	assert.Equal(t, archivedPosition, item.Position,
+		"a repeat must not move the workspace again, or every retry would reorder the sidebar")
 
-	unarchived := archive(leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ACTIVE)
-	require.Len(t, unarchived.GetWorkerTabs(), 2)
+	archive(leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ACTIVE)
+	assert.Len(t, nudges.snapshot(), 6, "the unarchive nudges every affected Worker too")
 	item, err = st.WorkspaceSectionItems().Get(ctx, store.GetWorkspaceSectionItemParams{UserID: owner, WorkspaceID: workspaceID})
 	require.NoError(t, err)
 	assert.Equal(t, inProgressID, item.SectionID)
-	assert.Equal(t, "yn", item.Position)
+	assert.Greater(t, item.Position, "y")
+}
+
+// TestWorkspaceService_SetWorkspaceArchiveState_HonorsAnExplicitDestination
+// pins the parameter that made a boundary-crossing move ONE transaction.
+//
+// "Move to <custom section>" on an archived workspace used to unarchive into In
+// progress and then issue a second MoveWorkspace. When the second call failed
+// the workspace came to rest in a section the user never chose, and the drag
+// position was thrown away because the lifecycle call always appended.
+//
+// The guard matters as much as the feature: a destination on the wrong side of
+// the boundary must be REFUSED, or this parameter becomes a second way to
+// archive a workspace, bypassing everything the lifecycle call does.
+func TestWorkspaceService_SetWorkspaceArchiveState_HonorsAnExplicitDestination(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	st := hubtestutil.OpenTestStore(t)
+	user := seedUserWithSections(t, st, "archive-destination")
+	owner := userid.MustNew(user.ID)
+	inProgressID := sectionIDOfType(t, st, user.ID, leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_IN_PROGRESS)
+	archivedID := sectionIDOfType(t, st, user.ID, leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_ARCHIVED)
+	customID := id.Generate()
+	require.NoError(t, st.WorkspaceSections().Create(ctx, store.CreateWorkspaceSectionParams{
+		ID: customID, UserID: owner, Name: "Later", Position: "z",
+		SectionType: leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_CUSTOM,
+		Sidebar:     leapmuxv1.Sidebar_SIDEBAR_LEFT,
+	}))
+
+	workspaceID := storetest.SeedWorkspace(t, st, user.ID, "target")
+	placeWorkspaceInSection(t, st, user.ID, workspaceID, archivedID)
+
+	svc := service.NewWorkspaceService(st, nil, &nudgeRecorder{})
+	authCtx := auth.WithUser(ctx, &auth.UserInfo{ID: owner})
+
+	// Unarchive straight into the custom section, at a chosen rank.
+	_, err := svc.SetWorkspaceArchiveState(authCtx, connect.NewRequest(&leapmuxv1.SetWorkspaceArchiveStateRequest{
+		WorkspaceId:          workspaceID,
+		ArchiveState:         leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ACTIVE,
+		DestinationSectionId: customID,
+		Position:             "q",
+	}))
+	require.NoError(t, err)
+	item, err := st.WorkspaceSectionItems().Get(ctx, store.GetWorkspaceSectionItemParams{UserID: owner, WorkspaceID: workspaceID})
+	require.NoError(t, err)
+	assert.Equal(t, customID, item.SectionID, "the workspace lands where the caller asked, not in In progress")
+	assert.Equal(t, "q", item.Position, "an explicit rank is used verbatim, so a drop keeps its place")
+
+	// A destination on the WRONG side is refused, and nothing moves.
+	_, err = svc.SetWorkspaceArchiveState(authCtx, connect.NewRequest(&leapmuxv1.SetWorkspaceArchiveStateRequest{
+		WorkspaceId:          workspaceID,
+		ArchiveState:         leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ACTIVE,
+		DestinationSectionId: archivedID,
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	item, err = st.WorkspaceSectionItems().Get(ctx, store.GetWorkspaceSectionItemParams{UserID: owner, WorkspaceID: workspaceID})
+	require.NoError(t, err)
+	assert.Equal(t, customID, item.SectionID, "a refused destination moves nothing")
+
+	// A destination that CANNOT hold a workspace is refused. The archive move
+	// and the sidebar move share requireWorkspaceSection, so neither can start
+	// accepting a section type the other refuses.
+	filesID := sectionIDOfType(t, st, user.ID, leapmuxv1.SectionType_SECTION_TYPE_FILES)
+	_, err = svc.SetWorkspaceArchiveState(authCtx, connect.NewRequest(&leapmuxv1.SetWorkspaceArchiveStateRequest{
+		WorkspaceId:          workspaceID,
+		ArchiveState:         leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ACTIVE,
+		DestinationSectionId: filesID,
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+
+	// A destination belonging to ANOTHER user is refused, and as NotFound, so
+	// the parameter cannot be used to probe which section ids exist.
+	stranger := seedUserWithSections(t, st, "archive-destination-stranger")
+	strangerSection := sectionIDOfType(t, st, stranger.ID, leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_IN_PROGRESS)
+	_, err = svc.SetWorkspaceArchiveState(authCtx, connect.NewRequest(&leapmuxv1.SetWorkspaceArchiveStateRequest{
+		WorkspaceId:          workspaceID,
+		ArchiveState:         leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ACTIVE,
+		DestinationSectionId: strangerSection,
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+	item, err = st.WorkspaceSectionItems().Get(ctx, store.GetWorkspaceSectionItemParams{UserID: owner, WorkspaceID: workspaceID})
+	require.NoError(t, err)
+	assert.Equal(t, customID, item.SectionID, "no refused destination moves the workspace")
+
+	// No destination keeps the built-in behaviour.
+	_, err = svc.SetWorkspaceArchiveState(authCtx, connect.NewRequest(&leapmuxv1.SetWorkspaceArchiveStateRequest{
+		WorkspaceId:  workspaceID,
+		ArchiveState: leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED,
+	}))
+	require.NoError(t, err)
+	item, err = st.WorkspaceSectionItems().Get(ctx, store.GetWorkspaceSectionItemParams{UserID: owner, WorkspaceID: workspaceID})
+	require.NoError(t, err)
+	assert.Equal(t, archivedID, item.SectionID)
+	assert.NotEqual(t, inProgressID, item.SectionID)
+}
+
+// TestWorkspaceService_SetWorkspaceArchiveState_ConcurrentMovesGetDistinctRanks
+// pins the rank tie-break. Two workspaces that cross the boundary against the
+// same destination tail must not land on the same lexorank: two items in a tie
+// come back in planner-defined order, which the user sees as the sidebar
+// reshuffling the whole set on every refresh. Sequencing the calls client-side
+// does not fix it, because a second browser or a second device defeats that.
+func TestWorkspaceService_SetWorkspaceArchiveState_ConcurrentMovesGetDistinctRanks(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	st := hubtestutil.OpenTestStore(t)
+	user := seedUserWithSections(t, st, "archive-rank-owner")
+	owner := userid.MustNew(user.ID)
+	inProgressID := sectionIDOfType(t, st, user.ID, leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_IN_PROGRESS)
+
+	svc := service.NewWorkspaceService(st, nil, &nudgeRecorder{})
+	authCtx := auth.WithUser(ctx, &auth.UserInfo{ID: owner})
+
+	// Every workspace here archives out of an EMPTY destination, so all three
+	// read the same tail ("") and compute their rank from it -- which is what
+	// two overlapping transactions observe at READ COMMITTED, without needing
+	// real concurrency to reproduce it.
+	positions := make(map[string]string)
+	for _, name := range []string{"ws-one", "ws-two", "ws-three"} {
+		workspaceID := storetest.SeedWorkspace(t, st, user.ID, name)
+		require.NoError(t, st.WorkspaceSectionItems().Set(ctx, store.SetWorkspaceSectionItemParams{
+			UserID: owner, WorkspaceID: workspaceID, SectionID: inProgressID, Position: "n",
+		}))
+		_, err := svc.SetWorkspaceArchiveState(authCtx, connect.NewRequest(&leapmuxv1.SetWorkspaceArchiveStateRequest{
+			WorkspaceId:  workspaceID,
+			ArchiveState: leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED,
+		}))
+		require.NoError(t, err)
+		item, err := st.WorkspaceSectionItems().Get(ctx, store.GetWorkspaceSectionItemParams{
+			UserID: owner, WorkspaceID: workspaceID,
+		})
+		require.NoError(t, err)
+		// Delete the row again, so the next workspace reads the same empty
+		// tail this one did instead of appending after it.
+		require.NoError(t, st.WorkspaceSectionItems().Delete(ctx, store.DeleteWorkspaceSectionItemParams{
+			UserID: owner, WorkspaceID: workspaceID,
+		}))
+		for other, position := range positions {
+			assert.NotEqual(t, position, item.Position,
+				"%s and %s must not share a rank in the destination section", other, name)
+		}
+		positions[name] = item.Position
+	}
+	assert.Len(t, positions, 3)
 }
 
 func TestWorkspaceService_SetWorkspaceArchiveState_RefusesForeignWorkspace(t *testing.T) {

--- a/backend/internal/hub/service/workspace_service_test.go
+++ b/backend/internal/hub/service/workspace_service_test.go
@@ -21,6 +21,23 @@ import (
 	"github.com/leapmux/leapmux/internal/util/userid"
 )
 
+type nudgeRecorder struct {
+	mu  sync.Mutex
+	ids []string
+}
+
+func (r *nudgeRecorder) NudgeReconcile(workerID string) {
+	r.mu.Lock()
+	r.ids = append(r.ids, workerID)
+	r.mu.Unlock()
+}
+
+func (r *nudgeRecorder) snapshot() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.ids...)
+}
+
 func TestWorkspaceServiceDeleteWorkspaceFansOutToOwnersWorkersOnly(t *testing.T) {
 	t.Parallel()
 
@@ -41,7 +58,7 @@ func TestWorkspaceServiceDeleteWorkspaceFansOutToOwnersWorkersOnly(t *testing.T)
 		TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabID: "tab-stranger", TileID: "tile", Position: "a1",
 	}))
 
-	svc := service.NewWorkspaceService(st, nil)
+	svc := service.NewWorkspaceService(st, nil, nil)
 	authCtx := auth.WithUser(ctx, &auth.UserInfo{ID: userid.MustNew(owner.ID)})
 	resp, err := svc.DeleteWorkspace(authCtx, connect.NewRequest(&leapmuxv1.DeleteWorkspaceRequest{WorkspaceId: workspaceID}))
 	require.NoError(t, err)
@@ -70,7 +87,7 @@ func TestWorkspaceService_ListWorkspaces_DelegationSeesTheOwnersWorkspaces(t *te
 	other := storetest.SeedUser(t, st, "bob")
 	storetest.SeedWorkspace(t, st, other.ID, "Other")
 
-	svc := service.NewWorkspaceService(st, nil)
+	svc := service.NewWorkspaceService(st, nil, nil)
 	ctx := auth.WithUser(context.Background(), &auth.UserInfo{
 		ID:         userid.MustNew(user.ID),
 		Credential: auth.DelegationCredential("test-delegation", "worker-mint"),
@@ -94,7 +111,7 @@ func TestWorkspaceService_GetWorkspace_NonOwnerIsDenied(t *testing.T) {
 	other := storetest.SeedUser(t, st, "other")
 	wsID := storetest.SeedWorkspace(t, st, owner.ID, "Owned")
 
-	svc := service.NewWorkspaceService(st, nil)
+	svc := service.NewWorkspaceService(st, nil, nil)
 	ctx := auth.WithUser(context.Background(), &auth.UserInfo{ID: userid.MustNew(other.ID)})
 
 	_, err := svc.GetWorkspace(ctx, connect.NewRequest(&leapmuxv1.GetWorkspaceRequest{
@@ -125,7 +142,7 @@ func TestWorkspaceService_LocateTile_FindsByWorkspaceRoot(t *testing.T) {
 		s.Workspaces[ws] = &leapmuxv1.WorkspaceContentsRecord{WorkspaceId: ws, RootNodeId: "root-1"}
 		s.Nodes["root-1"] = &leapmuxv1.NodeRecord{NodeId: "root-1"}
 	})
-	svc := service.NewWorkspaceService(st, env.registry)
+	svc := service.NewWorkspaceService(st, env.registry, nil)
 	ctx := auth.WithUser(context.Background(), &auth.UserInfo{ID: userid.MustNew(user.ID)})
 
 	resp, err := svc.LocateTile(ctx, connect.NewRequest(&leapmuxv1.LocateTileRequest{TileId: "root-1"}))
@@ -153,7 +170,7 @@ func TestWorkspaceService_LocateTile_WalksUpToOwningWorkspace(t *testing.T) {
 		s.Nodes["mid-1"] = &leapmuxv1.NodeRecord{NodeId: "mid-1", ParentId: "root-1"}
 		s.Nodes["leaf-1"] = &leapmuxv1.NodeRecord{NodeId: "leaf-1", ParentId: "mid-1"}
 	})
-	svc := service.NewWorkspaceService(st, env.registry)
+	svc := service.NewWorkspaceService(st, env.registry, nil)
 	ctx := auth.WithUser(context.Background(), &auth.UserInfo{ID: userid.MustNew(user.ID)})
 
 	resp, err := svc.LocateTile(ctx, connect.NewRequest(&leapmuxv1.LocateTileRequest{TileId: "leaf-1"}))
@@ -167,7 +184,7 @@ func TestWorkspaceService_LocateTile_RejectsEmptyTileID(t *testing.T) {
 	st := hubtestutil.OpenTestStore(t)
 	user := storetest.SeedUser(t, st, "alice")
 	env := setupLocateTileEnv(t, user.ID)
-	svc := service.NewWorkspaceService(st, env.registry)
+	svc := service.NewWorkspaceService(st, env.registry, nil)
 	ctx := auth.WithUser(context.Background(), &auth.UserInfo{ID: userid.MustNew(user.ID)})
 
 	_, err := svc.LocateTile(ctx, connect.NewRequest(&leapmuxv1.LocateTileRequest{TileId: ""}))
@@ -185,7 +202,7 @@ func TestWorkspaceService_LocateTile_NotFoundForUnknownTile(t *testing.T) {
 	st := hubtestutil.OpenTestStore(t)
 	user := storetest.SeedUser(t, st, "alice")
 	env := setupLocateTileEnv(t, user.ID)
-	svc := service.NewWorkspaceService(st, env.registry)
+	svc := service.NewWorkspaceService(st, env.registry, nil)
 	ctx := auth.WithUser(context.Background(), &auth.UserInfo{ID: userid.MustNew(user.ID)})
 
 	_, err := svc.LocateTile(ctx, connect.NewRequest(&leapmuxv1.LocateTileRequest{TileId: "ghost"}))
@@ -213,7 +230,7 @@ func TestWorkspaceService_LocateTile_TransientManagerErrorIsRetryable(t *testing
 	}, nil, crdt.WithManagerIdleTTL(0))
 	t.Cleanup(func() { registry.Shutdown(2 * time.Second) })
 
-	svc := service.NewWorkspaceService(st, registry)
+	svc := service.NewWorkspaceService(st, registry, nil)
 	ctx := auth.WithUser(context.Background(), &auth.UserInfo{ID: userid.MustNew(user.ID)})
 
 	_, err := svc.LocateTile(ctx, connect.NewRequest(&leapmuxv1.LocateTileRequest{TileId: "missing"}))
@@ -304,6 +321,179 @@ func placeWorkspaceInSection(t *testing.T, st store.Store, userID, workspaceID, 
 	}))
 }
 
+func TestWorkspaceService_SetWorkspaceArchiveState_TransitionsAndGroupsWorkers(t *testing.T) {
+	t.Parallel()
+
+	st := hubtestutil.OpenTestStore(t)
+	ctx := context.Background()
+	user := seedUserWithSections(t, st, "archive-lifecycle")
+	owner := userid.MustNew(user.ID)
+	workspaceID := storetest.SeedWorkspace(t, st, user.ID, "target")
+	inProgressID := sectionIDOfType(t, st, user.ID, leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_IN_PROGRESS)
+	archivedID := sectionIDOfType(t, st, user.ID, leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_ARCHIVED)
+	placeWorkspaceInSection(t, st, user.ID, workspaceID, inProgressID)
+
+	existingArchived := storetest.SeedWorkspace(t, st, user.ID, "existing archived")
+	require.NoError(t, st.WorkspaceSectionItems().Set(ctx, store.SetWorkspaceSectionItemParams{
+		UserID: owner, WorkspaceID: existingArchived, SectionID: archivedID, Position: "x",
+	}))
+	existingActive := storetest.SeedWorkspace(t, st, user.ID, "existing active")
+	require.NoError(t, st.WorkspaceSectionItems().Set(ctx, store.SetWorkspaceSectionItemParams{
+		UserID: owner, WorkspaceID: existingActive, SectionID: inProgressID, Position: "y",
+	}))
+
+	workerA := storetest.SeedWorker(t, st, user.ID)
+	workerB := storetest.SeedWorker(t, st, user.ID)
+	for _, tab := range []store.UpsertOwnedTabParams{
+		{UserID: owner, WorkspaceID: workspaceID, WorkerID: workerA.ID, TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabID: "agent-a", TileID: "tile-a", Position: "a"},
+		{UserID: owner, WorkspaceID: workspaceID, WorkerID: workerA.ID, TabType: leapmuxv1.TabType_TAB_TYPE_FILE, TabID: "file-a", TileID: "tile-a", Position: "b"},
+		{UserID: owner, WorkspaceID: workspaceID, WorkerID: workerB.ID, TabType: leapmuxv1.TabType_TAB_TYPE_TERMINAL, TabID: "terminal-b", TileID: "tile-b", Position: "c"},
+	} {
+		require.NoError(t, st.WorkspaceTabIndex().UpsertOwned(ctx, tab))
+	}
+
+	nudges := &nudgeRecorder{}
+	svc := service.NewWorkspaceService(st, nil, nudges)
+	authCtx := auth.WithUser(ctx, &auth.UserInfo{ID: owner})
+	archive := func(state leapmuxv1.WorkspaceArchiveState) *leapmuxv1.SetWorkspaceArchiveStateResponse {
+		resp, err := svc.SetWorkspaceArchiveState(authCtx, connect.NewRequest(&leapmuxv1.SetWorkspaceArchiveStateRequest{
+			WorkspaceId: workspaceID, ArchiveState: state,
+		}))
+		require.NoError(t, err)
+		return resp.Msg
+	}
+
+	archived := archive(leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED)
+	require.Len(t, archived.GetWorkerTabs(), 2)
+	tabsByWorker := make(map[string][]string)
+	for _, group := range archived.GetWorkerTabs() {
+		for _, tab := range group.GetTabs() {
+			tabsByWorker[group.GetWorkerId()] = append(tabsByWorker[group.GetWorkerId()], tab.GetTabId())
+		}
+	}
+	assert.ElementsMatch(t, []string{"agent-a", "file-a"}, tabsByWorker[workerA.ID])
+	assert.Equal(t, []string{"terminal-b"}, tabsByWorker[workerB.ID])
+	item, err := st.WorkspaceSectionItems().Get(ctx, store.GetWorkspaceSectionItemParams{UserID: owner, WorkspaceID: workspaceID})
+	require.NoError(t, err)
+	assert.Equal(t, archivedID, item.SectionID)
+	assert.Equal(t, "xn", item.Position, "the Hub appends after the current destination tail")
+	assert.ElementsMatch(t, []string{workerA.ID, workerB.ID}, nudges.snapshot())
+
+	idempotent := archive(leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED)
+	assert.Empty(t, idempotent.GetWorkerTabs())
+	assert.Len(t, nudges.snapshot(), 2, "an idempotent request has no affected Worker")
+
+	unarchived := archive(leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ACTIVE)
+	require.Len(t, unarchived.GetWorkerTabs(), 2)
+	item, err = st.WorkspaceSectionItems().Get(ctx, store.GetWorkspaceSectionItemParams{UserID: owner, WorkspaceID: workspaceID})
+	require.NoError(t, err)
+	assert.Equal(t, inProgressID, item.SectionID)
+	assert.Equal(t, "yn", item.Position)
+}
+
+func TestWorkspaceService_SetWorkspaceArchiveState_RefusesForeignWorkspace(t *testing.T) {
+	t.Parallel()
+
+	st := hubtestutil.OpenTestStore(t)
+	owner := seedUserWithSections(t, st, "archive-owner")
+	stranger := seedUserWithSections(t, st, "archive-stranger")
+	workspaceID := storetest.SeedWorkspace(t, st, owner.ID, "owned")
+	svc := service.NewWorkspaceService(st, nil, nil)
+	ctx := auth.WithUser(context.Background(), &auth.UserInfo{ID: userid.MustNew(stranger.ID)})
+
+	_, err := svc.SetWorkspaceArchiveState(ctx, connect.NewRequest(&leapmuxv1.SetWorkspaceArchiveStateRequest{
+		WorkspaceId:  workspaceID,
+		ArchiveState: leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED,
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+}
+
+type archiveFailureStore struct {
+	store.Store
+	failMove bool
+	failTabs bool
+}
+
+func (s archiveFailureStore) RunInTransaction(ctx context.Context, fn func(store.Store) error) error {
+	return s.Store.RunInTransaction(ctx, func(tx store.Store) error {
+		return fn(archiveFailureStore{Store: tx, failMove: s.failMove, failTabs: s.failTabs})
+	})
+}
+
+func (s archiveFailureStore) WorkspaceSectionItems() store.WorkspaceSectionItemStore {
+	return archiveFailureSectionItems{WorkspaceSectionItemStore: s.Store.WorkspaceSectionItems(), fail: s.failMove}
+}
+
+func (s archiveFailureStore) WorkspaceTabIndex() store.WorkspaceTabIndexStore {
+	return archiveFailureTabIndex{WorkspaceTabIndexStore: s.Store.WorkspaceTabIndex(), fail: s.failTabs}
+}
+
+type archiveFailureSectionItems struct {
+	store.WorkspaceSectionItemStore
+	fail bool
+}
+
+func (s archiveFailureSectionItems) Set(ctx context.Context, p store.SetWorkspaceSectionItemParams) error {
+	if s.fail {
+		return errors.New("forced section move failure")
+	}
+	return s.WorkspaceSectionItemStore.Set(ctx, p)
+}
+
+type archiveFailureTabIndex struct {
+	store.WorkspaceTabIndexStore
+	fail bool
+}
+
+func (s archiveFailureTabIndex) ListOwnedTabsByWorkspace(ctx context.Context, p store.ListOwnedTabsByWorkspaceParams) ([]store.OwnedTabRef, error) {
+	if s.fail {
+		return nil, errors.New("forced tab read failure")
+	}
+	return s.WorkspaceTabIndexStore.ListOwnedTabsByWorkspace(ctx, p)
+}
+
+func TestWorkspaceService_SetWorkspaceArchiveState_RollsBackTransactionFailures(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		name     string
+		username string
+		failMove bool
+		failTabs bool
+	}{
+		{name: "section move", username: "section-move", failMove: true},
+		{name: "tab read", username: "tab-read", failTabs: true},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			base := hubtestutil.OpenTestStore(t)
+			user := seedUserWithSections(t, base, "archive-failure-"+testCase.username)
+			owner := userid.MustNew(user.ID)
+			workspaceID := storetest.SeedWorkspace(t, base, user.ID, "target")
+			inProgressID := sectionIDOfType(t, base, user.ID, leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_IN_PROGRESS)
+			placeWorkspaceInSection(t, base, user.ID, workspaceID, inProgressID)
+			nudges := &nudgeRecorder{}
+			svc := service.NewWorkspaceService(archiveFailureStore{
+				Store: base, failMove: testCase.failMove, failTabs: testCase.failTabs,
+			}, nil, nudges)
+			ctx := auth.WithUser(context.Background(), &auth.UserInfo{ID: owner})
+
+			_, err := svc.SetWorkspaceArchiveState(ctx, connect.NewRequest(&leapmuxv1.SetWorkspaceArchiveStateRequest{
+				WorkspaceId:  workspaceID,
+				ArchiveState: leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED,
+			}))
+			require.Error(t, err)
+			assert.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+			item, getErr := base.WorkspaceSectionItems().Get(context.Background(), store.GetWorkspaceSectionItemParams{
+				UserID: owner, WorkspaceID: workspaceID,
+			})
+			require.NoError(t, getErr)
+			assert.Equal(t, inProgressID, item.SectionID)
+			assert.Empty(t, nudges.snapshot())
+		})
+	}
+}
+
 func TestWorkspaceService_RenameWorkspace_RenamesALiveWorkspace(t *testing.T) {
 	t.Parallel()
 
@@ -314,7 +504,7 @@ func TestWorkspaceService_RenameWorkspace_RenamesALiveWorkspace(t *testing.T) {
 	placeWorkspaceInSection(t, st, user.ID, workspaceID,
 		sectionIDOfType(t, st, user.ID, leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_IN_PROGRESS))
 
-	svc := service.NewWorkspaceService(st, nil)
+	svc := service.NewWorkspaceService(st, nil, nil)
 	authCtx := auth.WithUser(ctx, &auth.UserInfo{ID: userid.MustNew(user.ID)})
 	_, err := svc.RenameWorkspace(authCtx, connect.NewRequest(&leapmuxv1.RenameWorkspaceRequest{
 		WorkspaceId: workspaceID,
@@ -338,7 +528,7 @@ func TestWorkspaceService_RenameWorkspace_RenamesAnUnplacedWorkspace(t *testing.
 	user := seedUserWithSections(t, st, "rename-unplaced")
 	workspaceID := storetest.SeedWorkspace(t, st, user.ID, "before")
 
-	svc := service.NewWorkspaceService(st, nil)
+	svc := service.NewWorkspaceService(st, nil, nil)
 	authCtx := auth.WithUser(ctx, &auth.UserInfo{ID: userid.MustNew(user.ID)})
 	_, err := svc.RenameWorkspace(authCtx, connect.NewRequest(&leapmuxv1.RenameWorkspaceRequest{
 		WorkspaceId: workspaceID,
@@ -361,7 +551,7 @@ func TestWorkspaceService_RenameWorkspace_RefusesArchived(t *testing.T) {
 	placeWorkspaceInSection(t, st, user.ID, workspaceID,
 		sectionIDOfType(t, st, user.ID, leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_ARCHIVED))
 
-	svc := service.NewWorkspaceService(st, nil)
+	svc := service.NewWorkspaceService(st, nil, nil)
 	authCtx := auth.WithUser(ctx, &auth.UserInfo{ID: userid.MustNew(user.ID)})
 	_, err := svc.RenameWorkspace(authCtx, connect.NewRequest(&leapmuxv1.RenameWorkspaceRequest{
 		WorkspaceId: workspaceID,
@@ -395,7 +585,7 @@ func TestWorkspaceService_RenameWorkspace_AllowedAgainAfterUnarchive(t *testing.
 	placeWorkspaceInSection(t, st, user.ID, workspaceID,
 		sectionIDOfType(t, st, user.ID, leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_IN_PROGRESS))
 
-	svc := service.NewWorkspaceService(st, nil)
+	svc := service.NewWorkspaceService(st, nil, nil)
 	authCtx := auth.WithUser(ctx, &auth.UserInfo{ID: userid.MustNew(user.ID)})
 	_, err := svc.RenameWorkspace(authCtx, connect.NewRequest(&leapmuxv1.RenameWorkspaceRequest{
 		WorkspaceId: workspaceID,
@@ -424,7 +614,7 @@ func TestWorkspaceService_RenameWorkspace_ArchivedForAnotherUserDoesNotBlock(t *
 	placeWorkspaceInSection(t, st, other.ID, workspaceID,
 		sectionIDOfType(t, st, other.ID, leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_ARCHIVED))
 
-	svc := service.NewWorkspaceService(st, nil)
+	svc := service.NewWorkspaceService(st, nil, nil)
 	authCtx := auth.WithUser(ctx, &auth.UserInfo{ID: userid.MustNew(owner.ID)})
 	_, err := svc.RenameWorkspace(authCtx, connect.NewRequest(&leapmuxv1.RenameWorkspaceRequest{
 		WorkspaceId: workspaceID,
@@ -448,7 +638,7 @@ func TestWorkspaceService_DeleteWorkspace_StillWorksOnAnArchivedWorkspace(t *tes
 	placeWorkspaceInSection(t, st, user.ID, workspaceID,
 		sectionIDOfType(t, st, user.ID, leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_ARCHIVED))
 
-	svc := service.NewWorkspaceService(st, nil)
+	svc := service.NewWorkspaceService(st, nil, nil)
 	authCtx := auth.WithUser(ctx, &auth.UserInfo{ID: userid.MustNew(user.ID)})
 	_, err := svc.DeleteWorkspace(authCtx, connect.NewRequest(&leapmuxv1.DeleteWorkspaceRequest{
 		WorkspaceId: workspaceID,

--- a/backend/internal/hub/service/workspace_tabs_test.go
+++ b/backend/internal/hub/service/workspace_tabs_test.go
@@ -71,7 +71,7 @@ func TestWorkspaceService_GetTab_BindsTheCallerAsOwner(t *testing.T) {
 	st := hubtestutil.OpenTestStore(t)
 	ownerID, _, wsID, ownerTile, strangerTile := renderedTabCollision(t, st)
 
-	svc := service.NewWorkspaceService(st, nil)
+	svc := service.NewWorkspaceService(st, nil, nil)
 	ctx := auth.WithUser(context.Background(), &auth.UserInfo{ID: userid.MustNew(ownerID)})
 
 	resp, err := svc.GetTab(ctx, connect.NewRequest(&leapmuxv1.GetTabRequest{
@@ -126,7 +126,7 @@ func TestWorkspaceService_LocateTab_BindsTheCallerAsOwner(t *testing.T) {
 		require.NoError(t, st.WorkspaceTabIndex().UpsertRendered(ctx, row))
 	}
 
-	svc := service.NewWorkspaceService(st, nil)
+	svc := service.NewWorkspaceService(st, nil, nil)
 	locate := func(userID string) *connect.Response[leapmuxv1.LocateTabResponse] {
 		t.Helper()
 		ctx := auth.WithUser(context.Background(), &auth.UserInfo{ID: userid.MustNew(userID)})

--- a/backend/internal/hub/store/mysql/db/queries/workspace_tab_owned.sql
+++ b/backend/internal/hub/store/mysql/db/queries/workspace_tab_owned.sql
@@ -35,7 +35,17 @@ ON DUPLICATE KEY UPDATE
 -- selects across tenants. user_id is the tenancy axis; worker_id
 -- narrows within it.
 -- name: ListOwnedTabsByWorker :many
-SELECT * FROM workspace_tab_owned WHERE user_id = ? AND worker_id = ? ORDER BY workspace_id, position;
+SELECT wto.user_id, wto.workspace_id, wto.tab_type, wto.tab_id, wto.worker_id,
+       CASE WHEN ws.section_type = sqlc.arg(archived_section_type)
+            THEN CAST(sqlc.arg(archived_archive_state) AS SIGNED)
+            ELSE CAST(sqlc.arg(active_archive_state) AS SIGNED) END AS archive_state
+FROM workspace_tab_owned wto
+LEFT JOIN workspace_section_items wsi
+  ON wsi.user_id = wto.user_id AND wsi.workspace_id = wto.workspace_id
+LEFT JOIN workspace_sections ws
+  ON ws.id = wsi.section_id AND ws.user_id = wto.user_id
+WHERE wto.user_id = sqlc.arg(user_id) AND wto.worker_id = sqlc.arg(worker_id)
+ORDER BY wto.workspace_id, wto.position;
 
 -- ListOwnedTabsByWorkspace binds user_id as well as workspace_id. A
 -- workspace's owner does not constrain the user_id of rows written against

--- a/backend/internal/hub/store/mysql/workspace_tab_index.go
+++ b/backend/internal/hub/store/mysql/workspace_tab_index.go
@@ -51,7 +51,7 @@ func (s *workspaceTabIndexStore) BulkDeleteOwned(ctx context.Context, keys []sto
 	return bulkDeleteTabs(ctx, s.conn.exec, "workspace_tab_owned", keys)
 }
 
-func (s *workspaceTabIndexStore) ListOwnedByWorker(ctx context.Context, p store.ListOwnedTabsByWorkerParams) ([]store.WorkspaceTabRow, error) {
+func (s *workspaceTabIndexStore) ListOwnedByWorker(ctx context.Context, p store.ListOwnedTabsByWorkerParams) ([]store.WorkerTabStateRow, error) {
 	owner, ok := userid.OwnerFilter(p.UserID)
 	if !ok {
 		// An unminted caller owns nothing; binding "" would MATCH every
@@ -59,13 +59,16 @@ func (s *workspaceTabIndexStore) ListOwnedByWorker(ctx context.Context, p store.
 		return nil, nil
 	}
 	rows, err := s.conn.q.ListOwnedTabsByWorker(ctx, gendb.ListOwnedTabsByWorkerParams{
-		UserID:   owner,
-		WorkerID: p.WorkerID,
+		ArchivedSectionType:  leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_ARCHIVED,
+		ArchivedArchiveState: int64(leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED),
+		ActiveArchiveState:   int64(leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ACTIVE),
+		UserID:               owner,
+		WorkerID:             p.WorkerID,
 	})
 	if err != nil {
 		return nil, mapErr(err)
 	}
-	return store.MapSlice(rows, ownedTabRowFromDB), nil
+	return store.MapSlice(rows, ownedTabStateRowFromDB), nil
 }
 
 func (s *workspaceTabIndexStore) ListOwnedTabsByWorkspace(ctx context.Context, p store.ListOwnedTabsByWorkspaceParams) ([]store.OwnedTabRef, error) {
@@ -219,6 +222,17 @@ func ownedTabRefFromDB(r gendb.ListOwnedTabsByWorkspaceRow) store.OwnedTabRef {
 		WorkerID: r.WorkerID,
 		TabType:  leapmuxv1.TabType(r.TabType),
 		TabID:    r.TabID,
+	}
+}
+
+func ownedTabStateRowFromDB(r gendb.ListOwnedTabsByWorkerRow) store.WorkerTabStateRow {
+	return store.WorkerTabStateRow{
+		UserID:       r.UserID,
+		WorkspaceID:  r.WorkspaceID,
+		TabType:      leapmuxv1.TabType(r.TabType),
+		TabID:        r.TabID,
+		WorkerID:     r.WorkerID,
+		ArchiveState: leapmuxv1.WorkspaceArchiveState(r.ArchiveState),
 	}
 }
 

--- a/backend/internal/hub/store/postgres/db/queries/workspace_tab_owned.sql
+++ b/backend/internal/hub/store/postgres/db/queries/workspace_tab_owned.sql
@@ -47,7 +47,17 @@ WHERE t.user_id = k.user_id AND t.tab_id = k.tab_id;
 -- selects across tenants. user_id is the tenancy axis; worker_id
 -- narrows within it.
 -- name: ListOwnedTabsByWorker :many
-SELECT * FROM workspace_tab_owned WHERE user_id = $1 AND worker_id = $2 ORDER BY workspace_id, position;
+SELECT wto.user_id, wto.workspace_id, wto.tab_type, wto.tab_id, wto.worker_id,
+       CASE WHEN ws.section_type = sqlc.arg(archived_section_type)
+            THEN sqlc.arg(archived_archive_state)::INTEGER
+            ELSE sqlc.arg(active_archive_state)::INTEGER END AS archive_state
+FROM workspace_tab_owned wto
+LEFT JOIN workspace_section_items wsi
+  ON wsi.user_id = wto.user_id AND wsi.workspace_id = wto.workspace_id
+LEFT JOIN workspace_sections ws
+  ON ws.id = wsi.section_id AND ws.user_id = wto.user_id
+WHERE wto.user_id = sqlc.arg(user_id) AND wto.worker_id = sqlc.arg(worker_id)
+ORDER BY wto.workspace_id, wto.position;
 
 -- ListOwnedTabsByWorkspace binds user_id as well as workspace_id. A
 -- workspace's owner does not constrain the user_id of rows written against

--- a/backend/internal/hub/store/postgres/workspace_tab_index.go
+++ b/backend/internal/hub/store/postgres/workspace_tab_index.go
@@ -185,7 +185,7 @@ func (s *workspaceTabIndexStore) BulkDeleteOwned(ctx context.Context, keys []sto
 	})
 }
 
-func (s *workspaceTabIndexStore) ListOwnedByWorker(ctx context.Context, p store.ListOwnedTabsByWorkerParams) ([]store.WorkspaceTabRow, error) {
+func (s *workspaceTabIndexStore) ListOwnedByWorker(ctx context.Context, p store.ListOwnedTabsByWorkerParams) ([]store.WorkerTabStateRow, error) {
 	owner, ok := userid.OwnerFilter(p.UserID)
 	if !ok {
 		// An unminted caller owns nothing; binding "" would MATCH every
@@ -193,13 +193,16 @@ func (s *workspaceTabIndexStore) ListOwnedByWorker(ctx context.Context, p store.
 		return nil, nil
 	}
 	rows, err := s.conn.q.ListOwnedTabsByWorker(ctx, gendb.ListOwnedTabsByWorkerParams{
-		UserID:   owner,
-		WorkerID: p.WorkerID,
+		ArchivedSectionType:  leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_ARCHIVED,
+		ArchivedArchiveState: int32(leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED),
+		ActiveArchiveState:   int32(leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ACTIVE),
+		UserID:               owner,
+		WorkerID:             p.WorkerID,
 	})
 	if err != nil {
 		return nil, mapErr(err)
 	}
-	return store.MapSlice(rows, ownedTabRowFromDB), nil
+	return store.MapSlice(rows, ownedTabStateRowFromDB), nil
 }
 
 func (s *workspaceTabIndexStore) ListOwnedTabsByWorkspace(ctx context.Context, p store.ListOwnedTabsByWorkspaceParams) ([]store.OwnedTabRef, error) {
@@ -355,6 +358,17 @@ func ownedTabRefFromDB(r gendb.ListOwnedTabsByWorkspaceRow) store.OwnedTabRef {
 		WorkerID: r.WorkerID,
 		TabType:  leapmuxv1.TabType(r.TabType),
 		TabID:    r.TabID,
+	}
+}
+
+func ownedTabStateRowFromDB(r gendb.ListOwnedTabsByWorkerRow) store.WorkerTabStateRow {
+	return store.WorkerTabStateRow{
+		UserID:       r.UserID,
+		WorkspaceID:  r.WorkspaceID,
+		TabType:      leapmuxv1.TabType(r.TabType),
+		TabID:        r.TabID,
+		WorkerID:     r.WorkerID,
+		ArchiveState: leapmuxv1.WorkspaceArchiveState(r.ArchiveState),
 	}
 }
 

--- a/backend/internal/hub/store/sqlite/db/queries/workspace_tab_owned.sql
+++ b/backend/internal/hub/store/sqlite/db/queries/workspace_tab_owned.sql
@@ -34,7 +34,17 @@ ON CONFLICT (user_id, tab_id) DO UPDATE SET
 -- selects across tenants. user_id is the tenancy axis; worker_id
 -- narrows within it.
 -- name: ListOwnedTabsByWorker :many
-SELECT * FROM workspace_tab_owned WHERE user_id = ? AND worker_id = ? ORDER BY workspace_id, position;
+SELECT wto.user_id, wto.workspace_id, wto.tab_type, wto.tab_id, wto.worker_id,
+       CASE WHEN ws.section_type = sqlc.arg(archived_section_type)
+            THEN CAST(sqlc.arg(archived_archive_state) AS INTEGER)
+            ELSE CAST(sqlc.arg(active_archive_state) AS INTEGER) END AS archive_state
+FROM workspace_tab_owned wto
+LEFT JOIN workspace_section_items wsi
+  ON wsi.user_id = wto.user_id AND wsi.workspace_id = wto.workspace_id
+LEFT JOIN workspace_sections ws
+  ON ws.id = wsi.section_id AND ws.user_id = wto.user_id
+WHERE wto.user_id = sqlc.arg(user_id) AND wto.worker_id = sqlc.arg(worker_id)
+ORDER BY wto.workspace_id, wto.position;
 
 -- ListOwnedTabsByWorkspace binds user_id as well as workspace_id. A
 -- workspace's owner does not constrain the user_id of rows written against

--- a/backend/internal/hub/store/sqlite/workspace_tab_index.go
+++ b/backend/internal/hub/store/sqlite/workspace_tab_index.go
@@ -50,7 +50,7 @@ func (s *workspaceTabIndexStore) BulkDeleteOwned(ctx context.Context, keys []sto
 	return bulkDeleteTabs(ctx, s.conn.exec, "workspace_tab_owned", keys)
 }
 
-func (s *workspaceTabIndexStore) ListOwnedByWorker(ctx context.Context, p store.ListOwnedTabsByWorkerParams) ([]store.WorkspaceTabRow, error) {
+func (s *workspaceTabIndexStore) ListOwnedByWorker(ctx context.Context, p store.ListOwnedTabsByWorkerParams) ([]store.WorkerTabStateRow, error) {
 	owner, ok := userid.OwnerFilter(p.UserID)
 	if !ok {
 		// An unminted caller owns nothing; binding "" would MATCH every
@@ -58,13 +58,16 @@ func (s *workspaceTabIndexStore) ListOwnedByWorker(ctx context.Context, p store.
 		return nil, nil
 	}
 	rows, err := s.conn.q.ListOwnedTabsByWorker(ctx, gendb.ListOwnedTabsByWorkerParams{
-		UserID:   owner,
-		WorkerID: p.WorkerID,
+		ArchivedSectionType:  leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_ARCHIVED,
+		ArchivedArchiveState: int64(leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED),
+		ActiveArchiveState:   int64(leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ACTIVE),
+		UserID:               owner,
+		WorkerID:             p.WorkerID,
 	})
 	if err != nil {
 		return nil, mapErr(err)
 	}
-	return store.MapSlice(rows, ownedTabRowFromDB), nil
+	return store.MapSlice(rows, ownedTabStateRowFromDB), nil
 }
 
 func (s *workspaceTabIndexStore) ListOwnedTabsByWorkspace(ctx context.Context, p store.ListOwnedTabsByWorkspaceParams) ([]store.OwnedTabRef, error) {
@@ -219,6 +222,17 @@ func ownedTabRefFromDB(r gendb.ListOwnedTabsByWorkspaceRow) store.OwnedTabRef {
 		WorkerID: r.WorkerID,
 		TabType:  leapmuxv1.TabType(r.TabType),
 		TabID:    r.TabID,
+	}
+}
+
+func ownedTabStateRowFromDB(r gendb.ListOwnedTabsByWorkerRow) store.WorkerTabStateRow {
+	return store.WorkerTabStateRow{
+		UserID:       r.UserID,
+		WorkspaceID:  r.WorkspaceID,
+		TabType:      leapmuxv1.TabType(r.TabType),
+		TabID:        r.TabID,
+		WorkerID:     r.WorkerID,
+		ArchiveState: leapmuxv1.WorkspaceArchiveState(r.ArchiveState),
 	}
 }
 

--- a/backend/internal/hub/store/store.go
+++ b/backend/internal/hub/store/store.go
@@ -365,12 +365,13 @@ type WorkspaceTabIndexStore interface {
 	// invariant broke.
 	BulkDeleteOwned(ctx context.Context, keys []TabIndexKey) error
 	// ListOwnedByWorker returns p.UserID's owned tabs hosted by p.WorkerID.
+	// Each row includes the archive state derived from its current section.
 	// The result is authoritative ONLY for that owner: the worker's orphan
 	// reconciler infers "absent here means orphaned" from it, so a response
 	// must declare the owner it covers (see leapmuxv1.
 	// ListOwnedTabsForWorkerResponse.owner_user_id) rather than let a
 	// narrower scope read as a wider absence. A zero UserID returns nil.
-	ListOwnedByWorker(ctx context.Context, p ListOwnedTabsByWorkerParams) ([]WorkspaceTabRow, error)
+	ListOwnedByWorker(ctx context.Context, p ListOwnedTabsByWorkerParams) ([]WorkerTabStateRow, error)
 	// ListOwnedTabsByWorkspace returns every tab p.UserID holds in
 	// p.WorkspaceID, as (worker_id, tab_type, tab_id). A zero UserID returns
 	// nil. Owner-scoped because the caller cannot filter a foreign owner's rows

--- a/backend/internal/hub/store/storetest/test_workspace_tab_index.go
+++ b/backend/internal/hub/store/storetest/test_workspace_tab_index.go
@@ -85,6 +85,43 @@ func (s *Suite) testWorkspaceTabIndex(t *testing.T) {
 		assert.NoError(t, st.WorkspaceTabIndex().BulkDeleteRendered(ctx, nil))
 	})
 
+	t.Run("owned worker rows include authoritative archive state", func(t *testing.T) {
+		st := s.NewStore(t)
+		user := SeedUser(t, st, "tabidx-archive-state")
+		owner := userid.MustNew(user.ID)
+		worker := SeedWorker(t, st, user.ID)
+		activeWorkspace := SeedWorkspace(t, st, user.ID, "active")
+		archivedWorkspace := SeedWorkspace(t, st, user.ID, "archived")
+
+		for _, section := range []store.CreateWorkspaceSectionParams{
+			{ID: "active-section", UserID: owner, Name: "In progress", Position: "a", SectionType: leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_IN_PROGRESS, Sidebar: leapmuxv1.Sidebar_SIDEBAR_LEFT},
+			{ID: "archive-section", UserID: owner, Name: "Archived", Position: "z", SectionType: leapmuxv1.SectionType_SECTION_TYPE_WORKSPACES_ARCHIVED, Sidebar: leapmuxv1.Sidebar_SIDEBAR_LEFT},
+		} {
+			require.NoError(t, st.WorkspaceSections().Create(ctx, section))
+		}
+		require.NoError(t, st.WorkspaceSectionItems().Set(ctx, store.SetWorkspaceSectionItemParams{
+			UserID: owner, WorkspaceID: activeWorkspace, SectionID: "active-section", Position: "a",
+		}))
+		require.NoError(t, st.WorkspaceSectionItems().Set(ctx, store.SetWorkspaceSectionItemParams{
+			UserID: owner, WorkspaceID: archivedWorkspace, SectionID: "archive-section", Position: "a",
+		}))
+		require.NoError(t, st.WorkspaceTabIndex().BulkUpsertOwned(ctx, []store.UpsertOwnedTabParams{
+			{UserID: owner, WorkspaceID: activeWorkspace, WorkerID: worker.ID, TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabID: "active-agent", TileID: "active-tile", Position: "a"},
+			{UserID: owner, WorkspaceID: archivedWorkspace, WorkerID: worker.ID, TabType: leapmuxv1.TabType_TAB_TYPE_TERMINAL, TabID: "archived-terminal", TileID: "archive-tile", Position: "a"},
+		}))
+
+		rows, err := st.WorkspaceTabIndex().ListOwnedByWorker(ctx, store.ListOwnedTabsByWorkerParams{
+			UserID: owner, WorkerID: worker.ID,
+		})
+		require.NoError(t, err)
+		states := make(map[string]leapmuxv1.WorkspaceArchiveState, len(rows))
+		for _, row := range rows {
+			states[row.TabID] = row.ArchiveState
+		}
+		assert.Equal(t, leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ACTIVE, states["active-agent"])
+		assert.Equal(t, leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED, states["archived-terminal"])
+	})
+
 	// workspace_tab_owned.user_id REFERENCES users(id), mirroring every sibling
 	// CRDT table. That FK is what makes a blank-owner row UNREPRESENTABLE rather
 	// than merely undeletable: before it, a blank owner was insertable while

--- a/backend/internal/hub/store/types.go
+++ b/backend/internal/hub/store/types.go
@@ -257,7 +257,13 @@ type Workspace struct {
 }
 
 // WorkspaceTabRow is a stored row from workspace_tab_owned or
-// workspace_tab_rendered. The two tables have the same stored columns.
+// workspace_tab_rendered. The two tables hold the same stored columns; the
+// distinction is WHICH table a row came from, and which reader it serves.
+//
+// The client tab RPCs read `_rendered`. The worker delegation handler reads
+// `_owned` to find a tab's owning Worker. Worker reconciliation also reads
+// `_owned`, but through WorkerTabStateRow below, which carries the workspace's
+// archive state as well.
 type WorkspaceTabRow struct {
 	UserID      string
 	WorkspaceID string

--- a/backend/internal/hub/store/types.go
+++ b/backend/internal/hub/store/types.go
@@ -256,10 +256,8 @@ type Workspace struct {
 	DeletedAt   *time.Time
 }
 
-// WorkspaceTabRow is a row from workspace_tab_owned or
-// workspace_tab_rendered. The two views have the same shape; the
-// distinction is *which* table they came from. Worker reconciliation
-// reads from `_owned`; UI reads from `_rendered`.
+// WorkspaceTabRow is a stored row from workspace_tab_owned or
+// workspace_tab_rendered. The two tables have the same stored columns.
 type WorkspaceTabRow struct {
 	UserID      string
 	WorkspaceID string
@@ -268,6 +266,17 @@ type WorkspaceTabRow struct {
 	WorkerID    string
 	TileID      string
 	Position    string
+}
+
+// WorkerTabStateRow is the owner projection that Worker reconciliation reads.
+// ArchiveState is derived from the workspace's section in the same query.
+type WorkerTabStateRow struct {
+	UserID       string
+	WorkspaceID  string
+	TabType      leapmuxv1.TabType
+	TabID        string
+	WorkerID     string
+	ArchiveState leapmuxv1.WorkspaceArchiveState
 }
 
 // UserOpBatchRow is a single row of the CRDT op-batch journal.

--- a/backend/internal/worker/bootstrap/bootstrap.go
+++ b/backend/internal/worker/bootstrap/bootstrap.go
@@ -357,10 +357,9 @@ func startBackgroundLoops(p Params, svc *service.Service) *service.AgentResumer 
 	// CONVERGED pass -- see the OnConverged hook below for the reason.
 	resumer := svc.NewAgentResumer()
 
-	// Periodic orphan reconciler: walks worker-local rows against the hub's
-	// CRDT-derived workspace_tab_owned view and drops the rows the CRDT no
-	// longer agrees with. Runs once at startup and every hour after;
-	// cancelled on ctx done.
+	// Periodic reconciler: applies authoritative archive state and drops local
+	// rows that the Hub no longer owns. It runs once at startup and every hour
+	// after that. The context stops it.
 	reconciler := service.NewOrphanReconciler(
 		queries,
 		func(rctx context.Context) (*leapmuxv1.ListOwnedTabsForWorkerResponse, error) {
@@ -371,8 +370,10 @@ func startBackgroundLoops(p Params, svc *service.Service) *service.AgentResumer 
 			// strands (no live tab references them). Backstops the startup
 			// link guards so a close that raced startup can't leak the
 			// worktree dir.
-			ReapWorktree: svc.ReapOrphanWorktree,
-			CloseTab:     svc.CloseTabForReconcile,
+			ReapWorktree:      svc.ReapOrphanWorktree,
+			CloseTab:          svc.CloseTabForReconcile,
+			ApplyArchiveState: svc.ApplyTabArchiveStateForReconcile,
+			ResumeAgents:      func(agentIDs []string) { resumer.Schedule(p.Ctx, agentIDs) },
 			// The resume sweep's start signal, and the reason it is this and not
 			// "the worker finished wiring". A converged pass is the first moment
 			// two things are BOTH true: the Hub delivered this worker's owner (no

--- a/backend/internal/worker/bootstrap/bootstrap.go
+++ b/backend/internal/worker/bootstrap/bootstrap.go
@@ -355,7 +355,7 @@ func startBackgroundLoops(p Params, svc *service.Service) *service.AgentResumer 
 	// Respawn the agent processes the previous worker process left behind. It
 	// runs once, in the background, and only after the reconciler reports a
 	// CONVERGED pass -- see the OnConverged hook below for the reason.
-	resumer := svc.NewAgentResumer()
+	resumer := svc.AgentResumer()
 
 	// Periodic reconciler: applies authoritative archive state and drops local
 	// rows that the Hub no longer owns. It runs once at startup and every hour
@@ -372,7 +372,7 @@ func startBackgroundLoops(p Params, svc *service.Service) *service.AgentResumer 
 			// worktree dir.
 			ReapWorktree:      svc.ReapOrphanWorktree,
 			CloseTab:          svc.CloseTabForReconcile,
-			ApplyArchiveState: svc.ApplyTabArchiveStateForReconcile,
+			ApplyArchiveState: svc.ApplyTabArchiveState,
 			ResumeAgents:      func(agentIDs []string) { resumer.Schedule(p.Ctx, agentIDs) },
 			// The resume sweep's start signal, and the reason it is this and not
 			// "the worker finished wiring". A converged pass is the first moment

--- a/backend/internal/worker/db/db_test.go
+++ b/backend/internal/worker/db/db_test.go
@@ -51,6 +51,29 @@ func TestMigrate(t *testing.T) {
 	}
 }
 
+func TestMigrate_SeedsActiveArchiveState(t *testing.T) {
+	t.Parallel()
+
+	sqlDB, err := db.Open(":memory:", sqlitedb.Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	require.NoError(t, db.Migrate(context.Background(), sqlDB))
+	require.NoError(t, func() error {
+		_, err := sqlDB.Exec(`INSERT INTO agents (id) VALUES ('agent-1')`)
+		return err
+	}())
+	require.NoError(t, func() error {
+		_, err := sqlDB.Exec(`INSERT INTO terminals (id) VALUES ('terminal-1')`)
+		return err
+	}())
+
+	var agentArchived, terminalArchived int64
+	require.NoError(t, sqlDB.QueryRow(`SELECT workspace_archived FROM agents WHERE id = 'agent-1'`).Scan(&agentArchived))
+	require.NoError(t, sqlDB.QueryRow(`SELECT workspace_archived FROM terminals WHERE id = 'terminal-1'`).Scan(&terminalArchived))
+	assert.Zero(t, agentArchived)
+	assert.Zero(t, terminalArchived)
+}
+
 func TestMigrate_Idempotent(t *testing.T) {
 	sqlDB, err := db.Open(":memory:", sqlitedb.Config{})
 	require.NoError(t, err)

--- a/backend/internal/worker/db/migrations/00001_initial.sql
+++ b/backend/internal/worker/db/migrations/00001_initial.sql
@@ -48,6 +48,7 @@ CREATE TABLE agents (
     -- silently skip the new message. Maintained by the triggers on `messages` below.
     message_seq_hwm  INTEGER NOT NULL DEFAULT 0,
     startup_error    TEXT NOT NULL DEFAULT '',
+    workspace_archived INTEGER NOT NULL DEFAULT 0,
     created_at       DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
     closed_at        DATETIME
 );
@@ -202,6 +203,7 @@ CREATE TABLE terminals (
     screen        BLOB NOT NULL DEFAULT x'',
     exit_code     INTEGER NOT NULL DEFAULT 0,
     startup_error TEXT NOT NULL DEFAULT '',
+    workspace_archived INTEGER NOT NULL DEFAULT 0,
     created_at    DATETIME NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
     closed_at     DATETIME
 );

--- a/backend/internal/worker/db/queries/agents.sql
+++ b/backend/internal/worker/db/queries/agents.sql
@@ -8,11 +8,16 @@ INSERT INTO agents (id, working_dir, home_dir, title, title_auto_generated, opti
 SELECT * FROM agents WHERE id = ?;
 
 -- GetAgentID is the existence probe behind requireAgentID: it answers
--- sql.ErrNoRows for an unknown id while reading only the primary key, so a
+-- sql.ErrNoRows for an unknown id while reading two narrow columns, so a
 -- handler that needs no agent fields (close, interrupt) does not deserialize
 -- the options / option_groups JSON blobs SELECT * would.
+--
+-- workspace_archived rides along because the registrar refuses every write
+-- handler for an archived workspace, and this probe is what a by-id write
+-- handler loads. An INTEGER column costs nothing next to the blobs this query
+-- exists to skip.
 -- name: GetAgentID :one
-SELECT id FROM agents WHERE id = ?;
+SELECT id, workspace_archived FROM agents WHERE id = ?;
 
 -- GetAgentTitle reads only the title column, for the RenameAgent reply on the
 -- path that stores nothing: a request whose title cleans to empty keeps the
@@ -151,9 +156,23 @@ UPDATE agents SET startup_error = ? WHERE id = ?;
 
 -- SetAgentWorkspaceArchived changes only the cached workspace lifecycle state.
 -- The row stays open, and all transcript and worktree data stays unchanged.
+--
+-- closed_at IS NULL matters, because the caller treats a changed row as a tab
+-- to stop and broadcast for. A closed row stays in this table for the whole
+-- 7-day cleanup retention, so without the predicate an archive that races a
+-- close re-runs the full teardown for a tab that the worker already tore down,
+-- and the matching unarchive spends a startup permit on it. This is the same
+-- reason the orphan reconciler reads ListAllOpenRootAgentIDs.
 -- name: SetAgentWorkspaceArchived :execrows
 UPDATE agents SET workspace_archived = sqlc.arg(workspace_archived)
-WHERE id = sqlc.arg(id) AND workspace_archived <> sqlc.arg(workspace_archived);
+WHERE id = sqlc.arg(id) AND closed_at IS NULL
+  AND workspace_archived <> sqlc.arg(workspace_archived);
+
+-- GetAgentForInactiveBroadcast reads the three columns broadcastAgentInactive
+-- needs. GetAgentByID would answer the same question, and it reads the options
+-- and option_groups TEXT columns that this caller never looks at.
+-- name: GetAgentForInactiveBroadcast :one
+SELECT id, agent_session_id, agent_provider FROM agents WHERE id = ?;
 
 -- name: UpdateAgentHomeDir :exec
 UPDATE agents SET home_dir = ? WHERE id = ?;

--- a/backend/internal/worker/db/queries/agents.sql
+++ b/backend/internal/worker/db/queries/agents.sql
@@ -149,6 +149,12 @@ RETURNING *;
 -- name: SetAgentStartupError :exec
 UPDATE agents SET startup_error = ? WHERE id = ?;
 
+-- SetAgentWorkspaceArchived changes only the cached workspace lifecycle state.
+-- The row stays open, and all transcript and worktree data stays unchanged.
+-- name: SetAgentWorkspaceArchived :execrows
+UPDATE agents SET workspace_archived = sqlc.arg(workspace_archived)
+WHERE id = sqlc.arg(id) AND workspace_archived <> sqlc.arg(workspace_archived);
+
 -- name: UpdateAgentHomeDir :exec
 UPDATE agents SET home_dir = ? WHERE id = ?;
 
@@ -257,6 +263,13 @@ SELECT tree.id FROM tree;
 -- state sweep keeps seeing them.
 -- name: ListAllOpenRootAgentIDs :many
 SELECT id FROM agents WHERE closed_at IS NULL AND parent_agent_id IS NULL;
+
+-- ListRootAgentIDsForResume excludes archived rows before the resume scheduler
+-- dispatches them. The orphan reconciler uses ListAllOpenRootAgentIDs instead,
+-- because it must still reap an archived tab that the Hub deleted.
+-- name: ListRootAgentIDsForResume :many
+SELECT id FROM agents
+WHERE closed_at IS NULL AND parent_agent_id IS NULL AND workspace_archived = 0;
 
 
 -- ListSessionsForResume lists the resume handles this worker recorded for one

--- a/backend/internal/worker/db/queries/terminals.sql
+++ b/backend/internal/worker/db/queries/terminals.sql
@@ -36,12 +36,23 @@ ON CONFLICT (id) DO UPDATE SET
 -- name: GetTerminal :one
 SELECT * FROM terminals WHERE id = ?;
 
+-- GetTerminalExitCode reads the one column the archive teardown broadcasts.
+-- GetTerminal would answer the same question, and it reads the 100KB screen
+-- BLOB that this caller never looks at.
+-- name: GetTerminalExitCode :one
+SELECT exit_code FROM terminals WHERE id = ?;
+
 -- GetTerminalID is the existence probe behind requireTerminalID: it answers
--- sql.ErrNoRows for an unknown id while reading only the primary key, so the
+-- sql.ErrNoRows for an unknown id while reading two narrow columns, so the
 -- per-keystroke SendInput / per-resize ResizeTerminal paths never load the
 -- screen BLOB SELECT * would.
+--
+-- workspace_archived rides along for the same reason as in GetAgentID: the
+-- registrar refuses every terminal write handler for an archived workspace,
+-- and an INTEGER column costs nothing next to the screen BLOB this query
+-- exists to skip.
 -- name: GetTerminalID :one
-SELECT id FROM terminals WHERE id = ?;
+SELECT id, workspace_archived FROM terminals WHERE id = ?;
 
 -- name: GetTerminalForReady :one
 -- Narrow lookup used by the post-spawn tail of runTerminalStartup /
@@ -106,6 +117,11 @@ UPDATE terminals SET startup_error = ? WHERE id = ?;
 
 -- SetTerminalWorkspaceArchived changes only the cached workspace lifecycle
 -- state. The row, final screen, and worktree link stay unchanged.
+--
+-- closed_at IS NULL matters for the same reason as SetAgentWorkspaceArchived:
+-- the caller stops and broadcasts for every row this statement changes, and a
+-- closed row stays here for the whole cleanup retention window.
 -- name: SetTerminalWorkspaceArchived :execrows
 UPDATE terminals SET workspace_archived = sqlc.arg(workspace_archived)
-WHERE id = sqlc.arg(id) AND workspace_archived <> sqlc.arg(workspace_archived);
+WHERE id = sqlc.arg(id) AND closed_at IS NULL
+  AND workspace_archived <> sqlc.arg(workspace_archived);

--- a/backend/internal/worker/db/queries/terminals.sql
+++ b/backend/internal/worker/db/queries/terminals.sql
@@ -48,9 +48,9 @@ SELECT id FROM terminals WHERE id = ?;
 -- runTerminalRestart. closed_at drives the close-race teardown; title
 -- absorbs the value the frontend may have persisted between the
 -- handler returning and StartTerminal registering in-memory metadata
--- (restart ignores the title field). Two columns in one round-trip,
+-- (restart ignores the title field). Three columns in one round-trip,
 -- avoiding the SELECT * scan of the screen BLOB.
-SELECT closed_at, title FROM terminals WHERE id = ?;
+SELECT closed_at, title, workspace_archived FROM terminals WHERE id = ?;
 
 -- name: GetTerminalForRestart :one
 -- Restart hot path: returns the metadata the handler needs to respawn
@@ -61,7 +61,7 @@ SELECT closed_at, title FROM terminals WHERE id = ?;
 -- in the common case (in-memory entry still present, Respawn carries
 -- the live buffer forward and length is ignored).
 SELECT working_dir, shell_start_dir, shell, cols, rows,
-       length(screen) AS screen_length
+       length(screen) AS screen_length, workspace_archived
 FROM terminals WHERE id = ?;
 
 -- name: CloseTerminal :execresult
@@ -103,3 +103,9 @@ DELETE FROM terminals WHERE rowid IN (SELECT t.rowid FROM terminals t WHERE t.cl
 
 -- name: SetTerminalStartupError :exec
 UPDATE terminals SET startup_error = ? WHERE id = ?;
+
+-- SetTerminalWorkspaceArchived changes only the cached workspace lifecycle
+-- state. The row, final screen, and worktree link stay unchanged.
+-- name: SetTerminalWorkspaceArchived :execrows
+UPDATE terminals SET workspace_archived = sqlc.arg(workspace_archived)
+WHERE id = sqlc.arg(id) AND workspace_archived <> sqlc.arg(workspace_archived);

--- a/backend/internal/worker/service/access_control_test.go
+++ b/backend/internal/worker/service/access_control_test.go
@@ -293,6 +293,11 @@ var ownerGatedProbes = func() []ownerGatedProbe {
 		ownerGatedProbe{"CleanupWorkspace", "CleanupWorkspace", func() proto.Message {
 			return &leapmuxv1.CleanupWorkspaceRequest{}
 		}},
+		ownerGatedProbe{"SetTabArchiveState", "SetTabArchiveState", func() proto.Message {
+			return &leapmuxv1.SetTabArchiveStateRequest{
+				ArchiveState: leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED,
+			}
+		}},
 		ownerGatedProbe{"GetTabPayload", "GetTabPayload", func() proto.Message {
 			return &leapmuxv1.GetTabPayloadRequest{TabId: "tab-1"}
 		}},

--- a/backend/internal/worker/service/access_control_test.go
+++ b/backend/internal/worker/service/access_control_test.go
@@ -293,11 +293,6 @@ var ownerGatedProbes = func() []ownerGatedProbe {
 		ownerGatedProbe{"CleanupWorkspace", "CleanupWorkspace", func() proto.Message {
 			return &leapmuxv1.CleanupWorkspaceRequest{}
 		}},
-		ownerGatedProbe{"SetTabArchiveState", "SetTabArchiveState", func() proto.Message {
-			return &leapmuxv1.SetTabArchiveStateRequest{
-				ArchiveState: leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED,
-			}
-		}},
 		ownerGatedProbe{"GetTabPayload", "GetTabPayload", func() proto.Message {
 			return &leapmuxv1.GetTabPayloadRequest{TabId: "tab-1"}
 		}},

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -63,6 +63,14 @@ func (svc *Service) baseAgentOptions(agentID, workingDir string, provider leapmu
 	}
 }
 
+func refuseArchivedAgent(sender channel.ResponseWriter, row db.Agent) bool {
+	if row.WorkspaceArchived == 0 {
+		return false
+	}
+	sendFailedPrecondition(sender, "agent belongs to an archived workspace")
+	return true
+}
+
 // registerAgentHandlers registers all agent-related inner RPC handlers.
 func registerAgentHandlers(d registrar, svc *Service) {
 	registerOwnerGated(d, "OpenAgent", leapmuxv1.Scope_SCOPE_AGENT_WRITE, dispatchPlain,
@@ -262,7 +270,7 @@ func registerAgentHandlers(d registrar, svc *Service) {
 				}
 				slog.Error("refusing to start agent without an identity", "agent_id", agentID, "error", err)
 				sendInternalError(sender, "failed to start agent")
-				svc.AgentStartup.finish()
+				svc.AgentStartup.finishEntry(startupHandle)
 				return
 			}
 
@@ -314,6 +322,9 @@ func registerAgentHandlers(d registrar, svc *Service) {
 	registerAgentGated(d, "SendAgentMessage", leapmuxv1.Scope_SCOPE_AGENT_WRITE,
 		func(_ context.Context, _ channel.Caller, r *leapmuxv1.SendAgentMessageRequest, dbAgent db.Agent, sender channel.ResponseWriter) {
 			agentID := r.GetAgentId()
+			if refuseArchivedAgent(sender, dbAgent) {
+				return
+			}
 
 			// Reject sends only on permanent startup failure — STARTING
 			// messages are queued on the frontend and dispatched on the
@@ -533,6 +544,9 @@ func registerAgentHandlers(d registrar, svc *Service) {
 	registerAgentGated(d, "SendAgentRawMessage", leapmuxv1.Scope_SCOPE_AGENT_WRITE,
 		func(_ context.Context, _ channel.Caller, r *leapmuxv1.SendAgentRawMessageRequest, dbAgent db.Agent, sender channel.ResponseWriter) {
 			agentID := r.GetAgentId()
+			if refuseArchivedAgent(sender, dbAgent) {
+				return
+			}
 			// A child agent has no process and no raw-control surface; reject.
 			if dbAgent.ParentAgentID.Valid {
 				sendFailedPrecondition(sender, "this subagent cannot be messaged")
@@ -979,6 +993,9 @@ func registerAgentHandlers(d registrar, svc *Service) {
 	registerAgentGated(d, "UpdateAgentSettings", leapmuxv1.Scope_SCOPE_AGENT_WRITE,
 		func(_ context.Context, _ channel.Caller, r *leapmuxv1.UpdateAgentSettingsRequest, dbAgent db.Agent, sender channel.ResponseWriter) {
 			agentID := r.GetAgentId()
+			if refuseArchivedAgent(sender, dbAgent) {
+				return
+			}
 
 			// A virtual child agent has no process and no settings of its own
 			// (it inherits the owner's). Reject before the optimistic DB write
@@ -1051,6 +1068,9 @@ func registerAgentHandlers(d registrar, svc *Service) {
 	registerAgentGated(d, "SendControlResponse", leapmuxv1.Scope_SCOPE_AGENT_WRITE,
 		func(_ context.Context, _ channel.Caller, r *leapmuxv1.SendControlResponseRequest, dbAgent db.Agent, sender channel.ResponseWriter) {
 			agentID := r.GetAgentId()
+			if refuseArchivedAgent(sender, dbAgent) {
+				return
+			}
 
 			// The claim/dedup/plan-mode/forward orchestration lives in processControlResponse (dispatcher-
 			// free, unit-testable); the handler is just transport. It reports the bytes to forward, or
@@ -1841,7 +1861,7 @@ func (svc *Service) agentsHasAgentFor(agentRow *db.Agent, rootID string) bool {
 // {provider}…") rather than overlapping noise.
 func (svc *Service) runAgentStartup(ctx context.Context, dbAgent db.Agent, plan gitModePlan, agentOpts agent.Options, h *startupEntry) {
 	agentID := agentOpts.AgentID
-	defer svc.AgentStartup.finish()
+	defer svc.AgentStartup.finishEntry(h)
 	sink := svc.Output.NewSink(agentID, agentOpts.AgentProvider)
 
 	// Phase 0: execute the git-mode mutation (worktree add, branch create,
@@ -1907,14 +1927,22 @@ func (svc *Service) runAgentStartup(ctx context.Context, dbAgent db.Agent, plan 
 	if fetchErr == nil {
 		dbAgent = latest
 	}
-	if fetchErr == nil && dbAgent.ClosedAt.Valid {
+	_, closeRaced := svc.AgentStartup.dispositionOf(h)
+	if closeRaced || (fetchErr == nil && dbAgent.ClosedAt.Valid) {
 		if startErr == nil {
 			svc.Agents.StopAgent(agentID)
 		}
 		svc.finishStartupAfterClose(&svc.AgentStartup.startupCore, h, agentID, gm)
 		return
 	}
-
+	archiveStopped, _ := svc.AgentStartup.archiveDisposition(h)
+	if archiveStopped || (fetchErr == nil && dbAgent.WorkspaceArchived != 0) {
+		if startErr == nil {
+			svc.Agents.StopAndWaitAgent(agentID)
+		}
+		svc.AgentStartup.succeed(agentID)
+		return
+	}
 	if startErr != nil {
 		slog.Error("failed to start agent", "agent_id", agentID, "error", startErr)
 		svc.failAgentStartup(&dbAgent, gm, startErr, gitStatus, h)
@@ -1981,6 +2009,24 @@ func (svc *Service) runAgentStartup(ctx context.Context, dbAgent db.Agent, plan 
 	running := true
 	if relaunch {
 		activeDbAgent, running = svc.relaunchForStartupSettingsChange(agentID, dbAgent.AgentProvider, latestOpts, activeDbAgent)
+	}
+	archiveStopped, _ = svc.AgentStartup.archiveDisposition(h)
+	if latest, err := svc.getAgentByID(bgCtx(), agentID); err == nil {
+		activeDbAgent = latest
+	}
+	_, closeRaced = svc.AgentStartup.dispositionOf(h)
+	if closeRaced || activeDbAgent.ClosedAt.Valid {
+		if running {
+			svc.Agents.StopAndWaitAgent(agentID)
+		}
+		svc.finishStartupAfterClose(&svc.AgentStartup.startupCore, h, agentID, gm)
+		return
+	}
+	if archiveStopped || activeDbAgent.WorkspaceArchived != 0 {
+		if running {
+			svc.Agents.StopAndWaitAgent(agentID)
+		}
+		return
 	}
 
 	activeOptions := loadOptions(activeDbAgent.Options, activeDbAgent.AgentProvider)
@@ -3128,6 +3174,9 @@ func (svc *Service) ensureAgentRunning(agentID string, preResolvedResumeSessionI
 	if dbAgent.ClosedAt.Valid {
 		return fmt.Errorf("agent %s is closed; it takes no new process", agentID)
 	}
+	if dbAgent.WorkspaceArchived != 0 {
+		return fmt.Errorf("agent %s belongs to an archived workspace; it takes no new process", agentID)
+	}
 
 	var resumeSessionID string
 	if preResolvedResumeSessionID != nil {
@@ -3145,11 +3194,12 @@ func (svc *Service) ensureAgentRunning(agentID string, preResolvedResumeSessionI
 	// message that lands in that window used to spawn a second process for the
 	// same tab.
 	startupCtx, cancel := context.WithCancel(bgCtx())
-	if handle := svc.AgentStartup.begin(agentID, cancel); handle == nil {
+	handle := svc.AgentStartup.begin(agentID, cancel)
+	if handle == nil {
 		cancel()
 		return fmt.Errorf("agent %s already has a startup in progress", agentID)
 	}
-	defer svc.AgentStartup.finish()
+	defer svc.AgentStartup.finishEntry(handle)
 	// succeed() on BOTH outcomes, because it only means "drop the override and
 	// derive the status from the manager again". fail() would report
 	// STARTUP_FAILED, which refuses the user's next message for the whole

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -63,14 +63,6 @@ func (svc *Service) baseAgentOptions(agentID, workingDir string, provider leapmu
 	}
 }
 
-func refuseArchivedAgent(sender channel.ResponseWriter, row db.Agent) bool {
-	if row.WorkspaceArchived == 0 {
-		return false
-	}
-	sendFailedPrecondition(sender, "agent belongs to an archived workspace")
-	return true
-}
-
 // registerAgentHandlers registers all agent-related inner RPC handlers.
 func registerAgentHandlers(d registrar, svc *Service) {
 	registerOwnerGated(d, "OpenAgent", leapmuxv1.Scope_SCOPE_AGENT_WRITE, dispatchPlain,
@@ -322,9 +314,6 @@ func registerAgentHandlers(d registrar, svc *Service) {
 	registerAgentGated(d, "SendAgentMessage", leapmuxv1.Scope_SCOPE_AGENT_WRITE,
 		func(_ context.Context, _ channel.Caller, r *leapmuxv1.SendAgentMessageRequest, dbAgent db.Agent, sender channel.ResponseWriter) {
 			agentID := r.GetAgentId()
-			if refuseArchivedAgent(sender, dbAgent) {
-				return
-			}
 
 			// Reject sends only on permanent startup failure — STARTING
 			// messages are queued on the frontend and dispatched on the
@@ -544,9 +533,6 @@ func registerAgentHandlers(d registrar, svc *Service) {
 	registerAgentGated(d, "SendAgentRawMessage", leapmuxv1.Scope_SCOPE_AGENT_WRITE,
 		func(_ context.Context, _ channel.Caller, r *leapmuxv1.SendAgentRawMessageRequest, dbAgent db.Agent, sender channel.ResponseWriter) {
 			agentID := r.GetAgentId()
-			if refuseArchivedAgent(sender, dbAgent) {
-				return
-			}
 			// A child agent has no process and no raw-control surface; reject.
 			if dbAgent.ParentAgentID.Valid {
 				sendFailedPrecondition(sender, "this subagent cannot be messaged")
@@ -993,9 +979,6 @@ func registerAgentHandlers(d registrar, svc *Service) {
 	registerAgentGated(d, "UpdateAgentSettings", leapmuxv1.Scope_SCOPE_AGENT_WRITE,
 		func(_ context.Context, _ channel.Caller, r *leapmuxv1.UpdateAgentSettingsRequest, dbAgent db.Agent, sender channel.ResponseWriter) {
 			agentID := r.GetAgentId()
-			if refuseArchivedAgent(sender, dbAgent) {
-				return
-			}
 
 			// A virtual child agent has no process and no settings of its own
 			// (it inherits the owner's). Reject before the optimistic DB write
@@ -1068,9 +1051,6 @@ func registerAgentHandlers(d registrar, svc *Service) {
 	registerAgentGated(d, "SendControlResponse", leapmuxv1.Scope_SCOPE_AGENT_WRITE,
 		func(_ context.Context, _ channel.Caller, r *leapmuxv1.SendControlResponseRequest, dbAgent db.Agent, sender channel.ResponseWriter) {
 			agentID := r.GetAgentId()
-			if refuseArchivedAgent(sender, dbAgent) {
-				return
-			}
 
 			// The claim/dedup/plan-mode/forward orchestration lives in processControlResponse (dispatcher-
 			// free, unit-testable); the handler is just transport. It reports the bytes to forward, or
@@ -1927,21 +1907,28 @@ func (svc *Service) runAgentStartup(ctx context.Context, dbAgent db.Agent, plan 
 	if fetchErr == nil {
 		dbAgent = latest
 	}
-	_, closeRaced := svc.AgentStartup.dispositionOf(h)
-	if closeRaced || (fetchErr == nil && dbAgent.ClosedAt.Valid) {
+	switch svc.AgentStartup.interruptionOf(h, fetchErr == nil && dbAgent.ClosedAt.Valid, fetchErr == nil && dbAgent.WorkspaceArchived != 0) {
+	case interruptionClosed:
 		if startErr == nil {
 			svc.Agents.StopAgent(agentID)
 		}
 		svc.finishStartupAfterClose(&svc.AgentStartup.startupCore, h, agentID, gm)
 		return
-	}
-	archiveStopped, _ := svc.AgentStartup.archiveDisposition(h)
-	if archiveStopped || (fetchErr == nil && dbAgent.WorkspaceArchived != 0) {
+	case interruptionArchived:
 		if startErr == nil {
 			svc.Agents.StopAndWaitAgent(agentID)
 		}
-		svc.AgentStartup.succeed(agentID)
+		// succeed, not fail, even when startErr is non-nil: archival is not a
+		// startup failure, and STARTUP_FAILED would refuse the user's next
+		// message after the unarchive and make the resume sweep skip the tab.
+		// Log it, because otherwise a real provider failure inside the archive
+		// window leaves no evidence anywhere.
+		if startErr != nil {
+			slog.Warn("agent startup stopped by workspace archival", "agent_id", agentID, "error", startErr)
+		}
+		svc.AgentStartup.succeed(agentID, h)
 		return
+	case interruptionNone:
 	}
 	if startErr != nil {
 		slog.Error("failed to start agent", "agent_id", agentID, "error", startErr)
@@ -1955,7 +1942,7 @@ func (svc *Service) runAgentStartup(ctx context.Context, dbAgent db.Agent, plan 
 	// arrives inside startAgent) is not rejected by the SendAgentMessage
 	// startup-gate. The subprocess is up and ready for input at this
 	// point; settings persistence is a best-effort DB write.
-	svc.AgentStartup.succeed(agentID)
+	svc.AgentStartup.succeed(agentID, h)
 	if dbAgent.StartupError != "" {
 		svc.persistAgentStartupError(agentID, "")
 	}
@@ -2010,23 +1997,25 @@ func (svc *Service) runAgentStartup(ctx context.Context, dbAgent db.Agent, plan 
 	if relaunch {
 		activeDbAgent, running = svc.relaunchForStartupSettingsChange(agentID, dbAgent.AgentProvider, latestOpts, activeDbAgent)
 	}
-	archiveStopped, _ = svc.AgentStartup.archiveDisposition(h)
 	if latest, err := svc.getAgentByID(bgCtx(), agentID); err == nil {
 		activeDbAgent = latest
 	}
-	_, closeRaced = svc.AgentStartup.dispositionOf(h)
-	if closeRaced || activeDbAgent.ClosedAt.Valid {
+	switch svc.AgentStartup.interruptionOf(h, activeDbAgent.ClosedAt.Valid, activeDbAgent.WorkspaceArchived != 0) {
+	case interruptionClosed:
 		if running {
 			svc.Agents.StopAndWaitAgent(agentID)
 		}
 		svc.finishStartupAfterClose(&svc.AgentStartup.startupCore, h, agentID, gm)
 		return
-	}
-	if archiveStopped || activeDbAgent.WorkspaceArchived != 0 {
+	case interruptionArchived:
 		if running {
 			svc.Agents.StopAndWaitAgent(agentID)
 		}
+		// No broadcast here: succeed already ran above, so the client saw
+		// ACTIVE, and stopArchivedTabs broadcasts INACTIVE for every tab whose
+		// flag it changed once waitForFinished returns.
 		return
+	case interruptionNone:
 	}
 
 	activeOptions := loadOptions(activeDbAgent.Options, activeDbAgent.AgentProvider)
@@ -3205,7 +3194,7 @@ func (svc *Service) ensureAgentRunning(agentID string, preResolvedResumeSessionI
 	// STARTUP_FAILED, which refuses the user's next message for the whole
 	// failed-entry TTL; this path deliberately stays retryable, and the failure
 	// reaches the user as the caller's per-message delivery error.
-	defer svc.AgentStartup.succeed(agentID)
+	defer svc.AgentStartup.succeed(agentID, handle)
 
 	// Broadcast STARTING so the chat startup banner appears beneath any
 	// just-typed messages while the cold subprocess spins up. Symmetric

--- a/backend/internal/worker/service/agent_auto_start_test.go
+++ b/backend/internal/worker/service/agent_auto_start_test.go
@@ -385,7 +385,8 @@ func TestSendAgentMessage_DuringAnOpenStartupIsDelivered(t *testing.T) {
 	}))
 
 	// Stand in for the open path's in-flight startup.
-	require.NotNil(t, svc.AgentStartup.begin("agent-1", func() {}))
+	openHandle := svc.AgentStartup.begin("agent-1", func() {})
+	require.NotNil(t, openHandle)
 
 	sent := make(chan struct{})
 	go func() {
@@ -405,7 +406,7 @@ func TestSendAgentMessage_DuringAnOpenStartupIsDelivered(t *testing.T) {
 
 	// The open path finishes and hands over its process.
 	svc.AgentStartup.succeed("agent-1")
-	svc.AgentStartup.finish()
+	svc.AgentStartup.finishEntry(openHandle)
 
 	select {
 	case <-sent:

--- a/backend/internal/worker/service/agent_auto_start_test.go
+++ b/backend/internal/worker/service/agent_auto_start_test.go
@@ -405,7 +405,7 @@ func TestSendAgentMessage_DuringAnOpenStartupIsDelivered(t *testing.T) {
 	}
 
 	// The open path finishes and hands over its process.
-	svc.AgentStartup.succeed("agent-1")
+	svc.AgentStartup.succeed("agent-1", nil)
 	svc.AgentStartup.finishEntry(openHandle)
 
 	select {

--- a/backend/internal/worker/service/agent_auto_start_test.go
+++ b/backend/internal/worker/service/agent_auto_start_test.go
@@ -67,6 +67,31 @@ func TestEnsureAgentRunning_SerializesConcurrentColdStarts(t *testing.T) {
 	<-secondDone
 }
 
+func TestEnsureAgentRunning_RefusesArchivedAgent(t *testing.T) {
+	t.Parallel()
+
+	svc, _, _ := setupTestService(t)
+	require.NoError(t, svc.Queries.CreateAgent(t.Context(), db.CreateAgentParams{
+		ID: "agent-archived", WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+	}))
+	_, err := svc.Queries.SetAgentWorkspaceArchived(t.Context(), db.SetAgentWorkspaceArchivedParams{
+		WorkspaceArchived: 1, ID: "agent-archived",
+	})
+	require.NoError(t, err)
+	starts := 0
+	svc.startAgentFn = func(context.Context, agent.Options, agent.OutputSink) (map[string]string, error) {
+		starts++
+		return map[string]string{}, nil
+	}
+
+	err = svc.ensureAgentRunning("agent-archived", nil, interactiveStart)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "archived workspace")
+	assert.Zero(t, starts)
+}
+
 // TestSendAgentMessage_AutoStartBroadcastsStartingDuringEnsureRunning verifies
 // that when SendAgentMessage triggers ensureAgentRunning on an INACTIVE agent
 // (e.g. after a worker/desktop restart that killed the subprocess), the

--- a/backend/internal/worker/service/agent_control_ipc_test.go
+++ b/backend/internal/worker/service/agent_control_ipc_test.go
@@ -728,7 +728,7 @@ func TestEnsureAgentRunning_RefusesWhileAnotherStartupHoldsTheAgent(t *testing.T
 	t.Cleanup(openCancel)
 	openHandle := svc.AgentStartup.begin("agent-1", openCancel)
 	require.NotNil(t, openHandle)
-	t.Cleanup(func() { svc.AgentStartup.finish() })
+	t.Cleanup(func() { svc.AgentStartup.finishEntry(openHandle) })
 
 	errCh := make(chan error, 1)
 	go func() { errCh <- svc.ensureAgentRunning("agent-1", nil, interactiveStart) }()
@@ -794,7 +794,7 @@ func TestEnsureAgentRunning_WaitsForTheStartupThatHoldsTheAgent(t *testing.T) {
 
 	// The open path finishes.
 	svc.AgentStartup.succeed("agent-1")
-	svc.AgentStartup.finish()
+	svc.AgentStartup.finishEntry(openHandle)
 
 	select {
 	case err := <-errCh:
@@ -821,8 +821,9 @@ func TestEnsureAgentRunning_BackgroundStartDoesNotWaitForAnotherStartup(t *testi
 	clock := newFakeStartupClock()
 	svc.AgentStartup.clock = clock
 
-	require.NotNil(t, svc.AgentStartup.begin("agent-1", func() {}))
-	t.Cleanup(func() { svc.AgentStartup.finish() })
+	openHandle := svc.AgentStartup.begin("agent-1", func() {})
+	require.NotNil(t, openHandle)
+	t.Cleanup(func() { svc.AgentStartup.finishEntry(openHandle) })
 
 	require.Error(t, svc.ensureAgentRunning("agent-1", nil, backgroundStart))
 	assert.Empty(t, rec.ids())
@@ -851,8 +852,9 @@ func TestEnsureAgentRunning_RefusesWhenACloseEndedTheStartupItWaitedFor(t *testi
 	svc.AgentStartup.clock = clock
 
 	// Stand in for the open path's in-flight startup.
-	require.NotNil(t, svc.AgentStartup.begin("agent-1", func() {}))
-	t.Cleanup(func() { svc.AgentStartup.finish() })
+	openHandle := svc.AgentStartup.begin("agent-1", func() {})
+	require.NotNil(t, openHandle)
+	t.Cleanup(func() { svc.AgentStartup.finishEntry(openHandle) })
 
 	errCh := make(chan error, 1)
 	go func() { errCh <- svc.ensureAgentRunning("agent-1", nil, interactiveStart) }()

--- a/backend/internal/worker/service/agent_control_ipc_test.go
+++ b/backend/internal/worker/service/agent_control_ipc_test.go
@@ -793,7 +793,7 @@ func TestEnsureAgentRunning_WaitsForTheStartupThatHoldsTheAgent(t *testing.T) {
 	assert.Empty(t, rec.ids(), "it must not spawn a second process for the tab that is already starting")
 
 	// The open path finishes.
-	svc.AgentStartup.succeed("agent-1")
+	svc.AgentStartup.succeed("agent-1", nil)
 	svc.AgentStartup.finishEntry(openHandle)
 
 	select {

--- a/backend/internal/worker/service/agent_resume.go
+++ b/backend/internal/worker/service/agent_resume.go
@@ -53,8 +53,17 @@ type AgentResumer struct {
 	resumeSlots chan struct{}
 }
 
-// NewAgentResumer returns the service's shared resume scheduler.
-func (svc *Service) NewAgentResumer() *AgentResumer {
+// AgentResumer returns the service's shared resume scheduler, building it on
+// the first call. It is an accessor, not a constructor: bootstrap and the
+// unarchive RPC must reach the SAME scheduler, because a second one would
+// carry its own dedup set and its own stop channel, and nothing would ever
+// drain it.
+//
+// The concurrency read stays lazy on purpose. bootstrap calls
+// SetStartupConcurrency after service.New and before it starts the background
+// loops, so a resumer built in service.New would size its semaphore from the
+// manager's default pool instead of the configured value.
+func (svc *Service) AgentResumer() *AgentResumer {
 	svc.resumeSchedulerMu.Lock()
 	defer svc.resumeSchedulerMu.Unlock()
 	if svc.agentResumer == nil {
@@ -73,31 +82,62 @@ func (svc *Service) NewAgentResumer() *AgentResumer {
 	return svc.agentResumer
 }
 
+// claim reserves one agent id against concurrent resume work, and reports
+// whether the caller got it. Both producers -- Schedule and the boot sweep --
+// claim through this one set, so an id that one is already working on is never
+// started twice.
+//
+// It refuses every id once Stop latched, so a claim also answers "may I still
+// start work?".
+//
+// wg, when set, is joined UNDER the same lock that reads r.stopped. That
+// pairing is the whole reason the caller does not add to the group itself:
+// Stop latches r.stopped and then waits on the group, so an Add issued after
+// the lock was released could land after that Wait began -- the WaitGroup
+// misuse that reuse-after-Wait panics on, and, before it panics, a resume the
+// drain does not cover.
+func (r *AgentResumer) claim(agentID string, wg *sync.WaitGroup) bool {
+	if agentID == "" {
+		return false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.stopped {
+		return false
+	}
+	if _, exists := r.scheduled[agentID]; exists {
+		return false
+	}
+	r.scheduled[agentID] = struct{}{}
+	if wg != nil {
+		wg.Add(1)
+	}
+	return true
+}
+
+func (r *AgentResumer) releaseClaim(agentID string) {
+	r.mu.Lock()
+	delete(r.scheduled, agentID)
+	r.mu.Unlock()
+}
+
 // Schedule queues eligible agent rows for a reusable background resume pass.
 // It deduplicates one agent while a prior resume remains in flight.
+//
+// It does NOT block, and it cannot: its callers are the orphan reconciler's
+// single goroutine and an RPC handler, and neither may wait for a provider
+// handshake. resumeSlots is therefore the cap, and one goroutine per claimed
+// id parks on it. The boot sweep wants the opposite -- ordered admission with
+// backpressure at the loop -- so it keeps its own errgroup and shares only the
+// claim.
 func (r *AgentResumer) Schedule(ctx context.Context, agentIDs []string) {
 	for _, agentID := range agentIDs {
-		if agentID == "" || r.stopping() {
+		if !r.claim(agentID, &r.scheduledWG) {
 			continue
 		}
-		r.mu.Lock()
-		if r.stopped {
-			r.mu.Unlock()
-			return
-		}
-		if _, exists := r.scheduled[agentID]; exists {
-			r.mu.Unlock()
-			continue
-		}
-		r.scheduled[agentID] = struct{}{}
-		r.scheduledWG.Add(1)
-		r.mu.Unlock()
-
 		go func() {
 			defer func() {
-				r.mu.Lock()
-				delete(r.scheduled, agentID)
-				r.mu.Unlock()
+				r.releaseClaim(agentID)
 				r.scheduledWG.Done()
 			}()
 			select {
@@ -153,19 +193,17 @@ func (r *AgentResumer) Start(ctx context.Context) {
 // Stop tells the scheduler to accept no more candidates. It waits for the
 // initial sweep and all reusable jobs. A later Start schedules nothing.
 //
-// It DOES wait for the resumes the launcher already handed off, because the
-// sweep joins its own group on every exit. Two facts make that the correct
-// design rather than an expensive one. errgroup.Go blocks the launcher once the
-// fan-out limit is full, so a Stop could never return promptly anyway while a
-// handshake was in flight. And Service.Shutdown waits for exactly the same
-// startups a few lines later through AgentStartup.WaitForInFlight, so joining
-// here costs no additional time -- it only moves the wait earlier, to the point
-// where the sweep can still be observed as running.
+// It DOES wait for the resumes it already accepted -- scheduledWG covers every
+// job from both producers, and the sweep joins its own batch on every exit.
+// Service.Shutdown waits for exactly the same startups a few lines later
+// through AgentStartup.WaitForInFlight, so joining here costs no additional
+// time; it only moves the wait earlier, to the point where the scheduler can
+// still be observed as running.
 //
-// Not joining is what made WaitForInFlight unsafe. The launcher hands a
-// candidate to errgroup.Go, the runtime does not schedule it yet, and it is
-// therefore short of AgentStartup.begin. The drain then saw a zero count and
-// returned, and the straggler read a database the caller was about to close.
+// Not joining is what made WaitForInFlight unsafe. schedule accepts a
+// candidate, the runtime does not start its goroutine yet, and it is therefore
+// short of AgentStartup.begin. The drain then saw a zero count and returned,
+// and the straggler read a database the caller was about to close.
 func (r *AgentResumer) Stop() {
 	r.mu.Lock()
 	if !r.stopped {
@@ -269,6 +307,19 @@ func (r *AgentResumer) sweep(ctx context.Context) {
 		default:
 		}
 		g.Go(func() error {
+			// Claim through the SAME set Schedule uses. The two producers
+			// overlap in production: a pass that unarchives a workspace calls
+			// Schedule for those agents and then reports convergence, which
+			// starts this sweep, whose query selects the rows that pass just
+			// marked active. Without one shared claim each of those agents got
+			// two goroutines, and the loser parked on the per-agent lifecycle
+			// lock for the length of the winner's provider handshake while
+			// holding a permit -- halving the effective resume concurrency on
+			// exactly the boot that needed it most.
+			if !r.claim(id, nil) {
+				return nil
+			}
+			defer r.releaseClaim(id)
 			counts.record(r.resumeOne(ctx, id))
 			return nil
 		})
@@ -424,7 +475,7 @@ func (r *AgentResumer) skipReason(dbAgent db.Agent) resumeSkipReason {
 		return resumeSkipSubagent
 	}
 	// The candidate list is a SNAPSHOT: ListRootAgentIDsForResume ran once, and a
-	// candidate at the back of a throttled queue is reached much later -- minutes,
+	// the sweep reaches a candidate at the back of a throttled queue much later -- minutes,
 	// on a machine with many tabs and a concurrency of 1. A CloseAgent in between
 	// already ran that tab's whole teardown, so a process started for it now is
 	// one nothing will ever stop: it holds a CLI and its memory for the life of

--- a/backend/internal/worker/service/agent_resume.go
+++ b/backend/internal/worker/service/agent_resume.go
@@ -58,7 +58,11 @@ func (svc *Service) NewAgentResumer() *AgentResumer {
 	svc.resumeSchedulerMu.Lock()
 	defer svc.resumeSchedulerMu.Unlock()
 	if svc.agentResumer == nil {
-		limit := svc.Agents.StartupConcurrency()
+		// max(1): a zero capacity makes resumeSlots unbuffered, and no goroutine
+		// ever receives from it, so every scheduled resume would block until Stop.
+		// The manager caps the value at one already; this keeps the deadlock
+		// impossible rather than merely absent today.
+		limit := max(1, svc.Agents.StartupConcurrency())
 		svc.agentResumer = &AgentResumer{
 			svc:         svc,
 			stop:        make(chan struct{}),
@@ -377,6 +381,7 @@ type resumeSkipReason string
 
 const (
 	resumeSkipAlreadyRunning resumeSkipReason = "already running"
+	resumeSkipSubagent       resumeSkipReason = "subagent transcript, which owns no process"
 	resumeSkipClosed         resumeSkipReason = "tab closed since the sweep listed it"
 	resumeSkipStartupFailed  resumeSkipReason = "previous startup failed"
 	resumeSkipArchived       resumeSkipReason = "workspace archived"
@@ -409,7 +414,16 @@ func (r *AgentResumer) skipReason(dbAgent db.Agent) resumeSkipReason {
 	if r.svc.Agents.HasAgent(dbAgent.ID) {
 		return resumeSkipAlreadyRunning
 	}
-	// The candidate list is a SNAPSHOT: ListAllOpenRootAgentIDs ran once, and a
+	// A virtual child agent is a subagent transcript: it has no process of its
+	// own, and ensureAgentRunning refuses one. The boot sweep never lists a
+	// child (its query selects roots), but Schedule takes the tab ids the Hub
+	// fanned out, and a subagent transcript IS a tab in the workspace layout.
+	// Without this the unarchive of a workspace holding one logs a failed start
+	// per subagent tab and spends a startup permit on each.
+	if dbAgent.ParentAgentID.Valid {
+		return resumeSkipSubagent
+	}
+	// The candidate list is a SNAPSHOT: ListRootAgentIDsForResume ran once, and a
 	// candidate at the back of a throttled queue is reached much later -- minutes,
 	// on a machine with many tabs and a concurrency of 1. A CloseAgent in between
 	// already ran that tab's whole teardown, so a process started for it now is

--- a/backend/internal/worker/service/agent_resume.go
+++ b/backend/internal/worker/service/agent_resume.go
@@ -10,8 +10,8 @@ import (
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
 )
 
-// AgentResumer respawns, once per worker process, the agent subprocesses a
-// previous worker process left behind.
+// AgentResumer schedules background agent resumes. It runs one initial sweep
+// after reconciliation and accepts later unarchive transitions.
 //
 // It exists because several agent CLIs can list the agent sessions that run on
 // the same machine and send messages to them. A worker restart kills every
@@ -20,13 +20,12 @@ import (
 // and no amount of waiting fixed it. Respawning the processes is what puts them
 // back in their provider's machine-local view of each other.
 //
-// It is a type rather than a bare method for the same reason OrphanReconciler
-// is: the sweep owns a goroutine and a stop, and both have to be drivable from
-// a test without standing up bootstrap.
+// It is a type rather than a bare method because the scheduler owns goroutines
+// and a stop. Tests can drive both without bootstrap.
 type AgentResumer struct {
 	svc *Service
 
-	// mu guards the three fields below. Start and Stop take it for their WHOLE
+	// mu guards the lifecycle and scheduled-job fields below. Start and Stop take it for their WHOLE
 	// decision, not merely to read a field.
 	//
 	// The two race in production. Shutdown stops the resumer before the
@@ -47,11 +46,67 @@ type AgentResumer struct {
 	// stop closes on Stop and is what makes the launcher give up on the
 	// candidates that it did not reach yet.
 	stop chan struct{}
+	// scheduled contains reusable unarchive jobs. The wait counter increments
+	// before each goroutine starts, so Stop can drain every accepted job.
+	scheduled   map[string]struct{}
+	scheduledWG sync.WaitGroup
+	resumeSlots chan struct{}
 }
 
-// NewAgentResumer builds the boot-time resume sweep for this service.
+// NewAgentResumer returns the service's shared resume scheduler.
 func (svc *Service) NewAgentResumer() *AgentResumer {
-	return &AgentResumer{svc: svc, stop: make(chan struct{})}
+	svc.resumeSchedulerMu.Lock()
+	defer svc.resumeSchedulerMu.Unlock()
+	if svc.agentResumer == nil {
+		limit := svc.Agents.StartupConcurrency()
+		svc.agentResumer = &AgentResumer{
+			svc:         svc,
+			stop:        make(chan struct{}),
+			scheduled:   make(map[string]struct{}),
+			resumeSlots: make(chan struct{}, limit),
+		}
+	}
+	return svc.agentResumer
+}
+
+// Schedule queues eligible agent rows for a reusable background resume pass.
+// It deduplicates one agent while a prior resume remains in flight.
+func (r *AgentResumer) Schedule(ctx context.Context, agentIDs []string) {
+	for _, agentID := range agentIDs {
+		if agentID == "" || r.stopping() {
+			continue
+		}
+		r.mu.Lock()
+		if r.stopped {
+			r.mu.Unlock()
+			return
+		}
+		if _, exists := r.scheduled[agentID]; exists {
+			r.mu.Unlock()
+			continue
+		}
+		r.scheduled[agentID] = struct{}{}
+		r.scheduledWG.Add(1)
+		r.mu.Unlock()
+
+		go func() {
+			defer func() {
+				r.mu.Lock()
+				delete(r.scheduled, agentID)
+				r.mu.Unlock()
+				r.scheduledWG.Done()
+			}()
+			select {
+			case r.resumeSlots <- struct{}{}:
+				defer func() { <-r.resumeSlots }()
+			case <-r.stop:
+				return
+			case <-ctx.Done():
+				return
+			}
+			r.resumeOne(ctx, agentID)
+		}()
+	}
 }
 
 // Start runs the sweep once, in the background. Later calls do nothing, and so
@@ -91,8 +146,8 @@ func (r *AgentResumer) Start(ctx context.Context) {
 	}()
 }
 
-// Stop tells the launcher to reach no further candidates, and waits for the
-// sweep. A Start that arrives afterwards starts nothing.
+// Stop tells the scheduler to accept no more candidates. It waits for the
+// initial sweep and all reusable jobs. A later Start schedules nothing.
 //
 // It DOES wait for the resumes the launcher already handed off, because the
 // sweep joins its own group on every exit. Two facts make that the correct
@@ -115,6 +170,7 @@ func (r *AgentResumer) Stop() {
 	}
 	r.mu.Unlock()
 	r.waitForSweep()
+	r.scheduledWG.Wait()
 }
 
 // waitForSweep blocks until the sweep goroutine returns, or returns at once
@@ -158,7 +214,7 @@ func (r *AgentResumer) stopping() bool {
 // for what that means and for the predicate it deliberately does not use.
 func (r *AgentResumer) sweep(ctx context.Context) {
 	svc := r.svc
-	ids, err := svc.Queries.ListAllOpenRootAgentIDs(ctx)
+	ids, err := svc.Queries.ListRootAgentIDsForResume(ctx)
 	if err != nil {
 		slog.Error("agent resume: list open agents", "error", err)
 		return
@@ -319,17 +375,11 @@ func (r *AgentResumer) resumeOne(ctx context.Context, agentID string) resumeOutc
 // anybody asks of this feature.
 type resumeSkipReason string
 
-// There is deliberately no case for an ARCHIVED workspace, and today there
-// cannot be one: a Worker stores no workspace (see OpenAgentRequest in
-// agent.proto). Archiving a workspace also stops none of its agents, so their
-// rows stay open and this sweep starts every one of them again after a restart.
-// The fix is a design decision -- close the tabs at archive time, or give the
-// Worker the workspace -- and it is tracked in
-// https://github.com/leapmux/leapmux/issues/446.
 const (
 	resumeSkipAlreadyRunning resumeSkipReason = "already running"
 	resumeSkipClosed         resumeSkipReason = "tab closed since the sweep listed it"
 	resumeSkipStartupFailed  resumeSkipReason = "previous startup failed"
+	resumeSkipArchived       resumeSkipReason = "workspace archived"
 	resumeSkipNeverStarted   resumeSkipReason = "never started and not created from a session"
 )
 
@@ -379,6 +429,9 @@ func (r *AgentResumer) skipReason(dbAgent db.Agent) resumeSkipReason {
 	// fail again, and the row already tells the user to open a new agent.
 	if dbAgent.StartupError != "" {
 		return resumeSkipStartupFailed
+	}
+	if dbAgent.WorkspaceArchived != 0 {
+		return resumeSkipArchived
 	}
 	if dbAgent.AgentSessionID == "" && dbAgent.Resumed == 0 {
 		return resumeSkipNeverStarted

--- a/backend/internal/worker/service/agent_resume.go
+++ b/backend/internal/worker/service/agent_resume.go
@@ -474,13 +474,13 @@ func (r *AgentResumer) skipReason(dbAgent db.Agent) resumeSkipReason {
 	if dbAgent.ParentAgentID.Valid {
 		return resumeSkipSubagent
 	}
-	// The candidate list is a SNAPSHOT: ListRootAgentIDsForResume ran once, and a
-	// the sweep reaches a candidate at the back of a throttled queue much later -- minutes,
-	// on a machine with many tabs and a concurrency of 1. A CloseAgent in between
-	// already ran that tab's whole teardown, so a process started for it now is
-	// one nothing will ever stop: it holds a CLI and its memory for the life of
-	// the worker, under a tab no client can see. This row was read AFTER the
-	// list, which is what makes the check worth having.
+	// The candidate list is a SNAPSHOT: ListRootAgentIDsForResume ran once, and
+	// the sweep reaches a candidate at the back of a throttled queue much
+	// later -- minutes, on a machine with many tabs and a concurrency of 1. A
+	// CloseAgent in between already ran that tab's whole teardown, so a process
+	// started for it now is one nothing will ever stop: it holds a CLI and its
+	// memory for the life of the worker, under a tab no client can see. This
+	// row was read AFTER the list, which is what makes the check worth having.
 	//
 	// ensureAgentRunning refuses a closed row as well, under the per-agent
 	// lifecycle lock, which is what closes the window between this read and that

--- a/backend/internal/worker/service/agent_resume_test.go
+++ b/backend/internal/worker/service/agent_resume_test.go
@@ -210,6 +210,50 @@ func TestAgentResume_SkipsSubagentTranscripts(t *testing.T) {
 		"a subagent transcript owns no process, so it must never be a resume candidate")
 }
 
+// TestAgentResume_StopDrainsScheduledWork pins the shutdown half of the
+// reusable scheduler.
+//
+// Shutdown stops the resumer and then closes the worker database. A Stop that
+// returned while a scheduled resume was still in its handshake would leave that
+// goroutine reading a closed handle -- the same hazard the boot sweep joins its
+// errgroup for. Schedule therefore increments the wait counter BEFORE it starts
+// the goroutine, under the same lock that refuses a candidate once stopped, so
+// no job can slip in after Wait begins.
+func TestAgentResume_StopDrainsScheduledWork(t *testing.T) {
+	t.Parallel()
+
+	svc, _, _ := setupTestService(t)
+	recorder := newStartRecorder()
+	recorder.block = make(chan struct{})
+	recorder.install(svc)
+	seedOpenAgent(t, svc, "agent-scheduled", true)
+
+	resumer := svc.NewAgentResumer()
+	resumer.Schedule(t.Context(), []string{"agent-scheduled"})
+	testutil.AssertEventually(t, func() bool { return len(recorder.ids()) == 1 },
+		"the scheduled resume reached the start")
+
+	stopped := make(chan struct{})
+	go func() {
+		resumer.Stop()
+		close(stopped)
+	}()
+	// A window that is too SHORT can only miss a regression here, never invent
+	// one: a correct Stop blocks until the release below, whatever the machine.
+	select {
+	case <-stopped:
+		require.FailNow(t, "Stop returned while a scheduled resume was still running")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(recorder.block)
+	select {
+	case <-stopped:
+	case <-time.After(10 * time.Second):
+		require.FailNow(t, "Stop never returned after the scheduled resume finished")
+	}
+}
+
 // TestAgentResume_UsesTheBackgroundStartPath pins which manager entry point the
 // sweep reaches, which the shared recorder cannot see because it stubs both.
 //

--- a/backend/internal/worker/service/agent_resume_test.go
+++ b/backend/internal/worker/service/agent_resume_test.go
@@ -133,7 +133,7 @@ func seedOpenAgent(t *testing.T, svc *Service, agentID string, used bool) {
 // runSweep starts the resumer and waits for its one sweep to finish.
 func runSweep(t *testing.T, svc *Service) *AgentResumer {
 	t.Helper()
-	r := svc.NewAgentResumer()
+	r := svc.AgentResumer()
 	r.Start(t.Context())
 	r.WaitForSweepForTest()
 	return r
@@ -201,7 +201,7 @@ func TestAgentResume_SkipsSubagentTranscripts(t *testing.T) {
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
 	}))
 
-	resumer := svc.NewAgentResumer()
+	resumer := svc.AgentResumer()
 	t.Cleanup(resumer.Stop)
 	resumer.Schedule(t.Context(), []string{"agent-child", "agent-root"})
 
@@ -210,23 +210,22 @@ func TestAgentResume_SkipsSubagentTranscripts(t *testing.T) {
 		"a subagent transcript owns no process, so it must never be a resume candidate")
 }
 
-// TestNewAgentResumer_IsOneSchedulerPerService pins what makes the drain above
-// cover the RPC path as well as the boot sweep.
+// TestAgentResumer_IsOneSchedulerPerService pins what makes the drain above
+// cover every producer, not just the boot sweep.
 //
 // bootstrap holds the resumer it builds at startup and wires Shutdown to Stop
-// THAT one, while handleSetTabArchiveState asks for a resumer per unarchive
-// request. A fresh instance per call would give the RPC path a scheduler that
-// nothing stops: its goroutines would outlive Shutdown and read a database that
-// Shutdown closed. Nothing else in the wiring says the two must be the same
-// object, so it is stated here.
-func TestNewAgentResumer_IsOneSchedulerPerService(t *testing.T) {
+// THAT one. A fresh instance per call would give a later caller a scheduler
+// that nothing stops: its goroutines would outlive Shutdown and read a database
+// that Shutdown closed. Nothing else in the wiring says every caller must get
+// the same object, so it is stated here.
+func TestAgentResumer_IsOneSchedulerPerService(t *testing.T) {
 	t.Parallel()
 
 	svc, _, _ := setupTestService(t)
-	first := svc.NewAgentResumer()
+	first := svc.AgentResumer()
 	t.Cleanup(first.Stop)
 
-	assert.Same(t, first, svc.NewAgentResumer(),
+	assert.Same(t, first, svc.AgentResumer(),
 		"bootstrap stops the resumer it built; a second instance would never be drained")
 }
 
@@ -248,7 +247,7 @@ func TestAgentResume_StopDrainsScheduledWork(t *testing.T) {
 	recorder.install(svc)
 	seedOpenAgent(t, svc, "agent-scheduled", true)
 
-	resumer := svc.NewAgentResumer()
+	resumer := svc.AgentResumer()
 	resumer.Schedule(t.Context(), []string{"agent-scheduled"})
 	testutil.AssertEventually(t, func() bool { return len(recorder.ids()) == 1 },
 		"the scheduled resume reached the start")
@@ -416,7 +415,7 @@ func TestAgentResume_RootsTheProcessContextOutsideTheSweep(t *testing.T) {
 	seedOpenAgent(t, svc, "agent-1", true)
 
 	sweepCtx, cancelSweep := context.WithCancel(context.Background())
-	r := svc.NewAgentResumer()
+	r := svc.AgentResumer()
 	r.Start(sweepCtx)
 	r.WaitForSweepForTest()
 	require.Equal(t, []string{"agent-1"}, rec.ids())
@@ -604,7 +603,7 @@ func TestAgentResume_ACloseCancelsAnInFlightResume(t *testing.T) {
 	rec.install(svc)
 	seedOpenAgent(t, svc, "agent-1", true)
 
-	r := svc.NewAgentResumer()
+	r := svc.AgentResumer()
 	r.Start(t.Context())
 	require.Eventually(t, func() bool { return rec.inFlight.Load() == 1 }, 5*time.Second, 5*time.Millisecond,
 		"the resume never reached its start")
@@ -800,7 +799,7 @@ func TestAgentResume_WaitsForAWorkerOwner(t *testing.T) {
 	// setupTestService seeds an owner; clear it to model a worker whose Hub has
 	// not delivered WorkerIdentity yet.
 	svc.registeredBy.Store(&userid.UserID{})
-	r := svc.NewAgentResumer()
+	r := svc.AgentResumer()
 	r.Start(t.Context())
 	r.WaitForSweepForTest()
 	require.Empty(t, rec.ids(), "no owner means no control socket, so no resume")
@@ -842,7 +841,7 @@ func TestAgentResume_SweepsOnlyOnce(t *testing.T) {
 	rec.install(svc)
 	seedOpenAgent(t, svc, "agent-1", true)
 
-	r := svc.NewAgentResumer()
+	r := svc.AgentResumer()
 	r.Start(t.Context())
 	r.Start(t.Context())
 	r.WaitForSweepForTest()
@@ -869,7 +868,7 @@ func TestAgentResume_LimitsItsOwnFanOut(t *testing.T) {
 	seedOpenAgent(t, svc, "agent-a", true)
 	seedOpenAgent(t, svc, "agent-b", true)
 
-	r := svc.NewAgentResumer()
+	r := svc.AgentResumer()
 	r.Start(t.Context())
 
 	// Wait for the first resume to park inside its start, then prove no second
@@ -944,7 +943,7 @@ func TestAgentResume_StopAbandonsTheRemainingCandidates(t *testing.T) {
 		seedOpenAgent(t, svc, id, true)
 	}
 
-	r := svc.NewAgentResumer()
+	r := svc.AgentResumer()
 	r.Start(t.Context())
 	// Wait until the first resume is parked inside its start, so the launcher is
 	// definitely past the loop's stop check for that candidate and blocked on the
@@ -1005,7 +1004,7 @@ func TestAgentResume_SweepDoesNotReturnWhileAResumeIsInFlight(t *testing.T) {
 		return fetch(ctx, agentID)
 	}
 
-	r := svc.NewAgentResumer()
+	r := svc.AgentResumer()
 	r.Start(t.Context())
 	require.Equal(t, "agent-a", <-entered, "the sweep never reached its first candidate")
 
@@ -1042,7 +1041,7 @@ func TestAgentResume_AResumeAdmittedBeforeStopDoesNoWorkAfterIt(t *testing.T) {
 	rec.install(svc)
 	seedOpenAgent(t, svc, "agent-1", true)
 
-	r := svc.NewAgentResumer()
+	r := svc.AgentResumer()
 	reads := 0
 	fetch := svc.getAgentByIDFn
 	svc.getAgentByIDFn = func(ctx context.Context, agentID string) (db.Agent, error) {
@@ -1093,7 +1092,7 @@ func TestAgentResume_ACancelledSweepReportsItsOutcome(t *testing.T) {
 	}
 
 	sweepCtx, cancelSweep := context.WithCancel(context.Background())
-	r := svc.NewAgentResumer()
+	r := svc.AgentResumer()
 	r.Start(sweepCtx)
 	// Both slots are taken. Which two candidates got them does not matter; that
 	// the launcher is parked handing off the third does.
@@ -1128,7 +1127,7 @@ func TestAgentResume_StartAfterStopLaunchesNoSweep(t *testing.T) {
 	rec.install(svc)
 	seedOpenAgent(t, svc, "agent-1", true)
 
-	r := svc.NewAgentResumer()
+	r := svc.AgentResumer()
 	r.Stop()
 	r.Start(t.Context())
 
@@ -1147,7 +1146,7 @@ func TestAgentResume_StopBeforeTheSweepIsRunNeverBlocks(t *testing.T) {
 	t.Parallel()
 
 	svc, _, _ := setupTestService(t)
-	r := svc.NewAgentResumer()
+	r := svc.AgentResumer()
 	done := make(chan struct{})
 	go func() { defer close(done); r.Stop(); r.Stop() }()
 	select {

--- a/backend/internal/worker/service/agent_resume_test.go
+++ b/backend/internal/worker/service/agent_resume_test.go
@@ -175,6 +175,41 @@ func TestAgentResume_SkipsArchivedAgents(t *testing.T) {
 	assert.Empty(t, recorder.ids())
 }
 
+// TestAgentResume_SkipsSubagentTranscripts covers the candidate the BOOT sweep
+// cannot produce and the unarchive fan-out can.
+//
+// The sweep's own query selects roots, so a child never reaches it from there.
+// Schedule takes the tab ids the Hub listed for the workspace, and a subagent
+// transcript IS a tab in that layout -- so unarchiving a workspace that holds
+// one hands this scheduler an agent that owns no process. ensureAgentRunning
+// refuses it, which would spend a startup permit and log a failed start per
+// subagent tab.
+func TestAgentResume_SkipsSubagentTranscripts(t *testing.T) {
+	t.Parallel()
+
+	svc, _, _ := setupTestService(t)
+	recorder := newStartRecorder()
+	recorder.install(svc)
+	seedOpenAgent(t, svc, "agent-root", true)
+	require.NoError(t, svc.Queries.CreateChildAgent(t.Context(), db.CreateChildAgentParams{
+		ID:            "agent-child",
+		ParentAgentID: sql.NullString{String: "agent-root", Valid: true},
+		SpawnSpanID:   "span-1",
+		Title:         "child task",
+		WorkingDir:    t.TempDir(),
+		HomeDir:       t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+	}))
+
+	resumer := svc.NewAgentResumer()
+	t.Cleanup(resumer.Stop)
+	resumer.Schedule(t.Context(), []string{"agent-child", "agent-root"})
+
+	testutil.AssertEventually(t, func() bool { return len(recorder.ids()) == 1 }, "the root resumes")
+	assert.Equal(t, []string{"agent-root"}, recorder.ids(),
+		"a subagent transcript owns no process, so it must never be a resume candidate")
+}
+
 // TestAgentResume_UsesTheBackgroundStartPath pins which manager entry point the
 // sweep reaches, which the shared recorder cannot see because it stubs both.
 //

--- a/backend/internal/worker/service/agent_resume_test.go
+++ b/backend/internal/worker/service/agent_resume_test.go
@@ -210,6 +210,26 @@ func TestAgentResume_SkipsSubagentTranscripts(t *testing.T) {
 		"a subagent transcript owns no process, so it must never be a resume candidate")
 }
 
+// TestNewAgentResumer_IsOneSchedulerPerService pins what makes the drain above
+// cover the RPC path as well as the boot sweep.
+//
+// bootstrap holds the resumer it builds at startup and wires Shutdown to Stop
+// THAT one, while handleSetTabArchiveState asks for a resumer per unarchive
+// request. A fresh instance per call would give the RPC path a scheduler that
+// nothing stops: its goroutines would outlive Shutdown and read a database that
+// Shutdown closed. Nothing else in the wiring says the two must be the same
+// object, so it is stated here.
+func TestNewAgentResumer_IsOneSchedulerPerService(t *testing.T) {
+	t.Parallel()
+
+	svc, _, _ := setupTestService(t)
+	first := svc.NewAgentResumer()
+	t.Cleanup(first.Stop)
+
+	assert.Same(t, first, svc.NewAgentResumer(),
+		"bootstrap stops the resumer it built; a second instance would never be drained")
+}
+
 // TestAgentResume_StopDrainsScheduledWork pins the shutdown half of the
 // reusable scheduler.
 //

--- a/backend/internal/worker/service/agent_resume_test.go
+++ b/backend/internal/worker/service/agent_resume_test.go
@@ -157,6 +157,24 @@ func TestAgentResume_RestoresUsedAgents(t *testing.T) {
 	assert.Equal(t, []string{"agent-resumed"}, rec.ids())
 }
 
+func TestAgentResume_SkipsArchivedAgents(t *testing.T) {
+	t.Parallel()
+
+	svc, _, _ := setupTestService(t)
+	recorder := newStartRecorder()
+	recorder.install(svc)
+	seedOpenAgent(t, svc, "agent-archived", true)
+	_, err := svc.Queries.SetAgentWorkspaceArchived(t.Context(), db.SetAgentWorkspaceArchivedParams{
+		WorkspaceArchived: 1,
+		ID:                "agent-archived",
+	})
+	require.NoError(t, err)
+
+	runSweep(t, svc)
+
+	assert.Empty(t, recorder.ids())
+}
+
 // TestAgentResume_UsesTheBackgroundStartPath pins which manager entry point the
 // sweep reaches, which the shared recorder cannot see because it stubs both.
 //

--- a/backend/internal/worker/service/close_during_startup_test.go
+++ b/backend/internal/worker/service/close_during_startup_test.go
@@ -510,6 +510,46 @@ func TestFailStartup_UncontestedFailureStillRollsBack(t *testing.T) {
 	assert.False(t, localBranchExists(t, repoDir, branchName), "and delete the branch it created")
 }
 
+func TestFailStartup_ArchiveRollsBackOnlyIncompleteGitMutation(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		name           string
+		phase0Complete bool
+		wantRemoved    bool
+	}{
+		{name: "incomplete", wantRemoved: true},
+		{name: "complete", phase0Complete: true, wantRemoved: false},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			svc, _, _ := setupTestService(t)
+			repoDir := testutil.NewGitRepo(t)
+			gm := createWorktreeForTest(t, svc, repoDir, "feat/archive-"+testCase.name)
+			dbAgent := createAgentRowForTest(t, svc, gm.WorkingDir)
+			handle := svc.AgentStartup.begin(dbAgent.ID, func() {})
+			require.NotNil(t, handle)
+			if testCase.phase0Complete {
+				svc.linkWorktreeAfterPhase0(&svc.AgentStartup.startupCore, handle, gm.WorktreeID,
+					leapmuxv1.TabType_TAB_TYPE_AGENT, dbAgent.ID, false)
+			}
+			svc.AgentStartup.cancelForArchive(dbAgent.ID)
+
+			svc.failAgentStartup(&dbAgent, gm, context.Canceled, nil, handle)
+			svc.AgentStartup.finishEntry(handle)
+
+			_, statErr := os.Stat(gm.Rollback.CreatedWorktree.WorktreePath)
+			if testCase.wantRemoved {
+				assert.True(t, os.IsNotExist(statErr), "an incomplete archive startup must roll back")
+				return
+			}
+			assert.NoError(t, statErr, "a completed worktree association must survive archive")
+			links, err := svc.Queries.CountWorktreeTabs(context.Background(), gm.WorktreeID)
+			require.NoError(t, err)
+			assert.Equal(t, int64(1), links)
+		})
+	}
+}
+
 // createWorktreeForTest runs the real create-worktree git mode and returns its
 // result, so the rollback metadata under test is the metadata production
 // builds rather than a hand-assembled struct.

--- a/backend/internal/worker/service/close_during_startup_test.go
+++ b/backend/internal/worker/service/close_during_startup_test.go
@@ -478,7 +478,7 @@ func TestFailStartup_KeepCloseLeavesWorktreeAlone(t *testing.T) {
 				_, wtErr := svc.Queries.GetWorktreeByPath(ctx, gm.Rollback.CreatedWorktree.WorktreePath)
 				assert.NoError(t, wtErr, "the tracked worktree row must survive")
 			}
-			svc.AgentStartup.finish()
+			svc.AgentStartup.finishEntry(h)
 		})
 	}
 }

--- a/backend/internal/worker/service/orphan_reconciler.go
+++ b/backend/internal/worker/service/orphan_reconciler.go
@@ -68,9 +68,6 @@ type OrphanReconciler struct {
 	// the hub's owned-tab list. A tab must stay absent for tabGrace before any
 	// case tears it down. See orphanTabGrace for the size of that window.
 	prevOrphanTabs map[ownedTabKey]time.Time
-	// pendingResumeAgents retains active transitions until a complete pass can
-	// schedule them without racing an orphan close from that pass.
-	pendingResumeAgents map[string]struct{}
 	// tabGrace is orphanTabGrace unless a caller overrode it.
 	tabGrace time.Duration
 }
@@ -114,8 +111,9 @@ type OrphanReconcilerOptions struct {
 	// exactly the divergent close path this change set out to remove.
 	CloseTab func(tabType leapmuxv1.TabType, userID, tabID string)
 	// ApplyArchiveState applies grouped authoritative tab states. Production
-	// wires it to Service.applyTabArchiveState, the same implementation as the
-	// direct SetTabArchiveState RPC. It is required when listFn is set.
+	// wires it to Service.ApplyTabArchiveState, which is the ONLY way this
+	// Worker learns its archive state -- there is no RPC for it. Required when
+	// listFn is set.
 	ApplyArchiveState func(context.Context, leapmuxv1.WorkspaceArchiveState, []*leapmuxv1.TabRef) ([]string, error)
 	// ResumeAgents schedules agent IDs only after the whole pass converges. It
 	// is required when listFn is set.
@@ -186,7 +184,6 @@ func NewOrphanReconciler(queries *db.Queries, listFn func(ctx context.Context) (
 		onConverged:         opts.OnConverged,
 		prevOrphanWorktrees: make(map[string]time.Time),
 		prevOrphanTabs:      make(map[ownedTabKey]time.Time),
-		pendingResumeAgents: make(map[string]struct{}),
 		tabGrace:            opts.TabGrace,
 	}
 }
@@ -384,45 +381,45 @@ func (r *OrphanReconciler) reconcileOnce(ctx context.Context) bool {
 	// hooks, and the listFn == nil case returned above -- so reaching here means
 	// both are set. A nil check would read as "the hooks are optional", which is
 	// the opposite of what the constructor enforces.
-	byState := map[leapmuxv1.WorkspaceArchiveState][]*leapmuxv1.TabRef{
-		leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ACTIVE:   nil,
-		leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED: nil,
-	}
+	//
+	// A row this Worker cannot classify DROPS OUT of the archive pass and keeps
+	// the rest of the pass. It must not fail the pass: the archive step runs
+	// before all three local legs, so one such row would stop every tab reap,
+	// every worktree reap, and -- because OnConverged never fires -- the boot
+	// agent-resume sweep, on every pass for the life of the process. This
+	// matches closeTabForConvergence, which warns and continues for a tab type
+	// it does not know. The reap loops below key on (tab_type, tab_id), so a
+	// dropped row simply never matches, exactly as before the archive pass
+	// existed.
+	var archivedTabs, activeTabs []*leapmuxv1.TabRef
 	for _, tab := range hubTabs {
-		state := tab.GetArchiveState()
-		if state != leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ACTIVE &&
-			state != leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED {
-			r.logger.Warn("orphan reconciler: hub returned an unspecified archive state",
-				"tab_id", tab.GetTabId())
-			return false
-		}
-		byState[state] = append(byState[state], &leapmuxv1.TabRef{
-			TabType: tab.GetTabType(),
-			TabId:   tab.GetTabId(),
-		})
-	}
-	for _, state := range []leapmuxv1.WorkspaceArchiveState{
-		leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED,
-		leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ACTIVE,
-	} {
-		if len(byState[state]) == 0 {
+		if !archivableTabType(tab.GetTabType()) {
+			r.logger.Warn("orphan reconciler: hub returned a tab type this worker cannot archive",
+				"tab_id", tab.GetTabId(), "tab_type", tab.GetTabType())
 			continue
 		}
-		resumeAgentIDs, err := r.applyArchiveState(ctx, state, byState[state])
-		if err != nil {
-			r.logger.Warn("orphan reconciler: apply archive state", "state", state, "error", err)
-			return false
+		ref := &leapmuxv1.TabRef{TabType: tab.GetTabType(), TabId: tab.GetTabId()}
+		switch tab.GetArchiveState() {
+		case leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED:
+			archivedTabs = append(archivedTabs, ref)
+		case leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ACTIVE:
+			activeTabs = append(activeTabs, ref)
+		case leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_UNSPECIFIED:
+			r.logger.Warn("orphan reconciler: hub returned an unspecified archive state",
+				"tab_id", tab.GetTabId())
+		default:
+			r.logger.Warn("orphan reconciler: hub returned an unknown archive state",
+				"tab_id", tab.GetTabId(), "archive_state", tab.GetArchiveState())
 		}
-		for _, agentID := range resumeAgentIDs {
-			r.pendingResumeAgents[agentID] = struct{}{}
-		}
-		if state == leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED {
-			for _, tab := range byState[state] {
-				if tab.GetTabType() == leapmuxv1.TabType_TAB_TYPE_AGENT {
-					delete(r.pendingResumeAgents, tab.GetTabId())
-				}
-			}
-		}
+	}
+	// Each tab lands in exactly one bucket, so the order of these two calls
+	// does not decide any tab's outcome. Archived runs first only so that a
+	// pass which stops processes does that before it schedules any resume.
+	if !r.applyArchiveBucket(ctx, leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED, archivedTabs) {
+		return false
+	}
+	if !r.applyArchiveBucket(ctx, leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ACTIVE, activeTabs) {
+		return false
 	}
 	hubByKey := make(map[ownedTabKey]*leapmuxv1.WorkerTabState, len(hubTabs))
 	for _, t := range hubTabs {
@@ -436,34 +433,23 @@ func (r *OrphanReconciler) reconcileOnce(ctx context.Context) bool {
 	// mint gate above.
 	now := r.now()
 	next := make(map[ownedTabKey]time.Time)
-	localReconciled := r.reconcileTabPayloads(ctx, hubByKey, owner, now, next)
-	if !r.reconcileAgents(ctx, hubByKey, now, next) {
-		localReconciled = false
-	}
-	if !r.reconcileTerminals(ctx, hubByKey, now, next) {
-		localReconciled = false
-	}
-	if !localReconciled {
+	// Three named results, not an accumulator: every leg must RUN, so the
+	// conjunction cannot short-circuit, and naming them keeps that visible.
+	okPayloads := r.reconcileTabPayloads(ctx, hubByKey, owner, now, next)
+	okAgents := r.reconcileAgents(ctx, hubByKey, now, next)
+	okTerminals := r.reconcileTerminals(ctx, hubByKey, now, next)
+	if localReconciled := okPayloads && okAgents && okTerminals; !localReconciled {
 		converged = false
 	} else {
 		// Replace the clock map only after all three local reads succeed. A
 		// partial read cannot prove that an omitted clock should reset.
 		r.prevOrphanTabs = next
-	}
-	if localReconciled && len(next) > 0 {
-		// A deferred reap is unfinished business, not convergence. Report it so
-		// Run re-arms its retry backoff and a later pass does the teardown,
-		// instead of leaving it to the hourly tick.
-		converged = false
-	}
-	if converged && len(r.pendingResumeAgents) > 0 {
-		agentIDs := make([]string, 0, len(r.pendingResumeAgents))
-		for agentID := range r.pendingResumeAgents {
-			agentIDs = append(agentIDs, agentID)
+		if len(next) > 0 {
+			// A deferred reap is unfinished business, not convergence. Report it
+			// so Run re-arms its retry backoff and a later pass does the
+			// teardown, instead of leaving it to the hourly tick.
+			converged = false
 		}
-		sort.Strings(agentIDs)
-		clear(r.pendingResumeAgents)
-		r.resumeAgents(agentIDs)
 	}
 	return converged
 }
@@ -522,6 +508,36 @@ func (r *OrphanReconciler) hasAnyLocalRows(ctx context.Context) (has, ok bool) {
 		ok = false
 	}
 	return len(payloadRows) > 0 || len(agentIDs) > 0 || len(terminalIDs) > 0, ok
+}
+
+// applyArchiveBucket applies one archive state to the tabs the Hub reports in
+// it, and records the agents whose state changed to active. It reports whether
+// the pass may continue.
+func (r *OrphanReconciler) applyArchiveBucket(ctx context.Context, state leapmuxv1.WorkspaceArchiveState, tabs []*leapmuxv1.TabRef) bool {
+	if len(tabs) == 0 {
+		return true
+	}
+	resumeAgentIDs, err := r.applyArchiveState(ctx, state, tabs)
+	if err != nil {
+		r.logger.Warn("orphan reconciler: apply archive state", "state", state, "error", err)
+		return false
+	}
+	// Scheduled HERE, not held until the pass converges.
+	//
+	// The hold was there to keep a resume from racing an orphan close in the
+	// same pass, and it cannot: this list and the reap set are disjoint by
+	// construction. Both derive from the SAME hub response -- these ids come
+	// from tabs the hub listed, and reconcileAgents reaps only ids ABSENT from
+	// that listing. So no id can be in both.
+	//
+	// Holding them cost a delay on every unarchive, because any unrelated tab
+	// inside its orphan grace window keeps the pass non-converged. It also
+	// could not be re-driven: the flag write is an edge (`workspace_archived
+	// <> ?`), so once the row reached its new value no later pass produced the
+	// id again.
+	sort.Strings(resumeAgentIDs)
+	r.resumeAgents(resumeAgentIDs)
+	return true
 }
 
 // reconcileWorktrees reclaims worktrees whose tab links are all

--- a/backend/internal/worker/service/orphan_reconciler.go
+++ b/backend/internal/worker/service/orphan_reconciler.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"log/slog"
+	"sort"
 	"time"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
@@ -52,6 +53,10 @@ type OrphanReconciler struct {
 	// (closeTabForConvergence), and splitting it here meant every caller restated
 	// which policy each type gets.
 	closeTab func(tabType leapmuxv1.TabType, userID, tabID string)
+	// applyArchiveState reconciles the Hub's lifecycle state before the pass
+	// reports convergence and before the initial agent resume sweep can start.
+	applyArchiveState func(context.Context, leapmuxv1.WorkspaceArchiveState, []*leapmuxv1.TabRef) ([]string, error)
+	resumeAgents      func([]string)
 	// onConverged reports a CONVERGED pass to the caller. Nil disables the report.
 	onConverged func()
 	// prevOrphanWorktrees maps a worktree id to when it FIRST looked orphaned. A
@@ -63,13 +68,16 @@ type OrphanReconciler struct {
 	// the hub's owned-tab list. A tab must stay absent for tabGrace before any
 	// case tears it down. See orphanTabGrace for the size of that window.
 	prevOrphanTabs map[ownedTabKey]time.Time
+	// pendingResumeAgents retains active transitions until a complete pass can
+	// schedule them without racing an orphan close from that pass.
+	pendingResumeAgents map[string]struct{}
 	// tabGrace is orphanTabGrace unless a caller overrode it.
 	tabGrace time.Duration
 }
 
 // OrphanReconcilerOptions configures NewOrphanReconciler.
 //
-// The three Close*Tab hooks are required; everything else has a default. There
+// CloseTab is required. The archive hooks are required when listFn is set. There
 // are no longer separate Agents / Terminals process-stopper hooks: stopping the
 // subprocess is part of the shared per-type teardown the Close*Tab hooks run, so
 // a caller cannot wire one without the other.
@@ -105,6 +113,13 @@ type OrphanReconcilerOptions struct {
 	// manager entry per reap. A tier that exists only for test convenience is
 	// exactly the divergent close path this change set out to remove.
 	CloseTab func(tabType leapmuxv1.TabType, userID, tabID string)
+	// ApplyArchiveState applies grouped authoritative tab states. Production
+	// wires it to Service.applyTabArchiveState, the same implementation as the
+	// direct SetTabArchiveState RPC. It is required when listFn is set.
+	ApplyArchiveState func(context.Context, leapmuxv1.WorkspaceArchiveState, []*leapmuxv1.TabRef) ([]string, error)
+	// ResumeAgents schedules agent IDs only after the whole pass converges. It
+	// is required when listFn is set.
+	ResumeAgents func([]string)
 	// OnConverged, when set, is called after every pass that CONVERGED (see
 	// reconcileOnce). It is the ONE place a caller learns that this worker's
 	// local rows now agree with the hub, which is the precondition the boot-time
@@ -152,6 +167,9 @@ func NewOrphanReconciler(queries *db.Queries, listFn func(ctx context.Context) (
 		panic("service: NewOrphanReconciler requires CloseTab" +
 			" (the offline teardown must be the same one an online close runs)")
 	}
+	if listFn != nil && (nilcheck.IsNilDependency(opts.ApplyArchiveState) || nilcheck.IsNilDependency(opts.ResumeAgents)) {
+		panic("service: NewOrphanReconciler requires archive-state apply and resume hooks when it reads Hub tab state")
+	}
 	return &OrphanReconciler{
 		queries:             queries,
 		listFn:              listFn,
@@ -163,9 +181,12 @@ func NewOrphanReconciler(queries *db.Queries, listFn func(ctx context.Context) (
 		logger:              opts.Logger,
 		reapWorktree:        opts.ReapWorktree,
 		closeTab:            opts.CloseTab,
+		applyArchiveState:   opts.ApplyArchiveState,
+		resumeAgents:        opts.ResumeAgents,
 		onConverged:         opts.OnConverged,
 		prevOrphanWorktrees: make(map[string]time.Time),
 		prevOrphanTabs:      make(map[ownedTabKey]time.Time),
+		pendingResumeAgents: make(map[string]struct{}),
 		tabGrace:            opts.TabGrace,
 	}
 }
@@ -355,11 +376,53 @@ func (r *OrphanReconciler) reconcileOnce(ctx context.Context) bool {
 		// every absence below would be an unfounded reap. Nothing to do: a
 		// response with no owner is not one we can attribute any row to.
 		r.logger.Warn("orphan reconciler: hub response declares no owner scope; skipping this pass",
-			"hub_tabs", len(resp.GetTabs()))
+			"hub_tabs", len(resp.GetTabStates()))
 		return false
 	}
-	hubTabs := resp.GetTabs()
-	hubByKey := make(map[ownedTabKey]*leapmuxv1.OwnedTab, len(hubTabs))
+	hubTabs := resp.GetTabStates()
+	if r.applyArchiveState != nil {
+		byState := map[leapmuxv1.WorkspaceArchiveState][]*leapmuxv1.TabRef{
+			leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ACTIVE:   nil,
+			leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED: nil,
+		}
+		for _, tab := range hubTabs {
+			state := tab.GetArchiveState()
+			if state != leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ACTIVE &&
+				state != leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED {
+				r.logger.Warn("orphan reconciler: hub returned an unspecified archive state",
+					"tab_id", tab.GetTabId())
+				return false
+			}
+			byState[state] = append(byState[state], &leapmuxv1.TabRef{
+				TabType: tab.GetTabType(),
+				TabId:   tab.GetTabId(),
+			})
+		}
+		for _, state := range []leapmuxv1.WorkspaceArchiveState{
+			leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED,
+			leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ACTIVE,
+		} {
+			if len(byState[state]) == 0 {
+				continue
+			}
+			resumeAgentIDs, err := r.applyArchiveState(ctx, state, byState[state])
+			if err != nil {
+				r.logger.Warn("orphan reconciler: apply archive state", "state", state, "error", err)
+				return false
+			}
+			for _, agentID := range resumeAgentIDs {
+				r.pendingResumeAgents[agentID] = struct{}{}
+			}
+			if state == leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED {
+				for _, tab := range byState[state] {
+					if tab.GetTabType() == leapmuxv1.TabType_TAB_TYPE_AGENT {
+						delete(r.pendingResumeAgents, tab.GetTabId())
+					}
+				}
+			}
+		}
+	}
+	hubByKey := make(map[ownedTabKey]*leapmuxv1.WorkerTabState, len(hubTabs))
 	for _, t := range hubTabs {
 		hubByKey[newOwnedTabKey(t.GetTabType(), t.GetTabId(), t.GetUserId())] = t
 	}
@@ -371,18 +434,34 @@ func (r *OrphanReconciler) reconcileOnce(ctx context.Context) bool {
 	// mint gate above.
 	now := r.now()
 	next := make(map[ownedTabKey]time.Time)
-	r.reconcileTabPayloads(ctx, hubByKey, owner, now, next)
-	r.reconcileAgents(ctx, hubByKey, now, next)
-	r.reconcileTerminals(ctx, hubByKey, now, next)
-	// Assigned ONLY here, on the path where all three cases ran. Every early
-	// return above learned nothing about absence, so overwriting the map there
-	// would restart each tab's clock and defeat the grace.
-	r.prevOrphanTabs = next
-	if len(next) > 0 {
+	localReconciled := r.reconcileTabPayloads(ctx, hubByKey, owner, now, next)
+	if !r.reconcileAgents(ctx, hubByKey, now, next) {
+		localReconciled = false
+	}
+	if !r.reconcileTerminals(ctx, hubByKey, now, next) {
+		localReconciled = false
+	}
+	if !localReconciled {
+		converged = false
+	} else {
+		// Replace the clock map only after all three local reads succeed. A
+		// partial read cannot prove that an omitted clock should reset.
+		r.prevOrphanTabs = next
+	}
+	if localReconciled && len(next) > 0 {
 		// A deferred reap is unfinished business, not convergence. Report it so
 		// Run re-arms its retry backoff and a later pass does the teardown,
 		// instead of leaving it to the hourly tick.
 		converged = false
+	}
+	if converged && len(r.pendingResumeAgents) > 0 {
+		agentIDs := make([]string, 0, len(r.pendingResumeAgents))
+		for agentID := range r.pendingResumeAgents {
+			agentIDs = append(agentIDs, agentID)
+		}
+		sort.Strings(agentIDs)
+		clear(r.pendingResumeAgents)
+		r.resumeAgents(agentIDs)
 	}
 	return converged
 }
@@ -520,11 +599,11 @@ func (r *OrphanReconciler) reconcileWorktrees(ctx context.Context) bool {
 // and stating that at the destructive line is what keeps a future reader from
 // widening the read and silently widening the reap with it. Pinned by
 // TestOrphanReconciler_FileTab_SharedTabIDStaysWithItsOwner.
-func (r *OrphanReconciler) reconcileTabPayloads(ctx context.Context, hubByKey map[ownedTabKey]*leapmuxv1.OwnedTab, owner userid.UserID, now time.Time, next map[ownedTabKey]time.Time) {
+func (r *OrphanReconciler) reconcileTabPayloads(ctx context.Context, hubByKey map[ownedTabKey]*leapmuxv1.WorkerTabState, owner userid.UserID, now time.Time, next map[ownedTabKey]time.Time) bool {
 	rows, err := r.queries.ListAllWorkerTabPayloads(ctx)
 	if err != nil {
 		r.logger.Warn("orphan reconciler: list worker_tab_payloads", "err", err)
-		return
+		return false
 	}
 	for _, row := range rows {
 		// The row's OWN kind, not a constant: one table now holds both FILE and
@@ -581,11 +660,12 @@ func (r *OrphanReconciler) reconcileTabPayloads(ctx context.Context, hubByKey ma
 			r.closeTab(tabType, row.UserID, row.TabID)
 		}
 	}
+	return true
 }
 
 // reconcileAgents iterates every locally-known agent and absorbs the
 // hub's view: hub-absent -> stop the subprocess and close the row locally.
-func (r *OrphanReconciler) reconcileAgents(ctx context.Context, hubByKey map[ownedTabKey]*leapmuxv1.OwnedTab, now time.Time, next map[ownedTabKey]time.Time) {
+func (r *OrphanReconciler) reconcileAgents(ctx context.Context, hubByKey map[ownedTabKey]*leapmuxv1.WorkerTabState, now time.Time, next map[ownedTabKey]time.Time) bool {
 	// OPEN rows only. A closed row has already been torn down, so comparing it
 	// against the hub's live list only re-ran the full teardown -- cancelAndClear,
 	// StopAgent, ClearAgentRuntimeState, the registered cleanups -- and re-logged
@@ -601,7 +681,7 @@ func (r *OrphanReconciler) reconcileAgents(ctx context.Context, hubByKey map[own
 	rows, err := r.queries.ListAllOpenRootAgentIDs(ctx)
 	if err != nil {
 		r.logger.Warn("orphan reconciler: list agents", "err", err)
-		return
+		return false
 	}
 	for _, agentID := range rows {
 		k := newOwnedTabKey(leapmuxv1.TabType_TAB_TYPE_AGENT, agentID, "")
@@ -639,15 +719,16 @@ func (r *OrphanReconciler) reconcileAgents(ctx context.Context, hubByKey map[own
 			r.logger.Info("orphan reconciler: closed stale agent", "agent_id", agentID)
 		}
 	}
+	return true
 }
 
 // reconcileTerminals does the same for terminals.
-func (r *OrphanReconciler) reconcileTerminals(ctx context.Context, hubByKey map[ownedTabKey]*leapmuxv1.OwnedTab, now time.Time, next map[ownedTabKey]time.Time) {
+func (r *OrphanReconciler) reconcileTerminals(ctx context.Context, hubByKey map[ownedTabKey]*leapmuxv1.WorkerTabState, now time.Time, next map[ownedTabKey]time.Time) bool {
 	// OPEN rows only, for the same reasons as reconcileAgents.
 	rows, err := r.queries.ListAllOpenTerminalIDs(ctx)
 	if err != nil {
 		r.logger.Warn("orphan reconciler: list terminals", "err", err)
-		return
+		return false
 	}
 	for _, row := range rows {
 		k := newOwnedTabKey(leapmuxv1.TabType_TAB_TYPE_TERMINAL, row, "")
@@ -671,4 +752,5 @@ func (r *OrphanReconciler) reconcileTerminals(ctx context.Context, hubByKey map[
 			r.logger.Info("orphan reconciler: closed stale terminal", "terminal_id", row)
 		}
 	}
+	return true
 }

--- a/backend/internal/worker/service/orphan_reconciler.go
+++ b/backend/internal/worker/service/orphan_reconciler.go
@@ -380,44 +380,46 @@ func (r *OrphanReconciler) reconcileOnce(ctx context.Context) bool {
 		return false
 	}
 	hubTabs := resp.GetTabStates()
-	if r.applyArchiveState != nil {
-		byState := map[leapmuxv1.WorkspaceArchiveState][]*leapmuxv1.TabRef{
-			leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ACTIVE:   nil,
-			leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED: nil,
+	// Unconditional: NewOrphanReconciler refuses a listFn without both archive
+	// hooks, and the listFn == nil case returned above -- so reaching here means
+	// both are set. A nil check would read as "the hooks are optional", which is
+	// the opposite of what the constructor enforces.
+	byState := map[leapmuxv1.WorkspaceArchiveState][]*leapmuxv1.TabRef{
+		leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ACTIVE:   nil,
+		leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED: nil,
+	}
+	for _, tab := range hubTabs {
+		state := tab.GetArchiveState()
+		if state != leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ACTIVE &&
+			state != leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED {
+			r.logger.Warn("orphan reconciler: hub returned an unspecified archive state",
+				"tab_id", tab.GetTabId())
+			return false
 		}
-		for _, tab := range hubTabs {
-			state := tab.GetArchiveState()
-			if state != leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ACTIVE &&
-				state != leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED {
-				r.logger.Warn("orphan reconciler: hub returned an unspecified archive state",
-					"tab_id", tab.GetTabId())
-				return false
-			}
-			byState[state] = append(byState[state], &leapmuxv1.TabRef{
-				TabType: tab.GetTabType(),
-				TabId:   tab.GetTabId(),
-			})
+		byState[state] = append(byState[state], &leapmuxv1.TabRef{
+			TabType: tab.GetTabType(),
+			TabId:   tab.GetTabId(),
+		})
+	}
+	for _, state := range []leapmuxv1.WorkspaceArchiveState{
+		leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED,
+		leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ACTIVE,
+	} {
+		if len(byState[state]) == 0 {
+			continue
 		}
-		for _, state := range []leapmuxv1.WorkspaceArchiveState{
-			leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED,
-			leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ACTIVE,
-		} {
-			if len(byState[state]) == 0 {
-				continue
-			}
-			resumeAgentIDs, err := r.applyArchiveState(ctx, state, byState[state])
-			if err != nil {
-				r.logger.Warn("orphan reconciler: apply archive state", "state", state, "error", err)
-				return false
-			}
-			for _, agentID := range resumeAgentIDs {
-				r.pendingResumeAgents[agentID] = struct{}{}
-			}
-			if state == leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED {
-				for _, tab := range byState[state] {
-					if tab.GetTabType() == leapmuxv1.TabType_TAB_TYPE_AGENT {
-						delete(r.pendingResumeAgents, tab.GetTabId())
-					}
+		resumeAgentIDs, err := r.applyArchiveState(ctx, state, byState[state])
+		if err != nil {
+			r.logger.Warn("orphan reconciler: apply archive state", "state", state, "error", err)
+			return false
+		}
+		for _, agentID := range resumeAgentIDs {
+			r.pendingResumeAgents[agentID] = struct{}{}
+		}
+		if state == leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED {
+			for _, tab := range byState[state] {
+				if tab.GetTabType() == leapmuxv1.TabType_TAB_TYPE_AGENT {
+					delete(r.pendingResumeAgents, tab.GetTabId())
 				}
 			}
 		}

--- a/backend/internal/worker/service/orphan_reconciler_gc_test.go
+++ b/backend/internal/worker/service/orphan_reconciler_gc_test.go
@@ -12,6 +12,12 @@ import (
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
 )
 
+func ignoreArchiveState(context.Context, leapmuxv1.WorkspaceArchiveState, []*leapmuxv1.TabRef) ([]string, error) {
+	return nil, nil
+}
+
+func ignoreAgentResume([]string) {}
+
 // These exercise the worktree-GC two-pass logic directly via the
 // unexported reconcileOnce (so each call is exactly one pass and the
 // prevOrphanWorktrees state carries between them) with a fake ReapWorktree
@@ -261,8 +267,10 @@ func TestReconcileFileTabs_RoutesThroughSharedTeardownHonouringKeep(t *testing.T
 	// TabGrace -1: this test asserts WHAT the teardown does, not when it is due.
 	// TestReconcileTabs_* below covers the grace itself.
 	rec := NewOrphanReconciler(q, listFn, OrphanReconcilerOptions{
-		CloseTab: svc.CloseTabForReconcile,
-		TabGrace: -1,
+		CloseTab:          svc.CloseTabForReconcile,
+		ApplyArchiveState: ignoreArchiveState,
+		ResumeAgents:      ignoreAgentResume,
+		TabGrace:          -1,
 	})
 	rec.reconcileOnce(ctx)
 
@@ -366,7 +374,9 @@ func TestReconcileOnce_LocalProbeFailureIsNotConvergence(t *testing.T) {
 		return &leapmuxv1.ListOwnedTabsForWorkerResponse{OwnerUserId: "user-1"}, nil
 	}
 	rec := NewOrphanReconciler(q, listFn, OrphanReconcilerOptions{
-		CloseTab: svc.CloseTabForReconcile,
+		CloseTab:          svc.CloseTabForReconcile,
+		ApplyArchiveState: ignoreArchiveState,
+		ResumeAgents:      ignoreAgentResume,
 	})
 
 	// A healthy, genuinely idle worker converges and skips the hub RPC.
@@ -410,9 +420,11 @@ func TestReconcileTabs_DefersTheReapUntilTheGraceElapses(t *testing.T) {
 	}
 	clock := time.Now()
 	rec := NewOrphanReconciler(q, listFn, OrphanReconcilerOptions{
-		CloseTab: svc.CloseTabForReconcile,
-		Now:      func() time.Time { return clock },
-		TabGrace: 10 * time.Second,
+		CloseTab:          svc.CloseTabForReconcile,
+		ApplyArchiveState: ignoreArchiveState,
+		ResumeAgents:      ignoreAgentResume,
+		Now:               func() time.Time { return clock },
+		TabGrace:          10 * time.Second,
 	})
 
 	assert.False(t, rec.reconcileOnce(ctx),
@@ -446,17 +458,20 @@ func TestReconcileTabs_RestartsTheClockWhenTheHubListsTheTabAgain(t *testing.T) 
 	listFn := func(context.Context) (*leapmuxv1.ListOwnedTabsForWorkerResponse, error) {
 		resp := &leapmuxv1.ListOwnedTabsForWorkerResponse{OwnerUserId: "user-1"}
 		if present {
-			resp.Tabs = []*leapmuxv1.OwnedTab{{
+			resp.TabStates = []*leapmuxv1.WorkerTabState{{
 				TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: "flapping-agent",
+				ArchiveState: leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ACTIVE,
 			}}
 		}
 		return resp, nil
 	}
 	clock := time.Now()
 	rec := NewOrphanReconciler(q, listFn, OrphanReconcilerOptions{
-		CloseTab: svc.CloseTabForReconcile,
-		Now:      func() time.Time { return clock },
-		TabGrace: 10 * time.Second,
+		CloseTab:          svc.CloseTabForReconcile,
+		ApplyArchiveState: ignoreArchiveState,
+		ResumeAgents:      ignoreAgentResume,
+		Now:               func() time.Time { return clock },
+		TabGrace:          10 * time.Second,
 	})
 
 	rec.reconcileOnce(ctx) // absent: starts the clock
@@ -497,9 +512,11 @@ func TestReconcileTabs_RemoveCloseKeepsItsWorktreeLinkAcrossARacingPass(t *testi
 	}
 	clock := time.Now()
 	rec := NewOrphanReconciler(q, listFn, OrphanReconcilerOptions{
-		CloseTab: svc.CloseTabForReconcile,
-		Now:      func() time.Time { return clock },
-		TabGrace: 10 * time.Second,
+		CloseTab:          svc.CloseTabForReconcile,
+		ApplyArchiveState: ignoreArchiveState,
+		ResumeAgents:      ignoreAgentResume,
+		Now:               func() time.Time { return clock },
+		TabGrace:          10 * time.Second,
 	})
 
 	rec.reconcileOnce(ctx)

--- a/backend/internal/worker/service/orphan_reconciler_test.go
+++ b/backend/internal/worker/service/orphan_reconciler_test.go
@@ -33,7 +33,7 @@ func newOrphanReconcilerHarness(t *testing.T, opts service.OrphanReconcilerOptio
 	*db.Queries,
 	*service.TabPayloadStore,
 	*service.OrphanReconciler,
-	func(string, []*leapmuxv1.OwnedTab, error),
+	func(string, []*leapmuxv1.WorkerTabState, error),
 	*recordingTeardown,
 ) {
 	t.Helper()
@@ -66,6 +66,14 @@ func newOrphanReconcilerHarness(t *testing.T, opts service.OrphanReconcilerOptio
 	if opts.CloseTab == nil {
 		opts.CloseTab = teardown.closeTab
 	}
+	if opts.ApplyArchiveState == nil {
+		opts.ApplyArchiveState = func(context.Context, leapmuxv1.WorkspaceArchiveState, []*leapmuxv1.TabRef) ([]string, error) {
+			return nil, nil
+		}
+	}
+	if opts.ResumeAgents == nil {
+		opts.ResumeAgents = func([]string) {}
+	}
 	// These tests assert WHAT a reap does, not WHEN it is due, and they drive
 	// single passes on a real clock. Disable the grace so each one still reaps
 	// in one pass. The grace itself has its own tests, which drive a fake clock
@@ -74,10 +82,15 @@ func newOrphanReconcilerHarness(t *testing.T, opts service.OrphanReconcilerOptio
 		opts.TabGrace = -1
 	}
 	rec := service.NewOrphanReconciler(q, listFn, opts)
-	setFake := func(ownerUserID string, tabs []*leapmuxv1.OwnedTab, err error) {
+	setFake := func(ownerUserID string, tabs []*leapmuxv1.WorkerTabState, err error) {
 		fakeMu.Lock()
 		defer fakeMu.Unlock()
-		fakeResp = &leapmuxv1.ListOwnedTabsForWorkerResponse{OwnerUserId: ownerUserID, Tabs: tabs}
+		for _, tab := range tabs {
+			if tab.GetArchiveState() == leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_UNSPECIFIED {
+				tab.ArchiveState = leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ACTIVE
+			}
+		}
+		fakeResp = &leapmuxv1.ListOwnedTabsForWorkerResponse{OwnerUserId: ownerUserID, TabStates: tabs}
 		fakeErr = err
 	}
 	return q, files, rec, setFake, teardown
@@ -253,7 +266,7 @@ func TestOrphanReconciler_Agent_PresentOnHub_DoesNotStop(t *testing.T) {
 	require.NoError(t, q.CreateAgent(ctx, db.CreateAgentParams{
 		ID: "live-agent", AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX,
 	}))
-	setFake("user-1", []*leapmuxv1.OwnedTab{
+	setFake("user-1", []*leapmuxv1.WorkerTabState{
 		{TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: "live-agent"},
 	}, nil)
 
@@ -263,6 +276,90 @@ func TestOrphanReconciler_Agent_PresentOnHub_DoesNotStop(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, agent.ClosedAt.Valid, "agent still referenced by hub must stay open")
 	assert.Empty(t, teardown.agents, "live agent must NOT receive a stop signal")
+}
+
+func TestOrphanReconciler_AppliesArchiveStateBeforeConvergence(t *testing.T) {
+	t.Parallel()
+
+	var calls []leapmuxv1.WorkspaceArchiveState
+	q, _, rec, setFake, teardown := newOrphanReconcilerHarness(t, service.OrphanReconcilerOptions{
+		ApplyArchiveState: func(_ context.Context, state leapmuxv1.WorkspaceArchiveState, tabs []*leapmuxv1.TabRef) ([]string, error) {
+			calls = append(calls, state)
+			require.Equal(t, "agent-archived", tabs[0].GetTabId())
+			return nil, nil
+		},
+	})
+	require.NoError(t, q.CreateAgent(t.Context(), db.CreateAgentParams{
+		ID: "agent-archived", AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX,
+	}))
+	setFake("user-1", []*leapmuxv1.WorkerTabState{{
+		TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: "agent-archived",
+		ArchiveState: leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED,
+	}}, nil)
+
+	require.True(t, runOnce(t.Context(), rec))
+	assert.Equal(t, []leapmuxv1.WorkspaceArchiveState{
+		leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED,
+	}, calls)
+	assert.Empty(t, teardown.agents)
+}
+
+func TestOrphanReconciler_ArchiveFailurePreventsConvergenceAndReaping(t *testing.T) {
+	t.Parallel()
+
+	q, _, rec, setFake, teardown := newOrphanReconcilerHarness(t, service.OrphanReconcilerOptions{
+		ApplyArchiveState: func(context.Context, leapmuxv1.WorkspaceArchiveState, []*leapmuxv1.TabRef) ([]string, error) {
+			return nil, assert.AnError
+		},
+	})
+	require.NoError(t, q.CreateAgent(t.Context(), db.CreateAgentParams{
+		ID: "agent-live", AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX,
+	}))
+	setFake("user-1", []*leapmuxv1.WorkerTabState{{
+		TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: "agent-live",
+		ArchiveState: leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED,
+	}}, nil)
+
+	assert.False(t, runOnce(t.Context(), rec))
+	assert.Empty(t, teardown.agents)
+}
+
+func TestOrphanReconciler_DefersUnarchiveResumeUntilThePassConverges(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	firstApply := true
+	var resumed []string
+	q, _, rec, setFake, _ := newOrphanReconcilerHarness(t, service.OrphanReconcilerOptions{
+		Now:      func() time.Time { return now },
+		TabGrace: 10 * time.Second,
+		ApplyArchiveState: func(context.Context, leapmuxv1.WorkspaceArchiveState, []*leapmuxv1.TabRef) ([]string, error) {
+			if firstApply {
+				firstApply = false
+				return []string{"agent-active"}, nil
+			}
+			return nil, nil
+		},
+		ResumeAgents: func(agentIDs []string) {
+			resumed = append(resumed, agentIDs...)
+		},
+	})
+	for _, agentID := range []string{"agent-active", "agent-stale"} {
+		require.NoError(t, q.CreateAgent(t.Context(), db.CreateAgentParams{
+			ID: agentID, AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX,
+		}))
+	}
+	setFake("user-1", []*leapmuxv1.WorkerTabState{{
+		TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: "agent-active",
+		ArchiveState: leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ACTIVE,
+	}}, nil)
+
+	assert.False(t, runOnce(t.Context(), rec), "the stale tab still waits for its close grace")
+	assert.Empty(t, resumed, "unarchive must not resume before orphan deletion finishes")
+
+	now = now.Add(11 * time.Second)
+	assert.True(t, runOnce(t.Context(), rec))
+	assert.Equal(t, []string{"agent-active"}, resumed)
 }
 
 func TestOrphanReconciler_ListError_DoesNotPanic_DoesNotCloseRows(t *testing.T) {
@@ -423,7 +520,7 @@ func TestOrphanReconciler_FileTab_SharedTabIDStaysWithItsOwner(t *testing.T) {
 	// The hub knows both rows, each naming its own owner. Neither is absent,
 	// so neither is reaped -- and the owner-keyed comparison is what makes that
 	// true for BOTH: an owner-blind key would collapse them into one entry.
-	setFake("user-a", []*leapmuxv1.OwnedTab{
+	setFake("user-a", []*leapmuxv1.WorkerTabState{
 		{TabType: leapmuxv1.TabType_TAB_TYPE_FILE, TabId: sharedTabID, UserId: "user-a"},
 		{TabType: leapmuxv1.TabType_TAB_TYPE_FILE, TabId: sharedTabID, UserId: "user-b"},
 	}, nil)
@@ -465,7 +562,7 @@ func TestOrphanReconciler_FileTab_SharedTabIDReapsOnlyTheStaleOwner(t *testing.T
 	}))
 
 	// Only user-a's tab survives at the hub.
-	setFake("user-b", []*leapmuxv1.OwnedTab{
+	setFake("user-b", []*leapmuxv1.WorkerTabState{
 		{TabType: leapmuxv1.TabType_TAB_TYPE_FILE, TabId: sharedTabID, UserId: "user-a"},
 	}, nil)
 
@@ -513,7 +610,7 @@ func TestOrphanReconciler_FileTab_OutOfScopeOwnerIsNotReaped(t *testing.T) {
 
 	// A response scoped to user-a, listing user-a's live tab. It says nothing
 	// about user-b -- who is not "absent", merely not asked about.
-	setFake("user-a", []*leapmuxv1.OwnedTab{
+	setFake("user-a", []*leapmuxv1.WorkerTabState{
 		{TabType: leapmuxv1.TabType_TAB_TYPE_FILE, TabId: "file-a", UserId: "user-a"},
 	}, nil)
 

--- a/backend/internal/worker/service/orphan_reconciler_test.go
+++ b/backend/internal/worker/service/orphan_reconciler_test.go
@@ -387,7 +387,20 @@ func TestOrphanReconciler_ArchiveFailurePreventsConvergenceAndReaping(t *testing
 	assert.Empty(t, teardown.agents)
 }
 
-func TestOrphanReconciler_DefersUnarchiveResumeUntilThePassConverges(t *testing.T) {
+// TestOrphanReconciler_ResumesUnarchivedAgentsWithoutWaitingForConvergence
+// pins the resume timing, and it is the INVERSE of what this pass first did.
+//
+// The resume used to be held until the whole pass converged, so that it could
+// not race an orphan close from that same pass. It cannot race one: the resume
+// list and the reap set are disjoint by construction. Both derive from ONE hub
+// response -- a resumed id comes from a tab the hub LISTED, and reconcileAgents
+// reaps only ids the hub OMITTED.
+//
+// The hold cost a real delay. Any unrelated tab sitting inside its orphan grace
+// window keeps the pass non-converged, so an unarchive the user just asked for
+// waited on a countdown that had nothing to do with it -- which is exactly the
+// state this test sets up.
+func TestOrphanReconciler_ResumesUnarchivedAgentsWithoutWaitingForConvergence(t *testing.T) {
 	t.Parallel()
 
 	now := time.Now()
@@ -417,12 +430,17 @@ func TestOrphanReconciler_DefersUnarchiveResumeUntilThePassConverges(t *testing.
 		ArchiveState: leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ACTIVE,
 	}}, nil)
 
+	// agent-stale is absent from the hub list, so this pass starts its grace
+	// clock and reports NON-converged. The resume must not wait on that.
 	assert.False(t, runOnce(t.Context(), rec), "the stale tab still waits for its close grace")
-	assert.Empty(t, resumed, "unarchive must not resume before orphan deletion finishes")
+	assert.Equal(t, []string{"agent-active"}, resumed,
+		"an unarchived agent resumes on the pass that unarchived it, whatever an unrelated tab's grace is doing")
 
+	// The edge does not repeat: the second pass reports no changed row, so the
+	// agent is not scheduled twice.
 	now = now.Add(11 * time.Second)
 	assert.True(t, runOnce(t.Context(), rec))
-	assert.Equal(t, []string{"agent-active"}, resumed)
+	assert.Equal(t, []string{"agent-active"}, resumed, "a converged pass must not resume the same agent again")
 }
 
 func TestOrphanReconciler_ListError_DoesNotPanic_DoesNotCloseRows(t *testing.T) {

--- a/backend/internal/worker/service/orphan_reconciler_test.go
+++ b/backend/internal/worker/service/orphan_reconciler_test.go
@@ -102,6 +102,69 @@ type testWriter struct{ t *testing.T }
 
 func (w testWriter) Write(p []byte) (int, error) { w.t.Log(string(p)); return len(p), nil }
 
+// TestNewOrphanReconciler_RefusesAListFnWithoutArchiveHooks pins the
+// constructor guard that reconcileOnce depends on.
+//
+// A reconciler that reads the Hub's tab state MUST be able to apply it, so the
+// hooks are required rather than optional. reconcileOnce relies on exactly that
+// and calls applyArchiveState unconditionally: a nil check there would read as
+// "the hooks are optional", and a wiring that omitted one would then converge
+// while it silently skipped every archive transition. The panic is what keeps
+// that wiring impossible, so it is the thing to pin.
+func TestNewOrphanReconciler_RefusesAListFnWithoutArchiveHooks(t *testing.T) {
+	t.Parallel()
+
+	listFn := func(context.Context) (*leapmuxv1.ListOwnedTabsForWorkerResponse, error) {
+		return &leapmuxv1.ListOwnedTabsForWorkerResponse{}, nil
+	}
+	applyFn := func(context.Context, leapmuxv1.WorkspaceArchiveState, []*leapmuxv1.TabRef) ([]string, error) {
+		return nil, nil
+	}
+	resumeFn := func([]string) {}
+	closeTab := func(leapmuxv1.TabType, string, string) {}
+
+	for _, testCase := range []struct {
+		name   string
+		opts   service.OrphanReconcilerOptions
+		panics bool
+	}{
+		{name: "both hooks absent", panics: true, opts: service.OrphanReconcilerOptions{
+			CloseTab: closeTab,
+		}},
+		{name: "resume hook absent", panics: true, opts: service.OrphanReconcilerOptions{
+			CloseTab: closeTab, ApplyArchiveState: applyFn,
+		}},
+		{name: "apply hook absent", panics: true, opts: service.OrphanReconcilerOptions{
+			CloseTab: closeTab, ResumeAgents: resumeFn,
+		}},
+		{name: "both hooks present", panics: false, opts: service.OrphanReconcilerOptions{
+			CloseTab: closeTab, ApplyArchiveState: applyFn, ResumeAgents: resumeFn,
+		}},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			build := func() { service.NewOrphanReconciler(nil, listFn, testCase.opts) }
+			if testCase.panics {
+				assert.Panics(t, build)
+				return
+			}
+			assert.NotPanics(t, build)
+		})
+	}
+}
+
+// A reconciler with NO listFn reads no Hub state, so it needs no archive hooks:
+// reconcileOnce returns after the worktree sweep, before it could use them.
+func TestNewOrphanReconciler_LocalOnlyNeedsNoArchiveHooks(t *testing.T) {
+	t.Parallel()
+
+	assert.NotPanics(t, func() {
+		service.NewOrphanReconciler(nil, nil, service.OrphanReconcilerOptions{
+			CloseTab: func(leapmuxv1.TabType, string, string) {},
+		})
+	})
+}
+
 func TestOrphanReconciler_FileTab_MissingOnHub_Revoked(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/worker/service/registrar.go
+++ b/backend/internal/worker/service/registrar.go
@@ -231,17 +231,52 @@ func decodeInto[T any, PT decodedRequest[T]](
 	}
 }
 
+// refuseArchivedWrite answers a write RPC that names a row in an archived
+// workspace, and reports whether it answered. Read it as the one place the rule
+// "an archived workspace takes no mutation" lives on this side of the wire.
+//
+// The registrars call it rather than the handlers, so a new write handler is
+// refused by construction. A per-handler guard covered four of the thirteen
+// agent and terminal write RPCs, and the nine it missed included every one that
+// writes state outliving the archive: RenameAgent, DeleteAgentMessage,
+// UpdateTerminalTitle, and both closes.
+//
+// It keys on the SCOPE, not on the method, because the scope already states
+// whether a handler mutates. A read handler stays reachable, which is what
+// makes an archived workspace browsable rather than merely frozen.
+//
+// OpenAgent and OpenTerminal are deliberately NOT covered, and cannot be: they
+// create the row this guard reads, and a Worker stores no workspace id (see
+// OpenAgentRequest in agent.proto). The reconciler applies the Hub's
+// authoritative state to such a row on its next pass.
+func refuseArchivedWrite(sender channel.ResponseWriter, scope leapmuxv1.Scope, archived int64, subject string) bool {
+	if archived == 0 {
+		return false
+	}
+	switch scope {
+	case leapmuxv1.Scope_SCOPE_AGENT_WRITE, leapmuxv1.Scope_SCOPE_TERMINAL_WRITE:
+		sendFailedPrecondition(sender, subject+" belongs to an archived workspace")
+		return true
+	default:
+		return false
+	}
+}
+
 // agentGatedHandler builds the unmarshal → requireAgent → fn wrapper used by
 // registerAgentGated. Explicit type args sidestep constraint-inference edge
 // cases in nested generic calls (mirroring Dispatcher / ownerOnlyRegistrar
 // style).
 func agentGatedHandler[T any, PT agentScopedRequest[T]](
 	svc *Service,
+	scope leapmuxv1.Scope,
 	fn func(ctx context.Context, caller channel.Caller, req PT, row db.Agent, sender channel.ResponseWriter),
 ) channel.HandlerFunc {
 	return decodeInto[T, PT](func(ctx context.Context, caller channel.Caller, decoded PT, sender channel.ResponseWriter) {
 		row, ok := svc.requireAgent(sender, decoded.GetAgentId())
 		if !ok {
+			return
+		}
+		if refuseArchivedWrite(sender, scope, row.WorkspaceArchived, "agent") {
 			return
 		}
 		fn(ctx, caller, decoded, row, sender)
@@ -256,7 +291,7 @@ func registerAgentGated[T any, PT agentScopedRequest[T]](
 	scope leapmuxv1.Scope,
 	fn func(ctx context.Context, caller channel.Caller, req PT, row db.Agent, sender channel.ResponseWriter),
 ) {
-	r.ownerOnly().Register(method, scope, agentGatedHandler[T, PT](r.svc, fn))
+	r.ownerOnly().Register(method, scope, agentGatedHandler[T, PT](r.svc, scope, fn))
 }
 
 // agentGatedByIDHandler builds the unmarshal → requireAgentID → fn wrapper
@@ -266,10 +301,15 @@ func registerAgentGated[T any, PT agentScopedRequest[T]](
 // the loaded row.
 func agentGatedByIDHandler[T any, PT agentScopedRequest[T]](
 	svc *Service,
+	scope leapmuxv1.Scope,
 	fn func(ctx context.Context, caller channel.Caller, req PT, sender channel.ResponseWriter),
 ) channel.HandlerFunc {
 	return decodeInto[T, PT](func(ctx context.Context, caller channel.Caller, decoded PT, sender channel.ResponseWriter) {
-		if !svc.requireAgentID(sender, decoded.GetAgentId()) {
+		archived, ok := svc.requireAgentID(sender, decoded.GetAgentId())
+		if !ok {
+			return
+		}
+		if refuseArchivedWrite(sender, scope, archived, "agent") {
 			return
 		}
 		fn(ctx, caller, decoded, sender)
@@ -286,18 +326,22 @@ func registerAgentGatedByID[T any, PT agentScopedRequest[T]](
 	mode dispatchMode,
 	fn func(ctx context.Context, caller channel.Caller, req PT, sender channel.ResponseWriter),
 ) {
-	r.ownerOnly().RegisterMode(method, scope, mode, agentGatedByIDHandler[T, PT](r.svc, fn))
+	r.ownerOnly().RegisterMode(method, scope, mode, agentGatedByIDHandler[T, PT](r.svc, scope, fn))
 }
 
 // terminalGatedHandler builds the unmarshal → requireTerminal → fn wrapper
 // used by registerTerminalGated.
 func terminalGatedHandler[T any, PT terminalScopedRequest[T]](
 	svc *Service,
+	scope leapmuxv1.Scope,
 	fn func(ctx context.Context, caller channel.Caller, req PT, row db.Terminal, sender channel.ResponseWriter),
 ) channel.HandlerFunc {
 	return decodeInto[T, PT](func(ctx context.Context, caller channel.Caller, decoded PT, sender channel.ResponseWriter) {
 		row, ok := svc.requireTerminal(sender, decoded.GetTerminalId())
 		if !ok {
+			return
+		}
+		if refuseArchivedWrite(sender, scope, row.WorkspaceArchived, "terminal") {
 			return
 		}
 		fn(ctx, caller, decoded, row, sender)
@@ -312,7 +356,7 @@ func registerTerminalGated[T any, PT terminalScopedRequest[T]](
 	scope leapmuxv1.Scope,
 	fn func(ctx context.Context, caller channel.Caller, req PT, row db.Terminal, sender channel.ResponseWriter),
 ) {
-	r.ownerOnly().Register(method, scope, terminalGatedHandler[T, PT](r.svc, fn))
+	r.ownerOnly().Register(method, scope, terminalGatedHandler[T, PT](r.svc, scope, fn))
 }
 
 // terminalGatedByIDHandler builds the unmarshal → requireTerminalID → fn
@@ -321,10 +365,15 @@ func registerTerminalGated[T any, PT terminalScopedRequest[T]](
 // handlers that never read the row.
 func terminalGatedByIDHandler[T any, PT terminalScopedRequest[T]](
 	svc *Service,
+	scope leapmuxv1.Scope,
 	fn func(ctx context.Context, caller channel.Caller, req PT, sender channel.ResponseWriter),
 ) channel.HandlerFunc {
 	return decodeInto[T, PT](func(ctx context.Context, caller channel.Caller, decoded PT, sender channel.ResponseWriter) {
-		if !svc.requireTerminalID(sender, decoded.GetTerminalId()) {
+		archived, ok := svc.requireTerminalID(sender, decoded.GetTerminalId())
+		if !ok {
+			return
+		}
+		if refuseArchivedWrite(sender, scope, archived, "terminal") {
 			return
 		}
 		fn(ctx, caller, decoded, sender)
@@ -342,7 +391,7 @@ func registerTerminalGatedByID[T any, PT terminalScopedRequest[T]](
 	mode dispatchMode,
 	fn func(ctx context.Context, caller channel.Caller, req PT, sender channel.ResponseWriter),
 ) {
-	r.ownerOnly().RegisterMode(method, scope, mode, terminalGatedByIDHandler[T, PT](r.svc, fn))
+	r.ownerOnly().RegisterMode(method, scope, mode, terminalGatedByIDHandler[T, PT](r.svc, scope, fn))
 }
 
 // registerTerminalForRestartGated is the sole user of
@@ -357,6 +406,9 @@ func registerTerminalForRestartGated(
 	registerOwnerGated(r, method, scope, dispatchPlain, func(ctx context.Context, caller channel.Caller, decoded *leapmuxv1.RestartTerminalRequest, sender channel.ResponseWriter) {
 		row, ok := r.svc.requireTerminalForRestart(sender, decoded.GetTerminalId())
 		if !ok {
+			return
+		}
+		if refuseArchivedWrite(sender, scope, row.WorkspaceArchived, "terminal") {
 			return
 		}
 		fn(ctx, caller, decoded, row, sender)

--- a/backend/internal/worker/service/require_rows.go
+++ b/backend/internal/worker/service/require_rows.go
@@ -35,21 +35,25 @@ func (svc *Service) requireTerminalForRestart(sender channel.ResponseWriter, ter
 }
 
 // requireAgentID resolves the agent named by the request without loading it:
-// GetAgentID fetches only the id column, skipping the options / option-group
-// JSON blobs a full GetAgentByID deserializes. Both queries share the bare
-// `id = ?` predicate, so the error mapping (empty id, missing row, db error) is
-// identical to requireAgent — use that one instead when the handler body needs
-// the row.
-func (svc *Service) requireAgentID(sender channel.ResponseWriter, agentID string) bool {
-	_, ok := requireExistingRow(sender, agentID, "agent", svc.Queries.GetAgentID)
-	return ok
+// GetAgentID fetches the id and the archive flag, skipping the options /
+// option-group JSON blobs a full GetAgentByID deserializes. Both queries share
+// the bare `id = ?` predicate, so the error mapping (empty id, missing row, db
+// error) is identical to requireAgent — use that one instead when the handler
+// body needs the row.
+//
+// It returns the archive flag rather than a bare bool, because the registrar
+// refuses a write handler for an archived workspace and this probe is the only
+// row read a by-id handler does.
+func (svc *Service) requireAgentID(sender channel.ResponseWriter, agentID string) (int64, bool) {
+	row, ok := requireExistingRow(sender, agentID, "agent", svc.Queries.GetAgentID)
+	return row.WorkspaceArchived, ok
 }
 
-// requireTerminalID is the terminal mirror of requireAgentID: an id-only
-// lookup that skips the screen BLOB a full GetTerminal would read.
-func (svc *Service) requireTerminalID(sender channel.ResponseWriter, terminalID string) bool {
-	_, ok := requireExistingRow(sender, terminalID, "terminal", svc.Queries.GetTerminalID)
-	return ok
+// requireTerminalID is the terminal mirror of requireAgentID: a narrow lookup
+// that skips the screen BLOB a full GetTerminal would read.
+func (svc *Service) requireTerminalID(sender channel.ResponseWriter, terminalID string) (int64, bool) {
+	row, ok := requireExistingRow(sender, terminalID, "terminal", svc.Queries.GetTerminalID)
+	return row.WorkspaceArchived, ok
 }
 
 // requireExistingRow factors the error-mapping shell shared by every "load a

--- a/backend/internal/worker/service/restart_terminal_test.go
+++ b/backend/internal/worker/service/restart_terminal_test.go
@@ -335,13 +335,14 @@ func TestRestartTerminal_StartupInProgress(t *testing.T) {
 		ID: id, Cols: 80, Rows: 25, Shell: testutil.TestShell(), Screen: []byte{},
 	}))
 
-	svc.TerminalStartup.begin(id, func() {})
+	entry := svc.TerminalStartup.begin(id, func() {})
+	require.NotNil(t, entry)
 	// begin() bumps the in-flight WaitGroup. cancelAndClear only deletes
-	// the entry and runs the cancel — finish() is the matching Done()
+	// the entry and runs the cancel — finishEntry() is the matching Done()
 	// call. Without this, drainAllInFlight would block forever.
 	defer func() {
 		svc.TerminalStartup.cancelAndClear(id, keepWorktreeOnClose)
-		svc.TerminalStartup.finish()
+		svc.TerminalStartup.finishEntry(entry)
 	}()
 
 	dispatchRestart(d, id, w)

--- a/backend/internal/worker/service/restart_terminal_test.go
+++ b/backend/internal/worker/service/restart_terminal_test.go
@@ -133,6 +133,28 @@ func TestRestartTerminal_HappyPath(t *testing.T) {
 	}
 }
 
+func TestRestartTerminal_RefusesArchivedTerminal(t *testing.T) {
+	t.Parallel()
+
+	svc, dispatcher, _ := setupTestService(t)
+	require.NoError(t, svc.Queries.UpsertTerminal(t.Context(), db.UpsertTerminalParams{
+		ID: "terminal-archived", Shell: testutil.TestShell(), WorkingDir: t.TempDir(),
+		Cols: 80, Rows: 25, Screen: []byte("preserved"),
+	}))
+	_, err := svc.Queries.SetTerminalWorkspaceArchived(t.Context(), db.SetTerminalWorkspaceArchivedParams{
+		WorkspaceArchived: 1,
+		ID:                "terminal-archived",
+	})
+	require.NoError(t, err)
+
+	w := newTestWriter()
+	dispatchRestart(dispatcher, "terminal-archived", w)
+
+	require.Len(t, w.errors, 1)
+	assert.Equal(t, codeFailedPrecondition, w.errors[0].code)
+	assert.False(t, svc.Terminals.HasTerminal("terminal-archived"))
+}
+
 // TestRestartTerminal_StillRunning rejects restarts on a live terminal so
 // the alive PTY isn't orphaned.
 func TestRestartTerminal_StillRunning(t *testing.T) {

--- a/backend/internal/worker/service/service.go
+++ b/backend/internal/worker/service/service.go
@@ -200,10 +200,24 @@ type Service struct {
 	// contend. Entries are never deleted (bounded by the worker's
 	// distinct-worktree count over its lifetime).
 	worktreeRemovalLocks sync.Map
-	// archiveStateMu serializes archive and unarchive effects. The database
-	// state and process state must change in the same order when two lifecycle
-	// requests overlap.
-	archiveStateMu sync.Mutex
+	// archiveTabLocks serializes one tab's whole archive lifecycle -- the flag
+	// write AND the process teardown or resume that follows it -- keyed by tab.
+	//
+	// It must span both, not the write alone. The teardown reads no state after
+	// the transaction commits, so an unarchive that committed in between would
+	// have its freshly resumed process stopped by the earlier archive's still
+	// running drain, its runtime state cleared, and an INACTIVE broadcast sent
+	// for a tab whose row says active. The user sees an agent they just
+	// unarchived go inactive again, with no error.
+	//
+	// Keyed by tab rather than one process-wide mutex, because the drain has no
+	// upper time limit: StopAndWaitAgent and WaitForExit both wait for a
+	// subprocess. A global lock made every archive on the worker -- and the
+	// orphan reconciler's whole loop, which runs this teardown inline -- queue
+	// behind one agent that ignores its stop signal. Different tabs never
+	// contend. Entries are never deleted, bounded by the worker's distinct-tab
+	// count over its lifetime, exactly like worktreeRemovalLocks above.
+	archiveTabLocks sync.Map
 
 	// gitIndexLocks serializes INDEX-MUTATING git commands per repository:
 	// `worktree add`/`remove`, `checkout`, `checkout -b`, `branch -D`, `add -A`,

--- a/backend/internal/worker/service/service.go
+++ b/backend/internal/worker/service/service.go
@@ -180,6 +180,8 @@ type Service struct {
 	// One field for both, composed at the call site: bootstrap starts the loops
 	// and is therefore the only place that knows what order they must stop in.
 	stopBackgroundLoops func()
+	resumeSchedulerMu   sync.Mutex
+	agentResumer        *AgentResumer
 
 	// agentCleanups / terminalCleanups hold per-tab cleanup callbacks
 	// registered by spawn*RemoteIPC and fired on close (or before a
@@ -198,6 +200,10 @@ type Service struct {
 	// contend. Entries are never deleted (bounded by the worker's
 	// distinct-worktree count over its lifetime).
 	worktreeRemovalLocks sync.Map
+	// archiveStateMu serializes archive and unarchive effects. The database
+	// state and process state must change in the same order when two lifecycle
+	// requests overlap.
+	archiveStateMu sync.Mutex
 
 	// gitIndexLocks serializes INDEX-MUTATING git commands per repository:
 	// `worktree add`/`remove`, `checkout`, `checkout -b`, `branch -D`, `add -A`,

--- a/backend/internal/worker/service/startup_phase.go
+++ b/backend/internal/worker/service/startup_phase.go
@@ -23,7 +23,8 @@ type startupCallbacks struct {
 	// decided about the worktree, and whether such a close happened at all.
 	// failStartup needs both: see rollbackGitModeAfterStartup. Read through
 	// closeRaced rather than called directly.
-	closeDisposition func() (closeWorktreeDisposition, bool)
+	closeDisposition   func() (closeWorktreeDisposition, bool)
+	archiveDisposition func() (archived, phase0Complete bool)
 }
 
 // closeRaced reports the decision a close recorded against this startup.
@@ -37,6 +38,13 @@ func (cb startupCallbacks) closeRaced() (closeWorktreeDisposition, bool) {
 		return keepWorktreeOnClose, false
 	}
 	return cb.closeDisposition()
+}
+
+func (cb startupCallbacks) archived() (bool, bool) {
+	if cb.archiveDisposition == nil {
+		return false, false
+	}
+	return cb.archiveDisposition()
 }
 
 // runStartupPhase0 broadcasts the per-mode label (if any) and executes
@@ -64,6 +72,13 @@ func (svc *Service) runStartupPhase0(ctx context.Context, plan gitModePlan, cb s
 // Those arrive here, not on the close-detected branch, which is why the
 // rollback has to consult the disposition on this path too.
 func (svc *Service) failStartup(gm gitModeResult, cause error, cb startupCallbacks) {
+	_, closeRaced := cb.closeRaced()
+	if archived, phase0Complete := cb.archived(); archived && !closeRaced {
+		if gm.Rollback.HasPartialMutation() && !phase0Complete {
+			svc.rollbackGitMode(gm)
+		}
+		return
+	}
 	if gm.Rollback.HasPartialMutation() {
 		if label := rollbackLabelFromRollback(gm.Rollback); label != "" {
 			cb.setMessage(label)
@@ -94,6 +109,7 @@ func (svc *Service) failStartup(gm gitModeResult, cause error, cb startupCallbac
 func (svc *Service) linkWorktreeAfterPhase0(reg *startupCore, h *startupEntry, worktreeID string, tabType leapmuxv1.TabType, tabID string, closedInDB bool) {
 	disposition, raced := reg.dispositionOf(h)
 	svc.registerTabForWorktreeAfterClose(worktreeID, tabType, tabID, closedInDB || raced, disposition)
+	reg.markPhase0Complete(h)
 }
 
 // finishStartupAfterClose is the tail both startup goroutines run when their
@@ -125,6 +141,9 @@ func (svc *Service) agentStartupCallbacks(dbAgent *db.Agent, gitStatus *leapmuxv
 		closeDisposition: func() (closeWorktreeDisposition, bool) {
 			return svc.AgentStartup.dispositionOf(h)
 		},
+		archiveDisposition: func() (bool, bool) {
+			return svc.AgentStartup.archiveDisposition(h)
+		},
 	}
 }
 
@@ -140,6 +159,9 @@ func (svc *Service) terminalStartupCallbacks(terminalID string, h *startupEntry)
 		registryFail:      func(errMsg string) { svc.TerminalStartup.fail(terminalID, errMsg) },
 		closeDisposition: func() (closeWorktreeDisposition, bool) {
 			return svc.TerminalStartup.dispositionOf(h)
+		},
+		archiveDisposition: func() (bool, bool) {
+			return svc.TerminalStartup.archiveDisposition(h)
 		},
 	}
 }

--- a/backend/internal/worker/service/startup_phase.go
+++ b/backend/internal/worker/service/startup_phase.go
@@ -23,8 +23,13 @@ type startupCallbacks struct {
 	// decided about the worktree, and whether such a close happened at all.
 	// failStartup needs both: see rollbackGitModeAfterStartup. Read through
 	// closeRaced rather than called directly.
-	closeDisposition   func() (closeWorktreeDisposition, bool)
-	archiveDisposition func() (archived, phase0Complete bool)
+	closeDisposition func() (closeWorktreeDisposition, bool)
+	// archiveStopped reports whether an archive cancelled this startup, and
+	// phase0Complete whether its git-mode mutation is already linked to the
+	// tab. Two hooks rather than one pair, because the two facts are unrelated
+	// and only failStartup reads the second.
+	archiveStopped func() bool
+	phase0Complete func() bool
 }
 
 // closeRaced reports the decision a close recorded against this startup.
@@ -40,11 +45,21 @@ func (cb startupCallbacks) closeRaced() (closeWorktreeDisposition, bool) {
 	return cb.closeDisposition()
 }
 
-func (cb startupCallbacks) archived() (bool, bool) {
-	if cb.archiveDisposition == nil {
-		return false, false
+// archived reports whether an archive cancelled this startup. A nil hook means
+// a hand-built test callback set wired none, and reports "no archive raced".
+func (cb startupCallbacks) archived() bool {
+	if cb.archiveStopped == nil {
+		return false
 	}
-	return cb.archiveDisposition()
+	return cb.archiveStopped()
+}
+
+// pastPhase0 reports whether phase 0 finished and linked its worktree.
+func (cb startupCallbacks) pastPhase0() bool {
+	if cb.phase0Complete == nil {
+		return false
+	}
+	return cb.phase0Complete()
 }
 
 // runStartupPhase0 broadcasts the per-mode label (if any) and executes
@@ -73,8 +88,8 @@ func (svc *Service) runStartupPhase0(ctx context.Context, plan gitModePlan, cb s
 // rollback has to consult the disposition on this path too.
 func (svc *Service) failStartup(gm gitModeResult, cause error, cb startupCallbacks) {
 	_, closeRaced := cb.closeRaced()
-	if archived, phase0Complete := cb.archived(); archived && !closeRaced {
-		if gm.Rollback.HasPartialMutation() && !phase0Complete {
+	if cb.archived() && !closeRaced {
+		if gm.Rollback.HasPartialMutation() && !cb.pastPhase0() {
 			svc.rollbackGitMode(gm)
 		}
 		return
@@ -121,7 +136,9 @@ func (svc *Service) linkWorktreeAfterPhase0(reg *startupCore, h *startupEntry, w
 // that read. Reusing the earlier value would report the zero value (keep) for
 // every such close and silently skip a removal the user confirmed.
 func (svc *Service) finishStartupAfterClose(reg *startupCore, h *startupEntry, tabID string, gm gitModeResult) {
-	reg.succeed(tabID)
+	// Identity-guarded: this tail also runs for a close that landed AFTER the
+	// goroutine's own succeed, so the id can already belong to a newer startup.
+	reg.succeed(tabID, h)
 	disposition, _ := reg.dispositionOf(h)
 	svc.rollbackGitModeAfterClose(gm, disposition)
 }
@@ -141,9 +158,8 @@ func (svc *Service) agentStartupCallbacks(dbAgent *db.Agent, gitStatus *leapmuxv
 		closeDisposition: func() (closeWorktreeDisposition, bool) {
 			return svc.AgentStartup.dispositionOf(h)
 		},
-		archiveDisposition: func() (bool, bool) {
-			return svc.AgentStartup.archiveDisposition(h)
-		},
+		archiveStopped: func() bool { return svc.AgentStartup.archiveStopped(h) },
+		phase0Complete: func() bool { return svc.AgentStartup.phase0Complete(h) },
 	}
 }
 
@@ -160,8 +176,7 @@ func (svc *Service) terminalStartupCallbacks(terminalID string, h *startupEntry)
 		closeDisposition: func() (closeWorktreeDisposition, bool) {
 			return svc.TerminalStartup.dispositionOf(h)
 		},
-		archiveDisposition: func() (bool, bool) {
-			return svc.TerminalStartup.archiveDisposition(h)
-		},
+		archiveStopped: func() bool { return svc.TerminalStartup.archiveStopped(h) },
+		phase0Complete: func() bool { return svc.TerminalStartup.phase0Complete(h) },
 	}
 }

--- a/backend/internal/worker/service/startupstate.go
+++ b/backend/internal/worker/service/startupstate.go
@@ -254,8 +254,8 @@ func (r *startupCore) awaitInFlight(id string, limit time.Duration) startupWait 
 	}
 }
 
-// finishEntry marks one startup goroutine as returned. Always called via
-// `defer` at the top of runAgentStartup / runTerminalStartup so it fires
+// finishEntry marks one startup goroutine as returned. runAgentStartup and
+// runTerminalStartup always call it via `defer` at the top, so it fires
 // regardless of which branch the goroutine exits through (succeed, fail,
 // close-detected, archive-stopped, panic recovery elsewhere, …).
 //
@@ -268,7 +268,8 @@ func (r *startupCore) awaitInFlight(id string, limit time.Duration) startupWait 
 // would block for ever waiting on it.
 //
 // The entry carries no other cleanup: its close disposition lives on the handle
-// the goroutine is about to drop, so it is collected with it.
+// the goroutine is about to drop, so the garbage collector takes the entry with
+// that handle.
 func (r *startupCore) finishEntry(entry *startupEntry) {
 	if entry != nil {
 		r.mu.Lock()
@@ -305,11 +306,28 @@ func (r *startupCore) setMessage(id, message string) {
 
 // succeed removes the entry (on successful startup the runtime state comes
 // from the Manager, not from this registry).
-func (r *startupCore) succeed(id string) {
+//
+// handle, when set, makes the removal IDENTITY-GUARDED: the entry goes only
+// when it is still the one the caller started. Pass it from every path that
+// can run after another succeed already released the id, and pass nil only
+// when the caller is the sole owner of the claim.
+//
+// Why the guard exists. succeed frees the id, and begin admits a new startup
+// the moment it is free. A goroutine whose tail reaches succeed a second time
+// -- which the close-after-succeed branch does, because cancelAndClear now
+// stamps closeRaced on an entry it finds through inflight -- would otherwise
+// delete and release whatever claim currently holds that id. That is a
+// SECOND startup's claim, and freeing it admits a third: two startup
+// goroutines for one tab, the exact state begin exists to prevent.
+func (r *startupCore) succeed(id string, handle *startupEntry) {
 	r.mu.Lock()
 	entry := r.entries[id]
-	delete(r.entries, id)
-	entry.release()
+	if entry != nil && (handle == nil || entry == handle) {
+		delete(r.entries, id)
+		entry.release()
+	} else {
+		entry = nil
+	}
 	r.mu.Unlock()
 	if entry != nil && entry.evictTimer != nil {
 		entry.evictTimer.Stop()
@@ -355,41 +373,45 @@ func (r *startupCore) fail(id, startupError string) {
 // installed a different entry and this stamps that one, which no goroutine is
 // reading. Both fall out of the handle rather than needing a guard.
 func (r *startupCore) cancelAndClear(id string, disposition closeWorktreeDisposition) {
-	r.mu.Lock()
-	entry := r.entries[id]
-	if entry == nil {
-		entry = r.inflight[id]
-	}
-	if entry != nil {
-		entry.closeDisposition = disposition
-		entry.closeRaced = true
-		if r.entries[id] == entry {
-			delete(r.entries, id)
-			entry.release()
-		}
-	}
-	r.mu.Unlock()
-	if entry == nil {
-		return
-	}
-	if entry.evictTimer != nil {
-		entry.evictTimer.Stop()
-	}
-	if entry.cancel != nil {
-		entry.cancel()
-	}
+	r.cancelStartup(id, true, func(e *startupEntry) {
+		e.closeDisposition = disposition
+		e.closeRaced = true
+	})
 }
 
 // cancelForArchive stops an in-flight startup without marking the tab closed
 // or failed. It returns the startup handle so archival can wait for all
 // rollback and resource cleanup work to finish.
 func (r *startupCore) cancelForArchive(id string) *startupEntry {
-	r.mu.Lock()
-	entry := r.inflight[id]
-	if entry != nil {
+	return r.cancelStartup(id, false, func(e *startupEntry) {
 		// A permanent close carries the user's worktree decision and wins if
 		// both lifecycle operations reach the same startup.
-		entry.archiveStopped = !entry.closeRaced
+		e.archiveStopped = !e.closeRaced
+	})
+}
+
+// cancelStartup is the one detach-and-cancel body the two lifecycle
+// operations share: stamp the caller's disposition, drop the entry when it is
+// still the live one, then stop the evict timer and cancel the context outside
+// the lock. Sharing it is what keeps a close and an archive from drifting in
+// the ORDER they release `done`, stop the timer, and cancel.
+//
+// preferFinished picks which map answers first, and that is the only real
+// difference between the two callers. A close must reach a startup that
+// already FAILED, because fail() installed a different entry under the same id
+// and the close's worktree decision belongs on that one; an archive must not,
+// because a failed startup owns no process for it to stop.
+func (r *startupCore) cancelStartup(id string, preferFinished bool, stamp func(*startupEntry)) *startupEntry {
+	r.mu.Lock()
+	var entry *startupEntry
+	if preferFinished {
+		entry = r.entries[id]
+	}
+	if entry == nil {
+		entry = r.inflight[id]
+	}
+	if entry != nil {
+		stamp(entry)
 		if r.entries[id] == entry {
 			delete(r.entries, id)
 			entry.release()
@@ -423,13 +445,77 @@ func (r *startupCore) markPhase0Complete(entry *startupEntry) {
 	r.mu.Unlock()
 }
 
-func (r *startupCore) archiveDisposition(entry *startupEntry) (archived, phase0Complete bool) {
+// startupInterruption names the lifecycle event that must stop a startup
+// short of reporting success, and states their PRECEDENCE in one place.
+type startupInterruption int
+
+const (
+	// interruptionNone: nothing raced this startup; finish normally.
+	interruptionNone startupInterruption = iota
+	// interruptionClosed: the tab was closed. Its teardown owns the worktree
+	// decision the user made, so the goroutine must run the close tail.
+	interruptionClosed
+	// interruptionArchived: the workspace was archived. The tab and all of its
+	// data survive; only the process stops.
+	interruptionArchived
+)
+
+// interruptionOf resolves the two dispositions against the two persisted flags
+// and answers with the one that wins.
+//
+// A CLOSE BEATS AN ARCHIVE. A close is permanent and carries the user's
+// worktree decision; an archive is reversible and keeps every row. Reporting
+// the archive for a tab that was also closed would skip that decision and
+// leave the worktree on disk.
+//
+// This function is why that precedence is stated once. Four startup paths ask
+// it -- agent start, agent post-relaunch, terminal start, terminal restart --
+// and each of them used to spell the same two checks in sequence, so the order
+// was an invisible property of statement placement at four sites, and a fifth
+// path could get it backwards without contradicting anything.
+func (r *startupCore) interruptionOf(h *startupEntry, closedInDB, archivedInDB bool) startupInterruption {
+	closeRaced, archiveStopped := false, false
+	if h != nil {
+		r.mu.Lock()
+		closeRaced, archiveStopped = h.closeRaced, h.archiveStopped
+		r.mu.Unlock()
+	}
+	switch {
+	case closeRaced || closedInDB:
+		return interruptionClosed
+	case archiveStopped || archivedInDB:
+		return interruptionArchived
+	default:
+		return interruptionNone
+	}
+}
+
+// archiveStopped reports whether an archive cancelled this startup.
+func (r *startupCore) archiveStopped(entry *startupEntry) bool {
 	if entry == nil {
-		return false, false
+		return false
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	return entry.archiveStopped, entry.phase0Complete
+	return entry.archiveStopped
+}
+
+// phase0Complete reports whether the startup got past phase 0, so its git-mode
+// mutation is already linked to the tab and a rollback must not undo it.
+//
+// It is a SEPARATE accessor from archiveStopped on purpose. The two answer
+// unrelated questions -- one about the archive, one about the worktree -- and
+// only failStartup reads this one. Returning them as one unnamed (bool, bool)
+// meant four call sites wrote `archiveStopped, _ :=` and a reader had to open
+// the implementation to tell the two apart. Both flags are monotonic, so
+// reading them under two separate locks loses nothing.
+func (r *startupCore) phase0Complete(entry *startupEntry) bool {
+	if entry == nil {
+		return false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return entry.phase0Complete
 }
 
 // setPendingResize records the latest ResizeTerminal dims for id. Returns

--- a/backend/internal/worker/service/startupstate.go
+++ b/backend/internal/worker/service/startupstate.go
@@ -254,19 +254,23 @@ func (r *startupCore) awaitInFlight(id string, limit time.Duration) startupWait 
 	}
 }
 
-// finish marks one startup goroutine as returned. Always called via `defer` at
-// the top of runAgentStartup / runTerminalStartup so it fires regardless of
-// which branch the goroutine exits through (succeed, fail, close-detected,
-// panic recovery elsewhere, …).
+// finishEntry marks one startup goroutine as returned. Always called via
+// `defer` at the top of runAgentStartup / runTerminalStartup so it fires
+// regardless of which branch the goroutine exits through (succeed, fail,
+// close-detected, archive-stopped, panic recovery elsewhere, …).
 //
-// It has no cleanup to do beyond the counter: the close disposition lives on
-// the handle the goroutine is about to drop, so it is collected with it.
-func (r *startupCore) finish() {
-	r.wg.Done()
-}
-
+// It does two things, and the pairing is why there is no counter-only variant.
+// The WaitGroup counter is what WaitForInFlight joins. `finished` is what
+// cancelForArchive's caller waits on before it clears the tab's runtime state,
+// and `inflight` is what makes the handle reachable from a tab id at all. A
+// caller that dropped the counter alone would leave a live-looking inflight
+// entry whose `finished` nobody ever closes, and the next archive of that tab
+// would block for ever waiting on it.
+//
+// The entry carries no other cleanup: its close disposition lives on the handle
+// the goroutine is about to drop, so it is collected with it.
 func (r *startupCore) finishEntry(entry *startupEntry) {
-	if entry != nil && entry.finished != nil {
+	if entry != nil {
 		r.mu.Lock()
 		if r.inflight[entry.id] == entry {
 			delete(r.inflight, entry.id)
@@ -274,7 +278,7 @@ func (r *startupCore) finishEntry(entry *startupEntry) {
 		r.mu.Unlock()
 		close(entry.finished)
 	}
-	r.finish()
+	r.wg.Done()
 }
 
 // WaitForInFlight blocks until every startup goroutine counted by begin

--- a/backend/internal/worker/service/startupstate.go
+++ b/backend/internal/worker/service/startupstate.go
@@ -30,6 +30,7 @@ const failedEntryTTL = 5 * time.Minute
 //     PTY was registered in the Manager, so runTerminalStartup can apply
 //     it the moment StartTerminal returns.
 type startupEntry struct {
+	id string
 	// failed is set once startup fails terminally. While false and cancel
 	// is non-nil, startup is still in progress (STARTING).
 	failed       bool
@@ -76,6 +77,8 @@ type startupEntry struct {
 	// goroutine is reading.
 	closeDisposition closeWorktreeDisposition
 	closeRaced       bool
+	archiveStopped   bool
+	phase0Complete   bool
 	// done is closed when this startup stops being IN FLIGHT -- when succeed,
 	// fail or cancelAndClear takes the entry out of the map. awaitInFlight
 	// waits on it, so a caller that finds the id claimed can wait for the claim
@@ -85,6 +88,10 @@ type startupEntry struct {
 	// finished record with no goroutine behind it, and awaitInFlight skips a
 	// failed entry for the same reason begin does not refuse on one.
 	done chan struct{}
+	// finished closes after the startup goroutine completes its trailing
+	// rollback and cleanup work. Archival waits on it before it permits an
+	// unarchive resume to register replacement resources for the same tab.
+	finished chan struct{}
 }
 
 // release closes e.done, so every awaitInFlight waiting on this startup stops
@@ -134,9 +141,10 @@ func (systemStartupClock) NewTimer(d time.Duration) (<-chan time.Time, func()) {
 // work so callers — test cleanups and future graceful-shutdown paths —
 // observe the filesystem and DB in a quiescent state.
 type startupCore struct {
-	mu      sync.Mutex
-	entries map[string]*startupEntry
-	wg      sync.WaitGroup
+	mu       sync.Mutex
+	entries  map[string]*startupEntry
+	inflight map[string]*startupEntry
+	wg       sync.WaitGroup
 	// clock is the time source awaitInFlight limits its wait with. Set once by
 	// newStartupCore and never reassigned in production, so a waiter reads it
 	// without the mutex; a test substitutes a fake before it starts one.
@@ -144,7 +152,11 @@ type startupCore struct {
 }
 
 func newStartupCore() startupCore {
-	return startupCore{entries: make(map[string]*startupEntry), clock: systemStartupClock{}}
+	return startupCore{
+		entries:  make(map[string]*startupEntry),
+		inflight: make(map[string]*startupEntry),
+		clock:    systemStartupClock{},
+	}
 }
 
 // begin records an entry in STARTING state, adds one to the in-flight counter,
@@ -176,11 +188,14 @@ func (r *startupCore) begin(id string, cancel context.CancelFunc) *startupEntry 
 		return nil
 	}
 	entry := &startupEntry{
+		id:           id,
 		cancel:       cancel,
 		resizeSignal: make(chan struct{}, 1),
 		done:         make(chan struct{}),
+		finished:     make(chan struct{}),
 	}
 	r.entries[id] = entry
+	r.inflight[id] = entry
 	r.wg.Add(1)
 	return entry
 }
@@ -248,6 +263,18 @@ func (r *startupCore) awaitInFlight(id string, limit time.Duration) startupWait 
 // the handle the goroutine is about to drop, so it is collected with it.
 func (r *startupCore) finish() {
 	r.wg.Done()
+}
+
+func (r *startupCore) finishEntry(entry *startupEntry) {
+	if entry != nil && entry.finished != nil {
+		r.mu.Lock()
+		if r.inflight[entry.id] == entry {
+			delete(r.inflight, entry.id)
+		}
+		r.mu.Unlock()
+		close(entry.finished)
+	}
+	r.finish()
 }
 
 // WaitForInFlight blocks until every startup goroutine counted by begin
@@ -326,11 +353,16 @@ func (r *startupCore) fail(id, startupError string) {
 func (r *startupCore) cancelAndClear(id string, disposition closeWorktreeDisposition) {
 	r.mu.Lock()
 	entry := r.entries[id]
-	delete(r.entries, id)
+	if entry == nil {
+		entry = r.inflight[id]
+	}
 	if entry != nil {
 		entry.closeDisposition = disposition
 		entry.closeRaced = true
-		entry.release()
+		if r.entries[id] == entry {
+			delete(r.entries, id)
+			entry.release()
+		}
 	}
 	r.mu.Unlock()
 	if entry == nil {
@@ -342,6 +374,58 @@ func (r *startupCore) cancelAndClear(id string, disposition closeWorktreeDisposi
 	if entry.cancel != nil {
 		entry.cancel()
 	}
+}
+
+// cancelForArchive stops an in-flight startup without marking the tab closed
+// or failed. It returns the startup handle so archival can wait for all
+// rollback and resource cleanup work to finish.
+func (r *startupCore) cancelForArchive(id string) *startupEntry {
+	r.mu.Lock()
+	entry := r.inflight[id]
+	if entry != nil {
+		// A permanent close carries the user's worktree decision and wins if
+		// both lifecycle operations reach the same startup.
+		entry.archiveStopped = !entry.closeRaced
+		if r.entries[id] == entry {
+			delete(r.entries, id)
+			entry.release()
+		}
+	}
+	r.mu.Unlock()
+	if entry == nil {
+		return nil
+	}
+	if entry.evictTimer != nil {
+		entry.evictTimer.Stop()
+	}
+	if entry.cancel != nil {
+		entry.cancel()
+	}
+	return entry
+}
+
+func (r *startupCore) waitForFinished(entry *startupEntry) {
+	if entry != nil && entry.finished != nil {
+		<-entry.finished
+	}
+}
+
+func (r *startupCore) markPhase0Complete(entry *startupEntry) {
+	if entry == nil {
+		return
+	}
+	r.mu.Lock()
+	entry.phase0Complete = true
+	r.mu.Unlock()
+}
+
+func (r *startupCore) archiveDisposition(entry *startupEntry) (archived, phase0Complete bool) {
+	if entry == nil {
+		return false, false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return entry.archiveStopped, entry.phase0Complete
 }
 
 // setPendingResize records the latest ResizeTerminal dims for id. Returns

--- a/backend/internal/worker/service/startupstate_test.go
+++ b/backend/internal/worker/service/startupstate_test.go
@@ -22,6 +22,31 @@ func beginForTest(t *testing.T, r *startupCore, id string) {
 	})
 }
 
+func TestStartupCore_ArchiveCancellationIsDistinctFromCloseAndFailure(t *testing.T) {
+	t.Parallel()
+
+	core := newStartupCore()
+	cancelled := false
+	handle := core.begin("archive-tab", func() { cancelled = true })
+	require.NotNil(t, handle)
+	core.markPhase0Complete(handle)
+
+	archivedHandle := core.cancelForArchive("archive-tab")
+	require.Same(t, handle, archivedHandle)
+	archived, phase0Complete := core.archiveDisposition(handle)
+	assert.True(t, archived)
+	assert.True(t, phase0Complete)
+	assert.True(t, cancelled)
+	assert.Equal(t, startupWait{settled: true}, core.awaitInFlight("archive-tab", time.Hour),
+		"an archived stop must not report a permanent close")
+	_, _, _, present := core.snapshot("archive-tab")
+	assert.False(t, present, "an archived stop must not leave a startup failure")
+
+	core.finishEntry(handle)
+	core.waitForFinished(handle)
+	core.WaitForInFlight()
+}
+
 // TestStartupCore_ClearPendingResize_DrainsSignal pins the contract
 // that clearPendingResize empties the buffered resizeSignal along with
 // the hasPendingResize bool. Without the drain, a later

--- a/backend/internal/worker/service/startupstate_test.go
+++ b/backend/internal/worker/service/startupstate_test.go
@@ -33,7 +33,7 @@ func TestStartupCore_ArchiveCancellationIsDistinctFromCloseAndFailure(t *testing
 
 	archivedHandle := core.cancelForArchive("archive-tab")
 	require.Same(t, handle, archivedHandle)
-	archived, phase0Complete := core.archiveDisposition(handle)
+	archived, phase0Complete := core.archiveStopped(handle), core.phase0Complete(handle)
 	assert.True(t, archived)
 	assert.True(t, phase0Complete)
 	assert.True(t, cancelled)
@@ -61,7 +61,7 @@ func TestStartupCore_ArchiveFindsNoHandleOnceTheStartupFinished(t *testing.T) {
 	core := newStartupCore()
 	handle := core.begin("finished-tab", func() {})
 	require.NotNil(t, handle)
-	core.succeed("finished-tab")
+	core.succeed("finished-tab", nil)
 	core.finishEntry(handle)
 
 	assert.Nil(t, core.cancelForArchive("finished-tab"),
@@ -364,7 +364,7 @@ func TestStartupCore_AwaitInFlightWaitsForTheStartupThatHoldsTheID(t *testing.T)
 		end  func(core *startupCore)
 		want startupWait
 	}{
-		{"succeed", func(core *startupCore) { core.succeed("tab-1") }, startupWait{settled: true}},
+		{"succeed", func(core *startupCore) { core.succeed("tab-1", nil) }, startupWait{settled: true}},
 		{"fail", func(core *startupCore) { core.fail("tab-1", "boom") }, startupWait{settled: true}},
 		{
 			"cancelAndClear",
@@ -453,7 +453,7 @@ func TestStartupCore_AwaitInFlightIsSafeForManyWaiters(t *testing.T) {
 	}
 	clock.waitArmed(t)
 
-	core.succeed("tab-1")
+	core.succeed("tab-1", nil)
 	for range waiters {
 		select {
 		case got := <-done:
@@ -480,17 +480,17 @@ func TestStartupCore_ReleasingTheSameStartupTwiceIsSafe(t *testing.T) {
 		then  func(core *startupCore)
 	}{
 		{"succeed then succeed",
-			func(c *startupCore) { c.succeed("tab-1") },
-			func(c *startupCore) { c.succeed("tab-1") }},
+			func(c *startupCore) { c.succeed("tab-1", nil) },
+			func(c *startupCore) { c.succeed("tab-1", nil) }},
 		{"succeed then cancelAndClear",
-			func(c *startupCore) { c.succeed("tab-1") },
+			func(c *startupCore) { c.succeed("tab-1", nil) },
 			func(c *startupCore) { c.cancelAndClear("tab-1", keepWorktreeOnClose) }},
 		{"succeed then fail",
-			func(c *startupCore) { c.succeed("tab-1") },
+			func(c *startupCore) { c.succeed("tab-1", nil) },
 			func(c *startupCore) { c.fail("tab-1", "boom") }},
 		{"cancelAndClear then succeed",
 			func(c *startupCore) { c.cancelAndClear("tab-1", keepWorktreeOnClose) },
-			func(c *startupCore) { c.succeed("tab-1") }},
+			func(c *startupCore) { c.succeed("tab-1", nil) }},
 		{"fail then fail",
 			func(c *startupCore) { c.fail("tab-1", "boom") },
 			func(c *startupCore) { c.fail("tab-1", "boom again") }},

--- a/backend/internal/worker/service/startupstate_test.go
+++ b/backend/internal/worker/service/startupstate_test.go
@@ -9,16 +9,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// beginForTest records an entry and returns a cleanup that pairs with
-// finish() to keep WaitForInFlight happy. Tests use this to exercise
-// the startupCore primitives without the full startup-goroutine
-// machinery.
+// beginForTest records an entry and registers the finishEntry that keeps
+// WaitForInFlight happy. Tests use this to exercise the startupCore primitives
+// without the full startup-goroutine machinery.
 func beginForTest(t *testing.T, r *startupCore, id string) {
 	t.Helper()
-	r.begin(id, func() {})
+	entry := r.begin(id, func() {})
+	require.NotNil(t, entry)
 	t.Cleanup(func() {
 		r.cancelAndClear(id, keepWorktreeOnClose)
-		r.finish()
+		r.finishEntry(entry)
 	})
 }
 
@@ -44,6 +44,28 @@ func TestStartupCore_ArchiveCancellationIsDistinctFromCloseAndFailure(t *testing
 
 	core.finishEntry(handle)
 	core.waitForFinished(handle)
+	core.WaitForInFlight()
+}
+
+// TestStartupCore_ArchiveFindsNoHandleOnceTheStartupFinished pins the invariant
+// that makes finishEntry the ONLY exit a startup goroutine may take.
+//
+// finishEntry drops the in-flight counter AND takes the entry out of the map
+// that cancelForArchive resolves a tab id through. An exit that dropped the
+// counter alone would leave a live-looking entry whose `finished` channel
+// nobody ever closes -- so the next archive of that tab would resolve it, call
+// waitForFinished, and block for ever inside the archive RPC.
+func TestStartupCore_ArchiveFindsNoHandleOnceTheStartupFinished(t *testing.T) {
+	t.Parallel()
+
+	core := newStartupCore()
+	handle := core.begin("finished-tab", func() {})
+	require.NotNil(t, handle)
+	core.succeed("finished-tab")
+	core.finishEntry(handle)
+
+	assert.Nil(t, core.cancelForArchive("finished-tab"),
+		"a startup that already returned leaves nothing for an archive to wait on")
 	core.WaitForInFlight()
 }
 
@@ -163,7 +185,7 @@ func TestCancelAndClear_StampsTheHandleTheGoroutineHolds(t *testing.T) {
 	got, raced := core.dispositionOf(h)
 	require.True(t, raced, "a close that raced a live startup must reach its goroutine")
 	assert.Equal(t, removeWorktreeOnClose, got)
-	core.finish()
+	core.finishEntry(h)
 }
 
 // TestCancelAndClear_FailedStartupNeverReachesItsGoroutine is the property the
@@ -181,7 +203,7 @@ func TestCancelAndClear_FailedStartupNeverReachesItsGoroutine(t *testing.T) {
 	core := newStartupCore()
 	h := core.begin("a-failed", func() {})
 	core.fail("a-failed", "boom")
-	core.finish()
+	core.finishEntry(h)
 
 	core.cancelAndClear("a-failed", removeWorktreeOnClose)
 
@@ -226,7 +248,7 @@ func TestStartupCore_BeginClaimsTheIDAgainstASecondStartup(t *testing.T) {
 	assert.True(t, firstCancelled, "the close must reach the startup that owns the slot")
 	assert.False(t, secondCancelled)
 
-	core.finish()
+	core.finishEntry(first)
 	core.WaitForInFlight()
 }
 
@@ -242,7 +264,7 @@ func TestStartupCore_BeginReclaimsAFailedEntry(t *testing.T) {
 
 	h := core.begin("tab-1", func() {})
 	require.NotNil(t, h, "a retry after a failed startup must be able to claim the tab again")
-	core.finish()
+	core.finishEntry(h)
 	core.WaitForInFlight()
 }
 
@@ -356,7 +378,8 @@ func TestStartupCore_AwaitInFlightWaitsForTheStartupThatHoldsTheID(t *testing.T)
 			core := newStartupCore()
 			clock := newFakeStartupClock()
 			core.clock = clock
-			require.NotNil(t, core.begin("tab-1", func() {}))
+			holder := core.begin("tab-1", func() {})
+			require.NotNil(t, holder)
 
 			done := make(chan startupWait, 1)
 			go func() { done <- core.awaitInFlight("tab-1", time.Hour) }()
@@ -375,7 +398,7 @@ func TestStartupCore_AwaitInFlightWaitsForTheStartupThatHoldsTheID(t *testing.T)
 			case <-time.After(10 * time.Second):
 				require.FailNow(t, "the wait never returned after the holder finished")
 			}
-			core.finish()
+			core.finishEntry(holder)
 			core.WaitForInFlight()
 		})
 	}
@@ -390,7 +413,8 @@ func TestStartupCore_AwaitInFlightGivesUpOnItsLimit(t *testing.T) {
 	core := newStartupCore()
 	clock := newFakeStartupClock()
 	core.clock = clock
-	require.NotNil(t, core.begin("tab-1", func() {}))
+	holder := core.begin("tab-1", func() {})
+	require.NotNil(t, holder)
 
 	done := make(chan startupWait, 1)
 	go func() { done <- core.awaitInFlight("tab-1", 90*time.Second) }()
@@ -406,7 +430,7 @@ func TestStartupCore_AwaitInFlightGivesUpOnItsLimit(t *testing.T) {
 	}
 
 	core.cancelAndClear("tab-1", keepWorktreeOnClose)
-	core.finish()
+	core.finishEntry(holder)
 	core.WaitForInFlight()
 }
 
@@ -419,7 +443,8 @@ func TestStartupCore_AwaitInFlightIsSafeForManyWaiters(t *testing.T) {
 	core := newStartupCore()
 	clock := newFakeStartupClock()
 	core.clock = clock
-	require.NotNil(t, core.begin("tab-1", func() {}))
+	holder := core.begin("tab-1", func() {})
+	require.NotNil(t, holder)
 
 	const waiters = 8
 	done := make(chan startupWait, waiters)
@@ -437,7 +462,7 @@ func TestStartupCore_AwaitInFlightIsSafeForManyWaiters(t *testing.T) {
 			require.FailNow(t, "a waiter was left behind by the wake-up")
 		}
 	}
-	core.finish()
+	core.finishEntry(holder)
 	core.WaitForInFlight()
 }
 
@@ -475,7 +500,8 @@ func TestStartupCore_ReleasingTheSameStartupTwiceIsSafe(t *testing.T) {
 
 			core := newStartupCore()
 			core.clock = newFakeStartupClock()
-			require.NotNil(t, core.begin("tab-1", func() {}))
+			holder := core.begin("tab-1", func() {})
+			require.NotNil(t, holder)
 
 			tc.first(&core)
 			assert.NotPanics(t, func() { tc.then(&core) })
@@ -486,7 +512,7 @@ func TestStartupCore_ReleasingTheSameStartupTwiceIsSafe(t *testing.T) {
 			// close.
 			assert.Equal(t, startupWait{settled: true}, core.awaitInFlight("tab-1", time.Hour))
 
-			core.finish()
+			core.finishEntry(holder)
 			core.WaitForInFlight()
 		})
 	}

--- a/backend/internal/worker/service/terminal.go
+++ b/backend/internal/worker/service/terminal.go
@@ -194,6 +194,10 @@ func registerTerminalHandlers(d registrar, svc *Service) {
 			if svc.refuseIfShuttingDown(sender) {
 				return
 			}
+			if dbTerm.WorkspaceArchived != 0 {
+				sendFailedPrecondition(sender, "terminal belongs to an archived workspace")
+				return
+			}
 			// Reject overlapping restarts: a previous startup hasn't broadcast
 			// READY/FAILED yet (could be the original OpenTerminal still in
 			// flight, or a back-to-back restart).
@@ -549,7 +553,7 @@ func registerTerminalHandlers(d registrar, svc *Service) {
 // stretch the RPC latency the user sees.
 func (svc *Service) runTerminalStartup(ctx context.Context, opts terminal.Options, spawnInfo TerminalSpawnInfo, plan gitModePlan, outputFn terminal.OutputHandler, exitFn terminal.ExitHandler, h *startupEntry) {
 	terminalID := opts.ID
-	defer svc.TerminalStartup.finish()
+	defer svc.TerminalStartup.finishEntry(h)
 
 	// Mint the remote-IPC token before phase 0 so the cleanup is in the
 	// map by the time any concurrent CloseTerminal calls terminalCleanups.run.
@@ -629,7 +633,8 @@ func (svc *Service) runTerminalStartup(ctx context.Context, opts terminal.Option
 	// registering in-memory metadata. Single narrow query — avoids
 	// re-reading the screen BLOB the handler entry already fetched.
 	postSpawn, postSpawnErr := svc.Queries.GetTerminalForReady(bgCtx(), terminalID)
-	if postSpawnErr == nil && postSpawn.ClosedAt.Valid {
+	_, closeRaced := svc.TerminalStartup.dispositionOf(h)
+	if closeRaced || (postSpawnErr == nil && postSpawn.ClosedAt.Valid) {
 		if startErr == nil {
 			svc.Terminals.RemoveTerminal(terminalID)
 			svc.clearTerminalBellCoalesce(terminalID)
@@ -637,7 +642,15 @@ func (svc *Service) runTerminalStartup(ctx context.Context, opts terminal.Option
 		svc.finishStartupAfterClose(&svc.TerminalStartup.startupCore, h, terminalID, gm)
 		return
 	}
-
+	archiveStopped, _ := svc.TerminalStartup.archiveDisposition(h)
+	if archiveStopped || (postSpawnErr == nil && postSpawn.WorkspaceArchived != 0) {
+		if startErr == nil {
+			svc.Terminals.StopTerminal(terminalID)
+			svc.Terminals.WaitForExit(terminalID)
+		}
+		svc.TerminalStartup.succeed(terminalID)
+		return
+	}
 	if startErr != nil {
 		slog.Error("failed to start terminal", "terminal_id", terminalID, "error", startErr)
 		svc.failTerminalStartup(terminalID, gm, startErr, h)
@@ -682,7 +695,7 @@ func (svc *Service) runTerminalRestart(
 	h *startupEntry,
 ) {
 	terminalID := opts.ID
-	defer svc.TerminalStartup.finish()
+	defer svc.TerminalStartup.finishEntry(h)
 
 	// Swap the previous spawn's LEAPMUX_CONTROL_* token for a fresh one.
 	// remintControlIPC owns the ORDER -- retire, then mint -- because both
@@ -729,7 +742,9 @@ func (svc *Service) runTerminalRestart(
 	// by its own RemoveTerminal call instead. The title column from the
 	// same row is unused on the restart path (titles don't change
 	// across restart), so it's read-and-discarded.
-	if postSpawn, fetchErr := svc.Queries.GetTerminalForReady(bgCtx(), terminalID); fetchErr == nil && postSpawn.ClosedAt.Valid {
+	postSpawn, fetchErr := svc.Queries.GetTerminalForReady(bgCtx(), terminalID)
+	_, closeRaced := svc.TerminalStartup.dispositionOf(h)
+	if closeRaced || (fetchErr == nil && postSpawn.ClosedAt.Valid) {
 		if startErr == nil {
 			svc.Terminals.RemoveTerminal(terminalID)
 			svc.clearTerminalBellCoalesce(terminalID)
@@ -737,7 +752,15 @@ func (svc *Service) runTerminalRestart(
 		svc.TerminalStartup.succeed(terminalID)
 		return
 	}
-
+	archiveStopped, _ := svc.TerminalStartup.archiveDisposition(h)
+	if archiveStopped || (fetchErr == nil && postSpawn.WorkspaceArchived != 0) {
+		if startErr == nil {
+			svc.Terminals.StopTerminal(terminalID)
+			svc.Terminals.WaitForExit(terminalID)
+		}
+		svc.TerminalStartup.succeed(terminalID)
+		return
+	}
 	if startErr != nil {
 		slog.Error("failed to restart terminal", "terminal_id", terminalID, "error", startErr)
 		// No git-mode mutation in the restart path — pass a zero result so

--- a/backend/internal/worker/service/terminal.go
+++ b/backend/internal/worker/service/terminal.go
@@ -194,10 +194,6 @@ func registerTerminalHandlers(d registrar, svc *Service) {
 			if svc.refuseIfShuttingDown(sender) {
 				return
 			}
-			if dbTerm.WorkspaceArchived != 0 {
-				sendFailedPrecondition(sender, "terminal belongs to an archived workspace")
-				return
-			}
 			// Reject overlapping restarts: a previous startup hasn't broadcast
 			// READY/FAILED yet (could be the original OpenTerminal still in
 			// flight, or a back-to-back restart).
@@ -633,23 +629,26 @@ func (svc *Service) runTerminalStartup(ctx context.Context, opts terminal.Option
 	// registering in-memory metadata. Single narrow query — avoids
 	// re-reading the screen BLOB the handler entry already fetched.
 	postSpawn, postSpawnErr := svc.Queries.GetTerminalForReady(bgCtx(), terminalID)
-	_, closeRaced := svc.TerminalStartup.dispositionOf(h)
-	if closeRaced || (postSpawnErr == nil && postSpawn.ClosedAt.Valid) {
+	switch svc.TerminalStartup.interruptionOf(h, postSpawnErr == nil && postSpawn.ClosedAt.Valid, postSpawnErr == nil && postSpawn.WorkspaceArchived != 0) {
+	case interruptionClosed:
 		if startErr == nil {
 			svc.Terminals.RemoveTerminal(terminalID)
 			svc.clearTerminalBellCoalesce(terminalID)
 		}
 		svc.finishStartupAfterClose(&svc.TerminalStartup.startupCore, h, terminalID, gm)
 		return
-	}
-	archiveStopped, _ := svc.TerminalStartup.archiveDisposition(h)
-	if archiveStopped || (postSpawnErr == nil && postSpawn.WorkspaceArchived != 0) {
+	case interruptionArchived:
 		if startErr == nil {
 			svc.Terminals.StopTerminal(terminalID)
 			svc.Terminals.WaitForExit(terminalID)
 		}
-		svc.TerminalStartup.succeed(terminalID)
+		// succeed, not fail: see the matching branch in runAgentStartup.
+		if startErr != nil {
+			slog.Warn("terminal startup stopped by workspace archival", "terminal_id", terminalID, "error", startErr)
+		}
+		svc.TerminalStartup.succeed(terminalID, h)
 		return
+	case interruptionNone:
 	}
 	if startErr != nil {
 		slog.Error("failed to start terminal", "terminal_id", terminalID, "error", startErr)
@@ -674,7 +673,7 @@ func (svc *Service) runTerminalStartup(ctx context.Context, opts terminal.Option
 	// Spawn succeeded and no close-race; hand cleanup ownership to the
 	// eventual CloseTerminal handler.
 	ownsIPCToken = false
-	svc.succeedTerminalStartup(terminalID)
+	svc.succeedTerminalStartup(terminalID, h)
 }
 
 // runTerminalRestart is the async body of RestartTerminal: it spawns a
@@ -743,23 +742,26 @@ func (svc *Service) runTerminalRestart(
 	// same row is unused on the restart path (titles don't change
 	// across restart), so it's read-and-discarded.
 	postSpawn, fetchErr := svc.Queries.GetTerminalForReady(bgCtx(), terminalID)
-	_, closeRaced := svc.TerminalStartup.dispositionOf(h)
-	if closeRaced || (fetchErr == nil && postSpawn.ClosedAt.Valid) {
+	switch svc.TerminalStartup.interruptionOf(h, fetchErr == nil && postSpawn.ClosedAt.Valid, fetchErr == nil && postSpawn.WorkspaceArchived != 0) {
+	case interruptionClosed:
 		if startErr == nil {
 			svc.Terminals.RemoveTerminal(terminalID)
 			svc.clearTerminalBellCoalesce(terminalID)
 		}
-		svc.TerminalStartup.succeed(terminalID)
+		svc.TerminalStartup.succeed(terminalID, h)
 		return
-	}
-	archiveStopped, _ := svc.TerminalStartup.archiveDisposition(h)
-	if archiveStopped || (fetchErr == nil && postSpawn.WorkspaceArchived != 0) {
+	case interruptionArchived:
 		if startErr == nil {
 			svc.Terminals.StopTerminal(terminalID)
 			svc.Terminals.WaitForExit(terminalID)
 		}
-		svc.TerminalStartup.succeed(terminalID)
+		// succeed, not fail: see the matching branch in runAgentStartup.
+		if startErr != nil {
+			slog.Warn("terminal restart stopped by workspace archival", "terminal_id", terminalID, "error", startErr)
+		}
+		svc.TerminalStartup.succeed(terminalID, h)
 		return
+	case interruptionNone:
 	}
 	if startErr != nil {
 		slog.Error("failed to restart terminal", "terminal_id", terminalID, "error", startErr)
@@ -770,17 +772,17 @@ func (svc *Service) runTerminalRestart(
 	}
 
 	ownsIPCToken = false
-	svc.succeedTerminalStartup(terminalID)
+	svc.succeedTerminalStartup(terminalID, h)
 }
 
 // succeedTerminalStartup is the shared READY tail for runTerminalStartup
 // and runTerminalRestart: clear the persisted startup_error, broadcast
 // READY, and mark the registry succeeded last so observers see a durable
 // terminal state.
-func (svc *Service) succeedTerminalStartup(terminalID string) {
+func (svc *Service) succeedTerminalStartup(terminalID string, h *startupEntry) {
 	svc.persistTerminalStartupError(terminalID, "")
 	svc.broadcastTerminalReady(terminalID)
-	svc.TerminalStartup.succeed(terminalID)
+	svc.TerminalStartup.succeed(terminalID, h)
 }
 
 // runTerminalPhase0 broadcasts the per-mode label and executes the

--- a/backend/internal/worker/service/workspace_archive.go
+++ b/backend/internal/worker/service/workspace_archive.go
@@ -1,0 +1,187 @@
+package service
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	db "github.com/leapmux/leapmux/internal/worker/generated/db"
+)
+
+// applyTabArchiveState applies both direct Hub fan-out and reconciled archive
+// state through one lifecycle implementation. It returns agents whose state
+// changed to active. The caller schedules them at its safe convergence point.
+func (svc *Service) applyTabArchiveState(
+	ctx context.Context,
+	state leapmuxv1.WorkspaceArchiveState,
+	tabs []*leapmuxv1.TabRef,
+) ([]string, error) {
+	flag, err := workspaceArchiveFlag(state)
+	if err != nil {
+		return nil, err
+	}
+	agentIDs, terminalIDs, err := archiveTabIDs(tabs)
+	if err != nil {
+		return nil, err
+	}
+
+	svc.archiveStateMu.Lock()
+	defer svc.archiveStateMu.Unlock()
+
+	tx, err := svc.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("start archive-state transaction: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	queries := svc.Queries.WithTx(tx)
+	changedAgents := make([]string, 0, len(agentIDs))
+	changedTerminals := make([]string, 0, len(terminalIDs))
+	for _, agentID := range agentIDs {
+		rows, updateErr := queries.SetAgentWorkspaceArchived(ctx, db.SetAgentWorkspaceArchivedParams{
+			WorkspaceArchived: flag,
+			ID:                agentID,
+		})
+		if updateErr != nil {
+			return nil, fmt.Errorf("set agent %s archive state: %w", agentID, updateErr)
+		}
+		if rows > 0 {
+			changedAgents = append(changedAgents, agentID)
+		}
+	}
+	for _, terminalID := range terminalIDs {
+		rows, updateErr := queries.SetTerminalWorkspaceArchived(ctx, db.SetTerminalWorkspaceArchivedParams{
+			WorkspaceArchived: flag,
+			ID:                terminalID,
+		})
+		if updateErr != nil {
+			return nil, fmt.Errorf("set terminal %s archive state: %w", terminalID, updateErr)
+		}
+		if rows > 0 {
+			changedTerminals = append(changedTerminals, terminalID)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit archive state: %w", err)
+	}
+	committed = true
+
+	if state == leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED {
+		svc.stopArchivedTabs(changedAgents, changedTerminals)
+		return nil, nil
+	}
+	return changedAgents, nil
+}
+
+// ApplyTabArchiveStateForReconcile exposes the shared lifecycle operation to
+// bootstrap without exposing it as another RPC surface.
+func (svc *Service) ApplyTabArchiveStateForReconcile(
+	ctx context.Context,
+	state leapmuxv1.WorkspaceArchiveState,
+	tabs []*leapmuxv1.TabRef,
+) ([]string, error) {
+	return svc.applyTabArchiveState(ctx, state, tabs)
+}
+
+func workspaceArchiveFlag(state leapmuxv1.WorkspaceArchiveState) (int64, error) {
+	switch state {
+	case leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ACTIVE:
+		return 0, nil
+	case leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED:
+		return 1, nil
+	default:
+		return 0, fmt.Errorf("archive_state must be ACTIVE or ARCHIVED")
+	}
+}
+
+func archiveTabIDs(tabs []*leapmuxv1.TabRef) ([]string, []string, error) {
+	agentSeen := make(map[string]struct{})
+	terminalSeen := make(map[string]struct{})
+	var agentIDs, terminalIDs []string
+	for _, tab := range tabs {
+		if tab == nil || tab.GetTabId() == "" {
+			continue
+		}
+		switch tab.GetTabType() {
+		case leapmuxv1.TabType_TAB_TYPE_AGENT:
+			if _, exists := agentSeen[tab.GetTabId()]; !exists {
+				agentSeen[tab.GetTabId()] = struct{}{}
+				agentIDs = append(agentIDs, tab.GetTabId())
+			}
+		case leapmuxv1.TabType_TAB_TYPE_TERMINAL:
+			if _, exists := terminalSeen[tab.GetTabId()]; !exists {
+				terminalSeen[tab.GetTabId()] = struct{}{}
+				terminalIDs = append(terminalIDs, tab.GetTabId())
+			}
+		case leapmuxv1.TabType_TAB_TYPE_FILE, leapmuxv1.TabType_TAB_TYPE_IMAGE:
+			// Payload-backed tabs own no process and have no archive-state row.
+		case leapmuxv1.TabType_TAB_TYPE_UNSPECIFIED:
+			return nil, nil, fmt.Errorf("tab %q has an unspecified type", tab.GetTabId())
+		default:
+			return nil, nil, fmt.Errorf("tab %q has unsupported type %s", tab.GetTabId(), tab.GetTabType())
+		}
+	}
+	return agentIDs, terminalIDs, nil
+}
+
+func (svc *Service) stopArchivedTabs(agentIDs, terminalIDs []string) {
+	agentStarts := make(map[string]*startupEntry, len(agentIDs))
+	for _, agentID := range agentIDs {
+		agentStarts[agentID] = svc.AgentStartup.cancelForArchive(agentID)
+	}
+	terminalStarts := make(map[string]*startupEntry, len(terminalIDs))
+	for _, terminalID := range terminalIDs {
+		terminalStarts[terminalID] = svc.TerminalStartup.cancelForArchive(terminalID)
+	}
+	// Signal all running processes before any one process drain can block.
+	for _, agentID := range agentIDs {
+		svc.Agents.StopAgent(agentID)
+	}
+	for _, terminalID := range terminalIDs {
+		svc.Terminals.StopTerminal(terminalID)
+	}
+
+	for agentID, startup := range agentStarts {
+		svc.AgentStartup.waitForFinished(startup)
+		unlock := svc.Agents.LockAgent(agentID)
+		svc.Agents.StopAndWaitAgent(agentID)
+		unlock()
+		svc.Output.ClearAgentRuntimeState(agentID)
+		svc.agentCleanups.retire(agentID)
+		row, err := svc.Queries.GetAgentByID(bgCtx(), agentID)
+		if err == nil {
+			svc.broadcastAgentInactive(&row)
+		} else if !errors.Is(err, sql.ErrNoRows) {
+			slog.Warn("archive: read agent for inactive broadcast", "agent_id", agentID, "error", err)
+		}
+	}
+
+	for _, startup := range terminalStarts {
+		svc.TerminalStartup.waitForFinished(startup)
+	}
+	for _, terminalID := range terminalIDs {
+		svc.Terminals.WaitForExit(terminalID)
+		svc.terminalCleanups.retire(terminalID)
+		svc.clearTerminalBellCoalesce(terminalID)
+		row, err := svc.Queries.GetTerminal(bgCtx(), terminalID)
+		if err != nil {
+			if !errors.Is(err, sql.ErrNoRows) {
+				slog.Warn("archive: read terminal for exited broadcast", "terminal_id", terminalID, "error", err)
+			}
+			continue
+		}
+		svc.Watchers.BroadcastTerminalEvent(terminalID, &leapmuxv1.TerminalEvent{
+			TerminalId: terminalID,
+			Event: &leapmuxv1.TerminalEvent_Closed{Closed: &leapmuxv1.TerminalClosed{
+				ExitCode: int32(row.ExitCode),
+			}},
+		})
+	}
+}

--- a/backend/internal/worker/service/workspace_archive.go
+++ b/backend/internal/worker/service/workspace_archive.go
@@ -6,15 +6,32 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
+	"sync"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
 )
 
-// applyTabArchiveState applies both direct Hub fan-out and reconciled archive
-// state through one lifecycle implementation. It returns agents whose state
-// changed to active. The caller schedules them at its safe convergence point.
-func (svc *Service) applyTabArchiveState(
+// archiveTabSet holds the tab ids one archive request touches, split by the
+// table that stores them. It is a named record rather than two `[]string`
+// results, because two same-typed slices can be swapped at a call site and the
+// compiler cannot tell.
+type archiveTabSet struct {
+	agents    []string
+	terminals []string
+}
+
+// ApplyTabArchiveState applies the Hub's authoritative archive state to this
+// Worker's local rows. It returns the agents whose state changed to active, so
+// the caller can schedule their resume.
+//
+// The orphan reconciler is the only caller. There is deliberately no RPC for
+// this: the Hub nudges a Worker whenever a workspace's archive state or a tab's
+// workspace membership changes, and the reconcile pass that follows reads the
+// Hub's own answer. A client-driven variant would be a second delivery path
+// for one effect, and it would apply only while that client was connected.
+func (svc *Service) ApplyTabArchiveState(
 	ctx context.Context,
 	state leapmuxv1.WorkspaceArchiveState,
 	tabs []*leapmuxv1.TabRef,
@@ -23,17 +40,64 @@ func (svc *Service) applyTabArchiveState(
 	if err != nil {
 		return nil, err
 	}
-	agentIDs, terminalIDs, err := archiveTabIDs(tabs)
+	requested, err := archiveTabIDs(tabs)
 	if err != nil {
 		return nil, err
 	}
 
-	svc.archiveStateMu.Lock()
-	defer svc.archiveStateMu.Unlock()
+	// Held across the flag write AND the teardown below: see archiveTabLocks
+	// for why the pair must be atomic per tab.
+	unlock := svc.lockArchiveTabs(requested)
+	defer unlock()
 
+	changed, err := svc.persistArchiveFlags(ctx, flag, requested)
+	if err != nil {
+		return nil, err
+	}
+
+	if state == leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED {
+		svc.stopArchivedTabs(changed)
+		return nil, nil
+	}
+	return changed.agents, nil
+}
+
+// lockArchiveTabs takes every lock this request needs and returns their
+// release. It locks in SORTED order, which is what makes two overlapping
+// requests over intersecting tab sets unable to deadlock: both walk the same
+// global order, so neither can hold a lock the other wants next.
+func (svc *Service) lockArchiveTabs(tabs archiveTabSet) func() {
+	keys := make([]string, 0, len(tabs.agents)+len(tabs.terminals))
+	for _, id := range tabs.agents {
+		keys = append(keys, "agent:"+id)
+	}
+	for _, id := range tabs.terminals {
+		keys = append(keys, "terminal:"+id)
+	}
+	sort.Strings(keys)
+	locks := make([]*sync.Mutex, 0, len(keys))
+	for _, key := range keys {
+		v, _ := svc.archiveTabLocks.LoadOrStore(key, &sync.Mutex{})
+		mu := v.(*sync.Mutex)
+		mu.Lock()
+		locks = append(locks, mu)
+	}
+	return func() {
+		for i := len(locks) - 1; i >= 0; i-- {
+			locks[i].Unlock()
+		}
+	}
+}
+
+// persistArchiveFlags writes the flag for every requested tab in one
+// transaction, and reports the tabs whose stored value actually changed.
+//
+// The caller holds this request's per-tab locks, so no other archive operation
+// can write these rows between the read and the write.
+func (svc *Service) persistArchiveFlags(ctx context.Context, flag int64, requested archiveTabSet) (archiveTabSet, error) {
 	tx, err := svc.DB.BeginTx(ctx, nil)
 	if err != nil {
-		return nil, fmt.Errorf("start archive-state transaction: %w", err)
+		return archiveTabSet{}, fmt.Errorf("start archive-state transaction: %w", err)
 	}
 	committed := false
 	defer func() {
@@ -42,52 +106,47 @@ func (svc *Service) applyTabArchiveState(
 		}
 	}()
 	queries := svc.Queries.WithTx(tx)
-	changedAgents := make([]string, 0, len(agentIDs))
-	changedTerminals := make([]string, 0, len(terminalIDs))
-	for _, agentID := range agentIDs {
-		rows, updateErr := queries.SetAgentWorkspaceArchived(ctx, db.SetAgentWorkspaceArchivedParams{
+
+	changedAgents, err := applyArchiveFlag(ctx, requested.agents, "agent", func(ctx context.Context, id string) (int64, error) {
+		return queries.SetAgentWorkspaceArchived(ctx, db.SetAgentWorkspaceArchivedParams{
 			WorkspaceArchived: flag,
-			ID:                agentID,
+			ID:                id,
 		})
-		if updateErr != nil {
-			return nil, fmt.Errorf("set agent %s archive state: %w", agentID, updateErr)
-		}
-		if rows > 0 {
-			changedAgents = append(changedAgents, agentID)
-		}
+	})
+	if err != nil {
+		return archiveTabSet{}, err
 	}
-	for _, terminalID := range terminalIDs {
-		rows, updateErr := queries.SetTerminalWorkspaceArchived(ctx, db.SetTerminalWorkspaceArchivedParams{
+	changedTerminals, err := applyArchiveFlag(ctx, requested.terminals, "terminal", func(ctx context.Context, id string) (int64, error) {
+		return queries.SetTerminalWorkspaceArchived(ctx, db.SetTerminalWorkspaceArchivedParams{
 			WorkspaceArchived: flag,
-			ID:                terminalID,
+			ID:                id,
 		})
-		if updateErr != nil {
-			return nil, fmt.Errorf("set terminal %s archive state: %w", terminalID, updateErr)
-		}
-		if rows > 0 {
-			changedTerminals = append(changedTerminals, terminalID)
-		}
+	})
+	if err != nil {
+		return archiveTabSet{}, err
 	}
 	if err := tx.Commit(); err != nil {
-		return nil, fmt.Errorf("commit archive state: %w", err)
+		return archiveTabSet{}, fmt.Errorf("commit archive state: %w", err)
 	}
 	committed = true
-
-	if state == leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED {
-		svc.stopArchivedTabs(changedAgents, changedTerminals)
-		return nil, nil
-	}
-	return changedAgents, nil
+	return archiveTabSet{agents: changedAgents, terminals: changedTerminals}, nil
 }
 
-// ApplyTabArchiveStateForReconcile exposes the shared lifecycle operation to
-// bootstrap without exposing it as another RPC surface.
-func (svc *Service) ApplyTabArchiveStateForReconcile(
-	ctx context.Context,
-	state leapmuxv1.WorkspaceArchiveState,
-	tabs []*leapmuxv1.TabRef,
-) ([]string, error) {
-	return svc.applyTabArchiveState(ctx, state, tabs)
+// applyArchiveFlag runs one table's update loop and returns the ids whose row
+// changed. The statements skip a closed row, so an id that names one is absent
+// from the result and takes no teardown.
+func applyArchiveFlag(ctx context.Context, ids []string, kind string, set func(context.Context, string) (int64, error)) ([]string, error) {
+	changed := make([]string, 0, len(ids))
+	for _, id := range ids {
+		rows, err := set(ctx, id)
+		if err != nil {
+			return nil, fmt.Errorf("set %s %s archive state: %w", kind, id, err)
+		}
+		if rows > 0 {
+			changed = append(changed, id)
+		}
+	}
+	return changed, nil
 }
 
 func workspaceArchiveFlag(state leapmuxv1.WorkspaceArchiveState) (int64, error) {
@@ -101,10 +160,18 @@ func workspaceArchiveFlag(state leapmuxv1.WorkspaceArchiveState) (int64, error) 
 	}
 }
 
-func archiveTabIDs(tabs []*leapmuxv1.TabRef) ([]string, []string, error) {
+// archiveTabIDs sorts the requested tabs by the table that stores them, and
+// REFUSES a tab whose type it cannot classify.
+//
+// The refusal is correct here and belongs to the RPC alone. A caller that
+// reads the Hub's tab list instead — the orphan reconciler — must drop such a
+// row and converge over the rest, because one row it cannot classify would
+// otherwise stop every reap and every resume on this worker. The reconciler
+// therefore filters before it calls, and this function stays strict.
+func archiveTabIDs(tabs []*leapmuxv1.TabRef) (archiveTabSet, error) {
 	agentSeen := make(map[string]struct{})
 	terminalSeen := make(map[string]struct{})
-	var agentIDs, terminalIDs []string
+	var set archiveTabSet
 	for _, tab := range tabs {
 		if tab == nil || tab.GetTabId() == "" {
 			continue
@@ -113,67 +180,102 @@ func archiveTabIDs(tabs []*leapmuxv1.TabRef) ([]string, []string, error) {
 		case leapmuxv1.TabType_TAB_TYPE_AGENT:
 			if _, exists := agentSeen[tab.GetTabId()]; !exists {
 				agentSeen[tab.GetTabId()] = struct{}{}
-				agentIDs = append(agentIDs, tab.GetTabId())
+				set.agents = append(set.agents, tab.GetTabId())
 			}
 		case leapmuxv1.TabType_TAB_TYPE_TERMINAL:
 			if _, exists := terminalSeen[tab.GetTabId()]; !exists {
 				terminalSeen[tab.GetTabId()] = struct{}{}
-				terminalIDs = append(terminalIDs, tab.GetTabId())
+				set.terminals = append(set.terminals, tab.GetTabId())
 			}
 		case leapmuxv1.TabType_TAB_TYPE_FILE, leapmuxv1.TabType_TAB_TYPE_IMAGE:
 			// Payload-backed tabs own no process and have no archive-state row.
 		case leapmuxv1.TabType_TAB_TYPE_UNSPECIFIED:
-			return nil, nil, fmt.Errorf("tab %q has an unspecified type", tab.GetTabId())
+			return archiveTabSet{}, fmt.Errorf("tab %q has an unspecified type", tab.GetTabId())
 		default:
-			return nil, nil, fmt.Errorf("tab %q has unsupported type %s", tab.GetTabId(), tab.GetTabType())
+			return archiveTabSet{}, fmt.Errorf("tab %q has unsupported type %s", tab.GetTabId(), tab.GetTabType())
 		}
 	}
-	return agentIDs, terminalIDs, nil
+	return set, nil
 }
 
-func (svc *Service) stopArchivedTabs(agentIDs, terminalIDs []string) {
-	agentStarts := make(map[string]*startupEntry, len(agentIDs))
-	for _, agentID := range agentIDs {
+// archivableTabType reports whether archiveTabIDs accepts this type. The
+// orphan reconciler asks before it builds a TabRef, so a row the Hub sends
+// with a type this Worker does not know drops out of one pass instead of
+// failing it.
+func archivableTabType(tabType leapmuxv1.TabType) bool {
+	switch tabType {
+	case leapmuxv1.TabType_TAB_TYPE_AGENT,
+		leapmuxv1.TabType_TAB_TYPE_TERMINAL,
+		leapmuxv1.TabType_TAB_TYPE_FILE,
+		leapmuxv1.TabType_TAB_TYPE_IMAGE:
+		return true
+	case leapmuxv1.TabType_TAB_TYPE_UNSPECIFIED:
+		return false
+	default:
+		return false
+	}
+}
+
+func (svc *Service) stopArchivedTabs(changed archiveTabSet) {
+	agentStarts := make(map[string]*startupEntry, len(changed.agents))
+	for _, agentID := range changed.agents {
 		agentStarts[agentID] = svc.AgentStartup.cancelForArchive(agentID)
 	}
-	terminalStarts := make(map[string]*startupEntry, len(terminalIDs))
-	for _, terminalID := range terminalIDs {
+	terminalStarts := make(map[string]*startupEntry, len(changed.terminals))
+	for _, terminalID := range changed.terminals {
 		terminalStarts[terminalID] = svc.TerminalStartup.cancelForArchive(terminalID)
 	}
-	// Signal all running processes before any one process drain can block.
-	for _, agentID := range agentIDs {
-		svc.Agents.StopAgent(agentID)
+	// Signal every process before any one drain can block. StopAgent waits for
+	// the subprocess to answer its stop signal, so these run concurrently:
+	// serially, N agents that ignore the signal cost N times that wait before
+	// the first drain even starts.
+	var signalled sync.WaitGroup
+	for _, agentID := range changed.agents {
+		signalled.Add(1)
+		go func() {
+			defer signalled.Done()
+			svc.Agents.StopAgent(agentID)
+		}()
 	}
-	for _, terminalID := range terminalIDs {
-		svc.Terminals.StopTerminal(terminalID)
+	for _, terminalID := range changed.terminals {
+		signalled.Add(1)
+		go func() {
+			defer signalled.Done()
+			svc.Terminals.StopTerminal(terminalID)
+		}()
 	}
+	signalled.Wait()
 
 	// Iterate the SLICE, not the map: the broadcasts below reach every watcher
 	// in the order the caller listed the tabs, rather than in Go's randomized
 	// map order.
-	for _, agentID := range agentIDs {
+	for _, agentID := range changed.agents {
 		svc.AgentStartup.waitForFinished(agentStarts[agentID])
 		unlock := svc.Agents.LockAgent(agentID)
 		svc.Agents.StopAndWaitAgent(agentID)
 		unlock()
 		svc.Output.ClearAgentRuntimeState(agentID)
 		svc.agentCleanups.retire(agentID)
-		row, err := svc.Queries.GetAgentByID(bgCtx(), agentID)
+		row, err := svc.Queries.GetAgentForInactiveBroadcast(bgCtx(), agentID)
 		if err == nil {
-			svc.broadcastAgentInactive(&row)
+			svc.broadcastAgentInactive(&db.Agent{
+				ID:             row.ID,
+				AgentSessionID: row.AgentSessionID,
+				AgentProvider:  row.AgentProvider,
+			})
 		} else if !errors.Is(err, sql.ErrNoRows) {
 			slog.Warn("archive: read agent for inactive broadcast", "agent_id", agentID, "error", err)
 		}
 	}
 
-	for _, terminalID := range terminalIDs {
+	for _, terminalID := range changed.terminals {
 		svc.TerminalStartup.waitForFinished(terminalStarts[terminalID])
 	}
-	for _, terminalID := range terminalIDs {
+	for _, terminalID := range changed.terminals {
 		svc.Terminals.WaitForExit(terminalID)
 		svc.terminalCleanups.retire(terminalID)
 		svc.clearTerminalBellCoalesce(terminalID)
-		row, err := svc.Queries.GetTerminal(bgCtx(), terminalID)
+		exitCode, err := svc.Queries.GetTerminalExitCode(bgCtx(), terminalID)
 		if err != nil {
 			if !errors.Is(err, sql.ErrNoRows) {
 				slog.Warn("archive: read terminal for exited broadcast", "terminal_id", terminalID, "error", err)
@@ -190,7 +292,7 @@ func (svc *Service) stopArchivedTabs(agentIDs, terminalIDs []string) {
 		svc.Watchers.BroadcastTerminalEvent(terminalID, &leapmuxv1.TerminalEvent{
 			TerminalId: terminalID,
 			Event: &leapmuxv1.TerminalEvent_Closed{Closed: &leapmuxv1.TerminalClosed{
-				ExitCode: int32(row.ExitCode),
+				ExitCode: int32(exitCode),
 			}},
 		})
 	}

--- a/backend/internal/worker/service/workspace_archive.go
+++ b/backend/internal/worker/service/workspace_archive.go
@@ -148,8 +148,11 @@ func (svc *Service) stopArchivedTabs(agentIDs, terminalIDs []string) {
 		svc.Terminals.StopTerminal(terminalID)
 	}
 
-	for agentID, startup := range agentStarts {
-		svc.AgentStartup.waitForFinished(startup)
+	// Iterate the SLICE, not the map: the broadcasts below reach every watcher
+	// in the order the caller listed the tabs, rather than in Go's randomized
+	// map order.
+	for _, agentID := range agentIDs {
+		svc.AgentStartup.waitForFinished(agentStarts[agentID])
 		unlock := svc.Agents.LockAgent(agentID)
 		svc.Agents.StopAndWaitAgent(agentID)
 		unlock()
@@ -163,8 +166,8 @@ func (svc *Service) stopArchivedTabs(agentIDs, terminalIDs []string) {
 		}
 	}
 
-	for _, startup := range terminalStarts {
-		svc.TerminalStartup.waitForFinished(startup)
+	for _, terminalID := range terminalIDs {
+		svc.TerminalStartup.waitForFinished(terminalStarts[terminalID])
 	}
 	for _, terminalID := range terminalIDs {
 		svc.Terminals.WaitForExit(terminalID)
@@ -177,6 +180,13 @@ func (svc *Service) stopArchivedTabs(agentIDs, terminalIDs []string) {
 			}
 			continue
 		}
+		// Broadcast even though a PTY that was RUNNING already broadcast the
+		// same event from makeTerminalExitFn: a terminal that never spawned, or
+		// that exited before the archive, fires no exit handler, and the client
+		// has to learn that its shell is gone from something. WaitForExit above
+		// returns only after that handler persisted the row, so the exit code
+		// read here is the final one rather than a stale zero, and the repeat is
+		// a repeat rather than a contradiction.
 		svc.Watchers.BroadcastTerminalEvent(terminalID, &leapmuxv1.TerminalEvent{
 			TerminalId: terminalID,
 			Event: &leapmuxv1.TerminalEvent_Closed{Closed: &leapmuxv1.TerminalClosed{

--- a/backend/internal/worker/service/workspace_archive_test.go
+++ b/backend/internal/worker/service/workspace_archive_test.go
@@ -20,12 +20,18 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func archiveRequest(state leapmuxv1.WorkspaceArchiveState, tabs ...*leapmuxv1.TabRef) *leapmuxv1.SetTabArchiveStateRequest {
-	return &leapmuxv1.SetTabArchiveStateRequest{ArchiveState: state, Tabs: tabs}
+// applyArchive drives the lifecycle operation the way its one production
+// caller does -- the orphan reconciler, through the ApplyArchiveState hook.
+// There is no RPC for it: the Hub nudges, and the reconcile pass applies.
+func applyArchive(t *testing.T, svc *Service, state leapmuxv1.WorkspaceArchiveState, tabs ...*leapmuxv1.TabRef) []string {
+	t.Helper()
+	resumeAgentIDs, err := svc.ApplyTabArchiveState(context.Background(), state, tabs)
+	require.NoError(t, err)
+	return resumeAgentIDs
 }
 
 // agentStatuses collects the statuses broadcast for one agent from a writer
-// that a WatchEvents dispatch is streaming into. Duplicates are kept: "how many
+// that a WatchEvents dispatch streams into. Duplicates are kept: "how many
 // times" is exactly what the duplicate-request test asks.
 func agentStatuses(t *testing.T, w *testResponseWriter, agentID string) []leapmuxv1.AgentStatus {
 	t.Helper()
@@ -69,7 +75,7 @@ func TestWorkspaceArchive_StopsProcessesAndPreservesTabData(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	svc, dispatcher, _ := setupTestService(t)
+	svc, _, _ := setupTestService(t)
 	const agentID = "archive-agent"
 	const terminalID = "archive-terminal"
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
@@ -134,16 +140,12 @@ func TestWorkspaceArchive_StopsProcessesAndPreservesTabData(t *testing.T) {
 	svc.agentCleanups.register(agentID, func() { agentCleanup.Store(true) })
 	svc.terminalCleanups.register(terminalID, func() { terminalCleanup.Store(true) })
 
-	w := newTestWriter()
-	dispatch(dispatcher, "SetTabArchiveState", archiveRequest(
+	applyArchive(t, svc,
 		leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED,
 		&leapmuxv1.TabRef{TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: agentID},
 		&leapmuxv1.TabRef{TabType: leapmuxv1.TabType_TAB_TYPE_TERMINAL, TabId: terminalID},
-		&leapmuxv1.TabRef{TabType: leapmuxv1.TabType_TAB_TYPE_FILE, TabId: "archive-file"},
-	), w)
+		&leapmuxv1.TabRef{TabType: leapmuxv1.TabType_TAB_TYPE_FILE, TabId: "archive-file"})
 
-	require.Empty(t, w.errors)
-	require.Len(t, w.responses, 1)
 	assert.False(t, svc.Agents.HasAgent(agentID))
 	assert.False(t, svc.Terminals.IsRunning(terminalID))
 	agentRow, err := svc.Queries.GetAgentByID(ctx, agentID)
@@ -193,13 +195,10 @@ func TestWorkspaceArchive_StopsAnAgentThatOwnsNoProcess(t *testing.T) {
 	require.False(t, svc.Agents.HasAgent(agentID))
 	watcher := watchAgent(t, dispatcher, agentID)
 
-	w := newTestWriter()
-	dispatch(dispatcher, "SetTabArchiveState", archiveRequest(
+	applyArchive(t, svc,
 		leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED,
-		&leapmuxv1.TabRef{TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: agentID},
-	), w)
+		&leapmuxv1.TabRef{TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: agentID})
 
-	require.Empty(t, w.errors)
 	row, err := svc.Queries.GetAgentByID(ctx, agentID)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), row.WorkspaceArchived)
@@ -223,7 +222,7 @@ func TestWorkspaceArchive_StopsEveryTabInTheRequest(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	svc, dispatcher, _ := setupTestService(t)
+	svc, _, _ := setupTestService(t)
 	agentIDs := []string{"multi-agent-1", "multi-agent-2", "multi-agent-3"}
 	terminalIDs := []string{"multi-terminal-1", "multi-terminal-2"}
 	tabs := make([]*leapmuxv1.TabRef, 0, len(agentIDs)+len(terminalIDs))
@@ -254,11 +253,8 @@ func TestWorkspaceArchive_StopsEveryTabInTheRequest(t *testing.T) {
 		tabs = append(tabs, &leapmuxv1.TabRef{TabType: leapmuxv1.TabType_TAB_TYPE_TERMINAL, TabId: terminalID})
 	}
 
-	w := newTestWriter()
-	dispatch(dispatcher, "SetTabArchiveState", archiveRequest(
-		leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED, tabs...), w)
+	applyArchive(t, svc, leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED, tabs...)
 
-	require.Empty(t, w.errors)
 	for _, agentID := range agentIDs {
 		assert.False(t, svc.Agents.HasAgent(agentID), "agent %s must stop", agentID)
 		row, err := svc.Queries.GetAgentByID(ctx, agentID)
@@ -282,7 +278,7 @@ func TestWorkspaceArchive_DuplicateArchiveIsANoOp(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	svc, dispatcher, _ := setupTestService(t)
+	svc, _, _ := setupTestService(t)
 	const agentID = "archive-twice"
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
 		ID: agentID, WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
@@ -291,13 +287,8 @@ func TestWorkspaceArchive_DuplicateArchiveIsANoOp(t *testing.T) {
 	var firstCleanup atomic.Bool
 	svc.agentCleanups.register(agentID, func() { firstCleanup.Store(true) })
 
-	request := archiveRequest(
-		leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED,
-		&leapmuxv1.TabRef{TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: agentID},
-	)
-	first := newTestWriter()
-	dispatch(dispatcher, "SetTabArchiveState", request, first)
-	require.Empty(t, first.errors)
+	tab := &leapmuxv1.TabRef{TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: agentID}
+	applyArchive(t, svc, leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED, tab)
 	require.True(t, firstCleanup.Load(), "the first archive runs the teardown")
 
 	// A fresh cleanup under the same id: the second request must leave it
@@ -306,11 +297,8 @@ func TestWorkspaceArchive_DuplicateArchiveIsANoOp(t *testing.T) {
 	var secondCleanup atomic.Bool
 	svc.agentCleanups.register(agentID, func() { secondCleanup.Store(true) })
 
-	second := newTestWriter()
-	dispatch(dispatcher, "SetTabArchiveState", request, second)
+	applyArchive(t, svc, leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED, tab)
 
-	require.Empty(t, second.errors)
-	require.Len(t, second.responses, 1)
 	assert.False(t, secondCleanup.Load(), "an archive that changes no row runs no teardown")
 	row, err := svc.Queries.GetAgentByID(ctx, agentID)
 	require.NoError(t, err)
@@ -329,7 +317,7 @@ func TestWorkspaceArchive_CancelsAnInFlightStartup(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	svc, dispatcher, _ := setupTestService(t)
+	svc, _, _ := setupTestService(t)
 	const agentID = "archive-starting"
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
 		ID: agentID, WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
@@ -349,20 +337,16 @@ func TestWorkspaceArchive_CancelsAnInFlightStartup(t *testing.T) {
 		svc.AgentStartup.finishEntry(handle)
 	}()
 
-	w := newTestWriter()
-	dispatch(dispatcher, "SetTabArchiveState", archiveRequest(
-		leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED,
-		&leapmuxv1.TabRef{TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: agentID},
-	), w)
+	applyArchive(t, svc, leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED,
+		&leapmuxv1.TabRef{TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: agentID})
 
-	require.Empty(t, w.errors)
 	select {
 	case <-settled:
 	default:
 		require.FailNow(t, "the archive answered while the startup it cancelled was still running")
 	}
-	archived, _ := svc.AgentStartup.archiveDisposition(handle)
-	assert.True(t, archived, "the startup must read the stop as an archive")
+	assert.True(t, svc.AgentStartup.archiveStopped(handle),
+		"the startup must read the stop as an archive")
 	_, closeRaced := svc.AgentStartup.dispositionOf(handle)
 	assert.False(t, closeRaced, "archival is not a tab close, so no worktree decision is recorded")
 	row, err := svc.Queries.GetAgentByID(ctx, agentID)
@@ -379,7 +363,7 @@ func TestWorkspaceArchive_UnarchiveResumesOnlyEligibleAgents(t *testing.T) {
 	svc, _, _ := setupTestService(t)
 	recorder := newStartRecorder()
 	recorder.install(svc)
-	resumer := svc.NewAgentResumer()
+	resumer := svc.AgentResumer()
 	t.Cleanup(resumer.Stop)
 
 	for _, testAgent := range []struct {
@@ -433,7 +417,7 @@ func TestWorkspaceArchive_UnarchiveResumesOnlyEligibleAgents(t *testing.T) {
 		{TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: "closed"},
 		{TabType: leapmuxv1.TabType_TAB_TYPE_TERMINAL, TabId: "terminal-exited"},
 	}
-	resumeAgentIDs, err := svc.applyTabArchiveState(ctx,
+	resumeAgentIDs, err := svc.ApplyTabArchiveState(ctx,
 		leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ACTIVE, tabs)
 	require.NoError(t, err)
 	resumer.Schedule(ctx, resumeAgentIDs)
@@ -441,7 +425,7 @@ func TestWorkspaceArchive_UnarchiveResumesOnlyEligibleAgents(t *testing.T) {
 	assert.Equal(t, []string{"eligible"}, recorder.ids())
 	assert.False(t, svc.Terminals.HasTerminal("terminal-exited"), "unarchive never restarts a terminal shell")
 
-	resumeAgentIDs, err = svc.applyTabArchiveState(ctx,
+	resumeAgentIDs, err = svc.ApplyTabArchiveState(ctx,
 		leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ACTIVE, tabs)
 	require.NoError(t, err)
 	resumer.Schedule(ctx, resumeAgentIDs)
@@ -454,7 +438,7 @@ func TestWorkspaceArchive_DatabaseFailureStopsNoProcess(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	svc, dispatcher, _ := setupTestService(t)
+	svc, _, _ := setupTestService(t)
 	const agentID = "archive-db-failure"
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
 		ID: agentID, WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
@@ -474,35 +458,246 @@ BEGIN
 END`)
 	require.NoError(t, err)
 
-	w := newTestWriter()
-	dispatch(dispatcher, "SetTabArchiveState", archiveRequest(
-		leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED,
-		&leapmuxv1.TabRef{TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: agentID},
-	), w)
+	_, err = svc.ApplyTabArchiveState(ctx, leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED,
+		[]*leapmuxv1.TabRef{{TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: agentID}})
 
-	require.Len(t, w.errors, 1)
-	assert.Equal(t, int32(codes.Internal), w.errors[0].code)
-	assert.True(t, svc.Agents.HasAgent(agentID))
+	require.Error(t, err)
+	assert.True(t, svc.Agents.HasAgent(agentID),
+		"a failed flag write must stop no process: the teardown runs only after the commit")
 	row, err := svc.Queries.GetAgentByID(ctx, agentID)
 	require.NoError(t, err)
 	assert.Zero(t, row.WorkspaceArchived)
 }
 
-func TestWorkspaceArchive_InvalidStateChangesNothing(t *testing.T) {
+func TestWorkspaceArchive_InvalidRequestChangesNothing(t *testing.T) {
 	t.Parallel()
 
-	svc, dispatcher, _ := setupTestService(t)
-	require.NoError(t, svc.Queries.CreateAgent(context.Background(), db.CreateAgentParams{
+	ctx := context.Background()
+	svc, _, _ := setupTestService(t)
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
 		ID: "agent-1", AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
 	}))
-	w := newTestWriter()
-	dispatch(dispatcher, "SetTabArchiveState", archiveRequest(
-		leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_UNSPECIFIED,
-		&leapmuxv1.TabRef{TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: "agent-1"},
-	), w)
-	require.Len(t, w.errors, 1)
-	assert.Equal(t, codeInvalidArgument, w.errors[0].code)
-	row, err := svc.Queries.GetAgentByID(context.Background(), "agent-1")
+
+	// The reconciler drops an unclassifiable row through archivableTabType
+	// BEFORE it calls, so these refusals are a backstop for a future caller
+	// that forgets that filter. Each must refuse before it writes anything.
+	_, err := svc.ApplyTabArchiveState(ctx, leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_UNSPECIFIED,
+		[]*leapmuxv1.TabRef{{TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: "agent-1"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "archive_state must be ACTIVE or ARCHIVED")
+
+	_, err = svc.ApplyTabArchiveState(ctx, leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED,
+		[]*leapmuxv1.TabRef{{TabType: leapmuxv1.TabType_TAB_TYPE_UNSPECIFIED, TabId: "agent-1"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unspecified type")
+
+	row, err := svc.Queries.GetAgentByID(ctx, "agent-1")
 	require.NoError(t, err)
-	assert.Zero(t, row.WorkspaceArchived)
+	assert.Zero(t, row.WorkspaceArchived, "a refused request writes nothing")
+}
+
+// TestWorkspaceArchive_RefusesEveryWriteRPCOnAnArchivedTab pins the rule that
+// moved from four hand-written per-handler guards into the registrars.
+//
+// The four handlers that carried a guard were the four the browser happened to
+// call. Every OTHER write RPC ran, and three of them wrote state that outlives
+// the archive: RenameAgent stored a title, DeleteAgentMessage removed a
+// transcript row, UpdateTerminalTitle stored a title. A second client, the CLI,
+// or any holder of the write scope reached all of them.
+//
+// It also asserts the other half of the rule: a READ stays reachable, which is
+// what makes an archived workspace browsable rather than merely frozen.
+func TestWorkspaceArchive_RefusesEveryWriteRPCOnAnArchivedTab(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc, dispatcher, _ := setupTestService(t)
+	const agentID = "archived-agent"
+	const terminalID = "archived-terminal"
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: agentID, WorkingDir: t.TempDir(), HomeDir: t.TempDir(), Title: "before",
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+	}))
+	require.NoError(t, svc.Queries.UpsertTerminal(ctx, db.UpsertTerminalParams{
+		ID: terminalID, WorkingDir: t.TempDir(), HomeDir: t.TempDir(), Title: "before",
+		Shell: testutil.TestShell(), Cols: 80, Rows: 24, Screen: []byte{},
+	}))
+	_, err := svc.ApplyTabArchiveState(ctx, leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED,
+		[]*leapmuxv1.TabRef{
+			{TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: agentID},
+			{TabType: leapmuxv1.TabType_TAB_TYPE_TERMINAL, TabId: terminalID},
+		})
+	require.NoError(t, err)
+
+	refused := []struct {
+		method string
+		req    proto.Message
+	}{
+		{"RenameAgent", &leapmuxv1.RenameAgentRequest{AgentId: agentID, Title: "after"}},
+		{"DeleteAgentMessage", &leapmuxv1.DeleteAgentMessageRequest{AgentId: agentID, MessageId: "m-1"}},
+		{"CloseAgent", &leapmuxv1.CloseAgentRequest{AgentId: agentID}},
+		{"InterruptAgent", &leapmuxv1.InterruptAgentRequest{AgentId: agentID}},
+		{"SendAgentMessage", &leapmuxv1.SendAgentMessageRequest{AgentId: agentID, Content: "hi"}},
+		{"UpdateTerminalTitle", &leapmuxv1.UpdateTerminalTitleRequest{TerminalId: terminalID, Title: "after"}},
+		{"CloseTerminal", &leapmuxv1.CloseTerminalRequest{TerminalId: terminalID}},
+		{"SendInput", &leapmuxv1.SendInputRequest{TerminalId: terminalID, Data: []byte("x")}},
+		{"ResizeTerminal", &leapmuxv1.ResizeTerminalRequest{TerminalId: terminalID, Cols: 10, Rows: 10}},
+		{"RestartTerminal", &leapmuxv1.RestartTerminalRequest{TerminalId: terminalID}},
+	}
+	for _, tc := range refused {
+		t.Run(tc.method, func(t *testing.T) {
+			w := newTestWriter()
+			dispatch(dispatcher, tc.method, tc.req, w)
+			require.Len(t, w.errors, 1, "%s must answer an error while archived", tc.method)
+			assert.Equal(t, int32(codes.FailedPrecondition), w.errors[0].code,
+				"%s must name the archive as the reason, not fail for some other cause", tc.method)
+		})
+	}
+
+	// Nothing above stored anything.
+	agentRow, err := svc.Queries.GetAgentByID(ctx, agentID)
+	require.NoError(t, err)
+	assert.Equal(t, "before", agentRow.Title, "a refused rename must not store a title")
+	assert.False(t, agentRow.ClosedAt.Valid, "a refused close must not stamp closed_at")
+	terminalRow, err := svc.Queries.GetTerminal(ctx, terminalID)
+	require.NoError(t, err)
+	assert.Equal(t, "before", terminalRow.Title, "a refused rename must not store a title")
+	assert.False(t, terminalRow.ClosedAt.Valid, "a refused close must not stamp closed_at")
+
+	// A READ stays reachable: the archive freezes mutation, not visibility.
+	w := newTestWriter()
+	dispatch(dispatcher, "ListAgentMessages", &leapmuxv1.ListAgentMessagesRequest{AgentId: agentID}, w)
+	assert.Empty(t, w.errors, "an archived workspace must stay readable")
+}
+
+// TestWorkspaceArchive_SkipsAClosedRow pins the closed_at predicate on both
+// archive UPDATEs.
+//
+// A closed row stays in these tables for the whole 7-day cleanup retention, and
+// the caller treats every row the UPDATE changed as a tab to stop and broadcast
+// for. Without the predicate an archive that races a close re-ran the full
+// teardown for a tab the worker already tore down -- the same reason the orphan
+// reconciler reads ListAllOpenRootAgentIDs -- and the matching unarchive spent
+// a resume permit on it.
+func TestWorkspaceArchive_SkipsAClosedRow(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc, _, _ := setupTestService(t)
+	const closedAgent = "closed-agent"
+	const openAgent = "open-agent"
+	for _, id := range []string{closedAgent, openAgent} {
+		require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+			ID: id, WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+			AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+		}))
+	}
+	_, err := svc.Queries.CloseAgent(ctx, closedAgent)
+	require.NoError(t, err)
+
+	tabs := []*leapmuxv1.TabRef{
+		{TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: closedAgent},
+		{TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: openAgent},
+	}
+	_, err = svc.ApplyTabArchiveState(ctx, leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED, tabs)
+	require.NoError(t, err)
+
+	closedRow, err := svc.Queries.GetAgentByID(ctx, closedAgent)
+	require.NoError(t, err)
+	assert.Zero(t, closedRow.WorkspaceArchived, "a closed row takes no archive flag and no teardown")
+	openRow, err := svc.Queries.GetAgentByID(ctx, openAgent)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), openRow.WorkspaceArchived)
+
+	// The unarchive must not offer the closed row as a resume candidate.
+	resumeAgentIDs, err := svc.ApplyTabArchiveState(ctx, leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ACTIVE, tabs)
+	require.NoError(t, err)
+	assert.Equal(t, []string{openAgent}, resumeAgentIDs,
+		"a closed row must not spend a resume permit only to be skipped")
+}
+
+// TestWorkspaceArchive_UnarchiveWaitsForAnArchiveDrain pins the atomicity of
+// one tab's lifecycle: the flag write and the teardown that follows it are ONE
+// operation, not two.
+//
+// The failure it excludes: archive A commits workspace_archived=1 and starts
+// draining. Unarchive B commits 0 and hands its agent id back for a resume. A's
+// drain -- which re-reads nothing after its own commit -- then stops the
+// process the resume just started, clears its runtime state, and broadcasts
+// INACTIVE for a row that says active. The user watches an agent they just
+// unarchived go inactive again, with no error anywhere.
+//
+// LockAgent is the seam that makes this deterministic. The archive drain takes
+// it per agent, so holding it here parks A precisely mid-drain, with its flag
+// already committed. B must then WAIT. Without the per-tab lock B runs straight
+// through and answers with a resume id while A is still tearing that agent
+// down, which is the race in one step.
+func TestWorkspaceArchive_UnarchiveWaitsForAnArchiveDrain(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc, _, _ := setupTestService(t)
+	const agentID = "archive-drain-race"
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: agentID, WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE, Resumed: 1,
+	}))
+	_, err := svc.Agents.MockStartAgent(ctx, agent.Options{
+		AgentID: agentID, WorkingDir: t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+	}, svc.Output.NewSink(agentID, leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE))
+	require.NoError(t, err)
+
+	tabs := []*leapmuxv1.TabRef{{TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: agentID}}
+
+	// Park the archive inside its drain, holding the agent's lifecycle lock.
+	releaseAgent := svc.Agents.LockAgent(agentID)
+	archiveDone := make(chan struct{})
+	go func() {
+		defer close(archiveDone)
+		_, archiveErr := svc.ApplyTabArchiveState(ctx,
+			leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED, tabs)
+		assert.NoError(t, archiveErr)
+	}()
+
+	// The archive committed its flag and is now blocked in the drain.
+	testutil.AssertEventually(t, func() bool {
+		row, rowErr := svc.Queries.GetAgentByID(ctx, agentID)
+		return rowErr == nil && row.WorkspaceArchived == 1
+	}, "the archive commits its flag before it drains")
+
+	unarchiveDone := make(chan []string, 1)
+	go func() {
+		resumeIDs, unarchiveErr := svc.ApplyTabArchiveState(ctx,
+			leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ACTIVE, tabs)
+		assert.NoError(t, unarchiveErr)
+		unarchiveDone <- resumeIDs
+	}()
+
+	select {
+	case <-unarchiveDone:
+		require.FailNow(t, "the unarchive answered while the archive was still draining that same tab; "+
+			"its resume would be stopped by the drain that is still running")
+	case <-time.After(150 * time.Millisecond):
+	}
+	row, err := svc.Queries.GetAgentByID(ctx, agentID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), row.WorkspaceArchived,
+		"the unarchive must not commit its flag while the archive still owns the tab")
+
+	// Let the drain finish; the unarchive then proceeds in full.
+	releaseAgent()
+	<-archiveDone
+	select {
+	case resumeIDs := <-unarchiveDone:
+		assert.Equal(t, []string{agentID}, resumeIDs,
+			"the unarchive that ran after the drain must offer the resume")
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, "the unarchive never completed after the archive drain returned")
+	}
+	settled, err := svc.Queries.GetAgentByID(ctx, agentID)
+	require.NoError(t, err)
+	assert.Zero(t, settled.WorkspaceArchived)
+	assert.False(t, settled.ClosedAt.Valid, "neither operation may close the tab")
+	assert.Empty(t, settled.StartupError, "neither operation may mark the tab failed")
 }

--- a/backend/internal/worker/service/workspace_archive_test.go
+++ b/backend/internal/worker/service/workspace_archive_test.go
@@ -13,13 +13,56 @@ import (
 	"github.com/leapmux/leapmux/internal/util/sqltime"
 	"github.com/leapmux/leapmux/internal/util/testutil"
 	"github.com/leapmux/leapmux/internal/worker/agent"
+	"github.com/leapmux/leapmux/internal/worker/channel"
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
 	"github.com/leapmux/leapmux/internal/worker/terminal"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/protobuf/proto"
 )
 
 func archiveRequest(state leapmuxv1.WorkspaceArchiveState, tabs ...*leapmuxv1.TabRef) *leapmuxv1.SetTabArchiveStateRequest {
 	return &leapmuxv1.SetTabArchiveStateRequest{ArchiveState: state, Tabs: tabs}
+}
+
+// agentStatuses collects the statuses broadcast for one agent from a writer
+// that a WatchEvents dispatch is streaming into. Duplicates are kept: "how many
+// times" is exactly what the duplicate-request test asks.
+func agentStatuses(t *testing.T, w *testResponseWriter, agentID string) []leapmuxv1.AgentStatus {
+	t.Helper()
+	var out []leapmuxv1.AgentStatus
+	for _, s := range w.streamsSnapshot() {
+		var resp leapmuxv1.WatchEventsResponse
+		if err := proto.Unmarshal(s.GetPayload(), &resp); err != nil {
+			continue
+		}
+		event := resp.GetAgentEvent()
+		if event.GetAgentId() != agentID {
+			continue
+		}
+		if sc := event.GetStatusChange(); sc != nil {
+			out = append(out, sc.GetStatus())
+		}
+	}
+	return out
+}
+
+// watchAgent subscribes to one agent's events so a test can read the broadcasts
+// archival makes.
+//
+// The catch-up replay cannot forge a status: it replays MESSAGES, and an agent
+// StatusChange reaches a subscriber only from broadcastStatusChange. So every
+// status agentStatuses reports is one this operation emitted.
+func watchAgent(t *testing.T, d *channel.Dispatcher, agentID string) *testResponseWriter {
+	t.Helper()
+	w := newTestWriter()
+	dispatch(d, "WatchEvents", &leapmuxv1.WatchEventsRequest{
+		Agents: []*leapmuxv1.WatchAgentEntry{{
+			AgentId: agentID,
+			Replay:  leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_LATEST,
+			Mode:    leapmuxv1.WatchMode_WATCH_MODE_FULL,
+		}},
+	}, w)
+	return w
 }
 
 func TestWorkspaceArchive_StopsProcessesAndPreservesTabData(t *testing.T) {
@@ -130,6 +173,203 @@ func TestWorkspaceArchive_StopsProcessesAndPreservesTabData(t *testing.T) {
 	assert.Empty(t, activeSchedules)
 	assert.True(t, agentCleanup.Load())
 	assert.True(t, terminalCleanup.Load())
+}
+
+// TestWorkspaceArchive_StopsAnAgentThatOwnsNoProcess covers the tab that is
+// already INACTIVE when the archive lands -- a worker restart, or a tab the
+// user opened and never talked to. There is nothing to stop, so the DB write
+// and the broadcast are the whole operation, and a client watching that tab
+// still has to be told which state it settled in.
+func TestWorkspaceArchive_StopsAnAgentThatOwnsNoProcess(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc, dispatcher, _ := setupTestService(t)
+	const agentID = "archive-inactive"
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: agentID, WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+	}))
+	require.False(t, svc.Agents.HasAgent(agentID))
+	watcher := watchAgent(t, dispatcher, agentID)
+
+	w := newTestWriter()
+	dispatch(dispatcher, "SetTabArchiveState", archiveRequest(
+		leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED,
+		&leapmuxv1.TabRef{TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: agentID},
+	), w)
+
+	require.Empty(t, w.errors)
+	row, err := svc.Queries.GetAgentByID(ctx, agentID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), row.WorkspaceArchived)
+	assert.False(t, row.ClosedAt.Valid, "archival preserves the open row")
+	// The broadcast reaches a subscriber's stream asynchronously, so this waits
+	// for it rather than reading once: the DB write above is what the handler
+	// completes synchronously, and the delivery trails it.
+	testutil.AssertEventually(t, func() bool {
+		return len(agentStatuses(t, watcher, agentID)) == 1
+	}, "archival broadcasts the agent's settled state")
+	assert.Equal(t,
+		[]leapmuxv1.AgentStatus{leapmuxv1.AgentStatus_AGENT_STATUS_INACTIVE},
+		agentStatuses(t, watcher, agentID))
+}
+
+// TestWorkspaceArchive_StopsEveryTabInTheRequest covers the LIST, which the
+// single-tab cases cannot: a workspace normally holds several agents and
+// terminals, and a loop that stopped the first and returned -- or that stopped
+// the agents and skipped the terminals -- passes every other test in this file.
+func TestWorkspaceArchive_StopsEveryTabInTheRequest(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc, dispatcher, _ := setupTestService(t)
+	agentIDs := []string{"multi-agent-1", "multi-agent-2", "multi-agent-3"}
+	terminalIDs := []string{"multi-terminal-1", "multi-terminal-2"}
+	tabs := make([]*leapmuxv1.TabRef, 0, len(agentIDs)+len(terminalIDs))
+	for _, agentID := range agentIDs {
+		require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+			ID: agentID, WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+			AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+		}))
+		_, err := svc.Agents.MockStartAgent(ctx, agent.Options{
+			AgentID: agentID, WorkingDir: t.TempDir(),
+			AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+		}, svc.Output.NewSink(agentID, leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE))
+		require.NoError(t, err)
+		require.True(t, svc.Agents.HasAgent(agentID))
+		tabs = append(tabs, &leapmuxv1.TabRef{TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: agentID})
+	}
+	for _, terminalID := range terminalIDs {
+		terminalDir := t.TempDir()
+		require.NoError(t, svc.Queries.UpsertTerminal(ctx, db.UpsertTerminalParams{
+			ID: terminalID, WorkingDir: terminalDir, HomeDir: t.TempDir(),
+			Shell: testutil.TestShell(), Cols: 80, Rows: 24, Screen: []byte{},
+		}))
+		require.NoError(t, svc.Terminals.StartTerminal(ctx, terminal.Options{
+			ID: terminalID, Shell: testutil.TestShell(), WorkingDir: terminalDir, Cols: 80, Rows: 24,
+		}, svc.makeTerminalOutputFn(terminalID), svc.makeTerminalExitFn()))
+		testutil.RegisterTerminalCleanup(t, svc.Terminals, terminalID)
+		require.True(t, svc.Terminals.IsRunning(terminalID))
+		tabs = append(tabs, &leapmuxv1.TabRef{TabType: leapmuxv1.TabType_TAB_TYPE_TERMINAL, TabId: terminalID})
+	}
+
+	w := newTestWriter()
+	dispatch(dispatcher, "SetTabArchiveState", archiveRequest(
+		leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED, tabs...), w)
+
+	require.Empty(t, w.errors)
+	for _, agentID := range agentIDs {
+		assert.False(t, svc.Agents.HasAgent(agentID), "agent %s must stop", agentID)
+		row, err := svc.Queries.GetAgentByID(ctx, agentID)
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), row.WorkspaceArchived, "agent %s must record the archive", agentID)
+	}
+	for _, terminalID := range terminalIDs {
+		assert.False(t, svc.Terminals.IsRunning(terminalID), "terminal %s must stop", terminalID)
+		row, err := svc.Queries.GetTerminal(ctx, terminalID)
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), row.WorkspaceArchived, "terminal %s must record the archive", terminalID)
+	}
+}
+
+// TestWorkspaceArchive_DuplicateArchiveIsANoOp pins the idempotency the Hub
+// relies on: the reconciler re-sends the authoritative state on EVERY pass, so
+// a second ARCHIVED for a tab already archived must run no teardown at all.
+// Re-running it would retire a control socket that a legitimate later spawn had
+// registered, and re-broadcast a settled state on every hourly pass.
+func TestWorkspaceArchive_DuplicateArchiveIsANoOp(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc, dispatcher, _ := setupTestService(t)
+	const agentID = "archive-twice"
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: agentID, WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+	}))
+	var firstCleanup atomic.Bool
+	svc.agentCleanups.register(agentID, func() { firstCleanup.Store(true) })
+
+	request := archiveRequest(
+		leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED,
+		&leapmuxv1.TabRef{TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: agentID},
+	)
+	first := newTestWriter()
+	dispatch(dispatcher, "SetTabArchiveState", request, first)
+	require.Empty(t, first.errors)
+	require.True(t, firstCleanup.Load(), "the first archive runs the teardown")
+
+	// A fresh cleanup under the same id: the second request must leave it
+	// registered, which no assertion on the FIRST one could tell apart from a
+	// teardown that simply found an empty registry.
+	var secondCleanup atomic.Bool
+	svc.agentCleanups.register(agentID, func() { secondCleanup.Store(true) })
+
+	second := newTestWriter()
+	dispatch(dispatcher, "SetTabArchiveState", request, second)
+
+	require.Empty(t, second.errors)
+	require.Len(t, second.responses, 1)
+	assert.False(t, secondCleanup.Load(), "an archive that changes no row runs no teardown")
+	row, err := svc.Queries.GetAgentByID(ctx, agentID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), row.WorkspaceArchived)
+}
+
+// TestWorkspaceArchive_CancelsAnInFlightStartup covers the startup race.
+//
+// Archival cancels the startup context and then WAITS for that goroutine's own
+// trailing work before it clears the tab's runtime state -- otherwise the
+// startup registers a control socket after the teardown ran and nothing ever
+// retires it. It must also record the stop as an ARCHIVE rather than as a close
+// or a failure: the tab stays open, keeps its worktree decision unmade, and
+// starts again on unarchive.
+func TestWorkspaceArchive_CancelsAnInFlightStartup(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc, dispatcher, _ := setupTestService(t)
+	const agentID = "archive-starting"
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: agentID, WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+	}))
+	startupCtx, cancel := context.WithCancel(ctx)
+	t.Cleanup(cancel)
+	handle := svc.AgentStartup.begin(agentID, cancel)
+	require.NotNil(t, handle)
+
+	// Stands in for runAgentStartup: it returns only once the archive cancelled
+	// its context, so `settled` is closed strictly before finishEntry.
+	settled := make(chan struct{})
+	go func() {
+		<-startupCtx.Done()
+		close(settled)
+		svc.AgentStartup.finishEntry(handle)
+	}()
+
+	w := newTestWriter()
+	dispatch(dispatcher, "SetTabArchiveState", archiveRequest(
+		leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED,
+		&leapmuxv1.TabRef{TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: agentID},
+	), w)
+
+	require.Empty(t, w.errors)
+	select {
+	case <-settled:
+	default:
+		require.FailNow(t, "the archive answered while the startup it cancelled was still running")
+	}
+	archived, _ := svc.AgentStartup.archiveDisposition(handle)
+	assert.True(t, archived, "the startup must read the stop as an archive")
+	_, closeRaced := svc.AgentStartup.dispositionOf(handle)
+	assert.False(t, closeRaced, "archival is not a tab close, so no worktree decision is recorded")
+	row, err := svc.Queries.GetAgentByID(ctx, agentID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), row.WorkspaceArchived)
+	assert.False(t, row.ClosedAt.Valid)
+	assert.Empty(t, row.StartupError, "archival is not a startup failure, so the tab stays retryable")
 }
 
 func TestWorkspaceArchive_UnarchiveResumesOnlyEligibleAgents(t *testing.T) {

--- a/backend/internal/worker/service/workspace_archive_test.go
+++ b/backend/internal/worker/service/workspace_archive_test.go
@@ -1,0 +1,268 @@
+package service
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/util/sqltime"
+	"github.com/leapmux/leapmux/internal/util/testutil"
+	"github.com/leapmux/leapmux/internal/worker/agent"
+	db "github.com/leapmux/leapmux/internal/worker/generated/db"
+	"github.com/leapmux/leapmux/internal/worker/terminal"
+	"google.golang.org/grpc/codes"
+)
+
+func archiveRequest(state leapmuxv1.WorkspaceArchiveState, tabs ...*leapmuxv1.TabRef) *leapmuxv1.SetTabArchiveStateRequest {
+	return &leapmuxv1.SetTabArchiveStateRequest{ArchiveState: state, Tabs: tabs}
+}
+
+func TestWorkspaceArchive_StopsProcessesAndPreservesTabData(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc, dispatcher, _ := setupTestService(t)
+	const agentID = "archive-agent"
+	const terminalID = "archive-terminal"
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: agentID, WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+		Resumed:       1,
+	}))
+	require.NoError(t, svc.Queries.UpdateAgentSessionID(ctx, db.UpdateAgentSessionIDParams{
+		AgentSessionID: "session-archive", ID: agentID,
+	}))
+	_, err := svc.Queries.CreateMessage(ctx, db.CreateMessageParams{
+		ID: "message-1", AgentID: agentID, Source: leapmuxv1.MessageSource_MESSAGE_SOURCE_USER,
+		Content: []byte("preserved transcript"), ContentCompression: leapmuxv1.ContentCompression_CONTENT_COMPRESSION_NONE,
+		SpanLines: "[]", AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+		CreatedAt: sqltime.NewSQLiteTime(time.Now()),
+	})
+	require.NoError(t, err)
+	_, err = svc.Agents.MockStartAgent(ctx, agent.Options{
+		AgentID: agentID, WorkingDir: t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+	}, svc.Output.NewSink(agentID, leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE))
+	require.NoError(t, err)
+
+	terminalDir := t.TempDir()
+	require.NoError(t, svc.Queries.UpsertTerminal(ctx, db.UpsertTerminalParams{
+		ID: terminalID, WorkingDir: terminalDir, HomeDir: t.TempDir(),
+		Shell: testutil.TestShell(), Cols: 80, Rows: 24, Screen: []byte{},
+	}))
+	require.NoError(t, svc.Terminals.StartTerminal(ctx, terminal.Options{
+		ID: terminalID, Shell: testutil.TestShell(), WorkingDir: terminalDir, Cols: 80, Rows: 24,
+	}, svc.makeTerminalOutputFn(terminalID), svc.makeTerminalExitFn()))
+	testutil.RegisterTerminalCleanup(t, svc.Terminals, terminalID)
+	require.True(t, svc.Terminals.AppendOutput(terminalID, []byte("preserved terminal output")))
+
+	worktreePath := t.TempDir()
+	_, err = svc.Queries.CreateWorktree(ctx, db.CreateWorktreeParams{
+		ID: "worktree-1", WorktreePath: worktreePath, RepoRoot: t.TempDir(), BranchName: "archive-test",
+	})
+	require.NoError(t, err)
+	for _, tab := range []*leapmuxv1.TabRef{
+		{TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: agentID},
+		{TabType: leapmuxv1.TabType_TAB_TYPE_TERMINAL, TabId: terminalID},
+	} {
+		require.NoError(t, svc.Queries.AddWorktreeTab(ctx, db.AddWorktreeTabParams{
+			WorktreeID: "worktree-1", TabType: tab.GetTabType(), TabID: tab.GetTabId(),
+		}))
+	}
+	filePath := testutil.NativeAbsPath("/tmp/archive-preserved.txt")
+	require.NoError(t, svc.TabPayloads.Register(ctx, RegisterTabPayloadParams{
+		UserID: "user-1", TabID: "archive-file", Payload: &leapmuxv1.TabPayload{
+			Kind: &leapmuxv1.TabPayload_File{File: &leapmuxv1.FileTabPayload{FilePath: filePath}},
+		},
+	}))
+	require.NoError(t, svc.Queries.CreateControlRequest(ctx, db.CreateControlRequestParams{
+		AgentID: agentID, RequestID: "control-1", Payload: []byte("pending"), ClaimToken: "claim-1",
+	}))
+	require.NoError(t, svc.Queries.UpsertAutoContinueSchedule(ctx, db.UpsertAutoContinueScheduleParams{
+		AgentID: agentID, Reason: string(agent.AutoContinueReasonAPIError), Content: "Continue.",
+		DueAt: sqltime.NewSQLiteTime(time.Now().Add(time.Hour)), SourcePayload: []byte{},
+	}))
+	var agentCleanup, terminalCleanup atomic.Bool
+	svc.agentCleanups.register(agentID, func() { agentCleanup.Store(true) })
+	svc.terminalCleanups.register(terminalID, func() { terminalCleanup.Store(true) })
+
+	w := newTestWriter()
+	dispatch(dispatcher, "SetTabArchiveState", archiveRequest(
+		leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED,
+		&leapmuxv1.TabRef{TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: agentID},
+		&leapmuxv1.TabRef{TabType: leapmuxv1.TabType_TAB_TYPE_TERMINAL, TabId: terminalID},
+		&leapmuxv1.TabRef{TabType: leapmuxv1.TabType_TAB_TYPE_FILE, TabId: "archive-file"},
+	), w)
+
+	require.Empty(t, w.errors)
+	require.Len(t, w.responses, 1)
+	assert.False(t, svc.Agents.HasAgent(agentID))
+	assert.False(t, svc.Terminals.IsRunning(terminalID))
+	agentRow, err := svc.Queries.GetAgentByID(ctx, agentID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), agentRow.WorkspaceArchived)
+	assert.False(t, agentRow.ClosedAt.Valid)
+	terminalRow, err := svc.Queries.GetTerminal(ctx, terminalID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), terminalRow.WorkspaceArchived)
+	assert.False(t, terminalRow.ClosedAt.Valid)
+	assert.Contains(t, string(terminalRow.Screen), "preserved terminal output")
+	messages, err := svc.Queries.ListAllMessagesByAgentID(ctx, db.ListAllMessagesByAgentIDParams{AgentID: agentID})
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	assert.Equal(t, []byte("preserved transcript"), messages[0].Content)
+	links, err := svc.Queries.CountWorktreeTabs(ctx, "worktree-1")
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), links)
+	payload, err := svc.TabPayloads.Get(ctx, "user-1", "archive-file")
+	require.NoError(t, err)
+	assert.Equal(t, filePath, payload.GetFile().GetFilePath())
+	controls, err := svc.Queries.ListControlRequestsByAgentID(ctx, agentID)
+	require.NoError(t, err)
+	assert.Empty(t, controls)
+	activeSchedules, err := svc.Queries.ListActiveAutoContinueSchedules(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, activeSchedules)
+	assert.True(t, agentCleanup.Load())
+	assert.True(t, terminalCleanup.Load())
+}
+
+func TestWorkspaceArchive_UnarchiveResumesOnlyEligibleAgents(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc, _, _ := setupTestService(t)
+	recorder := newStartRecorder()
+	recorder.install(svc)
+	resumer := svc.NewAgentResumer()
+	t.Cleanup(resumer.Stop)
+
+	for _, testAgent := range []struct {
+		id           string
+		sessionID    string
+		resumed      int64
+		startupError string
+		closed       bool
+	}{
+		{id: "eligible", sessionID: "session-eligible", resumed: 1},
+		{id: "startup-failed", sessionID: "session-failed", resumed: 1, startupError: "failed"},
+		{id: "never-started"},
+		{id: "closed", sessionID: "session-closed", resumed: 1, closed: true},
+	} {
+		require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+			ID: testAgent.id, WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+			AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+			Resumed:       testAgent.resumed,
+		}))
+		if testAgent.sessionID != "" {
+			require.NoError(t, svc.Queries.UpdateAgentSessionID(ctx, db.UpdateAgentSessionIDParams{
+				AgentSessionID: testAgent.sessionID, ID: testAgent.id,
+			}))
+		}
+		if testAgent.startupError != "" {
+			require.NoError(t, svc.Queries.SetAgentStartupError(ctx, db.SetAgentStartupErrorParams{
+				StartupError: testAgent.startupError, ID: testAgent.id,
+			}))
+		}
+		if testAgent.closed {
+			_, err := svc.Queries.CloseAgent(ctx, testAgent.id)
+			require.NoError(t, err)
+		}
+		_, err := svc.Queries.SetAgentWorkspaceArchived(ctx, db.SetAgentWorkspaceArchivedParams{
+			WorkspaceArchived: 1, ID: testAgent.id,
+		})
+		require.NoError(t, err)
+	}
+	require.NoError(t, svc.Queries.UpsertTerminal(ctx, db.UpsertTerminalParams{
+		ID: "terminal-exited", Screen: []byte("screen"),
+	}))
+	_, err := svc.Queries.SetTerminalWorkspaceArchived(ctx, db.SetTerminalWorkspaceArchivedParams{
+		WorkspaceArchived: 1, ID: "terminal-exited",
+	})
+	require.NoError(t, err)
+
+	tabs := []*leapmuxv1.TabRef{
+		{TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: "eligible"},
+		{TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: "startup-failed"},
+		{TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: "never-started"},
+		{TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: "closed"},
+		{TabType: leapmuxv1.TabType_TAB_TYPE_TERMINAL, TabId: "terminal-exited"},
+	}
+	resumeAgentIDs, err := svc.applyTabArchiveState(ctx,
+		leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ACTIVE, tabs)
+	require.NoError(t, err)
+	resumer.Schedule(ctx, resumeAgentIDs)
+	testutil.AssertEventually(t, func() bool { return len(recorder.ids()) == 1 }, "eligible unarchive resume")
+	assert.Equal(t, []string{"eligible"}, recorder.ids())
+	assert.False(t, svc.Terminals.HasTerminal("terminal-exited"), "unarchive never restarts a terminal shell")
+
+	resumeAgentIDs, err = svc.applyTabArchiveState(ctx,
+		leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ACTIVE, tabs)
+	require.NoError(t, err)
+	resumer.Schedule(ctx, resumeAgentIDs)
+	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+		assert.Equal(collect, []string{"eligible"}, recorder.ids())
+	}, 100*time.Millisecond, 10*time.Millisecond)
+}
+
+func TestWorkspaceArchive_DatabaseFailureStopsNoProcess(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc, dispatcher, _ := setupTestService(t)
+	const agentID = "archive-db-failure"
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: agentID, WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+	}))
+	_, err := svc.Agents.MockStartAgent(ctx, agent.Options{
+		AgentID: agentID, WorkingDir: t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+	}, svc.Output.NewSink(agentID, leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE))
+	require.NoError(t, err)
+	t.Cleanup(func() { svc.Agents.StopAndWaitAgent(agentID) })
+	_, err = svc.DB.ExecContext(ctx, `
+CREATE TRIGGER fail_archive_update
+BEFORE UPDATE OF workspace_archived ON agents
+BEGIN
+  SELECT RAISE(FAIL, 'forced archive failure');
+END`)
+	require.NoError(t, err)
+
+	w := newTestWriter()
+	dispatch(dispatcher, "SetTabArchiveState", archiveRequest(
+		leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_ARCHIVED,
+		&leapmuxv1.TabRef{TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: agentID},
+	), w)
+
+	require.Len(t, w.errors, 1)
+	assert.Equal(t, int32(codes.Internal), w.errors[0].code)
+	assert.True(t, svc.Agents.HasAgent(agentID))
+	row, err := svc.Queries.GetAgentByID(ctx, agentID)
+	require.NoError(t, err)
+	assert.Zero(t, row.WorkspaceArchived)
+}
+
+func TestWorkspaceArchive_InvalidStateChangesNothing(t *testing.T) {
+	t.Parallel()
+
+	svc, dispatcher, _ := setupTestService(t)
+	require.NoError(t, svc.Queries.CreateAgent(context.Background(), db.CreateAgentParams{
+		ID: "agent-1", AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+	}))
+	w := newTestWriter()
+	dispatch(dispatcher, "SetTabArchiveState", archiveRequest(
+		leapmuxv1.WorkspaceArchiveState_WORKSPACE_ARCHIVE_STATE_UNSPECIFIED,
+		&leapmuxv1.TabRef{TabType: leapmuxv1.TabType_TAB_TYPE_AGENT, TabId: "agent-1"},
+	), w)
+	require.Len(t, w.errors, 1)
+	assert.Equal(t, codeInvalidArgument, w.errors[0].code)
+	row, err := svc.Queries.GetAgentByID(context.Background(), "agent-1")
+	require.NoError(t, err)
+	assert.Zero(t, row.WorkspaceArchived)
+}

--- a/backend/internal/worker/service/workspace_cleanup.go
+++ b/backend/internal/worker/service/workspace_cleanup.go
@@ -10,6 +10,29 @@ import (
 // registerCleanupHandlers registers workspace cleanup inner RPC handlers.
 func registerCleanupHandlers(d registrar, svc *Service) {
 	registerOwnerGated(d, "CleanupWorkspace", leapmuxv1.Scope_SCOPE_WORKSPACE_WRITE, dispatchTracked, handleCleanupWorkspace(svc))
+	registerOwnerGated(d, "SetTabArchiveState", leapmuxv1.Scope_SCOPE_WORKSPACE_WRITE, dispatchTracked, handleSetTabArchiveState(svc))
+}
+
+func handleSetTabArchiveState(svc *Service) func(context.Context, channel.Caller, *leapmuxv1.SetTabArchiveStateRequest, channel.ResponseWriter) {
+	return func(_ context.Context, _ channel.Caller, req *leapmuxv1.SetTabArchiveStateRequest, sender channel.ResponseWriter) {
+		if _, err := workspaceArchiveFlag(req.GetArchiveState()); err != nil {
+			sendInvalidArgument(sender, err.Error())
+			return
+		}
+		if _, _, err := archiveTabIDs(req.GetTabs()); err != nil {
+			sendInvalidArgument(sender, err.Error())
+			return
+		}
+		resumeAgentIDs, err := svc.applyTabArchiveState(bgCtx(), req.GetArchiveState(), req.GetTabs())
+		if err != nil {
+			sendInternalError(sender, err.Error())
+			return
+		}
+		if len(resumeAgentIDs) > 0 {
+			svc.NewAgentResumer().Schedule(bgCtx(), resumeAgentIDs)
+		}
+		sendProtoResponse(sender, &leapmuxv1.SetTabArchiveStateResponse{})
+	}
 }
 
 // handleCleanupWorkspace tears down the local resources behind the tabs a

--- a/backend/internal/worker/service/workspace_cleanup.go
+++ b/backend/internal/worker/service/workspace_cleanup.go
@@ -10,29 +10,6 @@ import (
 // registerCleanupHandlers registers workspace cleanup inner RPC handlers.
 func registerCleanupHandlers(d registrar, svc *Service) {
 	registerOwnerGated(d, "CleanupWorkspace", leapmuxv1.Scope_SCOPE_WORKSPACE_WRITE, dispatchTracked, handleCleanupWorkspace(svc))
-	registerOwnerGated(d, "SetTabArchiveState", leapmuxv1.Scope_SCOPE_WORKSPACE_WRITE, dispatchTracked, handleSetTabArchiveState(svc))
-}
-
-func handleSetTabArchiveState(svc *Service) func(context.Context, channel.Caller, *leapmuxv1.SetTabArchiveStateRequest, channel.ResponseWriter) {
-	return func(_ context.Context, _ channel.Caller, req *leapmuxv1.SetTabArchiveStateRequest, sender channel.ResponseWriter) {
-		if _, err := workspaceArchiveFlag(req.GetArchiveState()); err != nil {
-			sendInvalidArgument(sender, err.Error())
-			return
-		}
-		if _, _, err := archiveTabIDs(req.GetTabs()); err != nil {
-			sendInvalidArgument(sender, err.Error())
-			return
-		}
-		resumeAgentIDs, err := svc.applyTabArchiveState(bgCtx(), req.GetArchiveState(), req.GetTabs())
-		if err != nil {
-			sendInternalError(sender, err.Error())
-			return
-		}
-		if len(resumeAgentIDs) > 0 {
-			svc.NewAgentResumer().Schedule(bgCtx(), resumeAgentIDs)
-		}
-		sendProtoResponse(sender, &leapmuxv1.SetTabArchiveStateResponse{})
-	}
 }
 
 // handleCleanupWorkspace tears down the local resources behind the tabs a

--- a/frontend/src/api/workerRpc.ts
+++ b/frontend/src/api/workerRpc.ts
@@ -66,7 +66,6 @@ import type {
 } from '~/generated/proto/leapmux/v1/worker_private_pb'
 import type {
   CleanupWorkspaceResponse,
-  SetTabArchiveStateResponse,
   WatchEventsResponse,
 } from '~/generated/proto/leapmux/v1/workspace_pb'
 import type { ChannelSocket, ChannelTransport, KeyPinDecision, WorkerKeyBundle } from '~/lib/channel'
@@ -179,8 +178,6 @@ import {
 import {
   CleanupWorkspaceRequestSchema,
   CleanupWorkspaceResponseSchema,
-  SetTabArchiveStateRequestSchema,
-  SetTabArchiveStateResponseSchema,
   WatchEventsRequestSchema,
   WatchEventsResponseSchema,
 } from '~/generated/proto/leapmux/v1/workspace_pb'
@@ -354,10 +351,6 @@ export function getWorkerSystemInfo(workerId: string): Promise<GetWorkerSystemIn
 
 export function cleanupWorkspace(workerId: string, req: MessageInitShape<typeof CleanupWorkspaceRequestSchema>): Promise<CleanupWorkspaceResponse> {
   return callWorker(workerId, 'CleanupWorkspace', CleanupWorkspaceRequestSchema, CleanupWorkspaceResponseSchema, req)
-}
-
-export function setTabArchiveState(workerId: string, req: MessageInitShape<typeof SetTabArchiveStateRequestSchema>): Promise<SetTabArchiveStateResponse> {
-  return callWorker(workerId, 'SetTabArchiveState', SetTabArchiveStateRequestSchema, SetTabArchiveStateResponseSchema, req)
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/api/workerRpc.ts
+++ b/frontend/src/api/workerRpc.ts
@@ -66,6 +66,7 @@ import type {
 } from '~/generated/proto/leapmux/v1/worker_private_pb'
 import type {
   CleanupWorkspaceResponse,
+  SetTabArchiveStateResponse,
   WatchEventsResponse,
 } from '~/generated/proto/leapmux/v1/workspace_pb'
 import type { ChannelSocket, ChannelTransport, KeyPinDecision, WorkerKeyBundle } from '~/lib/channel'
@@ -178,6 +179,8 @@ import {
 import {
   CleanupWorkspaceRequestSchema,
   CleanupWorkspaceResponseSchema,
+  SetTabArchiveStateRequestSchema,
+  SetTabArchiveStateResponseSchema,
   WatchEventsRequestSchema,
   WatchEventsResponseSchema,
 } from '~/generated/proto/leapmux/v1/workspace_pb'
@@ -351,6 +354,10 @@ export function getWorkerSystemInfo(workerId: string): Promise<GetWorkerSystemIn
 
 export function cleanupWorkspace(workerId: string, req: MessageInitShape<typeof CleanupWorkspaceRequestSchema>): Promise<CleanupWorkspaceResponse> {
   return callWorker(workerId, 'CleanupWorkspace', CleanupWorkspaceRequestSchema, CleanupWorkspaceResponseSchema, req)
+}
+
+export function setTabArchiveState(workerId: string, req: MessageInitShape<typeof SetTabArchiveStateRequestSchema>): Promise<SetTabArchiveStateResponse> {
+  return callWorker(workerId, 'SetTabArchiveState', SetTabArchiveStateRequestSchema, SetTabArchiveStateResponseSchema, req)
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -1136,13 +1136,13 @@ export const AppShell: Component = () => {
       confirmEmptyArchiveDialog.open({ count, resolve })
     })
 
-  // Post-archive cleanup
+  // Clear transient write state for every agent in the archived workspace.
   const handlePostArchiveWorkspace = (workspaceId: string) => {
-    if (workspace.activeWorkspaceId() === workspaceId) {
-      for (const tab of tabView.forWorkspace(workspaceId)) {
-        if (tab.type === TabType.AGENT)
-          controlStore.clearAgent(tab.id)
-      }
+    for (const tab of tabView.forWorkspace(workspaceId)) {
+      if (tab.type !== TabType.AGENT)
+        continue
+      controlStore.clearAgent(tab.id)
+      chatStore.failPendingOutbound(tab.id, 'Workspace archived before the message was sent')
     }
   }
 

--- a/frontend/src/components/shell/AppShellDialogs.tsx
+++ b/frontend/src/components/shell/AppShellDialogs.tsx
@@ -498,12 +498,6 @@ export const AppShellDialogs: Component<AppShellDialogsProps> = (props) => {
               props.dialogs.confirmArchiveWs.close()
             }}
           >
-            {/* This sentence is NOT true today, and it stays until the behavior
-                matches it: archiving only moves the workspace into the archived
-                section, so every agent process and every PTY keeps running, and
-                the worker's resume sweep starts them again after a restart.
-                Correcting the copy alone would hide the defect.
-                See https://github.com/leapmux/leapmux/issues/446. */}
             <p>Are you sure you want to archive this workspace? All active agents and terminals will be stopped.</p>
           </ConfirmDialog>
         )}

--- a/frontend/src/components/shell/TabBar.test.tsx
+++ b/frontend/src/components/shell/TabBar.test.tsx
@@ -335,10 +335,12 @@ describe('tabBar archived prop', () => {
     expect(screen.getByTestId('tab-close')).toBeDisabled()
   })
 
-  it('hides close button for agent and terminal tabs when archived is true', () => {
+  it('hides close buttons for all tab types when archived is true', () => {
     const tabs = [
       makeTab(TabType.AGENT, 'a1', 'Agent Olivia'),
       makeTab(TabType.TERMINAL, 't1', 'Terminal Liam'),
+      makeTab(TabType.FILE, 'f1', 'readme.md'),
+      makeTab(TabType.IMAGE, 'i1', 'image.png'),
     ]
     render(() => (
       <PreferencesProvider>
@@ -351,43 +353,6 @@ describe('tabBar archived prop', () => {
     ))
     const closeButtons = screen.queryAllByTestId('tab-close')
     expect(closeButtons).toHaveLength(0)
-  })
-
-  it('shows close button for file tabs when archived is true', () => {
-    const tabs = [
-      makeTab(TabType.FILE, 'f1', 'readme.md'),
-    ]
-    render(() => (
-      <PreferencesProvider>
-        <TabBar
-          {...defaultProps}
-          tabs={tabs}
-          archived={true}
-        />
-      </PreferencesProvider>
-    ))
-    const closeButtons = screen.getAllByTestId('tab-close')
-    expect(closeButtons).toHaveLength(1)
-  })
-
-  it('shows close button for file tab but not agent/terminal when archived is true', () => {
-    const tabs = [
-      makeTab(TabType.AGENT, 'a1', 'Agent Olivia'),
-      makeTab(TabType.TERMINAL, 't1', 'Terminal Liam'),
-      makeTab(TabType.FILE, 'f1', 'readme.md'),
-    ]
-    render(() => (
-      <PreferencesProvider>
-        <TabBar
-          {...defaultProps}
-          tabs={tabs}
-          archived={true}
-        />
-      </PreferencesProvider>
-    ))
-    // Only the file tab should have a close button
-    const closeButtons = screen.getAllByTestId('tab-close')
-    expect(closeButtons).toHaveLength(1)
   })
 
   it('hides add-tab buttons when archived is true', () => {

--- a/frontend/src/components/shell/TabBar.tsx
+++ b/frontend/src/components/shell/TabBar.tsx
@@ -396,7 +396,7 @@ export const TabBar: Component<TabBarProps> = (props) => {
             {...terminalProgressBarProps(tab())}
           />
         </Show>
-        <Show when={canCloseTab(props.archived, tab())}>
+        <Show when={canCloseTab(props.archived)}>
           <IconButton
             icon={X}
             class={styles.tabClose}
@@ -418,7 +418,7 @@ export const TabBar: Component<TabBarProps> = (props) => {
           contextMenuFor={dnd?.rowEl}
           data-testid={surface.menuTestId}
           onRename={canRename() ? () => startEditing(tab()) : undefined}
-          onClose={canCloseTab(props.archived, tab()) ? () => props.onClose(tab()) : undefined}
+          onClose={canCloseTab(props.archived) ? () => props.onClose(tab()) : undefined}
           isClosing={isClosing()}
           pop={props.tabPop?.(tab())}
         />
@@ -445,7 +445,7 @@ export const TabBar: Component<TabBarProps> = (props) => {
     onAuxClick: (e: MouseEvent) => {
       if (e.button === 1) {
         e.preventDefault()
-        if (!canCloseTab(props.archived, tab()) || props.closingTabKeys?.has(tabKey(tab())))
+        if (!canCloseTab(props.archived) || props.closingTabKeys?.has(tabKey(tab())))
           return
         props.onClose(tab())
       }

--- a/frontend/src/components/shell/TabBar.tsx
+++ b/frontend/src/components/shell/TabBar.tsx
@@ -123,8 +123,7 @@ interface TabBarProps {
   activeTabKey: string | null
   /**
    * The workspace these tabs belong to is archived, so the strip offers no
-   * mutation: no close (except a payload-backed tab -- see `canCloseTab`), no
-   * rename, and no middle-click close.
+   * mutation. It offers no close, rename, or middle-click close.
    *
    * Was `readOnly`. Archival is the only thing that blocks mutation, so the two
    * were one concept under two names; the sidebar tree carries the same flag.

--- a/frontend/src/components/shell/useTerminalOperations.test.ts
+++ b/frontend/src/components/shell/useTerminalOperations.test.ts
@@ -49,6 +49,7 @@ const restartTerminalMock = workerRpc.restartTerminal as unknown as ReturnType<t
 const openTerminalMock = workerRpc.openTerminal as unknown as ReturnType<typeof vi.fn>
 const closeTerminalMock = workerRpc.closeTerminal as unknown as ReturnType<typeof vi.fn>
 const listAvailableShellsMock = workerRpc.listAvailableShells as unknown as ReturnType<typeof vi.fn>
+const resizeTerminalMock = workerRpc.resizeTerminal as unknown as ReturnType<typeof vi.fn>
 const showWarnToastMock = showWarnToast as unknown as ReturnType<typeof vi.fn>
 
 /**
@@ -585,6 +586,20 @@ describe('useterminaloperations.handleterminalinput', () => {
     await ops.handleTerminalInput('tid-1', new Uint8Array([0x0D]))
     expect(sendInputMock).not.toHaveBeenCalled()
     expect(restartTerminalMock).not.toHaveBeenCalled()
+  })
+
+  // Archival suppresses INPUT and nothing else. Reading a dead terminal is the
+  // point of keeping the tab, and reflow is what makes a resized window show
+  // the buffer correctly -- so the metadata patch that drives it must survive.
+  // The guard belongs on input alone; a copy of it here would freeze the
+  // archived screen at whatever width it had when the workspace was archived.
+  it('still records a resize while archived, and sends no RPC to the dead PTY', async () => {
+    const { ops, view } = setup(TerminalStatus.EXITED, {}, false)
+
+    await ops.handleTerminalResize('tid-1', 120, 40)
+
+    expect(view.getTerminalTab('tid-1')).toMatchObject({ cols: 120, rows: 40 })
+    expect(resizeTerminalMock).not.toHaveBeenCalled()
   })
 
   it('ignores non-Enter input on an EXITED terminal', async () => {

--- a/frontend/src/components/shell/useTerminalOperations.test.ts
+++ b/frontend/src/components/shell/useTerminalOperations.test.ts
@@ -128,7 +128,7 @@ function addTerminal(
   stores.metadata.patch(id, meta)
 }
 
-function setup(status: TerminalStatus | undefined = undefined, tabOverrides: TabOverrides = {}) {
+function setup(status: TerminalStatus | undefined = undefined, tabOverrides: TabOverrides = {}, isMutatable = true) {
   const harness = installTestBridge({ workspaceId: 'ws-1' })
   let stores!: ReturnType<typeof createTestTabStores>
   const [activeWorkspace] = createSignal<Workspace | null>({ id: 'ws-1' } as Workspace)
@@ -154,7 +154,7 @@ function setup(status: TerminalStatus | undefined = undefined, tabOverrides: Tab
       selection: stores.selection,
       layoutStore: stores.layoutStore,
       activeWorkspace,
-      isActiveWorkspaceMutatable: () => true,
+      isActiveWorkspaceMutatable: () => isMutatable,
       getCurrentTabContext: () => ({ workerId: 'worker-1', workingDir: '/tmp' }),
       newTerminalDialog: { open: () => {}, close: () => {}, value: () => null },
       setNewTerminalLoading: () => {},
@@ -578,6 +578,13 @@ describe('useterminaloperations.handleterminalinput', () => {
       cols: 100,
       rows: 30,
     })
+  })
+
+  it.each([TerminalStatus.READY, TerminalStatus.EXITED])('suppresses input for status %s while archived', async (status) => {
+    const { ops } = setup(status, {}, false)
+    await ops.handleTerminalInput('tid-1', new Uint8Array([0x0D]))
+    expect(sendInputMock).not.toHaveBeenCalled()
+    expect(restartTerminalMock).not.toHaveBeenCalled()
   })
 
   it('ignores non-Enter input on an EXITED terminal', async () => {

--- a/frontend/src/components/shell/useTerminalOperations.test.ts
+++ b/frontend/src/components/shell/useTerminalOperations.test.ts
@@ -599,7 +599,28 @@ describe('useterminaloperations.handleterminalinput', () => {
     await ops.handleTerminalResize('tid-1', 120, 40)
 
     expect(view.getTerminalTab('tid-1')).toMatchObject({ cols: 120, rows: 40 })
+    // An EXITED terminal sends no resize RPC whatever the archive state, so
+    // this half is about the dead PTY, not about archival. The READY case
+    // below is what pins archival's own reach.
     expect(resizeTerminalMock).not.toHaveBeenCalled()
+  })
+
+  // The assertion the EXITED fixture above CANNOT make: with a live PTY, the
+  // resize RPC must still go out while archived. A copy of the input guard at
+  // the top of `handleTerminalResize` fails this and passes the EXITED case,
+  // which is exactly the regression the pair exists to catch.
+  it('still resizes a live terminal while archived', async () => {
+    const { ops, view } = setup(TerminalStatus.READY, {}, false)
+
+    await ops.handleTerminalResize('tid-1', 120, 40)
+
+    expect(view.getTerminalTab('tid-1')).toMatchObject({ cols: 120, rows: 40 })
+    expect(resizeTerminalMock).toHaveBeenCalledTimes(1)
+    expect(resizeTerminalMock.mock.calls[0][1]).toMatchObject({
+      terminalId: 'tid-1',
+      cols: 120,
+      rows: 40,
+    })
   })
 
   it('ignores non-Enter input on an EXITED terminal', async () => {

--- a/frontend/src/components/shell/useTerminalOperations.ts
+++ b/frontend/src/components/shell/useTerminalOperations.ts
@@ -222,6 +222,8 @@ export function useTerminalOperations(props: UseTerminalOperationsProps) {
     openTerminalCore({ shell, target, setLoading: props.setNewShellLoading })
 
   const handleTerminalInput = async (terminalId: string, data: Uint8Array) => {
+    if (!props.isActiveWorkspaceMutatable())
+      return
     const tab = props.view.getTerminalTab(terminalId)
     if (!tab)
       return

--- a/frontend/src/components/shell/useWorkspaceOperations.test.ts
+++ b/frontend/src/components/shell/useWorkspaceOperations.test.ts
@@ -20,17 +20,24 @@ interface WorkerTabsLike { workerId: string, tabs: TabRefLike[] }
 
 const mockDeleteWorkspace = vi.fn<(req: { workspaceId: string }) => Promise<{ workerTabs: WorkerTabsLike[] }>>()
 const mockRenameWorkspace = vi.fn<(req: { workspaceId: string, title: string }) => Promise<unknown>>()
-const mockSetWorkspaceArchiveState = vi.fn<(req: { workspaceId: string, archiveState: WorkspaceArchiveState }) => Promise<{ workerTabs: WorkerTabsLike[] }>>()
+const mockSetWorkspaceArchiveState = vi.fn<(req: ArchiveStateRequest) => Promise<{ workerTabs: WorkerTabsLike[] }>>()
 const mockCleanupWorkspace = vi.fn<(workerId: string, req: { tabs: TabRefLike[] }) => Promise<unknown>>()
+interface ArchiveStateRequest {
+  workspaceId: string
+  archiveState: WorkspaceArchiveState
+  destinationSectionId: string
+  position: string
+}
 const mockSetTabArchiveState = vi.fn<(workerId: string, req: { tabs: TabRefLike[], archiveState: WorkspaceArchiveState }) => Promise<unknown>>()
 const mockMoveWorkspace = vi.fn<(req: { workspaceId: string, sectionId: string, position: string }) => Promise<unknown>>()
 const mockShowWarnToast = vi.fn()
+const mockShowStickyWarnToast = vi.fn()
 
 vi.mock('~/api/clients', () => ({
   workspaceClient: {
     deleteWorkspace: (...args: unknown[]) => mockDeleteWorkspace(...args as [{ workspaceId: string }]),
     renameWorkspace: (...args: unknown[]) => mockRenameWorkspace(...args as [{ workspaceId: string, title: string }]),
-    setWorkspaceArchiveState: (...args: unknown[]) => mockSetWorkspaceArchiveState(...args as [{ workspaceId: string, archiveState: WorkspaceArchiveState }]),
+    setWorkspaceArchiveState: (...args: unknown[]) => mockSetWorkspaceArchiveState(...args as [ArchiveStateRequest]),
   },
   sectionClient: {
     // Stubbed, and its ABSENCE used to hide a bug: `moveWorkspace` threw on
@@ -50,6 +57,7 @@ vi.mock('~/api/workerRpc', () => ({
 
 vi.mock('~/components/common/Toast', () => ({
   showWarnToast: (...args: unknown[]) => mockShowWarnToast(...args),
+  showStickyWarnToast: (...args: unknown[]) => mockShowStickyWarnToast(...args),
 }))
 
 interface HarnessOpts {
@@ -422,72 +430,56 @@ function bulkHarness(archivedIds: readonly string[], opts: {
 describe('useWorkspaceOperations archive lifecycle', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockSetTabArchiveState.mockResolvedValue({})
   })
 
-  it('marks the local workspace archived before the authoritative Worker fan-out', async () => {
-    const order: string[] = []
-    mockSetWorkspaceArchiveState.mockResolvedValue({
-      workerTabs: [
-        { workerId: 'worker-1', tabs: [{ tabType: TabType.AGENT, tabId: 'agent-1' }] },
-        { workerId: 'worker-2', tabs: [{ tabType: TabType.TERMINAL, tabId: 'terminal-1' }] },
-      ],
-    })
-    mockSetTabArchiveState.mockImplementation(async (workerId) => {
-      order.push(workerId)
-      return {}
-    })
-    const h = bulkHarness([], {
-      loadSections: async () => { order.push('sections') },
-      onPostArchiveWorkspace: () => { order.push('local-cleanup') },
-    })
-
-    await h.ops.archiveWorkspace('workspace-1')
-
-    expect(order.slice(0, 2)).toEqual(['sections', 'local-cleanup'])
-    expect(new Set(order.slice(2))).toEqual(new Set(['worker-1', 'worker-2']))
-    expect(mockSetTabArchiveState).toHaveBeenCalledWith('worker-1', {
-      archiveState: WorkspaceArchiveState.ARCHIVED,
-      tabs: [{ tabType: TabType.AGENT, tabId: 'agent-1' }],
-    })
-    expect(mockMoveWorkspace).not.toHaveBeenCalled()
-    h.dispose()
-  })
-
-  it('clears Worker state before the local workspace becomes writable', async () => {
-    const order: string[] = []
-    mockSetWorkspaceArchiveState.mockResolvedValue({
-      workerTabs: [{ workerId: 'worker-1', tabs: [{ tabType: TabType.AGENT, tabId: 'agent-1' }] }],
-    })
-    mockSetTabArchiveState.mockImplementation(async () => {
-      order.push('worker')
-    })
-    const h = bulkHarness(['workspace-1'], {
-      loadSections: async () => {
-        order.push('sections')
-      },
-    })
-
-    await h.ops.unarchiveWorkspace('workspace-1')
-
-    expect(order).toEqual(['worker', 'sections'])
-    h.dispose()
-  })
-
-  it('keeps the Hub transition and warns when a Worker call fails', async () => {
-    mockSetWorkspaceArchiveState.mockResolvedValue({
-      workerTabs: [{ workerId: 'worker-1', tabs: [{ tabType: TabType.AGENT, tabId: 'agent-1' }] }],
-    })
-    mockSetTabArchiveState.mockRejectedValue(new Error('worker offline'))
+  // The Worker fan-out belongs to the HUB. SetWorkspaceArchiveState nudges
+  // every Worker that hosts one of this workspace's tabs inside the call, and
+  // the Worker applies the state through the same path its reconcile pass uses.
+  // A second fan-out from the browser would deliver the same effect over a
+  // path that exists only while this tab is open, and that an archive from any
+  // other client would skip entirely.
+  it('leaves the Worker fan-out to the Hub', async () => {
     const h = bulkHarness([])
 
     await h.ops.archiveWorkspace('workspace-1')
 
-    expect(mockSetWorkspaceArchiveState).toHaveBeenCalledOnce()
-    expect(mockShowWarnToast).toHaveBeenCalledWith(
-      'Workspace archived, but a Worker did not stop its tabs',
-      expect.any(Error),
-    )
+    expect(mockSetWorkspaceArchiveState).toHaveBeenCalledWith({
+      workspaceId: 'workspace-1',
+      archiveState: WorkspaceArchiveState.ARCHIVED,
+      destinationSectionId: '',
+      position: '',
+    })
+    expect(mockSetTabArchiveState).not.toHaveBeenCalled()
+    expect(mockMoveWorkspace).not.toHaveBeenCalled()
+    h.dispose()
+  })
+
+  it('applies the local archived state after the Hub call, then refreshes', async () => {
+    const order: string[] = []
+    const h = bulkHarness([], {
+      loadSections: async () => {
+        order.push('sections')
+      },
+      onPostArchiveWorkspace: () => {
+        order.push('local-cleanup')
+      },
+    })
+
+    await h.ops.archiveWorkspace('workspace-1')
+
+    expect(order).toEqual(['sections', 'local-cleanup'])
+    h.dispose()
+  })
+
+  it('reports the Hub call failing and applies no local state', async () => {
+    mockSetWorkspaceArchiveState.mockRejectedValue(new Error('hub offline'))
+    const cleanups: string[] = []
+    const h = bulkHarness([], { onPostArchiveWorkspace: () => cleanups.push('local-cleanup') })
+
+    await h.ops.archiveWorkspace('workspace-1')
+
+    expect(mockShowWarnToast).toHaveBeenCalledWith('Failed to archive workspace', expect.any(Error))
+    expect(cleanups).toEqual([])
     h.dispose()
   })
 })
@@ -501,7 +493,6 @@ describe('useWorkspaceOperations moveWorkspace across the archive boundary', () 
   beforeEach(() => {
     vi.clearAllMocks()
     mockSetWorkspaceArchiveState.mockResolvedValue({ workerTabs: [] })
-    mockSetTabArchiveState.mockResolvedValue({})
     mockMoveWorkspace.mockResolvedValue({})
   })
 
@@ -521,12 +512,17 @@ describe('useWorkspaceOperations moveWorkspace across the archive boundary', () 
 
     await h.ops.moveWorkspace('w1', 's-custom')
 
+    // ONE call: the lifecycle RPC carries the destination, so the workspace
+    // lands in the custom section directly. It used to unarchive into In
+    // progress and then issue a second move, which left the workspace in the
+    // wrong section whenever that second call failed.
     expect(mockSetWorkspaceArchiveState).toHaveBeenCalledWith({
       workspaceId: 'w1',
       archiveState: WorkspaceArchiveState.ACTIVE,
+      destinationSectionId: 's-custom',
+      position: expect.any(String),
     })
-    expect(mockMoveWorkspace).toHaveBeenCalledOnce()
-    expect(mockMoveWorkspace.mock.calls[0][0]).toMatchObject({ workspaceId: 'w1', sectionId: 's-custom' })
+    expect(mockMoveWorkspace).not.toHaveBeenCalled()
     h.dispose()
   })
 
@@ -564,6 +560,8 @@ describe('useWorkspaceOperations moveWorkspace across the archive boundary', () 
     expect(mockSetWorkspaceArchiveState).toHaveBeenCalledWith({
       workspaceId: 'w1',
       archiveState: WorkspaceArchiveState.ARCHIVED,
+      destinationSectionId: 's-archived',
+      position: expect.any(String),
     })
     expect(mockMoveWorkspace).not.toHaveBeenCalled()
     h.dispose()
@@ -571,7 +569,7 @@ describe('useWorkspaceOperations moveWorkspace across the archive boundary', () 
 
   // Both sides are the archive, so nothing crosses. Reading the DESTINATION
   // alone would archive an already-archived workspace, which asks the user to
-  // confirm an operation that has already happened.
+  // confirm an operation that already happened.
   it('reorders inside the archive with the plain section move', async () => {
     const h = harnessWithCustomSection(['w1'])
 
@@ -600,16 +598,15 @@ describe('useWorkspaceOperations unarchiveAll', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockSetWorkspaceArchiveState.mockResolvedValue({ workerTabs: [] })
-    mockSetTabArchiveState.mockResolvedValue({})
   })
 
   it('sets every archived workspace active through the lifecycle RPC', async () => {
     const h = bulkHarness(['w1', 'w2', 'w3'])
     await h.ops.unarchiveAll()
     expect(mockSetWorkspaceArchiveState.mock.calls.map(c => c[0])).toEqual([
-      { workspaceId: 'w1', archiveState: WorkspaceArchiveState.ACTIVE },
-      { workspaceId: 'w2', archiveState: WorkspaceArchiveState.ACTIVE },
-      { workspaceId: 'w3', archiveState: WorkspaceArchiveState.ACTIVE },
+      { workspaceId: 'w1', archiveState: WorkspaceArchiveState.ACTIVE, destinationSectionId: '', position: '' },
+      { workspaceId: 'w2', archiveState: WorkspaceArchiveState.ACTIVE, destinationSectionId: '', position: '' },
+      { workspaceId: 'w3', archiveState: WorkspaceArchiveState.ACTIVE, destinationSectionId: '', position: '' },
     ])
     h.dispose()
   })
@@ -625,6 +622,65 @@ describe('useWorkspaceOperations unarchiveAll', () => {
     const h = bulkHarness([])
     await h.ops.unarchiveAll()
     expect(mockSetWorkspaceArchiveState).not.toHaveBeenCalled()
+    h.dispose()
+  })
+
+  // The loop must stay SEQUENTIAL. The hub computes each stored rank inside
+  // SetWorkspaceArchiveState by reading the destination's tail, so a
+  // Promise.all rewrite would hand overlapping transactions the same tail. The
+  // hub's own tie-break makes the resulting rank unique either way, but the
+  // ORDER the user sees should be the order they archived in, and nothing else
+  // in this file would fail if the loop stopped being ordered.
+  it('issues one lifecycle RPC at a time, never overlapping them', async () => {
+    let inFlight = 0
+    let maxInFlight = 0
+    const releases: Array<() => void> = []
+    mockSetWorkspaceArchiveState.mockImplementation(async () => {
+      inFlight += 1
+      maxInFlight = Math.max(maxInFlight, inFlight)
+      await new Promise<void>((resolve) => {
+        releases.push(resolve)
+      })
+      inFlight -= 1
+      return { workerTabs: [] }
+    })
+    const h = bulkHarness(['w1', 'w2', 'w3'])
+    const done = h.ops.unarchiveAll()
+    // Drain one call at a time. If the loop fanned out, all three would already
+    // be in flight before the first release.
+    for (let i = 0; i < 3; i++) {
+      await vi.waitFor(() => expect(releases).toHaveLength(i + 1))
+      releases[i]()
+    }
+    await done
+    expect(maxInFlight).toBe(1)
+    h.dispose()
+  })
+
+  // One reload at the end, not one per workspace. A per-item refresh costs N
+  // round trips to fetch N-1 states nobody sees; performDelete already takes
+  // the same parameter for the same reason.
+  it('reloads the sections once for the whole batch', async () => {
+    let reloads = 0
+    const h = bulkHarness(['w1', 'w2', 'w3'], {
+      loadSections: async () => {
+        reloads += 1
+      },
+    })
+    await h.ops.unarchiveAll()
+    expect(reloads).toBe(1)
+    h.dispose()
+  })
+
+  it('reloads nothing when the archive is empty', async () => {
+    let reloads = 0
+    const h = bulkHarness([], {
+      loadSections: async () => {
+        reloads += 1
+      },
+    })
+    await h.ops.unarchiveAll()
+    expect(reloads).toBe(0)
     h.dispose()
   })
 
@@ -916,7 +972,6 @@ describe('useWorkspaceOperations handleWorkspaceDragEnd', () => {
     vi.clearAllMocks()
     mockMoveWorkspace.mockResolvedValue({})
     mockSetWorkspaceArchiveState.mockResolvedValue({ workerTabs: [] })
-    mockSetTabArchiveState.mockResolvedValue({})
     localStorageClearForTests()
     setStorageAccount('u-1')
     resetWorkspaceListStateForTests()
@@ -1016,9 +1071,13 @@ describe('useWorkspaceOperations handleWorkspaceDragEnd', () => {
     const h = dragHarness()
     drop(h, 'd', 's-archived', 'a', 's-progress')
     await Promise.resolve()
+    // The drop POSITION rides along, so the row lands where the user dropped
+    // it instead of at the destination's end.
     expect(mockSetWorkspaceArchiveState).toHaveBeenCalledWith({
       workspaceId: 'd',
       archiveState: WorkspaceArchiveState.ACTIVE,
+      destinationSectionId: 's-progress',
+      position: expect.any(String),
     })
     h.dispose()
   })
@@ -1030,6 +1089,8 @@ describe('useWorkspaceOperations handleWorkspaceDragEnd', () => {
     expect(mockSetWorkspaceArchiveState).toHaveBeenCalledWith({
       workspaceId: 'a',
       archiveState: WorkspaceArchiveState.ARCHIVED,
+      destinationSectionId: 's-archived',
+      position: expect.any(String),
     })
     h.dispose()
   })

--- a/frontend/src/components/shell/useWorkspaceOperations.test.ts
+++ b/frontend/src/components/shell/useWorkspaceOperations.test.ts
@@ -11,7 +11,7 @@ import {
   toggleSectionFilter,
 } from '~/components/workspace/workspaceListState'
 import { SectionType } from '~/generated/proto/leapmux/v1/section_pb'
-import { TabType } from '~/generated/proto/leapmux/v1/workspace_pb'
+import { TabType, WorkspaceArchiveState } from '~/generated/proto/leapmux/v1/workspace_pb'
 import { localStorageClearForTests, setStorageAccount } from '~/lib/browserStorage'
 import { createSectionStore } from '~/stores/section.store'
 
@@ -20,7 +20,9 @@ interface WorkerTabsLike { workerId: string, tabs: TabRefLike[] }
 
 const mockDeleteWorkspace = vi.fn<(req: { workspaceId: string }) => Promise<{ workerTabs: WorkerTabsLike[] }>>()
 const mockRenameWorkspace = vi.fn<(req: { workspaceId: string, title: string }) => Promise<unknown>>()
+const mockSetWorkspaceArchiveState = vi.fn<(req: { workspaceId: string, archiveState: WorkspaceArchiveState }) => Promise<{ workerTabs: WorkerTabsLike[] }>>()
 const mockCleanupWorkspace = vi.fn<(workerId: string, req: { tabs: TabRefLike[] }) => Promise<unknown>>()
+const mockSetTabArchiveState = vi.fn<(workerId: string, req: { tabs: TabRefLike[], archiveState: WorkspaceArchiveState }) => Promise<unknown>>()
 const mockMoveWorkspace = vi.fn<(req: { workspaceId: string, sectionId: string, position: string }) => Promise<unknown>>()
 const mockShowWarnToast = vi.fn()
 
@@ -28,6 +30,7 @@ vi.mock('~/api/clients', () => ({
   workspaceClient: {
     deleteWorkspace: (...args: unknown[]) => mockDeleteWorkspace(...args as [{ workspaceId: string }]),
     renameWorkspace: (...args: unknown[]) => mockRenameWorkspace(...args as [{ workspaceId: string, title: string }]),
+    setWorkspaceArchiveState: (...args: unknown[]) => mockSetWorkspaceArchiveState(...args as [{ workspaceId: string, archiveState: WorkspaceArchiveState }]),
   },
   sectionClient: {
     // Stubbed, and its ABSENCE used to hide a bug: `moveWorkspace` threw on
@@ -41,6 +44,8 @@ vi.mock('~/api/clients', () => ({
 vi.mock('~/api/workerRpc', () => ({
   cleanupWorkspace: (...args: unknown[]) =>
     mockCleanupWorkspace(...args as [string, { tabs: TabRefLike[] }]),
+  setTabArchiveState: (...args: unknown[]) =>
+    mockSetTabArchiveState(...args as [string, { tabs: TabRefLike[], archiveState: WorkspaceArchiveState }]),
 }))
 
 vi.mock('~/components/common/Toast', () => ({
@@ -384,9 +389,12 @@ describe('useWorkspaceOperations commitRename', () => {
  * has to be real rather than empty.
  */
 function bulkHarness(archivedIds: readonly string[], opts: {
+  onConfirmArchive?: (workspaceId: string) => Promise<boolean>
   onConfirmEmptyArchive?: (count: number) => Promise<boolean>
   onConfirmDelete?: (workspaceId: string) => Promise<boolean>
   onRefreshWorkspaces?: () => void
+  loadSections?: () => Promise<void>
+  onPostArchiveWorkspace?: (workspaceId: string) => void
 } = {}) {
   const inProgress = section('s-progress', SectionType.WORKSPACES_IN_PROGRESS)
   const archived = section('s-archived', SectionType.WORKSPACES_ARCHIVED)
@@ -398,64 +406,137 @@ function bulkHarness(archivedIds: readonly string[], opts: {
       workspaces: () => archivedIds.map(ws),
       activeWorkspaceId: () => null,
       sectionStore,
-      loadSections: async () => {},
+      loadSections: opts.loadSections ?? (async () => {}),
       onSelectWorkspace: () => {},
       onRefreshWorkspaces: opts.onRefreshWorkspaces ?? (() => {}),
       onDeleteWorkspace: () => {},
       onConfirmDelete: opts.onConfirmDelete,
+      onConfirmArchive: opts.onConfirmArchive,
       onConfirmEmptyArchive: opts.onConfirmEmptyArchive,
+      onPostArchiveWorkspace: opts.onPostArchiveWorkspace,
     })
     return { dispose, ops, sectionStore }
   })
 }
 
-describe('useWorkspaceOperations unarchiveAll', () => {
+describe('useWorkspaceOperations archive lifecycle', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockMoveWorkspace.mockResolvedValue({})
+    mockSetTabArchiveState.mockResolvedValue({})
   })
 
-  it('moves every archived workspace to In progress', async () => {
-    const h = bulkHarness(['w1', 'w2', 'w3'])
-    await h.ops.unarchiveAll()
-    expect(mockMoveWorkspace.mock.calls.map(c => c[0].workspaceId)).toEqual(['w1', 'w2', 'w3'])
-    expect(mockMoveWorkspace.mock.calls.every(c => c[0].sectionId === 's-progress')).toBe(true)
+  it('marks the local workspace archived before the authoritative Worker fan-out', async () => {
+    const order: string[] = []
+    mockSetWorkspaceArchiveState.mockResolvedValue({
+      workerTabs: [
+        { workerId: 'worker-1', tabs: [{ tabType: TabType.AGENT, tabId: 'agent-1' }] },
+        { workerId: 'worker-2', tabs: [{ tabType: TabType.TERMINAL, tabId: 'terminal-1' }] },
+      ],
+    })
+    mockSetTabArchiveState.mockImplementation(async (workerId) => {
+      order.push(workerId)
+      return {}
+    })
+    const h = bulkHarness([], {
+      loadSections: async () => { order.push('sections') },
+      onPostArchiveWorkspace: () => { order.push('local-cleanup') },
+    })
+
+    await h.ops.archiveWorkspace('workspace-1')
+
+    expect(order.slice(0, 2)).toEqual(['sections', 'local-cleanup'])
+    expect(new Set(order.slice(2))).toEqual(new Set(['worker-1', 'worker-2']))
+    expect(mockSetTabArchiveState).toHaveBeenCalledWith('worker-1', {
+      archiveState: WorkspaceArchiveState.ARCHIVED,
+      tabs: [{ tabType: TabType.AGENT, tabId: 'agent-1' }],
+    })
+    expect(mockMoveWorkspace).not.toHaveBeenCalled()
     h.dispose()
   })
 
-  it('gives every move a DISTINCT position', async () => {
-    // This is what separates the sequential loop from `Promise.all`.
-    // `moveWorkspace` computes `appendPosition(getItemsForSection(...))`, which
-    // reads `items.at(-1)` BEFORE its await while the store write lands after
-    // it -- so a parallel fan-out hands every call the identical lexorank and
-    // the sidebar shuffles the whole set on the next refresh.
+  it('clears Worker state before the local workspace becomes writable', async () => {
+    const order: string[] = []
+    mockSetWorkspaceArchiveState.mockResolvedValue({
+      workerTabs: [{ workerId: 'worker-1', tabs: [{ tabType: TabType.AGENT, tabId: 'agent-1' }] }],
+    })
+    mockSetTabArchiveState.mockImplementation(async () => {
+      order.push('worker')
+    })
+    const h = bulkHarness(['workspace-1'], {
+      loadSections: async () => {
+        order.push('sections')
+      },
+    })
+
+    await h.ops.unarchiveWorkspace('workspace-1')
+
+    expect(order).toEqual(['worker', 'sections'])
+    h.dispose()
+  })
+
+  it('keeps the Hub transition and warns when a Worker call fails', async () => {
+    mockSetWorkspaceArchiveState.mockResolvedValue({
+      workerTabs: [{ workerId: 'worker-1', tabs: [{ tabType: TabType.AGENT, tabId: 'agent-1' }] }],
+    })
+    mockSetTabArchiveState.mockRejectedValue(new Error('worker offline'))
+    const h = bulkHarness([])
+
+    await h.ops.archiveWorkspace('workspace-1')
+
+    expect(mockSetWorkspaceArchiveState).toHaveBeenCalledOnce()
+    expect(mockShowWarnToast).toHaveBeenCalledWith(
+      'Workspace archived, but a Worker did not stop its tabs',
+      expect.any(Error),
+    )
+    h.dispose()
+  })
+})
+
+describe('useWorkspaceOperations unarchiveAll', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSetWorkspaceArchiveState.mockResolvedValue({ workerTabs: [] })
+    mockSetTabArchiveState.mockResolvedValue({})
+  })
+
+  it('sets every archived workspace active through the lifecycle RPC', async () => {
     const h = bulkHarness(['w1', 'w2', 'w3'])
     await h.ops.unarchiveAll()
-    const positions = mockMoveWorkspace.mock.calls.map(c => c[0].position)
-    expect(new Set(positions).size).toBe(positions.length)
+    expect(mockSetWorkspaceArchiveState.mock.calls.map(c => c[0])).toEqual([
+      { workspaceId: 'w1', archiveState: WorkspaceArchiveState.ACTIVE },
+      { workspaceId: 'w2', archiveState: WorkspaceArchiveState.ACTIVE },
+      { workspaceId: 'w3', archiveState: WorkspaceArchiveState.ACTIVE },
+    ])
+    h.dispose()
+  })
+
+  it('does not use the generic section move for an archive transition', async () => {
+    const h = bulkHarness(['w1', 'w2', 'w3'])
+    await h.ops.unarchiveAll()
+    expect(mockMoveWorkspace).not.toHaveBeenCalled()
     h.dispose()
   })
 
   it('does nothing for an empty archive', async () => {
     const h = bulkHarness([])
     await h.ops.unarchiveAll()
-    expect(mockMoveWorkspace).not.toHaveBeenCalled()
+    expect(mockSetWorkspaceArchiveState).not.toHaveBeenCalled()
     h.dispose()
   })
 
   it('warns for the workspace that failed and still moves the rest', async () => {
     // Both callees catch and toast, so "the loop continued" is true for every
     // loop shape including none. The TOAST is what says which one failed.
-    mockMoveWorkspace.mockImplementation(async (req) => {
+    mockSetWorkspaceArchiveState.mockImplementation(async (req) => {
       if (req.workspaceId === 'w2')
         throw new Error('nope')
-      return {}
+      return { workerTabs: [] }
     })
     const h = bulkHarness(['w1', 'w2', 'w3'])
     await h.ops.unarchiveAll()
-    expect(mockMoveWorkspace).toHaveBeenCalledTimes(3)
+    expect(mockSetWorkspaceArchiveState).toHaveBeenCalledTimes(3)
     expect(mockShowWarnToast).toHaveBeenCalledTimes(1)
-    expect(mockShowWarnToast.mock.calls[0][0]).toBe('Failed to move workspace')
+    expect(mockShowWarnToast.mock.calls[0][0]).toBe('Failed to unarchive workspace')
     h.dispose()
   })
 })
@@ -729,6 +810,7 @@ describe('useWorkspaceOperations startRename', () => {
 describe('useWorkspaceOperations handleWorkspaceDragEnd', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockMoveWorkspace.mockResolvedValue({})
     localStorageClearForTests()
     setStorageAccount('u-1')
     resetWorkspaceListStateForTests()

--- a/frontend/src/components/shell/useWorkspaceOperations.test.ts
+++ b/frontend/src/components/shell/useWorkspaceOperations.test.ts
@@ -492,6 +492,110 @@ describe('useWorkspaceOperations archive lifecycle', () => {
   })
 })
 
+// The archive boundary is the one crossing `SectionService.MoveWorkspace`
+// refuses, so every surface that offers a plain move -- the row menu's Move-to
+// and a sidebar drag -- has to resolve the crossing before it makes that call.
+// These pin that the resolution happens here, rather than reaching the hub and
+// coming back as a FailedPrecondition toast.
+describe('useWorkspaceOperations moveWorkspace across the archive boundary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSetWorkspaceArchiveState.mockResolvedValue({ workerTabs: [] })
+    mockSetTabArchiveState.mockResolvedValue({})
+    mockMoveWorkspace.mockResolvedValue({})
+  })
+
+  /** bulkHarness plus a CUSTOM section, which is the interesting destination. */
+  function harnessWithCustomSection(archivedIds: readonly string[]) {
+    const h = bulkHarness(archivedIds)
+    h.sectionStore.setSections([
+      section('s-progress', SectionType.WORKSPACES_IN_PROGRESS),
+      section('s-archived', SectionType.WORKSPACES_ARCHIVED),
+      section('s-custom', SectionType.WORKSPACES_CUSTOM),
+    ])
+    return h
+  }
+
+  it('unarchives, then moves, for a custom destination', async () => {
+    const h = harnessWithCustomSection(['w1'])
+
+    await h.ops.moveWorkspace('w1', 's-custom')
+
+    expect(mockSetWorkspaceArchiveState).toHaveBeenCalledWith({
+      workspaceId: 'w1',
+      archiveState: WorkspaceArchiveState.ACTIVE,
+    })
+    expect(mockMoveWorkspace).toHaveBeenCalledOnce()
+    expect(mockMoveWorkspace.mock.calls[0][0]).toMatchObject({ workspaceId: 'w1', sectionId: 's-custom' })
+    h.dispose()
+  })
+
+  // Unarchiving already lands the workspace in In progress, so a second move
+  // there would be a redundant RPC for a row that is already in place.
+  it('sends no section move when In progress IS the destination', async () => {
+    const h = harnessWithCustomSection(['w1'])
+
+    await h.ops.moveWorkspace('w1', 's-progress')
+
+    expect(mockSetWorkspaceArchiveState).toHaveBeenCalledOnce()
+    expect(mockMoveWorkspace).not.toHaveBeenCalled()
+    h.dispose()
+  })
+
+  // The hub refuses the move for the same reason it refused the unarchive's own
+  // transaction, so a second toast would name one failure twice.
+  it('attempts no section move when the unarchive failed', async () => {
+    mockSetWorkspaceArchiveState.mockRejectedValue(new Error('hub down'))
+    const h = harnessWithCustomSection(['w1'])
+
+    await h.ops.moveWorkspace('w1', 's-custom')
+
+    expect(mockMoveWorkspace).not.toHaveBeenCalled()
+    expect(mockShowWarnToast).toHaveBeenCalledOnce()
+    expect(mockShowWarnToast.mock.calls[0][0]).toBe('Failed to unarchive workspace')
+    h.dispose()
+  })
+
+  it('archives instead of moving when the destination IS the archive', async () => {
+    const h = harnessWithCustomSection([])
+
+    await h.ops.moveWorkspace('w1', 's-archived')
+
+    expect(mockSetWorkspaceArchiveState).toHaveBeenCalledWith({
+      workspaceId: 'w1',
+      archiveState: WorkspaceArchiveState.ARCHIVED,
+    })
+    expect(mockMoveWorkspace).not.toHaveBeenCalled()
+    h.dispose()
+  })
+
+  // Both sides are the archive, so nothing crosses. Reading the DESTINATION
+  // alone would archive an already-archived workspace, which asks the user to
+  // confirm an operation that has already happened.
+  it('reorders inside the archive with the plain section move', async () => {
+    const h = harnessWithCustomSection(['w1'])
+
+    await h.ops.moveWorkspace('w1', 's-archived')
+
+    expect(mockSetWorkspaceArchiveState).not.toHaveBeenCalled()
+    expect(mockMoveWorkspace).toHaveBeenCalledOnce()
+    expect(mockMoveWorkspace.mock.calls[0][0]).toMatchObject({ workspaceId: 'w1', sectionId: 's-archived' })
+    h.dispose()
+  })
+
+  // The ordinary same-side case keeps the plain section move, or every sidebar
+  // reorder would pay for a lifecycle round trip.
+  it('uses the plain section move when neither side is archived', async () => {
+    const h = harnessWithCustomSection([])
+
+    await h.ops.moveWorkspace('w1', 's-custom')
+
+    expect(mockSetWorkspaceArchiveState).not.toHaveBeenCalled()
+    expect(mockMoveWorkspace).toHaveBeenCalledOnce()
+    h.dispose()
+  })
+})
+
 describe('useWorkspaceOperations unarchiveAll', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -811,6 +915,8 @@ describe('useWorkspaceOperations handleWorkspaceDragEnd', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockMoveWorkspace.mockResolvedValue({})
+    mockSetWorkspaceArchiveState.mockResolvedValue({ workerTabs: [] })
+    mockSetTabArchiveState.mockResolvedValue({})
     localStorageClearForTests()
     setStorageAccount('u-1')
     resetWorkspaceListStateForTests()
@@ -819,16 +925,24 @@ describe('useWorkspaceOperations handleWorkspaceDragEnd', () => {
   function dragHarness() {
     const inProgress = section('s-progress', SectionType.WORKSPACES_IN_PROGRESS)
     const other = section('s-other', SectionType.WORKSPACES_CUSTOM)
+    const archived = section('s-archived', SectionType.WORKSPACES_ARCHIVED)
     return createRoot((dispose) => {
       const sectionStore = createSectionStore()
-      sectionStore.setSections([inProgress, other])
+      sectionStore.setSections([inProgress, other, archived])
+      // The ids are what `handleWorkspaceDragEnd` derives from a droppable:
+      // it strips the `ws-` prefix, so a row whose droppable is `ws-a` IS
+      // workspace `a`. They used to be stored as `ws-a`, which resolved to
+      // nothing -- harmless while every test asserted only a call count, and
+      // wrong the moment one asks which section the workspace is in.
       sectionStore.setItems([
-        item('ws-a', 's-progress', 'a'),
-        item('ws-b', 's-progress', 'b'),
-        item('ws-c', 's-other', 'a'),
+        item('a', 's-progress', 'a'),
+        item('b', 's-progress', 'b'),
+        item('c', 's-other', 'a'),
+        item('d', 's-archived', 'a'),
+        item('e', 's-archived', 'b'),
       ])
       const ops = useWorkspaceOperations({
-        workspaces: () => ['ws-a', 'ws-b', 'ws-c'].map(ws),
+        workspaces: () => ['a', 'b', 'c', 'd', 'e'].map(ws),
         activeWorkspaceId: () => null,
         sectionStore,
         loadSections: async () => {},
@@ -891,6 +1005,45 @@ describe('useWorkspaceOperations handleWorkspaceDragEnd', () => {
     drop(h, 'a', 's-progress', 'c', 's-other')
     expect(mockMoveWorkspace).toHaveBeenCalledOnce()
     expect(mockMoveWorkspace.mock.calls[0][0].sectionId).toBe('s-other')
+    h.dispose()
+  })
+
+  // A drag across the archive boundary is the surface the hub refuses a plain
+  // MoveWorkspace for. Dragging IN was already routed to the archive flow;
+  // dragging OUT was not, so it reached the hub and came back as a
+  // FailedPrecondition toast with the row snapping into place again.
+  it('unarchives a workspace dragged OUT of the archive', async () => {
+    const h = dragHarness()
+    drop(h, 'd', 's-archived', 'a', 's-progress')
+    await Promise.resolve()
+    expect(mockSetWorkspaceArchiveState).toHaveBeenCalledWith({
+      workspaceId: 'd',
+      archiveState: WorkspaceArchiveState.ACTIVE,
+    })
+    h.dispose()
+  })
+
+  it('archives a workspace dragged INTO the archive', async () => {
+    const h = dragHarness()
+    drop(h, 'a', 's-progress', 'd', 's-archived')
+    await Promise.resolve()
+    expect(mockSetWorkspaceArchiveState).toHaveBeenCalledWith({
+      workspaceId: 'a',
+      archiveState: WorkspaceArchiveState.ARCHIVED,
+    })
+    h.dispose()
+  })
+
+  // Both rows are already archived, so nothing crosses. Reading the DESTINATION
+  // alone would send this through the archive flow and ask the user to confirm
+  // archiving a workspace that is already archived.
+  it('reorders inside the archive without a lifecycle call', async () => {
+    const h = dragHarness()
+    drop(h, 'e', 's-archived', 'd', 's-archived')
+    await Promise.resolve()
+    expect(mockSetWorkspaceArchiveState).not.toHaveBeenCalled()
+    expect(mockMoveWorkspace).toHaveBeenCalledOnce()
+    expect(mockMoveWorkspace.mock.calls[0][0].sectionId).toBe('s-archived')
     h.dispose()
   })
 })

--- a/frontend/src/components/shell/useWorkspaceOperations.ts
+++ b/frontend/src/components/shell/useWorkspaceOperations.ts
@@ -9,6 +9,7 @@ import * as workerRpc from '~/api/workerRpc'
 import { showWarnToast } from '~/components/common/Toast'
 import { canReorderWithinSection, sectionFilterQuery, workspaceSortOrder } from '~/components/workspace/workspaceListState'
 import { SectionType } from '~/generated/proto/leapmux/v1/section_pb'
+import { WorkspaceArchiveState } from '~/generated/proto/leapmux/v1/workspace_pb'
 import { appendPosition, mid } from '~/lib/lexorank'
 import { cleanName } from '~/lib/validate'
 import { filterWorkspaces, sortWorkspaces } from '~/lib/workspaceSort'
@@ -267,15 +268,65 @@ export function useWorkspaceOperations(props: UseWorkspaceOperationsProps) {
       if (!confirmed)
         return
     }
-    await moveWorkspace(workspaceId, archivedSection.id)
-    props.onPostArchiveWorkspace?.(workspaceId)
+    const done = startWorkspaceLoading(workspaceId)
+    try {
+      const resp = await workspaceClient.setWorkspaceArchiveState({
+        workspaceId,
+        archiveState: WorkspaceArchiveState.ARCHIVED,
+      })
+      // Apply the Hub state before any Worker fan-out. Every local surface now
+      // treats the workspace as read-only while its processes stop.
+      store.moveWorkspace(workspaceId, archivedSection.id, appendPosition(store.getItemsForSection(archivedSection.id)))
+      await props.loadSections()
+      props.onPostArchiveWorkspace?.(workspaceId)
+      const results = await Promise.allSettled(resp.workerTabs.map(workerTabs =>
+        workerRpc.setTabArchiveState(workerTabs.workerId, {
+          tabs: workerTabs.tabs,
+          archiveState: WorkspaceArchiveState.ARCHIVED,
+        }),
+      ))
+      const failure = results.find(result => result.status === 'rejected')
+      if (failure?.status === 'rejected')
+        showWarnToast('Workspace archived, but a Worker did not stop its tabs', failure.reason)
+    }
+    catch (err) {
+      showWarnToast('Failed to archive workspace', err)
+    }
+    finally {
+      done()
+    }
   }
 
   const unarchiveWorkspace = async (workspaceId: string) => {
     const inProgressSection = store.getInProgressSection()
     if (!inProgressSection)
       return
-    await moveWorkspace(workspaceId, inProgressSection.id)
+    const done = startWorkspaceLoading(workspaceId)
+    try {
+      const resp = await workspaceClient.setWorkspaceArchiveState({
+        workspaceId,
+        archiveState: WorkspaceArchiveState.ACTIVE,
+      })
+      // Clear the Worker cache before the section refresh makes the workspace
+      // writable again. The Hub state stays active if a Worker call fails.
+      const results = await Promise.allSettled(resp.workerTabs.map(workerTabs =>
+        workerRpc.setTabArchiveState(workerTabs.workerId, {
+          tabs: workerTabs.tabs,
+          archiveState: WorkspaceArchiveState.ACTIVE,
+        }),
+      ))
+      store.moveWorkspace(workspaceId, inProgressSection.id, appendPosition(store.getItemsForSection(inProgressSection.id)))
+      await props.loadSections()
+      const failure = results.find(result => result.status === 'rejected')
+      if (failure?.status === 'rejected')
+        showWarnToast('Workspace unarchived, but a Worker did not update its tabs', failure.reason)
+    }
+    catch (err) {
+      showWarnToast('Failed to unarchive workspace', err)
+    }
+    finally {
+      done()
+    }
   }
 
   const findFirstNonArchivedWorkspaceId = (): string | null => {
@@ -370,25 +421,13 @@ export function useWorkspaceOperations(props: UseWorkspaceOperationsProps) {
     return store.getItemsForSection(archivedSection.id).map(i => i.workspaceId)
   }
 
-  /**
-   * Move every archived workspace back to In progress.
-   *
-   * SEQUENTIAL, and that is the whole implementation note. `moveWorkspace`
-   * computes `appendPosition(getItemsForSection(...))`, which reads
-   * `items.at(-1)` BEFORE its await while the store write lands after it -- so a
-   * parallel fan-out hands every call the identical lexorank and the sidebar
-   * shuffles the whole set on the next refresh.
-   *
-   * There is no transaction: each move is its own RPC, so a failure part way
-   * through leaves the archive partly emptied. Each failed move raises its own
-   * warning toast, which is the whole safety story.
-   */
+  /** Move every archived workspace back to In progress, in order. */
   const unarchiveAll = async () => {
     const inProgressSection = store.getInProgressSection()
     if (!inProgressSection)
       return
     for (const workspaceId of archivedWorkspaceIds())
-      await moveWorkspace(workspaceId, inProgressSection.id)
+      await unarchiveWorkspace(workspaceId)
   }
 
   /**

--- a/frontend/src/components/shell/useWorkspaceOperations.ts
+++ b/frontend/src/components/shell/useWorkspaceOperations.ts
@@ -47,6 +47,12 @@ export interface UseWorkspaceOperationsProps {
   onPostArchiveWorkspace?: (workspaceId: string) => void
 }
 
+/** Where a lifecycle move lands: a section, and a lexorank inside it. */
+interface MoveTarget {
+  sectionId: string
+  position: string
+}
+
 export function useWorkspaceOperations(props: UseWorkspaceOperationsProps) {
   const store = props.sectionStore
 
@@ -243,8 +249,10 @@ export function useWorkspaceOperations(props: UseWorkspaceOperationsProps) {
     cancelRename()
   }
 
-  const archiveWorkspace = async (workspaceId: string) => {
-    const archivedSection = store.getArchivedSection()
+  const archiveWorkspace = async (workspaceId: string, target?: MoveTarget, refresh = true) => {
+    const archivedSection = target?.sectionId
+      ? store.state.sections.find(section => section.id === target.sectionId)
+      : store.getArchivedSection()
     if (!archivedSection)
       return
     if (props.onConfirmArchive) {
@@ -254,24 +262,20 @@ export function useWorkspaceOperations(props: UseWorkspaceOperationsProps) {
     }
     const done = startWorkspaceLoading(workspaceId)
     try {
-      const resp = await workspaceClient.setWorkspaceArchiveState({
+      await workspaceClient.setWorkspaceArchiveState({
         workspaceId,
         archiveState: WorkspaceArchiveState.ARCHIVED,
+        destinationSectionId: target?.sectionId ?? '',
+        position: target?.position ?? '',
       })
-      // Apply the Hub state before any Worker fan-out. Every local surface now
-      // treats the workspace as read-only while its processes stop.
-      store.moveWorkspace(workspaceId, archivedSection.id, appendPosition(store.getItemsForSection(archivedSection.id)))
-      await props.loadSections()
+      // The Hub nudged every Worker that hosts one of this workspace's tabs
+      // inside the call above, so those processes are already stopping. Apply
+      // the local state now: every surface treats the workspace as read-only
+      // while that happens.
+      store.moveWorkspace(workspaceId, archivedSection.id, target?.position ?? appendPosition(store.getItemsForSection(archivedSection.id)))
+      if (refresh)
+        await props.loadSections()
       props.onPostArchiveWorkspace?.(workspaceId)
-      const results = await Promise.allSettled(resp.workerTabs.map(workerTabs =>
-        workerRpc.setTabArchiveState(workerTabs.workerId, {
-          tabs: workerTabs.tabs,
-          archiveState: WorkspaceArchiveState.ARCHIVED,
-        }),
-      ))
-      const failure = results.find(result => result.status === 'rejected')
-      if (failure?.status === 'rejected')
-        showWarnToast('Workspace archived, but a Worker did not stop its tabs', failure.reason)
     }
     catch (err) {
       showWarnToast('Failed to archive workspace', err)
@@ -281,29 +285,23 @@ export function useWorkspaceOperations(props: UseWorkspaceOperationsProps) {
     }
   }
 
-  const unarchiveWorkspace = async (workspaceId: string) => {
-    const inProgressSection = store.getInProgressSection()
+  const unarchiveWorkspace = async (workspaceId: string, target?: MoveTarget, refresh = true) => {
+    const inProgressSection = target?.sectionId
+      ? store.state.sections.find(section => section.id === target.sectionId)
+      : store.getInProgressSection()
     if (!inProgressSection)
       return
     const done = startWorkspaceLoading(workspaceId)
     try {
-      const resp = await workspaceClient.setWorkspaceArchiveState({
+      await workspaceClient.setWorkspaceArchiveState({
         workspaceId,
         archiveState: WorkspaceArchiveState.ACTIVE,
+        destinationSectionId: target?.sectionId ?? '',
+        position: target?.position ?? '',
       })
-      // Clear the Worker cache before the section refresh makes the workspace
-      // writable again. The Hub state stays active if a Worker call fails.
-      const results = await Promise.allSettled(resp.workerTabs.map(workerTabs =>
-        workerRpc.setTabArchiveState(workerTabs.workerId, {
-          tabs: workerTabs.tabs,
-          archiveState: WorkspaceArchiveState.ACTIVE,
-        }),
-      ))
-      store.moveWorkspace(workspaceId, inProgressSection.id, appendPosition(store.getItemsForSection(inProgressSection.id)))
-      await props.loadSections()
-      const failure = results.find(result => result.status === 'rejected')
-      if (failure?.status === 'rejected')
-        showWarnToast('Workspace unarchived, but a Worker did not update its tabs', failure.reason)
+      store.moveWorkspace(workspaceId, inProgressSection.id, target?.position ?? appendPosition(store.getItemsForSection(inProgressSection.id)))
+      if (refresh)
+        await props.loadSections()
     }
     catch (err) {
       showWarnToast('Failed to unarchive workspace', err)
@@ -319,36 +317,33 @@ export function useWorkspaceOperations(props: UseWorkspaceOperationsProps) {
    * Crossing that boundary is a LIFECYCLE change, not a sidebar move, and the
    * hub enforces it: `SectionService.MoveWorkspace` answers FailedPrecondition
    * for a destination on the other side, because stopping or restarting a
-   * workspace's processes must not ride on a generic reorder. So a crossing is
-   * routed through archive/unarchive here, and the plain move below runs only
-   * when both sides agree.
+   * workspace's processes must not ride on a generic reorder. So this function
+   * routes a crossing through archive/unarchive, and runs the plain move below
+   * only when both sides agree.
    *
-   * Unarchiving lands the workspace in In progress, so a destination that is
-   * neither Archived nor In progress takes the second, now same-side, move.
-   * That two-step is what keeps "Move to" working on an archived workspace,
-   * which is the only way to unarchive into a specific CUSTOM section.
+   * The crossing carries its DESTINATION, so it stays one hub transaction. It
+   * used to unarchive into In progress and then issue a second move, which
+   * left the workspace resting in In progress whenever that second call
+   * failed, and needed a "still archived?" branch to tell the two failures
+   * apart. `SetWorkspaceArchiveState` refuses a destination on the wrong side,
+   * so the parameter cannot become a second way to archive.
    */
-  const moveWorkspace = async (workspaceId: string, sectionId: string) => {
+  const moveWorkspace = async (workspaceId: string, sectionId: string, dropPosition?: string) => {
     const destination = store.state.sections.find(section => section.id === sectionId)
     const destinationArchived = destination?.sectionType === SectionType.WORKSPACES_ARCHIVED
-    // The two sides COMPARED, not the destination alone: a reorder inside the
-    // archive is a move within one side, and treating it as a crossing would
-    // ask the user to confirm archiving a workspace that is already archived.
+    // This code COMPARES the two sides, not the destination alone: a reorder
+    // inside the archive is a move within one side, and treating it as a
+    // crossing would ask the user to confirm archiving a workspace that is
+    // already archived.
     if (destinationArchived !== isWorkspaceArchived(workspaceId)) {
-      if (destinationArchived) {
-        await archiveWorkspace(workspaceId)
-        return
-      }
-      await unarchiveWorkspace(workspaceId)
-      // Still archived means the unarchive failed and already raised its own
-      // toast. A plain move now would fail again for the same reason and report
-      // it a second time, so stop here.
-      if (isWorkspaceArchived(workspaceId) || sectionId === store.getInProgressSection()?.id)
-        return
+      const target: MoveTarget = { sectionId, position: dropPosition ?? appendPosition(store.getItemsForSection(sectionId)) }
+      if (destinationArchived)
+        await archiveWorkspace(workspaceId, target)
+      else
+        await unarchiveWorkspace(workspaceId, target)
+      return
     }
-    // Read the destination AFTER any unarchive above, which appends a row to
-    // In progress and can therefore move what "the last position" is.
-    const position = appendPosition(store.getItemsForSection(sectionId))
+    const position = dropPosition ?? appendPosition(store.getItemsForSection(sectionId))
     const done = startWorkspaceLoading(workspaceId)
     try {
       await sectionClient.moveWorkspace({ workspaceId, sectionId, position })
@@ -454,13 +449,37 @@ export function useWorkspaceOperations(props: UseWorkspaceOperationsProps) {
     return store.getItemsForSection(archivedSection.id).map(i => i.workspaceId)
   }
 
-  /** Move every archived workspace back to In progress, in order. */
+  /**
+   * Move every archived workspace back to In progress.
+   *
+   * SEQUENTIAL, and that is still the whole implementation note, though the
+   * reason moved. The local `appendPosition` no longer collides -- it is
+   * computed beside the store write now -- but the HUB computes the stored rank
+   * inside `SetWorkspaceArchiveState`, reading the destination's tail and
+   * writing `After(tail)`. Two of these overlapping at READ COMMITTED read the
+   * same tail. `appendPositionAfter` on the hub makes that collision
+   * impossible, so this loop is no longer the only thing standing between the
+   * user and a sidebar that reshuffles on every refresh; it stays sequential
+   * because the order the user sees should be the order they archived in.
+   *
+   * There is no transaction: each workspace is its own pair of RPCs, so a
+   * failure part way through leaves the archive partly emptied. Each failed one
+   * raises its own toast, which is the whole safety story.
+   *
+   * ONE refresh at the end, not one per workspace: a per-item reload costs N
+   * round trips to fetch N-1 states nobody sees. `performDelete` takes the same
+   * parameter for the same reason.
+   */
   const unarchiveAll = async () => {
     const inProgressSection = store.getInProgressSection()
     if (!inProgressSection)
       return
-    for (const workspaceId of archivedWorkspaceIds())
-      await unarchiveWorkspace(workspaceId)
+    const ids = archivedWorkspaceIds()
+    if (ids.length === 0)
+      return
+    for (const workspaceId of ids)
+      await unarchiveWorkspace(workspaceId, undefined, false)
+    await props.loadSections()
   }
 
   /**
@@ -592,13 +611,14 @@ export function useWorkspaceOperations(props: UseWorkspaceOperationsProps) {
     // A drop that CROSSES the archive boundary -- in either direction -- is a
     // lifecycle change, and `moveWorkspace` owns what that means: the archive
     // confirmation on the way in, the unarchive on the way out, and the hub
-    // call that a plain `MoveWorkspace` would have been refused for. The drop
-    // POSITION is dropped with it, because both lifecycle calls append at the
-    // destination's end; a same-side drop keeps the optimistic path below.
+    // call that a plain `MoveWorkspace` refuses. The drop POSITION goes with
+    // it, because the lifecycle RPC takes a destination and a rank, so the
+    // workspace lands exactly where the user dropped it; a same-side drop
+    // keeps the optimistic path below.
     const resolvedTargetSection = store.state.sections.find(s => s.id === targetSectionId)
     const targetArchived = resolvedTargetSection?.sectionType === SectionType.WORKSPACES_ARCHIVED
     if (targetArchived !== isWorkspaceArchived(wsId)) {
-      void moveWorkspace(wsId, targetSectionId)
+      void moveWorkspace(wsId, targetSectionId, position)
       return
     }
 

--- a/frontend/src/components/shell/useWorkspaceOperations.ts
+++ b/frontend/src/components/shell/useWorkspaceOperations.ts
@@ -243,22 +243,6 @@ export function useWorkspaceOperations(props: UseWorkspaceOperationsProps) {
     cancelRename()
   }
 
-  const moveWorkspace = async (workspaceId: string, sectionId: string) => {
-    const sectionItems = store.getItemsForSection(sectionId)
-    const position = appendPosition(sectionItems)
-    const done = startWorkspaceLoading(workspaceId)
-    try {
-      await sectionClient.moveWorkspace({ workspaceId, sectionId, position })
-      store.moveWorkspace(workspaceId, sectionId, position)
-    }
-    catch (err) {
-      showWarnToast('Failed to move workspace', err)
-    }
-    finally {
-      done()
-    }
-  }
-
   const archiveWorkspace = async (workspaceId: string) => {
     const archivedSection = store.getArchivedSection()
     if (!archivedSection)
@@ -323,6 +307,55 @@ export function useWorkspaceOperations(props: UseWorkspaceOperationsProps) {
     }
     catch (err) {
       showWarnToast('Failed to unarchive workspace', err)
+    }
+    finally {
+      done()
+    }
+  }
+
+  /**
+   * Move one workspace into `sectionId`, resolving the archive boundary first.
+   *
+   * Crossing that boundary is a LIFECYCLE change, not a sidebar move, and the
+   * hub enforces it: `SectionService.MoveWorkspace` answers FailedPrecondition
+   * for a destination on the other side, because stopping or restarting a
+   * workspace's processes must not ride on a generic reorder. So a crossing is
+   * routed through archive/unarchive here, and the plain move below runs only
+   * when both sides agree.
+   *
+   * Unarchiving lands the workspace in In progress, so a destination that is
+   * neither Archived nor In progress takes the second, now same-side, move.
+   * That two-step is what keeps "Move to" working on an archived workspace,
+   * which is the only way to unarchive into a specific CUSTOM section.
+   */
+  const moveWorkspace = async (workspaceId: string, sectionId: string) => {
+    const destination = store.state.sections.find(section => section.id === sectionId)
+    const destinationArchived = destination?.sectionType === SectionType.WORKSPACES_ARCHIVED
+    // The two sides COMPARED, not the destination alone: a reorder inside the
+    // archive is a move within one side, and treating it as a crossing would
+    // ask the user to confirm archiving a workspace that is already archived.
+    if (destinationArchived !== isWorkspaceArchived(workspaceId)) {
+      if (destinationArchived) {
+        await archiveWorkspace(workspaceId)
+        return
+      }
+      await unarchiveWorkspace(workspaceId)
+      // Still archived means the unarchive failed and already raised its own
+      // toast. A plain move now would fail again for the same reason and report
+      // it a second time, so stop here.
+      if (isWorkspaceArchived(workspaceId) || sectionId === store.getInProgressSection()?.id)
+        return
+    }
+    // Read the destination AFTER any unarchive above, which appends a row to
+    // In progress and can therefore move what "the last position" is.
+    const position = appendPosition(store.getItemsForSection(sectionId))
+    const done = startWorkspaceLoading(workspaceId)
+    try {
+      await sectionClient.moveWorkspace({ workspaceId, sectionId, position })
+      store.moveWorkspace(workspaceId, sectionId, position)
+    }
+    catch (err) {
+      showWarnToast('Failed to move workspace', err)
     }
     finally {
       done()
@@ -556,10 +589,16 @@ export function useWorkspaceOperations(props: UseWorkspaceOperationsProps) {
       return
     }
 
-    // If dragging to the archived section, use the archive flow with confirmation
+    // A drop that CROSSES the archive boundary -- in either direction -- is a
+    // lifecycle change, and `moveWorkspace` owns what that means: the archive
+    // confirmation on the way in, the unarchive on the way out, and the hub
+    // call that a plain `MoveWorkspace` would have been refused for. The drop
+    // POSITION is dropped with it, because both lifecycle calls append at the
+    // destination's end; a same-side drop keeps the optimistic path below.
     const resolvedTargetSection = store.state.sections.find(s => s.id === targetSectionId)
-    if (resolvedTargetSection?.sectionType === SectionType.WORKSPACES_ARCHIVED) {
-      archiveWorkspace(wsId)
+    const targetArchived = resolvedTargetSection?.sectionType === SectionType.WORKSPACES_ARCHIVED
+    if (targetArchived !== isWorkspaceArchived(wsId)) {
+      void moveWorkspace(wsId, targetSectionId)
       return
     }
 

--- a/frontend/src/components/workspace/WorkspaceContextMenu.tsx
+++ b/frontend/src/components/workspace/WorkspaceContextMenu.tsx
@@ -186,7 +186,8 @@ export const WorkspaceContextMenu: Component<WorkspaceContextMenuProps> = (props
           SPECIFIC custom section, because `Unarchive` below always targets In
           progress. The hub REFUSES a `MoveWorkspace` that crosses the archive
           boundary (archival stops processes, so it cannot ride on a generic
-          reorder), so `onMoveTo` unarchives first and moves second -- see
+          reorder), so `onMoveTo` routes a crossing through
+          `SetWorkspaceArchiveState`, which carries the destination -- see
           `useWorkspaceOperations.moveWorkspace`. `isMoveTargetSection` excludes
           Archived as a target, so for an archived workspace every other
           workspace section is legal -- the list is non-empty exactly when it is

--- a/frontend/src/components/workspace/WorkspaceContextMenu.tsx
+++ b/frontend/src/components/workspace/WorkspaceContextMenu.tsx
@@ -182,14 +182,15 @@ export const WorkspaceContextMenu: Component<WorkspaceContextMenuProps> = (props
         {menuItem('Rename', () => props.onRename())}
       </Show>
 
-      {/* KEPT while archived. Moving a workspace writes
-          `workspace_section_items.section_id`, which is not a mutation OF the
-          workspace -- `MoveWorkspace` is unguarded in the hub by design, since
-          archive and unarchive are the same call. It is also the only way to
-          unarchive into a SPECIFIC custom section, because `Unarchive` below
-          always targets In progress. `isMoveTargetSection` excludes Archived
-          as a target, so for an archived workspace every other workspace
-          section is legal -- the list is non-empty exactly when it is useful. */}
+      {/* KEPT while archived, and it is the only way to unarchive into a
+          SPECIFIC custom section, because `Unarchive` below always targets In
+          progress. The hub REFUSES a `MoveWorkspace` that crosses the archive
+          boundary (archival stops processes, so it cannot ride on a generic
+          reorder), so `onMoveTo` unarchives first and moves second -- see
+          `useWorkspaceOperations.moveWorkspace`. `isMoveTargetSection` excludes
+          Archived as a target, so for an archived workspace every other
+          workspace section is legal -- the list is non-empty exactly when it is
+          useful. */}
       <Show when={moveTargets().length > 0}>
         <SubMenu label="Move to" data-testid="workspace-move-to" popoverTestId="workspace-move-to-popover">
           <For each={moveTargets()}>

--- a/frontend/src/components/workspace/WorkspaceTabTree.interactions.test.tsx
+++ b/frontend/src/components/workspace/WorkspaceTabTree.interactions.test.tsx
@@ -159,13 +159,15 @@ describe('workspaceTabTree interactions', () => {
     expect(onTabClose.mock.calls[0][0]).toMatchObject({ type: TabType.TERMINAL, id: 't1', workspaceId: 'ws-1' })
   })
 
-  it('hides close controls for agent and terminal tabs in archived mode', () => {
+  it('hides close controls for every tab type in archived mode', () => {
     render(() => (
       <WorkspaceTabTree
         repoGitStore={repoGitStore}
         tabs={[
           makeTab(TabType.AGENT, 'a1', 'Agent 1'),
           makeTab(TabType.TERMINAL, 't1', 'Terminal 1'),
+          makeTab(TabType.FILE, 'f1', 'readme.md'),
+          makeTab(TabType.IMAGE, 'i1', 'image.png'),
         ]}
         activeTabKey={null}
         onTabClick={() => {}}
@@ -175,21 +177,6 @@ describe('workspaceTabTree interactions', () => {
     ))
 
     expect(screen.queryByTestId('workspace-tab-close')).not.toBeInTheDocument()
-  })
-
-  it('keeps file tab close control in archived mode', () => {
-    render(() => (
-      <WorkspaceTabTree
-        repoGitStore={repoGitStore}
-        tabs={[makeTab(TabType.FILE, 'f1', 'readme.md')]}
-        activeTabKey={null}
-        onTabClick={() => {}}
-        archived
-        workspaceId="ws-1"
-      />
-    ))
-
-    expect(screen.getByTestId('workspace-tab-close')).toBeInTheDocument()
   })
 
   it('disables the close control while a close is in flight', () => {

--- a/frontend/src/components/workspace/WorkspaceTabTree.tsx
+++ b/frontend/src/components/workspace/WorkspaceTabTree.tsx
@@ -775,8 +775,8 @@ export interface WorkspaceTabTreeProps {
   tabItemOps?: TabItemOps
   /**
    * The workspace this tree belongs to is archived, so its rows offer no
-   * mutation: no branch menu, no close and no rename. A payload-backed tab
-   * keeps its close -- see `canCloseTab`, which the tab bar shares.
+   * mutation: no branch menu, no close, and no rename. See `canCloseTab`,
+   * which the tab bar shares.
    *
    * Named for the FACT rather than for the effect (this prop was `readOnly`).
    * Archival is the only thing that blocks mutation -- access is owner-only, and

--- a/frontend/src/components/workspace/WorkspaceTabTree.tsx
+++ b/frontend/src/components/workspace/WorkspaceTabTree.tsx
@@ -424,7 +424,7 @@ interface RowSelectionContextValue {
   activeTabKey: Accessor<string | null>
   tabItemOps: Accessor<TabItemOps | undefined>
   onTabClick: (type: TabType, id: string) => void
-  canClose: (tab: Tab) => boolean
+  canClose: () => boolean
   isCollapsed: (key: string) => boolean
   toggleCollapsed: (key: string) => void
   /**
@@ -507,7 +507,7 @@ const TabLeafSlot: Component<{ tab: Tab, depth: number }> = (props) => {
       onRename={edit.canRename(props.tab) ? () => edit.startEditing(props.tab) : undefined}
       onClose={() => sel.tabItemOps()?.onClose?.(props.tab)}
       isClosing={sel.tabItemOps()?.closingKeys?.has(tabKey(props.tab))}
-      canClose={sel.canClose(props.tab)}
+      canClose={sel.canClose()}
       onEditInput={v => edit.setEditingValue(v)}
       onEditCommit={() => edit.commitEdit(props.tab)}
       onEditCancel={edit.cancelEdit}
@@ -944,7 +944,7 @@ export const WorkspaceTabTree: Component<WorkspaceTabTreeProps> = (props) => {
   const [editingTabKey, setEditingTabKey] = createSignal<string | null>(null)
   const [editingValue, setEditingValue] = createSignal('')
   let editCancelled = false
-  const canClose = (tab: Tab) => canCloseTab(props.archived, tab)
+  const canClose = () => canCloseTab(props.archived)
 
   // `canRenameTab` states the rule; this surface adds only whether it HAS a
   // rename handler. Shared with the tab strip, which renders the same tabs.

--- a/frontend/src/hooks/useShortcuts.test.tsx
+++ b/frontend/src/hooks/useShortcuts.test.tsx
@@ -167,43 +167,23 @@ describe('useShortcuts', () => {
     expect(props.tabOps.handleTabClose).toHaveBeenCalledWith(tab)
   })
 
-  // The shortcut asks the SAME question the tab strip and the sidebar tree ask
-  // before they draw a close control. An archived workspace keeps its agents and
-  // terminals running, so a keyboard that still closed one would be the only
-  // surface that disagrees -- and the user would have no visible control to undo
-  // it with.
-  it('refuses to close a running tab the buttons refuse, in an archived workspace', () => {
-    const props = makeProps() as any
-    props.resolveFocusedTab = () => ({ type: TabType.TERMINAL, id: 'term-1', tileId: 'tile-1' })
-    props.isActiveWorkspaceArchived = () => true
+  it.each([TabType.AGENT, TabType.TERMINAL, TabType.FILE, TabType.IMAGE])(
+    'refuses to close tab type %s in an archived workspace',
+    (type) => {
+      const props = makeProps() as any
+      props.resolveFocusedTab = () => ({ type, id: 'tab-1', tileId: 'tile-1' })
+      props.isActiveWorkspaceArchived = () => true
 
-    render(() => {
-      useShortcuts(props as any)
-      return null
-    })
+      render(() => {
+        useShortcuts(props as any)
+        return null
+      })
 
-    executeCommand('app.closeActiveTab')
+      executeCommand('app.closeActiveTab')
 
-    expect(props.tabOps.handleTabClose).not.toHaveBeenCalled()
-  })
-
-  // A payload-backed tab is the exception on every surface: it owns no process,
-  // so closing one changes nothing on the Worker.
-  it('still closes a payload-backed tab in an archived workspace', () => {
-    const props = makeProps() as any
-    const tab = { type: TabType.FILE, id: 'file-1', tileId: 'tile-1' }
-    props.resolveFocusedTab = () => tab
-    props.isActiveWorkspaceArchived = () => true
-
-    render(() => {
-      useShortcuts(props as any)
-      return null
-    })
-
-    executeCommand('app.closeActiveTab')
-
-    expect(props.tabOps.handleTabClose).toHaveBeenCalledWith(tab)
-  })
+      expect(props.tabOps.handleTabClose).not.toHaveBeenCalled()
+    },
+  )
 
   describe('without an active workspace', () => {
     function makeNoWorkspaceProps() {

--- a/frontend/src/hooks/useShortcuts.ts
+++ b/frontend/src/hooks/useShortcuts.ts
@@ -158,10 +158,10 @@ export function useShortcuts(props: UseShortcutsProps): void {
   cmd('app.closeActiveTab', 'Close Active Tab', () => {
     const tab = resolveFocusedTab()
     // The SAME predicate the tab strip and the sidebar tree draw their close
-    // controls from. An archived workspace keeps its agent and terminal tabs, so
-    // a shortcut that closed one would be the only surface that disagrees --
-    // and the user would have no visible control to undo it with.
-    if (tab && canCloseTab(props.isActiveWorkspaceArchived(), tab))
+    // controls from. An archived workspace keeps EVERY tab it held, so a
+    // shortcut that closed one would be the only surface that disagrees -- and
+    // the user would have no visible control to undo it with.
+    if (tab && canCloseTab(props.isActiveWorkspaceArchived()))
       tabOps.handleTabClose(tab)
   }, 'Tab')
   cmd('app.toggleLeftSidebar', 'Toggle Left Sidebar', toggleLeftSidebar, 'Layout')

--- a/frontend/src/lib/crdt/checkpointRecorder.test.ts
+++ b/frontend/src/lib/crdt/checkpointRecorder.test.ts
@@ -130,9 +130,20 @@ function putNode(mgr: PendingOpsManager, nodeId: string, position: string): void
 }
 
 /** Let the queued microtask flush and its IDB write settle. */
-async function settle(): Promise<void> {
+/**
+ * Let the recorder's queued flush run, then wait for the WORK it started.
+ *
+ * The ticks are what let a debounced flush fire at all; `whenSettled` is what
+ * ends the state. Counting ticks alone could not: a case where one write's
+ * success re-issues another needs the second cycle to both start and finish,
+ * and on a loaded runner it had not started when the assertions ran. Pass the
+ * recorder wherever a case chains writes.
+ */
+async function settle(recorder?: { whenSettled: () => Promise<void> }): Promise<void> {
   for (let i = 0; i < 5; i++)
     await new Promise(resolve => setTimeout(resolve, 0))
+  if (recorder)
+    await recorder.whenSettled()
 }
 
 /** Seed a checkpoint so reads return `ok` rather than `miss`. */
@@ -165,7 +176,7 @@ describe('createCheckpointRecorder', () => {
     recorder.record(frame('a'))
     recorder.record(frame('b'))
     recorder.record(frame('c'))
-    await settle()
+    await settle(recorder)
 
     const read = await readCheckpoint(USER, CLIENT)
     expect(read.status).toBe('ok')
@@ -188,7 +199,7 @@ describe('createCheckpointRecorder', () => {
     })
     recorder.record(frame('a'))
     recorder.record(frame('b'))
-    await settle()
+    await settle(recorder)
 
     const read = await readCheckpoint(USER, CLIENT)
     expect(read.status).toBe('ok')
@@ -215,7 +226,7 @@ describe('createCheckpointRecorder', () => {
     expect(recorder.opLogCount).toBe(9)
 
     recorder.record(frame('one-more'))
-    await settle()
+    await settle(recorder)
 
     expect(recorder.opLogCount).toBe(0)
     await recorder.dispose()
@@ -229,12 +240,12 @@ describe('createCheckpointRecorder', () => {
     const recorder = createCheckpointRecorder({ userId: USER, clientId: CLIENT, mgr, threshold: 1 })
 
     recorder.record(frame('a'))
-    await settle()
+    await settle(recorder)
     expect(recorder.opLogCount).toBe(1)
 
     // The next flush must NOT retry -- the retry point moved out by a threshold.
     recorder.record(frame('b'))
-    await settle()
+    await settle(recorder)
     expect(recorder.opLogCount).toBe(2)
     await recorder.dispose()
   })
@@ -268,7 +279,7 @@ describe('createCheckpointRecorder', () => {
     await recorder.dispose()
 
     recorder.record(frame('after-dispose'))
-    await settle()
+    await settle(recorder)
 
     const read = await readCheckpoint(USER, CLIENT)
     expect(read.status).toBe('ok')
@@ -319,7 +330,7 @@ describe('createCheckpointRecorder incremental rewrites', () => {
     })
     putNode(mgr, 'edited', 'changed')
     recorder.record(nodeFrame('b1', 'edited'))
-    await settle()
+    await settle(recorder)
 
     // The write ASKED for is the observation: a full rewrite would leave
     // byte-identical rows behind, so the persisted result cannot tell the two
@@ -350,7 +361,7 @@ describe('createCheckpointRecorder incremental rewrites', () => {
     })
     putNode(mgr, 'bulk-3', 'v2')
     recorder.record(nodeFrame('b1', 'bulk-3'))
-    await settle()
+    await settle(recorder)
 
     expect(lastDelta().upserts).toHaveLength(1)
     await recorder.dispose()
@@ -383,7 +394,7 @@ describe('createCheckpointRecorder incremental rewrites', () => {
     putNode(mgr, 'n1', 'v1')
     recorder.record(nodeFrame('b1', 'n1'))
     expect(recorder.dirtyKeys.has('node:n1')).toBe(true)
-    await settle()
+    await settle(recorder)
     expect([...recorder.dirtyKeys]).toEqual([])
     await recorder.dispose()
   })
@@ -403,7 +414,7 @@ describe('createCheckpointRecorder incremental rewrites', () => {
     })
     delete confirmed(mgr).nodes.doomed
     recorder.record(nodeFrame('b1', 'doomed'))
-    await settle()
+    await settle(recorder)
 
     expect(keysOf(lastDelta().deletes)).toEqual(['node:doomed'])
     expect((await persistedChunks()).has('node:doomed')).toBe(false)
@@ -435,7 +446,7 @@ describe('createCheckpointRecorder incremental rewrites', () => {
     // watermark (physical 10) is past the tombstone (physical 2), so
     // compactTombstones collects it inside the rewrite.
     recorder.record(nodeFrame('b1', 'alive'))
-    await settle()
+    await settle(recorder)
 
     expect(keysOf(lastDelta().deletes)).toEqual(['node:tombstoned'])
     const chunks = await persistedChunks()
@@ -467,7 +478,9 @@ describe('createCheckpointRecorder incremental rewrites', () => {
     await Promise.resolve()
     putNode(mgr, 'second', 'v1')
     recorder.record(nodeFrame('b2', 'second'))
-    await settle()
+    // Chains two writes: the in-flight one, then the rewrite its success
+    // re-issues. Wait for the work, not for a tick count.
+    await settle(recorder)
 
     expect(recorder.dirtyKeys.has('node:first')).toBe(false)
     expect(recorder.dirtyKeys.has('node:second')).toBe(false)
@@ -486,7 +499,7 @@ describe('createCheckpointRecorder incremental rewrites', () => {
     expect(recorder.needsFullRewrite).toBe(true)
 
     recorder.record(nodeFrame('b1', 'a'))
-    await settle()
+    await settle(recorder)
 
     expect(lastDelta().full).toBe(true)
     expect([...(await persistedChunks()).keys()].sort()).toEqual(['node:a', 'node:b'])
@@ -538,11 +551,11 @@ describe('createCheckpointRecorder incremental rewrites', () => {
       })
       putNode(mgr, 'a', 'v1')
       recorder.record(nodeFrame('b1', 'a'))
-      await settle()
+      await settle(recorder)
       expect(storeSpy.appends).toBe(0)
 
       base.settle({ frames: [], nextOrdinal: 7 })
-      await settle()
+      await settle(recorder)
 
       // Released, not dropped -- and at the base's ordinal, not at 0.
       expect(storeSpy.appends).toBe(1)
@@ -564,11 +577,11 @@ describe('createCheckpointRecorder incremental rewrites', () => {
       })
       putNode(mgr, 'held', 'v1')
       recorder.record(nodeFrame('b1', 'held'))
-      await settle()
+      await settle(recorder)
       expect([...recorder.dirtyKeys]).toEqual(['node:held'])
 
       base.settle({ frames: [], nextOrdinal: 0 })
-      await settle()
+      await settle(recorder)
       expect(storeSpy.appends).toBe(1)
       await recorder.dispose()
     })
@@ -587,7 +600,7 @@ describe('createCheckpointRecorder incremental rewrites', () => {
         threshold: 1,
       })
       recorder.rewriteNow()
-      await settle()
+      await settle(recorder)
       expect(storeSpy.deltas).toHaveLength(0)
 
       // DEFERRED, not dropped: the base landing re-issues it with no second
@@ -596,7 +609,7 @@ describe('createCheckpointRecorder incremental rewrites', () => {
       // ALWAYS lands inside this hold on the seed path, so a dropped request
       // meant a seeded tab never performed that repair at all.
       base.settle(undefined)
-      await settle()
+      await settle(recorder)
       expect(storeSpy.deltas).toHaveLength(1)
       await recorder.dispose()
     })
@@ -614,7 +627,7 @@ describe('createCheckpointRecorder incremental rewrites', () => {
         hydratedFrom: base.promise,
       })
       base.settle({ frames: [], nextOrdinal: 0 })
-      await settle()
+      await settle(recorder)
       expect(storeSpy.deltas).toHaveLength(0)
       await recorder.dispose()
     })
@@ -637,16 +650,16 @@ describe('createCheckpointRecorder incremental rewrites', () => {
         hydratedFrom: base.promise,
       })
       recorder.record(nodeFrame('pre-bootstrap', 'a'))
-      await settle()
+      await settle(recorder)
       expect(storeSpy.appends).toBe(0)
 
       recorder.onCheckpointReset()
-      await settle()
+      await settle(recorder)
       base.settle(undefined)
-      await settle()
+      await settle(recorder)
 
       recorder.record(nodeFrame('post-bootstrap', 'a'))
-      await settle()
+      await settle(recorder)
 
       const read = await readCheckpoint(USER, CLIENT)
       expect(read.status).toBe('ok')
@@ -673,17 +686,17 @@ describe('createCheckpointRecorder incremental rewrites', () => {
         hydratedFrom: base.promise,
       })
       recorder.record(nodeFrame('held', 'a'))
-      await settle()
+      await settle(recorder)
 
       // Invalidate, so the settle below takes adoptBase's refusal arm...
       recorder.onCheckpointReset()
-      await settle()
+      await settle(recorder)
       base.settle({ frames: [], nextOrdinal: 4 })
-      await settle()
+      await settle(recorder)
 
       // ...and nothing is left queued: no later frame can carry it onto disk.
       recorder.record(nodeFrame('after', 'a'))
-      await settle()
+      await settle(recorder)
       const read = await readCheckpoint(USER, CLIENT)
       expect(read.status).toBe('ok')
       if (read.status !== 'ok')
@@ -707,7 +720,7 @@ describe('createCheckpointRecorder incremental rewrites', () => {
       expect(recorder.needsFullRewrite).toBe(true)
 
       base.settle({ frames: [], nextOrdinal: 0 })
-      await settle()
+      await settle(recorder)
       expect(recorder.needsFullRewrite).toBe(false)
       await recorder.dispose()
     })
@@ -727,11 +740,11 @@ describe('createCheckpointRecorder incremental rewrites', () => {
         threshold: 1,
       })
       base.settle(undefined)
-      await settle()
+      await settle(recorder)
       expect(recorder.needsFullRewrite).toBe(true)
 
       recorder.record(nodeFrame('b1', 'a'))
-      await settle()
+      await settle(recorder)
       expect(lastDelta().full).toBe(true)
       await recorder.dispose()
     })
@@ -749,11 +762,11 @@ describe('createCheckpointRecorder incremental rewrites', () => {
         threshold: 1,
       })
       base.reject(new Error('adopt blew up'))
-      await settle()
+      await settle(recorder)
       expect(recorder.needsFullRewrite).toBe(true)
 
       recorder.record(nodeFrame('b1', 'a'))
-      await settle()
+      await settle(recorder)
       expect(lastDelta().full).toBe(true)
       await recorder.dispose()
     })
@@ -773,10 +786,10 @@ describe('createCheckpointRecorder incremental rewrites', () => {
         threshold: 1,
       })
       recorder.onCheckpointReset()
-      await settle()
+      await settle(recorder)
 
       base.settle({ frames: [nodeFrame('r1', 'stale')], nextOrdinal: 9 })
-      await settle()
+      await settle(recorder)
 
       expect(recorder.dirtyKeys.has('node:stale')).toBe(false)
       // The bootstrap's own FULL rewrite is what re-establishes the base.
@@ -794,7 +807,7 @@ describe('createCheckpointRecorder incremental rewrites', () => {
       })
       await recorder.dispose()
       base.settle({ frames: [nodeFrame('r1', 'late')], nextOrdinal: 3 })
-      await settle()
+      await settle(recorder)
 
       expect(recorder.dirtyKeys.has('node:late')).toBe(false)
       expect(storeSpy.appends).toBe(0)
@@ -842,7 +855,7 @@ describe('createCheckpointRecorder incremental rewrites', () => {
       = create(UserCrdtStateSchema, { userId: USER, currentEpoch: 1n })
     putNode(mgr, 'from-new-lineage', 'v1')
     recorder.onCheckpointReset()
-    await settle()
+    await settle(recorder)
 
     expect(lastDelta().full).toBe(true)
     expect([...(await persistedChunks()).keys()]).toEqual(['node:from-new-lineage'])
@@ -874,7 +887,7 @@ describe('createCheckpointRecorder write-side bounds', () => {
 
     recorder.record(frame('a'))
     recorder.record(frame('b'))
-    await settle()
+    await settle(recorder)
 
     // The rewrite ran (it truncates, so the log is empty either way) -- what
     // must NOT have happened is the segment write that preceded it.
@@ -903,7 +916,7 @@ describe('createCheckpointRecorder write-side bounds', () => {
     })
 
     recorder.record(frame('a'))
-    await settle()
+    await settle(recorder)
 
     const read = await readCheckpoint(USER, CLIENT)
     expect(read.status).toBe('ok')
@@ -924,7 +937,7 @@ describe('createCheckpointRecorder rebase gating', () => {
     await writeBase()
 
     recorder.record(frame('before'))
-    await settle()
+    await settle(recorder)
     const afterFirst = await readCheckpoint(USER, CLIENT)
     if (afterFirst.status !== 'ok')
       throw new Error('expected a readable checkpoint')
@@ -932,11 +945,11 @@ describe('createCheckpointRecorder rebase gating', () => {
 
     // A frame that cannot be serialized: the oneof value is not a valid message.
     recorder.record({ event: { case: 'batch', value: { batchId: 1 } } } as never)
-    await settle()
+    await settle(recorder)
 
     recorder.record(frame('after-1'))
     recorder.record(frame('after-2'))
-    await settle()
+    await settle(recorder)
 
     const read = await readCheckpoint(USER, CLIENT)
     expect(read.status).toBe('ok')
@@ -973,7 +986,7 @@ describe('createCheckpointRecorder rebase gating', () => {
     recorder.record(frame('queued-2'))
     // Same synchronous turn: the microtask flush has not run yet.
     recorder.onCheckpointReset()
-    await settle()
+    await settle(recorder)
 
     const read = await readCheckpoint(USER, CLIENT)
     expect(read.status).toBe('ok')
@@ -1009,12 +1022,12 @@ describe('createCheckpointRecorder rebase gating', () => {
     recorder.onCheckpointReset()
     putNode(mgr, 'N', 'P1')
     recorder.record(nodeFrame('during-rebase', 'N'))
-    await settle()
+    await settle(recorder)
 
     // Trip one more rewrite so the dirty set is drained to disk.
     putNode(mgr, 'M', 'Q0')
     recorder.record(nodeFrame('after', 'M'))
-    await settle()
+    await settle(recorder)
 
     expect(storeSpy.deltas.some(delta => keysOf(delta.upserts).includes('node:N'))).toBe(true)
     expect((await persistedChunks()).get('node:N')).not.toBe(before)
@@ -1041,7 +1054,7 @@ describe('createCheckpointRecorder rebase gating', () => {
     // Arm the flush + rewrite, then invalidate before the IDB write settles.
     await Promise.resolve()
     recorder.onCheckpointReset()
-    await settle()
+    await settle(recorder)
 
     // The stale incremental write cannot clear the reset. Its deferred
     // successor must run as a full rewrite before the recorder becomes ready.

--- a/frontend/src/lib/crdt/checkpointRecorder.test.ts
+++ b/frontend/src/lib/crdt/checkpointRecorder.test.ts
@@ -448,11 +448,9 @@ describe('createCheckpointRecorder incremental rewrites', () => {
     await recorder.dispose()
   })
 
-  it('keeps entities dirtied WHILE a write was in flight', async () => {
-    // The write's success handler clears only the keys it actually serialized.
-    // Clearing the whole set would strand an entity changed between the
-    // serialize and the IDB commit -- its chunk stale on disk, and nothing left
-    // to say so.
+  it('rewrites entities dirtied while a write was in flight', async () => {
+    // The first success clears only the keys it serialized. The rewrite request
+    // from the second frame runs afterwards and drains that later dirty key.
     const mgr = fakeMgr()
     await writeBase(confirmed(mgr))
     const recorder = createCheckpointRecorder({
@@ -472,7 +470,9 @@ describe('createCheckpointRecorder incremental rewrites', () => {
     await settle()
 
     expect(recorder.dirtyKeys.has('node:first')).toBe(false)
-    expect(recorder.dirtyKeys.has('node:second')).toBe(true)
+    expect(recorder.dirtyKeys.has('node:second')).toBe(false)
+    expect(keysOf(lastDelta().upserts)).toContain('node:second')
+    expect((await persistedChunks()).has('node:second')).toBe(true)
     await recorder.dispose()
   })
 
@@ -1016,7 +1016,7 @@ describe('createCheckpointRecorder rebase gating', () => {
     recorder.record(nodeFrame('after', 'M'))
     await settle()
 
-    expect(keysOf(lastDelta().upserts)).toContain('node:N')
+    expect(storeSpy.deltas.some(delta => keysOf(delta.upserts).includes('node:N'))).toBe(true)
     expect((await persistedChunks()).get('node:N')).not.toBe(before)
     await recorder.dispose()
   })
@@ -1028,6 +1028,7 @@ describe('createCheckpointRecorder rebase gating', () => {
     // of the WRONG lineage -- the precise failure the flag exists to prevent.
     const mgr = fakeMgr()
     await writeBase()
+    const writesBeforeRecorder = storeSpy.deltas.length
     const recorder = createCheckpointRecorder({
       userId: USER,
       clientId: CLIENT,
@@ -1042,8 +1043,11 @@ describe('createCheckpointRecorder rebase gating', () => {
     recorder.onCheckpointReset()
     await settle()
 
-    // The rebase must still be pending, so the next rewrite is FULL.
-    expect(recorder.needsFullRewrite).toBe(true)
+    // The stale incremental write cannot clear the reset. Its deferred
+    // successor must run as a full rewrite before the recorder becomes ready.
+    expect(storeSpy.deltas).toHaveLength(writesBeforeRecorder + 2)
+    expect(lastDelta().full).toBe(true)
+    expect(recorder.needsFullRewrite).toBe(false)
     await recorder.dispose()
   })
 })

--- a/frontend/src/lib/crdt/checkpointRecorder.ts
+++ b/frontend/src/lib/crdt/checkpointRecorder.ts
@@ -129,6 +129,11 @@ export interface CheckpointRecorder {
   readonly dirtyKeys: ReadonlySet<string>
   /** Visible for testing: whether the next rewrite re-serializes everything. */
   readonly needsFullRewrite: boolean
+  /**
+   * Visible for testing: resolves when every checkpoint write started so far
+   * has settled, including one that another write's success re-issued.
+   */
+  whenSettled: () => Promise<void>
 }
 
 export function createCheckpointRecorder(opts: CheckpointRecorderOptions): CheckpointRecorder {
@@ -179,8 +184,8 @@ export function createCheckpointRecorder(opts: CheckpointRecorderOptions): Check
    */
   let base: 'pending' | 'none' | 'ready'
   /**
-   * A rewrite was asked for while the base or another rewrite was pending, and
-   * still needs an answer.
+   * A caller asked for a rewrite while the base or another rewrite was
+   * pending. The recorder still owes that caller an answer.
    *
    * The hold has to DEFER the request, not drop it, and the two are easy to
    * confuse because the threshold-driven trigger re-arms itself on the next
@@ -191,6 +196,15 @@ export function createCheckpointRecorder(opts: CheckpointRecorderOptions): Check
    * re-issued, so a seeded tab kept an over-ceiling log -- and, before the
    * validated-prefix copy, a poison tail -- on disk for its whole session,
    * re-truncating at the same frame on every later reload.
+   *
+   * The hold defers the request to the next ATTEMPT, not to the next SUCCESS,
+   * and the two failure tails clear it on purpose. A write that fails landed
+   * nothing: the op log, `opLogCount`, `dirty`, `needsRebase` and `base` are
+   * all exactly as they were, so the request has nothing left to protect, and
+   * `nextCompactAt` owns the retry from there. Re-issuing on failure instead
+   * would defeat that back-off and, in the `needsRebase` regime -- where
+   * `record` asks for a rewrite on every frame -- would chain failing full
+   * serializes back to back on the main thread for as long as frames arrive.
    */
   let heldRewrite = false
   /**
@@ -404,7 +418,7 @@ export function createCheckpointRecorder(opts: CheckpointRecorderOptions): Check
     if (disposed)
       return false
     if (writing) {
-      // The current delta is already serialized. Retain this request so any
+      // The in-flight write already serialized its delta. Retain this request so any
       // entity dirtied after that snapshot gets another rewrite when the
       // current write settles.
       heldRewrite = true
@@ -454,6 +468,9 @@ export function createCheckpointRecorder(opts: CheckpointRecorderOptions): Check
           // exactly as they were, or the entities this attempt described would
           // never be written again.
           nextCompactAt = opLogCount + threshold
+          // The hold is answered, not dropped: this attempt WAS the deferred
+          // rewrite. Nothing landed, so every trigger that armed it is still
+          // armed, and nextCompactAt above owns the retry.
           heldRewrite = false
           return
         }
@@ -484,6 +501,7 @@ export function createCheckpointRecorder(opts: CheckpointRecorderOptions): Check
       .catch(() => {
         writing = false
         nextCompactAt = opLogCount + threshold
+        // Answered, for the same reason as the `!ok` tail above.
         heldRewrite = false
       }))
     return true
@@ -714,6 +732,24 @@ export function createCheckpointRecorder(opts: CheckpointRecorderOptions): Check
       disposed = true
       pendingFrames.length = 0
       await inFlight.catch(() => {})
+    },
+    /**
+     * Resolves when every checkpoint write started so far has settled.
+     *
+     * It is the same chain `dispose` awaits, exposed so a test can wait for
+     * the WORK to end instead of counting event-loop ticks. A tick count
+     * cannot bound a case where one write's success re-issues another: the
+     * second cycle simply had not started yet on a loaded runner, which made
+     * those tests fail only under load.
+     *
+     * It re-reads `inFlight` after each await, because a settled write may
+     * have extended the chain.
+     */
+    async whenSettled(): Promise<void> {
+      for (let previous: Promise<unknown> | null = null; previous !== inFlight;) {
+        previous = inFlight
+        await inFlight.catch(() => {})
+      }
     },
     get opLogCount(): number {
       return opLogCount

--- a/frontend/src/lib/crdt/checkpointRecorder.ts
+++ b/frontend/src/lib/crdt/checkpointRecorder.ts
@@ -179,8 +179,8 @@ export function createCheckpointRecorder(opts: CheckpointRecorderOptions): Check
    */
   let base: 'pending' | 'none' | 'ready'
   /**
-   * A rewrite was asked for while `base` was `pending`, and still owes an
-   * answer.
+   * A rewrite was asked for while the base or another rewrite was pending, and
+   * still needs an answer.
    *
    * The hold has to DEFER the request, not drop it, and the two are easy to
    * confuse because the threshold-driven trigger re-arms itself on the next
@@ -401,8 +401,15 @@ export function createCheckpointRecorder(opts: CheckpointRecorderOptions): Check
 
   /** Returns whether a checkpoint write was actually ISSUED. */
   function rewriteCheckpoint(): boolean {
-    if (disposed || writing)
+    if (disposed)
       return false
+    if (writing) {
+      // The current delta is already serialized. Retain this request so any
+      // entity dirtied after that snapshot gets another rewrite when the
+      // current write settles.
+      heldRewrite = true
+      return false
+    }
     if (base === 'pending') {
       // A rewrite would serialize a base the in-flight adoption is about to
       // replace wholesale, and its truncate would race the adoption's own.
@@ -447,6 +454,7 @@ export function createCheckpointRecorder(opts: CheckpointRecorderOptions): Check
           // exactly as they were, or the entities this attempt described would
           // never be written again.
           nextCompactAt = opLogCount + threshold
+          heldRewrite = false
           return
         }
         // The truncate landed, so the on-disk log is empty whichever lineage
@@ -459,6 +467,8 @@ export function createCheckpointRecorder(opts: CheckpointRecorderOptions): Check
           // Invalidated after this write serialized. Its chunks describe the
           // superseded lineage, so leave needsRebase and the base phase standing
           // and let the retry re-base with a FULL rewrite.
+          if (heldRewrite)
+            rewriteCheckpoint()
           return
         }
         needsRebase = false
@@ -468,10 +478,13 @@ export function createCheckpointRecorder(opts: CheckpointRecorderOptions): Check
         // so clearing the whole set would strand them.
         for (const key of writtenKeys)
           dirty.delete(key)
+        if (heldRewrite)
+          rewriteCheckpoint()
       })
       .catch(() => {
         writing = false
         nextCompactAt = opLogCount + threshold
+        heldRewrite = false
       }))
     return true
   }

--- a/frontend/src/stores/tab.helpers.test.ts
+++ b/frontend/src/stores/tab.helpers.test.ts
@@ -1062,18 +1062,9 @@ describe('canCloseTab and canRenameTab', () => {
     expect(canRenameTab(false, terminal)).toBe(true)
   })
 
-  // An archived workspace takes no mutation, and an agent or a terminal has a
-  // process behind it that closing would stop.
-  it('refuses to close a process-backed tab in an archived workspace', () => {
-    expect(canCloseTab(true, agent)).toBe(false)
-    expect(canCloseTab(true, terminal)).toBe(false)
-  })
-
-  // A payload-backed tab is the exception: it owns no process, so closing one
-  // changes nothing on the Worker.
-  it('still closes a payload-backed tab in an archived workspace', () => {
-    expect(canCloseTab(true, file)).toBe(true)
-    expect(canCloseTab(true, image)).toBe(true)
+  it('refuses to close every tab type in an archived workspace', () => {
+    for (const tab of [agent, terminal, file, image])
+      expect(canCloseTab(true, tab)).toBe(false)
   })
 
   // A payload-backed tab takes its title from what it SHOWS, so a user-typed

--- a/frontend/src/stores/tab.helpers.test.ts
+++ b/frontend/src/stores/tab.helpers.test.ts
@@ -1053,8 +1053,7 @@ describe('canCloseTab and canRenameTab', () => {
   const image = { type: TabType.IMAGE, id: 'i-1' } as Tab
 
   it('closes every kind while the workspace is not archived', () => {
-    for (const tab of [agent, terminal, file, image])
-      expect(canCloseTab(false, tab)).toBe(true)
+    expect(canCloseTab(false)).toBe(true)
   })
 
   it('renames a process-backed tab while the workspace is not archived', () => {
@@ -1062,9 +1061,11 @@ describe('canCloseTab and canRenameTab', () => {
     expect(canRenameTab(false, terminal)).toBe(true)
   })
 
+  // Every tab TYPE, including the payload-backed pair that used to keep its
+  // close control: the predicate takes no tab at all now, so one call covers
+  // them, and `canRenameTab` below is what still varies by type.
   it('refuses to close every tab type in an archived workspace', () => {
-    for (const tab of [agent, terminal, file, image])
-      expect(canCloseTab(true, tab)).toBe(false)
+    expect(canCloseTab(true)).toBe(false)
   })
 
   // A payload-backed tab takes its title from what it SHOWS, so a user-typed
@@ -1083,7 +1084,7 @@ describe('canCloseTab and canRenameTab', () => {
   // `undefined` is what a surface that never learned the flag passes. It must
   // read as "not archived" rather than blocking every control.
   it('treats an absent archived flag as not archived', () => {
-    expect(canCloseTab(undefined, agent)).toBe(true)
+    expect(canCloseTab(undefined)).toBe(true)
     expect(canRenameTab(undefined, agent)).toBe(true)
   })
 })

--- a/frontend/src/stores/tab.helpers.ts
+++ b/frontend/src/stores/tab.helpers.ts
@@ -751,16 +751,14 @@ export function parseTabKey(key: string): { type: TabType, id: string } | null {
  * Whether a tab may be closed from a surface that renders `archived`'s
  * workspace.
  *
- * An archived workspace takes no mutation, so its agent and terminal tabs keep
- * no close control. A PAYLOAD-BACKED tab is the exception: it holds a file or an
- * image the client opened for itself, with nothing running behind it, so
- * closing one changes nothing on the Worker.
+ * An archived workspace takes no mutation, so no tab type keeps a close
+ * control.
  *
  * Shared by the tab bar and the sidebar tree, which render the same tabs and
  * must not disagree about which of them close.
  */
-export function canCloseTab(archived: boolean | undefined, tab: Tab): boolean {
-  return !archived || isPayloadBackedTabType(tab.type)
+export function canCloseTab(archived: boolean | undefined, _tab: Tab): boolean {
+  return !archived
 }
 
 /**

--- a/frontend/src/stores/tab.helpers.ts
+++ b/frontend/src/stores/tab.helpers.ts
@@ -752,12 +752,14 @@ export function parseTabKey(key: string): { type: TabType, id: string } | null {
  * workspace.
  *
  * An archived workspace takes no mutation, so no tab type keeps a close
- * control.
+ * control. The tab itself is therefore NOT a parameter, unlike
+ * {@link canRenameTab}: the answer is the same for every type, and taking a tab
+ * it never reads would read as a per-type rule that does not exist.
  *
- * Shared by the tab bar and the sidebar tree, which render the same tabs and
- * must not disagree about which of them close.
+ * Shared by the tab bar, the sidebar tree and the close shortcut, which render
+ * or act on the same tabs and must not disagree about which of them close.
  */
-export function canCloseTab(archived: boolean | undefined, _tab: Tab): boolean {
+export function canCloseTab(archived: boolean | undefined): boolean {
   return !archived
 }
 

--- a/frontend/src/stores/tab.types.ts
+++ b/frontend/src/stores/tab.types.ts
@@ -185,9 +185,14 @@ export function isImageTab(t: Tab): t is ImageTab {
  * register / replay / re-read / revoke path -- and every consumer of that path
  * asks this question rather than listing the two types again.
  *
- * The user-facing rename rule follows from the same property: such a tab has no
- * server-side name to rename because its title comes from the payload. Archive
- * state still blocks closing every tab type.
+ * Two user-facing rules follow from the same property. Such a tab has no
+ * server-side name to rename, because its title comes from the payload. And it
+ * owns no process, so a close drops a viewer and stops nothing -- which is why
+ * `LastTabCloseDialog` reads `willStop` from this predicate.
+ *
+ * A close is NOT merely a row delete, though: `useTabOperations` also revokes
+ * the payload, and that RPC can remove the worktree from disk. Archive state
+ * blocks the close of every tab type, this one included.
  */
 export function isPayloadBackedTabType(type: TabType): boolean {
   return type === TabType.FILE || type === TabType.IMAGE

--- a/frontend/src/stores/tab.types.ts
+++ b/frontend/src/stores/tab.types.ts
@@ -185,10 +185,9 @@ export function isImageTab(t: Tab): t is ImageTab {
  * register / replay / re-read / revoke path -- and every consumer of that path
  * asks this question rather than listing the two types again.
  *
- * The user-facing rules follow from the same property, which is why they ask it
- * too rather than growing their own list: such a tab has no server-side name to
- * rename (its title comes from the payload), it owns no process, and closing it
- * is a row delete -- so a read-only viewer may still close one.
+ * The user-facing rename rule follows from the same property: such a tab has no
+ * server-side name to rename because its title comes from the payload. Archive
+ * state still blocks closing every tab type.
  */
 export function isPayloadBackedTabType(type: TabType): boolean {
   return type === TabType.FILE || type === TabType.IMAGE

--- a/frontend/tests/e2e/014-workspace-archive.spec.ts
+++ b/frontend/tests/e2e/014-workspace-archive.spec.ts
@@ -1,7 +1,11 @@
 import path from 'node:path'
+import { AgentStatus } from '../../src/generated/proto/leapmux/v1/agent_pb'
 import { expect, test } from './fixtures'
-import { createWorkspaceViaAPI, deleteWorkspaceViaAPI, openAgentViaAPI } from './helpers/api'
-import { loginViaToken, openTreeContextMenu, openWorkspace, treeRow, workspaceRow } from './helpers/ui'
+import { cleanupWorkspaceViaAPI, createWorkspaceViaAPI, deleteWorkspaceViaAPI, openAgentViaAPI } from './helpers/api'
+import { sendActiveTerminalInput, typeInTerminal, waitForTerminalText } from './helpers/terminal'
+import { ARITHMETIC_PROMPT, expectAssistantAnswer, loginViaToken, openTerminalViaUI, openTreeContextMenu, openWorkspace, treeRow, workspaceRow } from './helpers/ui'
+import { listAgentsViaAPI, listTerminalsViaAPI } from './helpers/worktree'
+import { ensureWorkerOnline, processTest, restartWorker, stopWorker, waitForWorkerOffline } from './process-control-fixtures'
 
 const frontendDir = path.resolve(import.meta.dirname, '../..')
 
@@ -19,7 +23,7 @@ async function openContextMenu(item: ReturnType<import('@playwright/test').Page[
   await item.locator('button').first().click()
 }
 
-test.describe('Workspace Archive', () => {
+test.describe('workspace archive', () => {
   test('should archive workspace via context menu with confirmation dialog', async ({ page, authenticatedWorkspace }) => {
     const workspaceItem = workspaceRow(page, authenticatedWorkspace.workspaceId)
 
@@ -162,7 +166,76 @@ test.describe('Workspace Archive', () => {
     await expect(page.locator('[data-testid="agent-editor-panel"]')).not.toBeVisible()
   })
 
-  test('should allow closing file tabs in archived workspace', async ({ page, leapmuxServer }) => {
+  test('stops processes, preserves content, and resumes only the agent', async ({ page, authenticatedWorkspace, leapmuxServer }) => {
+    const { hubUrl, adminToken, workerId } = leapmuxServer
+    const workspaceId = authenticatedWorkspace.workspaceId
+    const agentTab = page.locator('[data-testid="tab"][data-tab-type="agent"]').first()
+    const agentId = await agentTab.getAttribute('data-tab-id')
+    expect(agentId).toBeTruthy()
+    await expect.poll(async () => {
+      const agents = await listAgentsViaAPI(hubUrl, adminToken, workerId, workspaceId)
+      return agents.find(agent => agent.id === agentId)?.status
+    }).toBe(AgentStatus.ACTIVE)
+    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    await editor.click()
+    await page.keyboard.type(ARITHMETIC_PROMPT)
+    await page.keyboard.press('Meta+Enter')
+    await expectAssistantAnswer(page)
+
+    await openTerminalViaUI(page)
+    const terminalTab = page.locator('[data-testid="tab"][data-tab-type="terminal"]').first()
+    await expect(terminalTab).toBeVisible()
+    const terminalId = await terminalTab.getAttribute('data-tab-id')
+    expect(terminalId).toBeTruthy()
+    await typeInTerminal(page, 'echo ARCHIVE_SCREEN_PRESERVED')
+    await waitForTerminalText(page, 'ARCHIVE_SCREEN_PRESERVED')
+
+    const workspaceItem = workspaceRow(page, workspaceId)
+    await openContextMenu(workspaceItem)
+    await page.getByRole('menuitem', { name: 'Archive', exact: true }).click()
+    await page.locator('dialog').getByRole('button', { name: 'Archive' }).click()
+    await expect(page.locator('[data-testid="section-header-workspaces_archived"]')).toBeVisible()
+
+    await expect.poll(async () => {
+      const agents = await listAgentsViaAPI(hubUrl, adminToken, workerId, workspaceId)
+      return agents.find(agent => agent.id === agentId)?.status
+    }).toBe(AgentStatus.INACTIVE)
+    await expect.poll(async () => {
+      const terminals = await listTerminalsViaAPI(hubUrl, adminToken, workerId, workspaceId)
+      return terminals.find(terminal => terminal.id === terminalId)?.exited
+    }).toBe(true)
+    await expect(agentTab).toBeVisible()
+    await expect(terminalTab).toBeVisible()
+    await agentTab.click()
+    await expectAssistantAnswer(page)
+    await terminalTab.click()
+    await waitForTerminalText(page, 'ARCHIVE_SCREEN_PRESERVED')
+
+    await page.evaluate(() => {
+      ;(window as unknown as { __archiveRestartCalls?: number }).__archiveRestartCalls = 0
+      window.addEventListener('leapmux:rpc-send', ((event: CustomEvent<{ method?: string }>) => {
+        if (event.detail?.method === 'RestartTerminal') {
+          const state = window as unknown as { __archiveRestartCalls?: number }
+          state.__archiveRestartCalls = (state.__archiveRestartCalls ?? 0) + 1
+        }
+      }) as EventListener)
+    })
+    expect(await sendActiveTerminalInput(page, '\r')).toBe(true)
+    expect(await page.evaluate(() => (window as unknown as { __archiveRestartCalls?: number }).__archiveRestartCalls)).toBe(0)
+
+    await openContextMenu(workspaceItem)
+    await page.getByRole('menuitem', { name: 'Unarchive', exact: true }).click()
+    await expect.poll(async () => {
+      const agents = await listAgentsViaAPI(hubUrl, adminToken, workerId, workspaceId)
+      return agents.find(agent => agent.id === agentId)?.status
+    }).toBe(AgentStatus.ACTIVE)
+    await expect.poll(async () => {
+      const terminals = await listTerminalsViaAPI(hubUrl, adminToken, workerId, workspaceId)
+      return terminals.find(terminal => terminal.id === terminalId)?.exited
+    }).toBe(true)
+  })
+
+  test('should keep file tabs uncloseable in an archived workspace', async ({ page, leapmuxServer }) => {
     const { hubUrl, adminToken, workerId } = leapmuxServer
     const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, 'File Tab Close')
     await openAgentViaAPI(hubUrl, adminToken, workerId, workspaceId, frontendDir)
@@ -189,16 +262,10 @@ test.describe('Workspace Archive', () => {
       const agentTab = page.locator('[data-testid="tab"][data-tab-type="agent"]').first()
       await expect(agentTab.locator('[data-testid="tab-close"]')).not.toBeVisible()
 
-      // File tab should still be visible with a close button
+      // The file tab stays visible, but archival blocks every tab mutation.
       await expect(fileTab).toBeVisible()
       const closeButton = fileTab.locator('[data-testid="tab-close"]')
-      await expect(closeButton).toBeVisible()
-
-      // Click the close button to close the file tab
-      await closeButton.click()
-
-      // File tab should be gone
-      await expect(fileTab).not.toBeVisible()
+      await expect(closeButton).not.toBeVisible()
     }
     finally {
       await deleteWorkspaceViaAPI(hubUrl, adminToken, workspaceId).catch(() => {})
@@ -315,5 +382,46 @@ test.describe('Workspace Archive', () => {
 
     // Workspace should be gone
     await expect(workspaceItem).not.toBeVisible()
+  })
+})
+
+processTest.describe('workspace archive reconciliation', () => {
+  processTest('prevents agent resume when archival happens while the Worker is offline', async ({ separateHubWorker, page }) => {
+    await ensureWorkerOnline(separateHubWorker)
+    const { hubUrl, adminToken, workerId } = separateHubWorker
+    const workspaceId = await createWorkspaceViaAPI(hubUrl, adminToken, 'Offline Archive')
+    const agentId = await openAgentViaAPI(hubUrl, adminToken, workerId, workspaceId, frontendDir)
+    try {
+      await loginViaToken(page, adminToken)
+      await openWorkspace(page, workspaceId)
+      await expect.poll(async () => {
+        const agents = await listAgentsViaAPI(hubUrl, adminToken, workerId, workspaceId)
+        return agents.find(agent => agent.id === agentId)?.status
+      }).toBe(AgentStatus.ACTIVE)
+      const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+      await editor.click()
+      await page.keyboard.type(ARITHMETIC_PROMPT)
+      await page.keyboard.press('Meta+Enter')
+      await expectAssistantAnswer(page)
+
+      await stopWorker()
+      await waitForWorkerOffline(hubUrl, adminToken)
+      const workspaceItem = workspaceRow(page, workspaceId)
+      await openContextMenu(workspaceItem)
+      await page.getByRole('menuitem', { name: 'Archive', exact: true }).click()
+      await page.locator('dialog').getByRole('button', { name: 'Archive' }).click()
+      await expect(page.locator('[data-testid="section-header-workspaces_archived"]')).toBeVisible()
+
+      await restartWorker(separateHubWorker)
+      await expect.poll(async () => {
+        const agents = await listAgentsViaAPI(hubUrl, adminToken, workerId, workspaceId)
+        return agents.find(agent => agent.id === agentId)?.status
+      }).toBe(AgentStatus.INACTIVE)
+    }
+    finally {
+      await restartWorker(separateHubWorker).catch(() => {})
+      await cleanupWorkspaceViaAPI(hubUrl, adminToken, workerId, workspaceId).catch(() => {})
+      await deleteWorkspaceViaAPI(hubUrl, adminToken, workspaceId).catch(() => {})
+    }
   })
 })

--- a/frontend/tests/e2e/helpers/worktree.ts
+++ b/frontend/tests/e2e/helpers/worktree.ts
@@ -428,7 +428,7 @@ export async function listTerminalsViaAPI(
   token: string,
   workerId: string,
   workspaceId: string,
-): Promise<Array<{ id: string, title: string }>> {
+): Promise<Array<{ id: string, title: string, status: number, exited: boolean }>> {
   const tabsRes = await fetch(`${hubUrl}/leapmux.v1.WorkspaceService/ListTabs`, {
     method: 'POST',
     headers: authedHeaders(token),
@@ -455,7 +455,12 @@ export async function listTerminalsViaAPI(
       ListTerminalsResponseSchema,
       { tabIds: terminalTabIds },
     )
-    return (resp.terminals ?? []).map(t => ({ id: t.terminalId, title: t.title }))
+    return (resp.terminals ?? []).map(t => ({
+      id: t.terminalId,
+      title: t.title,
+      status: t.status,
+      exited: t.exited,
+    }))
   }
   catch {
     // Treat as transient so a caller polling this converges instead of

--- a/proto/leapmux/v1/section.proto
+++ b/proto/leapmux/v1/section.proto
@@ -15,7 +15,9 @@ service SectionService {
   rpc DeleteSection(DeleteSectionRequest) returns (DeleteSectionResponse);
   // Move a section to a different sidebar and/or position.
   rpc MoveSection(MoveSectionRequest) returns (MoveSectionResponse);
-  // Move a workspace to a different section at a given position.
+  // Move a workspace to a different section at a given position. This method
+  // cannot move a workspace into or out of Archived. Use
+  // WorkspaceService.SetWorkspaceArchiveState for that lifecycle change.
   rpc MoveWorkspace(MoveWorkspaceRequest) returns (MoveWorkspaceResponse);
 }
 

--- a/proto/leapmux/v1/worker.proto
+++ b/proto/leapmux/v1/worker.proto
@@ -29,7 +29,7 @@ service WorkerReconcilerService {
 message ListOwnedTabsForWorkerRequest {}
 
 message ListOwnedTabsForWorkerResponse {
-  repeated OwnedTab tabs = 1;
+  repeated WorkerTabState tab_states = 1;
   // The single owner this response is authoritative for -- the calling
   // worker's registrant. The hub's query binds it (workspace_tab_owned is
   // keyed by (user_id, tab_id), so worker_id alone selects across tenants),
@@ -45,12 +45,10 @@ message ListOwnedTabsForWorkerResponse {
   string owner_user_id = 2;
 }
 
-// OwnedTab names one tab the Hub still knows about, for the worker's orphan
-// reconciler. It carries IDENTITY only -- no workspace, tile or position: the
-// reconciler's whole question is "does the Hub still list this tab?", and a
-// Worker that stores none of that placement state has nothing to compare it
-// against.
-message OwnedTab {
+// WorkerTabState identifies one tab that the Hub still owns and states whether
+// the workspace that contains it is archived. It carries no workspace, tile,
+// or position because the Worker stores none of that placement state.
+message WorkerTabState {
   TabType tab_type = 1;
   string  tab_id   = 2;
   // Owner of the row in workspace_tab_owned, which is keyed by
@@ -60,6 +58,7 @@ message OwnedTab {
   // another user misses the lookup and is reaped as an orphan. AGENT/TERMINAL
   // ids are globally unique, so their reconciliation ignores this field.
   string  user_id  = 3;
+  WorkspaceArchiveState archive_state = 4;
 }
 
 // WorkerManagementService is called BY Frontend on Hub via ConnectRPC.

--- a/proto/leapmux/v1/workspace.proto
+++ b/proto/leapmux/v1/workspace.proto
@@ -35,9 +35,14 @@ service WorkspaceService {
   rpc ListWorkspaces(ListWorkspacesRequest) returns (ListWorkspacesResponse);
   rpc GetWorkspace(GetWorkspaceRequest) returns (GetWorkspaceResponse);
   rpc RenameWorkspace(RenameWorkspaceRequest) returns (RenameWorkspaceResponse);
-  // SetWorkspaceArchiveState moves a workspace across the archive boundary.
-  // The Hub computes its destination and returns the Worker fan-out from the
-  // same transaction. An idempotent request returns no Worker groups.
+  // SetWorkspaceArchiveState moves a workspace across the archive boundary and
+  // tells every Worker that hosts one of its tabs to reconcile now.
+  //
+  // The Worker fan-out is the Hub's, not the caller's. The Hub already holds
+  // the authoritative tab list and already nudges each affected Worker inside
+  // this call, and the Worker applies the state through the same code path a
+  // reconcile pass uses. A second delivery path from the client would be a
+  // duplicate of that one, reachable only from a browser session.
   rpc SetWorkspaceArchiveState(SetWorkspaceArchiveStateRequest) returns (SetWorkspaceArchiveStateResponse);
   rpc DeleteWorkspace(DeleteWorkspaceRequest) returns (DeleteWorkspaceResponse);
   // ListTabs returns the materialized tab list across one or more
@@ -109,10 +114,22 @@ message RenameWorkspaceResponse {}
 message SetWorkspaceArchiveStateRequest {
   string workspace_id = 1;
   WorkspaceArchiveState archive_state = 2;
+  // Where the workspace lands, for the ACTIVE direction. Empty means the
+  // built-in In progress section.
+  //
+  // It exists so that "Move to <custom section>" on an archived workspace is
+  // ONE transaction. Without it the client had to unarchive first and move
+  // second, which left the workspace resting in In progress whenever the
+  // second call failed, and threw away the position the user dropped it at.
+  // The Hub refuses a destination whose archived side disagrees with
+  // archive_state, so this cannot become a second way to archive.
+  string destination_section_id = 3;
+  // Lexorank inside destination_section_id. Empty appends at the end.
+  string position = 4;
 }
 
 message SetWorkspaceArchiveStateResponse {
-  repeated WorkerTabs worker_tabs = 1;
+  // Empty on purpose. The Hub owns the Worker fan-out; see the rpc comment.
 }
 
 message DeleteWorkspaceRequest {
@@ -207,16 +224,6 @@ message CleanupWorkspaceResponse {
   // Worktree reclamation happens through the orphan reconciler, which reports
   // nothing back on this call.
 }
-
-// SetTabArchiveStateRequest applies the Hub's workspace state to the local
-// rows for the listed tabs. A Worker stores no workspace identifier, so the
-// Hub supplies the authoritative tab set.
-message SetTabArchiveStateRequest {
-  repeated TabRef tabs = 1;
-  WorkspaceArchiveState archive_state = 2;
-}
-
-message SetTabArchiveStateResponse {}
 
 // --- Event Streaming (per-agent / per-terminal) ---
 

--- a/proto/leapmux/v1/workspace.proto
+++ b/proto/leapmux/v1/workspace.proto
@@ -17,6 +17,14 @@ enum TabType {
   TAB_TYPE_IMAGE = 4;
 }
 
+// WorkspaceArchiveState identifies whether a workspace accepts mutations and
+// whether its Worker-hosted processes may run.
+enum WorkspaceArchiveState {
+  WORKSPACE_ARCHIVE_STATE_UNSPECIFIED = 0;
+  WORKSPACE_ARCHIVE_STATE_ACTIVE = 1;
+  WORKSPACE_ARCHIVE_STATE_ARCHIVED = 2;
+}
+
 // WorkspaceService manages workspace metadata + read-only tab views.
 // Layout / tab mutations live on UserCRDT (see user_ops.proto). The
 // WorkspaceCreated / WorkspaceRenamed / WorkspaceDeleted lifecycle
@@ -27,6 +35,10 @@ service WorkspaceService {
   rpc ListWorkspaces(ListWorkspacesRequest) returns (ListWorkspacesResponse);
   rpc GetWorkspace(GetWorkspaceRequest) returns (GetWorkspaceResponse);
   rpc RenameWorkspace(RenameWorkspaceRequest) returns (RenameWorkspaceResponse);
+  // SetWorkspaceArchiveState moves a workspace across the archive boundary.
+  // The Hub computes its destination and returns the Worker fan-out from the
+  // same transaction. An idempotent request returns no Worker groups.
+  rpc SetWorkspaceArchiveState(SetWorkspaceArchiveStateRequest) returns (SetWorkspaceArchiveStateResponse);
   rpc DeleteWorkspace(DeleteWorkspaceRequest) returns (DeleteWorkspaceResponse);
   // ListTabs returns the materialized tab list across one or more
   // workspaces. Reads `workspace_tab_rendered`.
@@ -93,6 +105,15 @@ message RenameWorkspaceRequest {
 }
 
 message RenameWorkspaceResponse {}
+
+message SetWorkspaceArchiveStateRequest {
+  string workspace_id = 1;
+  WorkspaceArchiveState archive_state = 2;
+}
+
+message SetWorkspaceArchiveStateResponse {
+  repeated WorkerTabs worker_tabs = 1;
+}
 
 message DeleteWorkspaceRequest {
   string workspace_id = 1;
@@ -186,6 +207,16 @@ message CleanupWorkspaceResponse {
   // Worktree reclamation happens through the orphan reconciler, which reports
   // nothing back on this call.
 }
+
+// SetTabArchiveStateRequest applies the Hub's workspace state to the local
+// rows for the listed tabs. A Worker stores no workspace identifier, so the
+// Hub supplies the authoritative tab set.
+message SetTabArchiveStateRequest {
+  repeated TabRef tabs = 1;
+  WorkspaceArchiveState archive_state = 2;
+}
+
+message SetTabArchiveStateResponse {}
 
 // --- Event Streaming (per-agent / per-terminal) ---
 


### PR DESCRIPTION
## Motivation

Archiving a workspace was a sidebar move. The confirmation dialog said "All
active agents and terminals will be stopped", and a comment in the code
directly under that sentence admitted it was untrue: archiving only moved the
workspace into the Archived section. Every agent process and every PTY kept
running, and the Worker's boot resume sweep started them again after a
restart. That was tracked as issue #446, and the comment stayed as the marker
for it.

This makes the promise true, and then makes the resulting state converge.

The hard part is not stopping the processes. It is that a Worker stores no
workspace identifier — by design, because a copy there would be a second
source of truth that goes stale on every cross-workspace move. So the Worker
cannot answer "is this tab's workspace archived?" on its own. The Hub has to
tell it, the Worker has to cache the answer per row, and every path that can
change the answer has to drive that cache back into agreement.

## Modifications

### The lifecycle operation

- New `WorkspaceService.SetWorkspaceArchiveState` RPC and a
  `WorkspaceArchiveState` enum. It moves the workspace across the boundary and
  nudges every Worker hosting one of its tabs, in one transaction. It takes an
  optional destination section and position, so "Move to \<custom section>" on
  an archived workspace is a single call rather than an unarchive followed by a
  move that could fail and strand the workspace in In progress.
- `SectionService.MoveWorkspace` now runs in a transaction, checks ownership,
  restricts the destination to a section type that can hold a workspace, and
  refuses a move that crosses the archive boundary. Stopping processes must not
  ride on a generic reorder.
- `OwnedTab` becomes `WorkerTabState` and carries `archive_state`, derived in
  the three dialect queries by joining the workspace's section. The Worker
  reads the Hub's answer instead of inferring one.
- Worker: `agents` and `terminals` gain `workspace_archived`. New
  `Service.ApplyTabArchiveState` persists the flag transactionally, then stops
  the affected processes and broadcasts, under a per-tab lock.

### Enforcement

The rule "an archived workspace takes no mutation" was enforced at 4 of the 13
agent and terminal write RPCs — the four the browser happened to call. The
refusal now lives in the entity-gated registrars, keyed on the write scope, so
every write RPC is refused by construction. The nine that were missed included
`RenameAgent`, `DeleteAgentMessage`, `UpdateTerminalTitle` and both closes,
each of which writes state that outlives the archive. Reads stay reachable, so
an archived workspace is browsable and not merely frozen.

`canCloseTab` lost its per-tab exception as part of this. A payload-backed
close is not the pure row delete its old comment claimed: it revokes the
payload through an RPC that can remove a worktree from disk. So no tab type
closes while its workspace is archived.

### Convergence

Three paths could leave the Worker's cache disagreeing with the Hub, each
repaired at its own level:

- A hub row the Worker cannot classify is now skipped with a warning rather
  than failing the pass. One such row previously stopped every tab reap, every
  worktree reap and — through `OnConverged` — the boot resume sweep, on every
  pass for the life of the process.
- The reconcile nudge now covers a tab **move**, not only a tombstone. A tab
  moved out of an archived workspace kept its flag and refused the user's
  messages for up to an hour, on a tab the sidebar showed as live. Creating a
  tab deliberately still does not nudge, so the commonest tab operation does
  not carry a reconcile pass.
- An unarchive resume is scheduled as soon as its bucket applies. Holding it
  until the pass converged protected nothing: the resume set and the reap set
  come from one hub response and are disjoint by construction.

The browser's own per-Worker fan-out was removed. The Hub nudges the same
Workers inside the same call and the Worker applies the state through the
reconciler's path, so the client's copy was a second delivery route that
existed only while a tab was open — and that an archive from any other client
would have skipped.

### Correctness found while reviewing this

- One tab's flag write and its teardown are serialized per tab. A
  process-wide mutex held across an unbounded drain blocked the reconciler's
  whole loop; releasing it before the drain instead let an unarchive resume a
  process the earlier drain then killed.
- The startup registry releases by handle. Keyed by id alone, a second release
  freed a *newer* startup's claim and admitted a third goroutine for one tab.
- Both archive UPDATEs skip a closed row. Closed rows live for the whole 7-day
  retention, so an archive racing a close re-ran a completed teardown.
- Two concurrent archive moves get distinct lexoranks; a tie made the sidebar
  reshuffle on every refresh.
- Four pairwise close/archive branches collapse into one `startupInterruption`
  decision, so "a close beats an archive" is stated once instead of four times.
- `ensureAgentRunning` refuses an archived row, and a startup error that
  archival discards is now logged rather than dropped silently.

## Result

Archiving stops the processes and the dialog's sentence is true, so the
comment that flagged it is gone and issue #446 is closed. An archived
workspace refuses every write, from any client, not just from the browser
that archived it. The Worker's cached state converges within seconds of a
create, a move or a state change, instead of at the hourly tick — and one
malformed row can no longer stop it converging at all.

Behavioural changes a reviewer should weigh:

- **File and image tabs no longer close while archived.** Pruning stale
  viewers now needs unarchive → close → archive. The exception was removed
  because it could delete a worktree from a workspace declared immutable.
- **`ListOwnedTabsForWorkerResponse.tabs` → `tab_states`**, and `OwnedTab` →
  `WorkerTabState`. A wire-breaking rename, intentional under this repo's
  pre-release convention.
- A partial Worker failure no longer raises a toast, because the Hub's nudge
  is now the delivery path and it is best-effort by contract; a repeat request
  re-nudges, which is the recovery route.

Also fixes a pre-existing flake in `checkpointRecorder.test.ts` that surfaced
during the review: `settle()` counted event-loop ticks, which cannot bound a
case where one write's success re-issues another. It now waits on the
recorder's own write chain through a documented `whenSettled()` seam. Three
consecutive full frontend runs are clean.

Verified with `task lint`, the full backend suite, and the full frontend suite
(718 files, 13,200 tests).
