### PR TITLE
refactor(time): Unify fake time with Quartz

### DIFF
--- a/NOTICE.html
+++ b/NOTICE.html
@@ -116,6 +116,7 @@ body {
 <li><a href="#githubcomcenkaltibackoffv7-v700">github.com/cenkalti/backoff/v7 v7.0.0</a></li>
 <li><a href="#githubcomcesparexxhashv2-v230">github.com/cespare/xxhash/v2 v2.3.0</a></li>
 <li><a href="#githubcomcloudflarecircl-v165">github.com/cloudflare/circl v1.6.5</a></li>
+<li><a href="#githubcomcoderquartz-v031">github.com/coder/quartz v0.3.1</a></li>
 <li><a href="#githubcomcoderwebsocket-v1815">github.com/coder/websocket v1.8.15</a></li>
 <li><a href="#githubcomcontainerderrdefs-v100">github.com/containerd/errdefs v1.0.0</a></li>
 <li><a href="#githubcomcontainerderrdefspkg-v030">github.com/containerd/errdefs/pkg v0.3.0</a></li>
@@ -1356,6 +1357,26 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</code></pre>
+<h3 id="githubcomcoderquartz-v031">github.com/coder/quartz v0.3.1</h3>
+<pre><code>MIT No Attribution
+
+Copyright (c) Coder Technologies, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 </code></pre>
 <h3 id="githubcomcoderwebsocket-v1815">github.com/coder/websocket v1.8.15</h3>
 <pre><code>Copyright (c) 2025 Coder

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -20,6 +20,7 @@ For the latest version, see [NOTICE.md on GitHub](https://github.com/leapmux/lea
 - [github.com/cenkalti/backoff/v7 v7.0.0](#githubcomcenkaltibackoffv7-v700)
 - [github.com/cespare/xxhash/v2 v2.3.0](#githubcomcesparexxhashv2-v230)
 - [github.com/cloudflare/circl v1.6.5](#githubcomcloudflarecircl-v165)
+- [github.com/coder/quartz v0.3.1](#githubcomcoderquartz-v031)
 - [github.com/coder/websocket v1.8.15](#githubcomcoderwebsocket-v1815)
 - [github.com/containerd/errdefs v1.0.0](#githubcomcontainerderrdefs-v100)
 - [github.com/containerd/errdefs/pkg v0.3.0](#githubcomcontainerderrdefspkg-v030)
@@ -1297,6 +1298,29 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+### github.com/coder/quartz v0.3.1
+
+```
+MIT No Attribution
+
+Copyright (c) Coder Technologies, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 ```
 
 ### github.com/coder/websocket v1.8.15

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/aymanbagabas/go-pty v0.2.3
 	github.com/cenkalti/backoff/v7 v7.0.0
 	github.com/cloudflare/circl v1.6.5
+	github.com/coder/quartz v0.3.1
 	github.com/coder/websocket v1.8.15
 	github.com/coreos/go-oidc/v3 v3.20.0
 	github.com/descope/virtualwebauthn v1.0.5

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -138,6 +138,8 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cloudflare/circl v1.6.5 h1:O64F26HEqNhznd/hrC5KZXVKYuKM2rx4deZDTc4ihQA=
 github.com/cloudflare/circl v1.6.5/go.mod h1:h5LNyxAc5nTue9DS5jT+48en2PSDYt3zdGnz5OstK6c=
+github.com/coder/quartz v0.3.1 h1:JMJLj4Xj4NLSrUC1R/g/Hn0y9fkyOvb8tf6P0j+kPn0=
+github.com/coder/quartz v0.3.1/go.mod h1:BgE7DOj/8NfvRgvKw0jPLDQH/2Lya2kxcTaNJ8X0rZk=
 github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=
 github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=

--- a/backend/hubtransport/probe_test.go
+++ b/backend/hubtransport/probe_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/coder/quartz"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -67,37 +68,14 @@ func TestVerdictIsCachedForTheLifeOfTheEndpoint(t *testing.T) {
 	}
 }
 
-// fakeClock is the seam undecidedCooldown is measured against. A test advances
-// it by hand, so the cooldown is exercised with no sleep and no window to race.
-type fakeClock struct {
-	mu  sync.Mutex
-	now time.Time
-}
-
-func newFakeClock() *fakeClock {
-	// A fixed instant, not time.Now(): the zero value of undecidedUntil must be
-	// strictly BEFORE it, so a prober that has never probed is not suppressed.
-	return &fakeClock{now: time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)}
-}
-
-func (c *fakeClock) Now() time.Time {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.now
-}
-
-func (c *fakeClock) Advance(d time.Duration) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.now = c.now.Add(d)
-}
-
 // newTestProber is newProber on a clock the test owns.
-func newTestProber(t *testing.T) (*prober, *fakeClock) {
+func newTestProber(t *testing.T) (*prober, *quartz.Mock) {
 	t.Helper()
-	clock := newFakeClock()
+	clock := quartz.NewMock(t).WithLogger(quartz.NoOpLogger)
+	// The zero value of undecidedUntil must be before the first reading.
+	clock.Set(time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC))
 	p := newProber("http://hub.invalid", nil)
-	p.now = clock.Now
+	p.now = func() time.Time { return clock.Now() }
 	return p, clock
 }
 

--- a/backend/internal/cli/control/streamevents/subscription.go
+++ b/backend/internal/cli/control/streamevents/subscription.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/coder/quartz"
 	"github.com/leapmux/leapmux/generated/contracts"
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/util/backoffutil"
@@ -36,7 +37,7 @@ var errSubscriptionClosed = ErrSubscriptionClosed
 // open/update/store sequence, not just field reads/writes, so concurrent
 // callers cannot orphan a newly-opened stream.
 //
-// Cancel is terminal: once it returns, Update refuses with
+// Cancel is final: once it returns, Update refuses with
 // ErrSubscriptionClosed for the life of the Subscription (the closed flag is
 // never cleared). Callers that need to re-subscribe after Cancel must build a
 // new Subscription. The CLI's agent-messages --follow reconnect loop honors
@@ -119,32 +120,24 @@ type Subscription struct {
 	// single-owner contract. Reset on each fresh open so a transient miss after
 	// a clean reconnect gets a fresh budget.
 	retry *backoffutil.Retry
-	// clock is the time source armLookupRetry waits on. Set once in
-	// NewSubscription (to systemClock) and never reassigned in production, so
-	// the retry goroutine can read it without a lock; the package's tests
-	// substitute a deterministic fake before the first Update.
-	clock retryClock
+	// clock supplies the retry timer. NewSubscription sets it before a retry
+	// goroutine can start, so the goroutine can read it without the mutex.
+	clock quartz.Clock
 }
 
-// retryClock is the time source for the LOOKUP_FAILED retry wait. Production
-// uses systemClock; the subscription tests substitute a fake that fires on
-// demand, so an assertion about the armed-but-not-yet-fired window cannot lose
-// a race to a real timer on a loaded machine, and one about NO retry arming
-// needs no sleep to find out.
-type retryClock interface {
-	// NewTimer starts a timer for d, returning the channel it delivers on and a
-	// stop func that releases it — time.Timer's C/Stop pair without the concrete
-	// type. The caller must call stop exactly once, whether or not it consumed
-	// the delivery.
-	NewTimer(d time.Duration) (<-chan time.Time, func())
-}
+const subscriptionRetryTimerTag = "subscription-retry"
 
-// systemClock is the production retryClock: a plain time.NewTimer.
-type systemClock struct{}
+// SubscriptionOption changes one NewSubscription setting.
+type SubscriptionOption func(*Subscription)
 
-func (systemClock) NewTimer(d time.Duration) (<-chan time.Time, func()) {
-	t := time.NewTimer(d)
-	return t.C, func() { t.Stop() }
+// WithClock sets the clock that supplies retry timers.
+func WithClock(clock quartz.Clock) SubscriptionOption {
+	if clock == nil {
+		panic("streamevents: clock must not be nil")
+	}
+	return func(s *Subscription) {
+		s.clock = clock
+	}
 }
 
 // LOOKUP_FAILED retry policy. The eventsRejection policy in
@@ -178,6 +171,7 @@ func NewSubscription(t Transport, agents *AgentCursor, terminals *TerminalCursor
 	onAgent func(*leapmuxv1.AgentEvent),
 	onTerminal func(*leapmuxv1.TerminalEvent),
 	onCursorReset func(terminalID string),
+	opts ...SubscriptionOption,
 ) *Subscription {
 	retryCtx, retryCancel := context.WithCancel(context.Background())
 	// lookupRetry* are compile-time constants, so NewRetry cannot fail; a panic
@@ -189,7 +183,7 @@ func NewSubscription(t Transport, agents *AgentCursor, terminals *TerminalCursor
 		retryCancel()
 		panic(fmt.Sprintf("streamevents: invalid LOOKUP_FAILED retry policy: %v", err))
 	}
-	return &Subscription{
+	sub := &Subscription{
 		transport:     t,
 		agents:        agents,
 		terminals:     terminals,
@@ -199,8 +193,12 @@ func NewSubscription(t Transport, agents *AgentCursor, terminals *TerminalCursor
 		retryCtx:      retryCtx,
 		retryCancel:   retryCancel,
 		retry:         retry,
-		clock:         systemClock{},
+		clock:         quartz.NewReal(),
 	}
+	for _, opt := range opts {
+		opt(sub)
+	}
+	return sub
 }
 
 // assignUpdateId stamps req with the next monotonic update_id and records it
@@ -313,7 +311,7 @@ func (s *Subscription) Update(ctx context.Context, req *leapmuxv1.WatchEventsReq
 }
 
 // Cancel stops the in-flight subscription, if any. Safe to call from
-// any goroutine; idempotent. Terminal: after Cancel returns, Update refuses
+// any goroutine; idempotent. After Cancel returns, Update always refuses
 // with errSubscriptionClosed for the life of the Subscription.
 func (s *Subscription) Cancel() {
 	s.lifecycleMu.Lock()
@@ -544,10 +542,10 @@ func (s *Subscription) dispatchUpdateAck(ack *leapmuxv1.WatchUpdateAck) {
 // once the Update is dispatched, so a fire that then loses the lifecycleMu race
 // to Cancel still counts as a real attempt.
 func (s *Subscription) armLookupRetry(retryCtx context.Context, delay time.Duration, armGen uint64) {
-	fired, stopTimer := s.clock.NewTimer(delay)
-	defer stopTimer()
+	timer := s.clock.NewTimer(delay, subscriptionRetryTimerTag)
+	defer timer.Stop(subscriptionRetryTimerTag)
 	select {
-	case <-fired:
+	case <-timer.C:
 	case <-retryCtx.Done():
 		// Cancel retired the subscription while the timer was pending. Roll back
 		// the peeked slot (no budget consumed) and bail. retryInFlight stays set:

--- a/backend/internal/cli/control/streamevents/subscription_test.go
+++ b/backend/internal/cli/control/streamevents/subscription_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/coder/quartz"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -204,151 +205,12 @@ func protoInt32(v int32) *int32 { return &v }
 
 // fastRetry is a small, jitterless LOOKUP_FAILED budget for tests that drive
 // the ladder to exhaustion: 3 attempts at a deterministic 10ms → 20ms → 30ms.
-// The delays never elapse in real time — every retry test waits on a fakeClock
-// — but keeping them tiny and un-jittered makes the ladder an exact,
-// assertable sequence rather than a fuzzed one.
 func fastRetry() *backoffutil.Retry {
 	r, err := backoffutil.NewRetry(10*time.Millisecond, 30*time.Millisecond, 2, 0, 3)
 	if err != nil {
 		panic(err) // constants are known-valid
 	}
 	return r
-}
-
-// waitTimeout bounds every wait in this file. It is a deadlock guard, not a
-// timing assumption: the events it waits for (a goroutine arming its timer,
-// that goroutine returning, a 1ms timer firing) happen in microseconds, so
-// crossing this bound means the code under test never got there at all.
-const waitTimeout = 10 * time.Second
-
-// fakeTimer is one timer the retry goroutine asked fakeClock for.
-type fakeTimer struct {
-	delay    time.Duration
-	deliver  chan time.Time // buffered(1) so firing never blocks on a bailed retry
-	released bool           // the retry goroutine called its stop func
-}
-
-// fakeClock is a deterministic retryClock. NewTimer records the requested delay
-// and hands back a channel the test fires explicitly, so nothing in the retry
-// path is timed by the wall clock: a test can hold the retry in its
-// armed-but-not-yet-fired window for as long as it likes, and a test asserting
-// that NO retry armed reads armedCount instead of sleeping to find out.
-//
-// Timers fire in arm order, one per fireRetry call, which is also the order a
-// real clock would fire them in (the retry ladder arms at most one at a time).
-type fakeClock struct {
-	mu     sync.Mutex
-	timers []*fakeTimer
-	fired  int           // how many of them fireRetry has fired, in arm order
-	armed  chan struct{} // buffered(1); pinged on every NewTimer
-	freed  chan struct{} // buffered(1); pinged on every stop func call
-}
-
-func newFakeClock() *fakeClock {
-	return &fakeClock{
-		armed: make(chan struct{}, 1),
-		freed: make(chan struct{}, 1),
-	}
-}
-
-func (c *fakeClock) NewTimer(d time.Duration) (<-chan time.Time, func()) {
-	tm := &fakeTimer{delay: d, deliver: make(chan time.Time, 1)}
-	c.mu.Lock()
-	c.timers = append(c.timers, tm)
-	c.mu.Unlock()
-	ping(c.armed)
-	return tm.deliver, func() {
-		c.mu.Lock()
-		tm.released = true
-		c.mu.Unlock()
-		ping(c.freed)
-	}
-}
-
-// ping delivers a non-blocking wake-up on a buffered(1) signal channel. A
-// pending signal already covers the waiter's next re-check, so a dropped send
-// loses nothing.
-func ping(ch chan struct{}) {
-	select {
-	case ch <- struct{}{}:
-	default:
-	}
-}
-
-// armedCount reports how many retry timers have been armed so far. Safe to read
-// synchronously for a negative assertion: dispatchUpdateAck decides whether to
-// arm under s.mu before pushFrame returns, so a push that armed nothing leaves
-// this at its prior value for good.
-func (c *fakeClock) armedCount() int {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return len(c.timers)
-}
-
-// waitArmed blocks until at least n retry timers have been armed. The arming
-// itself happens on the retry goroutine, so a test expecting a retry must wait
-// for it rather than read armedCount directly.
-func (c *fakeClock) waitArmed(t *testing.T, n int) {
-	t.Helper()
-	c.await(t, c.armed, func() (int, bool) { return len(c.timers), len(c.timers) >= n },
-		"armed retry timer(s)", n)
-}
-
-// waitRetrySettled blocks until at least n retry goroutines have finished.
-// armLookupRetry releases its timer on the way out (the deferred stop), whether
-// it fired its Update or bailed, so a released timer means that retry is done
-// and its effects — the committed slot, the restated interest — are visible.
-func (c *fakeClock) waitRetrySettled(t *testing.T, n int) {
-	t.Helper()
-	c.await(t, c.freed, func() (int, bool) {
-		got := 0
-		for _, tm := range c.timers {
-			if tm.released {
-				got++
-			}
-		}
-		return got, got >= n
-	}, "settled retries", n)
-}
-
-// await re-checks want (under c.mu) on every ping of signal until it is
-// satisfied, failing the test if waitTimeout elapses first.
-func (c *fakeClock) await(t *testing.T, signal chan struct{}, want func() (int, bool), what string, n int) {
-	t.Helper()
-	deadline := time.After(waitTimeout)
-	for {
-		c.mu.Lock()
-		got, ok := want()
-		c.mu.Unlock()
-		if ok {
-			return
-		}
-		select {
-		case <-signal:
-		case <-deadline:
-			t.Fatalf("timed out waiting for %d %s; got %d", n, what, got)
-		}
-	}
-}
-
-// fireRetry waits for the next armed retry timer and fires it, returning the
-// delay it was armed with so the caller can assert on the ladder. Each call
-// fires the next timer in arm order.
-func (c *fakeClock) fireRetry(t *testing.T) time.Duration {
-	t.Helper()
-	c.mu.Lock()
-	next := c.fired + 1
-	c.mu.Unlock()
-	c.waitArmed(t, next)
-
-	c.mu.Lock()
-	tm := c.timers[c.fired]
-	c.fired++
-	c.mu.Unlock()
-	// Buffered, so this never blocks even if the retry already bailed via
-	// retryCtx and will never read the delivery.
-	tm.deliver <- time.Time{}
-	return tm.delay
 }
 
 // retryState reads the LOOKUP_FAILED retry's observable state under s.mu — the
@@ -361,19 +223,39 @@ func retryState(sub *Subscription) (attempts int, inFlight bool) {
 	return sub.retry.Attempts(), sub.retryInFlight
 }
 
-// newRetrySub builds a Subscription over tr whose LOOKUP_FAILED retry waits on
-// a fakeClock instead of the wall clock, and registers Cancel for cleanup.
-// Every test that can arm a retry uses it, so no retry in this package is timed
-// by a real timer. Callers that drive the ladder to exhaustion still install
-// fastRetry themselves; the rest keep the production budget, which the fake
-// clock makes free to wait out.
-func newRetrySub(t *testing.T, tr *fakeTransport) (*Subscription, *fakeClock) {
+// armCountingClock is the Quartz mock plus a count of the retry timers armed
+// on it. Every other method routes to the embedded mock, so a test drives it
+// exactly as it drives a plain *quartz.Mock. It holds no time of its own, so it
+// is a decorator rather than a second fake clock.
+//
+// The count is what a trap cannot supply. A trap holds each NewTimer call until
+// the test collects it. A second timer that the code must coalesce away parks
+// inside the trap and registers no event: Peek reports an empty clock,
+// and every "no retry timer may arm" assertion passes on the very regression it
+// exists to catch. arms counts the call itself, before the trap sees it.
+type armCountingClock struct {
+	*quartz.Mock
+	arms atomic.Int64
+}
+
+func (c *armCountingClock) NewTimer(d time.Duration, tags ...string) *quartz.Timer {
+	c.arms.Add(1)
+	return c.Mock.NewTimer(d, tags...)
+}
+
+// armCount reports how many retry timers the subscription armed so far. It is
+// safe to read synchronously for a negative assertion: dispatchUpdateAck
+// decides whether to arm under s.mu before pushFrame returns, so a push that
+// armed nothing leaves this at its prior value permanently.
+func (c *armCountingClock) armCount() int {
+	return int(c.arms.Load())
+}
+
+// newRetrySub builds a Subscription over tr with a Quartz mock.
+func newRetrySub(t *testing.T, tr *fakeTransport) (*Subscription, *armCountingClock) {
 	t.Helper()
-	clk := newFakeClock()
-	sub := NewSubscription(tr, NewAgentCursor(), NewTerminalCursor(), nil, nil, nil)
-	// Safe without a lock: the retry goroutine that reads sub.clock cannot exist
-	// until the first Update, which every caller issues after this returns.
-	sub.clock = clk
+	clk := &armCountingClock{Mock: testutil.NewQuartzMock(t)}
+	sub := NewSubscription(tr, NewAgentCursor(), NewTerminalCursor(), nil, nil, nil, WithClock(clk))
 	t.Cleanup(sub.Cancel)
 	return sub, clk
 }
@@ -681,22 +563,22 @@ func TestSubscription_UpdateReopensAfterDone(t *testing.T) {
 	sub.Cancel()
 }
 
-// TestSubscription_DefaultSystemClockDrivesTheRetry is the one retry test that
-// does NOT substitute a fakeClock, and it exists because all the others do:
-// with the seam in place, nothing else exercises the clock NewSubscription
-// actually wires. A regression that left s.clock nil (panic on the first
-// LOOKUP_FAILED) or handed back a timer that never fires (the CLI silently
-// stops recovering from a transient miss) would pass every other test here.
+// TestSubscription_DefaultClockDrivesTheRetry is the one retry test that does
+// NOT substitute a mock, and it exists because all the others do: with the
+// option in place, nothing else exercises the clock NewSubscription actually
+// wires. A regression that left s.clock nil (panic on the first LOOKUP_FAILED)
+// or wired a clock whose timers never fire (the CLI silently stops recovering
+// from a transient miss) would pass every other test here.
 //
 // It waits on a real 1ms timer, which is safe in the one direction that
-// matters: the assertion is a positive edge — the retry fires and restates —
+// matters: the assertion is a positive edge -- the retry fires and restates --
 // so a loaded machine makes this slower, never wrong.
-func TestSubscription_DefaultSystemClockDrivesTheRetry(t *testing.T) {
+func TestSubscription_DefaultClockDrivesTheRetry(t *testing.T) {
 	tr := &fakeTransport{}
 	sub := NewSubscription(tr, NewAgentCursor(), NewTerminalCursor(), nil, nil, nil)
 	t.Cleanup(sub.Cancel)
-	require.IsType(t, systemClock{}, sub.clock,
-		"NewSubscription must wire the real clock, not leave the seam empty")
+	require.IsType(t, quartz.NewReal(), sub.clock,
+		"NewSubscription must wire the real clock, not a seeded mock a WithinDuration check would accept")
 
 	// 1ms so the real wait is negligible; the ladder shape is pinned elsewhere.
 	r, err := backoffutil.NewRetry(time.Millisecond, 2*time.Millisecond, 2, 0, 3)
@@ -710,9 +592,14 @@ func TestSubscription_DefaultSystemClockDrivesTheRetry(t *testing.T) {
 	require.Eventually(t, func() bool {
 		attempts, _ := retryState(sub)
 		return attempts == 1
-	}, waitTimeout, time.Millisecond,
+	}, 10*time.Second, time.Millisecond,
 		"a retry armed on the real clock must fire, commit its slot, and restate")
 	assert.Len(t, updatesOf(t, tr), 1, "the real-clock retry restates the interest once")
+}
+
+func TestSubscription_WithClockRejectsNil(t *testing.T) {
+	t.Parallel()
+	assert.Panics(t, func() { WithClock(nil) })
 }
 
 // TestSubscription_LookupFailedAckRetriesLastReq pins that a LOOKUP_FAILED
@@ -721,7 +608,9 @@ func TestSubscription_DefaultSystemClockDrivesTheRetry(t *testing.T) {
 // hardcoded constant that could drift from lookupRetryInitial).
 func TestSubscription_LookupFailedAckRetriesLastReq(t *testing.T) {
 	tr := &fakeTransport{}
-	sub, clk := newRetrySub(t, tr) // production budget: the fake clock makes it free
+	sub, clk := newRetrySub(t, tr)
+	ctx := testutil.DeadlineContext(t)
+	newTimer, stopTimer := testutil.NewTimerTraps(t, clk.Mock, subscriptionRetryTimerTag)
 
 	req := &leapmuxv1.WatchEventsRequest{
 		Agents: []*leapmuxv1.WatchAgentEntry{{AgentId: "a-1"}},
@@ -731,15 +620,15 @@ func TestSubscription_LookupFailedAckRetriesLastReq(t *testing.T) {
 
 	pushLookupFailed(tr, "a-1")
 
-	delay := clk.fireRetry(t)
+	delay := testutil.WaitForTimer(t, ctx, newTimer)
 	lo := time.Duration(float64(lookupRetryInitial) * (1 - lookupRetryJitter))
-	// +1ns: backoffutil's jitter window is inclusive of its upper bound.
+	// +1ns: backoffutil's jitter window includes its upper limit.
 	hi := time.Duration(float64(lookupRetryInitial)*(1+lookupRetryJitter)) + 1
 	assert.GreaterOrEqual(t, delay, lo,
 		"the first retry must wait the production ladder's first rung (±jitter)")
 	assert.LessOrEqual(t, delay, hi,
 		"the first retry must wait the production ladder's first rung (±jitter)")
-	clk.waitRetrySettled(t, 1)
+	testutil.AdvanceAndAwaitStop(t, ctx, clk.Mock, delay, stopTimer)
 
 	updates := updatesOf(t, tr)
 	require.Len(t, updates, 1, "the retry must restate lastReq exactly once")
@@ -759,16 +648,18 @@ func TestSubscription_LookupFailedRetryReadsLatestLastReqAtFireTime(t *testing.T
 	tr := &fakeTransport{}
 	sub, clk := newRetrySub(t, tr)
 	sub.retry = fastRetry()
+	ctx := testutil.DeadlineContext(t)
+	newTimer, stopTimer := testutil.NewTimerTraps(t, clk.Mock, subscriptionRetryTimerTag)
 
 	// Open with {a-1}; the retry will arm against this interest.
 	require.NoError(t, sub.Update(context.Background(),
 		&leapmuxv1.WatchEventsRequest{Agents: []*leapmuxv1.WatchAgentEntry{{AgentId: "a-1"}}}))
 
 	// Arm a retry by pushing a LOOKUP_FAILED ack for a-1, and hold it in its
-	// backoff window: the fake clock fires it only when this test says so, so
+	// backoff window: the Quartz clock advances only when this test says so, so
 	// the revise below is strictly inside the window.
 	pushLookupFailed(tr, "a-1")
-	clk.waitArmed(t, 1)
+	delay := testutil.WaitForTimer(t, ctx, newTimer)
 
 	// Revise the live stream to add a-2. The retry must fire against THIS
 	// interest, not the arm-time {a-1}. This lands as the handle's 1st update.
@@ -782,8 +673,7 @@ func TestSubscription_LookupFailedRetryReadsLatestLastReqAtFireTime(t *testing.T
 	// clobbering the revise and stalling a-2's events. Ordering here is exact
 	// (revise, then retry), so the assertion cannot be satisfied by the revise
 	// itself the way a "last update has both" poll could be.
-	clk.fireRetry(t)
-	clk.waitRetrySettled(t, 1)
+	testutil.AdvanceAndAwaitStop(t, ctx, clk.Mock, delay, stopTimer)
 
 	updates := updatesOf(t, tr)
 	require.Len(t, updates, 2, "the revise and the retry's restatement, in that order")
@@ -803,20 +693,22 @@ func TestSubscription_LookupFailedRetryReadsLatestLastReqAtFireTime(t *testing.T
 // goroutine now selects on retryCtx.Done(), which Cancel cancels, so it bails
 // promptly.
 //
-// The fake clock states that directly: its timer NEVER fires, so retryCtx is
+// The Quartz clock states that directly: its timer never fires, so retryCtx is
 // the only way out. A regression that dropped the select would hang here rather
 // than merely being slow.
 func TestSubscription_LookupFailedRetryWakesImmediatelyOnCancel(t *testing.T) {
 	tr := &fakeTransport{}
 	sub, clk := newRetrySub(t, tr)
 	sub.retry = fastRetry()
+	ctx := testutil.DeadlineContext(t)
+	newTimer, stopTimer := testutil.NewTimerTraps(t, clk.Mock, subscriptionRetryTimerTag)
 
 	require.NoError(t, sub.Update(context.Background(),
 		&leapmuxv1.WatchEventsRequest{Agents: []*leapmuxv1.WatchAgentEntry{{AgentId: "a-1"}}}))
 
 	// Arm the retry and let it park on a timer that will never be fired.
 	pushLookupFailed(tr, "a-1")
-	clk.waitArmed(t, 1)
+	assert.Equal(t, 10*time.Millisecond, testutil.WaitForTimer(t, ctx, newTimer))
 
 	// Cancel must wake the retry via retryCtx -- asserted as a COMPLETION
 	// against a generous deadline, not as a tight budget: a completion guard
@@ -829,13 +721,15 @@ func TestSubscription_LookupFailedRetryWakesImmediatelyOnCancel(t *testing.T) {
 	}()
 	select {
 	case <-cancelled:
-	case <-time.After(waitTimeout):
+	case <-ctx.Done():
 		t.Fatal("Cancel blocked on the retry timer instead of waking it via retryCtx")
 	}
 
 	// The woken retry must run to completion: refund its peeked slot (never
 	// committed) and release its timer on the way out.
-	clk.waitRetrySettled(t, 1)
+	stopTimer.MustWait(ctx).MustRelease(ctx)
+	_, running := clk.Peek()
+	assert.False(t, running, "Cancel must stop the pending retry timer")
 	attempts, _ := retryState(sub)
 	assert.Equal(t, 0, attempts, "a Cancelled retry must refund its consumed slot")
 }
@@ -967,7 +861,7 @@ func TestSubscription_LookupFailedAckWithNilLastReqDoesNotConsumeBudget(t *testi
 	attempts, inFlight := retryState(sub)
 	assert.Equal(t, 0, attempts, "LOOKUP_FAILED ack with nil lastReq must not consume a retry attempt")
 	assert.False(t, inFlight, "LOOKUP_FAILED ack with nil lastReq must not arm a retry")
-	assert.Equal(t, 0, clk.armedCount(), "no retry timer may be armed with nothing to restate")
+	assert.Zero(t, clk.armCount(), "no retry timer may be armed with nothing to restate")
 }
 
 // TestSubscription_LookupFailedRetryDoesNotReopenAfterCancel pins the fix for a
@@ -986,6 +880,8 @@ func TestSubscription_LookupFailedRetryDoesNotReopenAfterCancel(t *testing.T) {
 	tr := &fakeTransport{}
 	sub, clk := newRetrySub(t, tr)
 	sub.retry = fastRetry()
+	ctx := testutil.DeadlineContext(t)
+	newTimer, stopTimer := testutil.NewTimerTraps(t, clk.Mock, subscriptionRetryTimerTag)
 
 	req := &leapmuxv1.WatchEventsRequest{
 		Agents: []*leapmuxv1.WatchAgentEntry{{AgentId: "a-1"}},
@@ -995,16 +891,18 @@ func TestSubscription_LookupFailedRetryDoesNotReopenAfterCancel(t *testing.T) {
 	require.Equal(t, int32(1), openedBefore)
 
 	// Push LOOKUP_FAILED, then Cancel strictly inside the retry delay window --
-	// the fake clock's timer cannot fire until this test fires it, so the race
+	// the Quartz clock cannot advance until this test advances it, so the race
 	// the real clock left open (a 10ms timer beating Cancel on a stalled
 	// machine, re-opening the stream) is gone.
 	pushLookupFailed(tr, "a-1")
-	clk.waitArmed(t, 1)
+	assert.Equal(t, 10*time.Millisecond, testutil.WaitForTimer(t, ctx, newTimer))
 	sub.Cancel()
 
 	// The retry wakes on retryCtx and bails; it releases its timer as it returns,
 	// so a settled retry means every effect it could have had is already visible.
-	clk.waitRetrySettled(t, 1)
+	stopTimer.MustWait(ctx).MustRelease(ctx)
+	_, running := clk.Peek()
+	assert.False(t, running, "Cancel must stop the pending retry timer")
 	assert.Equal(t, openedBefore, atomic.LoadInt32(&tr.callsOpened),
 		"LOOKUP_FAILED retry must not re-open a stream after Cancel")
 	// The retry bailed when its gate retired, so it must refund the slot it
@@ -1013,7 +911,7 @@ func TestSubscription_LookupFailedRetryDoesNotReopenAfterCancel(t *testing.T) {
 	assert.Equal(t, 0, attempts, "a retry cancelled mid-wait must refund its attempt slot")
 }
 
-// TestSubscription_LookupFailedRetryBudgetExhausts pins the bounded-retry fix:
+// TestSubscription_LookupFailedRetryBudgetExhausts pins the retry limit:
 // previously every LOOKUP_FAILED ack spawned a fresh goroutine that produced
 // another LOOKUP_FAILED ack, compounding without limit on a flapping worker.
 // The retry must stop after the budget is spent.
@@ -1021,6 +919,8 @@ func TestSubscription_LookupFailedRetryBudgetExhausts(t *testing.T) {
 	tr := &fakeTransport{}
 	sub, clk := newRetrySub(t, tr)
 	sub.retry = fastRetry() // 3 attempts, 10 -> 20 -> 30ms, jitterless
+	ctx := testutil.DeadlineContext(t)
+	newTimer, stopTimer := testutil.NewTimerTraps(t, clk.Mock, subscriptionRetryTimerTag)
 
 	req := &leapmuxv1.WatchEventsRequest{
 		Agents: []*leapmuxv1.WatchAgentEntry{{AgentId: "a-missing"}},
@@ -1037,8 +937,9 @@ func TestSubscription_LookupFailedRetryBudgetExhausts(t *testing.T) {
 	}
 	for i, want := range wantLadder {
 		pushLookupFailed(tr, "a-missing")
-		assert.Equal(t, want, clk.fireRetry(t), "retry %d waits its ladder rung", i+1)
-		clk.waitRetrySettled(t, i+1)
+		delay := testutil.WaitForTimer(t, ctx, newTimer)
+		assert.Equal(t, want, delay, "retry %d waits its ladder rung", i+1)
+		testutil.AdvanceAndAwaitStop(t, ctx, clk.Mock, delay, stopTimer)
 
 		attempts, _ := retryState(sub)
 		require.Equal(t, i+1, attempts, "each fired retry consumes exactly one slot")
@@ -1055,7 +956,7 @@ func TestSubscription_LookupFailedRetryBudgetExhausts(t *testing.T) {
 	attempts, inFlight := retryState(sub)
 	assert.Equal(t, len(wantLadder), attempts, "exactly maxAttempts retries consumed")
 	assert.False(t, inFlight, "an ack past exhaustion must not arm a retry")
-	assert.Equal(t, len(wantLadder), clk.armedCount(), "no retry timer may arm past the budget")
+	assert.Equal(t, len(wantLadder), clk.armCount(), "no retry timer may arm past the budget")
 	assert.Equal(t, int32(1), atomic.LoadInt32(&tr.callsOpened),
 		"LOOKUP_FAILED retries must not re-open the stream (no re-open ladder)")
 	assert.Len(t, updatesOf(t, tr), len(wantLadder),
@@ -1109,12 +1010,14 @@ func TestSubscription_FreshOpenResetsRetryBudget(t *testing.T) {
 // recovery — it restated the interest and reset the budget — so the stale retry
 // rolls back its peeked slot and bails, leaving the new stream untouched.
 //
-// Holding a retry across a fresh open needs the fake clock: with a real timer
+// Holding a retry across a fresh open needs the Quartz clock. With a real timer,
 // the ordering (arm, re-open, THEN fire) could not be stated, only hoped for.
 func TestSubscription_FreshOpenRetiresArmedRetry(t *testing.T) {
 	tr := &fakeTransport{}
 	sub, clk := newRetrySub(t, tr)
 	sub.retry = fastRetry()
+	ctx := testutil.DeadlineContext(t)
+	newTimer, stopTimer := testutil.NewTimerTraps(t, clk.Mock, subscriptionRetryTimerTag)
 
 	req := &leapmuxv1.WatchEventsRequest{
 		Agents: []*leapmuxv1.WatchAgentEntry{{AgentId: "a-1"}},
@@ -1123,7 +1026,7 @@ func TestSubscription_FreshOpenRetiresArmedRetry(t *testing.T) {
 
 	// Arm a retry against the first stream and hold it in its backoff window.
 	pushLookupFailed(tr, "a-1")
-	clk.waitArmed(t, 1)
+	delay := testutil.WaitForTimer(t, ctx, newTimer)
 
 	// The stream dies and the caller re-opens it: a fresh open, which bumps the
 	// generation the armed retry captured.
@@ -1137,8 +1040,7 @@ func TestSubscription_FreshOpenRetiresArmedRetry(t *testing.T) {
 	require.Equal(t, int32(2), atomic.LoadInt32(&tr.callsOpened))
 
 	// Only now let the stale retry's timer fire.
-	clk.fireRetry(t)
-	clk.waitRetrySettled(t, 1)
+	testutil.AdvanceAndAwaitStop(t, ctx, clk.Mock, delay, stopTimer)
 
 	attempts, inFlight := retryState(sub)
 	assert.Equal(t, 0, attempts, "a retry retired by a fresh open must not consume a slot")
@@ -1150,8 +1052,8 @@ func TestSubscription_FreshOpenRetiresArmedRetry(t *testing.T) {
 	// The cleared in-flight flag means the new stream can still arm its own
 	// retry — the retirement must not wedge the subscription.
 	pushLookupFailed(tr, "a-1")
-	clk.fireRetry(t)
-	clk.waitRetrySettled(t, 2)
+	delay = testutil.WaitForTimer(t, ctx, newTimer)
+	testutil.AdvanceAndAwaitStop(t, ctx, clk.Mock, delay, stopTimer)
 	attempts, _ = retryState(sub)
 	assert.Equal(t, 1, attempts, "the fresh stream's own retry consumes a slot")
 	assert.Len(t, updatesOf(t, tr), 1, "the fresh stream's retry restates its interest")
@@ -1168,6 +1070,8 @@ func TestSubscription_LookupFailedRetryReopenSurvivesGateRetire(t *testing.T) {
 	tr := &fakeTransport{}
 	sub, clk := newRetrySub(t, tr)
 	sub.retry = fastRetry()
+	ctx := testutil.DeadlineContext(t)
+	newTimer, stopTimer := testutil.NewTimerTraps(t, clk.Mock, subscriptionRetryTimerTag)
 
 	require.NoError(t, sub.Update(context.Background(),
 		&leapmuxv1.WatchEventsRequest{Agents: []*leapmuxv1.WatchAgentEntry{{AgentId: "a-1"}}}))
@@ -1186,12 +1090,12 @@ func TestSubscription_LookupFailedRetryReopenSurvivesGateRetire(t *testing.T) {
 	// re-opens (fresh-open). The re-open runs on context.Background (no gate),
 	// so nothing inside Update can cancel the newborn stream.
 	pushLookupFailed(tr, "a-1")
-	clk.fireRetry(t)
+	delay := testutil.WaitForTimer(t, ctx, newTimer)
+	testutil.AdvanceAndAwaitStop(t, ctx, clk.Mock, delay, stopTimer)
 
 	// The retry releases its timer only after its Update returns, so a settled
 	// retry means the re-open has been published -- no sleep needed to observe
 	// the post-open state.
-	clk.waitRetrySettled(t, 1)
 	require.Equal(t, int32(2), atomic.LoadInt32(&tr.callsOpened),
 		"LOOKUP_FAILED retry must re-open the stream")
 
@@ -1426,6 +1330,8 @@ func TestSubscription_LateCancelRetryDoesNotOrphan(t *testing.T) {
 	tr := &fakeTransport{}
 	sub, clk := newRetrySub(t, tr)
 	sub.retry = fastRetry()
+	ctx := testutil.DeadlineContext(t)
+	newTimer, stopTimer := testutil.NewTimerTraps(t, clk.Mock, subscriptionRetryTimerTag)
 
 	require.NoError(t, sub.Update(context.Background(), &leapmuxv1.WatchEventsRequest{
 		Agents: []*leapmuxv1.WatchAgentEntry{{AgentId: "a-1"}},
@@ -1454,12 +1360,13 @@ func TestSubscription_LateCancelRetryDoesNotOrphan(t *testing.T) {
 	// Arm the retry and fire it. It passes the generation check (the generation
 	// has not moved), enters Update, and blocks on releaseOpen mid-open.
 	pushLookupFailed(tr, "a-1")
-	clk.fireRetry(t)
+	delay := testutil.WaitForTimer(t, ctx, newTimer)
+	advance := clk.Advance(delay)
 
 	// Wait for the retry's re-open to enter OpenWatchEvents.
 	select {
 	case <-openStarted:
-	case <-time.After(waitTimeout):
+	case <-ctx.Done():
 		t.Fatal("retry's re-open never entered OpenWatchEvents")
 	}
 
@@ -1477,9 +1384,11 @@ func TestSubscription_LateCancelRetryDoesNotOrphan(t *testing.T) {
 
 	select {
 	case <-cancelDone:
-	case <-time.After(2 * time.Second):
+	case <-ctx.Done():
 		t.Fatal("Cancel did not return after the retry's Update completed")
 	}
+	stopTimer.MustWait(ctx).MustRelease(ctx)
+	advance.MustWait(ctx)
 
 	// After Cancel returns, no stream may be active: the retry's re-open did not
 	// survive as an orphan. (callsOpened may be 2 -- the open happened -- but the
@@ -1533,6 +1442,8 @@ func TestSubscription_StaleLookupFailedAckDoesNotConsumeBudget(t *testing.T) {
 	tr := &fakeTransport{}
 	sub, clk := newRetrySub(t, tr)
 	sub.retry = fastRetry()
+	ctx := testutil.DeadlineContext(t)
+	newTimer, stopTimer := testutil.NewTimerTraps(t, clk.Mock, subscriptionRetryTimerTag)
 
 	require.NoError(t, sub.Update(context.Background(),
 		&leapmuxv1.WatchEventsRequest{Agents: []*leapmuxv1.WatchAgentEntry{{AgentId: "a-1"}}}))
@@ -1554,13 +1465,13 @@ func TestSubscription_StaleLookupFailedAckDoesNotConsumeBudget(t *testing.T) {
 	attempts, inFlight := retryState(sub)
 	assert.Equal(t, 0, attempts, "a stale ack must not consume the retry budget")
 	assert.False(t, inFlight, "a stale ack must not arm a retry")
-	assert.Equal(t, 0, clk.armedCount(), "a stale ack must not arm a retry timer")
+	assert.Zero(t, clk.armCount(), "a stale ack must not arm a retry timer")
 
 	// A current ack (update_id=0 is always processed, matching the frontend)
 	// for an entity STILL in the interest arms a retry and consumes a slot.
 	pushLookupFailed(tr, "a-2")
-	clk.fireRetry(t)
-	clk.waitRetrySettled(t, 1)
+	delay := testutil.WaitForTimer(t, ctx, newTimer)
+	testutil.AdvanceAndAwaitStop(t, ctx, clk.Mock, delay, stopTimer)
 	attempts, _ = retryState(sub)
 	assert.Equal(t, 1, attempts, "a current ack for a wanted entity must arm a retry")
 }
@@ -1576,6 +1487,8 @@ func TestSubscription_LookupFailedAckForDroppedEntityDoesNotRetry(t *testing.T) 
 	tr := &fakeTransport{}
 	sub, clk := newRetrySub(t, tr)
 	sub.retry = fastRetry()
+	ctx := testutil.DeadlineContext(t)
+	newTimer, stopTimer := testutil.NewTimerTraps(t, clk.Mock, subscriptionRetryTimerTag)
 
 	// Open with {a-1}, then revise to {a-2} — dropping a-1 from the interest.
 	require.NoError(t, sub.Update(context.Background(),
@@ -1588,12 +1501,12 @@ func TestSubscription_LookupFailedAckForDroppedEntityDoesNotRetry(t *testing.T) 
 	attempts, inFlight := retryState(sub)
 	assert.Equal(t, 0, attempts, "a LOOKUP_FAILED for a dropped entity must not consume a retry slot")
 	assert.False(t, inFlight, "a LOOKUP_FAILED for a dropped entity must not arm a retry")
-	assert.Equal(t, 0, clk.armedCount(), "a LOOKUP_FAILED for a dropped entity must not arm a retry timer")
+	assert.Zero(t, clk.armCount(), "a LOOKUP_FAILED for a dropped entity must not arm a retry timer")
 
 	// A LOOKUP_FAILED for the still-wanted a-2 DOES arm a retry.
 	pushLookupFailed(tr, "a-2")
-	clk.fireRetry(t)
-	clk.waitRetrySettled(t, 1)
+	delay := testutil.WaitForTimer(t, ctx, newTimer)
+	testutil.AdvanceAndAwaitStop(t, ctx, clk.Mock, delay, stopTimer)
 	attempts, _ = retryState(sub)
 	assert.Equal(t, 1, attempts, "a LOOKUP_FAILED for a wanted entity must arm a retry")
 }
@@ -1608,11 +1521,13 @@ func TestSubscription_LookupFailedRetryCoalescesInFlight(t *testing.T) {
 	tr := &fakeTransport{}
 	sub, clk := newRetrySub(t, tr)
 	sub.retry = fastRetry()
+	ctx := testutil.DeadlineContext(t)
+	newTimer, stopTimer := testutil.NewTimerTraps(t, clk.Mock, subscriptionRetryTimerTag)
 
 	require.NoError(t, sub.Update(context.Background(),
 		&leapmuxv1.WatchEventsRequest{Agents: []*leapmuxv1.WatchAgentEntry{{AgentId: "a-1"}}}))
 
-	// Push a burst of LOOKUP_FAILED acks. The fake clock holds the first retry
+	// Push a burst of LOOKUP_FAILED acks. The Quartz clock holds the first retry
 	// in its backoff window for the whole burst, so every ack after it lands
 	// while a retry is armed and must coalesce into that one retry. (With a real
 	// timer this window was 10ms wide and the assertions below raced it.)
@@ -1627,14 +1542,14 @@ func TestSubscription_LookupFailedRetryCoalescesInFlight(t *testing.T) {
 	attempts, inFlight := retryState(sub)
 	assert.True(t, inFlight, "a burst of acks must coalesce into one in-flight retry")
 	assert.Equal(t, 0, attempts, "an armed-but-unfired retry must not consume a slot")
-	clk.waitArmed(t, 1)
-	assert.Equal(t, 1, clk.armedCount(),
+	delay := testutil.WaitForTimer(t, ctx, newTimer)
+	assert.Equal(t, 10*time.Millisecond, delay)
+	assert.Equal(t, 1, clk.armCount(),
 		"a burst of acks must arm exactly one retry timer, not one per ack")
 
 	// After the retry fires, exactly one slot is committed (not 5) and the
 	// in-flight flag clears so the next ack can arm again.
-	clk.fireRetry(t)
-	clk.waitRetrySettled(t, 1)
+	testutil.AdvanceAndAwaitStop(t, ctx, clk.Mock, delay, stopTimer)
 	attempts, inFlight = retryState(sub)
 	assert.Equal(t, 1, attempts,
 		"a burst of acks must coalesce into one committed retry (one slot consumed, not 5)")
@@ -1682,7 +1597,7 @@ func TestSubscription_BudgetExhaustionLogsOnce(t *testing.T) {
 	count := strings.Count(buf.String(), "LOOKUP_FAILED retry budget exhausted")
 	assert.Equal(t, 1, count,
 		"the budget-exhausted Warn must fire once per cycle, not once per ack")
-	assert.Equal(t, 0, clk.armedCount(), "a spent budget must arm no retry timer")
+	assert.Zero(t, clk.armCount(), "a spent budget must arm no retry timer")
 }
 
 // TestSubscription_RapidSequentialUpdates pins back-to-back Update behaviour:

--- a/backend/internal/hub/config/config_test.go
+++ b/backend/internal/hub/config/config_test.go
@@ -15,7 +15,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func unsetAmbientEnvPrefix(t *testing.T, prefix string) {
+	t.Helper()
+	// testing.T.Setenv cannot represent an absent variable. An empty value still
+	// overrides defaults and configuration files.
+	for _, entry := range os.Environ() {
+		key, value, found := strings.Cut(entry, "=")
+		if !found || !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		require.NoError(t, os.Unsetenv(key))
+		t.Cleanup(func() {
+			require.NoError(t, os.Setenv(key, value))
+		})
+	}
+}
+
 func TestLoad(t *testing.T) {
+	unsetAmbientEnvPrefix(t, "LEAPMUX_HUB_")
 	home, err := os.UserHomeDir()
 	require.NoError(t, err)
 
@@ -130,6 +147,7 @@ log_level: "debug"
 }
 
 func TestLoadWithOptions(t *testing.T) {
+	unsetAmbientEnvPrefix(t, "LEAPMUX_HUB_")
 	t.Run("custom DefaultListen applied", func(t *testing.T) {
 		cfg, _, err := LoadWithOptions(nil, LoadOptions{
 			DefaultListen: "127.0.0.1:4327",

--- a/backend/internal/hub/service/channel_service_test.go
+++ b/backend/internal/hub/service/channel_service_test.go
@@ -1312,11 +1312,17 @@ func TestOpenChannel_PostQuantumHandshake(t *testing.T) {
 	// Times out because mock worker doesn't respond.
 	require.Error(t, err)
 
+	// A WAIT, not a non-blocking read: the send to the worker happens on the
+	// handler goroutine, and the RPC above returns on its own 100ms deadline
+	// without waiting for it. A read that gives up at once therefore races the
+	// send and fails under load, although the claim here -- that the hub handed
+	// the ChannelOpen to the worker -- says nothing about which happens first.
+	// The limit is a deadlock guard, matching the sibling case above.
 	select {
 	case sentMsg := <-sentCh:
 		assert.NotNil(t, sentMsg.GetChannelOpen())
 		assert.Equal(t, []byte("pq-handshake-msg1"), sentMsg.GetChannelOpen().GetHandshakePayload())
-	default:
+	case <-time.After(time.Second):
 		require.Fail(t, "expected a message to be sent to worker")
 	}
 }
@@ -1350,11 +1356,13 @@ func TestOpenChannel_ClassicHandshake(t *testing.T) {
 		}, token))
 	require.Error(t, err)
 
+	// A WAIT rather than a non-blocking read, for the reason given in
+	// TestOpenChannel_PostQuantumHandshake.
 	select {
 	case sentMsg := <-sentCh:
 		assert.NotNil(t, sentMsg.GetChannelOpen())
 		assert.Equal(t, []byte("classic-handshake-msg1"), sentMsg.GetChannelOpen().GetHandshakePayload())
-	default:
+	case <-time.After(time.Second):
 		require.Fail(t, "expected a message to be sent to worker")
 	}
 }

--- a/backend/internal/hub/service/oauth_server_elevation_test.go
+++ b/backend/internal/hub/service/oauth_server_elevation_test.go
@@ -175,7 +175,7 @@ func TestCLIConsent_SlidesTheWindowLikeEveryOtherRestrictedAction(t *testing.T) 
 	// Without it the store's own monotone guard would refuse a deadline that
 	// is not ahead of the stored one, and the case would pass for the wrong
 	// reason.
-	env.clock.advance(30 * time.Minute)
+	env.advance(30 * time.Minute)
 
 	resp := getWithCookie(t, env.server.URL+"/oauth/authorize?"+startQuery(nil).Encode(), cookie)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -218,7 +218,7 @@ func TestCLIConsent_ExpiredElevationClosesTheGate(t *testing.T) {
 	assert.NotContains(t, bodyOf(t, resp), "unverified")
 
 	// Past it: the same request bounces.
-	env.clock.advance(auth.ElevationWindow + time.Minute)
+	env.advance(auth.ElevationWindow + time.Minute)
 	resp = getWithCookie(t, env.server.URL+"/oauth/authorize?"+startQuery(nil).Encode(), cookie)
 	require.Equal(t, http.StatusFound, resp.StatusCode)
 	assert.Contains(t, resp.Header.Get("Location"), "/elevate")
@@ -333,7 +333,7 @@ func TestCLIConsent_AdminScopeRefusedForANonAdministrator(t *testing.T) {
 	token, _, _, err := auth.Login(ctx, env.store, "plainuser", "plainpass123", auth.DefaultSessionDuration)
 	require.NoError(t, err)
 	cookie := &http.Cookie{Name: auth.CookieName, Value: token}
-	now := env.clock.now()
+	now := env.now()
 	n, err := env.store.Sessions().Elevate(ctx, store.ElevateSessionParams{
 		SessionID:          token,
 		UserID:             userid.MustNew(plainID),
@@ -378,7 +378,7 @@ func TestCLIConsent_AdminScopeRefusedAtEveryLegThatBindsIt(t *testing.T) {
 		plainID := hubtestutil.CreateTestUser(t, env.store, "plainuser", "plainpass123")
 		token, _, _, err := auth.Login(ctx, env.store, "plainuser", "plainpass123", auth.DefaultSessionDuration)
 		require.NoError(t, err)
-		now := env.clock.now()
+		now := env.now()
 		n, err := env.store.Sessions().Elevate(ctx, store.ElevateSessionParams{
 			SessionID:          token,
 			UserID:             userid.MustNew(plainID),
@@ -429,7 +429,7 @@ func TestCLIConsent_AdminScopeRefusedAtEveryLegThatBindsIt(t *testing.T) {
 		cookie := elevatedPlainUser(t, env)
 
 		userCode := verifycode.Generate()
-		now := env.clock.now()
+		now := env.now()
 		// The ASK carries the admin scope, and it is on the GRANT ROW: the
 		// device flow's request and its consent happen on two machines with a
 		// six-character code between them, so the row is the only carrier.
@@ -472,7 +472,7 @@ func TestDeviceActivation_RequiresElevationAndBindsTheScope(t *testing.T) {
 			ClientID:        oauthapp.ControlCLIClientID,
 			RequestedScopes: ask,
 			DeviceCode:      id.Generate(), UserCode: userCode, DeviceName: "headless",
-			IntervalSeconds: 5, ExpiresAt: env.clock.now().Add(10 * time.Minute),
+			IntervalSeconds: 5, ExpiresAt: env.now().Add(10 * time.Minute),
 		}))
 		return userCode
 	}
@@ -594,7 +594,7 @@ func TestDeviceActivation_IdentifiesTheAppForACLISuppliedCode(t *testing.T) {
 	require.NoError(t, env.store.DeviceAuthorizations().Create(ctx, store.CreateDeviceAuthorizationParams{
 		ClientID:   oauthapp.ControlCLIClientID,
 		DeviceCode: id.Generate(), UserCode: userCode, DeviceName: "ci-runner-7",
-		IntervalSeconds: 5, ExpiresAt: env.clock.now().Add(10 * time.Minute),
+		IntervalSeconds: 5, ExpiresAt: env.now().Add(10 * time.Minute),
 	}))
 
 	resp := getWithCookie(t, env.server.URL+"/oauth/device?user_code="+url.QueryEscape(verifycode.Format(userCode)), cookie)
@@ -611,7 +611,7 @@ func TestDeviceActivation_IdentifiesTheAppForACLISuppliedCode(t *testing.T) {
 
 	// An EXPIRED grant is a miss too: it cannot be approved, so it has no
 	// device worth showing.
-	env.clock.advance(11 * time.Minute)
+	env.advance(11 * time.Minute)
 	expired := getWithCookie(t, env.server.URL+"/oauth/device?user_code="+url.QueryEscape(verifycode.Format(userCode)), cookie)
 	require.Equal(t, http.StatusOK, expired.StatusCode)
 	assert.NotContains(t, bodyOf(t, expired), "ci-runner-7")
@@ -659,7 +659,7 @@ func TestIssuedToken_CarriesTheAbsoluteLifetime(t *testing.T) {
 	require.NotNil(t, row.RefreshExpiresAt)
 	assert.False(t, row.RefreshExpiresAt.After(row.CreatedAt.Add(auth.AbsoluteTokenLifetime).Add(time.Minute)),
 		"a mint must not write a refresh window past the credential's ceiling")
-	assert.True(t, row.RefreshExpiresAt.After(env.clock.now()))
+	assert.True(t, row.RefreshExpiresAt.After(env.now()))
 }
 
 // TestIssuedToken_EmailsTheOwner pins the one signal that does not require
@@ -818,7 +818,7 @@ func TestRefresh_ClipsToTheAbsoluteLifetime(t *testing.T) {
 	// position where the access clip can be observed at all: further out,
 	// now+1h still lands under the ceiling and an unclipped access token
 	// looks correct. The refresh clip applies here just as it did a day out.
-	env.clock.advance(auth.AbsoluteTokenLifetime - 30*time.Minute)
+	env.advance(auth.AbsoluteTokenLifetime - 30*time.Minute)
 	resp, err := http.PostForm(env.server.URL+"/oauth/token", url.Values{"grant_type": {service.GrantTypeRefreshToken}, "client_id": {oauthapp.ControlCLIClientID}, "refresh_token": {refreshToken}})
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()
@@ -860,7 +860,7 @@ func TestRefresh_ClipsToTheAbsoluteLifetime(t *testing.T) {
 	// and each client renders its own remedy. The CLI's is ErrNotLoggedIn,
 	// which names the command; refresh.go turns invalid_grant into exactly
 	// that by deleting the stored credential.
-	env.clock.advance(48 * time.Hour)
+	env.advance(48 * time.Hour)
 	dead, err := http.PostForm(env.server.URL+"/oauth/token", url.Values{"grant_type": {service.GrantTypeRefreshToken}, "client_id": {oauthapp.ControlCLIClientID}, "refresh_token": {rotated.RefreshToken}})
 	require.NoError(t, err)
 	defer func() { _ = dead.Body.Close() }()

--- a/backend/internal/hub/service/oauth_server_handler_test.go
+++ b/backend/internal/hub/service/oauth_server_handler_test.go
@@ -14,10 +14,10 @@ import (
 	"slices"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/coder/quartz"
 	"github.com/leapmux/leapmux/internal/authscope"
 	"github.com/leapmux/leapmux/internal/hub/ratelimit"
 	"github.com/leapmux/leapmux/internal/util/userid"
@@ -46,30 +46,22 @@ type apiAuthEnv struct {
 	closer    *recordingBearerCloser
 	server    *httptest.Server
 	userID    string
-	clock     *testClock
+	// now is the handler clock every handler this env builds installs, and the
+	// ONE instant the tests read. Sharing one func is what keeps a second
+	// handler on the same notion of time as the first, which the step-up and
+	// activation cases both depend on.
+	//
+	// The mock clock behind it is not a field on purpose. It reads a FROZEN
+	// instant, so a row a test stamped from it and a deadline the handler
+	// derived from now would disagree by the test's own runtime -- and every
+	// site that reached for the wrong one compiled.
+	now func() time.Time
+	// advance moves the offset both now and the handler read.
+	advance func(time.Duration)
 	// set is the hub's own settings, wired exactly as production wires them.
 	// secure_cookies is the one key the handler reads from it, and it decides
 	// which session-cookie spelling the consent legs accept.
 	set *settings.Manager
-}
-
-// testClock drives the handler's OAuthServerHandler.Now seam: real time plus an
-// offset the test advances. It offsets rather than freezes because the
-// store's own clock stamps the rows the handler reads -- SQLite writes
-// last_polled_at with strftime('now') -- so a frozen handler clock would sit
-// permanently behind every row it compares against. Advancing lets a test
-// step past the device-code slow_down window (5s) instead of sleeping through
-// it, while every other instant stays anchored to real time.
-type testClock struct {
-	offset atomic.Int64
-}
-
-func (c *testClock) now() time.Time {
-	return time.Now().Add(time.Duration(c.offset.Load()))
-}
-
-func (c *testClock) advance(d time.Duration) {
-	c.offset.Add(int64(d))
 }
 
 type recordingBearerCloser struct {
@@ -159,7 +151,21 @@ func setupAPIAuth(t *testing.T) *apiAuthEnv {
 	t.Cleanup(srv.Close)
 
 	closer := &recordingBearerCloser{}
-	clock := &testClock{}
+	clock := quartz.NewMock(t).WithLogger(quartz.NoOpLogger)
+	clock.Set(time.Now())
+	// The handler reads real time PLUS the offset the test advanced. It never
+	// reads a frozen instant. It mints deadlines that assertions compare against
+	// limits the test derives from time.Now(). A clock stopped at setup drifts
+	// out of those limits by the test's own runtime.
+	// TestAPIAuth_Refresh_GraceRetryReportsStoredRemainingLifetime shows the
+	// cost: remainingExpiresIn rounds the remaining seconds UP, so a handler
+	// clock behind real time by any amount reports 11 where the test allows 10.
+	//
+	// An advance moves the offset. Each advance in these files steps past the
+	// device-code slow_down window or the elevation window without a sleep.
+	base := clock.Now()
+	now := func() time.Time { return time.Now().Add(clock.Now().Sub(base)) }
+	advance := func(d time.Duration) { clock.Advance(d).MustWait(t.Context()) }
 	set := servicetest.NewSettingsManager(t, st, nil)
 	h := service.NewOAuthServerHandler(service.OAuthServerDeps{
 		Store:     st,
@@ -168,7 +174,7 @@ func setupAPIAuth(t *testing.T) *apiAuthEnv {
 		Settings:  set,
 		HubURL:    func() string { return srv.URL },
 	})
-	h.Now = clock.now
+	h.Now = now
 	h.RegisterRoutes(mux)
 
 	u, err := st.Users().GetByUsername(context.Background(), "admin")
@@ -181,7 +187,8 @@ func setupAPIAuth(t *testing.T) *apiAuthEnv {
 		closer:    closer,
 		server:    srv,
 		userID:    u.ID,
-		clock:     clock,
+		now:       now,
+		advance:   advance,
 		set:       set,
 	}
 }
@@ -199,11 +206,11 @@ func (e *apiAuthEnv) adminCookie(t *testing.T) *http.Cookie {
 // through the REAL store write the RPCs use, so the dialect's own mapping of
 // the two columns is exercised rather than faked.
 //
-// Every instant comes from the handler's clock seam, so a test that advances
-// that clock past the window sees the gate close.
+// Every instant comes from e.now, the same seam the handler reads, so a test
+// that advances the clock past the window sees the gate close.
 func (e *apiAuthEnv) elevate(t *testing.T, cookie *http.Cookie) {
 	t.Helper()
-	now := e.clock.now()
+	now := e.now()
 	n, err := e.store.Sessions().Elevate(context.Background(), store.ElevateSessionParams{
 		SessionID:          cookie.Value,
 		UserID:             userid.MustNew(e.userID),
@@ -597,7 +604,7 @@ func TestAPIAuth_DeviceCode_Pending_Approval_Success(t *testing.T) {
 	require.Equal(t, http.StatusOK, approveResp.StatusCode)
 
 	// Step past the throttle window since the previous poll.
-	env.clock.advance(service.DeviceCodePollInterval + 100*time.Millisecond)
+	env.advance(service.DeviceCodePollInterval + 100*time.Millisecond)
 
 	// Successful exchange.
 	successResp, err := http.PostForm(env.server.URL+"/oauth/token", url.Values{
@@ -737,7 +744,7 @@ func TestAPIAuth_DeviceCode_AlreadyConsumed(t *testing.T) {
 	_ = approve.Body.Close()
 
 	// Step past the throttle, then exchange -- should succeed.
-	env.clock.advance(service.DeviceCodePollInterval + 100*time.Millisecond)
+	env.advance(service.DeviceCodePollInterval + 100*time.Millisecond)
 	first, err := http.PostForm(env.server.URL+"/oauth/token", url.Values{
 		"grant_type":  {"urn:ietf:params:oauth:grant-type:device_code"},
 		"client_id":   {oauthapp.ControlCLIClientID},
@@ -1464,7 +1471,7 @@ func TestAPIAuth_DeviceCode_UserLookupFailureLeavesGrantRetryable(t *testing.T) 
 	}))
 	rows, err := env.store.DeviceAuthorizations().Approve(context.Background(), store.ApproveDeviceAuthorizationParams{
 		DeviceCode: deviceCode, UserID: userid.MustNew(env.userID),
-	}, env.clock.now().UTC())
+	}, env.now().UTC())
 	require.NoError(t, err)
 	require.Equal(t, int64(1), rows)
 
@@ -1490,7 +1497,7 @@ func TestAPIAuth_DeviceCode_UserLookupFailureLeavesGrantRetryable(t *testing.T) 
 	// the interval, then confirm a clean retry succeeds -- proving the
 	// grant stayed retryable. The retry goes to env.server, whose handler
 	// is the one on env's clock.
-	env.clock.advance(service.DeviceCodePollInterval + 100*time.Millisecond)
+	env.advance(service.DeviceCodePollInterval + 100*time.Millisecond)
 	retry, err := http.PostForm(env.server.URL+"/oauth/token", form)
 	require.NoError(t, err)
 	defer func() { _ = retry.Body.Close() }()
@@ -1561,7 +1568,7 @@ func TestAPIAuth_DeviceCode_ConsumeRequiresOneRow(t *testing.T) {
 	}))
 	rows, err := env.store.DeviceAuthorizations().Approve(context.Background(), store.ApproveDeviceAuthorizationParams{
 		DeviceCode: deviceCode, UserID: userid.MustNew(env.userID),
-	}, env.clock.now().UTC())
+	}, env.now().UTC())
 	require.NoError(t, err)
 	require.Equal(t, int64(1), rows)
 	device := deviceAuthorizationOverride{DeviceAuthorizationStore: env.store.DeviceAuthorizations(), consume: func(context.Context, string) (int64, error) {
@@ -1604,7 +1611,7 @@ func TestAPIAuth_DeviceCode_ApprovedPollAdvancesThrottleDespiteIssuanceFailure(t
 	}))
 	rows, err := env.store.DeviceAuthorizations().Approve(context.Background(), store.ApproveDeviceAuthorizationParams{
 		DeviceCode: deviceCode, UserID: userid.MustNew(env.userID),
-	}, env.clock.now().UTC())
+	}, env.now().UTC())
 	require.NoError(t, err)
 	require.Equal(t, int64(1), rows)
 
@@ -2285,7 +2292,7 @@ func TestAPIAuth_Activate_GrantLookupFailureIsInternal(t *testing.T) {
 		Lifecycle: auth.NewCredentialLifecycleEffects(env.cache, noopBearerCloser{}, nil),
 		HubURL:    func() string { return env.server.URL },
 	})
-	h.Now = env.clock.now
+	h.Now = env.now
 	h.RegisterRoutes(mux)
 	cookie := env.elevatedAdminCookie(t)
 
@@ -2379,7 +2386,7 @@ func TestAPIAuth_DeviceCode_CollidingUserCodeIsRedrawn(t *testing.T) {
 				Lifecycle: auth.NewCredentialLifecycleEffects(env.cache, noopBearerCloser{}, nil),
 				HubURL:    func() string { return env.server.URL },
 			})
-			h.Now = env.clock.now
+			h.Now = env.now
 			h.RegisterRoutes(mux)
 
 			req := httptest.NewRequest(http.MethodPost, "/oauth/device-authorization",

--- a/backend/internal/hub/service/oauth_server_stepup_test.go
+++ b/backend/internal/hub/service/oauth_server_stepup_test.go
@@ -145,7 +145,7 @@ func TestCLIStepUp_BrowserApprovalStampsTheWindow(t *testing.T) {
 
 	// Past the poll throttle: the pending poll above stamped last_polled_at,
 	// and a second poll inside the interval answers slow_down.
-	env.clock.advance(2 * time.Duration(grant.Interval) * time.Second)
+	env.advance(2 * time.Duration(grant.Interval) * time.Second)
 
 	// The poll now reports success, and reports it as an ELEVATION -- a
 	// step-up mints nothing, so a token pair here would turn a request to
@@ -239,7 +239,7 @@ func TestCLIStepUp_AGrantIsSingleUse(t *testing.T) {
 	require.Equal(t, http.StatusOK, approveStepUp(t, env, grant.UserCode, env.elevatedAdminCookie(t)).StatusCode)
 	require.Equal(t, http.StatusOK, pollStepUp(t, env, grant.DeviceCode).StatusCode)
 
-	env.clock.advance(2 * time.Duration(grant.Interval) * time.Second)
+	env.advance(2 * time.Duration(grant.Interval) * time.Second)
 	assert.Equal(t, http.StatusBadRequest, pollStepUp(t, env, grant.DeviceCode).StatusCode,
 		"a consumed grant cannot be exchanged twice")
 }
@@ -281,7 +281,7 @@ func stepUpHandlerOn(t *testing.T, env *apiAuthEnv, st store.Store) *http.ServeM
 		Lifecycle: auth.NewCredentialLifecycleEffects(env.cache, noopBearerCloser{}, nil),
 		HubURL:    func() string { return env.server.URL },
 	})
-	h.Now = env.clock.now
+	h.Now = env.now
 	h.RegisterRoutes(mux)
 	return mux
 }
@@ -370,7 +370,7 @@ func TestCLIStepUp_ThePollReadsTheCredentialNotTheApprovalFlag(t *testing.T) {
 	rows, err := env.store.DeviceAuthorizations().ApproveByUserCode(ctx, store.ApproveDeviceAuthorizationByUserCodeParams{
 		UserCode: verifycode.Normalize(grant.UserCode),
 		UserID:   userid.MustNew(env.userID),
-	}, env.clock.now().UTC())
+	}, env.now().UTC())
 	require.NoError(t, err)
 	require.Equal(t, int64(1), rows)
 
@@ -407,7 +407,7 @@ func TestCLIStepUp_TheActivationPageIdentifiesTheStoredCredential(t *testing.T) 
 
 	assert.Contains(t, page, "Verify an app credential", "a step-up must not read as an issuance")
 	assert.Contains(t, page, storedName, "the page must identify the credential the hub recorded")
-	assert.Contains(t, page, env.clock.now().UTC().Format("2006-01-02"), "the page must show when the credential was added")
+	assert.Contains(t, page, env.now().UTC().Format("2006-01-02"), "the page must show when the credential was added")
 	assert.NotContains(t, page, chosenName, "the requester's own label must identify nothing here")
 	assert.NotContains(t, page, "administer the hub", "a step-up widens nothing, so it offers no scope")
 }

--- a/backend/internal/util/testutil/quartzclock.go
+++ b/backend/internal/util/testutil/quartzclock.go
@@ -1,0 +1,90 @@
+package testutil
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/coder/quartz"
+)
+
+// deadlineWindow limits every mock-clock wait these helpers make. It is a
+// DEADLOCK GUARD, not a timing assumption: a passing test never reaches it,
+// because each wait ends on a trap the test itself releases. A test that hangs
+// -- a trap nobody releases, a timer nobody arms -- fails here with the call it
+// was waiting for instead of running to the whole package's ten-minute panic.
+const deadlineWindow = 10 * time.Second
+
+// NewQuartzMock builds the mock clock these helpers drive.
+//
+// The logger is off because quartz logs every event through tb.Log, and a test
+// that advances a clock many times buries its own failure in that output.
+func NewQuartzMock(t *testing.T) *quartz.Mock {
+	t.Helper()
+	return quartz.NewMock(t).WithLogger(quartz.NoOpLogger)
+}
+
+// DeadlineContext returns the context every wait below takes. See
+// deadlineWindow for what the limit means.
+func DeadlineContext(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(t.Context(), deadlineWindow)
+	t.Cleanup(cancel)
+	return ctx
+}
+
+// NewTimerTraps catches both halves of one timer's life for tag: the arm, and
+// the stop that releases it. Both close when the test ends.
+//
+// A trap that stays open blocks the NEXT matching call for ever, because quartz
+// parks the calling goroutine inside the trapped call until the test releases
+// it. Registering the close here is what keeps that from reaching the test that
+// runs next.
+func NewTimerTraps(t *testing.T, clock *quartz.Mock, tag string) (newTimer, stopTimer *quartz.Trap) {
+	t.Helper()
+	newTimer = clock.Trap().NewTimer(tag)
+	stopTimer = clock.Trap().TimerStop(tag)
+	t.Cleanup(func() {
+		newTimer.Close()
+		stopTimer.Close()
+	})
+	return newTimer, stopTimer
+}
+
+// WaitForTimer catches the next timer the code arms on trap, returns the delay
+// it ASKED for, and lets the call proceed.
+//
+// The requested delay, never the gap it produces. A measured gap carries the
+// host's timer granularity too -- about 15.6ms on Windows -- which is wide
+// enough to swallow the difference between a 10ms and a 40ms rung and report
+// them in the wrong order, and that is how these tests failed there while the
+// policy was correct. A measured gap also forces a tolerance far wider than the
+// value under test, so it cannot catch a limit several times too large.
+func WaitForTimer(t *testing.T, ctx context.Context, trap *quartz.Trap) time.Duration {
+	t.Helper()
+	call := trap.MustWait(ctx)
+	delay := call.Duration
+	call.MustRelease(ctx)
+	return delay
+}
+
+// AdvanceAndAwaitStop moves the clock by delay and waits until the woken code
+// released its timer.
+//
+// The stop must be released BEFORE the advance is awaited. The fired timer
+// parks inside the trapped Stop, and the advance does not finish until that
+// call returns -- so awaiting the advance first deadlocks, and the failure
+// reads as "context expired while waiting for clock to advance" rather than as
+// the missing release.
+func AdvanceAndAwaitStop(
+	t *testing.T,
+	ctx context.Context,
+	clock *quartz.Mock,
+	delay time.Duration,
+	stopTimer *quartz.Trap,
+) {
+	t.Helper()
+	waiter := clock.Advance(delay)
+	stopTimer.MustWait(ctx).MustRelease(ctx)
+	waiter.MustWait(ctx)
+}

--- a/backend/internal/worker/agent/codex_settings_test.go
+++ b/backend/internal/worker/agent/codex_settings_test.go
@@ -533,22 +533,30 @@ func TestCodexSendTurnStartOmitsAccountDefaultModel(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			a, _, requests := newCodexAgentForRPC(t, func(string) json.RawMessage {
+			// turn/start resolves only at turn end, so the ack comes from the
+			// turn/started notification. Release it when the request ARRIVES,
+			// which the harness records just before it calls this responder.
+			//
+			// Not on a sleep: sendTurnStart writes the request on a detached
+			// goroutine and returns as soon as the ack closes, so a fixed sleep
+			// can release it before that goroutine ran. The assertion below then
+			// reads an empty slice, which is how this test failed under a loaded
+			// suite while the wire shape it checks was correct.
+			var a *CodexAgent
+			var requests func() []codexRecordedRequest
+			a, _, requests = newCodexAgentForRPC(t, func(method string) json.RawMessage {
+				if method == "turn/start" {
+					a.mu.Lock()
+					ack := a.turnStartAck
+					a.turnStartAck = nil
+					a.mu.Unlock()
+					if ack != nil {
+						close(ack)
+					}
+				}
 				return json.RawMessage(`{}`)
 			})
 			a.threadID = "thread-1"
-			go func() {
-				// turn/start resolves only at turn end, so the ack comes from the
-				// turn/started notification. Release it so the send returns.
-				time.Sleep(10 * time.Millisecond)
-				a.mu.Lock()
-				ack := a.turnStartAck
-				a.turnStartAck = nil
-				a.mu.Unlock()
-				if ack != nil {
-					close(ack)
-				}
-			}()
 
 			err := a.sendTurnStart("thread-1", []map[string]interface{}{{"type": "text", "text": "hi"}}, turnSettings{
 				model:          test.model,

--- a/backend/internal/worker/bootstrap/bootstrap.go
+++ b/backend/internal/worker/bootstrap/bootstrap.go
@@ -155,6 +155,7 @@ func Wire(p Params) *Wiring {
 		DB:                  p.DB,
 		Agents:              p.Client.AgentManager(),
 		Terminals:           p.Client.TerminalManager(),
+		Clock:               p.Client.Clock(),
 		HomeDir:             p.HomeDir,
 		DataDir:             p.DataDir,
 		WorkerID:            p.WorkerID,

--- a/backend/internal/worker/hub/backoff.go
+++ b/backend/internal/worker/hub/backoff.go
@@ -1,8 +1,10 @@
 package hub
 
 import (
+	"context"
 	"time"
 
+	"github.com/coder/quartz"
 	"github.com/leapmux/leapmux/internal/util/backoffutil"
 )
 
@@ -25,4 +27,24 @@ type backoff interface {
 // an outage would otherwise retry in lockstep.
 func newDefaultBackoff() *backoffutil.Backoff {
 	return backoffutil.NewBackoff(1*time.Second, 180*time.Second, 0.2)
+}
+
+// waitOrCancel waits d on clock and reports whether the wait finished. It
+// reports false when ctx ended first, which every caller here treats as "stop
+// retrying". It releases the timer on both paths.
+//
+// This is a function rather than a `defer` in the caller. Both callers wait
+// inside a retry LOOP, and a defer there runs only when the enclosing function
+// returns. For the reconnect loop that moment is the end of the worker process,
+// so every retry would hold its timer until then. The tag identifies which wait
+// it is, so a test traps one loop's timer without catching the other's.
+func waitOrCancel(ctx context.Context, clock quartz.Clock, d time.Duration, tag string) bool {
+	timer := clock.NewTimer(d, tag)
+	defer timer.Stop(tag)
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
 }

--- a/backend/internal/worker/hub/client.go
+++ b/backend/internal/worker/hub/client.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	"github.com/coder/quartz"
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/generated/proto/leapmux/v1/leapmuxv1connect"
 	"github.com/leapmux/leapmux/hubtransport"
@@ -25,7 +26,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// Connect-stream queue bounds are sendq.Default* so Hub and worker stay on
+// Connect-stream queue limits are sendq.Default* so Hub and worker stay on
 // one definition. A wall-clock stall cutoff on a server-to-server connection
 // invites a reconnect storm under sustained load, so there is none -- the
 // byte budget alone disconnects a Hub that cannot keep up.
@@ -99,34 +100,34 @@ type Client struct {
 	// connectWithReconnect after the connection drops.
 	hubRetryDelay atomic.Int64
 
-	// now and after are the clock connectWithReconnect measures its
-	// long-connection threshold against and waits its backoff on. A test owns
-	// both, so a whole reconnect sequence runs with no sleep and no window to
-	// race.
-	//
-	// A real sleep does not measure a backoff. It measures the host's timer
-	// granularity too, which is about 15.6ms on Windows -- wide enough to
-	// swallow the difference between this policy's 10ms and 40ms intervals and
-	// report them in the wrong order. Nil means the real clock, so the zero
-	// value of Client keeps working.
-	now   func() time.Time
-	after func(time.Duration) <-chan time.Time
+	// clock supplies every instant, timer and ticker this client reads, so a
+	// test drives a whole reconnect sequence with no sleep and no window to
+	// race. New installs the real clock; WithClock replaces it.
+	clock quartz.Clock
 }
 
-// clockNow reads the clock, defaulting to the real one.
-func (c *Client) clockNow() time.Time {
-	if c.now != nil {
-		return c.now()
-	}
-	return time.Now()
-}
+const (
+	hubReconnectTimeTag       = "hub-reconnect-time"
+	hubReconnectTimerTag      = "hub-reconnect"
+	hubRequestedRetryTimerTag = "hub-requested-retry"
+	hubIdentityTimerTag       = "hub-identity-timeout"
+	hubHeartbeatTickerTag     = "hub-heartbeat"
+	hubHeartbeatIdleTag       = "hub-heartbeat-idle"
+	hubSendTimestampTag       = "hub-send-timestamp"
+	hubConnectTimestampTag    = "hub-connect-timestamp"
+)
 
-// clockAfter waits on the clock, defaulting to the real one.
-func (c *Client) clockAfter(d time.Duration) <-chan time.Time {
-	if c.after != nil {
-		return c.after(d)
+// ClientOption changes one New setting.
+type ClientOption func(*Client)
+
+// WithClock sets the clock that supplies client times, timers, and tickers.
+func WithClock(clock quartz.Clock) ClientOption {
+	if clock == nil {
+		panic("hub: clock must not be nil")
 	}
-	return time.After(d)
+	return func(c *Client) {
+		c.clock = clock
+	}
 }
 
 // New creates a new Hub client with integrated lifecycle management.
@@ -139,7 +140,7 @@ func (c *Client) clockAfter(d time.Duration) <-chan time.Time {
 // cannot express. Against a cleartext hub with no h2c this client fails with
 // hubtransport.ErrH2CUnsupported, which states the URL and the remedy, instead
 // of degrading to a protocol on which the worker could never connect.
-func New(endpoint *hubtransport.Endpoint) *Client {
+func New(endpoint *hubtransport.Endpoint, opts ...ClientOption) *Client {
 	httpClient := endpoint.HTTP2OnlyClient()
 	connectURL := endpoint.BaseURL()
 	c := &Client{
@@ -152,9 +153,20 @@ func New(endpoint *hubtransport.Endpoint) *Client {
 			httpClient,
 			connectURL,
 		),
-		endpoint:  endpoint,
-		terminals: terminal.NewManager(),
+		endpoint: endpoint,
+		clock:    quartz.NewReal(),
 	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	// After the options, because the terminal Manager takes the clock this
+	// client settled on. A test that gives the Client a mock clock therefore
+	// drives the reader-drain grace inside its terminals too, and MUST advance
+	// that clock, or a reader that never ends parks the exit goroutine for
+	// ever. bootstrap.Wire reads the same clock back through Clock() for the
+	// Service, so those three share one. The registration retry holds its own,
+	// because Register runs before any Client exists.
+	c.terminals = terminal.NewManager(terminal.WithClock(c.clock))
 	c.agents = agent.NewManager(func(agentID string, exitCode int, err error, _ bool) {
 		if err != nil {
 			slog.Info("agent exited with error", "agent_id", agentID, "exit_code", exitCode, "error", err)
@@ -195,6 +207,10 @@ func (c *Client) SetChannelMgr(mgr *channel.Manager) {
 func (c *Client) AgentManager() *agent.Manager {
 	return c.agents
 }
+
+// Clock returns the clock this client and its terminal manager share, so
+// anything wired behind the client runs on the same one.
+func (c *Client) Clock() quartz.Clock { return c.clock }
 
 // TerminalManager returns the terminal manager.
 func (c *Client) TerminalManager() *terminal.Manager {
@@ -253,14 +269,14 @@ func sendFailureLevel(err error) slog.Level {
 	return slog.LevelWarn
 }
 
-// ShutdownFlushTimeout bounds FlushSends. Generous relative to the work (a
+// ShutdownFlushTimeout limits FlushSends. It is generous relative to the work (a
 // handful of small frames onto an open socket) because the cost of waiting too
 // long is a slower exit, while the cost of not waiting long enough is a user
 // staring at a terminal that silently stopped.
 const ShutdownFlushTimeout = 5 * time.Second
 
 // FlushSends blocks until everything already enqueued has been handed to the
-// Connect stream, bounded by ShutdownFlushTimeout. A nil writer (never
+// Connect stream, with ShutdownFlushTimeout as its limit. A nil writer (never
 // connected, or already torn down) is nothing to wait for and returns
 // immediately.
 //
@@ -271,7 +287,7 @@ const ShutdownFlushTimeout = 5 * time.Second
 // needed them is a browser that will never get another chance to hear from this
 // process.
 //
-// The bound lives here rather than in a parameter because there is one policy
+// The limit lives here rather than in a parameter because there is one policy
 // and two entry points that would otherwise each restate it.
 func (c *Client) FlushSends() error {
 	w := c.currentWriter()
@@ -329,9 +345,22 @@ func (c *Client) currentWriter() *sendq.Writer[*leapmuxv1.ConnectRequest] {
 	return w
 }
 
+// markEnqueued stamps the instant of this enqueue, which heartbeatLoop reads to
+// decide whether the connection went idle.
+//
+// The clock read sits OUTSIDE c.mu, like the one in Connect. A quartz trap
+// parks the calling goroutine inside Now, and a park under c.mu blocks
+// currentWriter, cancelConn and the heartbeat's own idle read, so a test that
+// traps this stamp would deadlock the client rather than observe it. Two
+// concurrent enqueues can then read the clock in one order and reach the lock
+// in the other, so the write keeps the later instant instead of overwriting it
+// -- lastSendTime only ever moves forward.
 func (c *Client) markEnqueued() {
+	now := c.clock.Now(hubSendTimestampTag)
 	c.mu.Lock()
-	c.lastSendTime = time.Now()
+	if now.After(c.lastSendTime) {
+		c.lastSendTime = now
+	}
 	c.mu.Unlock()
 }
 
@@ -426,11 +455,12 @@ func (c *Client) Connect(ctx context.Context, authToken string) error {
 		},
 	})
 
+	connectedAt := c.clock.Now(hubConnectTimestampTag)
 	c.mu.Lock()
 	c.stream = stream
 	c.writer = writer
 	c.connCancel = connCancel
-	c.lastSendTime = time.Now()
+	c.lastSendTime = connectedAt
 	c.mu.Unlock()
 	defer func() {
 		c.mu.Lock()
@@ -573,16 +603,15 @@ func resolveWorkingDir(path string) (string, error) {
 
 const heartbeatIdleTimeout = 5 * time.Second
 
-// workerIdentityTimeout bounds how long the worker waits for the Hub's
+// workerIdentityTimeout limits how long the worker waits for the Hub's
 // connect-time WorkerIdentity greeting before force-closing the stream. The
 // Hub sends it before publishing the connection, so its absence within this
 // budget signals a stripped/dropped greeting -- which would otherwise leave
 // requireWorkerOwner denying every machine-scoped RPC (file, git, sysinfo,
 // tunnel) for the connection's life, indistinguishable from a genuine
 // cross-tenant refusal. Force-closing triggers ConnectWithReconnect's
-// backoff, which re-runs the greeting on a fresh stream. A var so tests can
-// shorten it.
-var workerIdentityTimeout = 10 * time.Second
+// backoff, which re-runs the greeting on a fresh stream.
+const workerIdentityTimeout = 10 * time.Second
 
 // closeStreamOnCancel ends the bidi stream when ctx fires, because cancelling
 // it is NOT enough on its own. connect-go checks the context before each read,
@@ -616,8 +645,8 @@ func (c *Client) closeStreamOnCancel(
 // watchForIdentity force-closes the connection if the Hub does not deliver
 // WorkerIdentity within workerIdentityTimeout. See Client.identityReceived.
 func (c *Client) watchForIdentity(ctx context.Context) {
-	timer := time.NewTimer(workerIdentityTimeout)
-	defer timer.Stop()
+	timer := c.clock.NewTimer(workerIdentityTimeout, hubIdentityTimerTag)
+	defer timer.Stop(hubIdentityTimerTag)
 	select {
 	case <-ctx.Done():
 		return
@@ -643,8 +672,8 @@ func (c *Client) cancelConn() {
 }
 
 func (c *Client) heartbeatLoop(ctx context.Context) {
-	ticker := time.NewTicker(2 * time.Second)
-	defer ticker.Stop()
+	ticker := c.clock.NewTicker(2*time.Second, hubHeartbeatTickerTag)
+	defer ticker.Stop(hubHeartbeatTickerTag)
 
 	for {
 		select {
@@ -652,8 +681,10 @@ func (c *Client) heartbeatLoop(ctx context.Context) {
 			return
 		case <-ticker.C:
 			c.mu.Lock()
-			idle := time.Since(c.lastSendTime)
+			lastSend := c.lastSendTime
 			c.mu.Unlock()
+			// Outside the lock, for the reason markEnqueued states.
+			idle := c.clock.Since(lastSend, hubHeartbeatIdleTag)
 
 			if idle >= heartbeatIdleTimeout {
 				if err := c.Send(&leapmuxv1.ConnectRequest{
@@ -680,15 +711,15 @@ func (c *Client) heartbeatLoop(ctx context.Context) {
 type connectFn func(ctx context.Context, authToken string) error
 
 // ConnectWithReconnect wraps Connect with automatic reconnection using
-// exponential backoff. Starts at 1s, doubles up to 60s, resets on
-// successful connection lasting longer than resetThreshold.
+// exponential backoff. Starts at 1s, doubles up to 180s, and resets after a
+// connection lasts longer than resetThreshold.
 func (c *Client) ConnectWithReconnect(ctx context.Context, authToken string) {
 	c.connectWithReconnect(ctx, authToken, c.Connect, newDefaultBackoff(), resetThreshold)
 }
 
 func (c *Client) connectWithReconnect(ctx context.Context, authToken string, connect connectFn, bo backoff, threshold time.Duration) {
 	for {
-		start := c.clockNow()
+		start := c.clock.Now(hubReconnectTimeTag)
 		err := connect(ctx, authToken)
 		if ctx.Err() != nil {
 			return
@@ -709,26 +740,22 @@ func (c *Client) connectWithReconnect(ctx context.Context, authToken string, con
 		// so it only applies once.
 		if delay := c.hubRetryDelay.Swap(0); delay > 0 {
 			slog.Info("hub requested reconnect delay", "delay_seconds", delay)
-			select {
-			case <-ctx.Done():
+			if !waitOrCancel(ctx, c.clock, time.Duration(delay)*time.Second, hubRequestedRetryTimerTag) {
 				return
-			case <-c.clockAfter(time.Duration(delay) * time.Second):
 			}
 			bo.Reset()
 			continue
 		}
 
 		// If connection lasted long enough, reset backoff.
-		if c.clockNow().Sub(start) >= threshold {
+		if c.clock.Now(hubReconnectTimeTag).Sub(start) >= threshold {
 			bo.Reset()
 		}
 
 		interval := bo.Next()
 		slog.Warn("disconnected from hub, reconnecting...", "error", err, "backoff", interval)
-		select {
-		case <-ctx.Done():
+		if !waitOrCancel(ctx, c.clock, interval, hubReconnectTimerTag) {
 			return
-		case <-c.clockAfter(interval):
 		}
 	}
 }

--- a/backend/internal/worker/hub/client_test.go
+++ b/backend/internal/worker/hub/client_test.go
@@ -6,12 +6,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"connectrpc.com/connect"
+	"github.com/coder/quartz"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
@@ -20,17 +20,30 @@ import (
 	"github.com/leapmux/leapmux/hubtransport"
 	"github.com/leapmux/leapmux/internal/sendq"
 	"github.com/leapmux/leapmux/internal/util/backoffutil"
+	"github.com/leapmux/leapmux/internal/util/testutil"
 	"github.com/leapmux/leapmux/internal/worker/channel"
 )
+
+// newBareClient builds the minimal Client the transport tests need: no
+// endpoint and no managers, but a working clock.
+//
+// The clock is not optional here even though these tests never advance it. New
+// is the only place that installs one, and a successful enqueue stamps
+// lastSendTime through it -- so a bare `&Client{}` that reaches Send with a
+// live writer panics on a nil interface instead of failing an assertion. One
+// helper means no test has to decide whether its path reaches the clock.
+func newBareClient() *Client {
+	return &Client{clock: quartz.NewReal()}
+}
 
 // newTestClient builds a Client for url. It exists so these tests state a URL
 // rather than an Endpoint: hubtransport.New opens no connection, and every
 // caller here passes a literal it controls.
-func newTestClient(t *testing.T, url string) *Client {
+func newTestClient(t *testing.T, url string, opts ...ClientOption) *Client {
 	t.Helper()
 	endpoint, err := hubtransport.New(url)
 	require.NoError(t, err, "hubtransport.New(%q)", url)
-	return New(endpoint)
+	return New(endpoint, opts...)
 }
 
 // TestNew_PreservesTheEndpointURL verifies that New() builds a client for
@@ -59,6 +72,18 @@ func TestNew_PreservesTheEndpointURL(t *testing.T) {
 			assert.Equal(t, tc.url, client.Endpoint().URL(), "endpoint URL preserved verbatim")
 		})
 	}
+}
+
+func TestWithClockRejectsNil(t *testing.T) {
+	t.Parallel()
+	assert.Panics(t, func() { WithClock(nil) })
+}
+
+func TestNewUsesRealClockByDefault(t *testing.T) {
+	t.Parallel()
+	c := newTestClient(t, "http://localhost:0")
+	require.IsType(t, quartz.NewReal(), c.clock,
+		"New must wire the real clock, not a seeded mock a WithinDuration check would accept")
 }
 
 func TestResolveWorkingDir_HomeDir(t *testing.T) {
@@ -154,8 +179,12 @@ func TestConnectWithReconnect_ReconnectsOnFailure(t *testing.T) {
 	var attempts atomic.Int32
 	targetAttempts := int32(4)
 
-	client := &Client{}
+	clock := testutil.NewQuartzMock(t)
+	client := &Client{clock: clock}
+	testCtx := testutil.DeadlineContext(t)
 	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	newTimer, stopTimer := testutil.NewTimerTraps(t, clock, hubReconnectTimerTag)
 
 	mockConnect := func(_ context.Context, _ string) error {
 		n := attempts.Add(1)
@@ -165,95 +194,65 @@ func TestConnectWithReconnect_ReconnectsOnFailure(t *testing.T) {
 		return fmt.Errorf("connection lost")
 	}
 
-	client.connectWithReconnect(ctx, "token", mockConnect, newFastBackoff(), 5*time.Millisecond)
+	done := make(chan struct{})
+	go func() {
+		client.connectWithReconnect(ctx, "token", mockConnect, newFastBackoff(), 5*time.Millisecond)
+		close(done)
+	}()
+	for range targetAttempts - 1 {
+		delay := testutil.WaitForTimer(t, testCtx, newTimer)
+		testutil.AdvanceAndAwaitStop(t, testCtx, clock, delay, stopTimer)
+	}
+	select {
+	case <-done:
+	case <-testCtx.Done():
+		require.FailNow(t, "the reconnect loop did not stop after cancellation")
+	}
 
-	assert.GreaterOrEqual(t, attempts.Load(), targetAttempts, "connect call count")
+	assert.Equal(t, targetAttempts, attempts.Load(), "connect call count")
 }
 
 func TestConnectWithReconnect_StopsOnContextCancel(t *testing.T) {
 	var attempts atomic.Int32
 
-	client := &Client{}
+	clock := testutil.NewQuartzMock(t)
+	client := &Client{clock: clock}
+	testCtx := testutil.DeadlineContext(t)
 	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	newTimer, stopTimer := testutil.NewTimerTraps(t, clock, hubReconnectTimerTag)
 
 	mockConnect := func(_ context.Context, _ string) error {
 		attempts.Add(1)
 		return fmt.Errorf("connection lost")
 	}
 
-	// Cancel after a short delay.
+	done := make(chan struct{})
 	go func() {
-		time.Sleep(15 * time.Millisecond)
-		cancel()
+		client.connectWithReconnect(ctx, "token", mockConnect, newFastBackoff(), 5*time.Millisecond)
+		close(done)
 	}()
+	_ = testutil.WaitForTimer(t, testCtx, newTimer)
+	cancel()
+	stopTimer.MustWait(testCtx).MustRelease(testCtx)
+	select {
+	case <-done:
+	case <-testCtx.Done():
+		require.FailNow(t, "the reconnect loop ignored context cancellation")
+	}
 
-	client.connectWithReconnect(ctx, "token", mockConnect, newFastBackoff(), 5*time.Millisecond)
-
-	assert.GreaterOrEqual(t, attempts.Load(), int32(1), "expected at least 1 attempt")
-}
-
-// fakeClock is the clock the reconnect tests own. Now feeds the
-// long-connection threshold and After feeds the backoff wait, so a whole
-// reconnect sequence is exercised with no sleep and no window to race.
-//
-// A test asserts on the durations the code ASKED to wait, which a real sleep
-// cannot report: a measured gap carries the host's timer granularity too, and
-// on Windows that is about 15.6ms -- wide enough to swallow the difference
-// between this policy's 10ms and 40ms intervals and report them in the wrong
-// order, which is how these tests failed there while the policy was correct.
-type fakeClock struct {
-	mu     sync.Mutex
-	now    time.Time
-	waited []time.Duration
-}
-
-func newFakeClock() *fakeClock {
-	// A fixed instant rather than time.Now, so nothing about the result depends
-	// on when the suite runs.
-	return &fakeClock{now: time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)}
-}
-
-func (c *fakeClock) Now() time.Time {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.now
-}
-
-// After records the wait, advances the clock over it, and hands back a channel
-// that is already ready. The wait becomes a fact the test reads instead of a
-// delay it pays.
-func (c *fakeClock) After(d time.Duration) <-chan time.Time {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.waited = append(c.waited, d)
-	c.now = c.now.Add(d)
-	ch := make(chan time.Time, 1)
-	ch <- c.now
-	return ch
-}
-
-// Advance moves the clock without recording a wait, which is how a test states
-// that a connection LASTED some time.
-func (c *fakeClock) Advance(d time.Duration) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.now = c.now.Add(d)
-}
-
-// waits returns a copy, so a caller cannot read the slice while
-// connectWithReconnect still appends to it.
-func (c *fakeClock) waits() []time.Duration {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return append([]time.Duration(nil), c.waited...)
+	assert.Equal(t, int32(1), attempts.Load(), "context cancellation must stop before a second attempt")
 }
 
 func TestConnectWithReconnect_ResetsBackoffAfterLongConnection(t *testing.T) {
 	var attempts atomic.Int32
 
-	clock := newFakeClock()
-	client := &Client{now: clock.Now, after: clock.After}
+	clock := testutil.NewQuartzMock(t)
+	client := &Client{clock: clock}
+	testCtx := testutil.DeadlineContext(t)
 	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	newTimer, stopTimer := testutil.NewTimerTraps(t, clock, hubReconnectTimerTag)
 
 	// Zero jitter, so the sequence asserted below is the one the policy states.
 	bo := backoffutil.NewBackoff(10*time.Millisecond, 500*time.Millisecond, 0)
@@ -271,7 +270,12 @@ func TestConnectWithReconnect_ResetsBackoffAfterLongConnection(t *testing.T) {
 			return fmt.Errorf("fail 3")
 		case 4:
 			// Holds longer than the threshold, which resets the backoff.
-			clock.Advance(80 * time.Millisecond)
+			// Await the waiter: nothing is armed while connect runs today, so
+			// Advance completes at once, but a future timer here would
+			// otherwise fire beside the rest of the test. Wait, not MustWait --
+			// this is not the test goroutine, and MustWait calls Fatalf.
+			assert.NoError(t, clock.Advance(80*time.Millisecond).Wait(testCtx),
+				"the long-connection advance must settle")
 			return fmt.Errorf("disconnect after long session")
 		case 5:
 			// Fails at once → back to the initial 10ms.
@@ -282,31 +286,42 @@ func TestConnectWithReconnect_ResetsBackoffAfterLongConnection(t *testing.T) {
 		}
 	}
 
-	client.connectWithReconnect(ctx, "token", mockConnect, bo, 50*time.Millisecond)
+	done := make(chan struct{})
+	go func() {
+		client.connectWithReconnect(ctx, "token", mockConnect, bo, 50*time.Millisecond)
+		close(done)
+	}()
 
-	require.GreaterOrEqual(t, attempts.Load(), int32(6), "expected at least 6 connect attempts")
-
-	// The whole policy in one line: the interval doubles while the connections
-	// are short, and the connection that outlasted the threshold puts it back to
-	// the initial interval.
-	waits := clock.waits()
-	require.GreaterOrEqual(t, len(waits), 5)
-	assert.Equal(t, []time.Duration{
+	want := []time.Duration{
 		10 * time.Millisecond,
 		20 * time.Millisecond,
 		40 * time.Millisecond,
 		10 * time.Millisecond,
 		20 * time.Millisecond,
-	}, waits[:5], "the fourth disconnect follows a long connection, so it restarts the sequence")
+	}
+	for i, expected := range want {
+		delay := testutil.WaitForTimer(t, testCtx, newTimer)
+		assert.Equal(t, expected, delay, "reconnect delay %d", i+1)
+		testutil.AdvanceAndAwaitStop(t, testCtx, clock, delay, stopTimer)
+	}
+	select {
+	case <-done:
+	case <-testCtx.Done():
+		require.FailNow(t, "the reconnect loop did not stop after the expected attempts")
+	}
+	require.Equal(t, int32(6), attempts.Load(), "expected connect attempts")
 }
 
 func TestConnectWithReconnect_BackoffCapsAtMax(t *testing.T) {
 	targetAttempts := int32(8)
 	var attempts atomic.Int32
 
-	clock := newFakeClock()
-	client := &Client{now: clock.Now, after: clock.After}
+	clock := testutil.NewQuartzMock(t)
+	client := &Client{clock: clock}
+	testCtx := testutil.DeadlineContext(t)
 	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	newTimer, stopTimer := testutil.NewTimerTraps(t, clock, hubReconnectTimerTag)
 
 	const maxInterval = 10 * time.Millisecond
 	bo := backoffutil.NewBackoff(2*time.Millisecond, maxInterval, 0)
@@ -318,17 +333,27 @@ func TestConnectWithReconnect_BackoffCapsAtMax(t *testing.T) {
 		return fmt.Errorf("fail")
 	}
 
-	client.connectWithReconnect(ctx, "token", mockConnect, bo, 1*time.Hour)
-
-	// The waits the code asked for, not the gaps they produced: a measured gap
-	// carries the host's scheduling delay too, which is why this used to allow a
-	// 50ms tolerance against a 10ms cap -- and so could not have caught a cap
-	// five times too large.
-	waits := clock.waits()
-	require.NotEmpty(t, waits)
-	for i, wait := range waits {
-		assert.LessOrEqual(t, wait, maxInterval,
-			"wait[%d]=%v exceeds MaxInterval=%v", i, wait, maxInterval)
+	done := make(chan struct{})
+	go func() {
+		client.connectWithReconnect(ctx, "token", mockConnect, bo, time.Hour)
+		close(done)
+	}()
+	var waits []time.Duration
+	for range targetAttempts - 1 {
+		delay := testutil.WaitForTimer(t, testCtx, newTimer)
+		waits = append(waits, delay)
+		testutil.AdvanceAndAwaitStop(t, testCtx, clock, delay, stopTimer)
+	}
+	select {
+	case <-done:
+	case <-testCtx.Done():
+		require.FailNow(t, "the capped reconnect loop did not stop")
+	}
+	require.Len(t, waits, int(targetAttempts-1),
+		"one recorded wait per failed attempt, or the cap assertion below indexes nothing")
+	for i, delay := range waits {
+		assert.LessOrEqual(t, delay, maxInterval,
+			"wait[%d]=%v exceeds MaxInterval=%v", i, delay, maxInterval)
 	}
 	assert.Equal(t, maxInterval, waits[len(waits)-1],
 		"the sequence must actually reach the cap, or the loop above proves nothing")
@@ -480,11 +505,10 @@ func TestHandleMessage_WorkspaceTabsSyncResp_NilCallbackIsSafe(t *testing.T) {
 // force-closes the stream when the greeting does not arrive in time, so the
 // reconnect backoff re-runs the greeting on a fresh stream.
 func TestWatchForIdentity_ForceCancelsWhenIdentityMissing(t *testing.T) {
-	old := workerIdentityTimeout
-	workerIdentityTimeout = 20 * time.Millisecond
-	defer func() { workerIdentityTimeout = old }()
-
-	c := newTestClient(t, "http://localhost:0")
+	clock := testutil.NewQuartzMock(t)
+	c := newTestClient(t, "http://localhost:0", WithClock(clock))
+	testCtx := testutil.DeadlineContext(t)
+	newTimer, stopTimer := testutil.NewTimerTraps(t, clock, hubIdentityTimerTag)
 	var cancelled atomic.Bool
 	c.connCancel = func() { cancelled.Store(true) }
 
@@ -492,17 +516,18 @@ func TestWatchForIdentity_ForceCancelsWhenIdentityMissing(t *testing.T) {
 	defer cancel()
 	go c.watchForIdentity(ctx)
 
-	require.Eventually(t, func() bool { return cancelled.Load() },
-		1*time.Second, 5*time.Millisecond,
-		"watchdog must force-cancel the connection when WorkerIdentity is not delivered")
+	delay := testutil.WaitForTimer(t, testCtx, newTimer)
+	assert.Equal(t, workerIdentityTimeout, delay)
+	testutil.AdvanceAndAwaitStop(t, testCtx, clock, delay, stopTimer)
+	assert.True(t, cancelled.Load(),
+		"the watchdog must cancel the connection when the Hub omits WorkerIdentity")
 }
 
 func TestWatchForIdentity_DoesNotCancelWhenIdentityReceived(t *testing.T) {
-	old := workerIdentityTimeout
-	workerIdentityTimeout = 20 * time.Millisecond
-	defer func() { workerIdentityTimeout = old }()
-
-	c := newTestClient(t, "http://localhost:0")
+	clock := testutil.NewQuartzMock(t)
+	c := newTestClient(t, "http://localhost:0", WithClock(clock))
+	testCtx := testutil.DeadlineContext(t)
+	newTimer, stopTimer := testutil.NewTimerTraps(t, clock, hubIdentityTimerTag)
 	c.identityReceived.Store(true)
 	var cancelled atomic.Bool
 	c.connCancel = func() { cancelled.Store(true) }
@@ -511,7 +536,9 @@ func TestWatchForIdentity_DoesNotCancelWhenIdentityReceived(t *testing.T) {
 	defer cancel()
 	go c.watchForIdentity(ctx)
 
-	time.Sleep(80 * time.Millisecond)
+	delay := testutil.WaitForTimer(t, testCtx, newTimer)
+	assert.Equal(t, workerIdentityTimeout, delay)
+	testutil.AdvanceAndAwaitStop(t, testCtx, clock, delay, stopTimer)
 	assert.False(t, cancelled.Load(),
 		"watchdog must not fire once WorkerIdentity has been received")
 }
@@ -536,7 +563,7 @@ func TestHandleMessage_WorkerIdentity_SetsIdentityReceivedFlag(t *testing.T) {
 // stream tries one last frame as the connection unwinds, and Send is where that
 // attempt learns there is nothing left to send on.
 func TestClientSendReturnsTransportGoneWhenNotConnected(t *testing.T) {
-	c := &Client{}
+	c := newBareClient()
 	require.Nil(t, c.currentWriter(), "fixture must model a client that never connected")
 
 	err := c.Send(heartbeatMsg())
@@ -561,7 +588,8 @@ func TestClientSendReportsAClosedWriterAsTransportGone(t *testing.T) {
 	})
 	writer.Close()
 
-	c := &Client{writer: writer}
+	c := newBareClient()
+	c.writer = writer
 	require.NotNil(t, c.currentWriter(), "fixture must model an INSTALLED writer, not the nil-writer path")
 
 	err := c.Send(heartbeatMsg())
@@ -593,7 +621,7 @@ func TestClientSendDoesNotBlockReceiveWhenTransportBlocked(t *testing.T) {
 	blocked := make(chan struct{})
 	t.Cleanup(func() { close(blocked) })
 
-	c := &Client{}
+	c := newBareClient()
 	c.writer = sendq.New(ctx, sendq.Config[*leapmuxv1.ConnectRequest]{
 		Write: func(context.Context, *leapmuxv1.ConnectRequest) error {
 			<-blocked
@@ -633,7 +661,7 @@ func TestClientSendDoesNotBlockReceiveWhenTransportBlocked(t *testing.T) {
 func TestClientWriteFailureCancelsConnection(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	var cancelled atomic.Bool
-	c := &Client{}
+	c := newBareClient()
 	c.connCancel = func() {
 		cancelled.Store(true)
 		cancel()
@@ -679,7 +707,7 @@ func TestClientTrySendDropsWhenBudgetFull(t *testing.T) {
 	fillSize := connectReqSize(filler)
 	require.Greater(t, fillSize, 400)
 
-	c := &Client{}
+	c := newBareClient()
 	c.writer = sendq.New(ctx, sendq.Config[*leapmuxv1.ConnectRequest]{
 		Write: func(context.Context, *leapmuxv1.ConnectRequest) error {
 			select {
@@ -728,7 +756,7 @@ func TestClientTrySendOrResetUsesControlReserve(t *testing.T) {
 	reserve := int64(fillSize)     // one control frame of the same size
 
 	var cancelled atomic.Bool
-	c := &Client{}
+	c := newBareClient()
 	c.connCancel = func() { cancelled.Store(true) }
 	c.writer = sendq.New(ctx, sendq.Config[*leapmuxv1.ConnectRequest]{
 		Write: func(context.Context, *leapmuxv1.ConnectRequest) error {
@@ -768,8 +796,10 @@ func TestClientLastSendTimeAdvancesOnEnqueue(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	c := &Client{}
-	c.lastSendTime = time.Now().Add(-time.Hour)
+	clock := testutil.NewQuartzMock(t)
+	c := &Client{clock: clock}
+	now := clock.Now()
+	c.lastSendTime = now.Add(-time.Hour)
 	before := c.lastSendTime
 
 	c.writer = sendq.New(ctx, sendq.Config[*leapmuxv1.ConnectRequest]{
@@ -784,17 +814,234 @@ func TestClientLastSendTimeAdvancesOnEnqueue(t *testing.T) {
 	c.mu.Lock()
 	after := c.lastSendTime
 	c.mu.Unlock()
+	assert.Equal(t, now, after, "Send must use the client's clock for its enqueue timestamp")
 	assert.True(t, after.After(before), "lastSendTime must advance on enqueue")
 
 	// Reset before TrySend so the assertion does not depend on wall-clock
 	// ticks between two rapid enqueues (Windows time.Now can share a tick).
 	c.mu.Lock()
-	c.lastSendTime = time.Now().Add(-time.Hour)
+	c.lastSendTime = now.Add(-time.Hour)
 	before = c.lastSendTime
 	c.mu.Unlock()
 	require.True(t, c.TrySend(heartbeatMsg()))
 	c.mu.Lock()
 	after = c.lastSendTime
 	c.mu.Unlock()
+	assert.Equal(t, now, after, "TrySend must use the client's clock for its enqueue timestamp")
 	assert.True(t, after.After(before), "lastSendTime must advance on TrySend enqueue")
+}
+
+// TestClientLastSendTimeNeverMovesBackwards pins the monotonicity guard in
+// markEnqueued. The clock read sits outside c.mu so a trap on it cannot park
+// the whole client, which means two concurrent enqueues can read the clock in
+// one order and reach the lock in the other. The later instant must win.
+//
+// heartbeatIdleTimeout is 5s, so a regression here is not a wrong heartbeat --
+// it is lastSendTime drifting backwards under load, which makes the idle window
+// longer than the connection has really been quiet.
+func TestClientLastSendTimeNeverMovesBackwards(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	clock := testutil.NewQuartzMock(t)
+	c := &Client{clock: clock}
+	// A stamp from an enqueue whose clock read happened LATER, but which won the
+	// race to the lock first. The enqueue below reads an earlier instant.
+	ahead := clock.Now().Add(time.Minute)
+	c.lastSendTime = ahead
+
+	c.writer = sendq.New(ctx, sendq.Config[*leapmuxv1.ConnectRequest]{
+		Write:         func(context.Context, *leapmuxv1.ConnectRequest) error { return nil },
+		Size:          connectReqSize,
+		MaxBytes:      sendq.DefaultMaxBytes,
+		FrameOverhead: sendq.DefaultFrameOverhead,
+	})
+	t.Cleanup(func() { c.writer.Close() })
+
+	require.NoError(t, c.Send(heartbeatMsg()))
+	c.mu.Lock()
+	after := c.lastSendTime
+	c.mu.Unlock()
+	assert.Equal(t, ahead, after,
+		"an enqueue that read an earlier instant must not pull lastSendTime backwards")
+}
+
+// TestClientClockReturnsTheInstalledClock pins the accessor bootstrap.Wire
+// reads to give the Service the SAME clock this client and its terminal manager
+// run on. Without it the worker holds two clocks and a test can drive only one.
+func TestClientClockReturnsTheInstalledClock(t *testing.T) {
+	t.Parallel()
+	clock := testutil.NewQuartzMock(t)
+	c := newTestClient(t, "http://localhost:0", WithClock(clock))
+	assert.Same(t, clock, c.Clock(), "Clock must return the clock New installed")
+	assert.Same(t, clock, c.Clock(), "the accessor must be stable across calls")
+}
+
+// TestEnqueueStampDoesNotCarryTheConnectTag pins the tag split. One tag for two
+// call sites made a trap catch both, so a test that held the connect-time stamp
+// also parked every enqueue on the send path.
+func TestEnqueueStampDoesNotCarryTheConnectTag(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	require.NotEqual(t, hubSendTimestampTag, hubConnectTimestampTag,
+		"the two stamps must be separately trappable")
+
+	clock := testutil.NewQuartzMock(t)
+	c := &Client{clock: clock}
+	connectStamps := clock.Trap().Now(hubConnectTimestampTag)
+	defer connectStamps.Close()
+
+	c.writer = sendq.New(ctx, sendq.Config[*leapmuxv1.ConnectRequest]{
+		Write:         func(context.Context, *leapmuxv1.ConnectRequest) error { return nil },
+		Size:          connectReqSize,
+		MaxBytes:      sendq.DefaultMaxBytes,
+		FrameOverhead: sendq.DefaultFrameOverhead,
+	})
+	t.Cleanup(func() { c.writer.Close() })
+
+	// A trapped call parks its caller, so a Send that returned at all proves the
+	// enqueue stamp did not match the connect trap.
+	require.NoError(t, c.Send(heartbeatMsg()))
+	c.mu.Lock()
+	stamped := c.lastSendTime
+	c.mu.Unlock()
+	assert.Equal(t, clock.Now(), stamped, "the enqueue must still stamp its own instant")
+}
+
+func TestHeartbeatLoopUsesClockAndStopsTicker(t *testing.T) {
+	clock := testutil.NewQuartzMock(t)
+	testCtx := testutil.DeadlineContext(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	written := make(chan *leapmuxv1.ConnectRequest, 1)
+	start := clock.Now()
+	c := &Client{clock: clock, lastSendTime: start}
+	c.writer = sendq.New(ctx, sendq.Config[*leapmuxv1.ConnectRequest]{
+		Write: func(_ context.Context, msg *leapmuxv1.ConnectRequest) error {
+			written <- msg
+			return nil
+		},
+		Size:          connectReqSize,
+		MaxBytes:      sendq.DefaultMaxBytes,
+		FrameOverhead: sendq.DefaultFrameOverhead,
+	})
+	t.Cleanup(c.writer.Close)
+
+	newTicker := clock.Trap().NewTicker(hubHeartbeatTickerTag)
+	defer newTicker.Close()
+	stopTicker := clock.Trap().TickerStop(hubHeartbeatTickerTag)
+	defer stopTicker.Close()
+	// The idle measurement is the loop's synchronization point AND its subject.
+	// Its trapped argument is the lastSendTime the loop read, so each tick
+	// reports what the PREVIOUS tick did: an unchanged argument proves the
+	// previous tick sent nothing, and a moved one proves the heartbeat stamped
+	// its enqueue on this clock. The frame's arrival orders only the writer
+	// goroutine, so the sendStamps trap below is what orders markEnqueued's own
+	// clock read against the next advance.
+	idleReads := clock.Trap().Since(hubHeartbeatIdleTag)
+	defer idleReads.Close()
+	// The enqueue stamp is the value under test, so the test must own the
+	// instant markEnqueued reads. Nothing else orders that read: Send returns
+	// once the frame is QUEUED, so the loop's clock read runs beside the writer
+	// goroutine and beside the next Advance. Without this trap the fourth tick
+	// moved the clock first and the stamp reported 8s where 6s belongs.
+	sendStamps := clock.Trap().Now(hubSendTimestampTag)
+	defer sendStamps.Close()
+	done := make(chan struct{})
+	go func() {
+		c.heartbeatLoop(ctx)
+		close(done)
+	}()
+	call := newTicker.MustWait(testCtx)
+	assert.Equal(t, 2*time.Second, call.Duration)
+	call.MustRelease(testCtx)
+
+	// tick returns the lastSendTime the loop measured its idle window against.
+	tick := func() time.Time {
+		t.Helper()
+		advance := clock.Advance(2 * time.Second)
+		idle := idleReads.MustWait(testCtx)
+		measuredAgainst := idle.Time
+		idle.MustRelease(testCtx)
+		advance.MustWait(testCtx)
+		return measuredAgainst
+	}
+
+	// Ticks 1 and 2 sit at 2s and 4s idle, both under the 5s timeout.
+	assert.Equal(t, start, tick(), "the first tick measures idle time from the last enqueue")
+	assert.Equal(t, start, tick(), "the first tick was under the idle timeout, so it sent nothing")
+	// Tick 3 reaches 6s of idle time and sends.
+	assert.Equal(t, start, tick(), "the second tick was under the idle timeout, so it sent nothing")
+	heartbeatAt := clock.Now()
+	select {
+	case msg := <-written:
+		require.NotNil(t, msg.GetHeartbeat())
+	case <-testCtx.Done():
+		require.FailNow(t, "the idle heartbeat did not run on the third tick")
+	}
+	// Release the stamp BEFORE the next advance. Now reads the clock after the
+	// release and completes before MustRelease returns, so the stamp is the
+	// instant the heartbeat went out, not the one the fourth tick moves to.
+	sendStamps.MustWait(testCtx).MustRelease(testCtx)
+	assert.Equal(t, heartbeatAt, tick(),
+		"the heartbeat enqueue timestamp must come from the client clock")
+
+	cancel()
+	stopTicker.MustWait(testCtx).MustRelease(testCtx)
+	select {
+	case <-done:
+	case <-testCtx.Done():
+		require.FailNow(t, "the heartbeat loop did not stop after cancellation")
+	}
+	_, running := clock.Peek()
+	assert.False(t, running, "the heartbeat loop must stop its ticker")
+}
+
+// TestHeartbeatLoopStopsWhenTheSendFails covers the loop's error path: a
+// heartbeat that cannot reach the transport ends the loop. Without it the loop
+// keeps ticking against a connection that is already gone, and each tick logs
+// the same failure for the life of the process.
+func TestHeartbeatLoopStopsWhenTheSendFails(t *testing.T) {
+	clock := testutil.NewQuartzMock(t)
+	testCtx := testutil.DeadlineContext(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	// No writer, so Send reports the transport is gone. That is the ordinary
+	// end of a disconnect, and the loop must return on it rather than on the
+	// context, which stays live for the whole test.
+	c := &Client{clock: clock, lastSendTime: clock.Now()}
+
+	newTicker := clock.Trap().NewTicker(hubHeartbeatTickerTag)
+	defer newTicker.Close()
+	stopTicker := clock.Trap().TickerStop(hubHeartbeatTickerTag)
+	defer stopTicker.Close()
+	idleReads := clock.Trap().Since(hubHeartbeatIdleTag)
+	defer idleReads.Close()
+
+	done := make(chan struct{})
+	go func() {
+		c.heartbeatLoop(ctx)
+		close(done)
+	}()
+	newTicker.MustWait(testCtx).MustRelease(testCtx)
+
+	// Three ticks reach 6s of idle time, which is past the 5s timeout.
+	for range 3 {
+		advance := clock.Advance(2 * time.Second)
+		idleReads.MustWait(testCtx).MustRelease(testCtx)
+		advance.MustWait(testCtx)
+	}
+
+	stopTicker.MustWait(testCtx).MustRelease(testCtx)
+	select {
+	case <-done:
+	case <-testCtx.Done():
+		require.FailNow(t, "the heartbeat loop kept ticking after its send failed")
+	}
+	require.NoError(t, ctx.Err(), "the loop must have ended on the send, not on the context")
+	_, running := clock.Peek()
+	assert.False(t, running, "a loop that gave up must stop its ticker")
 }

--- a/backend/internal/worker/hub/registration.go
+++ b/backend/internal/worker/hub/registration.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	"github.com/coder/quartz"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/generated/proto/leapmux/v1/leapmuxv1connect"
@@ -43,7 +44,33 @@ func Register(ctx context.Context, endpoint *hubtransport.Endpoint, registration
 		endpoint.BaseURL(),
 		connect.WithGRPC(),
 	)
-	return registerWithClient(ctx, client, registrationKey, version, publicKey, mlkemPublicKey, slhdsaPublicKey, newDefaultBackoff(), registerAttemptTimeout)
+	return registerWithClient(ctx, client, registrationKey, version, publicKey, mlkemPublicKey, slhdsaPublicKey, newDefaultRegisterRetry())
+}
+
+const registerRetryTimerTag = "hub-register-retry"
+
+// registerRetry is the retry policy one registration run follows.
+//
+// The three travel as one value rather than as three more parameters on an
+// already long list, because they only make sense together: a caller that
+// shortens the backoff also wants the clock that makes the wait between
+// attempts instant, and the attempt limit is the third dial of the same
+// policy.
+type registerRetry struct {
+	backoff        backoff
+	attemptTimeout time.Duration
+	// clock supplies the wait between attempts. A test drives it, so a
+	// registration ladder costs no wall time and its rungs are exact.
+	clock quartz.Clock
+}
+
+// newDefaultRegisterRetry is the policy Register uses in production.
+func newDefaultRegisterRetry() registerRetry {
+	return registerRetry{
+		backoff:        newDefaultBackoff(),
+		attemptTimeout: registerAttemptTimeout,
+		clock:          quartz.NewReal(),
+	}
 }
 
 func registerWithClient(
@@ -52,8 +79,7 @@ func registerWithClient(
 	registrationKey string,
 	version string,
 	publicKey, mlkemPublicKey, slhdsaPublicKey []byte,
-	bo backoff,
-	attemptTimeout time.Duration,
+	retry registerRetry,
 ) (*RegistrationResult, error) {
 	if registrationKey == "" {
 		return nil, errors.New("registration key is required")
@@ -71,7 +97,7 @@ func registerWithClient(
 		// flow, that one is bound to a different RPC.
 		req.Header().Set("Authorization", "Bearer "+registrationKey)
 
-		resp, err := registerOnce(ctx, client, req, attemptTimeout)
+		resp, err := registerOnce(ctx, client, req, retry.attemptTimeout)
 		if err == nil {
 			// The owner is not recorded here: the Hub delivers it on every Connect
 			// (WorkerIdentity), so the worker never caches a copy that could go stale
@@ -101,12 +127,10 @@ func registerWithClient(
 			}
 		}
 
-		interval := bo.Next()
+		interval := retry.backoff.Next()
 		slog.Warn("hub unavailable, retrying registration...", "error", err, "backoff", interval)
-		select {
-		case <-ctx.Done():
+		if !waitOrCancel(ctx, retry.clock, interval, registerRetryTimerTag) {
 			return nil, ctx.Err()
-		case <-time.After(interval):
 		}
 	}
 }
@@ -124,6 +148,11 @@ func registerWithClient(
 //
 // It is generous: registration is one round trip, but it runs while a hub may
 // still be starting, and the retry costs a fresh key nothing.
+//
+// This limit stays on the CONTEXT rather than on registerRetry.clock, unlike
+// the wait between attempts. context.WithTimeout reads the real clock, and no
+// Quartz clock can drive it, so an attempt limit a test wants to reach must be
+// a short real duration.
 const registerAttemptTimeout = 30 * time.Second
 
 // registerOnce makes one attempt under timeout.

--- a/backend/internal/worker/hub/registration_test.go
+++ b/backend/internal/worker/hub/registration_test.go
@@ -8,12 +8,14 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	"github.com/coder/quartz"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/generated/proto/leapmux/v1/leapmuxv1connect"
 	"github.com/leapmux/leapmux/internal/util/backoffutil"
+	"github.com/leapmux/leapmux/internal/util/testutil"
 )
 
 // mockConnectorClient implements WorkerConnectorServiceClient for
@@ -30,6 +32,16 @@ func (m *mockConnectorClient) Register(ctx context.Context, req *connect.Request
 
 func (m *mockConnectorClient) Connect(_ context.Context) *connect.BidiStreamForClient[leapmuxv1.ConnectRequest, leapmuxv1.ConnectResponse] {
 	return nil
+}
+
+// fastRegisterRetry is the production registration policy with a tiny backoff
+// ladder and the clock the test drives, so a retry costs no wall time.
+func fastRegisterRetry(clock quartz.Clock) registerRetry {
+	return registerRetry{
+		backoff:        newFastBackoff(),
+		attemptTimeout: registerAttemptTimeout,
+		clock:          clock,
+	}
 }
 
 func TestRegisterWithClient_RetriesUntilHubAvailable(t *testing.T) {
@@ -51,15 +63,36 @@ func TestRegisterWithClient_RetriesUntilHubAvailable(t *testing.T) {
 		},
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
+	clock := testutil.NewQuartzMock(t)
+	testCtx := testutil.DeadlineContext(t)
+	newTimer, stopTimer := testutil.NewTimerTraps(t, clock, registerRetryTimerTag)
 
-	result, err := registerWithClient(ctx, mock, "key123", "0.0.1", nil, nil, nil, newFastBackoff(), registerAttemptTimeout)
-	require.NoError(t, err)
+	type outcome struct {
+		result *RegistrationResult
+		err    error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		result, err := registerWithClient(t.Context(), mock, "key123", "0.0.1", nil, nil, nil, fastRegisterRetry(clock))
+		done <- outcome{result: result, err: err}
+	}()
+	for range failCount {
+		delay := testutil.WaitForTimer(t, testCtx, newTimer)
+		testutil.AdvanceAndAwaitStop(t, testCtx, clock, delay, stopTimer)
+	}
 
+	var got outcome
+	select {
+	case got = <-done:
+	case <-testCtx.Done():
+		require.FailNow(t, "registration never returned after the hub came back")
+	}
+	require.NoError(t, got.err)
 	assert.Equal(t, int32(failCount+1), attempts.Load(), "Register call count")
-	assert.Equal(t, "worker-123", result.WorkerID)
-	assert.Equal(t, "auth-token-abc", result.AuthToken)
+	assert.Equal(t, "worker-123", got.result.WorkerID)
+	assert.Equal(t, "auth-token-abc", got.result.AuthToken)
+	_, running := clock.Peek()
+	assert.False(t, running, "the successful attempt must leave no retry armed")
 }
 
 func TestRegisterWithClient_RejectsEmptyKey(t *testing.T) {
@@ -69,8 +102,11 @@ func TestRegisterWithClient_RejectsEmptyKey(t *testing.T) {
 			return nil, nil
 		},
 	}
-	_, err := registerWithClient(context.Background(), mock, "", "v", nil, nil, nil, newFastBackoff(), registerAttemptTimeout)
+	clock := testutil.NewQuartzMock(t)
+	_, err := registerWithClient(t.Context(), mock, "", "v", nil, nil, nil, fastRegisterRetry(clock))
 	require.Error(t, err)
+	_, running := clock.Peek()
+	assert.False(t, running, "a missing key is permanent, so it must arm no retry")
 }
 
 func TestRegisterWithClient_StopsOnContextCancel(t *testing.T) {
@@ -83,15 +119,35 @@ func TestRegisterWithClient_StopsOnContextCancel(t *testing.T) {
 		},
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	clock := testutil.NewQuartzMock(t)
+	testCtx := testutil.DeadlineContext(t)
+	newTimer, stopTimer := testutil.NewTimerTraps(t, clock, registerRetryTimerTag)
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	errCh := make(chan error, 1)
 	go func() {
-		time.Sleep(20 * time.Millisecond)
-		cancel()
+		_, err := registerWithClient(ctx, mock, "k", "0.0.1", nil, nil, nil, fastRegisterRetry(clock))
+		errCh <- err
 	}()
 
-	_, err := registerWithClient(ctx, mock, "k", "0.0.1", nil, nil, nil, newFastBackoff(), registerAttemptTimeout)
-	assert.ErrorIs(t, err, context.Canceled)
-	assert.GreaterOrEqual(t, attempts.Load(), int32(1))
+	// The first attempt failed and its retry is armed. Cancelling HERE lands
+	// strictly inside the backoff window, which the sleep this replaces could
+	// only approximate -- and the exact attempt count below is what that
+	// certainty buys: the loop must stop without a second attempt.
+	_ = testutil.WaitForTimer(t, testCtx, newTimer)
+	cancel()
+	stopTimer.MustWait(testCtx).MustRelease(testCtx)
+
+	select {
+	case err := <-errCh:
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-testCtx.Done():
+		require.FailNow(t, "registration ignored the cancelled context and waited out its backoff")
+	}
+	assert.Equal(t, int32(1), attempts.Load(), "cancellation must stop before a second attempt")
+	_, running := clock.Peek()
+	assert.False(t, running, "cancellation must release the retry timer")
 }
 
 func TestRegisterWithClient_DoesNotRetryUnauthenticated(t *testing.T) {
@@ -105,28 +161,23 @@ func TestRegisterWithClient_DoesNotRetryUnauthenticated(t *testing.T) {
 			return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("nope"))
 		},
 	}
-	_, err := registerWithClient(context.Background(), mock, "k", "v", nil, nil, nil, newFastBackoff(), registerAttemptTimeout)
+	clock := testutil.NewQuartzMock(t)
+	_, err := registerWithClient(t.Context(), mock, "k", "v", nil, nil, nil, fastRegisterRetry(clock))
 	require.Error(t, err)
 	assert.Equal(t, int32(1), attempts.Load(), "Unauthenticated must not be retried")
+	_, running := clock.Peek()
+	assert.False(t, running, "a permanent rejection must arm no retry timer")
 }
 
-// recordingBackoff records each Next result so tests can assert
-// on the values requested rather than wall-clock elapsed time, which is
-// noisy on Windows where the scheduler tick (~15.6ms) dwarfs 10ms sleeps.
-type recordingBackoff struct {
-	inner     *backoffutil.Backoff
-	intervals []time.Duration
-}
-
-func (r *recordingBackoff) Next() time.Duration {
-	d := r.inner.Next()
-	r.intervals = append(r.intervals, d)
-	return d
-}
-
-func (r *recordingBackoff) Reset() { r.inner.Reset() }
-
-func TestRegisterWithClient_BackoffIncreases(t *testing.T) {
+// TestRegisterWithClient_BackoffFollowsItsLadder pins the interval sequence the
+// retry policy asks for, rung by rung.
+//
+// The delays the code REQUESTED, never the gaps they produced: a measured gap
+// carries the host's timer granularity too, about 15.6ms on Windows, which
+// dwarfs the 10ms first rung. That is why this used to assert only that the
+// sequence never decreased -- an assertion a policy stuck at one interval also
+// satisfies.
+func TestRegisterWithClient_BackoffFollowsItsLadder(t *testing.T) {
 	var attempts atomic.Int32
 	failCount := 4
 
@@ -140,20 +191,40 @@ func TestRegisterWithClient_BackoffIncreases(t *testing.T) {
 		},
 	}
 
-	inner := backoffutil.NewBackoff(10*time.Millisecond, 100*time.Millisecond, 0)
-	rec := &recordingBackoff{inner: inner}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	_, err := registerWithClient(ctx, mock, "k", "0.0.1", nil, nil, nil, rec, registerAttemptTimeout)
-	require.NoError(t, err)
-
-	require.Len(t, rec.intervals, failCount,
-		"expected one backoff interval per failed attempt")
-	for i := 1; i < len(rec.intervals); i++ {
-		assert.GreaterOrEqual(t, rec.intervals[i], rec.intervals[i-1])
+	clock := testutil.NewQuartzMock(t)
+	testCtx := testutil.DeadlineContext(t)
+	newTimer, stopTimer := testutil.NewTimerTraps(t, clock, registerRetryTimerTag)
+	// Zero jitter, so the ladder below is the one the policy states.
+	retry := registerRetry{
+		backoff:        backoffutil.NewBackoff(10*time.Millisecond, 100*time.Millisecond, 0),
+		attemptTimeout: registerAttemptTimeout,
+		clock:          clock,
 	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := registerWithClient(t.Context(), mock, "k", "0.0.1", nil, nil, nil, retry)
+		errCh <- err
+	}()
+	want := []time.Duration{
+		10 * time.Millisecond,
+		20 * time.Millisecond,
+		40 * time.Millisecond,
+		80 * time.Millisecond,
+	}
+	for i, expected := range want {
+		delay := testutil.WaitForTimer(t, testCtx, newTimer)
+		assert.Equal(t, expected, delay, "backoff interval %d", i+1)
+		testutil.AdvanceAndAwaitStop(t, testCtx, clock, delay, stopTimer)
+	}
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-testCtx.Done():
+		require.FailNow(t, "registration never returned after its backoff ladder")
+	}
+	assert.Equal(t, int32(failCount+1), attempts.Load(), "one attempt per rung, then the success")
 }
 
 // TestRegisterWithClient_LimitsOneAttempt pins the limit that keeps a stalled
@@ -164,6 +235,10 @@ func TestRegisterWithClient_BackoffIncreases(t *testing.T) {
 // whose body ends only when the stream does. The retry loop sits BELOW the
 // call, so before this an attempt that never returned took the loop with it,
 // and `leapmux worker` hung at startup for ever with no retry and no log line.
+//
+// The attempt limit is a real 20ms here, not a mocked one: it is a context
+// deadline, and context.WithTimeout reads the real clock. Only the wait
+// BETWEEN attempts is on the test's clock.
 func TestRegisterWithClient_LimitsOneAttempt(t *testing.T) {
 	var attempts atomic.Int32
 	var sawDeadline atomic.Bool
@@ -185,12 +260,35 @@ func TestRegisterWithClient_LimitsOneAttempt(t *testing.T) {
 		},
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	result, err := registerWithClient(ctx, mock, "key123", "0.0.1", nil, nil, nil, newFastBackoff(), 20*time.Millisecond)
+	clock := testutil.NewQuartzMock(t)
+	testCtx := testutil.DeadlineContext(t)
+	newTimer, stopTimer := testutil.NewTimerTraps(t, clock, registerRetryTimerTag)
+	retry := registerRetry{
+		backoff:        newFastBackoff(),
+		attemptTimeout: 20 * time.Millisecond,
+		clock:          clock,
+	}
 
-	require.NoError(t, err, "a stalled attempt must end and let the retry run")
-	assert.Equal(t, "w-1", result.WorkerID)
+	type outcome struct {
+		result *RegistrationResult
+		err    error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		result, err := registerWithClient(t.Context(), mock, "key123", "0.0.1", nil, nil, nil, retry)
+		done <- outcome{result: result, err: err}
+	}()
+	delay := testutil.WaitForTimer(t, testCtx, newTimer)
+	testutil.AdvanceAndAwaitStop(t, testCtx, clock, delay, stopTimer)
+
+	var got outcome
+	select {
+	case got = <-done:
+	case <-testCtx.Done():
+		require.FailNow(t, "the stalled attempt never ended")
+	}
+	require.NoError(t, got.err, "a stalled attempt must end and let the retry run")
+	assert.Equal(t, "w-1", got.result.WorkerID)
 	assert.True(t, sawDeadline.Load(), "each attempt must carry its own deadline")
 	assert.EqualValues(t, 2, attempts.Load(), "the stalled attempt is abandoned and retried exactly once")
 }
@@ -198,7 +296,7 @@ func TestRegisterWithClient_LimitsOneAttempt(t *testing.T) {
 // The per-attempt limit must not swallow the CALLER's cancellation: a worker
 // shutting down during registration still stops rather than retrying.
 func TestRegisterWithClient_AttemptLimitDoesNotHideCallerCancel(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	mock := &mockConnectorClient{
 		registerFn: func(ctx context.Context, _ *connect.Request[leapmuxv1.RegisterRequest]) (*connect.Response[leapmuxv1.RegisterResponse], error) {
 			cancel()
@@ -207,7 +305,15 @@ func TestRegisterWithClient_AttemptLimitDoesNotHideCallerCancel(t *testing.T) {
 		},
 	}
 
-	_, err := registerWithClient(ctx, mock, "k", "0.0.1", nil, nil, nil, newFastBackoff(), time.Minute)
+	clock := testutil.NewQuartzMock(t)
+	retry := registerRetry{
+		backoff:        newFastBackoff(),
+		attemptTimeout: time.Minute,
+		clock:          clock,
+	}
+	_, err := registerWithClient(ctx, mock, "k", "0.0.1", nil, nil, nil, retry)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.Canceled)
+	_, running := clock.Peek()
+	assert.False(t, running, "a cancelled caller must not leave a retry armed")
 }

--- a/backend/internal/worker/hub/shutdown_test.go
+++ b/backend/internal/worker/hub/shutdown_test.go
@@ -11,10 +11,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/util/testutil"
 )
 
 func TestHandleHubShuttingDown_StoresDelay(t *testing.T) {
-	c := &Client{}
+	c := newBareClient()
 
 	c.handleHubShuttingDown(&leapmuxv1.HubShuttingDownNotification{
 		RetryDelaySeconds: 15,
@@ -24,7 +25,7 @@ func TestHandleHubShuttingDown_StoresDelay(t *testing.T) {
 }
 
 func TestHandleHubShuttingDown_OverwritesPreviousDelay(t *testing.T) {
-	c := &Client{}
+	c := newBareClient()
 
 	c.handleHubShuttingDown(&leapmuxv1.HubShuttingDownNotification{
 		RetryDelaySeconds: 10,
@@ -38,10 +39,13 @@ func TestHandleHubShuttingDown_OverwritesPreviousDelay(t *testing.T) {
 
 func TestConnectWithReconnect_HubRetryDelayApplied(t *testing.T) {
 	var attempts atomic.Int32
-	var timestamps []time.Time
 
-	client := &Client{}
+	clock := testutil.NewQuartzMock(t)
+	client := &Client{clock: clock}
+	testCtx := testutil.DeadlineContext(t)
 	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	newTimer, stopTimer := testutil.NewTimerTraps(t, clock, hubRequestedRetryTimerTag)
 
 	// Simulate hub setting a retry delay of 100ms (scaled down for testing).
 	// We set the delay before the first connect call, as if the hub sent
@@ -50,7 +54,6 @@ func TestConnectWithReconnect_HubRetryDelayApplied(t *testing.T) {
 
 	mockConnect := func(_ context.Context, _ string) error {
 		n := attempts.Add(1)
-		timestamps = append(timestamps, time.Now())
 
 		if n == 1 {
 			// First connection: simulate hub sending shutdown notification.
@@ -64,30 +67,38 @@ func TestConnectWithReconnect_HubRetryDelayApplied(t *testing.T) {
 	}
 
 	bo := newFastBackoff()
-	client.connectWithReconnect(ctx, "token", mockConnect, bo, 5*time.Millisecond)
-
-	require.GreaterOrEqual(t, len(timestamps), 2, "expected at least 2 connect attempts")
-
-	// The gap between attempt 1 and 2 should be at least ~1 second (the retry delay),
-	// not just the fast backoff interval.
-	gap := timestamps[1].Sub(timestamps[0])
-	assert.GreaterOrEqual(t, gap, 900*time.Millisecond,
-		"gap should be at least ~1 second due to hub retry delay, got %v", gap)
+	done := make(chan struct{})
+	go func() {
+		client.connectWithReconnect(ctx, "token", mockConnect, bo, 5*time.Millisecond)
+		close(done)
+	}()
+	delay := testutil.WaitForTimer(t, testCtx, newTimer)
+	assert.Equal(t, time.Second, delay)
+	testutil.AdvanceAndAwaitStop(t, testCtx, clock, delay, stopTimer)
+	select {
+	case <-done:
+	case <-testCtx.Done():
+		require.FailNow(t, "the Hub retry delay did not lead to the second attempt")
+	}
+	assert.Equal(t, int32(2), attempts.Load())
 }
 
 func TestConnectWithReconnect_HubRetryDelayConsumedOnce(t *testing.T) {
 	var attempts atomic.Int32
-	var timestamps []time.Time
 
-	client := &Client{}
+	clock := testutil.NewQuartzMock(t)
+	client := &Client{clock: clock}
+	testCtx := testutil.DeadlineContext(t)
 	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	newHubTimer, stopHubTimer := testutil.NewTimerTraps(t, clock, hubRequestedRetryTimerTag)
+	newBackoffTimer, stopBackoffTimer := testutil.NewTimerTraps(t, clock, hubReconnectTimerTag)
 
 	// Pre-set the retry delay as if it was received during a previous connection.
 	client.hubRetryDelay.Store(1) // 1 second
 
 	mockConnect := func(_ context.Context, _ string) error {
 		n := attempts.Add(1)
-		timestamps = append(timestamps, time.Now())
 
 		if n >= 3 {
 			cancel()
@@ -96,31 +107,39 @@ func TestConnectWithReconnect_HubRetryDelayConsumedOnce(t *testing.T) {
 	}
 
 	bo := newFastBackoff()
-	client.connectWithReconnect(ctx, "token", mockConnect, bo, 5*time.Millisecond)
-
-	require.GreaterOrEqual(t, len(timestamps), 3, "expected at least 3 connect attempts")
-
-	// First gap: should include the 1-second retry delay.
-	gap1 := timestamps[1].Sub(timestamps[0])
-	assert.GreaterOrEqual(t, gap1, 900*time.Millisecond,
-		"first gap should include retry delay, got %v", gap1)
-
-	// Second gap: delay was consumed, so should fall back to fast backoff (< 100ms).
-	gap2 := timestamps[2].Sub(timestamps[1])
-	assert.Less(t, gap2, 100*time.Millisecond,
-		"second gap should use normal backoff (delay consumed), got %v", gap2)
+	done := make(chan struct{})
+	go func() {
+		client.connectWithReconnect(ctx, "token", mockConnect, bo, 5*time.Millisecond)
+		close(done)
+	}()
+	hubDelay := testutil.WaitForTimer(t, testCtx, newHubTimer)
+	assert.Equal(t, time.Second, hubDelay)
+	testutil.AdvanceAndAwaitStop(t, testCtx, clock, hubDelay, stopHubTimer)
+	backoffDelay := testutil.WaitForTimer(t, testCtx, newBackoffTimer)
+	assert.Equal(t, time.Millisecond, backoffDelay,
+		"the consumed Hub delay must give the next failure to normal backoff")
+	testutil.AdvanceAndAwaitStop(t, testCtx, clock, backoffDelay, stopBackoffTimer)
+	select {
+	case <-done:
+	case <-testCtx.Done():
+		require.FailNow(t, "the reconnect loop did not consume the Hub delay once")
+	}
+	assert.Equal(t, int32(3), attempts.Load())
 }
 
 func TestConnectWithReconnect_HubRetryDelayResetsBackoff(t *testing.T) {
 	var attempts atomic.Int32
-	var timestamps []time.Time
 
-	client := &Client{}
+	clock := testutil.NewQuartzMock(t)
+	client := &Client{clock: clock}
+	testCtx := testutil.DeadlineContext(t)
 	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	newHubTimer, stopHubTimer := testutil.NewTimerTraps(t, clock, hubRequestedRetryTimerTag)
+	newBackoffTimer, stopBackoffTimer := testutil.NewTimerTraps(t, clock, hubReconnectTimerTag)
 
 	mockConnect := func(_ context.Context, _ string) error {
 		n := attempts.Add(1)
-		timestamps = append(timestamps, time.Now())
 
 		switch n {
 		case 1:
@@ -143,21 +162,40 @@ func TestConnectWithReconnect_HubRetryDelayResetsBackoff(t *testing.T) {
 	}
 
 	bo := newFastBackoff()
-	client.connectWithReconnect(ctx, "token", mockConnect, bo, 5*time.Millisecond)
-
-	require.GreaterOrEqual(t, len(timestamps), 6)
-
-	// Gap between 5 and 6 should be small (reset backoff), not escalated.
-	gap56 := timestamps[5].Sub(timestamps[4])
-	assert.Less(t, gap56, 50*time.Millisecond,
-		"backoff should be reset after hub retry delay, got %v", gap56)
+	done := make(chan struct{})
+	go func() {
+		client.connectWithReconnect(ctx, "token", mockConnect, bo, 5*time.Millisecond)
+		close(done)
+	}()
+	for i, expected := range []time.Duration{time.Millisecond, 2 * time.Millisecond, 4 * time.Millisecond} {
+		delay := testutil.WaitForTimer(t, testCtx, newBackoffTimer)
+		assert.Equal(t, expected, delay, "backoff delay %d", i+1)
+		testutil.AdvanceAndAwaitStop(t, testCtx, clock, delay, stopBackoffTimer)
+	}
+	hubDelay := testutil.WaitForTimer(t, testCtx, newHubTimer)
+	assert.Equal(t, time.Second, hubDelay)
+	testutil.AdvanceAndAwaitStop(t, testCtx, clock, hubDelay, stopHubTimer)
+	delayAfterReset := testutil.WaitForTimer(t, testCtx, newBackoffTimer)
+	assert.Equal(t, time.Millisecond, delayAfterReset,
+		"a Hub-requested delay must reset normal backoff")
+	testutil.AdvanceAndAwaitStop(t, testCtx, clock, delayAfterReset, stopBackoffTimer)
+	select {
+	case <-done:
+	case <-testCtx.Done():
+		require.FailNow(t, "the reconnect loop did not stop after the reset sequence")
+	}
+	assert.Equal(t, int32(6), attempts.Load())
 }
 
 func TestConnectWithReconnect_HubRetryDelayCancelledByContext(t *testing.T) {
 	var attempts atomic.Int32
 
-	client := &Client{}
+	clock := testutil.NewQuartzMock(t)
+	client := &Client{clock: clock}
+	testCtx := testutil.DeadlineContext(t)
 	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	newTimer, stopTimer := testutil.NewTimerTraps(t, clock, hubRequestedRetryTimerTag)
 
 	// Pre-set a large retry delay.
 	client.hubRetryDelay.Store(60) // 60 seconds -- should not actually wait this long
@@ -167,33 +205,27 @@ func TestConnectWithReconnect_HubRetryDelayCancelledByContext(t *testing.T) {
 		return fmt.Errorf("fail")
 	}
 
-	// Cancel after a short time.
-	go func() {
-		time.Sleep(100 * time.Millisecond)
-		cancel()
-	}()
-
-	// Exiting on ctx cancel rather than the 60s reconnect delay, asserted as a
-	// COMPLETION against a generous guard: the failing case blocks for a full
-	// minute, so a guard catches it just as surely as a 2s budget and cannot be
-	// crossed by machine load. The attempt count below is the other half of the
-	// proof -- a run that waited out the delay would have retried.
 	returned := make(chan struct{})
 	go func() {
 		defer close(returned)
 		bo := newFastBackoff()
 		client.connectWithReconnect(ctx, "token", mockConnect, bo, 5*time.Millisecond)
 	}()
+	assert.Equal(t, 60*time.Second, testutil.WaitForTimer(t, testCtx, newTimer))
+	cancel()
+	stopTimer.MustWait(testCtx).MustRelease(testCtx)
 	select {
 	case <-returned:
-	case <-time.After(20 * time.Second):
+	case <-testCtx.Done():
 		t.Fatal("connectWithReconnect ignored the cancelled context and waited on its reconnect delay")
 	}
+	_, running := clock.Peek()
+	assert.False(t, running, "context cancellation must stop the Hub retry timer")
 	assert.Equal(t, int32(1), attempts.Load(), "expected exactly 1 attempt before cancel")
 }
 
 func TestHandleMessage_HubShuttingDown(t *testing.T) {
-	c := &Client{}
+	c := newBareClient()
 
 	msg := &leapmuxv1.ConnectResponse{
 		Payload: &leapmuxv1.ConnectResponse_HubShuttingDown{

--- a/backend/internal/worker/service/agent_auto_start_test.go
+++ b/backend/internal/worker/service/agent_auto_start_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/util/testutil"
 	"github.com/leapmux/leapmux/internal/worker/agent"
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
 )
@@ -365,12 +366,16 @@ func TestSendAgentMessage_DuringAnOpenStartupIsDelivered(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	svc, d, w := setupTestService(t)
-	// A fake clock, so the assertion that the handler WAITS cannot lose to a
-	// real timer, and a regression that refuses again fails in milliseconds
+	// Quartz controls the timer, so the assertion that the handler waits cannot
+	// lose to real time. A regression that refuses again fails immediately
 	// rather than after the whole startup budget.
-	clock := newFakeStartupClock()
-	svc.AgentStartup.clock = clock
+	clock := testutil.NewQuartzMock(t)
+	svc, d, w := setupTestService(t, withClock(clock))
+	testCtx := testutil.DeadlineContext(t)
+	newTimer := clock.Trap().NewTimer(startupAwaitTimerTag)
+	defer newTimer.Close()
+	stopTimer := clock.Trap().TimerStop(startupAwaitTimerTag)
+	defer stopTimer.Close()
 
 	// A start that REGISTERS in the manager, not a stub that returns success and
 	// leaves it empty: the delivery this test is about is the SendInput that
@@ -397,7 +402,9 @@ func TestSendAgentMessage_DuringAnOpenStartupIsDelivered(t *testing.T) {
 		}, w)
 	}()
 
-	clock.waitArmed(t)
+	call := newTimer.MustWait(testCtx)
+	assert.Equal(t, svc.agentAPITimeout(), call.Duration)
+	call.MustRelease(testCtx)
 	select {
 	case <-sent:
 		require.FailNow(t, "the send answered while the tab's own startup was still running")
@@ -405,12 +412,13 @@ func TestSendAgentMessage_DuringAnOpenStartupIsDelivered(t *testing.T) {
 	}
 
 	// The open path finishes and hands over its process.
-	svc.AgentStartup.succeed("agent-1", nil)
+	svc.AgentStartup.succeed("agent-1", openHandle)
 	svc.AgentStartup.finishEntry(openHandle)
+	stopTimer.MustWait(testCtx).MustRelease(testCtx)
 
 	select {
 	case <-sent:
-	case <-time.After(10 * time.Second):
+	case <-testCtx.Done():
 		require.FailNow(t, "the send never resumed after the startup it waited for finished")
 	}
 	require.Empty(t, w.errors)

--- a/backend/internal/worker/service/agent_control_ipc_test.go
+++ b/backend/internal/worker/service/agent_control_ipc_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/util/testutil"
 	"github.com/leapmux/leapmux/internal/util/userid"
 	"github.com/leapmux/leapmux/internal/worker/agent"
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
@@ -710,18 +711,22 @@ func TestRemintControlIPC_AFailedMintStillReleasesTheDelegation(t *testing.T) {
 // PERMANENT startup failure. A message that lands in that window used to spawn a
 // second process for the same tab, and its begin() overwrote the open's registry
 // entry, so a later CloseAgent cancelled the wrong context. The claim is what
-// stops that; this test drives the wait past its bound to reach it.
+// stops that; this test drives the wait past its limit to reach it.
 func TestEnsureAgentRunning_RefusesWhileAnotherStartupHoldsTheAgent(t *testing.T) {
 	t.Parallel()
 
-	svc, _, _ := setupTestService(t)
+	// Quartz makes the limit cost no wall time. Its trap also proves that the
+	// caller waits before it gives up.
+	clock := testutil.NewQuartzMock(t)
+	svc, _, _ := setupTestService(t, withClock(clock))
 	rec := newStartRecorder()
 	rec.install(svc)
 	seedOpenAgent(t, svc, "agent-1", true)
-	// A fake clock, so the give-up costs no wall time and the assertion below
-	// about the caller WAITING first cannot lose to a real timer.
-	clock := newFakeStartupClock()
-	svc.AgentStartup.clock = clock
+	ctx := testutil.DeadlineContext(t)
+	newTimer := clock.Trap().NewTimer(startupAwaitTimerTag)
+	defer newTimer.Close()
+	stopTimer := clock.Trap().TimerStop(startupAwaitTimerTag)
+	defer stopTimer.Close()
 
 	// Stand in for the open path's in-flight startup.
 	openCtx, openCancel := context.WithCancel(context.Background())
@@ -738,8 +743,10 @@ func TestEnsureAgentRunning_RefusesWhileAnotherStartupHoldsTheAgent(t *testing.T
 	// at roughly 1.5x the API timeout -- so a wait armed for the five-minute
 	// startup timeout would report a send as failed that this worker goes on to
 	// deliver, under a Retry button that then sends it twice.
-	assert.Equal(t, svc.agentAPITimeout(), clock.waitArmed(t),
+	call := newTimer.MustWait(ctx)
+	assert.Equal(t, svc.agentAPITimeout(), call.Duration,
 		"the wait must end inside the budget the client gives the RPC that holds it")
+	call.MustRelease(ctx)
 	assert.Less(t, svc.agentAPITimeout(), svc.agentStartupTimeout(),
 		"a wait as long as the whole startup budget is the defect this assertion exists to prevent")
 	select {
@@ -748,12 +755,14 @@ func TestEnsureAgentRunning_RefusesWhileAnotherStartupHoldsTheAgent(t *testing.T
 	default:
 	}
 
-	clock.fire(t)
+	advance := clock.Advance(svc.agentAPITimeout())
+	stopTimer.MustWait(ctx).MustRelease(ctx)
+	advance.MustWait(ctx)
 	select {
 	case err := <-errCh:
 		require.Error(t, err,
 			"a cold start ran while another startup held the agent; that spawns a second process for one tab")
-	case <-time.After(10 * time.Second):
+	case <-ctx.Done():
 		require.FailNow(t, "the wait outlived its own limit")
 	}
 	assert.Empty(t, rec.ids())
@@ -776,12 +785,16 @@ func TestEnsureAgentRunning_RefusesWhileAnotherStartupHoldsTheAgent(t *testing.T
 func TestEnsureAgentRunning_WaitsForTheStartupThatHoldsTheAgent(t *testing.T) {
 	t.Parallel()
 
-	svc, _, _ := setupTestService(t)
+	clock := testutil.NewQuartzMock(t)
+	svc, _, _ := setupTestService(t, withClock(clock))
 	rec := newStartRecorder()
 	rec.install(svc)
 	seedOpenAgent(t, svc, "agent-1", true)
-	clock := newFakeStartupClock()
-	svc.AgentStartup.clock = clock
+	ctx := testutil.DeadlineContext(t)
+	newTimer := clock.Trap().NewTimer(startupAwaitTimerTag)
+	defer newTimer.Close()
+	stopTimer := clock.Trap().TimerStop(startupAwaitTimerTag)
+	defer stopTimer.Close()
 
 	openHandle := svc.AgentStartup.begin("agent-1", func() {})
 	require.NotNil(t, openHandle)
@@ -789,17 +802,20 @@ func TestEnsureAgentRunning_WaitsForTheStartupThatHoldsTheAgent(t *testing.T) {
 	errCh := make(chan error, 1)
 	go func() { errCh <- svc.ensureAgentRunning("agent-1", nil, interactiveStart) }()
 
-	clock.waitArmed(t)
+	call := newTimer.MustWait(ctx)
+	assert.Equal(t, svc.agentAPITimeout(), call.Duration)
+	call.MustRelease(ctx)
 	assert.Empty(t, rec.ids(), "it must not spawn a second process for the tab that is already starting")
 
 	// The open path finishes.
-	svc.AgentStartup.succeed("agent-1", nil)
+	svc.AgentStartup.succeed("agent-1", openHandle)
 	svc.AgentStartup.finishEntry(openHandle)
+	stopTimer.MustWait(ctx).MustRelease(ctx)
 
 	select {
 	case err := <-errCh:
 		require.NoError(t, err, "the startup it waited for finished, so the message has a process to reach")
-	case <-time.After(10 * time.Second):
+	case <-ctx.Done():
 		require.FailNow(t, "the caller never resumed after the startup it waited for finished")
 	}
 	assert.Equal(t, []string{"agent-1"}, rec.ids(),
@@ -814,12 +830,11 @@ func TestEnsureAgentRunning_WaitsForTheStartupThatHoldsTheAgent(t *testing.T) {
 func TestEnsureAgentRunning_BackgroundStartDoesNotWaitForAnotherStartup(t *testing.T) {
 	t.Parallel()
 
-	svc, _, _ := setupTestService(t)
+	clock := testutil.NewQuartzMock(t)
+	svc, _, _ := setupTestService(t, withClock(clock))
 	rec := newStartRecorder()
 	rec.install(svc)
 	seedOpenAgent(t, svc, "agent-1", true)
-	clock := newFakeStartupClock()
-	svc.AgentStartup.clock = clock
 
 	openHandle := svc.AgentStartup.begin("agent-1", func() {})
 	require.NotNil(t, openHandle)
@@ -828,9 +843,8 @@ func TestEnsureAgentRunning_BackgroundStartDoesNotWaitForAnotherStartup(t *testi
 	require.Error(t, svc.ensureAgentRunning("agent-1", nil, backgroundStart))
 	assert.Empty(t, rec.ids())
 
-	clock.mu.Lock()
-	defer clock.mu.Unlock()
-	assert.Empty(t, clock.timers, "the sweep must not wait on a startup that is already doing its work")
+	_, running := clock.Peek()
+	assert.False(t, running, "the sweep must not wait on a startup that is already doing its work")
 }
 
 // TestEnsureAgentRunning_RefusesWhenACloseEndedTheStartupItWaitedFor pins the
@@ -844,12 +858,16 @@ func TestEnsureAgentRunning_BackgroundStartDoesNotWaitForAnotherStartup(t *testi
 func TestEnsureAgentRunning_RefusesWhenACloseEndedTheStartupItWaitedFor(t *testing.T) {
 	t.Parallel()
 
-	svc, _, _ := setupTestService(t)
+	clock := testutil.NewQuartzMock(t)
+	svc, _, _ := setupTestService(t, withClock(clock))
 	rec := newStartRecorder()
 	rec.install(svc)
 	seedOpenAgent(t, svc, "agent-1", true)
-	clock := newFakeStartupClock()
-	svc.AgentStartup.clock = clock
+	ctx := testutil.DeadlineContext(t)
+	newTimer := clock.Trap().NewTimer(startupAwaitTimerTag)
+	defer newTimer.Close()
+	stopTimer := clock.Trap().TimerStop(startupAwaitTimerTag)
+	defer stopTimer.Close()
 
 	// Stand in for the open path's in-flight startup.
 	openHandle := svc.AgentStartup.begin("agent-1", func() {})
@@ -858,11 +876,14 @@ func TestEnsureAgentRunning_RefusesWhenACloseEndedTheStartupItWaitedFor(t *testi
 
 	errCh := make(chan error, 1)
 	go func() { errCh <- svc.ensureAgentRunning("agent-1", nil, interactiveStart) }()
-	clock.waitArmed(t)
+	call := newTimer.MustWait(ctx)
+	assert.Equal(t, svc.agentAPITimeout(), call.Duration)
+	call.MustRelease(ctx)
 
 	// The user closes the tab. The row still reads OPEN at this point, exactly
 	// as it does for the whole of the close's own teardown.
 	svc.AgentStartup.cancelAndClear("agent-1", keepWorktreeOnClose)
+	stopTimer.MustWait(ctx).MustRelease(ctx)
 	row := requireAgentRow(t, svc, "agent-1")
 	require.False(t, row.ClosedAt.Valid,
 		"the premise: the close has not stamped closed_at yet, so that guard cannot carry this")
@@ -870,7 +891,7 @@ func TestEnsureAgentRunning_RefusesWhenACloseEndedTheStartupItWaitedFor(t *testi
 	select {
 	case err := <-errCh:
 		require.Error(t, err, "a close ended the startup, so there is no process to wait for and none to start")
-	case <-time.After(10 * time.Second):
+	case <-ctx.Done():
 		require.FailNow(t, "the caller never resumed after the close released it")
 	}
 	assert.Empty(t, rec.ids(),

--- a/backend/internal/worker/service/closed_tab_test.go
+++ b/backend/internal/worker/service/closed_tab_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/coder/quartz"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
@@ -186,6 +187,15 @@ type setupOption func(*setupConfig)
 type setupConfig struct {
 	remoteIPC    ControlIPCFactory
 	rewriteQuery func(string) string
+	clock        quartz.Clock
+}
+
+// withClock installs the clock the Service's startup registries arm their
+// timers on, through Config, so a test never writes svc.AgentStartup.clock
+// after construction. Those registries read the field without their own mutex,
+// so a write that lands after the first begin() is a data race.
+func withClock(clock quartz.Clock) setupOption {
+	return func(c *setupConfig) { c.clock = clock }
 }
 
 // withRemoteIPC wires the worker's RemoteIPC factory before handlers are
@@ -291,6 +301,7 @@ func setupTestService(t *testing.T, opts ...setupOption) (*Service, *channel.Dis
 		// only them. In production this arrives from the Hub's
 		// connect-time WorkerIdentity rather than at construction.
 		SeedRegisteredBy: "user-1",
+		Clock:            cfg.clock,
 	})
 	svc.ControlIPC = cfg.remoteIPC
 	// Before RegisterAll, exactly like every other field of Service: the

--- a/backend/internal/worker/service/service.go
+++ b/backend/internal/worker/service/service.go
@@ -18,6 +18,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/coder/quartz"
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/worker/bgtask"
 
@@ -529,6 +530,14 @@ type Config struct {
 	// and ReadFile's maxReadLimit; other stream sends still reject at
 	// sendEncrypted when the reassembled frame exceeds the negotiated gate.
 	MaxMessageSize int
+	// Clock supplies the two startup registries' timers. Nil installs the real
+	// clock.
+	//
+	// bootstrap.Wire passes the Client's clock, so the reader-drain grace inside
+	// a tab's terminal and that same tab's pending-resize wait run on ONE clock.
+	// Built here instead, they would run on two, and a test could drive only the
+	// half it reached.
+	Clock quartz.Clock
 }
 
 // New creates a fully wired Service.
@@ -553,6 +562,12 @@ func New(cfg Config) *Service {
 		panic("service.New: Send must be set")
 	}
 
+	// Written back into cfg before the copy below, so Service.Clock reads the
+	// installed clock rather than nil.
+	if cfg.Clock == nil {
+		cfg.Clock = quartz.NewReal()
+	}
+
 	queries := db.New(cfg.DB)
 	watchers := NewWatcherManager()
 	output := NewOutputHandler(cfg.DB, queries, watchers, cfg.Agents, cfg.WakeLock)
@@ -562,8 +577,8 @@ func New(cfg Config) *Service {
 		Queries:         queries,
 		Watchers:        watchers,
 		Output:          output,
-		AgentStartup:    newAgentStartupRegistry(),
-		TerminalStartup: newTerminalStartupRegistry(),
+		AgentStartup:    newAgentStartupRegistry(cfg.Clock),
+		TerminalStartup: newTerminalStartupRegistry(cfg.Clock),
 		PrivateEvents:   NewPrivateEventsBus(),
 		lastBellAt:      make(map[string]time.Time),
 	}

--- a/backend/internal/worker/service/service_test.go
+++ b/backend/internal/worker/service/service_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/coder/quartz"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -294,6 +295,7 @@ func TestNew_CarriesEveryConfigField(t *testing.T) {
 		UseLoginShell:       true,
 		WakeLock:            wakelock.NewActivityTracker(),
 		MaxMessageSize:      32 << 20,
+		Clock:               quartz.NewReal(),
 	}
 
 	v := reflect.ValueOf(cfg)
@@ -311,6 +313,7 @@ func TestNew_CarriesEveryConfigField(t *testing.T) {
 	assert.Same(t, cfg.Terminals, svc.Terminals)
 	assert.Same(t, cfg.Channels, svc.Channels)
 	assert.Same(t, cfg.WakeLock, svc.WakeLock)
+	assert.Equal(t, cfg.Clock, svc.Clock)
 	assert.Equal(t, "/home/x", svc.HomeDir)
 	assert.Equal(t, "/data/x", svc.DataDir)
 	assert.Equal(t, "worker-1", svc.WorkerID)

--- a/backend/internal/worker/service/startup_error_persist_test.go
+++ b/backend/internal/worker/service/startup_error_persist_test.go
@@ -31,7 +31,8 @@ func TestDeriveAgentStatus_AllBranches(t *testing.T) {
 	dbAgent := db.Agent{ID: "agent-1"}
 
 	// 1. Runtime ACTIVE: isRunning=true wins over everything.
-	svc.AgentStartup.begin("agent-1", func() {})
+	agentHandle := svc.AgentStartup.begin("agent-1", func() {})
+	require.NotNil(t, agentHandle)
 	dbAgent.StartupError = "stale error"
 	status, errStr, _ := svc.deriveAgentStatus(&dbAgent, true)
 	assert.Equal(t, leapmuxv1.AgentStatus_AGENT_STATUS_ACTIVE, status)
@@ -45,7 +46,7 @@ func TestDeriveAgentStatus_AllBranches(t *testing.T) {
 
 	// 3. Registry STARTUP_FAILED: fail() wins over DB column.
 	dbAgent.StartupError = "stale db error"
-	svc.AgentStartup.fail("agent-1", "registry error")
+	svc.AgentStartup.fail(agentHandle, "registry error")
 	status, errStr, _ = svc.deriveAgentStatus(&dbAgent, false)
 	assert.Equal(t, leapmuxv1.AgentStatus_AGENT_STATUS_STARTUP_FAILED, status)
 	assert.Equal(t, "registry error", errStr)
@@ -74,14 +75,15 @@ func TestDeriveTerminalStatus_AllBranches(t *testing.T) {
 	term := db.Terminal{ID: "term-1"}
 
 	// 1. Registry STARTING.
-	svc.TerminalStartup.begin("term-1", func() {})
+	terminalHandle := svc.TerminalStartup.begin("term-1", func() {})
+	require.NotNil(t, terminalHandle)
 	status, errStr, _ := svc.deriveTerminalStatus(&term)
 	assert.Equal(t, leapmuxv1.TerminalStatus_TERMINAL_STATUS_STARTING, status)
 	assert.Empty(t, errStr)
 
 	// 2. Registry STARTUP_FAILED wins over DB column.
 	term.StartupError = "stale db error"
-	svc.TerminalStartup.fail("term-1", "registry error")
+	svc.TerminalStartup.fail(terminalHandle, "registry error")
 	status, errStr, _ = svc.deriveTerminalStatus(&term)
 	assert.Equal(t, leapmuxv1.TerminalStatus_TERMINAL_STATUS_STARTUP_FAILED, status)
 	assert.Equal(t, "registry error", errStr)
@@ -209,7 +211,7 @@ func TestListAgents_ReportsStartupFailedFromDBColumnAfterRegistryWipe(t *testing
 
 	// Simulate worker restart: wipe the in-memory registry while the DB
 	// column remains populated.
-	svc.AgentStartup = newAgentStartupRegistry()
+	svc.AgentStartup = newAgentStartupRegistry(testutil.NewQuartzMock(t))
 
 	listW := newTestWriter()
 	dispatch(d, "ListAgents", &leapmuxv1.ListAgentsRequest{TabIds: []string{agentID}}, listW)
@@ -282,7 +284,7 @@ func TestWatchEvents_CatchUpBroadcastsStartupFailedFromDBColumn(t *testing.T) {
 	waitForStartupFailure(t, svc, agentID)
 
 	// Simulate worker restart: wipe the in-memory registry.
-	svc.AgentStartup = newAgentStartupRegistry()
+	svc.AgentStartup = newAgentStartupRegistry(testutil.NewQuartzMock(t))
 
 	wWatch := newTestWriter()
 	dispatch(d, "WatchEvents", &leapmuxv1.WatchEventsRequest{
@@ -370,7 +372,7 @@ func TestListTerminals_ReportsStartupFailedFromDBColumnAfterRegistryWipe(t *test
 	waitForStartupFailure(t, svc, terminalID)
 
 	// Simulate worker restart.
-	svc.TerminalStartup = newTerminalStartupRegistry()
+	svc.TerminalStartup = newTerminalStartupRegistry(testutil.NewQuartzMock(t))
 
 	listW := newTestWriter()
 	dispatch(d, "ListTerminals", &leapmuxv1.ListTerminalsRequest{TabIds: []string{terminalID}}, listW)

--- a/backend/internal/worker/service/startup_phase.go
+++ b/backend/internal/worker/service/startup_phase.go
@@ -154,7 +154,7 @@ func (svc *Service) agentStartupCallbacks(dbAgent *db.Agent, gitStatus *leapmuxv
 		broadcastStarting: func(label string) { svc.broadcastAgentStarting(dbAgent, label, nil) },
 		persistError:      func(errMsg string) { svc.persistAgentStartupError(dbAgent.ID, errMsg) },
 		broadcastFailed:   func(errMsg string) { svc.broadcastAgentFailed(dbAgent, errMsg, gitStatus) },
-		registryFail:      func(errMsg string) { svc.AgentStartup.fail(dbAgent.ID, errMsg) },
+		registryFail:      func(errMsg string) { svc.AgentStartup.fail(h, errMsg) },
 		closeDisposition: func() (closeWorktreeDisposition, bool) {
 			return svc.AgentStartup.dispositionOf(h)
 		},
@@ -172,7 +172,7 @@ func (svc *Service) terminalStartupCallbacks(terminalID string, h *startupEntry)
 		broadcastStarting: func(label string) { svc.broadcastTerminalStarting(terminalID, label, nil) },
 		persistError:      func(errMsg string) { svc.persistTerminalStartupError(terminalID, errMsg) },
 		broadcastFailed:   func(errMsg string) { svc.broadcastTerminalFailed(terminalID, errMsg) },
-		registryFail:      func(errMsg string) { svc.TerminalStartup.fail(terminalID, errMsg) },
+		registryFail:      func(errMsg string) { svc.TerminalStartup.fail(h, errMsg) },
 		closeDisposition: func() (closeWorktreeDisposition, bool) {
 			return svc.TerminalStartup.dispositionOf(h)
 		},

--- a/backend/internal/worker/service/startupstate.go
+++ b/backend/internal/worker/service/startupstate.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/coder/quartz"
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 )
 
@@ -14,7 +15,13 @@ import (
 // startup_error column is the authoritative source across restarts, so
 // expiry only evicts the in-memory copy; a later read falls back to
 // the DB path.
-const failedEntryTTL = 5 * time.Minute
+const (
+	failedEntryTTL = 5 * time.Minute
+
+	startupAwaitTimerTag         = "startup-await"
+	startupPendingResizeTimerTag = "startup-pending-resize"
+	startupFailedEvictionTag     = "startup-failed-eviction"
+)
 
 // startupEntry tracks the in-flight (or recently-failed) startup of a single
 // agent or terminal. It exists to:
@@ -30,8 +37,12 @@ const failedEntryTTL = 5 * time.Minute
 //     PTY was registered in the Manager, so runTerminalStartup can apply
 //     it the moment StartTerminal returns.
 type startupEntry struct {
+	// id is the agent or terminal this entry claims. It travels ON the entry so
+	// every transition can check that the map slot still holds THIS entry: a
+	// startup goroutine that a close already retired must not retire the
+	// replacement startup that reclaimed the same id.
 	id string
-	// failed is set once startup fails terminally. While false and cancel
+	// failed is set once startup reaches its failed state. While false and cancel
 	// is non-nil, startup is still in progress (STARTING).
 	failed       bool
 	startupError string
@@ -45,7 +56,7 @@ type startupEntry struct {
 	// evictTimer fires failedEntryTTL after fail() to drop the entry.
 	// Stored so cancelAndClear/succeed can Stop() it and release the
 	// runtime timer slot early.
-	evictTimer *time.Timer
+	evictTimer *quartz.Timer
 	// pendingResize carries the latest ResizeTerminal dims that arrived
 	// while the PTY was still being spawned. The backend PTY is created
 	// with the placeholder 80x24 from the OpenTerminal request; the
@@ -104,30 +115,17 @@ func (e *startupEntry) release() {
 	}
 }
 
-// startupTimerClock is the time source awaitInFlight limits its wait with.
-// Production uses systemStartupClock; the registry's tests substitute a fake
-// that fires on demand, so a test about the give-up path spends no wall time
-// and a test about the wait NOT giving up cannot lose to a real timer on a
-// loaded machine.
+// stopEviction stops the pending eviction of a failed entry that left its map
+// slot, which releases the runtime timer slot early. It does nothing for an
+// entry that never failed.
 //
-// It mirrors streamevents.retryClock deliberately: the same two-value
-// NewTimer, so the codebase has one shape for "a timer a test can drive".
-// The two are byte-for-byte the same type and could share one; see
-// https://github.com/leapmux/leapmux/issues/437.
-type startupTimerClock interface {
-	// NewTimer starts a timer for d, returning the channel it delivers on and a
-	// stop func that releases it -- time.Timer's C/Stop pair without the
-	// concrete type. The caller must call stop exactly once, whether or not it
-	// consumed the delivery.
-	NewTimer(d time.Duration) (<-chan time.Time, func())
-}
-
-// systemStartupClock is the production startupTimerClock: a plain time.NewTimer.
-type systemStartupClock struct{}
-
-func (systemStartupClock) NewTimer(d time.Duration) (<-chan time.Time, func()) {
-	t := time.NewTimer(d)
-	return t.C, func() { t.Stop() }
+// The caller must NOT hold r.mu. A quartz trap on TimerStop parks the calling
+// goroutine inside Stop, and a park under r.mu blocks every other registry
+// method until the test releases the trap.
+func (e *startupEntry) stopEviction() {
+	if e != nil && e.evictTimer != nil {
+		e.evictTimer.Stop(startupFailedEvictionTag)
+	}
 }
 
 // startupCore is the shared state-machine for tracking a set of in-flight
@@ -145,17 +143,22 @@ type startupCore struct {
 	entries  map[string]*startupEntry
 	inflight map[string]*startupEntry
 	wg       sync.WaitGroup
-	// clock is the time source awaitInFlight limits its wait with. Set once by
-	// newStartupCore and never reassigned in production, so a waiter reads it
-	// without the mutex; a test substitutes a fake before it starts one.
-	clock startupTimerClock
+	// clock supplies all startup timers. newStartupCore requires a non-nil clock
+	// and sets it once, and nothing replaces it after construction, so
+	// awaitInFlight, fail and waitForPendingResize read it without r.mu. A test
+	// substitutes a fake before it starts the first startup. A write after the
+	// first begin is a data race against those three reads.
+	clock quartz.Clock
 }
 
-func newStartupCore() startupCore {
+func newStartupCore(clock quartz.Clock) startupCore {
+	if clock == nil {
+		panic("service: startup clock must not be nil")
+	}
 	return startupCore{
 		entries:  make(map[string]*startupEntry),
 		inflight: make(map[string]*startupEntry),
-		clock:    systemStartupClock{},
+		clock:    clock,
 	}
 }
 
@@ -180,12 +183,19 @@ func newStartupCore() startupCore {
 // yet, so HasAgent is false.
 func (r *startupCore) begin(id string, cancel context.CancelFunc) *startupEntry {
 	r.mu.Lock()
-	defer r.mu.Unlock()
 	// Refuse only an IN-FLIGHT startup. A failed entry is a finished one that
 	// lingers for failedEntryTTL so a status query can still read the error;
 	// refusing on it would lock a tab out of every retry for those five minutes.
-	if existing, busy := r.entries[id]; busy && !existing.failed {
-		return nil
+	var replaced *startupEntry
+	if existing, claimed := r.entries[id]; claimed {
+		if !existing.failed {
+			r.mu.Unlock()
+			return nil
+		}
+		// A failed entry this startup replaces leaves the map below, so its
+		// pending eviction has nothing left to evict. Stopping it after the
+		// unlock keeps the timer call out of the lock.
+		replaced = existing
 	}
 	entry := &startupEntry{
 		id:           id,
@@ -197,6 +207,8 @@ func (r *startupCore) begin(id string, cancel context.CancelFunc) *startupEntry 
 	r.entries[id] = entry
 	r.inflight[id] = entry
 	r.wg.Add(1)
+	r.mu.Unlock()
+	replaced.stopEviction()
 	return entry
 }
 
@@ -241,15 +253,15 @@ func (r *startupCore) awaitInFlight(id string, limit time.Duration) startupWait 
 	if entry == nil {
 		return startupWait{settled: true}
 	}
-	expired, stop := r.clock.NewTimer(limit)
-	defer stop()
+	timer := r.clock.NewTimer(limit, startupAwaitTimerTag)
+	defer timer.Stop(startupAwaitTimerTag)
 	select {
 	case <-entry.done:
 		// cancelAndClear stamps closeRaced on this same entry BEFORE it closes
 		// done, so the read below sees the close that woke this waiter.
 		_, closed := r.dispositionOf(entry)
 		return startupWait{settled: true, closed: closed}
-	case <-expired:
+	case <-timer.C:
 		return startupWait{}
 	}
 }
@@ -304,7 +316,7 @@ func (r *startupCore) setMessage(id, message string) {
 	}
 }
 
-// succeed removes the entry (on successful startup the runtime state comes
+// succeed removes h's entry (on successful startup the runtime state comes
 // from the Manager, not from this registry).
 //
 // handle, when set, makes the removal IDENTITY-GUARDED: the entry goes only
@@ -313,12 +325,16 @@ func (r *startupCore) setMessage(id, message string) {
 // when the caller is the sole owner of the claim.
 //
 // Why the guard exists. succeed frees the id, and begin admits a new startup
-// the moment it is free. A goroutine whose tail reaches succeed a second time
-// -- which the close-after-succeed branch does, because cancelAndClear now
-// stamps closeRaced on an entry it finds through inflight -- would otherwise
-// delete and release whatever claim currently holds that id. That is a
-// SECOND startup's claim, and freeing it admits a third: two startup
-// goroutines for one tab, the exact state begin exists to prevent.
+// the moment it is free. Two paths reach it after the id was released. A
+// goroutine whose tail reaches succeed a second time -- which the
+// close-after-succeed branch does, because cancelAndClear stamps closeRaced on
+// an entry it finds through inflight. And a goroutine whose post-spawn re-read
+// still saw an open row, because a close retires the entry several steps before
+// it stamps closed_at. Either would otherwise delete and release whatever claim
+// currently holds that id. That is a SECOND startup's claim, and freeing it
+// admits a third: two startup goroutines for one tab, the exact state begin
+// exists to prevent. It also left the second startup's context uncancelled, so
+// its process outlived the tab.
 func (r *startupCore) succeed(id string, handle *startupEntry) {
 	r.mu.Lock()
 	entry := r.entries[id]
@@ -329,36 +345,48 @@ func (r *startupCore) succeed(id string, handle *startupEntry) {
 		entry = nil
 	}
 	r.mu.Unlock()
-	if entry != nil && entry.evictTimer != nil {
-		entry.evictTimer.Stop()
-	}
+	entry.stopEviction()
 }
 
 // fail retains the entry with the error string for later observation and
 // schedules its eviction after failedEntryTTL so a failed tab the user
 // never closes eventually drops out of the in-memory map. Status queries
 // after eviction fall back to the persisted startup_error column.
-func (r *startupCore) fail(id, startupError string) {
-	entry := &startupEntry{failed: true, startupError: startupError}
-	entry.evictTimer = time.AfterFunc(failedEntryTTL, func() {
+//
+// It takes the HANDLE begin returned, for the reason succeed states: a startup
+// that a close already retired must not overwrite the entry of the replacement
+// startup that reclaimed the same id.
+func (r *startupCore) fail(h *startupEntry, startupError string) {
+	if h == nil {
+		return
+	}
+	id := h.id
+	entry := &startupEntry{id: id, failed: true, startupError: startupError}
+	entry.evictTimer = r.clock.AfterFunc(failedEntryTTL, func() {
 		r.mu.Lock()
 		defer r.mu.Unlock()
 		if current, ok := r.entries[id]; ok && current == entry {
 			delete(r.entries, id)
 		}
-	})
+	}, startupFailedEvictionTag)
 	r.mu.Lock()
-	// Stop any prior pending eviction if fail is called twice, and release the
-	// startup this failure replaces: an awaited startup that FAILS has stopped
-	// being in flight just as surely as one that succeeded.
-	if prev, ok := r.entries[id]; ok {
-		if prev.evictTimer != nil {
-			prev.evictTimer.Stop()
-		}
-		prev.release()
+	prev, held := r.entries[id]
+	if held && prev != h {
+		// A close retired h and something else claimed the id. Recording this
+		// failure would evict that claim.
+		r.mu.Unlock()
+		entry.stopEviction()
+		return
 	}
+	// Release the startup this failure replaces: an awaited startup that FAILS
+	// has stopped being in flight just as surely as one that succeeded.
+	prev.release()
 	r.entries[id] = entry
 	r.mu.Unlock()
+	// Stop any prior pending eviction, after the unlock, so a trapped Stop
+	// cannot park this goroutine inside r.mu. h is never a failed entry, so
+	// prev carries a timer only when a caller failed the same handle twice.
+	prev.stopEviction()
 }
 
 // cancelAndClear triggers the cancel func if one is registered and removes
@@ -421,9 +449,7 @@ func (r *startupCore) cancelStartup(id string, preferFinished bool, stamp func(*
 	if entry == nil {
 		return nil
 	}
-	if entry.evictTimer != nil {
-		entry.evictTimer.Stop()
-	}
+	entry.stopEviction()
 	if entry.cancel != nil {
 		entry.cancel()
 	}
@@ -546,15 +572,22 @@ func (r *startupCore) setPendingResize(id string, cols, rows uint16) bool {
 // takePendingResize returns the stashed dims (if any) and clears the
 // slot. Called by runTerminalStartup after StartTerminal registers the
 // PTY so the stored size lands on the real terminal.
-func (r *startupCore) takePendingResize(id string) (cols, rows uint16, ok bool) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	entry, found := r.entries[id]
-	if !found || !entry.hasPendingResize {
+//
+// It takes the HANDLE begin returned, and it succeeds only while the map slot
+// still holds that entry. An id alone would let a startup that a close already
+// retired consume the dims of the REPLACEMENT startup that reclaimed the id,
+// and then size a PTY it does not own.
+func (r *startupCore) takePendingResize(h *startupEntry) (cols, rows uint16, ok bool) {
+	if h == nil {
 		return 0, 0, false
 	}
-	cols, rows = entry.pendingResize[0], entry.pendingResize[1]
-	entry.hasPendingResize = false
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.entries[h.id] != h || !h.hasPendingResize {
+		return 0, 0, false
+	}
+	cols, rows = h.pendingResize[0], h.pendingResize[1]
+	h.hasPendingResize = false
 	return cols, rows, true
 }
 
@@ -572,23 +605,26 @@ func (r *startupCore) waitForPendingResize(id string, timeout time.Duration) (co
 		r.mu.Unlock()
 		return 0, 0, false
 	}
-	if entry.hasPendingResize {
-		cols = entry.pendingResize[0]
-		rows = entry.pendingResize[1]
-		entry.hasPendingResize = false
-		r.mu.Unlock()
-		return cols, rows, true
-	}
 	ch := entry.resizeSignal
 	r.mu.Unlock()
 
-	timer := time.NewTimer(timeout)
-	defer timer.Stop()
+	// The already-stashed case takes the same path as the woken one, so one
+	// implementation of "take the stashed dims" serves both. It also arms no
+	// timer, which is what makes the fast path fast.
+	if cols, rows, ok := r.takePendingResize(entry); ok {
+		return cols, rows, true
+	}
+
+	timer := r.clock.NewTimer(timeout, startupPendingResizeTimerTag)
+	defer timer.Stop(startupPendingResizeTimerTag)
 	select {
 	case <-ch:
+	case <-entry.done:
+		return 0, 0, false
 	case <-timer.C:
 	}
-	return r.takePendingResize(id)
+
+	return r.takePendingResize(entry)
 }
 
 // clearPendingResize drops any stashed dims for id. Called from the
@@ -651,9 +687,9 @@ type startupRegistry[S ~int32] struct {
 	failedStatus      S
 }
 
-func newStartupRegistry[S ~int32](unspec, starting, failed S) *startupRegistry[S] {
+func newStartupRegistry[S ~int32](clock quartz.Clock, unspec, starting, failed S) *startupRegistry[S] {
 	return &startupRegistry[S]{
-		startupCore:       newStartupCore(),
+		startupCore:       newStartupCore(clock),
 		unspecifiedStatus: unspec,
 		startingStatus:    starting,
 		failedStatus:      failed,
@@ -675,16 +711,18 @@ func (r *startupRegistry[S]) status(id string) (status S, startupError, startupM
 	return r.startingStatus, "", msg, true
 }
 
-func newAgentStartupRegistry() *startupRegistry[leapmuxv1.AgentStatus] {
+func newAgentStartupRegistry(clock quartz.Clock) *startupRegistry[leapmuxv1.AgentStatus] {
 	return newStartupRegistry(
+		clock,
 		leapmuxv1.AgentStatus_AGENT_STATUS_UNSPECIFIED,
 		leapmuxv1.AgentStatus_AGENT_STATUS_STARTING,
 		leapmuxv1.AgentStatus_AGENT_STATUS_STARTUP_FAILED,
 	)
 }
 
-func newTerminalStartupRegistry() *startupRegistry[leapmuxv1.TerminalStatus] {
+func newTerminalStartupRegistry(clock quartz.Clock) *startupRegistry[leapmuxv1.TerminalStatus] {
 	return newStartupRegistry(
+		clock,
 		leapmuxv1.TerminalStatus_TERMINAL_STATUS_UNSPECIFIED,
 		leapmuxv1.TerminalStatus_TERMINAL_STATUS_STARTING,
 		leapmuxv1.TerminalStatus_TERMINAL_STATUS_STARTUP_FAILED,

--- a/backend/internal/worker/service/startupstate_test.go
+++ b/backend/internal/worker/service/startupstate_test.go
@@ -1,17 +1,29 @@
 package service
 
 import (
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/leapmux/leapmux/internal/util/testutil"
 )
 
-// beginForTest records an entry and registers the finishEntry that keeps
-// WaitForInFlight happy. Tests use this to exercise the startupCore primitives
-// without the full startup-goroutine machinery.
+func newTestStartupCore(t *testing.T) startupCore {
+	t.Helper()
+	return newStartupCore(testutil.NewQuartzMock(t))
+}
+
+func TestNewStartupCoreRejectsNilClock(t *testing.T) {
+	t.Parallel()
+	assert.Panics(t, func() { newStartupCore(nil) })
+}
+
+// beginForTest records an entry and returns a cleanup that pairs with
+// finish() to keep WaitForInFlight happy. Tests use this to exercise
+// the startupCore primitives without the full startup-goroutine
+// machinery.
 func beginForTest(t *testing.T, r *startupCore, id string) {
 	t.Helper()
 	entry := r.begin(id, func() {})
@@ -25,7 +37,7 @@ func beginForTest(t *testing.T, r *startupCore, id string) {
 func TestStartupCore_ArchiveCancellationIsDistinctFromCloseAndFailure(t *testing.T) {
 	t.Parallel()
 
-	core := newStartupCore()
+	core := newTestStartupCore(t)
 	cancelled := false
 	handle := core.begin("archive-tab", func() { cancelled = true })
 	require.NotNil(t, handle)
@@ -58,7 +70,7 @@ func TestStartupCore_ArchiveCancellationIsDistinctFromCloseAndFailure(t *testing
 func TestStartupCore_ArchiveFindsNoHandleOnceTheStartupFinished(t *testing.T) {
 	t.Parallel()
 
-	core := newStartupCore()
+	core := newTestStartupCore(t)
 	handle := core.begin("finished-tab", func() {})
 	require.NotNil(t, handle)
 	core.succeed("finished-tab", nil)
@@ -80,7 +92,9 @@ func TestStartupCore_ArchiveFindsNoHandleOnceTheStartupFinished(t *testing.T) {
 func TestStartupCore_ClearPendingResize_DrainsSignal(t *testing.T) {
 	t.Parallel()
 
-	r := newStartupCore()
+	clock := testutil.NewQuartzMock(t)
+	r := newStartupCore(clock)
+	ctx := testutil.DeadlineContext(t)
 	id := "term-clear-drain"
 	beginForTest(t, &r, id)
 
@@ -98,20 +112,34 @@ func TestStartupCore_ClearPendingResize_DrainsSignal(t *testing.T) {
 	assert.Equal(t, 0, len(ch),
 		"clearPendingResize must drain the buffered signal so a later waiter can't wake on it")
 
-	// A wait after clear must block for its full timeout rather than waking
-	// immediately on a stale signal. `ok` cannot tell those apart -- both return
-	// false -- so the duration is the discriminator, and it is a LOWER bound,
-	// which machine load cannot break: load only ever makes this slower, and the
-	// failure being guarded against is waking EARLY.
-	//
-	// The two outcomes are pushed far apart all the same, so the assertion does
-	// not depend on a 10ms cushion: a drained-signal wake returns in
-	// microseconds, while the timeout path cannot return before 2s.
-	start := time.Now()
-	_, _, ok := r.waitForPendingResize(id, 2*time.Second)
-	assert.False(t, ok, "no resize stashed, should time out")
-	assert.GreaterOrEqual(t, time.Since(start), time.Second,
-		"wait should block for roughly the full timeout, not wake on a drained signal")
+	newTimer := clock.Trap().NewTimer(startupPendingResizeTimerTag)
+	defer newTimer.Close()
+	stopTimer := clock.Trap().TimerStop(startupPendingResizeTimerTag)
+	defer stopTimer.Close()
+
+	result := make(chan bool, 1)
+	go func() {
+		_, _, ok := r.waitForPendingResize(id, 2*time.Second)
+		result <- ok
+	}()
+	call := newTimer.MustWait(ctx)
+	assert.Equal(t, 2*time.Second, call.Duration)
+	call.MustRelease(ctx)
+	// A check of `result` here would assert nothing: the waiter leaves through
+	// the trapped Stop below, so `result` is empty on every run, drained signal
+	// or not. The end-to-end claim rests on two facts instead. The drain is
+	// exact above (len(ch) == 0 after clearPendingResize), and
+	// TestStartupCore_WaitForPendingResize_WakesOnSignal proves that a value in
+	// that channel DOES end a wait. An undrained channel therefore wakes the
+	// next waiter, which is the regression this test refuses. The lines below
+	// pin the other half: with the signal drained, only the timer ends the wait.
+
+	advance := clock.Advance(2 * time.Second)
+	stopTimer.MustWait(ctx).MustRelease(ctx)
+	advance.MustWait(ctx)
+	assert.False(t, <-result, "no resize was stashed")
+	_, running := clock.Peek()
+	assert.False(t, running, "the expired timer must be stopped")
 }
 
 // TestStartupCore_WaitForPendingResize_WakesOnSignal covers the normal
@@ -120,34 +148,38 @@ func TestStartupCore_ClearPendingResize_DrainsSignal(t *testing.T) {
 func TestStartupCore_WaitForPendingResize_WakesOnSignal(t *testing.T) {
 	t.Parallel()
 
-	r := newStartupCore()
+	clock := testutil.NewQuartzMock(t)
+	r := newStartupCore(clock)
+	ctx := testutil.DeadlineContext(t)
 	id := "term-wake"
 	beginForTest(t, &r, id)
 
+	newTimer := clock.Trap().NewTimer(startupPendingResizeTimerTag)
+	defer newTimer.Close()
+	stopTimer := clock.Trap().TimerStop(startupPendingResizeTimerTag)
+	defer stopTimer.Close()
+	type resizeResult struct {
+		cols uint16
+		rows uint16
+		ok   bool
+	}
+	result := make(chan resizeResult, 1)
 	go func() {
-		time.Sleep(5 * time.Millisecond)
-		r.setPendingResize(id, 90, 30)
+		cols, rows, ok := r.waitForPendingResize(id, 30*time.Second)
+		result <- resizeResult{cols: cols, rows: rows, ok: ok}
 	}()
-
-	// The two outcomes are deliberately FAR apart. `ok` alone cannot tell them
-	// apart -- `waitForPendingResize` calls `takePendingResize` after either
-	// select arm, so a broken chan signal still returns the right dims once the
-	// timer fires -- which makes elapsed time the only discriminator. With a
-	// 500ms timeout and a 200ms bound the margin was 300ms, close enough to
-	// machine jitter to fail on a loaded box while the signal worked fine.
-	//
-	// A 30s timeout against a 5s bound keeps exactly the same proof with ~25s of
-	// margin instead: the signal path completes in single-digit ms, and the
-	// timeout path cannot finish under 30s, so nothing load can do reaches the
-	// boundary. The test still exits in milliseconds when it passes.
-	start := time.Now()
-	cols, rows, ok := r.waitForPendingResize(id, 30*time.Second)
-	elapsed := time.Since(start)
+	call := newTimer.MustWait(ctx)
+	assert.Equal(t, 30*time.Second, call.Duration)
+	call.MustRelease(ctx)
+	require.True(t, r.setPendingResize(id, 90, 30))
+	stopTimer.MustWait(ctx).MustRelease(ctx)
+	got := <-result
+	cols, rows, ok := got.cols, got.rows, got.ok
 	require.True(t, ok)
 	assert.Equal(t, uint16(90), cols)
 	assert.Equal(t, uint16(30), rows)
-	assert.Less(t, elapsed, 5*time.Second,
-		"chan signal should wake the waiter in ms, not hit the timeout")
+	_, running := clock.Peek()
+	assert.False(t, running, "the signal path must stop its timer")
 }
 
 // TestStartupCore_WaitForPendingResize_AlreadyStashed covers the fast
@@ -156,7 +188,8 @@ func TestStartupCore_WaitForPendingResize_WakesOnSignal(t *testing.T) {
 func TestStartupCore_WaitForPendingResize_AlreadyStashed(t *testing.T) {
 	t.Parallel()
 
-	r := newStartupCore()
+	clock := testutil.NewQuartzMock(t)
+	r := newStartupCore(clock)
 	id := "term-prestashed"
 	beginForTest(t, &r, id)
 
@@ -165,6 +198,66 @@ func TestStartupCore_WaitForPendingResize_AlreadyStashed(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, uint16(100), cols)
 	assert.Equal(t, uint16(50), rows)
+	_, running := clock.Peek()
+	assert.False(t, running, "the fast path must not create a timer")
+}
+
+func TestStartupCore_WaitForPendingResizeStopsWhenStartupIsCancelled(t *testing.T) {
+	t.Parallel()
+
+	clock := testutil.NewQuartzMock(t)
+	core := newStartupCore(clock)
+	ctx := testutil.DeadlineContext(t)
+	cancelledEntry := core.begin("term-cancelled", func() {})
+	require.NotNil(t, cancelledEntry)
+	newTimer := clock.Trap().NewTimer(startupPendingResizeTimerTag)
+	defer newTimer.Close()
+	stopTimer := clock.Trap().TimerStop(startupPendingResizeTimerTag)
+	defer stopTimer.Close()
+
+	result := make(chan bool, 1)
+	go func() {
+		_, _, ok := core.waitForPendingResize("term-cancelled", time.Hour)
+		result <- ok
+	}()
+	call := newTimer.MustWait(ctx)
+	assert.Equal(t, time.Hour, call.Duration)
+	call.MustRelease(ctx)
+	core.cancelAndClear("term-cancelled", keepWorktreeOnClose)
+	stopTimer.MustWait(ctx).MustRelease(ctx)
+	select {
+	case ok := <-result:
+		assert.False(t, ok)
+	case <-ctx.Done():
+		require.FailNow(t, "the pending-resize wait ignored startup cancellation")
+	}
+	core.finishEntry(cancelledEntry)
+	_, running := clock.Peek()
+	assert.False(t, running, "startup cancellation must stop the pending-resize timer")
+}
+
+func TestStartupCore_OldWaitCannotTakeReplacementResize(t *testing.T) {
+	t.Parallel()
+
+	core := newTestStartupCore(t)
+	oldEntry := core.begin("term-replaced", func() {})
+	require.NotNil(t, oldEntry)
+	core.fail(oldEntry, "first startup failed")
+	core.finishEntry(oldEntry)
+
+	newEntry := core.begin("term-replaced", func() {})
+	require.NotNil(t, newEntry)
+	require.True(t, core.setPendingResize("term-replaced", 120, 50))
+	_, _, ok := core.takePendingResize(oldEntry)
+	assert.False(t, ok, "an old wait must not take a replacement startup's resize")
+	cols, rows, ok := core.takePendingResize(newEntry)
+	require.True(t, ok, "the replacement startup must retain its resize")
+	assert.Equal(t, uint16(120), cols)
+	assert.Equal(t, uint16(50), rows)
+
+	core.cancelAndClear("term-replaced", keepWorktreeOnClose)
+	core.finishEntry(newEntry)
+	core.WaitForInFlight()
 }
 
 // TestCancelAndClear_StampsTheHandleTheGoroutineHolds pins how a close reaches
@@ -174,7 +267,7 @@ func TestStartupCore_WaitForPendingResize_AlreadyStashed(t *testing.T) {
 func TestCancelAndClear_StampsTheHandleTheGoroutineHolds(t *testing.T) {
 	t.Parallel()
 
-	core := newStartupCore()
+	core := newTestStartupCore(t)
 	h := core.begin("a-live", func() {})
 
 	_, raced := core.dispositionOf(h)
@@ -200,9 +293,10 @@ func TestCancelAndClear_StampsTheHandleTheGoroutineHolds(t *testing.T) {
 func TestCancelAndClear_FailedStartupNeverReachesItsGoroutine(t *testing.T) {
 	t.Parallel()
 
-	core := newStartupCore()
+	core := newTestStartupCore(t)
 	h := core.begin("a-failed", func() {})
-	core.fail("a-failed", "boom")
+	require.NotNil(t, h)
+	core.fail(h, "boom")
 	core.finishEntry(h)
 
 	core.cancelAndClear("a-failed", removeWorktreeOnClose)
@@ -218,7 +312,7 @@ func TestCancelAndClear_FailedStartupNeverReachesItsGoroutine(t *testing.T) {
 func TestDispositionOf_NilHandleIsAnUncontestedStartup(t *testing.T) {
 	t.Parallel()
 
-	core := newStartupCore()
+	core := newTestStartupCore(t)
 	got, raced := core.dispositionOf(nil)
 	assert.False(t, raced)
 	assert.Equal(t, keepWorktreeOnClose, got)
@@ -234,7 +328,7 @@ func TestDispositionOf_NilHandleIsAnUncontestedStartup(t *testing.T) {
 func TestStartupCore_BeginClaimsTheIDAgainstASecondStartup(t *testing.T) {
 	t.Parallel()
 
-	core := newStartupCore()
+	core := newTestStartupCore(t)
 	firstCancelled := false
 	first := core.begin("tab-1", func() { firstCancelled = true })
 	require.NotNil(t, first)
@@ -259,72 +353,190 @@ func TestStartupCore_BeginClaimsTheIDAgainstASecondStartup(t *testing.T) {
 func TestStartupCore_BeginReclaimsAFailedEntry(t *testing.T) {
 	t.Parallel()
 
-	core := newStartupCore()
-	core.fail("tab-1", "claude: command not found")
+	clock := testutil.NewQuartzMock(t)
+	core := newStartupCore(clock)
+	ctx := testutil.DeadlineContext(t)
+	first := core.begin("tab-1", func() {})
+	require.NotNil(t, first)
+	core.fail(first, "claude: command not found")
+	core.finishEntry(first)
+	stopTimer := clock.Trap().TimerStop(startupFailedEvictionTag)
+	defer stopTimer.Close()
 
-	h := core.begin("tab-1", func() {})
+	hCh := make(chan *startupEntry, 1)
+	go func() { hCh <- core.begin("tab-1", func() {}) }()
+	stopTimer.MustWait(ctx).MustRelease(ctx)
+	h := <-hCh
 	require.NotNil(t, h, "a retry after a failed startup must be able to claim the tab again")
+	_, running := clock.Peek()
+	assert.False(t, running, "replacing a failed entry must stop its eviction timer")
+	core.cancelAndClear("tab-1", keepWorktreeOnClose)
 	core.finishEntry(h)
 	core.WaitForInFlight()
 }
 
-// fakeStartupClock is a deterministic startupTimerClock. NewTimer records the
-// requested delay and hands back a channel the test fires explicitly, so
-// nothing in awaitInFlight is timed by the wall clock: a test can hold a wait
-// in its armed-but-not-expired window for as long as it likes, and a test about
-// the give-up path spends no wall time reaching it.
+func TestStartupCore_FailedEntryExpiresExactlyAtTTL(t *testing.T) {
+	t.Parallel()
+
+	clock := testutil.NewQuartzMock(t)
+	core := newStartupCore(clock)
+	ctx := testutil.DeadlineContext(t)
+	afterFunc := clock.Trap().AfterFunc(startupFailedEvictionTag)
+	defer afterFunc.Close()
+
+	h := core.begin("tab-1", func() {})
+	require.NotNil(t, h)
+	core.finishEntry(h)
+	failed := make(chan struct{})
+	go func() {
+		core.fail(h, "boom")
+		close(failed)
+	}()
+	call := afterFunc.MustWait(ctx)
+	assert.Equal(t, failedEntryTTL, call.Duration)
+	call.MustRelease(ctx)
+	<-failed
+	_, errText, _, ok := core.snapshot("tab-1")
+	require.True(t, ok)
+	assert.Equal(t, "boom", errText)
+
+	clock.Advance(failedEntryTTL - 1).MustWait(ctx)
+	_, _, _, ok = core.snapshot("tab-1")
+	assert.True(t, ok, "the failed entry must remain before its time-to-live ends")
+	clock.Advance(1).MustWait(ctx)
+	_, _, _, ok = core.snapshot("tab-1")
+	assert.False(t, ok, "the failed entry must leave at its exact time-to-live")
+	_, running := clock.Peek()
+	assert.False(t, running, "the expired eviction timer must leave no event")
+}
+
+// TestStartupCore_CancelAndClearStopsAFailedEntryEviction pins the one
+// transition that still reaches a failed entry. fail() installs a FRESH entry
+// that no handle points at, so only the id-keyed close can retire it -- a
+// retry's begin() is the other route, and TestStartupCore_BeginReclaimsAFailedEntry
+// covers that one.
+func TestStartupCore_CancelAndClearStopsAFailedEntryEviction(t *testing.T) {
+	t.Parallel()
+
+	clock := testutil.NewQuartzMock(t)
+	core := newStartupCore(clock)
+	ctx := testutil.DeadlineContext(t)
+	h := core.begin("tab-1", func() {})
+	require.NotNil(t, h)
+	core.fail(h, "first failure")
+	core.finishEntry(h)
+	stopTimer := clock.Trap().TimerStop(startupFailedEvictionTag)
+	defer stopTimer.Close()
+
+	done := make(chan struct{})
+	go func() {
+		core.cancelAndClear("tab-1", keepWorktreeOnClose)
+		close(done)
+	}()
+	stopTimer.MustWait(ctx).MustRelease(ctx)
+	<-done
+	_, running := clock.Peek()
+	assert.False(t, running, "a close must stop the failed entry's eviction timer")
+	core.WaitForInFlight()
+}
+
+// TestStartupCore_StaleTransitionsCannotDisturbAFailedEntry is the other half
+// of the identity guard: the handle a startup holds stops matching the map the
+// moment fail() replaces the entry, so that goroutine's own succeed() and a
+// second fail() must both do nothing.
 //
-// Timers fire in arm order, one per fire() call, which is also the order a real
-// clock would fire them in for the one-wait-at-a-time shape awaitInFlight has.
-type fakeStartupClock struct {
-	mu     sync.Mutex
-	timers []chan time.Time
-	fired  int
-	delays []time.Duration
-	armed  chan struct{} // buffered(1); pinged on every NewTimer
-}
+// Without the guard, succeed() deleted whatever the id held and fail() replaced
+// it, so a goroutine that already reported its failure could erase the record
+// the user is about to read.
+func TestStartupCore_StaleTransitionsCannotDisturbAFailedEntry(t *testing.T) {
+	t.Parallel()
 
-func newFakeStartupClock() *fakeStartupClock {
-	return &fakeStartupClock{armed: make(chan struct{}, 1)}
-}
+	for _, tc := range []struct {
+		name  string
+		stale func(core *startupCore, h *startupEntry)
+	}{
+		{"succeed", func(core *startupCore, h *startupEntry) { core.succeed(h.id, h) }},
+		{"fail again", func(core *startupCore, h *startupEntry) { core.fail(h, "second failure") }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-func (c *fakeStartupClock) NewTimer(d time.Duration) (<-chan time.Time, func()) {
-	ch := make(chan time.Time, 1)
-	c.mu.Lock()
-	c.timers = append(c.timers, ch)
-	c.delays = append(c.delays, d)
-	c.mu.Unlock()
-	// Buffered(1) and non-blocking: a pending ping already covers the waiter's
-	// next check, so a dropped send loses nothing.
-	select {
-	case c.armed <- struct{}{}:
-	default:
+			clock := testutil.NewQuartzMock(t)
+			core := newStartupCore(clock)
+			h := core.begin("tab-1", func() {})
+			require.NotNil(t, h)
+			core.fail(h, "first failure")
+			core.finishEntry(h)
+
+			tc.stale(&core, h)
+
+			_, errText, _, ok := core.snapshot("tab-1")
+			require.True(t, ok, "a stale transition must not remove the failed entry")
+			assert.Equal(t, "first failure", errText,
+				"a stale transition must not overwrite the error the user reads")
+			delay, running := clock.Peek()
+			assert.True(t, running, "the failed entry must keep its eviction timer")
+			assert.Equal(t, failedEntryTTL, delay)
+
+			core.cancelAndClear("tab-1", keepWorktreeOnClose)
+			core.WaitForInFlight()
+		})
 	}
-	return ch, func() {}
 }
 
-// waitArmed blocks until a timer is armed, which is the signal that the code
-// under test chose to WAIT rather than answer at once.
-func (c *fakeStartupClock) waitArmed(t *testing.T) time.Duration {
-	t.Helper()
-	select {
-	case <-c.armed:
-	case <-time.After(10 * time.Second):
-		require.FailNow(t, "no wait was armed; the caller answered without waiting")
+// TestStartupCore_StaleTransitionsCannotRetireAReplacement is the reachable
+// production case the identity guard exists for. A close retires the entry
+// several steps before it stamps closed_at, so a startup goroutine whose
+// post-spawn re-read still sees an open row runs its tail AFTER a replacement
+// startup claimed the same id.
+//
+// An id-keyed succeed() then deleted the replacement's entry, and the close
+// that followed found nothing to cancel -- so the replacement's context stayed
+// live and its process outlived the tab.
+func TestStartupCore_StaleTransitionsCannotRetireAReplacement(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name  string
+		stale func(core *startupCore, h *startupEntry)
+	}{
+		{"succeed", func(core *startupCore, h *startupEntry) { core.succeed(h.id, h) }},
+		{"fail", func(core *startupCore, h *startupEntry) { core.fail(h, "the retired startup failed") }},
+		{"take pending resize", func(core *startupCore, h *startupEntry) { core.takePendingResize(h) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			core := newTestStartupCore(t)
+			retired := core.begin("tab-1", func() {})
+			require.NotNil(t, retired)
+			core.cancelAndClear("tab-1", keepWorktreeOnClose)
+			core.finishEntry(retired)
+
+			var replacementCancelled bool
+			replacement := core.begin("tab-1", func() { replacementCancelled = true })
+			require.NotNil(t, replacement, "the close freed the id, so the replacement claims it")
+			require.True(t, core.setPendingResize("tab-1", 120, 50))
+
+			tc.stale(&core, retired)
+
+			// The replacement is still the claim holder, so a second startup
+			// cannot spawn beside it and its dims are still there to apply.
+			assert.Nil(t, core.begin("tab-1", func() {}),
+				"a stale transition must not free the id the replacement holds")
+			cols, rows, ok := core.takePendingResize(replacement)
+			require.True(t, ok, "a stale transition must not consume the replacement's resize")
+			assert.Equal(t, uint16(120), cols)
+			assert.Equal(t, uint16(50), rows)
+
+			// The close that follows must still reach the replacement's cancel.
+			core.cancelAndClear("tab-1", keepWorktreeOnClose)
+			assert.True(t, replacementCancelled,
+				"the close must still cancel the replacement's startup context")
+			core.finishEntry(replacement)
+			core.WaitForInFlight()
+		})
 	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.delays[len(c.delays)-1]
-}
-
-// fire expires the oldest timer that has not fired yet.
-func (c *fakeStartupClock) fire(t *testing.T) {
-	t.Helper()
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	require.Less(t, c.fired, len(c.timers), "no armed timer left to fire")
-	c.timers[c.fired] <- time.Now()
-	c.fired++
 }
 
 // TestStartupCore_AwaitInFlightReturnsAtOnceWhenNothingHoldsTheID pins the two
@@ -334,18 +546,30 @@ func (c *fakeStartupClock) fire(t *testing.T) {
 func TestStartupCore_AwaitInFlightReturnsAtOnceWhenNothingHoldsTheID(t *testing.T) {
 	t.Parallel()
 
-	core := newStartupCore()
-	clock := newFakeStartupClock()
-	core.clock = clock
+	clock := testutil.NewQuartzMock(t)
+	core := newStartupCore(clock)
 
 	assert.Equal(t, startupWait{settled: true}, core.awaitInFlight("tab-unclaimed", time.Hour))
+	_, running := clock.Peek()
+	assert.False(t, running, "an unclaimed ID must not create a timer")
 
-	core.fail("tab-failed", "claude: command not found")
+	h := core.begin("tab-failed", func() {})
+	require.NotNil(t, h)
+	core.fail(h, "claude: command not found")
+	core.finishEntry(h)
 	assert.Equal(t, startupWait{settled: true}, core.awaitInFlight("tab-failed", time.Hour))
+	delay, running := clock.Peek()
+	assert.True(t, running, "the failed entry keeps its eviction timer")
+	assert.Equal(t, failedEntryTTL, delay)
 
-	clock.mu.Lock()
-	defer clock.mu.Unlock()
-	assert.Empty(t, clock.timers, "neither state may arm a timer")
+	// Peek reports the NEAREST deadline only, so the five-minute eviction timer
+	// would hide an hour-long await timer behind it. cancelAndClear stops the
+	// eviction timer, and this clock holds no other one, so an empty Peek after
+	// it is the exact statement that awaitInFlight armed nothing.
+	core.cancelAndClear("tab-failed", keepWorktreeOnClose)
+	_, running = clock.Peek()
+	assert.False(t, running, "a failed entry must not leave an await timer behind")
+	core.WaitForInFlight()
 }
 
 // TestStartupCore_AwaitInFlightWaitsForTheStartupThatHoldsTheID is the wait
@@ -361,44 +585,52 @@ func TestStartupCore_AwaitInFlightWaitsForTheStartupThatHoldsTheID(t *testing.T)
 	// yet.
 	for _, tc := range []struct {
 		name string
-		end  func(core *startupCore)
+		end  func(core *startupCore, h *startupEntry)
 		want startupWait
 	}{
-		{"succeed", func(core *startupCore) { core.succeed("tab-1", nil) }, startupWait{settled: true}},
-		{"fail", func(core *startupCore) { core.fail("tab-1", "boom") }, startupWait{settled: true}},
+		{"succeed", func(core *startupCore, h *startupEntry) { core.succeed(h.id, h) }, startupWait{settled: true}},
+		{"fail", func(core *startupCore, h *startupEntry) { core.fail(h, "boom") }, startupWait{settled: true}},
 		{
 			"cancelAndClear",
-			func(core *startupCore) { core.cancelAndClear("tab-1", keepWorktreeOnClose) },
+			func(core *startupCore, _ *startupEntry) { core.cancelAndClear("tab-1", keepWorktreeOnClose) },
 			startupWait{settled: true, closed: true},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			core := newStartupCore()
-			clock := newFakeStartupClock()
-			core.clock = clock
-			holder := core.begin("tab-1", func() {})
-			require.NotNil(t, holder)
+			clock := testutil.NewQuartzMock(t)
+			core := newStartupCore(clock)
+			ctx := testutil.DeadlineContext(t)
+			h := core.begin("tab-1", func() {})
+			require.NotNil(t, h)
+			newTimer := clock.Trap().NewTimer(startupAwaitTimerTag)
+			defer newTimer.Close()
+			stopTimer := clock.Trap().TimerStop(startupAwaitTimerTag)
+			defer stopTimer.Close()
 
 			done := make(chan startupWait, 1)
 			go func() { done <- core.awaitInFlight("tab-1", time.Hour) }()
 
-			clock.waitArmed(t)
+			call := newTimer.MustWait(ctx)
+			assert.Equal(t, time.Hour, call.Duration)
+			call.MustRelease(ctx)
 			select {
 			case <-done:
 				require.FailNow(t, "the wait returned while the startup still held the id")
 			default:
 			}
 
-			tc.end(&core)
+			tc.end(&core, h)
+			stopTimer.MustWait(ctx).MustRelease(ctx)
 			select {
 			case got := <-done:
 				assert.Equal(t, tc.want, got, "the holder finished, so the wait must report how")
-			case <-time.After(10 * time.Second):
+			case <-ctx.Done():
 				require.FailNow(t, "the wait never returned after the holder finished")
 			}
-			core.finishEntry(holder)
+			core.cancelAndClear("tab-1", keepWorktreeOnClose)
+			core.finishEntry(h)
 			core.WaitForInFlight()
 		})
 	}
@@ -410,27 +642,35 @@ func TestStartupCore_AwaitInFlightWaitsForTheStartupThatHoldsTheID(t *testing.T)
 func TestStartupCore_AwaitInFlightGivesUpOnItsLimit(t *testing.T) {
 	t.Parallel()
 
-	core := newStartupCore()
-	clock := newFakeStartupClock()
-	core.clock = clock
-	holder := core.begin("tab-1", func() {})
-	require.NotNil(t, holder)
+	clock := testutil.NewQuartzMock(t)
+	core := newStartupCore(clock)
+	ctx := testutil.DeadlineContext(t)
+	h := core.begin("tab-1", func() {})
+	require.NotNil(t, h)
+	newTimer := clock.Trap().NewTimer(startupAwaitTimerTag)
+	defer newTimer.Close()
+	stopTimer := clock.Trap().TimerStop(startupAwaitTimerTag)
+	defer stopTimer.Close()
 
 	done := make(chan startupWait, 1)
 	go func() { done <- core.awaitInFlight("tab-1", 90*time.Second) }()
 
-	assert.Equal(t, 90*time.Second, clock.waitArmed(t), "the wait must be armed for the limit it was given")
-	clock.fire(t)
+	call := newTimer.MustWait(ctx)
+	assert.Equal(t, 90*time.Second, call.Duration, "the wait must use its supplied limit")
+	call.MustRelease(ctx)
+	advance := clock.Advance(90 * time.Second)
+	stopTimer.MustWait(ctx).MustRelease(ctx)
+	advance.MustWait(ctx)
 	select {
 	case got := <-done:
 		assert.Equal(t, startupWait{}, got,
 			"a wait that expired must report that it settled nothing, and must not claim a close")
-	case <-time.After(10 * time.Second):
+	case <-ctx.Done():
 		require.FailNow(t, "the wait outlived its own limit")
 	}
 
 	core.cancelAndClear("tab-1", keepWorktreeOnClose)
-	core.finishEntry(holder)
+	core.finishEntry(h)
 	core.WaitForInFlight()
 }
 
@@ -440,29 +680,40 @@ func TestStartupCore_AwaitInFlightGivesUpOnItsLimit(t *testing.T) {
 func TestStartupCore_AwaitInFlightIsSafeForManyWaiters(t *testing.T) {
 	t.Parallel()
 
-	core := newStartupCore()
-	clock := newFakeStartupClock()
-	core.clock = clock
-	holder := core.begin("tab-1", func() {})
-	require.NotNil(t, holder)
+	clock := testutil.NewQuartzMock(t)
+	core := newStartupCore(clock)
+	ctx := testutil.DeadlineContext(t)
+	h := core.begin("tab-1", func() {})
+	require.NotNil(t, h)
+	newTimer := clock.Trap().NewTimer(startupAwaitTimerTag)
+	defer newTimer.Close()
+	stopTimer := clock.Trap().TimerStop(startupAwaitTimerTag)
+	defer stopTimer.Close()
 
 	const waiters = 8
 	done := make(chan startupWait, waiters)
 	for range waiters {
 		go func() { done <- core.awaitInFlight("tab-1", time.Hour) }()
 	}
-	clock.waitArmed(t)
+	for range waiters {
+		call := newTimer.MustWait(ctx)
+		assert.Equal(t, time.Hour, call.Duration)
+		call.MustRelease(ctx)
+	}
 
-	core.succeed("tab-1", nil)
+	core.succeed(h.id, h)
+	for range waiters {
+		stopTimer.MustWait(ctx).MustRelease(ctx)
+	}
 	for range waiters {
 		select {
 		case got := <-done:
 			assert.Equal(t, startupWait{settled: true}, got)
-		case <-time.After(10 * time.Second):
+		case <-ctx.Done():
 			require.FailNow(t, "a waiter was left behind by the wake-up")
 		}
 	}
-	core.finishEntry(holder)
+	core.finishEntry(h)
 	core.WaitForInFlight()
 }
 
@@ -476,35 +727,34 @@ func TestStartupCore_ReleasingTheSameStartupTwiceIsSafe(t *testing.T) {
 
 	for _, tc := range []struct {
 		name  string
-		first func(core *startupCore)
-		then  func(core *startupCore)
+		first func(core *startupCore, h *startupEntry)
+		then  func(core *startupCore, h *startupEntry)
 	}{
 		{"succeed then succeed",
-			func(c *startupCore) { c.succeed("tab-1", nil) },
-			func(c *startupCore) { c.succeed("tab-1", nil) }},
+			func(c *startupCore, h *startupEntry) { c.succeed(h.id, h) },
+			func(c *startupCore, h *startupEntry) { c.succeed(h.id, h) }},
 		{"succeed then cancelAndClear",
-			func(c *startupCore) { c.succeed("tab-1", nil) },
-			func(c *startupCore) { c.cancelAndClear("tab-1", keepWorktreeOnClose) }},
+			func(c *startupCore, h *startupEntry) { c.succeed(h.id, h) },
+			func(c *startupCore, _ *startupEntry) { c.cancelAndClear("tab-1", keepWorktreeOnClose) }},
 		{"succeed then fail",
-			func(c *startupCore) { c.succeed("tab-1", nil) },
-			func(c *startupCore) { c.fail("tab-1", "boom") }},
+			func(c *startupCore, h *startupEntry) { c.succeed(h.id, h) },
+			func(c *startupCore, h *startupEntry) { c.fail(h, "boom") }},
 		{"cancelAndClear then succeed",
-			func(c *startupCore) { c.cancelAndClear("tab-1", keepWorktreeOnClose) },
-			func(c *startupCore) { c.succeed("tab-1", nil) }},
+			func(c *startupCore, _ *startupEntry) { c.cancelAndClear("tab-1", keepWorktreeOnClose) },
+			func(c *startupCore, h *startupEntry) { c.succeed(h.id, h) }},
 		{"fail then fail",
-			func(c *startupCore) { c.fail("tab-1", "boom") },
-			func(c *startupCore) { c.fail("tab-1", "boom again") }},
+			func(c *startupCore, h *startupEntry) { c.fail(h, "boom") },
+			func(c *startupCore, h *startupEntry) { c.fail(h, "boom again") }},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			core := newStartupCore()
-			core.clock = newFakeStartupClock()
-			holder := core.begin("tab-1", func() {})
-			require.NotNil(t, holder)
+			core := newTestStartupCore(t)
+			h := core.begin("tab-1", func() {})
+			require.NotNil(t, h)
 
-			tc.first(&core)
-			assert.NotPanics(t, func() { tc.then(&core) })
+			tc.first(&core, h)
+			assert.NotPanics(t, func() { tc.then(&core, h) })
 			// Whatever the pair did, the id must settle again without a wait:
 			// nothing is in flight for it any more. It settles as UNCLAIMED
 			// rather than as closed, because the entry the close stamped is
@@ -512,7 +762,7 @@ func TestStartupCore_ReleasingTheSameStartupTwiceIsSafe(t *testing.T) {
 			// close.
 			assert.Equal(t, startupWait{settled: true}, core.awaitInFlight("tab-1", time.Hour))
 
-			core.finishEntry(holder)
+			core.finishEntry(h)
 			core.WaitForInFlight()
 		})
 	}

--- a/backend/internal/worker/service/tab_payload_test.go
+++ b/backend/internal/worker/service/tab_payload_test.go
@@ -168,15 +168,27 @@ func TestTabPayload_RevokeRemovesAndEmits(t *testing.T) {
 
 	// Subscribe as the owner; expect a Revoked event after revoke.
 	got := make(chan *leapmuxv1.WorkerPrivateEvent, 4)
-	subCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	subCtx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
+	// The snapshot callback is the SIGNAL that this subscriber is attached:
+	// SnapshotAndSubscribe registers the channel under the bus lock and calls
+	// this only afterwards, so every event published from here on lands in it.
+	// A sleep in its place is a guess at how long the goroutine needs, and a
+	// loaded machine makes the guess wrong -- the revoke then publishes to
+	// nobody and the wait below reports an event the bus never had to send.
+	subscribed := make(chan struct{})
 	go func() {
-		_ = bus.SnapshotAndSubscribe(subCtx, userid.MustNew("user-1"), nil, func(evt *leapmuxv1.WorkerPrivateEvent) error {
-			got <- evt
-			return nil
-		})
+		_ = bus.SnapshotAndSubscribe(subCtx, userid.MustNew("user-1"),
+			func(userid.UserID) []*leapmuxv1.WorkerPrivateEvent {
+				close(subscribed)
+				return nil
+			},
+			func(evt *leapmuxv1.WorkerPrivateEvent) error {
+				got <- evt
+				return nil
+			})
 	}()
-	time.Sleep(50 * time.Millisecond)
+	<-subscribed
 
 	require.NoError(t, store.RevokeRow(ctx, "user-1", "t1"))
 
@@ -184,7 +196,7 @@ func TestTabPayload_RevokeRemovesAndEmits(t *testing.T) {
 	case evt := <-got:
 		require.NotNil(t, evt.GetTabPayloadRevoked(), "expected TabPayloadRevoked")
 		assert.Equal(t, "t1", evt.GetTabPayloadRevoked().GetTabId())
-	case <-time.After(time.Second):
+	case <-time.After(30 * time.Second):
 		t.Fatal("revoke did not produce a private event")
 	}
 
@@ -246,12 +258,19 @@ func TestTabPayload_SnapshotAndSubscribe_RaceFreeBootstrap(t *testing.T) {
 	// subsequent live event. The atomicity guarantee is critical: an
 	// external Register that lands during the subscribe call must not be
 	// missed.
-	subCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	subCtx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 	got := make(chan *leapmuxv1.WorkerPrivateEvent, 8)
+	// Closing at the TOP of the snapshot callback puts the live Register below
+	// strictly inside the subscribe call, which is the state this test is
+	// about. The sleep it replaces let the snapshot finish first on any
+	// unloaded machine, so the case never ran; on a loaded one the Register
+	// could instead beat the registration and be lost outright.
+	subscribed := make(chan struct{})
 	go func() {
 		_ = bus.SnapshotAndSubscribe(subCtx, userid.MustNew("user-1"),
 			func(owner userid.UserID) []*leapmuxv1.WorkerPrivateEvent {
+				close(subscribed)
 				snap, err := store.SnapshotForOwner(subCtx, owner)
 				if err != nil {
 					return nil
@@ -263,7 +282,7 @@ func TestTabPayload_SnapshotAndSubscribe_RaceFreeBootstrap(t *testing.T) {
 				return nil
 			})
 	}()
-	time.Sleep(50 * time.Millisecond)
+	<-subscribed
 
 	// A live Register after subscribe should arrive after the bootstrap
 	// snapshot.
@@ -272,7 +291,7 @@ func TestTabPayload_SnapshotAndSubscribe_RaceFreeBootstrap(t *testing.T) {
 	}))
 
 	collected := []*leapmuxv1.WorkerPrivateEvent{}
-	timeout := time.After(time.Second)
+	timeout := time.After(30 * time.Second)
 	for len(collected) < 2 {
 		select {
 		case evt := <-got:

--- a/backend/internal/worker/service/terminal.go
+++ b/backend/internal/worker/service/terminal.go
@@ -664,7 +664,7 @@ func (svc *Service) runTerminalStartup(ctx context.Context, opts terminal.Option
 	// above (e.g. the frontend's fit() was unusually slow, or a second
 	// resize has since landed). The PTY is already the correct size for
 	// the pre-wait case; this handler covers the rare late-arriving dims.
-	if cols, rows, ok := svc.TerminalStartup.takePendingResize(terminalID); ok {
+	if cols, rows, ok := svc.TerminalStartup.takePendingResize(h); ok {
 		if err := svc.Terminals.Resize(terminalID, cols, rows); err != nil {
 			slog.Warn("apply pending resize after startup", "terminal_id", terminalID, "error", err)
 		}

--- a/backend/internal/worker/terminal/manager.go
+++ b/backend/internal/worker/terminal/manager.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/coder/quartz"
 	"github.com/leapmux/leapmux/util/validate"
 )
 
@@ -50,7 +51,7 @@ type TerminalSnapshot struct {
 // not change that.
 //
 // The value only has to cover the scheduling of a reader the kernel already
-// woke, because waitForReadDrained starts it only after the child side of the
+// woke, because waitForReadDrainedWithin starts it only after the child side of the
 // pty is closed -- the act that wakes that reader. Measured from the exit
 // instead, this grace would also have to absorb the Windows console-host
 // flush, which happens between the two.
@@ -62,26 +63,39 @@ type Manager struct {
 	terminals map[string]*Terminal     // terminalID -> Terminal
 	meta      map[string]TerminalMeta  // terminalID -> metadata
 	exitDone  map[string]chan struct{} // terminalID -> closed once the exit-handler goroutine returned
-	// readDrainGrace limits the exit goroutine's wait for the reader. A field
-	// rather than a constant so a test can drive the give-up path without
-	// spending the real grace on it. Written only at construction -- by
-	// NewManager, or by a test before it installs a terminal -- so no lock
-	// guards it.
-	//
-	// A test reaching into an unexported field, and a REAL timer deciding what
-	// a deterministic clock should: startupCore.clock does the same job the
-	// other way. See https://github.com/leapmux/leapmux/issues/437.
-	readDrainGrace time.Duration
+	// clock is the one this Manager stamps on every Terminal it spawns, which
+	// makes "an installed terminal runs on the Manager's clock" hold by
+	// construction. The exit goroutine's two drain timers are armed from it, so
+	// a test drives the give-up path on this clock and spends no real time.
+	// NewManager installs the real clock; WithClock replaces it.
+	clock quartz.Clock
+}
+
+// ManagerOption changes one NewManager setting.
+type ManagerOption func(*Manager)
+
+// WithClock sets the clock that supplies reader-drain timers.
+func WithClock(clock quartz.Clock) ManagerOption {
+	if clock == nil {
+		panic("terminal: clock must not be nil")
+	}
+	return func(m *Manager) {
+		m.clock = clock
+	}
 }
 
 // NewManager creates a new terminal Manager.
-func NewManager() *Manager {
-	return &Manager{
-		terminals:      make(map[string]*Terminal),
-		meta:           make(map[string]TerminalMeta),
-		exitDone:       make(map[string]chan struct{}),
-		readDrainGrace: defaultReadDrainGrace,
+func NewManager(opts ...ManagerOption) *Manager {
+	m := &Manager{
+		terminals: make(map[string]*Terminal),
+		meta:      make(map[string]TerminalMeta),
+		exitDone:  make(map[string]chan struct{}),
+		clock:     quartz.NewReal(),
 	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
 }
 
 // ExitHandler is called when a terminal process exits.
@@ -101,7 +115,7 @@ func (m *Manager) StartTerminal(ctx context.Context, opts Options, outputFn Outp
 	}
 	m.mu.Unlock()
 
-	t, err := Start(ctx, opts, outputFn)
+	t, err := Start(ctx, opts, m.clock, outputFn)
 	if err != nil {
 		return err
 	}
@@ -158,13 +172,14 @@ func (m *Manager) installTerminal(id string, t *Terminal, exitFn ExitHandler, co
 		// end it: this process holds the child side too, and on Linux a master
 		// read ends only when the last descriptor for the tty is gone. The
 		// grace covers the holders this worker cannot reach -- see
-		// Terminal.waitForReadDrained, which starts it only once that close
-		// finished. A shell that leaves no such holder behind never reaches it.
-		if !t.waitForReadDrained(m.readDrainGrace) {
+		// Terminal.waitForReadDrainedWithin, which starts it only once that
+		// close finished. A shell that leaves no such holder behind never
+		// reaches it.
+		if !t.waitForReadDrainedWithin(defaultReadDrainGrace) {
 			slog.Warn("terminal reader did not drain after the shell exited; "+
 				"persisting the screen without its last output",
 				"terminal_id", id,
-				"grace", m.readDrainGrace,
+				"grace", defaultReadDrainGrace,
 			)
 		}
 		if exitFn != nil {
@@ -278,7 +293,7 @@ func (m *Manager) RestartTerminal(
 		prev.Stop()
 		t, err = prev.Respawn(ctx, opts, outputFn)
 	} else {
-		t, err = startWithScreenBuffer(ctx, opts, NewScreenBufferWithOffset(fallbackOffset), outputFn)
+		t, err = startWithScreenBuffer(ctx, opts, m.clock, NewScreenBufferWithOffset(fallbackOffset), outputFn)
 	}
 	if err != nil {
 		return err
@@ -369,11 +384,11 @@ func (m *Manager) IsExited(terminalID string) bool {
 }
 
 // WaitForReadDrained blocks until the terminal's read goroutine drained (see
-// Terminal.waitForReadDrained). Returns false if the terminal is unknown.
+// Terminal.waitForReadDone). Returns false if the terminal is unknown.
 //
 // It waits with NO limit, which is why it is a test-only entry point: every
 // caller of it stops the terminal first, so the reader is already ending.
-// Production waits through installTerminal, which passes the manager's grace.
+// Production waits through installTerminal, which passes defaultReadDrainGrace.
 func (m *Manager) WaitForReadDrained(terminalID string) bool {
 	m.mu.RLock()
 	t, ok := m.terminals[terminalID]
@@ -382,7 +397,7 @@ func (m *Manager) WaitForReadDrained(terminalID string) bool {
 	if !ok {
 		return false
 	}
-	t.waitForReadDrained(0)
+	t.waitForReadDone()
 	return true
 }
 

--- a/backend/internal/worker/terminal/terminal.go
+++ b/backend/internal/worker/terminal/terminal.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	pty "github.com/aymanbagabas/go-pty"
+	"github.com/coder/quartz"
 
 	"github.com/leapmux/leapmux/internal/util/envutil"
 	"github.com/leapmux/leapmux/internal/worker/gitutil"
@@ -20,6 +21,11 @@ import (
 )
 
 const screenBufferSize = 100 * 1024 // 100KB ring buffer for screen restore
+
+const (
+	terminalChildCloseTimerTag = "terminal-child-close"
+	terminalReadDrainTimerTag  = "terminal-read-drain"
+)
 
 // ScreenBuffer is a thread-safe ring buffer that stores recent PTY output.
 // It also tracks a cumulative byte counter so callers can resume from a
@@ -287,6 +293,15 @@ type Terminal struct {
 	cmd       *pty.Cmd
 	ptmx      pty.Pty
 	jobObject *procutil.JobObject
+	// clock supplies the two timers waitForReadDrainedWithin arms. The
+	// constructor requires it, so a Terminal cannot exist without one and a
+	// timer added later in this file finds the right clock already in scope.
+	// The alternative is a caller that forgets to thread it and falls back to
+	// the `time` package, which is the drift a mock clock cannot see.
+	//
+	// Respawn passes t.clock through, so a restarted terminal inherits it
+	// instead of depending on its caller to remember.
+	clock quartz.Clock
 	// outputFn is the internal dispatch for both live PTY reads and
 	// AppendOutput. It writes into screenBuf and forwards the resulting
 	// cumulative offset to the user-provided OutputHandler, through
@@ -391,14 +406,23 @@ func spawnEnv(environ, extraEnv []string) []string {
 // process the usual exec.CommandContext kill signal. The caller still
 // owns the long-running Terminal — its lifetime is independent of ctx
 // once Start returns successfully.
-func Start(ctx context.Context, opts Options, outputFn OutputHandler) (*Terminal, error) {
-	return startWithScreenBuffer(ctx, opts, NewScreenBuffer(), outputFn)
+func Start(ctx context.Context, opts Options, clock quartz.Clock, outputFn OutputHandler) (*Terminal, error) {
+	return startWithScreenBuffer(ctx, opts, clock, NewScreenBuffer(), outputFn)
 }
 
 // startWithScreenBuffer is the actual spawn implementation, parameterized
 // over the ScreenBuffer so RestartTerminal can carry the cumulative
 // offset (and any retained bytes) across PTY incarnations.
-func startWithScreenBuffer(ctx context.Context, opts Options, screenBuf *ScreenBuffer, outputFn OutputHandler) (*Terminal, error) {
+func startWithScreenBuffer(
+	ctx context.Context,
+	opts Options,
+	clock quartz.Clock,
+	screenBuf *ScreenBuffer,
+	outputFn OutputHandler,
+) (*Terminal, error) {
+	if clock == nil {
+		panic("terminal: clock must not be nil")
+	}
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -463,6 +487,7 @@ func startWithScreenBuffer(ctx context.Context, opts Options, screenBuf *ScreenB
 
 	t := &Terminal{
 		id:                opts.ID,
+		clock:             clock,
 		cmd:               cmd,
 		ptmx:              ptmx,
 		jobObject:         jobObject,
@@ -565,9 +590,56 @@ func (t *Terminal) Wait() int {
 	return t.exitCode
 }
 
-// waitForReadDrained blocks until readOutput returns, after which the screen
-// buffer's cumulative offset is stable, and reports whether the reader finished
-// inside `within`. A non-positive `within` waits with no limit.
+// waitForReadDone blocks with no limit until readOutput returns, after which
+// the screen buffer's cumulative offset is stable.
+//
+// Only a caller that already stopped the terminal uses this. Stop closes the
+// worker side of the pty, which ends the reader at once.
+// waitForReadDrainedWithin serves the caller that stopped nothing, where a
+// descendant that escaped the shell's kill group can hold the reader open for
+// ever.
+func (t *Terminal) waitForReadDone() {
+	<-t.readDoneCh
+}
+
+// childCloseOutcome says what ended the first stage of the drain wait.
+type childCloseOutcome int
+
+const (
+	// childSideClosed means the close that ends the reader finished. The
+	// reader-drain stage runs next.
+	childSideClosed childCloseOutcome = iota
+	// readerFinishedFirst means readOutput returned before the close, so the
+	// screen is already stable and no drain wait remains.
+	readerFinishedFirst
+	// childCloseGaveUp means the close did not finish inside the grace.
+	childCloseGaveUp
+)
+
+// waitForChildSideClose blocks until the natural-exit path closes the child
+// side of the pty -- the act that ends the reader -- or `within` runs out.
+//
+// A method of its own, so the deferred stop ends with THIS stage. A defer in
+// the caller runs when the caller returns. It would leave this timer armed for
+// the whole of the reader-drain stage, and the code would then hold two live
+// timers for one budget.
+func (t *Terminal) waitForChildSideClose(within time.Duration) childCloseOutcome {
+	timer := t.clock.NewTimer(within, terminalChildCloseTimerTag)
+	defer timer.Stop(terminalChildCloseTimerTag)
+	select {
+	case <-t.childSideClosedCh:
+		return childSideClosed
+	case <-t.readDoneCh:
+		// Already finished, by Stop's close or by the child's own EOF.
+		return readerFinishedFirst
+	case <-timer.C:
+		return childCloseGaveUp
+	}
+}
+
+// waitForReadDrainedWithin blocks until readOutput returns, after which the
+// screen buffer's cumulative offset is stable, and reports whether the reader
+// finished inside `within`.
 //
 // The limit exists for a pty this worker cannot end. The natural-exit path
 // closes the child side, and on a Unix tty that ends the reader only once the
@@ -583,11 +655,13 @@ func (t *Terminal) Wait() int {
 // for the reader itself. Measured as one budget from the exit, the flush would
 // consume the grace and it would expire before the reader was ever scheduled.
 // Stop never closes childSideClosedCh, so a caller that stopped the terminal
-// takes the direct path below -- it discards the unread output by design.
-func (t *Terminal) waitForReadDrained(within time.Duration) bool {
+// calls waitForReadDone instead -- it discards the unread output by design.
+//
+// `within` must be positive. A non-positive limit fires both timers at once on
+// the real clock and on a mock, which turns the grace into no wait at all.
+func (t *Terminal) waitForReadDrainedWithin(within time.Duration) bool {
 	if within <= 0 {
-		<-t.readDoneCh
-		return true
+		panic("terminal: waitForReadDrainedWithin needs a positive limit; use waitForReadDone")
 	}
 	// TWO waits, each with its OWN budget of `within`, because each can hang for
 	// a different reason and neither may spend the other's budget.
@@ -598,18 +672,16 @@ func (t *Terminal) waitForReadDrained(within time.Duration) bool {
 	// reader's grace and give up before the reader was ever scheduled -- on the
 	// one platform this whole path exists for. No timer at all would strand the
 	// caller there instead, which loses the exit outright.
-	closed := time.NewTimer(within)
-	defer closed.Stop()
-	select {
-	case <-t.childSideClosedCh:
-	case <-t.readDoneCh:
-		// Already finished, by Stop's close or by the child's own EOF.
+	switch t.waitForChildSideClose(within) {
+	case readerFinishedFirst:
 		return true
-	case <-closed.C:
+	case childCloseGaveUp:
 		return false
+	case childSideClosed:
+		// The reader is ending now. It gets its own budget below.
 	}
-	drained := time.NewTimer(within)
-	defer drained.Stop()
+	drained := t.clock.NewTimer(within, terminalReadDrainTimerTag)
+	defer drained.Stop(terminalReadDrainTimerTag)
 	select {
 	case <-t.readDoneCh:
 		return true
@@ -677,7 +749,7 @@ func (t *Terminal) ScreenSnapshot() ([]byte, int64) {
 // is no longer writing to t.screenBuf. Manager.RestartTerminal enforces
 // this under m.mu; external callers must do their own ordering.
 func (t *Terminal) Respawn(ctx context.Context, opts Options, outputFn OutputHandler) (*Terminal, error) {
-	return startWithScreenBuffer(ctx, opts, t.screenBuf, outputFn)
+	return startWithScreenBuffer(ctx, opts, t.clock, t.screenBuf, outputFn)
 }
 
 // ScreenSnapshotSince returns the bytes a subscriber needs to advance

--- a/backend/internal/worker/terminal/terminal_test.go
+++ b/backend/internal/worker/terminal/terminal_test.go
@@ -8,9 +8,11 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/coder/quartz"
 	"github.com/leapmux/leapmux/internal/util/sqlitedb"
 	"github.com/leapmux/leapmux/internal/util/testutil"
 	workerdb "github.com/leapmux/leapmux/internal/worker/db"
@@ -18,6 +20,143 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestManagerWithClockRejectsNil(t *testing.T) {
+	t.Parallel()
+	assert.Panics(t, func() { WithClock(nil) })
+}
+
+func TestNewManagerUsesRealClockByDefault(t *testing.T) {
+	t.Parallel()
+	m := NewManager()
+	require.IsType(t, quartz.NewReal(), m.clock,
+		"NewManager must wire the real clock, not a seeded mock a WithinDuration check would accept")
+}
+
+// TestStartRejectsNilClock pins the constructor guard. Start is the only route
+// to a Terminal that the drain path can reach, so refusing a nil clock here is
+// what makes "an installed terminal always has a clock" true by construction --
+// the alternative is a nil dereference inside the exit goroutine, far from the
+// call that omitted it.
+func TestStartRejectsNilClock(t *testing.T) {
+	t.Parallel()
+	assert.Panics(t, func() {
+		//nolint:errcheck // the panic is the assertion; Start never returns here.
+		_, _ = Start(t.Context(), Options{
+			ID:         "nil-clock",
+			Shell:      testutil.TestShell(),
+			WorkingDir: t.TempDir(),
+			Cols:       80,
+			Rows:       24,
+		}, nil, func([]byte, int64, []Signal) {})
+	})
+}
+
+// TestWaitForReadDrainedWithinRejectsANonPositiveLimit pins the other half of
+// the split. A non-positive limit fires both timers at once, on the real clock
+// and on a mock alike, so the "grace" becomes no wait at all and the caller
+// silently loses the shell's last output. waitForReadDone is the unlimited
+// wait; this method refuses to impersonate it.
+func TestWaitForReadDrainedWithinRejectsANonPositiveLimit(t *testing.T) {
+	t.Parallel()
+	for _, within := range []time.Duration{0, -time.Second} {
+		term := newDrainTestTerminal("nonpositive-limit", testutil.NewQuartzMock(t))
+		assert.Panicsf(t, func() { term.waitForReadDrainedWithin(within) },
+			"a limit of %s must be refused, not treated as an unlimited wait", within)
+	}
+}
+
+// armCountingClock is the Quartz mock plus a count of the drain timers armed on
+// it. Every other method routes to the embedded mock, so a test drives it
+// exactly as it drives a plain *quartz.Mock. It holds no time of its own, so it
+// is a decorator rather than a second fake clock.
+//
+// The count is what a trap cannot supply. A trap holds each NewTimer call until
+// the test collects it, and quartz matches the trap BEFORE it registers the
+// timer -- so an EXTRA arm parks inside the trap and registers no event, Peek
+// reports an empty clock, and every "both stages stopped their timers"
+// assertion passes on the very regression it exists to catch. arms counts the
+// call itself, before the trap sees it.
+type armCountingClock struct {
+	*quartz.Mock
+	arms sync.Map // tag -> *atomic.Int64
+}
+
+func (c *armCountingClock) NewTimer(d time.Duration, tags ...string) *quartz.Timer {
+	for _, tag := range tags {
+		counter, _ := c.arms.LoadOrStore(tag, &atomic.Int64{})
+		counter.(*atomic.Int64).Add(1)
+	}
+	return c.Mock.NewTimer(d, tags...)
+}
+
+// armCount reports how many timers carrying tag the code armed so far.
+func (c *armCountingClock) armCount(tag string) int {
+	counter, ok := c.arms.Load(tag)
+	if !ok {
+		return 0
+	}
+	return int(counter.(*atomic.Int64).Load())
+}
+
+type terminalDrainHarness struct {
+	clock      *armCountingClock
+	manager    *Manager
+	ctx        context.Context
+	childTimer *quartz.Trap
+	childStop  *quartz.Trap
+	drainTimer *quartz.Trap
+	drainStop  *quartz.Trap
+}
+
+func newTerminalDrainHarness(t *testing.T) terminalDrainHarness {
+	t.Helper()
+	clock := &armCountingClock{Mock: testutil.NewQuartzMock(t)}
+	h := terminalDrainHarness{
+		clock:      clock,
+		manager:    NewManager(WithClock(clock)),
+		ctx:        testutil.DeadlineContext(t),
+		childTimer: clock.Trap().NewTimer(terminalChildCloseTimerTag),
+		childStop:  clock.Trap().TimerStop(terminalChildCloseTimerTag),
+		drainTimer: clock.Trap().NewTimer(terminalReadDrainTimerTag),
+		drainStop:  clock.Trap().TimerStop(terminalReadDrainTimerTag),
+	}
+	t.Cleanup(func() {
+		h.childTimer.Close()
+		h.childStop.Close()
+		h.drainTimer.Close()
+		h.drainStop.Close()
+	})
+	return h
+}
+
+// assertStagesArmed states BOTH halves of "the timers are accounted for": no
+// event is left on the clock, AND each stage armed exactly the number of timers
+// the code is supposed to arm. Peek alone cannot see an extra arm that is still
+// parked in a trap, so the counts are what make the negative real.
+func (h terminalDrainHarness) assertStagesArmed(t *testing.T, childArms, drainArms int, msg string) {
+	t.Helper()
+	_, running := h.clock.Peek()
+	assert.False(t, running, msg)
+	assert.Equal(t, childArms, h.clock.armCount(terminalChildCloseTimerTag),
+		"child-close stage arm count")
+	assert.Equal(t, drainArms, h.clock.armCount(terminalReadDrainTimerTag),
+		"reader-drain stage arm count")
+}
+
+// newDrainTestTerminal builds the bare Terminal the drain tests install. It
+// takes the harness clock because a Terminal built outside startWithScreenBuffer
+// skips the constructor's nil guard, and the drain path dereferences the clock.
+func newDrainTestTerminal(id string, clock quartz.Clock) *Terminal {
+	return &Terminal{
+		id:                id,
+		clock:             clock,
+		exitCh:            make(chan struct{}),
+		readDoneCh:        make(chan struct{}),
+		childSideClosedCh: make(chan struct{}),
+		screenBuf:         NewScreenBuffer(),
+	}
+}
 
 func TestTerminal_StartAndStop(t *testing.T) {
 	var mu sync.Mutex
@@ -29,7 +168,7 @@ func TestTerminal_StartAndStop(t *testing.T) {
 		WorkingDir: t.TempDir(),
 		Cols:       80,
 		Rows:       24,
-	}, func(data []byte, _ int64, _ []Signal) {
+	}, quartz.NewReal(), func(data []byte, _ int64, _ []Signal) {
 		mu.Lock()
 		output = append(output, data...)
 		mu.Unlock()
@@ -82,7 +221,7 @@ func TestTerminal_AppImage_ScrubsEnv(t *testing.T) {
 		WorkingDir: t.TempDir(),
 		Cols:       80,
 		Rows:       24,
-	}, func(data []byte, _ int64, _ []Signal) {
+	}, quartz.NewReal(), func(data []byte, _ int64, _ []Signal) {
 		mu.Lock()
 		defer mu.Unlock()
 		output = append(output, data...)
@@ -146,7 +285,7 @@ func TestTerminal_Resize(t *testing.T) {
 		WorkingDir: t.TempDir(),
 		Cols:       80,
 		Rows:       24,
-	}, func([]byte, int64, []Signal) {})
+	}, quartz.NewReal(), func([]byte, int64, []Signal) {})
 	require.NoError(t, err, "Start")
 	defer func() {
 		term.Stop()
@@ -161,7 +300,7 @@ func TestTerminal_SendInputAfterStop(t *testing.T) {
 		ID:         "test-stopped",
 		Shell:      testutil.TestShell(),
 		WorkingDir: t.TempDir(),
-	}, func([]byte, int64, []Signal) {})
+	}, quartz.NewReal(), func([]byte, int64, []Signal) {})
 	require.NoError(t, err, "Start")
 
 	term.Stop()
@@ -183,7 +322,7 @@ func TestTerminal_StopAfterANaturalExitIsSafe(t *testing.T) {
 		ID:         "test-natural-exit-stop",
 		Shell:      testutil.TestShell(),
 		WorkingDir: t.TempDir(),
-	}, func([]byte, int64, []Signal) {})
+	}, quartz.NewReal(), func([]byte, int64, []Signal) {})
 	require.NoError(t, err, "Start")
 	t.Cleanup(term.Stop)
 
@@ -228,7 +367,7 @@ func TestTerminal_ResizeRacingANaturalExitIsSafe(t *testing.T) {
 		WorkingDir: t.TempDir(),
 		Cols:       80,
 		Rows:       24,
-	}, func([]byte, int64, []Signal) {})
+	}, quartz.NewReal(), func([]byte, int64, []Signal) {})
 	require.NoError(t, err, "Start")
 	t.Cleanup(term.Stop)
 
@@ -276,7 +415,7 @@ func TestTerminal_IsExited(t *testing.T) {
 		ID:         "test-exited",
 		Shell:      testutil.TestShell(),
 		WorkingDir: t.TempDir(),
-	}, func([]byte, int64, []Signal) {})
+	}, quartz.NewReal(), func([]byte, int64, []Signal) {})
 	require.NoError(t, err, "Start")
 
 	assert.False(t, term.IsExited(), "expected IsExited = false before stop")
@@ -389,41 +528,46 @@ func TestManager_ExitNotification(t *testing.T) {
 // is asserted rather than raced for. What ENDS a real reader is the subject of
 // TestManager_NaturalExitRunsTheExitHandler; this test covers only the wait.
 func TestInstallTerminal_ExitHandlerWaitsForTheReaderToDrain(t *testing.T) {
-	m := NewManager()
+	h := newTerminalDrainHarness(t)
 	const id = "tm-exit-order"
 
 	// No PTY: only the channels installTerminal orders against.
-	term := &Terminal{
-		id:                id,
-		exitCh:            make(chan struct{}),
-		readDoneCh:        make(chan struct{}),
-		childSideClosedCh: make(chan struct{}),
-		screenBuf:         NewScreenBuffer(),
-	}
+	term := newDrainTestTerminal(id, h.clock)
 	ran := make(chan struct{})
-	m.installTerminal(id, term, func(string, int) { close(ran) },
+	h.manager.installTerminal(id, term, func(string, int) { close(ran) },
 		func(TerminalMeta) TerminalMeta { return TerminalMeta{} })
 
-	// The child is reaped and the child side of the pty is closed, in the order
-	// waitForExit performs them. The reader has not finished.
+	// waitForExit reaps the child. The handler first waits for the child side to close.
 	close(term.exitCh)
+	call := h.childTimer.MustWait(h.ctx)
+	assert.Equal(t, defaultReadDrainGrace, call.Duration)
+	call.MustRelease(h.ctx)
+	select {
+	case <-ran:
+		require.FailNow(t, "the exit handler ran before the child side closed")
+	default:
+	}
+
 	close(term.childSideClosedCh)
+	h.childStop.MustWait(h.ctx).MustRelease(h.ctx)
+	call = h.drainTimer.MustWait(h.ctx)
+	assert.Equal(t, defaultReadDrainGrace, call.Duration)
+	call.MustRelease(h.ctx)
 	select {
 	case <-ran:
 		require.Fail(t, "the exit handler ran while the reader could still write the screen it persists")
-	case <-time.After(100 * time.Millisecond):
-		// The window only limits a "has not happened yet" claim, so a slow
-		// machine can only make this case weaker, never make it fail wrongly.
-		// Without the wait the handler runs at once and this fails every run.
+	default:
 	}
 
 	close(term.readDoneCh)
+	h.drainStop.MustWait(h.ctx).MustRelease(h.ctx)
 	select {
 	case <-ran:
-	case <-time.After(10 * time.Second):
+	case <-h.ctx.Done():
 		require.Fail(t, "the exit handler never ran after the reader drained")
 	}
-	m.WaitForExit(id)
+	h.manager.WaitForExit(id)
+	h.assertStagesArmed(t, 1, 1, "both completed stages must stop their timers")
 }
 
 // TestInstallTerminal_ExitHandlerGivesUpOnAReaderThatNeverDrains pins the limit
@@ -433,33 +577,34 @@ func TestInstallTerminal_ExitHandlerWaitsForTheReaderToDrain(t *testing.T) {
 // a natural exit performs, so waiting for ever would lose the exit code and the
 // screen outright. A screen one chunk short is the better answer.
 func TestInstallTerminal_ExitHandlerGivesUpOnAReaderThatNeverDrains(t *testing.T) {
-	m := NewManager()
-	// A real grace would spend itself on every run of this test for nothing:
-	// the reader here is one that never drains, by construction.
-	m.readDrainGrace = 10 * time.Millisecond
+	h := newTerminalDrainHarness(t)
 	const id = "tm-exit-stuck-reader"
 
-	term := &Terminal{
-		id:                id,
-		exitCh:            make(chan struct{}),
-		readDoneCh:        make(chan struct{}),
-		childSideClosedCh: make(chan struct{}),
-		screenBuf:         NewScreenBuffer(),
-	}
+	term := newDrainTestTerminal(id, h.clock)
 	ran := make(chan struct{})
-	m.installTerminal(id, term, func(string, int) { close(ran) },
+	h.manager.installTerminal(id, term, func(string, int) { close(ran) },
 		func(TerminalMeta) TerminalMeta { return TerminalMeta{} })
 
-	// The child is reaped, the child side is closed, and the reader never
-	// finishes.
+	// waitForExit reaps the child, the child side closes, and the reader never finishes.
 	close(term.exitCh)
+	call := h.childTimer.MustWait(h.ctx)
+	assert.Equal(t, defaultReadDrainGrace, call.Duration)
+	call.MustRelease(h.ctx)
 	close(term.childSideClosedCh)
+	h.childStop.MustWait(h.ctx).MustRelease(h.ctx)
+	call = h.drainTimer.MustWait(h.ctx)
+	assert.Equal(t, defaultReadDrainGrace, call.Duration)
+	call.MustRelease(h.ctx)
+	advance := h.clock.Advance(defaultReadDrainGrace)
+	h.drainStop.MustWait(h.ctx).MustRelease(h.ctx)
+	advance.MustWait(h.ctx)
 	select {
 	case <-ran:
-	case <-time.After(10 * time.Second):
+	case <-h.ctx.Done():
 		require.Fail(t, "the exit handler never ran for a reader that never drained")
 	}
-	m.WaitForExit(id)
+	h.manager.WaitForExit(id)
+	h.assertStagesArmed(t, 1, 1, "the expired drain timer must leave no event")
 }
 
 // TestInstallTerminal_TheGraceStartsAtTheChildSideClose pins WHERE the drain
@@ -473,42 +618,93 @@ func TestInstallTerminal_ExitHandlerGivesUpOnAReaderThatNeverDrains(t *testing.T
 // scheduled, losing the shell's last output on the one platform this whole path
 // exists for.
 func TestInstallTerminal_TheGraceStartsAtTheChildSideClose(t *testing.T) {
-	m := NewManager()
-	// Each phase below takes well under the grace on its own, and their SUM
-	// takes well over it -- so this passes only if the two phases hold separate
-	// budgets, and fails for one shared budget started at the exit.
-	m.readDrainGrace = 500 * time.Millisecond
-	const phase = 300 * time.Millisecond
+	h := newTerminalDrainHarness(t)
 	const id = "tm-exit-late-child-close"
 
-	term := &Terminal{
-		id:                id,
-		exitCh:            make(chan struct{}),
-		readDoneCh:        make(chan struct{}),
-		childSideClosedCh: make(chan struct{}),
-		screenBuf:         NewScreenBuffer(),
-	}
+	term := newDrainTestTerminal(id, h.clock)
 	drained := make(chan bool, 1)
-	m.installTerminal(id, term, func(string, int) { drained <- readerEnded(m, id) },
+	h.manager.installTerminal(id, term, func(string, int) { drained <- readerEnded(h.manager, id) },
 		func(TerminalMeta) TerminalMeta { return TerminalMeta{} })
 
-	// The child is reaped. The close that ends the reader takes a while --
+	// waitForExit reaps the child. The close that ends the reader takes a while --
 	// stand in for the console-host flush.
 	close(term.exitCh)
-	time.Sleep(phase)
+	call := h.childTimer.MustWait(h.ctx)
+	assert.Equal(t, defaultReadDrainGrace, call.Duration)
+	call.MustRelease(h.ctx)
+	h.clock.Advance(defaultReadDrainGrace - 1).MustWait(h.ctx)
 	close(term.childSideClosedCh)
-	// Only NOW does the reader wake, and it takes a while of its own.
-	time.Sleep(phase)
+	h.childStop.MustWait(h.ctx).MustRelease(h.ctx)
+	call = h.drainTimer.MustWait(h.ctx)
+	assert.Equal(t, defaultReadDrainGrace, call.Duration)
+	call.MustRelease(h.ctx)
+
+	// The second stage receives a full grace period from its own start.
+	h.clock.Advance(defaultReadDrainGrace - 1).MustWait(h.ctx)
+	select {
+	case <-drained:
+		require.FailNow(t, "the first stage consumed the reader-drain grace")
+	default:
+	}
 	close(term.readDoneCh)
+	h.drainStop.MustWait(h.ctx).MustRelease(h.ctx)
 
 	select {
 	case ok := <-drained:
 		assert.True(t, ok,
 			"the flush before the child-side close spent the reader's own grace; the two need separate budgets")
-	case <-time.After(10 * time.Second):
+	case <-h.ctx.Done():
 		require.Fail(t, "the exit handler never ran")
 	}
-	m.WaitForExit(id)
+	h.manager.WaitForExit(id)
+	h.assertStagesArmed(t, 1, 1, "both stage timers must stop after early completion")
+}
+
+func TestInstallTerminal_ExitHandlerGivesUpWhenChildSideNeverCloses(t *testing.T) {
+	h := newTerminalDrainHarness(t)
+	const id = "tm-exit-stuck-child-close"
+	term := newDrainTestTerminal(id, h.clock)
+	ran := make(chan struct{})
+	h.manager.installTerminal(id, term, func(string, int) { close(ran) },
+		func(TerminalMeta) TerminalMeta { return TerminalMeta{} })
+
+	close(term.exitCh)
+	call := h.childTimer.MustWait(h.ctx)
+	assert.Equal(t, defaultReadDrainGrace, call.Duration)
+	call.MustRelease(h.ctx)
+	advance := h.clock.Advance(defaultReadDrainGrace)
+	h.childStop.MustWait(h.ctx).MustRelease(h.ctx)
+	advance.MustWait(h.ctx)
+	select {
+	case <-ran:
+	case <-h.ctx.Done():
+		require.FailNow(t, "the exit handler waited past the child-close grace")
+	}
+	h.manager.WaitForExit(id)
+	h.assertStagesArmed(t, 1, 0, "the expired child-close timer must leave no event")
+}
+
+func TestInstallTerminal_EarlyReaderCompletionSkipsDrainStage(t *testing.T) {
+	h := newTerminalDrainHarness(t)
+	const id = "tm-exit-reader-already-done"
+	term := newDrainTestTerminal(id, h.clock)
+	ran := make(chan struct{})
+	h.manager.installTerminal(id, term, func(string, int) { close(ran) },
+		func(TerminalMeta) TerminalMeta { return TerminalMeta{} })
+
+	close(term.exitCh)
+	call := h.childTimer.MustWait(h.ctx)
+	assert.Equal(t, defaultReadDrainGrace, call.Duration)
+	call.MustRelease(h.ctx)
+	close(term.readDoneCh)
+	h.childStop.MustWait(h.ctx).MustRelease(h.ctx)
+	select {
+	case <-ran:
+	case <-h.ctx.Done():
+		require.FailNow(t, "the exit handler did not observe the completed reader")
+	}
+	h.manager.WaitForExit(id)
+	h.assertStagesArmed(t, 1, 0, "early reader completion must stop the child-close timer")
 }
 
 // readerEnded reports whether the terminal's read goroutine returned. It
@@ -541,20 +737,24 @@ func readerEnded(m *Manager, id string) bool {
 // is what ends it. Darwin is the one platform that hides the defect, because it
 // revokes the tty when the session leader exits.
 func TestManager_NaturalExitRunsTheExitHandler(t *testing.T) {
-	m := NewManager()
-	// A LONGER grace than production's, because this test asserts that the
-	// reader drained and the production value is what decides that on a loaded
-	// runner. Shortening it would make the flake worse, and zero would remove
-	// the limit entirely, which turns `drained` into a tautology.
-	m.readDrainGrace = 30 * time.Second
+	// A Quartz mock this test NEVER advances, so neither drain stage can expire.
+	// That makes the give-up path unreachable. Reaching the exit handler at all
+	// is therefore the proof that the child-side close ended the reader. The
+	// defect this test covers now fails as the deadline below. The shell and its
+	// pty are real, so nothing else here is mocked.
+	//
+	// The production grace is 2s, and a real timer would decide this test on a
+	// loaded runner rather than on the code. That is why the test used to raise
+	// the grace by hand. TestInstallTerminal_ExitHandlerGivesUpOnAReaderThatNeverDrains
+	// asserts the exact grace each stage arms.
+	m := NewManager(WithClock(testutil.NewQuartzMock(t)))
 	const id = "tm-natural-exit"
 	const marker = "natural_exit_marker"
 	const lastMarker = "natural_exit_last_write"
 
 	type exitReport struct {
-		code    int
-		screen  []byte
-		drained bool
+		code   int
+		screen []byte
 	}
 	exited := make(chan exitReport, 1)
 	require.NoError(t, m.StartTerminal(context.Background(), Options{
@@ -568,11 +768,7 @@ func TestManager_NaturalExitRunsTheExitHandler(t *testing.T) {
 		// persist a natural exit performs, so what is on the screen HERE is
 		// what the tab keeps.
 		screen, _, _ := m.ScreenSnapshotSince(tid, 0)
-		// Read the drain signal HERE, not after: the handler runs either
-		// because the reader ended or because the grace expired, and only this
-		// point tells the two apart. Asserting on the handler alone would pass
-		// on the give-up path and hide the very defect this test covers.
-		exited <- exitReport{code: code, screen: screen, drained: readerEnded(m, tid)}
+		exited <- exitReport{code: code, screen: screen}
 	}))
 	t.Cleanup(func() { m.RemoveTerminal(id) })
 
@@ -605,11 +801,9 @@ func TestManager_NaturalExitRunsTheExitHandler(t *testing.T) {
 	select {
 	case got = <-exited:
 	case <-time.After(30 * time.Second):
-		require.Fail(t, "the exit handler never ran for a shell that exited on its own")
+		require.Fail(t, "the exit handler never ran for a shell that exited on its own; "+
+			"no grace can expire on this clock, so the reader never ended")
 	}
-
-	require.True(t, got.drained,
-		"the natural exit must end the reader; the handler only ran because the grace expired")
 
 	if runtime.GOOS != "windows" {
 		assert.Equal(t, 7, got.code, "the handler must carry the shell's own exit code")
@@ -980,7 +1174,7 @@ func TestTerminal_AppendOutputCannotOvertakeLiveOutput(t *testing.T) {
 		WorkingDir: t.TempDir(),
 		Cols:       80,
 		Rows:       24,
-	}, func(data []byte, endOffset int64, _ []Signal) {
+	}, quartz.NewReal(), func(data []byte, endOffset int64, _ []Signal) {
 		mu.Lock()
 		defer mu.Unlock()
 		if !bytes.Equal(data, notice) {

--- a/backend/util/clockjump/clockjump_test.go
+++ b/backend/util/clockjump/clockjump_test.go
@@ -12,39 +12,38 @@ import (
 	"github.com/leapmux/leapmux/internal/util/testutil"
 )
 
-// fakeClock drives the two readings apart, which is the whole point of the
-// clock seam: a suspend advances the wall clock while the monotonic clock stays
-// put, and no time.Time can be built that way (see the clock interface).
-type fakeClock struct {
+// scriptedReadings moves the two readings independently. Quartz cannot model
+// a suspend that moves wall time while monotonic time stays unchanged.
+type scriptedReadings struct {
 	mono time.Duration
 	now  time.Time
 }
 
-func newFakeClock() *fakeClock {
+func newScriptedReadings() *scriptedReadings {
 	// A fixed instant, not time.Now: the wall reading must be free of a
 	// monotonic reading so Sub between two of them is a true wall difference.
-	return &fakeClock{now: time.Date(2026, 8, 22, 9, 0, 0, 0, time.UTC)}
+	return &scriptedReadings{now: time.Date(2026, 8, 22, 9, 0, 0, 0, time.UTC)}
 }
 
-func (c *fakeClock) monotonic() time.Duration { return c.mono }
-func (c *fakeClock) wall() time.Time          { return c.now }
+func (c *scriptedReadings) monotonic() time.Duration { return c.mono }
+func (c *scriptedReadings) wall() time.Time          { return c.now }
 
 // advance moves both clocks by the same amount: an ordinary interval in which
 // the process ran the whole time.
-func (c *fakeClock) advance(d time.Duration) {
+func (c *scriptedReadings) advance(d time.Duration) {
 	c.mono += d
 	c.now = c.now.Add(d)
 }
 
 // pause moves ONLY the wall clock, which is what a suspended process observes:
 // real time passed and it ran for none of it.
-func (c *fakeClock) pause(d time.Duration) { c.now = c.now.Add(d) }
+func (c *scriptedReadings) pause(d time.Duration) { c.now = c.now.Add(d) }
 
 // stepBack moves ONLY the wall clock backwards, as a clock correction does.
-func (c *fakeClock) stepBack(d time.Duration) { c.now = c.now.Add(-d) }
+func (c *scriptedReadings) stepBack(d time.Duration) { c.now = c.now.Add(-d) }
 
 func TestSampleIsQuietWhileTheProcessKeepsRunning(t *testing.T) {
-	c := newFakeClock()
+	c := newScriptedReadings()
 	d := newDetector(c, defaultInterval, defaultThreshold)
 
 	for range 5 {
@@ -55,7 +54,7 @@ func TestSampleIsQuietWhileTheProcessKeepsRunning(t *testing.T) {
 }
 
 func TestSampleIgnoresSkewUnderTheThreshold(t *testing.T) {
-	c := newFakeClock()
+	c := newScriptedReadings()
 	d := newDetector(c, defaultInterval, defaultThreshold)
 
 	// Scheduling jitter and garbage collection produce exactly this shape, and
@@ -67,7 +66,7 @@ func TestSampleIgnoresSkewUnderTheThreshold(t *testing.T) {
 }
 
 func TestSampleReportsAPauseOnce(t *testing.T) {
-	c := newFakeClock()
+	c := newScriptedReadings()
 	d := newDetector(c, defaultInterval, defaultThreshold)
 
 	// The ticker is frozen for the pause too, so the interval that spans a
@@ -88,7 +87,7 @@ func TestSampleReportsAPauseOnce(t *testing.T) {
 }
 
 func TestSampleReportsAWallClockStepBackwards(t *testing.T) {
-	c := newFakeClock()
+	c := newScriptedReadings()
 	d := newDetector(c, defaultInterval, defaultThreshold)
 
 	c.advance(defaultInterval)
@@ -128,7 +127,7 @@ func TestReportDistinguishesABackwardsStepFromAPause(t *testing.T) {
 // pieces.
 func TestRunReportsAPauseObservedByTheLoop(t *testing.T) {
 	logs := testutil.CaptureDefaultLogger(t)
-	c := newFakeClock()
+	c := newScriptedReadings()
 	// A tiny interval so the loop ticks promptly; the threshold stays large so
 	// only the injected pause can trip it, never the real time this test takes.
 	d := newDetector(c, time.Millisecond, defaultThreshold)
@@ -172,8 +171,8 @@ func TestStartLoopRunsOneDetectorPerProcess(t *testing.T) {
 
 	cancelSecond()
 	cancelThird()
-	// Long enough that a loop owned by either context would have exited.
-	time.Sleep(20 * time.Millisecond)
+	require.True(t, waitForRefs(1),
+		"both later holds must be released before the loop is checked")
 	assert.True(t, loopIsRunning(),
 		"the later calls share the one loop, so ending them while the first still holds must not stop it")
 
@@ -196,7 +195,8 @@ func TestStartLoopKeepsRunningWhileAnyCallerIsLive(t *testing.T) {
 	require.True(t, loopIsRunning())
 
 	cancelFirst()
-	time.Sleep(20 * time.Millisecond)
+	require.True(t, waitForRefs(1),
+		"the first hold must be released before the loop is checked")
 	assert.True(t, loopIsRunning(),
 		"the second caller still holds the loop, so ending the first must not stop it")
 
@@ -252,4 +252,25 @@ func waitForLoopToStop() {
 		}
 		time.Sleep(time.Millisecond)
 	}
+}
+
+// waitForRefs blocks until the process-wide hold count reaches n.
+//
+// A test that cancels a caller must OBSERVE the released hold before it asserts
+// on the loop. StartLoop releases through context.AfterFunc, which the runtime
+// schedules on its own goroutine, so no clock drives it. A fixed sleep asserts
+// at a moment the test does not control, and it passes without proving anything
+// when the callback has not run yet: the loop is then still running for the
+// trivial reason that nothing released it.
+func waitForRefs(n int) bool {
+	for range 2000 {
+		running.mu.Lock()
+		refs := running.refs
+		running.mu.Unlock()
+		if refs == n {
+			return true
+		}
+		time.Sleep(time.Millisecond)
+	}
+	return false
 }


### PR DESCRIPTION
## Motivation
Six packages each wrote their own time seam: `fakeClock`, `fakeTimer`, `retryClock`, `systemClock`, `startupTimerClock`, a mutable `Manager.readDrainGrace` field, and a mutable `workerIdentityTimeout` var. Several were near-copies of each other, and each covered only the timers its own package happened to arm, so a test that needed a second one added a third shape. Many tests waited with `time.Sleep` or `require.Eventually` instead of controlling time directly. That caused slow tests and real flakes, including the Codex turn-start test and the clockjump loop tests.

This change unifies every clock consumer, in production code and in tests, on one library: `quartz.Clock`. Threading a real clock field through each package surfaced a reachable production race in the startup registry: `fail()` and `takePendingResize()` took a bare tab id rather than the entry handle `begin()` returns, so a goroutine from a startup that a close already retired could evict, or steal the stashed terminal size from, a replacement startup that had since claimed the same id.

## Modifications
- **worker/service (startup registry):** Replace the bespoke clock interfaces with `quartz.Clock`. `service.Config` gains a `Clock` field (nil defaults to `quartz.NewReal()`), so the startup registries and the same tab's terminal reader-drain grace share one injectable clock instead of two independent ones. Extract `stopEviction()` and stop each eviction timer outside the registry lock — a Quartz trap parks the caller inside `Stop`, and parking there under the lock would block every other registry method. Add an identity guard to `fail()` and to `takePendingResize()`, matching the one `succeed()` already had: each now takes the `*startupEntry` handle and checks that the map slot still holds that exact entry. The nil-means-any-entry sentinel is deleted, so the guard is required rather than opt-in. Route `waitForPendingResize`'s fast path through the shared take helper; the two copies of that rule already disagreed on a failed entry. Two new regression tests fail against the old id-keyed code. (`tab_payload_test.go` in the same package is a separate flake fix: two subscribe tests replace a sleep with a signal fired from inside the snapshot callback, which is the actual moment the subscriber attaches.)
- **worker/hub:** Replace `Client.now`/`Client.after` and their nil-defaulting wrappers with one `quartz.Clock` field and a `WithClock` option. Add `Client.Clock()` so `bootstrap.Wire` gives the client, its terminal manager, and the Service the same instance. Demote `workerIdentityTimeout` from a mutable package var to a const. Extract `waitOrCancel` as the one cancel-or-wait primitive for both retry loops — a function rather than a caller-side `defer`, because both callers wait inside a loop where a `defer` would hold every iteration's timer until the enclosing function returns. Collapse `registerWithClient`'s two trailing parameters into one `registerRetry` struct; the per-attempt timeout deliberately stays on `context.WithTimeout`, because no Quartz clock can drive a context deadline and that deadline is what reaches the hub as `grpc-timeout`. Move the clock read in `markEnqueued` and `heartbeatLoop` outside the client mutex, and keep `lastSendTime` monotonic so the hoist changes no behaviour. Give the connect-time stamp its own tag, split from the enqueue stamp. Delete the hand-rolled `fakeClock` and `recordingBackoff` doubles, and tighten the backoff-ladder test, whose old assertion also passed for a flat sequence, to the exact ladder.
- **worker/terminal and clockjump:** Replace the mutable `readDrainGrace` seam with a `clock` field, a `WithClock` option, and a fixed `defaultReadDrainGrace` constant. Give `Terminal` its own clock, required by its constructor, so the type that arms the timers owns the clock that makes them; `Respawn` threads it through. Split `waitForReadDrained` into an unlimited `waitForReadDone` and a bounded `waitForReadDrainedWithin`, which removes a flag argument and an argument that was dead on one of the two paths, and which now panics on a non-positive limit where the old code silently degraded to an unlimited wait. Extract `waitForChildSideClose` with its own deferred stop and a `childCloseOutcome` enum, replacing three hand-written stop calls and an implicit `select` fallthrough. In the tests, an arm-counting clock states how many timers each stage armed, because `Peek()` alone cannot see a timer a trap captured but has not released. In `clockjump_test.go`, two fixed sleeps become a bounded poll on the state the assertion depends on, since the release path runs on a runtime goroutine no clock drives.
- **hub and CLI tests:** Replace the local `retryClock`/`systemClock` pair with `quartz.Clock` and a `WithClock` option, and delete roughly 150 lines of hand-rolled `fakeClock`/`fakeTimer`. Tighten the clock-identity assertion in three packages from `assert.WithinDuration(time.Now(), ...)`, which any mock seeded from `time.Now()` satisfies, to `require.IsType(quartz.NewReal(), ...)` — the tests whose stated job was "wire the real clock" were asserting nothing. In `oauth_server_handler_test.go` the harness held both a frozen mock and a separate real-time seam that the handler actually reads, and twelve sites stamped store rows from the frozen one, so every window they wrote was short by the test's own runtime; the harness now exposes one definition of now plus an `advance` method. Replace two racy non-blocking reads in `channel_service_test.go` with bounded waits, and guard `config_test.go` against ambient `LEAPMUX_HUB_*` variables leaking into the default-config assertions.
- **Shared helpers and dependency:** Add `github.com/coder/quartz` v0.3.1 (MIT No Attribution) and regenerate `NOTICE.md` and `NOTICE.html`. Add `backend/internal/util/testutil/quartzclock.go` with five helpers that six packages had each written for themselves; nine test files across four packages now share them. Their doc comments record the two silent Quartz failure modes: a trap that is never released deadlocks the advance and misreports as a context expiry, and a trap that is never closed blocks the next matching call. Fix an observed CI flake in `TestCodexSendTurnStartOmitsAccountDefaultModel`, where a fixed sleep raced the detached goroutine that writes the request, so the assertion could read an empty slice; the ack is now released when the request reaches the responder.

## Result
One clock type serves every consumer, in production code and in tests, so the next package that needs a fake clock inherits the release discipline instead of writing a seventh variant. The affected suites assert the duration the code asked for rather than the gap it produced, which is what made them fail on Windows, where the host's timer granularity is wide enough to swallow the difference between a 10 ms and a 40 ms rung and report them in the wrong order.

A closed tab no longer leaves a process behind. Previously a startup goroutine that a close had already retired could delete the registry entry of the retry that replaced it, and the next close then found nothing to cancel, so the replacement's context stayed live and its agent process and control socket outlived the tab. The same guard stops a retired goroutine from resizing a pty it does not own.

Three tests that reported success while checking nothing now check something: the three that claimed to pin the real clock, and the backoff ladder that a flat sequence also satisfied.
